### PR TITLE
fix: preserve committed partial deliveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsing them, preventing duplicate consumption under concurrent drains.
 - DLQ moves and retries now claim or update queue state before redelivery, and
   reject tampered original filenames before restoring messages.
+- Multi-recipient delivery now preserves already committed inbox messages when
+  a later recipient fails, and `amq send --project` now rejects multiple
+  recipients instead of applying undefined cross-project partial semantics.
 
 ## [0.38.0] - 2026-06-22
 ### Added

--- a/internal/cli/cross_project_test.go
+++ b/internal/cli/cross_project_test.go
@@ -413,3 +413,27 @@ func TestCrossProjectSendFromOutsideTree(t *testing.T) {
 		t.Errorf("expected 1 message in peer inbox, got %d", len(entries))
 	}
 }
+
+func TestCrossProjectSendRejectsMultipleRecipients(t *testing.T) {
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", "")
+	resetAmqrcCache()
+	defer resetAmqrcCache()
+
+	err := runSend([]string{
+		"--root", t.TempDir(),
+		"--me", "alice",
+		"--to", "bob,carol",
+		"--project", "peer-project",
+		"--body", "hello",
+	})
+	if err == nil {
+		t.Fatal("expected cross-project multi-recipient send to fail")
+	}
+	if code := GetExitCode(err); code != ExitUsage {
+		t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(err.Error(), "--project supports exactly one recipient") {
+		t.Fatalf("error = %q, want explicit cross-project multi-recipient rejection", err)
+	}
+}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -93,6 +93,9 @@ func runSend(args []string) error {
 		return UsageError("--to: %v", err)
 	}
 	recipients = dedupeStrings(recipients)
+	if targetProject != "" && len(recipients) > 1 {
+		return UsageError("--project supports exactly one recipient; got %d. Send one message per recipient.", len(recipients))
+	}
 
 	// Validate --wait-for (basic checks; cross-root check deferred until routing is resolved)
 	waitFor := strings.TrimSpace(*waitForFlag)

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"syscall"
 )
 
@@ -26,8 +28,49 @@ type stagedDelivery struct {
 	newPath   string
 }
 
+// PartialDeliveryError reports the delivery state after a multi-recipient
+// delivery fails during the tmp -> new commit phase.
+type PartialDeliveryError struct {
+	Delivered map[string]string
+	Failed    string
+	Pending   []string
+	Err       error
+}
+
+func (e *PartialDeliveryError) Error() string {
+	delivered := "none"
+	if len(e.Delivered) > 0 {
+		recipients := make([]string, 0, len(e.Delivered))
+		for recipient := range e.Delivered {
+			recipients = append(recipients, recipient)
+		}
+		sort.Strings(recipients)
+		delivered = strings.Join(recipients, ", ")
+	}
+
+	failed := e.Failed
+	if failed == "" {
+		failed = "unknown"
+	}
+
+	pending := "none"
+	if len(e.Pending) > 0 {
+		pending = strings.Join(e.Pending, ", ")
+	}
+
+	if e.Err == nil {
+		return fmt.Sprintf("partial delivery: delivered to %s; failed for %s; pending %s", delivered, failed, pending)
+	}
+	return fmt.Sprintf("partial delivery: delivered to %s; failed for %s; pending %s: %v", delivered, failed, pending, e.Err)
+}
+
+func (e *PartialDeliveryError) Unwrap() error {
+	return e.Err
+}
+
 // DeliverToInboxes writes a message to multiple inboxes.
-// On failure, it attempts to roll back any prior deliveries.
+// On partial failure, committed deliveries remain in new/ and undelivered tmp
+// files are removed.
 func DeliverToInboxes(root string, recipients []string, filename string, data []byte) (map[string]string, error) {
 	if len(recipients) == 0 {
 		return nil, fmt.Errorf("no recipients provided")
@@ -66,13 +109,13 @@ func DeliverToInboxes(root string, recipients []string, filename string, data []
 			} else {
 				err = fmt.Errorf("rename tmp->new for %s: %w", stage.recipient, err)
 			}
-			return nil, rollbackDeliveries(stages[:i], stages[i:], err)
+			return nil, partialDeliveryError(stages[:i], stage, stages[i+1:], err)
 		}
 		// Sync both directories after rename for fully durable delivery:
 		// - newDir: new entry is visible
 		// - tmpDir: old entry removal is durable
 		if err := SyncDir(stage.newDir); err != nil {
-			return nil, rollbackDeliveries(stages[:i+1], stages[i+1:], fmt.Errorf("sync new dir for %s: %w", stage.recipient, err))
+			return nil, partialDeliveryError(stages[:i+1], stage, stages[i+1:], fmt.Errorf("sync new dir for %s: %w", stage.recipient, err))
 		}
 		// Best-effort sync of tmpDir (non-fatal: message is already delivered)
 		_ = SyncDir(stage.tmpDir)
@@ -126,6 +169,40 @@ func dirExists(path string) bool {
 }
 
 func cleanupStagedTmp(stages []stagedDelivery, primary error) error {
+	cleanupErr := cleanupTmpStages(stages)
+	if cleanupErr == nil {
+		return primary
+	}
+	return fmt.Errorf("%w (cleanup: %v)", primary, cleanupErr)
+}
+
+func partialDeliveryError(committed []stagedDelivery, failed stagedDelivery, pending []stagedDelivery, primary error) error {
+	delivered := make(map[string]string, len(committed))
+	for _, stage := range committed {
+		delivered[stage.recipient] = stage.newPath
+	}
+
+	pendingRecipients := make([]string, 0, len(pending))
+	for _, stage := range pending {
+		pendingRecipients = append(pendingRecipients, stage.recipient)
+	}
+
+	undelivered := make([]stagedDelivery, 0, 1+len(pending))
+	undelivered = append(undelivered, failed)
+	undelivered = append(undelivered, pending...)
+	if cleanupErr := cleanupTmpStages(undelivered); cleanupErr != nil {
+		primary = fmt.Errorf("%w (cleanup: %v)", primary, cleanupErr)
+	}
+
+	return &PartialDeliveryError{
+		Delivered: delivered,
+		Failed:    failed.recipient,
+		Pending:   pendingRecipients,
+		Err:       primary,
+	}
+}
+
+func cleanupTmpStages(stages []stagedDelivery) error {
 	var cleanupErr error
 	for _, stage := range stages {
 		if err := os.Remove(stage.tmpPath); err != nil && !os.IsNotExist(err) {
@@ -135,32 +212,5 @@ func cleanupStagedTmp(stages []stagedDelivery, primary error) error {
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("sync tmp dir %s: %w", stage.tmpDir, err))
 		}
 	}
-	if cleanupErr == nil {
-		return primary
-	}
-	return fmt.Errorf("%w (cleanup: %v)", primary, cleanupErr)
-}
-
-func rollbackDeliveries(committed, pending []stagedDelivery, primary error) error {
-	var cleanupErr error
-	for _, stage := range committed {
-		if err := os.Remove(stage.newPath); err != nil && !os.IsNotExist(err) {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("rollback new %s: %w", stage.newPath, err))
-		}
-		if err := SyncDir(stage.newDir); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("sync new dir %s: %w", stage.newDir, err))
-		}
-	}
-	for _, stage := range pending {
-		if err := os.Remove(stage.tmpPath); err != nil && !os.IsNotExist(err) {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cleanup tmp %s: %w", stage.tmpPath, err))
-		}
-		if err := SyncDir(stage.tmpDir); err != nil {
-			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("sync tmp dir %s: %w", stage.tmpDir, err))
-		}
-	}
-	if cleanupErr == nil {
-		return primary
-	}
-	return fmt.Errorf("%w (rollback: %v)", primary, cleanupErr)
+	return cleanupErr
 }

--- a/internal/fsq/maildir_test.go
+++ b/internal/fsq/maildir_test.go
@@ -1,6 +1,7 @@
 package fsq
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -120,24 +121,55 @@ func TestDeliverToInboxesRollback(t *testing.T) {
 	if err := EnsureAgentDirs(root, "claude"); err != nil {
 		t.Fatalf("EnsureAgentDirs claude: %v", err)
 	}
+	if err := EnsureAgentDirs(root, "ada"); err != nil {
+		t.Fatalf("EnsureAgentDirs ada: %v", err)
+	}
 
 	cloudNew := AgentInboxNew(root, "claude")
 	if err := os.Chmod(cloudNew, 0o555); err != nil {
 		t.Fatalf("chmod claude new: %v", err)
 	}
+	defer func() { _ = os.Chmod(cloudNew, 0o700) }()
 
 	filename := "multi.md"
-	if _, err := DeliverToInboxes(root, []string{"codex", "claude"}, filename, []byte("hello")); err == nil {
+	_, err := DeliverToInboxes(root, []string{"codex", "claude", "ada"}, filename, []byte("hello"))
+	if err == nil {
 		t.Fatalf("expected delivery error")
+	}
+	var partial *PartialDeliveryError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected PartialDeliveryError, got %T: %v", err, err)
+	}
+	if partial.Failed != "claude" {
+		t.Fatalf("failed recipient = %q, want claude", partial.Failed)
+	}
+	if len(partial.Pending) != 1 || partial.Pending[0] != "ada" {
+		t.Fatalf("pending recipients = %#v, want [ada]", partial.Pending)
 	}
 
 	codexNew := filepath.Join(AgentInboxNew(root, "codex"), filename)
-	if _, err := os.Stat(codexNew); !os.IsNotExist(err) {
-		t.Fatalf("expected rollback to remove %s", codexNew)
+	if got := partial.Delivered["codex"]; got != codexNew {
+		t.Fatalf("delivered[codex] = %q, want %q", got, codexNew)
+	}
+	got, err := os.ReadFile(codexNew)
+	if err != nil {
+		t.Fatalf("expected committed delivery to remain at %s: %v", codexNew, err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("committed delivery content = %q, want hello", got)
 	}
 
 	cloudTmp := filepath.Join(AgentInboxTmp(root, "claude"), filename)
 	if _, err := os.Stat(cloudTmp); !os.IsNotExist(err) {
-		t.Fatalf("expected rollback to remove %s", cloudTmp)
+		t.Fatalf("expected failed tmp to be removed from %s", cloudTmp)
+	}
+
+	adaTmp := filepath.Join(AgentInboxTmp(root, "ada"), filename)
+	if _, err := os.Stat(adaTmp); !os.IsNotExist(err) {
+		t.Fatalf("expected pending tmp to be removed from %s", adaTmp)
+	}
+	adaNew := filepath.Join(AgentInboxNew(root, "ada"), filename)
+	if _, err := os.Stat(adaNew); !os.IsNotExist(err) {
+		t.Fatalf("expected pending recipient to have no new delivery at %s", adaNew)
 	}
 }


### PR DESCRIPTION
## Summary
- Preserve already committed new/ deliveries when multi-recipient delivery fails later in the commit phase
- Return typed fsq.PartialDeliveryError with delivered, failed, and pending recipient state
- Reject amq send --project with multiple recipients up front

## Verification
- go test ./internal/fsq ./internal/cli
- make ci
- git diff --check

Closes #4
Closes #5