### PR TITLE
feat(wake): refuse live raw Darwin wake orphans instead of bare-PID kill

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -264,6 +264,10 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 			PID:    inspection.PID,
 			Reason: inspection.Reason,
 		}
+		if isLiveRawOrphan(inspection) {
+			lock.Status = "live-raw-orphan"
+			lock.Reason = "live raw wake orphan; stop the owning terminal or launchd supervisor"
+		}
 		target, exists, targetErr := readWakeTarget(root, agent)
 		if exists {
 			lock.Target = wakeTargetPath(root, agent)

--- a/internal/cli/wake_raw_orphan_darwin_test.go
+++ b/internal/cli/wake_raw_orphan_darwin_test.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package cli
+
+import "testing"
+
+func TestLiveRawOrphanState(t *testing.T) {
+	i := wakeLockInspection{IdentityConfirmed: true, Process: wakeProcessInfo{Running: true}, Lock: wakeLock{WakeMode: "raw"}}
+	if !isLiveRawOrphan(i) {
+		t.Fatal("expected live raw orphan")
+	}
+	i.Process.Running = false
+	if isLiveRawOrphan(i) {
+		t.Fatal("dead process is not a live raw orphan")
+	}
+}

--- a/internal/cli/wake_raw_orphan_other.go
+++ b/internal/cli/wake_raw_orphan_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package cli
+
+func isLiveRawOrphan(wakeLockInspection) bool { return false }

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -31,6 +31,8 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	if recheck.Process.Running && recheck.Lock.WakeMode != wakeTargetInjectVia {
 		return false, fmt.Errorf("live raw wake orphan for %s (pid %d, start %s); stop the owning terminal/launchd supervisor; manual kill is non-identity-safe — recheck before running; see doctor --ops", recheck.Agent, recheck.PID, recheck.Lock.ProcessStart)
 	}
+	// W5a intentionally leaves live inject-via orphans on the legacy PID path;
+	// W5b replaces this with the nonce-bound control socket.
 	// Process termination can wait. It must happen after releasing the guard.
 	if recheck.Process.Running {
 		if err := terminateWakeProcess(recheck); err != nil {
@@ -53,6 +55,10 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 		return nil
 	})
 	return removed, err
+}
+
+func isLiveRawOrphan(inspection wakeLockInspection) bool {
+	return inspection.Process.Running && inspection.IdentityConfirmed && inspection.Lock.WakeMode != wakeTargetInjectVia
 }
 
 func terminateWakeProcess(inspection wakeLockInspection) error {

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -28,9 +28,14 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	if !sameWakeLockInspection(inspection, recheck) || !recheck.IdentityConfirmed {
 		return false, nil
 	}
+	if recheck.Process.Running && recheck.Lock.WakeMode != wakeTargetInjectVia {
+		return false, fmt.Errorf("live raw wake orphan for %s (pid %d, start %s); stop the owning terminal/launchd supervisor; manual kill is non-identity-safe — recheck before running; see doctor --ops", recheck.Agent, recheck.PID, recheck.Lock.ProcessStart)
+	}
 	// Process termination can wait. It must happen after releasing the guard.
-	if err := terminateWakeProcess(recheck); err != nil {
-		return false, err
+	if recheck.Process.Running {
+		if err := terminateWakeProcess(recheck); err != nil {
+			return false, err
+		}
 	}
 	removed := false
 	err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1706,6 +1706,7 @@ func TestShouldReplaceOrphanedWakeLockSignalsOnlyAfterRevalidation(t *testing.T)
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeTargetInjectVia,
 	})
 	killed := false
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
@@ -1782,8 +1783,8 @@ func TestShouldReplaceOrphanedWakeLockKeepsLockWhenKillDoesNotTerminate(t *testi
 
 	inspection := inspectWakeLock(root, "orchestrator")
 	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
-	if err == nil || !strings.Contains(err.Error(), "still alive after SIGKILL") {
-		t.Fatalf("expected still-alive error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "live raw wake orphan") {
+		t.Fatalf("expected live raw orphan refusal, got %v", err)
 	}
 	if replaced {
 		t.Fatal("should not replace lock when old wake remains alive")


### PR DESCRIPTION
## Summary

Wave 5a of #235 (Darwin bare-PID removal, safety-critical half). On Darwin, an orphaned wake whose process is proven **gone** is now removed cleanly with no signal; a **live raw** orphan is **refused** rather than bare-PID killed, with an actionable message (pid + start token + 'stop the owning terminal/launchd supervisor' + 'manual kill is non-identity-safe — recheck before running' + `doctor --ops` pointer). `doctor --ops` surfaces a distinct **live-raw-orphan** state.

The refusal propagates through `shouldReplaceOrphanedWakeLock` → `acquireWakeLock`, so `coop exec --require-wake` fails legibly instead of silently killing a possibly-recycled PID.

## Scope note

Live **inject-via** orphans still use the (guard-serialized) terminate path in this slice — documented in a code comment — because their identity-safe cooperative shutdown is **W5b** (nonce-bound unix-socket + generation ACK). So Darwin is bare-PID-free for **raw** orphans here; W5b completes it for inject-via. No worse than main for inject-via in the interim.

## Tests

Existing orphan-replacement tests updated to the new behavior: signal-after-revalidation coverage preserved via an inject-via fixture; raw-orphan cases assert the refusal + lock retention. New darwin-tagged doctor live-raw-orphan state test. Full darwin `go test`, all four GOOS builds, linux test compile green.

Part of #235. Implementation by Codex; design/review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)