### PR TITLE
chore: add CI, release, and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Agent Message Queue (AMQ)
 
+[![CI](https://github.com/avivsinai/agent-message-queue/actions/workflows/ci.yml/badge.svg)](https://github.com/avivsinai/agent-message-queue/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/avivsinai/agent-message-queue)](https://github.com/avivsinai/agent-message-queue/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 **The missing coordination layer for multi-agent development.**
 
 When you're running Claude Code and Codex CLI in parallel—reviewing each other's work, dividing tasks, iterating on implementations—how do they talk to each other? AMQ solves this.


### PR DESCRIPTION
## Summary
- Adds CI status, latest release, and MIT license badges to the top of README.md

## Test plan
- [x] Visual check — badges render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)