### PR TITLE
fix: wait for wake raw input drain before enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `amq wake` raw TIOCSTI injection now waits for the terminal input queue to
+  drain after writing notification text, then injects a single carriage return,
+  preventing Ghostty/Claude Code from intermittently receiving text and Enter
+  in one paste-shaped stdin chunk.
 - `make lint` now uses a checkout-local golangci-lint cache, preventing stale
   analyzer results from deleted git worktrees from leaking into future lint runs
   and failing pre-push checks (#199).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `amq wake` raw TIOCSTI injection now waits for the terminal input queue to
   drain after writing notification text, then injects a single carriage return,
   preventing Ghostty/Claude Code from intermittently receiving text and Enter
-  in one paste-shaped stdin chunk.
+  in one paste-shaped stdin chunk (#208).
 - `make lint` now uses a checkout-local golangci-lint cache, preventing stale
   analyzer results from deleted git worktrees from leaking into future lint runs
   and failing pre-push checks (#199).

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -44,6 +44,15 @@ type wakeConfig struct {
 }
 
 const defaultInjectTimeout = 5 * time.Second
+const (
+	rawInjectDrainTimeout      = 2 * time.Second
+	rawInjectDrainPollInterval = 10 * time.Millisecond
+)
+
+var (
+	tiocstiInject          = func(text string) error { return tiocsti.Inject(text) }
+	waitForRawInputDrained = waitForTTYInputDrain
+)
 
 type wakeMsgInfo struct {
 	from     string
@@ -358,49 +367,11 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		// Raw mode: inject text and CR separately to avoid paste detection.
 		// Ink treats multi-char input as paste, not keypresses. Sending text+CR
 		// as one chunk makes Ink see pasted text, not an Enter keypress.
-		// Solution: inject text, wait, then inject CR as separate single byte.
-		// Double-inject CR with a gap to increase reliability — a single CR
-		// can get swallowed by Ink's input buffer flush in newer versions.
 		injectedText := text
 		if cfg.bell {
 			injectedText = "\a" + injectedText
 		}
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
-		}
-		if err := tiocsti.Inject(injectedText); err != nil {
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: text inject failed: %v\n", err)
-			}
-			injectErr = err
-		} else {
-			// Delay so CR arrives in separate read cycle, detected as keypress.
-			// 50ms allows Ink to finish processing the text bytes before CR lands.
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: text injected OK, sleeping 50ms before CR\n")
-			}
-			time.Sleep(50 * time.Millisecond)
-			if err := tiocsti.Inject("\r"); err != nil {
-				if cfg.debug {
-					_ = writeStderr("amq wake [debug]: first CR inject failed: %v\n", err)
-				}
-				injectErr = err
-			} else {
-				if cfg.debug {
-					_ = writeStderr("amq wake [debug]: first CR injected OK, sleeping 20ms before second CR\n")
-				}
-				// Second CR after a short gap — belt-and-suspenders against
-				// Ink absorbing the first CR during buffer processing.
-				time.Sleep(20 * time.Millisecond)
-				if err := tiocsti.Inject("\r"); err != nil {
-					if cfg.debug {
-						_ = writeStderr("amq wake [debug]: second CR inject failed: %v\n", err)
-					}
-				} else if cfg.debug {
-					_ = writeStderr("amq wake [debug]: second CR injected OK (total inject time ~70ms + text)\n")
-				}
-			}
-		}
+		injectErr = injectRawNotification(cfg, injectedText)
 
 	case "paste":
 		// Paste mode: bracketed paste with delayed CR
@@ -410,12 +381,12 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		if cfg.bell {
 			pasteText = "\a" + pasteText
 		}
-		if err := tiocsti.Inject(pasteText); err != nil {
+		if err := tiocstiInject(pasteText); err != nil {
 			injectErr = err
 		} else {
 			// Small delay to ensure CR lands in separate read cycle
 			time.Sleep(25 * time.Millisecond)
-			injectErr = tiocsti.Inject("\r")
+			injectErr = tiocstiInject("\r")
 		}
 
 	default:
@@ -424,7 +395,7 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		if cfg.bell {
 			injectedText = "\a" + injectedText
 		}
-		injectErr = tiocsti.Inject(injectedText)
+		injectErr = tiocstiInject(injectedText)
 	}
 
 	if injectErr != nil {
@@ -439,6 +410,82 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	}
 
 	return nil
+}
+
+func injectRawNotification(cfg *wakeConfig, injectedText string) error {
+	if cfg.debug {
+		_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
+	}
+	if err := tiocstiInject(injectedText); err != nil {
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: text inject failed: %v\n", err)
+		}
+		return err
+	}
+
+	// The submit CR must arrive in its own read() chunk; otherwise Ink can
+	// treat text+CR as pasted input instead of key.return. Waiting for the
+	// text bytes to drain makes a single later CR safe even if the reader stalls.
+	waited, drained, err := waitForRawInputDrained(rawInjectDrainTimeout, rawInjectDrainPollInterval)
+	if cfg.debug {
+		switch {
+		case err != nil:
+			_ = writeStderr("amq wake [debug]: input drain wait unavailable after %s: %v; injecting CR fallback\n", waited, err)
+		case drained:
+			_ = writeStderr("amq wake [debug]: input queue drained after %s; injecting CR\n", waited)
+		default:
+			_ = writeStderr("amq wake [debug]: input drain timeout after %s; injecting CR fallback\n", waited)
+		}
+	}
+
+	if err := tiocstiInject("\r"); err != nil {
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: CR inject failed: %v\n", err)
+		}
+		return err
+	}
+	if cfg.debug {
+		_ = writeStderr("amq wake [debug]: CR injected OK\n")
+	}
+	return nil
+}
+
+func waitForInputQueueDrain(
+	samplePending func() (int, error),
+	now func() time.Time,
+	sleep func(time.Duration),
+	timeout time.Duration,
+	pollInterval time.Duration,
+) (time.Duration, bool, error) {
+	if pollInterval <= 0 {
+		pollInterval = rawInjectDrainPollInterval
+	}
+
+	start := now()
+	deadline := start.Add(timeout)
+	for {
+		pending, err := samplePending()
+		current := now()
+		elapsed := current.Sub(start)
+		if err != nil {
+			return elapsed, false, err
+		}
+		if pending <= 0 {
+			return elapsed, true, nil
+		}
+		if timeout <= 0 || !current.Before(deadline) {
+			return elapsed, false, nil
+		}
+
+		delay := pollInterval
+		if remaining := deadline.Sub(current); remaining > 0 && remaining < delay {
+			delay = remaining
+		}
+		if delay <= 0 {
+			return elapsed, false, nil
+		}
+		sleep(delay)
+	}
 }
 
 func injectVia(cfg *wakeConfig, text string) error {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -306,6 +307,104 @@ func captureWakeStderr(t *testing.T, fn func()) string {
 	return string(out)
 }
 
+func stubTIOCSTIInject(t *testing.T, fn func(string) error) {
+	t.Helper()
+	old := tiocstiInject
+	tiocstiInject = fn
+	t.Cleanup(func() {
+		tiocstiInject = old
+	})
+}
+
+func stubRawInputDrained(t *testing.T, fn func(time.Duration, time.Duration) (time.Duration, bool, error)) {
+	t.Helper()
+	old := waitForRawInputDrained
+	waitForRawInputDrained = fn
+	t.Cleanup(func() {
+		waitForRawInputDrained = old
+	})
+}
+
+func TestInjectNotificationRawWaitsForInputDrainThenInjectsSingleCR(t *testing.T) {
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+
+	var gotTimeout, gotPoll time.Duration
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		gotTimeout = timeout
+		gotPoll = pollInterval
+		return 30 * time.Millisecond, true, nil
+	})
+
+	cfg := &wakeConfig{injectMode: "raw"}
+	if err := injectNotification(cfg, "AMQ wake", true); err != nil {
+		t.Fatalf("injectNotification: %v", err)
+	}
+
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\r" {
+		t.Fatalf("raw injection sequence = %q, want text then one CR", got)
+	}
+	if gotTimeout != rawInjectDrainTimeout {
+		t.Fatalf("drain timeout = %s, want %s", gotTimeout, rawInjectDrainTimeout)
+	}
+	if gotPoll != rawInjectDrainPollInterval {
+		t.Fatalf("drain poll interval = %s, want %s", gotPoll, rawInjectDrainPollInterval)
+	}
+}
+
+func TestInjectNotificationRawInjectsSingleCROnDrainTimeout(t *testing.T) {
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		return timeout, false, nil
+	})
+
+	cfg := &wakeConfig{injectMode: "raw", debug: true}
+	stderr := captureWakeStderr(t, func() {
+		if err := injectNotification(cfg, "AMQ wake", true); err != nil {
+			t.Fatalf("injectNotification: %v", err)
+		}
+	})
+
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\r" {
+		t.Fatalf("raw injection sequence = %q, want text then one CR", got)
+	}
+	if !strings.Contains(stderr, "input drain timeout") {
+		t.Fatalf("expected drain timeout debug log, got %q", stderr)
+	}
+}
+
+func TestInjectNotificationRawInjectsSingleCROnDrainError(t *testing.T) {
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		return 15 * time.Millisecond, false, errors.New("open /dev/tty: permission denied")
+	})
+
+	cfg := &wakeConfig{injectMode: "raw", debug: true}
+	stderr := captureWakeStderr(t, func() {
+		if err := injectNotification(cfg, "AMQ wake", true); err != nil {
+			t.Fatalf("injectNotification: %v", err)
+		}
+	})
+
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\r" {
+		t.Fatalf("raw injection sequence = %q, want text then one CR", got)
+	}
+	if !strings.Contains(stderr, "input drain wait unavailable") {
+		t.Fatalf("expected drain unavailable debug log, got %q", stderr)
+	}
+}
+
 func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -493,6 +592,88 @@ func TestNotifyNewMessages_InjectViaInterruptFailureDoesNotUpdateCooldown(t *tes
 	}
 	if !cfg.lastInterrupt.IsZero() {
 		t.Fatalf("expected failed interrupt transport to leave cooldown unchanged, got %s", cfg.lastInterrupt)
+	}
+}
+
+func TestWaitForInputQueueDrainReturnsWhenQueueClears(t *testing.T) {
+	samples := []int{3, 1, 0}
+	sampleIndex := 0
+	now := time.Unix(0, 0)
+	var sleeps []time.Duration
+
+	waited, drained, err := waitForInputQueueDrain(
+		func() (int, error) {
+			if sampleIndex >= len(samples) {
+				t.Fatalf("sample called too many times")
+				return 0, nil
+			}
+			pending := samples[sampleIndex]
+			sampleIndex++
+			return pending, nil
+		},
+		func() time.Time {
+			return now
+		},
+		func(delay time.Duration) {
+			sleeps = append(sleeps, delay)
+			now = now.Add(delay)
+		},
+		100*time.Millisecond,
+		10*time.Millisecond,
+	)
+
+	if err != nil {
+		t.Fatalf("waitForInputQueueDrain: %v", err)
+	}
+	if !drained {
+		t.Fatal("expected queue to drain")
+	}
+	if waited != 20*time.Millisecond {
+		t.Fatalf("waited = %s, want 20ms", waited)
+	}
+	if sampleIndex != 3 {
+		t.Fatalf("sample calls = %d, want 3", sampleIndex)
+	}
+	if len(sleeps) != 2 || sleeps[0] != 10*time.Millisecond || sleeps[1] != 10*time.Millisecond {
+		t.Fatalf("sleeps = %v, want [10ms 10ms]", sleeps)
+	}
+}
+
+func TestWaitForInputQueueDrainBoundsSleepByTimeout(t *testing.T) {
+	now := time.Unix(0, 0)
+	sampleCalls := 0
+	var sleeps []time.Duration
+
+	waited, drained, err := waitForInputQueueDrain(
+		func() (int, error) {
+			sampleCalls++
+			return 1, nil
+		},
+		func() time.Time {
+			return now
+		},
+		func(delay time.Duration) {
+			sleeps = append(sleeps, delay)
+			now = now.Add(delay)
+		},
+		25*time.Millisecond,
+		10*time.Millisecond,
+	)
+
+	if err != nil {
+		t.Fatalf("waitForInputQueueDrain: %v", err)
+	}
+	if drained {
+		t.Fatal("expected drain timeout")
+	}
+	if waited != 25*time.Millisecond {
+		t.Fatalf("waited = %s, want 25ms", waited)
+	}
+	if sampleCalls != 4 {
+		t.Fatalf("sample calls = %d, want 4", sampleCalls)
+	}
+	if len(sleeps) != 3 || sleeps[0] != 10*time.Millisecond || sleeps[1] != 10*time.Millisecond || sleeps[2] != 5*time.Millisecond {
+		t.Fatalf("sleeps = %v, want [10ms 10ms 5ms]", sleeps)
 	}
 }
 

--- a/internal/cli/wake_tiocsti_stub.go
+++ b/internal/cli/wake_tiocsti_stub.go
@@ -2,7 +2,10 @@
 
 package cli
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
 // tiocsti provides a stub for non-Unix systems.
 var tiocsti = tiocstiFuncs{}
@@ -25,3 +28,7 @@ func (t tiocstiFuncs) Inject(text string) error {
 }
 
 func waitForTTYInputQuiet(cfg *wakeConfig) {}
+
+func waitForTTYInputDrain(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+	return 0, false, errors.New("TTY input drain unavailable on this platform")
+}

--- a/internal/cli/wake_tiocsti_unix.go
+++ b/internal/cli/wake_tiocsti_unix.go
@@ -131,6 +131,18 @@ func waitForTTYInputQuiet(cfg *wakeConfig) {
 	}
 }
 
+func waitForTTYInputDrain(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+	queueFD, err := unix.Open("/dev/tty", unix.O_RDONLY|unix.O_NOCTTY, 0)
+	if err != nil {
+		return 0, false, err
+	}
+	defer func() { _ = unix.Close(queueFD) }()
+
+	return waitForInputQueueDrain(func() (int, error) {
+		return ttyInputPendingBytes(uintptr(queueFD))
+	}, time.Now, time.Sleep, timeout, pollInterval)
+}
+
 func sampleTTYInputState(queueFD, atimeFD uintptr) (ttyInputState, error) {
 	// TIOCINQ/FIONREAD only sees bytes still buffered by the kernel. Raw-mode
 	// TUIs usually consume keystrokes quickly, so recent tty reads are the more


### PR DESCRIPTION
## Summary
- replace raw wake fixed sleeps/double-CR with a bounded tty input-drain wait and one CR
- add deterministic tests for drained, timeout, and unavailable drain paths
- document the Unreleased fix for Ghostty/Claude Code Enter coalescing

## Tests
- go test ./internal/cli -run 'TestInjectNotificationRaw|TestWaitForInputQueueDrain|TestTTYInputState|TestInputDeferralDelay|TestShouldDeferBeforeInject'\n- go test ./internal/cli\n- go test ./...\n- go vet ./...\n- git diff --check