### PR TITLE
fix(ci): skip release-please on release-commit pushes to avoid tag race

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,13 @@ concurrency:
 
 jobs:
   release-please:
+    # Release PRs squash to this prefix. Skip that push so release.yml can create
+    # the tag before the next conventional commit or manual dispatch scans again.
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        !startsWith(github.event.head_commit.message, 'chore(release): v')
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/scripts/test_release_please_config.py
+++ b/scripts/test_release_please_config.py
@@ -45,6 +45,16 @@ def test_release_please_workflow_is_pr_only_and_staged() -> None:
     assert "if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}" in workflow
     assert "if: ${{ env.RELEASE_PLEASE_TOKEN == '' }}" in workflow
 
+    release_commit_guard = """\
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        !startsWith(github.event.head_commit.message, 'chore(release): v')
+      }}
+"""
+    release_job = workflow[workflow.index("  release-please:\n") :]
+    assert release_commit_guard in release_job
+
     release_workflow = (ROOT / ".github/workflows/release.yml").read_text()
     assert "predates scripts/release_changelog_section.py" in release_workflow
     assert "python3 scripts/release_changelog_section.py" not in release_workflow


### PR DESCRIPTION
## Summary

- skip the Release Please job on squash release-commit pushes while preserving manual dispatch
- pin the guard in the existing release-please safety-contract test
- prevent the tag-creation race that produced the spurious v0.47.0 release PR #269

## Root cause

`release-please.yml` and `release.yml` both run on the merged release commit. The Release Please run can scan before `release.yml` creates the new tag, conclude that no latest release exists, and backfill repository history into a bogus next release PR.

Release Please is PR-only here (`skip-github-release: true`), so it has no work to perform on the release commit itself. The next conventional commit runs after the tag exists; `workflow_dispatch` remains available for manual recovery.

## Accepted residual

If a feature reaches `main` after Release Please last updated the release PR but before that release PR merges, skipping the release-commit push means the feature waits for the next `main` commit or a manual dispatch before appearing in the next release PR. This fails quiet and self-heals; it replaces the current behavior of generating a history-replay release PR.

## Verification

- `python3 scripts/test_release_please_config.py`
- `yamllint -d '{extends: relaxed, rules: {line-length: disable, truthy: disable}}' .github/workflows/release-please.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-please.yml`
- `git diff --check`
- `make ci`

Peer-reviewed by Claude before commit; PASS with the accepted residual above called out explicitly.
