### PR TITLE
feat(send): support from-session routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `amq env --json` now emits the documented v1 machine-readable contract with `schema_version`, `amq_version`, `base_root`, `in_session`, `root_source`, always-present string fields, and `{}` for unconfigured `peers` (#101).
 - Reserved extension metadata namespaces under `<AM_ROOT>/extensions/<layer>/` and `<AM_ROOT>/agents/<handle>/extensions/<layer>/`; `amq doctor --json` now reports passive root extension manifests and malformed extension metadata diagnostics without executing extension code (#102).
 - `amq route explain --json` now reports canonical route resolution with routability, structured `argv`, display command, source/delivery roots, project, and session metadata for same-session, cross-session, and cross-project sends (#103).
+- `amq send --from-session <source-session>` supports setup-terminal cross-session sends from a base root, writing the sender outbox in the source session and stamping `reply_to` for replies back to that session (#104).
 
 ## [0.32.2] - 2026-04-27
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ When `--kind` is set but `--priority` is not, priority defaults to `normal`.
 
 ```bash
 amq init --root <path> --agents a,b,c [--force]
-amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--body <str|@file|stdin>] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--wait-for <stage>] [--wait-timeout <duration>]
+amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--body <str|@file|stdin>] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--session <target-session>] [--from-session <source-session>] [--project <project>] [--wait-for <stage>] [--wait-timeout <duration>]
 amq list --me <agent> [--new | --cur] [--priority <p>] [--from <h>] [--kind <k>] [--label <l>...] [--limit N] [--offset N] [--json]
 amq read --me <agent> --id <msg_id> [--json]
 amq drain --me <agent> [--limit N] [--include-body] [--json]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ amq drain --include-body
 amq send --to codex --body "Please pick this up" \
   --wait-for drained --wait-timeout 60s
 
+# Send between known sessions before entering coop exec
+amq send --root .agent-mail --from-session feature-a --me claude \
+  --to codex --session feature-b --body "Please review the setup"
+
 # Inspect receipts for a message later
 amq receipts list --me codex --msg-id <msg_id>
 

--- a/docs/adr-layer-extensions.md
+++ b/docs/adr-layer-extensions.md
@@ -271,7 +271,7 @@ Layer guidance:
 
 ## Pre-Boot `--from-session` Sends
 
-AMQ will support explicit source-session stamping from setup terminals:
+AMQ supports explicit source-session stamping from setup terminals:
 
 ```bash
 amq send \

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -20,7 +20,7 @@ func runSend(args []string) error {
 	common := addCommonFlags(fs)
 	toFlag := fs.String("to", "", "Receiver handle (comma-separated)")
 	subjectFlag := fs.String("subject", "", "Message subject")
-	threadFlag := fs.String("thread", "", "Thread id (required for cross-session sends; default p2p/<a>__<b> for local)")
+	threadFlag := fs.String("thread", "", "Thread id (required for multiple recipients; default p2p/<a>__<b> for single-recipient sends)")
 	bodyFlag := fs.String("body", "", "Body string, @file, or empty to read stdin")
 	refsFlag := fs.String("refs", "", "Comma-separated related message ids")
 	waitForFlag := fs.String("wait-for", "", "Wait for receipt stage after send (drained, dlq)")
@@ -34,14 +34,16 @@ func runSend(args []string) error {
 
 	// Cross-session flag
 	sessionFlag := fs.String("session", "", "Target session (delivers to a different session's inbox)")
+	fromSessionFlag := fs.String("from-session", "", "Source session for setup-terminal cross-session sends")
 
 	// Cross-project flag
 	projectFlag := fs.String("project", "", "Target peer project name (delivers to a peer project's inbox)")
 
-	usage := usageWithFlags(fs, "amq send --me <agent> --to <recipients> [--project <name>] [--session <name>] [options]",
+	usage := usageWithFlags(fs, "amq send --me <agent> --to <recipients> [--project <name>] [--session <name>] [--from-session <name>] [options]",
 		"",
 		"Cross-session example:",
 		"  amq send --to codex --session auth --thread xsession/auth-review --body \"...\"",
+		"  amq send --root .agent-mail --from-session cto --me alice --to bob --session qa --body \"...\"",
 		"",
 		"Receipt example:",
 		"  amq send --to codex --body \"please review\" --wait-for drained --wait-timeout 60s",
@@ -112,7 +114,29 @@ func runSend(args []string) error {
 	if targetSession == "" && inlineSession != "" {
 		targetSession = inlineSession
 	}
+	sourceRoot := root
+	sourceSession := ""
+	fromSession := strings.TrimSpace(*fromSessionFlag)
 	var replyProject string
+	if fromSession != "" {
+		if targetProject != "" {
+			return UsageError("--from-session is not supported with --project")
+		}
+		if targetSession == "" {
+			return UsageError("--from-session requires --session")
+		}
+		if err := validateSessionName(fromSession); err != nil {
+			return UsageError("--from-session: %v", err)
+		}
+		if classifyRoot(root) != "" {
+			return UsageError("--from-session requires --root to be the base root, not a session root")
+		}
+		sourceRoot = filepath.Join(root, fromSession)
+		if !dirExists(sourceRoot) {
+			return fmt.Errorf("source session %q not found at %s", fromSession, sourceRoot)
+		}
+		sourceSession = fromSession
+	}
 
 	if targetProject != "" {
 		// Cross-project delivery.
@@ -168,11 +192,14 @@ func runSend(args []string) error {
 		}
 		targetSession = normalized
 
-		// Cross-session requires AM_BASE_ROOT to be set (by coop exec) or
-		// the root must be a session root (has a parent with sibling sessions).
-		// This eliminates the base-root ambiguity: --session only works from
-		// a session context, never from the base root directly.
-		baseRoot := classifyRoot(root)
+		baseRoot := root
+		if fromSession == "" {
+			// Cross-session requires AM_BASE_ROOT to be set (by coop exec) or
+			// the root must be a session root (has a parent with sibling sessions).
+			// This eliminates the base-root ambiguity: --session only works from
+			// a session context, never from the base root directly.
+			baseRoot = classifyRoot(root)
+		}
 		if baseRoot == "" {
 			return fmt.Errorf("--session requires a session context: run from inside 'amq coop exec --session <name>'")
 		}
@@ -193,7 +220,7 @@ func runSend(args []string) error {
 
 	// Validate sender in source root, recipients in target root. Always.
 	if targetProject != "" || targetSession != "" {
-		if err := validateKnownHandles(root, common.Strict, me); err != nil {
+		if err := validateKnownHandles(sourceRoot, common.Strict, me); err != nil {
 			return err
 		}
 		if err := validateKnownHandles(deliveryRoot, common.Strict, recipients...); err != nil {
@@ -236,7 +263,7 @@ func runSend(args []string) error {
 	}
 
 	// Detect whether sender is inside a session (needed for reply_to and thread IDs).
-	senderInSession := classifyRoot(root) != ""
+	senderInSession := sourceSession != "" || classifyRoot(root) != ""
 
 	// Thread ID: auto-generated for P2P, qualified for cross-session/cross-project.
 	threadID := strings.TrimSpace(*threadFlag)
@@ -246,7 +273,7 @@ func runSend(args []string) error {
 				// Cross-project: include project names (and session names when applicable).
 				srcProject := resolveProject(root)
 				if targetSession != "" && senderInSession {
-					srcSession := sessionName(root)
+					srcSession := sourceSessionName(root, sourceSession)
 					threadID = "p2p/" + srcProject + ":" + srcSession + ":" + common.Me + "__" + targetProject + ":" + targetSession + ":" + recipients[0]
 				} else if targetSession != "" {
 					// Sender at base root targeting a session.
@@ -256,7 +283,7 @@ func runSend(args []string) error {
 				}
 			} else if targetSession != "" {
 				// Cross-session: include session names to avoid collisions.
-				senderSession := sessionName(root)
+				senderSession := sourceSessionName(root, sourceSession)
 				threadID = "p2p/" + senderSession + ":" + common.Me + "__" + targetSession + ":" + recipients[0]
 			} else {
 				threadID = canonicalP2P(common.Me, recipients[0])
@@ -276,7 +303,7 @@ func runSend(args []string) error {
 	replyTo := ""
 	if senderInSession {
 		// Sender is in a session — stamp handle@session for reply routing.
-		replyTo = common.Me + "@" + sessionName(root)
+		replyTo = common.Me + "@" + sourceSessionName(root, sourceSession)
 	} else if targetProject != "" {
 		// Sender at base root, cross-project — stamp just handle.
 		replyTo = common.Me
@@ -330,10 +357,10 @@ func runSend(args []string) error {
 	}
 
 	// Best-effort presence touch.
-	_ = presence.Touch(root, common.Me)
+	_ = presence.Touch(sourceRoot, common.Me)
 
 	// Copy to sender outbox/sent for audit (always in sender's root).
-	outboxDir := fsq.AgentOutboxSent(root, common.Me)
+	outboxDir := fsq.AgentOutboxSent(sourceRoot, common.Me)
 	outboxErr := error(nil)
 	if _, err := fsq.WriteFileAtomic(outboxDir, filename, data, 0o600); err != nil {
 		outboxErr = err
@@ -341,7 +368,7 @@ func runSend(args []string) error {
 
 	session := ""
 	if senderInSession {
-		session = sessionName(root)
+		session = sourceSessionName(root, sourceSession)
 	}
 	targetDisplay := session
 	if targetSession != "" {
@@ -367,12 +394,13 @@ func runSend(args []string) error {
 
 	if common.JSON {
 		out := map[string]any{
-			"id":      id,
-			"thread":  threadID,
-			"to":      recipients,
-			"subject": msg.Header.Subject,
-			"session": targetDisplay,
-			"root":    deliveryRoot,
+			"id":          id,
+			"thread":      threadID,
+			"to":          recipients,
+			"subject":     msg.Header.Subject,
+			"session":     targetDisplay,
+			"root":        deliveryRoot,
+			"source_root": sourceRoot,
 			"outbox": map[string]any{
 				"written": outboxErr == nil,
 				"error":   errString(outboxErr),
@@ -465,4 +493,11 @@ func canonicalP2P(a, b string) string {
 		return "p2p/" + a + "__" + b
 	}
 	return "p2p/" + b + "__" + a
+}
+
+func sourceSessionName(root, explicitSourceSession string) string {
+	if explicitSourceSession != "" {
+		return explicitSourceSession
+	}
+	return sessionName(root)
 }

--- a/internal/cli/send_cross_session_test.go
+++ b/internal/cli/send_cross_session_test.go
@@ -4,11 +4,114 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"github.com/avivsinai/agent-message-queue/internal/receipt"
 )
+
+func TestSendFromSessionPreBootCrossSession(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	sourceRoot := filepath.Join(baseRoot, "cto")
+	targetRoot := filepath.Join(baseRoot, "qa")
+	ensureSendSessionAgent(t, sourceRoot, "alice")
+	ensureSendSessionAgent(t, targetRoot, "bob")
+
+	output := runSendJSONForTest(t,
+		"--me", "alice",
+		"--root", baseRoot,
+		"--from-session", "cto",
+		"--to", "bob",
+		"--session", "qa",
+		"--body", "hello from setup terminal",
+		"--json",
+	)
+
+	if got := output["root"]; got != targetRoot {
+		t.Fatalf("root = %v, want %q", got, targetRoot)
+	}
+	if got := output["source_root"]; got != sourceRoot {
+		t.Fatalf("source_root = %v, want %q", got, sourceRoot)
+	}
+	if output["cross_session"] != true {
+		t.Fatal("expected cross_session=true")
+	}
+	if got := output["source_session"]; got != "cto" {
+		t.Fatalf("source_session = %v, want cto", got)
+	}
+	if got := output["target_session"]; got != "qa" {
+		t.Fatalf("target_session = %v, want qa", got)
+	}
+
+	targetEntries := mustReadDir(t, filepath.Join(targetRoot, "agents", "bob", "inbox", "new"))
+	if len(targetEntries) != 1 {
+		t.Fatalf("expected 1 target inbox message, got %d", len(targetEntries))
+	}
+	sourceEntries := mustReadDir(t, filepath.Join(sourceRoot, "agents", "alice", "outbox", "sent"))
+	if len(sourceEntries) != 1 {
+		t.Fatalf("expected 1 source outbox copy, got %d", len(sourceEntries))
+	}
+	baseEntries := mustReadDir(t, filepath.Join(baseRoot, "agents", "alice", "outbox", "sent"))
+	if len(baseEntries) != 0 {
+		t.Fatalf("expected no base-root outbox copy, got %d", len(baseEntries))
+	}
+
+	messagePath := filepath.Join(targetRoot, "agents", "bob", "inbox", "new", targetEntries[0].Name())
+	header, err := format.ReadHeaderFile(messagePath)
+	if err != nil {
+		t.Fatalf("read target header: %v", err)
+	}
+	if header.ReplyTo != "alice@cto" {
+		t.Fatalf("reply_to = %q, want alice@cto", header.ReplyTo)
+	}
+	if header.Thread != "p2p/cto:alice__qa:bob" {
+		t.Fatalf("thread = %q, want p2p/cto:alice__qa:bob", header.Thread)
+	}
+}
+
+func TestSendFromSessionRejectsProject(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	ensureSendSessionAgent(t, filepath.Join(baseRoot, "cto"), "alice")
+
+	err := runSend([]string{
+		"--me", "alice",
+		"--root", baseRoot,
+		"--from-session", "cto",
+		"--to", "bob",
+		"--session", "qa",
+		"--project", "peer-project",
+		"--body", "not allowed",
+	})
+	if err == nil {
+		t.Fatal("expected --from-session with --project to fail")
+	}
+	if !strings.Contains(err.Error(), "--from-session is not supported with --project") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendFromSessionRequiresExistingSourceSession(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	ensureSendSessionAgent(t, filepath.Join(baseRoot, "qa"), "bob")
+
+	err := runSend([]string{
+		"--me", "alice",
+		"--root", baseRoot,
+		"--from-session", "cto",
+		"--to", "bob",
+		"--session", "qa",
+		"--body", "missing source",
+	})
+	if err == nil {
+		t.Fatal("expected missing source session to fail")
+	}
+	if !strings.Contains(err.Error(), `source session "cto" not found`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
 
 func TestSendCrossSessionWithExplicitRootOverride(t *testing.T) {
 	staleBase := filepath.Join(t.TempDir(), "stale-base")
@@ -180,4 +283,58 @@ func TestSendCrossSessionWaitForUsesDeliveryRoot(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("receipt emitter goroutine did not finish")
 	}
+}
+
+func runSendJSONForTest(t *testing.T, args ...string) map[string]any {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+	})
+
+	err = runSend(args)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	if err != nil {
+		t.Fatalf("runSend: %v", err)
+	}
+
+	var buf [8192]byte
+	n, _ := r.Read(buf[:])
+	var result map[string]any
+	if err := json.Unmarshal(buf[:n], &result); err != nil {
+		t.Fatalf("parse output: %v\nraw: %s", err, buf[:n])
+	}
+	return result
+}
+
+func ensureSendSessionAgent(t *testing.T, root, agent string) {
+	t.Helper()
+
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs(%q): %v", root, err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatalf("EnsureAgentDirs(%q, %q): %v", root, agent, err)
+	}
+}
+
+func mustReadDir(t *testing.T, path string) []os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("ReadDir(%q): %v", path, err)
+	}
+	return entries
 }


### PR DESCRIPTION
## Summary
- add `amq send --from-session <source-session>` for setup-terminal cross-session sends from a base root
- validate the source session, write the sender outbox/presence under that session, and stamp `reply_to` as `<sender>@<source-session>`
- document the new surface in the changelog, command reference, README, and ADR

Closes #104.
Closes #96.

## Validation
- `go test ./...`
- `make ci`