### PR TITLE
docs(coop): link amq-keepalive companion in supervisor recipes

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -354,6 +354,14 @@ For the consumer plist, replace the command arguments after the executable with
 Route stdout/stderr to supervisor-managed logs and secure the unit/plist for the
 local user who owns the mailbox.
 
+If you prefer a supervisor that follows explicitly registered terminal sessions
+instead of fixed plists, [amq-keepalive](https://github.com/ohade/amq-keepalive)
+is a standalone companion tool that implements this recipe for macOS: it keeps a
+registry of attached terminal targets (Ghostty, cmux), reattaches `wake` after
+reboot or sleep through a user LaunchAgent, and can install SessionStart
+reattach hooks for Claude Code and Codex. It follows the same daemon-free
+contract and talks to AMQ only through the public `amq` CLI.
+
 **Options:**
 - `--inject-mode auto|raw|paste|none` - Injection strategy; `none` enforces zero terminal input
 - `--wake-inject-mode auto|raw|paste|none` - `coop exec` pass-through for its managed wake


### PR DESCRIPTION
Recovers the docs link from Ohad's #244 (which he closed) and the outcome of the #245 review: keep `amq-keepalive` external, and link it from AMQ's supervisor-recipes section.

Adds a short pointer in COOP.md to [ohade/amq-keepalive](https://github.com/ohade/amq-keepalive) — a standalone macOS companion that supervises target-aware `amq wake` for explicitly registered terminal sessions (Ghostty, cmux) via a user LaunchAgent, with SessionStart reattach hooks. It stays external, keeps AMQ daemon-free/transport-only, and talks to AMQ solely through the public CLI.

Text is Ohad's own wording from #244; verified the target repo is public and non-empty.

Co-authored with Ohad (credited in the commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)