### PR TITLE
fix(cli): clarify Grok skill discovery docs and coop next-steps hint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ amq wake --me <agent> [--inject-cmd <cmd>] [--inject-via <absolute-executable>] 
 amq wake repair --me <agent> [--root <path>] [--json]
 amq upgrade
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--json]
-amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>]
+amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>] [--grok-alias <name>]
 amq coop init [--root <path>] [--agents <a,b,c>] [--force] [--json]
 amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-gitignore] [--no-wake] [--require-wake] [--wake-inject-via <absolute-executable>] [--wake-inject-arg <arg>...] [-y] <command> [-- <command-flags>]
 amq swarm list [--json]

--- a/COOP.md
+++ b/COOP.md
@@ -36,10 +36,14 @@ For swarm command reference, see [CLAUDE.md](CLAUDE.md).
    See [INSTALL.md](INSTALL.md) for manual installation or troubleshooting.
 
    If pairing with Grok CLI as an optional peer, Grok discovers skills the
-   same general way Claude Code and Codex CLI do: from a project-local
-   `.grok/skills` directory, a user-level `~/.grok/skills` directory,
-   installed plugin skills, and any explicitly configured skill paths. See
-   [INSTALL.md](INSTALL.md) for the manual `~/.grok/skills` copy example.
+   same general way Claude Code and Codex CLI do. Native locations include a
+   project-local `.grok/skills` directory, a user-level `~/.grok/skills`
+   directory, installed plugin skills, and explicitly configured skill paths;
+   Grok also reads Claude-compatible skill locations plus the user-level
+   `~/.agents/skills` directory — see the
+   [xAI skill discovery docs](https://docs.x.ai/build/features/skills-plugins-marketplaces)
+   for the authoritative list. See [INSTALL.md](INSTALL.md) for the manual
+   `~/.grok/skills` copy example.
 
 ### Running Co-op Mode
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,7 @@ mkdir -p ~/.grok/skills
 cp -r /tmp/amq/.agents/skills/amq-cli ~/.grok/skills/
 rm -rf /tmp/amq
 ```
-A project-local copy under `.grok/skills/amq-cli` in the repo works the same way if you prefer per-project installs. See [COOP.md](COOP.md) for the full list of paths Grok CLI checks.
+A project-local copy under `.grok/skills/amq-cli` in the repo works the same way if you prefer per-project installs. Inside a checkout of this repository, Grok discovers the bundled `.claude/skills/amq-cli` through its Claude Code compatibility with no copying at all; it also supports user-level `~/.agents/skills`. See the [xAI skill discovery docs](https://docs.x.ai/build/features/skills-plugins-marketplaces) for the authoritative list of paths Grok CLI checks.
 
 Restart your agent after installing.
 

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -221,6 +221,9 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 			}
 			terminalNum++
 		}
+		if err := writeStdoutLine("  (handle = command basename; custom handle: amq coop exec --me <handle> <command>)"); err != nil {
+			return err
+		}
 		if err := writeStdoutLine(""); err != nil {
 			return err
 		}

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -301,6 +301,9 @@ func TestCoopInitNextStepsDefaultAgentsSkipsUser(t *testing.T) {
 	if !containsStr(output, "Terminal 2: amq coop exec codex") {
 		t.Fatalf("missing Terminal 2 line for codex, output:\n%s", output)
 	}
+	if !containsStr(output, "custom handle: amq coop exec --me <handle> <command>") {
+		t.Fatalf("missing custom-handle hint line, output:\n%s", output)
+	}
 	for _, line := range strings.Split(output, "\n") {
 		if strings.Contains(line, "Terminal") && strings.Contains(line, "user") {
 			t.Fatalf("unexpected Terminal line mentioning reserved handle %q, output:\n%s", "user", output)


### PR DESCRIPTION
## Summary

Follow-up polish to #240, from the joint claude+codex review (all three agreed findings):

- **COOP.md / INSTALL.md**: the Grok skill-path enumeration was presented as the full list, but the [official xAI docs](https://docs.x.ai/build/features/skills-plugins-marketplaces) also list Claude-compatible skill locations and user-level `~/.agents/skills`. Qualified the native list, linked the authoritative docs, and noted that a checkout of this repo exposes `.claude/skills/amq-cli` to Grok via Claude Code compatibility with no copying.
- **CLAUDE.md**: the shell-setup reference line was missing the new `--grok-alias` flag.
- **coop init next steps**: the terminal enumeration recommends `amq coop exec <handle>` for every non-`user` handle, which conflates mailbox handles with executable names for custom rosters (pre-existing before #240). Added a one-line hint pointing at `amq coop exec --me <handle> <command>`.

## Validation

- `make ci` clean in the working tree
- codex peer review: PASS on the exact diff (verified wording against the live xAI docs page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)