### PR TITLE
fix(cli): keep configured AMQ bases authoritative in root classification

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -64,11 +64,15 @@ func sessionName(root string) string { return filepath.Base(root) }
 //
 // Resolution order:
 //  1. AM_BASE_ROOT, when root is a direct session below it
-//  2. Root-aware .amqrc, when root is a direct session below its configured base
-//  3. If root is a session root (parent contains sibling session dirs), return parent
-//  4. If the parent directory is the default root name (.agent-mail), return parent
-//  5. Otherwise, return "" (base or unknown — caller must handle)
+//  2. If root's parent is the default root (.agent-mail), return that parent
+//  3. The nearest root-aware .amqrc, when root is the configured base or a direct session below it
+//  4. If root itself is the default root name (.agent-mail), return "" (known base)
+//  5. If root is a session root (parent contains sibling session dirs), return parent
+//  6. Otherwise, return "" (base or unknown — caller must handle)
 func classifyRoot(root string) string {
+	if strings.TrimSpace(root) == "" {
+		return ""
+	}
 	resolvedRoot := absPath(resolveRoot(root))
 	if base := strings.TrimSpace(os.Getenv(envBaseRoot)); base != "" {
 		base = absPath(resolveRoot(base))
@@ -79,7 +83,13 @@ func classifyRoot(root string) string {
 			return base
 		}
 	}
-	if base := configuredBaseRoot(root); base != "" {
+	parent := filepath.Dir(resolvedRoot)
+	// The default layout convention is structural and deliberately outranks
+	// root-local .amqrc, which must not rebase a session into its own base.
+	if filepath.Base(parent) == defaultCoopRoot {
+		return parent
+	}
+	if base := configuredBaseRoot(resolvedRoot); base != "" {
 		if resolvedRoot == base {
 			return ""
 		}
@@ -89,7 +99,6 @@ func classifyRoot(root string) string {
 		return ""
 	}
 	// Check if root looks like a session: parent has sibling dirs with agents/.
-	parent := filepath.Dir(resolvedRoot)
 	entries, err := os.ReadDir(parent)
 	if err != nil {
 		return ""
@@ -101,9 +110,6 @@ func classifyRoot(root string) string {
 		if dirExists(filepath.Join(parent, e.Name(), "agents")) {
 			return parent // Found a sibling session — root is a session, parent is base.
 		}
-	}
-	if filepath.Base(parent) == defaultCoopRoot {
-		return parent
 	}
 	return ""
 }
@@ -186,6 +192,10 @@ func resolveRoot(raw string) string {
 }
 
 func configuredBaseRoot(root string) string {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return ""
+	}
 	result, err := findAmqrcForRoot(root)
 	if err != nil {
 		if !errors.Is(err, errAmqrcNotFound) {
@@ -210,11 +220,13 @@ func configuredBaseRoot(root string) string {
 // isBaseOrSessionRoot returns true when root is either the base itself or a
 // direct child session below it.
 func isBaseOrSessionRoot(root, base string) bool {
-	root = absPath(resolveRoot(root))
-	base = absPath(resolveRoot(base))
+	root = strings.TrimSpace(root)
+	base = strings.TrimSpace(base)
 	if root == "" || base == "" {
 		return false
 	}
+	root = absPath(resolveRoot(root))
+	base = absPath(resolveRoot(base))
 	return root == base || filepath.Dir(root) == base
 }
 
@@ -222,9 +234,14 @@ func isBaseOrSessionRoot(root, base string) bool {
 // (i.e., root is a session directory like .agent-mail/collab under .agent-mail).
 // Returns false when root == base (the base root itself is not a session).
 func isSessionRootUnderBase(root, base string) bool {
+	root = strings.TrimSpace(root)
+	base = strings.TrimSpace(base)
+	if root == "" || base == "" {
+		return false
+	}
 	root = absPath(resolveRoot(root))
 	base = absPath(resolveRoot(base))
-	if root == "" || base == "" || root == base {
+	if root == base {
 		return false
 	}
 	return filepath.Dir(root) == base
@@ -233,23 +250,10 @@ func isSessionRootUnderBase(root, base string) bool {
 // baseRootOf returns the base root for a queue root: the derived/configured base
 // when root is a session directory, or root itself otherwise.
 func baseRootOf(root string) string {
-	resolvedRoot := resolveRoot(root)
-	if base := strings.TrimSpace(os.Getenv(envBaseRoot)); base != "" {
-		base = resolveRoot(base)
-		if isBaseOrSessionRoot(resolvedRoot, base) {
-			return base
-		}
-	}
-	if base := configuredBaseRoot(resolvedRoot); base != "" {
-		return base
-	}
-	if filepath.Base(resolvedRoot) == defaultCoopRoot {
-		return resolvedRoot
-	}
 	if base := classifyRoot(root); base != "" {
 		return resolveRoot(base)
 	}
-	return resolvedRoot
+	return resolveRoot(root)
 }
 
 // sameBaseTree reports whether two roots belong to the same base tree — the same

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -63,26 +63,39 @@ func sessionName(root string) string { return filepath.Base(root) }
 // be determined. This is the single authoritative function for root classification.
 //
 // Resolution order:
-//  1. AM_BASE_ROOT, but only when the supplied root is still under that base
-//  2. If root is a session root (parent contains sibling session dirs), return parent
-//  3. If the parent directory is the default root name (.agent-mail), return parent
-//  4. Root-aware .amqrc lookup (works for explicit --root outside the cwd project)
-//  5. Otherwise, return "" (unknown — caller must handle)
+//  1. AM_BASE_ROOT, when root is a direct session below it
+//  2. Root-aware .amqrc, when root is a direct session below its configured base
+//  3. If root is a session root (parent contains sibling session dirs), return parent
+//  4. If the parent directory is the default root name (.agent-mail), return parent
+//  5. Otherwise, return "" (base or unknown — caller must handle)
 func classifyRoot(root string) string {
+	resolvedRoot := absPath(resolveRoot(root))
 	if base := strings.TrimSpace(os.Getenv(envBaseRoot)); base != "" {
-		base = resolveRoot(base)
-		if isSessionRootUnderBase(root, base) {
+		base = absPath(resolveRoot(base))
+		if resolvedRoot == base {
+			return ""
+		}
+		if isSessionRootUnderBase(resolvedRoot, base) {
 			return base
 		}
 	}
+	if base := configuredBaseRoot(root); base != "" {
+		if resolvedRoot == base {
+			return ""
+		}
+		return base
+	}
+	if filepath.Base(resolvedRoot) == defaultCoopRoot {
+		return ""
+	}
 	// Check if root looks like a session: parent has sibling dirs with agents/.
-	parent := filepath.Dir(root)
+	parent := filepath.Dir(resolvedRoot)
 	entries, err := os.ReadDir(parent)
 	if err != nil {
-		return configuredBaseRoot(root)
+		return ""
 	}
 	for _, e := range entries {
-		if !e.IsDir() || e.Name() == filepath.Base(root) {
+		if !e.IsDir() || e.Name() == filepath.Base(resolvedRoot) {
 			continue
 		}
 		if dirExists(filepath.Join(parent, e.Name(), "agents")) {
@@ -92,7 +105,7 @@ func classifyRoot(root string) string {
 	if filepath.Base(parent) == defaultCoopRoot {
 		return parent
 	}
-	return configuredBaseRoot(root)
+	return ""
 }
 
 // resolveSessionName returns the session name for the given root, or "" if
@@ -103,7 +116,7 @@ func resolveSessionName(root string) string {
 		return ""
 	}
 	// Ensure root actually differs from base (not just base root itself)
-	if root == base {
+	if absPath(resolveRoot(root)) == absPath(resolveRoot(base)) {
 		return ""
 	}
 	return sessionName(root)
@@ -188,10 +201,21 @@ func configuredBaseRoot(root string) string {
 		base = filepath.Join(result.Dir, base)
 	}
 	base = absPath(base)
-	if isSessionRootUnderBase(root, base) {
+	if isBaseOrSessionRoot(root, base) {
 		return base
 	}
 	return ""
+}
+
+// isBaseOrSessionRoot returns true when root is either the base itself or a
+// direct child session below it.
+func isBaseOrSessionRoot(root, base string) bool {
+	root = absPath(resolveRoot(root))
+	base = absPath(resolveRoot(base))
+	if root == "" || base == "" {
+		return false
+	}
+	return root == base || filepath.Dir(root) == base
 }
 
 // isSessionRootUnderBase returns true when root is a direct child of base
@@ -209,10 +233,23 @@ func isSessionRootUnderBase(root, base string) bool {
 // baseRootOf returns the base root for a queue root: the derived/configured base
 // when root is a session directory, or root itself otherwise.
 func baseRootOf(root string) string {
+	resolvedRoot := resolveRoot(root)
+	if base := strings.TrimSpace(os.Getenv(envBaseRoot)); base != "" {
+		base = resolveRoot(base)
+		if isBaseOrSessionRoot(resolvedRoot, base) {
+			return base
+		}
+	}
+	if base := configuredBaseRoot(resolvedRoot); base != "" {
+		return base
+	}
+	if filepath.Base(resolvedRoot) == defaultCoopRoot {
+		return resolvedRoot
+	}
 	if base := classifyRoot(root); base != "" {
 		return resolveRoot(base)
 	}
-	return resolveRoot(root)
+	return resolvedRoot
 }
 
 // sameBaseTree reports whether two roots belong to the same base tree — the same

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -59,6 +59,18 @@ func (f *commonFlags) warnRootOverride() {
 // sessionName extracts the session name (last path component) from a resolved root path.
 func sessionName(root string) string { return filepath.Base(root) }
 
+// isDefaultCoopRoot recognizes the default root by filesystem identity when a
+// case-insensitive volume presents an alternate spelling.
+func isDefaultCoopRoot(path string) bool {
+	if filepath.Base(path) == defaultCoopRoot {
+		return true
+	}
+	exact := filepath.Join(filepath.Dir(path), defaultCoopRoot)
+	got, gotErr := os.Lstat(path)
+	want, wantErr := os.Lstat(exact)
+	return gotErr == nil && wantErr == nil && os.SameFile(got, want)
+}
+
 // classifyRoot returns the base root for the given root, or "" if it cannot
 // be determined. This is the single authoritative function for root classification.
 //
@@ -84,9 +96,9 @@ func classifyRoot(root string) string {
 		}
 	}
 	parent := filepath.Dir(resolvedRoot)
-	// The default layout convention is structural and deliberately outranks
-	// root-local .amqrc, which must not rebase a session into its own base.
-	if filepath.Base(parent) == defaultCoopRoot {
+	// A direct child of .agent-mail is always a session; this structural rule
+	// deliberately outranks root-local .amqrc and must not be rebased.
+	if isDefaultCoopRoot(parent) {
 		return parent
 	}
 	if base := configuredBaseRoot(resolvedRoot); base != "" {
@@ -95,7 +107,7 @@ func classifyRoot(root string) string {
 		}
 		return base
 	}
-	if filepath.Base(resolvedRoot) == defaultCoopRoot {
+	if isDefaultCoopRoot(resolvedRoot) {
 		return ""
 	}
 	// Check if root looks like a session: parent has sibling dirs with agents/.

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -411,6 +411,29 @@ func TestClassifyRootDefaultLayoutConvention(t *testing.T) {
 	}
 }
 
+func TestBaseRootOfExactEnvBaseWinsOverUnrelatedSibling(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, defaultCoopRoot)
+	sessionRoot := filepath.Join(baseRoot, "collab")
+	if err := os.MkdirAll(sessionRoot, 0o700); err != nil {
+		t.Fatalf("mkdir session root: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(parent, ".claude", "agents"), 0o700); err != nil {
+		t.Fatalf("mkdir unrelated agents dir: %v", err)
+	}
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+
+	if got := classifyRoot(baseRoot); got != "" {
+		t.Fatalf("classifyRoot(%q) = %q, want empty for a base root", baseRoot, got)
+	}
+	if got := baseRootOf(baseRoot); got != baseRoot {
+		t.Fatalf("baseRootOf(%q) = %q, want exact env base %q", baseRoot, got, baseRoot)
+	}
+	if !sameBaseTree(baseRoot, sessionRoot) {
+		t.Fatalf("sameBaseTree(%q, %q) = false, want true", baseRoot, sessionRoot)
+	}
+}
+
 func TestClassifyRootCustomRootDoesNotMatchDefaultLayoutConvention(t *testing.T) {
 	t.Setenv("AM_BASE_ROOT", "")
 

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -849,6 +849,9 @@ func TestRunEnvInvalidGlobalAmqrcBeatsAutoDetect(t *testing.T) {
 
 func TestRunEnvJSONV1SessionFlag(t *testing.T) {
 	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".claude", "agents"), 0o700); err != nil {
+		t.Fatalf("mkdir unrelated agents dir: %v", err)
+	}
 
 	rcContent := `{"root": ".agent-mail"}`
 	if err := os.WriteFile(filepath.Join(root, ".amqrc"), []byte(rcContent), 0o644); err != nil {

--- a/internal/cli/root_classification_security_test.go
+++ b/internal/cli/root_classification_security_test.go
@@ -1,0 +1,225 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestBypassNestedDefaultName(t *testing.T) {
+	p := t.TempDir()
+	foreign := t.TempDir()
+
+	baseRoot := filepath.Join(p, ".agent-mail")
+	sessionRoot := filepath.Join(baseRoot, ".agent-mail")
+	if err := os.MkdirAll(filepath.Join(sessionRoot, "agents", "alice"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(foreign, "agents", "bob"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	targetRoot := filepath.Join(sessionRoot, "escape")
+	if err := os.Symlink(foreign, targetRoot); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_SESSION", "")
+	t.Setenv("AM_ROOT", sessionRoot)
+
+	if got := classifyRoot(sessionRoot); got != baseRoot {
+		t.Errorf("classifyRoot(%q) = %q, want parent base %q", sessionRoot, got, baseRoot)
+	}
+	if src, refused := conflictingSourceRoot(targetRoot); !refused {
+		t.Fatalf("cross-tree send guard did not refuse AM_ROOT=%q targeting %q (symlink to %q); source=%q", sessionRoot, targetRoot, foreign, src)
+	}
+}
+
+func TestBypassRootLocalAmqrcDoesNotRebaseDefaultSession(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		configRoot func(string) string
+	}{
+		{name: "relative dot", configRoot: func(string) string { return "." }},
+		{name: "absolute self path", configRoot: func(root string) string { return root }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := t.TempDir()
+			foreign := t.TempDir()
+
+			baseRoot := filepath.Join(p, ".agent-mail")
+			sessionRoot := filepath.Join(baseRoot, "collab")
+			if err := os.MkdirAll(filepath.Join(sessionRoot, "agents", "alice"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Join(foreign, "agents", "bob"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			config, err := json.Marshal(amqrc{Root: tc.configRoot(sessionRoot)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(sessionRoot, ".amqrc"), config, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			targetRoot := filepath.Join(sessionRoot, "escape")
+			if err := os.Symlink(foreign, targetRoot); err != nil {
+				t.Skipf("symlink unsupported: %v", err)
+			}
+
+			t.Setenv("AM_BASE_ROOT", "")
+			t.Setenv("AM_SESSION", "")
+			t.Setenv("AM_ROOT", sessionRoot)
+
+			if got := classifyRoot(sessionRoot); got != baseRoot {
+				t.Errorf("classifyRoot(%q) = %q, want parent base %q", sessionRoot, got, baseRoot)
+			}
+			if src, refused := conflictingSourceRoot(targetRoot); !refused {
+				t.Fatalf("cross-tree send guard did not refuse AM_ROOT=%q targeting %q (symlink to %q); source=%q", sessionRoot, targetRoot, foreign, src)
+			}
+		})
+	}
+}
+
+func TestRootLocalAmqrcCanDeclareLegitimateCustomBase(t *testing.T) {
+	t.Setenv("AM_BASE_ROOT", "")
+
+	p := t.TempDir()
+	baseRoot := filepath.Join(p, "queue")
+	sessionRoot := filepath.Join(baseRoot, "collab")
+	if err := os.MkdirAll(filepath.Join(sessionRoot, "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseRoot, ".amqrc"), []byte(`{"root":"."}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := configuredBaseRoot(baseRoot); got != baseRoot {
+		t.Errorf("configuredBaseRoot(%q) = %q, want self-declared base %q", baseRoot, got, baseRoot)
+	}
+	if got := classifyRoot(baseRoot); got != "" {
+		t.Errorf("classifyRoot(%q) = %q, want empty for configured base", baseRoot, got)
+	}
+	if got := classifyRoot(sessionRoot); got != baseRoot {
+		t.Errorf("classifyRoot(%q) = %q, want configured base %q", sessionRoot, got, baseRoot)
+	}
+	if !sameBaseTree(baseRoot, sessionRoot) {
+		t.Errorf("sameBaseTree(%q, %q) = false, want true", baseRoot, sessionRoot)
+	}
+}
+
+func TestClassifyRootConfiguredCustomBaseSurvivesPoisonSibling(t *testing.T) {
+	t.Setenv("AM_BASE_ROOT", "")
+
+	p := t.TempDir()
+	baseRoot := filepath.Join(p, "queue")
+	sessionRoot := filepath.Join(baseRoot, "collab")
+	if err := os.WriteFile(filepath.Join(p, ".amqrc"), []byte(`{"root":"queue"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(sessionRoot, "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(p, ".claude", "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := classifyRoot(baseRoot); got != "" {
+		t.Errorf("classifyRoot(%q) = %q, want empty for configured base", baseRoot, got)
+	}
+	if got := classifyRoot(sessionRoot); got != baseRoot {
+		t.Errorf("classifyRoot(%q) = %q, want configured base %q", sessionRoot, got, baseRoot)
+	}
+	if got := baseRootOf(baseRoot); got != baseRoot {
+		t.Errorf("baseRootOf(%q) = %q, want %q", baseRoot, got, baseRoot)
+	}
+	if !sameBaseTree(baseRoot, sessionRoot) {
+		t.Errorf("sameBaseTree(%q, %q) = false, want true", baseRoot, sessionRoot)
+	}
+}
+
+func TestIsBaseOrSessionRootRejectsEmptyInput(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		root string
+		base string
+	}{
+		{name: "empty root", root: "", base: cwd},
+		{name: "blank root", root: "   ", base: cwd},
+		{name: "empty base", root: cwd, base: ""},
+		{name: "blank base", root: cwd, base: "   "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if isBaseOrSessionRoot(tc.root, tc.base) {
+				t.Fatalf("isBaseOrSessionRoot(%q, %q) = true, want false", tc.root, tc.base)
+			}
+		})
+	}
+}
+
+func TestSendRefusesCrossTreeEscapeFromMisclassifiedRoot(t *testing.T) {
+	t.Run("nested default-name session", func(t *testing.T) {
+		p := t.TempDir()
+		sourceRoot := filepath.Join(p, ".agent-mail", ".agent-mail")
+		foreignRoot := filepath.Join(p, "foreign")
+		ensureBypassMailboxes(t, sourceRoot, foreignRoot)
+		targetRoot := filepath.Join(sourceRoot, "escape")
+		if err := os.Symlink(foreignRoot, targetRoot); err != nil {
+			t.Skipf("symlink unsupported: %v", err)
+		}
+
+		assertCrossTreeEscapeRefused(t, sourceRoot, targetRoot, foreignRoot)
+	})
+
+	t.Run("root-local amqrc", func(t *testing.T) {
+		p := t.TempDir()
+		sourceRoot := filepath.Join(p, ".agent-mail", "collab")
+		foreignRoot := filepath.Join(p, "foreign")
+		ensureBypassMailboxes(t, sourceRoot, foreignRoot)
+		if err := os.WriteFile(filepath.Join(sourceRoot, ".amqrc"), []byte(`{"root":"."}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		targetRoot := filepath.Join(sourceRoot, "escape")
+		if err := os.Symlink(foreignRoot, targetRoot); err != nil {
+			t.Skipf("symlink unsupported: %v", err)
+		}
+
+		assertCrossTreeEscapeRefused(t, sourceRoot, targetRoot, foreignRoot)
+	})
+}
+
+func ensureBypassMailboxes(t *testing.T, sourceRoot, foreignRoot string) {
+	t.Helper()
+	if err := fsq.EnsureAgentDirs(sourceRoot, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(foreignRoot, "bob"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertCrossTreeEscapeRefused(t *testing.T, sourceRoot, targetRoot, foreignRoot string) {
+	t.Helper()
+	t.Setenv("AM_ROOT", sourceRoot)
+	t.Setenv("AM_BASE_ROOT", "")
+	setOptionalEnv(t, "AM_SESSION", "", false)
+
+	err := runSend([]string{"--root", targetRoot, "--me", "alice", "--to", "bob", "--body", "must not escape"})
+	if err == nil || !strings.Contains(err.Error(), "refusing send") {
+		t.Fatalf("expected cross-tree refusal, got %v", err)
+	}
+	if code := GetExitCode(err); code != ExitUsage {
+		t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+	}
+	if got := inboxCount(t, foreignRoot, "bob"); got != 0 {
+		t.Fatalf("foreign inbox received %d messages, want 0", got)
+	}
+}

--- a/internal/cli/root_classification_security_test.go
+++ b/internal/cli/root_classification_security_test.go
@@ -85,6 +85,59 @@ func TestBypassRootLocalAmqrcDoesNotRebaseDefaultSession(t *testing.T) {
 	}
 }
 
+func TestCaseInsensitiveDefaultRootSpellingStillRefusesBothEscapes(t *testing.T) {
+	p := t.TempDir()
+	if !caseInsensitiveFS(t, p) {
+		t.Skip("case-sensitive filesystem")
+	}
+	for _, tc := range []struct {
+		name        string
+		sessionName string
+		writeRoot   bool
+	}{
+		{name: "nested default-name session", sessionName: ".agent-mail"},
+		{name: "root-local amqrc", sessionName: "collab", writeRoot: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			foreign := t.TempDir()
+			base := filepath.Join(p, ".agent-mail")
+			session := filepath.Join(base, tc.sessionName)
+			if err := fsq.EnsureAgentDirs(session, "alice"); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(foreign, "bob"); err != nil {
+				t.Fatal(err)
+			}
+			if tc.writeRoot {
+				if err := os.WriteFile(filepath.Join(session, ".amqrc"), []byte(`{"root":"."}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			upperBase := filepath.Join(p, ".AGENT-MAIL")
+			source := filepath.Join(upperBase, tc.sessionName)
+			target := filepath.Join(source, "escape")
+			if err := os.Symlink(foreign, target); err != nil {
+				t.Skipf("symlink unsupported: %v", err)
+			}
+			assertCrossTreeEscapeRefused(t, source, target, foreign)
+		})
+	}
+}
+
+func caseInsensitiveFS(t *testing.T, dir string) bool {
+	t.Helper()
+	lower := filepath.Join(dir, ".probe-case")
+	if err := os.MkdirAll(lower, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.Stat(lower)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.Stat(filepath.Join(dir, ".PROBE-CASE"))
+	return err == nil && os.SameFile(want, got)
+}
+
 func TestRootLocalAmqrcCanDeclareLegitimateCustomBase(t *testing.T) {
 	t.Setenv("AM_BASE_ROOT", "")
 
@@ -162,6 +215,40 @@ func TestIsBaseOrSessionRootRejectsEmptyInput(t *testing.T) {
 				t.Fatalf("isBaseOrSessionRoot(%q, %q) = true, want false", tc.root, tc.base)
 			}
 		})
+	}
+}
+
+func TestSameBaseTreeAllowsNonexistentSameTreeTarget(t *testing.T) {
+	p := t.TempDir()
+	base := filepath.Join(p, ".agent-mail")
+	source := filepath.Join(base, "collab")
+	target := filepath.Join(base, "newsession")
+	if err := os.MkdirAll(filepath.Join(source, "agents", "alice"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if !sameBaseTree(source, target) {
+		t.Fatal("same-tree target that delivery will create was treated as cross-tree")
+	}
+}
+
+func TestSameBaseTreeAllowsSymlinkedCustomBase(t *testing.T) {
+	realData := t.TempDir()
+	repoParent := t.TempDir()
+	repoQueue := filepath.Join(repoParent, "queue")
+	if err := os.Symlink(realData, repoQueue); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	source := filepath.Join(repoQueue, "collab")
+	target := filepath.Join(repoQueue, "auth")
+	for _, root := range []string{source, target} {
+		if err := os.MkdirAll(filepath.Join(root, "agents", "alice"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("AM_BASE_ROOT", repoQueue)
+	t.Setenv("AM_SESSION", "")
+	if !sameBaseTree(source, target) {
+		t.Fatal("custom base reached through a symlinked ancestor was treated as cross-tree")
 	}
 }
 

--- a/internal/cli/root_classification_security_test.go
+++ b/internal/cli/root_classification_security_test.go
@@ -86,10 +86,6 @@ func TestBypassRootLocalAmqrcDoesNotRebaseDefaultSession(t *testing.T) {
 }
 
 func TestCaseInsensitiveDefaultRootSpellingStillRefusesBothEscapes(t *testing.T) {
-	p := t.TempDir()
-	if !caseInsensitiveFS(t, p) {
-		t.Skip("case-sensitive filesystem")
-	}
 	for _, tc := range []struct {
 		name        string
 		sessionName string
@@ -99,6 +95,10 @@ func TestCaseInsensitiveDefaultRootSpellingStillRefusesBothEscapes(t *testing.T)
 		{name: "root-local amqrc", sessionName: "collab", writeRoot: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			p := t.TempDir()
+			if !caseInsensitiveFS(t, p) {
+				t.Skip("case-sensitive filesystem")
+			}
 			foreign := t.TempDir()
 			base := filepath.Join(p, ".agent-mail")
 			session := filepath.Join(base, tc.sessionName)
@@ -113,6 +113,14 @@ func TestCaseInsensitiveDefaultRootSpellingStillRefusesBothEscapes(t *testing.T)
 					t.Fatal(err)
 				}
 			}
+			if tc.sessionName == ".agent-mail" {
+				if err := os.MkdirAll(filepath.Join(p, "poison", "agents"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if got := classifyRoot(filepath.Join(p, ".AGENT-MAIL")); got != "" {
+					t.Fatalf("case-insensitive default base with poison sibling classified as %q, want base", got)
+				}
+			}
 			upperBase := filepath.Join(p, ".AGENT-MAIL")
 			source := filepath.Join(upperBase, tc.sessionName)
 			target := filepath.Join(source, "escape")
@@ -121,6 +129,32 @@ func TestCaseInsensitiveDefaultRootSpellingStillRefusesBothEscapes(t *testing.T)
 			}
 			assertCrossTreeEscapeRefused(t, source, target, foreign)
 		})
+	}
+}
+
+func TestIsDefaultCoopRootDoesNotFoldCaseOnCaseSensitiveFS(t *testing.T) {
+	p := t.TempDir()
+	lower := filepath.Join(p, defaultCoopRoot)
+	upper := filepath.Join(p, ".AGENT-MAIL")
+	if err := os.MkdirAll(lower, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(upper, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lowerInfo, err := os.Lstat(lower)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upperInfo, err := os.Lstat(upper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(lowerInfo, upperInfo) {
+		t.Skip("case-insensitive filesystem")
+	}
+	if isDefaultCoopRoot(upper) {
+		t.Fatal("isDefaultCoopRoot folded distinct case-sensitive directory names")
 	}
 }
 

--- a/internal/cli/send_cross_root_test.go
+++ b/internal/cli/send_cross_root_test.go
@@ -115,6 +115,9 @@ func TestSend_AllowsBareRootWithoutIdentity(t *testing.T) {
 // the caller's own tree is not a crossing and must be allowed.
 func TestSend_AllowsRedundantSameTreeRoot(t *testing.T) {
 	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, ".claude", "agents"), 0o700); err != nil {
+		t.Fatalf("mkdir unrelated agents dir: %v", err)
+	}
 	root := sessionRoot(t, tmp, "collab", "claude", "codex")
 	t.Setenv("AM_ROOT", root)
 	t.Setenv("AM_BASE_ROOT", filepath.Join(tmp, ".agent-mail"))


### PR DESCRIPTION
## What changed

- treat `AM_BASE_ROOT`, `.amqrc`, and the default `.agent-mail` directory as authoritative base roots before using sibling-session inference
- preserve the existing contract that `classifyRoot` returns a non-empty value only for session roots
- normalize base/session comparisons so relative and absolute paths agree
- add regressions for an unrelated sibling such as `~/.claude/agents`

## Why

The sibling heuristic classified a queue root as a session whenever any sibling directory contained `agents/`. With `~/.agent-mail` as the AMQ base and `~/.claude/agents` present, the classifier incorrectly selected `$HOME` as the base.

That caused redundant same-session `--root` sends to be rejected as cross-tree and made `amq env --session <name>` resolve under `$HOME` instead of `~/.agent-mail`.

## Validation

- `go test ./internal/cli -count=1`
- `make test smoke`
- `go vet ./...`
- `make check-skills`
- `make fmt-check`

`make ci` reaches the lint step locally, but `golangci-lint` is not installed on this machine. The repository's GitHub workflow will run the configured lint action.
