### PR TITLE
chore(release): v0.32.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.1] - 2026-04-13
 ### Fixed
 
 - `scripts/claude-session-start.sh` now rotates oversized `$HOOK_LOG` files opportunistically at hook start, keeping stderr logging bounded without affecting hook output or exit behavior.
+
 
 ## [0.32.0] - 2026-04-13
 ### Added

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-cli
-version: 0.32.0
+version: 0.32.1
 description: >-
   Coordinate agents via the AMQ CLI for file-based inter-agent messaging. Use
   this skill whenever you need to send messages to another agent (codex, claude,

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-spec
-version: 0.32.0
+version: 0.32.1
 description: >-
   Parallel-research-then-converge design workflow between two agents. Use this
   skill when the user wants two agents to independently think through a design


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.32.1`
- aligns skill/plugin metadata to `0.32.1`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.32.1`, publishes the GitHub/Homebrew release, and then publishes skills to the marketplace