### PR TITLE
feat(wake): add --inject-via for external injection commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ amq dlq list --me <agent> [--new | --cur] [--json]
 amq dlq read --me <agent> --id <dlq_id> [--json]
 amq dlq retry --me <agent> --id <dlq_id> [--all] [--force]
 amq dlq purge --me <agent> [--older-than <duration>] [--dry-run] [--yes]
-amq wake --me <agent> [--inject-cmd <cmd>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>]
+amq wake --me <agent> [--inject-cmd <cmd>] [--inject-via <executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>]
 amq upgrade
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--json]
 amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>]
@@ -350,7 +350,7 @@ Commands below assume `AM_ME` is set (e.g., `export AM_ME=claude`).
 | Waiting for reply | `amq watch --timeout 60s` | Blocks until message |
 | Quick peek only | `amq list --new` | Non-blocking, no side effects |
 | Filter messages | `amq list --new --priority urgent` | Show only urgent messages |
-| Background wake | `amq wake --me <agent> &` | Injects notification via TIOCSTI with best-effort input deferral (experimental) |
+| Background wake | `amq wake --me <agent> &` | Injects notification via TIOCSTI with best-effort input deferral, or via explicit external transport (experimental) |
 | Reply to message | `amq reply --id <msg_id>` | Auto thread/refs handling |
 
 ## Co-op Mode (Claude <-> Codex)
@@ -403,6 +403,22 @@ If `amq wake` fails (TIOCSTI unavailable on hardened Linux), use notify hook:
 # ~/.codex/config.toml
 notify = ["python3", "/path/to/repo/scripts/codex-amq-notify.py"]
 ```
+
+For a local terminal transport that can receive notifications without a
+controlling TTY, run wake with an explicit external injector:
+```bash
+amq wake --me orchestrator \
+  --inject-via ghostty-bridge \
+  --inject-arg exec \
+  --inject-arg "$TERMINAL_ID"
+```
+
+`--inject-via` is an executable path, not a shell command line. Repeat
+`--inject-arg` for fixed argv entries; AMQ appends the sanitized notification
+payload as the final argument and bounds each invocation with
+`--inject-timeout` (default `5s`). This executes local code for each
+notification, and the payload can include sanitized but message-derived sender
+and subject header content.
 
 ### Plan Mode Prompt Hook (Claude)
 

--- a/COOP.md
+++ b/COOP.md
@@ -214,10 +214,28 @@ amq reply --id "msg_123" --kind review_response --body "LGTM with minor suggesti
 
 > Co-op works without wake. `coop exec` starts it automatically.
 
-`amq wake` uses TIOCSTI to inject notifications into your terminal.
+`amq wake` uses TIOCSTI to inject notifications into your terminal by default.
+For orchestrators or hardened environments without a controlling TTY, use an
+explicit external transport:
+
+```bash
+amq wake --me orchestrator \
+  --inject-via ghostty-bridge \
+  --inject-arg exec \
+  --inject-arg "$TERMINAL_ID"
+```
+
+`--inject-via` is an executable path, not a shell command line. Repeat
+`--inject-arg` for fixed arguments; AMQ appends the sanitized notification text
+as the final argv element. This executes a local process for each notification,
+and the payload can include sanitized but message-derived header content such as
+sender and subject.
 
 **Options:**
 - `--inject-mode auto|raw|paste` - Injection strategy
+- `--inject-via <executable>` - External transport executable; bypasses TIOCSTI and local TTY startup checks
+- `--inject-arg <arg>` - Fixed argument before the payload; repeat for multiple arguments
+- `--inject-timeout 5s` - Maximum runtime for one external injection command
 - `--bell` - Ring terminal bell on new messages
 - `--debounce 250ms` - Batch rapid messages
 - `--defer-while-input` / `--defer-while-input=false` - Best-effort quiet-window gate before non-interrupt injection

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -19,6 +20,8 @@ type wakeConfig struct {
 	session           string
 	injectCmd         string
 	injectVia         string // external command for injection (replaces TIOCSTI)
+	injectArgs        []string
+	injectTimeout     time.Duration
 	bell              bool
 	debounce          time.Duration
 	previewLen        int
@@ -38,6 +41,8 @@ type wakeConfig struct {
 	interruptCooldown time.Duration
 	lastInterrupt     time.Time
 }
+
+const defaultInjectTimeout = 5 * time.Second
 
 type wakeMsgInfo struct {
 	from     string
@@ -89,7 +94,7 @@ func inputDeferralDelay(state ttyInputState, now, deadline time.Time, quietFor, 
 }
 
 func shouldDeferBeforeInject(cfg *wakeConfig, deferForInput bool) bool {
-	return deferForInput && cfg.deferWhileInput
+	return deferForInput && cfg.deferWhileInput && cfg.injectVia == ""
 }
 
 func notifyNewMessages(cfg *wakeConfig) error {
@@ -432,17 +437,32 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 
 func injectVia(cfg *wakeConfig, text string) error {
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: inject-via mode, running: %s <text>\n", cfg.injectVia)
+		_ = writeStderr("amq wake [debug]: inject-via mode, running: %s %s <text>\n", cfg.injectVia, strings.Join(cfg.injectArgs, " "))
 	}
 
-	parts := strings.Fields(cfg.injectVia)
-	if len(parts) == 0 {
+	executable := strings.TrimSpace(cfg.injectVia)
+	if executable == "" {
 		return fmt.Errorf("inject-via command is blank")
 	}
 
-	args := append(parts[1:], text)
-	cmd := exec.Command(parts[0], args...)
+	timeout := cfg.injectTimeout
+	if timeout <= 0 {
+		timeout = defaultInjectTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	args := append([]string{}, cfg.injectArgs...)
+	args = append(args, text)
+	cmd := exec.CommandContext(ctx, executable, args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			if cfg.debug {
+				_ = writeStderr("amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, string(out))
+			}
+			return fmt.Errorf("inject-via timed out after %s", timeout)
+		}
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: inject-via failed: %v (%s)\n", err, string(out))
 		}

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -17,6 +18,7 @@ type wakeConfig struct {
 	root              string
 	session           string
 	injectCmd         string
+	injectVia         string // external command for injection (replaces TIOCSTI)
 	bell              bool
 	debounce          time.Duration
 	previewLen        int
@@ -110,7 +112,12 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		interruptText := buildInterruptText(cfg.session, interruptMessages, interruptCounts, cfg.previewLen, cfg.interruptNotice)
 		now := time.Now()
 		if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
-			if err := tiocsti.Inject(cfg.interruptKey); err == nil {
+			if cfg.injectVia != "" {
+				if err := injectVia(cfg, cfg.interruptKey); err == nil {
+					cfg.lastInterrupt = now
+					time.Sleep(50 * time.Millisecond)
+				}
+			} else if err := tiocsti.Inject(cfg.interruptKey); err == nil {
 				cfg.lastInterrupt = now
 				time.Sleep(50 * time.Millisecond)
 			}
@@ -267,6 +274,15 @@ func injectNotification(cfg *wakeConfig, text string) error {
 		plainText = "\a" + plainText
 	}
 
+	// External injection: delegate to user-specified command instead of TIOCSTI.
+	// The command receives the notification text as its last argument.
+	if cfg.injectVia != "" {
+		if err := injectVia(cfg, text); err != nil {
+			_, _ = fmt.Fprint(os.Stderr, plainText+"\n")
+		}
+		return nil
+	}
+
 	mode := effectiveInjectMode(cfg)
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: mode=%s text_len=%d\n", mode, len(text))
@@ -355,6 +371,28 @@ func injectNotification(cfg *wakeConfig, text string) error {
 		// Fallback: print plain text to stderr (no escape sequences)
 		_, _ = fmt.Fprint(os.Stderr, plainText+"\n")
 		return nil
+	}
+
+	return nil
+}
+
+func injectVia(cfg *wakeConfig, text string) error {
+	if cfg.debug {
+		_ = writeStderr("amq wake [debug]: inject-via mode, running: %s <text>\n", cfg.injectVia)
+	}
+
+	parts := strings.Fields(cfg.injectVia)
+	if len(parts) == 0 {
+		return fmt.Errorf("inject-via command is blank")
+	}
+
+	args := append(parts[1:], text)
+	cmd := exec.Command(parts[0], args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: inject-via failed: %v (%s)\n", err, string(out))
+		}
+		return err
 	}
 
 	return nil

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -336,7 +336,12 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	// External injection: delegate to user-specified command instead of TIOCSTI.
 	// The command receives the notification text as its last argument.
 	if cfg.injectVia != "" {
-		if err := injectVia(cfg, text); err != nil {
+		if err := injectVia(cfg, plainText); err != nil {
+			if cfg.fallbackWarn {
+				_ = writeStderr("amq wake: --inject-via failed: %v\n", err)
+				_ = writeStderr("amq wake: falling back to stderr notification\n")
+				cfg.fallbackWarn = false
+			}
 			_, _ = fmt.Fprint(os.Stderr, plainText+"\n")
 		}
 		return nil

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,18 +114,26 @@ func TestInjectNotification_InjectVia(t *testing.T) {
 		t.Fatal(err)
 	}
 	tmpPath := tmp.Name()
-	tmp.Close()
-	defer os.Remove(tmpPath)
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp output: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	script, err := os.CreateTemp("", "wake-inject-via-*.sh")
 	if err != nil {
 		t.Fatal(err)
 	}
 	scriptPath := script.Name()
-	script.WriteString("#!/bin/sh\nprintf '%s' \"$1\" > " + tmpPath + "\n")
-	script.Close()
-	os.Chmod(scriptPath, 0o755)
-	defer os.Remove(scriptPath)
+	if _, err := script.WriteString("#!/bin/sh\nprintf '%s' \"$1\" > " + tmpPath + "\n"); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	if err := script.Close(); err != nil {
+		t.Fatalf("close script: %v", err)
+	}
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		t.Fatalf("chmod script: %v", err)
+	}
+	defer func() { _ = os.Remove(scriptPath) }()
 
 	cfg := &wakeConfig{
 		injectVia: scriptPath,
@@ -151,8 +160,10 @@ func TestInjectNotification_InjectVia_MultiWordCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 	tmpPath := tmp.Name()
-	tmp.Close()
-	defer os.Remove(tmpPath)
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp output: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	scriptDir := filepath.Join(t.TempDir(), "inject dir")
 	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
@@ -164,7 +175,9 @@ func TestInjectNotification_InjectVia_MultiWordCommand(t *testing.T) {
 		t.Fatalf("create script: %v", err)
 	}
 	// $1 = "exec", $2 = "TERMID", $3 = the notification text
-	script.WriteString("#!/bin/sh\nprintf '%s\\n%s\\n%s' \"$1\" \"$2\" \"$3\" > " + tmpPath + "\n")
+	if _, err := script.WriteString("#!/bin/sh\nprintf '%s\\n%s\\n%s' \"$1\" \"$2\" \"$3\" > " + tmpPath + "\n"); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
 	if err := script.Close(); err != nil {
 		t.Fatalf("close script: %v", err)
 	}
@@ -186,6 +199,53 @@ func TestInjectNotification_InjectVia_MultiWordCommand(t *testing.T) {
 		t.Fatalf("failed to read output: %v", err)
 	}
 	expected := "exec\nTeam Alpha\n" + text
+	if string(got) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(got))
+	}
+}
+
+func TestInjectNotification_InjectVia_Bell(t *testing.T) {
+	tmp, err := os.CreateTemp("", "wake-inject-via-bell-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp output: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	script, err := os.CreateTemp("", "wake-inject-via-bell-*.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := script.Name()
+	if _, err := script.WriteString("#!/bin/sh\nprintf '%s' \"$1\" > " + tmpPath + "\n"); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	if err := script.Close(); err != nil {
+		t.Fatalf("close script: %v", err)
+	}
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		t.Fatalf("chmod script: %v", err)
+	}
+	defer func() { _ = os.Remove(scriptPath) }()
+
+	cfg := &wakeConfig{
+		injectVia: scriptPath,
+		bell:      true,
+	}
+
+	text := "AMQ [collab]: message from codex - hello"
+	if err := injectNotification(cfg, text, true); err != nil {
+		t.Fatalf("injectNotification failed: %v", err)
+	}
+
+	got, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	expected := "\a" + text
 	if string(got) != expected {
 		t.Fatalf("expected %q, got %q", expected, string(got))
 	}
@@ -221,6 +281,61 @@ func TestInjectNotification_InjectVia_Failure(t *testing.T) {
 	if err := injectNotification(cfg, "test", true); err != nil {
 		t.Fatalf("expected graceful fallback, got error: %v", err)
 	}
+}
+
+func TestInjectNotification_InjectVia_FailureWarnsOnce(t *testing.T) {
+	cfg := &wakeConfig{
+		injectVia:    "/nonexistent/command",
+		fallbackWarn: true,
+	}
+
+	text := "fallback notice"
+	stderr := captureWakeStderr(t, func() {
+		if err := injectNotification(cfg, text, true); err != nil {
+			t.Fatalf("first injectNotification: %v", err)
+		}
+		if err := injectNotification(cfg, text, true); err != nil {
+			t.Fatalf("second injectNotification: %v", err)
+		}
+	})
+
+	if got := strings.Count(stderr, "amq wake: --inject-via failed:"); got != 1 {
+		t.Fatalf("expected one inject-via failure warning, got %d in %q", got, stderr)
+	}
+	if got := strings.Count(stderr, "amq wake: falling back to stderr notification\n"); got != 1 {
+		t.Fatalf("expected one fallback warning, got %d in %q", got, stderr)
+	}
+	if got := strings.Count(stderr, text+"\n"); got != 2 {
+		t.Fatalf("expected fallback text twice, got %d in %q", got, stderr)
+	}
+}
+
+func captureWakeStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close stderr reader: %v", err)
+	}
+	return string(out)
 }
 
 func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *testing.T) {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -154,21 +154,26 @@ func TestInjectNotification_InjectVia_MultiWordCommand(t *testing.T) {
 	tmp.Close()
 	defer os.Remove(tmpPath)
 
-	script, err := os.CreateTemp("", "wake-inject-via-multi-*.sh")
-	if err != nil {
-		t.Fatal(err)
+	scriptDir := filepath.Join(t.TempDir(), "inject dir")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir script dir: %v", err)
 	}
-	scriptPath := script.Name()
+	scriptPath := filepath.Join(scriptDir, "inject script.sh")
+	script, err := os.OpenFile(scriptPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("create script: %v", err)
+	}
 	// $1 = "exec", $2 = "TERMID", $3 = the notification text
-	script.WriteString("#!/bin/sh\nprintf '%s %s %s' \"$1\" \"$2\" \"$3\" > " + tmpPath + "\n")
-	script.Close()
-	os.Chmod(scriptPath, 0o755)
-	defer os.Remove(scriptPath)
+	script.WriteString("#!/bin/sh\nprintf '%s\\n%s\\n%s' \"$1\" \"$2\" \"$3\" > " + tmpPath + "\n")
+	if err := script.Close(); err != nil {
+		t.Fatalf("close script: %v", err)
+	}
 
-	// Simulates: ghostty-bridge exec ABC123 <text>
+	// Simulates: ghostty-bridge exec "Team Alpha" <text>.
 	cfg := &wakeConfig{
-		injectVia: scriptPath + " exec ABC123",
-		debug:     false,
+		injectVia:  scriptPath,
+		injectArgs: []string{"exec", "Team Alpha"},
+		debug:      false,
 	}
 
 	text := "AMQ [collab]: test message"
@@ -180,9 +185,29 @@ func TestInjectNotification_InjectVia_MultiWordCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read output: %v", err)
 	}
-	expected := "exec ABC123 " + text
+	expected := "exec\nTeam Alpha\n" + text
 	if string(got) != expected {
 		t.Fatalf("expected %q, got %q", expected, string(got))
+	}
+}
+
+func TestInjectViaTimeout(t *testing.T) {
+	scriptPath := filepath.Join(t.TempDir(), "sleep.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 2\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cfg := &wakeConfig{
+		injectVia:     scriptPath,
+		injectTimeout: 10 * time.Millisecond,
+	}
+
+	err := injectVia(cfg, "test")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got %v", err)
 	}
 }
 
@@ -280,6 +305,114 @@ func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *test
 	}
 }
 
+func TestNotifyNewMessages_InjectViaInjectCmdPayload(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	logPath := filepath.Join(root, "inject.log")
+	scriptPath := filepath.Join(root, "inject.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '%s' \"$1\" > "+logPath+"\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "msg-normal",
+			From:    "codex",
+			To:      []string{"alice"},
+			Thread:  "p2p/alice__codex",
+			Subject: "normal",
+			Created: "2026-04-25T10:00:00Z",
+		},
+		Body: "normal body",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := fsq.DeliverToInbox(root, "alice", "msg-normal.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	cfg := &wakeConfig{
+		me:         "alice",
+		root:       root,
+		injectVia:  scriptPath,
+		injectCmd:  "amq drain --include-body",
+		previewLen: 48,
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notifyNewMessages: %v", err)
+	}
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	expected := "\namq drain --include-body\n"
+	if string(got) != expected {
+		t.Fatalf("expected inject-cmd payload %q, got %q", expected, string(got))
+	}
+}
+
+func TestNotifyNewMessages_InjectViaInterruptFailureDoesNotUpdateCooldown(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	msg := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       "msg-urgent",
+			From:     "codex",
+			To:       []string{"alice"},
+			Thread:   "p2p/alice__codex",
+			Subject:  "help needed",
+			Created:  "2026-04-25T10:00:00Z",
+			Priority: "urgent",
+			Labels:   []string{"interrupt"},
+		},
+		Body: "urgent body",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := fsq.DeliverToInbox(root, "alice", "msg-urgent.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	cfg := &wakeConfig{
+		me:                "alice",
+		root:              root,
+		injectVia:         filepath.Join(root, "missing-injector"),
+		previewLen:        48,
+		interrupt:         true,
+		interruptKey:      "\x03",
+		interruptLabel:    "interrupt",
+		interruptPriority: "urgent",
+		interruptCooldown: 7 * time.Second,
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notifyNewMessages: %v", err)
+	}
+	if !cfg.lastInterrupt.IsZero() {
+		t.Fatalf("expected failed interrupt transport to leave cooldown unchanged, got %s", cfg.lastInterrupt)
+	}
+}
+
 func TestTTYInputStateActive(t *testing.T) {
 	now := time.Date(2026, 4, 24, 7, 0, 0, 0, time.UTC)
 	quietFor := 1200 * time.Millisecond
@@ -350,5 +483,11 @@ func TestShouldDeferBeforeInject(t *testing.T) {
 	cfg.deferWhileInput = false
 	if shouldDeferBeforeInject(cfg, true) {
 		t.Fatalf("expected disabled input deferral to inject immediately")
+	}
+
+	cfg.deferWhileInput = true
+	cfg.injectVia = "external-injector"
+	if shouldDeferBeforeInject(cfg, true) {
+		t.Fatalf("expected external injection to bypass local TTY input deferral")
 	}
 }

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -1,8 +1,14 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 func TestIsInterruptMessage(t *testing.T) {
@@ -97,5 +103,179 @@ func TestNotificationPrefix(t *testing.T) {
 	}
 	if got := notificationPrefix("[AMQ]", "stream3"); got != "[AMQ] [stream3]" {
 		t.Fatalf("expected '[AMQ] [stream3]', got: %s", got)
+	}
+}
+
+func TestInjectNotification_InjectVia(t *testing.T) {
+	// Use a shell script that writes the injected text to a temp file
+	tmp, err := os.CreateTemp("", "wake-inject-via-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+
+	script, err := os.CreateTemp("", "wake-inject-via-*.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := script.Name()
+	script.WriteString("#!/bin/sh\nprintf '%s' \"$1\" > " + tmpPath + "\n")
+	script.Close()
+	os.Chmod(scriptPath, 0o755)
+	defer os.Remove(scriptPath)
+
+	cfg := &wakeConfig{
+		injectVia: scriptPath,
+		debug:     false,
+	}
+
+	text := "AMQ [collab]: message from codex - hello"
+	if err := injectNotification(cfg, text); err != nil {
+		t.Fatalf("injectNotification failed: %v", err)
+	}
+
+	got, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	if string(got) != text {
+		t.Fatalf("expected %q, got %q", text, string(got))
+	}
+}
+
+func TestInjectNotification_InjectVia_MultiWordCommand(t *testing.T) {
+	tmp, err := os.CreateTemp("", "wake-inject-via-multi-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+
+	script, err := os.CreateTemp("", "wake-inject-via-multi-*.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := script.Name()
+	// $1 = "exec", $2 = "TERMID", $3 = the notification text
+	script.WriteString("#!/bin/sh\nprintf '%s %s %s' \"$1\" \"$2\" \"$3\" > " + tmpPath + "\n")
+	script.Close()
+	os.Chmod(scriptPath, 0o755)
+	defer os.Remove(scriptPath)
+
+	// Simulates: ghostty-bridge exec ABC123 <text>
+	cfg := &wakeConfig{
+		injectVia: scriptPath + " exec ABC123",
+		debug:     false,
+	}
+
+	text := "AMQ [collab]: test message"
+	if err := injectNotification(cfg, text); err != nil {
+		t.Fatalf("injectNotification failed: %v", err)
+	}
+
+	got, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	expected := "exec ABC123 " + text
+	if string(got) != expected {
+		t.Fatalf("expected %q, got %q", expected, string(got))
+	}
+}
+
+func TestInjectNotification_InjectVia_Failure(t *testing.T) {
+	cfg := &wakeConfig{
+		injectVia: "/nonexistent/command",
+		debug:     false,
+	}
+
+	// Should not return error — falls back to stderr
+	if err := injectNotification(cfg, "test"); err != nil {
+		t.Fatalf("expected graceful fallback, got error: %v", err)
+	}
+}
+
+func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	logPath := filepath.Join(root, "inject.log")
+	scriptPath := filepath.Join(root, "inject.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> "+logPath+"\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	msg := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       "msg-urgent",
+			From:     "codex",
+			To:       []string{"alice"},
+			Thread:   "p2p/alice__codex",
+			Subject:  "help needed",
+			Created:  "2026-04-25T10:00:00Z",
+			Priority: "urgent",
+			Labels:   []string{"interrupt"},
+		},
+		Body: "urgent body",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := fsq.DeliverToInbox(root, "alice", "msg-urgent.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	cfg := &wakeConfig{
+		me:                "alice",
+		root:              root,
+		session:           "collab",
+		injectVia:         scriptPath,
+		previewLen:        48,
+		interrupt:         true,
+		interruptKey:      "\x03",
+		interruptLabel:    "interrupt",
+		interruptPriority: "urgent",
+		interruptCooldown: 7 * time.Second,
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first notifyNewMessages: %v", err)
+	}
+	if cfg.lastInterrupt.IsZero() {
+		t.Fatal("expected interrupt cooldown timestamp to be updated")
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("second notifyNewMessages: %v", err)
+	}
+
+	expectedText := buildInterruptText(
+		"collab",
+		[]wakeMsgInfo{{from: "codex", subject: "help needed", priority: "urgent", labels: []string{"interrupt"}}},
+		map[string]int{"codex": 1},
+		48,
+		"",
+	)
+	expected := "\x03\n" + expectedText + "\n" + expectedText + "\n"
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if string(got) != expected {
+		t.Fatalf("expected inject-via log %q, got %q", expected, string(got))
 	}
 }

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -208,6 +208,7 @@ func runWake(args []string) error {
 	fs := flag.NewFlagSet("wake", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	injectCmdFlag := fs.String("inject-cmd", "", "Command to inject (power user mode)")
+	injectViaFlag := fs.String("inject-via", "", "External command for injection (text appended as last arg, bypasses TTY requirement)")
 	bellFlag := fs.Bool("bell", false, "Ring terminal bell on new messages")
 	debounceFlag := fs.Duration("debounce", 250*time.Millisecond, "Debounce window for batching messages")
 	previewLenFlag := fs.Int("preview-len", 48, "Max subject preview length")
@@ -284,14 +285,22 @@ func runWake(args []string) error {
 		return err
 	}
 
-	// Verify TIOCSTI is available
-	if !tiocsti.Available() {
-		return errors.New("TIOCSTI not available on this platform; use tmux send-keys or terminal-specific injection")
+	// Validate --inject-via: reject whitespace-only values that would panic on strings.Fields
+	injectVia := strings.TrimSpace(*injectViaFlag)
+	if *injectViaFlag != "" && injectVia == "" {
+		return UsageError("--inject-via must not be blank")
 	}
 
-	// Verify we have a real TTY
-	if !tiocsti.IsTTY() {
-		return errors.New("amq wake requires a real terminal (run in foreground or as background job in same terminal)")
+	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
+	if injectVia == "" {
+		if !tiocsti.Available() {
+			return errors.New("TIOCSTI not available on this platform; use tmux send-keys or terminal-specific injection")
+		}
+
+		// Verify we have a real TTY
+		if !tiocsti.IsTTY() {
+			return errors.New("amq wake requires a real terminal (run in foreground or as background job in same terminal, or use --inject-via for external injection)")
+		}
 	}
 
 	interruptKey, err := parseInterruptKey(*interruptCmdFlag)
@@ -311,6 +320,7 @@ func runWake(args []string) error {
 		root:              root,
 		session:           resolveSessionName(root),
 		injectCmd:         *injectCmdFlag,
+		injectVia:         injectVia,
 		bell:              *bellFlag,
 		debounce:          *debounceFlag,
 		previewLen:        *previewLenFlag,
@@ -451,8 +461,8 @@ func runWakeLoop(cfg wakeConfig) error {
 			// Keep presence alive so `amq who` reports the agent as active
 			_ = presence.Touch(cfg.root, cfg.me)
 
-			// Verify TTY is still valid by checking if we can open /dev/tty
-			if !ttyAvailable() {
+			// Verify TTY is still valid (skip in inject-via mode — no local TTY needed)
+			if cfg.injectVia == "" && !ttyAvailable() {
 				return errors.New("TTY no longer available")
 			}
 		}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -204,11 +204,20 @@ func processAlive(pid int) bool {
 	return false // ESRCH or other error => treat as dead
 }
 
+type wakeLoopFunc func(wakeConfig) error
+
 func runWake(args []string) error {
+	return runWakeWithLoop(args, runWakeLoop)
+}
+
+func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	fs := flag.NewFlagSet("wake", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	injectCmdFlag := fs.String("inject-cmd", "", "Command to inject (power user mode)")
-	injectViaFlag := fs.String("inject-via", "", "External command for injection (text appended as last arg, bypasses TTY requirement)")
+	injectViaFlag := fs.String("inject-via", "", "External executable for injection (payload appended as last arg, bypasses TTY requirement)")
+	var injectArgFlags multiStringFlag
+	fs.Var(&injectArgFlags, "inject-arg", "Argument for --inject-via before the payload (repeatable)")
+	injectTimeoutFlag := fs.Duration("inject-timeout", defaultInjectTimeout, "Timeout for one --inject-via command")
 	bellFlag := fs.Bool("bell", false, "Ring terminal bell on new messages")
 	debounceFlag := fs.Duration("debounce", 250*time.Millisecond, "Debounce window for batching messages")
 	previewLenFlag := fs.Int("preview-len", 48, "Max subject preview length")
@@ -233,6 +242,16 @@ func runWake(args []string) error {
 		"  auto  - Detect CLI type: raw for Claude Code/Codex, paste for others",
 		"  raw   - Plain text + CR, no bracketed paste (works with Ink-based CLIs)",
 		"  paste - Bracketed paste with delayed CR (works with crossterm-based CLIs)",
+		"",
+		"External injection:",
+		"  --inject-via runs a local executable for each notification, bypassing",
+		"  the TIOCSTI/stdin-TTY startup requirement. Fixed arguments use repeatable",
+		"  --inject-arg; AMQ appends the sanitized notification payload as the",
+		"  final argv element. The command is not run through a shell.",
+		"  Example: amq wake --me orchestrator --inject-via ghostty-bridge \\",
+		"    --inject-arg exec --inject-arg \"$TERMINAL_ID\"",
+		"  Trust boundary: --inject-via executes local code, and the payload can",
+		"  contain sanitized but message-derived header content.",
 		"",
 		"Input deferral (default on): wake samples terminal input only after",
 		"  a message is pending, then injects after a short quiet window.",
@@ -268,6 +287,9 @@ func runWake(args []string) error {
 	}
 	if *inputMaxHoldFlag < 0 {
 		return UsageError("--input-max-hold must be >= 0")
+	}
+	if *injectTimeoutFlag <= 0 {
+		return UsageError("--inject-timeout must be > 0")
 	}
 
 	injectMode := strings.ToLower(strings.TrimSpace(*injectModeFlag))
@@ -306,10 +328,13 @@ func runWake(args []string) error {
 		return err
 	}
 
-	// Validate --inject-via: reject whitespace-only values that would panic on strings.Fields
+	// Validate --inject-via: it is an executable path, not a shell command line.
 	injectVia := strings.TrimSpace(*injectViaFlag)
 	if *injectViaFlag != "" && injectVia == "" {
 		return UsageError("--inject-via must not be blank")
+	}
+	if injectVia == "" && len(injectArgFlags) > 0 {
+		return UsageError("--inject-arg requires --inject-via")
 	}
 
 	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
@@ -342,6 +367,8 @@ func runWake(args []string) error {
 		session:           resolveSessionName(root),
 		injectCmd:         *injectCmdFlag,
 		injectVia:         injectVia,
+		injectArgs:        []string(injectArgFlags),
+		injectTimeout:     *injectTimeoutFlag,
 		bell:              *bellFlag,
 		debounce:          *debounceFlag,
 		previewLen:        *previewLenFlag,
@@ -361,7 +388,7 @@ func runWake(args []string) error {
 		interruptCooldown: *interruptCooldownFlag,
 	}
 
-	return runWakeLoop(cfg)
+	return loop(cfg)
 }
 
 func parseInterruptKey(raw string) (string, error) {
@@ -486,12 +513,21 @@ func runWakeLoop(cfg wakeConfig) error {
 			// Keep presence alive so `amq who` reports the agent as active
 			_ = presence.Touch(cfg.root, cfg.me)
 
-			// Verify TTY is still valid (skip in inject-via mode — no local TTY needed)
-			if cfg.injectVia == "" && !ttyAvailable() {
-				return errors.New("TTY no longer available")
+			if err := wakeHealthCheck(cfg, ttyAvailable); err != nil {
+				return err
 			}
 		}
 	}
+}
+
+func wakeHealthCheck(cfg wakeConfig, ttyAvailableFn func() bool) error {
+	if cfg.injectVia != "" {
+		return nil
+	}
+	if !ttyAvailableFn() {
+		return errors.New("TTY no longer available")
+	}
+	return nil
 }
 
 func ttyAvailable() bool {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1,0 +1,104 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	var got wakeConfig
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/inject tool",
+		"--inject-arg", "exec",
+		"--inject-arg", "Team Alpha",
+		"--inject-timeout", "250ms",
+	}, func(cfg wakeConfig) error {
+		got = cfg
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+	if got.injectVia != "/tmp/inject tool" {
+		t.Fatalf("expected inject executable with spaces, got %q", got.injectVia)
+	}
+	if strings.Join(got.injectArgs, "|") != "exec|Team Alpha" {
+		t.Fatalf("expected fixed inject args, got %#v", got.injectArgs)
+	}
+	if got.injectTimeout != 250*time.Millisecond {
+		t.Fatalf("expected inject timeout 250ms, got %s", got.injectTimeout)
+	}
+}
+
+func TestRunWakeWithLoopRejectsInjectArgWithoutInjectVia(t *testing.T) {
+	err := runWakeWithLoop([]string{
+		"--root", t.TempDir(),
+		"--me", "orchestrator",
+		"--inject-arg", "exec",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with invalid flags: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "--inject-arg requires --inject-via") {
+		t.Fatalf("expected inject-arg usage error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopRejectsNonPositiveInjectTimeout(t *testing.T) {
+	err := runWakeWithLoop([]string{
+		"--root", t.TempDir(),
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--inject-timeout", "0",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with invalid timeout: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "--inject-timeout must be > 0") {
+		t.Fatalf("expected inject-timeout usage error, got %v", err)
+	}
+}
+
+func TestWakeHealthCheckSkipsTTYForInjectVia(t *testing.T) {
+	err := wakeHealthCheck(wakeConfig{injectVia: "/tmp/injector"}, func() bool {
+		return false
+	})
+	if err != nil {
+		t.Fatalf("expected external injection health check to skip TTY, got %v", err)
+	}
+}
+
+func TestWakeHealthCheckRequiresTTYForTIOCSTI(t *testing.T) {
+	err := wakeHealthCheck(wakeConfig{}, func() bool {
+		return false
+	})
+	if err == nil {
+		t.Fatal("expected TTY health failure")
+	}
+	if err.Error() != "TTY no longer available" {
+		t.Fatalf("expected TTY health error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- TIOCSTI is disabled by default on Linux 6.2+ and unavailable in non-TTY environments (CI, containers, remote agents). This adds `--inject-via`, a new flag that delegates text injection to a user-specified external command, bypassing the TIOCSTI and TTY requirements entirely.
- On injection failure, falls back to stderr output rather than hard-erroring.
- Orthogonal to `--inject-cmd` (which controls **what** text to inject); `--inject-via` controls **how** injection happens.

## Motivation

`amq wake` currently hard-depends on TIOCSTI for injecting notifications into the terminal. This is increasingly problematic:

- **Linux 6.2+** disables TIOCSTI by default (`dev.tty.legacy_tiocsti = 0`)
- **Hardened kernels** (grsecurity, etc.) block it entirely
- **Non-TTY environments** (containers, CI, remote agent sessions) have no `/dev/tty`

The existing fallback guidance ("use tmux send-keys") requires users to restructure their setup. `--inject-via` lets them plug in any injection mechanism without changing their workflow.

## Usage

```bash
# Ghostty terminal bridge
amq wake --me claude --inject-via "ghostty-bridge exec TERM_ID"

# Custom script
amq wake --me claude --inject-via /path/to/injector.sh

# The external command receives notification text as its last argument:
#   /path/to/injector.sh "AMQ [collab]: message from codex - hello"
```

## Security note

`--inject-via` executes a user-provided command, consistent with the existing `--inject-cmd` trust model. The text argument is constructed internally by AMQ (not from untrusted message content).

## Test plan

- [x] `TestInjectNotification_InjectVia` — basic external command injection
- [x] `TestInjectNotification_InjectVia_MultiWordCommand` — multi-word command with extra args
- [x] `TestInjectNotification_InjectVia_Failure` — graceful fallback to stderr on command failure
- [x] `TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown` — interrupt key injection + cooldown honoring via external command