### PR TITLE
fix: use amq env instead of hardcoded AM_ROOT exports

### DIFF
--- a/.claude/skills/amq-cli/SKILL.md
+++ b/.claude/skills/amq-cli/SKILL.md
@@ -34,6 +34,8 @@ amq watch --timeout 60s                        # Wait for messages
 
 **Note**: After setup, all commands work from any subdirectory.
 
+> **Important**: Don't hardcode `AM_ROOT=.agent-mail`. Use `amq env` which auto-detects the configured root from `.amqrc` or existing directories. Only set `AM_ROOT` explicitly when intentionally overriding (e.g., multi-pair isolation with `--root`).
+
 ## Co-op Mode (Autonomous Multi-Agent)
 
 In co-op mode, agents work autonomously. **Message your partner, not the user.**
@@ -60,7 +62,7 @@ Only use messages for: coordination, questions, review requests, status updates.
 Run once per project:
 ```bash
 curl -sL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/scripts/setup-coop.sh | bash
-export AM_ROOT=.agent-mail AM_ME=claude   # or: codex
+eval "$(amq env --me claude)"   # or: --me codex
 ```
 
 ### Multiple Pairs (Isolated Sessions)

--- a/.codex/skills/amq-cli/SKILL.md
+++ b/.codex/skills/amq-cli/SKILL.md
@@ -34,6 +34,8 @@ amq watch --timeout 60s                        # Wait for messages
 
 **Note**: After setup, all commands work from any subdirectory.
 
+> **Important**: Don't hardcode `AM_ROOT=.agent-mail`. Use `amq env` which auto-detects the configured root from `.amqrc` or existing directories. Only set `AM_ROOT` explicitly when intentionally overriding (e.g., multi-pair isolation with `--root`).
+
 ## Co-op Mode (Autonomous Multi-Agent)
 
 In co-op mode, agents work autonomously. **Message your partner, not the user.**
@@ -60,7 +62,7 @@ Only use messages for: coordination, questions, review requests, status updates.
 Run once per project:
 ```bash
 curl -sL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/scripts/setup-coop.sh | bash
-export AM_ROOT=.agent-mail AM_ME=claude   # or: codex
+eval "$(amq env --me claude)"   # or: --me codex
 ```
 
 ### Multiple Pairs (Isolated Sessions)

--- a/COOP.md
+++ b/COOP.md
@@ -70,15 +70,15 @@ This creates:
 
 **Terminal 1 - Claude Code:**
 ```bash
-export AM_ME=claude AM_ROOT=.agent-mail
-amq wake &
+eval "$(amq env --me claude)"
+amq wake &  # Optional: terminal notifications
 claude
 ```
 
 **Terminal 2 - Codex CLI:**
 ```bash
-export AM_ME=codex AM_ROOT=.agent-mail
-amq wake &
+eval "$(amq env --me codex)"
+amq wake &  # Optional: terminal notifications
 codex
 ```
 
@@ -91,23 +91,23 @@ Need multiple agent pairs working on different features simultaneously? Use sepa
 ```bash
 # Pair A: auth feature
 # Terminal 1
-export AM_ME=claude AM_ROOT=.agent-mail/auth
+eval "$(amq env --me claude --root .agent-mail/auth)"
 amq wake &
 claude
 
 # Terminal 2
-export AM_ME=codex AM_ROOT=.agent-mail/auth
+eval "$(amq env --me codex --root .agent-mail/auth)"
 amq wake &
 codex
 
 # Pair B: api refactor
 # Terminal 3
-export AM_ME=claude AM_ROOT=.agent-mail/api
+eval "$(amq env --me claude --root .agent-mail/api)"
 amq wake &
 claude
 
 # Terminal 4
-export AM_ME=codex AM_ROOT=.agent-mail/api
+eval "$(amq env --me codex --root .agent-mail/api)"
 amq wake &
 codex
 ```

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ amq init --root .agent-mail --agents claude,codex
 
 **Terminal 1 — Claude Code:**
 ```bash
-export AM_ME=claude AM_ROOT=.agent-mail
-amq wake &
+eval "$(amq env --me claude)"
+amq wake &  # Optional: terminal notifications
 claude
 ```
 
 **Terminal 2 — Codex CLI:**
 ```bash
-export AM_ME=codex AM_ROOT=.agent-mail
-amq wake &
+eval "$(amq env --me codex)"
+amq wake &  # Optional: terminal notifications
 codex
 ```
 

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -4,23 +4,28 @@
 
 set -euo pipefail
 
-if [ -z "${CLAUDE_ENV_FILE:-}" ]; then
-    exit 0
-fi
-
-DEFAULT_ROOT=".agent-mail"
-if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
-    DEFAULT_ROOT="${CLAUDE_PROJECT_DIR}/.agent-mail"
-fi
-
-ROOT="${AM_ROOT:-$DEFAULT_ROOT}"
-ME="${AM_ME:-claude}"
+[ -z "${CLAUDE_ENV_FILE:-}" ] && exit 0
 
 touch "$CLAUDE_ENV_FILE"
 
-if ! grep -q '^export AM_ROOT=' "$CLAUDE_ENV_FILE"; then
-    printf 'export AM_ROOT=%q\n' "$ROOT" >> "$CLAUDE_ENV_FILE"
-fi
-if ! grep -q '^export AM_ME=' "$CLAUDE_ENV_FILE"; then
-    printf 'export AM_ME=%q\n' "$ME" >> "$CLAUDE_ENV_FILE"
+# Run amq env from project dir (finds .amqrc there)
+# If CLAUDE_PROJECT_DIR not set, fall back to cwd
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+ME="${AM_ME:-claude}"
+
+if command -v amq &> /dev/null; then
+    ENV_OUT=$(cd "$PROJECT_DIR" && amq env --me "$ME" 2>/dev/null) || ENV_OUT=""
+
+    if [ -n "$ENV_OUT" ]; then
+        # Append AM_ROOT if not already set
+        if ! grep -q '^export AM_ROOT=' "$CLAUDE_ENV_FILE"; then
+            ROOT_LINE=$(echo "$ENV_OUT" | grep '^export AM_ROOT=' || true)
+            [ -n "$ROOT_LINE" ] && echo "$ROOT_LINE" >> "$CLAUDE_ENV_FILE"
+        fi
+        # Append AM_ME if not already set
+        if ! grep -q '^export AM_ME=' "$CLAUDE_ENV_FILE"; then
+            ME_LINE=$(echo "$ENV_OUT" | grep '^export AM_ME=' || true)
+            [ -n "$ME_LINE" ] && echo "$ME_LINE" >> "$CLAUDE_ENV_FILE"
+        fi
+    fi
 fi

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -34,6 +34,8 @@ amq watch --timeout 60s                        # Wait for messages
 
 **Note**: After setup, all commands work from any subdirectory.
 
+> **Important**: Don't hardcode `AM_ROOT=.agent-mail`. Use `amq env` which auto-detects the configured root from `.amqrc` or existing directories. Only set `AM_ROOT` explicitly when intentionally overriding (e.g., multi-pair isolation with `--root`).
+
 ## Co-op Mode (Autonomous Multi-Agent)
 
 In co-op mode, agents work autonomously. **Message your partner, not the user.**
@@ -60,7 +62,7 @@ Only use messages for: coordination, questions, review requests, status updates.
 Run once per project:
 ```bash
 curl -sL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/scripts/setup-coop.sh | bash
-export AM_ROOT=.agent-mail AM_ME=claude   # or: codex
+eval "$(amq env --me claude)"   # or: --me codex
 ```
 
 ### Multiple Pairs (Isolated Sessions)


### PR DESCRIPTION
## Summary

- Fixes issue where agents hardcode `export AM_ROOT=.agent-mail` instead of using `amq env`, causing messages to disappear when users have custom `.amqrc` configurations
- Updates all documentation to use `eval "$(amq env --me ...)"` pattern
- Simplifies `claude-session-start.sh` to delegate root detection to `amq env`
- Adds `.amqrc` detection to `setup-coop.sh`

## Test plan

- [x] `make ci` passes
- [x] Verified `amq env` respects `.amqrc` when present
- [x] Codex reviewed and approved changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)