### PR TITLE
docs: document operator gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Document operator-gate conventions in the `amq-cli` and `amq-spec` skills,
+  covering structural human handoffs, initialized human handles, and spec
+  approval gates (#136).
 
 ## [0.36.0] - 2026-06-13
 ### Changed

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -312,6 +312,63 @@ amq list --new --from codex --kind review_request
 amq list --new --label bug
 ```
 
+## Operator Gates
+
+Almost all coordination is agent-to-agent. Occasionally the **next required actor is a human**: an approval, a manual test, a deploy only a person can run, or sign-off that a goal is complete. AMQ has no separate "gate" feature. You represent this **structurally**: address a message to the human's mailbox instead of describing the wait in prose to another agent.
+
+The single invariant AMQ relies on here is **recipient-as-next-actor**: a message addressed to the human handle means a human is who must act next. Everything else below (the `gate/<topic>` thread name and the `APPROVAL:` / `DONE:` subject prefixes) is a **naming convention** that downstream tools like amq-noc watch for. AMQ routing and message classification do **not** special-case thread names or subject text; those are plain strings, useful only because humans and tooling agree to read them. They are conventions, not core AMQ semantics.
+
+### The human handle is `user`, and it must be initialized
+
+By convention the human/operator mailbox is `user`. It must be an initialized handle before you use gates. In current releases before the #139 follow-up, the default agent set may still be `claude,codex`, so sends addressed with `--to user` can warn about an unknown handle and **fail under `--strict`** unless the project initialized `user`. Initialize the handle before using gates:
+
+```bash
+# Seed the human mailbox alongside the agents (one-time, per project)
+amq init --root .agent-mail --agents claude,codex,user
+# or, for a coop project:
+amq coop init --agents claude,codex,user
+```
+
+Throughout this section, `user` means "the conventional human handle **in a project that has initialized it**." If your project has not added the handle, every `--to user` send can warn (and fail under `--strict`) until you do.
+
+### Raising a gate
+
+Use a stable `gate/<topic>` thread so a gate and its resolution stay together:
+
+```bash
+# Approval / choice / manual test a human must perform
+amq send --to user --thread gate/<topic> --kind question \
+  --subject "APPROVAL: <decision>" \
+  --body "<what you need a human to approve or run, and why>"
+
+# Human closeout of a completed goal (sign-off that the goal is done)
+amq send --to user --thread gate/<topic> --kind decision \
+  --subject "DONE: <goal>" \
+  --body "<what was completed; what the human should confirm or close>"
+```
+
+The human answers on the **same** thread from their own terminal or client, e.g. `amq send --me user --to <agent> --thread gate/<topic> --kind answer --subject "APPROVED: <decision>" --body "<approval / answer text>"` (use `DENIED:` or `ANSWER:` for a rejection or a plain answer). Reusing the `gate/<topic>` thread is what lets a watcher pair the answer with the open gate and clear it.
+
+### When NOT to raise a gate
+
+Keep ordinary coordination agent-to-agent. Do **not** send to `user` for:
+
+- FYIs and status updates -> `status` on a normal thread
+- Acknowledgements
+- Routine code review between agents -> `review_request` / `review_response`
+- Agent-owned blockers (waiting on another agent, a build, or a flaky test)
+
+If the escalation owner is a lead/CTO agent, **they** decide whether to escalate, and that decision is agent-to-agent. But once a human action is actually required, it still becomes a `to:user` gate so tooling can observe it.
+
+### Anti-pattern
+
+Prose like `operator-held`, `pending operator`, or `manual approval` **inside an agent-to-agent message is not a gate**. It is body text a human or tool has to guess at. If a human must act, address the human.
+
+### What a gate is, and is not
+
+- **It is an observability / handoff signal, not authorization or security.** AMQ sender identity is local convention, not authenticated approval. A `to:user` gate records that a human is the next actor; it does **not** grant permission or prove a human approved anything. Do not treat it as an access-control boundary.
+- **Cross-session / cross-project gates must be intentional.** Default examples target the human mailbox in the **current** session/project. Routing a gate to another session's or project's `user` is a deliberate act (`--session` / `--project`), never the default. Gate-clearing is a consumer/orchestrator convention unless AMQ later adds explicit gate state.
+
 ## Priority Handling
 
 | Priority | Action |

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -121,13 +121,16 @@ If you receive a message labeled `workflow:spec`, your action depends on the pha
 | `phase:discuss` | Reply with your analysis, continue discussion until aligned |
 | `phase:draft` | Review the plan and send feedback as `review_response` + `phase:review`. Your job here is review, not implementation — the plan needs to survive scrutiny before anyone builds it. |
 | `phase:review` | Revise plan if needed, or confirm alignment |
-| `phase:decision` | Stop. Only the user can authorize implementation. The initiator presents the plan to the user; you wait until the initiator confirms approval and assigns you work. |
+| `phase:decision` | Stop. A `phase:decision` message is agent-to-agent alignment, **not** user approval, so do **not** implement from a spec decision alone. Only the human authorizes implementation, recorded as a structural gate to the initialized human handle (conventionally `user`; see the Operator Gates section in /amq-cli). Wait until the initiator confirms the human approved on the gate thread and assigns you work. |
 
 **Why the partner doesn't implement**: The spec workflow is a design process.
 The initiator owns the relationship with the user and presents the final plan.
 If the partner implements without approval, the user loses control over what
-gets built. Implementation starts only after the initiator explicitly tells
-you the user approved and assigns work.
+gets built. The agent-to-agent `phase:decision` message is alignment, not
+authorization: human approval is a structural gate to the initialized human
+handle, and partner agents must not implement from a spec decision alone.
+Implementation starts only after the initiator explicitly tells you the human
+approved and assigns work.
 
 ## Protocol Discipline
 
@@ -138,7 +141,7 @@ These rules exist because violations silently break the workflow's value proposi
 - **Don't skip phases** — each phase builds on the previous. Collapsing directly to a finished spec skips the discussion where misunderstandings surface.
 - **Use `spec/<topic>` threads and the label convention** — this is how both agents (and the tooling) know which phase the conversation is in. Without consistent labels, the receiver-side protocol table above breaks.
 - **Don't enter plan mode during research** if it blocks tool usage — you need tools to explore the codebase.
-- **Present the final plan to the user before executing** — the initiator owns the user relationship. After the decision phase, present the plan in chat and wait for explicit approval. Only then assign implementation work to agents.
+- **Present the final plan to the user before executing, and raise a structural gate**. The initiator owns the user relationship. After the decision phase, present the plan in chat AND raise a structural human gate using the initialized human handle (conventionally `user`) on a stable `gate/<topic>` thread, then wait for explicit approval on that thread. The agent-to-agent `phase:decision` message is alignment only; partner agents must not implement from it. See the Operator Gates section in /amq-cli for canonical mechanics, seeding, and guardrails.
 
 ## Reference
 

--- a/skills/amq-spec/references/spec-workflow.md
+++ b/skills/amq-spec/references/spec-workflow.md
@@ -30,7 +30,7 @@ You MUST follow every phase in order.
 | 2 | **Discuss** | Both agents | Read each other's findings and align on architecture/trade-offs/scope. | Alignment reached |
 | 3 | **Draft** | Main agent | Main agent sends concrete implementation plan draft. | Partner receives draft |
 | 4 | **Review** | Partner agent | Partner reviews draft and sends feedback; main agent revises if needed. | Plan agreed |
-| 5 | **Present** | Main agent | Main agent presents final plan to user and waits for approval. | **User approves** |
+| 5 | **Present** | Main agent | Main agent presents final plan to user in chat AND raises a structural `to:user` gate on `gate/<topic>`, then waits for approval. | **User approves on the gate thread** |
 | 6 | **Execute** | Per user direction | Implement approved plan. | — |
 
 ## Label Convention (Required)
@@ -59,7 +59,8 @@ You MUST follow every phase in order.
 
 ### User Approval Gate (Phase 5)
 - Final plan must be presented to the user in chat.
-- Wait for explicit user approval before execution.
+- ALSO raise a **structural** gate: send the approval request to the initialized human handle (conventionally `user`) on a stable `gate/<topic>` thread. See the Operator Gates section in /amq-cli for canonical mechanics, seeding, and guardrails. An agent-to-agent `phase:decision` message is NOT the approval.
+- Wait for explicit user approval (the human's reply on the gate thread) before execution. Partner agents do not implement from a spec decision alone.
 
 ## Thread Convention
 
@@ -149,8 +150,21 @@ amq send --to <partner> --kind review_response \
 Main agent must:
 1. Synthesize final plan from discussion + review
 2. Present it directly to user in chat
-3. Wait for explicit approval
-4. Not implement before approval
+3. Raise a **structural gate**: address the approval request to the initialized
+   human handle (conventionally `user`) on a stable `gate/<topic>` thread:
+   ```bash
+   # See the Operator Gates section in /amq-cli for human-handle seeding and guardrails.
+   amq send --to user --thread gate/<topic> --kind question \
+     --subject "APPROVAL: <decision>" \
+     --body "<final plan summary; what you need the human to approve>"
+   ```
+4. Wait for explicit approval (the human's reply on the `gate/<topic>` thread)
+5. Not implement before approval; partner agents must NOT implement from the
+   agent-to-agent `phase:decision` message alone
+
+The `phase:decision` message below is an **optional partner alignment marker**,
+not the user approval. See /amq-cli's Operator Gates section for the canonical
+mechanics and guardrails.
 
 Optional partner notification after alignment:
 ```bash


### PR DESCRIPTION
## Summary

Addresses #136 with a strictly docs/changelog-only operator-gates convention:

- adds a first-class `Operator Gates` section to `skills/amq-cli/SKILL.md`
- upgrades the existing Phase 5 user approval gate in `skills/amq-spec/SKILL.md` and `skills/amq-spec/references/spec-workflow.md`
- adds an Unreleased changelog entry for the operator-gates skill docs
- intentionally leaves skill/plugin versions at the current repo version (`0.36.0`) so the Release Contract keeps one version across `CHANGELOG.md`, skill metadata, and plugin metadata; the next `scripts/release.sh` bump should carry this docs change

Note: #136 originally requested a skill version bump (`0.32.1 -> 0.33.0`). This PR intentionally does not carry a standalone version bump because upstream is now `0.36.0` and a docs-only PR would otherwise desync `skills/.../SKILL.md` from `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`. Maintainer can override in review if a standalone bump is still wanted.

Scope is limited to documentation/changelog files:

- `CHANGELOG.md`
- `skills/amq-cli/SKILL.md`
- `skills/amq-spec/SKILL.md`
- `skills/amq-spec/references/spec-workflow.md`

Core/product follow-up remains separate in #139.

## #136 acceptance mapping

1. Human/operator action required -> structural message addressed to the human handle.
   - `amq-cli` now says: "the next required actor is a human" and the wait is represented structurally by addressing the human mailbox.
2. Stable gate thread: `gate/<topic>`.
   - `amq-cli` documents reusing `gate/<topic>` so the gate and resolution stay together.
3. Approvals / choices / manual tests use `--kind question` + `APPROVAL: <decision>`.
   - `amq-cli` provides that command shape after the initialization/preflight text.
4. Human closeout uses `--kind decision` + `DONE: <goal>`.
   - `amq-cli` documents the closeout command shape in the same gated section.
5. Ordinary coordination stays in normal agent threads.
   - `amq-cli` explicitly says not to send FYIs, ACKs, routine review, or agent-owned blockers to `user`.
6. Lead/CTO escalation ownership does not replace the human gate.
   - `amq-cli` says a lead/CTO decides whether to escalate, but once human action is required it still becomes a `to:user` gate.

## Binding constraints A-D

A. Recipient-as-next-actor is the only core invariant.
- The docs state: "recipient-as-next-actor" is the invariant, while `gate/<topic>`, `APPROVAL:`, and `DONE:` are a naming convention watched by tools such as amq-noc.
- The docs also state AMQ routing and classification do not special-case thread names or subject text.

B. `user` is not assumed to exist unless initialized.
- The docs state `user` must be an initialized handle and include explicit bootstrap examples.
- The wording is forward-compatible with #139: it scopes current-default behavior to current releases before #139, while keeping `amq coop init --agents claude,codex,user` as the explicit setup command.

C. Required guardrails are explicit.
- The docs state this is an observability/handoff signal, not authorization or security, and that AMQ sender identity is local convention rather than authenticated approval.
- The docs state cross-session/cross-project `to:user` gates must be intentional and that examples target the current session/project human mailbox by default.

D. Anti-pattern is explicit.
- The docs state prose such as `operator-held`, `pending operator`, or `manual approval` inside an agent-to-agent message is not a gate.

## Aviv review follow-up

- Added `--body` to the human gate reply example and verified gate `amq send` examples are not bodyless.
- DRYed spec gate docs so `amq-cli` remains the canonical mechanics/guardrails source and spec docs cross-reference it.
- Added the Unreleased changelog bullet.
- Reconciled human-handle seeding wording with #139's accepted direction.

## Validation

- `make check-skills`
- `make ci` with golangci-lint v2.12.2 temporarily first on PATH
- senior-dev adversarial re-review of the final diff

Note: the local default PATH had golangci-lint v1.64.8, which cannot read this repo's v2 golangci config. With v2.12.2, `make ci` passes.
