### PR TITLE
Fix claim-first drain consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- `amq drain` and drain-mode `amq monitor` now claim inbox messages before
+  parsing them, preventing duplicate consumption under concurrent drains.
 
 ## [0.38.0] - 2026-06-22
 ### Added

--- a/internal/cli/drain.go
+++ b/internal/cli/drain.go
@@ -47,7 +47,7 @@ func runDrain(args []string) error {
 		return err
 	}
 
-	items, err := collectInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator)
+	items, err := drainInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator)
 	if err != nil {
 		return err
 	}
@@ -63,8 +63,6 @@ func runDrain(args []string) error {
 
 	// Best-effort presence touch.
 	_ = presence.Touch(root, common.Me)
-
-	processInboxItems(root, common.Me, items)
 
 	if common.JSON {
 		return writeJSON(os.Stdout, drainResult{Drained: items, Count: len(items)})

--- a/internal/cli/drain_test.go
+++ b/internal/cli/drain_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -309,6 +310,94 @@ func TestRunDrainLimit(t *testing.T) {
 	newEntries, _ := os.ReadDir(fsq.AgentInboxNew(root, "alice"))
 	if len(newEntries) != 3 {
 		t.Errorf("expected 3 in new, got %d", len(newEntries))
+	}
+}
+
+func TestDrainInboxItemsConcurrentClaimsSingleWinner(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "bob"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      "claim-once",
+			From:    "bob",
+			To:      []string{"alice"},
+			Thread:  "p2p/alice__bob",
+			Subject: "Claim once",
+			Created: "2025-12-24T10:00:00Z",
+		},
+		Body: "Only one drain may consume this.",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := fsq.DeliverToInbox(root, "alice", "claim-once.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	const workers = 2
+	start := make(chan struct{})
+	results := make(chan []inboxItem, workers)
+	errs := make(chan error, workers)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			items, err := drainInboxItems(root, "alice", false, 0, &headerValidator{})
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- items
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("drainInboxItems: %v", err)
+	}
+
+	total := 0
+	for items := range results {
+		total += len(items)
+		for _, item := range items {
+			if item.ID != "claim-once" {
+				t.Fatalf("unexpected drained item: %+v", item)
+			}
+			if !item.MovedToCur || item.MovedToDLQ {
+				t.Fatalf("expected a single cur claim, got %+v", item)
+			}
+		}
+	}
+	if total != 1 {
+		t.Fatalf("expected exactly one drained item across concurrent drains, got %d", total)
+	}
+
+	receipts, err := receipt.List(root, "alice", receipt.ListFilter{
+		MsgID: "claim-once",
+		Stage: receipt.StageDrained,
+	})
+	if err != nil {
+		t.Fatalf("receipt.List: %v", err)
+	}
+	if len(receipts) != 1 {
+		t.Fatalf("expected exactly one drained receipt, got %d", len(receipts))
 	}
 }
 

--- a/internal/cli/inbox_collect.go
+++ b/internal/cli/inbox_collect.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -11,11 +12,32 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/receipt"
 )
 
-// processInboxItems moves collected inbox items to cur (or DLQ for parse errors)
-// and emits receipts. Used by both drain and monitor commands.
-func processInboxItems(root, me string, items []inboxItem) {
-	for i := range items {
-		item := &items[i]
+// drainInboxItems claims inbox/new messages before parsing them, then emits
+// output items and receipts only for messages this process actually claimed.
+func drainInboxItems(root, me string, includeBody bool, limit int, validator *headerValidator) ([]inboxItem, error) {
+	filenames, err := collectInboxFilenames(root, me)
+	if err != nil {
+		return nil, err
+	}
+
+	if validator == nil {
+		validator = &headerValidator{}
+	}
+
+	items := make([]inboxItem, 0, len(filenames))
+	for _, filename := range filenames {
+		if limit > 0 && len(items) >= limit {
+			break
+		}
+		if err := fsq.MoveNewToCur(root, me, filename); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			_ = writeStderr("warning: failed to claim %s: %v\n", filename, err)
+			continue
+		}
+
+		item := readInboxItem(filepath.Join(fsq.AgentInboxCur(root, me), filename), filename, includeBody, validator)
 
 		// Move parse errors to DLQ instead of cur
 		if item.ParseError != "" {
@@ -23,33 +45,23 @@ func processInboxItems(root, me string, items []inboxItem) {
 			if reason == "" {
 				reason = "parse_error"
 			}
-			if _, err := fsq.MoveToDLQ(root, me, item.Filename, item.ID, reason, item.ParseError); err != nil {
+			if _, err := fsq.MoveCurToDLQ(root, me, item.Filename, item.ID, reason, item.ParseError); err != nil {
 				_ = writeStderr("warning: failed to move %s to DLQ: %v\n", item.Filename, err)
 			} else {
 				item.MovedToDLQ = true
-				emitReceipt(root, me, item, receipt.StageDLQ, item.ParseError)
+				emitReceipt(root, me, &item, receipt.StageDLQ, item.ParseError)
 			}
+			items = append(items, item)
 			continue
 		}
 
-		// Move new -> cur
-		if err := fsq.MoveNewToCur(root, me, item.Filename); err != nil {
-			if os.IsNotExist(err) {
-				// Likely moved by another drain; check if it's already in cur.
-				curPath := filepath.Join(fsq.AgentInboxCur(root, me), item.Filename)
-				if _, statErr := os.Stat(curPath); statErr == nil {
-					item.MovedToCur = true
-				} else if statErr != nil && !os.IsNotExist(statErr) {
-					_ = writeStderr("warning: failed to stat %s in cur: %v\n", item.Filename, statErr)
-				}
-			} else {
-				_ = writeStderr("warning: failed to move %s to cur: %v\n", item.Filename, err)
-			}
-		} else {
-			item.MovedToCur = true
-			emitReceipt(root, me, item, receipt.StageDrained, "")
-		}
+		item.MovedToCur = true
+		emitReceipt(root, me, &item, receipt.StageDrained, "")
+		items = append(items, item)
 	}
+
+	format.SortByTimestamp(items)
+	return items, nil
 }
 
 func emitReceipt(root, consumer string, item *inboxItem, stage, detail string) {
@@ -66,12 +78,8 @@ func emitReceipt(root, consumer string, item *inboxItem, stage, detail string) {
 }
 
 func collectInboxItems(root, me string, includeBody bool, limit int, validator *headerValidator) ([]inboxItem, error) {
-	newDir := fsq.AgentInboxNew(root, me)
-	entries, err := os.ReadDir(newDir)
+	filenames, err := collectInboxFilenames(root, me)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return []inboxItem{}, nil
-		}
 		return nil, err
 	}
 
@@ -79,75 +87,10 @@ func collectInboxItems(root, me string, includeBody bool, limit int, validator *
 		validator = &headerValidator{}
 	}
 
-	items := make([]inboxItem, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		filename := entry.Name()
-		// Skip dotfiles (like .DS_Store) and non-.md files
-		if strings.HasPrefix(filename, ".") || !strings.HasSuffix(filename, ".md") {
-			continue
-		}
-		path := filepath.Join(newDir, filename)
-
-		baseID := strings.TrimSuffix(filename, ".md")
-		item := inboxItem{
-			ID:       baseID, // fallback to filename base if parse fails
-			Filename: filename,
-		}
-
-		// Try to parse the message
-		var header format.Header
-		var body string
-		var parseErr error
-
-		if includeBody {
-			msg, err := format.ReadMessageFile(path)
-			if err != nil {
-				parseErr = err
-			} else {
-				header = msg.Header
-				body = msg.Body
-			}
-		} else {
-			header, parseErr = format.ReadHeaderFile(path)
-		}
-
-		if parseErr != nil {
-			item.ParseError = parseErr.Error()
-			item.FailureReason = "parse_error"
-			// Still move corrupt message to DLQ to avoid reprocessing
-		} else if err := validator.validate(header); err != nil {
-			item.From = header.From
-			item.Thread = header.Thread
-			item.ParseError = "invalid header: " + err.Error()
-			item.FailureReason = "invalid_header"
-			if safeID, ok := safeHeaderID(header.ID); ok {
-				item.ID = safeID
-			}
-		} else {
-			item.ID = header.ID
-			item.From = header.From
-			item.To = header.To
-			item.Thread = header.Thread
-			item.Subject = header.Subject
-			item.Created = header.Created
-			item.Priority = header.Priority
-			item.Kind = header.Kind
-			item.Labels = header.Labels
-			item.Context = header.Context
-			item.FromProject = header.FromProject
-			item.ReplyProject = header.ReplyProject
-			if includeBody {
-				item.Body = body
-			}
-			if ts, err := time.Parse(time.RFC3339Nano, header.Created); err == nil {
-				item.SortKey = ts
-			}
-		}
-
-		items = append(items, item)
+	items := make([]inboxItem, 0, len(filenames))
+	for _, filename := range filenames {
+		path := filepath.Join(fsq.AgentInboxNew(root, me), filename)
+		items = append(items, readInboxItem(path, filename, includeBody, validator))
 	}
 
 	format.SortByTimestamp(items)
@@ -157,4 +100,90 @@ func collectInboxItems(root, me string, includeBody bool, limit int, validator *
 	}
 
 	return items, nil
+}
+
+func collectInboxFilenames(root, me string) ([]string, error) {
+	newDir := fsq.AgentInboxNew(root, me)
+	entries, err := os.ReadDir(newDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	filenames := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filename := entry.Name()
+		// Skip dotfiles (like .DS_Store) and non-.md files
+		if strings.HasPrefix(filename, ".") || !strings.HasSuffix(filename, ".md") {
+			continue
+		}
+		filenames = append(filenames, filename)
+	}
+	sort.Strings(filenames)
+	return filenames, nil
+}
+
+func readInboxItem(path, filename string, includeBody bool, validator *headerValidator) inboxItem {
+	baseID := strings.TrimSuffix(filename, ".md")
+	item := inboxItem{
+		ID:       baseID, // fallback to filename base if parse fails
+		Filename: filename,
+	}
+
+	// Try to parse the message
+	var header format.Header
+	var body string
+	var parseErr error
+
+	if includeBody {
+		msg, err := format.ReadMessageFile(path)
+		if err != nil {
+			parseErr = err
+		} else {
+			header = msg.Header
+			body = msg.Body
+		}
+	} else {
+		header, parseErr = format.ReadHeaderFile(path)
+	}
+
+	if parseErr != nil {
+		item.ParseError = parseErr.Error()
+		item.FailureReason = "parse_error"
+		// Still move corrupt message to DLQ to avoid reprocessing.
+	} else if err := validator.validate(header); err != nil {
+		item.From = header.From
+		item.Thread = header.Thread
+		item.ParseError = "invalid header: " + err.Error()
+		item.FailureReason = "invalid_header"
+		if safeID, ok := safeHeaderID(header.ID); ok {
+			item.ID = safeID
+		}
+	} else {
+		item.ID = header.ID
+		item.From = header.From
+		item.To = header.To
+		item.Thread = header.Thread
+		item.Subject = header.Subject
+		item.Created = header.Created
+		item.Priority = header.Priority
+		item.Kind = header.Kind
+		item.Labels = header.Labels
+		item.Context = header.Context
+		item.FromProject = header.FromProject
+		item.ReplyProject = header.ReplyProject
+		if includeBody {
+			item.Body = body
+		}
+		if ts, err := time.Parse(time.RFC3339Nano, header.Created); err == nil {
+			item.SortKey = ts
+		}
+	}
+
+	return item
 }

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -77,15 +77,12 @@ func runMonitor(args []string) error {
 	}
 
 	// First, try to drain existing messages
-	items, err := collectInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator)
+	items, err := monitorInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator, mode)
 	if err != nil {
 		return err
 	}
 
 	if len(items) > 0 {
-		if mode == "drain" {
-			drainMonitorItems(root, common.Me, items)
-		}
 		return outputMonitorResult(common.JSON, monitorResult{
 			Event:      "messages",
 			WatchEvent: "existing",
@@ -132,12 +129,9 @@ func runMonitor(args []string) error {
 	}
 
 	// New message arrived - drain it
-	items, err = collectInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator)
+	items, err = monitorInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator, mode)
 	if err != nil {
 		return err
-	}
-	if mode == "drain" {
-		drainMonitorItems(root, common.Me, items)
 	}
 
 	result := monitorResult{
@@ -157,8 +151,11 @@ func runMonitor(args []string) error {
 	return outputMonitorResult(common.JSON, result)
 }
 
-func drainMonitorItems(root, me string, items []monitorItem) {
-	processInboxItems(root, me, items)
+func monitorInboxItems(root, me string, includeBody bool, limit int, validator *headerValidator, mode string) ([]monitorItem, error) {
+	if mode == "peek" {
+		return collectInboxItems(root, me, includeBody, limit, validator)
+	}
+	return drainInboxItems(root, me, includeBody, limit, validator)
 }
 
 func monitorWithFsnotify(ctx context.Context, inboxNew string) (string, error) {

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -39,9 +39,21 @@ func GenerateDLQID() string {
 }
 
 // MoveToDLQ moves a failed message from inbox/new to dlq/new with envelope.
-// Uses atomic rename when possible to prevent duplicates on cleanup failure.
 func MoveToDLQ(root, agent, filename, originalID, failureReason, failureDetail string) (string, error) {
-	srcPath := filepath.Join(AgentInboxNew(root, agent), filename)
+	return moveInboxMessageToDLQ(root, agent, BoxNew, filename, originalID, failureReason, failureDetail)
+}
+
+// MoveCurToDLQ moves an already-claimed inbox/cur message to dlq/new.
+func MoveCurToDLQ(root, agent, filename, originalID, failureReason, failureDetail string) (string, error) {
+	return moveInboxMessageToDLQ(root, agent, BoxCur, filename, originalID, failureReason, failureDetail)
+}
+
+func moveInboxMessageToDLQ(root, agent, sourceDir, filename, originalID, failureReason, failureDetail string) (string, error) {
+	srcDir, err := inboxSourceDir(root, agent, sourceDir)
+	if err != nil {
+		return "", err
+	}
+	srcPath := filepath.Join(srcDir, filename)
 
 	// Read original content
 	content, err := os.ReadFile(srcPath)
@@ -59,7 +71,7 @@ func MoveToDLQ(root, agent, filename, originalID, failureReason, failureDetail s
 		FailureDetail: failureDetail,
 		FailureTime:   time.Now().UTC().Format(time.RFC3339),
 		RetryCount:    0,
-		SourceDir:     "new",
+		SourceDir:     sourceDir,
 	}
 
 	// Serialize envelope + original content
@@ -75,23 +87,43 @@ func MoveToDLQ(root, agent, filename, originalID, failureReason, failureDetail s
 		return "", fmt.Errorf("deliver to dlq: %w", err)
 	}
 
-	// Remove from inbox/new - if this fails, the message is duplicated
-	// but the DLQ ID is unique so re-draining will create a new DLQ entry.
-	// To prevent this, we use rename to cur first (atomic), then remove from cur.
-	inboxCurPath := filepath.Join(AgentInboxCur(root, agent), filename)
-	if err := os.Rename(srcPath, inboxCurPath); err != nil {
-		// Fallback: try direct remove (may fail and leave duplicate)
-		if rmErr := os.Remove(srcPath); rmErr != nil && !os.IsNotExist(rmErr) {
-			return dlqPath, fmt.Errorf("remove original (dlq written): %w", rmErr)
+	if sourceDir == BoxNew {
+		// Remove from inbox/new - if this fails, the message is duplicated
+		// but the DLQ ID is unique so re-draining will create a new DLQ entry.
+		// To prevent this, we use rename to cur first (atomic), then remove from cur.
+		inboxCurPath := filepath.Join(AgentInboxCur(root, agent), filename)
+		if err := os.MkdirAll(filepath.Dir(inboxCurPath), 0o700); err != nil {
+			return dlqPath, fmt.Errorf("create inbox cur: %w", err)
+		}
+		if err := os.Rename(srcPath, inboxCurPath); err != nil {
+			// Fallback: try direct remove (may fail and leave duplicate)
+			if rmErr := os.Remove(srcPath); rmErr != nil && !os.IsNotExist(rmErr) {
+				return dlqPath, fmt.Errorf("remove original (dlq written): %w", rmErr)
+			}
+		} else {
+			// Successfully moved to cur, now remove from cur
+			_ = os.Remove(inboxCurPath)
+			_ = SyncDir(AgentInboxCur(root, agent))
 		}
 	} else {
-		// Successfully moved to cur, now remove from cur
-		_ = os.Remove(inboxCurPath)
-		_ = SyncDir(AgentInboxCur(root, agent))
+		if err := os.Remove(srcPath); err != nil && !os.IsNotExist(err) {
+			return dlqPath, fmt.Errorf("remove original (dlq written): %w", err)
+		}
 	}
-	_ = SyncDir(filepath.Dir(srcPath))
+	_ = SyncDir(srcDir)
 
 	return dlqPath, nil
+}
+
+func inboxSourceDir(root, agent, sourceDir string) (string, error) {
+	switch sourceDir {
+	case BoxNew:
+		return AgentInboxNew(root, agent), nil
+	case BoxCur:
+		return AgentInboxCur(root, agent), nil
+	default:
+		return "", fmt.Errorf("unsupported inbox source dir %q", sourceDir)
+	}
 }
 
 // deliverToDLQ writes a DLQ message using Maildir semantics (tmp -> new).

--- a/internal/fsq/dlq_test.go
+++ b/internal/fsq/dlq_test.go
@@ -63,6 +63,45 @@ func TestMoveToDLQ(t *testing.T) {
 	}
 }
 
+func TestMoveCurToDLQ(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	filename := "claimed_corrupt.md"
+	content := []byte("not valid frontmatter after claim")
+	if err := os.WriteFile(filepath.Join(AgentInboxNew(root, "alice"), filename), content, 0o600); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+	if err := MoveNewToCur(root, "alice", filename); err != nil {
+		t.Fatalf("MoveNewToCur: %v", err)
+	}
+
+	dlqPath, err := MoveCurToDLQ(root, "alice", filename, "claimed_corrupt", "parse_error", "missing frontmatter")
+	if err != nil {
+		t.Fatalf("MoveCurToDLQ: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(AgentInboxCur(root, "alice"), filename)); !os.IsNotExist(err) {
+		t.Fatalf("claimed original should be removed from inbox/cur")
+	}
+
+	env, body, err := ReadDLQEnvelope(dlqPath)
+	if err != nil {
+		t.Fatalf("ReadDLQEnvelope: %v", err)
+	}
+	if env.SourceDir != BoxCur {
+		t.Fatalf("expected source_dir %q, got %q", BoxCur, env.SourceDir)
+	}
+	if env.OriginalFile != filename {
+		t.Fatalf("expected original_file %q, got %q", filename, env.OriginalFile)
+	}
+	if string(body) != string(content) {
+		t.Fatalf("body mismatch: expected %q, got %q", content, body)
+	}
+}
+
 func TestRetryFromDLQ(t *testing.T) {
 	root := t.TempDir()
 	if err := EnsureAgentDirs(root, "alice"); err != nil {


### PR DESCRIPTION
## Summary
- make `amq drain` claim inbox messages with `new -> cur` before parsing or emitting output
- route drain-mode `amq monitor` through the same claim-first path while keeping `--peek` read-only
- add `fsq.MoveCurToDLQ` for corrupt messages that have already been claimed into `cur`
- add regression coverage for concurrent drains producing exactly one drained item and one drained receipt

## Tests
- `go test ./internal/cli -run 'TestDrainInboxItemsConcurrentClaimsSingleWinner|TestRunDrainMovesToCur|TestRunDrainLimit|TestRunDrainCorruptMessage|TestMonitor_ExistingMessages|TestMonitor_PeekDoesNotDrain' -count=1`
- `go test ./internal/fsq -run 'TestMoveCurToDLQ|TestMoveToDLQ|TestRetryFromDLQ' -count=1`
- `go test ./internal/cli -count=1`
- `go test ./internal/fsq -count=1`
- `make ci`

## Review
- Owner review from Claude: approved before push.
