### PR TITLE
Docs cleanup after v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved `classifyRoot` from `send.go` to `common.go` (shared by send, reply, who, env)
 - Added `resolveSessionName` helper combining `classifyRoot` + `sessionName`
 
+## [0.26.0] - 2026-03-29
+
+### Added
+
+- Embedded the AMQ design philosophy in the project docs.
+
+### Changed
+
+- Added the main-branch documentation policy and removed frozen implementation
+  specs from the docs tree.
+- Aligned plugin manifests and metadata for the 0.26.0 release.
+
+## [0.25.1] - 2026-03-28
+
+### Changed
+
+- Bumped the Codex plugin manifest version to 0.25.1.
+
+## [0.25.0] - 2026-03-28
+
+### Added
+
+- Added cross-orchestrator integration surfaces for Symphony, Kanban, and
+  `doctor --ops` (#47).
+- Added Codex interface metadata to the plugin manifest.
+
+### Fixed
+
+- Corrected cross-project sender identity by preserving `from_project` (#48).
+
+### Changed
+
+- Renamed the spec skill to `amq-spec` to avoid naming collisions.
+- Eliminated duplicated skill packaging.
+
 ## [0.24.1] - 2026-03-22
 
 ### Fixed
@@ -529,7 +564,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.29.1]: https://github.com/avivsinai/agent-message-queue/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.8...v0.29.0
 [0.28.8]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.7...v0.28.8
-[0.28.7]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.5...v0.28.7
+[0.28.7]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.6...v0.28.7
+[0.28.6]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.5...v0.28.6
 [0.28.5]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.4...v0.28.5
 [0.28.4]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.3...v0.28.4
 [0.28.3]: https://github.com/avivsinai/agent-message-queue/compare/v0.28.2...v0.28.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,13 @@ make fmt
 make test
 make vet
 make lint
+make ci
 ```
+
+Run `make ci` before opening a PR; it is the canonical local gate and includes
+format, vet, lint, test, and smoke-test coverage. Install local hooks with
+`scripts/install-hooks.sh` when working in this repo, and use
+`scripts/release.sh` for release PRs.
 
 ## Pull requests
 

--- a/COOP.md
+++ b/COOP.md
@@ -283,8 +283,11 @@ Input deferral is a heuristic, not a prompt-buffer guarantee. It only samples te
 | `question` | `answer` | normal |
 | `decision` | — | normal |
 | `todo` | — | normal |
-| `status` | — | low |
-| `brainstorm` | — | low |
+| `status` | — | normal |
+| `brainstorm` | — | normal |
+
+When `--kind` is set but `--priority` is omitted, the CLI defaults priority to
+`normal`.
 
 ## Spec Workflow
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ rm -rf /tmp/amq
 ```bash
 git clone https://github.com/avivsinai/agent-message-queue.git /tmp/amq
 mkdir -p ~/.codex/skills
-cp -r /tmp/amq/.codex/skills/amq-cli ~/.codex/skills/
+cp -r /tmp/amq/.agents/skills/amq-cli ~/.codex/skills/
 rm -rf /tmp/amq
 ```
 

--- a/docs/adr-layer-extensions.md
+++ b/docs/adr-layer-extensions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted. Implementation is split across follow-up issues.
+Accepted (implemented).
 
 ## Date
 
@@ -34,7 +34,7 @@ The current implicit integration points are too fragile for external layers:
 
 ## Decision
 
-AMQ will add four small, additive surfaces for layer interoperability:
+AMQ provides four small, additive surfaces for layer interoperability:
 
 1. A versioned `amq env --json` v1 contract.
 2. Reserved extension metadata directories plus a passive manifest convention.
@@ -355,13 +355,12 @@ evolve the mailbox.
 - `amq doctor --json` can report passive extension metadata without executing
   layer code.
 
-## Follow-Up Issues
+## Implementation
 
-Implementation should be tracked as separate issues:
+Implemented across #101-#104:
 
-- Add `amq env --json` v1 fields and stability documentation.
-- Reserve extension metadata directories and support passive manifests in
+- #101 added the `amq env --json` v1 fields and stability documentation.
+- #102 reserved extension metadata directories and reports passive manifests in
   diagnostics.
-- Add `amq route explain --json` with canonical `argv` output.
-- Add `amq send --from-session` for pre-boot cross-session sends and link it to
-  the existing cross-session bootstrap issue.
+- #103 added `amq route explain --json` with canonical `argv` output.
+- #104 added `amq send --from-session` for pre-boot cross-session sends.


### PR DESCRIPTION
## Summary
- fix the Codex manual install path to copy from `.agents/skills`
- align COOP message kind default priorities with CLI behavior
- mark the layer-extension ADR as implemented and replace follow-up issue language
- fill missing v0.25/v0.26 changelog sections and repair v0.28.6/v0.28.7 compare links
- document `make ci` plus hook/release helper pointers in CONTRIBUTING

Note: the stale `specs/001-local-maildir-queue/` removal from the original docs review is already handled on `main` by #159, so this PR intentionally leaves specs untouched.

## Verification
- `git diff --check`
- `make ci` (first run hit stale golangci-lint cache entries from the removed #158 worktree; reran after `golangci-lint cache clean` and passed)
