### PR TITLE
feat(cli): add Grok coop support

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -35,6 +35,12 @@ For swarm command reference, see [CLAUDE.md](CLAUDE.md).
 
    See [INSTALL.md](INSTALL.md) for manual installation or troubleshooting.
 
+   If pairing with Grok CLI as an optional peer, Grok discovers skills the
+   same general way Claude Code and Codex CLI do: from a project-local
+   `.grok/skills` directory, a user-level `~/.grok/skills` directory,
+   installed plugin skills, and any explicitly configured skill paths. See
+   [INSTALL.md](INSTALL.md) for the manual `~/.grok/skills` copy example.
+
 ### Running Co-op Mode
 
 **Terminal 1 - Claude Code:**
@@ -45,6 +51,20 @@ amq coop exec claude -- --dangerously-skip-permissions
 **Terminal 2 - Codex CLI:**
 ```bash
 amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
+```
+
+**Terminal 3 - Grok CLI (optional third peer):**
+```bash
+amq coop exec grok
+```
+
+Grok is a normal handle like any other — `coop exec` forwards caller flags to
+it unchanged (no baked-in permission bypass, unlike the Codex example above).
+The default `coop init`/`coop exec` agent set stays `claude,codex,user`; adding
+Grok is opt-in. To provision mailboxes for all three engines explicitly:
+
+```bash
+amq coop init --agents claude,codex,grok,user
 ```
 
 That's it. `coop exec` auto-initializes the project if needed, sets

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,6 +87,15 @@ cp -r /tmp/amq/.agents/skills/amq-cli ~/.codex/skills/
 rm -rf /tmp/amq
 ```
 
+**Grok CLI** (optional peer; same skill contents, Grok's own discovery path):
+```bash
+git clone https://github.com/avivsinai/agent-message-queue.git /tmp/amq
+mkdir -p ~/.grok/skills
+cp -r /tmp/amq/.agents/skills/amq-cli ~/.grok/skills/
+rm -rf /tmp/amq
+```
+A project-local copy under `.grok/skills/amq-cli` in the repo works the same way if you prefer per-project installs. See [COOP.md](COOP.md) for the full list of paths Grok CLI checks.
+
 Restart your agent after installing.
 
 ---

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ amq upgrade
 amq coop init
 ```
 
-Creates `.amqrc`, mailboxes for `claude` and `codex`, and updates `.gitignore`.
+Creates `.amqrc`, mailboxes for `claude`, `codex`, and the reserved `user` operator handle, and updates `.gitignore`.
 
-Optionally add shell aliases (`amc` for Claude, `amx` for Codex):
+Optionally add shell aliases (`amc` for Claude, `amx` for Codex, and `amg` for Grok CLI as an optional peer):
 ```bash
 eval "$(amq shell-setup)"
 ```
@@ -104,12 +104,14 @@ Each alias sets up the environment, starts wake notifications, and launches the 
 ```bash
 amc feature-a          # Claude in feature-a session
 amx feature-a          # Codex in feature-a session
+amg feature-a          # Grok CLI in feature-a session (optional third peer)
 ```
 
 Without aliases, use `amq coop exec` directly:
 ```bash
 amq coop exec claude -- --dangerously-skip-permissions
 amq coop exec --session feature-a codex
+amq coop exec grok     # Grok CLI as an optional peer; caller flags forwarded unchanged
 ```
 
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -211,13 +211,15 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 		if err := writeStdoutLine("Next steps:"); err != nil {
 			return err
 		}
-		if err := writeStdout("  Terminal 1: amq coop exec %s\n", agents[0]); err != nil {
-			return err
-		}
-		if len(agents) > 1 {
-			if err := writeStdout("  Terminal 2: amq coop exec %s\n", agents[1]); err != nil {
+		terminalNum := 1
+		for _, agent := range agents {
+			if agent == reservedHumanHandle {
+				continue
+			}
+			if err := writeStdout("  Terminal %d: amq coop exec %s\n", terminalNum, agent); err != nil {
 				return err
 			}
+			terminalNum++
 		}
 		if err := writeStdoutLine(""); err != nil {
 			return err

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -58,6 +58,9 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 		"",
 		"Defaults:",
 		fmt.Sprintf("  --root=%s  --agents=%s", defaultCoopRoot, defaultCoopAgents),
+		"",
+		"Explicit three-engine example (not a default):",
+		"  --agents claude,codex,grok,user",
 	)
 
 	if handled, err := parseFlags(fs, args, usage); err != nil {

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -368,6 +368,30 @@ func TestInitExplicitAgentsDoesNotInjectUser(t *testing.T) {
 	}
 }
 
+func TestCoopInitExplicitThreeEngineAgentsParses(t *testing.T) {
+	root := t.TempDir()
+	_, err := captureEnvStdout(t, func() error {
+		return runInit([]string{"--root", root, "--agents", "claude,codex,grok,user"})
+	})
+	if err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	cfg, err := config.LoadConfig(filepath.Join(root, "meta", "config.json"))
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	want := []string{"claude", "codex", "grok", "user"}
+	if !reflect.DeepEqual(cfg.Agents, want) {
+		t.Fatalf("config agents = %#v, want %#v", cfg.Agents, want)
+	}
+	for _, agent := range want {
+		if _, err := os.Stat(filepath.Join(root, "agents", agent, "inbox", "new")); err != nil {
+			t.Fatalf("%s inbox should be created: %v", agent, err)
+		}
+	}
+}
+
 func TestWakeReadyMessageReportsExistingWake(t *testing.T) {
 	const wakePID = 4242
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -273,6 +273,79 @@ func TestCoopInitDefaultIncludesUser(t *testing.T) {
 	}
 }
 
+func TestCoopInitNextStepsDefaultAgentsSkipsUser(t *testing.T) {
+	projectDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+		resetAmqrcCache()
+	})
+	resetAmqrcCache()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runCoopInitInternal(nil, true)
+	})
+	if err != nil {
+		t.Fatalf("runCoopInitInternal: %v", err)
+	}
+
+	if !containsStr(output, "Terminal 1: amq coop exec claude") {
+		t.Fatalf("missing Terminal 1 line for claude, output:\n%s", output)
+	}
+	if !containsStr(output, "Terminal 2: amq coop exec codex") {
+		t.Fatalf("missing Terminal 2 line for codex, output:\n%s", output)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "Terminal") && strings.Contains(line, "user") {
+			t.Fatalf("unexpected Terminal line mentioning reserved handle %q, output:\n%s", "user", output)
+		}
+	}
+}
+
+func TestCoopInitNextStepsThreeEngineAgentsSkipsUserKeepsContiguousNumbers(t *testing.T) {
+	projectDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+		resetAmqrcCache()
+	})
+	resetAmqrcCache()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runCoopInitInternal([]string{"--agents", "claude,codex,grok,user"}, true)
+	})
+	if err != nil {
+		t.Fatalf("runCoopInitInternal: %v", err)
+	}
+
+	if !containsStr(output, "Terminal 1: amq coop exec claude") {
+		t.Fatalf("missing Terminal 1 line for claude, output:\n%s", output)
+	}
+	if !containsStr(output, "Terminal 2: amq coop exec codex") {
+		t.Fatalf("missing Terminal 2 line for codex, output:\n%s", output)
+	}
+	if !containsStr(output, "Terminal 3: amq coop exec grok") {
+		t.Fatalf("missing Terminal 3 line for grok, output:\n%s", output)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "Terminal") && strings.Contains(line, "user") {
+			t.Fatalf("unexpected Terminal line mentioning reserved handle %q, output:\n%s", "user", output)
+		}
+	}
+}
+
 func TestCoopInitNoGitignore(t *testing.T) {
 	projectDir := t.TempDir()
 	oldDir, err := os.Getwd()

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -48,6 +48,7 @@ func runCoopExec(args []string) error {
 		"Examples:",
 		"  amq coop exec claude                              # Exec into Claude Code (session=collab)",
 		"  amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Codex with flags",
+		"  amq coop exec grok                                # Grok CLI, caller flags forwarded as-is",
 		"  amq coop exec --session feature-x claude          # Isolated session",
 		"  amq coop exec --root .agent-mail/auth claude      # Explicit root (no session default)",
 		"  amq coop exec --require-wake --wake-inject-mode none claude  # Zero-input wake",

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -176,7 +176,7 @@ func init() {
 			},
 		},
 		{Name: "doctor", Summary: "Verify installation and configuration", Handler: runDoctor},
-		{Name: "shell-setup", Summary: "Output shell aliases (amc/amx)", Handler: runShellSetup},
+		{Name: "shell-setup", Summary: "Output shell aliases (amc/amx/amg)", Handler: runShellSetup},
 		// Handler is nil to avoid an init cycle (runCompletion references commands).
 		// Dispatch is handled by commandHandlers in cli.go.
 		{Name: "completion", Summary: "Generate shell completions (bash, zsh, fish)"},

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -112,7 +112,7 @@ func TestTopLevelUsageLines(t *testing.T) {
 	if !containsLine(lines, "Commands:") {
 		t.Fatal("topLevelUsageLines missing Commands header")
 	}
-	if !containsLine(lines, "shell-setup  Output shell aliases (amc/amx)") {
+	if !containsLine(lines, "shell-setup  Output shell aliases (amc/amx/amg)") {
 		t.Fatal("topLevelUsageLines missing shell-setup summary")
 	}
 	if !containsLine(lines, "--no-update-check") {

--- a/internal/cli/shell_setup.go
+++ b/internal/cli/shell_setup.go
@@ -11,6 +11,7 @@ import (
 const (
 	defaultClaudeAlias = "amc"
 	defaultCodexAlias  = "amx"
+	defaultGrokAlias   = "amg"
 )
 
 func runShellSetup(args []string) error {
@@ -18,23 +19,26 @@ func runShellSetup(args []string) error {
 	shellFlag := fs.String("shell", detectShell(), "Shell format: bash, zsh, fish")
 	claudeAliasFlag := fs.String("claude-alias", defaultClaudeAlias, "Function name for Claude Code shortcut")
 	codexAliasFlag := fs.String("codex-alias", defaultCodexAlias, "Function name for Codex CLI shortcut")
+	grokAliasFlag := fs.String("grok-alias", defaultGrokAlias, "Function name for Grok CLI shortcut")
 
 	usage := usageWithFlags(fs, "amq shell-setup [options]",
 		"Outputs shell aliases for quick co-op session management.",
 		"",
-		"Defines two functions (names customizable via flags):",
+		"Defines three functions (names customizable via flags):",
 		fmt.Sprintf("  %s [session] [flags]  → amq coop exec [--session <s>] claude [flags]", defaultClaudeAlias),
 		fmt.Sprintf("  %s [session] [flags]  → amq coop exec [--session <s>] codex -- --dangerously-bypass-approvals-and-sandbox [flags]", defaultCodexAlias),
+		fmt.Sprintf("  %s [session] [flags]  → amq coop exec [--session <s>] grok [flags]", defaultGrokAlias),
 		"",
 		"Usage:",
 		"  eval \"$(amq shell-setup)\"           # Add to current shell (default names)",
 		"  amq shell-setup --shell fish         # Fish shell output",
-		"  amq shell-setup --claude-alias cc --codex-alias cx  # Custom names",
+		"  amq shell-setup --claude-alias cc --codex-alias cx --grok-alias gk  # Custom names",
 		"",
 		"Examples after setup:",
 		fmt.Sprintf("  %s                    # Start Claude Code (default session)", defaultClaudeAlias),
 		fmt.Sprintf("  %s feature-x          # Isolated session for feature-x", defaultClaudeAlias),
 		fmt.Sprintf("  %s feature-x          # Codex in same isolated session", defaultCodexAlias),
+		fmt.Sprintf("  %s feature-x          # Grok in same isolated session", defaultGrokAlias),
 	)
 
 	if handled, err := parseFlags(fs, args, usage); err != nil {
@@ -50,6 +54,7 @@ func runShellSetup(args []string) error {
 
 	claudeAlias := *claudeAliasFlag
 	codexAlias := *codexAliasFlag
+	grokAlias := *grokAliasFlag
 
 	if err := validateAliasName(claudeAlias); err != nil {
 		return err
@@ -57,8 +62,11 @@ func runShellSetup(args []string) error {
 	if err := validateAliasName(codexAlias); err != nil {
 		return err
 	}
+	if err := validateAliasName(grokAlias); err != nil {
+		return err
+	}
 
-	snippet := shellSnippet(shell, claudeAlias, codexAlias)
+	snippet := shellSnippet(shell, claudeAlias, codexAlias, grokAlias)
 	return writeStdout("%s", snippet)
 }
 
@@ -75,16 +83,16 @@ func validateAliasName(name string) error {
 	return nil
 }
 
-func shellSnippet(shell, claudeAlias, codexAlias string) string {
+func shellSnippet(shell, claudeAlias, codexAlias, grokAlias string) string {
 	switch shell {
 	case "fish":
-		return fishSnippet(claudeAlias, codexAlias)
+		return fishSnippet(claudeAlias, codexAlias, grokAlias)
 	default:
-		return posixSnippet(claudeAlias, codexAlias)
+		return posixSnippet(claudeAlias, codexAlias, grokAlias)
 	}
 }
 
-func posixSnippet(claudeAlias, codexAlias string) string {
+func posixSnippet(claudeAlias, codexAlias, grokAlias string) string {
 	return fmt.Sprintf(`# AMQ co-op aliases (added by amq shell-setup)
 function %s() {
   local session_args=()
@@ -102,10 +110,18 @@ function %s() {
   fi
   amq coop exec "${session_args[@]}" codex -- --dangerously-bypass-approvals-and-sandbox "$@"
 }
-`, claudeAlias, codexAlias)
+function %s() {
+  local session_args=()
+  if [ -n "${1:-}" ] && [ "${1#-}" = "$1" ]; then
+    session_args=(--session "$1")
+    shift
+  fi
+  amq coop exec "${session_args[@]}" grok "$@"
+}
+`, claudeAlias, codexAlias, grokAlias)
 }
 
-func fishSnippet(claudeAlias, codexAlias string) string {
+func fishSnippet(claudeAlias, codexAlias, grokAlias string) string {
 	return fmt.Sprintf(`# AMQ co-op aliases (added by amq shell-setup)
 function %s
   set -l session_args
@@ -123,7 +139,15 @@ function %s
   end
   amq coop exec $session_args codex -- --dangerously-bypass-approvals-and-sandbox $argv
 end
-`, claudeAlias, codexAlias)
+function %s
+  set -l session_args
+  if test (count $argv) -gt 0; and not string match -q -- '-*' $argv[1]
+    set session_args --session $argv[1]
+    set -e argv[1]
+  end
+  amq coop exec $session_args grok $argv
+end
+`, claudeAlias, codexAlias, grokAlias)
 }
 
 func detectShell() string {

--- a/internal/cli/shell_setup_test.go
+++ b/internal/cli/shell_setup_test.go
@@ -6,12 +6,15 @@ import (
 )
 
 func TestShellSnippetPosixDefaults(t *testing.T) {
-	snippet := posixSnippet(defaultClaudeAlias, defaultCodexAlias)
+	snippet := posixSnippet(defaultClaudeAlias, defaultCodexAlias, defaultGrokAlias)
 	if !strings.Contains(snippet, "function amc()") {
 		t.Error("posix snippet missing amc function")
 	}
 	if !strings.Contains(snippet, "function amx()") {
 		t.Error("posix snippet missing amx function")
+	}
+	if !strings.Contains(snippet, "function amg()") {
+		t.Error("posix snippet missing amg function")
 	}
 	if !strings.Contains(snippet, "--session") {
 		t.Error("posix snippet missing --session flag")
@@ -19,22 +22,38 @@ func TestShellSnippetPosixDefaults(t *testing.T) {
 }
 
 func TestShellSnippetPosixCustomNames(t *testing.T) {
-	snippet := posixSnippet("cc", "cx")
+	snippet := posixSnippet("cc", "cx", "cg")
 	if !strings.Contains(snippet, "function cc()") {
 		t.Error("posix snippet missing custom claude alias")
 	}
 	if !strings.Contains(snippet, "function cx()") {
 		t.Error("posix snippet missing custom codex alias")
 	}
+	if !strings.Contains(snippet, "function cg()") {
+		t.Error("posix snippet missing custom grok alias")
+	}
+}
+
+func TestShellSnippetPosixGrokIsBarePassthrough(t *testing.T) {
+	snippet := posixSnippet(defaultClaudeAlias, defaultCodexAlias, defaultGrokAlias)
+	if strings.Contains(snippet, "grok -- --dangerously-bypass-approvals-and-sandbox") {
+		t.Error("grok function should not bake in a permission-bypass flag")
+	}
+	if !strings.Contains(snippet, `amq coop exec "${session_args[@]}" grok "$@"`) {
+		t.Error("posix snippet missing bare grok pass-through invocation")
+	}
 }
 
 func TestShellSnippetFishDefaults(t *testing.T) {
-	snippet := fishSnippet(defaultClaudeAlias, defaultCodexAlias)
+	snippet := fishSnippet(defaultClaudeAlias, defaultCodexAlias, defaultGrokAlias)
 	if !strings.Contains(snippet, "function amc") {
 		t.Error("fish snippet missing amc function")
 	}
 	if !strings.Contains(snippet, "function amx") {
 		t.Error("fish snippet missing amx function")
+	}
+	if !strings.Contains(snippet, "function amg") {
+		t.Error("fish snippet missing amg function")
 	}
 	if !strings.Contains(snippet, "--session") {
 		t.Error("fish snippet missing --session flag")
@@ -42,12 +61,25 @@ func TestShellSnippetFishDefaults(t *testing.T) {
 }
 
 func TestShellSnippetFishCustomNames(t *testing.T) {
-	snippet := fishSnippet("cc", "cx")
+	snippet := fishSnippet("cc", "cx", "cg")
 	if !strings.Contains(snippet, "function cc") {
 		t.Error("fish snippet missing custom claude alias")
 	}
 	if !strings.Contains(snippet, "function cx") {
 		t.Error("fish snippet missing custom codex alias")
+	}
+	if !strings.Contains(snippet, "function cg") {
+		t.Error("fish snippet missing custom grok alias")
+	}
+}
+
+func TestShellSnippetFishGrokIsBarePassthrough(t *testing.T) {
+	snippet := fishSnippet(defaultClaudeAlias, defaultCodexAlias, defaultGrokAlias)
+	if strings.Contains(snippet, "grok -- --dangerously-bypass-approvals-and-sandbox") {
+		t.Error("grok function should not bake in a permission-bypass flag")
+	}
+	if !strings.Contains(snippet, "amq coop exec $session_args grok $argv") {
+		t.Error("fish snippet missing bare grok pass-through invocation")
 	}
 }
 
@@ -87,7 +119,7 @@ func TestIsValidSetupShell(t *testing.T) {
 }
 
 func TestValidateAliasName(t *testing.T) {
-	valid := []string{"amc", "amx", "cc", "my_alias", "Claude1"}
+	valid := []string{"amc", "amx", "amg", "cc", "my_alias", "Claude1"}
 	for _, name := range valid {
 		if err := validateAliasName(name); err != nil {
 			t.Errorf("validateAliasName(%q) unexpected error: %v", name, err)

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -16,7 +16,7 @@ description: >-
   (RabbitMQ, Kafka), CI/CD pipelines, or single-agent tasks with no partner.
 metadata:
   short-description: Inter-agent messaging via AMQ CLI
-  compatibility: claude-code, codex-cli
+  compatibility: claude-code, codex-cli, grok-cli
 ---
 
 # AMQ CLI Skill
@@ -114,6 +114,7 @@ amq coop init
 # Per-session (one command per terminal — defaults to --session collab)
 amq coop exec claude -- --dangerously-skip-permissions  # Terminal 1
 amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Terminal 2
+amq coop exec grok  # Terminal 3 (optional peer) — caller flags forwarded unchanged, no baked-in bypass
 ```
 
 Without `--session` or `--root`, `coop exec` defaults to `--session collab`.
@@ -346,6 +347,7 @@ amq drain --session auth --include-body           # Deliberate sibling-session r
 amq reply --id <msg_id> --body "Response"          # Reply in thread
 amq watch --timeout 60s                           # Block until message arrives
 amq list --new                                    # Peek without side effects
+amq send --to grok --body "hello"                 # Grok is a normal peer handle, like codex or claude
 ```
 
 ### Send with metadata

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -6,7 +6,7 @@
 - **Leader/Coordinator** = coordinates phases, merges, and final decisions (often the initiator).
 - **Worker** = executes assigned phases and reports back to the initiator.
 
-**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator.
+**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator. Grok CLI can join as an additional optional peer/worker (e.g. a third `amq coop exec grok` in a three-way session) without changing this default two-engine pairing note.
 
 ## Phased Flow
 


### PR DESCRIPTION
## Summary

- add a default `amg` shell helper and configurable `--grok-alias` output for POSIX shells and fish
- support launching bare `grok` through `amq coop exec` while forwarding caller flags unchanged
- document Grok as an optional AMQ peer, including explicit `claude,codex,grok,user` initialization and Grok skill discovery paths
- update the AMQ CLI skill compatibility and examples for Grok CLI
- render every configured non-`user` agent in `amq coop init` next steps, so Grok appears as Terminal 3

## Why

Issue #218 asks for first-class Grok CLI discoverability while preserving AMQ's handle-centric model and existing Claude/Codex/user defaults.

The next-steps renderer also assumed exactly two launchable agents by printing only the first two configured handles. The follow-up commit replaces that assumption with generic enumeration while excluding the reserved human handle.

## Behavior

The default coop roster remains `claude,codex,user`. Grok stays opt-in:

```bash
amq coop init --agents claude,codex,grok,user
amq coop exec grok
```

No permission mode is baked into the Grok launcher. Caller flags are passed through unchanged.

## Validation

- `git diff --check`
- `gofmt` checks
- `go vet ./...`
- focused coop, shell-setup, registry, and next-steps tests
- `go test ./...`
- built-binary stdout smokes for default, three-engine, and reserved-user-middle rosters
- live Grok CLI 0.2.93 AMQ drain/reply round trip on macOS arm64
- live wake notification to idle Grok, same-thread reply, and drained receipts in both directions
- independent QA of both reviewed candidate digests with no findings

Local `make ci` reached the lint step but the installed golangci-lint v1.64.8 cannot parse the repository's v2 configuration. The remaining vet, test, smoke, and focused checks passed; repository CI uses the current golangci-lint action.

## Scope notes

- no change to the default coop agent roster
- no Grok-specific core protocol, swarm engine type, message kinds, or permission enum
- no manual skill or plugin version bump

Refs #218
