### PR TITLE
feat(wake): Linux pidfd wake termination capability

### DIFF
--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -99,6 +99,19 @@ func (e *wakeAlreadyRunningError) Error() string {
 }
 
 func inspectWakeLock(root, me string) wakeLockInspection {
+	inspection := readWakeLockMetadata(root, me)
+	if !inspection.Exists || inspection.Status != wakeLockMissing {
+		return inspection
+	}
+	inspection.Process = inspectWakeProcess(inspection.Lock.PID)
+	classifyWakeLock(root, me, &inspection)
+	return inspection
+}
+
+// readWakeLockMetadata reads one exact lock generation without consulting the
+// process table. Linux orphan retirement uses this to acquire a pidfd before
+// the first PID-based identity inspection of the locked generation.
+func readWakeLockMetadata(root, me string) wakeLockInspection {
 	lockPath := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
 	inspection := wakeLockInspection{
 		Status:   wakeLockMissing,
@@ -135,8 +148,6 @@ func inspectWakeLock(root, me string) wakeLockInspection {
 
 	inspection.Lock = existing
 	inspection.PID = existing.PID
-	inspection.Process = inspectWakeProcess(existing.PID)
-	classifyWakeLock(root, me, &inspection)
 	return inspection
 }
 

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -1,0 +1,91 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+var signalWakeProcess = func(pid int, sig os.Signal) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(sig)
+}
+
+func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
+	var recheck wakeLockInspection
+	if err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
+		recheck = inspectWakeLock(inspection.Root, inspection.Agent)
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	if !sameWakeLockInspection(inspection, recheck) || !recheck.IdentityConfirmed {
+		return false, nil
+	}
+	// Process termination can wait. It must happen after releasing the guard.
+	if err := terminateWakeProcess(recheck); err != nil {
+		return false, err
+	}
+	removed := false
+	err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
+		current := inspectWakeLock(inspection.Root, inspection.Agent)
+		if !sameWakeLockGeneration(recheck, current) {
+			return nil
+		}
+		if err := validateWakeLockStaleRemoval(current); err != nil {
+			return err
+		}
+		if err := removeWakeLockIfUnchangedGuarded(current); err != nil {
+			return err
+		}
+		removed = true
+		return nil
+	})
+	return removed, err
+}
+
+func terminateWakeProcess(inspection wakeLockInspection) error {
+	if !sameConfirmedWakeLock(inspection) {
+		return fmt.Errorf("wake process identity changed before SIGTERM")
+	}
+	if err := signalWakeProcess(inspection.PID, syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal wake process SIGTERM: %w", err)
+	}
+	time.Sleep(wakeTerminateGrace)
+	switch state := inspectWakeIdentity(inspection); state {
+	case wakeIdentityGoneOrDifferent:
+		return nil
+	case wakeIdentityUnknown:
+		return fmt.Errorf("wake process identity is unknown after SIGTERM; preserving wake lock")
+	}
+	if !sameConfirmedWakeLock(inspection) {
+		return fmt.Errorf("wake process identity changed before SIGKILL")
+	}
+	if err := signalWakeProcess(inspection.PID, syscall.SIGKILL); err != nil {
+		return fmt.Errorf("signal wake process SIGKILL: %w", err)
+	}
+	deadline := time.Now().Add(wakeTerminateGrace)
+	for {
+		switch state := inspectWakeIdentity(inspection); state {
+		case wakeIdentityGoneOrDifferent:
+			return nil
+		case wakeIdentityUnknown:
+			return fmt.Errorf("wake process identity is unknown after SIGKILL; preserving wake lock")
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("wake process still alive after SIGKILL")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func sameConfirmedWakeLock(inspection wakeLockInspection) bool {
+	recheck := inspectWakeLock(inspection.Root, inspection.Agent)
+	return sameWakeLockInspection(inspection, recheck) && recheck.IdentityConfirmed
+}

--- a/internal/cli/wake_terminate_legacy_test_darwin.go
+++ b/internal/cli/wake_terminate_legacy_test_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package cli
+
+import "testing"
+
+func requireBarePIDWakeTermination(t *testing.T) {
+	t.Helper()
+}

--- a/internal/cli/wake_terminate_legacy_test_linux.go
+++ b/internal/cli/wake_terminate_legacy_test_linux.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+var signalWakeProcess = func(int, os.Signal) error {
+	return errors.New("bare-PID wake signaling is unavailable on Linux")
+}
+
+func terminateWakeProcess(wakeLockInspection) error {
+	return errors.New("bare-PID wake termination is unavailable on Linux")
+}
+
+func requireBarePIDWakeTermination(t *testing.T) {
+	t.Helper()
+	t.Skip("bare-PID termination is Darwin-only; Linux pidfd behavior has platform tests")
+}

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -1,0 +1,154 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	linuxPidfdOpen       = unix.PidfdOpen
+	linuxPidfdSendSignal = unix.PidfdSendSignal
+	linuxPidfdClose      = unix.Close
+	linuxPidfdPoll       = pollLinuxPidfd
+)
+
+func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
+	var locked wakeLockInspection
+	pidfd := -1
+	provenGone := false
+	if err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
+		locked = readWakeLockMetadata(inspection.Root, inspection.Agent)
+		if !sameWakeLockGeneration(inspection, locked) {
+			return nil
+		}
+
+		// Acquire the stable process capability before any PID-based identity
+		// inspection of this locked generation. From here onward, signaling and
+		// exit detection use only this descriptor.
+		fd, err := linuxPidfdOpen(locked.PID, 0)
+		if err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				provenGone = true
+				return removeWakeLockIfUnchangedGuarded(locked)
+			}
+			return fmt.Errorf("pidfd_open wake process %d: %w", locked.PID, err)
+		}
+		pidfd = fd
+
+		locked.Process = inspectWakeProcess(locked.PID)
+		classifyWakeLock(locked.Root, locked.Agent, &locked)
+		if !sameWakeLockInspection(inspection, locked) || !locked.IdentityConfirmed {
+			return nil
+		}
+		return nil
+	}); err != nil {
+		if pidfd >= 0 {
+			_ = linuxPidfdClose(pidfd)
+		}
+		return false, err
+	}
+	if provenGone {
+		return true, nil
+	}
+	if pidfd < 0 || !locked.IdentityConfirmed {
+		if pidfd >= 0 {
+			_ = linuxPidfdClose(pidfd)
+		}
+		return false, nil
+	}
+	defer func() { _ = linuxPidfdClose(pidfd) }()
+
+	// Signaling and both waits happen without the lifecycle guard. The retained
+	// pidfd cannot retarget a recycled numeric PID.
+	if err := terminateWakePidfd(pidfd); err != nil {
+		return false, err
+	}
+
+	removed := false
+	err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
+		current := inspectWakeLock(inspection.Root, inspection.Agent)
+		if !sameWakeLockGeneration(locked, current) {
+			return nil
+		}
+		if err := validateWakeLockStaleRemoval(current); err != nil {
+			return err
+		}
+		if err := removeWakeLockIfUnchangedGuarded(current); err != nil {
+			return err
+		}
+		removed = true
+		return nil
+	})
+	return removed, err
+}
+
+func terminateWakePidfd(pidfd int) error {
+	if err := linuxPidfdSendSignal(pidfd, unix.SIGTERM, nil, 0); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return fmt.Errorf("pidfd_send_signal SIGTERM: %w", err)
+	}
+	exited, err := linuxPidfdPoll(pidfd, wakeTerminateGrace)
+	if err != nil {
+		return fmt.Errorf("poll pidfd after SIGTERM: %w", err)
+	}
+	if exited {
+		return nil
+	}
+	if err := linuxPidfdSendSignal(pidfd, unix.SIGKILL, nil, 0); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return fmt.Errorf("pidfd_send_signal SIGKILL: %w", err)
+	}
+	exited, err = linuxPidfdPoll(pidfd, wakeTerminateGrace)
+	if err != nil {
+		return fmt.Errorf("poll pidfd after SIGKILL: %w", err)
+	}
+	if !exited {
+		return fmt.Errorf("wake process still alive after SIGKILL")
+	}
+	return nil
+}
+
+func pollLinuxPidfd(pidfd int, timeout time.Duration) (bool, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		remaining := time.Until(deadline)
+		if remaining < 0 {
+			remaining = 0
+		}
+		timeoutMillis := int((remaining + time.Millisecond - 1) / time.Millisecond)
+		fds := []unix.PollFd{{Fd: int32(pidfd), Events: unix.POLLIN}}
+		ready, err := unix.Poll(fds, timeoutMillis)
+		if errors.Is(err, syscall.EINTR) {
+			if time.Now().Before(deadline) {
+				continue
+			}
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if ready == 0 {
+			return false, nil
+		}
+		revents := fds[0].Revents
+		if revents&unix.POLLNVAL != 0 {
+			return false, fmt.Errorf("pidfd became invalid")
+		}
+		if revents&(unix.POLLIN|unix.POLLHUP) != 0 {
+			return true, nil
+		}
+		if revents&unix.POLLERR != 0 {
+			return false, fmt.Errorf("pidfd poll reported an error")
+		}
+	}
+}

--- a/internal/cli/wake_terminate_linux_test.go
+++ b/internal/cli/wake_terminate_linux_test.go
@@ -186,15 +186,20 @@ func TestTerminateOpensPidfdBeforeIdentityInspectionAndReleasesGuardBeforeWait(t
 		events = append(events, event)
 	}
 	inspectCalls := 0
+	releasePoll := make(chan struct{})
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		inspectCalls++
 		if inspectCalls > 1 {
 			record("inspect")
 		}
-		return matchingLinuxWakeProcess(pid, root)
+		select {
+		case <-releasePoll:
+			return wakeProcessInfo{PID: pid, Running: false}
+		default:
+			return matchingLinuxWakeProcess(pid, root)
+		}
 	})
 	pollEntered := make(chan struct{})
-	releasePoll := make(chan struct{})
 	stubLinuxPidfd(t,
 		func(pid, flags int) (int, error) { record("open"); return 99, nil },
 		func(fd int, sig unix.Signal, info *unix.Siginfo, flags int) error { return nil },

--- a/internal/cli/wake_terminate_linux_test.go
+++ b/internal/cli/wake_terminate_linux_test.go
@@ -56,9 +56,9 @@ func TestTerminateWakePidfdKillsValidatedChildAndCannotSignalAfterExit(t *testin
 	if err := terminateWakePidfd(pidfd); err != nil {
 		t.Fatalf("terminate child via pidfd: %v", err)
 	}
-	if _, err := cmd.Process.Wait(); err == nil {
-		t.Fatal("child wait unexpectedly succeeded after signal termination")
-	}
+	// Wait may report a normal exit when the child handles SIGTERM; pidfd
+	// ESRCH below is the authoritative proof that the process is gone.
+	_, _ = cmd.Process.Wait()
 	if err := linuxPidfdSendSignal(pidfd, unix.SIGTERM, nil, 0); !errors.Is(err, syscall.ESRCH) {
 		t.Fatalf("signal retained pidfd after exit = %v, want ESRCH", err)
 	}
@@ -109,7 +109,10 @@ func TestTerminateFailsClosedWhenPidfdOpenIsUnsupported(t *testing.T) {
 	inspectCalls := 0
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		inspectCalls++
-		return matchingLinuxWakeProcess(pid, root)
+		p := matchingLinuxWakeProcess(pid, root)
+		p.Executable = "/usr/bin/not-amq"
+		p.Args = []string{"not-amq"}
+		return p
 	})
 	stubLinuxPidfd(t,
 		func(pid, flags int) (int, error) { return -1, syscall.ENOSYS },

--- a/internal/cli/wake_terminate_linux_test.go
+++ b/internal/cli/wake_terminate_linux_test.go
@@ -1,0 +1,246 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func stubLinuxPidfd(t *testing.T, open func(int, int) (int, error), send func(int, unix.Signal, *unix.Siginfo, int) error, poll func(int, time.Duration) (bool, error)) {
+	t.Helper()
+	oldOpen := linuxPidfdOpen
+	oldSend := linuxPidfdSendSignal
+	oldPoll := linuxPidfdPoll
+	oldClose := linuxPidfdClose
+	linuxPidfdOpen = open
+	linuxPidfdSendSignal = send
+	linuxPidfdPoll = poll
+	linuxPidfdClose = func(int) error { return nil }
+	t.Cleanup(func() {
+		linuxPidfdOpen = oldOpen
+		linuxPidfdSendSignal = oldSend
+		linuxPidfdPoll = oldPoll
+		linuxPidfdClose = oldClose
+	})
+}
+
+func TestTerminateWakePidfdKillsValidatedChildAndCannotSignalAfterExit(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	proc := inspectWakeProcessPlatform(cmd.Process.Pid)
+	if !proc.Running || proc.PID != cmd.Process.Pid || proc.StartToken == "" {
+		t.Fatalf("child identity was not validated: %#v", proc)
+	}
+	pidfd, err := linuxPidfdOpen(cmd.Process.Pid, 0)
+	if err != nil {
+		t.Fatalf("pidfd_open child: %v", err)
+	}
+	defer func() { _ = linuxPidfdClose(pidfd) }()
+
+	if err := terminateWakePidfd(pidfd); err != nil {
+		t.Fatalf("terminate child via pidfd: %v", err)
+	}
+	if _, err := cmd.Process.Wait(); err == nil {
+		t.Fatal("child wait unexpectedly succeeded after signal termination")
+	}
+	if err := linuxPidfdSendSignal(pidfd, unix.SIGTERM, nil, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("signal retained pidfd after exit = %v, want ESRCH", err)
+	}
+}
+
+func TestRetireDoesNotSignalRecycledPID(t *testing.T) {
+	old := exec.Command("sleep", "30")
+	if err := old.Start(); err != nil {
+		t.Fatalf("start old child: %v", err)
+	}
+	pidfd, err := linuxPidfdOpen(old.Process.Pid, 0)
+	if err != nil {
+		_ = old.Process.Kill()
+		_, _ = old.Process.Wait()
+		t.Fatalf("pidfd_open old child: %v", err)
+	}
+	defer func() { _ = linuxPidfdClose(pidfd) }()
+	if err := linuxPidfdSendSignal(pidfd, unix.SIGKILL, nil, 0); err != nil {
+		t.Fatalf("kill old child via pidfd: %v", err)
+	}
+	if exited, err := linuxPidfdPoll(pidfd, time.Second); err != nil || !exited {
+		t.Fatalf("poll old child exit = (%v, %v), want exited", exited, err)
+	}
+	_, _ = old.Process.Wait()
+
+	replacement := exec.Command("sleep", "30")
+	if err := replacement.Start(); err != nil {
+		t.Fatalf("start replacement child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = replacement.Process.Kill()
+		_, _ = replacement.Process.Wait()
+	})
+	if err := linuxPidfdSendSignal(pidfd, unix.SIGTERM, nil, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("signal old pidfd after replacement start = %v, want ESRCH", err)
+	}
+	if err := replacement.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Fatalf("replacement child was signaled through stale pidfd: %v", err)
+	}
+}
+
+func TestTerminateFailsClosedWhenPidfdOpenIsUnsupported(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID: wakePID, TTY: "missing", ProcessStart: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
+	})
+	inspectCalls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspectCalls++
+		return matchingLinuxWakeProcess(pid, root)
+	})
+	stubLinuxPidfd(t,
+		func(pid, flags int) (int, error) { return -1, syscall.ENOSYS },
+		func(int, unix.Signal, *unix.Siginfo, int) error { t.Fatal("must not signal without pidfd"); return nil },
+		func(int, time.Duration) (bool, error) { t.Fatal("must not poll without pidfd"); return false, nil },
+	)
+
+	inspection := inspectWakeLock(root, "codex")
+	replaced, err := terminateAndRemoveOrphanedWakeLock(inspection)
+	if err == nil || !strings.Contains(err.Error(), "pidfd_open") {
+		t.Fatalf("termination error = %v, want pidfd_open failure", err)
+	}
+	if replaced {
+		t.Fatal("unsupported pidfd unexpectedly replaced lock")
+	}
+	if inspectCalls != 1 {
+		t.Fatalf("process inspections = %d, want only initial inspection before pidfd_open failure", inspectCalls)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock was not preserved: %v", err)
+	}
+}
+
+func TestTerminateTreatsPidfdESRCHAsProvenGone(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID: wakePID, TTY: "missing", ProcessStart: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
+	})
+	inspectCalls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspectCalls++
+		return matchingLinuxWakeProcess(pid, root)
+	})
+	stubLinuxPidfd(t,
+		func(pid, flags int) (int, error) { return -1, syscall.ESRCH },
+		func(int, unix.Signal, *unix.Siginfo, int) error {
+			t.Fatal("must not signal a proven-gone process")
+			return nil
+		},
+		func(int, time.Duration) (bool, error) {
+			t.Fatal("must not poll a proven-gone process")
+			return false, nil
+		},
+	)
+
+	inspection := inspectWakeLock(root, "codex")
+	replaced, err := terminateAndRemoveOrphanedWakeLock(inspection)
+	if err != nil || !replaced {
+		t.Fatalf("proven-gone replacement = (%v, %v), want (true, nil)", replaced, err)
+	}
+	if inspectCalls != 1 {
+		t.Fatalf("process inspections = %d, want no PID re-lookup after ESRCH", inspectCalls)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("proven-gone lock was not removed: %v", err)
+	}
+}
+
+func TestTerminateOpensPidfdBeforeIdentityInspectionAndReleasesGuardBeforeWait(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID: wakePID, TTY: "missing", ProcessStart: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
+	})
+	var mu sync.Mutex
+	var events []string
+	record := func(event string) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, event)
+	}
+	inspectCalls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspectCalls++
+		if inspectCalls > 1 {
+			record("inspect")
+		}
+		return matchingLinuxWakeProcess(pid, root)
+	})
+	pollEntered := make(chan struct{})
+	releasePoll := make(chan struct{})
+	stubLinuxPidfd(t,
+		func(pid, flags int) (int, error) { record("open"); return 99, nil },
+		func(fd int, sig unix.Signal, info *unix.Siginfo, flags int) error { return nil },
+		func(fd int, timeout time.Duration) (bool, error) {
+			close(pollEntered)
+			<-releasePoll
+			return true, nil
+		},
+	)
+
+	inspection := inspectWakeLock(root, "codex")
+	done := make(chan error, 1)
+	go func() {
+		_, err := terminateAndRemoveOrphanedWakeLock(inspection)
+		done <- err
+	}()
+	select {
+	case <-pollEntered:
+	case <-time.After(time.Second):
+		t.Fatal("pidfd poll was not reached")
+	}
+
+	guardAcquired := make(chan error, 1)
+	go func() {
+		guardAcquired <- withWakeLifecycleGuard(root, "codex", func() error { return nil })
+	}()
+	select {
+	case err := <-guardAcquired:
+		if err != nil {
+			t.Fatalf("acquire lifecycle guard during pidfd wait: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("lifecycle guard remained held during pidfd wait")
+	}
+	close(releasePoll)
+	if err := <-done; err != nil {
+		t.Fatalf("terminate after poll release: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) < 2 || events[0] != "open" || events[1] != "inspect" {
+		t.Fatalf("pre-signal events = %v, want pidfd open before identity inspection", events)
+	}
+}
+
+func matchingLinuxWakeProcess(pid int, root string) wakeProcessInfo {
+	return wakeProcessInfo{
+		PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
+		Args: []string{"/usr/bin/amq", "wake", "--root", root, "--me", "codex"},
+	}
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -25,13 +25,6 @@ import (
 )
 
 var (
-	signalWakeProcess = func(pid int, sig os.Signal) error {
-		proc, err := os.FindProcess(pid)
-		if err != nil {
-			return err
-		}
-		return proc.Signal(sig)
-	}
 	wakeTerminateGrace   = 100 * time.Millisecond
 	getWakeCurrentTTY    = getCurrentTTY
 	getWakeProcessSID    = unix.Getsid
@@ -336,39 +329,6 @@ func wakeArgsUseInjectVia(args []string) bool {
 	return false
 }
 
-func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
-	var recheck wakeLockInspection
-	if err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
-		recheck = inspectWakeLock(inspection.Root, inspection.Agent)
-		return nil
-	}); err != nil {
-		return false, err
-	}
-	if !sameWakeLockInspection(inspection, recheck) || !recheck.IdentityConfirmed {
-		return false, nil
-	}
-	// Process termination can wait. It must happen after releasing the guard.
-	if err := terminateWakeProcess(recheck); err != nil {
-		return false, err
-	}
-	removed := false
-	err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
-		current := inspectWakeLock(inspection.Root, inspection.Agent)
-		if !sameWakeLockGeneration(recheck, current) {
-			return nil
-		}
-		if err := validateWakeLockStaleRemoval(current); err != nil {
-			return err
-		}
-		if err := removeWakeLockIfUnchangedGuarded(current); err != nil {
-			return err
-		}
-		removed = true
-		return nil
-	})
-	return removed, err
-}
-
 func sameWakeLockInspection(first, second wakeLockInspection) bool {
 	if !second.Exists || second.Status != wakeLockValid {
 		return false
@@ -377,46 +337,6 @@ func sameWakeLockInspection(first, second wakeLockInspection) bool {
 		return false
 	}
 	return sameWakeLockGeneration(first, second)
-}
-
-func terminateWakeProcess(inspection wakeLockInspection) error {
-	if !sameConfirmedWakeLock(inspection) {
-		return fmt.Errorf("wake process identity changed before SIGTERM")
-	}
-	if err := signalWakeProcess(inspection.PID, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("signal wake process SIGTERM: %w", err)
-	}
-	time.Sleep(wakeTerminateGrace)
-	switch state := inspectWakeIdentity(inspection); state {
-	case wakeIdentityGoneOrDifferent:
-		return nil
-	case wakeIdentityUnknown:
-		return fmt.Errorf("wake process identity is unknown after SIGTERM; preserving wake lock")
-	}
-	if !sameConfirmedWakeLock(inspection) {
-		return fmt.Errorf("wake process identity changed before SIGKILL")
-	}
-	if err := signalWakeProcess(inspection.PID, syscall.SIGKILL); err != nil {
-		return fmt.Errorf("signal wake process SIGKILL: %w", err)
-	}
-	deadline := time.Now().Add(wakeTerminateGrace)
-	for {
-		switch state := inspectWakeIdentity(inspection); state {
-		case wakeIdentityGoneOrDifferent:
-			return nil
-		case wakeIdentityUnknown:
-			return fmt.Errorf("wake process identity is unknown after SIGKILL; preserving wake lock")
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("wake process still alive after SIGKILL")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
-func sameConfirmedWakeLock(inspection wakeLockInspection) bool {
-	recheck := inspectWakeLock(inspection.Root, inspection.Agent)
-	return sameWakeLockInspection(inspection, recheck) && recheck.IdentityConfirmed
 }
 
 // processAlive checks if a process with given PID is running.

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1697,6 +1697,7 @@ func TestInspectWakeLockRejectsSymlinkAndFIFO(t *testing.T) {
 }
 
 func TestShouldReplaceOrphanedWakeLockSignalsOnlyAfterRevalidation(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
@@ -1752,6 +1753,7 @@ func TestShouldReplaceOrphanedWakeLockSignalsOnlyAfterRevalidation(t *testing.T)
 }
 
 func TestShouldReplaceOrphanedWakeLockKeepsLockWhenKillDoesNotTerminate(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
@@ -1792,6 +1794,7 @@ func TestShouldReplaceOrphanedWakeLockKeepsLockWhenKillDoesNotTerminate(t *testi
 }
 
 func TestTerminateWakeProcessPreservesLiveWakeOnUnknownBootAfterSignal(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4343
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"})
@@ -1820,6 +1823,7 @@ func TestTerminateWakeProcessPreservesLiveWakeOnUnknownBootAfterSignal(t *testin
 }
 
 func TestTerminatePreservesLockOnUnknownInspectionAfterSIGTERM(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4350
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"})
@@ -1851,6 +1855,7 @@ func TestTerminatePreservesLockOnUnknownInspectionAfterSIGTERM(t *testing.T) {
 }
 
 func TestTerminatePreservesLockOnUnknownInspectionAfterSIGKILL(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4351
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1", Executable: "/opt/homebrew/bin/amq"})
@@ -1882,6 +1887,7 @@ func TestTerminatePreservesLockOnUnknownInspectionAfterSIGKILL(t *testing.T) {
 }
 
 func TestTerminateWakeProcessPreservesLiveWakeOnShiftedBootClock(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4344
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "100.000000000", Executable: "/opt/homebrew/bin/amq"})
@@ -1909,6 +1915,7 @@ func TestTerminateWakeProcessPreservesLiveWakeOnShiftedBootClock(t *testing.T) {
 }
 
 func TestTerminateWakeProcessPreservesLiveWakeOnShiftedLegacyBootInLegacyField(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4345
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "100.000000000", Executable: "/opt/homebrew/bin/amq"})
@@ -1935,6 +1942,7 @@ func TestTerminateWakeProcessPreservesLiveWakeOnShiftedLegacyBootInLegacyField(t
 }
 
 func TestShouldReplaceOrphanedWakeLockRevalidatesBeforeSignal(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
@@ -1988,6 +1996,7 @@ func TestShouldReplaceOrphanedWakeLockRevalidatesBeforeSignal(t *testing.T) {
 }
 
 func TestShouldReplaceOrphanedWakeLockReplacesInjectViaWhenOwnerGone(t *testing.T) {
+	requireBarePIDWakeTermination(t)
 	const wakePID = 4242
 	const ownerPID = 7777
 	root := secureTempDirForTest(t)


### PR DESCRIPTION
## Summary

Wave 4 of #235: replaces bare-PID signaling of orphaned wakes with a **pidfd-backed capability** on Linux. `unix.PidfdOpen` is acquired immediately after reading the locked generation (under the lifecycle guard, before identity inspection) and retained through SIGTERM → poll → SIGKILL → poll; signaling is exclusively via `unix.PidfdSendSignal`, and exit is detected by polling the pidfd (POLLIN/POLLHUP) — never by re-looking-up the PID. This closes the PID-reuse window: if the verified wake exits, `PidfdSendSignal` returns ESRCH and can never signal a recycled PID.

- **ESRCH-on-open** → the process is proven gone, so it takes the guarded stale-cleanup path without signaling.
- **Guard released before the exit/escalation waits** (per the normative lock order); exact-generation cleanup on reacquire.
- **Darwin**: unchanged this wave — bare-PID terminate is preserved (now running under the W3 guard with generation-exact cleanup); it is removed in W5 (cooperative shutdown).
- Unsupported pidfd (pre-5.3) / permission / unknown inspection → fail closed, metadata preserved.

Wake is darwin/linux only; the package still compiles on windows/freebsd (verified).

## Review

Original implementation reviewed at the pre-rebase commit (pidfd path: fd-before-inspection, retained through TERM/KILL/poll, ESRCH handling, guard-release-before-wait). This PR is that exact 8-file delta re-applied cleanly on the merged W3. `make ci`, all four GOOS builds, and `GOOS=linux go test -c` pass. Part of #235. Implementation by Codex; design/review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)