### PR TITLE
feat(wake): add identity-safe owner-bound lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,12 @@ draining mitigates that residual. `--require-wake` requires a usable notifier,
 not a rebased reused wake.
 Launchers that use an external injector can add `--wake-inject-via /absolute/path/to/injector`
 and repeated `--wake-inject-arg` values. When that invocation starts a new wake,
-the wake stores a repair target so `amq wake repair` can restart wake later
-without restarting the agent TUI. If `--require-wake` reuses an existing wake,
-that wake must already have repair metadata to be repairable.
+the wake is bound to the exact `coop exec` process identity and stores its
+injector target. The claim survives an ordinary wake exit so another process
+cannot silently take over the handle. If the owner or wake exits unexpectedly,
+use `amq wake recover-owner` instead of the ownerless repair path. When a
+required owner capability is conclusively unsupported before any claim exists,
+AMQ warns and starts one ownerless wake instead.
 
 ### 3. Send & Receive
 
@@ -205,6 +208,7 @@ amq doctor --ops
 amq doctor --ops --json
 amq doctor --ops --fix-wake-locks
 amq wake repair --me codex
+amq wake recover-owner --me codex
 amq wake retire --me codex --inject-via /absolute/injector \
   --inject-arg exec --inject-arg terminal-id
 ```
@@ -228,6 +232,15 @@ or injecting into the wrong terminal. Repaired wake output goes to
 `agents/<agent>/.wake.repair.log`; `doctor --ops` can report whether repair is
 available, but it never starts a wake process.
 
+`amq wake recover-owner` is the separate recovery path for an owner-bound
+`coop exec --wake-inject-via` claim. A live owner may release only its exact
+claim from the same OS session, using the inherited `AMQ_WAKE_OWNER` token.
+When the exact owner is dead, recovery does not require that token. AMQ stops
+only an identity-confirmed wake, re-checks the claim after every wait, and
+fails closed without mutation when the owner or claim is unknown, legacy, or
+corrupt. There is no force mode. The ownerless `repair`, `retire`, and
+`doctor --ops --fix-wake-locks` paths refuse owner-bound claims.
+
 `amq wake retire` is the exact managed-shutdown path. It requires the caller's
 expected `--inject-via` executable and ordered `--inject-arg` values. A live
 wake is retired only when its process identity, unchanged lock generation, and
@@ -239,6 +252,7 @@ target are preserved in either case; raw and unverified wakes fail closed.
 The lifecycle boundaries are:
 
 - repair = replace a proven-stale inject-via wake.
+- recover-owner = stop and release one exact owner-bound inject-via claim.
 - `doctor --ops --fix-wake-locks` = remove a proven-stale lock.
 - retire = stop an identity-confirmed live inject-via wake.
 - launchd, systemd, or the owning shell = stop a raw wake.
@@ -401,7 +415,7 @@ Common command groups:
 | Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `watch`, `monitor`, `receipts` |
 | Collaboration | `coop init`, `coop exec`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
-| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake repair`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
+| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake repair`, `wake recover-owner`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 
 For the full CLI syntax, examples, and message schema, see [CLAUDE.md](CLAUDE.md).
 

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 func TestSplitDashDash(t *testing.T) {
@@ -130,6 +131,73 @@ func TestCoopExecRequireWakeRejectsNoWake(t *testing.T) {
 	}
 	if !containsStr(err.Error(), "--require-wake cannot be used with --no-wake") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestCoopExecAlwaysOverwritesOwnerTokenImmediatelyBeforeExec(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	self := os.Getpid()
+	owner := wakeOwner{
+		PID:          self,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != self {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: owner.ProcessStart,
+			BootID:     owner.BootID,
+		}
+	})
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		if pid != self {
+			t.Fatalf("session lookup pid = %d, want %d", pid, self)
+		}
+		return owner.SessionID, nil
+	})
+	t.Setenv(envWakeOwner, `{"pid":1,"process_start":"stale","boot_id":"stale","session_id":1}`)
+
+	sentinel := errors.New("exec sentinel")
+	var execEnv []string
+	oldExec := coopExecProcess
+	coopExecProcess = func(_ string, _ []string, env []string) error {
+		execEnv = append([]string{}, env...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err := runCoopExec([]string{"--root", root, "--me", "codex", "--no-wake", "sh"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want sentinel", err)
+	}
+	raw := ""
+	count := 0
+	for _, entry := range execEnv {
+		if strings.HasPrefix(entry, envWakeOwner+"=") {
+			count++
+			raw = strings.TrimPrefix(entry, envWakeOwner+"=")
+		}
+	}
+	if count != 1 {
+		t.Fatalf("final %s count = %d, env=%v", envWakeOwner, count, execEnv)
+	}
+	var got wakeOwner
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("decode final owner: %v", err)
+	}
+	if got != owner {
+		t.Fatalf("final owner = %#v, want %#v", got, owner)
 	}
 }
 

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -20,6 +21,8 @@ const wakeReadyTimeout = 25 * time.Second
 const wakeProcessExitTimeout = 5 * time.Second
 
 var killWakeHelperProcess = func(proc *os.Process) error { return proc.Kill() }
+
+var coopExecProcess = syscall.Exec
 
 func runCoopExec(args []string) error {
 	// Split at "--" before flag parsing so agent flags aren't consumed.
@@ -236,7 +239,10 @@ func runCoopExec(args []string) error {
 	// On failed Exec, deferred kill cleans up the wake process.
 	var wakeProc *os.Process
 	var wakeWaiter *wakeProcessWaiter
+	var wakeChildCapability *authoritativeWakeChildCapability
 	var cleanupWakeReady func()
+	var earlyOwner *wakeOwner
+	baseEnv := unsetEnvVar(unsetEnvVar(os.Environ(), envWakeOwner), envWakePrivateStopFD)
 	if !*noWakeFlag {
 		amqBin, binErr := os.Executable()
 		if binErr != nil {
@@ -245,7 +251,12 @@ func runCoopExec(args []string) error {
 
 		var wakeOwner *wakeOwner
 		if wakeInjectVia != "" {
-			wakeOwner = currentWakeOwner()
+			captured, ownerErr := captureAuthoritativeCurrentWakeOwner()
+			if ownerErr != nil {
+				return ownerErr
+			}
+			earlyOwner = &captured
+			wakeOwner = earlyOwner
 		}
 		readyPath, cleanupReady, readyErr := newWakeReadyFile()
 		if readyErr != nil {
@@ -259,7 +270,7 @@ func runCoopExec(args []string) error {
 			wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, wakeInjectMode, wakeInjectVia, []string(wakeInjectArgFlags), readyPath)...)
 			// Set AM_ROOT in wake's env so the helper process resolves the same
 			// session root even if the parent shell inherited a different value.
-			wakeEnv, wakeEnvErr := wakeCommandEnv(os.Environ(), root, wakeOwner)
+			wakeEnv, wakeEnvErr := wakeCommandEnv(baseEnv, root, wakeOwner)
 			if wakeEnvErr != nil {
 				return wakeEnvErr
 			}
@@ -267,8 +278,27 @@ func runCoopExec(args []string) error {
 			wakeCmd.Stdin = os.Stdin
 			wakeCmd.Stdout = os.Stdout
 			wakeCmd.Stderr = os.Stderr
+			if earlyOwner != nil {
+				wakeChildCapability, err = configureAuthoritativeWakeChild(wakeCmd)
+				if err != nil {
+					var unsupported *wakeOwnerChildCapabilityUnsupportedError
+					if !errors.As(err, &unsupported) {
+						return fmt.Errorf("prepare owner-bound wake child: %w", err)
+					}
+					_ = writeStderr("warning: owner-bound wake child capability is unsupported; starting one ownerless inject-via wake\n")
+					earlyOwner = nil
+					wakeCmd.Env, wakeEnvErr = wakeCommandEnv(baseEnv, root, nil)
+					if wakeEnvErr != nil {
+						return wakeEnvErr
+					}
+				}
+			}
 
 			if err := wakeCmd.Start(); err != nil {
+				if wakeChildCapability != nil {
+					_ = wakeChildCapability.Close()
+					wakeChildCapability = nil
+				}
 				inspection := inspectWakeLock(root, agentHandle)
 				if err := handleCoopWakeSetupFailure(*requireWakeFlag, inspection, "start amq wake baseline helper", err); err != nil {
 					return err
@@ -276,8 +306,35 @@ func runCoopExec(args []string) error {
 			} else {
 				wakeProc = wakeCmd.Process
 				wakeWaiter = newWakeProcessWaiter(wakeProc)
-				if err := waitForWakeReadyWithWaiter(wakeWaiter, readyPath, root, agentHandle, wakeReadyTimeout); err != nil {
-					cleanupErr := terminateWakeHelperProcess(wakeProc, wakeWaiter, root, agentHandle)
+				if wakeChildCapability != nil {
+					if err := wakeChildCapability.Bind(wakeProc); err != nil {
+						stopErr := wakeChildCapability.Stop()
+						if stopErr == nil {
+							_ = wakeWaiter.waitForExit(wakeProcessExitTimeout)
+						}
+						_ = wakeChildCapability.Close()
+						if stopErr != nil {
+							return fmt.Errorf("bind stable owner-bound wake child: %w (stable cleanup unavailable: %v)", err, stopErr)
+						}
+						return fmt.Errorf("bind stable owner-bound wake child: %w", err)
+					}
+				}
+				if err := waitForWakeReadyWithOwner(
+					wakeWaiter,
+					readyPath,
+					root,
+					agentHandle,
+					earlyOwner,
+					wakeReadyTimeout,
+				); err != nil {
+					cleanupErr := cleanupStartedWakeHelper(
+						wakeProc,
+						wakeWaiter,
+						wakeChildCapability,
+						earlyOwner,
+						root,
+						agentHandle,
+					)
 					inspection := inspectWakeLock(root, agentHandle)
 					otherLiveWake := confirmedLiveWake(inspection) && inspection.PID != wakeProc.Pid
 					if *requireWakeFlag || otherLiveWake {
@@ -293,6 +350,7 @@ func runCoopExec(args []string) error {
 					}
 					wakeProc = nil
 					wakeWaiter = nil
+					wakeChildCapability = nil
 				} else {
 					_ = writeStderr("%s\n", wakeReadyMessage(root, agentHandle, wakeProc.Pid))
 				}
@@ -303,7 +361,7 @@ func runCoopExec(args []string) error {
 	// A named/default or session-shaped explicit root pins an identity
 	// independent of AM_ROOT. A custom sessionless --root clears inherited pins.
 	sessionIdentity := coopSessionIdentity(root, *sessionFlag, *rootFlag)
-	env := buildCoopExecEnvironment(os.Environ(), root, agentHandle, sessionIdentity)
+	env := buildCoopExecEnvironment(baseEnv, root, agentHandle, sessionIdentity)
 
 	// Build argv: command name + agent args.
 	argv := append([]string{cmdName}, agentArgs...)
@@ -313,9 +371,30 @@ func runCoopExec(args []string) error {
 	if cleanupWakeReady != nil {
 		cleanupWakeReady()
 	}
-	execErr := syscall.Exec(binaryPath, argv, env)
+	finalOwner, ownerErr := captureAuthoritativeCurrentWakeOwner()
+	if ownerErr != nil {
+		if wakeProc != nil {
+			_ = cleanupStartedWakeHelper(wakeProc, wakeWaiter, wakeChildCapability, earlyOwner, root, agentHandle)
+		}
+		return ownerErr
+	}
+	if earlyOwner != nil && *earlyOwner != finalOwner {
+		if wakeProc != nil {
+			_ = cleanupStartedWakeHelper(wakeProc, wakeWaiter, wakeChildCapability, earlyOwner, root, agentHandle)
+		}
+		return fmt.Errorf("coop exec process identity changed after owner-bound wake start")
+	}
+	encodedOwner, ownerErr := encodeWakeOwnerEnv(finalOwner)
+	if ownerErr != nil {
+		if wakeProc != nil {
+			_ = cleanupStartedWakeHelper(wakeProc, wakeWaiter, wakeChildCapability, earlyOwner, root, agentHandle)
+		}
+		return fmt.Errorf("encode final wake owner: %w", ownerErr)
+	}
+	env = setEnvVar(unsetEnvVar(env, envWakeOwner), envWakeOwner, encodedOwner)
+	execErr := coopExecProcess(binaryPath, argv, env)
 	if wakeProc != nil {
-		_ = terminateWakeHelperProcess(wakeProc, wakeWaiter, root, agentHandle)
+		_ = cleanupStartedWakeHelper(wakeProc, wakeWaiter, wakeChildCapability, earlyOwner, root, agentHandle)
 	}
 	return execErr
 }
@@ -397,6 +476,17 @@ func waitForWakeReady(proc *os.Process, readyPath, root, me string, timeout time
 }
 
 func waitForWakeReadyWithWaiter(waiter *wakeProcessWaiter, readyPath, root, me string, timeout time.Duration) error {
+	return waitForWakeReadyWithOwner(waiter, readyPath, root, me, nil, timeout)
+}
+
+func waitForWakeReadyWithOwner(
+	waiter *wakeProcessWaiter,
+	readyPath string,
+	root string,
+	me string,
+	requestedOwner *wakeOwner,
+	timeout time.Duration,
+) error {
 	if waiter == nil {
 		return fmt.Errorf("amq wake process waiter missing")
 	}
@@ -407,7 +497,7 @@ func waitForWakeReadyWithWaiter(waiter *wakeProcessWaiter, readyPath, root, me s
 	defer ticker.Stop()
 
 	for {
-		if ready, err := validateWakeReadyFileAgainstCurrent(root, me, readyPath); err != nil {
+		if ready, err := validateWakeReadyFileAgainstOwner(root, me, readyPath, requestedOwner); err != nil {
 			return fmt.Errorf("validate wake readiness: %w", err)
 		} else if ready {
 			return nil
@@ -415,7 +505,7 @@ func waitForWakeReadyWithWaiter(waiter *wakeProcessWaiter, readyPath, root, me s
 
 		select {
 		case <-waiter.done:
-			if ready, readyErr := validateWakeReadyFileAgainstCurrent(root, me, readyPath); readyErr != nil {
+			if ready, readyErr := validateWakeReadyFileAgainstOwner(root, me, readyPath, requestedOwner); readyErr != nil {
 				return fmt.Errorf("validate wake readiness: %w", readyErr)
 			} else if ready {
 				return nil
@@ -445,6 +535,97 @@ func terminateWakeHelperProcess(proc *os.Process, waiter *wakeProcessWaiter, roo
 		return cleanupTerminatedWakeLock(expected)
 	}
 	return cleanupTerminatedWakeLockForPID(root, me, proc.Pid)
+}
+
+func cleanupStartedWakeHelper(
+	proc *os.Process,
+	waiter *wakeProcessWaiter,
+	capability *authoritativeWakeChildCapability,
+	owner *wakeOwner,
+	root string,
+	me string,
+) error {
+	if owner == nil {
+		return terminateWakeHelperProcess(proc, waiter, root, me)
+	}
+	return terminateAuthoritativeWakeHelperProcess(proc, waiter, capability, root, me, *owner)
+}
+
+func terminateAuthoritativeWakeHelperProcess(
+	proc *os.Process,
+	waiter *wakeProcessWaiter,
+	capability *authoritativeWakeChildCapability,
+	root string,
+	me string,
+	owner wakeOwner,
+) error {
+	if proc == nil || waiter == nil {
+		if capability != nil {
+			_ = capability.Close()
+		}
+		return nil
+	}
+	if capability == nil {
+		return fmt.Errorf("stable owner-bound wake child capability is missing")
+	}
+	if err := capability.Stop(); err != nil {
+		_ = capability.Close()
+		return err
+	}
+	if err := waiter.waitForExit(wakeProcessExitTimeout); err != nil {
+		_ = capability.Close()
+		return err
+	}
+	if err := capability.Close(); err != nil {
+		return err
+	}
+	current := inspectWakeLock(root, me)
+	switch classifyPersistedWakeClaim(current) {
+	case wakeClaimAbsent:
+		return nil
+	case wakeClaimAuthoritative:
+		return rollbackAuthoritativeWakeClaim(root, me, owner)
+	case wakeClaimGeneric:
+		if current.PID != proc.Pid {
+			return fmt.Errorf("ownerless fallback wake generation changed before cleanup")
+		}
+		return cleanupTerminatedWakeLock(current)
+	default:
+		return fmt.Errorf("wake claim is unverified after exact helper stop; preserving it")
+	}
+}
+
+func rollbackAuthoritativeWakeClaim(root, me string, owner wakeOwner) error {
+	currentOwner, err := captureAuthoritativeCurrentWakeOwner()
+	if err != nil {
+		return err
+	}
+	if currentOwner != owner {
+		return fmt.Errorf("current process is not the exact owner authorized for wake rollback")
+	}
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = agentDir.Close() }()
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !current.Exists {
+			return nil
+		}
+		if classifyPersistedWakeClaim(current) != wakeClaimAuthoritative ||
+			!sameWakeOwner(current.Lock.Owner, &owner) {
+			return fmt.Errorf("wake claim changed before exact owner rollback")
+		}
+		target, err := validateAuthoritativeWakeClaimPairAt(dirfd, agentDir, current)
+		if err != nil {
+			return err
+		}
+		if current.Status != wakeLockStale {
+			return fmt.Errorf("owner-bound wake is not conclusively absent after helper stop")
+		}
+		return removeAuthoritativeWakeClaimAt(dirfd, agentDir, current, &target)
+	})
 }
 
 func cleanupTerminatedWakeLock(expected wakeLockInspection) error {

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -293,6 +293,10 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 			PID:    inspection.PID,
 			Reason: inspection.Reason,
 		}
+		ownerBound := classifyWakeClaimForGenericTransition(inspection) == wakeClaimAuthoritative
+		if ownerBound {
+			lock.Fix = wakeRecoverOwnerCommand(root, agent)
+		}
 		if isLiveRawOrphan(inspection) {
 			lock.Status = "live-raw-orphan"
 			lock.Reason = "live raw wake orphan; stop the owning terminal or launchd supervisor"
@@ -310,6 +314,10 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 			}
 		}
 		if inspection.Status == wakeLockStale {
+			if ownerBound {
+				locks = append(locks, lock)
+				continue
+			}
 			lock.Fix = fixWakeLocksCommand
 			if lock.TargetPresent && lock.TargetReason == "" && validateWakeLockRepairable(inspection) == nil {
 				lock.RepairAvailable = true
@@ -373,6 +381,10 @@ func validateWakeLockAgent(root, agent string) error {
 
 func wakeRepairCommand(root, agent string) string {
 	return fmt.Sprintf("amq wake repair --root %s --me %s", shellQuoteArg(root), shellQuoteArg(agent))
+}
+
+func wakeRecoverOwnerCommand(root, agent string) string {
+	return fmt.Sprintf("amq wake recover-owner --root %s --me %s", shellQuoteArg(root), shellQuoteArg(agent))
 }
 
 func shellQuoteArg(value string) string {

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -173,6 +173,58 @@ func TestRunOpsChecksDoesNotAdvertiseRepairForTamperedStaleLock(t *testing.T) {
 	}
 }
 
+func TestRunOpsChecksDirectsOwnerClaimToRecoverOwner(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "owner-doctor-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &owner
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Generation:   "owner-doctor-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockExactForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid}
+	})
+
+	result := runOpsChecks(root, "test", true)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) {
+		t.Fatalf("owner wake status = %q, want stale", got.Status)
+	}
+	if got.Fix != wakeRecoverOwnerCommand(root, "codex") {
+		t.Fatalf("owner wake fix = %q, want %q", got.Fix, wakeRecoverOwnerCommand(root, "codex"))
+	}
+	if got.Removed {
+		t.Fatal("doctor --fix removed an owner-bound wake claim")
+	}
+	if _, err := os.Lstat(lockPath); err != nil {
+		t.Fatalf("owner-bound wake claim was not preserved: %v", err)
+	}
+}
+
 func TestRunOpsChecksDoesNotAdvertiseRepairForUnknownBootIdentity(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -69,6 +69,7 @@ func init() {
 			Handler: runWake,
 			Children: []CommandInfo{
 				{Name: "repair", Summary: "Restart a proven-stale wake from a saved inject-via target", Handler: runWake},
+				{Name: "recover-owner", Summary: "Recover an exact owner-bound wake claim", Handler: runWake},
 				{Name: "retire", Summary: "Stop an exact managed inject-via wake", Handler: runWake},
 			},
 		},

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -84,6 +84,7 @@ func TestChildNames(t *testing.T) {
 	}{
 		{name: "presence", want: []string{"set", "list"}},
 		{name: "dlq", want: []string{"list", "read", "retry", "purge"}},
+		{name: "wake", want: []string{"repair", "recover-owner", "retire"}},
 		{name: "coop", want: []string{"init", "exec"}},
 		{name: "swarm", want: []string{"list", "join", "leave", "tasks", "claim", "complete", "fail", "block", "bridge"}},
 		{name: "receipts", want: []string{"list", "wait"}},
@@ -176,7 +177,7 @@ func TestGroupUsageLinesPresence(t *testing.T) {
 	}
 }
 
-func TestGroupUsageLinesWakeIncludesRetire(t *testing.T) {
+func TestGroupUsageLinesWakeIncludesLifecycleCommands(t *testing.T) {
 	wake := findCommand("wake")
 	if wake == nil {
 		t.Fatal("findCommand(wake) = nil")
@@ -186,10 +187,13 @@ func TestGroupUsageLinesWakeIncludesRetire(t *testing.T) {
 	if err != nil {
 		t.Fatalf("groupUsageLines(wake): %v", err)
 	}
-	if !containsLine(lines, "repair  Restart a proven-stale wake from a saved inject-via target") {
+	if !containsLine(lines, "repair         Restart a proven-stale wake from a saved inject-via target") {
 		t.Fatal("groupUsageLines(wake) missing repair subcommand")
 	}
-	if !containsLine(lines, "retire  Stop an exact managed inject-via wake") {
+	if !containsLine(lines, "recover-owner  Recover an exact owner-bound wake claim") {
+		t.Fatal("groupUsageLines(wake) missing recover-owner subcommand")
+	}
+	if !containsLine(lines, "retire         Stop an exact managed inject-via wake") {
 		t.Fatal("groupUsageLines(wake) missing retire subcommand")
 	}
 }

--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -21,6 +22,15 @@ import (
 )
 
 var darwinSocketCWDMu sync.Mutex
+
+// XUCRED_VERSION from Darwin's <sys/ucred.h>.
+const darwinXUCredVersion uint32 = 0
+
+type wakeControlOwnerRequest struct {
+	Generation string     `json:"generation"`
+	Owner      *wakeOwner `json:"owner,omitempty"`
+	Rollback   bool       `json:"rollback,omitempty"`
+}
 
 func wakeControlSocketPath(root, me, generation string) string {
 	sum := sha256.Sum256([]byte(canonicalWakeRoot(root) + "\x00" + me + "\x00" + generation))
@@ -124,6 +134,10 @@ func darwinControlSocketName(agentDir *wakeAgentDir, path string) (string, error
 	return name, nil
 }
 
+func darwinControlSocketBasenameForCleanup(agentDir *wakeAgentDir, path string) (string, error) {
+	return darwinControlSocketName(agentDir, path)
+}
+
 func removeDarwinControlSocketAt(dirfd int, name string) error {
 	err := unix.Unlinkat(dirfd, name, 0)
 	if err == nil || err == unix.ENOENT {
@@ -174,64 +188,6 @@ func secureDarwinControlSocketAt(dirfd int, name, path string) error {
 	return nil
 }
 
-func readWakeLockFileAt(dirfd int, path string) ([]byte, os.FileInfo, error) {
-	open := func() (*os.File, error) {
-		fd, err := unix.Openat(dirfd, ".wake.lock", unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
-		if err != nil {
-			return nil, err
-		}
-		return os.NewFile(uintptr(fd), path), nil
-	}
-	file, err := open()
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() { _ = file.Close() }()
-	info, err := file.Stat()
-	if err != nil {
-		return nil, nil, fmt.Errorf("stat wake lock: %w", err)
-	}
-	if err := validateWakeLockFile(path, info); err != nil {
-		return nil, nil, err
-	}
-	data, err := readWakeMetadata(file, "wake lock", path)
-	if err != nil {
-		return nil, nil, err
-	}
-	pathFile, err := open()
-	if err != nil {
-		return nil, nil, err
-	}
-	pathInfo, statErr := pathFile.Stat()
-	_ = pathFile.Close()
-	if statErr != nil {
-		return nil, nil, fmt.Errorf("re-stat wake lock: %w", statErr)
-	}
-	if err := validateWakeLockFile(path, pathInfo); err != nil {
-		return nil, nil, err
-	}
-	if !sameWakeFileIdentity(info, pathInfo) {
-		return nil, nil, fmt.Errorf("wake lock %s changed while opening", path)
-	}
-	return data, info, nil
-}
-
-func inspectWakeLockAt(dirfd int, agentDir *wakeAgentDir, root, me string) wakeLockInspection {
-	path := filepath.Join(agentDir.path, ".wake.lock")
-	return inspectWakeLockWithReader(root, me, path, func() ([]byte, os.FileInfo, error) {
-		return readWakeLockFileAt(dirfd, path)
-	})
-}
-
-func removeWakeLockIfUnchangedAt(dirfd int, agentDir *wakeAgentDir, inspection wakeLockInspection) error {
-	path := filepath.Join(agentDir.path, ".wake.lock")
-	return removeWakeLockIfUnchangedGuardedWithIO(
-		inspection,
-		func() ([]byte, os.FileInfo, error) { return readWakeLockFileAt(dirfd, path) },
-		func() error { return unix.Unlinkat(dirfd, ".wake.lock", 0) },
-	)
-}
-
 func darwinPeerEUID(conn *net.UnixConn) (uint32, error) {
 	raw, err := conn.SyscallConn()
 	if err != nil {
@@ -252,7 +208,209 @@ func darwinPeerEUID(conn *net.UnixConn) (uint32, error) {
 	if sockErr != nil {
 		return 0, sockErr
 	}
+	if cred.Version != darwinXUCredVersion {
+		return 0, fmt.Errorf("unsupported wake control peer credential version %d", cred.Version)
+	}
 	return cred.Uid, nil
+}
+
+func darwinPeerPID(conn *net.UnixConn) (int, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var pid int32
+	var sockErr error
+	err = raw.Control(func(fd uintptr) {
+		length := uint32(unsafe.Sizeof(pid))
+		_, _, errno := syscall.Syscall6(
+			syscall.SYS_GETSOCKOPT,
+			fd,
+			uintptr(unix.SOL_LOCAL),
+			uintptr(unix.LOCAL_PEERPID),
+			uintptr(unsafe.Pointer(&pid)),
+			uintptr(unsafe.Pointer(&length)),
+			0,
+		)
+		if errno != 0 {
+			sockErr = errno
+		}
+	})
+	if err != nil {
+		return 0, err
+	}
+	if sockErr != nil {
+		return 0, sockErr
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid wake control peer pid %d", pid)
+	}
+	return int(pid), nil
+}
+
+func captureDarwinControlPeerOwner(pid int) (wakeOwner, error) {
+	first := inspectWakeProcess(pid)
+	firstSessionID, firstSessionErr := getWakeProcessSID(pid)
+	if !first.Running || first.StartToken == "" || first.BootID == "" || firstSessionErr != nil {
+		return wakeOwner{}, fmt.Errorf("wake control peer identity is incomplete")
+	}
+	peer := wakeOwner{
+		PID:          pid,
+		ProcessStart: first.StartToken,
+		BootID:       first.BootID,
+		SessionID:    firstSessionID,
+	}
+	if err := validateAuthoritativeWakeOwner(peer); err != nil {
+		return wakeOwner{}, err
+	}
+	second := inspectWakeProcess(pid)
+	secondSessionID, secondSessionErr := getWakeProcessSID(pid)
+	state, reason := classifyStableAuthoritativeWakeOwner(
+		peer,
+		first, firstSessionID, firstSessionErr,
+		second, secondSessionID, secondSessionErr,
+	)
+	if state != wakeOwnerSame {
+		return wakeOwner{}, fmt.Errorf("wake control peer identity is %s: %s", state, reason)
+	}
+	return peer, nil
+}
+
+func authorizeDarwinOwnerControlAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	expected wakeLock,
+	request wakeControlOwnerRequest,
+	peerPID int,
+	peerUID uint32,
+) (wakeLockInspection, *wakeTarget, error) {
+	if peerUID != uint32(os.Geteuid()) {
+		return wakeLockInspection{}, nil, fmt.Errorf("wake control peer uid is not authorized")
+	}
+	current := inspectWakeLockAt(dirfd, agentDir, root, me)
+	if !current.Exists ||
+		current.Lock.Generation != expected.Generation ||
+		current.Lock.ControlSocket != expected.ControlSocket ||
+		request.Generation != expected.Generation {
+		return wakeLockInspection{}, nil, fmt.Errorf("authoritative wake generation changed")
+	}
+	if classifyPersistedWakeClaim(current) != wakeClaimAuthoritative {
+		return wakeLockInspection{}, nil, fmt.Errorf("wake control target is not an authoritative owner claim")
+	}
+	target, err := authoritativeWakeRecoveryTargetAt(dirfd, agentDir, current)
+	if err != nil {
+		return wakeLockInspection{}, nil, err
+	}
+	observation, err := observeAuthoritativeWakeOwner(*current.Lock.Owner)
+	defer func() { _ = observation.Close() }()
+	if err != nil {
+		return wakeLockInspection{}, nil, err
+	}
+	switch observation.State {
+	case wakeOwnerDead:
+		return current, target, nil
+	case wakeOwnerSame:
+		if request.Rollback {
+			peer, err := captureDarwinControlPeerOwner(peerPID)
+			if err == nil && sameWakeOwner(&peer, current.Lock.Owner) {
+				return current, target, nil
+			}
+			return wakeLockInspection{}, nil, fmt.Errorf("wake control rollback peer is not the exact owner")
+		}
+		if request.Owner == nil {
+			return wakeLockInspection{}, nil, fmt.Errorf("wake control owner token is missing")
+		}
+		if err := validateAuthoritativeWakeOwner(*request.Owner); err != nil {
+			return wakeLockInspection{}, nil, fmt.Errorf("wake control owner token is invalid: %w", err)
+		}
+		if !sameWakeOwner(request.Owner, current.Lock.Owner) {
+			return wakeLockInspection{}, nil, fmt.Errorf("wake control owner token does not match the claim")
+		}
+		peerSession, err := getWakeProcessSID(peerPID)
+		if err != nil {
+			return wakeLockInspection{}, nil, fmt.Errorf("wake control peer session unavailable: %w", err)
+		}
+		if peerSession != current.Lock.Owner.SessionID {
+			return wakeLockInspection{}, nil, fmt.Errorf(
+				"wake control peer session %d does not match owner session %d",
+				peerSession,
+				current.Lock.Owner.SessionID,
+			)
+		}
+		return current, target, nil
+	default:
+		return wakeLockInspection{}, nil, fmt.Errorf("wake control owner is unknown: %s", observation.Reason)
+	}
+}
+
+func handleDarwinOwnerControl(
+	conn *net.UnixConn,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	lock wakeLock,
+	request wakeControlOwnerRequest,
+	peerPID int,
+	peerUID uint32,
+	stopRequest chan<- struct{},
+	loopStopped <-chan struct{},
+) {
+	authorized := false
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		_, _, err := authorizeDarwinOwnerControlAt(
+			dirfd,
+			agentDir,
+			root,
+			me,
+			lock,
+			request,
+			peerPID,
+			peerUID,
+		)
+		if err != nil {
+			return err
+		}
+		authorized = true
+		return nil
+	})
+	if err != nil || !authorized {
+		return
+	}
+
+	_ = conn.SetDeadline(time.Time{})
+	select {
+	case stopRequest <- struct{}{}:
+	default:
+	}
+	<-loopStopped
+
+	removed := false
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current, target, err := authorizeDarwinOwnerControlAt(
+			dirfd,
+			agentDir,
+			root,
+			me,
+			lock,
+			request,
+			peerPID,
+			peerUID,
+		)
+		if err != nil {
+			return err
+		}
+		if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, current, target); err != nil {
+			return err
+		}
+		removed = true
+		return nil
+	})
+	if err != nil || !removed {
+		return
+	}
+	_, _ = conn.Write([]byte("ACK\n"))
 }
 
 func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan struct{}, func(), error) {
@@ -312,8 +470,34 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 				if err != nil || uid != uint32(os.Geteuid()) {
 					return
 				}
-				token, err := bufio.NewReader(conn).ReadString('\n')
-				if err != nil || strings.TrimSpace(token) != lock.Generation {
+				line, err := bufio.NewReader(conn).ReadString('\n')
+				if err != nil {
+					return
+				}
+				if lock.WakeMode == wakeOwnerWakeMode {
+					var request wakeControlOwnerRequest
+					if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &request); err != nil {
+						return
+					}
+					peerPID, err := darwinPeerPID(conn)
+					if err != nil {
+						return
+					}
+					handleDarwinOwnerControl(
+						conn,
+						agentDir,
+						root,
+						me,
+						lock,
+						request,
+						peerPID,
+						uid,
+						stopRequest,
+						loopStopped,
+					)
+					return
+				}
+				if strings.TrimSpace(line) != lock.Generation {
 					return
 				}
 				accepted := false
@@ -321,6 +505,9 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 					current := inspectWakeLockAt(dirfd, agentDir, root, me)
 					if !current.Exists || current.Lock.Generation != lock.Generation || current.Lock.ControlSocket != path {
 						return nil
+					}
+					if err := validateWakeLockOwnerlessMutation(current); err != nil {
+						return err
 					}
 					accepted = true
 					return nil
@@ -347,6 +534,9 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 					}
 					if current.Lock.ControlSocket != path {
 						return nil
+					}
+					if err := validateWakeLockOwnerlessMutation(current); err != nil {
+						return err
 					}
 					if err := removeWakeLockIfUnchangedAt(dirfd, agentDir, current); err != nil {
 						return err
@@ -408,6 +598,60 @@ func cooperativeStopInjectVia(i wakeLockInspection) (bool, error) {
 	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		cur := inspectWakeLockAt(dirfd, agentDir, i.Root, i.Agent)
 		gone = !cur.Exists || cur.Lock.Generation != i.Lock.Generation
+		return nil
+	})
+	return gone, err
+}
+
+func cooperativeStopAuthoritativeWake(
+	i wakeLockInspection,
+	auth wakeOwnerReleaseAuthorization,
+) (bool, error) {
+	if i.Lock.WakeMode != wakeOwnerWakeMode ||
+		i.Lock.ControlSocket == "" ||
+		i.Lock.Generation == "" ||
+		i.Lock.Owner == nil {
+		return false, fmt.Errorf("authoritative wake has no cooperative control endpoint")
+	}
+	request := wakeControlOwnerRequest{
+		Generation: i.Lock.Generation,
+		Rollback:   auth.Rollback,
+	}
+	if auth.Token != nil {
+		token := *auth.Token
+		request.Owner = &token
+	}
+	data, err := json.Marshal(request)
+	if err != nil {
+		return false, fmt.Errorf("marshal authoritative wake stop request: %w", err)
+	}
+	agentDir, err := openWakeAgentDir(i.Root, i.Agent)
+	if err != nil {
+		return false, fmt.Errorf("cooperative authoritative wake stop unavailable: %w", err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	name, err := darwinControlSocketName(agentDir, i.Lock.ControlSocket)
+	if err != nil {
+		return false, fmt.Errorf("cooperative authoritative wake stop unavailable: %w", err)
+	}
+	conn, err := dialDarwinUnixAt(agentDir, name, 2*time.Second)
+	if err != nil {
+		return false, fmt.Errorf("cooperative authoritative wake stop unavailable: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err := conn.Write(append(data, '\n')); err != nil {
+		return false, err
+	}
+	_ = conn.SetDeadline(time.Time{})
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil || strings.TrimSpace(line) != "ACK" {
+		return false, fmt.Errorf("cooperative authoritative wake stop refused")
+	}
+	gone := false
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, i.Root, i.Agent)
+		gone = !current.Exists || current.Lock.Generation != i.Lock.Generation
 		return nil
 	})
 	return gone, err

--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -37,6 +37,15 @@ func wakeControlSocketPath(root, me, generation string) string {
 	return filepath.Join(fsq.AgentBase(root, me), ".w."+hex.EncodeToString(sum[:8]))
 }
 
+func removeWakeLockIfUnchangedAt(dirfd int, agentDir *wakeAgentDir, inspection wakeLockInspection) error {
+	path := filepath.Join(agentDir.path, ".wake.lock")
+	return removeWakeLockIfUnchangedGuardedWithIO(
+		inspection,
+		func() ([]byte, os.FileInfo, error) { return readWakeLockFileAt(dirfd, path) },
+		func() error { return unix.Unlinkat(dirfd, ".wake.lock", 0) },
+	)
+}
+
 func withDarwinSocketDirFD(dirfd int, fn func() error) error {
 	darwinSocketCWDMu.Lock()
 	defer darwinSocketCWDMu.Unlock()

--- a/internal/cli/wake_control_darwin_test.go
+++ b/internal/cli/wake_control_darwin_test.go
@@ -4,8 +4,10 @@ package cli
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -24,6 +26,162 @@ func testDarwinControlLock(t *testing.T) (string, string, wakeLock) {
 	lock.ControlSocket = wakeControlSocketPath(root, agent, lock.Generation)
 	writeWakeLockForTest(t, root, agent, lock)
 	return root, agent, lock
+}
+
+func testDarwinOwnerControlLock(
+	t *testing.T,
+) (string, string, wakeOwner, wakeLock, *wakeOwnerIdentityState, *int) {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "darwin-owner-control-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, agent, injector, nil)
+	target.Owner = &owner
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          os.Getpid(),
+		TTY:          "unknown",
+		Root:         canonicalWakeRoot(root),
+		Agent:        agent,
+		Started:      "2026-07-23T00:00:00Z",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", agent, "--inject-via", injector},
+		Generation:   "0123456789abcdef0123456789abcdef",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lock.ControlSocket = wakeControlSocketPath(root, agent, lock.Generation)
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, agent, target, lock)
+	}); err != nil {
+		_ = agentDir.Close()
+		t.Fatal(err)
+	}
+	_ = agentDir.Close()
+
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != lock.PID {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: lock.ProcessStart,
+			BootID:     lock.BootID,
+			Executable: lock.Executable,
+			Args:       lock.Args,
+		}
+	})
+	ownerState := wakeOwnerSame
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("observed owner = %#v, want %#v", got, owner)
+		}
+		return wakeOwnerObservation{State: ownerState, Reason: "test owner evidence"}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+	peerSession := owner.SessionID
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		if pid != os.Getpid() {
+			t.Fatalf("peer session pid = %d, want %d", pid, os.Getpid())
+		}
+		return peerSession, nil
+	})
+	return root, agent, owner, lock, &ownerState, &peerSession
+}
+
+func TestDarwinStableOwnerStopTreatsDifferentLivePIDOccupantAsAbsent(t *testing.T) {
+	root, agent, _, lock, _, _ := testDarwinOwnerControlLock(t)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != lock.PID {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "78901",
+			BootID:     lock.BootID,
+			Executable: lock.Executable,
+			Args:       lock.Args,
+		}
+	})
+
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		expected := inspectWakeLockAt(dirfd, agentDir, root, agent)
+		if expected.Status != wakeLockStale {
+			t.Fatalf("reused wake PID status = %s, want stale", expected.Status)
+		}
+		capability, err := prepareAuthoritativeWakeStopPlatform(dirfd, agentDir, expected)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = capability.Close() }()
+		if !capability.Absent {
+			t.Fatal("different live PID occupant was treated as the recorded wake")
+		}
+		return capability.Stop(wakeOwnerReleaseAuthorization{})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sendDarwinOwnerControlRequest(
+	t *testing.T,
+	root string,
+	agent string,
+	lock wakeLock,
+	request wakeControlOwnerRequest,
+) string {
+	t.Helper()
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	name, err := darwinControlSocketName(agentDir, lock.ControlSocket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := dialDarwinUnixAt(agentDir, name, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	data, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.SetDeadline(time.Now().Add(time.Second))
+	if _, err := conn.Write(append(data, '\n')); err != nil {
+		t.Fatal(err)
+	}
+	line, _ := bufio.NewReader(conn).ReadString('\n')
+	return strings.TrimSpace(line)
 }
 
 func TestDarwinCooperativeStopACKAfterLockRemoval(t *testing.T) {
@@ -209,6 +367,191 @@ func TestDarwinControlTokenMismatchRefused(t *testing.T) {
 	}
 	if !inspectWakeLock(root, agent).Exists {
 		t.Fatal("mismatched token removed lock")
+	}
+}
+
+func TestDarwinOwnerControlRefusesGenerationOnlyAndWrongSessionBeforeQuiesce(t *testing.T) {
+	t.Run("generation only", func(t *testing.T) {
+		root, agent, _, lock, _, _ := testDarwinOwnerControlLock(t)
+		cleanup, stopped, _, err := startWakeControlListener(root, agent, lock)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if got := sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+			Generation: lock.Generation,
+		}); got == "ACK" {
+			t.Fatal("generation-only owner request was acknowledged")
+		}
+		select {
+		case <-stopped:
+			t.Fatal("generation-only owner request quiesced notification work")
+		default:
+		}
+		if !inspectWakeLock(root, agent).Exists {
+			t.Fatal("generation-only owner request removed claim")
+		}
+	})
+
+	t.Run("wrong peer session", func(t *testing.T) {
+		root, agent, owner, lock, _, peerSession := testDarwinOwnerControlLock(t)
+		*peerSession = owner.SessionID + 1
+		cleanup, stopped, _, err := startWakeControlListener(root, agent, lock)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if got := sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+			Generation: lock.Generation,
+			Owner:      &owner,
+		}); got == "ACK" {
+			t.Fatal("wrong-session owner request was acknowledged")
+		}
+		select {
+		case <-stopped:
+			t.Fatal("wrong-session owner request quiesced notification work")
+		default:
+		}
+		if !inspectWakeLock(root, agent).Exists {
+			t.Fatal("wrong-session owner request removed claim")
+		}
+	})
+}
+
+func TestDarwinOwnerControlAuthenticatedReleaseACKsAfterExactClaimRemoval(t *testing.T) {
+	root, agent, owner, lock, _, _ := testDarwinOwnerControlLock(t)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	result := make(chan string, 1)
+	go func() {
+		result <- sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+			Generation: lock.Generation,
+			Owner:      &owner,
+		})
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("authenticated owner request did not quiesce notification work")
+	}
+	if !inspectWakeLock(root, agent).Exists {
+		t.Fatal("owner claim was removed before notification work quiesced")
+	}
+
+	markStopped()
+	select {
+	case got := <-result:
+		if got != "ACK" {
+			t.Fatalf("authenticated owner release response = %q, want ACK", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("authenticated owner release did not acknowledge")
+	}
+	if inspectWakeLock(root, agent).Exists {
+		t.Fatal("authenticated owner release left the lock")
+	}
+	if _, exists, err := readWakeTarget(root, agent); err != nil || exists {
+		t.Fatalf("authenticated owner release target exists=%v err=%v", exists, err)
+	}
+}
+
+func TestDarwinOwnerControlReauthorizesAfterQuiesce(t *testing.T) {
+	root, agent, owner, lock, ownerState, _ := testDarwinOwnerControlLock(t)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	result := make(chan string, 1)
+	go func() {
+		result <- sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+			Generation: lock.Generation,
+			Owner:      &owner,
+		})
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("authorized owner request did not quiesce notification work")
+	}
+	if !inspectWakeLock(root, agent).Exists {
+		t.Fatal("owner claim was removed before loop quiesced")
+	}
+	*ownerState = wakeOwnerUnknown
+	markStopped()
+	select {
+	case got := <-result:
+		if got == "ACK" {
+			t.Fatal("pre-quiesce authorization survived changed post-quiesce owner evidence")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("owner control request did not finish after post-quiesce refusal")
+	}
+	if !inspectWakeLock(root, agent).Exists {
+		t.Fatal("post-quiesce reauthorization failure removed owner claim")
+	}
+}
+
+func TestDarwinOwnerWakeChildStopsThroughInheritedPrivateFD(t *testing.T) {
+	cmd := exec.Command("sh", "-c", `eval "dd bs=1 count=1 <&$AMQ_WAKE_PRIVATE_STOP_FD >/dev/null 2>&1"`)
+	cmd.Env = os.Environ()
+	capability, err := configureAuthoritativeWakeChild(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = capability.Close()
+		t.Fatal(err)
+	}
+	if err := capability.Bind(cmd.Process); err != nil {
+		_ = capability.Close()
+		t.Fatal(err)
+	}
+	waiter := newWakeProcessWaiter(cmd.Process)
+	if err := capability.Stop(); err != nil {
+		_ = capability.Close()
+		t.Fatal(err)
+	}
+	if err := waiter.waitForExit(2 * time.Second); err != nil {
+		_ = capability.Close()
+		t.Fatalf("private-stop child did not exit: %v", err)
+	}
+	if err := capability.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDarwinOwnerWakeChildAlreadyExitedStillClosesStableCapability(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 0")
+	cmd.Env = os.Environ()
+	capability, err := configureAuthoritativeWakeChild(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = capability.Close()
+		t.Fatal(err)
+	}
+	if err := capability.Bind(cmd.Process); err != nil {
+		_ = capability.Close()
+		t.Fatal(err)
+	}
+	waiter := newWakeProcessWaiter(cmd.Process)
+	if err := waiter.waitForExit(2 * time.Second); err != nil {
+		_ = capability.Close()
+		t.Fatal(err)
+	}
+	if err := capability.Stop(); err != nil {
+		_ = capability.Close()
+		t.Fatalf("already-exited child stop: %v", err)
+	}
+	if err := capability.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/cli/wake_control_linux.go
+++ b/internal/cli/wake_control_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package cli
+
+func darwinControlSocketBasenameForCleanup(*wakeAgentDir, string) (string, error) {
+	return "", nil
+}

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -15,21 +15,29 @@ import (
 
 // wakeLock represents the lock file content for wake process deduplication.
 type wakeLock struct {
-	PID           int      `json:"pid"`
-	TTY           string   `json:"tty"`
-	Root          string   `json:"root"`                     // Absolute path to disambiguate relative AM_ROOT
-	Agent         string   `json:"agent,omitempty"`          // Agent handle that owns this lock
-	Hostname      string   `json:"hostname,omitempty"`       // Host that created the lock
-	Started       string   `json:"started"`                  // Wall-clock diagnostic timestamp
-	ProcessStart  string   `json:"process_start,omitempty"`  // Kernel process start token, guards PID reuse
-	BootID        string   `json:"boot_id,omitempty"`        // Boot identity paired with ProcessStart when available
-	Executable    string   `json:"executable,omitempty"`     // Diagnostic process executable basename/path
-	Args          []string `json:"args,omitempty"`           // Diagnostic argv when available
-	WakeMode      string   `json:"wake_mode,omitempty"`      // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
-	TargetDigest  string   `json:"target_digest,omitempty"`  // Binds .wake.target to this lock instance
-	Generation    string   `json:"generation,omitempty"`     // Random nonce binding readiness and exact cleanup to this instance
-	ControlSocket string   `json:"control_socket,omitempty"` // Darwin cooperative shutdown endpoint
+	PID           int        `json:"pid"`
+	TTY           string     `json:"tty"`
+	Root          string     `json:"root"`                     // Absolute path to disambiguate relative AM_ROOT
+	Agent         string     `json:"agent,omitempty"`          // Agent handle that owns this lock
+	Hostname      string     `json:"hostname,omitempty"`       // Host that created the lock
+	Started       string     `json:"started"`                  // Wall-clock diagnostic timestamp
+	ProcessStart  string     `json:"process_start,omitempty"`  // Kernel process start token, guards PID reuse
+	BootID        string     `json:"boot_id,omitempty"`        // Boot identity paired with ProcessStart when available
+	Executable    string     `json:"executable,omitempty"`     // Diagnostic process executable basename/path
+	Args          []string   `json:"args,omitempty"`           // Diagnostic argv when available
+	WakeMode      string     `json:"wake_mode,omitempty"`      // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
+	TargetDigest  string     `json:"target_digest,omitempty"`  // Binds .wake.target to this lock instance
+	Generation    string     `json:"generation,omitempty"`     // Random nonce binding readiness and exact cleanup to this instance
+	ControlSocket string     `json:"control_socket,omitempty"` // Darwin cooperative shutdown endpoint
+	OwnerSchema   int        `json:"owner_schema,omitempty"`   // Non-zero only for an authoritative owner-bound lock
+	Owner         *wakeOwner `json:"owner,omitempty"`          // Exact owner identity for an authoritative owner-bound lock
 }
+
+const (
+	wakeOwnerLockSchema   = 1
+	wakeOwnerWakeMode     = "owner-inject-via-v1"
+	wakeOwnerLockFileMode = os.FileMode(0o400)
+)
 
 type wakeProcessInfo struct {
 	PID          int
@@ -66,6 +74,25 @@ func (state wakeIdentityState) String() string {
 		return "same"
 	case wakeIdentityGoneOrDifferent:
 		return "gone or different"
+	default:
+		return "unknown"
+	}
+}
+
+type wakeOwnerIdentityState uint8
+
+const (
+	wakeOwnerUnknown wakeOwnerIdentityState = iota
+	wakeOwnerSame
+	wakeOwnerDead
+)
+
+func (state wakeOwnerIdentityState) String() string {
+	switch state {
+	case wakeOwnerSame:
+		return "same"
+	case wakeOwnerDead:
+		return "dead"
 	default:
 		return "unknown"
 	}
@@ -142,6 +169,11 @@ func readWakeLockMetadataWithReader(root, me, lockPath string, read wakeLockFile
 	inspection.fileInfo = fileInfo
 	var existing wakeLock
 	if err := json.Unmarshal(data, &existing); err != nil {
+		if fileInfo != nil && fileInfo.Mode().Perm() == wakeOwnerLockFileMode {
+			inspection.Status = wakeLockUnverified
+			inspection.Reason = "wake owner schema is malformed; owner-bound lock may be from a newer amq"
+			return inspection
+		}
 		if fileInfo != nil && time.Since(fileInfo.ModTime()) < 2*time.Second {
 			inspection.Status = wakeLockCreating
 			inspection.Reason = "lock is being created"
@@ -191,14 +223,19 @@ func validateWakeLockFile(path string, info os.FileInfo) error {
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("wake lock %s must be a regular file", path)
 	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		return fmt.Errorf("wake lock %s mode is %o, want 0600", path, got)
+	if got := info.Mode().Perm(); got != 0o600 && got != wakeOwnerLockFileMode {
+		return fmt.Errorf("wake lock %s mode is %o, want 0600 or 0400", path, got)
 	}
 	return validateWakeTargetPathOwnership("wake lock", path, info)
 }
 
 func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
 	lock := inspection.Lock
+	if err := validateWakeLockFormat(lock, inspection.fileInfo); err != nil {
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = err.Error()
+		return
+	}
 	if lock.PID <= 0 {
 		inspection.Status = wakeLockStale
 		inspection.Reason = "invalid pid"
@@ -246,7 +283,70 @@ func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
 	}
 }
 
+func validateWakeLockFormat(lock wakeLock, info os.FileInfo) error {
+	if info == nil {
+		return fmt.Errorf("wake lock file identity unavailable")
+	}
+	switch info.Mode().Perm() {
+	case wakeOwnerLockFileMode:
+		if lock.OwnerSchema != wakeOwnerLockSchema {
+			return fmt.Errorf("wake owner schema %d unsupported; owner-bound lock may be from a newer amq", lock.OwnerSchema)
+		}
+		if lock.WakeMode != wakeOwnerWakeMode {
+			return fmt.Errorf("wake owner mode %q unsupported; owner-bound lock may be from a newer amq", lock.WakeMode)
+		}
+		if lock.Owner == nil {
+			return fmt.Errorf("wake owner identity missing")
+		}
+		if err := validateAuthoritativeWakeOwner(*lock.Owner); err != nil {
+			return fmt.Errorf("wake owner identity invalid: %w", err)
+		}
+		if err := validateAuthoritativeWakeProcessIdentity(lock); err != nil {
+			return err
+		}
+		if strings.TrimSpace(lock.TargetDigest) == "" {
+			return fmt.Errorf("wake owner target digest missing")
+		}
+		if strings.TrimSpace(lock.Generation) == "" {
+			return fmt.Errorf("wake owner generation missing")
+		}
+	case 0o600:
+		if lock.OwnerSchema != 0 || lock.Owner != nil || lock.WakeMode == wakeOwnerWakeMode {
+			return fmt.Errorf("wake owner markers require mode 0400")
+		}
+	default:
+		return fmt.Errorf("wake lock mode %o unsupported", info.Mode().Perm())
+	}
+	return nil
+}
+
+func validateAuthoritativeWakeProcessIdentity(lock wakeLock) error {
+	if err := validateAuthoritativeWakeOwnerToken("wake process start", lock.ProcessStart); err != nil {
+		return err
+	}
+	if err := validateAuthoritativeWakeOwnerToken("wake boot id", lock.BootID); err != nil {
+		return err
+	}
+	if !validWakeOwnerProcessStart(lock.ProcessStart) {
+		return fmt.Errorf("wake process start has malformed platform value")
+	}
+	if !validWakeOwnerBootID(lock.BootID) {
+		return fmt.Errorf("wake boot id has malformed platform value")
+	}
+	return nil
+}
+
+func sameWakeOwner(first, second *wakeOwner) bool {
+	if first == nil || second == nil {
+		return first == nil && second == nil
+	}
+	return *first == *second
+}
+
 func validateWakeLockRepairable(inspection wakeLockInspection) error {
+	if err := validateGenericWakeLifecycleTransition(inspection, wakeGenericRequestMutate); err != nil {
+		return err
+	}
 	if inspection.Status != wakeLockStale {
 		return fmt.Errorf("wake lock status %q is not repairable", inspection.Status)
 	}
@@ -259,6 +359,9 @@ func validateWakeLockRepairable(inspection wakeLockInspection) error {
 }
 
 func validateWakeLockStaleRemoval(inspection wakeLockInspection) error {
+	if wakeLockHasOwnerMarkers(inspection) {
+		return fmt.Errorf("owner-bound wake claims require 'amq wake recover-owner --me %s'", inspection.Agent)
+	}
 	if err := validateWakeLockRepairable(inspection); err == nil {
 		return nil
 	} else if inspection.Status != wakeLockStale {
@@ -267,6 +370,13 @@ func validateWakeLockStaleRemoval(inspection wakeLockInspection) error {
 	// Identity mismatches reach stale only when the tri-state classifier has
 	// affirmative proof that the recorded generation is gone or different.
 	return nil
+}
+
+func wakeLockHasOwnerMarkers(inspection wakeLockInspection) bool {
+	if inspection.Lock.OwnerSchema != 0 || inspection.Lock.Owner != nil || inspection.Lock.WakeMode == wakeOwnerWakeMode {
+		return true
+	}
+	return inspection.fileInfo != nil && inspection.fileInfo.Mode().Perm() == wakeOwnerLockFileMode
 }
 
 func wakeProcessProvenNotWake(proc wakeProcessInfo) bool {
@@ -297,6 +407,9 @@ func removeWakeLockIfUnchangedGuarded(inspection wakeLockInspection) error {
 }
 
 func removeWakeLockIfUnchangedGuardedWithIO(inspection wakeLockInspection, read wakeLockFileReader, remove func() error) error {
+	if err := validateGenericWakeLifecycleTransition(inspection, wakeGenericRequestMutate); err != nil {
+		return err
+	}
 	current, currentInfo, err := read()
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -429,6 +542,11 @@ func inspectWakeIdentity(inspection wakeLockInspection) wakeIdentityState {
 
 func classifyWakeIdentity(inspection wakeLockInspection, proc wakeProcessInfo) (wakeIdentityState, string) {
 	lock := inspection.Lock
+	if lock.WakeMode == wakeOwnerWakeMode {
+		if err := validateAuthoritativeWakeProcessIdentity(lock); err != nil {
+			return wakeIdentityUnknown, err.Error()
+		}
+	}
 	if !proc.Running {
 		return wakeIdentityGoneOrDifferent, "pid not running"
 	}
@@ -475,6 +593,74 @@ func classifyWakeIdentity(inspection wakeLockInspection, proc wakeProcessInfo) (
 		return wakeIdentitySame, ""
 	}
 	return wakeIdentityUnknown, "legacy lock lacks process start metadata"
+}
+
+func classifyAuthoritativeWakeOwner(owner wakeOwner, proc wakeProcessInfo, sessionID int, sessionErr error) (wakeOwnerIdentityState, string) {
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		return wakeOwnerUnknown, err.Error()
+	}
+	if !proc.Running {
+		return wakeOwnerDead, "owner process is not running"
+	}
+	if proc.StartToken == "" {
+		return wakeOwnerUnknown, inspectionReason("owner process start unavailable", proc.InspectError)
+	}
+	switch compareWakeBootID(owner.BootID, proc) {
+	case bootIDMismatch:
+		return wakeOwnerDead, "owner boot id changed"
+	case bootIDUnknown:
+		return wakeOwnerUnknown, "owner boot id unavailable or incomparable"
+	}
+	if proc.StartToken != owner.ProcessStart {
+		return wakeOwnerDead, "owner process start changed"
+	}
+	if sessionErr != nil {
+		return wakeOwnerUnknown, fmt.Sprintf("owner session unavailable: %v", sessionErr)
+	}
+	if sessionID <= 0 {
+		return wakeOwnerUnknown, "owner session unavailable"
+	}
+	if sessionID != owner.SessionID {
+		return wakeOwnerUnknown, "owner session changed"
+	}
+	return wakeOwnerSame, ""
+}
+
+func classifyStableAuthoritativeWakeOwner(
+	owner wakeOwner,
+	first wakeProcessInfo,
+	firstSessionID int,
+	firstSessionErr error,
+	second wakeProcessInfo,
+	secondSessionID int,
+	secondSessionErr error,
+) (wakeOwnerIdentityState, string) {
+	firstState, firstReason := classifyAuthoritativeWakeOwner(owner, first, firstSessionID, firstSessionErr)
+	secondState, secondReason := classifyAuthoritativeWakeOwner(owner, second, secondSessionID, secondSessionErr)
+	if firstState == wakeOwnerDead && secondState == wakeOwnerDead {
+		return wakeOwnerDead, firstReason
+	}
+	if firstState != wakeOwnerSame || secondState != wakeOwnerSame {
+		if firstState != secondState {
+			return wakeOwnerUnknown, "owner identity changed while inspecting"
+		}
+		if firstReason != "" {
+			return wakeOwnerUnknown, firstReason
+		}
+		return wakeOwnerUnknown, secondReason
+	}
+	if !sameWakeOwnerProcessSnapshot(first, second) || firstSessionID != secondSessionID {
+		return wakeOwnerUnknown, "owner identity changed while inspecting"
+	}
+	return wakeOwnerSame, ""
+}
+
+func sameWakeOwnerProcessSnapshot(first, second wakeProcessInfo) bool {
+	return first.PID == second.PID &&
+		first.Running == second.Running &&
+		first.StartToken == second.StartToken &&
+		first.BootID == second.BootID &&
+		first.LegacyBootID == second.LegacyBootID
 }
 
 type bootIDComparison int

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -67,15 +67,6 @@ func readWakeLockMetadataAt(dirfd int, agentDir *wakeAgentDir, root, me string) 
 	})
 }
 
-func removeWakeLockIfUnchangedAt(dirfd int, agentDir *wakeAgentDir, inspection wakeLockInspection) error {
-	path := filepath.Join(agentDir.path, ".wake.lock")
-	return removeWakeLockIfUnchangedGuardedWithIO(
-		inspection,
-		func() ([]byte, os.FileInfo, error) { return readWakeLockFileAt(dirfd, path) },
-		func() error { return unix.Unlinkat(dirfd, ".wake.lock", 0) },
-	)
-}
-
 func readWakeGenerationFileAt(
 	dirfd int,
 	agentDir *wakeAgentDir,

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -1,0 +1,165 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func readWakeLockFileAt(dirfd int, path string) ([]byte, os.FileInfo, error) {
+	open := func() (*os.File, error) {
+		fd, err := unix.Openat(dirfd, ".wake.lock", unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(uintptr(fd), path), nil
+	}
+	file, err := open()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat wake lock: %w", err)
+	}
+	if err := validateWakeLockFile(path, info); err != nil {
+		return nil, nil, err
+	}
+	data, err := readWakeMetadata(file, "wake lock", path)
+	if err != nil {
+		return nil, nil, err
+	}
+	pathFile, err := open()
+	if err != nil {
+		return nil, nil, err
+	}
+	pathInfo, statErr := pathFile.Stat()
+	_ = pathFile.Close()
+	if statErr != nil {
+		return nil, nil, fmt.Errorf("re-stat wake lock: %w", statErr)
+	}
+	if err := validateWakeLockFile(path, pathInfo); err != nil {
+		return nil, nil, err
+	}
+	if !sameWakeFileIdentity(info, pathInfo) {
+		return nil, nil, fmt.Errorf("wake lock %s changed while opening", path)
+	}
+	return data, info, nil
+}
+
+func inspectWakeLockAt(dirfd int, agentDir *wakeAgentDir, root, me string) wakeLockInspection {
+	path := filepath.Join(agentDir.path, ".wake.lock")
+	return inspectWakeLockWithReader(root, me, path, func() ([]byte, os.FileInfo, error) {
+		return readWakeLockFileAt(dirfd, path)
+	})
+}
+
+func readWakeLockMetadataAt(dirfd int, agentDir *wakeAgentDir, root, me string) wakeLockInspection {
+	path := filepath.Join(agentDir.path, ".wake.lock")
+	return readWakeLockMetadataWithReader(root, me, path, func() ([]byte, os.FileInfo, error) {
+		return readWakeLockFileAt(dirfd, path)
+	})
+}
+
+func removeWakeLockIfUnchangedAt(dirfd int, agentDir *wakeAgentDir, inspection wakeLockInspection) error {
+	path := filepath.Join(agentDir.path, ".wake.lock")
+	return removeWakeLockIfUnchangedGuardedWithIO(
+		inspection,
+		func() ([]byte, os.FileInfo, error) { return readWakeLockFileAt(dirfd, path) },
+		func() error { return unix.Unlinkat(dirfd, ".wake.lock", 0) },
+	)
+}
+
+func readWakeGenerationFileAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	name string,
+	label string,
+) (wakeReady, bool, error) {
+	path := filepath.Join(agentDir.path, name)
+	open := func() (*os.File, error) {
+		fd, err := unix.Openat(dirfd, name, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(uintptr(fd), path), nil
+	}
+	file, err := open()
+	if err != nil {
+		if err == unix.ENOENT {
+			return wakeReady{}, false, nil
+		}
+		return wakeReady{}, true, err
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return wakeReady{}, true, err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		return wakeReady{}, true, fmt.Errorf("%s must be a regular 0600 file", label)
+	}
+	if err := validateWakeTargetPathOwnership(label, path, info); err != nil {
+		return wakeReady{}, true, err
+	}
+	data, err := readWakeMetadata(file, label, path)
+	if err != nil {
+		return wakeReady{}, true, err
+	}
+	pathFile, err := open()
+	if err != nil {
+		return wakeReady{}, true, err
+	}
+	pathInfo, statErr := pathFile.Stat()
+	_ = pathFile.Close()
+	if statErr != nil {
+		return wakeReady{}, true, statErr
+	}
+	if !sameWakeFileIdentity(info, pathInfo) {
+		return wakeReady{}, true, fmt.Errorf("%s changed while opening", label)
+	}
+	var marker wakeReady
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return wakeReady{}, true, err
+	}
+	if marker.Schema != wakeReadySchema || marker.Generation == "" {
+		return wakeReady{}, true, fmt.Errorf("%s schema is unsupported", label)
+	}
+	return marker, true, nil
+}
+
+func writeWakeGenerationFileAt(
+	dirfd int,
+	name string,
+	label string,
+	marker wakeReady,
+) error {
+	data, err := json.Marshal(marker)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", label, err)
+	}
+	temp, err := writeWakeOwnerTempAt(dirfd, "wake-generation", append(data, '\n'), 0o600)
+	if err != nil {
+		return err
+	}
+	tempPresent := true
+	defer func() {
+		if tempPresent {
+			_ = unix.Unlinkat(dirfd, temp, 0)
+		}
+	}()
+	if err := unix.Renameat(dirfd, temp, dirfd, name); err != nil {
+		return fmt.Errorf("install %s: %w", label, err)
+	}
+	tempPresent = false
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync %s directory: %w", label, err)
+	}
+	return nil
+}

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -83,8 +83,16 @@ func writeWakeLockExactForTest(t *testing.T, root, agent string, lock wakeLock) 
 
 func bindWakeLockToTarget(lock wakeLock, target wakeTarget) wakeLock {
 	lock.WakeMode = wakeTargetInjectVia
-	lock.TargetDigest = wakeTargetDigest(target)
+	lock.TargetDigest = mustWakeTargetDigest(target)
 	return lock
+}
+
+func mustWakeTargetDigest(target wakeTarget) string {
+	digest, err := wakeTargetDigest(target)
+	if err != nil {
+		panic(err)
+	}
+	return digest
 }
 
 func TestSameWakeInjectorIdentityUsesOnlyPathAndOrderedArgs(t *testing.T) {

--- a/internal/cli/wake_owner_acquire_unix.go
+++ b/internal/cli/wake_owner_acquire_unix.go
@@ -1,0 +1,333 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+func classifyPersistedWakeClaim(inspection wakeLockInspection) wakeClaimClass {
+	if !inspection.Exists {
+		return wakeClaimAbsent
+	}
+	if inspection.fileInfo == nil {
+		return wakeClaimInvalid
+	}
+	switch inspection.fileInfo.Mode().Perm() {
+	case wakeOwnerLockFileMode:
+		if validateAuthoritativeWakeLockEnvelope(
+			inspection.Lock,
+			inspection.Root,
+			inspection.Agent,
+		) != nil {
+			return wakeClaimInvalid
+		}
+		return wakeClaimAuthoritative
+	case 0o600:
+		if inspection.Lock.OwnerSchema != 0 ||
+			inspection.Lock.Owner != nil ||
+			inspection.Lock.WakeMode == wakeOwnerWakeMode {
+			return wakeClaimInvalid
+		}
+		return wakeClaimGeneric
+	default:
+		return wakeClaimInvalid
+	}
+}
+
+func validateAuthoritativeWakeClaimPairAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	inspection wakeLockInspection,
+) (wakeTarget, error) {
+	if classifyPersistedWakeClaim(inspection) != wakeClaimAuthoritative {
+		return wakeTarget{}, fmt.Errorf("wake lock is not an authoritative owner claim")
+	}
+	return readAuthoritativeWakeTargetAt(
+		dirfd,
+		agentDir,
+		inspection.Root,
+		inspection.Agent,
+		inspection.Lock,
+	)
+}
+
+func authoritativeWakeRecoveryTargetAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	inspection wakeLockInspection,
+) (*wakeTarget, error) {
+	target, exists, err := readWakeTargetRawAt(
+		dirfd,
+		agentDir,
+		inspection.Root,
+		inspection.Agent,
+	)
+	if err != nil {
+		// The authoritative lock retains owner evidence. An unreadable or
+		// corrupt target is preserved as an orphan rather than becoming a
+		// permanent barrier to authenticated recovery.
+		return nil, nil
+	}
+	if !exists {
+		return nil, nil
+	}
+	if target.Owner == nil {
+		return nil, nil
+	}
+	if err := validateAuthoritativeWakeOwner(*target.Owner); err != nil {
+		return nil, nil
+	}
+	if !sameWakeOwner(target.Owner, inspection.Lock.Owner) {
+		return nil, fmt.Errorf("persisted wake target and lock name different owners")
+	}
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		return nil, err
+	}
+	if targetDigest != inspection.Lock.TargetDigest {
+		// A missing/older target is not part of the committed claim. Preserve it
+		// as an orphan while recovery releases the authoritative lock.
+		return nil, nil
+	}
+	if err := validateAuthoritativeWakeTarget(target, inspection.Root, inspection.Agent); err != nil {
+		return nil, nil
+	}
+	if err := validateAuthoritativeWakeLockRecord(
+		inspection.Lock,
+		inspection.Root,
+		inspection.Agent,
+		target,
+	); err != nil {
+		return nil, err
+	}
+	return &target, nil
+}
+
+func acquireAuthoritativeWakeLockWithOptions(
+	root string,
+	me string,
+	options wakeLockAcquireOptions,
+) (func(), error) {
+	requested := *options.target
+	if err := validateAuthoritativeWakeTarget(requested, root, me); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(fsq.AgentBase(root, me), 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create agent directory: %w", err)
+	}
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	for {
+		var created wakeLockInspection
+		var stopCapability *authoritativeWakeStopCapability
+		fallbackOwnerless := false
+		retry := false
+		err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+			inspection := inspectWakeLockForOwnerTransition(dirfd, agentDir, root, me)
+			claimClass := classifyPersistedWakeClaim(inspection)
+			switch claimClass {
+			case wakeClaimGeneric:
+				return fmt.Errorf("wake handle %s has an ownerless wake; stop or retire it before starting an owner-bound wake", me)
+			case wakeClaimInvalid:
+				reason := inspection.Reason
+				if reason == "" {
+					reason = "persisted wake claim is not authoritative"
+				}
+				return fmt.Errorf("wake state for %s is unverified; refusing owner-bound acquisition: %s", me, reason)
+			}
+
+			requestedObservation, observeErr := observeAuthoritativeWakeOwner(*requested.Owner)
+			defer func() { _ = requestedObservation.Close() }()
+			if observeErr != nil {
+				if requestedObservation.CapabilityUnsupported && claimClass == wakeClaimAbsent {
+					fallbackOwnerless = true
+					return nil
+				}
+				return observeErr
+			}
+			if requestedObservation.State != wakeOwnerSame {
+				return fmt.Errorf("requested wake owner is %s: %s", requestedObservation.State, requestedObservation.Reason)
+			}
+
+			if claimClass == wakeClaimAuthoritative {
+				persisted, err := validateAuthoritativeWakeClaimPairAt(dirfd, agentDir, inspection)
+				if err != nil {
+					return fmt.Errorf("persisted owner claim is unverified: %w", err)
+				}
+				persistedState := requestedObservation.State
+				persistedReason := requestedObservation.Reason
+				if !sameWakeOwner(inspection.Lock.Owner, requested.Owner) {
+					persistedObservation, err := observeAuthoritativeWakeOwner(*inspection.Lock.Owner)
+					defer func() { _ = persistedObservation.Close() }()
+					if err != nil {
+						return err
+					}
+					persistedState = persistedObservation.State
+					persistedReason = persistedObservation.Reason
+				}
+				ownersEqual := sameWakeOwner(inspection.Lock.Owner, requested.Owner)
+				wakeCapability, err := prepareAuthoritativeWakeStop(dirfd, agentDir, inspection)
+				if err != nil {
+					return fmt.Errorf("inspect authoritative wake through stable capability: %w", err)
+				}
+				keepWakeCapability := false
+				defer func() {
+					if !keepWakeCapability {
+						_ = wakeCapability.Close()
+					}
+				}()
+				classified := wakeCapability.Inspection
+				wakeUsable := classified.Status == wakeLockValid &&
+					classified.IdentityConfirmed &&
+					wakeLockHasUsableNotificationPath(classified) &&
+					ownersEqual &&
+					sameWakeInjectorIdentity(persisted, requested)
+				evidence := wakeOwnerTransitionEvidence{
+					Request:            wakeOwnerRequestAcquire,
+					Claim:              wakeClaimAuthoritative,
+					RequestedState:     requestedObservation.State,
+					PersistedState:     persistedState,
+					OwnersEqual:        ownersEqual,
+					WakeUsable:         wakeUsable,
+					WakeExactStoppable: classified.Status == wakeLockValid && classified.IdentityConfirmed,
+					WakeAbsent:         wakeCapability.Absent,
+				}
+				switch decideOwnerLifecycleTransition(evidence) {
+				case wakeOwnerActionReuse:
+					return wakeLockAlreadyRunningError(me, classified)
+				case wakeOwnerActionRelease:
+					if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, inspection, &persisted); err != nil {
+						return err
+					}
+					retry = true
+					return nil
+				case wakeOwnerActionStopAndRelease:
+					if wakeCapability.Absent {
+						if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, inspection, &persisted); err != nil {
+							return err
+						}
+						retry = true
+						return nil
+					}
+					stopCapability = &wakeCapability
+					keepWakeCapability = true
+					return nil
+				default:
+					switch persistedState {
+					case wakeOwnerSame:
+						if !ownersEqual {
+							return fmt.Errorf("wake handle %s is owned by live process pid %d, OS session %d", me, inspection.Lock.Owner.PID, inspection.Lock.Owner.SessionID)
+						}
+						return fmt.Errorf("wake handle %s has a live owner but an unusable wake; run 'amq wake recover-owner --me %s'", me, me)
+					case wakeOwnerUnknown:
+						return fmt.Errorf("wake owner for %s is unknown (%s); preserving owner claim", me, persistedReason)
+					default:
+						return fmt.Errorf("wake owner for %s cannot be safely reclaimed; run 'amq wake recover-owner --me %s'", me, me)
+					}
+				}
+			}
+
+			if orphan, exists, readErr := readWakeTargetAt(dirfd, agentDir, root, me); readErr != nil {
+				return fmt.Errorf("uncommitted wake target is unverified: %w", readErr)
+			} else if exists {
+				if err := validateWakeTarget(orphan, root, me); err != nil {
+					return fmt.Errorf("uncommitted wake target is invalid: %w", err)
+				}
+			}
+
+			lock, err := newWakeLock(root, me, options)
+			if err != nil {
+				return err
+			}
+			if err := publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, me, requested, lock); err != nil {
+				if errors.Is(err, errWakeOwnerLockExists) {
+					retry = true
+					return nil
+				}
+				var publicationErr *wakeOwnerPublicationError
+				if errors.As(err, &publicationErr) {
+					current := inspectWakeLockAt(dirfd, agentDir, root, me)
+					if current.Exists {
+						if current.Lock.Generation != lock.Generation {
+							return fmt.Errorf("%w (a different wake lock became visible)", err)
+						}
+						if _, verifyErr := validateAuthoritativeWakeClaimPairAt(dirfd, agentDir, current); verifyErr != nil {
+							return fmt.Errorf("%w (visible owner claim is unverified: %v)", err, verifyErr)
+						}
+						return fmt.Errorf("%w (the exact owner claim is visible and was preserved)", err)
+					}
+					if !publicationErr.Unsupported || publicationErr.Committed {
+						return err
+					}
+					if unlinkErr := unix.Unlinkat(dirfd, wakeTargetFileName, 0); unlinkErr != nil && unlinkErr != unix.ENOENT {
+						return fmt.Errorf("%w (remove uncommitted owner target: %v)", err, unlinkErr)
+					}
+					if syncErr := syncWakeOwnerDirFD(dirfd); syncErr != nil {
+						return fmt.Errorf("%w (sync ownerless fallback cleanup: %v)", err, syncErr)
+					}
+					fallbackOwnerless = true
+					return nil
+				}
+				return err
+			}
+			created = inspectWakeLockAt(dirfd, agentDir, root, me)
+			if !created.Exists || created.Lock.Generation != lock.Generation {
+				return fmt.Errorf("failed to verify created authoritative wake lock generation")
+			}
+			if _, err := validateAuthoritativeWakeClaimPairAt(dirfd, agentDir, created); err != nil {
+				return fmt.Errorf("verify created authoritative wake claim: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			if stopCapability != nil {
+				_ = stopCapability.Close()
+			}
+			return nil, err
+		}
+		if stopCapability != nil {
+			stopErr := stopCapability.Stop(wakeOwnerReleaseAuthorization{})
+			closeErr := stopCapability.Close()
+			if stopErr != nil {
+				return nil, stopErr
+			}
+			if closeErr != nil {
+				return nil, closeErr
+			}
+			// No pre-wait evidence survives. Darwin may have removed the claim;
+			// Linux leaves it for the next freshly guarded dead-owner pass.
+			continue
+		}
+		if retry {
+			continue
+		}
+		if fallbackOwnerless {
+			ownerless := requested
+			ownerless.Owner = nil
+			_ = writeStderr("warning: owner-bound wake capabilities are unavailable; starting one ownerless inject-via wake\n")
+			// Reflect the degradation in the caller's target too. The wake loop
+			// must not keep applying owner-health semantics to a claim that was
+			// deliberately published through the ownerless protocol.
+			*options.target = ownerless
+			options.wakeMode = wakeTargetInjectVia
+			return acquireWakeLockWithOptions(root, me, options)
+		}
+		if !created.Exists {
+			return nil, fmt.Errorf("authoritative wake acquisition produced no claim")
+		}
+
+		// Ordinary wake-loop termination is not an owner release. Recovery or
+		// an exact in-process rollback owns authoritative claim removal.
+		return func() {}, nil
+	}
+}

--- a/internal/cli/wake_owner_child_darwin.go
+++ b/internal/cli/wake_owner_child_darwin.go
@@ -1,0 +1,95 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+func prepareAuthoritativeWakeChildPlatform(cmd *exec.Cmd) (*authoritativeWakeChildCapability, error) {
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create authoritative wake child stop pipe: %w", err)
+	}
+	childFD := 3 + len(cmd.ExtraFiles)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, readEnd)
+	cmd.Env = setEnvVar(unsetEnvVar(cmd.Env, envWakePrivateStopFD), envWakePrivateStopFD, strconv.Itoa(childFD))
+
+	var stopOnce sync.Once
+	var stopErr error
+	bound := false
+	return &authoritativeWakeChildCapability{
+		bind: func(process *os.Process) error {
+			if process == nil || process.Pid <= 0 {
+				return fmt.Errorf("authoritative wake child process is missing")
+			}
+			bound = true
+			if err := readEnd.Close(); err != nil {
+				return err
+			}
+			// Keep the owner-side stop capability across the later TUI exec,
+			// but only after the wake child has spawned so the child cannot
+			// inherit its own writer and defeat EOF-based owner-exit cleanup.
+			flags, err := unix.FcntlInt(writeEnd.Fd(), unix.F_GETFD, 0)
+			if err != nil {
+				return fmt.Errorf("inspect authoritative wake owner stop fd: %w", err)
+			}
+			if _, err := unix.FcntlInt(writeEnd.Fd(), unix.F_SETFD, flags&^unix.FD_CLOEXEC); err != nil {
+				return fmt.Errorf("retain authoritative wake owner stop fd across exec: %w", err)
+			}
+			return nil
+		},
+		stop: func() error {
+			stopOnce.Do(func() {
+				if _, err := writeEnd.Write([]byte{1}); err != nil && !errors.Is(err, unix.EPIPE) {
+					stopErr = err
+				}
+				if err := writeEnd.Close(); stopErr == nil {
+					stopErr = err
+				}
+			})
+			return stopErr
+		},
+		close: func() error {
+			var first error
+			if !bound {
+				first = readEnd.Close()
+			}
+			stopOnce.Do(func() { stopErr = writeEnd.Close() })
+			if first == nil {
+				first = stopErr
+			}
+			return first
+		},
+	}, nil
+}
+
+func authoritativeWakePrivateStopFromEnv() (<-chan struct{}, func(), error) {
+	raw := strings.TrimSpace(os.Getenv(envWakePrivateStopFD))
+	if raw == "" {
+		return nil, func() {}, nil
+	}
+	fd, err := strconv.Atoi(raw)
+	if err != nil || fd < 3 {
+		return nil, nil, fmt.Errorf("%s is invalid", envWakePrivateStopFD)
+	}
+	file := os.NewFile(uintptr(fd), "authoritative-wake-private-stop")
+	if file == nil {
+		return nil, nil, fmt.Errorf("%s fd is unavailable", envWakePrivateStopFD)
+	}
+	stop := make(chan struct{})
+	go func() {
+		var one [1]byte
+		_, _ = file.Read(one[:])
+		close(stop)
+	}()
+	return stop, func() { _ = file.Close() }, nil
+}

--- a/internal/cli/wake_owner_child_linux.go
+++ b/internal/cli/wake_owner_child_linux.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func prepareAuthoritativeWakeChildPlatform(cmd *exec.Cmd) (*authoritativeWakeChildCapability, error) {
+	// Prove the syscall boundary before launch so a conclusively unsupported
+	// host can choose the fresh ownerless path before an owner child exists.
+	probe, err := linuxPidfdOpen(os.Getpid(), 0)
+	if err != nil {
+		if wakeOwnerCapabilityUnsupported(err) {
+			return nil, &wakeOwnerChildCapabilityUnsupportedError{
+				Err: fmt.Errorf("preflight owner wake child pidfd: %w", err),
+			}
+		}
+		return nil, fmt.Errorf("preflight owner wake child pidfd: %w", err)
+	}
+	if err := linuxPidfdClose(probe); err != nil {
+		return nil, fmt.Errorf("close owner wake child pidfd preflight: %w", err)
+	}
+	if cmd == nil {
+		return nil, fmt.Errorf("authoritative wake child command is missing")
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	if cmd.SysProcAttr.PidFD != nil {
+		return nil, fmt.Errorf("authoritative wake child command already owns a pidfd request")
+	}
+
+	// Ask os/exec to return the pidfd atomically with child creation. Opening
+	// one by numeric PID after Start would leave a PID-reuse window if the
+	// short-lived helper exited before the open.
+	pidfd := -1
+	cmd.SysProcAttr.PidFD = &pidfd
+	return &authoritativeWakeChildCapability{
+		bind: func(process *os.Process) error {
+			if process == nil || process.Pid <= 0 {
+				return fmt.Errorf("authoritative wake child process is missing")
+			}
+			if pidfd < 0 {
+				return fmt.Errorf("authoritative wake child pidfd was not returned at process creation")
+			}
+			return nil
+		},
+		stop: func() error {
+			if pidfd < 0 {
+				return fmt.Errorf("authoritative wake child pidfd is unavailable")
+			}
+			return terminateWakePidfd(pidfd)
+		},
+		close: func() error {
+			if pidfd < 0 {
+				return nil
+			}
+			fd := pidfd
+			pidfd = -1
+			return linuxPidfdClose(fd)
+		},
+	}, nil
+}
+
+func authoritativeWakePrivateStopFromEnv() (<-chan struct{}, func(), error) {
+	return nil, func() {}, nil
+}

--- a/internal/cli/wake_owner_child_unix.go
+++ b/internal/cli/wake_owner_child_unix.go
@@ -1,0 +1,76 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const envWakePrivateStopFD = "AMQ_WAKE_PRIVATE_STOP_FD"
+
+type wakeOwnerChildCapabilityUnsupportedError struct {
+	Err error
+}
+
+func (err *wakeOwnerChildCapabilityUnsupportedError) Error() string {
+	return err.Err.Error()
+}
+
+func (err *wakeOwnerChildCapabilityUnsupportedError) Unwrap() error {
+	return err.Err
+}
+
+type authoritativeWakeChildCapability struct {
+	bind  func(*os.Process) error
+	stop  func() error
+	close func() error
+}
+
+func (capability *authoritativeWakeChildCapability) Bind(process *os.Process) error {
+	if capability == nil || capability.bind == nil {
+		return fmt.Errorf("authoritative wake child capability cannot bind")
+	}
+	return capability.bind(process)
+}
+
+func (capability *authoritativeWakeChildCapability) Stop() error {
+	if capability == nil || capability.stop == nil {
+		return fmt.Errorf("authoritative wake child capability cannot stop")
+	}
+	return capability.stop()
+}
+
+func (capability *authoritativeWakeChildCapability) Close() error {
+	if capability == nil || capability.close == nil {
+		return nil
+	}
+	closeFn := capability.close
+	capability.close = nil
+	return closeFn()
+}
+
+var prepareAuthoritativeWakeChild = prepareAuthoritativeWakeChildPlatform
+
+func mergeWakeStopChannels(first, second <-chan struct{}) <-chan struct{} {
+	if first == nil {
+		return second
+	}
+	if second == nil {
+		return first
+	}
+	merged := make(chan struct{})
+	go func() {
+		select {
+		case <-first:
+		case <-second:
+		}
+		close(merged)
+	}()
+	return merged
+}
+
+func configureAuthoritativeWakeChild(cmd *exec.Cmd) (*authoritativeWakeChildCapability, error) {
+	return prepareAuthoritativeWakeChild(cmd)
+}

--- a/internal/cli/wake_owner_lifecycle_linux_test.go
+++ b/internal/cli/wake_owner_lifecycle_linux_test.go
@@ -1,0 +1,482 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+func TestLinuxOwnerWakeChildRequestsPidfdAtProcessCreation(t *testing.T) {
+	oldOpen := linuxPidfdOpen
+	oldClose := linuxPidfdClose
+	linuxPidfdOpen = func(pid, flags int) (int, error) {
+		if pid != os.Getpid() || flags != 0 {
+			t.Fatalf("pidfd preflight = (%d,%d)", pid, flags)
+		}
+		return 71, nil
+	}
+	linuxPidfdClose = func(fd int) error {
+		if fd != 71 && fd != 72 {
+			t.Fatalf("unexpected close fd = %d", fd)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		linuxPidfdOpen = oldOpen
+		linuxPidfdClose = oldClose
+	})
+
+	cmd := exec.Command("true")
+	capability, err := prepareAuthoritativeWakeChildPlatform(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = capability.Close() }()
+	if cmd.SysProcAttr == nil || cmd.SysProcAttr.PidFD == nil {
+		t.Fatal("owner wake child did not request an atomic pidfd")
+	}
+	*cmd.SysProcAttr.PidFD = 72
+	if err := capability.Bind(&os.Process{Pid: 4242}); err != nil {
+		t.Fatalf("bind atomic child pidfd: %v", err)
+	}
+}
+
+func TestLinuxOwnerObservationRetainsPidfdAcrossStableDoubleSnapshot(t *testing.T) {
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	var events []string
+	oldOpen := linuxPidfdOpen
+	oldPoll := linuxPidfdPoll
+	oldClose := linuxPidfdClose
+	linuxPidfdOpen = func(pid, flags int) (int, error) {
+		events = append(events, "open")
+		if pid != owner.PID || flags != 0 {
+			t.Fatalf("pidfd_open(%d,%d)", pid, flags)
+		}
+		return 77, nil
+	}
+	linuxPidfdPoll = func(fd int, _ time.Duration) (bool, error) {
+		events = append(events, "poll")
+		if fd != 77 {
+			t.Fatalf("poll fd = %d", fd)
+		}
+		return false, nil
+	}
+	linuxPidfdClose = func(fd int) error {
+		events = append(events, "close")
+		if fd != 77 {
+			t.Fatalf("close fd = %d", fd)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		linuxPidfdOpen = oldOpen
+		linuxPidfdPoll = oldPoll
+		linuxPidfdClose = oldClose
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		events = append(events, "inspect")
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: owner.ProcessStart,
+			BootID:     owner.BootID,
+		}
+	})
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		events = append(events, "session")
+		return owner.SessionID, nil
+	})
+
+	observation, err := observeAuthoritativeWakeOwnerPlatform(owner)
+	if err != nil || observation.State != wakeOwnerSame {
+		t.Fatalf("observation = %#v err=%v", observation, err)
+	}
+	if len(events) == 0 || events[0] != "open" {
+		t.Fatalf("events before close = %v, want pidfd open first", events)
+	}
+	if strings.Contains(strings.Join(events, ","), "close") {
+		t.Fatalf("owner pidfd closed before caller completed guarded work: %v", events)
+	}
+	if err := observation.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := events[len(events)-1]; got != "close" {
+		t.Fatalf("last event = %q, events=%v", got, events)
+	}
+}
+
+func TestLinuxOwnerObservationTreatsPidfdConfirmedMidSnapshotExitAsDead(t *testing.T) {
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	oldOpen := linuxPidfdOpen
+	oldPoll := linuxPidfdPoll
+	oldClose := linuxPidfdClose
+	linuxPidfdOpen = func(pid, flags int) (int, error) {
+		if pid != owner.PID || flags != 0 {
+			t.Fatalf("pidfd_open(%d,%d)", pid, flags)
+		}
+		return 77, nil
+	}
+	polls := 0
+	linuxPidfdPoll = func(fd int, _ time.Duration) (bool, error) {
+		if fd != 77 {
+			t.Fatalf("poll fd = %d", fd)
+		}
+		polls++
+		return polls == 2, nil
+	}
+	linuxPidfdClose = func(fd int) error {
+		if fd != 77 {
+			t.Fatalf("close fd = %d", fd)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		linuxPidfdOpen = oldOpen
+		linuxPidfdPoll = oldPoll
+		linuxPidfdClose = oldClose
+	})
+	inspections := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspections++
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: owner.ProcessStart,
+			BootID:     owner.BootID,
+		}
+	})
+	stubWakeProcessSID(t, func(int) (int, error) {
+		return owner.SessionID, nil
+	})
+
+	observation, err := observeAuthoritativeWakeOwnerPlatform(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = observation.Close() }()
+	if observation.State != wakeOwnerDead {
+		t.Fatalf("observation = %#v, want pidfd-confirmed dead", observation)
+	}
+	if inspections != 1 || polls != 2 {
+		t.Fatalf("mid-snapshot exit inspected=%d polled=%d, want 1 and 2", inspections, polls)
+	}
+}
+
+func TestLinuxUnsupportedPidfdStillCapturesCurrentOwnerForOwnerlessFallback(t *testing.T) {
+	oldOpen := linuxPidfdOpen
+	linuxPidfdOpen = func(int, int) (int, error) {
+		return -1, syscall.ENOSYS
+	}
+	t.Cleanup(func() { linuxPidfdOpen = oldOpen })
+
+	const bootID = "11111111-1111-1111-1111-111111111111"
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != os.Getpid() {
+			t.Fatalf("inspect pid = %d, want current pid %d", pid, os.Getpid())
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "12345",
+			BootID:     bootID,
+		}
+	})
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		if pid != os.Getpid() {
+			t.Fatalf("session pid = %d, want current pid %d", pid, os.Getpid())
+		}
+		return 99, nil
+	})
+
+	owner, err := captureAuthoritativeCurrentWakeOwner()
+	if err != nil {
+		t.Fatalf("capture current owner without pidfd: %v", err)
+	}
+	if owner.PID != os.Getpid() || owner.ProcessStart != "12345" ||
+		owner.BootID != bootID || owner.SessionID != 99 {
+		t.Fatalf("captured owner = %#v", owner)
+	}
+
+	_, err = prepareAuthoritativeWakeChildPlatform(exec.Command("true"))
+	var unsupported *wakeOwnerChildCapabilityUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("child capability error = %v, want ownerless-fallback signal", err)
+	}
+}
+
+func TestLinuxFreshUnsupportedOwnerPidfdFallsBackWithoutPublishingOwnerMarkers(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "linux-owner-fallback-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+
+	oldOpen := linuxPidfdOpen
+	linuxPidfdOpen = func(pid, flags int) (int, error) {
+		if pid == owner.PID {
+			return -1, syscall.ENOSYS
+		}
+		return oldOpen(pid, flags)
+	}
+	t.Cleanup(func() { linuxPidfdOpen = oldOpen })
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "67890",
+			BootID:     owner.BootID,
+			Executable: "/usr/local/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+		}
+	})
+
+	var cleanup func()
+	var acquireErr error
+	stderr := captureWakeStderr(t, func() {
+		cleanup, acquireErr = acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+			target:   &target,
+			wakeMode: wakeTargetInjectVia,
+		})
+	})
+	if acquireErr != nil {
+		t.Fatalf("ownerless fallback acquisition: %v", acquireErr)
+	}
+	defer cleanup()
+	if !strings.Contains(stderr, "ownerless") {
+		t.Fatalf("fallback warning = %q", stderr)
+	}
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.fileInfo.Mode().Perm() != 0o600 ||
+		inspection.Lock.OwnerSchema != 0 ||
+		inspection.Lock.Owner != nil ||
+		inspection.Lock.WakeMode != wakeTargetInjectVia {
+		t.Fatalf("fallback lock published owner markers: %#v", inspection)
+	}
+	persisted, exists, err := readWakeTarget(root, "codex")
+	if err != nil || !exists {
+		t.Fatalf("fallback target = %#v exists=%v err=%v", persisted, exists, err)
+	}
+	if persisted.Owner != nil {
+		t.Fatalf("fallback target retained owner: %#v", persisted.Owner)
+	}
+	if target.Owner != nil {
+		t.Fatalf("caller target retained owner-health semantics after fallback: %#v", target.Owner)
+	}
+}
+
+func TestLinuxStableOwnerWakeStopNeverSignalsReusedNumericPID(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "linux-owner-stop-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+		Generation:   "linux-owner-stop-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []string
+	oldOpen := linuxPidfdOpen
+	oldPoll := linuxPidfdPoll
+	oldClose := linuxPidfdClose
+	oldSignal := linuxPidfdSendSignal
+	linuxPidfdOpen = func(pid, flags int) (int, error) {
+		events = append(events, "open")
+		return 88, nil
+	}
+	linuxPidfdPoll = func(fd int, _ time.Duration) (bool, error) {
+		events = append(events, "poll")
+		return false, nil
+	}
+	linuxPidfdClose = func(fd int) error {
+		events = append(events, "close")
+		return nil
+	}
+	linuxPidfdSendSignal = func(int, unix.Signal, *unix.Siginfo, int) error {
+		t.Fatal("reused numeric PID received a signal")
+		return nil
+	}
+	t.Cleanup(func() {
+		linuxPidfdOpen = oldOpen
+		linuxPidfdPoll = oldPoll
+		linuxPidfdClose = oldClose
+		linuxPidfdSendSignal = oldSignal
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		events = append(events, "inspect")
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "99999",
+			BootID:     owner.BootID,
+			Executable: "/usr/local/bin/amq",
+			Args:       lock.Args,
+		}
+	})
+
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		expected := readWakeLockMetadataAt(dirfd, agentDir, root, "codex")
+		capability, err := prepareAuthoritativeWakeStopPlatform(dirfd, agentDir, expected)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = capability.Close() }()
+		if !capability.Absent {
+			t.Fatal("reused wake PID was treated as the recorded wake")
+		}
+		return capability.Stop(wakeOwnerReleaseAuthorization{})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) < 2 || events[0] != "open" {
+		t.Fatalf("stable stop events = %v, want pidfd open before inspection", events)
+	}
+}
+
+func TestLinuxMalformedOwnerWakeIdentityNeverSignalsMatchingArgvPID(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "linux-malformed-owner-stop-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		ProcessStart: "",
+		BootID:       owner.BootID,
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+		Generation:   "linux-malformed-owner-stop-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	oldOpen := linuxPidfdOpen
+	oldSignal := linuxPidfdSendSignal
+	linuxPidfdOpen = func(int, int) (int, error) {
+		t.Fatal("malformed authoritative identity reached pidfd_open")
+		return -1, nil
+	}
+	linuxPidfdSendSignal = func(int, unix.Signal, *unix.Siginfo, int) error {
+		t.Fatal("matching-argv PID received a signal from malformed owner lock")
+		return nil
+	}
+	t.Cleanup(func() {
+		linuxPidfdOpen = oldOpen
+		linuxPidfdSendSignal = oldSignal
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "99999",
+			BootID:     owner.BootID,
+			Executable: "/usr/local/bin/amq",
+			Args:       lock.Args,
+		}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockUnverified {
+		t.Fatalf("malformed owner wake status = %s, want unverified", inspection.Status)
+	}
+	state, _ := classifyWakeIdentity(inspection, inspection.Process)
+	if state != wakeIdentityUnknown {
+		t.Fatalf("matching-argv malformed owner wake identity = %s, want unknown", state)
+	}
+
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		expected := readWakeLockMetadataAt(dirfd, agentDir, root, "codex")
+		_, err := prepareAuthoritativeWakeStopPlatform(dirfd, agentDir, expected)
+		return err
+	})
+	if err == nil || !strings.Contains(err.Error(), "not authoritative") {
+		t.Fatalf("malformed stable-stop error = %v, want authoritative refusal", err)
+	}
+}

--- a/internal/cli/wake_owner_lifecycle_unix_test.go
+++ b/internal/cli/wake_owner_lifecycle_unix_test.go
@@ -1,0 +1,1703 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestValidateAuthoritativeWakeOwnerSeparatesStrictClaimsFromLegacyParsing(t *testing.T) {
+	valid := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	if err := validateWakeOwner(valid); err != nil {
+		t.Fatalf("legacy validator rejected valid owner: %v", err)
+	}
+	if err := validateAuthoritativeWakeOwner(valid); err != nil {
+		t.Fatalf("strict validator rejected valid owner: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		owner wakeOwner
+		want  string
+	}{
+		{name: "missing process start", owner: wakeOwner{PID: 4242, BootID: valid.BootID, SessionID: 99}, want: "process start"},
+		{name: "missing boot id", owner: wakeOwner{PID: 4242, ProcessStart: valid.ProcessStart, SessionID: 99}, want: "boot id"},
+		{name: "zero session", owner: wakeOwner{PID: 4242, ProcessStart: valid.ProcessStart, BootID: valid.BootID}, want: "session"},
+		{name: "surrounding process whitespace", owner: wakeOwner{PID: 4242, ProcessStart: " 12345 ", BootID: valid.BootID, SessionID: 99}, want: "canonical"},
+		{name: "surrounding boot whitespace", owner: wakeOwner{PID: 4242, ProcessStart: valid.ProcessStart, BootID: " " + valid.BootID + " ", SessionID: 99}, want: "canonical"},
+		{name: "process control character", owner: wakeOwner{PID: 4242, ProcessStart: "123\n45", BootID: valid.BootID, SessionID: 99}, want: "control"},
+		{name: "boot control character", owner: wakeOwner{PID: 4242, ProcessStart: valid.ProcessStart, BootID: "11111111-1111-1111-\t1111-111111111111", SessionID: 99}, want: "control"},
+		{name: "malformed process start", owner: wakeOwner{PID: 4242, ProcessStart: "owner-start", BootID: valid.BootID, SessionID: 99}, want: "malformed platform"},
+		{name: "noncanonical process start", owner: wakeOwner{PID: 4242, ProcessStart: "012345", BootID: valid.BootID, SessionID: 99}, want: "malformed platform"},
+		{name: "malformed boot id", owner: wakeOwner{PID: 4242, ProcessStart: valid.ProcessStart, BootID: "boot-1", SessionID: 99}, want: "malformed platform"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateWakeOwner(test.owner); err != nil {
+				t.Fatalf("legacy validator must keep record readable: %v", err)
+			}
+			err := validateAuthoritativeWakeOwner(test.owner)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("strict validator error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestOwnerWakeLockFenceRequiresStrictSchemaAndMode(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-fence-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &owner
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--me", "codex", "--root", root},
+		Generation:   "owner-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != lock.PID {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: lock.ProcessStart,
+			BootID:     lock.BootID,
+			Executable: lock.Executable,
+			Args:       lock.Args,
+		}
+	})
+
+	write := func(t *testing.T, value wakeLock, mode os.FileMode) {
+		t.Helper()
+		lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+		if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		path := writeWakeLockForTest(t, root, "codex", value)
+		if err := os.Chmod(path, mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("strict 0400 owner schema is readable", func(t *testing.T) {
+		write(t, lock, wakeOwnerLockFileMode)
+		inspection := inspectWakeLock(root, "codex")
+		if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+			t.Fatalf("owner lock inspection = %#v, want confirmed valid", inspection)
+		}
+		if !sameWakeOwner(inspection.Lock.Owner, &owner) {
+			t.Fatalf("owner lock owner = %#v, want %#v", inspection.Lock.Owner, owner)
+		}
+	})
+
+	t.Run("0400 without owner schema is unverified", func(t *testing.T) {
+		malformed := lock
+		malformed.OwnerSchema = 0
+		write(t, malformed, wakeOwnerLockFileMode)
+		inspection := inspectWakeLock(root, "codex")
+		if inspection.Status != wakeLockUnverified ||
+			!strings.Contains(inspection.Reason, "owner schema") ||
+			!strings.Contains(inspection.Reason, "newer amq") {
+			t.Fatalf("malformed owner lock inspection = %#v, want newer-amq owner-schema refusal", inspection)
+		}
+	})
+
+	t.Run("0400 requires strict wake process identity", func(t *testing.T) {
+		for _, test := range []struct {
+			name   string
+			mutate func(*wakeLock)
+			want   string
+		}{
+			{
+				name:   "missing process start",
+				mutate: func(value *wakeLock) { value.ProcessStart = "" },
+				want:   "wake process start is required",
+			},
+			{
+				name:   "missing boot id",
+				mutate: func(value *wakeLock) { value.BootID = "" },
+				want:   "wake boot id is required",
+			},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				malformed := lock
+				test.mutate(&malformed)
+				write(t, malformed, wakeOwnerLockFileMode)
+				inspection := inspectWakeLock(root, "codex")
+				if inspection.Status != wakeLockUnverified || !strings.Contains(inspection.Reason, test.want) {
+					t.Fatalf("owner wake identity inspection = %#v, want %q", inspection, test.want)
+				}
+				reused := wakeProcessInfo{
+					PID:        malformed.PID,
+					Running:    true,
+					StartToken: "99999",
+					BootID:     owner.BootID,
+					Executable: "/usr/local/bin/amq",
+					Args:       malformed.Args,
+				}
+				state, _ := classifyWakeIdentity(inspection, reused)
+				if state != wakeIdentityUnknown {
+					t.Fatalf("malformed owner wake classified %s against matching argv, want unknown", state)
+				}
+			})
+		}
+	})
+
+	t.Run("malformed 0400 record surfaces newer amq through acquisition", func(t *testing.T) {
+		lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+		if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(lockPath, []byte("{not-json"), wakeOwnerLockFileMode); err != nil {
+			t.Fatal(err)
+		}
+		inspection := inspectWakeLock(root, "codex")
+		if inspection.Status != wakeLockUnverified || !strings.Contains(inspection.Reason, "newer amq") {
+			t.Fatalf("malformed 0400 inspection = %#v, want newer-amq refusal", inspection)
+		}
+		if _, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{}); err == nil ||
+			!strings.Contains(err.Error(), "newer amq") {
+			t.Fatalf("generic acquisition error = %v, want newer-amq diagnostic", err)
+		}
+		requested := target
+		if _, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+			target:   &requested,
+			wakeMode: wakeTargetInjectVia,
+		}); err == nil || !strings.Contains(err.Error(), "newer amq") {
+			t.Fatalf("owner acquisition error = %v, want newer-amq diagnostic", err)
+		}
+	})
+
+	t.Run("0600 owner markers are unverified corruption", func(t *testing.T) {
+		write(t, lock, 0o600)
+		inspection := inspectWakeLock(root, "codex")
+		if inspection.Status != wakeLockUnverified || !strings.Contains(inspection.Reason, "owner") {
+			t.Fatalf("legacy-mode owner lock inspection = %#v, want owner-marker refusal", inspection)
+		}
+	})
+}
+
+func TestAuthoritativeOwnerLockRequiresTheSameStrictOwnerInTarget(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "owner-pair-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &owner
+	lock := wakeLock{
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		WakeMode:     wakeOwnerWakeMode,
+		TargetDigest: mustWakeTargetDigest(target),
+		Generation:   "owner-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}
+	if err := validateWakeTargetMatchesLock(lock, target); err != nil {
+		t.Fatalf("strict owner pair rejected: %v", err)
+	}
+
+	missing := target
+	missing.Owner = nil
+	missingLock := lock
+	missingLock.TargetDigest = mustWakeTargetDigest(missing)
+	if err := validateWakeTargetMatchesLock(missingLock, missing); err == nil || !strings.Contains(err.Error(), "owner") {
+		t.Fatalf("missing target owner error = %v, want owner refusal", err)
+	}
+
+	different := target
+	other := owner
+	other.PID++
+	different.Owner = &other
+	differentLock := lock
+	differentLock.TargetDigest = mustWakeTargetDigest(different)
+	if err := validateWakeTargetMatchesLock(differentLock, different); err == nil || !strings.Contains(err.Error(), "owner") {
+		t.Fatalf("different target owner error = %v, want owner refusal", err)
+	}
+}
+
+func TestPublishAuthoritativeWakeClaimCommitsACompleteReadOnlyGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-publish-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &owner
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-23T00:00:00Z",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--me", "codex", "--root", root},
+		Generation:   "owner-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, "codex", target, lock)
+	}); err != nil {
+		t.Fatalf("publish owner claim: %v", err)
+	}
+
+	lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+	targetPath := wakeTargetPath(root, "codex")
+	lockInfo, err := os.Lstat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := lockInfo.Mode().Perm(); got != wakeOwnerLockFileMode {
+		t.Fatalf("owner lock mode = %o, want %o", got, wakeOwnerLockFileMode)
+	}
+	targetInfo, err := os.Lstat(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := targetInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("owner target mode = %o, want 0600", got)
+	}
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted wakeLock
+	if err := json.Unmarshal(lockData, &persisted); err != nil {
+		t.Fatalf("parse committed owner lock: %v", err)
+	}
+	if persisted.OwnerSchema != wakeOwnerLockSchema || persisted.WakeMode != wakeOwnerWakeMode ||
+		!sameWakeOwner(persisted.Owner, &owner) || persisted.TargetDigest != mustWakeTargetDigest(target) {
+		t.Fatalf("committed owner lock = %#v", persisted)
+	}
+
+	replacement := lock
+	replacement.Generation = "replacement-generation"
+	replacementTarget := target
+	replacementTarget.Created = "2026-07-23T01:00:00Z"
+	replacement.TargetDigest = mustWakeTargetDigest(replacementTarget)
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, "codex", replacementTarget, replacement)
+	})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("replacement publication error = %v, want no-replace refusal", err)
+	}
+	afterInfo, err := os.Lstat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameWakeFileIdentity(lockInfo, afterInfo) || string(afterData) != string(lockData) {
+		t.Fatal("existing owner lock changed after no-replace refusal")
+	}
+}
+
+func TestPublishAuthoritativeWakeClaimDirectorySyncFailureIsNotDegradable(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-sync-failure-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Generation:   "owner-sync-failure-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+
+	originalSync := syncWakeOwnerDirFD
+	syncWakeOwnerDirFD = func(int) error { return syscall.ENOSYS }
+	t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
+
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, "codex", target, lock)
+	})
+	var publicationErr *wakeOwnerPublicationError
+	if !errors.As(err, &publicationErr) {
+		t.Fatalf("publication error = %v, want typed durability failure", err)
+	}
+	if publicationErr.Unsupported {
+		t.Fatalf("directory-sync failure was marked degradable: %#v", publicationErr)
+	}
+	if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+		t.Fatalf("directory-sync failure published a lock: %#v", inspection)
+	}
+}
+
+func TestReleasedWakeTargetCleanupPreservesAReplacementSnapshot(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-release-snapshot-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		snapshot, exists, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, "codex")
+		if err != nil || !exists {
+			return errors.New("initial wake target snapshot is unavailable")
+		}
+		replacement := target
+		replacement.Created = "2026-07-23T02:00:00Z"
+		data, err := json.MarshalIndent(replacement, "", "  ")
+		if err != nil {
+			return err
+		}
+		replacementPath := wakeTargetPath(root, "codex") + ".replacement"
+		if err := os.WriteFile(replacementPath, append(data, '\n'), 0o600); err != nil {
+			return err
+		}
+		if err := os.Rename(replacementPath, wakeTargetPath(root, "codex")); err != nil {
+			return err
+		}
+		removed, err := removeWakeTargetIfSnapshotMatchesAt(
+			dirfd,
+			agentDir,
+			root,
+			"codex",
+			snapshot,
+		)
+		if err == nil || !strings.Contains(err.Error(), "changed before cleanup") {
+			return errors.New("replacement wake target was not rejected")
+		}
+		if removed {
+			return errors.New("replacement wake target was removed")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, exists, err := readWakeTarget(root, "codex")
+	if err != nil || !exists || persisted.Created != "2026-07-23T02:00:00Z" {
+		t.Fatalf("replacement wake target was not preserved: target=%#v exists=%v err=%v", persisted, exists, err)
+	}
+}
+
+func TestAcquireAuthoritativeWakeClaimPublishesOwnerAndCleanupPreservesLifetime(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-acquire-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &owner
+
+	ownerState := wakeOwnerSame
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if err := validateAuthoritativeWakeOwner(got); err != nil {
+			t.Fatalf("observed invalid owner %#v: %v", got, err)
+		}
+		return wakeOwnerObservation{State: ownerState, Reason: "test owner evidence"}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+	wakeRunning := true
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != os.Getpid() {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    wakeRunning,
+			StartToken: "67890",
+			BootID:     owner.BootID,
+			Executable: "/usr/local/bin/amq",
+			Args:       []string{"amq", "wake", "--me", "codex", "--root", root},
+		}
+	})
+
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err != nil {
+		t.Fatalf("acquire owner claim: %v", err)
+	}
+	lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+	info, err := os.Lstat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != wakeOwnerLockFileMode {
+		t.Fatalf("owner lock mode = %o, want %o", got, wakeOwnerLockFileMode)
+	}
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockValid || inspection.Lock.OwnerSchema != wakeOwnerLockSchema ||
+		inspection.Lock.WakeMode != wakeOwnerWakeMode || !sameWakeOwner(inspection.Lock.Owner, &owner) {
+		t.Fatalf("owner inspection = %#v", inspection)
+	}
+	ownerState = wakeOwnerUnknown
+	if err := writeWakeReadyFile(root, "codex", filepath.Join(root, "owner.ready"), inspection); err == nil ||
+		!strings.Contains(err.Error(), "owner") {
+		t.Fatalf("readiness with unknown owner error = %v, want owner refusal", err)
+	}
+	if current := inspectWakeLock(root, "codex"); !sameWakeLockGeneration(inspection, current) {
+		t.Fatal("failed owner readiness validation changed claim")
+	}
+	ownerState = wakeOwnerSame
+	readyPath := filepath.Join(root, "owner.ready")
+	if err := writeWakeReadyFile(root, "codex", readyPath, inspection); err != nil {
+		t.Fatalf("write owner readiness: %v", err)
+	}
+	differentReadyOwner := owner
+	differentReadyOwner.PID++
+	differentReadyOwner.ProcessStart = "23456"
+	if _, err := validateWakeReadyFileAgainstOwner(
+		root,
+		"codex",
+		readyPath,
+		&differentReadyOwner,
+	); err == nil || !strings.Contains(err.Error(), "requested owner") {
+		t.Fatalf("different requested owner readiness error = %v", err)
+	}
+	if err := writeWakePreparedFile(root, "codex", inspection); err != nil {
+		t.Fatalf("write owner prepared marker: %v", err)
+	}
+	preparedInfo, err := os.Lstat(wakePreparedPath(root, "codex"))
+	if err != nil || preparedInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("owner prepared marker info=%v err=%v", preparedInfo, err)
+	}
+
+	cleanup()
+	after := inspectWakeLock(root, "codex")
+	if !sameWakeLockGeneration(inspection, after) {
+		t.Fatalf("ordinary wake cleanup removed owner claim: before=%#v after=%#v", inspection, after)
+	}
+
+	_, err = acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		acceptExistingValid: true,
+		target:              &target,
+		wakeMode:            wakeTargetInjectVia,
+	})
+	var alreadyRunning *wakeAlreadyRunningError
+	if !errors.As(err, &alreadyRunning) || !sameWakeLockGeneration(inspection, alreadyRunning.Inspection) {
+		t.Fatalf("same-owner reuse error = %v, want exact existing generation", err)
+	}
+
+	differentTarget := target
+	differentOwner := owner
+	differentOwner.PID++
+	differentOwner.ProcessStart = "23456"
+	differentTarget.Owner = &differentOwner
+	_, err = acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		acceptExistingValid: true,
+		target:              &differentTarget,
+		wakeMode:            wakeTargetInjectVia,
+	})
+	if err == nil || !strings.Contains(err.Error(), "owned by live process") {
+		t.Fatalf("different-owner acquisition error = %v, want live-owner conflict", err)
+	}
+
+	wakeRunning = false
+	_, err = acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		acceptExistingValid: true,
+		target:              &target,
+		wakeMode:            wakeTargetInjectVia,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unusable wake") {
+		t.Fatalf("same-owner damaged wake error = %v, want recover-owner refusal", err)
+	}
+	preserved := inspectWakeLock(root, "codex")
+	if !sameWakeLockGeneration(inspection, preserved) {
+		t.Fatalf("same-owner damaged wake changed claim: before=%#v after=%#v", inspection, preserved)
+	}
+}
+
+func TestConcurrentAuthoritativeAcquisitionPublishesOneGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-contention-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &owner
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "67890",
+			BootID:     owner.BootID,
+			Executable: "/usr/local/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+		}
+	})
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+		return wakeOwnerObservation{State: wakeOwnerSame}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+	const contenders = 16
+	start := make(chan struct{})
+	results := make(chan error, contenders)
+	var group sync.WaitGroup
+	for range contenders {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			requested := target
+			_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+				acceptExistingValid: true,
+				target:              &requested,
+				wakeMode:            wakeTargetInjectVia,
+			})
+			results <- err
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(results)
+
+	winners := 0
+	reusers := 0
+	for err := range results {
+		if err == nil {
+			winners++
+			continue
+		}
+		var alreadyRunning *wakeAlreadyRunningError
+		if errors.As(err, &alreadyRunning) {
+			reusers++
+			continue
+		}
+		t.Fatalf("contention result: %v", err)
+	}
+	if winners != 1 || reusers != contenders-1 {
+		t.Fatalf("contention winners=%d reusers=%d, want 1/%d", winners, reusers, contenders-1)
+	}
+	inspection := inspectWakeLock(root, "codex")
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		_, err := validateAuthoritativeWakeClaimPairAt(dirfd, agentDir, inspection)
+		return err
+	})
+	_ = agentDir.Close()
+	if err != nil {
+		t.Fatalf("contended claim is incomplete: %v", err)
+	}
+}
+
+func TestAcquireAuthoritativeWakeClaimReclaimsOnlyADeadOwnerWithAbsentWake(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-takeover-injector")
+	oldOwner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    88,
+	}
+	oldTarget := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	oldTarget.Owner = &oldOwner
+	oldLock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-23T00:00:00Z",
+		ProcessStart: "67890",
+		BootID:       oldOwner.BootID,
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--me", "codex", "--root", root},
+		Generation:   "old-owner-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &oldOwner,
+	}, oldTarget)
+	oldLock.WakeMode = wakeOwnerWakeMode
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, "codex", oldTarget, oldLock)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_ = agentDir.Close()
+
+	newOwner := wakeOwner{
+		PID:          6262,
+		ProcessStart: "23456",
+		BootID:       oldOwner.BootID,
+		SessionID:    99,
+	}
+	newTarget := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	newTarget.Owner = &newOwner
+
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(owner wakeOwner) (wakeOwnerObservation, error) {
+		switch owner {
+		case oldOwner:
+			return wakeOwnerObservation{State: wakeOwnerDead, Reason: "owner process is not running"}, nil
+		case newOwner:
+			return wakeOwnerObservation{State: wakeOwnerSame}, nil
+		default:
+			t.Fatalf("unexpected owner observation: %#v", owner)
+			return wakeOwnerObservation{}, nil
+		}
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		switch pid {
+		case oldLock.PID:
+			return wakeProcessInfo{PID: pid}
+		case os.Getpid():
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "78901",
+				BootID:     newOwner.BootID,
+				Executable: "/usr/local/bin/amq",
+				Args:       []string{"amq", "wake", "--me", "codex", "--root", root, "--inject-via", injector},
+			}
+		default:
+			return wakeProcessInfo{PID: pid}
+		}
+	})
+
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &newTarget,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err != nil {
+		t.Fatalf("dead-owner takeover: %v", err)
+	}
+	defer cleanup()
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Lock.Generation == oldLock.Generation ||
+		!sameWakeOwner(inspection.Lock.Owner, &newOwner) ||
+		inspection.Lock.TargetDigest != mustWakeTargetDigest(newTarget) {
+		t.Fatalf("takeover claim = %#v", inspection)
+	}
+}
+
+func TestGenericStaleCleanupCannotRemoveAuthoritativeOwnerClaim(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-cleanup-fence-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Generation:   "owner-cleanup-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockStale {
+		t.Fatalf("owner wake status = %s, want stale wake process", inspection.Status)
+	}
+	if err := validateWakeLockStaleRemoval(inspection); err == nil || !strings.Contains(err.Error(), "recover-owner") {
+		t.Fatalf("generic stale-removal gate = %v, want recover-owner refusal", err)
+	}
+	if err := cleanupTerminatedWakeLock(inspection); err == nil || !strings.Contains(err.Error(), "recover-owner") {
+		t.Fatalf("generic terminated cleanup = %v, want recover-owner refusal", err)
+	}
+	after := inspectWakeLock(root, "codex")
+	if !sameWakeLockGeneration(inspection, after) {
+		t.Fatalf("generic cleanup changed owner claim: before=%#v after=%#v", inspection, after)
+	}
+}
+
+func TestExactHelperCleanupHandlesFreshOwnerlessFallback(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "ownerless-fallback-cleanup-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	const wakePID = 5151
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "67890",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+		Generation:   "ownerless-fallback-cleanup-generation",
+	}, target)
+	lock.WakeMode = wakeTargetInjectVia
+	writeWakeLockForTest(t, root, "codex", lock)
+
+	stopped := false
+	closed := false
+	capability := &authoritativeWakeChildCapability{
+		stop: func() error {
+			stopped = true
+			return nil
+		},
+		close: func() error {
+			closed = true
+			return nil
+		},
+	}
+	waiter := &wakeProcessWaiter{done: make(chan struct{})}
+	close(waiter.done)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		if stopped {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: lock.ProcessStart,
+			BootID:     lock.BootID,
+			Executable: lock.Executable,
+			Args:       lock.Args,
+		}
+	})
+	owner := wakeOwner{
+		PID:          os.Getpid(),
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	if err := terminateAuthoritativeWakeHelperProcess(
+		&os.Process{Pid: wakePID},
+		waiter,
+		capability,
+		root,
+		"codex",
+		owner,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !stopped || !closed {
+		t.Fatalf("stable fallback cleanup stopped=%v closed=%v", stopped, closed)
+	}
+	if inspectWakeLock(root, "codex").Exists {
+		t.Fatal("stable fallback cleanup left the generic lock")
+	}
+}
+
+func TestExactHelperCleanupRollsBackOnlyCurrentAuthoritativeOwner(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := captureAuthoritativeCurrentWakeOwner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "authoritative-rollback-cleanup-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	const wakePID = 5151
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+		Generation:   "authoritative-rollback-cleanup-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, "codex", target, lock)
+	})
+	_ = agentDir.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stopped := false
+	capability := &authoritativeWakeChildCapability{
+		stop: func() error {
+			stopped = true
+			return nil
+		},
+	}
+	waiter := &wakeProcessWaiter{done: make(chan struct{})}
+	close(waiter.done)
+	realInspect := inspectWakeProcess
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			if stopped {
+				return wakeProcessInfo{
+					PID:        pid,
+					Running:    true,
+					StartToken: "78901",
+					BootID:     lock.BootID,
+					Executable: lock.Executable,
+					Args:       lock.Args,
+				}
+			}
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: lock.ProcessStart,
+				BootID:     lock.BootID,
+				Executable: lock.Executable,
+				Args:       lock.Args,
+			}
+		}
+		return realInspect(pid)
+	})
+	if err := terminateAuthoritativeWakeHelperProcess(
+		&os.Process{Pid: wakePID},
+		waiter,
+		capability,
+		root,
+		"codex",
+		owner,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !stopped {
+		t.Fatal("authoritative rollback did not use the stable child capability")
+	}
+	if inspectWakeLock(root, "codex").Exists {
+		t.Fatal("exact current-owner rollback left the authoritative lock")
+	}
+
+	stopped = false
+	agentDir, err = openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, "codex", target, lock)
+	})
+	_ = agentDir.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rollbackAuthoritativeWakeClaim(root, "codex", owner); err == nil ||
+		!strings.Contains(err.Error(), "not conclusively absent") {
+		t.Fatalf("live recorded wake rollback error = %v, want refusal", err)
+	}
+	if inspection := inspectWakeLock(root, "codex"); inspection.Status != wakeLockValid ||
+		!inspection.IdentityConfirmed {
+		t.Fatalf("refused live rollback changed authoritative claim: %#v", inspection)
+	}
+}
+
+func TestRecoverOwnerRequiresExactTokenAndCallerSessionForLiveOwner(t *testing.T) {
+	tests := []struct {
+		name        string
+		ownerState  wakeOwnerIdentityState
+		token       bool
+		callerSID   int
+		callerErr   error
+		wantSuccess bool
+		wantReason  string
+	}{
+		{
+			name:        "live owner exact token and session releases",
+			ownerState:  wakeOwnerSame,
+			token:       true,
+			callerSID:   99,
+			wantSuccess: true,
+		},
+		{
+			name:       "token replay from another session refuses",
+			ownerState: wakeOwnerSame,
+			token:      true,
+			callerSID:  100,
+			wantReason: "OS session",
+		},
+		{
+			name:       "caller session lookup failure refuses",
+			ownerState: wakeOwnerSame,
+			token:      true,
+			callerErr:  errors.New("session unavailable"),
+			wantReason: "session unavailable",
+		},
+		{
+			name:       "missing live owner token refuses",
+			ownerState: wakeOwnerSame,
+			callerSID:  99,
+			wantReason: "token",
+		},
+		{
+			name:        "dead owner needs no token",
+			ownerState:  wakeOwnerDead,
+			wantSuccess: true,
+		},
+		{
+			name:       "unknown owner preserves claim",
+			ownerState: wakeOwnerUnknown,
+			wantReason: "unknown",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			injector := writeExecutableForTest(t, "owner-recover-injector")
+			owner := wakeOwner{
+				PID:          4242,
+				ProcessStart: "12345",
+				BootID:       "11111111-1111-1111-1111-111111111111",
+				SessionID:    99,
+			}
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+			target.Owner = &owner
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatal(err)
+			}
+			lock := bindWakeLockToTarget(wakeLock{
+				PID:          5151,
+				TTY:          "unknown",
+				ProcessStart: "67890",
+				BootID:       owner.BootID,
+				Generation:   "owner-recover-generation",
+				OwnerSchema:  wakeOwnerLockSchema,
+				Owner:        &owner,
+			}, target)
+			lock.WakeMode = wakeOwnerWakeMode
+			lockPath := writeWakeLockForTest(t, root, "codex", lock)
+			if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+				t.Fatal(err)
+			}
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				return wakeProcessInfo{PID: pid}
+			})
+			oldObserve := observeAuthoritativeWakeOwner
+			observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+				if got != owner {
+					t.Fatalf("observed owner = %#v, want %#v", got, owner)
+				}
+				return wakeOwnerObservation{State: test.ownerState, Reason: test.wantReason}, nil
+			}
+			t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+			stubWakeProcessSID(t, func(pid int) (int, error) {
+				if pid != os.Getpid() {
+					t.Fatalf("caller sid lookup pid = %d, want %d", pid, os.Getpid())
+				}
+				return test.callerSID, test.callerErr
+			})
+			if test.token {
+				encoded, err := encodeWakeOwnerEnv(owner)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv(envWakeOwner, encoded)
+			} else {
+				t.Setenv(envWakeOwner, "")
+			}
+
+			result, err := recoverOwnerWake(root, "codex")
+			if test.wantSuccess {
+				if err != nil || result.Status != "recovered" {
+					t.Fatalf("recover result = %#v err=%v", result, err)
+				}
+				if inspectWakeLock(root, "codex").Exists {
+					t.Fatal("successful recovery preserved owner lock")
+				}
+				return
+			}
+			if err == nil || result.Status != "refused" ||
+				!strings.Contains(strings.ToLower(result.Reason), strings.ToLower(test.wantReason)) {
+				t.Fatalf("recover result = %#v err=%v, want reason %q", result, err, test.wantReason)
+			}
+			if !inspectWakeLock(root, "codex").Exists {
+				t.Fatal("refused recovery removed owner lock")
+			}
+		})
+	}
+}
+
+func TestRecoverOwnerUsesAuthoritativeLockEvidenceWhenTargetIsMissing(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-missing-target-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Generation:   "owner-missing-target-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid}
+	})
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+		return wakeOwnerObservation{State: wakeOwnerDead}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+	result, err := recoverOwnerWake(root, "codex")
+	if err != nil || result.Status != "recovered" {
+		t.Fatalf("missing-target recovery result = %#v err=%v", result, err)
+	}
+	if inspectWakeLock(root, "codex").Exists {
+		t.Fatal("missing-target recovery preserved authoritative lock")
+	}
+}
+
+func TestRecoverOwnerPreservesMalformedAuthoritativeLockEnvelope(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*wakeLock)
+	}{
+		{name: "root mismatch", mutate: func(lock *wakeLock) { lock.Root += "-other" }},
+		{name: "agent mismatch", mutate: func(lock *wakeLock) { lock.Agent = "claude" }},
+		{name: "invalid wake pid", mutate: func(lock *wakeLock) { lock.PID = 0 }},
+		{name: "malformed owner token", mutate: func(lock *wakeLock) { lock.Owner.ProcessStart = "not-a-platform-token" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			injector := writeExecutableForTest(t, "owner-malformed-envelope-injector")
+			owner := wakeOwner{
+				PID:          4242,
+				ProcessStart: "12345",
+				BootID:       "11111111-1111-1111-1111-111111111111",
+				SessionID:    99,
+			}
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+			target.Owner = &owner
+			lock := bindWakeLockToTarget(wakeLock{
+				PID:          5151,
+				TTY:          "unknown",
+				ProcessStart: "67890",
+				BootID:       owner.BootID,
+				Generation:   "owner-malformed-envelope-generation",
+				OwnerSchema:  wakeOwnerLockSchema,
+				Owner:        &owner,
+			}, target)
+			lock.WakeMode = wakeOwnerWakeMode
+			test.mutate(&lock)
+			lockPath := writeWakeLockForTest(t, root, "codex", lock)
+			if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(lockPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			beforeInfo, err := os.Lstat(lockPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldObserve := observeAuthoritativeWakeOwner
+			observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+				t.Fatal("malformed lock envelope reached owner observation")
+				return wakeOwnerObservation{}, nil
+			}
+			t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+			result, err := recoverOwnerWake(root, "codex")
+			if err == nil || result.Status != "refused" {
+				t.Fatalf("malformed-envelope recovery = %#v err=%v", result, err)
+			}
+			after, readErr := os.ReadFile(lockPath)
+			afterInfo, statErr := os.Lstat(lockPath)
+			if readErr != nil || statErr != nil || !bytes.Equal(before, after) || !os.SameFile(beforeInfo, afterInfo) {
+				t.Fatalf("malformed envelope changed: read=%v stat=%v", readErr, statErr)
+			}
+		})
+	}
+}
+
+func TestRecoverOwnerPreservesUntrustedTargetButRejectsDifferentCompleteOwner(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		different     bool
+		wantRecovered bool
+	}{
+		{name: "corrupt target is preserved", wantRecovered: true},
+		{name: "different complete owner is ambiguous", different: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			injector := writeExecutableForTest(t, "owner-untrusted-target-injector")
+			owner := wakeOwner{
+				PID:          4242,
+				ProcessStart: "12345",
+				BootID:       "11111111-1111-1111-1111-111111111111",
+				SessionID:    99,
+			}
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+			target.Owner = &owner
+			lock := bindWakeLockToTarget(wakeLock{
+				PID:          5151,
+				TTY:          "unknown",
+				ProcessStart: "67890",
+				BootID:       owner.BootID,
+				Generation:   "owner-untrusted-target-generation",
+				OwnerSchema:  wakeOwnerLockSchema,
+				Owner:        &owner,
+			}, target)
+			lock.WakeMode = wakeOwnerWakeMode
+			lockPath := writeWakeLockForTest(t, root, "codex", lock)
+			if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+				t.Fatal(err)
+			}
+			targetPath := wakeTargetPath(root, "codex")
+			if test.different {
+				other := owner
+				other.PID++
+				other.ProcessStart = "23456"
+				target.Owner = &other
+				data, err := json.Marshal(target)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(targetPath, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(targetPath, []byte("{not-json"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				return wakeProcessInfo{PID: pid}
+			})
+			oldObserve := observeAuthoritativeWakeOwner
+			observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+				return wakeOwnerObservation{State: wakeOwnerDead}, nil
+			}
+			t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+			result, err := recoverOwnerWake(root, "codex")
+			if test.wantRecovered {
+				if err != nil || result.Status != "recovered" {
+					t.Fatalf("untrusted-target recovery = %#v err=%v", result, err)
+				}
+				if inspectWakeLock(root, "codex").Exists {
+					t.Fatal("untrusted target prevented authoritative lock recovery")
+				}
+				if _, err := os.Lstat(targetPath); err != nil {
+					t.Fatalf("untrusted target was not preserved: %v", err)
+				}
+				return
+			}
+			if err == nil || result.Status != "refused" || !strings.Contains(result.Reason, "different owners") {
+				t.Fatalf("different-owner recovery = %#v err=%v", result, err)
+			}
+			if !inspectWakeLock(root, "codex").Exists {
+				t.Fatal("ambiguous different-owner target allowed lock removal")
+			}
+		})
+	}
+}
+
+func TestDecideOwnerLifecycleTransitionPreemptsLegacyMutationRules(t *testing.T) {
+	tests := []struct {
+		name     string
+		evidence wakeOwnerTransitionEvidence
+		want     wakeOwnerTransitionAction
+	}{
+		{
+			name: "fresh exact owner publishes",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:        wakeOwnerRequestAcquire,
+				Claim:          wakeClaimAbsent,
+				RequestedState: wakeOwnerSame,
+			},
+			want: wakeOwnerActionPublish,
+		},
+		{
+			name: "same owner reuses exact usable wake",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:        wakeOwnerRequestAcquire,
+				Claim:          wakeClaimAuthoritative,
+				RequestedState: wakeOwnerSame,
+				PersistedState: wakeOwnerSame,
+				OwnersEqual:    true,
+				WakeUsable:     true,
+			},
+			want: wakeOwnerActionReuse,
+		},
+		{
+			name: "same owner damaged wake requires explicit recovery",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:        wakeOwnerRequestAcquire,
+				Claim:          wakeClaimAuthoritative,
+				RequestedState: wakeOwnerSame,
+				PersistedState: wakeOwnerSame,
+				OwnersEqual:    true,
+			},
+			want: wakeOwnerActionRefuse,
+		},
+		{
+			name: "different live owner conflicts",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:        wakeOwnerRequestAcquire,
+				Claim:          wakeClaimAuthoritative,
+				RequestedState: wakeOwnerSame,
+				PersistedState: wakeOwnerSame,
+			},
+			want: wakeOwnerActionRefuse,
+		},
+		{
+			name: "dead owner with exact live wake stops before release",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:            wakeOwnerRequestAcquire,
+				Claim:              wakeClaimAuthoritative,
+				RequestedState:     wakeOwnerSame,
+				PersistedState:     wakeOwnerDead,
+				WakeExactStoppable: true,
+			},
+			want: wakeOwnerActionStopAndRelease,
+		},
+		{
+			name: "dead owner with absent wake releases",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:        wakeOwnerRequestAcquire,
+				Claim:          wakeClaimAuthoritative,
+				RequestedState: wakeOwnerSame,
+				PersistedState: wakeOwnerDead,
+				WakeAbsent:     true,
+			},
+			want: wakeOwnerActionRelease,
+		},
+		{
+			name: "unknown owner never aliases dead",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:        wakeOwnerRequestAcquire,
+				Claim:          wakeClaimAuthoritative,
+				RequestedState: wakeOwnerSame,
+				PersistedState: wakeOwnerUnknown,
+				WakeAbsent:     true,
+			},
+			want: wakeOwnerActionRefuse,
+		},
+		{
+			name: "generic acquisition cannot cross owner claim",
+			evidence: wakeOwnerTransitionEvidence{
+				Request: wakeGenericRequestAcquire,
+				Claim:   wakeClaimAuthoritative,
+			},
+			want: wakeOwnerActionRefuse,
+		},
+		{
+			name: "generic acquisition stays on the absent legacy path",
+			evidence: wakeOwnerTransitionEvidence{
+				Request: wakeGenericRequestAcquire,
+				Claim:   wakeClaimAbsent,
+			},
+			want: wakeOwnerActionLegacy,
+		},
+		{
+			name: "generic cleanup cannot cross owner claim",
+			evidence: wakeOwnerTransitionEvidence{
+				Request: wakeGenericRequestMutate,
+				Claim:   wakeClaimAuthoritative,
+			},
+			want: wakeOwnerActionRefuse,
+		},
+		{
+			name: "generic cleanup stays on the ownerless legacy path",
+			evidence: wakeOwnerTransitionEvidence{
+				Request: wakeGenericRequestMutate,
+				Claim:   wakeClaimGeneric,
+			},
+			want: wakeOwnerActionLegacy,
+		},
+		{
+			name: "authenticated live recovery stops exact wake",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:            wakeOwnerRequestRecover,
+				Claim:              wakeClaimAuthoritative,
+				PersistedState:     wakeOwnerSame,
+				Authenticated:      true,
+				WakeExactStoppable: true,
+			},
+			want: wakeOwnerActionStopAndRelease,
+		},
+		{
+			name: "token without caller authentication cannot recover",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:        wakeOwnerRequestRecover,
+				Claim:          wakeClaimAuthoritative,
+				PersistedState: wakeOwnerSame,
+				WakeAbsent:     true,
+			},
+			want: wakeOwnerActionRefuse,
+		},
+		{
+			name: "corruption is never downgraded",
+			evidence: wakeOwnerTransitionEvidence{
+				Request:        wakeOwnerRequestAcquire,
+				Claim:          wakeClaimInvalid,
+				RequestedState: wakeOwnerSame,
+			},
+			want: wakeOwnerActionRefuse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := decideOwnerLifecycleTransition(test.evidence); got != test.want {
+				t.Fatalf("transition = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAuthoritativeWakeOwnerKeepsDeadSeparateFromUnknown(t *testing.T) {
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	matching := wakeProcessInfo{
+		PID:        owner.PID,
+		Running:    true,
+		StartToken: owner.ProcessStart,
+		BootID:     owner.BootID,
+	}
+
+	tests := []struct {
+		name       string
+		process    wakeProcessInfo
+		sessionID  int
+		sessionErr error
+		want       wakeOwnerIdentityState
+	}{
+		{
+			name:       "conclusive absence wins without boot evidence",
+			process:    wakeProcessInfo{PID: owner.PID},
+			sessionErr: errors.New("session unavailable"),
+			want:       wakeOwnerDead,
+		},
+		{
+			name:      "present process without boot is unknown",
+			process:   wakeProcessInfo{PID: owner.PID, Running: true, StartToken: owner.ProcessStart},
+			sessionID: owner.SessionID,
+			want:      wakeOwnerUnknown,
+		},
+		{
+			name:      "matching exact identity is same",
+			process:   matching,
+			sessionID: owner.SessionID,
+			want:      wakeOwnerSame,
+		},
+		{
+			name: "comparable boot mismatch proves dead",
+			process: wakeProcessInfo{
+				PID:        owner.PID,
+				Running:    true,
+				StartToken: owner.ProcessStart,
+				BootID:     "22222222-2222-2222-2222-222222222222",
+			},
+			sessionID: owner.SessionID,
+			want:      wakeOwnerDead,
+		},
+		{
+			name: "start mismatch after boot match proves dead",
+			process: wakeProcessInfo{
+				PID:        owner.PID,
+				Running:    true,
+				StartToken: "replacement-start",
+				BootID:     owner.BootID,
+			},
+			sessionID: owner.SessionID,
+			want:      wakeOwnerDead,
+		},
+		{
+			name:      "session mismatch on same process is unknown",
+			process:   matching,
+			sessionID: owner.SessionID + 1,
+			want:      wakeOwnerUnknown,
+		},
+		{
+			name:       "session inspection failure is unknown",
+			process:    matching,
+			sessionErr: errors.New("permission denied"),
+			want:       wakeOwnerUnknown,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state, _ := classifyAuthoritativeWakeOwner(owner, test.process, test.sessionID, test.sessionErr)
+			if state != test.want {
+				t.Fatalf("state = %s, want %s", state, test.want)
+			}
+		})
+	}
+}
+
+func TestClassifyStableAuthoritativeWakeOwnerRejectsChangedSecondSnapshot(t *testing.T) {
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	matching := wakeProcessInfo{
+		PID:        owner.PID,
+		Running:    true,
+		StartToken: owner.ProcessStart,
+		BootID:     owner.BootID,
+	}
+
+	tests := []struct {
+		name      string
+		first     wakeProcessInfo
+		firstSID  int
+		second    wakeProcessInfo
+		secondSID int
+		want      wakeOwnerIdentityState
+	}{
+		{
+			name:      "two exact snapshots are same",
+			first:     matching,
+			firstSID:  owner.SessionID,
+			second:    matching,
+			secondSID: owner.SessionID,
+			want:      wakeOwnerSame,
+		},
+		{
+			name:      "process changes between snapshots",
+			first:     matching,
+			firstSID:  owner.SessionID,
+			second:    wakeProcessInfo{PID: owner.PID},
+			secondSID: owner.SessionID,
+			want:      wakeOwnerUnknown,
+		},
+		{
+			name:      "session changes between snapshots",
+			first:     matching,
+			firstSID:  owner.SessionID,
+			second:    matching,
+			secondSID: owner.SessionID + 1,
+			want:      wakeOwnerUnknown,
+		},
+		{
+			name:      "two conclusive absence snapshots are dead",
+			first:     wakeProcessInfo{PID: owner.PID},
+			second:    wakeProcessInfo{PID: owner.PID},
+			secondSID: owner.SessionID,
+			want:      wakeOwnerDead,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, _ := classifyStableAuthoritativeWakeOwner(
+				owner,
+				test.first, test.firstSID, nil,
+				test.second, test.secondSID, nil,
+			)
+			if got != test.want {
+				t.Fatalf("stable classification = %s, want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/cli/wake_owner_mixed_version_test.go
+++ b/internal/cli/wake_owner_mixed_version_test.go
@@ -1,0 +1,182 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const ownerFenceLegacyCommit = "e37067a91b4447c3ed99bf647b71e7ec9dbf3824"
+
+func TestOwnerFencePreservesClaimAgainstExactE370Binary(t *testing.T) {
+	repoRootCommand := exec.Command("git", "rev-parse", "--show-toplevel")
+	repoRootOutput, err := repoRootCommand.CombinedOutput()
+	if err != nil {
+		t.Skipf("mixed-version git history unavailable: %v", err)
+	}
+	repoRoot := strings.TrimSpace(string(repoRootOutput))
+	if output, err := exec.Command("git", "-C", repoRoot, "cat-file", "-e", ownerFenceLegacyCommit+"^{commit}").CombinedOutput(); err != nil {
+		t.Skipf("mixed-version commit %s unavailable: %v\n%s", ownerFenceLegacyCommit, err, output)
+	}
+
+	buildRoot := t.TempDir()
+	sourceRoot := filepath.Join(buildRoot, "source")
+	if err := os.Mkdir(sourceRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := filepath.Join(buildRoot, "legacy.tar")
+	commandOutputForOwnerFence(
+		t,
+		repoRoot,
+		"git",
+		"archive",
+		"--format=tar",
+		"--output="+archivePath,
+		ownerFenceLegacyCommit,
+	)
+	commandOutputForOwnerFence(t, "", "tar", "-xf", archivePath, "-C", sourceRoot)
+	legacyBinary := filepath.Join(buildRoot, "amq-e37067a")
+	commandOutputForOwnerFence(t, sourceRoot, "go", "build", "-o", legacyBinary, "./cmd/amq")
+
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "mixed-version-owner-injector")
+	owner, err := captureAuthoritativeCurrentWakeOwner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &owner
+	lock, err := newWakeLock(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, "codex", target, lock)
+	})
+	_ = agentDir.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+	beforeBytes, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeInfo, err := os.Lstat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if beforeInfo.Mode().Perm() != wakeOwnerLockFileMode {
+		t.Fatalf("owner fence mode = %o, want %o", beforeInfo.Mode().Perm(), wakeOwnerLockFileMode)
+	}
+
+	commands := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "acquire",
+			args: []string{"wake", "--root", root, "--me", "codex", "--inject-via", injector},
+			want: "unverified",
+		},
+		{
+			name: "doctor fix",
+			args: []string{"doctor", "--ops", "--fix-wake-locks"},
+			want: "unverified",
+		},
+		{
+			name: "repair",
+			args: []string{"wake", "repair", "--root", root, "--me", "codex"},
+			want: "refused",
+		},
+		{
+			name: "retire",
+			args: []string{"wake", "retire", "--root", root, "--me", "codex", "--inject-via", injector},
+			want: "refused",
+		},
+	}
+	for _, test := range commands {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, legacyBinary, test.args...)
+			cmd.Env = ownerFenceCommandEnv(root)
+			output, _ := cmd.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("legacy command timed out: %v\n%s", test.args, output)
+			}
+			if !strings.Contains(strings.ToLower(string(output)), test.want) {
+				t.Fatalf("legacy command %v output missing %q:\n%s", test.args, test.want, output)
+			}
+			afterBytes, err := os.ReadFile(lockPath)
+			if err != nil {
+				t.Fatalf("legacy command %v removed owner fence: %v\n%s", test.args, err, output)
+			}
+			afterInfo, err := os.Lstat(lockPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(afterBytes, beforeBytes) || !os.SameFile(beforeInfo, afterInfo) {
+				t.Fatalf("legacy command %v changed owner fence bytes or inode", test.args)
+			}
+		})
+	}
+}
+
+func commandOutputForOwnerFence(t *testing.T, dir, name string, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("%s %v timed out", name, args)
+	}
+	if err != nil {
+		t.Fatalf("%s %v: %v\n%s", name, args, err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func ownerFenceCommandEnv(root string) []string {
+	env := os.Environ()
+	for _, name := range []string{
+		envWakeOwner,
+		envRoot,
+		envRootID,
+		envBaseRoot,
+		envBaseRootID,
+		envSession,
+	} {
+		env = unsetEnvVar(env, name)
+	}
+	env = setEnvVar(env, envRoot, root)
+	return setEnvVar(env, "AMQ_NO_UPDATE_CHECK", "1")
+}

--- a/internal/cli/wake_owner_observation_darwin.go
+++ b/internal/cli/wake_owner_observation_darwin.go
@@ -1,0 +1,50 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+)
+
+func observeAuthoritativeWakeOwnerPlatform(owner wakeOwner) (wakeOwnerObservation, error) {
+	first := inspectWakeProcess(owner.PID)
+	firstSessionID, firstSessionErr := getWakeProcessSID(owner.PID)
+	second := inspectWakeProcess(owner.PID)
+	secondSessionID, secondSessionErr := getWakeProcessSID(owner.PID)
+	state, reason := classifyStableAuthoritativeWakeOwner(
+		owner,
+		first, firstSessionID, firstSessionErr,
+		second, secondSessionID, secondSessionErr,
+	)
+	return wakeOwnerObservation{State: state, Reason: reason}, nil
+}
+
+func captureAuthoritativeCurrentWakeOwnerPlatform() (wakeOwner, error) {
+	pid := os.Getpid()
+	first := inspectWakeProcess(pid)
+	firstSessionID, firstSessionErr := getWakeProcessSID(pid)
+	if !first.Running || firstSessionErr != nil {
+		return wakeOwner{}, fmt.Errorf("current process identity is unavailable")
+	}
+	owner := wakeOwner{
+		PID:          pid,
+		ProcessStart: first.StartToken,
+		BootID:       first.BootID,
+		SessionID:    firstSessionID,
+	}
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		return wakeOwner{}, err
+	}
+	second := inspectWakeProcess(pid)
+	secondSessionID, secondSessionErr := getWakeProcessSID(pid)
+	state, reason := classifyStableAuthoritativeWakeOwner(
+		owner,
+		first, firstSessionID, firstSessionErr,
+		second, secondSessionID, secondSessionErr,
+	)
+	if state != wakeOwnerSame {
+		return wakeOwner{}, fmt.Errorf("current process identity is %s: %s", state, reason)
+	}
+	return owner, nil
+}

--- a/internal/cli/wake_owner_observation_linux.go
+++ b/internal/cli/wake_owner_observation_linux.go
@@ -1,0 +1,155 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func observeAuthoritativeWakeOwnerPlatform(owner wakeOwner) (wakeOwnerObservation, error) {
+	pidfd, err := linuxPidfdOpen(owner.PID, 0)
+	if err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return wakeOwnerObservation{
+				State:  wakeOwnerDead,
+				Reason: "owner process is not running",
+			}, nil
+		}
+		unsupported := wakeOwnerCapabilityUnsupported(err)
+		return wakeOwnerObservation{
+			State:                 wakeOwnerUnknown,
+			Reason:                fmt.Sprintf("owner pidfd unavailable: %v", err),
+			CapabilityUnsupported: unsupported,
+		}, fmt.Errorf("pidfd_open owner process %d: %w", owner.PID, err)
+	}
+	observation := wakeOwnerObservation{
+		State: wakeOwnerUnknown,
+		close: func() error { return linuxPidfdClose(pidfd) },
+	}
+	exited, err := linuxPidfdPoll(pidfd, 0)
+	if err != nil {
+		_ = observation.Close()
+		return wakeOwnerObservation{}, fmt.Errorf("poll owner pidfd before inspection: %w", err)
+	}
+	if exited {
+		observation.State = wakeOwnerDead
+		observation.Reason = "owner process is not running"
+		return observation, nil
+	}
+
+	first := inspectWakeProcess(owner.PID)
+	firstSessionID, firstSessionErr := getWakeProcessSID(owner.PID)
+	exited, err = linuxPidfdPoll(pidfd, 0)
+	if err != nil {
+		_ = observation.Close()
+		return wakeOwnerObservation{}, fmt.Errorf("poll owner pidfd during inspection: %w", err)
+	}
+	if exited {
+		observation.State = wakeOwnerDead
+		observation.Reason = "owner process is not running"
+		return observation, nil
+	}
+	second := inspectWakeProcess(owner.PID)
+	secondSessionID, secondSessionErr := getWakeProcessSID(owner.PID)
+	exitedAfter, err := linuxPidfdPoll(pidfd, 0)
+	if err != nil {
+		_ = observation.Close()
+		return wakeOwnerObservation{}, fmt.Errorf("poll owner pidfd after inspection: %w", err)
+	}
+	if exitedAfter {
+		observation.State = wakeOwnerDead
+		observation.Reason = "owner process is not running"
+		return observation, nil
+	}
+	observation.State, observation.Reason = classifyStableAuthoritativeWakeOwner(
+		owner,
+		first, firstSessionID, firstSessionErr,
+		second, secondSessionID, secondSessionErr,
+	)
+	return observation, nil
+}
+
+func wakeOwnerCapabilityUnsupported(err error) bool {
+	return errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EOPNOTSUPP)
+}
+
+func captureAuthoritativeCurrentWakeOwnerPlatform() (wakeOwner, error) {
+	pid := os.Getpid()
+	pidfd, err := linuxPidfdOpen(pid, 0)
+	if err != nil {
+		if wakeOwnerCapabilityUnsupported(err) {
+			// The current process cannot be replaced while this function is
+			// executing, so a strict double snapshot remains stable without a
+			// pidfd. Coop will still detect the unsupported child capability
+			// and deliberately launch one ownerless wake.
+			return captureCurrentWakeOwnerWithoutPidfd()
+		}
+		return wakeOwner{}, fmt.Errorf("pidfd_open current process %d: %w", pid, err)
+	}
+	defer func() { _ = linuxPidfdClose(pidfd) }()
+	exited, err := linuxPidfdPoll(pidfd, 0)
+	if err != nil {
+		return wakeOwner{}, fmt.Errorf("poll current process pidfd before inspection: %w", err)
+	}
+	if exited {
+		return wakeOwner{}, fmt.Errorf("current process is not running")
+	}
+	first := inspectWakeProcess(pid)
+	firstSessionID, firstSessionErr := getWakeProcessSID(pid)
+	owner := wakeOwner{
+		PID:          pid,
+		ProcessStart: first.StartToken,
+		BootID:       first.BootID,
+		SessionID:    firstSessionID,
+	}
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		return wakeOwner{}, err
+	}
+	second := inspectWakeProcess(pid)
+	secondSessionID, secondSessionErr := getWakeProcessSID(pid)
+	exited, err = linuxPidfdPoll(pidfd, 0)
+	if err != nil {
+		return wakeOwner{}, fmt.Errorf("poll current process pidfd after inspection: %w", err)
+	}
+	if exited {
+		second = wakeProcessInfo{PID: pid}
+	}
+	state, reason := classifyStableAuthoritativeWakeOwner(
+		owner,
+		first, firstSessionID, firstSessionErr,
+		second, secondSessionID, secondSessionErr,
+	)
+	if state != wakeOwnerSame {
+		return wakeOwner{}, fmt.Errorf("current process identity is %s: %s", state, reason)
+	}
+	return owner, nil
+}
+
+func captureCurrentWakeOwnerWithoutPidfd() (wakeOwner, error) {
+	pid := os.Getpid()
+	first := inspectWakeProcess(pid)
+	firstSessionID, firstSessionErr := getWakeProcessSID(pid)
+	owner := wakeOwner{
+		PID:          pid,
+		ProcessStart: first.StartToken,
+		BootID:       first.BootID,
+		SessionID:    firstSessionID,
+	}
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		return wakeOwner{}, err
+	}
+	second := inspectWakeProcess(pid)
+	secondSessionID, secondSessionErr := getWakeProcessSID(pid)
+	state, reason := classifyStableAuthoritativeWakeOwner(
+		owner,
+		first, firstSessionID, firstSessionErr,
+		second, secondSessionID, secondSessionErr,
+	)
+	if state != wakeOwnerSame {
+		return wakeOwner{}, fmt.Errorf("current process identity is %s without pidfd: %s", state, reason)
+	}
+	return owner, nil
+}

--- a/internal/cli/wake_owner_observation_unix.go
+++ b/internal/cli/wake_owner_observation_unix.go
@@ -1,0 +1,31 @@
+//go:build darwin || linux
+
+package cli
+
+import "fmt"
+
+type wakeOwnerObservation struct {
+	State                 wakeOwnerIdentityState
+	Reason                string
+	CapabilityUnsupported bool
+	close                 func() error
+}
+
+func (observation *wakeOwnerObservation) Close() error {
+	if observation == nil || observation.close == nil {
+		return nil
+	}
+	closeFn := observation.close
+	observation.close = nil
+	return closeFn()
+}
+
+var observeAuthoritativeWakeOwner = observeAuthoritativeWakeOwnerPlatform
+
+func captureAuthoritativeCurrentWakeOwner() (wakeOwner, error) {
+	owner, err := captureAuthoritativeCurrentWakeOwnerPlatform()
+	if err != nil {
+		return wakeOwner{}, fmt.Errorf("capture current wake owner: %w", err)
+	}
+	return owner, nil
+}

--- a/internal/cli/wake_owner_recover_unix.go
+++ b/internal/cli/wake_owner_recover_unix.go
@@ -1,0 +1,287 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+type wakeOwnerRecoverResult struct {
+	Status       string `json:"status"`
+	Agent        string `json:"agent"`
+	Root         string `json:"root"`
+	Lock         string `json:"lock"`
+	Target       string `json:"target,omitempty"`
+	PID          int    `json:"pid,omitempty"`
+	OwnerPID     int    `json:"owner_pid,omitempty"`
+	OwnerSession int    `json:"owner_session,omitempty"`
+	Reason       string `json:"reason,omitempty"`
+	NextAction   string `json:"next_action,omitempty"`
+}
+
+func runWakeRecoverOwner(args []string) error {
+	fs := flag.NewFlagSet("wake recover-owner", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	usage := usageWithFlags(
+		fs,
+		"amq wake recover-owner --me <agent> [options]",
+		"Recover one exact owner-bound wake claim.",
+		"",
+		"Live release requires the exact AMQ_WAKE_OWNER token and the caller's",
+		"current OS session to match the persisted owner. There is no force mode.",
+	)
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if err := requireMe(common.Me); err != nil {
+		return err
+	}
+	me, err := normalizeHandle(common.Me)
+	if err != nil {
+		return UsageError("--me: %v", err)
+	}
+	root := resolveRoot(common.Root)
+	if err := validateKnownHandles(root, common.Strict, me); err != nil {
+		return err
+	}
+	result, recoverErr := recoverOwnerWake(root, me)
+	if common.JSON {
+		if err := writeJSON(os.Stdout, result); err != nil {
+			return err
+		}
+		return recoverErr
+	}
+	line := fmt.Sprintf("wake recover-owner: %s agent=%s root=%s", result.Status, result.Agent, result.Root)
+	if result.PID != 0 {
+		line += fmt.Sprintf(" pid=%d", result.PID)
+	}
+	if result.OwnerPID != 0 {
+		line += fmt.Sprintf(" owner_pid=%d owner_session=%d", result.OwnerPID, result.OwnerSession)
+	}
+	if result.Reason != "" {
+		line += " reason=" + result.Reason
+	}
+	if result.NextAction != "" {
+		line += " next_action=" + result.NextAction
+	}
+	if err := writeStdoutLine(line); err != nil {
+		return err
+	}
+	return recoverErr
+}
+
+func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
+	result := wakeOwnerRecoverResult{
+		Status: "unknown",
+		Agent:  me,
+		Root:   canonicalWakeRoot(root),
+		Lock:   filepath.Join(fsq.AgentBase(root, me), ".wake.lock"),
+		Target: wakeTargetPath(root, me),
+	}
+	if err := os.MkdirAll(fsq.AgentBase(root, me), 0o700); err != nil {
+		result.Status = "error"
+		result.Reason = err.Error()
+		return result, err
+	}
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		result.Status = "error"
+		result.Reason = err.Error()
+		return result, err
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	refuse := func(reason, next string) error {
+		result.Status = "refused"
+		result.Reason = reason
+		result.NextAction = next
+		return errors.New(reason)
+	}
+
+	for {
+		var stopCapability *authoritativeWakeStopCapability
+		var stopAuthorization wakeOwnerReleaseAuthorization
+		err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+			inspection := inspectWakeLockForOwnerTransition(dirfd, agentDir, root, me)
+			result.PID = inspection.PID
+			switch classifyPersistedWakeClaim(inspection) {
+			case wakeClaimAbsent:
+				target, exists, err := readWakeTargetAt(dirfd, agentDir, root, me)
+				if err != nil {
+					return refuse("orphan wake target is unverified: "+err.Error(), "inspect the target and retry")
+				}
+				if exists {
+					digest, err := wakeTargetDigest(target)
+					if err != nil {
+						return refuse("orphan wake target digest is unavailable: "+err.Error(), "inspect the target and retry")
+					}
+					current, currentExists, err := readWakeTargetAt(dirfd, agentDir, root, me)
+					if err != nil {
+						return refuse("orphan wake target changed while recovering: "+err.Error(), "retry")
+					}
+					currentDigest, digestErr := wakeTargetDigest(current)
+					if digestErr != nil {
+						return refuse("orphan wake target digest changed while recovering: "+digestErr.Error(), "retry")
+					}
+					if !currentExists || currentDigest != digest {
+						return refuse("orphan wake target changed while recovering", "retry")
+					}
+					if err := unix.Unlinkat(dirfd, wakeTargetFileName, 0); err != nil && err != unix.ENOENT {
+						return fmt.Errorf("remove orphan wake target: %w", err)
+					}
+					if err := syncWakeOwnerDirFD(dirfd); err != nil {
+						return fmt.Errorf("sync orphan wake target removal: %w", err)
+					}
+				}
+				result.Status = "recovered"
+				result.Reason = "owner claim is absent"
+				return nil
+			case wakeClaimGeneric:
+				return refuse("wake lock is ownerless; recover-owner cannot mutate it", "use wake repair or wake retire")
+			case wakeClaimInvalid:
+				return refuse("wake owner claim is unverified or corrupt", "inspect the claim and retry without mutating it")
+			}
+
+			target, err := authoritativeWakeRecoveryTargetAt(dirfd, agentDir, inspection)
+			if err != nil {
+				return refuse("wake owner claim is unverified: "+err.Error(), "repair the metadata manually only after preserving evidence")
+			}
+			owner := *inspection.Lock.Owner
+			result.OwnerPID = owner.PID
+			result.OwnerSession = owner.SessionID
+			observation, err := observeAuthoritativeWakeOwner(owner)
+			defer func() { _ = observation.Close() }()
+			if err != nil {
+				return refuse("wake owner is unknown: "+err.Error(), "retry after owner identity inspection is available")
+			}
+
+			authenticated := false
+			var token *wakeOwner
+			if observation.State == wakeOwnerSame {
+				token, err = wakeOwnerFromEnv()
+				if err != nil {
+					return refuse("wake owner token is invalid: "+err.Error(), "run recovery from the owning process session")
+				}
+				if token == nil {
+					return refuse("wake owner token is missing", "run recovery from the owning process session")
+				}
+				if err := validateAuthoritativeWakeOwner(*token); err != nil {
+					return refuse("wake owner token is not authoritative: "+err.Error(), "run recovery from the owning process session")
+				}
+				if !sameWakeOwner(token, &owner) {
+					return refuse("wake owner token does not match the persisted owner", "run recovery from the owning process session")
+				}
+				callerSession, err := getWakeProcessSID(os.Getpid())
+				if err != nil {
+					return refuse("recovery caller OS session unavailable: "+err.Error(), "retry from a process with a readable OS session")
+				}
+				if callerSession != owner.SessionID {
+					return refuse(
+						fmt.Sprintf("recovery caller OS session %d does not match owner OS session %d", callerSession, owner.SessionID),
+						fmt.Sprintf("exit or stop owner pid %d, then rerun amq wake recover-owner --me %s", owner.PID, me),
+					)
+				}
+				authenticated = true
+			}
+
+			if observation.State == wakeOwnerUnknown {
+				return refuse(
+					"wake owner is unknown: "+observation.Reason,
+					"retry after owner identity inspection is available",
+				)
+			}
+			wakeCapability, err := prepareAuthoritativeWakeStop(dirfd, agentDir, inspection)
+			if err != nil {
+				return refuse("exact wake inspection is unavailable: "+err.Error(), "preserve the claim and retry")
+			}
+			keepWakeCapability := false
+			defer func() {
+				if !keepWakeCapability {
+					_ = wakeCapability.Close()
+				}
+			}()
+			classified := wakeCapability.Inspection
+			action := decideOwnerLifecycleTransition(wakeOwnerTransitionEvidence{
+				Request:            wakeOwnerRequestRecover,
+				Claim:              wakeClaimAuthoritative,
+				PersistedState:     observation.State,
+				Authenticated:      authenticated,
+				WakeExactStoppable: classified.Status == wakeLockValid && classified.IdentityConfirmed,
+				WakeAbsent:         wakeCapability.Absent,
+			})
+			switch action {
+			case wakeOwnerActionRelease:
+				if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, inspection, target); err != nil {
+					return err
+				}
+				result.Status = "recovered"
+				result.Reason = "exact owner claim released"
+				return nil
+			case wakeOwnerActionStopAndRelease:
+				if wakeCapability.Absent {
+					if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, inspection, target); err != nil {
+						return err
+					}
+					result.Status = "recovered"
+					result.Reason = "exact owner claim released"
+					return nil
+				}
+				stopCapability = &wakeCapability
+				keepWakeCapability = true
+				stopAuthorization = wakeOwnerReleaseAuthorization{Token: token}
+				return nil
+			default:
+				switch observation.State {
+				case wakeOwnerUnknown:
+					return refuse(
+						"wake owner is unknown: "+observation.Reason,
+						"retry after owner identity inspection is available",
+					)
+				case wakeOwnerSame:
+					return refuse(
+						fmt.Sprintf("handle %s is owned by live process pid %d, OS session %d", me, owner.PID, owner.SessionID),
+						fmt.Sprintf("exit or stop that process, then rerun amq wake recover-owner --me %s", me),
+					)
+				default:
+					return refuse("wake process identity is not exactly stoppable", "preserve the claim and retry")
+				}
+			}
+		})
+		if err != nil {
+			if stopCapability != nil {
+				_ = stopCapability.Close()
+			}
+			if result.Status == "unknown" {
+				result.Status = "error"
+				result.Reason = err.Error()
+			}
+			return result, err
+		}
+		if stopCapability == nil {
+			return result, nil
+		}
+		stopErr := stopCapability.Stop(stopAuthorization)
+		closeErr := stopCapability.Close()
+		if stopErr != nil {
+			result.Status = "error"
+			result.Reason = stopErr.Error()
+			return result, stopErr
+		}
+		if closeErr != nil {
+			result.Status = "error"
+			result.Reason = closeErr.Error()
+			return result, closeErr
+		}
+		// Stop waits happen without the guard. Re-enter from a completely fresh
+		// persisted and process observation; no authorization decision survives.
+	}
+}

--- a/internal/cli/wake_owner_stop_darwin.go
+++ b/internal/cli/wake_owner_stop_darwin.go
@@ -1,0 +1,50 @@
+//go:build darwin
+
+package cli
+
+import "fmt"
+
+func prepareAuthoritativeWakeStopPlatform(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+) (authoritativeWakeStopCapability, error) {
+	current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
+	if !sameWakeLockGeneration(expected, current) {
+		return authoritativeWakeStopCapability{}, fmt.Errorf("authoritative wake generation changed before cooperative stop preparation")
+	}
+	if classifyPersistedWakeClaim(current) != wakeClaimAuthoritative {
+		return authoritativeWakeStopCapability{}, fmt.Errorf("wake claim is not authoritative during cooperative stop preparation")
+	}
+	if current.Status == wakeLockStale {
+		// Stale is affirmative proof that the recorded generation is absent.
+		// A live process here is a different occupant of the recycled PID and
+		// must never prevent release or receive a signal.
+		return authoritativeWakeStopCapability{Inspection: current, Absent: true}, nil
+	}
+	if current.Status != wakeLockValid || !current.IdentityConfirmed {
+		return authoritativeWakeStopCapability{}, fmt.Errorf("authoritative wake identity is %s: %s", current.Status, current.Reason)
+	}
+	return authoritativeWakeStopCapability{
+		Inspection: current,
+		stop: func(auth wakeOwnerReleaseAuthorization) error {
+			stopped, err := cooperativeStopAuthoritativeWake(current, auth)
+			if err != nil {
+				return err
+			}
+			if !stopped {
+				return fmt.Errorf("authoritative wake cooperative stop did not release the generation")
+			}
+			return nil
+		},
+	}, nil
+}
+
+func inspectWakeLockForOwnerTransitionPlatform(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) wakeLockInspection {
+	return inspectWakeLockAt(dirfd, agentDir, root, me)
+}

--- a/internal/cli/wake_owner_stop_linux.go
+++ b/internal/cli/wake_owner_stop_linux.go
@@ -1,0 +1,97 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+func prepareAuthoritativeWakeStopPlatform(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+) (authoritativeWakeStopCapability, error) {
+	metadata := readWakeLockMetadataAt(dirfd, agentDir, expected.Root, expected.Agent)
+	if !sameWakeLockGeneration(expected, metadata) {
+		return authoritativeWakeStopCapability{}, fmt.Errorf("authoritative wake generation changed before stable stop preparation")
+	}
+	if classifyPersistedWakeClaim(metadata) != wakeClaimAuthoritative {
+		return authoritativeWakeStopCapability{}, fmt.Errorf("wake claim is not authoritative during stable stop preparation")
+	}
+
+	pidfd, err := linuxPidfdOpen(metadata.PID, 0)
+	if err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			metadata.Process = wakeProcessInfo{PID: metadata.PID}
+			classifyWakeLock(metadata.Root, metadata.Agent, &metadata)
+			return authoritativeWakeStopCapability{Inspection: metadata, Absent: true}, nil
+		}
+		return authoritativeWakeStopCapability{}, fmt.Errorf("pidfd_open authoritative wake process %d: %w", metadata.PID, err)
+	}
+	capability := authoritativeWakeStopCapability{
+		Inspection: metadata,
+		close:      func() error { return linuxPidfdClose(pidfd) },
+	}
+	exited, err := linuxPidfdPoll(pidfd, 0)
+	if err != nil {
+		_ = capability.Close()
+		return authoritativeWakeStopCapability{}, fmt.Errorf("poll authoritative wake pidfd before inspection: %w", err)
+	}
+	if exited {
+		capability.Absent = true
+		capability.Inspection.Process = wakeProcessInfo{PID: metadata.PID}
+		classifyWakeLock(metadata.Root, metadata.Agent, &capability.Inspection)
+		return capability, nil
+	}
+
+	metadata.Process = inspectWakeProcess(metadata.PID)
+	classifyWakeLock(metadata.Root, metadata.Agent, &metadata)
+	capability.Inspection = metadata
+	if !sameWakeLockGeneration(expected, metadata) {
+		_ = capability.Close()
+		return authoritativeWakeStopCapability{}, fmt.Errorf("authoritative wake generation changed during stable stop preparation")
+	}
+	switch metadata.Status {
+	case wakeLockValid:
+		if !metadata.IdentityConfirmed {
+			_ = capability.Close()
+			return authoritativeWakeStopCapability{}, fmt.Errorf("authoritative wake identity is not confirmed")
+		}
+	case wakeLockStale:
+		// The retained pidfd names the current numeric-PID occupant. A proven
+		// generation mismatch means the recorded wake itself is already absent;
+		// do not signal the occupant.
+		capability.Absent = true
+		return capability, nil
+	default:
+		_ = capability.Close()
+		return authoritativeWakeStopCapability{}, fmt.Errorf("authoritative wake identity is %s: %s", metadata.Status, metadata.Reason)
+	}
+
+	exited, err = linuxPidfdPoll(pidfd, 0)
+	if err != nil {
+		_ = capability.Close()
+		return authoritativeWakeStopCapability{}, fmt.Errorf("poll authoritative wake pidfd after inspection: %w", err)
+	}
+	if exited {
+		capability.Absent = true
+		capability.Inspection.Process = wakeProcessInfo{PID: metadata.PID}
+		classifyWakeLock(metadata.Root, metadata.Agent, &capability.Inspection)
+		return capability, nil
+	}
+	capability.stop = func(wakeOwnerReleaseAuthorization) error {
+		return terminateWakePidfd(pidfd)
+	}
+	return capability, nil
+}
+
+func inspectWakeLockForOwnerTransitionPlatform(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) wakeLockInspection {
+	return readWakeLockMetadataAt(dirfd, agentDir, root, me)
+}

--- a/internal/cli/wake_owner_stop_unix.go
+++ b/internal/cli/wake_owner_stop_unix.go
@@ -1,0 +1,34 @@
+//go:build darwin || linux
+
+package cli
+
+type wakeOwnerReleaseAuthorization struct {
+	Token    *wakeOwner
+	Rollback bool
+}
+
+type authoritativeWakeStopCapability struct {
+	Inspection wakeLockInspection
+	Absent     bool
+	stop       func(wakeOwnerReleaseAuthorization) error
+	close      func() error
+}
+
+func (capability *authoritativeWakeStopCapability) Stop(auth wakeOwnerReleaseAuthorization) error {
+	if capability == nil || capability.Absent || capability.stop == nil {
+		return nil
+	}
+	return capability.stop(auth)
+}
+
+func (capability *authoritativeWakeStopCapability) Close() error {
+	if capability == nil || capability.close == nil {
+		return nil
+	}
+	closeFn := capability.close
+	capability.close = nil
+	return closeFn()
+}
+
+var prepareAuthoritativeWakeStop = prepareAuthoritativeWakeStopPlatform
+var inspectWakeLockForOwnerTransition = inspectWakeLockForOwnerTransitionPlatform

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -1,0 +1,503 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+type wakeOwnerPublicationError struct {
+	Err         error
+	Committed   bool
+	Unsupported bool
+}
+
+var errWakeOwnerLockExists = errors.New("wake lock already exists")
+
+func (err *wakeOwnerPublicationError) Error() string {
+	return err.Err.Error()
+}
+
+func (err *wakeOwnerPublicationError) Unwrap() error {
+	return err.Err
+}
+
+func publishAuthoritativeWakeClaimAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	target wakeTarget,
+	lock wakeLock,
+) error {
+	if err := validateAuthoritativeWakeTarget(target, root, me); err != nil {
+		return err
+	}
+	if err := validateAuthoritativeWakeLockRecord(lock, root, me, target); err != nil {
+		return err
+	}
+
+	existing, err := unix.Openat(dirfd, ".wake.lock", unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err == nil {
+		_ = unix.Close(existing)
+		return errWakeOwnerLockExists
+	}
+	if err != unix.ENOENT {
+		return fmt.Errorf("check existing wake lock: %w", err)
+	}
+
+	targetData, err := json.MarshalIndent(target, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal authoritative wake target: %w", err)
+	}
+	targetData = append(targetData, '\n')
+	lockData, err := json.Marshal(lock)
+	if err != nil {
+		return fmt.Errorf("marshal authoritative wake lock: %w", err)
+	}
+
+	targetTemp, err := writeWakeOwnerTempAt(dirfd, "wake-target", targetData, 0o600)
+	if err != nil {
+		return err
+	}
+	targetInstalled := false
+	defer func() {
+		if !targetInstalled {
+			_ = unix.Unlinkat(dirfd, targetTemp, 0)
+		}
+	}()
+	if err := unix.Renameat(dirfd, targetTemp, dirfd, wakeTargetFileName); err != nil {
+		return fmt.Errorf("install authoritative wake target: %w", err)
+	}
+	targetInstalled = true
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return &wakeOwnerPublicationError{
+			Err: fmt.Errorf("sync authoritative wake target directory: %w", err),
+		}
+	}
+
+	lockTemp, err := writeWakeOwnerTempAt(dirfd, "wake-lock", lockData, wakeOwnerLockFileMode)
+	if err != nil {
+		return err
+	}
+	lockTempPresent := true
+	defer func() {
+		if lockTempPresent {
+			_ = unix.Unlinkat(dirfd, lockTemp, 0)
+		}
+	}()
+	if err := unix.Linkat(dirfd, lockTemp, dirfd, ".wake.lock", 0); err != nil {
+		if err == unix.EEXIST {
+			return errWakeOwnerLockExists
+		}
+		return &wakeOwnerPublicationError{
+			Err:         fmt.Errorf("publish authoritative wake lock: %w", err),
+			Unsupported: wakeOwnerStorageUnsupported(err),
+		}
+	}
+	if err := unix.Unlinkat(dirfd, lockTemp, 0); err != nil {
+		return &wakeOwnerPublicationError{
+			Err:       fmt.Errorf("remove authoritative wake lock temp after commit: %w", err),
+			Committed: true,
+		}
+	}
+	lockTempPresent = false
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return &wakeOwnerPublicationError{
+			Err:       fmt.Errorf("sync authoritative wake lock directory after commit: %w", err),
+			Committed: true,
+		}
+	}
+	_ = agentDir
+	return nil
+}
+
+func validateAuthoritativeWakeTarget(target wakeTarget, root, me string) error {
+	if err := validateWakeTarget(target, root, me); err != nil {
+		return err
+	}
+	if target.Owner == nil {
+		return fmt.Errorf("authoritative wake target owner is missing")
+	}
+	if err := validateAuthoritativeWakeOwner(*target.Owner); err != nil {
+		return fmt.Errorf("authoritative wake target owner is invalid: %w", err)
+	}
+	return nil
+}
+
+func validateAuthoritativeWakeLockRecord(lock wakeLock, root, me string, target wakeTarget) error {
+	if err := validateAuthoritativeWakeLockEnvelope(lock, root, me); err != nil {
+		return err
+	}
+	return validateWakeTargetMatchesLock(lock, target)
+}
+
+func validateAuthoritativeWakeLockEnvelope(lock wakeLock, root, me string) error {
+	if lock.OwnerSchema != wakeOwnerLockSchema {
+		return fmt.Errorf("authoritative wake owner schema %d unsupported", lock.OwnerSchema)
+	}
+	if lock.WakeMode != wakeOwnerWakeMode {
+		return fmt.Errorf("authoritative wake mode %q unsupported", lock.WakeMode)
+	}
+	if lock.Owner == nil {
+		return fmt.Errorf("authoritative wake lock owner is missing")
+	}
+	if err := validateAuthoritativeWakeOwner(*lock.Owner); err != nil {
+		return fmt.Errorf("authoritative wake lock owner is invalid: %w", err)
+	}
+	if lock.PID <= 0 {
+		return fmt.Errorf("authoritative wake lock pid must be > 0")
+	}
+	if err := validateAuthoritativeWakeProcessIdentity(lock); err != nil {
+		return fmt.Errorf("authoritative wake lock process identity is invalid: %w", err)
+	}
+	if lock.Generation == "" {
+		return fmt.Errorf("authoritative wake lock generation is missing")
+	}
+	if lock.TargetDigest == "" {
+		return fmt.Errorf("authoritative wake target digest is missing")
+	}
+	if lock.Root == "" {
+		return fmt.Errorf("authoritative wake lock root is missing")
+	}
+	if canonicalWakeRoot(lock.Root) != canonicalWakeRoot(root) {
+		return fmt.Errorf("authoritative wake lock root mismatch")
+	}
+	if lock.Agent != me {
+		return fmt.Errorf("authoritative wake lock agent mismatch")
+	}
+	return nil
+}
+
+func writeWakeOwnerTempAt(dirfd int, label string, data []byte, mode os.FileMode) (string, error) {
+	var nonce [12]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", fmt.Errorf("generate %s temp name: %w", label, err)
+	}
+	name := fmt.Sprintf(".%s.tmp.%d.%s", label, os.Getpid(), hex.EncodeToString(nonce[:]))
+	fd, err := unix.Openat(
+		dirfd,
+		name,
+		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		uint32(mode.Perm()),
+	)
+	if err != nil {
+		return "", fmt.Errorf("create %s temp: %w", label, err)
+	}
+	file := os.NewFile(uintptr(fd), name)
+	keep := false
+	defer func() {
+		_ = file.Close()
+		if !keep {
+			_ = unix.Unlinkat(dirfd, name, 0)
+		}
+	}()
+	if err := file.Chmod(mode); err != nil {
+		return "", fmt.Errorf("chmod %s temp: %w", label, err)
+	}
+	n, err := file.Write(data)
+	if err != nil {
+		return "", fmt.Errorf("write %s temp: %w", label, err)
+	}
+	if n != len(data) {
+		return "", fmt.Errorf("write %s temp: %w", label, io.ErrShortWrite)
+	}
+	if err := file.Sync(); err != nil {
+		return "", fmt.Errorf("sync %s temp: %w", label, err)
+	}
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("close %s temp: %w", label, err)
+	}
+	keep = true
+	return name, nil
+}
+
+var syncWakeOwnerDirFD = unix.Fsync
+
+func wakeOwnerStorageUnsupported(err error) bool {
+	return errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EOPNOTSUPP)
+}
+
+func readAuthoritativeWakeTargetAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	lock wakeLock,
+) (wakeTarget, error) {
+	snapshot, err := readAuthoritativeWakeTargetSnapshotAt(dirfd, agentDir, root, me, lock)
+	if err != nil {
+		return wakeTarget{}, err
+	}
+	return snapshot.Target, nil
+}
+
+type wakeTargetSnapshot struct {
+	Target   wakeTarget
+	Raw      []byte
+	FileInfo os.FileInfo
+}
+
+func readAuthoritativeWakeTargetSnapshotAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	lock wakeLock,
+) (wakeTargetSnapshot, error) {
+	snapshot, exists, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return wakeTargetSnapshot{}, err
+	}
+	if !exists {
+		return wakeTargetSnapshot{}, fmt.Errorf("authoritative wake target is missing")
+	}
+	if err := validateAuthoritativeWakeTarget(snapshot.Target, root, me); err != nil {
+		return wakeTargetSnapshot{}, err
+	}
+	if err := validateAuthoritativeWakeLockRecord(lock, root, me, snapshot.Target); err != nil {
+		return wakeTargetSnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func readWakeTargetAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) (wakeTarget, bool, error) {
+	target, exists, err := readWakeTargetRawAt(dirfd, agentDir, root, me)
+	if err != nil || !exists {
+		return target, exists, err
+	}
+	if err := validateWakeTarget(target, root, me); err != nil {
+		return wakeTarget{}, true, err
+	}
+	return target, true, nil
+}
+
+func readWakeTargetRawAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) (wakeTarget, bool, error) {
+	snapshot, exists, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
+	return snapshot.Target, exists, err
+}
+
+func readWakeTargetSnapshotAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) (wakeTargetSnapshot, bool, error) {
+	path := wakeTargetPath(root, me)
+	open := func() (*os.File, error) {
+		fd, err := unix.Openat(dirfd, wakeTargetFileName, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(uintptr(fd), path), nil
+	}
+	file, err := open()
+	if err != nil {
+		if err == unix.ENOENT {
+			return wakeTargetSnapshot{}, false, nil
+		}
+		return wakeTargetSnapshot{}, true, fmt.Errorf("open wake target: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return wakeTargetSnapshot{}, true, fmt.Errorf("stat wake target: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		return wakeTargetSnapshot{}, true, fmt.Errorf("wake target must be a regular 0600 file")
+	}
+	if err := validateWakeTargetPathOwnership("wake target", path, info); err != nil {
+		return wakeTargetSnapshot{}, true, err
+	}
+	data, err := readWakeMetadata(file, "wake target", path)
+	if err != nil {
+		return wakeTargetSnapshot{}, true, err
+	}
+	pathFile, err := open()
+	if err != nil {
+		return wakeTargetSnapshot{}, true, fmt.Errorf("re-open wake target: %w", err)
+	}
+	pathInfo, statErr := pathFile.Stat()
+	_ = pathFile.Close()
+	if statErr != nil {
+		return wakeTargetSnapshot{}, true, fmt.Errorf("re-stat wake target: %w", statErr)
+	}
+	if !sameWakeFileIdentity(info, pathInfo) {
+		return wakeTargetSnapshot{}, true, fmt.Errorf("wake target changed while opening")
+	}
+	var target wakeTarget
+	if err := json.Unmarshal(data, &target); err != nil {
+		return wakeTargetSnapshot{}, true, fmt.Errorf("parse wake target: %w", err)
+	}
+	_ = agentDir
+	return wakeTargetSnapshot{
+		Target:   target,
+		Raw:      data,
+		FileInfo: info,
+	}, true, nil
+}
+
+func removeAuthoritativeWakeClaimAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+	target *wakeTarget,
+) error {
+	current := readWakeLockMetadataAt(dirfd, agentDir, expected.Root, expected.Agent)
+	if !sameWakeLockGeneration(expected, current) {
+		return fmt.Errorf("authoritative wake claim changed before release")
+	}
+	if classifyPersistedWakeClaim(current) != wakeClaimAuthoritative {
+		return fmt.Errorf("authoritative wake lock became invalid before release")
+	}
+	var releaseTargetSnapshot *wakeTargetSnapshot
+	if target != nil {
+		currentTarget, err := readAuthoritativeWakeTargetSnapshotAt(
+			dirfd,
+			agentDir,
+			expected.Root,
+			expected.Agent,
+			current.Lock,
+		)
+		if err != nil {
+			return fmt.Errorf("authoritative wake claim became invalid before release: %w", err)
+		}
+		expectedDigest, err := wakeTargetDigest(*target)
+		if err != nil {
+			return err
+		}
+		currentDigest, err := wakeTargetDigest(currentTarget.Target)
+		if err != nil {
+			return err
+		}
+		if expectedDigest != current.Lock.TargetDigest ||
+			currentDigest != current.Lock.TargetDigest {
+			return fmt.Errorf("authoritative wake target changed before release")
+		}
+		releaseTargetSnapshot = &currentTarget
+	}
+	if err := unix.Unlinkat(dirfd, ".wake.lock", 0); err != nil {
+		if err == unix.ENOENT {
+			return nil
+		}
+		return fmt.Errorf("unlink authoritative wake lock: %w", err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync authoritative wake lock release: %w", err)
+	}
+
+	// A replacement is never selected or cleaned. Cooperative writers cannot
+	// install one while this guard is held; this check also catches bypassers.
+	replacement, err := unix.Openat(dirfd, ".wake.lock", unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err == nil {
+		_ = unix.Close(replacement)
+		return nil
+	}
+	if err != unix.ENOENT {
+		return fmt.Errorf("check replacement wake lock after release: %w", err)
+	}
+
+	cleaned := false
+	if releaseTargetSnapshot != nil {
+		removed, err := removeWakeTargetIfSnapshotMatchesAt(
+			dirfd,
+			agentDir,
+			expected.Root,
+			expected.Agent,
+			*releaseTargetSnapshot,
+		)
+		if err != nil {
+			return err
+		}
+		cleaned = removed
+	}
+	if marker, exists, markerErr := readWakeGenerationFileAt(
+		dirfd,
+		agentDir,
+		wakePreparedFileName,
+		"wake prepared marker",
+	); markerErr == nil && exists && marker.Generation == expected.Lock.Generation {
+		if err := unix.Unlinkat(dirfd, wakePreparedFileName, 0); err != nil && err != unix.ENOENT {
+			return fmt.Errorf("remove released wake prepared marker: %w", err)
+		}
+		cleaned = true
+	}
+	if expected.Lock.ControlSocket != "" {
+		name, nameErr := darwinControlSocketBasenameForCleanup(agentDir, expected.Lock.ControlSocket)
+		if nameErr != nil {
+			return nameErr
+		}
+		if name != "" {
+			if err := unix.Unlinkat(dirfd, name, 0); err != nil && err != unix.ENOENT {
+				return fmt.Errorf("remove released wake control socket: %w", err)
+			}
+			cleaned = true
+		}
+	}
+	if cleaned {
+		if err := syncWakeOwnerDirFD(dirfd); err != nil {
+			return fmt.Errorf("sync authoritative wake claim cleanup: %w", err)
+		}
+	}
+	return nil
+}
+
+func removeWakeTargetIfSnapshotMatchesAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	expected wakeTargetSnapshot,
+) (bool, error) {
+	current, exists, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return false, fmt.Errorf("re-read released wake target: %w", err)
+	}
+	if !exists {
+		return false, nil
+	}
+	if expected.FileInfo == nil ||
+		current.FileInfo == nil ||
+		!sameWakeFileIdentity(expected.FileInfo, current.FileInfo) ||
+		!bytes.Equal(expected.Raw, current.Raw) {
+		return false, fmt.Errorf("released wake target changed before cleanup; preserving it")
+	}
+	expectedDigest, err := wakeTargetDigest(expected.Target)
+	if err != nil {
+		return false, err
+	}
+	currentDigest, err := wakeTargetDigest(current.Target)
+	if err != nil {
+		return false, err
+	}
+	if expectedDigest != currentDigest {
+		return false, fmt.Errorf("released wake target digest changed before cleanup; preserving it")
+	}
+	if err := unix.Unlinkat(dirfd, wakeTargetFileName, 0); err != nil {
+		if err == unix.ENOENT {
+			return false, nil
+		}
+		return false, fmt.Errorf("remove released wake target: %w", err)
+	}
+	return true, nil
+}

--- a/internal/cli/wake_owner_transition.go
+++ b/internal/cli/wake_owner_transition.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+type wakeClaimClass uint8
+
+const (
+	wakeClaimAbsent wakeClaimClass = iota
+	wakeClaimGeneric
+	wakeClaimAuthoritative
+	wakeClaimInvalid
+)
+
+type wakeOwnerTransitionRequest uint8
+
+const (
+	wakeGenericRequestAcquire wakeOwnerTransitionRequest = iota
+	wakeGenericRequestMutate
+	wakeOwnerRequestAcquire
+	wakeOwnerRequestRecover
+)
+
+type wakeOwnerTransitionAction uint8
+
+const (
+	wakeOwnerActionRefuse wakeOwnerTransitionAction = iota
+	wakeOwnerActionLegacy
+	wakeOwnerActionPublish
+	wakeOwnerActionReuse
+	wakeOwnerActionRelease
+	wakeOwnerActionStopAndRelease
+	wakeOwnerActionCleanOrphan
+)
+
+func (action wakeOwnerTransitionAction) String() string {
+	switch action {
+	case wakeOwnerActionLegacy:
+		return "legacy"
+	case wakeOwnerActionPublish:
+		return "publish"
+	case wakeOwnerActionReuse:
+		return "reuse"
+	case wakeOwnerActionRelease:
+		return "release"
+	case wakeOwnerActionStopAndRelease:
+		return "stop and release"
+	case wakeOwnerActionCleanOrphan:
+		return "clean orphan"
+	default:
+		return "refuse"
+	}
+}
+
+type wakeOwnerTransitionEvidence struct {
+	Request            wakeOwnerTransitionRequest
+	Claim              wakeClaimClass
+	RequestedState     wakeOwnerIdentityState
+	PersistedState     wakeOwnerIdentityState
+	OwnersEqual        bool
+	WakeUsable         bool
+	WakeExactStoppable bool
+	WakeAbsent         bool
+	Authenticated      bool
+}
+
+// decideOwnerLifecycleTransition is the policy core shared by acquisition,
+// recovery, and mutation gates. Callers gather fresh evidence while holding the
+// per-handle lifecycle guard; this function deliberately performs no I/O.
+func decideOwnerLifecycleTransition(e wakeOwnerTransitionEvidence) wakeOwnerTransitionAction {
+	switch e.Request {
+	case wakeGenericRequestAcquire, wakeGenericRequestMutate:
+		if e.Claim == wakeClaimAbsent || e.Claim == wakeClaimGeneric {
+			return wakeOwnerActionLegacy
+		}
+		return wakeOwnerActionRefuse
+
+	case wakeOwnerRequestAcquire:
+		if e.RequestedState != wakeOwnerSame {
+			return wakeOwnerActionRefuse
+		}
+		switch e.Claim {
+		case wakeClaimAbsent:
+			return wakeOwnerActionPublish
+		case wakeClaimAuthoritative:
+			switch e.PersistedState {
+			case wakeOwnerSame:
+				if e.OwnersEqual && e.WakeUsable {
+					return wakeOwnerActionReuse
+				}
+				return wakeOwnerActionRefuse
+			case wakeOwnerDead:
+				return ownerReleaseAction(e)
+			default:
+				return wakeOwnerActionRefuse
+			}
+		default:
+			return wakeOwnerActionRefuse
+		}
+
+	case wakeOwnerRequestRecover:
+		switch e.Claim {
+		case wakeClaimAbsent:
+			return wakeOwnerActionCleanOrphan
+		case wakeClaimAuthoritative:
+			if e.PersistedState == wakeOwnerDead ||
+				(e.PersistedState == wakeOwnerSame && e.Authenticated) {
+				return ownerReleaseAction(e)
+			}
+		}
+	}
+	return wakeOwnerActionRefuse
+}
+
+func validateGenericWakeLifecycleTransition(
+	inspection wakeLockInspection,
+	request wakeOwnerTransitionRequest,
+) error {
+	claim := classifyWakeClaimForGenericTransition(inspection)
+	action := decideOwnerLifecycleTransition(wakeOwnerTransitionEvidence{
+		Request: request,
+		Claim:   claim,
+	})
+	if action == wakeOwnerActionLegacy {
+		return nil
+	}
+	operation := "mutation"
+	if request == wakeGenericRequestAcquire {
+		operation = "acquisition"
+	}
+	if claim == wakeClaimAuthoritative {
+		return fmt.Errorf(
+			"owner-bound wake claims require 'amq wake recover-owner --me %s'",
+			inspection.Agent,
+		)
+	}
+	reason := strings.TrimSpace(inspection.Reason)
+	if reason == "" {
+		reason = "persisted wake claim is not a valid ownerless generation"
+	}
+	return fmt.Errorf(
+		"wake state for %s is unverified; refusing generic %s: %s",
+		inspection.Agent,
+		operation,
+		reason,
+	)
+}
+
+func ownerReleaseAction(e wakeOwnerTransitionEvidence) wakeOwnerTransitionAction {
+	if e.WakeExactStoppable {
+		return wakeOwnerActionStopAndRelease
+	}
+	if e.WakeAbsent {
+		return wakeOwnerActionRelease
+	}
+	return wakeOwnerActionRefuse
+}

--- a/internal/cli/wake_owner_transition_other.go
+++ b/internal/cli/wake_owner_transition_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin && !linux
+
+package cli
+
+func classifyWakeClaimForGenericTransition(inspection wakeLockInspection) wakeClaimClass {
+	if !inspection.Exists {
+		return wakeClaimAbsent
+	}
+	if inspection.fileInfo == nil {
+		return wakeClaimInvalid
+	}
+	if wakeLockHasOwnerMarkers(inspection) {
+		return wakeClaimAuthoritative
+	}
+	return wakeClaimGeneric
+}

--- a/internal/cli/wake_owner_transition_unix.go
+++ b/internal/cli/wake_owner_transition_unix.go
@@ -1,0 +1,7 @@
+//go:build darwin || linux
+
+package cli
+
+func classifyWakeClaimForGenericTransition(inspection wakeLockInspection) wakeClaimClass {
+	return classifyPersistedWakeClaim(inspection)
+}

--- a/internal/cli/wake_prepared_unix.go
+++ b/internal/cli/wake_prepared_unix.go
@@ -21,8 +21,13 @@ func wakePreparedPath(root, me string) string {
 }
 
 func writeWakePreparedFile(root, me string, expected wakeLockInspection) error {
-	return withWakeLifecycleGuard(root, me, func() error {
-		current := inspectWakeLock(root, me)
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = agentDir.Close() }()
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
 		if !sameWakeLockGeneration(expected, current) {
 			return fmt.Errorf("wake lock generation changed before preparation publication")
 		}
@@ -31,11 +36,14 @@ func writeWakePreparedFile(root, me string, expected wakeLockInspection) error {
 			Generation:   current.Lock.Generation,
 			TargetDigest: current.Lock.TargetDigest,
 		}
-		if err := validateWakeReadyLockAndTarget(root, me, current, marker); err != nil {
+		if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, marker); err != nil {
 			return err
 		}
 		// The marker intentionally persists after exit; its generation binding
 		// makes stale files unusable by later wake instances.
+		if current.Lock.WakeMode == wakeOwnerWakeMode {
+			return writeWakeGenerationFileAt(dirfd, wakePreparedFileName, "wake prepared marker", marker)
+		}
 		return writeWakeGenerationFile(wakePreparedPath(root, me), "wake prepared marker", marker)
 	})
 }
@@ -59,18 +67,48 @@ func validateWakePreparedFileAgainstInspection(root, me string, current wakeLock
 	return true, nil
 }
 
+func validateWakePreparedFileAgainstInspectionAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	current wakeLockInspection,
+) (bool, error) {
+	marker, exists, err := readWakeGenerationFileAt(
+		dirfd,
+		agentDir,
+		wakePreparedFileName,
+		"wake prepared marker",
+	)
+	if err != nil {
+		return false, err
+	}
+	if !exists || marker.Generation != current.Lock.Generation {
+		return false, nil
+	}
+	if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, marker); err != nil {
+		return false, fmt.Errorf("existing amq wake prepared marker is not valid: %w", err)
+	}
+	return true, nil
+}
+
 func writeWakeReadyFileForPreparedWake(root, me, path string, expected wakeLockInspection, deadline time.Time) error {
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = agentDir.Close() }()
 	for {
 		prepared := false
-		err := withWakeLifecycleGuard(root, me, func() error {
-			current := inspectWakeLock(root, me)
+		err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+			current := inspectWakeLockAt(dirfd, agentDir, root, me)
 			if !sameWakeLockGeneration(expected, current) {
 				return fmt.Errorf("wake lock generation changed before existing-wake readiness publication")
 			}
 			if !confirmedLiveWake(current) {
 				return fmt.Errorf("existing amq wake stopped before preparation completed")
 			}
-			if err := validateWakeReadyLockAndTarget(root, me, current, wakeReady{
+			if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, wakeReady{
 				Schema:       wakeReadySchema,
 				Generation:   current.Lock.Generation,
 				TargetDigest: current.Lock.TargetDigest,
@@ -78,7 +116,17 @@ func writeWakeReadyFileForPreparedWake(root, me, path string, expected wakeLockI
 				return fmt.Errorf("existing amq wake became incompatible before preparation completed: %w", err)
 			}
 			var err error
-			prepared, err = validateWakePreparedFileAgainstInspection(root, me, current)
+			if current.Lock.WakeMode == wakeOwnerWakeMode {
+				prepared, err = validateWakePreparedFileAgainstInspectionAt(
+					dirfd,
+					agentDir,
+					root,
+					me,
+					current,
+				)
+			} else {
+				prepared, err = validateWakePreparedFileAgainstInspection(root, me, current)
+			}
 			if err != nil || !prepared {
 				return err
 			}

--- a/internal/cli/wake_process_linux.go
+++ b/internal/cli/wake_process_linux.go
@@ -21,7 +21,11 @@ func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
 
 	statPath := fmt.Sprintf("/proc/%d/stat", pid)
 	if data, err := os.ReadFile(statPath); err == nil {
-		if token, parseErr := linuxProcStartToken(string(data)); parseErr == nil {
+		if token, state, parseErr := linuxProcIdentity(string(data)); parseErr == nil {
+			if state == "Z" {
+				info.Running = false
+				return info
+			}
 			info.StartToken = token
 		} else {
 			info.InspectError = parseErr
@@ -44,17 +48,25 @@ func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
 }
 
 func linuxProcStartToken(stat string) (string, error) {
+	token, _, err := linuxProcIdentity(stat)
+	return token, err
+}
+
+func linuxProcIdentity(stat string) (startToken string, state string, err error) {
 	endComm := strings.LastIndex(stat, ")")
 	if endComm < 0 || endComm+2 >= len(stat) {
-		return "", fmt.Errorf("malformed proc stat")
+		return "", "", fmt.Errorf("malformed proc stat")
 	}
 	fields := strings.Fields(stat[endComm+2:])
 	// fields[0] is stat field 3; starttime is field 22.
 	const startTimeIndex = 22 - 3
 	if len(fields) <= startTimeIndex {
-		return "", fmt.Errorf("proc stat missing starttime")
+		return "", "", fmt.Errorf("proc stat missing starttime")
 	}
-	return fields[startTimeIndex], nil
+	if len(fields[0]) != 1 {
+		return "", "", fmt.Errorf("proc stat has malformed state")
+	}
+	return fields[startTimeIndex], fields[0], nil
 }
 
 func splitProcCmdline(raw []byte) []string {

--- a/internal/cli/wake_process_linux_test.go
+++ b/internal/cli/wake_process_linux_test.go
@@ -31,6 +31,22 @@ func TestLinuxProcStartTokenRejectsMalformedStat(t *testing.T) {
 	}
 }
 
+func TestLinuxProcIdentityRecognizesZombie(t *testing.T) {
+	fields := make([]string, 20)
+	for i := range fields {
+		fields[i] = "0"
+	}
+	fields[0] = "Z"
+	fields[19] = "123456"
+	token, state, err := linuxProcIdentity("42 (amq wake) " + strings.Join(fields, " "))
+	if err != nil {
+		t.Fatalf("linuxProcIdentity: %v", err)
+	}
+	if token != "123456" || state != "Z" {
+		t.Fatalf("identity = token %q state %q, want 123456/Z", token, state)
+	}
+}
+
 func TestSplitProcCmdline(t *testing.T) {
 	got := splitProcCmdline([]byte("/bin/amq\x00wake\x00--me\x00codex\x00"))
 	want := []string{"/bin/amq", "wake", "--me", "codex"}

--- a/internal/cli/wake_raw_orphan_darwin_test.go
+++ b/internal/cli/wake_raw_orphan_darwin_test.go
@@ -9,6 +9,18 @@ func TestLiveRawOrphanState(t *testing.T) {
 	if !isLiveRawOrphan(i) {
 		t.Fatal("expected live raw orphan")
 	}
+	i.Lock.OwnerSchema = wakeOwnerLockSchema
+	i.Lock.Owner = &wakeOwner{
+		PID:          42,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    7,
+	}
+	if isLiveRawOrphan(i) {
+		t.Fatal("owner-bound wake is not a live raw orphan")
+	}
+	i.Lock.OwnerSchema = 0
+	i.Lock.Owner = nil
 	i.Process.Running = false
 	if isLiveRawOrphan(i) {
 		t.Fatal("dead process is not a live raw orphan")

--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -20,23 +20,25 @@ func writeWakeReadyFile(root, me, path string, expected wakeLockInspection) erro
 	if path == "" {
 		return nil
 	}
-	return withWakeLifecycleGuard(root, me, func() error {
-		current := inspectWakeLock(root, me)
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = agentDir.Close() }()
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
 		if !sameWakeLockGeneration(expected, current) {
 			return fmt.Errorf("wake lock generation changed before readiness publication")
 		}
-		if err := validateWakeReadyLockAndTarget(root, me, current, wakeReady{
+		ready := wakeReady{
 			Schema:       wakeReadySchema,
 			Generation:   current.Lock.Generation,
 			TargetDigest: current.Lock.TargetDigest,
-		}); err != nil {
+		}
+		if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, ready); err != nil {
 			return err
 		}
-		return writeWakeGenerationFile(path, "wake ready file", wakeReady{
-			Schema:       wakeReadySchema,
-			Generation:   current.Lock.Generation,
-			TargetDigest: current.Lock.TargetDigest,
-		})
+		return writeWakeGenerationFile(path, "wake ready file", ready)
 	})
 }
 
@@ -106,15 +108,8 @@ func validateWakeGenerationFile(path, label string, info os.FileInfo) error {
 }
 
 func validateWakeReadyLockAndTarget(root, me string, current wakeLockInspection, ready wakeReady) error {
-	confirmed := current.Status == wakeLockValid && current.IdentityConfirmed
-	if !confirmed && !currentWakeLockMatches(current.Lock) {
-		return fmt.Errorf("wake lock is not a confirmed valid wake during readiness validation")
-	}
-	if current.Lock.Generation == "" || ready.Generation != current.Lock.Generation {
-		return fmt.Errorf("wake readiness generation does not match current wake lock")
-	}
-	if ready.TargetDigest != current.Lock.TargetDigest {
-		return fmt.Errorf("wake readiness target does not match current wake lock")
+	if err := validateWakeReadyAgainstLock(current, ready); err != nil {
+		return err
 	}
 	if current.Lock.TargetDigest == "" {
 		_, exists, err := readWakeTarget(root, me)
@@ -133,23 +128,94 @@ func validateWakeReadyLockAndTarget(root, me string, current wakeLockInspection,
 	if !exists {
 		return fmt.Errorf("wake readiness target is missing")
 	}
-	if err := validateWakeTarget(target, root, me); err != nil {
-		return err
-	}
-	return validateWakeTargetMatchesLock(current.Lock, target)
+	return validateWakeReadyTargetAndOwner(current, target)
 }
 
-func validateWakeReadyFileAgainstCurrent(root, me, path string) (bool, error) {
+func validateWakeReadyLockAndTargetAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	current wakeLockInspection,
+	ready wakeReady,
+) error {
+	if err := validateWakeReadyAgainstLock(current, ready); err != nil {
+		return err
+	}
+	target, exists, err := readWakeTargetAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return err
+	}
+	if current.Lock.TargetDigest == "" {
+		if exists {
+			return fmt.Errorf("wake readiness target does not match current wake lock")
+		}
+		return nil
+	}
+	if !exists {
+		return fmt.Errorf("wake readiness target is missing")
+	}
+	return validateWakeReadyTargetAndOwner(current, target)
+}
+
+func validateWakeReadyAgainstLock(current wakeLockInspection, ready wakeReady) error {
+	confirmed := current.Status == wakeLockValid && current.IdentityConfirmed
+	if !confirmed && !currentWakeLockMatches(current.Lock) {
+		return fmt.Errorf("wake lock is not a confirmed valid wake during readiness validation")
+	}
+	if current.Lock.Generation == "" || ready.Generation != current.Lock.Generation {
+		return fmt.Errorf("wake readiness generation does not match current wake lock")
+	}
+	if ready.TargetDigest != current.Lock.TargetDigest {
+		return fmt.Errorf("wake readiness target does not match current wake lock")
+	}
+	return nil
+}
+
+func validateWakeReadyTargetAndOwner(current wakeLockInspection, target wakeTarget) error {
+	if err := validateWakeTargetMatchesLock(current.Lock, target); err != nil {
+		return err
+	}
+	if current.Lock.WakeMode == wakeOwnerWakeMode {
+		observation, err := observeAuthoritativeWakeOwner(*current.Lock.Owner)
+		defer func() { _ = observation.Close() }()
+		if err != nil {
+			return fmt.Errorf("inspect wake owner during readiness validation: %w", err)
+		}
+		if observation.State != wakeOwnerSame {
+			return fmt.Errorf("wake owner is %s during readiness validation: %s", observation.State, observation.Reason)
+		}
+	}
+	return nil
+}
+
+func validateWakeReadyFileAgainstOwner(
+	root string,
+	me string,
+	path string,
+	requestedOwner *wakeOwner,
+) (bool, error) {
 	// A wake can still die immediately after this guarded validation; the local
 	// process notifier has no durable liveness lease beyond the lock generation.
 	ready := false
-	err := withWakeLifecycleGuard(root, me, func() error {
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = agentDir.Close() }()
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		published, exists, err := readWakeReadyFile(path)
 		if err != nil || !exists {
 			return err
 		}
-		if err := validateWakeReadyLockAndTarget(root, me, inspectWakeLock(root, me), published); err != nil {
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
+		if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, published); err != nil {
 			return err
+		}
+		if requestedOwner != nil &&
+			current.Lock.WakeMode == wakeOwnerWakeMode &&
+			!sameWakeOwner(current.Lock.Owner, requestedOwner) {
+			return fmt.Errorf("wake readiness owner does not match the requested owner")
 		}
 		ready = true
 		return nil

--- a/internal/cli/wake_retire_unix.go
+++ b/internal/cli/wake_retire_unix.go
@@ -101,6 +101,9 @@ func retireWake(root, me string, requested wakeTarget) (wakeRetireResult, error)
 		return refuse("no wake lock present; wake process absence cannot be proven")
 	}
 	result.PID = inspection.PID
+	if wakeLockHasOwnerMarkers(inspection) {
+		return refuse(fmt.Sprintf("owner-bound wake claims require 'amq wake recover-owner --me %s'", me))
+	}
 
 	switch inspection.Status {
 	case wakeLockValid:
@@ -178,6 +181,9 @@ func requireExistingWakeTargetMatches(inspection wakeLockInspection, requested w
 	}
 	if !exists {
 		return errors.New("no saved inject-via wake target; refusing retirement")
+	}
+	if persisted.Owner != nil {
+		return fmt.Errorf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", inspection.Agent)
 	}
 	if err := validateWakeTarget(persisted, inspection.Root, inspection.Agent); err != nil {
 		return err

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
@@ -19,6 +22,8 @@ const (
 	wakeTargetFileName  = ".wake.target"
 	wakeTargetInjectVia = "inject-via"
 	envWakeOwner        = "AMQ_WAKE_OWNER"
+
+	maxWakeOwnerIdentityTokenBytes = 256
 )
 
 type wakeOwner struct {
@@ -69,15 +74,35 @@ func wakeTargetInjectViaPath(path string) (string, error) {
 	return validateWakeInjectViaPath(path)
 }
 
-func wakeTargetDigest(target wakeTarget) string {
-	data, _ := json.Marshal(target)
+func wakeTargetDigest(target wakeTarget) (string, error) {
+	data, err := json.Marshal(target)
+	if err != nil {
+		return "", fmt.Errorf("marshal wake target digest: %w", err)
+	}
 	sum := sha256.Sum256(data)
-	return "sha256:" + hex.EncodeToString(sum[:])
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
 func validateWakeTargetMatchesLock(lock wakeLock, target wakeTarget) error {
-	if lock.WakeMode != wakeTargetInjectVia || lock.TargetDigest == "" {
+	if (lock.WakeMode != wakeTargetInjectVia && lock.WakeMode != wakeOwnerWakeMode) || lock.TargetDigest == "" {
 		return fmt.Errorf("wake lock was not created for an inject-via repair target")
+	}
+	if lock.WakeMode == wakeOwnerWakeMode {
+		if lock.OwnerSchema != wakeOwnerLockSchema || lock.Owner == nil {
+			return fmt.Errorf("wake owner lock schema is incomplete")
+		}
+		if err := validateAuthoritativeWakeOwner(*lock.Owner); err != nil {
+			return fmt.Errorf("wake lock owner is invalid: %w", err)
+		}
+		if target.Owner == nil {
+			return fmt.Errorf("wake target owner is missing")
+		}
+		if err := validateAuthoritativeWakeOwner(*target.Owner); err != nil {
+			return fmt.Errorf("wake target owner is invalid: %w", err)
+		}
+		if !sameWakeOwner(lock.Owner, target.Owner) {
+			return fmt.Errorf("wake target owner does not match wake lock owner")
+		}
 	}
 	if strings.TrimSpace(lock.Root) == "" || canonicalWakeRoot(lock.Root) != canonicalWakeRoot(target.Root) {
 		return fmt.Errorf("wake lock root mismatch")
@@ -85,7 +110,11 @@ func validateWakeTargetMatchesLock(lock wakeLock, target wakeTarget) error {
 	if lock.Agent != target.Agent {
 		return fmt.Errorf("wake lock agent mismatch")
 	}
-	if got := wakeTargetDigest(target); got != lock.TargetDigest {
+	got, err := wakeTargetDigest(target)
+	if err != nil {
+		return err
+	}
+	if got != lock.TargetDigest {
 		return fmt.Errorf("wake target does not match wake lock")
 	}
 	return nil
@@ -208,7 +237,7 @@ func validateWakeTarget(target wakeTarget, root, me string) error {
 }
 
 func encodeWakeOwnerEnv(owner wakeOwner) (string, error) {
-	if err := validateWakeOwner(owner); err != nil {
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
 		return "", err
 	}
 	data, err := json.Marshal(owner)
@@ -247,6 +276,105 @@ func validateWakeOwner(owner wakeOwner) error {
 		return fmt.Errorf("wake owner session id must be >= 0")
 	}
 	return nil
+}
+
+func validateAuthoritativeWakeOwner(owner wakeOwner) error {
+	if err := validateWakeOwner(owner); err != nil {
+		return err
+	}
+	if err := validateAuthoritativeWakeOwnerToken("process start", owner.ProcessStart); err != nil {
+		return err
+	}
+	if err := validateAuthoritativeWakeOwnerToken("boot id", owner.BootID); err != nil {
+		return err
+	}
+	if owner.SessionID <= 0 {
+		return fmt.Errorf("wake owner session id must be > 0")
+	}
+	if !validWakeOwnerProcessStart(owner.ProcessStart) {
+		return fmt.Errorf("wake owner process start has malformed platform value")
+	}
+	if !validWakeOwnerBootID(owner.BootID) {
+		return fmt.Errorf("wake owner boot id has malformed platform value")
+	}
+	return nil
+}
+
+func validateAuthoritativeWakeOwnerToken(label, value string) error {
+	if value == "" {
+		return fmt.Errorf("wake owner %s is required", label)
+	}
+	if len(value) > maxWakeOwnerIdentityTokenBytes {
+		return fmt.Errorf("wake owner %s is too long", label)
+	}
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("wake owner %s is not valid UTF-8", label)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("wake owner %s contains a control character", label)
+		}
+	}
+	if strings.TrimSpace(value) != value {
+		return fmt.Errorf("wake owner %s is not canonical", label)
+	}
+	return nil
+}
+
+func validWakeOwnerProcessStart(value string) bool {
+	if validPositiveDecimal(value) {
+		return true
+	}
+	return validWakeOwnerTimestamp(value)
+}
+
+func validWakeOwnerBootID(value string) bool {
+	if validWakeOwnerTimestamp(value) {
+		return true
+	}
+	if len(value) != 36 {
+		return false
+	}
+	for index, r := range value {
+		switch index {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if (r < '0' || r > '9') &&
+				(r < 'a' || r > 'f') &&
+				(r < 'A' || r > 'F') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func validWakeOwnerTimestamp(value string) bool {
+	seconds, nanos, found := strings.Cut(value, ".")
+	if !found || !validPositiveDecimal(seconds) || len(nanos) != 9 {
+		return false
+	}
+	parsedNanos, err := strconv.ParseUint(nanos, 10, 32)
+	return err == nil && parsedNanos < 1_000_000_000
+}
+
+func validPositiveDecimal(value string) bool {
+	if value == "" {
+		return false
+	}
+	if len(value) > 1 && value[0] == '0' {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	return err == nil && parsed > 0
 }
 
 func validateWakeInjectViaPath(path string) (string, error) {

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -21,7 +21,10 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	var recheck wakeLockInspection
 	if err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
 		recheck = inspectWakeLock(inspection.Root, inspection.Agent)
-		return nil
+		if !sameWakeLockInspection(inspection, recheck) {
+			return nil
+		}
+		return validateWakeLockOwnerlessMutation(recheck)
 	}); err != nil {
 		return false, err
 	}
@@ -59,7 +62,10 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 }
 
 func isLiveRawOrphan(inspection wakeLockInspection) bool {
-	return inspection.Process.Running && inspection.IdentityConfirmed && inspection.Lock.WakeMode != wakeTargetInjectVia
+	return inspection.Process.Running &&
+		inspection.IdentityConfirmed &&
+		inspection.Lock.WakeMode != wakeTargetInjectVia &&
+		!wakeLockHasOwnerMarkers(inspection)
 }
 
 func terminateWakeProcess(inspection wakeLockInspection) error {

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -40,6 +40,9 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 		if !sameWakeLockGeneration(inspection, locked) {
 			return nil
 		}
+		if err := validateWakeLockOwnerlessMutation(locked); err != nil {
+			return err
+		}
 
 		// Acquire the stable process capability before any PID-based identity
 		// inspection of this locked generation. From here onward, signaling and

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -68,6 +68,10 @@ func acquireWakeLock(root, me string, target *wakeTarget) (cleanup func(), err e
 }
 
 func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions) (cleanup func(), err error) {
+	if options.target != nil && options.target.Owner != nil {
+		return acquireAuthoritativeWakeLockWithOptions(root, me, options)
+	}
+
 	agentBase := fsq.AgentBase(root, me)
 	lockPath := filepath.Join(agentBase, ".wake.lock")
 
@@ -81,6 +85,18 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 		var created wakeLockInspection
 		err := withWakeLifecycleGuard(root, me, func() error {
 			inspection := inspectWakeLock(root, me)
+			if err := validateGenericWakeLifecycleTransition(inspection, wakeGenericRequestAcquire); err != nil {
+				return err
+			}
+			if inspection.Exists && inspection.Lock.TargetDigest != "" {
+				persisted, exists, readErr := readWakeTarget(root, me)
+				if readErr != nil {
+					return fmt.Errorf("persisted wake target for %s is unverified: %w", me, readErr)
+				}
+				if exists && persisted.Owner != nil {
+					return fmt.Errorf("wake handle %s has legacy owner-bearing state; run 'amq wake recover-owner --me %s'", me, me)
+				}
+			}
 			if inspection.Exists {
 				switch inspection.Status {
 				case wakeLockStale:
@@ -115,6 +131,11 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 			}
 			if replace.Exists {
 				return nil
+			}
+			if orphan, exists, readErr := readWakeTarget(root, me); readErr != nil {
+				return fmt.Errorf("wake target for %s is unverified: %w", me, readErr)
+			} else if exists && orphan.Owner != nil {
+				return fmt.Errorf("wake handle %s has an owner-bearing orphan target; run 'amq wake recover-owner --me %s'", me, me)
 			}
 
 			// Stage target metadata first. The lock is the transaction commit point.
@@ -192,9 +213,19 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 		WakeMode:   options.wakeMode,
 	}
 	if options.target != nil {
+		targetDigest, err := wakeTargetDigest(*options.target)
+		if err != nil {
+			return wakeLock{}, err
+		}
 		lock.WakeMode = wakeTargetInjectVia
-		lock.TargetDigest = wakeTargetDigest(*options.target)
+		lock.TargetDigest = targetDigest
 		lock.ControlSocket = wakeControlSocketPath(root, me, lock.Generation)
+		if options.target.Owner != nil {
+			owner := *options.target.Owner
+			lock.WakeMode = wakeOwnerWakeMode
+			lock.OwnerSchema = wakeOwnerLockSchema
+			lock.Owner = &owner
+		}
 	}
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
@@ -217,10 +248,26 @@ func shouldReplaceOrphanedWakeLock(inspection wakeLockInspection) (bool, error) 
 }
 
 func wakeLockReplacementNeeded(inspection wakeLockInspection) (bool, error) {
-	if wakeLockNeedsReplacement(inspection) {
-		return true, nil
+	if err := validateWakeLockOwnerlessMutation(inspection); err != nil {
+		return false, err
 	}
-	return wakeLockNeedsOwnerReplacement(inspection)
+	return wakeLockNeedsReplacement(inspection), nil
+}
+
+func validateWakeLockOwnerlessMutation(inspection wakeLockInspection) error {
+	if err := validateGenericWakeLifecycleTransition(inspection, wakeGenericRequestMutate); err != nil {
+		return err
+	}
+	if inspection.Lock.TargetDigest != "" {
+		target, exists, err := readWakeTarget(inspection.Root, inspection.Agent)
+		if err != nil {
+			return fmt.Errorf("wake target is unverified before ownerless mutation: %w", err)
+		}
+		if exists && target.Owner != nil {
+			return fmt.Errorf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", inspection.Agent)
+		}
+	}
+	return nil
 }
 
 func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
@@ -252,23 +299,6 @@ func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
 		}
 	}
 	return false
-}
-
-func wakeLockNeedsOwnerReplacement(inspection wakeLockInspection) (bool, error) {
-	if !inspection.IdentityConfirmed || inspection.Lock.WakeMode != wakeTargetInjectVia || inspection.Lock.TargetDigest == "" {
-		return false, nil
-	}
-	target, exists, err := readWakeTarget(inspection.Root, inspection.Agent)
-	if err != nil || !exists {
-		return false, nil
-	}
-	if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
-		return false, nil
-	}
-	if target.Owner == nil {
-		return false, nil
-	}
-	return wakeOwnerHealthCheck(*target.Owner) != nil, nil
 }
 
 func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string, requestedTarget *wakeTarget) error {
@@ -322,7 +352,8 @@ func wakeLockHasUsableNotificationPath(inspection wakeLockInspection) bool {
 	if inspection.Lock.WakeMode == wakeInjectModeNone {
 		return true
 	}
-	if (inspection.Lock.WakeMode == wakeTargetInjectVia && inspection.Lock.TargetDigest != "") || wakeArgsUseInjectVia(inspection.Process.Args) {
+	if ((inspection.Lock.WakeMode == wakeTargetInjectVia || inspection.Lock.WakeMode == wakeOwnerWakeMode) &&
+		inspection.Lock.TargetDigest != "") || wakeArgsUseInjectVia(inspection.Process.Args) {
 		return true
 	}
 	tty := strings.TrimSpace(inspection.Lock.TTY)
@@ -381,6 +412,8 @@ func runWake(args []string) error {
 			return runWakeRepair(args[1:])
 		case "retire":
 			return runWakeRetire(args[1:])
+		case "recover-owner":
+			return runWakeRecoverOwner(args[1:])
 		}
 	}
 	return runWakeWithLoop(args, runWakeLoop)
@@ -497,6 +530,12 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 			result.Status = "refused"
 			result.Reason = err.Error()
 			return err
+		}
+		if target.Owner != nil {
+			result.Status = "refused"
+			result.PID = inspection.PID
+			result.Reason = fmt.Sprintf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", me)
+			return errors.New(result.Reason)
 		}
 		if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
 			result.Status = "refused"
@@ -651,6 +690,12 @@ func buildRepairWakeArgs(root, me string, target wakeTarget, readyPath string) [
 }
 
 func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
+	privateStop, cleanupPrivateStop, err := authoritativeWakePrivateStopFromEnv()
+	if err != nil {
+		return err
+	}
+	defer cleanupPrivateStop()
+
 	fs := flag.NewFlagSet("wake", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	injectCmdFlag := fs.String("inject-cmd", "", "Command to inject (power user mode)")
@@ -878,6 +923,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		defer markStopped()
 		controlStop = stop
 	}
+	controlStop = mergeWakeStopChannels(controlStop, privateStop)
 
 	if injectVia != "" {
 		if err := validateResolvedWakeInjectViaPath(injectVia); err != nil {
@@ -1225,18 +1271,6 @@ func targetOwner(target *wakeTarget) *wakeOwner {
 		return nil
 	}
 	owner := *target.Owner
-	return &owner
-}
-
-func currentWakeOwner() *wakeOwner {
-	owner := wakeOwner{PID: os.Getpid()}
-	if proc := inspectWakeProcess(owner.PID); proc.Running {
-		owner.ProcessStart = proc.StartToken
-		owner.BootID = proc.BootID
-	}
-	if sid, err := getWakeProcessSID(owner.PID); err == nil {
-		owner.SessionID = sid
-	}
 	return &owner
 }
 

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -531,8 +531,8 @@ func TestRunWakeWithLoopPersistsInjectViaWakeOwnerFromEnv(t *testing.T) {
 
 	owner := wakeOwner{
 		PID:          4242,
-		ProcessStart: "owner-start",
-		BootID:       "boot-1",
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
 		SessionID:    99,
 	}
 	ownerEnv, err := encodeWakeOwnerEnv(owner)
@@ -540,6 +540,25 @@ func TestRunWakeWithLoopPersistsInjectViaWakeOwnerFromEnv(t *testing.T) {
 		t.Fatalf("encodeWakeOwnerEnv: %v", err)
 	}
 	t.Setenv(envWakeOwner, ownerEnv)
+	realInspect := inspectWakeProcess
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == owner.PID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: owner.ProcessStart,
+				BootID:     owner.BootID,
+			}
+		}
+		return realInspect(pid)
+	})
+	realSID := getWakeProcessSID
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		if pid == owner.PID {
+			return owner.SessionID, nil
+		}
+		return realSID(pid)
+	})
 
 	injector := writeExecutableForTest(t, "injector")
 	errDone := errors.New("done")
@@ -918,7 +937,7 @@ func TestRunWakeWithLoopWaitsForCurrentPreparedMarkerPastStaleGeneration(t *test
 	if err := writeWakeGenerationFile(wakePreparedPath(root, "orchestrator"), "wake prepared marker", wakeReady{
 		Schema:       wakeReadySchema,
 		Generation:   "previous-generation",
-		TargetDigest: wakeTargetDigest(target),
+		TargetDigest: mustWakeTargetDigest(target),
 	}); err != nil {
 		t.Fatalf("write previous-generation prepared marker: %v", err)
 	}
@@ -2377,7 +2396,7 @@ func TestShouldReplaceOrphanedWakeLockRevalidatesBeforeSignal(t *testing.T) {
 	}
 }
 
-func TestShouldReplaceOrphanedWakeLockReplacesInjectViaWhenOwnerGone(t *testing.T) {
+func TestShouldReplaceOrphanedWakeLockRefusesLegacyOwnerStateWhenOwnerGone(t *testing.T) {
 	requireBarePIDWakeTermination(t)
 	const wakePID = 4242
 	const ownerPID = 7777
@@ -2430,8 +2449,8 @@ func TestShouldReplaceOrphanedWakeLockReplacesInjectViaWhenOwnerGone(t *testing.
 
 	inspection := inspectWakeLock(root, "orchestrator")
 	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
-	if err == nil || !strings.Contains(err.Error(), "no cooperative control endpoint") {
-		t.Fatalf("expected missing-control refusal, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "recover-owner") {
+		t.Fatalf("expected owner-state refusal, got %v", err)
 	}
 	if replaced || killed {
 		t.Fatal("legacy inject-via wake must not be terminated by PID")
@@ -2441,7 +2460,7 @@ func TestShouldReplaceOrphanedWakeLockReplacesInjectViaWhenOwnerGone(t *testing.
 	}
 }
 
-func TestShouldReplaceOrphanedWakeLockKeepsInjectViaWhenOwnerMatches(t *testing.T) {
+func TestShouldReplaceOrphanedWakeLockRefusesLegacyOwnerStateWhenOwnerMatches(t *testing.T) {
 	const wakePID = 4242
 	const ownerPID = 7777
 	root := secureTempDirForTest(t)
@@ -2489,11 +2508,11 @@ func TestShouldReplaceOrphanedWakeLockKeepsInjectViaWhenOwnerMatches(t *testing.
 
 	inspection := inspectWakeLock(root, "orchestrator")
 	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
-	if err != nil {
-		t.Fatalf("shouldReplaceOrphanedWakeLock: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "recover-owner") {
+		t.Fatalf("expected owner-state refusal, got %v", err)
 	}
 	if replaced {
-		t.Fatal("owner-matched inject-via wake should not be replaced")
+		t.Fatal("legacy owner-bearing wake should not be replaced")
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
 		t.Fatalf("lock should remain for owner-matched wake, stat=%v", statErr)
@@ -3157,37 +3176,13 @@ func TestWakeHealthCheckKeepsInjectViaWhenOwnerMatches(t *testing.T) {
 	}
 }
 
-func TestCurrentWakeOwnerIncludesProcessIdentityWhenAvailable(t *testing.T) {
-	self := os.Getpid()
-	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
-		if pid != self {
-			return wakeProcessInfo{PID: pid}
-		}
-		return wakeProcessInfo{
-			PID:        pid,
-			Running:    true,
-			StartToken: "self-start",
-			BootID:     "boot-1",
-		}
-	})
-	stubWakeProcessSID(t, func(pid int) (int, error) {
-		if pid != self {
-			t.Fatalf("unexpected sid lookup pid %d", pid)
-		}
-		return 99, nil
-	})
-
-	owner := currentWakeOwner()
-	if owner == nil {
-		t.Fatal("expected owner")
-	}
-	if owner.PID != self || owner.ProcessStart != "self-start" || owner.BootID != "boot-1" || owner.SessionID != 99 {
-		t.Fatalf("owner = %#v, want pid=%d start/self boot/session", owner, self)
-	}
-}
-
 func TestWakeCommandEnvCarriesOwnerToken(t *testing.T) {
-	owner := wakeOwner{PID: 4242, ProcessStart: "owner-start", BootID: "boot-1", SessionID: 99}
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
 	env, err := wakeCommandEnv([]string{
 		"PATH=/bin",
 		envRoot + "=/old/root",

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -540,25 +540,14 @@ func TestRunWakeWithLoopPersistsInjectViaWakeOwnerFromEnv(t *testing.T) {
 		t.Fatalf("encodeWakeOwnerEnv: %v", err)
 	}
 	t.Setenv(envWakeOwner, ownerEnv)
-	realInspect := inspectWakeProcess
-	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
-		if pid == owner.PID {
-			return wakeProcessInfo{
-				PID:        pid,
-				Running:    true,
-				StartToken: owner.ProcessStart,
-				BootID:     owner.BootID,
-			}
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("observed owner = %#v, want %#v", got, owner)
 		}
-		return realInspect(pid)
-	})
-	realSID := getWakeProcessSID
-	stubWakeProcessSID(t, func(pid int) (int, error) {
-		if pid == owner.PID {
-			return owner.SessionID, nil
-		}
-		return realSID(pid)
-	})
+		return wakeOwnerObservation{State: wakeOwnerSame}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
 
 	injector := writeExecutableForTest(t, "injector")
 	errDone := errors.New("done")

--- a/internal/cli/wake_upgrade_race_unix_test.go
+++ b/internal/cli/wake_upgrade_race_unix_test.go
@@ -75,7 +75,7 @@ func TestWakeUpgradeRaceRepairRejectsConcurrentCurrentAcquire(t *testing.T) {
 	if winner.Lock.Generation == "" || winner.Lock.Generation == legacyGeneration {
 		t.Fatalf("winner generation = %q, want a new current generation", winner.Lock.Generation)
 	}
-	if winner.Lock.WakeMode != wakeTargetInjectVia || winner.Lock.TargetDigest != wakeTargetDigest(target) {
+	if winner.Lock.WakeMode != wakeTargetInjectVia || winner.Lock.TargetDigest != mustWakeTargetDigest(target) {
 		t.Fatalf("winner metadata = %#v, want current inject-via target binding", winner.Lock)
 	}
 	if runtime.GOOS == "darwin" && winner.Lock.ControlSocket == "" {
@@ -120,7 +120,7 @@ func TestWakeUpgradeRaceCleanupAndReadinessPreserveReplacement(t *testing.T) {
 			}
 			replacement := original.Lock
 			replacement.Generation = "replacement-generation"
-			replacement.TargetDigest = wakeTargetDigest(replacementTarget)
+			replacement.TargetDigest = mustWakeTargetDigest(replacementTarget)
 			replacement.ControlSocket = wakeControlSocketPath(root, "codex", replacement.Generation)
 			data, err := json.Marshal(replacement)
 			if err != nil {


### PR DESCRIPTION
## Summary

Adds an owner-bound lifecycle for inject-via wake helpers so a wake claim can outlive its helper process without becoming unsafe to reclaim.

This design and implementation originated with Ohad Edelstein and is committed with his co-author credit.

## Changes

- Model owner identity as a strict PID, process-start, boot-ID, and OS-session tuple with `same`, `dead`, and `unknown` outcomes.
- Separate owner-claim lifetime from wake-process lifetime and route acquisition, reuse, recovery, and release through one guarded transition policy.
- Publish paired wake metadata atomically with a read-only `0400` mixed-version fence and exact target digest.
- Use stable Linux pidfds and Darwin cooperative control for identity-safe stop and cleanup, including PID-reuse boundaries.
- Add authenticated `wake recover-owner`, doctor guidance, coop-exec owner export, and ownerless fallback on unsupported capabilities.
- Preserve fail-closed behavior when identity evidence is unavailable or malformed.

## Testing

- [x] `make ci`
- [x] `go test -race ./... -count=1`
- [x] Darwin, Linux amd64/386/arm/arm64, FreeBSD amd64, and Windows amd64 builds
- [x] Linux-only CLI test compilation on amd64/386/arm/arm64
- [x] Claude six-axis review and exact-delta reviews
- [x] ChatGPT Pro design gate, full code gate, correction gate, and terminal confirmation

## Related Issues

Related to #235.

Supersedes the owner-lifecycle approach proposed in #266 and #270; this PR does not close or merge those items automatically.
