### PR TITLE
feat(coop): add coop exec, remove shell/start, .amqrc in defaultRoot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,7 @@ amq wake --me <agent> [--inject-cmd <cmd>] [--bell] [--debounce <duration>] [--p
 amq upgrade
 amq env [--me <agent>] [--root <path>] [--shell sh|bash|zsh|fish] [--wake] [--json]
 amq coop init [--root <path>] [--agents <a,b,c>] [--force] [--json]
-amq coop shell --me <agent> [--root <path>] [--shell sh|bash|zsh|fish] [--wake] [--json]
-amq coop start [--root <path>] [--no-init] [--no-wake] [-y] <agent>
+amq coop exec [--root <path>] [--me <handle>] [--no-init] [--no-wake] [-y] <command> [-- <command-flags>]
 amq swarm list [--json]
 amq swarm join --team <name> --me <agent> [--agent-id <id>] [--type codex|external] [--json]
 amq swarm leave --team <name> --agent-id <id> [--json]
@@ -253,21 +252,23 @@ Co-op mode enables real-time collaboration between Claude Code and Codex CLI ses
 
 ```bash
 # Terminal 1 - Claude Code
-amq coop start claude    # Initializes + starts wake, then run:
-claude                   # With any flags you need
+amq coop exec claude                              # Sets env, starts wake, execs into claude
 
 # Terminal 2 - Codex CLI
-amq coop start codex     # Initializes + starts wake, then run:
-codex                    # With any flags you need
+amq coop exec codex -- --dangerously-skip-permissions  # Same, with codex flags
 ```
 
 Use `--root` for isolated sessions:
 ```bash
-amq coop init --root .agent-mail/feature-a
-amq coop start --root .agent-mail/feature-a claude && claude
+amq coop exec --root .agent-mail/feature-a claude      # Isolated session
 ```
 
 Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments).
+
+**For scripts/CI** (non-interactive):
+```bash
+amq coop init && eval "$(amq env --me claude)"
+```
 
 ### Message Priority Handling
 

--- a/COOP.md
+++ b/COOP.md
@@ -10,86 +10,6 @@ Co-op mode enables multiple agents (e.g., Claude Code and Codex CLI) to work **i
 
 For swarm command reference, see [CLAUDE.md](CLAUDE.md).
 
-## Roles
-
-- **Initiator** = whoever starts the task (agent or human). Owns decisions and receives all updates.
-- **Leader/Coordinator** = coordinates phases, merges, and final decisions (often the initiator).
-- **Worker** = executes assigned phases and reports back to the initiator.
-
-**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator.
-
-## Phased Flow
-
-| Phase | Mode | Description |
-|-------|------|-------------|
-| **Research** | Parallel | Both explore codebase, read docs, search. No conflicts. |
-| **Design** | Parallel → Merge | Both propose approaches. Leader merges/decides. |
-| **Code** | Split | Divide by file/module. Never edit same file. |
-| **Review** | Parallel | Both review each other's code. Leader decides disputes. |
-| **Test** | Parallel | Both run tests, report results to leader. |
-
-```
-Research (parallel) → sync findings
-    ↓
-Design (parallel) → leader merges approach
-    ↓
-Code (split: e.g., Claude=files A,B; Codex=files C,D)
-    ↓
-Review (parallel: each reviews other's code)
-    ↓
-Test (parallel: both run tests)
-    ↓
-Leader prepares commit → user approves → push
-```
-
-## Core Principles
-
-1. **Parallel where safe** - Research, design, review, and test phases run in parallel.
-
-2. **Split where risky** - Code phase divides files/modules to avoid conflicts. If same file unavoidable, assign one owner; other reviews/proposes via message.
-
-3. **Never branch** - Always work on same branch (joined work). No feature branches.
-
-4. **Cognitive diversity** - Different models catch different bugs. Cross-model work > same-model self-review.
-
-5. **Leader coordinates** - The initiator or designated leader handles phase transitions, merges, and final decisions.
-
-6. **Coordinate between phases** - Sync findings/decisions before moving to next phase.
-
-## Initiator Rule
-
-- The **initiator** is whoever started the task (agent or human).
-- Always report progress and completion to the initiator.
-- Ask questions only to the initiator. Do not ask a third party.
-
-## Progress Protocol (Start / Heartbeat / Done)
-
-- **Start**: send `kind=status` with an ETA to the initiator as soon as you begin.
-- **Heartbeat**: update on phase boundaries (research/design/code/test) or every 10-15 minutes.
-- **Done**: send Summary / Changes / Tests / Notes to the initiator.
-- **Blocked**: send `kind=question` to the initiator with options and a recommendation.
-
-## Modes of Collaboration (Modus Operandi)
-
-Pick one mode per task; the initiator decides or delegates.
-
-- **Leader + Worker**: leader decides, worker executes; best default.
-- **Co-workers**: peers decide together; if no consensus, ask the initiator.
-- **Duplicate**: independent solutions or reviews; initiator merges results (good for high-risk tasks).
-- **Driver + Navigator**: pair-programming style; driver codes, navigator reviews/tests and can interrupt.
-- **Spec + Implementer**: one writes spec/tests, the other implements; good for API or behavior changes.
-- **Reviewer + Implementer**: one codes, the other focuses on review and risk detection.
-
-## When to Act
-
-| Role | Action |
-|------|--------|
-| Worker | Complete phase → report to initiator → await next assignment |
-| Leader/Initiator | Receive reports → merge/decide → assign next phase work |
-| Either | Ask the initiator for clarifications (if the initiator is the user, ask the user) |
-
-**While waiting**: Safe to do light work — review partner's code, run tests, read docs. If no assignment comes, ask the initiator for next task.
-
 ## Quick Start
 
 ### Prerequisites (One-Time)
@@ -113,68 +33,48 @@ Pick one mode per task; the initiator decides or delegates.
 
    See [INSTALL.md](INSTALL.md) for manual installation or troubleshooting.
 
-### Per-Project Setup
-
-Initialize your project for co-op mode:
-
-```bash
-amq coop init
-```
-
-This creates:
-- `.amqrc` - Configuration file
-- `.agent-mail/` - Agent mailboxes
-- Updates `.gitignore` (if present)
-
 ### Running Co-op Mode
 
 **Terminal 1 - Claude Code:**
 ```bash
-amq coop start claude   # Sets up + starts wake, then run:
-claude                  # With any flags you need
+amq coop exec claude
 ```
 
 **Terminal 2 - Codex CLI:**
 ```bash
-amq coop start codex    # Sets up + starts wake, then run:
-codex                   # With any flags you need
+amq coop exec codex -- --dangerously-skip-permissions
 ```
+
+That's it. `coop exec` auto-initializes the project if needed, sets `AM_ROOT`/`AM_ME`, starts wake notifications, and execs into the agent.
 
 To disable auto-wake (e.g., in CI or non-TTY environments):
 ```bash
-amq coop start --no-wake claude
+amq coop exec --no-wake claude
 ```
 
 ### Multiple Pairs (Isolated Sessions)
 
-Need multiple agent pairs working on different features simultaneously? Use separate `--root` paths:
+Run multiple agent pairs on different features using `--root`:
 
 ```bash
-# Initialize isolated roots
-amq coop init --root .agent-mail/auth
-amq coop init --root .agent-mail/api
-
 # Pair A: auth feature
-amq coop start --root .agent-mail/auth claude && claude   # Terminal 1
-amq coop start --root .agent-mail/auth codex && codex     # Terminal 2
+amq coop exec --root .agent-mail/auth claude      # Terminal 1
+amq coop exec --root .agent-mail/auth codex       # Terminal 2
 
 # Pair B: api refactor
-amq coop start --root .agent-mail/api claude && claude    # Terminal 3
-amq coop start --root .agent-mail/api codex && codex      # Terminal 4
-
-# Commands need --root to stay isolated
-amq send --me claude --to codex --root .agent-mail/auth --body "Auth review"
+amq coop exec --root .agent-mail/api claude       # Terminal 3
+amq coop exec --root .agent-mail/api codex        # Terminal 4
 ```
 
-Each pair has isolated inboxes and threads. Messages stay within their root—auth-Claude talks to auth-Codex, never api-Codex.
+Each pair has isolated inboxes and threads. Messages stay within their root.
 
-### How It Works
+### For Scripts/CI
 
-1. `amq coop start <agent>` initializes the project (if needed) and tells you to run the agent
-2. Run the agent yourself with any flags you need
-3. Use `amq drain --me <agent> --include-body` periodically to check for messages
-4. Optionally run `amq wake --me <agent> &` before starting for terminal notifications
-5. Agents work autonomously—messaging the initiator, not a bystander
+When you can't use `exec` (non-interactive environments):
+```bash
+amq coop init
+eval "$(amq env --me claude)"
+```
 
 ### Fallback: Notify Hook (if wake unavailable)
 
@@ -189,241 +89,151 @@ If wake fails, configure the notify hook for desktop notifications:
 notify = ["python3", "/path/to/repo/scripts/codex-amq-notify.py"]
 ```
 
-The hook surfaces pending messages after each agent turn + sends desktop notification.
+## Roles
 
-## Message Format
+- **Initiator** = whoever starts the task (agent or human). Owns decisions and receives all updates.
+- **Leader/Coordinator** = coordinates phases, merges, and final decisions (often the initiator).
+- **Worker** = executes assigned phases and reports back to the initiator.
 
-Co-op mode extends the standard AMQ message format with optional fields:
+**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator.
 
-```json
-{
-  "schema": 1,
-  "id": "2025-12-27T12-00-00.000Z_pid1234_abcd",
-  "from": "codex",
-  "to": ["claude"],
-  "thread": "p2p/claude__codex",
-  "subject": "Code review needed",
-  "created": "2025-12-27T12:00:00Z",
-  "ack_required": true,
-  "refs": ["msg_prev_123"],
-  "priority": "urgent",
-  "kind": "review_request",
-  "labels": ["parser", "edge-cases"],
-  "context": {
-    "paths": ["internal/cli/drain.go"],
-    "focus": "sorting + ack behavior"
-  }
-}
-```
+## Phased Flow
 
-### Priority Levels
+| Phase | Mode | Description |
+|-------|------|-------------|
+| **Research** | Parallel | Both explore codebase, read docs, search. No conflicts. |
+| **Design** | Parallel → Merge | Both propose approaches. Leader merges/decides. |
+| **Code** | Split | Divide by file/module. Never edit same file. |
+| **Review** | Parallel | Both review each other's code. Leader decides disputes. |
+| **Test** | Parallel | Both run tests, report results to leader. |
 
-| Priority | Behavior | Use When |
-|----------|----------|----------|
-| `urgent` | Interrupt current work (label `interrupt` enables wake Ctrl+C) | Blocking issues, critical bugs, time-sensitive |
-| `normal` | Add to TODO list | Code reviews, questions, standard requests |
-| `low` | Batch/digest later | Status updates, FYIs, non-blocking info |
+## Core Principles
 
-### Message Kinds
+1. **Parallel where safe** - Research, design, review, and test phases run in parallel.
+2. **Split where risky** - Code phase divides files/modules to avoid conflicts.
+3. **Never branch** - Always work on same branch (joined work).
+4. **Leader coordinates** - The initiator or designated leader handles phase transitions and final decisions.
 
-| Kind | Default Priority | Description |
-|------|------------------|-------------|
-| `review_request` | normal | Request code review |
-| `review_response` | normal | Code review feedback |
-| `question` | normal | Question needing answer |
-| `answer` | normal | Response to a question |
-| `decision` | normal | Decision request |
-| `brainstorm` | low | Open-ended discussion |
-| `status` | low | Status update/FYI |
-| `todo` | normal | Task assignment |
+## Initiator Rule
+
+- The **initiator** is whoever started the task (agent or human).
+- Always report progress and completion to the initiator.
+- Ask questions only to the initiator. Do not ask a third party.
+
+## Progress Protocol (Start / Heartbeat / Done)
+
+- **Start**: send `kind=status` with an ETA to the initiator as soon as you begin.
+- **Heartbeat**: update on phase boundaries or every 10-15 minutes.
+- **Done**: send Summary / Changes / Tests / Notes to the initiator.
+- **Blocked**: send `kind=question` to the initiator with options and a recommendation.
+
+## Modes of Collaboration
+
+Pick one mode per task; the initiator decides.
+
+- **Leader + Worker**: leader decides, worker executes; best default.
+- **Co-workers**: peers decide together; if no consensus, ask the initiator.
+- **Duplicate**: independent solutions or reviews; initiator merges results.
+- **Driver + Navigator**: driver codes, navigator reviews/tests and can interrupt.
+- **Spec + Implementer**: one writes spec/tests, the other implements.
+- **Reviewer + Implementer**: one codes, the other focuses on review and risk detection.
 
 ## CLI Commands
 
-### Send with Co-op Fields
+### Send
 
 ```bash
-# Request a code review
-amq send --me claude --to codex \
-  --subject "Review: New parser" \
-  --priority normal \
-  --kind review_request \
-  --body "Please review the new message parser..."
-
-# Urgent blocking question
-amq send --me codex --to claude \
-  --subject "Blocked: API design question" \
-  --priority urgent \
-  --kind question \
-  --body "I need to decide on the API shape..."
+amq send --to codex --subject "Review: New parser" --kind review_request --body "..."
+amq send --to codex --priority urgent --kind question --body "Blocked on API"
 ```
 
-### Receive Messages
+### Receive
 
 ```bash
-# Recommended: one-shot drain
-amq drain --include-body
-
-# Wait for messages (blocking)
-amq watch --timeout 60s
-
-# Peek without side effects
-amq list --new
+amq drain --include-body                          # One-shot, silent when empty
+amq watch --timeout 60s                           # Block until message arrives
+amq list --new                                    # Peek without side effects
 ```
 
 ### Reply (Auto Thread/Refs)
 
 ```bash
-amq reply --me codex --id "msg_123" \
-  --kind review_response \
-  --body "LGTM with minor suggestions..."
+amq reply --id "msg_123" --kind review_response --body "LGTM with minor suggestions..."
 ```
 
 ## Wake Command (Optional)
 
-> Co-op works without wake. This is an optional enhancement for interactive terminals.
+> Co-op works without wake. `coop exec` starts it automatically.
 
-`amq wake` uses TIOCSTI to inject notifications into your terminal:
-
-```bash
-# Start waker before CLI
-amq wake --me claude &
-claude
-```
+`amq wake` uses TIOCSTI to inject notifications into your terminal.
 
 **Options:**
-- `--inject-mode auto|raw|paste` - Injection strategy (see below)
+- `--inject-mode auto|raw|paste` - Injection strategy
 - `--bell` - Ring terminal bell on new messages
-- `--inject-cmd "..."` - Inject actual command instead of notification
 - `--debounce 250ms` - Batch rapid messages
-- `--preview-len 48` - Max subject preview length
-- `--interrupt` - Enable interrupt injection for urgent interrupt messages (default: true)
-- `--interrupt-label interrupt` - Label required to trigger interrupt
-- `--interrupt-priority urgent` - Priority required to trigger interrupt
-- `--interrupt-cmd ctrl-c|none` - Interrupt command to inject
-- `--interrupt-notice "..."` - Custom interrupt notice (default: auto)
-- `--interrupt-cooldown 7s` - Minimum time between interrupts
-
-**Inject Modes:**
-- `auto` (default) - Detects CLI type: uses `raw` for Claude Code/Codex, `paste` for others
-- `raw` - Plain text + carriage return, no bracketed paste (best for Ink-based CLIs)
-- `paste` - Bracketed paste with delayed CR (best for crossterm-based CLIs)
-
-If notifications appear but require manual Enter, use `--inject-mode=raw`.
-
-**Interrupts:**
-
-Urgent messages tagged with label `interrupt` trigger a Ctrl+C injection followed by an interrupt notice.
-
-```bash
-amq send --me claude --to codex \
-  --priority urgent --labels interrupt --kind status \
-  --body "Interrupt needed: stop and drain."
-```
-
-Disable interrupts with `--interrupt=false`. Use `--interrupt-cmd none` for notice-only.
-
-**Notification format:**
-- Single message: `AMQ: message from codex - Review complete. Drain with: amq drain --include-body — then act on it`
-- Multiple: `AMQ: 3 messages - 2 from codex, 1 from claude. Drain with: amq drain --include-body — then act on it`
+- `--interrupt` / `--interrupt=false` - Enable/disable Ctrl+C for urgent messages
 
 **Platform support:**
 - macOS: Works
 - Linux: May be disabled by kernel hardening (CONFIG_LEGACY_TIOCSTI)
 - Windows: Not supported (use WSL)
 
-## Review Partner Workflow
-
-### Requesting a Review
-
-```bash
-amq send --me claude --to codex \
-  --subject "Review: Authentication refactor" \
-  --kind review_request \
-  --priority normal \
-  --context '{"paths": ["internal/auth/"], "focus": "JWT handling"}' \
-  --body @review-request.md \
-  --ack
-```
-
-### Responding to a Review
-
-```bash
-amq reply --me codex --id "msg_review_123" \
-  --kind review_response \
-  --body @review-response.md
-```
-
-## Progress Updates for Long-Running Work
-
-When starting work that may take a while, send a status message to the initiator so they know you're working on it:
-
-```bash
-# Signal you've started (optional ETA)
-amq reply --me codex --id "msg_review_123" \
-  --kind status \
-  --body "Started processing, eta ~20m"
-
-# If blocked, send another status
-amq reply --me codex --id "msg_review_123" \
-  --kind status \
-  --body "Blocked: waiting for API clarification"
-
-# When done, send the final response (use appropriate kind: answer, review_response, etc.)
-amq reply --me codex --id "msg_review_123" \
-  --kind answer \
-  --body "Summary:\n- ...\nChanges:\n- ...\nTests:\n- ...\nNotes:\n- ..."
-```
-
-The sender can check progress via thread view:
-
-```bash
-amq thread --id <thread_id> --include-body --limit 5
-```
-
-This pattern helps when:
-- Claude is faster than Codex (or vice versa)
-- Long tasks where the sender might think you're not responding
-- You're blocked and need to communicate why
-
-## Context Object Schema
-
-The `context` field accepts any JSON object. Recommended structure:
+## Message Format
 
 ```json
 {
-  "paths": ["internal/cli/send.go", "internal/format/message.go"],
-  "symbols": ["Header", "runSend"],
-  "focus": "error handling in validation",
-  "commands": ["go test ./internal/cli/..."],
-  "hunks": [{"file": "send.go", "lines": "45-60"}]
+  "schema": 1,
+  "from": "codex",
+  "to": ["claude"],
+  "thread": "p2p/claude__codex",
+  "subject": "Code review needed",
+  "priority": "urgent",
+  "kind": "review_request",
+  "labels": ["parser"],
+  "context": {"paths": ["internal/cli/drain.go"], "focus": "sorting"}
 }
 ```
 
-## Best Practices
+### Priority Levels
 
-1. **Always set priority** - Helps receiving agent triage
-2. **Use appropriate kind** - Enables smart auto-responses
-3. **Include context.paths** - Helps focus the review
-4. **Keep bodies concise** - Agent context is precious
-5. **Use --ack for important messages** - Ensures delivery confirmation
-6. **Thread replies** - Use `amq reply` for conversation continuity
+| Priority | Behavior |
+|----------|----------|
+| `urgent` | Interrupt current work |
+| `normal` | Add to TODO list |
+| `low` | Batch for later |
+
+### Message Kinds
+
+| Kind | Reply Kind | Default Priority |
+|------|------------|------------------|
+| `review_request` | `review_response` | normal |
+| `question` | `answer` | normal |
+| `decision` | — | normal |
+| `todo` | — | normal |
+| `status` | — | low |
+| `brainstorm` | — | low |
+
+## Context Object Schema
+
+```json
+{
+  "paths": ["internal/cli/send.go"],
+  "symbols": ["Header", "runSend"],
+  "focus": "error handling in validation",
+  "commands": ["go test ./internal/cli/..."]
+}
+```
 
 ## Troubleshooting
 
 ### Wake not working
 ```bash
-# Test: run amq wake and watch for warnings
-amq wake --me claude
-
-# If TIOCSTI unavailable, use notify hook (see Fallback section above)
-# Or poll manually: amq drain --include-body
+amq wake --me claude                              # Watch for warnings
+amq drain --include-body                          # Manual fallback
 ```
 
 ### Messages not appearing
 ```bash
-# Check inbox directly
-amq list --me claude --new --json
-
-# Force poll mode if fsnotify issues
-amq watch --me claude --poll
+amq list --me claude --new --json                 # Check inbox directly
+amq watch --me claude --poll                      # Force poll mode
 ```

--- a/README.md
+++ b/README.md
@@ -83,20 +83,19 @@ This creates `.amqrc`, mailboxes for `claude` and `codex`, and updates `.gitigno
 
 **Terminal 1 — Claude Code:**
 ```bash
-amq coop start claude   # Sets up + starts wake, then run:
-claude                  # With any flags you need
+amq coop exec claude
 ```
 
 **Terminal 2 — Codex CLI:**
 ```bash
-amq coop start codex    # Sets up + starts wake, then run:
-codex                   # With any flags you need
+amq coop exec codex -- --dangerously-skip-permissions
 ```
+
+`coop exec` auto-initializes if needed, sets `AM_ROOT`/`AM_ME`, starts wake, and execs into the agent.
 
 Use `--root` for isolated sessions (multiple pairs):
 ```bash
-amq coop init --root .agent-mail/feature-a
-amq coop start --root .agent-mail/feature-a claude
+amq coop exec --root .agent-mail/feature-a claude
 ```
 
 ### 3. Send & Receive
@@ -145,9 +144,8 @@ For real-time Claude Code + Codex CLI collaboration, see [COOP.md](COOP.md).
 
 **Quick setup:**
 ```bash
-amq coop init              # Initialize project
-amq coop start claude      # Terminal 1: Claude Code
-amq coop start codex       # Terminal 2: Codex CLI
+amq coop exec claude       # Terminal 1: Claude Code
+amq coop exec codex        # Terminal 2: Codex CLI
 ```
 
 ## Swarm Mode (Claude Code Agent Teams)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -128,7 +128,7 @@ func printUsage() error {
 	if err := writeStdoutLine("  env       Output shell commands to set environment variables"); err != nil {
 		return err
 	}
-	if err := writeStdoutLine("  coop      Simplified co-op mode setup (init, shell, start)"); err != nil {
+	if err := writeStdoutLine("  coop      Co-op mode setup (init, exec)"); err != nil {
 		return err
 	}
 	if err := writeStdoutLine("  swarm     Claude Code Agent Teams integration (join, tasks, bridge)"); err != nil {

--- a/internal/cli/coop_exec_other.go
+++ b/internal/cli/coop_exec_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package cli
+
+import "errors"
+
+func runCoopExec(args []string) error {
+	return errors.New("amq coop exec is not supported on this platform (requires macOS or Linux)")
+}

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -1,0 +1,137 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"testing"
+)
+
+func TestSplitDashDash(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      []string
+		wantBefore []string
+		wantAfter  []string
+	}{
+		{
+			name:       "no separator",
+			input:      []string{"claude"},
+			wantBefore: []string{"claude"},
+			wantAfter:  nil,
+		},
+		{
+			name:       "separator with args",
+			input:      []string{"--root", "/tmp/q", "codex", "--", "--some-flag", "--other"},
+			wantBefore: []string{"--root", "/tmp/q", "codex"},
+			wantAfter:  []string{"--some-flag", "--other"},
+		},
+		{
+			name:       "separator at start",
+			input:      []string{"--", "claude", "-v"},
+			wantBefore: []string{},
+			wantAfter:  []string{"claude", "-v"},
+		},
+		{
+			name:       "separator at end",
+			input:      []string{"claude", "--"},
+			wantBefore: []string{"claude"},
+			wantAfter:  []string{},
+		},
+		{
+			name:       "empty input",
+			input:      []string{},
+			wantBefore: []string{},
+			wantAfter:  nil,
+		},
+		{
+			name:       "multiple separators",
+			input:      []string{"a", "--", "b", "--", "c"},
+			wantBefore: []string{"a"},
+			wantAfter:  []string{"b", "--", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before, after := splitDashDash(tt.input)
+			if !sliceEq(before, tt.wantBefore) {
+				t.Errorf("before = %v, want %v", before, tt.wantBefore)
+			}
+			if !sliceEq(after, tt.wantAfter) {
+				t.Errorf("after = %v, want %v", after, tt.wantAfter)
+			}
+		})
+	}
+}
+
+func TestSetEnvVar(t *testing.T) {
+	t.Run("append new", func(t *testing.T) {
+		env := []string{"PATH=/bin", "HOME=/home"}
+		got := setEnvVar(env, "AM_ROOT", "/tmp/q")
+		if len(got) != 3 {
+			t.Fatalf("len = %d, want 3", len(got))
+		}
+		if got[2] != "AM_ROOT=/tmp/q" {
+			t.Fatalf("got[2] = %q, want %q", got[2], "AM_ROOT=/tmp/q")
+		}
+	})
+
+	t.Run("replace existing", func(t *testing.T) {
+		env := []string{"PATH=/bin", "AM_ROOT=/old", "HOME=/home"}
+		got := setEnvVar(env, "AM_ROOT", "/new")
+		if len(got) != 3 {
+			t.Fatalf("len = %d, want 3", len(got))
+		}
+		if got[1] != "AM_ROOT=/new" {
+			t.Fatalf("got[1] = %q, want %q", got[1], "AM_ROOT=/new")
+		}
+	})
+}
+
+func TestCoopExecUsageError(t *testing.T) {
+	err := runCoopExec([]string{})
+	if err == nil {
+		t.Fatal("expected error for empty args")
+	}
+	exitErr, ok := err.(*ExitCodeError)
+	if !ok {
+		t.Fatalf("expected *ExitCodeError, got %T: %v", err, err)
+	}
+	if exitErr.Code != ExitUsage {
+		t.Fatalf("expected ExitUsage (%d), got %d", ExitUsage, exitErr.Code)
+	}
+	if !containsStr(err.Error(), "command required") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func sliceEq(a, b []string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && searchStr(s, sub)
+}
+
+func searchStr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -1,0 +1,195 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func runCoopExec(args []string) error {
+	// Split at "--" before flag parsing so agent flags aren't consumed.
+	amqArgs, agentArgs := splitDashDash(args)
+
+	fs := flag.NewFlagSet("coop exec", flag.ContinueOnError)
+	rootFlag := fs.String("root", "", "Root directory (override auto-detection)")
+	meFlag := fs.String("me", "", "Agent handle (override auto-derivation from command name)")
+	noInitFlag := fs.Bool("no-init", false, "Don't auto-initialize if .amqrc is missing")
+	noWakeFlag := fs.Bool("no-wake", false, "Don't start amq wake in background")
+	yesFlag := fs.Bool("y", false, "Skip confirmation prompts")
+
+	usage := usageWithFlags(fs, "amq coop exec [options] <command> [-- <command-flags>]",
+		"Set up co-op mode and exec into the agent (replaces this process).",
+		"",
+		"Sets AM_ROOT and AM_ME, starts amq wake in background, then",
+		"replaces itself with the given command via exec.",
+		"",
+		"The agent handle is derived from the command basename unless --me is set.",
+		"",
+		"Examples:",
+		"  amq coop exec claude                              # Exec into Claude Code",
+		"  amq coop exec codex -- --dangerously-skip-permissions  # Codex with flags",
+		"  amq coop exec --root .agent-mail/auth claude      # Isolated session",
+		"  amq coop exec --me myagent bash                   # Debug shell with AMQ env",
+	)
+
+	if handled, err := parseFlags(fs, amqArgs, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return UsageError("command required (e.g., 'claude', 'codex', 'bash')")
+	}
+	cmdName := remaining[0]
+	// Extra positional args before "--" are appended to agent args.
+	if len(remaining) > 1 {
+		agentArgs = append(remaining[1:], agentArgs...)
+	}
+
+	// Derive agent handle from command basename (or --me override).
+	agentHandle := *meFlag
+	if agentHandle == "" {
+		agentHandle = strings.ToLower(filepath.Base(cmdName))
+	}
+	agentHandle, err := normalizeHandle(agentHandle)
+	if err != nil {
+		return fmt.Errorf("cannot derive agent handle from %q: %w (use --me to override)", cmdName, err)
+	}
+
+	// Resolve root: --root flag > .amqrc > default.
+	root := *rootFlag
+	if root == "" {
+		existing, existingErr := findAndLoadAmqrc()
+		switch existingErr {
+		case nil:
+			root = existing.Config.Root
+			if root != "" && !filepath.IsAbs(root) {
+				root = filepath.Join(existing.Dir, root)
+			}
+		case errAmqrcNotFound:
+			// Will auto-init below.
+		default:
+			return fmt.Errorf("invalid .amqrc: %w", existingErr)
+		}
+	}
+
+	// Auto-init if needed.
+	if root == "" || !dirExists(root) {
+		if *noInitFlag {
+			if root == "" {
+				return fmt.Errorf("no .amqrc found and no --root specified; run 'amq coop init' first or remove --no-init")
+			}
+			return fmt.Errorf("root %q does not exist; run 'amq coop init' first or remove --no-init", root)
+		}
+
+		if !*yesFlag {
+			ok, err := confirmPromptYes("No .amqrc found. Initialize co-op mode in current directory?")
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("initialization cancelled")
+			}
+		}
+
+		var initArgs []string
+		if *rootFlag != "" {
+			initArgs = append(initArgs, "--root", *rootFlag)
+		}
+		if err := runCoopInitInternal(initArgs, false); err != nil {
+			return fmt.Errorf("init failed: %w", err)
+		}
+
+		// Reload root after init.
+		existing, existingErr := findAndLoadAmqrc()
+		if existingErr != nil {
+			return fmt.Errorf("failed to load .amqrc after init: %w", existingErr)
+		}
+		root = existing.Config.Root
+		if root != "" && !filepath.IsAbs(root) {
+			root = filepath.Join(existing.Dir, root)
+		}
+	}
+
+	// Ensure agent mailbox exists.
+	if err := fsq.EnsureAgentDirs(root, agentHandle); err != nil {
+		return fmt.Errorf("failed to ensure mailbox for %s: %w", agentHandle, err)
+	}
+
+	// Resolve command binary.
+	binaryPath, err := exec.LookPath(cmdName)
+	if err != nil {
+		return fmt.Errorf("command not found: %s", cmdName)
+	}
+
+	// Start amq wake in background (unless --no-wake).
+	// On successful Exec, wake is orphaned (reparented to init/launchd) — intended.
+	// On failed Exec, deferred kill cleans up the wake process.
+	var wakeProc *os.Process
+	if !*noWakeFlag {
+		amqBin, binErr := os.Executable()
+		if binErr != nil {
+			amqBin = "amq"
+		}
+
+		wakeCmd := exec.Command(amqBin, "wake", "--me", agentHandle, "--root", root)
+		wakeCmd.Stdin = os.Stdin
+		wakeCmd.Stdout = os.Stdout
+		wakeCmd.Stderr = os.Stderr
+
+		if err := wakeCmd.Start(); err != nil {
+			_ = writeStderr("warning: failed to start amq wake: %v\n", err)
+		} else {
+			wakeProc = wakeCmd.Process
+			_ = writeStderr("Started amq wake (pid %d)\n", wakeProc.Pid)
+		}
+	}
+
+	// Build environment with AM_ROOT and AM_ME.
+	env := setEnvVar(os.Environ(), envRoot, root)
+	env = setEnvVar(env, envMe, agentHandle)
+
+	// Build argv: command name + agent args.
+	argv := append([]string{cmdName}, agentArgs...)
+
+	// Replace process. On success, this never returns.
+	// On failure, clean up the wake process.
+	execErr := syscall.Exec(binaryPath, argv, env)
+	if wakeProc != nil {
+		_ = wakeProc.Kill()
+	}
+	return execErr
+}
+
+// splitDashDash splits args at the first "--" separator.
+// Returns (before, after) where "--" itself is excluded from both.
+func splitDashDash(args []string) ([]string, []string) {
+	for i, arg := range args {
+		if arg == "--" {
+			return args[:i], args[i+1:]
+		}
+	}
+	return args, nil
+}
+
+// setEnvVar sets or replaces an environment variable in a slice.
+func setEnvVar(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, v := range env {
+		if strings.HasPrefix(v, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -205,5 +205,4 @@ if [ "$INSTALL_SKILL" = true ]; then
 fi
 
 echo "Next steps:"
-echo "  1. Initialize: amq coop init"
-echo "  2. Start agent: amq coop start claude"
+echo "  1. Start agent: amq coop exec claude"


### PR DESCRIPTION
## Summary

- **`coop exec`**: one command to set `AM_ROOT`/`AM_ME`, start wake, and `syscall.Exec` into the agent — replaces the two-step `coop start` + manual agent launch
- **`.amqrc` in `defaultRoot()`**: all commands (`send`, `list`, `drain`, etc.) now resolve root from `.amqrc` automatically via `sync.Once` cache, no env vars needed for single-root projects
- **Removed `coop shell` and `coop start`**: `shell` was an alias for `amq env`; `start` was a subset of `exec` with root-mismatch risk. Simplifies coop surface from 5 commands to 3 (`init`, `exec`, `env`)

## Breaking Changes

- `amq coop shell` removed — use `amq env` directly
- `amq coop start` removed — use `amq coop exec <agent>`

## Migration

```bash
# Before (two steps):
amq coop start claude && claude

# After (one step):
amq coop exec claude
```

## Test plan

- [x] `make ci` passes (fmt-check, vet, lint, test, smoke)
- [x] Pre-push hook passes
- [x] Smoke test: `.amqrc` root detection
- [x] Smoke test: `coop exec bash -- -c 'echo $AM_ROOT:$AM_ME'`
- [x] Unit tests for `defaultRoot()` with `.amqrc` (3 tests)
- [x] Unit tests for `splitDashDash`, `setEnvVar`, `runCoopExec` error
- [x] Doc consistency: zero stale references to `coop shell`/`coop start`
- [x] Codex review: build tags, wake cleanup on exec failure

Net: +520/-1,378 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)