### PR TITLE
feat(wake): add --baseline-existing so a starting agent isn't injected with backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ amq dlq list --me <agent> [--new | --cur] [--json]
 amq dlq read --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--json]
 amq dlq retry --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--all] [--force]
 amq dlq purge --me <agent> [--session <name>] [--ignore-session-pin] [--older-than <duration>] [--dry-run] [--yes]
-amq wake --me <agent> [--inject-cmd <cmd>] [--inject-mode <auto|raw|paste|none>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>] [--interrupt] [--interrupt-label <label>] [--interrupt-priority <p>] [--interrupt-cmd <ctrl-c|none>] [--interrupt-notice <str>] [--interrupt-cooldown <duration>] [--debug]
+amq wake --me <agent> [--baseline-existing] [--inject-cmd <cmd>] [--inject-mode <auto|raw|paste|none>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>] [--interrupt] [--interrupt-label <label>] [--interrupt-priority <p>] [--interrupt-cmd <ctrl-c|none>] [--interrupt-notice <str>] [--interrupt-cooldown <duration>] [--debug]
 amq wake repair --me <agent> [--root <path>] [--json]
 amq wake retire --me <agent> --inject-via <absolute-executable> [--inject-arg <arg>...] [--root <path>] [--json]
 amq upgrade

--- a/COOP.md
+++ b/COOP.md
@@ -272,6 +272,13 @@ amq reply --id "msg_123" --kind review_response --body "LGTM with minor suggesti
 > Co-op works without wake. `coop exec` starts it automatically.
 
 `amq wake` uses TIOCSTI to inject notifications into your terminal by default.
+Pass `--baseline-existing` when starting a new wake after the agent already
+owns its terminal. Messages already present in `inbox/new` remain unread and do
+not trigger that fresh wake; later arrivals do. `coop exec` and `wake repair`
+add the flag to wakes they start. Reuse requires generation-bound proof that
+the live wake completed watcher preparation. It does not retroactively baseline
+that wake, so pending backlog can still notify; SessionStart draining mitigates
+that residual.
 For orchestrators or hardened environments without a controlling TTY, use an
 explicit external transport:
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ amq coop exec grok     # Grok CLI as an optional peer; caller flags forwarded un
 
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
 Managed launchers can add `--require-wake` to fail instead of launching the agent when the wake watcher cannot start.
+When `coop exec` starts a fresh wake, it baselines messages that were already
+waiting. Those messages remain unread, create no receipt, and do not trigger
+that wake. `coop exec` only reuses a compatible live wake that has already
+published generation-bound proof of watcher preparation. The existing wake is
+not retroactively baselined; pending backlog can still notify. SessionStart
+draining mitigates that residual. `--require-wake` requires a usable notifier,
+not a rebased reused wake.
 Launchers that use an external injector can add `--wake-inject-via /absolute/path/to/injector`
 and repeated `--wake-inject-arg` values. When that invocation starts a new wake,
 the wake stores a repair target so `amq wake repair` can restart wake later

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -132,6 +133,40 @@ func TestCoopExecRequireWakeRejectsNoWake(t *testing.T) {
 	}
 }
 
+func TestCoopWakeReadinessTempFailureDegradesOnlyWithoutRequiredOrLiveWake(t *testing.T) {
+	cause := errors.New("TMPDIR unavailable")
+	confirmedLive := wakeLockInspection{
+		Exists:            true,
+		Status:            wakeLockValid,
+		IdentityConfirmed: true,
+		Process:           wakeProcessInfo{Running: true},
+	}
+	tests := []struct {
+		name       string
+		require    bool
+		inspection wakeLockInspection
+		wantErr    bool
+	}{
+		{name: "optional without live wake degrades"},
+		{name: "required wake fails closed", require: true, wantErr: true},
+		{name: "confirmed live wake fails closed", inspection: confirmedLive, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			stderr := captureWakeStderr(t, func() {
+				err = handleCoopWakeSetupFailure(tc.require, tc.inspection, "create wake readiness file", cause)
+			})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error = %v, wantErr=%v", err, tc.wantErr)
+			}
+			if !tc.wantErr && !strings.Contains(stderr, "TMPDIR unavailable") {
+				t.Fatalf("degraded failure warning missing: %q", stderr)
+			}
+		})
+	}
+}
+
 func TestCoopExecWakeInjectViaValidation(t *testing.T) {
 	nonExecutable := filepath.Join(secureTempDirForTest(t), "injector")
 	if err := os.WriteFile(nonExecutable, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
@@ -212,10 +247,31 @@ func TestCoopExecWakeInjectModeValidation(t *testing.T) {
 }
 
 func TestBuildCoopWakeArgsIncludesNoneMode(t *testing.T) {
-	got := buildCoopWakeArgs("codex", "/tmp/root", "none", "", nil)
-	want := []string{"--no-update-check", "wake", "--me", "codex", "--root", "/tmp/root", "--inject-mode", "none"}
+	got := buildCoopWakeArgs("codex", "/tmp/root", "none", "", nil, "/tmp/ready")
+	want := []string{"--no-update-check", "wake", "--me", "codex", "--root", "/tmp/root", "--baseline-existing", "--inject-mode", "none", "--ready-file", "/tmp/ready", "--accept-existing-wake"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildCoopWakeArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestConfirmedLiveWakeRejectsStaleLockWithReusedPID(t *testing.T) {
+	inspection := wakeLockInspection{
+		Exists: true,
+		Status: wakeLockStale,
+		PID:    4242,
+		Process: wakeProcessInfo{
+			PID:     4242,
+			Running: true,
+		},
+	}
+	if confirmedLiveWake(inspection) {
+		t.Fatal("stale wake lock with a reused live PID must not block coop degradation")
+	}
+
+	inspection.Status = wakeLockValid
+	inspection.IdentityConfirmed = true
+	if !confirmedLiveWake(inspection) {
+		t.Fatal("confirmed valid live wake should block coop degradation")
 	}
 }
 

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -15,7 +15,11 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-const wakeReadyTimeout = 2 * time.Second
+const wakeReadyTimeout = 25 * time.Second
+
+const wakeProcessExitTimeout = 5 * time.Second
+
+var killWakeHelperProcess = func(proc *os.Process) error { return proc.Kill() }
 
 func runCoopExec(args []string) error {
 	// Split at "--" before flag parsing so agent flags aren't consumed.
@@ -231,6 +235,8 @@ func runCoopExec(args []string) error {
 	// On successful Exec, wake is orphaned (reparented to init/launchd) — intended.
 	// On failed Exec, deferred kill cleans up the wake process.
 	var wakeProc *os.Process
+	var wakeWaiter *wakeProcessWaiter
+	var cleanupWakeReady func()
 	if !*noWakeFlag {
 		amqBin, binErr := os.Executable()
 		if binErr != nil {
@@ -241,43 +247,56 @@ func runCoopExec(args []string) error {
 		if wakeInjectVia != "" {
 			wakeOwner = currentWakeOwner()
 		}
-		wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, wakeInjectMode, wakeInjectVia, []string(wakeInjectArgFlags))...)
-		var readyPath string
-		var cleanupReady func()
-		if *requireWakeFlag {
-			var readyErr error
-			readyPath, cleanupReady, readyErr = newWakeReadyFile()
-			if readyErr != nil {
-				return fmt.Errorf("create wake readiness file: %w", readyErr)
+		readyPath, cleanupReady, readyErr := newWakeReadyFile()
+		if readyErr != nil {
+			inspection := inspectWakeLock(root, agentHandle)
+			if err := handleCoopWakeSetupFailure(*requireWakeFlag, inspection, "create wake readiness file", readyErr); err != nil {
+				return err
 			}
-			defer cleanupReady()
-			wakeCmd.Args = append(wakeCmd.Args, "--ready-file", readyPath, "--accept-existing-wake")
-		}
-		// Set AM_ROOT in wake's env so the helper process resolves the same
-		// session root even if the parent shell inherited a different value.
-		wakeEnv, wakeEnvErr := wakeCommandEnv(os.Environ(), root, wakeOwner)
-		if wakeEnvErr != nil {
-			return wakeEnvErr
-		}
-		wakeCmd.Env = wakeEnv
-		wakeCmd.Stdin = os.Stdin
-		wakeCmd.Stdout = os.Stdout
-		wakeCmd.Stderr = os.Stderr
-
-		if err := wakeCmd.Start(); err != nil {
-			if *requireWakeFlag {
-				return fmt.Errorf("start required amq wake: %w", err)
-			}
-			_ = writeStderr("warning: failed to start amq wake: %v\n", err)
 		} else {
-			wakeProc = wakeCmd.Process
-			if *requireWakeFlag {
-				if err := waitForWakeReady(wakeProc, readyPath, root, agentHandle, wakeReadyTimeout); err != nil {
-					_ = wakeProc.Kill()
+			cleanupWakeReady = cleanupReady
+			defer cleanupReady()
+			wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, wakeInjectMode, wakeInjectVia, []string(wakeInjectArgFlags), readyPath)...)
+			// Set AM_ROOT in wake's env so the helper process resolves the same
+			// session root even if the parent shell inherited a different value.
+			wakeEnv, wakeEnvErr := wakeCommandEnv(os.Environ(), root, wakeOwner)
+			if wakeEnvErr != nil {
+				return wakeEnvErr
+			}
+			wakeCmd.Env = wakeEnv
+			wakeCmd.Stdin = os.Stdin
+			wakeCmd.Stdout = os.Stdout
+			wakeCmd.Stderr = os.Stderr
+
+			if err := wakeCmd.Start(); err != nil {
+				inspection := inspectWakeLock(root, agentHandle)
+				if err := handleCoopWakeSetupFailure(*requireWakeFlag, inspection, "start amq wake baseline helper", err); err != nil {
 					return err
 				}
+			} else {
+				wakeProc = wakeCmd.Process
+				wakeWaiter = newWakeProcessWaiter(wakeProc)
+				if err := waitForWakeReadyWithWaiter(wakeWaiter, readyPath, root, agentHandle, wakeReadyTimeout); err != nil {
+					cleanupErr := terminateWakeHelperProcess(wakeProc, wakeWaiter, root, agentHandle)
+					inspection := inspectWakeLock(root, agentHandle)
+					otherLiveWake := confirmedLiveWake(inspection) && inspection.PID != wakeProc.Pid
+					if *requireWakeFlag || otherLiveWake {
+						if cleanupErr != nil {
+							return fmt.Errorf("%w (cleanup: %v)", err, cleanupErr)
+						}
+						return err
+					}
+					if cleanupErr != nil {
+						_ = writeStderr("warning: failed to prepare amq wake: %v (cleanup: %v)\n", err, cleanupErr)
+					} else {
+						_ = writeStderr("warning: failed to prepare amq wake: %v\n", err)
+					}
+					wakeProc = nil
+					wakeWaiter = nil
+				} else {
+					_ = writeStderr("%s\n", wakeReadyMessage(root, agentHandle, wakeProc.Pid))
+				}
 			}
-			_ = writeStderr("%s\n", wakeReadyMessage(root, agentHandle, wakeProc.Pid))
 		}
 	}
 
@@ -291,15 +310,33 @@ func runCoopExec(args []string) error {
 
 	// Replace process. On success, this never returns.
 	// On failure, clean up the wake process.
+	if cleanupWakeReady != nil {
+		cleanupWakeReady()
+	}
 	execErr := syscall.Exec(binaryPath, argv, env)
 	if wakeProc != nil {
-		_ = wakeProc.Kill()
+		_ = terminateWakeHelperProcess(wakeProc, wakeWaiter, root, agentHandle)
 	}
 	return execErr
 }
 
-func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectArgs []string) []string {
-	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root}
+func confirmedLiveWake(inspection wakeLockInspection) bool {
+	return inspection.Exists &&
+		inspection.Status == wakeLockValid &&
+		inspection.IdentityConfirmed &&
+		inspection.Process.Running
+}
+
+func handleCoopWakeSetupFailure(requireWake bool, inspection wakeLockInspection, action string, cause error) error {
+	if requireWake || confirmedLiveWake(inspection) {
+		return fmt.Errorf("%s: %w", action, cause)
+	}
+	_ = writeStderr("warning: %s: %v\n", action, cause)
+	return nil
+}
+
+func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectArgs []string, readyFile string) []string {
+	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root, "--baseline-existing"}
 	if injectMode != "" && injectMode != wakeInjectModeAuto {
 		args = append(args, "--inject-mode", injectMode)
 	}
@@ -308,6 +345,9 @@ func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectAr
 		for _, arg := range injectArgs {
 			args = append(args, "--inject-arg", arg)
 		}
+	}
+	if readyFile != "" {
+		args = append(args, "--ready-file", readyFile, "--accept-existing-wake")
 	}
 	return args
 }
@@ -320,15 +360,46 @@ func newWakeReadyFile() (string, func(), error) {
 	return filepath.Join(dir, "ready"), func() { _ = os.RemoveAll(dir) }, nil
 }
 
+type wakeProcessWaiter struct {
+	done  chan struct{}
+	state *os.ProcessState
+	err   error
+}
+
+func newWakeProcessWaiter(proc *os.Process) *wakeProcessWaiter {
+	waiter := &wakeProcessWaiter{done: make(chan struct{})}
+	go func() {
+		waiter.state, waiter.err = proc.Wait()
+		close(waiter.done)
+	}()
+	return waiter
+}
+
+func (waiter *wakeProcessWaiter) waitForExit(timeout time.Duration) error {
+	if waiter == nil {
+		return fmt.Errorf("amq wake process waiter missing")
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-waiter.done:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("amq wake did not exit within %s", timeout)
+	}
+}
+
 func waitForWakeReady(proc *os.Process, readyPath, root, me string, timeout time.Duration) error {
 	if proc == nil {
 		return fmt.Errorf("amq wake process missing")
 	}
-	done := make(chan error, 1)
-	go func() {
-		_, err := proc.Wait()
-		done <- err
-	}()
+	return waitForWakeReadyWithWaiter(newWakeProcessWaiter(proc), readyPath, root, me, timeout)
+}
+
+func waitForWakeReadyWithWaiter(waiter *wakeProcessWaiter, readyPath, root, me string, timeout time.Duration) error {
+	if waiter == nil {
+		return fmt.Errorf("amq wake process waiter missing")
+	}
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -343,14 +414,14 @@ func waitForWakeReady(proc *os.Process, readyPath, root, me string, timeout time
 		}
 
 		select {
-		case err := <-done:
+		case <-waiter.done:
 			if ready, readyErr := validateWakeReadyFileAgainstCurrent(root, me, readyPath); readyErr != nil {
 				return fmt.Errorf("validate wake readiness: %w", readyErr)
 			} else if ready {
 				return nil
 			}
-			if err != nil {
-				return fmt.Errorf("amq wake exited before becoming ready: %w", err)
+			if waiter.err != nil {
+				return fmt.Errorf("amq wake exited before becoming ready: %w", waiter.err)
 			}
 			return fmt.Errorf("amq wake exited before becoming ready")
 		case <-timer.C:
@@ -358,6 +429,54 @@ func waitForWakeReady(proc *os.Process, readyPath, root, me string, timeout time
 		case <-ticker.C:
 		}
 	}
+}
+
+func terminateWakeHelperProcess(proc *os.Process, waiter *wakeProcessWaiter, root, me string) error {
+	if proc == nil || waiter == nil {
+		return nil
+	}
+	expected := inspectWakeLock(root, me)
+	ownedGeneration := confirmedLiveWake(expected) && expected.PID == proc.Pid && expected.Lock.Generation != ""
+	_ = killWakeHelperProcess(proc)
+	if err := waiter.waitForExit(wakeProcessExitTimeout); err != nil {
+		return err
+	}
+	if ownedGeneration {
+		return cleanupTerminatedWakeLock(expected)
+	}
+	return cleanupTerminatedWakeLockForPID(root, me, proc.Pid)
+}
+
+func cleanupTerminatedWakeLock(expected wakeLockInspection) error {
+	return withWakeLifecycleGuard(expected.Root, expected.Agent, func() error {
+		current := inspectWakeLock(expected.Root, expected.Agent)
+		if !sameWakeLockGeneration(expected, current) {
+			return nil
+		}
+		if current.Status != wakeLockStale {
+			return fmt.Errorf("terminated wake lock is not proven stale: %s", current.Status)
+		}
+		if err := validateWakeLockStaleRemoval(current); err != nil {
+			return err
+		}
+		return removeWakeLockIfUnchangedGuarded(current)
+	})
+}
+
+func cleanupTerminatedWakeLockForPID(root, me string, terminatedPID int) error {
+	return withWakeLifecycleGuard(root, me, func() error {
+		current := inspectWakeLock(root, me)
+		if !current.Exists || current.PID != terminatedPID || current.Lock.Generation == "" {
+			return nil
+		}
+		if current.Status != wakeLockStale {
+			return fmt.Errorf("terminated wake lock is not proven stale: %s", current.Status)
+		}
+		if err := validateWakeLockStaleRemoval(current); err != nil {
+			return err
+		}
+		return removeWakeLockIfUnchangedGuarded(current)
+	})
 }
 
 func wakeReadyMessage(root, agentHandle string, startedPID int) string {

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -42,6 +42,9 @@ type wakeConfig struct {
 	interruptCooldown time.Duration
 	lastInterrupt     time.Time
 	controlStop       <-chan struct{}
+	baselineRequested bool
+	baselineExisting  map[string]wakeFileIdentity
+	onPrepared        func() error
 }
 
 const defaultInjectTimeout = 5 * time.Second
@@ -156,6 +159,13 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		name := entry.Name()
 		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
 			continue
+		}
+		if baselineIdentity, ignored := cfg.baselineExisting[name]; ignored {
+			info, infoErr := entry.Info()
+			if infoErr == nil && matchesWakeFileIdentity(baselineIdentity, info) {
+				continue
+			}
+			delete(cfg.baselineExisting, name)
 		}
 
 		path := filepath.Join(inboxNew, name)

--- a/internal/cli/wake_file_identity_darwin.go
+++ b/internal/cli/wake_file_identity_darwin.go
@@ -12,3 +12,21 @@ func sameWakeFileIdentity(a, b os.FileInfo) bool {
 	sb, ob := b.Sys().(*syscall.Stat_t)
 	return oa && ob && sa.Dev == sb.Dev && sa.Ino == sb.Ino && sa.Ctimespec == sb.Ctimespec
 }
+
+func captureWakeFileIdentity(info os.FileInfo) (wakeFileIdentity, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return wakeFileIdentity{}, false
+	}
+	return wakeFileIdentity{
+		Device:    uint64(stat.Dev),
+		Inode:     uint64(stat.Ino),
+		CTimeSec:  int64(stat.Ctimespec.Sec),
+		CTimeNsec: int64(stat.Ctimespec.Nsec),
+	}, true
+}
+
+func matchesWakeFileIdentity(identity wakeFileIdentity, info os.FileInfo) bool {
+	current, ok := captureWakeFileIdentity(info)
+	return ok && identity == current
+}

--- a/internal/cli/wake_file_identity_linux.go
+++ b/internal/cli/wake_file_identity_linux.go
@@ -12,3 +12,21 @@ func sameWakeFileIdentity(a, b os.FileInfo) bool {
 	sb, ob := b.Sys().(*syscall.Stat_t)
 	return oa && ob && sa.Dev == sb.Dev && sa.Ino == sb.Ino && sa.Ctim == sb.Ctim
 }
+
+func captureWakeFileIdentity(info os.FileInfo) (wakeFileIdentity, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return wakeFileIdentity{}, false
+	}
+	return wakeFileIdentity{
+		Device:    uint64(stat.Dev),
+		Inode:     uint64(stat.Ino),
+		CTimeSec:  int64(stat.Ctim.Sec),
+		CTimeNsec: int64(stat.Ctim.Nsec),
+	}, true
+}
+
+func matchesWakeFileIdentity(identity wakeFileIdentity, info os.FileInfo) bool {
+	current, ok := captureWakeFileIdentity(info)
+	return ok && identity == current
+}

--- a/internal/cli/wake_file_identity_other.go
+++ b/internal/cli/wake_file_identity_other.go
@@ -5,3 +5,11 @@ package cli
 import "os"
 
 func sameWakeFileIdentity(a, b os.FileInfo) bool { return os.SameFile(a, b) }
+
+func captureWakeFileIdentity(info os.FileInfo) (wakeFileIdentity, bool) {
+	return wakeFileIdentity{fileInfo: info}, info != nil
+}
+
+func matchesWakeFileIdentity(identity wakeFileIdentity, info os.FileInfo) bool {
+	return identity.fileInfo != nil && info != nil && os.SameFile(identity.fileInfo, info)
+}

--- a/internal/cli/wake_file_identity_windows.go
+++ b/internal/cli/wake_file_identity_windows.go
@@ -5,3 +5,11 @@ package cli
 import "os"
 
 func sameWakeFileIdentity(a, b os.FileInfo) bool { return os.SameFile(a, b) }
+
+func captureWakeFileIdentity(info os.FileInfo) (wakeFileIdentity, bool) {
+	return wakeFileIdentity{fileInfo: info}, info != nil
+}
+
+func matchesWakeFileIdentity(identity wakeFileIdentity, info os.FileInfo) bool {
+	return identity.fileInfo != nil && info != nil && os.SameFile(identity.fileInfo, info)
+}

--- a/internal/cli/wake_message_identity_other.go
+++ b/internal/cli/wake_message_identity_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux
+
+package cli
+
+import "os"
+
+// wakeFileIdentity keeps the platform FileInfo needed by os.SameFile for local
+// baseline filtering.
+type wakeFileIdentity struct {
+	fileInfo os.FileInfo
+}

--- a/internal/cli/wake_message_identity_unix.go
+++ b/internal/cli/wake_message_identity_unix.go
@@ -1,0 +1,12 @@
+//go:build darwin || linux
+
+package cli
+
+// wakeFileIdentity is the stable portion of a mailbox file instance used by
+// local baseline filtering.
+type wakeFileIdentity struct {
+	Device    uint64
+	Inode     uint64
+	CTimeSec  int64
+	CTimeNsec int64
+}

--- a/internal/cli/wake_prepared_unix.go
+++ b/internal/cli/wake_prepared_unix.go
@@ -1,0 +1,116 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const wakePreparedFileName = ".wake.prepared"
+
+const wakePreparedPollInterval = 25 * time.Millisecond
+
+var waitForWakePreparedRetry = sleepUntilWakePreparedRetry
+
+func wakePreparedPath(root, me string) string {
+	return filepath.Join(fsq.AgentBase(root, me), wakePreparedFileName)
+}
+
+func writeWakePreparedFile(root, me string, expected wakeLockInspection) error {
+	return withWakeLifecycleGuard(root, me, func() error {
+		current := inspectWakeLock(root, me)
+		if !sameWakeLockGeneration(expected, current) {
+			return fmt.Errorf("wake lock generation changed before preparation publication")
+		}
+		marker := wakeReady{
+			Schema:       wakeReadySchema,
+			Generation:   current.Lock.Generation,
+			TargetDigest: current.Lock.TargetDigest,
+		}
+		if err := validateWakeReadyLockAndTarget(root, me, current, marker); err != nil {
+			return err
+		}
+		// The marker intentionally persists after exit; its generation binding
+		// makes stale files unusable by later wake instances.
+		return writeWakeGenerationFile(wakePreparedPath(root, me), "wake prepared marker", marker)
+	})
+}
+
+func validateWakePreparedFileAgainstInspection(root, me string, current wakeLockInspection) (bool, error) {
+	marker, exists, err := readWakeGenerationFile(wakePreparedPath(root, me), "wake prepared marker")
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	if marker.Generation != current.Lock.Generation {
+		// Persistent marker from the previous wake generation: this exact wake
+		// has not published preparation yet, so its caller should keep polling.
+		return false, nil
+	}
+	if err := validateWakeReadyLockAndTarget(root, me, current, marker); err != nil {
+		return false, fmt.Errorf("existing amq wake prepared marker is not valid: %w", err)
+	}
+	return true, nil
+}
+
+func writeWakeReadyFileForPreparedWake(root, me, path string, expected wakeLockInspection, deadline time.Time) error {
+	for {
+		prepared := false
+		err := withWakeLifecycleGuard(root, me, func() error {
+			current := inspectWakeLock(root, me)
+			if !sameWakeLockGeneration(expected, current) {
+				return fmt.Errorf("wake lock generation changed before existing-wake readiness publication")
+			}
+			if !confirmedLiveWake(current) {
+				return fmt.Errorf("existing amq wake stopped before preparation completed")
+			}
+			if err := validateWakeReadyLockAndTarget(root, me, current, wakeReady{
+				Schema:       wakeReadySchema,
+				Generation:   current.Lock.Generation,
+				TargetDigest: current.Lock.TargetDigest,
+			}); err != nil {
+				return fmt.Errorf("existing amq wake became incompatible before preparation completed: %w", err)
+			}
+			var err error
+			prepared, err = validateWakePreparedFileAgainstInspection(root, me, current)
+			if err != nil || !prepared {
+				return err
+			}
+			marker := wakeReady{
+				Schema:       wakeReadySchema,
+				Generation:   current.Lock.Generation,
+				TargetDigest: current.Lock.TargetDigest,
+			}
+			return writeWakeGenerationFile(path, "wake ready file", marker)
+		})
+		if err != nil {
+			return err
+		}
+		if prepared {
+			return nil
+		}
+		if !waitForWakePreparedRetry(deadline) {
+			return fmt.Errorf("existing amq wake did not publish its prepared marker before the readiness deadline")
+		}
+	}
+}
+
+func sleepUntilWakePreparedRetry(deadline time.Time) bool {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	delay := wakePreparedPollInterval
+	if remaining < delay {
+		delay = remaining
+	}
+	time.Sleep(delay)
+	// Let the caller perform one final guarded inspection at the deadline.
+	return true
+}

--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -32,69 +32,77 @@ func writeWakeReadyFile(root, me, path string, expected wakeLockInspection) erro
 		}); err != nil {
 			return err
 		}
-		data, err := json.Marshal(wakeReady{
+		return writeWakeGenerationFile(path, "wake ready file", wakeReady{
 			Schema:       wakeReadySchema,
 			Generation:   current.Lock.Generation,
 			TargetDigest: current.Lock.TargetDigest,
 		})
-		if err != nil {
-			return fmt.Errorf("marshal wake readiness: %w", err)
-		}
-		return writeWakeMetadataFile(path, append(data, '\n'), "wake ready file")
 	})
 }
 
+func writeWakeGenerationFile(path, label string, marker wakeReady) error {
+	data, err := json.Marshal(marker)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", label, err)
+	}
+	return writeWakeMetadataFile(path, append(data, '\n'), label)
+}
+
 func readWakeReadyFile(path string) (wakeReady, bool, error) {
+	return readWakeGenerationFile(path, "wake ready file")
+}
+
+func readWakeGenerationFile(path, label string) (wakeReady, bool, error) {
 	info, err := os.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return wakeReady{}, false, nil
 		}
-		return wakeReady{}, false, fmt.Errorf("stat wake ready file: %w", err)
+		return wakeReady{}, false, fmt.Errorf("stat %s: %w", label, err)
 	}
-	if err := validateWakeReadyFile(path, info); err != nil {
+	if err := validateWakeGenerationFile(path, label, info); err != nil {
 		return wakeReady{}, true, err
 	}
 	file, err := openWakeMetadataFile(path)
 	if err != nil {
-		return wakeReady{}, true, fmt.Errorf("open wake ready file: %w", err)
+		return wakeReady{}, true, fmt.Errorf("open %s: %w", label, err)
 	}
 	defer func() { _ = file.Close() }()
 	openedInfo, err := file.Stat()
 	if err != nil {
-		return wakeReady{}, true, fmt.Errorf("stat opened wake ready file: %w", err)
+		return wakeReady{}, true, fmt.Errorf("stat opened %s: %w", label, err)
 	}
-	if err := validateWakeReadyFile(path, openedInfo); err != nil {
+	if err := validateWakeGenerationFile(path, label, openedInfo); err != nil {
 		return wakeReady{}, true, err
 	}
 	if !os.SameFile(info, openedInfo) {
-		return wakeReady{}, true, fmt.Errorf("wake ready file %s changed while opening", path)
+		return wakeReady{}, true, fmt.Errorf("%s %s changed while opening", label, path)
 	}
-	data, err := readWakeMetadata(file, "wake ready file", path)
+	data, err := readWakeMetadata(file, label, path)
 	if err != nil {
 		return wakeReady{}, true, err
 	}
 	var ready wakeReady
 	if err := json.Unmarshal(data, &ready); err != nil {
-		return wakeReady{}, true, fmt.Errorf("legacy wake ready file refused")
+		return wakeReady{}, true, fmt.Errorf("legacy %s refused", label)
 	}
 	if ready.Schema != wakeReadySchema || ready.Generation == "" {
-		return wakeReady{}, true, fmt.Errorf("legacy wake ready file refused")
+		return wakeReady{}, true, fmt.Errorf("legacy %s refused", label)
 	}
 	return ready, true, nil
 }
 
-func validateWakeReadyFile(path string, info os.FileInfo) error {
+func validateWakeGenerationFile(path, label string, info os.FileInfo) error {
 	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("wake ready file %s must not be a symlink", path)
+		return fmt.Errorf("%s %s must not be a symlink", label, path)
 	}
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf("wake ready file %s must be a regular file", path)
+		return fmt.Errorf("%s %s must be a regular file", label, path)
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
-		return fmt.Errorf("wake ready file %s mode is %o, want 0600", path, got)
+		return fmt.Errorf("%s %s mode is %o, want 0600", label, path, got)
 	}
-	return validateWakeTargetPathOwnership("wake ready file", path, info)
+	return validateWakeTargetPathOwnership(label, path, info)
 }
 
 func validateWakeReadyLockAndTarget(root, me string, current wakeLockInspection, ready wakeReady) error {
@@ -132,6 +140,8 @@ func validateWakeReadyLockAndTarget(root, me string, current wakeLockInspection,
 }
 
 func validateWakeReadyFileAgainstCurrent(root, me, path string) (bool, error) {
+	// A wake can still die immediately after this guarded validation; the local
+	// process notifier has no durable liveness lease beyond the lock generation.
 	ready := false
 	err := withWakeLifecycleGuard(root, me, func() error {
 		published, exists, err := readWakeReadyFile(path)

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -752,7 +752,7 @@ func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 	}
 }
 
-func TestRepairWakeAcceptsConcurrentWinnerForExactTarget(t *testing.T) {
+func TestRepairWakeRejectsConcurrentWinnerForExactTarget(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
@@ -776,10 +776,10 @@ func TestRepairWakeAcceptsConcurrentWinnerForExactTarget(t *testing.T) {
 	})
 
 	result, err := repairWake(root, "codex")
-	if err != nil {
-		t.Fatalf("exact concurrent winner should satisfy repair: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "lost start race") {
+		t.Fatalf("exact concurrent winner should not satisfy baseline-aware repair: result=%#v err=%v", result, err)
 	}
-	if result.Status != "repaired" || result.PID != 9876 {
+	if result.Status != "error" {
 		t.Fatalf("unexpected repair result: %#v", result)
 	}
 }
@@ -1114,9 +1114,9 @@ func TestRunWakeRepairClearsRepairAvailableAfterStartFailure(t *testing.T) {
 }
 
 func TestBuildCoopWakeArgsIncludesInjectViaTarget(t *testing.T) {
-	args := buildCoopWakeArgs("codex", "/tmp/root", wakeInjectModeAuto, "/abs/injector", []string{"exec", "target"})
+	args := buildCoopWakeArgs("codex", "/tmp/root", wakeInjectModeAuto, "/abs/injector", []string{"exec", "target"}, "/tmp/ready")
 	got := strings.Join(args, "|")
-	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target"
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready|--accept-existing-wake"
 	if got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}
@@ -1162,7 +1162,7 @@ func TestBuildRepairWakeArgsIncludesReadyFileAndTarget(t *testing.T) {
 	}
 	args := buildRepairWakeArgs("/tmp/root", "codex", target, "/tmp/ready")
 	got := strings.Join(args, "|")
-	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready"
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready"
 	if got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -848,6 +848,83 @@ func TestNotifyNewMessages_InjectViaInjectCmdPayload(t *testing.T) {
 	}
 }
 
+func TestNotifyNewMessagesSkipsBaselineWithoutDraining(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	writeMessage := func(filename, id, subject string) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      id,
+				From:    "codex",
+				To:      []string{"alice"},
+				Thread:  "p2p/alice__codex",
+				Subject: subject,
+				Created: "2026-07-22T00:00:00Z",
+			},
+			Body: "body",
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "alice", filename, data); err != nil {
+			t.Fatalf("deliver %s: %v", id, err)
+		}
+	}
+
+	writeMessage("stale.md", "stale", "stale subject")
+	cfg, outputPath := injectViaCaptureConfig(t)
+	cfg.me = "alice"
+	cfg.root = root
+	cfg.previewLen = 48
+	staleInfo, err := os.Stat(filepath.Join(fsq.AgentInboxNew(root, "alice"), "stale.md"))
+	if err != nil {
+		t.Fatalf("stat stale baseline message: %v", err)
+	}
+	staleIdentity, ok := captureWakeFileIdentity(staleInfo)
+	if !ok {
+		t.Fatal("capture stale baseline identity")
+	}
+	cfg.baselineExisting = map[string]wakeFileIdentity{"stale.md": staleIdentity}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify stale baseline: %v", err)
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("baseline message triggered injection; output stat error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(fsq.AgentInboxNew(root, "alice"), "stale.md")); err != nil {
+		t.Fatalf("baseline message was moved or removed: %v", err)
+	}
+	receipts, err := os.ReadDir(fsq.AgentReceipts(root, "alice"))
+	if err != nil {
+		t.Fatalf("read receipts: %v", err)
+	}
+	if len(receipts) != 0 {
+		t.Fatalf("wake created receipts for an unread baseline: %v", receipts)
+	}
+
+	writeMessage("fresh.md", "fresh", "fresh subject")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify fresh message: %v", err)
+	}
+	got, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read injection output: %v", err)
+	}
+	if !strings.Contains(string(got), "fresh subject") || strings.Contains(string(got), "stale subject") {
+		t.Fatalf("injected payload = %q, want fresh message only", string(got))
+	}
+}
+
 func TestNotifyNewMessages_InjectViaInterruptFailureDoesNotUpdateCooldown(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/wake_tiocsti_unix.go
+++ b/internal/cli/wake_tiocsti_unix.go
@@ -189,5 +189,5 @@ func ttyLastReadTime(fd uintptr) (time.Time, bool, error) {
 	if st.Atim.Sec == 0 && st.Atim.Nsec == 0 {
 		return time.Time{}, false, nil
 	}
-	return time.Unix(st.Atim.Sec, st.Atim.Nsec), true, nil
+	return time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec)), true, nil
 }

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -26,6 +26,8 @@ import (
 
 var (
 	wakeTerminateGrace   = 100 * time.Millisecond
+	wakeBaselineTimeout  = 5 * time.Second
+	wakeBaselineSettle   = 50 * time.Millisecond
 	getWakeCurrentTTY    = getCurrentTTY
 	getWakeProcessSID    = unix.Getsid
 	wakeTIOCSTIAvailable = func() bool { return tiocsti.Available() }
@@ -49,6 +51,12 @@ type wakeLockAcquireOptions struct {
 	acceptExistingValid bool
 	target              *wakeTarget
 	wakeMode            string
+}
+
+type wakeLockCreatingError struct{}
+
+func (err *wakeLockCreatingError) Error() string {
+	return "wake lock is being created (retry shortly)"
 }
 
 var startWakeFromTarget = startWakeFromTargetDefault
@@ -83,7 +91,7 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 						return err
 					}
 				case wakeLockCreating:
-					return fmt.Errorf("wake lock is being created (retry shortly)")
+					return &wakeLockCreatingError{}
 				case wakeLockValid:
 					if options.acceptExistingValid {
 						if err := requireWakeLockUsable(inspection, options.wakeMode, options.target); err != nil {
@@ -511,7 +519,13 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 
 	// Spawning and readiness waiting happen without the lifecycle guard.
 	startedPID, startErr := startWakeFromTarget(root, me, target)
-	winner, winnerErr := validateRepairWakeWinner(root, me, target)
+	if startErr != nil {
+		result.RepairAvailable = false
+		result.Status = "error"
+		result.Reason = startErr.Error()
+		return result, startErr
+	}
+	winner, winnerErr := validateRepairWakeWinner(root, me, target, startedPID)
 	if winnerErr == nil {
 		result.Status = "repaired"
 		result.PID = winner.PID
@@ -519,21 +533,20 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 	}
 	result.RepairAvailable = false
 	result.Status = "error"
-	if startErr != nil {
-		result.Reason = startErr.Error()
-		return result, startErr
-	}
 	result.PID = startedPID
 	result.Reason = fmt.Sprintf("repaired wake failed exact readiness validation: %v", winnerErr)
 	return result, errors.New(result.Reason)
 }
 
-func validateRepairWakeWinner(root, me string, expected wakeTarget) (wakeLockInspection, error) {
+func validateRepairWakeWinner(root, me string, expected wakeTarget, startedPID int) (wakeLockInspection, error) {
 	var winner wakeLockInspection
 	err := withWakeLifecycleGuard(root, me, func() error {
 		winner = inspectWakeLock(root, me)
 		if winner.Status != wakeLockValid || !winner.IdentityConfirmed || winner.Lock.Generation == "" {
 			return fmt.Errorf("no confirmed generation-bound wake is ready")
+		}
+		if winner.PID != startedPID {
+			return fmt.Errorf("ready wake pid %d does not match started pid %d", winner.PID, startedPID)
 		}
 		persisted, exists, err := readWakeTarget(root, me)
 		if err != nil {
@@ -582,8 +595,11 @@ func startWakeFromTargetDefault(root, me string, target wakeTarget) (int, error)
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("start repaired amq wake: %w", err)
 	}
-	if err := waitForWakeReady(cmd.Process, readyPath, root, me, wakeReadyTimeout); err != nil {
-		_ = cmd.Process.Kill()
+	waiter := newWakeProcessWaiter(cmd.Process)
+	if err := waitForWakeReadyWithWaiter(waiter, readyPath, root, me, wakeReadyTimeout); err != nil {
+		if cleanupErr := terminateWakeHelperProcess(cmd.Process, waiter, root, me); cleanupErr != nil {
+			return 0, fmt.Errorf("%w (cleanup: %v)", err, cleanupErr)
+		}
 		return 0, err
 	}
 	return cmd.Process.Pid, nil
@@ -627,7 +643,7 @@ func configureRepairWakeCommand(cmd *exec.Cmd, output *os.File) {
 }
 
 func buildRepairWakeArgs(root, me string, target wakeTarget, readyPath string) []string {
-	args := []string{"--no-update-check", "wake", "--me", me, "--root", root, "--inject-via", target.InjectVia}
+	args := []string{"--no-update-check", "wake", "--me", me, "--root", root, "--baseline-existing", "--inject-via", target.InjectVia}
 	for _, arg := range target.InjectArgs {
 		args = append(args, "--inject-arg", arg)
 	}
@@ -659,6 +675,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
 	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
+	baselineExistingFlag := fs.Bool("baseline-existing", false, "Ignore messages already waiting when this wake starts")
 
 	usage := usageWithHiddenFlags(fs, "amq wake --me <agent> [options]",
 		[]string{"ready-file", "accept-existing-wake"},
@@ -755,7 +772,6 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	if err := validateKnownHandles(root, common.Strict, me); err != nil {
 		return err
 	}
-
 	injectVia := strings.TrimSpace(*injectViaFlag)
 	if *injectViaFlag != "" && injectVia == "" {
 		return UsageError("--inject-via must not be blank")
@@ -820,15 +836,33 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	} else if lockWakeMode != wakeInjectModeNone {
 		lockWakeMode = effectiveInjectMode(&wakeConfig{me: me, injectMode: lockWakeMode})
 	}
-	cleanup, err := acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
-		acceptExistingValid: acceptExistingWake,
-		target:              target,
-		wakeMode:            lockWakeMode,
-	})
-	if err != nil {
+	acceptExistingDeadline := time.Now().Add(wakeReadyTimeout)
+	var cleanup func()
+	for {
+		cleanup, err = acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
+			acceptExistingValid: acceptExistingWake,
+			target:              target,
+			wakeMode:            lockWakeMode,
+		})
+		if err == nil {
+			break
+		}
+		var creating *wakeLockCreatingError
+		if acceptExistingWake && errors.As(err, &creating) {
+			if !waitForWakePreparedRetry(acceptExistingDeadline) {
+				return fmt.Errorf("wake lock did not finish creation within %s", wakeReadyTimeout)
+			}
+			continue
+		}
 		var alreadyRunning *wakeAlreadyRunningError
 		if acceptExistingWake && errors.As(err, &alreadyRunning) {
-			return writeWakeReadyFile(root, me, readyFile, alreadyRunning.Inspection)
+			if err := writeWakeReadyFileForPreparedWake(root, me, readyFile, alreadyRunning.Inspection, acceptExistingDeadline); err != nil {
+				return err
+			}
+			if *baselineExistingFlag {
+				_ = writeStderr("warning: reusing existing amq wake; this launch did not re-baseline it, so pending backlog may still notify\n")
+			}
+			return nil
 		}
 		return err
 	}
@@ -851,6 +885,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		}
 	}
 
+	currentWake := inspectWakeLock(root, me)
 	cfg := wakeConfig{
 		me:                me,
 		root:              root,
@@ -878,13 +913,146 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		interruptNotice:   strings.TrimSpace(*interruptNoticeFlag),
 		interruptCooldown: *interruptCooldownFlag,
 		controlStop:       controlStop,
-	}
-
-	if err := writeWakeReadyFile(root, me, readyFile, inspectWakeLock(root, me)); err != nil {
-		return err
+		baselineRequested: *baselineExistingFlag,
+		onPrepared: func() error {
+			if err := writeWakePreparedFile(root, me, currentWake); err != nil {
+				return err
+			}
+			return writeWakeReadyFile(root, me, readyFile, currentWake)
+		},
 	}
 
 	return loop(cfg)
+}
+
+var snapshotWakeDirEntryInfo = func(entry os.DirEntry) (os.FileInfo, error) {
+	return entry.Info()
+}
+
+func snapshotWakeExistingMessages(root, me string) (map[string]wakeFileIdentity, error) {
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, me))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]wakeFileIdentity{}, nil
+		}
+		return nil, err
+	}
+	baseline := make(map[string]wakeFileIdentity, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		info, err := snapshotWakeDirEntryInfo(entry)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		identity, ok := captureWakeFileIdentity(info)
+		if !ok {
+			return nil, fmt.Errorf("capture identity for %s", name)
+		}
+		baseline[name] = identity
+	}
+	return baseline, nil
+}
+
+func invalidateWakeBaselineEvent(cfg *wakeConfig, event fsnotify.Event) {
+	if event.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Write|fsnotify.Remove) == 0 {
+		return
+	}
+	name := filepath.Base(event.Name)
+	if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
+		return
+	}
+	delete(cfg.baselineExisting, name)
+}
+
+// prepareWakeBaseline classifies startup backlog after the watcher is armed.
+// Linux/inotify provides an ordered marker fence; Darwin/kqueue uses the marker
+// plus a quiescence window, with watcher errors handled fail-closed.
+func prepareWakeBaseline(cfg *wakeConfig, watcher *fsnotify.Watcher, inboxNew string) error {
+	if !cfg.baselineRequested {
+		return nil
+	}
+	// Individual local-filesystem calls are intentionally not cancellable. Coop
+	// has an outer readiness timeout; standalone wake can wait on a stuck scan.
+	baseline, err := snapshotWakeExistingMessages(cfg.root, cfg.me)
+	if err != nil {
+		return fmt.Errorf("snapshot existing wake messages: %w", err)
+	}
+	cfg.baselineExisting = baseline
+
+	marker, err := os.CreateTemp(inboxNew, ".wake-baseline-barrier-")
+	if err != nil {
+		return fmt.Errorf("create wake baseline barrier: %w", err)
+	}
+	markerPath := marker.Name()
+	if err := marker.Close(); err != nil {
+		_ = os.Remove(markerPath)
+		return fmt.Errorf("close wake baseline barrier: %w", err)
+	}
+	// A crash can leave this hidden marker behind; message scans ignore it.
+	defer func() { _ = os.Remove(markerPath) }()
+
+	timer := time.NewTimer(wakeBaselineTimeout)
+	defer timer.Stop()
+	var settleTimer *time.Timer
+	var settleC <-chan time.Time
+	defer func() {
+		if settleTimer != nil {
+			settleTimer.Stop()
+		}
+	}()
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return failWakeOnWatcherError(cfg, "watcher closed while preparing wake baseline", nil)
+			}
+			invalidateWakeBaselineEvent(cfg, event)
+			if filepath.Clean(event.Name) == filepath.Clean(markerPath) && event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
+				if settleTimer == nil {
+					settleTimer = time.NewTimer(wakeBaselineSettle)
+				} else {
+					settleTimer.Reset(wakeBaselineSettle)
+				}
+				settleC = settleTimer.C
+			} else if settleTimer != nil {
+				if !settleTimer.Stop() {
+					select {
+					case <-settleTimer.C:
+					default:
+					}
+				}
+				settleTimer.Reset(wakeBaselineSettle)
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return failWakeOnWatcherError(cfg, "watcher closed while preparing wake baseline", nil)
+			}
+			return failWakeOnWatcherError(cfg, "watcher error while preparing wake baseline", err)
+		case <-timer.C:
+			return fmt.Errorf("wake baseline barrier was not observed within %s", wakeBaselineTimeout)
+		case <-settleC:
+			return nil
+		}
+	}
+}
+
+func failWakeOnWatcherError(cfg *wakeConfig, context string, cause error) error {
+	// Once event history is uncertain, retaining baseline tombstones could
+	// suppress a real arrival. Exit with them cleared so any restart scans all.
+	cfg.baselineExisting = nil
+	if cause == nil {
+		return errors.New(context)
+	}
+	return fmt.Errorf("%s: %w", context, cause)
 }
 
 func parseInterruptKey(raw string) (string, error) {
@@ -919,6 +1087,23 @@ func runWakeLoop(cfg wakeConfig) error {
 
 	if err := watcher.Add(inboxNew); err != nil {
 		return fmt.Errorf("failed to watch inbox: %w", err)
+	}
+	// The startup boundary is watcher installation, not lock acquisition;
+	// messages delivered in between are intentionally treated as startup backlog.
+	if err := prepareWakeBaseline(&cfg, watcher, inboxNew); err != nil {
+		return err
+	}
+	// This closes the already-pending stop case only; a stop or process death can
+	// still race immediately after readiness publication.
+	select {
+	case <-cfg.controlStop:
+		return nil
+	default:
+	}
+	if cfg.onPrepared != nil {
+		if err := cfg.onPrepared(); err != nil {
+			return err
+		}
 	}
 
 	// Ignore job control signals so background job can operate freely.
@@ -965,10 +1150,11 @@ func runWakeLoop(cfg wakeConfig) error {
 
 		case event, ok := <-watcher.Events:
 			if !ok {
-				return errors.New("watcher closed")
+				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
 			}
+			invalidateWakeBaselineEvent(&cfg, event)
 			// Only care about new files
-			if event.Op&(fsnotify.Create|fsnotify.Rename) == 0 {
+			if event.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Write) == 0 {
 				continue
 			}
 			// Skip non-.md files
@@ -992,9 +1178,9 @@ func runWakeLoop(cfg wakeConfig) error {
 
 		case err, ok := <-watcher.Errors:
 			if !ok {
-				return errors.New("watcher closed")
+				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
 			}
-			_ = writeStderr("amq wake: watcher error: %v\n", err)
+			return failWakeOnWatcherError(&cfg, "amq wake: watcher error", err)
 
 		case <-debounceC:
 			if !pendingNotify {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -14,7 +14,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/fsnotify/fsnotify"
 )
 
 func stubSignalWakeProcess(t *testing.T, fn func(pid int, sig os.Signal) error) {
@@ -45,6 +47,14 @@ func stubWakeProcessSID(t *testing.T, fn func(pid int) (int, error)) {
 	t.Cleanup(func() {
 		getWakeProcessSID = old
 	})
+}
+
+func writeWakePreparedForTest(t *testing.T, root, me string) {
+	t.Helper()
+	inspection := inspectWakeLock(root, me)
+	if err := writeWakePreparedFile(root, me, inspection); err != nil {
+		t.Fatalf("writeWakePreparedFile: %v", err)
+	}
 }
 
 func stubWakeTTYSupport(t *testing.T) {
@@ -123,13 +133,247 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 		"--inject-via", injector,
 		"--ready-file", readyPath,
 	}, func(cfg wakeConfig) error {
+		if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+			t.Fatalf("ready file published before wake preparation: %v", statErr)
+		}
+		if err := cfg.onPrepared(); err != nil {
+			t.Fatalf("publish readiness: %v", err)
+		}
 		if _, statErr := os.Stat(readyPath); statErr != nil {
-			t.Fatalf("expected ready file before wake loop: %v", statErr)
+			t.Fatalf("expected ready file after wake preparation: %v", statErr)
 		}
 		return errDone
 	})
 	if !errors.Is(err, errDone) {
 		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopBaselinesBeforeReadiness(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	inboxNew := fsq.AgentInboxNew(root, "orchestrator")
+	if err := os.WriteFile(filepath.Join(inboxNew, "stale.md"), []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale message: %v", err)
+	}
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	injector := writeExecutableForTest(t, "injector")
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", injector,
+		"--baseline-existing",
+		"--ready-file", readyPath,
+	}, func(cfg wakeConfig) error {
+		if !cfg.baselineRequested {
+			t.Fatal("baseline request was not carried into the owned wake loop")
+		}
+		if cfg.baselineExisting != nil {
+			t.Fatal("baseline was captured before watcher setup and wake ownership")
+		}
+		watcher, watcherErr := fsnotify.NewWatcher()
+		if watcherErr != nil {
+			t.Fatalf("NewWatcher: %v", watcherErr)
+		}
+		defer func() { _ = watcher.Close() }()
+		if watcherErr := watcher.Add(inboxNew); watcherErr != nil {
+			t.Fatalf("watch inbox: %v", watcherErr)
+		}
+		if prepErr := prepareWakeBaseline(&cfg, watcher, inboxNew); prepErr != nil {
+			t.Fatalf("prepareWakeBaseline: %v", prepErr)
+		}
+		if _, ok := cfg.baselineExisting["stale.md"]; !ok {
+			t.Fatal("stale message missing from watcher-armed startup baseline")
+		}
+		if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+			t.Fatalf("ready file published before baseline preparation: %v", statErr)
+		}
+		if err := cfg.onPrepared(); err != nil {
+			t.Fatalf("publish readiness: %v", err)
+		}
+		if _, statErr := os.Stat(readyPath); statErr != nil {
+			t.Fatalf("expected ready file after baseline snapshot: %v", statErr)
+		}
+		if _, exists, preparedErr := readWakeGenerationFile(wakePreparedPath(root, "orchestrator"), "wake prepared marker"); preparedErr != nil || !exists {
+			t.Fatalf("generation-bound prepared marker missing: exists=%v err=%v", exists, preparedErr)
+		}
+		if err := os.WriteFile(filepath.Join(inboxNew, "fresh.md"), []byte("fresh"), 0o600); err != nil {
+			t.Fatalf("write fresh message: %v", err)
+		}
+		if _, ok := cfg.baselineExisting["fresh.md"]; ok {
+			t.Fatal("message arriving after readiness was incorrectly baselined")
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestBaselineFreshMailboxStillStarts(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+
+	baseline, err := snapshotWakeExistingMessages(root, "fresh-agent")
+	if err != nil {
+		t.Fatalf("missing inbox/new should be treated as an empty baseline: %v", err)
+	}
+	if len(baseline) != 0 {
+		t.Fatalf("baseline = %#v, want empty", baseline)
+	}
+}
+
+func TestPrepareWakeBaselineInvalidatesSameNameReplacementDuringSnapshot(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	inboxNew := fsq.AgentInboxNew(root, "alice")
+	samePath := filepath.Join(inboxNew, "same.md")
+	if err := os.WriteFile(samePath, []byte("old"), 0o600); err != nil {
+		t.Fatalf("write old message: %v", err)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = watcher.Close() }()
+	if err := watcher.Add(inboxNew); err != nil {
+		t.Fatalf("watch inbox: %v", err)
+	}
+
+	originalInfo := snapshotWakeDirEntryInfo
+	replaced := false
+	snapshotWakeDirEntryInfo = func(entry os.DirEntry) (os.FileInfo, error) {
+		if entry.Name() == "same.md" && !replaced {
+			replaced = true
+			if err := os.Rename(samePath, filepath.Join(inboxNew, "old.md")); err != nil {
+				return nil, err
+			}
+			if err := os.WriteFile(samePath, []byte("replacement"), 0o600); err != nil {
+				return nil, err
+			}
+		}
+		return entry.Info()
+	}
+	t.Cleanup(func() { snapshotWakeDirEntryInfo = originalInfo })
+
+	cfg := wakeConfig{root: root, me: "alice", baselineRequested: true}
+	if err := prepareWakeBaseline(&cfg, watcher, inboxNew); err != nil {
+		t.Fatalf("prepareWakeBaseline: %v", err)
+	}
+	if !replaced {
+		t.Fatal("same-name replacement hook did not run")
+	}
+	if _, ignored := cfg.baselineExisting["same.md"]; ignored {
+		t.Fatal("same-name replacement created during snapshot remained baselined")
+	}
+}
+
+func TestFailWakeOnWatcherErrorClearsBaselineAndExits(t *testing.T) {
+	cfg := wakeConfig{baselineExisting: map[string]wakeFileIdentity{"stale.md": {}}}
+	cause := errors.New("overflow")
+	err := failWakeOnWatcherError(&cfg, "watcher error", cause)
+	if err == nil || !strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("watcher failure = %v", err)
+	}
+	if cfg.baselineExisting != nil {
+		t.Fatalf("watcher error retained baseline tombstones: %#v", cfg.baselineExisting)
+	}
+}
+
+func TestRunWakeLoopStopsBeforePublishingPreparedMarker(t *testing.T) {
+	stop := make(chan struct{})
+	close(stop)
+	prepared := false
+	err := runWakeLoop(wakeConfig{
+		root:        secureTempDirForTest(t),
+		me:          "orchestrator",
+		controlStop: stop,
+		onPrepared: func() error {
+			prepared = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runWakeLoop: %v", err)
+	}
+	if prepared {
+		t.Fatal("prepared marker was published after cooperative stop was already pending")
+	}
+}
+
+func TestBaselineDLQRetryWithSameFilenameRemainsNotifyEligible(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	msg := format.Message{
+		Header: format.Header{
+			Schema: 1, ID: "stale", From: "codex", To: []string{"alice"},
+			Thread: "p2p/alice__codex", Subject: "stale", Created: "2026-07-22T00:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(root, "alice"), "same.md"), data, 0o600); err != nil {
+		t.Fatalf("write message: %v", err)
+	}
+
+	cfg, outputPath := injectViaCaptureConfig(t)
+	cfg.me = "alice"
+	cfg.root = root
+	cfg.previewLen = 48
+	baseline, err := snapshotWakeExistingMessages(root, "alice")
+	if err != nil {
+		t.Fatalf("snapshot baseline: %v", err)
+	}
+	cfg.baselineExisting = baseline
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify stale baseline: %v", err)
+	}
+
+	rootIdentity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		t.Fatalf("snapshot delivery root: %v", err)
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, rootIdentity)
+	if err != nil {
+		t.Fatalf("open delivery root: %v", err)
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+	dlqPath, err := fsq.MoveToDLQ(deliveryRoot, "alice", "same.md", "stale", "test", "retry identity")
+	if err != nil {
+		t.Fatalf("move baseline message to DLQ: %v", err)
+	}
+	if err := fsq.RetryFromDLQ(deliveryRoot, "alice", filepath.Base(dlqPath), false); err != nil {
+		t.Fatalf("retry baseline message from DLQ: %v", err)
+	}
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify DLQ retry: %v", err)
+	}
+	if got, err := os.ReadFile(outputPath); err != nil || len(got) == 0 {
+		t.Fatalf("same-name DLQ retry did not notify: bytes=%d err=%v", len(got), err)
 	}
 }
 
@@ -153,8 +397,11 @@ func TestRunWakeWithLoopNoneSkipsTTYAndWritesReadyFile(t *testing.T) {
 		if cfg.injectMode != wakeInjectModeNone {
 			t.Fatalf("injectMode = %q, want none", cfg.injectMode)
 		}
+		if err := cfg.onPrepared(); err != nil {
+			t.Fatalf("publish readiness: %v", err)
+		}
 		if _, statErr := os.Stat(readyPath); statErr != nil {
-			t.Fatalf("expected ready file before wake loop: %v", statErr)
+			t.Fatalf("expected ready file after wake preparation: %v", statErr)
 		}
 		return errDone
 	})
@@ -224,6 +471,9 @@ func TestRunWakeHelpHidesInternalReadyFlags(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "inject-cmd") {
 		t.Fatalf("wake help should keep --inject-cmd visible:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "baseline-existing") {
+		t.Fatalf("wake help should keep --baseline-existing visible:\n%s", stdout)
 	}
 	if !strings.Contains(stdout, "none") || !strings.Contains(stdout, "zero terminal input") {
 		t.Fatalf("wake help should document none as zero-input mode:\n%s", stdout)
@@ -621,7 +871,7 @@ func TestRunWakeWithLoopDoesNotWriteReadyFileWhenLockBlocked(t *testing.T) {
 	}
 }
 
-func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
+func TestRunWakeWithLoopWaitsForCurrentPreparedMarkerPastStaleGeneration(t *testing.T) {
 	const wakePID = 4242
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == wakePID {
@@ -652,21 +902,136 @@ func TestRunWakeWithLoopWritesReadyFileForExistingUsableWake(t *testing.T) {
 	}
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
-	err := runWakeWithLoop([]string{
-		"--root", root,
-		"--me", "orchestrator",
-		"--inject-via", injector,
-		"--ready-file", readyPath,
-		"--accept-existing-wake",
-	}, func(cfg wakeConfig) error {
-		t.Fatalf("loop should not run with an existing live wake lock: %#v", cfg)
-		return nil
-	})
-	if err != nil {
+	run := func() error {
+		return runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-via", injector,
+			"--ready-file", readyPath,
+			"--accept-existing-wake",
+		}, func(cfg wakeConfig) error {
+			t.Fatalf("loop should not run with an existing live wake lock: %#v", cfg)
+			return nil
+		})
+	}
+
+	if err := writeWakeGenerationFile(wakePreparedPath(root, "orchestrator"), "wake prepared marker", wakeReady{
+		Schema:       wakeReadySchema,
+		Generation:   "previous-generation",
+		TargetDigest: wakeTargetDigest(target),
+	}); err != nil {
+		t.Fatalf("write previous-generation prepared marker: %v", err)
+	}
+	inspection := inspectWakeLock(root, "orchestrator")
+	if err := writeWakeReadyFileForPreparedWake(root, "orchestrator", readyPath, inspection, time.Now().Add(40*time.Millisecond)); err == nil || !strings.Contains(err.Error(), "deadline") {
+		t.Fatalf("stale prepared marker deadline error = %v", err)
+	}
+
+	retryEntered := make(chan struct{}, 1)
+	originalRetry := waitForWakePreparedRetry
+	waitForWakePreparedRetry = func(deadline time.Time) bool {
+		select {
+		case retryEntered <- struct{}{}:
+		default:
+		}
+		return originalRetry(deadline)
+	}
+	t.Cleanup(func() { waitForWakePreparedRetry = originalRetry })
+	done := make(chan error, 1)
+	go func() { done <- run() }()
+	select {
+	case <-retryEntered:
+	case err := <-done:
+		t.Fatalf("existing wake returned instead of polling past the stale marker: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("existing wake never entered prepared-marker polling")
+	}
+	writeWakePreparedForTest(t, root, "orchestrator")
+	if err := <-done; err != nil {
 		t.Fatalf("expected existing usable wake to satisfy ready file, got %v", err)
 	}
 	if _, statErr := os.Stat(readyPath); statErr != nil {
 		t.Fatalf("ready file should exist, statErr=%v", statErr)
+	}
+	current := inspectWakeLock(root, "orchestrator")
+	if err := writeWakeGenerationFile(wakePreparedPath(root, "orchestrator"), "wake prepared marker", wakeReady{
+		Schema:       wakeReadySchema,
+		Generation:   current.Lock.Generation,
+		TargetDigest: "same-generation-wrong-target",
+	}); err != nil {
+		t.Fatalf("write same-generation invalid marker: %v", err)
+	}
+	if _, err := validateWakePreparedFileAgainstInspection(root, "orchestrator", current); err == nil || !strings.Contains(err.Error(), "target") {
+		t.Fatalf("same-generation target mismatch was not rejected: %v", err)
+	}
+}
+
+func TestRunWakeWithLoopRetriesCreatingWakeUntilPrepared(t *testing.T) {
+	const wakePID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1",
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	lockPath := filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock")
+	if err := os.WriteFile(lockPath, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write creating lock: %v", err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, nil)
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	retryEntered := make(chan struct{}, 1)
+	originalRetry := waitForWakePreparedRetry
+	waitForWakePreparedRetry = func(deadline time.Time) bool {
+		select {
+		case retryEntered <- struct{}{}:
+		default:
+		}
+		return originalRetry(deadline)
+	}
+	t.Cleanup(func() { waitForWakePreparedRetry = originalRetry })
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-via", injector,
+			"--ready-file", readyPath,
+			"--accept-existing-wake",
+		}, func(cfg wakeConfig) error {
+			t.Errorf("loop should not run with an existing wake: %#v", cfg)
+			return nil
+		})
+	}()
+	select {
+	case <-retryEntered:
+	case err := <-done:
+		t.Fatalf("helper returned instead of retrying transient lock creation: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("helper never retried transient lock creation")
+	}
+	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
+		PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1",
+		Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
+	}, target))
+	writeWakePreparedForTest(t, root, "orchestrator")
+	if err := <-done; err != nil {
+		t.Fatalf("creating wake did not become reusable: %v", err)
+	}
+	if _, err := os.Stat(readyPath); err != nil {
+		t.Fatalf("ready file missing: %v", err)
 	}
 }
 
@@ -738,23 +1103,38 @@ func TestRunWakeWithLoopNoneAcceptsExistingNoneWake(t *testing.T) {
 		WakeMode:     wakeInjectModeNone,
 		Generation:   "generation-1",
 	})
+	writeWakePreparedForTest(t, root, "orchestrator")
+	stalePath := filepath.Join(fsq.AgentInboxNew(root, "orchestrator"), "stale.md")
+	if err := os.WriteFile(stalePath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale message: %v", err)
+	}
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
-	err := runWakeWithLoop([]string{
-		"--root", root,
-		"--me", "orchestrator",
-		"--inject-mode", "none",
-		"--ready-file", readyPath,
-		"--accept-existing-wake",
-	}, func(cfg wakeConfig) error {
-		t.Fatalf("loop should not run with an existing none wake: %#v", cfg)
-		return nil
+	var err error
+	stderr := captureWakeStderr(t, func() {
+		err = runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-mode", "none",
+			"--baseline-existing",
+			"--ready-file", readyPath,
+			"--accept-existing-wake",
+		}, func(cfg wakeConfig) error {
+			t.Fatalf("loop should not run with an existing none wake: %#v", cfg)
+			return nil
+		})
 	})
 	if err != nil {
 		t.Fatalf("expected existing none wake to satisfy readiness, got %v", err)
 	}
 	if _, statErr := os.Stat(readyPath); statErr != nil {
 		t.Fatalf("ready file should exist, statErr=%v", statErr)
+	}
+	if !strings.Contains(stderr, "this launch did not re-baseline it, so pending backlog may still notify") {
+		t.Fatalf("reuse warning missing from stderr: %q", stderr)
+	}
+	if _, statErr := os.Stat(stalePath); statErr != nil {
+		t.Fatalf("reused wake moved or removed stale backlog: %v", statErr)
 	}
 }
 
@@ -1018,6 +1398,7 @@ func TestRunWakeWithLoopAcceptExistingWakeAcceptsInjectViaUnknownTTY(t *testing.
 	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
+	writeWakePreparedForTest(t, root, "orchestrator")
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
@@ -2267,6 +2648,128 @@ func TestAcceptExistingReadinessNotPublishedOnReplacement(t *testing.T) {
 	}
 	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
 		t.Fatalf("replacement readiness must not be published, statErr=%v", statErr)
+	}
+}
+
+func TestCleanupTerminatedWakeLockRemovesOnlyCapturedStaleGeneration(t *testing.T) {
+	const wakePID = 4242
+	running := true
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    running,
+			StartToken: "start-1",
+			BootID:     "boot-1",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+		}
+	})
+
+	t.Run("captured generation", func(t *testing.T) {
+		root := secureTempDirForTest(t)
+		lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+			PID: wakePID, ProcessStart: "start-1", BootID: "boot-1",
+			Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
+		})
+		expected := inspectWakeLock(root, "orchestrator")
+		running = false
+		if err := cleanupTerminatedWakeLock(expected); err != nil {
+			t.Fatalf("cleanupTerminatedWakeLock: %v", err)
+		}
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatalf("captured stale lock was not removed, statErr=%v", err)
+		}
+	})
+
+	t.Run("replacement generation", func(t *testing.T) {
+		running = true
+		root := secureTempDirForTest(t)
+		lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+			PID: wakePID, ProcessStart: "start-1", BootID: "boot-1",
+			Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
+		})
+		expected := inspectWakeLock(root, "orchestrator")
+		if err := os.Remove(lockPath); err != nil {
+			t.Fatalf("remove captured lock: %v", err)
+		}
+		writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+			PID: wakePID, ProcessStart: "start-1", BootID: "boot-1",
+			Executable: "/opt/homebrew/bin/amq", Generation: "generation-2",
+		})
+		running = false
+		if err := cleanupTerminatedWakeLock(expected); err != nil {
+			t.Fatalf("cleanup replacement: %v", err)
+		}
+		if _, err := os.Stat(lockPath); err != nil {
+			t.Fatalf("replacement generation was removed: %v", err)
+		}
+	})
+}
+
+func TestTerminateWakeHelperProcessKillsWaitsAndRemovesCapturedLock(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	wakePID := cmd.Process.Pid
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		running := syscall.Kill(pid, 0) == nil
+		return wakeProcessInfo{
+			PID: pid, Running: running, StartToken: "start-1", BootID: "boot-1",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+		}
+	})
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID: wakePID, ProcessStart: "start-1", BootID: "boot-1",
+		Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
+	})
+	waiter := newWakeProcessWaiter(cmd.Process)
+	if err := terminateWakeHelperProcess(cmd.Process, waiter, root, "orchestrator"); err != nil {
+		t.Fatalf("terminateWakeHelperProcess: %v", err)
+	}
+	if waiter.state == nil {
+		t.Fatalf("wake helper was not waited: state=%v", waiter.state)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("terminated helper lock was not removed, statErr=%v", err)
+	}
+}
+
+func TestTerminateWakeHelperProcessRemovesLockCommittedAfterFirstInspection(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	root := secureTempDirForTest(t)
+	lockPath := filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock")
+	originalKill := killWakeHelperProcess
+	killWakeHelperProcess = func(proc *os.Process) error {
+		writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+			PID: proc.Pid, Generation: "generation-after-first-inspection",
+		})
+		return originalKill(proc)
+	}
+	t.Cleanup(func() { killWakeHelperProcess = originalKill })
+
+	waiter := newWakeProcessWaiter(cmd.Process)
+	if err := terminateWakeHelperProcess(cmd.Process, waiter, root, "orchestrator"); err != nil {
+		t.Fatalf("terminateWakeHelperProcess: %v", err)
+	}
+	if waiter.state == nil {
+		t.Fatal("wake helper was not waited")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("post-inspection child lock was not removed, statErr=%v", err)
 	}
 }
 

--- a/internal/cli/wake_upgrade_race_unix_test.go
+++ b/internal/cli/wake_upgrade_race_unix_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-func TestWakeUpgradeRaceRepairAcceptsConcurrentCurrentAcquire(t *testing.T) {
+func TestWakeUpgradeRaceRepairRejectsConcurrentCurrentAcquire(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
 	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-a"})
@@ -84,11 +84,11 @@ func TestWakeUpgradeRaceRepairAcceptsConcurrentCurrentAcquire(t *testing.T) {
 
 	close(releaseRepair)
 	got := <-repaired
-	if got.err != nil {
-		t.Fatalf("repair rejected exact concurrent winner: result=%#v err=%v", got.result, got.err)
+	if got.err == nil || !strings.Contains(got.err.Error(), "lost start race") {
+		t.Fatalf("repair accepted a winner that did not install its baseline: result=%#v err=%v", got.result, got.err)
 	}
-	if got.result.Status != "repaired" || got.result.PID != os.Getpid() {
-		t.Fatalf("repair result = %#v, want current acquire as repaired winner", got.result)
+	if got.result.Status != "error" {
+		t.Fatalf("repair result = %#v, want rejected concurrent winner", got.result)
 	}
 	persisted, exists, err := readWakeTarget(root, "codex")
 	if err != nil || !exists || !sameWakeInjectorIdentity(persisted, target) {

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -80,6 +80,13 @@ Leader prepares commit -> user approves -> push
   writes notices to wake stderr, turns urgent interrupts into one bell plus the
   output notice, and rejects `--inject-via`, `--inject-arg`, and `--inject-cmd`.
   Stderr shares the TUI terminal by default and may remain visible until redraw.
+- When starting a new wake after the agent owns its terminal, pass `amq wake
+  --baseline-existing ...`. Existing `inbox/new` messages remain unread and
+  emit no receipts; only later arrivals trigger that fresh wake. `coop exec`
+  and `wake repair` add the flag to wakes they start. Reuse requires
+  generation-bound proof that the live wake completed watcher preparation. It
+  does not retroactively baseline that wake, so pending backlog can still
+  notify; SessionStart draining mitigates that residual.
 
 ## Message Handling
 


### PR DESCRIPTION
Takes over and supersedes #265 (Ohad Edelstein's `amq-keepalive`-adjacent wake-stale-baseline fix). Originated from Ohad's PR #265; we took the work over with his encouragement and credit him as co-author.

## What
Adds `amq wake --baseline-existing`: snapshot `inbox/new` at wake startup and suppress those pre-existing messages from injection while a terminal is still starting, so an old unread notification (including an urgent Ctrl-C) can't be injected into a freshly-launched agent. Messages arriving after startup notify normally. Auto-enabled for `coop exec` and `wake repair`.

## Scope & guarantees
- **Fresh-wake only.** A reused (same-terminal) wake keeps its own baseline; that reuse case is a documented, accepted residual (SessionStart drain mitigates). The cross-process reuse "handoff" that an earlier iteration attempted was deliberately **descoped** — a two-phase quiescence protocol can't guarantee raw-TIOCSTI terminal-queue safety without destructive input flushing, so it wasn't worth the complexity on a personal tool.
- Instance identity is **dev+inode+ctime** (not filename), so a same-name DLQ redelivery stays notify-eligible.
- Missing inbox → empty baseline (no fail-closed).
- Watcher armed **before** an event-fenced baseline (sentinel barrier marker) so an arrival during enumeration can't be permanently suppressed.
- Generation-bound `.wake.prepared` marker gates reuse readiness with **bounded, guard-free polling** (waits for a mid-startup wake instead of falsely degrading).
- Watcher errors **fail closed**; coop degradation requires a confirmed-live wake; SIGKILL-on-timeout does generation-bound stale-lock cleanup.
- 32-bit Linux `Stat_t.Ctim` casts (linux/386 + linux/arm compile).

## Verification
- `make ci` green; `go test -race ./internal/cli` clean; 9 cross-build targets (darwin/linux/freebsd/windows incl. linux/386 + linux/arm).
- No `#235`/`#260` wake-lifecycle regression (lock/cooperative-stop/retire/upgrade-race/doctor suites pass under `-race`).
- **No message data loss** at any point — baselined messages stay unread and drainable; only notifications are suppressed.

## Review
Reviewed by Claude + Codex, then gated through **ChatGPT-Pro (GPT-5.6 Sol Pro) across 4 rounds** — descope + 3 hardening rounds — converging from 4 P1 races to zero, with 5 edge cases documented as accepted personal-tool residuals.

Co-authored with Ohad Edelstein (credited in the commit).

Co-Authored-By: Ohad Edelstein <ohade@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)