### PR TITLE
fix: isolate smoke git sandboxes from hook env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Wake tests now create secure sandboxes under the physical repository path, so
   symlink-spelled checkouts no longer fail loop/inject-via assertions (closes #193).
+- Smoke-test git sandboxes now ignore hook-provided repository environment, so
+  pre-push checks no longer write synthetic release refs into the caller repo
+  (closes #195).
 - Windows `WriteFileAtomic` replacement now uses an atomic replace operation
   instead of deleting the destination before retrying the rename (#181).
 - Wake metadata and readiness writes now reject symlink destinations and use

--- a/scripts/check_pr_changelog.py
+++ b/scripts/check_pr_changelog.py
@@ -15,6 +15,15 @@ import sys
 CHANGELOG_PATH = "CHANGELOG.md"
 SKIP_LABELS = {"no-changelog", "docs", "chore"}
 DEPENDABOT_ACTORS = {"dependabot", "dependabot[bot]"}
+GIT_REPOSITORY_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_COMMON_DIR",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+)
 
 
 class PRMetadata:
@@ -39,6 +48,13 @@ def load_event(path: pathlib.Path) -> dict:
         return {}
     with path.open() as f:
         return json.load(f)
+
+
+def git_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for name in GIT_REPOSITORY_ENV_VARS:
+        env.pop(name, None)
+    return env
 
 
 def metadata_from_event(event: dict, actor: str = "") -> PRMetadata:
@@ -82,6 +98,7 @@ def git_show(repo: pathlib.Path, ref: str, path: str) -> str:
     return subprocess.check_output(
         ["git", "show", f"{ref}:{path}"],
         cwd=repo,
+        env=git_env(),
         stderr=subprocess.STDOUT,
         text=True,
     )

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 # caller's home root, so an ambient coop session would otherwise make explicit
 # --root sends to the temp queue look like a refused cross-tree send.
 unset AM_ROOT AM_ME AM_BASE_ROOT AMQ_GLOBAL_ROOT 2>/dev/null || true
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
 
 ROOT_DIR="$(mktemp -d)"
 cleanup() {
@@ -130,6 +132,7 @@ if command -v python3 >/dev/null 2>&1; then
   python3 scripts/test_release_changelog.py
   python3 scripts/test_check_pr_changelog.py
   bash scripts/test_release_metadata.sh
+  bash scripts/test_git_env_sanitization.sh
 fi
 
 # --- SessionStart hook test (claude-session-start.sh) ---

--- a/scripts/test_check_pr_changelog.py
+++ b/scripts/test_check_pr_changelog.py
@@ -27,7 +27,12 @@ BASE_CHANGELOG = """# Changelog
 
 
 def run_git(repo: pathlib.Path, *args: str) -> str:
-    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=repo,
+        env=check_pr_changelog.git_env(),
+        text=True,
+    ).strip()
 
 
 def commit(repo: pathlib.Path, message: str) -> str:

--- a/scripts/test_git_env_sanitization.sh
+++ b/scripts/test_git_env_sanitization.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
+
+ROOT="$(git rev-parse --show-toplevel)"
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+new_victim_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name "Git Env Test"
+  printf 'victim\n' >"$repo/README.md"
+  git -C "$repo" add README.md
+  git -C "$repo" commit -qm "victim base"
+}
+
+assert_victim_unchanged() {
+  local repo="$1"
+  local before_sha="$2"
+  local label="$3"
+  local after_sha
+  after_sha="$(git -C "$repo" rev-parse HEAD)"
+  if [[ "$after_sha" != "$before_sha" ]]; then
+    echo "$label changed victim HEAD: $before_sha -> $after_sha"
+    exit 1
+  fi
+  if git -C "$repo" show-ref --verify --quiet refs/heads/docs-change; then
+    echo "$label created docs-change in victim repo"
+    exit 1
+  fi
+  if git -C "$repo" show-ref --verify --quiet refs/heads/release/v9.9.9; then
+    echo "$label created release/v9.9.9 in victim repo"
+    exit 1
+  fi
+  if [[ -n "$(git -C "$repo" status --porcelain)" ]]; then
+    echo "$label dirtied victim repo"
+    git -C "$repo" status --short
+    exit 1
+  fi
+}
+
+release_victim="$TMPDIR/release-victim"
+new_victim_repo "$release_victim"
+release_before="$(git -C "$release_victim" rev-parse HEAD)"
+GIT_DIR="$release_victim/.git" bash "$ROOT/scripts/test_release_metadata.sh" >/dev/null
+assert_victim_unchanged "$release_victim" "$release_before" "test_release_metadata.sh"
+
+changelog_victim="$TMPDIR/changelog-victim"
+new_victim_repo "$changelog_victim"
+changelog_before="$(git -C "$changelog_victim" rev-parse HEAD)"
+GIT_DIR="$changelog_victim/.git" python3 "$ROOT/scripts/test_check_pr_changelog.py" >/dev/null
+assert_victim_unchanged "$changelog_victim" "$changelog_before" "test_check_pr_changelog.py"
+
+printf 'git env sanitization tests ok\n'

--- a/scripts/test_release_metadata.sh
+++ b/scripts/test_release_metadata.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
+
 ROOT="$(git rev-parse --show-toplevel)"
 TMPDIR="$(mktemp -d)"
 cleanup() {


### PR DESCRIPTION
## Summary

- scrub repository-scoped Git environment before smoke-release and changelog sandboxes run
- add a regression smoke check that proves hook-provided `GIT_DIR` cannot mutate the caller repo
- include the new regression in the smoke-test suite

## Verification

- `bash scripts/test_git_env_sanitization.sh`
- `GIT_DIR=$victim/.git bash scripts/test_git_env_sanitization.sh`
- `python3 scripts/test_check_pr_changelog.py`
- `bash scripts/test_release_metadata.sh`
- `make ci`
- `GIT_DIR=$victim/.git make ci` with victim HEAD, refs, and status unchanged
- normal `git push -u origin codex/issue-195-git-env` with hooks enabled; local branch/ref state remained clean

Closes #195
