### PR TITLE
fix: canonicalize wake test temp dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Wake tests now create secure sandboxes under the physical repository path, so
+  symlink-spelled checkouts no longer fail loop/inject-via assertions (closes #193).
 - Windows `WriteFileAtomic` replacement now uses an atomic replace operation
   instead of deleting the destination before retrying the rename (#181).
 - Wake metadata and readiness writes now reject symlink destinations and use

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -23,13 +23,20 @@ func secureTempDirForTest(t *testing.T) string {
 	t.Helper()
 	cwd, err := os.Getwd()
 	if err == nil {
+		if resolved, resolveErr := filepath.EvalSymlinks(cwd); resolveErr == nil {
+			cwd = resolved
+		}
 		dir, mkErr := os.MkdirTemp(cwd, ".amq-secure-test-")
 		if mkErr == nil {
 			t.Cleanup(func() { _ = os.RemoveAll(dir) })
 			return dir
 		}
 	}
-	return t.TempDir()
+	dir := t.TempDir()
+	if resolved, resolveErr := filepath.EvalSymlinks(dir); resolveErr == nil {
+		return resolved
+	}
+	return dir
 }
 
 func mustNewWakeTargetForTest(t *testing.T, root, me, injectVia string, injectArgs []string) wakeTarget {


### PR DESCRIPTION
## Summary
- canonicalize `secureTempDirForTest` temp roots with `filepath.EvalSymlinks`
- keep wake production path hardening unchanged while aligning test fixtures with physical path expectations
- add the #193 changelog entry

## Tests
All verification was run from the symlink-spelled checkout under `/Users/avivsinai/workspace/...`:
- `go test ./internal/cli -run TestRunWakeWithLoop -count=1`
- `go test ./internal/cli -run 'TestRunWakeWithLoop|TestWakeTarget' -count=1`
- `go test ./...`
- `make ci`

Closes #193
