### PR TITLE
fix: use atomic replace on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows `WriteFileAtomic` replacement now uses an atomic replace operation
+  instead of deleting the destination before retrying the rename (#181).
 - Wake metadata and readiness writes now reject symlink destinations and use
   fsynced atomic installs, while live wake identity mismatches stay
   `unverified` unless the PID is proven not to be `amq wake` (#181).

--- a/internal/fsq/atomic.go
+++ b/internal/fsq/atomic.go
@@ -23,19 +23,8 @@ func WriteFileAtomic(dir, filename string, data []byte, perm os.FileMode) (strin
 	if err := SyncDir(dir); err != nil {
 		return "", cleanupTemp(tmpPath, err)
 	}
-	if err := os.Rename(tmpPath, finalPath); err != nil {
-		// On Windows, rename to existing file may return access denied instead of ErrExist.
-		// Check if destination exists and retry after removal.
-		if _, statErr := os.Stat(finalPath); statErr == nil {
-			if removeErr := os.Remove(finalPath); removeErr != nil && !os.IsNotExist(removeErr) {
-				return "", cleanupTemp(tmpPath, err)
-			}
-			if err := os.Rename(tmpPath, finalPath); err != nil {
-				return "", cleanupTemp(tmpPath, err)
-			}
-		} else {
-			return "", cleanupTemp(tmpPath, err)
-		}
+	if err := replaceFile(tmpPath, finalPath); err != nil {
+		return "", cleanupTemp(tmpPath, err)
 	}
 	if err := SyncDir(dir); err != nil {
 		return "", err

--- a/internal/fsq/atomic_replace_other.go
+++ b/internal/fsq/atomic_replace_other.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package fsq
+
+import "os"
+
+func replaceFile(tmpPath, finalPath string) error {
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		if _, statErr := os.Stat(finalPath); statErr == nil {
+			if removeErr := os.Remove(finalPath); removeErr != nil && !os.IsNotExist(removeErr) {
+				return err
+			}
+			if err := os.Rename(tmpPath, finalPath); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/fsq/atomic_replace_windows.go
+++ b/internal/fsq/atomic_replace_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package fsq
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func replaceFile(tmpPath, finalPath string) error {
+	from, err := windows.UTF16PtrFromString(tmpPath)
+	if err != nil {
+		return fmt.Errorf("prepare atomic replace source path: %w", err)
+	}
+	to, err := windows.UTF16PtrFromString(finalPath)
+	if err != nil {
+		return fmt.Errorf("prepare atomic replace destination path: %w", err)
+	}
+	flags := uint32(windows.MOVEFILE_REPLACE_EXISTING | windows.MOVEFILE_WRITE_THROUGH)
+	if err := windows.MoveFileEx(from, to, flags); err != nil {
+		return fmt.Errorf("atomic replace %s: %w", finalPath, err)
+	}
+	return nil
+}

--- a/internal/fsq/atomic_replace_windows_test.go
+++ b/internal/fsq/atomic_replace_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package fsq
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceFileWindowsReplacesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	finalPath := filepath.Join(dir, "state.json")
+	tmpPath := filepath.Join(dir, ".state.json.tmp-test")
+	if err := os.WriteFile(finalPath, []byte("old"), 0o600); err != nil {
+		t.Fatalf("write final file: %v", err)
+	}
+	if err := os.WriteFile(tmpPath, []byte("new"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	if err := replaceFile(tmpPath, finalPath); err != nil {
+		t.Fatalf("replaceFile: %v", err)
+	}
+
+	data, err := os.ReadFile(finalPath)
+	if err != nil {
+		t.Fatalf("read final file: %v", err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("final data = %q, want new", data)
+	}
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Fatalf("temp path should be gone, stat err=%v", err)
+	}
+}

--- a/internal/fsq/atomic_test.go
+++ b/internal/fsq/atomic_test.go
@@ -3,6 +3,8 @@ package fsq
 import (
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -45,5 +47,32 @@ func TestWriteAllAndSyncSyncsAfterFullWrite(t *testing.T) {
 	}
 	if writer.syncCalls != 1 {
 		t.Fatalf("Sync called %d times, want 1", writer.syncCalls)
+	}
+}
+
+func TestWriteFileAtomicReplacesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	finalPath, err := WriteFileAtomic(dir, "state.json", []byte("old"), 0o600)
+	if err != nil {
+		t.Fatalf("initial WriteFileAtomic: %v", err)
+	}
+	if _, err := WriteFileAtomic(dir, "state.json", []byte("new"), 0o600); err != nil {
+		t.Fatalf("replacement WriteFileAtomic: %v", err)
+	}
+
+	data, err := os.ReadFile(finalPath)
+	if err != nil {
+		t.Fatalf("read final file: %v", err)
+	}
+	if string(data) != "new" {
+		t.Fatalf("final data = %q, want new", data)
+	}
+	tmpMatches, err := filepath.Glob(filepath.Join(dir, ".state.json.tmp-*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(tmpMatches) != 0 {
+		t.Fatalf("temporary files remain: %v", tmpMatches)
 	}
 }


### PR DESCRIPTION
## Summary
- split `WriteFileAtomic` replacement into platform helpers
- preserve the existing non-Windows rename behavior
- use Windows `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH` to avoid delete-before-rename replacement windows

Fixes part of #181.

## Tests
- go test ./internal/fsq
- GOOS=windows GOARCH=amd64 go test -c ./internal/fsq -o /tmp/amq-fsq-windows.test.exe
- per-package Windows compile-only loop with `GOOS=windows GOARCH=amd64 go test -c` for `go list ./...`
- git diff --check
- go test ./...
- make ci

Peer review: Claude approved via AMQ before commit/push.