### PR TITLE
chore(release): v0.31.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.31.0] - 2026-04-09
+### Added
+
+- Added delivery receipts with `drained` and `dlq` stages, plus the new `amq receipts list` and `amq receipts wait` commands for querying receipt history and waiting on receipt arrival.
+- Added `amq send --wait-for <stage>` so senders can block for delivery confirmation on single-recipient handoffs.
+- Added `receipt.WaitFor()` for targeted receipt polling by message id, consumer, and stage.
+
+### Changed
+
+- Replaced the old ack model with a receipt ledger stored under agent `receipts/` directories.
+- Simplified receipt emission to consumer-local writes, with send-side waits reading from the actual delivery root instead of relying on mirrored receipt files.
+- Bumped the Go toolchain to 1.25.9.
+
+### Removed
+
+- Removed the `amq ack` command, `--ack` flags, `ack_required` header field, and `acks/` directories from the active protocol and docs.
+
+### Fixed
+
+- Validated `header.ID` in `amq read` before emitting receipts, closing a path-manipulation risk on malformed message headers.
 
 ## [0.30.1] - 2026-04-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-04-09
+
 ## [0.30.1] - 2026-04-05
 ### Added
 

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-cli
-version: 0.30.1
+version: 0.31.0
 description: >-
   Coordinate agents via the AMQ CLI for file-based inter-agent messaging. Use
   this skill whenever you need to send messages to another agent (codex, claude,

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-spec
-version: 0.30.1
+version: 0.31.0
 description: >-
   Parallel-research-then-converge design workflow between two agents. Use this
   skill when the user wants two agents to independently think through a design


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.31.0`
- aligns skill/plugin metadata to `0.31.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.31.0`, publishes the GitHub/Homebrew release, and then publishes skills to the marketplace