### PR TITLE
fix: pin session roots to absolute paths (+ reply --wait-for, who base-root header)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- `amq reply --wait-for <stage> --wait-timeout <duration>` blocks on the
+  recipient's delivery receipt, mirroring `amq send --wait-for`, so reply
+  delivery can be confirmed instead of assumed.
+- `amq who` text output now prints a `Base root:` header naming the tree it is
+  reading, so per-root `active`/`stale` presence is not mistaken for global
+  liveness when the same session name exists in another root (JSON output is
+  unchanged).
+
+### Fixed
+
+- `amq coop exec` now pins the session root to an absolute path before
+  starting wake and exporting `AM_ROOT`/`AM_BASE_ROOT`. A relative root
+  (e.g. from the `.agent-mail` default) re-resolved against every future cwd
+  of the agent process, silently splitting one session name into
+  per-directory mailbox trees across git worktrees — peers on the "same"
+  session could not see each other and sends queued where nobody was reading.
+- `amq env` shell output (plain and `--export`) now emits absolute
+  `AM_ROOT`/`AM_BASE_ROOT` values for the same reason: these exports exist to
+  pin a terminal to one mailbox, and a relative export re-splits per cwd
+  (JSON output is unchanged).
 
 ## [0.40.0] - 2026-07-05
 ### Added

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -188,6 +188,16 @@ func runCoopExec(args []string) error {
 		}
 	}
 
+	// Pin the session root to an absolute path before it reaches the wake
+	// process and the exported AM_ROOT/AM_BASE_ROOT. A relative root
+	// re-resolves against every future cwd of the agent process, silently
+	// splitting one session name into per-directory mailbox trees
+	// (messages land where no peer is reading).
+	root, err = absoluteSessionRoot(root)
+	if err != nil {
+		return fmt.Errorf("resolve absolute session root: %w", err)
+	}
+
 	// Ensure agent mailbox exists.
 	if err := fsq.EnsureAgentDirs(root, agentHandle); err != nil {
 		return fmt.Errorf("failed to ensure mailbox for %s: %w", agentHandle, err)
@@ -273,6 +283,14 @@ func runCoopExec(args []string) error {
 		_ = wakeProc.Kill()
 	}
 	return execErr
+}
+
+// absoluteSessionRoot resolves root against the current working directory at
+// session start. This is the single point where a coop session's mailbox
+// identity is frozen; everything downstream (wake, AM_ROOT, AM_BASE_ROOT)
+// must see an absolute path.
+func absoluteSessionRoot(root string) (string, error) {
+	return filepath.Abs(root)
 }
 
 func buildCoopWakeArgs(agentHandle, root, injectVia string, injectArgs []string) []string {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -158,6 +158,14 @@ func runEnv(args []string) error {
 		return writeJSON(os.Stdout, out)
 	}
 
+	// Shell output pins this terminal to the resolved root, so emit it as an
+	// absolute path: a relative export would re-resolve against every future
+	// cwd, silently splitting one session name across per-directory trees.
+	root, err = filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("resolve absolute root for shell output: %w", err)
+	}
+
 	// Generate shell commands
 	if *exportFlag {
 		baseRoot, sessionName, inSession := classifyEnvRoot(root)
@@ -165,6 +173,11 @@ func runEnv(args []string) error {
 			baseRoot = sessionBaseRoot
 			sessionName = sessionNameOverride
 			inSession = true
+		}
+		if baseRoot != "" {
+			if baseRoot, err = filepath.Abs(baseRoot); err != nil {
+				return fmt.Errorf("resolve absolute base root for shell output: %w", err)
+			}
 		}
 		if err := writeShellExportEnv(root, baseRoot, me, shell, *wakeFlag, inSession); err != nil {
 			return err

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -481,6 +481,11 @@ func TestResolveEnvConfigFlagOverridesEnv(t *testing.T) {
 func TestResolveEnvConfigAutoDetect(t *testing.T) {
 	root := t.TempDir()
 
+	// Isolate from the developer's real global config: a ~/.amqrc or
+	// AMQ_GLOBAL_ROOT on the machine would win over auto-detect.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+
 	// Create .agent-mail directory (no .amqrc)
 	agentMailDir := filepath.Join(root, ".agent-mail")
 	if err := os.MkdirAll(agentMailDir, 0o755); err != nil {
@@ -635,6 +640,11 @@ func TestResolveEnvConfigInvalidAmqrcWithAutoDetect(t *testing.T) {
 
 func TestResolveEnvConfigNoConfig(t *testing.T) {
 	root := t.TempDir()
+
+	// Isolate from the developer's real global config: a ~/.amqrc or
+	// AMQ_GLOBAL_ROOT on the machine would make resolution succeed.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
 
 	oldWd, _ := os.Getwd()
 	defer func() { _ = os.Chdir(oldWd) }()

--- a/internal/cli/reply.go
+++ b/internal/cli/reply.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"github.com/avivsinai/agent-message-queue/internal/presence"
+	"github.com/avivsinai/agent-message-queue/internal/receipt"
 )
 
 func runReply(args []string) error {
@@ -26,12 +28,16 @@ func runReply(args []string) error {
 	kindFlag := fs.String("kind", "", fmt.Sprintf("Message kind: %s (default: same as original, review_response for review_request, answer for question)", format.ValidKindsList()))
 	labelsFlag := fs.String("labels", "", "Comma-separated labels/tags")
 	contextFlag := fs.String("context", "", "JSON context object or @file.json")
+	waitForFlag := fs.String("wait-for", "", "Wait for receipt stage after reply (e.g., drained)")
+	waitTimeoutFlag := fs.Duration("wait-timeout", 120*time.Second, "Timeout for --wait-for")
 
 	usage := usageWithFlags(fs, "amq reply --me <agent> --id <msg_id> [options]",
 		"Reply to a message with automatic thread/refs handling.",
 		"Finds the original message, sets to/thread/refs automatically.",
 		"Cross-session replies are routed via reply_to header.",
-		"To follow up on a sent cross-session message, use amq send --session instead.")
+		"To follow up on a sent cross-session message, use amq send --session instead.",
+		"Use --wait-for drained to block until the recipient ingests the reply,",
+		"mirroring amq send --wait-for.")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
@@ -63,6 +69,13 @@ func runReply(args []string) error {
 	}
 	if !format.IsValidKind(kind) {
 		return UsageError("--kind must be one of: %s", format.ValidKindsList())
+	}
+
+	waitFor := strings.TrimSpace(*waitForFlag)
+	if waitFor != "" {
+		if err := validateStage(waitFor); err != nil {
+			return UsageError("--wait-for: %v", err)
+		}
 	}
 
 	labels := splitList(*labelsFlag)
@@ -308,6 +321,22 @@ func runReply(args []string) error {
 		outboxErr = err
 	}
 
+	// Wait for receipt if requested (mirrors amq send --wait-for).
+	var waitResult *waitForResult
+	var waitErr error
+	if waitFor != "" {
+		r, err := receipt.WaitFor(deliveryRoot, id, recipient, waitFor, *waitTimeoutFlag, 1*time.Second)
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			waitResult = &waitForResult{Event: "timeout", Stage: waitFor, Timeout: waitTimeoutFlag.String()}
+			waitErr = TimeoutError("reply --wait-for %s timed out after %s", waitFor, *waitTimeoutFlag)
+		} else if err != nil {
+			waitResult = &waitForResult{Event: "error", Stage: waitFor, Detail: err.Error()}
+			waitErr = fmt.Errorf("reply --wait-for: %w", err)
+		} else {
+			waitResult = &waitForResult{Event: "matched", Stage: waitFor, Receipt: &r}
+		}
+	}
+
 	// Fix 5: Report target session in reply output (consistent with send).
 	session := sessionName(root)
 	targetDisplay := session
@@ -339,11 +368,34 @@ func runReply(args []string) error {
 			out["source_session"] = session
 			out["target_session"] = targetSession
 		}
-		return writeJSON(os.Stdout, out)
+		if waitResult != nil {
+			out["wait"] = waitResult
+		}
+		if err := writeJSON(os.Stdout, out); err != nil {
+			return err
+		}
+		return waitErr
 	}
 
 	if outboxErr != nil {
 		_ = writeStderr("warning: outbox write failed: %v\n", outboxErr)
+	}
+	if waitResult != nil {
+		switch waitResult.Event {
+		case "matched":
+			if err := writeStdout("Replied %s to %s; %s by %s at %s\n", id, recipient, waitFor, recipient, waitResult.Receipt.EmittedAt); err != nil {
+				return err
+			}
+		case "timeout":
+			if err := writeStdout("Replied %s to %s; timed out waiting %s for %s receipt\n", id, recipient, *waitTimeoutFlag, waitFor); err != nil {
+				return err
+			}
+		default:
+			if err := writeStdout("Replied %s to %s; wait error: %s\n", id, recipient, waitResult.Detail); err != nil {
+				return err
+			}
+		}
+		return waitErr
 	}
 	return writeStdout("Replied %s to %s (session: %s, root: %s)\n", id, recipient, targetDisplay, deliveryRoot)
 }

--- a/internal/cli/roots_absolute_test.go
+++ b/internal/cli/roots_absolute_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/receipt"
+)
+
+func TestAbsoluteSessionRootResolvesRelativeAgainstCwd(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	got, err := absoluteSessionRoot(filepath.Join(".agent-mail", "collab"))
+	if err != nil {
+		t.Fatalf("absoluteSessionRoot: %v", err)
+	}
+	want := filepath.Join(dir, ".agent-mail", "collab")
+	if got != want {
+		t.Fatalf("absoluteSessionRoot = %q, want %q", got, want)
+	}
+}
+
+func TestAbsoluteSessionRootKeepsAbsoluteUnchanged(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), ".agent-mail", "collab")
+	got, err := absoluteSessionRoot(abs)
+	if err != nil {
+		t.Fatalf("absoluteSessionRoot: %v", err)
+	}
+	if got != abs {
+		t.Fatalf("absoluteSessionRoot = %q, want %q unchanged", got, abs)
+	}
+}
+
+func TestEnvShellOutputEmitsAbsoluteRoot(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	relRoot := filepath.Join(".agent-mail", "collab")
+	if err := fsq.EnsureRootDirs(filepath.Join(dir, relRoot)); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	t.Setenv("AM_ROOT", relRoot)
+	t.Setenv("AM_BASE_ROOT", "")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runEnv([]string{"--me", "claude"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+	wantRoot := filepath.Join(dir, relRoot)
+	if !strings.Contains(output, "export AM_ROOT="+wantRoot) &&
+		!strings.Contains(output, "export AM_ROOT='"+wantRoot+"'") {
+		t.Fatalf("shell output should pin absolute AM_ROOT %q, got:\n%s", wantRoot, output)
+	}
+}
+
+func TestEnvExportEmitsAbsoluteRoots(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	relRoot := filepath.Join(".agent-mail", "collab")
+	if err := fsq.EnsureRootDirs(filepath.Join(dir, relRoot)); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	t.Setenv("AM_ROOT", relRoot)
+	t.Setenv("AM_BASE_ROOT", ".agent-mail")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runEnv([]string{"--me", "claude", "--export"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv --export: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		for _, prefix := range []string{"export AM_ROOT=", "export AM_BASE_ROOT="} {
+			if !strings.HasPrefix(line, prefix) {
+				continue
+			}
+			value := strings.Trim(strings.TrimPrefix(line, prefix), "'")
+			if !filepath.IsAbs(value) {
+				t.Fatalf("%s should be absolute, got %q (output:\n%s)", prefix, value, output)
+			}
+		}
+	}
+	if !strings.Contains(output, "export AM_ROOT=") {
+		t.Fatalf("expected AM_ROOT export, got:\n%s", output)
+	}
+}
+
+func TestReplyWaitForDrained(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs: %v", err)
+		}
+	}
+
+	now := time.Now()
+	originalID, _ := format.NewMessageID(now)
+	originalMsg := format.Message{
+		Header: format.Header{
+			Schema:   format.CurrentSchema,
+			ID:       originalID,
+			From:     "bob",
+			To:       []string{"alice"},
+			Thread:   "p2p/alice__bob",
+			Subject:  "Question",
+			Created:  now.UTC().Format(time.RFC3339Nano),
+			Priority: format.PriorityNormal,
+			Kind:     format.KindQuestion,
+		},
+		Body: "ping",
+	}
+	data, _ := originalMsg.Marshal()
+	if _, err := fsq.DeliverToInboxes(root, []string{"alice"}, originalID+".md", data); err != nil {
+		t.Fatalf("DeliverToInboxes: %v", err)
+	}
+
+	// Simulate bob draining the reply: emit a drained receipt once it lands.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			entries, err := os.ReadDir(filepath.Join(root, "agents", "bob", "inbox", "new"))
+			if err == nil && len(entries) == 1 {
+				msgID := strings.TrimSuffix(entries[0].Name(), ".md")
+				r := receipt.New(msgID, "", "alice", "bob", receipt.StageDrained, "")
+				_ = receipt.Emit(root, r)
+				return
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+	}()
+
+	output, err := captureEnvStdout(t, func() error {
+		return runReply([]string{
+			"--me", "alice",
+			"--root", root,
+			"--id", originalID,
+			"--body", "pong",
+			"--wait-for", "drained",
+			"--wait-timeout", "3s",
+			"--json",
+		})
+	})
+	<-done
+	if err != nil {
+		t.Fatalf("runReply --wait-for: %v (output: %s)", err, output)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("parse output: %v\nraw: %s", err, output)
+	}
+	wait, ok := result["wait"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected wait object in result, got %v", result["wait"])
+	}
+	if wait["event"] != "matched" {
+		t.Fatalf("wait.event = %v, want matched (output: %s)", wait["event"], output)
+	}
+}
+
+func TestReplyWaitForRejectsInvalidStage(t *testing.T) {
+	err := runReply([]string{
+		"--me", "alice",
+		"--root", t.TempDir(),
+		"--id", "someid",
+		"--body", "x",
+		"--wait-for", "bogus",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--wait-for") {
+		t.Fatalf("expected --wait-for usage error, got %v", err)
+	}
+}
+
+func TestWhoTextOutputShowsBaseRoot(t *testing.T) {
+	baseRoot := t.TempDir()
+	root := filepath.Join(baseRoot, "collab")
+	if err := fsq.EnsureAgentDirs(root, "claude"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWho([]string{"--root", root})
+	})
+	if err != nil {
+		t.Fatalf("runWho: %v", err)
+	}
+	if !strings.Contains(output, "Base root: ") {
+		t.Fatalf("who text output should include base root header, got:\n%s", output)
+	}
+	if !strings.Contains(output, baseRoot) {
+		t.Fatalf("who text output should name %q, got:\n%s", baseRoot, output)
+	}
+}

--- a/internal/cli/who.go
+++ b/internal/cli/who.go
@@ -116,6 +116,17 @@ func runWho(args []string) error {
 		return writeJSON(os.Stdout, sessions)
 	}
 
+	// Presence in this output is scoped to one base root. Show which tree is
+	// being read so "active/stale" is never mistaken for global liveness when
+	// the same session name exists in another root.
+	displayBase := baseRoot
+	if abs, err := filepath.Abs(baseRoot); err == nil {
+		displayBase = abs
+	}
+	if err := writeStdout("Base root: %s\n", displayBase); err != nil {
+		return err
+	}
+
 	if len(sessions) == 0 {
 		return writeStdoutLine("No sessions found.")
 	}


### PR DESCRIPTION
## Summary

Yesterday I hit a full day of silent message loss between a Claude and a Codex session that were both on "the same" session name. Root cause: `coop exec --session X` resolves to a **relative** `AM_ROOT=.agent-mail/X`, so the physical mailbox re-resolves against each agent's cwd. Two agents in different git worktrees ended up on two disjoint trees with the same session name — presence looked stale from each side, and sends queued where nobody was reading. A `--wait-for drained` receipt timing out was the only visible symptom. (This is the incident behind discussions #202/#203.)

This PR fixes the root cause and adds two small delivery-visibility improvements that came out of the same incident:

- **`coop exec` pins the session root to an absolute path** before starting wake and exporting `AM_ROOT`/`AM_BASE_ROOT`. The session's mailbox identity is frozen at launch instead of drifting with cwd.
- **`amq env` shell output (plain and `--export`) emits absolute roots** — these exports exist to pin a terminal, and a relative export re-splits per cwd. JSON output is unchanged.
- **`amq reply --wait-for <stage> --wait-timeout <d>`** — parity with `amq send --wait-for`, so reply delivery can be confirmed instead of assumed. In the incident, the reply leg was exactly where the split re-appeared.
- **`amq who` text output prints a `Base root:` header** naming the tree it reads, so per-root active/stale presence isn't mistaken for global liveness. JSON output unchanged (kept as a bare array for compat).
- **Test-isolation fix:** `TestResolveEnvConfigAutoDetect` and `TestResolveEnvConfigNoConfig` read the developer's real `~/.amqrc`/`AMQ_GLOBAL_ROOT` and failed on any machine that has one; they now isolate `HOME` and `AMQ_GLOBAL_ROOT`.

## Compatibility

- Sessions launched from a project root behave identically — the same directory is used, just addressed absolutely.
- If anyone relied on a relative `AM_ROOT` deliberately re-resolving per cwd, this changes that; I couldn't find a case where that's desirable rather than a footgun, but happy to gate it behind a flag if you know of one.
- `env --json`, `who --json` unchanged.

## Tests

- New `internal/cli/roots_absolute_test.go`: absolute pinning (relative→abs under a temp cwd, absolute unchanged), env shell/export absolute emission, reply `--wait-for drained` matched-receipt flow (mirrors the send cross-session wait test harness), invalid-stage rejection, who base-root header.
- `go test ./...`: 748 passed, 0 failed — including on a machine with a real `~/.amqrc`, which previously broke the two env tests above.
- `gofmt`/`go vet` clean; I don't have golangci-lint locally, so relying on CI for lint.