### PR TITLE
feat(wake): serialize wake lifecycle under permanent guard with generation-bound readiness

### DIFF
--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -272,7 +272,7 @@ func runCoopExec(args []string) error {
 		} else {
 			wakeProc = wakeCmd.Process
 			if *requireWakeFlag {
-				if err := waitForWakeReady(wakeProc, readyPath, wakeReadyTimeout); err != nil {
+				if err := waitForWakeReady(wakeProc, readyPath, root, agentHandle, wakeReadyTimeout); err != nil {
 					_ = wakeProc.Kill()
 					return err
 				}
@@ -320,7 +320,7 @@ func newWakeReadyFile() (string, func(), error) {
 	return filepath.Join(dir, "ready"), func() { _ = os.RemoveAll(dir) }, nil
 }
 
-func waitForWakeReady(proc *os.Process, readyPath string, timeout time.Duration) error {
+func waitForWakeReady(proc *os.Process, readyPath, root, me string, timeout time.Duration) error {
 	if proc == nil {
 		return fmt.Errorf("amq wake process missing")
 	}
@@ -336,18 +336,18 @@ func waitForWakeReady(proc *os.Process, readyPath string, timeout time.Duration)
 	defer ticker.Stop()
 
 	for {
-		if _, err := os.Stat(readyPath); err == nil {
+		if ready, err := validateWakeReadyFileAgainstCurrent(root, me, readyPath); err != nil {
+			return fmt.Errorf("validate wake readiness: %w", err)
+		} else if ready {
 			return nil
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("check wake readiness file: %w", err)
 		}
 
 		select {
 		case err := <-done:
-			if _, statErr := os.Stat(readyPath); statErr == nil {
+			if ready, readyErr := validateWakeReadyFileAgainstCurrent(root, me, readyPath); readyErr != nil {
+				return fmt.Errorf("validate wake readiness: %w", readyErr)
+			} else if ready {
 				return nil
-			} else if !os.IsNotExist(statErr) {
-				return fmt.Errorf("check wake readiness file: %w", statErr)
 			}
 			if err != nil {
 				return fmt.Errorf("amq wake exited before becoming ready: %w", err)

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -283,27 +283,28 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 				lock.Repair = wakeRepairCommand(root, agent)
 			}
 			if fix {
-				recheck := inspectWakeLock(root, agent)
-				if recheck.Status != wakeLockStale {
-					lock.Status = string(recheck.Status)
-					lock.Reason = "wake lock changed before fix"
-					lock.RepairAvailable = false
-					lock.Repair = ""
-				} else if err := validateWakeLockStaleRemoval(recheck); err != nil {
-					lock.Status = "error"
-					lock.Reason = err.Error()
-					lock.RepairAvailable = false
-					lock.Repair = ""
-				} else if err := removeWakeLockIfUnchanged(recheck); err != nil {
-					lock.Status = "error"
-					lock.Reason = err.Error()
-					lock.RepairAvailable = false
-					lock.Repair = ""
-				} else {
+				guardErr := withWakeLifecycleGuard(root, agent, func() error {
+					recheck := inspectWakeLock(root, agent)
+					if !sameWakeLockGeneration(inspection, recheck) || recheck.Status != wakeLockStale {
+						lock.Status = string(recheck.Status)
+						lock.Reason = "wake lock changed before fix"
+						return nil
+					}
+					if err := validateWakeLockStaleRemoval(recheck); err != nil {
+						return err
+					}
+					if err := removeWakeLockIfUnchangedGuarded(recheck); err != nil {
+						return err
+					}
 					lock.Status = "fixed"
 					lock.Removed = true
-					lock.RepairAvailable = false
-					lock.Repair = ""
+					return nil
+				})
+				lock.RepairAvailable = false
+				lock.Repair = ""
+				if guardErr != nil {
+					lock.Status = "error"
+					lock.Reason = guardErr.Error()
 				}
 			}
 		}

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -266,6 +266,49 @@ func TestRunOpsChecksFixRefusesUnknownBootIdentity(t *testing.T) {
 	}
 }
 
+func TestDoctorFixWaitsForWakeLifecycleGuard(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID: 4242, Executable: "/opt/homebrew/bin/amq", Generation: "stale-generation",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- withWakeLifecycleGuard(root, "codex", func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	fixed := make(chan []opsWakeLock, 1)
+	go func() { fixed <- checkWakeLocks(root, []string{"codex"}, true) }()
+	time.Sleep(25 * time.Millisecond)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("doctor fix removed lock before lifecycle guard release: %v", err)
+	}
+	close(release)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("guard holder: %v", err)
+	}
+	locks := <-fixed
+	if len(locks) != 1 || locks[0].Status != "fixed" || !locks[0].Removed {
+		t.Fatalf("unexpected doctor fix result: %#v", locks)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("doctor fix did not remove stale generation: %v", err)
+	}
+	if _, err := os.Stat(wakeLifecycleGuardPath(root, "codex")); err != nil {
+		t.Fatalf("doctor fix removed permanent lifecycle guard: %v", err)
+	}
+}
+
 func TestRunOpsChecksReportsProvenStartMismatchAsStale(t *testing.T) {
 	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "codex", wakeLock{

--- a/internal/cli/wake_file_identity_darwin.go
+++ b/internal/cli/wake_file_identity_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+func sameWakeFileIdentity(a, b os.FileInfo) bool {
+	sa, oa := a.Sys().(*syscall.Stat_t)
+	sb, ob := b.Sys().(*syscall.Stat_t)
+	return oa && ob && sa.Dev == sb.Dev && sa.Ino == sb.Ino && sa.Ctimespec == sb.Ctimespec
+}

--- a/internal/cli/wake_file_identity_linux.go
+++ b/internal/cli/wake_file_identity_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+func sameWakeFileIdentity(a, b os.FileInfo) bool {
+	sa, oa := a.Sys().(*syscall.Stat_t)
+	sb, ob := b.Sys().(*syscall.Stat_t)
+	return oa && ob && sa.Dev == sb.Dev && sa.Ino == sb.Ino && sa.Ctim == sb.Ctim
+}

--- a/internal/cli/wake_file_identity_other.go
+++ b/internal/cli/wake_file_identity_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux && !windows
+
+package cli
+
+import "os"
+
+func sameWakeFileIdentity(a, b os.FileInfo) bool { return os.SameFile(a, b) }

--- a/internal/cli/wake_file_identity_windows.go
+++ b/internal/cli/wake_file_identity_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package cli
+
+import "os"
+
+func sameWakeFileIdentity(a, b os.FileInfo) bool { return os.SameFile(a, b) }

--- a/internal/cli/wake_lifecycle_guard_other.go
+++ b/internal/cli/wake_lifecycle_guard_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package cli
+
+// Wake itself is unsupported on these platforms. Keep shared metadata helpers
+// buildable without pretending to provide the Unix lifecycle serialization.
+func withWakeLifecycleGuard(_, _ string, fn func() error) error {
+	return fn()
+}

--- a/internal/cli/wake_lifecycle_guard_unix.go
+++ b/internal/cli/wake_lifecycle_guard_unix.go
@@ -1,0 +1,88 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+const wakeLifecycleGuardFileName = ".wake.lifecycle.lock"
+
+func wakeLifecycleGuardPath(root, me string) string {
+	return filepath.Join(fsq.AgentBase(root, me), wakeLifecycleGuardFileName)
+}
+
+// Lock order: lifecycle guard -> wake lock/target/ready reads and mutations.
+// Release the lifecycle guard before any child wait, pidfd exit wait, or
+// control wait. Child/cooperative wake paths reacquire it for exact-generation
+// cleanup and final readiness publication. Never wait on a child while holding
+// the lifecycle guard.
+func withWakeLifecycleGuard(root, me string, fn func() error) error {
+	path := wakeLifecycleGuardPath(root, me)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create wake lifecycle guard directory: %w", err)
+	}
+	file, err := openWakeLifecycleGuard(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		return fmt.Errorf("acquire wake lifecycle guard %s: %w", path, err)
+	}
+	defer func() { _ = unix.Flock(int(file.Fd()), unix.LOCK_UN) }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat wake lifecycle guard %s: %w", path, err)
+	}
+	if err := validateWakeLifecycleGuard(path, info); err != nil {
+		return err
+	}
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat wake lifecycle guard path %s: %w", path, err)
+	}
+	if err := validateWakeLifecycleGuard(path, pathInfo); err != nil {
+		return err
+	}
+	if !os.SameFile(info, pathInfo) {
+		return fmt.Errorf("wake lifecycle guard %s changed while acquiring", path)
+	}
+	return fn()
+}
+
+func openWakeLifecycleGuard(path string) (*os.File, error) {
+	flags := os.O_RDWR | os.O_CREATE | syscall.O_NONBLOCK | syscall.O_NOFOLLOW
+	file, err := os.OpenFile(path, flags, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open wake lifecycle guard %s: %w", path, err)
+	}
+	info, statErr := file.Stat()
+	if statErr != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("stat wake lifecycle guard %s: %w", path, statErr)
+	}
+	if validateErr := validateWakeLifecycleGuard(path, info); validateErr != nil {
+		_ = file.Close()
+		return nil, validateErr
+	}
+	return file, nil
+}
+
+func validateWakeLifecycleGuard(path string, info os.FileInfo) error {
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("wake lifecycle guard %s must be a regular file", path)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return fmt.Errorf("wake lifecycle guard %s mode is %o, want 0600", path, got)
+	}
+	return validateWakeTargetPathOwnership("wake lifecycle guard", path, info)
+}

--- a/internal/cli/wake_lifecycle_guard_unix.go
+++ b/internal/cli/wake_lifecycle_guard_unix.go
@@ -53,7 +53,7 @@ func withWakeLifecycleGuard(root, me string, fn func() error) error {
 	if err := validateWakeLifecycleGuard(path, pathInfo); err != nil {
 		return err
 	}
-	if !os.SameFile(info, pathInfo) {
+	if !sameWakeFileIdentity(info, pathInfo) {
 		return fmt.Errorf("wake lifecycle guard %s changed while acquiring", path)
 	}
 	return fn()

--- a/internal/cli/wake_lifecycle_guard_unix_test.go
+++ b/internal/cli/wake_lifecycle_guard_unix_test.go
@@ -1,0 +1,137 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestWakeLifecycleGuardIsPermanentAndSerializes(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- withWakeLifecycleGuard(root, "codex", func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	var secondEntered atomic.Bool
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- withWakeLifecycleGuard(root, "codex", func() error {
+			secondEntered.Store(true)
+			return nil
+		})
+	}()
+	time.Sleep(25 * time.Millisecond)
+	if secondEntered.Load() {
+		t.Fatal("second lifecycle mutator entered before the first released the guard")
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("first withWakeLifecycleGuard: %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second withWakeLifecycleGuard: %v", err)
+	}
+
+	info, err := os.Stat(wakeLifecycleGuardPath(root, "codex"))
+	if err != nil {
+		t.Fatalf("permanent lifecycle guard missing: %v", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		t.Fatalf("lifecycle guard mode = %v, want regular 0600", info.Mode())
+	}
+}
+
+func TestWakeLifecycleGuardRejectsSymlink(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "target")
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, wakeLifecycleGuardPath(root, "codex")); err != nil {
+		t.Fatalf("symlink lifecycle guard: %v", err)
+	}
+
+	err := withWakeLifecycleGuard(root, "codex", func() error {
+		t.Fatal("guard callback must not run")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "lifecycle guard") {
+		t.Fatalf("expected lifecycle guard symlink rejection, got %v", err)
+	}
+}
+
+func TestWakeLifecycleGuardRejectsWrongOwner(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	guardPath := wakeLifecycleGuardPath(root, "codex")
+	if err := os.WriteFile(guardPath, nil, 0o600); err != nil {
+		t.Fatalf("write lifecycle guard: %v", err)
+	}
+	oldOwner := wakeTargetFileOwnerUID
+	wakeTargetFileOwnerUID = func(os.FileInfo) (int, bool) { return os.Geteuid() + 1, true }
+	t.Cleanup(func() { wakeTargetFileOwnerUID = oldOwner })
+
+	err := withWakeLifecycleGuard(root, "codex", func() error {
+		t.Fatal("guard callback must not run")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "owned by uid") {
+		t.Fatalf("expected lifecycle guard ownership rejection, got %v", err)
+	}
+}
+
+func TestWakeLifecycleGuardRejectsNonRegularFile(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	guardPath := wakeLifecycleGuardPath(root, "codex")
+	if err := syscall.Mkfifo(guardPath, 0o600); err != nil {
+		t.Fatalf("mkfifo lifecycle guard: %v", err)
+	}
+
+	done := make(chan error, 1)
+	var callbackRan atomic.Bool
+	go func() {
+		done <- withWakeLifecycleGuard(root, "codex", func() error {
+			callbackRan.Store(true)
+			return nil
+		})
+	}()
+	select {
+	case err := <-done:
+		if callbackRan.Load() {
+			t.Fatal("guard callback ran for non-regular guard")
+		}
+		if err == nil || !strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("expected non-regular lifecycle guard rejection, got %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("lifecycle guard open blocked on FIFO")
+	}
+}

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -282,7 +282,7 @@ func removeWakeLockIfUnchangedGuarded(inspection wakeLockInspection) error {
 	if !bytes.Equal(current, inspection.raw) {
 		return fmt.Errorf("wake lock changed while cleaning stale lock; retry")
 	}
-	if inspection.fileInfo == nil || currentInfo == nil || !os.SameFile(inspection.fileInfo, currentInfo) {
+	if inspection.fileInfo == nil || currentInfo == nil || !sameWakeFileIdentity(inspection.fileInfo, currentInfo) {
 		return fmt.Errorf("wake lock generation changed while cleaning stale lock; retry")
 	}
 	if err := os.Remove(inspection.LockPath); err != nil && !os.IsNotExist(err) {
@@ -295,7 +295,7 @@ func sameWakeLockGeneration(first, second wakeLockInspection) bool {
 	if !first.Exists || !second.Exists || first.fileInfo == nil || second.fileInfo == nil {
 		return false
 	}
-	if !os.SameFile(first.fileInfo, second.fileInfo) || !bytes.Equal(first.raw, second.raw) {
+	if !sameWakeFileIdentity(first.fileInfo, second.fileInfo) || !bytes.Equal(first.raw, second.raw) {
 		return false
 	}
 	if first.Lock.Generation != "" || second.Lock.Generation != "" {

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -27,6 +27,7 @@ type wakeLock struct {
 	Args         []string `json:"args,omitempty"`          // Diagnostic argv when available
 	WakeMode     string   `json:"wake_mode,omitempty"`     // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
 	TargetDigest string   `json:"target_digest,omitempty"` // Binds .wake.target to this lock instance
+	Generation   string   `json:"generation,omitempty"`    // Random nonce binding readiness and exact cleanup to this instance
 }
 
 type wakeProcessInfo struct {
@@ -81,6 +82,7 @@ type wakeLockInspection struct {
 	Process           wakeProcessInfo
 	IdentityConfirmed bool
 	raw               []byte
+	fileInfo          os.FileInfo
 }
 
 var inspectWakeProcess = inspectWakeProcessPlatform
@@ -105,7 +107,7 @@ func inspectWakeLock(root, me string) wakeLockInspection {
 		LockPath: lockPath,
 	}
 
-	data, err := readWakeLockFile(lockPath)
+	data, fileInfo, err := readWakeLockFileWithInfo(lockPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return inspection
@@ -118,6 +120,7 @@ func inspectWakeLock(root, me string) wakeLockInspection {
 
 	inspection.Exists = true
 	inspection.raw = data
+	inspection.fileInfo = fileInfo
 	var existing wakeLock
 	if err := json.Unmarshal(data, &existing); err != nil {
 		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) < 2*time.Second {
@@ -137,27 +140,31 @@ func inspectWakeLock(root, me string) wakeLockInspection {
 	return inspection
 }
 
-func readWakeLockFile(path string) ([]byte, error) {
+func readWakeLockFileWithInfo(path string) ([]byte, os.FileInfo, error) {
 	info, err := os.Lstat(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := validateWakeLockFile(path, info); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	file, err := openWakeMetadataFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() { _ = file.Close() }()
 	openedInfo, err := file.Stat()
 	if err != nil {
-		return nil, fmt.Errorf("stat wake lock: %w", err)
+		return nil, nil, fmt.Errorf("stat wake lock: %w", err)
 	}
 	if err := validateWakeLockFile(path, openedInfo); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return readWakeMetadata(file, "wake lock", path)
+	if !os.SameFile(info, openedInfo) {
+		return nil, nil, fmt.Errorf("wake lock %s changed while opening", path)
+	}
+	data, err := readWakeMetadata(file, "wake lock", path)
+	return data, openedInfo, err
 }
 
 func validateWakeLockFile(path string, info os.FileInfo) error {
@@ -259,7 +266,13 @@ func wakeProcessProvenNotWake(proc wakeProcessInfo) bool {
 }
 
 func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
-	current, err := readWakeLockFile(inspection.LockPath)
+	return withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
+		return removeWakeLockIfUnchangedGuarded(inspection)
+	})
+}
+
+func removeWakeLockIfUnchangedGuarded(inspection wakeLockInspection) error {
+	current, currentInfo, err := readWakeLockFileWithInfo(inspection.LockPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -269,10 +282,26 @@ func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
 	if !bytes.Equal(current, inspection.raw) {
 		return fmt.Errorf("wake lock changed while cleaning stale lock; retry")
 	}
+	if inspection.fileInfo == nil || currentInfo == nil || !os.SameFile(inspection.fileInfo, currentInfo) {
+		return fmt.Errorf("wake lock generation changed while cleaning stale lock; retry")
+	}
 	if err := os.Remove(inspection.LockPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove stale wake lock: %w", err)
 	}
 	return nil
+}
+
+func sameWakeLockGeneration(first, second wakeLockInspection) bool {
+	if !first.Exists || !second.Exists || first.fileInfo == nil || second.fileInfo == nil {
+		return false
+	}
+	if !os.SameFile(first.fileInfo, second.fileInfo) || !bytes.Equal(first.raw, second.raw) {
+		return false
+	}
+	if first.Lock.Generation != "" || second.Lock.Generation != "" {
+		return first.Lock.Generation != "" && first.Lock.Generation == second.Lock.Generation
+	}
+	return true
 }
 
 func currentWakeLockMatches(lock wakeLock) bool {

--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -1,0 +1,148 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const wakeReadySchema = 1
+
+type wakeReady struct {
+	Schema       int    `json:"schema"`
+	Generation   string `json:"generation"`
+	TargetDigest string `json:"target_digest,omitempty"`
+}
+
+func writeWakeReadyFile(root, me, path string, expected wakeLockInspection) error {
+	if path == "" {
+		return nil
+	}
+	return withWakeLifecycleGuard(root, me, func() error {
+		current := inspectWakeLock(root, me)
+		if !sameWakeLockGeneration(expected, current) {
+			return fmt.Errorf("wake lock generation changed before readiness publication")
+		}
+		if err := validateWakeReadyLockAndTarget(root, me, current, wakeReady{
+			Schema:       wakeReadySchema,
+			Generation:   current.Lock.Generation,
+			TargetDigest: current.Lock.TargetDigest,
+		}); err != nil {
+			return err
+		}
+		data, err := json.Marshal(wakeReady{
+			Schema:       wakeReadySchema,
+			Generation:   current.Lock.Generation,
+			TargetDigest: current.Lock.TargetDigest,
+		})
+		if err != nil {
+			return fmt.Errorf("marshal wake readiness: %w", err)
+		}
+		return writeWakeMetadataFile(path, append(data, '\n'), "wake ready file")
+	})
+}
+
+func readWakeReadyFile(path string) (wakeReady, bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return wakeReady{}, false, nil
+		}
+		return wakeReady{}, false, fmt.Errorf("stat wake ready file: %w", err)
+	}
+	if err := validateWakeReadyFile(path, info); err != nil {
+		return wakeReady{}, true, err
+	}
+	file, err := openWakeMetadataFile(path)
+	if err != nil {
+		return wakeReady{}, true, fmt.Errorf("open wake ready file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return wakeReady{}, true, fmt.Errorf("stat opened wake ready file: %w", err)
+	}
+	if err := validateWakeReadyFile(path, openedInfo); err != nil {
+		return wakeReady{}, true, err
+	}
+	if !os.SameFile(info, openedInfo) {
+		return wakeReady{}, true, fmt.Errorf("wake ready file %s changed while opening", path)
+	}
+	data, err := readWakeMetadata(file, "wake ready file", path)
+	if err != nil {
+		return wakeReady{}, true, err
+	}
+	var ready wakeReady
+	if err := json.Unmarshal(data, &ready); err != nil {
+		return wakeReady{}, true, fmt.Errorf("legacy wake ready file refused")
+	}
+	if ready.Schema != wakeReadySchema || ready.Generation == "" {
+		return wakeReady{}, true, fmt.Errorf("legacy wake ready file refused")
+	}
+	return ready, true, nil
+}
+
+func validateWakeReadyFile(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("wake ready file %s must not be a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("wake ready file %s must be a regular file", path)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return fmt.Errorf("wake ready file %s mode is %o, want 0600", path, got)
+	}
+	return validateWakeTargetPathOwnership("wake ready file", path, info)
+}
+
+func validateWakeReadyLockAndTarget(root, me string, current wakeLockInspection, ready wakeReady) error {
+	confirmed := current.Status == wakeLockValid && current.IdentityConfirmed
+	if !confirmed && !currentWakeLockMatches(current.Lock) {
+		return fmt.Errorf("wake lock is not a confirmed valid wake during readiness validation")
+	}
+	if current.Lock.Generation == "" || ready.Generation != current.Lock.Generation {
+		return fmt.Errorf("wake readiness generation does not match current wake lock")
+	}
+	if ready.TargetDigest != current.Lock.TargetDigest {
+		return fmt.Errorf("wake readiness target does not match current wake lock")
+	}
+	if current.Lock.TargetDigest == "" {
+		_, exists, err := readWakeTarget(root, me)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("wake readiness target does not match current wake lock")
+		}
+		return nil
+	}
+	target, exists, err := readWakeTarget(root, me)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("wake readiness target is missing")
+	}
+	if err := validateWakeTarget(target, root, me); err != nil {
+		return err
+	}
+	return validateWakeTargetMatchesLock(current.Lock, target)
+}
+
+func validateWakeReadyFileAgainstCurrent(root, me, path string) (bool, error) {
+	ready := false
+	err := withWakeLifecycleGuard(root, me, func() error {
+		published, exists, err := readWakeReadyFile(path)
+		if err != nil || !exists {
+			return err
+		}
+		if err := validateWakeReadyLockAndTarget(root, me, inspectWakeLock(root, me), published); err != nil {
+			return err
+		}
+		ready = true
+		return nil
+	})
+	return ready, err
+}

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -719,6 +719,9 @@ func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 		Executable: "/opt/homebrew/bin/amq",
 	}, target))
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == 9876 {
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "new-start", Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
+		}
 		return wakeProcessInfo{PID: pid, Running: false}
 	})
 	if err := writeWakeTarget(root, "codex", target); err != nil {
@@ -734,6 +737,9 @@ func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 			t.Fatalf("lock should be removed before start, stat=%v", err)
 		}
+		writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+			PID: 9876, ProcessStart: "new-start", Executable: "/opt/homebrew/bin/amq", Generation: "generation-new",
+		}, target))
 		return 9876, nil
 	})
 
@@ -743,6 +749,76 @@ func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 	}
 	if result.Status != "repaired" || result.PID != 9876 {
 		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestRepairWakeAcceptsConcurrentWinnerForExactTarget(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID: 4242, Executable: "/opt/homebrew/bin/amq", Generation: "stale-generation",
+	}, target))
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == 9876 {
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "winner-start", Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget) (int, error) {
+		writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+			PID: 9876, ProcessStart: "winner-start", Executable: "/opt/homebrew/bin/amq", Generation: "winner-generation",
+		}, gotTarget))
+		return 0, errors.New("lost start race")
+	})
+
+	result, err := repairWake(root, "codex")
+	if err != nil {
+		t.Fatalf("exact concurrent winner should satisfy repair: %v", err)
+	}
+	if result.Status != "repaired" || result.PID != 9876 {
+		t.Fatalf("unexpected repair result: %#v", result)
+	}
+}
+
+func TestRepairWakeRefusesConcurrentWinnerForDifferentTarget(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID: 4242, Executable: "/opt/homebrew/bin/amq", Generation: "stale-generation",
+	}, target))
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == 9876 {
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "winner-start", Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	var winnerPath string
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget) (int, error) {
+		winner := gotTarget
+		winner.InjectArgs = []string{"different"}
+		if err := writeWakeTarget(root, "codex", winner); err != nil {
+			t.Fatalf("write concurrent target: %v", err)
+		}
+		winnerPath = writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+			PID: 9876, ProcessStart: "winner-start", Executable: "/opt/homebrew/bin/amq", Generation: "winner-generation",
+		}, winner))
+		return 0, errors.New("lost start race")
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil || !strings.Contains(err.Error(), "lost start race") {
+		t.Fatalf("different concurrent winner should not satisfy repair: result=%#v err=%v", result, err)
+	}
+	if _, statErr := os.Stat(winnerPath); statErr != nil {
+		t.Fatalf("different concurrent winner must remain untouched: %v", statErr)
 	}
 }
 
@@ -960,6 +1036,9 @@ func TestRunWakeRepairCLIRepairsStaleWakeWithJSON(t *testing.T) {
 		Executable: "/opt/homebrew/bin/amq",
 	}, target))
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == 9876 {
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "new-start", Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
+		}
 		return wakeProcessInfo{PID: pid, Running: false}
 	})
 	if err := writeWakeTarget(root, "codex", target); err != nil {
@@ -975,6 +1054,9 @@ func TestRunWakeRepairCLIRepairsStaleWakeWithJSON(t *testing.T) {
 		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 			t.Fatalf("lock should be removed before start, stat=%v", err)
 		}
+		writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+			PID: 9876, ProcessStart: "new-start", Executable: "/opt/homebrew/bin/amq", Generation: "generation-new",
+		}, target))
 		return 9876, nil
 	})
 

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -150,12 +150,18 @@ func validateWakeTargetFile(path string, info os.FileInfo) error {
 }
 
 func writeWakeTarget(root, me string, target wakeTarget) error {
-	if err := validateWakeTarget(target, root, me); err != nil {
-		return err
-	}
 	agentBase := fsq.AgentBase(root, me)
 	if err := os.MkdirAll(agentBase, 0o700); err != nil {
 		return fmt.Errorf("create wake target directory: %w", err)
+	}
+	return withWakeLifecycleGuard(root, me, func() error {
+		return writeWakeTargetGuarded(root, me, target)
+	})
+}
+
+func writeWakeTargetGuarded(root, me string, target wakeTarget) error {
+	if err := validateWakeTarget(target, root, me); err != nil {
+		return err
 	}
 	data, err := json.MarshalIndent(target, "", "  ")
 	if err != nil {
@@ -165,7 +171,7 @@ func writeWakeTarget(root, me string, target wakeTarget) error {
 	return writeWakeMetadataFile(wakeTargetPath(root, me), data, "wake target")
 }
 
-func removeWakeTarget(root, me string) error {
+func removeWakeTargetGuarded(root, me string) error {
 	if err := os.Remove(wakeTargetPath(root, me)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove wake target: %w", err)
 	}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -3,7 +3,8 @@
 package cli
 
 import (
-	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -74,60 +75,124 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 		return nil, fmt.Errorf("failed to create agent directory: %w", err)
 	}
 
-	// Check existing lock
-	inspection := inspectWakeLock(root, me)
-	if inspection.Exists {
-		switch inspection.Status {
-		case wakeLockStale:
-			if err := validateWakeLockStaleRemoval(inspection); err != nil {
-				return nil, err
-			}
-			if err := removeWakeLockIfUnchanged(inspection); err != nil {
-				return nil, err
-			}
-		case wakeLockCreating:
-			return nil, fmt.Errorf("wake lock is being created (retry shortly)")
-		case wakeLockValid:
-			if options.acceptExistingValid {
-				if err := requireWakeLockUsable(inspection, options.wakeMode, options.target); err != nil {
-					return nil, err
+	for {
+		var replace wakeLockInspection
+		var created wakeLockInspection
+		err := withWakeLifecycleGuard(root, me, func() error {
+			inspection := inspectWakeLock(root, me)
+			if inspection.Exists {
+				switch inspection.Status {
+				case wakeLockStale:
+					if err := validateWakeLockStaleRemoval(inspection); err != nil {
+						return err
+					}
+					if err := removeWakeLockIfUnchangedGuarded(inspection); err != nil {
+						return err
+					}
+				case wakeLockCreating:
+					return fmt.Errorf("wake lock is being created (retry shortly)")
+				case wakeLockValid:
+					if options.acceptExistingValid {
+						if err := requireWakeLockUsable(inspection, options.wakeMode, options.target); err != nil {
+							return err
+						}
+						return wakeLockAlreadyRunningError(me, inspection)
+					}
+					replaceNeeded, replaceErr := wakeLockReplacementNeeded(inspection)
+					if replaceErr != nil {
+						return replaceErr
+					}
+					if replaceNeeded {
+						replace = inspection
+						return nil
+					}
+					return wakeLockAlreadyRunningError(me, inspection)
+				case wakeLockUnverified:
+					return fmt.Errorf("wake lock for %s is unverified (pid %d on %s since %s): %s; run 'amq doctor --ops' for details",
+						me, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started, inspection.Reason)
 				}
-				return nil, wakeLockAlreadyRunningError(me, inspection)
 			}
-			replace, replaceErr := shouldReplaceOrphanedWakeLock(inspection)
-			if replaceErr != nil {
-				return nil, replaceErr
+			if replace.Exists {
+				return nil
 			}
-			if replace {
-				goto createLock
-			}
-			return nil, wakeLockAlreadyRunningError(me, inspection)
-		case wakeLockUnverified:
-			return nil, fmt.Errorf("wake lock for %s is unverified (pid %d on %s since %s): %s; run 'amq doctor --ops' for details",
-				me, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started, inspection.Reason)
-		}
-	}
 
-createLock:
-	// Get TTY name - reuse getCurrentTTY for consistency
+			// Stage target metadata first. The lock is the transaction commit point.
+			if options.target != nil {
+				if err := writeWakeTargetGuarded(root, me, *options.target); err != nil {
+					return err
+				}
+			} else if err := removeWakeTargetGuarded(root, me); err != nil {
+				return err
+			}
+
+			lock, err := newWakeLock(root, me, options)
+			if err != nil {
+				return err
+			}
+			lockData, _ := json.Marshal(lock)
+			f, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0o600)
+			if err != nil {
+				return fmt.Errorf("failed to create wake lock: %w", err)
+			}
+			_, writeErr := f.Write(lockData)
+			closeErr := f.Close()
+			if writeErr != nil || closeErr != nil {
+				_ = os.Remove(lockPath)
+				if writeErr != nil {
+					return fmt.Errorf("failed to write wake lock: %w", writeErr)
+				}
+				return fmt.Errorf("failed to close wake lock: %w", closeErr)
+			}
+			created = inspectWakeLock(root, me)
+			if !created.Exists || created.Lock.Generation != lock.Generation {
+				return fmt.Errorf("failed to verify created wake lock generation")
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if replace.Exists {
+			if _, err := terminateAndRemoveOrphanedWakeLock(replace); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		cleanup = func() {
+			_ = withWakeLifecycleGuard(root, me, func() error {
+				current := inspectWakeLock(root, me)
+				if !sameWakeLockGeneration(created, current) || !currentWakeLockMatches(current.Lock) {
+					return nil
+				}
+				return removeWakeLockIfUnchangedGuarded(current)
+			})
+		}
+		return cleanup, nil
+	}
+}
+
+func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, error) {
+	generationBytes := make([]byte, 16)
+	if _, err := rand.Read(generationBytes); err != nil {
+		return wakeLock{}, fmt.Errorf("generate wake lock nonce: %w", err)
+	}
 	ttyName := getCurrentTTY()
 	if ttyName == "" {
 		ttyName = "unknown"
 	}
-
-	// Write lock atomically using O_EXCL to prevent race conditions
 	lock := wakeLock{
-		PID:     os.Getpid(),
-		TTY:     ttyName,
-		Root:    canonicalWakeRoot(root),
-		Agent:   me,
-		Started: time.Now().UTC().Format(time.RFC3339),
+		PID:        os.Getpid(),
+		TTY:        ttyName,
+		Root:       canonicalWakeRoot(root),
+		Agent:      me,
+		Started:    time.Now().UTC().Format(time.RFC3339),
+		Generation: hex.EncodeToString(generationBytes),
+		WakeMode:   options.wakeMode,
 	}
 	if options.target != nil {
 		lock.WakeMode = wakeTargetInjectVia
 		lock.TargetDigest = wakeTargetDigest(*options.target)
-	} else {
-		lock.WakeMode = options.wakeMode
 	}
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
@@ -138,59 +203,22 @@ createLock:
 		lock.Executable = proc.Executable
 		lock.Args = proc.Args
 	}
-	lockData, _ := json.Marshal(lock)
-
-	// Use O_EXCL for atomic creation - fails if file exists (race protection)
-	f, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		if os.IsExist(err) {
-			// Another process won the race; reuse only if the shared
-			// classifier proves it is the matching wake.
-			winner := inspectWakeLock(root, me)
-			if winner.Status == wakeLockValid {
-				if options.acceptExistingValid {
-					if usableErr := requireWakeLockUsable(winner, options.wakeMode, options.target); usableErr != nil {
-						return nil, usableErr
-					}
-				}
-				return nil, wakeLockAlreadyRunningError(me, winner)
-			}
-			return nil, fmt.Errorf("wake lock exists for %s (concurrent start)", me)
-		}
-		return nil, fmt.Errorf("failed to create wake lock: %w", err)
-	}
-	_, writeErr := f.Write(lockData)
-	closeErr := f.Close()
-	if writeErr != nil {
-		_ = os.Remove(lockPath)
-		return nil, fmt.Errorf("failed to write wake lock: %w", writeErr)
-	}
-	if closeErr != nil {
-		_ = os.Remove(lockPath)
-		return nil, fmt.Errorf("failed to close wake lock: %w", closeErr)
-	}
-
-	cleanup = func() {
-		// Only remove if it's still our lock
-		if data, err := os.ReadFile(lockPath); err == nil {
-			var current wakeLock
-			if json.Unmarshal(data, &current) == nil && currentWakeLockMatches(current) {
-				_ = os.Remove(lockPath)
-			}
-		}
-	}
-
-	return cleanup, nil
+	return lock, nil
 }
 
 func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
-	if !wakeLockNeedsReplacement(inspection) {
-		replace, err := wakeLockNeedsOwnerReplacement(inspection)
-		if err != nil || !replace {
-			return replace, err
-		}
+	replace, err := wakeLockReplacementNeeded(inspection)
+	if err != nil || !replace {
+		return replace, err
 	}
-	return replaceConfirmedOrphanedWakeLock(inspection)
+	return terminateAndRemoveOrphanedWakeLock(inspection)
+}
+
+func wakeLockReplacementNeeded(inspection wakeLockInspection) (bool, error) {
+	if wakeLockNeedsReplacement(inspection) {
+		return true, nil
+	}
+	return wakeLockNeedsOwnerReplacement(inspection)
 }
 
 func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
@@ -308,22 +336,37 @@ func wakeArgsUseInjectVia(args []string) bool {
 	return false
 }
 
-func replaceConfirmedOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
-	return terminateAndRemoveOrphanedWakeLock(inspection)
-}
-
 func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
-	recheck := inspectWakeLock(inspection.Root, inspection.Agent)
+	var recheck wakeLockInspection
+	if err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
+		recheck = inspectWakeLock(inspection.Root, inspection.Agent)
+		return nil
+	}); err != nil {
+		return false, err
+	}
 	if !sameWakeLockInspection(inspection, recheck) || !recheck.IdentityConfirmed {
 		return false, nil
 	}
+	// Process termination can wait. It must happen after releasing the guard.
 	if err := terminateWakeProcess(recheck); err != nil {
 		return false, err
 	}
-	if err := removeWakeLockIfUnchanged(recheck); err != nil {
-		return false, err
-	}
-	return true, nil
+	removed := false
+	err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
+		current := inspectWakeLock(inspection.Root, inspection.Agent)
+		if !sameWakeLockGeneration(recheck, current) {
+			return nil
+		}
+		if err := validateWakeLockStaleRemoval(current); err != nil {
+			return err
+		}
+		if err := removeWakeLockIfUnchangedGuarded(current); err != nil {
+			return err
+		}
+		removed = true
+		return nil
+	})
+	return removed, err
 }
 
 func sameWakeLockInspection(first, second wakeLockInspection) bool {
@@ -333,7 +376,7 @@ func sameWakeLockInspection(first, second wakeLockInspection) bool {
 	if first.PID != second.PID || first.Root != second.Root || first.Agent != second.Agent {
 		return false
 	}
-	return bytes.Equal(first.raw, second.raw)
+	return sameWakeLockGeneration(first, second)
 }
 
 func terminateWakeProcess(inspection wakeLockInspection) error {
@@ -461,110 +504,130 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 		Lock:   filepath.Join(fsq.AgentBase(root, me), ".wake.lock"),
 		Target: wakeTargetPath(root, me),
 	}
-	inspection := inspectWakeLock(root, me)
-	if !inspection.Exists {
-		result.Status = "refused"
-		result.Reason = "no wake lock present; start wake normally"
-		return result, errors.New(result.Reason)
+	if err := os.MkdirAll(fsq.AgentBase(root, me), 0o700); err != nil {
+		result.Status = "error"
+		result.Reason = err.Error()
+		return result, err
 	}
-	switch inspection.Status {
-	case wakeLockValid:
-		result.Status = "refused"
-		result.PID = inspection.PID
-		result.Reason = "wake lock is already valid; refusing repair"
-		return result, errors.New(result.Reason)
-	case wakeLockStale:
-		if err := validateWakeLockRepairable(inspection); err != nil {
+
+	var target wakeTarget
+	prepareErr := withWakeLifecycleGuard(root, me, func() error {
+		inspection := inspectWakeLock(root, me)
+		if !inspection.Exists {
+			result.Status = "refused"
+			result.Reason = "no wake lock present; start wake normally"
+			return errors.New(result.Reason)
+		}
+		switch inspection.Status {
+		case wakeLockValid:
 			result.Status = "refused"
 			result.PID = inspection.PID
-			result.Reason = err.Error()
-			return result, err
+			result.Reason = "wake lock is already valid; refusing repair"
+			return errors.New(result.Reason)
+		case wakeLockStale:
+			if err := validateWakeLockRepairable(inspection); err != nil {
+				result.Status = "refused"
+				result.PID = inspection.PID
+				result.Reason = err.Error()
+				return err
+			}
+		case wakeLockCreating:
+			result.Status = "refused"
+			result.Reason = "wake lock is being created; retry shortly"
+			return errors.New(result.Reason)
+		case wakeLockUnverified:
+			result.Status = "refused"
+			result.PID = inspection.PID
+			result.Reason = "wake lock is unverified; refusing to start a second injector"
+			return fmt.Errorf("%s: %s", result.Reason, inspection.Reason)
+		default:
+			result.Status = "refused"
+			result.Reason = fmt.Sprintf("wake lock status %q is not repairable", inspection.Status)
+			return errors.New(result.Reason)
 		}
-	case wakeLockCreating:
-		result.Status = "refused"
-		result.Reason = "wake lock is being created; retry shortly"
-		return result, errors.New(result.Reason)
-	case wakeLockUnverified:
-		result.Status = "refused"
-		result.PID = inspection.PID
-		result.Reason = "wake lock is unverified; refusing to start a second injector"
-		return result, fmt.Errorf("%s: %s", result.Reason, inspection.Reason)
-	default:
-		result.Status = "refused"
-		result.Reason = fmt.Sprintf("wake lock status %q is not repairable", inspection.Status)
-		return result, errors.New(result.Reason)
+
+		var exists bool
+		var err error
+		target, exists, err = readWakeTarget(root, me)
+		if err != nil {
+			result.Status = "refused"
+			result.Reason = err.Error()
+			return err
+		}
+		if !exists {
+			result.Status = "refused"
+			result.Reason = "no inject-via wake target; restart wake manually"
+			return errors.New(result.Reason)
+		}
+		if err := validateWakeTarget(target, root, me); err != nil {
+			result.Status = "refused"
+			result.Reason = err.Error()
+			return err
+		}
+		if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
+			result.Status = "refused"
+			result.Reason = err.Error()
+			return err
+		}
+		result.RepairAvailable = true
+		if err := removeWakeLockIfUnchangedGuarded(inspection); err != nil {
+			result.Status = "refused"
+			result.RepairAvailable = false
+			result.PID = inspectWakeLock(root, me).PID
+			result.Reason = "wake lock changed before repair"
+			return errors.New(result.Reason)
+		}
+		return nil
+	})
+	if prepareErr != nil {
+		return result, prepareErr
 	}
 
-	target, exists, err := readWakeTarget(root, me)
-	if err != nil {
-		result.Status = "refused"
-		result.Reason = err.Error()
-		return result, err
+	// Spawning and readiness waiting happen without the lifecycle guard.
+	startedPID, startErr := startWakeFromTarget(root, me, target)
+	winner, winnerErr := validateRepairWakeWinner(root, me, target)
+	if winnerErr == nil {
+		result.Status = "repaired"
+		result.PID = winner.PID
+		return result, nil
 	}
-	if !exists {
-		result.Status = "refused"
-		result.Reason = "no inject-via wake target; restart wake manually"
-		return result, errors.New(result.Reason)
+	result.RepairAvailable = false
+	result.Status = "error"
+	if startErr != nil {
+		result.Reason = startErr.Error()
+		return result, startErr
 	}
-	if err := validateWakeTarget(target, root, me); err != nil {
-		result.Status = "refused"
-		result.Reason = err.Error()
-		return result, err
-	}
-	if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
-		result.Status = "refused"
-		result.Reason = err.Error()
-		return result, err
-	}
-	result.RepairAvailable = true
-	clearRepairAvailable := func() {
-		result.RepairAvailable = false
-	}
+	result.PID = startedPID
+	result.Reason = fmt.Sprintf("repaired wake failed exact readiness validation: %v", winnerErr)
+	return result, errors.New(result.Reason)
+}
 
-	recheck := inspectWakeLock(root, me)
-	if recheck.Status != wakeLockStale {
-		clearRepairAvailable()
-		result.Status = "refused"
-		result.PID = recheck.PID
-		result.Reason = "wake lock changed before repair"
-		return result, errors.New(result.Reason)
-	}
-	if err := validateWakeLockRepairable(recheck); err != nil {
-		clearRepairAvailable()
-		result.Status = "refused"
-		result.PID = recheck.PID
-		result.Reason = "wake lock changed before repair"
-		return result, errors.New(result.Reason)
-	}
-	if !bytes.Equal(inspection.raw, recheck.raw) {
-		clearRepairAvailable()
-		result.Status = "refused"
-		result.PID = recheck.PID
-		result.Reason = "wake lock changed before repair"
-		return result, errors.New(result.Reason)
-	}
-	if err := validateWakeTargetMatchesLock(recheck.Lock, target); err != nil {
-		clearRepairAvailable()
-		result.Status = "refused"
-		result.Reason = err.Error()
-		return result, err
-	}
-	if err := removeWakeLockIfUnchanged(recheck); err != nil {
-		clearRepairAvailable()
-		result.Status = "error"
-		result.Reason = err.Error()
-		return result, err
-	}
-	pid, err := startWakeFromTarget(root, me, target)
-	if err != nil {
-		clearRepairAvailable()
-		result.Status = "error"
-		result.Reason = err.Error()
-		return result, err
-	}
-	result.Status = "repaired"
-	result.PID = pid
-	return result, nil
+func validateRepairWakeWinner(root, me string, expected wakeTarget) (wakeLockInspection, error) {
+	var winner wakeLockInspection
+	err := withWakeLifecycleGuard(root, me, func() error {
+		winner = inspectWakeLock(root, me)
+		if winner.Status != wakeLockValid || !winner.IdentityConfirmed || winner.Lock.Generation == "" {
+			return fmt.Errorf("no confirmed generation-bound wake is ready")
+		}
+		persisted, exists, err := readWakeTarget(root, me)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("repaired wake target is missing")
+		}
+		if err := validateWakeTarget(persisted, root, me); err != nil {
+			return err
+		}
+		if err := validateWakeTargetMatchesLock(winner.Lock, persisted); err != nil {
+			return err
+		}
+		if !sameWakeInjectorIdentity(persisted, expected) {
+			return fmt.Errorf("concurrent wake uses a different injector path or fixed arguments")
+		}
+		return nil
+	})
+	return winner, err
 }
 
 func startWakeFromTargetDefault(root, me string, target wakeTarget) (int, error) {
@@ -593,7 +656,7 @@ func startWakeFromTargetDefault(root, me string, target wakeTarget) (int, error)
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("start repaired amq wake: %w", err)
 	}
-	if err := waitForWakeReady(cmd.Process, readyPath, wakeReadyTimeout); err != nil {
+	if err := waitForWakeReady(cmd.Process, readyPath, root, me, wakeReadyTimeout); err != nil {
 		_ = cmd.Process.Kill()
 		return 0, err
 	}
@@ -839,24 +902,16 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	if err != nil {
 		var alreadyRunning *wakeAlreadyRunningError
 		if acceptExistingWake && errors.As(err, &alreadyRunning) {
-			return writeWakeReadyFile(readyFile)
+			return writeWakeReadyFile(root, me, readyFile, alreadyRunning.Inspection)
 		}
 		return err
 	}
 	defer cleanup()
 
 	if injectVia != "" {
-		if err := writeWakeTarget(root, me, *target); err != nil {
-			_ = writeStderr("warning: wake target not persisted; live repair disabled: %v\n", err)
-			if removeErr := removeWakeTarget(root, me); removeErr != nil {
-				return fmt.Errorf("clear stale wake target after persist failure: %w", removeErr)
-			}
-		}
 		if err := validateResolvedWakeInjectViaPath(injectVia); err != nil {
 			return err
 		}
-	} else if err := removeWakeTarget(root, me); err != nil {
-		return err
 	}
 
 	cfg := wakeConfig{
@@ -887,18 +942,11 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		interruptCooldown: *interruptCooldownFlag,
 	}
 
-	if err := writeWakeReadyFile(readyFile); err != nil {
+	if err := writeWakeReadyFile(root, me, readyFile, inspectWakeLock(root, me)); err != nil {
 		return err
 	}
 
 	return loop(cfg)
-}
-
-func writeWakeReadyFile(path string) error {
-	if path == "" {
-		return nil
-	}
-	return writeWakeMetadataFile(path, []byte("ready\n"), "wake ready file")
 }
 
 func parseInterruptKey(raw string) (string, error) {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -645,6 +645,7 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		Generation:   "generation-1",
 	}, target))
 	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
@@ -735,6 +736,7 @@ func TestRunWakeWithLoopNoneAcceptsExistingNoneWake(t *testing.T) {
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
 		WakeMode:     wakeInjectModeNone,
+		Generation:   "generation-1",
 	})
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
@@ -1011,6 +1013,7 @@ func TestRunWakeWithLoopAcceptExistingWakeAcceptsInjectViaUnknownTTY(t *testing.
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		Generation:   "generation-1",
 	}, target))
 	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
@@ -1507,6 +1510,132 @@ func TestRemoveWakeLockIfUnchangedRefusesChangedLock(t *testing.T) {
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
 		t.Fatalf("changed lock should remain, stat=%v", statErr)
+	}
+}
+
+func TestRemoveWakeLockDoesNotDeleteReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{PID: 4242, Generation: "old"})
+	inspection := inspectWakeLock(root, "orchestrator")
+	if !inspection.Exists {
+		t.Fatal("expected lock inspection")
+	}
+
+	replacement := wakeLock{
+		PID:        4242,
+		Root:       canonicalWakeRoot(root),
+		Agent:      "orchestrator",
+		Started:    time.Now().UTC().Format(time.RFC3339),
+		Generation: "old",
+	}
+	data, _ := json.Marshal(replacement)
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove original lock: %v", err)
+	}
+	if err := os.WriteFile(lockPath, data, 0o600); err != nil {
+		t.Fatalf("write byte-compatible replacement lock: %v", err)
+	}
+
+	err := removeWakeLockIfUnchanged(inspection)
+	if err == nil {
+		t.Fatal("expected replacement generation removal refusal")
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("replacement lock should remain, stat=%v", statErr)
+	}
+}
+
+func TestWakeCleanupDoesNotDeleteReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
+	if err != nil {
+		t.Fatalf("acquireWakeLock: %v", err)
+	}
+	lockPath := filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock")
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read acquired lock: %v", err)
+	}
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove acquired lock: %v", err)
+	}
+	if err := os.WriteFile(lockPath, data, 0o600); err != nil {
+		t.Fatalf("write byte-compatible replacement: %v", err)
+	}
+
+	cleanup()
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("replacement lock should survive old cleanup: %v", statErr)
+	}
+}
+
+func TestAcquireAndCleanupWaitForWakeLifecycleGuard(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- withWakeLifecycleGuard(root, "orchestrator", func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	type acquireResult struct {
+		cleanup func()
+		err     error
+	}
+	acquired := make(chan acquireResult, 1)
+	go func() {
+		cleanup, err := acquireWakeLock(root, "orchestrator", nil)
+		acquired <- acquireResult{cleanup: cleanup, err: err}
+	}()
+	time.Sleep(25 * time.Millisecond)
+	lockPath := filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock")
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("acquire mutated lock before lifecycle guard release: %v", err)
+	}
+	close(release)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("guard holder: %v", err)
+	}
+	result := <-acquired
+	if result.err != nil {
+		t.Fatalf("acquireWakeLock: %v", result.err)
+	}
+
+	entered = make(chan struct{})
+	release = make(chan struct{})
+	holderDone = make(chan error, 1)
+	go func() {
+		holderDone <- withWakeLifecycleGuard(root, "orchestrator", func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+	cleanupDone := make(chan struct{})
+	go func() {
+		result.cleanup()
+		close(cleanupDone)
+	}()
+	time.Sleep(25 * time.Millisecond)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("cleanup removed lock before lifecycle guard release: %v", err)
+	}
+	close(release)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("guard holder: %v", err)
+	}
+	<-cleanupDone
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("cleanup did not remove exact lock: %v", err)
 	}
 }
 
@@ -2010,8 +2139,14 @@ func TestRunWakeWithLoopRejectsRecentlyCorruptLock(t *testing.T) {
 }
 
 func TestWaitForWakeReadyReturnsWhenReadyFileAppears(t *testing.T) {
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID: os.Getpid(), Root: canonicalWakeRoot(root), Agent: "orchestrator",
+		Started: time.Now().UTC().Format(time.RFC3339), Generation: "generation-1",
+	})
+	inspection := inspectWakeLock(root, "orchestrator")
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
-	cmd := exec.Command("sh", "-c", `sleep 0.05; : > "$1"; sleep 1`, "sh", readyPath)
+	cmd := exec.Command("sh", "-c", "sleep 1")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
@@ -2019,7 +2154,10 @@ func TestWaitForWakeReadyReturnsWhenReadyFileAppears(t *testing.T) {
 		_ = cmd.Process.Kill()
 	})
 
-	if err := waitForWakeReady(cmd.Process, readyPath, time.Second); err != nil {
+	if err := writeWakeReadyFile(root, "orchestrator", readyPath, inspection); err != nil {
+		t.Fatalf("writeWakeReadyFile: %v", err)
+	}
+	if err := waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second); err != nil {
 		t.Fatalf("waitForWakeReady: %v", err)
 	}
 }
@@ -2031,7 +2169,7 @@ func TestWaitForWakeReadyFailsWhenWakeExitsBeforeReady(t *testing.T) {
 		t.Fatalf("start helper: %v", err)
 	}
 
-	err := waitForWakeReady(cmd.Process, readyPath, time.Second)
+	err := waitForWakeReady(cmd.Process, readyPath, t.TempDir(), "orchestrator", time.Second)
 	if err == nil {
 		t.Fatal("expected readiness failure")
 	}
@@ -2041,18 +2179,188 @@ func TestWaitForWakeReadyFailsWhenWakeExitsBeforeReady(t *testing.T) {
 }
 
 func TestWaitForWakeReadyAcceptsReadyFileWrittenBeforeExit(t *testing.T) {
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID: os.Getpid(), Root: canonicalWakeRoot(root), Agent: "orchestrator",
+		Started: time.Now().UTC().Format(time.RFC3339), Generation: "generation-1",
+	})
+	inspection := inspectWakeLock(root, "orchestrator")
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
-	cmd := exec.Command("sh", "-c", `: > "$1"; exit 0`, "sh", readyPath)
+	if err := writeWakeReadyFile(root, "orchestrator", readyPath, inspection); err != nil {
+		t.Fatalf("writeWakeReadyFile: %v", err)
+	}
+	cmd := exec.Command("sh", "-c", "exit 0")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
 
-	if err := waitForWakeReady(cmd.Process, readyPath, time.Second); err != nil {
+	if err := waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second); err != nil {
 		t.Fatalf("waitForWakeReady should accept ready file written before exit: %v", err)
 	}
 }
 
+func TestWaitForWakeReadyRefusesLegacyReadyFile(t *testing.T) {
+	root := secureTempDirForTest(t)
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	if err := os.WriteFile(readyPath, []byte("ready\n"), 0o600); err != nil {
+		t.Fatalf("write legacy ready file: %v", err)
+	}
+	cmd := exec.Command("sh", "-c", "sleep 1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	err := waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "legacy") {
+		t.Fatalf("expected legacy readiness refusal, got %v", err)
+	}
+}
+
+func TestWaitForWakeReadyRefusesEmptyReadyFile(t *testing.T) {
+	root := secureTempDirForTest(t)
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	if err := os.WriteFile(readyPath, nil, 0o600); err != nil {
+		t.Fatalf("write empty ready file: %v", err)
+	}
+	cmd := exec.Command("sh", "-c", "sleep 1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	err := waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "legacy") {
+		t.Fatalf("expected empty readiness refusal, got %v", err)
+	}
+}
+
+func TestAcceptExistingReadinessNotPublishedOnReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID: 4242, Root: canonicalWakeRoot(root), Agent: "orchestrator",
+		Started: time.Now().UTC().Format(time.RFC3339), Generation: "generation-1",
+	})
+	expected := inspectWakeLock(root, "orchestrator")
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove original lock: %v", err)
+	}
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID: 4242, Root: canonicalWakeRoot(root), Agent: "orchestrator",
+		Started: time.Now().UTC().Format(time.RFC3339), Generation: "generation-2",
+	})
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+
+	err := writeWakeReadyFile(root, "orchestrator", readyPath, expected)
+	if err == nil {
+		t.Fatal("expected replacement readiness refusal")
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("replacement readiness must not be published, statErr=%v", statErr)
+	}
+}
+
+func TestWaitForWakeReadyRefusesLockReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
+	if err != nil {
+		t.Fatalf("acquireWakeLock: %v", err)
+	}
+	defer cleanup()
+	inspection := inspectWakeLock(root, "orchestrator")
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	if err := writeWakeReadyFile(root, "orchestrator", readyPath, inspection); err != nil {
+		t.Fatalf("writeWakeReadyFile: %v", err)
+	}
+	lockPath := inspection.LockPath
+	replacement := inspection.Lock
+	replacement.Generation = "replacement-generation"
+	data, _ := json.Marshal(replacement)
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove original lock: %v", err)
+	}
+	if err := os.WriteFile(lockPath, data, 0o600); err != nil {
+		t.Fatalf("write replacement lock: %v", err)
+	}
+	cmd := exec.Command("sh", "-c", "sleep 1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	err = waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "generation") {
+		t.Fatalf("expected replacement generation refusal, got %v", err)
+	}
+}
+
+func TestWaitForWakeReadyRefusesTargetReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})
+	cleanup, err := acquireWakeLock(root, "orchestrator", &target)
+	if err != nil {
+		t.Fatalf("acquireWakeLock: %v", err)
+	}
+	defer cleanup()
+	inspection := inspectWakeLock(root, "orchestrator")
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	if err := writeWakeReadyFile(root, "orchestrator", readyPath, inspection); err != nil {
+		t.Fatalf("writeWakeReadyFile: %v", err)
+	}
+	tampered := target
+	tampered.InjectArgs = []string{"different"}
+	if err := writeWakeTarget(root, "orchestrator", tampered); err != nil {
+		t.Fatalf("write replacement target: %v", err)
+	}
+	cmd := exec.Command("sh", "-c", "sleep 1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	err = waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "does not match wake lock") {
+		t.Fatalf("expected replacement target refusal, got %v", err)
+	}
+}
+
+func TestWaitForWakeReadyRefusesStrayTargetForTargetlessLock(t *testing.T) {
+	root := secureTempDirForTest(t)
+	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
+	if err != nil {
+		t.Fatalf("acquireWakeLock: %v", err)
+	}
+	defer cleanup()
+	inspection := inspectWakeLock(root, "orchestrator")
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	if err := writeWakeReadyFile(root, "orchestrator", readyPath, inspection); err != nil {
+		t.Fatalf("writeWakeReadyFile: %v", err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	strayTarget := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})
+	if err := writeWakeTarget(root, "orchestrator", strayTarget); err != nil {
+		t.Fatalf("write stray target: %v", err)
+	}
+	cmd := exec.Command("sh", "-c", "sleep 1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	err = waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "target does not match current wake lock") {
+		t.Fatalf("expected stray target refusal for targetless lock, got %v", err)
+	}
+}
+
 func TestWriteWakeReadyFileRejectsSymlink(t *testing.T) {
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID: os.Getpid(), Root: canonicalWakeRoot(root), Agent: "orchestrator",
+		Started: time.Now().UTC().Format(time.RFC3339), Generation: "generation-1",
+	})
+	inspection := inspectWakeLock(root, "orchestrator")
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target.ready")
 	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
@@ -2063,7 +2371,7 @@ func TestWriteWakeReadyFileRejectsSymlink(t *testing.T) {
 		t.Fatalf("symlink ready file: %v", err)
 	}
 
-	err := writeWakeReadyFile(readyPath)
+	err := writeWakeReadyFile(root, "orchestrator", readyPath, inspection)
 	if err == nil {
 		t.Fatal("expected wake ready symlink rejection")
 	}


### PR DESCRIPTION
## Summary

Wave 3 of #235: introduces a permanent `.wake.lifecycle.lock` that serializes every wake-lock / target / readiness mutation (acquire, child cleanup, stale removal, repair, doctor --fix, target commit/removal, readiness publication). The target is staged first and the lock is published last as the commit point; `--accept-existing-wake` readiness is now bound to the exact lock generation **and** target, so a stale or replaced wake can never satisfy a consumer's readiness wait.

## Key properties

- **Guard wrapper**: opens with `O_NOFOLLOW|O_NONBLOCK`, validates regular-file + owner + 0600 after flock, re-stats fd vs path via `os.SameFile` (defeats post-open swaps), and is **never unlinked**.
- **Lock order (normative, commented at the guard def)**: guard → metadata/target mutations; release before any child wait / pidfd exit wait / control wait; the child reacquires the guard for exact-generation cleanup. No path waits on a child while holding the guard.
- **Exact-generation cleanup**: removal re-reads under the guard and unlinks only the exact generation (inode/nonce + `os.SameFile`).
- **Repair**: guarded validate/remove → release → spawn → guarded exact-ready validation; a concurrent winner is accepted only on exact target match, else refused without deletion.
- **Doctor**: `--ops` read-only; `--fix-wake-locks` removes only an exact proven-stale generation under the guard; unknown untouched.

## Upgrade note

A pre-guard wake already running during rollout is not serialized by the new guard; it degrades to the retained inode/generation defense — no weaker than the pre-#246 base.

## Review

`make ci` + `-race` suite green; all four GOOS builds compile. Reviewed by a dedicated code-review agent (all 8 spec items) and independently by Gemini 3.1 Pro (clean on deadlock, guard security, TOCTOU, readiness binding, safe deletion, fd leaks). Part of #235. Implementation by Codex; design/review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)