### PR TITLE
chore(release): v0.33.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.33.0] - 2026-04-27
 ### Added
 
 - `amq env --json` now emits the documented v1 machine-readable contract with `schema_version`, `amq_version`, `base_root`, `in_session`, `root_source`, always-present string fields, and `{}` for unconfigured `peers` (#101).
 - Reserved extension metadata namespaces under `<AM_ROOT>/extensions/<layer>/` and `<AM_ROOT>/agents/<handle>/extensions/<layer>/`; `amq doctor --json` now reports passive root extension manifests and malformed extension metadata diagnostics without executing extension code (#102).
 - `amq route explain --json` now reports canonical route resolution with routability, structured `argv`, display command, source/delivery roots, project, and session metadata for same-session, cross-session, and cross-project sends (#103).
 - `amq send --from-session <source-session>` supports setup-terminal cross-session sends from a base root, writing the sender outbox in the source session and stamping `reply_to` for replies back to that session (#104).
+
 
 ## [0.32.2] - 2026-04-27
 ### Added

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-cli
-version: 0.32.2
+version: 0.33.0
 description: >-
   Coordinate agents via the AMQ CLI for file-based inter-agent messaging. Use
   this skill whenever you need to send messages to another agent (codex, claude,

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-spec
-version: 0.32.2
+version: 0.33.0
 description: >-
   Parallel-research-then-converge design workflow between two agents. Use this
   skill when the user wants two agents to independently think through a design


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.33.0`
- aligns skill/plugin metadata to `0.33.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.33.0`, publishes the GitHub/Homebrew release, and then publishes skills to the marketplace