### PR TITLE
fix: harden wake metadata writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Wake metadata and readiness writes now reject symlink destinations and use
+  fsynced atomic installs, while live wake identity mismatches stay
+  `unverified` unless the PID is proven not to be `amq wake` (#181).
 - Queue artifact reads now reject symlinks and non-regular files before parsing
   messages, DLQ envelopes, or receipts (#181).
 - Inbox and DLQ queue operations now share canonical `.md` filename validation

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -209,7 +209,7 @@ func TestRunOpsChecksDoesNotAdvertiseRepairForLiveIdentityMismatchLock(t *testin
 				t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
 			}
 			got := result.WakeLocks[0]
-			if got.Status != string(wakeLockStale) || got.Reason != tc.wantReason {
+			if got.Status != string(wakeLockUnverified) || got.Reason != tc.wantReason {
 				t.Fatalf("unexpected wake lock: %#v", got)
 			}
 			if !got.TargetPresent || got.TargetReason != "" {
@@ -284,7 +284,7 @@ func TestRunOpsChecksFixRefusesLiveIdentityMismatchLock(t *testing.T) {
 				t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
 			}
 			got := result.WakeLocks[0]
-			if got.Status != "error" || !strings.Contains(got.Reason, tc.wantReason) || !strings.Contains(got.Reason, "not removable") {
+			if got.Status != string(wakeLockUnverified) || got.Reason != tc.wantReason {
 				t.Fatalf("unexpected wake lock fix result: %#v", got)
 			}
 			if got.Removed {

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -201,12 +201,18 @@ func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
 			return
 		}
 		if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
-			inspection.Status = wakeLockStale
+			inspection.Status = wakeLockUnverified
+			if wakeProcessProvenNotWake(proc) {
+				inspection.Status = wakeLockStale
+			}
 			inspection.Reason = "boot id mismatch"
 			return
 		}
 		if lock.ProcessStart != proc.StartToken {
-			inspection.Status = wakeLockStale
+			inspection.Status = wakeLockUnverified
+			if wakeProcessProvenNotWake(proc) {
+				inspection.Status = wakeLockStale
+			}
 			inspection.Reason = "process start time mismatch"
 			return
 		}

--- a/internal/cli/wake_metadata.go
+++ b/internal/cli/wake_metadata.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 const maxWakeMetadataFileBytes = 64 * 1024
@@ -17,4 +22,95 @@ func readWakeMetadata(file *os.File, label, path string) ([]byte, error) {
 		return nil, fmt.Errorf("%s %s is too large", label, path)
 	}
 	return data, nil
+}
+
+func writeWakeMetadataFile(path string, data []byte, label string) error {
+	dir := filepath.Dir(path)
+	if err := validateWakeMetadataDestination(path, label); err != nil {
+		return err
+	}
+	tmp, file, err := createWakeMetadataTempFile(dir, filepath.Base(path), label)
+	if err != nil {
+		return err
+	}
+	installed := false
+	defer func() {
+		if !installed {
+			_ = os.Remove(tmp)
+		}
+	}()
+
+	if err := writeAllAndSyncWakeMetadata(file, data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write %s temp file: %w", label, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close %s temp file: %w", label, err)
+	}
+	if err := fsq.SyncDir(dir); err != nil {
+		return fmt.Errorf("sync %s directory before install: %w", label, err)
+	}
+	if err := validateWakeMetadataDestination(path, label); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("install %s: %w", label, err)
+	}
+	installed = true
+	if err := fsq.SyncDir(dir); err != nil {
+		return fmt.Errorf("sync %s directory after install: %w", label, err)
+	}
+	return nil
+}
+
+func validateWakeMetadataDestination(path, label string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", label, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s %s must not be a symlink", label, path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s %s must be a regular file", label, path)
+	}
+	return nil
+}
+
+func createWakeMetadataTempFile(dir, base, label string) (string, *os.File, error) {
+	tmpBase := strings.TrimLeft(base, ".")
+	if tmpBase == "" {
+		tmpBase = "wake-metadata"
+	}
+	for attempt := 0; attempt < 1000; attempt++ {
+		tmp := filepath.Join(dir, fmt.Sprintf(".%s.tmp.%d.%d.%d", tmpBase, os.Getpid(), time.Now().UnixNano(), attempt))
+		file, err := openWakeMetadataTempFile(tmp)
+		if err == nil {
+			if err := file.Chmod(0o600); err != nil {
+				_ = file.Close()
+				_ = os.Remove(tmp)
+				return "", nil, fmt.Errorf("chmod %s temp file: %w", label, err)
+			}
+			return tmp, file, nil
+		}
+		if os.IsExist(err) {
+			continue
+		}
+		return "", nil, fmt.Errorf("create %s temp file: %w", label, err)
+	}
+	return "", nil, fmt.Errorf("create %s temp file: too many name collisions", label)
+}
+
+func writeAllAndSyncWakeMetadata(file *os.File, data []byte) error {
+	n, err := file.Write(data)
+	if err != nil {
+		return err
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
+	}
+	return file.Sync()
 }

--- a/internal/cli/wake_metadata_other.go
+++ b/internal/cli/wake_metadata_other.go
@@ -7,3 +7,7 @@ import "os"
 func openWakeMetadataFile(path string) (*os.File, error) {
 	return os.Open(path)
 }
+
+func openWakeMetadataTempFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+}

--- a/internal/cli/wake_metadata_unix.go
+++ b/internal/cli/wake_metadata_unix.go
@@ -10,3 +10,7 @@ import (
 func openWakeMetadataFile(path string) (*os.File, error) {
 	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0)
 }
+
+func openWakeMetadataTempFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0o600)
+}

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 func stubStartWakeFromTarget(t *testing.T, fn wakeRepairStarter) {
@@ -51,6 +53,64 @@ func TestWakeTargetWriteReadRoundTripAndPermissions(t *testing.T) {
 	}
 	if strings.Join(got.InjectArgs, "|") != "exec|target" {
 		t.Fatalf("inject args = %#v", got.InjectArgs)
+	}
+}
+
+func TestWriteWakeTargetRejectsSymlink(t *testing.T) {
+	root := secureTempDirForTest(t)
+	agentBase := fsq.AgentBase(root, "codex")
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		t.Fatalf("mkdir agent base: %v", err)
+	}
+	targetPath := filepath.Join(t.TempDir(), "target.json")
+	if err := os.WriteFile(targetPath, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	if err := os.Symlink(targetPath, wakeTargetPath(root, "codex")); err != nil {
+		t.Fatalf("symlink wake target: %v", err)
+	}
+
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	err := writeWakeTarget(root, "codex", target)
+	if err == nil {
+		t.Fatal("expected wake target symlink rejection")
+	}
+	if got, readErr := os.ReadFile(targetPath); readErr != nil || string(got) != "old\n" {
+		t.Fatalf("symlink target changed: data=%q err=%v", got, readErr)
+	}
+}
+
+func TestWriteWakeTargetSurvivesConcurrentCreate(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	start := make(chan struct{})
+	errs := make(chan error, 8)
+
+	for i := 0; i < cap(errs); i++ {
+		i := i
+		go func() {
+			<-start
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{fmt.Sprintf("exec-%d", i)})
+			errs <- writeWakeTarget(root, "codex", target)
+		}()
+	}
+	close(start)
+	for i := 0; i < cap(errs); i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("writeWakeTarget concurrent writer %d: %v", i, err)
+		}
+	}
+
+	if _, exists, err := readWakeTarget(root, "codex"); err != nil || !exists {
+		t.Fatalf("readWakeTarget after concurrent writes: exists=%v err=%v", exists, err)
+	}
+	tmpMatches, err := filepath.Glob(filepath.Join(fsq.AgentBase(root, "codex"), ".wake.target.tmp.*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(tmpMatches) != 0 {
+		t.Fatalf("temporary wake target files remain: %v", tmpMatches)
 	}
 }
 
@@ -725,8 +785,8 @@ func TestRepairWakeRefusesLiveIdentityMismatchLock(t *testing.T) {
 				t.Fatal("expected repair refusal")
 			}
 			if result.Status != "refused" ||
-				!strings.Contains(result.Reason, tc.wantReason) ||
-				!strings.Contains(result.Reason, "not repairable") {
+				!strings.Contains(result.Reason, "unverified") ||
+				!strings.Contains(err.Error(), tc.wantReason) {
 				t.Fatalf("unexpected result: %#v err=%v", result, err)
 			}
 			if _, statErr := os.Stat(lockPath); statErr != nil {

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -167,22 +167,7 @@ func writeWakeTarget(root, me string, target wakeTarget) error {
 		return fmt.Errorf("marshal wake target: %w", err)
 	}
 	data = append(data, '\n')
-	tmp := filepath.Join(agentBase, fmt.Sprintf(".wake.target.tmp.%d", os.Getpid()))
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return fmt.Errorf("write wake target temp file: %w", err)
-	}
-	if err := os.Chmod(tmp, 0o600); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("chmod wake target temp file: %w", err)
-	}
-	if err := os.Rename(tmp, wakeTargetPath(root, me)); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("install wake target: %w", err)
-	}
-	if err := os.Chmod(wakeTargetPath(root, me), 0o600); err != nil {
-		return fmt.Errorf("chmod wake target: %w", err)
-	}
-	return nil
+	return writeWakeMetadataFile(wakeTargetPath(root, me), data, "wake target")
 }
 
 func removeWakeTarget(root, me string) error {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -832,10 +832,7 @@ func writeWakeReadyFile(path string) error {
 	if path == "" {
 		return nil
 	}
-	if err := os.WriteFile(path, []byte("ready\n"), 0o600); err != nil {
-		return fmt.Errorf("write wake ready file: %w", err)
-	}
-	return nil
+	return writeWakeMetadataFile(path, []byte("ready\n"), "wake ready file")
 }
 
 func parseInterruptKey(raw string) (string, error) {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -823,7 +823,7 @@ func TestAcquireWakeLockSelfHealsPIDReusedByNonAMQ(t *testing.T) {
 	}
 }
 
-func TestAcquireWakeLockRefusesLiveWakeIdentityMismatch(t *testing.T) {
+func TestAcquireWakeLockTreatsLiveWakeIdentityMismatchAsUnverified(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		lock       wakeLock
@@ -881,8 +881,8 @@ func TestAcquireWakeLockRefusesLiveWakeIdentityMismatch(t *testing.T) {
 			if cleanup != nil {
 				defer cleanup()
 			}
-			if err == nil || !strings.Contains(err.Error(), tc.wantReason) || !strings.Contains(err.Error(), "not removable") {
-				t.Fatalf("expected identity-mismatch removal refusal, got %v", err)
+			if err == nil || !strings.Contains(err.Error(), tc.wantReason) || !strings.Contains(err.Error(), "unverified") {
+				t.Fatalf("expected identity-mismatch unverified refusal, got %v", err)
 			}
 			if _, statErr := os.Stat(lockPath); statErr != nil {
 				t.Fatalf("identity-mismatch lock should remain, stat=%v", statErr)
@@ -917,8 +917,8 @@ func TestAcquireWakeLockRefusesStartMismatchWhenExecutableUnavailable(t *testing
 	if cleanup != nil {
 		defer cleanup()
 	}
-	if err == nil || !strings.Contains(err.Error(), "process start time mismatch") || !strings.Contains(err.Error(), "not removable") {
-		t.Fatalf("expected start-token mismatch refusal without executable identity, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "process start time mismatch") || !strings.Contains(err.Error(), "unverified") {
+		t.Fatalf("expected start-token mismatch to be unverified without executable identity, got %v", err)
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
 		t.Fatalf("lock should remain when executable identity is unavailable, stat=%v", statErr)
@@ -1416,6 +1416,26 @@ func TestWaitForWakeReadyAcceptsReadyFileWrittenBeforeExit(t *testing.T) {
 
 	if err := waitForWakeReady(cmd.Process, readyPath, time.Second); err != nil {
 		t.Fatalf("waitForWakeReady should accept ready file written before exit: %v", err)
+	}
+}
+
+func TestWriteWakeReadyFileRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.ready")
+	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	readyPath := filepath.Join(dir, "wake.ready")
+	if err := os.Symlink(target, readyPath); err != nil {
+		t.Fatalf("symlink ready file: %v", err)
+	}
+
+	err := writeWakeReadyFile(readyPath)
+	if err == nil {
+		t.Fatal("expected wake ready symlink rejection")
+	}
+	if got, readErr := os.ReadFile(target); readErr != nil || string(got) != "old\n" {
+		t.Fatalf("symlink target changed: data=%q err=%v", got, readErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- write `.wake.target` and `.wake.ready` through a shared no-follow atomic metadata writer with exclusive temp files and parent directory fsyncs
- reject symlink/non-regular wake metadata destinations before install
- classify live boot-id/start-token wake mismatches as `unverified` unless the PID is proven not to be `amq wake`

Fixes part of #181.

## Tests
- go test ./internal/cli -run 'Test(WriteWakeTargetRejectsSymlink|WriteWakeTargetSurvivesConcurrentCreate|WriteWakeReadyFileRejectsSymlink|AcquireWakeLockTreatsLiveWakeIdentityMismatchAsUnverified|AcquireWakeLockRefusesStartMismatchWhenExecutableUnavailable|RunOpsChecksDoesNotAdvertiseRepairForLiveIdentityMismatchLock|RunOpsChecksFixRefusesLiveIdentityMismatchLock|RepairWakeRefusesLiveIdentityMismatchLock|AcquireWakeLockSelfHealsPIDReusedByNonAMQ)'\n- git diff --check\n- make ci\n\nPeer review: Claude approved via AMQ before commit/push.