### PR TITLE
Reserve the human operator user handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The human operator handle `user` is now reserved for configured projects, and
+  `amq coop init` seeds `claude,codex,user` by default so strict operator gates
+  no longer require custom coop setup (#139).
 - Release publishing now detects release commits inside normally merged release
   PRs while ordinary feature merge commits no-op before tag, artifact, or skill
   publishing jobs (#163).

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -22,6 +22,8 @@ type commonFlags struct {
 	flagSet *flag.FlagSet
 }
 
+const reservedHumanHandle = "user"
+
 func addCommonFlags(fs *flag.FlagSet) *commonFlags {
 	flags := &commonFlags{flagSet: fs}
 	fs.StringVar(&flags.Root, "root", defaultRoot(), "Root directory for the queue")
@@ -359,7 +361,22 @@ func loadKnownAgents(root string, strict bool) ([]string, error) {
 		return nil, nil
 	}
 
-	return cfg.Agents, nil
+	return withReservedHumanHandle(cfg.Agents), nil
+}
+
+func withReservedHumanHandle(agents []string) []string {
+	if len(agents) == 0 {
+		return agents
+	}
+	for _, agent := range agents {
+		if agent == reservedHumanHandle {
+			return agents
+		}
+	}
+	out := make([]string, 0, len(agents)+1)
+	out = append(out, agents...)
+	out = append(out, reservedHumanHandle)
+	return out
 }
 
 func loadKnownAgentSet(root string, strict bool) (map[string]struct{}, error) {

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
 )
 
 func TestNormalizeHandle(t *testing.T) {
@@ -70,12 +73,100 @@ func TestValidateKnownHandle(t *testing.T) {
 	}
 }
 
+func TestValidateKnownHandlesAllowsReservedUserWithConfig(t *testing.T) {
+	root := t.TempDir()
+	writeKnownAgentsConfig(t, root, []string{"alice", "bob"})
+
+	if err := validateKnownHandles(root, true, "user"); err != nil {
+		t.Fatalf("reserved user handle should pass strict validation: %v", err)
+	}
+	if err := validateKnownHandles(root, true, "alice", "user"); err != nil {
+		t.Fatalf("mixed configured and reserved handles should pass: %v", err)
+	}
+	if err := validateKnownHandles(root, true, "unknown"); err == nil {
+		t.Fatal("unknown handle should still fail strict validation")
+	}
+}
+
+func TestLoadKnownAgentsDoesNotReserveUserWithoutConfiguredAgents(t *testing.T) {
+	root := t.TempDir()
+
+	agents, err := loadKnownAgents(root, true)
+	if err != nil {
+		t.Fatalf("loadKnownAgents without config: %v", err)
+	}
+	if agents != nil {
+		t.Fatalf("no config should return nil agents, got %#v", agents)
+	}
+	known, err := loadKnownAgentSet(root, true)
+	if err != nil {
+		t.Fatalf("loadKnownAgentSet without config: %v", err)
+	}
+	if known != nil {
+		t.Fatalf("no config should return nil known set, got %#v", known)
+	}
+
+	writeKnownAgentsConfig(t, root, []string{})
+	agents, err = loadKnownAgents(root, true)
+	if err != nil {
+		t.Fatalf("loadKnownAgents with empty config: %v", err)
+	}
+	if len(agents) != 0 {
+		t.Fatalf("empty configured agents should not synthesize user, got %#v", agents)
+	}
+}
+
+func TestHeaderValidatorAllowsReservedUserUnderStrict(t *testing.T) {
+	root := t.TempDir()
+	writeKnownAgentsConfig(t, root, []string{"claude", "codex"})
+
+	validator, err := newHeaderValidator(root, true)
+	if err != nil {
+		t.Fatalf("newHeaderValidator: %v", err)
+	}
+	header := format.Header{
+		Schema:  format.CurrentSchema,
+		ID:      "operator-gate",
+		From:    "claude",
+		To:      []string{"user"},
+		Thread:  "p2p/claude__user",
+		Created: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if err := validator.validate(header); err != nil {
+		t.Fatalf("strict validator should accept reserved user recipient: %v", err)
+	}
+
+	header.To = []string{"unknown"}
+	if err := validator.validate(header); err == nil {
+		t.Fatal("strict validator should still reject unknown recipients")
+	}
+}
+
 func TestValidateKnownHandleNoConfig(t *testing.T) {
 	root := t.TempDir()
 
 	// No config file - should pass any handle
 	if err := validateKnownHandles(root, true, "anyhandle"); err != nil {
 		t.Errorf("no config should pass any handle: %v", err)
+	}
+}
+
+func writeKnownAgentsConfig(t *testing.T, root string, agents []string) {
+	t.Helper()
+	metaDir := filepath.Join(root, "meta")
+	if err := os.MkdirAll(metaDir, 0o700); err != nil {
+		t.Fatalf("mkdir meta: %v", err)
+	}
+	cfg := map[string]any{
+		"version": 1,
+		"agents":  agents,
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "config.json"), data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
 	}
 }
 

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	defaultCoopRoot    = ".agent-mail"
-	defaultCoopAgents  = "claude,codex"
+	defaultCoopAgents  = "claude,codex,user"
 	defaultSessionName = "collab"
 )
 

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -3,9 +3,13 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
 )
 
 func TestSplitDashDash(t *testing.T) {
@@ -175,6 +179,72 @@ func TestCoopExecSessionInvalidName(t *testing.T) {
 	}
 	if !containsStr(err.Error(), "invalid session name") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestCoopInitDefaultIncludesUser(t *testing.T) {
+	projectDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+		resetAmqrcCache()
+	})
+	resetAmqrcCache()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runCoopInitInternal([]string{"--json"}, false)
+	})
+	if err != nil {
+		t.Fatalf("runCoopInitInternal: %v", err)
+	}
+	var result struct {
+		Agents []string `json:"agents"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (output: %s)", err, output)
+	}
+	want := []string{"claude", "codex", "user"}
+	if !reflect.DeepEqual(result.Agents, want) {
+		t.Fatalf("agents = %#v, want %#v", result.Agents, want)
+	}
+
+	cfg, err := config.LoadConfig(filepath.Join(projectDir, defaultCoopRoot, "meta", "config.json"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.Agents, want) {
+		t.Fatalf("config agents = %#v, want %#v", cfg.Agents, want)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, defaultCoopRoot, "agents", "user", "inbox", "new")); err != nil {
+		t.Fatalf("user inbox should be created: %v", err)
+	}
+}
+
+func TestInitExplicitAgentsDoesNotInjectUser(t *testing.T) {
+	root := t.TempDir()
+	_, err := captureEnvStdout(t, func() error {
+		return runInit([]string{"--root", root, "--agents", "claude,codex"})
+	})
+	if err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	cfg, err := config.LoadConfig(filepath.Join(root, "meta", "config.json"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	want := []string{"claude", "codex"}
+	if !reflect.DeepEqual(cfg.Agents, want) {
+		t.Fatalf("config agents = %#v, want %#v", cfg.Agents, want)
+	}
+	if _, err := os.Stat(filepath.Join(root, "agents", "user")); !os.IsNotExist(err) {
+		t.Fatalf("user mailbox should not be created by explicit init, stat err=%v", err)
 	}
 }
 

--- a/internal/cli/drain_test.go
+++ b/internal/cli/drain_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -118,6 +119,72 @@ func TestRunDrainMovesToCur(t *testing.T) {
 	result2 := runDrainJSON(t, root, "alice", 0, false)
 	if result2.Count != 0 {
 		t.Errorf("second drain should be empty, got %d", result2.Count)
+	}
+}
+
+func TestRunDrainStrictAllowsReservedUserInbox(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	for _, agent := range []string{"claude", "codex", "user"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	writeKnownAgentsConfig(t, root, []string{"claude", "codex"})
+
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      "operator-gate",
+			From:    "claude",
+			To:      []string{"user"},
+			Thread:  "p2p/claude__user",
+			Subject: "Need operator",
+			Created: time.Now().UTC().Format(time.RFC3339Nano),
+		},
+		Body: "Please decide.",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := fsq.DeliverToInbox(root, "user", "operator-gate.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	result := runDrainJSONStrict(t, root, "user")
+	if result.Count != 1 {
+		t.Fatalf("expected count 1, got %d", result.Count)
+	}
+	item := result.Drained[0]
+	if item.ID != "operator-gate" || item.ParseError != "" || !item.MovedToCur || item.MovedToDLQ {
+		t.Fatalf("unexpected drain item: %+v", item)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentInboxCur(root, "user"), "operator-gate.md")); err != nil {
+		t.Fatalf("message should move to user cur: %v", err)
+	}
+	dlqEntries, err := os.ReadDir(fsq.AgentDLQNew(root, "user"))
+	if err != nil {
+		t.Fatalf("read user dlq: %v", err)
+	}
+	if len(dlqEntries) != 0 {
+		t.Fatalf("expected no user DLQ entries, got %d", len(dlqEntries))
+	}
+
+	receipts, err := receipt.List(root, "user", receipt.ListFilter{
+		MsgID: "operator-gate",
+		Stage: receipt.StageDrained,
+	})
+	if err != nil {
+		t.Fatalf("receipt.List: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("expected 1 drained receipt, got %d", len(receipts))
+	}
+	if receipts[0].Sender != "claude" || receipts[0].Consumer != "user" {
+		t.Fatalf("unexpected drained receipt: %+v", receipts[0])
 	}
 }
 
@@ -367,6 +434,31 @@ func runDrainJSON(t *testing.T, root, agent string, limit int, includeBody bool)
 	os.Stdout = w
 
 	err := runDrain(args)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("runDrain: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	var result drainResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v (output: %s)", err, buf.String())
+	}
+	return result
+}
+
+func runDrainJSONStrict(t *testing.T, root, agent string) drainResult {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runDrain([]string{"--root", root, "--me", agent, "--strict", "--json"})
 
 	_ = w.Close()
 	os.Stdout = oldStdout

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -318,9 +318,9 @@ Almost all coordination is agent-to-agent. Occasionally the **next required acto
 
 The single invariant AMQ relies on here is **recipient-as-next-actor**: a message addressed to the human handle means a human is who must act next. Everything else below (the `gate/<topic>` thread name and the `APPROVAL:` / `DONE:` subject prefixes) is a **naming convention** that downstream tools like amq-noc watch for. AMQ routing and message classification do **not** special-case thread names or subject text; those are plain strings, useful only because humans and tooling agree to read them. They are conventions, not core AMQ semantics.
 
-### The human handle is `user`, and it must be initialized
+### The human handle is `user`
 
-By convention the human/operator mailbox is `user`. It must be an initialized handle before you use gates. In current releases before the #139 follow-up, the default agent set may still be `claude,codex`, so sends addressed with `--to user` can warn about an unknown handle and **fail under `--strict`** unless the project initialized `user`. Initialize the handle before using gates:
+By convention the human/operator mailbox is `user`. AMQ reserves this handle for validation in configured projects, so `--to user` is accepted wherever the project has a configured agent list. New co-op projects include `user` in the default agent set. For explicit `amq init --agents ...` projects or older roots, initialize the mailbox layout before relying on human drain/receipt/DLQ ergonomics:
 
 ```bash
 # Seed the human mailbox alongside the agents (one-time, per project)
@@ -329,7 +329,7 @@ amq init --root .agent-mail --agents claude,codex,user
 amq coop init --agents claude,codex,user
 ```
 
-Throughout this section, `user` means "the conventional human handle **in a project that has initialized it**." If your project has not added the handle, every `--to user` send can warn (and fail under `--strict`) until you do.
+Throughout this section, `user` means "the conventional human handle." In configured projects it is warning-free for strict handle validation; in older or explicitly seeded roots, make sure the `agents/user/` mailbox exists before expecting a human to drain and reply from it.
 
 ### Raising a gate
 


### PR DESCRIPTION
## Summary
- Reserve `user` as the conventional human operator handle for configured roots, without changing no-config validation bypass behavior.
- Update `amq coop init` defaults to seed `claude,codex,user`; leave explicit `amq init --agents ...` unchanged.
- Refresh the operator-gate skill docs so they no longer claim `--to user` fails under `--strict` for configured projects.

Closes part of #139. This is PR1 only: no `who`/presence human rendering, no `doctor --ops` operator gate block, and no gate-state/thread/subject special-casing.

## Landmine Coverage
- `loadKnownAgents` returns `nil` when config is absent and does not synthesize `user` for `agents: []`.
- `loadKnownAgentSet` keeps the nil known-set path for no config.
- Strict header validation accepts `To: ["user"]` when the configured agents are `claude,codex`, but still rejects unknown recipients.
- Strict drain of a valid `claude -> user` message moves to `cur`, not DLQ, and writes a drained receipt.
- Persisted config tests use `config.LoadConfig`, not `loadKnownAgents`, so synthetic validation handles are not confused with stored config.

## Verification
- RED before implementation: focused new tests failed for strict `user` validation, strict drain, and coop defaults.
- `go test ./internal/cli`
- `make check-skills`
- `git diff --check`
- `make ci`
