### PR TITLE
ci(release): mark published release PR as tagged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      pull-requests: write
       attestations: write
       id-token: write
     steps:
@@ -184,6 +185,44 @@ jobs:
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4
         with:
           subject-path: ${{ steps.attestation_subjects.outputs.subjects }}
+
+      - name: Mark release pull request as tagged
+        if: github.event_name == 'push'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          release_prs="$(
+            gh api \
+              --header "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/pulls" \
+              --jq ".[] | select(.merged_at != null and .base.ref == \"main\" and .title == \"chore(release): v${VERSION}\") | .number"
+          )"
+          release_pr_count="$(printf '%s\n' "$release_prs" | awk 'NF { count++ } END { print count + 0 }')"
+          if [[ "$release_pr_count" != "1" ]]; then
+            echo "::error::Expected one merged release PR for v${VERSION} at ${RELEASE_SHA}; found ${release_pr_count}: ${release_prs:-none}."
+            exit 1
+          fi
+          release_pr="$(printf '%s\n' "$release_prs" | awk 'NF { print; exit }')"
+
+          labels="$(gh pr view "$release_pr" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name')"
+          edit_args=()
+          if printf '%s\n' "$labels" | grep -Fxq 'autorelease: pending'; then
+            edit_args+=(--remove-label 'autorelease: pending')
+          fi
+          if ! printf '%s\n' "$labels" | grep -Fxq 'autorelease: tagged'; then
+            edit_args+=(--add-label 'autorelease: tagged')
+          fi
+
+          if [[ ${#edit_args[@]} -gt 0 ]]; then
+            gh pr edit "$release_pr" --repo "$GITHUB_REPOSITORY" "${edit_args[@]}"
+          else
+            echo "Release PR #${release_pr} is already tagged."
+          fi
 
   skill-publish:
     needs: [prepare, release]

--- a/scripts/test_release_please_config.py
+++ b/scripts/test_release_please_config.py
@@ -50,6 +50,29 @@ def test_release_please_workflow_is_pr_only_and_staged() -> None:
     assert "python3 scripts/release_changelog_section.py" not in release_workflow
 
 
+def test_release_workflow_marks_published_release_pr_as_tagged() -> None:
+    workflow = (ROOT / ".github/workflows/release.yml").read_text()
+
+    release_job = workflow[workflow.index("  release:\n") : workflow.index("  skill-publish:\n")]
+    assert "pull-requests: write" in release_job
+
+    publish = release_job.index("      - name: Release\n")
+    mark_tagged = release_job.index(
+        "      - name: Mark release pull request as tagged\n"
+    )
+    attest = release_job.index("      - name: Collect attestation subjects\n")
+    assert publish < attest < mark_tagged
+
+    mark_step = release_job[mark_tagged:]
+    assert "if: github.event_name == 'push'" in mark_step
+    assert "RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}" in mark_step
+    assert "VERSION: ${{ needs.prepare.outputs.version }}" in mark_step
+    assert 'commits/${RELEASE_SHA}/pulls' in mark_step
+    assert 'chore(release): v${VERSION}' in mark_step
+    assert "autorelease: pending" in mark_step
+    assert "autorelease: tagged" in mark_step
+
+
 def test_version_files_and_replacement_gates() -> None:
     version = json.loads((ROOT / ".release-please-manifest.json").read_text())["."]
     for path in ["skills/amq-cli/SKILL.md", "skills/amq-spec/SKILL.md"]:
@@ -76,5 +99,6 @@ def test_version_files_and_replacement_gates() -> None:
 if __name__ == "__main__":
     test_release_please_config()
     test_release_please_workflow_is_pr_only_and_staged()
+    test_release_workflow_marks_published_release_pr_as_tagged()
     test_version_files_and_replacement_gates()
     print("release-please config tests ok")


### PR DESCRIPTION
## Summary

- grant the release job pull-request write permission for release-please bookkeeping
- after artifacts are published and attested on push releases, resolve the unique merged release PR from the validated release SHA and version
- idempotently replace autorelease: pending with autorelease: tagged while leaving manual old-tag dispatches unchanged

## Verification

- make ci
- python3 scripts/test_release_please_config.py
- parsed release.yml and ran bash -n on the extracted label step
- live read-only resolver uniquely matched merged PR #226 at 15c1ee8
- gitleaks dir --no-banner --redact --exit-code 1 .

No changelog entry: this is release-pipeline bookkeeping and the ci type does not open a release PR.