### PR TITLE
docs(amq-cli): tighten token-efficiency guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added token-efficiency guidance to the `amq-cli` skill: send file paths instead of inlining large file contents, and run multi-round AMQ review loops in background workers or subagents so intermediate rounds stay out of the main context.
+
 ## [0.31.2] - 2026-04-10
 ### Changed
 

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -298,7 +298,7 @@ amq send --to codex --priority urgent --kind question --body "Blocked on API"
 amq send --to codex --labels "bug,parser" --context '{"paths": ["src/"]}' --body "Found issue"
 ```
 
-**Send file paths, not file contents.** When attaching source code, configs, or large text for review, send the file path in the message body, not the contents inline. The receiver can `Read` the file themselves. If the receiver cannot access that worktree, send a short diff instead of the full source.
+**Send file paths, not file contents.** When attaching source code, configs, or large text for review, send the file path in the message body, not the contents inline. The receiver can open the file with their local tools. If the receiver cannot access that worktree, send a short diff instead of the full source.
 
 ### Filter
 ```bash

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -298,6 +298,8 @@ amq send --to codex --priority urgent --kind question --body "Blocked on API"
 amq send --to codex --labels "bug,parser" --context '{"paths": ["src/"]}' --body "Found issue"
 ```
 
+**Send file paths, not file contents.** When attaching source code, configs, or large text for review, send the file path in the message body, not the contents inline. The receiver can `Read` the file themselves. If the receiver cannot access that worktree, send a short diff instead of the full source.
+
 ### Filter
 ```bash
 amq list --new --priority urgent
@@ -333,3 +335,4 @@ For detailed protocols, read the reference file FIRST, then follow its instructi
 - [references/integrations.md](references/integrations.md) — Symphony + Kanban integration commands, global root fallback, ops checks
 - [references/message-format.md](references/message-format.md) — Message format: frontmatter schema, field reference
 - [references/cross-project.md](references/cross-project.md) — Cross-project routing: peer config, addressing, decision threads
+- [references/review-loop.md](references/review-loop.md) — Token-efficient review cycles: delegate multi-round reviews to background agents

--- a/skills/amq-cli/references/review-loop.md
+++ b/skills/amq-cli/references/review-loop.md
@@ -14,7 +14,7 @@ When a `review_request` may take multiple rounds, do not keep the whole loop in 
 - It waits for replies with `amq drain --include-body`.
 - If the reviewer finds issues, it applies fixes and re-sends for review.
 - It stops when the reviewer says the change is green or a max round count is hit.
-- It returns one line to the main context, for example: `codex signed off after 3 rounds, 5 findings fixed`.
+- It returns one line to the main context, for example: `reviewer signed off after 3 rounds, 5 findings fixed`.
 
 ## Why
 
@@ -36,7 +36,7 @@ Agent({
     - apply the requested fixes
     - amq send --to codex --kind review_request --body "Updated: src/foo.go"
     Return one line only:
-    "codex signed off after 3 rounds, 5 findings fixed"
+    "reviewer signed off after 3 rounds, 5 findings fixed"
   `
 })
 ```
@@ -48,7 +48,7 @@ Start a background worker/subagent for the AMQ review loop
 - amq drain --include-body
 - apply fixes and re-send until green or max rounds
 Return one line only:
-"codex signed off after 3 rounds, 5 findings fixed"
+"reviewer signed off after 3 rounds, 5 findings fixed"
 ```
 
 This is behavioral guidance for agents using AMQ, not a CLI feature or protocol change.

--- a/skills/amq-cli/references/review-loop.md
+++ b/skills/amq-cli/references/review-loop.md
@@ -1,6 +1,12 @@
 # Token-Efficient Review Loops
 
-When a `review_request` may take multiple rounds, do not keep the whole loop in the main conversation. Spawn a background agent to own the AMQ exchange and return only the final verdict.
+When a `review_request` may take multiple rounds, do not keep the whole loop in the main conversation. Use your host's background worker or subagent primitive so the AMQ exchange runs in isolated context and only the final verdict returns.
+
+## Host Mapping
+
+- Claude Code: use a subagent or background agent.
+- Codex-based agents: use a spawned/background Codex worker or task.
+- Tool names vary by host. The invariant is the same: intermediate AMQ rounds stay off the main thread.
 
 ## Pattern
 
@@ -16,9 +22,10 @@ When a `review_request` may take multiple rounds, do not keep the whole loop in 
 - Repeated diffs, logs, and review notes do not accumulate as stale history.
 - The main conversation keeps only the durable outcome.
 
-## Example
+## Examples
 
 ```text
+Claude Code:
 Agent({
   run_in_background: true,
   task: `
@@ -32,6 +39,16 @@ Agent({
     "codex signed off after 3 rounds, 5 findings fixed"
   `
 })
+```
+
+```text
+Codex-style host:
+Start a background worker/subagent for the AMQ review loop
+- amq send --to codex --kind review_request --body "Please review: src/foo.go"
+- amq drain --include-body
+- apply fixes and re-send until green or max rounds
+Return one line only:
+"codex signed off after 3 rounds, 5 findings fixed"
 ```
 
 This is behavioral guidance for agents using AMQ, not a CLI feature or protocol change.

--- a/skills/amq-cli/references/review-loop.md
+++ b/skills/amq-cli/references/review-loop.md
@@ -1,0 +1,37 @@
+# Token-Efficient Review Loops
+
+When a `review_request` may take multiple rounds, do not keep the whole loop in the main conversation. Spawn a background agent to own the AMQ exchange and return only the final verdict.
+
+## Pattern
+
+- The background agent sends the initial `review_request` via `amq send`.
+- It waits for replies with `amq drain --include-body`.
+- If the reviewer finds issues, it applies fixes and re-sends for review.
+- It stops when the reviewer says the change is green or a max round count is hit.
+- It returns one line to the main context, for example: `codex signed off after 3 rounds, 5 findings fixed`.
+
+## Why
+
+- Intermediate review rounds stay out of the main context.
+- Repeated diffs, logs, and review notes do not accumulate as stale history.
+- The main conversation keeps only the durable outcome.
+
+## Example
+
+```text
+Agent({
+  run_in_background: true,
+  task: `
+    Send: amq send --to codex --kind review_request --body "Please review: src/foo.go"
+    Loop up to 3 rounds:
+    - amq drain --include-body
+    - if codex is green, stop
+    - apply the requested fixes
+    - amq send --to codex --kind review_request --body "Updated: src/foo.go"
+    Return one line only:
+    "codex signed off after 3 rounds, 5 findings fixed"
+  `
+})
+```
+
+This is behavioral guidance for agents using AMQ, not a CLI feature or protocol change.


### PR DESCRIPTION
## Summary
- add token-efficiency guidance for multi-round AMQ review loops
- make the wording host-neutral for Claude Code and Codex-based agents
- add an unreleased changelog entry for the docs change

## Verification
- pre-push checks passed: go vet, golangci-lint, go test ./..., ./scripts/smoke-test.sh