### PR TITLE
fix: honor no-gitignore in coop exec auto-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicitly skipped by Dependabot, release branch, or `no-changelog`/`docs`/`chore`
   labels (#181).
 - `amq coop init --no-gitignore` skips updating `.gitignore`, for setups that manage ignores globally or elsewhere (closes #172)
+- `amq coop exec --no-gitignore` forwards the gitignore opt-out to auto-init, so the common entry point can skip `.gitignore` changes (closes #179)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ amq upgrade
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--json]
 amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>]
 amq coop init [--root <path>] [--agents <a,b,c>] [--force] [--json]
-amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-wake] [--require-wake] [--wake-inject-via <absolute-executable>] [--wake-inject-arg <arg>...] [-y] <command> [-- <command-flags>]
+amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-gitignore] [--no-wake] [--require-wake] [--wake-inject-via <absolute-executable>] [--wake-inject-arg <arg>...] [-y] <command> [-- <command-flags>]
 amq swarm list [--json]
 amq swarm join --team <name> --me <agent> [--agent-id <id>] [--type codex|external] [--json]
 amq swarm leave --team <name> --agent-id <id> [--json]
@@ -406,7 +406,7 @@ Use `--session` for a different isolated session:
 amq coop exec --session feature-a claude               # Isolated session
 ```
 
-Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments). Use `--require-wake` in managed launchers that should refuse to start an agent unless the wake process starts and acquires its lock.
+Use `--no-gitignore` to opt out of `.gitignore` changes when `coop exec` auto-initializes a project. Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments). Use `--require-wake` in managed launchers that should refuse to start an agent unless the wake process starts and acquires its lock.
 Use `--wake-inject-via /absolute/path/to/injector` plus repeated
 `--wake-inject-arg` values when a launcher has a terminal-specific injector and
 wants later `amq wake repair` to work without restarting the agent TUI. Repair

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ amq coop exec claude -- --dangerously-skip-permissions
 amq coop exec --session feature-a codex
 ```
 
+Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
 Managed launchers can add `--require-wake` to fail instead of launching the agent when the wake watcher cannot start.
 Launchers that use an external injector can add `--wake-inject-via /absolute/path/to/injector`
 and repeated `--wake-inject-arg` values. When that invocation starts a new wake,

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -261,6 +261,44 @@ func TestCoopInitNoGitignore(t *testing.T) {
 	}
 }
 
+func TestCoopExecAutoInitNoGitignore(t *testing.T) {
+	projectDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+		resetAmqrcCache()
+	})
+	resetAmqrcCache()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	const gitignoreBefore = "# keep me\n"
+	if err := os.WriteFile(filepath.Join(projectDir, ".gitignore"), []byte(gitignoreBefore), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	err = runCoopExec([]string{"--no-gitignore", "--no-wake", "-y", "definitely-missing-amq-test-binary"})
+	if err == nil {
+		t.Fatal("expected command lookup error")
+	}
+	if !containsStr(err.Error(), "command not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".amqrc")); err != nil {
+		t.Fatalf(".amqrc should be created by coop exec auto-init: %v", err)
+	}
+	gitignoreAfter, err := os.ReadFile(filepath.Join(projectDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if string(gitignoreAfter) != gitignoreBefore {
+		t.Fatalf(".gitignore changed with coop exec --no-gitignore:\n%s", gitignoreAfter)
+	}
+}
+
 func TestInitExplicitAgentsDoesNotInjectUser(t *testing.T) {
 	root := t.TempDir()
 	_, err := captureEnvStdout(t, func() error {

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -26,6 +26,7 @@ func runCoopExec(args []string) error {
 	sessionFlag := fs.String("session", "", "Session name (shorthand for --root .agent-mail/<name>)")
 	meFlag := fs.String("me", "", "Agent handle (override auto-derivation from command name)")
 	noInitFlag := fs.Bool("no-init", false, "Don't auto-initialize if .amqrc is missing")
+	noGitignoreFlag := fs.Bool("no-gitignore", false, "When auto-initializing, do not modify .gitignore")
 	noWakeFlag := fs.Bool("no-wake", false, "Don't start amq wake in background")
 	requireWakeFlag := fs.Bool("require-wake", false, "Fail if amq wake cannot start and acquire its lock")
 	wakeInjectViaFlag := fs.String("wake-inject-via", "", "Start wake with this absolute --inject-via executable, enabling later amq wake repair")
@@ -151,7 +152,11 @@ func runCoopExec(args []string) error {
 				}
 			}
 
-			if err := runCoopInitInternal(nil, false); err != nil {
+			var initArgs []string
+			if *noGitignoreFlag {
+				initArgs = []string{"--no-gitignore"}
+			}
+			if err := runCoopInitInternal(initArgs, false); err != nil {
 				return fmt.Errorf("init failed: %w", err)
 			}
 

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -93,6 +93,8 @@ amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Terminal 2
 
 Without `--session` or `--root`, `coop exec` defaults to `--session collab`.
 
+Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
+
 ## Statusline (Claude Code)
 
 To show the current AMQ session in your Claude Code status bar, add this snippet to your statusline script (e.g., `~/.claude/statusline.sh`):


### PR DESCRIPTION
## Summary
- add `amq coop exec --no-gitignore` and forward it into full auto-init
- add a regression test proving auto-init leaves an existing `.gitignore` unchanged
- document the flag in README, CLAUDE.md, skill docs, and CHANGELOG.md

## Tests
- `go test ./internal/cli -run 'TestCoop(ExecAutoInitNoGitignore|InitNoGitignore)'`\n- `go test ./...`\n- `make ci`\n\nCloses #179