### PR TITLE
chore(release): v0.37.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.37.0] - 2026-06-22
 ### Added
 
 - Document operator-gate conventions in the `amq-cli` and `amq-spec` skills,
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `amq coop exec --require-wake` can reuse an existing usable wake process, while
   still failing closed when the existing wake cannot safely inject (#153).
+
 
 ## [0.36.0] - 2026-06-13
 ### Changed
@@ -507,7 +510,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Auto-create `.gitignore` with `agent-mail` directory entry
 
-[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.36.0...HEAD
+[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.37.0...HEAD
+[0.37.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.34.1...v0.35.0
 [0.34.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.34.0...v0.34.1

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-cli
-version: 0.36.0
+version: 0.37.0
 description: >-
   Coordinate agents via the AMQ CLI for file-based inter-agent messaging. Use
   this skill whenever you need to send messages to another agent (codex, claude,

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-spec
-version: 0.36.0
+version: 0.37.0
 description: >-
   Parallel-research-then-converge design workflow between two agents. Use this
   skill when the user wants two agents to independently think through a design


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.37.0`
- aligns skill/plugin metadata to `0.37.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.37.0`, publishes the GitHub/Homebrew release, and then publishes skills to the marketplace