### PR TITLE
fix(cli): refuse unqualified cross-tree --root sends (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- `amq send` now refuses an explicit `--root` that targets a different base tree
+  than the caller's active session (`AM_ROOT`/`AM_BASE_ROOT`) when no routing
+  dimension (`--project`/`--session`/`--from-session`) is given. A direct `--root`
+  is root selection, not federation routing: such a message carried no
+  sender-origin metadata, so the recipient could not reply and a naive reply
+  looped back into their own tree. Replyable cross-tree messaging must use
+  `--project`/`--session`. Bare-root sends with no session env set are
+  unaffected (#144).
+- `amq send` no longer stamps `reply_to` on ordinary same-session sends; it is
+  stamped only for actual cross-session/cross-project routes. The stray
+  same-session `reply_to` is what made a direct cross-root send look replyable
+  while looping into the replier's own tree (#144).
 
 ## [0.35.0] - 2026-06-13
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and do
 
 `AM_ROOT` points to the queue root. When `--root` is explicitly provided, it takes precedence over `AM_ROOT`. `send` and `reply` emit a `note:` on stderr when an explicit `--root` overrides `AM_ROOT`.
 
+**Cross-tree send guard**: A direct `--root` is root *selection*, not federation routing. `send` refuses an explicit `--root` that targets a different base tree than the caller's own active session (`AM_ROOT`/`AM_BASE_ROOT`) when no routing dimension (`--project`/`--session`/`--from-session`) is given — such a message carries no sender-origin metadata, so the recipient could not reply and a naive reply would loop into their own tree. Replyable cross-tree messaging must use `--project`/`--session`, which stamp the routing headers. With no session env set (bare-root scripts/CI), the guard does not fire; a direct `--root` cross-tree send in that case can still produce an unreplyable message — the documented cost of keeping bare-root sends working.
+
 **Session Configuration**: The `amq env` command outputs shell commands to set environment variables. It reads configuration from (highest to lowest precedence):
 - **Root**: flags > env (`AM_ROOT`) > project `.amqrc` > `AMQ_GLOBAL_ROOT` > `~/.amqrc` > auto-detect
 - **Me**: flags > env (`AM_ME`)

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -31,20 +31,27 @@ func addCommonFlags(fs *flag.FlagSet) *commonFlags {
 	return flags
 }
 
+// rootExplicit reports whether --root was passed on the command line (as opposed
+// to defaulted from env/.amqrc). Used to distinguish a deliberate root override
+// from the resolved default.
+func (f *commonFlags) rootExplicit() bool {
+	if f.flagSet == nil {
+		return false
+	}
+	explicit := false
+	f.flagSet.Visit(func(fl *flag.Flag) {
+		if fl.Name == "root" {
+			explicit = true
+		}
+	})
+	return explicit
+}
+
 // warnRootOverride emits a diagnostic note to stderr when --root was explicitly
 // provided and differs from AM_ROOT. This helps users notice when a command
 // operates on a different root than their session. Not an error — --root wins.
 func (f *commonFlags) warnRootOverride() {
-	if f.flagSet == nil {
-		return
-	}
-	rootExplicit := false
-	f.flagSet.Visit(func(fl *flag.Flag) {
-		if fl.Name == "root" {
-			rootExplicit = true
-		}
-	})
-	if !rootExplicit {
+	if !f.rootExplicit() {
 		return
 	}
 	envVal := strings.TrimSpace(os.Getenv(envRoot))
@@ -204,6 +211,66 @@ func isSessionRootUnderBase(root, base string) bool {
 		return false
 	}
 	return filepath.Dir(root) == base
+}
+
+// baseRootOf returns the base root for a queue root: the derived/configured base
+// when root is a session directory, or root itself otherwise.
+func baseRootOf(root string) string {
+	if base := classifyRoot(root); base != "" {
+		return resolveRoot(base)
+	}
+	return resolveRoot(root)
+}
+
+// sameBaseTree reports whether two roots belong to the same base tree — the same
+// project/base root, including any of its session subdirectories. This is the
+// boundary used to decide whether an explicit --root crosses into a different
+// AMQ tree than the caller's own.
+func sameBaseTree(a, b string) bool {
+	a, b = resolveRoot(a), resolveRoot(b)
+	if a == "" || b == "" {
+		return false
+	}
+	return baseRootOf(a) == baseRootOf(b)
+}
+
+// conflictingSourceRoot returns an established "home" root for the caller that
+// belongs to a DIFFERENT base tree than target, when one is evident. Evidence is
+// taken only from the caller's active session env — AM_ROOT and AM_BASE_ROOT,
+// which coop exec / `amq env` set — never invented. It returns ok=false when
+// there is no such evidence (bare-root scripts, CI, and tests passing --root to
+// a temp dir), so those keep working untouched.
+//
+// This backs the cross-tree send guard (issue #144): a direct --root that
+// crosses into another tree carries no sender-origin metadata, so the recipient
+// cannot reply. Replyable cross-tree messaging must use --project/--session.
+//
+// Note: cwd-based project .amqrc is deliberately NOT consulted here. It would
+// flag any `amq send --root X` run from inside a project directory, breaking
+// hermetic scripts/harnesses for marginal coverage — the env signals already
+// cover the coop-session case that motivated the guard. A direct --root send
+// with no session env set folds into the documented residual.
+func conflictingSourceRoot(target string) (string, bool) {
+	target = resolveRoot(target)
+	if target == "" {
+		return "", false
+	}
+	for _, raw := range []string{
+		strings.TrimSpace(os.Getenv(envRoot)),
+		strings.TrimSpace(os.Getenv(envBaseRoot)),
+	} {
+		if raw == "" {
+			continue
+		}
+		src := resolveRoot(raw)
+		if src == "" || src == target {
+			continue
+		}
+		if !sameBaseTree(src, target) {
+			return src, true
+		}
+	}
+	return "", false
 }
 
 func dirExists(path string) bool {

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain gives the cli package a hermetic environment so the developer's shell
+// can't leak routing context into tests. The cross-tree send guard (issue #144)
+// keys off AM_ROOT / AM_BASE_ROOT; without this, running the suite from inside a
+// coop session (where those are set) would make tests that pass --root to a temp
+// dir look like refused cross-tree sends. Tests that need these signals set them
+// explicitly via t.Setenv, which overrides and restores around this clean baseline.
+func TestMain(m *testing.M) {
+	for _, k := range []string{"AM_ROOT", "AM_BASE_ROOT", "AMQ_GLOBAL_ROOT"} {
+		_ = os.Unsetenv(k)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -118,6 +118,24 @@ func runSend(args []string) error {
 	sourceRoot := root
 	sourceSession := ""
 	fromSession := strings.TrimSpace(*fromSessionFlag)
+
+	// Cross-tree guard (issue #144): a direct, unqualified --root that crosses
+	// into a different AMQ tree carries no sender-origin metadata, so the
+	// recipient cannot reply — and a naive reply would loop back into the
+	// replier's own tree. Refuse with guidance instead of minting an
+	// unreplyable message. Replyable cross-tree messaging must declare a routing
+	// dimension (--project / --session), which stamps the routing headers.
+	// Fires only on positive evidence of a different home root (AM_ROOT /
+	// AM_BASE_ROOT); bare-root sends with no session env set are unaffected.
+	routed := targetProject != "" || targetSession != "" || fromSession != ""
+	if common.rootExplicit() && !routed {
+		if src, ok := conflictingSourceRoot(root); ok {
+			return UsageError("refusing send: --root %s targets a different AMQ tree than your own (%s), "+
+				"but no routing dimension was given, so the recipient could not reply.\n"+
+				"Use --project <peer> or --session <name> for replyable cross-tree routing, "+
+				"or set the target as AM_ROOT if this send is genuinely local.", root, src)
+		}
+	}
 	var replyProject string
 	if fromSession != "" {
 		if targetProject != "" {
@@ -303,13 +321,17 @@ func runSend(args []string) error {
 		return err
 	}
 
-	// Build reply_to for cross-session/cross-project sends.
+	// Build reply_to only for sends that actually cross a session or project
+	// boundary. Ordinary same-session sends reply locally and need no hint —
+	// stamping handle@session for them is what made a direct cross-root send
+	// look replyable while looping into the replier's own tree (issue #144).
 	replyTo := ""
-	if senderInSession {
-		// Sender is in a session — stamp handle@session for reply routing.
+	switch {
+	case senderInSession && (targetProject != "" || targetSession != ""):
+		// Cross-session or cross-project from a session — stamp handle@session.
 		replyTo = common.Me + "@" + sourceSessionName(root, sourceSession)
-	} else if targetProject != "" {
-		// Sender at base root, cross-project — stamp just handle.
+	case targetProject != "":
+		// Cross-project from a base root — stamp just the handle.
 		replyTo = common.Me
 	}
 

--- a/internal/cli/send_cross_root_test.go
+++ b/internal/cli/send_cross_root_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// sessionRoot builds <parent>/.agent-mail/<session> with the given agents and
+// returns the session root. The ".agent-mail" parent makes classifyRoot treat it
+// as a session under a base, so senderInSession / cross-tree detection behave as
+// they do in a real coop layout.
+func sessionRoot(t *testing.T, parent, session string, agents ...string) string {
+	t.Helper()
+	root := filepath.Join(parent, ".agent-mail", session)
+	for _, a := range agents {
+		if err := fsq.EnsureAgentDirs(root, a); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s, %s): %v", root, a, err)
+		}
+	}
+	return root
+}
+
+func inboxCount(t *testing.T, root, agent string) int {
+	t.Helper()
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, agent))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("ReadDir inbox: %v", err)
+	}
+	return len(entries)
+}
+
+// soleDeliveredHeader returns the header of the single message delivered to
+// agent's inbox/new, failing if there is not exactly one.
+func soleDeliveredHeader(t *testing.T, root, agent string) format.Header {
+	t.Helper()
+	dir := fsq.AgentInboxNew(root, agent)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", dir, err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 delivered message for %s, got %d", agent, len(entries))
+	}
+	hdr, err := format.ReadHeaderFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadHeaderFile: %v", err)
+	}
+	return hdr
+}
+
+// TestSend_RefusesUnqualifiedCrossTreeRoot is the core #144 guard: a direct
+// --root into a different base tree, with no routing dimension, must fail loudly
+// and deliver nothing — rather than mint an unreplyable message.
+func TestSend_RefusesUnqualifiedCrossTreeRoot(t *testing.T) {
+	tmp := t.TempDir()
+	srcRoot := sessionRoot(t, filepath.Join(tmp, "projA"), "collab", "claude")
+	dstRoot := sessionRoot(t, filepath.Join(tmp, "projB"), "collab", "claude")
+
+	t.Run("AM_ROOT evidence", func(t *testing.T) {
+		t.Setenv("AM_ROOT", srcRoot)
+		err := runSend([]string{"--root", dstRoot, "--me", "claude", "--to", "claude", "--body", "evidence"})
+		if err == nil {
+			t.Fatal("expected refusal, got nil")
+		}
+		if code := GetExitCode(err); code != ExitUsage {
+			t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+		}
+		if !strings.Contains(err.Error(), "refusing send") {
+			t.Errorf("error should explain the refusal, got: %v", err)
+		}
+		if n := inboxCount(t, dstRoot, "claude"); n != 0 {
+			t.Fatalf("nothing should be delivered, got %d", n)
+		}
+	})
+
+	t.Run("AM_BASE_ROOT evidence", func(t *testing.T) {
+		t.Setenv("AM_BASE_ROOT", filepath.Join(tmp, "projA", ".agent-mail"))
+		err := runSend([]string{"--root", dstRoot, "--me", "claude", "--to", "claude", "--body", "evidence"})
+		if err == nil || !strings.Contains(err.Error(), "refusing send") {
+			t.Fatalf("expected refusal via AM_BASE_ROOT, got: %v", err)
+		}
+		if n := inboxCount(t, dstRoot, "claude"); n != 0 {
+			t.Fatalf("nothing should be delivered, got %d", n)
+		}
+	})
+}
+
+// TestSend_AllowsBareRootWithoutIdentity guards the "no evidence ⇒ allow"
+// invariant: with no AM_ROOT / AM_BASE_ROOT / project .amqrc (the CI/test/script
+// case), an explicit --root to a temp dir must still deliver.
+func TestSend_AllowsBareRootWithoutIdentity(t *testing.T) {
+	root := t.TempDir()
+	for _, a := range []string{"claude", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, a); err != nil {
+			t.Fatalf("EnsureAgentDirs: %v", err)
+		}
+	}
+	if err := runSend([]string{"--root", root, "--me", "claude", "--to", "bob", "--body", "hi"}); err != nil {
+		t.Fatalf("bare-root send should succeed, got: %v", err)
+	}
+	if n := inboxCount(t, root, "bob"); n != 1 {
+		t.Fatalf("expected 1 delivered message, got %d", n)
+	}
+}
+
+// TestSend_AllowsRedundantSameTreeRoot: an explicit --root equal to (or within)
+// the caller's own tree is not a crossing and must be allowed.
+func TestSend_AllowsRedundantSameTreeRoot(t *testing.T) {
+	tmp := t.TempDir()
+	root := sessionRoot(t, tmp, "collab", "claude", "codex")
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", filepath.Join(tmp, ".agent-mail"))
+	if err := runSend([]string{"--root", root, "--me", "claude", "--to", "codex", "--body", "hi"}); err != nil {
+		t.Fatalf("same-tree --root should succeed, got: %v", err)
+	}
+	if n := inboxCount(t, root, "codex"); n != 1 {
+		t.Fatalf("expected 1 delivered message, got %d", n)
+	}
+}
+
+// TestSend_SameSessionOmitsReplyTo verifies point 2: an ordinary same-session
+// send no longer stamps reply_to (which is what made cross-root sends look
+// replyable while looping locally).
+func TestSend_SameSessionOmitsReplyTo(t *testing.T) {
+	tmp := t.TempDir()
+	root := sessionRoot(t, tmp, "collab", "claude", "codex")
+	if err := runSend([]string{"--root", root, "--me", "claude", "--to", "codex", "--body", "hi"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	hdr := soleDeliveredHeader(t, root, "codex")
+	if hdr.ReplyTo != "" {
+		t.Errorf("same-session reply_to should be empty, got %q", hdr.ReplyTo)
+	}
+	if hdr.ReplyProject != "" {
+		t.Errorf("same-session reply_project should be empty, got %q", hdr.ReplyProject)
+	}
+}
+
+// TestSend_CrossSessionStampsReplyTo verifies point 2 did not over-remove:
+// a real cross-session send (--session) still stamps reply_to for routing back.
+func TestSend_CrossSessionStampsReplyTo(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, ".agent-mail")
+	srcRoot := sessionRoot(t, tmp, "collab", "claude")
+	dstRoot := sessionRoot(t, tmp, "auth", "codex")
+	_ = srcRoot
+
+	t.Setenv("AM_ROOT", srcRoot)
+	t.Setenv("AM_BASE_ROOT", base)
+	if err := runSend([]string{"--me", "claude", "--to", "codex", "--session", "auth", "--body", "hi"}); err != nil {
+		t.Fatalf("cross-session send: %v", err)
+	}
+	hdr := soleDeliveredHeader(t, dstRoot, "codex")
+	if hdr.ReplyTo != "claude@collab" {
+		t.Errorf("cross-session reply_to = %q, want %q", hdr.ReplyTo, "claude@collab")
+	}
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Clear env vars that could interfere with explicit --root/--me flags.
-unset AM_ROOT AM_ME 2>/dev/null || true
+# Clear env vars that could interfere with explicit --root/--me flags. AM_BASE_ROOT
+# matters too: the cross-tree send guard treats AM_ROOT/AM_BASE_ROOT as the
+# caller's home root, so an ambient coop session would otherwise make explicit
+# --root sends to the temp queue look like a refused cross-tree send.
+unset AM_ROOT AM_ME AM_BASE_ROOT AMQ_GLOBAL_ROOT 2>/dev/null || true
 
 ROOT_DIR="$(mktemp -d)"
 cleanup() {

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -196,6 +196,8 @@ Add `project` and `peers` to your `.amqrc`:
 
 Both projects must register each other as peers for round-trip messaging.
 
+**Use `--project`/`--session` to route, not a raw `--root`.** A direct `--root` selects which tree to operate on; it carries no sender-origin metadata, so the recipient can't reply (a naive reply loops back into their own tree). `amq send` therefore **refuses** an explicit `--root` that crosses into a different base tree than your active session (`AM_ROOT`/`AM_BASE_ROOT`) when no `--project`/`--session`/`--from-session` is given. To message another project replyably, register the peer and use `--project` (or inline `@project`). If a send is genuinely local, set the target as your `AM_ROOT` instead of passing `--root`.
+
 ### Sending cross-project
 
 ```bash


### PR DESCRIPTION
Closes #144.

## Problem

A direct `amq send --root <other-tree>` resolved all identity from the *target* root, so the message carried no sender-origin metadata: `reply_to` was stamped with the target's session and `reply_project` was empty. The recipient couldn't reply, and a naive `amq reply` looped back into their own tree — a silent misroute (same "no silent failures" class as the `--body` footgun #143).

Design was debated and decided with **codex** on AMQ thread `decision/issue-144` (see issue #144 for the recorded decision + the env-only refinement).

## Fix (owning layer = send)

- **send refuses an unqualified cross-tree `--root`**: when `--root` is explicit, crosses into a different base tree than the caller's active session (`AM_ROOT`/`AM_BASE_ROOT`), and no routing dimension (`--project`/`--session`/`--from-session`) is given. A direct `--root` is root *selection*, not federation routing. Actionable error guidance.
- **send no longer stamps `reply_to` on same-session sends** — only real cross-session/cross-project routes. The stray same-session `reply_to` is what made a cross-root send look replyable while looping locally.
- **reply unchanged**: the `reply_project`-set path already fails loudly (`peer %q not found in .amqrc`). No new empty-`reply_project` refusal — that would have broken legitimate in-flight same-session replies (the point-4 objection, conceded in the debate).

### Evidence is env-only (AM_ROOT / AM_BASE_ROOT)
Deliberately **not** cwd `.amqrc`: keying off a project `.amqrc` would flag any `amq send --root X` run from inside a project dir, breaking hermetic scripts/harnesses for marginal coverage. The coop-session repro always has the env set. Residual (documented): an identity-less direct `--root` cross-tree send can still be unreplyable — the cost of keeping bare-root sends working.

## Behavior (verified e2e with the real binary)

| Case | Result |
|------|--------|
| coop agent (`AM_ROOT`=projA) `--root` projB, no route flag | **exit 2**, refused, nothing delivered |
| local same-tree (`AM_ROOT`=root, `--root` root) | delivered |
| bare env (no `AM_ROOT`/`AM_BASE_ROOT`) `--root` anywhere | delivered |
| `--project` / `--session` (routed) | guard skipped — stamps routing headers as before |

## Tests / hygiene

- `internal/cli/send_cross_root_test.go`: refusal via `AM_ROOT` + `AM_BASE_ROOT`, bare-root allowance, redundant same-tree allowance, same-session `reply_to` removal, cross-session `reply_to` retention.
- New `TestMain` unsets `AM_ROOT`/`AM_BASE_ROOT`/`AMQ_GLOBAL_ROOT` so the suite is independent of the developer's coop session; `smoke-test.sh` unsets them too.
- Docs: `CLAUDE.md` + `amq-cli` SKILL.md document the contract and guard. CHANGELOG Unreleased updated.
- `make ci` green (fmt/vet/lint/test/smoke).

Reviewed by **codex** (env-only evidence + `sameBaseTree` boundary accepted; no code blockers; ran `git diff --check`, `go test`, smoke, `make ci` in-worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)