### PR TITLE
feat: initiator protocol + wake interrupts

### DIFF
--- a/.claude/skills/amq-cli/references/coop-mode.md
+++ b/.claude/skills/amq-cli/references/coop-mode.md
@@ -2,8 +2,11 @@
 
 ## Roles
 
-- **Claude Code** = Leader + Worker (coordinates phases, merges, prepares commits, gets user approval)
-- **Codex** = Worker (executes phases, reports to leader, awaits next assignment)
+- **Initiator** = whoever starts the task (agent or human). Owns decisions and receives updates.
+- **Leader/Coordinator** = coordinates phases, merges, and final decisions (often the initiator).
+- **Worker** = executes assigned phases and reports back to the initiator.
+
+**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator.
 
 ## Phased Flow
 
@@ -31,23 +34,43 @@ Leader prepares commit → user approves → push
 
 ## Key Rules
 
-1. **Never branch** — always work on same branch (joined work)
-2. **Code phase = split** — divide files/modules to avoid conflicts
-3. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
-4. **Coordinate between phases** — sync before moving to next phase
-5. **Leader decides** — Claude Code makes final calls at merge points
-6. **Ask user only for** — credentials, unclear requirements
+1. **Initiator rule** — reply to the initiator and ask the initiator for clarifications
+2. **Never branch** — always work on same branch (joined work)
+3. **Code phase = split** — divide files/modules to avoid conflicts
+4. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
+5. **Coordinate between phases** — sync before moving to next phase
+6. **Leader decides** — initiator or designated leader makes final calls
 
 ## Stay in Sync
 
-- After completing a phase, report to leader and await next assignment
+- After completing a phase, report to the initiator and await next assignment
 - While waiting, safe to do: review partner's work, run tests, read docs
-- If no assignment comes, ask leader (not user) for next task
+- If no assignment comes, ask the initiator (not a third party) for next task
+
+## Progress Protocol (Start / Heartbeat / Done)
+
+- **Start**: send `kind=status` with an ETA to the initiator as soon as you begin.
+- **Heartbeat**: update on phase boundaries or every 10-15 minutes.
+- **Done**: send Summary / Changes / Tests / Notes to the initiator.
+- **Blocked**: send `kind=question` to the initiator with options and a recommendation.
+
+## Modes of Collaboration (Modus Operandi)
+
+- **Leader + Worker**: leader decides, worker executes; best default.
+- **Co-workers**: peers decide together; if no consensus, ask the initiator.
+- **Duplicate**: independent solutions or reviews; initiator merges results.
+- **Driver + Navigator**: driver codes, navigator reviews/tests and can interrupt.
+- **Spec + Implementer**: one writes spec/tests, the other implements.
+- **Reviewer + Implementer**: one codes, the other focuses on review and risk detection.
 
 ## Communication
 
-- Use AMQ messages to coordinate between phases
+- Use AMQ messages to coordinate between phases and report to the initiator
 - Don't paste code blocks — reference file paths (shared workspace)
+
+## Interrupts
+
+- Urgent messages labeled `interrupt` trigger wake Ctrl+C injection + an interrupt notice (when wake is running).
 
 ## Message Handling
 

--- a/.codex/skills/amq-cli/references/coop-mode.md
+++ b/.codex/skills/amq-cli/references/coop-mode.md
@@ -2,8 +2,11 @@
 
 ## Roles
 
-- **Claude Code** = Leader + Worker (coordinates phases, merges, prepares commits, gets user approval)
-- **Codex** = Worker (executes phases, reports to leader, awaits next assignment)
+- **Initiator** = whoever starts the task (agent or human). Owns decisions and receives updates.
+- **Leader/Coordinator** = coordinates phases, merges, and final decisions (often the initiator).
+- **Worker** = executes assigned phases and reports back to the initiator.
+
+**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator.
 
 ## Phased Flow
 
@@ -31,23 +34,43 @@ Leader prepares commit → user approves → push
 
 ## Key Rules
 
-1. **Never branch** — always work on same branch (joined work)
-2. **Code phase = split** — divide files/modules to avoid conflicts
-3. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
-4. **Coordinate between phases** — sync before moving to next phase
-5. **Leader decides** — Claude Code makes final calls at merge points
-6. **Ask user only for** — credentials, unclear requirements
+1. **Initiator rule** — reply to the initiator and ask the initiator for clarifications
+2. **Never branch** — always work on same branch (joined work)
+3. **Code phase = split** — divide files/modules to avoid conflicts
+4. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
+5. **Coordinate between phases** — sync before moving to next phase
+6. **Leader decides** — initiator or designated leader makes final calls
 
 ## Stay in Sync
 
-- After completing a phase, report to leader and await next assignment
+- After completing a phase, report to the initiator and await next assignment
 - While waiting, safe to do: review partner's work, run tests, read docs
-- If no assignment comes, ask leader (not user) for next task
+- If no assignment comes, ask the initiator (not a third party) for next task
+
+## Progress Protocol (Start / Heartbeat / Done)
+
+- **Start**: send `kind=status` with an ETA to the initiator as soon as you begin.
+- **Heartbeat**: update on phase boundaries or every 10-15 minutes.
+- **Done**: send Summary / Changes / Tests / Notes to the initiator.
+- **Blocked**: send `kind=question` to the initiator with options and a recommendation.
+
+## Modes of Collaboration (Modus Operandi)
+
+- **Leader + Worker**: leader decides, worker executes; best default.
+- **Co-workers**: peers decide together; if no consensus, ask the initiator.
+- **Duplicate**: independent solutions or reviews; initiator merges results.
+- **Driver + Navigator**: driver codes, navigator reviews/tests and can interrupt.
+- **Spec + Implementer**: one writes spec/tests, the other implements.
+- **Reviewer + Implementer**: one codes, the other focuses on review and risk detection.
 
 ## Communication
 
-- Use AMQ messages to coordinate between phases
+- Use AMQ messages to coordinate between phases and report to the initiator
 - Don't paste code blocks — reference file paths (shared workspace)
+
+## Interrupts
+
+- Urgent messages labeled `interrupt` trigger wake Ctrl+C injection + an interrupt notice (when wake is running).
 
 ## Message Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,14 @@ Commands below assume `AM_ME` is set (e.g., `export AM_ME=claude`).
 
 Co-op mode enables real-time collaboration between Claude Code and Codex CLI sessions. See `COOP.md` for full documentation.
 
+**Initiator rule**: The initiator (agent or human) receives all updates and decisions. Always reply to the initiator and ask the initiator for clarifications. Do not ask a third party.
+
+**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator.
+
+**Progress protocol**: Start with a `kind=status` + ETA, send heartbeats on phase boundaries or every 10-15 minutes, and finish with Summary / Changes / Tests / Notes.
+
+**Modes of collaboration**: Leader+Worker (default), Co-workers, Duplicate (independent solutions), Driver+Navigator, Spec+Implementer, Reviewer+Implementer. See `COOP.md` for details.
+
 ### Quick Start
 
 ```bash
@@ -252,7 +260,7 @@ Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments).
 ### Message Priority Handling
 
 When you see a notification, run `amq drain --include-body`:
-- **urgent** → Interrupt current work, respond immediately
+- **urgent** → Interrupt current work, respond immediately (label `interrupt` enables wake Ctrl+C)
 - **normal** → Add to TodoWrite, respond when current task done
 - **low** → Batch for end of session
 

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsInterruptMessage(t *testing.T) {
+	cfg := &wakeConfig{
+		interrupt:         true,
+		interruptLabel:    "interrupt",
+		interruptPriority: "urgent",
+	}
+
+	if !isInterruptMessage(wakeMsgInfo{priority: "urgent", labels: []string{"interrupt"}}, cfg) {
+		t.Fatalf("expected interrupt message to match")
+	}
+	if isInterruptMessage(wakeMsgInfo{priority: "normal", labels: []string{"interrupt"}}, cfg) {
+		t.Fatalf("expected priority mismatch to not match")
+	}
+	if isInterruptMessage(wakeMsgInfo{priority: "urgent", labels: []string{"other"}}, cfg) {
+		t.Fatalf("expected label mismatch to not match")
+	}
+}
+
+func TestBuildInterruptText_DefaultSingle(t *testing.T) {
+	msg := wakeMsgInfo{from: "alice", subject: "hello world"}
+	text := buildInterruptText([]wakeMsgInfo{msg}, map[string]int{"alice": 1}, 48, "")
+	if !strings.Contains(text, "AMQ interrupt") {
+		t.Fatalf("expected interrupt prefix, got: %s", text)
+	}
+	if !strings.Contains(text, "alice") {
+		t.Fatalf("expected sender in text, got: %s", text)
+	}
+}

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -2,8 +2,11 @@
 
 ## Roles
 
-- **Claude Code** = Leader + Worker (coordinates phases, merges, prepares commits, gets user approval)
-- **Codex** = Worker (executes phases, reports to leader, awaits next assignment)
+- **Initiator** = whoever starts the task (agent or human). Owns decisions and receives updates.
+- **Leader/Coordinator** = coordinates phases, merges, and final decisions (often the initiator).
+- **Worker** = executes assigned phases and reports back to the initiator.
+
+**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator.
 
 ## Phased Flow
 
@@ -31,23 +34,43 @@ Leader prepares commit → user approves → push
 
 ## Key Rules
 
-1. **Never branch** — always work on same branch (joined work)
-2. **Code phase = split** — divide files/modules to avoid conflicts
-3. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
-4. **Coordinate between phases** — sync before moving to next phase
-5. **Leader decides** — Claude Code makes final calls at merge points
-6. **Ask user only for** — credentials, unclear requirements
+1. **Initiator rule** — reply to the initiator and ask the initiator for clarifications
+2. **Never branch** — always work on same branch (joined work)
+3. **Code phase = split** — divide files/modules to avoid conflicts
+4. **File overlap** — if same file unavoidable, assign one owner; other reviews/proposes via message
+5. **Coordinate between phases** — sync before moving to next phase
+6. **Leader decides** — initiator or designated leader makes final calls
 
 ## Stay in Sync
 
-- After completing a phase, report to leader and await next assignment
+- After completing a phase, report to the initiator and await next assignment
 - While waiting, safe to do: review partner's work, run tests, read docs
-- If no assignment comes, ask leader (not user) for next task
+- If no assignment comes, ask the initiator (not a third party) for next task
+
+## Progress Protocol (Start / Heartbeat / Done)
+
+- **Start**: send `kind=status` with an ETA to the initiator as soon as you begin.
+- **Heartbeat**: update on phase boundaries or every 10-15 minutes.
+- **Done**: send Summary / Changes / Tests / Notes to the initiator.
+- **Blocked**: send `kind=question` to the initiator with options and a recommendation.
+
+## Modes of Collaboration (Modus Operandi)
+
+- **Leader + Worker**: leader decides, worker executes; best default.
+- **Co-workers**: peers decide together; if no consensus, ask the initiator.
+- **Duplicate**: independent solutions or reviews; initiator merges results.
+- **Driver + Navigator**: driver codes, navigator reviews/tests and can interrupt.
+- **Spec + Implementer**: one writes spec/tests, the other implements.
+- **Reviewer + Implementer**: one codes, the other focuses on review and risk detection.
 
 ## Communication
 
-- Use AMQ messages to coordinate between phases
+- Use AMQ messages to coordinate between phases and report to the initiator
 - Don't paste code blocks — reference file paths (shared workspace)
+
+## Interrupts
+
+- Urgent messages labeled `interrupt` trigger wake Ctrl+C injection + an interrupt notice (when wake is running).
 
 ## Message Handling
 


### PR DESCRIPTION
## Summary
- add wake interrupt support (urgent + interrupt label)
- codify initiator rule, progress protocol, and collaboration modes
- update skills/docs and add wake tests

## Testing
- go test ./internal/cli
- go vet ./...
- golangci-lint run
- go test ./...
- ./scripts/smoke-test.sh