### PR TITLE
fix(wake): enforce exact wake-mode compatibility

### DIFF
--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -25,7 +25,7 @@ type wakeLock struct {
 	BootID       string   `json:"boot_id,omitempty"`       // Boot identity paired with ProcessStart when available
 	Executable   string   `json:"executable,omitempty"`    // Diagnostic process executable basename/path
 	Args         []string `json:"args,omitempty"`          // Diagnostic argv when available
-	WakeMode     string   `json:"wake_mode,omitempty"`     // Proven wake transport/mode (inject-via or none)
+	WakeMode     string   `json:"wake_mode,omitempty"`     // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
 	TargetDigest string   `json:"target_digest,omitempty"` // Binds .wake.target to this lock instance
 }
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -124,8 +124,8 @@ createLock:
 	if options.target != nil {
 		lock.WakeMode = wakeTargetInjectVia
 		lock.TargetDigest = wakeTargetDigest(*options.target)
-	} else if options.wakeMode == wakeInjectModeNone {
-		lock.WakeMode = wakeInjectModeNone
+	} else {
+		lock.WakeMode = options.wakeMode
 	}
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
@@ -243,8 +243,11 @@ func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string) e
 	if !inspection.Exists || inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
 		return fmt.Errorf("existing wake lock for %s is not a confirmed valid wake", inspection.Agent)
 	}
-	if requiredMode == wakeInjectModeNone && inspection.Lock.WakeMode != wakeInjectModeNone {
-		return fmt.Errorf("existing wake for %s cannot satisfy requested --inject-mode none; stop the existing wake and retry", inspection.Agent)
+	if inspection.Lock.WakeMode != requiredMode {
+		if requiredMode == wakeInjectModeNone {
+			return fmt.Errorf("existing wake for %s cannot satisfy requested --inject-mode none; stop the existing wake and retry", inspection.Agent)
+		}
+		return fmt.Errorf("existing wake for %s cannot satisfy requested wake mode %q (existing %q); stop the existing wake and retry", inspection.Agent, requiredMode, inspection.Lock.WakeMode)
 	}
 	if !wakeLockHasUsableNotificationPath(inspection) {
 		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
@@ -261,7 +264,7 @@ func wakeLockHasUsableNotificationPath(inspection wakeLockInspection) bool {
 	if inspection.Lock.WakeMode == wakeInjectModeNone {
 		return true
 	}
-	if inspection.Lock.WakeMode == wakeTargetInjectVia || wakeArgsUseInjectVia(inspection.Process.Args) {
+	if (inspection.Lock.WakeMode == wakeTargetInjectVia && inspection.Lock.TargetDigest != "") || wakeArgsUseInjectVia(inspection.Process.Args) {
 		return true
 	}
 	tty := strings.TrimSpace(inspection.Lock.TTY)
@@ -786,10 +789,16 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 
 	// Acquire lock to prevent duplicate wake processes
 	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
+	lockWakeMode := injectMode
+	if target != nil {
+		lockWakeMode = wakeTargetInjectVia
+	} else if lockWakeMode != wakeInjectModeNone {
+		lockWakeMode = effectiveInjectMode(&wakeConfig{me: me, injectMode: lockWakeMode})
+	}
 	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
 		acceptExistingValid: acceptExistingWake,
 		target:              target,
-		wakeMode:            injectMode,
+		wakeMode:            lockWakeMode,
 	})
 	if err != nil {
 		var alreadyRunning *wakeAlreadyRunningError

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -31,9 +31,11 @@ var (
 		}
 		return proc.Signal(sig)
 	}
-	wakeTerminateGrace = 100 * time.Millisecond
-	getWakeCurrentTTY  = getCurrentTTY
-	getWakeProcessSID  = unix.Getsid
+	wakeTerminateGrace   = 100 * time.Millisecond
+	getWakeCurrentTTY    = getCurrentTTY
+	getWakeProcessSID    = unix.Getsid
+	wakeTIOCSTIAvailable = func() bool { return tiocsti.Available() }
+	wakeInputIsTTY       = func() bool { return tiocsti.IsTTY() }
 )
 
 type wakeRepairResult struct {
@@ -247,7 +249,12 @@ func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string) e
 		if requiredMode == wakeInjectModeNone {
 			return fmt.Errorf("existing wake for %s cannot satisfy requested --inject-mode none; stop the existing wake and retry", inspection.Agent)
 		}
-		return fmt.Errorf("existing wake for %s cannot satisfy requested wake mode %q (existing %q); stop the existing wake and retry", inspection.Agent, requiredMode, inspection.Lock.WakeMode)
+		// Legacy locks recorded WakeMode only for none and inject-via.
+		legacyTTYWake := inspection.Lock.WakeMode == "" &&
+			(requiredMode == wakeInjectModeRaw || requiredMode == wakeInjectModePaste)
+		if !legacyTTYWake {
+			return fmt.Errorf("existing wake for %s cannot satisfy requested wake mode %q (existing %q); stop the existing wake and retry", inspection.Agent, requiredMode, inspection.Lock.WakeMode)
+		}
 	}
 	if !wakeLockHasUsableNotificationPath(inspection) {
 		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
@@ -754,12 +761,12 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 
 	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
 	if injectVia == "" && injectMode != wakeInjectModeNone {
-		if !tiocsti.Available() {
+		if !wakeTIOCSTIAvailable() {
 			return errors.New("TIOCSTI not available on this platform; use tmux send-keys or terminal-specific injection")
 		}
 
 		// Verify we have a real TTY
-		if !tiocsti.IsTTY() {
+		if !wakeInputIsTTY() {
 			return errors.New("amq wake requires a real terminal (run in foreground or as background job in same terminal, or use --inject-via for external injection)")
 		}
 	}

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -46,6 +46,18 @@ func stubWakeProcessSID(t *testing.T, fn func(pid int) (int, error)) {
 	})
 }
 
+func stubWakeTTYSupport(t *testing.T) {
+	t.Helper()
+	oldAvailable := wakeTIOCSTIAvailable
+	oldIsTTY := wakeInputIsTTY
+	wakeTIOCSTIAvailable = func() bool { return true }
+	wakeInputIsTTY = func() bool { return true }
+	t.Cleanup(func() {
+		wakeTIOCSTIAvailable = oldAvailable
+		wakeInputIsTTY = oldIsTTY
+	})
+}
+
 func writeExecutableForTest(t *testing.T, name string) string {
 	t.Helper()
 	path := filepath.Join(secureTempDirForTest(t), name)
@@ -147,6 +159,53 @@ func TestRunWakeWithLoopNoneSkipsTTYAndWritesReadyFile(t *testing.T) {
 	})
 	if !errors.Is(err, errDone) {
 		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopPersistsEffectiveAutoMode(t *testing.T) {
+	stubWakeTTYSupport(t)
+
+	for _, tc := range []struct {
+		name string
+		me   string
+		want string
+	}{
+		{name: "claude uses raw", me: "claude", want: wakeInjectModeRaw},
+		{name: "other handles use paste", me: "grok", want: wakeInjectModePaste},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatalf("EnsureRootDirs: %v", err)
+			}
+			if err := fsq.EnsureAgentDirs(root, tc.me); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+
+			errDone := errors.New("done")
+			err := runWakeWithLoop([]string{
+				"--root", root,
+				"--me", tc.me,
+				"--inject-mode", "auto",
+			}, func(cfg wakeConfig) error {
+				lockPath := filepath.Join(fsq.AgentBase(root, tc.me), ".wake.lock")
+				data, readErr := os.ReadFile(lockPath)
+				if readErr != nil {
+					t.Fatalf("read wake lock: %v", readErr)
+				}
+				var lock wakeLock
+				if unmarshalErr := json.Unmarshal(data, &lock); unmarshalErr != nil {
+					t.Fatalf("unmarshal wake lock: %v", unmarshalErr)
+				}
+				if lock.WakeMode != tc.want {
+					t.Fatalf("WakeMode = %q, want %q", lock.WakeMode, tc.want)
+				}
+				return errDone
+			})
+			if !errors.Is(err, errDone) {
+				t.Fatalf("expected loop sentinel error, got %v", err)
+			}
+		})
 	}
 }
 
@@ -719,6 +778,37 @@ func TestRequireWakeLockUsableRawVsPaste(t *testing.T) {
 	}
 	if err := requireWakeLockUsable(inspection, wakeInjectModeRaw); err != nil {
 		t.Fatalf("expected matching raw wake to be usable: %v", err)
+	}
+}
+
+func TestRequireWakeLockUsableLegacyModeCompatibility(t *testing.T) {
+	inspection := wakeLockInspection{
+		Exists:            true,
+		Status:            wakeLockValid,
+		IdentityConfirmed: true,
+		Agent:             "codex",
+		Lock:              wakeLock{TTY: "test-tty"},
+	}
+
+	for _, tc := range []struct {
+		name         string
+		requiredMode string
+		wantErr      bool
+	}{
+		{name: "raw accepted", requiredMode: wakeInjectModeRaw},
+		{name: "paste accepted", requiredMode: wakeInjectModePaste},
+		{name: "none rejected", requiredMode: wakeInjectModeNone, wantErr: true},
+		{name: "inject-via rejected", requiredMode: wakeTargetInjectVia, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireWakeLockUsable(inspection, tc.requiredMode)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected legacy wake to reject %q", tc.requiredMode)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected legacy wake to accept %q: %v", tc.requiredMode, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -583,6 +583,7 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeTargetInjectVia,
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
@@ -692,6 +693,35 @@ func TestRunWakeWithLoopNoneAcceptsExistingNoneWake(t *testing.T) {
 	}
 }
 
+func TestRequireWakeLockUsableRejectsNoneForNonNone(t *testing.T) {
+	inspection := wakeLockInspection{
+		Exists:            true,
+		Status:            wakeLockValid,
+		IdentityConfirmed: true,
+		Agent:             "codex",
+		Lock:              wakeLock{WakeMode: wakeInjectModeNone, TTY: "test-tty"},
+	}
+	if err := requireWakeLockUsable(inspection, wakeInjectModeRaw); err == nil {
+		t.Fatal("expected a none wake to be rejected for raw mode")
+	}
+}
+
+func TestRequireWakeLockUsableRawVsPaste(t *testing.T) {
+	inspection := wakeLockInspection{
+		Exists:            true,
+		Status:            wakeLockValid,
+		IdentityConfirmed: true,
+		Agent:             "codex",
+		Lock:              wakeLock{WakeMode: wakeInjectModeRaw, TTY: "test-tty"},
+	}
+	if err := requireWakeLockUsable(inspection, wakeInjectModePaste); err == nil {
+		t.Fatal("expected raw and paste wakes to be incompatible")
+	}
+	if err := requireWakeLockUsable(inspection, wakeInjectModeRaw); err != nil {
+		t.Fatalf("expected matching raw wake to be usable: %v", err)
+	}
+}
+
 func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 	const wakePID = 4242
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
@@ -714,6 +744,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeTargetInjectVia,
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
@@ -772,6 +803,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsBlankOrUnknownTTY(t *testing.T)
 				ProcessStart: "start-1",
 				BootID:       "boot-1",
 				Executable:   "/opt/homebrew/bin/amq",
+				WakeMode:     wakeTargetInjectVia,
 			})
 
 			readyPath := filepath.Join(t.TempDir(), "wake.ready")
@@ -882,6 +914,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *test
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeTargetInjectVia,
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")


### PR DESCRIPTION
## Summary

Persist the normalized wake injection mode in every wake lock and require exact mode compatibility when `--accept-existing-wake` reuses a live wake — with a legacy fallback so pre-upgrade locks keep working.

Takes over #241 by @ohade (his commit cherry-picked, authorship preserved) and folds in the review feedback: the exact compatibility matrix, a legacy pre-persistence lock fallback, and regression tests that pin the persistence wiring.

## Why

An existing `none` wake could satisfy a requested raw/paste wake, and raw/paste/auto modes were never persisted, so exact compatibility was impossible (#235, weakness 2). A naive exact check alone would however reject every pre-upgrade lock (empty `wake_mode`) even on a matching mode, breaking `coop exec --require-wake` reuse during the upgrade window — and Darwin process inspection cannot recover a legacy wake's raw/paste mode after the fact.

## Behavior

- `auto` resolves to its effective raw/paste before both persisting and comparing — the lock records what the loop actually does.
- Non-empty persisted modes require exact equality; `none` never satisfies a non-`none` request and vice versa.
- Empty persisted mode = legacy TTY wake: accepts a normalized raw/paste request, rejects `none` and `inject-via`. The raw-vs-paste ambiguity exists only for already-running pre-upgrade wakes and ages out as they restart.

## Tests

- `TestRunWakeWithLoopPersistsEffectiveAutoMode` — run-level round-trip pinning the `effectiveInjectMode` wiring (auto + claude → raw persisted; other handle → paste; fails if literal "auto" is ever persisted).
- `TestRequireWakeLockUsableLegacyModeCompatibility` — legacy matrix: raw/paste accepted, `none`/`inject-via` rejected.
- Plus #241's original regressions. RED confirmed on the legacy cases before the fix; `make ci` green.

Supersedes #241 — thanks @ohade for the fix and the clean scoping. Implementation of the legacy fallback by Codex; reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)