### PR TITLE
fix: self-heal stale wake locks via verified ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document operator-gate conventions in the `amq-cli` and `amq-spec` skills,
   covering structural human handoffs, initialized human handles, and spec
   approval gates (#136).
+- Report and optionally fix identity-verified stale `.wake.lock` files from
+  `amq doctor --ops`, including roots whose config is missing or corrupt (#151).
 
 ## [0.36.0] - 2026-06-13
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,7 @@ Use `--force` with retry to override the max retry limit.
 - Queue depth and oldest unread per agent
 - DLQ count and oldest age
 - Presence freshness
+- Wake lock health (`--fix-wake-locks` removes stale locks)
 - Integration hints for Kanban and Symphony
 
 Use `amq doctor --ops --json` for machine-readable health output.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ amq reply --id <msg_id> --kind review_response --body "LGTM with comments"
 amq doctor
 amq doctor --ops
 amq doctor --ops --json
+amq doctor --ops --fix-wake-locks
 ```
 
 ## Message Kinds & Priority

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -184,9 +184,10 @@ func runDoctor(args []string) error {
 				continue
 			}
 			icon := statusIcons["warn"]
-			if wl.Status == "fixed" {
+			switch wl.Status {
+			case "fixed":
 				icon = statusIcons["ok"]
-			} else if wl.Status == "error" {
+			case "error":
 				icon = statusIcons["error"]
 			}
 			line := fmt.Sprintf("  %s wake lock: %s agent=%s root=%s lock=%s",

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -32,6 +32,7 @@ func runDoctor(args []string) error {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	jsonFlag := fs.Bool("json", false, "Output as JSON")
 	opsFlag := fs.Bool("ops", false, "Include runtime operational checks")
+	fixWakeLocksFlag := fs.Bool("fix-wake-locks", false, "With --ops, remove stale wake lock files")
 
 	usage := usageWithFlags(fs, "amq doctor [options]",
 		"Verify AMQ installation and configuration.",
@@ -48,6 +49,7 @@ func runDoctor(args []string) error {
 		"  - Queue depth and oldest unread per agent",
 		"  - DLQ count and age",
 		"  - Presence freshness",
+		"  - Wake lock health",
 		"  - Integration hints (Kanban, Symphony)",
 	)
 
@@ -55,6 +57,9 @@ func runDoctor(args []string) error {
 		return err
 	} else if handled {
 		return nil
+	}
+	if *fixWakeLocksFlag && !*opsFlag {
+		return UsageError("--fix-wake-locks requires --ops")
 	}
 
 	result := doctorResult{}
@@ -99,7 +104,7 @@ func runDoctor(args []string) error {
 	if *opsFlag && root != "" {
 		// Resolve root source once here; avoids re-resolving with empty flags in runOpsChecks.
 		_, source, _, _ := resolveEnvConfigWithSource("", "")
-		result.Ops = runOpsChecks(root, string(source))
+		result.Ops = runOpsChecks(root, string(source), *fixWakeLocksFlag)
 	}
 
 	// Calculate summary
@@ -170,6 +175,31 @@ func runDoctor(args []string) error {
 				line += fmt.Sprintf(", %d DLQ", a.DLQCount)
 			}
 			line += fmt.Sprintf(", presence %s (%.0fs ago)", a.PresenceStatus, a.PresenceAgeSeconds)
+			if err := writeStdoutLine(line); err != nil {
+				return err
+			}
+		}
+		for _, wl := range result.Ops.WakeLocks {
+			if wl.Status == string(wakeLockValid) {
+				continue
+			}
+			icon := statusIcons["warn"]
+			if wl.Status == "fixed" {
+				icon = statusIcons["ok"]
+			} else if wl.Status == "error" {
+				icon = statusIcons["error"]
+			}
+			line := fmt.Sprintf("  %s wake lock: %s agent=%s root=%s lock=%s",
+				icon, wl.Status, wl.Agent, wl.Root, wl.Lock)
+			if wl.PID != 0 {
+				line += fmt.Sprintf(" pid=%d", wl.PID)
+			}
+			if wl.Reason != "" {
+				line += " reason=" + wl.Reason
+			}
+			if wl.Fix != "" && wl.Status == string(wakeLockStale) {
+				line += " fix=" + wl.Fix
+			}
 			if err := writeStdoutLine(line); err != nil {
 				return err
 			}

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -15,9 +15,10 @@ import (
 )
 
 type doctorOpsResult struct {
-	Root   opsRoot    `json:"root"`
-	Agents []opsAgent `json:"agents"`
-	Hints  []opsHint  `json:"hints"`
+	Root      opsRoot       `json:"root"`
+	Agents    []opsAgent    `json:"agents"`
+	WakeLocks []opsWakeLock `json:"wake_locks,omitempty"`
+	Hints     []opsHint     `json:"hints"`
 }
 
 type opsRoot struct {
@@ -41,7 +42,20 @@ type opsHint struct {
 	Message string `json:"message"`
 }
 
-func runOpsChecks(root string, rootSource string) *doctorOpsResult {
+type opsWakeLock struct {
+	Status  string `json:"status"`
+	Agent   string `json:"agent"`
+	Root    string `json:"root"`
+	Lock    string `json:"lock"`
+	PID     int    `json:"pid,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+	Fix     string `json:"fix,omitempty"`
+	Removed bool   `json:"removed,omitempty"`
+}
+
+const fixWakeLocksCommand = "amq doctor --ops --fix-wake-locks"
+
+func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsResult {
 	result := &doctorOpsResult{}
 	now := time.Now()
 
@@ -115,12 +129,51 @@ func runOpsChecks(root string, rootSource string) *doctorOpsResult {
 		result.Agents = append(result.Agents, agent)
 	}
 
+	result.WakeLocks = checkWakeLocks(root, cfg.Agents, fixWakeLocks)
+
 	// Integration hints
 	result.Hints = append(result.Hints, checkGlobalRootHint()...)
 	result.Hints = append(result.Hints, checkKanbanHint()...)
 	result.Hints = append(result.Hints, checkSymphonyHint()...)
 
 	return result
+}
+
+func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
+	var locks []opsWakeLock
+	for _, agent := range agents {
+		inspection := inspectWakeLock(root, agent)
+		if !inspection.Exists {
+			continue
+		}
+
+		lock := opsWakeLock{
+			Status: string(inspection.Status),
+			Agent:  agent,
+			Root:   inspection.Root,
+			Lock:   inspection.LockPath,
+			PID:    inspection.PID,
+			Reason: inspection.Reason,
+		}
+		if inspection.Status == wakeLockStale {
+			lock.Fix = fixWakeLocksCommand
+			if fix {
+				recheck := inspectWakeLock(root, agent)
+				if recheck.Status != wakeLockStale {
+					lock.Status = string(recheck.Status)
+					lock.Reason = "wake lock changed before fix"
+				} else if err := removeWakeLockIfUnchanged(recheck); err != nil {
+					lock.Status = "error"
+					lock.Reason = err.Error()
+				} else {
+					lock.Status = "fixed"
+					lock.Removed = true
+				}
+			}
+		}
+		locks = append(locks, lock)
+	}
+	return locks
 }
 
 func checkGlobalRootHint() []opsHint {

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -72,6 +72,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 			Status:  "error",
 			Message: fmt.Sprintf("Cannot load config: %v", err),
 		})
+		result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, nil), fixWakeLocks)
 		return result
 	}
 
@@ -129,7 +130,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		result.Agents = append(result.Agents, agent)
 	}
 
-	result.WakeLocks = checkWakeLocks(root, cfg.Agents, fixWakeLocks)
+	result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, cfg.Agents), fixWakeLocks)
 
 	// Integration hints
 	result.Hints = append(result.Hints, checkGlobalRootHint()...)
@@ -137,6 +138,34 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 	result.Hints = append(result.Hints, checkSymphonyHint()...)
 
 	return result
+}
+
+func discoveredWakeLockAgents(root string, configured []string) []string {
+	seen := make(map[string]struct{}, len(configured))
+	agents := make([]string, 0, len(configured))
+	for _, agent := range configured {
+		if _, ok := seen[agent]; ok {
+			continue
+		}
+		seen[agent] = struct{}{}
+		agents = append(agents, agent)
+	}
+
+	discovered, err := fsq.ListAgents(root)
+	if err != nil {
+		return agents
+	}
+	for _, agent := range discovered {
+		if _, ok := seen[agent]; ok {
+			continue
+		}
+		if err := fsq.ValidateHandle(agent); err != nil {
+			continue
+		}
+		seen[agent] = struct{}{}
+		agents = append(agents, agent)
+	}
+	return agents
 }
 
 func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -135,6 +135,57 @@ func TestRunOpsChecks_NoConfig(t *testing.T) {
 	}
 }
 
+func TestRunOpsChecks_ReportsAndFixesStaleWakeLockWithoutConfig(t *testing.T) {
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "alice", wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+
+	result := runOpsChecks(root, "test_source", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) {
+		t.Fatalf("status = %q, want stale", got.Status)
+	}
+	if got.Agent != "alice" {
+		t.Fatalf("agent = %q, want alice", got.Agent)
+	}
+	if got.Fix != fixWakeLocksCommand {
+		t.Fatalf("fix = %q, want %q", got.Fix, fixWakeLocksCommand)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock should not be removed without fix flag: %v", err)
+	}
+
+	fixed := runOpsChecks(root, "test_source", true)
+	if len(fixed.WakeLocks) != 1 {
+		t.Fatalf("fixed wake lock count = %d, want 1", len(fixed.WakeLocks))
+	}
+	if fixed.WakeLocks[0].Status != "fixed" {
+		t.Fatalf("fixed status = %q, want fixed", fixed.WakeLocks[0].Status)
+	}
+	if !fixed.WakeLocks[0].Removed {
+		t.Fatal("expected Removed=true")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock should be removed with fix flag, stat err=%v", err)
+	}
+
+	foundConfigError := false
+	for _, h := range result.Hints {
+		if h.Code == "config_error" && h.Status == "error" {
+			foundConfigError = true
+			break
+		}
+	}
+	if !foundConfigError {
+		t.Fatalf("expected config_error hint, got: %+v", result.Hints)
+	}
+}
+
 func TestRunOpsChecks_RootSourceThreaded(t *testing.T) {
 	root := t.TempDir()
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -55,7 +55,7 @@ func TestRunOpsChecks_BasicAgentStats(t *testing.T) {
 		t.Fatalf("write presence: %v", err)
 	}
 
-	result := runOpsChecks(root, "test_source")
+	result := runOpsChecks(root, "test_source", false)
 
 	// Check root
 	if result.Root.Path != root {
@@ -113,7 +113,7 @@ func TestRunOpsChecks_NoConfig(t *testing.T) {
 	}
 	// No config.json written
 
-	result := runOpsChecks(root, "env")
+	result := runOpsChecks(root, "env", false)
 
 	// Should return config_error hint
 	if len(result.Hints) == 0 {
@@ -149,10 +149,90 @@ func TestRunOpsChecks_RootSourceThreaded(t *testing.T) {
 	}
 
 	for _, src := range []string{"flag", "env", "project_amqrc", "global_amqrc"} {
-		result := runOpsChecks(root, src)
+		result := runOpsChecks(root, src, false)
 		if result.Root.Source != src {
 			t.Errorf("runOpsChecks(_, %q).Root.Source = %q", src, result.Root.Source)
 		}
+	}
+}
+
+func TestRunOpsChecks_ReportsStaleWakeLock(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lockPath := writeWakeLockForTest(t, root, "alice", wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+
+	result := runOpsChecks(root, "test_source", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) {
+		t.Fatalf("status = %q, want stale", got.Status)
+	}
+	if got.Agent != "alice" {
+		t.Fatalf("agent = %q, want alice", got.Agent)
+	}
+	if got.Reason != "pid not running" {
+		t.Fatalf("reason = %q, want pid not running", got.Reason)
+	}
+	if got.Fix != fixWakeLocksCommand {
+		t.Fatalf("fix = %q, want %q", got.Fix, fixWakeLocksCommand)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock should not be removed without fix flag: %v", err)
+	}
+}
+
+func TestRunOpsChecks_FixesStaleWakeLock(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lockPath := writeWakeLockForTest(t, root, "alice", wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+
+	result := runOpsChecks(root, "test_source", true)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != "fixed" {
+		t.Fatalf("status = %q, want fixed", got.Status)
+	}
+	if !got.Removed {
+		t.Fatal("expected Removed=true")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock should be removed, stat err=%v", err)
 	}
 }
 

--- a/internal/cli/wake_process_darwin.go
+++ b/internal/cli/wake_process_darwin.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
+	info := wakeProcessInfo{PID: pid}
+	if !processAlive(pid) {
+		return info
+	}
+	info.Running = true
+
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		info.InspectError = err
+		return info
+	}
+	if kp == nil {
+		info.Running = false
+		return info
+	}
+
+	sec, nsec := kp.Proc.P_starttime.Unix()
+	info.StartToken = fmt.Sprintf("%d.%09d", sec, nsec)
+	info.Executable = nulTerminatedString(kp.Proc.P_comm[:])
+
+	if boot, err := unix.SysctlTimeval("kern.boottime"); err == nil && boot != nil {
+		bsec, bnsec := boot.Unix()
+		info.BootID = fmt.Sprintf("%d.%09d", bsec, bnsec)
+	}
+
+	return info
+}
+
+func nulTerminatedString(raw []byte) string {
+	for i, b := range raw {
+		if b == 0 {
+			return string(raw[:i])
+		}
+	}
+	return string(raw)
+}

--- a/internal/cli/wake_process_linux.go
+++ b/internal/cli/wake_process_linux.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
+	info := wakeProcessInfo{PID: pid}
+	if !processAlive(pid) {
+		return info
+	}
+	info.Running = true
+
+	if bootID, err := os.ReadFile("/proc/sys/kernel/random/boot_id"); err == nil {
+		info.BootID = strings.TrimSpace(string(bootID))
+	}
+
+	statPath := fmt.Sprintf("/proc/%d/stat", pid)
+	if data, err := os.ReadFile(statPath); err == nil {
+		if token, parseErr := linuxProcStartToken(string(data)); parseErr == nil {
+			info.StartToken = token
+		} else {
+			info.InspectError = parseErr
+		}
+	} else {
+		info.InspectError = err
+	}
+
+	if exe, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid)); err == nil {
+		info.Executable = exe
+	} else if info.InspectError == nil {
+		info.InspectError = err
+	}
+
+	if cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid)); err == nil {
+		info.Args = splitProcCmdline(cmdline)
+	}
+
+	return info
+}
+
+func linuxProcStartToken(stat string) (string, error) {
+	endComm := strings.LastIndex(stat, ")")
+	if endComm < 0 || endComm+2 >= len(stat) {
+		return "", fmt.Errorf("malformed proc stat")
+	}
+	fields := strings.Fields(stat[endComm+2:])
+	// fields[0] is stat field 3; starttime is field 22.
+	const startTimeIndex = 22 - 3
+	if len(fields) <= startTimeIndex {
+		return "", fmt.Errorf("proc stat missing starttime")
+	}
+	return fields[startTimeIndex], nil
+}
+
+func splitProcCmdline(raw []byte) []string {
+	parts := strings.Split(strings.TrimRight(string(raw), "\x00"), "\x00")
+	args := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			args = append(args, part)
+		}
+	}
+	return args
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -323,9 +323,7 @@ func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
 	// that orphan before taking over; never signal an unconfirmed PID.
 	if strings.HasPrefix(existing.TTY, "/dev/") {
 		if _, statErr := os.Stat(existing.TTY); os.IsNotExist(statErr) {
-			terminateWakeProcess(existing.PID)
-			_ = removeWakeLockIfUnchanged(inspection)
-			return true
+			return replaceConfirmedOrphanedWakeLock(inspection)
 		}
 	}
 
@@ -340,22 +338,44 @@ func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
 		existingSid, sidErr := unix.Getsid(existing.PID)
 		currentSid, _ := unix.Getsid(0)
 		if sidErr == nil && existingSid != currentSid {
-			terminateWakeProcess(existing.PID)
-			_ = removeWakeLockIfUnchanged(inspection)
-			return true
+			return replaceConfirmedOrphanedWakeLock(inspection)
 		}
 	}
 	return false
 }
 
-func terminateWakeProcess(pid int) {
+func replaceConfirmedOrphanedWakeLock(inspection wakeLockInspection) bool {
+	if !terminateWakeProcessIfStillConfirmed(inspection) {
+		return false
+	}
+	return removeWakeLockIfUnchanged(inspection) == nil
+}
+
+func terminateWakeProcessIfStillConfirmed(inspection wakeLockInspection) bool {
+	if !sameConfirmedWakeLock(inspection) {
+		return false
+	}
+	pid := inspection.PID
 	if proc, err := os.FindProcess(pid); err == nil {
 		_ = proc.Signal(syscall.SIGTERM)
 		time.Sleep(100 * time.Millisecond)
 		if processAlive(pid) {
+			if !sameConfirmedWakeLock(inspection) {
+				return false
+			}
 			_ = proc.Signal(syscall.SIGKILL)
 		}
 	}
+	return true
+}
+
+func sameConfirmedWakeLock(inspection wakeLockInspection) bool {
+	recheck := inspectWakeLock(inspection.Root, inspection.Agent)
+	return recheck.Exists &&
+		recheck.Status == wakeLockValid &&
+		recheck.IdentityConfirmed &&
+		recheck.PID == inspection.PID &&
+		bytes.Equal(recheck.raw, inspection.raw)
 }
 
 func currentWakeLockMatches(lock wakeLock) bool {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -23,11 +24,53 @@ import (
 
 // wakeLock represents the lock file content for wake process deduplication.
 type wakeLock struct {
-	PID     int    `json:"pid"`
-	TTY     string `json:"tty"`
-	Root    string `json:"root"`    // Absolute path to disambiguate relative AM_ROOT
-	Started string `json:"started"` // ISO8601 timestamp
+	PID          int      `json:"pid"`
+	TTY          string   `json:"tty"`
+	Root         string   `json:"root"`                    // Absolute path to disambiguate relative AM_ROOT
+	Agent        string   `json:"agent,omitempty"`         // Agent handle that owns this lock
+	Hostname     string   `json:"hostname,omitempty"`      // Host that created the lock
+	Started      string   `json:"started"`                 // Wall-clock diagnostic timestamp
+	ProcessStart string   `json:"process_start,omitempty"` // Kernel process start token, guards PID reuse
+	BootID       string   `json:"boot_id,omitempty"`       // Boot identity paired with ProcessStart when available
+	Executable   string   `json:"executable,omitempty"`    // Diagnostic process executable basename/path
+	Args         []string `json:"args,omitempty"`          // Diagnostic argv when available
 }
+
+type wakeProcessInfo struct {
+	PID          int
+	Running      bool
+	StartToken   string
+	BootID       string
+	Executable   string
+	Args         []string
+	InspectError error
+}
+
+type wakeLockStatus string
+
+const (
+	wakeLockMissing    wakeLockStatus = "missing"
+	wakeLockValid      wakeLockStatus = "valid"
+	wakeLockStale      wakeLockStatus = "stale"
+	wakeLockCreating   wakeLockStatus = "creating"
+	wakeLockUnverified wakeLockStatus = "unverified"
+)
+
+type wakeLockInspection struct {
+	Exists            bool
+	Status            wakeLockStatus
+	Reason            string
+	Root              string
+	Agent             string
+	LockPath          string
+	PID               int
+	Lock              wakeLock
+	Process           wakeProcessInfo
+	IdentityConfirmed bool
+	raw               []byte
+}
+
+var inspectWakeProcess = inspectWakeProcessPlatform
 
 // acquireWakeLock attempts to acquire the wake lock for an agent's inbox.
 // Returns cleanup function and error. If another wake is running, returns error.
@@ -40,87 +83,24 @@ func acquireWakeLock(root, me string) (cleanup func(), err error) {
 		return nil, fmt.Errorf("failed to create agent directory: %w", err)
 	}
 
-	// Resolve absolute path for comparison (normalize symlinks if possible)
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		absRoot = root
-	}
-	if realRoot, err := filepath.EvalSymlinks(absRoot); err == nil {
-		absRoot = realRoot
-	}
-
 	// Check existing lock
-	if data, err := os.ReadFile(lockPath); err == nil {
-		var existing wakeLock
-		if json.Unmarshal(data, &existing) == nil {
-			// Normalize stored root if possible to avoid symlink mismatches.
-			if realRoot, err := filepath.EvalSymlinks(existing.Root); err == nil {
-				existing.Root = realRoot
+	inspection := inspectWakeLock(root, me)
+	if inspection.Exists {
+		switch inspection.Status {
+		case wakeLockStale:
+			if err := removeWakeLockIfUnchanged(inspection); err != nil {
+				return nil, err
 			}
-
-			// Check if process is still alive
-			if processAlive(existing.PID) {
-				// Process alive, but check if its TTY is still valid.
-				// If terminal was closed, the wake process is orphaned and should be replaced.
-				// Only check absolute paths (skip "stdin", "unknown", "pipe:[...]", etc.)
-				if strings.HasPrefix(existing.TTY, "/dev/") {
-					if _, statErr := os.Stat(existing.TTY); os.IsNotExist(statErr) {
-						// TTY gone - orphaned wake, kill it and take over
-						if proc, err := os.FindProcess(existing.PID); err == nil {
-							_ = proc.Signal(syscall.SIGTERM)
-							time.Sleep(100 * time.Millisecond)
-							if processAlive(existing.PID) {
-								_ = proc.Signal(syscall.SIGKILL)
-							}
-						}
-						_ = os.Remove(lockPath)
-						goto createLock
-					}
-				}
-
-				// Check if existing wake is in a different session (orphaned from closed shell).
-				// Same TTY + different session = old wake is orphaned, safe to take over.
-				currentTTY := getCurrentTTY()
-				existingTTY := existing.TTY
-				if strings.HasPrefix(existingTTY, "/dev/") {
-					if real, err := filepath.EvalSymlinks(existingTTY); err == nil {
-						existingTTY = real
-					}
-				}
-				if currentTTY != "" && currentTTY == existingTTY {
-					// Same TTY - check session IDs
-					existingSid, sidErr := unix.Getsid(existing.PID)
-					currentSid, _ := unix.Getsid(0)
-					if sidErr == nil && existingSid != currentSid {
-						// Different session on same TTY - old one is orphaned.
-						// Kill the orphaned process before taking over to prevent duplicates.
-						if proc, err := os.FindProcess(existing.PID); err == nil {
-							_ = proc.Signal(syscall.SIGTERM)
-							// Brief wait for graceful shutdown
-							time.Sleep(100 * time.Millisecond)
-							// Force kill if still alive
-							if processAlive(existing.PID) {
-								_ = proc.Signal(syscall.SIGKILL)
-							}
-						}
-						_ = os.Remove(lockPath)
-						goto createLock
-					}
-				}
-
-				return nil, fmt.Errorf("wake already running for %s (pid %d on %s since %s)",
-					me, existing.PID, existing.TTY, existing.Started)
+		case wakeLockCreating:
+			return nil, fmt.Errorf("wake lock is being created (retry shortly)")
+		case wakeLockValid:
+			if shouldReplaceOrphanedWakeLock(inspection) {
+				goto createLock
 			}
-			// Stale lock - remove it before trying to acquire
-			_ = os.Remove(lockPath)
-		} else {
-			// Invalid/corrupt lock. If it was just created, avoid stomping a writer in progress.
-			if info, statErr := os.Stat(lockPath); statErr == nil {
-				if time.Since(info.ModTime()) < 2*time.Second {
-					return nil, fmt.Errorf("wake lock is being created (retry shortly)")
-				}
-			}
-			_ = os.Remove(lockPath)
+			return nil, wakeLockAlreadyRunningError(me, inspection.Lock)
+		case wakeLockUnverified:
+			return nil, fmt.Errorf("wake lock for %s is unverified (pid %d on %s since %s): %s; run 'amq doctor --ops' for details",
+				me, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started, inspection.Reason)
 		}
 	}
 
@@ -135,8 +115,18 @@ createLock:
 	lock := wakeLock{
 		PID:     os.Getpid(),
 		TTY:     ttyName,
-		Root:    absRoot,
+		Root:    canonicalWakeRoot(root),
+		Agent:   me,
 		Started: time.Now().UTC().Format(time.RFC3339),
+	}
+	if hostname, err := os.Hostname(); err == nil {
+		lock.Hostname = hostname
+	}
+	if proc := inspectWakeProcess(os.Getpid()); proc.Running {
+		lock.ProcessStart = proc.StartToken
+		lock.BootID = proc.BootID
+		lock.Executable = proc.Executable
+		lock.Args = proc.Args
 	}
 	lockData, _ := json.Marshal(lock)
 
@@ -171,13 +161,292 @@ createLock:
 		// Only remove if it's still our lock
 		if data, err := os.ReadFile(lockPath); err == nil {
 			var current wakeLock
-			if json.Unmarshal(data, &current) == nil && current.PID == os.Getpid() {
+			if json.Unmarshal(data, &current) == nil && currentWakeLockMatches(current) {
 				_ = os.Remove(lockPath)
 			}
 		}
 	}
 
 	return cleanup, nil
+}
+
+func inspectWakeLock(root, me string) wakeLockInspection {
+	lockPath := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
+	inspection := wakeLockInspection{
+		Status:   wakeLockMissing,
+		Root:     canonicalWakeRoot(root),
+		Agent:    me,
+		LockPath: lockPath,
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return inspection
+		}
+		inspection.Exists = true
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = fmt.Sprintf("cannot read lock: %v", err)
+		return inspection
+	}
+
+	inspection.Exists = true
+	inspection.raw = data
+	var existing wakeLock
+	if err := json.Unmarshal(data, &existing); err != nil {
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) < 2*time.Second {
+			inspection.Status = wakeLockCreating
+			inspection.Reason = "lock is being created"
+			return inspection
+		}
+		inspection.Status = wakeLockStale
+		inspection.Reason = "invalid lock json"
+		return inspection
+	}
+
+	inspection.Lock = existing
+	inspection.PID = existing.PID
+	inspection.Process = inspectWakeProcess(existing.PID)
+	classifyWakeLock(root, me, &inspection)
+	return inspection
+}
+
+func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
+	lock := inspection.Lock
+	if lock.PID <= 0 {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "invalid pid"
+		return
+	}
+	if strings.TrimSpace(lock.Root) == "" {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "lock root missing"
+		return
+	}
+	if canonicalWakeRoot(lock.Root) != canonicalWakeRoot(root) {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "root mismatch"
+		return
+	}
+	if lock.Agent != "" && lock.Agent != me {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "agent mismatch"
+		return
+	}
+	if lock.Hostname != "" {
+		if hostname, err := os.Hostname(); err == nil && hostname != "" && lock.Hostname != hostname {
+			inspection.Status = wakeLockUnverified
+			inspection.Reason = "hostname mismatch"
+			return
+		}
+	}
+
+	proc := inspection.Process
+	if !proc.Running {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "pid not running"
+		return
+	}
+	if lock.ProcessStart != "" {
+		if proc.StartToken == "" {
+			inspection.Status = wakeLockUnverified
+			inspection.Reason = inspectionReason("process start time unavailable", proc.InspectError)
+			return
+		}
+		if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
+			inspection.Status = wakeLockStale
+			inspection.Reason = "boot id mismatch"
+			return
+		}
+		if lock.ProcessStart != proc.StartToken {
+			inspection.Status = wakeLockStale
+			inspection.Reason = "process start time mismatch"
+			return
+		}
+	}
+	if proc.Executable == "" {
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = inspectionReason("process identity unavailable", proc.InspectError)
+		return
+	}
+	if !processLooksLikeAMQ(proc) {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "pid is not amq"
+		return
+	}
+	if len(proc.Args) > 0 && !processArgsLookLikeWake(proc.Args) {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "pid is not amq wake"
+		return
+	}
+
+	if lock.ProcessStart != "" {
+		inspection.IdentityConfirmed = true
+		inspection.Status = wakeLockValid
+		return
+	}
+
+	if wakeArgsMatchRootAgent(proc.Args, root, me) {
+		inspection.IdentityConfirmed = true
+		inspection.Status = wakeLockValid
+		return
+	}
+
+	inspection.Status = wakeLockUnverified
+	inspection.Reason = "legacy lock lacks process start metadata"
+}
+
+func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
+	current, err := os.ReadFile(inspection.LockPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("re-read wake lock before removal: %w", err)
+	}
+	if !bytes.Equal(current, inspection.raw) {
+		return fmt.Errorf("wake lock changed while cleaning stale lock; retry")
+	}
+	if err := os.Remove(inspection.LockPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale wake lock: %w", err)
+	}
+	return nil
+}
+
+func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
+	if !inspection.IdentityConfirmed {
+		return false
+	}
+	existing := inspection.Lock
+
+	// Process is a confirmed matching amq wake. If its TTY disappeared, stop
+	// that orphan before taking over; never signal an unconfirmed PID.
+	if strings.HasPrefix(existing.TTY, "/dev/") {
+		if _, statErr := os.Stat(existing.TTY); os.IsNotExist(statErr) {
+			terminateWakeProcess(existing.PID)
+			_ = removeWakeLockIfUnchanged(inspection)
+			return true
+		}
+	}
+
+	currentTTY := getCurrentTTY()
+	existingTTY := existing.TTY
+	if strings.HasPrefix(existingTTY, "/dev/") {
+		if real, err := filepath.EvalSymlinks(existingTTY); err == nil {
+			existingTTY = real
+		}
+	}
+	if currentTTY != "" && currentTTY == existingTTY {
+		existingSid, sidErr := unix.Getsid(existing.PID)
+		currentSid, _ := unix.Getsid(0)
+		if sidErr == nil && existingSid != currentSid {
+			terminateWakeProcess(existing.PID)
+			_ = removeWakeLockIfUnchanged(inspection)
+			return true
+		}
+	}
+	return false
+}
+
+func terminateWakeProcess(pid int) {
+	if proc, err := os.FindProcess(pid); err == nil {
+		_ = proc.Signal(syscall.SIGTERM)
+		time.Sleep(100 * time.Millisecond)
+		if processAlive(pid) {
+			_ = proc.Signal(syscall.SIGKILL)
+		}
+	}
+}
+
+func currentWakeLockMatches(lock wakeLock) bool {
+	if lock.PID != os.Getpid() {
+		return false
+	}
+	if lock.ProcessStart == "" {
+		return true
+	}
+	proc := inspectWakeProcess(os.Getpid())
+	if !proc.Running || proc.StartToken == "" {
+		return false
+	}
+	if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
+		return false
+	}
+	return lock.ProcessStart == proc.StartToken
+}
+
+func canonicalWakeRoot(root string) string {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		absRoot = root
+	}
+	if realRoot, err := filepath.EvalSymlinks(absRoot); err == nil {
+		absRoot = realRoot
+	}
+	return filepath.Clean(absRoot)
+}
+
+func wakeLockAlreadyRunningError(me string, lock wakeLock) error {
+	return fmt.Errorf("wake already running for %s (pid %d on %s since %s)",
+		me, lock.PID, lock.TTY, lock.Started)
+}
+
+func inspectionReason(base string, err error) string {
+	if err == nil {
+		return base
+	}
+	return fmt.Sprintf("%s: %v", base, err)
+}
+
+func processLooksLikeAMQ(proc wakeProcessInfo) bool {
+	if isAMQExecutable(proc.Executable) {
+		return true
+	}
+	if len(proc.Args) > 0 && isAMQExecutable(proc.Args[0]) {
+		return true
+	}
+	return false
+}
+
+func processArgsLookLikeWake(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	for _, arg := range args[1:] {
+		if arg == "wake" {
+			return true
+		}
+	}
+	return false
+}
+
+func wakeArgsMatchRootAgent(args []string, root, me string) bool {
+	if !processArgsLookLikeWake(args) {
+		return false
+	}
+	rootMatch := false
+	meMatch := false
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--root" && i+1 < len(args):
+			rootMatch = canonicalWakeRoot(args[i+1]) == canonicalWakeRoot(root)
+			i++
+		case strings.HasPrefix(arg, "--root="):
+			rootMatch = canonicalWakeRoot(strings.TrimPrefix(arg, "--root=")) == canonicalWakeRoot(root)
+		case arg == "--me" && i+1 < len(args):
+			meMatch = args[i+1] == me
+			i++
+		case strings.HasPrefix(arg, "--me="):
+			meMatch = strings.TrimPrefix(arg, "--me=") == me
+		}
+	}
+	return rootMatch && meMatch
+}
+
+func isAMQExecutable(value string) bool {
+	base := filepath.Base(strings.Trim(value, `"'`))
+	return base == "amq"
 }
 
 // processAlive checks if a process with given PID is running.

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -374,6 +374,58 @@ func TestRemoveWakeLockIfUnchangedRefusesChangedLock(t *testing.T) {
 	}
 }
 
+func TestShouldReplaceOrphanedWakeLockReverifiesBeforeSignal(t *testing.T) {
+	const pid = 4242
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          pid,
+		TTY:          "/dev/amq-missing-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	inspections := 0
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID == pid {
+			inspections++
+			if inspections == 1 {
+				return wakeProcessInfo{
+					PID:        gotPID,
+					Running:    true,
+					StartToken: "start-1",
+					BootID:     "boot-1",
+					Executable: "/opt/homebrew/bin/amq",
+					Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root},
+				}
+			}
+			return wakeProcessInfo{
+				PID:        gotPID,
+				Running:    true,
+				StartToken: "start-2",
+				BootID:     "boot-1",
+				Executable: "/bin/sleep",
+				Args:       []string{"/bin/sleep", "100"},
+			}
+		}
+		return wakeProcessInfo{PID: gotPID}
+	})
+
+	inspection := inspectWakeLock(root, "orchestrator")
+	if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+		t.Fatalf("expected initial valid confirmed lock, got status=%s confirmed=%v", inspection.Status, inspection.IdentityConfirmed)
+	}
+	if shouldReplaceOrphanedWakeLock(inspection) {
+		t.Fatal("should not replace when recheck no longer confirms the same wake lock")
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock should remain after failed recheck: %v", err)
+	}
+	if inspections < 2 {
+		t.Fatalf("expected re-inspection before replacement, got %d inspection(s)", inspections)
+	}
+}
+
 func TestRunWakeWithLoopRejectsRecentlyCorruptLock(t *testing.T) {
 	root := t.TempDir()
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -13,6 +14,43 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
+
+func stubInspectWakeProcess(t *testing.T, fn func(pid int) wakeProcessInfo) {
+	t.Helper()
+	old := inspectWakeProcess
+	inspectWakeProcess = fn
+	t.Cleanup(func() {
+		inspectWakeProcess = old
+	})
+}
+
+func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) string {
+	t.Helper()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	if lock.Root == "" {
+		lock.Root = canonicalWakeRoot(root)
+	}
+	if lock.Agent == "" {
+		lock.Agent = agent
+	}
+	if lock.Started == "" {
+		lock.Started = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	}
+	data, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatalf("marshal wake lock: %v", err)
+	}
+	lockPath := filepath.Join(fsq.AgentBase(root, agent), ".wake.lock")
+	if err := os.WriteFile(lockPath, data, 0o600); err != nil {
+		t.Fatalf("write wake lock: %v", err)
+	}
+	return lockPath
+}
 
 func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 	root := t.TempDir()
@@ -78,21 +116,30 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 }
 
 func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
 	root := t.TempDir()
-	if err := fsq.EnsureRootDirs(root); err != nil {
-		t.Fatalf("EnsureRootDirs: %v", err)
-	}
-	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
-		t.Fatalf("EnsureAgentDirs: %v", err)
-	}
-	cleanup, err := acquireWakeLock(root, "orchestrator")
-	if err != nil {
-		t.Fatalf("acquireWakeLock: %v", err)
-	}
-	defer cleanup()
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
-	err = runWakeWithLoop([]string{
+	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
 		"--inject-via", "/tmp/injector",
@@ -109,6 +156,250 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 	}
 	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
 		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+}
+
+func TestAcquireWakeLockSelfHealsPIDReusedByNonAMQ(t *testing.T) {
+	const reusedPID = 4242
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          reusedPID,
+		ProcessStart: "old-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == reusedPID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "new-start",
+				BootID:     "boot-1",
+				Executable: "/bin/sleep",
+				Args:       []string{"/bin/sleep", "100"},
+			}
+		}
+		if pid == os.Getpid() {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "self-start",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+
+	cleanup, err := acquireWakeLock(root, "orchestrator")
+	if err != nil {
+		t.Fatalf("acquireWakeLock should replace stale PID-reuse lock: %v", err)
+	}
+	defer cleanup()
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read replacement lock: %v", err)
+	}
+	var got wakeLock
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal replacement lock: %v", err)
+	}
+	if got.PID != os.Getpid() {
+		t.Fatalf("replacement pid = %d, want %d", got.PID, os.Getpid())
+	}
+	if got.ProcessStart != "self-start" {
+		t.Fatalf("replacement process_start = %q, want self-start", got.ProcessStart)
+	}
+}
+
+func TestAcquireWakeLockSelfHealsPIDReusedByDifferentAMQStart(t *testing.T) {
+	const reusedPID = 4242
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          reusedPID,
+		ProcessStart: "old-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == reusedPID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "new-start",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root},
+			}
+		}
+		if pid == os.Getpid() {
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "self-start", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+
+	cleanup, err := acquireWakeLock(root, "orchestrator")
+	if err != nil {
+		t.Fatalf("acquireWakeLock should replace mismatched start-token lock: %v", err)
+	}
+	defer cleanup()
+}
+
+func TestAcquireWakeLockSelfHealsStartMismatchWhenExecutableUnavailable(t *testing.T) {
+	const reusedPID = 4242
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          reusedPID,
+		ProcessStart: "old-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == reusedPID {
+			return wakeProcessInfo{
+				PID:          pid,
+				Running:      true,
+				StartToken:   "new-start",
+				BootID:       "boot-1",
+				InspectError: errors.New("executable unavailable"),
+			}
+		}
+		if pid == os.Getpid() {
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "self-start", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+
+	cleanup, err := acquireWakeLock(root, "orchestrator")
+	if err != nil {
+		t.Fatalf("acquireWakeLock should replace start-token mismatch even without executable: %v", err)
+	}
+	defer cleanup()
+}
+
+func TestAcquireWakeLockStartReadFailureIsUnverifiedNotMismatch(t *testing.T) {
+	const pid = 4242
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          pid,
+		ProcessStart: "old-start",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID == pid {
+			return wakeProcessInfo{
+				PID:          gotPID,
+				Running:      true,
+				Executable:   "/opt/homebrew/bin/amq",
+				InspectError: errors.New("permission denied"),
+			}
+		}
+		return wakeProcessInfo{PID: gotPID}
+	})
+
+	cleanup, err := acquireWakeLock(root, "orchestrator")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err == nil {
+		t.Fatal("expected unverified lock error")
+	}
+	if !strings.Contains(err.Error(), "unverified") {
+		t.Fatalf("expected unverified error, got %v", err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("unverified lock should remain, stat=%v", statErr)
+	}
+}
+
+func TestAcquireWakeLockLegacyLiveLockDoesNotAutoDelete(t *testing.T) {
+	const pid = 4242
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:        pid,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID == pid {
+			return wakeProcessInfo{
+				PID:        gotPID,
+				Running:    true,
+				Executable: "/opt/homebrew/bin/amq",
+			}
+		}
+		return wakeProcessInfo{PID: gotPID}
+	})
+
+	cleanup, err := acquireWakeLock(root, "orchestrator")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err == nil {
+		t.Fatal("expected legacy unverified lock error")
+	}
+	if !strings.Contains(err.Error(), "unverified") {
+		t.Fatalf("expected unverified error, got %v", err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("legacy unverified lock should remain, stat=%v", statErr)
+	}
+}
+
+func TestRemoveWakeLockIfUnchangedRefusesChangedLock(t *testing.T) {
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{PID: 4242})
+	inspection := inspectWakeLock(root, "orchestrator")
+	if !inspection.Exists {
+		t.Fatal("expected lock inspection")
+	}
+	changed := wakeLock{
+		PID:     4243,
+		Root:    canonicalWakeRoot(root),
+		Agent:   "orchestrator",
+		Started: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, _ := json.Marshal(changed)
+	if err := os.WriteFile(lockPath, data, 0o600); err != nil {
+		t.Fatalf("write changed lock: %v", err)
+	}
+
+	err := removeWakeLockIfUnchanged(inspection)
+	if err == nil {
+		t.Fatal("expected changed lock removal error")
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("changed lock should remain, stat=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopRejectsRecentlyCorruptLock(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	lockPath := filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock")
+	if err := os.WriteFile(lockPath, []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("write corrupt lock: %v", err)
+	}
+
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with recent corrupt lock: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected recent corrupt lock error")
+	}
+	if !strings.Contains(err.Error(), "being created") {
+		t.Fatalf("expected being-created error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Minimized stale wake-lock bugfix. Wake repair was split out to draft follow-up #154 so this PR only carries the proven stale-lock self-heal and doctor visibility/fix path.

## Scope

- Make `.wake.lock` an identity-verified ownership record instead of a bare PID marker.
- Store process start token, boot ID, executable, argv, root, agent, and hostname diagnostics.
- Classify locks as stale only when proven: dead PID, root/agent mismatch, non-`amq` process, boot mismatch, or process-start mismatch.
- Treat inconclusive inspection as `unverified`: refuse, never auto-delete.
- Never signal a lock PID unless it is identity-confirmed as the matching `amq wake`.
- Re-read and byte-compare the lock before removal to avoid TOCTOU cleanup.
- Keep legacy locks without new metadata from being auto-deleted merely for missing fields.
- Report stale wake locks from `amq doctor --ops`; `--fix-wake-locks` removes only locks that re-inspect as stale.
- Preserve stale-lock visibility/fix even when `meta/config.json` is missing or corrupt by enumerating `agents/*` for wake-lock checks.
- Add a `CHANGELOG.md` Unreleased entry.

## Split Out

Moved to draft #154:
- persisted `.wake.target`
- `amq wake repair`
- saved-injector execution / detached repair process
- repair availability reporting
- `coop exec --wake-inject-via` / `--wake-inject-arg`

## Testing

- `go test ./internal/cli -run 'TestRunOpsChecks_(NoConfig|ReportsAndFixesStaleWakeLockWithoutConfig|ReportsStaleWakeLock|FixesStaleWakeLock)' -count=1`
- `make ci`

Both are green locally after minimization.
