### PR TITLE
draft: amq wake repair from saved inject target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approval gates (#136).
 - Report and optionally fix identity-verified stale `.wake.lock` files from
   `amq doctor --ops`, including roots whose config is missing or corrupt (#151).
+- Add `amq wake repair` plus `coop exec --wake-inject-via` support so managed
+  launchers can restart a dead external-injector wake for a still-running agent
+  session from a digest-bound, private saved target (#154).
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,12 +173,13 @@ amq dlq list --me <agent> [--new | --cur] [--json]
 amq dlq read --me <agent> --id <dlq_id> [--json]
 amq dlq retry --me <agent> --id <dlq_id> [--all] [--force]
 amq dlq purge --me <agent> [--older-than <duration>] [--dry-run] [--yes]
-amq wake --me <agent> [--inject-cmd <cmd>] [--inject-via <executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>]
+amq wake --me <agent> [--inject-cmd <cmd>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>]
+amq wake repair --me <agent> [--root <path>] [--json]
 amq upgrade
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--json]
 amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>]
 amq coop init [--root <path>] [--agents <a,b,c>] [--force] [--json]
-amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-wake] [--require-wake] [-y] <command> [-- <command-flags>]
+amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-wake] [--require-wake] [--wake-inject-via <absolute-executable>] [--wake-inject-arg <arg>...] [-y] <command> [-- <command-flags>]
 amq swarm list [--json]
 amq swarm join --team <name> --me <agent> [--agent-id <id>] [--type codex|external] [--json]
 amq swarm leave --team <name> --agent-id <id> [--json]
@@ -335,6 +336,23 @@ Use `--force` with retry to override the max retry limit.
 - Wake lock health (`--fix-wake-locks` removes stale locks)
 - Integration hints for Kanban and Symphony
 
+Wake lock states are intentionally conservative:
+
+- `stale`: AMQ proved the recorded PID is gone, mismatched, or not the same `amq wake`; `amq doctor --ops --fix-wake-locks` re-inspects and removes only these locks.
+- `unverified`: AMQ could not prove either ownership or staleness, so startup fails closed and doctor leaves the lock in place. Confirm the PID/root/agent manually before removing the `.wake.lock`.
+
+Live wake repair is explicit: `amq wake repair --me <agent>` may remove a
+proven-stale lock and start a fresh wake only when the stale lock was created
+for `--inject-via`, and `agents/<agent>/.wake.target` exists with a digest that
+matches the lock's repair metadata. `.wake.target` is mode `0600`, contains only
+`mode:"inject-via"`, an absolute executable path, and fixed argv. Raw TTY wake
+has no repair target; repair must refuse raw locks, leftover targets from old
+locks, and `unverified` locks. Repaired wake stdout/stderr goes to
+`agents/<agent>/.wake.repair.log`; repair itself must not keep stdout/stderr
+pipes open after its JSON/text output exits. `doctor --ops` may report
+`target_present` and `repair_available`, but must remain diagnostic-only and
+never spawn a wake process.
+
 Use `amq doctor --ops --json` for machine-readable health output.
 
 ## Multi-Agent Coordination
@@ -388,6 +406,9 @@ amq coop exec --session feature-a claude               # Isolated session
 ```
 
 Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments). Use `--require-wake` in managed launchers that should refuse to start an agent unless the wake process starts and acquires its lock.
+Use `--wake-inject-via /absolute/path/to/injector` plus repeated
+`--wake-inject-arg` values when a launcher has a terminal-specific injector and
+wants later `amq wake repair` to work without restarting the agent TUI.
 
 **For scripts/CI** (non-interactive):
 ```bash
@@ -413,7 +434,7 @@ For a local terminal transport that can receive notifications without a
 controlling TTY, run wake with an explicit external injector:
 ```bash
 amq wake --me orchestrator \
-  --inject-via ghostty-bridge \
+  --inject-via /absolute/path/to/ghostty-bridge \
   --inject-arg exec \
   --inject-arg "$TERMINAL_ID"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,10 +344,11 @@ Wake lock states are intentionally conservative:
 Live wake repair is explicit: `amq wake repair --me <agent>` may remove a
 proven-stale lock and start a fresh wake only when the stale lock was created
 for `--inject-via`, and `agents/<agent>/.wake.target` exists with a digest that
-matches the lock's repair metadata. `.wake.target` is mode `0600`, contains only
-`mode:"inject-via"`, an absolute executable path, and fixed argv. Raw TTY wake
-has no repair target; repair must refuse raw locks, leftover targets from old
-locks, and `unverified` locks. Repaired wake stdout/stderr goes to
+matches the lock's repair metadata. `.wake.target` is mode `0600` and stores
+schema metadata, root, agent, creation time, `mode:"inject-via"`, an absolute
+executable path, and fixed argv. Raw TTY wake has no repair target; repair must
+refuse raw locks, leftover targets from old locks, and `unverified` locks.
+Repaired wake stdout/stderr goes to
 `agents/<agent>/.wake.repair.log`; repair itself must not keep stdout/stderr
 pipes open after its JSON/text output exits. `doctor --ops` may report
 `target_present` and `repair_available`, but must remain diagnostic-only and
@@ -408,7 +409,9 @@ amq coop exec --session feature-a claude               # Isolated session
 Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments). Use `--require-wake` in managed launchers that should refuse to start an agent unless the wake process starts and acquires its lock.
 Use `--wake-inject-via /absolute/path/to/injector` plus repeated
 `--wake-inject-arg` values when a launcher has a terminal-specific injector and
-wants later `amq wake repair` to work without restarting the agent TUI.
+wants later `amq wake repair` to work without restarting the agent TUI. Repair
+metadata is written only when this invocation starts a new wake; a reused
+existing wake must already have repair metadata to be repairable.
 
 **For scripts/CI** (non-interactive):
 ```bash

--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ amq coop exec --session feature-a codex
 
 Managed launchers can add `--require-wake` to fail instead of launching the agent when the wake watcher cannot start.
 Launchers that use an external injector can add `--wake-inject-via /absolute/path/to/injector`
-and repeated `--wake-inject-arg` values. That stores a repair target so
-`amq wake repair` can restart wake later without restarting the agent TUI.
+and repeated `--wake-inject-arg` values. When that invocation starts a new wake,
+the wake stores a repair target so `amq wake repair` can restart wake later
+without restarting the agent TUI. If `--require-wake` reuses an existing wake,
+that wake must already have repair metadata to be repairable.
 
 ### 3. Send & Receive
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ amq coop exec --session feature-a codex
 ```
 
 Managed launchers can add `--require-wake` to fail instead of launching the agent when the wake watcher cannot start.
+Launchers that use an external injector can add `--wake-inject-via /absolute/path/to/injector`
+and repeated `--wake-inject-arg` values. That stores a repair target so
+`amq wake repair` can restart wake later without restarting the agent TUI.
 
 ### 3. Send & Receive
 
@@ -155,7 +158,27 @@ amq doctor
 amq doctor --ops
 amq doctor --ops --json
 amq doctor --ops --fix-wake-locks
+amq wake repair --me codex
 ```
+
+Wake locks reported by `doctor --ops` can be `stale`, `unverified`, or, in JSON
+output, any current lock state. With `--fix-wake-locks`, fixed and error states
+can also appear. `stale` means AMQ proved the recorded owner is gone or is not
+the same wake process, so `--fix-wake-locks` can remove the lock after a fresh
+re-check. `unverified` means AMQ could not prove ownership either way, such as a
+legacy lock with a live PID but no process-start token, a hostname mismatch, or
+an unsupported platform. AMQ leaves `unverified` locks in place; inspect the PID
+and remove the named `.wake.lock` manually only after confirming no matching
+`amq wake` still owns that agent/root.
+
+`amq wake repair` is an explicit live-session repair path. It only runs when
+the lock is proven `stale`, the lock was created for `--inject-via`, and the
+agent has a saved `agents/<agent>/.wake.target` whose digest matches the lock's
+repair metadata. It refuses raw terminal wake targets, leftover targets from old
+locks, and `unverified` locks to avoid double-injecting into an active session
+or injecting into the wrong terminal. Repaired wake output goes to
+`agents/<agent>/.wake.repair.log`; `doctor --ops` can report whether repair is
+available, but it never starts a wake process.
 
 ## Message Kinds & Priority
 
@@ -288,7 +311,7 @@ Common command groups:
 | Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `watch`, `monitor`, `receipts` |
 | Collaboration | `coop init`, `coop exec`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
-| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
+| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake repair`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 
 For the full CLI syntax, examples, and message schema, see [CLAUDE.md](CLAUDE.md).
 
@@ -338,7 +361,7 @@ Files are universal, debuggable, and work everywhere. No connection strings, no 
 Those require infrastructure. AMQ is for local inter-process communication where agents share a filesystem. No server to configure or keep running.
 
 **What about Windows?**
-The core queue works on Windows. The `amq wake` notification feature requires WSL.
+The core queue works on Windows. The `amq wake` notification feature requires WSL. `doctor --ops` can still report wake lock files on unsupported platforms, but it cannot verify live wake process identity there and will not auto-fix `unverified` locks.
 
 **Is this production-ready?**
 For local development workflows, yes. AMQ is intentionally simple—it's not trying to be a distributed message broker.

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -3,6 +3,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -122,6 +124,47 @@ func TestCoopExecRequireWakeRejectsNoWake(t *testing.T) {
 	}
 	if !containsStr(err.Error(), "--require-wake cannot be used with --no-wake") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestCoopExecWakeInjectViaValidation(t *testing.T) {
+	nonExecutable := filepath.Join(secureTempDirForTest(t), "injector")
+	if err := os.WriteFile(nonExecutable, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "blank inject via",
+			args:    []string{"--wake-inject-via", "   ", "claude"},
+			wantErr: "--wake-inject-via must not be blank",
+		},
+		{
+			name:    "inject arg without inject via",
+			args:    []string{"--wake-inject-arg", "exec", "claude"},
+			wantErr: "--wake-inject-arg requires --wake-inject-via",
+		},
+		{
+			name:    "non executable injector",
+			args:    []string{"--wake-inject-via", nonExecutable, "claude"},
+			wantErr: "not executable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runCoopExec(tt.args)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !containsStr(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -28,6 +28,9 @@ func runCoopExec(args []string) error {
 	noInitFlag := fs.Bool("no-init", false, "Don't auto-initialize if .amqrc is missing")
 	noWakeFlag := fs.Bool("no-wake", false, "Don't start amq wake in background")
 	requireWakeFlag := fs.Bool("require-wake", false, "Fail if amq wake cannot start and acquire its lock")
+	wakeInjectViaFlag := fs.String("wake-inject-via", "", "Start wake with this absolute --inject-via executable, enabling later amq wake repair")
+	var wakeInjectArgFlags multiStringFlag
+	fs.Var(&wakeInjectArgFlags, "wake-inject-arg", "Fixed argument for wake --inject-via before the payload (repeatable)")
 	yesFlag := fs.Bool("y", false, "Skip confirmation prompts")
 
 	usage := usageWithFlags(fs, "amq coop exec [options] <command> [-- <command-flags>]",
@@ -45,6 +48,7 @@ func runCoopExec(args []string) error {
 		"  amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Codex with flags",
 		"  amq coop exec --session feature-x claude          # Isolated session",
 		"  amq coop exec --root .agent-mail/auth claude      # Explicit root (no session default)",
+		"  amq coop exec --wake-inject-via /path/to/injector codex",
 		"  amq coop exec --me myagent bash                   # Debug shell with AMQ env",
 	)
 
@@ -55,6 +59,18 @@ func runCoopExec(args []string) error {
 	}
 	if *noWakeFlag && *requireWakeFlag {
 		return UsageError("--require-wake cannot be used with --no-wake")
+	}
+	wakeInjectVia := strings.TrimSpace(*wakeInjectViaFlag)
+	if *wakeInjectViaFlag != "" && wakeInjectVia == "" {
+		return UsageError("--wake-inject-via must not be blank")
+	}
+	if wakeInjectVia == "" && len(wakeInjectArgFlags) > 0 {
+		return UsageError("--wake-inject-arg requires --wake-inject-via")
+	}
+	if wakeInjectVia != "" {
+		if err := validateWakeInjectViaPath(wakeInjectVia); err != nil {
+			return UsageError("--wake-inject-via: %v", err)
+		}
 	}
 
 	remaining := fs.Args()
@@ -186,7 +202,7 @@ func runCoopExec(args []string) error {
 			amqBin = "amq"
 		}
 
-		wakeCmd := exec.Command(amqBin, "--no-update-check", "wake", "--me", agentHandle, "--root", root)
+		wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, wakeInjectVia, []string(wakeInjectArgFlags))...)
 		var readyPath string
 		var cleanupReady func()
 		if *requireWakeFlag {
@@ -242,6 +258,17 @@ func runCoopExec(args []string) error {
 		_ = wakeProc.Kill()
 	}
 	return execErr
+}
+
+func buildCoopWakeArgs(agentHandle, root, injectVia string, injectArgs []string) []string {
+	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root}
+	if injectVia != "" {
+		args = append(args, "--inject-via", injectVia)
+		for _, arg := range injectArgs {
+			args = append(args, "--inject-arg", arg)
+		}
+	}
+	return args
 }
 
 func newWakeReadyFile() (string, func(), error) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -201,6 +201,15 @@ func runDoctor(args []string) error {
 			if wl.Fix != "" && wl.Status == string(wakeLockStale) {
 				line += " fix=" + wl.Fix
 			}
+			if wl.TargetPresent {
+				line += " target=" + wl.Target
+			}
+			if wl.TargetReason != "" {
+				line += " target_reason=" + wl.TargetReason
+			}
+			if wl.RepairAvailable && wl.Status == string(wakeLockStale) {
+				line += " repair=" + wl.Repair
+			}
 			if err := writeStdoutLine(line); err != nil {
 				return err
 			}

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -203,7 +203,7 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 		}
 		if inspection.Status == wakeLockStale {
 			lock.Fix = fixWakeLocksCommand
-			if lock.TargetPresent && lock.TargetReason == "" {
+			if lock.TargetPresent && lock.TargetReason == "" && validateWakeLockRepairable(inspection) == nil {
 				lock.RepairAvailable = true
 				lock.Repair = wakeRepairCommand(root, agent)
 			}

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -43,14 +43,19 @@ type opsHint struct {
 }
 
 type opsWakeLock struct {
-	Status  string `json:"status"`
-	Agent   string `json:"agent"`
-	Root    string `json:"root"`
-	Lock    string `json:"lock"`
-	PID     int    `json:"pid,omitempty"`
-	Reason  string `json:"reason,omitempty"`
-	Fix     string `json:"fix,omitempty"`
-	Removed bool   `json:"removed,omitempty"`
+	Status          string `json:"status"`
+	Agent           string `json:"agent"`
+	Root            string `json:"root"`
+	Lock            string `json:"lock"`
+	PID             int    `json:"pid,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	Fix             string `json:"fix,omitempty"`
+	Removed         bool   `json:"removed,omitempty"`
+	Target          string `json:"target,omitempty"`
+	TargetPresent   bool   `json:"target_present,omitempty"`
+	TargetReason    string `json:"target_reason,omitempty"`
+	Repair          string `json:"repair,omitempty"`
+	RepairAvailable bool   `json:"repair_available,omitempty"`
 }
 
 const fixWakeLocksCommand = "amq doctor --ops --fix-wake-locks"
@@ -184,25 +189,74 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 			PID:    inspection.PID,
 			Reason: inspection.Reason,
 		}
+		target, exists, targetErr := readWakeTarget(root, agent)
+		if exists {
+			lock.Target = wakeTargetPath(root, agent)
+			lock.TargetPresent = true
+			if targetErr != nil {
+				lock.TargetReason = targetErr.Error()
+			} else if err := validateWakeTarget(target, root, agent); err != nil {
+				lock.TargetReason = err.Error()
+			} else if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
+				lock.TargetReason = err.Error()
+			}
+		}
 		if inspection.Status == wakeLockStale {
 			lock.Fix = fixWakeLocksCommand
+			if lock.TargetPresent && lock.TargetReason == "" {
+				lock.RepairAvailable = true
+				lock.Repair = wakeRepairCommand(root, agent)
+			}
 			if fix {
 				recheck := inspectWakeLock(root, agent)
 				if recheck.Status != wakeLockStale {
 					lock.Status = string(recheck.Status)
 					lock.Reason = "wake lock changed before fix"
+					lock.RepairAvailable = false
+					lock.Repair = ""
 				} else if err := removeWakeLockIfUnchanged(recheck); err != nil {
 					lock.Status = "error"
 					lock.Reason = err.Error()
+					lock.RepairAvailable = false
+					lock.Repair = ""
 				} else {
 					lock.Status = "fixed"
 					lock.Removed = true
+					lock.RepairAvailable = false
+					lock.Repair = ""
 				}
 			}
 		}
 		locks = append(locks, lock)
 	}
 	return locks
+}
+
+func wakeRepairCommand(root, agent string) string {
+	return fmt.Sprintf("amq wake repair --root %s --me %s", shellQuoteArg(root), shellQuoteArg(agent))
+}
+
+func shellQuoteArg(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return false
+		case r >= 'A' && r <= 'Z':
+			return false
+		case r >= '0' && r <= '9':
+			return false
+		case strings.ContainsRune("@%_+=:,./-", r):
+			return false
+		default:
+			return true
+		}
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func checkGlobalRootHint() []opsHint {

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -311,7 +311,7 @@ func TestRunOpsChecks_ReportsWakeRepairAvailabilityWithoutSpawning(t *testing.T)
 	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write injector: %v", err)
 	}
-	target := newWakeTarget(root, "alice", injector, []string{"exec"})
+	target := mustNewWakeTargetForTest(t, root, "alice", injector, []string{"exec"})
 	lockPath := writeWakeLockForTest(t, root, "alice", bindWakeLockToTarget(wakeLock{
 		PID:        999999999,
 		Executable: "/opt/homebrew/bin/amq",
@@ -369,7 +369,7 @@ func TestRunOpsChecks_StaleRawLockWithLeftoverTargetHasNoRepair(t *testing.T) {
 	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write injector: %v", err)
 	}
-	if err := writeWakeTarget(root, "alice", newWakeTarget(root, "alice", injector, []string{"exec"})); err != nil {
+	if err := writeWakeTarget(root, "alice", mustNewWakeTargetForTest(t, root, "alice", injector, []string{"exec"})); err != nil {
 		t.Fatalf("write wake target: %v", err)
 	}
 
@@ -424,7 +424,7 @@ func TestRunOpsChecks_UnverifiedWakeLockHasTargetButNoRepair(t *testing.T) {
 	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write injector: %v", err)
 	}
-	if err := writeWakeTarget(root, "alice", newWakeTarget(root, "alice", injector, nil)); err != nil {
+	if err := writeWakeTarget(root, "alice", mustNewWakeTargetForTest(t, root, "alice", injector, nil)); err != nil {
 		t.Fatalf("write wake target: %v", err)
 	}
 

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRunOpsChecks_BasicAgentStats(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 
 	// Set up agent dirs and config
 	agents := []string{"alice", "bob"}
@@ -108,7 +108,7 @@ func TestRunOpsChecks_BasicAgentStats(t *testing.T) {
 }
 
 func TestRunOpsChecks_NoConfig(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("ensure root dirs: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestRunOpsChecks_NoConfig(t *testing.T) {
 }
 
 func TestRunOpsChecks_ReportsAndFixesStaleWakeLockWithoutConfig(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "alice", wakeLock{
 		PID:        999999999,
 		Executable: "/opt/homebrew/bin/amq",
@@ -188,7 +188,7 @@ func TestRunOpsChecks_ReportsAndFixesStaleWakeLockWithoutConfig(t *testing.T) {
 }
 
 func TestRunOpsChecks_RootSourceThreaded(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("ensure root dirs: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestRunOpsChecks_RootSourceThreaded(t *testing.T) {
 }
 
 func TestRunOpsChecks_ReportsStaleWakeLock(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("ensure root dirs: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestRunOpsChecks_ReportsStaleWakeLock(t *testing.T) {
 }
 
 func TestRunOpsChecks_FixesStaleWakeLock(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("ensure root dirs: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestRunOpsChecks_FixesStaleWakeLock(t *testing.T) {
 }
 
 func TestRunOpsChecks_ReportsWakeRepairAvailabilityWithoutSpawning(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("ensure root dirs: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestRunOpsChecks_ReportsWakeRepairAvailabilityWithoutSpawning(t *testing.T)
 		t.Fatalf("write config: %v", err)
 	}
 
-	injector := filepath.Join(t.TempDir(), "injector")
+	injector := filepath.Join(secureTempDirForTest(t), "injector")
 	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write injector: %v", err)
 	}
@@ -346,7 +346,7 @@ func TestRunOpsChecks_ReportsWakeRepairAvailabilityWithoutSpawning(t *testing.T)
 }
 
 func TestRunOpsChecks_StaleRawLockWithLeftoverTargetHasNoRepair(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("ensure root dirs: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestRunOpsChecks_StaleRawLockWithLeftoverTargetHasNoRepair(t *testing.T) {
 		PID:        999999999,
 		Executable: "/opt/homebrew/bin/amq",
 	})
-	injector := filepath.Join(t.TempDir(), "injector")
+	injector := filepath.Join(secureTempDirForTest(t), "injector")
 	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write injector: %v", err)
 	}
@@ -390,7 +390,7 @@ func TestRunOpsChecks_StaleRawLockWithLeftoverTargetHasNoRepair(t *testing.T) {
 }
 
 func TestRunOpsChecks_UnverifiedWakeLockHasTargetButNoRepair(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("ensure root dirs: %v", err)
 	}
@@ -420,7 +420,7 @@ func TestRunOpsChecks_UnverifiedWakeLockHasTargetButNoRepair(t *testing.T) {
 		}
 		return wakeProcessInfo{PID: gotPID}
 	})
-	injector := filepath.Join(t.TempDir(), "injector")
+	injector := filepath.Join(secureTempDirForTest(t), "injector")
 	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write injector: %v", err)
 	}

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -282,8 +283,172 @@ func TestRunOpsChecks_FixesStaleWakeLock(t *testing.T) {
 	if !got.Removed {
 		t.Fatal("expected Removed=true")
 	}
+	if got.RepairAvailable || got.Repair != "" {
+		t.Fatalf("repair should be cleared after fix: %#v", got)
+	}
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Fatalf("lock should be removed, stat err=%v", err)
+	}
+}
+
+func TestRunOpsChecks_ReportsWakeRepairAvailabilityWithoutSpawning(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	injector := filepath.Join(t.TempDir(), "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+	target := newWakeTarget(root, "alice", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "alice", bindWakeLockToTarget(wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	if err := writeWakeTarget(root, "alice", target); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) {
+		t.Fatalf("status = %q, want stale", got.Status)
+	}
+	if !got.TargetPresent {
+		t.Fatalf("target_present = false, want true")
+	}
+	if got.TargetReason != "" {
+		t.Fatalf("target_reason = %q, want empty", got.TargetReason)
+	}
+	if !got.RepairAvailable {
+		t.Fatal("repair_available = false, want true")
+	}
+	if got.Repair != wakeRepairCommand(root, "alice") {
+		t.Fatalf("repair = %q, want %q", got.Repair, wakeRepairCommand(root, "alice"))
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("doctor report should not remove lock: %v", err)
+	}
+}
+
+func TestRunOpsChecks_StaleRawLockWithLeftoverTargetHasNoRepair(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	writeWakeLockForTest(t, root, "alice", wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	injector := filepath.Join(t.TempDir(), "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+	if err := writeWakeTarget(root, "alice", newWakeTarget(root, "alice", injector, []string{"exec"})); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) {
+		t.Fatalf("status = %q, want stale", got.Status)
+	}
+	if got.RepairAvailable || got.Repair != "" {
+		t.Fatalf("repair should not be available for unbound target: %#v", got)
+	}
+	if !strings.Contains(got.TargetReason, "not created for an inject-via repair target") {
+		t.Fatalf("target_reason = %q, want unbound target reason", got.TargetReason)
+	}
+}
+
+func TestRunOpsChecks_UnverifiedWakeLockHasTargetButNoRepair(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	const pid = 4242
+	writeWakeLockForTest(t, root, "alice", wakeLock{
+		PID:        pid,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID == pid {
+			return wakeProcessInfo{
+				PID:        gotPID,
+				Running:    true,
+				Executable: "/opt/homebrew/bin/amq",
+			}
+		}
+		return wakeProcessInfo{PID: gotPID}
+	})
+	injector := filepath.Join(t.TempDir(), "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+	if err := writeWakeTarget(root, "alice", newWakeTarget(root, "alice", injector, nil)); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockUnverified) {
+		t.Fatalf("status = %q, want unverified", got.Status)
+	}
+	if !got.TargetPresent {
+		t.Fatal("target_present = false, want true")
+	}
+	if got.RepairAvailable || got.Repair != "" {
+		t.Fatalf("repair should not be available for unverified lock: %#v", got)
+	}
+}
+
+func TestWakeRepairCommandQuotesRoot(t *testing.T) {
+	got := wakeRepairCommand("/tmp/amq root/it's", "alice")
+	want := "amq wake repair --root '/tmp/amq root/it'\"'\"'s' --me alice"
+	if got != want {
+		t.Fatalf("wakeRepairCommand = %q, want %q", got, want)
 	}
 }
 

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -146,3 +146,78 @@ func TestRunOpsChecksDoesNotAdvertiseRepairForTamperedStaleLock(t *testing.T) {
 		t.Fatalf("repair advertised for tampered stale lock: %#v", got)
 	}
 }
+
+func TestRunOpsChecksDoesNotAdvertiseRepairForLiveIdentityMismatchLock(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		lock       wakeLock
+		process    wakeProcessInfo
+		wantReason string
+	}{
+		{
+			name: "boot id mismatch",
+			lock: wakeLock{
+				PID:          4242,
+				ProcessStart: "start-token",
+				BootID:       "recorded-boot",
+				Executable:   "/opt/homebrew/bin/amq",
+			},
+			process: wakeProcessInfo{
+				PID:        4242,
+				Running:    true,
+				StartToken: "start-token",
+				BootID:     "actual-boot",
+				Executable: "/opt/homebrew/bin/amq",
+			},
+			wantReason: "boot id mismatch",
+		},
+		{
+			name: "process start mismatch",
+			lock: wakeLock{
+				PID:          4242,
+				ProcessStart: "recorded-start",
+				BootID:       "same-boot",
+				Executable:   "/opt/homebrew/bin/amq",
+			},
+			process: wakeProcessInfo{
+				PID:        4242,
+				Running:    true,
+				StartToken: "actual-start",
+				BootID:     "same-boot",
+				Executable: "/opt/homebrew/bin/amq",
+			},
+			wantReason: "process start time mismatch",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatalf("write wake target: %v", err)
+			}
+			writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(tc.lock, target))
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				proc := tc.process
+				proc.PID = pid
+				proc.Args = []string{"amq", "wake", "--root", root, "--me", "codex"}
+				return proc
+			})
+
+			result := runOpsChecks(root, "test", false)
+			if len(result.WakeLocks) != 1 {
+				t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+			}
+			got := result.WakeLocks[0]
+			if got.Status != string(wakeLockStale) || got.Reason != tc.wantReason {
+				t.Fatalf("unexpected wake lock: %#v", got)
+			}
+			if !got.TargetPresent || got.TargetReason != "" {
+				t.Fatalf("unexpected target fields: %#v", got)
+			}
+			if got.RepairAvailable || got.Repair != "" {
+				t.Fatalf("repair advertised for live identity mismatch: %#v", got)
+			}
+		})
+	}
+}

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -1,0 +1,148 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestRunOpsChecksRejectsSymlinkAndFIFOWakeLocks(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		setup     func(t *testing.T, path string)
+		wantError string
+	}{
+		{
+			name: "symlink",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				target := filepath.Join(t.TempDir(), "lock.json")
+				if err := os.WriteFile(target, []byte(`{"pid":4242}`), 0o600); err != nil {
+					t.Fatalf("write target lock: %v", err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatalf("symlink lock: %v", err)
+				}
+			},
+			wantError: "must not be a symlink",
+		},
+		{
+			name: "fifo",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := syscall.Mkfifo(path, 0o600); err != nil {
+					t.Fatalf("mkfifo lock: %v", err)
+				}
+			},
+			wantError: "must be a regular file",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			agentBase := fsq.AgentBase(root, "codex")
+			if err := os.MkdirAll(agentBase, 0o700); err != nil {
+				t.Fatalf("mkdir agent base: %v", err)
+			}
+			tc.setup(t, filepath.Join(agentBase, ".wake.lock"))
+
+			done := make(chan *doctorOpsResult, 1)
+			go func() {
+				done <- runOpsChecks(root, "test", false)
+			}()
+
+			select {
+			case result := <-done:
+				if len(result.WakeLocks) != 1 {
+					t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+				}
+				got := result.WakeLocks[0]
+				if got.Status != string(wakeLockUnverified) || !strings.Contains(got.Reason, tc.wantError) {
+					t.Fatalf("unexpected wake lock: %#v", got)
+				}
+				if got.RepairAvailable || got.Repair != "" {
+					t.Fatalf("repair advertised for unsafe lock: %#v", got)
+				}
+			case <-time.After(250 * time.Millisecond):
+				t.Fatal("doctor ops blocked on wake lock")
+			}
+		})
+	}
+}
+
+func TestRunOpsChecksRejectsFIFOWakeTargetWithoutBlocking(t *testing.T) {
+	root := secureTempDirForTest(t)
+	agentBase := fsq.AgentBase(root, "codex")
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		t.Fatalf("mkdir agent base: %v", err)
+	}
+	targetPath := wakeTargetPath(root, "codex")
+	if err := syscall.Mkfifo(targetPath, 0o600); err != nil {
+		t.Fatalf("mkfifo wake target: %v", err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeTargetInjectVia,
+		TargetDigest: "sha256:fake",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	done := make(chan *doctorOpsResult, 1)
+	go func() {
+		done <- runOpsChecks(root, "test", false)
+	}()
+
+	select {
+	case result := <-done:
+		if len(result.WakeLocks) != 1 {
+			t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+		}
+		got := result.WakeLocks[0]
+		if !got.TargetPresent || !strings.Contains(got.TargetReason, "must be a regular file") {
+			t.Fatalf("unexpected target fields: %#v", got)
+		}
+		if got.RepairAvailable || got.Repair != "" {
+			t.Fatalf("repair advertised for unsafe target: %#v", got)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("doctor ops blocked on wake target")
+	}
+}
+
+func TestRunOpsChecksDoesNotAdvertiseRepairForTamperedStaleLock(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+	writeWakeLockExactForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:   4242,
+		Root:  filepath.Join(root, "other-root"),
+		Agent: "codex",
+	}, target))
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	result := runOpsChecks(root, "test", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) || got.Reason != "root mismatch" {
+		t.Fatalf("unexpected wake lock: %#v", got)
+	}
+	if got.RepairAvailable || got.Repair != "" {
+		t.Fatalf("repair advertised for tampered stale lock: %#v", got)
+	}
+}

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -63,7 +63,14 @@ func init() {
 				{Name: "purge", Summary: "Permanently remove DLQ messages", Handler: runDLQPurge},
 			},
 		},
-		{Name: "wake", Summary: "Background waker (TIOCSTI injection, experimental)", Handler: runWake},
+		{
+			Name:    "wake",
+			Summary: "Background waker (TIOCSTI injection, experimental)",
+			Handler: runWake,
+			Children: []CommandInfo{
+				{Name: "repair", Summary: "Restart a proven-stale wake from a saved inject-via target", Handler: runWake},
+			},
+		},
 		{Name: "upgrade", Summary: "Upgrade amq to the latest release", Handler: runUpgradeRegistry},
 		{Name: "env", Summary: "Output shell commands to set environment variables", Handler: runEnv},
 		{

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -449,6 +449,9 @@ func injectVia(cfg *wakeConfig, text string) error {
 	if executable == "" {
 		return fmt.Errorf("inject-via command is blank")
 	}
+	if err := validateWakeInjectViaPath(executable); err != nil {
+		return err
+	}
 
 	timeout := cfg.injectTimeout
 	if timeout <= 0 {

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -84,7 +84,7 @@ func inspectWakeLock(root, me string) wakeLockInspection {
 		LockPath: lockPath,
 	}
 
-	data, err := os.ReadFile(lockPath)
+	data, err := readWakeLockFile(lockPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return inspection
@@ -114,6 +114,42 @@ func inspectWakeLock(root, me string) wakeLockInspection {
 	inspection.Process = inspectWakeProcess(existing.PID)
 	classifyWakeLock(root, me, &inspection)
 	return inspection
+}
+
+func readWakeLockFile(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateWakeLockFile(path, info); err != nil {
+		return nil, err
+	}
+	file, err := openWakeMetadataFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat wake lock: %w", err)
+	}
+	if err := validateWakeLockFile(path, openedInfo); err != nil {
+		return nil, err
+	}
+	return readWakeMetadata(file, "wake lock", path)
+}
+
+func validateWakeLockFile(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("wake lock %s must not be a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("wake lock %s must be a regular file", path)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return fmt.Errorf("wake lock %s mode is %o, want 0600", path, got)
+	}
+	return validateWakeTargetPathOwnership("wake lock", path, info)
 }
 
 func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
@@ -208,7 +244,7 @@ func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
 }
 
 func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
-	current, err := os.ReadFile(inspection.LockPath)
+	current, err := readWakeLockFile(inspection.LockPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -1,0 +1,343 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// wakeLock represents the lock file content for wake process deduplication.
+type wakeLock struct {
+	PID          int      `json:"pid"`
+	TTY          string   `json:"tty"`
+	Root         string   `json:"root"`                    // Absolute path to disambiguate relative AM_ROOT
+	Agent        string   `json:"agent,omitempty"`         // Agent handle that owns this lock
+	Hostname     string   `json:"hostname,omitempty"`      // Host that created the lock
+	Started      string   `json:"started"`                 // Wall-clock diagnostic timestamp
+	ProcessStart string   `json:"process_start,omitempty"` // Kernel process start token, guards PID reuse
+	BootID       string   `json:"boot_id,omitempty"`       // Boot identity paired with ProcessStart when available
+	Executable   string   `json:"executable,omitempty"`    // Diagnostic process executable basename/path
+	Args         []string `json:"args,omitempty"`          // Diagnostic argv when available
+	WakeMode     string   `json:"wake_mode,omitempty"`     // Injection mode that created repair metadata
+	TargetDigest string   `json:"target_digest,omitempty"` // Binds .wake.target to this lock instance
+}
+
+type wakeProcessInfo struct {
+	PID          int
+	Running      bool
+	StartToken   string
+	BootID       string
+	Executable   string
+	Args         []string
+	InspectError error
+}
+
+type wakeLockStatus string
+
+const (
+	wakeLockMissing    wakeLockStatus = "missing"
+	wakeLockValid      wakeLockStatus = "valid"
+	wakeLockStale      wakeLockStatus = "stale"
+	wakeLockCreating   wakeLockStatus = "creating"
+	wakeLockUnverified wakeLockStatus = "unverified"
+)
+
+type wakeLockInspection struct {
+	Exists            bool
+	Status            wakeLockStatus
+	Reason            string
+	Root              string
+	Agent             string
+	LockPath          string
+	PID               int
+	Lock              wakeLock
+	Process           wakeProcessInfo
+	IdentityConfirmed bool
+	raw               []byte
+}
+
+var inspectWakeProcess = inspectWakeProcessPlatform
+
+type wakeAlreadyRunningError struct {
+	Agent      string
+	Inspection wakeLockInspection
+}
+
+func (e *wakeAlreadyRunningError) Error() string {
+	lock := e.Inspection.Lock
+	return fmt.Sprintf("wake already running for %s (pid %d on %s since %s)",
+		e.Agent, lock.PID, lock.TTY, lock.Started)
+}
+
+func inspectWakeLock(root, me string) wakeLockInspection {
+	lockPath := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
+	inspection := wakeLockInspection{
+		Status:   wakeLockMissing,
+		Root:     canonicalWakeRoot(root),
+		Agent:    me,
+		LockPath: lockPath,
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return inspection
+		}
+		inspection.Exists = true
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = fmt.Sprintf("cannot read lock: %v", err)
+		return inspection
+	}
+
+	inspection.Exists = true
+	inspection.raw = data
+	var existing wakeLock
+	if err := json.Unmarshal(data, &existing); err != nil {
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) < 2*time.Second {
+			inspection.Status = wakeLockCreating
+			inspection.Reason = "lock is being created"
+			return inspection
+		}
+		inspection.Status = wakeLockStale
+		inspection.Reason = "invalid lock json"
+		return inspection
+	}
+
+	inspection.Lock = existing
+	inspection.PID = existing.PID
+	inspection.Process = inspectWakeProcess(existing.PID)
+	classifyWakeLock(root, me, &inspection)
+	return inspection
+}
+
+func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
+	lock := inspection.Lock
+	if lock.PID <= 0 {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "invalid pid"
+		return
+	}
+	if strings.TrimSpace(lock.Root) == "" {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "lock root missing"
+		return
+	}
+	if canonicalWakeRoot(lock.Root) != canonicalWakeRoot(root) {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "root mismatch"
+		return
+	}
+	if lock.Agent != "" && lock.Agent != me {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "agent mismatch"
+		return
+	}
+	if lock.Hostname != "" {
+		hostname, err := os.Hostname()
+		if err != nil || hostname == "" {
+			inspection.Status = wakeLockUnverified
+			inspection.Reason = inspectionReason("hostname unavailable", err)
+			return
+		}
+		if lock.Hostname != hostname {
+			inspection.Status = wakeLockUnverified
+			inspection.Reason = "hostname mismatch"
+			return
+		}
+	}
+
+	proc := inspection.Process
+	if !proc.Running {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "pid not running"
+		return
+	}
+	if lock.ProcessStart != "" {
+		if proc.StartToken == "" {
+			inspection.Status = wakeLockUnverified
+			inspection.Reason = inspectionReason("process start time unavailable", proc.InspectError)
+			return
+		}
+		if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
+			inspection.Status = wakeLockStale
+			inspection.Reason = "boot id mismatch"
+			return
+		}
+		if lock.ProcessStart != proc.StartToken {
+			inspection.Status = wakeLockStale
+			inspection.Reason = "process start time mismatch"
+			return
+		}
+	}
+	if proc.Executable == "" {
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = inspectionReason("process identity unavailable", proc.InspectError)
+		return
+	}
+	if !processLooksLikeAMQ(proc) {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "pid is not amq"
+		return
+	}
+	if len(proc.Args) > 0 && !processArgsLookLikeWake(proc.Args) {
+		inspection.Status = wakeLockStale
+		inspection.Reason = "pid is not amq wake"
+		return
+	}
+
+	if lock.ProcessStart != "" {
+		inspection.IdentityConfirmed = true
+		inspection.Status = wakeLockValid
+		return
+	}
+
+	if wakeArgsMatchRootAgent(proc.Args, root, me) {
+		inspection.IdentityConfirmed = true
+		inspection.Status = wakeLockValid
+		return
+	}
+
+	inspection.Status = wakeLockUnverified
+	inspection.Reason = "legacy lock lacks process start metadata"
+}
+
+func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
+	current, err := os.ReadFile(inspection.LockPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("re-read wake lock before removal: %w", err)
+	}
+	if !bytes.Equal(current, inspection.raw) {
+		return fmt.Errorf("wake lock changed while cleaning stale lock; retry")
+	}
+	if err := os.Remove(inspection.LockPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale wake lock: %w", err)
+	}
+	return nil
+}
+
+func currentWakeLockMatches(lock wakeLock) bool {
+	if lock.PID != os.Getpid() {
+		return false
+	}
+	if lock.ProcessStart == "" {
+		return true
+	}
+	proc := inspectWakeProcess(os.Getpid())
+	if !proc.Running || proc.StartToken == "" {
+		return false
+	}
+	if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
+		return false
+	}
+	return lock.ProcessStart == proc.StartToken
+}
+
+func canonicalWakeRoot(root string) string {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		absRoot = root
+	}
+	if realRoot, err := filepath.EvalSymlinks(absRoot); err == nil {
+		absRoot = realRoot
+	}
+	return filepath.Clean(absRoot)
+}
+
+func wakeLockAlreadyRunningError(me string, inspection wakeLockInspection) error {
+	return &wakeAlreadyRunningError{
+		Agent:      me,
+		Inspection: inspection,
+	}
+}
+
+func inspectionReason(base string, err error) string {
+	if err == nil {
+		return base
+	}
+	return fmt.Sprintf("%s: %v", base, err)
+}
+
+func processLooksLikeAMQ(proc wakeProcessInfo) bool {
+	if isAMQExecutable(proc.Executable) {
+		return true
+	}
+	if len(proc.Args) > 0 && isAMQExecutable(proc.Args[0]) {
+		return true
+	}
+	return false
+}
+
+func processArgsLookLikeWake(args []string) bool {
+	if len(args) < 2 {
+		return false
+	}
+	for _, arg := range args[1:] {
+		if arg == "wake" {
+			return true
+		}
+	}
+	return false
+}
+
+func wakeArgsMatchRootAgent(args []string, root, me string) bool {
+	if !processArgsLookLikeWake(args) {
+		return false
+	}
+	rootMatch := false
+	meMatch := false
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--root" && i+1 < len(args):
+			rootMatch = canonicalWakeRoot(args[i+1]) == canonicalWakeRoot(root)
+			i++
+		case strings.HasPrefix(arg, "--root="):
+			rootMatch = canonicalWakeRoot(strings.TrimPrefix(arg, "--root=")) == canonicalWakeRoot(root)
+		case arg == "--me" && i+1 < len(args):
+			meMatch = args[i+1] == me
+			i++
+		case strings.HasPrefix(arg, "--me="):
+			meMatch = strings.TrimPrefix(arg, "--me=") == me
+		}
+	}
+	return rootMatch && meMatch
+}
+
+func isAMQExecutable(value string) bool {
+	base := filepath.Base(strings.Trim(value, `"'`))
+	return base == "amq"
+}
+
+func wakeProcessStillMatches(inspection wakeLockInspection) bool {
+	proc := inspectWakeProcess(inspection.PID)
+	if !proc.Running {
+		return false
+	}
+	if inspection.Lock.ProcessStart != "" {
+		if proc.StartToken == "" || inspection.Lock.ProcessStart != proc.StartToken {
+			return false
+		}
+		if inspection.Lock.BootID != "" && proc.BootID != "" && inspection.Lock.BootID != proc.BootID {
+			return false
+		}
+	}
+	if proc.Executable == "" || !processLooksLikeAMQ(proc) {
+		return false
+	}
+	if len(proc.Args) > 0 && !processArgsLookLikeWake(proc.Args) {
+		return false
+	}
+	if inspection.Lock.ProcessStart == "" && !wakeArgsMatchRootAgent(proc.Args, inspection.Root, inspection.Agent) {
+		return false
+	}
+	return true
+}

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -19,6 +19,19 @@ func stubInspectWakeProcess(t *testing.T, fn func(pid int) wakeProcessInfo) {
 	})
 }
 
+func secureTempDirForTest(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err == nil {
+		dir, mkErr := os.MkdirTemp(cwd, ".amq-secure-test-")
+		if mkErr == nil {
+			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+			return dir
+		}
+	}
+	return t.TempDir()
+}
+
 func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) string {
 	t.Helper()
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func stubInspectWakeProcess(t *testing.T, fn func(pid int) wakeProcessInfo) {
+	t.Helper()
+	old := inspectWakeProcess
+	inspectWakeProcess = fn
+	t.Cleanup(func() {
+		inspectWakeProcess = old
+	})
+}
+
+func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) string {
+	t.Helper()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	if lock.Root == "" {
+		lock.Root = canonicalWakeRoot(root)
+	}
+	if lock.Agent == "" {
+		lock.Agent = agent
+	}
+	if lock.Started == "" {
+		lock.Started = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	}
+	data, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatalf("marshal wake lock: %v", err)
+	}
+	lockPath := filepath.Join(fsq.AgentBase(root, agent), ".wake.lock")
+	if err := os.WriteFile(lockPath, data, 0o600); err != nil {
+		t.Fatalf("write wake lock: %v", err)
+	}
+	return lockPath
+}
+
+func bindWakeLockToTarget(lock wakeLock, target wakeTarget) wakeLock {
+	lock.WakeMode = wakeTargetInjectVia
+	lock.TargetDigest = wakeTargetDigest(target)
+	return lock
+}

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -32,6 +32,15 @@ func secureTempDirForTest(t *testing.T) string {
 	return t.TempDir()
 }
 
+func mustNewWakeTargetForTest(t *testing.T, root, me, injectVia string, injectArgs []string) wakeTarget {
+	t.Helper()
+	target, err := newWakeTarget(root, me, injectVia, injectArgs)
+	if err != nil {
+		t.Fatalf("newWakeTarget: %v", err)
+	}
+	return target
+}
+
 func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) string {
 	t.Helper()
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -43,17 +43,22 @@ func mustNewWakeTargetForTest(t *testing.T, root, me, injectVia string, injectAr
 
 func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) string {
 	t.Helper()
-	if err := fsq.EnsureRootDirs(root); err != nil {
-		t.Fatalf("EnsureRootDirs: %v", err)
-	}
-	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
-		t.Fatalf("EnsureAgentDirs: %v", err)
-	}
 	if lock.Root == "" {
 		lock.Root = canonicalWakeRoot(root)
 	}
 	if lock.Agent == "" {
 		lock.Agent = agent
+	}
+	return writeWakeLockExactForTest(t, root, agent, lock)
+}
+
+func writeWakeLockExactForTest(t *testing.T, root, agent string, lock wakeLock) string {
+	t.Helper()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
 	}
 	if lock.Started == "" {
 		lock.Started = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)

--- a/internal/cli/wake_metadata.go
+++ b/internal/cli/wake_metadata.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const maxWakeMetadataFileBytes = 64 * 1024
+
+func readWakeMetadata(file *os.File, label, path string) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(file, maxWakeMetadataFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", label, err)
+	}
+	if len(data) > maxWakeMetadataFileBytes {
+		return nil, fmt.Errorf("%s %s is too large", label, path)
+	}
+	return data, nil
+}

--- a/internal/cli/wake_metadata_other.go
+++ b/internal/cli/wake_metadata_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package cli
+
+import "os"
+
+func openWakeMetadataFile(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/internal/cli/wake_metadata_unix.go
+++ b/internal/cli/wake_metadata_unix.go
@@ -1,0 +1,12 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+func openWakeMetadataFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0)
+}

--- a/internal/cli/wake_process_linux_test.go
+++ b/internal/cli/wake_process_linux_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLinuxProcStartTokenHandlesParensInCommand(t *testing.T) {
+	fields := make([]string, 20)
+	for i := range fields {
+		fields[i] = "0"
+	}
+	fields[0] = "S"
+	fields[19] = "123456"
+	stat := "42 (amq wake ) with spaces) " + strings.Join(fields, " ")
+
+	token, err := linuxProcStartToken(stat)
+	if err != nil {
+		t.Fatalf("linuxProcStartToken: %v", err)
+	}
+	if token != "123456" {
+		t.Fatalf("token = %q, want 123456", token)
+	}
+}
+
+func TestLinuxProcStartTokenRejectsMalformedStat(t *testing.T) {
+	if _, err := linuxProcStartToken("42 amq S 0 0"); err == nil {
+		t.Fatal("expected malformed stat error")
+	}
+}
+
+func TestSplitProcCmdline(t *testing.T) {
+	got := splitProcCmdline([]byte("/bin/amq\x00wake\x00--me\x00codex\x00"))
+	want := []string{"/bin/amq", "wake", "--me", "codex"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("arg[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/cli/wake_process_other.go
+++ b/internal/cli/wake_process_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !linux
+
+package cli
+
+import "fmt"
+
+func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
+	return wakeProcessInfo{
+		PID:          pid,
+		Running:      true,
+		InspectError: fmt.Errorf("wake process inspection is not supported on this platform"),
+	}
+}

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -1,0 +1,439 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func stubStartWakeFromTarget(t *testing.T, fn wakeRepairStarter) {
+	t.Helper()
+	old := startWakeFromTarget
+	startWakeFromTarget = fn
+	t.Cleanup(func() {
+		startWakeFromTarget = old
+	})
+}
+
+func TestWakeTargetWriteReadRoundTripAndPermissions(t *testing.T) {
+	root := t.TempDir()
+	injector := writeExecutableForTest(t, "injector")
+	target := newWakeTarget(root, "codex", injector, []string{"exec", "target"})
+
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	info, err := os.Stat(wakeTargetPath(root, "codex"))
+	if err != nil {
+		t.Fatalf("stat wake target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("wake target mode = %o, want 0600", got)
+	}
+	got, exists, err := readWakeTarget(root, "codex")
+	if err != nil {
+		t.Fatalf("readWakeTarget: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected wake target to exist")
+	}
+	if got.Mode != wakeTargetInjectVia || got.InjectVia != injector {
+		t.Fatalf("unexpected target: %#v", got)
+	}
+	if strings.Join(got.InjectArgs, "|") != "exec|target" {
+		t.Fatalf("inject args = %#v", got.InjectArgs)
+	}
+}
+
+func TestWakeTargetRejectsWorldWritableInjectVia(t *testing.T) {
+	injector := writeExecutableForTest(t, "injector")
+	if err := os.Chmod(injector, 0o777); err != nil {
+		t.Fatalf("chmod injector: %v", err)
+	}
+	err := validateWakeInjectViaPath(injector)
+	if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("expected world-writable rejection, got %v", err)
+	}
+}
+
+func TestWakeTargetRejectsGroupWritableInjectVia(t *testing.T) {
+	injector := writeExecutableForTest(t, "injector")
+	if err := os.Chmod(injector, 0o775); err != nil {
+		t.Fatalf("chmod injector: %v", err)
+	}
+	err := validateWakeInjectViaPath(injector)
+	if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("expected group-writable rejection, got %v", err)
+	}
+}
+
+func TestWakeTargetRejectsNonOwnedInjectVia(t *testing.T) {
+	oldCurrent := wakeTargetCurrentUID
+	oldOwner := wakeTargetFileOwnerUID
+	wakeTargetCurrentUID = func() (int, bool) { return 1000, true }
+	wakeTargetFileOwnerUID = func(info os.FileInfo) (int, bool) { return 2000, true }
+	t.Cleanup(func() {
+		wakeTargetCurrentUID = oldCurrent
+		wakeTargetFileOwnerUID = oldOwner
+	})
+
+	injector := writeExecutableForTest(t, "injector")
+	err := validateWakeInjectViaPath(injector)
+	if err == nil || !strings.Contains(err.Error(), "owned by uid 2000") {
+		t.Fatalf("expected owner rejection, got %v", err)
+	}
+}
+
+func TestReadWakeTargetRejectsUnsafeFileMode(t *testing.T) {
+	root := t.TempDir()
+	injector := writeExecutableForTest(t, "injector")
+	target := newWakeTarget(root, "codex", injector, nil)
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	if err := os.Chmod(wakeTargetPath(root, "codex"), 0o644); err != nil {
+		t.Fatalf("chmod wake target: %v", err)
+	}
+
+	_, exists, err := readWakeTarget(root, "codex")
+	if !exists {
+		t.Fatal("expected unsafe target to be reported present")
+	}
+	if err == nil || !strings.Contains(err.Error(), "mode is 644, want 0600") {
+		t.Fatalf("expected unsafe mode rejection, got %v", err)
+	}
+}
+
+func TestReadWakeTargetRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	injector := writeExecutableForTest(t, "injector")
+	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", injector, nil)); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	targetPath := wakeTargetPath(root, "codex")
+	symlinkTarget := targetPath + ".other"
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if err := os.WriteFile(symlinkTarget, data, 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	if err := os.Remove(targetPath); err != nil {
+		t.Fatalf("remove target: %v", err)
+	}
+	if err := os.Symlink(symlinkTarget, targetPath); err != nil {
+		t.Fatalf("symlink target: %v", err)
+	}
+
+	_, exists, err := readWakeTarget(root, "codex")
+	if !exists {
+		t.Fatal("expected symlink target to be reported present")
+	}
+	if err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestRepairWakeRefusesRawTTYWithoutInjectTarget(t *testing.T) {
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run without target")
+		return 0, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil {
+		t.Fatal("expected repair refusal")
+	}
+	if result.Status != "refused" || !strings.Contains(result.Reason, "no inject-via wake target") {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain on refused raw repair: %v", statErr)
+	}
+}
+
+func TestRepairWakeRefusesUnverifiedLock(t *testing.T) {
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == 4242 {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				Executable: "/opt/homebrew/bin/amq",
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", writeExecutableForTest(t, "injector"), nil)); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run for unverified lock")
+		return 0, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil {
+		t.Fatal("expected unverified repair refusal")
+	}
+	if result.Status != "refused" || !strings.Contains(result.Reason, "unverified") {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("unverified lock should remain: %v", statErr)
+	}
+}
+
+func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
+	root := t.TempDir()
+	injector := writeExecutableForTest(t, "injector")
+	target := newWakeTarget(root, "codex", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget) (int, error) {
+		if gotRoot != root || gotMe != "codex" {
+			t.Fatalf("start root/me = %q/%q", gotRoot, gotMe)
+		}
+		if target.InjectVia != injector || strings.Join(target.InjectArgs, "|") != "exec" {
+			t.Fatalf("unexpected target: %#v", target)
+		}
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatalf("lock should be removed before start, stat=%v", err)
+		}
+		return 9876, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err != nil {
+		t.Fatalf("repairWake: %v", err)
+	}
+	if result.Status != "repaired" || result.PID != 9876 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestRepairWakeRefusesStaleRawLockWithLeftoverTarget(t *testing.T) {
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	injector := writeExecutableForTest(t, "injector")
+	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", injector, []string{"exec"})); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run for a target not bound to the lock")
+		return 0, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil {
+		t.Fatal("expected repair refusal")
+	}
+	if result.Status != "refused" || !strings.Contains(result.Reason, "not created for an inject-via repair target") {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain on refused raw repair: %v", statErr)
+	}
+}
+
+func TestRunWakeRepairCLIRefusesMissingLockWithJSON(t *testing.T) {
+	root := t.TempDir()
+
+	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+		return runWakeRepair([]string{"--root", root, "--me", "codex", "--json"})
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "no wake lock present") {
+		t.Fatalf("runWakeRepair error = %v, want missing-lock refusal", runErr)
+	}
+
+	var result wakeRepairResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if result.Status != "refused" {
+		t.Fatalf("status = %q, want refused; result=%#v", result.Status, result)
+	}
+	if !strings.Contains(result.Reason, "no wake lock present") {
+		t.Fatalf("reason = %q, want missing-lock refusal", result.Reason)
+	}
+}
+
+func TestRunDispatchWakeRepairCLIRefusesMissingLockWithJSON(t *testing.T) {
+	root := t.TempDir()
+
+	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+		return Run([]string{"--no-update-check", "wake", "repair", "--root", root, "--me", "codex", "--json"}, "test")
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "no wake lock present") {
+		t.Fatalf("Run error = %v, want missing-lock refusal", runErr)
+	}
+
+	var result wakeRepairResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if result.Status != "refused" || !strings.Contains(result.Reason, "no wake lock present") {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestRunWakeRepairCLIReportsAlreadyRunning(t *testing.T) {
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		Executable:   "/opt/homebrew/bin/amq",
+		ProcessStart: "start-token",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "start-token",
+			Executable: "/opt/homebrew/bin/amq",
+		}
+	})
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run for an already-running wake")
+		return 0, nil
+	})
+
+	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+		return runWakeRepair([]string{"--root", root, "--me", "codex"})
+	})
+	if runErr != nil {
+		t.Fatalf("runWakeRepair: %v", runErr)
+	}
+
+	if !strings.Contains(stdout, "wake repair: already-running") || !strings.Contains(stdout, "pid=4242") {
+		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+}
+
+func TestRunWakeRepairCLIRepairsStaleWakeWithJSON(t *testing.T) {
+	root := t.TempDir()
+	injector := writeExecutableForTest(t, "injector")
+	target := newWakeTarget(root, "codex", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget) (int, error) {
+		if gotRoot != root || gotMe != "codex" {
+			t.Fatalf("start root/me = %q/%q", gotRoot, gotMe)
+		}
+		if target.InjectVia != injector || strings.Join(target.InjectArgs, "|") != "exec" {
+			t.Fatalf("unexpected target: %#v", target)
+		}
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatalf("lock should be removed before start, stat=%v", err)
+		}
+		return 9876, nil
+	})
+
+	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+		return runWakeRepair([]string{"--root", root, "--me", "codex", "--json"})
+	})
+	if runErr != nil {
+		t.Fatalf("runWakeRepair: %v", runErr)
+	}
+
+	var result wakeRepairResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if result.Status != "repaired" || result.PID != 9876 || !result.RepairAvailable {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestBuildCoopWakeArgsIncludesInjectViaTarget(t *testing.T) {
+	args := buildCoopWakeArgs("codex", "/tmp/root", "/abs/injector", []string{"exec", "target"})
+	got := strings.Join(args, "|")
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target"
+	if got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+}
+
+func captureWakeRepairOutput(t *testing.T, fn func() error) (stdout, stderr string, runErr error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	defer func() {
+		_ = wOut.Close()
+		_ = wErr.Close()
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	runErr = fn()
+	_ = wOut.Close()
+	_ = wErr.Close()
+	outBytes, _ := io.ReadAll(rOut)
+	errBytes, _ := io.ReadAll(rErr)
+	_ = rOut.Close()
+	_ = rErr.Close()
+	return string(outBytes), string(errBytes), runErr
+}
+
+func TestBuildRepairWakeArgsIncludesReadyFileAndTarget(t *testing.T) {
+	target := wakeTarget{
+		InjectVia:  "/abs/injector",
+		InjectArgs: []string{"exec", "target"},
+	}
+	args := buildRepairWakeArgs("/tmp/root", "codex", target, "/tmp/ready")
+	got := strings.Join(args, "|")
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready"
+	if got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -23,7 +23,7 @@ func stubStartWakeFromTarget(t *testing.T, fn wakeRepairStarter) {
 func TestWakeTargetWriteReadRoundTripAndPermissions(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	target := newWakeTarget(root, "codex", injector, []string{"exec", "target"})
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "target"})
 
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
@@ -109,7 +109,7 @@ func TestWakeTargetAllowsSymlinkedParentWhenResolvedPathIsSafe(t *testing.T) {
 		t.Fatalf("symlink root: %v", err)
 	}
 	injector := writeExecutableForTest(t, "injector")
-	target := newWakeTarget(linkRoot, "codex", injector, nil)
+	target := mustNewWakeTargetForTest(t, linkRoot, "codex", injector, nil)
 
 	if err := writeWakeTarget(linkRoot, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget through symlinked root: %v", err)
@@ -134,7 +134,7 @@ func TestWakeTargetResolvesSymlinkedInjectViaParent(t *testing.T) {
 		t.Fatalf("symlink bin: %v", err)
 	}
 
-	target := newWakeTarget(base, "codex", filepath.Join(linkDir, "injector"), nil)
+	target := mustNewWakeTargetForTest(t, base, "codex", filepath.Join(linkDir, "injector"), nil)
 	if target.InjectVia != injector {
 		t.Fatalf("target inject_via = %q, want resolved %q", target.InjectVia, injector)
 	}
@@ -151,12 +151,22 @@ func TestWakeTargetKeepsSymlinkInjectViaForValidationRejection(t *testing.T) {
 		t.Fatalf("symlink injector: %v", err)
 	}
 
-	target := newWakeTarget(base, "codex", link, nil)
+	target := mustNewWakeTargetForTest(t, base, "codex", link, nil)
 	if target.InjectVia != link {
 		t.Fatalf("target inject_via = %q, want unresolved symlink %q", target.InjectVia, link)
 	}
 	if err := validateWakeTarget(target, base, "codex"); err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
 		t.Fatalf("expected symlink validation rejection, got %v", err)
+	}
+}
+
+func TestWakeTargetCreationRejectsMissingInjectVia(t *testing.T) {
+	root := secureTempDirForTest(t)
+	missing := filepath.Join(root, "missing-injector")
+
+	_, err := newWakeTarget(root, "codex", missing, nil)
+	if err == nil || !strings.Contains(err.Error(), "stat inject_via") {
+		t.Fatalf("expected inject_via stat failure, got %v", err)
 	}
 }
 
@@ -215,7 +225,7 @@ func TestReadWakeTargetRejectsNonRegularFile(t *testing.T) {
 func TestReadWakeTargetRejectsUnsafeFileMode(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	target := newWakeTarget(root, "codex", injector, nil)
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
@@ -235,7 +245,7 @@ func TestReadWakeTargetRejectsUnsafeFileMode(t *testing.T) {
 func TestReadWakeTargetRejectsNonOwnedFile(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", injector, nil)); err != nil {
+	if err := writeWakeTarget(root, "codex", mustNewWakeTargetForTest(t, root, "codex", injector, nil)); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
 
@@ -260,7 +270,7 @@ func TestReadWakeTargetRejectsNonOwnedFile(t *testing.T) {
 func TestReadWakeTargetRejectsSymlink(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", injector, nil)); err != nil {
+	if err := writeWakeTarget(root, "codex", mustNewWakeTargetForTest(t, root, "codex", injector, nil)); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
 	targetPath := wakeTargetPath(root, "codex")
@@ -316,7 +326,7 @@ func TestReadWakeTargetRejectsWorldWritableParent(t *testing.T) {
 func TestRepairWakeRefusesTamperedTargetDigest(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	target := newWakeTarget(root, "codex", injector, []string{"exec"})
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
 	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",
@@ -389,7 +399,7 @@ func TestRepairWakeRefusesUnverifiedLock(t *testing.T) {
 		}
 		return wakeProcessInfo{PID: pid}
 	})
-	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", writeExecutableForTest(t, "injector"), nil)); err != nil {
+	if err := writeWakeTarget(root, "codex", mustNewWakeTargetForTest(t, root, "codex", writeExecutableForTest(t, "injector"), nil)); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
 	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
@@ -439,7 +449,7 @@ func TestRepairWakeRefusesCreatingLock(t *testing.T) {
 func TestRepairWakeRefusesLockChangedBeforeRemoval(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	target := newWakeTarget(root, "codex", injector, []string{"exec"})
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
 	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",
@@ -478,7 +488,7 @@ func TestRepairWakeRefusesLockChangedBeforeRemoval(t *testing.T) {
 func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	target := newWakeTarget(root, "codex", injector, []string{"exec"})
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
 	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",
@@ -521,7 +531,7 @@ func TestRepairWakeRefusesStaleRawLockWithLeftoverTarget(t *testing.T) {
 		return wakeProcessInfo{PID: pid, Running: false}
 	})
 	injector := writeExecutableForTest(t, "injector")
-	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", injector, []string{"exec"})); err != nil {
+	if err := writeWakeTarget(root, "codex", mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
 	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
@@ -617,7 +627,7 @@ func TestRunWakeRepairCLIReportsAlreadyRunning(t *testing.T) {
 func TestRunWakeRepairCLIRepairsStaleWakeWithJSON(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	target := newWakeTarget(root, "codex", injector, []string{"exec"})
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
 	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -592,7 +592,7 @@ func TestRunDispatchWakeRepairCLIRefusesMissingLockWithJSON(t *testing.T) {
 	}
 }
 
-func TestRunWakeRepairCLIReportsAlreadyRunning(t *testing.T) {
+func TestRunWakeRepairCLIRefusesValidLock(t *testing.T) {
 	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "codex", wakeLock{
 		PID:          4242,
@@ -615,11 +615,13 @@ func TestRunWakeRepairCLIReportsAlreadyRunning(t *testing.T) {
 	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
 		return runWakeRepair([]string{"--root", root, "--me", "codex"})
 	})
-	if runErr != nil {
-		t.Fatalf("runWakeRepair: %v", runErr)
+	if runErr == nil || !strings.Contains(runErr.Error(), "already valid") {
+		t.Fatalf("runWakeRepair error = %v, want valid-lock refusal", runErr)
 	}
 
-	if !strings.Contains(stdout, "wake repair: already-running") || !strings.Contains(stdout, "pid=4242") {
+	if !strings.Contains(stdout, "wake repair: refused") ||
+		!strings.Contains(stdout, "pid=4242") ||
+		!strings.Contains(stdout, "already valid") {
 		t.Fatalf("unexpected stdout: %q", stdout)
 	}
 }

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -20,7 +21,7 @@ func stubStartWakeFromTarget(t *testing.T, fn wakeRepairStarter) {
 }
 
 func TestWakeTargetWriteReadRoundTripAndPermissions(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	target := newWakeTarget(root, "codex", injector, []string{"exec", "target"})
 
@@ -60,6 +61,105 @@ func TestWakeTargetRejectsWorldWritableInjectVia(t *testing.T) {
 	}
 }
 
+func TestWakeTargetRejectsWorldWritableInjectViaAncestor(t *testing.T) {
+	base := secureTempDirForTest(t)
+	writableParent := filepath.Join(base, "writable")
+	safeChild := filepath.Join(writableParent, "safe")
+	if err := os.MkdirAll(safeChild, 0o700); err != nil {
+		t.Fatalf("mkdir safe child: %v", err)
+	}
+	if err := os.Chmod(writableParent, 0o777); err != nil {
+		t.Fatalf("chmod writable parent: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(writableParent, 0o700)
+	})
+	injector := filepath.Join(safeChild, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+
+	err := validateWakeInjectViaPath(injector)
+	if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("expected writable ancestor rejection, got %v", err)
+	}
+}
+
+func TestWakeTargetRejectsSymlinkInjectVia(t *testing.T) {
+	injector := writeExecutableForTest(t, "injector")
+	link := filepath.Join(t.TempDir(), "injector-link")
+	if err := os.Symlink(injector, link); err != nil {
+		t.Fatalf("symlink injector: %v", err)
+	}
+
+	err := validateWakeInjectViaPath(link)
+	if err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestWakeTargetAllowsSymlinkedParentWhenResolvedPathIsSafe(t *testing.T) {
+	base := secureTempDirForTest(t)
+	realRoot := filepath.Join(base, "real-root")
+	if err := os.MkdirAll(realRoot, 0o700); err != nil {
+		t.Fatalf("mkdir real root: %v", err)
+	}
+	linkRoot := filepath.Join(base, "link-root")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Fatalf("symlink root: %v", err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	target := newWakeTarget(linkRoot, "codex", injector, nil)
+
+	if err := writeWakeTarget(linkRoot, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget through symlinked root: %v", err)
+	}
+	if _, exists, err := readWakeTarget(linkRoot, "codex"); err != nil || !exists {
+		t.Fatalf("readWakeTarget through symlinked root exists=%v err=%v", exists, err)
+	}
+}
+
+func TestWakeTargetResolvesSymlinkedInjectViaParent(t *testing.T) {
+	base := secureTempDirForTest(t)
+	realDir := filepath.Join(base, "real-bin")
+	if err := os.MkdirAll(realDir, 0o700); err != nil {
+		t.Fatalf("mkdir real bin: %v", err)
+	}
+	injector := filepath.Join(realDir, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+	linkDir := filepath.Join(base, "link-bin")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("symlink bin: %v", err)
+	}
+
+	target := newWakeTarget(base, "codex", filepath.Join(linkDir, "injector"), nil)
+	if target.InjectVia != injector {
+		t.Fatalf("target inject_via = %q, want resolved %q", target.InjectVia, injector)
+	}
+	if err := validateWakeTarget(target, base, "codex"); err != nil {
+		t.Fatalf("validateWakeTarget: %v", err)
+	}
+}
+
+func TestWakeTargetKeepsSymlinkInjectViaForValidationRejection(t *testing.T) {
+	base := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	link := filepath.Join(base, "injector-link")
+	if err := os.Symlink(injector, link); err != nil {
+		t.Fatalf("symlink injector: %v", err)
+	}
+
+	target := newWakeTarget(base, "codex", link, nil)
+	if target.InjectVia != link {
+		t.Fatalf("target inject_via = %q, want unresolved symlink %q", target.InjectVia, link)
+	}
+	if err := validateWakeTarget(target, base, "codex"); err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected symlink validation rejection, got %v", err)
+	}
+}
+
 func TestWakeTargetRejectsGroupWritableInjectVia(t *testing.T) {
 	injector := writeExecutableForTest(t, "injector")
 	if err := os.Chmod(injector, 0o775); err != nil {
@@ -68,6 +168,15 @@ func TestWakeTargetRejectsGroupWritableInjectVia(t *testing.T) {
 	err := validateWakeInjectViaPath(injector)
 	if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
 		t.Fatalf("expected group-writable rejection, got %v", err)
+	}
+}
+
+func TestWakeTargetRejectsNonRegularInjectVia(t *testing.T) {
+	path := t.TempDir()
+
+	err := validateWakeInjectViaPath(path)
+	if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
+		t.Fatalf("expected non-regular rejection, got %v", err)
 	}
 }
 
@@ -88,8 +197,23 @@ func TestWakeTargetRejectsNonOwnedInjectVia(t *testing.T) {
 	}
 }
 
+func TestReadWakeTargetRejectsNonRegularFile(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := os.MkdirAll(wakeTargetPath(root, "codex"), 0o700); err != nil {
+		t.Fatalf("mkdir wake target path: %v", err)
+	}
+
+	_, exists, err := readWakeTarget(root, "codex")
+	if !exists {
+		t.Fatal("expected non-regular target to be reported present")
+	}
+	if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
+		t.Fatalf("expected non-regular target rejection, got %v", err)
+	}
+}
+
 func TestReadWakeTargetRejectsUnsafeFileMode(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	target := newWakeTarget(root, "codex", injector, nil)
 	if err := writeWakeTarget(root, "codex", target); err != nil {
@@ -108,8 +232,33 @@ func TestReadWakeTargetRejectsUnsafeFileMode(t *testing.T) {
 	}
 }
 
+func TestReadWakeTargetRejectsNonOwnedFile(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", injector, nil)); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+
+	oldCurrent := wakeTargetCurrentUID
+	oldOwner := wakeTargetFileOwnerUID
+	wakeTargetCurrentUID = func() (int, bool) { return 1000, true }
+	wakeTargetFileOwnerUID = func(info os.FileInfo) (int, bool) { return 2000, true }
+	t.Cleanup(func() {
+		wakeTargetCurrentUID = oldCurrent
+		wakeTargetFileOwnerUID = oldOwner
+	})
+
+	_, exists, err := readWakeTarget(root, "codex")
+	if !exists {
+		t.Fatal("expected non-owned target to be reported present")
+	}
+	if err == nil || !strings.Contains(err.Error(), "owned by uid 2000") {
+		t.Fatalf("expected target owner rejection, got %v", err)
+	}
+}
+
 func TestReadWakeTargetRejectsSymlink(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	if err := writeWakeTarget(root, "codex", newWakeTarget(root, "codex", injector, nil)); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
@@ -139,8 +288,67 @@ func TestReadWakeTargetRejectsSymlink(t *testing.T) {
 	}
 }
 
+func TestReadWakeTargetRejectsWorldWritableParent(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := os.MkdirAll(filepath.Join(root, "agents", "codex"), 0o700); err != nil {
+		t.Fatalf("mkdir agent dir: %v", err)
+	}
+	if err := os.Chmod(filepath.Join(root, "agents"), 0o777); err != nil {
+		t.Fatalf("chmod agents dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(filepath.Join(root, "agents"), 0o700)
+	})
+	targetPath := wakeTargetPath(root, "codex")
+	if err := os.WriteFile(targetPath, []byte(`{"schema":1}`), 0o600); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	_, exists, err := readWakeTarget(root, "codex")
+	if !exists {
+		t.Fatal("expected unsafe target to be reported present")
+	}
+	if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("expected writable parent rejection, got %v", err)
+	}
+}
+
+func TestRepairWakeRefusesTamperedTargetDigest(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := newWakeTarget(root, "codex", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	tampered := target
+	tampered.InjectArgs = []string{"evil"}
+	if err := writeWakeTarget(root, "codex", tampered); err != nil {
+		t.Fatalf("write tampered wake target: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run for tampered target")
+		return 0, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil {
+		t.Fatal("expected digest mismatch refusal")
+	}
+	if result.Status != "refused" || !strings.Contains(result.Reason, "does not match") {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain on refused tampered target: %v", statErr)
+	}
+}
+
 func TestRepairWakeRefusesRawTTYWithoutInjectTarget(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",
@@ -166,7 +374,7 @@ func TestRepairWakeRefusesRawTTYWithoutInjectTarget(t *testing.T) {
 }
 
 func TestRepairWakeRefusesUnverifiedLock(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",
@@ -201,8 +409,74 @@ func TestRepairWakeRefusesUnverifiedLock(t *testing.T) {
 	}
 }
 
+func TestRepairWakeRefusesCreatingLock(t *testing.T) {
+	root := secureTempDirForTest(t)
+	agentBase := filepath.Dir(wakeTargetPath(root, "codex"))
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		t.Fatalf("mkdir agent base: %v", err)
+	}
+	lockPath := filepath.Join(agentBase, ".wake.lock")
+	if err := os.WriteFile(lockPath, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write creating lock: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run for creating lock")
+		return 0, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil {
+		t.Fatal("expected creating-lock refusal")
+	}
+	if result.Status != "refused" || !strings.Contains(result.Reason, "being created") {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("creating lock should remain: %v", statErr)
+	}
+}
+
+func TestRepairWakeRefusesLockChangedBeforeRemoval(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := newWakeTarget(root, "codex", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	calls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		calls++
+		if calls == 1 {
+			writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+				PID:        4243,
+				Executable: "/opt/homebrew/bin/amq",
+			}, target))
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run after lock changed")
+		return 0, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil {
+		t.Fatal("expected changed-lock refusal")
+	}
+	if result.Status != "refused" || !strings.Contains(result.Reason, "changed before repair") {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("changed lock should remain: %v", statErr)
+	}
+}
+
 func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	target := newWakeTarget(root, "codex", injector, []string{"exec"})
 	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
@@ -238,7 +512,7 @@ func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 }
 
 func TestRepairWakeRefusesStaleRawLockWithLeftoverTarget(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",
@@ -268,7 +542,7 @@ func TestRepairWakeRefusesStaleRawLockWithLeftoverTarget(t *testing.T) {
 }
 
 func TestRunWakeRepairCLIRefusesMissingLockWithJSON(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 
 	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
 		return runWakeRepair([]string{"--root", root, "--me", "codex", "--json"})
@@ -290,7 +564,7 @@ func TestRunWakeRepairCLIRefusesMissingLockWithJSON(t *testing.T) {
 }
 
 func TestRunDispatchWakeRepairCLIRefusesMissingLockWithJSON(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 
 	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
 		return Run([]string{"--no-update-check", "wake", "repair", "--root", root, "--me", "codex", "--json"}, "test")
@@ -309,7 +583,7 @@ func TestRunDispatchWakeRepairCLIRefusesMissingLockWithJSON(t *testing.T) {
 }
 
 func TestRunWakeRepairCLIReportsAlreadyRunning(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "codex", wakeLock{
 		PID:          4242,
 		Executable:   "/opt/homebrew/bin/amq",
@@ -341,7 +615,7 @@ func TestRunWakeRepairCLIReportsAlreadyRunning(t *testing.T) {
 }
 
 func TestRunWakeRepairCLIRepairsStaleWakeWithJSON(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	target := newWakeTarget(root, "codex", injector, []string{"exec"})
 	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -658,6 +658,83 @@ func TestRepairWakeRefusesStaleRawLockWithLeftoverTarget(t *testing.T) {
 	}
 }
 
+func TestRepairWakeRefusesLiveIdentityMismatchLock(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		lock       wakeLock
+		process    wakeProcessInfo
+		wantReason string
+	}{
+		{
+			name: "boot id mismatch",
+			lock: wakeLock{
+				PID:          4242,
+				ProcessStart: "start-token",
+				BootID:       "recorded-boot",
+				Executable:   "/opt/homebrew/bin/amq",
+			},
+			process: wakeProcessInfo{
+				PID:        4242,
+				Running:    true,
+				StartToken: "start-token",
+				BootID:     "actual-boot",
+				Executable: "/opt/homebrew/bin/amq",
+			},
+			wantReason: "boot id mismatch",
+		},
+		{
+			name: "process start mismatch",
+			lock: wakeLock{
+				PID:          4242,
+				ProcessStart: "recorded-start",
+				BootID:       "same-boot",
+				Executable:   "/opt/homebrew/bin/amq",
+			},
+			process: wakeProcessInfo{
+				PID:        4242,
+				Running:    true,
+				StartToken: "actual-start",
+				BootID:     "same-boot",
+				Executable: "/opt/homebrew/bin/amq",
+			},
+			wantReason: "process start time mismatch",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+			lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(tc.lock, target))
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatalf("writeWakeTarget: %v", err)
+			}
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				proc := tc.process
+				proc.PID = pid
+				proc.Args = []string{"amq", "wake", "--root", root, "--me", "codex"}
+				return proc
+			})
+			stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+				t.Fatalf("startWakeFromTarget should not run for live identity mismatch")
+				return 0, nil
+			})
+
+			result, err := repairWake(root, "codex")
+			if err == nil {
+				t.Fatal("expected repair refusal")
+			}
+			if result.Status != "refused" ||
+				!strings.Contains(result.Reason, tc.wantReason) ||
+				!strings.Contains(result.Reason, "not repairable") {
+				t.Fatalf("unexpected result: %#v err=%v", result, err)
+			}
+			if _, statErr := os.Stat(lockPath); statErr != nil {
+				t.Fatalf("lock should remain on refused live identity mismatch: %v", statErr)
+			}
+		})
+	}
+}
+
 func TestRunWakeRepairCLIRefusesMissingLockWithJSON(t *testing.T) {
 	root := secureTempDirForTest(t)
 

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -4,11 +4,14 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func stubStartWakeFromTarget(t *testing.T, fn wakeRepairStarter) {
@@ -222,6 +225,36 @@ func TestReadWakeTargetRejectsNonRegularFile(t *testing.T) {
 	}
 }
 
+func TestReadWakeTargetRejectsFIFOWithoutBlocking(t *testing.T) {
+	root := secureTempDirForTest(t)
+	agentBase := filepath.Dir(wakeTargetPath(root, "codex"))
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		t.Fatalf("mkdir agent base: %v", err)
+	}
+	if err := syscall.Mkfifo(wakeTargetPath(root, "codex"), 0o600); err != nil {
+		t.Fatalf("mkfifo wake target: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, exists, err := readWakeTarget(root, "codex")
+		if !exists {
+			done <- fmt.Errorf("expected FIFO target to be reported present")
+			return
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
+			t.Fatalf("expected FIFO rejection, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("readWakeTarget blocked on FIFO")
+	}
+}
+
 func TestReadWakeTargetRejectsUnsafeFileMode(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
@@ -354,6 +387,80 @@ func TestRepairWakeRefusesTamperedTargetDigest(t *testing.T) {
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
 		t.Fatalf("lock should remain on refused tampered target: %v", statErr)
+	}
+}
+
+func TestRepairWakeRefusesStructurallyTamperedStaleLock(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run for structurally tampered lock")
+		return 0, nil
+	})
+
+	for _, tc := range []struct {
+		name       string
+		lock       wakeLock
+		wantReason string
+	}{
+		{
+			name: "invalid pid",
+			lock: bindWakeLockToTarget(wakeLock{
+				PID:   -1,
+				Root:  canonicalWakeRoot(root),
+				Agent: "codex",
+			}, target),
+			wantReason: "invalid pid",
+		},
+		{
+			name: "missing root",
+			lock: bindWakeLockToTarget(wakeLock{
+				PID:   4242,
+				Agent: "codex",
+			}, target),
+			wantReason: "lock root missing",
+		},
+		{
+			name: "root mismatch",
+			lock: bindWakeLockToTarget(wakeLock{
+				PID:   4242,
+				Root:  filepath.Join(root, "other-root"),
+				Agent: "codex",
+			}, target),
+			wantReason: "root mismatch",
+		},
+		{
+			name: "agent mismatch",
+			lock: bindWakeLockToTarget(wakeLock{
+				PID:   4242,
+				Root:  canonicalWakeRoot(root),
+				Agent: "other",
+			}, target),
+			wantReason: "agent mismatch",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lockPath := writeWakeLockExactForTest(t, root, "codex", tc.lock)
+
+			result, err := repairWake(root, "codex")
+			if err == nil {
+				t.Fatal("expected repair refusal")
+			}
+			if result.Status != "refused" || !strings.Contains(result.Reason, tc.wantReason) ||
+				!strings.Contains(result.Reason, "not repairable") {
+				t.Fatalf("unexpected result: %#v err=%v", result, err)
+			}
+			if _, statErr := os.Stat(lockPath); statErr != nil {
+				t.Fatalf("tampered lock should remain: %v", statErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -40,9 +40,21 @@ func newWakeTarget(root, me, injectVia string, injectArgs []string) wakeTarget {
 		Root:       canonicalWakeRoot(root),
 		Agent:      me,
 		Created:    time.Now().UTC().Format(time.RFC3339),
-		InjectVia:  strings.TrimSpace(injectVia),
+		InjectVia:  wakeTargetInjectViaPath(injectVia),
 		InjectArgs: append([]string{}, injectArgs...),
 	}
+}
+
+func wakeTargetInjectViaPath(path string) string {
+	trimmed := strings.TrimSpace(path)
+	info, err := os.Lstat(trimmed)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 {
+		return trimmed
+	}
+	if resolved, err := filepath.EvalSymlinks(trimmed); err == nil {
+		return resolved
+	}
+	return trimmed
 }
 
 func wakeTargetDigest(target wakeTarget) string {
@@ -97,7 +109,14 @@ func validateWakeTargetFile(path string, info os.FileInfo) error {
 	if got := info.Mode().Perm(); got != 0o600 {
 		return fmt.Errorf("wake target %s mode is %o, want 0600", path, got)
 	}
-	return validateWakeTargetPathOwnership("wake target", path, info)
+	if err := validateWakeTargetPathOwnership("wake target", path, info); err != nil {
+		return err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return fmt.Errorf("resolve wake target: %w", err)
+	}
+	return validateWakeTargetParentDirs("wake target", resolvedPath)
 }
 
 func writeWakeTarget(root, me string, target wakeTarget) error {
@@ -172,12 +191,15 @@ func validateWakeInjectViaPath(path string) error {
 	if !filepath.IsAbs(path) {
 		return fmt.Errorf("inject_via must be an absolute path")
 	}
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return fmt.Errorf("stat inject_via: %w", err)
 	}
-	if info.IsDir() {
-		return fmt.Errorf("inject_via must be a file, not a directory")
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("inject_via must not be a symlink")
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("inject_via must be a regular file")
 	}
 	if info.Mode().Perm()&0o111 == 0 {
 		return fmt.Errorf("inject_via is not executable")
@@ -185,12 +207,11 @@ func validateWakeInjectViaPath(path string) error {
 	if err := validateWakeTargetPathOwnership("inject_via", path, info); err != nil {
 		return err
 	}
-	parent := filepath.Dir(path)
-	parentInfo, err := os.Stat(parent)
+	resolvedPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return fmt.Errorf("stat inject_via parent: %w", err)
+		return fmt.Errorf("resolve inject_via: %w", err)
 	}
-	if err := validateWakeTargetPathOwnership("inject_via parent", parent, parentInfo); err != nil {
+	if err := validateWakeTargetParentDirs("inject_via", resolvedPath); err != nil {
 		return err
 	}
 	return nil
@@ -206,4 +227,28 @@ func validateWakeTargetPathOwnership(label, path string, info os.FileInfo) error
 		return fmt.Errorf("%s %s is owned by uid %d, want current uid %d", label, path, ownerUID, currentUID)
 	}
 	return nil
+}
+
+func validateWakeTargetParentDirs(label, path string) error {
+	cleanParent := filepath.Dir(filepath.Clean(path))
+	start, err := filepath.EvalSymlinks(cleanParent)
+	if err != nil {
+		return fmt.Errorf("resolve %s parent %s: %w", label, cleanParent, err)
+	}
+	for dir := start; ; dir = filepath.Dir(dir) {
+		info, err := os.Stat(dir)
+		if err != nil {
+			return fmt.Errorf("stat %s parent %s: %w", label, dir, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s parent %s must be a directory", label, dir)
+		}
+		if info.Mode().Perm()&0o022 != 0 {
+			return fmt.Errorf("%s parent %s is group/world-writable", label, dir)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+	}
 }

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	wakeTargetSchema    = 1
+	wakeTargetFileName  = ".wake.target"
+	wakeTargetInjectVia = "inject-via"
+)
+
+type wakeTarget struct {
+	Schema     int      `json:"schema"`
+	Mode       string   `json:"mode"`
+	Root       string   `json:"root"`
+	Agent      string   `json:"agent"`
+	Created    string   `json:"created"`
+	InjectVia  string   `json:"inject_via"`
+	InjectArgs []string `json:"inject_args,omitempty"`
+}
+
+func wakeTargetPath(root, me string) string {
+	return filepath.Join(fsq.AgentBase(root, me), wakeTargetFileName)
+}
+
+func newWakeTarget(root, me, injectVia string, injectArgs []string) wakeTarget {
+	return wakeTarget{
+		Schema:     wakeTargetSchema,
+		Mode:       wakeTargetInjectVia,
+		Root:       canonicalWakeRoot(root),
+		Agent:      me,
+		Created:    time.Now().UTC().Format(time.RFC3339),
+		InjectVia:  strings.TrimSpace(injectVia),
+		InjectArgs: append([]string{}, injectArgs...),
+	}
+}
+
+func wakeTargetDigest(target wakeTarget) string {
+	data, _ := json.Marshal(target)
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func validateWakeTargetMatchesLock(lock wakeLock, target wakeTarget) error {
+	if lock.WakeMode != wakeTargetInjectVia || lock.TargetDigest == "" {
+		return fmt.Errorf("wake lock was not created for an inject-via repair target")
+	}
+	if got := wakeTargetDigest(target); got != lock.TargetDigest {
+		return fmt.Errorf("wake target does not match wake lock")
+	}
+	return nil
+}
+
+func readWakeTarget(root, me string) (wakeTarget, bool, error) {
+	path := wakeTargetPath(root, me)
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return wakeTarget{}, false, nil
+		}
+		return wakeTarget{}, true, fmt.Errorf("stat wake target: %w", err)
+	}
+	if err := validateWakeTargetFile(path, info); err != nil {
+		return wakeTarget{}, true, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return wakeTarget{}, false, nil
+		}
+		return wakeTarget{}, true, fmt.Errorf("read wake target: %w", err)
+	}
+	var target wakeTarget
+	if err := json.Unmarshal(data, &target); err != nil {
+		return wakeTarget{}, true, fmt.Errorf("parse wake target: %w", err)
+	}
+	return target, true, nil
+}
+
+func validateWakeTargetFile(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("wake target %s must not be a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("wake target %s must be a regular file", path)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return fmt.Errorf("wake target %s mode is %o, want 0600", path, got)
+	}
+	return validateWakeTargetPathOwnership("wake target", path, info)
+}
+
+func writeWakeTarget(root, me string, target wakeTarget) error {
+	if err := validateWakeTarget(target, root, me); err != nil {
+		return err
+	}
+	agentBase := fsq.AgentBase(root, me)
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		return fmt.Errorf("create wake target directory: %w", err)
+	}
+	data, err := json.MarshalIndent(target, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal wake target: %w", err)
+	}
+	data = append(data, '\n')
+	tmp := filepath.Join(agentBase, fmt.Sprintf(".wake.target.tmp.%d", os.Getpid()))
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write wake target temp file: %w", err)
+	}
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("chmod wake target temp file: %w", err)
+	}
+	if err := os.Rename(tmp, wakeTargetPath(root, me)); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("install wake target: %w", err)
+	}
+	if err := os.Chmod(wakeTargetPath(root, me), 0o600); err != nil {
+		return fmt.Errorf("chmod wake target: %w", err)
+	}
+	return nil
+}
+
+func removeWakeTarget(root, me string) error {
+	if err := os.Remove(wakeTargetPath(root, me)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove wake target: %w", err)
+	}
+	return nil
+}
+
+func validateWakeTarget(target wakeTarget, root, me string) error {
+	if target.Schema != wakeTargetSchema {
+		return fmt.Errorf("wake target schema %d unsupported", target.Schema)
+	}
+	if target.Mode != wakeTargetInjectVia {
+		return fmt.Errorf("wake target mode %q unsupported", target.Mode)
+	}
+	if canonicalWakeRoot(target.Root) != canonicalWakeRoot(root) {
+		return fmt.Errorf("wake target root mismatch")
+	}
+	if target.Agent != me {
+		return fmt.Errorf("wake target agent mismatch")
+	}
+	if err := validateWakeInjectViaPath(target.InjectVia); err != nil {
+		return err
+	}
+	for _, arg := range target.InjectArgs {
+		if strings.ContainsRune(arg, 0) {
+			return fmt.Errorf("wake target inject arg contains NUL")
+		}
+	}
+	return nil
+}
+
+func validateWakeInjectViaPath(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("inject_via must not be blank")
+	}
+	if strings.ContainsRune(path, 0) {
+		return fmt.Errorf("inject_via contains NUL")
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("inject_via must be an absolute path")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat inject_via: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("inject_via must be a file, not a directory")
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("inject_via is not executable")
+	}
+	if err := validateWakeTargetPathOwnership("inject_via", path, info); err != nil {
+		return err
+	}
+	parent := filepath.Dir(path)
+	parentInfo, err := os.Stat(parent)
+	if err != nil {
+		return fmt.Errorf("stat inject_via parent: %w", err)
+	}
+	if err := validateWakeTargetPathOwnership("inject_via parent", parent, parentInfo); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateWakeTargetPathOwnership(label, path string, info os.FileInfo) error {
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf("%s %s is group/world-writable", label, path)
+	}
+	ownerUID, ownerOK := wakeTargetFileOwnerUID(info)
+	currentUID, currentOK := wakeTargetCurrentUID()
+	if ownerOK && currentOK && ownerUID != currentUID {
+		return fmt.Errorf("%s %s is owned by uid %d, want current uid %d", label, path, ownerUID, currentUID)
+	}
+	return nil
+}

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -75,6 +75,12 @@ func validateWakeTargetMatchesLock(lock wakeLock, target wakeTarget) error {
 	if lock.WakeMode != wakeTargetInjectVia || lock.TargetDigest == "" {
 		return fmt.Errorf("wake lock was not created for an inject-via repair target")
 	}
+	if strings.TrimSpace(lock.Root) == "" || canonicalWakeRoot(lock.Root) != canonicalWakeRoot(target.Root) {
+		return fmt.Errorf("wake lock root mismatch")
+	}
+	if lock.Agent != target.Agent {
+		return fmt.Errorf("wake lock agent mismatch")
+	}
 	if got := wakeTargetDigest(target); got != lock.TargetDigest {
 		return fmt.Errorf("wake target does not match wake lock")
 	}
@@ -93,12 +99,24 @@ func readWakeTarget(root, me string) (wakeTarget, bool, error) {
 	if err := validateWakeTargetFile(path, info); err != nil {
 		return wakeTarget{}, true, err
 	}
-	data, err := os.ReadFile(path)
+	file, err := openWakeMetadataFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return wakeTarget{}, false, nil
 		}
-		return wakeTarget{}, true, fmt.Errorf("read wake target: %w", err)
+		return wakeTarget{}, true, fmt.Errorf("open wake target: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return wakeTarget{}, true, fmt.Errorf("stat wake target: %w", err)
+	}
+	if err := validateWakeTargetFile(path, openedInfo); err != nil {
+		return wakeTarget{}, true, err
+	}
+	data, err := readWakeMetadata(file, "wake target", path)
+	if err != nil {
+		return wakeTarget{}, true, err
 	}
 	var target wakeTarget
 	if err := json.Unmarshal(data, &target); err != nil {

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -33,28 +33,36 @@ func wakeTargetPath(root, me string) string {
 	return filepath.Join(fsq.AgentBase(root, me), wakeTargetFileName)
 }
 
-func newWakeTarget(root, me, injectVia string, injectArgs []string) wakeTarget {
+func newWakeTarget(root, me, injectVia string, injectArgs []string) (wakeTarget, error) {
+	resolvedInjectVia, err := wakeTargetInjectViaPath(injectVia)
+	if err != nil {
+		return wakeTarget{}, err
+	}
 	return wakeTarget{
 		Schema:     wakeTargetSchema,
 		Mode:       wakeTargetInjectVia,
 		Root:       canonicalWakeRoot(root),
 		Agent:      me,
 		Created:    time.Now().UTC().Format(time.RFC3339),
-		InjectVia:  wakeTargetInjectViaPath(injectVia),
+		InjectVia:  resolvedInjectVia,
 		InjectArgs: append([]string{}, injectArgs...),
-	}
+	}, nil
 }
 
-func wakeTargetInjectViaPath(path string) string {
+func wakeTargetInjectViaPath(path string) (string, error) {
 	trimmed := strings.TrimSpace(path)
 	info, err := os.Lstat(trimmed)
-	if err != nil || info.Mode()&os.ModeSymlink != 0 {
-		return trimmed
+	if err != nil {
+		return "", fmt.Errorf("stat inject_via: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return trimmed, nil
 	}
 	if resolved, err := filepath.EvalSymlinks(trimmed); err == nil {
-		return resolved
+		return resolved, nil
+	} else {
+		return "", fmt.Errorf("resolve inject_via: %w", err)
 	}
-	return trimmed
 }
 
 func wakeTargetDigest(target wakeTarget) string {

--- a/internal/cli/wake_target_owner_other.go
+++ b/internal/cli/wake_target_owner_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin && !linux
+
+package cli
+
+import "os"
+
+var (
+	wakeTargetCurrentUID   = func() (int, bool) { return 0, false }
+	wakeTargetFileOwnerUID = func(info os.FileInfo) (int, bool) { return 0, false }
+)

--- a/internal/cli/wake_target_owner_unix.go
+++ b/internal/cli/wake_target_owner_unix.go
@@ -1,0 +1,19 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	wakeTargetCurrentUID   = func() (int, bool) { return os.Geteuid(), true }
+	wakeTargetFileOwnerUID = func(info os.FileInfo) (int, bool) {
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return 0, false
+		}
+		return int(stat.Uid), true
+	}
+)

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -119,7 +119,7 @@ func TestInjectNotification_InjectVia(t *testing.T) {
 	}
 	defer func() { _ = os.Remove(tmpPath) }()
 
-	script, err := os.CreateTemp("", "wake-inject-via-*.sh")
+	script, err := os.CreateTemp(secureTempDirForTest(t), "wake-inject-via-*.sh")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestInjectNotification_InjectVia_MultiWordCommand(t *testing.T) {
 	}
 	defer func() { _ = os.Remove(tmpPath) }()
 
-	scriptDir := filepath.Join(t.TempDir(), "inject dir")
+	scriptDir := filepath.Join(secureTempDirForTest(t), "inject dir")
 	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
 		t.Fatalf("mkdir script dir: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestInjectNotification_InjectVia_Bell(t *testing.T) {
 	}
 	defer func() { _ = os.Remove(tmpPath) }()
 
-	script, err := os.CreateTemp("", "wake-inject-via-bell-*.sh")
+	script, err := os.CreateTemp(secureTempDirForTest(t), "wake-inject-via-bell-*.sh")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestInjectNotification_InjectVia_Bell(t *testing.T) {
 }
 
 func TestInjectViaTimeout(t *testing.T) {
-	scriptPath := filepath.Join(t.TempDir(), "sleep.sh")
+	scriptPath := filepath.Join(secureTempDirForTest(t), "sleep.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 2\n"), 0o755); err != nil {
 		t.Fatalf("write script: %v", err)
 	}
@@ -339,7 +339,7 @@ func captureWakeStderr(t *testing.T, fn func()) string {
 }
 
 func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
@@ -421,7 +421,7 @@ func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *test
 }
 
 func TestNotifyNewMessages_InjectViaInjectCmdPayload(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
@@ -478,7 +478,7 @@ func TestNotifyNewMessages_InjectViaInjectCmdPayload(t *testing.T) {
 }
 
 func TestNotifyNewMessages_InjectViaInterruptFailureDoesNotUpdateCooldown(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -22,79 +23,43 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// wakeLock represents the lock file content for wake process deduplication.
-type wakeLock struct {
-	PID          int      `json:"pid"`
-	TTY          string   `json:"tty"`
-	Root         string   `json:"root"`                    // Absolute path to disambiguate relative AM_ROOT
-	Agent        string   `json:"agent,omitempty"`         // Agent handle that owns this lock
-	Hostname     string   `json:"hostname,omitempty"`      // Host that created the lock
-	Started      string   `json:"started"`                 // Wall-clock diagnostic timestamp
-	ProcessStart string   `json:"process_start,omitempty"` // Kernel process start token, guards PID reuse
-	BootID       string   `json:"boot_id,omitempty"`       // Boot identity paired with ProcessStart when available
-	Executable   string   `json:"executable,omitempty"`    // Diagnostic process executable basename/path
-	Args         []string `json:"args,omitempty"`          // Diagnostic argv when available
-}
-
-type wakeProcessInfo struct {
-	PID          int
-	Running      bool
-	StartToken   string
-	BootID       string
-	Executable   string
-	Args         []string
-	InspectError error
-}
-
-type wakeLockStatus string
-
-const (
-	wakeLockMissing    wakeLockStatus = "missing"
-	wakeLockValid      wakeLockStatus = "valid"
-	wakeLockStale      wakeLockStatus = "stale"
-	wakeLockCreating   wakeLockStatus = "creating"
-	wakeLockUnverified wakeLockStatus = "unverified"
-)
-
-type wakeLockInspection struct {
-	Exists            bool
-	Status            wakeLockStatus
-	Reason            string
-	Root              string
-	Agent             string
-	LockPath          string
-	PID               int
-	Lock              wakeLock
-	Process           wakeProcessInfo
-	IdentityConfirmed bool
-	raw               []byte
-}
-
 var (
-	inspectWakeProcess = inspectWakeProcessPlatform
+	signalWakeProcess = func(pid int, sig os.Signal) error {
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return err
+		}
+		return proc.Signal(sig)
+	}
+	wakeTerminateGrace = 100 * time.Millisecond
 	getWakeCurrentTTY  = getCurrentTTY
 	getWakeProcessSID  = unix.Getsid
 )
 
+type wakeRepairResult struct {
+	Status          string `json:"status"`
+	Agent           string `json:"agent"`
+	Root            string `json:"root"`
+	Lock            string `json:"lock"`
+	Target          string `json:"target,omitempty"`
+	PID             int    `json:"pid,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	RepairAvailable bool   `json:"repair_available,omitempty"`
+}
+
+type wakeRepairStarter func(root, me string, target wakeTarget) (int, error)
+
 type wakeLockAcquireOptions struct {
 	acceptExistingValid bool
+	target              *wakeTarget
 }
 
-type wakeAlreadyRunningError struct {
-	Agent      string
-	Inspection wakeLockInspection
-}
-
-func (e *wakeAlreadyRunningError) Error() string {
-	lock := e.Inspection.Lock
-	return fmt.Sprintf("wake already running for %s (pid %d on %s since %s)",
-		e.Agent, lock.PID, lock.TTY, lock.Started)
-}
+var startWakeFromTarget = startWakeFromTargetDefault
 
 // acquireWakeLock attempts to acquire the wake lock for an agent's inbox.
 // Returns cleanup function and error. If another wake is running, returns error.
-func acquireWakeLock(root, me string) (cleanup func(), err error) {
-	return acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{})
+func acquireWakeLock(root, me string, target *wakeTarget) (cleanup func(), err error) {
+	return acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{target: target})
 }
 
 func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions) (cleanup func(), err error) {
@@ -123,7 +88,11 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 				}
 				return nil, wakeLockAlreadyRunningError(me, inspection)
 			}
-			if shouldReplaceOrphanedWakeLock(inspection) {
+			replace, replaceErr := shouldReplaceOrphanedWakeLock(inspection)
+			if replaceErr != nil {
+				return nil, replaceErr
+			}
+			if replace {
 				goto createLock
 			}
 			return nil, wakeLockAlreadyRunningError(me, inspection)
@@ -147,6 +116,10 @@ createLock:
 		Root:    canonicalWakeRoot(root),
 		Agent:   me,
 		Started: time.Now().UTC().Format(time.RFC3339),
+	}
+	if options.target != nil {
+		lock.WakeMode = wakeTargetInjectVia
+		lock.TargetDigest = wakeTargetDigest(*options.target)
 	}
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
@@ -202,152 +175,9 @@ createLock:
 	return cleanup, nil
 }
 
-func inspectWakeLock(root, me string) wakeLockInspection {
-	lockPath := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
-	inspection := wakeLockInspection{
-		Status:   wakeLockMissing,
-		Root:     canonicalWakeRoot(root),
-		Agent:    me,
-		LockPath: lockPath,
-	}
-
-	data, err := os.ReadFile(lockPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return inspection
-		}
-		inspection.Exists = true
-		inspection.Status = wakeLockUnverified
-		inspection.Reason = fmt.Sprintf("cannot read lock: %v", err)
-		return inspection
-	}
-
-	inspection.Exists = true
-	inspection.raw = data
-	var existing wakeLock
-	if err := json.Unmarshal(data, &existing); err != nil {
-		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) < 2*time.Second {
-			inspection.Status = wakeLockCreating
-			inspection.Reason = "lock is being created"
-			return inspection
-		}
-		inspection.Status = wakeLockStale
-		inspection.Reason = "invalid lock json"
-		return inspection
-	}
-
-	inspection.Lock = existing
-	inspection.PID = existing.PID
-	inspection.Process = inspectWakeProcess(existing.PID)
-	classifyWakeLock(root, me, &inspection)
-	return inspection
-}
-
-func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
-	lock := inspection.Lock
-	if lock.PID <= 0 {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "invalid pid"
-		return
-	}
-	if strings.TrimSpace(lock.Root) == "" {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "lock root missing"
-		return
-	}
-	if canonicalWakeRoot(lock.Root) != canonicalWakeRoot(root) {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "root mismatch"
-		return
-	}
-	if lock.Agent != "" && lock.Agent != me {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "agent mismatch"
-		return
-	}
-	if lock.Hostname != "" {
-		if hostname, err := os.Hostname(); err == nil && hostname != "" && lock.Hostname != hostname {
-			inspection.Status = wakeLockUnverified
-			inspection.Reason = "hostname mismatch"
-			return
-		}
-	}
-
-	proc := inspection.Process
-	if !proc.Running {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "pid not running"
-		return
-	}
-	if lock.ProcessStart != "" {
-		if proc.StartToken == "" {
-			inspection.Status = wakeLockUnverified
-			inspection.Reason = inspectionReason("process start time unavailable", proc.InspectError)
-			return
-		}
-		if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
-			inspection.Status = wakeLockStale
-			inspection.Reason = "boot id mismatch"
-			return
-		}
-		if lock.ProcessStart != proc.StartToken {
-			inspection.Status = wakeLockStale
-			inspection.Reason = "process start time mismatch"
-			return
-		}
-	}
-	if proc.Executable == "" {
-		inspection.Status = wakeLockUnverified
-		inspection.Reason = inspectionReason("process identity unavailable", proc.InspectError)
-		return
-	}
-	if !processLooksLikeAMQ(proc) {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "pid is not amq"
-		return
-	}
-	if len(proc.Args) > 0 && !processArgsLookLikeWake(proc.Args) {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "pid is not amq wake"
-		return
-	}
-
-	if lock.ProcessStart != "" {
-		inspection.IdentityConfirmed = true
-		inspection.Status = wakeLockValid
-		return
-	}
-
-	if wakeArgsMatchRootAgent(proc.Args, root, me) {
-		inspection.IdentityConfirmed = true
-		inspection.Status = wakeLockValid
-		return
-	}
-
-	inspection.Status = wakeLockUnverified
-	inspection.Reason = "legacy lock lacks process start metadata"
-}
-
-func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
-	current, err := os.ReadFile(inspection.LockPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("re-read wake lock before removal: %w", err)
-	}
-	if !bytes.Equal(current, inspection.raw) {
-		return fmt.Errorf("wake lock changed while cleaning stale lock; retry")
-	}
-	if err := os.Remove(inspection.LockPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove stale wake lock: %w", err)
-	}
-	return nil
-}
-
-func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
+func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
 	if !wakeLockNeedsReplacement(inspection) {
-		return false
+		return false, nil
 	}
 	return replaceConfirmedOrphanedWakeLock(inspection)
 }
@@ -394,131 +224,64 @@ func requireWakeLockUsable(inspection wakeLockInspection) error {
 	return nil
 }
 
-func replaceConfirmedOrphanedWakeLock(inspection wakeLockInspection) bool {
-	if !terminateWakeProcessIfStillConfirmed(inspection) {
-		return false
-	}
-	return removeWakeLockIfUnchanged(inspection) == nil
+func replaceConfirmedOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
+	return terminateAndRemoveOrphanedWakeLock(inspection)
 }
 
-func terminateWakeProcessIfStillConfirmed(inspection wakeLockInspection) bool {
-	if !sameConfirmedWakeLock(inspection) {
+func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
+	recheck := inspectWakeLock(inspection.Root, inspection.Agent)
+	if !sameWakeLockInspection(inspection, recheck) || !recheck.IdentityConfirmed {
+		return false, nil
+	}
+	if err := terminateWakeProcess(recheck); err != nil {
+		return false, err
+	}
+	if err := removeWakeLockIfUnchanged(recheck); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func sameWakeLockInspection(first, second wakeLockInspection) bool {
+	if !second.Exists || second.Status != wakeLockValid {
 		return false
 	}
-	pid := inspection.PID
-	if proc, err := os.FindProcess(pid); err == nil {
-		_ = proc.Signal(syscall.SIGTERM)
-		time.Sleep(100 * time.Millisecond)
-		if processAlive(pid) {
-			if !sameConfirmedWakeLock(inspection) {
-				return false
-			}
-			_ = proc.Signal(syscall.SIGKILL)
-		}
+	if first.PID != second.PID || first.Root != second.Root || first.Agent != second.Agent {
+		return false
 	}
-	return true
+	return bytes.Equal(first.raw, second.raw)
+}
+
+func terminateWakeProcess(inspection wakeLockInspection) error {
+	if !sameConfirmedWakeLock(inspection) {
+		return fmt.Errorf("wake process identity changed before SIGTERM")
+	}
+	if err := signalWakeProcess(inspection.PID, syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal wake process SIGTERM: %w", err)
+	}
+	time.Sleep(wakeTerminateGrace)
+	if !wakeProcessStillMatches(inspection) {
+		return nil
+	}
+	if !sameConfirmedWakeLock(inspection) {
+		return fmt.Errorf("wake process identity changed before SIGKILL")
+	}
+	if err := signalWakeProcess(inspection.PID, syscall.SIGKILL); err != nil {
+		return fmt.Errorf("signal wake process SIGKILL: %w", err)
+	}
+	deadline := time.Now().Add(wakeTerminateGrace)
+	for wakeProcessStillMatches(inspection) {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("wake process still alive after SIGKILL")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil
 }
 
 func sameConfirmedWakeLock(inspection wakeLockInspection) bool {
 	recheck := inspectWakeLock(inspection.Root, inspection.Agent)
-	return recheck.Exists &&
-		recheck.Status == wakeLockValid &&
-		recheck.IdentityConfirmed &&
-		recheck.PID == inspection.PID &&
-		bytes.Equal(recheck.raw, inspection.raw)
-}
-
-func currentWakeLockMatches(lock wakeLock) bool {
-	if lock.PID != os.Getpid() {
-		return false
-	}
-	if lock.ProcessStart == "" {
-		return true
-	}
-	proc := inspectWakeProcess(os.Getpid())
-	if !proc.Running || proc.StartToken == "" {
-		return false
-	}
-	if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
-		return false
-	}
-	return lock.ProcessStart == proc.StartToken
-}
-
-func canonicalWakeRoot(root string) string {
-	absRoot, err := filepath.Abs(root)
-	if err != nil {
-		absRoot = root
-	}
-	if realRoot, err := filepath.EvalSymlinks(absRoot); err == nil {
-		absRoot = realRoot
-	}
-	return filepath.Clean(absRoot)
-}
-
-func wakeLockAlreadyRunningError(me string, inspection wakeLockInspection) error {
-	return &wakeAlreadyRunningError{
-		Agent:      me,
-		Inspection: inspection,
-	}
-}
-
-func inspectionReason(base string, err error) string {
-	if err == nil {
-		return base
-	}
-	return fmt.Sprintf("%s: %v", base, err)
-}
-
-func processLooksLikeAMQ(proc wakeProcessInfo) bool {
-	if isAMQExecutable(proc.Executable) {
-		return true
-	}
-	if len(proc.Args) > 0 && isAMQExecutable(proc.Args[0]) {
-		return true
-	}
-	return false
-}
-
-func processArgsLookLikeWake(args []string) bool {
-	if len(args) < 2 {
-		return false
-	}
-	for _, arg := range args[1:] {
-		if arg == "wake" {
-			return true
-		}
-	}
-	return false
-}
-
-func wakeArgsMatchRootAgent(args []string, root, me string) bool {
-	if !processArgsLookLikeWake(args) {
-		return false
-	}
-	rootMatch := false
-	meMatch := false
-	for i := 1; i < len(args); i++ {
-		arg := args[i]
-		switch {
-		case arg == "--root" && i+1 < len(args):
-			rootMatch = canonicalWakeRoot(args[i+1]) == canonicalWakeRoot(root)
-			i++
-		case strings.HasPrefix(arg, "--root="):
-			rootMatch = canonicalWakeRoot(strings.TrimPrefix(arg, "--root=")) == canonicalWakeRoot(root)
-		case arg == "--me" && i+1 < len(args):
-			meMatch = args[i+1] == me
-			i++
-		case strings.HasPrefix(arg, "--me="):
-			meMatch = strings.TrimPrefix(arg, "--me=") == me
-		}
-	}
-	return rootMatch && meMatch
-}
-
-func isAMQExecutable(value string) bool {
-	base := filepath.Base(strings.Trim(value, `"'`))
-	return base == "amq"
+	return sameWakeLockInspection(inspection, recheck) && recheck.IdentityConfirmed
 }
 
 // processAlive checks if a process with given PID is running.
@@ -548,7 +311,204 @@ func processAlive(pid int) bool {
 type wakeLoopFunc func(wakeConfig) error
 
 func runWake(args []string) error {
+	if len(args) > 0 && args[0] == "repair" {
+		return runWakeRepair(args[1:])
+	}
 	return runWakeWithLoop(args, runWakeLoop)
+}
+
+func runWakeRepair(args []string) error {
+	fs := flag.NewFlagSet("wake repair", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	usage := usageWithFlags(fs, "amq wake repair --me <agent> [options]",
+		"Repair a proven-stale wake by restarting it from a saved inject-via target.",
+		"",
+		"Refuses unverified locks and raw terminal wake targets. This command only",
+		"uses .wake.target files created for --inject-via wake processes.")
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if err := requireMe(common.Me); err != nil {
+		return err
+	}
+	me, err := normalizeHandle(common.Me)
+	if err != nil {
+		return UsageError("--me: %v", err)
+	}
+	root := resolveRoot(common.Root)
+	if err := validateKnownHandles(root, common.Strict, me); err != nil {
+		return err
+	}
+	result, repairErr := repairWake(root, me)
+	if common.JSON {
+		if err := writeJSON(os.Stdout, result); err != nil {
+			return err
+		}
+		return repairErr
+	}
+	line := fmt.Sprintf("wake repair: %s agent=%s root=%s", result.Status, result.Agent, result.Root)
+	if result.PID != 0 {
+		line += fmt.Sprintf(" pid=%d", result.PID)
+	}
+	if result.Reason != "" {
+		line += " reason=" + result.Reason
+	}
+	if err := writeStdoutLine(line); err != nil {
+		return err
+	}
+	return repairErr
+}
+
+func repairWake(root, me string) (wakeRepairResult, error) {
+	result := wakeRepairResult{
+		Status: "unknown",
+		Agent:  me,
+		Root:   canonicalWakeRoot(root),
+		Lock:   filepath.Join(fsq.AgentBase(root, me), ".wake.lock"),
+		Target: wakeTargetPath(root, me),
+	}
+	inspection := inspectWakeLock(root, me)
+	if !inspection.Exists {
+		result.Status = "refused"
+		result.Reason = "no wake lock present; start wake normally"
+		return result, errors.New(result.Reason)
+	}
+	switch inspection.Status {
+	case wakeLockValid:
+		result.Status = "already-running"
+		result.PID = inspection.PID
+		return result, nil
+	case wakeLockStale:
+		// ok; continue after target validation
+	case wakeLockCreating:
+		result.Status = "refused"
+		result.Reason = "wake lock is being created; retry shortly"
+		return result, errors.New(result.Reason)
+	case wakeLockUnverified:
+		result.Status = "refused"
+		result.PID = inspection.PID
+		result.Reason = "wake lock is unverified; refusing to start a second injector"
+		return result, fmt.Errorf("%s: %s", result.Reason, inspection.Reason)
+	default:
+		result.Status = "refused"
+		result.Reason = fmt.Sprintf("wake lock status %q is not repairable", inspection.Status)
+		return result, errors.New(result.Reason)
+	}
+
+	target, exists, err := readWakeTarget(root, me)
+	if err != nil {
+		result.Status = "refused"
+		result.Reason = err.Error()
+		return result, err
+	}
+	if !exists {
+		result.Status = "refused"
+		result.Reason = "no inject-via wake target; restart wake manually"
+		return result, errors.New(result.Reason)
+	}
+	if err := validateWakeTarget(target, root, me); err != nil {
+		result.Status = "refused"
+		result.Reason = err.Error()
+		return result, err
+	}
+	if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
+		result.Status = "refused"
+		result.Reason = err.Error()
+		return result, err
+	}
+	result.RepairAvailable = true
+
+	recheck := inspectWakeLock(root, me)
+	if recheck.Status != wakeLockStale {
+		result.Status = "refused"
+		result.PID = recheck.PID
+		result.Reason = "wake lock changed before repair"
+		return result, errors.New(result.Reason)
+	}
+	if !bytes.Equal(inspection.raw, recheck.raw) {
+		result.Status = "refused"
+		result.PID = recheck.PID
+		result.Reason = "wake lock changed before repair"
+		return result, errors.New(result.Reason)
+	}
+	if err := validateWakeTargetMatchesLock(recheck.Lock, target); err != nil {
+		result.Status = "refused"
+		result.Reason = err.Error()
+		return result, err
+	}
+	if err := removeWakeLockIfUnchanged(recheck); err != nil {
+		result.Status = "error"
+		result.Reason = err.Error()
+		return result, err
+	}
+	pid, err := startWakeFromTarget(root, me, target)
+	if err != nil {
+		result.Status = "error"
+		result.Reason = err.Error()
+		return result, err
+	}
+	result.Status = "repaired"
+	result.PID = pid
+	return result, nil
+}
+
+func startWakeFromTargetDefault(root, me string, target wakeTarget) (int, error) {
+	amqBin, err := os.Executable()
+	if err != nil {
+		amqBin = "amq"
+	}
+	readyPath, cleanupReady, err := newWakeReadyFile()
+	if err != nil {
+		return 0, fmt.Errorf("create wake readiness file: %w", err)
+	}
+	defer cleanupReady()
+	args := buildRepairWakeArgs(root, me, target, readyPath)
+	cmd := exec.Command(amqBin, args...)
+	cmd.Env = setEnvVar(os.Environ(), envRoot, root)
+	output, err := openWakeRepairOutput(root, me)
+	if err != nil {
+		return 0, err
+	}
+	defer output.Close()
+	configureRepairWakeCommand(cmd, output)
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("start repaired amq wake: %w", err)
+	}
+	if err := waitForWakeReady(cmd.Process, readyPath, wakeReadyTimeout); err != nil {
+		_ = cmd.Process.Kill()
+		return 0, err
+	}
+	return cmd.Process.Pid, nil
+}
+
+func openWakeRepairOutput(root, me string) (*os.File, error) {
+	agentBase := fsq.AgentBase(root, me)
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		return nil, fmt.Errorf("create repair wake log directory: %w", err)
+	}
+	path := filepath.Join(agentBase, ".wake.repair.log")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open repair wake log: %w", err)
+	}
+	return file, nil
+}
+
+func configureRepairWakeCommand(cmd *exec.Cmd, output *os.File) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Stdin = nil
+	cmd.Stdout = output
+	cmd.Stderr = output
+}
+
+func buildRepairWakeArgs(root, me string, target wakeTarget, readyPath string) []string {
+	args := []string{"--no-update-check", "wake", "--me", me, "--root", root, "--inject-via", target.InjectVia}
+	for _, arg := range target.InjectArgs {
+		args = append(args, "--inject-arg", arg)
+	}
+	return append(args, "--ready-file", readyPath)
 }
 
 func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
@@ -591,7 +551,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		"  the TIOCSTI/stdin-TTY startup requirement. Fixed arguments use repeatable",
 		"  --inject-arg; AMQ appends the sanitized notification payload as the",
 		"  final argv element. The command is not run through a shell.",
-		"  Example: amq wake --me orchestrator --inject-via ghostty-bridge \\",
+		"  Example: amq wake --me orchestrator --inject-via /path/to/ghostty-bridge \\",
 		"    --inject-arg exec --inject-arg \"$TERMINAL_ID\"",
 		"  Trust boundary: --inject-via executes local code, and the payload can",
 		"  contain sanitized but message-derived header content.",
@@ -671,7 +631,6 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return err
 	}
 
-	// Validate --inject-via: it is an executable path, not a shell command line.
 	injectVia := strings.TrimSpace(*injectViaFlag)
 	if *injectViaFlag != "" && injectVia == "" {
 		return UsageError("--inject-via must not be blank")
@@ -701,10 +660,17 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return UsageError("%v", err)
 	}
 
+	var target *wakeTarget
+	if injectVia != "" {
+		value := newWakeTarget(root, me, injectVia, []string(injectArgFlags))
+		target = &value
+	}
+
 	// Acquire lock to prevent duplicate wake processes
 	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
 	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
 		acceptExistingValid: acceptExistingWake,
+		target:              target,
 	})
 	if err != nil {
 		var alreadyRunning *wakeAlreadyRunningError
@@ -714,6 +680,17 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return err
 	}
 	defer cleanup()
+
+	if injectVia != "" {
+		if err := writeWakeTarget(root, me, *target); err != nil {
+			_ = writeStderr("warning: wake target not persisted; live repair disabled: %v\n", err)
+			if removeErr := removeWakeTarget(root, me); removeErr != nil {
+				return fmt.Errorf("clear stale wake target after persist failure: %w", removeErr)
+			}
+		}
+	} else if err := removeWakeTarget(root, me); err != nil {
+		return err
+	}
 
 	cfg := wakeConfig{
 		me:                me,

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -403,7 +403,12 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 		result.Reason = "wake lock is already valid; refusing repair"
 		return result, errors.New(result.Reason)
 	case wakeLockStale:
-		// ok; continue after target validation
+		if err := validateWakeLockRepairable(inspection); err != nil {
+			result.Status = "refused"
+			result.PID = inspection.PID
+			result.Reason = err.Error()
+			return result, err
+		}
 	case wakeLockCreating:
 		result.Status = "refused"
 		result.Reason = "wake lock is being created; retry shortly"
@@ -449,6 +454,12 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 		result.Reason = "wake lock changed before repair"
 		return result, errors.New(result.Reason)
 	}
+	if err := validateWakeLockRepairable(recheck); err != nil {
+		result.Status = "refused"
+		result.PID = recheck.PID
+		result.Reason = "wake lock changed before repair"
+		return result, errors.New(result.Reason)
+	}
 	if !bytes.Equal(inspection.raw, recheck.raw) {
 		result.Status = "refused"
 		result.PID = recheck.PID
@@ -474,6 +485,18 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 	result.Status = "repaired"
 	result.PID = pid
 	return result, nil
+}
+
+func validateWakeLockRepairable(inspection wakeLockInspection) error {
+	if inspection.Status != wakeLockStale {
+		return fmt.Errorf("wake lock status %q is not repairable", inspection.Status)
+	}
+	switch inspection.Reason {
+	case "pid not running", "boot id mismatch", "process start time mismatch", "pid is not amq", "pid is not amq wake":
+		return nil
+	default:
+		return fmt.Errorf("wake lock stale reason %q is not repairable", inspection.Reason)
+	}
 }
 
 func startWakeFromTargetDefault(root, me string, target wakeTarget) (int, error) {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -489,9 +489,26 @@ func openWakeRepairOutput(root, me string) (*os.File, error) {
 		return nil, fmt.Errorf("create repair wake log directory: %w", err)
 	}
 	path := filepath.Join(agentBase, ".wake.repair.log")
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("repair wake log %s must not be a symlink", path)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("repair wake log %s must be a regular file", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat repair wake log: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open repair wake log: %w", err)
+	}
+	if info, err := file.Stat(); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("stat repair wake log: %w", err)
+	} else if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("repair wake log %s must be a regular file", path)
 	}
 	return file, nil
 }

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -217,11 +217,32 @@ func requireWakeLockUsable(inspection wakeLockInspection) error {
 	if !inspection.Exists || inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
 		return fmt.Errorf("existing wake lock for %s is not a confirmed valid wake", inspection.Agent)
 	}
+	if !wakeLockHasTTYOrExternalInjector(inspection) {
+		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
+			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
+	}
 	if wakeLockNeedsReplacement(inspection) {
 		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
 			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
 	}
 	return nil
+}
+
+func wakeLockHasTTYOrExternalInjector(inspection wakeLockInspection) bool {
+	if inspection.Lock.WakeMode == wakeTargetInjectVia || wakeArgsUseInjectVia(inspection.Process.Args) {
+		return true
+	}
+	tty := strings.TrimSpace(inspection.Lock.TTY)
+	return tty != "" && tty != "unknown"
+}
+
+func wakeArgsUseInjectVia(args []string) bool {
+	for _, arg := range args {
+		if arg == "--inject-via" || strings.HasPrefix(arg, "--inject-via=") {
+			return true
+		}
+	}
+	return false
 }
 
 func replaceConfirmedOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
@@ -377,9 +398,10 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 	}
 	switch inspection.Status {
 	case wakeLockValid:
-		result.Status = "already-running"
+		result.Status = "refused"
 		result.PID = inspection.PID
-		return result, nil
+		result.Reason = "wake lock is already valid; refusing repair"
+		return result, errors.New(result.Reason)
 	case wakeLockStale:
 		// ok; continue after target validation
 	case wakeLockCreating:

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -471,7 +471,7 @@ func startWakeFromTargetDefault(root, me string, target wakeTarget) (int, error)
 	if err != nil {
 		return 0, err
 	}
-	defer output.Close()
+	defer func() { _ = output.Close() }()
 	configureRepairWakeCommand(cmd, output)
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("start repaired amq wake: %w", err)

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -679,7 +679,14 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 
 	var target *wakeTarget
 	if injectVia != "" {
-		value := newWakeTarget(root, me, injectVia, []string(injectArgFlags))
+		value, err := newWakeTarget(root, me, injectVia, []string(injectArgFlags))
+		if err != nil {
+			return err
+		}
+		if err := validateWakeTarget(value, root, me); err != nil {
+			return err
+		}
+		injectVia = value.InjectVia
 		target = &value
 	}
 
@@ -704,6 +711,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 			if removeErr := removeWakeTarget(root, me); removeErr != nil {
 				return fmt.Errorf("clear stale wake target after persist failure: %w", removeErr)
 			}
+		}
+		if err := validateWakeInjectViaPath(injectVia); err != nil {
+			return err
 		}
 	} else if err := removeWakeTarget(root, me); err != nil {
 		return err

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -492,7 +492,7 @@ func validateWakeLockRepairable(inspection wakeLockInspection) error {
 		return fmt.Errorf("wake lock status %q is not repairable", inspection.Status)
 	}
 	switch inspection.Reason {
-	case "pid not running", "boot id mismatch", "process start time mismatch", "pid is not amq", "pid is not amq wake":
+	case "pid not running", "pid is not amq", "pid is not amq wake":
 		return nil
 	default:
 		return fmt.Errorf("wake lock stale reason %q is not repairable", inspection.Reason)

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -929,6 +929,63 @@ func TestRemoveWakeLockIfUnchangedRefusesChangedLock(t *testing.T) {
 	}
 }
 
+func TestInspectWakeLockRejectsSymlinkAndFIFO(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		setup     func(t *testing.T, path string)
+		wantError string
+	}{
+		{
+			name: "symlink",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				target := filepath.Join(t.TempDir(), "lock.json")
+				if err := os.WriteFile(target, []byte(`{"pid":4242}`), 0o600); err != nil {
+					t.Fatalf("write target lock: %v", err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatalf("symlink lock: %v", err)
+				}
+			},
+			wantError: "must not be a symlink",
+		},
+		{
+			name: "fifo",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := syscall.Mkfifo(path, 0o600); err != nil {
+					t.Fatalf("mkfifo lock: %v", err)
+				}
+			},
+			wantError: "must be a regular file",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			agentBase := fsq.AgentBase(root, "orchestrator")
+			if err := os.MkdirAll(agentBase, 0o700); err != nil {
+				t.Fatalf("mkdir agent base: %v", err)
+			}
+			tc.setup(t, filepath.Join(agentBase, ".wake.lock"))
+
+			done := make(chan wakeLockInspection, 1)
+			go func() {
+				done <- inspectWakeLock(root, "orchestrator")
+			}()
+
+			select {
+			case inspection := <-done:
+				if !inspection.Exists || inspection.Status != wakeLockUnverified ||
+					!strings.Contains(inspection.Reason, tc.wantError) {
+					t.Fatalf("unexpected inspection: %#v", inspection)
+				}
+			case <-time.After(250 * time.Millisecond):
+				t.Fatal("inspectWakeLock blocked")
+			}
+		})
+	}
+}
+
 func TestShouldReplaceOrphanedWakeLockSignalsOnlyAfterRevalidation(t *testing.T) {
 	const wakePID = 4242
 	root := secureTempDirForTest(t)

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -15,12 +15,15 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-func stubInspectWakeProcess(t *testing.T, fn func(pid int) wakeProcessInfo) {
+func stubSignalWakeProcess(t *testing.T, fn func(pid int, sig os.Signal) error) {
 	t.Helper()
-	old := inspectWakeProcess
-	inspectWakeProcess = fn
+	oldSignal := signalWakeProcess
+	oldGrace := wakeTerminateGrace
+	signalWakeProcess = fn
+	wakeTerminateGrace = 0
 	t.Cleanup(func() {
-		inspectWakeProcess = old
+		signalWakeProcess = oldSignal
+		wakeTerminateGrace = oldGrace
 	})
 }
 
@@ -42,32 +45,13 @@ func stubWakeProcessSID(t *testing.T, fn func(pid int) (int, error)) {
 	})
 }
 
-func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) string {
+func writeExecutableForTest(t *testing.T, name string) string {
 	t.Helper()
-	if err := fsq.EnsureRootDirs(root); err != nil {
-		t.Fatalf("EnsureRootDirs: %v", err)
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
 	}
-	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
-		t.Fatalf("EnsureAgentDirs: %v", err)
-	}
-	if lock.Root == "" {
-		lock.Root = canonicalWakeRoot(root)
-	}
-	if lock.Agent == "" {
-		lock.Agent = agent
-	}
-	if lock.Started == "" {
-		lock.Started = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	}
-	data, err := json.Marshal(lock)
-	if err != nil {
-		t.Fatalf("marshal wake lock: %v", err)
-	}
-	lockPath := filepath.Join(fsq.AgentBase(root, agent), ".wake.lock")
-	if err := os.WriteFile(lockPath, data, 0o600); err != nil {
-		t.Fatalf("write wake lock: %v", err)
-	}
-	return lockPath
+	return path
 }
 
 func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
@@ -81,10 +65,11 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 
 	var got wakeConfig
 	errDone := errors.New("done")
+	injector := writeExecutableForTest(t, "inject tool")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/inject tool",
+		"--inject-via", injector,
 		"--inject-arg", "exec",
 		"--inject-arg", "Team Alpha",
 		"--inject-timeout", "250ms",
@@ -95,7 +80,7 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 	if !errors.Is(err, errDone) {
 		t.Fatalf("expected loop sentinel error, got %v", err)
 	}
-	if got.injectVia != "/tmp/inject tool" {
+	if got.injectVia != injector {
 		t.Fatalf("expected inject executable with spaces, got %q", got.injectVia)
 	}
 	if strings.Join(got.injectArgs, "|") != "exec|Team Alpha" {
@@ -116,11 +101,12 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	}
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	injector := writeExecutableForTest(t, "injector")
 	errDone := errors.New("done")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/injector",
+		"--inject-via", injector,
 		"--ready-file", readyPath,
 	}, func(cfg wakeConfig) error {
 		if _, statErr := os.Stat(readyPath); statErr != nil {
@@ -130,6 +116,122 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	})
 	if !errors.Is(err, errDone) {
 		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopWritesInjectViaWakeTarget(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	injector := writeExecutableForTest(t, "injector")
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", injector,
+		"--inject-arg", "exec",
+	}, func(cfg wakeConfig) error {
+		target, exists, targetErr := readWakeTarget(root, "orchestrator")
+		if targetErr != nil {
+			t.Fatalf("readWakeTarget: %v", targetErr)
+		}
+		if !exists {
+			t.Fatal("expected wake target to be written")
+		}
+		if target.InjectVia != injector || strings.Join(target.InjectArgs, "|") != "exec" {
+			t.Fatalf("unexpected target: %#v", target)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopStartsWhenInjectViaTargetIsNotPersistable(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	injector := writeExecutableForTest(t, "injector")
+	if err := os.Chmod(injector, 0o777); err != nil {
+		t.Fatalf("chmod injector: %v", err)
+	}
+	errDone := errors.New("done")
+	var runErr error
+	stderr := captureWakeStderr(t, func() {
+		runErr = runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-via", injector,
+			"--inject-arg", "exec",
+		}, func(cfg wakeConfig) error {
+			if cfg.injectVia != injector {
+				t.Fatalf("injectVia = %q, want %q", cfg.injectVia, injector)
+			}
+			if _, exists, targetErr := readWakeTarget(root, "orchestrator"); targetErr != nil || exists {
+				t.Fatalf("wake target exists=%v err=%v, want absent with no read error", exists, targetErr)
+			}
+			return errDone
+		})
+	})
+	if !errors.Is(runErr, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "warning: wake target not persisted; live repair disabled:") ||
+		!strings.Contains(stderr, "group/world-writable") {
+		t.Fatalf("expected non-fatal target warning, got %q", stderr)
+	}
+}
+
+func TestRunWakeWithLoopClearsOldWakeTargetWhenNewTargetIsNotPersistable(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	oldInjector := writeExecutableForTest(t, "old-injector")
+	if err := writeWakeTarget(root, "orchestrator", newWakeTarget(root, "orchestrator", oldInjector, []string{"old"})); err != nil {
+		t.Fatalf("write old wake target: %v", err)
+	}
+	newInjector := writeExecutableForTest(t, "new-injector")
+	if err := os.Chmod(newInjector, 0o777); err != nil {
+		t.Fatalf("chmod injector: %v", err)
+	}
+	errDone := errors.New("done")
+	var runErr error
+	stderr := captureWakeStderr(t, func() {
+		runErr = runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-via", newInjector,
+		}, func(cfg wakeConfig) error {
+			if _, exists, targetErr := readWakeTarget(root, "orchestrator"); targetErr != nil || exists {
+				t.Fatalf("wake target exists=%v err=%v, want old target cleared", exists, targetErr)
+			}
+			return errDone
+		})
+	})
+	if !errors.Is(runErr, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", runErr)
+	}
+	if !strings.Contains(stderr, "warning: wake target not persisted; live repair disabled:") {
+		t.Fatalf("expected target warning, got %q", stderr)
+	}
+	if _, exists, err := readWakeTarget(root, "orchestrator"); err != nil || exists {
+		t.Fatalf("wake target exists=%v err=%v after loop, want cleared", exists, err)
 	}
 }
 
@@ -157,10 +259,11 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	injector := writeExecutableForTest(t, "injector")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/injector",
+		"--inject-via", injector,
 		"--ready-file", readyPath,
 	}, func(cfg wakeConfig) error {
 		t.Fatalf("loop should not run with an existing live wake lock: %#v", cfg)
@@ -409,7 +512,7 @@ func TestAcquireWakeLockSelfHealsPIDReusedByNonAMQ(t *testing.T) {
 		return wakeProcessInfo{PID: pid}
 	})
 
-	cleanup, err := acquireWakeLock(root, "orchestrator")
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
 	if err != nil {
 		t.Fatalf("acquireWakeLock should replace stale PID-reuse lock: %v", err)
 	}
@@ -457,7 +560,7 @@ func TestAcquireWakeLockSelfHealsPIDReusedByDifferentAMQStart(t *testing.T) {
 		return wakeProcessInfo{PID: pid}
 	})
 
-	cleanup, err := acquireWakeLock(root, "orchestrator")
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
 	if err != nil {
 		t.Fatalf("acquireWakeLock should replace mismatched start-token lock: %v", err)
 	}
@@ -489,7 +592,7 @@ func TestAcquireWakeLockSelfHealsStartMismatchWhenExecutableUnavailable(t *testi
 		return wakeProcessInfo{PID: pid}
 	})
 
-	cleanup, err := acquireWakeLock(root, "orchestrator")
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
 	if err != nil {
 		t.Fatalf("acquireWakeLock should replace start-token mismatch even without executable: %v", err)
 	}
@@ -516,7 +619,7 @@ func TestAcquireWakeLockStartReadFailureIsUnverifiedNotMismatch(t *testing.T) {
 		return wakeProcessInfo{PID: gotPID}
 	})
 
-	cleanup, err := acquireWakeLock(root, "orchestrator")
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
 	if cleanup != nil {
 		defer cleanup()
 	}
@@ -549,7 +652,7 @@ func TestAcquireWakeLockLegacyLiveLockDoesNotAutoDelete(t *testing.T) {
 		return wakeProcessInfo{PID: gotPID}
 	})
 
-	cleanup, err := acquireWakeLock(root, "orchestrator")
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
 	if cleanup != nil {
 		defer cleanup()
 	}
@@ -591,24 +694,118 @@ func TestRemoveWakeLockIfUnchangedRefusesChangedLock(t *testing.T) {
 	}
 }
 
-func TestShouldReplaceOrphanedWakeLockReverifiesBeforeSignal(t *testing.T) {
-	const pid = 4242
+func TestShouldReplaceOrphanedWakeLockSignalsOnlyAfterRevalidation(t *testing.T) {
+	const wakePID = 4242
 	root := t.TempDir()
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
-		PID:          pid,
+		PID:          wakePID,
 		TTY:          "/dev/amq-missing-tty",
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
 	})
+	killed := false
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			if killed {
+				return wakeProcessInfo{PID: pid, Running: false}
+			}
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	signals := []os.Signal{}
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		if pid != wakePID {
+			t.Fatalf("signal pid = %d, want %d", pid, wakePID)
+		}
+		signals = append(signals, sig)
+		if sig == os.Kill {
+			killed = true
+		}
+		return nil
+	})
 
-	inspections := 0
-	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
-		if gotPID == pid {
-			inspections++
-			if inspections == 1 {
+	inspection := inspectWakeLock(root, "orchestrator")
+	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
+	if err != nil {
+		t.Fatalf("shouldReplaceOrphanedWakeLock: %v", err)
+	}
+	if !replaced {
+		t.Fatal("expected confirmed orphan to be replaced")
+	}
+	if len(signals) != 2 {
+		t.Fatalf("signals = %d, want SIGTERM and SIGKILL", len(signals))
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock should be removed after confirmed orphan replacement, stat=%v", err)
+	}
+}
+
+func TestShouldReplaceOrphanedWakeLockKeepsLockWhenKillDoesNotTerminate(t *testing.T) {
+	const wakePID = 4242
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		TTY:          "/dev/amq-missing-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		return nil
+	})
+
+	inspection := inspectWakeLock(root, "orchestrator")
+	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
+	if err == nil || !strings.Contains(err.Error(), "still alive after SIGKILL") {
+		t.Fatalf("expected still-alive error, got %v", err)
+	}
+	if replaced {
+		t.Fatal("should not replace lock when old wake remains alive")
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain after failed kill, stat=%v", statErr)
+	}
+}
+
+func TestShouldReplaceOrphanedWakeLockRevalidatesBeforeSignal(t *testing.T) {
+	const wakePID = 4242
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		TTY:          "/dev/amq-missing-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	inspectCalls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			inspectCalls++
+			if inspectCalls <= 2 {
 				return wakeProcessInfo{
-					PID:        gotPID,
+					PID:        pid,
 					Running:    true,
 					StartToken: "start-1",
 					BootID:     "boot-1",
@@ -617,29 +814,31 @@ func TestShouldReplaceOrphanedWakeLockReverifiesBeforeSignal(t *testing.T) {
 				}
 			}
 			return wakeProcessInfo{
-				PID:        gotPID,
+				PID:        pid,
 				Running:    true,
-				StartToken: "start-2",
+				StartToken: "reused-start",
 				BootID:     "boot-1",
 				Executable: "/bin/sleep",
 				Args:       []string{"/bin/sleep", "100"},
 			}
 		}
-		return wakeProcessInfo{PID: gotPID}
+		return wakeProcessInfo{PID: pid}
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		t.Fatalf("must not signal after process identity changes, got pid=%d sig=%v", pid, sig)
+		return nil
 	})
 
 	inspection := inspectWakeLock(root, "orchestrator")
-	if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
-		t.Fatalf("expected initial valid confirmed lock, got status=%s confirmed=%v", inspection.Status, inspection.IdentityConfirmed)
+	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
+	if err == nil {
+		t.Fatal("expected identity-changed error")
 	}
-	if shouldReplaceOrphanedWakeLock(inspection) {
-		t.Fatal("should not replace when recheck no longer confirms the same wake lock")
+	if replaced {
+		t.Fatal("should not replace lock when process identity changes before signal")
 	}
-	if _, err := os.Stat(lockPath); err != nil {
-		t.Fatalf("lock should remain after failed recheck: %v", err)
-	}
-	if inspections < 2 {
-		t.Fatalf("expected re-inspection before replacement, got %d inspection(s)", inspections)
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain after aborted signal, stat=%v", statErr)
 	}
 }
 
@@ -659,7 +858,7 @@ func TestRunWakeWithLoopRejectsRecentlyCorruptLock(t *testing.T) {
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/injector",
+		"--inject-via", writeExecutableForTest(t, "injector"),
 	}, func(cfg wakeConfig) error {
 		t.Fatalf("loop should not run with recent corrupt lock: %#v", cfg)
 		return nil
@@ -715,6 +914,45 @@ func TestWaitForWakeReadyAcceptsReadyFileWrittenBeforeExit(t *testing.T) {
 	}
 }
 
+func TestConfigureRepairWakeCommandDetachesOutput(t *testing.T) {
+	output, err := os.OpenFile(filepath.Join(t.TempDir(), "repair.log"), os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open output: %v", err)
+	}
+	defer output.Close()
+
+	cmd := exec.Command("amq")
+	configureRepairWakeCommand(cmd, output)
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Fatalf("repair wake command should start in a new session: %#v", cmd.SysProcAttr)
+	}
+	if cmd.Stdout != output || cmd.Stderr != output {
+		t.Fatalf("repair wake command should redirect stdout/stderr to repair log")
+	}
+	if cmd.Stdout == os.Stdout || cmd.Stderr == os.Stderr {
+		t.Fatalf("repair wake command must not inherit parent stdout/stderr")
+	}
+}
+
+func TestOpenWakeRepairOutputCreatesPrivateLog(t *testing.T) {
+	root := t.TempDir()
+	output, err := openWakeRepairOutput(root, "orchestrator")
+	if err != nil {
+		t.Fatalf("openWakeRepairOutput: %v", err)
+	}
+	path := output.Name()
+	if err := output.Close(); err != nil {
+		t.Fatalf("close output: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat repair output: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("repair output mode = %o, want 0600", got)
+	}
+}
+
 func TestRunWakeWithLoopRejectsInjectArgWithoutInjectVia(t *testing.T) {
 	err := runWakeWithLoop([]string{
 		"--root", t.TempDir(),
@@ -736,7 +974,7 @@ func TestRunWakeWithLoopRejectsNonPositiveInjectTimeout(t *testing.T) {
 	err := runWakeWithLoop([]string{
 		"--root", t.TempDir(),
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/injector",
+		"--inject-via", writeExecutableForTest(t, "injector"),
 		"--inject-timeout", "0",
 	}, func(cfg wakeConfig) error {
 		t.Fatalf("loop should not run with invalid timeout: %#v", cfg)

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -919,7 +919,7 @@ func TestConfigureRepairWakeCommandDetachesOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open output: %v", err)
 	}
-	defer output.Close()
+	defer func() { _ = output.Close() }()
 
 	cmd := exec.Command("amq")
 	configureRepairWakeCommand(cmd, output)

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -376,6 +376,7 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
+		TTY:          "tty",
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
@@ -421,6 +422,7 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
+		TTY:          "tty",
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
@@ -493,6 +495,111 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
 		t.Fatalf("existing lock should remain, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsBlankOrUnknownTTY(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tty  string
+	}{
+		{name: "blank", tty: ""},
+		{name: "unknown", tty: "unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const wakePID = 4242
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid == wakePID {
+					return wakeProcessInfo{
+						PID:        pid,
+						Running:    true,
+						StartToken: "start-1",
+						BootID:     "boot-1",
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+					}
+				}
+				return wakeProcessInfo{PID: pid}
+			})
+			root := secureTempDirForTest(t)
+			lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+				PID:          wakePID,
+				TTY:          tc.tty,
+				ProcessStart: "start-1",
+				BootID:       "boot-1",
+				Executable:   "/opt/homebrew/bin/amq",
+			})
+
+			readyPath := filepath.Join(t.TempDir(), "wake.ready")
+			injector := writeExecutableForTest(t, "injector")
+			err := runWakeWithLoop([]string{
+				"--root", root,
+				"--me", "orchestrator",
+				"--inject-via", injector,
+				"--ready-file", readyPath,
+				"--accept-existing-wake",
+			}, func(cfg wakeConfig) error {
+				t.Fatalf("loop should not run with an unusable existing wake lock: %#v", cfg)
+				return nil
+			})
+			if err == nil {
+				t.Fatal("expected unusable wake lock error")
+			}
+			if !strings.Contains(err.Error(), "not usable for --require-wake") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+				t.Fatalf("ready file should not exist, statErr=%v", statErr)
+			}
+			if _, statErr := os.Stat(lockPath); statErr != nil {
+				t.Fatalf("existing lock should remain, statErr=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeAcceptsInjectViaUnknownTTY(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--inject-via", injector},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, target))
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", injector,
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an existing live wake lock: %#v", cfg)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected inject-via wake to satisfy ready file despite unknown tty, got %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); statErr != nil {
+		t.Fatalf("ready file should exist, statErr=%v", statErr)
 	}
 }
 
@@ -578,6 +685,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
 	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
+		TTY:          "test-tty",
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -47,7 +48,7 @@ func stubWakeProcessSID(t *testing.T, fn func(pid int) (int, error)) {
 
 func writeExecutableForTest(t *testing.T, name string) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), name)
+	path := filepath.Join(secureTempDirForTest(t), name)
 	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write executable: %v", err)
 	}
@@ -55,7 +56,7 @@ func writeExecutableForTest(t *testing.T, name string) string {
 }
 
 func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
@@ -92,7 +93,7 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 }
 
 func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
@@ -120,7 +121,7 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 }
 
 func TestRunWakeWithLoopWritesInjectViaWakeTarget(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
@@ -154,7 +155,7 @@ func TestRunWakeWithLoopWritesInjectViaWakeTarget(t *testing.T) {
 }
 
 func TestRunWakeWithLoopStartsWhenInjectViaTargetIsNotPersistable(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
@@ -194,7 +195,7 @@ func TestRunWakeWithLoopStartsWhenInjectViaTargetIsNotPersistable(t *testing.T) 
 }
 
 func TestRunWakeWithLoopClearsOldWakeTargetWhenNewTargetIsNotPersistable(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
@@ -250,7 +251,7 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 		}
 		return wakeProcessInfo{PID: pid}
 	})
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
 		ProcessStart: "start-1",
@@ -295,7 +296,7 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 		}
 		return wakeProcessInfo{PID: pid}
 	})
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
 		ProcessStart: "start-1",
@@ -304,10 +305,11 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	injector := writeExecutableForTest(t, "injector")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/injector",
+		"--inject-via", injector,
 		"--ready-file", readyPath,
 		"--accept-existing-wake",
 	}, func(cfg wakeConfig) error {
@@ -337,7 +339,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 		}
 		return wakeProcessInfo{PID: pid}
 	})
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
 		TTY:          "/dev/amq-missing-tty",
@@ -347,10 +349,11 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	injector := writeExecutableForTest(t, "injector")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/injector",
+		"--inject-via", injector,
 		"--ready-file", readyPath,
 		"--accept-existing-wake",
 	}, func(cfg wakeConfig) error {
@@ -399,7 +402,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *test
 		}
 		return wakeProcessInfo{PID: pid}
 	})
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
 		TTY:          ttyPath,
@@ -409,10 +412,11 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *test
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	injector := writeExecutableForTest(t, "injector")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/injector",
+		"--inject-via", injector,
 		"--ready-file", readyPath,
 		"--accept-existing-wake",
 	}, func(cfg wakeConfig) error {
@@ -449,7 +453,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
 		}
 		return wakeProcessInfo{PID: pid}
 	})
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
 		ProcessStart: "start-1",
@@ -458,10 +462,11 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	injector := writeExecutableForTest(t, "injector")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
-		"--inject-via", "/tmp/injector",
+		"--inject-via", injector,
 		"--ready-file", readyPath,
 		"--accept-existing-wake",
 	}, func(cfg wakeConfig) error {
@@ -481,7 +486,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
 
 func TestAcquireWakeLockSelfHealsPIDReusedByNonAMQ(t *testing.T) {
 	const reusedPID = 4242
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          reusedPID,
 		ProcessStart: "old-start",
@@ -536,7 +541,7 @@ func TestAcquireWakeLockSelfHealsPIDReusedByNonAMQ(t *testing.T) {
 
 func TestAcquireWakeLockSelfHealsPIDReusedByDifferentAMQStart(t *testing.T) {
 	const reusedPID = 4242
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          reusedPID,
 		ProcessStart: "old-start",
@@ -569,7 +574,7 @@ func TestAcquireWakeLockSelfHealsPIDReusedByDifferentAMQStart(t *testing.T) {
 
 func TestAcquireWakeLockSelfHealsStartMismatchWhenExecutableUnavailable(t *testing.T) {
 	const reusedPID = 4242
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          reusedPID,
 		ProcessStart: "old-start",
@@ -601,7 +606,7 @@ func TestAcquireWakeLockSelfHealsStartMismatchWhenExecutableUnavailable(t *testi
 
 func TestAcquireWakeLockStartReadFailureIsUnverifiedNotMismatch(t *testing.T) {
 	const pid = 4242
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          pid,
 		ProcessStart: "old-start",
@@ -636,7 +641,7 @@ func TestAcquireWakeLockStartReadFailureIsUnverifiedNotMismatch(t *testing.T) {
 
 func TestAcquireWakeLockLegacyLiveLockDoesNotAutoDelete(t *testing.T) {
 	const pid = 4242
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:        pid,
 		Executable: "/opt/homebrew/bin/amq",
@@ -668,7 +673,7 @@ func TestAcquireWakeLockLegacyLiveLockDoesNotAutoDelete(t *testing.T) {
 }
 
 func TestRemoveWakeLockIfUnchangedRefusesChangedLock(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{PID: 4242})
 	inspection := inspectWakeLock(root, "orchestrator")
 	if !inspection.Exists {
@@ -696,7 +701,7 @@ func TestRemoveWakeLockIfUnchangedRefusesChangedLock(t *testing.T) {
 
 func TestShouldReplaceOrphanedWakeLockSignalsOnlyAfterRevalidation(t *testing.T) {
 	const wakePID = 4242
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
 		TTY:          "/dev/amq-missing-tty",
@@ -751,7 +756,7 @@ func TestShouldReplaceOrphanedWakeLockSignalsOnlyAfterRevalidation(t *testing.T)
 
 func TestShouldReplaceOrphanedWakeLockKeepsLockWhenKillDoesNotTerminate(t *testing.T) {
 	const wakePID = 4242
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
 		TTY:          "/dev/amq-missing-tty",
@@ -791,7 +796,7 @@ func TestShouldReplaceOrphanedWakeLockKeepsLockWhenKillDoesNotTerminate(t *testi
 
 func TestShouldReplaceOrphanedWakeLockRevalidatesBeforeSignal(t *testing.T) {
 	const wakePID = 4242
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
 		TTY:          "/dev/amq-missing-tty",
@@ -843,7 +848,7 @@ func TestShouldReplaceOrphanedWakeLockRevalidatesBeforeSignal(t *testing.T) {
 }
 
 func TestRunWakeWithLoopRejectsRecentlyCorruptLock(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
 	}
@@ -935,7 +940,7 @@ func TestConfigureRepairWakeCommandDetachesOutput(t *testing.T) {
 }
 
 func TestOpenWakeRepairOutputCreatesPrivateLog(t *testing.T) {
-	root := t.TempDir()
+	root := secureTempDirForTest(t)
 	output, err := openWakeRepairOutput(root, "orchestrator")
 	if err != nil {
 		t.Fatalf("openWakeRepairOutput: %v", err)
@@ -950,6 +955,93 @@ func TestOpenWakeRepairOutputCreatesPrivateLog(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("repair output mode = %o, want 0600", got)
+	}
+}
+
+func TestOpenWakeRepairOutputRejectsSymlinkLog(t *testing.T) {
+	root := secureTempDirForTest(t)
+	agentBase := fsq.AgentBase(root, "orchestrator")
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		t.Fatalf("mkdir agent base: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "repair.log")
+	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("write target log: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(agentBase, ".wake.repair.log")); err != nil {
+		t.Fatalf("symlink repair log: %v", err)
+	}
+
+	output, err := openWakeRepairOutput(root, "orchestrator")
+	if err == nil {
+		_ = output.Close()
+		t.Fatal("expected symlink repair log rejection")
+	}
+	if !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func TestOpenWakeRepairOutputRejectsFIFOWithoutBlocking(t *testing.T) {
+	root := secureTempDirForTest(t)
+	agentBase := fsq.AgentBase(root, "orchestrator")
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		t.Fatalf("mkdir agent base: %v", err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(agentBase, ".wake.repair.log"), 0o600); err != nil {
+		t.Fatalf("mkfifo repair log: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		output, err := openWakeRepairOutput(root, "orchestrator")
+		if output != nil {
+			_ = output.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
+			t.Fatalf("expected FIFO rejection, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("openWakeRepairOutput blocked on FIFO")
+	}
+}
+
+func TestRunWakeRepairJSONRejectsFIFOLogWithoutBlocking(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := newWakeTarget(root, "orchestrator", injector, []string{"exec"})
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	agentBase := fsq.AgentBase(root, "orchestrator")
+	if err := syscall.Mkfifo(filepath.Join(agentBase, ".wake.repair.log"), 0o600); err != nil {
+		t.Fatalf("mkfifo repair log: %v", err)
+	}
+
+	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+		return runWakeRepair([]string{"--root", root, "--me", "orchestrator", "--json"})
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "regular file") {
+		t.Fatalf("runWakeRepair error = %v, want regular-file refusal", runErr)
+	}
+	var result wakeRepairResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if result.Status != "error" || !strings.Contains(result.Reason, "regular file") {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }
 

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -154,7 +154,45 @@ func TestRunWakeWithLoopWritesInjectViaWakeTarget(t *testing.T) {
 	}
 }
 
-func TestRunWakeWithLoopStartsWhenInjectViaTargetIsNotPersistable(t *testing.T) {
+func TestRunWakeWithLoopExecutesResolvedInjectViaPath(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	base := secureTempDirForTest(t)
+	realDir := filepath.Join(base, "real-bin")
+	if err := os.MkdirAll(realDir, 0o700); err != nil {
+		t.Fatalf("mkdir real bin: %v", err)
+	}
+	injector := filepath.Join(realDir, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+	linkDir := filepath.Join(base, "link-bin")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("symlink bin: %v", err)
+	}
+
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", filepath.Join(linkDir, "injector"),
+	}, func(cfg wakeConfig) error {
+		if cfg.injectVia != injector {
+			t.Fatalf("cfg.injectVia = %q, want resolved %q", cfg.injectVia, injector)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopRejectsUnsafeInjectViaBeforeLoop(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
@@ -167,34 +205,87 @@ func TestRunWakeWithLoopStartsWhenInjectViaTargetIsNotPersistable(t *testing.T) 
 	if err := os.Chmod(injector, 0o777); err != nil {
 		t.Fatalf("chmod injector: %v", err)
 	}
-	errDone := errors.New("done")
 	var runErr error
-	stderr := captureWakeStderr(t, func() {
+	_ = captureWakeStderr(t, func() {
 		runErr = runWakeWithLoop([]string{
 			"--root", root,
 			"--me", "orchestrator",
 			"--inject-via", injector,
 			"--inject-arg", "exec",
 		}, func(cfg wakeConfig) error {
-			if cfg.injectVia != injector {
-				t.Fatalf("injectVia = %q, want %q", cfg.injectVia, injector)
-			}
-			if _, exists, targetErr := readWakeTarget(root, "orchestrator"); targetErr != nil || exists {
-				t.Fatalf("wake target exists=%v err=%v, want absent with no read error", exists, targetErr)
-			}
-			return errDone
+			t.Fatalf("loop should not run with unsafe inject_via: %#v", cfg)
+			return nil
 		})
 	})
-	if !errors.Is(runErr, errDone) {
-		t.Fatalf("expected loop sentinel error, got %v", runErr)
+	if runErr == nil || !strings.Contains(runErr.Error(), "group/world-writable") {
+		t.Fatalf("expected unsafe inject_via rejection, got %v", runErr)
 	}
-	if !strings.Contains(stderr, "warning: wake target not persisted; live repair disabled:") ||
-		!strings.Contains(stderr, "group/world-writable") {
-		t.Fatalf("expected non-fatal target warning, got %q", stderr)
+	if _, exists, targetErr := readWakeTarget(root, "orchestrator"); targetErr != nil || exists {
+		t.Fatalf("wake target exists=%v err=%v, want absent with no read error", exists, targetErr)
 	}
 }
 
-func TestRunWakeWithLoopClearsOldWakeTargetWhenNewTargetIsNotPersistable(t *testing.T) {
+func TestInjectViaRevalidatesExecutableBeforeExec(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mutate   func(t *testing.T, path string)
+		wantText string
+	}{
+		{
+			name: "symlink",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				target := writeExecutableForTest(t, "target-injector")
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("remove injector: %v", err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatalf("symlink injector: %v", err)
+				}
+			},
+			wantText: "must not be a symlink",
+		},
+		{
+			name: "nonregular",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("remove injector: %v", err)
+				}
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatalf("mkdir injector path: %v", err)
+				}
+			},
+			wantText: "must be a regular file",
+		},
+		{
+			name: "world_writable",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Chmod(path, 0o777); err != nil {
+					t.Fatalf("chmod injector: %v", err)
+				}
+			},
+			wantText: "group/world-writable",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			injector := writeExecutableForTest(t, "injector-"+tc.name)
+			cfg := &wakeConfig{
+				injectVia:     injector,
+				injectTimeout: time.Second,
+			}
+			tc.mutate(t, injector)
+
+			err := injectVia(cfg, "payload")
+			if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("expected %q rejection, got %v", tc.wantText, err)
+			}
+		})
+	}
+}
+
+func TestRunWakeWithLoopKeepsOldWakeTargetWhenNewTargetIsUnsafe(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
@@ -204,35 +295,66 @@ func TestRunWakeWithLoopClearsOldWakeTargetWhenNewTargetIsNotPersistable(t *test
 	}
 
 	oldInjector := writeExecutableForTest(t, "old-injector")
-	if err := writeWakeTarget(root, "orchestrator", newWakeTarget(root, "orchestrator", oldInjector, []string{"old"})); err != nil {
+	if err := writeWakeTarget(root, "orchestrator", mustNewWakeTargetForTest(t, root, "orchestrator", oldInjector, []string{"old"})); err != nil {
 		t.Fatalf("write old wake target: %v", err)
 	}
 	newInjector := writeExecutableForTest(t, "new-injector")
 	if err := os.Chmod(newInjector, 0o777); err != nil {
 		t.Fatalf("chmod injector: %v", err)
 	}
-	errDone := errors.New("done")
 	var runErr error
-	stderr := captureWakeStderr(t, func() {
+	_ = captureWakeStderr(t, func() {
 		runErr = runWakeWithLoop([]string{
 			"--root", root,
 			"--me", "orchestrator",
 			"--inject-via", newInjector,
 		}, func(cfg wakeConfig) error {
-			if _, exists, targetErr := readWakeTarget(root, "orchestrator"); targetErr != nil || exists {
-				t.Fatalf("wake target exists=%v err=%v, want old target cleared", exists, targetErr)
-			}
-			return errDone
+			t.Fatalf("loop should not run with unsafe inject_via: %#v", cfg)
+			return nil
 		})
 	})
-	if !errors.Is(runErr, errDone) {
-		t.Fatalf("expected loop sentinel error, got %v", runErr)
+	if runErr == nil || !strings.Contains(runErr.Error(), "group/world-writable") {
+		t.Fatalf("expected unsafe inject_via rejection, got %v", runErr)
 	}
-	if !strings.Contains(stderr, "warning: wake target not persisted; live repair disabled:") {
-		t.Fatalf("expected target warning, got %q", stderr)
+	target, exists, err := readWakeTarget(root, "orchestrator")
+	if err != nil || !exists {
+		t.Fatalf("wake target exists=%v err=%v, want old target retained", exists, err)
 	}
-	if _, exists, err := readWakeTarget(root, "orchestrator"); err != nil || exists {
-		t.Fatalf("wake target exists=%v err=%v after loop, want cleared", exists, err)
+	if target.InjectVia != oldInjector {
+		t.Fatalf("wake target inject_via = %q, want old target %q", target.InjectVia, oldInjector)
+	}
+}
+
+func TestRunWakeWithLoopRejectsInjectorSwappedAfterTargetWrite(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	if err := writeWakeTarget(root, "orchestrator", mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+	if err := os.Remove(injector); err != nil {
+		t.Fatalf("remove injector: %v", err)
+	}
+	if err := os.Symlink("/bin/sh", injector); err != nil {
+		t.Fatalf("swap injector to symlink: %v", err)
+	}
+
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", injector,
+		"--inject-arg", "exec",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run after injector swap: %#v", cfg)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected swapped injector rejection, got %v", err)
 	}
 }
 
@@ -1014,7 +1136,7 @@ func TestOpenWakeRepairOutputRejectsFIFOWithoutBlocking(t *testing.T) {
 func TestRunWakeRepairJSONRejectsFIFOLogWithoutBlocking(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	target := newWakeTarget(root, "orchestrator", injector, []string{"exec"})
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})
 	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",


### PR DESCRIPTION
Draft follow-up split out of #151 per review scope.\n\nThis preserves Ohad's wake-repair commit as its own branch/PR instead of carrying the durable saved-injector execution surface in the stale-lock bugfix PR. It is intentionally stacked on the minimized #151 work and should not be reviewed or merged until #151 lands and this branch is rebased onto main.\n\nScope moved here from #151:\n- persisted per-agent .wake.target for inject-via wakes\n- amq wake repair\n- target digest binding and repair availability reporting\n- detached repaired wake process and .wake.repair.log\n- coop exec wake-inject flags\n\nAuthor note: the preserved repair commit is authored by Ohad; this PR is draft because the surface needs separate focused security/product review.