### PR TITLE
[codex] Add Ghostty wake targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report and optionally fix identity-verified stale `.wake.lock` files from
   `amq doctor --ops`, including roots whose config is missing or corrupt (#151).
 
+### Fixed
+
+- `amq coop exec --require-wake` can reuse an existing usable wake process, while
+  still failing closed when the existing wake cannot safely inject (#153).
+
 ## [0.36.0] - 2026-06-13
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approval gates (#136).
 - Report and optionally fix identity-verified stale `.wake.lock` files from
   `amq doctor --ops`, including roots whose config is missing or corrupt (#151).
+- Add native macOS Ghostty wake injection by terminal id via
+  `amq wake --inject-ghostty` and `amq coop exec --wake-inject-ghostty`.
+- Track wake injection targets beside wake locks and expose orphaned target
+  cleanup through `amq doctor --ops --fix-wake-targets`.
 
 ### Fixed
 
 - `amq coop exec --require-wake` can reuse an existing usable wake process, while
   still failing closed when the existing wake cannot safely inject (#153).
+- Wake reuse is now target-aware, so a live wake bound to a different Ghostty or
+  external injection target is not silently reused.
 
 ## [0.36.0] - 2026-06-13
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,12 +173,12 @@ amq dlq list --me <agent> [--new | --cur] [--json]
 amq dlq read --me <agent> --id <dlq_id> [--json]
 amq dlq retry --me <agent> --id <dlq_id> [--all] [--force]
 amq dlq purge --me <agent> [--older-than <duration>] [--dry-run] [--yes]
-amq wake --me <agent> [--inject-cmd <cmd>] [--inject-via <executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>]
+amq wake --me <agent> [--inject-cmd <cmd>] [--inject-via <executable>] [--inject-arg <arg>...] [--inject-ghostty] [--inject-ghostty-terminal-id <id>] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>]
 amq upgrade
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--json]
 amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>]
 amq coop init [--root <path>] [--agents <a,b,c>] [--force] [--json]
-amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-wake] [--require-wake] [-y] <command> [-- <command-flags>]
+amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-wake] [--require-wake] [--wake-inject-ghostty] [--wake-inject-ghostty-terminal-id <id>] [-y] <command> [-- <command-flags>]
 amq swarm list [--json]
 amq swarm join --team <name> --me <agent> [--agent-id <id>] [--type codex|external] [--json]
 amq swarm leave --team <name> --agent-id <id> [--json]
@@ -332,7 +332,7 @@ Use `--force` with retry to override the max retry limit.
 - Queue depth and oldest unread per agent
 - DLQ count and oldest age
 - Presence freshness
-- Wake lock health (`--fix-wake-locks` removes stale locks)
+- Wake lock and wake target health (`--fix-wake-locks` removes stale locks; `--fix-wake-targets` removes orphaned target metadata)
 - Integration hints for Kanban and Symphony
 
 Use `amq doctor --ops --json` for machine-readable health output.
@@ -424,6 +424,17 @@ payload as the final argument and bounds each invocation with
 `--inject-timeout` (default `5s`). This executes local code for each
 notification, and the payload can include sanitized but message-derived sender
 and subject header content.
+
+On macOS Ghostty, prefer native terminal-id injection:
+
+```bash
+amq coop exec --wake-inject-ghostty codex
+amq wake --me codex --inject-ghostty
+```
+
+AMQ stores the Ghostty terminal id beside the wake lock and rejects reuse when a
+live wake is bound to a different target. This keeps routing by AMQ root/agent
+while making the terminal injection destination stable.
 
 ### Plan Mode Prompt Hook (Claude)
 

--- a/COOP.md
+++ b/COOP.md
@@ -215,6 +215,19 @@ amq reply --id "msg_123" --kind review_response --body "LGTM with minor suggesti
 > Co-op works without wake. `coop exec` starts it automatically.
 
 `amq wake` uses TIOCSTI to inject notifications into your terminal by default.
+On macOS Ghostty, prefer native terminal-id injection so notifications target
+the exact terminal instead of a title:
+
+```bash
+amq coop exec --wake-inject-ghostty codex
+amq wake --me codex --inject-ghostty
+```
+
+If `--inject-ghostty-terminal-id` is omitted, AMQ discovers the focused Ghostty
+terminal when wake starts, stores the target beside the wake lock, and refuses to
+reuse a live wake that points at a different target. Use
+`amq doctor --ops --fix-wake-targets` to remove orphaned target metadata.
+
 For orchestrators or hardened environments without a controlling TTY, use an
 explicit external transport:
 
@@ -235,6 +248,8 @@ sender and subject.
 - `--inject-mode auto|raw|paste` - Injection strategy
 - `--inject-via <executable>` - External transport executable; bypasses TIOCSTI and local TTY startup checks
 - `--inject-arg <arg>` - Fixed argument before the payload; repeat for multiple arguments
+- `--inject-ghostty` - Native macOS Ghostty terminal-id injection
+- `--inject-ghostty-terminal-id <id>` - Explicit Ghostty terminal id; defaults to the focused terminal
 - `--inject-timeout 5s` - Maximum runtime for one external injection command
 - `--bell` - Ring terminal bell on new messages
 - `--debounce 250ms` - Batch rapid messages

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ amq doctor
 amq doctor --ops
 amq doctor --ops --json
 amq doctor --ops --fix-wake-locks
+amq doctor --ops --fix-wake-targets
+```
+
+On macOS Ghostty, launchers can bind wake notifications to the terminal id
+instead of relying on terminal titles:
+
+```bash
+amq coop exec --wake-inject-ghostty codex
 ```
 
 ## Message Kinds & Priority

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -135,6 +135,64 @@ func TestCoopExecSessionInvalidName(t *testing.T) {
 	}
 }
 
+func TestWakeReadyMessageReportsExistingWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "codex"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	got := wakeReadyMessage(root, "codex", 1000)
+	if got != "Using existing amq wake (pid 4242)" {
+		t.Fatalf("message = %q", got)
+	}
+}
+
+func TestWakeReadyMessageReportsStartedWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "codex"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	got := wakeReadyMessage(root, "codex", wakePID)
+	if got != "Started amq wake (pid 4242)" {
+		t.Fatalf("message = %q", got)
+	}
+}
+
 func sliceEq(a, b []string) bool {
 	if a == nil && b == nil {
 		return true

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -125,6 +125,34 @@ func TestCoopExecRequireWakeRejectsNoWake(t *testing.T) {
 	}
 }
 
+func TestCoopExecWakeGhosttyTerminalIDRequiresGhostty(t *testing.T) {
+	err := runCoopExec([]string{"--wake-inject-ghostty-terminal-id", "terminal-1", "claude"})
+	if err == nil {
+		t.Fatal("expected error for terminal id without --wake-inject-ghostty")
+	}
+	if !containsStr(err.Error(), "--wake-inject-ghostty-terminal-id requires --wake-inject-ghostty") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestBuildCoopWakeArgsGhostty(t *testing.T) {
+	got := buildCoopWakeArgs("codex", "/tmp/q", true, "terminal-1")
+	want := []string{
+		"--no-update-check",
+		"wake",
+		"--me",
+		"codex",
+		"--root",
+		"/tmp/q",
+		"--inject-ghostty",
+		"--inject-ghostty-terminal-id",
+		"terminal-1",
+	}
+	if !sliceEq(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
 func TestCoopExecSessionInvalidName(t *testing.T) {
 	err := runCoopExec([]string{"--session", "Bad/Name", "claude"})
 	if err == nil {

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -196,7 +196,7 @@ func runCoopExec(args []string) error {
 				return fmt.Errorf("create wake readiness file: %w", readyErr)
 			}
 			defer cleanupReady()
-			wakeCmd.Args = append(wakeCmd.Args, "--ready-file", readyPath)
+			wakeCmd.Args = append(wakeCmd.Args, "--ready-file", readyPath, "--accept-existing-wake")
 		}
 		// Set AM_ROOT in wake's env so the helper process resolves the same
 		// session root even if the parent shell inherited a different value.
@@ -218,7 +218,7 @@ func runCoopExec(args []string) error {
 					return err
 				}
 			}
-			_ = writeStderr("Started amq wake (pid %d)\n", wakeProc.Pid)
+			_ = writeStderr("%s\n", wakeReadyMessage(root, agentHandle, wakeProc.Pid))
 		}
 	}
 
@@ -276,6 +276,11 @@ func waitForWakeReady(proc *os.Process, readyPath string, timeout time.Duration)
 
 		select {
 		case err := <-done:
+			if _, statErr := os.Stat(readyPath); statErr == nil {
+				return nil
+			} else if !os.IsNotExist(statErr) {
+				return fmt.Errorf("check wake readiness file: %w", statErr)
+			}
 			if err != nil {
 				return fmt.Errorf("amq wake exited before becoming ready: %w", err)
 			}
@@ -285,6 +290,13 @@ func waitForWakeReady(proc *os.Process, readyPath string, timeout time.Duration)
 		case <-ticker.C:
 		}
 	}
+}
+
+func wakeReadyMessage(root, agentHandle string, startedPID int) string {
+	if inspection := inspectWakeLock(root, agentHandle); inspection.Status == wakeLockValid && inspection.PID != 0 && inspection.PID != startedPID {
+		return fmt.Sprintf("Using existing amq wake (pid %d)", inspection.PID)
+	}
+	return fmt.Sprintf("Started amq wake (pid %d)", startedPID)
 }
 
 // splitDashDash splits args at the first "--" separator.

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -28,6 +28,8 @@ func runCoopExec(args []string) error {
 	noInitFlag := fs.Bool("no-init", false, "Don't auto-initialize if .amqrc is missing")
 	noWakeFlag := fs.Bool("no-wake", false, "Don't start amq wake in background")
 	requireWakeFlag := fs.Bool("require-wake", false, "Fail if amq wake cannot start and acquire its lock")
+	wakeInjectGhosttyFlag := fs.Bool("wake-inject-ghostty", false, "Start wake with native Ghostty terminal-id injection")
+	wakeInjectGhosttyTerminalIDFlag := fs.String("wake-inject-ghostty-terminal-id", "", "Ghostty terminal id for --wake-inject-ghostty")
 	yesFlag := fs.Bool("y", false, "Skip confirmation prompts")
 
 	usage := usageWithFlags(fs, "amq coop exec [options] <command> [-- <command-flags>]",
@@ -45,6 +47,7 @@ func runCoopExec(args []string) error {
 		"  amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Codex with flags",
 		"  amq coop exec --session feature-x claude          # Isolated session",
 		"  amq coop exec --root .agent-mail/auth claude      # Explicit root (no session default)",
+		"  amq coop exec --wake-inject-ghostty codex         # Wake the current Ghostty terminal by id",
 		"  amq coop exec --me myagent bash                   # Debug shell with AMQ env",
 	)
 
@@ -55,6 +58,17 @@ func runCoopExec(args []string) error {
 	}
 	if *noWakeFlag && *requireWakeFlag {
 		return UsageError("--require-wake cannot be used with --no-wake")
+	}
+	if strings.TrimSpace(*wakeInjectGhosttyTerminalIDFlag) != "" && !*wakeInjectGhosttyFlag {
+		return UsageError("--wake-inject-ghostty-terminal-id requires --wake-inject-ghostty")
+	}
+	wakeInjectGhosttyTerminalID := ""
+	if *wakeInjectGhosttyFlag && strings.TrimSpace(*wakeInjectGhosttyTerminalIDFlag) != "" {
+		var normalizeErr error
+		wakeInjectGhosttyTerminalID, normalizeErr = normalizeGhosttyTerminalID(*wakeInjectGhosttyTerminalIDFlag)
+		if normalizeErr != nil {
+			return UsageError("--wake-inject-ghostty-terminal-id: %v", normalizeErr)
+		}
 	}
 
 	remaining := fs.Args()
@@ -186,7 +200,7 @@ func runCoopExec(args []string) error {
 			amqBin = "amq"
 		}
 
-		wakeCmd := exec.Command(amqBin, "--no-update-check", "wake", "--me", agentHandle, "--root", root)
+		wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, *wakeInjectGhosttyFlag, wakeInjectGhosttyTerminalID)...)
 		var readyPath string
 		var cleanupReady func()
 		if *requireWakeFlag {
@@ -242,6 +256,17 @@ func runCoopExec(args []string) error {
 		_ = wakeProc.Kill()
 	}
 	return execErr
+}
+
+func buildCoopWakeArgs(agentHandle, root string, injectGhostty bool, ghosttyTerminalID string) []string {
+	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root}
+	if injectGhostty {
+		args = append(args, "--inject-ghostty")
+		if ghosttyTerminalID != "" {
+			args = append(args, "--inject-ghostty-terminal-id", ghosttyTerminalID)
+		}
+	}
+	return args
 }
 
 func newWakeReadyFile() (string, func(), error) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -33,6 +33,7 @@ func runDoctor(args []string) error {
 	jsonFlag := fs.Bool("json", false, "Output as JSON")
 	opsFlag := fs.Bool("ops", false, "Include runtime operational checks")
 	fixWakeLocksFlag := fs.Bool("fix-wake-locks", false, "With --ops, remove stale wake lock files")
+	fixWakeTargetsFlag := fs.Bool("fix-wake-targets", false, "With --ops, remove orphaned wake target files")
 
 	usage := usageWithFlags(fs, "amq doctor [options]",
 		"Verify AMQ installation and configuration.",
@@ -49,7 +50,7 @@ func runDoctor(args []string) error {
 		"  - Queue depth and oldest unread per agent",
 		"  - DLQ count and age",
 		"  - Presence freshness",
-		"  - Wake lock health",
+		"  - Wake lock and wake target health",
 		"  - Integration hints (Kanban, Symphony)",
 	)
 
@@ -60,6 +61,9 @@ func runDoctor(args []string) error {
 	}
 	if *fixWakeLocksFlag && !*opsFlag {
 		return UsageError("--fix-wake-locks requires --ops")
+	}
+	if *fixWakeTargetsFlag && !*opsFlag {
+		return UsageError("--fix-wake-targets requires --ops")
 	}
 
 	result := doctorResult{}
@@ -104,7 +108,7 @@ func runDoctor(args []string) error {
 	if *opsFlag && root != "" {
 		// Resolve root source once here; avoids re-resolving with empty flags in runOpsChecks.
 		_, source, _, _ := resolveEnvConfigWithSource("", "")
-		result.Ops = runOpsChecks(root, string(source), *fixWakeLocksFlag)
+		result.Ops = runOpsChecks(root, string(source), *fixWakeLocksFlag, *fixWakeTargetsFlag)
 	}
 
 	// Calculate summary
@@ -198,7 +202,13 @@ func runDoctor(args []string) error {
 			if wl.Reason != "" {
 				line += " reason=" + wl.Reason
 			}
-			if wl.Fix != "" && wl.Status == string(wakeLockStale) {
+			if wl.TargetPresent {
+				line += fmt.Sprintf(" target=%s", wl.TargetStatus)
+				if wl.TargetReason != "" {
+					line += " target_reason=" + wl.TargetReason
+				}
+			}
+			if wl.Fix != "" {
 				line += " fix=" + wl.Fix
 			}
 			if err := writeStdoutLine(line); err != nil {

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net"
@@ -43,19 +44,29 @@ type opsHint struct {
 }
 
 type opsWakeLock struct {
-	Status  string `json:"status"`
-	Agent   string `json:"agent"`
-	Root    string `json:"root"`
-	Lock    string `json:"lock"`
-	PID     int    `json:"pid,omitempty"`
-	Reason  string `json:"reason,omitempty"`
-	Fix     string `json:"fix,omitempty"`
-	Removed bool   `json:"removed,omitempty"`
+	Status        string `json:"status"`
+	Agent         string `json:"agent"`
+	Root          string `json:"root"`
+	Lock          string `json:"lock"`
+	PID           int    `json:"pid,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+	Fix           string `json:"fix,omitempty"`
+	Removed       bool   `json:"removed,omitempty"`
+	Target        string `json:"target,omitempty"`
+	TargetPresent bool   `json:"target_present,omitempty"`
+	TargetStatus  string `json:"target_status,omitempty"`
+	TargetReason  string `json:"target_reason,omitempty"`
+	TargetRemoved bool   `json:"target_removed,omitempty"`
 }
 
 const fixWakeLocksCommand = "amq doctor --ops --fix-wake-locks"
+const fixWakeTargetsCommand = "amq doctor --ops --fix-wake-targets"
 
-func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsResult {
+var probeWakeGhosttyTarget = func(ctx context.Context, terminalID string) error {
+	return probeGhosttyTerminalID(ctx, terminalID)
+}
+
+func runOpsChecks(root string, rootSource string, fixWakeLocks bool, fixWakeTargets bool) *doctorOpsResult {
 	result := &doctorOpsResult{}
 	now := time.Now()
 
@@ -72,7 +83,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 			Status:  "error",
 			Message: fmt.Sprintf("Cannot load config: %v", err),
 		})
-		result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, nil), fixWakeLocks)
+		result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, nil), fixWakeLocks, fixWakeTargets)
 		return result
 	}
 
@@ -130,7 +141,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		result.Agents = append(result.Agents, agent)
 	}
 
-	result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, cfg.Agents), fixWakeLocks)
+	result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, cfg.Agents), fixWakeLocks, fixWakeTargets)
 
 	// Integration hints
 	result.Hints = append(result.Hints, checkGlobalRootHint()...)
@@ -168,11 +179,14 @@ func discoveredWakeLockAgents(root string, configured []string) []string {
 	return agents
 }
 
-func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
+func checkWakeLocks(root string, agents []string, fixLocks bool, fixTargets bool) []opsWakeLock {
 	var locks []opsWakeLock
 	for _, agent := range agents {
 		inspection := inspectWakeLock(root, agent)
 		if !inspection.Exists {
+			if targetLock, ok := inspectOrphanedWakeTarget(root, agent, fixTargets); ok {
+				locks = append(locks, targetLock)
+			}
 			continue
 		}
 
@@ -184,9 +198,10 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 			PID:    inspection.PID,
 			Reason: inspection.Reason,
 		}
+		applyWakeTargetHealth(root, agent, inspection, &lock)
 		if inspection.Status == wakeLockStale {
 			lock.Fix = fixWakeLocksCommand
-			if fix {
+			if fixLocks {
 				recheck := inspectWakeLock(root, agent)
 				if recheck.Status != wakeLockStale {
 					lock.Status = string(recheck.Status)
@@ -197,12 +212,109 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 				} else {
 					lock.Status = "fixed"
 					lock.Removed = true
+					if fixTargets && lock.TargetPresent && lock.TargetStatus == "bound" {
+						if err := removeWakeTarget(root, agent); err != nil {
+							lock.Status = "error"
+							lock.Reason = err.Error()
+						} else {
+							lock.TargetRemoved = true
+							lock.TargetStatus = "fixed"
+						}
+					}
 				}
 			}
 		}
 		locks = append(locks, lock)
 	}
 	return locks
+}
+
+func inspectOrphanedWakeTarget(root, agent string, fix bool) (opsWakeLock, bool) {
+	lock := opsWakeLock{
+		Status: string(wakeLockMissing),
+		Agent:  agent,
+		Root:   canonicalWakeRoot(root),
+		Lock:   filepath.Join(fsq.AgentBase(root, agent), ".wake.lock"),
+	}
+	target, exists, targetErr := readWakeTarget(root, agent)
+	if !exists {
+		return opsWakeLock{}, false
+	}
+	lock.Target = wakeTargetPath(root, agent)
+	lock.TargetPresent = true
+	if targetErr != nil {
+		lock.TargetStatus = "invalid"
+		lock.TargetReason = targetErr.Error()
+	} else if err := validateWakeTarget(target, root, agent); err != nil {
+		lock.TargetStatus = "invalid"
+		lock.TargetReason = err.Error()
+	} else {
+		lock.TargetStatus = "orphaned"
+		lock.TargetReason = "wake target has no wake lock"
+	}
+	lock.Fix = fixWakeTargetsCommand
+	if fix {
+		if err := removeWakeTarget(root, agent); err != nil {
+			lock.Status = "error"
+			lock.TargetReason = err.Error()
+		} else {
+			lock.Status = "fixed"
+			lock.TargetRemoved = true
+			lock.TargetStatus = "fixed"
+			lock.TargetReason = ""
+		}
+	}
+	return lock, true
+}
+
+func applyWakeTargetHealth(root, agent string, inspection wakeLockInspection, lock *opsWakeLock) {
+	target, exists, targetErr := readWakeTarget(root, agent)
+	if !exists {
+		return
+	}
+	lock.Target = wakeTargetPath(root, agent)
+	lock.TargetPresent = true
+	if targetErr != nil {
+		lock.TargetStatus = "invalid"
+		lock.TargetReason = targetErr.Error()
+		return
+	}
+	if err := validateWakeTarget(target, root, agent); err != nil {
+		lock.TargetStatus = "invalid"
+		lock.TargetReason = err.Error()
+		return
+	}
+	if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
+		lock.TargetStatus = "mismatched"
+		lock.TargetReason = err.Error()
+		return
+	}
+	if status, reason := ghosttyWakeTargetStatus(target); status != "" {
+		lock.TargetStatus = status
+		lock.TargetReason = reason
+		return
+	}
+	lock.TargetStatus = "bound"
+}
+
+func ghosttyWakeTargetStatus(target wakeTarget) (status, reason string) {
+	if target.Mode != wakeTargetGhostty {
+		return "", ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultInjectTimeout)
+	defer cancel()
+	if err := probeWakeGhosttyTarget(ctx, target.GhosttyTerminalID); err != nil {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "no Ghostty terminal with id"):
+			return "missing-terminal", msg
+		case strings.Contains(msg, "ambiguous Ghostty terminal id"):
+			return "ambiguous-terminal", msg
+		default:
+			return "invalid", msg
+		}
+	}
+	return "", ""
 }
 
 func checkGlobalRootHint() []opsHint {

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,7 +57,7 @@ func TestRunOpsChecks_BasicAgentStats(t *testing.T) {
 		t.Fatalf("write presence: %v", err)
 	}
 
-	result := runOpsChecks(root, "test_source", false)
+	result := runOpsChecks(root, "test_source", false, false)
 
 	// Check root
 	if result.Root.Path != root {
@@ -113,7 +115,7 @@ func TestRunOpsChecks_NoConfig(t *testing.T) {
 	}
 	// No config.json written
 
-	result := runOpsChecks(root, "env", false)
+	result := runOpsChecks(root, "env", false, false)
 
 	// Should return config_error hint
 	if len(result.Hints) == 0 {
@@ -142,7 +144,7 @@ func TestRunOpsChecks_ReportsAndFixesStaleWakeLockWithoutConfig(t *testing.T) {
 		Executable: "/opt/homebrew/bin/amq",
 	})
 
-	result := runOpsChecks(root, "test_source", false)
+	result := runOpsChecks(root, "test_source", false, false)
 	if len(result.WakeLocks) != 1 {
 		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
 	}
@@ -160,7 +162,7 @@ func TestRunOpsChecks_ReportsAndFixesStaleWakeLockWithoutConfig(t *testing.T) {
 		t.Fatalf("lock should not be removed without fix flag: %v", err)
 	}
 
-	fixed := runOpsChecks(root, "test_source", true)
+	fixed := runOpsChecks(root, "test_source", true, false)
 	if len(fixed.WakeLocks) != 1 {
 		t.Fatalf("fixed wake lock count = %d, want 1", len(fixed.WakeLocks))
 	}
@@ -200,7 +202,7 @@ func TestRunOpsChecks_RootSourceThreaded(t *testing.T) {
 	}
 
 	for _, src := range []string{"flag", "env", "project_amqrc", "global_amqrc"} {
-		result := runOpsChecks(root, src, false)
+		result := runOpsChecks(root, src, false, false)
 		if result.Root.Source != src {
 			t.Errorf("runOpsChecks(_, %q).Root.Source = %q", src, result.Root.Source)
 		}
@@ -228,7 +230,7 @@ func TestRunOpsChecks_ReportsStaleWakeLock(t *testing.T) {
 		Executable: "/opt/homebrew/bin/amq",
 	})
 
-	result := runOpsChecks(root, "test_source", false)
+	result := runOpsChecks(root, "test_source", false, false)
 	if len(result.WakeLocks) != 1 {
 		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
 	}
@@ -271,7 +273,7 @@ func TestRunOpsChecks_FixesStaleWakeLock(t *testing.T) {
 		Executable: "/opt/homebrew/bin/amq",
 	})
 
-	result := runOpsChecks(root, "test_source", true)
+	result := runOpsChecks(root, "test_source", true, false)
 	if len(result.WakeLocks) != 1 {
 		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
 	}
@@ -284,6 +286,165 @@ func TestRunOpsChecks_FixesStaleWakeLock(t *testing.T) {
 	}
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Fatalf("lock should be removed, stat err=%v", err)
+	}
+}
+
+func TestRunOpsChecks_ReportsOrphanedWakeTarget(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := writeWakeTarget(root, "alice", newInjectViaWakeTarget(root, "alice", "/tmp/injector", nil)); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false, false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want target-only entry", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockMissing) {
+		t.Fatalf("status = %q, want missing", got.Status)
+	}
+	if got.TargetStatus != "orphaned" {
+		t.Fatalf("target_status = %q, want orphaned", got.TargetStatus)
+	}
+	if got.Fix != fixWakeTargetsCommand {
+		t.Fatalf("fix = %q, want %q", got.Fix, fixWakeTargetsCommand)
+	}
+}
+
+func TestRunOpsChecks_FixesOnlyOrphanedWakeTarget(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := writeWakeTarget(root, "alice", newInjectViaWakeTarget(root, "alice", "/tmp/injector", nil)); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false, true)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want target-only entry", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != "fixed" || !got.TargetRemoved || got.TargetStatus != "fixed" {
+		t.Fatalf("unexpected target cleanup result: %#v", got)
+	}
+	if _, exists, err := readWakeTarget(root, "alice"); err != nil || exists {
+		t.Fatalf("wake target exists=%v err=%v, want removed", exists, err)
+	}
+}
+
+func TestRunOpsChecks_DoesNotFixTargetAttachedToUnverifiedLock(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	const pid = 4242
+	writeWakeLockForTest(t, root, "alice", wakeLock{
+		PID:        pid,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID == pid {
+			return wakeProcessInfo{
+				PID:        gotPID,
+				Running:    true,
+				Executable: "/opt/homebrew/bin/amq",
+			}
+		}
+		return wakeProcessInfo{PID: gotPID}
+	})
+	if err := writeWakeTarget(root, "alice", newInjectViaWakeTarget(root, "alice", "/tmp/injector", nil)); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false, true)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockUnverified) {
+		t.Fatalf("status = %q, want unverified", got.Status)
+	}
+	if got.TargetRemoved {
+		t.Fatalf("target should not be removed for unverified lock: %#v", got)
+	}
+	if _, exists, err := readWakeTarget(root, "alice"); err != nil || !exists {
+		t.Fatalf("wake target exists=%v err=%v, want present", exists, err)
+	}
+}
+
+func TestRunOpsChecks_ReportsGhosttyMissingTerminal(t *testing.T) {
+	old := probeWakeGhosttyTarget
+	probeWakeGhosttyTarget = func(ctx context.Context, terminalID string) error {
+		return errors.New("probe Ghostty target \"ghostty:terminal:terminal-1\": exit status 1: no Ghostty terminal with id: terminal-1")
+	}
+	t.Cleanup(func() {
+		probeWakeGhosttyTarget = old
+	})
+
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root dirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("ensure alice dirs: %v", err)
+	}
+	cfgPath := filepath.Join(root, "meta", "config.json")
+	if err := config.WriteConfig(cfgPath, config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	target := newGhosttyWakeTarget(root, "alice", "terminal-1")
+	writeWakeLockForTest(t, root, "alice", bindWakeLockToTarget(wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	if err := writeWakeTarget(root, "alice", target); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	result := runOpsChecks(root, "test_source", false, false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.TargetStatus != "missing-terminal" {
+		t.Fatalf("target_status = %q, want missing-terminal; lock=%#v", got.TargetStatus, got)
 	}
 }
 

--- a/internal/cli/ghostty.go
+++ b/internal/cli/ghostty.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+const ghosttyTerminalTargetPrefix = "ghostty:terminal:"
+
+var runGhosttyCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func discoverGhosttyTerminalID(ctx context.Context) (string, error) {
+	if err := requireGhosttyDarwin(); err != nil {
+		return "", err
+	}
+	out, err := runGhosttyCommand(ctx, "osascript", "-e", ghosttyDiscoverScript)
+	if err != nil {
+		return "", fmt.Errorf("discover Ghostty terminal: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	id, err := normalizeGhosttyTerminalID(string(out))
+	if err != nil {
+		return "", fmt.Errorf("discover Ghostty terminal: %w", err)
+	}
+	return id, nil
+}
+
+func probeGhosttyTerminalID(ctx context.Context, terminalID string) error {
+	if err := requireGhosttyDarwin(); err != nil {
+		return err
+	}
+	id, err := normalizeGhosttyTerminalID(terminalID)
+	if err != nil {
+		return err
+	}
+	out, err := runGhosttyCommand(ctx, "osascript", "-e", ghosttyProbeScript, id)
+	if err != nil {
+		return fmt.Errorf("probe Ghostty target %q: %w: %s", ghosttyTargetString(id), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func injectGhostty(ctx context.Context, terminalID string, payload string) error {
+	if err := requireGhosttyDarwin(); err != nil {
+		return err
+	}
+	id, err := normalizeGhosttyTerminalID(terminalID)
+	if err != nil {
+		return err
+	}
+	payload = strings.TrimRight(payload, "\r\n")
+	out, err := runGhosttyCommand(ctx, "osascript", "-e", ghosttyInjectScript, id, payload)
+	if err != nil {
+		return fmt.Errorf("inject into Ghostty target %q: %w: %s", ghosttyTargetString(id), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func normalizeGhosttyTerminalID(raw string) (string, error) {
+	id := strings.TrimSpace(raw)
+	if id == "" {
+		return "", errors.New("ghostty terminal id is required")
+	}
+	id = strings.TrimPrefix(id, ghosttyTerminalTargetPrefix)
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", errors.New("ghostty terminal target is missing an id")
+	}
+	if strings.ContainsRune(id, 0) {
+		return "", errors.New("ghostty terminal id contains NUL")
+	}
+	return id, nil
+}
+
+func ghosttyTargetString(terminalID string) string {
+	return ghosttyTerminalTargetPrefix + terminalID
+}
+
+func requireGhosttyDarwin() error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("ghostty wake requires macOS, got %s", runtime.GOOS)
+	}
+	return nil
+}
+
+const ghosttyDiscoverScript = `
+tell application "Ghostty"
+	if (count of terminals) is 0 then error "Ghostty has no terminals"
+	return id of focused terminal of selected tab of front window
+end tell
+`
+
+const ghosttyProbeScript = `
+on run argv
+	set targetID to item 1 of argv
+	tell application "Ghostty"
+		set matches to terminals whose id is targetID
+		set matchCount to count of matches
+		if matchCount is 1 then return "ok"
+		if matchCount is 0 then error "no Ghostty terminal with id: " & targetID
+		error "ambiguous Ghostty terminal id: " & targetID
+	end tell
+end run
+`
+
+const ghosttyInjectScript = `
+on run argv
+	set targetID to item 1 of argv
+	set payload to item 2 of argv
+	tell application "Ghostty"
+		set matches to terminals whose id is targetID
+		set matchCount to count of matches
+		if matchCount is 0 then error "no Ghostty terminal with id: " & targetID
+		if matchCount is greater than 1 then error "ambiguous Ghostty terminal id: " & targetID
+		set targetTerminal to item 1 of matches
+		input text payload to targetTerminal
+		send key "enter" to targetTerminal
+	end tell
+end run
+`

--- a/internal/cli/ghostty_test.go
+++ b/internal/cli/ghostty_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type ghosttyCommandCall struct {
+	name string
+	args []string
+}
+
+func stubGhosttyCommand(t *testing.T, fn func(context.Context, string, ...string) ([]byte, error)) *[]ghosttyCommandCall {
+	t.Helper()
+	var calls []ghosttyCommandCall
+	old := runGhosttyCommand
+	runGhosttyCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		calls = append(calls, ghosttyCommandCall{name: name, args: append([]string{}, args...)})
+		return fn(ctx, name, args...)
+	}
+	t.Cleanup(func() {
+		runGhosttyCommand = old
+	})
+	return &calls
+}
+
+func TestNormalizeGhosttyTerminalIDAcceptsTargetPrefix(t *testing.T) {
+	got, err := normalizeGhosttyTerminalID(" ghostty:terminal:terminal-1 ")
+	if err != nil {
+		t.Fatalf("normalizeGhosttyTerminalID: %v", err)
+	}
+	if got != "terminal-1" {
+		t.Fatalf("id = %q, want terminal-1", got)
+	}
+}
+
+func TestNormalizeGhosttyTerminalIDRejectsEmptyAndNUL(t *testing.T) {
+	if _, err := normalizeGhosttyTerminalID("ghostty:terminal:"); err == nil {
+		t.Fatal("expected empty id error")
+	}
+	if _, err := normalizeGhosttyTerminalID("terminal\x00id"); err == nil {
+		t.Fatal("expected NUL id error")
+	}
+}
+
+func TestInjectGhosttyTrimsTrailingCRLFAndTargetsTerminal(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Ghostty AppleScript injection is macOS-only")
+	}
+	calls := stubGhosttyCommand(t, func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+
+	if err := injectGhostty(context.Background(), "terminal-1", "payload\r\n\n"); err != nil {
+		t.Fatalf("injectGhostty: %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(*calls))
+	}
+	call := (*calls)[0]
+	if call.name != "osascript" {
+		t.Fatalf("command = %q, want osascript", call.name)
+	}
+	if got := call.args[len(call.args)-2]; got != "terminal-1" {
+		t.Fatalf("terminal arg = %q, want terminal-1", got)
+	}
+	if got := call.args[len(call.args)-1]; got != "payload" {
+		t.Fatalf("payload arg = %q, want payload", got)
+	}
+	if !strings.Contains(call.args[1], "input text payload to targetTerminal") {
+		t.Fatalf("script does not input text to target terminal: %q", call.args[1])
+	}
+	if !strings.Contains(call.args[1], `send key "enter" to targetTerminal`) {
+		t.Fatalf("script does not submit target terminal: %q", call.args[1])
+	}
+}
+
+func TestGhosttyScriptsCheckUniqueTerminalID(t *testing.T) {
+	for name, script := range map[string]string{
+		"probe":  ghosttyProbeScript,
+		"inject": ghosttyInjectScript,
+	} {
+		if !strings.Contains(script, "set matches to terminals whose id is targetID") {
+			t.Fatalf("%s script does not query by terminal id", name)
+		}
+		if !strings.Contains(script, "count of matches") {
+			t.Fatalf("%s script does not count matches", name)
+		}
+		if !strings.Contains(script, "no Ghostty terminal with id") {
+			t.Fatalf("%s script does not report missing terminal", name)
+		}
+		if !strings.Contains(script, "ambiguous Ghostty terminal id") {
+			t.Fatalf("%s script does not report ambiguous terminal", name)
+		}
+	}
+}
+
+func TestProbeGhosttyTerminalIDPropagatesScriptFailure(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Ghostty AppleScript probing is macOS-only")
+	}
+	stubGhosttyCommand(t, func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return []byte("no Ghostty terminal with id: terminal-1"), errors.New("exit status 1")
+	})
+
+	err := probeGhosttyTerminalID(context.Background(), "terminal-1")
+	if err == nil {
+		t.Fatal("expected probe failure")
+	}
+	if !strings.Contains(err.Error(), "no Ghostty terminal with id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -21,6 +21,7 @@ type wakeConfig struct {
 	injectCmd         string
 	injectVia         string // external command for injection (replaces TIOCSTI)
 	injectArgs        []string
+	ghosttyTerminalID string
 	injectTimeout     time.Duration
 	bell              bool
 	debounce          time.Duration
@@ -94,7 +95,7 @@ func inputDeferralDelay(state ttyInputState, now, deadline time.Time, quietFor, 
 }
 
 func shouldDeferBeforeInject(cfg *wakeConfig, deferForInput bool) bool {
-	return deferForInput && cfg.deferWhileInput && cfg.injectVia == ""
+	return deferForInput && cfg.deferWhileInput && !cfg.hasExternalWakeTarget()
 }
 
 func notifyNewMessages(cfg *wakeConfig) error {
@@ -167,8 +168,8 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		interruptText := buildInterruptText(cfg.session, interruptMessages, interruptCounts, cfg.previewLen, cfg.interruptNotice)
 		now := time.Now()
 		if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
-			if cfg.injectVia != "" {
-				if err := injectVia(cfg, cfg.interruptKey); err == nil {
+			if cfg.hasExternalWakeTarget() {
+				if err := injectExternal(cfg, cfg.interruptKey); err == nil {
 					cfg.lastInterrupt = now
 					time.Sleep(50 * time.Millisecond)
 				}
@@ -333,12 +334,12 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		waitForTTYInputQuiet(cfg)
 	}
 
-	// External injection: delegate to user-specified command instead of TIOCSTI.
-	// The command receives the notification text as its last argument.
-	if cfg.injectVia != "" {
-		if err := injectVia(cfg, plainText); err != nil {
+	// External injection: delegate to a user-specified command or Ghostty
+	// terminal-id target instead of TIOCSTI.
+	if cfg.hasExternalWakeTarget() {
+		if err := injectExternal(cfg, plainText); err != nil {
 			if cfg.fallbackWarn {
-				_ = writeStderr("amq wake: --inject-via failed: %v\n", err)
+				_ = writeStderr("amq wake: %s failed: %v\n", externalWakeTargetLabel(cfg), err)
 				_ = writeStderr("amq wake: falling back to stderr notification\n")
 				cfg.fallbackWarn = false
 			}
@@ -440,6 +441,27 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	return nil
 }
 
+func externalWakeTargetLabel(cfg *wakeConfig) string {
+	if cfg.injectVia != "" {
+		return "--inject-via"
+	}
+	if cfg.ghosttyTerminalID != "" {
+		return "--inject-ghostty"
+	}
+	return "external injection"
+}
+
+func (cfg *wakeConfig) hasExternalWakeTarget() bool {
+	return cfg.injectVia != "" || cfg.ghosttyTerminalID != ""
+}
+
+func injectExternal(cfg *wakeConfig, text string) error {
+	if cfg.ghosttyTerminalID != "" {
+		return injectGhosttyWithTimeout(cfg, text)
+	}
+	return injectVia(cfg, text)
+}
+
 func injectVia(cfg *wakeConfig, text string) error {
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: inject-via mode, running: %s %s <text>\n", cfg.injectVia, strings.Join(cfg.injectArgs, " "))
@@ -475,6 +497,23 @@ func injectVia(cfg *wakeConfig, text string) error {
 	}
 
 	return nil
+}
+
+func injectGhosttyWithTimeout(cfg *wakeConfig, text string) error {
+	if cfg.debug {
+		_ = writeStderr("amq wake [debug]: ghostty mode, target=%s\n", ghosttyTargetString(cfg.ghosttyTerminalID))
+	}
+	timeout := cfg.injectTimeout
+	if timeout <= 0 {
+		timeout = defaultInjectTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := injectGhostty(ctx, cfg.ghosttyTerminalID, text)
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("ghostty injection timed out after %s", timeout)
+	}
+	return err
 }
 
 func sanitizeForTTY(s string) string {

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	wakeTargetSchema    = 1
+	wakeTargetFileName  = ".wake.target"
+	wakeTargetInjectVia = "inject-via"
+	wakeTargetGhostty   = "ghostty"
+)
+
+type wakeTarget struct {
+	Schema            int      `json:"schema"`
+	Mode              string   `json:"mode"`
+	Root              string   `json:"root"`
+	Agent             string   `json:"agent"`
+	Created           string   `json:"created"`
+	InjectVia         string   `json:"inject_via,omitempty"`
+	InjectArgs        []string `json:"inject_args,omitempty"`
+	GhosttyTerminalID string   `json:"ghostty_terminal_id,omitempty"`
+}
+
+func wakeTargetPath(root, me string) string {
+	return filepath.Join(fsq.AgentBase(root, me), wakeTargetFileName)
+}
+
+func newInjectViaWakeTarget(root, me, injectVia string, injectArgs []string) wakeTarget {
+	return wakeTarget{
+		Schema:     wakeTargetSchema,
+		Mode:       wakeTargetInjectVia,
+		Root:       canonicalWakeRoot(root),
+		Agent:      me,
+		Created:    time.Now().UTC().Format(time.RFC3339),
+		InjectVia:  strings.TrimSpace(injectVia),
+		InjectArgs: append([]string{}, injectArgs...),
+	}
+}
+
+func newGhosttyWakeTarget(root, me, terminalID string) wakeTarget {
+	return wakeTarget{
+		Schema:            wakeTargetSchema,
+		Mode:              wakeTargetGhostty,
+		Root:              canonicalWakeRoot(root),
+		Agent:             me,
+		Created:           time.Now().UTC().Format(time.RFC3339),
+		GhosttyTerminalID: strings.TrimSpace(terminalID),
+	}
+}
+
+func wakeTargetDigest(target wakeTarget) string {
+	target.Created = ""
+	data, _ := json.Marshal(target)
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func validateWakeTargetMatchesLock(lock wakeLock, target wakeTarget) error {
+	if lock.WakeMode != target.Mode || lock.TargetDigest == "" {
+		return fmt.Errorf("wake lock was not created for target mode %q", target.Mode)
+	}
+	if got := wakeTargetDigest(target); got != lock.TargetDigest {
+		return fmt.Errorf("wake target does not match wake lock")
+	}
+	return nil
+}
+
+func readWakeTarget(root, me string) (wakeTarget, bool, error) {
+	path := wakeTargetPath(root, me)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return wakeTarget{}, false, nil
+		}
+		return wakeTarget{}, true, fmt.Errorf("read wake target: %w", err)
+	}
+	var target wakeTarget
+	if err := json.Unmarshal(data, &target); err != nil {
+		return wakeTarget{}, true, fmt.Errorf("parse wake target: %w", err)
+	}
+	return target, true, nil
+}
+
+func writeWakeTarget(root, me string, target wakeTarget) error {
+	if err := validateWakeTarget(target, root, me); err != nil {
+		return err
+	}
+	agentBase := fsq.AgentBase(root, me)
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		return fmt.Errorf("create wake target directory: %w", err)
+	}
+	data, err := json.MarshalIndent(target, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal wake target: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(wakeTargetPath(root, me), data, 0o600); err != nil {
+		return fmt.Errorf("write wake target: %w", err)
+	}
+	return nil
+}
+
+func removeWakeTarget(root, me string) error {
+	if err := os.Remove(wakeTargetPath(root, me)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove wake target: %w", err)
+	}
+	return nil
+}
+
+func validateWakeTarget(target wakeTarget, root, me string) error {
+	if target.Schema != wakeTargetSchema {
+		return fmt.Errorf("wake target schema %d unsupported", target.Schema)
+	}
+	if canonicalWakeRoot(target.Root) != canonicalWakeRoot(root) {
+		return fmt.Errorf("wake target root mismatch")
+	}
+	if target.Agent != me {
+		return fmt.Errorf("wake target agent mismatch")
+	}
+	switch target.Mode {
+	case wakeTargetInjectVia:
+		if strings.TrimSpace(target.InjectVia) == "" {
+			return fmt.Errorf("inject_via must not be blank")
+		}
+		if strings.ContainsRune(target.InjectVia, 0) {
+			return fmt.Errorf("inject_via contains NUL")
+		}
+		for _, arg := range target.InjectArgs {
+			if strings.ContainsRune(arg, 0) {
+				return fmt.Errorf("wake target inject arg contains NUL")
+			}
+		}
+	case wakeTargetGhostty:
+		if _, err := normalizeGhosttyTerminalID(target.GhosttyTerminalID); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("wake target mode %q unsupported", target.Mode)
+	}
+	return nil
+}
+
+func wakeTargetDescription(target wakeTarget) string {
+	switch target.Mode {
+	case wakeTargetGhostty:
+		return ghosttyTargetString(target.GhosttyTerminalID)
+	case wakeTargetInjectVia:
+		return target.InjectVia
+	default:
+		return target.Mode
+	}
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -70,11 +70,34 @@ type wakeLockInspection struct {
 	raw               []byte
 }
 
-var inspectWakeProcess = inspectWakeProcessPlatform
+var (
+	inspectWakeProcess = inspectWakeProcessPlatform
+	getWakeCurrentTTY  = getCurrentTTY
+	getWakeProcessSID  = unix.Getsid
+)
+
+type wakeLockAcquireOptions struct {
+	acceptExistingValid bool
+}
+
+type wakeAlreadyRunningError struct {
+	Agent      string
+	Inspection wakeLockInspection
+}
+
+func (e *wakeAlreadyRunningError) Error() string {
+	lock := e.Inspection.Lock
+	return fmt.Sprintf("wake already running for %s (pid %d on %s since %s)",
+		e.Agent, lock.PID, lock.TTY, lock.Started)
+}
 
 // acquireWakeLock attempts to acquire the wake lock for an agent's inbox.
 // Returns cleanup function and error. If another wake is running, returns error.
 func acquireWakeLock(root, me string) (cleanup func(), err error) {
+	return acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{})
+}
+
+func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions) (cleanup func(), err error) {
 	agentBase := fsq.AgentBase(root, me)
 	lockPath := filepath.Join(agentBase, ".wake.lock")
 
@@ -94,10 +117,16 @@ func acquireWakeLock(root, me string) (cleanup func(), err error) {
 		case wakeLockCreating:
 			return nil, fmt.Errorf("wake lock is being created (retry shortly)")
 		case wakeLockValid:
+			if options.acceptExistingValid {
+				if err := requireWakeLockUsable(inspection); err != nil {
+					return nil, err
+				}
+				return nil, wakeLockAlreadyRunningError(me, inspection)
+			}
 			if shouldReplaceOrphanedWakeLock(inspection) {
 				goto createLock
 			}
-			return nil, wakeLockAlreadyRunningError(me, inspection.Lock)
+			return nil, wakeLockAlreadyRunningError(me, inspection)
 		case wakeLockUnverified:
 			return nil, fmt.Errorf("wake lock for %s is unverified (pid %d on %s since %s): %s; run 'amq doctor --ops' for details",
 				me, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started, inspection.Reason)
@@ -134,13 +163,16 @@ createLock:
 	f, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		if os.IsExist(err) {
-			// Another process won the race - re-read to get its info
-			if data, readErr := os.ReadFile(lockPath); readErr == nil {
-				var winner wakeLock
-				if json.Unmarshal(data, &winner) == nil {
-					return nil, fmt.Errorf("wake already running for %s (pid %d on %s since %s)",
-						me, winner.PID, winner.TTY, winner.Started)
+			// Another process won the race; reuse only if the shared
+			// classifier proves it is the matching wake.
+			winner := inspectWakeLock(root, me)
+			if winner.Status == wakeLockValid {
+				if options.acceptExistingValid {
+					if usableErr := requireWakeLockUsable(winner); usableErr != nil {
+						return nil, usableErr
+					}
 				}
+				return nil, wakeLockAlreadyRunningError(me, winner)
 			}
 			return nil, fmt.Errorf("wake lock exists for %s (concurrent start)", me)
 		}
@@ -314,6 +346,13 @@ func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
 }
 
 func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
+	if !wakeLockNeedsReplacement(inspection) {
+		return false
+	}
+	return replaceConfirmedOrphanedWakeLock(inspection)
+}
+
+func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
 	if !inspection.IdentityConfirmed {
 		return false
 	}
@@ -323,11 +362,11 @@ func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
 	// that orphan before taking over; never signal an unconfirmed PID.
 	if strings.HasPrefix(existing.TTY, "/dev/") {
 		if _, statErr := os.Stat(existing.TTY); os.IsNotExist(statErr) {
-			return replaceConfirmedOrphanedWakeLock(inspection)
+			return true
 		}
 	}
 
-	currentTTY := getCurrentTTY()
+	currentTTY := getWakeCurrentTTY()
 	existingTTY := existing.TTY
 	if strings.HasPrefix(existingTTY, "/dev/") {
 		if real, err := filepath.EvalSymlinks(existingTTY); err == nil {
@@ -335,13 +374,24 @@ func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) bool {
 		}
 	}
 	if currentTTY != "" && currentTTY == existingTTY {
-		existingSid, sidErr := unix.Getsid(existing.PID)
-		currentSid, _ := unix.Getsid(0)
+		existingSid, sidErr := getWakeProcessSID(existing.PID)
+		currentSid, _ := getWakeProcessSID(0)
 		if sidErr == nil && existingSid != currentSid {
-			return replaceConfirmedOrphanedWakeLock(inspection)
+			return true
 		}
 	}
 	return false
+}
+
+func requireWakeLockUsable(inspection wakeLockInspection) error {
+	if !inspection.Exists || inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+		return fmt.Errorf("existing wake lock for %s is not a confirmed valid wake", inspection.Agent)
+	}
+	if wakeLockNeedsReplacement(inspection) {
+		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
+			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
+	}
+	return nil
 }
 
 func replaceConfirmedOrphanedWakeLock(inspection wakeLockInspection) bool {
@@ -406,9 +456,11 @@ func canonicalWakeRoot(root string) string {
 	return filepath.Clean(absRoot)
 }
 
-func wakeLockAlreadyRunningError(me string, lock wakeLock) error {
-	return fmt.Errorf("wake already running for %s (pid %d on %s since %s)",
-		me, lock.PID, lock.TTY, lock.Started)
+func wakeLockAlreadyRunningError(me string, inspection wakeLockInspection) error {
+	return &wakeAlreadyRunningError{
+		Agent:      me,
+		Inspection: inspection,
+	}
 }
 
 func inspectionReason(base string, err error) string {
@@ -523,6 +575,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	interruptCooldownFlag := fs.Duration("interrupt-cooldown", 7*time.Second, "Minimum time between interrupts")
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
+	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
 
 	usage := usageWithFlags(fs, "amq wake --me <agent> [options]",
 		"Background waker: injects terminal notification when messages arrive.",
@@ -649,8 +702,15 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	}
 
 	// Acquire lock to prevent duplicate wake processes
-	cleanup, err := acquireWakeLock(root, me)
+	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
+	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
+		acceptExistingValid: acceptExistingWake,
+	})
 	if err != nil {
+		var alreadyRunning *wakeAlreadyRunningError
+		if acceptExistingWake && errors.As(err, &alreadyRunning) {
+			return writeWakeReadyFile(readyFile)
+		}
 		return err
 	}
 	defer cleanup()

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -34,6 +35,8 @@ type wakeLock struct {
 	BootID       string   `json:"boot_id,omitempty"`       // Boot identity paired with ProcessStart when available
 	Executable   string   `json:"executable,omitempty"`    // Diagnostic process executable basename/path
 	Args         []string `json:"args,omitempty"`          // Diagnostic argv when available
+	WakeMode     string   `json:"wake_mode,omitempty"`     // Injection mode that created target metadata
+	TargetDigest string   `json:"target_digest,omitempty"` // Binds .wake.target to this lock instance
 }
 
 type wakeProcessInfo struct {
@@ -78,6 +81,7 @@ var (
 
 type wakeLockAcquireOptions struct {
 	acceptExistingValid bool
+	replaceExistingWake bool
 }
 
 type wakeAlreadyRunningError struct {
@@ -94,10 +98,10 @@ func (e *wakeAlreadyRunningError) Error() string {
 // acquireWakeLock attempts to acquire the wake lock for an agent's inbox.
 // Returns cleanup function and error. If another wake is running, returns error.
 func acquireWakeLock(root, me string) (cleanup func(), err error) {
-	return acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{})
+	return acquireWakeLockWithOptions(root, me, nil, wakeLockAcquireOptions{})
 }
 
-func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions) (cleanup func(), err error) {
+func acquireWakeLockWithOptions(root, me string, target *wakeTarget, options wakeLockAcquireOptions) (cleanup func(), err error) {
 	agentBase := fsq.AgentBase(root, me)
 	lockPath := filepath.Join(agentBase, ".wake.lock")
 
@@ -117,11 +121,26 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 		case wakeLockCreating:
 			return nil, fmt.Errorf("wake lock is being created (retry shortly)")
 		case wakeLockValid:
+			if err := validateExistingWakeTarget(inspection, target); err != nil {
+				if options.replaceExistingWake {
+					if !replaceConfirmedExistingWakeLock(inspection) {
+						return nil, fmt.Errorf("wake lock for %s could not be safely replaced", me)
+					}
+					goto createLock
+				}
+				return nil, err
+			}
 			if options.acceptExistingValid {
 				if err := requireWakeLockUsable(inspection); err != nil {
 					return nil, err
 				}
 				return nil, wakeLockAlreadyRunningError(me, inspection)
+			}
+			if options.replaceExistingWake {
+				if !replaceConfirmedExistingWakeLock(inspection) {
+					return nil, fmt.Errorf("wake lock for %s could not be safely replaced", me)
+				}
+				goto createLock
 			}
 			if shouldReplaceOrphanedWakeLock(inspection) {
 				goto createLock
@@ -157,6 +176,10 @@ createLock:
 		lock.Executable = proc.Executable
 		lock.Args = proc.Args
 	}
+	if target != nil {
+		lock.WakeMode = target.Mode
+		lock.TargetDigest = wakeTargetDigest(*target)
+	}
 	lockData, _ := json.Marshal(lock)
 
 	// Use O_EXCL for atomic creation - fails if file exists (race protection)
@@ -167,6 +190,9 @@ createLock:
 			// classifier proves it is the matching wake.
 			winner := inspectWakeLock(root, me)
 			if winner.Status == wakeLockValid {
+				if err := validateExistingWakeTarget(winner, target); err != nil {
+					return nil, err
+				}
 				if options.acceptExistingValid {
 					if usableErr := requireWakeLockUsable(winner); usableErr != nil {
 						return nil, usableErr
@@ -200,6 +226,36 @@ createLock:
 	}
 
 	return cleanup, nil
+}
+
+func validateExistingWakeTarget(inspection wakeLockInspection, target *wakeTarget) error {
+	lock := inspection.Lock
+	if target == nil {
+		if lock.WakeMode == "" && lock.TargetDigest == "" {
+			return nil
+		}
+		return fmt.Errorf("wake already running for %s with target mode %q; requested raw terminal wake", inspection.Agent, lock.WakeMode)
+	}
+	if lock.WakeMode == "" || lock.TargetDigest == "" {
+		return fmt.Errorf("wake already running for %s without a persisted target; requested %s target %s",
+			inspection.Agent, target.Mode, wakeTargetDescription(*target))
+	}
+	if lock.WakeMode != target.Mode {
+		return fmt.Errorf("wake already running for %s with target mode %q; requested %s target %s",
+			inspection.Agent, lock.WakeMode, target.Mode, wakeTargetDescription(*target))
+	}
+	if got := wakeTargetDigest(*target); got != lock.TargetDigest {
+		return fmt.Errorf("wake already running for %s with a different %s target; use --replace-existing-wake to retarget",
+			inspection.Agent, target.Mode)
+	}
+	return nil
+}
+
+func replaceConfirmedExistingWakeLock(inspection wakeLockInspection) bool {
+	if !inspection.IdentityConfirmed {
+		return false
+	}
+	return replaceConfirmedOrphanedWakeLock(inspection)
 }
 
 func inspectWakeLock(root, me string) wakeLockInspection {
@@ -558,6 +614,8 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	injectViaFlag := fs.String("inject-via", "", "External executable for injection (payload appended as last arg, bypasses TTY requirement)")
 	var injectArgFlags multiStringFlag
 	fs.Var(&injectArgFlags, "inject-arg", "Argument for --inject-via before the payload (repeatable)")
+	injectGhosttyFlag := fs.Bool("inject-ghostty", false, "Use Ghostty's native macOS terminal-id injection")
+	injectGhosttyTerminalIDFlag := fs.String("inject-ghostty-terminal-id", "", "Ghostty terminal id for --inject-ghostty (default: focused terminal)")
 	injectTimeoutFlag := fs.Duration("inject-timeout", defaultInjectTimeout, "Timeout for one --inject-via command")
 	bellFlag := fs.Bool("bell", false, "Ring terminal bell on new messages")
 	debounceFlag := fs.Duration("debounce", 250*time.Millisecond, "Debounce window for batching messages")
@@ -576,6 +634,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
 	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
+	replaceExistingWakeFlag := fs.Bool("replace-existing-wake", false, "Replace a confirmed existing wake when its target differs")
 
 	usage := usageWithFlags(fs, "amq wake --me <agent> [options]",
 		"Background waker: injects terminal notification when messages arrive.",
@@ -595,6 +654,12 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		"    --inject-arg exec --inject-arg \"$TERMINAL_ID\"",
 		"  Trust boundary: --inject-via executes local code, and the payload can",
 		"  contain sanitized but message-derived header content.",
+		"",
+		"Ghostty injection:",
+		"  --inject-ghostty targets Ghostty by terminal id via macOS AppleScript.",
+		"  If --inject-ghostty-terminal-id is omitted, AMQ uses the focused",
+		"  terminal in the selected tab of the front Ghostty window. Existing wake",
+		"  reuse is target-aware; use --replace-existing-wake to retarget.",
 		"",
 		"Input deferral (default on): wake samples terminal input only after",
 		"  a message is pending, then injects after a short quiet window.",
@@ -676,16 +741,44 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	if *injectViaFlag != "" && injectVia == "" {
 		return UsageError("--inject-via must not be blank")
 	}
+	if injectVia != "" && *injectGhosttyFlag {
+		return UsageError("--inject-via and --inject-ghostty are mutually exclusive")
+	}
 	if injectVia == "" && len(injectArgFlags) > 0 {
 		return UsageError("--inject-arg requires --inject-via")
+	}
+	if strings.TrimSpace(*injectGhosttyTerminalIDFlag) != "" && !*injectGhosttyFlag {
+		return UsageError("--inject-ghostty-terminal-id requires --inject-ghostty")
 	}
 	readyFile := strings.TrimSpace(*readyFileFlag)
 	if *readyFileFlag != "" && readyFile == "" {
 		return UsageError("--ready-file must not be blank")
 	}
 
-	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
-	if injectVia == "" {
+	var ghosttyTerminalID string
+	if *injectGhosttyFlag {
+		ctx, cancel := context.WithTimeout(context.Background(), *injectTimeoutFlag)
+		defer cancel()
+		if explicit := strings.TrimSpace(*injectGhosttyTerminalIDFlag); explicit != "" {
+			var normalizeErr error
+			ghosttyTerminalID, normalizeErr = normalizeGhosttyTerminalID(explicit)
+			if normalizeErr != nil {
+				return UsageError("--inject-ghostty-terminal-id: %v", normalizeErr)
+			}
+		} else {
+			var discoverErr error
+			ghosttyTerminalID, discoverErr = discoverGhosttyTerminalID(ctx)
+			if discoverErr != nil {
+				return discoverErr
+			}
+		}
+		if err := probeGhosttyTerminalID(ctx, ghosttyTerminalID); err != nil {
+			return err
+		}
+	}
+
+	// Verify TIOCSTI is available (skip in external injection modes).
+	if injectVia == "" && ghosttyTerminalID == "" {
 		if !tiocsti.Available() {
 			return errors.New("TIOCSTI not available on this platform; use tmux send-keys or terminal-specific injection")
 		}
@@ -701,10 +794,20 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return UsageError("%v", err)
 	}
 
+	var target *wakeTarget
+	if injectVia != "" {
+		value := newInjectViaWakeTarget(root, me, injectVia, []string(injectArgFlags))
+		target = &value
+	} else if ghosttyTerminalID != "" {
+		value := newGhosttyWakeTarget(root, me, ghosttyTerminalID)
+		target = &value
+	}
+
 	// Acquire lock to prevent duplicate wake processes
 	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
-	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
+	cleanup, err := acquireWakeLockWithOptions(root, me, target, wakeLockAcquireOptions{
 		acceptExistingValid: acceptExistingWake,
+		replaceExistingWake: *replaceExistingWakeFlag,
 	})
 	if err != nil {
 		var alreadyRunning *wakeAlreadyRunningError
@@ -714,6 +817,24 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return err
 	}
 	defer cleanup()
+	if target != nil {
+		defer func() {
+			if err := removeWakeTarget(root, me); err != nil && *debugFlag {
+				_ = writeStderr("amq wake [debug]: remove wake target on exit failed: %v\n", err)
+			}
+		}()
+	}
+
+	if target != nil {
+		if err := writeWakeTarget(root, me, *target); err != nil {
+			_ = writeStderr("warning: wake target not persisted: %v\n", err)
+			if removeErr := removeWakeTarget(root, me); removeErr != nil {
+				return fmt.Errorf("clear stale wake target after persist failure: %w", removeErr)
+			}
+		}
+	} else if err := removeWakeTarget(root, me); err != nil {
+		return err
+	}
 
 	cfg := wakeConfig{
 		me:                me,
@@ -722,6 +843,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		injectCmd:         *injectCmdFlag,
 		injectVia:         injectVia,
 		injectArgs:        []string(injectArgFlags),
+		ghosttyTerminalID: ghosttyTerminalID,
 		injectTimeout:     *injectTimeoutFlag,
 		bell:              *bellFlag,
 		debounce:          *debounceFlag,
@@ -889,7 +1011,7 @@ func runWakeLoop(cfg wakeConfig) error {
 }
 
 func wakeHealthCheck(cfg wakeConfig, ttyAvailableFn func() bool) error {
-	if cfg.injectVia != "" {
+	if cfg.hasExternalWakeTarget() {
 		return nil
 	}
 	if !ttyAvailableFn() {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -70,6 +70,12 @@ func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) strin
 	return lockPath
 }
 
+func bindWakeLockToTarget(lock wakeLock, target wakeTarget) wakeLock {
+	lock.WakeMode = target.Mode
+	lock.TargetDigest = wakeTargetDigest(target)
+	return lock
+}
+
 func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 	root := t.TempDir()
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -131,6 +137,42 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	if !errors.Is(err, errDone) {
 		t.Fatalf("expected loop sentinel error, got %v", err)
 	}
+	if _, exists, targetErr := readWakeTarget(root, "orchestrator"); targetErr != nil || exists {
+		t.Fatalf("wake target exists=%v err=%v after clean exit, want removed", exists, targetErr)
+	}
+}
+
+func TestRunWakeWithLoopWritesInjectViaWakeTarget(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--inject-arg", "exec",
+	}, func(cfg wakeConfig) error {
+		target, exists, targetErr := readWakeTarget(root, "orchestrator")
+		if targetErr != nil {
+			t.Fatalf("readWakeTarget: %v", targetErr)
+		}
+		if !exists {
+			t.Fatal("expected wake target to be written")
+		}
+		if target.Mode != wakeTargetInjectVia || target.InjectVia != "/tmp/injector" || strings.Join(target.InjectArgs, "|") != "exec" {
+			t.Fatalf("unexpected target: %#v", target)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
 }
 
 func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
@@ -149,12 +191,13 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 		return wakeProcessInfo{PID: pid}
 	})
 	root := t.TempDir()
-	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+	target := newInjectViaWakeTarget(root, "orchestrator", "/tmp/injector", nil)
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
 		PID:          wakePID,
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
-	})
+	}, target))
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
@@ -193,12 +236,13 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 		return wakeProcessInfo{PID: pid}
 	})
 	root := t.TempDir()
-	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+	target := newInjectViaWakeTarget(root, "orchestrator", "/tmp/injector", nil)
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
 		PID:          wakePID,
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
-	})
+	}, target))
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
@@ -219,6 +263,52 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopAcceptExistingWakeRejectsDifferentTarget(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	oldTarget := newInjectViaWakeTarget(root, "orchestrator", "/tmp/old-injector", nil)
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, oldTarget))
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/new-injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with a different target: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected target mismatch error")
+	}
+	if !strings.Contains(err.Error(), "different inject-via target") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+}
+
 func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 	const wakePID = 4242
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
@@ -235,13 +325,14 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 		return wakeProcessInfo{PID: pid}
 	})
 	root := t.TempDir()
-	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+	target := newInjectViaWakeTarget(root, "orchestrator", "/tmp/injector", nil)
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
 		PID:          wakePID,
 		TTY:          "/dev/amq-missing-tty",
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
-	})
+	}, target))
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
@@ -297,13 +388,14 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *test
 		return wakeProcessInfo{PID: pid}
 	})
 	root := t.TempDir()
-	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+	target := newInjectViaWakeTarget(root, "orchestrator", "/tmp/injector", nil)
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
 		PID:          wakePID,
 		TTY:          ttyPath,
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
-	})
+	}, target))
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
@@ -732,6 +824,23 @@ func TestRunWakeWithLoopRejectsInjectArgWithoutInjectVia(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopRejectsGhosttyTerminalIDWithoutGhostty(t *testing.T) {
+	err := runWakeWithLoop([]string{
+		"--root", t.TempDir(),
+		"--me", "orchestrator",
+		"--inject-ghostty-terminal-id", "terminal-1",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with invalid flags: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "--inject-ghostty-terminal-id requires --inject-ghostty") {
+		t.Fatalf("expected ghostty usage error, got %v", err)
+	}
+}
+
 func TestRunWakeWithLoopRejectsNonPositiveInjectTimeout(t *testing.T) {
 	err := runWakeWithLoop([]string{
 		"--root", t.TempDir(),
@@ -756,6 +865,15 @@ func TestWakeHealthCheckSkipsTTYForInjectVia(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("expected external injection health check to skip TTY, got %v", err)
+	}
+}
+
+func TestWakeHealthCheckSkipsTTYForGhostty(t *testing.T) {
+	err := wakeHealthCheck(wakeConfig{ghosttyTerminalID: "terminal-1"}, func() bool {
+		return false
+	})
+	if err != nil {
+		t.Fatalf("expected Ghostty injection health check to skip TTY, got %v", err)
 	}
 }
 

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -24,6 +24,24 @@ func stubInspectWakeProcess(t *testing.T, fn func(pid int) wakeProcessInfo) {
 	})
 }
 
+func stubWakeCurrentTTY(t *testing.T, fn func() string) {
+	t.Helper()
+	old := getWakeCurrentTTY
+	getWakeCurrentTTY = fn
+	t.Cleanup(func() {
+		getWakeCurrentTTY = old
+	})
+}
+
+func stubWakeProcessSID(t *testing.T, fn func(pid int) (int, error)) {
+	t.Helper()
+	old := getWakeProcessSID
+	getWakeProcessSID = fn
+	t.Cleanup(func() {
+		getWakeProcessSID = old
+	})
+}
+
 func writeWakeLockForTest(t *testing.T, root, agent string, lock wakeLock) string {
 	t.Helper()
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -152,6 +170,205 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 		t.Fatal("expected existing wake lock error")
 	}
 	if !strings.Contains(err.Error(), "wake already running") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an existing live wake lock: %#v", cfg)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected existing usable wake to satisfy ready file, got %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); statErr != nil {
+		t.Fatalf("ready file should exist, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		TTY:          "/dev/amq-missing-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an unusable existing wake lock: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected unusable wake lock error")
+	}
+	if !strings.Contains(err.Error(), "not usable for --require-wake") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("existing lock should remain, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *testing.T) {
+	const wakePID = 4242
+	ttyPath := filepath.Join(t.TempDir(), "amq-test-tty")
+	if err := os.WriteFile(ttyPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("write fake tty path: %v", err)
+	}
+	stubWakeCurrentTTY(t, func() string { return ttyPath })
+	sidCalls := 0
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		sidCalls++
+		if pid == wakePID {
+			return 100, nil
+		}
+		return 200, nil
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		TTY:          ttyPath,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an unusable existing wake lock: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected unusable wake lock error")
+	}
+	if !strings.Contains(err.Error(), "not usable for --require-wake") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("existing lock should remain, statErr=%v", statErr)
+	}
+	if sidCalls < 2 {
+		t.Fatalf("expected same-TTY branch to inspect wake and current SIDs, got %d calls", sidCalls)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := t.TempDir()
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", "/tmp/injector",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an unverified wake lock: %#v", cfg)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected unverified wake lock error")
+	}
+	if !strings.Contains(err.Error(), "unverified") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
@@ -483,6 +700,18 @@ func TestWaitForWakeReadyFailsWhenWakeExitsBeforeReady(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "amq wake exited before becoming ready") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitForWakeReadyAcceptsReadyFileWrittenBeforeExit(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	cmd := exec.Command("sh", "-c", `: > "$1"; exit 0`, "sh", readyPath)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+
+	if err := waitForWakeReady(cmd.Process, readyPath, time.Second); err != nil {
+		t.Fatalf("waitForWakeReady should accept ready file written before exit: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds native macOS Ghostty wake delivery that targets a stable Ghostty terminal id instead of relying on terminal titles or session labels.

- adds `amq wake --inject-ghostty` and `--inject-ghostty-terminal-id`
- adds `amq coop exec --wake-inject-ghostty` for normal launcher use
- persists `.wake.target` metadata beside `.wake.lock` so wake reuse is target-aware
- reports stale/orphaned/mismatched wake target state in `amq doctor --ops`
- adds `amq doctor --ops --fix-wake-targets` for orphan target cleanup

## Why

In multi-terminal setups, terminal titles can be duplicated or renamed. AMQ routing should remain root/agent based, but terminal injection needs a stable terminal destination. Binding the wake process to a Ghostty terminal id prevents silent injection into the wrong terminal when labels collide.

## Validation

- `go test ./...`
- `git diff --check`
- CLI help smoke checks for `--inject-ghostty`, `--wake-inject-ghostty`, and `--fix-wake-targets`
