### PR TITLE
chore(release): v0.31.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.31.2] - 2026-04-10
 ### Changed
 
 - Doc sweep to align CLAUDE.md, README.md, skills, and CLI help text with the receipt ledger model — no more stale ack references in agent-facing or user-facing docs.
 - Removed the unused `Header.AckRequired` field and `ack_required` JSON tag from the message format. Outgoing messages no longer carry the dead `"ack_required": false` field in their frontmatter.
 - Dropped dead `--ack=false` branches from drain test helpers; simplified signatures to match the current drain API.
+
 
 ## [0.31.1] - 2026-04-10
 ### Changed

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-cli
-version: 0.31.1
+version: 0.31.2
 description: >-
   Coordinate agents via the AMQ CLI for file-based inter-agent messaging. Use
   this skill whenever you need to send messages to another agent (codex, claude,

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-spec
-version: 0.31.1
+version: 0.31.2
 description: >-
   Parallel-research-then-converge design workflow between two agents. Use this
   skill when the user wants two agents to independently think through a design


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.31.2`
- aligns skill/plugin metadata to `0.31.2`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.31.2`, publishes the GitHub/Homebrew release, and then publishes skills to the marketplace