### PR TITLE
feat(coop): add --no-gitignore flag to coop init

### DIFF
--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -46,6 +46,7 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 	agentsFlag := fs.String("agents", defaultCoopAgents, "Comma-separated agent handles")
 	forceFlag := fs.Bool("force", false, "Overwrite existing config if present")
 	jsonFlag := fs.Bool("json", false, "Output as JSON")
+	noGitignoreFlag := fs.Bool("no-gitignore", false, "Do not modify .gitignore")
 
 	usage := usageWithFlags(fs, "amq coop init [options]",
 		"Initialize a project for co-op mode with sensible defaults.",
@@ -53,7 +54,7 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 		"Creates:",
 		"  - .amqrc file with root configuration",
 		"  - Mailbox directories for each agent",
-		"  - Updates .gitignore (if present)",
+		"  - Updates .gitignore (unless --no-gitignore)",
 		"",
 		"Defaults:",
 		fmt.Sprintf("  --root=%s  --agents=%s", defaultCoopRoot, defaultCoopAgents),
@@ -157,8 +158,11 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 		amqrcWritten = true
 	}
 
-	// Update .gitignore (creates if needed, only for relative paths)
-	gitignoreUpdated := ensureGitignore(root)
+	// Update .gitignore (creates if needed, only for relative paths) unless opted out
+	gitignoreUpdated := false
+	if !*noGitignoreFlag {
+		gitignoreUpdated = ensureGitignore(root)
+	}
 
 	// Output
 	if *jsonFlag {

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -226,6 +226,41 @@ func TestCoopInitDefaultIncludesUser(t *testing.T) {
 	}
 }
 
+func TestCoopInitNoGitignore(t *testing.T) {
+	projectDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+		resetAmqrcCache()
+	})
+	resetAmqrcCache()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runCoopInitInternal([]string{"--json", "--no-gitignore"}, false)
+	})
+	if err != nil {
+		t.Fatalf("runCoopInitInternal: %v", err)
+	}
+	var result struct {
+		GitignoreUpdated bool `json:"gitignore_updated"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("unmarshal output: %v (output: %s)", err, output)
+	}
+	if result.GitignoreUpdated {
+		t.Fatalf("gitignore_updated = true, want false with --no-gitignore")
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".gitignore")); !os.IsNotExist(err) {
+		t.Fatalf(".gitignore should not be created with --no-gitignore (stat err: %v)", err)
+	}
+}
+
 func TestInitExplicitAgentsDoesNotInjectUser(t *testing.T) {
 	root := t.TempDir()
 	_, err := captureEnvStdout(t, func() error {


### PR DESCRIPTION
Closes #172.

## What

Adds a `--no-gitignore` flag to `amq coop init` that skips the `.gitignore` update step. Default behavior is unchanged.

```
amq coop init --no-gitignore   # mailboxes + .amqrc, .gitignore untouched
```

## Why

`coop init` always appends an ignore block (`.agent-mail/`, `.amqrc`) to the repo `.gitignore`, with no way to opt out. People who ignore these globally via `core.excludesfile` (e.g. `~/.config/git/ignore`) get a redundant block, and every `coop init` dirties the working tree with a `.gitignore` change they have to revert by hand. Same for anyone managing ignores elsewhere (committed top-level `.gitignore`, monorepo central ignores).

An opt-out flag is mechanism, not policy — it just says "don't touch `.gitignore`" and leaves *where* ignores live to the user. It's strictly more general than a "redirect to global excludesfile" mode, which would silently mutate machine-wide git config from a project-scoped command.

## Changes

- `internal/cli/coop.go`: register `--no-gitignore`, guard the `ensureGitignore` call, update the usage note.
- `internal/cli/coop_exec_test.go`: `TestCoopInitNoGitignore` asserts no `.gitignore` is created and `gitignore_updated` is `false`.

Scope kept to `coop init` per the issue; `amq init` is left untouched.

## Testing

- `go build ./...`, `go vet ./internal/cli/`, `gofmt -l` clean.
- New test plus existing coop init tests pass.
- Manual: `coop init --no-gitignore` in a fresh repo creates `.amqrc` but no `.gitignore`; `coop init -h` lists the flag.

> Note: one unrelated test (`TestRunWakeRepairJSONRejectsFIFOLogWithoutBlocking`) fails in my sandbox because its temp root `/private/tmp` is world-writable; it fails identically on a pristine checkout, so it's environmental, not from this change.
