### PR TITLE
Fix DLQ move and retry integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `amq drain` and drain-mode `amq monitor` now claim inbox messages before
   parsing them, preventing duplicate consumption under concurrent drains.
+- DLQ moves and retries now claim or update queue state before redelivery, and
+  reject tampered original filenames before restoring messages.
 
 ## [0.38.0] - 2026-06-22
 ### Added

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,16 +39,19 @@ func GenerateDLQID() string {
 
 // MoveToDLQ moves a failed message from inbox/new to dlq/new with envelope.
 func MoveToDLQ(root, agent, filename, originalID, failureReason, failureDetail string) (string, error) {
-	return moveInboxMessageToDLQ(root, agent, BoxNew, filename, originalID, failureReason, failureDetail)
+	if err := MoveNewToCur(root, agent, filename); err != nil {
+		return "", fmt.Errorf("claim original: %w", err)
+	}
+	return moveInboxMessageToDLQ(root, agent, BoxCur, BoxNew, filename, originalID, failureReason, failureDetail)
 }
 
 // MoveCurToDLQ moves an already-claimed inbox/cur message to dlq/new.
 func MoveCurToDLQ(root, agent, filename, originalID, failureReason, failureDetail string) (string, error) {
-	return moveInboxMessageToDLQ(root, agent, BoxCur, filename, originalID, failureReason, failureDetail)
+	return moveInboxMessageToDLQ(root, agent, BoxCur, BoxCur, filename, originalID, failureReason, failureDetail)
 }
 
-func moveInboxMessageToDLQ(root, agent, sourceDir, filename, originalID, failureReason, failureDetail string) (string, error) {
-	srcDir, err := inboxSourceDir(root, agent, sourceDir)
+func moveInboxMessageToDLQ(root, agent, readDir, envelopeSourceDir, filename, originalID, failureReason, failureDetail string) (string, error) {
+	srcDir, err := inboxSourceDir(root, agent, readDir)
 	if err != nil {
 		return "", err
 	}
@@ -71,7 +73,7 @@ func moveInboxMessageToDLQ(root, agent, sourceDir, filename, originalID, failure
 		FailureDetail: failureDetail,
 		FailureTime:   time.Now().UTC().Format(time.RFC3339),
 		RetryCount:    0,
-		SourceDir:     sourceDir,
+		SourceDir:     envelopeSourceDir,
 	}
 
 	// Serialize envelope + original content
@@ -87,28 +89,8 @@ func moveInboxMessageToDLQ(root, agent, sourceDir, filename, originalID, failure
 		return "", fmt.Errorf("deliver to dlq: %w", err)
 	}
 
-	if sourceDir == BoxNew {
-		// Remove from inbox/new - if this fails, the message is duplicated
-		// but the DLQ ID is unique so re-draining will create a new DLQ entry.
-		// To prevent this, we use rename to cur first (atomic), then remove from cur.
-		inboxCurPath := filepath.Join(AgentInboxCur(root, agent), filename)
-		if err := os.MkdirAll(filepath.Dir(inboxCurPath), 0o700); err != nil {
-			return dlqPath, fmt.Errorf("create inbox cur: %w", err)
-		}
-		if err := os.Rename(srcPath, inboxCurPath); err != nil {
-			// Fallback: try direct remove (may fail and leave duplicate)
-			if rmErr := os.Remove(srcPath); rmErr != nil && !os.IsNotExist(rmErr) {
-				return dlqPath, fmt.Errorf("remove original (dlq written): %w", rmErr)
-			}
-		} else {
-			// Successfully moved to cur, now remove from cur
-			_ = os.Remove(inboxCurPath)
-			_ = SyncDir(AgentInboxCur(root, agent))
-		}
-	} else {
-		if err := os.Remove(srcPath); err != nil && !os.IsNotExist(err) {
-			return dlqPath, fmt.Errorf("remove original (dlq written): %w", err)
-		}
+	if err := os.Remove(srcPath); err != nil && !os.IsNotExist(err) {
+		return dlqPath, fmt.Errorf("remove original (dlq written): %w", err)
 	}
 	_ = SyncDir(srcDir)
 
@@ -190,51 +172,86 @@ func RetryFromDLQ(root, agent, dlqFilename string, force bool) error {
 	if envelope.RetryCount >= MaxRetries && !force {
 		return fmt.Errorf("max retries (%d) exceeded; use --force to override", MaxRetries)
 	}
+	if err := validateInboxFilename(envelope.OriginalFile); err != nil {
+		return fmt.Errorf("invalid original_file %q: %w", envelope.OriginalFile, err)
+	}
 
 	// Check if original file already exists in inbox/new (avoid overwrite)
 	inboxNewPath := filepath.Join(AgentInboxNew(root, agent), envelope.OriginalFile)
 	if _, err := os.Stat(inboxNewPath); err == nil {
 		return fmt.Errorf("original file already exists in inbox/new: %s", envelope.OriginalFile)
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("stat inbox/new original: %w", err)
 	}
 
-	// Deliver original content back to inbox
+	envelope.RetryCount++
+	updatedData, err := serializeDLQMessage(*envelope, originalContent)
+	if err != nil {
+		return fmt.Errorf("serialize updated dlq envelope: %w", err)
+	}
+
+	if err := updateRetriedDLQEnvelope(root, agent, dlqFilename, dlqPath, box, updatedData); err != nil {
+		return err
+	}
+
+	// Deliver original content back to inbox only after the DLQ state transition
+	// succeeds, so metadata failures cannot duplicate retry delivery.
 	if _, err := DeliverToInbox(root, agent, envelope.OriginalFile, originalContent); err != nil {
 		return fmt.Errorf("redeliver to inbox: %w", err)
 	}
 
-	// Update envelope with incremented retry count
-	envelope.RetryCount++
-	updatedData, err := serializeDLQMessage(*envelope, originalContent)
-	if err != nil {
-		// Best effort: message is already in inbox
-		log.Printf("dlq: failed to serialize updated envelope for %s: %v", dlqFilename, err)
-		return nil
-	}
+	return nil
+}
 
-	// Handle based on source location
+func updateRetriedDLQEnvelope(root, agent, dlqFilename, dlqPath, box string, updatedData []byte) error {
 	curDir := AgentDLQCur(root, agent)
 	if err := os.MkdirAll(curDir, 0o700); err != nil {
-		log.Printf("dlq: failed to create cur dir for %s: %v", agent, err)
-		return nil
+		return fmt.Errorf("prepare dlq envelope cur dir: %w", err)
 	}
 
 	if box == BoxNew {
 		// Source is dlq/new: write to dlq/cur atomically, then remove from dlq/new
 		if _, err := WriteFileAtomic(curDir, dlqFilename, updatedData, 0o600); err != nil {
-			log.Printf("dlq: failed to write updated envelope to cur for %s: %v", dlqFilename, err)
-			return nil
+			return fmt.Errorf("write updated dlq envelope to cur: %w", err)
 		}
-		_ = os.Remove(dlqPath)
-		_ = SyncDir(filepath.Dir(dlqPath))
-	} else {
-		// Source is dlq/cur: update in place atomically (same location)
-		if _, err := WriteFileAtomic(curDir, dlqFilename, updatedData, 0o600); err != nil {
-			log.Printf("dlq: failed to update envelope in cur for %s: %v", dlqFilename, err)
-			return nil
+		if err := os.Remove(dlqPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove old dlq envelope from new: %w", err)
 		}
+		if err := SyncDir(filepath.Dir(dlqPath)); err != nil {
+			return fmt.Errorf("sync old dlq envelope dir: %w", err)
+		}
+		return SyncDir(curDir)
 	}
-	_ = SyncDir(curDir)
 
+	// Source is dlq/cur: update in place atomically (same location)
+	if _, err := WriteFileAtomic(curDir, dlqFilename, updatedData, 0o600); err != nil {
+		return fmt.Errorf("update dlq envelope in cur: %w", err)
+	}
+	return SyncDir(curDir)
+}
+
+func validateInboxFilename(filename string) error {
+	if filename == "" {
+		return fmt.Errorf("empty filename")
+	}
+	if strings.HasPrefix(filename, ".") {
+		return fmt.Errorf("dotfile names are not allowed")
+	}
+	if filepath.IsAbs(filename) {
+		return fmt.Errorf("absolute path is not allowed")
+	}
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") {
+		return fmt.Errorf("path separators are not allowed")
+	}
+	if strings.Contains(filename, "\x00") {
+		return fmt.Errorf("NUL byte is not allowed")
+	}
+	if filename == "." || filename == ".." {
+		return fmt.Errorf("path traversal is not allowed")
+	}
+	if !strings.HasSuffix(filename, ".md") {
+		return fmt.Errorf("filename must end with .md")
+	}
 	return nil
 }
 

--- a/internal/fsq/dlq_test.go
+++ b/internal/fsq/dlq_test.go
@@ -63,6 +63,43 @@ func TestMoveToDLQ(t *testing.T) {
 	}
 }
 
+func TestMoveToDLQClaimsBeforeDLQDelivery(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	filename := "claim_before_dlq.md"
+	content := []byte("not valid frontmatter")
+	if err := os.WriteFile(filepath.Join(AgentInboxNew(root, "alice"), filename), content, 0o600); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+
+	dlqTmp := AgentDLQTmp(root, "alice")
+	if err := os.RemoveAll(dlqTmp); err != nil {
+		t.Fatalf("remove dlq tmp: %v", err)
+	}
+	if err := os.WriteFile(dlqTmp, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("block dlq tmp: %v", err)
+	}
+
+	_, err := MoveToDLQ(root, "alice", filename, "claim_before_dlq", "parse_error", "missing frontmatter")
+	if err == nil {
+		t.Fatal("expected MoveToDLQ to fail when DLQ delivery cannot create tmp dir")
+	}
+
+	if _, err := os.Stat(filepath.Join(AgentInboxNew(root, "alice"), filename)); !os.IsNotExist(err) {
+		t.Fatalf("source should be claimed out of inbox/new before DLQ delivery, stat err: %v", err)
+	}
+	claimedContent, err := os.ReadFile(filepath.Join(AgentInboxCur(root, "alice"), filename))
+	if err != nil {
+		t.Fatalf("claimed source should remain in inbox/cur: %v", err)
+	}
+	if string(claimedContent) != string(content) {
+		t.Fatalf("claimed content mismatch: got %q", claimedContent)
+	}
+}
+
 func TestMoveCurToDLQ(t *testing.T) {
 	root := t.TempDir()
 	if err := EnsureAgentDirs(root, "alice"); err != nil {
@@ -151,6 +188,98 @@ func TestRetryFromDLQ(t *testing.T) {
 	}
 }
 
+func TestRetryFromDLQRejectsTraversalOriginalFile(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	dlqPath := createDLQMessage(t, root, "alice", "safe_msg.md", []byte("test content"))
+	env, body, err := ReadDLQEnvelope(dlqPath)
+	if err != nil {
+		t.Fatalf("ReadDLQEnvelope: %v", err)
+	}
+	env.OriginalFile = "../escape.md"
+	data, err := serializeDLQMessage(*env, body)
+	if err != nil {
+		t.Fatalf("serialize tampered envelope: %v", err)
+	}
+	if err := os.WriteFile(dlqPath, data, 0o600); err != nil {
+		t.Fatalf("write tampered envelope: %v", err)
+	}
+
+	err = RetryFromDLQ(root, "alice", filepath.Base(dlqPath), false)
+	if err == nil {
+		t.Fatal("expected traversal original_file to be rejected")
+	}
+	if !strings.Contains(err.Error(), "invalid original_file") {
+		t.Fatalf("expected invalid original_file error, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "agents", "alice", "inbox", "escape.md")); !os.IsNotExist(err) {
+		t.Fatalf("retry should not create escaped inbox file, stat err: %v", err)
+	}
+}
+
+func TestRetryFromDLQEnvelopeUpdateFailureReturnsErrorBeforeRedelivery(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	dlqPath := createDLQMessage(t, root, "alice", "update_failure.md", []byte("test content"))
+	dlqCur := AgentDLQCur(root, "alice")
+	if err := os.RemoveAll(dlqCur); err != nil {
+		t.Fatalf("remove dlq cur: %v", err)
+	}
+	if err := os.WriteFile(dlqCur, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("block dlq cur: %v", err)
+	}
+
+	err := RetryFromDLQ(root, "alice", filepath.Base(dlqPath), false)
+	if err == nil {
+		t.Fatal("expected RetryFromDLQ to return envelope update error")
+	}
+	if !strings.Contains(err.Error(), "dlq envelope") {
+		t.Fatalf("expected dlq envelope error, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(AgentInboxNew(root, "alice"), "update_failure.md")); !os.IsNotExist(err) {
+		t.Fatalf("retry should not redeliver before envelope update succeeds, stat err: %v", err)
+	}
+}
+
+func TestRetryFromDLQRedeliveryFailureReturnsError(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	dlqPath := createDLQMessage(t, root, "alice", "redelivery_failure.md", []byte("test content"))
+	inboxTmp := AgentInboxTmp(root, "alice")
+	if err := os.RemoveAll(inboxTmp); err != nil {
+		t.Fatalf("remove inbox tmp: %v", err)
+	}
+	if err := os.WriteFile(inboxTmp, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("block inbox tmp: %v", err)
+	}
+
+	err := RetryFromDLQ(root, "alice", filepath.Base(dlqPath), false)
+	if err == nil {
+		t.Fatal("expected RetryFromDLQ to return redelivery error")
+	}
+	if !strings.Contains(err.Error(), "redeliver to inbox") {
+		t.Fatalf("expected redelivery error, got: %v", err)
+	}
+
+	curPath := filepath.Join(AgentDLQCur(root, "alice"), filepath.Base(dlqPath))
+	env, _, err := ReadDLQEnvelope(curPath)
+	if err != nil {
+		t.Fatalf("expected updated DLQ envelope in cur: %v", err)
+	}
+	if env.RetryCount != 1 {
+		t.Fatalf("expected retry_count 1 after state transition, got %d", env.RetryCount)
+	}
+}
+
 func TestRetryFromDLQMaxRetries(t *testing.T) {
 	root := t.TempDir()
 	if err := EnsureAgentDirs(root, "alice"); err != nil {
@@ -193,6 +322,18 @@ func TestRetryFromDLQMaxRetries(t *testing.T) {
 	if err := RetryFromDLQ(root, "alice", dlqFilename, true); err != nil {
 		t.Fatalf("RetryFromDLQ with force: %v", err)
 	}
+}
+
+func createDLQMessage(t *testing.T, root, agent, filename string, content []byte) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(AgentInboxNew(root, agent), filename), content, 0o600); err != nil {
+		t.Fatalf("write source message: %v", err)
+	}
+	dlqPath, err := MoveToDLQ(root, agent, filename, strings.TrimSuffix(filename, ".md"), "test_failure", "test detail")
+	if err != nil {
+		t.Fatalf("MoveToDLQ: %v", err)
+	}
+	return dlqPath
 }
 
 func TestFindDLQMessage(t *testing.T) {


### PR DESCRIPTION
## Summary
- claim `inbox/new` messages into `cur` before creating DLQ envelopes
- validate DLQ `original_file` before retry path joins or redelivery
- update/move the DLQ envelope before redelivery and return retry-state/redelivery errors instead of logging success
- add regression coverage for DLQ claim-first failure paths, tampered filenames, metadata update failures, and redelivery failures

## Tests
- `go test ./internal/fsq -run 'TestMoveToDLQClaimsBeforeDLQDelivery|TestRetryFromDLQRejectsTraversalOriginalFile|TestRetryFromDLQEnvelopeUpdateFailureReturnsErrorBeforeRedelivery|TestRetryFromDLQRedeliveryFailureReturnsError|TestMoveToDLQ|TestMoveCurToDLQ|TestRetryFromDLQ|TestRetryFromDLQMaxRetries|TestFindDLQMessage' -count=1`
- `go test ./internal/fsq -count=1`
- `go test ./internal/cli -count=1`
- `git diff --check`
- `make ci`

## Review
- Owner review from Claude: approved before push.
