### PR TITLE
fix(wake): close cooperative-stop duplicate-injection window and harden Darwin lifecycle

### DIFF
--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -27,12 +27,7 @@ func wakeControlSocketPath(root, me, generation string) string {
 	return filepath.Join(fsq.AgentBase(root, me), ".w."+hex.EncodeToString(sum[:8]))
 }
 
-func withDarwinSocketDir(dir string, fn func() error) error {
-	dirfd, err := unix.Open(dir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = unix.Close(dirfd) }()
+func withDarwinSocketDirFD(dirfd int, fn func() error) error {
 	darwinSocketCWDMu.Lock()
 	defer darwinSocketCWDMu.Unlock()
 	oldfd, err := unix.Open(".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
@@ -51,7 +46,7 @@ func withDarwinSocketDir(dir string, fn func() error) error {
 	return restoreErr
 }
 
-func listenDarwinUnix(path string) (*net.UnixListener, error) {
+func listenDarwinUnixAt(agentDir *wakeAgentDir, name string) (*net.UnixListener, error) {
 	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
 	if err != nil {
 		return nil, err
@@ -63,11 +58,13 @@ func listenDarwinUnix(path string) (*net.UnixListener, error) {
 			_ = unix.Close(fd)
 		}
 	}()
-	err = withDarwinSocketDir(filepath.Dir(path), func() error {
-		if err := unix.Bind(fd, &unix.SockaddrUnix{Name: filepath.Base(path)}); err != nil {
-			return err
-		}
-		return unix.Listen(fd, 16)
+	err = agentDir.withFD(func(dirfd int) error {
+		return withDarwinSocketDirFD(dirfd, func() error {
+			if err := unix.Bind(fd, &unix.SockaddrUnix{Name: name}); err != nil {
+				return err
+			}
+			return unix.Listen(fd, 16)
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -87,7 +84,7 @@ func listenDarwinUnix(path string) (*net.UnixListener, error) {
 	return listener, nil
 }
 
-func dialDarwinUnix(path string, timeout time.Duration) (net.Conn, error) {
+func dialDarwinUnixAt(agentDir *wakeAgentDir, name string, timeout time.Duration) (net.Conn, error) {
 	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
 	if err != nil {
 		return nil, err
@@ -99,8 +96,10 @@ func dialDarwinUnix(path string, timeout time.Duration) (net.Conn, error) {
 			_ = unix.Close(fd)
 		}
 	}()
-	err = withDarwinSocketDir(filepath.Dir(path), func() error {
-		return unix.Connect(fd, &unix.SockaddrUnix{Name: filepath.Base(path)})
+	err = agentDir.withFD(func(dirfd int) error {
+		return withDarwinSocketDirFD(dirfd, func() error {
+			return unix.Connect(fd, &unix.SockaddrUnix{Name: name})
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -114,6 +113,123 @@ func dialDarwinUnix(path string, timeout time.Duration) (net.Conn, error) {
 	}
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 	return conn, nil
+}
+
+func darwinControlSocketName(agentDir *wakeAgentDir, path string) (string, error) {
+	cleanPath := filepath.Clean(path)
+	name := filepath.Base(cleanPath)
+	if filepath.Dir(cleanPath) != filepath.Clean(agentDir.path) || !strings.HasPrefix(name, ".w.") || name == ".w." {
+		return "", fmt.Errorf("wake control socket %s is outside authorized agent directory %s", path, agentDir.path)
+	}
+	return name, nil
+}
+
+func removeDarwinControlSocketAt(dirfd int, name string) error {
+	err := unix.Unlinkat(dirfd, name, 0)
+	if err == nil || err == unix.ENOENT {
+		return nil
+	}
+	return err
+}
+
+func removeStaleDarwinControlSocketsAt(dirfd int) error {
+	scanfd, err := unix.Openat(dirfd, ".", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return err
+	}
+	scan := os.NewFile(uintptr(scanfd), "wake-agent-directory-scan")
+	defer func() { _ = scan.Close() }()
+	entries, err := scan.ReadDir(-1)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".w.") {
+			continue
+		}
+		if err := removeDarwinControlSocketAt(dirfd, entry.Name()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func secureDarwinControlSocketAt(dirfd int, name, path string) error {
+	if err := unix.Fchmodat(dirfd, name, 0o600, 0); err != nil {
+		return fmt.Errorf("chmod wake control socket %s: %w", path, err)
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstatat(dirfd, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return fmt.Errorf("stat wake control socket %s: %w", path, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFSOCK {
+		return fmt.Errorf("wake control socket %s is not a socket", path)
+	}
+	if stat.Mode&0o777 != 0o600 {
+		return fmt.Errorf("wake control socket %s mode is %o, want 0600", path, stat.Mode&0o777)
+	}
+	if stat.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("wake control socket %s is owned by uid %d, want %d", path, stat.Uid, os.Geteuid())
+	}
+	return nil
+}
+
+func readWakeLockFileAt(dirfd int, path string) ([]byte, os.FileInfo, error) {
+	open := func() (*os.File, error) {
+		fd, err := unix.Openat(dirfd, ".wake.lock", unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(uintptr(fd), path), nil
+	}
+	file, err := open()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat wake lock: %w", err)
+	}
+	if err := validateWakeLockFile(path, info); err != nil {
+		return nil, nil, err
+	}
+	data, err := readWakeMetadata(file, "wake lock", path)
+	if err != nil {
+		return nil, nil, err
+	}
+	pathFile, err := open()
+	if err != nil {
+		return nil, nil, err
+	}
+	pathInfo, statErr := pathFile.Stat()
+	_ = pathFile.Close()
+	if statErr != nil {
+		return nil, nil, fmt.Errorf("re-stat wake lock: %w", statErr)
+	}
+	if err := validateWakeLockFile(path, pathInfo); err != nil {
+		return nil, nil, err
+	}
+	if !sameWakeFileIdentity(info, pathInfo) {
+		return nil, nil, fmt.Errorf("wake lock %s changed while opening", path)
+	}
+	return data, info, nil
+}
+
+func inspectWakeLockAt(dirfd int, agentDir *wakeAgentDir, root, me string) wakeLockInspection {
+	path := filepath.Join(agentDir.path, ".wake.lock")
+	return inspectWakeLockWithReader(root, me, path, func() ([]byte, os.FileInfo, error) {
+		return readWakeLockFileAt(dirfd, path)
+	})
+}
+
+func removeWakeLockIfUnchangedAt(dirfd int, agentDir *wakeAgentDir, inspection wakeLockInspection) error {
+	path := filepath.Join(agentDir.path, ".wake.lock")
+	return removeWakeLockIfUnchangedGuardedWithIO(
+		inspection,
+		func() ([]byte, os.FileInfo, error) { return readWakeLockFileAt(dirfd, path) },
+		func() error { return unix.Unlinkat(dirfd, ".wake.lock", 0) },
+	)
 }
 
 func darwinPeerEUID(conn *net.UnixConn) (uint32, error) {
@@ -144,33 +260,41 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 	if path == "" {
 		return func() {}, nil, func() {}, nil
 	}
-	if err := withWakeLifecycleGuard(root, me, func() error {
-		current := inspectWakeLock(root, me)
-		if !current.Exists || current.Lock.Generation != lock.Generation || current.Lock.ControlSocket != path {
-			return fmt.Errorf("wake control metadata changed before listener start")
-		}
-		stale, err := filepath.Glob(filepath.Join(fsq.AgentBase(root, me), ".w.*"))
-		if err != nil {
-			return err
-		}
-		for _, candidate := range stale {
-			if err := os.Remove(candidate); err != nil && !os.IsNotExist(err) {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		return nil, nil, nil, err
-	}
-	listener, err := listenDarwinUnix(path)
+	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if err := os.Chmod(path, 0o600); err != nil {
-		_ = listener.Close()
-		_ = os.Remove(path)
+	keepAgentDir := false
+	defer func() {
+		if !keepAgentDir {
+			_ = agentDir.Close()
+		}
+	}()
+	name, err := darwinControlSocketName(agentDir, path)
+	if err != nil {
 		return nil, nil, nil, err
 	}
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !current.Exists || current.Lock.Generation != lock.Generation || current.Lock.ControlSocket != path {
+			return fmt.Errorf("wake control metadata changed before listener start")
+		}
+		return removeStaleDarwinControlSocketsAt(dirfd)
+	}); err != nil {
+		return nil, nil, nil, err
+	}
+	listener, err := listenDarwinUnixAt(agentDir, name)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err := agentDir.withFD(func(dirfd int) error {
+		return secureDarwinControlSocketAt(dirfd, name, path)
+	}); err != nil {
+		_ = listener.Close()
+		_ = agentDir.withFD(func(dirfd int) error { return removeDarwinControlSocketAt(dirfd, name) })
+		return nil, nil, nil, err
+	}
+	keepAgentDir = true
 	stopRequest := make(chan struct{}, 1)
 	loopStopped := make(chan struct{})
 	var loopStoppedOnce sync.Once
@@ -192,13 +316,39 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 				if err != nil || strings.TrimSpace(token) != lock.Generation {
 					return
 				}
-				removed := false
-				err = withWakeLifecycleGuard(root, me, func() error {
-					current := inspectWakeLock(root, me)
+				accepted := false
+				err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+					current := inspectWakeLockAt(dirfd, agentDir, root, me)
 					if !current.Exists || current.Lock.Generation != lock.Generation || current.Lock.ControlSocket != path {
 						return nil
 					}
-					if err := removeWakeLockIfUnchangedGuarded(current); err != nil {
+					accepted = true
+					return nil
+				})
+				if err != nil || !accepted {
+					return
+				}
+				// Authentication is bounded, but completion is bounded by the
+				// configured inject-via execution timeout. Keep the generation
+				// published until the loop has actually quiesced so a concurrent
+				// acquire cannot start a second injector.
+				_ = conn.SetDeadline(time.Time{})
+				select {
+				case stopRequest <- struct{}{}:
+				default:
+				}
+				<-loopStopped
+				removed := false
+				err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+					current := inspectWakeLockAt(dirfd, agentDir, root, me)
+					if !current.Exists || current.Lock.Generation != lock.Generation {
+						removed = true
+						return nil
+					}
+					if current.Lock.ControlSocket != path {
+						return nil
+					}
+					if err := removeWakeLockIfUnchangedAt(dirfd, agentDir, current); err != nil {
 						return err
 					}
 					removed = true
@@ -207,25 +357,21 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 				if err != nil || !removed {
 					return
 				}
-				select {
-				case stopRequest <- struct{}{}:
-				default:
-				}
-				<-loopStopped
 				_, _ = conn.Write([]byte("ACK\n"))
 			}(conn)
 		}
 	}()
+	var cleanupOnce sync.Once
 	cleanup := func() {
-		_ = listener.Close()
-		_ = withWakeLifecycleGuard(root, me, func() error {
-			if cur := inspectWakeLock(root, me); cur.Exists && cur.Lock.Generation != lock.Generation {
-				return nil
-			}
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				return err
-			}
-			return nil
+		cleanupOnce.Do(func() {
+			_ = listener.Close()
+			_ = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+				if cur := inspectWakeLockAt(dirfd, agentDir, root, me); cur.Exists && cur.Lock.Generation != lock.Generation {
+					return nil
+				}
+				return removeDarwinControlSocketAt(dirfd, name)
+			})
+			_ = agentDir.Close()
 		})
 	}
 	return cleanup, stopRequest, markLoopStopped, nil
@@ -235,7 +381,16 @@ func cooperativeStopInjectVia(i wakeLockInspection) (bool, error) {
 	if i.Lock.ControlSocket == "" || i.Lock.Generation == "" {
 		return false, fmt.Errorf("live inject-via wake orphan has no cooperative control endpoint; stop the owning supervisor")
 	}
-	conn, err := dialDarwinUnix(i.Lock.ControlSocket, 2*time.Second)
+	agentDir, err := openWakeAgentDir(i.Root, i.Agent)
+	if err != nil {
+		return false, fmt.Errorf("cooperative wake stop unavailable: %w", err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	name, err := darwinControlSocketName(agentDir, i.Lock.ControlSocket)
+	if err != nil {
+		return false, fmt.Errorf("cooperative wake stop unavailable: %w", err)
+	}
+	conn, err := dialDarwinUnixAt(agentDir, name, 2*time.Second)
 	if err != nil {
 		return false, fmt.Errorf("cooperative wake stop unavailable: %w", err)
 	}
@@ -244,13 +399,14 @@ func cooperativeStopInjectVia(i wakeLockInspection) (bool, error) {
 	if _, err = fmt.Fprintf(conn, "%s\n", i.Lock.Generation); err != nil {
 		return false, err
 	}
+	_ = conn.SetDeadline(time.Time{})
 	line, err := bufio.NewReader(conn).ReadString('\n')
 	if err != nil || strings.TrimSpace(line) != "ACK" {
 		return false, fmt.Errorf("cooperative wake stop refused")
 	}
 	var gone bool
-	err = withWakeLifecycleGuard(i.Root, i.Agent, func() error {
-		cur := inspectWakeLock(i.Root, i.Agent)
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		cur := inspectWakeLockAt(dirfd, agentDir, i.Root, i.Agent)
 		gone = !cur.Exists || cur.Lock.Generation != i.Lock.Generation
 		return nil
 	})

--- a/internal/cli/wake_control_darwin_test.go
+++ b/internal/cli/wake_control_darwin_test.go
@@ -4,9 +4,12 @@ package cli
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -62,8 +65,8 @@ func TestDarwinCooperativeStopACKWaitsForLoopExit(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("listener did not request loop stop")
 	}
-	if current := inspectWakeLock(root, agent); current.Exists {
-		t.Fatal("listener requested loop stop before removing its lock")
+	if current := inspectWakeLock(root, agent); !current.Exists || current.Lock.Generation != lock.Generation {
+		t.Fatal("listener unpublished its generation before loop exit")
 	}
 	if err := withWakeLifecycleGuard(root, agent, func() error { return nil }); err != nil {
 		t.Fatalf("listener held lifecycle guard while waiting for loop exit: %v", err)
@@ -84,6 +87,99 @@ func TestDarwinCooperativeStopACKWaitsForLoopExit(t *testing.T) {
 	}
 }
 
+func TestDarwinCooperativeStopKeepsGenerationPublishedUntilLoopExit(t *testing.T) {
+	root, agent, lock := testDarwinControlLock(t)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", agent},
+		}
+	})
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	type result struct {
+		stopped bool
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		stopped, err := cooperativeStopInjectVia(inspectWakeLock(root, agent))
+		resultCh <- result{stopped: stopped, err: err}
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not request loop stop")
+	}
+	defer markStopped()
+
+	current := inspectWakeLock(root, agent)
+	if !current.Exists || current.Lock.Generation != lock.Generation {
+		t.Fatalf("stopping generation was unpublished before loop exit: %#v", current)
+	}
+	concurrentCleanup, acquireErr := acquireWakeLock(root, agent, nil)
+	if concurrentCleanup != nil {
+		concurrentCleanup()
+	}
+	if acquireErr == nil {
+		t.Fatalf("concurrent acquire started a second generation before the old loop exited; stopping=%#v", current)
+	}
+	if !strings.Contains(acquireErr.Error(), "already running") {
+		t.Fatalf("concurrent acquire error = %v, want already-running refusal", acquireErr)
+	}
+
+	markStopped()
+	select {
+	case got := <-resultCh:
+		if got.err != nil || !got.stopped {
+			t.Fatalf("stop=(%v,%v)", got.stopped, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop did not complete after loop exit")
+	}
+}
+
+func TestDarwinCooperativeStopCompletionOutlivesAuthenticationDeadline(t *testing.T) {
+	root, agent, lock := testDarwinControlLock(t)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	type result struct {
+		stopped bool
+		err     error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		stopped, err := cooperativeStopInjectVia(inspectWakeLock(root, agent))
+		resultCh <- result{stopped: stopped, err: err}
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not request loop stop")
+	}
+
+	// Authentication is complete, but the synchronous injector may still be
+	// running for longer than the authentication deadline.
+	time.Sleep(2200 * time.Millisecond)
+	markStopped()
+	select {
+	case got := <-resultCh:
+		if got.err != nil || !got.stopped {
+			t.Fatalf("stop=(%v,%v), want completion after delayed loop exit", got.stopped, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop did not complete after delayed loop exit")
+	}
+}
+
 func TestDarwinControlTokenMismatchRefused(t *testing.T) {
 	root, agent, lock := testDarwinControlLock(t)
 	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
@@ -91,7 +187,16 @@ func TestDarwinControlTokenMismatchRefused(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer cleanup()
-	conn, err := dialDarwinUnix(lock.ControlSocket, time.Second)
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	name, err := darwinControlSocketName(agentDir, lock.ControlSocket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := dialDarwinUnixAt(agentDir, name, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,4 +236,182 @@ func TestDarwinControlRemovesStaleSocketBeforeListen(t *testing.T) {
 		t.Fatalf("old generation socket still exists: %v", err)
 	}
 	cleanup()
+}
+
+func TestDarwinControlStartPinsAuthorizedAgentDirectory(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	root := filepath.Join(parent, "root")
+	parkedRoot := filepath.Join(parent, "authorized-root")
+	replacementRoot := filepath.Join(parent, "replacement-root")
+	const agent = "codex"
+	lock := wakeLock{PID: os.Getpid(), WakeMode: wakeTargetInjectVia, Generation: "0123456789abcdef0123456789abcdef"}
+	lock.ControlSocket = wakeControlSocketPath(root, agent, lock.Generation)
+	writeWakeLockForTest(t, root, agent, lock)
+	if err := fsq.EnsureAgentDirs(replacementRoot, agent); err != nil {
+		t.Fatal(err)
+	}
+	replacementSocket := filepath.Join(fsq.AgentBase(replacementRoot, agent), filepath.Base(lock.ControlSocket))
+	const sentinel = "replacement-tree-sentinel"
+	if err := os.WriteFile(replacementSocket, []byte(sentinel), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var swapOnce sync.Once
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		swapOnce.Do(func() {
+			if err := os.Rename(root, parkedRoot); err != nil {
+				t.Fatalf("park authorized root: %v", err)
+			}
+			if err := os.Rename(replacementRoot, root); err != nil {
+				t.Fatalf("install replacement root: %v", err)
+			}
+		})
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", agent},
+		}
+	})
+
+	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatalf("start control listener: %v", err)
+	}
+	parkedSocket := filepath.Join(fsq.AgentBase(parkedRoot, agent), filepath.Base(lock.ControlSocket))
+	if info, err := os.Lstat(parkedSocket); err != nil || info.Mode()&os.ModeSocket == 0 {
+		cleanup()
+		t.Fatalf("listener was not bound in authorized agent directory: info=%v err=%v", info, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(fsq.AgentBase(root, agent), filepath.Base(lock.ControlSocket))); err != nil || string(got) != sentinel {
+		cleanup()
+		t.Fatalf("replacement tree was modified: got=%q err=%v", got, err)
+	}
+
+	cleanup()
+	if _, err := os.Lstat(parkedSocket); !os.IsNotExist(err) {
+		t.Fatalf("authorized socket survived cleanup: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(fsq.AgentBase(root, agent), filepath.Base(lock.ControlSocket))); err != nil || string(got) != sentinel {
+		t.Fatalf("cleanup modified replacement tree: got=%q err=%v", got, err)
+	}
+}
+
+func TestDarwinControlCleanupPinsAuthorizedAgentDirectory(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	root := filepath.Join(parent, "root")
+	parkedRoot := filepath.Join(parent, "authorized-root")
+	replacementRoot := filepath.Join(parent, "replacement-root")
+	const agent = "codex"
+	lock := wakeLock{PID: os.Getpid(), WakeMode: wakeTargetInjectVia, Generation: "0123456789abcdef0123456789abcdef"}
+	lock.ControlSocket = wakeControlSocketPath(root, agent, lock.Generation)
+	writeWakeLockForTest(t, root, agent, lock)
+
+	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatalf("start control listener: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(replacementRoot, agent); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	replacementSocket := filepath.Join(fsq.AgentBase(replacementRoot, agent), filepath.Base(lock.ControlSocket))
+	const sentinel = "replacement-tree-sentinel"
+	if err := os.WriteFile(replacementSocket, []byte(sentinel), 0o600); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if err := os.Rename(root, parkedRoot); err != nil {
+		cleanup()
+		t.Fatalf("park authorized root: %v", err)
+	}
+	if err := os.Rename(replacementRoot, root); err != nil {
+		cleanup()
+		t.Fatalf("install replacement root: %v", err)
+	}
+
+	cleanup()
+	parkedSocket := filepath.Join(fsq.AgentBase(parkedRoot, agent), filepath.Base(lock.ControlSocket))
+	if _, err := os.Lstat(parkedSocket); !os.IsNotExist(err) {
+		t.Fatalf("authorized socket survived cleanup: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(fsq.AgentBase(root, agent), filepath.Base(lock.ControlSocket))); err != nil || string(got) != sentinel {
+		t.Fatalf("cleanup modified replacement tree: got=%q err=%v", got, err)
+	}
+}
+
+func TestDarwinControlAuthenticationPinsAuthorizedAgentDirectory(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	root := filepath.Join(parent, "root")
+	parkedRoot := filepath.Join(parent, "authorized-root")
+	replacementRoot := filepath.Join(parent, "replacement-root")
+	const agent = "codex"
+	lock := wakeLock{
+		PID:        os.Getpid(),
+		Root:       canonicalWakeRoot(root),
+		Agent:      agent,
+		WakeMode:   wakeTargetInjectVia,
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	lock.ControlSocket = wakeControlSocketPath(root, agent, lock.Generation)
+	writeWakeLockExactForTest(t, root, agent, lock)
+	writeWakeLockExactForTest(t, replacementRoot, agent, lock)
+
+	var inspections atomic.Int32
+	swapErr := make(chan error, 1)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if inspections.Add(1) == 2 {
+			if err := os.Rename(root, parkedRoot); err != nil {
+				swapErr <- fmt.Errorf("park authorized root: %w", err)
+			} else if err := os.Rename(replacementRoot, root); err != nil {
+				swapErr <- fmt.Errorf("install replacement root: %w", err)
+			}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", agent},
+		}
+	})
+
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatalf("start control listener: %v", err)
+	}
+	defer cleanup()
+	type stopResult struct {
+		stopped bool
+		err     error
+	}
+	resultCh := make(chan stopResult, 1)
+	go func() {
+		stopped, err := cooperativeStopInjectVia(wakeLockInspection{Root: root, Agent: agent, Lock: lock})
+		resultCh <- stopResult{stopped: stopped, err: err}
+	}()
+	select {
+	case <-stopped:
+	case err := <-swapErr:
+		t.Fatal(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not request stop after authenticated ancestor swap")
+	}
+	markStopped()
+	select {
+	case got := <-resultCh:
+		if got.err != nil || !got.stopped {
+			t.Fatalf("stop=(%v,%v)", got.stopped, got.err)
+		}
+	case err := <-swapErr:
+		t.Fatal(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not ACK after authenticated ancestor swap")
+	}
+
+	if _, err := os.Lstat(filepath.Join(fsq.AgentBase(parkedRoot, agent), ".wake.lock")); !os.IsNotExist(err) {
+		t.Fatalf("authorized generation survived cooperative cleanup: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(fsq.AgentBase(root, agent), ".wake.lock")); err != nil {
+		t.Fatalf("replacement-tree generation was modified: %v", err)
+	}
 }

--- a/internal/cli/wake_lifecycle_guard_unix.go
+++ b/internal/cli/wake_lifecycle_guard_unix.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
+	"sync"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"golang.org/x/sys/unix"
@@ -14,8 +14,89 @@ import (
 
 const wakeLifecycleGuardFileName = ".wake.lifecycle.lock"
 
+type wakeAgentDir struct {
+	path   string
+	file   *os.File
+	mu     sync.RWMutex
+	closed bool
+}
+
 func wakeLifecycleGuardPath(root, me string) string {
 	return filepath.Join(fsq.AgentBase(root, me), wakeLifecycleGuardFileName)
+}
+
+func openWakeAgentDir(root, me string) (*wakeAgentDir, error) {
+	if err := fsq.ValidateHandle(me); err != nil {
+		return nil, err
+	}
+	path := fsq.AgentBase(root, me)
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return nil, fmt.Errorf("create wake agent directory %s: %w", path, err)
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat wake agent directory %s: %w", path, err)
+	}
+	if err := validateWakeAgentDir(path, before); err != nil {
+		return nil, err
+	}
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open wake agent directory %s: %w", path, err)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	opened, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("stat opened wake agent directory %s: %w", path, err)
+	}
+	if err := validateWakeAgentDir(path, opened); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	after, err := os.Lstat(path)
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("re-stat wake agent directory %s: %w", path, err)
+	}
+	if err := validateWakeAgentDir(path, after); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	// Directory ctime changes for ordinary child creates/removes. Device+inode
+	// identity is the stable capability boundary here; the metadata files inside
+	// it retain the stricter ctime-aware generation checks.
+	if !os.SameFile(before, opened) || !os.SameFile(opened, after) {
+		_ = file.Close()
+		return nil, fmt.Errorf("wake agent directory %s changed while opening", path)
+	}
+	return &wakeAgentDir{path: path, file: file}, nil
+}
+
+func validateWakeAgentDir(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("wake agent directory %s must be a directory, not a symlink", path)
+	}
+	return validateWakeTargetPathOwnership("wake agent directory", path, info)
+}
+
+func (d *wakeAgentDir) withFD(fn func(int) error) error {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.closed {
+		return fmt.Errorf("wake agent directory %s is closed", d.path)
+	}
+	return fn(int(d.file.Fd()))
+}
+
+func (d *wakeAgentDir) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	return d.file.Close()
 }
 
 // Lock order: lifecycle guard -> wake lock/target/ready reads and mutations.
@@ -24,47 +105,75 @@ func wakeLifecycleGuardPath(root, me string) string {
 // cleanup and final readiness publication. Never wait on a child while holding
 // the lifecycle guard.
 func withWakeLifecycleGuard(root, me string, fn func() error) error {
-	path := wakeLifecycleGuardPath(root, me)
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("create wake lifecycle guard directory: %w", err)
-	}
-	file, err := openWakeLifecycleGuard(path)
+	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = file.Close() }()
-
-	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
-		return fmt.Errorf("acquire wake lifecycle guard %s: %w", path, err)
-	}
-	defer func() { _ = unix.Flock(int(file.Fd()), unix.LOCK_UN) }()
-
-	info, err := file.Stat()
-	if err != nil {
-		return fmt.Errorf("stat wake lifecycle guard %s: %w", path, err)
-	}
-	if err := validateWakeLifecycleGuard(path, info); err != nil {
-		return err
-	}
-	pathInfo, err := os.Lstat(path)
-	if err != nil {
-		return fmt.Errorf("stat wake lifecycle guard path %s: %w", path, err)
-	}
-	if err := validateWakeLifecycleGuard(path, pathInfo); err != nil {
-		return err
-	}
-	if !sameWakeFileIdentity(info, pathInfo) {
-		return fmt.Errorf("wake lifecycle guard %s changed while acquiring", path)
-	}
-	return fn()
+	defer func() { _ = agentDir.Close() }()
+	return withWakeLifecycleGuardInDir(agentDir, func(int) error { return fn() })
 }
 
-func openWakeLifecycleGuard(path string) (*os.File, error) {
-	flags := os.O_RDWR | os.O_CREATE | syscall.O_NONBLOCK | syscall.O_NOFOLLOW
-	file, err := os.OpenFile(path, flags, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("open wake lifecycle guard %s: %w", path, err)
+func withWakeLifecycleGuardInDir(agentDir *wakeAgentDir, fn func(int) error) error {
+	return agentDir.withFD(func(dirfd int) error {
+		path := filepath.Join(agentDir.path, wakeLifecycleGuardFileName)
+		file, err := openWakeLifecycleGuardAt(dirfd, path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = file.Close() }()
+
+		if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+			return fmt.Errorf("acquire wake lifecycle guard %s: %w", path, err)
+		}
+		defer func() { _ = unix.Flock(int(file.Fd()), unix.LOCK_UN) }()
+
+		info, err := file.Stat()
+		if err != nil {
+			return fmt.Errorf("stat wake lifecycle guard %s: %w", path, err)
+		}
+		if err := validateWakeLifecycleGuard(path, info); err != nil {
+			return err
+		}
+		pathFile, err := openWakeLifecycleGuardAt(dirfd, path)
+		if err != nil {
+			return fmt.Errorf("re-open wake lifecycle guard after acquisition: %w", err)
+		}
+		pathInfo, statErr := pathFile.Stat()
+		_ = pathFile.Close()
+		if statErr != nil {
+			return fmt.Errorf("stat wake lifecycle guard path %s: %w", path, statErr)
+		}
+		if !sameWakeFileIdentity(info, pathInfo) {
+			return fmt.Errorf("wake lifecycle guard %s changed while acquiring", path)
+		}
+		return fn(dirfd)
+	})
+}
+
+func openWakeLifecycleGuardAt(dirfd int, path string) (*os.File, error) {
+	flags := unix.O_RDWR | unix.O_NONBLOCK | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	var fd int
+	var err error
+	for attempt := 0; attempt < 100; attempt++ {
+		fd, err = unix.Openat(dirfd, wakeLifecycleGuardFileName, flags, 0)
+		if err == nil {
+			break
+		}
+		if err != unix.ENOENT {
+			return nil, fmt.Errorf("open wake lifecycle guard %s: %w", path, err)
+		}
+		fd, err = unix.Openat(dirfd, wakeLifecycleGuardFileName, flags|unix.O_CREAT|unix.O_EXCL, 0o600)
+		if err == nil {
+			break
+		}
+		if err != unix.EEXIST {
+			return nil, fmt.Errorf("create wake lifecycle guard %s: %w", path, err)
+		}
 	}
+	if err != nil {
+		return nil, fmt.Errorf("open wake lifecycle guard %s after concurrent creation: %w", path, err)
+	}
+	file := os.NewFile(uintptr(fd), path)
 	info, statErr := file.Stat()
 	if statErr != nil {
 		_ = file.Close()

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -88,6 +88,8 @@ type wakeLockInspection struct {
 
 var inspectWakeProcess = inspectWakeProcessPlatform
 
+type wakeLockFileReader func() ([]byte, os.FileInfo, error)
+
 type wakeAlreadyRunningError struct {
 	Agent      string
 	Inspection wakeLockInspection
@@ -100,7 +102,14 @@ func (e *wakeAlreadyRunningError) Error() string {
 }
 
 func inspectWakeLock(root, me string) wakeLockInspection {
-	inspection := readWakeLockMetadata(root, me)
+	lockPath := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
+	return inspectWakeLockWithReader(root, me, lockPath, func() ([]byte, os.FileInfo, error) {
+		return readWakeLockFileWithInfo(lockPath)
+	})
+}
+
+func inspectWakeLockWithReader(root, me, lockPath string, read wakeLockFileReader) wakeLockInspection {
+	inspection := readWakeLockMetadataWithReader(root, me, lockPath, read)
 	if !inspection.Exists || inspection.Status != wakeLockMissing {
 		return inspection
 	}
@@ -114,6 +123,12 @@ func inspectWakeLock(root, me string) wakeLockInspection {
 // the first PID-based identity inspection of the locked generation.
 func readWakeLockMetadata(root, me string) wakeLockInspection {
 	lockPath := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
+	return readWakeLockMetadataWithReader(root, me, lockPath, func() ([]byte, os.FileInfo, error) {
+		return readWakeLockFileWithInfo(lockPath)
+	})
+}
+
+func readWakeLockMetadataWithReader(root, me, lockPath string, read wakeLockFileReader) wakeLockInspection {
 	inspection := wakeLockInspection{
 		Status:   wakeLockMissing,
 		Root:     canonicalWakeRoot(root),
@@ -121,7 +136,7 @@ func readWakeLockMetadata(root, me string) wakeLockInspection {
 		LockPath: lockPath,
 	}
 
-	data, fileInfo, err := readWakeLockFileWithInfo(lockPath)
+	data, fileInfo, err := read()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return inspection
@@ -137,7 +152,7 @@ func readWakeLockMetadata(root, me string) wakeLockInspection {
 	inspection.fileInfo = fileInfo
 	var existing wakeLock
 	if err := json.Unmarshal(data, &existing); err != nil {
-		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) < 2*time.Second {
+		if fileInfo != nil && time.Since(fileInfo.ModTime()) < 2*time.Second {
 			inspection.Status = wakeLockCreating
 			inspection.Reason = "lock is being created"
 			return inspection
@@ -284,7 +299,15 @@ func removeWakeLockIfUnchanged(inspection wakeLockInspection) error {
 }
 
 func removeWakeLockIfUnchangedGuarded(inspection wakeLockInspection) error {
-	current, currentInfo, err := readWakeLockFileWithInfo(inspection.LockPath)
+	return removeWakeLockIfUnchangedGuardedWithIO(
+		inspection,
+		func() ([]byte, os.FileInfo, error) { return readWakeLockFileWithInfo(inspection.LockPath) },
+		func() error { return os.Remove(inspection.LockPath) },
+	)
+}
+
+func removeWakeLockIfUnchangedGuardedWithIO(inspection wakeLockInspection, read wakeLockFileReader, remove func() error) error {
+	current, currentInfo, err := read()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -297,7 +320,7 @@ func removeWakeLockIfUnchangedGuarded(inspection wakeLockInspection) error {
 	if inspection.fileInfo == nil || currentInfo == nil || !sameWakeFileIdentity(inspection.fileInfo, currentInfo) {
 		return fmt.Errorf("wake lock generation changed while cleaning stale lock; retry")
 	}
-	if err := os.Remove(inspection.LockPath); err != nil && !os.IsNotExist(err) {
+	if err := remove(); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove stale wake lock: %w", err)
 	}
 	return nil

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -118,16 +118,6 @@ func inspectWakeLockWithReader(root, me, lockPath string, read wakeLockFileReade
 	return inspection
 }
 
-// readWakeLockMetadata reads one exact lock generation without consulting the
-// process table. Linux orphan retirement uses this to acquire a pidfd before
-// the first PID-based identity inspection of the locked generation.
-func readWakeLockMetadata(root, me string) wakeLockInspection {
-	lockPath := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
-	return readWakeLockMetadataWithReader(root, me, lockPath, func() ([]byte, os.FileInfo, error) {
-		return readWakeLockFileWithInfo(lockPath)
-	})
-}
-
 func readWakeLockMetadataWithReader(root, me, lockPath string, read wakeLockFileReader) wakeLockInspection {
 	inspection := wakeLockInspection{
 		Status:   wakeLockMissing,

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -5,9 +5,12 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"golang.org/x/sys/unix"
 )
 
@@ -17,6 +20,16 @@ var (
 	linuxPidfdClose      = unix.Close
 	linuxPidfdPoll       = pollLinuxPidfd
 )
+
+// readWakeLockMetadata reads one exact lock generation without consulting the
+// process table. Linux orphan retirement uses this to acquire a pidfd before
+// the first PID-based identity inspection of the locked generation.
+func readWakeLockMetadata(root, me string) wakeLockInspection {
+	lockPath := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
+	return readWakeLockMetadataWithReader(root, me, lockPath, func() ([]byte, os.FileInfo, error) {
+		return readWakeLockFileWithInfo(lockPath)
+	})
+}
 
 func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
 	var locked wakeLockInspection


### PR DESCRIPTION
## Summary

Two fixes to the Darwin cooperative wake shutdown surfaced by the pre-release ChatGPT-Pro review:

**A-2 (correctness bug — duplicate injection):** the cooperative stop removed the exact-generation lock *before* the injection loop had quiesced, so a concurrent acquire during the `loopStopped` wait could start a second generation and both would inject the same backlog. Now the generation is validated under the guard but **retained** through quiescence; the lock is removed only after `loopStopped`, under a reacquired guard, before ACK — so a concurrent acquire gets "already-running." Also splits the token-auth deadline from the (longer) completion wait, fixing a false "cooperative wake stop refused" when an in-flight injector legitimately runs past the 2s dial deadline.

**A-1 (defense-in-depth hardening):** the lifecycle guard, stale-`.w.*` sweep, socket bind, chmod, and cleanup now operate on one identity-verified agent-directory fd (TOCTOU-hardened open: Lstat→`O_NOFOLLOW` open→Fstat→Lstat→triple-`SameFile`; then `Openat`/`Unlinkat`/`Fchmodat`/`Fstatat` relative to that fd), instead of re-resolving the agent base by pathname mid-lifecycle.

## Review

A-2 has RED-proof regressions (concurrent-acquire-during-stop, delayed-completion) green under `-race -count=20`; A-1 has deterministic ancestor-swap tests at listener-start / post-auth / pre-cleanup. Full `make ci` + four GOOS builds green. Post-#235 hardening. Implementation by Codex; review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)