### PR TITLE
docs(coop): link amq-keepalive companion in supervisor recipes

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -354,6 +354,14 @@ For the consumer plist, replace the command arguments after the executable with
 Route stdout/stderr to supervisor-managed logs and secure the unit/plist for the
 local user who owns the mailbox.
 
+If you prefer a supervisor that follows explicitly registered terminal sessions
+instead of fixed plists, [amq-keepalive](https://github.com/ohade/amq-keepalive)
+is a standalone companion tool that implements this recipe for macOS: it keeps a
+registry of attached terminal targets (Ghostty, cmux), reattaches `wake` after
+reboot or sleep through a user LaunchAgent, and can install SessionStart
+reattach hooks for Claude Code and Codex. It follows the same daemon-free
+contract and talks to AMQ only through the public `amq` CLI.
+
 **Options:**
 - `--inject-mode auto|raw|paste|none` - Injection strategy; `none` enforces zero terminal input
 - `--wake-inject-mode auto|raw|paste|none` - `coop exec` pass-through for its managed wake


### PR DESCRIPTION
Docs only. I added a short pointer in the Supervisor recipes section to [amq-keepalive](https://github.com/ohade/amq-keepalive), a standalone companion I built for the macOS side of this recipe. It keeps `wake` attached to explicitly registered terminal targets (Ghostty and cmux adapters), reattaches after reboot or sleep via a user LaunchAgent, and can install SessionStart reattach hooks for Claude Code and Codex.

It sticks to the daemon-free contract this section describes, meaning it never parses AMQ mailbox, lock, or presence state and only talks to AMQ through the public CLI (target-aware `amq wake`, `amq env --json`).

If you'd rather keep external tool links out of the docs, feel free to close, I'll keep it as a personal tool.