### PR TITLE
fix(wake): adopt tri-state identity classification for wake locks

### DIFF
--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -147,7 +147,7 @@ func TestRunOpsChecksDoesNotAdvertiseRepairForTamperedStaleLock(t *testing.T) {
 	}
 }
 
-func TestRunOpsChecksDoesNotAdvertiseRepairForLiveIdentityMismatchLock(t *testing.T) {
+func TestRunOpsChecksDoesNotAdvertiseRepairForUnknownBootIdentity(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		lock       wakeLock
@@ -170,23 +170,6 @@ func TestRunOpsChecksDoesNotAdvertiseRepairForLiveIdentityMismatchLock(t *testin
 				Executable: "/opt/homebrew/bin/amq",
 			},
 			wantReason: "boot id mismatch",
-		},
-		{
-			name: "process start mismatch",
-			lock: wakeLock{
-				PID:          4242,
-				ProcessStart: "recorded-start",
-				BootID:       "same-boot",
-				Executable:   "/opt/homebrew/bin/amq",
-			},
-			process: wakeProcessInfo{
-				PID:        4242,
-				Running:    true,
-				StartToken: "actual-start",
-				BootID:     "same-boot",
-				Executable: "/opt/homebrew/bin/amq",
-			},
-			wantReason: "process start time mismatch",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -222,7 +205,7 @@ func TestRunOpsChecksDoesNotAdvertiseRepairForLiveIdentityMismatchLock(t *testin
 	}
 }
 
-func TestRunOpsChecksFixRefusesLiveIdentityMismatchLock(t *testing.T) {
+func TestRunOpsChecksFixRefusesUnknownBootIdentity(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		lock       wakeLock
@@ -245,23 +228,6 @@ func TestRunOpsChecksFixRefusesLiveIdentityMismatchLock(t *testing.T) {
 				Executable: "/opt/homebrew/bin/amq",
 			},
 			wantReason: "boot id mismatch",
-		},
-		{
-			name: "process start mismatch",
-			lock: wakeLock{
-				PID:          4242,
-				ProcessStart: "recorded-start",
-				BootID:       "same-boot",
-				Executable:   "/opt/homebrew/bin/amq",
-			},
-			process: wakeProcessInfo{
-				PID:        4242,
-				Running:    true,
-				StartToken: "actual-start",
-				BootID:     "same-boot",
-				Executable: "/opt/homebrew/bin/amq",
-			},
-			wantReason: "process start time mismatch",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -297,5 +263,66 @@ func TestRunOpsChecksFixRefusesLiveIdentityMismatchLock(t *testing.T) {
 				t.Fatalf("identity-mismatch lock should remain after fix refusal: %v", statErr)
 			}
 		})
+	}
+}
+
+func TestRunOpsChecksReportsProvenStartMismatchAsStale(t *testing.T) {
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		ProcessStart: "recorded-start",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "actual-start",
+			BootID:     "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+
+	result := runOpsChecks(root, "test", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) || got.Reason != "process start time mismatch" {
+		t.Fatalf("unexpected wake lock: %#v", got)
+	}
+}
+
+func TestRunOpsChecksFixRemovesProvenStartMismatch(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		ProcessStart: "recorded-start",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "actual-start",
+			BootID:     "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+
+	result := runOpsChecks(root, "test", true)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != "fixed" || !got.Removed {
+		t.Fatalf("unexpected wake lock fix result: %#v", got)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("proven stale lock still exists: %v", err)
 	}
 }

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -50,6 +50,25 @@ const (
 	wakeLockUnverified wakeLockStatus = "unverified"
 )
 
+type wakeIdentityState uint8
+
+const (
+	wakeIdentityUnknown wakeIdentityState = iota
+	wakeIdentitySame
+	wakeIdentityGoneOrDifferent
+)
+
+func (state wakeIdentityState) String() string {
+	switch state {
+	case wakeIdentitySame:
+		return "same"
+	case wakeIdentityGoneOrDifferent:
+		return "gone or different"
+	default:
+		return "unknown"
+	}
+}
+
 type wakeLockInspection struct {
 	Exists            bool
 	Status            wakeLockStatus
@@ -190,65 +209,17 @@ func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
 		}
 	}
 
-	proc := inspection.Process
-	if !proc.Running {
+	state, reason := classifyWakeIdentity(*inspection, inspection.Process)
+	inspection.Reason = reason
+	switch state {
+	case wakeIdentitySame:
+		inspection.IdentityConfirmed = true
+		inspection.Status = wakeLockValid
+	case wakeIdentityGoneOrDifferent:
 		inspection.Status = wakeLockStale
-		inspection.Reason = "pid not running"
-		return
-	}
-	if lock.ProcessStart != "" {
-		if proc.StartToken == "" {
-			inspection.Status = wakeLockUnverified
-			inspection.Reason = inspectionReason("process start time unavailable", proc.InspectError)
-			return
-		}
-		if lock.ProcessStart != proc.StartToken {
-			inspection.Status = wakeLockUnverified
-			if wakeProcessProvenNotWake(proc) {
-				inspection.Status = wakeLockStale
-			}
-			inspection.Reason = "process start time mismatch"
-			return
-		}
-		if compareWakeBootID(lock.BootID, proc) != bootIDMatch {
-			inspection.Status = wakeLockUnverified
-			if wakeProcessProvenNotWake(proc) {
-				inspection.Status = wakeLockStale
-			}
-			inspection.Reason = "boot id mismatch"
-			return
-		}
-	}
-	if proc.Executable == "" {
+	default:
 		inspection.Status = wakeLockUnverified
-		inspection.Reason = inspectionReason("process identity unavailable", proc.InspectError)
-		return
 	}
-	if !processLooksLikeAMQ(proc) {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "pid is not amq"
-		return
-	}
-	if len(proc.Args) > 0 && !processArgsLookLikeWake(proc.Args) {
-		inspection.Status = wakeLockStale
-		inspection.Reason = "pid is not amq wake"
-		return
-	}
-
-	if lock.ProcessStart != "" {
-		inspection.IdentityConfirmed = true
-		inspection.Status = wakeLockValid
-		return
-	}
-
-	if wakeArgsMatchRootAgent(proc.Args, root, me) {
-		inspection.IdentityConfirmed = true
-		inspection.Status = wakeLockValid
-		return
-	}
-
-	inspection.Status = wakeLockUnverified
-	inspection.Reason = "legacy lock lacks process start metadata"
 }
 
 func validateWakeLockRepairable(inspection wakeLockInspection) error {
@@ -269,18 +240,9 @@ func validateWakeLockStaleRemoval(inspection wakeLockInspection) error {
 	} else if inspection.Status != wakeLockStale {
 		return err
 	}
-	// Identity-token mismatches are removable only when process inspection proves
-	// the live PID is not an amq wake. Other stale reasons keep the historical
-	// self-heal behavior for corrupt or structurally stale lock files.
-	switch inspection.Reason {
-	case "boot id mismatch", "process start time mismatch":
-		if wakeProcessProvenNotWake(inspection.Process) {
-			return nil
-		}
-		return fmt.Errorf("wake lock stale reason %q is not removable while pid %d may still be amq wake", inspection.Reason, inspection.PID)
-	default:
-		return nil
-	}
+	// Identity mismatches reach stale only when the tri-state classifier has
+	// affirmative proof that the recorded generation is gone or different.
+	return nil
 }
 
 func wakeProcessProvenNotWake(proc wakeProcessInfo) bool {
@@ -406,29 +368,59 @@ func isAMQExecutable(value string) bool {
 	return base == "amq"
 }
 
-func wakeProcessStillMatches(inspection wakeLockInspection) bool {
-	proc := inspectWakeProcess(inspection.PID)
+func inspectWakeIdentity(inspection wakeLockInspection) wakeIdentityState {
+	state, _ := classifyWakeIdentity(inspection, inspectWakeProcess(inspection.PID))
+	return state
+}
+
+func classifyWakeIdentity(inspection wakeLockInspection, proc wakeProcessInfo) (wakeIdentityState, string) {
+	lock := inspection.Lock
 	if !proc.Running {
-		return false
+		return wakeIdentityGoneOrDifferent, "pid not running"
 	}
-	if inspection.Lock.ProcessStart != "" {
-		if proc.StartToken == "" || inspection.Lock.ProcessStart != proc.StartToken {
-			return false
+	if lock.ProcessStart != "" {
+		if proc.StartToken == "" {
+			return wakeIdentityUnknown, inspectionReason("process start time unavailable", proc.InspectError)
 		}
-		if compareWakeBootID(inspection.Lock.BootID, proc) == bootIDMismatch {
-			return false
+		bootComparison := compareWakeBootID(lock.BootID, proc)
+		switch bootComparison {
+		case bootIDMismatch:
+			return wakeIdentityGoneOrDifferent, "boot id mismatch"
+		case bootIDUnknown:
+			if wakeProcessProvenNotWake(proc) {
+				return wakeIdentityGoneOrDifferent, "boot id mismatch"
+			}
+			return wakeIdentityUnknown, "boot id mismatch"
+		}
+		if lock.ProcessStart != proc.StartToken {
+			if lock.BootID == "" {
+				if wakeProcessProvenNotWake(proc) {
+					return wakeIdentityGoneOrDifferent, "process start time mismatch"
+				}
+				return wakeIdentityUnknown, "process start time mismatch"
+			}
+			return wakeIdentityGoneOrDifferent, "process start time mismatch"
 		}
 	}
 	if proc.Executable == "" || !processLooksLikeAMQ(proc) {
-		return false
+		if proc.Executable == "" {
+			return wakeIdentityUnknown, inspectionReason("process identity unavailable", proc.InspectError)
+		}
+		return wakeIdentityGoneOrDifferent, "pid is not amq"
 	}
 	if len(proc.Args) > 0 && !processArgsLookLikeWake(proc.Args) {
-		return false
+		return wakeIdentityGoneOrDifferent, "pid is not amq wake"
 	}
-	if inspection.Lock.ProcessStart == "" && !wakeArgsMatchRootAgent(proc.Args, inspection.Root, inspection.Agent) {
-		return false
+	if lock.ProcessStart != "" {
+		return wakeIdentitySame, ""
 	}
-	return true
+	if lock.BootID != "" {
+		return wakeIdentityUnknown, "boot id requires process start metadata"
+	}
+	if wakeArgsMatchRootAgent(proc.Args, inspection.Root, inspection.Agent) {
+		return wakeIdentitySame, ""
+	}
+	return wakeIdentityUnknown, "legacy lock lacks process start metadata"
 }
 
 type bootIDComparison int

--- a/internal/cli/wake_lock_boot_regression_test.go
+++ b/internal/cli/wake_lock_boot_regression_test.go
@@ -2,22 +2,32 @@ package cli
 
 import "testing"
 
-func TestStillMatchesLiveWakeUncheckableBootIsStillPresent(t *testing.T) {
+func TestWakeIdentityStateIsSameForMatchingProcess(t *testing.T) {
+	insp := wakeLockInspection{PID: 4343, Lock: wakeLock{PID: 4343, ProcessStart: "start-1", BootID: "recorded-boot"}, Root: "/tmp/x", Agent: "codex"}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: true, StartToken: "start-1", BootID: "recorded-boot", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", "/tmp/x", "--me", "codex"}}
+	})
+	if got := inspectWakeIdentity(insp); got != wakeIdentitySame {
+		t.Fatalf("inspectWakeIdentity() = %v, want same", got)
+	}
+}
+
+func TestWakeIdentityStateIsUnknownWhenLiveWakeBootIsUnavailable(t *testing.T) {
 	insp := wakeLockInspection{PID: 4343, Lock: wakeLock{PID: 4343, ProcessStart: "start-1", BootID: "recorded-boot", Executable: "/opt/homebrew/bin/amq"}, Root: "/tmp/x", Agent: "codex"}
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		return wakeProcessInfo{PID: pid, Running: true, StartToken: "start-1", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", "/tmp/x", "--me", "codex"}}
 	})
-	if !wakeProcessStillMatches(insp) {
-		t.Fatal("live wake with unknown boot identity must remain present")
+	if got := inspectWakeIdentity(insp); got != wakeIdentityUnknown {
+		t.Fatalf("inspectWakeIdentity() = %v, want unknown", got)
 	}
 }
 
-func TestStillMatchesDifferentUUIDBootIsGone(t *testing.T) {
+func TestWakeIdentityStateIsGoneOrDifferentForDifferentUUIDBoot(t *testing.T) {
 	insp := wakeLockInspection{PID: 4343, Lock: wakeLock{PID: 4343, ProcessStart: "start-1", BootID: "9C0682F4-901B-4243-8B5C-287FAFB9AD0E", Executable: "/opt/homebrew/bin/amq"}, Root: "/tmp/x", Agent: "codex"}
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		return wakeProcessInfo{PID: pid, Running: true, StartToken: "start-1", BootID: "AAAAAAAA-901B-4243-8B5C-287FAFB9AD0E", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", "/tmp/x", "--me", "codex"}}
 	})
-	if wakeProcessStillMatches(insp) {
-		t.Fatal("different UUID boot must be gone")
+	if got := inspectWakeIdentity(insp); got != wakeIdentityGoneOrDifferent {
+		t.Fatalf("inspectWakeIdentity() = %v, want gone or different", got)
 	}
 }

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -214,3 +214,31 @@ func TestInspectWakeLockTreatsUnavailableCurrentBootIdentityAsUnverified(t *test
 		t.Fatalf("inspection status = %q, want unverified (reason %q)", inspection.Status, inspection.Reason)
 	}
 }
+
+func TestInspectWakeLockRejectsBootIDWithoutProcessStart(t *testing.T) {
+	const wakePID = 4444
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        wakePID,
+		TTY:        "tty",
+		BootID:     "recorded-boot",
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockUnverified || inspection.IdentityConfirmed {
+		t.Fatalf("inspection = status %q reason %q confirmed %v; want unverified and unconfirmed",
+			inspection.Status, inspection.Reason, inspection.IdentityConfirmed)
+	}
+	if inspection.Reason != "boot id requires process start metadata" {
+		t.Fatalf("inspection reason = %q", inspection.Reason)
+	}
+}

--- a/internal/cli/wake_process_darwin_test.go
+++ b/internal/cli/wake_process_darwin_test.go
@@ -26,6 +26,22 @@ func TestInspectWakeProcessPlatformTreatsDarwinZombieAsNotRunning(t *testing.T) 
 	}
 }
 
+func TestInspectWakeProcessPlatformPreservesAliveStateWhenKinfoFails(t *testing.T) {
+	old := readDarwinKinfoProc
+	readDarwinKinfoProc = func(name string, args ...int) (*unix.KinfoProc, error) {
+		if name != "kern.proc.pid" || len(args) != 1 || args[0] != os.Getpid() {
+			t.Fatalf("unexpected sysctl request: name=%q args=%v", name, args)
+		}
+		return nil, errors.New("sysctl kinfo failed")
+	}
+	t.Cleanup(func() { readDarwinKinfoProc = old })
+
+	info := inspectWakeProcessPlatform(os.Getpid())
+	if !info.Running || info.InspectError == nil {
+		t.Fatalf("inspection = %#v; want running with inspection error", info)
+	}
+}
+
 func stubDarwinBootIdentityReaders(
 	t *testing.T,
 	session func() (string, error),

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -776,7 +776,7 @@ func TestRepairWakeRefusesStaleRawLockWithLeftoverTarget(t *testing.T) {
 	}
 }
 
-func TestRepairWakeRefusesLiveIdentityMismatchLock(t *testing.T) {
+func TestRepairWakeRefusesUnknownBootIdentityLock(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		lock       wakeLock
@@ -799,23 +799,6 @@ func TestRepairWakeRefusesLiveIdentityMismatchLock(t *testing.T) {
 				Executable: "/opt/homebrew/bin/amq",
 			},
 			wantReason: "boot id mismatch",
-		},
-		{
-			name: "process start mismatch",
-			lock: wakeLock{
-				PID:          4242,
-				ProcessStart: "recorded-start",
-				BootID:       "same-boot",
-				Executable:   "/opt/homebrew/bin/amq",
-			},
-			process: wakeProcessInfo{
-				PID:        4242,
-				Running:    true,
-				StartToken: "actual-start",
-				BootID:     "same-boot",
-				Executable: "/opt/homebrew/bin/amq",
-			},
-			wantReason: "process start time mismatch",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -850,6 +833,46 @@ func TestRepairWakeRefusesLiveIdentityMismatchLock(t *testing.T) {
 				t.Fatalf("lock should remain on refused live identity mismatch: %v", statErr)
 			}
 		})
+	}
+}
+
+func TestRepairWakeRefusesProvenStartMismatchAsNonRepairable(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:          4242,
+		ProcessStart: "recorded-start",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+	}, target))
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "actual-start",
+			BootID:     "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+		t.Fatalf("startWakeFromTarget should not run for a non-repairable stale reason")
+		return 0, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil || !strings.Contains(err.Error(), `stale reason "process start time mismatch" is not repairable`) {
+		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	}
+	if result.Status != "refused" {
+		t.Fatalf("status = %q, want refused", result.Status)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain after refused repair: %v", statErr)
 	}
 }
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -323,8 +323,11 @@ func terminateWakeProcess(inspection wakeLockInspection) error {
 		return fmt.Errorf("signal wake process SIGTERM: %w", err)
 	}
 	time.Sleep(wakeTerminateGrace)
-	if !wakeProcessStillMatches(inspection) {
+	switch state := inspectWakeIdentity(inspection); state {
+	case wakeIdentityGoneOrDifferent:
 		return nil
+	case wakeIdentityUnknown:
+		return fmt.Errorf("wake process identity is unknown after SIGTERM; preserving wake lock")
 	}
 	if !sameConfirmedWakeLock(inspection) {
 		return fmt.Errorf("wake process identity changed before SIGKILL")
@@ -333,13 +336,18 @@ func terminateWakeProcess(inspection wakeLockInspection) error {
 		return fmt.Errorf("signal wake process SIGKILL: %w", err)
 	}
 	deadline := time.Now().Add(wakeTerminateGrace)
-	for wakeProcessStillMatches(inspection) {
+	for {
+		switch state := inspectWakeIdentity(inspection); state {
+		case wakeIdentityGoneOrDifferent:
+			return nil
+		case wakeIdentityUnknown:
+			return fmt.Errorf("wake process identity is unknown after SIGKILL; preserving wake lock")
+		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("wake process still alive after SIGKILL")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	return nil
 }
 
 func sameConfirmedWakeLock(inspection wakeLockInspection) bool {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1136,7 +1136,7 @@ func TestAcquireWakeLockSelfHealsPIDReusedByNonAMQ(t *testing.T) {
 	}
 }
 
-func TestAcquireWakeLockTreatsLiveWakeIdentityMismatchAsUnverified(t *testing.T) {
+func TestAcquireWakeLockTreatsUnknownBootIdentityAsUnverified(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		lock       wakeLock
@@ -1158,22 +1158,6 @@ func TestAcquireWakeLockTreatsLiveWakeIdentityMismatchAsUnverified(t *testing.T)
 				Executable: "/opt/homebrew/bin/amq",
 			},
 			wantReason: "boot id mismatch",
-		},
-		{
-			name: "process start mismatch",
-			lock: wakeLock{
-				PID:          4242,
-				ProcessStart: "old-start",
-				BootID:       "boot-1",
-				Executable:   "/opt/homebrew/bin/amq",
-			},
-			process: wakeProcessInfo{
-				Running:    true,
-				StartToken: "new-start",
-				BootID:     "boot-1",
-				Executable: "/opt/homebrew/bin/amq",
-			},
-			wantReason: "process start time mismatch",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1204,7 +1188,7 @@ func TestAcquireWakeLockTreatsLiveWakeIdentityMismatchAsUnverified(t *testing.T)
 	}
 }
 
-func TestAcquireWakeLockRefusesStartMismatchWhenExecutableUnavailable(t *testing.T) {
+func TestAcquireWakeLockReplacesProvenStartMismatchWhenBootMatches(t *testing.T) {
 	const reusedPID = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
@@ -1227,14 +1211,89 @@ func TestAcquireWakeLockRefusesStartMismatchWhenExecutableUnavailable(t *testing
 	})
 
 	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
+	if err != nil {
+		t.Fatalf("acquireWakeLock: %v", err)
+	}
+	defer cleanup()
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read replacement lock: %v", err)
+	}
+	var got wakeLock
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal replacement lock: %v", err)
+	}
+	if got.PID != os.Getpid() {
+		t.Fatalf("replacement pid = %d, want %d", got.PID, os.Getpid())
+	}
+}
+
+func TestAcquireWakeLockPreservesStartMismatchWhenBootIsUnknown(t *testing.T) {
+	const reusedPID = 4242
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          reusedPID,
+		ProcessStart: "old-start",
+		BootID:       "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == reusedPID {
+			return wakeProcessInfo{
+				PID:          pid,
+				Running:      true,
+				StartToken:   "new-start",
+				BootID:       "100.000000000",
+				Executable:   "/opt/homebrew/bin/amq",
+				Args:         []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root},
+				InspectError: errors.New("boot representations are not comparable"),
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err == nil || !strings.Contains(err.Error(), "boot id mismatch") || !strings.Contains(err.Error(), "unverified") {
+		t.Fatalf("expected unknown-boot refusal, got %v", err)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("lock should remain when boot identity is unknown, stat=%v", statErr)
+	}
+}
+
+func TestAcquireWakeLockPreservesStartMismatchWithoutBootIdentity(t *testing.T) {
+	const reusedPID = 4242
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:          reusedPID,
+		ProcessStart: "old-start",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == reusedPID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "new-start",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--root", root},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
 	if cleanup != nil {
 		defer cleanup()
 	}
 	if err == nil || !strings.Contains(err.Error(), "process start time mismatch") || !strings.Contains(err.Error(), "unverified") {
-		t.Fatalf("expected start-token mismatch to be unverified without executable identity, got %v", err)
+		t.Fatalf("expected missing-boot refusal, got %v", err)
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
-		t.Fatalf("lock should remain when executable identity is unavailable, stat=%v", statErr)
+		t.Fatalf("lock should remain without comparable boot identity, stat=%v", statErr)
 	}
 }
 
@@ -1507,6 +1566,68 @@ func TestTerminateWakeProcessPreservesLiveWakeOnUnknownBootAfterSignal(t *testin
 	}
 	if len(signals) != 1 || signals[0] != syscall.SIGTERM {
 		t.Fatalf("signals = %v, want only SIGTERM", signals)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock was removed or became unreadable: %v", err)
+	}
+}
+
+func TestTerminatePreservesLockOnUnknownInspectionAfterSIGTERM(t *testing.T) {
+	const wakePID = 4350
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"})
+	calls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		calls++
+		if calls >= 3 {
+			return wakeProcessInfo{PID: pid, Running: true, InspectError: errors.New("sysctl kinfo failed")}
+		}
+		return wakeProcessInfo{PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}}
+	})
+	var signals []os.Signal
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	err := terminateWakeProcess(inspection)
+	if err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("terminateWakeProcess error = %v, want unknown-inspection error", err)
+	}
+	if len(signals) != 1 || signals[0] != syscall.SIGTERM {
+		t.Fatalf("signals = %v, want only SIGTERM", signals)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock was removed or became unreadable: %v", err)
+	}
+}
+
+func TestTerminatePreservesLockOnUnknownInspectionAfterSIGKILL(t *testing.T) {
+	const wakePID = 4351
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"})
+	calls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		calls++
+		if calls >= 5 {
+			return wakeProcessInfo{PID: pid, Running: true, InspectError: errors.New("sysctl kinfo failed")}
+		}
+		return wakeProcessInfo{PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}}
+	})
+	var signals []os.Signal
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	err := terminateWakeProcess(inspection)
+	if err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("terminateWakeProcess error = %v, want unknown-inspection error", err)
+	}
+	if len(signals) != 2 || signals[0] != syscall.SIGTERM || signals[1] != syscall.SIGKILL {
+		t.Fatalf("signals = %v, want SIGTERM then SIGKILL", signals)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("lock was removed or became unreadable: %v", err)


### PR DESCRIPTION
## Summary

Wave 1 of the wake-lifecycle signal-safety plan (#235): introduce `wakeIdentityState` (`same` / `gone-or-different` / `unknown`) as the single identity vocabulary consumed by both lock classification and the termination path, replacing the boolean `wakeProcessStillMatches` that conflated "proven gone" with "inspection failed".

## Behavior changes (intentional)

1. **Proven start-token mismatch reclassifies `unverified` → `stale` and becomes removable** — when both ProcessStart tokens are present and boot identity affirmatively supports the comparison, a mismatch is kernel proof the recorded generation is gone, regardless of what now occupies the PID. This fixes a real deadlock: a recycled-PID lock previously stayed `unverified` forever, and acquire fails closed on unverified, so the agent could never start a wake again without manual `rm`.
2. **Post-signal unknown inspection now errors and preserves the lock** where it previously reported success — on Darwin, `kill(pid,0)` can succeed while `SysctlKinfoProc` fails; the old code treated that as "process gone", removed the lock while the wake lived, and enabled duplicate injection.

Conservatism is preserved where evidence is genuinely short: token missing on either side, unknown/cross-representation boot identity, or any inspection failure stays `unverified` and is never removable (regression-locked by new sibling tests). `BootID` without `ProcessStart` is now explicitly rejected before the legacy argv fallback (malformed identity pair, #235).

## Tests

RED→GREEN: TestTerminatePreservesLockOnUnknownInspectionAfterSIGTERM/AfterSIGKILL, TestInspectWakeProcessPlatformPreservesAliveStateWhenKinfoFails (new Darwin sysctl seam), TestInspectWakeLockRejectsBootIDWithoutProcessStart, TestAcquireWakeLockReplacesProvenStartMismatchWhenBootMatches + unknown-boot/missing-boot preservation siblings, doctor report/fix conversions. `make ci` green; linux/amd64 cross-build green.

Part of #235 (design spec converged claude+codex; approved by maintainer). Implementation by Codex; design/review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)