### PR TITLE
fix: skip changelog gate on Dependabot PR author, not only event actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.41.1] - 2026-07-10
 ### Fixed
 
+- CI changelog gate no longer fails Dependabot PRs after a maintainer updates
+  the branch: a manual `gh pr update-branch` makes the maintainer the
+  synchronize-event actor, so the actor-based skip stopped applying. The gate
+  now also skips on the PR author (`pull_request.user.login`), GitHub's
+  documented Dependabot-detection pattern, which stays `dependabot[bot]`
+  regardless of who updates the branch.
+
 - `amq wake` raw injection submits again in fast-reading TUIs (codex-tui, busy
   Claude Code): the v0.41.0 drain-wait completes within microseconds when the
   TUI is actively reading, so the submit CR landed inside the TUI's paste-burst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 
+- CI changelog gate no longer fails Dependabot PRs after a maintainer updates
+  the branch: a manual `gh pr update-branch` makes the maintainer the
+  synchronize-event actor, so the actor-based skip stopped applying. The gate
+  now also skips on the PR author (`pull_request.user.login`), GitHub's
+  documented Dependabot-detection pattern, which stays `dependabot[bot]`
+  regardless of who updates the branch.
+
 - `amq wake` raw injection submits again in fast-reading TUIs (codex-tui, busy
   Claude Code): the v0.41.0 drain-wait completes within microseconds when the
   TUI is actively reading, so the submit CR landed inside the TUI's paste-burst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.41.1] - 2026-07-10
 ### Fixed
 
 - CI changelog gate no longer fails Dependabot PRs after a maintainer updates
@@ -16,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now also skips on the PR author (`pull_request.user.login`), GitHub's
   documented Dependabot-detection pattern, which stays `dependabot[bot]`
   regardless of who updates the branch.
+
+## [0.41.1] - 2026-07-10
+### Fixed
 
 - `amq wake` raw injection submits again in fast-reading TUIs (codex-tui, busy
   Claude Code): the v0.41.0 drain-wait completes within microseconds when the

--- a/scripts/check_pr_changelog.py
+++ b/scripts/check_pr_changelog.py
@@ -31,12 +31,14 @@ class PRMetadata:
         self,
         *,
         actor: str,
+        author: str,
         head_ref: str,
         base_sha: str,
         head_sha: str,
         labels: list[str],
     ) -> None:
         self.actor = actor
+        self.author = author
         self.head_ref = head_ref
         self.base_sha = base_sha
         self.head_sha = head_sha
@@ -60,6 +62,7 @@ def git_env() -> dict[str, str]:
 def metadata_from_event(event: dict, actor: str = "") -> PRMetadata:
     pr = event.get("pull_request") or {}
     sender = event.get("sender") or {}
+    author = pr.get("user") or {}
     head = pr.get("head") or {}
     base = pr.get("base") or {}
     labels = pr.get("labels") or []
@@ -75,6 +78,7 @@ def metadata_from_event(event: dict, actor: str = "") -> PRMetadata:
 
     return PRMetadata(
         actor=(actor or str(sender.get("login") or "")).strip(),
+        author=str(author.get("login") or "").strip(),
         head_ref=str(head.get("ref") or "").strip(),
         base_sha=str(base.get("sha") or "").strip(),
         head_sha=str(head.get("sha") or "").strip(),
@@ -82,9 +86,13 @@ def metadata_from_event(event: dict, actor: str = "") -> PRMetadata:
     )
 
 
-def skip_reason(*, actor: str, head_ref: str, labels: list[str]) -> str | None:
+def skip_reason(*, actor: str, head_ref: str, labels: list[str], author: str = "") -> str | None:
     if actor.strip().lower() in DEPENDABOT_ACTORS:
         return "dependabot actor"
+    # A maintainer updating the branch becomes the synchronize-event actor;
+    # the PR author stays dependabot[bot].
+    if author.strip().lower() in DEPENDABOT_ACTORS:
+        return "dependabot author"
     if head_ref.strip().startswith("release/"):
         return "release branch"
     normalized_labels = {label.strip().lower() for label in labels}
@@ -155,7 +163,12 @@ def main(argv: list[str]) -> int:
     event = load_event(pathlib.Path(args.event_path)) if args.event_path else {}
     metadata = metadata_from_event(event, actor=args.actor)
 
-    reason = skip_reason(actor=metadata.actor, head_ref=metadata.head_ref, labels=metadata.labels)
+    reason = skip_reason(
+        actor=metadata.actor,
+        author=metadata.author,
+        head_ref=metadata.head_ref,
+        labels=metadata.labels,
+    )
     if reason:
         print(f"CHANGELOG.md check skipped: {reason}")
         return 0

--- a/scripts/test_check_pr_changelog.py
+++ b/scripts/test_check_pr_changelog.py
@@ -147,6 +147,27 @@ def test_event_file_loader() -> None:
         assert check_pr_changelog.load_event(path)["pull_request"]["labels"][0]["name"] == "docs"
 
 
+def test_main_skips_dependabot_author_on_maintainer_synchronize() -> None:
+    # A maintainer's `gh pr update-branch` on a Dependabot PR: the actor is the
+    # maintainer, only the PR author identifies Dependabot. No git repo is
+    # provided, so anything short of the author-based skip would fail.
+    event = {
+        "sender": {"login": "avivsinai"},
+        "pull_request": {
+            "user": {"login": "dependabot[bot]"},
+            "head": {"ref": "dependabot/go_modules/x", "sha": "head-sha"},
+            "base": {"sha": "base-sha"},
+            "labels": [],
+        },
+    }
+    with tempfile.TemporaryDirectory() as temp:
+        path = pathlib.Path(temp) / "event.json"
+        path.write_text(json.dumps(event))
+        assert (
+            check_pr_changelog.main(["--event-path", str(path), "--actor", "avivsinai"]) == 0
+        )
+
+
 def main() -> int:
     test_added_unreleased_bullet_passes()
     test_missing_unreleased_bullet_fails()
@@ -155,6 +176,7 @@ def main() -> int:
     test_title_like_branch_does_not_skip_without_label()
     test_event_metadata_prefers_pull_request_fields()
     test_event_file_loader()
+    test_main_skips_dependabot_author_on_maintainer_synchronize()
     print("check PR changelog tests ok")
     return 0
 

--- a/scripts/test_check_pr_changelog.py
+++ b/scripts/test_check_pr_changelog.py
@@ -111,6 +111,9 @@ def test_explicit_skip_reasons() -> None:
     assert check_pr_changelog.skip_reason(
         actor="avivsinai", head_ref="feature/x", labels=["no-changelog"]
     ) == "label no-changelog"
+    assert check_pr_changelog.skip_reason(
+        actor="avivsinai", author="dependabot[bot]", head_ref="dependabot/go_modules/x", labels=[]
+    ) == "dependabot author"
 
 
 def test_title_like_branch_does_not_skip_without_label() -> None:
@@ -122,6 +125,7 @@ def test_event_metadata_prefers_pull_request_fields() -> None:
     event = {
         "sender": {"login": "ignored"},
         "pull_request": {
+            "user": {"login": "dependabot[bot]"},
             "head": {"ref": "feature/changelog", "sha": "head-sha"},
             "base": {"sha": "base-sha"},
             "labels": [{"name": "no-changelog"}],
@@ -129,6 +133,7 @@ def test_event_metadata_prefers_pull_request_fields() -> None:
     }
     metadata = check_pr_changelog.metadata_from_event(event, actor="avivsinai")
     assert metadata.actor == "avivsinai"
+    assert metadata.author == "dependabot[bot]"
     assert metadata.head_ref == "feature/changelog"
     assert metadata.base_sha == "base-sha"
     assert metadata.head_sha == "head-sha"


### PR DESCRIPTION
## Problem

All four open Dependabot PRs (#210–#213) fail the changelog gate after a maintainer refreshes their branches: `gh pr update-branch` makes the maintainer the synchronize-event actor (`GITHUB_ACTOR`/`sender`), so the gate's actor-based Dependabot skip stops applying, and Dependabot PRs by design add no changelog entry.

## Fix

Skip on the PR author (`pull_request.user.login`) as well — GitHub's documented Dependabot-detection pattern (the same condition `dependabot/fetch-metadata` prescribes). The author stays `dependabot[bot]` no matter who updates the branch, and `[bot]` logins are app-reserved, so this is not spoofable via login choice.

## Verification

- `scripts/test_check_pr_changelog.py` extended: author-based skip + metadata extraction; simulated the exact failing payload (sender=avivsinai, author=dependabot[bot]) → skips with `dependabot author`.
- `make ci` green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqHEdyeAB6dkp4ufzqjeMh