### PR TITLE
docs: credit amq-squad as a project built on AMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Higher-level layers can store launch records, role metadata, restore state, and 
 <AM_ROOT>/agents/<handle>/extensions/<layer>/
 ```
 
-Layer names use lowercase ASCII letters, digits, hyphen, underscore, and dot; reverse-DNS names such as `io.github.omriariav.amq-squad` are supported. AMQ does not create files inside layer-owned directories, and `amq cleanup` leaves extension directories alone unless a future command explicitly targets extension metadata.
+Layer names use lowercase ASCII letters, digits, hyphen, underscore, and dot; reverse-DNS names are supported. For example, [amq-squad](https://github.com/omriariav/amq-squad) — a role-aware agent team launcher built on AMQ — stores its launch records and role state under `io.github.omriariav.amq-squad`. AMQ does not create files inside layer-owned directories, and `amq cleanup` leaves extension directories alone unless a future command explicitly targets extension metadata.
 
 Layers may publish a passive manifest at:
 
@@ -301,6 +301,14 @@ AMQ uses the battle-tested [Maildir](https://cr.yp.to/proto/maildir.html) format
 4. **Process** — Reader moves to `cur/` after reading
 
 This guarantees crash-safety: if the process dies mid-write, no corrupt message appears in the inbox. See [CLAUDE.md](CLAUDE.md) for the full directory layout.
+
+## Built on AMQ
+
+AMQ is meant to be the messaging layer underneath higher-level orchestrators. Projects building on it:
+
+- **[amq-squad](https://github.com/omriariav/amq-squad)** by [@omriariav](https://github.com/omriariav) — a role-aware agent team launcher. AMQ owns messaging between agents; amq-squad owns the layer above: who is on the team, what role each agent plays, the shared norms they follow, and how to bring the whole squad up, down, back, or into a new workstream. It builds on AMQ's [extension metadata](#extension-metadata) surface for launch records and role state.
+
+Building something on AMQ? Open an issue or PR to be listed here.
 
 ## Documentation
 

--- a/docs/adr-layer-extensions.md
+++ b/docs/adr-layer-extensions.md
@@ -125,7 +125,9 @@ Root or session metadata:
 
 The `<layer>` name must be identifier-like: lowercase ASCII letters, digits,
 hyphen, underscore, and dot. Reverse-DNS names are allowed, for example
-`io.github.omriariav.amq-squad`.
+`io.github.omriariav.amq-squad` — the namespace used by
+[amq-squad](https://github.com/omriariav/amq-squad), a role-aware agent team
+launcher built on AMQ and a live implementation of this extension contract.
 
 AMQ guarantees:
 


### PR DESCRIPTION
## What

Reciprocal credit for [omriariav/amq-squad](https://github.com/omriariav/amq-squad) — a role-aware agent team launcher built on top of AMQ. It already appeared in our docs only as an anonymous reverse-DNS example string (`io.github.omriariav.amq-squad`); this names and links it.

## Changes (docs-only)

- **README "Extension Metadata"** — the reverse-DNS example string is now a named, linked amq-squad reference.
- **README** — new "Built on AMQ" section crediting amq-squad / [@omriariav](https://github.com/omriariav), framed as the layer above AMQ, with an open invitation for other projects to be listed.
- **docs/adr-layer-extensions.md** — names amq-squad as a live implementation of the extension contract.

## Verification

- Reviewed by Codex (no blocking findings).
- Attribution wording checked against upstream amq-squad README and source (it does write `launch.json` / `role.md` under the `io.github.omriariav.amq-squad` extension namespace).
- `[extension metadata](#extension-metadata)` anchor resolves to `## Extension Metadata`.
- `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)