### PR TITLE
feat(doctor): report extension manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `amq env --json` now emits the documented v1 machine-readable contract with `schema_version`, `amq_version`, `base_root`, `in_session`, `root_source`, always-present string fields, and `{}` for unconfigured `peers` (#101).
+- Reserved extension metadata namespaces under `<AM_ROOT>/extensions/<layer>/` and `<AM_ROOT>/agents/<handle>/extensions/<layer>/`; `amq doctor --json` now reports passive root extension manifests and malformed extension metadata diagnostics without executing extension code (#102).
 
 ## [0.32.2] - 2026-04-27
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,13 @@ internal/
 
 **Receipt Ledger**: Delivery outcomes are recorded as consumer-local receipts under `agents/<consumer>/receipts/`. Stages are `drained` and `dlq`. Use `amq receipts list`, `amq receipts wait`, or `amq send --wait-for <stage>` to query or block on them.
 
+**Extension Metadata Namespaces**: Higher-level layers may store their own metadata under reserved extension directories:
+```
+<AM_ROOT>/extensions/<layer>/
+<AM_ROOT>/agents/<handle>/extensions/<layer>/
+```
+Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and dot (for example `io.github.omriariav.amq-squad`). AMQ will not create files inside layer-owned directories, and `amq cleanup` does not remove extension directories unless a future command explicitly targets extension metadata. Layers may publish a passive root manifest at `<AM_ROOT>/extensions/<layer>/manifest.json`; `amq doctor --json` may report it, but AMQ must not execute extension code or invoke hooks from manifests.
+
 **Environment Variables**: `AM_ROOT` (queue root, e.g., `.agent-mail/collab`), `AM_ME` (agent handle), `AM_BASE_ROOT` (base root set by `coop exec` for cross-session resolution; only trusted when the current root still lives under it), `AMQ_GLOBAL_ROOT` (global root fallback for orchestrator-spawned agents), `AMQ_NO_UPDATE_CHECK` (disable update check)
 
 **Session Layout**: The default base root directory is `.agent-mail/`. `.amqrc` can configure that root explicitly, but the default `.agent-mail/<session>` layout is also recognized without `.amqrc`. `coop exec` defaults to `--session collab`, so agents get session isolation without explicit flags. Use `--session` to override:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,25 @@ flags > AM_ROOT > project .amqrc > AMQ_GLOBAL_ROOT > ~/.amqrc > auto-detect
 Auto-detect covers the default `.agent-mail` layout, including `.agent-mail/<session>` session roots without `.amqrc`. Custom root names and peer config still require `.amqrc` or explicit flags/env.
 This same chain is used by `amq env`, `amq doctor`, and the integration commands, so Symphony and Kanban-launched agents can find the correct queue even when they are not started from the project directory.
 
+## Extension Metadata
+
+Higher-level layers can store launch records, role metadata, restore state, and indexes without writing into AMQ-owned mailbox directories. AMQ reserves these extension namespaces:
+
+```text
+<AM_ROOT>/extensions/<layer>/
+<AM_ROOT>/agents/<handle>/extensions/<layer>/
+```
+
+Layer names use lowercase ASCII letters, digits, hyphen, underscore, and dot; reverse-DNS names such as `io.github.omriariav.amq-squad` are supported. AMQ does not create files inside layer-owned directories, and `amq cleanup` leaves extension directories alone unless a future command explicitly targets extension metadata.
+
+Layers may publish a passive manifest at:
+
+```text
+<AM_ROOT>/extensions/<layer>/manifest.json
+```
+
+`amq doctor --json` reports valid manifests under `extension_manifests` and malformed metadata under `extension_diagnostics`. Manifests are diagnostics-only: AMQ does not execute extension code, load callbacks, or invoke hooks from them. See [docs/adr-layer-extensions.md](docs/adr-layer-extensions.md) for the full contract.
+
 ## Integrations
 
 AMQ transports **messages**, not remote task state. The integration layer is intentionally narrow: optional adapters convert external lifecycle or task events into normal AMQ messages. Integration messages are self-delivered (`from=<me>`, `to=<me>`) so an agent monitoring its own inbox can react without polling another tool directly.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -17,8 +17,10 @@ type doctorCheck struct {
 }
 
 type doctorResult struct {
-	Checks  []doctorCheck `json:"checks"`
-	Summary struct {
+	Checks               []doctorCheck               `json:"checks"`
+	ExtensionManifests   []doctorExtensionManifest   `json:"extension_manifests,omitempty"`
+	ExtensionDiagnostics []doctorExtensionDiagnostic `json:"extension_diagnostics,omitempty"`
+	Summary              struct {
 		OK    int `json:"ok"`
 		Warn  int `json:"warn"`
 		Error int `json:"error"`
@@ -78,10 +80,18 @@ func runDoctor(args []string) error {
 		result.Checks = append(result.Checks, checkMailboxes(root))
 	}
 
-	// Check 6: Claude Code skill
+	// Check 6: Extension metadata
+	if root != "" {
+		manifests, diagnostics := scanExtensionMetadata(root)
+		result.ExtensionManifests = manifests
+		result.ExtensionDiagnostics = diagnostics
+		result.Checks = append(result.Checks, checkExtensions(manifests, diagnostics))
+	}
+
+	// Check 7: Claude Code skill
 	result.Checks = append(result.Checks, checkSkill("claude"))
 
-	// Check 7: Codex skill
+	// Check 8: Codex skill
 	result.Checks = append(result.Checks, checkSkill("codex"))
 
 	// Ops checks (runtime health)

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type doctorExtensionManifest struct {
+	Scope         string   `json:"scope"`
+	Layer         string   `json:"layer"`
+	Path          string   `json:"path"`
+	SchemaVersion int      `json:"schema_version"`
+	Version       string   `json:"version"`
+	Owns          []string `json:"owns"`
+}
+
+type doctorExtensionDiagnostic struct {
+	Scope   string `json:"scope"`
+	Agent   string `json:"agent,omitempty"`
+	Layer   string `json:"layer,omitempty"`
+	Path    string `json:"path"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+type passiveExtensionManifest struct {
+	SchemaVersion int      `json:"schema_version"`
+	Layer         string   `json:"layer"`
+	Version       string   `json:"version"`
+	Owns          []string `json:"owns"`
+}
+
+func isValidExtensionLayerName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' ||
+			c == '_' ||
+			c == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func scanExtensionMetadata(root string) ([]doctorExtensionManifest, []doctorExtensionDiagnostic) {
+	var manifests []doctorExtensionManifest
+	var diagnostics []doctorExtensionDiagnostic
+
+	rootExtensionsDir := filepath.Join(root, "extensions")
+	scanRootExtensions(root, rootExtensionsDir, &manifests, &diagnostics)
+	scanAgentExtensions(root, &diagnostics)
+
+	return manifests, diagnostics
+}
+
+func scanRootExtensions(root, extensionsDir string, manifests *[]doctorExtensionManifest, diagnostics *[]doctorExtensionDiagnostic) {
+	entries, err := os.ReadDir(extensionsDir)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		*diagnostics = append(*diagnostics, doctorExtensionDiagnostic{
+			Scope:   "root",
+			Path:    rootRelativePath(root, extensionsDir),
+			Status:  "error",
+			Message: fmt.Sprintf("cannot read extension directory: %v", err),
+		})
+		return
+	}
+
+	for _, entry := range entries {
+		layer := entry.Name()
+		layerPath := filepath.Join(extensionsDir, layer)
+		if !entry.IsDir() {
+			*diagnostics = append(*diagnostics, doctorExtensionDiagnostic{
+				Scope:   "root",
+				Layer:   layer,
+				Path:    rootRelativePath(root, layerPath),
+				Status:  "warn",
+				Message: "extension entry is not a directory",
+			})
+			continue
+		}
+		if !isValidExtensionLayerName(layer) {
+			*diagnostics = append(*diagnostics, invalidLayerDiagnostic(root, "root", "", layer, layerPath))
+			continue
+		}
+
+		manifestPath := filepath.Join(layerPath, "manifest.json")
+		manifest, diag, ok := readPassiveExtensionManifest(root, layer, manifestPath)
+		if diag != nil {
+			*diagnostics = append(*diagnostics, *diag)
+		}
+		if ok {
+			*manifests = append(*manifests, manifest)
+		}
+	}
+}
+
+func scanAgentExtensions(root string, diagnostics *[]doctorExtensionDiagnostic) {
+	agentsDir := filepath.Join(root, "agents")
+	agents, err := os.ReadDir(agentsDir)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		*diagnostics = append(*diagnostics, doctorExtensionDiagnostic{
+			Scope:   "agent",
+			Path:    rootRelativePath(root, agentsDir),
+			Status:  "error",
+			Message: fmt.Sprintf("cannot read agents directory for extensions: %v", err),
+		})
+		return
+	}
+
+	for _, agentEntry := range agents {
+		if !agentEntry.IsDir() {
+			continue
+		}
+		agent := agentEntry.Name()
+		extensionsDir := filepath.Join(agentsDir, agent, "extensions")
+		entries, err := os.ReadDir(extensionsDir)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			*diagnostics = append(*diagnostics, doctorExtensionDiagnostic{
+				Scope:   "agent",
+				Agent:   agent,
+				Path:    rootRelativePath(root, extensionsDir),
+				Status:  "error",
+				Message: fmt.Sprintf("cannot read agent extension directory: %v", err),
+			})
+			continue
+		}
+		for _, entry := range entries {
+			layer := entry.Name()
+			layerPath := filepath.Join(extensionsDir, layer)
+			if !entry.IsDir() {
+				*diagnostics = append(*diagnostics, doctorExtensionDiagnostic{
+					Scope:   "agent",
+					Agent:   agent,
+					Layer:   layer,
+					Path:    rootRelativePath(root, layerPath),
+					Status:  "warn",
+					Message: "extension entry is not a directory",
+				})
+				continue
+			}
+			if !isValidExtensionLayerName(layer) {
+				*diagnostics = append(*diagnostics, invalidLayerDiagnostic(root, "agent", agent, layer, layerPath))
+			}
+		}
+	}
+}
+
+func readPassiveExtensionManifest(root, layer, manifestPath string) (doctorExtensionManifest, *doctorExtensionDiagnostic, bool) {
+	data, err := os.ReadFile(manifestPath)
+	if os.IsNotExist(err) {
+		return doctorExtensionManifest{}, nil, false
+	}
+	if err != nil {
+		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
+			Scope:   "root",
+			Layer:   layer,
+			Path:    rootRelativePath(root, manifestPath),
+			Status:  "warn",
+			Message: fmt.Sprintf("cannot read manifest: %v", err),
+		}, false
+	}
+
+	var manifest passiveExtensionManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
+			Scope:   "root",
+			Layer:   layer,
+			Path:    rootRelativePath(root, manifestPath),
+			Status:  "warn",
+			Message: fmt.Sprintf("malformed manifest: %v", err),
+		}, false
+	}
+	if manifest.SchemaVersion != 1 {
+		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
+			Scope:   "root",
+			Layer:   layer,
+			Path:    rootRelativePath(root, manifestPath),
+			Status:  "warn",
+			Message: fmt.Sprintf("unsupported manifest schema_version %d", manifest.SchemaVersion),
+		}, false
+	}
+	if !isValidExtensionLayerName(manifest.Layer) {
+		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
+			Scope:   "root",
+			Layer:   layer,
+			Path:    rootRelativePath(root, manifestPath),
+			Status:  "warn",
+			Message: "manifest layer is not a valid extension layer name",
+		}, false
+	}
+	if manifest.Layer != layer {
+		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
+			Scope:   "root",
+			Layer:   layer,
+			Path:    rootRelativePath(root, manifestPath),
+			Status:  "warn",
+			Message: fmt.Sprintf("manifest layer %q does not match directory %q", manifest.Layer, layer),
+		}, false
+	}
+	if manifest.Owns == nil {
+		manifest.Owns = []string{}
+	}
+
+	return doctorExtensionManifest{
+		Scope:         "root",
+		Layer:         manifest.Layer,
+		Path:          rootRelativePath(root, manifestPath),
+		SchemaVersion: manifest.SchemaVersion,
+		Version:       manifest.Version,
+		Owns:          manifest.Owns,
+	}, nil, true
+}
+
+func invalidLayerDiagnostic(root, scope, agent, layer, path string) doctorExtensionDiagnostic {
+	return doctorExtensionDiagnostic{
+		Scope:   scope,
+		Agent:   agent,
+		Layer:   layer,
+		Path:    rootRelativePath(root, path),
+		Status:  "warn",
+		Message: "invalid extension layer name",
+	}
+}
+
+func checkExtensions(manifests []doctorExtensionManifest, diagnostics []doctorExtensionDiagnostic) doctorCheck {
+	check := doctorCheck{Name: "Extensions"}
+	if len(diagnostics) == 0 {
+		check.Status = "ok"
+		check.Message = fmt.Sprintf("%d manifest(s)", len(manifests))
+		return check
+	}
+
+	check.Status = "warn"
+	for _, diag := range diagnostics {
+		if diag.Status == "error" {
+			check.Status = "error"
+			break
+		}
+	}
+	check.Message = fmt.Sprintf("%d manifest(s), %d diagnostic(s)", len(manifests), len(diagnostics))
+	return check
+}
+
+func rootRelativePath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/cli/extensions_test.go
+++ b/internal/cli/extensions_test.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestIsValidExtensionLayerName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"io.github.omriariav.amq-squad", true},
+		{"amq_squad-1.2", true},
+		{"", false},
+		{".", false},
+		{"..", false},
+		{"Upper", false},
+		{"has space", false},
+		{"slash/name", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidExtensionLayerName(tt.name); got != tt.want {
+				t.Fatalf("isValidExtensionLayerName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunDoctorJSONReportsExtensionManifestsAndDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	layer := "io.github.omriariav.amq-squad"
+	manifestDir := filepath.Join(root, "extensions", layer)
+	if err := os.MkdirAll(manifestDir, 0o700); err != nil {
+		t.Fatalf("mkdir manifest dir: %v", err)
+	}
+	manifest := map[string]any{
+		"schema_version": 1,
+		"layer":          layer,
+		"version":        "0.3.1",
+		"owns": []string{
+			"agents/*/extensions/io.github.omriariav.amq-squad/launch.json",
+			"agents/*/extensions/io.github.omriariav.amq-squad/role.md",
+		},
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "manifest.json"), manifestData, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	badJSONDir := filepath.Join(root, "extensions", "bad-json")
+	if err := os.MkdirAll(badJSONDir, 0o700); err != nil {
+		t.Fatalf("mkdir bad json dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(badJSONDir, "manifest.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write bad manifest: %v", err)
+	}
+
+	invalidRootLayer := filepath.Join(root, "extensions", "BadLayer")
+	if err := os.MkdirAll(invalidRootLayer, 0o700); err != nil {
+		t.Fatalf("mkdir invalid root layer: %v", err)
+	}
+	invalidAgentLayer := filepath.Join(root, "agents", "alice", "extensions", "BadLayer")
+	if err := os.MkdirAll(invalidAgentLayer, 0o700); err != nil {
+		t.Fatalf("mkdir invalid agent layer: %v", err)
+	}
+
+	// Legacy direct-agent-root files from the migration overlap are not part of
+	// the reserved namespace and should not produce extension diagnostics.
+	if err := os.WriteFile(filepath.Join(root, "agents", "alice", "launch.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write legacy launch file: %v", err)
+	}
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_ME", "")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--json"})
+	})
+	if err != nil {
+		t.Fatalf("runDoctor: %v", err)
+	}
+
+	var result doctorResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("unmarshal doctor output: %v, output was: %s", err, output)
+	}
+	if len(result.ExtensionManifests) != 1 {
+		t.Fatalf("expected 1 extension manifest, got %d: %+v", len(result.ExtensionManifests), result.ExtensionManifests)
+	}
+	gotManifest := result.ExtensionManifests[0]
+	if gotManifest.Layer != layer {
+		t.Errorf("manifest layer = %q, want %q", gotManifest.Layer, layer)
+	}
+	if gotManifest.Version != "0.3.1" {
+		t.Errorf("manifest version = %q, want 0.3.1", gotManifest.Version)
+	}
+	if gotManifest.Path != "extensions/io.github.omriariav.amq-squad/manifest.json" {
+		t.Errorf("manifest path = %q", gotManifest.Path)
+	}
+	if len(gotManifest.Owns) != 2 {
+		t.Errorf("manifest owns length = %d, want 2", len(gotManifest.Owns))
+	}
+
+	if len(result.ExtensionDiagnostics) != 3 {
+		t.Fatalf("expected 3 extension diagnostics, got %d: %+v", len(result.ExtensionDiagnostics), result.ExtensionDiagnostics)
+	}
+	for _, diag := range result.ExtensionDiagnostics {
+		if diag.Path == "agents/alice/launch.json" {
+			t.Fatalf("legacy direct-agent-root file should not be diagnosed: %+v", diag)
+		}
+	}
+	if !hasExtensionDiagnostic(result.ExtensionDiagnostics, "root", "", "BadLayer", "invalid extension layer name") {
+		t.Fatalf("expected invalid root layer diagnostic, got %+v", result.ExtensionDiagnostics)
+	}
+	if !hasExtensionDiagnostic(result.ExtensionDiagnostics, "agent", "alice", "BadLayer", "invalid extension layer name") {
+		t.Fatalf("expected invalid agent layer diagnostic, got %+v", result.ExtensionDiagnostics)
+	}
+	if !hasExtensionDiagnostic(result.ExtensionDiagnostics, "root", "", "bad-json", "malformed manifest") {
+		t.Fatalf("expected malformed manifest diagnostic, got %+v", result.ExtensionDiagnostics)
+	}
+}
+
+func hasExtensionDiagnostic(diagnostics []doctorExtensionDiagnostic, scope, agent, layer, messagePrefix string) bool {
+	for _, diag := range diagnostics {
+		if diag.Scope != scope || diag.Agent != agent || diag.Layer != layer {
+			continue
+		}
+		if len(diag.Message) >= len(messagePrefix) && diag.Message[:len(messagePrefix)] == messagePrefix {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- reserve/document AMQ extension metadata namespaces for root/session and per-agent layer data
- add passive extension manifest reporting to `amq doctor --json`
- report malformed extension metadata diagnostics without executing code or invoking hooks

Closes #102.

## Notes

`doctor --json` now emits two additive fields when applicable:

- `extension_manifests` for valid root manifests at `<AM_ROOT>/extensions/<layer>/manifest.json`
- `extension_diagnostics` for malformed manifests, invalid layer directory names, or invalid reserved namespace entries

The scanner is intentionally passive. It does not inspect old direct-agent-root files, so migration overlap files such as `agents/<handle>/launch.json` do not become doctor warnings.

## Validation

- `go test ./internal/cli -run 'TestIsValidExtensionLayerName|TestRunDoctorJSONReportsExtensionManifestsAndDiagnostics' -count=1`
- `go test ./internal/cli -count=1`
- `make ci`
