### PR TITLE
chore(release): v0.41.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-cli",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Agent Message Queue - file-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.41.0] - 2026-07-08
 ### Added
 
 - `amq reply --wait-for <stage> --wait-timeout <duration>` blocks on the
@@ -35,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AM_ROOT`/`AM_BASE_ROOT` values for the same reason: these exports exist to
   pin a terminal to one mailbox, and a relative export re-splits per cwd
   (JSON output is unchanged).
+
 
 ## [0.40.0] - 2026-07-05
 ### Added
@@ -677,7 +680,8 @@ directories are impacted.
 
 - Auto-create `.gitignore` with `agent-mail` directory entry
 
-[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.40.0...HEAD
+[Unreleased]: https://github.com/avivsinai/agent-message-queue/compare/v0.41.0...HEAD
+[0.41.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/avivsinai/agent-message-queue/compare/v0.37.1...v0.38.0

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-cli
-version: 0.40.0
+version: 0.41.0
 description: >-
   Coordinate agents via the AMQ CLI for file-based inter-agent messaging. Use
   this skill whenever you need to send messages to another agent (codex, claude,

--- a/skills/amq-spec/SKILL.md
+++ b/skills/amq-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-spec
-version: 0.40.0
+version: 0.41.0
 description: >-
   Parallel-research-then-converge design workflow between two agents. Use this
   skill when the user wants two agents to independently think through a design


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.41.0`
- aligns skill/plugin metadata to `0.41.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.41.0`, publishes the GitHub/Homebrew release, and then publishes skills to the marketplace