### PR TITLE
fix(session): refuse cross-session mailbox access and surface sibling backlogs (#224)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ internal/
 ```
 Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and dot (for example `io.github.omriariav.amq-squad`). AMQ will not create files inside layer-owned directories, and `amq cleanup` does not remove extension directories unless a future command explicitly targets extension metadata. Layers may publish a passive root manifest at `<AM_ROOT>/extensions/<layer>/manifest.json`; `amq doctor --json` may report it, but AMQ must not execute extension code or invoke hooks from manifests.
 
-**Environment Variables**: `AM_ROOT` (queue root, e.g., `.agent-mail/collab`), `AM_ME` (agent handle), `AM_BASE_ROOT` (base root set for cross-session resolution), `AM_SESSION` (independent session identity set by `coop exec` and every shell-mode `amq env`, empty for sessionless roots), `AMQ_GLOBAL_ROOT` (global root fallback for orchestrator-spawned agents), `AMQ_NO_UPDATE_CHECK` (disable update check)
+**Environment Variables**: `AM_ROOT` (queue root, e.g., `.agent-mail/collab`), `AM_ME` (agent handle), `AM_BASE_ROOT` (authorized parent for named-session routing, or the exact root for a sessionless pin), `AM_SESSION` (independent session identity set by `coop exec` and every shell-mode `amq env`, empty for sessionless roots), `AMQ_GLOBAL_ROOT` (global root fallback for orchestrator-spawned agents), `AMQ_NO_UPDATE_CHECK` (disable update check)
 
 **Session Layout**: The default base root directory is `.agent-mail/`. `.amqrc` can configure that root explicitly, but the default `.agent-mail/<session>` layout is also recognized without `.amqrc`. `coop exec` defaults to `--session collab`, so agents get session isolation without explicit flags. Use `--session` to override:
 ```
@@ -112,9 +112,9 @@ Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and do
 
 **Cross-tree send guard**: A direct `--root` is root *selection*, not federation routing. `send` refuses an explicit `--root` that targets a different base tree than the caller's own active session (`AM_ROOT`/`AM_BASE_ROOT`) when no routing dimension (`--project`/`--session`/`--from-session`) is given — such a message carries no sender-origin metadata, so the recipient could not reply and a naive reply would loop into their own tree. Replyable cross-tree messaging must use `--project`/`--session`, which stamp the routing headers. With no session env set (bare-root scripts/CI), the guard does not fire; a direct `--root` cross-tree send in that case can still produce an unreplyable message — the documented cost of keeping bare-root sends working.
 
-**Session-root guard**: `read`, `drain`, and `monitor` compare their resolved target against the session identity pinned by `AM_SESSION` (and the full expected path from `AM_BASE_ROOT` when available) before inspecting or moving inbox messages. A mismatch exits with code 5; use `--session <name>` as the deliberate routing dimension. The raw-root escape hatch is `--ignore-session-pin`, which requires an explicit `--root`. `send` applies the same pin check to its local source; target routing never authorizes a mismatched source. `list` warns instead of refusing so it remains a non-destructive inspection path. With no positive session/tree evidence, scripts and CI remain fail-open. A missing mailbox is a not-found error. Empty `drain` and `list --new` results perform a shallow sibling-session scan and write exact `amq list --session <name> --me <handle> --new` inspection commands to stderr; `doctor --ops` reports the same condition as `sibling_backlog` hints.
+**Session-root guard**: `read`, `drain`, `monitor`, `watch`, and mutating DLQ commands compare their resolved target against the exact context pinned by `AM_BASE_ROOT`/`AM_SESSION` before inspecting or moving mailbox state; `send` and `reply` apply the same check to their local source. For named sessions `AM_BASE_ROOT` is the authorized parent; for sessionless contexts it is the exact root and `AM_SESSION` is empty. A mismatch exits with code 5; use `--session <name>` as the deliberate routing dimension. The raw-root escape hatch is `--ignore-session-pin`, which requires a non-empty explicit `--root`; explicitly blank `--root`/`--session` values are usage errors. Target routing never authorizes a mismatched source. `list` warns instead of refusing so it remains a non-destructive inspection path. With no positive session/tree evidence, scripts and CI remain fail-open. A missing mailbox is a not-found error. Empty `drain` and `list --new` results perform a shallow sibling-session scan and write exact `amq list --session <name> --me <handle> --new` inspection commands to stderr; `doctor --ops` reports the same condition as `sibling_backlog` hints. Known limitation: `send --from-session` remains a double-explicit legacy route from its supplied raw base; callers must ensure that base is intentional until the follow-up resolver work lands.
 
-**Environment context replacement**: Every shell-mode `amq env` output replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`, and `AM_SESSION` as one context. Sessionless output unsets `AM_BASE_ROOT` and emits an empty `AM_SESSION`; `--export` additionally prints a pin note. An ambient root that conflicts with an existing pin is rejected unless `--root` or `--session` explicitly repins it.
+**Environment context replacement**: Every shell-mode `amq env` output replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`, and `AM_SESSION` as one context. Sessionless output pins `AM_BASE_ROOT` to the exact root and emits an empty `AM_SESSION`; `--export` additionally prints a pin note. An ambient root that conflicts with an existing pin is rejected unless a non-empty `--root` or `--session` explicitly repins it. `amq env --session` routes from a valid existing pin base before consulting cwd configuration.
 
 **Session Configuration**: The `amq env` command outputs shell commands to set environment variables. It reads configuration from (highest to lowest precedence):
 - **Root**: flags > env (`AM_ROOT`) > project `.amqrc` > `AMQ_GLOBAL_ROOT` > `~/.amqrc` > auto-detect
@@ -179,13 +179,13 @@ amq presence set --me <agent> --status <busy|idle|...> [--note <str>]
 amq presence list [--json]
 amq route explain --to <handle> [--project <project>] [--session <session>] [--from-root <path>] [--from-cwd <path>] [--me <handle>] --json
 amq cleanup --tmp-older-than <duration> [--dry-run] [--yes]
-amq watch --me <agent> [--timeout <duration>] [--poll] [--json]
+amq watch --me <agent> [--session <name>] [--ignore-session-pin] [--timeout <duration>] [--poll] [--json]
 amq monitor --me <agent> [--session <name>] [--ignore-session-pin] [--timeout <duration>] [--poll] [--include-body] [--peek] [--json]
-amq reply --me <agent> --id <msg_id> [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>]
+amq reply --me <agent> --id <msg_id> [--ignore-session-pin] [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>]
 amq dlq list --me <agent> [--new | --cur] [--json]
-amq dlq read --me <agent> --id <dlq_id> [--json]
-amq dlq retry --me <agent> --id <dlq_id> [--all] [--force]
-amq dlq purge --me <agent> [--older-than <duration>] [--dry-run] [--yes]
+amq dlq read --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--json]
+amq dlq retry --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--all] [--force]
+amq dlq purge --me <agent> [--session <name>] [--ignore-session-pin] [--older-than <duration>] [--dry-run] [--yes]
 amq wake --me <agent> [--inject-cmd <cmd>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>]
 amq wake repair --me <agent> [--root <path>] [--json]
 amq upgrade

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ internal/
 ```
 Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and dot (for example `io.github.omriariav.amq-squad`). AMQ will not create files inside layer-owned directories, and `amq cleanup` does not remove extension directories unless a future command explicitly targets extension metadata. Layers may publish a passive root manifest at `<AM_ROOT>/extensions/<layer>/manifest.json`; `amq doctor --json` may report it, but AMQ must not execute extension code or invoke hooks from manifests.
 
-**Environment Variables**: `AM_ROOT` (queue root, e.g., `.agent-mail/collab`), `AM_ME` (agent handle), `AM_BASE_ROOT` (base root set by `coop exec` for cross-session resolution; only trusted when the current root still lives under it), `AMQ_GLOBAL_ROOT` (global root fallback for orchestrator-spawned agents), `AMQ_NO_UPDATE_CHECK` (disable update check)
+**Environment Variables**: `AM_ROOT` (queue root, e.g., `.agent-mail/collab`), `AM_ME` (agent handle), `AM_BASE_ROOT` (base root set for cross-session resolution), `AM_SESSION` (independent session identity set by `coop exec` and every shell-mode `amq env`, empty for sessionless roots), `AMQ_GLOBAL_ROOT` (global root fallback for orchestrator-spawned agents), `AMQ_NO_UPDATE_CHECK` (disable update check)
 
 **Session Layout**: The default base root directory is `.agent-mail/`. `.amqrc` can configure that root explicitly, but the default `.agent-mail/<session>` layout is also recognized without `.amqrc`. `coop exec` defaults to `--session collab`, so agents get session isolation without explicit flags. Use `--session` to override:
 ```
@@ -111,6 +111,10 @@ Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and do
 `AM_ROOT` points to the queue root. When `--root` is explicitly provided, it takes precedence over `AM_ROOT`. `send` and `reply` emit a `note:` on stderr when an explicit `--root` overrides `AM_ROOT`.
 
 **Cross-tree send guard**: A direct `--root` is root *selection*, not federation routing. `send` refuses an explicit `--root` that targets a different base tree than the caller's own active session (`AM_ROOT`/`AM_BASE_ROOT`) when no routing dimension (`--project`/`--session`/`--from-session`) is given — such a message carries no sender-origin metadata, so the recipient could not reply and a naive reply would loop into their own tree. Replyable cross-tree messaging must use `--project`/`--session`, which stamp the routing headers. With no session env set (bare-root scripts/CI), the guard does not fire; a direct `--root` cross-tree send in that case can still produce an unreplyable message — the documented cost of keeping bare-root sends working.
+
+**Session-root guard**: `read`, `drain`, and `monitor` compare their resolved target against the session identity pinned by `AM_SESSION` (and the full expected path from `AM_BASE_ROOT` when available) before inspecting or moving inbox messages. A mismatch exits with code 5; use `--session <name>` as the deliberate routing dimension. The raw-root escape hatch is `--ignore-session-pin`, which requires an explicit `--root`. `send` applies the same pin check to its local source; target routing never authorizes a mismatched source. `list` warns instead of refusing so it remains a non-destructive inspection path. With no positive session/tree evidence, scripts and CI remain fail-open. A missing mailbox is a not-found error. Empty `drain` and `list --new` results perform a shallow sibling-session scan and write exact `amq list --session <name> --me <handle> --new` inspection commands to stderr; `doctor --ops` reports the same condition as `sibling_backlog` hints.
+
+**Environment context replacement**: Every shell-mode `amq env` output replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`, and `AM_SESSION` as one context. Sessionless output unsets `AM_BASE_ROOT` and emits an empty `AM_SESSION`; `--export` additionally prints a pin note. An ambient root that conflicts with an existing pin is rejected unless `--root` or `--session` explicitly repins it.
 
 **Session Configuration**: The `amq env` command outputs shell commands to set environment variables. It reads configuration from (highest to lowest precedence):
 - **Root**: flags > env (`AM_ROOT`) > project `.amqrc` > `AMQ_GLOBAL_ROOT` > `~/.amqrc` > auto-detect
@@ -164,10 +168,10 @@ When `--kind` is set but `--priority` is not, priority defaults to `normal`.
 
 ```bash
 amq init --root <path> --agents a,b,c [--force]
-amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--session <target-session>] [--from-session <source-session>] [--project <project>] [--wait-for <stage>] [--wait-timeout <duration>]
-amq list --me <agent> [--new | --cur] [--priority <p>] [--from <h>] [--kind <k>] [--label <l>...] [--limit N] [--offset N] [--json]
-amq read --me <agent> --id <msg_id> [--json]
-amq drain --me <agent> [--limit N] [--include-body] [--json]
+amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--session <target-session>] [--from-session <source-session>] [--project <project>] [--ignore-session-pin] [--wait-for <stage>] [--wait-timeout <duration>]
+amq list --me <agent> [--session <name>] [--new | --cur] [--priority <p>] [--from <h>] [--kind <k>] [--label <l>...] [--limit N] [--offset N] [--json]
+amq read --me <agent> --id <msg_id> [--session <name>] [--ignore-session-pin] [--json]
+amq drain --me <agent> [--session <name>] [--ignore-session-pin] [--limit N] [--include-body] [--json]
 amq thread --id <thread_id> [--limit N] [--include-body] [--json]
 amq receipts list --me <agent> [--msg-id <id>] [--stage <stage>] [--json]
 amq receipts wait --me <agent> --msg-id <id> [--stage <stage>] [--timeout <duration>] [--poll-interval <duration>] [--json]
@@ -176,7 +180,7 @@ amq presence list [--json]
 amq route explain --to <handle> [--project <project>] [--session <session>] [--from-root <path>] [--from-cwd <path>] [--me <handle>] --json
 amq cleanup --tmp-older-than <duration> [--dry-run] [--yes]
 amq watch --me <agent> [--timeout <duration>] [--poll] [--json]
-amq monitor --me <agent> [--timeout <duration>] [--poll] [--include-body] [--peek] [--json]
+amq monitor --me <agent> [--session <name>] [--ignore-session-pin] [--timeout <duration>] [--poll] [--include-body] [--peek] [--json]
 amq reply --me <agent> --id <msg_id> [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>]
 amq dlq list --me <agent> [--new | --cur] [--json]
 amq dlq read --me <agent> --id <dlq_id> [--json]
@@ -340,6 +344,7 @@ Use `--force` with retry to override the max retry limit.
 `amq doctor --ops` adds runtime checks:
 
 - Queue depth and oldest unread per agent
+- Sibling-session backlogs for the same handles
 - DLQ count and oldest age
 - Presence freshness
 - Wake lock health (`--fix-wake-locks` removes stale locks)

--- a/COOP.md
+++ b/COOP.md
@@ -84,11 +84,12 @@ amq list --session auth --new
 amq drain --session auth --include-body
 ```
 
-When a terminal has an `AM_SESSION` pin, `read`, `drain`, and `monitor` refuse a
-conflicting raw `AM_ROOT`/`--root` before inspecting or moving messages. Use
-`--session <name>` for sibling routing. For deliberate raw-root access,
-`--ignore-session-pin` requires an explicit `--root`; it never blesses an
-inherited `AM_ROOT`. `list` warns on a mismatch but remains available for
+When a terminal has a complete `AM_BASE_ROOT`/`AM_SESSION` pin, `read`, `drain`,
+`monitor`, `watch`, `reply`, and mutating DLQ commands refuse a conflicting raw
+`AM_ROOT`/`--root` before inspecting or moving mailbox state. Use `--session
+<name>` for sibling routing. For deliberate raw-root access,
+`--ignore-session-pin` requires a non-empty explicit `--root`; it never blesses
+an inherited `AM_ROOT`. `list` warns on a mismatch but remains available for
 non-destructive inspection. A missing mailbox is an error, not an empty inbox.
 
 ### For Scripts/CI
@@ -100,8 +101,8 @@ eval "$(amq env --me claude)"
 ```
 
 All shell-mode `amq env` output replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`,
-and `AM_SESSION` as one context. For a base/sessionless root it unsets
-`AM_BASE_ROOT` and sets `AM_SESSION` to the empty string.
+and `AM_SESSION` as one context. For a base/sessionless root it sets
+`AM_BASE_ROOT` to that exact root and `AM_SESSION` to the empty string.
 
 `amq env` resolves the root with the full precedence chain:
 

--- a/COOP.md
+++ b/COOP.md
@@ -47,7 +47,13 @@ amq coop exec claude -- --dangerously-skip-permissions
 amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
 ```
 
-That's it. `coop exec` auto-initializes the project if needed, sets `AM_ROOT`/`AM_ME` (and `AM_BASE_ROOT` for cross-session resolution), starts wake notifications, and execs into the agent. Without `--session` or `--root`, it defaults to `--session collab` (i.e., `AM_ROOT=.agent-mail/collab`).
+That's it. `coop exec` auto-initializes the project if needed, sets
+`AM_ROOT`/`AM_ME`, `AM_BASE_ROOT`, and the independent `AM_SESSION` identity,
+starts wake notifications, and execs into the agent. Without `--session` or
+`--root`, it defaults to `--session collab` (i.e.,
+`AM_ROOT=.agent-mail/collab`, `AM_SESSION=collab`). A session-shaped explicit
+root such as `.agent-mail/auth` pins the inferred session; a custom sessionless
+root clears `AM_SESSION`.
 
 To disable auto-wake (e.g., in CI or non-TTY environments):
 ```bash
@@ -71,6 +77,20 @@ amq coop exec --session api codex                 # Terminal 4
 Each pair has isolated inboxes and threads. Messages stay within their root.
 Equivalent explicit root form: `--root .agent-mail/<session>`.
 
+For read-side access, prefer the named route:
+
+```bash
+amq list --session auth --new
+amq drain --session auth --include-body
+```
+
+When a terminal has an `AM_SESSION` pin, `read`, `drain`, and `monitor` refuse a
+conflicting raw `AM_ROOT`/`--root` before inspecting or moving messages. Use
+`--session <name>` for sibling routing. For deliberate raw-root access,
+`--ignore-session-pin` requires an explicit `--root`; it never blesses an
+inherited `AM_ROOT`. `list` warns on a mismatch but remains available for
+non-destructive inspection. A missing mailbox is an error, not an empty inbox.
+
 ### For Scripts/CI
 
 When you can't use `exec` (non-interactive environments):
@@ -78,6 +98,10 @@ When you can't use `exec` (non-interactive environments):
 amq coop init
 eval "$(amq env --me claude)"
 ```
+
+All shell-mode `amq env` output replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`,
+and `AM_SESSION` as one context. For a base/sessionless root it unsets
+`AM_BASE_ROOT` and sets `AM_SESSION` to the empty string.
 
 `amq env` resolves the root with the full precedence chain:
 

--- a/README.md
+++ b/README.md
@@ -154,15 +154,17 @@ amq reply --id <msg_id> --kind review_response --body "LGTM with comments"
 
 `amq read`, `amq drain`, and `amq monitor` now share the same strict header validation. If a message in `inbox/new` is corrupt or has malformed headers, the command moves it to DLQ and emits a `dlq` receipt instead of leaving it in place.
 
-`coop exec` and every shell-mode `amq env` invocation pin the terminal's
-session identity in `AM_SESSION`. `read`, `drain`, and `monitor` refuse to
-inspect or consume a raw root that conflicts with that pin before moving any
-message. Use `--session <name>` to target a sibling deliberately. For deliberate
-raw-root access, `--ignore-session-pin` is accepted only together with an
-explicit `--root`; it cannot turn an inherited `AM_ROOT` into an implicit
-override. `list` remains a non-destructive inspection path: it warns on a pin
-mismatch but still lists the resolved mailbox. Unpinned scripts and CI retain
-the existing fail-open behavior.
+`coop exec` and every shell-mode `amq env` invocation pin the terminal's exact
+root context with `AM_BASE_ROOT` plus `AM_SESSION`. For named sessions,
+`AM_BASE_ROOT` is the authorized parent; for sessionless contexts, it is the
+exact root and `AM_SESSION` is empty. `read`, `drain`, `monitor`, `watch`,
+`reply`, and mutating DLQ commands refuse a raw root that conflicts with that
+pin before reading or moving mailbox state. Use `--session <name>` to target a
+sibling deliberately. For deliberate raw-root access, `--ignore-session-pin`
+is accepted only together with a non-empty explicit `--root`; blank `--root`
+and `--session` values are usage errors. `list` remains a non-destructive
+inspection path: it warns on a pin mismatch but still lists the resolved
+mailbox. Unpinned scripts and CI retain the existing fail-open behavior.
 
 A missing mailbox is an error, not an empty inbox. When `drain` or `list --new`
 finds an actually empty inbox, it prints a stderr-only note if the same handle
@@ -268,10 +270,11 @@ eval "$(amq env --session auth --me claude --export)"
 ```
 
 Every shell-mode `amq env` output replaces the complete context: `AM_ROOT`,
-`AM_ME`, and `AM_SESSION`, plus `AM_BASE_ROOT` for session roots. Sessionless
-output unsets `AM_BASE_ROOT` and writes an empty `AM_SESSION`, so stale context
-cannot survive `eval`. `--export` additionally prints a stderr note that the
-terminal is pinned. Treat this as one terminal, one session.
+`AM_ME`, `AM_BASE_ROOT`, and `AM_SESSION`. Sessionless output sets
+`AM_BASE_ROOT` to the exact root and writes an empty `AM_SESSION`, so changing
+to another sessionless root is detectable. `--export` additionally prints a
+stderr note that the terminal is pinned. Treat this as one terminal, one
+session.
 
 Auto-detect covers the default `.agent-mail` layout, including `.agent-mail/<session>` session roots without `.amqrc`. Custom root names and peer config still require `.amqrc` or explicit flags/env.
 This same chain is used by `amq env`, `amq doctor`, and the integration commands, so Symphony and Kanban-launched agents can find the correct queue even when they are not started from the project directory.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ AMQ gives agents a **local interoperability bus**: they can send messages, reply
 - **Cross-project federation** — Route messages across peer repos, preserve reply routing, and run decision threads that span projects.
 - **Swarm mode** — Join Claude Code Agent Teams, claim tasks, and bridge task notifications into AMQ.
 - **Optional adapters** — Lightweight Symphony hooks and an experimental Kanban bridge can emit normal AMQ messages with structured metadata.
-- **Operational diagnostics** — `amq doctor --ops` shows queue depth, DLQ state, presence freshness, and integration hints.
+- **Operational diagnostics** — `amq doctor --ops` shows queue depth, sibling-session backlogs, DLQ state, presence freshness, and integration hints.
 
 ![AMQ Demo — Claude and Codex collaborating via split-pane terminal](docs/assets/demo.gif)
 
@@ -154,6 +154,24 @@ amq reply --id <msg_id> --kind review_response --body "LGTM with comments"
 
 `amq read`, `amq drain`, and `amq monitor` now share the same strict header validation. If a message in `inbox/new` is corrupt or has malformed headers, the command moves it to DLQ and emits a `dlq` receipt instead of leaving it in place.
 
+`coop exec` and every shell-mode `amq env` invocation pin the terminal's
+session identity in `AM_SESSION`. `read`, `drain`, and `monitor` refuse to
+inspect or consume a raw root that conflicts with that pin before moving any
+message. Use `--session <name>` to target a sibling deliberately. For deliberate
+raw-root access, `--ignore-session-pin` is accepted only together with an
+explicit `--root`; it cannot turn an inherited `AM_ROOT` into an implicit
+override. `list` remains a non-destructive inspection path: it warns on a pin
+mismatch but still lists the resolved mailbox. Unpinned scripts and CI retain
+the existing fail-open behavior.
+
+A missing mailbox is an error, not an empty inbox. When `drain` or `list --new`
+finds an actually empty inbox, it prints a stderr-only note if the same handle
+has pending messages in a sibling session, including an exact non-destructive
+`amq list --session <name> --me <handle> --new` command. `doctor --ops` reports
+the same condition as a `sibling_backlog` warning. The pin is an operational
+safety check, not access control: a local process can still repin the
+environment or use the explicit override.
+
 ### 4. Inspect Health
 
 ```bash
@@ -249,9 +267,11 @@ session, opt in explicitly:
 eval "$(amq env --session auth --me claude --export)"
 ```
 
-That exports `AM_ROOT`, `AM_ME`, and, for session roots, `AM_BASE_ROOT`, and
-prints a stderr note that the terminal is pinned. Treat this as one terminal,
-one session.
+Every shell-mode `amq env` output replaces the complete context: `AM_ROOT`,
+`AM_ME`, and `AM_SESSION`, plus `AM_BASE_ROOT` for session roots. Sessionless
+output unsets `AM_BASE_ROOT` and writes an empty `AM_SESSION`, so stale context
+cannot survive `eval`. `--export` additionally prints a stderr note that the
+terminal is pinned. Treat this as one terminal, one session.
 
 Auto-detect covers the default `.agent-mail` layout, including `.agent-mail/<session>` session roots without `.amqrc`. Custom root names and peer config still require `.amqrc` or explicit flags/env.
 This same chain is used by `amq env`, `amq doctor`, and the integration commands, so Symphony and Kanban-launched agents can find the correct queue even when they are not started from the project directory.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,6 +6,7 @@ const (
 	envRoot       = "AM_ROOT"
 	envMe         = "AM_ME"
 	envBaseRoot   = "AM_BASE_ROOT"
+	envSession    = "AM_SESSION"
 	envGlobalRoot = "AMQ_GLOBAL_ROOT"
 )
 

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -37,16 +37,7 @@ func addCommonFlags(fs *flag.FlagSet) *commonFlags {
 // to defaulted from env/.amqrc). Used to distinguish a deliberate root override
 // from the resolved default.
 func (f *commonFlags) rootExplicit() bool {
-	if f.flagSet == nil {
-		return false
-	}
-	explicit := false
-	f.flagSet.Visit(func(fl *flag.Flag) {
-		if fl.Name == "root" {
-			explicit = true
-		}
-	})
-	return explicit
+	return flagWasVisited(f.flagSet, "root")
 }
 
 // warnRootOverride emits a diagnostic note to stderr when --root was explicitly
@@ -606,7 +597,25 @@ func parseFlags(fs *flag.FlagSet, args []string, usage func()) (bool, error) {
 		}
 		return false, UsageError("%v", err)
 	}
+	for _, name := range []string{"root", "session"} {
+		if fl := fs.Lookup(name); fl != nil && flagWasVisited(fs, name) && strings.TrimSpace(fl.Value.String()) == "" {
+			return false, UsageError("--%s cannot be empty", name)
+		}
+	}
 	return false, nil
+}
+
+func flagWasVisited(fs *flag.FlagSet, name string) bool {
+	if fs == nil {
+		return false
+	}
+	visited := false
+	fs.Visit(func(fl *flag.Flag) {
+		if fl.Name == name {
+			visited = true
+		}
+	})
+	return visited
 }
 
 // rejectPositionalArgs returns a UsageError if the flag set has any remaining

--- a/internal/cli/consume_session_guard_test.go
+++ b/internal/cli/consume_session_guard_test.go
@@ -369,11 +369,12 @@ func TestDrainAllowsBareRootWithoutSessionIdentity(t *testing.T) {
 
 func TestDrainTreatsPresentEmptySessionPinAsBaseContext(t *testing.T) {
 	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
 	targetRoot := sessionRoot(t, parent, "session2", "alice")
 	deliverGuardMessage(t, targetRoot, "alice", "base-pin-mismatch")
 
 	t.Setenv("AM_ROOT", targetRoot)
-	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", baseRoot)
 	t.Setenv("AM_SESSION", "")
 
 	err := runDrain([]string{"--me", "alice"})
@@ -399,7 +400,10 @@ func TestEnvExportPinsAndClearsAMSession(t *testing.T) {
 
 	t.Setenv("AM_ROOT", "")
 	t.Setenv("AM_BASE_ROOT", "")
-	t.Setenv("AM_SESSION", "stale")
+	t.Setenv("AM_SESSION", "temporary")
+	if err := os.Unsetenv("AM_SESSION"); err != nil {
+		t.Fatalf("unset AM_SESSION: %v", err)
+	}
 	t.Setenv("AM_ME", "")
 	t.Setenv("AMQ_GLOBAL_ROOT", "")
 
@@ -417,6 +421,8 @@ func TestEnvExportPinsAndClearsAMSession(t *testing.T) {
 	if err := os.MkdirAll(baseRoot, 0o700); err != nil {
 		t.Fatalf("mkdir base root: %v", err)
 	}
+	t.Setenv("AM_BASE_ROOT", filepath.Join(project, "stale-base"))
+	t.Setenv("AM_SESSION", "stale")
 	stdout, _, err = captureEnvOutput(t, func() error {
 		return runEnv([]string{"--root", baseRoot, "--me", "codex", "--export"})
 	})
@@ -499,8 +505,8 @@ func TestEnvExplicitRepinReplacesFullContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("explicit base repin: %v", err)
 	}
-	if !strings.Contains(stdout, "unset AM_BASE_ROOT\n") || !strings.Contains(stdout, "export AM_SESSION=\n") {
-		t.Fatalf("base repin did not clear session context: %q", stdout)
+	if !strings.Contains(stdout, "export AM_BASE_ROOT="+baseRoot+"\n") || !strings.Contains(stdout, "export AM_SESSION=\n") {
+		t.Fatalf("base repin did not replace session context: %q", stdout)
 	}
 
 	stdout, _, err = captureEnvOutput(t, func() error {
@@ -509,8 +515,8 @@ func TestEnvExplicitRepinReplacesFullContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("explicit fish base repin: %v", err)
 	}
-	if !strings.Contains(stdout, "set -e AM_BASE_ROOT\n") || !strings.Contains(stdout, "set -gx AM_SESSION ''\n") {
-		t.Fatalf("fish base repin did not clear session context: %q", stdout)
+	if !strings.Contains(stdout, "set -gx AM_BASE_ROOT "+baseRoot+"\n") || !strings.Contains(stdout, "set -gx AM_SESSION ''\n") {
+		t.Fatalf("fish base repin did not replace session context: %q", stdout)
 	}
 }
 
@@ -542,8 +548,11 @@ func TestBuildCoopExecEnvironmentPinsSessionIdentity(t *testing.T) {
 	if got := envValue(env, "AM_SESSION"); got != "" {
 		t.Fatalf("custom sessionless --root should clear AM_SESSION, got %q", got)
 	}
-	if envHasKey(env, "AM_BASE_ROOT") {
-		t.Fatalf("custom sessionless --root should remove AM_BASE_ROOT: %#v", env)
+	if !envHasKey(env, "AM_BASE_ROOT") {
+		t.Fatalf("custom sessionless --root should include AM_BASE_ROOT: %#v", env)
+	}
+	if got := envValue(env, "AM_BASE_ROOT"); got != customRoot {
+		t.Fatalf("custom sessionless --root should pin exact AM_BASE_ROOT, got %q", got)
 	}
 }
 

--- a/internal/cli/consume_session_guard_test.go
+++ b/internal/cli/consume_session_guard_test.go
@@ -1,0 +1,630 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestDrainRefusesSiblingSessionFromOverriddenAMRoot(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "sibling-theft")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runDrain([]string{"--me", "alice"})
+	assertConsumeRefused(t, err, "drain")
+	if got := inboxCount(t, targetRoot, "alice"); got != 1 {
+		t.Fatalf("foreign message count = %d, want 1 untouched in inbox/new", got)
+	}
+}
+
+func TestDrainRefusesCrossTreeWithoutSessionPin(t *testing.T) {
+	parent := t.TempDir()
+	sourceBase := filepath.Join(parent, "source", ".agent-mail")
+	targetRoot := sessionRoot(t, filepath.Join(parent, "target"), "session1", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "cross-tree-theft")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", sourceBase)
+	t.Setenv("AM_SESSION", "temporary")
+	if err := os.Unsetenv("AM_SESSION"); err != nil {
+		t.Fatalf("unset AM_SESSION: %v", err)
+	}
+
+	err := runDrain([]string{"--me", "alice"})
+	assertConsumeRefused(t, err, "drain")
+	if got := inboxCount(t, targetRoot, "alice"); got != 1 {
+		t.Fatalf("foreign message count = %d, want 1 untouched in inbox/new", got)
+	}
+}
+
+func TestDrainRefusesSameNamedSessionInDifferentBaseTree(t *testing.T) {
+	parent := t.TempDir()
+	sourceBase := filepath.Join(parent, "source", ".agent-mail")
+	targetRoot := sessionRoot(t, filepath.Join(parent, "target"), "session1", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "same-name-foreign-tree")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", sourceBase)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runDrain([]string{"--me", "alice"})
+	assertConsumeRefused(t, err, "drain")
+	if got := inboxCount(t, targetRoot, "alice"); got != 1 {
+		t.Fatalf("foreign same-named session count = %d, want 1 untouched", got)
+	}
+}
+
+func TestDrainAllowsPinnedSessionRoot(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	root := sessionRoot(t, parent, "session1", "alice")
+	deliverGuardMessage(t, root, "alice", "owned")
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	if err := runDrain([]string{"--me", "alice"}); err != nil {
+		t.Fatalf("pinned session drain should succeed: %v", err)
+	}
+}
+
+func TestDrainAllowsExplicitSessionRouting(t *testing.T) {
+	parent := t.TempDir()
+	authorizedParent := filepath.Join(parent, "authorized")
+	ambientParent := filepath.Join(parent, "ambient")
+	authorizedBase := filepath.Join(authorizedParent, ".agent-mail")
+	_ = sessionRoot(t, authorizedParent, "session1", "alice")
+	authorizedTarget := sessionRoot(t, authorizedParent, "session2", "alice")
+	ambientRoot := sessionRoot(t, ambientParent, "session9", "alice")
+	ambientTarget := sessionRoot(t, ambientParent, "session2", "alice")
+	deliverGuardMessage(t, authorizedTarget, "alice", "authorized-target")
+	deliverGuardMessage(t, ambientTarget, "alice", "ambient-target")
+
+	t.Setenv("AM_ROOT", ambientRoot)
+	t.Setenv("AM_BASE_ROOT", authorizedBase)
+	t.Setenv("AM_SESSION", "session1")
+
+	if err := runDrain([]string{"--me", "alice", "--session", "session2"}); err != nil {
+		t.Fatalf("explicit --session should route through the pinned base: %v", err)
+	}
+	if got := inboxCount(t, authorizedTarget, "alice"); got != 0 {
+		t.Fatalf("authorized target count = %d, want 0 after routed drain", got)
+	}
+	if got := inboxCount(t, ambientTarget, "alice"); got != 1 {
+		t.Fatalf("ambient-base target count = %d, want 1 untouched", got)
+	}
+}
+
+func TestDrainSessionRouteRequiresExistingMailbox(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	sourceRoot := sessionRoot(t, parent, "session1", "alice")
+	missingMailboxRoot := filepath.Join(baseRoot, "session2")
+	if err := os.MkdirAll(missingMailboxRoot, 0o700); err != nil {
+		t.Fatalf("mkdir target root: %v", err)
+	}
+
+	t.Setenv("AM_ROOT", sourceRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runDrain([]string{"--me", "alice", "--session", "session2"})
+	if err == nil || GetExitCode(err) != ExitNotFound {
+		t.Fatalf("missing routed mailbox should be not-found, got %v", err)
+	}
+}
+
+func TestDrainAllowsExplicitRootWhenIgnoringSessionPin(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	sourceRoot := sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "explicit-override")
+
+	t.Setenv("AM_ROOT", sourceRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	if err := runDrain([]string{"--root", targetRoot, "--me", "alice", "--ignore-session-pin"}); err != nil {
+		t.Fatalf("explicit root plus pin override should allow drain: %v", err)
+	}
+	if got := inboxCount(t, targetRoot, "alice"); got != 0 {
+		t.Fatalf("target inbox/new count = %d, want 0 after override drain", got)
+	}
+}
+
+func TestDrainRejectsPinOverrideWithoutExplicitRoot(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "ambient-override")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runDrain([]string{"--me", "alice", "--ignore-session-pin"})
+	if err == nil || GetExitCode(err) != ExitUsage {
+		t.Fatalf("ambient pin override should be a usage error, got %v", err)
+	}
+	if got := inboxCount(t, targetRoot, "alice"); got != 1 {
+		t.Fatalf("target count = %d, want 1 untouched", got)
+	}
+}
+
+func TestDrainRejectsPinOverrideWithSessionRoute(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	sourceRoot := sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "routed-override")
+
+	t.Setenv("AM_ROOT", sourceRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runDrain([]string{"--me", "alice", "--session", "session2", "--ignore-session-pin"})
+	if err == nil || GetExitCode(err) != ExitUsage {
+		t.Fatalf("pin override plus named route should be a usage error, got %v", err)
+	}
+	if got := inboxCount(t, targetRoot, "alice"); got != 1 {
+		t.Fatalf("target count = %d, want 1 untouched", got)
+	}
+}
+
+func TestMonitorRefusesForeignSessionBeforeDrain(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "monitor-theft")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runMonitor([]string{"--me", "alice", "--timeout", "1ms"})
+	assertConsumeRefused(t, err, "monitor")
+	if got := inboxCount(t, targetRoot, "alice"); got != 1 {
+		t.Fatalf("foreign message count = %d, want 1 untouched in inbox/new", got)
+	}
+}
+
+func TestMonitorMissingMailboxDoesNotCreateIt(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	root := filepath.Join(baseRoot, "session1")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runMonitor([]string{"--me", "alice", "--timeout", "1ms", "--poll"})
+	if err == nil || GetExitCode(err) != ExitNotFound {
+		t.Fatalf("missing monitor mailbox should be not-found, got %v", err)
+	}
+	if _, statErr := os.Stat(fsq.AgentInboxNew(root, "alice")); !os.IsNotExist(statErr) {
+		t.Fatalf("monitor created missing inbox, stat error = %v", statErr)
+	}
+}
+
+func TestMonitorRechecksSessionPinBeforePostWatchDrain(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	root := sessionRoot(t, parent, "session1", "alice")
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	delivered := make(chan error, 1)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		if err := os.Setenv("AM_SESSION", "session2"); err != nil {
+			delivered <- err
+			return
+		}
+		delivered <- deliverGuardMessageError(root, "alice", "after-pin-change")
+	}()
+
+	err := runMonitor([]string{"--me", "alice", "--timeout", "2s", "--poll"})
+	if deliverErr := <-delivered; deliverErr != nil {
+		t.Fatalf("deliver message: %v", deliverErr)
+	}
+	assertConsumeRefused(t, err, "monitor")
+	if got := inboxCount(t, root, "alice"); got != 1 {
+		t.Fatalf("post-watch message count = %d, want 1 untouched", got)
+	}
+}
+
+func TestMonitorMailboxDisappearanceIsNotTimeout(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	root := sessionRoot(t, parent, "session1", "alice")
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	removed := make(chan error, 1)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		removed <- os.RemoveAll(fsq.AgentInboxNew(root, "alice"))
+	}()
+
+	err := runMonitor([]string{"--me", "alice", "--timeout", "2s", "--poll"})
+	if removeErr := <-removed; removeErr != nil {
+		t.Fatalf("remove inbox: %v", removeErr)
+	}
+	if err == nil || GetExitCode(err) != ExitNotFound {
+		t.Fatalf("disappeared mailbox should be not-found, got %v", err)
+	}
+}
+
+func TestMonitorMailboxDisappearanceWithFsnotifyIsNotTimeout(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	root := sessionRoot(t, parent, "session1", "alice")
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	removed := make(chan error, 1)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		removed <- os.RemoveAll(fsq.AgentInboxNew(root, "alice"))
+	}()
+
+	err := runMonitor([]string{"--me", "alice", "--timeout", "2s"})
+	if removeErr := <-removed; removeErr != nil {
+		t.Fatalf("remove inbox: %v", removeErr)
+	}
+	if err == nil || GetExitCode(err) != ExitNotFound {
+		t.Fatalf("fsnotify disappearance should be not-found, got %v", err)
+	}
+}
+
+func TestReadRefusesForeignSessionBeforeMove(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "read-theft")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runRead([]string{"--me", "alice", "--id", "read-theft"})
+	assertConsumeRefused(t, err, "read")
+	if got := inboxCount(t, targetRoot, "alice"); got != 1 {
+		t.Fatalf("foreign message count = %d, want 1 untouched in inbox/new", got)
+	}
+}
+
+func TestReadRefusesForeignSessionBeforeDLQMove(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	badPath := filepath.Join(fsq.AgentInboxNew(targetRoot, "alice"), "corrupt.md")
+	if err := os.WriteFile(badPath, []byte("not an AMQ message"), 0o600); err != nil {
+		t.Fatalf("write corrupt message: %v", err)
+	}
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runRead([]string{"--me", "alice", "--id", "corrupt"})
+	assertConsumeRefused(t, err, "read")
+	if _, statErr := os.Stat(badPath); statErr != nil {
+		t.Fatalf("corrupt message moved from inbox/new: %v", statErr)
+	}
+	dlqEntries, dlqErr := os.ReadDir(fsq.AgentDLQNew(targetRoot, "alice"))
+	if dlqErr != nil {
+		t.Fatalf("read DLQ: %v", dlqErr)
+	}
+	if len(dlqEntries) != 0 {
+		t.Fatalf("foreign read moved %d message(s) to DLQ", len(dlqEntries))
+	}
+}
+
+func TestDrainAllowsBareRootWithoutSessionIdentity(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	deliverGuardMessage(t, root, "alice", "bare-root")
+
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_SESSION", "temporary")
+	if err := os.Unsetenv("AM_SESSION"); err != nil {
+		t.Fatalf("unset AM_SESSION: %v", err)
+	}
+
+	if err := runDrain([]string{"--root", root, "--me", "alice"}); err != nil {
+		t.Fatalf("bare-root drain should stay fail-open: %v", err)
+	}
+}
+
+func TestDrainTreatsPresentEmptySessionPinAsBaseContext(t *testing.T) {
+	parent := t.TempDir()
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "base-pin-mismatch")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_SESSION", "")
+
+	err := runDrain([]string{"--me", "alice"})
+	assertConsumeRefused(t, err, "drain")
+	if got := inboxCount(t, targetRoot, "alice"); got != 1 {
+		t.Fatalf("target count = %d, want 1 untouched", got)
+	}
+}
+
+func TestEnvExportPinsAndClearsAMSession(t *testing.T) {
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), []byte(`{"root":".agent-mail"}`), 0o600); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWD) }()
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	t.Setenv("AM_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_SESSION", "stale")
+	t.Setenv("AM_ME", "")
+	t.Setenv("AMQ_GLOBAL_ROOT", "")
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--session", "session1", "--me", "codex", "--export"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv session export: %v", err)
+	}
+	if !strings.Contains(stdout, "export AM_SESSION=session1\n") {
+		t.Fatalf("session export must pin AM_SESSION, got %q", stdout)
+	}
+
+	baseRoot := filepath.Join(project, ".agent-mail")
+	if err := os.MkdirAll(baseRoot, 0o700); err != nil {
+		t.Fatalf("mkdir base root: %v", err)
+	}
+	stdout, _, err = captureEnvOutput(t, func() error {
+		return runEnv([]string{"--root", baseRoot, "--me", "codex", "--export"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv base export: %v", err)
+	}
+	if !strings.Contains(stdout, "export AM_SESSION=\n") {
+		t.Fatalf("sessionless export must clear stale AM_SESSION, got %q", stdout)
+	}
+}
+
+func TestEnvRejectsAmbientRootLaundering(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "codex")
+	targetRoot := sessionRoot(t, parent, "session2", "codex")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+	t.Setenv("AM_ME", "codex")
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv(nil)
+	})
+	if err == nil || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("plain env should reject laundering a mismatched AM_ROOT, got %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("mismatched env emitted shell commands: %q", stdout)
+	}
+}
+
+func TestEnvExplicitRepinReplacesFullContext(t *testing.T) {
+	project := t.TempDir()
+	baseRoot := filepath.Join(project, ".agent-mail")
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), []byte(`{"root":".agent-mail"}`), 0o600); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+	_ = sessionRoot(t, project, "session1", "codex")
+	_ = sessionRoot(t, project, "session2", "codex")
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWD) }()
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	resolvedProject, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("resolved getwd: %v", err)
+	}
+	baseRoot = filepath.Join(resolvedProject, ".agent-mail")
+
+	t.Setenv("AM_ROOT", filepath.Join(baseRoot, "session1"))
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+	t.Setenv("AM_ME", "codex")
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--session", "session2", "--me", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("explicit session repin: %v", err)
+	}
+	for _, want := range []string{
+		"export AM_ROOT=" + filepath.Join(baseRoot, "session2") + "\n",
+		"export AM_BASE_ROOT=" + baseRoot + "\n",
+		"export AM_SESSION=session2\n",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("session repin missing %q: %q", want, stdout)
+		}
+	}
+
+	stdout, _, err = captureEnvOutput(t, func() error {
+		return runEnv([]string{"--root", baseRoot, "--me", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("explicit base repin: %v", err)
+	}
+	if !strings.Contains(stdout, "unset AM_BASE_ROOT\n") || !strings.Contains(stdout, "export AM_SESSION=\n") {
+		t.Fatalf("base repin did not clear session context: %q", stdout)
+	}
+
+	stdout, _, err = captureEnvOutput(t, func() error {
+		return runEnv([]string{"--root", baseRoot, "--me", "codex", "--shell", "fish"})
+	})
+	if err != nil {
+		t.Fatalf("explicit fish base repin: %v", err)
+	}
+	if !strings.Contains(stdout, "set -e AM_BASE_ROOT\n") || !strings.Contains(stdout, "set -gx AM_SESSION ''\n") {
+		t.Fatalf("fish base repin did not clear session context: %q", stdout)
+	}
+}
+
+func TestBuildCoopExecEnvironmentPinsSessionIdentity(t *testing.T) {
+	base := []string{
+		"PATH=/bin",
+		"AM_ROOT=/stale/root",
+		"AM_BASE_ROOT=/stale/base",
+		"AM_SESSION=stale",
+	}
+	root := filepath.Join(t.TempDir(), ".agent-mail", "session1")
+	env := buildCoopExecEnvironment(base, root, "codex", "session1")
+
+	if got := envValue(env, "AM_ROOT"); got != root {
+		t.Fatalf("AM_ROOT = %q, want %q", got, root)
+	}
+	if got := envValue(env, "AM_BASE_ROOT"); got != filepath.Dir(root) {
+		t.Fatalf("AM_BASE_ROOT = %q, want %q", got, filepath.Dir(root))
+	}
+	if got := envValue(env, "AM_SESSION"); got != "session1" {
+		t.Fatalf("AM_SESSION = %q, want session1", got)
+	}
+	if got := envValue(env, "AM_ME"); got != "codex" {
+		t.Fatalf("AM_ME = %q, want codex", got)
+	}
+
+	customRoot := filepath.Join(t.TempDir(), "custom-root")
+	env = buildCoopExecEnvironment(base, customRoot, "codex", "")
+	if got := envValue(env, "AM_SESSION"); got != "" {
+		t.Fatalf("custom sessionless --root should clear AM_SESSION, got %q", got)
+	}
+	if envHasKey(env, "AM_BASE_ROOT") {
+		t.Fatalf("custom sessionless --root should remove AM_BASE_ROOT: %#v", env)
+	}
+}
+
+func TestCoopSessionIdentityDistinguishesNamedAndSessionlessRoots(t *testing.T) {
+	base := filepath.Join(t.TempDir(), ".agent-mail")
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+	if got := coopSessionIdentity(filepath.Join(base, "auth"), "auth", filepath.Join(base, "auth")); got != "auth" {
+		t.Fatalf("explicit --session identity = %q, want auth", got)
+	}
+	if got := coopSessionIdentity(filepath.Join(base, "collab"), "", ""); got != defaultSessionName {
+		t.Fatalf("default identity = %q, want %q", got, defaultSessionName)
+	}
+	if got := coopSessionIdentity(filepath.Join(base, "auth"), "", filepath.Join(base, "auth")); got != "auth" {
+		t.Fatalf("session-shaped explicit --root identity = %q, want auth", got)
+	}
+	if got := coopSessionIdentity(filepath.Join(t.TempDir(), "custom-root"), "", "/custom-root"); got != "" {
+		t.Fatalf("custom sessionless --root identity = %q, want empty", got)
+	}
+}
+
+func deliverGuardMessage(t *testing.T, root, agent, id string) {
+	t.Helper()
+	if err := deliverGuardMessageError(root, agent, id); err != nil {
+		t.Fatalf("deliver message: %v", err)
+	}
+}
+
+func deliverGuardMessageError(root, agent, id string) error {
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      id,
+			From:    "bob",
+			To:      []string{agent},
+			Thread:  "p2p/alice__bob",
+			Subject: "guard test",
+			Created: time.Now().UTC().Format(time.RFC3339Nano),
+		},
+		Body: "must remain owned by the target session",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		return err
+	}
+	if _, err := fsq.DeliverToInbox(root, agent, id+".md", data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func assertConsumeRefused(t *testing.T, err error, command string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected %s refusal, got nil", command)
+	}
+	if code := GetExitCode(err); code != ExitContextMismatch {
+		t.Fatalf("exit code = %d, want %d: %v", code, ExitContextMismatch, err)
+	}
+	if !strings.Contains(err.Error(), "refusing "+command) {
+		t.Fatalf("error should explain %s refusal, got %v", command, err)
+	}
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}
+
+func envHasKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/coop_exec_env.go
+++ b/internal/cli/coop_exec_env.go
@@ -19,17 +19,17 @@ func coopSessionIdentity(root, requestedSession, requestedRoot string) string {
 	if requestedRoot == "" {
 		return defaultSessionName
 	}
-	return resolveSessionName(root)
+	return inferredSessionIdentity(root)
 }
 
 func buildCoopExecEnvironment(base []string, root, me, session string) []string {
 	env := setEnvVar(base, envRoot, root)
 	env = setEnvVar(env, envMe, me)
+	baseRoot := root
 	if session != "" {
-		env = setEnvVar(env, envBaseRoot, filepath.Dir(root))
-	} else {
-		env = unsetEnvVar(env, envBaseRoot)
+		baseRoot = filepath.Dir(root)
 	}
+	env = setEnvVar(env, envBaseRoot, baseRoot)
 	return setEnvVar(env, envSession, session)
 }
 

--- a/internal/cli/coop_exec_env.go
+++ b/internal/cli/coop_exec_env.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// absoluteSessionRoot resolves root against the current working directory at
+// session start. This is the single point where a coop session's mailbox
+// identity is frozen; everything downstream must see an absolute path.
+func absoluteSessionRoot(root string) (string, error) {
+	return filepath.Abs(root)
+}
+
+func coopSessionIdentity(root, requestedSession, requestedRoot string) string {
+	if requestedSession != "" {
+		return requestedSession
+	}
+	if requestedRoot == "" {
+		return defaultSessionName
+	}
+	return resolveSessionName(root)
+}
+
+func buildCoopExecEnvironment(base []string, root, me, session string) []string {
+	env := setEnvVar(base, envRoot, root)
+	env = setEnvVar(env, envMe, me)
+	if session != "" {
+		env = setEnvVar(env, envBaseRoot, filepath.Dir(root))
+	} else {
+		env = unsetEnvVar(env, envBaseRoot)
+	}
+	return setEnvVar(env, envSession, session)
+}
+
+// setEnvVar sets or replaces an environment variable in a slice.
+func setEnvVar(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}
+
+func unsetEnvVar(env []string, key string) []string {
+	prefix := key + "="
+	out := env[:0]
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			out = append(out, entry)
+		}
+	}
+	return out
+}

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -280,15 +280,10 @@ func runCoopExec(args []string) error {
 		}
 	}
 
-	// Derive base root for AM_BASE_ROOT (parent of the session directory).
-	baseRoot := filepath.Dir(root)
-
-	// Build environment with AM_ROOT, AM_ME, and AM_BASE_ROOT.
-	// AM_ROOT always points to the session queue root (base/session), never the base.
-	// AM_BASE_ROOT points to the base root (parent of sessions) for cross-session resolution.
-	env := setEnvVar(os.Environ(), envRoot, root)
-	env = setEnvVar(env, envMe, agentHandle)
-	env = setEnvVar(env, envBaseRoot, baseRoot)
+	// A named/default or session-shaped explicit root pins an identity
+	// independent of AM_ROOT. A custom sessionless --root clears inherited pins.
+	sessionIdentity := coopSessionIdentity(root, *sessionFlag, *rootFlag)
+	env := buildCoopExecEnvironment(os.Environ(), root, agentHandle, sessionIdentity)
 
 	// Build argv: command name + agent args.
 	argv := append([]string{cmdName}, agentArgs...)
@@ -300,14 +295,6 @@ func runCoopExec(args []string) error {
 		_ = wakeProc.Kill()
 	}
 	return execErr
-}
-
-// absoluteSessionRoot resolves root against the current working directory at
-// session start. This is the single point where a coop session's mailbox
-// identity is frozen; everything downstream (wake, AM_ROOT, AM_BASE_ROOT)
-// must see an absolute path.
-func absoluteSessionRoot(root string) (string, error) {
-	return filepath.Abs(root)
 }
 
 func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectArgs []string) []string {
@@ -388,16 +375,4 @@ func splitDashDash(args []string) ([]string, []string) {
 		}
 	}
 	return args, nil
-}
-
-// setEnvVar sets or replaces an environment variable in a slice.
-func setEnvVar(env []string, key, value string) []string {
-	prefix := key + "="
-	for i, v := range env {
-		if strings.HasPrefix(v, prefix) {
-			env[i] = prefix + value
-			return env
-		}
-	}
-	return append(env, prefix+value)
 }

--- a/internal/cli/dlq.go
+++ b/internal/cli/dlq.go
@@ -172,8 +172,10 @@ func runDLQRead(args []string) error {
 	fs := flag.NewFlagSet("dlq read", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	idFlag := fs.String("id", "", "DLQ message ID to read")
+	sessionFlag := fs.String("session", "", "Target session under the resolved base root")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION pin")
 
-	usage := usageWithFlags(fs, "amq dlq read --me <agent> --id <dlq_id> [options]")
+	usage := usageWithFlags(fs, "amq dlq read --me <agent> --id <dlq_id> [--session <name>] [options]")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
@@ -190,7 +192,19 @@ func runDLQRead(args []string) error {
 		return UsageError("--me: %v", err)
 	}
 	common.Me = me
-	root := resolveRoot(common.Root)
+	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
+	if err != nil {
+		return err
+	}
+	if err := validatePinOverride(common, *ignoreSessionPinFlag, routed); err != nil {
+		return err
+	}
+	if err := guardMailboxContext("dlq read", root, routed, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
+	if err := requireMailbox(root, me); err != nil {
+		return err
+	}
 
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
@@ -273,9 +287,11 @@ func runDLQRetry(args []string) error {
 	idFlag := fs.String("id", "", "DLQ message ID to retry")
 	allFlag := fs.Bool("all", false, "Retry all DLQ messages")
 	forceFlag := fs.Bool("force", false, "Force retry even if max retries exceeded")
+	sessionFlag := fs.String("session", "", "Target session under the resolved base root")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION pin")
 
-	usage := usageWithFlags(fs, "amq dlq retry --me <agent> --id <dlq_id> [--force] [options]",
-		"Or: amq dlq retry --me <agent> --all [--force]")
+	usage := usageWithFlags(fs, "amq dlq retry --me <agent> --id <dlq_id> [--session <name>] [--force] [options]",
+		"Or: amq dlq retry --me <agent> --all [--session <name>] [--force]")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
@@ -295,7 +311,19 @@ func runDLQRetry(args []string) error {
 		return UsageError("--me: %v", err)
 	}
 	common.Me = me
-	root := resolveRoot(common.Root)
+	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
+	if err != nil {
+		return err
+	}
+	if err := validatePinOverride(common, *ignoreSessionPinFlag, routed); err != nil {
+		return err
+	}
+	if err := guardMailboxContext("dlq retry", root, routed, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
+	if err := requireMailbox(root, me); err != nil {
+		return err
+	}
 
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
@@ -370,8 +398,10 @@ func runDLQPurge(args []string) error {
 	olderFlag := fs.String("older-than", "", "Duration (e.g. 24h) - only purge messages older than this")
 	dryRunFlag := fs.Bool("dry-run", false, "Show what would be removed without deleting")
 	yesFlag := fs.Bool("yes", false, "Skip confirmation prompt")
+	sessionFlag := fs.String("session", "", "Target session under the resolved base root")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION pin")
 
-	usage := usageWithFlags(fs, "amq dlq purge --me <agent> [--older-than <duration>] [--dry-run] [--yes] [options]")
+	usage := usageWithFlags(fs, "amq dlq purge --me <agent> [--session <name>] [--older-than <duration>] [--dry-run] [--yes] [options]")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
@@ -385,7 +415,19 @@ func runDLQPurge(args []string) error {
 		return UsageError("--me: %v", err)
 	}
 	common.Me = me
-	root := resolveRoot(common.Root)
+	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
+	if err != nil {
+		return err
+	}
+	if err := validatePinOverride(common, *ignoreSessionPinFlag, routed); err != nil {
+		return err
+	}
+	if err := guardMailboxContext("dlq purge", root, routed, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
+	if err := requireMailbox(root, me); err != nil {
+		return err
+	}
 
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -76,8 +76,9 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 	}
 	result.OperatorGate = checkOperatorGate(root, now)
 
-	// Load config for agent list
-	cfg, err := config.LoadConfig(filepath.Join(root, "meta", "config.json"))
+	// Load the active root's config, falling back to the base config for normal
+	// session layouts where coop init owns the single config.json.
+	agents, err := loadOpsAgents(root)
 	if err != nil {
 		result.Hints = append(result.Hints, opsHint{
 			Code:    "config_error",
@@ -88,7 +89,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		return result
 	}
 
-	for _, handle := range cfg.Agents {
+	for _, handle := range agents {
 		agent := opsAgent{Handle: handle}
 
 		// Unread count + oldest
@@ -142,14 +143,50 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		result.Agents = append(result.Agents, agent)
 	}
 
-	result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, cfg.Agents), fixWakeLocks)
+	result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, agents), fixWakeLocks)
 
-	// Integration hints
+	// Operational and integration hints
+	result.Hints = append(result.Hints, checkSiblingBacklogHints(root, agents)...)
 	result.Hints = append(result.Hints, checkGlobalRootHint()...)
 	result.Hints = append(result.Hints, checkKanbanHint()...)
 	result.Hints = append(result.Hints, checkSymphonyHint()...)
 
 	return result
+}
+
+func loadOpsAgents(root string) ([]string, error) {
+	cfg, err := config.LoadConfig(filepath.Join(root, "meta", "config.json"))
+	if err == nil {
+		return cfg.Agents, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	base := baseRootOf(root)
+	if absPath(resolveRoot(base)) == absPath(resolveRoot(root)) {
+		return nil, err
+	}
+	baseCfg, baseErr := config.LoadConfig(filepath.Join(base, "meta", "config.json"))
+	if baseErr != nil {
+		return nil, baseErr
+	}
+	return baseCfg.Agents, nil
+}
+
+func checkSiblingBacklogHints(root string, agents []string) []opsHint {
+	current := siblingContext(root)
+	var hints []opsHint
+	for _, agent := range agents {
+		for _, backlog := range findSiblingBacklogs(root, agent) {
+			hints = append(hints, opsHint{
+				Code:    "sibling_backlog",
+				Status:  "warn",
+				Message: formatSiblingBacklogHint(backlog, agent, current),
+			})
+		}
+	}
+	return hints
 }
 
 func checkOperatorGate(root string, now time.Time) *opsOperatorGate {

--- a/internal/cli/drain.go
+++ b/internal/cli/drain.go
@@ -17,8 +17,10 @@ func runDrain(args []string) error {
 	common := addCommonFlags(fs)
 	limitFlag := fs.Int("limit", 20, "Max messages to drain (0 = no limit)")
 	includeBodyFlag := fs.Bool("include-body", false, "Include message body in output")
+	sessionFlag := fs.String("session", "", "Target session under the resolved base root")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION pin")
 
-	usage := usageWithFlags(fs, "amq drain --me <agent> [options]",
+	usage := usageWithFlags(fs, "amq drain --me <agent> [--session <name>] [options]",
 		"Drains new messages: reads, moves to cur, emits receipts.",
 		"Designed for hook/script integration. Quiet when empty.")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
@@ -37,7 +39,20 @@ func runDrain(args []string) error {
 		return UsageError("--me: %v", err)
 	}
 	common.Me = me
-	root := resolveRoot(common.Root)
+	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
+	if err != nil {
+		return err
+	}
+	if err := validatePinOverride(common, *ignoreSessionPinFlag, routed); err != nil {
+		return err
+	}
+	if err := guardMailboxContext("drain", root, routed, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
+	if err := requireMailbox(root, me); err != nil {
+		emitSiblingBacklogHintsIfInboxEmpty(root, me)
+		return err
+	}
 
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
@@ -49,11 +64,15 @@ func runDrain(args []string) error {
 
 	items, err := drainInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return NotFoundError("mailbox for %q disappeared while draining root %s", common.Me, root)
+		}
 		return err
 	}
 
 	// Nothing to drain
 	if len(items) == 0 {
+		emitSiblingBacklogHintsIfInboxEmpty(root, common.Me)
 		if common.JSON {
 			return writeJSON(os.Stdout, drainResult{Drained: []drainItem{}, Count: 0})
 		}

--- a/internal/cli/drain_test.go
+++ b/internal/cli/drain_test.go
@@ -401,6 +401,24 @@ func TestDrainInboxItemsConcurrentClaimsSingleWinner(t *testing.T) {
 	}
 }
 
+func TestClaimMailboxDirsExistRejectsMissingCur(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	if err := os.RemoveAll(fsq.AgentInboxCur(root, "alice")); err != nil {
+		t.Fatalf("remove inbox/cur: %v", err)
+	}
+
+	exists, err := claimMailboxDirsExist(root, "alice")
+	if err != nil {
+		t.Fatalf("claimMailboxDirsExist: %v", err)
+	}
+	if exists {
+		t.Fatal("missing inbox/cur must not be classified as a concurrent message claim")
+	}
+}
+
 func TestRunDrainCorruptMessage(t *testing.T) {
 	root := t.TempDir()
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -91,7 +91,7 @@ func runEnv(args []string) error {
 	if *exportFlag && *sessionNameFlag {
 		return UsageError("--export and --session-name are mutually exclusive")
 	}
-	contextExplicit := strings.TrimSpace(*rootFlag) != "" || strings.TrimSpace(*sessionFlag) != ""
+	contextExplicit := flagWasVisited(fs, "root") || flagWasVisited(fs, "session")
 
 	// Resolve --session into --root (mutually exclusive).
 	sessionBaseRoot := ""
@@ -103,11 +103,23 @@ func runEnv(args []string) error {
 		if err := validateSessionName(*sessionFlag); err != nil {
 			return err
 		}
-		// Resolve base from .amqrc or default
-		base := resolveBaseRoot()
-		sessionBaseRoot = base
+		pin, err := loadSessionPin()
+		if err != nil {
+			return err
+		}
+		base := ""
+		if pin.Present {
+			base = pin.BaseRoot
+		} else {
+			resolved, _, _, err := resolveEnvConfigWithSource("", *meFlag)
+			if err != nil {
+				return err
+			}
+			base = baseRootOf(absPath(resolveRoot(resolved)))
+		}
+		sessionBaseRoot = absPath(resolveRoot(base))
 		sessionNameOverride = *sessionFlag
-		*rootFlag = filepath.Join(base, *sessionFlag)
+		*rootFlag = filepath.Join(sessionBaseRoot, *sessionFlag)
 	}
 
 	// Resolve configuration with precedence
@@ -134,7 +146,7 @@ func runEnv(args []string) error {
 		if sessionNameOverride != "" {
 			return writeStdout("%s\n", sessionNameOverride)
 		}
-		if name := resolveSessionName(root); name != "" {
+		if name := inferredSessionIdentity(root); name != "" {
 			return writeStdout("%s\n", name)
 		}
 		return nil // Not in a session — empty output, exit 0
@@ -185,7 +197,7 @@ func runEnv(args []string) error {
 			return fmt.Errorf("resolve absolute base root for shell output: %w", err)
 		}
 	}
-	if err := writeShellEnv(root, baseRoot, sessionName, me, shell, *wakeFlag, inSession); err != nil {
+	if err := writeShellEnv(root, baseRoot, sessionName, me, shell, *wakeFlag); err != nil {
 		return err
 	}
 	if *exportFlag {
@@ -197,9 +209,19 @@ func runEnv(args []string) error {
 func classifyEnvRoot(root string) (baseRoot, sessionNameOut string, inSession bool) {
 	base := classifyRoot(root)
 	if base != "" && absPath(resolveRoot(root)) != absPath(resolveRoot(base)) {
-		return base, sessionName(root), true
+		if session := inferredSessionIdentity(root); session != "" {
+			return base, session, true
+		}
 	}
 	return root, "", false
+}
+
+func inferredSessionIdentity(root string) string {
+	session := resolveSessionName(root)
+	if session == "" || validateSessionName(session) != nil {
+		return ""
+	}
+	return session
 }
 
 func envProjectAndPeers(root string) (string, map[string]string) {
@@ -470,26 +492,25 @@ func isValidShell(shell string) bool {
 	}
 }
 
-func writeShellEnv(root, baseRoot, session, me, shell string, wake bool, includeBaseRoot bool) error {
+func writeShellEnv(root, baseRoot, session, me, shell string, wake bool) error {
 	switch shell {
 	case "fish":
-		return writeFishEnv(root, baseRoot, session, me, wake, includeBaseRoot)
+		return writeFishEnv(root, baseRoot, session, me, wake)
 	default:
-		return writePosixEnv(root, baseRoot, session, me, wake, includeBaseRoot)
+		return writePosixEnv(root, baseRoot, session, me, wake)
 	}
 }
 
-func writePosixEnv(root, baseRoot, session, me string, wake bool, includeBaseRoot bool) error {
+func writePosixEnv(root, baseRoot, session, me string, wake bool) error {
 	if root != "" {
 		if err := writeStdout("export AM_ROOT=%s\n", shellQuotePosix(root)); err != nil {
 			return err
 		}
 	}
-	if includeBaseRoot && baseRoot != "" {
-		if err := writeStdout("export AM_BASE_ROOT=%s\n", shellQuotePosix(baseRoot)); err != nil {
-			return err
-		}
-	} else if err := writeStdoutLine("unset AM_BASE_ROOT"); err != nil {
+	if baseRoot == "" {
+		return fmt.Errorf("cannot emit AMQ context without an exact AM_BASE_ROOT")
+	}
+	if err := writeStdout("export AM_BASE_ROOT=%s\n", shellQuotePosix(baseRoot)); err != nil {
 		return err
 	}
 	if err := writeStdout("export AM_SESSION=%s\n", shellQuotePosix(session)); err != nil {
@@ -510,17 +531,16 @@ func writePosixEnv(root, baseRoot, session, me string, wake bool, includeBaseRoo
 	return nil
 }
 
-func writeFishEnv(root, baseRoot, session, me string, wake bool, includeBaseRoot bool) error {
+func writeFishEnv(root, baseRoot, session, me string, wake bool) error {
 	if root != "" {
 		if err := writeStdout("set -gx AM_ROOT %s\n", shellQuoteFish(root)); err != nil {
 			return err
 		}
 	}
-	if includeBaseRoot && baseRoot != "" {
-		if err := writeStdout("set -gx AM_BASE_ROOT %s\n", shellQuoteFish(baseRoot)); err != nil {
-			return err
-		}
-	} else if err := writeStdoutLine("set -e AM_BASE_ROOT"); err != nil {
+	if baseRoot == "" {
+		return fmt.Errorf("cannot emit AMQ context without an exact AM_BASE_ROOT")
+	}
+	if err := writeStdout("set -gx AM_BASE_ROOT %s\n", shellQuoteFish(baseRoot)); err != nil {
 		return err
 	}
 	if session == "" {
@@ -573,7 +593,9 @@ func shellQuoteFish(s string) string {
 	}
 	// In fish, single quotes work but single quotes inside need escaping with backslash
 	// Unlike POSIX, fish allows \' inside single-quoted strings
-	return "'" + strings.ReplaceAll(s, "'", "\\'") + "'"
+	escaped := strings.ReplaceAll(s, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "'", "\\'")
+	return "'" + escaped + "'"
 }
 
 func isSimpleString(s string) bool {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -52,11 +52,11 @@ func runEnv(args []string) error {
 	shellFlag := fs.String("shell", "sh", "Shell format: sh, bash, zsh, fish")
 	wakeFlag := fs.Bool("wake", false, "Include amq wake & in output")
 	jsonFlag := fs.Bool("json", false, "Output as JSON (for scripts)")
-	exportFlag := fs.Bool("export", false, "Output shell exports for pinning this terminal to the resolved root")
+	exportFlag := fs.Bool("export", false, "Also print a note confirming the resolved terminal pin")
 	sessionNameFlag := fs.Bool("session-name", false, "Print current session name (for statusline integration)")
 
 	usage := usageWithFlags(fs, "amq env [options]",
-		"Outputs shell commands to set AM_ROOT and AM_ME environment variables.",
+		"Outputs shell commands that replace the complete AMQ root/session context.",
 		"",
 		"Configuration precedence (highest to lowest):",
 		"  Root: flags > env (AM_ROOT) > .amqrc > AMQ_GLOBAL_ROOT > ~/.amqrc > auto-detect",
@@ -67,7 +67,7 @@ func runEnv(args []string) error {
 		"different agents on the same project.",
 		"",
 		"Examples:",
-		"  eval \"$(amq env --me claude)\"                # Set up for Claude",
+		"  eval \"$(amq env --me claude)\"                # Set up Claude and clear stale session context",
 		"  eval \"$(amq env --session feature-x --me claude --export)\"  # Pin this terminal to one session",
 		"  eval \"$(amq env --me codex --wake)\"          # Set up for Codex with wake",
 		"  eval \"$(amq env --session feature-x --me claude)\"  # Isolated session",
@@ -91,6 +91,7 @@ func runEnv(args []string) error {
 	if *exportFlag && *sessionNameFlag {
 		return UsageError("--export and --session-name are mutually exclusive")
 	}
+	contextExplicit := strings.TrimSpace(*rootFlag) != "" || strings.TrimSpace(*sessionFlag) != ""
 
 	// Resolve --session into --root (mutually exclusive).
 	sessionBaseRoot := ""
@@ -113,6 +114,13 @@ func runEnv(args []string) error {
 	root, source, me, err := resolveEnvConfigWithSource(*rootFlag, *meFlag)
 	if err != nil {
 		return err
+	}
+	if !contextExplicit {
+		if mismatch, checkErr := sessionPinMismatch(root); checkErr != nil {
+			return checkErr
+		} else if mismatch != nil {
+			return ContextMismatchError("refusing env: %s. Use explicit --session <name> or --root <path> to repin", mismatch.Error())
+		}
 	}
 
 	// Validate shell
@@ -166,25 +174,24 @@ func runEnv(args []string) error {
 		return fmt.Errorf("resolve absolute root for shell output: %w", err)
 	}
 
-	// Generate shell commands
+	baseRoot, sessionName, inSession := classifyEnvRoot(root)
+	if sessionNameOverride != "" {
+		baseRoot = sessionBaseRoot
+		sessionName = sessionNameOverride
+		inSession = true
+	}
+	if baseRoot != "" {
+		if baseRoot, err = filepath.Abs(baseRoot); err != nil {
+			return fmt.Errorf("resolve absolute base root for shell output: %w", err)
+		}
+	}
+	if err := writeShellEnv(root, baseRoot, sessionName, me, shell, *wakeFlag, inSession); err != nil {
+		return err
+	}
 	if *exportFlag {
-		baseRoot, sessionName, inSession := classifyEnvRoot(root)
-		if sessionNameOverride != "" {
-			baseRoot = sessionBaseRoot
-			sessionName = sessionNameOverride
-			inSession = true
-		}
-		if baseRoot != "" {
-			if baseRoot, err = filepath.Abs(baseRoot); err != nil {
-				return fmt.Errorf("resolve absolute base root for shell output: %w", err)
-			}
-		}
-		if err := writeShellExportEnv(root, baseRoot, me, shell, *wakeFlag, inSession); err != nil {
-			return err
-		}
 		return writeEnvExportPinNote(root, baseRoot, sessionName, inSession)
 	}
-	return writeShellEnv(root, me, shell, *wakeFlag)
+	return nil
 }
 
 func classifyEnvRoot(root string) (baseRoot, sessionNameOut string, inSession bool) {
@@ -463,45 +470,16 @@ func isValidShell(shell string) bool {
 	}
 }
 
-func writeShellEnv(root, me, shell string, wake bool) error {
+func writeShellEnv(root, baseRoot, session, me, shell string, wake bool, includeBaseRoot bool) error {
 	switch shell {
 	case "fish":
-		return writeFishEnv(root, me, wake)
+		return writeFishEnv(root, baseRoot, session, me, wake, includeBaseRoot)
 	default:
-		return writePosixEnv(root, me, wake)
+		return writePosixEnv(root, baseRoot, session, me, wake, includeBaseRoot)
 	}
 }
 
-func writeShellExportEnv(root, baseRoot, me, shell string, wake bool, includeBaseRoot bool) error {
-	switch shell {
-	case "fish":
-		return writeFishExportEnv(root, baseRoot, me, wake, includeBaseRoot)
-	default:
-		return writePosixExportEnv(root, baseRoot, me, wake, includeBaseRoot)
-	}
-}
-
-func writePosixEnv(root, me string, wake bool) error {
-	// Use proper shell quoting
-	if root != "" {
-		if err := writeStdout("export AM_ROOT=%s\n", shellQuotePosix(root)); err != nil {
-			return err
-		}
-	}
-	if me != "" {
-		if err := writeStdout("export AM_ME=%s\n", shellQuotePosix(me)); err != nil {
-			return err
-		}
-	}
-	if wake {
-		if err := writeStdoutLine("amq wake &"); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func writePosixExportEnv(root, baseRoot, me string, wake bool, includeBaseRoot bool) error {
+func writePosixEnv(root, baseRoot, session, me string, wake bool, includeBaseRoot bool) error {
 	if root != "" {
 		if err := writeStdout("export AM_ROOT=%s\n", shellQuotePosix(root)); err != nil {
 			return err
@@ -511,11 +489,18 @@ func writePosixExportEnv(root, baseRoot, me string, wake bool, includeBaseRoot b
 		if err := writeStdout("export AM_BASE_ROOT=%s\n", shellQuotePosix(baseRoot)); err != nil {
 			return err
 		}
+	} else if err := writeStdoutLine("unset AM_BASE_ROOT"); err != nil {
+		return err
+	}
+	if err := writeStdout("export AM_SESSION=%s\n", shellQuotePosix(session)); err != nil {
+		return err
 	}
 	if me != "" {
 		if err := writeStdout("export AM_ME=%s\n", shellQuotePosix(me)); err != nil {
 			return err
 		}
+	} else if err := writeStdoutLine("unset AM_ME"); err != nil {
+		return err
 	}
 	if wake {
 		if err := writeStdoutLine("amq wake &"); err != nil {
@@ -525,26 +510,7 @@ func writePosixExportEnv(root, baseRoot, me string, wake bool, includeBaseRoot b
 	return nil
 }
 
-func writeFishEnv(root, me string, wake bool) error {
-	if root != "" {
-		if err := writeStdout("set -gx AM_ROOT %s\n", shellQuoteFish(root)); err != nil {
-			return err
-		}
-	}
-	if me != "" {
-		if err := writeStdout("set -gx AM_ME %s\n", shellQuoteFish(me)); err != nil {
-			return err
-		}
-	}
-	if wake {
-		if err := writeStdoutLine("amq wake &"); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func writeFishExportEnv(root, baseRoot, me string, wake bool, includeBaseRoot bool) error {
+func writeFishEnv(root, baseRoot, session, me string, wake bool, includeBaseRoot bool) error {
 	if root != "" {
 		if err := writeStdout("set -gx AM_ROOT %s\n", shellQuoteFish(root)); err != nil {
 			return err
@@ -554,11 +520,22 @@ func writeFishExportEnv(root, baseRoot, me string, wake bool, includeBaseRoot bo
 		if err := writeStdout("set -gx AM_BASE_ROOT %s\n", shellQuoteFish(baseRoot)); err != nil {
 			return err
 		}
+	} else if err := writeStdoutLine("set -e AM_BASE_ROOT"); err != nil {
+		return err
+	}
+	if session == "" {
+		if err := writeStdoutLine("set -gx AM_SESSION ''"); err != nil {
+			return err
+		}
+	} else if err := writeStdout("set -gx AM_SESSION %s\n", shellQuoteFish(session)); err != nil {
+		return err
 	}
 	if me != "" {
 		if err := writeStdout("set -gx AM_ME %s\n", shellQuoteFish(me)); err != nil {
 			return err
 		}
+	} else if err := writeStdoutLine("set -e AM_ME"); err != nil {
+		return err
 	}
 	if wake {
 		if err := writeStdoutLine("amq wake &"); err != nil {

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -141,6 +141,8 @@ func TestShellQuoteFish(t *testing.T) {
 		{"path/to/dir", "path/to/dir"},
 		{"has space", "'has space'"},
 		{"has'quote", "'has\\'quote'"},
+		{"trailing\\", "'trailing\\\\'"},
+		{"two\\\\slashes", "'two\\\\\\\\slashes'"},
 		{"$VAR", "'$VAR'"},
 	}
 
@@ -975,7 +977,7 @@ func TestRunEnvExportSessionEmitsBaseRootAndPinNote(t *testing.T) {
 	}
 }
 
-func TestRunEnvExportNonSessionOmitsBaseRoot(t *testing.T) {
+func TestRunEnvExportNonSessionPinsExactBaseRoot(t *testing.T) {
 	root := t.TempDir()
 	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
@@ -1007,14 +1009,14 @@ func TestRunEnvExportNonSessionOmitsBaseRoot(t *testing.T) {
 
 	expectedRoot := filepath.Join(projectRoot, ".agent-mail")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
-		"unset AM_BASE_ROOT\n" +
+		"export AM_BASE_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_SESSION=\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
 	}
-	if !strings.Contains(stdout, "unset AM_BASE_ROOT") {
-		t.Fatalf("non-session export should clear AM_BASE_ROOT: %q", stdout)
+	if !strings.Contains(stdout, "export AM_BASE_ROOT="+shellQuotePosix(expectedRoot)) {
+		t.Fatalf("non-session export should pin exact AM_BASE_ROOT: %q", stdout)
 	}
 	if !strings.Contains(stderr, "pinned to AMQ root") {
 		t.Fatalf("stderr should contain root pin note, got %q", stderr)
@@ -1142,7 +1144,7 @@ func TestRunEnvExportSessionIgnoresStaleAmbientBaseRoot(t *testing.T) {
 	}
 }
 
-func TestRunEnvExportExplicitBaseRootOmitsBaseRoot(t *testing.T) {
+func TestRunEnvExportExplicitBaseRootPinsExactBaseRoot(t *testing.T) {
 	root := filepath.Join(t.TempDir(), ".agent-mail")
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatalf("mkdir root: %v", err)
@@ -1156,14 +1158,14 @@ func TestRunEnvExportExplicitBaseRootOmitsBaseRoot(t *testing.T) {
 	}
 
 	want := "export AM_ROOT=" + shellQuotePosix(root) + "\n" +
-		"unset AM_BASE_ROOT\n" +
+		"export AM_BASE_ROOT=" + shellQuotePosix(root) + "\n" +
 		"export AM_SESSION=\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
 	}
-	if !strings.Contains(stdout, "unset AM_BASE_ROOT") {
-		t.Fatalf("explicit base-root export should clear AM_BASE_ROOT: %q", stdout)
+	if !strings.Contains(stdout, "export AM_BASE_ROOT="+shellQuotePosix(root)) {
+		t.Fatalf("explicit base-root export should pin exact AM_BASE_ROOT: %q", stdout)
 	}
 }
 

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -884,7 +884,7 @@ func TestRunEnvJSONV1SessionFlag(t *testing.T) {
 	}
 }
 
-func TestRunEnvNonExportSessionOutputStaysRootAndMeOnly(t *testing.T) {
+func TestRunEnvNonExportSessionEmitsFullContext(t *testing.T) {
 	root := t.TempDir()
 	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {
@@ -914,17 +914,17 @@ func TestRunEnvNonExportSessionOutputStaysRootAndMeOnly(t *testing.T) {
 		t.Fatalf("runEnv: %v", err)
 	}
 
-	expectedRoot := filepath.Join(projectRoot, ".agent-mail", "feature-x")
+	expectedBase := filepath.Join(projectRoot, ".agent-mail")
+	expectedRoot := filepath.Join(expectedBase, "feature-x")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
+		"export AM_BASE_ROOT=" + shellQuotePosix(expectedBase) + "\n" +
+		"export AM_SESSION=feature-x\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
 	}
 	if stderr != "" {
 		t.Fatalf("stderr = %q, want empty", stderr)
-	}
-	if strings.Contains(stdout, "AM_BASE_ROOT") {
-		t.Fatalf("non-export output should not include AM_BASE_ROOT: %q", stdout)
 	}
 }
 
@@ -962,6 +962,7 @@ func TestRunEnvExportSessionEmitsBaseRootAndPinNote(t *testing.T) {
 	expectedRoot := filepath.Join(expectedBase, "feature-x")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(expectedBase) + "\n" +
+		"export AM_SESSION=feature-x\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
@@ -1006,12 +1007,14 @@ func TestRunEnvExportNonSessionOmitsBaseRoot(t *testing.T) {
 
 	expectedRoot := filepath.Join(projectRoot, ".agent-mail")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
+		"unset AM_BASE_ROOT\n" +
+		"export AM_SESSION=\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
 	}
-	if strings.Contains(stdout, "AM_BASE_ROOT") {
-		t.Fatalf("non-session export should not include AM_BASE_ROOT: %q", stdout)
+	if !strings.Contains(stdout, "unset AM_BASE_ROOT") {
+		t.Fatalf("non-session export should clear AM_BASE_ROOT: %q", stdout)
 	}
 	if !strings.Contains(stderr, "pinned to AMQ root") {
 		t.Fatalf("stderr should contain root pin note, got %q", stderr)
@@ -1052,6 +1055,7 @@ func TestRunEnvExportFishSessionEmitsBaseRoot(t *testing.T) {
 	expectedRoot := filepath.Join(expectedBase, "feature-x")
 	want := "set -gx AM_ROOT " + shellQuoteFish(expectedRoot) + "\n" +
 		"set -gx AM_BASE_ROOT " + shellQuoteFish(expectedBase) + "\n" +
+		"set -gx AM_SESSION feature-x\n" +
 		"set -gx AM_ME codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
@@ -1084,6 +1088,7 @@ func TestRunEnvExportSessionFromGlobalRootEmitsBaseRoot(t *testing.T) {
 	expectedRoot := filepath.Join(globalRoot, "feature-x")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(globalRoot) + "\n" +
+		"export AM_SESSION=feature-x\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
@@ -1127,6 +1132,7 @@ func TestRunEnvExportSessionIgnoresStaleAmbientBaseRoot(t *testing.T) {
 	expectedRoot := filepath.Join(expectedBase, "feature-x")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(expectedBase) + "\n" +
+		"export AM_SESSION=feature-x\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
@@ -1150,12 +1156,14 @@ func TestRunEnvExportExplicitBaseRootOmitsBaseRoot(t *testing.T) {
 	}
 
 	want := "export AM_ROOT=" + shellQuotePosix(root) + "\n" +
+		"unset AM_BASE_ROOT\n" +
+		"export AM_SESSION=\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
 		t.Fatalf("stdout = %q, want %q", stdout, want)
 	}
-	if strings.Contains(stdout, "AM_BASE_ROOT") {
-		t.Fatalf("explicit base-root export should not include AM_BASE_ROOT: %q", stdout)
+	if !strings.Contains(stdout, "unset AM_BASE_ROOT") {
+		t.Fatalf("explicit base-root export should clear AM_BASE_ROOT: %q", stdout)
 	}
 }
 
@@ -1431,9 +1439,9 @@ func TestRunEnvPosix(t *testing.T) {
 	if !strings.Contains(output, "export AM_ROOT=/tmp/test-root\n") {
 		t.Errorf("expected export AM_ROOT=/tmp/test-root, got: %s", output)
 	}
-	// AM_ME is not set from .amqrc (use env var or --me flag)
-	if strings.Contains(output, "export AM_ME") {
-		t.Errorf("unexpected AM_ME in output (not from .amqrc): %s", output)
+	// A missing identity clears any stale terminal identity.
+	if !strings.Contains(output, "unset AM_ME\n") {
+		t.Errorf("expected stale AM_ME to be cleared, got: %s", output)
 	}
 }
 
@@ -1477,9 +1485,9 @@ func TestRunEnvFish(t *testing.T) {
 	if !strings.Contains(output, "set -gx AM_ROOT /tmp/test-root\n") {
 		t.Errorf("expected set -gx AM_ROOT /tmp/test-root, got: %s", output)
 	}
-	// AM_ME is not set from .amqrc (use env var or --me flag)
-	if strings.Contains(output, "set -gx AM_ME") {
-		t.Errorf("unexpected AM_ME in output (not from .amqrc): %s", output)
+	// A missing identity clears any stale terminal identity.
+	if !strings.Contains(output, "set -e AM_ME\n") {
+		t.Errorf("expected stale AM_ME to be cleared, got: %s", output)
 	}
 }
 

--- a/internal/cli/exitcode.go
+++ b/internal/cli/exitcode.go
@@ -20,7 +20,19 @@ const (
 
 	// ExitTimeout indicates a timeout occurred (watch, monitor commands).
 	ExitTimeout = 4
+
+	// ExitContextMismatch indicates a valid command was blocked because its
+	// resolved mailbox root conflicts with the pinned AMQ session context.
+	ExitContextMismatch = 5
 )
+
+// SessionContextError identifies an unsafe or incoherent mailbox context.
+// It is distinct from a usage error: the command syntax was valid.
+type SessionContextError struct {
+	Message string
+}
+
+func (e *SessionContextError) Error() string { return e.Message }
 
 // ExitCodeError wraps an error with a specific exit code.
 type ExitCodeError struct {
@@ -82,5 +94,13 @@ func TimeoutError(format string, args ...any) error {
 	return &ExitCodeError{
 		Code: ExitTimeout,
 		Err:  fmt.Errorf(format, args...),
+	}
+}
+
+// ContextMismatchError creates an error with ExitContextMismatch code.
+func ContextMismatchError(format string, args ...any) error {
+	return &ExitCodeError{
+		Code: ExitContextMismatch,
+		Err:  &SessionContextError{Message: fmt.Sprintf(format, args...)},
 	}
 }

--- a/internal/cli/exitcode_test.go
+++ b/internal/cli/exitcode_test.go
@@ -16,6 +16,7 @@ func TestGetExitCode(t *testing.T) {
 		{"usage error", UsageError("bad flag"), ExitUsage},
 		{"not found error", NotFoundError("msg not found"), ExitNotFound},
 		{"timeout error", TimeoutError("timed out"), ExitTimeout},
+		{"context mismatch", ContextMismatchError("unsafe context"), ExitContextMismatch},
 		{"wrapped exit code", WithExitCode(ExitNotFound, errors.New("custom")), ExitNotFound},
 	}
 

--- a/internal/cli/inbox_collect.go
+++ b/internal/cli/inbox_collect.go
@@ -31,7 +31,14 @@ func drainInboxItems(root, me string, includeBody bool, limit int, validator *he
 		}
 		if err := fsq.MoveNewToCur(root, me, filename); err != nil {
 			if os.IsNotExist(err) {
-				continue
+				exists, checkErr := claimMailboxDirsExist(root, me)
+				if checkErr != nil {
+					return nil, checkErr
+				}
+				if exists {
+					continue
+				}
+				return nil, NotFoundError("mailbox for %q disappeared while claiming %s at root %s", me, filename, root)
 			}
 			_ = writeStderr("warning: failed to claim %s: %v\n", filename, err)
 			continue
@@ -62,6 +69,22 @@ func drainInboxItems(root, me string, includeBody bool, limit int, validator *he
 
 	format.SortByTimestamp(items)
 	return items, nil
+}
+
+func claimMailboxDirsExist(root, me string) (bool, error) {
+	for _, dir := range []string{fsq.AgentInboxNew(root, me), fsq.AgentInboxCur(root, me)} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if !info.IsDir() {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func emitReceipt(root, consumer string, item *inboxItem, stage, detail string) {

--- a/internal/cli/inbox_collect.go
+++ b/internal/cli/inbox_collect.go
@@ -106,9 +106,6 @@ func collectInboxFilenames(root, me string) ([]string, error) {
 	newDir := fsq.AgentInboxNew(root, me)
 	entries, err := os.ReadDir(newDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return []string{}, nil
-		}
 		return nil, err
 	}
 

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -44,6 +44,7 @@ func runList(args []string) error {
 	curFlag := fs.Bool("cur", false, "List messages in inbox/cur")
 	limitFlag := fs.Int("limit", 0, "Limit number of messages (0 = no limit)")
 	offsetFlag := fs.Int("offset", 0, "Offset into sorted results (0 = start)")
+	sessionFlag := fs.String("session", "", "Target session under the resolved base root")
 
 	// Filter flags
 	priorityFlag := fs.String("priority", "", "Filter by priority (urgent, normal, low)")
@@ -52,7 +53,7 @@ func runList(args []string) error {
 	var labelFlags multiStringFlag
 	fs.Var(&labelFlags, "label", "Filter by label (can be repeated)")
 
-	usage := usageWithFlags(fs, "amq list --me <agent> [--new | --cur] [options]")
+	usage := usageWithFlags(fs, "amq list --me <agent> [--session <name>] [--new | --cur] [options]")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
@@ -66,7 +67,21 @@ func runList(args []string) error {
 		return UsageError("--me: %v", err)
 	}
 	common.Me = me
-	root := resolveRoot(common.Root)
+	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
+	if err != nil {
+		return err
+	}
+	if !routed {
+		if mismatch, checkErr := sessionPinMismatch(root); checkErr != nil {
+			_ = writeStderr("warning: %v\n", checkErr)
+		} else if mismatch != nil {
+			_ = writeStderr("warning: %s\n", mismatch.Error())
+		}
+	}
+	if err := requireMailbox(root, me); err != nil {
+		emitSiblingBacklogHintsIfInboxEmpty(root, me)
+		return err
+	}
 
 	// Validate handle against config.json
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
@@ -113,13 +128,7 @@ func runList(args []string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if common.JSON {
-				return writeJSON(os.Stdout, []listItem{})
-			}
-			if err := writeStdoutLine("No messages."); err != nil {
-				return err
-			}
-			return nil
+			return NotFoundError("mailbox for %q disappeared while listing %s", common.Me, dir)
 		}
 		return err
 	}
@@ -187,6 +196,9 @@ func runList(args []string) error {
 		items = items[:*limitFlag]
 	}
 
+	if len(items) == 0 && box == "new" {
+		emitSiblingBacklogHintsIfInboxEmpty(root, common.Me)
+	}
 	if common.JSON {
 		return writeJSON(os.Stdout, items)
 	}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -12,7 +12,7 @@ import (
 // dir look like refused cross-tree sends. Tests that need these signals set them
 // explicitly via t.Setenv, which overrides and restores around this clean baseline.
 func TestMain(m *testing.M) {
-	for _, k := range []string{"AM_ROOT", "AM_BASE_ROOT", "AMQ_GLOBAL_ROOT"} {
+	for _, k := range []string{"AM_ROOT", "AM_BASE_ROOT", "AM_SESSION", "AMQ_GLOBAL_ROOT"} {
 		_ = os.Unsetenv(k)
 	}
 	os.Exit(m.Run())

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -30,8 +31,10 @@ func runMonitor(args []string) error {
 	includeBodyFlag := fs.Bool("include-body", false, "Include message body in output")
 	limitFlag := fs.Int("limit", 20, "Max messages to drain (0 = no limit)")
 	peekFlag := fs.Bool("peek", false, "Peek without moving messages to cur")
+	sessionFlag := fs.String("session", "", "Target session under the resolved base root")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION pin")
 
-	usage := usageWithFlags(fs, "amq monitor --me <agent> [options]",
+	usage := usageWithFlags(fs, "amq monitor --me <agent> [--session <name>] [options]",
 		"Combined watch+drain: waits for messages, drains them, outputs structured payload.",
 		"Use --peek to watch without moving messages to cur (no ack).",
 		"Ideal for co-op mode background watchers in Claude Code or Codex.")
@@ -54,7 +57,19 @@ func runMonitor(args []string) error {
 		return UsageError("--me: %v", err)
 	}
 	common.Me = me
-	root := resolveRoot(common.Root)
+	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
+	if err != nil {
+		return err
+	}
+	if err := validatePinOverride(common, *ignoreSessionPinFlag, routed); err != nil {
+		return err
+	}
+	if err := guardMailboxContext("monitor", root, routed, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
+	if err := requireMailbox(root, me); err != nil {
+		return err
+	}
 
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
@@ -65,9 +80,6 @@ func runMonitor(args []string) error {
 	}
 
 	inboxNew := fsq.AgentInboxNew(root, common.Me)
-	if err := os.MkdirAll(inboxNew, 0o700); err != nil {
-		return err
-	}
 
 	session := resolveSessionName(root)
 
@@ -79,6 +91,9 @@ func runMonitor(args []string) error {
 	// First, try to drain existing messages
 	items, err := monitorInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator, mode)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return NotFoundError("mailbox for %q disappeared while monitoring root %s", common.Me, root)
+		}
 		return err
 	}
 
@@ -112,6 +127,9 @@ func runMonitor(args []string) error {
 	}
 
 	if watchErr != nil {
+		if os.IsNotExist(watchErr) {
+			return NotFoundError("mailbox for %q disappeared while monitoring %s", common.Me, inboxNew)
+		}
 		if errors.Is(watchErr, context.DeadlineExceeded) {
 			if err := outputMonitorResult(common.JSON, monitorResult{
 				Event:   "timeout",
@@ -129,8 +147,17 @@ func runMonitor(args []string) error {
 	}
 
 	// New message arrived - drain it
+	if err := guardMailboxContext("monitor", root, routed, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
+	if err := requireMailbox(root, me); err != nil {
+		return err
+	}
 	items, err = monitorInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator, mode)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return NotFoundError("mailbox for %q disappeared while monitoring root %s", common.Me, root)
+		}
 		return err
 	}
 
@@ -187,6 +214,10 @@ func monitorWithFsnotify(ctx context.Context, inboxNew string) (string, error) {
 			if !ok {
 				return "", errors.New("watcher closed")
 			}
+			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 &&
+				filepath.Clean(event.Name) == filepath.Clean(inboxNew) {
+				return "", os.ErrNotExist
+			}
 			if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
 				time.Sleep(10 * time.Millisecond)
 				return "new_message", nil
@@ -233,9 +264,6 @@ func monitorWithPolling(ctx context.Context, inboxNew string) (string, error) {
 func hasMessageFiles(dir string) (bool, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
 		return false, err
 	}
 	for _, entry := range entries {

--- a/internal/cli/mutation_guard_followup_test.go
+++ b/internal/cli/mutation_guard_followup_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestSendRefusesAMBaseRootOnlyCrossTreeEvidence(t *testing.T) {
+	parent := t.TempDir()
+	sourceBase := filepath.Join(parent, "source", ".agent-mail")
+	foreignRoot := sessionRoot(t, filepath.Join(parent, "foreign"), "session1", "alice", "bob")
+
+	t.Setenv(envRoot, foreignRoot)
+	t.Setenv(envBaseRoot, sourceBase)
+	setOptionalEnv(t, envSession, "", false)
+
+	err := runSend([]string{"--me", "alice", "--to", "bob", "--body", "wrong tree"})
+	assertConsumeRefused(t, err, "send")
+	if got := inboxCount(t, foreignRoot, "bob"); got != 0 {
+		t.Fatalf("foreign send delivered %d message(s)", got)
+	}
+}
+
+func TestMutatingCommandsRefuseForeignPinnedSession(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "reply",
+			run: func() error {
+				return runReply([]string{"--me", "alice", "--id", "missing", "--body", "reply"})
+			},
+		},
+		{
+			name: "watch",
+			run: func() error {
+				_, _, err := captureEnvOutput(t, func() error {
+					return runWatch([]string{"--me", "alice", "--timeout", "1ms", "--poll"})
+				})
+				return err
+			},
+		},
+		{
+			name: "dlq read",
+			run: func() error {
+				return runDLQRead([]string{"--me", "alice", "--id", "missing"})
+			},
+		},
+		{
+			name: "dlq retry",
+			run: func() error {
+				return runDLQRetry([]string{"--me", "alice", "--id", "missing"})
+			},
+		},
+		{
+			name: "dlq purge",
+			run: func() error {
+				return runDLQPurge([]string{"--me", "alice", "--yes"})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := t.TempDir()
+			baseRoot := filepath.Join(parent, ".agent-mail")
+			_ = sessionRoot(t, parent, "session1", "alice", "bob")
+			foreignRoot := sessionRoot(t, parent, "session2", "alice", "bob")
+
+			t.Setenv(envRoot, foreignRoot)
+			t.Setenv(envBaseRoot, baseRoot)
+			t.Setenv(envSession, "session1")
+
+			err := tt.run()
+			if err == nil || GetExitCode(err) != ExitContextMismatch {
+				t.Fatalf("%s should refuse foreign pinned session, got %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestWatchMissingMailboxDoesNotCreateIt(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	root := filepath.Join(baseRoot, "session1")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	t.Setenv(envRoot, root)
+	t.Setenv(envBaseRoot, baseRoot)
+	t.Setenv(envSession, "session1")
+
+	_, _, err := captureEnvOutput(t, func() error {
+		return runWatch([]string{"--me", "alice", "--timeout", "1ms", "--poll"})
+	})
+	if err == nil || GetExitCode(err) != ExitNotFound {
+		t.Fatalf("missing watch mailbox should be not-found, got %v", err)
+	}
+	if _, statErr := os.Stat(fsq.AgentInboxNew(root, "alice")); !os.IsNotExist(statErr) {
+		t.Fatalf("watch created missing inbox, stat error = %v", statErr)
+	}
+}

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -15,8 +15,10 @@ func runRead(args []string) error {
 	fs := flag.NewFlagSet("read", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	idFlag := fs.String("id", "", "Message id")
+	sessionFlag := fs.String("session", "", "Target session under the resolved base root")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION pin")
 
-	usage := usageWithFlags(fs, "amq read --me <agent> --id <msg_id> [options]",
+	usage := usageWithFlags(fs, "amq read --me <agent> --id <msg_id> [--session <name>] [options]",
 		"Read a message by id.",
 		"",
 		"If the message is in inbox/new, AMQ only moves it to inbox/cur after parse and header validation succeed.",
@@ -35,7 +37,19 @@ func runRead(args []string) error {
 		return UsageError("--me: %v", err)
 	}
 	common.Me = me
-	root := resolveRoot(common.Root)
+	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
+	if err != nil {
+		return err
+	}
+	if err := validatePinOverride(common, *ignoreSessionPinFlag, routed); err != nil {
+		return err
+	}
+	if err := guardMailboxContext("read", root, routed, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
+	if err := requireMailbox(root, me); err != nil {
+		return err
+	}
 
 	// Validate handle against config.json
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -190,8 +190,8 @@ var usageGlobalOptions = []string{
 var usageEnvironment = []string{
 	"  AM_ROOT             Queue root directory (from flags, env, config, or coop exec session setup)",
 	"  AM_ME               Default agent handle",
-	"  AM_BASE_ROOT        Base queue root for named-session routing",
-	"  AM_SESSION          Pinned session identity (empty means base-root context)",
+	"  AM_BASE_ROOT        Authorized session base, or exact root for a sessionless pin",
+	"  AM_SESSION          Pinned session identity (empty means exact-root context)",
 	"  AMQ_GLOBAL_ROOT     Global root fallback (for agents spawned by external orchestrators)",
 	"  AMQ_NO_UPDATE_CHECK  Disable update check (1/true/yes/on)",
 }

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -190,6 +190,8 @@ var usageGlobalOptions = []string{
 var usageEnvironment = []string{
 	"  AM_ROOT             Queue root directory (from flags, env, config, or coop exec session setup)",
 	"  AM_ME               Default agent handle",
+	"  AM_BASE_ROOT        Base queue root for named-session routing",
+	"  AM_SESSION          Pinned session identity (empty means base-root context)",
 	"  AMQ_GLOBAL_ROOT     Global root fallback (for agents spawned by external orchestrators)",
 	"  AMQ_NO_UPDATE_CHECK  Disable update check (1/true/yes/on)",
 }

--- a/internal/cli/reply.go
+++ b/internal/cli/reply.go
@@ -30,6 +30,7 @@ func runReply(args []string) error {
 	contextFlag := fs.String("context", "", "JSON context object or @file.json")
 	waitForFlag := fs.String("wait-for", "", "Wait for receipt stage after reply (e.g., drained)")
 	waitTimeoutFlag := fs.Duration("wait-timeout", 120*time.Second, "Timeout for --wait-for")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION source pin")
 
 	usage := usageWithFlags(fs, "amq reply --me <agent> --id <msg_id> [options]",
 		"Reply to a message with automatic thread/refs handling.",
@@ -56,6 +57,12 @@ func runReply(args []string) error {
 	common.Me = me
 	common.warnRootOverride()
 	root := resolveRoot(common.Root)
+	if err := validatePinOverride(common, *ignoreSessionPinFlag, false); err != nil {
+		return err
+	}
+	if err := guardPinnedSourceContext("reply", root, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
 
 	if *idFlag == "" {
 		return UsageError("--id is required")

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -36,6 +36,7 @@ func runSend(args []string) error {
 	// Cross-session flag
 	sessionFlag := fs.String("session", "", "Target session (delivers to a different session's inbox)")
 	fromSessionFlag := fs.String("from-session", "", "Source session for setup-terminal cross-session sends")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION source pin")
 
 	// Cross-project flag
 	projectFlag := fs.String("project", "", "Target peer project name (delivers to a peer project's inbox)")
@@ -121,6 +122,12 @@ func runSend(args []string) error {
 	sourceRoot := root
 	sourceSession := ""
 	fromSession := strings.TrimSpace(*fromSessionFlag)
+	if *ignoreSessionPinFlag && !common.rootExplicit() {
+		return UsageError("--ignore-session-pin requires an explicit --root")
+	}
+	if *ignoreSessionPinFlag && fromSession != "" {
+		return UsageError("--ignore-session-pin cannot be used with --from-session")
+	}
 
 	// Cross-tree guard (issue #144): a direct, unqualified --root that crosses
 	// into a different AMQ tree carries no sender-origin metadata, so the
@@ -161,6 +168,11 @@ func runSend(args []string) error {
 			return fmt.Errorf("agent %q not found in source session %q", me, fromSession)
 		}
 		sourceSession = fromSession
+	}
+	if fromSession == "" {
+		if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
+			return err
+		}
 	}
 
 	if targetProject != "" {

--- a/internal/cli/send_cross_session_test.go
+++ b/internal/cli/send_cross_session_test.go
@@ -236,6 +236,7 @@ func TestSendCrossSessionWithExplicitRootOverride(t *testing.T) {
 	err = runSend([]string{
 		"--me", "claude",
 		"--root", sourceRoot,
+		"--ignore-session-pin",
 		"--to", "codex",
 		"--session", "session3",
 		"--body", "hello across sessions",
@@ -332,6 +333,7 @@ func TestSendCrossSessionWaitForUsesDeliveryRoot(t *testing.T) {
 	err = runSend([]string{
 		"--me", "claude",
 		"--root", sourceRoot,
+		"--ignore-session-pin",
 		"--to", "codex",
 		"--session", "session3",
 		"--body", "hello across sessions",

--- a/internal/cli/send_session_pin_test.go
+++ b/internal/cli/send_session_pin_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSendRefusesMismatchedPinnedSourceSession(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "alice", "bob")
+	targetRoot := sessionRoot(t, parent, "session2", "alice", "bob")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runSend([]string{"--me", "alice", "--to", "bob", "--body", "wrong source"})
+	assertConsumeRefused(t, err, "send")
+	if got := inboxCount(t, targetRoot, "bob"); got != 0 {
+		t.Fatalf("mismatched local send delivered %d message(s)", got)
+	}
+}
+
+func TestSendTargetSessionDoesNotAuthorizeMismatchedSource(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "alice")
+	ambientRoot := sessionRoot(t, parent, "session2", "alice")
+	targetRoot := sessionRoot(t, parent, "session3", "bob")
+
+	t.Setenv("AM_ROOT", ambientRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runSend([]string{"--me", "alice", "--to", "bob", "--session", "session3", "--body", "wrong source"})
+	assertConsumeRefused(t, err, "send")
+	if got := inboxCount(t, targetRoot, "bob"); got != 0 {
+		t.Fatalf("target routing authorized mismatched source and delivered %d message(s)", got)
+	}
+}
+
+func TestSendAllowsExplicitRootWhenIgnoringSessionPin(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	sourceRoot := sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice", "bob")
+
+	t.Setenv("AM_ROOT", sourceRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runSend([]string{
+		"--root", targetRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--body", "deliberate source override",
+		"--ignore-session-pin",
+	})
+	if err != nil {
+		t.Fatalf("explicit root plus pin override should allow send: %v", err)
+	}
+	if got := inboxCount(t, targetRoot, "bob"); got != 1 {
+		t.Fatalf("target inbox count = %d, want 1", got)
+	}
+}
+
+func TestSendRejectsPinOverrideWithoutExplicitRoot(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	root := sessionRoot(t, parent, "session1", "alice", "bob")
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	err := runSend([]string{
+		"--me", "alice",
+		"--to", "bob",
+		"--body", "ambient override",
+		"--ignore-session-pin",
+	})
+	if err == nil || GetExitCode(err) != ExitUsage {
+		t.Fatalf("ambient send override should be a usage error, got %v", err)
+	}
+	if got := inboxCount(t, root, "bob"); got != 0 {
+		t.Fatalf("ambient override delivered %d message(s)", got)
+	}
+}

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -39,14 +39,12 @@ func loadSessionPin() (sessionPin, error) {
 		pin.BaseRoot = absPath(filepath.Clean(base))
 	}
 
+	if pin.BaseRoot == "" {
+		return sessionPin{}, ContextMismatchError("incomplete AMQ session pin: %s=%q requires an exact %s", envSession, pin.Session, envBaseRoot)
+	}
 	if pin.Session != "" {
-		if pin.BaseRoot == "" {
-			return sessionPin{}, ContextMismatchError("incomplete AMQ session pin: %s=%q requires %s", envSession, pin.Session, envBaseRoot)
-		}
 		pin.ExpectedRoot = filepath.Join(pin.BaseRoot, pin.Session)
-	} else if pin.BaseRoot != "" {
-		// Tolerate a stale base variable long enough for an explicit env repin
-		// to clear it; it still provides positive evidence for guard checks.
+	} else {
 		pin.ExpectedRoot = pin.BaseRoot
 	}
 	return pin, nil
@@ -59,15 +57,8 @@ func sessionPinMismatch(target string) (*SessionContextError, error) {
 		return nil, err
 	}
 	if pin.Present {
-		matches := false
 		expected := pin.ExpectedRoot
-		if expected != "" {
-			matches = target == expected
-		} else {
-			matches = resolveSessionName(target) == ""
-			expected = "an explicitly pinned base-root context"
-		}
-		if matches {
+		if target == expected {
 			return nil, nil
 		}
 		return &SessionContextError{Message: fmt.Sprintf(
@@ -107,15 +98,8 @@ func resolveMailboxRoot(common *commonFlags, rawSession string) (root string, ro
 	}
 	base := ""
 	switch {
-	case pin.Present && pin.BaseRoot != "":
-		base = pin.BaseRoot
 	case pin.Present:
-		if mismatch, checkErr := sessionPinMismatch(root); checkErr != nil {
-			return "", false, checkErr
-		} else if mismatch != nil {
-			return "", false, ContextMismatchError("cannot route --session %q: %s", session, mismatch.Error())
-		}
-		base = root
+		base = pin.BaseRoot
 	default:
 		base = baseRootOf(root)
 	}
@@ -145,13 +129,6 @@ func guardPinnedSourceContext(command, target string, ignorePin bool) error {
 	if ignorePin {
 		return nil
 	}
-	pin, err := loadSessionPin()
-	if err != nil {
-		return err
-	}
-	if !pin.Present {
-		return nil
-	}
 	mismatch, err := sessionPinMismatch(target)
 	if err != nil {
 		return err
@@ -159,7 +136,7 @@ func guardPinnedSourceContext(command, target string, ignorePin bool) error {
 	if mismatch == nil {
 		return nil
 	}
-	return ContextMismatchError("refusing %s: %s. Target routing does not authorize a mismatched source; use --from-session or explicit --root with --ignore-session-pin", command, mismatch.Error())
+	return ContextMismatchError("refusing %s: %s. Target routing does not authorize a mismatched source; use an explicit source route, or explicit --root with --ignore-session-pin", command, mismatch.Error())
 }
 
 func validatePinOverride(common *commonFlags, ignorePin bool, routed bool) error {

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type sessionPin struct {
+	Present      bool
+	Session      string
+	BaseRoot     string
+	ExpectedRoot string
+}
+
+// loadSessionPin distinguishes an absent legacy pin from an explicitly empty
+// base-root pin. New shell writers always replace the complete context set.
+func loadSessionPin() (sessionPin, error) {
+	rawSession, present := os.LookupEnv(envSession)
+	if !present {
+		return sessionPin{}, nil
+	}
+
+	pin := sessionPin{Present: true, Session: strings.TrimSpace(rawSession)}
+	if pin.Session != "" {
+		if err := validateSessionName(pin.Session); err != nil {
+			return sessionPin{}, ContextMismatchError("invalid %s=%q: %v", envSession, rawSession, err)
+		}
+	}
+
+	base := strings.TrimSpace(os.Getenv(envBaseRoot))
+	if base != "" {
+		if !filepath.IsAbs(base) {
+			return sessionPin{}, ContextMismatchError("invalid %s=%q: pinned base root must be absolute", envBaseRoot, base)
+		}
+		pin.BaseRoot = absPath(filepath.Clean(base))
+	}
+
+	if pin.Session != "" {
+		if pin.BaseRoot == "" {
+			return sessionPin{}, ContextMismatchError("incomplete AMQ session pin: %s=%q requires %s", envSession, pin.Session, envBaseRoot)
+		}
+		pin.ExpectedRoot = filepath.Join(pin.BaseRoot, pin.Session)
+	} else if pin.BaseRoot != "" {
+		// Tolerate a stale base variable long enough for an explicit env repin
+		// to clear it; it still provides positive evidence for guard checks.
+		pin.ExpectedRoot = pin.BaseRoot
+	}
+	return pin, nil
+}
+
+func sessionPinMismatch(target string) (*SessionContextError, error) {
+	target = absPath(resolveRoot(target))
+	pin, err := loadSessionPin()
+	if err != nil {
+		return nil, err
+	}
+	if pin.Present {
+		matches := false
+		expected := pin.ExpectedRoot
+		if expected != "" {
+			matches = target == expected
+		} else {
+			matches = resolveSessionName(target) == ""
+			expected = "an explicitly pinned base-root context"
+		}
+		if matches {
+			return nil, nil
+		}
+		return &SessionContextError{Message: fmt.Sprintf(
+			"session context mismatch: target root %s differs from pinned root %s (AM_SESSION=%q)",
+			target, expected, pin.Session,
+		)}, nil
+	}
+
+	if source, ok := conflictingSourceRoot(target); ok {
+		return &SessionContextError{Message: fmt.Sprintf(
+			"session context mismatch: target root %s belongs to a different AMQ tree than established root %s",
+			target, source,
+		)}, nil
+	}
+	return nil, nil
+}
+
+// resolveMailboxRoot makes --session a routing operation. With a pin, the
+// target is always constructed from the authorized base rather than ambient
+// AM_ROOT. Without a pin, an explicit session remains deliberate legacy input.
+func resolveMailboxRoot(common *commonFlags, rawSession string) (root string, routed bool, err error) {
+	root = absPath(resolveRoot(common.Root))
+	session := strings.TrimSpace(rawSession)
+	if session == "" {
+		return root, false, nil
+	}
+	if common.rootExplicit() {
+		return "", false, UsageError("--session and --root are mutually exclusive")
+	}
+	if err := validateSessionName(session); err != nil {
+		return "", false, UsageError("--session: %v", err)
+	}
+
+	pin, err := loadSessionPin()
+	if err != nil {
+		return "", false, err
+	}
+	base := ""
+	switch {
+	case pin.Present && pin.BaseRoot != "":
+		base = pin.BaseRoot
+	case pin.Present:
+		if mismatch, checkErr := sessionPinMismatch(root); checkErr != nil {
+			return "", false, checkErr
+		} else if mismatch != nil {
+			return "", false, ContextMismatchError("cannot route --session %q: %s", session, mismatch.Error())
+		}
+		base = root
+	default:
+		base = baseRootOf(root)
+	}
+
+	target := absPath(filepath.Join(base, session))
+	if !dirExists(target) {
+		return "", false, NotFoundError("session %q not found at %s", session, target)
+	}
+	return target, true, nil
+}
+
+func guardMailboxContext(command, target string, routed, ignorePin bool) error {
+	if routed || ignorePin {
+		return nil
+	}
+	mismatch, err := sessionPinMismatch(target)
+	if err != nil {
+		return err
+	}
+	if mismatch == nil {
+		return nil
+	}
+	return ContextMismatchError("refusing %s: %s. Use --session <name> to route deliberately, or explicit --root with --ignore-session-pin", command, mismatch.Error())
+}
+
+func guardPinnedSourceContext(command, target string, ignorePin bool) error {
+	if ignorePin {
+		return nil
+	}
+	pin, err := loadSessionPin()
+	if err != nil {
+		return err
+	}
+	if !pin.Present {
+		return nil
+	}
+	mismatch, err := sessionPinMismatch(target)
+	if err != nil {
+		return err
+	}
+	if mismatch == nil {
+		return nil
+	}
+	return ContextMismatchError("refusing %s: %s. Target routing does not authorize a mismatched source; use --from-session or explicit --root with --ignore-session-pin", command, mismatch.Error())
+}
+
+func validatePinOverride(common *commonFlags, ignorePin bool, routed bool) error {
+	if !ignorePin {
+		return nil
+	}
+	if routed {
+		return UsageError("--ignore-session-pin cannot be used with --session")
+	}
+	if !common.rootExplicit() {
+		return UsageError("--ignore-session-pin requires an explicit --root")
+	}
+	return nil
+}
+
+func requireMailbox(root, me string) error {
+	for _, dir := range []string{
+		fsq.AgentInboxNew(root, me),
+		fsq.AgentInboxCur(root, me),
+		fsq.AgentDLQNew(root, me),
+	} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return NotFoundError("mailbox for %q is missing at root %s (missing %s); check AM_ROOT or use --session <name>", me, root, dir)
+			}
+			return err
+		}
+		if !info.IsDir() {
+			return NotFoundError("mailbox path for %q is not a directory: %s", me, dir)
+		}
+	}
+	return nil
+}

--- a/internal/cli/session_guard_followup_test.go
+++ b/internal/cli/session_guard_followup_test.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestSessionlessCoopPinRejectsRootSwitch(t *testing.T) {
+	commands := []struct {
+		name string
+		run  func(root string) error
+	}{
+		{
+			name: "drain",
+			run: func(_ string) error {
+				return runDrain([]string{"--me", "alice"})
+			},
+		},
+		{
+			name: "send",
+			run: func(_ string) error {
+				return runSend([]string{"--me", "alice", "--to", "bob", "--body", "wrong root"})
+			},
+		},
+		{
+			name: "env",
+			run: func(_ string) error {
+				_, _, err := captureEnvOutput(t, func() error { return runEnv(nil) })
+				return err
+			},
+		},
+	}
+
+	for _, tt := range commands {
+		t.Run(tt.name, func(t *testing.T) {
+			rootA := filepath.Join(t.TempDir(), "queue-a")
+			rootB := filepath.Join(t.TempDir(), "queue-b")
+			for _, root := range []string{rootA, rootB} {
+				for _, agent := range []string{"alice", "bob"} {
+					if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+						t.Fatalf("EnsureAgentDirs(%s, %s): %v", root, agent, err)
+					}
+				}
+			}
+			if tt.name == "drain" {
+				deliverGuardMessage(t, rootB, "alice", "sessionless-theft")
+			}
+
+			pinEnv := buildCoopExecEnvironment(nil, rootA, "alice", "")
+			applyEnvSlice(t, pinEnv, envRoot, envBaseRoot, envSession, envMe)
+			t.Setenv(envRoot, rootB)
+
+			err := tt.run(rootB)
+			assertConsumeRefused(t, err, tt.name)
+		})
+	}
+}
+
+func TestSessionlessEnvOutputPinsExactRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "queue-a")
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--root", root, "--me", "alice"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+	if !strings.Contains(stdout, "export AM_BASE_ROOT="+shellQuotePosix(root)+"\n") {
+		t.Fatalf("sessionless output must pin the exact root in AM_BASE_ROOT: %q", stdout)
+	}
+	if !strings.Contains(stdout, "export AM_SESSION=\n") {
+		t.Fatalf("sessionless output must emit an empty AM_SESSION: %q", stdout)
+	}
+}
+
+func TestLoadSessionPinRejectsEmptySessionWithoutBaseRoot(t *testing.T) {
+	t.Setenv(envSession, "")
+	setOptionalEnv(t, envBaseRoot, "", false)
+
+	_, err := loadSessionPin()
+	if err == nil || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("empty session without exact base pin should be context mismatch, got %v", err)
+	}
+}
+
+func TestEnvSessionFlagUsesPinnedCustomBaseFromForeignCWD(t *testing.T) {
+	customBase := filepath.Join(t.TempDir(), "custom-queue")
+	sourceRoot := filepath.Join(customBase, "session1")
+	targetRoot := filepath.Join(customBase, "session2")
+	for _, root := range []string{sourceRoot, targetRoot} {
+		if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", root, err)
+		}
+	}
+
+	foreignProject := t.TempDir()
+	if err := os.WriteFile(filepath.Join(foreignProject, ".amqrc"), []byte(`{"root":"foreign-mail"}`), 0o600); err != nil {
+		t.Fatalf("write foreign .amqrc: %v", err)
+	}
+	t.Chdir(foreignProject)
+
+	t.Setenv(envRoot, sourceRoot)
+	t.Setenv(envBaseRoot, customBase)
+	t.Setenv(envSession, "session1")
+	t.Setenv(envMe, "alice")
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--session", "session2", "--me", "alice"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv --session: %v", err)
+	}
+	for _, want := range []string{
+		"export AM_ROOT=" + shellQuotePosix(targetRoot) + "\n",
+		"export AM_BASE_ROOT=" + shellQuotePosix(customBase) + "\n",
+		"export AM_SESSION=session2\n",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("pinned-base session route missing %q: %q", want, stdout)
+		}
+	}
+}
+
+func TestBlankRootAndSessionFlagsAreUsageErrors(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "queue")
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	t.Setenv(envRoot, root)
+	setOptionalEnv(t, envSession, "", false)
+	setOptionalEnv(t, envBaseRoot, "", false)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "root", args: []string{"--root=", "--ignore-session-pin", "--me", "alice"}},
+		{name: "session", args: []string{"--session=", "--me", "alice"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runDrain(tt.args)
+			if err == nil || GetExitCode(err) != ExitUsage {
+				t.Fatalf("blank --%s should be usage error, got %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestInvalidInferredSessionFallsBackToExactRootPin(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-mail", "Foo.Bar")
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runEnv([]string{"--root", root, "--me", "alice"})
+	})
+	if err != nil {
+		t.Fatalf("runEnv: %v", err)
+	}
+	if !strings.Contains(stdout, "export AM_BASE_ROOT="+shellQuotePosix(root)+"\n") ||
+		!strings.Contains(stdout, "export AM_SESSION=\n") {
+		t.Fatalf("invalid inferred session must become an exact-root pin: %q", stdout)
+	}
+	if strings.Contains(stdout, "AM_SESSION=Foo.Bar") {
+		t.Fatalf("env emitted an invalid session identity: %q", stdout)
+	}
+	if got := coopSessionIdentity(root, "", root); got != "" {
+		t.Fatalf("coop inferred invalid session %q, want sessionless identity", got)
+	}
+}
+
+func applyEnvSlice(t *testing.T, env []string, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		value, present := lookupEnvSlice(env, key)
+		setOptionalEnv(t, key, value, present)
+	}
+}
+
+func lookupEnvSlice(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix), true
+		}
+	}
+	return "", false
+}
+
+func setOptionalEnv(t *testing.T, key, value string, present bool) {
+	t.Helper()
+	old, hadOld := os.LookupEnv(key)
+	t.Cleanup(func() {
+		if hadOld {
+			_ = os.Setenv(key, old)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+	if present {
+		if err := os.Setenv(key, value); err != nil {
+			t.Fatalf("set %s: %v", key, err)
+		}
+	} else if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+}

--- a/internal/cli/sibling_backlog.go
+++ b/internal/cli/sibling_backlog.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type siblingBacklog struct {
+	Session string
+	Pending int
+}
+
+// findSiblingBacklogs performs a shallow, best-effort scan under the current
+// base root. It counts message-shaped files only; parsing headers here would
+// turn an empty-inbox diagnostic into an expensive second validation path.
+func findSiblingBacklogs(root, me string) []siblingBacklog {
+	normalized, err := normalizeHandle(me)
+	if err != nil {
+		return nil
+	}
+	me = normalized
+	root = absPath(resolveRoot(root))
+	base := baseRootOf(root)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return nil
+	}
+
+	var backlogs []siblingBacklog
+	for _, entry := range entries {
+		if !entry.IsDir() || validateSessionName(entry.Name()) != nil {
+			continue
+		}
+		candidate := absPath(filepath.Join(base, entry.Name()))
+		if candidate == root {
+			continue
+		}
+		pending, err := countPendingMessageFiles(fsq.AgentInboxNew(candidate, me))
+		if err != nil || pending == 0 {
+			continue
+		}
+		backlogs = append(backlogs, siblingBacklog{
+			Session: entry.Name(),
+			Pending: pending,
+		})
+	}
+	return backlogs
+}
+
+func countPendingMessageFiles(dir string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, ".") && strings.HasSuffix(name, ".md") {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func emitSiblingBacklogHintsIfInboxEmpty(root, me string) {
+	pending, err := countPendingMessageFiles(fsq.AgentInboxNew(root, me))
+	if err != nil || pending != 0 {
+		return
+	}
+	current := siblingContext(root)
+	for _, backlog := range findSiblingBacklogs(root, me) {
+		_ = writeStderr("note: %s\n", formatSiblingBacklogHint(backlog, me, current))
+	}
+}
+
+func siblingContext(root string) string {
+	if session := resolveSessionName(absPath(resolveRoot(root))); session != "" && validateSessionName(session) == nil {
+		return session
+	}
+	return "base root"
+}
+
+func formatSiblingBacklogHint(backlog siblingBacklog, me, current string) string {
+	return fmt.Sprintf("%d pending for %q in sibling session %q (current: %s); use: "+
+		"amq list --session %s --me %s --new",
+		backlog.Pending, me, backlog.Session, current, backlog.Session, me)
+}

--- a/internal/cli/sibling_backlog_test.go
+++ b/internal/cli/sibling_backlog_test.go
@@ -71,7 +71,7 @@ func TestListEmptyBaseRootHintsSiblingBacklog(t *testing.T) {
 	deliverGuardMessage(t, siblingRoot, "alice", "waiting")
 
 	t.Setenv("AM_ROOT", baseRoot)
-	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", baseRoot)
 	t.Setenv("AM_SESSION", "")
 
 	stdout, stderr, err := captureEnvOutput(t, func() error {
@@ -163,7 +163,7 @@ func TestListSessionFlagTargetsSiblingFromBaseRoot(t *testing.T) {
 	deliverGuardMessage(t, siblingRoot, "alice", "targeted")
 
 	t.Setenv("AM_ROOT", baseRoot)
-	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_BASE_ROOT", baseRoot)
 	t.Setenv("AM_SESSION", "")
 
 	stdout, _, err := captureEnvOutput(t, func() error {

--- a/internal/cli/sibling_backlog_test.go
+++ b/internal/cli/sibling_backlog_test.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestDrainEmptyHintsSiblingBacklogWithoutCorruptingJSON(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	siblingRoot := sessionRoot(t, parent, "session1", "alice")
+	deliverGuardMessage(t, siblingRoot, "alice", "waiting-1")
+	deliverGuardMessage(t, siblingRoot, "alice", "waiting-2")
+	if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(siblingRoot, "alice"), ".ignored.md"), []byte("ignored"), 0o600); err != nil {
+		t.Fatalf("write dotfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(siblingRoot, "alice"), "ignored.txt"), []byte("ignored"), 0o600); err != nil {
+		t.Fatalf("write non-message: %v", err)
+	}
+
+	t.Setenv("AM_ROOT", currentRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "collab")
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runDrain([]string{"--me", "alice", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runDrain: %v", err)
+	}
+	if !strings.Contains(stdout, `"count": 0`) {
+		t.Fatalf("stdout must remain valid empty drain JSON, got %q", stdout)
+	}
+	assertSiblingHint(t, stderr, 2, "alice", "session1")
+}
+
+func TestListEmptyJSONHintsSiblingBacklogWithoutCorruptingJSON(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	siblingRoot := sessionRoot(t, parent, "session1", "alice")
+	deliverGuardMessage(t, siblingRoot, "alice", "waiting")
+
+	t.Setenv("AM_ROOT", currentRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "collab")
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--new", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+	if strings.TrimSpace(stdout) != "[]" {
+		t.Fatalf("stdout must remain valid empty-list JSON, got %q", stdout)
+	}
+	assertSiblingHint(t, stderr, 1, "alice", "session1")
+}
+
+func TestListEmptyBaseRootHintsSiblingBacklog(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	siblingRoot := sessionRoot(t, parent, "session1", "alice")
+	deliverGuardMessage(t, siblingRoot, "alice", "waiting")
+
+	t.Setenv("AM_ROOT", baseRoot)
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_SESSION", "")
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--new"})
+	})
+	if err == nil || GetExitCode(err) != ExitNotFound {
+		t.Fatalf("missing base-root mailbox should be not-found, got %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want no false empty-list output", stdout)
+	}
+	assertSiblingHint(t, stderr, 1, "alice", "session1")
+}
+
+func TestListFilteredEmptyDoesNotHintWhenCurrentInboxHasMessages(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	siblingRoot := sessionRoot(t, parent, "session1", "alice")
+	deliverGuardMessage(t, currentRoot, "alice", "current")
+	deliverGuardMessage(t, siblingRoot, "alice", "sibling")
+
+	t.Setenv("AM_ROOT", currentRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "collab")
+
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--new", "--from", "carol"})
+	})
+	if err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+	if strings.Contains(stderr, "pending for") {
+		t.Fatalf("filtered-empty results must not claim the current inbox is empty: %q", stderr)
+	}
+}
+
+func TestListWarnsOnPinnedSessionMismatch(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	_ = sessionRoot(t, parent, "session1", "alice")
+	targetRoot := sessionRoot(t, parent, "session2", "alice")
+	deliverGuardMessage(t, targetRoot, "alice", "wrong-context")
+
+	t.Setenv("AM_ROOT", targetRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "session1")
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--new", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("list remains an inspection path, got %v", err)
+	}
+	if !strings.Contains(stdout, `"id": "wrong-context"`) {
+		t.Fatalf("list did not inspect resolved target: %q", stdout)
+	}
+	if !strings.Contains(stderr, "warning: session context mismatch") ||
+		!strings.Contains(stderr, targetRoot) ||
+		!strings.Contains(stderr, filepath.Join(baseRoot, "session1")) {
+		t.Fatalf("list warning must name actual and pinned roots: %q", stderr)
+	}
+}
+
+func TestListMissingMailboxIsNotEmpty(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	root := filepath.Join(baseRoot, "collab")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "collab")
+
+	_, _, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--new"})
+	})
+	if err == nil || GetExitCode(err) != ExitNotFound {
+		t.Fatalf("missing mailbox should be a not-found error, got %v", err)
+	}
+}
+
+func TestListSessionFlagTargetsSiblingFromBaseRoot(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	siblingRoot := sessionRoot(t, parent, "session1", "alice")
+	deliverGuardMessage(t, siblingRoot, "alice", "targeted")
+
+	t.Setenv("AM_ROOT", baseRoot)
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_SESSION", "")
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--session", "session1", "--new", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runList --session: %v", err)
+	}
+	if !strings.Contains(stdout, `"id": "targeted"`) {
+		t.Fatalf("session-targeted list did not return sibling message: %q", stdout)
+	}
+}
+
+func TestDoctorOpsReportsSiblingBacklogMismatch(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	siblingRoot := sessionRoot(t, parent, "session1", "alice")
+	deliverGuardMessage(t, siblingRoot, "alice", "waiting-1")
+	deliverGuardMessage(t, siblingRoot, "alice", "waiting-2")
+	if err := os.MkdirAll(filepath.Join(baseRoot, "meta"), 0o700); err != nil {
+		t.Fatalf("mkdir base meta: %v", err)
+	}
+	if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result := runOpsChecks(currentRoot, "env", false)
+	for _, hint := range result.Hints {
+		if hint.Code != "sibling_backlog" {
+			continue
+		}
+		if hint.Status != "warn" {
+			t.Fatalf("sibling backlog status = %q, want warn", hint.Status)
+		}
+		assertSiblingHint(t, "note: "+hint.Message, 2, "alice", "session1")
+		if !strings.Contains(hint.Message, "current: collab") {
+			t.Fatalf("doctor hint must identify current context: %q", hint.Message)
+		}
+		return
+	}
+	t.Fatalf("doctor ops missing sibling_backlog hint: %#v", result.Hints)
+}
+
+func assertSiblingHint(t *testing.T, stderr string, count int, handle, session string) {
+	t.Helper()
+	wantSummary := strings.Join([]string{
+		"note:",
+		strconv.Itoa(count),
+		"pending for \"" + handle + "\"",
+		"in sibling session \"" + session + "\"",
+	}, " ")
+	if !strings.Contains(stderr, wantSummary) {
+		t.Fatalf("stderr missing sibling summary %q: %q", wantSummary, stderr)
+	}
+	wantCommand := "amq list --session " + session + " --me " + handle + " --new"
+	if !strings.Contains(stderr, wantCommand) {
+		t.Fatalf("stderr missing exact inspection command %q: %q", wantCommand, stderr)
+	}
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1034,17 +1034,6 @@ func wakeCommandEnv(base []string, root string, owner *wakeOwner) ([]string, err
 	return setEnvVar(env, envWakeOwner, encoded), nil
 }
 
-func unsetEnvVar(env []string, key string) []string {
-	prefix := key + "="
-	out := env[:0]
-	for _, entry := range env {
-		if !strings.HasPrefix(entry, prefix) {
-			out = append(out, entry)
-		}
-	}
-	return out
-}
-
 func wakeOwnerHealthCheck(owner wakeOwner) error {
 	if err := validateWakeOwner(owner); err != nil {
 		return err

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -40,8 +40,10 @@ func runWatch(args []string) error {
 	common := addCommonFlags(fs)
 	timeoutFlag := fs.Duration("timeout", 60*time.Second, "Maximum time to wait for messages (0 = wait forever)")
 	pollFlag := fs.Bool("poll", false, "Use polling fallback instead of fsnotify (for network filesystems)")
+	sessionFlag := fs.String("session", "", "Target session under the resolved base root")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, ignore a conflicting AM_SESSION pin")
 
-	usage := usageWithFlags(fs, "amq watch --me <agent> [options]")
+	usage := usageWithFlags(fs, "amq watch --me <agent> [--session <name>] [options]")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
@@ -59,7 +61,19 @@ func runWatch(args []string) error {
 	}
 	common.Me = me
 
-	root := resolveRoot(common.Root)
+	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
+	if err != nil {
+		return err
+	}
+	if err := validatePinOverride(common, *ignoreSessionPinFlag, routed); err != nil {
+		return err
+	}
+	if err := guardMailboxContext("watch", root, routed, *ignoreSessionPinFlag); err != nil {
+		return err
+	}
+	if err := requireMailbox(root, me); err != nil {
+		return err
+	}
 
 	// Validate handle against config.json
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
@@ -71,11 +85,6 @@ func runWatch(args []string) error {
 	}
 
 	inboxNew := fsq.AgentInboxNew(root, common.Me)
-
-	// Ensure inbox directory exists
-	if err := os.MkdirAll(inboxNew, 0o700); err != nil {
-		return err
-	}
 
 	// Set up context with timeout
 	ctx := context.Background()
@@ -97,7 +106,13 @@ func runWatch(args []string) error {
 	}
 
 	if watchErr != nil {
+		if os.IsNotExist(watchErr) {
+			return NotFoundError("mailbox for %q disappeared while watching %s", common.Me, inboxNew)
+		}
 		if errors.Is(watchErr, context.DeadlineExceeded) {
+			if err := requireMailbox(root, me); err != nil {
+				return err
+			}
 			// Output timeout result but return a timeout exit code
 			if err := outputWatchResult(common.JSON, "timeout", nil); err != nil {
 				return err
@@ -139,6 +154,10 @@ func watchWithFsnotify(ctx context.Context, inboxNew string, validator *headerVa
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return nil, "", errors.New("watcher closed")
+			}
+			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 &&
+				filepath.Clean(event.Name) == filepath.Clean(inboxNew) {
+				return nil, "", os.ErrNotExist
 			}
 			// Only care about new files (Create or Rename into directory)
 			if event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
@@ -193,9 +212,6 @@ func watchWithPolling(ctx context.Context, inboxNew string, validator *headerVal
 func listNewMessages(inboxNew string, validator *headerValidator) ([]msgInfo, error) {
 	entries, err := os.ReadDir(inboxNew)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Clear env vars that could interfere with explicit --root/--me flags. AM_BASE_ROOT
-# matters too: the cross-tree send guard treats AM_ROOT/AM_BASE_ROOT as the
-# caller's home root, so an ambient coop session would otherwise make explicit
-# --root sends to the temp queue look like a refused cross-tree send.
-unset AM_ROOT AM_ME AM_BASE_ROOT AMQ_GLOBAL_ROOT 2>/dev/null || true
+# Clear env vars that could interfere with explicit --root/--me flags. The
+# session guards treat AM_BASE_ROOT/AM_SESSION as positive caller context, so an
+# ambient coop session would otherwise make the temp queue look foreign.
+unset AM_ROOT AM_ME AM_BASE_ROOT AM_SESSION AMQ_GLOBAL_ROOT 2>/dev/null || true
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
   GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
 

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -35,9 +35,10 @@ curl -fsSL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/
 ## Environment Rules
 
 AMQ primarily uses `AM_ROOT` (which mailbox tree) and `AM_ME` (which agent).
-Session-launched terminals also carry `AM_BASE_ROOT` plus an independent
-`AM_SESSION` identity. Getting these wrong means messages go to the wrong place
-or silently disappear, so let the CLI handle them rather than guessing.
+Pinned terminals also carry `AM_BASE_ROOT` plus an independent `AM_SESSION`
+identity; sessionless pins use the exact root as `AM_BASE_ROOT` and an empty
+`AM_SESSION`. Getting these wrong means messages go to the wrong place or
+silently disappear, so let the CLI handle them rather than guessing.
 
 **Inside `coop exec`** — everything is pre-configured. Just run bare commands:
 ```bash
@@ -61,7 +62,8 @@ AM_ME=claude AM_ROOT=$(amq env --json | jq -r .root) amq send --to codex --body 
 Why not hardcode? The root path depends on the config chain (project `.amqrc` → `AMQ_GLOBAL_ROOT` → `~/.amqrc`). Hardcoding skips this and breaks when the project moves or config changes.
 Every shell-mode `amq env` invocation replaces the complete context. It emits
 `AM_SESSION` unconditionally (empty for a sessionless root), exports
-`AM_BASE_ROOT` for session roots, and unsets `AM_BASE_ROOT` otherwise.
+`AM_BASE_ROOT` as the authorized parent for named sessions or the exact root for
+a sessionless context.
 `--export` additionally prints a stderr pin note. Treat the evaluated output as
 one terminal, one session.
 
@@ -173,17 +175,17 @@ amq receipts wait --me codex --msg-id <msg_id> --stage drained --timeout 60s
 
 `amq read`, `amq drain`, and `amq monitor` all apply the same strict header validation. Messages in `inbox/new` that are corrupt or have malformed headers are moved to DLQ and produce a `dlq` receipt.
 
-Those consuming commands also refuse a raw target that conflicts with a
-positive `AM_SESSION` pin before touching inbox state. Use `--session <name>`
-for deliberate sibling access. The raw-root escape hatch,
-`--ignore-session-pin`, requires an explicit `--root`; it never blesses an
-inherited `AM_ROOT`. `send` applies the same check to its source context, while
-`list` warns and remains available for non-destructive inspection. With no
-session/tree evidence, scripts and CI remain fail-open. A missing mailbox is an
-error, not an empty inbox. Empty `drain` and `list --new` results may print a
-stderr note when the same handle has pending messages in a sibling session;
-follow the exact `amq list --session <name> --me <handle> --new` command in that
-note.
+Those consuming commands, `watch`, and mutating DLQ commands refuse a raw
+target that conflicts with a complete `AM_BASE_ROOT`/`AM_SESSION` pin before
+touching mailbox state. `send` and `reply` apply the same check to their source
+context. Use `--session <name>` for deliberate sibling access. The raw-root
+escape hatch, `--ignore-session-pin`, requires a non-empty explicit `--root`;
+it never blesses an inherited `AM_ROOT`. `list` warns and remains available for
+non-destructive inspection. With no session/tree evidence, scripts and CI
+remain fail-open. A missing mailbox is an error, not an empty inbox. Empty
+`drain` and `list --new` results may print a stderr note when the same handle
+has pending messages in a sibling session; follow the exact `amq list --session
+<name> --me <handle> --new` command in that note.
 This is an operational safety check, not an authorization boundary; a local
 process can deliberately repin or override it.
 

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -34,7 +34,10 @@ curl -fsSL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/
 
 ## Environment Rules
 
-AMQ primarily uses two env vars for routing: `AM_ROOT` (which mailbox tree) and `AM_ME` (which agent). Getting these wrong means messages go to the wrong place or silently disappear, so it matters to let the CLI handle them rather than guessing.
+AMQ primarily uses `AM_ROOT` (which mailbox tree) and `AM_ME` (which agent).
+Session-launched terminals also carry `AM_BASE_ROOT` plus an independent
+`AM_SESSION` identity. Getting these wrong means messages go to the wrong place
+or silently disappear, so let the CLI handle them rather than guessing.
 
 **Inside `coop exec`** — everything is pre-configured. Just run bare commands:
 ```bash
@@ -42,18 +45,25 @@ amq send --to codex --body "hello"     # correct
 amq send --me claude --to codex ...    # wrong — --me overrides the env
 ./amq send ...                         # wrong — use amq from PATH
 ```
-The reason: `coop exec` sets `AM_ROOT` and `AM_ME` precisely for the session. Passing `--me` overrides the env, and passing `--root` intentionally overrides the current root (the CLI will note that on stderr if it differs from `AM_ROOT`). Prefer bare commands unless you mean to target a different root.
+The reason: `coop exec` sets `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`, and
+`AM_SESSION` precisely for the session. Passing `--me` overrides the identity;
+for read-side sibling access, use `--session <name>` instead of overriding the
+raw root.
 
 **Outside `coop exec`** — resolve the root from config, don't hardcode it:
 ```bash
-eval "$(amq env --me claude)"          # reads .amqrc chain, sets both vars
+eval "$(amq env --me claude)"          # reads .amqrc chain, replaces the full context
 eval "$(amq env --session auth --me claude --export)"  # pin this terminal to one session
 
 # Or pin per-command without polluting the shell (useful in scripts):
 AM_ME=claude AM_ROOT=$(amq env --json | jq -r .root) amq send --to codex --body "hello"
 ```
 Why not hardcode? The root path depends on the config chain (project `.amqrc` → `AMQ_GLOBAL_ROOT` → `~/.amqrc`). Hardcoding skips this and breaks when the project moves or config changes.
-Use `--export` only when the whole terminal should stay pinned; it exports `AM_BASE_ROOT` for session roots and prints a stderr note. Treat it as one terminal, one session.
+Every shell-mode `amq env` invocation replaces the complete context. It emits
+`AM_SESSION` unconditionally (empty for a sessionless root), exports
+`AM_BASE_ROOT` for session roots, and unsets `AM_BASE_ROOT` otherwise.
+`--export` additionally prints a stderr pin note. Treat the evaluated output as
+one terminal, one session.
 
 **Global fallback**: Orchestrator-spawned agents often start outside the repo root where no project `.amqrc` exists. Set `AMQ_GLOBAL_ROOT` or `~/.amqrc` so `amq env` and `amq doctor` still resolve the correct queue.
 
@@ -163,6 +173,20 @@ amq receipts wait --me codex --msg-id <msg_id> --stage drained --timeout 60s
 
 `amq read`, `amq drain`, and `amq monitor` all apply the same strict header validation. Messages in `inbox/new` that are corrupt or have malformed headers are moved to DLQ and produce a `dlq` receipt.
 
+Those consuming commands also refuse a raw target that conflicts with a
+positive `AM_SESSION` pin before touching inbox state. Use `--session <name>`
+for deliberate sibling access. The raw-root escape hatch,
+`--ignore-session-pin`, requires an explicit `--root`; it never blesses an
+inherited `AM_ROOT`. `send` applies the same check to its source context, while
+`list` warns and remains available for non-destructive inspection. With no
+session/tree evidence, scripts and CI remain fail-open. A missing mailbox is an
+error, not an empty inbox. Empty `drain` and `list --new` results may print a
+stderr note when the same handle has pending messages in a sibling session;
+follow the exact `amq list --session <name> --me <handle> --new` command in that
+note.
+This is an operational safety check, not an authorization boundary; a local
+process can deliberately repin or override it.
+
 ## Session Layout
 
 By default, the root is `.agent-mail` (from `.amqrc` or auto-detect). Use `--session` to create isolated subdirectories:
@@ -176,7 +200,11 @@ By default, the root is `.agent-mail` (from `.amqrc` or auto-detect). Use `--ses
 - `amq coop exec claude` → `AM_ROOT=.agent-mail/collab` (default session)
 - `amq coop exec --session auth claude` → `AM_ROOT=.agent-mail/auth`
 
-The main env vars are `AM_ROOT` (where) + `AM_ME` (who). `coop exec` may also set `AM_BASE_ROOT` for cross-session resolution. The CLI enforces correct routing — just run `amq` commands as-is.
+The main env vars are `AM_ROOT` (where) + `AM_ME` (who). `coop exec` also sets
+`AM_BASE_ROOT` for cross-session resolution and `AM_SESSION` as the independent
+session identity used by consuming-command guards. The CLI enforces correct
+routing — run bare commands for the current session or use `--session` for a
+named sibling.
 Default `.agent-mail/<session>` layouts are recognized even without `.amqrc`; custom root names still need config or explicit flags/env.
 
 ## Cross-Project Routing
@@ -292,6 +320,7 @@ Note: The `agent@name` inline syntax (e.g., `codex@infra`) is for cross-project 
 ```bash
 amq send --to codex --body "Message"              # Send (uses AM_ROOT/AM_ME from env)
 amq drain --include-body                          # Receive (one-shot, silent when empty)
+amq drain --session auth --include-body           # Deliberate sibling-session receive
 amq reply --id <msg_id> --body "Response"          # Reply in thread
 amq watch --timeout 60s                           # Block until message arrives
 amq list --new                                    # Peek without side effects

--- a/skills/amq-cli/references/integrations.md
+++ b/skills/amq-cli/references/integrations.md
@@ -70,7 +70,10 @@ amq doctor --ops
 amq doctor --ops --json
 ```
 
-`doctor --ops` adds queue depth, oldest unread age, DLQ state, presence freshness, and integration hints on top of the base `doctor` checks.
+`doctor --ops` adds queue depth, sibling-session backlog hints, oldest unread
+age, DLQ state, presence freshness, and integration hints on top of the base
+`doctor` checks. A `sibling_backlog` hint includes an exact non-destructive
+`amq list --session <name> --me <handle> --new` inspection command.
 
 ## Message Shape
 


### PR DESCRIPTION
## Summary

- Pin every shell/coop context with an exact AM_BASE_ROOT plus AM_SESSION; sessionless contexts use their exact root and an empty session.
- Refuse mismatched read, drain, monitor, watch, reply, mutating DLQ, and local-send source contexts with exit 5; route explicit --session from the pinned base.
- Reject explicitly blank --root/--session values, preserve missing-mailbox failures during watch/drain races, and escape Fish backslashes correctly.
- Keep list warning-only and retain sibling-backlog hints for non-destructive recovery.

## Behavioral changes

- --ignore-session-pin requires a non-empty explicit --root and cannot be combined with --session.
- Every shell-mode amq env output replaces AM_ROOT, AM_BASE_ROOT, AM_SESSION, and AM_ME. Sessionless output now pins AM_BASE_ROOT to the exact root.
- amq env --session uses a valid pinned base before cwd configuration.
- Invalid inferred session names fall back to an exact-root sessionless pin.
- Mailbox validation requires inbox/new, inbox/cur, and dlq/new; missing paths are not treated as empty.

## Verification

- make ci
- go test -race ./...
- Linux and Windows internal/cli test-binary compilation
- Windows and FreeBSD full builds
- Fresh binary incident replay: sessionless root switch refusal=5 for drain/send/env; foreign reply/watch/DLQ refusal=5; blank flags=2; pinned custom-base env routing succeeds

## Known limitation

send --from-session remains a double-explicit legacy route from its supplied raw base. Callers must ensure that base is intentional until the follow-up resolver work lands.

Closes #224