### PR TITLE
feat(doctor): detect mailbox divergence across worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,7 @@ Use `--force` with retry to override the max retry limit.
 
 - Queue depth and oldest unread per agent
 - Sibling-session backlogs for the same handles
+- Same-session mailbox divergence across git worktrees (diagnostic-only)
 - DLQ count and oldest age
 - Presence freshness
 - Wake lock health (`--fix-wake-locks` removes stale locks)
@@ -367,6 +368,14 @@ Repaired wake stdout/stderr goes to
 pipes open after its JSON/text output exits. `doctor --ops` may report
 `target_present` and `repair_available`, but must remain diagnostic-only and
 never spawn a wake process.
+
+Git worktree diagnostics stay in `doctor --ops`, never in the send routing
+path. Relative project roots and auto-detected roots are per-worktree; sharing
+requires the same absolute `.amqrc` root or `AMQ_GLOBAL_ROOT`. The deep check is
+best-effort and warns only when the same session exists under another worktree
+root with fresher peer presence. `send --wait-for` timeout text may name the
+already-resolved delivery root/session and recommend `doctor --ops`, but must
+not scan git worktrees itself.
 
 Use `amq doctor --ops --json` for machine-readable health output.
 

--- a/COOP.md
+++ b/COOP.md
@@ -77,6 +77,14 @@ amq coop exec --session api codex                 # Terminal 4
 Each pair has isolated inboxes and threads. Messages stay within their root.
 Equivalent explicit root form: `--root .agent-mail/<session>`.
 
+That isolation also applies across git worktrees. A relative project root such
+as `{"root":".agent-mail"}` resolves separately inside every worktree, even when
+the session names match. To share a mailbox intentionally, configure the same
+absolute `.amqrc` root in each worktree, or remove the relative project config
+and set `AMQ_GLOBAL_ROOT` to one absolute base. Use `amq doctor --ops` when a
+delivery receipt times out; it can name divergent same-session roots when a
+peer has fresher presence in another worktree.
+
 For read-side access, prefer the named route:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -174,6 +174,20 @@ the same condition as a `sibling_backlog` warning. The pin is an operational
 safety check, not access control: a local process can still repin the
 environment or use the explicit override.
 
+Git worktrees are isolated by default when the project root is relative (for
+example `{"root":".agent-mail"}`): the same session name resolves beneath each
+worktree, so two agents can appear to share `collab` while reading different
+mailboxes. `amq doctor --ops` warns when a linked worktree uses this local
+layout and when a peer has fresher presence in the same session under another
+worktree root. A `send --wait-for` timeout names its delivery root/session and
+points to that diagnostic.
+
+If agents in several worktrees should share one mailbox, give all of them the
+same absolute base root. Use an absolute, machine-local `.amqrc` value such as
+`{"root":"/absolute/path/to/shared/.agent-mail"}`, or remove the project-relative
+`.amqrc` and export `AMQ_GLOBAL_ROOT=/absolute/path/to/shared/.agent-mail`.
+Per-worktree isolation remains the default when sharing is not intended.
+
 ### 4. Inspect Health
 
 ```bash

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -49,6 +49,7 @@ func runDoctor(args []string) error {
 		"  - Queue depth and oldest unread per agent",
 		"  - DLQ count and age",
 		"  - Presence freshness",
+		"  - Git worktree mailbox divergence",
 		"  - Wake lock health",
 		"  - Integration hints (Kanban, Symphony)",
 	)

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -75,6 +75,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		Source: rootSource,
 	}
 	result.OperatorGate = checkOperatorGate(root, now)
+	result.Hints = append(result.Hints, checkLinkedWorktreeLocalHint(root, rootSource)...)
 
 	// Load the active root's config, falling back to the base config for normal
 	// session layouts where coop init owns the single config.json.
@@ -147,6 +148,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 
 	// Operational and integration hints
 	result.Hints = append(result.Hints, checkSiblingBacklogHints(root, agents)...)
+	result.Hints = append(result.Hints, checkWorktreeDivergenceHints(root, agents)...)
 	result.Hints = append(result.Hints, checkGlobalRootHint()...)
 	result.Hints = append(result.Hints, checkKanbanHint()...)
 	result.Hints = append(result.Hints, checkSymphonyHint()...)

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -427,7 +427,7 @@ func runSend(args []string) error {
 		r, err := receipt.WaitFor(deliveryRoot, id, consumer, waitFor, *waitTimeoutFlag, 1*time.Second)
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			waitResult = &waitForResult{Event: "timeout", Stage: waitFor, Timeout: waitTimeoutFlag.String()}
-			waitErr = TimeoutError("send --wait-for %s timed out after %s", waitFor, *waitTimeoutFlag)
+			waitErr = TimeoutError("send --wait-for %s timed out after %s (delivery session %s, root %s); run 'amq doctor --ops' to diagnose mailbox divergence", waitFor, *waitTimeoutFlag, targetDisplay, deliveryRoot)
 		} else if err != nil {
 			waitResult = &waitForResult{Event: "error", Stage: waitFor, Detail: err.Error()}
 			waitErr = fmt.Errorf("send --wait-for: %w", err)

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -100,6 +100,37 @@ func TestSendRootOnlyJSONUsesRootBasenameAsSession(t *testing.T) {
 	}
 }
 
+func TestSendWaitTimeoutNamesDeliveryContextAndDoctor(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-mail", "collab")
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs: %v", err)
+		}
+	}
+	for _, key := range []string{envRoot, envBaseRoot, envSession} {
+		setOptionalEnv(t, key, "", false)
+	}
+
+	_, _, err := captureEnvOutput(t, func() error {
+		return runSend([]string{
+			"--root", root,
+			"--me", "alice",
+			"--to", "bob",
+			"--body", "timeout hint",
+			"--wait-for", "drained",
+			"--wait-timeout", "1ms",
+		})
+	})
+	if err == nil || GetExitCode(err) != ExitTimeout {
+		t.Fatalf("send wait should time out, got %v", err)
+	}
+	for _, want := range []string{root, "collab", "amq doctor --ops"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("timeout hint missing %q: %v", want, err)
+		}
+	}
+}
+
 func TestReply_RejectsPositionalArgs(t *testing.T) {
 	root := t.TempDir()
 	for _, agent := range []string{"alice", "bob"} {

--- a/internal/cli/worktree_divergence.go
+++ b/internal/cli/worktree_divergence.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/presence"
+)
+
+const gitDiagnosticTimeout = 2 * time.Second
+
+func checkLinkedWorktreeLocalHint(root, rootSource string) []opsHint {
+	if !worktreeLocalRootSource(rootSource) {
+		return nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	top, err := gitTopLevel(cwd)
+	if err != nil || !pathWithin(top, root) {
+		return nil
+	}
+	gitMarker, err := os.Stat(filepath.Join(top, ".git"))
+	if err != nil || !gitMarker.Mode().IsRegular() {
+		return nil
+	}
+	session := validSessionNameForRoot(root)
+	if session == "" {
+		return nil
+	}
+	return []opsHint{{
+		Code:   "worktree_session_isolation",
+		Status: "warn",
+		Message: fmt.Sprintf(
+			"linked git worktree session %q is per-worktree at %s (root source: %s); use an absolute root in .amqrc or AMQ_GLOBAL_ROOT to share one mailbox across worktrees",
+			session, absPath(resolveRoot(root)), rootSource,
+		),
+	}}
+}
+
+func worktreeLocalRootSource(source string) bool {
+	switch rootSource(source) {
+	case rootSourceAutoDetect:
+		return true
+	case rootSourceProjectRC:
+		result, err := findAndLoadAmqrc()
+		return err == nil && result.Config.Root != "" && !filepath.IsAbs(result.Config.Root)
+	default:
+		return false
+	}
+}
+
+func checkWorktreeDivergenceHints(root string, agents []string) []opsHint {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	top, err := gitTopLevel(cwd)
+	if err != nil {
+		return nil
+	}
+
+	root = canonicalDiagnosticPath(root)
+	session := validSessionNameForRoot(root)
+	if session == "" {
+		return nil
+	}
+	base := canonicalDiagnosticPath(baseRootOf(root))
+	relBase, err := filepath.Rel(top, base)
+	if err != nil || relBase == ".." || strings.HasPrefix(relBase, ".."+string(filepath.Separator)) || filepath.IsAbs(relBase) {
+		return nil
+	}
+
+	worktrees, err := listGitWorktrees(top)
+	if err != nil {
+		return nil
+	}
+	caller := strings.TrimSpace(os.Getenv(envMe))
+	var hints []opsHint
+	for _, worktree := range worktrees {
+		candidate := canonicalDiagnosticPath(filepath.Join(worktree, relBase, session))
+		if candidate == root || !dirExists(candidate) {
+			continue
+		}
+		peers := fresherPresenceAgents(root, candidate, agents, caller)
+		if len(peers) == 0 {
+			continue
+		}
+		hints = append(hints, opsHint{
+			Code:   "worktree_divergence",
+			Status: "warn",
+			Message: fmt.Sprintf(
+				"session %q resolves to different roots across git worktrees: current %s, fresher presence for peer(s) %s at %s; use an absolute root in .amqrc or AMQ_GLOBAL_ROOT to share one mailbox intentionally",
+				session, root, strings.Join(peers, ","), candidate,
+			),
+		})
+	}
+	return hints
+}
+
+func validSessionNameForRoot(root string) string {
+	session := resolveSessionName(absPath(resolveRoot(root)))
+	if session == "" || validateSessionName(session) != nil {
+		return ""
+	}
+	return session
+}
+
+func fresherPresenceAgents(currentRoot, candidateRoot string, agents []string, caller string) []string {
+	var fresher []string
+	for _, agent := range agents {
+		if agent == caller {
+			continue
+		}
+		candidateSeen, ok := presenceLastSeen(candidateRoot, agent)
+		if !ok {
+			continue
+		}
+		currentSeen, currentOK := presenceLastSeen(currentRoot, agent)
+		if currentOK && !candidateSeen.After(currentSeen) {
+			continue
+		}
+		fresher = append(fresher, agent)
+	}
+	sort.Strings(fresher)
+	return fresher
+}
+
+func presenceLastSeen(root, agent string) (time.Time, bool) {
+	p, err := presence.Read(root, agent)
+	if err != nil {
+		return time.Time{}, false
+	}
+	seen, err := time.Parse(time.RFC3339Nano, p.LastSeen)
+	return seen, err == nil
+}
+
+func gitTopLevel(cwd string) (string, error) {
+	output, err := runGitDiagnostic(cwd, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+	top := strings.TrimSpace(string(output))
+	if top == "" {
+		return "", fmt.Errorf("git returned an empty worktree root")
+	}
+	return canonicalDiagnosticPath(top), nil
+}
+
+func listGitWorktrees(cwd string) ([]string, error) {
+	output, err := runGitDiagnostic(cwd, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return nil, err
+	}
+	var worktrees []string
+	for _, field := range bytes.Split(output, []byte{0}) {
+		const prefix = "worktree "
+		if !bytes.HasPrefix(field, []byte(prefix)) {
+			continue
+		}
+		path := strings.TrimSpace(string(field[len(prefix):]))
+		if path != "" {
+			worktrees = append(worktrees, canonicalDiagnosticPath(path))
+		}
+	}
+	return worktrees, nil
+}
+
+func runGitDiagnostic(cwd string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitDiagnosticTimeout)
+	defer cancel()
+	cmdArgs := append([]string{"-C", cwd}, args...)
+	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+	cmd.Env = gitDiagnosticEnv()
+	return cmd.Output()
+}
+
+func gitDiagnosticEnv() []string {
+	blocked := map[string]struct{}{
+		"GIT_COMMON_DIR": {},
+		"GIT_DIR":        {},
+		"GIT_WORK_TREE":  {},
+	}
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, skip := blocked[key]; !skip {
+			env = append(env, entry)
+		}
+	}
+	return env
+}
+
+func pathWithin(parent, child string) bool {
+	parent = canonicalDiagnosticPath(parent)
+	child = canonicalDiagnosticPath(child)
+	rel, err := filepath.Rel(parent, child)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func canonicalDiagnosticPath(path string) string {
+	path = absPath(resolveRoot(path))
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(path)
+}

--- a/internal/cli/worktree_divergence_test.go
+++ b/internal/cli/worktree_divergence_test.go
@@ -1,0 +1,206 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/presence"
+)
+
+func TestDoctorOpsHintsPerWorktreeSessionForLocalRootSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		rootSource string
+		rcRoot     string
+		wantHint   bool
+	}{
+		{name: "relative project config", rootSource: string(rootSourceProjectRC), rcRoot: ".agent-mail", wantHint: true},
+		{name: "auto detected root", rootSource: string(rootSourceAutoDetect), rcRoot: ".agent-mail", wantHint: true},
+		{name: "absolute project config", rootSource: string(rootSourceProjectRC), rcRoot: "absolute", wantHint: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, linked := createGitWorktreeFixture(t)
+			t.Chdir(linked)
+
+			root := filepath.Join(linked, ".agent-mail", "collab")
+			ensureOpsRoot(t, root, "alice")
+			if top, err := gitTopLevel(linked); err != nil || top != canonicalDiagnosticPath(linked) {
+				t.Fatalf("gitTopLevel(%s)=%q, %v", linked, top, err)
+			}
+			if session := validSessionNameForRoot(root); session != "collab" {
+				t.Fatalf("validSessionNameForRoot(%s)=%q, want collab", root, session)
+			}
+			rcRoot := tt.rcRoot
+			if rcRoot == "absolute" {
+				rcRoot = filepath.Join(t.TempDir(), "shared-agent-mail")
+			}
+			if err := os.WriteFile(filepath.Join(linked, ".amqrc"), []byte(`{"root":"`+rcRoot+`"}`), 0o600); err != nil {
+				t.Fatalf("write linked .amqrc: %v", err)
+			}
+
+			result := runOpsChecks(root, tt.rootSource, false)
+			hint, found := findOpsHint(result.Hints, "worktree_session_isolation")
+			if found != tt.wantHint {
+				t.Fatalf("worktree_session_isolation found=%v, want %v; hints=%#v", found, tt.wantHint, result.Hints)
+			}
+			if !found {
+				return
+			}
+			for _, want := range []string{root, "collab", "per-worktree", "absolute"} {
+				if !strings.Contains(hint.Message, want) {
+					t.Fatalf("hint missing %q: %q", want, hint.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorOpsWarnsWhenPeerPresenceIsFresherInSameSessionOtherWorktree(t *testing.T) {
+	primary, linked := createGitWorktreeFixture(t)
+	t.Chdir(primary)
+	t.Setenv(envMe, "alice")
+	t.Setenv("GIT_DIR", filepath.Join(t.TempDir(), "wrong-git-dir"))
+	t.Setenv("GIT_WORK_TREE", filepath.Join(t.TempDir(), "wrong-worktree"))
+	t.Setenv("GIT_COMMON_DIR", filepath.Join(t.TempDir(), "wrong-common-dir"))
+
+	currentRoot := filepath.Join(primary, ".agent-mail", "collab")
+	otherRoot := filepath.Join(linked, ".agent-mail", "collab")
+	for _, root := range []string{currentRoot, otherRoot} {
+		ensureOpsRoot(t, root, "alice", "bob")
+	}
+	worktrees, err := listGitWorktrees(primary)
+	if err != nil {
+		t.Fatalf("listGitWorktrees: %v", err)
+	}
+	if len(worktrees) != 2 {
+		t.Fatalf("worktrees=%#v, want primary and linked", worktrees)
+	}
+	now := time.Now()
+	if err := presence.Write(currentRoot, presence.New("bob", "active", "current", now.Add(-time.Minute))); err != nil {
+		t.Fatalf("write current presence: %v", err)
+	}
+	if err := presence.Write(otherRoot, presence.New("bob", "active", "other", now)); err != nil {
+		t.Fatalf("write other presence: %v", err)
+	}
+
+	result := runOpsChecks(currentRoot, string(rootSourceProjectRC), false)
+	hint, found := findOpsHint(result.Hints, "worktree_divergence")
+	if !found {
+		t.Fatalf("doctor ops missing worktree_divergence hint: %#v", result.Hints)
+	}
+	if hint.Status != "warn" {
+		t.Fatalf("worktree divergence status=%q, want warn", hint.Status)
+	}
+	for _, want := range []string{canonicalDiagnosticPath(currentRoot), canonicalDiagnosticPath(otherRoot), "collab", "bob", ".amqrc", "AMQ_GLOBAL_ROOT"} {
+		if !strings.Contains(hint.Message, want) {
+			t.Fatalf("divergence hint missing %q: %q", want, hint.Message)
+		}
+	}
+}
+
+func TestDoctorOpsDoesNotWarnForOlderPeerOrFresherCallerPresence(t *testing.T) {
+	primary, linked := createGitWorktreeFixture(t)
+	t.Chdir(primary)
+	t.Setenv(envMe, "alice")
+
+	currentRoot := filepath.Join(primary, ".agent-mail", "collab")
+	otherRoot := filepath.Join(linked, ".agent-mail", "collab")
+	for _, root := range []string{currentRoot, otherRoot} {
+		ensureOpsRoot(t, root, "alice", "bob")
+	}
+	now := time.Now()
+	for _, item := range []struct {
+		root   string
+		agent  string
+		seenAt time.Time
+	}{
+		{root: currentRoot, agent: "bob", seenAt: now},
+		{root: otherRoot, agent: "bob", seenAt: now.Add(-time.Minute)},
+		{root: currentRoot, agent: "alice", seenAt: now.Add(-time.Minute)},
+		{root: otherRoot, agent: "alice", seenAt: now},
+	} {
+		if err := presence.Write(item.root, presence.New(item.agent, "active", "", item.seenAt)); err != nil {
+			t.Fatalf("write %s presence at %s: %v", item.agent, item.root, err)
+		}
+	}
+
+	result := runOpsChecks(currentRoot, string(rootSourceProjectRC), false)
+	if hint, found := findOpsHint(result.Hints, "worktree_divergence"); found {
+		t.Fatalf("unexpected divergence hint: %#v", hint)
+	}
+}
+
+func TestWorktreeDiagnosticsFailOpenOutsideGitRepository(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if hints := checkLinkedWorktreeLocalHint(filepath.Join(t.TempDir(), ".agent-mail", "collab"), string(rootSourceAutoDetect)); len(hints) != 0 {
+		t.Fatalf("local hints outside git=%#v, want none", hints)
+	}
+	if hints := checkWorktreeDivergenceHints(filepath.Join(t.TempDir(), ".agent-mail", "collab"), []string{"alice"}); len(hints) != 0 {
+		t.Fatalf("divergence hints outside git=%#v, want none", hints)
+	}
+}
+
+func createGitWorktreeFixture(t *testing.T) (primary, linked string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for worktree diagnostics")
+	}
+	parent := filepath.Join(t.TempDir(), "worktree parent")
+	primary = filepath.Join(parent, "primary")
+	linked = filepath.Join(parent, "linked")
+	if err := os.MkdirAll(primary, 0o700); err != nil {
+		t.Fatalf("mkdir primary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(primary, ".amqrc"), []byte(`{"root":".agent-mail"}`), 0o600); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(primary, "README.md"), []byte("fixture\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGitForTest(t, primary, "init")
+	runGitForTest(t, primary, "add", ".amqrc", "README.md")
+	runGitForTest(t, primary, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "-m", "fixture")
+	runGitForTest(t, primary, "worktree", "add", "-b", "linked", linked)
+	return primary, linked
+}
+
+func runGitForTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func ensureOpsRoot(t *testing.T, root string, agents ...string) {
+	t.Helper()
+	for _, agent := range agents {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s, %s): %v", root, agent, err)
+		}
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  agents,
+	}, true); err != nil {
+		t.Fatalf("write config at %s: %v", root, err)
+	}
+}
+
+func findOpsHint(hints []opsHint, code string) (opsHint, bool) {
+	for _, hint := range hints {
+		if hint.Code == code {
+			return hint, true
+		}
+	}
+	return opsHint{}, false
+}

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -81,6 +81,19 @@ one terminal, one session.
 | Inside `coop exec` (no flags) | automatic | `.agent-mail/collab` (default session) |
 | Inside `coop exec --session X` | automatic | `.agent-mail/X` |
 
+### Git worktrees
+
+A relative project root such as `{"root":".agent-mail"}` and auto-detected
+roots are intentionally per-worktree. Two terminals in different git
+worktrees can therefore use the same session name while reading different
+mailboxes. If a delivery receipt times out, run `amq doctor --ops`; it can warn
+when a peer has fresher presence in the same session under another worktree.
+
+To share one mailbox across worktrees, use the same absolute root in each
+worktree's machine-local `.amqrc`, or remove the project-relative `.amqrc` and
+set `AMQ_GLOBAL_ROOT` to one absolute base. Keep the relative default when
+per-worktree isolation is intended.
+
 ## Task Routing
 
 Before diving in, match the task to the right workflow — this avoids wasted effort:


### PR DESCRIPTION
## Summary

- add best-effort doctor --ops diagnostics for per-worktree relative roots and same-session roots with fresher peer presence
- keep all git discovery in doctor, bounded to two seconds and fail-open, with canonical path and NUL-porcelain handling
- make send --wait-for timeout errors name the resolved delivery session/root and point to doctor --ops
- document per-worktree isolation and the absolute shared-root pattern

## Verification

- make ci
- go test -race ./...
- GOOS=windows go build ./...
- GOOS=freebsd go build ./...
- real temporary two-worktree regressions covering relative/auto sources, absolute-root suppression, fresher-peer matching, caller/older-presence suppression, path spaces, stale GIT_* overrides, and non-git fail-open
- Gitleaks clean
- independent Claude live two-worktree witness and pre-commit PASS

## Behavioral boundaries

- The cheap linked-worktree isolation hint is intentionally limited to auto-detected and relative project-config sources. Coop shells report an env source and rely on the deeper same-session/fresher-peer scan.
- On a bare base root with no usable config, doctor --ops retains the existing config_error early exit before the deep worktree scan.
- send performs no git discovery; it only reports the delivery context it already resolved.

Closes #207