### PR TITLE
fix: harden 0.33 routing contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `amq route explain --json` now reports canonical route resolution with routability, structured `argv`, display command, source/delivery roots, project, and session metadata for same-session, cross-session, and cross-project sends (#103).
 - `amq send --from-session <source-session>` supports setup-terminal cross-session sends from a base root, writing the sender outbox in the source session and stamping `reply_to` for replies back to that session (#104).
 
+### Fixed
+
+- Explicit `--root`/`--from-root` project lookups no longer fall back to the current working directory's `.amqrc`, and global `~/.amqrc` no longer infers project identity from the home directory basename.
+- `amq env --json` now emits `.amqrc` peer paths as resolved absolute paths so consumers do not need to reimplement AMQ's peer path resolution.
+- Extension layer names now reject `..` substrings, and `amq doctor --json` only reads passive extension manifests that are regular files below the size cap.
+
 ## [0.32.2] - 2026-04-27
 ### Added
 

--- a/docs/adr-layer-extensions.md
+++ b/docs/adr-layer-extensions.md
@@ -67,7 +67,7 @@ The v1 output includes:
 | `me` | string | Resolved and validated sender handle. |
 | `project` | string | Project identity from `.amqrc`, or its documented fallback when available. |
 | `root_source` | string | Source used to resolve `root`, for diagnostics. |
-| `peers` | object | Peer project map from `.amqrc`, when configured. |
+| `peers` | object | Peer project map from `.amqrc`, when configured. Values are resolved absolute base-root paths. |
 
 Allowed `root_source` values are:
 
@@ -103,6 +103,8 @@ Layer guidance:
   rules.
 - Use `base_root`, `session_name`, and `in_session` instead of inferring session
   state from path shape.
+- Use `peers` directly; relative peer paths from `.amqrc` are resolved against
+  the `.amqrc` directory before they appear in this response.
 
 ## Extension Metadata Directories
 

--- a/internal/cli/cross_project_test.go
+++ b/internal/cli/cross_project_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -158,6 +159,50 @@ func TestResolvePeerFromRoot(t *testing.T) {
 	}
 }
 
+func TestFindAmqrcForRootDoesNotFallBackToCwd(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "project-a")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rc := map[string]any{
+		"root":    ".agent-mail",
+		"project": "project-a",
+		"peers": map[string]string{
+			"infra": filepath.Join(t.TempDir(), "infra", ".agent-mail"),
+		},
+	}
+	rcData, _ := json.Marshal(rc)
+	if err := os.WriteFile(filepath.Join(projectDir, ".amqrc"), rcData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orphanRoot := filepath.Join(t.TempDir(), "orphan", ".agent-mail")
+	if err := os.MkdirAll(orphanRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDir, _ := os.Getwd()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldDir) }()
+	resetAmqrcCache()
+	defer resetAmqrcCache()
+
+	_, err := findAmqrcForRoot(orphanRoot)
+	if !errors.Is(err, errAmqrcNotFound) {
+		t.Fatalf("findAmqrcForRoot(orphan) error = %v, want errAmqrcNotFound", err)
+	}
+
+	_, err = resolvePeer(orphanRoot, "infra")
+	if err == nil {
+		t.Fatal("expected resolvePeer from orphan root to fail")
+	}
+	if !strings.Contains(err.Error(), ".amqrc not found") {
+		t.Fatalf("resolvePeer error = %v, want .amqrc not found", err)
+	}
+}
+
 func TestFindAmqrcForRootSessionDetection(t *testing.T) {
 	// Verify that findAmqrcForRoot can locate .amqrc from a session root
 	// when cwd is outside the project tree. This is the key fix for the
@@ -236,6 +281,30 @@ func TestResolveProjectFallbackToBasename(t *testing.T) {
 	name := resolveProject("")
 	if name != "my-project" {
 		t.Errorf("resolveProject = %q, want %q", name, "my-project")
+	}
+}
+
+func TestResolveProjectGlobalAmqrcWithoutProjectIsEmpty(t *testing.T) {
+	fakeHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fakeHome, ".amqrc"), []byte(`{"root": ".agent-mail"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	outsideDir := t.TempDir()
+	oldDir, _ := os.Getwd()
+	if err := os.Chdir(outsideDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+	resetAmqrcCache()
+	defer resetAmqrcCache()
+
+	if got := resolveProject(""); got != "" {
+		t.Fatalf("resolveProject with global ~/.amqrc and no project = %q, want empty", got)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -41,6 +41,7 @@ func runDoctor(args []string) error {
 		"  - .amqrc configuration",
 		"  - Mailbox directory permissions",
 		"  - Agent configuration (config.json)",
+		"  - Extension metadata manifests and diagnostics",
 		"  - Skill installation (Claude Code / Codex)",
 		"",
 		"With --ops, also checks runtime health:",

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -160,17 +160,14 @@ func envProjectAndPeers(root string) (string, map[string]string) {
 		return "", peers
 	}
 
-	project := rcResult.Config.Project
-	if project == "" {
-		// Only infer project from directory basename for project-local .amqrc,
-		// not global ~/.amqrc (which is a queue locator, not a project identity).
-		home, _ := os.UserHomeDir()
-		if home == "" || rcResult.Dir != home {
-			project = filepath.Base(rcResult.Dir)
-		}
-	}
+	project := projectFromAmqrcResult(rcResult)
 	for name, path := range rcResult.Config.Peers {
-		peers[name] = path
+		resolved, err := resolvePeerPath(rcResult, path)
+		if err != nil {
+			peers[name] = path
+			continue
+		}
+		peers[name] = resolved
 	}
 	return project, peers
 }
@@ -223,12 +220,15 @@ func resolveEnvConfigWithSource(rootFlag, meFlag string) (string, rootSource, st
 
 	// 3. Try global ~/.amqrc
 	var globalRCRoot string
+	var globalRCErr error
 	globalResult, err := loadGlobalAmqrc()
 	if err == nil && globalResult.Config.Root != "" {
 		globalRCRoot = globalResult.Config.Root
 		if !filepath.IsAbs(globalRCRoot) {
 			globalRCRoot = filepath.Join(globalResult.Dir, globalRCRoot)
 		}
+	} else if err != nil && !errors.Is(err, errAmqrcNotFound) {
+		globalRCErr = err
 	}
 
 	// 4. Auto-detect .agent-mail/ directory
@@ -270,6 +270,13 @@ func resolveEnvConfigWithSource(rootFlag, meFlag string) (string, rootSource, st
 			return "", "", "", rcErr
 		}
 		_ = writeStderr("warning: %v (using override from flags/env)\n", rcErr)
+	}
+	if globalRCErr != nil {
+		hasHigherPrecedenceRoot := rootFlag != "" || envRootVal != "" || rcRoot != "" || globalEnvRoot != ""
+		if !hasHigherPrecedenceRoot {
+			return "", "", "", globalRCErr
+		}
+		_ = writeStderr("warning: %v (using higher-precedence root)\n", globalRCErr)
 	}
 
 	if root == "" {
@@ -503,39 +510,38 @@ func isSimpleString(s string) bool {
 }
 
 // findAmqrcForRoot locates the .amqrc for the given root.
-// When root is provided (non-empty), root-based lookup takes priority over
-// cwd-based search. This ensures --root / AM_ROOT fully determines which
-// project config is used, even when cwd is inside a different project.
+// When root is provided (non-empty), lookup is scoped to root's ancestors only.
+// This ensures --root / AM_ROOT fully determines which project config is used,
+// even when cwd is inside a different project.
 func findAmqrcForRoot(root string) (amqrcResult, error) {
-	// When root is provided, search from root first (authoritative).
 	if root != "" {
 		absRoot, absErr := filepath.Abs(root)
-		if absErr == nil {
-			dir := absRoot
-			for {
-				rcPath := filepath.Join(dir, ".amqrc")
-				data, readErr := os.ReadFile(rcPath)
-				if readErr == nil {
-					var rc amqrc
-					if jsonErr := json.Unmarshal(data, &rc); jsonErr != nil {
-						return amqrcResult{}, fmt.Errorf("invalid .amqrc at %s: %w", rcPath, jsonErr)
-					}
-					return amqrcResult{Config: rc, Dir: dir}, nil
-				}
-				if !os.IsNotExist(readErr) {
-					// Permission or I/O error — report it, don't mask it.
-					return amqrcResult{}, fmt.Errorf("cannot read .amqrc at %s: %w", rcPath, readErr)
-				}
-				parent := filepath.Dir(dir)
-				if parent == dir {
-					break
-				}
-				dir = parent
-			}
+		if absErr != nil {
+			return amqrcResult{}, absErr
 		}
+		dir := absRoot
+		for {
+			rcPath := filepath.Join(dir, ".amqrc")
+			data, readErr := os.ReadFile(rcPath)
+			if readErr == nil {
+				var rc amqrc
+				if jsonErr := json.Unmarshal(data, &rc); jsonErr != nil {
+					return amqrcResult{}, fmt.Errorf("invalid .amqrc at %s: %w", rcPath, jsonErr)
+				}
+				return amqrcResult{Config: rc, Dir: dir}, nil
+			}
+			if !os.IsNotExist(readErr) {
+				// Permission or I/O error — report it, don't mask it.
+				return amqrcResult{}, fmt.Errorf("cannot read .amqrc at %s: %w", rcPath, readErr)
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+		return amqrcResult{}, errAmqrcNotFound
 	}
-	// Fall back to cwd-based search (standard behavior when root is empty
-	// or root-based search found nothing).
 	return findAndLoadAmqrc()
 }
 
@@ -558,14 +564,31 @@ func resolvePeer(root, project string) (string, error) {
 		}
 		return "", fmt.Errorf("peer %q not found in .amqrc (known: %v)", project, known)
 	}
-	if !filepath.IsAbs(peerPath) {
-		peerPath = filepath.Join(result.Dir, peerPath)
-	}
-	abs, err := filepath.Abs(peerPath)
+	abs, err := resolvePeerPath(result, peerPath)
 	if err != nil {
 		return "", fmt.Errorf("resolve peer path for %q: %w", project, err)
 	}
 	return abs, nil
+}
+
+func resolvePeerPath(result amqrcResult, peerPath string) (string, error) {
+	if !filepath.IsAbs(peerPath) {
+		peerPath = filepath.Join(result.Dir, peerPath)
+	}
+	return filepath.Abs(peerPath)
+}
+
+func projectFromAmqrcResult(result amqrcResult) string {
+	if result.Config.Project != "" {
+		return result.Config.Project
+	}
+	// Only infer project from directory basename for project-local .amqrc,
+	// not global ~/.amqrc (which is a queue locator, not a project identity).
+	home, _ := os.UserHomeDir()
+	if home != "" && result.Dir == home {
+		return ""
+	}
+	return filepath.Base(result.Dir)
 }
 
 // resolveProject returns the project name for the current .amqrc.
@@ -576,8 +599,5 @@ func resolveProject(root string) string {
 	if err != nil {
 		return ""
 	}
-	if result.Config.Project != "" {
-		return result.Config.Project
-	}
-	return filepath.Base(result.Dir)
+	return projectFromAmqrcResult(result)
 }

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -678,7 +678,7 @@ func TestRunEnvJSONWithPeers(t *testing.T) {
 	root := t.TempDir()
 
 	// Write .amqrc with project + peers
-	rcContent := `{"root": ".agent-mail", "project": "my-app", "peers": {"infra": "/tmp/infra/.agent-mail", "api": "/tmp/api/.agent-mail"}}`
+	rcContent := `{"root": ".agent-mail", "project": "my-app", "peers": {"infra": "/tmp/infra/.agent-mail", "api": "/tmp/api/.agent-mail", "shared": "../shared/.agent-mail"}}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
 		t.Fatalf("write .amqrc: %v", err)
 	}
@@ -701,8 +701,8 @@ func TestRunEnvJSONWithPeers(t *testing.T) {
 	if result.Me != "claude" {
 		t.Errorf("expected me=%q, got %q", "claude", result.Me)
 	}
-	if len(result.Peers) != 2 {
-		t.Fatalf("expected 2 peers, got %d", len(result.Peers))
+	if len(result.Peers) != 3 {
+		t.Fatalf("expected 3 peers, got %d", len(result.Peers))
 	}
 	if result.Peers["infra"] != "/tmp/infra/.agent-mail" {
 		t.Errorf("expected peer infra=%q, got %q", "/tmp/infra/.agent-mail", result.Peers["infra"])
@@ -710,6 +710,11 @@ func TestRunEnvJSONWithPeers(t *testing.T) {
 	if result.Peers["api"] != "/tmp/api/.agent-mail" {
 		t.Errorf("expected peer api=%q, got %q", "/tmp/api/.agent-mail", result.Peers["api"])
 	}
+	expectedShared, err := filepath.Abs(filepath.Join(root, "../shared/.agent-mail"))
+	if err != nil {
+		t.Fatalf("abs shared peer: %v", err)
+	}
+	expectSamePath(t, result.Peers["shared"], expectedShared)
 }
 
 func TestRunEnvJSONGlobalAmqrcNoProject(t *testing.T) {
@@ -756,6 +761,39 @@ func TestRunEnvJSONGlobalAmqrcNoProject(t *testing.T) {
 	}
 	if len(result.Peers) != 0 {
 		t.Errorf("expected peers={}, got %v", result.Peers)
+	}
+}
+
+func TestRunEnvInvalidGlobalAmqrcBeatsAutoDetect(t *testing.T) {
+	cwd := t.TempDir()
+	fakeHome := t.TempDir()
+	if err := os.Mkdir(filepath.Join(cwd, ".agent-mail"), 0o755); err != nil {
+		t.Fatalf("mkdir .agent-mail: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fakeHome, ".amqrc"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write invalid ~/.amqrc: %v", err)
+	}
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_ME", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	_, err := captureEnvStdout(t, func() error {
+		return runEnv([]string{"--json"})
+	})
+	if err == nil {
+		t.Fatal("expected invalid global ~/.amqrc to fail before auto-detect")
+	}
+	if !strings.Contains(err.Error(), "invalid ~/.amqrc") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+const maxPassiveExtensionManifestBytes int64 = 64 * 1024
 
 type doctorExtensionManifest struct {
 	Scope         string   `json:"scope"`
@@ -34,6 +37,9 @@ type passiveExtensionManifest struct {
 
 func isValidExtensionLayerName(name string) bool {
 	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.Contains(name, "..") {
 		return false
 	}
 	for i := 0; i < len(name); i++ {
@@ -163,10 +169,39 @@ func scanAgentExtensions(root string, diagnostics *[]doctorExtensionDiagnostic) 
 }
 
 func readPassiveExtensionManifest(root, layer, manifestPath string) (doctorExtensionManifest, *doctorExtensionDiagnostic, bool) {
-	data, err := os.ReadFile(manifestPath)
+	info, err := os.Lstat(manifestPath)
 	if os.IsNotExist(err) {
 		return doctorExtensionManifest{}, nil, false
 	}
+	if err != nil {
+		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
+			Scope:   "root",
+			Layer:   layer,
+			Path:    rootRelativePath(root, manifestPath),
+			Status:  "warn",
+			Message: fmt.Sprintf("cannot read manifest: %v", err),
+		}, false
+	}
+	if !info.Mode().IsRegular() {
+		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
+			Scope:   "root",
+			Layer:   layer,
+			Path:    rootRelativePath(root, manifestPath),
+			Status:  "warn",
+			Message: "manifest is not a regular file",
+		}, false
+	}
+	if info.Size() > maxPassiveExtensionManifestBytes {
+		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
+			Scope:   "root",
+			Layer:   layer,
+			Path:    rootRelativePath(root, manifestPath),
+			Status:  "warn",
+			Message: fmt.Sprintf("manifest is too large: %d bytes (max %d)", info.Size(), maxPassiveExtensionManifestBytes),
+		}, false
+	}
+
+	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return doctorExtensionManifest{}, &doctorExtensionDiagnostic{
 			Scope:   "root",

--- a/internal/cli/extensions_test.go
+++ b/internal/cli/extensions_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
@@ -20,6 +21,9 @@ func TestIsValidExtensionLayerName(t *testing.T) {
 		{"", false},
 		{".", false},
 		{"..", false},
+		{"a..b", false},
+		{"..layer", false},
+		{"layer..", false},
 		{"Upper", false},
 		{"has space", false},
 		{"slash/name", false},
@@ -141,6 +145,52 @@ func TestRunDoctorJSONReportsExtensionManifestsAndDiagnostics(t *testing.T) {
 	}
 	if !hasExtensionDiagnostic(result.ExtensionDiagnostics, "root", "", "bad-json", "malformed manifest") {
 		t.Fatalf("expected malformed manifest diagnostic, got %+v", result.ExtensionDiagnostics)
+	}
+}
+
+func TestReadPassiveExtensionManifestRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	layer := "symlink-manifest"
+	layerDir := filepath.Join(root, "extensions", layer)
+	if err := os.MkdirAll(layerDir, 0o700); err != nil {
+		t.Fatalf("mkdir layer dir: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "manifest.json")
+	if err := os.WriteFile(target, []byte(`{"schema_version":1,"layer":"symlink-manifest"}`), 0o600); err != nil {
+		t.Fatalf("write target manifest: %v", err)
+	}
+	manifestPath := filepath.Join(layerDir, "manifest.json")
+	if err := os.Symlink(target, manifestPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	_, diag, ok := readPassiveExtensionManifest(root, layer, manifestPath)
+	if ok {
+		t.Fatal("expected symlink manifest to be rejected")
+	}
+	if diag == nil || !strings.Contains(diag.Message, "not a regular file") {
+		t.Fatalf("diagnostic = %+v, want not a regular file", diag)
+	}
+}
+
+func TestReadPassiveExtensionManifestRejectsOversizedFile(t *testing.T) {
+	root := t.TempDir()
+	layer := "oversized-manifest"
+	layerDir := filepath.Join(root, "extensions", layer)
+	if err := os.MkdirAll(layerDir, 0o700); err != nil {
+		t.Fatalf("mkdir layer dir: %v", err)
+	}
+	manifestPath := filepath.Join(layerDir, "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(strings.Repeat("x", 300*1024)), 0o600); err != nil {
+		t.Fatalf("write oversized manifest: %v", err)
+	}
+
+	_, diag, ok := readPassiveExtensionManifest(root, layer, manifestPath)
+	if ok {
+		t.Fatal("expected oversized manifest to be rejected")
+	}
+	if diag == nil || !strings.Contains(diag.Message, "manifest is too large") {
+		t.Fatalf("diagnostic = %+v, want manifest is too large", diag)
 	}
 }
 

--- a/internal/cli/extensions_unix_test.go
+++ b/internal/cli/extensions_unix_test.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestReadPassiveExtensionManifestRejectsFIFO(t *testing.T) {
+	root := t.TempDir()
+	layer := "fifo-manifest"
+	layerDir := filepath.Join(root, "extensions", layer)
+	if err := os.MkdirAll(layerDir, 0o700); err != nil {
+		t.Fatalf("mkdir layer dir: %v", err)
+	}
+	manifestPath := filepath.Join(layerDir, "manifest.json")
+	if err := syscall.Mkfifo(manifestPath, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+
+	_, diag, ok := readPassiveExtensionManifest(root, layer, manifestPath)
+	if ok {
+		t.Fatal("expected FIFO manifest to be rejected")
+	}
+	if diag == nil || !strings.Contains(diag.Message, "not a regular file") {
+		t.Fatalf("diagnostic = %+v, want not a regular file", diag)
+	}
+}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -135,6 +135,9 @@ func runSend(args []string) error {
 		if !dirExists(sourceRoot) {
 			return fmt.Errorf("source session %q not found at %s", fromSession, sourceRoot)
 		}
+		if !dirExists(filepath.Join(sourceRoot, "agents", me)) {
+			return fmt.Errorf("agent %q not found in source session %q", me, fromSession)
+		}
 		sourceSession = fromSession
 	}
 

--- a/internal/cli/send_cross_session_test.go
+++ b/internal/cli/send_cross_session_test.go
@@ -113,6 +113,97 @@ func TestSendFromSessionRequiresExistingSourceSession(t *testing.T) {
 	}
 }
 
+func TestSendFromSessionRejectsSessionRootAsRoot(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	sourceRoot := filepath.Join(baseRoot, "cto")
+	ensureSendSessionAgent(t, sourceRoot, "alice")
+	ensureSendSessionAgent(t, filepath.Join(baseRoot, "qa"), "bob")
+
+	err := runSend([]string{
+		"--me", "alice",
+		"--root", sourceRoot,
+		"--from-session", "cto",
+		"--to", "bob",
+		"--session", "qa",
+		"--body", "wrong root",
+	})
+	if err == nil {
+		t.Fatal("expected session root --root to fail")
+	}
+	if !strings.Contains(err.Error(), "--from-session requires --root to be the base root") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendFromSessionRequiresSenderInSourceSession(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	ensureSendSessionAgent(t, baseRoot, "alice")
+	if err := fsq.EnsureRootDirs(filepath.Join(baseRoot, "cto")); err != nil {
+		t.Fatalf("EnsureRootDirs(source): %v", err)
+	}
+	ensureSendSessionAgent(t, filepath.Join(baseRoot, "qa"), "bob")
+
+	err := runSend([]string{
+		"--me", "alice",
+		"--root", baseRoot,
+		"--from-session", "cto",
+		"--to", "bob",
+		"--session", "qa",
+		"--body", "sender only exists at base",
+	})
+	if err == nil {
+		t.Fatal("expected sender missing from source session to fail")
+	}
+	if !strings.Contains(err.Error(), `agent "alice" not found in source session "cto"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendFromSessionRequiresRecipientInTargetSession(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	sourceRoot := filepath.Join(baseRoot, "cto")
+	targetRoot := filepath.Join(baseRoot, "qa")
+	ensureSendSessionAgent(t, sourceRoot, "alice")
+	if err := fsq.EnsureRootDirs(targetRoot); err != nil {
+		t.Fatalf("EnsureRootDirs(target): %v", err)
+	}
+	ensureSendSessionAgent(t, sourceRoot, "bob")
+
+	err := runSend([]string{
+		"--me", "alice",
+		"--root", baseRoot,
+		"--from-session", "cto",
+		"--to", "bob",
+		"--session", "qa",
+		"--body", "recipient only exists in source",
+	})
+	if err == nil {
+		t.Fatal("expected recipient missing from target session to fail")
+	}
+	if !strings.Contains(err.Error(), `agent "bob" not found in session "qa"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSendFromSessionRequiresTargetSessionFlag(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
+	ensureSendSessionAgent(t, filepath.Join(baseRoot, "cto"), "alice")
+
+	err := runSend([]string{
+		"--me", "alice",
+		"--root", baseRoot,
+		"--from-session", "cto",
+		"--to", "bob",
+		"--body", "missing target session",
+	})
+	if err == nil {
+		t.Fatal("expected missing --session to fail")
+	}
+	if !strings.Contains(err.Error(), "--from-session requires --session") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestSendCrossSessionWithExplicitRootOverride(t *testing.T) {
 	staleBase := filepath.Join(t.TempDir(), "stale-base")
 	t.Setenv("AM_ROOT", filepath.Join(staleBase, "session1"))


### PR DESCRIPTION
## Summary
- scope explicit `--root` / `--from-root` `.amqrc` lookup to the supplied root ancestors instead of falling back to cwd
- share project identity derivation so global `~/.amqrc` does not infer project names, and emit resolved absolute peer paths from `amq env --json`
- harden extension layer/manifest validation against `..` names, symlinks/FIFOs, and oversized manifests
- add the requested `--from-session` negative coverage and document the env peer path contract

## Review Queue Coverage
- P1 #1: fixed root-scoped `.amqrc` lookup and added cwd-vs-orphan root regression
- P1 #2: fixed global `~/.amqrc` project fallback via shared helper
- P1 #3: rejected extension layer names containing `..`
- P1 #4: manifest `Lstat` + regular-file + 64 KiB cap before read
- P1 #5: API call is absolute peer paths in `env --json`; ADR + changelog updated
- P2: invalid global `~/.amqrc` now beats auto-detect; doctor help mentions extension checks; `--from-session` negative tests added

## Validation
- targeted `go test ./internal/cli -run ... -count=1`
- `go test ./...`
- `make ci`