### PR TITLE
Fix release workflow merge commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,12 @@ concurrency:
 
 jobs:
   prepare:
-    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release): v') }}"
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.event.head_commit.message, 'chore(release): v') ||
+        startsWith(github.event.head_commit.message, 'Merge pull request')
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -47,78 +52,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GITHUB_SHA: ${{ github.sha }}
         shell: bash
-        run: |
-          set -euo pipefail
-
-          validate_tag() {
-            local tag="$1"
-            if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
-              echo "::error::Release identifiers must use vX.Y.Z style tags."
-              exit 1
-            fi
-          }
-
-          tag_commit_sha() {
-            git rev-parse "refs/tags/${1}^{commit}" 2>/dev/null || git rev-parse "refs/tags/${1}"
-          }
-
-          case "$EVENT_NAME" in
-            workflow_dispatch)
-              tag="$INPUT_TAG"
-              validate_tag "$tag"
-              git fetch --force --tags origin
-              if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
-                echo "::error::Tag ${tag} does not exist. workflow_dispatch is only for rerunning an existing release."
-                exit 1
-              fi
-              version="${tag#v}"
-              git checkout --detach "$tag"
-              ./scripts/check-release-version.sh "$version"
-              release_ref="$tag"
-              release_sha="$(tag_commit_sha "$tag")"
-              ;;
-            push)
-              commit_subject="${COMMIT_MESSAGE%%$'\n'*}"
-              tag="${commit_subject#chore(release): }"
-              tag="${tag%% \(#*}"
-              validate_tag "$tag"
-
-              version="${tag#v}"
-              ./scripts/check-release-version.sh "$version"
-
-              release_sha="${GITHUB_SHA}"
-              if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
-                existing_sha="$(tag_commit_sha "$tag")"
-                if [[ "$existing_sha" != "$release_sha" ]]; then
-                  echo "::error::Tag ${tag} already exists but points to ${existing_sha}, not ${release_sha}."
-                  exit 1
-                fi
-              fi
-              release_ref="${release_sha}"
-              ;;
-            *)
-              echo "::error::Unsupported event: ${EVENT_NAME}"
-              exit 1
-              ;;
-          esac
-
-          prerelease=false
-          if [[ "$tag" == *-* ]]; then
-            prerelease=true
-          fi
-
-          {
-            echo "tag=${tag}"
-            echo "version=${version}"
-            echo "release_ref=${release_ref}"
-            echo "release_sha=${release_sha}"
-            echo "prerelease=${prerelease}"
-          } >> "$GITHUB_OUTPUT"
+        run: ./scripts/resolve-release-metadata.sh
 
   verify:
     needs: prepare
-    if: needs.prepare.result == 'success'
+    if: needs.prepare.result == 'success' && needs.prepare.outputs.tag != ''
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -144,7 +84,7 @@ jobs:
 
   release:
     needs: [prepare, verify]
-    if: needs.prepare.result == 'success' && needs.verify.result == 'success'
+    if: needs.prepare.result == 'success' && needs.prepare.outputs.tag != '' && needs.verify.result == 'success'
     runs-on: macos-latest
     timeout-minutes: 30
     permissions:
@@ -240,6 +180,7 @@ jobs:
   skill-publish:
     needs: [prepare, release]
     if: >-
+      needs.prepare.outputs.tag != '' &&
       needs.release.result == 'success' &&
       (github.event_name == 'push' || inputs.skip-skill-publish != true)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Release publishing now detects release commits inside normally merged release
+  PRs while ordinary feature merge commits no-op before tag, artifact, or skill
+  publishing jobs (#163).
+
 ## [0.37.1] - 2026-06-22
 
 ### Fixed

--- a/scripts/resolve-release-metadata.sh
+++ b/scripts/resolve-release-metadata.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+event_name="${EVENT_NAME:-}"
+input_tag="${INPUT_TAG:-}"
+commit_message="${COMMIT_MESSAGE:-}"
+github_sha="${GITHUB_SHA:-}"
+github_output="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+validate_tag() {
+  local tag="$1"
+  if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+    echo "::error::Release identifiers must use vX.Y.Z style tags."
+    exit 1
+  fi
+}
+
+tag_commit_sha() {
+  git rev-parse "refs/tags/${1}^{commit}" 2>/dev/null || git rev-parse "refs/tags/${1}"
+}
+
+push_release_subject() {
+  local commit_subject="$1"
+
+  if [[ "$commit_subject" =~ ^chore\(release\):\ v ]]; then
+    printf '%s\n' "$commit_subject"
+    return 0
+  fi
+
+  if [[ "$commit_subject" == Merge\ pull\ request* ]] &&
+    git rev-parse -q --verify "${github_sha}^1" >/dev/null 2>&1; then
+    git log --format='%s' --no-merges "${github_sha}^1..${github_sha}" |
+      awk 'found == 0 && /^chore\(release\): v/ { print; found = 1 }'
+  fi
+}
+
+case "$event_name" in
+  workflow_dispatch)
+    tag="$input_tag"
+    validate_tag "$tag"
+    git fetch --force --tags origin
+    if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+      echo "::error::Tag ${tag} does not exist. workflow_dispatch is only for rerunning an existing release."
+      exit 1
+    fi
+    version="${tag#v}"
+    git checkout --detach "$tag"
+    ./scripts/check-release-version.sh "$version"
+    release_ref="$tag"
+    release_sha="$(tag_commit_sha "$tag")"
+    ;;
+  push)
+    if [[ -z "$github_sha" ]]; then
+      echo "::error::GITHUB_SHA is required for push release resolution."
+      exit 1
+    fi
+
+    commit_subject="${commit_message%%$'\n'*}"
+    release_subject="$(push_release_subject "$commit_subject")"
+    if [[ -z "$release_subject" ]]; then
+      echo "::notice::No release commit found for push ${github_sha}; skipping release jobs."
+      exit 0
+    fi
+
+    tag="${release_subject#chore(release): }"
+    tag="${tag%% \(#*}"
+    validate_tag "$tag"
+
+    version="${tag#v}"
+    ./scripts/check-release-version.sh "$version"
+
+    release_sha="${github_sha}"
+    if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+      existing_sha="$(tag_commit_sha "$tag")"
+      if [[ "$existing_sha" != "$release_sha" ]]; then
+        echo "::error::Tag ${tag} already exists but points to ${existing_sha}, not ${release_sha}."
+        exit 1
+      fi
+    fi
+    release_ref="${release_sha}"
+    ;;
+  *)
+    echo "::error::Unsupported event: ${event_name}"
+    exit 1
+    ;;
+esac
+
+prerelease=false
+if [[ "$tag" == *-* ]]; then
+  prerelease=true
+fi
+
+{
+  echo "tag=${tag}"
+  echo "version=${version}"
+  echo "release_ref=${release_ref}"
+  echo "release_sha=${release_sha}"
+  echo "prerelease=${prerelease}"
+} >>"$github_output"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -128,6 +128,7 @@ if command -v python3 >/dev/null 2>&1; then
   python3 scripts/test_session_name.py
   echo "python session-name tests ok"
   python3 scripts/test_release_changelog.py
+  bash scripts/test_release_metadata.sh
 fi
 
 # --- SessionStart hook test (claude-session-start.sh) ---

--- a/scripts/test_release_metadata.sh
+++ b/scripts/test_release_metadata.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+REPO="$TMPDIR/repo"
+mkdir -p "$REPO/scripts" "$REPO/skills/amq-cli" "$REPO/skills/amq-spec" \
+  "$REPO/.claude-plugin" "$REPO/.codex-plugin"
+
+cp "$ROOT/scripts/resolve-release-metadata.sh" "$REPO/scripts/"
+cp "$ROOT/scripts/check-release-version.sh" "$REPO/scripts/"
+chmod +x "$REPO/scripts/resolve-release-metadata.sh" "$REPO/scripts/check-release-version.sh"
+
+cat >"$REPO/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [9.9.9] - 2026-06-22
+
+### Fixed
+
+- Test release.
+EOF
+
+for skill in amq-cli amq-spec; do
+  cat >"$REPO/skills/$skill/SKILL.md" <<'EOF'
+---
+name: test
+version: 9.9.9
+---
+
+# Test
+EOF
+done
+
+printf '{"version":"9.9.9"}\n' >"$REPO/.claude-plugin/plugin.json"
+printf '{"version":"9.9.9"}\n' >"$REPO/.codex-plugin/plugin.json"
+
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name "Release Test"
+git -C "$REPO" add .
+git -C "$REPO" commit -qm "base"
+
+git -C "$REPO" checkout -qb release/v9.9.9
+git -C "$REPO" commit --allow-empty -qm "chore(release): v9.9.9"
+release_commit="$(git -C "$REPO" rev-parse HEAD)"
+
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge --no-ff -m $'Merge pull request #1 from test/release/v9.9.9\n\nchore(release): v9.9.9' release/v9.9.9
+release_merge="$(git -C "$REPO" rev-parse HEAD)"
+
+git -C "$REPO" checkout -qb docs-change
+git -C "$REPO" commit --allow-empty -qm "docs: cleanup"
+git -C "$REPO" checkout -q main
+git -C "$REPO" merge --no-ff -m $'Merge pull request #2 from test/docs-change\n\nchore(release): v9.9.9' docs-change
+feature_merge="$(git -C "$REPO" rev-parse HEAD)"
+
+git -C "$REPO" commit --allow-empty -qm "chore(release): v9.9.9 (#3)"
+release_squash="$(git -C "$REPO" rev-parse HEAD)"
+
+run_resolver() {
+  local sha="$1"
+  local output="$TMPDIR/output"
+  local stdout="$TMPDIR/stdout"
+  rm -f "$output" "$stdout"
+  (
+    cd "$REPO"
+    EVENT_NAME=push \
+      INPUT_TAG= \
+      COMMIT_MESSAGE="$(git log -1 --format=%B "$sha")" \
+      GITHUB_SHA="$sha" \
+      GITHUB_OUTPUT="$output" \
+      ./scripts/resolve-release-metadata.sh
+  ) >"$stdout"
+}
+
+assert_release_output() {
+  local sha="$1"
+  local output="$TMPDIR/output"
+  grep -Fx "tag=v9.9.9" "$output"
+  grep -Fx "version=9.9.9" "$output"
+  grep -Fx "release_ref=$sha" "$output"
+  grep -Fx "release_sha=$sha" "$output"
+  grep -Fx "prerelease=false" "$output"
+}
+
+run_resolver "$release_squash"
+assert_release_output "$release_squash" >/dev/null
+
+run_resolver "$release_merge"
+assert_release_output "$release_merge" >/dev/null
+
+run_resolver "$feature_merge"
+if [[ -s "$TMPDIR/output" ]]; then
+  echo "feature merge unexpectedly produced release outputs"
+  cat "$TMPDIR/output"
+  exit 1
+fi
+grep -F "No release commit found" "$TMPDIR/stdout" >/dev/null
+
+printf 'release metadata resolver tests ok\n'


### PR DESCRIPTION
## Summary
- Move release metadata resolution into `scripts/resolve-release-metadata.sh` so the behavior is unit-testable.
- Let `prepare` run for GitHub merge commits, then resolve the first non-merge `chore(release): v...` subject from the merge side.
- Keep squash release commits supported, keep CI tag creation after verification, and make non-release merge commits exit `prepare` with no outputs so `verify`, `release`, and `skill-publish` skip.

Closes #163.

## Release-engineering checks
- Uses GitHub Actions job outputs through `$GITHUB_OUTPUT` / `needs.prepare.outputs.*`, matching GitHub's documented job-output pattern.
- Keeps `actions/checkout` at `fetch-depth: 0`, which checkout documents as needed for full branch/tag history; the merge-parent scan does not rely on shallow history.
- Uses `::notice::` for the intentional no-op path and `::error::` for refusal paths, matching GitHub workflow command conventions.
- Avoids `git log --grep` for merge detection because it searches commit bodies; the resolver filters subject lines only and excludes merge commits.

Docs checked:
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
- https://github.com/actions/checkout

## Verification
- `bash scripts/test_release_metadata.sh`
- live history probe: real release merge `139e648` resolves `chore(release): v0.37.1`; non-release path stays empty
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- `make ci`
