### PR TITLE
docs(coop): correct amq-keepalive reboot vs sleep mechanism

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -357,10 +357,11 @@ local user who owns the mailbox.
 If you prefer a supervisor that follows explicitly registered terminal sessions
 instead of fixed plists, [amq-keepalive](https://github.com/ohade/amq-keepalive)
 is a standalone companion tool that implements this recipe for macOS: it keeps a
-registry of attached terminal targets (Ghostty, cmux), reattaches `wake` after
-reboot or sleep through a user LaunchAgent, and can install SessionStart
-reattach hooks for Claude Code and Codex. It follows the same daemon-free
-contract and talks to AMQ only through the public `amq` CLI.
+registry of attached terminal targets (Ghostty, cmux), keeps registered wakes
+supervised through sleep with a user LaunchAgent, and can install SessionStart
+hooks for Claude Code and Codex to reattach recreated sessions after reboot. It
+follows the same daemon-free contract and talks to AMQ only through the public
+`amq` CLI.
 
 **Options:**
 - `--inject-mode auto|raw|paste|none` - Injection strategy; `none` enforces zero terminal input


### PR DESCRIPTION
Follow-up accuracy fix to #263. Codex caught that the wording (inherited verbatim from Ohad's #244) conflated two distinct mechanisms — it credited the user LaunchAgent with reattaching wake after reboot.

Verified against the companion README's Boundaries section:
- "The tool does not launch or resurrect terminal sessions."
- "Reboot survival comes from reattaching on session start, not from assuming a terminal id survives … restart. The recreated session registers its current target."

So: the LaunchAgent supervises registered wakes through sleep; the SessionStart hooks handle reboot reattach. Split the claim accordingly.

Caught by codex; verified live against ohade/amq-keepalive README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)