### PR TITLE
fix: expire owner-dead inject-via wakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-recipient delivery now preserves already committed inbox messages when
   a later recipient fails, and `amq send --project` now rejects multiple
   recipients instead of applying undefined cross-project partial semantics.
+- AMQ-owned `--inject-via` wake processes started by `coop exec` or
+  `wake repair` now exit when their recorded owner process is gone or no
+  longer matches, preventing stale terminal injectors from blocking session
+  reopen recovery.
 
 ## [0.38.0] - 2026-06-22
 ### Added

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -202,6 +202,10 @@ func runCoopExec(args []string) error {
 			amqBin = "amq"
 		}
 
+		var wakeOwner *wakeOwner
+		if wakeInjectVia != "" {
+			wakeOwner = currentWakeOwner()
+		}
 		wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, wakeInjectVia, []string(wakeInjectArgFlags))...)
 		var readyPath string
 		var cleanupReady func()
@@ -216,7 +220,11 @@ func runCoopExec(args []string) error {
 		}
 		// Set AM_ROOT in wake's env so the helper process resolves the same
 		// session root even if the parent shell inherited a different value.
-		wakeCmd.Env = setEnvVar(os.Environ(), envRoot, root)
+		wakeEnv, wakeEnvErr := wakeCommandEnv(os.Environ(), root, wakeOwner)
+		if wakeEnvErr != nil {
+			return wakeEnvErr
+		}
+		wakeCmd.Env = wakeEnv
 		wakeCmd.Stdin = os.Stdin
 		wakeCmd.Stdout = os.Stdout
 		wakeCmd.Stderr = os.Stderr

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -21,6 +21,7 @@ type wakeConfig struct {
 	injectCmd         string
 	injectVia         string // external command for injection (replaces TIOCSTI)
 	injectArgs        []string
+	wakeOwner         *wakeOwner
 	injectTimeout     time.Duration
 	bell              bool
 	debounce          time.Duration

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -17,16 +17,25 @@ const (
 	wakeTargetSchema    = 1
 	wakeTargetFileName  = ".wake.target"
 	wakeTargetInjectVia = "inject-via"
+	envWakeOwner        = "AMQ_WAKE_OWNER"
 )
 
+type wakeOwner struct {
+	PID          int    `json:"pid"`
+	ProcessStart string `json:"process_start,omitempty"`
+	BootID       string `json:"boot_id,omitempty"`
+	SessionID    int    `json:"session_id,omitempty"`
+}
+
 type wakeTarget struct {
-	Schema     int      `json:"schema"`
-	Mode       string   `json:"mode"`
-	Root       string   `json:"root"`
-	Agent      string   `json:"agent"`
-	Created    string   `json:"created"`
-	InjectVia  string   `json:"inject_via"`
-	InjectArgs []string `json:"inject_args,omitempty"`
+	Schema     int        `json:"schema"`
+	Mode       string     `json:"mode"`
+	Root       string     `json:"root"`
+	Agent      string     `json:"agent"`
+	Created    string     `json:"created"`
+	InjectVia  string     `json:"inject_via"`
+	InjectArgs []string   `json:"inject_args,omitempty"`
+	Owner      *wakeOwner `json:"owner,omitempty"`
 }
 
 func wakeTargetPath(root, me string) string {
@@ -203,6 +212,53 @@ func validateWakeTarget(target wakeTarget, root, me string) error {
 		if strings.ContainsRune(arg, 0) {
 			return fmt.Errorf("wake target inject arg contains NUL")
 		}
+	}
+	if target.Owner != nil {
+		if err := validateWakeOwner(*target.Owner); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodeWakeOwnerEnv(owner wakeOwner) (string, error) {
+	if err := validateWakeOwner(owner); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(owner)
+	if err != nil {
+		return "", fmt.Errorf("marshal wake owner: %w", err)
+	}
+	return string(data), nil
+}
+
+func wakeOwnerFromEnv() (*wakeOwner, error) {
+	raw := strings.TrimSpace(os.Getenv(envWakeOwner))
+	if raw == "" {
+		return nil, nil
+	}
+	var owner wakeOwner
+	if err := json.Unmarshal([]byte(raw), &owner); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", envWakeOwner, err)
+	}
+	if err := validateWakeOwner(owner); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", envWakeOwner, err)
+	}
+	return &owner, nil
+}
+
+func validateWakeOwner(owner wakeOwner) error {
+	if owner.PID <= 0 {
+		return fmt.Errorf("wake owner pid must be > 0")
+	}
+	if strings.ContainsRune(owner.ProcessStart, 0) {
+		return fmt.Errorf("wake owner process start contains NUL")
+	}
+	if strings.ContainsRune(owner.BootID, 0) {
+		return fmt.Errorf("wake owner boot id contains NUL")
+	}
+	if owner.SessionID < 0 {
+		return fmt.Errorf("wake owner session id must be >= 0")
 	}
 	return nil
 }

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -180,7 +180,10 @@ createLock:
 
 func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
 	if !wakeLockNeedsReplacement(inspection) {
-		return false, nil
+		replace, err := wakeLockNeedsOwnerReplacement(inspection)
+		if err != nil || !replace {
+			return replace, err
+		}
 	}
 	return replaceConfirmedOrphanedWakeLock(inspection)
 }
@@ -214,6 +217,23 @@ func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
 		}
 	}
 	return false
+}
+
+func wakeLockNeedsOwnerReplacement(inspection wakeLockInspection) (bool, error) {
+	if !inspection.IdentityConfirmed || inspection.Lock.WakeMode != wakeTargetInjectVia || inspection.Lock.TargetDigest == "" {
+		return false, nil
+	}
+	target, exists, err := readWakeTarget(inspection.Root, inspection.Agent)
+	if err != nil || !exists {
+		return false, nil
+	}
+	if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
+		return false, nil
+	}
+	if target.Owner == nil {
+		return false, nil
+	}
+	return wakeOwnerHealthCheck(*target.Owner) != nil, nil
 }
 
 func requireWakeLockUsable(inspection wakeLockInspection) error {
@@ -511,7 +531,11 @@ func startWakeFromTargetDefault(root, me string, target wakeTarget) (int, error)
 	defer cleanupReady()
 	args := buildRepairWakeArgs(root, me, target, readyPath)
 	cmd := exec.Command(amqBin, args...)
-	cmd.Env = setEnvVar(os.Environ(), envRoot, root)
+	env, err := wakeCommandEnv(os.Environ(), root, target.Owner)
+	if err != nil {
+		return 0, err
+	}
+	cmd.Env = env
 	output, err := openWakeRepairOutput(root, me)
 	if err != nil {
 		return 0, err
@@ -724,10 +748,15 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 
 	var target *wakeTarget
 	if injectVia != "" {
+		owner, err := wakeOwnerFromEnv()
+		if err != nil {
+			return err
+		}
 		value, err := newWakeTarget(root, me, injectVia, []string(injectArgFlags))
 		if err != nil {
 			return err
 		}
+		value.Owner = owner
 		if err := validateWakeTarget(value, root, me); err != nil {
 			return err
 		}
@@ -771,6 +800,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		injectCmd:         *injectCmdFlag,
 		injectVia:         injectVia,
 		injectArgs:        []string(injectArgFlags),
+		wakeOwner:         targetOwner(target),
 		injectTimeout:     *injectTimeoutFlag,
 		bell:              *bellFlag,
 		debounce:          *debounceFlag,
@@ -939,10 +969,88 @@ func runWakeLoop(cfg wakeConfig) error {
 
 func wakeHealthCheck(cfg wakeConfig, ttyAvailableFn func() bool) error {
 	if cfg.injectVia != "" {
+		if cfg.wakeOwner != nil {
+			return wakeOwnerHealthCheck(*cfg.wakeOwner)
+		}
 		return nil
 	}
 	if !ttyAvailableFn() {
 		return errors.New("TTY no longer available")
+	}
+	return nil
+}
+
+func targetOwner(target *wakeTarget) *wakeOwner {
+	if target == nil || target.Owner == nil {
+		return nil
+	}
+	owner := *target.Owner
+	return &owner
+}
+
+func currentWakeOwner() *wakeOwner {
+	owner := wakeOwner{PID: os.Getpid()}
+	if proc := inspectWakeProcess(owner.PID); proc.Running {
+		owner.ProcessStart = proc.StartToken
+		owner.BootID = proc.BootID
+	}
+	if sid, err := getWakeProcessSID(owner.PID); err == nil {
+		owner.SessionID = sid
+	}
+	return &owner
+}
+
+func wakeCommandEnv(base []string, root string, owner *wakeOwner) ([]string, error) {
+	env := setEnvVar(base, envRoot, root)
+	env = unsetEnvVar(env, envWakeOwner)
+	if owner == nil {
+		return env, nil
+	}
+	encoded, err := encodeWakeOwnerEnv(*owner)
+	if err != nil {
+		return nil, err
+	}
+	return setEnvVar(env, envWakeOwner, encoded), nil
+}
+
+func unsetEnvVar(env []string, key string) []string {
+	prefix := key + "="
+	out := env[:0]
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func wakeOwnerHealthCheck(owner wakeOwner) error {
+	if err := validateWakeOwner(owner); err != nil {
+		return err
+	}
+	proc := inspectWakeProcess(owner.PID)
+	if !proc.Running {
+		return fmt.Errorf("inject-via wake owner pid %d is not running", owner.PID)
+	}
+	if owner.ProcessStart != "" {
+		if proc.StartToken == "" {
+			return fmt.Errorf("inject-via wake owner process start unavailable for pid %d: %v", owner.PID, proc.InspectError)
+		}
+		if proc.StartToken != owner.ProcessStart {
+			return fmt.Errorf("inject-via wake owner process start changed for pid %d", owner.PID)
+		}
+	}
+	if owner.BootID != "" && proc.BootID != "" && proc.BootID != owner.BootID {
+		return fmt.Errorf("inject-via wake owner boot id changed for pid %d", owner.PID)
+	}
+	if owner.SessionID != 0 {
+		sid, err := getWakeProcessSID(owner.PID)
+		if err != nil {
+			return fmt.Errorf("inject-via wake owner session unavailable for pid %d: %w", owner.PID, err)
+		}
+		if sid != owner.SessionID {
+			return fmt.Errorf("inject-via wake owner session changed for pid %d", owner.PID)
+		}
 	}
 	return nil
 }

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -147,6 +147,60 @@ func TestRunWakeWithLoopWritesInjectViaWakeTarget(t *testing.T) {
 		if target.InjectVia != injector || strings.Join(target.InjectArgs, "|") != "exec" {
 			t.Fatalf("unexpected target: %#v", target)
 		}
+		if target.Owner != nil {
+			t.Fatalf("generic inject-via wake target should not record owner: %#v", target.Owner)
+		}
+		if cfg.wakeOwner != nil {
+			t.Fatalf("generic inject-via wake config should not record owner: %#v", cfg.wakeOwner)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopPersistsInjectViaWakeOwnerFromEnv(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "owner-start",
+		BootID:       "boot-1",
+		SessionID:    99,
+	}
+	ownerEnv, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatalf("encodeWakeOwnerEnv: %v", err)
+	}
+	t.Setenv(envWakeOwner, ownerEnv)
+
+	injector := writeExecutableForTest(t, "injector")
+	errDone := errors.New("done")
+	err = runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", injector,
+	}, func(cfg wakeConfig) error {
+		if cfg.wakeOwner == nil || *cfg.wakeOwner != owner {
+			t.Fatalf("cfg.wakeOwner = %#v, want %#v", cfg.wakeOwner, owner)
+		}
+		target, exists, targetErr := readWakeTarget(root, "orchestrator")
+		if targetErr != nil {
+			t.Fatalf("readWakeTarget: %v", targetErr)
+		}
+		if !exists {
+			t.Fatal("expected wake target to be written")
+		}
+		if target.Owner == nil || *target.Owner != owner {
+			t.Fatalf("target.Owner = %#v, want %#v", target.Owner, owner)
+		}
 		return errDone
 	})
 	if !errors.Is(err, errDone) {
@@ -1171,6 +1225,128 @@ func TestShouldReplaceOrphanedWakeLockRevalidatesBeforeSignal(t *testing.T) {
 	}
 }
 
+func TestShouldReplaceOrphanedWakeLockReplacesInjectViaWhenOwnerGone(t *testing.T) {
+	const wakePID = 4242
+	const ownerPID = 7777
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	owner := wakeOwner{PID: ownerPID, ProcessStart: "owner-start", BootID: "boot-1"}
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})
+	target.Owner = &owner
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "wake-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, target))
+	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+
+	killed := false
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		switch pid {
+		case wakePID:
+			if killed {
+				return wakeProcessInfo{PID: pid, Running: false}
+			}
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "wake-start",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root, "--inject-via", injector},
+			}
+		case ownerPID:
+			return wakeProcessInfo{PID: pid, Running: false}
+		default:
+			return wakeProcessInfo{PID: pid}
+		}
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		if pid != wakePID {
+			t.Fatalf("signal pid = %d, want %d", pid, wakePID)
+		}
+		if sig == os.Kill {
+			killed = true
+		}
+		return nil
+	})
+
+	inspection := inspectWakeLock(root, "orchestrator")
+	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
+	if err != nil {
+		t.Fatalf("shouldReplaceOrphanedWakeLock: %v", err)
+	}
+	if !replaced {
+		t.Fatal("expected owner-dead inject-via wake to be replaced")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock should be removed after owner-dead replacement, stat=%v", err)
+	}
+}
+
+func TestShouldReplaceOrphanedWakeLockKeepsInjectViaWhenOwnerMatches(t *testing.T) {
+	const wakePID = 4242
+	const ownerPID = 7777
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	owner := wakeOwner{PID: ownerPID, ProcessStart: "owner-start", BootID: "boot-1"}
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})
+	target.Owner = &owner
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "wake-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, target))
+	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		switch pid {
+		case wakePID:
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "wake-start",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root, "--inject-via", injector},
+			}
+		case ownerPID:
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "owner-start",
+				BootID:     "boot-1",
+			}
+		default:
+			return wakeProcessInfo{PID: pid}
+		}
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		t.Fatalf("must not signal owner-matched inject-via wake, got pid=%d sig=%v", pid, sig)
+		return nil
+	})
+
+	inspection := inspectWakeLock(root, "orchestrator")
+	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
+	if err != nil {
+		t.Fatalf("shouldReplaceOrphanedWakeLock: %v", err)
+	}
+	if replaced {
+		t.Fatal("owner-matched inject-via wake should not be replaced")
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain for owner-matched wake, stat=%v", statErr)
+	}
+}
+
 func TestRunWakeWithLoopRejectsRecentlyCorruptLock(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -1413,6 +1589,126 @@ func TestWakeHealthCheckSkipsTTYForInjectVia(t *testing.T) {
 	}
 }
 
+func TestWakeHealthCheckExitsWhenInjectViaOwnerGone(t *testing.T) {
+	owner := wakeOwner{PID: 4242, ProcessStart: "owner-start", BootID: "boot-1"}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	err := wakeHealthCheck(wakeConfig{injectVia: "/tmp/injector", wakeOwner: &owner}, func() bool {
+		return false
+	})
+	if err == nil {
+		t.Fatal("expected owner liveness failure")
+	}
+	if !strings.Contains(err.Error(), "owner pid 4242 is not running") {
+		t.Fatalf("unexpected owner liveness error: %v", err)
+	}
+}
+
+func TestWakeHealthCheckExitsWhenInjectViaOwnerIdentityChanges(t *testing.T) {
+	owner := wakeOwner{PID: 4242, ProcessStart: "owner-start", BootID: "boot-1", SessionID: 99}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "other-start",
+			BootID:     "boot-1",
+		}
+	})
+
+	err := wakeHealthCheck(wakeConfig{injectVia: "/tmp/injector", wakeOwner: &owner}, func() bool {
+		return false
+	})
+	if err == nil {
+		t.Fatal("expected owner identity failure")
+	}
+	if !strings.Contains(err.Error(), "owner process start changed") {
+		t.Fatalf("unexpected owner identity error: %v", err)
+	}
+}
+
+func TestWakeHealthCheckKeepsInjectViaWhenOwnerMatches(t *testing.T) {
+	owner := wakeOwner{PID: 4242, ProcessStart: "owner-start", BootID: "boot-1"}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "owner-start",
+			BootID:     "boot-1",
+		}
+	})
+
+	err := wakeHealthCheck(wakeConfig{injectVia: "/tmp/injector", wakeOwner: &owner}, func() bool {
+		return false
+	})
+	if err != nil {
+		t.Fatalf("expected owner-matched inject-via health check to pass, got %v", err)
+	}
+}
+
+func TestCurrentWakeOwnerIncludesProcessIdentityWhenAvailable(t *testing.T) {
+	self := os.Getpid()
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != self {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "self-start",
+			BootID:     "boot-1",
+		}
+	})
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		if pid != self {
+			t.Fatalf("unexpected sid lookup pid %d", pid)
+		}
+		return 99, nil
+	})
+
+	owner := currentWakeOwner()
+	if owner == nil {
+		t.Fatal("expected owner")
+	}
+	if owner.PID != self || owner.ProcessStart != "self-start" || owner.BootID != "boot-1" || owner.SessionID != 99 {
+		t.Fatalf("owner = %#v, want pid=%d start/self boot/session", owner, self)
+	}
+}
+
+func TestWakeCommandEnvCarriesOwnerToken(t *testing.T) {
+	owner := wakeOwner{PID: 4242, ProcessStart: "owner-start", BootID: "boot-1", SessionID: 99}
+	env, err := wakeCommandEnv([]string{
+		"PATH=/bin",
+		envRoot + "=/old/root",
+		envWakeOwner + `={"pid":111}`,
+	}, "/new/root", &owner)
+	if err != nil {
+		t.Fatalf("wakeCommandEnv: %v", err)
+	}
+	if got := testEnvValue(env, envRoot); got != "/new/root" {
+		t.Fatalf("%s = %q, want /new/root", envRoot, got)
+	}
+	var decoded wakeOwner
+	if err := json.Unmarshal([]byte(testEnvValue(env, envWakeOwner)), &decoded); err != nil {
+		t.Fatalf("decode %s: %v", envWakeOwner, err)
+	}
+	if decoded != owner {
+		t.Fatalf("decoded owner = %#v, want %#v", decoded, owner)
+	}
+
+	env, err = wakeCommandEnv(env, "/raw/root", nil)
+	if err != nil {
+		t.Fatalf("wakeCommandEnv without owner: %v", err)
+	}
+	if got := testEnvValue(env, envRoot); got != "/raw/root" {
+		t.Fatalf("%s = %q, want /raw/root", envRoot, got)
+	}
+	if got := testEnvValue(env, envWakeOwner); got != "" {
+		t.Fatalf("%s should be cleared without owner, got %q", envWakeOwner, got)
+	}
+}
+
 func TestWakeHealthCheckRequiresTTYForTIOCSTI(t *testing.T) {
 	err := wakeHealthCheck(wakeConfig{}, func() bool {
 		return false
@@ -1423,4 +1719,14 @@ func TestWakeHealthCheckRequiresTTYForTIOCSTI(t *testing.T) {
 	if err.Error() != "TTY no longer available" {
 		t.Fatalf("expected TTY health error, got %v", err)
 	}
+}
+
+func testEnvValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary
- Persist an internal owner identity for AMQ-owned coop/repair --inject-via wake targets
- Exit owner-tokened inject-via wakes when the owner process is gone or no longer matches
- Replace confirmed AMQ inject-via wake locks immediately when the matching target owner is dead, so same-session reopen self-heals without waiting for the health tick
- Keep generic/manual amq wake --inject-via behavior unchanged when no owner token is present

## #171 note
This fixes the stale/dead-owner reopen regression path related to #171. It does not close draft PR #171, which remains broader native Ghostty target support.

## Verification
- go test ./internal/cli
- make ci
- git diff --check

Closes #8