### PR TITLE
fix: coop exec reuses only usable existing wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report and optionally fix identity-verified stale `.wake.lock` files from
   `amq doctor --ops`, including roots whose config is missing or corrupt (#151).
 
+### Fixed
+
+- `amq coop exec --require-wake` can reuse an existing usable wake process, while
+  still failing closed when the existing wake cannot safely inject (#153).
+
 ## [0.36.0] - 2026-06-13
 ### Changed
 

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -135,6 +135,64 @@ func TestCoopExecSessionInvalidName(t *testing.T) {
 	}
 }
 
+func TestWakeReadyMessageReportsExistingWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "codex"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	got := wakeReadyMessage(root, "codex", 1000)
+	if got != "Using existing amq wake (pid 4242)" {
+		t.Fatalf("message = %q", got)
+	}
+}
+
+func TestWakeReadyMessageReportsStartedWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "codex"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	got := wakeReadyMessage(root, "codex", wakePID)
+	if got != "Started amq wake (pid 4242)" {
+		t.Fatalf("message = %q", got)
+	}
+}
+
 func sliceEq(a, b []string) bool {
 	if a == nil && b == nil {
 		return true

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -196,7 +196,7 @@ func runCoopExec(args []string) error {
 				return fmt.Errorf("create wake readiness file: %w", readyErr)
 			}
 			defer cleanupReady()
-			wakeCmd.Args = append(wakeCmd.Args, "--ready-file", readyPath)
+			wakeCmd.Args = append(wakeCmd.Args, "--ready-file", readyPath, "--accept-existing-wake")
 		}
 		// Set AM_ROOT in wake's env so the helper process resolves the same
 		// session root even if the parent shell inherited a different value.
@@ -218,7 +218,7 @@ func runCoopExec(args []string) error {
 					return err
 				}
 			}
-			_ = writeStderr("Started amq wake (pid %d)\n", wakeProc.Pid)
+			_ = writeStderr("%s\n", wakeReadyMessage(root, agentHandle, wakeProc.Pid))
 		}
 	}
 
@@ -276,6 +276,11 @@ func waitForWakeReady(proc *os.Process, readyPath string, timeout time.Duration)
 
 		select {
 		case err := <-done:
+			if _, statErr := os.Stat(readyPath); statErr == nil {
+				return nil
+			} else if !os.IsNotExist(statErr) {
+				return fmt.Errorf("check wake readiness file: %w", statErr)
+			}
 			if err != nil {
 				return fmt.Errorf("amq wake exited before becoming ready: %w", err)
 			}
@@ -285,6 +290,13 @@ func waitForWakeReady(proc *os.Process, readyPath string, timeout time.Duration)
 		case <-ticker.C:
 		}
 	}
+}
+
+func wakeReadyMessage(root, agentHandle string, startedPID int) string {
+	if inspection := inspectWakeLock(root, agentHandle); inspection.Status == wakeLockValid && inspection.PID != 0 && inspection.PID != startedPID {
+		return fmt.Sprintf("Using existing amq wake (pid %d)", inspection.PID)
+	}
+	return fmt.Sprintf("Started amq wake (pid %d)", startedPID)
 }
 
 // splitDashDash splits args at the first "--" separator.

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -70,11 +70,34 @@ type wakeLockInspection struct {
 	raw               []byte
 }
 
-var inspectWakeProcess = inspectWakeProcessPlatform
+var (
+	inspectWakeProcess = inspectWakeProcessPlatform
+	getWakeCurrentTTY  = getCurrentTTY
+	getWakeProcessSID  = unix.Getsid
+)
+
+type wakeLockAcquireOptions struct {
+	acceptExistingValid bool
+}
+
+type wakeAlreadyRunningError struct {
+	Agent      string
+	Inspection wakeLockInspection
+}
+
+func (e *wakeAlreadyRunningError) Error() string {
+	lock := e.Inspection.Lock
+	return fmt.Sprintf("wake already running for %s (pid %d on %s since %s)",
+		e.Agent, lock.PID, lock.TTY, lock.Started)
+}
 
 // acquireWakeLock attempts to acquire the wake lock for an agent's inbox.
 // Returns cleanup function and error. If another wake is running, returns error.
 func acquireWakeLock(root, me string) (cleanup func(), err error) {
+	return acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{})
+}
+
+func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions) (cleanup func(), err error) {
 	agentBase := fsq.AgentBase(root, me)
 	lockPath := filepath.Join(agentBase, ".wake.lock")
 
@@ -94,10 +117,16 @@ func acquireWakeLock(root, me string) (cleanup func(), err error) {
 		case wakeLockCreating:
 			return nil, fmt.Errorf("wake lock is being created (retry shortly)")
 		case wakeLockValid:
+			if options.acceptExistingValid {
+				if err := requireWakeLockUsable(inspection); err != nil {
+					return nil, err
+				}
+				return nil, wakeLockAlreadyRunningError(me, inspection)
+			}
 			if shouldReplaceOrphanedWakeLock(inspection) {
 				goto createLock
 			}
-			return nil, wakeLockAlreadyRunningError(me, inspection.Lock)
+			return nil, wakeLockAlreadyRunningError(me, inspection)
 		case wakeLockUnverified:
 			return nil, fmt.Errorf("wake lock for %s is unverified (pid %d on %s since %s): %s; run 'amq doctor --ops' for details",
 				me, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started, inspection.Reason)
@@ -134,13 +163,16 @@ createLock:
 	f, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		if os.IsExist(err) {
-			// Another process won the race - re-read to get its info
-			if data, readErr := os.ReadFile(lockPath); readErr == nil {
-				var winner wakeLock
-				if json.Unmarshal(data, &winner) == nil {
-					return nil, fmt.Errorf("wake already running for %s (pid %d on %s since %s)",
-						me, winner.PID, winner.TTY, winner.Started)
+			// Another process won the race; reuse only if the shared
+			// classifier proves it is the matching wake.
+			winner := inspectWakeLock(root, me)
+			if winner.Status == wakeLockValid {
+				if options.acceptExistingValid {
+					if usableErr := requireWakeLockUsable(winner); usableErr != nil {
+						return nil, usableErr
+					}
 				}
+				return nil, wakeLockAlreadyRunningError(me, winner)
 			}
 			return nil, fmt.Errorf("wake lock exists for %s (concurrent start)", me)
 		}
@@ -314,6 +346,13 @@ func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
 }
 
 func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
+	if !wakeLockNeedsReplacement(inspection) {
+		return false
+	}
+	return replaceConfirmedOrphanedWakeLock(inspection)
+}
+
+func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
 	if !inspection.IdentityConfirmed {
 		return false
 	}
@@ -323,11 +362,11 @@ func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
 	// that orphan before taking over; never signal an unconfirmed PID.
 	if strings.HasPrefix(existing.TTY, "/dev/") {
 		if _, statErr := os.Stat(existing.TTY); os.IsNotExist(statErr) {
-			return replaceConfirmedOrphanedWakeLock(inspection)
+			return true
 		}
 	}
 
-	currentTTY := getCurrentTTY()
+	currentTTY := getWakeCurrentTTY()
 	existingTTY := existing.TTY
 	if strings.HasPrefix(existingTTY, "/dev/") {
 		if real, err := filepath.EvalSymlinks(existingTTY); err == nil {
@@ -335,13 +374,24 @@ func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
 		}
 	}
 	if currentTTY != "" && currentTTY == existingTTY {
-		existingSid, sidErr := unix.Getsid(existing.PID)
-		currentSid, _ := unix.Getsid(0)
+		existingSid, sidErr := getWakeProcessSID(existing.PID)
+		currentSid, _ := getWakeProcessSID(0)
 		if sidErr == nil && existingSid != currentSid {
-			return replaceConfirmedOrphanedWakeLock(inspection)
+			return true
 		}
 	}
 	return false
+}
+
+func requireWakeLockUsable(inspection wakeLockInspection) error {
+	if !inspection.Exists || inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+		return fmt.Errorf("existing wake lock for %s is not a confirmed valid wake", inspection.Agent)
+	}
+	if wakeLockNeedsReplacement(inspection) {
+		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
+			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
+	}
+	return nil
 }
 
 func replaceConfirmedOrphanedWakeLock(inspection wakeLockInspection) bool {
@@ -406,9 +456,11 @@ func canonicalWakeRoot(root string) string {
 	return filepath.Clean(absRoot)
 }
 
-func wakeLockAlreadyRunningError(me string, lock wakeLock) error {
-	return fmt.Errorf("wake already running for %s (pid %d on %s since %s)",
-		me, lock.PID, lock.TTY, lock.Started)
+func wakeLockAlreadyRunningError(me string, inspection wakeLockInspection) error {
+	return &wakeAlreadyRunningError{
+		Agent:      me,
+		Inspection: inspection,
+	}
 }
 
 func inspectionReason(base string, err error) string {
@@ -523,6 +575,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	interruptCooldownFlag := fs.Duration("interrupt-cooldown", 7*time.Second, "Minimum time between interrupts")
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
+	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
 
 	usage := usageWithFlags(fs, "amq wake --me <agent> [options]",
 		"Background waker: injects terminal notification when messages arrive.",
@@ -649,8 +702,15 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	}
 
 	// Acquire lock to prevent duplicate wake processes
-	cleanup, err := acquireWakeLock(root, me)
+	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
+	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
+		acceptExistingValid: acceptExistingWake,
+	})
 	if err != nil {
+		var alreadyRunning *wakeAlreadyRunningError
+		if acceptExistingWake && errors.As(err, &alreadyRunning) {
+			return writeWakeReadyFile(readyFile)
+		}
 		return err
 	}
 	defer cleanup()

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -24,6 +24,24 @@ func stubInspectWakeProcess(t *testing.T, fn func(pid int) wakeProcessInfo) {
 	})
 }
 
+func stubWakeCurrentTTY(t *testing.T, fn func() string) {
+	t.Helper()
+	old := getWakeCurrentTTY
+	getWakeCurrentTTY = fn
+	t.Cleanup(func() {
+		getWakeCurrentTTY = old
+	})
+}
+
+func stubWakeProcessSID(t *testing.T, fn func(pid int) (int, error)) {
+	t.Helper()
+	old := getWakeProcessSID
+	getWakeProcessSID = fn
+	t.Cleanup(func() {
+		getWakeProcessSID = old
+	})
+}
+
 func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) string {
 	t.Helper()
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -152,6 +170,205 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 		t.Fatal("expected existing wake lock error")
 	}
 	if !strings.Contains(err.Error(), "wake already running") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an existing live wake lock: %#v", cfg)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected existing usable wake to satisfy ready file, got %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); statErr != nil {
+		t.Fatalf("ready file should exist, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		TTY:          "/dev/amq-missing-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an unusable existing wake lock: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected unusable wake lock error")
+	}
+	if !strings.Contains(err.Error(), "not usable for --require-wake") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("existing lock should remain, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *testing.T) {
+	const wakePID = 4242
+	ttyPath := filepath.Join(t.TempDir(), "amq-test-tty")
+	if err := os.WriteFile(ttyPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("write fake tty path: %v", err)
+	}
+	stubWakeCurrentTTY(t, func() string { return ttyPath })
+	sidCalls := 0
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		sidCalls++
+		if pid == wakePID {
+			return 100, nil
+		}
+		return 200, nil
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		TTY:          ttyPath,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an unusable existing wake lock: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected unusable wake lock error")
+	}
+	if !strings.Contains(err.Error(), "not usable for --require-wake") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("existing lock should remain, statErr=%v", statErr)
+	}
+	if sidCalls < 2 {
+		t.Fatalf("expected same-TTY branch to inspect wake and current SIDs, got %d calls", sidCalls)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an unverified wake lock: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected unverified wake lock error")
+	}
+	if !strings.Contains(err.Error(), "unverified") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
@@ -483,6 +700,18 @@ func TestWaitForWakeReadyFailsWhenWakeExitsBeforeReady(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "amq wake exited before becoming ready") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitForWakeReadyAcceptsReadyFileWrittenBeforeExit(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	cmd := exec.Command("sh", "-c", `: > "$1"; exit 0`, "sh", readyPath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+
+	if err := waitForWakeReady(cmd.Process, readyPath, time.Second); err != nil {
+		t.Fatalf("waitForWakeReady should accept ready file written before exit: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`amq coop exec --require-wake` can now reuse an already-running wake only when the lock is both identity-verified and usable for injection. The transient wake process writes readiness and exits when the existing wake is safe to use; otherwise it fails closed and the agent command is not launched.

This is now rebased onto merged `main` after #151, so the PR contains a single functional change on top of the stale-lock self-heal.

## Behavior

- `coop exec --require-wake` passes internal `amq wake --ready-file ... --accept-existing-wake`.
- `amq wake` writes the ready file for an existing wake only when `--ready-file` and `--accept-existing-wake` are both present.
- The accept path requires the shared wake-lock classifier to report a confirmed valid wake.
- The accept path also checks the existing wake is usable: missing TTY and same-TTY/different-session orphan candidates fail closed instead of reporting readiness.
- Stale, creating, and unverified locks still fail closed under the accept path.
- Normal duplicate `amq wake` behavior is unchanged.
- `waitForWakeReady` accepts the ready file if the transient child writes it and exits immediately.

## Tests

Added/updated coverage for:

- existing usable wake writes the ready file;
- ready-file without `--accept-existing-wake` still rejects an existing wake;
- missing-TTY existing wake rejects and does not write the ready file;
- same-TTY/different-session existing wake rejects and does not write the ready file;
- unverified existing wake remains fail-closed;
- ready file written just before child exit is accepted;
- `Started amq wake` vs `Using existing amq wake` status text.

Verified locally: `go test ./internal/cli ...` focused set and `make ci`.

---
Co-op: authored by Ohad, completed with Codex review/fixes.
