### PR TITLE
fix(cli): fail closed on empty --body, treat - as stdin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ When `--kind` is set but `--priority` is not, priority defaults to `normal`.
 
 ```bash
 amq init --root <path> --agents a,b,c [--force]
-amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--body <str|@file|stdin>] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--session <target-session>] [--from-session <source-session>] [--project <project>] [--wait-for <stage>] [--wait-timeout <duration>]
+amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--session <target-session>] [--from-session <source-session>] [--project <project>] [--wait-for <stage>] [--wait-timeout <duration>]
 amq list --me <agent> [--new | --cur] [--priority <p>] [--from <h>] [--kind <k>] [--label <l>...] [--limit N] [--offset N] [--json]
 amq read --me <agent> --id <msg_id> [--json]
 amq drain --me <agent> [--limit N] [--include-body] [--json]
@@ -166,7 +166,7 @@ amq route explain --to <handle> [--project <project>] [--session <session>] [--f
 amq cleanup --tmp-older-than <duration> [--dry-run] [--yes]
 amq watch --me <agent> [--timeout <duration>] [--poll] [--json]
 amq monitor --me <agent> [--timeout <duration>] [--poll] [--include-body] [--peek] [--json]
-amq reply --me <agent> --id <msg_id> [--body <str|@file|stdin>] [--priority <p>] [--kind <k>]
+amq reply --me <agent> --id <msg_id> [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>]
 amq dlq list --me <agent> [--new | --cur] [--json]
 amq dlq read --me <agent> --id <dlq_id> [--json]
 amq dlq retry --me <agent> --id <dlq_id> [--all] [--force]
@@ -194,6 +194,8 @@ amq doctor [--ops] [--json]
 ```
 
 Common flags: `--root`, `--json`, `--strict` (error instead of warn on unknown handles or unreadable/corrupt config). Global option: `--no-update-check`. Note: `init` has its own flags and doesn't accept these.
+
+**Body resolution (`send`/`reply`)**: `--body` resolves from `@file`, a literal string, or stdin. A bare `--body -`, `--body @-`, or an omitted `--body` reads stdin (standard CLI convention). A send whose resolved body is empty or whitespace-only **fails closed** with a usage error rather than delivering a blank message — pass `--allow-empty` to send a blank body intentionally. This prevents a dropped or mistyped body (e.g. `--body -` with nothing piped) from silently shipping an empty message.
 
 Swarm-specific flags: `--team`, `--task`, `--agent-id`, `--type`, `--status`, `--poll`, `--poll-interval`, `--reason`, `--evidence`.
 

--- a/internal/cli/body_test.go
+++ b/internal/cli/body_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// withStdin swaps os.Stdin for a regular file containing content (empty string
+// for an empty stdin) and returns a restore func. A regular file is never a
+// char device, so readStdinBody takes the ReadAll path deterministically.
+func withStdin(t *testing.T, content string) func() {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write stdin file: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open stdin file: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = f
+	return func() {
+		os.Stdin = orig
+		_ = f.Close()
+	}
+}
+
+func TestReadBody(t *testing.T) {
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "body.md")
+	if err := os.WriteFile(filePath, []byte("from file"), 0o600); err != nil {
+		t.Fatalf("write body file: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		flag       string
+		stdin      string
+		useStdin   bool
+		allowEmpty bool
+		want       string
+		wantErr    bool
+	}{
+		{name: "literal", flag: "hello", want: "hello"},
+		{name: "file", flag: "@" + filePath, want: "from file"},
+		{name: "dash reads stdin", flag: "-", stdin: "piped body", useStdin: true, want: "piped body"},
+		{name: "at-dash reads stdin", flag: "@-", stdin: "piped body", useStdin: true, want: "piped body"},
+		{name: "empty flag reads stdin", flag: "", stdin: "piped body", useStdin: true, want: "piped body"},
+		{name: "dash with empty stdin errors", flag: "-", stdin: "", useStdin: true, wantErr: true},
+		{name: "empty flag with empty stdin errors", flag: "", stdin: "", useStdin: true, wantErr: true},
+		{name: "whitespace-only literal errors", flag: "   ", wantErr: true},
+		{name: "dash with empty stdin allowed", flag: "-", stdin: "", useStdin: true, allowEmpty: true, want: ""},
+		{name: "whitespace-only literal allowed", flag: "   ", allowEmpty: true, want: "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.useStdin {
+				restore := withStdin(t, tt.stdin)
+				defer restore()
+			}
+			got, err := readBody(tt.flag, tt.allowEmpty)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got body %q", got)
+				}
+				if !strings.Contains(err.Error(), "empty body") {
+					t.Errorf("error should mention empty body, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("body = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSend_DashBodyDoesNotDeliverLiteralHyphen guards the reported footgun: a
+// send with --body - and no piped input must fail visibly instead of silently
+// delivering a "-" (or blank) body to the recipient.
+func TestSend_DashBodyDoesNotDeliverLiteralHyphen(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs: %v", err)
+		}
+	}
+
+	restore := withStdin(t, "")
+	defer restore()
+
+	err := runSend([]string{"--root", root, "--me", "alice", "--to", "bob", "--subject", "evidence", "--body", "-"})
+	if err == nil {
+		t.Fatal("expected error for empty --body -, got nil")
+	}
+	if code := GetExitCode(err); code != ExitUsage {
+		t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(err.Error(), "empty body") {
+		t.Errorf("error should mention empty body, got: %v", err)
+	}
+
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, "bob"))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected bob inbox to remain empty, got %d message(s)", len(entries))
+	}
+}
+
+// TestSend_AllowEmptyDeliversBlankBody confirms the explicit escape hatch still
+// lets a blank body through when the sender opts in.
+func TestSend_AllowEmptyDeliversBlankBody(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs: %v", err)
+		}
+	}
+
+	restore := withStdin(t, "")
+	defer restore()
+
+	err := runSend([]string{"--root", root, "--me", "alice", "--to", "bob", "--subject", "fyi", "--body", "-", "--allow-empty"})
+	if err != nil {
+		t.Fatalf("unexpected error with --allow-empty: %v", err)
+	}
+
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, "bob"))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 message in bob inbox, got %d", len(entries))
+	}
+}

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -449,13 +449,32 @@ func splitList(raw string) []string {
 	return out
 }
 
-func readBody(bodyFlag string) (string, error) {
-	if bodyFlag == "" || bodyFlag == "@-" {
-		data, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return "", err
-		}
-		return string(data), nil
+// readBody resolves a message body from the --body flag value.
+//
+// Sources:
+//   - "", "-", "@-"   → read from stdin (standard CLI convention)
+//   - "@<path>"       → read the named file
+//   - anything else   → the literal string
+//
+// A send that loses its body should fail visibly, not deliver silently. When
+// the resolved body is empty after trimming, readBody returns an error unless
+// allowEmpty is set, so a dropped or mistyped body never ships as a blank
+// message. The lone "-" footgun (previously delivered as a literal hyphen) is
+// now treated as stdin and caught by the same empty check.
+func readBody(bodyFlag string, allowEmpty bool) (string, error) {
+	body, err := resolveBody(bodyFlag)
+	if err != nil {
+		return "", err
+	}
+	if !allowEmpty && strings.TrimSpace(body) == "" {
+		return "", UsageError("empty body; pass --body \"text\", --body @file, pipe stdin, or --allow-empty to send a blank body")
+	}
+	return body, nil
+}
+
+func resolveBody(bodyFlag string) (string, error) {
+	if bodyFlag == "" || bodyFlag == "-" || bodyFlag == "@-" {
+		return readStdinBody()
 	}
 	if strings.HasPrefix(bodyFlag, "@") {
 		path := strings.TrimPrefix(bodyFlag, "@")
@@ -466,6 +485,21 @@ func readBody(bodyFlag string) (string, error) {
 		return string(data), nil
 	}
 	return bodyFlag, nil
+}
+
+// readStdinBody reads the body from stdin. If stdin is an interactive terminal
+// there is nothing piped in, so it returns an empty string immediately rather
+// than blocking on a read that would never see EOF; the caller's empty-body
+// check then decides whether that is an error.
+func readStdinBody() (string, error) {
+	if fi, err := os.Stdin.Stat(); err == nil && fi.Mode()&os.ModeCharDevice != 0 {
+		return "", nil
+	}
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func isHelp(arg string) bool {

--- a/internal/cli/reply.go
+++ b/internal/cli/reply.go
@@ -17,7 +17,8 @@ func runReply(args []string) error {
 	fs := flag.NewFlagSet("reply", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	idFlag := fs.String("id", "", "Message ID to reply to")
-	bodyFlag := fs.String("body", "", "Body string, @file, or empty to read stdin")
+	bodyFlag := fs.String("body", "", "Body string, @file, or - / empty to read stdin")
+	allowEmptyFlag := fs.Bool("allow-empty", false, "Allow sending a blank body (otherwise an empty body is rejected)")
 	subjectFlag := fs.String("subject", "", "Override subject (default: Re: <original>)")
 
 	// Co-op mode flags
@@ -90,7 +91,7 @@ func runReply(args []string) error {
 		return fmt.Errorf("cannot reply to a sent cross-session/cross-project message (reply_to points back to you); use amq send --session/--project for follow-ups")
 	}
 
-	body, err := readBody(*bodyFlag)
+	body, err := readBody(*bodyFlag, *allowEmptyFlag)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -21,7 +21,8 @@ func runSend(args []string) error {
 	toFlag := fs.String("to", "", "Receiver handle (comma-separated)")
 	subjectFlag := fs.String("subject", "", "Message subject")
 	threadFlag := fs.String("thread", "", "Thread id (required for multiple recipients; default p2p/<a>__<b> for single-recipient sends)")
-	bodyFlag := fs.String("body", "", "Body string, @file, or empty to read stdin")
+	bodyFlag := fs.String("body", "", "Body string, @file, or - / empty to read stdin")
+	allowEmptyFlag := fs.Bool("allow-empty", false, "Allow sending a blank body (otherwise an empty body is rejected)")
 	refsFlag := fs.String("refs", "", "Comma-separated related message ids")
 	waitForFlag := fs.String("wait-for", "", "Wait for receipt stage after send (drained, dlq)")
 	waitTimeoutFlag := fs.Duration("wait-timeout", 120*time.Second, "Timeout for --wait-for (0 = wait forever)")
@@ -236,7 +237,7 @@ func runSend(args []string) error {
 		}
 	}
 
-	body, err := readBody(*bodyFlag)
+	body, err := readBody(*bodyFlag, *allowEmptyFlag)
 	if err != nil {
 		return err
 	}

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -296,7 +296,10 @@ amq list --new                                    # Peek without side effects
 amq send --to codex --subject "Review" --kind review_request --body @file.md
 amq send --to codex --priority urgent --kind question --body "Blocked on API"
 amq send --to codex --labels "bug,parser" --context '{"paths": ["src/"]}' --body "Found issue"
+echo "evidence: tests green" | amq send --to codex --subject "done" --body -   # - reads stdin
 ```
+
+**Body is fail-closed.** `--body -` (or `--body @-`, or omitting `--body`) reads stdin; a literal string or `@file` is used as-is. A send whose resolved body is empty/whitespace is **rejected** with a usage error instead of delivering a blank message — so `--body -` with nothing piped fails loudly rather than shipping an empty body. Pass `--allow-empty` only when you truly want a blank body (subject carries everything).
 
 **Send file paths, not file contents.** When attaching source code, configs, or large text for review, send the file path in the message body, not the contents inline. The receiver can open the file with their local tools. If the receiver cannot access that worktree, send a short diff instead of the full source.
 


### PR DESCRIPTION
## Problem

`amq send/reply --body -` delivered a literal `"-"` — effectively a **blank message**: subject present, body lost, no warning. A cross-project report hit this when an agent's "live verified" evidence shipped empty, leaving the reviewer with nothing to act on. Same "no silent failures" bar we enforce on the data side.

## Fix

Body resolution now fails *visibly* instead of silently:

- `--body -`, `--body @-`, and omitted `--body` all read **stdin** (standard CLI convention); `-` is no longer a literal hyphen.
- A resolved body that is empty or whitespace-only is **rejected** with a usage error unless the new `--allow-empty` flag is set.
- stdin reads detect an interactive terminal (nothing piped) and return empty immediately rather than blocking on a read that never sees EOF — so the empty-body check fires instead of hanging.

`readBody` is split into `resolveBody` (source) + `readStdinBody` (TTY-aware read) + the empty-body policy check.

## Behavior

| Case | Result |
|------|--------|
| `--body -` no pipe | exit 2, `empty body; …`, nothing delivered |
| `echo x \| send --body -` | body delivered intact |
| `--body - --allow-empty` | intentional blank delivered |

## Tests / verification

- New `internal/cli/body_test.go`: table tests for `readBody` + 2 `runSend` integration tests guarding the footgun and the escape hatch.
- `gofmt` clean, `go vet` clean, `golangci-lint` 0 issues, `go test ./...` green, smoke green.
- Docs updated: `CLAUDE.md` synopsis + body-resolution note; `skills/amq-cli/SKILL.md` fail-closed note + stdin example.

Reviewed by **codex** (review_response: approve, no blocking findings; independent verification incl. a PTY test of the `ModeCharDevice` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)