### PR TITLE
fix: require wake readiness for coop exec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ amq upgrade
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--json]
 amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>]
 amq coop init [--root <path>] [--agents <a,b,c>] [--force] [--json]
-amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-wake] [-y] <command> [-- <command-flags>]
+amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-wake] [--require-wake] [-y] <command> [-- <command-flags>]
 amq swarm list [--json]
 amq swarm join --team <name> --me <agent> [--agent-id <id>] [--type codex|external] [--json]
 amq swarm leave --team <name> --agent-id <id> [--json]
@@ -382,7 +382,7 @@ Use `--session` for a different isolated session:
 amq coop exec --session feature-a claude               # Isolated session
 ```
 
-Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments).
+Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments). Use `--require-wake` in managed launchers that should refuse to start an agent unless the wake process starts and acquires its lock.
 
 **For scripts/CI** (non-interactive):
 ```bash

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ amq coop exec claude -- --dangerously-skip-permissions
 amq coop exec --session feature-a codex
 ```
 
+Managed launchers can add `--require-wake` to fail instead of launching the agent when the wake watcher cannot start.
+
 ### 3. Send & Receive
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/avivsinai/agent-message-queue
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/coder/websocket v1.8.14

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -115,6 +115,16 @@ func TestCoopExecSessionRootMutuallyExclusive(t *testing.T) {
 	}
 }
 
+func TestCoopExecRequireWakeRejectsNoWake(t *testing.T) {
+	err := runCoopExec([]string{"--require-wake", "--no-wake", "claude"})
+	if err == nil {
+		t.Fatal("expected error for --require-wake + --no-wake")
+	}
+	if !containsStr(err.Error(), "--require-wake cannot be used with --no-wake") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
 func TestCoopExecSessionInvalidName(t *testing.T) {
 	err := runCoopExec([]string{"--session", "Bad/Name", "claude"})
 	if err == nil {

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -10,9 +10,12 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
+
+const wakeReadyTimeout = 2 * time.Second
 
 func runCoopExec(args []string) error {
 	// Split at "--" before flag parsing so agent flags aren't consumed.
@@ -24,6 +27,7 @@ func runCoopExec(args []string) error {
 	meFlag := fs.String("me", "", "Agent handle (override auto-derivation from command name)")
 	noInitFlag := fs.Bool("no-init", false, "Don't auto-initialize if .amqrc is missing")
 	noWakeFlag := fs.Bool("no-wake", false, "Don't start amq wake in background")
+	requireWakeFlag := fs.Bool("require-wake", false, "Fail if amq wake cannot start and acquire its lock")
 	yesFlag := fs.Bool("y", false, "Skip confirmation prompts")
 
 	usage := usageWithFlags(fs, "amq coop exec [options] <command> [-- <command-flags>]",
@@ -48,6 +52,9 @@ func runCoopExec(args []string) error {
 		return err
 	} else if handled {
 		return nil
+	}
+	if *noWakeFlag && *requireWakeFlag {
+		return UsageError("--require-wake cannot be used with --no-wake")
 	}
 
 	remaining := fs.Args()
@@ -180,6 +187,17 @@ func runCoopExec(args []string) error {
 		}
 
 		wakeCmd := exec.Command(amqBin, "--no-update-check", "wake", "--me", agentHandle, "--root", root)
+		var readyPath string
+		var cleanupReady func()
+		if *requireWakeFlag {
+			var readyErr error
+			readyPath, cleanupReady, readyErr = newWakeReadyFile()
+			if readyErr != nil {
+				return fmt.Errorf("create wake readiness file: %w", readyErr)
+			}
+			defer cleanupReady()
+			wakeCmd.Args = append(wakeCmd.Args, "--ready-file", readyPath)
+		}
 		// Set AM_ROOT in wake's env so the helper process resolves the same
 		// session root even if the parent shell inherited a different value.
 		wakeCmd.Env = setEnvVar(os.Environ(), envRoot, root)
@@ -188,9 +206,18 @@ func runCoopExec(args []string) error {
 		wakeCmd.Stderr = os.Stderr
 
 		if err := wakeCmd.Start(); err != nil {
+			if *requireWakeFlag {
+				return fmt.Errorf("start required amq wake: %w", err)
+			}
 			_ = writeStderr("warning: failed to start amq wake: %v\n", err)
 		} else {
 			wakeProc = wakeCmd.Process
+			if *requireWakeFlag {
+				if err := waitForWakeReady(wakeProc, readyPath, wakeReadyTimeout); err != nil {
+					_ = wakeProc.Kill()
+					return err
+				}
+			}
 			_ = writeStderr("Started amq wake (pid %d)\n", wakeProc.Pid)
 		}
 	}
@@ -215,6 +242,49 @@ func runCoopExec(args []string) error {
 		_ = wakeProc.Kill()
 	}
 	return execErr
+}
+
+func newWakeReadyFile() (string, func(), error) {
+	dir, err := os.MkdirTemp("", "amq-wake-ready-")
+	if err != nil {
+		return "", nil, err
+	}
+	return filepath.Join(dir, "ready"), func() { _ = os.RemoveAll(dir) }, nil
+}
+
+func waitForWakeReady(proc *os.Process, readyPath string, timeout time.Duration) error {
+	if proc == nil {
+		return fmt.Errorf("amq wake process missing")
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := proc.Wait()
+		done <- err
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("check wake readiness file: %w", err)
+		}
+
+		select {
+		case err := <-done:
+			if err != nil {
+				return fmt.Errorf("amq wake exited before becoming ready: %w", err)
+			}
+			return fmt.Errorf("amq wake exited before becoming ready")
+		case <-timer.C:
+			return fmt.Errorf("amq wake did not become ready within %s", timeout)
+		case <-ticker.C:
+		}
+	}
 }
 
 // splitDashDash splits args at the first "--" separator.

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -232,6 +232,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	interruptCmdFlag := fs.String("interrupt-cmd", "ctrl-c", "Interrupt command to inject (ctrl-c or none)")
 	interruptNoticeFlag := fs.String("interrupt-notice", "", "Custom interrupt notice (default: auto)")
 	interruptCooldownFlag := fs.Duration("interrupt-cooldown", 7*time.Second, "Minimum time between interrupts")
+	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
 
 	usage := usageWithFlags(fs, "amq wake --me <agent> [options]",
@@ -336,6 +337,10 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	if injectVia == "" && len(injectArgFlags) > 0 {
 		return UsageError("--inject-arg requires --inject-via")
 	}
+	readyFile := strings.TrimSpace(*readyFileFlag)
+	if *readyFileFlag != "" && readyFile == "" {
+		return UsageError("--ready-file must not be blank")
+	}
 
 	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
 	if injectVia == "" {
@@ -388,7 +393,21 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		interruptCooldown: *interruptCooldownFlag,
 	}
 
+	if err := writeWakeReadyFile(readyFile); err != nil {
+		return err
+	}
+
 	return loop(cfg)
+}
+
+func writeWakeReadyFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte("ready\n"), 0o600); err != nil {
+		return fmt.Errorf("write wake ready file: %w", err)
+	}
+	return nil
 }
 
 func parseInterruptKey(raw string) (string, error) {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -4,6 +4,9 @@ package cli
 
 import (
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +47,99 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 	}
 	if got.injectTimeout != 250*time.Millisecond {
 		t.Fatalf("expected inject timeout 250ms, got %s", got.injectTimeout)
+	}
+}
+
+func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+	}, func(cfg wakeConfig) error {
+		if _, statErr := os.Stat(readyPath); statErr != nil {
+			t.Fatalf("expected ready file before wake loop: %v", statErr)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	cleanup, err := acquireWakeLock(root, "orchestrator")
+	if err != nil {
+		t.Fatalf("acquireWakeLock: %v", err)
+	}
+	defer cleanup()
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err = runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an existing live wake lock: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected existing wake lock error")
+	}
+	if !strings.Contains(err.Error(), "wake already running") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+}
+
+func TestWaitForWakeReadyReturnsWhenReadyFileAppears(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	cmd := exec.Command("sh", "-c", `sleep 0.05; : > "$1"; sleep 1`, "sh", readyPath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+	})
+
+	if err := waitForWakeReady(cmd.Process, readyPath, time.Second); err != nil {
+		t.Fatalf("waitForWakeReady: %v", err)
+	}
+}
+
+func TestWaitForWakeReadyFailsWhenWakeExitsBeforeReady(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	cmd := exec.Command("sh", "-c", "exit 7")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+
+	err := waitForWakeReady(cmd.Process, readyPath, time.Second)
+	if err == nil {
+		t.Fatal("expected readiness failure")
+	}
+	if !strings.Contains(err.Error(), "amq wake exited before becoming ready") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `amq coop exec --require-wake` so managed launchers can refuse to exec an agent unless wake starts and acquires its lock
- add an internal `amq wake --ready-file` handshake written only after wake lock acquisition
- cover the existing-lock failure path and readiness wait behavior with tests
- bump the Go directive to `1.25.10` so CI govulncheck uses the fixed standard library version

Fixes #120.

## Test plan
- `go test ./internal/cli -run 'TestRunWakeWithLoop(DoesNotWriteReadyFileWhenLockBlocked|WritesReadyFileAfterLock)|TestWaitForWakeReady|TestCoopExecRequireWakeRejectsNoWake'`\n- `GOTOOLCHAIN=go1.25.10 go test ./...`\n- `GOTOOLCHAIN=go1.25.10 go vet ./...`\n- `GOTOOLCHAIN=go1.25.10 go run golang.org/x/vuln/cmd/govulncheck@latest ./...`\n- `GOTOOLCHAIN=go1.25.10 make build`\n- `GOTOOLCHAIN=go1.25.10 make lint`\n- `git diff --check`\n- manual smoke: `./amq coop exec --require-wake --no-wake claude` rejects the incompatible flags\n- manual smoke: non-TTY `--require-wake` launch refuses to exec when wake cannot become ready\n- GitHub Actions push run `25678242140` passed