### PR TITLE
feat(presence): distinguish notifier liveness from activity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,14 @@ pipes open after its JSON/text output exits. `doctor --ops` may report
 `target_present` and `repair_available`, but must remain diagnostic-only and
 never spawn a wake process.
 
+`who` and `doctor --ops` presence sources have narrow semantics:
+`notifier_live` requires a valid wake lock with process identity confirmed by
+the existing wake-lock inspector; it proves prompt notification only, never
+consumption. `recent_activity` means a fresh `last_seen` without that proof.
+Do not introduce `consumer_live` wording without a separate monitor heartbeat
+or lock. Long-running wake/monitor supervision belongs to launchd, systemd, or
+another layer above daemon-free AMQ.
+
 Git worktree diagnostics stay in `doctor --ops`, never in the send routing
 path. Relative project roots and auto-detected roots are per-worktree; sharing
 requires the same absolute `.amqrc` root or `AMQ_GLOBAL_ROOT`. The deep check is

--- a/COOP.md
+++ b/COOP.md
@@ -280,6 +280,56 @@ code and may itself inject terminal input, `none` rejects `--inject-via`,
 `--inject-arg`, and `--inject-cmd`. Stderr output shares the TUI terminal by
 default and may remain visible until the TUI redraws.
 
+### Supervisor recipes
+
+AMQ remains daemon-free. If `wake` or `monitor` must stay attached across
+terminal restarts, let the operating system supervise the CLI process. Keep
+notification and consumption separate: `wake` only scans and notifies;
+`monitor` is the path that drains messages and emits receipts.
+
+For systemd, use separate services with an absolute root. A notifier unit can
+use:
+
+```ini
+[Service]
+Environment=AM_ROOT=/absolute/path/to/shared/.agent-mail/collab
+ExecStart=/usr/local/bin/amq wake --me claude --inject-mode none --bell
+Restart=always
+RestartSec=2
+```
+
+A consumer unit uses the same environment but a different `ExecStart`; it
+restarts after each emitted batch:
+
+```ini
+[Service]
+Environment=AM_ROOT=/absolute/path/to/shared/.agent-mail/collab
+ExecStart=/usr/local/bin/amq monitor --me claude --timeout 0 --include-body --json
+Restart=always
+RestartSec=2
+```
+
+For launchd, put the equivalent absolute arguments in `ProgramArguments` and
+enable `KeepAlive`. Use one plist for `wake` and another for `monitor`:
+
+```xml
+<key>ProgramArguments</key>
+<array>
+  <string>/usr/local/bin/amq</string>
+  <string>wake</string>
+  <string>--root</string><string>/absolute/path/to/shared/.agent-mail/collab</string>
+  <string>--me</string><string>claude</string>
+  <string>--inject-mode</string><string>none</string>
+</array>
+<key>KeepAlive</key><true/>
+<key>ThrottleInterval</key><integer>2</integer>
+```
+
+For the consumer plist, replace the command arguments after the executable with
+`monitor --root <absolute-root> --me claude --timeout 0 --include-body --json`.
+Route stdout/stderr to supervisor-managed logs and secure the unit/plist for the
+local user who owns the mailbox.
+
 **Options:**
 - `--inject-mode auto|raw|paste|none` - Injection strategy; `none` enforces zero terminal input
 - `--wake-inject-mode auto|raw|paste|none` - `coop exec` pass-through for its managed wake

--- a/README.md
+++ b/README.md
@@ -217,6 +217,18 @@ or injecting into the wrong terminal. Repaired wake output goes to
 `agents/<agent>/.wake.repair.log`; `doctor --ops` can report whether repair is
 available, but it never starts a wake process.
 
+`amq who` and `amq doctor --ops` distinguish two activity sources:
+
+- `notifier_live` means AMQ verified the process identity behind a valid
+  `amq wake` lock. It proves prompt notification is attached; it does **not**
+  prove messages are consumed.
+- `recent_activity` means `last_seen` was refreshed in the last 10 minutes,
+  without a verified live notifier.
+
+Consumption remains the job of `drain` or `monitor` and is evidenced by
+receipts. For long-running `wake` and `monitor` examples under systemd or
+launchd, see [Supervisor recipes](COOP.md#supervisor-recipes).
+
 ## Message Kinds & Priority
 
 AMQ messages support kinds (`review_request`, `question`, `todo`, etc.) and priority levels (`urgent`, `normal`, `low`). See [COOP.md](COOP.md) for the full protocol.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -176,6 +176,9 @@ func runDoctor(args []string) error {
 				line += fmt.Sprintf(", %d DLQ", a.DLQCount)
 			}
 			line += fmt.Sprintf(", presence %s (%.0fs ago)", a.PresenceStatus, a.PresenceAgeSeconds)
+			if a.PresenceSource != "" {
+				line += ", source " + a.PresenceSource
+			}
 			if err := writeStdoutLine(line); err != nil {
 				return err
 			}

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -35,6 +35,7 @@ type opsAgent struct {
 	OldestDLQAgeSeconds    float64 `json:"oldest_dlq_age_seconds"`
 	PresenceStatus         string  `json:"presence_status"`
 	PresenceAgeSeconds     float64 `json:"presence_age_seconds"`
+	PresenceSource         string  `json:"presence_source,omitempty"`
 }
 
 type opsOperatorGate struct {
@@ -126,15 +127,18 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		}
 
 		// Presence
+		recentActivity := false
 		p, err := presence.Read(root, handle)
 		if err == nil {
 			agent.PresenceStatus = p.Status
 			if t, err := time.Parse(time.RFC3339Nano, p.LastSeen); err == nil {
 				agent.PresenceAgeSeconds = now.Sub(t).Seconds()
+				recentActivity = agent.PresenceAgeSeconds < (10 * time.Minute).Seconds()
 			}
 		} else {
 			agent.PresenceStatus = "unknown"
 		}
+		agent.PresenceSource = resolvePresenceSource(root, handle, recentActivity)
 
 		// Round to reasonable precision
 		agent.OldestUnreadAgeSeconds = math.Round(agent.OldestUnreadAgeSeconds)

--- a/internal/cli/presence_source.go
+++ b/internal/cli/presence_source.go
@@ -1,0 +1,17 @@
+package cli
+
+const (
+	presenceSourceNotifierLive   = "notifier_live"
+	presenceSourceRecentActivity = "recent_activity"
+)
+
+func resolvePresenceSource(root, agent string, recentActivity bool) string {
+	inspection := inspectWakeLock(root, agent)
+	if inspection.Status == wakeLockValid && inspection.IdentityConfirmed {
+		return presenceSourceNotifierLive
+	}
+	if recentActivity {
+		return presenceSourceRecentActivity
+	}
+	return ""
+}

--- a/internal/cli/presence_source_test.go
+++ b/internal/cli/presence_source_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/presence"
+)
+
+func TestRunWhoDistinguishesNotifierLiveFromRecentActivity(t *testing.T) {
+	root := setupPresenceSourceFixture(t)
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWho([]string{"--root", root, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runWho json: %v", err)
+	}
+	var sessions []struct {
+		Agents []struct {
+			Handle         string `json:"handle"`
+			Active         bool   `json:"active"`
+			PresenceSource string `json:"presence_source"`
+		} `json:"agents"`
+	}
+	if err := json.Unmarshal([]byte(output), &sessions); err != nil {
+		t.Fatalf("unmarshal who json: %v\n%s", err, output)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions=%#v, want one", sessions)
+	}
+	agents := make(map[string]struct {
+		Active bool
+		Source string
+	})
+	for _, agent := range sessions[0].Agents {
+		agents[agent.Handle] = struct {
+			Active bool
+			Source string
+		}{Active: agent.Active, Source: agent.PresenceSource}
+	}
+	if got := agents["notifier"]; !got.Active || got.Source != "notifier_live" {
+		t.Fatalf("notifier=%#v, want active notifier_live", got)
+	}
+	if got := agents["recent"]; !got.Active || got.Source != "recent_activity" {
+		t.Fatalf("recent=%#v, want active recent_activity", got)
+	}
+	if got := agents["unverified"]; !got.Active || got.Source != "recent_activity" {
+		t.Fatalf("unverified=%#v, want recent_activity without notifier claim", got)
+	}
+	if got := agents["stale"]; got.Active || got.Source != "" {
+		t.Fatalf("stale=%#v, want inactive without source", got)
+	}
+
+	text, err := captureEnvStdout(t, func() error {
+		return runWho([]string{"--root", root})
+	})
+	if err != nil {
+		t.Fatalf("runWho text: %v", err)
+	}
+	for _, want := range []string{
+		"notifier  active (notifier_live)",
+		"recent  active (recent_activity)",
+		"unverified  active (recent_activity)",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("who text missing %q:\n%s", want, text)
+		}
+	}
+	for _, forbidden := range []string{"consumer_live", "consumption"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("who text must not claim %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestDoctorOpsDistinguishesNotifierLiveFromRecentActivity(t *testing.T) {
+	root := setupPresenceSourceFixture(t)
+	result := runOpsChecks(root, "test", false)
+
+	agents := make(map[string]opsAgent)
+	for _, agent := range result.Agents {
+		agents[agent.Handle] = agent
+	}
+	if got := agents["notifier"].PresenceSource; got != "notifier_live" {
+		t.Fatalf("notifier presence_source=%q, want notifier_live", got)
+	}
+	if got := agents["recent"].PresenceSource; got != "recent_activity" {
+		t.Fatalf("recent presence_source=%q, want recent_activity", got)
+	}
+	if got := agents["unverified"].PresenceSource; got != "recent_activity" {
+		t.Fatalf("unverified presence_source=%q, want recent_activity", got)
+	}
+	if got := agents["stale"].PresenceSource; got != "" {
+		t.Fatalf("stale presence_source=%q, want empty", got)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal ops result: %v", err)
+	}
+	if !strings.Contains(string(data), `"presence_source":"notifier_live"`) ||
+		!strings.Contains(string(data), `"presence_source":"recent_activity"`) {
+		t.Fatalf("doctor JSON missing presence sources: %s", data)
+	}
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_SESSION", "")
+	text, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--ops"})
+	})
+	if err != nil {
+		t.Fatalf("runDoctor text: %v", err)
+	}
+	for agent, source := range map[string]string{
+		"notifier": "notifier_live",
+		"recent":   "recent_activity",
+	} {
+		line := lineWithPrefix(text, "  "+agent+":")
+		if !strings.Contains(line, ", source "+source) {
+			t.Fatalf("doctor line for %s missing source %q: %q\n%s", agent, source, line, text)
+		}
+	}
+}
+
+func lineWithPrefix(text, prefix string) string {
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return line
+		}
+	}
+	return ""
+}
+
+func setupPresenceSourceFixture(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(secureTempDirForTest(t), "collab")
+	agents := []string{"notifier", "recent", "stale", "unverified"}
+	for _, agent := range agents {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  agents,
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	now := time.Now()
+	for _, item := range []struct {
+		agent  string
+		seenAt time.Time
+	}{
+		{agent: "notifier", seenAt: now.Add(-time.Hour)},
+		{agent: "recent", seenAt: now},
+		{agent: "stale", seenAt: now.Add(-time.Hour)},
+		{agent: "unverified", seenAt: now},
+	} {
+		if err := presence.Write(root, presence.New(item.agent, "active", "", item.seenAt)); err != nil {
+			t.Fatalf("write %s presence: %v", item.agent, err)
+		}
+	}
+
+	const pid = 4242
+	const processStart = "verified-start"
+	const bootID = "verified-boot"
+	args := []string{"amq", "wake", "--root", root, "--me", "notifier"}
+	writeWakeLockForTest(t, root, "notifier", wakeLock{
+		PID:          pid,
+		ProcessStart: processStart,
+		BootID:       bootID,
+		Executable:   "amq",
+		Args:         args,
+	})
+	const unverifiedPID = 4343
+	writeWakeLockForTest(t, root, "unverified", wakeLock{
+		PID:        unverifiedPID,
+		Executable: "amq",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID == unverifiedPID {
+			return wakeProcessInfo{
+				PID:        gotPID,
+				Running:    true,
+				Executable: "/usr/local/bin/amq",
+			}
+		}
+		if gotPID != pid {
+			return wakeProcessInfo{PID: gotPID}
+		}
+		return wakeProcessInfo{
+			PID:        gotPID,
+			Running:    true,
+			StartToken: processStart,
+			BootID:     bootID,
+			Executable: "/usr/local/bin/amq",
+			Args:       args,
+		}
+	})
+	return root
+}

--- a/internal/cli/who.go
+++ b/internal/cli/who.go
@@ -16,7 +16,7 @@ func runWho(args []string) error {
 
 	usage := usageWithFlags(fs, "amq who [options]",
 		"List sessions and agents in the current project.",
-		"Shows active/stale status based on presence data.")
+		"Shows active/stale status and whether activity comes from a verified notifier or recent commands.")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
@@ -48,6 +48,7 @@ func runWho(args []string) error {
 		Kind               string `json:"kind"`
 		PresenceApplicable bool   `json:"presence_applicable"`
 		Active             bool   `json:"active"`
+		PresenceSource     string `json:"presence_source,omitempty"`
 		Note               string `json:"note,omitempty"`
 	}
 	type sessionInfo struct {
@@ -94,13 +95,17 @@ func runWho(args []string) error {
 				continue
 			}
 
-			// Check presence for activity status.
+			// Recent presence proves activity only; a verified wake lock separately
+			// proves that a prompt notifier is currently attached.
+			recentActivity := false
 			if p, err := presence.Read(sessDir, ae.Name()); err == nil {
 				if t, err := time.Parse(time.RFC3339Nano, p.LastSeen); err == nil {
-					ai.Active = time.Since(t) < 10*time.Minute
+					recentActivity = time.Since(t) < 10*time.Minute
 				}
 				ai.Note = p.Note
 			}
+			ai.PresenceSource = resolvePresenceSource(sessDir, ae.Name(), recentActivity)
+			ai.Active = recentActivity || ai.PresenceSource == presenceSourceNotifierLive
 			agents = append(agents, ai)
 		}
 
@@ -145,6 +150,9 @@ func runWho(args []string) error {
 				status = "human"
 			} else if a.Active {
 				status = "active"
+				if a.PresenceSource != "" {
+					status += " (" + a.PresenceSource + ")"
+				}
 			}
 			note := ""
 			if a.Note != "" {

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -188,6 +188,13 @@ amq receipts wait --me codex --msg-id <msg_id> --stage drained --timeout 60s
 
 `amq read`, `amq drain`, and `amq monitor` all apply the same strict header validation. Messages in `inbox/new` that are corrupt or have malformed headers are moved to DLQ and produce a `dlq` receipt.
 
+`amq who` and `amq doctor --ops` report `notifier_live` only when the wake-lock
+inspector verifies a live `amq wake` process identity. That proves prompt
+notification, not message consumption. `recent_activity` means only that
+`last_seen` is fresh. Use `drain` or `monitor` when consumption is required;
+run long-lived wake/monitor commands under launchd, systemd, or another
+supervisor rather than treating AMQ itself as a daemon.
+
 Those consuming commands, `watch`, and mutating DLQ commands refuse a raw
 target that conflicts with a complete `AM_BASE_ROOT`/`AM_SESSION` pin before
 touching mailbox state. `send` and `reply` apply the same check to their source


### PR DESCRIPTION
## Summary
- classify a verified wake process as `notifier_live` and fresh `last_seen` as `recent_activity`
- expose the source in `who` and `doctor --ops` without implying message consumption
- document daemon-free systemd and launchd supervision for separate wake and monitor processes

## Verification
- `make ci`
- `go test -race ./...`
- `GOOS=windows go build ./...`
- `GOOS=freebsd go build ./...`
- `gitleaks dir --no-banner --redact --exit-code 1 .`

Closes #206