### PR TITLE
fix: reject unsafe queue artifact reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Queue artifact reads now reject symlinks and non-regular files before parsing
+  messages, DLQ envelopes, or receipts (#181).
 - Inbox and DLQ queue operations now share canonical `.md` filename validation
   at fsq boundaries to reject malformed or tampered names (#181).
 - Atomic queue file writes now return `io.ErrShortWrite` when a partial write

--- a/internal/format/message.go
+++ b/internal/format/message.go
@@ -7,10 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 // Schema and version constants.
@@ -181,14 +182,15 @@ func ParseHeader(data []byte) (Header, error) {
 }
 
 func ReadMessageFile(path string) (Message, error) {
-	info, err := os.Stat(path)
+	file, info, err := fsq.OpenRegularNoFollow(path)
 	if err != nil {
 		return Message{}, err
 	}
+	defer func() { _ = file.Close() }()
 	if info.Size() > MaxMessageSize {
 		return Message{}, fmt.Errorf("%w: %d bytes", ErrMessageTooLarge, info.Size())
 	}
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(io.LimitReader(file, MaxMessageSize+1))
 	if err != nil {
 		return Message{}, err
 	}
@@ -196,7 +198,7 @@ func ReadMessageFile(path string) (Message, error) {
 }
 
 func ReadHeaderFile(path string) (Header, error) {
-	file, err := os.Open(path)
+	file, _, err := fsq.OpenRegularNoFollow(path)
 	if err != nil {
 		return Header{}, err
 	}

--- a/internal/format/message_nofollow_unix_test.go
+++ b/internal/format/message_nofollow_unix_test.go
@@ -1,0 +1,33 @@
+//go:build darwin || linux
+
+package format
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestReadMessageFileRejectsFIFO(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo.md")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	_, err := ReadMessageFile(path)
+	if err == nil {
+		t.Fatal("expected FIFO message file to be rejected")
+	}
+}
+
+func TestReadHeaderFileRejectsFIFO(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo.md")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	_, err := ReadHeaderFile(path)
+	if err == nil {
+		t.Fatal("expected FIFO header file to be rejected")
+	}
+}

--- a/internal/format/message_test.go
+++ b/internal/format/message_test.go
@@ -292,6 +292,97 @@ func TestReadHeaderFile(t *testing.T) {
 	}
 }
 
+func TestReadMessageFile(t *testing.T) {
+	msg := Message{
+		Header: Header{
+			Schema:  1,
+			ID:      "message-file-test",
+			From:    "codex",
+			To:      []string{"claude"},
+			Created: "2025-01-01T00:00:00Z",
+		},
+		Body: "Body content\n",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.md")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := ReadMessageFile(path)
+	if err != nil {
+		t.Fatalf("ReadMessageFile: %v", err)
+	}
+	if got.Header.ID != "message-file-test" || got.Body != "Body content\n" {
+		t.Fatalf("unexpected message: %+v", got)
+	}
+}
+
+func TestReadMessageFileRejectsSymlink(t *testing.T) {
+	msg := Message{
+		Header: Header{
+			Schema:  1,
+			ID:      "symlink-message",
+			From:    "codex",
+			To:      []string{"claude"},
+			Created: "2025-01-01T00:00:00Z",
+		},
+		Body: "Body content\n",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.md")
+	if err := os.WriteFile(target, data, 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err = ReadMessageFile(link)
+	if err == nil {
+		t.Fatal("expected symlink message file to be rejected")
+	}
+}
+
+func TestReadHeaderFileRejectsSymlink(t *testing.T) {
+	msg := Message{
+		Header: Header{
+			Schema:  1,
+			ID:      "symlink-header",
+			From:    "codex",
+			To:      []string{"claude"},
+			Created: "2025-01-01T00:00:00Z",
+		},
+		Body: "Body content\n",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.md")
+	if err := os.WriteFile(target, data, 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err = ReadHeaderFile(link)
+	if err == nil {
+		t.Fatal("expected symlink header file to be rejected")
+	}
+}
+
 func TestReadMessageFile_SizeLimit(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "huge.md")

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -61,7 +61,7 @@ func moveInboxMessageToDLQ(root, agent, readDir, envelopeSourceDir, filename, or
 	srcPath := filepath.Join(srcDir, filename)
 
 	// Read original content
-	content, err := os.ReadFile(srcPath)
+	content, err := ReadRegularNoFollow(srcPath)
 	if err != nil {
 		return "", fmt.Errorf("read original: %w", err)
 	}
@@ -145,7 +145,7 @@ func deliverToDLQ(root, agent, filename string, data []byte) (string, error) {
 
 // ReadDLQEnvelope reads and parses a DLQ message.
 func ReadDLQEnvelope(path string) (*DLQEnvelope, []byte, error) {
-	data, err := os.ReadFile(path)
+	data, err := ReadRegularNoFollow(path)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/fsq/dlq_nofollow_unix_test.go
+++ b/internal/fsq/dlq_nofollow_unix_test.go
@@ -1,0 +1,21 @@
+//go:build darwin || linux
+
+package fsq
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestReadDLQEnvelopeRejectsFIFO(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo.md")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	_, _, err := ReadDLQEnvelope(path)
+	if err == nil {
+		t.Fatal("expected FIFO DLQ envelope to be rejected")
+	}
+}

--- a/internal/fsq/dlq_test.go
+++ b/internal/fsq/dlq_test.go
@@ -188,6 +188,46 @@ func TestRetryFromDLQ(t *testing.T) {
 	}
 }
 
+func TestReadDLQEnvelopeRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	dlqPath := createDLQMessage(t, root, "alice", "symlink_source.md", []byte("test content"))
+	link := filepath.Join(AgentDLQNew(root, "alice"), "symlink_dlq.md")
+	if err := os.Symlink(dlqPath, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, _, err := ReadDLQEnvelope(link)
+	if err == nil {
+		t.Fatal("expected symlink DLQ envelope to be rejected")
+	}
+}
+
+func TestMoveCurToDLQRejectsSymlinkSource(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "target.md")
+	if err := os.WriteFile(target, []byte("target content"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(AgentInboxCur(root, "alice"), "symlink_source.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := MoveCurToDLQ(root, "alice", "symlink_source.md", "symlink_source", "parse_error", "test")
+	if err == nil {
+		t.Fatal("expected symlink inbox source to be rejected")
+	}
+	if _, statErr := os.Stat(target); statErr != nil {
+		t.Fatalf("target should remain untouched: %v", statErr)
+	}
+}
+
 func TestRetryFromDLQRejectsTraversalOriginalFile(t *testing.T) {
 	root := t.TempDir()
 	if err := EnsureAgentDirs(root, "alice"); err != nil {

--- a/internal/fsq/regular_file.go
+++ b/internal/fsq/regular_file.go
@@ -1,0 +1,52 @@
+package fsq
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// OpenRegularNoFollow opens path only if it is a regular file and not a symlink.
+func OpenRegularNoFollow(path string) (*os.File, os.FileInfo, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateRegularNoFollowFile(path, info); err != nil {
+		return nil, nil, err
+	}
+
+	file, err := openRegularNoFollow(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("stat queue artifact %s: %w", path, err)
+	}
+	if err := validateRegularNoFollowFile(path, openedInfo); err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	return file, openedInfo, nil
+}
+
+func ReadRegularNoFollow(path string) ([]byte, error) {
+	file, _, err := OpenRegularNoFollow(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	return io.ReadAll(file)
+}
+
+func validateRegularNoFollowFile(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("queue artifact %s must not be a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("queue artifact %s must be a regular file", path)
+	}
+	return nil
+}

--- a/internal/fsq/regular_file_other.go
+++ b/internal/fsq/regular_file_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package fsq
+
+import "os"
+
+func openRegularNoFollow(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/internal/fsq/regular_file_unix.go
+++ b/internal/fsq/regular_file_unix.go
@@ -1,0 +1,12 @@
+//go:build darwin || linux
+
+package fsq
+
+import (
+	"os"
+	"syscall"
+)
+
+func openRegularNoFollow(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0)
+}

--- a/internal/receipt/receipt.go
+++ b/internal/receipt/receipt.go
@@ -98,7 +98,7 @@ func WaitFor(root, msgID, consumer, stage string, timeout, pollInterval time.Dur
 }
 
 func Read(path string) (Receipt, error) {
-	data, err := os.ReadFile(path)
+	data, err := fsq.ReadRegularNoFollow(path)
 	if err != nil {
 		return Receipt{}, err
 	}

--- a/internal/receipt/receipt_nofollow_unix_test.go
+++ b/internal/receipt/receipt_nofollow_unix_test.go
@@ -1,0 +1,21 @@
+//go:build darwin || linux
+
+package receipt
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestReadRejectsFIFO(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo.json")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	_, err := Read(path)
+	if err == nil {
+		t.Fatal("expected FIFO receipt to be rejected")
+	}
+}

--- a/internal/receipt/receipt_test.go
+++ b/internal/receipt/receipt_test.go
@@ -44,6 +44,25 @@ func TestEmitAndRead(t *testing.T) {
 	}
 }
 
+func TestReadRejectsSymlink(t *testing.T) {
+	root := setupTestRoot(t)
+
+	r := New("msg_symlink", "p2p/claude__codex", "claude", "codex", StageDrained, "")
+	if err := Emit(root, r); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	target := filepath.Join(root, "agents", "codex", "receipts", r.filename())
+	link := filepath.Join(root, "agents", "codex", "receipts", "linked.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := Read(link)
+	if err == nil {
+		t.Fatal("expected symlink receipt to be rejected")
+	}
+}
+
 func TestEmitSelfSend(t *testing.T) {
 	root := setupTestRoot(t)
 


### PR DESCRIPTION
## Summary
- add `fsq.OpenRegularNoFollow` / `ReadRegularNoFollow` for AMQ-owned queue artifact reads
- reject symlink and non-regular message, DLQ, receipt, and DLQ source files before parsing or wrapping
- preserve config/plugin/manifest read behavior outside this queue-artifact scope

Refs #181.

## Verification
- RED: symlink read tests failed before implementation because existing reads followed symlink targets
- RED: `TestMoveCurToDLQRejectsSymlinkSource` failed until the raw DLQ source read used the helper
- `go test ./internal/format ./internal/fsq ./internal/receipt`
- `git diff --check`
- `make ci`
- `python3 scripts/check_pr_changelog.py --base-ref origin/main --head-ref HEAD`