### PR TITLE
Fix exact wake-mode compatibility

### DIFF
--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -124,8 +124,8 @@ createLock:
 	if options.target != nil {
 		lock.WakeMode = wakeTargetInjectVia
 		lock.TargetDigest = wakeTargetDigest(*options.target)
-	} else if options.wakeMode == wakeInjectModeNone {
-		lock.WakeMode = wakeInjectModeNone
+	} else {
+		lock.WakeMode = options.wakeMode
 	}
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
@@ -243,8 +243,11 @@ func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string) e
 	if !inspection.Exists || inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
 		return fmt.Errorf("existing wake lock for %s is not a confirmed valid wake", inspection.Agent)
 	}
-	if requiredMode == wakeInjectModeNone && inspection.Lock.WakeMode != wakeInjectModeNone {
-		return fmt.Errorf("existing wake for %s cannot satisfy requested --inject-mode none; stop the existing wake and retry", inspection.Agent)
+	if inspection.Lock.WakeMode != requiredMode {
+		if requiredMode == wakeInjectModeNone {
+			return fmt.Errorf("existing wake for %s cannot satisfy requested --inject-mode none; stop the existing wake and retry", inspection.Agent)
+		}
+		return fmt.Errorf("existing wake for %s cannot satisfy requested wake mode %q (existing %q); stop the existing wake and retry", inspection.Agent, requiredMode, inspection.Lock.WakeMode)
 	}
 	if !wakeLockHasUsableNotificationPath(inspection) {
 		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
@@ -261,7 +264,7 @@ func wakeLockHasUsableNotificationPath(inspection wakeLockInspection) bool {
 	if inspection.Lock.WakeMode == wakeInjectModeNone {
 		return true
 	}
-	if inspection.Lock.WakeMode == wakeTargetInjectVia || wakeArgsUseInjectVia(inspection.Process.Args) {
+	if (inspection.Lock.WakeMode == wakeTargetInjectVia && inspection.Lock.TargetDigest != "") || wakeArgsUseInjectVia(inspection.Process.Args) {
 		return true
 	}
 	tty := strings.TrimSpace(inspection.Lock.TTY)
@@ -786,10 +789,16 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 
 	// Acquire lock to prevent duplicate wake processes
 	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
+	lockWakeMode := injectMode
+	if target != nil {
+		lockWakeMode = wakeTargetInjectVia
+	} else if lockWakeMode != wakeInjectModeNone {
+		lockWakeMode = effectiveInjectMode(&wakeConfig{me: me, injectMode: lockWakeMode})
+	}
 	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
 		acceptExistingValid: acceptExistingWake,
 		target:              target,
-		wakeMode:            injectMode,
+		wakeMode:            lockWakeMode,
 	})
 	if err != nil {
 		var alreadyRunning *wakeAlreadyRunningError

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -583,6 +583,7 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeTargetInjectVia,
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
@@ -692,6 +693,35 @@ func TestRunWakeWithLoopNoneAcceptsExistingNoneWake(t *testing.T) {
 	}
 }
 
+func TestRequireWakeLockUsableRejectsNoneForNonNone(t *testing.T) {
+	inspection := wakeLockInspection{
+		Exists:            true,
+		Status:            wakeLockValid,
+		IdentityConfirmed: true,
+		Agent:             "codex",
+		Lock:              wakeLock{WakeMode: wakeInjectModeNone, TTY: "test-tty"},
+	}
+	if err := requireWakeLockUsable(inspection, wakeInjectModeRaw); err == nil {
+		t.Fatal("expected a none wake to be rejected for raw mode")
+	}
+}
+
+func TestRequireWakeLockUsableRawVsPaste(t *testing.T) {
+	inspection := wakeLockInspection{
+		Exists:            true,
+		Status:            wakeLockValid,
+		IdentityConfirmed: true,
+		Agent:             "codex",
+		Lock:              wakeLock{WakeMode: wakeInjectModeRaw, TTY: "test-tty"},
+	}
+	if err := requireWakeLockUsable(inspection, wakeInjectModePaste); err == nil {
+		t.Fatal("expected raw and paste wakes to be incompatible")
+	}
+	if err := requireWakeLockUsable(inspection, wakeInjectModeRaw); err != nil {
+		t.Fatalf("expected matching raw wake to be usable: %v", err)
+	}
+}
+
 func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 	const wakePID = 4242
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
@@ -714,6 +744,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeTargetInjectVia,
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
@@ -772,6 +803,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsBlankOrUnknownTTY(t *testing.T)
 				ProcessStart: "start-1",
 				BootID:       "boot-1",
 				Executable:   "/opt/homebrew/bin/amq",
+				WakeMode:     wakeTargetInjectVia,
 			})
 
 			readyPath := filepath.Join(t.TempDir(), "wake.ready")
@@ -882,6 +914,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *test
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeTargetInjectVia,
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")


### PR DESCRIPTION
## Summary

Persist the normalized wake injection mode in every wake lock and require exact mode compatibility when `--accept-existing-wake` reuses a live wake.

## Why

An existing `none` wake could satisfy a requested raw/paste wake, and raw/paste/auto modes were not persisted, so exact compatibility could not be enforced. This is the narrow prerequisite identified in #235.

## Scope

- Persist `none`, `raw`, `paste`, the effective auto mode, and `inject-via` in the lock.
- Reject `none` for non-`none` requests.
- Reject raw/paste mismatches.
- Add regression coverage for both compatibility cases.

This PR deliberately does not reintroduce `amq wake retire`; PID-reuse-safe signaling, tri-state inspection, and atomic lifecycle work remain outside this change.

## Validation

- `go test ./...`
- `go test ./internal/cli`
