### PR TITLE
fix: resolve wake inject-via symlinks before validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   install atomically with fsync (#187).
 - Wake identity mismatches now stay `unverified` unless AMQ can prove the
   recorded PID is not an `amq wake` process (#187).
+- `amq wake --inject-via` now accepts symlinked executables, such as
+  Homebrew-installed injectors, by resolving them before validation; validation,
+  persistence, and execution all use the resolved physical path (closes #197).
 - On Windows, atomic file writes now replace existing files atomically instead
   of temporarily deleting the destination during rename retries (#188).
 - Atomic queue-file writes now fail with `io.ErrShortWrite` if the filesystem

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -69,9 +69,11 @@ func runCoopExec(args []string) error {
 		return UsageError("--wake-inject-arg requires --wake-inject-via")
 	}
 	if wakeInjectVia != "" {
-		if err := validateWakeInjectViaPath(wakeInjectVia); err != nil {
+		resolvedWakeInjectVia, err := validateWakeInjectViaPath(wakeInjectVia)
+		if err != nil {
 			return UsageError("--wake-inject-via: %v", err)
 		}
+		wakeInjectVia = resolvedWakeInjectVia
 	}
 
 	remaining := fs.Args()

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -450,7 +450,7 @@ func injectVia(cfg *wakeConfig, text string) error {
 	if executable == "" {
 		return fmt.Errorf("inject-via command is blank")
 	}
-	if err := validateWakeInjectViaPath(executable); err != nil {
+	if err := validateResolvedWakeInjectViaPath(executable); err != nil {
 		return err
 	}
 

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -119,7 +119,7 @@ func TestWakeTargetRejectsWorldWritableInjectVia(t *testing.T) {
 	if err := os.Chmod(injector, 0o777); err != nil {
 		t.Fatalf("chmod injector: %v", err)
 	}
-	err := validateWakeInjectViaPath(injector)
+	_, err := validateWakeInjectViaPath(injector)
 	if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
 		t.Fatalf("expected world-writable rejection, got %v", err)
 	}
@@ -143,22 +143,26 @@ func TestWakeTargetRejectsWorldWritableInjectViaAncestor(t *testing.T) {
 		t.Fatalf("write injector: %v", err)
 	}
 
-	err := validateWakeInjectViaPath(injector)
+	_, err := validateWakeInjectViaPath(injector)
 	if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
 		t.Fatalf("expected writable ancestor rejection, got %v", err)
 	}
 }
 
-func TestWakeTargetRejectsSymlinkInjectVia(t *testing.T) {
+func TestWakeTargetResolvesLeafSymlinkInjectVia(t *testing.T) {
+	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	link := filepath.Join(t.TempDir(), "injector-link")
 	if err := os.Symlink(injector, link); err != nil {
 		t.Fatalf("symlink injector: %v", err)
 	}
 
-	err := validateWakeInjectViaPath(link)
-	if err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
-		t.Fatalf("expected symlink rejection, got %v", err)
+	target := mustNewWakeTargetForTest(t, root, "codex", link, nil)
+	if target.InjectVia != injector {
+		t.Fatalf("target inject_via = %q, want resolved %q", target.InjectVia, injector)
+	}
+	if err := validateWakeTarget(target, root, "codex"); err != nil {
+		t.Fatalf("validateWakeTarget: %v", err)
 	}
 }
 
@@ -207,7 +211,7 @@ func TestWakeTargetResolvesSymlinkedInjectViaParent(t *testing.T) {
 	}
 }
 
-func TestWakeTargetKeepsSymlinkInjectViaForValidationRejection(t *testing.T) {
+func TestWakeTargetResolvesLeafSymlinkInjectViaForValidation(t *testing.T) {
 	base := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	link := filepath.Join(base, "injector-link")
@@ -216,11 +220,64 @@ func TestWakeTargetKeepsSymlinkInjectViaForValidationRejection(t *testing.T) {
 	}
 
 	target := mustNewWakeTargetForTest(t, base, "codex", link, nil)
-	if target.InjectVia != link {
-		t.Fatalf("target inject_via = %q, want unresolved symlink %q", target.InjectVia, link)
+	if target.InjectVia != injector {
+		t.Fatalf("target inject_via = %q, want resolved %q", target.InjectVia, injector)
 	}
-	if err := validateWakeTarget(target, base, "codex"); err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
-		t.Fatalf("expected symlink validation rejection, got %v", err)
+	if err := validateWakeTarget(target, base, "codex"); err != nil {
+		t.Fatalf("validateWakeTarget: %v", err)
+	}
+}
+
+func TestWakeTargetRejectsDanglingSymlinkInjectVia(t *testing.T) {
+	root := secureTempDirForTest(t)
+	link := filepath.Join(root, "injector-link")
+	if err := os.Symlink(filepath.Join(root, "missing-injector"), link); err != nil {
+		t.Fatalf("symlink injector: %v", err)
+	}
+
+	_, err := newWakeTarget(root, "codex", link, nil)
+	if err == nil || !strings.Contains(err.Error(), "resolve inject_via") {
+		t.Fatalf("expected dangling symlink rejection, got %v", err)
+	}
+}
+
+func TestWakeTargetRejectsSymlinkToNonExecutableInjectVia(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := filepath.Join(root, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+	link := filepath.Join(root, "injector-link")
+	if err := os.Symlink(injector, link); err != nil {
+		t.Fatalf("symlink injector: %v", err)
+	}
+
+	_, err := newWakeTarget(root, "codex", link, nil)
+	if err == nil || !strings.Contains(err.Error(), "not executable") {
+		t.Fatalf("expected non-executable resolved target rejection, got %v", err)
+	}
+}
+
+func TestWakeTargetRejectsSymlinkToNonOwnedInjectVia(t *testing.T) {
+	oldCurrent := wakeTargetCurrentUID
+	oldOwner := wakeTargetFileOwnerUID
+	wakeTargetCurrentUID = func() (int, bool) { return 1000, true }
+	wakeTargetFileOwnerUID = func(info os.FileInfo) (int, bool) { return 2000, true }
+	t.Cleanup(func() {
+		wakeTargetCurrentUID = oldCurrent
+		wakeTargetFileOwnerUID = oldOwner
+	})
+
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	link := filepath.Join(root, "injector-link")
+	if err := os.Symlink(injector, link); err != nil {
+		t.Fatalf("symlink injector: %v", err)
+	}
+
+	_, err := newWakeTarget(root, "codex", link, nil)
+	if err == nil || !strings.Contains(err.Error(), "owned by uid 2000") {
+		t.Fatalf("expected owner rejection, got %v", err)
 	}
 }
 
@@ -229,8 +286,8 @@ func TestWakeTargetCreationRejectsMissingInjectVia(t *testing.T) {
 	missing := filepath.Join(root, "missing-injector")
 
 	_, err := newWakeTarget(root, "codex", missing, nil)
-	if err == nil || !strings.Contains(err.Error(), "stat inject_via") {
-		t.Fatalf("expected inject_via stat failure, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "resolve inject_via") {
+		t.Fatalf("expected inject_via resolve failure, got %v", err)
 	}
 }
 
@@ -239,7 +296,7 @@ func TestWakeTargetRejectsGroupWritableInjectVia(t *testing.T) {
 	if err := os.Chmod(injector, 0o775); err != nil {
 		t.Fatalf("chmod injector: %v", err)
 	}
-	err := validateWakeInjectViaPath(injector)
+	_, err := validateWakeInjectViaPath(injector)
 	if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
 		t.Fatalf("expected group-writable rejection, got %v", err)
 	}
@@ -248,7 +305,7 @@ func TestWakeTargetRejectsGroupWritableInjectVia(t *testing.T) {
 func TestWakeTargetRejectsNonRegularInjectVia(t *testing.T) {
 	path := t.TempDir()
 
-	err := validateWakeInjectViaPath(path)
+	_, err := validateWakeInjectViaPath(path)
 	if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
 		t.Fatalf("expected non-regular rejection, got %v", err)
 	}
@@ -265,7 +322,7 @@ func TestWakeTargetRejectsNonOwnedInjectVia(t *testing.T) {
 	})
 
 	injector := writeExecutableForTest(t, "injector")
-	err := validateWakeInjectViaPath(injector)
+	_, err := validateWakeInjectViaPath(injector)
 	if err == nil || !strings.Contains(err.Error(), "owned by uid 2000") {
 		t.Fatalf("expected owner rejection, got %v", err)
 	}

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -59,19 +59,7 @@ func newWakeTarget(root, me, injectVia string, injectArgs []string) (wakeTarget,
 }
 
 func wakeTargetInjectViaPath(path string) (string, error) {
-	trimmed := strings.TrimSpace(path)
-	info, err := os.Lstat(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("stat inject_via: %w", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return trimmed, nil
-	}
-	if resolved, err := filepath.EvalSymlinks(trimmed); err == nil {
-		return resolved, nil
-	} else {
-		return "", fmt.Errorf("resolve inject_via: %w", err)
-	}
+	return validateWakeInjectViaPath(path)
 }
 
 func wakeTargetDigest(target wakeTarget) string {
@@ -190,7 +178,7 @@ func validateWakeTarget(target wakeTarget, root, me string) error {
 	if target.Agent != me {
 		return fmt.Errorf("wake target agent mismatch")
 	}
-	if err := validateWakeInjectViaPath(target.InjectVia); err != nil {
+	if err := validateResolvedWakeInjectViaPath(target.InjectVia); err != nil {
 		return err
 	}
 	for _, arg := range target.InjectArgs {
@@ -248,22 +236,39 @@ func validateWakeOwner(owner wakeOwner) error {
 	return nil
 }
 
-func validateWakeInjectViaPath(path string) error {
-	if strings.TrimSpace(path) == "" {
-		return fmt.Errorf("inject_via must not be blank")
+func validateWakeInjectViaPath(path string) (string, error) {
+	resolvedPath, err := resolveWakeInjectViaPath(path)
+	if err != nil {
+		return "", err
+	}
+	if err := validateResolvedWakeInjectViaTarget(resolvedPath); err != nil {
+		return "", err
+	}
+	return resolvedPath, nil
+}
+
+func resolveWakeInjectViaPath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("inject_via must not be blank")
 	}
 	if strings.ContainsRune(path, 0) {
-		return fmt.Errorf("inject_via contains NUL")
+		return "", fmt.Errorf("inject_via contains NUL")
 	}
-	if !filepath.IsAbs(path) {
-		return fmt.Errorf("inject_via must be an absolute path")
+	if !filepath.IsAbs(trimmed) {
+		return "", fmt.Errorf("inject_via must be an absolute path")
 	}
-	info, err := os.Lstat(path)
+	resolvedPath, err := filepath.EvalSymlinks(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve inject_via: %w", err)
+	}
+	return resolvedPath, nil
+}
+
+func validateResolvedWakeInjectViaTarget(resolvedPath string) error {
+	info, err := os.Stat(resolvedPath)
 	if err != nil {
 		return fmt.Errorf("stat inject_via: %w", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("inject_via must not be a symlink")
 	}
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("inject_via must be a regular file")
@@ -271,14 +276,24 @@ func validateWakeInjectViaPath(path string) error {
 	if info.Mode().Perm()&0o111 == 0 {
 		return fmt.Errorf("inject_via is not executable")
 	}
-	if err := validateWakeTargetPathOwnership("inject_via", path, info); err != nil {
+	if err := validateWakeTargetPathOwnership("inject_via", resolvedPath, info); err != nil {
 		return err
 	}
-	resolvedPath, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return fmt.Errorf("resolve inject_via: %w", err)
-	}
 	if err := validateWakeTargetParentDirs("inject_via", resolvedPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateResolvedWakeInjectViaPath(path string) error {
+	resolvedPath, err := resolveWakeInjectViaPath(path)
+	if err != nil {
+		return err
+	}
+	if resolvedPath != strings.TrimSpace(path) {
+		return fmt.Errorf("inject_via must be a resolved path")
+	}
+	if err := validateResolvedWakeInjectViaTarget(resolvedPath); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -787,7 +787,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 				return fmt.Errorf("clear stale wake target after persist failure: %w", removeErr)
 			}
 		}
-		if err := validateWakeInjectViaPath(injectVia); err != nil {
+		if err := validateResolvedWakeInjectViaPath(injectVia); err != nil {
 			return err
 		}
 	} else if err := removeWakeTarget(root, me); err != nil {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -263,6 +263,55 @@ func TestRunWakeWithLoopExecutesResolvedInjectViaPath(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopPersistsResolvedLeafSymlinkInjectViaPath(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	base := secureTempDirForTest(t)
+	cellarDir := filepath.Join(base, "Cellar", "injector", "1.0.0", "bin")
+	if err := os.MkdirAll(cellarDir, 0o700); err != nil {
+		t.Fatalf("mkdir cellar bin: %v", err)
+	}
+	injector := filepath.Join(cellarDir, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+	binDir := filepath.Join(base, "bin")
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	link := filepath.Join(binDir, "injector")
+	if err := os.Symlink(injector, link); err != nil {
+		t.Fatalf("symlink injector: %v", err)
+	}
+
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", link,
+	}, func(cfg wakeConfig) error {
+		if cfg.injectVia != injector {
+			t.Fatalf("cfg.injectVia = %q, want resolved %q", cfg.injectVia, injector)
+		}
+		target, exists, err := readWakeTarget(root, "orchestrator")
+		if err != nil || !exists {
+			t.Fatalf("readWakeTarget exists=%v err=%v", exists, err)
+		}
+		if target.InjectVia != injector {
+			t.Fatalf("target inject_via = %q, want resolved %q", target.InjectVia, injector)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
 func TestRunWakeWithLoopRejectsUnsafeInjectViaBeforeLoop(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -314,7 +363,7 @@ func TestInjectViaRevalidatesExecutableBeforeExec(t *testing.T) {
 					t.Fatalf("symlink injector: %v", err)
 				}
 			},
-			wantText: "must not be a symlink",
+			wantText: "must be a resolved path",
 		},
 		{
 			name: "nonregular",
@@ -411,7 +460,11 @@ func TestRunWakeWithLoopRejectsInjectorSwappedAfterTargetWrite(t *testing.T) {
 	if err := os.Remove(injector); err != nil {
 		t.Fatalf("remove injector: %v", err)
 	}
-	if err := os.Symlink("/bin/sh", injector); err != nil {
+	nonExecutable := filepath.Join(secureTempDirForTest(t), "non-executable-injector")
+	if err := os.WriteFile(nonExecutable, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
+		t.Fatalf("write non-executable injector: %v", err)
+	}
+	if err := os.Symlink(nonExecutable, injector); err != nil {
 		t.Fatalf("swap injector to symlink: %v", err)
 	}
 
@@ -424,7 +477,7 @@ func TestRunWakeWithLoopRejectsInjectorSwappedAfterTargetWrite(t *testing.T) {
 		t.Fatalf("loop should not run after injector swap: %#v", cfg)
 		return nil
 	})
-	if err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+	if err == nil || !strings.Contains(err.Error(), "not executable") {
 		t.Fatalf("expected swapped injector rejection, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- resolve user-supplied `--inject-via` / `--wake-inject-via` paths before validating and persisting them
- keep stored `.wake.target` and exec-side validation strict so the path that was validated is exactly the path that runs
- add leaf-symlink, dangling-symlink, non-executable-target, wrong-owner-target, and loop persistence coverage

## Verification

- `go test ./internal/cli -run 'TestWakeTarget(ResolvesLeafSymlinkInjectVia|ResolvesLeafSymlinkInjectViaForValidation|RejectsDanglingSymlinkInjectVia|RejectsSymlinkToNonExecutableInjectVia|RejectsSymlinkToNonOwnedInjectVia|CreationRejectsMissingInjectVia|RejectsWorldWritableInjectVia|RejectsWorldWritableInjectViaAncestor|RejectsGroupWritableInjectVia|RejectsNonRegularInjectVia|RejectsNonOwnedInjectVia)|TestRunWakeWithLoop(PersistsResolvedLeafSymlinkInjectViaPath|ExecutesResolvedInjectViaPath|RejectsUnsafeInjectViaBeforeLoop|KeepsOldWakeTargetWhenNewTargetIsUnsafe|RejectsInjectorSwappedAfterTargetWrite)|TestInjectViaRevalidatesExecutableBeforeExec|TestCoopExecWakeInjectViaValidation' -count=1`
- `go test ./internal/cli -run TestRunWakeWithLoop -count=1`
- `go test ./internal/cli -count=1`
- `python3 scripts/test_release_changelog.py`
- `python3 scripts/test_check_pr_changelog.py`
- `make ci`

Closes #197
