### PR TITLE
fix(wake): ignore stale backlog on managed startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ amq dlq list --me <agent> [--new | --cur] [--json]
 amq dlq read --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--json]
 amq dlq retry --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--all] [--force]
 amq dlq purge --me <agent> [--session <name>] [--ignore-session-pin] [--older-than <duration>] [--dry-run] [--yes]
-amq wake --me <agent> [--inject-cmd <cmd>] [--inject-mode <auto|raw|paste|none>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>] [--interrupt] [--interrupt-label <label>] [--interrupt-priority <p>] [--interrupt-cmd <ctrl-c|none>] [--interrupt-notice <str>] [--interrupt-cooldown <duration>] [--debug]
+amq wake --me <agent> [--baseline-existing] [--inject-cmd <cmd>] [--inject-mode <auto|raw|paste|none>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>] [--interrupt] [--interrupt-label <label>] [--interrupt-priority <p>] [--interrupt-cmd <ctrl-c|none>] [--interrupt-notice <str>] [--interrupt-cooldown <duration>] [--debug]
 amq wake repair --me <agent> [--root <path>] [--json]
 amq wake retire --me <agent> --inject-via <absolute-executable> [--inject-arg <arg>...] [--root <path>] [--json]
 amq upgrade

--- a/COOP.md
+++ b/COOP.md
@@ -272,6 +272,10 @@ amq reply --id "msg_123" --kind review_response --body "LGTM with minor suggesti
 > Co-op works without wake. `coop exec` starts it automatically.
 
 `amq wake` uses TIOCSTI to inject notifications into your terminal by default.
+Pass `--baseline-existing` when attaching a wake to an already-running agent:
+messages already present in `inbox/new` remain unread and do not trigger that
+wake, while messages arriving after the startup snapshot do. `coop exec` and
+`wake repair` enable this behavior automatically.
 For orchestrators or hardened environments without a controlling TTY, use an
 explicit external transport:
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ amq coop exec grok     # Grok CLI as an optional peer; caller flags forwarded un
 
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
 Managed launchers can add `--require-wake` to fail instead of launching the agent when the wake watcher cannot start.
+`coop exec` baselines messages that were already waiting before its wake starts,
+so an old unread message cannot inject text or an interrupt into the newly
+launched terminal. The messages remain unread and no delivery receipt is
+created; only messages arriving after the baseline trigger that wake.
 Launchers that use an external injector can add `--wake-inject-via /absolute/path/to/injector`
 and repeated `--wake-inject-arg` values. When that invocation starts a new wake,
 the wake stores a repair target so `amq wake repair` can restart wake later

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -213,7 +213,7 @@ func TestCoopExecWakeInjectModeValidation(t *testing.T) {
 
 func TestBuildCoopWakeArgsIncludesNoneMode(t *testing.T) {
 	got := buildCoopWakeArgs("codex", "/tmp/root", "none", "", nil)
-	want := []string{"--no-update-check", "wake", "--me", "codex", "--root", "/tmp/root", "--inject-mode", "none"}
+	want := []string{"--no-update-check", "wake", "--me", "codex", "--root", "/tmp/root", "--baseline-existing", "--inject-mode", "none"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildCoopWakeArgs() = %#v, want %#v", got, want)
 	}

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -299,7 +299,7 @@ func runCoopExec(args []string) error {
 }
 
 func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectArgs []string) []string {
-	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root}
+	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root, "--baseline-existing"}
 	if injectMode != "" && injectMode != wakeInjectModeAuto {
 		args = append(args, "--inject-mode", injectMode)
 	}

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -42,6 +42,7 @@ type wakeConfig struct {
 	interruptCooldown time.Duration
 	lastInterrupt     time.Time
 	controlStop       <-chan struct{}
+	baselineExisting  map[string]struct{}
 }
 
 const defaultInjectTimeout = 5 * time.Second
@@ -155,6 +156,9 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		}
 		name := entry.Name()
 		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		if _, ignored := cfg.baselineExisting[name]; ignored {
 			continue
 		}
 

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -1116,7 +1116,7 @@ func TestRunWakeRepairClearsRepairAvailableAfterStartFailure(t *testing.T) {
 func TestBuildCoopWakeArgsIncludesInjectViaTarget(t *testing.T) {
 	args := buildCoopWakeArgs("codex", "/tmp/root", wakeInjectModeAuto, "/abs/injector", []string{"exec", "target"})
 	got := strings.Join(args, "|")
-	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target"
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target"
 	if got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}
@@ -1162,7 +1162,7 @@ func TestBuildRepairWakeArgsIncludesReadyFileAndTarget(t *testing.T) {
 	}
 	args := buildRepairWakeArgs("/tmp/root", "codex", target, "/tmp/ready")
 	got := strings.Join(args, "|")
-	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready"
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready"
 	if got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -848,6 +848,75 @@ func TestNotifyNewMessages_InjectViaInjectCmdPayload(t *testing.T) {
 	}
 }
 
+func TestNotifyNewMessagesSkipsBaselineWithoutDraining(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	writeMessage := func(filename, id, subject string) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      id,
+				From:    "codex",
+				To:      []string{"alice"},
+				Thread:  "p2p/alice__codex",
+				Subject: subject,
+				Created: "2026-07-22T00:00:00Z",
+			},
+			Body: "body",
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "alice", filename, data); err != nil {
+			t.Fatalf("deliver %s: %v", id, err)
+		}
+	}
+
+	writeMessage("stale.md", "stale", "stale subject")
+	cfg, outputPath := injectViaCaptureConfig(t)
+	cfg.me = "alice"
+	cfg.root = root
+	cfg.previewLen = 48
+	cfg.baselineExisting = map[string]struct{}{"stale.md": {}}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify stale baseline: %v", err)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("baseline message triggered injection; output stat error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentInboxNew(root, "alice"), "stale.md")); err != nil {
+		t.Fatalf("baseline message was moved or removed: %v", err)
+	}
+	receipts, err := os.ReadDir(fsq.AgentReceipts(root, "alice"))
+	if err != nil {
+		t.Fatalf("read receipts: %v", err)
+	}
+	if len(receipts) != 0 {
+		t.Fatalf("wake created receipts for an unread baseline: %v", receipts)
+	}
+
+	writeMessage("fresh.md", "fresh", "fresh subject")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify fresh message: %v", err)
+	}
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read injection output: %v", err)
+	}
+	if !strings.Contains(string(got), "fresh subject") || strings.Contains(string(got), "stale subject") {
+		t.Fatalf("injected payload = %q, want fresh message only", string(got))
+	}
+}
+
 func TestNotifyNewMessages_InjectViaInterruptFailureDoesNotUpdateCooldown(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -627,7 +627,7 @@ func configureRepairWakeCommand(cmd *exec.Cmd, output *os.File) {
 }
 
 func buildRepairWakeArgs(root, me string, target wakeTarget, readyPath string) []string {
-	args := []string{"--no-update-check", "wake", "--me", me, "--root", root, "--inject-via", target.InjectVia}
+	args := []string{"--no-update-check", "wake", "--me", me, "--root", root, "--baseline-existing", "--inject-via", target.InjectVia}
 	for _, arg := range target.InjectArgs {
 		args = append(args, "--inject-arg", arg)
 	}
@@ -659,6 +659,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
 	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
+	baselineExistingFlag := fs.Bool("baseline-existing", false, "Ignore messages already waiting when this wake starts")
 
 	usage := usageWithHiddenFlags(fs, "amq wake --me <agent> [options]",
 		[]string{"ready-file", "accept-existing-wake"},
@@ -879,12 +880,38 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		interruptCooldown: *interruptCooldownFlag,
 		controlStop:       controlStop,
 	}
+	if *baselineExistingFlag {
+		baseline, err := snapshotWakeExistingMessages(root, me)
+		if err != nil {
+			return fmt.Errorf("snapshot existing wake messages: %w", err)
+		}
+		cfg.baselineExisting = baseline
+	}
 
 	if err := writeWakeReadyFile(root, me, readyFile, inspectWakeLock(root, me)); err != nil {
 		return err
 	}
 
 	return loop(cfg)
+}
+
+func snapshotWakeExistingMessages(root, me string) (map[string]struct{}, error) {
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, me))
+	if err != nil {
+		return nil, err
+	}
+	baseline := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		baseline[name] = struct{}{}
+	}
+	return baseline, nil
 }
 
 func parseInterruptKey(raw string) (string, error) {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -133,6 +133,48 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopBaselinesBeforeReadiness(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	inboxNew := fsq.AgentInboxNew(root, "orchestrator")
+	if err := os.WriteFile(filepath.Join(inboxNew, "stale.md"), []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale message: %v", err)
+	}
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	injector := writeExecutableForTest(t, "injector")
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", injector,
+		"--baseline-existing",
+		"--ready-file", readyPath,
+	}, func(cfg wakeConfig) error {
+		if _, ok := cfg.baselineExisting["stale.md"]; !ok {
+			t.Fatal("stale message missing from startup baseline")
+		}
+		if _, statErr := os.Stat(readyPath); statErr != nil {
+			t.Fatalf("expected ready file after baseline snapshot: %v", statErr)
+		}
+		if err := os.WriteFile(filepath.Join(inboxNew, "fresh.md"), []byte("fresh"), 0o600); err != nil {
+			t.Fatalf("write fresh message: %v", err)
+		}
+		if _, ok := cfg.baselineExisting["fresh.md"]; ok {
+			t.Fatal("message arriving after readiness was incorrectly baselined")
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
 func TestRunWakeWithLoopNoneSkipsTTYAndWritesReadyFile(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -224,6 +266,9 @@ func TestRunWakeHelpHidesInternalReadyFlags(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "inject-cmd") {
 		t.Fatalf("wake help should keep --inject-cmd visible:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "baseline-existing") {
+		t.Fatalf("wake help should keep --baseline-existing visible:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "none") || !strings.Contains(stdout, "zero terminal input") {
 		t.Fatalf("wake help should document none as zero-input mode:\n%s", stdout)

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -80,6 +80,10 @@ Leader prepares commit -> user approves -> push
   writes notices to wake stderr, turns urgent interrupts into one bell plus the
   output notice, and rejects `--inject-via`, `--inject-arg`, and `--inject-cmd`.
   Stderr shares the TUI terminal by default and may remain visible until redraw.
+- When attaching wake after the agent owns its terminal, pass
+  `amq wake --baseline-existing ...`. Existing `inbox/new` messages remain
+  unread and emit no receipts; only later arrivals trigger that wake. `coop
+  exec` and `wake repair` add this baseline automatically.
 
 ## Message Handling
 


### PR DESCRIPTION
## Summary
- add a wake startup baseline that suppresses only messages already present in inbox/new
- enable it automatically for coop exec and wake repair
- preserve stale messages as unread without emitting delivery receipts
- keep messages arriving after the snapshot eligible for notification

## Why
A managed wake could inject an old unread notification, including an urgent Ctrl-C, while a newly launched agent terminal was still starting. Baseline-before-readiness prevents that stale backlog from becoming terminal input.

## Verification
- make ci
- focused baseline/readiness and unread/no-receipt regression tests
- gitleaks staged scan