### PR TITLE
ci(release): make attestation subject collection portable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,14 +221,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t subjects < <(find dist -maxdepth 1 -type f | sort)
-          if ((${#subjects[@]} == 0)); then
+          subjects="$(find dist -maxdepth 1 -type f | sort)"
+          if [[ -z "$subjects" ]]; then
             echo "::error::No release artifacts found to attest."
             exit 1
           fi
           {
             echo "subjects<<EOF"
-            printf '%s\n' "${subjects[@]}"
+            printf '%s\n' "$subjects"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- replace Bash 4 `mapfile` usage in the macOS release job with portable command substitution
- keep the attestation subject output format unchanged for `actions/attest`

## Context
The v0.32.2 release published successfully, but run 25003681403 failed after upload because macOS bash lacks `mapfile`. This prevents the post-release attestation step and leaves the workflow red.

## Testing
- `git diff --check`
- `make ci`