### PR TITLE
docs: hide internal wake readiness flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `amq wake --help` now hides internal readiness coordination flags while
+  continuing to parse them for managed wake startup flows (#181).
 - Bump `github.com/coder/websocket` from 1.8.14 to 1.8.15
 - Bump `actions/checkout` from 6.0.3 to 7.0.0
 

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -625,8 +625,18 @@ func usageWithFlags(fs *flag.FlagSet, usage string, notes ...string) func() {
 	}
 }
 
+func usageWithHiddenFlags(fs *flag.FlagSet, usage string, hiddenFlags []string, notes ...string) func() {
+	return func() {
+		writeUsageToWithHiddenFlags(os.Stdout, fs, usage, hiddenFlags, notes...)
+	}
+}
+
 // writeUsageTo renders usage text to the given writer.
 func writeUsageTo(w io.Writer, fs *flag.FlagSet, usage string, notes ...string) {
+	writeUsageToWithHiddenFlags(w, fs, usage, nil, notes...)
+}
+
+func writeUsageToWithHiddenFlags(w io.Writer, fs *flag.FlagSet, usage string, hiddenFlags []string, notes ...string) {
 	_, _ = fmt.Fprintln(w, "Usage:")
 	_, _ = fmt.Fprintln(w, "  "+usage)
 	if len(notes) > 0 {
@@ -637,28 +647,56 @@ func writeUsageTo(w io.Writer, fs *flag.FlagSet, usage string, notes ...string) 
 	}
 	_, _ = fmt.Fprintln(w)
 	// Only print Options header if there are visible flags.
-	if hasFlagDefaults(fs) {
+	flagDefaults := visibleFlagDefaults(fs, hiddenFlags)
+	if flagDefaults != "" {
 		_, _ = fmt.Fprintln(w, "Options:")
-		writeFlagDefaultsTo(w, fs)
+		_, _ = fmt.Fprint(w, flagDefaults)
 	}
 }
 
-func hasFlagDefaults(fs *flag.FlagSet) bool {
+func visibleFlagDefaults(fs *flag.FlagSet, hiddenFlags []string) string {
 	var buf bytes.Buffer
 	fs.SetOutput(&buf)
 	fs.PrintDefaults()
 	fs.SetOutput(io.Discard)
-	return buf.Len() > 0
+	return filterHiddenFlagDefaults(buf.String(), hiddenFlags)
 }
 
-func writeFlagDefaultsTo(w io.Writer, fs *flag.FlagSet) {
-	var buf bytes.Buffer
-	fs.SetOutput(&buf)
-	fs.PrintDefaults()
-	fs.SetOutput(io.Discard)
-	if buf.Len() > 0 {
-		_, _ = fmt.Fprint(w, buf.String())
+func filterHiddenFlagDefaults(defaults string, hiddenFlags []string) string {
+	if defaults == "" || len(hiddenFlags) == 0 {
+		return defaults
 	}
+	hidden := make(map[string]struct{}, len(hiddenFlags))
+	for _, name := range hiddenFlags {
+		hidden[name] = struct{}{}
+	}
+	var out strings.Builder
+	skip := false
+	for _, line := range strings.SplitAfter(defaults, "\n") {
+		trimmed := strings.TrimSuffix(line, "\n")
+		if name, ok := printedFlagName(trimmed); ok {
+			_, skip = hidden[name]
+		}
+		if !skip {
+			out.WriteString(line)
+		}
+	}
+	return out.String()
+}
+
+func printedFlagName(line string) (string, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "-") || strings.HasPrefix(trimmed, "--") {
+		return "", false
+	}
+	name := strings.TrimPrefix(trimmed, "-")
+	if name == "" {
+		return "", false
+	}
+	if idx := strings.IndexAny(name, " \t"); idx >= 0 {
+		name = name[:idx]
+	}
+	return name, true
 }
 
 func confirmPrompt(prompt string) (bool, error) {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -623,7 +623,8 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
 	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
 
-	usage := usageWithFlags(fs, "amq wake --me <agent> [options]",
+	usage := usageWithHiddenFlags(fs, "amq wake --me <agent> [options]",
+		[]string{"ready-file", "accept-existing-wake"},
 		"Background waker: injects terminal notification when messages arrive.",
 		"Run as background job before starting CLI: amq wake --me claude &",
 		"",

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -120,6 +120,23 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	}
 }
 
+func TestRunWakeHelpHidesInternalReadyFlags(t *testing.T) {
+	stdout, _, err := captureWakeRepairOutput(t, func() error {
+		return runWake([]string{"--help"})
+	})
+	if err != nil {
+		t.Fatalf("runWake --help: %v", err)
+	}
+	for _, hidden := range []string{"ready-file", "accept-existing-wake"} {
+		if strings.Contains(stdout, hidden) {
+			t.Fatalf("wake help should hide %s:\n%s", hidden, stdout)
+		}
+	}
+	if !strings.Contains(stdout, "inject-cmd") {
+		t.Fatalf("wake help should keep --inject-cmd visible:\n%s", stdout)
+	}
+}
+
 func TestRunWakeWithLoopWritesInjectViaWakeTarget(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {


### PR DESCRIPTION
## Summary
- hide internal `amq wake` readiness flags from public help output
- keep `--ready-file` and `--accept-existing-wake` registered and parsed for managed startup flows
- leave `--inject-cmd` documented as the power-user transport escape hatch

Fixes part of #181.

## Tests
- go test ./internal/cli -run 'Test(RunWakeHelpHidesInternalReadyFlags|RunWakeWithLoopWritesReadyFileAfterLock|RunWakeWithLoopWritesReadyFileForExistingUsableWake|RunWakeWithLoopRequiresAcceptExistingWakeForExistingLock|RunWakeWithLoopAcceptExistingWakeRejectsMissingTTY)'\n- go test ./internal/cli\n- git diff --check\n- make ci\n\nPeer review: Claude approved via AMQ before commit/push and accepted the recommendation to keep `--inject-cmd` documented.