### PR TITLE
fix(wake): defer managed wake until SessionStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ the wake stores a repair target so `amq wake repair` can restart wake later
 without restarting the agent TUI. If `--require-wake` reuses an existing wake,
 that wake must already have repair metadata to be repairable.
 
+SessionStart-managed launchers can use `amq coop exec --defer-wake ...` to start
+the TUI before attaching wake. AMQ captures the pre-launch unread floor in a
+private manifest and exports its path as `AMQ_WAKE_BASELINE_FILE`; the hook must
+start `amq wake --baseline-file "$AMQ_WAKE_BASELINE_FILE"` and require its
+generation-bound readiness acknowledgement. Messages arriving between capture
+and hook attachment remain eligible for notification. Baseline capture failure
+does not block the TUI: AMQ exports the sanitized `AMQ_WAKE_BASELINE_ERROR`, and
+the hook should show a visible “wake unavailable; messages remain queued”
+warning. Installing that SessionStart hook is a hard prerequisite: without it,
+`--defer-wake` intentionally starts the TUI but cannot attach wake or show the
+hook-owned warning. Wake never drains messages or emits consumption receipts.
+
 ### 3. Send & Receive
 
 ```bash
@@ -221,6 +233,11 @@ or injecting into the wrong terminal. Repaired wake output goes to
 `agents/<agent>/.wake.repair.log`; `doctor --ops` can report whether repair is
 available, but it never starts a wake process.
 
+Repairable `--baseline-existing` inject-via wakes materialize and persist their
+original floor once. A restart reuses that exact manifest, so messages that
+arrived during notifier downtime are not accidentally suppressed by a fresh
+snapshot. A missing or changed persisted floor fails closed.
+
 `amq wake retire` is the exact managed-shutdown path. It requires the caller's
 expected `--inject-via` executable and ordered `--inject-arg` values. A live
 wake is retired only when its process identity, unchanged lock generation, and
@@ -228,6 +245,9 @@ saved target all match: Linux signals through its pidfd capability and macOS
 uses the generation-bound cooperative control socket. An exactly-bound
 proven-stale lock may be removed without signaling. The mailbox and saved
 target are preserved in either case; raw and unverified wakes fail closed.
+The requested retire target need not repeat persisted baseline metadata: process
+signaling is bound to the unchanged lock generation and exact injector transport,
+while the saved floor remains part of the lock-bound target validation.
 
 The lifecycle boundaries are:
 

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -4,6 +4,8 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 func TestSplitDashDash(t *testing.T) {
@@ -132,6 +135,87 @@ func TestCoopExecRequireWakeRejectsNoWake(t *testing.T) {
 	}
 }
 
+func TestCoopExecDeferWakeRejectsActiveWakeOptions(t *testing.T) {
+	for _, args := range [][]string{
+		{"--defer-wake", "--no-wake", "claude"},
+		{"--defer-wake", "--require-wake", "claude"},
+		{"--defer-wake", "--wake-inject-mode", "none", "claude"},
+		{"--defer-wake", "--wake-inject-via", "/tmp/injector", "claude"},
+		{"--defer-wake", "--wake-inject-arg", "exec", "claude"},
+	} {
+		err := runCoopExec(args)
+		if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+			t.Fatalf("runCoopExec(%v) error = %v, want defer-wake conflict", args, err)
+		}
+	}
+}
+
+func TestCoopExecDeferWakeExportsManifestBeforeExec(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeTestMessage(t, root, "codex", "stale.md", "stale-id", "private subject", "private body")
+
+	oldExec := coopExecProcess
+	defer func() { coopExecProcess = oldExec }()
+	sentinel := errors.New("exec intercepted")
+	coopExecProcess = func(_ string, _ []string, env []string) error {
+		path := envValue(env, envWakeBaselineFile)
+		if path == "" || envValue(env, envWakeBaselineError) != "" {
+			t.Fatalf("deferred env missing manifest or contains error: %#v", env)
+		}
+		baseline, err := readWakeBaseline(path, root, "codex")
+		if err != nil {
+			t.Fatalf("readWakeBaseline before exec: %v", err)
+		}
+		if _, ok := baseline.IDs["stale-id"]; !ok {
+			t.Fatalf("baseline ids = %#v", baseline.IDs)
+		}
+		return sentinel
+	}
+	err := runCoopExec([]string{"--defer-wake", "--no-init", "--root", root, "--me", "codex", "true"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("runCoopExec error = %v", err)
+	}
+}
+
+func TestCoopExecDeferWakeCaptureFailureStillExecsWithSanitizedError(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i <= maxWakeBaselineMessages; i++ {
+		name := fmt.Sprintf("stale-%04d.md", i)
+		if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(root, "codex"), name), []byte("invalid"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldExec := coopExecProcess
+	defer func() { coopExecProcess = oldExec }()
+	sentinel := errors.New("exec intercepted")
+	coopExecProcess = func(_ string, _ []string, env []string) error {
+		if got := envValue(env, envWakeBaselineFile); got != "" {
+			t.Fatalf("baseline file = %q, want empty", got)
+		}
+		if got := envValue(env, envWakeBaselineError); got != wakeBaselineCaptureError {
+			t.Fatalf("baseline error = %q, want sanitized code", got)
+		}
+		return sentinel
+	}
+	err := runCoopExec([]string{"--defer-wake", "--no-init", "--root", root, "--me", "codex", "true"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("runCoopExec error = %v", err)
+	}
+}
+
 func TestCoopExecWakeInjectViaValidation(t *testing.T) {
 	nonExecutable := filepath.Join(secureTempDirForTest(t), "injector")
 	if err := os.WriteFile(nonExecutable, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
@@ -213,7 +297,7 @@ func TestCoopExecWakeInjectModeValidation(t *testing.T) {
 
 func TestBuildCoopWakeArgsIncludesNoneMode(t *testing.T) {
 	got := buildCoopWakeArgs("codex", "/tmp/root", "none", "", nil)
-	want := []string{"--no-update-check", "wake", "--me", "codex", "--root", "/tmp/root", "--inject-mode", "none"}
+	want := []string{"--no-update-check", "wake", "--me", "codex", "--root", "/tmp/root", "--baseline-existing", "--inject-mode", "none"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildCoopWakeArgs() = %#v, want %#v", got, want)
 	}

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -17,6 +17,8 @@ import (
 
 const wakeReadyTimeout = 2 * time.Second
 
+var coopExecProcess = syscall.Exec
+
 func runCoopExec(args []string) error {
 	// Split at "--" before flag parsing so agent flags aren't consumed.
 	amqArgs, agentArgs := splitDashDash(args)
@@ -28,6 +30,7 @@ func runCoopExec(args []string) error {
 	noInitFlag := fs.Bool("no-init", false, "Don't auto-initialize if .amqrc is missing")
 	noGitignoreFlag := fs.Bool("no-gitignore", false, "When auto-initializing, do not modify .gitignore")
 	noWakeFlag := fs.Bool("no-wake", false, "Don't start amq wake in background")
+	deferWakeFlag := fs.Bool("defer-wake", false, "Capture the unread floor for a SessionStart hook instead of starting wake before exec")
 	requireWakeFlag := fs.Bool("require-wake", false, "Fail if amq wake cannot start and acquire its lock")
 	wakeInjectModeFlag := fs.String("wake-inject-mode", wakeInjectModeAuto, "Wake injection mode: auto, raw, paste, none")
 	wakeInjectViaFlag := fs.String("wake-inject-via", "", "Start wake with this absolute --inject-via executable, enabling later amq wake repair")
@@ -51,6 +54,7 @@ func runCoopExec(args []string) error {
 		"  amq coop exec grok                                # Grok CLI, caller flags forwarded as-is",
 		"  amq coop exec --session feature-x claude          # Isolated session",
 		"  amq coop exec --root .agent-mail/auth claude      # Explicit root (no session default)",
+		"  amq coop exec --defer-wake claude                  # SessionStart attaches wake from a pre-launch floor",
 		"  amq coop exec --require-wake --wake-inject-mode none claude  # Zero-input wake",
 		"  amq coop exec --wake-inject-via /path/to/injector codex",
 		"  amq coop exec --me myagent bash                   # Debug shell with AMQ env",
@@ -68,6 +72,18 @@ func runCoopExec(args []string) error {
 	}
 	if *noWakeFlag && *requireWakeFlag {
 		return UsageError("--require-wake cannot be used with --no-wake")
+	}
+	if *deferWakeFlag {
+		var conflicts []string
+		fs.Visit(func(f *flag.Flag) {
+			switch f.Name {
+			case "no-wake", "require-wake", "wake-inject-mode", "wake-inject-via", "wake-inject-arg":
+				conflicts = append(conflicts, "--"+f.Name)
+			}
+		})
+		if len(conflicts) > 0 {
+			return UsageError("--defer-wake cannot be combined with active wake option(s): %s", strings.Join(conflicts, ", "))
+		}
 	}
 	wakeInjectVia := strings.TrimSpace(*wakeInjectViaFlag)
 	wakeInjectMode, err := normalizeWakeInjectMode(*wakeInjectModeFlag)
@@ -227,11 +243,24 @@ func runCoopExec(args []string) error {
 		return fmt.Errorf("command not found: %s", cmdName)
 	}
 
+	var deferredBaseline wakeBaseline
+	var baselineCaptured bool
+	var baselineCaptureFailed bool
+	if *deferWakeFlag {
+		deferredBaseline, err = captureWakeBaseline(root, agentHandle)
+		if err != nil {
+			baselineCaptureFailed = true
+			_ = writeStderr("warning: could not capture the AMQ wake baseline; wake attachment must fail closed after startup: %v\n", err)
+		} else {
+			baselineCaptured = true
+		}
+	}
+
 	// Start amq wake in background (unless --no-wake).
 	// On successful Exec, wake is orphaned (reparented to init/launchd) — intended.
 	// On failed Exec, deferred kill cleans up the wake process.
 	var wakeProc *os.Process
-	if !*noWakeFlag {
+	if !*noWakeFlag && !*deferWakeFlag {
 		amqBin, binErr := os.Executable()
 		if binErr != nil {
 			amqBin = "amq"
@@ -285,21 +314,34 @@ func runCoopExec(args []string) error {
 	// independent of AM_ROOT. A custom sessionless --root clears inherited pins.
 	sessionIdentity := coopSessionIdentity(root, *sessionFlag, *rootFlag)
 	env := buildCoopExecEnvironment(os.Environ(), root, agentHandle, sessionIdentity)
+	if baselineCaptured {
+		env = setEnvVar(env, envWakeBaselineFile, deferredBaseline.Path)
+		env = unsetEnvVar(env, envWakeBaselineError)
+	} else if baselineCaptureFailed {
+		env = unsetEnvVar(env, envWakeBaselineFile)
+		env = setEnvVar(env, envWakeBaselineError, wakeBaselineCaptureError)
+	} else {
+		env = unsetEnvVar(env, envWakeBaselineFile)
+		env = unsetEnvVar(env, envWakeBaselineError)
+	}
 
 	// Build argv: command name + agent args.
 	argv := append([]string{cmdName}, agentArgs...)
 
 	// Replace process. On success, this never returns.
 	// On failure, clean up the wake process.
-	execErr := syscall.Exec(binaryPath, argv, env)
+	execErr := coopExecProcess(binaryPath, argv, env)
 	if wakeProc != nil {
 		_ = wakeProc.Kill()
+	}
+	if baselineCaptured {
+		removeWakeBaselineIfUnreferenced(root, agentHandle, deferredBaseline.Path)
 	}
 	return execErr
 }
 
 func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectArgs []string) []string {
-	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root}
+	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root, "--baseline-existing"}
 	if injectMode != "" && injectMode != wakeInjectModeAuto {
 		args = append(args, "--inject-mode", injectMode)
 	}

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/receipt"
 )
 
 type wakeConfig struct {
@@ -42,6 +43,10 @@ type wakeConfig struct {
 	interruptCooldown time.Duration
 	lastInterrupt     time.Time
 	controlStop       <-chan struct{}
+	baseline          *wakeBaseline
+	seen              map[string]struct{}
+	readyFile         string
+	readyInspection   wakeLockInspection
 }
 
 const defaultInjectTimeout = 5 * time.Second
@@ -81,6 +86,8 @@ var (
 )
 
 type wakeMsgInfo struct {
+	id       string
+	filename string
 	from     string
 	subject  string
 	priority string
@@ -144,8 +151,8 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		return err
 	}
 
-	var messages []wakeMsgInfo
-	senderCounts := make(map[string]int)
+	var normalMessages []wakeMsgInfo
+	normalCounts := make(map[string]int)
 	var interruptMessages []wakeMsgInfo
 	interruptCounts := make(map[string]int)
 
@@ -157,7 +164,9 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
 			continue
 		}
-
+		if wakeMessageSeen(cfg, "", name) {
+			continue
+		}
 		path := filepath.Join(inboxNew, name)
 		header, err := format.ReadHeaderFile(path)
 		if err != nil {
@@ -165,8 +174,12 @@ func notifyNewMessages(cfg *wakeConfig) error {
 				continue
 			}
 			// Count corrupt messages too
-			messages = append(messages, wakeMsgInfo{from: "unknown", subject: "(parse error)"})
-			senderCounts["unknown"]++
+			normalMessages = append(normalMessages, wakeMsgInfo{filename: name, from: "unknown", subject: "(parse error)"})
+			normalCounts["unknown"]++
+			continue
+		}
+		id := strings.TrimSpace(header.ID)
+		if wakeMessageSeen(cfg, id, name) || hasValidDrainedReceipt(cfg.root, cfg.me, id) {
 			continue
 		}
 
@@ -180,22 +193,24 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		priority := strings.TrimSpace(header.Priority)
 
 		info := wakeMsgInfo{
+			id:       id,
+			filename: name,
 			from:     from,
 			subject:  subject,
 			priority: priority,
 			labels:   header.Labels,
 		}
 
-		messages = append(messages, info)
-		senderCounts[from]++
-
 		if cfg.interrupt && isInterruptMessage(info, cfg) {
 			interruptMessages = append(interruptMessages, info)
 			interruptCounts[from]++
+		} else {
+			normalMessages = append(normalMessages, info)
+			normalCounts[from]++
 		}
 	}
 
-	if len(messages) == 0 {
+	if len(normalMessages) == 0 && len(interruptMessages) == 0 {
 		return nil
 	}
 
@@ -203,21 +218,29 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		interruptText := buildInterruptText(cfg.session, interruptMessages, interruptCounts, cfg.previewLen, cfg.interruptNotice)
 		if cfg.injectMode == wakeInjectModeNone {
 			writeWakeOutput(interruptText, true)
-			return nil
-		}
-		now := time.Now()
-		if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
-			if cfg.injectVia != "" {
-				if err := injectVia(cfg, cfg.interruptKey); err == nil {
+			markWakeMessagesSeen(cfg, interruptMessages)
+		} else {
+			now := time.Now()
+			if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
+				if cfg.injectVia != "" {
+					if err := injectVia(cfg, cfg.interruptKey); err == nil {
+						cfg.lastInterrupt = now
+						time.Sleep(50 * time.Millisecond)
+					}
+				} else if err := tiocsti.Inject(cfg.interruptKey); err == nil {
 					cfg.lastInterrupt = now
 					time.Sleep(50 * time.Millisecond)
 				}
-			} else if err := tiocsti.Inject(cfg.interruptKey); err == nil {
-				cfg.lastInterrupt = now
-				time.Sleep(50 * time.Millisecond)
 			}
+			if err := injectNotification(cfg, interruptText, false); err != nil {
+				return err
+			}
+			markWakeMessagesSeen(cfg, interruptMessages)
 		}
-		return injectNotification(cfg, interruptText, false)
+	}
+
+	if len(normalMessages) == 0 {
+		return nil
 	}
 
 	// Build notification text
@@ -227,10 +250,60 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		text = "\n" + cfg.injectCmd + "\n"
 	} else {
 		// Default: informational notice
-		text = buildNotificationText(cfg.session, messages, senderCounts, cfg.previewLen)
+		text = buildNotificationText(cfg.session, normalMessages, normalCounts, cfg.previewLen)
 	}
 
-	return injectNotification(cfg, text, true)
+	if err := injectNotification(cfg, text, true); err != nil {
+		return err
+	}
+	markWakeMessagesSeen(cfg, normalMessages)
+	return nil
+}
+
+func wakeMessageSeen(cfg *wakeConfig, id, filename string) bool {
+	if sameWakeBaselineMessage(cfg.baseline, id, filename) {
+		return true
+	}
+	if cfg.seen == nil {
+		return false
+	}
+	if id != "" {
+		if _, ok := cfg.seen["id:"+id]; ok {
+			return true
+		}
+	}
+	_, ok := cfg.seen["file:"+filename]
+	return ok
+}
+
+func markWakeMessagesSeen(cfg *wakeConfig, messages []wakeMsgInfo) {
+	if cfg.seen == nil {
+		cfg.seen = make(map[string]struct{})
+	}
+	for _, message := range messages {
+		if message.id != "" {
+			cfg.seen["id:"+message.id] = struct{}{}
+		}
+		if message.filename != "" {
+			cfg.seen["file:"+message.filename] = struct{}{}
+		}
+	}
+}
+
+func hasValidDrainedReceipt(root, me, id string) bool {
+	if id == "" {
+		return false
+	}
+	receipts, err := receipt.List(root, me, receipt.ListFilter{MsgID: id, Consumer: me, Stage: receipt.StageDrained})
+	if err != nil {
+		return false
+	}
+	for _, item := range receipts {
+		if item.Schema == format.CurrentSchema && item.MsgID == id && item.Consumer == me && item.Stage == receipt.StageDrained {
+			return true
+		}
+	}
+	return false
 }
 
 func buildNotificationText(session string, messages []wakeMsgInfo, senderCounts map[string]int, previewLen int) string {
@@ -408,6 +481,10 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 				cfg.fallbackWarn = false
 			}
 			_, _ = fmt.Fprint(os.Stderr, plainText+"\n")
+			// An external injector is commonly the only path back into a TUI.
+			// Stderr may be detached or hidden, so it is a diagnostic fallback,
+			// not a delivery acknowledgement. Keep the message retryable.
+			return err
 		}
 		return nil
 	}

--- a/internal/cli/wake_baseline.go
+++ b/internal/cli/wake_baseline.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	wakeBaselineSchema       = 1
+	wakeBaselineFilePrefix   = ".wake-baseline-"
+	wakeBaselineFileSuffix   = ".json"
+	maxWakeBaselineMessages  = 512
+	envWakeBaselineFile      = "AMQ_WAKE_BASELINE_FILE"
+	envWakeBaselineError     = "AMQ_WAKE_BASELINE_ERROR"
+	wakeBaselineCaptureError = "baseline_capture_failed"
+)
+
+type wakeBaselineMessage struct {
+	ID       string `json:"id,omitempty"`
+	Filename string `json:"filename"`
+}
+
+type wakeBaselineManifest struct {
+	Schema   int                   `json:"schema"`
+	Root     string                `json:"root"`
+	RootID   string                `json:"root_id"`
+	Agent    string                `json:"agent"`
+	LaunchID string                `json:"launch_id"`
+	Created  string                `json:"created"`
+	Messages []wakeBaselineMessage `json:"messages"`
+}
+
+type wakeBaseline struct {
+	Manifest wakeBaselineManifest
+	Path     string
+	Digest   string
+	IDs      map[string]struct{}
+	Files    map[string]struct{}
+}
+
+func captureWakeBaseline(root, me string) (wakeBaseline, error) {
+	root = canonicalWakeRoot(root)
+	rootID, err := resolveTreeIdentityToken(root)
+	if err != nil {
+		return wakeBaseline{}, fmt.Errorf("resolve baseline root identity: %w", err)
+	}
+	launchID, err := newWakeBaselineLaunchID()
+	if err != nil {
+		return wakeBaseline{}, err
+	}
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, me))
+	if err != nil {
+		return wakeBaseline{}, fmt.Errorf("scan baseline inbox: %w", err)
+	}
+	manifest := wakeBaselineManifest{
+		Schema:   wakeBaselineSchema,
+		Root:     root,
+		RootID:   rootID,
+		Agent:    me,
+		LaunchID: launchID,
+		Created:  time.Now().UTC().Format(time.RFC3339Nano),
+		Messages: make([]wakeBaselineMessage, 0, len(entries)),
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		if len(manifest.Messages) >= maxWakeBaselineMessages {
+			return wakeBaseline{}, fmt.Errorf("baseline contains more than %d messages", maxWakeBaselineMessages)
+		}
+		item := wakeBaselineMessage{Filename: entry.Name()}
+		if header, readErr := format.ReadHeaderFile(filepath.Join(fsq.AgentInboxNew(root, me), entry.Name())); readErr == nil {
+			item.ID = strings.TrimSpace(header.ID)
+		}
+		manifest.Messages = append(manifest.Messages, item)
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return wakeBaseline{}, fmt.Errorf("marshal wake baseline: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > maxWakeMetadataFileBytes {
+		return wakeBaseline{}, fmt.Errorf("wake baseline exceeds %d bytes", maxWakeMetadataFileBytes)
+	}
+	path := filepath.Join(fsq.AgentBase(root, me), wakeBaselineFilePrefix+launchID+wakeBaselineFileSuffix)
+	if err := writeWakeMetadataFile(path, data, "wake baseline"); err != nil {
+		return wakeBaseline{}, err
+	}
+	baseline, err := readWakeBaseline(path, root, me)
+	if err != nil {
+		_ = os.Remove(path)
+		return wakeBaseline{}, err
+	}
+	return baseline, nil
+}
+
+func newWakeBaselineLaunchID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate wake baseline launch id: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func readWakeBaseline(path, root, me string) (wakeBaseline, error) {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "." || !filepath.IsAbs(path) {
+		return wakeBaseline{}, fmt.Errorf("wake baseline path must be absolute")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return wakeBaseline{}, fmt.Errorf("stat wake baseline: %w", err)
+	}
+	if err := validateWakeBaselineFile(path, root, me, info); err != nil {
+		return wakeBaseline{}, err
+	}
+	file, err := openWakeMetadataFile(path)
+	if err != nil {
+		return wakeBaseline{}, fmt.Errorf("open wake baseline: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return wakeBaseline{}, fmt.Errorf("stat opened wake baseline: %w", err)
+	}
+	if err := validateWakeBaselineFile(path, root, me, openedInfo); err != nil {
+		return wakeBaseline{}, err
+	}
+	if !os.SameFile(info, openedInfo) {
+		return wakeBaseline{}, fmt.Errorf("wake baseline %s changed while opening", path)
+	}
+	data, err := readWakeMetadata(file, "wake baseline", path)
+	if err != nil {
+		return wakeBaseline{}, err
+	}
+	var manifest wakeBaselineManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return wakeBaseline{}, fmt.Errorf("parse wake baseline: %w", err)
+	}
+	if err := validateWakeBaselineManifest(manifest, path, root, me); err != nil {
+		return wakeBaseline{}, err
+	}
+	ids := make(map[string]struct{}, len(manifest.Messages))
+	files := make(map[string]struct{}, len(manifest.Messages))
+	for _, message := range manifest.Messages {
+		if message.ID != "" {
+			ids[message.ID] = struct{}{}
+		}
+		files[message.Filename] = struct{}{}
+	}
+	return wakeBaseline{
+		Manifest: manifest,
+		Path:     path,
+		Digest:   wakeBaselineDigest(data),
+		IDs:      ids,
+		Files:    files,
+	}, nil
+}
+
+func validateWakeBaselineFile(path, root, me string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("wake baseline %s must not be a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("wake baseline %s must be a regular file", path)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return fmt.Errorf("wake baseline %s mode is %o, want 0600", path, got)
+	}
+	if err := validateWakeTargetPathOwnership("wake baseline", path, info); err != nil {
+		return err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return fmt.Errorf("resolve wake baseline: %w", err)
+	}
+	resolvedAgent, err := filepath.EvalSymlinks(fsq.AgentBase(canonicalWakeRoot(root), me))
+	if err != nil {
+		return fmt.Errorf("resolve wake baseline agent root: %w", err)
+	}
+	if filepath.Dir(resolvedPath) != resolvedAgent {
+		return fmt.Errorf("wake baseline must be directly under the exact agent root")
+	}
+	return validateWakeTargetParentDirs("wake baseline", resolvedPath)
+}
+
+func validateWakeBaselineManifest(manifest wakeBaselineManifest, path, root, me string) error {
+	if manifest.Schema != wakeBaselineSchema {
+		return fmt.Errorf("wake baseline schema %d unsupported", manifest.Schema)
+	}
+	if canonicalWakeRoot(manifest.Root) != canonicalWakeRoot(root) {
+		return fmt.Errorf("wake baseline root mismatch")
+	}
+	if manifest.Agent != me {
+		return fmt.Errorf("wake baseline agent mismatch")
+	}
+	if verifyTreeIdentityToken(root, manifest.RootID) != TreeRelationSame {
+		return fmt.Errorf("wake baseline root identity mismatch")
+	}
+	if len(manifest.LaunchID) != 32 {
+		return fmt.Errorf("wake baseline launch id is invalid")
+	}
+	if _, err := hex.DecodeString(manifest.LaunchID); err != nil {
+		return fmt.Errorf("wake baseline launch id is invalid")
+	}
+	wantName := wakeBaselineFilePrefix + manifest.LaunchID + wakeBaselineFileSuffix
+	if filepath.Base(path) != wantName {
+		return fmt.Errorf("wake baseline launch id does not match its filename")
+	}
+	if len(manifest.Messages) > maxWakeBaselineMessages {
+		return fmt.Errorf("wake baseline contains more than %d messages", maxWakeBaselineMessages)
+	}
+	seenFiles := make(map[string]struct{}, len(manifest.Messages))
+	for _, message := range manifest.Messages {
+		if message.Filename == "" || filepath.Base(message.Filename) != message.Filename ||
+			strings.HasPrefix(message.Filename, ".") || !strings.HasSuffix(message.Filename, ".md") {
+			return fmt.Errorf("wake baseline contains invalid message filename")
+		}
+		if strings.ContainsRune(message.ID, 0) || strings.ContainsAny(message.ID, "/\\") {
+			return fmt.Errorf("wake baseline contains invalid message id")
+		}
+		if _, exists := seenFiles[message.Filename]; exists {
+			return fmt.Errorf("wake baseline contains duplicate message filename")
+		}
+		seenFiles[message.Filename] = struct{}{}
+	}
+	return nil
+}
+
+func wakeBaselineDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func sameWakeBaselineMessage(baseline *wakeBaseline, id, filename string) bool {
+	if baseline == nil {
+		return false
+	}
+	if id != "" {
+		_, ok := baseline.IDs[id]
+		return ok
+	}
+	_, ok := baseline.Files[filename]
+	return ok
+}
+
+func removeWakeBaselineIfUnreferenced(root, me, path string) {
+	if strings.TrimSpace(path) == "" {
+		return
+	}
+	if target, exists, err := readWakeTarget(root, me); err == nil && exists && target.BaselineFile == path {
+		return
+	}
+	if info, err := os.Lstat(path); err == nil && validateWakeBaselineFile(path, root, me, info) == nil {
+		_ = os.Remove(path)
+	}
+}

--- a/internal/cli/wake_baseline_test.go
+++ b/internal/cli/wake_baseline_test.go
@@ -1,0 +1,911 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/receipt"
+)
+
+func writeWakeTestMessage(t *testing.T, root, me, filename, id, subject, body string) {
+	t.Helper()
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      id,
+			From:    "claude",
+			To:      []string{me},
+			Thread:  "p2p/claude__" + me,
+			Subject: subject,
+			Created: time.Now().UTC().Format(time.RFC3339Nano),
+		},
+		Body: body,
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(root, me), filename), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCaptureWakeBaselineContainsIdentifiersOnly(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeTestMessage(t, root, "codex", "stale.md", "msg-stale", "secret subject", "secret body")
+
+	baseline, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatalf("captureWakeBaseline: %v", err)
+	}
+	info, err := os.Lstat(baseline.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 || !info.Mode().IsRegular() {
+		t.Fatalf("baseline mode = %v", info.Mode())
+	}
+	data, err := os.ReadFile(baseline.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "secret subject") || strings.Contains(string(data), "secret body") {
+		t.Fatalf("manifest leaked message content: %s", data)
+	}
+	if !strings.Contains(string(data), "msg-stale") || !strings.Contains(string(data), "stale.md") {
+		t.Fatalf("manifest omitted message identifiers: %s", data)
+	}
+	if baseline.Manifest.RootID == "" || baseline.Manifest.LaunchID == "" {
+		t.Fatalf("manifest identity binding incomplete: %#v", baseline.Manifest)
+	}
+}
+
+func TestReadWakeBaselineRejectsSecurityAndIdentityMismatches(t *testing.T) {
+	root := secureTempDirForTest(t)
+	otherRoot := secureTempDirForTest(t)
+	for _, candidate := range []string{root, otherRoot} {
+		if err := fsq.EnsureRootDirs(candidate); err != nil {
+			t.Fatal(err)
+		}
+		if err := fsq.EnsureAgentDirs(candidate, "codex"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	baseline, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readWakeBaseline(baseline.Path, root, "claude"); err == nil {
+		t.Fatalf("wrong-agent error = %v", err)
+	}
+	if _, err := readWakeBaseline(baseline.Path, otherRoot, "codex"); err == nil || !strings.Contains(err.Error(), "exact agent root") {
+		t.Fatalf("wrong-root error = %v", err)
+	}
+	if err := os.Chmod(baseline.Path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readWakeBaseline(baseline.Path, root, "codex"); err == nil || !strings.Contains(err.Error(), "want 0600") {
+		t.Fatalf("mode error = %v", err)
+	}
+	if err := os.Chmod(baseline.Path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(fsq.AgentBase(root, "codex"), wakeBaselineFilePrefix+strings.Repeat("a", 32)+wakeBaselineFileSuffix)
+	if err := os.Symlink(baseline.Path, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readWakeBaseline(link, root, "codex"); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink error = %v", err)
+	}
+}
+
+func TestWakeBaselineManifestRejectsRootIdentityTampering(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := baseline.Manifest
+	manifest.RootID = "v1:darwin:0:0"
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(baseline.Path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readWakeBaseline(baseline.Path, root, "codex"); err == nil || !strings.Contains(err.Error(), "root identity mismatch") {
+		t.Fatalf("identity error = %v", err)
+	}
+}
+
+func TestWakeBaselineExplicitCleanupPreservesTargetAndSkipsSymlink(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	protected, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.BaselineFile = protected.Path
+	target.BaselineDigest = protected.Digest
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	orphan, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.WriteFile(outside, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(fsq.AgentBase(root, "codex"), wakeBaselineFilePrefix+strings.Repeat("b", 32)+wakeBaselineFileSuffix)
+	if err := os.Symlink(outside, symlink); err != nil {
+		t.Fatal(err)
+	}
+
+	removeWakeBaselineIfUnreferenced(root, "codex", orphan.Path)
+	removeWakeBaselineIfUnreferenced(root, "codex", protected.Path)
+	removeWakeBaselineIfUnreferenced(root, "codex", symlink)
+	if _, err := os.Stat(orphan.Path); !os.IsNotExist(err) {
+		t.Fatalf("orphan remains: %v", err)
+	}
+	if _, err := os.Stat(protected.Path); err != nil {
+		t.Fatalf("target baseline removed: %v", err)
+	}
+	if _, err := os.Lstat(symlink); err != nil {
+		t.Fatalf("symlink was removed: %v", err)
+	}
+	if data, err := os.ReadFile(outside); err != nil || string(data) != "keep" {
+		t.Fatalf("outside target changed: %q %v", data, err)
+	}
+}
+
+func TestNotifyNewMessagesSkipsCorruptPrelaunchBaselineByFilename(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	corruptPath := filepath.Join(fsq.AgentInboxNew(root, "alice"), "corrupt.md")
+	if err := os.WriteFile(corruptPath, []byte("not a message"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := captureWakeBaseline(root, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, outputPath := injectViaCaptureConfig(t)
+	cfg.root = root
+	cfg.me = "alice"
+	cfg.baseline = &baseline
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notifyNewMessages: %v", err)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("corrupt prelaunch message triggered injection: %v", err)
+	}
+}
+
+func TestWakeLoopClosesPrelaunchGapBeforePublishingReadiness(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeTestMessage(t, root, "codex", "stale.md", "msg-stale", "stale floor", "body")
+	baseline, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This is the launch gap: the floor already exists, but wake has not yet
+	// installed its watcher.
+	writeWakeTestMessage(t, root, "codex", "gap.md", "msg-gap", "launch gap", "body")
+
+	toolDir := secureTempDirForTest(t)
+	outputPath := filepath.Join(toolDir, "injections.log")
+	injector := filepath.Join(toolDir, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nprintf '%s\\n' \"$2\" >> \"$1\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{outputPath})
+	target.BaselineFile = baseline.Path
+	target.BaselineDigest = baseline.Digest
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{target: &target, wakeMode: wakeTargetInjectVia})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	readyPath := filepath.Join(secureTempDirForTest(t), "wake.ready")
+	stop := make(chan struct{})
+	cfg := wakeConfig{
+		me:              "codex",
+		root:            root,
+		session:         "gap-test",
+		injectVia:       injector,
+		injectArgs:      []string{outputPath},
+		injectTimeout:   time.Second,
+		previewLen:      200,
+		baseline:        &baseline,
+		seen:            make(map[string]struct{}),
+		readyFile:       readyPath,
+		readyInspection: inspectWakeLock(root, "codex"),
+		controlStop:     stop,
+	}
+	done := make(chan error, 1)
+	go func() { done <- runWakeLoop(cfg) }()
+	stopped := false
+	defer func() {
+		if !stopped {
+			close(stop)
+			<-done
+		}
+	}()
+	waitForTestCondition(t, 3*time.Second, func() bool {
+		_, statErr := os.Stat(readyPath)
+		return statErr == nil
+	}, "wake readiness after launch-gap catch-up")
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(data), "launch gap") != 1 || strings.Contains(string(data), "stale floor") {
+		t.Fatalf("initial catch-up output = %q", data)
+	}
+
+	writeWakeTestMessage(t, root, "codex", "post.md", "msg-post", "post ready", "body")
+	waitForTestCondition(t, 3*time.Second, func() bool {
+		data, readErr := os.ReadFile(outputPath)
+		return readErr == nil && strings.Contains(string(data), "post ready")
+	}, "post-ready watcher notification")
+	close(stop)
+	stopped = true
+	if err := <-done; err != nil {
+		t.Fatalf("runWakeLoop: %v", err)
+	}
+	data, err = os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(data), "launch gap") != 1 || strings.Count(string(data), "post ready") != 1 {
+		t.Fatalf("messages were not notified exactly once: %q", data)
+	}
+	for _, name := range []string{"stale.md", "gap.md", "post.md"} {
+		if _, err := os.Stat(filepath.Join(fsq.AgentInboxNew(root, "codex"), name)); err != nil {
+			t.Fatalf("wake consumed %s: %v", name, err)
+		}
+	}
+	receipts, err := os.ReadDir(fsq.AgentReceipts(root, "codex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipts) != 0 {
+		t.Fatalf("wake emitted receipts: %v", receipts)
+	}
+}
+
+func TestWakeLoopDoesNotPublishReadyWhenCatchupInjectionFails(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeWakeTestMessage(t, root, "codex", "gap.md", "msg-gap", "must fail", "body")
+	injector := filepath.Join(secureTempDirForTest(t), "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 9\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.BaselineFile = baseline.Path
+	target.BaselineDigest = baseline.Digest
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{target: &target, wakeMode: wakeTargetInjectVia})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	readyPath := filepath.Join(secureTempDirForTest(t), "wake.ready")
+	cfg := wakeConfig{
+		me: "codex", root: root, injectVia: injector, injectTimeout: time.Second,
+		baseline: &baseline, seen: make(map[string]struct{}), readyFile: readyPath,
+		readyInspection: inspectWakeLock(root, "codex"),
+	}
+	err = runWakeLoop(cfg)
+	if err == nil || !strings.Contains(err.Error(), "initial wake catch-up") {
+		t.Fatalf("runWakeLoop error = %v", err)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file exists after failed catch-up: %v", statErr)
+	}
+	if _, statErr := os.Stat(wakeCatchupReadyPath(root, "codex")); !os.IsNotExist(statErr) {
+		t.Fatalf("persistent catch-up readiness exists after failed catch-up: %v", statErr)
+	}
+	if len(cfg.seen) != 0 {
+		t.Fatalf("failed catch-up acknowledged messages: %#v", cfg.seen)
+	}
+}
+
+func TestWakeLoopMixedUrgentAndNormalCatchupCompletesBeforeReady(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeWakeTestMessage(t, root, "codex", "normal.md", "msg-normal", "normal gap", "body")
+	urgent := format.Message{
+		Header: format.Header{
+			Schema: format.CurrentSchema, ID: "msg-urgent", From: "claude", To: []string{"codex"},
+			Thread: "p2p/claude__codex", Subject: "urgent gap", Created: time.Now().UTC().Format(time.RFC3339Nano),
+			Priority: "urgent", Labels: []string{"interrupt"},
+		},
+		Body: "body",
+	}
+	data, err := urgent.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(root, "codex"), "urgent.md"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	toolDir := secureTempDirForTest(t)
+	outputPath := filepath.Join(toolDir, "injections.log")
+	injector := filepath.Join(toolDir, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nprintf '%s\\n' \"$2\" >> \"$1\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{outputPath})
+	target.BaselineFile = baseline.Path
+	target.BaselineDigest = baseline.Digest
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{target: &target, wakeMode: wakeTargetInjectVia})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	readyPath := filepath.Join(secureTempDirForTest(t), "wake.ready")
+	stop := make(chan struct{})
+	cfg := wakeConfig{
+		me: "codex", root: root, session: "mixed", injectVia: injector, injectArgs: []string{outputPath},
+		injectTimeout: time.Second, previewLen: 200, interrupt: true, interruptLabel: "interrupt",
+		interruptPriority: "urgent", baseline: &baseline, seen: make(map[string]struct{}), readyFile: readyPath,
+		readyInspection: inspectWakeLock(root, "codex"), controlStop: stop,
+	}
+	done := make(chan error, 1)
+	go func() { done <- runWakeLoop(cfg) }()
+	stopped := false
+	defer func() {
+		if !stopped {
+			close(stop)
+			<-done
+		}
+	}()
+	waitForTestCondition(t, 3*time.Second, func() bool {
+		_, statErr := os.Stat(readyPath)
+		return statErr == nil
+	}, "mixed catch-up readiness")
+	output, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(output), "urgent gap") || !strings.Contains(string(output), "normal gap") {
+		t.Fatalf("readiness preceded complete mixed catch-up: %q", output)
+	}
+	if ready, err := wakeCatchupReadyMatches(root, "codex", cfg.readyInspection); err != nil || !ready {
+		t.Fatalf("persistent catch-up readiness = %v, err=%v", ready, err)
+	}
+	close(stop)
+	stopped = true
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNotifyNewMessagesIgnoresValidDrainedDuplicate(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeTestMessage(t, root, "alice", "duplicate.md", "msg-drained", "already drained", "body")
+	if err := receipt.Emit(root, receipt.New("msg-drained", "", "claude", "alice", receipt.StageDrained, "")); err != nil {
+		t.Fatal(err)
+	}
+	cfg, outputPath := injectViaCaptureConfig(t)
+	cfg.root = root
+	cfg.me = "alice"
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("drained duplicate triggered injection: %v", err)
+	}
+}
+
+func TestAcceptExistingWakeRequiresExactBaselineFloor(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatal(err)
+	}
+	first, err := captureWakeBaseline(root, "orchestrator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := captureWakeBaseline(root, "orchestrator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})
+	target.BaselineFile = first.Path
+	target.BaselineDigest = first.Digest
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--inject-via", injector, "--baseline-file", first.Path},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID: wakePID, TTY: "unknown", ProcessStart: "start-1", BootID: "boot-1",
+		Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
+	}, target))
+	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+		t.Fatal(err)
+	}
+	inspection := inspectWakeLock(root, "orchestrator")
+	if err := waitForWakeCatchupReady(root, "orchestrator", inspection, 40*time.Millisecond); err == nil || !strings.Contains(err.Error(), "did not attest") {
+		t.Fatalf("missing catch-up attestation error = %v", err)
+	}
+	if err := os.WriteFile(wakeCatchupReadyPath(root, "orchestrator"), []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitForWakeCatchupReady(root, "orchestrator", inspection, 40*time.Millisecond); err == nil || !strings.Contains(err.Error(), "did not attest") {
+		t.Fatalf("corrupt catch-up attestation error = %v", err)
+	}
+	if err := writeWakeCatchupReadyFile(root, "orchestrator", inspection); err != nil {
+		t.Fatal(err)
+	}
+
+	wrongReady := filepath.Join(secureTempDirForTest(t), "wrong.ready")
+	err = runWakeWithLoop([]string{
+		"--root", root, "--me", "orchestrator", "--inject-via", injector,
+		"--inject-arg", "exec", "--baseline-file", second.Path,
+		"--ready-file", wrongReady, "--accept-existing-wake",
+	}, func(wakeConfig) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "baseline floor") {
+		t.Fatalf("different floor error = %v", err)
+	}
+	if _, statErr := os.Stat(wrongReady); !os.IsNotExist(statErr) {
+		t.Fatalf("wrong floor published readiness: %v", statErr)
+	}
+	persisted, exists, err := readWakeTarget(root, "orchestrator")
+	if err != nil || !exists {
+		t.Fatalf("read persisted target: exists=%v err=%v", exists, err)
+	}
+	if persisted.BaselineFile != first.Path || persisted.BaselineDigest != first.Digest {
+		t.Fatalf("wrong floor replaced target: %#v", persisted)
+	}
+
+	exactReady := filepath.Join(secureTempDirForTest(t), "exact.ready")
+	err = runWakeWithLoop([]string{
+		"--root", root, "--me", "orchestrator", "--inject-via", injector,
+		"--inject-arg", "exec", "--baseline-file", first.Path,
+		"--ready-file", exactReady, "--accept-existing-wake",
+	}, func(wakeConfig) error { return nil })
+	if err != nil {
+		t.Fatalf("exact floor reuse: %v", err)
+	}
+	if _, statErr := os.Stat(exactReady); statErr != nil {
+		t.Fatalf("exact floor did not publish readiness: %v", statErr)
+	}
+}
+
+func TestWakeBaselineRotationAndConcurrentExistingSemantics(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatal(err)
+	}
+	first, err := captureWakeBaseline(root, "orchestrator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := captureWakeBaseline(root, "orchestrator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	withBaseline := func(baseline wakeBaseline, args ...string) wakeTarget {
+		target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, args)
+		target.BaselineFile = baseline.Path
+		target.BaselineDigest = baseline.Digest
+		return target
+	}
+	firstTarget := withBaseline(first, "exec")
+	secondTarget := withBaseline(second, "exec")
+	// Both starters completed their precheck/capture before either staged a
+	// target. The acquire transition below reproduces the winner appearing in
+	// that gap and proves the loser reuses it instead of rotating it.
+	for _, provisional := range []wakeTarget{firstTarget, secondTarget} {
+		if _, found, err := persistedExactWakeBaseline(root, "orchestrator", provisional); err != nil || found {
+			t.Fatalf("provisional starter precheck found=%v err=%v, want clean miss", found, err)
+		}
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--inject-via", injector},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	installExisting := func(target wakeTarget) {
+		_ = os.Remove(filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock"))
+		if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+			t.Fatal(err)
+		}
+		writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+			PID: wakePID, TTY: "unknown", ProcessStart: "start-1", BootID: "boot-1",
+			Executable: "/opt/homebrew/bin/amq", Generation: "generation-old",
+		}, target))
+	}
+
+	oldReplace := replaceExistingWakeLock
+	replacementCalls := 0
+	replaceExistingWakeLock = func(inspection wakeLockInspection) (bool, error) {
+		replacementCalls++
+		if err := os.Remove(inspection.LockPath); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	t.Cleanup(func() { replaceExistingWakeLock = oldReplace })
+
+	t.Run("concurrent baseline-existing reuses winner floor", func(t *testing.T) {
+		installExisting(firstTarget)
+		replacementCalls = 0
+		_, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+			acceptExistingValid: true, materializeLegacyBaseline: true,
+			target: &secondTarget, wakeMode: wakeTargetInjectVia,
+		})
+		var alreadyRunning *wakeAlreadyRunningError
+		if !errors.As(err, &alreadyRunning) {
+			t.Fatalf("acquire error = %v, want existing winner", err)
+		}
+		if replacementCalls != 0 {
+			t.Fatalf("provisional floor rotated a concurrent winner %d times", replacementCalls)
+		}
+		persisted, exists, readErr := readWakeTarget(root, "orchestrator")
+		if readErr != nil || !exists || !sameWakeInjectorIdentity(persisted, firstTarget) {
+			t.Fatalf("persisted winner changed: exists=%v target=%#v err=%v", exists, persisted, readErr)
+		}
+	})
+
+	t.Run("legacy target without floor migrates once", func(t *testing.T) {
+		legacy := mustNewWakeTargetForTest(t, root, "orchestrator", injector, []string{"exec"})
+		installExisting(legacy)
+		replacementCalls = 0
+		cleanup, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+			acceptExistingValid: true, materializeLegacyBaseline: true,
+			target: &secondTarget, wakeMode: wakeTargetInjectVia,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if replacementCalls != 1 {
+			t.Fatalf("legacy migration replacements = %d, want 1", replacementCalls)
+		}
+		persisted, exists, readErr := readWakeTarget(root, "orchestrator")
+		if readErr != nil || !exists || !sameWakeInjectorIdentity(persisted, secondTarget) {
+			t.Fatalf("legacy target did not migrate exactly: exists=%v target=%#v err=%v", exists, persisted, readErr)
+		}
+	})
+
+	t.Run("explicit floor replacement rotates same transport", func(t *testing.T) {
+		installExisting(firstTarget)
+		replacementCalls = 0
+		cleanup, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+			acceptExistingValid: true, replaceExistingBaseline: true,
+			target: &secondTarget, wakeMode: wakeTargetInjectVia,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if replacementCalls != 1 {
+			t.Fatalf("exact floor replacements = %d, want 1", replacementCalls)
+		}
+	})
+
+	t.Run("explicit replacement refuses different arguments", func(t *testing.T) {
+		installExisting(firstTarget)
+		replacementCalls = 0
+		different := withBaseline(second, "different")
+		_, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+			acceptExistingValid: true, replaceExistingBaseline: true,
+			target: &different, wakeMode: wakeTargetInjectVia,
+		})
+		if err == nil {
+			t.Fatal("different transport unexpectedly replaced the existing wake")
+		}
+		if replacementCalls != 0 {
+			t.Fatalf("different transport replacement calls = %d", replacementCalls)
+		}
+	})
+
+	t.Run("explicit replacement refuses different injector path", func(t *testing.T) {
+		installExisting(firstTarget)
+		replacementCalls = 0
+		otherInjector := writeExecutableForTest(t, "other-injector")
+		different := mustNewWakeTargetForTest(t, root, "orchestrator", otherInjector, []string{"exec"})
+		different.BaselineFile = second.Path
+		different.BaselineDigest = second.Digest
+		_, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+			acceptExistingValid: true, replaceExistingBaseline: true,
+			target: &different, wakeMode: wakeTargetInjectVia,
+		})
+		if err == nil || replacementCalls != 0 {
+			t.Fatalf("different injector error=%v replacement calls=%d", err, replacementCalls)
+		}
+	})
+
+	t.Run("explicit replacement refuses different owner", func(t *testing.T) {
+		const existingOwnerPID = 5001
+		const requestedOwnerPID = 5002
+		stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+			switch pid {
+			case wakePID:
+				return wakeProcessInfo{
+					PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1",
+					Executable: "/opt/homebrew/bin/amq",
+					Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator", "--inject-via", injector},
+				}
+			case existingOwnerPID:
+				return wakeProcessInfo{PID: pid, Running: true, StartToken: "owner-a", BootID: "boot-1"}
+			case requestedOwnerPID:
+				return wakeProcessInfo{PID: pid, Running: true, StartToken: "owner-b", BootID: "boot-1"}
+			default:
+				return wakeProcessInfo{PID: pid}
+			}
+		})
+		owner := wakeOwner{PID: existingOwnerPID, ProcessStart: "owner-a", BootID: "boot-1"}
+		existing := firstTarget
+		existing.Owner = &owner
+		installExisting(existing)
+		replacementCalls = 0
+		requestedOwner := wakeOwner{PID: requestedOwnerPID, ProcessStart: "owner-b", BootID: "boot-1"}
+		requested := firstTarget
+		requested.Owner = &requestedOwner
+		_, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+			acceptExistingValid: true, replaceExistingBaseline: true,
+			target: &requested, wakeMode: wakeTargetInjectVia,
+		})
+		if err == nil || replacementCalls != 0 {
+			t.Fatalf("different owner error=%v replacement calls=%d", err, replacementCalls)
+		}
+	})
+
+	t.Run("explicit replacement refuses unverified identity", func(t *testing.T) {
+		stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+			if pid == wakePID {
+				return wakeProcessInfo{
+					PID: pid, Running: true, Executable: "/opt/homebrew/bin/amq",
+					Args: []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+				}
+			}
+			return wakeProcessInfo{PID: pid}
+		})
+		_ = os.Remove(filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock"))
+		if err := writeWakeTarget(root, "orchestrator", firstTarget); err != nil {
+			t.Fatal(err)
+		}
+		writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+			PID: wakePID, TTY: "unknown", ProcessStart: "start-1", BootID: "boot-1",
+			Executable: "/opt/homebrew/bin/amq", Generation: "generation-unverified",
+		}, firstTarget))
+		replacementCalls = 0
+		_, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+			acceptExistingValid: true, replaceExistingBaseline: true,
+			target: &secondTarget, wakeMode: wakeTargetInjectVia,
+		})
+		if err == nil || replacementCalls != 0 {
+			t.Fatalf("unverified identity error=%v replacement calls=%d", err, replacementCalls)
+		}
+	})
+}
+
+func TestBaselineExistingInjectViaPersistsExactRepairFloor(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeTestMessage(t, root, "codex", "existing.md", "msg-existing", "existing", "body")
+	injector := writeExecutableForTest(t, "injector")
+	called := false
+	err := runWakeWithLoop([]string{
+		"--root", root, "--me", "codex", "--inject-via", injector,
+		"--inject-arg", "exec", "--baseline-existing",
+	}, func(cfg wakeConfig) error {
+		called = true
+		target, exists, err := readWakeTarget(root, "codex")
+		if err != nil || !exists {
+			return fmt.Errorf("read persisted target: exists=%v err=%w", exists, err)
+		}
+		if target.BaselineFile == "" || target.BaselineDigest == "" || cfg.baseline == nil || cfg.baseline.Path != target.BaselineFile {
+			return fmt.Errorf("baseline-existing target is not exact: %#v", target)
+		}
+		args := strings.Join(buildRepairWakeArgs(root, "codex", target, "/tmp/ready"), "|")
+		if !strings.Contains(args, "|--baseline-file|"+target.BaselineFile+"|") || strings.Contains(args, "|--baseline-existing|") {
+			return fmt.Errorf("repair args lost exact floor: %s", args)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("wake loop callback was not called")
+	}
+}
+
+func TestBaselineExistingRestartReusesPersistedFloorAcrossDowntime(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeTestMessage(t, root, "codex", "before.md", "msg-before", "before first start", "body")
+	toolDir := secureTempDirForTest(t)
+	outputPath := filepath.Join(toolDir, "injections.log")
+	injector := filepath.Join(toolDir, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nprintf '%s\\n' \"$2\" >> \"$1\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	baseArgs := []string{
+		"--root", root, "--me", "codex", "--inject-via", injector,
+		"--inject-arg", outputPath, "--baseline-existing",
+	}
+	var originalFloor string
+	if err := runWakeWithLoop(baseArgs, func(cfg wakeConfig) error {
+		if cfg.baseline == nil || cfg.baseline.Path == "" {
+			return fmt.Errorf("first start did not materialize an exact floor")
+		}
+		originalFloor = cfg.baseline.Path
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")); !os.IsNotExist(err) {
+		t.Fatalf("first wake lock still exists after simulated stop: %v", err)
+	}
+	writeWakeTestMessage(t, root, "codex", "downtime.md", "msg-downtime", "arrived during downtime", "body")
+
+	readyPath := filepath.Join(secureTempDirForTest(t), "wake.ready")
+	restartArgs := append(append([]string{}, baseArgs...), "--accept-existing-wake", "--ready-file", readyPath)
+	if err := runWakeWithLoop(restartArgs, func(cfg wakeConfig) error {
+		gotFloor := ""
+		if cfg.baseline != nil {
+			gotFloor = cfg.baseline.Path
+		}
+		if gotFloor != originalFloor {
+			return fmt.Errorf("restart floor = %q, want persisted %q", gotFloor, originalFloor)
+		}
+		return notifyNewMessages(&cfg)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	output, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(output), "arrived during downtime") || strings.Contains(string(output), "before first start") {
+		t.Fatalf("restart notification output = %q", output)
+	}
+	persisted, exists, err := readWakeTarget(root, "codex")
+	if err != nil || !exists || persisted.BaselineFile != originalFloor {
+		t.Fatalf("restart persisted floor changed: exists=%v target=%#v err=%v", exists, persisted, err)
+	}
+	if err := os.Remove(originalFloor); err != nil {
+		t.Fatal(err)
+	}
+	err = runWakeWithLoop(restartArgs, func(wakeConfig) error {
+		t.Fatal("wake loop ran after persisted floor disappeared")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "persisted exact wake floor is unusable") {
+		t.Fatalf("missing persisted floor error = %v", err)
+	}
+}
+
+func TestRepairArgsReusePersistedBaselineFile(t *testing.T) {
+	target := wakeTarget{
+		InjectVia:      "/abs/injector",
+		InjectArgs:     []string{"exec", "target"},
+		BaselineFile:   "/private/baseline.json",
+		BaselineDigest: "sha256:abc",
+	}
+	args := buildRepairWakeArgs("/tmp/root", "codex", target, "/tmp/ready")
+	got := strings.Join(args, "|")
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--baseline-file|/private/baseline.json|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready"
+	if got != want {
+		t.Fatalf("repair args = %q, want %q", got, want)
+	}
+}
+
+func waitForTestCondition(t *testing.T, timeout time.Duration, condition func() bool, label string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", label)
+}

--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -23,8 +23,9 @@ import (
 var darwinSocketCWDMu sync.Mutex
 
 func wakeControlSocketPath(root, me, generation string) string {
-	sum := sha256.Sum256([]byte(canonicalWakeRoot(root) + "\x00" + me + "\x00" + generation))
-	return filepath.Join(fsq.AgentBase(root, me), ".w."+hex.EncodeToString(sum[:8]))
+	canonicalRoot := canonicalWakeRoot(root)
+	sum := sha256.Sum256([]byte(canonicalRoot + "\x00" + me + "\x00" + generation))
+	return filepath.Join(fsq.AgentBase(canonicalRoot, me), ".w."+hex.EncodeToString(sum[:8]))
 }
 
 func withDarwinSocketDirFD(dirfd int, fn func() error) error {
@@ -260,7 +261,7 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 	if path == "" {
 		return func() {}, nil, func() {}, nil
 	}
-	agentDir, err := openWakeAgentDir(root, me)
+	agentDir, err := openWakeAgentDir(canonicalWakeRoot(root), me)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/cli/wake_control_darwin_test.go
+++ b/internal/cli/wake_control_darwin_test.go
@@ -44,6 +44,43 @@ func TestDarwinCooperativeStopACKAfterLockRemoval(t *testing.T) {
 	}
 }
 
+func TestDarwinControlRootAliasSupportsStartAndCooperativeStop(t *testing.T) {
+	realRoot := filepath.Join(secureTempDirForTest(t), "real-root")
+	if err := fsq.EnsureAgentDirs(realRoot, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot := filepath.Join(secureTempDirForTest(t), "root-alias")
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("root symlinks unsupported: %v", err)
+	}
+	lock := wakeLock{
+		PID:        os.Getpid(),
+		Root:       canonicalWakeRoot(aliasRoot),
+		Agent:      "codex",
+		WakeMode:   wakeTargetInjectVia,
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	lock.ControlSocket = wakeControlSocketPath(aliasRoot, "codex", lock.Generation)
+	if got, want := filepath.Dir(lock.ControlSocket), fsq.AgentBase(realRoot, "codex"); got != want {
+		t.Fatalf("control socket directory = %q, want canonical agent directory %q", got, want)
+	}
+	writeWakeLockExactForTest(t, aliasRoot, "codex", lock)
+
+	cleanup, stopped, markStopped, err := startWakeControlListener(aliasRoot, "codex", lock)
+	if err != nil {
+		t.Fatalf("start through root alias: %v", err)
+	}
+	defer cleanup()
+	go func() { <-stopped; markStopped() }()
+	replaced, err := cooperativeStopInjectVia(inspectWakeLock(aliasRoot, "codex"))
+	if err != nil || !replaced {
+		t.Fatalf("stop through root alias=(%v,%v)", replaced, err)
+	}
+	if current := inspectWakeLock(realRoot, "codex"); current.Exists {
+		t.Fatal("canonical generation remained after cooperative stop")
+	}
+}
+
 func TestDarwinCooperativeStopACKWaitsForLoopExit(t *testing.T) {
 	root, agent, lock := testDarwinControlLock(t)
 	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)

--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -6,9 +6,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-const wakeReadySchema = 1
+const (
+	wakeReadySchema              = 1
+	wakeCatchupReadyFileName     = ".wake.catchup-ready"
+	wakeCatchupReadyPollInterval = 20 * time.Millisecond
+)
 
 type wakeReady struct {
 	Schema       int    `json:"schema"`
@@ -145,4 +153,78 @@ func validateWakeReadyFileAgainstCurrent(root, me, path string) (bool, error) {
 		return nil
 	})
 	return ready, err
+}
+
+func wakeCatchupReadyPath(root, me string) string {
+	return filepath.Join(fsq.AgentBase(root, me), wakeCatchupReadyFileName)
+}
+
+func writeWakeCatchupReadyFile(root, me string, expected wakeLockInspection) error {
+	return writeWakeReadyFile(root, me, wakeCatchupReadyPath(root, me), expected)
+}
+
+func wakeCatchupReadyMatches(root, me string, expected wakeLockInspection) (bool, error) {
+	ready := false
+	err := withWakeLifecycleGuard(root, me, func() error {
+		current := inspectWakeLock(root, me)
+		if !sameWakeLockGeneration(expected, current) {
+			return fmt.Errorf("wake lock generation changed while waiting for catch-up readiness")
+		}
+		path := wakeCatchupReadyPath(root, me)
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := validateWakeReadyFile(path, info); err != nil {
+			return err
+		}
+		published, exists, err := readWakeReadyFile(path)
+		if err != nil || !exists {
+			// A securely located but partial/corrupt stale marker is never
+			// trusted. The active generation may replace it before the timeout.
+			return nil
+		}
+		// A previous generation's securely written attestation is harmless and
+		// remains not-ready until the current generation replaces it.
+		if published.Generation != current.Lock.Generation || published.TargetDigest != current.Lock.TargetDigest {
+			return nil
+		}
+		if err := validateWakeReadyLockAndTarget(root, me, current, published); err != nil {
+			return err
+		}
+		ready = true
+		return nil
+	})
+	return ready, err
+}
+
+func existingWakeCatchupTimeout(injectTimeout time.Duration) time.Duration {
+	timeout := 2*injectTimeout + time.Second
+	if timeout < wakeReadyTimeout {
+		return wakeReadyTimeout
+	}
+	if timeout > 30*time.Second {
+		return 30 * time.Second
+	}
+	return timeout
+}
+
+func waitForWakeCatchupReady(root, me string, expected wakeLockInspection, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		ready, err := wakeCatchupReadyMatches(root, me, expected)
+		if err != nil {
+			return err
+		}
+		if ready {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("existing wake for %s did not attest initial catch-up readiness", me)
+		}
+		time.Sleep(wakeCatchupReadyPollInterval)
+	}
 }

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -1116,7 +1116,7 @@ func TestRunWakeRepairClearsRepairAvailableAfterStartFailure(t *testing.T) {
 func TestBuildCoopWakeArgsIncludesInjectViaTarget(t *testing.T) {
 	args := buildCoopWakeArgs("codex", "/tmp/root", wakeInjectModeAuto, "/abs/injector", []string{"exec", "target"})
 	got := strings.Join(args, "|")
-	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target"
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target"
 	if got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}

--- a/internal/cli/wake_retire_unix.go
+++ b/internal/cli/wake_retire_unix.go
@@ -185,7 +185,7 @@ func requireExistingWakeTargetMatches(inspection wakeLockInspection, requested w
 	if err := validateWakeTargetMatchesLock(inspection.Lock, persisted); err != nil {
 		return err
 	}
-	if !sameWakeInjectorIdentity(persisted, requested) {
+	if !sameWakeInjectorTransport(persisted, requested) {
 		return errors.New("saved wake target uses a different injector path or fixed arguments")
 	}
 	return nil

--- a/internal/cli/wake_retire_unix_test.go
+++ b/internal/cli/wake_retire_unix_test.go
@@ -112,6 +112,48 @@ func TestRetireWakeRemovesExactlyBoundProvenStaleLock(t *testing.T) {
 	}
 }
 
+func TestRetireWakeMatchesTransportWhenPersistedTargetHasBaseline(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	baseline, err := captureWakeBaseline(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	persisted := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-a"})
+	persisted.BaselineFile = baseline.Path
+	persisted.BaselineDigest = baseline.Digest
+	if err := writeWakeTarget(root, "codex", persisted); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID: wakePID, TTY: "unknown", ProcessStart: "wake-start", BootID: "boot-1",
+		Executable: "/opt/homebrew/bin/amq", Generation: "0123456789abcdef0123456789abcdef",
+	}, persisted))
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	requested := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-a"})
+
+	result, err := retireWake(root, "codex", requested)
+	if err != nil || result.Status != "retired" {
+		t.Fatalf("baseline-bound retire result=%#v err=%v", result, err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("baseline-bound stale lock still exists: %v", err)
+	}
+	target, exists, err := readWakeTarget(root, "codex")
+	if err != nil || !exists || target.BaselineFile != baseline.Path {
+		t.Fatalf("retire did not preserve exact target: exists=%v target=%#v err=%v", exists, target, err)
+	}
+}
+
 func TestRetireWakeRefusesMissingSavedTarget(t *testing.T) {
 	const wakePID = 4242
 	root := secureTempDirForTest(t)

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -29,20 +29,39 @@ type wakeOwner struct {
 }
 
 type wakeTarget struct {
-	Schema     int        `json:"schema"`
-	Mode       string     `json:"mode"`
-	Root       string     `json:"root"`
-	Agent      string     `json:"agent"`
-	Created    string     `json:"created"`
-	InjectVia  string     `json:"inject_via"`
-	InjectArgs []string   `json:"inject_args,omitempty"`
-	Owner      *wakeOwner `json:"owner,omitempty"`
+	Schema         int        `json:"schema"`
+	Mode           string     `json:"mode"`
+	Root           string     `json:"root"`
+	Agent          string     `json:"agent"`
+	Created        string     `json:"created"`
+	InjectVia      string     `json:"inject_via"`
+	InjectArgs     []string   `json:"inject_args,omitempty"`
+	Owner          *wakeOwner `json:"owner,omitempty"`
+	BaselineFile   string     `json:"baseline_file,omitempty"`
+	BaselineDigest string     `json:"baseline_digest,omitempty"`
 }
 
-// sameWakeInjectorIdentity compares the behavior fixed at launch. Created and
-// owner metadata describe an instance, not the injector semantics it provides.
+// sameWakeInjectorTransport compares the executable behavior fixed at launch.
+// Owner and baseline metadata are checked separately by callers because they
+// have different lifecycle semantics.
+func sameWakeInjectorTransport(first, second wakeTarget) bool {
+	return first.InjectVia == second.InjectVia &&
+		slices.Equal(first.InjectArgs, second.InjectArgs)
+}
+
+// sameWakeInjectorIdentity requires the exact notification floor as well as
+// the executable transport. Created and owner metadata describe an instance.
 func sameWakeInjectorIdentity(first, second wakeTarget) bool {
-	return first.InjectVia == second.InjectVia && slices.Equal(first.InjectArgs, second.InjectArgs)
+	return sameWakeInjectorTransport(first, second) &&
+		first.BaselineFile == second.BaselineFile &&
+		first.BaselineDigest == second.BaselineDigest
+}
+
+func sameWakeOwner(first, second *wakeOwner) bool {
+	if first == nil || second == nil {
+		return first == nil && second == nil
+	}
+	return *first == *second
 }
 
 func wakeTargetPath(root, me string) string {
@@ -202,6 +221,18 @@ func validateWakeTarget(target wakeTarget, root, me string) error {
 	if target.Owner != nil {
 		if err := validateWakeOwner(*target.Owner); err != nil {
 			return err
+		}
+	}
+	if (target.BaselineFile == "") != (target.BaselineDigest == "") {
+		return fmt.Errorf("wake target baseline file and digest must be set together")
+	}
+	if target.BaselineFile != "" {
+		baseline, err := readWakeBaseline(target.BaselineFile, root, me)
+		if err != nil {
+			return fmt.Errorf("validate wake target baseline: %w", err)
+		}
+		if baseline.Digest != target.BaselineDigest {
+			return fmt.Errorf("wake target baseline digest mismatch")
 		}
 	}
 	return nil

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -287,9 +287,10 @@ func TestInjectNotification_InjectVia_Failure(t *testing.T) {
 		debug:     false,
 	}
 
-	// Should not return error — falls back to stderr
-	if err := injectNotification(cfg, "test", true); err != nil {
-		t.Fatalf("expected graceful fallback, got error: %v", err)
+	// Stderr remains diagnostic output, but the failed external injector must
+	// not acknowledge delivery or make the message ineligible for retry.
+	if err := injectNotification(cfg, "test", true); err == nil {
+		t.Fatal("expected failed external injection to remain retryable")
 	}
 }
 
@@ -301,11 +302,11 @@ func TestInjectNotification_InjectVia_FailureWarnsOnce(t *testing.T) {
 
 	text := "fallback notice"
 	stderr := captureWakeStderr(t, func() {
-		if err := injectNotification(cfg, text, true); err != nil {
-			t.Fatalf("first injectNotification: %v", err)
+		if err := injectNotification(cfg, text, true); err == nil {
+			t.Fatal("first injectNotification unexpectedly succeeded")
 		}
-		if err := injectNotification(cfg, text, true); err != nil {
-			t.Fatalf("second injectNotification: %v", err)
+		if err := injectNotification(cfg, text, true); err == nil {
+			t.Fatal("second injectNotification unexpectedly succeeded")
 		}
 	})
 
@@ -685,7 +686,7 @@ func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *test
 		48,
 		"",
 	)
-	expected := "\x03\n" + expectedText + "\n" + expectedText + "\n"
+	expected := "\x03\n" + expectedText + "\n"
 
 	got, err := os.ReadFile(logPath)
 	if err != nil {
@@ -891,8 +892,8 @@ func TestNotifyNewMessages_InjectViaInterruptFailureDoesNotUpdateCooldown(t *tes
 		interruptCooldown: 7 * time.Second,
 	}
 
-	if err := notifyNewMessages(cfg); err != nil {
-		t.Fatalf("notifyNewMessages: %v", err)
+	if err := notifyNewMessages(cfg); err == nil {
+		t.Fatal("notifyNewMessages unexpectedly acknowledged failed external injection")
 	}
 	if !cfg.lastInterrupt.IsZero() {
 		t.Fatalf("expected failed interrupt transport to leave cooldown unchanged, got %s", cfg.lastInterrupt)

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -46,12 +46,15 @@ type wakeRepairResult struct {
 type wakeRepairStarter func(root, me string, target wakeTarget) (int, error)
 
 type wakeLockAcquireOptions struct {
-	acceptExistingValid bool
-	target              *wakeTarget
-	wakeMode            string
+	acceptExistingValid       bool
+	replaceExistingBaseline   bool
+	materializeLegacyBaseline bool
+	target                    *wakeTarget
+	wakeMode                  string
 }
 
 var startWakeFromTarget = startWakeFromTargetDefault
+var replaceExistingWakeLock = terminateAndRemoveOrphanedWakeLock
 
 // acquireWakeLock attempts to acquire the wake lock for an agent's inbox.
 // Returns cleanup function and error. If another wake is running, returns error.
@@ -86,10 +89,34 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 					return fmt.Errorf("wake lock is being created (retry shortly)")
 				case wakeLockValid:
 					if options.acceptExistingValid {
-						if err := requireWakeLockUsable(inspection, options.wakeMode, options.target); err != nil {
-							return err
+						usableErr := requireWakeLockUsable(inspection, options.wakeMode, options.target)
+						if usableErr == nil {
+							return wakeLockAlreadyRunningError(me, inspection)
 						}
-						return wakeLockAlreadyRunningError(me, inspection)
+						if options.materializeLegacyBaseline {
+							reuse, migrate, err := wakeBaselineExistingTransition(inspection, options)
+							if err != nil {
+								return err
+							}
+							if reuse {
+								return wakeLockAlreadyRunningError(me, inspection)
+							}
+							if migrate {
+								replace = inspection
+								return nil
+							}
+						}
+						if options.replaceExistingBaseline {
+							eligible, err := wakeBaselineRotationEligible(inspection, options)
+							if err != nil {
+								return err
+							}
+							if eligible {
+								replace = inspection
+								return nil
+							}
+						}
+						return usableErr
 					}
 					replaceNeeded, replaceErr := wakeLockReplacementNeeded(inspection)
 					if replaceErr != nil {
@@ -146,7 +173,7 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 			return nil, err
 		}
 		if replace.Exists {
-			if _, err := terminateAndRemoveOrphanedWakeLock(replace); err != nil {
+			if _, err := replaceExistingWakeLock(replace); err != nil {
 				return nil, err
 			}
 			continue
@@ -163,6 +190,137 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 		}
 		return cleanup, nil
 	}
+}
+
+func wakeBaselineRotationEligible(inspection wakeLockInspection, options wakeLockAcquireOptions) (bool, error) {
+	if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed ||
+		options.wakeMode != wakeTargetInjectVia || options.target == nil ||
+		options.target.BaselineFile == "" || options.target.BaselineDigest == "" {
+		return false, nil
+	}
+	persisted, exists, err := readWakeTarget(inspection.Root, inspection.Agent)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	if err := validateWakeTarget(persisted, inspection.Root, inspection.Agent); err != nil {
+		return false, err
+	}
+	if err := validateWakeTargetMatchesLock(inspection.Lock, persisted); err != nil {
+		return false, err
+	}
+	requested := *options.target
+	if !sameWakeInjectorTransport(persisted, requested) || !sameWakeOwner(persisted.Owner, requested.Owner) {
+		return false, nil
+	}
+	return persisted.BaselineFile != requested.BaselineFile || persisted.BaselineDigest != requested.BaselineDigest, nil
+}
+
+// wakeBaselineExistingTransition resolves the race between independent
+// --baseline-existing starters. Once one exact floor wins, later starters
+// reuse it. Only a same-transport legacy target with no floor is migrated.
+func wakeBaselineExistingTransition(inspection wakeLockInspection, options wakeLockAcquireOptions) (reuse, migrate bool, err error) {
+	if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed ||
+		options.wakeMode != wakeTargetInjectVia || options.target == nil ||
+		options.target.BaselineFile == "" || options.target.BaselineDigest == "" {
+		return false, false, nil
+	}
+	persisted, exists, err := readWakeTarget(inspection.Root, inspection.Agent)
+	if err != nil {
+		return false, false, err
+	}
+	if !exists {
+		return false, false, nil
+	}
+	if err := validateWakeTarget(persisted, inspection.Root, inspection.Agent); err != nil {
+		return false, false, err
+	}
+	if err := validateWakeTargetMatchesLock(inspection.Lock, persisted); err != nil {
+		return false, false, err
+	}
+	requested := *options.target
+	if !sameWakeInjectorTransport(persisted, requested) || !sameWakeOwner(persisted.Owner, requested.Owner) {
+		return false, false, nil
+	}
+	if persisted.BaselineFile != "" && persisted.BaselineDigest != "" {
+		return true, false, nil
+	}
+	return false, true, nil
+}
+
+// reusableExistingWake handles --baseline-existing without taking a new
+// snapshot on every supervisor pass. A confirmed existing generation keeps
+// the exact floor already bound to its persisted target.
+func reusableExistingWake(root, me string, requested wakeTarget) (wakeLockInspection, bool, error) {
+	var inspection wakeLockInspection
+	reusable := false
+	err := withWakeLifecycleGuard(root, me, func() error {
+		inspection = inspectWakeLock(root, me)
+		if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+			return nil
+		}
+		persisted, exists, err := readWakeTarget(root, me)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("existing inject-via wake for %s has no persisted wake target", me)
+		}
+		if err := validateWakeTarget(persisted, root, me); err != nil {
+			return err
+		}
+		if err := validateWakeTargetMatchesLock(inspection.Lock, persisted); err != nil {
+			return err
+		}
+		if !sameWakeInjectorTransport(persisted, requested) || !sameWakeOwner(persisted.Owner, requested.Owner) {
+			return fmt.Errorf("existing inject-via wake for %s uses a different injector path, fixed arguments, or owner", me)
+		}
+		if persisted.BaselineFile == "" || persisted.BaselineDigest == "" {
+			return nil
+		}
+		if err := requireWakeLockUsable(inspection, wakeTargetInjectVia, &persisted); err != nil {
+			return err
+		}
+		reusable = true
+		return nil
+	})
+	return inspection, reusable, err
+}
+
+// persistedExactWakeBaseline preserves the original notification floor across
+// wake downtime. A compatible saved target is repair state, not a fresh-launch
+// hint: corrupt or missing floor data fails closed instead of resnapshotting.
+func persistedExactWakeBaseline(root, me string, requested wakeTarget) (wakeBaseline, bool, error) {
+	var baseline wakeBaseline
+	found := false
+	err := withWakeLifecycleGuard(root, me, func() error {
+		persisted, exists, err := readWakeTarget(root, me)
+		if err != nil || !exists {
+			return err
+		}
+		if !sameWakeInjectorTransport(persisted, requested) || !sameWakeOwner(persisted.Owner, requested.Owner) {
+			return nil
+		}
+		if persisted.BaselineFile == "" && persisted.BaselineDigest == "" {
+			return nil
+		}
+		if err := validateWakeTarget(persisted, root, me); err != nil {
+			return fmt.Errorf("persisted exact wake floor is unusable: %w", err)
+		}
+		loaded, err := readWakeBaseline(persisted.BaselineFile, root, me)
+		if err != nil {
+			return fmt.Errorf("persisted exact wake floor is unusable: %w", err)
+		}
+		if loaded.Digest != persisted.BaselineDigest {
+			return fmt.Errorf("persisted exact wake floor digest changed")
+		}
+		baseline = loaded
+		found = true
+		return nil
+	})
+	return baseline, found, err
 }
 
 func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, error) {
@@ -282,7 +440,9 @@ func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string, r
 		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
 			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
 	}
-	if wakeLockNeedsReplacement(inspection) {
+	if replace, err := wakeLockReplacementNeeded(inspection); err != nil {
+		return fmt.Errorf("existing wake lock for %s could not be health-checked: %w", inspection.Agent, err)
+	} else if replace {
 		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
 			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
 	}
@@ -303,8 +463,8 @@ func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string, r
 		if err := validateWakeTarget(persistedTarget, inspection.Root, inspection.Agent); err != nil {
 			return fmt.Errorf("existing inject-via wake target for %s is invalid: %w", inspection.Agent, err)
 		}
-		if !sameWakeInjectorIdentity(persistedTarget, *requestedTarget) {
-			return fmt.Errorf("existing inject-via wake for %s uses a different injector path or fixed arguments", inspection.Agent)
+		if !sameWakeInjectorIdentity(persistedTarget, *requestedTarget) || !sameWakeOwner(persistedTarget.Owner, requestedTarget.Owner) {
+			return fmt.Errorf("existing inject-via wake for %s uses a different injector path, fixed arguments, owner, or baseline floor", inspection.Agent)
 		}
 	}
 	return nil
@@ -628,6 +788,9 @@ func configureRepairWakeCommand(cmd *exec.Cmd, output *os.File) {
 
 func buildRepairWakeArgs(root, me string, target wakeTarget, readyPath string) []string {
 	args := []string{"--no-update-check", "wake", "--me", me, "--root", root, "--inject-via", target.InjectVia}
+	if target.BaselineFile != "" {
+		args = append(args, "--baseline-file", target.BaselineFile)
+	}
 	for _, arg := range target.InjectArgs {
 		args = append(args, "--inject-arg", arg)
 	}
@@ -659,9 +822,12 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
 	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
+	replaceExistingBaselineFlag := fs.Bool("replace-existing-baseline", false, "Internal: rotate an exact inject-via wake to a new baseline floor")
+	baselineExistingFlag := fs.Bool("baseline-existing", false, "Ignore messages already waiting when this wake starts")
+	baselineFileFlag := fs.String("baseline-file", "", "Pre-launch unread-floor manifest produced by coop exec --defer-wake")
 
 	usage := usageWithHiddenFlags(fs, "amq wake --me <agent> [options]",
-		[]string{"ready-file", "accept-existing-wake"},
+		[]string{"ready-file", "accept-existing-wake", "replace-existing-baseline"},
 		"Background waker: injects terminal notification when messages arrive.",
 		"Run as background job before starting CLI: amq wake --me claude &",
 		"",
@@ -755,6 +921,21 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
 	}
+	baselineFile := strings.TrimSpace(*baselineFileFlag)
+	if *baselineFileFlag != "" && baselineFile == "" {
+		return UsageError("--baseline-file must not be blank")
+	}
+	if *baselineExistingFlag && baselineFile != "" {
+		return UsageError("--baseline-file and --baseline-existing are mutually exclusive")
+	}
+	var baseline *wakeBaseline
+	if baselineFile != "" {
+		loaded, err := readWakeBaseline(baselineFile, root, me)
+		if err != nil {
+			return fmt.Errorf("load wake baseline: %w", err)
+		}
+		baseline = &loaded
+	}
 
 	injectVia := strings.TrimSpace(*injectViaFlag)
 	if *injectViaFlag != "" && injectVia == "" {
@@ -776,6 +957,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	if *readyFileFlag != "" && readyFile == "" {
 		return UsageError("--ready-file must not be blank")
 	}
+	if *replaceExistingBaselineFlag && (!*acceptExistingWakeFlag || readyFile == "" || baselineFile == "" || injectVia == "") {
+		return UsageError("--replace-existing-baseline requires --accept-existing-wake, --ready-file, --baseline-file, and --inject-via")
+	}
 
 	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
 	if injectVia == "" && injectMode != wakeInjectModeNone {
@@ -794,6 +978,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return UsageError("%v", err)
 	}
 
+	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
 	var target *wakeTarget
 	if injectVia != "" {
 		owner, err := wakeOwnerFromEnv()
@@ -805,15 +990,55 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 			return err
 		}
 		value.Owner = owner
+		if *baselineExistingFlag {
+			persistedFloor := false
+			if acceptExistingWake {
+				inspection, reusable, err := reusableExistingWake(root, me, value)
+				if err != nil {
+					return err
+				}
+				if reusable {
+					if err := waitForWakeCatchupReady(root, me, inspection, existingWakeCatchupTimeout(*injectTimeoutFlag)); err != nil {
+						return err
+					}
+					return writeWakeReadyFile(root, me, readyFile, inspection)
+				}
+				loaded, found, err := persistedExactWakeBaseline(root, me, value)
+				if err != nil {
+					return err
+				}
+				if found {
+					baseline = &loaded
+					persistedFloor = true
+				}
+			}
+			if !persistedFloor {
+				loaded, err := captureWakeBaseline(root, me)
+				if err != nil {
+					return fmt.Errorf("capture existing wake baseline: %w", err)
+				}
+				baseline = &loaded
+				defer removeWakeBaselineIfUnreferenced(root, me, loaded.Path)
+			}
+		}
+		if baseline != nil && baseline.Path != "" {
+			value.BaselineFile = baseline.Path
+			value.BaselineDigest = baseline.Digest
+		}
 		if err := validateWakeTarget(value, root, me); err != nil {
 			return err
 		}
 		injectVia = value.InjectVia
 		target = &value
+	} else if *baselineExistingFlag {
+		loaded, err := snapshotWakeExistingMessages(root, me)
+		if err != nil {
+			return fmt.Errorf("snapshot existing wake messages: %w", err)
+		}
+		baseline = &loaded
 	}
 
 	// Acquire lock to prevent duplicate wake processes
-	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
 	lockWakeMode := injectMode
 	if target != nil {
 		lockWakeMode = wakeTargetInjectVia
@@ -821,13 +1046,18 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		lockWakeMode = effectiveInjectMode(&wakeConfig{me: me, injectMode: lockWakeMode})
 	}
 	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
-		acceptExistingValid: acceptExistingWake,
-		target:              target,
-		wakeMode:            lockWakeMode,
+		acceptExistingValid:       acceptExistingWake,
+		replaceExistingBaseline:   *replaceExistingBaselineFlag,
+		materializeLegacyBaseline: *baselineExistingFlag && target != nil && target.BaselineFile != "",
+		target:                    target,
+		wakeMode:                  lockWakeMode,
 	})
 	if err != nil {
 		var alreadyRunning *wakeAlreadyRunningError
 		if acceptExistingWake && errors.As(err, &alreadyRunning) {
+			if err := waitForWakeCatchupReady(root, me, alreadyRunning.Inspection, existingWakeCatchupTimeout(*injectTimeoutFlag)); err != nil {
+				return err
+			}
 			return writeWakeReadyFile(root, me, readyFile, alreadyRunning.Inspection)
 		}
 		return err
@@ -878,13 +1108,41 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		interruptNotice:   strings.TrimSpace(*interruptNoticeFlag),
 		interruptCooldown: *interruptCooldownFlag,
 		controlStop:       controlStop,
-	}
-
-	if err := writeWakeReadyFile(root, me, readyFile, inspectWakeLock(root, me)); err != nil {
-		return err
+		baseline:          baseline,
+		seen:              make(map[string]struct{}),
+		readyFile:         readyFile,
+		readyInspection:   inspectWakeLock(root, me),
 	}
 
 	return loop(cfg)
+}
+
+func snapshotWakeExistingMessages(root, me string) (wakeBaseline, error) {
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, me))
+	if err != nil {
+		return wakeBaseline{}, err
+	}
+	baseline := wakeBaseline{IDs: make(map[string]struct{}), Files: make(map[string]struct{})}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		name := entry.Name()
+		baseline.Files[name] = struct{}{}
+		if header, readErr := format.ReadHeaderFile(filepath.Join(fsq.AgentInboxNew(root, me), name)); readErr == nil {
+			if id := strings.TrimSpace(header.ID); id != "" {
+				baseline.IDs[id] = struct{}{}
+			}
+		}
+	}
+	return baseline, nil
+}
+
+func publishWakeReady(cfg wakeConfig) error {
+	if err := writeWakeCatchupReadyFile(cfg.root, cfg.me, cfg.readyInspection); err != nil {
+		return err
+	}
+	return writeWakeReadyFile(cfg.root, cfg.me, cfg.readyFile, cfg.readyInspection)
 }
 
 func parseInterruptKey(raw string) (string, error) {
@@ -945,9 +1203,13 @@ func runWakeLoop(cfg wakeConfig) error {
 	// Touch presence immediately so `amq who` shows agent as active
 	_ = presence.Touch(cfg.root, cfg.me)
 
-	// Notify if messages already exist
+	// The watcher is installed before this catch-up scan, so messages arriving
+	// after the floor snapshot cannot fall into a scan/watch gap.
 	if err := notifyNewMessages(&cfg); err != nil {
-		_ = writeStderr("amq wake: notify error: %v\n", err)
+		return fmt.Errorf("initial wake catch-up: %w", err)
+	}
+	if err := publishWakeReady(cfg); err != nil {
+		return err
 	}
 
 	for {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -123,8 +123,14 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 		"--inject-via", injector,
 		"--ready-file", readyPath,
 	}, func(cfg wakeConfig) error {
+		if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+			t.Fatalf("ready file existed before loop catch-up: %v", statErr)
+		}
+		if readyErr := publishWakeReady(cfg); readyErr != nil {
+			t.Fatalf("publishWakeReady: %v", readyErr)
+		}
 		if _, statErr := os.Stat(readyPath); statErr != nil {
-			t.Fatalf("expected ready file before wake loop: %v", statErr)
+			t.Fatalf("expected ready file after catch-up acknowledgement: %v", statErr)
 		}
 		return errDone
 	})
@@ -153,8 +159,14 @@ func TestRunWakeWithLoopNoneSkipsTTYAndWritesReadyFile(t *testing.T) {
 		if cfg.injectMode != wakeInjectModeNone {
 			t.Fatalf("injectMode = %q, want none", cfg.injectMode)
 		}
+		if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+			t.Fatalf("ready file existed before loop catch-up: %v", statErr)
+		}
+		if readyErr := publishWakeReady(cfg); readyErr != nil {
+			t.Fatalf("publishWakeReady: %v", readyErr)
+		}
 		if _, statErr := os.Stat(readyPath); statErr != nil {
-			t.Fatalf("expected ready file before wake loop: %v", statErr)
+			t.Fatalf("expected ready file after catch-up acknowledgement: %v", statErr)
 		}
 		return errDone
 	})
@@ -650,6 +662,9 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
+	if err := writeWakeCatchupReadyFile(root, "orchestrator", inspectWakeLock(root, "orchestrator")); err != nil {
+		t.Fatalf("writeWakeCatchupReadyFile: %v", err)
+	}
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
@@ -738,6 +753,9 @@ func TestRunWakeWithLoopNoneAcceptsExistingNoneWake(t *testing.T) {
 		WakeMode:     wakeInjectModeNone,
 		Generation:   "generation-1",
 	})
+	if err := writeWakeCatchupReadyFile(root, "orchestrator", inspectWakeLock(root, "orchestrator")); err != nil {
+		t.Fatalf("writeWakeCatchupReadyFile: %v", err)
+	}
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
@@ -1017,6 +1035,9 @@ func TestRunWakeWithLoopAcceptExistingWakeAcceptsInjectViaUnknownTTY(t *testing.
 	}, target))
 	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	if err := writeWakeCatchupReadyFile(root, "orchestrator", inspectWakeLock(root, "orchestrator")); err != nil {
+		t.Fatalf("writeWakeCatchupReadyFile: %v", err)
 	}
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Clear env vars that could interfere with explicit --root/--me flags. The
 # session guards treat AM_BASE_ROOT/AM_SESSION as positive caller context, so an
 # ambient coop session would otherwise make the temp queue look foreign.
-unset AM_ROOT AM_ME AM_BASE_ROOT AM_SESSION AMQ_GLOBAL_ROOT 2>/dev/null || true
+unset AM_ROOT AM_ROOT_ID AM_ME AM_BASE_ROOT AM_BASE_ROOT_ID AM_SESSION AMQ_GLOBAL_ROOT 2>/dev/null || true
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
   GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
 


### PR DESCRIPTION
## Summary
Defers managed wake startup until agent SessionStart while preserving arrivals between the pre-launch floor capture and notifier readiness. This avoids binding a wake to a stale or restored terminal identity and fails visibly without consuming queued messages.

## Changes
- add `coop exec --defer-wake` with a private, identity-bound unread-floor manifest
- add `wake --baseline-file` with exact floor persistence, reuse, and generation-bound readiness
- start the watcher before catch-up, rotate floors only for the same owner and transport, and preserve exact repair/retire behavior
- canonicalize macOS control-socket roots so `/var` and `/private/var` address the same wake
- document the companion SessionStart hook contract

## Testing
- [x] `make ci` passes
- [x] New baseline, rotation, downtime, lifecycle, and Darwin root-alias tests added
- [x] Paired installed-binary E2E with `amq-keepalive` verified exact `notifier_live`, no receipts, and exact retirement
- [x] `gitleaks` found no leaks

## Related Issues
Supersedes #265.

Companion integration: ohade/amq-keepalive#1.
