### PR TITLE
fix(release): maintain changelog compare links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -432,6 +432,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Auto-create `.gitignore` with `agent-mail` directory entry
 
+[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.32.2...v0.33.0
+[0.32.2]: https://github.com/avivsinai/agent-message-queue/compare/v0.32.1...v0.32.2
+[0.32.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.32.0...v0.32.1
+[0.32.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.31.3...v0.32.0
+[0.31.3]: https://github.com/avivsinai/agent-message-queue/compare/v0.31.2...v0.31.3
+[0.31.2]: https://github.com/avivsinai/agent-message-queue/compare/v0.31.1...v0.31.2
+[0.31.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.31.0...v0.31.1
+[0.31.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.30.1...v0.31.0
+[0.30.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.30.0...v0.30.1
+[0.30.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.29.1...v0.30.0
+[0.29.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.29.0...v0.29.1
+[0.29.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.8...v0.29.0
+[0.28.8]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.7...v0.28.8
+[0.28.7]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.5...v0.28.7
+[0.28.5]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.4...v0.28.5
+[0.28.4]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.3...v0.28.4
+[0.28.3]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.2...v0.28.3
+[0.28.2]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.1...v0.28.2
+[0.28.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.0...v0.28.1
+[0.28.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.27.0...v0.28.0
+[0.27.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.26.0...v0.27.0
+[0.26.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.25.1...v0.26.0
+[0.25.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.25.0...v0.25.1
+[0.25.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.24.1...v0.25.0
+[0.24.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.21.0...v0.22.0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -143,39 +143,15 @@ fi
 
 git switch -c "$branch"
 
-python3 - "$version" "$release_date" "$allow_empty" <<'PY'
+python3 scripts/release_changelog.py "$version" "$release_date" "$allow_empty"
+
+python3 - "$version" <<'PY'
 import json
 import pathlib
 import re
 import sys
 
-version, release_date, allow_empty = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
-
-changelog = pathlib.Path("CHANGELOG.md")
-text = changelog.read_text()
-marker = "## [Unreleased]"
-if marker not in text:
-    raise SystemExit("error: CHANGELOG.md is missing the Unreleased section")
-
-start = text.index(marker)
-after_marker = start + len(marker)
-rest = text[after_marker:]
-match = re.search(r"(?m)^## \[", rest)
-if match:
-    unreleased_body = rest[:match.start()]
-    suffix = rest[match.start():]
-else:
-    unreleased_body = rest
-    suffix = ""
-
-if not unreleased_body.strip() and not allow_empty:
-    raise SystemExit("error: CHANGELOG.md Unreleased section is empty; add release notes first or pass --allow-empty")
-
-release_header = f"\n\n## [{version}] - {release_date}\n"
-new_text = text[:start] + marker + release_header + unreleased_body.lstrip("\n")
-if suffix:
-    new_text += suffix if suffix.startswith("\n") else "\n" + suffix
-changelog.write_text(new_text)
+version = sys.argv[1]
 
 changed = ["CHANGELOG.md"]
 

--- a/scripts/release_changelog.py
+++ b/scripts/release_changelog.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Prepare CHANGELOG.md for a release.
+
+This script intentionally owns only the changelog rewrite. The shell release
+flow owns git/GitHub operations and version metadata updates.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+
+REPO_URL = "https://github.com/avivsinai/agent-message-queue"
+VERSION_PATTERN = r"\d+\.\d+\.\d+(?:[-.][0-9A-Za-z.]+)?"
+LINK_RE = re.compile(rf"^\[(?P<label>Unreleased|{VERSION_PATTERN})\]:\s+\S+", re.MULTILINE)
+VERSION_LINK_RE = re.compile(rf"^\[(?P<version>{VERSION_PATTERN})\]:\s+\S+", re.MULTILINE)
+
+
+def release_compare_url(previous: str, current: str) -> str:
+    return f"{REPO_URL}/compare/v{previous}...v{current}"
+
+
+def unreleased_compare_url(current: str) -> str:
+    return f"{REPO_URL}/compare/v{current}...HEAD"
+
+
+def previous_version_from_links(text: str, current: str) -> str:
+    for match in VERSION_LINK_RE.finditer(text):
+        version = match.group("version")
+        if version != current:
+            return version
+    return ""
+
+
+def previous_version_from_git() -> str:
+    for args in (
+        ["git", "describe", "--tags", "--abbrev=0", "HEAD~"],
+        ["git", "describe", "--tags", "--abbrev=0", "HEAD"],
+    ):
+        try:
+            out = subprocess.check_output(args, text=True, stderr=subprocess.DEVNULL).strip()
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        if out:
+            return out.removeprefix("v")
+    return ""
+
+
+def update_compare_links(text: str, version: str, previous: str) -> str:
+    if not previous:
+        raise SystemExit("error: cannot determine previous version for CHANGELOG compare link")
+
+    lines = text.splitlines()
+    filtered = [
+        line
+        for line in lines
+        if not line.startswith("[Unreleased]:") and not line.startswith(f"[{version}]:")
+    ]
+
+    insert_at = next((i for i, line in enumerate(filtered) if LINK_RE.match(line)), None)
+    block = [
+        f"[Unreleased]: {unreleased_compare_url(version)}",
+        f"[{version}]: {release_compare_url(previous, version)}",
+    ]
+
+    if insert_at is None:
+        while filtered and filtered[-1] == "":
+            filtered.pop()
+        filtered.extend(["", *block])
+    else:
+        filtered[insert_at:insert_at] = block
+
+    return "\n".join(filtered) + "\n"
+
+
+def prepare_changelog(text: str, version: str, release_date: str, allow_empty: bool) -> str:
+    marker = "## [Unreleased]"
+    if marker not in text:
+        raise SystemExit("error: CHANGELOG.md is missing the Unreleased section")
+
+    start = text.index(marker)
+    after_marker = start + len(marker)
+    rest = text[after_marker:]
+    match = re.search(r"(?m)^## \[", rest)
+    if match:
+        unreleased_body = rest[: match.start()]
+        suffix = rest[match.start() :]
+    else:
+        unreleased_body = rest
+        suffix = ""
+
+    if not unreleased_body.strip() and not allow_empty:
+        raise SystemExit(
+            "error: CHANGELOG.md Unreleased section is empty; add release notes first or pass --allow-empty"
+        )
+
+    release_header = f"\n\n## [{version}] - {release_date}\n"
+    new_text = text[:start] + marker + release_header + unreleased_body.lstrip("\n")
+    if suffix:
+        new_text += suffix if suffix.startswith("\n") else "\n" + suffix
+
+    previous = previous_version_from_links(text, version) or previous_version_from_git()
+    return update_compare_links(new_text, version, previous)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print("usage: release_changelog.py VERSION YYYY-MM-DD ALLOW_EMPTY", file=sys.stderr)
+        return 2
+    version, release_date, allow_empty_raw = argv[1], argv[2], argv[3]
+    allow_empty = allow_empty_raw == "1"
+
+    changelog = pathlib.Path("CHANGELOG.md")
+    text = changelog.read_text()
+    changelog.write_text(prepare_changelog(text, version, release_date, allow_empty))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -124,6 +124,7 @@ if command -v python3 >/dev/null 2>&1; then
   unset AM_BASE_ROOT 2>/dev/null || true
   python3 scripts/test_session_name.py
   echo "python session-name tests ok"
+  python3 scripts/test_release_changelog.py
 fi
 
 # --- SessionStart hook test (claude-session-start.sh) ---

--- a/scripts/test_release_changelog.py
+++ b/scripts/test_release_changelog.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+
+SCRIPT = pathlib.Path(__file__).with_name("release_changelog.py")
+spec = importlib.util.spec_from_file_location("release_changelog", SCRIPT)
+assert spec is not None and spec.loader is not None
+release_changelog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release_changelog)
+
+
+def test_prepare_changelog_updates_release_and_compare_links() -> None:
+    text = """# Changelog
+
+## [Unreleased]
+### Added
+
+- New thing.
+
+## [0.33.0] - 2026-04-28
+### Added
+
+- Previous thing.
+
+[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.32.2...HEAD
+[0.33.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.32.2...v0.33.0
+[0.32.2]: https://github.com/avivsinai/agent-message-queue/compare/v0.32.1...v0.32.2
+"""
+
+    got = release_changelog.prepare_changelog(text, "0.34.0", "2026-05-01", False)
+
+    assert "## [0.34.0] - 2026-05-01" in got
+    assert "- New thing." in got
+    assert (
+        "[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.34.0...HEAD"
+        in got
+    )
+    assert (
+        "[0.34.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.33.0...v0.34.0"
+        in got
+    )
+    assert got.count("[Unreleased]:") == 1
+    assert got.count("[0.34.0]:") == 1
+
+
+def test_update_compare_links_appends_when_footer_missing() -> None:
+    text = "# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2026-01-01\n"
+
+    got = release_changelog.update_compare_links(text, "0.2.0", "0.1.0")
+
+    assert got.endswith(
+        "\n[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.2.0...HEAD\n"
+        "[0.2.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.1.0...v0.2.0\n"
+    )
+
+
+def main() -> int:
+    test_prepare_changelog_updates_release_and_compare_links()
+    test_update_compare_links_appends_when_footer_missing()
+    print("release changelog tests ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- backfill CHANGELOG compare links from v0.24.1 through v0.33.0 and add the current `[Unreleased]` compare link
- move the release changelog rewrite into `scripts/release_changelog.py` so compare links are automatically maintained
- add smoke coverage for a hypothetical next release link rewrite

## Validation
- `python3 scripts/test_release_changelog.py`
- verified all changelog release sections have compare links matching adjacent git tags
- dry-run helper check for hypothetical `0.34.0` produced `[0.34.0]: ...v0.33.0...v0.34.0` and refreshed `[Unreleased]: ...v0.34.0...HEAD`
- `make ci`