### PR TITLE
fix: validate queue message filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Inbox and DLQ queue operations now share canonical `.md` filename validation
+  at fsq boundaries to reject malformed or tampered names (#181).
 - Atomic queue file writes now return `io.ErrShortWrite` when a partial write
   reports success before syncing (#181).
 - De-flaked inject-via wake notification tests by replacing shell-redirection

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -51,6 +51,9 @@ func MoveCurToDLQ(root, agent, filename, originalID, failureReason, failureDetai
 }
 
 func moveInboxMessageToDLQ(root, agent, readDir, envelopeSourceDir, filename, originalID, failureReason, failureDetail string) (string, error) {
+	if err := ValidateMessageFilename(filename); err != nil {
+		return "", err
+	}
 	srcDir, err := inboxSourceDir(root, agent, readDir)
 	if err != nil {
 		return "", err
@@ -172,7 +175,7 @@ func RetryFromDLQ(root, agent, dlqFilename string, force bool) error {
 	if envelope.RetryCount >= MaxRetries && !force {
 		return fmt.Errorf("max retries (%d) exceeded; use --force to override", MaxRetries)
 	}
-	if err := validateInboxFilename(envelope.OriginalFile); err != nil {
+	if err := ValidateMessageFilename(envelope.OriginalFile); err != nil {
 		return fmt.Errorf("invalid original_file %q: %w", envelope.OriginalFile, err)
 	}
 
@@ -230,33 +233,11 @@ func updateRetriedDLQEnvelope(root, agent, dlqFilename, dlqPath, box string, upd
 	return SyncDir(curDir)
 }
 
-func validateInboxFilename(filename string) error {
-	if filename == "" {
-		return fmt.Errorf("empty filename")
-	}
-	if strings.HasPrefix(filename, ".") {
-		return fmt.Errorf("dotfile names are not allowed")
-	}
-	if filepath.IsAbs(filename) {
-		return fmt.Errorf("absolute path is not allowed")
-	}
-	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") {
-		return fmt.Errorf("path separators are not allowed")
-	}
-	if strings.Contains(filename, "\x00") {
-		return fmt.Errorf("NUL byte is not allowed")
-	}
-	if filename == "." || filename == ".." {
-		return fmt.Errorf("path traversal is not allowed")
-	}
-	if !strings.HasSuffix(filename, ".md") {
-		return fmt.Errorf("filename must end with .md")
-	}
-	return nil
-}
-
 // FindDLQMessage locates a DLQ message in dlq/new or dlq/cur.
 func FindDLQMessage(root, agent, filename string) (string, string, error) {
+	if err := ValidateMessageFilename(filename); err != nil {
+		return "", "", err
+	}
 	newPath := filepath.Join(AgentDLQNew(root, agent), filename)
 	if _, err := os.Stat(newPath); err == nil {
 		return newPath, BoxNew, nil
@@ -274,6 +255,9 @@ func FindDLQMessage(root, agent, filename string) (string, string, error) {
 
 // MoveDLQNewToCur moves a DLQ message from new to cur (marks as inspected).
 func MoveDLQNewToCur(root, agent, filename string) error {
+	if err := ValidateMessageFilename(filename); err != nil {
+		return err
+	}
 	newPath := filepath.Join(AgentDLQNew(root, agent), filename)
 	curDir := AgentDLQCur(root, agent)
 	curPath := filepath.Join(curDir, filename)

--- a/internal/fsq/filename.go
+++ b/internal/fsq/filename.go
@@ -1,0 +1,33 @@
+package fsq
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ValidateMessageFilename validates an inbox or DLQ message filename.
+func ValidateMessageFilename(filename string) error {
+	if filename == "" {
+		return fmt.Errorf("empty filename")
+	}
+	if strings.HasPrefix(filename, ".") {
+		return fmt.Errorf("dotfile names are not allowed")
+	}
+	if filepath.IsAbs(filename) {
+		return fmt.Errorf("absolute path is not allowed")
+	}
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") {
+		return fmt.Errorf("path separators are not allowed")
+	}
+	if strings.Contains(filename, "\x00") {
+		return fmt.Errorf("NUL byte is not allowed")
+	}
+	if filename == "." || filename == ".." {
+		return fmt.Errorf("path traversal is not allowed")
+	}
+	if !strings.HasSuffix(filename, ".md") {
+		return fmt.Errorf("filename must end with .md")
+	}
+	return nil
+}

--- a/internal/fsq/filename_test.go
+++ b/internal/fsq/filename_test.go
@@ -1,0 +1,208 @@
+package fsq
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func invalidMessageFilenames(t *testing.T) []string {
+	t.Helper()
+	return []string{
+		"../message.md",
+		"nested/message.md",
+		`nested\message.md`,
+		filepath.Join(os.TempDir(), "message.md"),
+		"message\x00.md",
+		"message.txt",
+	}
+}
+
+func TestValidateMessageFilename(t *testing.T) {
+	for _, filename := range invalidMessageFilenames(t) {
+		t.Run(filename, func(t *testing.T) {
+			if err := ValidateMessageFilename(filename); err == nil {
+				t.Fatalf("ValidateMessageFilename(%q) error = nil, want error", filename)
+			}
+		})
+	}
+
+	if err := ValidateMessageFilename("message.md"); err != nil {
+		t.Fatalf("ValidateMessageFilename(valid) error = %v, want nil", err)
+	}
+}
+
+func TestMessageFilenameEntryPointsAcceptValidFilenames(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	inboxFilename := "valid_msg.md"
+	inboxPath := filepath.Join(AgentInboxNew(root, "alice"), inboxFilename)
+	if err := os.WriteFile(inboxPath, []byte("test content"), 0o600); err != nil {
+		t.Fatalf("write inbox message: %v", err)
+	}
+
+	path, box, err := FindMessage(root, "alice", inboxFilename)
+	if err != nil {
+		t.Fatalf("FindMessage: %v", err)
+	}
+	if path != inboxPath || box != BoxNew {
+		t.Fatalf("FindMessage = (%q, %q), want (%q, %q)", path, box, inboxPath, BoxNew)
+	}
+	if err := MoveNewToCur(root, "alice", inboxFilename); err != nil {
+		t.Fatalf("MoveNewToCur: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(AgentInboxCur(root, "alice"), inboxFilename)); err != nil {
+		t.Fatalf("expected inbox cur file: %v", err)
+	}
+
+	dlqPath := createDLQMessage(t, root, "alice", "valid_dlq_source.md", []byte("dlq content"))
+	dlqFilename := filepath.Base(dlqPath)
+	path, box, err = FindDLQMessage(root, "alice", dlqFilename)
+	if err != nil {
+		t.Fatalf("FindDLQMessage: %v", err)
+	}
+	if path != dlqPath || box != BoxNew {
+		t.Fatalf("FindDLQMessage = (%q, %q), want (%q, %q)", path, box, dlqPath, BoxNew)
+	}
+	if err := MoveDLQNewToCur(root, "alice", dlqFilename); err != nil {
+		t.Fatalf("MoveDLQNewToCur: %v", err)
+	}
+	dlqCurPath := filepath.Join(AgentDLQCur(root, "alice"), dlqFilename)
+	if _, err := os.Stat(dlqCurPath); err != nil {
+		t.Fatalf("expected dlq cur file: %v", err)
+	}
+	if err := RetryFromDLQ(root, "alice", dlqFilename, false); err != nil {
+		t.Fatalf("RetryFromDLQ: %v", err)
+	}
+	restoredPath := filepath.Join(AgentInboxNew(root, "alice"), "valid_dlq_source.md")
+	if _, err := os.Stat(restoredPath); err != nil {
+		t.Fatalf("expected retry to restore original filename unchanged: %v", err)
+	}
+}
+
+func TestFindMessageRejectsInvalidFilenames(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	for _, filename := range invalidMessageFilenames(t) {
+		t.Run(filename, func(t *testing.T) {
+			if _, _, err := FindMessage(root, "alice", filename); err == nil {
+				t.Fatalf("FindMessage(%q) error = nil, want error", filename)
+			}
+		})
+	}
+}
+
+func TestMoveNewToCurRejectsInvalidFilenames(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	for _, filename := range invalidMessageFilenames(t) {
+		t.Run(filename, func(t *testing.T) {
+			if err := MoveNewToCur(root, "alice", filename); err == nil {
+				t.Fatalf("MoveNewToCur(%q) error = nil, want error", filename)
+			}
+		})
+	}
+}
+
+func TestMoveCurToDLQRejectsInvalidFilenames(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	for _, filename := range invalidMessageFilenames(t) {
+		t.Run(filename, func(t *testing.T) {
+			if _, err := MoveCurToDLQ(root, "alice", filename, "msg", "test_failure", "test detail"); err == nil {
+				t.Fatalf("MoveCurToDLQ(%q) error = nil, want error", filename)
+			}
+		})
+	}
+}
+
+func TestFindDLQMessageRejectsInvalidFilenames(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	for _, filename := range invalidMessageFilenames(t) {
+		t.Run(filename, func(t *testing.T) {
+			if _, _, err := FindDLQMessage(root, "alice", filename); err == nil {
+				t.Fatalf("FindDLQMessage(%q) error = nil, want error", filename)
+			}
+		})
+	}
+}
+
+func TestMoveDLQNewToCurRejectsInvalidFilenames(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	for _, filename := range invalidMessageFilenames(t) {
+		t.Run(filename, func(t *testing.T) {
+			if err := MoveDLQNewToCur(root, "alice", filename); err == nil {
+				t.Fatalf("MoveDLQNewToCur(%q) error = nil, want error", filename)
+			}
+		})
+	}
+}
+
+func TestRetryFromDLQRejectsInvalidDLQFilenames(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	for _, filename := range invalidMessageFilenames(t) {
+		t.Run(filename, func(t *testing.T) {
+			if err := RetryFromDLQ(root, "alice", filename, false); err == nil {
+				t.Fatalf("RetryFromDLQ(%q) error = nil, want error", filename)
+			}
+		})
+	}
+}
+
+func TestRetryFromDLQRejectsInvalidOriginalFilenames(t *testing.T) {
+	for _, originalFile := range invalidMessageFilenames(t) {
+		t.Run(originalFile, func(t *testing.T) {
+			root := t.TempDir()
+			if err := EnsureAgentDirs(root, "alice"); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+
+			dlqPath := createDLQMessage(t, root, "alice", "safe_msg.md", []byte("test content"))
+			env, body, err := ReadDLQEnvelope(dlqPath)
+			if err != nil {
+				t.Fatalf("ReadDLQEnvelope: %v", err)
+			}
+			env.OriginalFile = originalFile
+			data, err := serializeDLQMessage(*env, body)
+			if err != nil {
+				t.Fatalf("serialize tampered envelope: %v", err)
+			}
+			if err := os.WriteFile(dlqPath, data, 0o600); err != nil {
+				t.Fatalf("write tampered envelope: %v", err)
+			}
+
+			err = RetryFromDLQ(root, "alice", filepath.Base(dlqPath), false)
+			if err == nil {
+				t.Fatal("expected invalid original_file to be rejected")
+			}
+			if !strings.Contains(err.Error(), "invalid original_file") {
+				t.Fatalf("expected invalid original_file error, got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/fsq/find.go
+++ b/internal/fsq/find.go
@@ -11,6 +11,9 @@ const (
 )
 
 func FindMessage(root, agent, filename string) (string, string, error) {
+	if err := ValidateMessageFilename(filename); err != nil {
+		return "", "", err
+	}
 	newPath := filepath.Join(root, "agents", agent, "inbox", "new", filename)
 	if _, err := os.Stat(newPath); err == nil {
 		return newPath, BoxNew, nil
@@ -27,6 +30,9 @@ func FindMessage(root, agent, filename string) (string, string, error) {
 }
 
 func MoveNewToCur(root, agent, filename string) error {
+	if err := ValidateMessageFilename(filename); err != nil {
+		return err
+	}
 	newPath := filepath.Join(root, "agents", agent, "inbox", "new", filename)
 	curDir := filepath.Join(root, "agents", agent, "inbox", "cur")
 	curPath := filepath.Join(curDir, filename)


### PR DESCRIPTION
## Summary
- export `fsq.ValidateMessageFilename` for `.md` inbox/DLQ message filenames
- validate message filenames at fsq lookup, move, DLQ, and retry boundaries before path construction
- keep receipt `.json` naming on its separate safe-name path

Refs #181.

## Verification
- RED: focused filename tests failed before implementation with undefined `ValidateMessageFilename`
- `go test ./internal/fsq -run "Test(ValidateMessageFilename|FindMessageRejectsInvalidFilenames|MoveNewToCurRejectsInvalidFilenames|FindDLQMessageRejectsInvalidFilenames|MoveDLQNewToCurRejectsInvalidFilenames|RetryFromDLQRejectsInvalid)"`
- `go test ./internal/fsq`
- `git diff --check`
- `make ci`
- `python3 scripts/check_pr_changelog.py --base-ref origin/main --head-ref HEAD`