### PR TITLE
chore(release): v0.32.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.32.2] - 2026-04-27
 ### Added
 
 - `amq wake` now has an enabled-by-default, best-effort input-activity deferral gate before non-interrupt TIOCSTI injection. The gate only runs after a wake notification is pending, samples the controlling terminal for unread input and recent reads, and is bounded by `--input-poll-interval`, `--input-quiet-for`, and `--input-max-hold`. This does not prove the foreground app's prompt buffer is empty; a paused in-progress prompt can still be injected into and submitted. Atime sampling uses stdin when it is a TTY (the `/dev/tty` alias inode does not track underlying ttys reads on macOS, and a freshly opened `/dev/tty` fd is not always in the tty's open-file list on Linux); Linux tty atime is maintained at ~8s granularity, so `--input-quiet-for` values shorter than that are advisory.
+
 
 ## [0.32.1] - 2026-04-13
 ### Fixed

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-cli
-version: 0.32.1
+version: 0.32.2
 description: >-
   Coordinate agents via the AMQ CLI for file-based inter-agent messaging. Use
   this skill whenever you need to send messages to another agent (codex, claude,

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-spec
-version: 0.32.1
+version: 0.32.2
 description: >-
   Parallel-research-then-converge design workflow between two agents. Use this
   skill when the user wants two agents to independently think through a design


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.32.2`
- aligns skill/plugin metadata to `0.32.2`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.32.2`, publishes the GitHub/Homebrew release, and then publishes skills to the marketplace