### PR TITLE
fix(delivery): report indeterminate-durability commits + capability-relative reads

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,28 @@ already opened root, including privileged bind mounts, or against writing to
 pre-existing device files. Those cases require separate mount and file-type
 hardening and remain outside the rooted-delivery guarantee.
 
+### Threat model and accepted residuals
+
+AMQ is a **personal, single-user, on-machine** tool: each engineer runs it under
+their own account on their own machine. The security bar reflects that. An
+attacker who already has the ability to run code as your user, or to swap
+symlinks in your home/ancestor directories mid-command, has full control of your
+environment; defending the message queue against them would not meaningfully
+improve your posture. Accordingly, the following are **accepted residuals**, not
+defended against:
+
+- **Untrusted-ancestor / TOCTOU alias swaps.** A different-euid local attacker
+  who can retarget an ancestor symlink between commands (cross-command alias
+  retarget for `--project`/`--session` routes; ABA swaps of config or message
+  files) is out of scope. Legitimate in-tree symlinks continue to work.
+- **Bind mounts and device files below an opened root** (as noted above).
+
+What AMQ **does** defend correctness for, because these bite without any
+attacker: no duplicate message injection or delivery, no cross-tree leakage from
+ordinary misconfiguration, owner-only `0700`/`0600` permissions, and handle/ID
+validation. Bugs and reliability are the priority; same-machine security
+hardening beyond the above is intentionally out of scope.
+
 ### Known Risks
 
 #### TIOCSTI Terminal Injection (`amq wake`)

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 type commonFlags struct {
@@ -425,7 +427,19 @@ func requireMe(handle string) error {
 // If strict=true, returns an error for unreadable/corrupt config; otherwise warns to stderr.
 func loadKnownAgents(root string, strict bool) ([]string, error) {
 	configPath := filepath.Join(root, "meta", "config.json")
-	data, err := os.ReadFile(configPath)
+	return loadKnownAgentsWithRead(strict, func() ([]byte, error) {
+		return os.ReadFile(configPath)
+	})
+}
+
+func loadKnownAgentsDeliveryRoot(root *fsq.DeliveryRoot, strict bool) ([]string, error) {
+	return loadKnownAgentsWithRead(strict, func() ([]byte, error) {
+		return root.ReadRegularNoFollow(filepath.Join("meta", "config.json"))
+	})
+}
+
+func loadKnownAgentsWithRead(strict bool, read func() ([]byte, error)) ([]string, error) {
+	data, err := read()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil // No config, no validation
@@ -482,14 +496,35 @@ func loadKnownAgentSet(root string, strict bool) (map[string]struct{}, error) {
 	return known, nil
 }
 
+func loadKnownAgentSetDeliveryRoot(root *fsq.DeliveryRoot, strict bool) (map[string]struct{}, error) {
+	agents, err := loadKnownAgentsDeliveryRoot(root, strict)
+	if err != nil || len(agents) == 0 {
+		return nil, err
+	}
+	known := make(map[string]struct{}, len(agents))
+	for _, agent := range agents {
+		known[agent] = struct{}{}
+	}
+	return known, nil
+}
+
 // validateKnownHandles validates handles against config.json.
 // Accepts variadic handles for convenience (single or multiple).
 // Returns nil if config doesn't exist or all handles are known.
 // If strict=true, returns an error for unknown handles or unreadable/corrupt config; otherwise warns to stderr.
 func validateKnownHandles(root string, strict bool, handles ...string) error {
 	agents, err := loadKnownAgents(root, strict)
-	if err != nil {
-		return err
+	return validateKnownHandlesFromAgents(agents, err, strict, handles...)
+}
+
+func validateKnownHandlesDeliveryRoot(root *fsq.DeliveryRoot, strict bool, handles ...string) error {
+	agents, err := loadKnownAgentsDeliveryRoot(root, strict)
+	return validateKnownHandlesFromAgents(agents, err, strict, handles...)
+}
+
+func validateKnownHandlesFromAgents(agents []string, loadErr error, strict bool, handles ...string) error {
+	if loadErr != nil {
+		return loadErr
 	}
 	if agents == nil {
 		return nil // No config, no validation

--- a/internal/cli/delivery_reads.go
+++ b/internal/cli/delivery_reads.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func requireMailboxDeliveryRoot(root *fsq.DeliveryRoot, displayRoot, me string) error {
+	for _, dir := range []string{
+		filepath.Join("agents", me, "inbox", "new"),
+		filepath.Join("agents", me, "inbox", "cur"),
+		filepath.Join("agents", me, "dlq", "new"),
+	} {
+		info, err := root.Stat(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return NotFoundError("mailbox for %q is missing at root %s (missing %s); check AM_ROOT or use --session <name>", me, displayRoot, root.DisplayPath(dir))
+			}
+			return err
+		}
+		if !info.IsDir() {
+			return NotFoundError("mailbox path for %q is not a directory: %s", me, root.DisplayPath(dir))
+		}
+	}
+	return nil
+}
+
+func deliveryInboxExists(root *fsq.DeliveryRoot, agent string) bool {
+	info, err := root.Stat(filepath.Join("agents", agent, "inbox"))
+	return err == nil && info.IsDir()
+}
+
+func deliveryAgentExists(root *fsq.DeliveryRoot, agent string) bool {
+	info, err := root.Stat(filepath.Join("agents", agent))
+	return err == nil && info.IsDir()
+}
+
+func findMessageDeliveryRoot(root *fsq.DeliveryRoot, agent, filename string, includeSent bool) (string, string, error) {
+	if err := fsq.ValidateMessageFilename(filename); err != nil {
+		return "", "", err
+	}
+	candidates := []struct {
+		path string
+		box  string
+	}{
+		{path: filepath.Join("agents", agent, "inbox", "new", filename), box: fsq.BoxNew},
+		{path: filepath.Join("agents", agent, "inbox", "cur", filename), box: fsq.BoxCur},
+	}
+	if includeSent {
+		candidates = append(candidates, struct {
+			path string
+			box  string
+		}{path: filepath.Join("agents", agent, "outbox", "sent", filename), box: "sent"})
+	}
+	for _, candidate := range candidates {
+		if _, err := root.Stat(candidate.path); err == nil {
+			return candidate.path, candidate.box, nil
+		} else if !os.IsNotExist(err) {
+			return "", "", err
+		}
+	}
+	return "", "", os.ErrNotExist
+}
+
+func readMessageDeliveryRoot(root *fsq.DeliveryRoot, path string) (format.Message, error) {
+	info, err := root.Stat(path)
+	if err != nil {
+		return format.Message{}, err
+	}
+	if info.Size() > format.MaxMessageSize {
+		return format.Message{}, fmt.Errorf("%w: %d bytes", format.ErrMessageTooLarge, info.Size())
+	}
+	data, err := root.ReadRegularNoFollow(path)
+	if err != nil {
+		return format.Message{}, err
+	}
+	if len(data) > format.MaxMessageSize {
+		return format.Message{}, fmt.Errorf("%w: %d bytes", format.ErrMessageTooLarge, len(data))
+	}
+	return format.ParseMessage(data)
+}

--- a/internal/cli/delivery_reads_unix_test.go
+++ b/internal/cli/delivery_reads_unix_test.go
@@ -1,0 +1,105 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestCapabilityConfigReadRefusesRetargetedAlias(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	alias := filepath.Join(parent, "authorized")
+	parked := filepath.Join(parent, "authorized-parked")
+	replacement := filepath.Join(parent, "replacement")
+	for _, root := range []string{alias, replacement} {
+		if err := fsq.EnsureRootDirs(root); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(alias, "meta", "config.json"), []byte(`{"agents":["alice","bob"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(replacement, "meta", "config.json"), []byte(`{"agents":["alice","mallory"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(alias, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	if err := os.Rename(alias, parked); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(replacement, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	err = validateKnownHandlesDeliveryRoot(root, true, "mallory")
+	if err == nil || !strings.Contains(err.Error(), "delivery root changed after authorization") {
+		t.Fatalf("strict config validation error = %v, want retarget refusal", err)
+	}
+}
+
+func TestCapabilityMessageReadRefusesRetargetedAlias(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	alias := filepath.Join(parent, "authorized")
+	parked := filepath.Join(parent, "authorized-parked")
+	replacement := filepath.Join(parent, "replacement")
+	const agent = "alice"
+	const filename = "msg.md"
+	for _, root := range []string{alias, replacement} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeMessage := func(root, from, body string) {
+		t.Helper()
+		msg := format.Message{Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      "msg",
+			From:    from,
+			To:      []string{agent},
+			Thread:  "p2p/alice__bob",
+			Created: "2026-07-21T00:00:00Z",
+		}, Body: body}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(root, agent), filename), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeMessage(alias, "bob", "authorized")
+	writeMessage(replacement, "mallory", "forged")
+	identity, err := fsq.SnapshotDeliveryRoot(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(alias, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	if err := os.Rename(alias, parked); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(replacement, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = findMessageDeliveryRoot(root, agent, filename, false)
+	if err == nil || !strings.Contains(err.Error(), "delivery root changed after authorization") {
+		t.Fatalf("message discovery error = %v, want retarget refusal", err)
+	}
+}

--- a/internal/cli/delivery_status.go
+++ b/internal/cli/delivery_status.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func reportDeliveryError(messageID string, err error) error {
+	var committed *fsq.CommittedDurabilityError
+	if !errors.As(err, &committed) {
+		return err
+	}
+	return fmt.Errorf("message %s has a committed delivery; retrying may duplicate it: %w", messageID, err)
+}
+
+func outboxResult(err error) map[string]any {
+	result := map[string]any{
+		"written": err == nil,
+		"error":   errString(err),
+	}
+	var committed *fsq.CommittedDurabilityError
+	if errors.As(err, &committed) {
+		result["written"] = true
+		result["durability"] = "indeterminate"
+		result["path"] = committed.FinalPath
+	}
+	return result
+}
+
+func reportOutboxError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var committed *fsq.CommittedDurabilityError
+	if errors.As(err, &committed) {
+		return writeStderr("warning: outbox is written, but durability is indeterminate: %v\n", err)
+	}
+	return writeStderr("warning: outbox write failed: %v\n", err)
+}

--- a/internal/cli/delivery_status_test.go
+++ b/internal/cli/delivery_status_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestReportDeliveryErrorPreservesCommittedState(t *testing.T) {
+	committed := &fsq.CommittedDurabilityError{
+		FinalPath: "/delivery/agents/codex/inbox/new/msg.md",
+		Recipient: "codex",
+		Err:       errors.New("fsync failed"),
+	}
+	err := reportDeliveryError("msg", committed)
+	if !errors.Is(err, committed) {
+		t.Fatalf("reportDeliveryError did not preserve committed error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "message msg has a committed delivery") || !strings.Contains(err.Error(), "retrying may duplicate") {
+		t.Fatalf("reportDeliveryError = %q, want explicit committed retry warning", err)
+	}
+}
+
+func TestOutboxResultTreatsIndeterminateDurabilityAsWritten(t *testing.T) {
+	committed := &fsq.CommittedDurabilityError{
+		FinalPath: "/source/agents/codex/outbox/sent/msg.md",
+		Err:       errors.New("fsync failed"),
+	}
+	result := outboxResult(committed)
+	if written, _ := result["written"].(bool); !written {
+		t.Fatalf("written = %#v, want true for committed outbox", result["written"])
+	}
+	if result["durability"] != "indeterminate" || result["path"] != committed.FinalPath {
+		t.Fatalf("outbox result = %#v", result)
+	}
+}

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -51,30 +51,30 @@ func runRead(args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := requireMailbox(root, me); err != nil {
-		return err
-	}
-
-	// Validate handle against config.json
-	if err := validateKnownHandles(root, common.Strict, me); err != nil {
-		return err
-	}
-	validator, err := newHeaderValidator(root, common.Strict)
-	if err != nil {
-		return err
-	}
 	deliveryRoot, err := fsq.OpenDeliveryRoot(root, deliveryIdentity)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = deliveryRoot.Close() }()
+	if err := requireMailboxDeliveryRoot(deliveryRoot, root, me); err != nil {
+		return err
+	}
+
+	// Validate handle against config.json
+	if err := validateKnownHandlesDeliveryRoot(deliveryRoot, common.Strict, me); err != nil {
+		return err
+	}
+	validator, err := newHeaderValidatorDeliveryRoot(deliveryRoot, common.Strict)
+	if err != nil {
+		return err
+	}
 
 	filename, err := ensureFilename(*idFlag)
 	if err != nil {
 		return UsageError("--id: %v", err)
 	}
 
-	path, box, err := fsq.FindMessage(root, common.Me, filename)
+	path, box, err := findMessageDeliveryRoot(deliveryRoot, common.Me, filename, false)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return NotFoundError("message not found: %s", *idFlag)
@@ -83,7 +83,7 @@ func runRead(args []string) error {
 	}
 
 	// Parse first before moving to avoid stuck corrupt messages in cur
-	msg, err := format.ReadMessageFile(path)
+	msg, err := readMessageDeliveryRoot(deliveryRoot, path)
 	if err != nil {
 		// If message is corrupt and in new, move to DLQ
 		if box == fsq.BoxNew {

--- a/internal/cli/reply.go
+++ b/internal/cli/reply.go
@@ -344,11 +344,11 @@ func runReply(args []string) error {
 	if targetProject != "" {
 		// Cross-project: use DeliverToExistingInbox (never creates dirs in peer).
 		if _, err := fsq.DeliverToExistingInbox(deliveryFS, recipient, filename, data); err != nil {
-			return err
+			return reportDeliveryError(id, err)
 		}
 	} else {
 		if _, err := fsq.DeliverToInboxes(deliveryFS, []string{recipient}, filename, data); err != nil {
-			return err
+			return reportDeliveryError(id, err)
 		}
 	}
 
@@ -393,10 +393,7 @@ func runReply(args []string) error {
 			"root":         deliveryRoot,
 			"in_reply_to":  originalMsg.Header.ID,
 			"original_box": originalBox,
-			"outbox": map[string]any{
-				"written": outboxErr == nil,
-				"error":   errString(outboxErr),
-			},
+			"outbox":       outboxResult(outboxErr),
 		}
 		if targetProject != "" {
 			out["cross_project"] = true
@@ -418,7 +415,7 @@ func runReply(args []string) error {
 	}
 
 	if outboxErr != nil {
-		_ = writeStderr("warning: outbox write failed: %v\n", outboxErr)
+		_ = reportOutboxError(outboxErr)
 	}
 	if waitResult != nil {
 		switch waitResult.Event {

--- a/internal/cli/reply.go
+++ b/internal/cli/reply.go
@@ -96,17 +96,45 @@ func runReply(args []string) error {
 		}
 	}
 
-	// Find the original message
-	originalMsg, originalPath, err := findMessage(root, me, *idFlag)
+	// Pin the source tree before reading the original. Its contents determine
+	// the reply recipient and routing destination.
+	sourceIdentity, err := fsq.SnapshotDeliveryRoot(root)
 	if err != nil {
 		return err
+	}
+	pin, err := loadSessionPin()
+	if err != nil {
+		return err
+	}
+	if pin.IdentityPin && !*ignoreSessionPinFlag &&
+		verifyTreeIdentityInfo(sourceIdentity.FileInfo(), pin.RootID) != TreeRelationSame {
+		return ContextMismatchError("authorized source root identity changed before capability open")
+	}
+	sourceFS, err := fsq.OpenDeliveryRoot(root, sourceIdentity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = sourceFS.Close() }()
+	originalFilename, err := ensureFilename(*idFlag)
+	if err != nil {
+		return UsageError("--id: %v", err)
+	}
+	originalPath, originalBox, err := findMessageDeliveryRoot(sourceFS, me, originalFilename, true)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return NotFoundError("message not found: %s", *idFlag)
+		}
+		return err
+	}
+	originalMsg, err := readMessageDeliveryRoot(sourceFS, originalPath)
+	if err != nil {
+		return fmt.Errorf("read message %s: %w", *idFlag, err)
 	}
 
 	// Disallow reply on sent cross-session/cross-project messages.
 	// If the message was found in outbox/sent and has a reply_to, the user
 	// is trying to follow up on their own send. This is under-specified
 	// (no target metadata in outbox copy).
-	originalBox := filepath.Base(filepath.Dir(originalPath))
 	if originalBox == "sent" && originalMsg.Header.ReplyTo != "" {
 		return fmt.Errorf("cannot reply to a sent cross-session/cross-project message (reply_to points back to you); use amq send --session/--project for follow-ups")
 	}
@@ -147,19 +175,6 @@ func runReply(args []string) error {
 			deliveryRoot = peerBaseRoot
 		}
 
-		if !dirExists(deliveryRoot) {
-			if targetSession != "" {
-				return fmt.Errorf("session %q not found in peer %q at %s", targetSession, targetProject, deliveryRoot)
-			}
-			return fmt.Errorf("peer %q root does not exist at %s", targetProject, deliveryRoot)
-		}
-		inbox := filepath.Join(deliveryRoot, "agents", recipient, "inbox")
-		if !dirExists(inbox) {
-			if targetSession != "" {
-				return fmt.Errorf("agent %q not found in peer %q session %q", recipient, targetProject, targetSession)
-			}
-			return fmt.Errorf("agent %q not found in peer %q", recipient, targetProject)
-		}
 	} else if originalMsg.Header.ReplyTo != "" {
 		// Cross-session reply (no cross-project). Strict reply_to parsing.
 		parts := strings.SplitN(originalMsg.Header.ReplyTo, "@", 2)
@@ -183,14 +198,6 @@ func runReply(args []string) error {
 			return fmt.Errorf("cannot route cross-session reply: run from inside 'amq coop exec --session <name>'")
 		}
 		deliveryRoot = filepath.Join(baseRoot, targetSession)
-		if !dirExists(deliveryRoot) {
-			return fmt.Errorf("reply_to session %q not found at %s", targetSession, deliveryRoot)
-		}
-		// Verify recipient inbox exists in target session.
-		inbox := filepath.Join(deliveryRoot, "agents", recipient, "inbox")
-		if !dirExists(inbox) {
-			return fmt.Errorf("agent %q not found in session %q", recipient, targetSession)
-		}
 	} else {
 		// Local reply: send to original sender in current session.
 		rawRecipient := originalMsg.Header.From
@@ -211,49 +218,36 @@ func runReply(args []string) error {
 		recipient = recipientNorm
 		deliveryRoot = root
 
-		// Verify the recipient's inbox exists locally.
-		inbox := filepath.Join(deliveryRoot, "agents", recipient, "inbox")
-		if !dirExists(inbox) {
+	}
+
+	deliveryFS := sourceFS
+	if filepath.Clean(root) != filepath.Clean(deliveryRoot) {
+		deliveryIdentity, err := fsq.SnapshotDeliveryRoot(deliveryRoot)
+		if err != nil {
+			return err
+		}
+		deliveryFS, err = fsq.OpenDeliveryRoot(deliveryRoot, deliveryIdentity)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = deliveryFS.Close() }()
+	}
+	if !deliveryInboxExists(deliveryFS, recipient) {
+		switch {
+		case targetProject != "" && targetSession != "":
+			return fmt.Errorf("agent %q not found in peer %q session %q", recipient, targetProject, targetSession)
+		case targetProject != "":
+			return fmt.Errorf("agent %q not found in peer %q", recipient, targetProject)
+		case targetSession != "":
+			return fmt.Errorf("agent %q not found in session %q", recipient, targetSession)
+		default:
 			return fmt.Errorf("agent %q not found in current session (no reply_to in original message — sender may not be in a session)", recipient)
 		}
 	}
 
-	deliveryIdentity, err := fsq.SnapshotDeliveryRoot(deliveryRoot)
-	if err != nil {
+	// Validate recipient through the same capability used for delivery.
+	if err := validateKnownHandlesDeliveryRoot(deliveryFS, common.Strict, recipient); err != nil {
 		return err
-	}
-	sourceIdentity := deliveryIdentity
-	if filepath.Clean(root) != filepath.Clean(deliveryRoot) {
-		sourceIdentity, err = fsq.SnapshotDeliveryRoot(root)
-		if err != nil {
-			return err
-		}
-	}
-	pin, err := loadSessionPin()
-	if err != nil {
-		return err
-	}
-	if pin.IdentityPin && !*ignoreSessionPinFlag &&
-		verifyTreeIdentityInfo(sourceIdentity.FileInfo(), pin.RootID) != TreeRelationSame {
-		return ContextMismatchError("authorized source root identity changed before capability open")
-	}
-
-	// Validate recipient in delivery root.
-	if err := validateKnownHandles(deliveryRoot, common.Strict, recipient); err != nil {
-		return err
-	}
-	deliveryFS, err := fsq.OpenDeliveryRoot(deliveryRoot, deliveryIdentity)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = deliveryFS.Close() }()
-	sourceFS := deliveryFS
-	if filepath.Clean(root) != filepath.Clean(deliveryRoot) {
-		sourceFS, err = fsq.OpenDeliveryRoot(root, sourceIdentity)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = sourceFS.Close() }()
 	}
 
 	body, err := readBody(*bodyFlag, *allowEmptyFlag)
@@ -435,29 +429,4 @@ func runReply(args []string) error {
 		return waitErr
 	}
 	return writeStdout("Replied %s to %s (session: %s, root: %s)\n", id, recipient, targetDisplay, deliveryRoot)
-}
-
-// findMessage searches for a message by ID in the agent's inbox (new and cur).
-func findMessage(root, me, msgID string) (format.Message, string, error) {
-	filename, err := ensureFilename(msgID)
-	if err != nil {
-		return format.Message{}, "", err
-	}
-
-	newPath := filepath.Join(fsq.AgentInboxNew(root, me), filename)
-	if msg, err := format.ReadMessageFile(newPath); err == nil {
-		return msg, newPath, nil
-	}
-
-	curPath := filepath.Join(fsq.AgentInboxCur(root, me), filename)
-	if msg, err := format.ReadMessageFile(curPath); err == nil {
-		return msg, curPath, nil
-	}
-
-	sentPath := filepath.Join(fsq.AgentOutboxSent(root, me), filename)
-	if msg, err := format.ReadMessageFile(sentPath); err == nil {
-		return msg, sentPath, nil
-	}
-
-	return format.Message{}, "", fmt.Errorf("message not found: %s", msgID)
 }

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -448,12 +448,12 @@ func runSend(args []string) error {
 		// Cross-project: use DeliverToExistingInbox (never creates dirs in peer).
 		for _, r := range recipients {
 			if _, err := fsq.DeliverToExistingInbox(deliveryFS, r, filename, data); err != nil {
-				return err
+				return reportDeliveryError(id, err)
 			}
 		}
 	} else {
 		if _, err := fsq.DeliverToInboxes(deliveryFS, recipients, filename, data); err != nil {
-			return err
+			return reportDeliveryError(id, err)
 		}
 	}
 
@@ -505,10 +505,7 @@ func runSend(args []string) error {
 			"session":     targetDisplay,
 			"root":        deliveryRoot,
 			"source_root": sourceRoot,
-			"outbox": map[string]any{
-				"written": outboxErr == nil,
-				"error":   errString(outboxErr),
-			},
+			"outbox":      outboxResult(outboxErr),
 		}
 		if targetProject != "" {
 			out["cross_project"] = true
@@ -529,7 +526,7 @@ func runSend(args []string) error {
 		return waitErr
 	}
 	if outboxErr != nil {
-		if err := writeStderr("warning: outbox write failed: %v\n", outboxErr); err != nil {
+		if err := reportOutboxError(outboxErr); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -192,9 +192,6 @@ func runSend(args []string) error {
 		if err != nil {
 			return fmt.Errorf("source session %q not found: %w", fromSession, err)
 		}
-		if !dirExists(filepath.Join(sourceRoot, "agents", me)) {
-			return fmt.Errorf("agent %q not found in source session %q", me, fromSession)
-		}
 		sourceSession = fromSession
 	}
 	if targetProject != "" {
@@ -202,9 +199,6 @@ func runSend(args []string) error {
 		peerBaseRoot, err := resolvePeer(root, targetProject)
 		if err != nil {
 			return err
-		}
-		if !dirExists(peerBaseRoot) {
-			return fmt.Errorf("peer root for %q does not exist: %s", targetProject, peerBaseRoot)
 		}
 
 		if targetSession != "" {
@@ -234,21 +228,6 @@ func runSend(args []string) error {
 			}
 		}
 
-		if !dirExists(deliveryRoot) {
-			if targetSession != "" {
-				return fmt.Errorf("session %q not found in peer %q at %s", targetSession, targetProject, deliveryRoot)
-			}
-			return fmt.Errorf("peer %q root does not exist at %s", targetProject, deliveryRoot)
-		}
-		for _, r := range recipients {
-			inbox := filepath.Join(deliveryRoot, "agents", r, "inbox")
-			if !dirExists(inbox) {
-				if targetSession != "" {
-					return fmt.Errorf("agent %q not found in peer %q session %q", r, targetProject, targetSession)
-				}
-				return fmt.Errorf("agent %q not found in peer %q", r, targetProject)
-			}
-		}
 		replyProject = resolveProject(root)
 	} else if targetSession != "" {
 		normalized, err := normalizeHandle(targetSession)
@@ -274,13 +253,6 @@ func runSend(args []string) error {
 			return err
 		}
 
-		// Verify the target session and agent inboxes exist.
-		for _, r := range recipients {
-			inbox := filepath.Join(deliveryRoot, "agents", r, "inbox")
-			if !dirExists(inbox) {
-				return fmt.Errorf("agent %q not found in session %q", r, targetSession)
-			}
-		}
 	}
 
 	// Snapshot the physical roots at the authorization boundary. Opening the
@@ -301,21 +273,6 @@ func runSend(args []string) error {
 		return ContextMismatchError("authorized source root identity changed before capability open")
 	}
 
-	// Validate sender in source root, recipients in target root. Always.
-	if targetProject != "" || targetSession != "" {
-		if err := validateKnownHandles(sourceRoot, common.Strict, me); err != nil {
-			return err
-		}
-		if err := validateKnownHandles(deliveryRoot, common.Strict, recipients...); err != nil {
-			return err
-		}
-	} else {
-		allHandles := append([]string{me}, recipients...)
-		if err := validateKnownHandles(root, common.Strict, allHandles...); err != nil {
-			return err
-		}
-	}
-
 	deliveryFS, err := fsq.OpenDeliveryRoot(deliveryRoot, deliveryIdentity)
 	if err != nil {
 		return err
@@ -328,6 +285,39 @@ func runSend(args []string) error {
 			return err
 		}
 		defer func() { _ = sourceFS.Close() }()
+	}
+
+	if fromSession != "" && !deliveryAgentExists(sourceFS, me) {
+		return fmt.Errorf("agent %q not found in source session %q", me, fromSession)
+	}
+	for _, recipient := range recipients {
+		if deliveryInboxExists(deliveryFS, recipient) {
+			continue
+		}
+		switch {
+		case targetProject != "" && targetSession != "":
+			return fmt.Errorf("agent %q not found in peer %q session %q", recipient, targetProject, targetSession)
+		case targetProject != "":
+			return fmt.Errorf("agent %q not found in peer %q", recipient, targetProject)
+		case targetSession != "":
+			return fmt.Errorf("agent %q not found in session %q", recipient, targetSession)
+		}
+	}
+
+	// Validate sender in source root and recipients in target root through the
+	// same capabilities that will perform delivery.
+	if targetProject != "" || targetSession != "" {
+		if err := validateKnownHandlesDeliveryRoot(sourceFS, common.Strict, me); err != nil {
+			return err
+		}
+		if err := validateKnownHandlesDeliveryRoot(deliveryFS, common.Strict, recipients...); err != nil {
+			return err
+		}
+	} else {
+		allHandles := append([]string{me}, recipients...)
+		if err := validateKnownHandlesDeliveryRoot(deliveryFS, common.Strict, allHandles...); err != nil {
+			return err
+		}
 	}
 
 	body, err := readBody(*bodyFlag, *allowEmptyFlag)

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 type headerValidator struct {
@@ -19,6 +20,17 @@ func newHeaderValidator(root string, strict bool) (*headerValidator, error) {
 		return &headerValidator{strict: false}, nil
 	}
 	known, err := loadKnownAgentSet(root, strict)
+	if err != nil {
+		return nil, err
+	}
+	return &headerValidator{strict: true, known: known}, nil
+}
+
+func newHeaderValidatorDeliveryRoot(root *fsq.DeliveryRoot, strict bool) (*headerValidator, error) {
+	if !strict {
+		return &headerValidator{strict: false}, nil
+	}
+	known, err := loadKnownAgentSetDeliveryRoot(root, strict)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fsq/commit_error.go
+++ b/internal/fsq/commit_error.go
@@ -1,0 +1,40 @@
+package fsq
+
+import "fmt"
+
+// CommittedDurabilityError means the visible rename succeeded, but the
+// destination directory could not be synced. Retrying with a new identifier
+// may duplicate an artifact that is already present at FinalPath.
+type CommittedDurabilityError struct {
+	FinalPath string
+	Recipient string
+	Err       error
+}
+
+func (e *CommittedDurabilityError) Error() string {
+	if e.Recipient != "" {
+		return fmt.Sprintf("delivery to %s committed at %s, but durability is indeterminate: %v; do not retry blindly", e.Recipient, e.FinalPath, e.Err)
+	}
+	return fmt.Sprintf("artifact committed at %s, but durability is indeterminate: %v; do not retry blindly", e.FinalPath, e.Err)
+}
+
+func (e *CommittedDurabilityError) Unwrap() error {
+	return e.Err
+}
+
+// DLQTransitionError reports that a DLQ envelope is visible but its directory
+// sync failed, so the claimed source was deliberately retained for recovery.
+type DLQTransitionError struct {
+	EnvelopePath   string
+	SourcePath     string
+	SourceRetained bool
+	Err            error
+}
+
+func (e *DLQTransitionError) Error() string {
+	return fmt.Sprintf("DLQ envelope committed at %s with indeterminate durability; source retained at %s: %v; resolve the partial transition before retrying", e.EnvelopePath, e.SourcePath, e.Err)
+}
+
+func (e *DLQTransitionError) Unwrap() error {
+	return e.Err
+}

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -177,10 +177,14 @@ func (r *DeliveryRoot) WriteFileAtomic(dir, filename string, data []byte, perm o
 	if err := r.root.Rename(tmpPath, finalPath); err != nil {
 		return "", r.cleanupTemp(tmpPath, err)
 	}
+	committedPath := r.displayPath(finalPath)
 	if err := r.syncDir(dir); err != nil {
-		return "", err
+		return committedPath, &CommittedDurabilityError{
+			FinalPath: committedPath,
+			Err:       err,
+		}
 	}
-	return r.displayPath(finalPath), nil
+	return committedPath, nil
 }
 
 // ReadFile reads a root-relative file through the pinned capability.

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -89,6 +90,16 @@ func moveInboxMessageToDLQ(root *DeliveryRoot, agent, readDir, envelopeSourceDir
 	dlqFilename := envelope.ID + ".md"
 	dlqPath, err := deliverToDLQ(root, agent, dlqFilename, data)
 	if err != nil {
+		var committed *CommittedDurabilityError
+		if errors.As(err, &committed) {
+			sourcePath := root.displayPath(srcPath)
+			return dlqPath, &DLQTransitionError{
+				EnvelopePath:   dlqPath,
+				SourcePath:     sourcePath,
+				SourceRetained: true,
+				Err:            err,
+			}
+		}
 		return "", fmt.Errorf("deliver to dlq: %w", err)
 	}
 
@@ -138,12 +149,17 @@ func deliverToDLQ(root *DeliveryRoot, agent, filename string, data []byte) (stri
 	if err := root.root.Rename(tmpPath, newPath); err != nil {
 		return "", root.cleanupTemp(tmpPath, err)
 	}
+	committedPath := root.displayPath(newPath)
 	if err := root.syncDir(newDir); err != nil {
-		return "", err
+		return committedPath, &CommittedDurabilityError{
+			FinalPath: committedPath,
+			Recipient: agent,
+			Err:       fmt.Errorf("sync dlq new dir: %w", err),
+		}
 	}
 	_ = root.syncDir(tmpDir)
 
-	return root.displayPath(newPath), nil
+	return committedPath, nil
 }
 
 // ReadDLQEnvelope reads and parses a DLQ message.

--- a/internal/fsq/dlq_test.go
+++ b/internal/fsq/dlq_test.go
@@ -1,6 +1,7 @@
 package fsq
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,6 +137,47 @@ func TestMoveCurToDLQ(t *testing.T) {
 	}
 	if string(body) != string(content) {
 		t.Fatalf("body mismatch: expected %q, got %q", content, body)
+	}
+}
+
+func TestMoveCurToDLQPostRenameSyncFailureReportsRetainedTransition(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	filename := "indeterminate_dlq.md"
+	sourcePath := filepath.Join(AgentInboxCur(root, "alice"), filename)
+	if err := os.WriteFile(sourcePath, []byte("corrupt"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	deliveryRoot := openDeliveryRootForTest(t, root)
+	dlqNewDir := filepath.Join("agents", "alice", "dlq", "new")
+	deliveryRoot.syncDirForTest = func(dir string) error {
+		if dir == dlqNewDir {
+			return errors.New("injected post-rename sync failure")
+		}
+		return deliveryRoot.syncDirPlatform(dir)
+	}
+
+	dlqPath, err := MoveCurToDLQ(deliveryRoot, "alice", filename, "indeterminate_dlq", "parse_error", "bad data")
+	if err == nil {
+		t.Fatal("MoveCurToDLQ error = nil, want partial transition")
+	}
+	if dlqPath == "" {
+		t.Fatal("MoveCurToDLQ discarded the committed envelope path")
+	}
+	var transition *DLQTransitionError
+	if !errors.As(err, &transition) {
+		t.Fatalf("error = %T %v, want typed DLQ transition", err, err)
+	}
+	if transition.EnvelopePath != dlqPath || transition.SourcePath != sourcePath || !transition.SourceRetained {
+		t.Fatalf("transition = (%q,%q,%v), want (%q,%q,true)", transition.EnvelopePath, transition.SourcePath, transition.SourceRetained, dlqPath, sourcePath)
+	}
+	if _, statErr := os.Stat(dlqPath); statErr != nil {
+		t.Fatalf("committed DLQ envelope missing: %v", statErr)
+	}
+	if _, statErr := os.Stat(sourcePath); statErr != nil {
+		t.Fatalf("source was not retained: %v", statErr)
 	}
 }
 

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -118,7 +118,12 @@ func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, 
 		// - newDir: new entry is visible
 		// - tmpDir: old entry removal is durable
 		if err := root.syncDir(stage.newDir); err != nil {
-			return nil, committedDeliveryError(root, stages[:i+1], stages[i+1:], fmt.Errorf("sync new dir for %s: %w", stage.recipient, err))
+			commitErr := &CommittedDurabilityError{
+				FinalPath: root.displayPath(stage.newPath),
+				Recipient: stage.recipient,
+				Err:       fmt.Errorf("sync new dir: %w", err),
+			}
+			return nil, committedDeliveryError(root, stages[:i+1], stages[i+1:], commitErr)
 		}
 		// Best-effort sync of tmpDir (non-fatal: message is already delivered)
 		_ = root.syncDir(stage.tmpDir)
@@ -162,11 +167,16 @@ func DeliverToExistingInbox(root *DeliveryRoot, agent, filename string, data []b
 	if err := root.root.Rename(tmpPath, newPath); err != nil {
 		return "", root.cleanupTemp(tmpPath, fmt.Errorf("rename tmp->new for %s: %w", agent, err))
 	}
+	committedPath := root.displayPath(newPath)
 	if err := root.syncDir(newDir); err != nil {
-		return "", fmt.Errorf("sync new dir for %s: %w", agent, err)
+		return committedPath, &CommittedDurabilityError{
+			FinalPath: committedPath,
+			Recipient: agent,
+			Err:       fmt.Errorf("sync new dir: %w", err),
+		}
 	}
 	_ = root.syncDir(tmpDir) // best-effort
-	return root.displayPath(newPath), nil
+	return committedPath, nil
 }
 
 func cleanupStagedTmp(root *DeliveryRoot, stages []stagedDelivery, primary error) error {

--- a/internal/fsq/maildir_test.go
+++ b/internal/fsq/maildir_test.go
@@ -107,6 +107,75 @@ func TestDeliverToExistingInboxNoDir(t *testing.T) {
 	}
 }
 
+func TestDeliverToExistingInboxPostRenameSyncFailureReportsCommittedResult(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	deliveryRoot := openDeliveryRootForTest(t, root)
+	newDir := filepath.Join("agents", "codex", "inbox", "new")
+	deliveryRoot.syncDirForTest = func(dir string) error {
+		if dir == newDir {
+			return errors.New("injected post-rename sync failure")
+		}
+		return deliveryRoot.syncDirPlatform(dir)
+	}
+
+	filename := "indeterminate.md"
+	path, err := DeliverToExistingInbox(deliveryRoot, "codex", filename, []byte("committed"))
+	if err == nil {
+		t.Fatal("DeliverToExistingInbox error = nil, want indeterminate durability")
+	}
+	wantPath := filepath.Join(AgentInboxNew(root, "codex"), filename)
+	if path != wantPath {
+		t.Fatalf("path = %q, want committed path %q", path, wantPath)
+	}
+	var committed *CommittedDurabilityError
+	if !errors.As(err, &committed) {
+		t.Fatalf("error = %T %v, want typed committed result", err, err)
+	}
+	if committed.FinalPath != wantPath || committed.Recipient != "codex" {
+		t.Fatalf("committed result = (%q,%q), want (%q,codex)", committed.FinalPath, committed.Recipient, wantPath)
+	}
+	if _, statErr := os.Stat(wantPath); statErr != nil {
+		t.Fatalf("committed message missing: %v", statErr)
+	}
+}
+
+func TestDeliveryRootWriteFileAtomicPostRenameSyncFailureReportsCommittedResult(t *testing.T) {
+	root := openDeliveryRootForTest(t, t.TempDir())
+	const dir = "meta"
+	syncCalls := 0
+	root.syncDirForTest = func(got string) error {
+		if got == dir {
+			syncCalls++
+			if syncCalls == 2 {
+				return errors.New("injected post-rename sync failure")
+			}
+		}
+		return root.syncDirPlatform(got)
+	}
+
+	path, err := root.WriteFileAtomic(dir, "state.json", []byte("committed"), 0o600)
+	if err == nil {
+		t.Fatal("WriteFileAtomic error = nil, want indeterminate durability")
+	}
+	wantPath := filepath.Join(root.Base(), dir, "state.json")
+	if path != wantPath {
+		t.Fatalf("path = %q, want committed path %q", path, wantPath)
+	}
+	var committed *CommittedDurabilityError
+	if !errors.As(err, &committed) {
+		t.Fatalf("error = %T %v, want typed committed result", err, err)
+	}
+	if committed.FinalPath != wantPath || committed.Recipient != "" {
+		t.Fatalf("committed result = (%q,%q), want (%q,empty)", committed.FinalPath, committed.Recipient, wantPath)
+	}
+	if data, readErr := os.ReadFile(wantPath); readErr != nil || string(data) != "committed" {
+		t.Fatalf("committed file = %q, err=%v", data, readErr)
+	}
+}
+
 func TestDeliverToInboxesRollback(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("chmod permissions are unreliable on Windows")


### PR DESCRIPTION
## Summary

Delivery fixes from the pre-release ChatGPT-Pro review, plus a threat-model note.

**B-3 (correctness bug — duplicate delivery):** a post-rename directory `fsync` failure was reported as an ordinary delivery failure even though the message file already existed, so a retry created a duplicate. Now returns typed `CommittedDurabilityError` (final path + recipient, "do not retry blindly") and `DLQTransitionError` (envelope visible, source retained); `send`/`reply`/outbox surface the committed-with-indeterminate-durability state, and DLQ no longer removes the source on a partial transition.

**B-2 (hardening — kept, DX-neutral):** authorization and routing decisions (config load, strict-handle validation, message discovery, header validation, parse, DLQ/move/receipt) now run through the verified `DeliveryRoot` capability with no-follow reads, instead of ambient pathname reads before the capability is opened. Legitimate in-tree symlinks still work; only escaping/retargeted aliases refuse.

**SECURITY.md:** documents that AMQ is a personal single-user on-machine tool — untrusted-ancestor / cross-command-retarget / TOCTOU alias-swap threats are **accepted residuals**, not defended against; correctness (no duplicate delivery/injection) and reliability are the priority.

## Note

A related routed-retarget defense (a new `AM_PEER_ROOT_IDS` attestation contract) was intentionally **not** built — it's over-scoped for a personal tool.

## Review

B-3 has an fsync-failure regression; B-2 has capability-relative alias-retarget refusal tests. Both green under `-race`; `make ci` + four GOOS builds green. Post-#233 hardening. Implementation by Codex; review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)