### PR TITLE
fix: tighten post-merge spec workflow follow-ups

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   "repository": "https://github.com/avivsinai/agent-message-queue",
   "license": "MIT",
   "skills": "./skills/",
-  "keywords": ["messaging", "agents", "maildir", "queue", "inter-agent", "coop"]
+  "keywords": ["messaging", "agents", "maildir", "queue", "inter-agent", "coop", "spec"]
 }

--- a/.claude/skills/amq-cli/references/coop-mode.md
+++ b/.claude/skills/amq-cli/references/coop-mode.md
@@ -13,22 +13,22 @@
 | Phase | Mode | Description |
 |-------|------|-------------|
 | **Research** | Parallel | Both explore codebase, read docs, search. No conflicts. |
-| **Design** | Parallel → Merge | Both propose approaches. Leader merges/decides. |
+| **Design** | Parallel -> Merge | Both propose approaches. Leader merges/decides. |
 | **Code** | Split | Divide by file/module. Never edit same file. |
 | **Review** | Parallel | Both review each other's code. Leader decides disputes. |
 | **Test** | Parallel | Both run tests, report results to leader. |
 
 ```
 Research (parallel) -> sync findings
-    ↓
+    v
 Design (parallel) -> leader merges approach
-    ↓
+    v
 Code (split: divide files/modules)
-    ↓
+    v
 Review (parallel: each reviews other's code)
-    ↓
+    v
 Test (parallel: both run tests)
-    ↓
+    v
 Leader prepares commit -> user approves -> push
 ```
 

--- a/.codex/skills/amq-cli/references/coop-mode.md
+++ b/.codex/skills/amq-cli/references/coop-mode.md
@@ -13,22 +13,22 @@
 | Phase | Mode | Description |
 |-------|------|-------------|
 | **Research** | Parallel | Both explore codebase, read docs, search. No conflicts. |
-| **Design** | Parallel → Merge | Both propose approaches. Leader merges/decides. |
+| **Design** | Parallel -> Merge | Both propose approaches. Leader merges/decides. |
 | **Code** | Split | Divide by file/module. Never edit same file. |
 | **Review** | Parallel | Both review each other's code. Leader decides disputes. |
 | **Test** | Parallel | Both run tests, report results to leader. |
 
 ```
 Research (parallel) -> sync findings
-    ↓
+    v
 Design (parallel) -> leader merges approach
-    ↓
+    v
 Code (split: divide files/modules)
-    ↓
+    v
 Review (parallel: each reviews other's code)
-    ↓
+    v
 Test (parallel: both run tests)
-    ↓
+    v
 Leader prepares commit -> user approves -> push
 ```
 

--- a/.github/workflows/publish-skill.yml
+++ b/.github/workflows/publish-skill.yml
@@ -29,24 +29,28 @@ jobs:
           FAILED=0
 
           for SKILL in amq-cli amq-spec; do
-            VERSION=$(grep -oP 'version:\s*\K[\d.]+' "skills/$SKILL/SKILL.md")
+            VERSION=$(grep -oP 'version:\s*\K[\d.]+' "skills/$SKILL/SKILL.md") || true
+            if [ -z "$VERSION" ]; then
+              echo "ERROR: Could not extract version from skills/$SKILL/SKILL.md"
+              FAILED=1
+              continue
+            fi
             echo "Publishing $SKILL version: $VERSION"
 
-            OUTPUT=$(npx skild publish \
+            if OUTPUT=$(npx skild publish \
               --dir "skills/$SKILL" \
               --alias "$SKILL" \
-              --skill-version "$VERSION" 2>&1) || true
-
-            echo "$OUTPUT"
-
-            if echo "$OUTPUT" | grep -q "Version already exists"; then
+              --skill-version "$VERSION" 2>&1); then
+              echo "$OUTPUT"
+              echo "✓ Published $SKILL version $VERSION"
+            elif echo "$OUTPUT" | grep -q "Version already exists"; then
+              echo "$OUTPUT"
               echo ""
               echo "⚠ $SKILL version $VERSION already published - skipping"
               echo "  To publish updates, bump version in skills/$SKILL/SKILL.md"
-            elif echo "$OUTPUT" | grep -q "✔\|Published\|success"; then
-              echo "✓ Published $SKILL version $VERSION"
             else
               echo "✖ Publish failed for $SKILL"
+              echo "$OUTPUT"
               FAILED=1
             fi
           done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,7 +412,8 @@ This repo includes skills for Claude Code and Codex CLI, distributed via the [sk
 ├── SKILL.md
 └── references/
     ├── coop-mode.md
-    └── message-format.md
+    ├── message-format.md
+    └── swarm-mode.md
 .claude/skills/amq-spec/       → Spec workflow skill (SOURCE OF TRUTH)
 ├── SKILL.md
 └── references/

--- a/internal/cli/reply_test.go
+++ b/internal/cli/reply_test.go
@@ -123,6 +123,7 @@ func TestReply_Basic(t *testing.T) {
 }
 
 func TestReply_ReviewRequest(t *testing.T) {
+	t.Setenv("AM_ROOT", "") // Clear to avoid guardRootOverride conflict with --root
 	root := t.TempDir()
 	alice := "alice"
 	bob := "bob"
@@ -179,7 +180,9 @@ func TestReply_ReviewRequest(t *testing.T) {
 	n, _ := r.Read(buf[:])
 
 	var result map[string]any
-	_ = json.Unmarshal(buf[:n], &result)
+	if err := json.Unmarshal(buf[:n], &result); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
 
 	// Verify Bob received the reply
 	bobInbox := fsq.AgentInboxNew(root, bob)
@@ -189,7 +192,10 @@ func TestReply_ReviewRequest(t *testing.T) {
 	}
 
 	replyPath := filepath.Join(bobInbox, entries[0].Name())
-	replyMsg, _ := format.ReadMessageFile(replyPath)
+	replyMsg, err := format.ReadMessageFile(replyPath)
+	if err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
 
 	// Kind should be auto-set to review_response
 	if replyMsg.Header.Kind != format.KindReviewResponse {
@@ -254,7 +260,9 @@ func TestReply_BrainstormPassthrough(t *testing.T) {
 	n, _ := r.Read(buf[:])
 
 	var result map[string]any
-	_ = json.Unmarshal(buf[:n], &result)
+	if err := json.Unmarshal(buf[:n], &result); err != nil {
+		t.Fatalf("parse output: %v", err)
+	}
 
 	// Verify Bob received the reply
 	bobInbox := fsq.AgentInboxNew(root, bob)
@@ -264,7 +272,10 @@ func TestReply_BrainstormPassthrough(t *testing.T) {
 	}
 
 	replyPath := filepath.Join(bobInbox, entries[0].Name())
-	replyMsg, _ := format.ReadMessageFile(replyPath)
+	replyMsg, err := format.ReadMessageFile(replyPath)
+	if err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
 
 	// Kind should be preserved as brainstorm (default passthrough)
 	if replyMsg.Header.Kind != format.KindBrainstorm {
@@ -273,6 +284,7 @@ func TestReply_BrainstormPassthrough(t *testing.T) {
 }
 
 func TestReply_PreservesThread(t *testing.T) {
+	t.Setenv("AM_ROOT", "") // Clear to avoid guardRootOverride conflict with --root
 	root := t.TempDir()
 	alice := "alice"
 	bob := "bob"

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -13,22 +13,22 @@
 | Phase | Mode | Description |
 |-------|------|-------------|
 | **Research** | Parallel | Both explore codebase, read docs, search. No conflicts. |
-| **Design** | Parallel → Merge | Both propose approaches. Leader merges/decides. |
+| **Design** | Parallel -> Merge | Both propose approaches. Leader merges/decides. |
 | **Code** | Split | Divide by file/module. Never edit same file. |
 | **Review** | Parallel | Both review each other's code. Leader decides disputes. |
 | **Test** | Parallel | Both run tests, report results to leader. |
 
 ```
 Research (parallel) -> sync findings
-    ↓
+    v
 Design (parallel) -> leader merges approach
-    ↓
+    v
 Code (split: divide files/modules)
-    ↓
+    v
 Review (parallel: each reviews other's code)
-    ↓
+    v
 Test (parallel: both run tests)
-    ↓
+    v
 Leader prepares commit -> user approves -> push
 ```
 


### PR DESCRIPTION
## Summary
- Add empty-version guard in publish-skill.yml to fail fast with clear error
- Switch publish success detection from output-scraping to exit code check
- Fix two reply tests missing `t.Setenv("AM_ROOT", "")` (environment-dependent failures)
- Stop silently discarding errors from `json.Unmarshal` and `ReadMessageFile` in tests
- Add `swarm-mode.md` to CLAUDE.md skill structure tree
- Convert remaining unicode arrows to ASCII in coop-mode.md
- Add "spec" keyword to plugin.json

## Test plan
- [x] `make ci` passes
- [x] `make check-skills` passes (all 3 copies synced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)