### PR TITLE
fix: harden Darwin wake lifecycle and root classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ editing the release PR.
 - Darwin wake identity now uses the stable `kern.bootsessionuuid` instead of
   the wall-clock-derived `kern.boottime`, while retaining a bounded legacy
   compatibility path and a safe `kern.boottime` fallback for older macOS.
+  Darwin process inspection also treats unreaped `SZOMB` wake processes as
+  stopped, so their stale wake locks can be replaced.
 - Accept-existing wake startup now verifies that an existing wake's injection
   mode and, for external wakes, persisted injector path and ordered arguments
   match the requested target; mismatched, owner-orphaned, or concurrently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ editing the release PR.
   mode and, for external wakes, persisted injector path and ordered arguments
   match the requested target; mismatched, owner-orphaned, or concurrently
   replaced terminal targets do not report readiness.
+- Add `amq wake retire` for identity-verified managed shutdown of an exact
+  inject-via wake while preserving its mailbox and saved target. The command
+  refuses target mismatches, unverified locks, and process/lock replacement
+  races before signaling.
 
 ## [0.41.1] - 2026-07-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ editing the release PR.
   documented Dependabot-detection pattern, which stays `dependabot[bot]`
   regardless of who updates the branch.
 
+### Fixed
+
+- Darwin wake identity now uses the stable `kern.bootsessionuuid` instead of
+  the wall-clock-derived `kern.boottime`, while retaining a bounded legacy
+  compatibility path and a safe `kern.boottime` fallback for older macOS.
+- Accept-existing wake startup now verifies that an existing wake's injection
+  mode and, for external wakes, persisted injector path and ordered arguments
+  match the requested target; mismatched, owner-orphaned, or concurrently
+  replaced terminal targets do not report readiness.
+
 ## [0.41.1] - 2026-07-10
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ amq doctor --ops
 amq doctor --ops --json
 amq doctor --ops --fix-wake-locks
 amq wake repair --me codex
+amq wake retire --me codex --inject-via /absolute/injector \
+  --inject-arg inject --inject-arg cmux --inject-arg cmux:surface:<uuid>
 ```
 
 Wake locks reported by `doctor --ops` can be `stale`, `unverified`, or, in JSON
@@ -216,6 +218,13 @@ locks, and `unverified` locks to avoid double-injecting into an active session
 or injecting into the wrong terminal. Repaired wake output goes to
 `agents/<agent>/.wake.repair.log`; `doctor --ops` can report whether repair is
 available, but it never starts a wake process.
+
+`amq wake retire` is the symmetric managed-shutdown path. It stops a wake only
+when the live process identity, unchanged lock contents, and saved inject-via
+executable plus ordered arguments all match the caller's exact expectation.
+PID reuse, unverified locks, different terminal targets, and concurrent lock
+replacement fail closed. Retirement removes only the wake lock; the AMQ
+mailbox and saved target remain available for a fresh agent pair to reuse.
 
 `amq who` and `amq doctor --ops` distinguish two activity sources:
 

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -64,16 +64,20 @@ func sessionName(root string) string { return filepath.Base(root) }
 //
 // Resolution order:
 //  1. AM_BASE_ROOT, but only when the supplied root is still under that base
-//  2. If root is a session root (parent contains sibling session dirs), return parent
-//  3. If the parent directory is the default root name (.agent-mail), return parent
-//  4. Root-aware .amqrc lookup (works for explicit --root outside the cwd project)
-//  5. Otherwise, return "" (unknown — caller must handle)
+//  2. If root itself is the default base (.agent-mail), return "" (it is not a session)
+//  3. If root is a session root (parent contains sibling session dirs), return parent
+//  4. If the parent directory is the default root name (.agent-mail), return parent
+//  5. Root-aware .amqrc lookup (works for explicit --root outside the cwd project)
+//  6. Otherwise, return "" (unknown — caller must handle)
 func classifyRoot(root string) string {
 	if base := strings.TrimSpace(os.Getenv(envBaseRoot)); base != "" {
 		base = resolveRoot(base)
 		if isSessionRootUnderBase(root, base) {
 			return base
 		}
+	}
+	if filepath.Base(filepath.Clean(root)) == defaultCoopRoot {
+		return ""
 	}
 	// Check if root looks like a session: parent has sibling dirs with agents/.
 	parent := filepath.Dir(root)

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -411,6 +411,30 @@ func TestClassifyRootDefaultLayoutConvention(t *testing.T) {
 	}
 }
 
+func TestClassifyRootDefaultBaseIgnoresPoisonSiblingAgentsDirectory(t *testing.T) {
+	t.Setenv("AM_BASE_ROOT", "")
+
+	home := t.TempDir()
+	baseRoot := filepath.Join(home, defaultCoopRoot)
+	sessionRoot := filepath.Join(baseRoot, "dashboard")
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "agents"), 0o700); err != nil {
+		t.Fatalf("mkdir poison sibling: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sessionRoot, "agents"), 0o700); err != nil {
+		t.Fatalf("mkdir session root: %v", err)
+	}
+
+	if got := classifyRoot(baseRoot); got != "" {
+		t.Fatalf("classifyRoot(base) = %q, want empty for a base root", got)
+	}
+	if got := baseRootOf(baseRoot); got != baseRoot {
+		t.Fatalf("baseRootOf(base) = %q, want %q", got, baseRoot)
+	}
+	if !sameBaseTree(baseRoot, sessionRoot) {
+		t.Fatalf("sameBaseTree(base, session) = false, want true")
+	}
+}
+
 func TestClassifyRootCustomRootDoesNotMatchDefaultLayoutConvention(t *testing.T) {
 	t.Setenv("AM_BASE_ROOT", "")
 

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,6 +34,7 @@ type wakeProcessInfo struct {
 	Running      bool
 	StartToken   string
 	BootID       string
+	LegacyBootID string
 	Executable   string
 	Args         []string
 	InspectError error
@@ -200,7 +202,7 @@ func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
 			inspection.Reason = inspectionReason("process start time unavailable", proc.InspectError)
 			return
 		}
-		if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
+		if wakeBootIDMismatch(lock.BootID, proc) {
 			inspection.Status = wakeLockUnverified
 			if wakeProcessProvenNotWake(proc) {
 				inspection.Status = wakeLockStale
@@ -322,7 +324,7 @@ func currentWakeLockMatches(lock wakeLock) bool {
 	if !proc.Running || proc.StartToken == "" {
 		return false
 	}
-	if lock.BootID != "" && proc.BootID != "" && lock.BootID != proc.BootID {
+	if wakeBootIDMismatch(lock.BootID, proc) {
 		return false
 	}
 	return lock.ProcessStart == proc.StartToken
@@ -413,7 +415,7 @@ func wakeProcessStillMatches(inspection wakeLockInspection) bool {
 		if proc.StartToken == "" || inspection.Lock.ProcessStart != proc.StartToken {
 			return false
 		}
-		if inspection.Lock.BootID != "" && proc.BootID != "" && inspection.Lock.BootID != proc.BootID {
+		if wakeBootIDMismatch(inspection.Lock.BootID, proc) {
 			return false
 		}
 	}
@@ -427,4 +429,51 @@ func wakeProcessStillMatches(inspection wakeLockInspection) bool {
 		return false
 	}
 	return true
+}
+
+func wakeBootIDMismatch(recorded string, proc wakeProcessInfo) bool {
+	if recorded == "" || proc.BootID == "" {
+		return false
+	}
+	if recorded == proc.BootID || recorded == proc.LegacyBootID {
+		return false
+	}
+	for _, current := range []string{proc.BootID, proc.LegacyBootID} {
+		if legacyDarwinBootIDsMatch(recorded, current) {
+			return false
+		}
+	}
+	return true
+}
+
+// Legacy Darwin boot IDs came from kern.boottime, which can move slightly as
+// macOS corrects wall-clock time. A one-second migration tolerance preserves
+// old live wake locks without making two realistically distinct boots equal.
+func legacyDarwinBootIDsMatch(first, second string) bool {
+	firstTime, firstOK := parseLegacyDarwinBootID(first)
+	secondTime, secondOK := parseLegacyDarwinBootID(second)
+	if !firstOK || !secondOK {
+		return false
+	}
+	delta := firstTime.Sub(secondTime)
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta <= time.Second
+}
+
+func parseLegacyDarwinBootID(value string) (time.Time, bool) {
+	seconds, nanos, ok := strings.Cut(value, ".")
+	if !ok || seconds == "" || len(nanos) != 9 || strings.Contains(nanos, ".") {
+		return time.Time{}, false
+	}
+	sec, err := strconv.ParseInt(seconds, 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	nsec, err := strconv.ParseInt(nanos, 10, 64)
+	if err != nil || nsec < 0 || nsec >= int64(time.Second) {
+		return time.Time{}, false
+	}
+	return time.Unix(sec, nsec), true
 }

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -86,3 +86,85 @@ func bindWakeLockToTarget(lock wakeLock, target wakeTarget) wakeLock {
 	lock.TargetDigest = wakeTargetDigest(target)
 	return lock
 }
+
+func TestWakeBootIDMismatchAcceptsDarwinLegacyMigration(t *testing.T) {
+	tests := []struct {
+		name     string
+		recorded string
+		process  wakeProcessInfo
+		mismatch bool
+	}{
+		{
+			name:     "current boot session uuid",
+			recorded: "9C0682F4-901B-4243-8B5C-287FAFB9AD0E",
+			process:  wakeProcessInfo{BootID: "9C0682F4-901B-4243-8B5C-287FAFB9AD0E"},
+		},
+		{
+			name:     "legacy boot time with macOS clock correction",
+			recorded: "1783327533.465308000",
+			process: wakeProcessInfo{
+				BootID:       "9C0682F4-901B-4243-8B5C-287FAFB9AD0E",
+				LegacyBootID: "1783327533.407566000",
+			},
+		},
+		{
+			name:     "boot time fallback with macOS clock correction",
+			recorded: "1783327533.465308000",
+			process:  wakeProcessInfo{BootID: "1783327533.407566000"},
+		},
+		{
+			name:     "different legacy boot",
+			recorded: "1783327533.465308000",
+			process: wakeProcessInfo{
+				BootID:       "9C0682F4-901B-4243-8B5C-287FAFB9AD0E",
+				LegacyBootID: "1783327535.407566000",
+			},
+			mismatch: true,
+		},
+		{
+			name:     "different boot session uuid",
+			recorded: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+			process:  wakeProcessInfo{BootID: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB"},
+			mismatch: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := wakeBootIDMismatch(tc.recorded, tc.process); got != tc.mismatch {
+				t.Fatalf("wakeBootIDMismatch() = %v, want %v", got, tc.mismatch)
+			}
+		})
+	}
+}
+
+func TestInspectWakeLockAcceptsLegacyDarwinBootIDForProvenWake(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "tty",
+		ProcessStart: "start-1",
+		BootID:       "1783327533.465308000",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:          pid,
+				Running:      true,
+				StartToken:   "start-1",
+				BootID:       "9C0682F4-901B-4243-8B5C-287FAFB9AD0E",
+				LegacyBootID: "1783327533.407566000",
+				Executable:   "/opt/homebrew/bin/amq",
+				Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+		t.Fatalf("inspection = status %q reason %q confirmed %v", inspection.Status, inspection.Reason, inspection.IdentityConfirmed)
+	}
+}

--- a/internal/cli/wake_process_darwin.go
+++ b/internal/cli/wake_process_darwin.go
@@ -9,7 +9,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// SZOMB from <sys/proc.h>: the process has exited and is waiting for its
+// parent to reap it. kill(pid, 0) still succeeds for this state.
+const darwinProcessStateZombie int8 = 5
+
 var (
+	readDarwinKinfoProc       = unix.SysctlKinfoProc
 	readDarwinBootSessionUUID = func() (string, error) {
 		return unix.Sysctl("kern.bootsessionuuid")
 	}
@@ -25,12 +30,16 @@ func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
 	}
 	info.Running = true
 
-	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	kp, err := readDarwinKinfoProc("kern.proc.pid", pid)
 	if err != nil {
 		info.InspectError = err
 		return info
 	}
 	if kp == nil {
+		info.Running = false
+		return info
+	}
+	if kp.Proc.P_stat == darwinProcessStateZombie {
 		info.Running = false
 		return info
 	}

--- a/internal/cli/wake_process_darwin.go
+++ b/internal/cli/wake_process_darwin.go
@@ -4,8 +4,18 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"golang.org/x/sys/unix"
+)
+
+var (
+	readDarwinBootSessionUUID = func() (string, error) {
+		return unix.Sysctl("kern.bootsessionuuid")
+	}
+	readDarwinBootTime = func() (*unix.Timeval, error) {
+		return unix.SysctlTimeval("kern.boottime")
+	}
 )
 
 func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
@@ -29,12 +39,27 @@ func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
 	info.StartToken = fmt.Sprintf("%d.%09d", sec, nsec)
 	info.Executable = nulTerminatedString(kp.Proc.P_comm[:])
 
-	if boot, err := unix.SysctlTimeval("kern.boottime"); err == nil && boot != nil {
-		bsec, bnsec := boot.Unix()
-		info.BootID = fmt.Sprintf("%d.%09d", bsec, bnsec)
-	}
+	info.BootID, info.LegacyBootID = darwinBootIdentity()
 
 	return info
+}
+
+func darwinBootIdentity() (bootID, legacyBootID string) {
+	if boot, err := readDarwinBootTime(); err == nil && boot != nil {
+		sec, nsec := boot.Unix()
+		legacyBootID = fmt.Sprintf("%d.%09d", sec, nsec)
+	}
+
+	if sessionUUID, err := readDarwinBootSessionUUID(); err == nil {
+		sessionUUID = strings.TrimSpace(sessionUUID)
+		if sessionUUID != "" && !strings.ContainsRune(sessionUUID, 0) {
+			return sessionUUID, legacyBootID
+		}
+	}
+
+	// kern.boottime was AMQ's Darwin boot identity before v0.42. Keep it as a
+	// best-effort fallback for macOS versions where bootsessionuuid is absent.
+	return legacyBootID, ""
 }
 
 func nulTerminatedString(raw []byte) string {

--- a/internal/cli/wake_process_darwin_test.go
+++ b/internal/cli/wake_process_darwin_test.go
@@ -4,10 +4,27 @@ package cli
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"golang.org/x/sys/unix"
 )
+
+func TestInspectWakeProcessPlatformTreatsDarwinZombieAsNotRunning(t *testing.T) {
+	old := readDarwinKinfoProc
+	readDarwinKinfoProc = func(name string, args ...int) (*unix.KinfoProc, error) {
+		if name != "kern.proc.pid" || len(args) != 1 || args[0] != os.Getpid() {
+			t.Fatalf("unexpected sysctl request: name=%q args=%v", name, args)
+		}
+		return &unix.KinfoProc{Proc: unix.ExternProc{P_stat: darwinProcessStateZombie}}, nil
+	}
+	t.Cleanup(func() { readDarwinKinfoProc = old })
+
+	info := inspectWakeProcessPlatform(os.Getpid())
+	if info.Running {
+		t.Fatalf("zombie process reported running: %#v", info)
+	}
+}
 
 func stubDarwinBootIdentityReaders(
 	t *testing.T,

--- a/internal/cli/wake_process_darwin_test.go
+++ b/internal/cli/wake_process_darwin_test.go
@@ -1,0 +1,70 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func stubDarwinBootIdentityReaders(
+	t *testing.T,
+	session func() (string, error),
+	bootTime func() (*unix.Timeval, error),
+) {
+	t.Helper()
+	oldSession := readDarwinBootSessionUUID
+	oldBootTime := readDarwinBootTime
+	readDarwinBootSessionUUID = session
+	readDarwinBootTime = bootTime
+	t.Cleanup(func() {
+		readDarwinBootSessionUUID = oldSession
+		readDarwinBootTime = oldBootTime
+	})
+}
+
+func TestDarwinBootIdentityPrefersBootSessionUUIDAndKeepsLegacyAlias(t *testing.T) {
+	bootTime := unix.NsecToTimeval(1783327533407566000)
+	stubDarwinBootIdentityReaders(t,
+		func() (string, error) { return "  9C0682F4-901B-4243-8B5C-287FAFB9AD0E\n", nil },
+		func() (*unix.Timeval, error) { return &bootTime, nil },
+	)
+
+	bootID, legacyBootID := darwinBootIdentity()
+	if bootID != "9C0682F4-901B-4243-8B5C-287FAFB9AD0E" {
+		t.Fatalf("boot id = %q", bootID)
+	}
+	if legacyBootID != "1783327533.407566000" {
+		t.Fatalf("legacy boot id = %q", legacyBootID)
+	}
+}
+
+func TestDarwinBootIdentityFallsBackToBootTime(t *testing.T) {
+	bootTime := unix.NsecToTimeval(1783327533407566000)
+	stubDarwinBootIdentityReaders(t,
+		func() (string, error) { return "", errors.New("unsupported") },
+		func() (*unix.Timeval, error) { return &bootTime, nil },
+	)
+
+	bootID, legacyBootID := darwinBootIdentity()
+	if bootID != "1783327533.407566000" {
+		t.Fatalf("fallback boot id = %q", bootID)
+	}
+	if legacyBootID != "" {
+		t.Fatalf("fallback legacy boot id = %q, want empty", legacyBootID)
+	}
+}
+
+func TestDarwinBootIdentityReturnsEmptyWhenBothSourcesUnavailable(t *testing.T) {
+	stubDarwinBootIdentityReaders(t,
+		func() (string, error) { return "\x00", nil },
+		func() (*unix.Timeval, error) { return nil, errors.New("unsupported") },
+	)
+
+	bootID, legacyBootID := darwinBootIdentity()
+	if bootID != "" || legacyBootID != "" {
+		t.Fatalf("boot ids = %q, %q; want empty", bootID, legacyBootID)
+	}
+}

--- a/internal/cli/wake_retire_unix_test.go
+++ b/internal/cli/wake_retire_unix_test.go
@@ -1,0 +1,190 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func installRetireWakeFixture(t *testing.T, root, me, injector string, args []string, pid int) (wakeTarget, string) {
+	t.Helper()
+	target := mustNewWakeTargetForTest(t, root, me, injector, args)
+	lockPath := writeWakeLockForTest(t, root, me, bindWakeLockToTarget(wakeLock{
+		PID:          pid,
+		TTY:          "unknown",
+		ProcessStart: "wake-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, target))
+	if err := writeWakeTarget(root, me, target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	return target, lockPath
+}
+
+func matchingRetireWakeProcess(pid int, root, me, injector string) wakeProcessInfo {
+	return wakeProcessInfo{
+		PID:        pid,
+		Running:    true,
+		StartToken: "wake-start",
+		BootID:     "boot-1",
+		Executable: "/opt/homebrew/bin/amq",
+		Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", me, "--root", root, "--inject-via", injector},
+	}
+}
+
+func TestRetireWakeStopsExactIdentityAndPreservesMailboxTarget(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	injector := writeExecutableForTest(t, "amq-keepalive")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector,
+		[]string{"inject", "cmux", "cmux:surface:AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"}, wakePID)
+
+	killed := false
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		if killed {
+			return wakeProcessInfo{PID: pid, Running: false}
+		}
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		if pid != wakePID {
+			t.Fatalf("signal pid = %d, want %d", pid, wakePID)
+		}
+		killed = true
+		return nil
+	})
+
+	result, err := retireWake(root, "codex", requested)
+	if err != nil {
+		t.Fatalf("retireWake: %v", err)
+	}
+	if result.Status != "retired" || result.PID != wakePID {
+		t.Fatalf("result = %#v", result)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("wake lock should be removed, stat=%v", err)
+	}
+	if _, err := os.Stat(wakeTargetPath(root, "codex")); err != nil {
+		t.Fatalf("saved target should be preserved, stat=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentBase(root, "codex"), "inbox")); err != nil {
+		t.Fatalf("mailbox should be preserved, stat=%v", err)
+	}
+}
+
+func TestRetireWakeRefusesDifferentInjectTarget(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	injector := writeExecutableForTest(t, "amq-keepalive")
+	_, lockPath := installRetireWakeFixture(t, root, "codex", injector,
+		[]string{"inject", "cmux", "cmux:surface:AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"}, wakePID)
+	requested := mustNewWakeTargetForTest(t, root, "codex", injector,
+		[]string{"inject", "cmux", "cmux:surface:11111111-2222-3333-4444-555555555555"})
+
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		t.Fatalf("mismatched target must not be signaled, got pid=%d sig=%v", pid, sig)
+		return nil
+	})
+
+	result, err := retireWake(root, "codex", requested)
+	if err == nil || result.Status != "refused" || !strings.Contains(result.Reason, "does not match") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("mismatched wake lock should remain, stat=%v", err)
+	}
+}
+
+func TestRetireWakeRevalidatesIdentityBeforeSignal(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	injector := writeExecutableForTest(t, "amq-keepalive")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector,
+		[]string{"inject", "cmux", "cmux:surface:AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"}, wakePID)
+
+	inspectCalls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspectCalls++
+		if inspectCalls <= 2 {
+			return matchingRetireWakeProcess(pid, root, "codex", injector)
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "reused-start",
+			BootID:     "boot-1",
+			Executable: "/bin/sleep",
+			Args:       []string{"/bin/sleep", "100"},
+		}
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		t.Fatalf("changed process identity must not be signaled, got pid=%d sig=%v", pid, sig)
+		return nil
+	})
+
+	result, err := retireWake(root, "codex", requested)
+	if err == nil || result.Status != "error" || !strings.Contains(result.Reason, "identity changed") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("wake lock should remain after identity change, stat=%v", err)
+	}
+}
+
+func TestRetireWakeRemovesExactStaleLockWithoutSignal(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	injector := writeExecutableForTest(t, "amq-keepalive")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector,
+		[]string{"inject", "cmux", "cmux:surface:AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"}, wakePID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		t.Fatalf("stale wake must not be signaled, got pid=%d sig=%v", pid, sig)
+		return nil
+	})
+
+	result, err := retireWake(root, "codex", requested)
+	if err != nil || result.Status != "retired" {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale wake lock should be removed, stat=%v", err)
+	}
+}
+
+func TestRetireWakeRefusesWhenLockIsAbsent(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "amq-keepalive")
+	requested := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"inject", "cmux", "surface"})
+
+	result, err := retireWake(root, "codex", requested)
+	if err == nil || result.Status != "refused" || !strings.Contains(result.Reason, "cannot be proven") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -52,6 +52,16 @@ type wakeRepairResult struct {
 	RepairAvailable bool   `json:"repair_available,omitempty"`
 }
 
+type wakeRetireResult struct {
+	Status string `json:"status"`
+	Agent  string `json:"agent"`
+	Root   string `json:"root"`
+	Lock   string `json:"lock"`
+	Target string `json:"target,omitempty"`
+	PID    int    `json:"pid,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
 type wakeRepairStarter func(root, me string, target wakeTarget) (int, error)
 
 type wakeLockAcquireOptions struct {
@@ -450,10 +460,149 @@ func processAlive(pid int) bool {
 type wakeLoopFunc func(wakeConfig) error
 
 func runWake(args []string) error {
-	if len(args) > 0 && args[0] == "repair" {
-		return runWakeRepair(args[1:])
+	if len(args) > 0 {
+		switch args[0] {
+		case "repair":
+			return runWakeRepair(args[1:])
+		case "retire":
+			return runWakeRetire(args[1:])
+		}
 	}
 	return runWakeWithLoop(args, runWakeLoop)
+}
+
+func runWakeRetire(args []string) error {
+	fs := flag.NewFlagSet("wake retire", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	injectViaFlag := fs.String("inject-via", "", "Expected external injection executable")
+	var injectArgFlags multiStringFlag
+	fs.Var(&injectArgFlags, "inject-arg", "Expected fixed injection argument (repeatable)")
+	usage := usageWithFlags(fs, "amq wake retire --me <agent> --inject-via <path> [options]",
+		"Retire an identity-confirmed wake only when its saved inject-via target exactly matches.",
+		"",
+		"The command revalidates the wake process identity, lock contents, and saved",
+		"inject-via target before signaling. It preserves the mailbox and saved target.")
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if err := requireMe(common.Me); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*injectViaFlag) == "" {
+		return UsageError("--inject-via is required")
+	}
+	me, err := normalizeHandle(common.Me)
+	if err != nil {
+		return UsageError("--me: %v", err)
+	}
+	root := resolveRoot(common.Root)
+	if err := validateKnownHandles(root, common.Strict, me); err != nil {
+		return err
+	}
+	requested, err := newWakeTarget(root, me, *injectViaFlag, []string(injectArgFlags))
+	if err != nil {
+		return UsageError("--inject-via: %v", err)
+	}
+	result, retireErr := retireWake(root, me, requested)
+	if common.JSON {
+		if err := writeJSON(os.Stdout, result); err != nil {
+			return err
+		}
+		return retireErr
+	}
+	line := fmt.Sprintf("wake retire: %s agent=%s root=%s", result.Status, result.Agent, result.Root)
+	if result.PID != 0 {
+		line += fmt.Sprintf(" pid=%d", result.PID)
+	}
+	if result.Reason != "" {
+		line += " reason=" + result.Reason
+	}
+	if err := writeStdoutLine(line); err != nil {
+		return err
+	}
+	return retireErr
+}
+
+func retireWake(root, me string, requested wakeTarget) (wakeRetireResult, error) {
+	result := wakeRetireResult{
+		Status: "unknown",
+		Agent:  me,
+		Root:   canonicalWakeRoot(root),
+		Lock:   filepath.Join(fsq.AgentBase(root, me), ".wake.lock"),
+		Target: wakeTargetPath(root, me),
+	}
+	inspection := inspectWakeLock(root, me)
+	if !inspection.Exists {
+		result.Status = "refused"
+		result.Reason = "no wake lock present; wake process absence cannot be proven"
+		return result, errors.New(result.Reason)
+	}
+	result.PID = inspection.PID
+	refuse := func(reason string) (wakeRetireResult, error) {
+		result.Status = "refused"
+		result.Reason = reason
+		return result, errors.New(reason)
+	}
+
+	switch inspection.Status {
+	case wakeLockValid:
+		if !inspection.IdentityConfirmed {
+			return refuse("wake process identity is not confirmed")
+		}
+		if err := requireExistingWakeTargetMatches(inspection, requested); err != nil {
+			return refuse(err.Error())
+		}
+		recheck := inspectWakeLock(root, me)
+		if !sameWakeLockInspection(inspection, recheck) || !recheck.IdentityConfirmed {
+			return refuse("wake lock changed before retirement")
+		}
+		if err := requireExistingWakeTargetMatches(recheck, requested); err != nil {
+			return refuse("wake target changed before retirement: " + err.Error())
+		}
+		if err := terminateWakeProcess(recheck); err != nil {
+			result.Status = "error"
+			result.Reason = err.Error()
+			return result, err
+		}
+		if err := removeWakeLockIfUnchanged(recheck); err != nil {
+			result.Status = "error"
+			result.Reason = err.Error()
+			return result, err
+		}
+	case wakeLockStale:
+		if err := validateWakeLockStaleRemoval(inspection); err != nil {
+			return refuse(err.Error())
+		}
+		if err := requireExistingWakeTargetMatches(inspection, requested); err != nil {
+			return refuse(err.Error())
+		}
+		recheck := inspectWakeLock(root, me)
+		if !recheck.Exists || recheck.Status != wakeLockStale ||
+			recheck.Root != inspection.Root || recheck.Agent != inspection.Agent ||
+			!bytes.Equal(recheck.raw, inspection.raw) {
+			return refuse("wake lock changed before retirement")
+		}
+		if err := requireExistingWakeTargetMatches(recheck, requested); err != nil {
+			return refuse("wake target changed before retirement: " + err.Error())
+		}
+		if err := removeWakeLockIfUnchanged(recheck); err != nil {
+			result.Status = "error"
+			result.Reason = err.Error()
+			return result, err
+		}
+	case wakeLockCreating:
+		return refuse("wake lock is being created; retry shortly")
+	case wakeLockUnverified:
+		return refuse("wake lock is unverified; refusing retirement: " + inspection.Reason)
+	default:
+		return refuse(fmt.Sprintf("wake lock status %q cannot be retired", inspection.Status))
+	}
+
+	result.Status = "retired"
+	result.Reason = "wake stopped; mailbox and saved target preserved"
+	return result, nil
 }
 
 func runWakeRepair(args []string) error {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -22,6 +23,10 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"golang.org/x/sys/unix"
 )
+
+const maxWakeLockAcquireInspections = 8
+
+var errWakeLockChangedDuringReplacement = errors.New("wake lock changed during orphan replacement")
 
 var (
 	signalWakeProcess = func(pid int, sig os.Signal) error {
@@ -72,7 +77,15 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 		return nil, fmt.Errorf("failed to create agent directory: %w", err)
 	}
 
-	// Check existing lock
+	inspectionCount := 0
+
+retryInspection:
+	if inspectionCount >= maxWakeLockAcquireInspections {
+		return nil, fmt.Errorf("wake lock changed repeatedly while acquiring for %s; retry", me)
+	}
+	inspectionCount++
+
+	// Check existing lock.
 	inspection := inspectWakeLock(root, me)
 	if inspection.Exists {
 		switch inspection.Status {
@@ -87,13 +100,26 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 			return nil, fmt.Errorf("wake lock is being created (retry shortly)")
 		case wakeLockValid:
 			if options.acceptExistingValid {
-				if err := requireWakeLockUsable(inspection, options.wakeMode); err != nil {
+				replace, replaceErr := shouldReplaceOwnerOrphanedWakeLock(inspection)
+				if replaceErr != nil {
+					if errors.Is(replaceErr, errWakeLockChangedDuringReplacement) {
+						goto retryInspection
+					}
+					return nil, replaceErr
+				}
+				if replace {
+					goto createLock
+				}
+				if err := requireWakeLockUsable(inspection, options.target, options.wakeMode); err != nil {
 					return nil, err
 				}
 				return nil, wakeLockAlreadyRunningError(me, inspection)
 			}
 			replace, replaceErr := shouldReplaceOrphanedWakeLock(inspection)
 			if replaceErr != nil {
+				if errors.Is(replaceErr, errWakeLockChangedDuringReplacement) {
+					goto retryInspection
+				}
 				return nil, replaceErr
 			}
 			if replace {
@@ -147,9 +173,20 @@ createLock:
 			winner := inspectWakeLock(root, me)
 			if winner.Status == wakeLockValid {
 				if options.acceptExistingValid {
-					if usableErr := requireWakeLockUsable(winner, options.wakeMode); usableErr != nil {
+					replace, replaceErr := shouldReplaceOwnerOrphanedWakeLock(winner)
+					if replaceErr != nil {
+						if errors.Is(replaceErr, errWakeLockChangedDuringReplacement) {
+							goto retryInspection
+						}
+						return nil, replaceErr
+					}
+					if replace {
+						goto createLock
+					}
+					if usableErr := requireWakeLockUsable(winner, options.target, options.wakeMode); usableErr != nil {
 						return nil, usableErr
 					}
+					return nil, wakeLockAlreadyRunningError(me, winner)
 				}
 				return nil, wakeLockAlreadyRunningError(me, winner)
 			}
@@ -182,11 +219,16 @@ createLock:
 }
 
 func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
-	if !wakeLockNeedsReplacement(inspection) {
-		replace, err := wakeLockNeedsOwnerReplacement(inspection)
-		if err != nil || !replace {
-			return replace, err
-		}
+	if wakeLockNeedsReplacement(inspection) {
+		return replaceConfirmedOrphanedWakeLock(inspection)
+	}
+	return shouldReplaceOwnerOrphanedWakeLock(inspection)
+}
+
+func shouldReplaceOwnerOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
+	replace, err := wakeLockNeedsOwnerReplacement(inspection)
+	if err != nil || !replace {
+		return replace, err
 	}
 	return replaceConfirmedOrphanedWakeLock(inspection)
 }
@@ -239,7 +281,7 @@ func wakeLockNeedsOwnerReplacement(inspection wakeLockInspection) (bool, error) 
 	return wakeOwnerHealthCheck(*target.Owner) != nil, nil
 }
 
-func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string) error {
+func requireWakeLockUsable(inspection wakeLockInspection, requestedTarget *wakeTarget, requiredMode string) error {
 	if !inspection.Exists || inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
 		return fmt.Errorf("existing wake lock for %s is not a confirmed valid wake", inspection.Agent)
 	}
@@ -254,6 +296,19 @@ func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string) e
 		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
 			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
 	}
+	external := wakeLockUsesExternalInjector(inspection)
+	if requestedTarget == nil {
+		if external {
+			return fmt.Errorf("existing wake for %s uses inject-via and does not match the requested raw terminal target", inspection.Agent)
+		}
+	} else {
+		if !external {
+			return fmt.Errorf("existing wake for %s uses raw terminal injection and does not match the requested inject-via target", inspection.Agent)
+		}
+		if err := requireExistingWakeTargetMatches(inspection, *requestedTarget); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -261,11 +316,42 @@ func wakeLockHasUsableNotificationPath(inspection wakeLockInspection) bool {
 	if inspection.Lock.WakeMode == wakeInjectModeNone {
 		return true
 	}
-	if inspection.Lock.WakeMode == wakeTargetInjectVia || wakeArgsUseInjectVia(inspection.Process.Args) {
+	if wakeLockUsesExternalInjector(inspection) {
 		return true
 	}
 	tty := strings.TrimSpace(inspection.Lock.TTY)
 	return tty != "" && tty != "unknown"
+}
+
+func wakeLockUsesExternalInjector(inspection wakeLockInspection) bool {
+	return inspection.Lock.WakeMode == wakeTargetInjectVia || wakeArgsUseInjectVia(inspection.Process.Args)
+}
+
+func requireExistingWakeTargetMatches(inspection wakeLockInspection, requested wakeTarget) error {
+	existing, exists, err := readWakeTarget(inspection.Root, inspection.Agent)
+	if err != nil {
+		return fmt.Errorf("existing inject-via wake target cannot be verified: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("existing inject-via wake target cannot be verified: wake target is missing")
+	}
+	if err := validateWakeTarget(existing, inspection.Root, inspection.Agent); err != nil {
+		return fmt.Errorf("existing inject-via wake target cannot be verified: %w", err)
+	}
+	if err := validateWakeTargetMatchesLock(inspection.Lock, existing); err != nil {
+		return fmt.Errorf("existing inject-via wake target cannot be verified: %w", err)
+	}
+	if err := validateWakeTarget(requested, inspection.Root, inspection.Agent); err != nil {
+		return fmt.Errorf("requested inject-via wake target is invalid: %w", err)
+	}
+	if existing.Mode != requested.Mode ||
+		canonicalWakeRoot(existing.Root) != canonicalWakeRoot(requested.Root) ||
+		existing.Agent != requested.Agent ||
+		existing.InjectVia != requested.InjectVia ||
+		!slices.Equal(existing.InjectArgs, requested.InjectArgs) {
+		return fmt.Errorf("existing inject-via wake target does not match requested --wake-inject-via/--wake-inject-arg values")
+	}
+	return nil
 }
 
 func wakeArgsUseInjectVia(args []string) bool {
@@ -284,7 +370,7 @@ func replaceConfirmedOrphanedWakeLock(inspection wakeLockInspection) (bool, erro
 func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
 	recheck := inspectWakeLock(inspection.Root, inspection.Agent)
 	if !sameWakeLockInspection(inspection, recheck) || !recheck.IdentityConfirmed {
-		return false, nil
+		return false, errWakeLockChangedDuringReplacement
 	}
 	if err := terminateWakeProcess(recheck); err != nil {
 		return false, err
@@ -1050,7 +1136,7 @@ func wakeOwnerHealthCheck(owner wakeOwner) error {
 			return fmt.Errorf("inject-via wake owner process start changed for pid %d", owner.PID)
 		}
 	}
-	if owner.BootID != "" && proc.BootID != "" && proc.BootID != owner.BootID {
+	if wakeBootIDMismatch(owner.BootID, proc) {
 		return fmt.Errorf("inject-via wake owner boot id changed for pid %d", owner.PID)
 	}
 	if owner.SessionID != 0 {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -561,7 +561,7 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 	}
 }
 
-func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
+func TestRunWakeWithLoopRejectsRawExistingWakeWhenInjectViaRequested(t *testing.T) {
 	const wakePID = 4242
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == wakePID {
@@ -591,17 +591,18 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 		"--root", root,
 		"--me", "orchestrator",
 		"--inject-via", injector,
+		"--inject-arg", "exec",
 		"--ready-file", readyPath,
 		"--accept-existing-wake",
 	}, func(cfg wakeConfig) error {
 		t.Fatalf("loop should not run with an existing live wake lock: %#v", cfg)
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("expected existing usable wake to satisfy ready file, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "raw terminal injection") {
+		t.Fatalf("expected raw wake target mismatch, got %v", err)
 	}
-	if _, statErr := os.Stat(readyPath); statErr != nil {
-		t.Fatalf("ready file should exist, statErr=%v", statErr)
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
 	}
 }
 
@@ -827,12 +828,16 @@ func TestRunWakeWithLoopAcceptExistingWakeAcceptsInjectViaUnknownTTY(t *testing.
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
 	}, target))
+	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "orchestrator",
 		"--inject-via", injector,
+		"--inject-arg", "exec",
 		"--ready-file", readyPath,
 		"--accept-existing-wake",
 	}, func(cfg wakeConfig) error {
@@ -844,6 +849,160 @@ func TestRunWakeWithLoopAcceptExistingWakeAcceptsInjectViaUnknownTTY(t *testing.
 	}
 	if _, statErr := os.Stat(readyPath); statErr != nil {
 		t.Fatalf("ready file should exist, statErr=%v", statErr)
+	}
+}
+
+func TestExistingWakeTargetMatchIgnoresCreatedAndOwner(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	existing := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"inject", "cmux", "surface-29"})
+	existing.Created = "2026-07-10T13:50:00Z"
+	existing.Owner = &wakeOwner{PID: 100, ProcessStart: "owner-old", BootID: "boot-old", SessionID: 10}
+	if err := writeWakeTarget(root, "orchestrator", existing); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+
+	requested := existing
+	requested.Created = "2026-07-11T09:00:00Z"
+	requested.Owner = &wakeOwner{PID: 200, ProcessStart: "owner-new", BootID: "boot-new", SessionID: 20}
+	inspection := wakeLockInspection{
+		Root:  canonicalWakeRoot(root),
+		Agent: "orchestrator",
+		Lock: bindWakeLockToTarget(wakeLock{
+			Root:  canonicalWakeRoot(root),
+			Agent: "orchestrator",
+		}, existing),
+	}
+
+	if err := requireExistingWakeTargetMatches(inspection, requested); err != nil {
+		t.Fatalf("same semantic target should match despite Created/Owner changes: %v", err)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsDifferentInjectViaTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingArgs  []string
+		requestedArgs []string
+		differentPath bool
+	}{
+		{
+			name:          "inject via path",
+			existingArgs:  []string{"inject", "ghostty", "terminal-1"},
+			requestedArgs: []string{"inject", "ghostty", "terminal-1"},
+			differentPath: true,
+		},
+		{
+			name:          "ordered inject args",
+			existingArgs:  []string{"inject", "ghostty", "terminal-1"},
+			requestedArgs: []string{"terminal-1", "ghostty", "inject"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const wakePID = 4242
+			root := secureTempDirForTest(t)
+			existingInjector := writeExecutableForTest(t, "existing-injector")
+			requestedInjector := existingInjector
+			if tc.differentPath {
+				requestedInjector = writeExecutableForTest(t, "requested-injector")
+			}
+			existingTarget := mustNewWakeTargetForTest(t, root, "orchestrator", existingInjector, tc.existingArgs)
+			if err := writeWakeTarget(root, "orchestrator", existingTarget); err != nil {
+				t.Fatalf("write wake target: %v", err)
+			}
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid == wakePID {
+					return wakeProcessInfo{
+						PID:        pid,
+						Running:    true,
+						StartToken: "start-1",
+						BootID:     "boot-1",
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--inject-via", existingInjector},
+					}
+				}
+				return wakeProcessInfo{PID: pid}
+			})
+			writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+				PID:          wakePID,
+				TTY:          "unknown",
+				ProcessStart: "start-1",
+				BootID:       "boot-1",
+				Executable:   "/opt/homebrew/bin/amq",
+			}, existingTarget))
+
+			readyPath := filepath.Join(t.TempDir(), "wake.ready")
+			args := []string{
+				"--root", root,
+				"--me", "orchestrator",
+				"--inject-via", requestedInjector,
+				"--ready-file", readyPath,
+				"--accept-existing-wake",
+			}
+			for _, arg := range tc.requestedArgs {
+				args = append(args, "--inject-arg", arg)
+			}
+			err := runWakeWithLoop(args, func(cfg wakeConfig) error {
+				t.Fatalf("loop should not run with a mismatched existing wake: %#v", cfg)
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), "does not match requested") {
+				t.Fatalf("expected target mismatch, got %v", err)
+			}
+			if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+				t.Fatalf("ready file should not exist, statErr=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingPersistedTarget(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"inject", "cmux", "surface-29"})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "start-1",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--inject-via", injector},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, target))
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", injector,
+		"--inject-arg", "inject",
+		"--inject-arg", "cmux",
+		"--inject-arg", "surface-29",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run without a persisted existing target: %#v", cfg)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "wake target is missing") {
+		t.Fatalf("expected missing target refusal, got %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
 	}
 }
 
@@ -1534,6 +1693,262 @@ func TestShouldReplaceOrphanedWakeLockKeepsInjectViaWhenOwnerMatches(t *testing.
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
 		t.Fatalf("lock should remain for owner-matched wake, stat=%v", statErr)
+	}
+}
+
+func TestAcquireWakeLockAcceptExistingReplacesInjectViaWhenOwnerGone(t *testing.T) {
+	const wakePID = 424242
+	const ownerPID = 777777
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	existing := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"inject", "cmux", "surface-old"})
+	existing.Owner = &wakeOwner{PID: ownerPID, ProcessStart: "owner-start", BootID: "boot-1"}
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "wake-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, existing))
+	if err := writeWakeTarget(root, "orchestrator", existing); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+
+	requested := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"inject", "cmux", "surface-new"})
+	killed := false
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		switch pid {
+		case wakePID:
+			if killed {
+				return wakeProcessInfo{PID: pid, Running: false}
+			}
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "wake-start",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root, "--inject-via", injector},
+			}
+		case ownerPID:
+			return wakeProcessInfo{PID: pid, Running: false}
+		case os.Getpid():
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "new-wake-start",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root, "--inject-via", injector},
+			}
+		default:
+			return wakeProcessInfo{PID: pid}
+		}
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		if pid != wakePID {
+			t.Fatalf("signal pid = %d, want %d", pid, wakePID)
+		}
+		killed = true
+		return nil
+	})
+
+	cleanup, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+		acceptExistingValid: true,
+		target:              &requested,
+	})
+	if err != nil {
+		t.Fatalf("owner-orphaned wake should be replaced, not accepted as ready: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("replacement wake should acquire a new lock")
+	}
+	defer cleanup()
+	if !killed {
+		t.Fatal("owner-orphaned wake was not terminated")
+	}
+
+	data, err := os.ReadFile(filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock"))
+	if err != nil {
+		t.Fatalf("read replacement lock: %v", err)
+	}
+	var lock wakeLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		t.Fatalf("unmarshal replacement lock: %v", err)
+	}
+	if lock.PID != os.Getpid() || lock.TargetDigest != wakeTargetDigest(requested) {
+		t.Fatalf("replacement lock = pid %d target %q", lock.PID, lock.TargetDigest)
+	}
+}
+
+func TestAcquireWakeLockAcceptExistingRejectsExternalWithoutRequestedTarget(t *testing.T) {
+	const wakePID = 424242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"inject", "cmux", "surface-29"})
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "wake-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, target))
+	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "wake-start",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root, "--inject-via", injector},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		t.Fatalf("matching live external wake must not be signaled, got pid=%d sig=%v", pid, sig)
+		return nil
+	})
+
+	cleanup, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+		acceptExistingValid: true,
+		target:              nil,
+	})
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err == nil || !strings.Contains(err.Error(), "does not match the requested raw terminal target") {
+		t.Fatalf("expected unspecified external target refusal, got %v", err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("existing external lock should remain, stat=%v", statErr)
+	}
+}
+
+func TestAcquireWakeLockAcceptExistingReinspectsChangedOwnerReplacement(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		winnerViaOEXCL bool
+	}{
+		{name: "initial inspection", winnerViaOEXCL: false},
+		{name: "o_excl winner", winnerViaOEXCL: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const oldWakePID = 900001
+			const newWakePID = 900002
+			const ownerPID = 900003
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "injector")
+
+			oldTarget := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"inject", "cmux", "surface-old"})
+			oldTarget.Owner = &wakeOwner{PID: ownerPID, ProcessStart: "owner-start", BootID: "boot-1"}
+			newTarget := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"inject", "cmux", "surface-new"})
+			writeLock := func(pid int, start string, target wakeTarget) {
+				writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+					PID:          pid,
+					TTY:          "unknown",
+					ProcessStart: start,
+					BootID:       "boot-1",
+					Executable:   "/opt/homebrew/bin/amq",
+				}, target))
+			}
+
+			winnerCreated := !tc.winnerViaOEXCL
+			if winnerCreated {
+				writeLock(oldWakePID, "old-wake-start", oldTarget)
+			}
+			if err := writeWakeTarget(root, "orchestrator", oldTarget); err != nil {
+				t.Fatalf("write old wake target: %v", err)
+			}
+
+			lockChanged := false
+			newWakeInspections := 0
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				switch pid {
+				case os.Getpid():
+					if tc.winnerViaOEXCL && !winnerCreated {
+						writeLock(oldWakePID, "old-wake-start", oldTarget)
+						winnerCreated = true
+					}
+					return wakeProcessInfo{
+						PID:        pid,
+						Running:    true,
+						StartToken: "candidate-start",
+						BootID:     "boot-1",
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root, "--inject-via", injector},
+					}
+				case oldWakePID:
+					return wakeProcessInfo{
+						PID:        pid,
+						Running:    true,
+						StartToken: "old-wake-start",
+						BootID:     "boot-1",
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root, "--inject-via", injector},
+					}
+				case newWakePID:
+					newWakeInspections++
+					return wakeProcessInfo{
+						PID:        pid,
+						Running:    true,
+						StartToken: "new-wake-start",
+						BootID:     "boot-1",
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root, "--inject-via", injector},
+					}
+				case ownerPID:
+					if !lockChanged {
+						// Model a concurrent winner publishing its lock before it
+						// replaces the prior target file.
+						writeLock(newWakePID, "new-wake-start", newTarget)
+						lockChanged = true
+					}
+					return wakeProcessInfo{PID: pid, Running: false}
+				default:
+					return wakeProcessInfo{PID: pid}
+				}
+			})
+			stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+				t.Fatalf("changed wake lock must be re-inspected before signaling, got pid=%d sig=%v", pid, sig)
+				return nil
+			})
+
+			cleanup, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+				acceptExistingValid: true,
+				target:              &oldTarget,
+			})
+			if cleanup != nil {
+				defer cleanup()
+			}
+			var alreadyRunning *wakeAlreadyRunningError
+			if err == nil || errors.As(err, &alreadyRunning) || !strings.Contains(err.Error(), "wake target does not match wake lock") {
+				t.Fatalf("changed winner must fail closed after reinspection, got %v", err)
+			}
+			if !winnerCreated || !lockChanged || newWakeInspections < 2 {
+				t.Fatalf("sequence not exercised: winner=%v changed=%v new inspections=%d", winnerCreated, lockChanged, newWakeInspections)
+			}
+
+			data, readErr := os.ReadFile(filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock"))
+			if readErr != nil {
+				t.Fatalf("read winner lock: %v", readErr)
+			}
+			var lock wakeLock
+			if unmarshalErr := json.Unmarshal(data, &lock); unmarshalErr != nil {
+				t.Fatalf("unmarshal winner lock: %v", unmarshalErr)
+			}
+			if lock.PID != newWakePID {
+				t.Fatalf("winner lock pid = %d, want %d", lock.PID, newWakePID)
+			}
+			persisted, exists, targetErr := readWakeTarget(root, "orchestrator")
+			if targetErr != nil || !exists || wakeTargetDigest(persisted) != wakeTargetDigest(oldTarget) {
+				t.Fatalf("old target window not preserved: exists=%v err=%v target=%#v", exists, targetErr, persisted)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
Harden AMQ wake lifecycle handling on Darwin and fix default `.agent-mail` base-root classification when unrelated sibling `agents/` directories exist.

## Changes
- stabilize exact Darwin wake-target reuse and treat zombie wake processes as stopped
- add identity-safe `amq wake retire` for an exact managed wake, including PID/start-token/boot-ID and lock revalidation before signaling
- preserve mailbox wake-target metadata while safely retiring the managed process
- classify the default `.agent-mail` base before the sibling-session heuristic, preventing `$HOME/.claude/agents` from making same-tree sends look cross-tree
- add regression coverage for target mismatch, identity changes, missing locks, stale locks, zombie processes, and poisoned sibling directories

## Testing
- [ ] `make ci` passes locally (only blocked because `golangci-lint` is not installed on this machine)
- [x] `make check-skills fmt-check vet test smoke`
- [x] new focused Darwin wake-retire and root-classification tests

## Related Issues
None.