### PR TITLE
[codex] Grant Gitleaks PR read permission

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  pull-requests: read
   contents: read
   security-events: write  # For uploading SARIF results
   actions: read


### PR DESCRIPTION
## Summary
- Grant the Gitleaks workflow explicit `pull-requests: read` permission.

## Why
Repository default `GITHUB_TOKEN` permissions are now read-only. `gitleaks/gitleaks-action` reads pull request commits via the GitHub API during PR scans, so it needs this explicit minimal permission.

## Validation
- Triggered by the token-permission hardening pass; no scan rules were loosened.
