### PR TITLE
feat(wake): Darwin cooperative unix-socket shutdown for inject-via wakes

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -41,6 +41,7 @@ type wakeConfig struct {
 	interruptNotice   string
 	interruptCooldown time.Duration
 	lastInterrupt     time.Time
+	controlStop       <-chan struct{}
 }
 
 const defaultInjectTimeout = 5 * time.Second

--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -1,0 +1,258 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+var darwinSocketCWDMu sync.Mutex
+
+func wakeControlSocketPath(root, me, generation string) string {
+	sum := sha256.Sum256([]byte(canonicalWakeRoot(root) + "\x00" + me + "\x00" + generation))
+	return filepath.Join(fsq.AgentBase(root, me), ".w."+hex.EncodeToString(sum[:8]))
+}
+
+func withDarwinSocketDir(dir string, fn func() error) error {
+	dirfd, err := unix.Open(dir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(dirfd) }()
+	darwinSocketCWDMu.Lock()
+	defer darwinSocketCWDMu.Unlock()
+	oldfd, err := unix.Open(".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(oldfd) }()
+	if err := unix.Fchdir(dirfd); err != nil {
+		return err
+	}
+	callErr := fn()
+	restoreErr := unix.Fchdir(oldfd)
+	if callErr != nil {
+		return callErr
+	}
+	return restoreErr
+}
+
+func listenDarwinUnix(path string) (*net.UnixListener, error) {
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+	unix.CloseOnExec(fd)
+	bound := false
+	defer func() {
+		if !bound {
+			_ = unix.Close(fd)
+		}
+	}()
+	err = withDarwinSocketDir(filepath.Dir(path), func() error {
+		if err := unix.Bind(fd, &unix.SockaddrUnix{Name: filepath.Base(path)}); err != nil {
+			return err
+		}
+		return unix.Listen(fd, 16)
+	})
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), "wake-control-listener")
+	bound = true
+	listenerAny, err := net.FileListener(file)
+	_ = file.Close()
+	if err != nil {
+		return nil, err
+	}
+	listener, ok := listenerAny.(*net.UnixListener)
+	if !ok {
+		_ = listenerAny.Close()
+		return nil, fmt.Errorf("wake control listener is not unix")
+	}
+	return listener, nil
+}
+
+func dialDarwinUnix(path string, timeout time.Duration) (net.Conn, error) {
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+	unix.CloseOnExec(fd)
+	connected := false
+	defer func() {
+		if !connected {
+			_ = unix.Close(fd)
+		}
+	}()
+	err = withDarwinSocketDir(filepath.Dir(path), func() error {
+		return unix.Connect(fd, &unix.SockaddrUnix{Name: filepath.Base(path)})
+	})
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), "wake-control-client")
+	connected = true
+	conn, err := net.FileConn(file)
+	_ = file.Close()
+	if err != nil {
+		return nil, err
+	}
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	return conn, nil
+}
+
+func darwinPeerEUID(conn *net.UnixConn) (uint32, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var cred unix.Xucred
+	var sockErr error
+	err = raw.Control(func(fd uintptr) {
+		length := uint32(unsafe.Sizeof(cred))
+		_, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT, fd, uintptr(unix.SOL_LOCAL), uintptr(unix.LOCAL_PEERCRED), uintptr(unsafe.Pointer(&cred)), uintptr(unsafe.Pointer(&length)), 0)
+		if errno != 0 {
+			sockErr = errno
+		}
+	})
+	if err != nil {
+		return 0, err
+	}
+	if sockErr != nil {
+		return 0, sockErr
+	}
+	return cred.Uid, nil
+}
+
+func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan struct{}, func(), error) {
+	path := lock.ControlSocket
+	if path == "" {
+		return func() {}, nil, func() {}, nil
+	}
+	if err := withWakeLifecycleGuard(root, me, func() error {
+		current := inspectWakeLock(root, me)
+		if !current.Exists || current.Lock.Generation != lock.Generation || current.Lock.ControlSocket != path {
+			return fmt.Errorf("wake control metadata changed before listener start")
+		}
+		stale, err := filepath.Glob(filepath.Join(fsq.AgentBase(root, me), ".w.*"))
+		if err != nil {
+			return err
+		}
+		for _, candidate := range stale {
+			if err := os.Remove(candidate); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, nil, nil, err
+	}
+	listener, err := listenDarwinUnix(path)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(path)
+		return nil, nil, nil, err
+	}
+	stopRequest := make(chan struct{}, 1)
+	loopStopped := make(chan struct{})
+	var loopStoppedOnce sync.Once
+	markLoopStopped := func() { loopStoppedOnce.Do(func() { close(loopStopped) }) }
+	go func() {
+		for {
+			conn, err := listener.AcceptUnix()
+			if err != nil {
+				return
+			}
+			go func(conn *net.UnixConn) {
+				defer func() { _ = conn.Close() }()
+				_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+				uid, err := darwinPeerEUID(conn)
+				if err != nil || uid != uint32(os.Geteuid()) {
+					return
+				}
+				token, err := bufio.NewReader(conn).ReadString('\n')
+				if err != nil || strings.TrimSpace(token) != lock.Generation {
+					return
+				}
+				removed := false
+				err = withWakeLifecycleGuard(root, me, func() error {
+					current := inspectWakeLock(root, me)
+					if !current.Exists || current.Lock.Generation != lock.Generation || current.Lock.ControlSocket != path {
+						return nil
+					}
+					if err := removeWakeLockIfUnchangedGuarded(current); err != nil {
+						return err
+					}
+					removed = true
+					return nil
+				})
+				if err != nil || !removed {
+					return
+				}
+				select {
+				case stopRequest <- struct{}{}:
+				default:
+				}
+				<-loopStopped
+				_, _ = conn.Write([]byte("ACK\n"))
+			}(conn)
+		}
+	}()
+	cleanup := func() {
+		_ = listener.Close()
+		_ = withWakeLifecycleGuard(root, me, func() error {
+			if cur := inspectWakeLock(root, me); cur.Exists && cur.Lock.Generation != lock.Generation {
+				return nil
+			}
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			return nil
+		})
+	}
+	return cleanup, stopRequest, markLoopStopped, nil
+}
+
+func cooperativeStopInjectVia(i wakeLockInspection) (bool, error) {
+	if i.Lock.ControlSocket == "" || i.Lock.Generation == "" {
+		return false, fmt.Errorf("live inject-via wake orphan has no cooperative control endpoint; stop the owning supervisor")
+	}
+	conn, err := dialDarwinUnix(i.Lock.ControlSocket, 2*time.Second)
+	if err != nil {
+		return false, fmt.Errorf("cooperative wake stop unavailable: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err = fmt.Fprintf(conn, "%s\n", i.Lock.Generation); err != nil {
+		return false, err
+	}
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil || strings.TrimSpace(line) != "ACK" {
+		return false, fmt.Errorf("cooperative wake stop refused")
+	}
+	var gone bool
+	err = withWakeLifecycleGuard(i.Root, i.Agent, func() error {
+		cur := inspectWakeLock(i.Root, i.Agent)
+		gone = !cur.Exists || cur.Lock.Generation != i.Lock.Generation
+		return nil
+	})
+	return gone, err
+}

--- a/internal/cli/wake_control_darwin_test.go
+++ b/internal/cli/wake_control_darwin_test.go
@@ -1,0 +1,134 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func testDarwinControlLock(t *testing.T) (string, string, wakeLock) {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	lock := wakeLock{PID: os.Getpid(), WakeMode: wakeTargetInjectVia, Generation: "0123456789abcdef0123456789abcdef"}
+	lock.ControlSocket = wakeControlSocketPath(root, agent, lock.Generation)
+	writeWakeLockForTest(t, root, agent, lock)
+	return root, agent, lock
+}
+
+func TestDarwinCooperativeStopACKAfterLockRemoval(t *testing.T) {
+	root, agent, lock := testDarwinControlLock(t)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	go func() { <-stopped; markStopped() }()
+	inspection := inspectWakeLock(root, agent)
+	replaced, err := cooperativeStopInjectVia(inspection)
+	if err != nil || !replaced {
+		t.Fatalf("stop=(%v,%v)", replaced, err)
+	}
+	if current := inspectWakeLock(root, agent); current.Exists {
+		t.Fatal("ACK arrived before lock removal")
+	}
+}
+
+func TestDarwinCooperativeStopACKWaitsForLoopExit(t *testing.T) {
+	root, agent, lock := testDarwinControlLock(t)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	type result struct {
+		stopped bool
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		stopped, err := cooperativeStopInjectVia(inspectWakeLock(root, agent))
+		resultCh <- result{stopped: stopped, err: err}
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not request loop stop")
+	}
+	if current := inspectWakeLock(root, agent); current.Exists {
+		t.Fatal("listener requested loop stop before removing its lock")
+	}
+	if err := withWakeLifecycleGuard(root, agent, func() error { return nil }); err != nil {
+		t.Fatalf("listener held lifecycle guard while waiting for loop exit: %v", err)
+	}
+	select {
+	case got := <-resultCh:
+		t.Fatalf("stop returned before loop exit: %+v", got)
+	default:
+	}
+	markStopped()
+	select {
+	case got := <-resultCh:
+		if got.err != nil || !got.stopped {
+			t.Fatalf("stop=(%v,%v)", got.stopped, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not ACK after loop exit")
+	}
+}
+
+func TestDarwinControlTokenMismatchRefused(t *testing.T) {
+	root, agent, lock := testDarwinControlLock(t)
+	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	conn, err := dialDarwinUnix(lock.ControlSocket, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(time.Second))
+	_, _ = conn.Write([]byte("wrong-token\n"))
+	line, _ := bufio.NewReader(conn).ReadString('\n')
+	if strings.TrimSpace(line) == "ACK" {
+		t.Fatal("mismatched token acknowledged")
+	}
+	if !inspectWakeLock(root, agent).Exists {
+		t.Fatal("mismatched token removed lock")
+	}
+}
+
+func TestDarwinMissingControlMetadataRefused(t *testing.T) {
+	_, err := cooperativeStopInjectVia(wakeLockInspection{Lock: wakeLock{Generation: "g"}})
+	if err == nil {
+		t.Fatal("legacy inject-via wake accepted without control metadata")
+	}
+}
+
+func TestDarwinControlRemovesStaleSocketBeforeListen(t *testing.T) {
+	root, agent, lock := testDarwinControlLock(t)
+	oldSocket := filepath.Join(fsq.AgentBase(root, agent), ".w.stale-generation")
+	if err := os.WriteFile(oldSocket, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lock.ControlSocket, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatalf("stale socket prevented listener: %v", err)
+	}
+	if _, err := os.Lstat(oldSocket); !os.IsNotExist(err) {
+		t.Fatalf("old generation socket still exists: %v", err)
+	}
+	cleanup()
+}

--- a/internal/cli/wake_control_other.go
+++ b/internal/cli/wake_control_other.go
@@ -2,12 +2,7 @@
 
 package cli
 
-import "errors"
-
-var errNotSupported = errors.New("cooperative wake control is not supported on this platform")
-
 func wakeControlSocketPath(string, string, string) string { return "" }
 func startWakeControlListener(string, string, wakeLock) (func(), <-chan struct{}, func(), error) {
 	return func() {}, nil, func() {}, nil
 }
-func cooperativeStopInjectVia(wakeLockInspection) (bool, error) { return false, errNotSupported }

--- a/internal/cli/wake_control_other.go
+++ b/internal/cli/wake_control_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package cli
+
+import "errors"
+
+var errNotSupported = errors.New("cooperative wake control is not supported on this platform")
+
+func wakeControlSocketPath(string, string, string) string { return "" }
+func startWakeControlListener(string, string, wakeLock) (func(), <-chan struct{}, func(), error) {
+	return func() {}, nil, func() {}, nil
+}
+func cooperativeStopInjectVia(wakeLockInspection) (bool, error) { return false, errNotSupported }

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -15,19 +15,20 @@ import (
 
 // wakeLock represents the lock file content for wake process deduplication.
 type wakeLock struct {
-	PID          int      `json:"pid"`
-	TTY          string   `json:"tty"`
-	Root         string   `json:"root"`                    // Absolute path to disambiguate relative AM_ROOT
-	Agent        string   `json:"agent,omitempty"`         // Agent handle that owns this lock
-	Hostname     string   `json:"hostname,omitempty"`      // Host that created the lock
-	Started      string   `json:"started"`                 // Wall-clock diagnostic timestamp
-	ProcessStart string   `json:"process_start,omitempty"` // Kernel process start token, guards PID reuse
-	BootID       string   `json:"boot_id,omitempty"`       // Boot identity paired with ProcessStart when available
-	Executable   string   `json:"executable,omitempty"`    // Diagnostic process executable basename/path
-	Args         []string `json:"args,omitempty"`          // Diagnostic argv when available
-	WakeMode     string   `json:"wake_mode,omitempty"`     // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
-	TargetDigest string   `json:"target_digest,omitempty"` // Binds .wake.target to this lock instance
-	Generation   string   `json:"generation,omitempty"`    // Random nonce binding readiness and exact cleanup to this instance
+	PID           int      `json:"pid"`
+	TTY           string   `json:"tty"`
+	Root          string   `json:"root"`                     // Absolute path to disambiguate relative AM_ROOT
+	Agent         string   `json:"agent,omitempty"`          // Agent handle that owns this lock
+	Hostname      string   `json:"hostname,omitempty"`       // Host that created the lock
+	Started       string   `json:"started"`                  // Wall-clock diagnostic timestamp
+	ProcessStart  string   `json:"process_start,omitempty"`  // Kernel process start token, guards PID reuse
+	BootID        string   `json:"boot_id,omitempty"`        // Boot identity paired with ProcessStart when available
+	Executable    string   `json:"executable,omitempty"`     // Diagnostic process executable basename/path
+	Args          []string `json:"args,omitempty"`           // Diagnostic argv when available
+	WakeMode      string   `json:"wake_mode,omitempty"`      // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
+	TargetDigest  string   `json:"target_digest,omitempty"`  // Binds .wake.target to this lock instance
+	Generation    string   `json:"generation,omitempty"`     // Random nonce binding readiness and exact cleanup to this instance
+	ControlSocket string   `json:"control_socket,omitempty"` // Darwin cooperative shutdown endpoint
 }
 
 type wakeProcessInfo struct {

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -31,8 +31,9 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	if recheck.Process.Running && recheck.Lock.WakeMode != wakeTargetInjectVia {
 		return false, fmt.Errorf("live raw wake orphan for %s (pid %d, start %s); stop the owning terminal/launchd supervisor; manual kill is non-identity-safe — recheck before running; see doctor --ops", recheck.Agent, recheck.PID, recheck.Lock.ProcessStart)
 	}
-	// W5a intentionally leaves live inject-via orphans on the legacy PID path;
-	// W5b replaces this with the nonce-bound control socket.
+	if recheck.Process.Running && recheck.Lock.WakeMode == wakeTargetInjectVia {
+		return cooperativeStopInjectVia(recheck)
+	}
 	// Process termination can wait. It must happen after releasing the guard.
 	if recheck.Process.Running {
 		if err := terminateWakeProcess(recheck); err != nil {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -186,6 +186,7 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 	if options.target != nil {
 		lock.WakeMode = wakeTargetInjectVia
 		lock.TargetDigest = wakeTargetDigest(*options.target)
+		lock.ControlSocket = wakeControlSocketPath(root, me, lock.Generation)
 	}
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
@@ -827,6 +828,17 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return err
 	}
 	defer cleanup()
+	var controlStop <-chan struct{}
+	if injectVia != "" {
+		current := inspectWakeLock(root, me)
+		controlCleanup, stop, markStopped, controlErr := startWakeControlListener(root, me, current.Lock)
+		if controlErr != nil {
+			return controlErr
+		}
+		defer controlCleanup()
+		defer markStopped()
+		controlStop = stop
+	}
 
 	if injectVia != "" {
 		if err := validateResolvedWakeInjectViaPath(injectVia); err != nil {
@@ -860,6 +872,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		interruptKey:      interruptKey,
 		interruptNotice:   strings.TrimSpace(*interruptNoticeFlag),
 		interruptCooldown: *interruptCooldownFlag,
+		controlStop:       controlStop,
 	}
 
 	if err := writeWakeReadyFile(root, me, readyFile, inspectWakeLock(root, me)); err != nil {
@@ -939,6 +952,8 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 
 		select {
+		case <-cfg.controlStop:
+			return nil
 		case <-sigCh:
 			// Clean exit on SIGHUP/SIGTERM
 			return nil

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1739,17 +1739,17 @@ func TestShouldReplaceOrphanedWakeLockSignalsOnlyAfterRevalidation(t *testing.T)
 
 	inspection := inspectWakeLock(root, "orchestrator")
 	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
-	if err != nil {
-		t.Fatalf("shouldReplaceOrphanedWakeLock: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "no cooperative control endpoint") {
+		t.Fatalf("expected missing-control refusal, got %v", err)
 	}
-	if !replaced {
-		t.Fatal("expected confirmed orphan to be replaced")
+	if replaced {
+		t.Fatal("legacy inject-via orphan must not be replaced by PID")
 	}
-	if len(signals) != 2 {
-		t.Fatalf("signals = %d, want SIGTERM and SIGKILL", len(signals))
+	if len(signals) != 0 {
+		t.Fatalf("signals = %d, want none", len(signals))
 	}
-	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Fatalf("lock should be removed after confirmed orphan replacement, stat=%v", err)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock should remain after refusal, stat=%v", err)
 	}
 }
 
@@ -2049,14 +2049,14 @@ func TestShouldReplaceOrphanedWakeLockReplacesInjectViaWhenOwnerGone(t *testing.
 
 	inspection := inspectWakeLock(root, "orchestrator")
 	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
-	if err != nil {
-		t.Fatalf("shouldReplaceOrphanedWakeLock: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "no cooperative control endpoint") {
+		t.Fatalf("expected missing-control refusal, got %v", err)
 	}
-	if !replaced {
-		t.Fatal("expected owner-dead inject-via wake to be replaced")
+	if replaced || killed {
+		t.Fatal("legacy inject-via wake must not be terminated by PID")
 	}
-	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Fatalf("lock should be removed after owner-dead replacement, stat=%v", err)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock should remain after refusal, stat=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wave 5b of #235 — completes Darwin bare-PID removal for the inject-via case. A managed inject-via wake creates a **nonce-bound unix-domain control socket** in its 0700 agent dir (path derived from the generation nonce; bound via a raw AF_UNIX socket + relative bind under a briefly-held `fchdir` so it stays under the 104-byte `sun_path` limit regardless of directory depth), stores the socket path in the 0600 lock, and listens. To stop it, the orphan-replacement path dials the socket, sends the generation nonce as a token; the wake verifies **peer euid (LOCAL_PEERCRED)** + token, then under the lifecycle guard removes its exact lock generation, **signals its run loop and waits for the loop to confirm it stopped injecting (`loopStopped`) before writing ACK**, then exits.

With W5a (raw orphans) + this, **no bare-PID TERM/KILL remains on Darwin**: proven-gone orphans remove cleanly, live raw orphans refuse, live inject-via orphans stop cooperatively (or refuse if there's no control endpoint — never bare-PID).

## Review

Reviewed against the security-critical properties (peer-euid check, token=generation-nonce, ACK-strictly-after-guarded-removal, guard never held across network I/O, stale-`.w.*`-socket sweep under the guard). Adversarial gate (Gemini 3.1 Pro) found three issues — process-wide `fchdir` held across blocking I/O, stale-socket leak on SIGKILL, ACK-before-loop-exit duplicate-injection window — **all three fixed** (raw bind/connect with cwd restored before net I/O; glob stale-socket cleanup; two-phase loop-exit-before-ACK). Full Darwin `go test`, `make ci`, and all four GOOS builds green. The ChatGPT-Pro gate re-runs at release time (currently blocked by an unrelated yoetz extension bug the yoetz team is fixing).

Part of #235. Implementation by Codex; design/review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)