### PR TITLE
ci: require PR changelog entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Check PR changelog
+        if: github.event_name == 'pull_request'
+        run: python3 scripts/check_pr_changelog.py --base-ref "${{ github.event.pull_request.base.sha }}" --head-ref HEAD
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- CI now requires pull requests to add a `CHANGELOG.md` Unreleased entry unless
+  explicitly skipped by Dependabot, release branch, or `no-changelog`/`docs`/`chore`
+  labels (#181).
 - `amq coop init --no-gitignore` skips updating `.gitignore`, for setups that manage ignores globally or elsewhere (closes #172)
 
 ### Changed

--- a/scripts/check_pr_changelog.py
+++ b/scripts/check_pr_changelog.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Require PRs to add a CHANGELOG.md Unreleased entry unless explicitly skipped."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+
+CHANGELOG_PATH = "CHANGELOG.md"
+SKIP_LABELS = {"no-changelog", "docs", "chore"}
+DEPENDABOT_ACTORS = {"dependabot", "dependabot[bot]"}
+
+
+class PRMetadata:
+    def __init__(
+        self,
+        *,
+        actor: str,
+        head_ref: str,
+        base_sha: str,
+        head_sha: str,
+        labels: list[str],
+    ) -> None:
+        self.actor = actor
+        self.head_ref = head_ref
+        self.base_sha = base_sha
+        self.head_sha = head_sha
+        self.labels = labels
+
+
+def load_event(path: pathlib.Path) -> dict:
+    if not path:
+        return {}
+    with path.open() as f:
+        return json.load(f)
+
+
+def metadata_from_event(event: dict, actor: str = "") -> PRMetadata:
+    pr = event.get("pull_request") or {}
+    sender = event.get("sender") or {}
+    head = pr.get("head") or {}
+    base = pr.get("base") or {}
+    labels = pr.get("labels") or []
+
+    label_names = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = str(label.get("name") or "").strip()
+        else:
+            name = str(label).strip()
+        if name:
+            label_names.append(name)
+
+    return PRMetadata(
+        actor=(actor or str(sender.get("login") or "")).strip(),
+        head_ref=str(head.get("ref") or "").strip(),
+        base_sha=str(base.get("sha") or "").strip(),
+        head_sha=str(head.get("sha") or "").strip(),
+        labels=label_names,
+    )
+
+
+def skip_reason(*, actor: str, head_ref: str, labels: list[str]) -> str | None:
+    if actor.strip().lower() in DEPENDABOT_ACTORS:
+        return "dependabot actor"
+    if head_ref.strip().startswith("release/"):
+        return "release branch"
+    normalized_labels = {label.strip().lower() for label in labels}
+    for label in sorted(SKIP_LABELS):
+        if label in normalized_labels:
+            return f"label {label}"
+    return None
+
+
+def git_show(repo: pathlib.Path, ref: str, path: str) -> str:
+    return subprocess.check_output(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=repo,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def unreleased_lines(changelog: str) -> list[str]:
+    lines = changelog.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "## [Unreleased]":
+            start = i + 1
+            break
+    if start is None:
+        raise ValueError("CHANGELOG.md is missing ## [Unreleased]")
+
+    end = len(lines)
+    for i in range(start, len(lines)):
+        if lines[i].startswith("## ["):
+            end = i
+            break
+    return lines[start:end]
+
+
+def added_unreleased_entry(base_changelog: str, head_changelog: str) -> bool:
+    base_lines = unreleased_lines(base_changelog)
+    head_lines = unreleased_lines(head_changelog)
+    for diff_line in difflib.ndiff(base_lines, head_lines):
+        if not diff_line.startswith("+ "):
+            continue
+        line = diff_line[2:].strip()
+        if line.startswith("- "):
+            return True
+    return False
+
+
+def has_added_unreleased_entry(repo: pathlib.Path, base_ref: str, head_ref: str) -> bool:
+    base_changelog = git_show(repo, base_ref, CHANGELOG_PATH)
+    head_changelog = git_show(repo, head_ref, CHANGELOG_PATH)
+    return added_unreleased_entry(base_changelog, head_changelog)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root to inspect")
+    parser.add_argument("--event-path", default=os.environ.get("GITHUB_EVENT_PATH", ""))
+    parser.add_argument("--actor", default=os.environ.get("GITHUB_ACTOR", ""))
+    parser.add_argument("--base-ref", default="", help="Base git ref/SHA for the PR diff")
+    parser.add_argument("--head-ref", default="HEAD", help="Head git ref/SHA for the PR diff")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    event = load_event(pathlib.Path(args.event_path)) if args.event_path else {}
+    metadata = metadata_from_event(event, actor=args.actor)
+
+    reason = skip_reason(actor=metadata.actor, head_ref=metadata.head_ref, labels=metadata.labels)
+    if reason:
+        print(f"CHANGELOG.md check skipped: {reason}")
+        return 0
+
+    base_ref = args.base_ref or metadata.base_sha
+    if not base_ref:
+        print("error: cannot determine PR base ref; pass --base-ref", file=sys.stderr)
+        return 2
+
+    repo = pathlib.Path(args.repo_root)
+    try:
+        ok = has_added_unreleased_entry(repo, base_ref, args.head_ref)
+    except (subprocess.CalledProcessError, ValueError) as err:
+        print(f"error: failed to inspect CHANGELOG.md: {err}", file=sys.stderr)
+        return 2
+
+    if ok:
+        print("CHANGELOG.md Unreleased entry found")
+        return 0
+
+    print(
+        "error: PRs must add a bullet entry to CHANGELOG.md under ## [Unreleased]. "
+        "Use an explicit no-changelog, docs, or chore label only for PRs that should skip this gate.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -128,6 +128,7 @@ if command -v python3 >/dev/null 2>&1; then
   python3 scripts/test_session_name.py
   echo "python session-name tests ok"
   python3 scripts/test_release_changelog.py
+  python3 scripts/test_check_pr_changelog.py
   bash scripts/test_release_metadata.sh
 fi
 

--- a/scripts/test_check_pr_changelog.py
+++ b/scripts/test_check_pr_changelog.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import subprocess
+import tempfile
+
+
+SCRIPT = pathlib.Path(__file__).with_name("check_pr_changelog.py")
+spec = importlib.util.spec_from_file_location("check_pr_changelog", SCRIPT)
+assert spec is not None and spec.loader is not None
+check_pr_changelog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_pr_changelog)
+
+
+BASE_CHANGELOG = """# Changelog
+
+## [Unreleased]
+### Added
+
+- Existing entry.
+
+## [0.1.0] - 2026-01-01
+"""
+
+
+def run_git(repo: pathlib.Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+
+def commit(repo: pathlib.Path, message: str) -> str:
+    run_git(repo, "add", "CHANGELOG.md")
+    run_git(repo, "commit", "--allow-empty", "-m", message)
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+def with_git_repo(head_changelog: str) -> tuple[pathlib.Path, str, str, tempfile.TemporaryDirectory[str]]:
+    temp = tempfile.TemporaryDirectory()
+    repo = pathlib.Path(temp.name)
+    run_git(repo, "init")
+    run_git(repo, "config", "user.email", "test@example.com")
+    run_git(repo, "config", "user.name", "Test User")
+    (repo / "CHANGELOG.md").write_text(BASE_CHANGELOG)
+    base = commit(repo, "base")
+    (repo / "CHANGELOG.md").write_text(head_changelog)
+    head = commit(repo, "head")
+    return repo, base, head, temp
+
+
+def test_added_unreleased_bullet_passes() -> None:
+    repo, base, head, temp = with_git_repo(
+        """# Changelog
+
+## [Unreleased]
+### Added
+
+- Existing entry.
+- Enforce per-PR changelog entries in CI.
+
+## [0.1.0] - 2026-01-01
+"""
+    )
+    with temp:
+        assert check_pr_changelog.has_added_unreleased_entry(repo, base, head)
+
+
+def test_missing_unreleased_bullet_fails() -> None:
+    repo, base, head, temp = with_git_repo(BASE_CHANGELOG)
+    with temp:
+        assert not check_pr_changelog.has_added_unreleased_entry(repo, base, head)
+
+
+def test_added_heading_without_entry_fails() -> None:
+    repo, base, head, temp = with_git_repo(
+        """# Changelog
+
+## [Unreleased]
+### Added
+
+- Existing entry.
+
+### Fixed
+
+## [0.1.0] - 2026-01-01
+"""
+    )
+    with temp:
+        assert not check_pr_changelog.has_added_unreleased_entry(repo, base, head)
+
+
+def test_explicit_skip_reasons() -> None:
+    assert check_pr_changelog.skip_reason(actor="dependabot[bot]", head_ref="deps/x", labels=[]) == (
+        "dependabot actor"
+    )
+    assert check_pr_changelog.skip_reason(actor="avivsinai", head_ref="release/v0.40.0", labels=[]) == (
+        "release branch"
+    )
+    assert check_pr_changelog.skip_reason(actor="avivsinai", head_ref="docs/update", labels=["docs"]) == (
+        "label docs"
+    )
+    assert check_pr_changelog.skip_reason(actor="avivsinai", head_ref="chore/tooling", labels=["chore"]) == (
+        "label chore"
+    )
+    assert check_pr_changelog.skip_reason(
+        actor="avivsinai", head_ref="feature/x", labels=["no-changelog"]
+    ) == "label no-changelog"
+
+
+def test_title_like_branch_does_not_skip_without_label() -> None:
+    assert check_pr_changelog.skip_reason(actor="avivsinai", head_ref="docs/update", labels=[]) is None
+    assert check_pr_changelog.skip_reason(actor="avivsinai", head_ref="chore/tooling", labels=[]) is None
+
+
+def test_event_metadata_prefers_pull_request_fields() -> None:
+    event = {
+        "sender": {"login": "ignored"},
+        "pull_request": {
+            "head": {"ref": "feature/changelog", "sha": "head-sha"},
+            "base": {"sha": "base-sha"},
+            "labels": [{"name": "no-changelog"}],
+        },
+    }
+    metadata = check_pr_changelog.metadata_from_event(event, actor="avivsinai")
+    assert metadata.actor == "avivsinai"
+    assert metadata.head_ref == "feature/changelog"
+    assert metadata.base_sha == "base-sha"
+    assert metadata.head_sha == "head-sha"
+    assert metadata.labels == ["no-changelog"]
+
+
+def test_event_file_loader() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        path = pathlib.Path(temp) / "event.json"
+        path.write_text(json.dumps({"pull_request": {"labels": [{"name": "docs"}]}}))
+        assert check_pr_changelog.load_event(path)["pull_request"]["labels"][0]["name"] == "docs"
+
+
+def main() -> int:
+    test_added_unreleased_bullet_passes()
+    test_missing_unreleased_bullet_fails()
+    test_added_heading_without_entry_fails()
+    test_explicit_skip_reasons()
+    test_title_like_branch_does_not_skip_without_label()
+    test_event_metadata_prefers_pull_request_fields()
+    test_event_file_loader()
+    print("check PR changelog tests ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a pull_request CI gate requiring a CHANGELOG.md Unreleased bullet for PRs.
- Skip only explicit cases: dependabot actor, release/* branches, and no-changelog/docs/chore labels.
- Add Python self-tests and run them from smoke.

Refs #181 (W2-A).

## Testing
- python3 scripts/test_check_pr_changelog.py
- python3 scripts/test_release_changelog.py
- python3 scripts/check_pr_changelog.py --base-ref origin/main --head-ref HEAD
- make smoke
- make ci
