### PR TITLE
feat(cli): tri-state tree identity, physical pins, and authority de-laundering

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,8 @@ AMQ enforces strict permissions:
 
 ## Reporting a Vulnerability
 
+Windows runtime is out of scope for cross-tree identity and `.amqrc` authority hardening; it degrades to legacy lexical behavior.
+
 Please report security issues by opening a GitHub Security Advisory for this repository. If that is not available, open a regular issue and label it `security`.
 
 We will acknowledge receipt as soon as possible and work to provide a fix or mitigation.

--- a/internal/cli/amqrc_provenance_test.go
+++ b/internal/cli/amqrc_provenance_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindAmqrcForRootLstatFailureRefused(t *testing.T) {
+	root := t.TempDir()
+	rc := filepath.Join(root, ".amqrc")
+	if err := os.WriteFile(rc, []byte(`{"root":".agent-mail"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	orig := amqrcLstat
+	amqrcLstat = func(string) (os.FileInfo, error) { return nil, errors.New("metadata denied") }
+	defer func() { amqrcLstat = orig }()
+	if _, err := findAmqrcForRoot(root); err == nil {
+		t.Fatal("expected Lstat failure to refuse config")
+	}
+}

--- a/internal/cli/amqrc_security_unix.go
+++ b/internal/cli/amqrc_security_unix.go
@@ -26,5 +26,8 @@ func validateAmqrcFile(path string) error {
 	if uint32(st.Uid) != uint32(os.Geteuid()) {
 		return fmt.Errorf(".amqrc at %s is owned by uid %d, want euid %d", path, st.Uid, os.Geteuid())
 	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf(".amqrc at %s is group/world-writable", path)
+	}
 	return nil
 }

--- a/internal/cli/amqrc_security_unix.go
+++ b/internal/cli/amqrc_security_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// validateAmqrcFile enforces that project configuration is owned by the
+// invoking user. Permission bits are intentionally not enforced here: older
+// configs commonly use 0644 and the file contains no secrets.
+func validateAmqrcFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if ok && uint32(st.Uid) != uint32(os.Getuid()) {
+		return fmt.Errorf(".amqrc at %s is owned by uid %d, want uid %d", path, st.Uid, os.Getuid())
+	}
+	return nil
+}

--- a/internal/cli/amqrc_security_unix.go
+++ b/internal/cli/amqrc_security_unix.go
@@ -12,13 +12,19 @@ import (
 // invoking user. Permission bits are intentionally not enforced here: older
 // configs commonly use 0644 and the file contains no secrets.
 func validateAmqrcFile(path string) error {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return err
 	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf(".amqrc at %s is a symlink", path)
+	}
 	st, ok := info.Sys().(*syscall.Stat_t)
-	if ok && uint32(st.Uid) != uint32(os.Getuid()) {
-		return fmt.Errorf(".amqrc at %s is owned by uid %d, want uid %d", path, st.Uid, os.Getuid())
+	if !ok {
+		return fmt.Errorf(".amqrc at %s has unavailable ownership metadata", path)
+	}
+	if uint32(st.Uid) != uint32(os.Geteuid()) {
+		return fmt.Errorf(".amqrc at %s is owned by uid %d, want euid %d", path, st.Uid, os.Geteuid())
 	}
 	return nil
 }

--- a/internal/cli/amqrc_security_unix_test.go
+++ b/internal/cli/amqrc_security_unix_test.go
@@ -12,6 +12,9 @@ func TestValidateAmqrcFileRejectsWorldWritable(t *testing.T) {
 	if err := os.WriteFile(p, []byte(`{"root":".agent-mail"}`), 0o666); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chmod(p, 0o666); err != nil {
+		t.Fatal(err)
+	}
 	if err := validateAmqrcFile(p); err == nil {
 		t.Fatal("expected world-writable config rejection")
 	}

--- a/internal/cli/amqrc_security_unix_test.go
+++ b/internal/cli/amqrc_security_unix_test.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestValidateAmqrcFileRejectsWorldWritable(t *testing.T) {
+	p := t.TempDir() + "/.amqrc"
+	if err := os.WriteFile(p, []byte(`{"root":".agent-mail"}`), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateAmqrcFile(p); err == nil {
+		t.Fatal("expected world-writable config rejection")
+	}
+}

--- a/internal/cli/amqrc_security_windows.go
+++ b/internal/cli/amqrc_security_windows.go
@@ -2,10 +2,21 @@
 
 package cli
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // Windows has no portable Unix ownership or mode bits to validate.
 func validateAmqrcFile(path string) error {
-	_, err := os.Stat(path)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	// Windows has no portable Unix ownership or mode bits. Symlinked project
+	// configs are nevertheless rejected so lookup cannot escape its root.
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf(".amqrc at %s is a symlink", path)
+	}
 	return err
 }

--- a/internal/cli/amqrc_security_windows.go
+++ b/internal/cli/amqrc_security_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cli
+
+import "os"
+
+// Windows has no portable Unix ownership or mode bits to validate.
+func validateAmqrcFile(path string) error {
+	_, err := os.Stat(path)
+	return err
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,8 +4,10 @@ package cli
 
 const (
 	envRoot       = "AM_ROOT"
+	envRootID     = "AM_ROOT_ID"
 	envMe         = "AM_ME"
 	envBaseRoot   = "AM_BASE_ROOT"
+	envBaseRootID = "AM_BASE_ROOT_ID"
 	envSession    = "AM_SESSION"
 	envGlobalRoot = "AMQ_GLOBAL_ROOT"
 )

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -66,9 +66,7 @@ func isDefaultCoopRoot(path string) bool {
 		return true
 	}
 	exact := filepath.Join(filepath.Dir(path), defaultCoopRoot)
-	got, gotErr := os.Lstat(path)
-	want, wantErr := os.Lstat(exact)
-	return gotErr == nil && wantErr == nil && os.SameFile(got, want)
+	return relateTrees(path, exact) == TreeRelationSame
 }
 
 // classifyRoot returns the base root for the given root, or "" if it cannot
@@ -79,8 +77,7 @@ func isDefaultCoopRoot(path string) bool {
 //  2. If root's parent is the default root (.agent-mail), return that parent
 //  3. The nearest root-aware .amqrc, when root is the configured base or a direct session below it
 //  4. If root itself is the default root name (.agent-mail), return "" (known base)
-//  5. If root is a session root (parent contains sibling session dirs), return parent
-//  6. Otherwise, return "" (base or unknown — caller must handle)
+//  5. Otherwise, return "" (base or unknown — caller must handle)
 func classifyRoot(root string) string {
 	if strings.TrimSpace(root) == "" {
 		return ""
@@ -110,6 +107,20 @@ func classifyRoot(root string) string {
 	if isDefaultCoopRoot(resolvedRoot) {
 		return ""
 	}
+	return ""
+}
+
+// classifyRootForDisplay adds a lexical sibling-session hint for diagnostics.
+// It must never feed routing, pinning, or environment authority decisions.
+func classifyRootForDisplay(root string) string {
+	if base := classifyRoot(root); base != "" {
+		return base
+	}
+	if strings.TrimSpace(root) == "" {
+		return ""
+	}
+	resolvedRoot := absPath(resolveRoot(root))
+	parent := filepath.Dir(resolvedRoot)
 	// Check if root looks like a session: parent has sibling dirs with agents/.
 	entries, err := os.ReadDir(parent)
 	if err != nil {
@@ -135,6 +146,14 @@ func resolveSessionName(root string) string {
 	}
 	// Ensure root actually differs from base (not just base root itself)
 	if absPath(resolveRoot(root)) == absPath(resolveRoot(base)) {
+		return ""
+	}
+	return sessionName(root)
+}
+
+func resolveSessionNameForDisplay(root string) string {
+	base := classifyRootForDisplay(root)
+	if base == "" || absPath(resolveRoot(root)) == absPath(resolveRoot(base)) {
 		return ""
 	}
 	return sessionName(root)
@@ -268,16 +287,27 @@ func baseRootOf(root string) string {
 	return resolveRoot(root)
 }
 
+func baseRootOfForDisplay(root string) string {
+	if base := classifyRootForDisplay(root); base != "" {
+		return resolveRoot(base)
+	}
+	return resolveRoot(root)
+}
+
 // sameBaseTree reports whether two roots belong to the same base tree — the same
 // project/base root, including any of its session subdirectories. This is the
 // boundary used to decide whether an explicit --root crosses into a different
 // AMQ tree than the caller's own.
 func sameBaseTree(a, b string) bool {
+	return baseTreeRelation(a, b) == TreeRelationSame
+}
+
+func baseTreeRelation(a, b string) TreeRelation {
 	a, b = resolveRoot(a), resolveRoot(b)
 	if a == "" || b == "" {
-		return false
+		return TreeRelationUnknown
 	}
-	return baseRootOf(a) == baseRootOf(b)
+	return relateTrees(baseRootOf(a), baseRootOf(b))
 }
 
 // conflictingSourceRoot returns an established "home" root for the caller that
@@ -301,10 +331,16 @@ func conflictingSourceRoot(target string) (string, bool) {
 	if target == "" {
 		return "", false
 	}
-	for _, raw := range []string{
-		strings.TrimSpace(os.Getenv(envRoot)),
-		strings.TrimSpace(os.Getenv(envBaseRoot)),
+	type sourceEvidence struct {
+		raw       string
+		exactBase bool
+	}
+	var unknownBase string
+	for _, evidence := range []sourceEvidence{
+		{raw: strings.TrimSpace(os.Getenv(envRoot))},
+		{raw: strings.TrimSpace(os.Getenv(envBaseRoot)), exactBase: true},
 	} {
+		raw := evidence.raw
 		if raw == "" {
 			continue
 		}
@@ -312,9 +348,20 @@ func conflictingSourceRoot(target string) (string, bool) {
 		if src == "" || src == target {
 			continue
 		}
-		if !sameBaseTree(src, target) {
+		switch baseTreeRelation(src, target) {
+		case TreeRelationDifferent:
 			return src, true
+		case TreeRelationUnknown:
+			if evidence.exactBase {
+				unknownBase = src
+			}
 		}
+	}
+	// AM_ROOT alone is advisory: unresolved identity carries no cross-tree
+	// evidence. AM_BASE_ROOT explicitly claims the authority boundary, so an
+	// unverifiable claimed base is unsafe.
+	if unknownBase != "" {
+		return unknownBase, true
 	}
 	return "", false
 }

--- a/internal/cli/consume_session_guard_test.go
+++ b/internal/cli/consume_session_guard_test.go
@@ -524,7 +524,9 @@ func TestBuildCoopExecEnvironmentPinsSessionIdentity(t *testing.T) {
 	base := []string{
 		"PATH=/bin",
 		"AM_ROOT=/stale/root",
+		"AM_ROOT_ID=v1:stale:root",
 		"AM_BASE_ROOT=/stale/base",
+		"AM_BASE_ROOT_ID=v1:stale:base",
 		"AM_SESSION=stale",
 	}
 	root := filepath.Join(t.TempDir(), ".agent-mail", "session1")
@@ -541,6 +543,28 @@ func TestBuildCoopExecEnvironmentPinsSessionIdentity(t *testing.T) {
 	}
 	if got := envValue(env, "AM_ME"); got != "codex" {
 		t.Fatalf("AM_ME = %q, want codex", got)
+	}
+	if envHasKey(env, envRootID) || envHasKey(env, envBaseRootID) {
+		t.Fatalf("unresolvable coop roots retained stale identity tokens: %#v", env)
+	}
+
+	liveBase := filepath.Join(t.TempDir(), ".agent-mail")
+	liveRoot := filepath.Join(liveBase, "session1")
+	if err := os.MkdirAll(liveRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	env = buildCoopExecEnvironment(base, liveRoot, "codex", "session1")
+	for _, tc := range []struct {
+		key  string
+		path string
+	}{
+		{key: envRootID, path: liveRoot},
+		{key: envBaseRootID, path: liveBase},
+	} {
+		token, present := lookupEnvSlice(env, tc.key)
+		if !present || verifyTreeIdentityToken(tc.path, token) != TreeRelationSame {
+			t.Fatalf("%s = %q, want authoritative identity for %s", tc.key, token, tc.path)
+		}
 	}
 
 	customRoot := filepath.Join(t.TempDir(), "custom-root")

--- a/internal/cli/coop_exec_env.go
+++ b/internal/cli/coop_exec_env.go
@@ -30,7 +30,17 @@ func buildCoopExecEnvironment(base []string, root, me, session string) []string 
 		baseRoot = filepath.Dir(root)
 	}
 	env = setEnvVar(env, envBaseRoot, baseRoot)
-	return setEnvVar(env, envSession, session)
+	env = setEnvVar(env, envSession, session)
+	rootID, baseRootID := treeIdentityTokens(root, baseRoot)
+	env = setOrUnsetEnvVar(env, envRootID, rootID)
+	return setOrUnsetEnvVar(env, envBaseRootID, baseRootID)
+}
+
+func setOrUnsetEnvVar(env []string, key, value string) []string {
+	if value == "" {
+		return unsetEnvVar(env, key)
+	}
+	return setEnvVar(env, key, value)
 }
 
 // setEnvVar sets or replaces an environment variable in a slice.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -75,7 +75,10 @@ func runDoctor(args []string) error {
 	// Check 3: Root directory
 	if root != "" {
 		result.Checks = append(result.Checks, checkRootDir(root))
-		if _, pinPresent := os.LookupEnv(envSession); pinPresent {
+		_, sessionPresent := os.LookupEnv(envSession)
+		_, rootIDPresent := os.LookupEnv(envRootID)
+		_, baseIDPresent := os.LookupEnv(envBaseRootID)
+		if sessionPresent || rootIDPresent || baseIDPresent {
 			result.Checks = append(result.Checks, checkSessionPinIdentity(root))
 		}
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -75,6 +75,9 @@ func runDoctor(args []string) error {
 	// Check 3: Root directory
 	if root != "" {
 		result.Checks = append(result.Checks, checkRootDir(root))
+		if _, pinPresent := os.LookupEnv(envSession); pinPresent {
+			result.Checks = append(result.Checks, checkSessionPinIdentity(root))
+		}
 	}
 
 	// Check 4: Config.json
@@ -236,6 +239,35 @@ func runDoctor(args []string) error {
 	}
 
 	return nil
+}
+
+func checkSessionPinIdentity(root string) doctorCheck {
+	check := doctorCheck{Name: "Session identity pin"}
+	pin, err := loadSessionPin()
+	if err != nil {
+		check.Status = "warn"
+		check.Message = err.Error()
+		return check
+	}
+	if !pin.IdentityPin {
+		check.Status = "ok"
+		check.Message = "legacy lexical pin (identity tokens absent)"
+		return check
+	}
+	mismatch, err := sessionPinMismatch(root)
+	if err != nil {
+		check.Status = "warn"
+		check.Message = err.Error()
+		return check
+	}
+	if mismatch != nil {
+		check.Status = "warn"
+		check.Message = mismatch.Error()
+		return check
+	}
+	check.Status = "ok"
+	check.Message = "verified"
+	return check
 }
 
 func checkBinary() doctorCheck {

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -92,6 +92,16 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 	}
 
 	for _, handle := range agents {
+		// Configured handles are untrusted input. Validate before deriving any
+		// mailbox/presence paths so traversal-like values cannot escape root.
+		if err := fsq.ValidateHandle(handle); err != nil {
+			result.Hints = append(result.Hints, opsHint{
+				Code:    "config_error",
+				Status:  "error",
+				Message: fmt.Sprintf("Ignoring invalid configured agent handle %q: %v", handle, err),
+			})
+			continue
+		}
 		agent := opsAgent{Handle: handle}
 
 		// Unread count + oldest

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -80,7 +80,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 
 	// Load the active root's config, falling back to the base config for normal
 	// session layouts where coop init owns the single config.json.
-	agents, err := loadOpsAgents(root)
+	agents, err := loadOpsAgents(root, fixWakeLocks)
 	if err != nil {
 		result.Hints = append(result.Hints, opsHint{
 			Code:    "config_error",
@@ -170,7 +170,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 	return result
 }
 
-func loadOpsAgents(root string) ([]string, error) {
+func loadOpsAgents(root string, fixWakeLocks bool) ([]string, error) {
 	cfg, err := config.LoadConfig(filepath.Join(root, "meta", "config.json"))
 	if err == nil {
 		return cfg.Agents, nil
@@ -179,6 +179,9 @@ func loadOpsAgents(root string) ([]string, error) {
 		return nil, err
 	}
 
+	if fixWakeLocks {
+		return nil, err
+	}
 	base := baseRootOfForDisplay(root)
 	if absPath(resolveRoot(base)) == absPath(resolveRoot(root)) {
 		return nil, err

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -91,6 +91,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		return result
 	}
 
+	validatedAgents := make([]string, 0, len(agents))
 	for _, handle := range agents {
 		// Configured handles are untrusted input. Validate before deriving any
 		// mailbox/presence paths so traversal-like values cannot escape root.
@@ -102,6 +103,11 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 			})
 			continue
 		}
+		if err := validateWakeLockAgent(root, handle); err != nil {
+			result.Hints = append(result.Hints, opsHint{Code: "config_error", Status: "error", Message: fmt.Sprintf("Ignoring unsafe configured agent handle %q: %v", handle, err)})
+			continue
+		}
+		validatedAgents = append(validatedAgents, handle)
 		agent := opsAgent{Handle: handle}
 
 		// Unread count + oldest
@@ -158,7 +164,11 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		result.Agents = append(result.Agents, agent)
 	}
 
-	result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, agents), fixWakeLocks)
+	// Only handles which passed validation while traversing the config are
+	// eligible for diagnostic wake-lock inspection.  Discovery performs the
+	// same check for handles found on disk; checkWakeLocks repeats it at its
+	// boundary as a defense against future callers passing untrusted input.
+	result.WakeLocks = checkWakeLocks(root, discoveredWakeLockAgents(root, validatedAgents), fixWakeLocks)
 
 	// Operational and integration hints
 	result.Hints = append(result.Hints, checkSiblingBacklogHints(root, agents)...)
@@ -237,6 +247,9 @@ func discoveredWakeLockAgents(root string, configured []string) []string {
 	seen := make(map[string]struct{}, len(configured))
 	agents := make([]string, 0, len(configured))
 	for _, agent := range configured {
+		if validateWakeLockAgent(root, agent) != nil {
+			continue
+		}
 		if _, ok := seen[agent]; ok {
 			continue
 		}
@@ -252,7 +265,7 @@ func discoveredWakeLockAgents(root string, configured []string) []string {
 		if _, ok := seen[agent]; ok {
 			continue
 		}
-		if err := fsq.ValidateHandle(agent); err != nil {
+		if err := validateWakeLockAgent(root, agent); err != nil {
 			continue
 		}
 		seen[agent] = struct{}{}
@@ -264,6 +277,9 @@ func discoveredWakeLockAgents(root string, configured []string) []string {
 func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 	var locks []opsWakeLock
 	for _, agent := range agents {
+		if validateWakeLockAgent(root, agent) != nil {
+			continue
+		}
 		inspection := inspectWakeLock(root, agent)
 		if !inspection.Exists {
 			continue
@@ -323,6 +339,31 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 		locks = append(locks, lock)
 	}
 	return locks
+}
+
+// validateWakeLockAgent ensures diagnostics cannot follow an agent directory
+// symlink (including one pointing outside this AMQ root). Missing directories
+// remain valid for configured agents: inspectWakeLock will simply report no
+// lock, preserving diagnostics for partially initialized roots.
+func validateWakeLockAgent(root, agent string) error {
+	if err := fsq.ValidateHandle(agent); err != nil {
+		return err
+	}
+	path := fsq.AgentBase(root, agent)
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("agent directory is a symlink")
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("agent path is not a directory")
+	}
+	return nil
 }
 
 func wakeRepairCommand(root, agent string) string {

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -169,7 +169,7 @@ func loadOpsAgents(root string) ([]string, error) {
 		return nil, err
 	}
 
-	base := baseRootOf(root)
+	base := baseRootOfForDisplay(root)
 	if absPath(resolveRoot(base)) == absPath(resolveRoot(root)) {
 		return nil, err
 	}

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -136,6 +136,34 @@ func TestRunOpsChecks_NoConfig(t *testing.T) {
 	}
 }
 
+func TestRunOpsChecks_RejectsInvalidConfiguredHandleBeforePaths(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"../escape", "good"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	result := runOpsChecks(root, "test", false)
+	for _, agent := range result.Agents {
+		if agent.Handle == "../escape" {
+			t.Fatal("invalid configured handle was used")
+		}
+	}
+	found := false
+	for _, hint := range result.Hints {
+		if hint.Code == "config_error" && strings.Contains(hint.Message, "../escape") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected config_error hint for invalid configured handle")
+	}
+}
+
 func TestRunOpsChecks_OperatorGateReportsWithoutConfig(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -76,6 +76,32 @@ func TestRunOpsChecksRejectsSymlinkAndFIFOWakeLocks(t *testing.T) {
 	}
 }
 
+func TestRunOpsChecksLeavesForeignAgentSymlinkWakeLockUntouched(t *testing.T) {
+	root := secureTempDirForTest(t)
+	foreign := secureTempDirForTest(t)
+	foreignAgent := fsq.AgentBase(foreign, "codex")
+	if err := os.MkdirAll(foreignAgent, 0o700); err != nil {
+		t.Fatalf("mkdir foreign agent: %v", err)
+	}
+	lockPath := filepath.Join(foreignAgent, ".wake.lock")
+	if err := os.WriteFile(lockPath, []byte(`{"pid":4242}`), 0o600); err != nil {
+		t.Fatalf("write foreign lock: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(fsq.AgentBase(root, "codex")), 0o700); err != nil {
+		t.Fatalf("mkdir agents root: %v", err)
+	}
+	if err := os.Symlink(foreignAgent, fsq.AgentBase(root, "codex")); err != nil {
+		t.Fatalf("symlink foreign agent: %v", err)
+	}
+	result := runOpsChecks(root, "test", true)
+	if len(result.WakeLocks) != 0 {
+		t.Fatalf("foreign agent symlink should not be inspected: %#v", result.WakeLocks)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("foreign wake lock was touched: %v", err)
+	}
+}
+
 func TestRunOpsChecksRejectsFIFOWakeTargetWithoutBlocking(t *testing.T) {
 	root := secureTempDirForTest(t)
 	agentBase := fsq.AgentBase(root, "codex")

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -30,7 +30,9 @@ type envOutput struct {
 	SchemaVersion int               `json:"schema_version"`
 	AMQVersion    string            `json:"amq_version"`
 	Root          string            `json:"root"`
+	RootID        string            `json:"root_id,omitempty"`
 	BaseRoot      string            `json:"base_root"`
+	BaseRootID    string            `json:"base_root_id,omitempty"`
 	SessionName   string            `json:"session_name"`
 	InSession     bool              `json:"in_session"`
 	Me            string            `json:"me"`
@@ -109,6 +111,11 @@ func runEnv(args []string) error {
 		}
 		base := ""
 		if pin.Present {
+			if pin.IdentityPin {
+				if relation := verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID); relation != TreeRelationSame {
+					return ContextMismatchError("refusing env session route: pinned base root identity is %s for %s", relation, pin.BaseRoot)
+				}
+			}
 			base = pin.BaseRoot
 		} else {
 			resolved, _, _, err := resolveEnvConfigWithSource("", *meFlag)
@@ -161,11 +168,14 @@ func runEnv(args []string) error {
 			inSession = true
 		}
 		project, peers := envProjectAndPeers(root)
+		rootID, baseRootID := treeIdentityTokens(root, baseRoot)
 		out := envOutput{
 			SchemaVersion: 1,
 			AMQVersion:    cliVersion,
 			Root:          root,
+			RootID:        rootID,
 			BaseRoot:      baseRoot,
+			BaseRootID:    baseRootID,
 			SessionName:   sessionName,
 			InSession:     inSession,
 			Me:            me,
@@ -197,7 +207,8 @@ func runEnv(args []string) error {
 			return fmt.Errorf("resolve absolute base root for shell output: %w", err)
 		}
 	}
-	if err := writeShellEnv(root, baseRoot, sessionName, me, shell, *wakeFlag); err != nil {
+	rootID, baseRootID := treeIdentityTokens(root, baseRoot)
+	if err := writeShellEnv(root, baseRoot, rootID, baseRootID, sessionName, me, shell, *wakeFlag); err != nil {
 		return err
 	}
 	if *exportFlag {
@@ -492,16 +503,26 @@ func isValidShell(shell string) bool {
 	}
 }
 
-func writeShellEnv(root, baseRoot, session, me, shell string, wake bool) error {
+func treeIdentityTokens(root, baseRoot string) (rootID, baseRootID string) {
+	var rootErr, baseRootErr error
+	rootID, rootErr = resolveTreeIdentityToken(root)
+	baseRootID, baseRootErr = resolveTreeIdentityToken(baseRoot)
+	if rootErr != nil || baseRootErr != nil {
+		return "", ""
+	}
+	return rootID, baseRootID
+}
+
+func writeShellEnv(root, baseRoot, rootID, baseRootID, session, me, shell string, wake bool) error {
 	switch shell {
 	case "fish":
-		return writeFishEnv(root, baseRoot, session, me, wake)
+		return writeFishEnv(root, baseRoot, rootID, baseRootID, session, me, wake)
 	default:
-		return writePosixEnv(root, baseRoot, session, me, wake)
+		return writePosixEnv(root, baseRoot, rootID, baseRootID, session, me, wake)
 	}
 }
 
-func writePosixEnv(root, baseRoot, session, me string, wake bool) error {
+func writePosixEnv(root, baseRoot, rootID, baseRootID, session, me string, wake bool) error {
 	if root != "" {
 		if err := writeStdout("export AM_ROOT=%s\n", shellQuotePosix(root)); err != nil {
 			return err
@@ -511,6 +532,20 @@ func writePosixEnv(root, baseRoot, session, me string, wake bool) error {
 		return fmt.Errorf("cannot emit AMQ context without an exact AM_BASE_ROOT")
 	}
 	if err := writeStdout("export AM_BASE_ROOT=%s\n", shellQuotePosix(baseRoot)); err != nil {
+		return err
+	}
+	if rootID != "" {
+		if err := writeStdout("export AM_ROOT_ID=%s\n", shellQuotePosix(rootID)); err != nil {
+			return err
+		}
+	} else if err := writeStdoutLine("unset AM_ROOT_ID"); err != nil {
+		return err
+	}
+	if baseRootID != "" {
+		if err := writeStdout("export AM_BASE_ROOT_ID=%s\n", shellQuotePosix(baseRootID)); err != nil {
+			return err
+		}
+	} else if err := writeStdoutLine("unset AM_BASE_ROOT_ID"); err != nil {
 		return err
 	}
 	if err := writeStdout("export AM_SESSION=%s\n", shellQuotePosix(session)); err != nil {
@@ -531,7 +566,7 @@ func writePosixEnv(root, baseRoot, session, me string, wake bool) error {
 	return nil
 }
 
-func writeFishEnv(root, baseRoot, session, me string, wake bool) error {
+func writeFishEnv(root, baseRoot, rootID, baseRootID, session, me string, wake bool) error {
 	if root != "" {
 		if err := writeStdout("set -gx AM_ROOT %s\n", shellQuoteFish(root)); err != nil {
 			return err
@@ -541,6 +576,20 @@ func writeFishEnv(root, baseRoot, session, me string, wake bool) error {
 		return fmt.Errorf("cannot emit AMQ context without an exact AM_BASE_ROOT")
 	}
 	if err := writeStdout("set -gx AM_BASE_ROOT %s\n", shellQuoteFish(baseRoot)); err != nil {
+		return err
+	}
+	if rootID != "" {
+		if err := writeStdout("set -gx AM_ROOT_ID %s\n", shellQuoteFish(rootID)); err != nil {
+			return err
+		}
+	} else if err := writeStdoutLine("set -e AM_ROOT_ID"); err != nil {
+		return err
+	}
+	if baseRootID != "" {
+		if err := writeStdout("set -gx AM_BASE_ROOT_ID %s\n", shellQuoteFish(baseRootID)); err != nil {
+			return err
+		}
+	} else if err := writeStdoutLine("set -e AM_BASE_ROOT_ID"); err != nil {
 		return err
 	}
 	if session == "" {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -112,6 +112,13 @@ func runEnv(args []string) error {
 		base := ""
 		if pin.Present {
 			if pin.IdentityPin {
+				ambient := strings.TrimSpace(os.Getenv(envRoot))
+				if ambient == "" {
+					ambient = pin.ExpectedRoot
+				}
+				if err := verifyRootUnderBase(pin.BaseRoot, pin.BaseRootID, pin.Session, ambient, pin.RootID); err != nil {
+					return err
+				}
 				if relation := verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID); relation != TreeRelationSame {
 					return ContextMismatchError("refusing env session route: pinned base root identity is %s for %s", relation, pin.BaseRoot)
 				}

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -19,6 +19,8 @@ type amqrc struct {
 	Peers   map[string]string `json:"peers,omitempty"`   // peer name → peer's base root path
 }
 
+var amqrcLstat = os.Lstat
+
 // amqrcResult holds both the parsed config and the directory where it was found.
 type amqrcResult struct {
 	Config amqrc
@@ -465,7 +467,7 @@ func findAndLoadAmqrc() (amqrcResult, error) {
 		// Refuse configuration whose provenance cannot be established. In
 		// particular, symlinks and group/world-writable files are attacker
 		// controlled in common shared-directory setups.
-		if info, statErr := os.Lstat(rcPath); statErr == nil {
+		if info, statErr := amqrcLstat(rcPath); statErr == nil {
 			if err := validateAmqrcInfo(rcPath, info); err != nil {
 				return amqrcResult{}, err
 			}
@@ -732,7 +734,7 @@ func findAmqrcForRoot(root string) (amqrcResult, error) {
 		dir := absRoot
 		for {
 			rcPath := filepath.Join(dir, ".amqrc")
-			if info, statErr := os.Lstat(rcPath); statErr == nil {
+			if info, statErr := amqrcLstat(rcPath); statErr == nil {
 				if err := validateAmqrcInfo(rcPath, info); err != nil {
 					return amqrcResult{}, err
 				}

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -115,6 +115,11 @@ func runEnv(args []string) error {
 				if relation := verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID); relation != TreeRelationSame {
 					return ContextMismatchError("refusing env session route: pinned base root identity is %s for %s", relation, pin.BaseRoot)
 				}
+				entry := filepath.Join(pin.BaseRoot, *sessionFlag)
+				info, statErr := os.Lstat(entry)
+				if statErr != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+					return ContextMismatchError("refusing env session route: %q is not a direct directory under pinned base", *sessionFlag)
+				}
 			}
 			base = pin.BaseRoot
 		} else {
@@ -386,6 +391,12 @@ func loadGlobalAmqrc() (amqrcResult, error) {
 		return amqrcResult{}, errAmqrcNotFound
 	}
 	path := filepath.Join(home, ".amqrc")
+	if err := validateAmqrcProvenance(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return amqrcResult{}, errAmqrcNotFound
+		}
+		return amqrcResult{}, err
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return amqrcResult{}, errAmqrcNotFound
@@ -440,6 +451,16 @@ func findAndLoadAmqrc() (amqrcResult, error) {
 	dir := cwd
 	for {
 		rcPath := filepath.Join(dir, ".amqrc")
+		// Refuse configuration whose provenance cannot be established. In
+		// particular, symlinks and group/world-writable files are attacker
+		// controlled in common shared-directory setups.
+		if info, statErr := os.Lstat(rcPath); statErr == nil {
+			if err := validateAmqrcInfo(rcPath, info); err != nil {
+				return amqrcResult{}, err
+			}
+		} else if !os.IsNotExist(statErr) {
+			return amqrcResult{}, fmt.Errorf("cannot inspect .amqrc at %s: %w", rcPath, statErr)
+		}
 		data, err := os.ReadFile(rcPath)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -464,6 +485,27 @@ func findAndLoadAmqrc() (amqrcResult, error) {
 	}
 
 	return amqrcResult{}, errAmqrcNotFound
+}
+
+func validateAmqrcProvenance(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	return validateAmqrcInfo(path, info)
+}
+
+func validateAmqrcInfo(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing untrusted .amqrc at %s: symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("refusing untrusted .amqrc at %s: not a regular file", path)
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf("refusing untrusted .amqrc at %s: group/world-writable mode %o", path, info.Mode().Perm())
+	}
+	return nil
 }
 
 // detectAgentMailDir searches for .agent-mail/ in current and parent directories.

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -742,6 +742,9 @@ func findAmqrcForRoot(root string) (amqrcResult, error) {
 				if validateErr := validateAmqrcFile(rcPath); validateErr != nil {
 					return amqrcResult{}, validateErr
 				}
+			} else if !os.IsNotExist(statErr) {
+				// Do not walk past an unreadable or otherwise unverifiable config.
+				return amqrcResult{}, fmt.Errorf("cannot inspect .amqrc at %s: %w", rcPath, statErr)
 			}
 			data, readErr := os.ReadFile(rcPath)
 			if readErr == nil {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -469,11 +469,11 @@ func findAndLoadAmqrc() (amqrcResult, error) {
 			if err := validateAmqrcInfo(rcPath, info); err != nil {
 				return amqrcResult{}, err
 			}
+			if err := validateAmqrcFile(rcPath); err != nil {
+				return amqrcResult{}, err
+			}
 		} else if !os.IsNotExist(statErr) {
 			return amqrcResult{}, fmt.Errorf("cannot inspect .amqrc at %s: %w", rcPath, statErr)
-			if validateErr := validateAmqrcFile(rcPath); validateErr != nil {
-				return amqrcResult{}, validateErr
-			}
 		}
 		data, err := os.ReadFile(rcPath)
 		if err != nil {
@@ -735,7 +735,10 @@ func findAmqrcForRoot(root string) (amqrcResult, error) {
 		dir := absRoot
 		for {
 			rcPath := filepath.Join(dir, ".amqrc")
-			if _, statErr := os.Stat(rcPath); statErr == nil {
+			if info, statErr := os.Lstat(rcPath); statErr == nil {
+				if err := validateAmqrcInfo(rcPath, info); err != nil {
+					return amqrcResult{}, err
+				}
 				if validateErr := validateAmqrcFile(rcPath); validateErr != nil {
 					return amqrcResult{}, validateErr
 				}

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -516,9 +516,6 @@ func validateAmqrcInfo(path string, info os.FileInfo) error {
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("refusing untrusted .amqrc at %s: not a regular file", path)
 	}
-	if info.Mode().Perm()&0o022 != 0 {
-		return fmt.Errorf("refusing untrusted .amqrc at %s: group/world-writable mode %o", path, info.Mode().Perm())
-	}
 	return nil
 }
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -23,6 +23,7 @@ type amqrc struct {
 type amqrcResult struct {
 	Config amqrc
 	Dir    string // Directory containing .amqrc (for resolving relative paths)
+	Path   string // Canonical path of the config file (shared provenance)
 }
 
 // envOutput is the JSON output format for amq env --json.
@@ -408,11 +409,14 @@ func loadGlobalAmqrc() (amqrcResult, error) {
 	if err != nil {
 		return amqrcResult{}, errAmqrcNotFound
 	}
+	if err := validateAmqrcFile(path); err != nil {
+		return amqrcResult{}, err
+	}
 	var cfg amqrc
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return amqrcResult{}, fmt.Errorf("invalid ~/.amqrc: %w", err)
 	}
-	return amqrcResult{Config: cfg, Dir: home}, nil
+	return amqrcResult{Config: cfg, Dir: home, Path: path}, nil
 }
 
 // resolveBaseRoot returns the base root directory (without session suffix).
@@ -467,6 +471,9 @@ func findAndLoadAmqrc() (amqrcResult, error) {
 			}
 		} else if !os.IsNotExist(statErr) {
 			return amqrcResult{}, fmt.Errorf("cannot inspect .amqrc at %s: %w", rcPath, statErr)
+			if validateErr := validateAmqrcFile(rcPath); validateErr != nil {
+				return amqrcResult{}, validateErr
+			}
 		}
 		data, err := os.ReadFile(rcPath)
 		if err != nil {
@@ -488,7 +495,7 @@ func findAndLoadAmqrc() (amqrcResult, error) {
 		if err := json.Unmarshal(data, &rc); err != nil {
 			return amqrcResult{}, fmt.Errorf("invalid .amqrc at %s: %w", rcPath, err)
 		}
-		return amqrcResult{Config: rc, Dir: dir}, nil
+		return amqrcResult{Config: rc, Dir: dir, Path: rcPath}, nil
 	}
 
 	return amqrcResult{}, errAmqrcNotFound
@@ -728,13 +735,18 @@ func findAmqrcForRoot(root string) (amqrcResult, error) {
 		dir := absRoot
 		for {
 			rcPath := filepath.Join(dir, ".amqrc")
+			if _, statErr := os.Stat(rcPath); statErr == nil {
+				if validateErr := validateAmqrcFile(rcPath); validateErr != nil {
+					return amqrcResult{}, validateErr
+				}
+			}
 			data, readErr := os.ReadFile(rcPath)
 			if readErr == nil {
 				var rc amqrc
 				if jsonErr := json.Unmarshal(data, &rc); jsonErr != nil {
 					return amqrcResult{}, fmt.Errorf("invalid .amqrc at %s: %w", rcPath, jsonErr)
 				}
-				return amqrcResult{Config: rc, Dir: dir}, nil
+				return amqrcResult{Config: rc, Dir: dir, Path: rcPath}, nil
 			}
 			if !os.IsNotExist(readErr) {
 				// Permission or I/O error — report it, don't mask it.

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -4,11 +4,48 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func expectedPosixIdentityLines(t *testing.T, root, baseRoot string) string {
+	t.Helper()
+	rootID, rootErr := resolveTreeIdentityToken(root)
+	baseRootID, baseErr := resolveTreeIdentityToken(baseRoot)
+	var out strings.Builder
+	if rootErr == nil {
+		fmt.Fprintf(&out, "export AM_ROOT_ID=%s\n", shellQuotePosix(rootID))
+	} else {
+		out.WriteString("unset AM_ROOT_ID\n")
+	}
+	if baseErr == nil {
+		fmt.Fprintf(&out, "export AM_BASE_ROOT_ID=%s\n", shellQuotePosix(baseRootID))
+	} else {
+		out.WriteString("unset AM_BASE_ROOT_ID\n")
+	}
+	return out.String()
+}
+
+func expectedFishIdentityLines(t *testing.T, root, baseRoot string) string {
+	t.Helper()
+	rootID, rootErr := resolveTreeIdentityToken(root)
+	baseRootID, baseErr := resolveTreeIdentityToken(baseRoot)
+	var out strings.Builder
+	if rootErr == nil {
+		fmt.Fprintf(&out, "set -gx AM_ROOT_ID %s\n", shellQuoteFish(rootID))
+	} else {
+		out.WriteString("set -e AM_ROOT_ID\n")
+	}
+	if baseErr == nil {
+		fmt.Fprintf(&out, "set -gx AM_BASE_ROOT_ID %s\n", shellQuoteFish(baseRootID))
+	} else {
+		out.WriteString("set -e AM_BASE_ROOT_ID\n")
+	}
+	return out.String()
+}
 
 func captureEnvStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
@@ -923,6 +960,7 @@ func TestRunEnvNonExportSessionEmitsFullContext(t *testing.T) {
 	expectedRoot := filepath.Join(expectedBase, "feature-x")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(expectedBase) + "\n" +
+		expectedPosixIdentityLines(t, expectedRoot, expectedBase) +
 		"export AM_SESSION=feature-x\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
@@ -967,6 +1005,7 @@ func TestRunEnvExportSessionEmitsBaseRootAndPinNote(t *testing.T) {
 	expectedRoot := filepath.Join(expectedBase, "feature-x")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(expectedBase) + "\n" +
+		expectedPosixIdentityLines(t, expectedRoot, expectedBase) +
 		"export AM_SESSION=feature-x\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
@@ -1013,6 +1052,7 @@ func TestRunEnvExportNonSessionPinsExactBaseRoot(t *testing.T) {
 	expectedRoot := filepath.Join(projectRoot, ".agent-mail")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
+		expectedPosixIdentityLines(t, expectedRoot, expectedRoot) +
 		"export AM_SESSION=\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
@@ -1060,6 +1100,7 @@ func TestRunEnvExportFishSessionEmitsBaseRoot(t *testing.T) {
 	expectedRoot := filepath.Join(expectedBase, "feature-x")
 	want := "set -gx AM_ROOT " + shellQuoteFish(expectedRoot) + "\n" +
 		"set -gx AM_BASE_ROOT " + shellQuoteFish(expectedBase) + "\n" +
+		expectedFishIdentityLines(t, expectedRoot, expectedBase) +
 		"set -gx AM_SESSION feature-x\n" +
 		"set -gx AM_ME codex\n"
 	if stdout != want {
@@ -1093,6 +1134,7 @@ func TestRunEnvExportSessionFromGlobalRootEmitsBaseRoot(t *testing.T) {
 	expectedRoot := filepath.Join(globalRoot, "feature-x")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(globalRoot) + "\n" +
+		expectedPosixIdentityLines(t, expectedRoot, globalRoot) +
 		"export AM_SESSION=feature-x\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
@@ -1137,6 +1179,7 @@ func TestRunEnvExportSessionIgnoresStaleAmbientBaseRoot(t *testing.T) {
 	expectedRoot := filepath.Join(expectedBase, "feature-x")
 	want := "export AM_ROOT=" + shellQuotePosix(expectedRoot) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(expectedBase) + "\n" +
+		expectedPosixIdentityLines(t, expectedRoot, expectedBase) +
 		"export AM_SESSION=feature-x\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {
@@ -1162,6 +1205,7 @@ func TestRunEnvExportExplicitBaseRootPinsExactBaseRoot(t *testing.T) {
 
 	want := "export AM_ROOT=" + shellQuotePosix(root) + "\n" +
 		"export AM_BASE_ROOT=" + shellQuotePosix(root) + "\n" +
+		expectedPosixIdentityLines(t, root, root) +
 		"export AM_SESSION=\n" +
 		"export AM_ME=codex\n"
 	if stdout != want {

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -1625,6 +1625,40 @@ func TestLoadGlobalAmqrc(t *testing.T) {
 	}
 }
 
+func TestFindAndLoadAmqrcRejectsUntrustedProvenance(t *testing.T) {
+	root := t.TempDir()
+	old, _ := os.Getwd()
+	defer func() { _ = os.Chdir(old) }()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(root, ".amqrc")
+	if err := os.WriteFile(path, []byte(`{"root":".agent-mail"}`), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := findAndLoadAmqrc(); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("expected writable .amqrc rejection, got %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "real.amqrc")
+	if err := os.WriteFile(target, []byte(`{"root":".agent-mail"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := findAndLoadAmqrc(); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
 func TestLoadGlobalAmqrcNotFound(t *testing.T) {
 	// Create a fake HOME without ~/.amqrc
 	fakeHome := t.TempDir()

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -69,7 +69,10 @@ func runList(args []string) error {
 	common.Me = me
 	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
 	if err != nil {
-		return err
+		// list is diagnostic/read-only: preserve visibility even when pin
+		// verification is stale or malformed, but make the failure explicit.
+		_ = writeStderr("warning: %v\n", err)
+		root, routed = absPath(resolveRoot(common.Root)), false
 	}
 	if !routed {
 		if mismatch, checkErr := sessionPinMismatch(root); checkErr != nil {

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -76,7 +76,7 @@ func runList(args []string) error {
 	}
 	if !routed {
 		if mismatch, checkErr := sessionPinMismatch(root); checkErr != nil {
-			_ = writeStderr("warning: %v\n", checkErr)
+			return checkErr
 		} else if mismatch != nil {
 			_ = writeStderr("warning: %s\n", mismatch.Error())
 		}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -69,14 +69,18 @@ func runList(args []string) error {
 	common.Me = me
 	root, routed, err := resolveMailboxRoot(common, *sessionFlag)
 	if err != nil {
-		// list is diagnostic/read-only: preserve visibility even when pin
-		// verification is stale or malformed, but make the failure explicit.
+		if GetExitCode(err) != ExitContextMismatch {
+			return err
+		}
 		_ = writeStderr("warning: %v\n", err)
 		root, routed = absPath(resolveRoot(common.Root)), false
 	}
 	if !routed {
 		if mismatch, checkErr := sessionPinMismatch(root); checkErr != nil {
-			return checkErr
+			if GetExitCode(checkErr) != ExitContextMismatch {
+				return checkErr
+			}
+			_ = writeStderr("warning: %v\n", checkErr)
 		} else if mismatch != nil {
 			_ = writeStderr("warning: %s\n", mismatch.Error())
 		}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -130,3 +130,17 @@ func runListJSON(t *testing.T, root, agent string, limit, offset int) []listItem
 	}
 	return items
 }
+
+func TestListSessionDoesNotExistReturnsNotFound(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	err := runList([]string{"--root", root, "--me", "alice", "--session", "missing", "--new"})
+	if GetExitCode(err) != ExitNotFound {
+		t.Fatalf("exit = %d, want %d (err=%v)", GetExitCode(err), ExitNotFound, err)
+	}
+}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -139,7 +139,10 @@ func TestListSessionDoesNotExistReturnsNotFound(t *testing.T) {
 	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
 		t.Fatal(err)
 	}
-	err := runList([]string{"--root", root, "--me", "alice", "--session", "missing", "--new"})
+	t.Setenv(envRoot, root)
+	t.Setenv(envBaseRoot, root)
+	t.Setenv(envSession, "")
+	err := runList([]string{"--me", "alice", "--session", "missing", "--new"})
 	if GetExitCode(err) != ExitNotFound {
 		t.Fatalf("exit = %d, want %d (err=%v)", GetExitCode(err), ExitNotFound, err)
 	}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -12,7 +12,7 @@ import (
 // dir look like refused cross-tree sends. Tests that need these signals set them
 // explicitly via t.Setenv, which overrides and restores around this clean baseline.
 func TestMain(m *testing.M) {
-	for _, k := range []string{"AM_ROOT", "AM_BASE_ROOT", "AM_SESSION", "AMQ_GLOBAL_ROOT"} {
+	for _, k := range []string{"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION", "AMQ_GLOBAL_ROOT"} {
 		_ = os.Unsetenv(k)
 	}
 	os.Exit(m.Run())

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -189,8 +189,10 @@ var usageGlobalOptions = []string{
 
 var usageEnvironment = []string{
 	"  AM_ROOT             Queue root directory (from flags, env, config, or coop exec session setup)",
+	"  AM_ROOT_ID          Opaque physical identity token for AM_ROOT when available",
 	"  AM_ME               Default agent handle",
 	"  AM_BASE_ROOT        Authorized session base, or exact root for a sessionless pin",
+	"  AM_BASE_ROOT_ID     Opaque physical identity token for AM_BASE_ROOT when available",
 	"  AM_SESSION          Pinned session identity (empty means exact-root context)",
 	"  AMQ_GLOBAL_ROOT     Global root fallback (for agents spawned by external orchestrators)",
 	"  AMQ_NO_UPDATE_CHECK  Disable update check (1/true/yes/on)",

--- a/internal/cli/root_classification_security_test.go
+++ b/internal/cli/root_classification_security_test.go
@@ -286,6 +286,244 @@ func TestSameBaseTreeAllowsSymlinkedCustomBase(t *testing.T) {
 	}
 }
 
+func TestEnvDoesNotLaunderSiblingHintIntoBaseRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "queue")
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(parent, "other", "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envRoot, "")
+	t.Setenv(envBaseRoot, "")
+	setOptionalEnv(t, envSession, "", false)
+
+	if got := classifyRoot(root); got != "" {
+		t.Fatalf("authority classification laundered sibling hint into base %q", got)
+	}
+	if got := classifyRootForDisplay(root); got != parent {
+		t.Fatalf("display classification = %q, want sibling hint %q", got, parent)
+	}
+	result := runEnvJSONForTest(t, "--root", root, "--me", "alice")
+	expectSamePath(t, result.BaseRoot, root)
+	if result.InSession || result.SessionName != "" {
+		t.Fatalf("heuristic root became session authority: %+v", result)
+	}
+}
+
+func TestConflictingSourceRootStaleAMRootValidBase(t *testing.T) {
+	base := filepath.Join(t.TempDir(), defaultCoopRoot)
+	target := filepath.Join(base, "target")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envRoot, filepath.Join(t.TempDir(), "stale", "session"))
+	t.Setenv(envBaseRoot, base)
+	setOptionalEnv(t, envSession, "", false)
+
+	if source, refused := conflictingSourceRoot(target); refused {
+		t.Fatalf("stale AM_ROOT overrode valid same-tree AM_BASE_ROOT evidence: %q", source)
+	}
+}
+
+func TestPinnedRootCanonicalAlias(t *testing.T) {
+	realRoot := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(realRoot, alias); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	token, err := resolveTreeIdentityToken(realRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envRoot, alias)
+	t.Setenv(envBaseRoot, alias)
+	t.Setenv(envSession, "")
+	t.Setenv(envRootID, token)
+	t.Setenv(envBaseRootID, token)
+
+	mismatch, err := sessionPinMismatch(realRoot)
+	if err != nil {
+		t.Fatalf("canonical alias verification failed: %v", err)
+	}
+	if mismatch != nil {
+		t.Fatalf("canonical alias rejected: %v", mismatch)
+	}
+}
+
+func TestPinnedRootRetargetedAlias(t *testing.T) {
+	realRoot := t.TempDir()
+	replacement := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(realRoot, alias); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	token, err := resolveTreeIdentityToken(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(replacement, alias); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envRoot, alias)
+	t.Setenv(envBaseRoot, alias)
+	t.Setenv(envSession, "")
+	t.Setenv(envRootID, token)
+	t.Setenv(envBaseRootID, token)
+
+	mismatch, err := sessionPinMismatch(alias)
+	if err != nil {
+		t.Fatalf("retargeted alias check: %v", err)
+	}
+	if mismatch == nil {
+		t.Fatal("retargeted alias was accepted by an identity-bound pin")
+	}
+}
+
+func TestRoutedSessionRefusesRetargetedBaseIdentity(t *testing.T) {
+	baseOne := t.TempDir()
+	baseTwo := t.TempDir()
+	for _, base := range []string{baseOne, baseTwo} {
+		for _, session := range []string{"session1", "session2"} {
+			if err := fsq.EnsureAgentDirs(filepath.Join(base, session), "alice"); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	alias := filepath.Join(t.TempDir(), "base")
+	if err := os.Symlink(baseOne, alias); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	baseToken, err := resolveTreeIdentityToken(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootToken, err := resolveTreeIdentityToken(filepath.Join(alias, "session1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(baseTwo, alias); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envRoot, filepath.Join(alias, "session1"))
+	t.Setenv(envBaseRoot, alias)
+	t.Setenv(envSession, "session1")
+	t.Setenv(envRootID, rootToken)
+	t.Setenv(envBaseRootID, baseToken)
+
+	err = runDrain([]string{"--me", "alice", "--session", "session2"})
+	if err == nil || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("routed session accepted retargeted base identity: %v", err)
+	}
+}
+
+func TestEnvEmitsAuthoritativeIdentityTokens(t *testing.T) {
+	root := t.TempDir()
+	result := runEnvJSONForTest(t, "--root", root, "--me", "alice")
+	if result.RootID == "" || result.BaseRootID == "" {
+		t.Fatalf("env omitted authoritative identities: %+v", result)
+	}
+	if verifyTreeIdentityToken(root, result.RootID) != TreeRelationSame ||
+		verifyTreeIdentityToken(root, result.BaseRootID) != TreeRelationSame {
+		t.Fatalf("env emitted unverifiable identities: %+v", result)
+	}
+}
+
+func TestPinnedRootIdentityTokenStates(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	rootToken, err := resolveTreeIdentityToken(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherToken, err := resolveTreeIdentityToken(other)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("absent retains legacy semantics", func(t *testing.T) {
+		t.Setenv(envRoot, root)
+		t.Setenv(envBaseRoot, root)
+		t.Setenv(envSession, "")
+		setOptionalEnv(t, envRootID, "", false)
+		setOptionalEnv(t, envBaseRootID, "", false)
+		mismatch, err := sessionPinMismatch(root)
+		if err != nil || mismatch != nil {
+			t.Fatalf("legacy pin rejected: mismatch=%v err=%v", mismatch, err)
+		}
+	})
+
+	t.Run("mismatch refuses", func(t *testing.T) {
+		t.Setenv(envRoot, root)
+		t.Setenv(envBaseRoot, root)
+		t.Setenv(envSession, "")
+		t.Setenv(envRootID, otherToken)
+		t.Setenv(envBaseRootID, otherToken)
+		mismatch, err := sessionPinMismatch(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mismatch == nil {
+			t.Fatal("mismatched tokens were accepted")
+		}
+	})
+
+	t.Run("unknown version refuses", func(t *testing.T) {
+		t.Setenv(envRoot, root)
+		t.Setenv(envBaseRoot, root)
+		t.Setenv(envSession, "")
+		t.Setenv(envRootID, strings.Replace(rootToken, "v1:", "v999:", 1))
+		t.Setenv(envBaseRootID, strings.Replace(rootToken, "v1:", "v999:", 1))
+		mismatch, err := sessionPinMismatch(root)
+		if mismatch == nil && err == nil {
+			t.Fatal("unknown token version was accepted")
+		}
+	})
+}
+
+func TestListWarnsOnUnverifiableIdentityToken(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envRoot, root)
+	t.Setenv(envBaseRoot, root)
+	t.Setenv(envSession, "")
+	t.Setenv(envRootID, "v999:test:opaque")
+	t.Setenv(envBaseRootID, "v999:test:opaque")
+
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("advisory list rejected unverifiable token: %v", err)
+	}
+	if !strings.Contains(stderr, "warning:") || !strings.Contains(stderr, "unverifiable AMQ identity pin") {
+		t.Fatalf("list warning = %q", stderr)
+	}
+}
+
+func TestDoctorWarnsOnUnverifiableIdentityToken(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(envRoot, root)
+	t.Setenv(envBaseRoot, root)
+	t.Setenv(envSession, "")
+	t.Setenv(envRootID, "v999:test:opaque")
+	t.Setenv(envBaseRootID, "v999:test:opaque")
+
+	check := checkSessionPinIdentity(root)
+	if check.Status != "warn" || !strings.Contains(check.Message, "unverifiable AMQ identity pin") {
+		t.Fatalf("doctor identity check = %+v, want warning", check)
+	}
+}
+
 func TestSendRefusesCrossTreeEscapeFromMisclassifiedRoot(t *testing.T) {
 	t.Run("nested default-name session", func(t *testing.T) {
 		p := t.TempDir()

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -142,12 +142,15 @@ func runSend(args []string) error {
 	// malformed pins must fail closed with the context-mismatch exit status.
 	var pin sessionPin
 	var pinErr error
-	if fromSession == "" {
-		pin, pinErr = loadSessionPin()
-		if pinErr != nil {
-			return pinErr
+	pin, pinErr = loadSessionPin()
+	if pinErr != nil {
+		return pinErr
+	}
+	if pin.Present && pin.IdentityPin {
+		if verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID) != TreeRelationSame {
+			return ContextMismatchError("pinned base root identity is not current")
 		}
-		if pin.Present && pin.IdentityPin {
+		if fromSession == "" {
 			if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
 				return err
 			}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -138,6 +138,13 @@ func runSend(args []string) error {
 	// Fires only on positive evidence of a different home root (AM_ROOT /
 	// AM_BASE_ROOT); bare-root sends with no session env set are unaffected.
 	routed := targetProject != "" || targetSession != "" || fromSession != ""
+	// Validate explicit session evidence before advisory cross-tree classification;
+	// malformed pins must fail closed with the context-mismatch exit status.
+	if fromSession == "" {
+		if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
+			return err
+		}
+	}
 	if common.rootExplicit() && !routed {
 		if src, ok := conflictingSourceRoot(root); ok {
 			return UsageError("refusing send: --root %s targets a different AMQ tree than your own (%s), "+
@@ -169,12 +176,6 @@ func runSend(args []string) error {
 		}
 		sourceSession = fromSession
 	}
-	if fromSession == "" {
-		if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
-			return err
-		}
-	}
-
 	if targetProject != "" {
 		// Cross-project delivery.
 		peerBaseRoot, err := resolvePeer(root, targetProject)

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -182,9 +182,9 @@ func runSend(args []string) error {
 		if classifyRoot(root) != "" {
 			return UsageError("--from-session requires --root to be the base root, not a session root")
 		}
-		sourceRoot = filepath.Join(root, fromSession)
-		if !dirExists(sourceRoot) {
-			return fmt.Errorf("source session %q not found at %s", fromSession, sourceRoot)
+		sourceRoot, err = resolveSessionRoot(root, fromSession)
+		if err != nil {
+			return err
 		}
 		if !dirExists(filepath.Join(sourceRoot, "agents", me)) {
 			return fmt.Errorf("agent %q not found in source session %q", me, fromSession)
@@ -257,12 +257,12 @@ func runSend(args []string) error {
 			return fmt.Errorf("--session requires a session context: run from inside 'amq coop exec --session <name>'")
 		}
 
-		deliveryRoot = filepath.Join(baseRoot, targetSession)
+		deliveryRoot, err = resolveSessionRoot(baseRoot, targetSession)
+		if err != nil {
+			return err
+		}
 
 		// Verify the target session and agent inboxes exist.
-		if !dirExists(deliveryRoot) {
-			return fmt.Errorf("session %q not found at %s", targetSession, deliveryRoot)
-		}
 		for _, r := range recipients {
 			inbox := filepath.Join(deliveryRoot, "agents", r, "inbox")
 			if !dirExists(inbox) {

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -163,7 +163,7 @@ func runSend(args []string) error {
 	}
 	// Preserve the original lexical source guard after the advisory check. An
 	// identity pin was already validated above; lexical pins still need refusal.
-	if fromSession == "" && !(pin.Present && pin.IdentityPin) {
+	if fromSession == "" && (!pin.Present || !pin.IdentityPin) {
 		if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
 			return err
 		}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -150,6 +150,9 @@ func runSend(args []string) error {
 		if verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID) != TreeRelationSame {
 			return ContextMismatchError("pinned base root identity is not current")
 		}
+		if fromSession != "" && verifyTreeIdentityToken(root, pin.RootID) != TreeRelationSame {
+			return ContextMismatchError("pinned root identity is not current")
+		}
 		if fromSession == "" {
 			if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
 				return err

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -184,7 +184,7 @@ func runSend(args []string) error {
 		}
 		sourceRoot, err = resolveSessionRoot(root, fromSession)
 		if err != nil {
-			return err
+			return fmt.Errorf("source session %q not found: %w", fromSession, err)
 		}
 		if !dirExists(filepath.Join(sourceRoot, "agents", me)) {
 			return fmt.Errorf("agent %q not found in source session %q", me, fromSession)
@@ -208,14 +208,20 @@ func runSend(args []string) error {
 				return UsageError("--session: %v", err)
 			}
 			targetSession = normalized
-			deliveryRoot = filepath.Join(peerBaseRoot, targetSession)
+			deliveryRoot, err = resolveSessionRoot(peerBaseRoot, targetSession)
+			if err != nil {
+				return err
+			}
 		} else {
 			// Cross-project, no explicit session. Mirror the sender's session when
 			// the source root is itself a session root.
 			if classifyRoot(root) != "" {
 				// Inside a session — use same session name in peer.
 				targetSession = sessionName(root)
-				deliveryRoot = filepath.Join(peerBaseRoot, targetSession)
+				deliveryRoot, err = resolveSessionRoot(peerBaseRoot, targetSession)
+				if err != nil {
+					return err
+				}
 			} else {
 				// At base root — deliver to peer's base root directly.
 				deliveryRoot = peerBaseRoot

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -140,9 +140,17 @@ func runSend(args []string) error {
 	routed := targetProject != "" || targetSession != "" || fromSession != ""
 	// Validate explicit session evidence before advisory cross-tree classification;
 	// malformed pins must fail closed with the context-mismatch exit status.
+	var pin sessionPin
+	var pinErr error
 	if fromSession == "" {
-		if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
-			return err
+		pin, pinErr = loadSessionPin()
+		if pinErr != nil {
+			return pinErr
+		}
+		if pin.Present && pin.IdentityPin {
+			if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
+				return err
+			}
 		}
 	}
 	if common.rootExplicit() && !routed {
@@ -151,6 +159,13 @@ func runSend(args []string) error {
 				"but no routing dimension was given, so the recipient could not reply.\n"+
 				"Use --project <peer> or --session <name> for replyable cross-tree routing, "+
 				"or set the target as AM_ROOT if this send is genuinely local.", root, src)
+		}
+	}
+	// Preserve the original lexical source guard after the advisory check. An
+	// identity pin was already validated above; lexical pins still need refusal.
+	if fromSession == "" && !(pin.Present && pin.IdentityPin) {
+		if err := guardPinnedSourceContext("send", sourceRoot, *ignoreSessionPinFlag); err != nil {
+			return err
 		}
 	}
 	var replyProject string

--- a/internal/cli/send_cross_session_test.go
+++ b/internal/cli/send_cross_session_test.go
@@ -72,6 +72,17 @@ func TestSendFromSessionPreBootCrossSession(t *testing.T) {
 	}
 }
 
+func TestSendCrossProjectSessionSymlinkToForeignRefused(t *testing.T) {
+	peer := t.TempDir()
+	foreign := t.TempDir()
+	if err := os.Symlink(foreign, filepath.Join(peer, "evil")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveSessionRoot(peer, "evil"); err == nil {
+		t.Fatal("expected symlinked peer session to be refused")
+	}
+}
+
 func TestSendFromSessionRejectsProject(t *testing.T) {
 	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
 	ensureSendSessionAgent(t, filepath.Join(baseRoot, "cto"), "alice")

--- a/internal/cli/send_cross_session_test.go
+++ b/internal/cli/send_cross_session_test.go
@@ -83,6 +83,28 @@ func TestSendCrossProjectSessionSymlinkToForeignRefused(t *testing.T) {
 	}
 }
 
+func TestSendFromSessionRetargetedStrongBasePinRefused(t *testing.T) {
+	baseA := filepath.Join(t.TempDir(), ".agent-mail")
+	baseB := filepath.Join(t.TempDir(), ".agent-mail")
+	if err := fsq.EnsureRootDirs(baseA); err != nil {
+		t.Fatal(err)
+	}
+	ensureSendSessionAgent(t, filepath.Join(baseB, "cto"), "alice")
+	idA, err := resolveTreeIdentityToken(baseA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envBaseRoot, baseA)
+	t.Setenv(envRoot, baseB)
+	t.Setenv(envSession, "")
+	t.Setenv(envBaseRootID, idA)
+	t.Setenv(envRootID, idA)
+	err = runSend([]string{"--me", "alice", "--root", baseB, "--from-session", "cto", "--session", "cto", "--to", "alice", "--body", "x"})
+	if GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("exit=%d err=%v, want context mismatch", GetExitCode(err), err)
+	}
+}
+
 func TestSendFromSessionRejectsProject(t *testing.T) {
 	baseRoot := filepath.Join(t.TempDir(), ".agent-mail")
 	ensureSendSessionAgent(t, filepath.Join(baseRoot, "cto"), "alice")

--- a/internal/cli/send_cross_session_test.go
+++ b/internal/cli/send_cross_session_test.go
@@ -83,6 +83,20 @@ func TestSendCrossProjectSessionSymlinkToForeignRefused(t *testing.T) {
 	}
 }
 
+func TestResolveSessionRootRejectsInBaseSymlink(t *testing.T) {
+	base := t.TempDir()
+	prod := filepath.Join(base, "prod")
+	if err := os.Mkdir(prod, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(prod, filepath.Join(base, "qa")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveSessionRoot(base, "qa"); err == nil {
+		t.Fatal("expected in-base session symlink refusal")
+	}
+}
+
 func TestSendFromSessionRetargetedStrongBasePinRefused(t *testing.T) {
 	baseA := filepath.Join(t.TempDir(), ".agent-mail")
 	baseB := filepath.Join(t.TempDir(), ".agent-mail")

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -23,7 +23,9 @@ type sessionPin struct {
 // base-root pin. New shell writers always replace the complete context set.
 func loadSessionPin() (sessionPin, error) {
 	rawSession, present := os.LookupEnv(envSession)
-	if !present {
+	_, rootIDPresent := os.LookupEnv(envRootID)
+	_, baseRootIDPresent := os.LookupEnv(envBaseRootID)
+	if !present && !rootIDPresent && !baseRootIDPresent {
 		return sessionPin{}, nil
 	}
 
@@ -70,6 +72,34 @@ func loadSessionPin() (sessionPin, error) {
 	return pin, nil
 }
 
+// verifyRootUnderBase authenticates the base and proves that session is a
+// direct, non-symlink child of it before authenticating the resulting root.
+func verifyRootUnderBase(base, baseID, session, root, rootID string) error {
+	if verifyTreeIdentityToken(base, baseID) != TreeRelationSame {
+		return ContextMismatchError("pinned base root identity is not current: %s", base)
+	}
+	base = absPath(resolveRoot(base))
+	root = absPath(resolveRoot(root))
+	if session == "" {
+		if root != base {
+			return ContextMismatchError("root is not the pinned base root")
+		}
+	} else {
+		entry := filepath.Join(base, session)
+		info, err := os.Lstat(entry)
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return ContextMismatchError("pinned session %q is not a direct directory under base", session)
+		}
+		if root != absPath(entry) {
+			return ContextMismatchError("root is not the pinned session directory")
+		}
+	}
+	if verifyTreeIdentityToken(root, rootID) != TreeRelationSame {
+		return ContextMismatchError("target root identity is not current: %s", root)
+	}
+	return nil
+}
+
 func sessionPinMismatch(target string) (*SessionContextError, error) {
 	target = absPath(resolveRoot(target))
 	pin, err := loadSessionPin()
@@ -78,17 +108,8 @@ func sessionPinMismatch(target string) (*SessionContextError, error) {
 	}
 	if pin.Present {
 		if pin.IdentityPin {
-			if relation := verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID); relation != TreeRelationSame {
-				return &SessionContextError{Message: fmt.Sprintf(
-					"session context mismatch: pinned base root identity is %s for %s",
-					relation, pin.BaseRoot,
-				)}, nil
-			}
-			if relation := verifyTreeIdentityToken(target, pin.RootID); relation != TreeRelationSame {
-				return &SessionContextError{Message: fmt.Sprintf(
-					"session context mismatch: target root identity is %s for %s",
-					relation, target,
-				)}, nil
+			if err := verifyRootUnderBase(pin.BaseRoot, pin.BaseRootID, pin.Session, target, pin.RootID); err != nil {
+				return &SessionContextError{Message: err.Error()}, nil
 			}
 			return nil, nil
 		}
@@ -135,8 +156,15 @@ func resolveMailboxRoot(common *commonFlags, rawSession string) (root string, ro
 	switch {
 	case pin.Present:
 		if pin.IdentityPin {
-			if relation := verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID); relation != TreeRelationSame {
-				return "", false, ContextMismatchError("refusing routed session: pinned base root identity is %s for %s", relation, pin.BaseRoot)
+			// The requested session must be a direct, non-symlink child of the
+			// authenticated base; do not route through an attacker-controlled alias.
+			if verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID) != TreeRelationSame {
+				return "", false, ContextMismatchError("refusing routed session: pinned base root identity is not current")
+			}
+			entry := filepath.Join(pin.BaseRoot, session)
+			info, e := os.Lstat(entry)
+			if e != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				return "", false, ContextMismatchError("refusing routed session: %q is not a direct directory under pinned base", session)
 			}
 		}
 		base = pin.BaseRoot

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -14,6 +14,9 @@ type sessionPin struct {
 	Session      string
 	BaseRoot     string
 	ExpectedRoot string
+	BaseRootID   string
+	RootID       string
+	IdentityPin  bool
 }
 
 // loadSessionPin distinguishes an absent legacy pin from an explicitly empty
@@ -47,6 +50,23 @@ func loadSessionPin() (sessionPin, error) {
 	} else {
 		pin.ExpectedRoot = pin.BaseRoot
 	}
+
+	rootID, rootIDPresent := os.LookupEnv(envRootID)
+	baseRootID, baseRootIDPresent := os.LookupEnv(envBaseRootID)
+	if !rootIDPresent && !baseRootIDPresent {
+		return pin, nil
+	}
+	rootID = strings.TrimSpace(rootID)
+	baseRootID = strings.TrimSpace(baseRootID)
+	if !rootIDPresent || !baseRootIDPresent || rootID == "" || baseRootID == "" {
+		return sessionPin{}, ContextMismatchError("incomplete AMQ identity pin: %s and %s must both be present and non-empty", envRootID, envBaseRootID)
+	}
+	if !validTreeIdentityToken(rootID) || !validTreeIdentityToken(baseRootID) {
+		return sessionPin{}, ContextMismatchError("unverifiable AMQ identity pin: unsupported or malformed %s/%s", envRootID, envBaseRootID)
+	}
+	pin.RootID = rootID
+	pin.BaseRootID = baseRootID
+	pin.IdentityPin = true
 	return pin, nil
 }
 
@@ -57,6 +77,21 @@ func sessionPinMismatch(target string) (*SessionContextError, error) {
 		return nil, err
 	}
 	if pin.Present {
+		if pin.IdentityPin {
+			if relation := verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID); relation != TreeRelationSame {
+				return &SessionContextError{Message: fmt.Sprintf(
+					"session context mismatch: pinned base root identity is %s for %s",
+					relation, pin.BaseRoot,
+				)}, nil
+			}
+			if relation := verifyTreeIdentityToken(target, pin.RootID); relation != TreeRelationSame {
+				return &SessionContextError{Message: fmt.Sprintf(
+					"session context mismatch: target root identity is %s for %s",
+					relation, target,
+				)}, nil
+			}
+			return nil, nil
+		}
 		expected := pin.ExpectedRoot
 		if target == expected {
 			return nil, nil
@@ -99,6 +134,11 @@ func resolveMailboxRoot(common *commonFlags, rawSession string) (root string, ro
 	base := ""
 	switch {
 	case pin.Present:
+		if pin.IdentityPin {
+			if relation := verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID); relation != TreeRelationSame {
+				return "", false, ContextMismatchError("refusing routed session: pinned base root identity is %s for %s", relation, pin.BaseRoot)
+			}
+		}
 		base = pin.BaseRoot
 	default:
 		base = baseRootOf(root)

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -191,6 +191,10 @@ func resolveSessionRoot(base, session string) (string, error) {
 		return "", NotFoundError("base root not found at %s", base)
 	}
 	target := absPath(filepath.Join(base, session))
+	entry, err := os.Lstat(target)
+	if err != nil || !entry.IsDir() || entry.Mode()&os.ModeSymlink != 0 {
+		return "", ContextMismatchError("session %q is not a direct directory under base", session)
+	}
 	if !dirExists(target) {
 		return "", NotFoundError("session %q not found at %s", session, target)
 	}

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -179,11 +179,40 @@ func resolveMailboxRoot(common *commonFlags, rawSession string) (root string, ro
 		base = baseRootOf(root)
 	}
 
-	target := absPath(filepath.Join(base, session))
-	if !dirExists(target) {
-		return "", false, NotFoundError("session %q not found at %s", session, target)
+	target, err := resolveSessionRoot(base, session)
+	if err != nil {
+		return "", false, err
 	}
 	return target, true, nil
+}
+
+// resolveSessionRoot resolves a session beneath base using canonical paths. This
+// prevents a symlinked session (or base) from bypassing tree/session identity
+// checks performed by callers.
+func resolveSessionRoot(base, session string) (string, error) {
+	base = absPath(resolveRoot(base))
+	if !dirExists(base) {
+		return "", NotFoundError("base root not found at %s", base)
+	}
+	target := absPath(filepath.Join(base, session))
+	if !dirExists(target) {
+		return "", NotFoundError("session %q not found at %s", session, target)
+	}
+	canonBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		return "", err
+	}
+	canonTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(canonBase, canonTarget)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", ContextMismatchError("session %q resolves outside base root", session)
+	}
+	// Preserve the caller's lexical root for mailbox layout and diagnostics;
+	// canonical paths above are used only for containment validation.
+	return target, nil
 }
 
 func guardMailboxContext(command, target string, routed, ignorePin bool) error {

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -160,6 +160,9 @@ func resolveMailboxRoot(common *commonFlags, rawSession string) (root string, ro
 	switch {
 	case pin.Present:
 		if pin.IdentityPin {
+			if err := verifyRootUnderBase(pin.BaseRoot, pin.BaseRootID, pin.Session, root, pin.RootID); err != nil {
+				return "", false, err
+			}
 			// The requested session must be a direct, non-symlink child of the
 			// authenticated base; do not route through an attacker-controlled alias.
 			if verifyTreeIdentityToken(pin.BaseRoot, pin.BaseRootID) != TreeRelationSame {

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -81,7 +81,9 @@ func verifyRootUnderBase(base, baseID, session, root, rootID string) error {
 	base = absPath(resolveRoot(base))
 	root = absPath(resolveRoot(root))
 	if session == "" {
-		if root != base {
+		baseInfo, baseErr := os.Stat(base)
+		rootInfo, rootErr := os.Stat(root)
+		if baseErr != nil || rootErr != nil || !os.SameFile(baseInfo, rootInfo) {
 			return ContextMismatchError("root is not the pinned base root")
 		}
 	} else {
@@ -90,7 +92,9 @@ func verifyRootUnderBase(base, baseID, session, root, rootID string) error {
 		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return ContextMismatchError("pinned session %q is not a direct directory under base", session)
 		}
-		if root != absPath(entry) {
+		entryInfo, entryErr := os.Stat(entry)
+		rootInfo, rootErr := os.Stat(root)
+		if entryErr != nil || rootErr != nil || !os.SameFile(entryInfo, rootInfo) {
 			return ContextMismatchError("root is not the pinned session directory")
 		}
 	}

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -81,9 +81,7 @@ func verifyRootUnderBase(base, baseID, session, root, rootID string) error {
 	base = absPath(resolveRoot(base))
 	root = absPath(resolveRoot(root))
 	if session == "" {
-		baseInfo, baseErr := os.Stat(base)
-		rootInfo, rootErr := os.Stat(root)
-		if baseErr != nil || rootErr != nil || !os.SameFile(baseInfo, rootInfo) {
+		if !sameTreeIdentity(base, root) {
 			return ContextMismatchError("root is not the pinned base root")
 		}
 	} else {
@@ -92,9 +90,7 @@ func verifyRootUnderBase(base, baseID, session, root, rootID string) error {
 		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return ContextMismatchError("pinned session %q is not a direct directory under base", session)
 		}
-		entryInfo, entryErr := os.Stat(entry)
-		rootInfo, rootErr := os.Stat(root)
-		if entryErr != nil || rootErr != nil || !os.SameFile(entryInfo, rootInfo) {
+		if !sameTreeIdentity(entry, root) {
 			return ContextMismatchError("root is not the pinned session directory")
 		}
 	}

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -192,11 +192,14 @@ func resolveSessionRoot(base, session string) (string, error) {
 	}
 	target := absPath(filepath.Join(base, session))
 	entry, err := os.Lstat(target)
-	if err != nil || !entry.IsDir() || entry.Mode()&os.ModeSymlink != 0 {
-		return "", ContextMismatchError("session %q is not a direct directory under base", session)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", NotFoundError("session %q not found at %s", session, target)
+		}
+		return "", ContextMismatchError("cannot inspect session %q: %v", session, err)
 	}
-	if !dirExists(target) {
-		return "", NotFoundError("session %q not found at %s", session, target)
+	if !entry.IsDir() || entry.Mode()&os.ModeSymlink != 0 {
+		return "", ContextMismatchError("session %q is not a direct directory under base", session)
 	}
 	canonBase, err := filepath.EvalSymlinks(base)
 	if err != nil {

--- a/internal/cli/sibling_backlog.go
+++ b/internal/cli/sibling_backlog.go
@@ -24,7 +24,7 @@ func findSiblingBacklogs(root, me string) []siblingBacklog {
 	}
 	me = normalized
 	root = absPath(resolveRoot(root))
-	base := baseRootOf(root)
+	base := baseRootOfForDisplay(root)
 	entries, err := os.ReadDir(base)
 	if err != nil {
 		return nil
@@ -84,7 +84,7 @@ func emitSiblingBacklogHintsIfInboxEmpty(root, me string) {
 }
 
 func siblingContext(root string) string {
-	if session := resolveSessionName(absPath(resolveRoot(root))); session != "" && validateSessionName(session) == nil {
+	if session := resolveSessionNameForDisplay(absPath(resolveRoot(root))); session != "" && validateSessionName(session) == nil {
 		return session
 	}
 	return "base root"

--- a/internal/cli/tree_identity.go
+++ b/internal/cli/tree_identity.go
@@ -74,7 +74,9 @@ func relateTrees(a, b string) TreeRelation {
 	if leftErr != nil || rightErr != nil {
 		return TreeRelationUnknown
 	}
-	if os.SameFile(left.info, right.info) {
+	// Authority decisions must use the platform token, not os.SameFile's
+	// potentially lossy FileInfo comparison (notably on Windows/ReFS).
+	if left.token == right.token {
 		return TreeRelationSame
 	}
 	return TreeRelationDifferent

--- a/internal/cli/tree_identity.go
+++ b/internal/cli/tree_identity.go
@@ -96,6 +96,12 @@ func verifyTreeIdentityToken(path, token string) TreeRelation {
 	return TreeRelationDifferent
 }
 
+func sameTreeIdentity(a, b string) bool {
+	left, le := resolveTreeIdentity(a)
+	right, re := resolveTreeIdentity(b)
+	return le == nil && re == nil && left.token == right.token
+}
+
 func validTreeIdentityToken(token string) bool {
 	return validPlatformTreeIdentityToken(token)
 }

--- a/internal/cli/tree_identity.go
+++ b/internal/cli/tree_identity.go
@@ -11,6 +11,11 @@ import (
 // advisory or authority-bearing instead of accidentally collapsing failures.
 type TreeRelation uint8
 
+// Identity tokens are a pathname snapshot. ABA reuse (delete/recreate of a
+// directory with the same file ID beneath an untrusted ancestor) remains an
+// accepted single-user residual; a durable-handle capability is deferred to W2
+// if multi-tenant deployments make this material.
+
 const (
 	TreeRelationUnknown TreeRelation = iota
 	TreeRelationSame

--- a/internal/cli/tree_identity.go
+++ b/internal/cli/tree_identity.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// TreeRelation is a physical-filesystem relationship. Unknown is deliberately
+// distinct from Different: callers must choose whether unverifiable identity is
+// advisory or authority-bearing instead of accidentally collapsing failures.
+type TreeRelation uint8
+
+const (
+	TreeRelationUnknown TreeRelation = iota
+	TreeRelationSame
+	TreeRelationDifferent
+)
+
+func (r TreeRelation) String() string {
+	switch r {
+	case TreeRelationSame:
+		return "Same"
+	case TreeRelationDifferent:
+		return "Different"
+	default:
+		return "Unknown"
+	}
+}
+
+type treeIdentity struct {
+	info  os.FileInfo
+	token string
+}
+
+func resolveTreeIdentity(path string) (treeIdentity, error) {
+	if strings.TrimSpace(path) == "" {
+		return treeIdentity{}, fmt.Errorf("empty tree path")
+	}
+	path = absPath(resolveRoot(path))
+	info, err := os.Stat(path)
+	if err != nil {
+		return treeIdentity{}, err
+	}
+	if !info.IsDir() {
+		return treeIdentity{}, fmt.Errorf("tree path is not a directory: %s", path)
+	}
+	token, err := platformTreeIdentityToken(path, info)
+	if err != nil {
+		return treeIdentity{}, err
+	}
+	return treeIdentity{info: info, token: token}, nil
+}
+
+// resolveTreeIdentityToken returns an opaque, versioned, platform-tagged
+// identity. Consumers must compare it through verifyTreeIdentityToken and must
+// not parse or persist assumptions about its payload encoding.
+func resolveTreeIdentityToken(path string) (string, error) {
+	identity, err := resolveTreeIdentity(path)
+	if err != nil {
+		return "", err
+	}
+	return identity.token, nil
+}
+
+func relateTrees(a, b string) TreeRelation {
+	left, leftErr := resolveTreeIdentity(a)
+	right, rightErr := resolveTreeIdentity(b)
+	if leftErr != nil || rightErr != nil {
+		return TreeRelationUnknown
+	}
+	if os.SameFile(left.info, right.info) {
+		return TreeRelationSame
+	}
+	return TreeRelationDifferent
+}
+
+func verifyTreeIdentityToken(path, token string) TreeRelation {
+	if !validTreeIdentityToken(token) {
+		return TreeRelationUnknown
+	}
+	current, err := resolveTreeIdentityToken(path)
+	if err != nil {
+		return TreeRelationUnknown
+	}
+	if current == token {
+		return TreeRelationSame
+	}
+	return TreeRelationDifferent
+}
+
+func validTreeIdentityToken(token string) bool {
+	return validPlatformTreeIdentityToken(token)
+}

--- a/internal/cli/tree_identity_test.go
+++ b/internal/cli/tree_identity_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cli
 
 import (

--- a/internal/cli/tree_identity_test.go
+++ b/internal/cli/tree_identity_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestTreeRelationUsesPhysicalIdentity(t *testing.T) {
+	realRoot := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(realRoot, alias); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	if got := relateTrees(realRoot, alias); got != TreeRelationSame {
+		t.Fatalf("relateTrees(real, alias) = %v, want Same", got)
+	}
+	if got := relateTrees(realRoot, t.TempDir()); got != TreeRelationDifferent {
+		t.Fatalf("relateTrees(distinct roots) = %v, want Different", got)
+	}
+	if got := relateTrees(realRoot, filepath.Join(t.TempDir(), "missing")); got != TreeRelationUnknown {
+		t.Fatalf("relateTrees(real, missing) = %v, want Unknown", got)
+	}
+}
+
+func TestTreeIdentityTokenIsOpaqueAndPlatformTagged(t *testing.T) {
+	token, err := resolveTreeIdentityToken(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPrefix := "v1:" + runtime.GOOS + ":"
+	if !strings.HasPrefix(token, wantPrefix) {
+		t.Fatalf("token %q does not have platform/version prefix %q", token, wantPrefix)
+	}
+	if got := verifyTreeIdentityToken(t.TempDir(), wantPrefix+"malformed"); got != TreeRelationUnknown {
+		t.Fatalf("malformed token relation = %v, want Unknown", got)
+	}
+}
+
+func TestTreeIdentityCaseInsensitiveAlias(t *testing.T) {
+	root := t.TempDir()
+	probe := filepath.Join(root, ".probe-case")
+	if err := os.MkdirAll(probe, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(root, ".PROBE-CASE")
+	if _, err := os.Stat(alias); err != nil {
+		t.Skip("case-sensitive filesystem")
+	}
+
+	want, err := resolveTreeIdentityToken(probe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveTreeIdentityToken(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("case-insensitive aliases have different identity tokens: %q != %q", got, want)
+	}
+}

--- a/internal/cli/tree_identity_unix.go
+++ b/internal/cli/tree_identity_unix.go
@@ -18,7 +18,7 @@ func platformTreeIdentityToken(_ string, info os.FileInfo) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("filesystem identity unavailable on %s", runtime.GOOS)
 	}
-	return fmt.Sprintf("v1:%s:%x:%x", treeIdentityPlatform, stat.Dev, stat.Ino), nil
+	return fmt.Sprintf("v1:%s:%x:%x", treeIdentityPlatform, uint64(stat.Dev), uint64(stat.Ino)), nil
 }
 
 func validPlatformTreeIdentityToken(token string) bool {

--- a/internal/cli/tree_identity_unix.go
+++ b/internal/cli/tree_identity_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const treeIdentityPlatform = runtime.GOOS
+
+func platformTreeIdentityToken(_ string, info os.FileInfo) (string, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("filesystem identity unavailable on %s", runtime.GOOS)
+	}
+	return fmt.Sprintf("v1:%s:%x:%x", treeIdentityPlatform, stat.Dev, stat.Ino), nil
+}
+
+func validPlatformTreeIdentityToken(token string) bool {
+	parts := strings.Split(token, ":")
+	if len(parts) != 4 || parts[0] != "v1" || parts[1] != treeIdentityPlatform {
+		return false
+	}
+	if _, err := strconv.ParseUint(parts[2], 16, 64); err != nil {
+		return false
+	}
+	_, err := strconv.ParseUint(parts[3], 16, 64)
+	return err == nil
+}

--- a/internal/cli/tree_identity_windows.go
+++ b/internal/cli/tree_identity_windows.go
@@ -43,7 +43,21 @@ func platformTreeIdentityToken(path string, _ os.FileInfo) (string, error) {
 	if err := windows.GetFileInformationByHandleEx(handle, windows.FileIdInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
 		return "", err
 	}
+	if invalidWindowsIdentity(info.VolumeSerialNumber, info.FileID) {
+		return "", fmt.Errorf("filesystem returned sentinel file identity")
+	}
 	return fmt.Sprintf("v1:windows:%x:%x", info.VolumeSerialNumber, info.FileID), nil
+}
+
+func invalidWindowsIdentity(volume uint64, id [16]byte) bool {
+	if volume == 0 || volume == ^uint64(0) {
+		return true
+	}
+	var zero, ff [16]byte
+	for i := range ff {
+		ff[i] = 0xff
+	}
+	return id == zero || id == ff
 }
 
 func validPlatformTreeIdentityToken(token string) bool {
@@ -51,16 +65,31 @@ func validPlatformTreeIdentityToken(token string) bool {
 	if len(parts) != 4 || parts[0] != "v1" || parts[1] != treeIdentityPlatform {
 		return false
 	}
-	if _, err := strconv.ParseUint(parts[2], 16, 64); err != nil {
+	volume, err := strconv.ParseUint(parts[2], 16, 64)
+	if err != nil || volume == 0 || volume == ^uint64(0) {
 		return false
 	}
 	if len(parts[3]) != 32 {
 		return false
 	}
-	_, err := strconv.ParseUint(parts[3][:16], 16, 64)
+	_, err = strconv.ParseUint(parts[3][:16], 16, 64)
 	if err != nil {
 		return false
 	}
 	_, err = strconv.ParseUint(parts[3][16:], 16, 64)
-	return err == nil
+	if err != nil {
+		return false
+	}
+	var id, zero, ff [16]byte
+	for i := range ff {
+		ff[i] = 0xff
+	}
+	for i := range id {
+		v, parseErr := strconv.ParseUint(parts[3][i*2:i*2+2], 16, 8)
+		if parseErr != nil {
+			return false
+		}
+		id[i] = byte(v)
+	}
+	return id != zero && id != ff
 }

--- a/internal/cli/tree_identity_windows.go
+++ b/internal/cli/tree_identity_windows.go
@@ -13,39 +13,6 @@ const treeIdentityPlatform = "windows"
 
 func platformTreeIdentityToken(path string, _ os.FileInfo) (string, error) {
 	return "", fmt.Errorf("Windows identity pinning is out of scope")
-	/*
-		pathPtr, err := windows.UTF16PtrFromString(path)
-		if err != nil {
-			return "", err
-		}
-		handle, err := windows.CreateFile(
-			pathPtr,
-			windows.FILE_READ_ATTRIBUTES,
-			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
-			nil,
-			windows.OPEN_EXISTING,
-			windows.FILE_FLAG_BACKUP_SEMANTICS,
-			0,
-		)
-		if err != nil {
-			return "", err
-		}
-		defer windows.CloseHandle(handle)
-
-		// FILE_ID_INFO is required for ReFS: the legacy 64-bit file index can
-		// collide. Unsupported/partial filesystems remain unverifiable.
-		type fileIDInfo struct {
-			VolumeSerialNumber uint64
-			FileID             [16]byte
-		}
-		var info fileIDInfo
-		if err := windows.GetFileInformationByHandleEx(handle, windows.FileIdInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
-			return "", err
-		}
-		if invalidWindowsIdentity(info.VolumeSerialNumber, info.FileID) {
-			return "", fmt.Errorf("filesystem returned sentinel file identity")
-		}
-		return fmt.Sprintf("v1:windows:%x:%x", info.VolumeSerialNumber, info.FileID), nil */
 }
 
 func invalidWindowsIdentity(volume uint64, id [16]byte) bool {

--- a/internal/cli/tree_identity_windows.go
+++ b/internal/cli/tree_identity_windows.go
@@ -7,46 +7,45 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
 
 const treeIdentityPlatform = "windows"
 
 func platformTreeIdentityToken(path string, _ os.FileInfo) (string, error) {
-	pathPtr, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return "", err
-	}
-	handle, err := windows.CreateFile(
-		pathPtr,
-		windows.FILE_READ_ATTRIBUTES,
-		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
-		nil,
-		windows.OPEN_EXISTING,
-		windows.FILE_FLAG_BACKUP_SEMANTICS,
-		0,
-	)
-	if err != nil {
-		return "", err
-	}
-	defer windows.CloseHandle(handle)
+	return "", fmt.Errorf("Windows identity pinning is out of scope")
+	/*
+		pathPtr, err := windows.UTF16PtrFromString(path)
+		if err != nil {
+			return "", err
+		}
+		handle, err := windows.CreateFile(
+			pathPtr,
+			windows.FILE_READ_ATTRIBUTES,
+			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+			nil,
+			windows.OPEN_EXISTING,
+			windows.FILE_FLAG_BACKUP_SEMANTICS,
+			0,
+		)
+		if err != nil {
+			return "", err
+		}
+		defer windows.CloseHandle(handle)
 
-	// FILE_ID_INFO is required for ReFS: the legacy 64-bit file index can
-	// collide. Unsupported/partial filesystems remain unverifiable.
-	type fileIDInfo struct {
-		VolumeSerialNumber uint64
-		FileID             [16]byte
-	}
-	var info fileIDInfo
-	if err := windows.GetFileInformationByHandleEx(handle, windows.FileIdInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
-		return "", err
-	}
-	if invalidWindowsIdentity(info.VolumeSerialNumber, info.FileID) {
-		return "", fmt.Errorf("filesystem returned sentinel file identity")
-	}
-	return fmt.Sprintf("v1:windows:%x:%x", info.VolumeSerialNumber, info.FileID), nil
+		// FILE_ID_INFO is required for ReFS: the legacy 64-bit file index can
+		// collide. Unsupported/partial filesystems remain unverifiable.
+		type fileIDInfo struct {
+			VolumeSerialNumber uint64
+			FileID             [16]byte
+		}
+		var info fileIDInfo
+		if err := windows.GetFileInformationByHandleEx(handle, windows.FileIdInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
+			return "", err
+		}
+		if invalidWindowsIdentity(info.VolumeSerialNumber, info.FileID) {
+			return "", fmt.Errorf("filesystem returned sentinel file identity")
+		}
+		return fmt.Sprintf("v1:windows:%x:%x", info.VolumeSerialNumber, info.FileID), nil */
 }
 
 func invalidWindowsIdentity(volume uint64, id [16]byte) bool {

--- a/internal/cli/tree_identity_windows.go
+++ b/internal/cli/tree_identity_windows.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -32,22 +33,34 @@ func platformTreeIdentityToken(path string, _ os.FileInfo) (string, error) {
 	}
 	defer windows.CloseHandle(handle)
 
-	var info windows.ByHandleFileInformation
-	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+	// FILE_ID_INFO is required for ReFS: the legacy 64-bit file index can
+	// collide. Unsupported/partial filesystems remain unverifiable.
+	type fileIDInfo struct {
+		VolumeSerialNumber uint64
+		FileID             [16]byte
+	}
+	var info fileIDInfo
+	if err := windows.GetFileInformationByHandleEx(handle, windows.FileIdInfo, (*byte)(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("v1:windows:%x:%x:%x", info.VolumeSerialNumber, info.FileIndexHigh, info.FileIndexLow), nil
+	return fmt.Sprintf("v1:windows:%x:%x", info.VolumeSerialNumber, info.FileID), nil
 }
 
 func validPlatformTreeIdentityToken(token string) bool {
 	parts := strings.Split(token, ":")
-	if len(parts) != 5 || parts[0] != "v1" || parts[1] != treeIdentityPlatform {
+	if len(parts) != 4 || parts[0] != "v1" || parts[1] != treeIdentityPlatform {
 		return false
 	}
-	for _, part := range parts[2:] {
-		if _, err := strconv.ParseUint(part, 16, 32); err != nil {
-			return false
-		}
+	if _, err := strconv.ParseUint(parts[2], 16, 64); err != nil {
+		return false
 	}
-	return true
+	if len(parts[3]) != 32 {
+		return false
+	}
+	_, err := strconv.ParseUint(parts[3][:16], 16, 64)
+	if err != nil {
+		return false
+	}
+	_, err = strconv.ParseUint(parts[3][16:], 16, 64)
+	return err == nil
 }

--- a/internal/cli/tree_identity_windows.go
+++ b/internal/cli/tree_identity_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+const treeIdentityPlatform = "windows"
+
+func platformTreeIdentityToken(path string, _ os.FileInfo) (string, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return "", err
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer windows.CloseHandle(handle)
+
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("v1:windows:%x:%x:%x", info.VolumeSerialNumber, info.FileIndexHigh, info.FileIndexLow), nil
+}
+
+func validPlatformTreeIdentityToken(token string) bool {
+	parts := strings.Split(token, ":")
+	if len(parts) != 5 || parts[0] != "v1" || parts[1] != treeIdentityPlatform {
+		return false
+	}
+	for _, part := range parts[2:] {
+		if _, err := strconv.ParseUint(part, 16, 32); err != nil {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/tree_identity_windows_test.go
+++ b/internal/cli/tree_identity_windows_test.go
@@ -2,7 +2,26 @@
 
 package cli
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+func TestWindowsIdentityPinningOutOfScope(t *testing.T) {
+	if _, err := platformTreeIdentityToken("C:\\", nil); err == nil {
+		t.Fatal("expected no Windows identity token")
+	}
+}
+
+func TestWindowsWritableAmqrcAvailability(t *testing.T) {
+	p := t.TempDir() + "\\.amqrc"
+	if err := os.WriteFile(p, []byte(`{"root":".agent-mail"}`), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateAmqrcFile(p); err != nil {
+		t.Fatalf("writable Windows config rejected: %v", err)
+	}
+}
 
 func TestInvalidWindowsIdentityRejectsSentinels(t *testing.T) {
 	var zero, ff [16]byte

--- a/internal/cli/tree_identity_windows_test.go
+++ b/internal/cli/tree_identity_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package cli
+
+import "testing"
+
+func TestInvalidWindowsIdentityRejectsSentinels(t *testing.T) {
+	var zero, ff [16]byte
+	for i := range ff {
+		ff[i] = 0xff
+	}
+	if !invalidWindowsIdentity(1, zero) || !invalidWindowsIdentity(1, ff) {
+		t.Fatal("zero and all-ff file IDs must be rejected")
+	}
+	var good [16]byte
+	good[0] = 1
+	if invalidWindowsIdentity(1, good) || invalidWindowsIdentity(0, good) || invalidWindowsIdentity(^uint64(0), good) {
+		t.Fatal("valid file ID or sentinel volume was classified incorrectly")
+	}
+}
+
+func TestValidWindowsIdentityTokenRejectsSentinels(t *testing.T) {
+	if validPlatformTreeIdentityToken("v1:windows:0:01000000000000000000000000000000") {
+		t.Fatal("zero volume accepted")
+	}
+	if validPlatformTreeIdentityToken("v1:windows:1:00000000000000000000000000000000") {
+		t.Fatal("zero file ID accepted")
+	}
+}

--- a/internal/cli/who.go
+++ b/internal/cli/who.go
@@ -26,7 +26,7 @@ func runWho(args []string) error {
 
 	// Determine base root using the centralized classifier.
 	// Falls back to checking if root itself contains session subdirs.
-	baseRoot := classifyRoot(root)
+	baseRoot := classifyRootForDisplay(root)
 	if baseRoot == "" {
 		// classifyRoot couldn't determine from env or sibling sessions.
 		// Check if root IS the base root (contains session subdirs).

--- a/internal/cli/worktree_divergence.go
+++ b/internal/cli/worktree_divergence.go
@@ -73,7 +73,7 @@ func checkWorktreeDivergenceHints(root string, agents []string) []opsHint {
 	if session == "" {
 		return nil
 	}
-	base := canonicalDiagnosticPath(baseRootOf(root))
+	base := canonicalDiagnosticPath(baseRootOfForDisplay(root))
 	relBase, err := filepath.Rel(top, base)
 	if err != nil || relBase == ".." || strings.HasPrefix(relBase, ".."+string(filepath.Separator)) || filepath.IsAbs(relBase) {
 		return nil
@@ -107,7 +107,7 @@ func checkWorktreeDivergenceHints(root string, agents []string) []opsHint {
 }
 
 func validSessionNameForRoot(root string) string {
-	session := resolveSessionName(absPath(resolveRoot(root)))
+	session := resolveSessionNameForDisplay(absPath(resolveRoot(root)))
 	if session == "" || validateSessionName(session) != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary

Wave 1 of the cross-tree hardening plan (#233). Establishes the **identity/authority foundation** the later fd-relative delivery waves build on, and closes a set of authority-laundering and confused-deputy defects surfaced by adversarial review.

## Threat model (documented in SECURITY.md)

Same-euid attackers and privileged mount manipulation are out of scope; **untrusted ancestor directories, adversarial topology under a selected root, and cross-command alias retarget are in scope.** Windows runtime is explicitly out of scope for identity/`.amqrc` authority hardening and degrades to legacy lexical behavior (never false authority). Boundary is containment; the deferred fd-relative delivery capability (wave 2, `os.Root`) makes verification authoritative for the mutation itself.

## What changed

- **`TreeRelation{Same,Different,Unknown}`** backed by a physical-identity resolver (platform token: unix dev+ino, Windows FILE_ID_INFO — or Unknown). `Unknown` is never silently collapsed; callers pick policy.
- **Opaque versioned identity tokens** (`AM_ROOT_ID`/`AM_BASE_ROOT_ID`) emitted by `amq env` only when authoritative, and a single `verifyRootUnderBase` primitive that proves a session is a real direct (non-symlink) child of the authenticated base — used by session-pin, routed mailbox, and `env --session`.
- **Sibling-`agents` heuristic demoted to display-only**; it no longer produces authority, and cannot reach the mutating `doctor --ops --fix-wake-locks` path (configured handles are `fsq.ValidateHandle`-checked before any wake-lock path is built — closes a cross-tree lock-deletion confused deputy).
- **`.amqrc` provenance**: every loader (home, cwd-walk, root-scoped) fails closed on non-ENOENT inspection errors, refuses symlink/non-regular/group-or-world-writable configs, and (unix) requires effective-uid ownership.
- **`resolveSessionRoot`** refuses in-base session symlinks (`base/qa -> base/prod`) via `Lstat` direct-entry check while preserving not-found semantics; all send/from-session/cross-project session joins route through it.
- Caller policy: absence of explicit evidence stays fail-open (nonexistent same-tree target and symlinked custom base remain allowed — regression-locked); verification failure of *present* evidence fails closed (exit 5) for mutating/consuming commands; `list`/`doctor` warn only.

## Review

Adversarially reviewed across multiple gate rounds (ChatGPT Pro + Gemini 3.1 Pro); all findings closed. `make ci` green; all four GOOS builds. Accepted residuals (documented): inode/file-id ABA reuse; W1 verification is a pathname snapshot until the wave-2 `os.Root` capability lands. Part of #233. Implementation by Codex; design/review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)