### PR TITLE
feat(keepalive): add amq-keepalive, a terminal-session wake supervisor for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /amq
+/amq-keepalive
 /.agent-mail/
 /bin/
 /dist/

--- a/COOP.md
+++ b/COOP.md
@@ -354,6 +354,23 @@ For the consumer plist, replace the command arguments after the executable with
 Route stdout/stderr to supervisor-managed logs and secure the unit/plist for the
 local user who owns the mailbox.
 
+On macOS, `amq-keepalive` (built from `cmd/amq-keepalive`) packages this recipe
+for wake delivery that must follow a specific terminal session rather than a
+fixed plist. It keeps a private registry of explicitly attached terminal
+targets (Ghostty and cmux adapters), reattaches `wake` after reboot or sleep
+through a user LaunchAgent (`install-launchd`), and can register SessionStart
+reattach hooks for Claude Code and Codex (`install-hook`). It stays inside the
+daemon-free contract: the OS supervises it, it never parses AMQ mailbox, lock,
+presence, or target files, and it talks to AMQ only through the public `amq`
+CLI (target-aware `amq wake`, `amq env --json`).
+
+```bash
+go build ./cmd/amq-keepalive
+./amq-keepalive attach --adapter ghostty --me claude
+./amq-keepalive install-launchd
+./amq-keepalive doctor
+```
+
 **Options:**
 - `--inject-mode auto|raw|paste|none` - Injection strategy; `none` enforces zero terminal input
 - `--wake-inject-mode auto|raw|paste|none` - `coop exec` pass-through for its managed wake

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOLANGCI_LINT_CACHE ?= $(CURDIR)/.golangci-cache
 
 build:
 	go build -ldflags "-X main.version=$(VERSION)" -o amq ./cmd/amq
+	go build -o amq-keepalive ./cmd/amq-keepalive
 
 test:
 	go test ./...

--- a/cmd/amq-keepalive/main.go
+++ b/cmd/amq-keepalive/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/app"
+)
+
+func main() {
+	os.Exit(app.App{}.Run(context.Background(), os.Args[1:]))
+}

--- a/internal/keepalive/adapter/adapter.go
+++ b/internal/keepalive/adapter/adapter.go
@@ -1,0 +1,47 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var ErrTargetNotFound = errors.New("adapter target not found")
+
+type Adapter interface {
+	Name() string
+	Probe(ctx context.Context, target string) error
+	Inject(ctx context.Context, target string, payload string) error
+}
+
+type Discoverer interface {
+	Discover(ctx context.Context) (string, error)
+}
+
+type TargetNormalizer interface {
+	NormalizeTarget(target string) (string, error)
+}
+
+type Registry struct {
+	adapters map[string]Adapter
+}
+
+func NewRegistry(adapters ...Adapter) Registry {
+	out := Registry{adapters: map[string]Adapter{}}
+	for _, adapter := range adapters {
+		out.adapters[adapter.Name()] = adapter
+	}
+	return out
+}
+
+func DefaultRegistry() Registry {
+	return NewRegistry(File{}, Ghostty{}, Cmux{})
+}
+
+func (r Registry) Get(name string) (Adapter, error) {
+	adapter, ok := r.adapters[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown adapter %q", name)
+	}
+	return adapter, nil
+}

--- a/internal/keepalive/adapter/cmux.go
+++ b/internal/keepalive/adapter/cmux.go
@@ -1,0 +1,278 @@
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	cmuxSurfaceTargetPrefix = "cmux:surface:"
+	defaultCmuxSettleDelay  = 150 * time.Millisecond
+)
+
+type Cmux struct {
+	Runner       CommandRunner
+	Path         string
+	Getenv       func(string) string
+	LookPath     func(string) (string, error)
+	UserHomeDir  func() (string, error)
+	IsExecutable func(string) bool
+	Sleep        func(context.Context, time.Duration) error
+	SettleDelay  time.Duration
+}
+
+func (Cmux) Name() string {
+	return "cmux"
+}
+
+func (c Cmux) Discover(_ context.Context) (string, error) {
+	if err := requireCmuxPlatform(); err != nil {
+		return "", err
+	}
+	id, err := normalizeCmuxSurfaceID(c.getenv("CMUX_SURFACE_ID"))
+	if err != nil {
+		return "", fmt.Errorf("discover cmux surface from CMUX_SURFACE_ID: %w", err)
+	}
+	return cmuxSurfaceTargetPrefix + id, nil
+}
+
+func (Cmux) NormalizeTarget(target string) (string, error) {
+	id, err := parseCmuxSurfaceTarget(target)
+	if err != nil {
+		return "", err
+	}
+	return cmuxSurfaceTargetPrefix + id, nil
+}
+
+func (c Cmux) Probe(ctx context.Context, target string) error {
+	if err := requireCmuxPlatform(); err != nil {
+		return err
+	}
+	id, err := parseCmuxSurfaceTarget(target)
+	if err != nil {
+		return err
+	}
+	params, err := json.Marshal(map[string]any{
+		"lines":      1,
+		"surface_id": id,
+	})
+	if err != nil {
+		return fmt.Errorf("encode cmux probe parameters: %w", err)
+	}
+	path, err := c.executable()
+	if err != nil {
+		return err
+	}
+	out, err := c.runner().Run(ctx, path, "rpc", "surface.read_text", string(params))
+	if err != nil {
+		message := strings.TrimSpace(string(out))
+		if strings.Contains(message, "not_found:") && strings.Contains(message, "Workspace not found") {
+			return fmt.Errorf("%w: probe cmux target %q: %v: %s", ErrTargetNotFound, target, err, message)
+		}
+		return fmt.Errorf("probe cmux target %q: %w: %s", target, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func (c Cmux) Inject(ctx context.Context, target string, payload string) error {
+	if err := requireCmuxPlatform(); err != nil {
+		return err
+	}
+	id, err := parseCmuxSurfaceTarget(target)
+	if err != nil {
+		return err
+	}
+	path, err := c.executable()
+	if err != nil {
+		return err
+	}
+
+	payload = sanitizePayloadForSubmit(payload)
+	textParams, err := json.Marshal(map[string]string{
+		"surface_id": id,
+		"text":       payload,
+	})
+	if err != nil {
+		return fmt.Errorf("encode cmux text parameters: %w", err)
+	}
+	if out, err := c.runner().Run(ctx, path, "rpc", "surface.send_text", string(textParams)); err != nil {
+		return fmt.Errorf("inject text into cmux target %q: %w: %s", target, err, strings.TrimSpace(string(out)))
+	}
+
+	if err := c.sleep(ctx, c.settleDelay()); err != nil {
+		return fmt.Errorf("wait before submitting cmux target %q: %w", target, err)
+	}
+
+	keyParams, err := json.Marshal(map[string]string{
+		"key":        "enter",
+		"surface_id": id,
+	})
+	if err != nil {
+		return fmt.Errorf("encode cmux key parameters: %w", err)
+	}
+	if out, err := c.runner().Run(ctx, path, "rpc", "surface.send_key", string(keyParams)); err != nil {
+		return fmt.Errorf("submit cmux target %q: %w: %s", target, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func (c Cmux) runner() CommandRunner {
+	if c.Runner != nil {
+		return c.Runner
+	}
+	return ExecRunner{}
+}
+
+func (c Cmux) executable() (string, error) {
+	if strings.TrimSpace(c.Path) != "" {
+		return filepath.Clean(strings.TrimSpace(c.Path)), nil
+	}
+	if override := strings.TrimSpace(c.getenv("AMQ_KEEPALIVE_CMUX")); override != "" {
+		path, err := c.resolveCandidate(override)
+		if err != nil {
+			return "", fmt.Errorf("resolve AMQ_KEEPALIVE_CMUX: %w", err)
+		}
+		return path, nil
+	}
+	if bundled := strings.TrimSpace(c.getenv("CMUX_BUNDLED_CLI_PATH")); bundled != "" && c.isExecutable(bundled) {
+		return filepath.Clean(bundled), nil
+	}
+	if path, err := c.lookPath("cmux"); err == nil {
+		return filepath.Clean(path), nil
+	}
+
+	candidates := []string{"/Applications/cmux.app/Contents/Resources/bin/cmux"}
+	if home, err := c.userHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		candidates = append(candidates, filepath.Join(home, "Applications", "cmux.app", "Contents", "Resources", "bin", "cmux"))
+	}
+	for _, candidate := range candidates {
+		if c.isExecutable(candidate) {
+			return filepath.Clean(candidate), nil
+		}
+	}
+	return "", fmt.Errorf("cmux CLI not found; set AMQ_KEEPALIVE_CMUX or install the bundled CLI at %s", candidates[0])
+}
+
+func (c Cmux) resolveCandidate(candidate string) (string, error) {
+	if filepath.IsAbs(candidate) || strings.ContainsRune(candidate, filepath.Separator) {
+		if !c.isExecutable(candidate) {
+			return "", fmt.Errorf("%q is not an executable file", candidate)
+		}
+		return filepath.Clean(candidate), nil
+	}
+	path, err := c.lookPath(candidate)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(path), nil
+}
+
+func (c Cmux) getenv(key string) string {
+	if c.Getenv != nil {
+		return c.Getenv(key)
+	}
+	return os.Getenv(key)
+}
+
+func (c Cmux) lookPath(file string) (string, error) {
+	if c.LookPath != nil {
+		return c.LookPath(file)
+	}
+	return exec.LookPath(file)
+}
+
+func (c Cmux) userHomeDir() (string, error) {
+	if c.UserHomeDir != nil {
+		return c.UserHomeDir()
+	}
+	return os.UserHomeDir()
+}
+
+func (c Cmux) isExecutable(path string) bool {
+	if c.IsExecutable != nil {
+		return c.IsExecutable(path)
+	}
+	return isExecutableFile(path)
+}
+
+func (c Cmux) sleep(ctx context.Context, delay time.Duration) error {
+	if c.Sleep != nil {
+		return c.Sleep(ctx, delay)
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (c Cmux) settleDelay() time.Duration {
+	if c.SettleDelay < 0 {
+		return 0
+	}
+	if c.SettleDelay == 0 {
+		return defaultCmuxSettleDelay
+	}
+	return c.SettleDelay
+}
+
+func requireCmuxPlatform() error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("cmux adapter requires macOS, got %s", runtime.GOOS)
+	}
+	return nil
+}
+
+func parseCmuxSurfaceTarget(target string) (string, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", errors.New("cmux adapter target is required")
+	}
+	id, ok := strings.CutPrefix(target, cmuxSurfaceTargetPrefix)
+	if !ok {
+		return "", fmt.Errorf("unsupported cmux target %q; reattach required: run reattach --adapter cmux from the target surface", target)
+	}
+	id, err := normalizeCmuxSurfaceID(id)
+	if err != nil {
+		return "", fmt.Errorf("invalid cmux surface target: %w", err)
+	}
+	return strings.ToUpper(id), nil
+}
+
+func normalizeCmuxSurfaceID(id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", errors.New("cmux surface id is empty")
+	}
+	if len(id) != 36 {
+		return "", fmt.Errorf("cmux surface id %q is not a UUID", id)
+	}
+	for i, r := range id {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if r != '-' {
+				return "", fmt.Errorf("cmux surface id %q is not a UUID", id)
+			}
+			continue
+		}
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return "", fmt.Errorf("cmux surface id %q is not a UUID", id)
+		}
+	}
+	return id, nil
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0
+}

--- a/internal/keepalive/adapter/cmux_test.go
+++ b/internal/keepalive/adapter/cmux_test.go
@@ -1,0 +1,230 @@
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testCmuxSurfaceID = "F901D722-6789-4BBB-9818-C4E97F20BEB3"
+
+func TestCmuxDiscoverUsesExactSurfaceID(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	adapter := Cmux{Getenv: func(key string) string {
+		if key == "CMUX_SURFACE_ID" {
+			return testCmuxSurfaceID
+		}
+		return ""
+	}}
+	target, err := adapter.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if want := "cmux:surface:" + testCmuxSurfaceID; target != want {
+		t.Fatalf("target = %q, want %q", target, want)
+	}
+}
+
+func TestCmuxDiscoverRejectsMissingSurfaceID(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	_, err := (Cmux{Getenv: func(string) string { return "" }}).Discover(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "CMUX_SURFACE_ID") {
+		t.Fatalf("Discover() error = %v, want CMUX_SURFACE_ID guidance", err)
+	}
+}
+
+func TestParseCmuxSurfaceTargetRequiresUUID(t *testing.T) {
+	id, err := parseCmuxSurfaceTarget(" cmux:surface:" + testCmuxSurfaceID + " ")
+	if err != nil {
+		t.Fatalf("parseCmuxSurfaceTarget() error = %v", err)
+	}
+	if id != testCmuxSurfaceID {
+		t.Fatalf("id = %q, want %q", id, testCmuxSurfaceID)
+	}
+	for _, target := range []string{"cmux:surface:", "cmux:surface:surface:2", "ghostty:terminal:abc"} {
+		if _, err := parseCmuxSurfaceTarget(target); err == nil {
+			t.Fatalf("parseCmuxSurfaceTarget(%q) error = nil, want error", target)
+		}
+	}
+}
+
+func TestCmuxNormalizeTargetCanonicalizesUUIDCase(t *testing.T) {
+	got, err := (Cmux{}).NormalizeTarget("cmux:surface:f901d722-6789-4bbb-9818-c4e97f20beb3")
+	if err != nil {
+		t.Fatalf("NormalizeTarget() error = %v", err)
+	}
+	if want := "cmux:surface:" + testCmuxSurfaceID; got != want {
+		t.Fatalf("target = %q, want %q", got, want)
+	}
+}
+
+func TestCmuxProbeUsesRawRPCForExactSurface(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte(`{"ok":true}`)}
+	err := (Cmux{Runner: runner, Path: "/fake/cmux"}).Probe(context.Background(), "cmux:surface:"+testCmuxSurfaceID)
+	if err != nil {
+		t.Fatalf("Probe() error = %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(runner.calls))
+	}
+	call := runner.calls[0]
+	if call.name != "/fake/cmux" || len(call.args) != 3 || call.args[0] != "rpc" || call.args[1] != "surface.read_text" {
+		t.Fatalf("call = %#v, want raw surface.read_text RPC", call)
+	}
+	var params map[string]any
+	if err := json.Unmarshal([]byte(call.args[2]), &params); err != nil {
+		t.Fatalf("probe params are not JSON: %v", err)
+	}
+	if params["surface_id"] != testCmuxSurfaceID || params["lines"] != float64(1) {
+		t.Fatalf("probe params = %#v, want exact surface and one line", params)
+	}
+}
+
+func TestCmuxProbeClassifiesMissingWorkspace(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{
+		output: []byte("Error: not_found: Workspace not found"),
+		err:    errors.New("exit status 1"),
+	}
+	err := (Cmux{Runner: runner, Path: "/fake/cmux"}).Probe(context.Background(), "cmux:surface:"+testCmuxSurfaceID)
+	if !errors.Is(err, ErrTargetNotFound) {
+		t.Fatalf("Probe() error = %v, want ErrTargetNotFound", err)
+	}
+}
+
+func TestCmuxProbeDoesNotClassifyGenericFailureAsMissing(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte("cmux daemon unavailable"), err: errors.New("exit status 1")}
+	err := (Cmux{Runner: runner, Path: "/fake/cmux"}).Probe(context.Background(), "cmux:surface:"+testCmuxSurfaceID)
+	if err == nil || errors.Is(err, ErrTargetNotFound) {
+		t.Fatalf("Probe() error = %v, want non-missing failure", err)
+	}
+}
+
+func TestCmuxInjectUsesRawRPCThenSettlesAndSendsEnter(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{}
+	var delays []time.Duration
+	adapter := Cmux{
+		Runner: runner,
+		Path:   "/fake/cmux",
+		Sleep: func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			return nil
+		},
+	}
+	payload := `AMQ subject contains literal \n and --flags` + "\nsecond line\r\n"
+	if err := adapter.Inject(context.Background(), "cmux:surface:"+testCmuxSurfaceID, payload); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(runner.calls))
+	}
+	textCall := runner.calls[0]
+	if textCall.name != "/fake/cmux" || textCall.args[0] != "rpc" || textCall.args[1] != "surface.send_text" {
+		t.Fatalf("text call = %#v, want raw surface.send_text RPC", textCall)
+	}
+	var textParams map[string]string
+	if err := json.Unmarshal([]byte(textCall.args[2]), &textParams); err != nil {
+		t.Fatalf("text params are not JSON: %v", err)
+	}
+	if got, want := textParams["text"], `AMQ subject contains literal \n and --flags`+"\nsecond line"; got != want {
+		t.Fatalf("text = %q, want exact %q", got, want)
+	}
+	if textParams["surface_id"] != testCmuxSurfaceID {
+		t.Fatalf("surface_id = %q, want %q", textParams["surface_id"], testCmuxSurfaceID)
+	}
+	if len(delays) != 1 || delays[0] != defaultCmuxSettleDelay {
+		t.Fatalf("delays = %v, want [%s]", delays, defaultCmuxSettleDelay)
+	}
+	keyCall := runner.calls[1]
+	if keyCall.args[0] != "rpc" || keyCall.args[1] != "surface.send_key" {
+		t.Fatalf("key call = %#v, want raw surface.send_key RPC", keyCall)
+	}
+	var keyParams map[string]string
+	if err := json.Unmarshal([]byte(keyCall.args[2]), &keyParams); err != nil {
+		t.Fatalf("key params are not JSON: %v", err)
+	}
+	if keyParams["surface_id"] != testCmuxSurfaceID || keyParams["key"] != "enter" {
+		t.Fatalf("key params = %#v, want exact surface enter", keyParams)
+	}
+}
+
+func TestCmuxInjectDoesNotSendEnterWhenTextFails(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte("surface unavailable"), err: errors.New("exit status 1")}
+	adapter := Cmux{Runner: runner, Path: "/fake/cmux"}
+	err := adapter.Inject(context.Background(), "cmux:surface:"+testCmuxSurfaceID, "payload")
+	if err == nil || !strings.Contains(err.Error(), "surface unavailable") {
+		t.Fatalf("Inject() error = %v, want command output", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls = %d, want failed text call only", len(runner.calls))
+	}
+}
+
+func TestCmuxExecutablePrefersBundledEnvironmentPath(t *testing.T) {
+	dir := t.TempDir()
+	bundled := filepath.Join(dir, "cmux")
+	if err := os.WriteFile(bundled, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatalf("write bundled CLI: %v", err)
+	}
+	adapter := Cmux{
+		Getenv: func(key string) string {
+			if key == "CMUX_BUNDLED_CLI_PATH" {
+				return bundled
+			}
+			return ""
+		},
+		LookPath: func(string) (string, error) {
+			return "", errors.New("not found")
+		},
+	}
+	got, err := adapter.executable()
+	if err != nil {
+		t.Fatalf("executable() error = %v", err)
+	}
+	if got != bundled {
+		t.Fatalf("executable = %q, want bundled %q", got, bundled)
+	}
+}
+
+func TestCmuxExecutableFallsBackToApplicationBundleWithoutPATH(t *testing.T) {
+	dir := t.TempDir()
+	bundled := filepath.Join(dir, "Applications", "cmux.app", "Contents", "Resources", "bin", "cmux")
+	if err := os.MkdirAll(filepath.Dir(bundled), 0o700); err != nil {
+		t.Fatalf("mkdir bundled CLI: %v", err)
+	}
+	if err := os.WriteFile(bundled, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatalf("write bundled CLI: %v", err)
+	}
+	adapter := Cmux{
+		Getenv: func(string) string { return "" },
+		LookPath: func(string) (string, error) {
+			return "", errors.New("not found")
+		},
+		UserHomeDir:  func() (string, error) { return dir, nil },
+		IsExecutable: func(path string) bool { return path == bundled },
+	}
+	got, err := adapter.executable()
+	if err != nil {
+		t.Fatalf("executable() error = %v", err)
+	}
+	if got != bundled {
+		t.Fatalf("executable = %q, want user bundle %q", got, bundled)
+	}
+}
+
+func skipCmuxNonDarwin(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		t.Skip("cmux adapter requires macOS")
+	}
+}

--- a/internal/keepalive/adapter/file.go
+++ b/internal/keepalive/adapter/file.go
@@ -1,0 +1,59 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type File struct{}
+
+func (File) Name() string {
+	return "file"
+}
+
+func (File) Probe(ctx context.Context, target string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if target == "" {
+		return errors.New("file adapter target is required")
+	}
+	clean := filepath.Clean(target)
+	parent := filepath.Dir(clean)
+	info, err := os.Stat(parent)
+	if err != nil {
+		return fmt.Errorf("target parent is not reachable: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("target parent %q is not a directory", parent)
+	}
+	targetInfo, err := os.Stat(clean)
+	if err == nil && targetInfo.IsDir() {
+		return fmt.Errorf("target %q is a directory", clean)
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (File) Inject(ctx context.Context, target string, payload string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := (File{}).Probe(ctx, target); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(filepath.Clean(target), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.WriteString(payload + "\n"); err != nil {
+		return err
+	}
+	return file.Chmod(0o600)
+}

--- a/internal/keepalive/adapter/file_test.go
+++ b/internal/keepalive/adapter/file_test.go
@@ -1,0 +1,46 @@
+package adapter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileAdapterInjectsPayloads(t *testing.T) {
+	ctx := context.Background()
+	target := filepath.Join(t.TempDir(), "inbox.txt")
+	file := File{}
+
+	if err := file.Probe(ctx, target); err != nil {
+		t.Fatalf("Probe() error = %v", err)
+	}
+	if err := file.Inject(ctx, target, "first"); err != nil {
+		t.Fatalf("Inject(first) error = %v", err)
+	}
+	if err := file.Inject(ctx, target, "second"); err != nil {
+		t.Fatalf("Inject(second) error = %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if got, want := string(data), "first\nsecond\n"; got != want {
+		t.Fatalf("payloads = %q, want %q", got, want)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("file mode = %v, want 0600", got)
+	}
+}
+
+func TestFileAdapterRejectsDirectoryTarget(t *testing.T) {
+	ctx := context.Background()
+	target := t.TempDir()
+	if err := (File{}).Probe(ctx, target); err == nil {
+		t.Fatal("Probe(directory) error = nil, want error")
+	}
+}

--- a/internal/keepalive/adapter/ghostty.go
+++ b/internal/keepalive/adapter/ghostty.go
@@ -1,0 +1,146 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type ExecRunner struct{}
+
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+type Ghostty struct {
+	Runner CommandRunner
+}
+
+const ghosttyTerminalTargetPrefix = "ghostty:terminal:"
+
+func (Ghostty) Name() string {
+	return "ghostty"
+}
+
+func (g Ghostty) Discover(ctx context.Context) (string, error) {
+	if err := requireDarwin(); err != nil {
+		return "", err
+	}
+	out, err := g.runner().Run(ctx, "osascript", "-e", ghosttyDiscoverScript)
+	if err != nil {
+		return "", fmt.Errorf("discover Ghostty terminal: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	id := strings.TrimSpace(string(out))
+	if id == "" {
+		return "", errors.New("discover Ghostty terminal: empty terminal id")
+	}
+	return ghosttyTerminalTargetPrefix + id, nil
+}
+
+func (g Ghostty) Probe(ctx context.Context, target string) error {
+	if err := requireDarwin(); err != nil {
+		return err
+	}
+	id, err := parseGhosttyTerminalTarget(target)
+	if err != nil {
+		return err
+	}
+	out, err := g.runner().Run(ctx, "osascript", "-e", ghosttyProbeScript, id)
+	if err != nil {
+		return fmt.Errorf("probe Ghostty target %q: %w: %s", target, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func (g Ghostty) Inject(ctx context.Context, target string, payload string) error {
+	if err := requireDarwin(); err != nil {
+		return err
+	}
+	id, err := parseGhosttyTerminalTarget(target)
+	if err != nil {
+		return err
+	}
+	payload = sanitizePayloadForSubmit(payload)
+	out, err := g.runner().Run(ctx, "osascript", "-e", ghosttyInjectScript, id, payload)
+	if err != nil {
+		return fmt.Errorf("inject into Ghostty target %q: %w: %s", target, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func (g Ghostty) runner() CommandRunner {
+	if g.Runner != nil {
+		return g.Runner
+	}
+	return ExecRunner{}
+}
+
+func requireDarwin() error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("ghostty adapter requires macOS, got %s", runtime.GOOS)
+	}
+	return nil
+}
+
+func parseGhosttyTerminalTarget(target string) (string, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", errors.New("ghostty adapter target is required")
+	}
+	id, ok := strings.CutPrefix(target, ghosttyTerminalTargetPrefix)
+	if !ok {
+		return "", fmt.Errorf("unsupported Ghostty target %q; reattach required: run reattach --adapter ghostty to register a terminal-id target", target)
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", errors.New("ghostty terminal target is missing an id")
+	}
+	return id, nil
+}
+
+func sanitizePayloadForSubmit(payload string) string {
+	return strings.TrimRight(payload, "\r\n")
+}
+
+const ghosttyDiscoverScript = `
+tell application "Ghostty"
+	if (count of terminals) is 0 then error "Ghostty has no terminals"
+	return id of focused terminal of selected tab of front window
+end tell
+`
+
+const ghosttyProbeScript = `
+on run argv
+	set targetID to item 1 of argv
+	tell application "Ghostty"
+		set matches to terminals whose id is targetID
+		set matchCount to count of matches
+		if matchCount is 1 then return "ok"
+		if matchCount is 0 then error "no Ghostty terminal with id: " & targetID
+		error "ambiguous Ghostty terminal id: " & targetID
+	end tell
+end run
+`
+
+const ghosttyInjectScript = `
+on run argv
+	set targetID to item 1 of argv
+	set payload to item 2 of argv
+	tell application "Ghostty"
+		set matches to terminals whose id is targetID
+		set matchCount to count of matches
+		if matchCount is 0 then error "no Ghostty terminal with id: " & targetID
+		if matchCount is greater than 1 then error "ambiguous Ghostty terminal id: " & targetID
+		set targetTerminal to item 1 of matches
+		input text payload to targetTerminal
+		send key "enter" to targetTerminal
+	end tell
+end run
+`

--- a/internal/keepalive/adapter/ghostty_test.go
+++ b/internal/keepalive/adapter/ghostty_test.go
@@ -1,0 +1,161 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type fakeCommandRunner struct {
+	output []byte
+	err    error
+	calls  []commandCall
+}
+
+type commandCall struct {
+	name string
+	args []string
+}
+
+func (f *fakeCommandRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, commandCall{name: name, args: append([]string{}, args...)})
+	return f.output, f.err
+}
+
+func TestGhosttyDiscoverReturnsTerminalTarget(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte("BEDE3893-CE56-4309-8AEC-3D930F11225D\n")}
+	target, err := (Ghostty{Runner: runner}).Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if target != "ghostty:terminal:BEDE3893-CE56-4309-8AEC-3D930F11225D" {
+		t.Fatalf("target = %q, want terminal id target", target)
+	}
+	if len(runner.calls) != 1 || runner.calls[0].name != "osascript" {
+		t.Fatalf("calls = %#v, want one osascript call", runner.calls)
+	}
+}
+
+func TestParseGhosttyTerminalTarget(t *testing.T) {
+	id, err := parseGhosttyTerminalTarget(" ghostty:terminal:terminal-1 ")
+	if err != nil {
+		t.Fatalf("parseGhosttyTerminalTarget() error = %v", err)
+	}
+	if id != "terminal-1" {
+		t.Fatalf("id = %q, want terminal-1", id)
+	}
+}
+
+func TestParseGhosttyTerminalTargetRejectsOldTitleTargets(t *testing.T) {
+	_, err := parseGhosttyTerminalTarget("Team Alpha")
+	if err == nil {
+		t.Fatal("parseGhosttyTerminalTarget(old title) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "reattach") {
+		t.Fatalf("error = %v, want reattach guidance", err)
+	}
+}
+
+func TestParseGhosttyTerminalTargetRejectsEmptyID(t *testing.T) {
+	_, err := parseGhosttyTerminalTarget("ghostty:terminal:")
+	if err == nil {
+		t.Fatal("parseGhosttyTerminalTarget(empty id) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "missing an id") {
+		t.Fatalf("error = %v, want missing id", err)
+	}
+}
+
+func TestGhosttyProbePassesTerminalIDAsArgument(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte("ok\n")}
+	err := (Ghostty{Runner: runner}).Probe(context.Background(), "ghostty:terminal:terminal-1")
+	if err != nil {
+		t.Fatalf("Probe() error = %v", err)
+	}
+	call := runner.calls[0]
+	if got := call.args[len(call.args)-1]; got != "terminal-1" {
+		t.Fatalf("last osascript arg = %q, want terminal id", got)
+	}
+}
+
+func TestGhosttyInjectPassesTerminalIDAndPayloadAsArguments(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{}
+	payload := "AMQ [team-upgrader_v3]: message from claude\nline two"
+	err := (Ghostty{Runner: runner}).Inject(context.Background(), "ghostty:terminal:terminal-1", payload)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	call := runner.calls[0]
+	if got := call.args[len(call.args)-2]; got != "terminal-1" {
+		t.Fatalf("target arg = %q, want terminal id", got)
+	}
+	if got := call.args[len(call.args)-1]; got != payload {
+		t.Fatalf("payload arg = %q, want payload", got)
+	}
+	if !strings.Contains(call.args[1], "input text payload to targetTerminal") {
+		t.Fatalf("script does not use native Ghostty input: %q", call.args[1])
+	}
+	if !strings.Contains(call.args[1], `send key "enter" to targetTerminal`) {
+		t.Fatalf("script does not send enter to target terminal: %q", call.args[1])
+	}
+	for _, disallowed := range []string{"System Events", "the clipboard", "keystroke", "AXRaise", "activate"} {
+		if strings.Contains(call.args[1], disallowed) {
+			t.Fatalf("script still uses %q: %q", disallowed, call.args[1])
+		}
+	}
+}
+
+func TestGhosttyInjectTrimsTrailingLineBreaksBeforeEnter(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{}
+	payload := "AMQ [team-upgrader_v3]: message from claude\nline two\r\n\n"
+	err := (Ghostty{Runner: runner}).Inject(context.Background(), "ghostty:terminal:terminal-1", payload)
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	call := runner.calls[0]
+	if got, want := call.args[len(call.args)-1], "AMQ [team-upgrader_v3]: message from claude\nline two"; got != want {
+		t.Fatalf("payload arg = %q, want %q", got, want)
+	}
+}
+
+func TestGhosttyScriptsFailClosedOnTerminalIDs(t *testing.T) {
+	for name, script := range map[string]string{
+		"probe":  ghosttyProbeScript,
+		"inject": ghosttyInjectScript,
+	} {
+		if !strings.Contains(script, "matchCount") {
+			t.Fatalf("%s script does not count matching terminals", name)
+		}
+		if !strings.Contains(script, "no Ghostty terminal with id") {
+			t.Fatalf("%s script does not fail on missing target", name)
+		}
+		if !strings.Contains(script, "ambiguous Ghostty terminal id") {
+			t.Fatalf("%s script does not fail on duplicate target", name)
+		}
+	}
+}
+
+func TestGhosttyErrorsIncludeCommandOutput(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte("accessibility denied"), err: errors.New("exit status 1")}
+	err := (Ghostty{Runner: runner}).Probe(context.Background(), "ghostty:terminal:terminal-1")
+	if err == nil {
+		t.Fatal("Probe() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "accessibility denied") {
+		t.Fatalf("error = %v, want command output", err)
+	}
+}
+
+func skipNonDarwin(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		t.Skip("Ghostty adapter uses macOS Accessibility")
+	}
+}

--- a/internal/keepalive/amq/runner.go
+++ b/internal/keepalive/amq/runner.go
@@ -1,0 +1,291 @@
+package amq
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var ErrAlreadyRunning = errors.New("amq wake already running")
+
+const defaultWakeReadyTimeout = 10 * time.Second
+
+type Env struct {
+	SchemaVersion int               `json:"schema_version"`
+	AMQVersion    string            `json:"amq_version"`
+	Root          string            `json:"root"`
+	BaseRoot      string            `json:"base_root"`
+	SessionName   string            `json:"session_name"`
+	InSession     bool              `json:"in_session"`
+	Me            string            `json:"me"`
+	Project       string            `json:"project"`
+	RootSource    string            `json:"root_source"`
+	Peers         map[string]string `json:"peers"`
+	Shell         string            `json:"shell"`
+}
+
+type WakeRepairResult struct {
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+type WakeRetireResult struct {
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+	Agent  string `json:"agent,omitempty"`
+	Root   string `json:"root,omitempty"`
+	PID    int    `json:"pid,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (r WakeRepairResult) Text() string {
+	return strings.TrimSpace(strings.Join([]string{r.Status, r.Reason, r.Message, r.Error}, " "))
+}
+
+type StartWakeRequest struct {
+	Root      string
+	Me        string
+	InjectVia string
+	Adapter   string
+	Target    string
+	Timeout   time.Duration
+}
+
+type RetireWakeRequest struct {
+	Root      string
+	Me        string
+	InjectVia string
+	Adapter   string
+	Target    string
+}
+
+type CLI struct {
+	Path string
+}
+
+func NewCLI(path string) CLI {
+	if path == "" {
+		path = "amq"
+	}
+	return CLI{Path: path}
+}
+
+func (c CLI) Env(ctx context.Context) (Env, error) {
+	stdout, stderr, err := c.run(ctx, "env", "--json")
+	if err != nil {
+		return Env{}, fmt.Errorf("amq env failed: %w: %s", err, strings.TrimSpace(stderr))
+	}
+	var env Env
+	if err := json.Unmarshal(stdout, &env); err != nil {
+		return Env{}, fmt.Errorf("parse amq env: %w", err)
+	}
+	return env, nil
+}
+
+func (c CLI) RepairWake(ctx context.Context, root, me string) (WakeRepairResult, error) {
+	args := []string{"wake", "repair", "-json"}
+	if root != "" {
+		args = append(args, "-root", root)
+	}
+	if me != "" {
+		args = append(args, "-me", me)
+	}
+	stdout, stderr, err := c.run(ctx, args...)
+	result, parseErr := parseWakeRepair(stdout)
+	if parseErr != nil {
+		if err != nil {
+			return WakeRepairResult{
+				Status: "error",
+				Error:  strings.TrimSpace(strings.Join([]string{err.Error(), stderr}, ": ")),
+			}, err
+		}
+		return WakeRepairResult{}, parseErr
+	}
+	if result.Error == "" && len(stderr) > 0 {
+		result.Error = strings.TrimSpace(stderr)
+	}
+	return result, err
+}
+
+func (c CLI) RetireWake(ctx context.Context, req RetireWakeRequest) (WakeRetireResult, error) {
+	if req.InjectVia == "" {
+		return WakeRetireResult{}, errors.New("inject-via executable is required")
+	}
+	if req.Adapter == "" {
+		return WakeRetireResult{}, errors.New("adapter is required")
+	}
+	if req.Target == "" {
+		return WakeRetireResult{}, errors.New("target is required")
+	}
+	args := []string{"wake", "retire", "-json"}
+	if req.Root != "" {
+		args = append(args, "-root", req.Root)
+	}
+	if req.Me != "" {
+		args = append(args, "-me", req.Me)
+	}
+	args = append(args,
+		"-inject-via", req.InjectVia,
+		"-inject-arg", "inject",
+		"-inject-arg", req.Adapter,
+		"-inject-arg", req.Target,
+	)
+	stdout, stderr, err := c.run(ctx, args...)
+	var result WakeRetireResult
+	if parseErr := json.Unmarshal(stdout, &result); parseErr != nil {
+		if err != nil {
+			return WakeRetireResult{Status: "error", Error: strings.TrimSpace(stderr)},
+				fmt.Errorf("amq wake retire failed: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		return WakeRetireResult{}, fmt.Errorf("parse amq wake retire: %w", parseErr)
+	}
+	if result.Error == "" && len(stderr) > 0 {
+		result.Error = strings.TrimSpace(stderr)
+	}
+	if err != nil {
+		return result, fmt.Errorf("amq wake retire failed: %w: %s", err, strings.TrimSpace(stderr))
+	}
+	return result, nil
+}
+
+func (c CLI) StartWake(ctx context.Context, req StartWakeRequest) error {
+	if req.InjectVia == "" {
+		return errors.New("inject-via executable is required")
+	}
+	if req.Adapter == "" {
+		return errors.New("adapter is required")
+	}
+	if req.Target == "" {
+		return errors.New("target is required")
+	}
+
+	args := []string{"wake"}
+	readyDir, err := os.MkdirTemp("", "amq-keepalive-wake-*")
+	if err != nil {
+		return fmt.Errorf("create wake readiness directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(readyDir) }()
+	readyFile := filepath.Join(readyDir, "ready")
+
+	if req.Root != "" {
+		args = append(args, "-root", req.Root)
+	}
+	if req.Me != "" {
+		args = append(args, "-me", req.Me)
+	}
+	args = append(args,
+		"-inject-via", req.InjectVia,
+		"-inject-arg", "inject",
+		"-inject-arg", req.Adapter,
+		"-inject-arg", req.Target,
+		"--accept-existing-wake",
+		"-ready-file", readyFile,
+	)
+
+	cmd := exec.CommandContext(ctx, c.Path, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "already") {
+			return ErrAlreadyRunning
+		}
+		return err
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	if processDone, err := waitForWakeReady(ctx, done, readyFile, req.Timeout); err != nil {
+		if !processDone && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			<-done
+		}
+		return err
+	}
+	return nil
+}
+
+func (c CLI) run(ctx context.Context, args ...string) ([]byte, string, error) {
+	cmd := exec.CommandContext(ctx, c.Path, args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.String(), err
+}
+
+func parseWakeRepair(data []byte) (WakeRepairResult, error) {
+	var result WakeRepairResult
+	if len(bytes.TrimSpace(data)) == 0 {
+		return WakeRepairResult{}, errors.New("empty amq wake repair output")
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		var raw map[string]any
+		if rawErr := json.Unmarshal(data, &raw); rawErr != nil {
+			return WakeRepairResult{}, err
+		}
+		result.Status = stringField(raw, "status")
+		result.Reason = stringField(raw, "reason")
+		result.Message = stringField(raw, "message")
+		result.Error = stringField(raw, "error")
+	}
+	result.Status = strings.TrimSpace(result.Status)
+	return result, nil
+}
+
+func waitForWakeReady(ctx context.Context, done <-chan error, readyFile string, timeout time.Duration) (bool, error) {
+	if timeout <= 0 {
+		timeout = defaultWakeReadyTimeout
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if wakeReadyFileExists(readyFile) {
+			return false, nil
+		}
+		select {
+		case err := <-done:
+			if wakeReadyFileExists(readyFile) {
+				return true, nil
+			}
+			if err == nil {
+				return true, errors.New("amq wake exited before becoming ready")
+			}
+			if strings.Contains(strings.ToLower(err.Error()), "already") {
+				return true, ErrAlreadyRunning
+			}
+			return true, fmt.Errorf("amq wake exited before becoming ready: %w", err)
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-timer.C:
+			return false, fmt.Errorf("timed out after %s waiting for amq wake readiness", timeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+func wakeReadyFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func stringField(raw map[string]any, key string) string {
+	value, ok := raw[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}

--- a/internal/keepalive/amq/runner_test.go
+++ b/internal/keepalive/amq/runner_test.go
@@ -1,0 +1,161 @@
+package amq
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartWakeWaitsForReadyFileAndPassesTarget(t *testing.T) {
+	dir := t.TempDir()
+	argsLog := filepath.Join(dir, "args.log")
+	t.Setenv("AMQ_KEEPALIVE_ARGS_LOG", argsLog)
+	fakeAMQ := writeExecutable(t, filepath.Join(dir, "amq"), `#!/bin/sh
+printf '%s\n' "$@" > "$AMQ_KEEPALIVE_ARGS_LOG"
+ready=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-ready-file" ]; then
+    ready="$arg"
+  fi
+  previous="$arg"
+done
+if [ -z "$ready" ]; then
+  exit 11
+fi
+printf ready > "$ready"
+`)
+
+	err := NewCLI(fakeAMQ).StartWake(context.Background(), StartWakeRequest{
+		Root:      "/tmp/amq-root",
+		Me:        "codex",
+		InjectVia: "/tmp/amq-keepalive",
+		Adapter:   "ghostty",
+		Target:    "ghostty:terminal:abc",
+		Timeout:   5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("StartWake() error = %v", err)
+	}
+	data, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read args log: %v", err)
+	}
+	args := string(data)
+	for _, want := range []string{
+		"wake\n",
+		"-root\n/tmp/amq-root\n",
+		"-me\ncodex\n",
+		"-inject-via\n/tmp/amq-keepalive\n",
+		"-inject-arg\ninject\n",
+		"-inject-arg\nghostty\n",
+		"-inject-arg\nghostty:terminal:abc\n",
+		"--accept-existing-wake\n",
+		"-ready-file\n",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("args log missing %q:\n%s", want, args)
+		}
+	}
+}
+
+func TestStartWakeFailsWhenProcessExitsBeforeReady(t *testing.T) {
+	dir := t.TempDir()
+	fakeAMQ := writeExecutable(t, filepath.Join(dir, "amq"), `#!/bin/sh
+exit 7
+`)
+
+	err := NewCLI(fakeAMQ).StartWake(context.Background(), StartWakeRequest{
+		Root:      "/tmp/amq-root",
+		Me:        "codex",
+		InjectVia: "/tmp/amq-keepalive",
+		Adapter:   "ghostty",
+		Target:    "ghostty:terminal:abc",
+		Timeout:   5 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("StartWake() error = nil, want readiness failure")
+	}
+	if !strings.Contains(err.Error(), "amq wake exited before becoming ready") {
+		t.Fatalf("error = %v, want readiness failure", err)
+	}
+}
+
+func TestRetireWakePassesExactSavedTargetIdentity(t *testing.T) {
+	dir := t.TempDir()
+	argsLog := filepath.Join(dir, "args.log")
+	t.Setenv("AMQ_KEEPALIVE_ARGS_LOG", argsLog)
+	fakeAMQ := writeExecutable(t, filepath.Join(dir, "amq"), `#!/bin/sh
+printf '%s\n' "$@" > "$AMQ_KEEPALIVE_ARGS_LOG"
+printf '%s\n' '{"status":"retired","agent":"codex","root":"/tmp/amq-root","pid":4242}'
+`)
+
+	result, err := NewCLI(fakeAMQ).RetireWake(context.Background(), RetireWakeRequest{
+		Root:      "/tmp/amq-root",
+		Me:        "codex",
+		InjectVia: "/tmp/amq-keepalive",
+		Adapter:   "cmux",
+		Target:    "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3",
+	})
+	if err != nil {
+		t.Fatalf("RetireWake() error = %v", err)
+	}
+	if result.Status != "retired" || result.PID != 4242 {
+		t.Fatalf("result = %#v", result)
+	}
+	data, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read args log: %v", err)
+	}
+	args := string(data)
+	for _, want := range []string{
+		"wake\nretire\n-json\n",
+		"-root\n/tmp/amq-root\n",
+		"-me\ncodex\n",
+		"-inject-via\n/tmp/amq-keepalive\n",
+		"-inject-arg\ninject\n",
+		"-inject-arg\ncmux\n",
+		"-inject-arg\ncmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3\n",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("args log missing %q:\n%s", want, args)
+		}
+	}
+}
+
+func TestStartWakeTimesOutWhenReadyFileNeverAppears(t *testing.T) {
+	dir := t.TempDir()
+	fakeAMQ := writeExecutable(t, filepath.Join(dir, "amq"), `#!/bin/sh
+sleep 10
+`)
+
+	start := time.Now()
+	err := NewCLI(fakeAMQ).StartWake(context.Background(), StartWakeRequest{
+		Root:      "/tmp/amq-root",
+		Me:        "codex",
+		InjectVia: "/tmp/amq-keepalive",
+		Adapter:   "ghostty",
+		Target:    "ghostty:terminal:abc",
+		Timeout:   500 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("StartWake() error = nil, want readiness timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %v, want timeout", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("StartWake took %s, want timeout branch to return promptly", elapsed)
+	}
+}
+
+func writeExecutable(t *testing.T, path string, body string) string {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	return path
+}

--- a/internal/keepalive/app/app.go
+++ b/internal/keepalive/app/app.go
@@ -1,0 +1,685 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/adapter"
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/amq"
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/hookinstall"
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/launchd"
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/registry"
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/supervisor"
+)
+
+type App struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func (a App) Run(ctx context.Context, args []string) int {
+	if a.Stdout == nil {
+		a.Stdout = os.Stdout
+	}
+	if a.Stderr == nil {
+		a.Stderr = os.Stderr
+	}
+	if len(args) == 0 {
+		a.usage(a.Stderr)
+		return 2
+	}
+
+	var err error
+	switch args[0] {
+	case "-h", "--help", "help":
+		a.usage(a.Stdout)
+		return 0
+	case "attach":
+		err = a.attach(ctx, args[1:])
+	case "reattach":
+		err = a.reattach(ctx, args[1:])
+	case "supervise":
+		err = a.supervise(ctx, args[1:])
+	case "inject":
+		err = a.inject(ctx, args[1:])
+	case "doctor":
+		err = a.doctor(args[1:])
+	case "retire-session":
+		err = a.retireSession(ctx, args[1:])
+	case "forget":
+		err = a.forget(args[1:])
+	case "install-launchd":
+		err = a.installLaunchd(ctx, args[1:])
+	case "install-hook":
+		err = a.installHook(args[1:])
+	case "uninstall":
+		err = a.uninstallLaunchd(ctx, args[1:])
+	default:
+		_, _ = fmt.Fprintf(a.Stderr, "unknown command %q\n", args[0])
+		a.usage(a.Stderr)
+		return 2
+	}
+	if err != nil {
+		_, _ = fmt.Fprintln(a.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+type registerOptions struct {
+	RegistryPath string
+	AdapterName  string
+	Target       string
+	Root         string
+	BaseRoot     string
+	SessionName  string
+	Me           string
+	AMQPath      string
+	Self         string
+	WakeTimeout  time.Duration
+	NoStart      bool
+	Replace      bool
+}
+
+type registerResult struct {
+	Entry          registry.Entry   `json:"entry"`
+	RemovedEntries []registry.Entry `json:"removed_entries,omitempty"`
+}
+
+func (a App) attach(ctx context.Context, args []string) error {
+	return a.register(ctx, args, false)
+}
+
+func (a App) reattach(ctx context.Context, args []string) error {
+	return a.register(ctx, args, true)
+}
+
+func (a App) register(ctx context.Context, args []string, replace bool) error {
+	commandName := "attach"
+	if replace {
+		commandName = "reattach"
+	}
+	fs := flag.NewFlagSet(commandName, flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	registryPath := fs.String("registry", mustDefaultRegistryPath(), "registry file path")
+	adapterName := fs.String("adapter", "file", "adapter name")
+	target := fs.String("target", "", "adapter target")
+	root := fs.String("root", "", "AMQ root")
+	baseRoot := fs.String("base-root", "", "AMQ base root")
+	sessionName := fs.String("session", "", "AMQ session name")
+	me := fs.String("me", "", "AMQ agent handle")
+	amqPath := fs.String("amq", "amq", "amq executable path")
+	self := fs.String("self", executablePath(), "amq-keepalive executable path for --inject-via")
+	wakeTimeout := fs.Duration("wake-ready-timeout", 10*time.Second, "maximum time to wait for amq wake readiness")
+	noStart := fs.Bool("no-start", false, "register without starting/reconciling wake")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return a.registerWithOptions(ctx, registerOptions{
+		RegistryPath: *registryPath,
+		AdapterName:  *adapterName,
+		Target:       *target,
+		Root:         *root,
+		BaseRoot:     *baseRoot,
+		SessionName:  *sessionName,
+		Me:           *me,
+		AMQPath:      *amqPath,
+		Self:         *self,
+		WakeTimeout:  *wakeTimeout,
+		NoStart:      *noStart,
+		Replace:      replace,
+	})
+}
+
+func (a App) registerWithOptions(ctx context.Context, opts registerOptions) error {
+	envCLI := amq.NewCLI(opts.AMQPath)
+	if opts.Root == "" || opts.Me == "" || opts.BaseRoot == "" || opts.SessionName == "" {
+		env, err := envCLI.Env(ctx)
+		if err != nil && (opts.Root == "" || opts.Me == "") {
+			return err
+		}
+		if opts.Root == "" {
+			opts.Root = env.Root
+		}
+		if opts.BaseRoot == "" {
+			opts.BaseRoot = env.BaseRoot
+		}
+		if opts.SessionName == "" {
+			opts.SessionName = env.SessionName
+		}
+		if opts.Me == "" {
+			opts.Me = env.Me
+		}
+	}
+	opts.Root, opts.BaseRoot = normalizeAMQPaths(opts.Root, opts.BaseRoot, opts.SessionName)
+
+	adapters := adapter.DefaultRegistry()
+	selected, err := adapters.Get(opts.AdapterName)
+	if err != nil {
+		return err
+	}
+	if opts.Target == "" {
+		discoverer, ok := selected.(adapter.Discoverer)
+		if !ok {
+			return errors.New("--target is required")
+		}
+		discovered, err := discoverer.Discover(ctx)
+		if err != nil {
+			return err
+		}
+		opts.Target = discovered
+	}
+	if normalizer, ok := selected.(adapter.TargetNormalizer); ok {
+		normalized, err := normalizer.NormalizeTarget(opts.Target)
+		if err != nil {
+			return err
+		}
+		opts.Target = normalized
+	}
+	if err := selected.Probe(ctx, opts.Target); err != nil {
+		return err
+	}
+
+	store := registry.New(opts.RegistryPath)
+	next := registry.Entry{
+		Root:        opts.Root,
+		BaseRoot:    opts.BaseRoot,
+		SessionName: opts.SessionName,
+		Agent:       opts.Me,
+		Adapter:     opts.AdapterName,
+		Target:      opts.Target,
+		State:       registry.StateAttached,
+	}
+	reconciler := supervisor.Reconciler{
+		Wake:        envCLI,
+		Adapter:     selected,
+		InjectVia:   opts.Self,
+		WakeTimeout: opts.WakeTimeout,
+	}
+
+	if opts.Replace {
+		if !opts.NoStart {
+			updated, result := reconciler.StartFresh(ctx, next)
+			if result.Error != nil {
+				return result.Error
+			}
+			next = updated
+		}
+		entry, removed, err := store.ReplaceSessionAdapter(next)
+		if err != nil {
+			return err
+		}
+		return printJSON(a.Stdout, registerResult{Entry: entry, RemovedEntries: removed})
+	}
+
+	entry, err := store.Upsert(next)
+	if err != nil {
+		return err
+	}
+	if !opts.NoStart {
+		updated, result := reconciler.Reconcile(ctx, entry)
+		if updateErr := store.UpdateEntry(updated); updateErr != nil {
+			return updateErr
+		}
+		entry = updated
+		if result.Error != nil && result.Action != supervisor.ActionDetached {
+			return result.Error
+		}
+	}
+	return printJSON(a.Stdout, entry)
+}
+
+func (a App) supervise(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("supervise", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	registryPath := fs.String("registry", mustDefaultRegistryPath(), "registry file path")
+	amqPath := fs.String("amq", "amq", "amq executable path")
+	self := fs.String("self", executablePath(), "amq-keepalive executable path for --inject-via")
+	once := fs.Bool("once", false, "run one supervisor pass")
+	interval := fs.Duration("interval", 10*time.Second, "supervisor interval")
+	wakeTimeout := fs.Duration("wake-ready-timeout", 10*time.Second, "maximum time to wait for amq wake readiness")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	runOnce := func() error {
+		return a.superviseOnce(ctx, *registryPath, amq.NewCLI(*amqPath), *self, *wakeTimeout)
+	}
+	if *once {
+		return runOnce()
+	}
+	for {
+		if err := runOnce(); err != nil {
+			_, _ = fmt.Fprintln(a.Stderr, err)
+		}
+		timer := time.NewTimer(*interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (a App) superviseOnce(ctx context.Context, registryPath string, wake supervisor.WakeRunner, self string, wakeTimeout time.Duration) error {
+	store := registry.New(registryPath)
+	file, err := store.Load()
+	if err != nil {
+		return err
+	}
+	adapters := adapter.DefaultRegistry()
+	results := make([]supervisor.Result, 0, len(file.Entries))
+	for _, entry := range file.Entries {
+		previous := entry
+		selected, err := adapters.Get(entry.Adapter)
+		if err != nil {
+			entry.LastError = err.Error()
+			entry.LastSupervisorDecision = supervisor.ActionBackoff
+			entry.State = registry.StateAttached
+			if updateErr := store.UpdateEntry(entry); updateErr != nil {
+				return updateErr
+			}
+			result := supervisor.Result{Action: supervisor.ActionBackoff, Error: err}
+			a.warnReconcileFailure(previous, entry, result)
+			results = append(results, result)
+			continue
+		}
+		reconciler := supervisor.Reconciler{
+			Wake:        wake,
+			Adapter:     selected,
+			InjectVia:   self,
+			WakeTimeout: wakeTimeout,
+		}
+		updated, result := reconciler.Reconcile(ctx, entry)
+		if err := store.UpdateEntry(updated); err != nil {
+			return err
+		}
+		a.warnReconcileFailure(previous, updated, result)
+		results = append(results, result)
+	}
+	return printJSON(a.Stdout, results)
+}
+
+func (a App) warnReconcileFailure(previous, updated registry.Entry, result supervisor.Result) {
+	if result.Error == nil {
+		return
+	}
+	switch result.Action {
+	case supervisor.ActionBackoff, supervisor.ActionDetached, supervisor.ActionStartFailed:
+	default:
+		return
+	}
+	if previous.State == updated.State &&
+		previous.LastError == updated.LastError &&
+		previous.LastSupervisorDecision == updated.LastSupervisorDecision &&
+		previous.FailureCount == updated.FailureCount {
+		return
+	}
+	w := a.Stderr
+	if w == nil {
+		w = os.Stderr
+	}
+	_, _ = fmt.Fprintf(w,
+		"amq-keepalive reconcile warning: action=%s root=%q agent=%q adapter=%q target=%q failure_count=%d error=%q\n",
+		result.Action,
+		updated.Root,
+		updated.Agent,
+		updated.Adapter,
+		updated.Target,
+		updated.FailureCount,
+		result.Error.Error(),
+	)
+}
+
+func (a App) inject(ctx context.Context, args []string) error {
+	if len(args) != 3 {
+		return errors.New("usage: amq-keepalive inject <adapter> <target> <payload>")
+	}
+	adapters := adapter.DefaultRegistry()
+	selected, err := adapters.Get(args[0])
+	if err != nil {
+		return err
+	}
+	return selected.Inject(ctx, args[1], args[2])
+}
+
+func (a App) doctor(args []string) error {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	registryPath := fs.String("registry", mustDefaultRegistryPath(), "registry file path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	store := registry.New(*registryPath)
+	file, err := store.Load()
+	if err != nil {
+		return err
+	}
+	return printJSON(a.Stdout, file)
+}
+
+func (a App) forget(args []string) error {
+	fs := flag.NewFlagSet("forget", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	registryPath := fs.String("registry", mustDefaultRegistryPath(), "registry file path")
+	id := fs.String("id", "", "registry entry id")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *id == "" {
+		return errors.New("--id is required")
+	}
+	store := registry.New(*registryPath)
+	removed, err := store.Forget(*id)
+	if err != nil {
+		return err
+	}
+	return printJSON(a.Stdout, map[string]any{"removed": removed})
+}
+
+type retiredSessionEntry struct {
+	ID     string `json:"id"`
+	Agent  string `json:"agent"`
+	Target string `json:"target"`
+	Status string `json:"status"`
+	PID    int    `json:"pid,omitempty"`
+}
+
+type retireSessionResult struct {
+	Root    string                `json:"root"`
+	Adapter string                `json:"adapter"`
+	Entries []retiredSessionEntry `json:"entries"`
+}
+
+func (a App) retireSession(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("retire-session", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	registryPath := fs.String("registry", mustDefaultRegistryPath(), "registry file path")
+	rootFlag := fs.String("root", "", "exact AMQ session root")
+	adapterName := fs.String("adapter", "cmux", "adapter name")
+	agentsFlag := fs.String("agents", "codex,claude", "comma-separated required agent handles")
+	amqPath := fs.String("amq", "amq", "amq executable path")
+	self := fs.String("self", executablePath(), "amq-keepalive executable path used by the wake")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*rootFlag) == "" {
+		return errors.New("--root is required")
+	}
+	root, err := canonicalExistingPath(*rootFlag)
+	if err != nil {
+		return fmt.Errorf("resolve --root: %w", err)
+	}
+	agents, err := parseRequiredAgents(*agentsFlag)
+	if err != nil {
+		return err
+	}
+
+	store := registry.New(*registryPath)
+	file, err := store.Load()
+	if err != nil {
+		return err
+	}
+	entries := make([]registry.Entry, 0, len(agents))
+	for _, agent := range agents {
+		matches := make([]registry.Entry, 0, 1)
+		for _, entry := range file.Entries {
+			entryRoot, pathErr := canonicalExistingPath(entry.Root)
+			if pathErr != nil {
+				continue
+			}
+			if entryRoot == root && entry.Adapter == *adapterName && entry.Agent == agent {
+				matches = append(matches, entry)
+			}
+		}
+		if len(matches) != 1 {
+			return fmt.Errorf("expected exactly one %s registry entry for agent %s at %s, found %d", *adapterName, agent, root, len(matches))
+		}
+		entries = append(entries, matches[0])
+	}
+
+	adapters := adapter.DefaultRegistry()
+	selected, err := adapters.Get(*adapterName)
+	if err != nil {
+		return err
+	}
+	for i := range entries {
+		entry := &entries[i]
+		if normalizer, ok := selected.(adapter.TargetNormalizer); ok {
+			normalized, normalizeErr := normalizer.NormalizeTarget(entry.Target)
+			if normalizeErr != nil {
+				return fmt.Errorf("normalize target for %s: %w", entry.Agent, normalizeErr)
+			}
+			entry.Target = normalized
+		}
+		probeErr := selected.Probe(ctx, entry.Target)
+		if probeErr == nil {
+			return fmt.Errorf("refusing to retire %s wake: adapter target %s still exists", entry.Agent, entry.Target)
+		}
+		if !errors.Is(probeErr, adapter.ErrTargetNotFound) {
+			return fmt.Errorf("refusing to retire %s wake because target absence is not proven: %w", entry.Agent, probeErr)
+		}
+	}
+
+	cli := amq.NewCLI(*amqPath)
+	result := retireSessionResult{Root: root, Adapter: *adapterName}
+	forgetRetired := func() error {
+		ids := make([]string, 0, len(result.Entries))
+		for _, entry := range result.Entries {
+			ids = append(ids, entry.ID)
+		}
+		if len(ids) == 0 {
+			return nil
+		}
+		removed, forgetErr := store.ForgetMany(ids)
+		if forgetErr != nil {
+			return forgetErr
+		}
+		if removed != len(ids) {
+			return fmt.Errorf("removed %d, want %d", removed, len(ids))
+		}
+		return nil
+	}
+	for _, entry := range entries {
+		retired, retireErr := cli.RetireWake(ctx, amq.RetireWakeRequest{
+			Root:      root,
+			Me:        entry.Agent,
+			InjectVia: *self,
+			Adapter:   entry.Adapter,
+			Target:    entry.Target,
+		})
+		if retireErr != nil {
+			if forgetErr := forgetRetired(); forgetErr != nil {
+				return fmt.Errorf("retire %s wake: %v; also failed to forget already-retired entries: %w", entry.Agent, retireErr, forgetErr)
+			}
+			return fmt.Errorf("retire %s wake: %w", entry.Agent, retireErr)
+		}
+		if retired.Status != "retired" {
+			if forgetErr := forgetRetired(); forgetErr != nil {
+				return fmt.Errorf("retire %s wake returned unexpected status %q; also failed to forget already-retired entries: %w", entry.Agent, retired.Status, forgetErr)
+			}
+			return fmt.Errorf("retire %s wake returned unexpected status %q", entry.Agent, retired.Status)
+		}
+		result.Entries = append(result.Entries, retiredSessionEntry{
+			ID: entry.ID, Agent: entry.Agent, Target: entry.Target, Status: retired.Status, PID: retired.PID,
+		})
+	}
+	if err := forgetRetired(); err != nil {
+		return fmt.Errorf("forget retired session registry entries: %w", err)
+	}
+	return printJSON(a.Stdout, result)
+}
+
+func canonicalExistingPath(path string) (string, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		return real, nil
+	}
+	return abs, nil
+}
+
+func parseRequiredAgents(raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	agents := make([]string, 0, len(parts))
+	seen := map[string]bool{}
+	for _, part := range parts {
+		agent := strings.TrimSpace(part)
+		if agent == "" {
+			return nil, errors.New("--agents must contain non-empty handles")
+		}
+		if seen[agent] {
+			return nil, fmt.Errorf("--agents contains duplicate handle %q", agent)
+		}
+		seen[agent] = true
+		agents = append(agents, agent)
+	}
+	if len(agents) == 0 {
+		return nil, errors.New("--agents is required")
+	}
+	return agents, nil
+}
+
+func (a App) installLaunchd(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("install-launchd", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	label := fs.String("label", launchd.DefaultLabel, "launchd label")
+	plistPath := fs.String("plist", "", "plist path")
+	registryPath := fs.String("registry", mustDefaultRegistryPath(), "registry file path")
+	amqPath := fs.String("amq", "amq", "amq executable path")
+	self := fs.String("self", executablePath(), "amq-keepalive executable path")
+	interval := fs.Duration("interval", 10*time.Second, "supervisor interval")
+	noLoad := fs.Bool("no-load", false, "write plist without loading it")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	opts := launchd.Options{
+		Label:        *label,
+		PlistPath:    *plistPath,
+		BinaryPath:   *self,
+		RegistryPath: *registryPath,
+		AMQPath:      *amqPath,
+		Interval:     *interval,
+		Load:         !*noLoad,
+	}
+	normalized, err := launchd.NormalizeOptions(opts)
+	if err != nil {
+		return err
+	}
+	if err := launchd.Install(ctx, normalized); err != nil {
+		return err
+	}
+	return printJSON(a.Stdout, map[string]any{
+		"label":      normalized.Label,
+		"plist":      normalized.PlistPath,
+		"loaded":     normalized.Load,
+		"supervisor": normalized.BinaryPath,
+	})
+}
+
+func (a App) installHook(args []string) error {
+	fs := flag.NewFlagSet("install-hook", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	agent := fs.String("agent", hookinstall.AgentBoth, "agent config to update: claude, codex, or both")
+	scriptPath := fs.String("script", "", "installed hook script path")
+	binaryPath := fs.String("bin", executablePath(), "amq-keepalive binary path")
+	claudeConfig := fs.String("claude-config", "", "Claude settings.json path")
+	codexConfig := fs.String("codex-config", "", "Codex hooks.json path")
+	timeout := fs.Duration("timeout", hookinstall.DefaultTimeout, "self-timeout for reattach work inside the hook")
+	dryRun := fs.Bool("dry-run", false, "print install plan without writing files")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	result, err := hookinstall.Install(hookinstall.Options{
+		Agent:        *agent,
+		ScriptPath:   *scriptPath,
+		BinaryPath:   *binaryPath,
+		ClaudeConfig: *claudeConfig,
+		CodexConfig:  *codexConfig,
+		Timeout:      *timeout,
+		DryRun:       *dryRun,
+	})
+	if err != nil {
+		return err
+	}
+	return printJSON(a.Stdout, result)
+}
+
+func (a App) uninstallLaunchd(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("uninstall", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	label := fs.String("label", launchd.DefaultLabel, "launchd label")
+	plistPath := fs.String("plist", "", "plist path")
+	noUnload := fs.Bool("no-unload", false, "remove plist without bootout")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := launchd.Uninstall(ctx, *label, *plistPath, !*noUnload); err != nil {
+		return err
+	}
+	return printJSON(a.Stdout, map[string]any{"label": *label, "removed": true, "unloaded": !*noUnload})
+}
+
+func (a App) usage(writer io.Writer) {
+	_, _ = fmt.Fprintln(writer, "usage: amq-keepalive <attach|reattach|supervise|inject|doctor|retire-session|forget|install-launchd|install-hook|uninstall> [options]")
+}
+
+func mustDefaultRegistryPath() string {
+	path, err := registry.DefaultPath()
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func executablePath() string {
+	path, err := os.Executable()
+	if err != nil {
+		return os.Args[0]
+	}
+	return path
+}
+
+func printJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func normalizeAMQPaths(root, baseRoot, sessionName string) (string, string) {
+	root = strings.TrimSpace(root)
+	baseRoot = strings.TrimSpace(baseRoot)
+	sessionName = strings.TrimSpace(sessionName)
+
+	if baseRoot != "" && !filepath.IsAbs(baseRoot) {
+		if abs, err := filepath.Abs(baseRoot); err == nil {
+			baseRoot = abs
+		}
+	}
+	if root == "" || filepath.IsAbs(root) {
+		return root, baseRoot
+	}
+	if baseRoot != "" && filepath.IsAbs(baseRoot) {
+		if sessionName != "" && filepath.Base(root) == sessionName {
+			return filepath.Join(baseRoot, sessionName), baseRoot
+		}
+		if filepath.Base(root) == filepath.Base(baseRoot) {
+			return baseRoot, baseRoot
+		}
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		return abs, baseRoot
+	}
+	return root, baseRoot
+}

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -1,0 +1,547 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/amq"
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/registry"
+)
+
+func TestHelpWritesUsageToStdoutAndExitsZero(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{"--help"})
+	if code != 0 {
+		t.Fatalf("help code = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "usage: amq-keepalive") {
+		t.Fatalf("stdout does not contain usage: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestReattachReplacesCurrentSessionAdapterEntry(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "registry.json")
+	oldTarget := filepath.Join(dir, "old-inbox.txt")
+	newTarget := filepath.Join(dir, "new-inbox.txt")
+	otherTarget := filepath.Join(dir, "other-inbox.txt")
+
+	runApp(t, "attach",
+		"--registry", registryPath,
+		"--adapter", "file",
+		"--target", oldTarget,
+		"--root", "/tmp/amq-root",
+		"--base-root", "/tmp",
+		"--session", "amq-root",
+		"--me", "codex",
+		"--no-start",
+	)
+	runApp(t, "attach",
+		"--registry", registryPath,
+		"--adapter", "file",
+		"--target", otherTarget,
+		"--root", "/tmp/amq-root",
+		"--base-root", "/tmp",
+		"--session", "amq-root",
+		"--me", "claude",
+		"--no-start",
+	)
+
+	runApp(t, "reattach",
+		"--registry", registryPath,
+		"--adapter", "file",
+		"--target", newTarget,
+		"--root", "/tmp/amq-root",
+		"--base-root", "/tmp",
+		"--session", "amq-root",
+		"--me", "codex",
+		"--no-start",
+	)
+
+	loaded, err := registry.New(registryPath).Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2: %#v", len(loaded.Entries), loaded.Entries)
+	}
+	targets := map[string]string{}
+	for _, entry := range loaded.Entries {
+		targets[entry.Agent] = entry.Target
+	}
+	if targets["codex"] != newTarget {
+		t.Fatalf("codex target = %q, want %q", targets["codex"], newTarget)
+	}
+	if targets["claude"] != otherTarget {
+		t.Fatalf("claude target = %q, want %q", targets["claude"], otherTarget)
+	}
+}
+
+func TestReattachPreservesRegistryWhenWakeTargetCannotChange(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "registry.json")
+	oldTarget := filepath.Join(dir, "old-inbox.txt")
+	newTarget := filepath.Join(dir, "new-inbox.txt")
+	runApp(t, "attach",
+		"--registry", registryPath,
+		"--adapter", "file",
+		"--target", oldTarget,
+		"--root", "/tmp/amq-root",
+		"--base-root", "/tmp",
+		"--session", "amq-root",
+		"--me", "codex",
+		"--no-start",
+	)
+	fakeAMQ := filepath.Join(dir, "amq")
+	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\necho 'existing wake target differs' >&2\nexit 7\n"), 0o700); err != nil {
+		t.Fatalf("write fake AMQ: %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{
+		"reattach",
+		"--registry", registryPath,
+		"--adapter", "file",
+		"--target", newTarget,
+		"--root", "/tmp/amq-root",
+		"--base-root", "/tmp",
+		"--session", "amq-root",
+		"--me", "codex",
+		"--amq", fakeAMQ,
+		"--wake-ready-timeout", "5s",
+	})
+	if code != 1 {
+		t.Fatalf("reattach code = %d, want 1\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "amq wake exited before becoming ready") {
+		t.Fatalf("stderr does not expose wake failure:\n%s", stderr.String())
+	}
+	loaded, err := registry.New(registryPath).Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Entries) != 1 || loaded.Entries[0].Target != oldTarget {
+		t.Fatalf("entries = %#v, want old target restored", loaded.Entries)
+	}
+}
+
+func TestReattachDoesNotExposeCandidateRegistryBeforeWakeSuccess(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "registry.json")
+	oldTarget := filepath.Join(dir, "old-inbox.txt")
+	newTarget := filepath.Join(dir, "new-inbox.txt")
+	runApp(t, "attach",
+		"--registry", registryPath,
+		"--adapter", "file",
+		"--target", oldTarget,
+		"--root", "/tmp/amq-root",
+		"--base-root", "/tmp",
+		"--session", "amq-root",
+		"--me", "codex",
+		"--no-start",
+	)
+	startedPath := filepath.Join(dir, "wake-started")
+	releasePath := filepath.Join(dir, "wake-release")
+	t.Setenv("AMQ_KEEPALIVE_TEST_STARTED", startedPath)
+	t.Setenv("AMQ_KEEPALIVE_TEST_RELEASE", releasePath)
+	fakeAMQ := filepath.Join(dir, "amq")
+	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+: > "$AMQ_KEEPALIVE_TEST_STARTED"
+while [ ! -f "$AMQ_KEEPALIVE_TEST_RELEASE" ]; do sleep 0.01; done
+exit 7
+`), 0o700); err != nil {
+		t.Fatalf("write fake AMQ: %v", err)
+	}
+	defer func() { _ = os.WriteFile(releasePath, []byte("release"), 0o600) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	done := make(chan int, 1)
+	go func() {
+		done <- (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).Run(ctx, []string{
+			"reattach",
+			"--registry", registryPath,
+			"--adapter", "file",
+			"--target", newTarget,
+			"--root", "/tmp/amq-root",
+			"--base-root", "/tmp",
+			"--session", "amq-root",
+			"--me", "codex",
+			"--amq", fakeAMQ,
+			"--wake-ready-timeout", "5s",
+		})
+	}()
+	waitForPath(t, startedPath, 2*time.Second)
+
+	loaded, err := registry.New(registryPath).Load()
+	if err != nil {
+		t.Fatalf("Load(in-flight) error = %v", err)
+	}
+	if len(loaded.Entries) != 1 || loaded.Entries[0].Target != oldTarget {
+		t.Fatalf("in-flight entries = %#v, candidate target leaked before wake success", loaded.Entries)
+	}
+	if err := os.WriteFile(releasePath, []byte("release"), 0o600); err != nil {
+		t.Fatalf("release fake AMQ: %v", err)
+	}
+	if code := <-done; code != 1 {
+		t.Fatalf("reattach code = %d, want failure", code)
+	}
+	loaded, err = registry.New(registryPath).Load()
+	if err != nil {
+		t.Fatalf("Load(final) error = %v", err)
+	}
+	if len(loaded.Entries) != 1 || loaded.Entries[0].Target != oldTarget {
+		t.Fatalf("final entries = %#v, want old target preserved", loaded.Entries)
+	}
+}
+
+func TestReattachPersistsCandidateOnlyAfterWakeReady(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "registry.json")
+	oldTarget := filepath.Join(dir, "old-inbox.txt")
+	newTarget := filepath.Join(dir, "new-inbox.txt")
+	runApp(t, "attach",
+		"--registry", registryPath,
+		"--adapter", "file",
+		"--target", oldTarget,
+		"--root", "/tmp/amq-root",
+		"--base-root", "/tmp",
+		"--session", "amq-root",
+		"--me", "codex",
+		"--no-start",
+	)
+	fakeAMQ := filepath.Join(dir, "amq")
+	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+ready=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-ready-file" ]; then ready="$arg"; fi
+  previous="$arg"
+done
+[ -n "$ready" ] || exit 11
+printf ready > "$ready"
+`), 0o700); err != nil {
+		t.Fatalf("write fake AMQ: %v", err)
+	}
+	runApp(t, "reattach",
+		"--registry", registryPath,
+		"--adapter", "file",
+		"--target", newTarget,
+		"--root", "/tmp/amq-root",
+		"--base-root", "/tmp",
+		"--session", "amq-root",
+		"--me", "codex",
+		"--amq", fakeAMQ,
+		"--wake-ready-timeout", "2s",
+	)
+	loaded, err := registry.New(registryPath).Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Entries) != 1 || loaded.Entries[0].Target != newTarget {
+		t.Fatalf("entries = %#v, want ready candidate persisted", loaded.Entries)
+	}
+	if loaded.Entries[0].State != registry.StateActive || loaded.Entries[0].LastSupervisorDecision != "ensured" {
+		t.Fatalf("candidate was not persisted active after readiness: %#v", loaded.Entries[0])
+	}
+}
+
+func TestNormalizeAMQPathsUsesAbsoluteBaseSessionRoot(t *testing.T) {
+	root, base := normalizeAMQPaths(".agent-mail/team-upgrader_v3", "/Users/test/git/.agent-mail", "team-upgrader_v3")
+	if root != "/Users/test/git/.agent-mail/team-upgrader_v3" {
+		t.Fatalf("root = %q, want absolute session root", root)
+	}
+	if base != "/Users/test/git/.agent-mail" {
+		t.Fatalf("base = %q, want absolute base root", base)
+	}
+}
+
+func TestRetireSessionProvesTargetsMissingRetiresExactWakesAndPreservesOtherEntries(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cmux adapter requires macOS")
+	}
+	dir := t.TempDir()
+	root := filepath.Join(dir, "dashboard")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("MkdirAll root: %v", err)
+	}
+	registryPath := filepath.Join(dir, "registry.json")
+	store := registry.New(registryPath)
+	entries := []registry.Entry{
+		{Root: root, BaseRoot: dir, SessionName: "dashboard", Agent: "codex", Adapter: "cmux", Target: "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3", State: registry.StateDetached},
+		{Root: root, BaseRoot: dir, SessionName: "dashboard", Agent: "claude", Adapter: "cmux", Target: "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2", State: registry.StateDetached},
+		{Root: root, BaseRoot: dir, SessionName: "dashboard", Agent: "observer", Adapter: "file", Target: filepath.Join(dir, "observer.txt"), State: registry.StateActive},
+	}
+	for _, entry := range entries {
+		if _, err := store.Upsert(entry); err != nil {
+			t.Fatalf("Upsert(%s): %v", entry.Agent, err)
+		}
+	}
+
+	fakeCmux := filepath.Join(dir, "cmux")
+	if err := os.WriteFile(fakeCmux, []byte("#!/bin/sh\necho 'Error: not_found: Workspace not found'\nexit 1\n"), 0o700); err != nil {
+		t.Fatalf("write fake cmux: %v", err)
+	}
+	t.Setenv("CMUX_BUNDLED_CLI_PATH", fakeCmux)
+	argsLog := filepath.Join(dir, "amq-args.log")
+	t.Setenv("AMQ_KEEPALIVE_ARGS_LOG", argsLog)
+	fakeAMQ := filepath.Join(dir, "amq")
+	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+printf '%s\n' "$@" >> "$AMQ_KEEPALIVE_ARGS_LOG"
+agent=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-me" ]; then agent="$arg"; fi
+  previous="$arg"
+done
+printf '{"status":"retired","agent":"%s","pid":4242}\n' "$agent"
+`), 0o700); err != nil {
+		t.Fatalf("write fake AMQ: %v", err)
+	}
+	fakeKeepalive := filepath.Join(dir, "amq-keepalive")
+	if err := os.WriteFile(fakeKeepalive, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write fake keepalive: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{
+		"retire-session",
+		"--registry", registryPath,
+		"--root", root,
+		"--agents", "codex,claude",
+		"--adapter", "cmux",
+		"--amq", fakeAMQ,
+		"--self", fakeKeepalive,
+	})
+	if code != 0 {
+		t.Fatalf("retire-session code=%d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Entries) != 1 || loaded.Entries[0].Agent != "observer" {
+		t.Fatalf("entries after retirement = %#v, want observer only", loaded.Entries)
+	}
+	data, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read args log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{"codex", "claude", entries[0].Target, entries[1].Target, fakeKeepalive} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("AMQ args missing %q:\n%s", want, log)
+		}
+	}
+}
+
+func TestRetireSessionRefusesWhenTargetStillExists(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cmux adapter requires macOS")
+	}
+	dir := t.TempDir()
+	root := filepath.Join(dir, "dashboard")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("MkdirAll root: %v", err)
+	}
+	registryPath := filepath.Join(dir, "registry.json")
+	store := registry.New(registryPath)
+	for _, entry := range []registry.Entry{
+		{Root: root, Agent: "codex", Adapter: "cmux", Target: "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3", State: registry.StateDetached},
+		{Root: root, Agent: "claude", Adapter: "cmux", Target: "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2", State: registry.StateDetached},
+	} {
+		if _, err := store.Upsert(entry); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+	}
+	fakeCmux := filepath.Join(dir, "cmux")
+	if err := os.WriteFile(fakeCmux, []byte("#!/bin/sh\necho '{\"ok\":true}'\n"), 0o700); err != nil {
+		t.Fatalf("write fake cmux: %v", err)
+	}
+	t.Setenv("CMUX_BUNDLED_CLI_PATH", fakeCmux)
+	fakeAMQ := filepath.Join(dir, "amq")
+	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nexit 99\n"), 0o700); err != nil {
+		t.Fatalf("write fake AMQ: %v", err)
+	}
+	var stderr bytes.Buffer
+	code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr}).Run(context.Background(), []string{
+		"retire-session", "--registry", registryPath, "--root", root, "--amq", fakeAMQ,
+	})
+	if code != 1 || !strings.Contains(stderr.String(), "still exists") {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	loaded, err := store.Load()
+	if err != nil || len(loaded.Entries) != 2 {
+		t.Fatalf("registry changed after refusal: entries=%#v err=%v", loaded.Entries, err)
+	}
+}
+
+func TestRetireSessionForgetsOnlyProvenRetiredEntryWhenSecondWakeRefuses(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cmux adapter requires macOS")
+	}
+	dir := t.TempDir()
+	root := filepath.Join(dir, "dashboard")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("MkdirAll root: %v", err)
+	}
+	registryPath := filepath.Join(dir, "registry.json")
+	store := registry.New(registryPath)
+	for _, entry := range []registry.Entry{
+		{Root: root, Agent: "codex", Adapter: "cmux", Target: "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3", State: registry.StateDetached},
+		{Root: root, Agent: "claude", Adapter: "cmux", Target: "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2", State: registry.StateDetached},
+	} {
+		if _, err := store.Upsert(entry); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+	}
+	fakeCmux := filepath.Join(dir, "cmux")
+	if err := os.WriteFile(fakeCmux, []byte("#!/bin/sh\necho 'Error: not_found: Workspace not found'\nexit 1\n"), 0o700); err != nil {
+		t.Fatalf("write fake cmux: %v", err)
+	}
+	t.Setenv("CMUX_BUNDLED_CLI_PATH", fakeCmux)
+	fakeAMQ := filepath.Join(dir, "amq")
+	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+agent=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-me" ]; then agent="$arg"; fi
+  previous="$arg"
+done
+if [ "$agent" = "claude" ]; then
+  printf '%s\n' '{"status":"refused","agent":"claude","reason":"target changed"}'
+  exit 7
+fi
+printf '%s\n' '{"status":"retired","agent":"codex","pid":4242}'
+`), 0o700); err != nil {
+		t.Fatalf("write fake AMQ: %v", err)
+	}
+	fakeKeepalive := filepath.Join(dir, "amq-keepalive")
+	if err := os.WriteFile(fakeKeepalive, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatalf("write fake keepalive: %v", err)
+	}
+	var stderr bytes.Buffer
+	code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr}).Run(context.Background(), []string{
+		"retire-session", "--registry", registryPath, "--root", root,
+		"--amq", fakeAMQ, "--self", fakeKeepalive,
+	})
+	if code != 1 || !strings.Contains(stderr.String(), "retire claude wake") {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	loaded, err := store.Load()
+	if err != nil || len(loaded.Entries) != 1 || loaded.Entries[0].Agent != "claude" {
+		t.Fatalf("partial retirement must forget only proven-retired codex entry: entries=%#v err=%v", loaded.Entries, err)
+	}
+}
+
+func TestInstallHookCommandWritesRequestedConfig(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "amq-keepalive")
+	if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	runApp(t, "install-hook",
+		"--agent", "codex",
+		"--script", filepath.Join(dir, "hook.sh"),
+		"--bin", binaryPath,
+		"--codex-config", filepath.Join(dir, "hooks.json"),
+		"--timeout", "1s",
+	)
+	if _, err := os.Stat(filepath.Join(dir, "hook.sh")); err != nil {
+		t.Fatalf("hook not installed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks config: %v", err)
+	}
+	if !bytes.Contains(data, []byte("AMQ_KEEPALIVE_TIMEOUT_SECONDS='1'")) {
+		t.Fatalf("hooks config missing timeout command:\n%s", data)
+	}
+}
+
+type appFailingWake struct{}
+
+func (appFailingWake) RepairWake(context.Context, string, string) (amq.WakeRepairResult, error) {
+	return amq.WakeRepairResult{Status: "refused", Reason: "unverified wake lock; refusing repair"}, errors.New("exit status 1")
+}
+
+func (appFailingWake) StartWake(context.Context, amq.StartWakeRequest) error {
+	return errors.New("unverified wake lock; refusing second injector")
+}
+
+func TestSuperviseWarnsOncePerPersistentFailureTransition(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "registry.json")
+	_, err := registry.New(registryPath).Upsert(registry.Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "file",
+		Target:  filepath.Join(dir, "inbox.txt"),
+	})
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.superviseOnce(context.Background(), registryPath, appFailingWake{}, "/bin/amq-keepalive", time.Second); err != nil {
+		t.Fatalf("first superviseOnce() error = %v", err)
+	}
+	warning := stderr.String()
+	for _, want := range []string{
+		"action=start_failed",
+		`root="/tmp/amq-root"`,
+		`agent="codex"`,
+		`adapter="file"`,
+		`target="` + filepath.Join(dir, "inbox.txt") + `"`,
+		"failure_count=1",
+		"unverified wake lock",
+	} {
+		if !strings.Contains(warning, want) {
+			t.Fatalf("warning missing %q:\n%s", want, warning)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := app.superviseOnce(context.Background(), registryPath, appFailingWake{}, "/bin/amq-keepalive", time.Second); err != nil {
+		t.Fatalf("second superviseOnce() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("backoff recheck repeated warning:\n%s", stderr.String())
+	}
+}
+
+func runApp(t *testing.T, args ...string) {
+	t.Helper()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), args)
+	if code != 0 {
+		t.Fatalf("Run(%v) = %d\nstdout:\n%s\nstderr:\n%s", args, code, stdout.String(), stderr.String())
+	}
+}
+
+func waitForPath(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}

--- a/internal/keepalive/hookinstall/hookinstall.go
+++ b/internal/keepalive/hookinstall/hookinstall.go
@@ -1,0 +1,617 @@
+package hookinstall
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	AgentBoth   = "both"
+	AgentClaude = "claude"
+	AgentCodex  = "codex"
+
+	DefaultTimeout = 10 * time.Second
+)
+
+const SessionStartScript = `#!/usr/bin/env bash
+# SessionStart hook wrapper for amq-keepalive.
+#
+# This hook is intentionally non-blocking: it logs reattach failures and always
+# returns an empty hook response so agent startup is not held hostage by AMQ.
+
+set -u
+
+BIN="${AMQ_KEEPALIVE_BIN:-amq-keepalive}"
+ADAPTER="${AMQ_KEEPALIVE_ADAPTER:-}"
+TARGET="${AMQ_KEEPALIVE_TARGET:-}"
+REGISTRY="${AMQ_KEEPALIVE_REGISTRY:-}"
+AMQ_BIN="${AMQ_KEEPALIVE_AMQ:-amq}"
+SELF_BIN="${AMQ_KEEPALIVE_SELF:-$BIN}"
+ROOT="${AMQ_KEEPALIVE_ROOT:-}"
+BASE_ROOT="${AMQ_KEEPALIVE_BASE_ROOT:-}"
+SESSION_NAME="${AMQ_KEEPALIVE_SESSION:-}"
+ME="${AMQ_KEEPALIVE_ME:-}"
+LOG_PATH="${AMQ_KEEPALIVE_LOG:-$HOME/.amq-keepalive/session-start.log}"
+DEFAULT_TIMEOUT_SECONDS="${AMQ_KEEPALIVE_DEFAULT_TIMEOUT_SECONDS:-10}"
+TIMEOUT_SECONDS="${AMQ_KEEPALIVE_TIMEOUT_SECONDS:-$DEFAULT_TIMEOUT_SECONDS}"
+STDIN_TIMEOUT_SECONDS="${AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS:-1}"
+WAKE_TIMEOUT_MILLISECONDS="${AMQ_KEEPALIVE_WAKE_TIMEOUT_MILLISECONDS:-}"
+
+if [[ -z "$ADAPTER" ]]; then
+    if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
+        ADAPTER="cmux"
+    else
+        ADAPTER="ghostty"
+    fi
+fi
+if [[ "$ADAPTER" == "cmux" && -z "$TARGET" && -n "${CMUX_SURFACE_ID:-}" ]]; then
+    TARGET="cmux:surface:${CMUX_SURFACE_ID}"
+fi
+
+if [[ "${AMQ_KEEPALIVE_DISABLED:-0}" == "1" ]]; then
+    printf '{}\n'
+    exit 0
+fi
+
+mkdir -p "$(dirname "$LOG_PATH")" 2>/dev/null || true
+
+log() {
+    printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$LOG_PATH" 2>/dev/null || true
+}
+
+if ! [[ "$DEFAULT_TIMEOUT_SECONDS" =~ ^[0-9]+$ && "$DEFAULT_TIMEOUT_SECONDS" -gt 0 ]]; then
+    DEFAULT_TIMEOUT_SECONDS=10
+fi
+if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ && "$TIMEOUT_SECONDS" -gt 0 ]]; then
+    log "invalid timeout ${TIMEOUT_SECONDS}; using ${DEFAULT_TIMEOUT_SECONDS}s"
+    TIMEOUT_SECONDS="$DEFAULT_TIMEOUT_SECONDS"
+fi
+if ! [[ "$STDIN_TIMEOUT_SECONDS" =~ ^[0-9]+$ && "$STDIN_TIMEOUT_SECONDS" -gt 0 ]]; then
+    STDIN_TIMEOUT_SECONDS=1
+fi
+
+outer_timeout_milliseconds=$((TIMEOUT_SECONDS * 1000))
+default_wake_timeout_milliseconds=$((outer_timeout_milliseconds - 2000))
+if [[ "$default_wake_timeout_milliseconds" -le 0 ]]; then
+    default_wake_timeout_milliseconds=$((outer_timeout_milliseconds / 2))
+fi
+if [[ "$default_wake_timeout_milliseconds" -le 0 ]]; then
+    default_wake_timeout_milliseconds=100
+fi
+if ! [[ "$WAKE_TIMEOUT_MILLISECONDS" =~ ^[0-9]+$ && "$WAKE_TIMEOUT_MILLISECONDS" -gt 0 ]]; then
+    [[ -n "$WAKE_TIMEOUT_MILLISECONDS" ]] && log "invalid wake timeout ${WAKE_TIMEOUT_MILLISECONDS}ms; using ${default_wake_timeout_milliseconds}ms"
+    WAKE_TIMEOUT_MILLISECONDS="$default_wake_timeout_milliseconds"
+fi
+if [[ "$WAKE_TIMEOUT_MILLISECONDS" -ge "$outer_timeout_milliseconds" ]]; then
+    clamped_wake_timeout_milliseconds=$((outer_timeout_milliseconds - 500))
+    if [[ "$clamped_wake_timeout_milliseconds" -le 0 ]]; then
+        clamped_wake_timeout_milliseconds=100
+    fi
+    log "wake timeout ${WAKE_TIMEOUT_MILLISECONDS}ms must be shorter than outer ${outer_timeout_milliseconds}ms; using ${clamped_wake_timeout_milliseconds}ms"
+    WAKE_TIMEOUT_MILLISECONDS="$clamped_wake_timeout_milliseconds"
+fi
+
+read_hook_input() {
+    local line=""
+    IFS= read -r -t "$STDIN_TIMEOUT_SECONDS" line || true
+    printf '%s' "$line"
+}
+
+INPUT="$(read_hook_input 2>/dev/null || true)"
+
+CWD=""
+if command -v jq >/dev/null 2>&1 && [[ -n "$INPUT" ]]; then
+    CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // .workdir // .working_directory // empty' 2>/dev/null || true)"
+fi
+if [[ -n "$CWD" && -d "$CWD" ]]; then
+    cd "$CWD" 2>/dev/null || true
+fi
+
+if ! command -v "$BIN" >/dev/null 2>&1; then
+    log "skip: amq-keepalive binary not found: $BIN"
+    printf '{}\n'
+    exit 0
+fi
+
+args=(reattach --adapter "$ADAPTER" --amq "$AMQ_BIN" --wake-ready-timeout "${WAKE_TIMEOUT_MILLISECONDS}ms")
+[[ -n "${AMQ_KEEPALIVE_SELF:-}" ]] && args+=(--self "$SELF_BIN")
+[[ -n "$TARGET" ]] && args+=(--target "$TARGET")
+[[ -n "$REGISTRY" ]] && args+=(--registry "$REGISTRY")
+[[ -n "$ROOT" ]] && args+=(--root "$ROOT")
+[[ -n "$BASE_ROOT" ]] && args+=(--base-root "$BASE_ROOT")
+[[ -n "$SESSION_NAME" ]] && args+=(--session "$SESSION_NAME")
+[[ -n "$ME" ]] && args+=(--me "$ME")
+[[ "${AMQ_KEEPALIVE_NO_START:-0}" == "1" ]] && args+=(--no-start)
+
+run_reattach() {
+    "$BIN" "${args[@]}" >> "$LOG_PATH" 2>&1
+}
+
+timeout_marker="${TMPDIR:-/tmp}/amq-keepalive-timeout.$$"
+rm -f "$timeout_marker" 2>/dev/null || true
+
+(
+    trap 'exit 143' TERM
+    run_reattach
+) 2>> "$LOG_PATH" &
+reattach_pid=$!
+(
+    sleep "$TIMEOUT_SECONDS"
+    if kill -0 "$reattach_pid" 2>/dev/null; then
+        : > "$timeout_marker" 2>/dev/null || true
+        pkill -TERM -P "$reattach_pid" 2>/dev/null || true
+        kill -TERM "$reattach_pid" 2>/dev/null || true
+        sleep 1
+        pkill -KILL -P "$reattach_pid" 2>/dev/null || true
+        kill -KILL "$reattach_pid" 2>/dev/null || true
+    fi
+) >/dev/null 2>&1 &
+watchdog_pid=$!
+
+wait "$reattach_pid" 2>/dev/null
+status=$?
+pkill -TERM -P "$watchdog_pid" 2>/dev/null || true
+kill "$watchdog_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
+
+if [[ -f "$timeout_marker" ]]; then
+    rm -f "$timeout_marker" 2>/dev/null || true
+    log "reattach timed out after ${TIMEOUT_SECONDS}s adapter=$ADAPTER target=${TARGET:-auto}"
+    printf '{}\n'
+    exit 0
+fi
+
+if [[ "$status" -eq 0 ]]; then
+    log "reattach ok adapter=$ADAPTER target=${TARGET:-auto}"
+else
+    log "reattach failed status=$status adapter=$ADAPTER target=${TARGET:-auto}"
+fi
+
+printf '{}\n'
+exit 0
+`
+
+type Options struct {
+	Agent        string
+	ScriptPath   string
+	BinaryPath   string
+	ClaudeConfig string
+	CodexConfig  string
+	Timeout      time.Duration
+	DryRun       bool
+}
+
+type FileResult struct {
+	Path    string `json:"path"`
+	Changed bool   `json:"changed"`
+	Backup  string `json:"backup,omitempty"`
+}
+
+type Result struct {
+	Agent              string                 `json:"agent"`
+	Script             FileResult             `json:"script"`
+	Configs            map[string]FileResult  `json:"configs"`
+	Commands           map[string]string      `json:"commands"`
+	Snippets           map[string]interface{} `json:"snippets"`
+	TimeoutSeconds     int                    `json:"timeout_seconds"`
+	HookTimeoutSeconds int                    `json:"hook_timeout_seconds"`
+	DryRun             bool                   `json:"dry_run"`
+}
+
+func DefaultScriptPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".amq-keepalive", "hooks", "amq-keepalive-session-start.sh"), nil
+}
+
+func DefaultClaudeConfig() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "settings.json"), nil
+}
+
+func DefaultCodexConfig() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex", "hooks.json"), nil
+}
+
+func Install(opts Options) (Result, error) {
+	normalized, err := NormalizeOptions(opts)
+	if err != nil {
+		return Result{}, err
+	}
+	command := buildHookCommand(normalized.BinaryPath, normalized.ScriptPath, normalized.Timeout)
+	hookTimeoutSeconds := int(normalized.Timeout.Seconds()) + 5
+	result := Result{
+		Agent:              normalized.Agent,
+		Configs:            map[string]FileResult{},
+		Commands:           map[string]string{},
+		Snippets:           map[string]interface{}{},
+		TimeoutSeconds:     int(normalized.Timeout.Seconds()),
+		HookTimeoutSeconds: hookTimeoutSeconds,
+		DryRun:             normalized.DryRun,
+	}
+
+	scriptResult := FileResult{Path: normalized.ScriptPath}
+	if !normalized.DryRun {
+		changed, err := writeExecutableIfChanged(normalized.ScriptPath, []byte(SessionStartScript))
+		if err != nil {
+			return Result{}, err
+		}
+		scriptResult.Changed = changed
+	}
+	result.Script = scriptResult
+
+	if normalized.Agent == AgentClaude || normalized.Agent == AgentBoth {
+		snippet := claudeSessionStartEntry(command, hookTimeoutSeconds)
+		result.Commands[AgentClaude] = command
+		result.Snippets[AgentClaude] = snippet
+		if !normalized.DryRun {
+			fileResult, err := installClaudeHook(normalized.ClaudeConfig, command, hookTimeoutSeconds)
+			if err != nil {
+				return Result{}, err
+			}
+			result.Configs[AgentClaude] = fileResult
+		}
+	}
+	if normalized.Agent == AgentCodex || normalized.Agent == AgentBoth {
+		snippet := codexSessionStartEntry(command, hookTimeoutSeconds)
+		result.Commands[AgentCodex] = command
+		result.Snippets[AgentCodex] = snippet
+		if !normalized.DryRun {
+			fileResult, err := installCodexHook(normalized.CodexConfig, command, hookTimeoutSeconds)
+			if err != nil {
+				return Result{}, err
+			}
+			result.Configs[AgentCodex] = fileResult
+		}
+	}
+	return result, nil
+}
+
+func NormalizeOptions(opts Options) (Options, error) {
+	switch opts.Agent {
+	case "", AgentBoth:
+		opts.Agent = AgentBoth
+	case AgentClaude, AgentCodex:
+	default:
+		return Options{}, fmt.Errorf("--agent must be one of %s, %s, %s", AgentClaude, AgentCodex, AgentBoth)
+	}
+	if opts.ScriptPath == "" {
+		path, err := DefaultScriptPath()
+		if err != nil {
+			return Options{}, err
+		}
+		opts.ScriptPath = path
+	}
+	scriptPath, err := absPath(opts.ScriptPath)
+	if err != nil {
+		return Options{}, fmt.Errorf("resolve script path: %w", err)
+	}
+	opts.ScriptPath = scriptPath
+
+	if opts.BinaryPath == "" {
+		return Options{}, errors.New("binary path is required")
+	}
+	binaryPath, err := resolveExecutable(opts.BinaryPath)
+	if err != nil {
+		return Options{}, fmt.Errorf("resolve binary path: %w", err)
+	}
+	opts.BinaryPath = binaryPath
+
+	if opts.ClaudeConfig == "" {
+		path, err := DefaultClaudeConfig()
+		if err != nil {
+			return Options{}, err
+		}
+		opts.ClaudeConfig = path
+	}
+	opts.ClaudeConfig, err = absPath(opts.ClaudeConfig)
+	if err != nil {
+		return Options{}, fmt.Errorf("resolve Claude config: %w", err)
+	}
+
+	if opts.CodexConfig == "" {
+		path, err := DefaultCodexConfig()
+		if err != nil {
+			return Options{}, err
+		}
+		opts.CodexConfig = path
+	}
+	opts.CodexConfig, err = absPath(opts.CodexConfig)
+	if err != nil {
+		return Options{}, fmt.Errorf("resolve Codex config: %w", err)
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = DefaultTimeout
+	}
+	if opts.Timeout < time.Second {
+		return Options{}, errors.New("--timeout must be at least 1s")
+	}
+	return opts, nil
+}
+
+func installClaudeHook(path, command string, hookTimeoutSeconds int) (FileResult, error) {
+	doc, err := loadJSONObject(path)
+	if err != nil {
+		return FileResult{}, err
+	}
+	hooks, err := objectField(doc, "hooks")
+	if err != nil {
+		return FileResult{}, err
+	}
+	sessionStart, err := arrayField(hooks, "SessionStart")
+	if err != nil {
+		return FileResult{}, err
+	}
+	changed := false
+	if !claudeHasCommand(sessionStart, command) {
+		sessionStart = append(sessionStart, claudeSessionStartEntry(command, hookTimeoutSeconds))
+		hooks["SessionStart"] = sessionStart
+		doc["hooks"] = hooks
+		changed = true
+	}
+	return saveJSONIfChanged(path, doc, changed)
+}
+
+func installCodexHook(path, command string, hookTimeoutSeconds int) (FileResult, error) {
+	doc, err := loadJSONObject(path)
+	if err != nil {
+		return FileResult{}, err
+	}
+	hooks, err := objectField(doc, "hooks")
+	if err != nil {
+		return FileResult{}, err
+	}
+	sessionStart, err := arrayField(hooks, "SessionStart")
+	if err != nil {
+		return FileResult{}, err
+	}
+	changed := false
+	if !codexHasCommand(sessionStart, command) {
+		hook := codexHook(command, hookTimeoutSeconds)
+		if len(sessionStart) == 0 {
+			sessionStart = append(sessionStart, map[string]interface{}{"hooks": []interface{}{hook}})
+		} else {
+			first, ok := sessionStart[0].(map[string]interface{})
+			if !ok {
+				sessionStart = append(sessionStart, map[string]interface{}{"hooks": []interface{}{hook}})
+				hooks["SessionStart"] = sessionStart
+				doc["hooks"] = hooks
+				return saveJSONIfChanged(path, doc, true)
+			}
+			hookList := interfaceArray(first["hooks"])
+			hookList = append(hookList, hook)
+			first["hooks"] = hookList
+		}
+		hooks["SessionStart"] = sessionStart
+		doc["hooks"] = hooks
+		changed = true
+	}
+	return saveJSONIfChanged(path, doc, changed)
+}
+
+func claudeSessionStartEntry(command string, hookTimeoutSeconds int) map[string]interface{} {
+	return map[string]interface{}{
+		"matcher": "*",
+		"hooks": []interface{}{
+			map[string]interface{}{
+				"type":          "command",
+				"command":       command,
+				"timeout":       hookTimeoutSeconds,
+				"statusMessage": "Reattaching AMQ wake...",
+			},
+		},
+	}
+}
+
+func codexSessionStartEntry(command string, hookTimeoutSeconds int) map[string]interface{} {
+	return map[string]interface{}{
+		"hooks": []interface{}{
+			codexHook(command, hookTimeoutSeconds),
+		},
+	}
+}
+
+func codexHook(command string, hookTimeoutSeconds int) map[string]interface{} {
+	return map[string]interface{}{
+		"type":    "command",
+		"command": command,
+		"timeout": hookTimeoutSeconds * 1000,
+	}
+}
+
+func claudeHasCommand(entries []interface{}, command string) bool {
+	for _, entry := range entries {
+		obj, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, hook := range interfaceArray(obj["hooks"]) {
+			hookObj, ok := hook.(map[string]interface{})
+			if ok && strings.TrimSpace(fmt.Sprint(hookObj["command"])) == command {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func codexHasCommand(entries []interface{}, command string) bool {
+	return claudeHasCommand(entries, command)
+}
+
+func loadJSONObject(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]interface{}{}, nil
+		}
+		return nil, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return map[string]interface{}{}, nil
+	}
+	var doc map[string]interface{}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if doc == nil {
+		doc = map[string]interface{}{}
+	}
+	return doc, nil
+}
+
+func saveJSONIfChanged(path string, doc map[string]interface{}, changed bool) (FileResult, error) {
+	result := FileResult{Path: path, Changed: changed}
+	if !changed {
+		return result, nil
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return FileResult{}, err
+	}
+	data = append(data, '\n')
+	backup, err := backupIfExists(path)
+	if err != nil {
+		return FileResult{}, err
+	}
+	if err := writeFileAtomic(path, data, 0o600); err != nil {
+		return FileResult{}, err
+	}
+	result.Backup = backup
+	return result, nil
+}
+
+func backupIfExists(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	backup := fmt.Sprintf("%s.bak-%s", path, time.Now().UTC().Format("20060102T150405Z"))
+	if err := os.WriteFile(backup, data, 0o600); err != nil {
+		return "", err
+	}
+	return backup, nil
+}
+
+func writeExecutableIfChanged(path string, data []byte) (bool, error) {
+	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, data) {
+		return false, os.Chmod(path, 0o755)
+	} else if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	return true, writeFileAtomic(path, data, 0o755)
+}
+
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".amq-keepalive-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
+func objectField(doc map[string]interface{}, key string) (map[string]interface{}, error) {
+	if raw, ok := doc[key]; ok {
+		if obj, ok := raw.(map[string]interface{}); ok {
+			return obj, nil
+		}
+		return nil, fmt.Errorf("%q must be a JSON object", key)
+	}
+	obj := map[string]interface{}{}
+	doc[key] = obj
+	return obj, nil
+}
+
+func arrayField(doc map[string]interface{}, key string) ([]interface{}, error) {
+	if raw, ok := doc[key]; ok {
+		values, ok := raw.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%q must be a JSON array", key)
+		}
+		return values, nil
+	}
+	values := []interface{}{}
+	doc[key] = values
+	return values, nil
+}
+
+func interfaceArray(raw interface{}) []interface{} {
+	if values, ok := raw.([]interface{}); ok {
+		return values
+	}
+	return []interface{}{}
+}
+
+func buildHookCommand(binaryPath, scriptPath string, timeout time.Duration) string {
+	return fmt.Sprintf("AMQ_KEEPALIVE_BIN=%s AMQ_KEEPALIVE_TIMEOUT_SECONDS=%s %s",
+		shellQuote(binaryPath),
+		shellQuote(fmt.Sprintf("%d", int(timeout.Seconds()))),
+		shellQuote(scriptPath),
+	)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func resolveExecutable(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	resolved, err := exec.LookPath(path)
+	if err != nil {
+		return "", err
+	}
+	return absPath(resolved)
+}
+
+func absPath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	return filepath.Abs(path)
+}

--- a/internal/keepalive/hookinstall/hookinstall_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_test.go
@@ -1,0 +1,438 @@
+package hookinstall
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInstallBothWritesScriptAndMergesConfigs(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "hooks", "amq-keepalive-session-start.sh")
+	binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+	claudeConfig := filepath.Join(dir, "claude", "settings.json")
+	codexConfig := filepath.Join(dir, "codex", "hooks.json")
+	mustWrite(t, claudeConfig, []byte(`{"hooks":{"SessionStart":[{"matcher":"resume","hooks":[{"type":"command","command":"existing"}]}]}}`))
+	mustWrite(t, codexConfig, []byte(`{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"existing","timeout":5000}]}]}}`))
+
+	result, err := Install(Options{
+		Agent:        AgentBoth,
+		ScriptPath:   scriptPath,
+		BinaryPath:   binaryPath,
+		ClaudeConfig: claudeConfig,
+		CodexConfig:  codexConfig,
+		Timeout:      time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if !result.Script.Changed {
+		t.Fatal("script changed = false, want true")
+	}
+	if result.Configs[AgentClaude].Backup == "" || result.Configs[AgentCodex].Backup == "" {
+		t.Fatalf("expected config backups, got %#v", result.Configs)
+	}
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		t.Fatalf("stat script: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("script mode = %o, want 755", info.Mode().Perm())
+	}
+	scriptData, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	if string(scriptData) != SessionStartScript {
+		t.Fatal("installed script does not match embedded script")
+	}
+
+	claude := readJSON(t, claudeConfig)
+	if countCommand(claude, result.Commands[AgentClaude]) != 1 {
+		t.Fatalf("Claude command not installed exactly once:\n%s", mustMarshal(t, claude))
+	}
+	if !strings.Contains(result.Commands[AgentClaude], "AMQ_KEEPALIVE_TIMEOUT_SECONDS='1'") {
+		t.Fatalf("Claude command missing timeout env: %q", result.Commands[AgentClaude])
+	}
+
+	codex := readJSON(t, codexConfig)
+	if countCommand(codex, result.Commands[AgentCodex]) != 1 {
+		t.Fatalf("Codex command not installed exactly once:\n%s", mustMarshal(t, codex))
+	}
+	if !strings.Contains(mustMarshal(t, codex), `"timeout": 6000`) {
+		t.Fatalf("Codex hook timeout missing or wrong:\n%s", mustMarshal(t, codex))
+	}
+}
+
+func TestInstallIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+	claudeConfig := filepath.Join(dir, "settings.json")
+
+	opts := Options{
+		Agent:        AgentClaude,
+		ScriptPath:   filepath.Join(dir, "hook.sh"),
+		BinaryPath:   binaryPath,
+		ClaudeConfig: claudeConfig,
+		Timeout:      time.Second,
+	}
+	first, err := Install(opts)
+	if err != nil {
+		t.Fatalf("first Install() error = %v", err)
+	}
+	second, err := Install(opts)
+	if err != nil {
+		t.Fatalf("second Install() error = %v", err)
+	}
+	if second.Configs[AgentClaude].Changed {
+		t.Fatal("second config install changed file, want idempotent no-op")
+	}
+	doc := readJSON(t, claudeConfig)
+	if countCommand(doc, first.Commands[AgentClaude]) != 1 {
+		t.Fatalf("command count != 1 after repeat install:\n%s", mustMarshal(t, doc))
+	}
+}
+
+func TestDryRunDoesNotWriteFiles(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+	scriptPath := filepath.Join(dir, "hook.sh")
+	configPath := filepath.Join(dir, "settings.json")
+
+	result, err := Install(Options{
+		Agent:        AgentClaude,
+		ScriptPath:   scriptPath,
+		BinaryPath:   binaryPath,
+		ClaudeConfig: configPath,
+		Timeout:      time.Second,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("Install(dry-run) error = %v", err)
+	}
+	if !result.DryRun || result.Commands[AgentClaude] == "" {
+		t.Fatalf("bad dry-run result: %#v", result)
+	}
+	if _, err := os.Stat(scriptPath); !os.IsNotExist(err) {
+		t.Fatalf("script stat err = %v, want not exist", err)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("config stat err = %v, want not exist", err)
+	}
+}
+
+func TestEmbeddedScriptMatchesRepositoryHook(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "scripts", "amq-keepalive-session-start.sh"))
+	if err != nil {
+		t.Fatalf("read repository hook: %v", err)
+	}
+	if string(data) != SessionStartScript {
+		t.Fatal("embedded SessionStart script drifted from hooks/amq-keepalive-session-start.sh")
+	}
+}
+
+func TestSessionStartScriptNormalizesInvalidTimeoutAndReturns(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := writeSessionStartScript(t, dir)
+	binaryPath := writeExecutableBody(t, filepath.Join(dir, "amq-keepalive"), "#!/bin/sh\nsleep 5\n")
+	logPath := filepath.Join(dir, "session-start.log")
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Env = append(os.Environ(),
+		"AMQ_KEEPALIVE_BIN="+binaryPath,
+		"AMQ_KEEPALIVE_LOG="+logPath,
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS=0",
+		"AMQ_KEEPALIVE_DEFAULT_TIMEOUT_SECONDS=1",
+		"AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS=1",
+	)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook run error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if elapsed := time.Since(start); elapsed > 4*time.Second {
+		t.Fatalf("hook took %s, want bounded return", elapsed)
+	}
+	if got := stdout.String(); got != "{}\n" {
+		t.Fatalf("stdout = %q, want empty hook response", got)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "invalid timeout 0; using 1s") {
+		t.Fatalf("log missing invalid timeout normalization:\n%s", logText)
+	}
+	if !strings.Contains(logText, "reattach timed out after 1s") {
+		t.Fatalf("log missing timeout:\n%s", logText)
+	}
+}
+
+func TestSessionStartScriptDoesNotBlockOnOpenStdin(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := writeSessionStartScript(t, dir)
+	binaryPath := writeExecutableBody(t, filepath.Join(dir, "amq-keepalive"), "#!/bin/sh\nexit 0\n")
+	logPath := filepath.Join(dir, "session-start.log")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", scriptPath)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error = %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	defer func() { _ = writer.Close() }()
+	cmd.Stdin = reader
+	cmd.Env = append(os.Environ(),
+		"AMQ_KEEPALIVE_BIN="+binaryPath,
+		"AMQ_KEEPALIVE_LOG="+logPath,
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS=2",
+		"AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS=1",
+	)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook run error = %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("hook took %s, want stdin read bounded", elapsed)
+	}
+	if got := stdout.String(); got != "{}\n" {
+		t.Fatalf("stdout = %q, want empty hook response", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want silent quick success", got)
+	}
+}
+
+func TestSessionStartScriptAutoSelectsExactCmuxSurfaceAndLogsFailure(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := writeSessionStartScript(t, dir)
+	argsPath := filepath.Join(dir, "args.log")
+	binaryPath := writeExecutableBody(t, filepath.Join(dir, "amq-keepalive"), `#!/bin/sh
+printf '%s\n' "$@" > "$AMQ_KEEPALIVE_CAPTURE"
+echo 'existing wake target differs' >&2
+exit 7
+`)
+	logPath := filepath.Join(dir, "session-start.log")
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Stdin = strings.NewReader("{}\n")
+	cmd.Env = append(withoutEnv(os.Environ(),
+		"AMQ_KEEPALIVE_ADAPTER",
+		"AMQ_KEEPALIVE_TARGET",
+		"CMUX_SURFACE_ID",
+	),
+		"AMQ_KEEPALIVE_BIN="+binaryPath,
+		"AMQ_KEEPALIVE_CAPTURE="+argsPath,
+		"AMQ_KEEPALIVE_LOG="+logPath,
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS=2",
+		"CMUX_SURFACE_ID=F901D722-6789-4BBB-9818-C4E97F20BEB3",
+	)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook run error = %v", err)
+	}
+	if got := stdout.String(); got != "{}\n" {
+		t.Fatalf("stdout = %q, want empty hook response", got)
+	}
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	argsText := string(argsData)
+	for _, want := range []string{
+		"reattach\n",
+		"--adapter\ncmux\n",
+		"--wake-ready-timeout\n1000ms\n",
+		"--target\ncmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3\n",
+	} {
+		if !strings.Contains(argsText, want) {
+			t.Fatalf("args missing %q:\n%s", want, argsText)
+		}
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "existing wake target differs") ||
+		!strings.Contains(logText, "reattach failed status=7 adapter=cmux target=cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3") {
+		t.Fatalf("log does not expose target mismatch:\n%s", logText)
+	}
+}
+
+func TestSessionStartScriptFallsBackToGhosttyOutsideCmux(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := writeSessionStartScript(t, dir)
+	argsPath := filepath.Join(dir, "args.log")
+	binaryPath := writeExecutableBody(t, filepath.Join(dir, "amq-keepalive"), `#!/bin/sh
+printf '%s\n' "$@" > "$AMQ_KEEPALIVE_CAPTURE"
+`)
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Stdin = strings.NewReader("{}\n")
+	cmd.Env = append(withoutEnv(os.Environ(),
+		"AMQ_KEEPALIVE_ADAPTER",
+		"AMQ_KEEPALIVE_TARGET",
+		"CMUX_SURFACE_ID",
+	),
+		"AMQ_KEEPALIVE_BIN="+binaryPath,
+		"AMQ_KEEPALIVE_CAPTURE="+argsPath,
+		"AMQ_KEEPALIVE_LOG="+filepath.Join(dir, "session-start.log"),
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS=2",
+	)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook run error = %v", err)
+	}
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	argsText := string(argsData)
+	if !strings.Contains(argsText, "--adapter\nghostty\n") {
+		t.Fatalf("args do not fall back to Ghostty:\n%s", argsText)
+	}
+	if strings.Contains(argsText, "--target\n") {
+		t.Fatalf("fallback unexpectedly supplied a target:\n%s", argsText)
+	}
+}
+
+func TestSessionStartScriptClampsInnerWakeTimeoutBelowOuterWatchdog(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := writeSessionStartScript(t, dir)
+	argsPath := filepath.Join(dir, "args.log")
+	logPath := filepath.Join(dir, "session-start.log")
+	binaryPath := writeExecutableBody(t, filepath.Join(dir, "amq-keepalive"), `#!/bin/sh
+printf '%s\n' "$@" > "$AMQ_KEEPALIVE_CAPTURE"
+`)
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Stdin = strings.NewReader("{}\n")
+	cmd.Env = append(os.Environ(),
+		"AMQ_KEEPALIVE_BIN="+binaryPath,
+		"AMQ_KEEPALIVE_CAPTURE="+argsPath,
+		"AMQ_KEEPALIVE_LOG="+logPath,
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS=2",
+		"AMQ_KEEPALIVE_WAKE_TIMEOUT_MILLISECONDS=2000",
+	)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook run error = %v", err)
+	}
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	if !strings.Contains(string(argsData), "--wake-ready-timeout\n1500ms\n") {
+		t.Fatalf("inner timeout was not clamped below outer watchdog:\n%s", argsData)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logData), "wake timeout 2000ms must be shorter than outer 2000ms; using 1500ms") {
+		t.Fatalf("clamp was not logged:\n%s", logData)
+	}
+}
+
+func writeExecutable(t *testing.T, path string) string {
+	t.Helper()
+	return writeExecutableBody(t, path, "#!/bin/sh\nexit 0\n")
+}
+
+func withoutEnv(env []string, keys ...string) []string {
+	blocked := map[string]bool{}
+	for _, key := range keys {
+		blocked[key] = true
+	}
+	out := make([]string, 0, len(env))
+	for _, item := range env {
+		key, _, _ := strings.Cut(item, "=")
+		if !blocked[key] {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func writeSessionStartScript(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "hook.sh")
+	return writeExecutableBody(t, path, SessionStartScript)
+}
+
+func writeExecutableBody(t *testing.T, path string, body string) string {
+	t.Helper()
+	mustWrite(t, path, []byte(body))
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("chmod executable: %v", err)
+	}
+	return path
+}
+
+func mustWrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readJSON(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read json: %v", err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal json: %v\n%s", err, data)
+	}
+	return doc
+}
+
+func countCommand(doc map[string]interface{}, command string) int {
+	count := 0
+	hooks, _ := doc["hooks"].(map[string]interface{})
+	for _, entry := range interfaceArray(hooks["SessionStart"]) {
+		entryObj, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, hook := range interfaceArray(entryObj["hooks"]) {
+			hookObj, ok := hook.(map[string]interface{})
+			if ok && hookObj["command"] == command {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func mustMarshal(t *testing.T, v interface{}) string {
+	t.Helper()
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(data)
+}

--- a/internal/keepalive/launchd/launchd.go
+++ b/internal/keepalive/launchd/launchd.go
@@ -1,0 +1,331 @@
+package launchd
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const DefaultLabel = "com.ohade.amq-keepalive"
+
+type Options struct {
+	Label        string
+	PlistPath    string
+	BinaryPath   string
+	RegistryPath string
+	AMQPath      string
+	Interval     time.Duration
+	StdoutPath   string
+	StderrPath   string
+	Load         bool
+}
+
+func DefaultPlistPath(label string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if label == "" {
+		label = DefaultLabel
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", label+".plist"), nil
+}
+
+func DefaultLogPaths(label string) (stdoutPath, stderrPath string, err error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", err
+	}
+	if label == "" {
+		label = DefaultLabel
+	}
+	dir := filepath.Join(home, "Library", "Logs", "amq-keepalive")
+	return filepath.Join(dir, label+".out.log"), filepath.Join(dir, label+".err.log"), nil
+}
+
+func ResolveExecutable(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("executable path is required")
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	resolved, err := exec.LookPath(path)
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(resolved) {
+		return filepath.Clean(resolved), nil
+	}
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+func NormalizeOptions(opts Options) (Options, error) {
+	if opts.Label == "" {
+		opts.Label = DefaultLabel
+	}
+	if opts.BinaryPath == "" {
+		return Options{}, errors.New("binary path is required")
+	}
+	binary, err := ResolveExecutable(opts.BinaryPath)
+	if err != nil {
+		return Options{}, fmt.Errorf("resolve binary path: %w", err)
+	}
+	opts.BinaryPath = binary
+
+	if opts.AMQPath == "" {
+		opts.AMQPath = "amq"
+	}
+	amqPath, err := ResolveExecutable(opts.AMQPath)
+	if err != nil {
+		return Options{}, fmt.Errorf("resolve amq path: %w", err)
+	}
+	opts.AMQPath = amqPath
+
+	if opts.RegistryPath == "" {
+		return Options{}, errors.New("registry path is required")
+	}
+	if !filepath.IsAbs(opts.RegistryPath) {
+		abs, err := filepath.Abs(opts.RegistryPath)
+		if err != nil {
+			return Options{}, err
+		}
+		opts.RegistryPath = abs
+	}
+	if opts.Interval <= 0 {
+		opts.Interval = 10 * time.Second
+	}
+	if opts.PlistPath == "" {
+		path, err := DefaultPlistPath(opts.Label)
+		if err != nil {
+			return Options{}, err
+		}
+		opts.PlistPath = path
+	}
+	if opts.StdoutPath == "" || opts.StderrPath == "" {
+		stdoutPath, stderrPath, err := DefaultLogPaths(opts.Label)
+		if err != nil {
+			return Options{}, err
+		}
+		if opts.StdoutPath == "" {
+			opts.StdoutPath = stdoutPath
+		}
+		if opts.StderrPath == "" {
+			opts.StderrPath = stderrPath
+		}
+	}
+	return opts, nil
+}
+
+func Install(ctx context.Context, opts Options) error {
+	opts, err := NormalizeOptions(opts)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(opts.PlistPath), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(opts.StdoutPath), 0o755); err != nil {
+		return err
+	}
+	if err := ensureExistingPlistOwned(opts.PlistPath, opts.Label); err != nil {
+		return err
+	}
+	if err := writeFileAtomic(opts.PlistPath, BuildPlist(opts), 0o644); err != nil {
+		return err
+	}
+	if !opts.Load {
+		return nil
+	}
+	_ = runLaunchctl(ctx, "bootout", serviceTarget(opts.Label))
+	if err := runLaunchctl(ctx, "bootstrap", userDomain(), opts.PlistPath); err != nil {
+		return err
+	}
+	return runLaunchctl(ctx, "kickstart", "-k", userDomain()+"/"+opts.Label)
+}
+
+func Uninstall(ctx context.Context, label string, plistPath string, unload bool) error {
+	if label == "" {
+		label = DefaultLabel
+	}
+	if plistPath == "" {
+		path, err := DefaultPlistPath(label)
+		if err != nil {
+			return err
+		}
+		plistPath = path
+	}
+	if err := ensureExistingPlistOwned(plistPath, label); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	if unload {
+		_ = runLaunchctl(ctx, "bootout", serviceTarget(label))
+	}
+	err := os.Remove(plistPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func BuildPlist(opts Options) []byte {
+	args := []string{
+		opts.BinaryPath,
+		"supervise",
+		"--registry", opts.RegistryPath,
+		"--amq", opts.AMQPath,
+		"--self", opts.BinaryPath,
+		"--interval", opts.Interval.String(),
+	}
+	var buf bytes.Buffer
+	buf.WriteString(xml.Header)
+	buf.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	buf.WriteString(`<plist version="1.0">` + "\n")
+	buf.WriteString("<dict>\n")
+	writeKeyString(&buf, "Label", opts.Label)
+	writeKeyArray(&buf, "ProgramArguments", args)
+	writeKeyBool(&buf, "RunAtLoad", true)
+	writeKeyBool(&buf, "KeepAlive", true)
+	writeKeyString(&buf, "StandardOutPath", opts.StdoutPath)
+	writeKeyString(&buf, "StandardErrorPath", opts.StderrPath)
+	writeKeyDict(&buf, "EnvironmentVariables", map[string]string{
+		"PATH": "/Applications/cmux.app/Contents/Resources/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+	})
+	buf.WriteString("</dict>\n")
+	buf.WriteString("</plist>\n")
+	return buf.Bytes()
+}
+
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".plist-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
+func ensureExistingPlistOwned(path, label string) error {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !isOwnedPlist(data, label) {
+		return fmt.Errorf("refusing to modify non-amq-keepalive launchd plist %s", path)
+	}
+	return nil
+}
+
+func isOwnedPlist(data []byte, label string) bool {
+	return bytes.Contains(data, []byte("<key>Label</key>")) &&
+		bytes.Contains(data, []byte("<string>"+label+"</string>")) &&
+		bytes.Contains(data, []byte("<key>ProgramArguments</key>")) &&
+		bytes.Contains(data, []byte("<string>supervise</string>")) &&
+		bytes.Contains(data, []byte("<string>--registry</string>")) &&
+		bytes.Contains(data, []byte("<string>--amq</string>")) &&
+		bytes.Contains(data, []byte("<string>--self</string>"))
+}
+
+func runLaunchctl(ctx context.Context, args ...string) error {
+	out, err := exec.CommandContext(ctx, "launchctl", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("launchctl %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func userDomain() string {
+	return "gui/" + strconv.Itoa(os.Getuid())
+}
+
+func serviceTarget(label string) string {
+	return userDomain() + "/" + label
+}
+
+func writeKeyString(buf *bytes.Buffer, key string, value string) {
+	buf.WriteString("\t<key>")
+	_ = xml.EscapeText(buf, []byte(key))
+	buf.WriteString("</key>\n\t<string>")
+	_ = xml.EscapeText(buf, []byte(value))
+	buf.WriteString("</string>\n")
+}
+
+func writeKeyArray(buf *bytes.Buffer, key string, values []string) {
+	buf.WriteString("\t<key>")
+	_ = xml.EscapeText(buf, []byte(key))
+	buf.WriteString("</key>\n\t<array>\n")
+	for _, value := range values {
+		buf.WriteString("\t\t<string>")
+		_ = xml.EscapeText(buf, []byte(value))
+		buf.WriteString("</string>\n")
+	}
+	buf.WriteString("\t</array>\n")
+}
+
+func writeKeyBool(buf *bytes.Buffer, key string, value bool) {
+	buf.WriteString("\t<key>")
+	_ = xml.EscapeText(buf, []byte(key))
+	if value {
+		buf.WriteString("</key>\n\t<true/>\n")
+		return
+	}
+	buf.WriteString("</key>\n\t<false/>\n")
+}
+
+func writeKeyDict(buf *bytes.Buffer, key string, values map[string]string) {
+	buf.WriteString("\t<key>")
+	_ = xml.EscapeText(buf, []byte(key))
+	buf.WriteString("</key>\n\t<dict>\n")
+	keys := make([]string, 0, len(values))
+	for dictKey := range values {
+		keys = append(keys, dictKey)
+	}
+	sort.Strings(keys)
+	for _, dictKey := range keys {
+		value := values[dictKey]
+		buf.WriteString("\t\t<key>")
+		_ = xml.EscapeText(buf, []byte(dictKey))
+		buf.WriteString("</key>\n\t\t<string>")
+		_ = xml.EscapeText(buf, []byte(value))
+		buf.WriteString("</string>\n")
+	}
+	buf.WriteString("\t</dict>\n")
+}

--- a/internal/keepalive/launchd/launchd_test.go
+++ b/internal/keepalive/launchd/launchd_test.go
@@ -1,0 +1,174 @@
+package launchd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestBuildPlistContainsSupervisorContract(t *testing.T) {
+	opts := Options{
+		Label:        "com.example.amq-keepalive",
+		BinaryPath:   "/usr/local/bin/amq-keepalive",
+		RegistryPath: "/Users/test/.amq-keepalive/registry.json",
+		AMQPath:      "/opt/homebrew/bin/amq",
+		Interval:     15 * time.Second,
+		StdoutPath:   "/Users/test/Library/Logs/amq-keepalive/out.log",
+		StderrPath:   "/Users/test/Library/Logs/amq-keepalive/err.log",
+	}
+	plist := BuildPlist(opts)
+
+	for _, want := range []string{
+		"<key>Label</key>",
+		"<string>com.example.amq-keepalive</string>",
+		"<key>ProgramArguments</key>",
+		"<string>/usr/local/bin/amq-keepalive</string>",
+		"<string>supervise</string>",
+		"<string>--registry</string>",
+		"<string>/Users/test/.amq-keepalive/registry.json</string>",
+		"<string>--amq</string>",
+		"<string>/opt/homebrew/bin/amq</string>",
+		"<string>--self</string>",
+		"<string>--interval</string>",
+		"<string>15s</string>",
+		"<key>RunAtLoad</key>",
+		"<true/>",
+		"<key>KeepAlive</key>",
+		"/Applications/cmux.app/Contents/Resources/bin:/opt/homebrew/bin",
+	} {
+		if !bytes.Contains(plist, []byte(want)) {
+			t.Fatalf("plist missing %q:\n%s", want, plist)
+		}
+	}
+}
+
+func TestInstallNoLoadWritesPlist(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "LaunchAgents", "com.example.amq-keepalive.plist")
+	opts := Options{
+		Label:        "com.example.amq-keepalive",
+		PlistPath:    plistPath,
+		BinaryPath:   "/bin/echo",
+		RegistryPath: filepath.Join(dir, "registry.json"),
+		AMQPath:      "/bin/echo",
+		Interval:     time.Second,
+		Load:         false,
+	}
+	if err := Install(context.Background(), opts); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !bytes.Contains(data, []byte("<string>supervise</string>")) {
+		t.Fatalf("plist missing supervise command:\n%s", data)
+	}
+	info, err := os.Stat(plistPath)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("plist mode = %v, want 0644", got)
+	}
+}
+
+func TestUninstallNoUnloadRemovesPlist(t *testing.T) {
+	plistPath := filepath.Join(t.TempDir(), "com.example.amq-keepalive.plist")
+	data := BuildPlist(Options{
+		Label:        "com.example.amq-keepalive",
+		BinaryPath:   "/bin/echo",
+		RegistryPath: "/tmp/registry.json",
+		AMQPath:      "/bin/echo",
+		Interval:     time.Second,
+		StdoutPath:   "/tmp/out.log",
+		StderrPath:   "/tmp/err.log",
+	})
+	if err := os.WriteFile(plistPath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := Uninstall(context.Background(), "com.example.amq-keepalive", plistPath, false); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	if _, err := os.Stat(plistPath); !os.IsNotExist(err) {
+		t.Fatalf("Stat() error = %v, want not exist", err)
+	}
+}
+
+func TestInstallRefusesForeignPlist(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "LaunchAgents", "com.example.amq-keepalive.plist")
+	foreign := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.example.amq-keepalive</string>
+	<key>ProgramArguments</key>
+	<array><string>/usr/bin/true</string></array>
+</dict>
+</plist>
+`)
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(plistPath, foreign, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	opts := Options{
+		Label:        "com.example.amq-keepalive",
+		PlistPath:    plistPath,
+		BinaryPath:   "/bin/echo",
+		RegistryPath: filepath.Join(dir, "registry.json"),
+		AMQPath:      "/bin/echo",
+		Interval:     time.Second,
+		Load:         false,
+	}
+	if err := Install(context.Background(), opts); err == nil {
+		t.Fatal("Install() error = nil, want foreign plist refusal")
+	}
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !bytes.Equal(data, foreign) {
+		t.Fatalf("foreign plist was modified:\n%s", data)
+	}
+}
+
+func TestUninstallRefusesForeignPlist(t *testing.T) {
+	plistPath := filepath.Join(t.TempDir(), "com.example.amq-keepalive.plist")
+	foreign := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.example.amq-keepalive</string>
+	<key>ProgramArguments</key>
+	<array><string>/usr/bin/true</string></array>
+</dict>
+</plist>
+`)
+	if err := os.WriteFile(plistPath, foreign, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := Uninstall(context.Background(), "com.example.amq-keepalive", plistPath, false); err == nil {
+		t.Fatal("Uninstall() error = nil, want foreign plist refusal")
+	}
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !bytes.Equal(data, foreign) {
+		t.Fatalf("foreign plist was modified:\n%s", data)
+	}
+}
+
+func TestServiceTargetUsesLaunchdLabelTarget(t *testing.T) {
+	want := "gui/" + strconv.Itoa(os.Getuid()) + "/com.example.amq-keepalive"
+	if got := serviceTarget("com.example.amq-keepalive"); got != want {
+		t.Fatalf("serviceTarget() = %q, want %q", got, want)
+	}
+}

--- a/internal/keepalive/registry/flock_other.go
+++ b/internal/keepalive/registry/flock_other.go
@@ -1,0 +1,15 @@
+//go:build !unix
+
+package registry
+
+import "os"
+
+// flockExclusive is a compile-only fallback for platforms without flock
+// (e.g. Windows). Cross-process locking is not supported there; the
+// in-process mutex in withLock still serializes access within one process.
+func flockExclusive(_ *os.File) error {
+	return nil
+}
+
+// flockRelease matches the Unix implementation's signature.
+func flockRelease(_ *os.File) {}

--- a/internal/keepalive/registry/flock_unix.go
+++ b/internal/keepalive/registry/flock_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package registry
+
+import (
+	"os"
+	"syscall"
+)
+
+// flockExclusive takes an exclusive advisory lock on the open lock file,
+// blocking until it is available.
+func flockExclusive(lock *os.File) error {
+	return syscall.Flock(int(lock.Fd()), syscall.LOCK_EX)
+}
+
+// flockRelease releases the advisory lock taken by flockExclusive.
+func flockRelease(lock *os.File) {
+	_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+}

--- a/internal/keepalive/registry/store.go
+++ b/internal/keepalive/registry/store.go
@@ -1,0 +1,365 @@
+package registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	SchemaVersion = 1
+
+	StateAttached State = "attached"
+	StateActive   State = "active"
+	StateDetached State = "detached"
+	StateStale    State = "stale"
+)
+
+type State string
+
+type Entry struct {
+	ID                     string    `json:"id"`
+	Root                   string    `json:"root"`
+	BaseRoot               string    `json:"base_root,omitempty"`
+	SessionName            string    `json:"session_name,omitempty"`
+	Agent                  string    `json:"agent"`
+	Adapter                string    `json:"adapter"`
+	Target                 string    `json:"target"`
+	State                  State     `json:"state"`
+	LastAttach             time.Time `json:"last_attach,omitempty"`
+	LastSeenBySupervisor   time.Time `json:"last_seen_by_supervisor,omitempty"`
+	FailureCount           int       `json:"failure_count,omitempty"`
+	BackoffUntil           time.Time `json:"backoff_until,omitempty"`
+	LastError              string    `json:"last_error,omitempty"`
+	LastSupervisorDecision string    `json:"last_supervisor_decision,omitempty"`
+}
+
+type File struct {
+	SchemaVersion int     `json:"schema_version"`
+	Entries       []Entry `json:"entries"`
+}
+
+type Store struct {
+	Path string
+	Now  func() time.Time
+}
+
+var ErrCorrupt = errors.New("registry file is corrupt")
+
+var processLocks sync.Map
+
+func New(path string) *Store {
+	return &Store{Path: path, Now: time.Now}
+}
+
+func DefaultPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".amq-keepalive", "registry.json"), nil
+}
+
+func EntryID(root, agent, adapterName, target string) string {
+	sum := sha256.Sum256([]byte(root + "\x00" + agent + "\x00" + adapterName + "\x00" + target))
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *Store) Load() (File, error) {
+	if s.Path == "" {
+		return File{}, errors.New("registry path is required")
+	}
+	var file File
+	err := s.withLock(func() error {
+		loaded, err := s.loadUnlocked()
+		file = loaded
+		return err
+	})
+	return file, err
+}
+
+func (s *Store) loadUnlocked() (File, error) {
+	data, err := os.ReadFile(s.Path)
+	if errors.Is(err, os.ErrNotExist) {
+		return File{SchemaVersion: SchemaVersion}, nil
+	}
+	if err != nil {
+		return File{}, err
+	}
+	var file File
+	if err := json.Unmarshal(data, &file); err != nil {
+		return File{}, fmt.Errorf("%w %q: %w", ErrCorrupt, s.Path, err)
+	}
+	if file.SchemaVersion == 0 {
+		file.SchemaVersion = SchemaVersion
+	}
+	if file.SchemaVersion != SchemaVersion {
+		return File{}, fmt.Errorf("unsupported registry schema version %d", file.SchemaVersion)
+	}
+	sortEntries(file.Entries)
+	return file, nil
+}
+
+func (s *Store) Save(file File) error {
+	if s.Path == "" {
+		return errors.New("registry path is required")
+	}
+	return s.withLock(func() error {
+		return s.saveUnlocked(file)
+	})
+}
+
+func (s *Store) saveUnlocked(file File) error {
+	file.SchemaVersion = SchemaVersion
+	sortEntries(file.Entries)
+
+	dir := filepath.Dir(s.Path)
+	tmp, err := os.CreateTemp(dir, ".registry-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(file); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, s.Path); err != nil {
+		return err
+	}
+	if err := os.Chmod(s.Path, 0o600); err != nil {
+		return err
+	}
+	return syncDir(dir)
+}
+
+func (s *Store) Upsert(entry Entry) (Entry, error) {
+	prepared, err := s.prepareEntry(entry)
+	if err != nil {
+		return Entry{}, err
+	}
+
+	err = s.withLock(func() error {
+		file, err := s.loadUnlocked()
+		if err != nil {
+			return err
+		}
+		replaced := false
+		for i := range file.Entries {
+			if file.Entries[i].ID == prepared.ID {
+				file.Entries[i] = prepared
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			file.Entries = append(file.Entries, prepared)
+		}
+		return s.saveUnlocked(file)
+	})
+	return prepared, err
+}
+
+func (s *Store) ReplaceSessionAdapter(entry Entry) (Entry, []Entry, error) {
+	prepared, err := s.prepareEntry(entry)
+	if err != nil {
+		return Entry{}, nil, err
+	}
+
+	var removed []Entry
+	err = s.withLock(func() error {
+		file, err := s.loadUnlocked()
+		if err != nil {
+			return err
+		}
+		next := make([]Entry, 0, len(file.Entries)+1)
+		for _, existing := range file.Entries {
+			// AMQ permits one wake process per root and agent. Reattach therefore
+			// replaces the old registration even when the terminal adapter changed.
+			if existing.Root == prepared.Root && existing.Agent == prepared.Agent {
+				removed = append(removed, existing)
+				continue
+			}
+			next = append(next, existing)
+		}
+		next = append(next, prepared)
+		file.Entries = next
+		return s.saveUnlocked(file)
+	})
+	return prepared, removed, err
+}
+
+func (s *Store) prepareEntry(entry Entry) (Entry, error) {
+	now := s.now()
+	if entry.Root == "" {
+		return Entry{}, errors.New("entry root is required")
+	}
+	if entry.Agent == "" {
+		return Entry{}, errors.New("entry agent is required")
+	}
+	if entry.Adapter == "" {
+		return Entry{}, errors.New("entry adapter is required")
+	}
+	if entry.Target == "" {
+		return Entry{}, errors.New("entry target is required")
+	}
+	if entry.ID == "" {
+		entry.ID = EntryID(entry.Root, entry.Agent, entry.Adapter, entry.Target)
+	}
+	if entry.State == "" {
+		entry.State = StateAttached
+	}
+	if entry.LastAttach.IsZero() {
+		entry.LastAttach = now
+	}
+	return entry, nil
+}
+
+func (s *Store) UpdateEntry(entry Entry) error {
+	return s.withLock(func() error {
+		file, err := s.loadUnlocked()
+		if err != nil {
+			return err
+		}
+		for i := range file.Entries {
+			if file.Entries[i].ID == entry.ID {
+				file.Entries[i] = entry
+				return s.saveUnlocked(file)
+			}
+		}
+		return fmt.Errorf("registry entry %q not found", entry.ID)
+	})
+}
+
+func (s *Store) Forget(id string) (bool, error) {
+	removed, err := s.ForgetMany([]string{id})
+	return removed == 1, err
+}
+
+func (s *Store) ForgetMany(ids []string) (int, error) {
+	wanted := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			wanted[id] = struct{}{}
+		}
+	}
+	removed := 0
+	err := s.withLock(func() error {
+		file, err := s.loadUnlocked()
+		if err != nil {
+			return err
+		}
+		found := 0
+		for _, entry := range file.Entries {
+			if _, ok := wanted[entry.ID]; ok {
+				found++
+			}
+		}
+		if found != len(wanted) {
+			return fmt.Errorf("found %d of %d registry entries requested for removal", found, len(wanted))
+		}
+		next := file.Entries[:0]
+		for _, entry := range file.Entries {
+			if _, ok := wanted[entry.ID]; ok {
+				removed++
+				continue
+			}
+			next = append(next, entry)
+		}
+		file.Entries = next
+		return s.saveUnlocked(file)
+	})
+	return removed, err
+}
+
+func (s *Store) now() time.Time {
+	if s.Now != nil {
+		return s.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func sortEntries(entries []Entry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].ID < entries[j].ID
+	})
+}
+
+func (s *Store) withLock(fn func() error) error {
+	if s.Path == "" {
+		return errors.New("registry path is required")
+	}
+	path, err := filepath.Abs(s.Path)
+	if err != nil {
+		return err
+	}
+	mutexValue, _ := processLocks.LoadOrStore(path, &sync.Mutex{})
+	mutex := mutexValue.(*sync.Mutex)
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	dir := filepath.Dir(s.Path)
+	if err := ensureRegistryDir(dir); err != nil {
+		return err
+	}
+
+	lock, err := os.OpenFile(s.Path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lock.Close() }()
+	if err := lock.Chmod(0o600); err != nil {
+		return err
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
+
+	return fn()
+}
+
+func ensureRegistryDir(dir string) error {
+	_, err := os.Stat(dir)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return os.Chmod(dir, 0o700)
+}
+
+func syncDir(dir string) error {
+	file, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	return file.Sync()
+}

--- a/internal/keepalive/registry/store.go
+++ b/internal/keepalive/registry/store.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -333,10 +332,10 @@ func (s *Store) withLock(fn func() error) error {
 	if err := lock.Chmod(0o600); err != nil {
 		return err
 	}
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+	if err := flockExclusive(lock); err != nil {
 		return err
 	}
-	defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
+	defer flockRelease(lock)
 
 	return fn()
 }

--- a/internal/keepalive/registry/store_test.go
+++ b/internal/keepalive/registry/store_test.go
@@ -1,0 +1,318 @@
+package registry
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStoreUpsertRoundTripAndPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".amq-keepalive", "registry.json")
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	store := New(path)
+	store.Now = func() time.Time { return now }
+
+	entry, err := store.Upsert(Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "file",
+		Target:  "/tmp/inbox.txt",
+	})
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	if entry.ID == "" {
+		t.Fatal("entry ID is empty")
+	}
+	if entry.State != StateAttached {
+		t.Fatalf("state = %q, want %q", entry.State, StateAttached)
+	}
+	if !entry.LastAttach.Equal(now) {
+		t.Fatalf("LastAttach = %v, want %v", entry.LastAttach, now)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema = %d, want %d", loaded.SchemaVersion, SchemaVersion)
+	}
+	if len(loaded.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(loaded.Entries))
+	}
+	if loaded.Entries[0].ID != entry.ID {
+		t.Fatalf("loaded ID = %q, want %q", loaded.Entries[0].ID, entry.ID)
+	}
+
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("dir mode = %v, want 0700", got)
+	}
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat registry: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("file mode = %v, want 0600", got)
+	}
+}
+
+func TestStoreForget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	store := New(path)
+	entry, err := store.Upsert(Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "file",
+		Target:  "/tmp/inbox.txt",
+	})
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	removed, err := store.Forget(entry.ID)
+	if err != nil {
+		t.Fatalf("Forget() error = %v", err)
+	}
+	if !removed {
+		t.Fatal("Forget() removed = false, want true")
+	}
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Entries) != 0 {
+		t.Fatalf("entries = %d, want 0", len(loaded.Entries))
+	}
+}
+
+func TestStoreForgetManyRemovesRequestedEntriesInOneSave(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	store := New(path)
+	var ids []string
+	for _, agent := range []string{"codex", "claude", "observer"} {
+		entry, err := store.Upsert(Entry{Root: "/tmp/amq-root", Agent: agent, Adapter: "file", Target: "/tmp/" + agent})
+		if err != nil {
+			t.Fatalf("Upsert(%s): %v", agent, err)
+		}
+		ids = append(ids, entry.ID)
+	}
+	removed, err := store.ForgetMany(ids[:2])
+	if err != nil || removed != 2 {
+		t.Fatalf("ForgetMany removed=%d err=%v", removed, err)
+	}
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Entries) != 1 || loaded.Entries[0].Agent != "observer" {
+		t.Fatalf("entries=%#v, want observer only", loaded.Entries)
+	}
+}
+
+func TestStoreForgetManyRefusesPartialMatchWithoutRemovingAnything(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	store := New(path)
+	entry, err := store.Upsert(Entry{Root: "/tmp/amq-root", Agent: "codex", Adapter: "file", Target: "/tmp/codex"})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	removed, err := store.ForgetMany([]string{entry.ID, "missing-id"})
+	if err == nil || removed != 0 {
+		t.Fatalf("ForgetMany removed=%d err=%v, want refusal", removed, err)
+	}
+	loaded, loadErr := store.Load()
+	if loadErr != nil || len(loaded.Entries) != 1 || loaded.Entries[0].ID != entry.ID {
+		t.Fatalf("registry changed after partial-match refusal: entries=%#v err=%v", loaded.Entries, loadErr)
+	}
+}
+
+func TestStoreDoesNotChmodExistingCustomRegistryDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "custom")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	store := New(filepath.Join(dir, "registry.json"))
+	_, err := store.Upsert(Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "file",
+		Target:  "/tmp/inbox.txt",
+	})
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("dir mode = %v, want existing 0755 preserved", got)
+	}
+}
+
+func TestStoreReplaceSessionAdapterRemovesAllEntriesForRootAndAgent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	store := New(path)
+
+	replaceMe, err := store.Upsert(Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "file",
+		Target:  "/tmp/old-inbox.txt",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(replaceMe) error = %v", err)
+	}
+	keepDifferentAgent, err := store.Upsert(Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "claude",
+		Adapter: "file",
+		Target:  "/tmp/claude-inbox.txt",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(keepDifferentAgent) error = %v", err)
+	}
+	replaceDifferentAdapter, err := store.Upsert(Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "ghostty",
+		Target:  "ghostty:terminal:old",
+	})
+	if err != nil {
+		t.Fatalf("Upsert(replaceDifferentAdapter) error = %v", err)
+	}
+
+	next, removed, err := store.ReplaceSessionAdapter(Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "cmux",
+		Target:  "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3",
+	})
+	if err != nil {
+		t.Fatalf("ReplaceSessionAdapter() error = %v", err)
+	}
+	if next.Adapter != "cmux" {
+		t.Fatalf("Adapter = %q, want cmux", next.Adapter)
+	}
+	removedIDs := map[string]bool{}
+	for _, entry := range removed {
+		removedIDs[entry.ID] = true
+	}
+	if len(removed) != 2 || !removedIDs[replaceMe.ID] || !removedIDs[replaceDifferentAdapter.ID] {
+		t.Fatalf("removed = %#v, want old file and Ghostty entries", removed)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(loaded.Entries))
+	}
+	ids := map[string]bool{}
+	for _, entry := range loaded.Entries {
+		ids[entry.ID] = true
+		if entry.ID == replaceMe.ID || entry.ID == replaceDifferentAdapter.ID {
+			t.Fatalf("old matching entry still present: %#v", entry)
+		}
+	}
+	for _, want := range []string{keepDifferentAgent.ID, next.ID} {
+		if !ids[want] {
+			t.Fatalf("entry %q missing after replace; entries=%#v", want, loaded.Entries)
+		}
+	}
+}
+
+func TestStoreConcurrentUpsertsDoNotLoseEntries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	store := New(path)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := store.Upsert(Entry{
+				Root:    "/tmp/amq-root",
+				Agent:   "codex",
+				Adapter: "file",
+				Target:  filepath.Join("/tmp", "inbox", string(rune('a'+i))),
+			})
+			if err != nil {
+				t.Errorf("Upsert(%d) error = %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Entries) != 20 {
+		t.Fatalf("entries = %d, want 20", len(loaded.Entries))
+	}
+}
+
+func TestStoreConcurrentSameTargetReplacementsConverge(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	store := New(path)
+	if _, err := store.Upsert(Entry{
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "ghostty",
+		Target:  "ghostty:terminal:old",
+	}); err != nil {
+		t.Fatalf("Upsert(old) error = %v", err)
+	}
+
+	const target = "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, _, err := store.ReplaceSessionAdapter(Entry{
+				Root:    "/tmp/amq-root",
+				Agent:   "codex",
+				Adapter: "cmux",
+				Target:  target,
+			}); err != nil {
+				t.Errorf("ReplaceSessionAdapter() error = %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Entries) != 1 || loaded.Entries[0].Adapter != "cmux" || loaded.Entries[0].Target != target {
+		t.Fatalf("entries = %#v, want one converged cmux registration", loaded.Entries)
+	}
+}
+
+func TestStoreCorruptRegistryReturnsTypedError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "registry.json")
+	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	store := New(path)
+
+	_, err := store.Load()
+	if !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("Load() error = %v, want ErrCorrupt", err)
+	}
+}

--- a/internal/keepalive/supervisor/supervisor.go
+++ b/internal/keepalive/supervisor/supervisor.go
@@ -1,0 +1,195 @@
+package supervisor
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/amq"
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/registry"
+)
+
+const (
+	ActionBackoff     = "backoff"
+	ActionDetached    = "detached"
+	ActionEnsured     = "ensured"
+	ActionStartFailed = "start_failed"
+)
+
+type Adapter interface {
+	Probe(ctx context.Context, target string) error
+}
+
+type WakeRunner interface {
+	StartWake(ctx context.Context, req amq.StartWakeRequest) error
+}
+
+type Reconciler struct {
+	Wake        WakeRunner
+	Adapter     Adapter
+	Now         func() time.Time
+	BackoffBase time.Duration
+	BackoffMax  time.Duration
+	Jitter      func(time.Duration) time.Duration
+	InjectVia   string
+	WakeTimeout time.Duration
+}
+
+type Result struct {
+	Action     string
+	AMQTouched bool
+	Error      error
+}
+
+func (r Reconciler) Reconcile(ctx context.Context, entry registry.Entry) (registry.Entry, Result) {
+	now := r.now()
+	entry.LastSeenBySupervisor = now
+
+	if blocked, result, ok := r.checkLocalReadiness(ctx, entry, now); ok {
+		return blocked, result
+	}
+
+	// The registry target is authoritative. StartWake uses AMQ's target-aware
+	// --accept-existing-wake path, which removes stale locks, starts missing
+	// wakes, accepts an exact live target, and rejects a different live target.
+	// Calling wake repair first could resurrect an obsolete persisted adapter.
+	return r.ensureWake(ctx, entry, now)
+}
+
+func (r Reconciler) StartFresh(ctx context.Context, entry registry.Entry) (registry.Entry, Result) {
+	now := r.now()
+	entry.LastSeenBySupervisor = now
+
+	if blocked, result, ok := r.checkLocalReadiness(ctx, entry, now); ok {
+		return blocked, result
+	}
+
+	return r.ensureWake(ctx, entry, now)
+}
+
+func (r Reconciler) checkLocalReadiness(ctx context.Context, entry registry.Entry, now time.Time) (registry.Entry, Result, bool) {
+	if !entry.BackoffUntil.IsZero() && now.Before(entry.BackoffUntil) {
+		entry.LastSupervisorDecision = ActionBackoff
+		return entry, Result{Action: ActionBackoff}, true
+	}
+
+	if r.Adapter == nil {
+		updated, result := r.markBackoff(entry, now, errors.New("adapter is not configured"), ActionBackoff, false)
+		return updated, result, true
+	}
+	if err := r.Adapter.Probe(ctx, entry.Target); err != nil {
+		entry.State = registry.StateDetached
+		entry.LastError = err.Error()
+		entry.LastSupervisorDecision = ActionDetached
+		return entry, Result{Action: ActionDetached, Error: err}, true
+	}
+
+	if r.Wake == nil {
+		updated, result := r.markBackoff(entry, now, errors.New("amq runner is not configured"), ActionBackoff, false)
+		return updated, result, true
+	}
+	return entry, Result{}, false
+}
+
+func (r Reconciler) ensureWake(ctx context.Context, entry registry.Entry, now time.Time) (registry.Entry, Result) {
+	err := r.Wake.StartWake(ctx, amq.StartWakeRequest{
+		Root:      entry.Root,
+		Me:        entry.Agent,
+		InjectVia: r.InjectVia,
+		Adapter:   entry.Adapter,
+		Target:    entry.Target,
+		Timeout:   r.WakeTimeout,
+	})
+	if err == nil {
+		return markActive(entry, now, ActionEnsured), Result{Action: ActionEnsured, AMQTouched: true}
+	}
+	return r.markBackoff(entry, now, err, ActionStartFailed, true)
+}
+
+func (r Reconciler) markBackoff(entry registry.Entry, now time.Time, err error, action string, amqTouched bool) (registry.Entry, Result) {
+	entry.State = registry.StateAttached
+	entry.FailureCount++
+	entry.BackoffUntil = now.Add(r.backoff(entry.FailureCount))
+	entry.LastSupervisorDecision = action
+	if err != nil {
+		entry.LastError = err.Error()
+	}
+	return entry, Result{Action: action, AMQTouched: amqTouched, Error: err}
+}
+
+func markActive(entry registry.Entry, now time.Time, action string) registry.Entry {
+	entry.State = registry.StateActive
+	entry.LastSeenBySupervisor = now
+	entry.FailureCount = 0
+	entry.BackoffUntil = time.Time{}
+	entry.LastError = ""
+	entry.LastSupervisorDecision = action
+	return entry
+}
+
+func (r Reconciler) now() time.Time {
+	if r.Now != nil {
+		return r.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (r Reconciler) backoff(failureCount int) time.Duration {
+	base := r.BackoffBase
+	if base <= 0 {
+		base = time.Second
+	}
+	maxDelay := r.BackoffMax
+	if maxDelay <= 0 {
+		maxDelay = time.Minute
+	}
+	if failureCount < 1 {
+		failureCount = 1
+	}
+	delay := base
+	for i := 1; i < failureCount; i++ {
+		delay *= 2
+		if delay >= maxDelay {
+			return maxDelay
+		}
+	}
+	if delay > maxDelay {
+		return maxDelay
+	}
+	return r.jitter(delay, maxDelay)
+}
+
+func (r Reconciler) jitter(delay time.Duration, maxDelay time.Duration) time.Duration {
+	if r.Jitter != nil {
+		jittered := r.Jitter(delay)
+		if jittered < 0 {
+			return 0
+		}
+		if jittered > maxDelay {
+			return maxDelay
+		}
+		return jittered
+	}
+	if delay <= 0 {
+		return delay
+	}
+	window := delay / 5
+	if window <= 0 {
+		return delay
+	}
+	span := int64(window*2) + 1
+	offset, err := rand.Int(rand.Reader, big.NewInt(span))
+	if err != nil {
+		return delay
+	}
+	jittered := delay - window + time.Duration(offset.Int64())
+	if jittered < 0 {
+		return 0
+	}
+	if jittered > maxDelay {
+		return maxDelay
+	}
+	return jittered
+}

--- a/internal/keepalive/supervisor/supervisor_test.go
+++ b/internal/keepalive/supervisor/supervisor_test.go
@@ -1,0 +1,271 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/amq"
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/registry"
+)
+
+type fakeWake struct {
+	repairCalls int
+	starts      []amq.StartWakeRequest
+	startErr    error
+}
+
+func (f *fakeWake) RepairWake(ctx context.Context, root, me string) (amq.WakeRepairResult, error) {
+	f.repairCalls++
+	return amq.WakeRepairResult{Status: "repaired", Reason: "would restore persisted target"}, nil
+}
+
+func (f *fakeWake) StartWake(ctx context.Context, req amq.StartWakeRequest) error {
+	f.starts = append(f.starts, req)
+	return f.startErr
+}
+
+type probeAdapter struct {
+	err error
+}
+
+func (p probeAdapter) Probe(ctx context.Context, target string) error {
+	return p.err
+}
+
+func TestReconcileEnsuresRegistryTarget(t *testing.T) {
+	now := fixedNow()
+	wake := &fakeWake{}
+
+	updated, result := testReconciler(wake, probeAdapter{}, now).Reconcile(context.Background(), testEntry())
+
+	if result.Action != ActionEnsured {
+		t.Fatalf("action = %q, want %q", result.Action, ActionEnsured)
+	}
+	if len(wake.starts) != 1 {
+		t.Fatalf("ensure calls = %d, want 1", len(wake.starts))
+	}
+	if wake.repairCalls != 0 {
+		t.Fatalf("repairCalls = %d, want 0", wake.repairCalls)
+	}
+	if wake.starts[0].Timeout != 7*time.Second {
+		t.Fatalf("start timeout = %s, want 7s", wake.starts[0].Timeout)
+	}
+	if updated.State != registry.StateActive {
+		t.Fatalf("state = %q, want %q", updated.State, registry.StateActive)
+	}
+	if updated.FailureCount != 0 || !updated.BackoffUntil.IsZero() || updated.LastError != "" {
+		t.Fatalf("active entry retained failure data: %+v", updated)
+	}
+}
+
+func TestReconcileNeverRepairsPersistedTargetBeforeEnsuringRegistryTarget(t *testing.T) {
+	now := fixedNow()
+	wake := &fakeWake{}
+	entry := testEntry()
+	entry.Adapter = "cmux"
+	entry.Target = "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
+
+	updated, result := testReconciler(wake, probeAdapter{}, now).Reconcile(context.Background(), entry)
+
+	if wake.repairCalls != 0 {
+		t.Fatalf("repairCalls = %d, want 0; repair could resurrect the persisted Ghostty target", wake.repairCalls)
+	}
+	if len(wake.starts) != 1 || wake.starts[0].Adapter != "cmux" || wake.starts[0].Target != entry.Target {
+		t.Fatalf("ensure requests = %#v, want exact registry cmux target", wake.starts)
+	}
+	if result.Action != ActionEnsured || updated.State != registry.StateActive {
+		t.Fatalf("result = %+v updated = %+v, want ensured active target", result, updated)
+	}
+}
+
+func TestWrongExistingTargetFailsClosedInsteadOfMarkingActive(t *testing.T) {
+	now := fixedNow()
+	wake := &fakeWake{
+		startErr: errors.New("existing wake inject-via target does not match requested target"),
+	}
+	entry := testEntry()
+	entry.Adapter = "cmux"
+	entry.Target = "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
+
+	updated, result := testReconciler(wake, probeAdapter{}, now).Reconcile(context.Background(), entry)
+
+	if result.Action != ActionStartFailed {
+		t.Fatalf("action = %q, want %q", result.Action, ActionStartFailed)
+	}
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "does not match") {
+		t.Fatalf("error = %v, want target mismatch", result.Error)
+	}
+	if updated.State == registry.StateActive {
+		t.Fatalf("state = %q, must not mark wrong target active", updated.State)
+	}
+	if updated.LastError == "" || updated.FailureCount != 1 {
+		t.Fatalf("failure state not persisted: %+v", updated)
+	}
+}
+
+func TestStartFreshStartsWithoutRepair(t *testing.T) {
+	now := fixedNow()
+	wake := &fakeWake{}
+
+	updated, result := testReconciler(wake, probeAdapter{}, now).StartFresh(context.Background(), testEntry())
+
+	if wake.repairCalls != 0 {
+		t.Fatalf("repairCalls = %d, want 0", wake.repairCalls)
+	}
+	if len(wake.starts) != 1 {
+		t.Fatalf("starts = %d, want 1", len(wake.starts))
+	}
+	if result.Action != ActionEnsured {
+		t.Fatalf("action = %q, want %q", result.Action, ActionEnsured)
+	}
+	if updated.State != registry.StateActive {
+		t.Fatalf("state = %q, want %q", updated.State, registry.StateActive)
+	}
+}
+
+func TestStartFreshDoesNotAcceptAlreadyRunningAsSuccess(t *testing.T) {
+	now := fixedNow()
+	wake := &fakeWake{startErr: amq.ErrAlreadyRunning}
+
+	updated, result := testReconciler(wake, probeAdapter{}, now).StartFresh(context.Background(), testEntry())
+
+	if result.Action != ActionStartFailed {
+		t.Fatalf("action = %q, want %q", result.Action, ActionStartFailed)
+	}
+	if !errors.Is(result.Error, amq.ErrAlreadyRunning) {
+		t.Fatalf("error = %v, want ErrAlreadyRunning", result.Error)
+	}
+	if updated.State != registry.StateAttached {
+		t.Fatalf("state = %q, want %q", updated.State, registry.StateAttached)
+	}
+	if updated.LastSupervisorDecision != ActionStartFailed {
+		t.Fatalf("LastSupervisorDecision = %q, want %q", updated.LastSupervisorDecision, ActionStartFailed)
+	}
+}
+
+func TestUnverifiedWakeEnsureBacksOffWithoutRepair(t *testing.T) {
+	now := fixedNow()
+	wake := &fakeWake{startErr: errors.New("wake lock is unverified; refusing second injector")}
+
+	reconciler := testReconciler(wake, probeAdapter{}, now)
+	reconciler.Jitter = func(delay time.Duration) time.Duration { return delay + delay/10 }
+	updated, result := reconciler.Reconcile(context.Background(), testEntry())
+
+	if result.Action != ActionStartFailed {
+		t.Fatalf("action = %q, want %q", result.Action, ActionStartFailed)
+	}
+	if len(wake.starts) != 1 {
+		t.Fatalf("ensure calls = %d, want 1", len(wake.starts))
+	}
+	if wake.repairCalls != 0 {
+		t.Fatalf("repairCalls = %d, want 0", wake.repairCalls)
+	}
+	if updated.State != registry.StateAttached {
+		t.Fatalf("state = %q, want %q", updated.State, registry.StateAttached)
+	}
+	if updated.FailureCount != 1 {
+		t.Fatalf("FailureCount = %d, want 1", updated.FailureCount)
+	}
+	if !updated.BackoffUntil.After(now) {
+		t.Fatalf("BackoffUntil = %v, want after %v", updated.BackoffUntil, now)
+	}
+	if got, want := updated.BackoffUntil.Sub(now), 1100*time.Millisecond; got != want {
+		t.Fatalf("BackoffUntil-now = %v, want %v", got, want)
+	}
+}
+
+func TestDetachedTargetDoesNotTouchAMQ(t *testing.T) {
+	now := fixedNow()
+	wake := &fakeWake{}
+
+	updated, result := testReconciler(wake, probeAdapter{err: errors.New("target gone")}, now).Reconcile(context.Background(), testEntry())
+
+	if result.Action != ActionDetached {
+		t.Fatalf("action = %q, want %q", result.Action, ActionDetached)
+	}
+	if result.AMQTouched {
+		t.Fatal("AMQTouched = true, want false")
+	}
+	if len(wake.starts) != 0 {
+		t.Fatalf("starts = %d, want 0", len(wake.starts))
+	}
+	if updated.State != registry.StateDetached {
+		t.Fatalf("state = %q, want %q", updated.State, registry.StateDetached)
+	}
+}
+
+func TestRepeatedReconcileUsesTargetAwareEnsure(t *testing.T) {
+	now := fixedNow()
+	wake := &fakeWake{}
+	reconciler := testReconciler(wake, probeAdapter{}, now)
+
+	updated, result := reconciler.Reconcile(context.Background(), testEntry())
+	if result.Action != ActionEnsured {
+		t.Fatalf("first action = %q, want %q", result.Action, ActionEnsured)
+	}
+	updated, result = reconciler.Reconcile(context.Background(), updated)
+
+	if result.Action != ActionEnsured {
+		t.Fatalf("second action = %q, want %q", result.Action, ActionEnsured)
+	}
+	if len(wake.starts) != 2 {
+		t.Fatalf("wake assertions = %d, want one exact-target ensure per pass", len(wake.starts))
+	}
+	if wake.starts[0].Target != wake.starts[1].Target || wake.starts[0].Adapter != wake.starts[1].Adapter {
+		t.Fatalf("ensure requests drifted: %#v", wake.starts)
+	}
+	if updated.State != registry.StateActive {
+		t.Fatalf("state = %q, want %q", updated.State, registry.StateActive)
+	}
+}
+
+func TestNilWakeBackoffDoesNotReportAMQTouched(t *testing.T) {
+	now := fixedNow()
+
+	updated, result := Reconciler{
+		Adapter:     probeAdapter{},
+		Now:         func() time.Time { return now },
+		BackoffBase: time.Second,
+		Jitter:      func(delay time.Duration) time.Duration { return delay },
+	}.Reconcile(context.Background(), testEntry())
+
+	if result.Action != ActionBackoff {
+		t.Fatalf("action = %q, want %q", result.Action, ActionBackoff)
+	}
+	if result.AMQTouched {
+		t.Fatal("AMQTouched = true, want false")
+	}
+	if updated.State != registry.StateAttached {
+		t.Fatalf("state = %q, want %q", updated.State, registry.StateAttached)
+	}
+}
+
+func testReconciler(wake *fakeWake, adapter probeAdapter, now time.Time) Reconciler {
+	return Reconciler{
+		Wake:        wake,
+		Adapter:     adapter,
+		Now:         func() time.Time { return now },
+		BackoffBase: time.Second,
+		Jitter:      func(delay time.Duration) time.Duration { return delay },
+		InjectVia:   "/bin/amq-keepalive",
+		WakeTimeout: 7 * time.Second,
+	}
+}
+
+func testEntry() registry.Entry {
+	return registry.Entry{
+		ID:      "entry-1",
+		Root:    "/tmp/amq-root",
+		Agent:   "codex",
+		Adapter: "file",
+		Target:  "/tmp/inbox.txt",
+		State:   registry.StateAttached,
+	}
+}
+
+func fixedNow() time.Time {
+	return time.Date(2026, 6, 26, 15, 0, 0, 0, time.UTC)
+}

--- a/scripts/amq-keepalive-session-start.sh
+++ b/scripts/amq-keepalive-session-start.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# SessionStart hook wrapper for amq-keepalive.
+#
+# This hook is intentionally non-blocking: it logs reattach failures and always
+# returns an empty hook response so agent startup is not held hostage by AMQ.
+
+set -u
+
+BIN="${AMQ_KEEPALIVE_BIN:-amq-keepalive}"
+ADAPTER="${AMQ_KEEPALIVE_ADAPTER:-}"
+TARGET="${AMQ_KEEPALIVE_TARGET:-}"
+REGISTRY="${AMQ_KEEPALIVE_REGISTRY:-}"
+AMQ_BIN="${AMQ_KEEPALIVE_AMQ:-amq}"
+SELF_BIN="${AMQ_KEEPALIVE_SELF:-$BIN}"
+ROOT="${AMQ_KEEPALIVE_ROOT:-}"
+BASE_ROOT="${AMQ_KEEPALIVE_BASE_ROOT:-}"
+SESSION_NAME="${AMQ_KEEPALIVE_SESSION:-}"
+ME="${AMQ_KEEPALIVE_ME:-}"
+LOG_PATH="${AMQ_KEEPALIVE_LOG:-$HOME/.amq-keepalive/session-start.log}"
+DEFAULT_TIMEOUT_SECONDS="${AMQ_KEEPALIVE_DEFAULT_TIMEOUT_SECONDS:-10}"
+TIMEOUT_SECONDS="${AMQ_KEEPALIVE_TIMEOUT_SECONDS:-$DEFAULT_TIMEOUT_SECONDS}"
+STDIN_TIMEOUT_SECONDS="${AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS:-1}"
+WAKE_TIMEOUT_MILLISECONDS="${AMQ_KEEPALIVE_WAKE_TIMEOUT_MILLISECONDS:-}"
+
+if [[ -z "$ADAPTER" ]]; then
+    if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
+        ADAPTER="cmux"
+    else
+        ADAPTER="ghostty"
+    fi
+fi
+if [[ "$ADAPTER" == "cmux" && -z "$TARGET" && -n "${CMUX_SURFACE_ID:-}" ]]; then
+    TARGET="cmux:surface:${CMUX_SURFACE_ID}"
+fi
+
+if [[ "${AMQ_KEEPALIVE_DISABLED:-0}" == "1" ]]; then
+    printf '{}\n'
+    exit 0
+fi
+
+mkdir -p "$(dirname "$LOG_PATH")" 2>/dev/null || true
+
+log() {
+    printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$LOG_PATH" 2>/dev/null || true
+}
+
+if ! [[ "$DEFAULT_TIMEOUT_SECONDS" =~ ^[0-9]+$ && "$DEFAULT_TIMEOUT_SECONDS" -gt 0 ]]; then
+    DEFAULT_TIMEOUT_SECONDS=10
+fi
+if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ && "$TIMEOUT_SECONDS" -gt 0 ]]; then
+    log "invalid timeout ${TIMEOUT_SECONDS}; using ${DEFAULT_TIMEOUT_SECONDS}s"
+    TIMEOUT_SECONDS="$DEFAULT_TIMEOUT_SECONDS"
+fi
+if ! [[ "$STDIN_TIMEOUT_SECONDS" =~ ^[0-9]+$ && "$STDIN_TIMEOUT_SECONDS" -gt 0 ]]; then
+    STDIN_TIMEOUT_SECONDS=1
+fi
+
+outer_timeout_milliseconds=$((TIMEOUT_SECONDS * 1000))
+default_wake_timeout_milliseconds=$((outer_timeout_milliseconds - 2000))
+if [[ "$default_wake_timeout_milliseconds" -le 0 ]]; then
+    default_wake_timeout_milliseconds=$((outer_timeout_milliseconds / 2))
+fi
+if [[ "$default_wake_timeout_milliseconds" -le 0 ]]; then
+    default_wake_timeout_milliseconds=100
+fi
+if ! [[ "$WAKE_TIMEOUT_MILLISECONDS" =~ ^[0-9]+$ && "$WAKE_TIMEOUT_MILLISECONDS" -gt 0 ]]; then
+    [[ -n "$WAKE_TIMEOUT_MILLISECONDS" ]] && log "invalid wake timeout ${WAKE_TIMEOUT_MILLISECONDS}ms; using ${default_wake_timeout_milliseconds}ms"
+    WAKE_TIMEOUT_MILLISECONDS="$default_wake_timeout_milliseconds"
+fi
+if [[ "$WAKE_TIMEOUT_MILLISECONDS" -ge "$outer_timeout_milliseconds" ]]; then
+    clamped_wake_timeout_milliseconds=$((outer_timeout_milliseconds - 500))
+    if [[ "$clamped_wake_timeout_milliseconds" -le 0 ]]; then
+        clamped_wake_timeout_milliseconds=100
+    fi
+    log "wake timeout ${WAKE_TIMEOUT_MILLISECONDS}ms must be shorter than outer ${outer_timeout_milliseconds}ms; using ${clamped_wake_timeout_milliseconds}ms"
+    WAKE_TIMEOUT_MILLISECONDS="$clamped_wake_timeout_milliseconds"
+fi
+
+read_hook_input() {
+    local line=""
+    IFS= read -r -t "$STDIN_TIMEOUT_SECONDS" line || true
+    printf '%s' "$line"
+}
+
+INPUT="$(read_hook_input 2>/dev/null || true)"
+
+CWD=""
+if command -v jq >/dev/null 2>&1 && [[ -n "$INPUT" ]]; then
+    CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // .workdir // .working_directory // empty' 2>/dev/null || true)"
+fi
+if [[ -n "$CWD" && -d "$CWD" ]]; then
+    cd "$CWD" 2>/dev/null || true
+fi
+
+if ! command -v "$BIN" >/dev/null 2>&1; then
+    log "skip: amq-keepalive binary not found: $BIN"
+    printf '{}\n'
+    exit 0
+fi
+
+args=(reattach --adapter "$ADAPTER" --amq "$AMQ_BIN" --wake-ready-timeout "${WAKE_TIMEOUT_MILLISECONDS}ms")
+[[ -n "${AMQ_KEEPALIVE_SELF:-}" ]] && args+=(--self "$SELF_BIN")
+[[ -n "$TARGET" ]] && args+=(--target "$TARGET")
+[[ -n "$REGISTRY" ]] && args+=(--registry "$REGISTRY")
+[[ -n "$ROOT" ]] && args+=(--root "$ROOT")
+[[ -n "$BASE_ROOT" ]] && args+=(--base-root "$BASE_ROOT")
+[[ -n "$SESSION_NAME" ]] && args+=(--session "$SESSION_NAME")
+[[ -n "$ME" ]] && args+=(--me "$ME")
+[[ "${AMQ_KEEPALIVE_NO_START:-0}" == "1" ]] && args+=(--no-start)
+
+run_reattach() {
+    "$BIN" "${args[@]}" >> "$LOG_PATH" 2>&1
+}
+
+timeout_marker="${TMPDIR:-/tmp}/amq-keepalive-timeout.$$"
+rm -f "$timeout_marker" 2>/dev/null || true
+
+(
+    trap 'exit 143' TERM
+    run_reattach
+) 2>> "$LOG_PATH" &
+reattach_pid=$!
+(
+    sleep "$TIMEOUT_SECONDS"
+    if kill -0 "$reattach_pid" 2>/dev/null; then
+        : > "$timeout_marker" 2>/dev/null || true
+        pkill -TERM -P "$reattach_pid" 2>/dev/null || true
+        kill -TERM "$reattach_pid" 2>/dev/null || true
+        sleep 1
+        pkill -KILL -P "$reattach_pid" 2>/dev/null || true
+        kill -KILL "$reattach_pid" 2>/dev/null || true
+    fi
+) >/dev/null 2>&1 &
+watchdog_pid=$!
+
+wait "$reattach_pid" 2>/dev/null
+status=$?
+pkill -TERM -P "$watchdog_pid" 2>/dev/null || true
+kill "$watchdog_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
+
+if [[ -f "$timeout_marker" ]]; then
+    rm -f "$timeout_marker" 2>/dev/null || true
+    log "reattach timed out after ${TIMEOUT_SECONDS}s adapter=$ADAPTER target=${TARGET:-auto}"
+    printf '{}\n'
+    exit 0
+fi
+
+if [[ "$status" -eq 0 ]]; then
+    log "reattach ok adapter=$ADAPTER target=${TARGET:-auto}"
+else
+    log "reattach failed status=$status adapter=$ADAPTER target=${TARGET:-auto}"
+fi
+
+printf '{}\n'
+exit 0


### PR DESCRIPTION
This adds `amq-keepalive` as a second binary (`cmd/amq-keepalive` + `internal/keepalive/*`): a supervisor that keeps wake delivery attached to explicitly registered terminal sessions on macOS. It implements the Supervisor recipes contract from COOP.md, meaning the OS supervises it (user LaunchAgent), it never parses AMQ mailbox, lock, presence, or target files, and it talks to AMQ only through the public CLI (target-aware `amq wake`, `amq env --json`).

What it adds over the raw launchd recipe: a registry of attached terminal targets with Ghostty and cmux adapters (exact terminal-id targeting, fail-closed injection), reattach after reboot or sleep, SessionStart reattach hooks for Claude Code and Codex (`install-hook`), and a `doctor` command.

I know the repo is deliberately daemon-free, so to be upfront about it: I read this as staying inside that boundary (launchd owns the lifecycle, this is just the CLI it supervises plus a registry). If you'd rather not take a supervisor into the tree at all, no hard feelings, close it, but I wanted to offer the real thing rather than just a docs pointer.

Scope notes:
1. Runtime behavior is macOS-oriented (launchd, Ghostty AppleScript, cmux JSON RPC). It compiles on all four `GOOS` targets your CI cross-builds (linux, darwin, windows, freebsd) and vets clean. The one platform-specific call is the registry advisory lock (`syscall.Flock`), which is behind a `//go:build unix` file with a compile-only no-op fallback for Windows; the in-process mutex still serializes access within a process there.
2. Not touched: goreleaser/Homebrew packaging and the release manifest. If you take this, shipping the second binary in releases can be a follow-up.
3. The sample SessionStart hook script lives at `scripts/amq-keepalive-session-start.sh` with a drift test keeping it in sync with the embedded copy.

Verification: `make ci` green locally (check-skills, fmt-check, vet, golangci-lint 0 issues, full `go test`, smoke). The ported packages bring 70 tests of their own; adapters are tested through a deterministic `file` adapter.

