### PR TITLE
feat(wake): add zero-input notification mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- `amq wake --inject-mode none` now provides an AMQ-enforced zero-input mode
+  for permission-prompt workflows: normal notices go to wake stderr, urgent
+  interrupts emit one bell plus the stderr notice instead of Ctrl+C, and the
+  mode needs neither TIOCSTI nor a controlling TTY. It fails closed when
+  combined with `--inject-via`, `--inject-arg`, or `--inject-cmd`; `coop exec`
+  exposes the mode through `--wake-inject-mode` and refuses to satisfy an
+  explicit `none` request by reusing a wake whose zero-input mode cannot be
+  proven. Documentation now warns that every input-injecting mode can activate
+  a focused permission/approval dialog and that input deferral cannot detect
+  modal state (closes #216).
+
 ### Fixed
 
 - CI changelog gate no longer fails Dependabot PRs after a maintainer updates

--- a/COOP.md
+++ b/COOP.md
@@ -231,8 +231,25 @@ as the final argv element. This executes a local process for each notification,
 and the payload can include sanitized but message-derived header content such as
 sender and subject.
 
+For permission-prompt workflows, use AMQ's fail-closed zero-input mode:
+
+```bash
+amq wake --me claude --inject-mode none --bell &
+
+# Or let coop exec start it and prove readiness before launching the agent.
+amq coop exec --require-wake --wake-inject-mode none claude
+```
+
+`none` writes notification text (and the optional bell) to wake's stderr and
+never writes terminal input. Urgent interrupt messages degrade to one bell plus
+the stderr notice instead of Ctrl+C. Because `--inject-via` is arbitrary local
+code and may itself inject terminal input, `none` rejects `--inject-via`,
+`--inject-arg`, and `--inject-cmd`. Stderr output shares the TUI terminal by
+default and may remain visible until the TUI redraws.
+
 **Options:**
-- `--inject-mode auto|raw|paste` - Injection strategy
+- `--inject-mode auto|raw|paste|none` - Injection strategy; `none` enforces zero terminal input
+- `--wake-inject-mode auto|raw|paste|none` - `coop exec` pass-through for its managed wake
 - `--inject-via <executable>` - External transport executable; bypasses TIOCSTI and local TTY startup checks
 - `--inject-arg <arg>` - Fixed argument before the payload; repeat for multiple arguments
 - `--inject-timeout 5s` - Maximum runtime for one external injection command
@@ -244,7 +261,19 @@ sender and subject.
 - `--input-max-hold 15s` - Maximum hold time for one deferred wake injection
 - `--interrupt` / `--interrupt=false` - Enable/disable Ctrl+C for urgent messages
 
-Input deferral is a heuristic, not a prompt-buffer guarantee. It only samples terminal state while a wake notification is already pending: unread bytes in the TTY input queue plus recent reads from the controlling terminal. If the foreground app has already consumed a partially typed prompt into its own editor buffer and the user pauses longer than `--input-quiet-for`, wake can still inject and submit. Explicit urgent interrupt messages bypass this deferral.
+Every input-injecting mode can activate a focused permission or approval dialog:
+raw and paste payload bytes, `--inject-cmd`, external injectors, and urgent Ctrl+C
+all carry this hazard. Single-key dialog shortcuts mean that removing Enter or
+sanitizing the payload is not a safety boundary.
+
+Input deferral is collision reduction, not modal detection or a prompt-buffer
+guarantee. It samples unread TTY input bytes and recent terminal reads only
+after a wake notification is pending. An idle approval dialog is
+indistinguishable from an idle composer. If the foreground app has already
+consumed a partially typed prompt and the user pauses longer than
+`--input-quiet-for`, wake can still inject and submit. Explicit urgent interrupt
+messages bypass this deferral. Use `none` when AMQ must guarantee zero synthetic
+input.
 
 **Platform support:**
 - macOS: Works

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
@@ -169,6 +170,52 @@ func TestCoopExecWakeInjectViaValidation(t *testing.T) {
 				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestCoopExecWakeInjectModeValidation(t *testing.T) {
+	injector := filepath.Join(secureTempDirForTest(t), "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "unknown mode",
+			args:    []string{"--wake-inject-mode", "silent", "claude"},
+			wantErr: "supported: auto, raw, paste, none",
+		},
+		{
+			name:    "none with inject via",
+			args:    []string{"--wake-inject-mode", "none", "--wake-inject-via", injector, "claude"},
+			wantErr: "--wake-inject-via cannot be used with --wake-inject-mode none",
+		},
+		{
+			name:    "none with inject arg",
+			args:    []string{"--wake-inject-mode", "none", "--wake-inject-arg", "exec", "claude"},
+			wantErr: "--wake-inject-arg cannot be used with --wake-inject-mode none",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runCoopExec(tt.args)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildCoopWakeArgsIncludesNoneMode(t *testing.T) {
+	got := buildCoopWakeArgs("codex", "/tmp/root", "none", "", nil)
+	want := []string{"--no-update-check", "wake", "--me", "codex", "--root", "/tmp/root", "--inject-mode", "none"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildCoopWakeArgs() = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -29,6 +29,7 @@ func runCoopExec(args []string) error {
 	noGitignoreFlag := fs.Bool("no-gitignore", false, "When auto-initializing, do not modify .gitignore")
 	noWakeFlag := fs.Bool("no-wake", false, "Don't start amq wake in background")
 	requireWakeFlag := fs.Bool("require-wake", false, "Fail if amq wake cannot start and acquire its lock")
+	wakeInjectModeFlag := fs.String("wake-inject-mode", wakeInjectModeAuto, "Wake injection mode: auto, raw, paste, none")
 	wakeInjectViaFlag := fs.String("wake-inject-via", "", "Start wake with this absolute --inject-via executable, enabling later amq wake repair")
 	var wakeInjectArgFlags multiStringFlag
 	fs.Var(&wakeInjectArgFlags, "wake-inject-arg", "Fixed argument for wake --inject-via before the payload (repeatable)")
@@ -49,8 +50,14 @@ func runCoopExec(args []string) error {
 		"  amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Codex with flags",
 		"  amq coop exec --session feature-x claude          # Isolated session",
 		"  amq coop exec --root .agent-mail/auth claude      # Explicit root (no session default)",
+		"  amq coop exec --require-wake --wake-inject-mode none claude  # Zero-input wake",
 		"  amq coop exec --wake-inject-via /path/to/injector codex",
 		"  amq coop exec --me myagent bash                   # Debug shell with AMQ env",
+		"",
+		"Zero-input readiness:",
+		"  --wake-inject-mode none never reuses an existing wake unless its lock",
+		"  proves it was also started in none mode; stop an older wake and retry.",
+		"  A default request remains transport-agnostic and may reuse a none wake.",
 	)
 
 	if handled, err := parseFlags(fs, amqArgs, usage); err != nil {
@@ -62,8 +69,18 @@ func runCoopExec(args []string) error {
 		return UsageError("--require-wake cannot be used with --no-wake")
 	}
 	wakeInjectVia := strings.TrimSpace(*wakeInjectViaFlag)
+	wakeInjectMode, err := normalizeWakeInjectMode(*wakeInjectModeFlag)
+	if err != nil {
+		return UsageError("--wake-inject-mode: %v", err)
+	}
 	if *wakeInjectViaFlag != "" && wakeInjectVia == "" {
 		return UsageError("--wake-inject-via must not be blank")
+	}
+	if wakeInjectMode == wakeInjectModeNone && wakeInjectVia != "" {
+		return UsageError("--wake-inject-via cannot be used with --wake-inject-mode none")
+	}
+	if wakeInjectMode == wakeInjectModeNone && len(wakeInjectArgFlags) > 0 {
+		return UsageError("--wake-inject-arg cannot be used with --wake-inject-mode none")
 	}
 	if wakeInjectVia == "" && len(wakeInjectArgFlags) > 0 {
 		return UsageError("--wake-inject-arg requires --wake-inject-via")
@@ -91,7 +108,7 @@ func runCoopExec(args []string) error {
 	if agentHandle == "" {
 		agentHandle = strings.ToLower(filepath.Base(cmdName))
 	}
-	agentHandle, err := normalizeHandle(agentHandle)
+	agentHandle, err = normalizeHandle(agentHandle)
 	if err != nil {
 		return fmt.Errorf("cannot derive agent handle from %q: %w (use --me to override)", cmdName, err)
 	}
@@ -223,7 +240,7 @@ func runCoopExec(args []string) error {
 		if wakeInjectVia != "" {
 			wakeOwner = currentWakeOwner()
 		}
-		wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, wakeInjectVia, []string(wakeInjectArgFlags))...)
+		wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, wakeInjectMode, wakeInjectVia, []string(wakeInjectArgFlags))...)
 		var readyPath string
 		var cleanupReady func()
 		if *requireWakeFlag {
@@ -293,8 +310,11 @@ func absoluteSessionRoot(root string) (string, error) {
 	return filepath.Abs(root)
 }
 
-func buildCoopWakeArgs(agentHandle, root, injectVia string, injectArgs []string) []string {
+func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectArgs []string) []string {
 	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root}
+	if injectMode != "" && injectMode != wakeInjectModeAuto {
+		args = append(args, "--inject-mode", injectMode)
+	}
 	if injectVia != "" {
 		args = append(args, "--inject-via", injectVia)
 		for _, arg := range injectArgs {

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -45,6 +45,11 @@ type wakeConfig struct {
 
 const defaultInjectTimeout = 5 * time.Second
 const (
+	wakeInjectModeAuto  = "auto"
+	wakeInjectModeRaw   = "raw"
+	wakeInjectModePaste = "paste"
+	wakeInjectModeNone  = "none"
+
 	rawInjectDrainTimeout      = 2 * time.Second
 	rawInjectDrainPollInterval = 10 * time.Millisecond
 	// rawInjectCRDrainTimeout bounds the wait for the submit CR itself to be
@@ -124,7 +129,7 @@ func inputDeferralDelay(state ttyInputState, now, deadline time.Time, quietFor, 
 }
 
 func shouldDeferBeforeInject(cfg *wakeConfig, deferForInput bool) bool {
-	return deferForInput && cfg.deferWhileInput && cfg.injectVia == ""
+	return deferForInput && cfg.deferWhileInput && cfg.injectVia == "" && cfg.injectMode != wakeInjectModeNone
 }
 
 func notifyNewMessages(cfg *wakeConfig) error {
@@ -195,6 +200,10 @@ func notifyNewMessages(cfg *wakeConfig) error {
 
 	if cfg.interrupt && len(interruptMessages) > 0 {
 		interruptText := buildInterruptText(cfg.session, interruptMessages, interruptCounts, cfg.previewLen, cfg.interruptNotice)
+		if cfg.injectMode == wakeInjectModeNone {
+			writeWakeOutput(interruptText, true)
+			return nil
+		}
 		now := time.Now()
 		if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
 			if cfg.injectVia != "" {
@@ -337,22 +346,47 @@ func shouldInterruptNow(cfg *wakeConfig, now time.Time) bool {
 
 func effectiveInjectMode(cfg *wakeConfig) string {
 	mode := cfg.injectMode
-	if mode == "" || mode == "auto" {
+	if mode == "" || mode == wakeInjectModeAuto {
 		// Auto-detect: use raw mode for Claude Code and Codex to avoid bracketed-paste
 		// Enter swallowing in some CLIs. Paste mode remains available via flag.
 		// Claude Code's Ink framework has buggy bracketed paste handling where CR gets
 		// coalesced with the paste-end sequence and swallowed by the input parser.
 		meLower := strings.ToLower(cfg.me)
 		if strings.Contains(meLower, "claude") || strings.Contains(meLower, "codex") {
-			mode = "raw"
+			mode = wakeInjectModeRaw
 		} else {
-			mode = "paste"
+			mode = wakeInjectModePaste
 		}
 	}
 	return mode
 }
 
+func normalizeWakeInjectMode(raw string) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(raw))
+	if mode == "" {
+		mode = wakeInjectModeAuto
+	}
+	switch mode {
+	case wakeInjectModeAuto, wakeInjectModeRaw, wakeInjectModePaste, wakeInjectModeNone:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid injection mode %q (supported: auto, raw, paste, none)", raw)
+	}
+}
+
+func writeWakeOutput(text string, bell bool) {
+	if bell {
+		text = "\a" + text
+	}
+	_, _ = fmt.Fprint(os.Stderr, text+"\n")
+}
+
 func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error {
+	if cfg.injectMode == wakeInjectModeNone {
+		writeWakeOutput(text, cfg.bell)
+		return nil
+	}
+
 	// Keep plain text for stderr fallback
 	plainText := text
 	if cfg.bell {
@@ -383,7 +417,7 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	}
 	var injectErr error
 	switch mode {
-	case "raw":
+	case wakeInjectModeRaw:
 		// Raw mode: inject text and CR separately to avoid paste detection.
 		// Ink treats multi-char input as paste, not keypresses. Sending text+CR
 		// as one chunk makes Ink see pasted text, not an Enter keypress.
@@ -393,7 +427,7 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		}
 		injectErr = injectRawNotification(cfg, injectedText)
 
-	case "paste":
+	case wakeInjectModePaste:
 		// Paste mode: bracketed paste with delayed CR
 		// Works with crossterm/ratatui apps
 		// Send paste content first, then CR after short delay to avoid coalescing

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -24,7 +24,7 @@ type wakeLock struct {
 	BootID       string   `json:"boot_id,omitempty"`       // Boot identity paired with ProcessStart when available
 	Executable   string   `json:"executable,omitempty"`    // Diagnostic process executable basename/path
 	Args         []string `json:"args,omitempty"`          // Diagnostic argv when available
-	WakeMode     string   `json:"wake_mode,omitempty"`     // Injection mode that created repair metadata
+	WakeMode     string   `json:"wake_mode,omitempty"`     // Proven wake transport/mode (inject-via or none)
 	TargetDigest string   `json:"target_digest,omitempty"` // Binds .wake.target to this lock instance
 }
 

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -1009,7 +1009,7 @@ func TestRunWakeRepairClearsRepairAvailableAfterStartFailure(t *testing.T) {
 }
 
 func TestBuildCoopWakeArgsIncludesInjectViaTarget(t *testing.T) {
-	args := buildCoopWakeArgs("codex", "/tmp/root", "/abs/injector", []string{"exec", "target"})
+	args := buildCoopWakeArgs("codex", "/tmp/root", wakeInjectModeAuto, "/abs/injector", []string{"exec", "target"})
 	got := strings.Join(args, "|")
 	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target"
 	if got != want {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -220,6 +220,47 @@ func TestInjectNotification_InjectVia_Bell(t *testing.T) {
 	}
 }
 
+func TestInjectNotificationNoneWritesOutputWithoutTIOCSTI(t *testing.T) {
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return errors.New("none mode must not inject")
+	})
+
+	stderr := captureWakeStderr(t, func() {
+		cfg := &wakeConfig{injectMode: wakeInjectModeNone, bell: true}
+		if err := injectNotification(cfg, "safe notice", true); err != nil {
+			t.Fatalf("injectNotification: %v", err)
+		}
+	})
+
+	if len(injected) != 0 {
+		t.Fatalf("none mode injected terminal input: %q", injected)
+	}
+	if stderr != "\asafe notice\n" {
+		t.Fatalf("stderr = %q, want bell + notice", stderr)
+	}
+}
+
+func TestInjectNotificationNoneDoesNotInvokeInjectVia(t *testing.T) {
+	cfg, outputPath := injectViaCaptureConfig(t)
+	cfg.injectMode = wakeInjectModeNone
+	cfg.bell = true
+
+	stderr := captureWakeStderr(t, func() {
+		if err := injectNotification(cfg, "safe notice", true); err != nil {
+			t.Fatalf("injectNotification: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("none mode invoked inject-via; output stat error = %v", err)
+	}
+	if stderr != "\asafe notice\n" {
+		t.Fatalf("stderr = %q, want bell + notice", stderr)
+	}
+}
+
 func TestInjectViaTimeout(t *testing.T) {
 	scriptPath := filepath.Join(secureTempDirForTest(t), "sleep.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 2\n"), 0o755); err != nil {
@@ -652,6 +693,101 @@ func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *test
 	}
 	if string(got) != expected {
 		t.Fatalf("expected inject-via log %q, got %q", expected, string(got))
+	}
+}
+
+func TestNotifyNewMessagesNoneUrgentUsesOutputBellWithoutInput(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	msg := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       "msg-urgent-none",
+			From:     "codex",
+			To:       []string{"alice"},
+			Thread:   "p2p/alice__codex",
+			Subject:  "help needed",
+			Created:  "2026-07-11T07:00:00Z",
+			Priority: "urgent",
+			Labels:   []string{"interrupt"},
+		},
+		Body: "urgent body",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := fsq.DeliverToInbox(root, "alice", "msg-urgent-none.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return errors.New("none mode must not inject")
+	})
+
+	cfg := &wakeConfig{
+		me:                "alice",
+		root:              root,
+		session:           "collab",
+		injectMode:        wakeInjectModeNone,
+		previewLen:        48,
+		interrupt:         true,
+		interruptKey:      "\x03",
+		interruptLabel:    "interrupt",
+		interruptPriority: "urgent",
+		interruptCooldown: 7 * time.Second,
+	}
+	stderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notifyNewMessages: %v", err)
+		}
+	})
+
+	if len(injected) != 0 {
+		t.Fatalf("none mode injected urgent terminal input: %q", injected)
+	}
+	if !cfg.lastInterrupt.IsZero() {
+		t.Fatalf("none mode recorded a synthetic interrupt: %s", cfg.lastInterrupt)
+	}
+	expectedText := buildInterruptText(
+		"collab",
+		[]wakeMsgInfo{{from: "codex", subject: "help needed", priority: "urgent", labels: []string{"interrupt"}}},
+		map[string]int{"codex": 1},
+		48,
+		"",
+	)
+	if stderr != "\a"+expectedText+"\n" {
+		t.Fatalf("stderr = %q, want one bell + urgent notice %q", stderr, expectedText)
+	}
+
+	externalCfg, outputPath := injectViaCaptureConfig(t)
+	externalCfg.me = "alice"
+	externalCfg.root = root
+	externalCfg.session = "collab"
+	externalCfg.injectMode = wakeInjectModeNone
+	externalCfg.previewLen = 48
+	externalCfg.interrupt = true
+	externalCfg.interruptKey = "\x03"
+	externalCfg.interruptLabel = "interrupt"
+	externalCfg.interruptPriority = "urgent"
+	externalStderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(externalCfg); err != nil {
+			t.Fatalf("notifyNewMessages with inject-via config: %v", err)
+		}
+	})
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("none mode invoked inject-via for urgent notice; output stat error = %v", err)
+	}
+	if externalStderr != "\a"+expectedText+"\n" {
+		t.Fatalf("external stderr = %q, want one bell + urgent notice %q", externalStderr, expectedText)
 	}
 }
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -52,6 +52,7 @@ type wakeRepairStarter func(root, me string, target wakeTarget) (int, error)
 type wakeLockAcquireOptions struct {
 	acceptExistingValid bool
 	target              *wakeTarget
+	wakeMode            string
 }
 
 var startWakeFromTarget = startWakeFromTargetDefault
@@ -86,7 +87,7 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 			return nil, fmt.Errorf("wake lock is being created (retry shortly)")
 		case wakeLockValid:
 			if options.acceptExistingValid {
-				if err := requireWakeLockUsable(inspection); err != nil {
+				if err := requireWakeLockUsable(inspection, options.wakeMode); err != nil {
 					return nil, err
 				}
 				return nil, wakeLockAlreadyRunningError(me, inspection)
@@ -123,6 +124,8 @@ createLock:
 	if options.target != nil {
 		lock.WakeMode = wakeTargetInjectVia
 		lock.TargetDigest = wakeTargetDigest(*options.target)
+	} else if options.wakeMode == wakeInjectModeNone {
+		lock.WakeMode = wakeInjectModeNone
 	}
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
@@ -144,7 +147,7 @@ createLock:
 			winner := inspectWakeLock(root, me)
 			if winner.Status == wakeLockValid {
 				if options.acceptExistingValid {
-					if usableErr := requireWakeLockUsable(winner); usableErr != nil {
+					if usableErr := requireWakeLockUsable(winner, options.wakeMode); usableErr != nil {
 						return nil, usableErr
 					}
 				}
@@ -236,11 +239,14 @@ func wakeLockNeedsOwnerReplacement(inspection wakeLockInspection) (bool, error) 
 	return wakeOwnerHealthCheck(*target.Owner) != nil, nil
 }
 
-func requireWakeLockUsable(inspection wakeLockInspection) error {
+func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string) error {
 	if !inspection.Exists || inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
 		return fmt.Errorf("existing wake lock for %s is not a confirmed valid wake", inspection.Agent)
 	}
-	if !wakeLockHasTTYOrExternalInjector(inspection) {
+	if requiredMode == wakeInjectModeNone && inspection.Lock.WakeMode != wakeInjectModeNone {
+		return fmt.Errorf("existing wake for %s cannot satisfy requested --inject-mode none; stop the existing wake and retry", inspection.Agent)
+	}
+	if !wakeLockHasUsableNotificationPath(inspection) {
 		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
 			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
 	}
@@ -251,7 +257,10 @@ func requireWakeLockUsable(inspection wakeLockInspection) error {
 	return nil
 }
 
-func wakeLockHasTTYOrExternalInjector(inspection wakeLockInspection) bool {
+func wakeLockHasUsableNotificationPath(inspection wakeLockInspection) bool {
+	if inspection.Lock.WakeMode == wakeInjectModeNone {
+		return true
+	}
 	if inspection.Lock.WakeMode == wakeTargetInjectVia || wakeArgsUseInjectVia(inspection.Process.Args) {
 		return true
 	}
@@ -608,7 +617,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	bellFlag := fs.Bool("bell", false, "Ring terminal bell on new messages")
 	debounceFlag := fs.Duration("debounce", 250*time.Millisecond, "Debounce window for batching messages")
 	previewLenFlag := fs.Int("preview-len", 48, "Max subject preview length")
-	injectModeFlag := fs.String("inject-mode", "auto", "Injection mode: auto, raw, paste (auto detects CLI type)")
+	injectModeFlag := fs.String("inject-mode", wakeInjectModeAuto, "Injection mode: auto, raw, paste, none (auto detects CLI type)")
 	deferWhileInputFlag := fs.Bool("defer-while-input", true, "Best-effort: defer non-interrupt injection while terminal input appears active")
 	inputQuietForFlag := fs.Duration("input-quiet-for", 1200*time.Millisecond, "Quiet window before deferred injection (best-effort; Linux tty atime granularity is ~8s)")
 	inputPollIntervalFlag := fs.Duration("input-poll-interval", 200*time.Millisecond, "Polling interval while waiting for quiet terminal input")
@@ -632,6 +641,8 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		"  auto  - Detect CLI type: raw for Claude Code/Codex, paste for others",
 		"  raw   - Plain text + CR, no bracketed paste (works with Ink-based CLIs)",
 		"  paste - Bracketed paste with delayed CR (works with crossterm-based CLIs)",
+		"  none  - Output notice on wake stderr; zero terminal input injection",
+		"          (urgent interrupts degrade to one bell + output notice)",
 		"",
 		"External injection:",
 		"  --inject-via runs a local executable for each notification, bypassing",
@@ -645,14 +656,19 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		"",
 		"Input deferral (default on): wake samples terminal input only after",
 		"  a message is pending, then injects after a short quiet window.",
-		"  Best-effort only: a pause longer than --input-quiet-for can still",
-		"  inject while a prompt is being composed. Interrupt messages bypass it.",
+		"  Collision reduction only: it cannot detect permission/approval dialogs.",
+		"  A pause longer than --input-quiet-for can still inject while a prompt",
+		"  is being composed. Interrupt messages bypass it.",
 		"  Atime sampling uses stdin (when a TTY) for cross-platform fidelity;",
 		"  Linux tty atime is updated at ~8s granularity, so quiet windows",
 		"  shorter than that are advisory.",
 		"",
 		"Interrupts (default on): urgent messages tagged with label \"interrupt\"",
-		"  trigger Ctrl+C injection + an interrupt notice.",
+		"  trigger Ctrl+C injection + an interrupt notice except in none mode.",
+		"",
+		"Safety: raw, paste, --inject-cmd, --inject-via, and interrupt Ctrl+C",
+		"  can activate a focused permission/approval dialog. Use none when AMQ",
+		"  must enforce zero synthetic input; stderr output may scribble until redraw.",
 		"",
 		"EXPERIMENTAL: Uses TIOCSTI ioctl (macOS/Linux). May not work on all systems.")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
@@ -682,15 +698,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return UsageError("--inject-timeout must be > 0")
 	}
 
-	injectMode := strings.ToLower(strings.TrimSpace(*injectModeFlag))
-	if injectMode == "" {
-		injectMode = "auto"
-	}
-	switch injectMode {
-	case "auto", "raw", "paste":
-		// ok
-	default:
-		return UsageError("invalid --inject-mode %q (supported: auto, raw, paste)", *injectModeFlag)
+	injectMode, err := normalizeWakeInjectMode(*injectModeFlag)
+	if err != nil {
+		return UsageError("%v", err)
 	}
 
 	interruptLabel := strings.TrimSpace(*interruptLabelFlag)
@@ -722,6 +732,15 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	if *injectViaFlag != "" && injectVia == "" {
 		return UsageError("--inject-via must not be blank")
 	}
+	if injectMode == wakeInjectModeNone && injectVia != "" {
+		return UsageError("--inject-via cannot be used with --inject-mode none")
+	}
+	if injectMode == wakeInjectModeNone && len(injectArgFlags) > 0 {
+		return UsageError("--inject-arg cannot be used with --inject-mode none")
+	}
+	if injectMode == wakeInjectModeNone && *injectCmdFlag != "" {
+		return UsageError("--inject-cmd cannot be used with --inject-mode none")
+	}
 	if injectVia == "" && len(injectArgFlags) > 0 {
 		return UsageError("--inject-arg requires --inject-via")
 	}
@@ -731,7 +750,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	}
 
 	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
-	if injectVia == "" {
+	if injectVia == "" && injectMode != wakeInjectModeNone {
 		if !tiocsti.Available() {
 			return errors.New("TIOCSTI not available on this platform; use tmux send-keys or terminal-specific injection")
 		}
@@ -770,6 +789,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
 		acceptExistingValid: acceptExistingWake,
 		target:              target,
+		wakeMode:            injectMode,
 	})
 	if err != nil {
 		var alreadyRunning *wakeAlreadyRunningError
@@ -966,6 +986,9 @@ func runWakeLoop(cfg wakeConfig) error {
 }
 
 func wakeHealthCheck(cfg wakeConfig, ttyAvailableFn func() bool) error {
+	if cfg.injectMode == wakeInjectModeNone {
+		return nil
+	}
 	if cfg.injectVia != "" {
 		if cfg.wakeOwner != nil {
 			return wakeOwnerHealthCheck(*cfg.wakeOwner)

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -120,6 +120,36 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopNoneSkipsTTYAndWritesReadyFile(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-mode", "none",
+		"--ready-file", readyPath,
+	}, func(cfg wakeConfig) error {
+		if cfg.injectMode != wakeInjectModeNone {
+			t.Fatalf("injectMode = %q, want none", cfg.injectMode)
+		}
+		if _, statErr := os.Stat(readyPath); statErr != nil {
+			t.Fatalf("expected ready file before wake loop: %v", statErr)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
 func TestRunWakeHelpHidesInternalReadyFlags(t *testing.T) {
 	stdout, _, err := captureWakeRepairOutput(t, func() error {
 		return runWake([]string{"--help"})
@@ -134,6 +164,9 @@ func TestRunWakeHelpHidesInternalReadyFlags(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "inject-cmd") {
 		t.Fatalf("wake help should keep --inject-cmd visible:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "none") || !strings.Contains(stdout, "zero terminal input") {
+		t.Fatalf("wake help should document none as zero-input mode:\n%s", stdout)
 	}
 }
 
@@ -566,6 +599,93 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("expected existing usable wake to satisfy ready file, got %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); statErr != nil {
+		t.Fatalf("ready file should exist, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopNoneRejectsExistingInputWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--inject-mode", "auto"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		TTY:          "test-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-mode", "none",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an existing input wake: %#v", cfg)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "requested --inject-mode none") {
+		t.Fatalf("error = %v, want zero-input existing-wake refusal", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+}
+
+func TestRunWakeWithLoopNoneAcceptsExistingNoneWake(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--inject-mode", "none"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeNone,
+	})
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-mode", "none",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an existing none wake: %#v", cfg)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected existing none wake to satisfy readiness, got %v", err)
 	}
 	if _, statErr := os.Stat(readyPath); statErr != nil {
 		t.Fatalf("ready file should exist, statErr=%v", statErr)
@@ -1652,6 +1772,33 @@ func TestRunWakeWithLoopRejectsInjectArgWithoutInjectVia(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopRejectsNoneWithInputTransports(t *testing.T) {
+	injector := writeExecutableForTest(t, "injector")
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "inject via", args: []string{"--inject-via", injector}, want: "--inject-via"},
+		{name: "inject arg", args: []string{"--inject-arg", "exec"}, want: "--inject-arg"},
+		{name: "inject cmd", args: []string{"--inject-cmd", "amq drain"}, want: "--inject-cmd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{"--root", t.TempDir(), "--me", "orchestrator", "--inject-mode", "none"}
+			args = append(args, tt.args...)
+			err := runWakeWithLoop(args, func(cfg wakeConfig) error {
+				t.Fatalf("loop should not run with invalid flags: %#v", cfg)
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.want) || !strings.Contains(err.Error(), "none") {
+				t.Fatalf("error = %v, want none-mode conflict mentioning %s", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunWakeWithLoopRejectsNonPositiveInjectTimeout(t *testing.T) {
 	err := runWakeWithLoop([]string{
 		"--root", t.TempDir(),
@@ -1676,6 +1823,15 @@ func TestWakeHealthCheckSkipsTTYForInjectVia(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("expected external injection health check to skip TTY, got %v", err)
+	}
+}
+
+func TestWakeHealthCheckSkipsTTYForNoneMode(t *testing.T) {
+	err := wakeHealthCheck(wakeConfig{injectMode: wakeInjectModeNone}, func() bool {
+		return false
+	})
+	if err != nil {
+		t.Fatalf("expected none mode health check to skip TTY, got %v", err)
 	}
 }
 

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -71,6 +71,15 @@ Leader prepares commit -> user approves -> push
 ## Interrupts
 
 - Urgent messages labeled `interrupt` trigger wake Ctrl+C injection + an interrupt notice (when wake is running).
+- Input injection can activate a focused permission or approval dialog. Payload
+  text alone may match single-key shortcuts, so removing Enter is not safe.
+- `--defer-while-input` reduces collisions with recent typing but cannot detect
+  modal state; an idle dialog looks like an idle composer.
+- For an AMQ-enforced zero-input watcher, run `amq wake --inject-mode none` or
+  `amq coop exec --require-wake --wake-inject-mode none <agent>`. This mode
+  writes notices to wake stderr, turns urgent interrupts into one bell plus the
+  output notice, and rejects `--inject-via`, `--inject-arg`, and `--inject-cmd`.
+  Stderr shares the TUI terminal by default and may remain visible until redraw.
 
 ## Message Handling
 


### PR DESCRIPTION
## Summary
- add fail-closed `amq wake --inject-mode none` output-only notifications
- suppress urgent Ctrl+C and emit exactly one BEL plus the stderr notice
- expose zero-input wake through `amq coop exec --wake-inject-mode none` with proven-mode reuse
- document input-injection hazards and modal-detection limits

## Verification
- `go test ./internal/cli`
- `make ci`
- runtime temp-queue proof: one BEL, stderr notice present, no controlling TTY

Closes #216