### PR TITLE
Render user as human operator in ops views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `amq who`, `amq presence list`, and `amq doctor --ops` now present the
+  reserved `user` mailbox as a human operator gate instead of a stale agent
+  process (#139).
 - The human operator handle `user` is now reserved for configured projects, and
   `amq coop init` seeds `claude,codex,user` by default so strict operator gates
   no longer require custom coop setup (#139).

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -179,6 +179,15 @@ func runDoctor(args []string) error {
 				return err
 			}
 		}
+		if result.Ops.OperatorGate != nil {
+			line := fmt.Sprintf("  operator gate: %d open", result.Ops.OperatorGate.OpenCount)
+			if result.Ops.OperatorGate.OldestGateAgeSeconds > 0 {
+				line += fmt.Sprintf(", oldest %.0fs", result.Ops.OperatorGate.OldestGateAgeSeconds)
+			}
+			if err := writeStdoutLine(line); err != nil {
+				return err
+			}
+		}
 		for _, wl := range result.Ops.WakeLocks {
 			if wl.Status == string(wakeLockValid) {
 				continue

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -15,10 +15,11 @@ import (
 )
 
 type doctorOpsResult struct {
-	Root      opsRoot       `json:"root"`
-	Agents    []opsAgent    `json:"agents"`
-	WakeLocks []opsWakeLock `json:"wake_locks,omitempty"`
-	Hints     []opsHint     `json:"hints"`
+	Root         opsRoot          `json:"root"`
+	Agents       []opsAgent       `json:"agents"`
+	OperatorGate *opsOperatorGate `json:"operator_gate,omitempty"`
+	WakeLocks    []opsWakeLock    `json:"wake_locks,omitempty"`
+	Hints        []opsHint        `json:"hints"`
 }
 
 type opsRoot struct {
@@ -34,6 +35,11 @@ type opsAgent struct {
 	OldestDLQAgeSeconds    float64 `json:"oldest_dlq_age_seconds"`
 	PresenceStatus         string  `json:"presence_status"`
 	PresenceAgeSeconds     float64 `json:"presence_age_seconds"`
+}
+
+type opsOperatorGate struct {
+	OpenCount            int     `json:"open_count"`
+	OldestGateAgeSeconds float64 `json:"oldest_gate_age_seconds"`
 }
 
 type opsHint struct {
@@ -68,6 +74,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		Path:   root,
 		Source: rootSource,
 	}
+	result.OperatorGate = checkOperatorGate(root, now)
 
 	// Load config for agent list
 	cfg, err := config.LoadConfig(filepath.Join(root, "meta", "config.json"))
@@ -143,6 +150,31 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 	result.Hints = append(result.Hints, checkSymphonyHint()...)
 
 	return result
+}
+
+func checkOperatorGate(root string, now time.Time) *opsOperatorGate {
+	inboxNew := fsq.AgentInboxNew(root, reservedHumanHandle)
+	entries, err := os.ReadDir(inboxNew)
+	if err != nil {
+		return nil
+	}
+	gate := &opsOperatorGate{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		gate.OpenCount++
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		age := now.Sub(info.ModTime()).Seconds()
+		if age > gate.OldestGateAgeSeconds {
+			gate.OldestGateAgeSeconds = age
+		}
+	}
+	gate.OldestGateAgeSeconds = math.Round(gate.OldestGateAgeSeconds)
+	return gate
 }
 
 func discoveredWakeLockAgents(root string, configured []string) []string {

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -136,6 +136,123 @@ func TestRunOpsChecks_NoConfig(t *testing.T) {
 	}
 }
 
+func TestRunOpsChecks_OperatorGateReportsWithoutConfig(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, reservedHumanHandle); err != nil {
+		t.Fatalf("ensure user dirs: %v", err)
+	}
+	gatePath := filepath.Join(fsq.AgentInboxNew(root, reservedHumanHandle), "gate.md")
+	if err := os.WriteFile(gatePath, []byte("gate"), 0o600); err != nil {
+		t.Fatalf("write gate: %v", err)
+	}
+	if err := os.Chtimes(gatePath, time.Now().Add(-44*time.Second), time.Now().Add(-44*time.Second)); err != nil {
+		t.Fatalf("chtimes gate: %v", err)
+	}
+
+	result := runOpsChecks(root, "env", false)
+	if result.OperatorGate == nil {
+		t.Fatal("operator_gate is nil, want populated")
+	}
+	if result.OperatorGate.OpenCount != 1 {
+		t.Fatalf("open_count = %d, want 1", result.OperatorGate.OpenCount)
+	}
+	if result.OperatorGate.OldestGateAgeSeconds < 43 || result.OperatorGate.OldestGateAgeSeconds > 45 {
+		t.Fatalf("oldest_gate_age_seconds = %v, want about 44", result.OperatorGate.OldestGateAgeSeconds)
+	}
+}
+
+func TestRunOpsChecks_OperatorGateOmittedWhenUserInboxMissing(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"claude"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false)
+	if result.OperatorGate != nil {
+		t.Fatalf("operator_gate = %#v, want nil", result.OperatorGate)
+	}
+}
+
+func TestRunOpsChecks_OperatorGateReportsEmptyUserInbox(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, reservedHumanHandle); err != nil {
+		t.Fatalf("ensure user dirs: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false)
+	if result.OperatorGate == nil {
+		t.Fatal("operator_gate is nil, want populated")
+	}
+	if result.OperatorGate.OpenCount != 0 {
+		t.Fatalf("open_count = %d, want 0", result.OperatorGate.OpenCount)
+	}
+	if result.OperatorGate.OldestGateAgeSeconds != 0 {
+		t.Fatalf("oldest_gate_age_seconds = %v, want 0", result.OperatorGate.OldestGateAgeSeconds)
+	}
+}
+
+func TestRunOpsChecks_OperatorGateReportsUserInboxConfigIndependently(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	for _, agent := range []string{"claude", reservedHumanHandle} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("ensure agent dirs for %s: %v", agent, err)
+		}
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"claude"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	now := time.Now()
+	young := filepath.Join(fsq.AgentInboxNew(root, reservedHumanHandle), "young.md")
+	old := filepath.Join(fsq.AgentInboxNew(root, reservedHumanHandle), "old.md")
+	if err := os.WriteFile(young, []byte("young"), 0o600); err != nil {
+		t.Fatalf("write young gate: %v", err)
+	}
+	if err := os.WriteFile(old, []byte("old"), 0o600); err != nil {
+		t.Fatalf("write old gate: %v", err)
+	}
+	if err := os.Chtimes(young, now.Add(-15*time.Second), now.Add(-15*time.Second)); err != nil {
+		t.Fatalf("chtimes young gate: %v", err)
+	}
+	if err := os.Chtimes(old, now.Add(-125*time.Second), now.Add(-125*time.Second)); err != nil {
+		t.Fatalf("chtimes old gate: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false)
+	if result.OperatorGate == nil {
+		t.Fatal("operator_gate is nil, want populated")
+	}
+	if result.OperatorGate.OpenCount != 2 {
+		t.Fatalf("open_count = %d, want 2", result.OperatorGate.OpenCount)
+	}
+	if result.OperatorGate.OldestGateAgeSeconds < 124 || result.OperatorGate.OldestGateAgeSeconds > 126 {
+		t.Fatalf("oldest_gate_age_seconds = %v, want about 125", result.OperatorGate.OldestGateAgeSeconds)
+	}
+	if len(result.Agents) != 1 || result.Agents[0].Handle != "claude" {
+		t.Fatalf("operator gate should not inject user into per-agent ops: %#v", result.Agents)
+	}
+}
+
 func TestRunOpsChecks_ReportsAndFixesStaleWakeLockWithoutConfig(t *testing.T) {
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "alice", wakeLock{

--- a/internal/cli/presence.go
+++ b/internal/cli/presence.go
@@ -3,14 +3,22 @@ package cli
 import (
 	"flag"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"github.com/avivsinai/agent-message-queue/internal/presence"
 )
+
+type presenceListItem struct {
+	Schema             int    `json:"schema,omitempty"`
+	Handle             string `json:"handle"`
+	Status             string `json:"status"`
+	LastSeen           string `json:"last_seen,omitempty"`
+	Note               string `json:"note,omitempty"`
+	Kind               string `json:"kind"`
+	PresenceApplicable bool   `json:"presence_applicable"`
+}
 
 func runPresence(args []string) error {
 	if len(args) == 0 || isHelp(args[0]) {
@@ -80,10 +88,11 @@ func runPresenceList(args []string) error {
 	}
 	root := resolveRoot(common.Root)
 
-	var agents []string
-	if cfg, err := config.LoadConfig(filepath.Join(root, "meta", "config.json")); err == nil {
-		agents = cfg.Agents
-	} else {
+	agents, err := loadKnownAgents(root, false)
+	if err != nil {
+		return err
+	}
+	if agents == nil {
 		var listErr error
 		agents, listErr = fsq.ListAgents(root)
 		if listErr != nil && !os.IsNotExist(listErr) {
@@ -91,7 +100,7 @@ func runPresenceList(args []string) error {
 		}
 	}
 
-	items := make([]presence.Presence, 0, len(agents))
+	items := make([]presenceListItem, 0, len(agents))
 	for _, raw := range agents {
 		agent, err := normalizeHandle(raw)
 		if err != nil {
@@ -100,6 +109,25 @@ func runPresenceList(args []string) error {
 			}
 			continue
 		}
+
+		if agent == reservedHumanHandle {
+			p, err := presence.Read(root, agent)
+			if err != nil {
+				if os.IsNotExist(err) {
+					items = append(items, presenceListItem{
+						Handle:             reservedHumanHandle,
+						Status:             "human",
+						Kind:               "human",
+						PresenceApplicable: false,
+					})
+					continue
+				}
+				return err
+			}
+			items = append(items, presenceListItemFromPresence(p, "human", false))
+			continue
+		}
+
 		p, err := presence.Read(root, agent)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -107,7 +135,7 @@ func runPresenceList(args []string) error {
 			}
 			return err
 		}
-		items = append(items, p)
+		items = append(items, presenceListItemFromPresence(p, "agent", true))
 	}
 
 	if common.JSON {
@@ -120,6 +148,17 @@ func runPresenceList(args []string) error {
 		return nil
 	}
 	for _, item := range items {
+		if !item.PresenceApplicable {
+			if err := writeStdout("%s  human\n", item.Handle); err != nil {
+				return err
+			}
+			if item.Note != "" {
+				if err := writeStdout("  %s\n", item.Note); err != nil {
+					return err
+				}
+			}
+			continue
+		}
 		if err := writeStdout("%s  %s  %s\n", item.Handle, item.Status, item.LastSeen); err != nil {
 			return err
 		}
@@ -130,4 +169,20 @@ func runPresenceList(args []string) error {
 		}
 	}
 	return nil
+}
+
+func presenceListItemFromPresence(p presence.Presence, kind string, presenceApplicable bool) presenceListItem {
+	status := p.Status
+	if status == "" && kind == "human" {
+		status = "human"
+	}
+	return presenceListItem{
+		Schema:             p.Schema,
+		Handle:             p.Handle,
+		Status:             status,
+		LastSeen:           p.LastSeen,
+		Note:               p.Note,
+		Kind:               kind,
+		PresenceApplicable: presenceApplicable,
+	}
 }

--- a/internal/cli/presence_cli_test.go
+++ b/internal/cli/presence_cli_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/presence"
+)
+
+func TestRunPresenceListSynthesizesUserHumanEntry(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"claude", reservedHumanHandle} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	writeKnownAgentsConfig(t, root, []string{"claude"})
+	if err := presence.Write(root, presence.New("claude", "busy", "reviewing", time.Now())); err != nil {
+		t.Fatalf("write claude presence: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runPresenceList([]string{"--root", root, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runPresenceList: %v", err)
+	}
+	var items []struct {
+		Handle             string `json:"handle"`
+		Status             string `json:"status"`
+		Kind               string `json:"kind"`
+		PresenceApplicable bool   `json:"presence_applicable"`
+		LastSeen           string `json:"last_seen,omitempty"`
+		Note               string `json:"note,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(output), &items); err != nil {
+		t.Fatalf("unmarshal presence list: %v (output: %s)", err, output)
+	}
+
+	var claude, user *struct {
+		Handle             string `json:"handle"`
+		Status             string `json:"status"`
+		Kind               string `json:"kind"`
+		PresenceApplicable bool   `json:"presence_applicable"`
+		LastSeen           string `json:"last_seen,omitempty"`
+		Note               string `json:"note,omitempty"`
+	}
+	for i := range items {
+		item := &items[i]
+		switch item.Handle {
+		case "claude":
+			claude = item
+		case reservedHumanHandle:
+			user = item
+		}
+	}
+	if claude == nil || user == nil {
+		t.Fatalf("expected claude and user presence items: %#v", items)
+	}
+	if claude.Kind != "agent" || !claude.PresenceApplicable || claude.Status != "busy" || claude.LastSeen == "" {
+		t.Fatalf("claude = %+v, want agent presence item", *claude)
+	}
+	if user.Kind != "human" || user.PresenceApplicable || user.Status != "human" || user.LastSeen != "" {
+		t.Fatalf("user = %+v, want synthesized human item without last_seen", *user)
+	}
+}
+
+func TestRunPresenceSetUserListsAsHuman(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, reservedHumanHandle); err != nil {
+		t.Fatalf("EnsureAgentDirs(user): %v", err)
+	}
+	writeKnownAgentsConfig(t, root, []string{"claude"})
+
+	if _, err := captureEnvStdout(t, func() error {
+		return runPresenceSet([]string{"--root", root, "--me", reservedHumanHandle, "--strict", "--status", "available", "--note", "watching gates"})
+	}); err != nil {
+		t.Fatalf("runPresenceSet user: %v", err)
+	}
+	output, err := captureEnvStdout(t, func() error {
+		return runPresenceList([]string{"--root", root, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runPresenceList: %v", err)
+	}
+
+	var items []struct {
+		Handle             string `json:"handle"`
+		Status             string `json:"status"`
+		Kind               string `json:"kind"`
+		PresenceApplicable bool   `json:"presence_applicable"`
+		LastSeen           string `json:"last_seen,omitempty"`
+		Note               string `json:"note,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(output), &items); err != nil {
+		t.Fatalf("unmarshal presence list: %v (output: %s)", err, output)
+	}
+	var user *struct {
+		Handle             string `json:"handle"`
+		Status             string `json:"status"`
+		Kind               string `json:"kind"`
+		PresenceApplicable bool   `json:"presence_applicable"`
+		LastSeen           string `json:"last_seen,omitempty"`
+		Note               string `json:"note,omitempty"`
+	}
+	for i := range items {
+		if items[i].Handle == reservedHumanHandle {
+			user = &items[i]
+			break
+		}
+	}
+	if user == nil {
+		t.Fatalf("expected user presence item: %#v", items)
+	}
+	if user.Kind != "human" || user.PresenceApplicable || user.Status != "available" || user.Note != "watching gates" || user.LastSeen == "" {
+		t.Fatalf("user = %+v, want real human presence item marked not applicable", *user)
+	}
+}

--- a/internal/cli/who.go
+++ b/internal/cli/who.go
@@ -44,9 +44,11 @@ func runWho(args []string) error {
 	}
 
 	type agentInfo struct {
-		Handle string `json:"handle"`
-		Active bool   `json:"active"`
-		Note   string `json:"note,omitempty"`
+		Handle             string `json:"handle"`
+		Kind               string `json:"kind"`
+		PresenceApplicable bool   `json:"presence_applicable"`
+		Active             bool   `json:"active"`
+		Note               string `json:"note,omitempty"`
 	}
 	type sessionInfo struct {
 		Name   string      `json:"name"`
@@ -77,7 +79,21 @@ func runWho(args []string) error {
 				continue
 			}
 
-			ai := agentInfo{Handle: ae.Name()}
+			ai := agentInfo{
+				Handle:             ae.Name(),
+				Kind:               "agent",
+				PresenceApplicable: true,
+			}
+			if ai.Handle == reservedHumanHandle {
+				ai.Kind = "human"
+				ai.PresenceApplicable = false
+				if p, err := presence.Read(sessDir, ae.Name()); err == nil {
+					ai.Note = p.Note
+				}
+				agents = append(agents, ai)
+				continue
+			}
+
 			// Check presence for activity status.
 			if p, err := presence.Read(sessDir, ae.Name()); err == nil {
 				if t, err := time.Parse(time.RFC3339Nano, p.LastSeen); err == nil {
@@ -114,7 +130,9 @@ func runWho(args []string) error {
 		}
 		for _, a := range s.Agents {
 			status := "stale"
-			if a.Active {
+			if !a.PresenceApplicable {
+				status = "human"
+			} else if a.Active {
 				status = "active"
 			}
 			note := ""

--- a/internal/cli/who_test.go
+++ b/internal/cli/who_test.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/presence"
+)
+
+func TestRunWhoRendersUserAsHuman(t *testing.T) {
+	baseRoot := t.TempDir()
+	root := filepath.Join(baseRoot, "collab")
+	for _, agent := range []string{"claude", reservedHumanHandle} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	if err := presence.Write(root, presence.New("claude", "busy", "reviewing", time.Now())); err != nil {
+		t.Fatalf("write claude presence: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWho([]string{"--root", root, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runWho json: %v", err)
+	}
+	var sessions []struct {
+		Name   string `json:"name"`
+		Agents []struct {
+			Handle             string `json:"handle"`
+			Kind               string `json:"kind"`
+			PresenceApplicable bool   `json:"presence_applicable"`
+			Active             bool   `json:"active"`
+			Note               string `json:"note,omitempty"`
+		} `json:"agents"`
+	}
+	if err := json.Unmarshal([]byte(output), &sessions); err != nil {
+		t.Fatalf("unmarshal who json: %v (output: %s)", err, output)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("session count = %d, want 1: %#v", len(sessions), sessions)
+	}
+
+	var claude, user *struct {
+		Handle             string `json:"handle"`
+		Kind               string `json:"kind"`
+		PresenceApplicable bool   `json:"presence_applicable"`
+		Active             bool   `json:"active"`
+		Note               string `json:"note,omitempty"`
+	}
+	for i := range sessions[0].Agents {
+		agent := &sessions[0].Agents[i]
+		switch agent.Handle {
+		case "claude":
+			claude = agent
+		case reservedHumanHandle:
+			user = agent
+		}
+	}
+	if claude == nil || user == nil {
+		t.Fatalf("expected claude and user in who output: %#v", sessions[0].Agents)
+	}
+	if claude.Kind != "agent" || !claude.PresenceApplicable || !claude.Active {
+		t.Fatalf("claude = %+v, want active agent with applicable presence", *claude)
+	}
+	if user.Kind != "human" || user.PresenceApplicable || user.Active {
+		t.Fatalf("user = %+v, want inactive human with non-applicable presence", *user)
+	}
+
+	text, err := captureEnvStdout(t, func() error {
+		return runWho([]string{"--root", root})
+	})
+	if err != nil {
+		t.Fatalf("runWho text: %v", err)
+	}
+	if !strings.Contains(text, "user  human") {
+		t.Fatalf("text output should render user as human, got:\n%s", text)
+	}
+	if strings.Contains(text, "user  stale") {
+		t.Fatalf("text output should not render user as stale, got:\n%s", text)
+	}
+}


### PR DESCRIPTION
## Summary
- render the reserved `user` mailbox as `kind: human` / `presence_applicable: false` in `amq who` and `amq presence list`
- add a config-independent `doctor --ops` `operator_gate` summary for `agents/user/inbox/new`
- keep `user` out of per-agent ops stats while preserving any real user presence note/status

## Scope
- No APPROVAL/DONE parsing.
- No new gate state machine or auth model.
- No change to agent liveness semantics for real agents.

## Verification
- RED before implementation: targeted PR2 tests failed on missing operator gate / human render behavior.
- `go test ./internal/cli -run 'TestRunWhoRendersUserAsHuman|TestRunPresenceListSynthesizesUserHumanEntry|TestRunPresenceSetUserListsAsHuman|TestRunOpsChecks_OperatorGate'`
- `git diff --check`
- `make ci`
