### PR TITLE
chore(release): v0.34.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.34.1] - 2026-05-11
 ### Added
 
 - `amq coop exec --require-wake` now refuses to launch the agent command unless
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the Go toolchain directive to 1.25.10 so CI and release checks use the
   standard-library vulnerability fixes required by `govulncheck`.
+
 
 ## [0.34.0] - 2026-04-28
 ### Added
@@ -453,7 +456,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Auto-create `.gitignore` with `agent-mail` directory entry
 
-[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.34.1...HEAD
+[0.34.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.34.0...v0.34.1
 [0.34.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.32.2...v0.33.0
 [0.32.2]: https://github.com/avivsinai/agent-message-queue/compare/v0.32.1...v0.32.2

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-cli
-version: 0.34.0
+version: 0.34.1
 description: >-
   Coordinate agents via the AMQ CLI for file-based inter-agent messaging. Use
   this skill whenever you need to send messages to another agent (codex, claude,

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-spec
-version: 0.34.0
+version: 0.34.1
 description: >-
   Parallel-research-then-converge design workflow between two agents. Use this
   skill when the user wants two agents to independently think through a design


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.34.1`
- aligns skill/plugin metadata to `0.34.1`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.34.1`, publishes the GitHub/Homebrew release, and then publishes skills to the marketplace