### PR TITLE
fix: detect short atomic writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Atomic queue file writes now return `io.ErrShortWrite` when a partial write
+  reports success before syncing (#181).
 - De-flaked inject-via wake notification tests by replacing shell-redirection
   capture with a deterministic helper process (#181).
 

--- a/internal/fsq/atomic.go
+++ b/internal/fsq/atomic.go
@@ -2,6 +2,7 @@ package fsq
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -55,8 +56,24 @@ func writeAndSync(path string, data []byte, perm os.FileMode) (err error) {
 			_ = os.Remove(path)
 		}
 	}()
-	if _, err = file.Write(data); err != nil {
+	if err = writeAllAndSync(file, data); err != nil {
 		return err
+	}
+	return nil
+}
+
+type writeSyncer interface {
+	Write([]byte) (int, error)
+	Sync() error
+}
+
+func writeAllAndSync(file writeSyncer, data []byte) error {
+	n, err := file.Write(data)
+	if err != nil {
+		return err
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
 	}
 	return file.Sync()
 }

--- a/internal/fsq/atomic_test.go
+++ b/internal/fsq/atomic_test.go
@@ -1,0 +1,49 @@
+package fsq
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+type writeSyncStub struct {
+	writeN    int
+	writeErr  error
+	syncErr   error
+	syncCalls int
+}
+
+func (s *writeSyncStub) Write(data []byte) (int, error) {
+	return s.writeN, s.writeErr
+}
+
+func (s *writeSyncStub) Sync() error {
+	s.syncCalls++
+	return s.syncErr
+}
+
+func TestWriteAllAndSyncReturnsShortWrite(t *testing.T) {
+	writer := &writeSyncStub{writeN: 3}
+
+	err := writeAllAndSync(writer, []byte("hello"))
+
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("writeAllAndSync() error = %v, want io.ErrShortWrite", err)
+	}
+	if writer.syncCalls != 0 {
+		t.Fatalf("Sync called %d times, want 0", writer.syncCalls)
+	}
+}
+
+func TestWriteAllAndSyncSyncsAfterFullWrite(t *testing.T) {
+	writer := &writeSyncStub{writeN: len("hello")}
+
+	err := writeAllAndSync(writer, []byte("hello"))
+
+	if err != nil {
+		t.Fatalf("writeAllAndSync() error = %v, want nil", err)
+	}
+	if writer.syncCalls != 1 {
+		t.Fatalf("Sync called %d times, want 1", writer.syncCalls)
+	}
+}


### PR DESCRIPTION
## Summary
- return `io.ErrShortWrite` when atomic queue file writes report a partial write without an error
- keep the existing sync, close-error, and temp cleanup behavior in `writeAndSync`
- add focused unit coverage for short-write and full-write sync behavior

Refs #181.

## Verification
- RED: `go test ./internal/fsq -run TestWriteAllAndSync` failed before implementation with undefined `writeAllAndSync`
- `go test ./internal/fsq -run TestWriteAllAndSync`
- `go test ./internal/fsq`
- `git diff --check`
- `make ci`
- `python3 scripts/check_pr_changelog.py --base-ref origin/main --head-ref HEAD`