### PR TITLE
fix: hold wake submit CR past TUI paste-burst window and restore rescue CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- `amq wake` raw injection submits again in fast-reading TUIs (codex-tui, busy
+  Claude Code): the v0.41.0 drain-wait completes within microseconds when the
+  TUI is actively reading, so the submit CR landed inside the TUI's paste-burst
+  window and was inserted as a pasted newline instead of pressing Enter. The
+  injector now holds the CR for a 50ms settle delay after the text drains and
+  restores the second rescue CR (a no-op when the first CR already submitted),
+  skipping the rescue only when the first CR is provably still queued.
+
 ### Security
 
 - Bumped the Go toolchain to 1.25.12 to pick up the GO-2026-5856 fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Claude Code): the v0.41.0 drain-wait completes within microseconds when the
   TUI is actively reading, so the submit CR landed inside the TUI's paste-burst
   window and was inserted as a pasted newline instead of pressing Enter. The
-  injector now holds the CR for a 50ms settle delay after the text drains and
-  restores the second rescue CR (a no-op when the first CR already submitted),
+  injector now holds the CR for a 150ms settle delay after the text drains
+  (clearing codex-tui's 120ms Enter-suppress window) and restores the second
+  rescue CR on the same spacing (a no-op when the first CR already submitted),
   skipping the rescue only when the first CR is provably still queued.
 
 ## [0.41.0] - 2026-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- `amq wake` raw injection submits again in fast-reading TUIs (codex-tui, busy
+  Claude Code): the v0.41.0 drain-wait completes within microseconds when the
+  TUI is actively reading, so the submit CR landed inside the TUI's paste-burst
+  window and was inserted as a pasted newline instead of pressing Enter. The
+  injector now holds the CR for a 50ms settle delay after the text drains and
+  restores the second rescue CR (a no-op when the first CR already submitted),
+  skipping the rescue only when the first CR is provably still queued.
 
 ## [0.41.0] - 2026-07-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   second rescue submit on the same spacing (a no-op when the first already
   submitted), skipping the rescue only when the first is provably still queued.
 - `amq wake` submits with the kitty CSI-u Enter encoding (`ESC[13u`) for codex
-  targets: once codex-tui negotiates kitty keyboard enhancement with the
-  terminal (e.g. Ghostty), an injected raw `\r` never submits regardless of
-  delay, while the CSI-u encoding is parsed as Enter by its crossterm parser in
-  both legacy and enhanced modes. Verified end-to-end in Ghostty (enhanced and
-  enhancement-disabled) and tmux, idle and mid-turn; Claude Code targets keep
-  the plain `\r` submit.
+  targets: in the reproduced Ghostty wake path with codex-tui's kitty keyboard
+  enhancement active, an injected raw `\r` did not submit at any tested delay,
+  while CSI-u — parsed as Enter by codex's crossterm in both legacy and
+  enhanced modes — passed enhanced Ghostty, enhancement-disabled Ghostty, and
+  tmux end-to-end, idle and mid-turn. (Both encodings map to Enter in the
+  parser and Ghostty emits a physical Enter as `\r` under codex's flags, so the
+  lower-layer cause is event/timing behavior in the enhanced path, not parser
+  classification.) Claude Code targets keep the plain `\r` submit.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Claude Code): the v0.41.0 drain-wait completes within microseconds when the
   TUI is actively reading, so the submit CR landed inside the TUI's paste-burst
   window and was inserted as a pasted newline instead of pressing Enter. The
-  injector now holds the CR for a 50ms settle delay after the text drains and
-  restores the second rescue CR (a no-op when the first CR already submitted),
+  injector now holds the CR for a 150ms settle delay after the text drains
+  (clearing codex-tui's 120ms Enter-suppress window) and restores the second
+  rescue CR on the same spacing (a no-op when the first CR already submitted),
   skipping the rescue only when the first CR is provably still queued.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Claude Code): the v0.41.0 drain-wait completes within microseconds when the
   TUI is actively reading, so the submit CR landed inside the TUI's paste-burst
   window and was inserted as a pasted newline instead of pressing Enter. The
-  injector now holds the CR for a 150ms settle delay after the text drains
-  (clearing codex-tui's 120ms Enter-suppress window) and restores the second
-  rescue CR on the same spacing (a no-op when the first CR already submitted),
-  skipping the rescue only when the first CR is provably still queued.
+  injector now holds the submit key for a 150ms settle delay after the text
+  drains (clearing codex-tui's 120ms Enter-suppress window) and restores the
+  second rescue submit on the same spacing (a no-op when the first already
+  submitted), skipping the rescue only when the first is provably still queued.
+- `amq wake` submits with the kitty CSI-u Enter encoding (`ESC[13u`) for codex
+  targets: once codex-tui negotiates kitty keyboard enhancement with the
+  terminal (e.g. Ghostty), an injected raw `\r` never submits regardless of
+  delay, while the CSI-u encoding is parsed as Enter by its crossterm parser in
+  both legacy and enhanced modes. Verified end-to-end in Ghostty (enhanced and
+  enhancement-disabled) and tmux, idle and mid-turn; Claude Code targets keep
+  the plain `\r` submit.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+
+- Bumped the Go toolchain to 1.25.12 to pick up the GO-2026-5856 fix
+  (Encrypted Client Hello privacy leak in crypto/tls).
 
 ## [0.41.0] - 2026-07-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   drains (clearing codex-tui's 120ms Enter-suppress window) and restores the
   second rescue submit on the same spacing (a no-op when the first already
   submitted), skipping the rescue only when the first is provably still queued.
-- `amq wake` submits with the kitty CSI-u Enter encoding (`ESC[13u`) for codex
+- `amq wake` injects a single LF prelude before the submit CR for codex
   targets: in the reproduced Ghostty wake path with codex-tui's kitty keyboard
-  enhancement active, an injected raw `\r` did not submit at any tested delay,
-  while CSI-u — parsed as Enter by codex's crossterm in both legacy and
-  enhanced modes — passed enhanced Ghostty, enhancement-disabled Ghostty, and
-  tmux end-to-end, idle and mid-turn. (Both encodings map to Enter in the
-  parser and Ghostty emits a physical Enter as `\r` under codex's flags, so the
-  lower-layer cause is event/timing behavior in the enhanced path, not parser
-  classification.) Claude Code targets keep the plain `\r` submit.
+  enhancement active, a bare `\r` did not submit at any tested delay; the LF
+  routes through codex-tui's Ctrl-J binding, which flushes and clears
+  paste-burst state before the CR lands (the prelude newline is trimmed from
+  the submitted payload). Raw-mode injection deliberately stays single-byte —
+  TIOCSTI delivers one byte per ioctl, so a multi-byte escape sequence (such as
+  the kitty CSI-u Enter) can be split by reader scheduling into a lone ESC,
+  which a TUI parses as the Escape key and cancels an active turn. Claude Code
+  targets keep the plain `\r` submit with no prelude.
 
 ### Security
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/avivsinai/agent-message-queue
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/coder/websocket v1.8.15

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -432,28 +432,24 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	return nil
 }
 
-// kittyEnterSequence is the kitty CSI-u encoding of the Enter key. codex-tui's
-// crossterm parser maps it to KeyCode::Enter unconditionally (parse.rs routes
-// any numbered CSI ending in 'u' to parse_csi_u_encoded_key_code regardless of
-// pushed enhancement flags), so it is accepted in both legacy and
-// kitty-enhanced terminal modes. In the reproduced Ghostty + kitty-enhanced
-// codex-tui wake path, an injected raw \r did not submit at any tested delay
-// while CSI-u did; crossterm parses both encodings as Enter and Ghostty still
-// emits a physical Enter as \r under codex's flags (1|2|4), so the lower-layer
-// cause is event/timing behavior in the enhanced path, not parser
-// classification.
-const kittyEnterSequence = "\x1b[13u"
-
-// rawSubmitKey picks the submit keypress encoding per target TUI. codex-tui
-// gets the kitty CSI-u Enter (accepted in both of its input modes, and the
-// encoding that passed enhanced/legacy Ghostty and tmux e2e); Claude Code's
-// Ink fork keeps plain \r — it parses \r as Enter at any delay, and an
-// unrecognized CSI sequence could render as literal text in its composer.
-func rawSubmitKey(me string) string {
+// rawSubmitPrelude returns the bytes injected between the drained notification
+// text and the settle delay. codex targets get a single LF: codex-tui maps a
+// raw 0x0A to Ctrl-J, whose editor binding routes through handle_input_basic,
+// which flushes and clears any active paste-burst state before inserting a
+// newline (trailing whitespace is trimmed from the submitted payload). In the
+// reproduced Ghostty + kitty-enhanced codex-tui wake path a raw \r alone did
+// not submit at any tested delay; the LF prelude unlocks the later \r submit.
+//
+// Everything injected here must stay single-byte control characters. TIOCSTI
+// delivers one byte per ioctl, so a multi-byte escape sequence (e.g. the kitty
+// CSI-u Enter ESC[13u) can be split by reader scheduling — and a reader that
+// sees a lone ESC parses the Escape key, which cancels an active codex turn
+// and leaves the sequence tail as literal composer text.
+func rawSubmitPrelude(me string) string {
 	if strings.Contains(strings.ToLower(me), "codex") {
-		return kittyEnterSequence
+		return "\n"
 	}
-	return "\r"
+	return ""
 }
 
 func injectRawNotification(cfg *wakeConfig, injectedText string) error {
@@ -466,7 +462,7 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		}
 		return err
 	}
-	submitKey := rawSubmitKey(cfg.me)
+	prelude := rawSubmitPrelude(cfg.me)
 
 	// The submit key must arrive in its own read() chunk; otherwise the TUI can
 	// treat text+Enter as pasted input instead of a keypress. Waiting for the
@@ -484,20 +480,33 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		}
 	}
 
-	// Hold the submit key past the TUI's paste-burst window (see
+	// Prelude (codex: a lone LF) clears the TUI's paste-burst state while the
+	// injected text is fresh; its newline is trimmed from the submitted payload.
+	if prelude != "" {
+		if err := tiocstiInject(prelude); err != nil {
+			if cfg.debug {
+				_ = writeStderr("amq wake [debug]: prelude inject failed: %v\n", err)
+			}
+			return err
+		}
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: prelude injected OK (%q)\n", prelude)
+		}
+	}
+
+	// Hold the submit CR past the TUI's paste-burst window (see
 	// rawInjectSettleDelay) so it is classified as a real Enter keypress, not a
-	// pasted newline. The suppress window applies regardless of the Enter
-	// encoding — CSI-u Enter inside the window is swallowed too.
+	// pasted newline.
 	rawInjectSleep(rawInjectSettleDelay)
 
-	if err := tiocstiInject(submitKey); err != nil {
+	if err := tiocstiInject("\r"); err != nil {
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: submit key inject failed: %v\n", err)
 		}
 		return err
 	}
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: submit key injected OK (%q)\n", submitKey)
+		_ = writeStderr("amq wake [debug]: submit key injected OK\n")
 	}
 
 	// Rescue submit: if the first Enter was swallowed anyway (input buffer
@@ -516,7 +525,7 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		return nil
 	}
 	rawInjectSleep(rawInjectSettleDelay)
-	if err := tiocstiInject(submitKey); err != nil {
+	if err := tiocstiInject("\r"); err != nil {
 		// The text and first submit key were already delivered; the rescue is
 		// best-effort.
 		if cfg.debug {

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -54,8 +54,14 @@ const (
 	// drained. A drained queue only proves the TUI read the bytes, not that its
 	// paste-burst window expired: fast readers (codex-tui) consume injected
 	// bytes within microseconds, and a CR landing inside the burst window is
-	// inserted as a pasted newline instead of submitting.
-	rawInjectSettleDelay = 50 * time.Millisecond
+	// inserted as a pasted newline instead of submitting. codex-tui suppresses
+	// Enter for PASTE_ENTER_SUPPRESS_WINDOW = 120ms after the last burst char
+	// (codex-rs/tui/src/bottom_pane/paste_burst.rs, rust-v0.144.1 and main),
+	// and a suppressed Enter RE-EXTENDS the window by another 120ms, so both
+	// the settle and the rescue spacing must exceed 120ms. Claude Code's Ink
+	// fork has no timing heuristic (bracketed-paste markers only) and accepts
+	// any delay. Re-check the upstream constant if codex-tui changes.
+	rawInjectSettleDelay = 150 * time.Millisecond
 )
 
 var (
@@ -465,9 +471,12 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 
 	// Rescue CR: if the first CR was swallowed anyway (input buffer flush or a
 	// burst-window race), a repeat Enter submits the composer; if the first CR
-	// already submitted, Enter on an empty composer is a no-op. Skip the rescue
-	// only when the first CR is provably still queued — a second CR would
-	// coalesce with it into a pasted "\r\r" chunk and both would be swallowed.
+	// already submitted, Enter on an empty composer is a no-op. The rescue must
+	// be spaced a full settle delay after the first CR: a swallowed Enter
+	// re-extends codex-tui's 120ms suppress window, so a faster rescue would be
+	// swallowed too. Skip the rescue only when the first CR is provably still
+	// queued — a second CR would coalesce with it into a pasted "\r\r" chunk
+	// and both would be swallowed.
 	crWaited, crDrained, crErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
 	if crErr == nil && !crDrained {
 		if cfg.debug {

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -50,18 +50,22 @@ const (
 	// rawInjectCRDrainTimeout bounds the wait for the submit CR itself to be
 	// consumed before deciding whether the second rescue CR is safe to send.
 	rawInjectCRDrainTimeout = 1 * time.Second
+	// codexTUIEnterSuppressWindow mirrors codex-tui's
+	// PASTE_ENTER_SUPPRESS_WINDOW (codex-rs/tui/src/bottom_pane/paste_burst.rs,
+	// verified at rust-v0.144.1 and main): an Enter arriving within this window
+	// after the last rapid-input char is inserted as a pasted newline instead
+	// of submitting, and RE-EXTENDS the window by the same amount. Re-pin this
+	// value if upstream codex-tui changes.
+	codexTUIEnterSuppressWindow = 120 * time.Millisecond
 	// rawInjectSettleDelay holds the submit CR after the notification text has
 	// drained. A drained queue only proves the TUI read the bytes, not that its
 	// paste-burst window expired: fast readers (codex-tui) consume injected
-	// bytes within microseconds, and a CR landing inside the burst window is
-	// inserted as a pasted newline instead of submitting. codex-tui suppresses
-	// Enter for PASTE_ENTER_SUPPRESS_WINDOW = 120ms after the last burst char
-	// (codex-rs/tui/src/bottom_pane/paste_burst.rs, rust-v0.144.1 and main),
-	// and a suppressed Enter RE-EXTENDS the window by another 120ms, so both
-	// the settle and the rescue spacing must exceed 120ms. Claude Code's Ink
-	// fork has no timing heuristic (bracketed-paste markers only) and accepts
-	// any delay. Re-check the upstream constant if codex-tui changes.
-	rawInjectSettleDelay = 150 * time.Millisecond
+	// bytes within microseconds, and a CR landing inside the suppress window is
+	// swallowed. The settle must clear the window with margin for scheduler and
+	// timer jitter; the rescue CR uses the same spacing because a swallowed
+	// Enter re-extends the window. Claude Code's Ink fork has no timing
+	// heuristic (bracketed-paste markers only) and accepts any delay.
+	rawInjectSettleDelay = codexTUIEnterSuppressWindow + 30*time.Millisecond
 )
 
 var (

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -47,11 +47,21 @@ const defaultInjectTimeout = 5 * time.Second
 const (
 	rawInjectDrainTimeout      = 2 * time.Second
 	rawInjectDrainPollInterval = 10 * time.Millisecond
+	// rawInjectCRDrainTimeout bounds the wait for the submit CR itself to be
+	// consumed before deciding whether the second rescue CR is safe to send.
+	rawInjectCRDrainTimeout = 1 * time.Second
+	// rawInjectSettleDelay holds the submit CR after the notification text has
+	// drained. A drained queue only proves the TUI read the bytes, not that its
+	// paste-burst window expired: fast readers (codex-tui) consume injected
+	// bytes within microseconds, and a CR landing inside the burst window is
+	// inserted as a pasted newline instead of submitting.
+	rawInjectSettleDelay = 50 * time.Millisecond
 )
 
 var (
 	tiocstiInject          = func(text string) error { return tiocsti.Inject(text) }
 	waitForRawInputDrained = waitForTTYInputDrain
+	rawInjectSleep         = time.Sleep
 )
 
 type wakeMsgInfo struct {
@@ -425,18 +435,23 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 
 	// The submit CR must arrive in its own read() chunk; otherwise Ink can
 	// treat text+CR as pasted input instead of key.return. Waiting for the
-	// text bytes to drain makes a single later CR safe even if the reader stalls.
+	// text bytes to drain keeps the CR out of a paste-shaped chunk even when
+	// the reader stalls (#208).
 	waited, drained, err := waitForRawInputDrained(rawInjectDrainTimeout, rawInjectDrainPollInterval)
 	if cfg.debug {
 		switch {
 		case err != nil:
-			_ = writeStderr("amq wake [debug]: input drain wait unavailable after %s: %v; injecting CR fallback\n", waited, err)
+			_ = writeStderr("amq wake [debug]: input drain wait unavailable after %s: %v; continuing on timing alone\n", waited, err)
 		case drained:
-			_ = writeStderr("amq wake [debug]: input queue drained after %s; injecting CR\n", waited)
+			_ = writeStderr("amq wake [debug]: input queue drained after %s\n", waited)
 		default:
-			_ = writeStderr("amq wake [debug]: input drain timeout after %s; injecting CR fallback\n", waited)
+			_ = writeStderr("amq wake [debug]: input drain timeout after %s; injecting CR anyway\n", waited)
 		}
 	}
+
+	// Hold the CR past the TUI's paste-burst window (see rawInjectSettleDelay)
+	// so it is classified as a real Enter keypress, not a pasted newline.
+	rawInjectSleep(rawInjectSettleDelay)
 
 	if err := tiocstiInject("\r"); err != nil {
 		if cfg.debug {
@@ -446,6 +461,30 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 	}
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: CR injected OK\n")
+	}
+
+	// Rescue CR: if the first CR was swallowed anyway (input buffer flush or a
+	// burst-window race), a repeat Enter submits the composer; if the first CR
+	// already submitted, Enter on an empty composer is a no-op. Skip the rescue
+	// only when the first CR is provably still queued — a second CR would
+	// coalesce with it into a pasted "\r\r" chunk and both would be swallowed.
+	crWaited, crDrained, crErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
+	if crErr == nil && !crDrained {
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: CR still queued after %s; skipping second CR\n", crWaited)
+		}
+		return nil
+	}
+	rawInjectSleep(rawInjectSettleDelay)
+	if err := tiocstiInject("\r"); err != nil {
+		// The text and first CR were already delivered; the rescue is best-effort.
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: second CR inject failed: %v\n", err)
+		}
+		return nil
+	}
+	if cfg.debug {
+		_ = writeStderr("amq wake [debug]: second CR injected OK\n")
 	}
 	return nil
 }

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -432,6 +432,25 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	return nil
 }
 
+// kittyEnterSequence is the kitty CSI-u encoding of the Enter key. codex-tui's
+// crossterm parser maps it to KeyCode::Enter unconditionally (parse.rs routes
+// any numbered CSI ending in 'u' to parse_csi_u_encoded_key_code regardless of
+// pushed enhancement flags), so it submits in both legacy and kitty-enhanced
+// terminal modes. Empirically a raw \r never submits once codex-tui negotiates
+// kitty keyboard enhancement with the terminal (Ghostty), while CSI-u does.
+const kittyEnterSequence = "\x1b[13u"
+
+// rawSubmitKey picks the submit keypress encoding per target TUI. codex-tui
+// gets the kitty CSI-u Enter (works in both of its input modes); Claude Code's
+// Ink fork keeps plain \r — it parses \r as Enter at any delay, and an
+// unrecognized CSI sequence could render as literal text in its composer.
+func rawSubmitKey(me string) string {
+	if strings.Contains(strings.ToLower(me), "codex") {
+		return kittyEnterSequence
+	}
+	return "\r"
+}
+
 func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
@@ -442,11 +461,12 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		}
 		return err
 	}
+	submitKey := rawSubmitKey(cfg.me)
 
-	// The submit CR must arrive in its own read() chunk; otherwise Ink can
-	// treat text+CR as pasted input instead of key.return. Waiting for the
-	// text bytes to drain keeps the CR out of a paste-shaped chunk even when
-	// the reader stalls (#208).
+	// The submit key must arrive in its own read() chunk; otherwise the TUI can
+	// treat text+Enter as pasted input instead of a keypress. Waiting for the
+	// text bytes to drain keeps the submit key out of a paste-shaped chunk even
+	// when the reader stalls (#208).
 	waited, drained, err := waitForRawInputDrained(rawInjectDrainTimeout, rawInjectDrainPollInterval)
 	if cfg.debug {
 		switch {
@@ -455,49 +475,52 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		case drained:
 			_ = writeStderr("amq wake [debug]: input queue drained after %s\n", waited)
 		default:
-			_ = writeStderr("amq wake [debug]: input drain timeout after %s; injecting CR anyway\n", waited)
+			_ = writeStderr("amq wake [debug]: input drain timeout after %s; injecting submit key anyway\n", waited)
 		}
 	}
 
-	// Hold the CR past the TUI's paste-burst window (see rawInjectSettleDelay)
-	// so it is classified as a real Enter keypress, not a pasted newline.
+	// Hold the submit key past the TUI's paste-burst window (see
+	// rawInjectSettleDelay) so it is classified as a real Enter keypress, not a
+	// pasted newline. The suppress window applies regardless of the Enter
+	// encoding — CSI-u Enter inside the window is swallowed too.
 	rawInjectSleep(rawInjectSettleDelay)
 
-	if err := tiocstiInject("\r"); err != nil {
+	if err := tiocstiInject(submitKey); err != nil {
 		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: CR inject failed: %v\n", err)
+			_ = writeStderr("amq wake [debug]: submit key inject failed: %v\n", err)
 		}
 		return err
 	}
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: CR injected OK\n")
+		_ = writeStderr("amq wake [debug]: submit key injected OK (%q)\n", submitKey)
 	}
 
-	// Rescue CR: if the first CR was swallowed anyway (input buffer flush or a
-	// burst-window race), a repeat Enter submits the composer; if the first CR
-	// already submitted, Enter on an empty composer is a no-op. The rescue must
-	// be spaced a full settle delay after the first CR: a swallowed Enter
-	// re-extends codex-tui's 120ms suppress window, so a faster rescue would be
-	// swallowed too. Skip the rescue only when the first CR is provably still
-	// queued — a second CR would coalesce with it into a pasted "\r\r" chunk
-	// and both would be swallowed.
+	// Rescue submit: if the first Enter was swallowed anyway (input buffer
+	// flush or a burst-window race), a repeat Enter submits the composer; if
+	// the first already submitted, Enter on an empty composer is a no-op. The
+	// rescue must be spaced a full settle delay after the first: a swallowed
+	// Enter re-extends codex-tui's 120ms suppress window, so a faster rescue
+	// would be swallowed too. Skip the rescue only when the first submit key is
+	// provably still queued — a second would coalesce with it into one
+	// paste-shaped chunk and both would be swallowed.
 	crWaited, crDrained, crErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
 	if crErr == nil && !crDrained {
 		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: CR still queued after %s; skipping second CR\n", crWaited)
+			_ = writeStderr("amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", crWaited)
 		}
 		return nil
 	}
 	rawInjectSleep(rawInjectSettleDelay)
-	if err := tiocstiInject("\r"); err != nil {
-		// The text and first CR were already delivered; the rescue is best-effort.
+	if err := tiocstiInject(submitKey); err != nil {
+		// The text and first submit key were already delivered; the rescue is
+		// best-effort.
 		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: second CR inject failed: %v\n", err)
+			_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
 		}
 		return nil
 	}
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: second CR injected OK\n")
+		_ = writeStderr("amq wake [debug]: rescue submit injected OK\n")
 	}
 	return nil
 }

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -435,13 +435,18 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 // kittyEnterSequence is the kitty CSI-u encoding of the Enter key. codex-tui's
 // crossterm parser maps it to KeyCode::Enter unconditionally (parse.rs routes
 // any numbered CSI ending in 'u' to parse_csi_u_encoded_key_code regardless of
-// pushed enhancement flags), so it submits in both legacy and kitty-enhanced
-// terminal modes. Empirically a raw \r never submits once codex-tui negotiates
-// kitty keyboard enhancement with the terminal (Ghostty), while CSI-u does.
+// pushed enhancement flags), so it is accepted in both legacy and
+// kitty-enhanced terminal modes. In the reproduced Ghostty + kitty-enhanced
+// codex-tui wake path, an injected raw \r did not submit at any tested delay
+// while CSI-u did; crossterm parses both encodings as Enter and Ghostty still
+// emits a physical Enter as \r under codex's flags (1|2|4), so the lower-layer
+// cause is event/timing behavior in the enhanced path, not parser
+// classification.
 const kittyEnterSequence = "\x1b[13u"
 
 // rawSubmitKey picks the submit keypress encoding per target TUI. codex-tui
-// gets the kitty CSI-u Enter (works in both of its input modes); Claude Code's
+// gets the kitty CSI-u Enter (accepted in both of its input modes, and the
+// encoding that passed enhanced/legacy Ghostty and tmux e2e); Claude Code's
 // Ink fork keeps plain \r — it parses \r as Enter at any delay, and an
 // unrecognized CSI sequence could render as literal text in its composer.
 func rawSubmitKey(me string) string {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -387,6 +387,55 @@ func TestInjectNotificationRawDrainsSettlesThenInjectsCRWithRescue(t *testing.T)
 }
 
 func TestInjectNotificationRawSkipsRescueCRWhenFirstCRStillQueued(t *testing.T) {
+	// Models the stated skip branch precisely: the notification text drains
+	// normally, then the first CR is still queued at the CR-drain deadline.
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+	var drainCalls [][2]time.Duration
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		drainCalls = append(drainCalls, [2]time.Duration{timeout, pollInterval})
+		if len(drainCalls) == 1 {
+			return 5 * time.Millisecond, true, nil // text consumed by the TUI
+		}
+		return timeout, false, nil // first CR still in the kernel queue
+	})
+	slept := stubRawInjectSleep(t)
+
+	cfg := &wakeConfig{injectMode: "raw", debug: true}
+	stderr := captureWakeStderr(t, func() {
+		if err := injectNotification(cfg, "AMQ wake", true); err != nil {
+			t.Fatalf("injectNotification: %v", err)
+		}
+	})
+
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\r" {
+		t.Fatalf("raw injection sequence = %q, want text then one CR", got)
+	}
+	wantDrains := [][2]time.Duration{
+		{rawInjectDrainTimeout, rawInjectDrainPollInterval},
+		{rawInjectCRDrainTimeout, rawInjectDrainPollInterval},
+	}
+	if len(drainCalls) != len(wantDrains) || drainCalls[0] != wantDrains[0] || drainCalls[1] != wantDrains[1] {
+		t.Fatalf("drain calls = %v, want %v", drainCalls, wantDrains)
+	}
+	if !strings.Contains(stderr, "input queue drained") {
+		t.Fatalf("expected text drain debug log, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "skipping second CR") {
+		t.Fatalf("expected rescue skip debug log, got %q", stderr)
+	}
+	if len(*slept) != 1 || (*slept)[0] != rawInjectSettleDelay {
+		t.Fatalf("settle sleeps = %v, want one of %s", *slept, rawInjectSettleDelay)
+	}
+}
+
+func TestInjectNotificationRawSkipsRescueCROnTotalReaderStall(t *testing.T) {
+	// Degraded branch: the reader is fully stalled — the text drain times out,
+	// the CR is injected anyway, and the rescue is skipped because the CR is
+	// provably still queued behind the unread text.
 	var injected []string
 	stubTIOCSTIInject(t, func(text string) error {
 		injected = append(injected, text)

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -352,6 +352,51 @@ func TestRawInjectSettleDelayClearsCodexEnterSuppressWindow(t *testing.T) {
 	}
 }
 
+func TestRawSubmitKeyPicksEncodingByTarget(t *testing.T) {
+	cases := []struct {
+		me   string
+		want string
+	}{
+		{"codex", kittyEnterSequence},
+		{"codex-test", kittyEnterSequence},
+		{"my-codex-2", kittyEnterSequence},
+		{"claude", "\r"},
+		{"claude-test", "\r"},
+		{"", "\r"},
+	}
+	for _, c := range cases {
+		if got := rawSubmitKey(c.me); got != c.want {
+			t.Fatalf("rawSubmitKey(%q) = %q, want %q", c.me, got, c.want)
+		}
+	}
+}
+
+func TestInjectNotificationRawUsesKittyEnterForCodex(t *testing.T) {
+	// codex-tui never submits on a raw \r once it negotiates kitty keyboard
+	// enhancement with the terminal (Ghostty); the CSI-u Enter encoding is
+	// parsed as Enter by its crossterm parser in both legacy and enhanced
+	// modes, so codex targets get CSI-u for the primary and rescue submit.
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		return time.Millisecond, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	cfg := &wakeConfig{injectMode: "raw", me: "codex"}
+	if err := injectNotification(cfg, "AMQ wake", true); err != nil {
+		t.Fatalf("injectNotification: %v", err)
+	}
+
+	want := "AMQ wake|" + kittyEnterSequence + "|" + kittyEnterSequence
+	if got := strings.Join(injected, "|"); got != want {
+		t.Fatalf("raw injection sequence = %q, want %q", got, want)
+	}
+}
+
 func TestInjectNotificationRawDrainsSettlesThenInjectsCRWithRescue(t *testing.T) {
 	var injected []string
 	stubTIOCSTIInject(t, func(text string) error {
@@ -424,7 +469,7 @@ func TestInjectNotificationRawSkipsRescueCRWhenFirstCRStillQueued(t *testing.T) 
 	if !strings.Contains(stderr, "input queue drained") {
 		t.Fatalf("expected text drain debug log, got %q", stderr)
 	}
-	if !strings.Contains(stderr, "skipping second CR") {
+	if !strings.Contains(stderr, "skipping rescue submit") {
 		t.Fatalf("expected rescue skip debug log, got %q", stderr)
 	}
 	if len(*slept) != 1 || (*slept)[0] != rawInjectSettleDelay {
@@ -459,7 +504,7 @@ func TestInjectNotificationRawSkipsRescueCROnTotalReaderStall(t *testing.T) {
 	if !strings.Contains(stderr, "input drain timeout") {
 		t.Fatalf("expected drain timeout debug log, got %q", stderr)
 	}
-	if !strings.Contains(stderr, "skipping second CR") {
+	if !strings.Contains(stderr, "skipping rescue submit") {
 		t.Fatalf("expected rescue skip debug log, got %q", stderr)
 	}
 	if len(*slept) != 1 || (*slept)[0] != rawInjectSettleDelay {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -325,37 +325,54 @@ func stubRawInputDrained(t *testing.T, fn func(time.Duration, time.Duration) (ti
 	})
 }
 
-func TestInjectNotificationRawWaitsForInputDrainThenInjectsSingleCR(t *testing.T) {
+func stubRawInjectSleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+	var slept []time.Duration
+	old := rawInjectSleep
+	rawInjectSleep = func(d time.Duration) {
+		slept = append(slept, d)
+	}
+	t.Cleanup(func() {
+		rawInjectSleep = old
+	})
+	return &slept
+}
+
+func TestInjectNotificationRawDrainsSettlesThenInjectsCRWithRescue(t *testing.T) {
 	var injected []string
 	stubTIOCSTIInject(t, func(text string) error {
 		injected = append(injected, text)
 		return nil
 	})
 
-	var gotTimeout, gotPoll time.Duration
+	var drainCalls [][2]time.Duration
 	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
-		gotTimeout = timeout
-		gotPoll = pollInterval
+		drainCalls = append(drainCalls, [2]time.Duration{timeout, pollInterval})
 		return 30 * time.Millisecond, true, nil
 	})
+	slept := stubRawInjectSleep(t)
 
 	cfg := &wakeConfig{injectMode: "raw"}
 	if err := injectNotification(cfg, "AMQ wake", true); err != nil {
 		t.Fatalf("injectNotification: %v", err)
 	}
 
-	if got := strings.Join(injected, "|"); got != "AMQ wake|\r" {
-		t.Fatalf("raw injection sequence = %q, want text then one CR", got)
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\r|\r" {
+		t.Fatalf("raw injection sequence = %q, want text then CR then rescue CR", got)
 	}
-	if gotTimeout != rawInjectDrainTimeout {
-		t.Fatalf("drain timeout = %s, want %s", gotTimeout, rawInjectDrainTimeout)
+	wantDrains := [][2]time.Duration{
+		{rawInjectDrainTimeout, rawInjectDrainPollInterval},
+		{rawInjectCRDrainTimeout, rawInjectDrainPollInterval},
 	}
-	if gotPoll != rawInjectDrainPollInterval {
-		t.Fatalf("drain poll interval = %s, want %s", gotPoll, rawInjectDrainPollInterval)
+	if len(drainCalls) != len(wantDrains) || drainCalls[0] != wantDrains[0] || drainCalls[1] != wantDrains[1] {
+		t.Fatalf("drain calls = %v, want %v", drainCalls, wantDrains)
+	}
+	if len(*slept) != 2 || (*slept)[0] != rawInjectSettleDelay || (*slept)[1] != rawInjectSettleDelay {
+		t.Fatalf("settle sleeps = %v, want two of %s", *slept, rawInjectSettleDelay)
 	}
 }
 
-func TestInjectNotificationRawInjectsSingleCROnDrainTimeout(t *testing.T) {
+func TestInjectNotificationRawSkipsRescueCRWhenFirstCRStillQueued(t *testing.T) {
 	var injected []string
 	stubTIOCSTIInject(t, func(text string) error {
 		injected = append(injected, text)
@@ -364,6 +381,7 @@ func TestInjectNotificationRawInjectsSingleCROnDrainTimeout(t *testing.T) {
 	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
 		return timeout, false, nil
 	})
+	slept := stubRawInjectSleep(t)
 
 	cfg := &wakeConfig{injectMode: "raw", debug: true}
 	stderr := captureWakeStderr(t, func() {
@@ -378,9 +396,15 @@ func TestInjectNotificationRawInjectsSingleCROnDrainTimeout(t *testing.T) {
 	if !strings.Contains(stderr, "input drain timeout") {
 		t.Fatalf("expected drain timeout debug log, got %q", stderr)
 	}
+	if !strings.Contains(stderr, "skipping second CR") {
+		t.Fatalf("expected rescue skip debug log, got %q", stderr)
+	}
+	if len(*slept) != 1 || (*slept)[0] != rawInjectSettleDelay {
+		t.Fatalf("settle sleeps = %v, want one of %s", *slept, rawInjectSettleDelay)
+	}
 }
 
-func TestInjectNotificationRawInjectsSingleCROnDrainError(t *testing.T) {
+func TestInjectNotificationRawInjectsBothCRsOnDrainError(t *testing.T) {
 	var injected []string
 	stubTIOCSTIInject(t, func(text string) error {
 		injected = append(injected, text)
@@ -389,6 +413,7 @@ func TestInjectNotificationRawInjectsSingleCROnDrainError(t *testing.T) {
 	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
 		return 15 * time.Millisecond, false, errors.New("open /dev/tty: permission denied")
 	})
+	slept := stubRawInjectSleep(t)
 
 	cfg := &wakeConfig{injectMode: "raw", debug: true}
 	stderr := captureWakeStderr(t, func() {
@@ -397,11 +422,16 @@ func TestInjectNotificationRawInjectsSingleCROnDrainError(t *testing.T) {
 		}
 	})
 
-	if got := strings.Join(injected, "|"); got != "AMQ wake|\r" {
-		t.Fatalf("raw injection sequence = %q, want text then one CR", got)
+	// With the queue unobservable, fall back to timing alone: both CRs are sent
+	// on the settle cadence, mirroring the pre-drain-wait behavior.
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\r|\r" {
+		t.Fatalf("raw injection sequence = %q, want text then CR then rescue CR", got)
 	}
 	if !strings.Contains(stderr, "input drain wait unavailable") {
 		t.Fatalf("expected drain unavailable debug log, got %q", stderr)
+	}
+	if len(*slept) != 2 {
+		t.Fatalf("settle sleeps = %v, want two settle delays", *slept)
 	}
 }
 

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -372,10 +372,10 @@ func TestRawSubmitKeyPicksEncodingByTarget(t *testing.T) {
 }
 
 func TestInjectNotificationRawUsesKittyEnterForCodex(t *testing.T) {
-	// codex-tui never submits on a raw \r once it negotiates kitty keyboard
-	// enhancement with the terminal (Ghostty); the CSI-u Enter encoding is
-	// parsed as Enter by its crossterm parser in both legacy and enhanced
-	// modes, so codex targets get CSI-u for the primary and rescue submit.
+	// In the reproduced Ghostty + kitty-enhanced codex-tui wake path a raw \r
+	// did not submit while CSI-u did; CSI-u is parsed as Enter by codex's
+	// crossterm parser in both legacy and enhanced modes, so codex targets get
+	// CSI-u for the primary and rescue submit.
 	var injected []string
 	stubTIOCSTIInject(t, func(text string) error {
 		injected = append(injected, text)

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -338,6 +338,20 @@ func stubRawInjectSleep(t *testing.T) *[]time.Duration {
 	return &slept
 }
 
+func TestRawInjectSettleDelayClearsCodexEnterSuppressWindow(t *testing.T) {
+	// Regression guard for the v0.41.0 Enter swallow: the settle (and rescue
+	// spacing, which reuses it) must exceed codex-tui's Enter-suppress window,
+	// or injected CRs are inserted as pasted newlines instead of submitting.
+	// A revert to the old 50ms floor must fail this test, not just review.
+	if rawInjectSettleDelay <= codexTUIEnterSuppressWindow {
+		t.Fatalf("rawInjectSettleDelay = %s, must exceed codex-tui Enter-suppress window %s",
+			rawInjectSettleDelay, codexTUIEnterSuppressWindow)
+	}
+	if margin := rawInjectSettleDelay - codexTUIEnterSuppressWindow; margin < 20*time.Millisecond {
+		t.Fatalf("settle margin over suppress window = %s, want >= 20ms for scheduler jitter", margin)
+	}
+}
+
 func TestInjectNotificationRawDrainsSettlesThenInjectsCRWithRescue(t *testing.T) {
 	var injected []string
 	stubTIOCSTIInject(t, func(text string) error {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -352,30 +352,30 @@ func TestRawInjectSettleDelayClearsCodexEnterSuppressWindow(t *testing.T) {
 	}
 }
 
-func TestRawSubmitKeyPicksEncodingByTarget(t *testing.T) {
+func TestRawSubmitPreludePicksByTarget(t *testing.T) {
 	cases := []struct {
 		me   string
 		want string
 	}{
-		{"codex", kittyEnterSequence},
-		{"codex-test", kittyEnterSequence},
-		{"my-codex-2", kittyEnterSequence},
-		{"claude", "\r"},
-		{"claude-test", "\r"},
-		{"", "\r"},
+		{"codex", "\n"},
+		{"codex-test", "\n"},
+		{"my-codex-2", "\n"},
+		{"claude", ""},
+		{"claude-test", ""},
+		{"", ""},
 	}
 	for _, c := range cases {
-		if got := rawSubmitKey(c.me); got != c.want {
-			t.Fatalf("rawSubmitKey(%q) = %q, want %q", c.me, got, c.want)
+		if got := rawSubmitPrelude(c.me); got != c.want {
+			t.Fatalf("rawSubmitPrelude(%q) = %q, want %q", c.me, got, c.want)
 		}
 	}
 }
 
-func TestInjectNotificationRawUsesKittyEnterForCodex(t *testing.T) {
-	// In the reproduced Ghostty + kitty-enhanced codex-tui wake path a raw \r
-	// did not submit while CSI-u did; CSI-u is parsed as Enter by codex's
-	// crossterm parser in both legacy and enhanced modes, so codex targets get
-	// CSI-u for the primary and rescue submit.
+func TestInjectNotificationRawInjectsLFPreludeForCodex(t *testing.T) {
+	// codex targets get a lone LF between the drained text and the settle: it
+	// routes through codex-tui's Ctrl-J binding, which flushes and clears
+	// paste-burst state before the \r submit. In the reproduced Ghostty +
+	// kitty-enhanced path a bare \r did not submit without it.
 	var injected []string
 	stubTIOCSTIInject(t, func(text string) error {
 		injected = append(injected, text)
@@ -384,16 +384,46 @@ func TestInjectNotificationRawUsesKittyEnterForCodex(t *testing.T) {
 	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
 		return time.Millisecond, true, nil
 	})
-	stubRawInjectSleep(t)
+	slept := stubRawInjectSleep(t)
 
 	cfg := &wakeConfig{injectMode: "raw", me: "codex"}
 	if err := injectNotification(cfg, "AMQ wake", true); err != nil {
 		t.Fatalf("injectNotification: %v", err)
 	}
 
-	want := "AMQ wake|" + kittyEnterSequence + "|" + kittyEnterSequence
-	if got := strings.Join(injected, "|"); got != want {
-		t.Fatalf("raw injection sequence = %q, want %q", got, want)
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\n|\r|\r" {
+		t.Fatalf("raw injection sequence = %q, want text, LF prelude, CR, rescue CR", got)
+	}
+	if len(*slept) != 2 {
+		t.Fatalf("settle sleeps = %v, want two settle delays", *slept)
+	}
+}
+
+func TestInjectNotificationRawNeverInjectsEscapeBytes(t *testing.T) {
+	// TIOCSTI delivers one byte per ioctl, so a multi-byte escape sequence can
+	// be split by reader scheduling: a reader that sees a lone ESC parses the
+	// Escape key, which cancels an active codex turn. Raw-mode injection must
+	// therefore never contain ESC for any target.
+	for _, me := range []string{"", "claude", "codex", "codex-test"} {
+		var injected []string
+		stubTIOCSTIInject(t, func(text string) error {
+			injected = append(injected, text)
+			return nil
+		})
+		stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+			return time.Millisecond, true, nil
+		})
+		stubRawInjectSleep(t)
+
+		cfg := &wakeConfig{injectMode: "raw", me: me}
+		if err := injectNotification(cfg, "AMQ wake", true); err != nil {
+			t.Fatalf("injectNotification(me=%q): %v", me, err)
+		}
+		for _, chunk := range injected {
+			if strings.Contains(chunk, "\x1b") {
+				t.Fatalf("me=%q injected chunk %q contains ESC", me, chunk)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

Since v0.41.0 (#208), `amq wake` raw injection types the notification into the TUI composer but Enter never submits — messages sit unsent. Reported on live Ghostty/macOS coop sessions (codex-tui deterministically; Claude Code intermittently when busy).

## Root causes (empirically established)

**1. The v0.41.0 drain-wait is a no-op against a live reader.** TIOCSTI injects byte-by-byte and an active TUI consumes each byte immediately, so the kernel queue never accumulates — tty tracing shows the drain completing in ~1µs and the submit CR landing ~50µs after the text (pre-0.41 guaranteed 50ms). A CR inside codex-tui's Enter-suppress window (`PASTE_ENTER_SUPPRESS_WINDOW` = 120ms, re-extended by each suppressed Enter — codex-rs `paste_burst.rs`) is inserted as a pasted newline. #208 also removed the rescue second CR.

**2. Raw `\r` alone failed in the reproduced Ghostty + kitty-enhanced codex-tui wake path at any tested delay.** With `CODEX_TUI_DISABLE_KEYBOARD_ENHANCEMENT=1`, or under tmux (no kitty support), the same cadence submits. The pinned crossterm parser maps raw `0x0D` to Enter unconditionally and Ghostty emits a physical Enter as `\r` under codex's flags (1|2|4), so the cause is event/timing behavior in the enhanced path, not parser classification.

## Fix

- Keep #208's drain-wait (still correct for stalled readers).
- Hold the submit CR for a **150ms settle** after the text drains — derived as `codexTUIEnterSuppressWindow (120ms, pinned) + 30ms`, with a guard test on the margin.
- Restore the **rescue CR** on the same spacing (no-op on an empty composer), skipped only when the first CR is provably still queued.
- **LF prelude for codex targets**: a single `0x0A` between the drained text and the settle. It routes through codex-tui's Ctrl-J binding, which flushes and clears paste-burst state before the CR lands; the prelude newline is trimmed from the submitted payload. This unlocks the kitty-enhanced path.
- **All injected control bytes are single-byte, by invariant.** A multi-byte escape sequence (e.g. kitty CSI-u Enter) can be split across TIOCSTI ioctls by reader scheduling — a lone ESC parses as the Escape key, which cancels an active codex turn. A regression test asserts no injected chunk ever contains ESC. (A CSI-u variant passed the full matrix but was rejected for exactly this race.)

## Verification (this build; submission proven via codex session rollouts, not screen-scraping)

| Environment | Result |
|---|---|
| Ghostty + codex-tui, kitty enhancement active — idle | ✅ submits, byte-exact payload (prelude trimmed) |
| Ghostty + codex-tui, kitty enhancement active — mid-turn | ✅ queued and submitted |
| tmux + codex-tui — idle and mid-turn | ✅ submits |
| tmux + Claude Code (`\r`, no prelude) | ✅ submits |
| Ghostty + Claude Code (live sessions) | ✅ submits |

Unit tests: per-target inject sequence, settle cadence, both drain calls, rescue-skip on queued CR, total-stall behavior, drain-error fallback, settle-vs-window margin invariant, prelude selection, and the no-ESC invariant. `make ci` green.

Peer review: iterative staff-engineer audits by two Codex instances and a Claude reviewer drove five hardening rounds — margin invariant, skip-branch test modeling, the kitty-enhancement discovery, the CSI-u fragmentation-race rejection, and the final LF-prelude design (Codex's own lead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9bL1rztoJSqzuYvcfrmi8