### PR TITLE
Align read validation with receipt wait cleanup

### DIFF
--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -36,6 +36,10 @@ func runRead(args []string) error {
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
 	}
+	validator, err := newHeaderValidator(root, common.Strict)
+	if err != nil {
+		return err
+	}
 
 	filename, err := ensureFilename(*idFlag)
 	if err != nil {
@@ -55,14 +59,15 @@ func runRead(args []string) error {
 	if err != nil {
 		// If message is corrupt and in new, move to DLQ
 		if box == fsq.BoxNew {
-			if _, dlqErr := fsq.MoveToDLQ(root, common.Me, filename, *idFlag, "parse_error", err.Error()); dlqErr != nil {
-				_ = writeStderr("warning: failed to move corrupt message to DLQ: %v\n", dlqErr)
-			} else {
-				r := receipt.New(*idFlag, "", "", common.Me, receipt.StageDLQ, err.Error())
-				_ = receipt.Emit(root, r)
-			}
+			moveReadFailureToDLQ(root, common.Me, filename, *idFlag, "parse_error", err.Error(), nil)
 		}
 		return fmt.Errorf("failed to parse message %s: %w", *idFlag, err)
+	}
+	if err := validator.validate(msg.Header); err != nil {
+		if box == fsq.BoxNew {
+			moveReadFailureToDLQ(root, common.Me, filename, *idFlag, "invalid_header", "invalid header: "+err.Error(), &msg.Header)
+		}
+		return fmt.Errorf("invalid message header %s: %w", *idFlag, err)
 	}
 
 	// Move to cur only after successful parse
@@ -90,4 +95,21 @@ func runRead(args []string) error {
 		return err
 	}
 	return nil
+}
+
+func moveReadFailureToDLQ(root, me, filename, fallbackID, reason, detail string, header *format.Header) {
+	if _, err := fsq.MoveToDLQ(root, me, filename, fallbackID, reason, detail); err != nil {
+		_ = writeStderr("warning: failed to move invalid message to DLQ: %v\n", err)
+		return
+	}
+
+	item := &inboxItem{ID: fallbackID}
+	if header != nil {
+		if safeID, ok := safeHeaderID(header.ID); ok {
+			item.ID = safeID
+		}
+		item.From = header.From
+		item.Thread = header.Thread
+	}
+	emitReceipt(root, me, item, receipt.StageDLQ, detail)
 }

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -75,13 +75,11 @@ func runRead(args []string) error {
 		if err := fsq.MoveNewToCur(root, common.Me, filename); err != nil {
 			return err
 		}
-		// Validate header fields before using them in receipt filenames
-		safeID, err := ensureSafeBaseName(msg.Header.ID)
-		if err == nil {
-			sender, _ := normalizeHandle(msg.Header.From)
-			r := receipt.New(safeID, msg.Header.Thread, sender, common.Me, receipt.StageDrained, "")
-			_ = receipt.Emit(root, r)
-		}
+		emitReceipt(root, common.Me, &inboxItem{
+			ID:     msg.Header.ID,
+			From:   msg.Header.From,
+			Thread: msg.Header.Thread,
+		}, receipt.StageDrained, "")
 	}
 
 	if common.JSON {

--- a/internal/cli/read_test.go
+++ b/internal/cli/read_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/receipt"
+)
+
+func TestRunReadInvalidHeaderMovesToDLQ(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      "msg-read-001",
+			From:    "Bob",
+			To:      []string{"alice"},
+			Thread:  "p2p/alice__bob",
+			Created: time.Now().UTC().Format(time.RFC3339Nano),
+		},
+		Body: "hello\n",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if _, err := fsq.DeliverToInbox(root, "alice", "msg-read-001.md", data); err != nil {
+		t.Fatalf("DeliverToInbox: %v", err)
+	}
+
+	err = runRead([]string{"--me", "alice", "--root", root, "--id", "msg-read-001"})
+	if err == nil {
+		t.Fatal("expected runRead to fail on invalid header")
+	}
+	if !strings.Contains(err.Error(), "invalid message header msg-read-001") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(fsq.AgentInboxNew(root, "alice"), "msg-read-001.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected message removed from inbox/new, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentInboxCur(root, "alice"), "msg-read-001.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected message absent from inbox/cur, stat err = %v", err)
+	}
+
+	dlqEntries, err := os.ReadDir(fsq.AgentDLQNew(root, "alice"))
+	if err != nil {
+		t.Fatalf("ReadDir(dlq/new): %v", err)
+	}
+	if len(dlqEntries) != 1 {
+		t.Fatalf("expected 1 message in dlq/new, got %d", len(dlqEntries))
+	}
+
+	receipts, err := receipt.List(root, "alice", receipt.ListFilter{
+		MsgID: "msg-read-001",
+		Stage: receipt.StageDLQ,
+	})
+	if err != nil {
+		t.Fatalf("receipt.List: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("expected 1 dlq receipt, got %d", len(receipts))
+	}
+	if receipts[0].Detail == "" {
+		t.Fatal("expected dlq receipt detail")
+	}
+}

--- a/internal/cli/read_test.go
+++ b/internal/cli/read_test.go
@@ -77,3 +77,57 @@ func TestRunReadInvalidHeaderMovesToDLQ(t *testing.T) {
 		t.Fatal("expected dlq receipt detail")
 	}
 }
+
+func TestRunReadParseErrorMovesToDLQ(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(root, "alice"), "msg-read-corrupt.md"), []byte("not valid frontmatter"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err := runRead([]string{"--me", "alice", "--root", root, "--id", "msg-read-corrupt"})
+	if err == nil {
+		t.Fatal("expected runRead to fail on parse error")
+	}
+	if !strings.Contains(err.Error(), "failed to parse message msg-read-corrupt") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(fsq.AgentInboxNew(root, "alice"), "msg-read-corrupt.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected message removed from inbox/new, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentInboxCur(root, "alice"), "msg-read-corrupt.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected message absent from inbox/cur, stat err = %v", err)
+	}
+
+	dlqEntries, err := os.ReadDir(fsq.AgentDLQNew(root, "alice"))
+	if err != nil {
+		t.Fatalf("ReadDir(dlq/new): %v", err)
+	}
+	if len(dlqEntries) != 1 {
+		t.Fatalf("expected 1 message in dlq/new, got %d", len(dlqEntries))
+	}
+
+	receipts, err := receipt.List(root, "alice", receipt.ListFilter{
+		MsgID: "msg-read-corrupt",
+		Stage: receipt.StageDLQ,
+	})
+	if err != nil {
+		t.Fatalf("receipt.List: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("expected 1 dlq receipt, got %d", len(receipts))
+	}
+	if receipts[0].Sender != "" {
+		t.Fatalf("expected empty sender for parse_error receipt, got %q", receipts[0].Sender)
+	}
+	if receipts[0].Detail == "" {
+		t.Fatal("expected dlq receipt detail")
+	}
+}

--- a/internal/cli/receipts.go
+++ b/internal/cli/receipts.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -140,43 +141,29 @@ func runReceiptsWait(args []string) error {
 	}
 	root := resolveRoot(common.Root)
 
-	deadline := time.Time{}
-	if *timeoutFlag > 0 {
-		deadline = time.Now().Add(*timeoutFlag)
+	r, err := receipt.WaitFor(root, *msgID, me, *stage, *timeoutFlag, *pollInterval)
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		if common.JSON {
+			if err := writeJSON(os.Stdout, receiptsWaitResult{Event: "timeout"}); err != nil {
+				return err
+			}
+		} else {
+			if err := writeStdout("No %s receipt for %s (timeout)\n", *stage, *msgID); err != nil {
+				return err
+			}
+		}
+		return TimeoutError("receipts wait timed out")
+	}
+	if err != nil {
+		return err
 	}
 
-	for {
-		receipts, err := receipt.List(root, me, receipt.ListFilter{
-			MsgID: *msgID,
-			Stage: *stage,
+	if common.JSON {
+		return writeJSON(os.Stdout, receiptsWaitResult{
+			Event:   "matched",
+			Receipt: &r,
 		})
-		if err != nil {
-			return err
-		}
-		if len(receipts) > 0 {
-			r := receipts[0]
-			if common.JSON {
-				return writeJSON(os.Stdout, receiptsWaitResult{
-					Event:   "matched",
-					Receipt: &r,
-				})
-			}
-			return writeStdout("Receipt: %s %s by %s at %s\n", r.Stage, r.MsgID, r.Consumer, r.EmittedAt)
-		}
-
-		if !deadline.IsZero() && time.Now().After(deadline) {
-			if common.JSON {
-				if err := writeJSON(os.Stdout, receiptsWaitResult{Event: "timeout"}); err != nil {
-					return err
-				}
-			} else {
-				if err := writeStdout("No %s receipt for %s (timeout)\n", *stage, *msgID); err != nil {
-					return err
-				}
-			}
-			return TimeoutError("receipts wait timed out")
-		}
-
-		time.Sleep(*pollInterval)
 	}
+
+	return writeStdout("Receipt: %s %s by %s at %s\n", r.Stage, r.MsgID, r.Consumer, r.EmittedAt)
 }

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -350,7 +350,7 @@ func runSend(args []string) error {
 	var waitErr error
 	if waitFor != "" {
 		consumer := recipients[0]
-		r, err := receipt.WaitFor(deliveryRoot, consumer, id, consumer, waitFor, *waitTimeoutFlag, 1*time.Second)
+		r, err := receipt.WaitFor(deliveryRoot, id, consumer, waitFor, *waitTimeoutFlag, 1*time.Second)
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			waitResult = &waitForResult{Event: "timeout", Stage: waitFor, Timeout: waitTimeoutFlag.String()}
 			waitErr = TimeoutError("send --wait-for %s timed out after %s", waitFor, *waitTimeoutFlag)

--- a/internal/receipt/receipt.go
+++ b/internal/receipt/receipt.go
@@ -71,11 +71,11 @@ func Emit(root string, r Receipt) error {
 	return nil
 }
 
-// WaitFor polls for a specific receipt by deterministic filename.
+// WaitFor polls for a specific consumer-local receipt by deterministic filename.
 // Returns the receipt on match, or an error on timeout.
-func WaitFor(root, agent, msgID, consumer, stage string, timeout, pollInterval time.Duration) (Receipt, error) {
+func WaitFor(root, msgID, consumer, stage string, timeout, pollInterval time.Duration) (Receipt, error) {
 	name := fmt.Sprintf("%s__%s__%s.json", msgID, consumer, stage)
-	path := filepath.Join(fsq.AgentReceipts(root, agent), name)
+	path := filepath.Join(fsq.AgentReceipts(root, consumer), name)
 
 	deadline := time.Time{}
 	if timeout > 0 {

--- a/internal/receipt/receipt_test.go
+++ b/internal/receipt/receipt_test.go
@@ -158,7 +158,7 @@ func TestWaitForCrossRoot(t *testing.T) {
 		_ = Emit(deliveryRoot, r)
 	}()
 
-	got, err := WaitFor(deliveryRoot, "codex", "msg_cross_root", "codex", StageDrained, 2*time.Second, 25*time.Millisecond)
+	got, err := WaitFor(deliveryRoot, "msg_cross_root", "codex", StageDrained, 2*time.Second, 25*time.Millisecond)
 	if err != nil {
 		t.Fatalf("WaitFor(deliveryRoot): %v", err)
 	}
@@ -172,7 +172,7 @@ func TestWaitForCrossRoot(t *testing.T) {
 		t.Fatal("emit goroutine did not finish")
 	}
 
-	if _, err := WaitFor(sourceRoot, "claude", "msg_cross_root", "codex", StageDrained, 150*time.Millisecond, 25*time.Millisecond); !os.IsTimeout(err) && err != os.ErrDeadlineExceeded {
+	if _, err := WaitFor(sourceRoot, "msg_cross_root", "codex", StageDrained, 150*time.Millisecond, 25*time.Millisecond); !os.IsTimeout(err) && err != os.ErrDeadlineExceeded {
 		t.Fatalf("WaitFor(sourceRoot) error = %v, want deadline exceeded", err)
 	}
 }


### PR DESCRIPTION
## Summary
- align `amq read` header validation with the drain/monitor path and DLQ malformed messages from `inbox/new`
- collapse `receipt.WaitFor` to the consumer-owned receipt path and reuse it from `receipts wait`
- add focused coverage for invalid-header reads and the simplified wait path

## Validation
- `go test ./internal/cli ./internal/receipt`
- `make ci`