### PR TITLE
feat(route): explain send routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `amq env --json` now emits the documented v1 machine-readable contract with `schema_version`, `amq_version`, `base_root`, `in_session`, `root_source`, always-present string fields, and `{}` for unconfigured `peers` (#101).
 - Reserved extension metadata namespaces under `<AM_ROOT>/extensions/<layer>/` and `<AM_ROOT>/agents/<handle>/extensions/<layer>/`; `amq doctor --json` now reports passive root extension manifests and malformed extension metadata diagnostics without executing extension code (#102).
+- `amq route explain --json` now reports canonical route resolution with routability, structured `argv`, display command, source/delivery roots, project, and session metadata for same-session, cross-session, and cross-project sends (#103).
 
 ## [0.32.2] - 2026-04-27
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ amq receipts list --me <agent> [--msg-id <id>] [--stage <stage>] [--json]
 amq receipts wait --me <agent> --msg-id <id> [--stage <stage>] [--timeout <duration>] [--poll-interval <duration>] [--json]
 amq presence set --me <agent> --status <busy|idle|...> [--note <str>]
 amq presence list [--json]
+amq route explain --to <handle> [--project <project>] [--session <session>] [--from-root <path>] [--from-cwd <path>] [--me <handle>] --json
 amq cleanup --tmp-older-than <duration> [--dry-run] [--yes]
 amq watch --me <agent> [--timeout <duration>] [--poll] [--json]
 amq monitor --me <agent> [--timeout <duration>] [--poll] [--include-body] [--peek] [--json]

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Common command groups:
 | Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `watch`, `monitor`, `receipts` |
 | Collaboration | `coop init`, `coop exec`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
-| Operations | `presence set`, `presence list`, `who`, `doctor`, `doctor --ops`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
+| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 
 For the full CLI syntax, examples, and message schema, see [CLAUDE.md](CLAUDE.md).
 

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -155,6 +155,19 @@ func init() {
 			},
 		},
 		{Name: "who", Summary: "Show sessions and agents in current project", Handler: runWho},
+		{
+			Name:        "route",
+			Summary:     "Explain canonical routing",
+			Description: "Explain AMQ route resolution without sending a message",
+			Examples: []string{
+				"amq route explain --to codex --json",
+				"amq route explain --to qa --project project-b --session qa --json",
+			},
+			Handler: runRoute,
+			Children: []CommandInfo{
+				{Name: "explain", Summary: "Explain a send route as canonical JSON", Handler: runRouteExplain},
+			},
+		},
 		{Name: "doctor", Summary: "Verify installation and configuration", Handler: runDoctor},
 		{Name: "shell-setup", Summary: "Output shell aliases (amc/amx)", Handler: runShellSetup},
 		// Handler is nil to avoid an init cycle (runCompletion references commands).

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -30,6 +30,7 @@ func TestCommandNames(t *testing.T) {
 		"integration",
 		"receipts",
 		"who",
+		"route",
 		"doctor",
 		"shell-setup",
 		"completion",
@@ -86,6 +87,7 @@ func TestChildNames(t *testing.T) {
 		{name: "coop", want: []string{"init", "exec"}},
 		{name: "swarm", want: []string{"list", "join", "leave", "tasks", "claim", "complete", "fail", "block", "bridge"}},
 		{name: "receipts", want: []string{"list", "wait"}},
+		{name: "route", want: []string{"explain"}},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/route.go
+++ b/internal/cli/route.go
@@ -1,0 +1,305 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type routeExplainResult struct {
+	SchemaVersion  int      `json:"schema_version"`
+	Routable       bool     `json:"routable"`
+	Argv           []string `json:"argv"`
+	DisplayCommand string   `json:"display_command"`
+	SourceRoot     string   `json:"source_root"`
+	DeliveryRoot   string   `json:"delivery_root"`
+	SourceProject  string   `json:"source_project"`
+	TargetProject  string   `json:"target_project"`
+	SourceSession  string   `json:"source_session"`
+	TargetSession  string   `json:"target_session"`
+	Error          string   `json:"error,omitempty"`
+}
+
+func runRoute(args []string) error {
+	if len(args) == 0 || isHelp(args[0]) {
+		return printGroupUsage(findCommand("route"))
+	}
+
+	switch args[0] {
+	case "explain":
+		return runRouteExplain(args[1:])
+	default:
+		return formatUnknownSubcommand("route", args[0])
+	}
+}
+
+func runRouteExplain(args []string) error {
+	fs := flag.NewFlagSet("route explain", flag.ContinueOnError)
+	toFlag := fs.String("to", "", "Receiver handle")
+	projectFlag := fs.String("project", "", "Target peer project name")
+	sessionFlag := fs.String("session", "", "Target session")
+	fromRootFlag := fs.String("from-root", "", "Source AMQ root to explain from")
+	rootFlag := fs.String("root", "", "Source AMQ root to explain from (alias for --from-root)")
+	fromCwdFlag := fs.String("from-cwd", "", "Working directory to resolve .amqrc and auto-detection from")
+	meFlag := fs.String("me", defaultMe(), "Sender handle (or AM_ME)")
+	jsonFlag := fs.Bool("json", false, "Emit JSON output")
+
+	usage := usageWithFlags(fs, "amq route explain --to <handle> [--project <project>] [--session <session>] --json",
+		"Explains canonical AMQ routing without sending a message.",
+		"",
+		"Examples:",
+		"  amq route explain --to codex --json",
+		"  amq route explain --to qa --project project-b --session qa --json",
+	)
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if fs.NArg() > 0 {
+		return UsageError("route explain does not accept positional arguments (got %q)", strings.Join(fs.Args(), " "))
+	}
+	if !*jsonFlag {
+		return UsageError("route explain requires --json")
+	}
+	if strings.TrimSpace(*fromRootFlag) != "" && strings.TrimSpace(*rootFlag) != "" {
+		return UsageError("--from-root and --root are mutually exclusive")
+	}
+
+	restore, err := chdirForRouteExplain(*fromCwdFlag)
+	if err != nil {
+		result := newRouteExplainResult()
+		result.Error = err.Error()
+		return writeJSON(os.Stdout, result)
+	}
+	defer restore()
+
+	result := explainRoute(routeExplainOptions{
+		To:       *toFlag,
+		Project:  *projectFlag,
+		Session:  *sessionFlag,
+		FromRoot: firstNonEmpty(*fromRootFlag, *rootFlag),
+		Me:       *meFlag,
+	})
+	return writeJSON(os.Stdout, result)
+}
+
+type routeExplainOptions struct {
+	To       string
+	Project  string
+	Session  string
+	FromRoot string
+	Me       string
+}
+
+func explainRoute(opts routeExplainOptions) routeExplainResult {
+	result := newRouteExplainResult()
+
+	sourceRoot, me, err := resolveRouteSource(opts.FromRoot, opts.Me)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.SourceRoot = sourceRoot
+	result.SourceProject = resolveProject(sourceRoot)
+	result.SourceSession = resolveSessionName(sourceRoot)
+
+	me, err = normalizeHandle(me)
+	if err != nil {
+		result.Error = fmt.Sprintf("--me: %v", err)
+		return result
+	}
+
+	targetProject := strings.TrimSpace(opts.Project)
+	targetSession := strings.TrimSpace(opts.Session)
+	rawTo := strings.TrimSpace(opts.To)
+	if targetProject == "" && rawTo != "" && strings.Contains(rawTo, "@") {
+		if handle, project, session, ok := parseInlineRecipient(rawTo); ok {
+			rawTo = handle
+			targetProject = project
+			if targetSession == "" {
+				targetSession = session
+			}
+		}
+	}
+	result.TargetProject = targetProject
+	result.TargetSession = targetSession
+
+	recipients, err := splitRecipients(rawTo)
+	if err != nil {
+		result.Error = fmt.Sprintf("--to: %v", err)
+		return result
+	}
+	recipients = dedupeStrings(recipients)
+	if len(recipients) != 1 {
+		result.Error = fmt.Sprintf("--to requires exactly one recipient for route explain (got %d)", len(recipients))
+		return result
+	}
+	target := recipients[0]
+
+	deliveryRoot, normalizedTargetSession, err := resolveRouteDelivery(sourceRoot, targetProject, targetSession, target)
+	if err != nil {
+		result.TargetSession = normalizedTargetSession
+		result.Error = err.Error()
+		return result
+	}
+
+	result.Routable = true
+	result.DeliveryRoot = deliveryRoot
+	result.TargetSession = normalizedTargetSession
+	if result.TargetProject == "" {
+		result.TargetProject = targetProject
+	}
+	if result.TargetSession == "" {
+		result.TargetSession = result.SourceSession
+	}
+	result.Argv = buildRouteArgv(sourceRoot, me, target, targetProject, normalizedTargetSession)
+	result.DisplayCommand = displayCommand(result.Argv)
+	return result
+}
+
+func newRouteExplainResult() routeExplainResult {
+	return routeExplainResult{
+		SchemaVersion: 1,
+		Argv:          []string{},
+	}
+}
+
+func resolveRouteSource(fromRoot, meFlag string) (sourceRoot, me string, err error) {
+	if strings.TrimSpace(fromRoot) != "" {
+		sourceRoot = resolveRoot(fromRoot)
+		me = strings.TrimSpace(meFlag)
+		if me == "" {
+			return sourceRoot, "", fmt.Errorf("--me is required (or set AM_ME)")
+		}
+		return sourceRoot, me, nil
+	}
+
+	root, _, resolvedMe, err := resolveEnvConfigWithSource("", meFlag)
+	if err != nil {
+		return "", "", err
+	}
+	sourceRoot = resolveRoot(root)
+	if strings.TrimSpace(resolvedMe) == "" {
+		return sourceRoot, "", fmt.Errorf("--me is required (or set AM_ME)")
+	}
+	return sourceRoot, resolvedMe, nil
+}
+
+func resolveRouteDelivery(sourceRoot, targetProject, targetSession, target string) (deliveryRoot, normalizedTargetSession string, err error) {
+	deliveryRoot = sourceRoot
+	normalizedTargetSession = strings.TrimSpace(targetSession)
+
+	if targetProject != "" {
+		peerBaseRoot, err := resolvePeer(sourceRoot, targetProject)
+		if err != nil {
+			return "", normalizedTargetSession, err
+		}
+		if !dirExists(peerBaseRoot) {
+			return "", normalizedTargetSession, fmt.Errorf("peer root for %q does not exist: %s", targetProject, peerBaseRoot)
+		}
+
+		if normalizedTargetSession != "" {
+			normalized, err := normalizeHandle(normalizedTargetSession)
+			if err != nil {
+				return "", normalizedTargetSession, fmt.Errorf("--session: %v", err)
+			}
+			normalizedTargetSession = normalized
+			deliveryRoot = filepath.Join(peerBaseRoot, normalizedTargetSession)
+		} else if classifyRoot(sourceRoot) != "" {
+			normalizedTargetSession = sessionName(sourceRoot)
+			deliveryRoot = filepath.Join(peerBaseRoot, normalizedTargetSession)
+		} else {
+			deliveryRoot = peerBaseRoot
+		}
+
+		if !dirExists(deliveryRoot) {
+			if normalizedTargetSession != "" {
+				return "", normalizedTargetSession, fmt.Errorf("session %q not found in peer %q at %s", normalizedTargetSession, targetProject, deliveryRoot)
+			}
+			return "", normalizedTargetSession, fmt.Errorf("peer %q root does not exist at %s", targetProject, deliveryRoot)
+		}
+		inbox := filepath.Join(deliveryRoot, "agents", target, "inbox")
+		if !dirExists(inbox) {
+			if normalizedTargetSession != "" {
+				return "", normalizedTargetSession, fmt.Errorf("agent %q not found in peer %q session %q", target, targetProject, normalizedTargetSession)
+			}
+			return "", normalizedTargetSession, fmt.Errorf("agent %q not found in peer %q", target, targetProject)
+		}
+		return deliveryRoot, normalizedTargetSession, nil
+	}
+
+	if normalizedTargetSession != "" {
+		normalized, err := normalizeHandle(normalizedTargetSession)
+		if err != nil {
+			return "", normalizedTargetSession, fmt.Errorf("--session: %v", err)
+		}
+		normalizedTargetSession = normalized
+		baseRoot := classifyRoot(sourceRoot)
+		if baseRoot == "" {
+			return "", normalizedTargetSession, fmt.Errorf("--session requires a session context: run from inside 'amq coop exec --session <name>'")
+		}
+		deliveryRoot = filepath.Join(baseRoot, normalizedTargetSession)
+		if !dirExists(deliveryRoot) {
+			return "", normalizedTargetSession, fmt.Errorf("session %q not found at %s", normalizedTargetSession, deliveryRoot)
+		}
+		inbox := filepath.Join(deliveryRoot, "agents", target, "inbox")
+		if !dirExists(inbox) {
+			return "", normalizedTargetSession, fmt.Errorf("agent %q not found in session %q", target, normalizedTargetSession)
+		}
+		return deliveryRoot, normalizedTargetSession, nil
+	}
+
+	return deliveryRoot, "", nil
+}
+
+func buildRouteArgv(sourceRoot, me, target, targetProject, targetSession string) []string {
+	// Keep argv self-contained for tooling; display_command is presentation only.
+	argv := []string{"amq", "send", "--root", sourceRoot, "--me", me, "--to", target}
+	if targetProject != "" {
+		argv = append(argv, "--project", targetProject)
+	}
+	if targetSession != "" {
+		argv = append(argv, "--session", targetSession)
+	}
+	return argv
+}
+
+func displayCommand(argv []string) string {
+	parts := make([]string, 0, len(argv))
+	for _, arg := range argv {
+		parts = append(parts, shellQuotePosix(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func chdirForRouteExplain(fromCwd string) (func(), error) {
+	fromCwd = strings.TrimSpace(fromCwd)
+	if fromCwd == "" {
+		return func() {}, nil
+	}
+	info, err := os.Stat(fromCwd)
+	if err != nil {
+		return nil, fmt.Errorf("--from-cwd: %v", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("--from-cwd is not a directory: %s", fromCwd)
+	}
+	oldWd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chdir(fromCwd); err != nil {
+		return nil, fmt.Errorf("--from-cwd: %v", err)
+	}
+	return func() { _ = os.Chdir(oldWd) }, nil
+}
+
+func firstNonEmpty(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return a
+	}
+	return b
+}

--- a/internal/cli/route_test.go
+++ b/internal/cli/route_test.go
@@ -1,0 +1,351 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestRouteExplainSameSession(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	sourceRoot := filepath.Join(baseRoot, "collab")
+	ensureRouteAgents(t, sourceRoot, "alice", "bob")
+
+	result := runRouteExplainJSONForTest(t,
+		"--from-root", sourceRoot,
+		"--me", "alice",
+		"--to", "bob",
+	)
+
+	if !result.Routable {
+		t.Fatalf("expected routable route, got error: %s", result.Error)
+	}
+	expectSamePath(t, result.SourceRoot, sourceRoot)
+	expectSamePath(t, result.DeliveryRoot, sourceRoot)
+	if result.SourceSession != "collab" {
+		t.Errorf("source_session = %q, want collab", result.SourceSession)
+	}
+	if result.TargetSession != "collab" {
+		t.Errorf("target_session = %q, want collab", result.TargetSession)
+	}
+	wantArgv := []string{"amq", "send", "--root", sourceRoot, "--me", "alice", "--to", "bob"}
+	expectStringSlice(t, result.Argv, wantArgv)
+}
+
+func TestRouteExplainCrossSession(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	sourceRoot := filepath.Join(baseRoot, "dev")
+	targetRoot := filepath.Join(baseRoot, "qa")
+	ensureRouteAgents(t, sourceRoot, "alice")
+	ensureRouteAgents(t, targetRoot, "bob")
+
+	result := runRouteExplainJSONForTest(t,
+		"--from-root", sourceRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--session", "qa",
+	)
+
+	if !result.Routable {
+		t.Fatalf("expected routable route, got error: %s", result.Error)
+	}
+	if result.DeliveryRoot != targetRoot {
+		t.Errorf("delivery_root = %q, want %q", result.DeliveryRoot, targetRoot)
+	}
+	if result.SourceSession != "dev" {
+		t.Errorf("source_session = %q, want dev", result.SourceSession)
+	}
+	if result.TargetSession != "qa" {
+		t.Errorf("target_session = %q, want qa", result.TargetSession)
+	}
+	wantArgv := []string{"amq", "send", "--root", sourceRoot, "--me", "alice", "--to", "bob", "--session", "qa"}
+	expectStringSlice(t, result.Argv, wantArgv)
+}
+
+func TestRouteExplainCrossProjectMirrorsSourceSession(t *testing.T) {
+	srcProjectDir := filepath.Join(t.TempDir(), "src-project")
+	sourceRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+	peerProjectDir := filepath.Join(t.TempDir(), "peer-project")
+	peerBaseRoot := filepath.Join(peerProjectDir, ".agent-mail")
+	peerSessionRoot := filepath.Join(peerBaseRoot, "collab")
+	ensureRouteAgents(t, sourceRoot, "alice")
+	ensureRouteAgents(t, peerSessionRoot, "bob")
+	writeRouteAmqrc(t, srcProjectDir, map[string]any{
+		"root":    ".agent-mail",
+		"project": "src-project",
+		"peers": map[string]string{
+			"peer-project": peerBaseRoot,
+		},
+	})
+
+	result := runRouteExplainJSONForTest(t,
+		"--from-root", sourceRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--project", "peer-project",
+	)
+
+	if !result.Routable {
+		t.Fatalf("expected routable route, got error: %s", result.Error)
+	}
+	if result.DeliveryRoot != peerSessionRoot {
+		t.Errorf("delivery_root = %q, want %q", result.DeliveryRoot, peerSessionRoot)
+	}
+	if result.SourceProject != "src-project" {
+		t.Errorf("source_project = %q, want src-project", result.SourceProject)
+	}
+	if result.TargetProject != "peer-project" {
+		t.Errorf("target_project = %q, want peer-project", result.TargetProject)
+	}
+	if result.TargetSession != "collab" {
+		t.Errorf("target_session = %q, want collab", result.TargetSession)
+	}
+	wantArgv := []string{"amq", "send", "--root", sourceRoot, "--me", "alice", "--to", "bob", "--project", "peer-project", "--session", "collab"}
+	expectStringSlice(t, result.Argv, wantArgv)
+}
+
+func TestRouteExplainCrossProjectExplicitSession(t *testing.T) {
+	srcProjectDir := filepath.Join(t.TempDir(), "src-project")
+	sourceRoot := filepath.Join(srcProjectDir, ".agent-mail", "cto")
+	peerProjectDir := filepath.Join(t.TempDir(), "peer-project")
+	peerBaseRoot := filepath.Join(peerProjectDir, ".agent-mail")
+	peerSessionRoot := filepath.Join(peerBaseRoot, "qa")
+	ensureRouteAgents(t, sourceRoot, "alice")
+	ensureRouteAgents(t, peerSessionRoot, "bob")
+	writeRouteAmqrc(t, srcProjectDir, map[string]any{
+		"root":    ".agent-mail",
+		"project": "src-project",
+		"peers": map[string]string{
+			"peer-project": peerBaseRoot,
+		},
+	})
+
+	result := runRouteExplainJSONForTest(t,
+		"--from-root", sourceRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--project", "peer-project",
+		"--session", "qa",
+	)
+
+	if !result.Routable {
+		t.Fatalf("expected routable route, got error: %s", result.Error)
+	}
+	if result.DeliveryRoot != peerSessionRoot {
+		t.Errorf("delivery_root = %q, want %q", result.DeliveryRoot, peerSessionRoot)
+	}
+	if result.SourceSession != "cto" {
+		t.Errorf("source_session = %q, want cto", result.SourceSession)
+	}
+	if result.TargetSession != "qa" {
+		t.Errorf("target_session = %q, want qa", result.TargetSession)
+	}
+	wantArgv := []string{"amq", "send", "--root", sourceRoot, "--me", "alice", "--to", "bob", "--project", "peer-project", "--session", "qa"}
+	expectStringSlice(t, result.Argv, wantArgv)
+}
+
+func TestRouteExplainMissingPeerIsNonRoutable(t *testing.T) {
+	srcProjectDir := filepath.Join(t.TempDir(), "src-project")
+	sourceRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+	ensureRouteAgents(t, sourceRoot, "alice")
+	writeRouteAmqrc(t, srcProjectDir, map[string]any{
+		"root":    ".agent-mail",
+		"project": "src-project",
+	})
+
+	result := runRouteExplainJSONForTest(t,
+		"--from-root", sourceRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--project", "peer-project",
+	)
+
+	if result.Routable {
+		t.Fatalf("expected non-routable result")
+	}
+	if len(result.Argv) != 0 {
+		t.Fatalf("expected empty argv for non-routable result, got %v", result.Argv)
+	}
+	if result.DisplayCommand != "" {
+		t.Fatalf("expected empty display_command for non-routable result, got %q", result.DisplayCommand)
+	}
+	if result.Error == "" {
+		t.Fatalf("expected error for non-routable result")
+	}
+	if result.SourceRoot != sourceRoot {
+		t.Errorf("source_root = %q, want %q", result.SourceRoot, sourceRoot)
+	}
+	if result.TargetProject != "peer-project" {
+		t.Errorf("target_project = %q, want peer-project", result.TargetProject)
+	}
+}
+
+func TestRouteExplainFromCWD(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "project-a")
+	sourceRoot := filepath.Join(projectDir, ".agent-mail")
+	ensureRouteAgents(t, sourceRoot, "alice", "bob")
+	writeRouteAmqrc(t, projectDir, map[string]any{
+		"root":    ".agent-mail",
+		"project": "project-a",
+	})
+
+	outsideDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	t.Setenv(envRoot, "")
+	t.Setenv(envGlobalRoot, "")
+	if err := os.Chdir(outsideDir); err != nil {
+		t.Fatalf("chdir outside: %v", err)
+	}
+	resetAmqrcCache()
+	t.Cleanup(resetAmqrcCache)
+
+	result := runRouteExplainJSONForTest(t,
+		"--from-cwd", projectDir,
+		"--me", "alice",
+		"--to", "bob",
+	)
+
+	if !result.Routable {
+		t.Fatalf("expected routable route, got error: %s", result.Error)
+	}
+	expectSamePath(t, result.SourceRoot, sourceRoot)
+	expectSamePath(t, result.DeliveryRoot, sourceRoot)
+	if result.SourceProject != "project-a" {
+		t.Errorf("source_project = %q, want project-a", result.SourceProject)
+	}
+}
+
+func TestRouteExplainJSONV1Fields(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	sourceRoot := filepath.Join(baseRoot, "collab")
+	ensureRouteAgents(t, sourceRoot, "alice", "bob")
+
+	routable := runRouteExplainRawJSONForTest(t,
+		"--from-root", sourceRoot,
+		"--me", "alice",
+		"--to", "bob",
+	)
+	required := []string{
+		"schema_version",
+		"routable",
+		"argv",
+		"display_command",
+		"source_root",
+		"delivery_root",
+		"source_project",
+		"target_project",
+		"source_session",
+		"target_session",
+	}
+	for _, key := range required {
+		if _, ok := routable[key]; !ok {
+			t.Errorf("expected routable JSON field %q to be present", key)
+		}
+	}
+	if _, ok := routable["error"]; ok {
+		t.Errorf("expected routable JSON output to omit error, got %s", routable["error"])
+	}
+
+	srcProjectDir := filepath.Join(t.TempDir(), "src-project")
+	nonRoutableRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+	ensureRouteAgents(t, nonRoutableRoot, "alice")
+	writeRouteAmqrc(t, srcProjectDir, map[string]any{
+		"root":    ".agent-mail",
+		"project": "src-project",
+	})
+	nonRoutable := runRouteExplainRawJSONForTest(t,
+		"--from-root", nonRoutableRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--project", "peer-project",
+	)
+	for _, key := range required {
+		if _, ok := nonRoutable[key]; !ok {
+			t.Errorf("expected non-routable JSON field %q to be present", key)
+		}
+	}
+	if _, ok := nonRoutable["error"]; !ok {
+		t.Errorf("expected non-routable JSON output to include error")
+	}
+}
+
+func runRouteExplainJSONForTest(t *testing.T, args ...string) routeExplainResult {
+	t.Helper()
+
+	outArgs := append([]string{"--json"}, args...)
+	output, err := captureEnvStdout(t, func() error {
+		return runRouteExplain(outArgs)
+	})
+	if err != nil {
+		t.Fatalf("runRouteExplain: %v", err)
+	}
+
+	var result routeExplainResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("unmarshal route explain output: %v, output was: %s", err, output)
+	}
+	return result
+}
+
+func runRouteExplainRawJSONForTest(t *testing.T, args ...string) map[string]json.RawMessage {
+	t.Helper()
+
+	outArgs := append([]string{"--json"}, args...)
+	output, err := captureEnvStdout(t, func() error {
+		return runRouteExplain(outArgs)
+	})
+	if err != nil {
+		t.Fatalf("runRouteExplain: %v", err)
+	}
+
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("unmarshal raw route explain output: %v, output was: %s", err, output)
+	}
+	return result
+}
+
+func ensureRouteAgents(t *testing.T, root string, agents ...string) {
+	t.Helper()
+
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs(%q): %v", root, err)
+	}
+	for _, agent := range agents {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%q, %q): %v", root, agent, err)
+		}
+	}
+}
+
+func writeRouteAmqrc(t *testing.T, dir string, value map[string]any) {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal amqrc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".amqrc"), data, 0o600); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+}
+
+func expectStringSlice(t *testing.T, got, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("slice length = %d, want %d; got %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("slice[%d] = %q, want %q; got %v", i, got[i], want[i], got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add `amq route explain --json` with canonical route metadata and structured argv output
- support same-session, cross-session, cross-project, and cross-project explicit-session explanations
- return `routable: false` with empty `argv` and a useful `error` for non-routable routes

Closes #103.

## Notes

The JSON contract includes:

- `schema_version`
- `routable`
- `argv`
- `display_command`
- `source_root` / `delivery_root`
- `source_project` / `target_project`
- `source_session` / `target_session`
- `error` when non-routable

`argv` is intentionally self-contained for tooling: it includes `amq send`, `--root <source_root>`, `--me <sender>`, `--to <handle>`, and any `--project` / `--session` route flags. Consumers should treat `argv` as canonical and `display_command` as human presentation only.

## Validation

- `go test ./internal/cli -run 'TestRouteExplain' -count=1`
- `go test ./internal/cli -count=1`
- `make ci`
