### PR TITLE
Fix stale wake cleanup and root-only send labels

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -214,6 +214,11 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 					lock.Reason = "wake lock changed before fix"
 					lock.RepairAvailable = false
 					lock.Repair = ""
+				} else if err := validateWakeLockStaleRemoval(recheck); err != nil {
+					lock.Status = "error"
+					lock.Reason = err.Error()
+					lock.RepairAvailable = false
+					lock.Repair = ""
 				} else if err := removeWakeLockIfUnchanged(recheck); err != nil {
 					lock.Status = "error"
 					lock.Reason = err.Error()

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -221,3 +221,81 @@ func TestRunOpsChecksDoesNotAdvertiseRepairForLiveIdentityMismatchLock(t *testin
 		})
 	}
 }
+
+func TestRunOpsChecksFixRefusesLiveIdentityMismatchLock(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		lock       wakeLock
+		process    wakeProcessInfo
+		wantReason string
+	}{
+		{
+			name: "boot id mismatch",
+			lock: wakeLock{
+				PID:          4242,
+				ProcessStart: "start-token",
+				BootID:       "recorded-boot",
+				Executable:   "/opt/homebrew/bin/amq",
+			},
+			process: wakeProcessInfo{
+				PID:        4242,
+				Running:    true,
+				StartToken: "start-token",
+				BootID:     "actual-boot",
+				Executable: "/opt/homebrew/bin/amq",
+			},
+			wantReason: "boot id mismatch",
+		},
+		{
+			name: "process start mismatch",
+			lock: wakeLock{
+				PID:          4242,
+				ProcessStart: "recorded-start",
+				BootID:       "same-boot",
+				Executable:   "/opt/homebrew/bin/amq",
+			},
+			process: wakeProcessInfo{
+				PID:        4242,
+				Running:    true,
+				StartToken: "actual-start",
+				BootID:     "same-boot",
+				Executable: "/opt/homebrew/bin/amq",
+			},
+			wantReason: "process start time mismatch",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatalf("write wake target: %v", err)
+			}
+			lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(tc.lock, target))
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				proc := tc.process
+				proc.PID = pid
+				proc.Args = []string{"amq", "wake", "--root", root, "--me", "codex"}
+				return proc
+			})
+
+			result := runOpsChecks(root, "test", true)
+			if len(result.WakeLocks) != 1 {
+				t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+			}
+			got := result.WakeLocks[0]
+			if got.Status != "error" || !strings.Contains(got.Reason, tc.wantReason) || !strings.Contains(got.Reason, "not removable") {
+				t.Fatalf("unexpected wake lock fix result: %#v", got)
+			}
+			if got.Removed {
+				t.Fatalf("identity-mismatch lock should not be marked removed: %#v", got)
+			}
+			if got.RepairAvailable || got.Repair != "" {
+				t.Fatalf("repair should be cleared after refused fix: %#v", got)
+			}
+			if _, statErr := os.Stat(lockPath); statErr != nil {
+				t.Fatalf("identity-mismatch lock should remain after fix refusal: %v", statErr)
+			}
+		})
+	}
+}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -400,6 +400,9 @@ func runSend(args []string) error {
 	if targetSession != "" {
 		targetDisplay = targetSession
 	}
+	if targetDisplay == "" && common.rootExplicit() && targetProject == "" && targetSession == "" && fromSession == "" {
+		targetDisplay = sessionName(deliveryRoot)
+	}
 
 	// Wait for receipt if requested (single-recipient only, validated above).
 	var waitResult *waitForResult

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -57,6 +58,45 @@ func TestSend_RejectsPositionalArgs(t *testing.T) {
 				t.Fatalf("expected bob inbox to remain empty, got %d message(s)", len(entries))
 			}
 		})
+	}
+}
+
+func TestSendRootOnlyConfirmationUsesRootBasename(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "custom-root", "clitest")
+	for _, agent := range []string{"lead", "qa"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs: %v", err)
+		}
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runSend([]string{"--root", root, "--me", "lead", "--to", "qa", "--subject", "x", "--body", "y"})
+	})
+	if err != nil {
+		t.Fatalf("runSend: %v", err)
+	}
+	if !strings.Contains(output, "session: clitest") {
+		t.Fatalf("confirmation should include root basename as session label, got %q", output)
+	}
+	if strings.Contains(output, "session: ,") {
+		t.Fatalf("confirmation should not contain a blank session label, got %q", output)
+	}
+}
+
+func TestSendRootOnlyJSONUsesRootBasenameAsSession(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "custom-root", "clitest")
+	for _, agent := range []string{"lead", "qa"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs: %v", err)
+		}
+	}
+
+	output := runSendJSONForTest(t, "--root", root, "--me", "lead", "--to", "qa", "--subject", "x", "--body", "y", "--json")
+	if got := output["session"]; got != "clitest" {
+		t.Fatalf("session = %v, want clitest", got)
+	}
+	if got := output["root"]; got != root {
+		t.Fatalf("root = %v, want %s", got, root)
 	}
 }
 

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -255,6 +255,39 @@ func validateWakeLockRepairable(inspection wakeLockInspection) error {
 	}
 }
 
+func validateWakeLockStaleRemoval(inspection wakeLockInspection) error {
+	if err := validateWakeLockRepairable(inspection); err == nil {
+		return nil
+	} else if inspection.Status != wakeLockStale {
+		return err
+	}
+	// Identity-token mismatches are removable only when process inspection proves
+	// the live PID is not an amq wake. Other stale reasons keep the historical
+	// self-heal behavior for corrupt or structurally stale lock files.
+	switch inspection.Reason {
+	case "boot id mismatch", "process start time mismatch":
+		if wakeProcessProvenNotWake(inspection.Process) {
+			return nil
+		}
+		return fmt.Errorf("wake lock stale reason %q is not removable while pid %d may still be amq wake", inspection.Reason, inspection.PID)
+	default:
+		return nil
+	}
+}
+
+func wakeProcessProvenNotWake(proc wakeProcessInfo) bool {
+	if !proc.Running {
+		return true
+	}
+	if proc.Executable == "" && len(proc.Args) == 0 {
+		return false
+	}
+	if !processLooksLikeAMQ(proc) {
+		return true
+	}
+	return len(proc.Args) > 0 && !processArgsLookLikeWake(proc.Args)
+}
+
 func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
 	current, err := readWakeLockFile(inspection.LockPath)
 	if err != nil {

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -850,6 +851,43 @@ func TestRunWakeRepairCLIRepairsStaleWakeWithJSON(t *testing.T) {
 	}
 	if result.Status != "repaired" || result.PID != 9876 || !result.RepairAvailable {
 		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestRunWakeRepairClearsRepairAvailableAfterStartFailure(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget) (int, error) {
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatalf("lock should be removed before start, stat=%v", err)
+		}
+		return 0, errors.New("start failed")
+	})
+
+	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+		return runWakeRepair([]string{"--root", root, "--me", "codex", "--json"})
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "start failed") {
+		t.Fatalf("runWakeRepair error = %v, want start failure", runErr)
+	}
+
+	var result wakeRepairResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+	}
+	if result.Status != "error" || result.RepairAvailable {
+		t.Fatalf("repair_available should be cleared after start failure: %#v", result)
 	}
 }
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -76,6 +76,9 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 	if inspection.Exists {
 		switch inspection.Status {
 		case wakeLockStale:
+			if err := validateWakeLockStaleRemoval(inspection); err != nil {
+				return nil, err
+			}
 			if err := removeWakeLockIfUnchanged(inspection); err != nil {
 				return nil, err
 			}
@@ -446,38 +449,47 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 		return result, err
 	}
 	result.RepairAvailable = true
+	clearRepairAvailable := func() {
+		result.RepairAvailable = false
+	}
 
 	recheck := inspectWakeLock(root, me)
 	if recheck.Status != wakeLockStale {
+		clearRepairAvailable()
 		result.Status = "refused"
 		result.PID = recheck.PID
 		result.Reason = "wake lock changed before repair"
 		return result, errors.New(result.Reason)
 	}
 	if err := validateWakeLockRepairable(recheck); err != nil {
+		clearRepairAvailable()
 		result.Status = "refused"
 		result.PID = recheck.PID
 		result.Reason = "wake lock changed before repair"
 		return result, errors.New(result.Reason)
 	}
 	if !bytes.Equal(inspection.raw, recheck.raw) {
+		clearRepairAvailable()
 		result.Status = "refused"
 		result.PID = recheck.PID
 		result.Reason = "wake lock changed before repair"
 		return result, errors.New(result.Reason)
 	}
 	if err := validateWakeTargetMatchesLock(recheck.Lock, target); err != nil {
+		clearRepairAvailable()
 		result.Status = "refused"
 		result.Reason = err.Error()
 		return result, err
 	}
 	if err := removeWakeLockIfUnchanged(recheck); err != nil {
+		clearRepairAvailable()
 		result.Status = "error"
 		result.Reason = err.Error()
 		return result, err
 	}
 	pid, err := startWakeFromTarget(root, me, target)
 	if err != nil {
+		clearRepairAvailable()
 		result.Status = "error"
 		result.Reason = err.Error()
 		return result, err

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -769,43 +769,78 @@ func TestAcquireWakeLockSelfHealsPIDReusedByNonAMQ(t *testing.T) {
 	}
 }
 
-func TestAcquireWakeLockSelfHealsPIDReusedByDifferentAMQStart(t *testing.T) {
-	const reusedPID = 4242
-	root := secureTempDirForTest(t)
-	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
-		PID:          reusedPID,
-		ProcessStart: "old-start",
-		BootID:       "boot-1",
-		Executable:   "/opt/homebrew/bin/amq",
-	})
-	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
-		if pid == reusedPID {
-			return wakeProcessInfo{
-				PID:        pid,
+func TestAcquireWakeLockRefusesLiveWakeIdentityMismatch(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		lock       wakeLock
+		process    wakeProcessInfo
+		wantReason string
+	}{
+		{
+			name: "boot id mismatch",
+			lock: wakeLock{
+				PID:          4242,
+				ProcessStart: "start-1",
+				BootID:       "recorded-boot",
+				Executable:   "/opt/homebrew/bin/amq",
+			},
+			process: wakeProcessInfo{
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "actual-boot",
+				Executable: "/opt/homebrew/bin/amq",
+			},
+			wantReason: "boot id mismatch",
+		},
+		{
+			name: "process start mismatch",
+			lock: wakeLock{
+				PID:          4242,
+				ProcessStart: "old-start",
+				BootID:       "boot-1",
+				Executable:   "/opt/homebrew/bin/amq",
+			},
+			process: wakeProcessInfo{
 				Running:    true,
 				StartToken: "new-start",
 				BootID:     "boot-1",
 				Executable: "/opt/homebrew/bin/amq",
-				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root},
-			}
-		}
-		if pid == os.Getpid() {
-			return wakeProcessInfo{PID: pid, Running: true, StartToken: "self-start", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"}
-		}
-		return wakeProcessInfo{PID: pid}
-	})
+			},
+			wantReason: "process start time mismatch",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const reusedPID = 4242
+			root := secureTempDirForTest(t)
+			lockPath := writeWakeLockForTest(t, root, "orchestrator", tc.lock)
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid == reusedPID {
+					proc := tc.process
+					proc.PID = pid
+					proc.Args = []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root}
+					return proc
+				}
+				return wakeProcessInfo{PID: pid}
+			})
 
-	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
-	if err != nil {
-		t.Fatalf("acquireWakeLock should replace mismatched start-token lock: %v", err)
+			cleanup, err := acquireWakeLock(root, "orchestrator", nil)
+			if cleanup != nil {
+				defer cleanup()
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantReason) || !strings.Contains(err.Error(), "not removable") {
+				t.Fatalf("expected identity-mismatch removal refusal, got %v", err)
+			}
+			if _, statErr := os.Stat(lockPath); statErr != nil {
+				t.Fatalf("identity-mismatch lock should remain, stat=%v", statErr)
+			}
+		})
 	}
-	defer cleanup()
 }
 
-func TestAcquireWakeLockSelfHealsStartMismatchWhenExecutableUnavailable(t *testing.T) {
+func TestAcquireWakeLockRefusesStartMismatchWhenExecutableUnavailable(t *testing.T) {
 	const reusedPID = 4242
 	root := secureTempDirForTest(t)
-	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          reusedPID,
 		ProcessStart: "old-start",
 		BootID:       "boot-1",
@@ -821,17 +856,19 @@ func TestAcquireWakeLockSelfHealsStartMismatchWhenExecutableUnavailable(t *testi
 				InspectError: errors.New("executable unavailable"),
 			}
 		}
-		if pid == os.Getpid() {
-			return wakeProcessInfo{PID: pid, Running: true, StartToken: "self-start", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"}
-		}
 		return wakeProcessInfo{PID: pid}
 	})
 
 	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
-	if err != nil {
-		t.Fatalf("acquireWakeLock should replace start-token mismatch even without executable: %v", err)
+	if cleanup != nil {
+		defer cleanup()
 	}
-	defer cleanup()
+	if err == nil || !strings.Contains(err.Error(), "process start time mismatch") || !strings.Contains(err.Error(), "not removable") {
+		t.Fatalf("expected start-token mismatch refusal without executable identity, got %v", err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain when executable identity is unavailable, stat=%v", statErr)
+	}
 }
 
 func TestAcquireWakeLockStartReadFailureIsUnverifiedNotMismatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- harden general stale wake-lock cleanup so live amq wake identity mismatches are not removed by acquireWakeLock or doctor --ops --fix-wake-locks
- clear repair_available on wake repair post-validation/start failures
- show the explicit root basename as the send session label for root-only local sends

Closes #156.
Closes #150.

## Verification
- go test ./internal/cli -run 'Test(AcquireWakeLockSelfHealsPIDReusedByNonAMQ|AcquireWakeLockRefusesLiveWakeIdentityMismatch|AcquireWakeLockRefusesStartMismatchWhenExecutableUnavailable|RunOpsChecksDoesNotAdvertiseRepairForLiveIdentityMismatchLock|RunOpsChecksFixRefusesLiveIdentityMismatchLock|RunOpsChecks_FixesStaleWakeLock|RunWakeRepairClearsRepairAvailableAfterStartFailure|RunWakeRepairCLIRepairsStaleWakeWithJSON|SendRootOnlyConfirmationUsesRootBasename|SendRootOnlyJSONUsesRootBasenameAsSession)$' -count=1
- go test ./internal/cli -count=1
- go test ./...
- GOOS=windows go build ./...
- GOOS=freebsd go build ./...
- make ci

## Review
- Claude pre-commit review: PASS
- Codex independent review: PASS