### PR TITLE
fix: isolate golangci-lint cache per checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.test
 *.prof
 .amqrc
+.golangci-cache/
 __pycache__/
 
 # AI agent configuration (track only skills for distribution)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `make lint` now uses a checkout-local golangci-lint cache, preventing stale
+  analyzer results from deleted git worktrees from leaking into future lint runs
+  and failing pre-push checks (#199).
 - `amq coop exec` now pins the session root to an absolute path before
   starting wake and exporting `AM_ROOT`/`AM_BASE_ROOT`. A relative root
   (e.g. from the `.agent-mail` default) re-resolved against every future cwd

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+GOLANGCI_LINT_CACHE ?= $(CURDIR)/.golangci-cache
 
 build:
 	go build -ldflags "-X main.version=$(VERSION)" -o amq ./cmd/amq
@@ -20,7 +21,7 @@ vet:
 
 lint:
 	@command -v golangci-lint >/dev/null 2>&1 || { echo "golangci-lint not installed. Install from https://golangci-lint.run/usage/install/"; exit 1; }
-	golangci-lint run
+	GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" golangci-lint run
 
 smoke:
 	./scripts/smoke-test.sh


### PR DESCRIPTION
## Summary

- make `make lint` use a checkout-local `.golangci-cache` by default
- ignore the local cache directory
- document the fix under `CHANGELOG.md` Unreleased

Closes #199.

## Root Cause

`golangci-lint` can replay cached staticcheck findings with absolute paths from a deleted worktree. When later processors such as `generated_file_filter` and `nolint_filter` try to reopen the deleted source file, filtering fails and suppressed SA1019 findings leak into unrelated lint runs.

## Verification

- Reproduced the stale-cache failure with a throwaway worktree and shared temp `GOLANGCI_LINT_CACHE`:
  - first lint in `.codex/worktrees/gcl-cache-repro-*` passed with the two SA1019 findings filtered by `nolint_filter`
  - after deleting that worktree, linting the main checkout with the same cache failed on stale `.codex/worktrees/.../wake_tiocsti_unix.go` paths and `generated_file_filter processor: no such file or directory`
- `make lint` in this branch uses `GOLANGCI_LINT_CACHE="$(CURDIR)/.golangci-cache"` and passed after a disposable worktree was removed
- `make ci`
