### PR TITLE
feat(coop): introduce phased parallel work model

### DIFF
--- a/.claude/skills/amq-cli/references/coop-mode.md
+++ b/.claude/skills/amq-cli/references/coop-mode.md
@@ -1,7 +1,56 @@
 # Co-op Mode Protocol
 
-- Use AMQ messages to coordinate with the partner agent, not the user.
-- Share status, questions, and review requests; avoid pasting large code blocks.
-- When a partner references files, read them directly from the shared workspace.
-- For message handling, prefer `amq monitor --peek` for passive watching, and `amq drain --include-body` to process.
-- If a stop hook is installed, drain pending messages before stopping.
+## Roles
+
+- **Claude Code** = Leader + Worker (coordinates phases, merges, prepares commits, gets user approval)
+- **Codex** = Worker (executes phases, reports to leader, awaits next assignment)
+
+## Phased Flow
+
+| Phase | Mode | Description |
+|-------|------|-------------|
+| **Research** | Parallel | Both explore codebase, read docs, search. No conflicts. |
+| **Design** | Parallel → Merge | Both propose approaches. Leader merges/decides. |
+| **Code** | Split | Divide by file/module. Never edit same file. |
+| **Review** | Parallel | Both review each other's code. Leader decides disputes. |
+| **Test** | Parallel | Both run tests, report results to leader. |
+
+```
+Research (parallel) → sync findings
+    ↓
+Design (parallel) → leader merges approach
+    ↓
+Code (split: divide files/modules)
+    ↓
+Review (parallel: each reviews other's code)
+    ↓
+Test (parallel: both run tests)
+    ↓
+Leader prepares commit → user approves → push
+```
+
+## Key Rules
+
+1. **Never branch** — always work on same branch (joined work)
+2. **Code phase = split** — divide files/modules to avoid conflicts
+3. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
+4. **Coordinate between phases** — sync before moving to next phase
+5. **Leader decides** — Claude Code makes final calls at merge points
+6. **Ask user only for** — credentials, unclear requirements
+
+## Stay in Sync
+
+- After completing a phase, report to leader and await next assignment
+- While waiting, safe to do: review partner's work, run tests, read docs
+- If no assignment comes, ask leader (not user) for next task
+
+## Communication
+
+- Use AMQ messages to coordinate between phases
+- Don't paste code blocks — reference file paths (shared workspace)
+
+## Message Handling
+
+- `amq drain --include-body` — process incoming messages
+- `amq send --to <partner>` — send work/findings to partner
+- `amq reply --id <msg_id>` — reply in thread

--- a/.codex/skills/amq-cli/references/coop-mode.md
+++ b/.codex/skills/amq-cli/references/coop-mode.md
@@ -1,7 +1,56 @@
 # Co-op Mode Protocol
 
-- Use AMQ messages to coordinate with the partner agent, not the user.
-- Share status, questions, and review requests; avoid pasting large code blocks.
-- When a partner references files, read them directly from the shared workspace.
-- For message handling, prefer `amq monitor --peek` for passive watching, and `amq drain --include-body` to process.
-- If a stop hook is installed, drain pending messages before stopping.
+## Roles
+
+- **Claude Code** = Leader + Worker (coordinates phases, merges, prepares commits, gets user approval)
+- **Codex** = Worker (executes phases, reports to leader, awaits next assignment)
+
+## Phased Flow
+
+| Phase | Mode | Description |
+|-------|------|-------------|
+| **Research** | Parallel | Both explore codebase, read docs, search. No conflicts. |
+| **Design** | Parallel → Merge | Both propose approaches. Leader merges/decides. |
+| **Code** | Split | Divide by file/module. Never edit same file. |
+| **Review** | Parallel | Both review each other's code. Leader decides disputes. |
+| **Test** | Parallel | Both run tests, report results to leader. |
+
+```
+Research (parallel) → sync findings
+    ↓
+Design (parallel) → leader merges approach
+    ↓
+Code (split: divide files/modules)
+    ↓
+Review (parallel: each reviews other's code)
+    ↓
+Test (parallel: both run tests)
+    ↓
+Leader prepares commit → user approves → push
+```
+
+## Key Rules
+
+1. **Never branch** — always work on same branch (joined work)
+2. **Code phase = split** — divide files/modules to avoid conflicts
+3. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
+4. **Coordinate between phases** — sync before moving to next phase
+5. **Leader decides** — Claude Code makes final calls at merge points
+6. **Ask user only for** — credentials, unclear requirements
+
+## Stay in Sync
+
+- After completing a phase, report to leader and await next assignment
+- While waiting, safe to do: review partner's work, run tests, read docs
+- If no assignment comes, ask leader (not user) for next task
+
+## Communication
+
+- Use AMQ messages to coordinate between phases
+- Don't paste code blocks — reference file paths (shared workspace)
+
+## Message Handling
+
+- `amq drain --include-body` — process incoming messages
+- `amq send --to <partner>` — send work/findings to partner
+- `amq reply --id <msg_id>` — reply in thread

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -185,7 +185,7 @@ func buildNotificationText(messages []wakeMsgInfo, senderCounts map[string]int, 
 			subject = "(no subject)"
 		}
 		subject = truncateSubject(subject, previewLen)
-		return fmt.Sprintf("AMQ: message from %s - %s. Run: amq drain --include-body", msg.from, subject)
+		return fmt.Sprintf("AMQ: message from %s - %s. Drain with: amq drain --include-body — then act on it", msg.from, subject)
 	}
 
 	// Multiple messages: show counts by sender
@@ -201,7 +201,7 @@ func buildNotificationText(messages []wakeMsgInfo, senderCounts map[string]int, 
 		parts = append(parts, fmt.Sprintf("%d from %s", c, sender))
 	}
 
-	return fmt.Sprintf("AMQ: %d messages - %s. Run: amq drain --include-body",
+	return fmt.Sprintf("AMQ: %d messages - %s. Drain with: amq drain --include-body — then act on it",
 		count, strings.Join(parts, ", "))
 }
 

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -1,7 +1,56 @@
 # Co-op Mode Protocol
 
-- Use AMQ messages to coordinate with the partner agent, not the user.
-- Share status, questions, and review requests; avoid pasting large code blocks.
-- When a partner references files, read them directly from the shared workspace.
-- For message handling, prefer `amq monitor --peek` for passive watching, and `amq drain --include-body` to process.
-- If a stop hook is installed, drain pending messages before stopping.
+## Roles
+
+- **Claude Code** = Leader + Worker (coordinates phases, merges, prepares commits, gets user approval)
+- **Codex** = Worker (executes phases, reports to leader, awaits next assignment)
+
+## Phased Flow
+
+| Phase | Mode | Description |
+|-------|------|-------------|
+| **Research** | Parallel | Both explore codebase, read docs, search. No conflicts. |
+| **Design** | Parallel → Merge | Both propose approaches. Leader merges/decides. |
+| **Code** | Split | Divide by file/module. Never edit same file. |
+| **Review** | Parallel | Both review each other's code. Leader decides disputes. |
+| **Test** | Parallel | Both run tests, report results to leader. |
+
+```
+Research (parallel) → sync findings
+    ↓
+Design (parallel) → leader merges approach
+    ↓
+Code (split: divide files/modules)
+    ↓
+Review (parallel: each reviews other's code)
+    ↓
+Test (parallel: both run tests)
+    ↓
+Leader prepares commit → user approves → push
+```
+
+## Key Rules
+
+1. **Never branch** — always work on same branch (joined work)
+2. **Code phase = split** — divide files/modules to avoid conflicts
+3. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
+4. **Coordinate between phases** — sync before moving to next phase
+5. **Leader decides** — Claude Code makes final calls at merge points
+6. **Ask user only for** — credentials, unclear requirements
+
+## Stay in Sync
+
+- After completing a phase, report to leader and await next assignment
+- While waiting, safe to do: review partner's work, run tests, read docs
+- If no assignment comes, ask leader (not user) for next task
+
+## Communication
+
+- Use AMQ messages to coordinate between phases
+- Don't paste code blocks — reference file paths (shared workspace)
+
+## Message Handling
+
+- `amq drain --include-body` — process incoming messages
+- `amq send --to <partner>` — send work/findings to partner
+- `amq reply --id <msg_id>` — reply in thread


### PR DESCRIPTION
## Summary

- Introduces phased parallel work model for co-op mode, replacing simple "both do everything" approach
- Phases: Research (parallel) → Design (parallel→merge) → Code (split) → Review (parallel) → Test (parallel)
- Roles clarified: Claude Code = Leader + Worker, Codex = Worker
- Wake notification softened to "then act on it" (detailed guidance in docs only)
- Added file overlap fallback: assign owner, other reviews via message
- Renamed "Never Idle" to "Stay in Sync" with safe waiting activities

## Motivation

- Prevents file clobbering when both agents edit same file
- Leverages cognitive diversity (different models catch different bugs)
- Based on XP pair programming principles and Anthropic's multi-agent research
- Codex reviewed and approved this model

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `make sync-skills` syncs all 3 skill locations
- [x] Pre-push hooks (vet, lint, test, smoke) pass
- [ ] Manual test: run co-op session with new phased workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)