### PR TITLE
chore: bump Go toolchain directive to 1.25.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Bumped the Go toolchain directive to 1.25.11 so CI and release checks pick up
+  the standard-library fixes for GO-2026-5039 (`net/textproto`) and GO-2026-5037
+  (`crypto/x509`) that `govulncheck` now flags.
 
 ## [0.34.1] - 2026-05-11
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/avivsinai/agent-message-queue
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/coder/websocket v1.8.14


### PR DESCRIPTION
## What

Bumps the `go.mod` `go` directive from `1.25.10` → `1.25.11` and adds a matching CHANGELOG entry.

## Why

`govulncheck ./...` (run in CI) started failing because two newly-published Go standard-library advisories are reachable from our code:

- **GO-2026-5039** (`net/textproto`) — unescaped arbitrary input in errors, reached via `update.DownloadReleaseAsset` → `io.Copy`
- **GO-2026-5037** (`crypto/x509`) — inefficient candidate hostname parsing

Both are **Fixed in go1.25.11**. This was reddening CI on *every* PR (e.g. #137), not just one — and `main`'s last green check predates the advisories.

## How

CI installs Go via `actions/setup-go` with `go-version-file: go.mod` (ci.yml + release.yml), so bumping the directive is sufficient — setup-go installs the patched toolchain and the findings clear. No workflow edits needed; no other file pins the patch version.

## Verification

- `make ci` green locally
- `govulncheck ./...` → `No vulnerabilities found.`
- Independent review: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)