### PR TITLE
feat(fsq): fd-confined message delivery via os.Root capability

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,20 @@ AMQ does **not** protect against:
 - **Malicious agents with same-user access**: If an attacker has shell access as the same user, they can read/write queue files directly
 - **Multi-user scenarios**: AMQ is not designed for use across user accounts
 
+### Rooted Delivery Boundary
+
+After `send` or `reply` authorizes a source and destination tree, AMQ opens each
+tree once with Go's `os.Root` and performs mailbox delivery, directory sync,
+presence touch, and outbox writes relative to that pinned directory capability.
+Replacing the authorized path or one of its ancestors with a symlink cannot
+redirect those writes outside the opened tree. Relative symlinks that remain
+inside the tree continue to work; symlinks that escape it are refused.
+
+This boundary does not defend against filesystem namespace changes below an
+already opened root, including privileged bind mounts, or against writing to
+pre-existing device files. Those cases require separate mount and file-type
+hardening and remain outside the rooted-delivery guarantee.
+
 ### Known Risks
 
 #### TIOCSTI Terminal Injection (`amq wake`)

--- a/internal/cli/consume_session_guard_test.go
+++ b/internal/cli/consume_session_guard_test.go
@@ -623,7 +623,16 @@ func deliverGuardMessageError(root, agent, id string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := fsq.DeliverToInbox(root, agent, id+".md", data); err != nil {
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		return err
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+	if _, err := fsq.DeliverToInbox(deliveryRoot, agent, id+".md", data); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cli/delivery_root.go
+++ b/internal/cli/delivery_root.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func snapshotMailboxDeliveryRoot(root string, routed, ignorePin bool) (fsq.DeliveryRootIdentity, error) {
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		return fsq.DeliveryRootIdentity{}, err
+	}
+	if routed || ignorePin {
+		return identity, nil
+	}
+	pin, err := loadSessionPin()
+	if err != nil {
+		return fsq.DeliveryRootIdentity{}, err
+	}
+	if pin.IdentityPin && verifyTreeIdentityInfo(identity.FileInfo(), pin.RootID) != TreeRelationSame {
+		return fsq.DeliveryRootIdentity{}, ContextMismatchError("authorized mailbox root identity changed before capability open")
+	}
+	return identity, nil
+}

--- a/internal/cli/delivery_root_test.go
+++ b/internal/cli/delivery_root_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func openDeliveryRootForCLITest(t testing.TB, base string) *fsq.DeliveryRoot {
+	t.Helper()
+	identity, err := fsq.SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot(%s): %v", base, err)
+	}
+	root, err := fsq.OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot(%s): %v", base, err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return root
+}
+
+func deliverToInboxForTest(t testing.TB, base, agent, filename string, data []byte) (string, error) {
+	t.Helper()
+	identity, err := fsq.SnapshotDeliveryRoot(base)
+	if err != nil {
+		return "", err
+	}
+	root, err := fsq.OpenDeliveryRoot(base, identity)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = root.Close() }()
+	return fsq.DeliverToInbox(root, agent, filename, data)
+}
+
+func deliverToInboxesForTest(t testing.TB, base string, recipients []string, filename string, data []byte) (map[string]string, error) {
+	t.Helper()
+	identity, err := fsq.SnapshotDeliveryRoot(base)
+	if err != nil {
+		return nil, err
+	}
+	root, err := fsq.OpenDeliveryRoot(base, identity)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = root.Close() }()
+	return fsq.DeliverToInboxes(root, recipients, filename, data)
+}

--- a/internal/cli/dlq.go
+++ b/internal/cli/dlq.go
@@ -103,7 +103,7 @@ func runDLQList(args []string) error {
 				continue
 			}
 			path := filepath.Join(dir, entry.Name())
-			env, _, err := fsq.ReadDLQEnvelope(path)
+			env, _, err := fsq.ReadDLQEnvelopePath(path)
 			if err != nil {
 				_ = writeStderr("warning: skipping corrupt DLQ message %s: %v\n", entry.Name(), err)
 				continue
@@ -202,6 +202,10 @@ func runDLQRead(args []string) error {
 	if err := guardMailboxContext("dlq read", root, routed, *ignoreSessionPinFlag); err != nil {
 		return err
 	}
+	deliveryIdentity, err := snapshotMailboxDeliveryRoot(root, routed, *ignoreSessionPinFlag)
+	if err != nil {
+		return err
+	}
 	if err := requireMailbox(root, me); err != nil {
 		return err
 	}
@@ -209,13 +213,18 @@ func runDLQRead(args []string) error {
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
 	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, deliveryIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
 
 	filename, err := ensureFilename(*idFlag)
 	if err != nil {
 		return UsageError("--id: %v", err)
 	}
 
-	path, box, err := fsq.FindDLQMessage(root, me, filename)
+	path, box, err := fsq.FindDLQMessage(deliveryRoot, me, filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("DLQ message not found: %s", *idFlag)
@@ -223,14 +232,14 @@ func runDLQRead(args []string) error {
 		return err
 	}
 
-	env, originalContent, err := fsq.ReadDLQEnvelope(path)
+	env, originalContent, err := fsq.ReadDLQEnvelope(deliveryRoot, path)
 	if err != nil {
 		return fmt.Errorf("read DLQ message: %w", err)
 	}
 
 	// Move to cur if in new
 	if box == fsq.BoxNew {
-		if err := fsq.MoveDLQNewToCur(root, me, filename); err != nil {
+		if err := fsq.MoveDLQNewToCur(deliveryRoot, me, filename); err != nil {
 			_ = writeStderr("warning: failed to move DLQ message to cur: %v\n", err)
 		}
 	}
@@ -321,6 +330,10 @@ func runDLQRetry(args []string) error {
 	if err := guardMailboxContext("dlq retry", root, routed, *ignoreSessionPinFlag); err != nil {
 		return err
 	}
+	deliveryIdentity, err := snapshotMailboxDeliveryRoot(root, routed, *ignoreSessionPinFlag)
+	if err != nil {
+		return err
+	}
 	if err := requireMailbox(root, me); err != nil {
 		return err
 	}
@@ -328,9 +341,14 @@ func runDLQRetry(args []string) error {
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
 	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, deliveryIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
 
 	if *allFlag {
-		return retryAllDLQ(root, me, *forceFlag, common.JSON)
+		return retryAllDLQ(deliveryRoot, me, *forceFlag, common.JSON)
 	}
 
 	filename, err := ensureFilename(*idFlag)
@@ -338,7 +356,7 @@ func runDLQRetry(args []string) error {
 		return UsageError("--id: %v", err)
 	}
 
-	if err := fsq.RetryFromDLQ(root, me, filename, *forceFlag); err != nil {
+	if err := fsq.RetryFromDLQ(deliveryRoot, me, filename, *forceFlag); err != nil {
 		return err
 	}
 
@@ -350,9 +368,9 @@ func runDLQRetry(args []string) error {
 	return writeStdout("Retried: %s\n", *idFlag)
 }
 
-func retryAllDLQ(root, me string, force, jsonOutput bool) error {
-	dir := fsq.AgentDLQNew(root, me)
-	entries, err := os.ReadDir(dir)
+func retryAllDLQ(root *fsq.DeliveryRoot, me string, force, jsonOutput bool) error {
+	dir := filepath.Join("agents", me, "dlq", "new")
+	entries, err := root.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			if jsonOutput {
@@ -425,6 +443,10 @@ func runDLQPurge(args []string) error {
 	if err := guardMailboxContext("dlq purge", root, routed, *ignoreSessionPinFlag); err != nil {
 		return err
 	}
+	deliveryIdentity, err := snapshotMailboxDeliveryRoot(root, routed, *ignoreSessionPinFlag)
+	if err != nil {
+		return err
+	}
 	if err := requireMailbox(root, me); err != nil {
 		return err
 	}
@@ -432,6 +454,11 @@ func runDLQPurge(args []string) error {
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
 	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, deliveryIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
 
 	var cutoff time.Time
 	if *olderFlag != "" {
@@ -450,11 +477,11 @@ func runDLQPurge(args []string) error {
 	for _, box := range []string{"new", "cur"} {
 		var dir string
 		if box == "new" {
-			dir = fsq.AgentDLQNew(root, me)
+			dir = filepath.Join("agents", me, "dlq", "new")
 		} else {
-			dir = fsq.AgentDLQCur(root, me)
+			dir = filepath.Join("agents", me, "dlq", "cur")
 		}
-		entries, err := os.ReadDir(dir)
+		entries, err := deliveryRoot.ReadDir(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
@@ -467,7 +494,7 @@ func runDLQPurge(args []string) error {
 			}
 			path := filepath.Join(dir, entry.Name())
 			if !cutoff.IsZero() {
-				env, _, err := fsq.ReadDLQEnvelope(path)
+				env, _, err := fsq.ReadDLQEnvelope(deliveryRoot, path)
 				if err != nil {
 					// Can't parse, include anyway
 					candidates = append(candidates, path)
@@ -491,13 +518,17 @@ func runDLQPurge(args []string) error {
 
 	if *dryRunFlag {
 		if common.JSON {
-			return writeJSON(os.Stdout, map[string]any{"candidates": candidates, "count": len(candidates)})
+			displayCandidates := make([]string, len(candidates))
+			for i, path := range candidates {
+				displayCandidates[i] = deliveryRoot.DisplayPath(path)
+			}
+			return writeJSON(os.Stdout, map[string]any{"candidates": displayCandidates, "count": len(candidates)})
 		}
 		if err := writeStdout("Would remove %d DLQ message(s):\n", len(candidates)); err != nil {
 			return err
 		}
 		for _, path := range candidates {
-			if err := writeStdout("  %s\n", path); err != nil {
+			if err := writeStdout("  %s\n", deliveryRoot.DisplayPath(path)); err != nil {
 				return err
 			}
 		}
@@ -516,13 +547,18 @@ func runDLQPurge(args []string) error {
 
 	removed := 0
 	for _, path := range candidates {
-		if err := os.Remove(path); err != nil {
+		if err := deliveryRoot.Remove(path); err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
 			_ = writeStderr("warning: failed to remove %s: %v\n", path, err)
 		} else {
 			removed++
+		}
+	}
+	for _, dir := range []string{filepath.Join("agents", me, "dlq", "new"), filepath.Join("agents", me, "dlq", "cur")} {
+		if err := deliveryRoot.SyncDir(dir); err != nil && !os.IsNotExist(err) {
+			return err
 		}
 	}
 

--- a/internal/cli/drain.go
+++ b/internal/cli/drain.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"github.com/avivsinai/agent-message-queue/internal/presence"
 )
 
@@ -49,6 +50,10 @@ func runDrain(args []string) error {
 	if err := guardMailboxContext("drain", root, routed, *ignoreSessionPinFlag); err != nil {
 		return err
 	}
+	deliveryIdentity, err := snapshotMailboxDeliveryRoot(root, routed, *ignoreSessionPinFlag)
+	if err != nil {
+		return err
+	}
 	if err := requireMailbox(root, me); err != nil {
 		emitSiblingBacklogHintsIfInboxEmpty(root, me)
 		return err
@@ -61,8 +66,13 @@ func runDrain(args []string) error {
 	if err != nil {
 		return err
 	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, deliveryIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
 
-	items, err := drainInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator)
+	items, err := drainInboxItems(deliveryRoot, root, common.Me, *includeBodyFlag, *limitFlag, validator)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return NotFoundError("mailbox for %q disappeared while draining root %s", common.Me, root)
@@ -81,7 +91,7 @@ func runDrain(args []string) error {
 	}
 
 	// Best-effort presence touch.
-	_ = presence.Touch(root, common.Me)
+	_ = presence.TouchDeliveryRoot(deliveryRoot, common.Me)
 
 	if common.JSON {
 		return writeJSON(os.Stdout, drainResult{Drained: items, Count: len(items)})

--- a/internal/cli/drain_test.go
+++ b/internal/cli/drain_test.go
@@ -71,7 +71,7 @@ func TestRunDrainMovesToCur(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "test-msg-1.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "test-msg-1.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 
@@ -151,7 +151,7 @@ func TestRunDrainStrictAllowsReservedUserInbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "user", "operator-gate.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "user", "operator-gate.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 
@@ -214,7 +214,7 @@ func TestRunDrainWithBody(t *testing.T) {
 		Body: "This is the message body.",
 	}
 	data, _ := msg.Marshal()
-	if _, err := fsq.DeliverToInbox(root, "alice", "body-test.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "body-test.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 
@@ -230,7 +230,7 @@ func TestRunDrainWithBody(t *testing.T) {
 		if err := fsq.EnsureAgentDirs(root, "bob"); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := fsq.DeliverToInbox(root, "alice", "body-test.md", data); err != nil {
+		if _, err := deliverToInboxForTest(t, root, "alice", "body-test.md", data); err != nil {
 			t.Fatal(err)
 		}
 
@@ -251,7 +251,7 @@ func TestRunDrainWithBody(t *testing.T) {
 		if err := fsq.EnsureAgentDirs(root, "bob"); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := fsq.DeliverToInbox(root, "alice", "body-test.md", data); err != nil {
+		if _, err := deliverToInboxForTest(t, root, "alice", "body-test.md", data); err != nil {
 			t.Fatal(err)
 		}
 
@@ -289,7 +289,7 @@ func TestRunDrainLimit(t *testing.T) {
 			Body: "body",
 		}
 		data, _ := msg.Marshal()
-		if _, err := fsq.DeliverToInbox(root, "alice", "msg-"+string(rune('a'+i))+".md", data); err != nil {
+		if _, err := deliverToInboxForTest(t, root, "alice", "msg-"+string(rune('a'+i))+".md", data); err != nil {
 			t.Fatalf("deliver msg %d: %v", i, err)
 		}
 	}
@@ -341,11 +341,12 @@ func TestDrainInboxItemsConcurrentClaimsSingleWinner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "claim-once.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "claim-once.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 
 	const workers = 2
+	deliveryRoot := openDeliveryRootForCLITest(t, root)
 	start := make(chan struct{})
 	results := make(chan []inboxItem, workers)
 	errs := make(chan error, workers)
@@ -356,7 +357,7 @@ func TestDrainInboxItemsConcurrentClaimsSingleWinner(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			items, err := drainInboxItems(root, "alice", false, 0, &headerValidator{})
+			items, err := drainInboxItems(deliveryRoot, root, "alice", false, 0, &headerValidator{})
 			if err != nil {
 				errs <- err
 				return
@@ -410,7 +411,7 @@ func TestClaimMailboxDirsExistRejectsMissingCur(t *testing.T) {
 		t.Fatalf("remove inbox/cur: %v", err)
 	}
 
-	exists, err := claimMailboxDirsExist(root, "alice")
+	exists, err := claimMailboxDirsExist(openDeliveryRootForCLITest(t, root), "alice")
 	if err != nil {
 		t.Fatalf("claimMailboxDirsExist: %v", err)
 	}
@@ -508,7 +509,7 @@ func TestRunDrainSorting(t *testing.T) {
 			Body: "body",
 		}
 		data, _ := msg.Marshal()
-		if _, err := fsq.DeliverToInbox(root, "alice", "msg-"+string(rune('a'+i))+".md", data); err != nil {
+		if _, err := deliverToInboxForTest(t, root, "alice", "msg-"+string(rune('a'+i))+".md", data); err != nil {
 			t.Fatalf("deliver msg %d: %v", i, err)
 		}
 	}

--- a/internal/cli/inbox_collect.go
+++ b/internal/cli/inbox_collect.go
@@ -14,7 +14,7 @@ import (
 
 // drainInboxItems claims inbox/new messages before parsing them, then emits
 // output items and receipts only for messages this process actually claimed.
-func drainInboxItems(root, me string, includeBody bool, limit int, validator *headerValidator) ([]inboxItem, error) {
+func drainInboxItems(deliveryRoot *fsq.DeliveryRoot, root, me string, includeBody bool, limit int, validator *headerValidator) ([]inboxItem, error) {
 	filenames, err := collectInboxFilenames(root, me)
 	if err != nil {
 		return nil, err
@@ -29,9 +29,9 @@ func drainInboxItems(root, me string, includeBody bool, limit int, validator *he
 		if limit > 0 && len(items) >= limit {
 			break
 		}
-		if err := fsq.MoveNewToCur(root, me, filename); err != nil {
+		if err := fsq.MoveNewToCur(deliveryRoot, me, filename); err != nil {
 			if os.IsNotExist(err) {
-				exists, checkErr := claimMailboxDirsExist(root, me)
+				exists, checkErr := claimMailboxDirsExist(deliveryRoot, me)
 				if checkErr != nil {
 					return nil, checkErr
 				}
@@ -52,18 +52,18 @@ func drainInboxItems(root, me string, includeBody bool, limit int, validator *he
 			if reason == "" {
 				reason = "parse_error"
 			}
-			if _, err := fsq.MoveCurToDLQ(root, me, item.Filename, item.ID, reason, item.ParseError); err != nil {
+			if _, err := fsq.MoveCurToDLQ(deliveryRoot, me, item.Filename, item.ID, reason, item.ParseError); err != nil {
 				_ = writeStderr("warning: failed to move %s to DLQ: %v\n", item.Filename, err)
 			} else {
 				item.MovedToDLQ = true
-				emitReceipt(root, me, &item, receipt.StageDLQ, item.ParseError)
+				emitReceipt(deliveryRoot, me, &item, receipt.StageDLQ, item.ParseError)
 			}
 			items = append(items, item)
 			continue
 		}
 
 		item.MovedToCur = true
-		emitReceipt(root, me, &item, receipt.StageDrained, "")
+		emitReceipt(deliveryRoot, me, &item, receipt.StageDrained, "")
 		items = append(items, item)
 	}
 
@@ -71,9 +71,9 @@ func drainInboxItems(root, me string, includeBody bool, limit int, validator *he
 	return items, nil
 }
 
-func claimMailboxDirsExist(root, me string) (bool, error) {
-	for _, dir := range []string{fsq.AgentInboxNew(root, me), fsq.AgentInboxCur(root, me)} {
-		info, err := os.Stat(dir)
+func claimMailboxDirsExist(root *fsq.DeliveryRoot, me string) (bool, error) {
+	for _, dir := range []string{filepath.Join("agents", me, "inbox", "new"), filepath.Join("agents", me, "inbox", "cur")} {
+		info, err := root.Stat(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return false, nil
@@ -87,7 +87,7 @@ func claimMailboxDirsExist(root, me string) (bool, error) {
 	return true, nil
 }
 
-func emitReceipt(root, consumer string, item *inboxItem, stage, detail string) {
+func emitReceipt(root *fsq.DeliveryRoot, consumer string, item *inboxItem, stage, detail string) {
 	sender, err := normalizeHandle(item.From)
 	if err != nil {
 		sender = ""
@@ -95,7 +95,7 @@ func emitReceipt(root, consumer string, item *inboxItem, stage, detail string) {
 	}
 
 	r := receipt.New(item.ID, item.Thread, sender, consumer, stage, detail)
-	if err := receipt.Emit(root, r); err != nil {
+	if err := receipt.EmitDeliveryRoot(root, r); err != nil {
 		_ = writeStderr("warning: failed to emit %s receipt for %s: %v\n", stage, item.ID, err)
 	}
 }

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -41,7 +41,7 @@ func TestRunListPagination(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal msg %d: %v", i, err)
 		}
-		if _, err := fsq.DeliverToInbox(root, "alice", "msg-"+string(rune('a'+i))+".md", data); err != nil {
+		if _, err := deliverToInboxForTest(t, root, "alice", "msg-"+string(rune('a'+i))+".md", data); err != nil {
 			t.Fatalf("deliver msg %d: %v", i, err)
 		}
 	}

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -67,6 +67,10 @@ func runMonitor(args []string) error {
 	if err := guardMailboxContext("monitor", root, routed, *ignoreSessionPinFlag); err != nil {
 		return err
 	}
+	deliveryIdentity, err := snapshotMailboxDeliveryRoot(root, routed, *ignoreSessionPinFlag)
+	if err != nil {
+		return err
+	}
 	if err := requireMailbox(root, me); err != nil {
 		return err
 	}
@@ -78,6 +82,11 @@ func runMonitor(args []string) error {
 	if err != nil {
 		return err
 	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, deliveryIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
 
 	inboxNew := fsq.AgentInboxNew(root, common.Me)
 
@@ -89,7 +98,7 @@ func runMonitor(args []string) error {
 	}
 
 	// First, try to drain existing messages
-	items, err := monitorInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator, mode)
+	items, err := monitorInboxItems(deliveryRoot, root, common.Me, *includeBodyFlag, *limitFlag, validator, mode)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return NotFoundError("mailbox for %q disappeared while monitoring root %s", common.Me, root)
@@ -153,7 +162,7 @@ func runMonitor(args []string) error {
 	if err := requireMailbox(root, me); err != nil {
 		return err
 	}
-	items, err = monitorInboxItems(root, common.Me, *includeBodyFlag, *limitFlag, validator, mode)
+	items, err = monitorInboxItems(deliveryRoot, root, common.Me, *includeBodyFlag, *limitFlag, validator, mode)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return NotFoundError("mailbox for %q disappeared while monitoring root %s", common.Me, root)
@@ -178,11 +187,11 @@ func runMonitor(args []string) error {
 	return outputMonitorResult(common.JSON, result)
 }
 
-func monitorInboxItems(root, me string, includeBody bool, limit int, validator *headerValidator, mode string) ([]monitorItem, error) {
+func monitorInboxItems(deliveryRoot *fsq.DeliveryRoot, root, me string, includeBody bool, limit int, validator *headerValidator, mode string) ([]monitorItem, error) {
 	if mode == "peek" {
 		return collectInboxItems(root, me, includeBody, limit, validator)
 	}
-	return drainInboxItems(root, me, includeBody, limit, validator)
+	return drainInboxItems(deliveryRoot, root, me, includeBody, limit, validator)
 }
 
 func monitorWithFsnotify(ctx context.Context, inboxNew string) (string, error) {

--- a/internal/cli/monitor_test.go
+++ b/internal/cli/monitor_test.go
@@ -41,7 +41,7 @@ func TestMonitor_ExistingMessages(t *testing.T) {
 	}
 	data, _ := msg.Marshal()
 	filename := id + ".md"
-	if _, err := fsq.DeliverToInboxes(root, []string{agent}, filename, data); err != nil {
+	if _, err := deliverToInboxesForTest(t, root, []string{agent}, filename, data); err != nil {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 
@@ -149,7 +149,7 @@ func TestMonitor_PeekDoesNotDrain(t *testing.T) {
 	}
 	data, _ := msg.Marshal()
 	filename := id + ".md"
-	if _, err := fsq.DeliverToInboxes(root, []string{agent}, filename, data); err != nil {
+	if _, err := deliverToInboxesForTest(t, root, []string{agent}, filename, data); err != nil {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 
@@ -305,7 +305,7 @@ func TestMonitor_SessionInJSON(t *testing.T) {
 		Body: "Test message in session.",
 	}
 	data, _ := msg.Marshal()
-	if _, err := fsq.DeliverToInboxes(sessionRoot, []string{agent}, id+".md", data); err != nil {
+	if _, err := deliverToInboxesForTest(t, sessionRoot, []string{agent}, id+".md", data); err != nil {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 
@@ -365,7 +365,7 @@ func TestMonitor_NoSessionForPlainRoot(t *testing.T) {
 		Body: "Test.",
 	}
 	data, _ := msg.Marshal()
-	if _, err := fsq.DeliverToInboxes(root, []string{agent}, id+".md", data); err != nil {
+	if _, err := deliverToInboxesForTest(t, root, []string{agent}, id+".md", data); err != nil {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 
@@ -428,7 +428,7 @@ func TestMonitor_PriorityInOutput(t *testing.T) {
 			Body: "Test",
 		}
 		data, _ := msg.Marshal()
-		_, _ = fsq.DeliverToInboxes(root, []string{agent}, id+".md", data)
+		_, _ = deliverToInboxesForTest(t, root, []string{agent}, id+".md", data)
 	}
 
 	// Capture output

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -47,6 +47,10 @@ func runRead(args []string) error {
 	if err := guardMailboxContext("read", root, routed, *ignoreSessionPinFlag); err != nil {
 		return err
 	}
+	deliveryIdentity, err := snapshotMailboxDeliveryRoot(root, routed, *ignoreSessionPinFlag)
+	if err != nil {
+		return err
+	}
 	if err := requireMailbox(root, me); err != nil {
 		return err
 	}
@@ -59,6 +63,11 @@ func runRead(args []string) error {
 	if err != nil {
 		return err
 	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, deliveryIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
 
 	filename, err := ensureFilename(*idFlag)
 	if err != nil {
@@ -78,23 +87,23 @@ func runRead(args []string) error {
 	if err != nil {
 		// If message is corrupt and in new, move to DLQ
 		if box == fsq.BoxNew {
-			moveReadFailureToDLQ(root, common.Me, filename, *idFlag, "parse_error", err.Error(), nil)
+			moveReadFailureToDLQ(deliveryRoot, common.Me, filename, *idFlag, "parse_error", err.Error(), nil)
 		}
 		return fmt.Errorf("failed to parse message %s: %w", *idFlag, err)
 	}
 	if err := validator.validate(msg.Header); err != nil {
 		if box == fsq.BoxNew {
-			moveReadFailureToDLQ(root, common.Me, filename, *idFlag, "invalid_header", "invalid header: "+err.Error(), &msg.Header)
+			moveReadFailureToDLQ(deliveryRoot, common.Me, filename, *idFlag, "invalid_header", "invalid header: "+err.Error(), &msg.Header)
 		}
 		return fmt.Errorf("invalid message header %s: %w", *idFlag, err)
 	}
 
 	// Move to cur only after successful parse
 	if box == fsq.BoxNew {
-		if err := fsq.MoveNewToCur(root, common.Me, filename); err != nil {
+		if err := fsq.MoveNewToCur(deliveryRoot, common.Me, filename); err != nil {
 			return err
 		}
-		emitReceipt(root, common.Me, &inboxItem{
+		emitReceipt(deliveryRoot, common.Me, &inboxItem{
 			ID:     msg.Header.ID,
 			From:   msg.Header.From,
 			Thread: msg.Header.Thread,
@@ -114,7 +123,7 @@ func runRead(args []string) error {
 	return nil
 }
 
-func moveReadFailureToDLQ(root, me, filename, fallbackID, reason, detail string, header *format.Header) {
+func moveReadFailureToDLQ(root *fsq.DeliveryRoot, me, filename, fallbackID, reason, detail string, header *format.Header) {
 	if _, err := fsq.MoveToDLQ(root, me, filename, fallbackID, reason, detail); err != nil {
 		_ = writeStderr("warning: failed to move invalid message to DLQ: %v\n", err)
 		return

--- a/internal/cli/read_test.go
+++ b/internal/cli/read_test.go
@@ -36,7 +36,7 @@ func TestRunReadInvalidHeaderMovesToDLQ(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "msg-read-001.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-read-001.md", data); err != nil {
 		t.Fatalf("DeliverToInbox: %v", err)
 	}
 

--- a/internal/cli/receipts_test.go
+++ b/internal/cli/receipts_test.go
@@ -41,7 +41,7 @@ func deliverTestMsg(t *testing.T, root, from, to, msgID string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := fsq.DeliverToInbox(root, to, msgID+".md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, to, msgID+".md", data); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/cli/reply.go
+++ b/internal/cli/reply.go
@@ -111,11 +111,6 @@ func runReply(args []string) error {
 		return fmt.Errorf("cannot reply to a sent cross-session/cross-project message (reply_to points back to you); use amq send --session/--project for follow-ups")
 	}
 
-	body, err := readBody(*bodyFlag, *allowEmptyFlag)
-	if err != nil {
-		return err
-	}
-
 	// Determine recipient and delivery root.
 	var recipient string
 	var deliveryRoot string
@@ -223,8 +218,46 @@ func runReply(args []string) error {
 		}
 	}
 
+	deliveryIdentity, err := fsq.SnapshotDeliveryRoot(deliveryRoot)
+	if err != nil {
+		return err
+	}
+	sourceIdentity := deliveryIdentity
+	if filepath.Clean(root) != filepath.Clean(deliveryRoot) {
+		sourceIdentity, err = fsq.SnapshotDeliveryRoot(root)
+		if err != nil {
+			return err
+		}
+	}
+	pin, err := loadSessionPin()
+	if err != nil {
+		return err
+	}
+	if pin.IdentityPin && !*ignoreSessionPinFlag &&
+		verifyTreeIdentityInfo(sourceIdentity.FileInfo(), pin.RootID) != TreeRelationSame {
+		return ContextMismatchError("authorized source root identity changed before capability open")
+	}
+
 	// Validate recipient in delivery root.
 	if err := validateKnownHandles(deliveryRoot, common.Strict, recipient); err != nil {
+		return err
+	}
+	deliveryFS, err := fsq.OpenDeliveryRoot(deliveryRoot, deliveryIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryFS.Close() }()
+	sourceFS := deliveryFS
+	if filepath.Clean(root) != filepath.Clean(deliveryRoot) {
+		sourceFS, err = fsq.OpenDeliveryRoot(root, sourceIdentity)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = sourceFS.Close() }()
+	}
+
+	body, err := readBody(*bodyFlag, *allowEmptyFlag)
+	if err != nil {
 		return err
 	}
 
@@ -310,21 +343,21 @@ func runReply(args []string) error {
 	filename := id + ".md"
 	if targetProject != "" {
 		// Cross-project: use DeliverToExistingInbox (never creates dirs in peer).
-		if _, err := fsq.DeliverToExistingInbox(deliveryRoot, recipient, filename, data); err != nil {
+		if _, err := fsq.DeliverToExistingInbox(deliveryFS, recipient, filename, data); err != nil {
 			return err
 		}
 	} else {
-		if _, err := fsq.DeliverToInboxes(deliveryRoot, []string{recipient}, filename, data); err != nil {
+		if _, err := fsq.DeliverToInboxes(deliveryFS, []string{recipient}, filename, data); err != nil {
 			return err
 		}
 	}
 
 	// Best-effort presence touch.
-	_ = presence.Touch(root, me)
+	_ = presence.TouchDeliveryRoot(sourceFS, me)
 
-	outboxDir := fsq.AgentOutboxSent(root, me)
+	outboxDir := filepath.Join("agents", me, "outbox", "sent")
 	outboxErr := error(nil)
-	if _, err := fsq.WriteFileAtomic(outboxDir, filename, data, 0o600); err != nil {
+	if _, err := sourceFS.WriteFileAtomic(outboxDir, filename, data, 0o600); err != nil {
 		outboxErr = err
 	}
 
@@ -332,7 +365,7 @@ func runReply(args []string) error {
 	var waitResult *waitForResult
 	var waitErr error
 	if waitFor != "" {
-		r, err := receipt.WaitFor(deliveryRoot, id, recipient, waitFor, *waitTimeoutFlag, 1*time.Second)
+		r, err := receipt.WaitForDeliveryRoot(deliveryFS, id, recipient, waitFor, *waitTimeoutFlag, 1*time.Second)
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			waitResult = &waitForResult{Event: "timeout", Stage: waitFor, Timeout: waitTimeoutFlag.String()}
 			waitErr = TimeoutError("reply --wait-for %s timed out after %s", waitFor, *waitTimeoutFlag)

--- a/internal/cli/reply_test.go
+++ b/internal/cli/reply_test.go
@@ -43,7 +43,7 @@ func TestReply_Basic(t *testing.T) {
 	}
 	data, _ := originalMsg.Marshal()
 	filename := originalID + ".md"
-	if _, err := fsq.DeliverToInboxes(root, []string{alice}, filename, data); err != nil {
+	if _, err := deliverToInboxesForTest(t, root, []string{alice}, filename, data); err != nil {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 
@@ -150,7 +150,7 @@ func TestReply_ReviewRequest(t *testing.T) {
 		Body: "Please review this feature.",
 	}
 	data, _ := originalMsg.Marshal()
-	_, _ = fsq.DeliverToInboxes(root, []string{alice}, originalID+".md", data)
+	_, _ = deliverToInboxesForTest(t, root, []string{alice}, originalID+".md", data)
 
 	// Alice replies with explicit kind
 	oldStdout := os.Stdout
@@ -230,7 +230,7 @@ func TestReply_BrainstormPassthrough(t *testing.T) {
 		Body: "My research findings...",
 	}
 	data, _ := originalMsg.Marshal()
-	_, _ = fsq.DeliverToInboxes(root, []string{alice}, originalID+".md", data)
+	_, _ = deliverToInboxesForTest(t, root, []string{alice}, originalID+".md", data)
 
 	// Alice replies without explicit kind
 	oldStdout := os.Stdout
@@ -304,7 +304,7 @@ func TestReply_PreservesThread(t *testing.T) {
 		Body: "Let's discuss.",
 	}
 	data, _ := originalMsg.Marshal()
-	_, _ = fsq.DeliverToInboxes(root, []string{alice}, originalID+".md", data)
+	_, _ = deliverToInboxesForTest(t, root, []string{alice}, originalID+".md", data)
 
 	// Reply
 	oldStdout := os.Stdout

--- a/internal/cli/roots_absolute_test.go
+++ b/internal/cli/roots_absolute_test.go
@@ -118,7 +118,7 @@ func TestReplyWaitForDrained(t *testing.T) {
 		Body: "ping",
 	}
 	data, _ := originalMsg.Marshal()
-	if _, err := fsq.DeliverToInboxes(root, []string{"alice"}, originalID+".md", data); err != nil {
+	if _, err := deliverToInboxesForTest(t, root, []string{"alice"}, originalID+".md", data); err != nil {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -283,6 +283,24 @@ func runSend(args []string) error {
 		}
 	}
 
+	// Snapshot the physical roots at the authorization boundary. Opening the
+	// capabilities below must prove it got these exact directories.
+	deliveryIdentity, err := fsq.SnapshotDeliveryRoot(deliveryRoot)
+	if err != nil {
+		return err
+	}
+	sourceIdentity := deliveryIdentity
+	if filepath.Clean(sourceRoot) != filepath.Clean(deliveryRoot) {
+		sourceIdentity, err = fsq.SnapshotDeliveryRoot(sourceRoot)
+		if err != nil {
+			return err
+		}
+	}
+	if pin.IdentityPin && !*ignoreSessionPinFlag && fromSession == "" &&
+		verifyTreeIdentityInfo(sourceIdentity.FileInfo(), pin.RootID) != TreeRelationSame {
+		return ContextMismatchError("authorized source root identity changed before capability open")
+	}
+
 	// Validate sender in source root, recipients in target root. Always.
 	if targetProject != "" || targetSession != "" {
 		if err := validateKnownHandles(sourceRoot, common.Strict, me); err != nil {
@@ -296,6 +314,20 @@ func runSend(args []string) error {
 		if err := validateKnownHandles(root, common.Strict, allHandles...); err != nil {
 			return err
 		}
+	}
+
+	deliveryFS, err := fsq.OpenDeliveryRoot(deliveryRoot, deliveryIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryFS.Close() }()
+	sourceFS := deliveryFS
+	if filepath.Clean(sourceRoot) != filepath.Clean(deliveryRoot) {
+		sourceFS, err = fsq.OpenDeliveryRoot(sourceRoot, sourceIdentity)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = sourceFS.Close() }()
 	}
 
 	body, err := readBody(*bodyFlag, *allowEmptyFlag)
@@ -415,23 +447,23 @@ func runSend(args []string) error {
 	if targetProject != "" {
 		// Cross-project: use DeliverToExistingInbox (never creates dirs in peer).
 		for _, r := range recipients {
-			if _, err := fsq.DeliverToExistingInbox(deliveryRoot, r, filename, data); err != nil {
+			if _, err := fsq.DeliverToExistingInbox(deliveryFS, r, filename, data); err != nil {
 				return err
 			}
 		}
 	} else {
-		if _, err := fsq.DeliverToInboxes(deliveryRoot, recipients, filename, data); err != nil {
+		if _, err := fsq.DeliverToInboxes(deliveryFS, recipients, filename, data); err != nil {
 			return err
 		}
 	}
 
 	// Best-effort presence touch.
-	_ = presence.Touch(sourceRoot, common.Me)
+	_ = presence.TouchDeliveryRoot(sourceFS, common.Me)
 
 	// Copy to sender outbox/sent for audit (always in sender's root).
-	outboxDir := fsq.AgentOutboxSent(sourceRoot, common.Me)
+	outboxDir := filepath.Join("agents", common.Me, "outbox", "sent")
 	outboxErr := error(nil)
-	if _, err := fsq.WriteFileAtomic(outboxDir, filename, data, 0o600); err != nil {
+	if _, err := sourceFS.WriteFileAtomic(outboxDir, filename, data, 0o600); err != nil {
 		outboxErr = err
 	}
 
@@ -452,7 +484,7 @@ func runSend(args []string) error {
 	var waitErr error
 	if waitFor != "" {
 		consumer := recipients[0]
-		r, err := receipt.WaitFor(deliveryRoot, id, consumer, waitFor, *waitTimeoutFlag, 1*time.Second)
+		r, err := receipt.WaitForDeliveryRoot(deliveryFS, id, consumer, waitFor, *waitTimeoutFlag, 1*time.Second)
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			waitResult = &waitForResult{Event: "timeout", Stage: waitFor, Timeout: waitTimeoutFlag.String()}
 			waitErr = TimeoutError("send --wait-for %s timed out after %s (delivery session %s, root %s); run 'amq doctor --ops' to diagnose mailbox divergence", waitFor, *waitTimeoutFlag, targetDisplay, deliveryRoot)

--- a/internal/cli/send_delivery_root_unix_test.go
+++ b/internal/cli/send_delivery_root_unix_test.go
@@ -1,0 +1,291 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestSendRejectsSymlinkSwapAfterGuard(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	authorizedAlias := filepath.Join(parent, "authorized")
+	authorizedMoved := filepath.Join(parent, "authorized-moved")
+	outside := filepath.Join(parent, "outside")
+	for _, root := range []string{authorizedAlias, outside} {
+		for _, agent := range []string{"alice", "bob"} {
+			if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+				t.Fatalf("EnsureAgentDirs(%s,%s): %v", root, agent, err)
+			}
+		}
+	}
+	clearDeliveryRootTestEnv(t)
+
+	bodyFIFO := filepath.Join(parent, "body.fifo")
+	if err := syscall.Mkfifo(bodyFIFO, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	type openResult struct {
+		file *os.File
+		err  error
+	}
+	writerCh := make(chan openResult, 1)
+	go func() {
+		file, err := os.OpenFile(bodyFIFO, os.O_WRONLY, 0)
+		writerCh <- openResult{file: file, err: err}
+	}()
+	t.Cleanup(func() {
+		// Release the blocked writer if runSend returns before opening the FIFO.
+		reader, err := os.OpenFile(bodyFIFO, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+		if err == nil {
+			_ = reader.Close()
+		}
+	})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runSend([]string{
+			"--root", authorizedAlias,
+			"--me", "alice",
+			"--to", "bob",
+			"--body", "@" + bodyFIFO,
+		})
+	}()
+
+	var writer *os.File
+	select {
+	case result := <-writerCh:
+		if result.err != nil {
+			t.Fatalf("open FIFO writer: %v", result.err)
+		}
+		writer = result.file
+	case err := <-errCh:
+		t.Fatalf("send returned before reading body: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("send did not reach post-authorization body read")
+	}
+	if err := os.Rename(authorizedAlias, authorizedMoved); err != nil {
+		t.Fatalf("move authorized root: %v", err)
+	}
+	if err := os.Symlink(outside, authorizedAlias); err != nil {
+		t.Fatalf("replace authorized alias: %v", err)
+	}
+	if _, err := writer.Write([]byte("after authorization")); err != nil {
+		t.Fatalf("write FIFO body: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close FIFO writer: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "delivery root changed after authorization") {
+			t.Fatalf("send error = %v, want post-authorization root-change refusal", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("send did not return after body was released")
+	}
+	if entries, err := os.ReadDir(fsq.AgentInboxNew(outside, "bob")); err != nil {
+		t.Fatalf("ReadDir outside inbox: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("escaped delivery wrote %d message(s) outside authorized root", len(entries))
+	}
+	if entries, err := os.ReadDir(fsq.AgentInboxNew(authorizedMoved, "bob")); err != nil {
+		t.Fatalf("ReadDir original inbox: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("refused send wrote %d message(s) into moved authorized root", len(entries))
+	}
+}
+
+func TestSendRejectsEscapingMailboxSymlink(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	root := filepath.Join(parent, "authorized")
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	outsideInbox := filepath.Join(parent, "outside-inbox")
+	for _, box := range []string{"tmp", "new"} {
+		if err := os.MkdirAll(filepath.Join(outsideInbox, box), 0o700); err != nil {
+			t.Fatalf("mkdir outside inbox: %v", err)
+		}
+	}
+	bobInbox := filepath.Join(root, "agents", "bob", "inbox")
+	if err := os.RemoveAll(bobInbox); err != nil {
+		t.Fatalf("remove bob inbox: %v", err)
+	}
+	if err := os.Symlink(filepath.Join("..", "..", "..", "outside-inbox"), bobInbox); err != nil {
+		t.Fatalf("symlink escaping inbox: %v", err)
+	}
+	clearDeliveryRootTestEnv(t)
+
+	err := runSend([]string{
+		"--root", root,
+		"--me", "alice",
+		"--to", "bob",
+		"--body", "must stay in root",
+	})
+	if err == nil {
+		t.Fatal("send through an escaping mailbox symlink succeeded")
+	}
+	if entries, readErr := os.ReadDir(filepath.Join(outsideInbox, "new")); readErr != nil {
+		t.Fatalf("ReadDir outside inbox: %v", readErr)
+	} else if len(entries) != 0 {
+		t.Fatalf("escaping mailbox symlink received %d message(s)", len(entries))
+	}
+}
+
+func TestReplyRejectsSymlinkSwapAfterGuard(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	authorizedAlias := filepath.Join(parent, "authorized")
+	authorizedMoved := filepath.Join(parent, "authorized-moved")
+	outside := filepath.Join(parent, "outside")
+	for _, root := range []string{authorizedAlias, outside} {
+		for _, agent := range []string{"alice", "bob"} {
+			if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+				t.Fatalf("EnsureAgentDirs(%s,%s): %v", root, agent, err)
+			}
+		}
+	}
+	now := time.Now()
+	originalID, err := format.NewMessageID(now)
+	if err != nil {
+		t.Fatalf("NewMessageID: %v", err)
+	}
+	original := format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      originalID,
+			From:    "bob",
+			To:      []string{"alice"},
+			Thread:  "p2p/alice__bob",
+			Subject: "root swap",
+			Created: now.UTC().Format(time.RFC3339Nano),
+		},
+		Body: "authorize before replying",
+	}
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if _, err := deliverToInboxForTest(t, authorizedAlias, "alice", originalID+".md", data); err != nil {
+		t.Fatalf("deliver original: %v", err)
+	}
+	clearDeliveryRootTestEnv(t)
+
+	bodyFIFO := filepath.Join(parent, "reply-body.fifo")
+	if err := syscall.Mkfifo(bodyFIFO, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	type openResult struct {
+		file *os.File
+		err  error
+	}
+	writerCh := make(chan openResult, 1)
+	go func() {
+		file, err := os.OpenFile(bodyFIFO, os.O_WRONLY, 0)
+		writerCh <- openResult{file: file, err: err}
+	}()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runReply([]string{
+			"--root", authorizedAlias,
+			"--me", "alice",
+			"--id", originalID,
+			"--body", "@" + bodyFIFO,
+		})
+	}()
+
+	var writer *os.File
+	select {
+	case result := <-writerCh:
+		if result.err != nil {
+			t.Fatalf("open FIFO writer: %v", result.err)
+		}
+		writer = result.file
+	case err := <-errCh:
+		t.Fatalf("reply returned before reading body: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("reply did not reach post-authorization body read")
+	}
+	if err := os.Rename(authorizedAlias, authorizedMoved); err != nil {
+		t.Fatalf("move authorized root: %v", err)
+	}
+	if err := os.Symlink(outside, authorizedAlias); err != nil {
+		t.Fatalf("replace authorized alias: %v", err)
+	}
+	if _, err := writer.Write([]byte("after authorization")); err != nil {
+		t.Fatalf("write FIFO body: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close FIFO writer: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "delivery root changed after authorization") {
+			t.Fatalf("reply error = %v, want post-authorization root-change refusal", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reply did not return after body was released")
+	}
+	if entries, err := os.ReadDir(fsq.AgentInboxNew(outside, "bob")); err != nil {
+		t.Fatalf("ReadDir outside inbox: %v", err)
+	} else if len(entries) != 0 {
+		t.Fatalf("escaped reply wrote %d message(s) outside authorized root", len(entries))
+	}
+}
+
+func TestSendAllowsInRootRelativeMailboxSymlink(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	root := filepath.Join(parent, "authorized")
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	inRootInbox := filepath.Join(root, "mailboxes", "bob")
+	for _, box := range []string{"tmp", "new"} {
+		if err := os.MkdirAll(filepath.Join(inRootInbox, box), 0o700); err != nil {
+			t.Fatalf("mkdir in-root inbox: %v", err)
+		}
+	}
+	bobInbox := filepath.Join(root, "agents", "bob", "inbox")
+	if err := os.RemoveAll(bobInbox); err != nil {
+		t.Fatalf("remove bob inbox: %v", err)
+	}
+	if err := os.Symlink(filepath.Join("..", "..", "mailboxes", "bob"), bobInbox); err != nil {
+		t.Fatalf("symlink in-root inbox: %v", err)
+	}
+	clearDeliveryRootTestEnv(t)
+
+	if err := runSend([]string{
+		"--root", root,
+		"--me", "alice",
+		"--to", "bob",
+		"--body", "contained symlink",
+	}); err != nil {
+		t.Fatalf("send through contained mailbox symlink: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(inRootInbox, "new"))
+	if err != nil {
+		t.Fatalf("ReadDir in-root inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("in-root mailbox received %d messages, want 1", len(entries))
+	}
+}
+
+func clearDeliveryRootTestEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{envRoot, envBaseRoot, envSession, "AMQ_GLOBAL_ROOT"} {
+		setOptionalEnv(t, key, "", false)
+	}
+}

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -161,7 +161,7 @@ func TestReply_RejectsPositionalArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInboxes(root, []string{"alice"}, originalID+".md", data); err != nil {
+	if _, err := deliverToInboxesForTest(t, root, []string{"alice"}, originalID+".md", data); err != nil {
 		t.Fatalf("DeliverToInboxes: %v", err)
 	}
 

--- a/internal/cli/tree_identity.go
+++ b/internal/cli/tree_identity.go
@@ -96,6 +96,20 @@ func verifyTreeIdentityToken(path, token string) TreeRelation {
 	return TreeRelationDifferent
 }
 
+func verifyTreeIdentityInfo(info os.FileInfo, token string) TreeRelation {
+	if info == nil || !validTreeIdentityToken(token) {
+		return TreeRelationUnknown
+	}
+	current, err := platformTreeIdentityToken("", info)
+	if err != nil {
+		return TreeRelationUnknown
+	}
+	if current == token {
+		return TreeRelationSame
+	}
+	return TreeRelationDifferent
+}
+
 func sameTreeIdentity(a, b string) bool {
 	left, le := resolveTreeIdentity(a)
 	right, re := resolveTreeIdentity(b)

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -650,7 +650,7 @@ func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *test
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "msg-urgent.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-urgent.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 
@@ -723,7 +723,7 @@ func TestNotifyNewMessagesNoneUrgentUsesOutputBellWithoutInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "msg-urgent-none.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-urgent-none.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 
@@ -822,7 +822,7 @@ func TestNotifyNewMessages_InjectViaInjectCmdPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "msg-normal.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-normal.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 
@@ -875,7 +875,7 @@ func TestNotifyNewMessages_InjectViaInterruptFailureDoesNotUpdateCooldown(t *tes
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "msg-urgent.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-urgent.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -41,7 +41,7 @@ func TestRunWatchExistingMessages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "msg-existing.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-existing.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 
@@ -171,7 +171,7 @@ func TestRunWatchNewMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "alice", "msg-new.md", data); err != nil {
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-new.md", data); err != nil {
 		t.Fatalf("deliver: %v", err)
 	}
 

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -1,0 +1,260 @@
+package fsq
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DeliveryRootIdentity is an opaque physical-identity snapshot taken at the
+// authorization boundary and consumed when the directory capability is opened.
+type DeliveryRootIdentity struct {
+	info os.FileInfo
+}
+
+// DeliveryRoot is an authorized, pinned filesystem capability for one AMQ
+// tree. All delivery paths are resolved relative to the open directory rather
+// than by reopening Base through the ambient filesystem namespace.
+type DeliveryRoot struct {
+	base     string
+	root     *os.Root
+	identity os.FileInfo
+
+	syncDirForTest func(string) error
+}
+
+// SnapshotDeliveryRoot captures the physical directory identity at the
+// authorization boundary. The snapshot is intentionally opaque so callers
+// cannot forge or reinterpret it.
+func SnapshotDeliveryRoot(base string) (DeliveryRootIdentity, error) {
+	abs, err := filepath.Abs(base)
+	if err != nil {
+		return DeliveryRootIdentity{}, fmt.Errorf("resolve delivery root %q: %w", base, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return DeliveryRootIdentity{}, fmt.Errorf("stat delivery root %s: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return DeliveryRootIdentity{}, fmt.Errorf("delivery root is not a directory: %s", abs)
+	}
+	return DeliveryRootIdentity{info: info}, nil
+
+}
+
+// FileInfo returns the captured identity for comparison with an existing
+// platform identity token. Filesystem operations cannot be performed through
+// this value.
+func (i DeliveryRootIdentity) FileInfo() os.FileInfo {
+	return i.info
+}
+
+// OpenDeliveryRoot opens base once and proves the opened directory is the same
+// physical object authorized by expected. Subsequent operations are pinned to
+// that handle and never reopen base through the ambient namespace.
+func OpenDeliveryRoot(base string, expected DeliveryRootIdentity) (*DeliveryRoot, error) {
+	if expected.info == nil {
+		return nil, fmt.Errorf("missing authorized delivery root identity")
+	}
+	abs, err := filepath.Abs(base)
+	if err != nil {
+		return nil, fmt.Errorf("resolve delivery root %q: %w", base, err)
+	}
+	root, err := os.OpenRoot(abs)
+	if err != nil {
+		return nil, fmt.Errorf("open delivery root %s: %w", abs, err)
+	}
+	identity, err := root.Stat(".")
+	if err != nil {
+		_ = root.Close()
+		return nil, fmt.Errorf("stat delivery root %s: %w", abs, err)
+	}
+	if !identity.IsDir() {
+		_ = root.Close()
+		return nil, fmt.Errorf("delivery root is not a directory: %s", abs)
+	}
+	if !os.SameFile(expected.info, identity) {
+		_ = root.Close()
+		return nil, fmt.Errorf("delivery root changed between authorization and capability open: %s", abs)
+	}
+	return &DeliveryRoot{base: abs, root: root, identity: identity}, nil
+}
+
+func (r *DeliveryRoot) Close() error {
+	if r == nil || r.root == nil {
+		return nil
+	}
+	return r.root.Close()
+}
+
+// Base returns the authorized path for diagnostics only. Filesystem operations
+// must stay relative to the pinned root.
+func (r *DeliveryRoot) Base() string {
+	if r == nil {
+		return ""
+	}
+	return r.base
+}
+
+// VerifyBase reports a lexical alias change after authorization. The open root
+// remains the security boundary even if an alias changes immediately after
+// this check; this verification makes a detected swap fail closed instead of
+// silently delivering into the formerly named tree.
+func (r *DeliveryRoot) VerifyBase() error {
+	if r == nil || r.root == nil {
+		return fmt.Errorf("delivery root is closed")
+	}
+	current, err := os.Stat(r.base)
+	if err != nil {
+		return fmt.Errorf("delivery root changed after authorization: %s: %w", r.base, err)
+	}
+	if !os.SameFile(r.identity, current) {
+		return fmt.Errorf("delivery root changed after authorization: %s", r.base)
+	}
+	return nil
+}
+
+func (r *DeliveryRoot) displayPath(name string) string {
+	return filepath.Join(r.base, name)
+}
+
+// DisplayPath returns the diagnostic path for a root-relative name. The result
+// must not be used for filesystem I/O.
+func (r *DeliveryRoot) DisplayPath(name string) string {
+	return r.displayPath(name)
+}
+
+func (r *DeliveryRoot) dirExists(name string) bool {
+	info, err := r.root.Stat(name)
+	return err == nil && info.IsDir()
+}
+
+func (r *DeliveryRoot) writeAndSync(name string, data []byte, perm os.FileMode) (err error) {
+	file, err := r.root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			_ = r.root.Remove(name)
+		}
+	}()
+	return writeAllAndSync(file, data)
+}
+
+func (r *DeliveryRoot) cleanupTemp(name string, primary error) error {
+	if primary == nil {
+		return nil
+	}
+	if err := r.root.Remove(name); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("%w (cleanup: %v)", primary, err)
+	}
+	return primary
+}
+
+// WriteFileAtomic writes a root-relative file through the pinned capability.
+func (r *DeliveryRoot) WriteFileAtomic(dir, filename string, data []byte, perm os.FileMode) (string, error) {
+	if err := r.VerifyBase(); err != nil {
+		return "", err
+	}
+	if err := r.root.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	tmpName := fmt.Sprintf(".%s.tmp-%d", filename, time.Now().UnixNano())
+	tmpPath := filepath.Join(dir, tmpName)
+	finalPath := filepath.Join(dir, filename)
+	if err := r.writeAndSync(tmpPath, data, perm); err != nil {
+		return "", err
+	}
+	if err := r.syncDir(dir); err != nil {
+		return "", r.cleanupTemp(tmpPath, err)
+	}
+	if err := r.root.Rename(tmpPath, finalPath); err != nil {
+		return "", r.cleanupTemp(tmpPath, err)
+	}
+	if err := r.syncDir(dir); err != nil {
+		return "", err
+	}
+	return r.displayPath(finalPath), nil
+}
+
+// ReadFile reads a root-relative file through the pinned capability.
+func (r *DeliveryRoot) ReadFile(name string) ([]byte, error) {
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+	return r.root.ReadFile(name)
+}
+
+// ReadDir reads a root-relative directory through the pinned capability.
+func (r *DeliveryRoot) ReadDir(name string) ([]os.DirEntry, error) {
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+	file, err := r.root.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	return file.ReadDir(-1)
+}
+
+// Stat stats a root-relative path through the pinned capability.
+func (r *DeliveryRoot) Stat(name string) (os.FileInfo, error) {
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+	return r.root.Stat(name)
+}
+
+// Remove removes a root-relative path through the pinned capability.
+func (r *DeliveryRoot) Remove(name string) error {
+	if err := r.VerifyBase(); err != nil {
+		return err
+	}
+	return r.root.Remove(name)
+}
+
+// SyncDir syncs a root-relative directory through the pinned capability.
+func (r *DeliveryRoot) SyncDir(name string) error {
+	if err := r.VerifyBase(); err != nil {
+		return err
+	}
+	return r.syncDir(name)
+}
+
+// ReadRegularNoFollow reads a root-relative regular file while refusing an
+// initially symlinked artifact and detecting replacement between lstat/open.
+func (r *DeliveryRoot) ReadRegularNoFollow(name string) ([]byte, error) {
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+	before, err := r.root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRegularNoFollowFile(r.displayPath(name), before); err != nil {
+		return nil, err
+	}
+	file, err := openRegularNoFollowRoot(r.root, name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	after, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if err := validateRegularNoFollowFile(r.displayPath(name), after); err != nil {
+		return nil, err
+	}
+	if !os.SameFile(before, after) {
+		return nil, fmt.Errorf("queue artifact changed while opening: %s", r.displayPath(name))
+	}
+	return io.ReadAll(file)
+}

--- a/internal/fsq/delivery_root_regular_other.go
+++ b/internal/fsq/delivery_root_regular_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package fsq
+
+import "os"
+
+func openRegularNoFollowRoot(root *os.Root, name string) (*os.File, error) {
+	return root.Open(name)
+}

--- a/internal/fsq/delivery_root_regular_unix.go
+++ b/internal/fsq/delivery_root_regular_unix.go
@@ -1,0 +1,12 @@
+//go:build darwin || linux
+
+package fsq
+
+import (
+	"os"
+	"syscall"
+)
+
+func openRegularNoFollowRoot(root *os.Root, name string) (*os.File, error) {
+	return root.OpenFile(name, os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0)
+}

--- a/internal/fsq/delivery_root_sync_unix.go
+++ b/internal/fsq/delivery_root_sync_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package fsq
+
+func (r *DeliveryRoot) syncDir(dir string) error {
+	if r.syncDirForTest != nil {
+		return r.syncDirForTest(dir)
+	}
+	return r.syncDirPlatform(dir)
+}
+
+func (r *DeliveryRoot) syncDirPlatform(dir string) error {
+	file, err := r.root.Open(dir)
+	if err != nil {
+		return err
+	}
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if syncErr != nil {
+		if isSyncUnsupported(syncErr) {
+			return nil
+		}
+		return syncErr
+	}
+	return closeErr
+}

--- a/internal/fsq/delivery_root_sync_windows.go
+++ b/internal/fsq/delivery_root_sync_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package fsq
+
+func (r *DeliveryRoot) syncDir(dir string) error {
+	if r.syncDirForTest != nil {
+		return r.syncDirForTest(dir)
+	}
+	return r.syncDirPlatform(dir)
+}
+
+func (r *DeliveryRoot) syncDirPlatform(_ string) error {
+	return nil
+}

--- a/internal/fsq/delivery_root_unix_test.go
+++ b/internal/fsq/delivery_root_unix_test.go
@@ -1,0 +1,140 @@
+//go:build darwin || linux
+
+package fsq
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenDeliveryRootRejectsSwapBetweenAuthorizationAndOpen(t *testing.T) {
+	parent := t.TempDir()
+	base := filepath.Join(parent, "authorized")
+	parked := filepath.Join(parent, "authorized-parked")
+	outside := filepath.Join(parent, "outside")
+	for _, path := range []string{base, outside} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", path, err)
+		}
+	}
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	if err := os.Rename(base, parked); err != nil {
+		t.Fatalf("park authorized root: %v", err)
+	}
+	if err := os.Symlink(outside, base); err != nil {
+		t.Fatalf("install malicious alias: %v", err)
+	}
+
+	root, err := OpenDeliveryRoot(base, identity)
+	if root != nil {
+		_ = root.Close()
+		t.Fatal("OpenDeliveryRoot returned a capability for the swapped root")
+	}
+	if err == nil || !strings.Contains(err.Error(), "changed between authorization and capability open") {
+		t.Fatalf("OpenDeliveryRoot error = %v, want authorization/open mismatch", err)
+	}
+}
+
+func TestDeliveryRootConcurrentAncestorAndRootAliasSwap(t *testing.T) {
+	tests := []struct {
+		name string
+		make func(t *testing.T) (base, swapPath, parkedPath, maliciousTarget, maliciousBase string)
+	}{
+		{
+			name: "root alias",
+			make: func(t *testing.T) (string, string, string, string, string) {
+				parent := t.TempDir()
+				base := filepath.Join(parent, "authorized")
+				outside := filepath.Join(parent, "outside")
+				return base, base, filepath.Join(parent, "authorized-parked"), outside, outside
+			},
+		},
+		{
+			name: "ancestor alias",
+			make: func(t *testing.T) (string, string, string, string, string) {
+				parent := t.TempDir()
+				ancestor := filepath.Join(parent, "authorized-parent")
+				outsideAncestor := filepath.Join(parent, "outside-parent")
+				return filepath.Join(ancestor, "root"), ancestor, filepath.Join(parent, "authorized-parent-parked"), outsideAncestor, filepath.Join(outsideAncestor, "root")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, swapPath, parkedPath, maliciousTarget, maliciousBase := tt.make(t)
+			for _, tree := range []string{base, maliciousBase} {
+				if err := EnsureAgentDirs(tree, "bob"); err != nil {
+					t.Fatalf("EnsureAgentDirs(%s): %v", tree, err)
+				}
+			}
+			identity, err := SnapshotDeliveryRoot(base)
+			if err != nil {
+				t.Fatalf("SnapshotDeliveryRoot: %v", err)
+			}
+			root, err := OpenDeliveryRoot(base, identity)
+			if err != nil {
+				t.Fatalf("OpenDeliveryRoot: %v", err)
+			}
+			defer func() { _ = root.Close() }()
+
+			for i := 0; i < 200; i++ {
+				installed := make(chan error, 1)
+				release := make(chan struct{})
+				restored := make(chan error, 1)
+				go func() {
+					if err := os.Rename(swapPath, parkedPath); err != nil {
+						err = fmt.Errorf("park authorized path: %w", err)
+						installed <- err
+						restored <- err
+						return
+					}
+					if err := os.Symlink(maliciousTarget, swapPath); err != nil {
+						_ = os.Rename(parkedPath, swapPath)
+						err = fmt.Errorf("install malicious alias: %w", err)
+						installed <- err
+						restored <- err
+						return
+					}
+					installed <- nil
+					<-release
+					if err := os.Remove(swapPath); err != nil {
+						restored <- fmt.Errorf("remove malicious alias: %w", err)
+						return
+					}
+					if err := os.Rename(parkedPath, swapPath); err != nil {
+						restored <- fmt.Errorf("restore authorized path: %w", err)
+						return
+					}
+					restored <- nil
+				}()
+				if err := <-installed; err != nil {
+					<-restored
+					t.Fatal(err)
+				}
+				filename := fmt.Sprintf("stress-%03d.md", i)
+				_, err := DeliverToInboxes(root, []string{"bob"}, filename, []byte("contained"))
+				close(release)
+				if restoreErr := <-restored; restoreErr != nil {
+					t.Fatal(restoreErr)
+				}
+				if err == nil || !strings.Contains(err.Error(), "delivery root changed after authorization") {
+					t.Fatalf("DeliverToInboxes error = %v, want root-change refusal", err)
+				}
+			}
+			entries, err := os.ReadDir(AgentInboxNew(maliciousBase, "bob"))
+			if err != nil {
+				t.Fatalf("ReadDir malicious inbox: %v", err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("malicious inbox received %d messages", len(entries))
+			}
+		})
+	}
+}

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -38,7 +38,7 @@ func GenerateDLQID() string {
 }
 
 // MoveToDLQ moves a failed message from inbox/new to dlq/new with envelope.
-func MoveToDLQ(root, agent, filename, originalID, failureReason, failureDetail string) (string, error) {
+func MoveToDLQ(root *DeliveryRoot, agent, filename, originalID, failureReason, failureDetail string) (string, error) {
 	if err := MoveNewToCur(root, agent, filename); err != nil {
 		return "", fmt.Errorf("claim original: %w", err)
 	}
@@ -46,22 +46,22 @@ func MoveToDLQ(root, agent, filename, originalID, failureReason, failureDetail s
 }
 
 // MoveCurToDLQ moves an already-claimed inbox/cur message to dlq/new.
-func MoveCurToDLQ(root, agent, filename, originalID, failureReason, failureDetail string) (string, error) {
+func MoveCurToDLQ(root *DeliveryRoot, agent, filename, originalID, failureReason, failureDetail string) (string, error) {
 	return moveInboxMessageToDLQ(root, agent, BoxCur, BoxCur, filename, originalID, failureReason, failureDetail)
 }
 
-func moveInboxMessageToDLQ(root, agent, readDir, envelopeSourceDir, filename, originalID, failureReason, failureDetail string) (string, error) {
+func moveInboxMessageToDLQ(root *DeliveryRoot, agent, readDir, envelopeSourceDir, filename, originalID, failureReason, failureDetail string) (string, error) {
 	if err := ValidateMessageFilename(filename); err != nil {
 		return "", err
 	}
-	srcDir, err := inboxSourceDir(root, agent, readDir)
+	srcDir, err := inboxSourceDir(agent, readDir)
 	if err != nil {
 		return "", err
 	}
 	srcPath := filepath.Join(srcDir, filename)
 
 	// Read original content
-	content, err := ReadRegularNoFollow(srcPath)
+	content, err := root.ReadRegularNoFollow(srcPath)
 	if err != nil {
 		return "", fmt.Errorf("read original: %w", err)
 	}
@@ -92,60 +92,63 @@ func moveInboxMessageToDLQ(root, agent, readDir, envelopeSourceDir, filename, or
 		return "", fmt.Errorf("deliver to dlq: %w", err)
 	}
 
-	if err := os.Remove(srcPath); err != nil && !os.IsNotExist(err) {
+	if err := root.root.Remove(srcPath); err != nil && !os.IsNotExist(err) {
 		return dlqPath, fmt.Errorf("remove original (dlq written): %w", err)
 	}
-	_ = SyncDir(srcDir)
+	_ = root.syncDir(srcDir)
 
 	return dlqPath, nil
 }
 
-func inboxSourceDir(root, agent, sourceDir string) (string, error) {
+func inboxSourceDir(agent, sourceDir string) (string, error) {
 	switch sourceDir {
 	case BoxNew:
-		return AgentInboxNew(root, agent), nil
+		return filepath.Join("agents", agent, "inbox", "new"), nil
 	case BoxCur:
-		return AgentInboxCur(root, agent), nil
+		return filepath.Join("agents", agent, "inbox", "cur"), nil
 	default:
 		return "", fmt.Errorf("unsupported inbox source dir %q", sourceDir)
 	}
 }
 
 // deliverToDLQ writes a DLQ message using Maildir semantics (tmp -> new).
-func deliverToDLQ(root, agent, filename string, data []byte) (string, error) {
-	tmpDir := AgentDLQTmp(root, agent)
-	newDir := AgentDLQNew(root, agent)
-
-	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
+func deliverToDLQ(root *DeliveryRoot, agent, filename string, data []byte) (string, error) {
+	if err := root.VerifyBase(); err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(newDir, 0o700); err != nil {
+	tmpDir := filepath.Join("agents", agent, "dlq", "tmp")
+	newDir := filepath.Join("agents", agent, "dlq", "new")
+
+	if err := root.root.MkdirAll(tmpDir, 0o700); err != nil {
+		return "", err
+	}
+	if err := root.root.MkdirAll(newDir, 0o700); err != nil {
 		return "", err
 	}
 
 	tmpPath := filepath.Join(tmpDir, filename)
 	newPath := filepath.Join(newDir, filename)
 
-	if err := writeAndSync(tmpPath, data, 0o600); err != nil {
+	if err := root.writeAndSync(tmpPath, data, 0o600); err != nil {
 		return "", err
 	}
-	if err := SyncDir(tmpDir); err != nil {
-		return "", cleanupTemp(tmpPath, err)
+	if err := root.syncDir(tmpDir); err != nil {
+		return "", root.cleanupTemp(tmpPath, err)
 	}
-	if err := os.Rename(tmpPath, newPath); err != nil {
-		return "", cleanupTemp(tmpPath, err)
+	if err := root.root.Rename(tmpPath, newPath); err != nil {
+		return "", root.cleanupTemp(tmpPath, err)
 	}
-	if err := SyncDir(newDir); err != nil {
+	if err := root.syncDir(newDir); err != nil {
 		return "", err
 	}
-	_ = SyncDir(tmpDir)
+	_ = root.syncDir(tmpDir)
 
-	return newPath, nil
+	return root.displayPath(newPath), nil
 }
 
 // ReadDLQEnvelope reads and parses a DLQ message.
-func ReadDLQEnvelope(path string) (*DLQEnvelope, []byte, error) {
-	data, err := ReadRegularNoFollow(path)
+func ReadDLQEnvelope(root *DeliveryRoot, path string) (*DLQEnvelope, []byte, error) {
+	data, err := root.ReadRegularNoFollow(path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -158,16 +161,26 @@ func ReadDLQEnvelope(path string) (*DLQEnvelope, []byte, error) {
 	return envelope, body, nil
 }
 
+// ReadDLQEnvelopePath is the legacy pathname reader used only by non-mutating
+// listing code. Mutating DLQ flows must use ReadDLQEnvelope with a capability.
+func ReadDLQEnvelopePath(path string) (*DLQEnvelope, []byte, error) {
+	data, err := ReadRegularNoFollow(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return parseDLQMessage(data)
+}
+
 // RetryFromDLQ moves a message from DLQ back to inbox/new for reprocessing.
 // Returns error if retry_count >= MaxRetries and force is false.
-func RetryFromDLQ(root, agent, dlqFilename string, force bool) error {
+func RetryFromDLQ(root *DeliveryRoot, agent, dlqFilename string, force bool) error {
 	// Find in dlq/new or dlq/cur
 	dlqPath, box, err := FindDLQMessage(root, agent, dlqFilename)
 	if err != nil {
 		return err
 	}
 
-	envelope, originalContent, err := ReadDLQEnvelope(dlqPath)
+	envelope, originalContent, err := ReadDLQEnvelope(root, dlqPath)
 	if err != nil {
 		return fmt.Errorf("read dlq envelope: %w", err)
 	}
@@ -180,8 +193,8 @@ func RetryFromDLQ(root, agent, dlqFilename string, force bool) error {
 	}
 
 	// Check if original file already exists in inbox/new (avoid overwrite)
-	inboxNewPath := filepath.Join(AgentInboxNew(root, agent), envelope.OriginalFile)
-	if _, err := os.Stat(inboxNewPath); err == nil {
+	inboxNewPath := filepath.Join("agents", agent, "inbox", "new", envelope.OriginalFile)
+	if _, err := root.Stat(inboxNewPath); err == nil {
 		return fmt.Errorf("original file already exists in inbox/new: %s", envelope.OriginalFile)
 	} else if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("stat inbox/new original: %w", err)
@@ -206,46 +219,46 @@ func RetryFromDLQ(root, agent, dlqFilename string, force bool) error {
 	return nil
 }
 
-func updateRetriedDLQEnvelope(root, agent, dlqFilename, dlqPath, box string, updatedData []byte) error {
-	curDir := AgentDLQCur(root, agent)
-	if err := os.MkdirAll(curDir, 0o700); err != nil {
+func updateRetriedDLQEnvelope(root *DeliveryRoot, agent, dlqFilename, dlqPath, box string, updatedData []byte) error {
+	curDir := filepath.Join("agents", agent, "dlq", "cur")
+	if err := root.root.MkdirAll(curDir, 0o700); err != nil {
 		return fmt.Errorf("prepare dlq envelope cur dir: %w", err)
 	}
 
 	if box == BoxNew {
 		// Source is dlq/new: write to dlq/cur atomically, then remove from dlq/new
-		if _, err := WriteFileAtomic(curDir, dlqFilename, updatedData, 0o600); err != nil {
+		if _, err := root.WriteFileAtomic(curDir, dlqFilename, updatedData, 0o600); err != nil {
 			return fmt.Errorf("write updated dlq envelope to cur: %w", err)
 		}
-		if err := os.Remove(dlqPath); err != nil && !os.IsNotExist(err) {
+		if err := root.root.Remove(dlqPath); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove old dlq envelope from new: %w", err)
 		}
-		if err := SyncDir(filepath.Dir(dlqPath)); err != nil {
+		if err := root.syncDir(filepath.Dir(dlqPath)); err != nil {
 			return fmt.Errorf("sync old dlq envelope dir: %w", err)
 		}
-		return SyncDir(curDir)
+		return root.syncDir(curDir)
 	}
 
 	// Source is dlq/cur: update in place atomically (same location)
-	if _, err := WriteFileAtomic(curDir, dlqFilename, updatedData, 0o600); err != nil {
+	if _, err := root.WriteFileAtomic(curDir, dlqFilename, updatedData, 0o600); err != nil {
 		return fmt.Errorf("update dlq envelope in cur: %w", err)
 	}
-	return SyncDir(curDir)
+	return root.syncDir(curDir)
 }
 
 // FindDLQMessage locates a DLQ message in dlq/new or dlq/cur.
-func FindDLQMessage(root, agent, filename string) (string, string, error) {
+func FindDLQMessage(root *DeliveryRoot, agent, filename string) (string, string, error) {
 	if err := ValidateMessageFilename(filename); err != nil {
 		return "", "", err
 	}
-	newPath := filepath.Join(AgentDLQNew(root, agent), filename)
-	if _, err := os.Stat(newPath); err == nil {
+	newPath := filepath.Join("agents", agent, "dlq", "new", filename)
+	if _, err := root.Stat(newPath); err == nil {
 		return newPath, BoxNew, nil
 	} else if err != nil && !os.IsNotExist(err) {
 		return "", "", err
 	}
-	curPath := filepath.Join(AgentDLQCur(root, agent), filename)
-	if _, err := os.Stat(curPath); err == nil {
+	curPath := filepath.Join("agents", agent, "dlq", "cur", filename)
+	if _, err := root.Stat(curPath); err == nil {
 		return curPath, BoxCur, nil
 	} else if err != nil && !os.IsNotExist(err) {
 		return "", "", err
@@ -254,23 +267,23 @@ func FindDLQMessage(root, agent, filename string) (string, string, error) {
 }
 
 // MoveDLQNewToCur moves a DLQ message from new to cur (marks as inspected).
-func MoveDLQNewToCur(root, agent, filename string) error {
+func MoveDLQNewToCur(root *DeliveryRoot, agent, filename string) error {
 	if err := ValidateMessageFilename(filename); err != nil {
 		return err
 	}
-	newPath := filepath.Join(AgentDLQNew(root, agent), filename)
-	curDir := AgentDLQCur(root, agent)
+	newPath := filepath.Join("agents", agent, "dlq", "new", filename)
+	curDir := filepath.Join("agents", agent, "dlq", "cur")
 	curPath := filepath.Join(curDir, filename)
-	if err := os.MkdirAll(curDir, 0o700); err != nil {
+	if err := root.root.MkdirAll(curDir, 0o700); err != nil {
 		return err
 	}
-	if err := os.Rename(newPath, curPath); err != nil {
+	if err := root.root.Rename(newPath, curPath); err != nil {
 		return err
 	}
-	if err := SyncDir(filepath.Dir(newPath)); err != nil {
+	if err := root.syncDir(filepath.Dir(newPath)); err != nil {
 		return err
 	}
-	return SyncDir(curDir)
+	return root.syncDir(curDir)
 }
 
 // serializeDLQMessage creates a DLQ file with JSON frontmatter and original content.

--- a/internal/fsq/dlq_nofollow_unix_test.go
+++ b/internal/fsq/dlq_nofollow_unix_test.go
@@ -3,6 +3,7 @@
 package fsq
 
 import (
+	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -14,8 +15,74 @@ func TestReadDLQEnvelopeRejectsFIFO(t *testing.T) {
 		t.Fatalf("mkfifo: %v", err)
 	}
 
-	_, _, err := ReadDLQEnvelope(path)
+	_, _, err := ReadDLQEnvelopePath(path)
 	if err == nil {
 		t.Fatal("expected FIFO DLQ envelope to be rejected")
+	}
+}
+
+func TestMoveCurToDLQRejectsEscapingTmpSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	filename := "escape_tmp.md"
+	source := filepath.Join(AgentInboxCur(root, "alice"), filename)
+	if err := os.WriteFile(source, []byte("contained"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	outside := t.TempDir()
+	tmpDir := AgentDLQTmp(root, "alice")
+	if err := os.RemoveAll(tmpDir); err != nil {
+		t.Fatalf("remove dlq tmp: %v", err)
+	}
+	if err := os.Symlink(outside, tmpDir); err != nil {
+		t.Fatalf("symlink dlq tmp: %v", err)
+	}
+
+	if _, err := MoveCurToDLQ(openDeliveryRootForTest(t, root), "alice", filename, "escape_tmp", "parse_error", "test"); err == nil {
+		t.Fatal("MoveCurToDLQ succeeded through an escaping dlq/tmp symlink")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("read outside: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("escaping dlq/tmp received %d files", len(entries))
+	}
+	if _, err := os.Stat(source); err != nil {
+		t.Fatalf("source should remain after refused DLQ delivery: %v", err)
+	}
+}
+
+func TestRetryFromDLQRejectsEscapingCurSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	dlqPath := createDLQMessage(t, root, "alice", "escape_retry.md", []byte("contained"))
+
+	outside := t.TempDir()
+	curDir := AgentDLQCur(root, "alice")
+	if err := os.RemoveAll(curDir); err != nil {
+		t.Fatalf("remove dlq cur: %v", err)
+	}
+	if err := os.Symlink(outside, curDir); err != nil {
+		t.Fatalf("symlink dlq cur: %v", err)
+	}
+
+	if err := RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", filepath.Base(dlqPath), false); err == nil {
+		t.Fatal("RetryFromDLQ succeeded through an escaping dlq/cur symlink")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatalf("read outside: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("escaping dlq/cur received %d files", len(entries))
+	}
+	if _, err := os.Stat(filepath.Join(AgentInboxNew(root, "alice"), "escape_retry.md")); !os.IsNotExist(err) {
+		t.Fatalf("retry redelivered before the confined envelope update, stat err: %v", err)
 	}
 }

--- a/internal/fsq/dlq_test.go
+++ b/internal/fsq/dlq_test.go
@@ -22,7 +22,7 @@ func TestMoveToDLQ(t *testing.T) {
 	}
 
 	// Move to DLQ
-	dlqPath, err := MoveToDLQ(root, "alice", filename, "corrupt_123", "parse_error", "missing frontmatter")
+	dlqPath, err := MoveToDLQ(openDeliveryRootForTest(t, root), "alice", filename, "corrupt_123", "parse_error", "missing frontmatter")
 	if err != nil {
 		t.Fatalf("MoveToDLQ: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestMoveToDLQ(t *testing.T) {
 	}
 
 	// Verify DLQ envelope content
-	env, body, err := ReadDLQEnvelope(dlqPath)
+	env, body, err := ReadDLQEnvelopePath(dlqPath)
 	if err != nil {
 		t.Fatalf("ReadDLQEnvelope: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestMoveToDLQClaimsBeforeDLQDelivery(t *testing.T) {
 		t.Fatalf("block dlq tmp: %v", err)
 	}
 
-	_, err := MoveToDLQ(root, "alice", filename, "claim_before_dlq", "parse_error", "missing frontmatter")
+	_, err := MoveToDLQ(openDeliveryRootForTest(t, root), "alice", filename, "claim_before_dlq", "parse_error", "missing frontmatter")
 	if err == nil {
 		t.Fatal("expected MoveToDLQ to fail when DLQ delivery cannot create tmp dir")
 	}
@@ -111,11 +111,11 @@ func TestMoveCurToDLQ(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(AgentInboxNew(root, "alice"), filename), content, 0o600); err != nil {
 		t.Fatalf("write corrupt: %v", err)
 	}
-	if err := MoveNewToCur(root, "alice", filename); err != nil {
+	if err := MoveNewToCur(openDeliveryRootForTest(t, root), "alice", filename); err != nil {
 		t.Fatalf("MoveNewToCur: %v", err)
 	}
 
-	dlqPath, err := MoveCurToDLQ(root, "alice", filename, "claimed_corrupt", "parse_error", "missing frontmatter")
+	dlqPath, err := MoveCurToDLQ(openDeliveryRootForTest(t, root), "alice", filename, "claimed_corrupt", "parse_error", "missing frontmatter")
 	if err != nil {
 		t.Fatalf("MoveCurToDLQ: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestMoveCurToDLQ(t *testing.T) {
 		t.Fatalf("claimed original should be removed from inbox/cur")
 	}
 
-	env, body, err := ReadDLQEnvelope(dlqPath)
+	env, body, err := ReadDLQEnvelopePath(dlqPath)
 	if err != nil {
 		t.Fatalf("ReadDLQEnvelope: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestRetryFromDLQ(t *testing.T) {
 	}
 
 	// Move to DLQ
-	dlqPath, err := MoveToDLQ(root, "alice", filename, "test_msg", "test_failure", "test detail")
+	dlqPath, err := MoveToDLQ(openDeliveryRootForTest(t, root), "alice", filename, "test_msg", "test_failure", "test detail")
 	if err != nil {
 		t.Fatalf("MoveToDLQ: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestRetryFromDLQ(t *testing.T) {
 	dlqFilename := filepath.Base(dlqPath)
 
 	// Retry from DLQ
-	if err := RetryFromDLQ(root, "alice", dlqFilename, false); err != nil {
+	if err := RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", dlqFilename, false); err != nil {
 		t.Fatalf("RetryFromDLQ: %v", err)
 	}
 
@@ -179,7 +179,7 @@ func TestRetryFromDLQ(t *testing.T) {
 	// Verify DLQ envelope moved to cur with incremented retry count
 	dlqCur := AgentDLQCur(root, "alice")
 	curPath := filepath.Join(dlqCur, dlqFilename)
-	env, _, err := ReadDLQEnvelope(curPath)
+	env, _, err := ReadDLQEnvelopePath(curPath)
 	if err != nil {
 		t.Fatalf("ReadDLQEnvelope from cur: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestReadDLQEnvelopeRejectsSymlink(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	_, _, err := ReadDLQEnvelope(link)
+	_, _, err := ReadDLQEnvelopePath(link)
 	if err == nil {
 		t.Fatal("expected symlink DLQ envelope to be rejected")
 	}
@@ -219,7 +219,7 @@ func TestMoveCurToDLQRejectsSymlinkSource(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	_, err := MoveCurToDLQ(root, "alice", "symlink_source.md", "symlink_source", "parse_error", "test")
+	_, err := MoveCurToDLQ(openDeliveryRootForTest(t, root), "alice", "symlink_source.md", "symlink_source", "parse_error", "test")
 	if err == nil {
 		t.Fatal("expected symlink inbox source to be rejected")
 	}
@@ -235,7 +235,7 @@ func TestRetryFromDLQRejectsTraversalOriginalFile(t *testing.T) {
 	}
 
 	dlqPath := createDLQMessage(t, root, "alice", "safe_msg.md", []byte("test content"))
-	env, body, err := ReadDLQEnvelope(dlqPath)
+	env, body, err := ReadDLQEnvelopePath(dlqPath)
 	if err != nil {
 		t.Fatalf("ReadDLQEnvelope: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestRetryFromDLQRejectsTraversalOriginalFile(t *testing.T) {
 		t.Fatalf("write tampered envelope: %v", err)
 	}
 
-	err = RetryFromDLQ(root, "alice", filepath.Base(dlqPath), false)
+	err = RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", filepath.Base(dlqPath), false)
 	if err == nil {
 		t.Fatal("expected traversal original_file to be rejected")
 	}
@@ -275,7 +275,7 @@ func TestRetryFromDLQEnvelopeUpdateFailureReturnsErrorBeforeRedelivery(t *testin
 		t.Fatalf("block dlq cur: %v", err)
 	}
 
-	err := RetryFromDLQ(root, "alice", filepath.Base(dlqPath), false)
+	err := RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", filepath.Base(dlqPath), false)
 	if err == nil {
 		t.Fatal("expected RetryFromDLQ to return envelope update error")
 	}
@@ -302,7 +302,7 @@ func TestRetryFromDLQRedeliveryFailureReturnsError(t *testing.T) {
 		t.Fatalf("block inbox tmp: %v", err)
 	}
 
-	err := RetryFromDLQ(root, "alice", filepath.Base(dlqPath), false)
+	err := RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", filepath.Base(dlqPath), false)
 	if err == nil {
 		t.Fatal("expected RetryFromDLQ to return redelivery error")
 	}
@@ -311,7 +311,7 @@ func TestRetryFromDLQRedeliveryFailureReturnsError(t *testing.T) {
 	}
 
 	curPath := filepath.Join(AgentDLQCur(root, "alice"), filepath.Base(dlqPath))
-	env, _, err := ReadDLQEnvelope(curPath)
+	env, _, err := ReadDLQEnvelopePath(curPath)
 	if err != nil {
 		t.Fatalf("expected updated DLQ envelope in cur: %v", err)
 	}
@@ -334,13 +334,13 @@ func TestRetryFromDLQMaxRetries(t *testing.T) {
 		t.Fatalf("write test msg: %v", err)
 	}
 
-	dlqPath, err := MoveToDLQ(root, "alice", filename, "test_msg", "test_failure", "test")
+	dlqPath, err := MoveToDLQ(openDeliveryRootForTest(t, root), "alice", filename, "test_msg", "test_failure", "test")
 	if err != nil {
 		t.Fatalf("MoveToDLQ: %v", err)
 	}
 
 	// Manually set retry_count to MaxRetries
-	env, body, _ := ReadDLQEnvelope(dlqPath)
+	env, body, _ := ReadDLQEnvelopePath(dlqPath)
 	env.RetryCount = MaxRetries
 	data, _ := serializeDLQMessage(*env, body)
 	if err := os.WriteFile(dlqPath, data, 0o600); err != nil {
@@ -350,7 +350,7 @@ func TestRetryFromDLQMaxRetries(t *testing.T) {
 	dlqFilename := filepath.Base(dlqPath)
 
 	// Retry should fail without --force
-	err = RetryFromDLQ(root, "alice", dlqFilename, false)
+	err = RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", dlqFilename, false)
 	if err == nil {
 		t.Errorf("expected error due to max retries")
 	}
@@ -359,7 +359,7 @@ func TestRetryFromDLQMaxRetries(t *testing.T) {
 	}
 
 	// Retry with --force should succeed
-	if err := RetryFromDLQ(root, "alice", dlqFilename, true); err != nil {
+	if err := RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", dlqFilename, true); err != nil {
 		t.Fatalf("RetryFromDLQ with force: %v", err)
 	}
 }
@@ -369,7 +369,7 @@ func createDLQMessage(t *testing.T, root, agent, filename string, content []byte
 	if err := os.WriteFile(filepath.Join(AgentInboxNew(root, agent), filename), content, 0o600); err != nil {
 		t.Fatalf("write source message: %v", err)
 	}
-	dlqPath, err := MoveToDLQ(root, agent, filename, strings.TrimSuffix(filename, ".md"), "test_failure", "test detail")
+	dlqPath, err := MoveToDLQ(openDeliveryRootForTest(t, root), agent, filename, strings.TrimSuffix(filename, ".md"), "test_failure", "test detail")
 	if err != nil {
 		t.Fatalf("MoveToDLQ: %v", err)
 	}
@@ -390,7 +390,7 @@ func TestFindDLQMessage(t *testing.T) {
 	}
 
 	// Find in new
-	path, box, err := FindDLQMessage(root, "alice", filename)
+	path, box, err := FindDLQMessage(openDeliveryRootForTest(t, root), "alice", filename)
 	if err != nil {
 		t.Fatalf("FindDLQMessage: %v", err)
 	}
@@ -402,12 +402,12 @@ func TestFindDLQMessage(t *testing.T) {
 	}
 
 	// Move to cur
-	if err := MoveDLQNewToCur(root, "alice", filename); err != nil {
+	if err := MoveDLQNewToCur(openDeliveryRootForTest(t, root), "alice", filename); err != nil {
 		t.Fatalf("MoveDLQNewToCur: %v", err)
 	}
 
 	// Find in cur
-	_, box, err = FindDLQMessage(root, "alice", filename)
+	_, box, err = FindDLQMessage(openDeliveryRootForTest(t, root), "alice", filename)
 	if err != nil {
 		t.Fatalf("FindDLQMessage after move: %v", err)
 	}

--- a/internal/fsq/filename_test.go
+++ b/internal/fsq/filename_test.go
@@ -52,7 +52,7 @@ func TestMessageFilenameEntryPointsAcceptValidFilenames(t *testing.T) {
 	if path != inboxPath || box != BoxNew {
 		t.Fatalf("FindMessage = (%q, %q), want (%q, %q)", path, box, inboxPath, BoxNew)
 	}
-	if err := MoveNewToCur(root, "alice", inboxFilename); err != nil {
+	if err := MoveNewToCur(openDeliveryRootForTest(t, root), "alice", inboxFilename); err != nil {
 		t.Fatalf("MoveNewToCur: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(AgentInboxCur(root, "alice"), inboxFilename)); err != nil {
@@ -61,21 +61,22 @@ func TestMessageFilenameEntryPointsAcceptValidFilenames(t *testing.T) {
 
 	dlqPath := createDLQMessage(t, root, "alice", "valid_dlq_source.md", []byte("dlq content"))
 	dlqFilename := filepath.Base(dlqPath)
-	path, box, err = FindDLQMessage(root, "alice", dlqFilename)
+	path, box, err = FindDLQMessage(openDeliveryRootForTest(t, root), "alice", dlqFilename)
 	if err != nil {
 		t.Fatalf("FindDLQMessage: %v", err)
 	}
-	if path != dlqPath || box != BoxNew {
-		t.Fatalf("FindDLQMessage = (%q, %q), want (%q, %q)", path, box, dlqPath, BoxNew)
+	wantDLQPath := filepath.Join("agents", "alice", "dlq", "new", dlqFilename)
+	if path != wantDLQPath || box != BoxNew {
+		t.Fatalf("FindDLQMessage = (%q, %q), want (%q, %q)", path, box, wantDLQPath, BoxNew)
 	}
-	if err := MoveDLQNewToCur(root, "alice", dlqFilename); err != nil {
+	if err := MoveDLQNewToCur(openDeliveryRootForTest(t, root), "alice", dlqFilename); err != nil {
 		t.Fatalf("MoveDLQNewToCur: %v", err)
 	}
 	dlqCurPath := filepath.Join(AgentDLQCur(root, "alice"), dlqFilename)
 	if _, err := os.Stat(dlqCurPath); err != nil {
 		t.Fatalf("expected dlq cur file: %v", err)
 	}
-	if err := RetryFromDLQ(root, "alice", dlqFilename, false); err != nil {
+	if err := RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", dlqFilename, false); err != nil {
 		t.Fatalf("RetryFromDLQ: %v", err)
 	}
 	restoredPath := filepath.Join(AgentInboxNew(root, "alice"), "valid_dlq_source.md")
@@ -107,7 +108,7 @@ func TestMoveNewToCurRejectsInvalidFilenames(t *testing.T) {
 
 	for _, filename := range invalidMessageFilenames(t) {
 		t.Run(filename, func(t *testing.T) {
-			if err := MoveNewToCur(root, "alice", filename); err == nil {
+			if err := MoveNewToCur(openDeliveryRootForTest(t, root), "alice", filename); err == nil {
 				t.Fatalf("MoveNewToCur(%q) error = nil, want error", filename)
 			}
 		})
@@ -122,7 +123,7 @@ func TestMoveCurToDLQRejectsInvalidFilenames(t *testing.T) {
 
 	for _, filename := range invalidMessageFilenames(t) {
 		t.Run(filename, func(t *testing.T) {
-			if _, err := MoveCurToDLQ(root, "alice", filename, "msg", "test_failure", "test detail"); err == nil {
+			if _, err := MoveCurToDLQ(openDeliveryRootForTest(t, root), "alice", filename, "msg", "test_failure", "test detail"); err == nil {
 				t.Fatalf("MoveCurToDLQ(%q) error = nil, want error", filename)
 			}
 		})
@@ -137,7 +138,7 @@ func TestFindDLQMessageRejectsInvalidFilenames(t *testing.T) {
 
 	for _, filename := range invalidMessageFilenames(t) {
 		t.Run(filename, func(t *testing.T) {
-			if _, _, err := FindDLQMessage(root, "alice", filename); err == nil {
+			if _, _, err := FindDLQMessage(openDeliveryRootForTest(t, root), "alice", filename); err == nil {
 				t.Fatalf("FindDLQMessage(%q) error = nil, want error", filename)
 			}
 		})
@@ -152,7 +153,7 @@ func TestMoveDLQNewToCurRejectsInvalidFilenames(t *testing.T) {
 
 	for _, filename := range invalidMessageFilenames(t) {
 		t.Run(filename, func(t *testing.T) {
-			if err := MoveDLQNewToCur(root, "alice", filename); err == nil {
+			if err := MoveDLQNewToCur(openDeliveryRootForTest(t, root), "alice", filename); err == nil {
 				t.Fatalf("MoveDLQNewToCur(%q) error = nil, want error", filename)
 			}
 		})
@@ -167,7 +168,7 @@ func TestRetryFromDLQRejectsInvalidDLQFilenames(t *testing.T) {
 
 	for _, filename := range invalidMessageFilenames(t) {
 		t.Run(filename, func(t *testing.T) {
-			if err := RetryFromDLQ(root, "alice", filename, false); err == nil {
+			if err := RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", filename, false); err == nil {
 				t.Fatalf("RetryFromDLQ(%q) error = nil, want error", filename)
 			}
 		})
@@ -183,7 +184,7 @@ func TestRetryFromDLQRejectsInvalidOriginalFilenames(t *testing.T) {
 			}
 
 			dlqPath := createDLQMessage(t, root, "alice", "safe_msg.md", []byte("test content"))
-			env, body, err := ReadDLQEnvelope(dlqPath)
+			env, body, err := ReadDLQEnvelopePath(dlqPath)
 			if err != nil {
 				t.Fatalf("ReadDLQEnvelope: %v", err)
 			}
@@ -196,7 +197,7 @@ func TestRetryFromDLQRejectsInvalidOriginalFilenames(t *testing.T) {
 				t.Fatalf("write tampered envelope: %v", err)
 			}
 
-			err = RetryFromDLQ(root, "alice", filepath.Base(dlqPath), false)
+			err = RetryFromDLQ(openDeliveryRootForTest(t, root), "alice", filepath.Base(dlqPath), false)
 			if err == nil {
 				t.Fatal("expected invalid original_file to be rejected")
 			}

--- a/internal/fsq/find.go
+++ b/internal/fsq/find.go
@@ -29,21 +29,21 @@ func FindMessage(root, agent, filename string) (string, string, error) {
 	return "", "", os.ErrNotExist
 }
 
-func MoveNewToCur(root, agent, filename string) error {
+func MoveNewToCur(root *DeliveryRoot, agent, filename string) error {
 	if err := ValidateMessageFilename(filename); err != nil {
 		return err
 	}
-	newPath := filepath.Join(root, "agents", agent, "inbox", "new", filename)
-	curDir := filepath.Join(root, "agents", agent, "inbox", "cur")
+	newPath := filepath.Join("agents", agent, "inbox", "new", filename)
+	curDir := filepath.Join("agents", agent, "inbox", "cur")
 	curPath := filepath.Join(curDir, filename)
-	if err := os.MkdirAll(curDir, 0o700); err != nil {
+	if err := root.root.MkdirAll(curDir, 0o700); err != nil {
 		return err
 	}
-	if err := os.Rename(newPath, curPath); err != nil {
+	if err := root.root.Rename(newPath, curPath); err != nil {
 		return err
 	}
-	if err := SyncDir(filepath.Dir(newPath)); err != nil {
+	if err := root.syncDir(filepath.Dir(newPath)); err != nil {
 		return err
 	}
-	return SyncDir(curDir)
+	return root.syncDir(curDir)
 }

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -12,7 +12,7 @@ import (
 
 // DeliverToInbox writes a message using Maildir semantics (tmp -> new).
 // It returns the final path in inbox/new.
-func DeliverToInbox(root, agent, filename string, data []byte) (string, error) {
+func DeliverToInbox(root *DeliveryRoot, agent, filename string, data []byte) (string, error) {
 	paths, err := DeliverToInboxes(root, []string{agent}, filename, data)
 	if err != nil {
 		return "", err
@@ -50,7 +50,7 @@ func (e *PartialDeliveryError) Error() string {
 
 	failed := e.Failed
 	if failed == "" {
-		failed = "unknown"
+		failed = "none"
 	}
 
 	pending := "none"
@@ -71,27 +71,30 @@ func (e *PartialDeliveryError) Unwrap() error {
 // DeliverToInboxes writes a message to multiple inboxes.
 // On partial failure, committed deliveries remain in new/ and undelivered tmp
 // files are removed.
-func DeliverToInboxes(root string, recipients []string, filename string, data []byte) (map[string]string, error) {
+func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, data []byte) (map[string]string, error) {
 	if len(recipients) == 0 {
 		return nil, fmt.Errorf("no recipients provided")
 	}
+	if err := root.VerifyBase(); err != nil {
+		return nil, err
+	}
 	stages := make([]stagedDelivery, 0, len(recipients))
 	for _, recipient := range recipients {
-		tmpDir := AgentInboxTmp(root, recipient)
-		newDir := AgentInboxNew(root, recipient)
-		if err := os.MkdirAll(tmpDir, 0o700); err != nil {
-			return nil, cleanupStagedTmp(stages, err)
+		tmpDir := filepath.Join("agents", recipient, "inbox", "tmp")
+		newDir := filepath.Join("agents", recipient, "inbox", "new")
+		if err := root.root.MkdirAll(tmpDir, 0o700); err != nil {
+			return nil, cleanupStagedTmp(root, stages, err)
 		}
-		if err := os.MkdirAll(newDir, 0o700); err != nil {
-			return nil, cleanupStagedTmp(stages, err)
+		if err := root.root.MkdirAll(newDir, 0o700); err != nil {
+			return nil, cleanupStagedTmp(root, stages, err)
 		}
 		tmpPath := filepath.Join(tmpDir, filename)
 		newPath := filepath.Join(newDir, filename)
-		if err := writeAndSync(tmpPath, data, 0o600); err != nil {
-			return nil, cleanupStagedTmp(stages, err)
+		if err := root.writeAndSync(tmpPath, data, 0o600); err != nil {
+			return nil, cleanupStagedTmp(root, stages, err)
 		}
-		if err := SyncDir(tmpDir); err != nil {
-			return nil, cleanupStagedTmp(stages, cleanupTemp(tmpPath, err))
+		if err := root.syncDir(tmpDir); err != nil {
+			return nil, cleanupStagedTmp(root, stages, root.cleanupTemp(tmpPath, err))
 		}
 		stages = append(stages, stagedDelivery{
 			recipient: recipient,
@@ -103,27 +106,27 @@ func DeliverToInboxes(root string, recipients []string, filename string, data []
 	}
 
 	for i, stage := range stages {
-		if err := os.Rename(stage.tmpPath, stage.newPath); err != nil {
+		if err := root.root.Rename(stage.tmpPath, stage.newPath); err != nil {
 			if errors.Is(err, syscall.EXDEV) {
 				err = fmt.Errorf("rename tmp->new for %s: different filesystems: %w", stage.recipient, err)
 			} else {
 				err = fmt.Errorf("rename tmp->new for %s: %w", stage.recipient, err)
 			}
-			return nil, partialDeliveryError(stages[:i], stage, stages[i+1:], err)
+			return nil, partialDeliveryError(root, stages[:i], stage, stages[i+1:], err)
 		}
 		// Sync both directories after rename for fully durable delivery:
 		// - newDir: new entry is visible
 		// - tmpDir: old entry removal is durable
-		if err := SyncDir(stage.newDir); err != nil {
-			return nil, partialDeliveryError(stages[:i+1], stage, stages[i+1:], fmt.Errorf("sync new dir for %s: %w", stage.recipient, err))
+		if err := root.syncDir(stage.newDir); err != nil {
+			return nil, committedDeliveryError(root, stages[:i+1], stages[i+1:], fmt.Errorf("sync new dir for %s: %w", stage.recipient, err))
 		}
 		// Best-effort sync of tmpDir (non-fatal: message is already delivered)
-		_ = SyncDir(stage.tmpDir)
+		_ = root.syncDir(stage.tmpDir)
 	}
 
 	paths := make(map[string]string, len(stages))
 	for _, stage := range stages {
-		paths[stage.recipient] = stage.newPath
+		paths[stage.recipient] = root.displayPath(stage.newPath)
 	}
 	return paths, nil
 }
@@ -132,54 +135,52 @@ func DeliverToInboxes(root string, recipients []string, filename string, data []
 // Maildir semantics (tmp -> new). Unlike DeliverToInboxes, it never creates
 // directories — the target inbox must already exist. This prevents a sender
 // from accidentally scaffolding structure in a peer project.
-func DeliverToExistingInbox(root, agent, filename string, data []byte) (string, error) {
-	tmpDir := AgentInboxTmp(root, agent)
-	newDir := AgentInboxNew(root, agent)
+func DeliverToExistingInbox(root *DeliveryRoot, agent, filename string, data []byte) (string, error) {
+	if err := root.VerifyBase(); err != nil {
+		return "", err
+	}
+	tmpDir := filepath.Join("agents", agent, "inbox", "tmp")
+	newDir := filepath.Join("agents", agent, "inbox", "new")
 
 	// Verify directories exist (never create in foreign roots).
-	if !dirExists(tmpDir) {
-		return "", fmt.Errorf("peer inbox tmp dir does not exist: %s", tmpDir)
+	if !root.dirExists(tmpDir) {
+		return "", fmt.Errorf("peer inbox tmp dir does not exist: %s", root.displayPath(tmpDir))
 	}
-	if !dirExists(newDir) {
-		return "", fmt.Errorf("peer inbox new dir does not exist: %s", newDir)
+	if !root.dirExists(newDir) {
+		return "", fmt.Errorf("peer inbox new dir does not exist: %s", root.displayPath(newDir))
 	}
 
 	tmpPath := filepath.Join(tmpDir, filename)
 	newPath := filepath.Join(newDir, filename)
 
-	if err := writeAndSync(tmpPath, data, 0o600); err != nil {
+	if err := root.writeAndSync(tmpPath, data, 0o600); err != nil {
 		return "", err
 	}
-	if err := SyncDir(tmpDir); err != nil {
-		return "", cleanupTemp(tmpPath, err)
+	if err := root.syncDir(tmpDir); err != nil {
+		return "", root.cleanupTemp(tmpPath, err)
 	}
-	if err := os.Rename(tmpPath, newPath); err != nil {
-		return "", cleanupTemp(tmpPath, fmt.Errorf("rename tmp->new for %s: %w", agent, err))
+	if err := root.root.Rename(tmpPath, newPath); err != nil {
+		return "", root.cleanupTemp(tmpPath, fmt.Errorf("rename tmp->new for %s: %w", agent, err))
 	}
-	if err := SyncDir(newDir); err != nil {
+	if err := root.syncDir(newDir); err != nil {
 		return "", fmt.Errorf("sync new dir for %s: %w", agent, err)
 	}
-	_ = SyncDir(tmpDir) // best-effort
-	return newPath, nil
+	_ = root.syncDir(tmpDir) // best-effort
+	return root.displayPath(newPath), nil
 }
 
-func dirExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
-}
-
-func cleanupStagedTmp(stages []stagedDelivery, primary error) error {
-	cleanupErr := cleanupTmpStages(stages)
+func cleanupStagedTmp(root *DeliveryRoot, stages []stagedDelivery, primary error) error {
+	cleanupErr := cleanupTmpStages(root, stages)
 	if cleanupErr == nil {
 		return primary
 	}
 	return fmt.Errorf("%w (cleanup: %v)", primary, cleanupErr)
 }
 
-func partialDeliveryError(committed []stagedDelivery, failed stagedDelivery, pending []stagedDelivery, primary error) error {
+func partialDeliveryError(root *DeliveryRoot, committed []stagedDelivery, failed stagedDelivery, pending []stagedDelivery, primary error) error {
 	delivered := make(map[string]string, len(committed))
 	for _, stage := range committed {
-		delivered[stage.recipient] = stage.newPath
+		delivered[stage.recipient] = root.displayPath(stage.newPath)
 	}
 
 	pendingRecipients := make([]string, 0, len(pending))
@@ -190,7 +191,7 @@ func partialDeliveryError(committed []stagedDelivery, failed stagedDelivery, pen
 	undelivered := make([]stagedDelivery, 0, 1+len(pending))
 	undelivered = append(undelivered, failed)
 	undelivered = append(undelivered, pending...)
-	if cleanupErr := cleanupTmpStages(undelivered); cleanupErr != nil {
+	if cleanupErr := cleanupTmpStages(root, undelivered); cleanupErr != nil {
 		primary = fmt.Errorf("%w (cleanup: %v)", primary, cleanupErr)
 	}
 
@@ -202,13 +203,32 @@ func partialDeliveryError(committed []stagedDelivery, failed stagedDelivery, pen
 	}
 }
 
-func cleanupTmpStages(stages []stagedDelivery) error {
+func committedDeliveryError(root *DeliveryRoot, committed, pending []stagedDelivery, primary error) error {
+	delivered := make(map[string]string, len(committed))
+	for _, stage := range committed {
+		delivered[stage.recipient] = root.displayPath(stage.newPath)
+	}
+	pendingRecipients := make([]string, 0, len(pending))
+	for _, stage := range pending {
+		pendingRecipients = append(pendingRecipients, stage.recipient)
+	}
+	if cleanupErr := cleanupTmpStages(root, pending); cleanupErr != nil {
+		primary = fmt.Errorf("%w (cleanup: %v)", primary, cleanupErr)
+	}
+	return &PartialDeliveryError{
+		Delivered: delivered,
+		Pending:   pendingRecipients,
+		Err:       primary,
+	}
+}
+
+func cleanupTmpStages(root *DeliveryRoot, stages []stagedDelivery) error {
 	var cleanupErr error
 	for _, stage := range stages {
-		if err := os.Remove(stage.tmpPath); err != nil && !os.IsNotExist(err) {
+		if err := root.root.Remove(stage.tmpPath); err != nil && !os.IsNotExist(err) {
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cleanup tmp %s: %w", stage.tmpPath, err))
 		}
-		if err := SyncDir(stage.tmpDir); err != nil {
+		if err := root.syncDir(stage.tmpDir); err != nil {
 			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("sync tmp dir %s: %w", stage.tmpDir, err))
 		}
 	}

--- a/internal/fsq/maildir_test.go
+++ b/internal/fsq/maildir_test.go
@@ -18,7 +18,7 @@ func TestDeliverToInbox(t *testing.T) {
 	}
 	data := []byte("hello")
 	filename := "test.md"
-	path, err := DeliverToInbox(root, "codex", filename, data)
+	path, err := DeliverToInbox(openDeliveryRootForTest(t, root), "codex", filename, data)
 	if err != nil {
 		t.Fatalf("DeliverToInbox: %v", err)
 	}
@@ -45,10 +45,10 @@ func TestMoveNewToCur(t *testing.T) {
 	}
 	data := []byte("hello")
 	filename := "move.md"
-	if _, err := DeliverToInbox(root, "codex", filename, data); err != nil {
+	if _, err := DeliverToInbox(openDeliveryRootForTest(t, root), "codex", filename, data); err != nil {
 		t.Fatalf("DeliverToInbox: %v", err)
 	}
-	if err := MoveNewToCur(root, "codex", filename); err != nil {
+	if err := MoveNewToCur(openDeliveryRootForTest(t, root), "codex", filename); err != nil {
 		t.Fatalf("MoveNewToCur: %v", err)
 	}
 	newPath := filepath.Join(root, "agents", "codex", "inbox", "new", filename)
@@ -72,7 +72,7 @@ func TestDeliverToExistingInbox(t *testing.T) {
 
 	data := []byte("cross-project message")
 	filename := "xproj.md"
-	path, err := DeliverToExistingInbox(root, "codex", filename, data)
+	path, err := DeliverToExistingInbox(openDeliveryRootForTest(t, root), "codex", filename, data)
 	if err != nil {
 		t.Fatalf("DeliverToExistingInbox: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestDeliverToExistingInbox(t *testing.T) {
 func TestDeliverToExistingInboxNoDir(t *testing.T) {
 	root := t.TempDir()
 	// Do NOT create agent dirs — inbox doesn't exist.
-	_, err := DeliverToExistingInbox(root, "ghost", "test.md", []byte("nope"))
+	_, err := DeliverToExistingInbox(openDeliveryRootForTest(t, root), "ghost", "test.md", []byte("nope"))
 	if err == nil {
 		t.Fatal("expected error for non-existent inbox")
 	}
@@ -132,7 +132,7 @@ func TestDeliverToInboxesRollback(t *testing.T) {
 	defer func() { _ = os.Chmod(cloudNew, 0o700) }()
 
 	filename := "multi.md"
-	_, err := DeliverToInboxes(root, []string{"codex", "claude", "ada"}, filename, []byte("hello"))
+	_, err := DeliverToInboxes(openDeliveryRootForTest(t, root), []string{"codex", "claude", "ada"}, filename, []byte("hello"))
 	if err == nil {
 		t.Fatalf("expected delivery error")
 	}
@@ -172,4 +172,60 @@ func TestDeliverToInboxesRollback(t *testing.T) {
 	if _, err := os.Stat(adaNew); !os.IsNotExist(err) {
 		t.Fatalf("expected pending recipient to have no new delivery at %s", adaNew)
 	}
+}
+
+func TestDeliverToInboxesSyncFailureCountsRenamedStageOnlyAsDelivered(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"codex", "claude"} {
+		if err := EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	deliveryRoot := openDeliveryRootForTest(t, root)
+	failingDir := filepath.Join("agents", "codex", "inbox", "new")
+	deliveryRoot.syncDirForTest = func(dir string) error {
+		if dir == failingDir {
+			return errors.New("injected post-rename sync failure")
+		}
+		return deliveryRoot.syncDirPlatform(dir)
+	}
+
+	filename := "sync-failure.md"
+	_, err := DeliverToInboxes(deliveryRoot, []string{"codex", "claude"}, filename, []byte("hello"))
+	var partial *PartialDeliveryError
+	if !errors.As(err, &partial) {
+		t.Fatalf("DeliverToInboxes error = %T %v, want PartialDeliveryError", err, err)
+	}
+	if partial.Failed != "" {
+		t.Fatalf("Failed = %q, want empty after successful rename", partial.Failed)
+	}
+	if got := partial.Delivered["codex"]; got != filepath.Join(AgentInboxNew(root, "codex"), filename) {
+		t.Fatalf("Delivered[codex] = %q", got)
+	}
+	if len(partial.Pending) != 1 || partial.Pending[0] != "claude" {
+		t.Fatalf("Pending = %#v, want [claude]", partial.Pending)
+	}
+	if _, err := os.Stat(filepath.Join(AgentInboxNew(root, "codex"), filename)); err != nil {
+		t.Fatalf("committed delivery missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(AgentInboxTmp(root, "codex"), filename)); !os.IsNotExist(err) {
+		t.Fatalf("renamed tmp still exists: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(AgentInboxTmp(root, "claude"), filename)); !os.IsNotExist(err) {
+		t.Fatalf("pending tmp still exists: %v", err)
+	}
+}
+
+func openDeliveryRootForTest(t testing.TB, base string) *DeliveryRoot {
+	t.Helper()
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot(%s): %v", base, err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot(%s): %v", base, err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return root
 }

--- a/internal/integration/common/deliver.go
+++ b/internal/integration/common/deliver.go
@@ -53,7 +53,16 @@ func DeliverIntegrationMessage(root, from, to, subject, body string, ctx map[str
 	}
 
 	filename := id + ".md"
-	paths, err := fsq.DeliverToInboxes(root, msg.Header.To, filename, data)
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		return "", fmt.Errorf("authorize delivery root: %w", err)
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		return "", fmt.Errorf("open delivery root: %w", err)
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+	paths, err := fsq.DeliverToInboxes(deliveryRoot, msg.Header.To, filename, data)
 	if err != nil {
 		return "", fmt.Errorf("deliver message: %w", err)
 	}

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -39,6 +39,20 @@ func Write(root string, p Presence) error {
 	return err
 }
 
+// WriteDeliveryRoot writes presence through an already authorized root
+// capability. Send/reply use this form so a path alias change cannot redirect a
+// best-effort presence update outside the authorized tree.
+func WriteDeliveryRoot(root *fsq.DeliveryRoot, p Presence) error {
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	dir := filepath.Join("agents", p.Handle)
+	_, err = root.WriteFileAtomic(dir, "presence.json", data, 0o600)
+	return err
+}
+
 // Touch updates the LastSeen timestamp for an agent's presence.
 // If presence already exists, it preserves Status and Note.
 // If no presence exists, it creates one with status "active".
@@ -54,6 +68,25 @@ func Touch(root, handle string) error {
 		p.LastSeen = time.Now().UTC().Format(time.RFC3339Nano)
 	}
 	return Write(root, p)
+}
+
+// TouchDeliveryRoot updates presence through a pinned root capability.
+func TouchDeliveryRoot(root *fsq.DeliveryRoot, handle string) error {
+	path := filepath.Join("agents", handle, "presence.json")
+	data, err := root.ReadFile(path)
+	var p Presence
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		p = New(handle, "active", "", time.Now())
+	} else {
+		if err := json.Unmarshal(data, &p); err != nil {
+			return err
+		}
+		p.LastSeen = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	return WriteDeliveryRoot(root, p)
 }
 
 func Read(root, handle string) (Presence, error) {

--- a/internal/receipt/receipt.go
+++ b/internal/receipt/receipt.go
@@ -71,6 +71,19 @@ func Emit(root string, r Receipt) error {
 	return nil
 }
 
+// EmitDeliveryRoot writes a receipt through an already authorized root.
+func EmitDeliveryRoot(root *fsq.DeliveryRoot, r Receipt) error {
+	data, err := r.Marshal()
+	if err != nil {
+		return fmt.Errorf("receipt marshal: %w", err)
+	}
+	dir := filepath.Join("agents", r.Consumer, "receipts")
+	if _, err := root.WriteFileAtomic(dir, r.filename(), data, 0o600); err != nil {
+		return fmt.Errorf("receipt write (consumer %s): %w", r.Consumer, err)
+	}
+	return nil
+}
+
 // WaitFor polls for a specific consumer-local receipt by deterministic filename.
 // Returns the receipt on match, or an error on timeout.
 func WaitFor(root, msgID, consumer, stage string, timeout, pollInterval time.Duration) (Receipt, error) {
@@ -97,11 +110,39 @@ func WaitFor(root, msgID, consumer, stage string, timeout, pollInterval time.Dur
 	}
 }
 
+// WaitForDeliveryRoot polls through the same capability used for delivery so a
+// renamed root cannot redirect receipt observation to another tree.
+func WaitForDeliveryRoot(root *fsq.DeliveryRoot, msgID, consumer, stage string, timeout, pollInterval time.Duration) (Receipt, error) {
+	name := fmt.Sprintf("%s__%s__%s.json", msgID, consumer, stage)
+	path := filepath.Join("agents", consumer, "receipts", name)
+	deadline := time.Time{}
+	if timeout > 0 {
+		deadline = time.Now().Add(timeout)
+	}
+	for {
+		data, err := root.ReadRegularNoFollow(path)
+		if err == nil {
+			return parseReceipt(data)
+		}
+		if !os.IsNotExist(err) {
+			return Receipt{}, err
+		}
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return Receipt{}, os.ErrDeadlineExceeded
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
 func Read(path string) (Receipt, error) {
 	data, err := fsq.ReadRegularNoFollow(path)
 	if err != nil {
 		return Receipt{}, err
 	}
+	return parseReceipt(data)
+}
+
+func parseReceipt(data []byte) (Receipt, error) {
 	var r Receipt
 	if err := json.Unmarshal(data, &r); err != nil {
 		return Receipt{}, err

--- a/internal/receipt/receipt_delivery_root_unix_test.go
+++ b/internal/receipt/receipt_delivery_root_unix_test.go
@@ -1,0 +1,53 @@
+//go:build darwin || linux
+
+package receipt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestWaitForDeliveryRootRejectsReplacedRootAlias(t *testing.T) {
+	parent := t.TempDir()
+	rootPath := filepath.Join(parent, "delivery")
+	if err := os.MkdirAll(rootPath, 0o700); err != nil {
+		t.Fatalf("create delivery root: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(rootPath, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	parked := filepath.Join(parent, "delivery-parked")
+	if err := os.Rename(rootPath, parked); err != nil {
+		t.Fatalf("park delivery root: %v", err)
+	}
+	if err := os.MkdirAll(rootPath, 0o700); err != nil {
+		t.Fatalf("create replacement root: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(rootPath, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs replacement: %v", err)
+	}
+	malicious := New("msg_replaced", "", "attacker", "codex", StageDrained, "")
+	if err := Emit(rootPath, malicious); err != nil {
+		t.Fatalf("emit replacement receipt: %v", err)
+	}
+
+	_, err = WaitForDeliveryRoot(root, malicious.MsgID, malicious.Consumer, malicious.Stage, 100*time.Millisecond, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "delivery root changed after authorization") {
+		t.Fatalf("WaitForDeliveryRoot error = %v, want root-change refusal", err)
+	}
+}

--- a/internal/swarm/bridge.go
+++ b/internal/swarm/bridge.go
@@ -382,6 +382,15 @@ func deliverBridgeEvent(cfg BridgeConfig, event BridgeEvent) error {
 	}
 
 	filename := id + ".md"
-	_, err = fsq.DeliverToInboxes(cfg.AMQRoot, msg.Header.To, filename, data)
+	identity, err := fsq.SnapshotDeliveryRoot(cfg.AMQRoot)
+	if err != nil {
+		return err
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(cfg.AMQRoot, identity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+	_, err = fsq.DeliverToInboxes(deliveryRoot, msg.Header.To, filename, data)
 	return err
 }

--- a/internal/thread/thread_test.go
+++ b/internal/thread/thread_test.go
@@ -57,10 +57,19 @@ func TestCollectThread(t *testing.T) {
 		t.Fatalf("marshal msg2: %v", err)
 	}
 
-	if _, err := fsq.DeliverToInbox(root, "claude", "msg-1.md", data1); err != nil {
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+	if _, err := fsq.DeliverToInbox(deliveryRoot, "claude", "msg-1.md", data1); err != nil {
 		t.Fatalf("deliver msg1: %v", err)
 	}
-	if _, err := fsq.DeliverToInbox(root, "codex", "msg-2.md", data2); err != nil {
+	if _, err := fsq.DeliverToInbox(deliveryRoot, "codex", "msg-2.md", data2); err != nil {
 		t.Fatalf("deliver msg2: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Wave 2 of #233 — the **real cross-tree security boundary** (W1 was advisory identity/de-laundering). All message delivery now goes through an `fsq.DeliveryRoot` capability wrapping Go 1.25 `os.Root`: opened **once at authorization** and verified against the pinned identity token (`OpenDeliveryRoot(base, expected)` → the opened fd's physical identity must equal the authorized identity, closing the authorize→open swap window), then the **same handle** threads into every delivery-layer write. All mutations are root-relative on the handle (`MkdirAll`/`OpenFile` O_EXCL 0600/`Rename`/`Remove` + handle dir-sync) — inbox delivery, cross-project delivery, DLQ, outbox, presence, receipts. A post-authorization symlink swap on any ancestor/mailbox component cannot retarget the pinned dirfd.

## Threat model (SECURITY.md)

Same-euid attackers out of scope; **untrusted ancestor dirs + post-authorization symlink/topology swaps in scope**. `os.Root` confines to the opened dirfd (escaping symlinks refused). Documented residual: `os.Root` does not stop bind mounts / device files — a future gated wave.

## Review

Adversarial gate (Gemini 3.1 Pro) BLOCKed the first cut with 5 real findings — a critical authorize→open bypass, unconfined DLQ/atomic writes, a receipt-wait pathname reopen, and rollback double-counting — **all fixed and re-gated to PASS**. Deterministic 200-swap stress test (handshaked so every delivery runs with the malicious alias installed) + `-race` green. `make ci` (golangci-lint 0 issues) + all four GOOS builds green. ChatGPT-Pro sign-off runs pre-release.

Part of #233. Implementation by Codex; design/review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)