### PR TITLE
chore: bump Go to 1.25.12 for GO-2026-5856

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+
+- Bumped the Go toolchain to 1.25.12 to pick up the GO-2026-5856 fix
+  (Encrypted Client Hello privacy leak in crypto/tls).
 
 ## [0.41.0] - 2026-07-08
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/avivsinai/agent-message-queue
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/coder/websocket v1.8.15


### PR DESCRIPTION
Govulncheck fails every CI run on go1.25.11: [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak in crypto/tls), fixed in go1.25.12. Mechanical toolchain patch bump; unblocks CI for all open PRs (currently blocking #214).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9bL1rztoJSqzuYvcfrmi8