### PR TITLE
docs: add v0.31.2 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Doc sweep to align CLAUDE.md, README.md, skills, and CLI help text with the receipt ledger model — no more stale ack references in agent-facing or user-facing docs.
+- Removed the unused `Header.AckRequired` field and `ack_required` JSON tag from the message format. Outgoing messages no longer carry the dead `"ack_required": false` field in their frontmatter.
+- Dropped dead `--ack=false` branches from drain test helpers; simplified signatures to match the current drain API.
 
 ## [0.31.1] - 2026-04-10
 ### Changed


### PR DESCRIPTION
## Summary
- Staging for v0.31.2 release
- Entries cover the doc sweep (PR #81) and the Header.AckRequired field removal

## Test plan
- [x] Pre-push CI green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)