### PR TITLE
fix(hook): cap/rotate $HOOK_LOG in claude-session-start.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `scripts/claude-session-start.sh` now rotates oversized `$HOOK_LOG` files opportunistically at hook start, keeping stderr logging bounded without affecting hook output or exit behavior.
+
 ## [0.32.0] - 2026-04-13
 ### Added
 

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -10,6 +10,7 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 ME="${AM_ME:-claude}"
 RESOLVED_ROOT="${AM_ROOT:-}"
 HOOK_LOG="${TMPDIR:-/tmp}/amq-hook-${USER:-unknown}.log"
+HOOK_LOG_MAX_BYTES=$((1024 * 1024))
 
 first_export_line() {
     local var_name="$1"
@@ -31,6 +32,32 @@ decode_export_line() {
             return 0
             ;;
     esac
+}
+
+rotate_hook_log() {
+    local log_path="${1:-}"
+    local max_bytes="${2:-}"
+    local log_size=""
+
+    [ -n "$log_path" ] || return 0
+    [ -f "$log_path" ] || return 0
+
+    case "$max_bytes" in
+        ''|*[!0-9]*)
+            return 0
+            ;;
+    esac
+
+    log_size=$(wc -c < "$log_path" 2>/dev/null | tr -d '[:space:]') || log_size=""
+    case "$log_size" in
+        ''|*[!0-9]*)
+            return 0
+            ;;
+    esac
+
+    [ "$log_size" -lt "$max_bytes" ] && return 0
+
+    mv -f "$log_path" "$log_path.1" 2>/dev/null || : > "$log_path" 2>/dev/null || true
 }
 
 # --- Phase 1: Environment injection (existing behavior) ---
@@ -83,6 +110,8 @@ fi
 # --- Phase 2: Context re-injection ---
 # Compose existing CLI primitives to build a coop preamble that restores
 # session awareness after /clear or compaction (see issue #71).
+
+rotate_hook_log "$HOOK_LOG" "$HOOK_LOG_MAX_BYTES"
 
 if command -v amq &> /dev/null; then
     if [ -n "$RESOLVED_ROOT" ]; then

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -271,6 +271,55 @@ print("  hook /clear env-file AM_ME scenario: JSON assertions passed")
 PYEOF
 fi
 
+# HOOK_LOG rotation: oversized logs should rotate to .1; smaller logs should stay in place.
+HOOK_LOG_ROTATE_DIR="$(mktemp -d)"
+hook_log_rotate_cleanup() {
+  rm -rf "$HOOK_LOG_ROTATE_DIR"
+}
+trap 'cleanup; amqrc_cleanup; exec_cleanup; iso_cleanup; hook_tmpdir_cleanup; hook_log_rotate_cleanup' EXIT
+
+HOOK_LOG_PATH="$HOOK_LOG_ROTATE_DIR/amq-hook-hooklogtest.log"
+HOOK_LOG_BACKUP="$HOOK_LOG_PATH.1"
+dd if=/dev/zero of="$HOOK_LOG_PATH" bs=1024 count=1025 >/dev/null 2>&1
+
+CLAUDE_ENV_FILE="$HOOK_LOG_ROTATE_DIR/env" \
+CLAUDE_PROJECT_DIR="$HOOK_LOG_ROTATE_DIR" \
+TMPDIR="$HOOK_LOG_ROTATE_DIR" \
+USER="hooklogtest" \
+PATH="$(dirname "$BIN"):$PATH" \
+bash scripts/claude-session-start.sh >/dev/null 2>/dev/null
+
+test -f "$HOOK_LOG_BACKUP"
+test -f "$HOOK_LOG_PATH"
+ROTATED_SIZE="$(wc -c < "$HOOK_LOG_BACKUP" | tr -d '[:space:]')"
+CURRENT_SIZE="$(wc -c < "$HOOK_LOG_PATH" | tr -d '[:space:]')"
+if [[ "$ROTATED_SIZE" -lt 1048576 ]]; then
+  echo "hook log rotation backup size too small: $ROTATED_SIZE"
+  exit 1
+fi
+if [[ "$CURRENT_SIZE" -ge 1048576 ]]; then
+  echo "hook log rotation did not cap current log: $CURRENT_SIZE"
+  exit 1
+fi
+echo "  hook log rotation: oversized log rotated"
+
+rm -f "$HOOK_LOG_BACKUP"
+printf 'small-log\n' > "$HOOK_LOG_PATH"
+
+CLAUDE_ENV_FILE="$HOOK_LOG_ROTATE_DIR/env2" \
+CLAUDE_PROJECT_DIR="$HOOK_LOG_ROTATE_DIR" \
+TMPDIR="$HOOK_LOG_ROTATE_DIR" \
+USER="hooklogtest" \
+PATH="$(dirname "$BIN"):$PATH" \
+bash scripts/claude-session-start.sh >/dev/null 2>/dev/null
+
+if [[ -f "$HOOK_LOG_BACKUP" ]]; then
+  echo "hook log rotation unexpectedly rotated small log"
+  exit 1
+fi
+grep -q '^small-log$' "$HOOK_LOG_PATH"
+echo "  hook log rotation: small log left in place"
+
 echo "claude-session-start.sh hook test ok"
 
 echo "smoke test ok"


### PR DESCRIPTION
## Summary

- rotate oversized `HOOK_LOG` files to `.1` opportunistically at SessionStart hook entry
- keep the log-maintenance path best-effort so it cannot affect hook stdout or exit behavior
- add smoke coverage for both oversized-log rotation and under-threshold no-op behavior
- add an `Unreleased` changelog line for the patch release path

## Links

- Closes #90
- Follow-up to #84

## Testing

- `make ci`
- `bash scripts/smoke-test.sh`
