### PR TITLE
test(wake): integration and upgrade race coverage for wake lifecycle

### DIFF
--- a/internal/cli/wake_upgrade_race_darwin_test.go
+++ b/internal/cli/wake_upgrade_race_darwin_test.go
@@ -1,0 +1,34 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWakeUpgradeRetireLegacyWithoutControlMetadataFailsClosed(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, wakePID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("legacy inject-via retirement must not fall back to a bare PID signal")
+		return nil
+	})
+
+	result, err := retireWake(root, "codex", requested)
+	if err == nil || result.Status != "error" || !strings.Contains(result.Reason, "no cooperative control endpoint") {
+		t.Fatalf("retire result = %#v err=%v, want missing-control failure", result, err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("legacy lock was not preserved: %v", err)
+	}
+	if _, err := os.Stat(wakeTargetPath(root, "codex")); err != nil {
+		t.Fatalf("legacy target was not preserved: %v", err)
+	}
+}

--- a/internal/cli/wake_upgrade_race_linux_test.go
+++ b/internal/cli/wake_upgrade_race_linux_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestWakeUpgradeRetireUnsupportedPidfdFailsClosed(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, wakePID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	stubLinuxPidfd(t,
+		func(int, int) (int, error) { return -1, syscall.ENOSYS },
+		func(int, unix.Signal, *unix.Siginfo, int) error {
+			t.Fatal("retirement must not signal without a pidfd")
+			return nil
+		},
+		func(int, time.Duration) (bool, error) {
+			t.Fatal("retirement must not poll without a pidfd")
+			return false, nil
+		},
+	)
+
+	result, err := retireWake(root, "codex", requested)
+	if err == nil || result.Status != "error" || !strings.Contains(result.Reason, "pidfd_open") {
+		t.Fatalf("retire result = %#v err=%v, want unsupported-pidfd failure", result, err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("lock was not preserved: %v", err)
+	}
+	if _, err := os.Stat(wakeTargetPath(root, "codex")); err != nil {
+		t.Fatalf("target was not preserved: %v", err)
+	}
+}

--- a/internal/cli/wake_upgrade_race_unix_test.go
+++ b/internal/cli/wake_upgrade_race_unix_test.go
@@ -1,0 +1,250 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestWakeUpgradeRaceRepairAcceptsConcurrentCurrentAcquire(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-a"})
+	legacyGeneration := "legacy-without-control-metadata"
+	writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+		Generation: legacyGeneration,
+	}, target))
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("write legacy wake target: %v", err)
+	}
+
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == os.Getpid() {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "current-start",
+				BootID:     "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+			}
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	repairStarted := make(chan struct{})
+	releaseRepair := make(chan struct{})
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget) (int, error) {
+		if gotRoot != root || gotMe != "codex" || !sameWakeInjectorIdentity(gotTarget, target) {
+			t.Fatalf("repair starter got root=%q me=%q target=%#v", gotRoot, gotMe, gotTarget)
+		}
+		close(repairStarted)
+		<-releaseRepair
+		return 0, errors.New("lost start race")
+	})
+
+	type repairResult struct {
+		result wakeRepairResult
+		err    error
+	}
+	repaired := make(chan repairResult, 1)
+	go func() {
+		result, err := repairWake(root, "codex")
+		repaired <- repairResult{result: result, err: err}
+	}()
+	<-repairStarted // The legacy stale generation has been removed and the guard released.
+
+	cleanup, err := acquireWakeLock(root, "codex", &target)
+	if err != nil {
+		t.Fatalf("concurrent current-version acquire: %v", err)
+	}
+	defer cleanup()
+	winner := inspectWakeLock(root, "codex")
+	if winner.Status != wakeLockValid || !winner.IdentityConfirmed {
+		t.Fatalf("concurrent winner = %#v, want confirmed valid", winner)
+	}
+	if winner.Lock.Generation == "" || winner.Lock.Generation == legacyGeneration {
+		t.Fatalf("winner generation = %q, want a new current generation", winner.Lock.Generation)
+	}
+	if winner.Lock.WakeMode != wakeTargetInjectVia || winner.Lock.TargetDigest != wakeTargetDigest(target) {
+		t.Fatalf("winner metadata = %#v, want current inject-via target binding", winner.Lock)
+	}
+	if runtime.GOOS == "darwin" && winner.Lock.ControlSocket == "" {
+		t.Fatal("Darwin current-version winner omitted cooperative control metadata")
+	}
+
+	close(releaseRepair)
+	got := <-repaired
+	if got.err != nil {
+		t.Fatalf("repair rejected exact concurrent winner: result=%#v err=%v", got.result, got.err)
+	}
+	if got.result.Status != "repaired" || got.result.PID != os.Getpid() {
+		t.Fatalf("repair result = %#v, want current acquire as repaired winner", got.result)
+	}
+	persisted, exists, err := readWakeTarget(root, "codex")
+	if err != nil || !exists || !sameWakeInjectorIdentity(persisted, target) {
+		t.Fatalf("persisted target = (%#v,%v,%v), want exact current target", persisted, exists, err)
+	}
+}
+
+func TestWakeUpgradeRaceCleanupAndReadinessPreserveReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	originalTarget := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-a"})
+	replacementTarget := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-b"})
+	cleanup, err := acquireWakeLock(root, "codex", &originalTarget)
+	if err != nil {
+		t.Fatalf("acquire original wake: %v", err)
+	}
+	original := inspectWakeLock(root, "codex")
+	readyPath := fsq.AgentBase(root, "codex") + "/wake-upgrade.ready"
+
+	holderEntered := make(chan struct{})
+	replaceNow := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- withWakeLifecycleGuard(root, "codex", func() error {
+			close(holderEntered)
+			<-replaceNow
+			if err := writeWakeTargetGuarded(root, "codex", replacementTarget); err != nil {
+				return err
+			}
+			replacement := original.Lock
+			replacement.Generation = "replacement-generation"
+			replacement.TargetDigest = wakeTargetDigest(replacementTarget)
+			replacement.ControlSocket = wakeControlSocketPath(root, "codex", replacement.Generation)
+			data, err := json.Marshal(replacement)
+			if err != nil {
+				return err
+			}
+			if err := os.Remove(original.LockPath); err != nil {
+				return err
+			}
+			return os.WriteFile(original.LockPath, data, 0o600)
+		})
+	}()
+	<-holderEntered
+
+	cleanupStarted := make(chan struct{})
+	cleanupDone := make(chan struct{})
+	go func() {
+		close(cleanupStarted)
+		cleanup()
+		close(cleanupDone)
+	}()
+	readyStarted := make(chan struct{})
+	readyDone := make(chan error, 1)
+	go func() {
+		close(readyStarted)
+		readyDone <- writeWakeReadyFile(root, "codex", readyPath, original)
+	}()
+	<-cleanupStarted
+	<-readyStarted
+	close(replaceNow)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("replace under lifecycle guard: %v", err)
+	}
+	<-cleanupDone
+	readyErr := <-readyDone
+	if readyErr == nil || !strings.Contains(readyErr.Error(), "generation changed") {
+		t.Fatalf("old readiness error = %v, want generation-change refusal", readyErr)
+	}
+	if _, err := os.Stat(readyPath); !os.IsNotExist(err) {
+		t.Fatalf("old generation published readiness: %v", err)
+	}
+
+	current := inspectWakeLock(root, "codex")
+	if !current.Exists || current.Lock.Generation != "replacement-generation" {
+		t.Fatalf("old cleanup removed replacement: %#v", current)
+	}
+	persisted, exists, err := readWakeTarget(root, "codex")
+	if err != nil || !exists || !sameWakeInjectorIdentity(persisted, replacementTarget) {
+		t.Fatalf("replacement target = (%#v,%v,%v), want exact replacement", persisted, exists, err)
+	}
+}
+
+func TestWakeUpgradeRaceRetireRefusesLockAndTargetReplacement(t *testing.T) {
+	const oldPID = 4242
+	const replacementPID = 4343
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, oldPID)
+	replacementTarget := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-b"})
+
+	initialInspected := make(chan struct{})
+	var initialOnce sync.Once
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == oldPID {
+			initialOnce.Do(func() { close(initialInspected) })
+		}
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	holderEntered := make(chan struct{})
+	replaceNow := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- withWakeLifecycleGuard(root, "codex", func() error {
+			close(holderEntered)
+			<-replaceNow
+			if err := writeWakeTargetGuarded(root, "codex", replacementTarget); err != nil {
+				return err
+			}
+			replacement := bindWakeLockToTarget(wakeLock{
+				PID:          replacementPID,
+				TTY:          "unknown",
+				ProcessStart: "wake-start",
+				BootID:       "boot-1",
+				Executable:   "/opt/homebrew/bin/amq",
+				Args:         []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+				Generation:   "replacement-generation",
+			}, replacementTarget)
+			replacement.ControlSocket = wakeControlSocketPath(root, "codex", replacement.Generation)
+			data, err := json.Marshal(replacement)
+			if err != nil {
+				return err
+			}
+			if err := os.Remove(lockPath); err != nil {
+				return err
+			}
+			return os.WriteFile(lockPath, data, 0o600)
+		})
+	}()
+	<-holderEntered
+
+	type retireResult struct {
+		result wakeRetireResult
+		err    error
+	}
+	retired := make(chan retireResult, 1)
+	go func() {
+		result, err := retireWake(root, "codex", requested)
+		retired <- retireResult{result: result, err: err}
+	}()
+	<-initialInspected // retire captured the old generation before waiting on the guard.
+	close(replaceNow)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("replace under lifecycle guard: %v", err)
+	}
+	got := <-retired
+	if got.err == nil || got.result.Status != "refused" || !strings.Contains(got.result.Reason, "changed before retirement") {
+		t.Fatalf("retire result = %#v err=%v, want replacement refusal", got.result, got.err)
+	}
+
+	current := inspectWakeLock(root, "codex")
+	if !current.Exists || current.PID != replacementPID || current.Lock.Generation != "replacement-generation" {
+		t.Fatalf("retire changed replacement lock: %#v", current)
+	}
+	persisted, exists, err := readWakeTarget(root, "codex")
+	if err != nil || !exists || !sameWakeInjectorIdentity(persisted, replacementTarget) {
+		t.Fatalf("retire changed replacement target: (%#v,%v,%v)", persisted, exists, err)
+	}
+}


### PR DESCRIPTION
## Summary

Wave 7 of #235 — regression-only, zero production delta. Deterministic cross-operation and legacy-to-current upgrade race coverage over the lifecycle-guard-serialized primitives:

- Stale pre-control lock **repair** races a current exact-target **acquire** and accepts that current generation as the winner (incl. Darwin control metadata).
- Old **cleanup + readiness** race a guarded lock+target replacement and cannot delete or impersonate it.
- **retire** captures an old generation, then refuses and preserves a guarded lock+target replacement.
- Darwin operator-path **retire** fails closed without legacy control metadata and never bare-PID-signals.
- Linux operator-path **retire** fails closed on ENOSYS pidfd and preserves the lock+target.

New suite green under `-race -count=20`; full CLI `-race` green; `make ci` + four GOOS builds green.

Completes #235 (waves 1–7). Implementation by Codex; review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)