### PR TITLE
ci: add manual release asset attestation recovery

### DIFF
--- a/.github/workflows/attest-release-assets.yml
+++ b/.github/workflows/attest-release-assets.yml
@@ -1,0 +1,154 @@
+# Manual recovery workflow. Attests existing release assets after checksum
+# validation. Attestation is signed by THIS workflow run, not the original build
+# CI; it proves deliberate post-publish attestation, not build-time provenance.
+# For new releases, attestation comes from the normal Release workflow.
+
+name: Attest Release Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to attest (e.g. v0.32.2)"
+        required: true
+        type: string
+      expected-sha:
+        description: "Expected commit SHA for the tag"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: attest-release-assets-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ inputs.tag }}
+      EXPECTED_SHA: ${{ inputs.expected-sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate release target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "::error::Release identifiers must use vX.Y.Z style tags."
+            exit 1
+          fi
+
+          if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::expected-sha must be a 40-character lowercase commit SHA."
+            exit 1
+          fi
+
+          git fetch --force --tags origin
+          if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} does not exist."
+            exit 1
+          fi
+
+          actual_sha="$(git rev-parse "refs/tags/${TAG}^{commit}")"
+          if [[ "$actual_sha" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Tag ${TAG} points to ${actual_sha}, not ${EXPECTED_SHA}."
+            exit 1
+          fi
+
+          is_draft="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)"
+          if [[ "$is_draft" != "false" ]]; then
+            echo "::error::Release ${TAG} is a draft or could not be resolved."
+            exit 1
+          fi
+
+      - name: Download release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir dist
+
+      - name: Validate downloaded assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${TAG#v}"
+          expected=(
+            "amq_${version}_darwin_amd64.tar.gz"
+            "amq_${version}_darwin_arm64.tar.gz"
+            "amq_${version}_linux_amd64.tar.gz"
+            "amq_${version}_linux_arm64.tar.gz"
+            "amq_${version}_windows_amd64.zip"
+            "amq_${version}_windows_arm64.zip"
+            "checksums.txt"
+          )
+
+          for name in "${expected[@]}"; do
+            if [[ ! -f "dist/${name}" ]]; then
+              echo "::error::Missing expected release asset: ${name}"
+              exit 1
+            fi
+          done
+
+          actual_count="$(find dist -maxdepth 1 -type f | wc -l | tr -d '[:space:]')"
+          if [[ "$actual_count" != "${#expected[@]}" ]]; then
+            echo "::error::Expected ${#expected[@]} release assets, found ${actual_count}."
+            find dist -maxdepth 1 -type f -print | sort
+            exit 1
+          fi
+
+          (cd dist && sha256sum -c checksums.txt)
+
+      - name: Attest release archives
+        id: attest_archives
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-checksums: dist/checksums.txt
+
+      - name: Attest checksum manifest
+        id: attest_checksums
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: dist/checksums.txt
+
+      - name: Verify generated attestations
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Archives attestation: ${{ steps.attest_archives.outputs.attestation-id }}"
+          echo "Checksums attestation: ${{ steps.attest_checksums.outputs.attestation-id }}"
+
+          for file in dist/*; do
+            echo "Verifying ${file}"
+            verified=false
+            for attempt in {1..6}; do
+              if gh attestation verify "$file" --repo "$GITHUB_REPOSITORY"; then
+                verified=true
+                break
+              fi
+              if [[ "$attempt" -lt 6 ]]; then
+                sleep 10
+              fi
+            done
+
+            if [[ "$verified" != "true" ]]; then
+              echo "::error::Failed to verify attestation for ${file}."
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary
- add a manual `Attest Release Assets` workflow for deliberate post-publish attestation recovery
- validate tag syntax, exact tag commit SHA, release existence, expected asset set, and release checksums before attesting
- attest existing release archives via `subject-checksums` and attest `checksums.txt` separately
- make `gh attestation verify` mandatory for all 7 downloaded files before the workflow can pass

## Context
This is for the one-time v0.32.2 recovery path Aviv authorized. The original Release workflow published the GitHub release and assets, but failed red after GoReleaser because macOS bash 3.2 lacks `mapfile`; #106 fixed future releases. Because the failure happened before `actions/attest`, v0.32.2 has no artifact attestations today.

This workflow intentionally does not rerun GoReleaser and does not upload, delete, replace, or edit release assets, Homebrew state, or skills. It downloads the already-published assets, proves they match the published `checksums.txt`, then attests those exact bytes.

## Recovery Semantics
The attestation is signed by this manual recovery workflow run, not by the original build CI. It proves deliberate post-publish attestation of the existing release assets after checksum validation; it is not original build-time provenance. For new releases, attestation comes from the normal Release workflow.

## Testing
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attest-release-assets.yml"); puts "yaml ok"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/attest-release-assets.yml`\n- `make ci`