### PR TITLE
fix: remove me from .amqrc (root-only config)

### DIFF
--- a/.claude/skills/amq-cli/SKILL.md
+++ b/.claude/skills/amq-cli/SKILL.md
@@ -21,11 +21,7 @@ Verify: `amq --version`
 ## Quick Reference
 
 ```bash
-# Option 1: Using .amqrc (recommended)
-echo '{"root": ".agent-mail", "me": "claude"}' > .amqrc
-eval "$(amq env --wake)"
-
-# Option 2: Manual exports
+# Set once per session - commands work from any directory
 export AM_ROOT=.agent-mail AM_ME=claude   # or: AM_ME=codex
 
 amq send --to codex --body "Message"           # Send
@@ -36,6 +32,12 @@ amq list --new --priority urgent               # Filter messages
 ```
 
 **Note**: With env vars set, all commands work from any subdirectory.
+
+Optionally create `.amqrc` for project-level root config:
+```bash
+echo '{"root": ".agent-mail"}' > .amqrc
+```
+Then only `AM_ME` needs to be set per terminal.
 
 ## Co-op Mode (Autonomous Multi-Agent)
 

--- a/.codex/skills/amq-cli/SKILL.md
+++ b/.codex/skills/amq-cli/SKILL.md
@@ -21,11 +21,7 @@ Verify: `amq --version`
 ## Quick Reference
 
 ```bash
-# Option 1: Using .amqrc (recommended)
-echo '{"root": ".agent-mail", "me": "claude"}' > .amqrc
-eval "$(amq env --wake)"
-
-# Option 2: Manual exports
+# Set once per session - commands work from any directory
 export AM_ROOT=.agent-mail AM_ME=claude   # or: AM_ME=codex
 
 amq send --to codex --body "Message"           # Send
@@ -36,6 +32,12 @@ amq list --new --priority urgent               # Filter messages
 ```
 
 **Note**: With env vars set, all commands work from any subdirectory.
+
+Optionally create `.amqrc` for project-level root config:
+```bash
+echo '{"root": ".agent-mail"}' > .amqrc
+```
+Then only `AM_ME` needs to be set per terminal.
 
 ## Co-op Mode (Autonomous Multi-Agent)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,22 +65,22 @@ internal/
 **Environment Variables**: `AM_ROOT` (default root dir), `AM_ME` (default agent handle), `AMQ_NO_UPDATE_CHECK` (disable update check)
 
 **Session Configuration**: The `amq env` command outputs shell commands to set environment variables. It reads configuration from (highest to lowest precedence):
-1. Command-line flags (`--root`, `--me`)
-2. Environment variables (`AM_ROOT`, `AM_ME`)
-3. `.amqrc` file in current or parent directories
-4. Auto-detect `.agent-mail/` directory
+- **Root**: flags > env (`AM_ROOT`) > `.amqrc` > auto-detect (`.agent-mail/`)
+- **Me**: flags > env (`AM_ME`)
 
-The `.amqrc` file is JSON:
+Note: `.amqrc` only configures `root`. Agent identity (`me`) is set per-terminal via `--me` or `AM_ME`, since different terminals may use different agents on the same project.
+
+The `.amqrc` file is JSON (root only):
 ```json
-{"root": ".agent-mail", "me": "claude"}
+{"root": ".agent-mail"}
 ```
 
 Usage:
 ```bash
-eval "$(amq env)"           # Load env vars
-eval "$(amq env --wake)"    # Load env vars and start wake
-amq env --shell fish        # Fish shell syntax
-amq env --json              # Machine-readable output
+eval "$(amq env --me claude)"        # Set up for Claude
+eval "$(amq env --me codex --wake)"  # Set up for Codex with wake
+amq env --shell fish                 # Fish shell syntax
+amq env --json                       # Machine-readable output
 ```
 
 ## Message Kinds
@@ -227,21 +227,6 @@ Co-op mode enables real-time collaboration between Claude Code and Codex CLI ses
 
 ### Quick Start
 
-**Option 1: Using `.amqrc` (recommended)**
-
-Create `.amqrc` in your project root:
-```json
-{"root": ".agent-mail", "me": "claude"}
-```
-
-Then start your session:
-```bash
-eval "$(amq env --wake)"
-claude
-```
-
-**Option 2: Manual exports**
-
 ```bash
 # Terminal 1 - Claude Code
 export AM_ME=claude AM_ROOT=.agent-mail
@@ -253,6 +238,12 @@ export AM_ME=codex AM_ROOT=.agent-mail
 amq wake &
 codex
 ```
+
+Optionally create `.amqrc` in your project root for shared root config:
+```json
+{"root": ".agent-mail"}
+```
+Then only `AM_ME` needs to be set per terminal.
 
 `amq wake` runs as a background job and attempts to inject notifications into your terminal when messages arrive (uses TIOCSTI, experimental).
 

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -64,7 +64,7 @@ func TestFindAndLoadAmqrc(t *testing.T) {
 	}
 
 	// Write .amqrc in root
-	rcContent := `{"root": ".agent-mail", "me": "claude"}`
+	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -85,9 +85,7 @@ func TestFindAndLoadAmqrc(t *testing.T) {
 	if result.Config.Root != ".agent-mail" {
 		t.Errorf("expected root=.agent-mail, got %q", result.Config.Root)
 	}
-	if result.Config.Me != "claude" {
-		t.Errorf("expected me=claude, got %q", result.Config.Me)
-	}
+	// 'me' is not in .amqrc
 
 	// Verify Dir is set correctly (should be the root where .amqrc was found)
 	resolvedDir, _ := filepath.EvalSymlinks(result.Dir)
@@ -203,7 +201,7 @@ func TestResolveEnvConfigFromAmqrc(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc
-	rcContent := `{"root": ".agent-mail", "me": "claude"}`
+	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -231,8 +229,9 @@ func TestResolveEnvConfigFromAmqrc(t *testing.T) {
 	if resolvedRoot != expectedResolved {
 		t.Errorf("expected root=%q, got %q", expectedResolved, resolvedRoot)
 	}
-	if meVal != "claude" {
-		t.Errorf("expected me=claude, got %q", meVal)
+	// me is NOT read from .amqrc (use env var or flag instead)
+	if meVal != "" {
+		t.Errorf("expected me=empty (not from .amqrc), got %q", meVal)
 	}
 }
 
@@ -246,7 +245,7 @@ func TestResolveEnvConfigRelativeRootFromSubdir(t *testing.T) {
 	}
 
 	// Write .amqrc in root with relative path
-	rcContent := `{"root": ".agent-mail", "me": "claude"}`
+	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -280,7 +279,7 @@ func TestResolveEnvConfigFlagOverride(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc with one set of values
-	rcContent := `{"root": ".agent-mail", "me": "claude"}`
+	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -313,7 +312,7 @@ func TestResolveEnvConfigEnvOverride(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc with one set of values
-	rcContent := `{"root": ".agent-mail", "me": "claude"}`
+	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -348,7 +347,7 @@ func TestResolveEnvConfigFlagOverridesEnv(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc
-	rcContent := `{"root": ".agent-mail", "me": "claude"}`
+	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -561,7 +560,7 @@ func TestRunEnvJSON(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc
-	rcContent := `{"root": ".agent-mail", "me": "claude"}`
+	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -606,8 +605,9 @@ func TestRunEnvJSON(t *testing.T) {
 	if resolvedResult != resolvedExpected {
 		t.Errorf("expected root=%q, got %q", resolvedExpected, resolvedResult)
 	}
-	if result.Me != "claude" {
-		t.Errorf("expected me=claude, got %q", result.Me)
+	// 'me' is not in .amqrc
+	if result.Me != "" {
+		t.Errorf("expected me=empty, got %q", result.Me)
 	}
 }
 
@@ -615,7 +615,7 @@ func TestRunEnvPosix(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc with absolute path to avoid resolution issues
-	rcContent := `{"root": "/tmp/test-root", "me": "claude"}`
+	rcContent := `{"root": "/tmp/test-root"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -651,8 +651,9 @@ func TestRunEnvPosix(t *testing.T) {
 	if !strings.Contains(output, "export AM_ROOT=/tmp/test-root") {
 		t.Errorf("expected export AM_ROOT, got: %s", output)
 	}
-	if !strings.Contains(output, "export AM_ME=claude") {
-		t.Errorf("expected export AM_ME, got: %s", output)
+	// AM_ME is not set from .amqrc (use env var or --me flag)
+	if strings.Contains(output, "export AM_ME") {
+		t.Errorf("unexpected AM_ME in output (not from .amqrc): %s", output)
 	}
 }
 
@@ -660,7 +661,7 @@ func TestRunEnvFish(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc with absolute path
-	rcContent := `{"root": "/tmp/test-root", "me": "claude"}`
+	rcContent := `{"root": "/tmp/test-root"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -696,8 +697,9 @@ func TestRunEnvFish(t *testing.T) {
 	if !strings.Contains(output, "set -gx AM_ROOT /tmp/test-root") {
 		t.Errorf("expected set -gx AM_ROOT, got: %s", output)
 	}
-	if !strings.Contains(output, "set -gx AM_ME claude") {
-		t.Errorf("expected set -gx AM_ME, got: %s", output)
+	// AM_ME is not set from .amqrc (use env var or --me flag)
+	if strings.Contains(output, "set -gx AM_ME") {
+		t.Errorf("unexpected AM_ME in output (not from .amqrc): %s", output)
 	}
 }
 
@@ -705,7 +707,7 @@ func TestRunEnvWake(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc
-	rcContent := `{"root": "/tmp/test-root", "me": "claude"}`
+	rcContent := `{"root": "/tmp/test-root"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -21,11 +21,7 @@ Verify: `amq --version`
 ## Quick Reference
 
 ```bash
-# Option 1: Using .amqrc (recommended)
-echo '{"root": ".agent-mail", "me": "claude"}' > .amqrc
-eval "$(amq env --wake)"
-
-# Option 2: Manual exports
+# Set once per session - commands work from any directory
 export AM_ROOT=.agent-mail AM_ME=claude   # or: AM_ME=codex
 
 amq send --to codex --body "Message"           # Send
@@ -36,6 +32,12 @@ amq list --new --priority urgent               # Filter messages
 ```
 
 **Note**: With env vars set, all commands work from any subdirectory.
+
+Optionally create `.amqrc` for project-level root config:
+```bash
+echo '{"root": ".agent-mail"}' > .amqrc
+```
+Then only `AM_ME` needs to be set per terminal.
 
 ## Co-op Mode (Autonomous Multi-Agent)
 


### PR DESCRIPTION
## Summary
- `.amqrc` now only configures `root`, not `me`
- Agent identity should be set per-terminal via `AM_ME` env var or `--me` flag
- This supports the common case where multiple agents work on the same project from different terminals

## Changes
- Remove `Me` field from `amqrc` struct
- Update `resolveEnvConfig` to not read `me` from `.amqrc`
- Update help text to clarify new precedence
- Update tests to reflect new behavior
- Update SKILL.md and CLAUDE.md documentation

## Test plan
- [x] All existing tests pass
- [x] CI passes
- [x] Smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)