### PR TITLE
Add guarded env export for session shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `amq env --export` now prints eval-safe shell exports for opt-in terminal
+  pinning, including `AM_BASE_ROOT` only when the resolved root is a session
+  root (#149).
+
 ### Fixed
 
 - `amq who`, `amq presence list`, and `amq doctor --ops` now present the

--- a/README.md
+++ b/README.md
@@ -241,6 +241,17 @@ Root resolution precedence is:
 flags > AM_ROOT > project .amqrc > AMQ_GLOBAL_ROOT > ~/.amqrc > auto-detect
 ```
 
+For an external orchestrator or plain shell that should stay pinned to one
+session, opt in explicitly:
+
+```sh
+eval "$(amq env --session auth --me claude --export)"
+```
+
+That exports `AM_ROOT`, `AM_ME`, and, for session roots, `AM_BASE_ROOT`, and
+prints a stderr note that the terminal is pinned. Treat this as one terminal,
+one session.
+
 Auto-detect covers the default `.agent-mail` layout, including `.agent-mail/<session>` session roots without `.amqrc`. Custom root names and peer config still require `.amqrc` or explicit flags/env.
 This same chain is used by `amq env`, `amq doctor`, and the integration commands, so Symphony and Kanban-launched agents can find the correct queue even when they are not started from the project directory.
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -52,6 +52,7 @@ func runEnv(args []string) error {
 	shellFlag := fs.String("shell", "sh", "Shell format: sh, bash, zsh, fish")
 	wakeFlag := fs.Bool("wake", false, "Include amq wake & in output")
 	jsonFlag := fs.Bool("json", false, "Output as JSON (for scripts)")
+	exportFlag := fs.Bool("export", false, "Output shell exports for pinning this terminal to the resolved root")
 	sessionNameFlag := fs.Bool("session-name", false, "Print current session name (for statusline integration)")
 
 	usage := usageWithFlags(fs, "amq env [options]",
@@ -67,6 +68,7 @@ func runEnv(args []string) error {
 		"",
 		"Examples:",
 		"  eval \"$(amq env --me claude)\"                # Set up for Claude",
+		"  eval \"$(amq env --session feature-x --me claude --export)\"  # Pin this terminal to one session",
 		"  eval \"$(amq env --me codex --wake)\"          # Set up for Codex with wake",
 		"  eval \"$(amq env --session feature-x --me claude)\"  # Isolated session",
 		"  amq env --json                                # Machine-readable output",
@@ -83,8 +85,16 @@ func runEnv(args []string) error {
 	if *sessionNameFlag && *jsonFlag {
 		return UsageError("--session-name and --json are mutually exclusive")
 	}
+	if *exportFlag && *jsonFlag {
+		return UsageError("--export and --json are mutually exclusive")
+	}
+	if *exportFlag && *sessionNameFlag {
+		return UsageError("--export and --session-name are mutually exclusive")
+	}
 
 	// Resolve --session into --root (mutually exclusive).
+	sessionBaseRoot := ""
+	sessionNameOverride := ""
 	if *sessionFlag != "" {
 		if *rootFlag != "" {
 			return UsageError("--session and --root are mutually exclusive")
@@ -94,6 +104,8 @@ func runEnv(args []string) error {
 		}
 		// Resolve base from .amqrc or default
 		base := resolveBaseRoot()
+		sessionBaseRoot = base
+		sessionNameOverride = *sessionFlag
 		*rootFlag = filepath.Join(base, *sessionFlag)
 	}
 
@@ -111,6 +123,9 @@ func runEnv(args []string) error {
 
 	// --session-name output mode: print session name and exit
 	if *sessionNameFlag {
+		if sessionNameOverride != "" {
+			return writeStdout("%s\n", sessionNameOverride)
+		}
 		if name := resolveSessionName(root); name != "" {
 			return writeStdout("%s\n", name)
 		}
@@ -120,6 +135,11 @@ func runEnv(args []string) error {
 	// JSON output mode
 	if *jsonFlag {
 		baseRoot, sessionName, inSession := classifyEnvRoot(root)
+		if sessionNameOverride != "" {
+			baseRoot = sessionBaseRoot
+			sessionName = sessionNameOverride
+			inSession = true
+		}
 		project, peers := envProjectAndPeers(root)
 		out := envOutput{
 			SchemaVersion: 1,
@@ -139,6 +159,18 @@ func runEnv(args []string) error {
 	}
 
 	// Generate shell commands
+	if *exportFlag {
+		baseRoot, sessionName, inSession := classifyEnvRoot(root)
+		if sessionNameOverride != "" {
+			baseRoot = sessionBaseRoot
+			sessionName = sessionNameOverride
+			inSession = true
+		}
+		if err := writeShellExportEnv(root, baseRoot, me, shell, *wakeFlag, inSession); err != nil {
+			return err
+		}
+		return writeEnvExportPinNote(root, baseRoot, sessionName, inSession)
+	}
 	return writeShellEnv(root, me, shell, *wakeFlag)
 }
 
@@ -427,10 +459,43 @@ func writeShellEnv(root, me, shell string, wake bool) error {
 	}
 }
 
+func writeShellExportEnv(root, baseRoot, me, shell string, wake bool, includeBaseRoot bool) error {
+	switch shell {
+	case "fish":
+		return writeFishExportEnv(root, baseRoot, me, wake, includeBaseRoot)
+	default:
+		return writePosixExportEnv(root, baseRoot, me, wake, includeBaseRoot)
+	}
+}
+
 func writePosixEnv(root, me string, wake bool) error {
 	// Use proper shell quoting
 	if root != "" {
 		if err := writeStdout("export AM_ROOT=%s\n", shellQuotePosix(root)); err != nil {
+			return err
+		}
+	}
+	if me != "" {
+		if err := writeStdout("export AM_ME=%s\n", shellQuotePosix(me)); err != nil {
+			return err
+		}
+	}
+	if wake {
+		if err := writeStdoutLine("amq wake &"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writePosixExportEnv(root, baseRoot, me string, wake bool, includeBaseRoot bool) error {
+	if root != "" {
+		if err := writeStdout("export AM_ROOT=%s\n", shellQuotePosix(root)); err != nil {
+			return err
+		}
+	}
+	if includeBaseRoot && baseRoot != "" {
+		if err := writeStdout("export AM_BASE_ROOT=%s\n", shellQuotePosix(baseRoot)); err != nil {
 			return err
 		}
 	}
@@ -464,6 +529,37 @@ func writeFishEnv(root, me string, wake bool) error {
 		}
 	}
 	return nil
+}
+
+func writeFishExportEnv(root, baseRoot, me string, wake bool, includeBaseRoot bool) error {
+	if root != "" {
+		if err := writeStdout("set -gx AM_ROOT %s\n", shellQuoteFish(root)); err != nil {
+			return err
+		}
+	}
+	if includeBaseRoot && baseRoot != "" {
+		if err := writeStdout("set -gx AM_BASE_ROOT %s\n", shellQuoteFish(baseRoot)); err != nil {
+			return err
+		}
+	}
+	if me != "" {
+		if err := writeStdout("set -gx AM_ME %s\n", shellQuoteFish(me)); err != nil {
+			return err
+		}
+	}
+	if wake {
+		if err := writeStdoutLine("amq wake &"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeEnvExportPinNote(root, baseRoot, session string, inSession bool) error {
+	if inSession {
+		return writeStderr("note: pinned to AMQ session %s; use one terminal, one session (AM_ROOT=%s, AM_BASE_ROOT=%s)\n", session, root, baseRoot)
+	}
+	return writeStderr("note: pinned to AMQ root %s\n", root)
 }
 
 // shellQuotePosix quotes a string for safe use in POSIX shell commands.

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -33,6 +33,44 @@ func captureEnvStdout(t *testing.T, fn func() error) (string, error) {
 	return buf.String(), runErr
 }
 
+func captureEnvOutput(t *testing.T, fn func() error) (stdout, stderr string, runErr error) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = wOut
+	os.Stderr = wErr
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	})
+
+	runErr = fn()
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	var outBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(rOut)
+	_ = rOut.Close()
+
+	var errBuf bytes.Buffer
+	_, _ = errBuf.ReadFrom(rErr)
+	_ = rErr.Close()
+
+	return outBuf.String(), errBuf.String(), runErr
+}
+
 func runEnvJSONForTest(t *testing.T, args ...string) envOutput {
 	t.Helper()
 
@@ -833,6 +871,314 @@ func TestRunEnvJSONV1SessionFlag(t *testing.T) {
 	}
 	if result.RootSource != string(rootSourceFlag) {
 		t.Errorf("expected root_source=%q, got %q", rootSourceFlag, result.RootSource)
+	}
+}
+
+func TestRunEnvNonExportSessionOutputStaysRootAndMeOnly(t *testing.T) {
+	root := t.TempDir()
+	rcContent := `{"root": ".agent-mail"}`
+	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_ME", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--session", "feature-x", "--me", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+
+	expectedRoot := filepath.Join(projectRoot, ".agent-mail", "feature-x")
+	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
+		"export AM_ME=codex\n"
+	if stdout != want {
+		t.Fatalf("stdout = %q, want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if strings.Contains(stdout, "AM_BASE_ROOT") {
+		t.Fatalf("non-export output should not include AM_BASE_ROOT: %q", stdout)
+	}
+}
+
+func TestRunEnvExportSessionEmitsBaseRootAndPinNote(t *testing.T) {
+	root := t.TempDir()
+	rcContent := `{"root": ".agent-mail"}`
+	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_ME", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--session", "feature-x", "--me", "codex", "--export"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+
+	expectedBase := filepath.Join(projectRoot, ".agent-mail")
+	expectedRoot := filepath.Join(expectedBase, "feature-x")
+	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
+		"export AM_BASE_ROOT=" + shellQuotePosix(expectedBase) + "\n" +
+		"export AM_ME=codex\n"
+	if stdout != want {
+		t.Fatalf("stdout = %q, want %q", stdout, want)
+	}
+	if !strings.Contains(stderr, "pinned to AMQ session feature-x") {
+		t.Fatalf("stderr should contain session pin note, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "one terminal, one session") {
+		t.Fatalf("stderr should mention one terminal, one session, got %q", stderr)
+	}
+}
+
+func TestRunEnvExportNonSessionOmitsBaseRoot(t *testing.T) {
+	root := t.TempDir()
+	rcContent := `{"root": ".agent-mail"}`
+	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_ME", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--me", "codex", "--export"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+
+	expectedRoot := filepath.Join(projectRoot, ".agent-mail")
+	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
+		"export AM_ME=codex\n"
+	if stdout != want {
+		t.Fatalf("stdout = %q, want %q", stdout, want)
+	}
+	if strings.Contains(stdout, "AM_BASE_ROOT") {
+		t.Fatalf("non-session export should not include AM_BASE_ROOT: %q", stdout)
+	}
+	if !strings.Contains(stderr, "pinned to AMQ root") {
+		t.Fatalf("stderr should contain root pin note, got %q", stderr)
+	}
+}
+
+func TestRunEnvExportFishSessionEmitsBaseRoot(t *testing.T) {
+	root := t.TempDir()
+	rcContent := `{"root": ".agent-mail"}`
+	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_ME", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--session", "feature-x", "--me", "codex", "--export", "--shell", "fish"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+
+	expectedBase := filepath.Join(projectRoot, ".agent-mail")
+	expectedRoot := filepath.Join(expectedBase, "feature-x")
+	want := "set -gx AM_ROOT " + shellQuoteFish(expectedRoot) + "\n" +
+		"set -gx AM_BASE_ROOT " + shellQuoteFish(expectedBase) + "\n" +
+		"set -gx AM_ME codex\n"
+	if stdout != want {
+		t.Fatalf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+func TestRunEnvExportSessionFromGlobalRootEmitsBaseRoot(t *testing.T) {
+	cwd := t.TempDir()
+	globalRoot := filepath.Join(t.TempDir(), "custom-root")
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_ME", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", globalRoot)
+
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--session", "feature-x", "--me", "codex", "--export"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+
+	expectedRoot := filepath.Join(globalRoot, "feature-x")
+	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
+		"export AM_BASE_ROOT=" + shellQuotePosix(globalRoot) + "\n" +
+		"export AM_ME=codex\n"
+	if stdout != want {
+		t.Fatalf("stdout = %q, want %q", stdout, want)
+	}
+	if !strings.Contains(stderr, "pinned to AMQ session feature-x") {
+		t.Fatalf("stderr should contain session pin note, got %q", stderr)
+	}
+}
+
+func TestRunEnvExportSessionIgnoresStaleAmbientBaseRoot(t *testing.T) {
+	root := t.TempDir()
+	rcContent := `{"root": ".agent-mail"}`
+	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", filepath.Join(t.TempDir(), "stale-root"))
+	t.Setenv("AM_ME", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--session", "feature-x", "--me", "codex", "--export"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+
+	expectedBase := filepath.Join(projectRoot, ".agent-mail")
+	expectedRoot := filepath.Join(expectedBase, "feature-x")
+	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
+		"export AM_BASE_ROOT=" + shellQuotePosix(expectedBase) + "\n" +
+		"export AM_ME=codex\n"
+	if stdout != want {
+		t.Fatalf("stdout = %q, want %q", stdout, want)
+	}
+	if strings.Contains(stdout, "stale-root") {
+		t.Fatalf("stdout should not contain stale AM_BASE_ROOT: %q", stdout)
+	}
+}
+
+func TestRunEnvExportExplicitBaseRootOmitsBaseRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-mail")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--root", root, "--me", "codex", "--export"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+
+	want := "export AM_ROOT=" + shellQuotePosix(root) + "\n" +
+		"export AM_ME=codex\n"
+	if stdout != want {
+		t.Fatalf("stdout = %q, want %q", stdout, want)
+	}
+	if strings.Contains(stdout, "AM_BASE_ROOT") {
+		t.Fatalf("explicit base-root export should not include AM_BASE_ROOT: %q", stdout)
+	}
+}
+
+func TestRunEnvExportMutuallyExclusiveOutputModes(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "json",
+			args: []string{"--export", "--json"},
+			want: "--export and --json are mutually exclusive",
+		},
+		{
+			name: "session-name",
+			args: []string{"--export", "--session-name"},
+			want: "--export and --session-name are mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := captureEnvOutput(t, func() error {
+				return runEnv(tt.args)
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("err = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -47,11 +47,13 @@ The reason: `coop exec` sets `AM_ROOT` and `AM_ME` precisely for the session. Pa
 **Outside `coop exec`** — resolve the root from config, don't hardcode it:
 ```bash
 eval "$(amq env --me claude)"          # reads .amqrc chain, sets both vars
+eval "$(amq env --session auth --me claude --export)"  # pin this terminal to one session
 
 # Or pin per-command without polluting the shell (useful in scripts):
 AM_ME=claude AM_ROOT=$(amq env --json | jq -r .root) amq send --to codex --body "hello"
 ```
 Why not hardcode? The root path depends on the config chain (project `.amqrc` → `AMQ_GLOBAL_ROOT` → `~/.amqrc`). Hardcoding skips this and breaks when the project moves or config changes.
+Use `--export` only when the whole terminal should stay pinned; it exports `AM_BASE_ROOT` for session roots and prints a stderr note. Treat it as one terminal, one session.
 
 **Global fallback**: Orchestrator-spawned agents often start outside the repo root where no project `.amqrc` exists. Set `AMQ_GLOBAL_ROOT` or `~/.amqrc` so `amq env` and `amq doctor` still resolve the correct queue.
 


### PR DESCRIPTION
## Summary
- add `amq env --export` as an opt-in shell-output mode for pinning a terminal to the resolved AMQ root
- emit `AM_BASE_ROOT` only when the resolved root is a confirmed session root, including explicit `--session` roots backed by custom/global base roots
- print a stderr pin note while keeping stdout eval-safe, and preserve non-export `amq env` stdout behavior
- document the one-terminal/one-session guardrail in README and the AMQ skill

## Scope
- No change to bare/default `amq env` shell output.
- No `AMQ_GLOBAL_ROOT` export.
- No broader root-resolution precedence changes.

## Verification
- RED before implementation: focused `--export` tests failed because the flag did not exist.
- `go test ./internal/cli -run 'TestRunEnv'`
- `git diff --check`
- `make check-skills`
- `make ci`
