### PR TITLE
feat(wake): add amq wake retire for identity-safe inject-via stop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,7 @@ amq dlq retry --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pi
 amq dlq purge --me <agent> [--session <name>] [--ignore-session-pin] [--older-than <duration>] [--dry-run] [--yes]
 amq wake --me <agent> [--inject-cmd <cmd>] [--inject-mode <auto|raw|paste|none>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>] [--interrupt] [--interrupt-label <label>] [--interrupt-priority <p>] [--interrupt-cmd <ctrl-c|none>] [--interrupt-notice <str>] [--interrupt-cooldown <duration>] [--debug]
 amq wake repair --me <agent> [--root <path>] [--json]
+amq wake retire --me <agent> --inject-via <absolute-executable> [--inject-arg <arg>...] [--root <path>] [--json]
 amq upgrade
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--export] [--session-name] [--json]
 amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>] [--grok-alias <name>]
@@ -368,6 +369,17 @@ Repaired wake stdout/stderr goes to
 pipes open after its JSON/text output exits. `doctor --ops` may report
 `target_present` and `repair_available`, but must remain diagnostic-only and
 never spawn a wake process.
+
+`amq wake retire` requires the expected inject-via executable and ordered fixed
+arguments. It stops only an identity-confirmed live inject-via wake with an
+unchanged, exactly matching saved target, using Linux pidfd signaling or the
+Darwin cooperative control socket; it may also remove an exactly-bound
+proven-stale lock. It preserves the mailbox and saved target. The lifecycle
+boundaries are: repair = replace a proven-stale inject-via wake; `doctor --ops
+--fix-wake-locks` = remove a proven-stale lock; retire = stop an
+identity-confirmed live inject-via wake; launchd, systemd, or the owning shell =
+stop a raw wake. Retire neither unloads supervisors nor promises that they will
+not restart a wake.
 
 `who` and `doctor --ops` presence sources have narrow semantics:
 `notifier_live` requires a valid wake lock with process identity confirmed by

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ amq doctor --ops
 amq doctor --ops --json
 amq doctor --ops --fix-wake-locks
 amq wake repair --me codex
+amq wake retire --me codex --inject-via /absolute/injector \
+  --inject-arg exec --inject-arg terminal-id
 ```
 
 Wake locks reported by `doctor --ops` can be `stale`, `unverified`, or, in JSON
@@ -218,6 +220,22 @@ locks, and `unverified` locks to avoid double-injecting into an active session
 or injecting into the wrong terminal. Repaired wake output goes to
 `agents/<agent>/.wake.repair.log`; `doctor --ops` can report whether repair is
 available, but it never starts a wake process.
+
+`amq wake retire` is the exact managed-shutdown path. It requires the caller's
+expected `--inject-via` executable and ordered `--inject-arg` values. A live
+wake is retired only when its process identity, unchanged lock generation, and
+saved target all match: Linux signals through its pidfd capability and macOS
+uses the generation-bound cooperative control socket. An exactly-bound
+proven-stale lock may be removed without signaling. The mailbox and saved
+target are preserved in either case; raw and unverified wakes fail closed.
+
+The lifecycle boundaries are:
+
+- repair = replace a proven-stale inject-via wake.
+- `doctor --ops --fix-wake-locks` = remove a proven-stale lock.
+- retire = stop an identity-confirmed live inject-via wake.
+- launchd, systemd, or the owning shell = stop a raw wake.
+- retire neither unloads supervisors nor promises that they will not restart a wake.
 
 `amq who` and `amq doctor --ops` distinguish two activity sources:
 
@@ -376,7 +394,7 @@ Common command groups:
 | Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `watch`, `monitor`, `receipts` |
 | Collaboration | `coop init`, `coop exec`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
-| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake repair`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
+| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake repair`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 
 For the full CLI syntax, examples, and message schema, see [CLAUDE.md](CLAUDE.md).
 

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -69,6 +69,7 @@ func init() {
 			Handler: runWake,
 			Children: []CommandInfo{
 				{Name: "repair", Summary: "Restart a proven-stale wake from a saved inject-via target", Handler: runWake},
+				{Name: "retire", Summary: "Stop an exact managed inject-via wake", Handler: runWake},
 			},
 		},
 		{Name: "upgrade", Summary: "Upgrade amq to the latest release", Handler: runUpgradeRegistry},

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -176,6 +176,24 @@ func TestGroupUsageLinesPresence(t *testing.T) {
 	}
 }
 
+func TestGroupUsageLinesWakeIncludesRetire(t *testing.T) {
+	wake := findCommand("wake")
+	if wake == nil {
+		t.Fatal("findCommand(wake) = nil")
+	}
+
+	lines, err := groupUsageLines(wake)
+	if err != nil {
+		t.Fatalf("groupUsageLines(wake): %v", err)
+	}
+	if !containsLine(lines, "repair  Restart a proven-stale wake from a saved inject-via target") {
+		t.Fatal("groupUsageLines(wake) missing repair subcommand")
+	}
+	if !containsLine(lines, "retire  Stop an exact managed inject-via wake") {
+		t.Fatal("groupUsageLines(wake) missing retire subcommand")
+	}
+}
+
 func TestPrintUsageRegistry(t *testing.T) {
 	output := captureRegistryStdout(t, func() error {
 		return printUsageRegistry()

--- a/internal/cli/wake_retire_darwin_test.go
+++ b/internal/cli/wake_retire_darwin_test.go
@@ -1,0 +1,42 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRetireWakeUsesDarwinCooperativeControlAndPreservesTarget(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, wakePID)
+	lock := inspectWakeLock(root, "codex").Lock
+	lock.ControlSocket = wakeControlSocketPath(root, "codex", lock.Generation)
+	writeWakeLockForTest(t, root, "codex", lock)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+
+	cleanup, stopRequested, markStopped, err := startWakeControlListener(root, "codex", lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	go func() {
+		<-stopRequested
+		markStopped()
+	}()
+
+	result, err := retireWake(root, "codex", requested)
+	if err != nil || result.Status != "retired" {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("wake lock still exists: %v", err)
+	}
+	if _, err := os.Stat(wakeTargetPath(root, "codex")); err != nil {
+		t.Fatalf("saved target was not preserved: %v", err)
+	}
+}

--- a/internal/cli/wake_retire_linux_test.go
+++ b/internal/cli/wake_retire_linux_test.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestRetireWakeUsesLinuxPidfdAndPreservesTarget(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, wakePID)
+	stopped := false
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if stopped {
+			return wakeProcessInfo{PID: pid, Running: false}
+		}
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	opened := false
+	stubLinuxPidfd(t,
+		func(pid, flags int) (int, error) {
+			if pid != wakePID || flags != 0 {
+				t.Fatalf("pidfd_open(%d,%d)", pid, flags)
+			}
+			opened = true
+			return 99, nil
+		},
+		func(fd int, sig unix.Signal, _ *unix.Siginfo, flags int) error {
+			if !opened || fd != 99 || sig != unix.SIGTERM || flags != 0 {
+				t.Fatalf("pidfd_send_signal(fd=%d,sig=%v,flags=%d), opened=%v", fd, sig, flags, opened)
+			}
+			stopped = true
+			return nil
+		},
+		func(fd int, _ time.Duration) (bool, error) {
+			if fd != 99 || !stopped {
+				t.Fatalf("pidfd poll before capability stop: fd=%d stopped=%v", fd, stopped)
+			}
+			return true, nil
+		},
+	)
+
+	result, err := retireWake(root, "codex", requested)
+	if err != nil || result.Status != "retired" {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("wake lock still exists: %v", err)
+	}
+	if _, err := os.Stat(wakeTargetPath(root, "codex")); err != nil {
+		t.Fatalf("saved target was not preserved: %v", err)
+	}
+}

--- a/internal/cli/wake_retire_unix.go
+++ b/internal/cli/wake_retire_unix.go
@@ -1,0 +1,192 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type wakeRetireResult struct {
+	Status string `json:"status"`
+	Agent  string `json:"agent"`
+	Root   string `json:"root"`
+	Lock   string `json:"lock"`
+	Target string `json:"target,omitempty"`
+	PID    int    `json:"pid,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+func runWakeRetire(args []string) error {
+	fs := flag.NewFlagSet("wake retire", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	injectViaFlag := fs.String("inject-via", "", "Expected external injection executable")
+	var injectArgFlags multiStringFlag
+	fs.Var(&injectArgFlags, "inject-arg", "Expected fixed injection argument (repeatable)")
+	usage := usageWithFlags(fs, "amq wake retire --me <agent> --inject-via <path> [options]",
+		"Stop an identity-confirmed live inject-via wake or remove its exactly-bound proven-stale lock.",
+		"",
+		"The expected executable and ordered arguments must exactly match the saved target.",
+		"Retirement preserves the mailbox and saved target and never stops raw wakes.")
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if err := requireMe(common.Me); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*injectViaFlag) == "" {
+		return UsageError("--inject-via is required")
+	}
+	me, err := normalizeHandle(common.Me)
+	if err != nil {
+		return UsageError("--me: %v", err)
+	}
+	root := resolveRoot(common.Root)
+	if err := validateKnownHandles(root, common.Strict, me); err != nil {
+		return err
+	}
+	requested, err := newWakeTarget(root, me, *injectViaFlag, []string(injectArgFlags))
+	if err != nil {
+		return UsageError("--inject-via: %v", err)
+	}
+	result, retireErr := retireWake(root, me, requested)
+	if common.JSON {
+		if err := writeJSON(os.Stdout, result); err != nil {
+			return err
+		}
+		return retireErr
+	}
+	line := fmt.Sprintf("wake retire: %s agent=%s root=%s", result.Status, result.Agent, result.Root)
+	if result.PID != 0 {
+		line += fmt.Sprintf(" pid=%d", result.PID)
+	}
+	if result.Reason != "" {
+		line += " reason=" + result.Reason
+	}
+	if err := writeStdoutLine(line); err != nil {
+		return err
+	}
+	return retireErr
+}
+
+func retireWake(root, me string, requested wakeTarget) (wakeRetireResult, error) {
+	result := wakeRetireResult{
+		Status: "unknown",
+		Agent:  me,
+		Root:   canonicalWakeRoot(root),
+		Lock:   filepath.Join(fsq.AgentBase(root, me), ".wake.lock"),
+		Target: wakeTargetPath(root, me),
+	}
+	refuse := func(reason string) (wakeRetireResult, error) {
+		result.Status = "refused"
+		result.Reason = reason
+		return result, errors.New(reason)
+	}
+	fail := func(err error) (wakeRetireResult, error) {
+		result.Status = "error"
+		result.Reason = err.Error()
+		return result, err
+	}
+
+	inspection := inspectWakeLock(root, me)
+	if !inspection.Exists {
+		return refuse("no wake lock present; wake process absence cannot be proven")
+	}
+	result.PID = inspection.PID
+
+	switch inspection.Status {
+	case wakeLockValid:
+		if !inspection.IdentityConfirmed {
+			return refuse("wake process identity is not confirmed")
+		}
+		if inspection.Lock.WakeMode != wakeTargetInjectVia {
+			return refuse("live raw wake retirement is owned by its terminal or supervisor")
+		}
+
+		var confirmed wakeLockInspection
+		if err := withWakeLifecycleGuard(root, me, func() error {
+			confirmed = inspectWakeLock(root, me)
+			if !sameWakeLockInspection(inspection, confirmed) || !confirmed.IdentityConfirmed {
+				return errors.New("wake lock changed before retirement")
+			}
+			return requireExistingWakeTargetMatches(confirmed, requested)
+		}); err != nil {
+			return refuse(err.Error())
+		}
+
+		retired, err := terminateAndRemoveOrphanedWakeLock(confirmed)
+		if err != nil {
+			return fail(err)
+		}
+		if !retired {
+			return refuse("wake lock or process identity changed before retirement")
+		}
+		result.Status = "retired"
+		result.Reason = "live inject-via wake stopped; mailbox and saved target preserved"
+		return result, nil
+
+	case wakeLockStale:
+		removeFailed := false
+		err := withWakeLifecycleGuard(root, me, func() error {
+			current := inspectWakeLock(root, me)
+			if !sameWakeLockGeneration(inspection, current) || current.Status != wakeLockStale {
+				return errors.New("wake lock changed before retirement")
+			}
+			if err := validateWakeLockStaleRemoval(current); err != nil {
+				return err
+			}
+			if err := requireExistingWakeTargetMatches(current, requested); err != nil {
+				return err
+			}
+			if err := removeWakeLockIfUnchangedGuarded(current); err != nil {
+				removeFailed = true
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			if removeFailed {
+				return fail(err)
+			}
+			return refuse(err.Error())
+		}
+		result.Status = "retired"
+		result.Reason = "exactly-bound proven-stale wake lock removed; mailbox and saved target preserved"
+		return result, nil
+
+	case wakeLockCreating:
+		return refuse("wake lock is being created; retry shortly")
+	case wakeLockUnverified:
+		return refuse("wake lock is unverified; refusing retirement: " + inspection.Reason)
+	default:
+		return refuse(fmt.Sprintf("wake lock status %q cannot be retired", inspection.Status))
+	}
+}
+
+func requireExistingWakeTargetMatches(inspection wakeLockInspection, requested wakeTarget) error {
+	persisted, exists, err := readWakeTarget(inspection.Root, inspection.Agent)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return errors.New("no saved inject-via wake target; refusing retirement")
+	}
+	if err := validateWakeTarget(persisted, inspection.Root, inspection.Agent); err != nil {
+		return err
+	}
+	if err := validateWakeTargetMatchesLock(inspection.Lock, persisted); err != nil {
+		return err
+	}
+	if !sameWakeInjectorIdentity(persisted, requested) {
+		return errors.New("saved wake target uses a different injector path or fixed arguments")
+	}
+	return nil
+}

--- a/internal/cli/wake_retire_unix_test.go
+++ b/internal/cli/wake_retire_unix_test.go
@@ -1,0 +1,174 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func installRetireWakeFixture(t *testing.T, root, me, injector string, args []string, pid int) (wakeTarget, string) {
+	t.Helper()
+	target := mustNewWakeTargetForTest(t, root, me, injector, args)
+	if err := writeWakeTarget(root, me, target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	lockPath := writeWakeLockForTest(t, root, me, bindWakeLockToTarget(wakeLock{
+		PID:          pid,
+		TTY:          "unknown",
+		ProcessStart: "wake-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", me, "--inject-via", injector},
+		Generation:   "0123456789abcdef0123456789abcdef",
+	}, target))
+	return target, lockPath
+}
+
+func matchingRetireWakeProcess(pid int, root, me, injector string) wakeProcessInfo {
+	return wakeProcessInfo{
+		PID:        pid,
+		Running:    true,
+		StartToken: "wake-start",
+		BootID:     "boot-1",
+		Executable: "/opt/homebrew/bin/amq",
+		Args:       []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", me, "--inject-via", injector},
+	}
+}
+
+func TestRetireWakeRefusesLiveRawWake(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "/dev/ttys001",
+		ProcessStart: "wake-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "0123456789abcdef0123456789abcdef",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	requested := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+
+	result, err := retireWake(root, "codex", requested)
+	if err == nil || result.Status != "refused" || !strings.Contains(result.Reason, "raw wake") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("raw wake lock changed: %v", err)
+	}
+}
+
+func TestRetireWakeRefusesDifferentInjectTarget(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	_, lockPath := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, wakePID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	requested := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-b"})
+
+	result, err := retireWake(root, "codex", requested)
+	if err == nil || result.Status != "refused" || !strings.Contains(result.Reason, "different injector") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("mismatched wake lock changed: %v", err)
+	}
+}
+
+func TestRetireWakeRemovesExactlyBoundProvenStaleLock(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, wakePID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	result, err := retireWake(root, "codex", requested)
+	if err != nil || result.Status != "retired" || !strings.Contains(result.Reason, "proven-stale") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale lock still exists: %v", err)
+	}
+	if _, err := os.Stat(wakeTargetPath(root, "codex")); err != nil {
+		t.Fatalf("saved target was not preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentBase(root, "codex"), "inbox")); err != nil {
+		t.Fatalf("mailbox was not preserved: %v", err)
+	}
+}
+
+func TestRetireWakeRefusesMissingSavedTarget(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-a"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID: wakePID, ProcessStart: "wake-start", BootID: "boot-1", Generation: "0123456789abcdef0123456789abcdef",
+	}, requested))
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+
+	result, err := retireWake(root, "codex", requested)
+	if err == nil || result.Status != "refused" || !strings.Contains(result.Reason, "no saved inject-via wake target") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock changed after missing-target refusal: %v", err)
+	}
+}
+
+func TestRunWakeRetireRequiresExpectedInjectVia(t *testing.T) {
+	err := runWake([]string{"retire", "--root", secureTempDirForTest(t), "--me", "codex"})
+	if err == nil || !strings.Contains(err.Error(), "--inject-via is required") {
+		t.Fatalf("runWake retire error = %v", err)
+	}
+}
+
+func TestRunWakeRetireJSONReportsRefusal(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+		return runWake([]string{"retire", "--root", root, "--me", "codex", "--inject-via", injector, "--json"})
+	})
+	if runErr == nil {
+		t.Fatal("missing wake lock unexpectedly retired")
+	}
+	var result wakeRetireResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\nstdout=%s", err, stdout)
+	}
+	if result.Status != "refused" || result.Agent != "codex" || result.Root != canonicalWakeRoot(root) {
+		t.Fatalf("result=%#v", result)
+	}
+}
+
+func TestRunWakeRetireTextReportsRefusal(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+		return runWake([]string{"retire", "--root", root, "--me", "codex", "--inject-via", injector})
+	})
+	if runErr == nil {
+		t.Fatal("missing wake lock unexpectedly retired")
+	}
+	if !strings.Contains(stdout, "wake retire: refused agent=codex") ||
+		!strings.Contains(stdout, "reason=no wake lock present") {
+		t.Fatalf("stdout=%q", stdout)
+	}
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -367,8 +367,13 @@ func processAlive(pid int) bool {
 type wakeLoopFunc func(wakeConfig) error
 
 func runWake(args []string) error {
-	if len(args) > 0 && args[0] == "repair" {
-		return runWakeRepair(args[1:])
+	if len(args) > 0 {
+		switch args[0] {
+		case "repair":
+			return runWakeRepair(args[1:])
+		case "retire":
+			return runWakeRetire(args[1:])
+		}
 	}
 	return runWakeWithLoop(args, runWakeLoop)
 }


### PR DESCRIPTION
## Summary

Wave 6 of #235 — reintroduces `amq wake retire` on the identity-safe primitives now in place (deferred out of #232 until the signal-safety work landed). Retires **only** an identity-confirmed live inject-via wake whose saved target exactly matches the expected `--inject-via` + ordered `--inject-arg`, using the W4 Linux-pidfd / W5b Darwin-cooperative stop — **never bare-PID** — or removes an exactly-bound proven-stale lock. Preserves the mailbox and saved target. Structured `retired`/`refused`/`error` output (JSON + text).

## Boundary (documented in CLAUDE.md/README)

- `repair` = replace a proven-stale inject-via wake
- `doctor --fix-wake-locks` = remove a proven-stale lock
- `retire` = stop an identity-confirmed **live** inject-via wake
- launchd/systemd/shell owns raw-wake stop; retire refuses raw wakes, never unloads supervisors, and makes no promise against restart

## Fail-closed refusals

Missing lock (absence unprovable), raw wake, unconfirmed identity, unverified/creating lock, missing saved target, and any injector path/argv mismatch all refuse. The stop path runs under the lifecycle guard for validation and releases it for the actual cooperative/pidfd stop.

## Review

`amq wake retire` dispatch runtime-verified (`runWake` → `case "retire"` → `runWakeRetire`; executes, not the generic loop — closing the exact gap #245's keepalive hit). Tests: Darwin cooperative retire + target preservation, Linux pidfd retire (CI-only), raw refusal, exact-target-mismatch refusal, proven-stale removal, missing-target refusal, JSON+text output. `make ci` (incl golangci-lint 0 issues) + all four GOOS builds green.

Part of #235. Implementation by Codex; design/review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)