### PR TITLE
docs(changelog): backfill Unreleased entries for #169/#170/#173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- `amq coop init --no-gitignore` skips updating `.gitignore`, for setups that manage ignores globally or elsewhere (closes #172)
+
+### Changed
+
+- Bump `github.com/coder/websocket` from 1.8.14 to 1.8.15
+- Bump `actions/checkout` from 6.0.3 to 7.0.0
 
 ## [0.39.0] - 2026-06-30
 ### Fixed


### PR DESCRIPTION
#169, #170, and #173 landed right after v0.39.0 was cut, so none added a CHANGELOG entry, leaving `[Unreleased]` empty and the new `--no-gitignore` flag undocumented.

This records:
- **Added:** `amq coop init --no-gitignore` (closes #172, landed in #173)
- **Changed:** the two dependency bumps (#169 websocket, #170 actions/checkout), matching the existing `### Changed` dependency-bump convention

Keeps the changelog pristine for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)