### PR TITLE
fix(wake): make repair continuity fail closed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,13 +362,19 @@ proven-stale lock and start a fresh wake only when the stale lock was created
 for `--inject-via`, and `agents/<agent>/.wake.target` exists with a digest that
 matches the lock's repair metadata. `.wake.target` is mode `0600` and stores
 schema metadata, root, agent, creation time, `mode:"inject-via"`, an absolute
-executable path, and fixed argv. Raw TTY wake has no repair target; repair must
-refuse raw locks, leftover targets from old locks, and `unverified` locks.
+executable path, and fixed argv. The private mode-`0600` `.wake.repair-floor`
+must also match the exact generation, target, physical root, boot, and owner
+state. It persists only the device/inode/ctime identities already suppressed by
+that wake, never message IDs. Repair hands that floor to the replacement rather
+than re-snapshotting `inbox/new`, so downtime arrivals and same-name DLQ retries
+remain eligible. Missing, corrupt, or mismatched floor state requires a normal
+wake restart. Raw TTY wake has no repair target; repair must refuse raw locks,
+leftover targets from old locks, and `unverified` locks.
 Repaired wake stdout/stderr goes to
 `agents/<agent>/.wake.repair.log`; repair itself must not keep stdout/stderr
 pipes open after its JSON/text output exits. `doctor --ops` may report
-`target_present` and `repair_available`, but must remain diagnostic-only and
-never spawn a wake process.
+`target_present`, `repair_available`, and a continuity `repair_reason`, but must
+remain diagnostic-only and never spawn a wake process.
 
 `amq wake retire` requires the expected inject-via executable and ordered fixed
 arguments. It stops only an identity-confirmed live inject-via wake with an

--- a/README.md
+++ b/README.md
@@ -226,9 +226,17 @@ and remove the named `.wake.lock` manually only after confirming no matching
 `amq wake repair` is an explicit live-session repair path. It only runs when
 the lock is proven `stale`, the lock was created for `--inject-via`, and the
 agent has a saved `agents/<agent>/.wake.target` whose digest matches the lock's
-repair metadata. It refuses raw terminal wake targets, leftover targets from old
-locks, and `unverified` locks to avoid double-injecting into an active session
-or injecting into the wrong terminal. Repaired wake output goes to
+repair metadata. It also requires AMQ's private `.wake.repair-floor` to match
+the exact dead generation, boot, physical queue root, owner state, and target.
+That floor carries only the existing-message identities already suppressed by
+the dead wake (device, inode, and ctime), never message IDs. A repaired wake
+inherits it instead of re-snapshotting `inbox/new`, so messages delivered while
+the notifier was down remain eligible to notify and same-name DLQ retries
+remain eligible when their file identity changes. Missing, corrupt, or
+mismatched continuity state fails closed and requires a normal wake restart.
+Repair refuses raw terminal wake targets, leftover targets from old locks, and
+`unverified` locks to avoid double-injecting into an active session or injecting
+into the wrong terminal. Repaired wake output goes to
 `agents/<agent>/.wake.repair.log`; `doctor --ops` can report whether repair is
 available, but it never starts a wake process.
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -226,6 +226,9 @@ func runDoctor(args []string) error {
 			if wl.TargetReason != "" {
 				line += " target_reason=" + wl.TargetReason
 			}
+			if wl.RepairReason != "" {
+				line += " repair_reason=" + wl.RepairReason
+			}
 			if wl.RepairAvailable && wl.Status == string(wakeLockStale) {
 				line += " repair=" + wl.Repair
 			}

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -63,6 +63,7 @@ type opsWakeLock struct {
 	TargetReason    string `json:"target_reason,omitempty"`
 	Repair          string `json:"repair,omitempty"`
 	RepairAvailable bool   `json:"repair_available,omitempty"`
+	RepairReason    string `json:"repair_reason,omitempty"`
 }
 
 const fixWakeLocksCommand = "amq doctor --ops --fix-wake-locks"
@@ -320,8 +321,12 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 			}
 			lock.Fix = fixWakeLocksCommand
 			if lock.TargetPresent && lock.TargetReason == "" && validateWakeLockRepairable(inspection) == nil {
-				lock.RepairAvailable = true
-				lock.Repair = wakeRepairCommand(root, agent)
+				if err := validateWakeRepairFloorAvailable(root, agent, inspection, target); err != nil {
+					lock.RepairReason = err.Error()
+				} else {
+					lock.RepairAvailable = true
+					lock.Repair = wakeRepairCommand(root, agent)
+				}
 			}
 			if fix {
 				guardErr := withWakeLifecycleGuard(root, agent, func() error {
@@ -343,6 +348,7 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 				})
 				lock.RepairAvailable = false
 				lock.Repair = ""
+				lock.RepairReason = ""
 				if guardErr != nil {
 					lock.Status = "error"
 					lock.Reason = guardErr.Error()

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -436,7 +436,7 @@ func TestRunOpsChecks_FixesStaleWakeLock(t *testing.T) {
 	}
 }
 
-func TestRunOpsChecks_ReportsWakeRepairAvailabilityWithoutSpawning(t *testing.T) {
+func TestRunOpsChecks_RequiresWakeRepairFloor(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("ensure root dirs: %v", err)
@@ -479,11 +479,11 @@ func TestRunOpsChecks_ReportsWakeRepairAvailabilityWithoutSpawning(t *testing.T)
 	if got.TargetReason != "" {
 		t.Fatalf("target_reason = %q, want empty", got.TargetReason)
 	}
-	if !got.RepairAvailable {
-		t.Fatal("repair_available = false, want true")
+	if got.RepairAvailable || got.Repair != "" {
+		t.Fatalf("repair advertised without continuity floor: %#v", got)
 	}
-	if got.Repair != wakeRepairCommand(root, "alice") {
-		t.Fatalf("repair = %q, want %q", got.Repair, wakeRepairCommand(root, "alice"))
+	if !strings.Contains(got.RepairReason, "wake repair floor is missing") {
+		t.Fatalf("repair_reason = %q, want missing floor", got.RepairReason)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("doctor report should not remove lock: %v", err)

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -10,8 +10,61 @@ import (
 	"testing"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
+
+func TestRunOpsChecksReportsWakeRepairAvailabilityWithFloor(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	injector := writeExecutableForTest(t, "doctor-repair-injector")
+	target := mustNewWakeTargetForTest(t, root, "alice", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "alice", bindWakeLockToTarget(wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	}, target))
+	if err := writeWakeTarget(root, "alice", target); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+	writeWakeRepairFloorForTest(t, root, "alice", target, nil)
+
+	result := runOpsChecks(root, "test_source", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) || !got.TargetPresent || got.TargetReason != "" {
+		t.Fatalf("unexpected stale repair state: %#v", got)
+	}
+	if !got.RepairAvailable || got.Repair != wakeRepairCommand(root, "alice") || got.RepairReason != "" {
+		t.Fatalf("repair availability = %#v", got)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("doctor report removed lock: %v", err)
+	}
+
+	stubCurrentWakeBootID(t, "22222222-2222-2222-2222-222222222222")
+	result = runOpsChecks(root, "test_source", false)
+	got = result.WakeLocks[0]
+	if got.RepairAvailable || got.Repair != "" ||
+		!strings.Contains(got.RepairReason, "does not match the current boot") {
+		t.Fatalf("doctor advertised prior-boot repair floor: %#v", got)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("doctor prior-boot report removed lock: %v", err)
+	}
+}
 
 func TestRunOpsChecksRejectsSymlinkAndFIFOWakeLocks(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
+
+const cliHelperEnv = "AMQ_TEST_CLI_HELPER"
 
 // TestMain gives the cli package a hermetic environment so the developer's shell
 // can't leak routing context into tests. The cross-tree send guard (issue #144)
@@ -12,6 +15,14 @@ import (
 // dir look like refused cross-tree sends. Tests that need these signals set them
 // explicitly via t.Setenv, which overrides and restores around this clean baseline.
 func TestMain(m *testing.M) {
+	if os.Getenv(cliHelperEnv) == "1" {
+		if err := Run(os.Args[1:], "test"); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(GetExitCode(err))
+		}
+		os.Exit(0)
+	}
+
 	for _, k := range []string{"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION", "AMQ_GLOBAL_ROOT"} {
 		_ = os.Unsetenv(k)
 	}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -3,10 +3,13 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 const cliHelperEnv = "AMQ_TEST_CLI_HELPER"
+
+var cliSecureTempRoot string
 
 // TestMain gives the cli package a hermetic environment so the developer's shell
 // can't leak routing context into tests. The cross-tree send guard (issue #144)
@@ -22,9 +25,41 @@ func TestMain(m *testing.M) {
 		}
 		os.Exit(0)
 	}
+	if os.Getenv(injectViaHelperEnv) == "1" {
+		os.Exit(m.Run())
+	}
 
 	for _, k := range []string{"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION", "AMQ_GLOBAL_ROOT"} {
 		_ = os.Unsetenv(k)
 	}
-	os.Exit(m.Run())
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "resolve test home directory: %v\n", err)
+		os.Exit(1)
+	}
+	home, err = filepath.EvalSymlinks(home)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "resolve test home directory symlinks: %v\n", err)
+		os.Exit(1)
+	}
+	tempRoot, err := os.MkdirTemp(home, ".amq-cli-test-")
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "create secure test temp root: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.Chmod(tempRoot, 0o700); err != nil {
+		_ = os.RemoveAll(tempRoot)
+		_, _ = fmt.Fprintf(os.Stderr, "secure test temp root: %v\n", err)
+		os.Exit(1)
+	}
+
+	cliSecureTempRoot = tempRoot
+	exitCode := m.Run()
+	cliSecureTempRoot = ""
+	if err := os.RemoveAll(tempRoot); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "remove secure test temp root: %v\n", err)
+		exitCode = 1
+	}
+	os.Exit(exitCode)
 }

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -43,8 +43,21 @@ type wakeConfig struct {
 	lastInterrupt     time.Time
 	controlStop       <-chan struct{}
 	baselineRequested bool
+	baselineInherited bool
 	baselineExisting  map[string]wakeFileIdentity
-	onPrepared        func() error
+	onBaselineReady   func(map[string]wakeFileIdentity) error
+	onPrepared        func(wakeAdmissionWatcher) error
+	retainedInbox     wakeInboxReader
+	touchPresence     func() error
+}
+
+type wakeAdmissionWatcher interface {
+	Errors() <-chan error
+}
+
+type wakeInboxReader interface {
+	ReadDir() ([]os.DirEntry, error)
+	ReadHeader(name string) (format.Header, error)
 }
 
 const defaultInjectTimeout = 5 * time.Second
@@ -139,7 +152,13 @@ func shouldDeferBeforeInject(cfg *wakeConfig, deferForInput bool) bool {
 func notifyNewMessages(cfg *wakeConfig) error {
 	inboxNew := fsq.AgentInboxNew(cfg.root, cfg.me)
 
-	entries, err := os.ReadDir(inboxNew)
+	var entries []os.DirEntry
+	var err error
+	if cfg.retainedInbox != nil {
+		entries, err = cfg.retainedInbox.ReadDir()
+	} else {
+		entries, err = os.ReadDir(inboxNew)
+	}
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -168,8 +187,12 @@ func notifyNewMessages(cfg *wakeConfig) error {
 			delete(cfg.baselineExisting, name)
 		}
 
-		path := filepath.Join(inboxNew, name)
-		header, err := format.ReadHeaderFile(path)
+		var header format.Header
+		if cfg.retainedInbox != nil {
+			header, err = cfg.retainedInbox.ReadHeader(name)
+		} else {
+			header, err = format.ReadHeaderFile(filepath.Join(inboxNew, name))
+		}
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -423,20 +423,44 @@ func handleDarwinOwnerControl(
 }
 
 func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan struct{}, func(), error) {
-	path := lock.ControlSocket
-	if path == "" {
-		return func() {}, nil, func() {}, nil
-	}
 	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	keepAgentDir := false
-	defer func() {
-		if !keepAgentDir {
-			_ = agentDir.Close()
-		}
-	}()
+	cleanup, stop, markStopped, err := startWakeControlListenerInDirOwned(
+		agentDir,
+		root,
+		me,
+		lock,
+		true,
+	)
+	if err != nil {
+		_ = agentDir.Close()
+	}
+	return cleanup, stop, markStopped, err
+}
+
+func startWakeControlListenerInDir(
+	agentDir *wakeAgentDir,
+	root, me string,
+	lock wakeLock,
+) (func(), <-chan struct{}, func(), error) {
+	return startWakeControlListenerInDirOwned(agentDir, root, me, lock, false)
+}
+
+func startWakeControlListenerInDirOwned(
+	agentDir *wakeAgentDir,
+	root, me string,
+	lock wakeLock,
+	closeAgentDir bool,
+) (func(), <-chan struct{}, func(), error) {
+	path := lock.ControlSocket
+	if path == "" {
+		return func() {}, nil, func() {}, nil
+	}
+	if agentDir == nil {
+		return nil, nil, nil, fmt.Errorf("wake agent directory capability is missing")
+	}
 	name, err := darwinControlSocketName(agentDir, path)
 	if err != nil {
 		return nil, nil, nil, err
@@ -461,7 +485,6 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 		_ = agentDir.withFD(func(dirfd int) error { return removeDarwinControlSocketAt(dirfd, name) })
 		return nil, nil, nil, err
 	}
-	keepAgentDir = true
 	stopRequest := make(chan struct{}, 1)
 	loopStopped := make(chan struct{})
 	var loopStoppedOnce sync.Once
@@ -570,7 +593,9 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 				}
 				return removeDarwinControlSocketAt(dirfd, name)
 			})
-			_ = agentDir.Close()
+			if closeAgentDir {
+				_ = agentDir.Close()
+			}
 		})
 	}
 	return cleanup, stopRequest, markLoopStopped, nil

--- a/internal/cli/wake_control_linux.go
+++ b/internal/cli/wake_control_linux.go
@@ -5,3 +5,12 @@ package cli
 func darwinControlSocketBasenameForCleanup(*wakeAgentDir, string) (string, error) {
 	return "", nil
 }
+
+func startWakeControlListenerInDir(
+	*wakeAgentDir,
+	string,
+	string,
+	wakeLock,
+) (func(), <-chan struct{}, func(), error) {
+	return func() {}, nil, func() {}, nil
+}

--- a/internal/cli/wake_control_other.go
+++ b/internal/cli/wake_control_other.go
@@ -6,6 +6,3 @@ func wakeControlSocketPath(string, string, string) string { return "" }
 func startWakeControlListener(string, string, wakeLock) (func(), <-chan struct{}, func(), error) {
 	return func() {}, nil, func() {}, nil
 }
-func startWakeControlListenerInDir(*wakeAgentDir, string, string, wakeLock) (func(), <-chan struct{}, func(), error) {
-	return func() {}, nil, func() {}, nil
-}

--- a/internal/cli/wake_control_other.go
+++ b/internal/cli/wake_control_other.go
@@ -6,3 +6,6 @@ func wakeControlSocketPath(string, string, string) string { return "" }
 func startWakeControlListener(string, string, wakeLock) (func(), <-chan struct{}, func(), error) {
 	return func() {}, nil, func() {}, nil
 }
+func startWakeControlListenerInDir(*wakeAgentDir, string, string, wakeLock) (func(), <-chan struct{}, func(), error) {
+	return func() {}, nil, func() {}, nil
+}

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -15,22 +15,24 @@ import (
 
 // wakeLock represents the lock file content for wake process deduplication.
 type wakeLock struct {
-	PID           int        `json:"pid"`
-	TTY           string     `json:"tty"`
-	Root          string     `json:"root"`                     // Absolute path to disambiguate relative AM_ROOT
-	Agent         string     `json:"agent,omitempty"`          // Agent handle that owns this lock
-	Hostname      string     `json:"hostname,omitempty"`       // Host that created the lock
-	Started       string     `json:"started"`                  // Wall-clock diagnostic timestamp
-	ProcessStart  string     `json:"process_start,omitempty"`  // Kernel process start token, guards PID reuse
-	BootID        string     `json:"boot_id,omitempty"`        // Boot identity paired with ProcessStart when available
-	Executable    string     `json:"executable,omitempty"`     // Diagnostic process executable basename/path
-	Args          []string   `json:"args,omitempty"`           // Diagnostic argv when available
-	WakeMode      string     `json:"wake_mode,omitempty"`      // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
-	TargetDigest  string     `json:"target_digest,omitempty"`  // Binds .wake.target to this lock instance
-	Generation    string     `json:"generation,omitempty"`     // Random nonce binding readiness and exact cleanup to this instance
-	ControlSocket string     `json:"control_socket,omitempty"` // Darwin cooperative shutdown endpoint
-	OwnerSchema   int        `json:"owner_schema,omitempty"`   // Non-zero only for an authoritative owner-bound lock
-	Owner         *wakeOwner `json:"owner,omitempty"`          // Exact owner identity for an authoritative owner-bound lock
+	PID               int        `json:"pid"`
+	TTY               string     `json:"tty"`
+	Root              string     `json:"root"`                          // Absolute path to disambiguate relative AM_ROOT
+	Agent             string     `json:"agent,omitempty"`               // Agent handle that owns this lock
+	Hostname          string     `json:"hostname,omitempty"`            // Host that created the lock
+	Started           string     `json:"started"`                       // Wall-clock diagnostic timestamp
+	ProcessStart      string     `json:"process_start,omitempty"`       // Kernel process start token, guards PID reuse
+	BootID            string     `json:"boot_id,omitempty"`             // Boot identity paired with ProcessStart when available
+	Executable        string     `json:"executable,omitempty"`          // Diagnostic process executable basename/path
+	Args              []string   `json:"args,omitempty"`                // Diagnostic argv when available
+	WakeMode          string     `json:"wake_mode,omitempty"`           // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
+	TargetDigest      string     `json:"target_digest,omitempty"`       // Binds .wake.target to this lock instance
+	Generation        string     `json:"generation,omitempty"`          // Random nonce binding readiness and exact cleanup to this instance
+	SourceGeneration  string     `json:"source_generation,omitempty"`   // Dead generation inherited by a repaired wake
+	SourceFloorDigest string     `json:"source_floor_digest,omitempty"` // Exact repair floor inherited by a repaired wake
+	ControlSocket     string     `json:"control_socket,omitempty"`      // Darwin cooperative shutdown endpoint
+	OwnerSchema       int        `json:"owner_schema,omitempty"`        // Non-zero only for an authoritative owner-bound lock
+	Owner             *wakeOwner `json:"owner,omitempty"`               // Exact owner identity for an authoritative owner-bound lock
 }
 
 const (

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -3,10 +3,13 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/sys/unix"
 )
@@ -65,6 +68,118 @@ func readWakeLockMetadataAt(dirfd int, agentDir *wakeAgentDir, root, me string) 
 	return readWakeLockMetadataWithReader(root, me, path, func() ([]byte, os.FileInfo, error) {
 		return readWakeLockFileAt(dirfd, path)
 	})
+}
+
+func createWakeLockAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	lock wakeLock,
+) error {
+	if strings.TrimSpace(lock.Generation) == "" {
+		return fmt.Errorf("wake lock generation is missing")
+	}
+	if canonicalWakeRoot(lock.Root) != canonicalWakeRoot(root) {
+		return fmt.Errorf("wake lock root mismatch")
+	}
+	if lock.Agent != me {
+		return fmt.Errorf("wake lock agent mismatch")
+	}
+	data, err := json.Marshal(lock)
+	if err != nil {
+		return fmt.Errorf("marshal wake lock: %w", err)
+	}
+	fd, err := unix.Openat(
+		dirfd,
+		".wake.lock",
+		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create wake lock: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), filepath.Join(agentDir.path, ".wake.lock"))
+	createdInfo, statErr := file.Stat()
+	if statErr != nil {
+		_ = file.Close()
+		return fmt.Errorf("stat created wake lock: %w", statErr)
+	}
+	committed := false
+	defer func() {
+		_ = file.Close()
+		if !committed {
+			currentFD, openErr := unix.Openat(
+				dirfd,
+				".wake.lock",
+				unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+				0,
+			)
+			if openErr == nil {
+				currentFile := os.NewFile(uintptr(currentFD), filepath.Join(agentDir.path, ".wake.lock"))
+				currentInfo, currentErr := currentFile.Stat()
+				_ = currentFile.Close()
+				if currentErr == nil && sameWakeFileIdentity(createdInfo, currentInfo) {
+					_ = unix.Unlinkat(dirfd, ".wake.lock", 0)
+					_ = syncWakeOwnerDirFD(dirfd)
+				}
+			}
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		return fmt.Errorf("chmod created wake lock: %w", err)
+	}
+	n, err := file.Write(data)
+	if err != nil {
+		return fmt.Errorf("failed to write wake lock: %w", err)
+	}
+	if n != len(data) {
+		return fmt.Errorf("failed to write wake lock: %w", io.ErrShortWrite)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync wake lock: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("failed to close wake lock: %w", err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync wake lock directory after commit: %w", err)
+	}
+	created := readWakeLockMetadataAt(dirfd, agentDir, root, me)
+	if !created.Exists ||
+		created.Lock.Generation != lock.Generation ||
+		!bytes.Equal(created.raw, data) {
+		return fmt.Errorf("failed to verify created wake lock generation")
+	}
+	committed = true
+	return nil
+}
+
+func createWakeRepairLockAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	rootIdentity string,
+	lock wakeLock,
+) error {
+	if err := revalidateWakeRepairRootIdentity(root, rootIdentity); err != nil {
+		return err
+	}
+	return createWakeLockAt(dirfd, agentDir, root, me, lock)
+}
+
+func removeWakeLockIfUnchangedGuardedAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	inspection wakeLockInspection,
+) error {
+	path := filepath.Join(agentDir.path, ".wake.lock")
+	return removeWakeLockIfUnchangedGuardedWithIO(
+		inspection,
+		func() ([]byte, os.FileInfo, error) { return readWakeLockFileAt(dirfd, path) },
+		func() error { return unix.Unlinkat(dirfd, ".wake.lock", 0) },
+	)
 }
 
 func readWakeGenerationFileAt(

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -21,17 +21,6 @@ func stubInspectWakeProcess(t *testing.T, fn func(pid int) wakeProcessInfo) {
 
 func secureTempDirForTest(t *testing.T) string {
 	t.Helper()
-	cwd, err := os.Getwd()
-	if err == nil {
-		if resolved, resolveErr := filepath.EvalSymlinks(cwd); resolveErr == nil {
-			cwd = resolved
-		}
-		dir, mkErr := os.MkdirTemp(cwd, ".amq-secure-test-")
-		if mkErr == nil {
-			t.Cleanup(func() { _ = os.RemoveAll(dir) })
-			return dir
-		}
-	}
 	dir := t.TempDir()
 	if resolved, resolveErr := filepath.EvalSymlinks(dir); resolveErr == nil {
 		return resolved

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -21,7 +21,15 @@ func stubInspectWakeProcess(t *testing.T, fn func(pid int) wakeProcessInfo) {
 
 func secureTempDirForTest(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp(cliSecureTempRoot, "amq-test-")
+	if err != nil {
+		t.Fatalf("create secure test temp directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("remove secure test temp directory: %v", err)
+		}
+	})
 	if resolved, resolveErr := filepath.EvalSymlinks(dir); resolveErr == nil {
 		return resolved
 	}

--- a/internal/cli/wake_message_identity_unix.go
+++ b/internal/cli/wake_message_identity_unix.go
@@ -5,8 +5,8 @@ package cli
 // wakeFileIdentity is the stable portion of a mailbox file instance used by
 // local baseline filtering.
 type wakeFileIdentity struct {
-	Device    uint64
-	Inode     uint64
-	CTimeSec  int64
-	CTimeNsec int64
+	Device    uint64 `json:"device"`
+	Inode     uint64 `json:"inode"`
+	CTimeSec  int64  `json:"ctime_sec"`
+	CTimeNsec int64  `json:"ctime_nsec"`
 }

--- a/internal/cli/wake_prepared_unix.go
+++ b/internal/cli/wake_prepared_unix.go
@@ -26,6 +26,17 @@ func writeWakePreparedFile(root, me string, expected wakeLockInspection) error {
 		return err
 	}
 	defer func() { _ = agentDir.Close() }()
+	return writeWakePreparedFileInDir(agentDir, root, me, expected)
+}
+
+func writeWakePreparedFileInDir(
+	agentDir *wakeAgentDir,
+	root, me string,
+	expected wakeLockInspection,
+) error {
+	if agentDir == nil {
+		return fmt.Errorf("wake agent directory capability is missing")
+	}
 	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		current := inspectWakeLockAt(dirfd, agentDir, root, me)
 		if !sameWakeLockGeneration(expected, current) {
@@ -41,10 +52,7 @@ func writeWakePreparedFile(root, me string, expected wakeLockInspection) error {
 		}
 		// The marker intentionally persists after exit; its generation binding
 		// makes stale files unusable by later wake instances.
-		if current.Lock.WakeMode == wakeOwnerWakeMode {
-			return writeWakeGenerationFileAt(dirfd, wakePreparedFileName, "wake prepared marker", marker)
-		}
-		return writeWakeGenerationFile(wakePreparedPath(root, me), "wake prepared marker", marker)
+		return writeWakeGenerationFileAt(dirfd, wakePreparedFileName, "wake prepared marker", marker)
 	})
 }
 

--- a/internal/cli/wake_repair_at_unix.go
+++ b/internal/cli/wake_repair_at_unix.go
@@ -1,0 +1,519 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+type wakeRepairFloorSnapshot struct {
+	Floor    wakeRepairFloor
+	Raw      []byte
+	FileInfo os.FileInfo
+}
+
+type wakeRepairFloorAuthority struct {
+	ChildGeneration   string
+	SourceFloorDigest string
+	RawDigest         string
+	FileIdentity      wakeFileIdentity
+}
+
+const wakeRepairFloorQuarantinePrefix = ".wake.repair-floor.quarantine."
+
+var renameWakeRepairFloorNoReplaceAt = renameWakeRepairNoReplaceAt
+
+func newWakeRepairFloorAuthority(snapshot wakeRepairFloorSnapshot) (wakeRepairFloorAuthority, error) {
+	if snapshot.FileInfo == nil {
+		return wakeRepairFloorAuthority{}, fmt.Errorf("wake repair floor file identity is missing")
+	}
+	identity, ok := captureWakeFileIdentity(snapshot.FileInfo)
+	if !ok {
+		return wakeRepairFloorAuthority{}, fmt.Errorf("capture wake repair floor file identity")
+	}
+	authority := wakeRepairFloorAuthority{
+		ChildGeneration:   snapshot.Floor.Generation,
+		SourceFloorDigest: snapshot.Floor.SourceFloorDigest,
+		RawDigest:         wakeMetadataDigest(snapshot.Raw),
+		FileIdentity:      identity,
+	}
+	if err := authority.validate(); err != nil {
+		return wakeRepairFloorAuthority{}, err
+	}
+	return authority, nil
+}
+
+func (authority wakeRepairFloorAuthority) validate() error {
+	if strings.TrimSpace(authority.ChildGeneration) == "" {
+		return fmt.Errorf("wake repair child generation is missing")
+	}
+	if strings.TrimSpace(authority.SourceFloorDigest) == "" {
+		return fmt.Errorf("wake repair source floor digest is missing")
+	}
+	if err := validateWakeRepairHandoffDigest("floor raw", authority.RawDigest); err != nil {
+		return err
+	}
+	if authority.FileIdentity.Device == 0 || authority.FileIdentity.Inode == 0 {
+		return fmt.Errorf("wake repair floor file identity is invalid")
+	}
+	return nil
+}
+
+func sameWakeRepairFloorAuthorityAfterRename(
+	expected wakeRepairFloorAuthority,
+	actual wakeRepairFloorAuthority,
+) bool {
+	// rename(2) may update ctime on the same file. Device+inode prove that the
+	// quarantined file is the captured file instance; the raw digest proves its
+	// bytes did not change while it moved.
+	return actual.ChildGeneration == expected.ChildGeneration &&
+		actual.SourceFloorDigest == expected.SourceFloorDigest &&
+		actual.RawDigest == expected.RawDigest &&
+		actual.FileIdentity.Device == expected.FileIdentity.Device &&
+		actual.FileIdentity.Inode == expected.FileIdentity.Inode
+}
+
+func revalidateWakeRepairRootIdentity(root, expected string) error {
+	if strings.TrimSpace(expected) == "" {
+		return fmt.Errorf("wake repair root identity is missing")
+	}
+	switch verifyTreeIdentityToken(root, expected) {
+	case TreeRelationSame:
+		return nil
+	case TreeRelationDifferent:
+		return fmt.Errorf("wake repair root identity changed")
+	default:
+		return fmt.Errorf("wake repair root identity is unverified")
+	}
+}
+
+func readWakeRepairFloorAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+) (wakeRepairFloor, bool, error) {
+	snapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+	return snapshot.Floor, exists, err
+}
+
+func readWakeRepairFloorSnapshotAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+) (wakeRepairFloorSnapshot, bool, error) {
+	return readWakeRepairFloorSnapshotNamedAt(
+		dirfd,
+		agentDir,
+		wakeRepairFloorFileName,
+	)
+}
+
+func readWakeRepairFloorSnapshotNamedAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	name string,
+) (wakeRepairFloorSnapshot, bool, error) {
+	path := filepath.Join(agentDir.path, name)
+	data, info, exists, err := readWakeRepairMetadataAt(
+		dirfd,
+		name,
+		"wake repair floor",
+		path,
+		maxWakeRepairFloorFileBytes,
+	)
+	if err != nil || !exists {
+		return wakeRepairFloorSnapshot{}, exists, err
+	}
+	var floor wakeRepairFloor
+	if err := json.Unmarshal(data, &floor); err != nil {
+		return wakeRepairFloorSnapshot{}, true, fmt.Errorf("parse wake repair floor: %w", err)
+	}
+	return wakeRepairFloorSnapshot{
+		Floor:    floor,
+		Raw:      data,
+		FileInfo: info,
+	}, true, nil
+}
+
+func writeWakeRepairFloorAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	floor wakeRepairFloor,
+) error {
+	if err := revalidateWakeRepairRootIdentity(root, floor.RootIdentity); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(floor, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal wake repair floor: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > maxWakeRepairFloorFileBytes {
+		return fmt.Errorf("wake repair floor has too many existing messages (%d-byte limit)", maxWakeRepairFloorFileBytes)
+	}
+	return writeWakeRepairMetadataAt(
+		dirfd,
+		agentDir,
+		wakeRepairFloorFileName,
+		"wake repair floor",
+		data,
+		maxWakeRepairFloorFileBytes,
+	)
+}
+
+func writeWakeRepairFloorAndCaptureAuthorityAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	floor wakeRepairFloor,
+) (wakeRepairFloorAuthority, error) {
+	if err := writeWakeRepairFloorAt(dirfd, agentDir, root, floor); err != nil {
+		return wakeRepairFloorAuthority{}, err
+	}
+	snapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+	if err != nil {
+		return wakeRepairFloorAuthority{}, err
+	}
+	if !exists {
+		return wakeRepairFloorAuthority{}, fmt.Errorf("published wake repair floor disappeared")
+	}
+	return newWakeRepairFloorAuthority(snapshot)
+}
+
+func removeWakeRepairFloorGuardedAt(dirfd int, agentDir *wakeAgentDir) error {
+	if err := unix.Unlinkat(dirfd, wakeRepairFloorFileName, 0); err != nil {
+		if err == unix.ENOENT {
+			return nil
+		}
+		return fmt.Errorf("remove wake repair floor: %w", err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync wake repair floor removal: %w", err)
+	}
+	_ = agentDir
+	return nil
+}
+
+func removeWakeRepairFloorIfGenerationGuardedAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeRepairFloorAuthority,
+) error {
+	if err := expected.validate(); err != nil {
+		return err
+	}
+	current, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	currentAuthority, err := newWakeRepairFloorAuthority(current)
+	if err != nil {
+		return err
+	}
+	if currentAuthority != expected {
+		return nil
+	}
+
+	quarantine, moved, err := quarantineWakeRepairFloorAt(dirfd)
+	if err != nil {
+		return err
+	}
+	if !moved {
+		return nil
+	}
+	quarantined, exists, inspectErr := readWakeRepairFloorSnapshotNamedAt(
+		dirfd,
+		agentDir,
+		quarantine,
+	)
+	if inspectErr != nil {
+		if restoreErr := restoreWakeRepairFloorQuarantineAt(dirfd, quarantine); restoreErr != nil {
+			return errors.Join(
+				fmt.Errorf("inspect quarantined wake repair floor: %w", inspectErr),
+				restoreErr,
+			)
+		}
+		return fmt.Errorf("inspect quarantined wake repair floor: %w", inspectErr)
+	}
+	if !exists {
+		missingErr := fmt.Errorf("quarantined wake repair floor disappeared before verification")
+		if restoreErr := restoreWakeRepairFloorQuarantineAt(dirfd, quarantine); restoreErr != nil {
+			return errors.Join(missingErr, restoreErr)
+		}
+		return missingErr
+	}
+	quarantinedAuthority, authorityErr := newWakeRepairFloorAuthority(quarantined)
+	if authorityErr != nil ||
+		!sameWakeRepairFloorAuthorityAfterRename(expected, quarantinedAuthority) {
+		restoreErr := restoreWakeRepairFloorQuarantineAt(dirfd, quarantine)
+		if authorityErr != nil {
+			return errors.Join(
+				fmt.Errorf("verify quarantined wake repair floor: %w", authorityErr),
+				restoreErr,
+			)
+		}
+		return errors.Join(
+			fmt.Errorf("wake repair floor changed before cleanup; preserving it"),
+			restoreErr,
+		)
+	}
+	if err := unix.Unlinkat(dirfd, quarantine, 0); err != nil {
+		if err == unix.ENOENT {
+			return nil
+		}
+		return fmt.Errorf("remove quarantined wake repair floor: %w", err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync wake repair floor removal: %w", err)
+	}
+	return nil
+}
+
+func quarantineWakeRepairFloorAt(dirfd int) (string, bool, error) {
+	for attempt := 0; attempt < 16; attempt++ {
+		var nonce [12]byte
+		if _, err := rand.Read(nonce[:]); err != nil {
+			return "", false, fmt.Errorf("generate wake repair floor quarantine name: %w", err)
+		}
+		name := fmt.Sprintf(
+			"%s%d.%s",
+			wakeRepairFloorQuarantinePrefix,
+			os.Getpid(),
+			hex.EncodeToString(nonce[:]),
+		)
+		err := renameWakeRepairFloorNoReplaceAt(
+			dirfd,
+			wakeRepairFloorFileName,
+			dirfd,
+			name,
+		)
+		switch {
+		case err == nil:
+			if err := syncWakeOwnerDirFD(dirfd); err != nil {
+				restoreErr := restoreWakeRepairFloorQuarantineAt(dirfd, name)
+				return "", false, errors.Join(
+					fmt.Errorf("sync wake repair floor quarantine: %w", err),
+					restoreErr,
+				)
+			}
+			return name, true, nil
+		case errors.Is(err, unix.ENOENT):
+			return "", false, nil
+		case errors.Is(err, unix.EEXIST):
+			continue
+		default:
+			return "", false, fmt.Errorf("quarantine wake repair floor: %w", err)
+		}
+	}
+	return "", false, fmt.Errorf("quarantine wake repair floor: too many name collisions")
+}
+
+func restoreWakeRepairFloorQuarantineAt(dirfd int, quarantine string) error {
+	err := renameWakeRepairFloorNoReplaceAt(
+		dirfd,
+		quarantine,
+		dirfd,
+		wakeRepairFloorFileName,
+	)
+	if err != nil {
+		if errors.Is(err, unix.EEXIST) {
+			return fmt.Errorf(
+				"wake repair floor changed during cleanup; preserved mismatch as %s",
+				quarantine,
+			)
+		}
+		return fmt.Errorf(
+			"restore mismatched wake repair floor from %s: %w",
+			quarantine,
+			err,
+		)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync restored wake repair floor: %w", err)
+	}
+	return nil
+}
+
+func writeWakeTargetGuardedAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	target wakeTarget,
+) error {
+	if err := validateWakeTarget(target, root, me); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(target, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal wake target: %w", err)
+	}
+	return writeWakeRepairMetadataAt(
+		dirfd,
+		agentDir,
+		wakeTargetFileName,
+		"wake target",
+		append(data, '\n'),
+		maxWakeMetadataFileBytes,
+	)
+}
+
+func removeWakeTargetGuardedAt(dirfd int, agentDir *wakeAgentDir) error {
+	if err := unix.Unlinkat(dirfd, wakeTargetFileName, 0); err != nil {
+		if err == unix.ENOENT {
+			return nil
+		}
+		return fmt.Errorf("remove wake target: %w", err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync wake target removal: %w", err)
+	}
+	_ = agentDir
+	return nil
+}
+
+func writeWakeRepairMetadataAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	name string,
+	label string,
+	data []byte,
+	maxBytes int,
+) error {
+	if err := validateWakeRepairMetadataDestinationAt(dirfd, agentDir, name, label); err != nil {
+		return err
+	}
+	temp, err := writeWakeOwnerTempAt(dirfd, strings.TrimLeft(name, "."), data, 0o600)
+	if err != nil {
+		return err
+	}
+	tempPresent := true
+	defer func() {
+		if tempPresent {
+			_ = unix.Unlinkat(dirfd, temp, 0)
+		}
+	}()
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync %s directory before install: %w", label, err)
+	}
+	if err := validateWakeRepairMetadataDestinationAt(dirfd, agentDir, name, label); err != nil {
+		return err
+	}
+	if err := unix.Renameat(dirfd, temp, dirfd, name); err != nil {
+		return fmt.Errorf("install %s: %w", label, err)
+	}
+	tempPresent = false
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync %s directory after install: %w", label, err)
+	}
+	installed, _, exists, err := readWakeRepairMetadataAt(dirfd, name, label, filepath.Join(agentDir.path, name), maxBytes)
+	if err != nil {
+		return fmt.Errorf("verify installed %s: %w", label, err)
+	}
+	if !exists || !bytes.Equal(installed, data) {
+		return fmt.Errorf("installed %s changed before verification", label)
+	}
+	return nil
+}
+
+func validateWakeRepairMetadataDestinationAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	name string,
+	label string,
+) error {
+	path := filepath.Join(agentDir.path, name)
+	fd, err := unix.Openat(dirfd, name, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if err == unix.ENOENT {
+			return nil
+		}
+		if err == unix.ELOOP {
+			return fmt.Errorf("%s %s must not be a symlink", label, path)
+		}
+		return fmt.Errorf("open %s destination: %w", label, err)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat %s destination: %w", label, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s %s must be a regular file", label, path)
+	}
+	return nil
+}
+
+func readWakeRepairMetadataAt(
+	dirfd int,
+	name string,
+	label string,
+	path string,
+	maxBytes int,
+) ([]byte, os.FileInfo, bool, error) {
+	open := func() (*os.File, error) {
+		fd, err := unix.Openat(dirfd, name, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(uintptr(fd), path), nil
+	}
+	file, err := open()
+	if err != nil {
+		if err == unix.ENOENT {
+			return nil, nil, false, nil
+		}
+		if err == unix.ELOOP {
+			return nil, nil, true, fmt.Errorf("%s %s must not be a symlink", label, path)
+		}
+		return nil, nil, true, fmt.Errorf("open %s: %w", label, err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, true, fmt.Errorf("stat %s: %w", label, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, true, fmt.Errorf("%s %s must be a regular file", label, path)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return nil, nil, true, fmt.Errorf("%s %s mode is %o, want 0600", label, path, got)
+	}
+	if err := validateWakeTargetPathOwnership(label, path, info); err != nil {
+		return nil, nil, true, err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, int64(maxBytes)+1))
+	if err != nil {
+		return nil, nil, true, fmt.Errorf("read %s: %w", label, err)
+	}
+	if len(data) > maxBytes {
+		return nil, nil, true, fmt.Errorf("%s %s is too large", label, path)
+	}
+	pathFile, err := open()
+	if err != nil {
+		return nil, nil, true, fmt.Errorf("re-open %s: %w", label, err)
+	}
+	pathInfo, statErr := pathFile.Stat()
+	_ = pathFile.Close()
+	if statErr != nil {
+		return nil, nil, true, fmt.Errorf("re-stat %s: %w", label, statErr)
+	}
+	if !sameWakeFileIdentity(info, pathInfo) {
+		return nil, nil, true, fmt.Errorf("%s changed while opening", label)
+	}
+	return data, info, true, nil
+}

--- a/internal/cli/wake_repair_at_unix_test.go
+++ b/internal/cli/wake_repair_at_unix_test.go
@@ -1,0 +1,497 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+func replaceWakeRepairFloorWithNewInodeForTest(
+	t *testing.T,
+	root, me string,
+	mutate bool,
+) []byte {
+	t.Helper()
+	path := wakeRepairFloorPath(root, me)
+	original, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open original wake repair floor: %v", err)
+	}
+	defer func() { _ = original.Close() }()
+	originalInfo, err := original.Stat()
+	if err != nil {
+		t.Fatalf("stat original wake repair floor: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read original wake repair floor: %v", err)
+	}
+	replacement := append([]byte(nil), raw...)
+	if mutate {
+		var floor wakeRepairFloor
+		if err := json.Unmarshal(raw, &floor); err != nil {
+			t.Fatalf("decode original wake repair floor: %v", err)
+		}
+		if floor.Existing == nil {
+			floor.Existing = make(map[string]wakeFileIdentity)
+		}
+		floor.Existing["replacement.md"] = wakeFileIdentity{
+			Device:    91,
+			Inode:     92,
+			CTimeSec:  93,
+			CTimeNsec: 94,
+		}
+		replacement, err = json.MarshalIndent(floor, "", "  ")
+		if err != nil {
+			t.Fatalf("encode replacement wake repair floor: %v", err)
+		}
+		replacement = append(replacement, '\n')
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("unlink original wake repair floor: %v", err)
+	}
+	if err := os.WriteFile(path, replacement, 0o600); err != nil {
+		t.Fatalf("write replacement wake repair floor: %v", err)
+	}
+	replacementInfo, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("stat replacement wake repair floor: %v", err)
+	}
+	if sameWakeFileIdentity(originalInfo, replacementInfo) {
+		t.Fatal("replacement wake repair floor reused the original file identity")
+	}
+	if !mutate && !bytes.Equal(raw, replacement) {
+		t.Fatal("byte-identical replacement changed floor bytes")
+	}
+	return replacement
+}
+
+func TestWakeRepairMetadataAtUsesRetainedAgentDirectory(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatalf("openWakeAgentDir: %v", err)
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	injector := writeExecutableForTest(t, "repair-at-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-a"})
+	targetDigest := mustWakeTargetDigest(target)
+	floor := wakeRepairFloor{
+		Schema:            wakeRepairFloorSchema,
+		Root:              canonicalWakeRoot(root),
+		RootIdentity:      mustTreeIdentityTokenForTest(t, root),
+		Agent:             "codex",
+		Generation:        "child-generation",
+		SourceGeneration:  "source-generation",
+		SourceFloorDigest: "sha256:source-floor",
+		TargetDigest:      targetDigest,
+		BootID:            wakeRepairTestBootID,
+		Existing:          map[string]wakeFileIdentity{},
+	}
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:               os.Getpid(),
+		Root:              canonicalWakeRoot(root),
+		Agent:             "codex",
+		Generation:        floor.Generation,
+		SourceGeneration:  floor.SourceGeneration,
+		SourceFloorDigest: floor.SourceFloorDigest,
+		BootID:            wakeRepairTestBootID,
+	}, target)
+
+	originalAgentPath := fsq.AgentBase(root, "codex")
+	detachedAgentPath := filepath.Join(filepath.Dir(originalAgentPath), "codex-detached")
+	if err := os.Rename(originalAgentPath, detachedAgentPath); err != nil {
+		t.Fatalf("detach agent directory: %v", err)
+	}
+	if err := os.Mkdir(originalAgentPath, 0o700); err != nil {
+		t.Fatalf("create replacement agent directory: %v", err)
+	}
+
+	err = agentDir.withFD(func(dirfd int) error {
+		if err := writeWakeTargetGuardedAt(dirfd, agentDir, root, "codex", target); err != nil {
+			return err
+		}
+		if err := writeWakeRepairFloorAt(dirfd, agentDir, root, floor); err != nil {
+			return err
+		}
+		return createWakeRepairLockAt(
+			dirfd,
+			agentDir,
+			root,
+			"codex",
+			floor.RootIdentity,
+			lock,
+		)
+	})
+	if err != nil {
+		t.Fatalf("write retained repair metadata: %v", err)
+	}
+
+	for _, name := range []string{wakeTargetFileName, wakeRepairFloorFileName, ".wake.lock"} {
+		if _, err := os.Stat(filepath.Join(originalAgentPath, name)); !os.IsNotExist(err) {
+			t.Fatalf("replacement path unexpectedly received %s: %v", name, err)
+		}
+		if _, err := os.Stat(filepath.Join(detachedAgentPath, name)); err != nil {
+			t.Fatalf("retained directory missing %s: %v", name, err)
+		}
+	}
+
+	err = agentDir.withFD(func(dirfd int) error {
+		persistedTarget, exists, err := readWakeTargetAt(dirfd, agentDir, root, "codex")
+		if err != nil || !exists || !sameWakeTarget(persistedTarget, target) {
+			t.Fatalf("retained target = (%#v,%v,%v), want exact target", persistedTarget, exists, err)
+		}
+		persistedFloor, exists, err := readWakeRepairFloorAt(dirfd, agentDir)
+		if err != nil || !exists || persistedFloor.Generation != floor.Generation {
+			t.Fatalf("retained floor = (%#v,%v,%v), want child floor", persistedFloor, exists, err)
+		}
+		inspection := inspectWakeLockAt(dirfd, agentDir, root, "codex")
+		if !inspection.Exists || inspection.Lock.Generation != lock.Generation {
+			t.Fatalf("retained lock = %#v, want child lock", inspection)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("read retained repair metadata: %v", err)
+	}
+}
+
+func TestRemoveWakeRepairFloorAtRequiresChildGenerationAndSourceDigest(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatalf("openWakeAgentDir: %v", err)
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	floor := wakeRepairFloor{
+		Schema:            wakeRepairFloorSchema,
+		Root:              canonicalWakeRoot(root),
+		RootIdentity:      mustTreeIdentityTokenForTest(t, root),
+		Agent:             "codex",
+		Generation:        "child-generation",
+		SourceGeneration:  "source-generation",
+		SourceFloorDigest: "sha256:source-floor",
+		TargetDigest:      "sha256:target",
+		BootID:            wakeRepairTestBootID,
+		Existing:          map[string]wakeFileIdentity{},
+	}
+
+	err = agentDir.withFD(func(dirfd int) error {
+		if err := writeWakeRepairFloorAt(dirfd, agentDir, root, floor); err != nil {
+			return err
+		}
+		snapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+		if err != nil || !exists {
+			t.Fatalf("read exact floor authority: exists=%v err=%v", exists, err)
+		}
+		exactAuthority, err := newWakeRepairFloorAuthority(snapshot)
+		if err != nil {
+			t.Fatalf("capture exact floor authority: %v", err)
+		}
+		wrongGeneration := exactAuthority
+		wrongGeneration.ChildGeneration = "replacement-generation"
+		if err := removeWakeRepairFloorIfGenerationGuardedAt(
+			dirfd,
+			agentDir,
+			wrongGeneration,
+		); err != nil {
+			return err
+		}
+		if _, exists, err := readWakeRepairFloorAt(dirfd, agentDir); err != nil || !exists {
+			t.Fatalf("wrong child generation removed floor: exists=%v err=%v", exists, err)
+		}
+		wrongSource := exactAuthority
+		wrongSource.SourceFloorDigest = "sha256:replacement-source-floor"
+		if err := removeWakeRepairFloorIfGenerationGuardedAt(dirfd, agentDir, wrongSource); err != nil {
+			return err
+		}
+		if _, exists, err := readWakeRepairFloorAt(dirfd, agentDir); err != nil || !exists {
+			t.Fatalf("wrong source digest removed floor: exists=%v err=%v", exists, err)
+		}
+		if err := removeWakeRepairFloorIfGenerationGuardedAt(
+			dirfd,
+			agentDir,
+			exactAuthority,
+		); err != nil {
+			return err
+		}
+		if _, exists, err := readWakeRepairFloorAt(dirfd, agentDir); err != nil || exists {
+			t.Fatalf("exact lineage floor survived: exists=%v err=%v", exists, err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("generation-safe floor removal: %v", err)
+	}
+}
+
+func TestRemoveWakeRepairFloorQuarantineRestoresInjectedReplacement(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate bool
+	}{
+		{name: "byte-identical new inode"},
+		{name: "same generation and source digest changed bytes", mutate: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testRemoveWakeRepairFloorQuarantineRestoresInjectedReplacement(t, tc.mutate)
+		})
+	}
+}
+
+func testRemoveWakeRepairFloorQuarantineRestoresInjectedReplacement(
+	t *testing.T,
+	mutate bool,
+) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatalf("openWakeAgentDir: %v", err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	floor := wakeRepairFloor{
+		Schema:            wakeRepairFloorSchema,
+		Root:              canonicalWakeRoot(root),
+		RootIdentity:      mustTreeIdentityTokenForTest(t, root),
+		Agent:             "codex",
+		Generation:        "child-generation",
+		SourceGeneration:  "source-generation",
+		SourceFloorDigest: "sha256:source-floor",
+		TargetDigest:      "sha256:target",
+		BootID:            wakeRepairTestBootID,
+		Existing:          map[string]wakeFileIdentity{},
+	}
+
+	var replacement []byte
+	err = agentDir.withFD(func(dirfd int) error {
+		if err := writeWakeRepairFloorAt(dirfd, agentDir, root, floor); err != nil {
+			return err
+		}
+		snapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+		if err != nil || !exists {
+			t.Fatalf("read original floor authority: exists=%v err=%v", exists, err)
+		}
+		authority, err := newWakeRepairFloorAuthority(snapshot)
+		if err != nil {
+			t.Fatalf("capture original floor authority: %v", err)
+		}
+		originalRename := renameWakeRepairFloorNoReplaceAt
+		injected := false
+		renameWakeRepairFloorNoReplaceAt = func(fromDirFD int, from string, toDirFD int, to string) error {
+			if !injected && from == wakeRepairFloorFileName {
+				injected = true
+				replacement = replaceWakeRepairFloorWithNewInodeForTest(t, root, "codex", mutate)
+			}
+			return renameWakeRepairNoReplaceAt(fromDirFD, from, toDirFD, to)
+		}
+		defer func() { renameWakeRepairFloorNoReplaceAt = originalRename }()
+
+		err = removeWakeRepairFloorIfGenerationGuardedAt(dirfd, agentDir, authority)
+		if err == nil || !strings.Contains(err.Error(), "changed before cleanup") {
+			t.Fatalf("injected replacement removal error = %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("quarantine replacement race: %v", err)
+	}
+	got, err := os.ReadFile(wakeRepairFloorPath(root, "codex"))
+	if err != nil {
+		t.Fatalf("restored replacement floor is missing: %v", err)
+	}
+	if !bytes.Equal(got, replacement) {
+		t.Fatal("restored replacement floor bytes changed")
+	}
+	entries, err := os.ReadDir(fsq.AgentBase(root, "codex"))
+	if err != nil {
+		t.Fatalf("read wake agent directory: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), wakeRepairFloorQuarantinePrefix) {
+			t.Fatalf("restored replacement left quarantine %s", entry.Name())
+		}
+	}
+}
+
+func TestRemoveWakeRepairFloorQuarantineNeverOverwritesNewerCanonicalFloor(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatalf("openWakeAgentDir: %v", err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	floor := wakeRepairFloor{
+		Schema:            wakeRepairFloorSchema,
+		Root:              canonicalWakeRoot(root),
+		RootIdentity:      mustTreeIdentityTokenForTest(t, root),
+		Agent:             "codex",
+		Generation:        "child-generation",
+		SourceGeneration:  "source-generation",
+		SourceFloorDigest: "sha256:source-floor",
+		TargetDigest:      "sha256:target",
+		BootID:            wakeRepairTestBootID,
+		Existing:          map[string]wakeFileIdentity{},
+	}
+	newer := floor
+	newer.Existing = map[string]wakeFileIdentity{
+		"newer.md": {Device: 101, Inode: 102, CTimeSec: 103, CTimeNsec: 104},
+	}
+
+	var replacement []byte
+	var quarantine string
+	err = agentDir.withFD(func(dirfd int) error {
+		if err := writeWakeRepairFloorAt(dirfd, agentDir, root, floor); err != nil {
+			return err
+		}
+		snapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+		if err != nil || !exists {
+			t.Fatalf("read original floor authority: exists=%v err=%v", exists, err)
+		}
+		authority, err := newWakeRepairFloorAuthority(snapshot)
+		if err != nil {
+			t.Fatalf("capture original floor authority: %v", err)
+		}
+		originalRename := renameWakeRepairFloorNoReplaceAt
+		renameCount := 0
+		renameWakeRepairFloorNoReplaceAt = func(fromDirFD int, from string, toDirFD int, to string) error {
+			renameCount++
+			switch renameCount {
+			case 1:
+				replacement = replaceWakeRepairFloorWithNewInodeForTest(t, root, "codex", true)
+				quarantine = to
+			case 2:
+				if from != quarantine || to != wakeRepairFloorFileName {
+					t.Fatalf("restore rename = %q -> %q, want %q -> %q", from, to, quarantine, wakeRepairFloorFileName)
+				}
+				if err := writeWakeRepairFloorAt(dirfd, agentDir, root, newer); err != nil {
+					t.Fatalf("install newer canonical floor: %v", err)
+				}
+			}
+			return renameWakeRepairNoReplaceAt(fromDirFD, from, toDirFD, to)
+		}
+		defer func() { renameWakeRepairFloorNoReplaceAt = originalRename }()
+
+		err = removeWakeRepairFloorIfGenerationGuardedAt(dirfd, agentDir, authority)
+		if err == nil || !strings.Contains(err.Error(), "preserved mismatch as") {
+			t.Fatalf("occupied restore error = %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("quarantine occupied restore race: %v", err)
+	}
+	gotNewer, err := os.ReadFile(wakeRepairFloorPath(root, "codex"))
+	if err != nil {
+		t.Fatalf("newer canonical floor is missing: %v", err)
+	}
+	wantNewer, err := json.MarshalIndent(newer, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal newer canonical floor: %v", err)
+	}
+	wantNewer = append(wantNewer, '\n')
+	if !bytes.Equal(gotNewer, wantNewer) {
+		t.Fatal("mismatched quarantine overwrote newer canonical floor")
+	}
+	gotQuarantine, err := os.ReadFile(filepath.Join(fsq.AgentBase(root, "codex"), quarantine))
+	if err != nil {
+		t.Fatalf("mismatched quarantine was deleted: %v", err)
+	}
+	if !bytes.Equal(gotQuarantine, replacement) {
+		t.Fatal("preserved mismatch quarantine bytes changed")
+	}
+}
+
+func TestRenameWakeRepairNoReplaceAtNeverOverwritesDestination(t *testing.T) {
+	dir := secureTempDirForTest(t)
+	fromPath := filepath.Join(dir, "from")
+	toPath := filepath.Join(dir, "to")
+	if err := os.WriteFile(fromPath, []byte("from"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(toPath, []byte("to"), 0o600); err != nil {
+		t.Fatalf("write destination: %v", err)
+	}
+	file, err := os.Open(dir)
+	if err != nil {
+		t.Fatalf("open rename directory: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	dirfd := int(file.Fd())
+
+	err = renameWakeRepairNoReplaceAt(dirfd, "from", dirfd, "to")
+	if !errors.Is(err, unix.EEXIST) {
+		t.Fatalf("occupied no-replace rename error = %v, want EEXIST", err)
+	}
+	for path, want := range map[string]string{fromPath: "from", toPath: "to"} {
+		got, err := os.ReadFile(path)
+		if err != nil || string(got) != want {
+			t.Fatalf("no-replace result %s = %q, %v; want %q", path, got, err, want)
+		}
+	}
+	if err := os.Remove(toPath); err != nil {
+		t.Fatalf("remove destination: %v", err)
+	}
+	if err := renameWakeRepairNoReplaceAt(dirfd, "from", dirfd, "to"); err != nil {
+		t.Fatalf("unoccupied no-replace rename: %v", err)
+	}
+	if _, err := os.Lstat(fromPath); !os.IsNotExist(err) {
+		t.Fatalf("source survived successful rename: %v", err)
+	}
+	if got, err := os.ReadFile(toPath); err != nil || string(got) != "from" {
+		t.Fatalf("renamed destination = %q, %v; want source bytes", got, err)
+	}
+}
+
+func TestRevalidateWakeRepairRootIdentityRejectsPathReplacement(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	identity := mustTreeIdentityTokenForTest(t, root)
+	if err := revalidateWakeRepairRootIdentity(root, identity); err != nil {
+		t.Fatalf("revalidate unchanged root: %v", err)
+	}
+	if err := os.Rename(root, filepath.Join(parent, "root-detached")); err != nil {
+		t.Fatalf("detach root: %v", err)
+	}
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatalf("create replacement root: %v", err)
+	}
+	err := revalidateWakeRepairRootIdentity(root, identity)
+	if err == nil || !strings.Contains(err.Error(), "root identity changed") {
+		t.Fatalf("replacement root error = %v, want identity-change refusal", err)
+	}
+}
+
+func mustTreeIdentityTokenForTest(t *testing.T, path string) string {
+	t.Helper()
+	token, err := resolveTreeIdentityToken(path)
+	if err != nil {
+		t.Fatalf("resolveTreeIdentityToken(%s): %v", path, err)
+	}
+	return token
+}

--- a/internal/cli/wake_repair_child_lifecycle_unix_test.go
+++ b/internal/cli/wake_repair_child_lifecycle_unix_test.go
@@ -574,7 +574,7 @@ func newWakeRepairLifecycleFixture(t *testing.T) wakeRepairLifecycleFixture {
 
 func wakeRepairLifecycleTempDir(t *testing.T) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("", "amq-wr-")
+	dir, err := os.MkdirTemp(cliSecureTempRoot, "amq-wr-")
 	if err != nil {
 		t.Fatalf("create short wake repair lifecycle temp directory: %v", err)
 	}

--- a/internal/cli/wake_repair_child_lifecycle_unix_test.go
+++ b/internal/cli/wake_repair_child_lifecycle_unix_test.go
@@ -1,0 +1,799 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const wakeRepairLifecycleDeadPID = 424242
+
+type wakeRepairLifecycleFixture struct {
+	root       string
+	target     wakeTarget
+	lineage    wakeRepairLineage
+	lockPath   string
+	outputPath string
+	agentDir   *wakeAgentDir
+	inboxDir   *wakeInboxDir
+}
+
+func TestWakeRepairPreparedChildCannotNotifyBeforeAdmission(t *testing.T) {
+	fixture := newWakeRepairLifecycleFixture(t)
+	if err := os.Remove(fixture.lockPath); err != nil {
+		t.Fatalf("remove dead source lock: %v", err)
+	}
+
+	child, err := startWakeFromTargetDefault(
+		fixture.agentDir,
+		fixture.inboxDir,
+		fixture.root,
+		"codex",
+		fixture.target,
+		fixture.lineage,
+	)
+	cleanupRepairLifecycleChild(t, child)
+	if err != nil {
+		t.Fatalf(
+			"start prepared repair child: %v\n%s",
+			err,
+			wakeRepairLifecycleDiagnostics(fixture, child),
+		)
+	}
+
+	if !processAlive(child.Process.Pid) {
+		t.Fatal("prepared repair child exited before parent admission decision")
+	}
+	time.Sleep(250 * time.Millisecond)
+	if output, readErr := os.ReadFile(fixture.outputPath); readErr == nil {
+		t.Fatalf("prepared but unadmitted child injected notification: %q", output)
+	} else if !os.IsNotExist(readErr) {
+		t.Fatalf("read pre-admission injection output: %v", readErr)
+	}
+
+	agentDir, err := openWakeAgentDir(fixture.root, "codex")
+	if err != nil {
+		t.Fatalf("open retained repair directory: %v", err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	if err := cleanupFailedWakeRepairChild(agentDir, fixture.root, "codex", child); err != nil {
+		t.Fatalf("cleanup prepared but unadmitted child: %v", err)
+	}
+	assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+}
+
+func TestWakeRepairChildUsesExactPersistedTargetAcrossCreationSecond(t *testing.T) {
+	fixture := newWakeRepairLifecycleFixture(t)
+	if err := os.Remove(fixture.lockPath); err != nil {
+		t.Fatalf("remove dead source lock: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().UTC().Format(time.RFC3339) == fixture.target.Created {
+		if time.Now().After(deadline) {
+			t.Fatal("wall clock did not advance beyond persisted target creation second")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	child, err := startWakeFromTargetDefault(
+		fixture.agentDir,
+		fixture.inboxDir,
+		fixture.root,
+		"codex",
+		fixture.target,
+		fixture.lineage,
+	)
+	cleanupRepairLifecycleChild(t, child)
+	if err != nil {
+		t.Fatalf(
+			"start repair child from exact persisted target: %v\n%s",
+			err,
+			wakeRepairLifecycleDiagnostics(fixture, child),
+		)
+	}
+	if child.Prepared.ChildPID() != child.Process.Pid {
+		t.Fatalf(
+			"prepared child pid=%d, want exact process pid=%d",
+			child.Prepared.ChildPID(),
+			child.Process.Pid,
+		)
+	}
+	if err := cleanupFailedWakeRepairChild(
+		fixture.agentDir,
+		fixture.root,
+		"codex",
+		child,
+	); err != nil {
+		t.Fatalf("cleanup prepared repair child: %v", err)
+	}
+	assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+}
+
+func TestWakeRepairParentWinnerMismatchStopsAndReapsPreparedChild(t *testing.T) {
+	fixture := newWakeRepairLifecycleFixture(t)
+	var child *wakeRepairChild
+	var startupDiagnostics string
+	stubRealRepairStarter(
+		t,
+		func(started *wakeRepairChild, startErr error) {
+			child = started
+			if startErr != nil {
+				startupDiagnostics = wakeRepairLifecycleDiagnostics(fixture, started)
+			}
+		},
+		func(started *wakeRepairChild) {
+			forceRepairLifecycleChildInspection(t, fixture, started)
+			started.Prepared.childPID++
+		},
+	)
+
+	result, err := repairWake(fixture.root, "codex")
+	if err == nil || !strings.Contains(err.Error(), "does not match started pid") {
+		t.Fatalf(
+			"winner mismatch result=%#v err=%v\n%s",
+			result,
+			err,
+			startupDiagnostics,
+		)
+	}
+	if strings.Contains(err.Error(), "(cleanup:") {
+		t.Fatalf("winner mismatch left child cleanup failure: %v", err)
+	}
+	assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+}
+
+func TestWakeRepairAdmissionFailureStopsAndReapsPreparedChild(t *testing.T) {
+	fixture := newWakeRepairLifecycleFixture(t)
+	var child *wakeRepairChild
+	var startupDiagnostics string
+	stubRealRepairStarter(
+		t,
+		func(started *wakeRepairChild, startErr error) {
+			child = started
+			if startErr != nil {
+				startupDiagnostics = wakeRepairLifecycleDiagnostics(fixture, started)
+			}
+		},
+		func(started *wakeRepairChild) {
+			forceRepairLifecycleChildInspection(t, fixture, started)
+			started.admit = func() error {
+				return errors.New("injected admission failure")
+			}
+		},
+	)
+
+	result, err := repairWake(fixture.root, "codex")
+	if err == nil || !strings.Contains(err.Error(), "injected admission failure") {
+		t.Fatalf(
+			"admission failure result=%#v err=%v\n%s",
+			result,
+			err,
+			startupDiagnostics,
+		)
+	}
+	if strings.Contains(err.Error(), "(cleanup:") {
+		t.Fatalf("admission failure left child cleanup failure: %v", err)
+	}
+	assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+}
+
+func TestWakeRepairFailedChildCleanupPreservesFloorReplacedBeforeCleanup(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate bool
+	}{
+		{name: "byte-identical new inode"},
+		{name: "same generation and source digest changed bytes", mutate: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newWakeRepairLifecycleFixture(t)
+			var child *wakeRepairChild
+			var replacement []byte
+			var startupDiagnostics string
+			stubRealRepairStarter(
+				t,
+				func(started *wakeRepairChild, startErr error) {
+					child = started
+					if startErr != nil {
+						startupDiagnostics = wakeRepairLifecycleDiagnostics(fixture, started)
+					}
+				},
+				func(started *wakeRepairChild) {
+					forceRepairLifecycleChildInspection(t, fixture, started)
+					replacement = replaceWakeRepairFloorWithNewInodeForTest(
+						t,
+						fixture.root,
+						"codex",
+						tc.mutate,
+					)
+					started.Prepared.childPID++
+				},
+			)
+
+			result, err := repairWake(fixture.root, "codex")
+			if err == nil || !strings.Contains(err.Error(), "does not match started pid") {
+				t.Fatalf(
+					"winner mismatch result=%#v err=%v\n%s",
+					result,
+					err,
+					startupDiagnostics,
+				)
+			}
+			if strings.Contains(err.Error(), "(cleanup:") {
+				t.Fatalf("replacement-preserving cleanup failed: %v", err)
+			}
+			assertRepairLifecycleChildReapedWithFloor(t, fixture, child, replacement)
+		})
+	}
+}
+
+func wakeRepairLifecycleDiagnostics(
+	fixture wakeRepairLifecycleFixture,
+	child *wakeRepairChild,
+) string {
+	var diagnostics strings.Builder
+	fmt.Fprintf(
+		&diagnostics,
+		"wake-repair diagnostics root=%q agent-dir=%q inbox=%q\n",
+		fixture.root,
+		fsq.AgentBase(fixture.root, "codex"),
+		filepath.Dir(fsq.AgentInboxNew(fixture.root, "codex")),
+	)
+	if child == nil {
+		diagnostics.WriteString("child=<nil>\n")
+	} else {
+		fmt.Fprintf(
+			&diagnostics,
+			"child pid=%d alive=%v process-start=%q source=%+v prepared=%+v handoff=%t capability=%t waiter=%t\n",
+			wakeRepairLifecycleChildPID(child),
+			wakeRepairLifecycleChildAlive(child),
+			child.ProcessStart,
+			child.Source,
+			child.Prepared,
+			child.Handoff != nil,
+			child.Capability != nil,
+			child.Waiter != nil,
+		)
+	}
+
+	inspection := inspectWakeLock(fixture.root, "codex")
+	fmt.Fprintf(
+		&diagnostics,
+		"lock exists=%v status=%q identity-confirmed=%v reason=%q pid=%d control-socket=%q lock=%+v\n",
+		inspection.Exists,
+		inspection.Status,
+		inspection.IdentityConfirmed,
+		inspection.Reason,
+		inspection.PID,
+		inspection.Lock.ControlSocket,
+		inspection.Lock,
+	)
+
+	agentBase := fsq.AgentBase(fixture.root, "codex")
+	for _, name := range []string{
+		".wake.lock",
+		wakeTargetFileName,
+		wakeRepairFloorFileName,
+		wakePreparedFileName,
+		".wake.repair.log",
+	} {
+		fmt.Fprintf(
+			&diagnostics,
+			"state %s\n",
+			wakeRepairLifecycleFileDiagnostic(filepath.Join(agentBase, name)),
+		)
+	}
+
+	pid := wakeRepairLifecycleChildPID(child)
+	if pid <= 0 {
+		return diagnostics.String()
+	}
+	for _, command := range [][]string{
+		{"ps", "-p", strconv.Itoa(pid), "-o", "pid=,ppid=,state=,etime=,command="},
+		{"lsof", "-nP", "-p", strconv.Itoa(pid)},
+	} {
+		fmt.Fprintf(
+			&diagnostics,
+			"command %q\n%s\n",
+			strings.Join(command, " "),
+			wakeRepairLifecycleCommandDiagnostic(command[0], command[1:]...),
+		)
+	}
+	if runtime.GOOS == "darwin" {
+		command := []string{"sample", strconv.Itoa(pid), "1", "1"}
+		fmt.Fprintf(
+			&diagnostics,
+			"command %q\n%s\n",
+			strings.Join(command, " "),
+			wakeRepairLifecycleCommandDiagnostic(command[0], command[1:]...),
+		)
+	}
+	fmt.Fprintf(
+		&diagnostics,
+		"go-stack %s\n",
+		wakeRepairLifecycleGoStackDiagnostic(fixture, child),
+	)
+	return diagnostics.String()
+}
+
+func wakeRepairLifecycleChildPID(child *wakeRepairChild) int {
+	if child == nil || child.Process == nil {
+		return 0
+	}
+	return child.Process.Pid
+}
+
+func wakeRepairLifecycleChildAlive(child *wakeRepairChild) bool {
+	pid := wakeRepairLifecycleChildPID(child)
+	return pid > 0 && processAlive(pid)
+}
+
+func wakeRepairLifecycleFileDiagnostic(path string) string {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Sprintf("path=%q lstat=%v", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Sprintf(
+			"path=%q mode=%s size=%d data=<not-read: non-regular>",
+			path,
+			info.Mode(),
+			info.Size(),
+		)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Sprintf(
+			"path=%q mode=%s size=%d open=%v",
+			path,
+			info.Mode(),
+			info.Size(),
+			err,
+		)
+	}
+	defer func() { _ = file.Close() }()
+	const diagnosticFileLimit = 16 << 10
+	data, readErr := io.ReadAll(io.LimitReader(file, diagnosticFileLimit+1))
+	if len(data) > diagnosticFileLimit {
+		data = append(data[:diagnosticFileLimit], []byte("\n<truncated>")...)
+	}
+	return fmt.Sprintf(
+		"path=%q mode=%s size=%d data=%q read=%v",
+		path,
+		info.Mode(),
+		info.Size(),
+		data,
+		readErr,
+	)
+}
+
+type wakeRepairLifecycleBoundedBuffer struct {
+	mu        sync.Mutex
+	data      []byte
+	limit     int
+	truncated bool
+}
+
+func (buffer *wakeRepairLifecycleBoundedBuffer) Write(data []byte) (int, error) {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	remaining := buffer.limit - len(buffer.data)
+	if remaining > 0 {
+		if remaining > len(data) {
+			remaining = len(data)
+		}
+		buffer.data = append(buffer.data, data[:remaining]...)
+	}
+	if remaining < len(data) {
+		buffer.truncated = true
+	}
+	return len(data), nil
+}
+
+func (buffer *wakeRepairLifecycleBoundedBuffer) String() string {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	output := string(buffer.data)
+	if buffer.truncated {
+		output += "\n<truncated>"
+	}
+	return output
+}
+
+func wakeRepairLifecycleCommandDiagnostic(name string, args ...string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	const diagnosticCommandLimit = 32 << 10
+	output := &wakeRepairLifecycleBoundedBuffer{limit: diagnosticCommandLimit}
+	command := exec.CommandContext(ctx, name, args...)
+	command.Stdout = output
+	command.Stderr = output
+	command.WaitDelay = 500 * time.Millisecond
+	err := command.Run()
+	return fmt.Sprintf("output=%q err=%v context=%v", output.String(), err, ctx.Err())
+}
+
+func wakeRepairLifecycleGoStackDiagnostic(
+	fixture wakeRepairLifecycleFixture,
+	child *wakeRepairChild,
+) string {
+	if child == nil || child.Process == nil || child.Process.Pid <= 0 {
+		return "child unavailable"
+	}
+	if err := child.Process.Signal(syscall.SIGQUIT); err != nil {
+		return fmt.Sprintf("signal SIGQUIT: %v", err)
+	}
+	if child.Waiter != nil {
+		select {
+		case <-child.Waiter.done:
+		case <-time.After(2 * time.Second):
+		}
+	} else {
+		time.Sleep(200 * time.Millisecond)
+	}
+	return wakeRepairLifecycleFileDiagnostic(
+		filepath.Join(fsq.AgentBase(fixture.root, "codex"), ".wake.repair.log"),
+	)
+}
+
+func newWakeRepairLifecycleFixture(t *testing.T) wakeRepairLifecycleFixture {
+	t.Helper()
+	t.Setenv(cliHelperEnv, "1")
+	t.Setenv("AMQ_NO_UPDATE_CHECK", "1")
+
+	root := wakeRepairLifecycleTempDir(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatalf("open lifecycle agent directory: %v", err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatalf("open lifecycle inbox directory: %v", err)
+	}
+	t.Cleanup(func() { _ = inboxDir.Close() })
+	agentIdentity, err := wakeRepairDirectoryIdentityForFile(agentDir.file)
+	if err != nil {
+		t.Fatalf("identify lifecycle agent directory: %v", err)
+	}
+	inboxIdentity, err := wakeRepairDirectoryIdentityForFile(inboxDir.file)
+	if err != nil {
+		t.Fatalf("identify lifecycle inbox directory: %v", err)
+	}
+
+	outputPath := filepath.Join(root, "injected.txt")
+	injector := filepath.Join(wakeRepairLifecycleTempDir(t), "injector")
+	script := "#!/bin/sh\noutput=$1\nshift\nprintf '%s\\n' \"$@\" >> \"$output\"\n"
+	if err := os.WriteFile(injector, []byte(script), 0o700); err != nil {
+		t.Fatalf("write lifecycle injector: %v", err)
+	}
+	target, err := newWakeTarget(root, "codex", injector, []string{outputPath})
+	if err != nil {
+		t.Fatalf("new lifecycle target: %v", err)
+	}
+
+	bootID := inspectWakeProcessPlatform(os.Getpid()).BootID
+	if bootID == "" {
+		t.Fatal("current boot identity is unavailable")
+	}
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		t.Fatalf("digest lifecycle target: %v", err)
+	}
+	deadLock := wakeLock{
+		PID:          wakeRepairLifecycleDeadPID,
+		ProcessStart: "dead-process-start",
+		BootID:       bootID,
+		Executable:   "/opt/homebrew/bin/amq",
+		Generation:   "dead-generation",
+		WakeMode:     wakeTargetInjectVia,
+		TargetDigest: targetDigest,
+	}
+	lockPath := writeWakeRepairLifecycleLock(t, root, "codex", deadLock)
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("write lifecycle target: %v", err)
+	}
+	floor, err := newWakeRepairFloor(root, "codex", deadLock, target, nil)
+	if err != nil {
+		t.Fatalf("new lifecycle floor: %v", err)
+	}
+	if err := writeWakeRepairFloor(root, "codex", floor); err != nil {
+		t.Fatalf("write lifecycle floor: %v", err)
+	}
+	floorDigest, err := wakeRepairFloorDigest(floor)
+	if err != nil {
+		t.Fatalf("digest lifecycle floor: %v", err)
+	}
+	lineage := wakeRepairLineage{
+		source: wakeRepairSource{
+			Root:               floor.Root,
+			RootIdentity:       floor.RootIdentity,
+			Agent:              floor.Agent,
+			DeadGeneration:     floor.Generation,
+			BootID:             floor.BootID,
+			Owner:              floor.Owner,
+			SourceTargetDigest: targetDigest,
+			SourceFloorDigest:  floorDigest,
+			AgentDirDevice:     agentIdentity.device,
+			AgentDirInode:      agentIdentity.inode,
+			InboxDirDevice:     inboxIdentity.device,
+			InboxDirInode:      inboxIdentity.inode,
+		},
+		floor: floor,
+	}
+	writeWakeRepairLifecycleMessage(t, root)
+
+	oldInspect := inspectWakeProcess
+	inspectWakeProcess = func(pid int) wakeProcessInfo {
+		if pid == wakeRepairLifecycleDeadPID {
+			return wakeProcessInfo{PID: pid, Running: false}
+		}
+		return inspectWakeProcessPlatform(pid)
+	}
+	t.Cleanup(func() {
+		inspectWakeProcess = oldInspect
+	})
+
+	return wakeRepairLifecycleFixture{
+		root:       root,
+		target:     target,
+		lineage:    lineage,
+		lockPath:   lockPath,
+		outputPath: outputPath,
+		agentDir:   agentDir,
+		inboxDir:   inboxDir,
+	}
+}
+
+func wakeRepairLifecycleTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "amq-wr-")
+	if err != nil {
+		t.Fatalf("create short wake repair lifecycle temp directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("remove wake repair lifecycle temp directory: %v", err)
+		}
+	})
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return resolved
+	}
+	return dir
+}
+
+func writeWakeRepairLifecycleLock(
+	t *testing.T,
+	root, me string,
+	lock wakeLock,
+) string {
+	t.Helper()
+	lock.Root = canonicalWakeRoot(root)
+	lock.Agent = me
+	lock.Started = time.Now().UTC().Format(time.RFC3339)
+	data, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatalf("marshal lifecycle lock: %v", err)
+	}
+	path := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write lifecycle lock: %v", err)
+	}
+	return path
+}
+
+func writeWakeRepairLifecycleMessage(t *testing.T, root string) {
+	t.Helper()
+	message := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       "pending",
+			From:     "claude",
+			To:       []string{"codex"},
+			Thread:   "p2p/claude__codex",
+			Subject:  "must wait for admission",
+			Created:  "2026-07-24T00:00:00Z",
+			Priority: "normal",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatalf("marshal lifecycle message: %v", err)
+	}
+	path := filepath.Join(fsq.AgentInboxNew(root, "codex"), "pending.md")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write lifecycle message: %v", err)
+	}
+}
+
+func stubRealRepairStarter(
+	t *testing.T,
+	capture func(*wakeRepairChild, error),
+	mutate func(*wakeRepairChild),
+) {
+	t.Helper()
+	old := startWakeFromTarget
+	startWakeFromTarget = func(
+		agentDir *wakeAgentDir,
+		inboxDir *wakeInboxDir,
+		root, me string,
+		target wakeTarget,
+		lineage wakeRepairLineage,
+	) (*wakeRepairChild, error) {
+		child, err := startWakeFromTargetDefault(
+			agentDir,
+			inboxDir,
+			root,
+			me,
+			target,
+			lineage,
+		)
+		if capture != nil {
+			capture(child, err)
+		}
+		if err == nil {
+			mutate(child)
+		}
+		return child, err
+	}
+	t.Cleanup(func() {
+		startWakeFromTarget = old
+	})
+}
+
+func cleanupRepairLifecycleChild(t *testing.T, child *wakeRepairChild) {
+	t.Helper()
+	t.Cleanup(func() {
+		if child == nil || child.Process == nil || child.Process.Pid <= 0 {
+			return
+		}
+		if processAlive(child.Process.Pid) {
+			_ = child.Process.Kill()
+		}
+		if child.Handoff != nil {
+			_ = child.Handoff.Close()
+		}
+		if child.Capability != nil {
+			_ = child.Capability.Close()
+		}
+		if child.Waiter != nil {
+			_ = child.Waiter.waitForExit(5 * time.Second)
+		}
+	})
+}
+
+func forceRepairLifecycleChildInspection(
+	t *testing.T,
+	fixture wakeRepairLifecycleFixture,
+	child *wakeRepairChild,
+) {
+	t.Helper()
+	if child == nil || child.Process == nil {
+		t.Fatal("prepared repair child is missing")
+	}
+	inspection := inspectWakeLock(fixture.root, "codex")
+	if !inspection.Exists {
+		t.Fatal("prepared repair child did not publish a lock")
+	}
+	lock := inspection.Lock
+	lock.Executable = "/opt/homebrew/bin/amq"
+	lock.Args = []string{"amq", "wake", "--root", fixture.root, "--me", "codex"}
+	data, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatalf("marshal authoritative child inspection fixture: %v", err)
+	}
+	if err := os.WriteFile(inspection.LockPath, data, 0o600); err != nil {
+		t.Fatalf("write authoritative child inspection fixture: %v", err)
+	}
+	previous := inspectWakeProcess
+	inspectWakeProcess = func(pid int) wakeProcessInfo {
+		if pid == child.Process.Pid {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: lock.ProcessStart,
+				BootID:     lock.BootID,
+				Executable: lock.Executable,
+				Args:       append([]string(nil), lock.Args...),
+			}
+		}
+		return previous(pid)
+	}
+	t.Cleanup(func() {
+		inspectWakeProcess = previous
+	})
+	confirmed := inspectWakeLock(fixture.root, "codex")
+	if confirmed.Status != wakeLockValid || !confirmed.IdentityConfirmed {
+		t.Fatalf(
+			"forced prepared child inspection status=%q identity=%v reason=%q",
+			confirmed.Status,
+			confirmed.IdentityConfirmed,
+			confirmed.Reason,
+		)
+	}
+}
+
+func assertRepairLifecycleChildReapedWithoutClaim(
+	t *testing.T,
+	fixture wakeRepairLifecycleFixture,
+	child *wakeRepairChild,
+) {
+	t.Helper()
+	if child == nil || child.Process == nil || child.Waiter == nil {
+		t.Fatal("repair child did not retain exact process and waiter")
+	}
+	if err := child.Waiter.waitForExit(time.Second); err != nil {
+		t.Fatalf("repair child was not reaped: %v", err)
+	}
+	if child.Waiter.state == nil {
+		t.Fatal("repair child waiter completed without a process state")
+	}
+	if processAlive(child.Process.Pid) {
+		t.Fatalf("repair child pid %d remains alive", child.Process.Pid)
+	}
+	if _, err := os.Lstat(fixture.lockPath); !os.IsNotExist(err) {
+		t.Fatalf("repair child lock residue remains: %v", err)
+	}
+	if _, err := os.Lstat(wakeRepairFloorPath(fixture.root, "codex")); !os.IsNotExist(err) {
+		t.Fatalf("repair child floor residue remains: %v", err)
+	}
+}
+
+func assertRepairLifecycleChildReapedWithFloor(
+	t *testing.T,
+	fixture wakeRepairLifecycleFixture,
+	child *wakeRepairChild,
+	expectedFloor []byte,
+) {
+	t.Helper()
+	if child == nil || child.Process == nil || child.Waiter == nil {
+		t.Fatal("repair child did not retain exact process and waiter")
+	}
+	if err := child.Waiter.waitForExit(time.Second); err != nil {
+		t.Fatalf("repair child was not reaped: %v", err)
+	}
+	if child.Waiter.state == nil {
+		t.Fatal("repair child waiter completed without a process state")
+	}
+	if processAlive(child.Process.Pid) {
+		t.Fatalf("repair child pid %d remains alive", child.Process.Pid)
+	}
+	if _, err := os.Lstat(fixture.lockPath); !os.IsNotExist(err) {
+		t.Fatalf("repair child lock residue remains: %v", err)
+	}
+	got, err := os.ReadFile(wakeRepairFloorPath(fixture.root, "codex"))
+	if err != nil {
+		t.Fatalf("replacement repair child floor was removed: %v", err)
+	}
+	if !bytes.Equal(got, expectedFloor) {
+		t.Fatal("replacement repair child floor changed during cleanup")
+	}
+}

--- a/internal/cli/wake_repair_continuity_unix_test.go
+++ b/internal/cli/wake_repair_continuity_unix_test.go
@@ -1,0 +1,235 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestWakeRepairNotifiesMessageDeliveredDuringDowntime(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	writeWakeContinuityMessage(t, root, "startup.md", "startup", "startup backlog", "normal", nil)
+
+	helper := copyTestBinaryForWakeContinuity(t)
+	injectedPath := filepath.Join(root, "injected.txt")
+	injector := filepath.Join(secureTempDirForTest(t), "injector")
+	injectorScript := "#!/bin/sh\noutput=$1\nshift\nprintf '%s\\n' \"$@\" >> \"$output\"\n"
+	if err := os.WriteFile(injector, []byte(injectorScript), 0o700); err != nil {
+		t.Fatalf("write injector: %v", err)
+	}
+
+	readyPath := filepath.Join(root, "initial.ready")
+	initial := exec.Command(
+		helper,
+		"--no-update-check",
+		"wake",
+		"--root", root,
+		"--me", "codex",
+		"--baseline-existing",
+		"--inject-via", injector,
+		"--inject-arg", injectedPath,
+		"--ready-file", readyPath,
+	)
+	initial.Env = wakeContinuityCLIEnv()
+	if err := initial.Start(); err != nil {
+		t.Fatalf("start initial wake: %v", err)
+	}
+	initialWaiter := newWakeProcessWaiter(initial.Process)
+	t.Cleanup(func() {
+		_ = initial.Process.Kill()
+		_ = initialWaiter.waitForExit(time.Second)
+	})
+	if err := waitForWakeReadyWithWaiter(initialWaiter, readyPath, root, "codex", 5*time.Second); err != nil {
+		t.Fatalf("wait for initial wake: %v\ninspection: %#v", err, inspectWakeLock(root, "codex"))
+	}
+
+	if err := initial.Process.Kill(); err != nil {
+		t.Fatalf("kill initial wake: %v", err)
+	}
+	if err := initialWaiter.waitForExit(5 * time.Second); err != nil {
+		t.Fatalf("wait for killed initial wake: %v", err)
+	}
+
+	writeWakeContinuityMessage(
+		t,
+		root,
+		"downtime.md",
+		"downtime",
+		"urgent message delivered during downtime",
+		"urgent",
+		[]string{"interrupt"},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	repair := exec.CommandContext(
+		ctx,
+		helper,
+		"--no-update-check",
+		"wake",
+		"repair",
+		"--root", root,
+		"--me", "codex",
+		"--json",
+	)
+	repair.Env = wakeContinuityCLIEnv()
+	output, err := repair.CombinedOutput()
+	if err != nil {
+		t.Fatalf("repair wake: %v\noutput: %s", err, output)
+	}
+	var result wakeRepairResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("decode repair result: %v\noutput: %s", err, output)
+	}
+	if result.Status != "repaired" {
+		t.Fatalf("repair result = %#v", result)
+	}
+	t.Cleanup(func() {
+		retire := exec.Command(
+			helper,
+			"--no-update-check",
+			"wake",
+			"retire",
+			"--root", root,
+			"--me", "codex",
+			"--inject-via", injector,
+			"--inject-arg", injectedPath,
+		)
+		retire.Env = wakeContinuityCLIEnv()
+		retireOutput, retireErr := retire.CombinedOutput()
+		if stopped := stopWakeContinuityHelper(result.PID, helper, root, "codex"); !stopped && retireErr != nil {
+			t.Logf("stop repaired wake: retire=%v output=%s", retireErr, retireOutput)
+		}
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, readErr := os.ReadFile(injectedPath)
+		if readErr == nil && strings.Contains(string(data), "urgent message delivered during downtime") {
+			if strings.Contains(string(data), "startup backlog") {
+				t.Fatalf("repaired wake re-notified the startup backlog: %q", data)
+			}
+			return
+		}
+		if readErr != nil && !os.IsNotExist(readErr) {
+			t.Fatalf("read injected output: %v", readErr)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	data, _ := os.ReadFile(injectedPath)
+	t.Fatalf("repaired wake suppressed the downtime message; injected output: %q", data)
+}
+
+func stopWakeContinuityHelper(pid int, helper, root, me string) bool {
+	proc := inspectWakeProcessPlatform(pid)
+	if !proc.Running {
+		return true
+	}
+	if filepath.Clean(proc.Executable) != filepath.Clean(helper) ||
+		!wakeArgsMatchRootAgent(proc.Args, root, me) {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	_ = process.Kill()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return !processAlive(pid)
+}
+
+func copyTestBinaryForWakeContinuity(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(os.Args[0])
+	if err != nil {
+		t.Fatalf("read test binary: %v", err)
+	}
+	path := filepath.Join(secureTempDirForTest(t), "amq")
+	if err := os.WriteFile(path, data, 0o700); err != nil {
+		t.Fatalf("write test helper: %v", err)
+	}
+	return path
+}
+
+func wakeContinuityCLIEnv() []string {
+	drop := []string{
+		"AM_ROOT=",
+		"AM_ROOT_ID=",
+		"AM_BASE_ROOT=",
+		"AM_BASE_ROOT_ID=",
+		"AM_SESSION=",
+		"AM_ME=",
+		"AMQ_GLOBAL_ROOT=",
+		"AMQ_WAKE_OWNER=",
+	}
+	env := make([]string, 0, len(os.Environ())+2)
+	for _, value := range os.Environ() {
+		keep := true
+		for _, prefix := range drop {
+			if strings.HasPrefix(value, prefix) {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			env = append(env, value)
+		}
+	}
+	return append(env, cliHelperEnv+"=1", "AMQ_NO_UPDATE_CHECK=1")
+}
+
+func writeWakeContinuityMessage(
+	t *testing.T,
+	root string,
+	filename string,
+	id string,
+	subject string,
+	priority string,
+	labels []string,
+) {
+	t.Helper()
+	msg := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       id,
+			From:     "claude",
+			To:       []string{"codex"},
+			Thread:   "p2p/claude__codex",
+			Subject:  subject,
+			Created:  "2026-07-24T00:00:00Z",
+			Priority: priority,
+			Labels:   labels,
+		},
+		Body: "body",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal %s: %v", id, err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", filename, data); err != nil {
+		t.Fatalf("deliver %s: %v", id, err)
+	}
+}

--- a/internal/cli/wake_repair_dirs_darwin.go
+++ b/internal/cli/wake_repair_dirs_darwin.go
@@ -1,0 +1,96 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"golang.org/x/sys/unix"
+)
+
+type retainedWakeInboxKqueueWatcher struct {
+	kqueueFD int
+	events   chan fsnotify.Event
+	errors   chan error
+	done     chan struct{}
+	close    sync.Once
+}
+
+func newRetainedWakeInboxWatcher(dirfd int, label string) (wakeEventWatcher, error) {
+	kqueueFD, err := unix.Kqueue()
+	if err != nil {
+		return nil, fmt.Errorf("create retained wake inbox kqueue: %w", err)
+	}
+	change := unix.Kevent_t{
+		Ident:  uint64(dirfd),
+		Filter: unix.EVFILT_VNODE,
+		Flags:  unix.EV_ADD | unix.EV_ENABLE | unix.EV_CLEAR,
+		Fflags: unix.NOTE_WRITE | unix.NOTE_EXTEND | unix.NOTE_ATTRIB | unix.NOTE_LINK | unix.NOTE_RENAME | unix.NOTE_DELETE,
+	}
+	if _, err := unix.Kevent(kqueueFD, []unix.Kevent_t{change}, nil, nil); err != nil {
+		_ = unix.Close(kqueueFD)
+		return nil, fmt.Errorf("register retained wake inbox kqueue: %w", err)
+	}
+	watcher := &retainedWakeInboxKqueueWatcher{
+		kqueueFD: kqueueFD,
+		events:   make(chan fsnotify.Event, 1),
+		errors:   make(chan error, 1),
+		done:     make(chan struct{}),
+	}
+	go watcher.run(label)
+	return watcher, nil
+}
+
+func (w *retainedWakeInboxKqueueWatcher) run(label string) {
+	defer close(w.done)
+	defer close(w.events)
+	defer close(w.errors)
+	eventName := filepath.Join(label, "retained-inbox-event.md")
+	for {
+		events := make([]unix.Kevent_t, 1)
+		count, err := unix.Kevent(w.kqueueFD, nil, events, nil)
+		if err != nil {
+			if err != unix.EBADF && err != unix.EINVAL {
+				select {
+				case w.errors <- fmt.Errorf("wait for retained wake inbox event: %w", err):
+				default:
+				}
+			}
+			return
+		}
+		if count == 0 {
+			continue
+		}
+		if events[0].Fflags&(unix.NOTE_RENAME|unix.NOTE_DELETE) != 0 {
+			select {
+			case w.errors <- fmt.Errorf("retained wake inbox directory was renamed or deleted"):
+			default:
+			}
+			return
+		}
+		select {
+		case w.events <- fsnotify.Event{Name: eventName, Op: fsnotify.Write}:
+		default:
+		}
+	}
+}
+
+func (w *retainedWakeInboxKqueueWatcher) Events() <-chan fsnotify.Event {
+	return w.events
+}
+
+func (w *retainedWakeInboxKqueueWatcher) Errors() <-chan error {
+	return w.errors
+}
+
+func (w *retainedWakeInboxKqueueWatcher) Close() error {
+	var closeErr error
+	w.close.Do(func() {
+		closeErr = unix.Close(w.kqueueFD)
+		<-w.done
+	})
+	return closeErr
+}

--- a/internal/cli/wake_repair_dirs_darwin.go
+++ b/internal/cli/wake_repair_dirs_darwin.go
@@ -12,69 +12,154 @@ import (
 )
 
 type retainedWakeInboxKqueueWatcher struct {
-	kqueueFD int
-	events   chan fsnotify.Event
-	errors   chan error
-	done     chan struct{}
-	close    sync.Once
+	kqueueFD  int
+	agentFD   int
+	inboxFD   int
+	authority retainedWakeDirectoryAuthority
+	events    chan fsnotify.Event
+	errors    chan error
+	done      chan struct{}
+	closing   chan struct{}
+	close     sync.Once
+	closeErr  error
 }
 
-func newRetainedWakeInboxWatcher(dirfd int, label string) (wakeEventWatcher, error) {
+func newRetainedWakeInboxWatcher(
+	agentFD, inboxFD int,
+	agentLabel, inboxLabel string,
+) (wakeEventWatcher, error) {
+	authority, err := newRetainedWakeDirectoryAuthority(
+		agentFD,
+		inboxFD,
+		agentLabel,
+		inboxLabel,
+	)
+	if err != nil {
+		return nil, err
+	}
 	kqueueFD, err := unix.Kqueue()
 	if err != nil {
-		return nil, fmt.Errorf("create retained wake inbox kqueue: %w", err)
+		return nil, fmt.Errorf("create retained wake directory kqueue: %w", err)
 	}
-	change := unix.Kevent_t{
-		Ident:  uint64(dirfd),
-		Filter: unix.EVFILT_VNODE,
-		Flags:  unix.EV_ADD | unix.EV_ENABLE | unix.EV_CLEAR,
-		Fflags: unix.NOTE_WRITE | unix.NOTE_EXTEND | unix.NOTE_ATTRIB | unix.NOTE_LINK | unix.NOTE_RENAME | unix.NOTE_DELETE,
+	flags := uint32(
+		unix.NOTE_WRITE |
+			unix.NOTE_EXTEND |
+			unix.NOTE_ATTRIB |
+			unix.NOTE_LINK |
+			unix.NOTE_RENAME |
+			unix.NOTE_DELETE |
+			unix.NOTE_REVOKE,
+	)
+	changes := []unix.Kevent_t{
+		{
+			Ident:  uint64(agentFD),
+			Filter: unix.EVFILT_VNODE,
+			Flags:  unix.EV_ADD | unix.EV_ENABLE | unix.EV_CLEAR,
+			Fflags: flags,
+		},
+		{
+			Ident:  uint64(inboxFD),
+			Filter: unix.EVFILT_VNODE,
+			Flags:  unix.EV_ADD | unix.EV_ENABLE | unix.EV_CLEAR,
+			Fflags: flags,
+		},
 	}
-	if _, err := unix.Kevent(kqueueFD, []unix.Kevent_t{change}, nil, nil); err != nil {
+	if _, err := unix.Kevent(kqueueFD, changes, nil, nil); err != nil {
 		_ = unix.Close(kqueueFD)
-		return nil, fmt.Errorf("register retained wake inbox kqueue: %w", err)
+		return nil, fmt.Errorf("register retained wake directory kqueue: %w", err)
+	}
+	if err := authority.validateCanonical(); err != nil {
+		closeErr := unix.Close(kqueueFD)
+		if closeErr != nil {
+			return nil, fmt.Errorf(
+				"validate retained wake directories after watch registration: %w (close kqueue: %v)",
+				err,
+				closeErr,
+			)
+		}
+		return nil, fmt.Errorf(
+			"validate retained wake directories after watch registration: %w",
+			err,
+		)
 	}
 	watcher := &retainedWakeInboxKqueueWatcher{
-		kqueueFD: kqueueFD,
-		events:   make(chan fsnotify.Event, 1),
-		errors:   make(chan error, 1),
-		done:     make(chan struct{}),
+		kqueueFD:  kqueueFD,
+		agentFD:   agentFD,
+		inboxFD:   inboxFD,
+		authority: authority,
+		events:    make(chan fsnotify.Event, 1),
+		errors:    make(chan error, 1),
+		done:      make(chan struct{}),
+		closing:   make(chan struct{}),
 	}
-	go watcher.run(label)
+	go watcher.run()
 	return watcher, nil
 }
 
-func (w *retainedWakeInboxKqueueWatcher) run(label string) {
+func (w *retainedWakeInboxKqueueWatcher) run() {
 	defer close(w.done)
 	defer close(w.events)
 	defer close(w.errors)
-	eventName := filepath.Join(label, "retained-inbox-event.md")
+	eventName := filepath.Join(w.authority.inboxPath, "retained-inbox-event.md")
 	for {
-		events := make([]unix.Kevent_t, 1)
+		events := make([]unix.Kevent_t, 2)
 		count, err := unix.Kevent(w.kqueueFD, nil, events, nil)
 		if err != nil {
-			if err != unix.EBADF && err != unix.EINVAL {
-				select {
-				case w.errors <- fmt.Errorf("wait for retained wake inbox event: %w", err):
-				default:
-				}
+			select {
+			case <-w.closing:
+				return
+			default:
+				w.fail(fmt.Errorf("wait for retained wake directory event: %w", err))
+				return
 			}
-			return
 		}
 		if count == 0 {
 			continue
 		}
-		if events[0].Fflags&(unix.NOTE_RENAME|unix.NOTE_DELETE) != 0 {
-			select {
-			case w.errors <- fmt.Errorf("retained wake inbox directory was renamed or deleted"):
-			default:
+
+		inboxEvent := false
+		for _, event := range events[:count] {
+			source, sourceErr := w.eventSource(event.Ident)
+			if sourceErr != nil {
+				w.fail(sourceErr)
+				return
 			}
+			if event.Fflags&(unix.NOTE_RENAME|unix.NOTE_DELETE|unix.NOTE_REVOKE) != 0 {
+				w.fail(fmt.Errorf("retained wake %s directory was renamed or deleted", source))
+				return
+			}
+			if source == "inbox" {
+				inboxEvent = true
+			}
+		}
+		if err := w.authority.validateCanonical(); err != nil {
+			w.fail(fmt.Errorf("retained wake directory namespace validation failed: %w", err))
 			return
 		}
-		select {
-		case w.events <- fsnotify.Event{Name: eventName, Op: fsnotify.Write}:
-		default:
+		if inboxEvent {
+			select {
+			case w.events <- fsnotify.Event{Name: eventName, Op: fsnotify.Write}:
+			default:
+			}
 		}
+	}
+}
+
+func (w *retainedWakeInboxKqueueWatcher) eventSource(ident uint64) (string, error) {
+	switch int(ident) {
+	case w.agentFD:
+		return "agent", nil
+	case w.inboxFD:
+		return "inbox", nil
+	default:
+		return "", fmt.Errorf("retained wake kqueue returned unknown directory descriptor %d", ident)
+	}
+}
+
+func (w *retainedWakeInboxKqueueWatcher) fail(err error) {
+	select {
+	case w.errors <- err:
+	default:
 	}
 }
 
@@ -87,10 +172,10 @@ func (w *retainedWakeInboxKqueueWatcher) Errors() <-chan error {
 }
 
 func (w *retainedWakeInboxKqueueWatcher) Close() error {
-	var closeErr error
 	w.close.Do(func() {
-		closeErr = unix.Close(w.kqueueFD)
+		close(w.closing)
+		w.closeErr = unix.Close(w.kqueueFD)
 		<-w.done
 	})
-	return closeErr
+	return w.closeErr
 }

--- a/internal/cli/wake_repair_dirs_darwin_test.go
+++ b/internal/cli/wake_repair_dirs_darwin_test.go
@@ -1,0 +1,76 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestDarwinRetainedWakeInboxWatcherFailsOnRootLoss(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		lose func(*testing.T, string)
+	}{
+		{
+			name: "rename",
+			lose: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Rename(path, filepath.Join(filepath.Dir(path), "new-detached")); err != nil {
+					t.Fatalf("rename retained inbox: %v", err)
+				}
+			},
+		},
+		{
+			name: "delete",
+			lose: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("delete retained inbox: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			watcher, inboxPath := newDarwinRetainedWakeInboxWatcherForTest(t)
+			test.lose(t, inboxPath)
+			select {
+			case err, ok := <-watcher.Errors():
+				if !ok || err == nil || !strings.Contains(err.Error(), "renamed or deleted") {
+					t.Fatalf("root-loss error = %v ok=%v", err, ok)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("retained watcher continued blind after inbox root loss")
+			}
+		})
+	}
+}
+
+func newDarwinRetainedWakeInboxWatcherForTest(t *testing.T) (wakeEventWatcher, string) {
+	t.Helper()
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inboxDir.Close() })
+	watcher, err := inboxDir.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = watcher.Close() })
+	return watcher, fsq.AgentInboxNew(root, "codex")
+}

--- a/internal/cli/wake_repair_dirs_darwin_test.go
+++ b/internal/cli/wake_repair_dirs_darwin_test.go
@@ -9,10 +9,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/fsnotify/fsnotify"
 )
 
-func TestDarwinRetainedWakeInboxWatcherFailsOnRootLoss(t *testing.T) {
+type darwinRetainedWakeWatcherFixture struct {
+	watcher   wakeEventWatcher
+	root      string
+	agentPath string
+	inboxPath string
+}
+
+func TestDarwinRetainedWakeWatcherNormalizesCanonicalCreate(t *testing.T) {
+	fixture := newDarwinRetainedWakeWatcherForTest(t)
+	writeDarwinRetainedWakeWatcherMessage(
+		t,
+		filepath.Join(fixture.inboxPath, "delivered.md"),
+		"delivered",
+	)
+	assertDarwinRetainedWakeWatcherEvent(t, fixture.watcher, fixture.inboxPath)
+}
+
+func TestDarwinRetainedWakeWatcherFailsOnDirectInboxLossWithoutForwarding(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		lose func(*testing.T, string)
@@ -21,7 +40,7 @@ func TestDarwinRetainedWakeInboxWatcherFailsOnRootLoss(t *testing.T) {
 			name: "rename",
 			lose: func(t *testing.T, path string) {
 				t.Helper()
-				if err := os.Rename(path, filepath.Join(filepath.Dir(path), "new-detached")); err != nil {
+				if err := os.Rename(path, filepath.Join(filepath.Dir(path), "renamed-detached")); err != nil {
 					t.Fatalf("rename retained inbox: %v", err)
 				}
 			},
@@ -35,23 +54,74 @@ func TestDarwinRetainedWakeInboxWatcherFailsOnRootLoss(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "delete and recreate",
+			lose: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("delete retained inbox: %v", err)
+				}
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatalf("recreate retained inbox: %v", err)
+				}
+			},
+		},
+		{
+			name: "rename and recreate",
+			lose: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Rename(path, filepath.Join(filepath.Dir(path), "replaced-detached")); err != nil {
+					t.Fatalf("rename retained inbox: %v", err)
+				}
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatalf("recreate retained inbox: %v", err)
+				}
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			watcher, inboxPath := newDarwinRetainedWakeInboxWatcherForTest(t)
-			test.lose(t, inboxPath)
-			select {
-			case err, ok := <-watcher.Errors():
-				if !ok || err == nil || !strings.Contains(err.Error(), "renamed or deleted") {
-					t.Fatalf("root-loss error = %v ok=%v", err, ok)
-				}
-			case <-time.After(2 * time.Second):
-				t.Fatal("retained watcher continued blind after inbox root loss")
-			}
+			fixture := newDarwinRetainedWakeWatcherForTest(t)
+			test.lose(t, fixture.inboxPath)
+			assertDarwinRetainedWakeWatcherTerminalWithoutEvents(t, fixture.watcher)
 		})
 	}
 }
 
-func newDarwinRetainedWakeInboxWatcherForTest(t *testing.T) (wakeEventWatcher, string) {
+func TestDarwinRetainedWakeWatcherFailsOnAncestorReplacementBeforeDetachedDelivery(t *testing.T) {
+	fixture := newDarwinRetainedWakeWatcherForTest(t)
+	detachedAgentPath := fixture.agentPath + ".detached"
+	if err := os.Rename(fixture.agentPath, detachedAgentPath); err != nil {
+		t.Fatalf("rename retained agent directory: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(fixture.root, "codex"); err != nil {
+		t.Fatalf("recreate canonical agent directory: %v", err)
+	}
+	writeDarwinRetainedWakeWatcherMessage(
+		t,
+		filepath.Join(detachedAgentPath, "inbox", "new", "late.md"),
+		"detached late delivery",
+	)
+	assertDarwinRetainedWakeWatcherTerminalWithoutEvents(t, fixture.watcher)
+}
+
+func TestDarwinRetainedWakeWatcherCloseIsIdempotentAndBounded(t *testing.T) {
+	fixture := newDarwinRetainedWakeWatcherForTest(t)
+	results := make(chan [2]error, 1)
+	go func() {
+		results <- [2]error{fixture.watcher.Close(), fixture.watcher.Close()}
+	}()
+
+	select {
+	case result := <-results:
+		if result[0] != nil || result[1] != nil {
+			t.Fatalf("idempotent retained watcher close = (%v, %v)", result[0], result[1])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("idempotent retained watcher close did not finish")
+	}
+}
+
+func newDarwinRetainedWakeWatcherForTest(t *testing.T) darwinRetainedWakeWatcherFixture {
 	t.Helper()
 	root := t.TempDir()
 	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
@@ -71,6 +141,121 @@ func newDarwinRetainedWakeInboxWatcherForTest(t *testing.T) (wakeEventWatcher, s
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = watcher.Close() })
-	return watcher, fsq.AgentInboxNew(root, "codex")
+	t.Cleanup(func() {
+		closeDarwinRetainedWakeWatcherBounded(t, watcher)
+	})
+	return darwinRetainedWakeWatcherFixture{
+		watcher:   watcher,
+		root:      root,
+		agentPath: fsq.AgentBase(root, "codex"),
+		inboxPath: fsq.AgentInboxNew(root, "codex"),
+	}
+}
+
+func closeDarwinRetainedWakeWatcherBounded(t *testing.T, watcher wakeEventWatcher) {
+	t.Helper()
+	result := make(chan error, 1)
+	go func() {
+		result <- watcher.Close()
+	}()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Errorf("close retained wake watcher: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("close retained wake watcher did not finish")
+	}
+}
+
+func writeDarwinRetainedWakeWatcherMessage(t *testing.T, path, subject string) {
+	t.Helper()
+	message := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       filepath.Base(path),
+			From:     "claude",
+			To:       []string{"codex"},
+			Thread:   "p2p/claude__codex",
+			Subject:  subject,
+			Created:  "2026-07-24T00:00:00Z",
+			Priority: "normal",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatalf("marshal retained watcher message: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write retained watcher message: %v", err)
+	}
+}
+
+func assertDarwinRetainedWakeWatcherEvent(
+	t *testing.T,
+	watcher wakeEventWatcher,
+	inboxPath string,
+) {
+	t.Helper()
+	select {
+	case event, ok := <-watcher.Events():
+		if !ok {
+			t.Fatal("retained watcher closed before forwarding message trigger")
+		}
+		want := fsnotify.Event{
+			Name: filepath.Join(inboxPath, "retained-inbox-event.md"),
+			Op:   fsnotify.Write,
+		}
+		if event != want {
+			t.Fatalf("normalized retained event = %#v, want %#v", event, want)
+		}
+	case err, ok := <-watcher.Errors():
+		t.Fatalf("retained watcher failed on canonical message create: %v ok=%v", err, ok)
+	case <-time.After(2 * time.Second):
+		t.Fatal("retained watcher did not forward a canonical message scan trigger")
+	}
+}
+
+func assertDarwinRetainedWakeWatcherTerminalWithoutEvents(
+	t *testing.T,
+	watcher wakeEventWatcher,
+) {
+	t.Helper()
+	events := watcher.Events()
+	errorsCh := watcher.Errors()
+	var terminalErr error
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+
+	for events != nil || errorsCh != nil {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				events = nil
+				continue
+			}
+			t.Fatalf("terminal retained watcher forwarded event: %#v", event)
+		case err, ok := <-errorsCh:
+			if !ok {
+				errorsCh = nil
+				continue
+			}
+			if err == nil {
+				t.Fatal("terminal retained watcher reported an empty error")
+			}
+			if terminalErr != nil {
+				t.Fatalf("terminal retained watcher reported multiple errors: %v and %v", terminalErr, err)
+			}
+			terminalErr = err
+		case <-timer.C:
+			t.Fatal("terminal retained watcher did not close its event and error channels")
+		}
+	}
+	if terminalErr == nil {
+		t.Fatal("retained watcher closed without a terminal namespace error")
+	}
+	if !strings.Contains(terminalErr.Error(), "retained wake") {
+		t.Fatalf("terminal retained watcher error = %v", terminalErr)
+	}
 }

--- a/internal/cli/wake_repair_dirs_linux.go
+++ b/internal/cli/wake_repair_dirs_linux.go
@@ -1,0 +1,91 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type retainedWakeInboxFSNotifyWatcher struct {
+	watcher  *fsnotify.Watcher
+	events   chan fsnotify.Event
+	errors   chan error
+	done     chan struct{}
+	close    sync.Once
+	closeErr error
+}
+
+func newRetainedWakeInboxWatcher(dirfd int, label string) (wakeEventWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create retained wake inbox watcher: %w", err)
+	}
+	descriptorPath := fmt.Sprintf("/proc/self/fd/%d", dirfd)
+	if err := watcher.Add(descriptorPath); err != nil {
+		_ = watcher.Close()
+		return nil, fmt.Errorf("watch retained wake inbox descriptor: %w", err)
+	}
+	retained := &retainedWakeInboxFSNotifyWatcher{
+		watcher: watcher,
+		events:  make(chan fsnotify.Event, 1),
+		errors:  make(chan error, 1),
+		done:    make(chan struct{}),
+	}
+	go retained.run(label)
+	return retained, nil
+}
+
+func (w *retainedWakeInboxFSNotifyWatcher) run(label string) {
+	defer close(w.done)
+	defer close(w.events)
+	defer close(w.errors)
+	eventName := filepath.Join(label, "retained-inbox-event.md")
+	for {
+		select {
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+			if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
+				select {
+				case w.errors <- fmt.Errorf("retained wake inbox directory was renamed or deleted"):
+				default:
+				}
+				return
+			}
+			select {
+			case w.events <- fsnotify.Event{Name: eventName, Op: fsnotify.Write}:
+			default:
+			}
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			select {
+			case w.errors <- fmt.Errorf("watch retained wake inbox: %w", err):
+			default:
+			}
+			return
+		}
+	}
+}
+
+func (w *retainedWakeInboxFSNotifyWatcher) Events() <-chan fsnotify.Event {
+	return w.events
+}
+
+func (w *retainedWakeInboxFSNotifyWatcher) Errors() <-chan error {
+	return w.errors
+}
+
+func (w *retainedWakeInboxFSNotifyWatcher) Close() error {
+	w.close.Do(func() {
+		w.closeErr = w.watcher.Close()
+		<-w.done
+	})
+	return w.closeErr
+}

--- a/internal/cli/wake_repair_dirs_linux.go
+++ b/internal/cli/wake_repair_dirs_linux.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -11,66 +12,134 @@ import (
 )
 
 type retainedWakeInboxFSNotifyWatcher struct {
-	watcher  *fsnotify.Watcher
-	events   chan fsnotify.Event
-	errors   chan error
-	done     chan struct{}
-	close    sync.Once
-	closeErr error
+	agentWatcher *fsnotify.Watcher
+	inboxWatcher *fsnotify.Watcher
+	authority    retainedWakeDirectoryAuthority
+	events       chan fsnotify.Event
+	errors       chan error
+	done         chan struct{}
+	close        sync.Once
+	closeErr     error
 }
 
-func newRetainedWakeInboxWatcher(dirfd int, label string) (wakeEventWatcher, error) {
-	watcher, err := fsnotify.NewWatcher()
+func newRetainedWakeInboxWatcher(
+	agentFD, inboxFD int,
+	agentLabel, inboxLabel string,
+) (wakeEventWatcher, error) {
+	authority, err := newRetainedWakeDirectoryAuthority(
+		agentFD,
+		inboxFD,
+		agentLabel,
+		inboxLabel,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("create retained wake inbox watcher: %w", err)
+		return nil, err
 	}
-	descriptorPath := fmt.Sprintf("/proc/self/fd/%d", dirfd)
-	if err := watcher.Add(descriptorPath); err != nil {
-		_ = watcher.Close()
-		return nil, fmt.Errorf("watch retained wake inbox descriptor: %w", err)
+	agentWatcher, err := newRetainedWakeFSNotifyWatcher(
+		agentFD,
+		"agent",
+	)
+	if err != nil {
+		return nil, err
+	}
+	inboxWatcher, err := newRetainedWakeFSNotifyWatcher(
+		inboxFD,
+		"inbox",
+	)
+	if err != nil {
+		_ = agentWatcher.Close()
+		return nil, err
+	}
+	if err := authority.validateCanonical(); err != nil {
+		closeErr := errors.Join(inboxWatcher.Close(), agentWatcher.Close())
+		return nil, errors.Join(
+			fmt.Errorf("validate retained wake directories after watch registration: %w", err),
+			closeErr,
+		)
 	}
 	retained := &retainedWakeInboxFSNotifyWatcher{
-		watcher: watcher,
-		events:  make(chan fsnotify.Event, 1),
-		errors:  make(chan error, 1),
-		done:    make(chan struct{}),
+		agentWatcher: agentWatcher,
+		inboxWatcher: inboxWatcher,
+		authority:    authority,
+		events:       make(chan fsnotify.Event, 1),
+		errors:       make(chan error, 1),
+		done:         make(chan struct{}),
 	}
-	go retained.run(label)
+	go retained.run()
 	return retained, nil
 }
 
-func (w *retainedWakeInboxFSNotifyWatcher) run(label string) {
+func newRetainedWakeFSNotifyWatcher(
+	fd int,
+	label string,
+) (*fsnotify.Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create retained wake %s watcher: %w", label, err)
+	}
+	descriptorPath := fmt.Sprintf("/proc/self/fd/%d", fd)
+	if err := watcher.Add(descriptorPath); err != nil {
+		_ = watcher.Close()
+		return nil, fmt.Errorf("watch retained wake %s descriptor: %w", label, err)
+	}
+	return watcher, nil
+}
+
+func (w *retainedWakeInboxFSNotifyWatcher) run() {
 	defer close(w.done)
 	defer close(w.events)
 	defer close(w.errors)
-	eventName := filepath.Join(label, "retained-inbox-event.md")
+	eventName := filepath.Join(w.authority.inboxPath, "retained-inbox-event.md")
 	for {
 		select {
-		case event, ok := <-w.watcher.Events:
+		case event, ok := <-w.agentWatcher.Events:
 			if !ok {
 				return
 			}
 			if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
-				select {
-				case w.errors <- fmt.Errorf("retained wake inbox directory was renamed or deleted"):
-				default:
-				}
+				w.fail(fmt.Errorf("retained wake agent directory was renamed or deleted"))
+				return
+			}
+			if err := w.authority.validateCanonical(); err != nil {
+				w.fail(fmt.Errorf("retained wake directory namespace validation failed: %w", err))
+				return
+			}
+		case event, ok := <-w.inboxWatcher.Events:
+			if !ok {
+				return
+			}
+			if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
+				w.fail(fmt.Errorf("retained wake inbox directory was renamed or deleted"))
+				return
+			}
+			if err := w.authority.validateCanonical(); err != nil {
+				w.fail(fmt.Errorf("retained wake directory namespace validation failed: %w", err))
 				return
 			}
 			select {
 			case w.events <- fsnotify.Event{Name: eventName, Op: fsnotify.Write}:
 			default:
 			}
-		case err, ok := <-w.watcher.Errors:
+		case err, ok := <-w.agentWatcher.Errors:
 			if !ok {
 				return
 			}
-			select {
-			case w.errors <- fmt.Errorf("watch retained wake inbox: %w", err):
-			default:
+			w.fail(fmt.Errorf("watch retained wake agent: %w", err))
+			return
+		case err, ok := <-w.inboxWatcher.Errors:
+			if !ok {
+				return
 			}
+			w.fail(fmt.Errorf("watch retained wake inbox: %w", err))
 			return
 		}
+	}
+}
+
+func (w *retainedWakeInboxFSNotifyWatcher) fail(err error) {
+	select {
+	case w.errors <- err:
+	default:
 	}
 }
 
@@ -84,7 +153,10 @@ func (w *retainedWakeInboxFSNotifyWatcher) Errors() <-chan error {
 
 func (w *retainedWakeInboxFSNotifyWatcher) Close() error {
 	w.close.Do(func() {
-		w.closeErr = w.watcher.Close()
+		w.closeErr = errors.Join(
+			w.inboxWatcher.Close(),
+			w.agentWatcher.Close(),
+		)
 		<-w.done
 	})
 	return w.closeErr

--- a/internal/cli/wake_repair_dirs_linux.go
+++ b/internal/cli/wake_repair_dirs_linux.go
@@ -5,21 +5,24 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
+	"golang.org/x/sys/unix"
 )
 
 type retainedWakeInboxFSNotifyWatcher struct {
-	agentWatcher *fsnotify.Watcher
-	inboxWatcher *fsnotify.Watcher
-	authority    retainedWakeDirectoryAuthority
-	events       chan fsnotify.Event
-	errors       chan error
-	done         chan struct{}
-	close        sync.Once
-	closeErr     error
+	namespaceWatcher *fsnotify.Watcher
+	inboxWatcher     *fsnotify.Watcher
+	inboxParent      *os.File
+	authority        retainedWakeDirectoryAuthority
+	events           chan fsnotify.Event
+	errors           chan error
+	done             chan struct{}
+	close            sync.Once
+	closeErr         error
 }
 
 func newRetainedWakeInboxWatcher(
@@ -35,11 +38,25 @@ func newRetainedWakeInboxWatcher(
 	if err != nil {
 		return nil, err
 	}
-	agentWatcher, err := newRetainedWakeFSNotifyWatcher(
-		agentFD,
-		"agent",
+	inboxParentFD, err := unix.Openat(
+		inboxFD,
+		"..",
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
 	)
 	if err != nil {
+		return nil, fmt.Errorf("open retained wake inbox parent directory: %w", err)
+	}
+	inboxParent := os.NewFile(
+		uintptr(inboxParentFD),
+		filepath.Dir(inboxLabel),
+	)
+	namespaceWatcher, err := newRetainedWakeNamespaceFSNotifyWatcher(
+		agentFD,
+		inboxParentFD,
+	)
+	if err != nil {
+		_ = inboxParent.Close()
 		return nil, err
 	}
 	inboxWatcher, err := newRetainedWakeFSNotifyWatcher(
@@ -47,26 +64,50 @@ func newRetainedWakeInboxWatcher(
 		"inbox",
 	)
 	if err != nil {
-		_ = agentWatcher.Close()
+		_ = namespaceWatcher.Close()
+		_ = inboxParent.Close()
 		return nil, err
 	}
 	if err := authority.validateCanonical(); err != nil {
-		closeErr := errors.Join(inboxWatcher.Close(), agentWatcher.Close())
+		closeErr := errors.Join(
+			namespaceWatcher.Close(),
+			inboxWatcher.Close(),
+			inboxParent.Close(),
+		)
 		return nil, errors.Join(
 			fmt.Errorf("validate retained wake directories after watch registration: %w", err),
 			closeErr,
 		)
 	}
 	retained := &retainedWakeInboxFSNotifyWatcher{
-		agentWatcher: agentWatcher,
-		inboxWatcher: inboxWatcher,
-		authority:    authority,
-		events:       make(chan fsnotify.Event, 1),
-		errors:       make(chan error, 1),
-		done:         make(chan struct{}),
+		namespaceWatcher: namespaceWatcher,
+		inboxWatcher:     inboxWatcher,
+		inboxParent:      inboxParent,
+		authority:        authority,
+		events:           make(chan fsnotify.Event, 1),
+		errors:           make(chan error, 1),
+		done:             make(chan struct{}),
 	}
 	go retained.run()
 	return retained, nil
+}
+
+func newRetainedWakeNamespaceFSNotifyWatcher(
+	agentFD, inboxParentFD int,
+) (*fsnotify.Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create retained wake namespace watcher: %w", err)
+	}
+	if err := addRetainedWakeFSNotifyDescriptor(watcher, agentFD, "agent"); err != nil {
+		_ = watcher.Close()
+		return nil, err
+	}
+	if err := addRetainedWakeFSNotifyDescriptor(watcher, inboxParentFD, "inbox parent"); err != nil {
+		_ = watcher.Close()
+		return nil, err
+	}
+	return watcher, nil
 }
 
 func newRetainedWakeFSNotifyWatcher(
@@ -77,12 +118,23 @@ func newRetainedWakeFSNotifyWatcher(
 	if err != nil {
 		return nil, fmt.Errorf("create retained wake %s watcher: %w", label, err)
 	}
-	descriptorPath := fmt.Sprintf("/proc/self/fd/%d", fd)
-	if err := watcher.Add(descriptorPath); err != nil {
+	if err := addRetainedWakeFSNotifyDescriptor(watcher, fd, label); err != nil {
 		_ = watcher.Close()
-		return nil, fmt.Errorf("watch retained wake %s descriptor: %w", label, err)
+		return nil, err
 	}
 	return watcher, nil
+}
+
+func addRetainedWakeFSNotifyDescriptor(
+	watcher *fsnotify.Watcher,
+	fd int,
+	label string,
+) error {
+	descriptorPath := fmt.Sprintf("/proc/self/fd/%d", fd)
+	if err := watcher.Add(descriptorPath); err != nil {
+		return fmt.Errorf("watch retained wake %s descriptor: %w", label, err)
+	}
+	return nil
 }
 
 func (w *retainedWakeInboxFSNotifyWatcher) run() {
@@ -92,24 +144,16 @@ func (w *retainedWakeInboxFSNotifyWatcher) run() {
 	eventName := filepath.Join(w.authority.inboxPath, "retained-inbox-event.md")
 	for {
 		select {
-		case event, ok := <-w.agentWatcher.Events:
+		case _, ok := <-w.namespaceWatcher.Events:
 			if !ok {
-				return
-			}
-			if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
-				w.fail(fmt.Errorf("retained wake agent directory was renamed or deleted"))
 				return
 			}
 			if err := w.authority.validateCanonical(); err != nil {
 				w.fail(fmt.Errorf("retained wake directory namespace validation failed: %w", err))
 				return
 			}
-		case event, ok := <-w.inboxWatcher.Events:
+		case _, ok := <-w.inboxWatcher.Events:
 			if !ok {
-				return
-			}
-			if event.Op&(fsnotify.Rename|fsnotify.Remove) != 0 {
-				w.fail(fmt.Errorf("retained wake inbox directory was renamed or deleted"))
 				return
 			}
 			if err := w.authority.validateCanonical(); err != nil {
@@ -120,11 +164,11 @@ func (w *retainedWakeInboxFSNotifyWatcher) run() {
 			case w.events <- fsnotify.Event{Name: eventName, Op: fsnotify.Write}:
 			default:
 			}
-		case err, ok := <-w.agentWatcher.Errors:
+		case err, ok := <-w.namespaceWatcher.Errors:
 			if !ok {
 				return
 			}
-			w.fail(fmt.Errorf("watch retained wake agent: %w", err))
+			w.fail(fmt.Errorf("watch retained wake namespace: %w", err))
 			return
 		case err, ok := <-w.inboxWatcher.Errors:
 			if !ok {
@@ -153,11 +197,14 @@ func (w *retainedWakeInboxFSNotifyWatcher) Errors() <-chan error {
 
 func (w *retainedWakeInboxFSNotifyWatcher) Close() error {
 	w.close.Do(func() {
-		w.closeErr = errors.Join(
-			w.inboxWatcher.Close(),
-			w.agentWatcher.Close(),
-		)
+		namespaceErr := w.namespaceWatcher.Close()
+		inboxErr := w.inboxWatcher.Close()
 		<-w.done
+		w.closeErr = errors.Join(
+			namespaceErr,
+			inboxErr,
+			w.inboxParent.Close(),
+		)
 	})
 	return w.closeErr
 }

--- a/internal/cli/wake_repair_dirs_linux_test.go
+++ b/internal/cli/wake_repair_dirs_linux_test.go
@@ -31,6 +31,86 @@ func TestLinuxRetainedWakeWatcherNormalizesCanonicalCreate(t *testing.T) {
 	assertLinuxRetainedWakeWatcherEvent(t, fixture.watcher, fixture.inboxPath)
 }
 
+func TestLinuxRetainedWakeWatcherIgnoresAgentChildLifecycleChurn(t *testing.T) {
+	fixture := newLinuxRetainedWakeWatcherForTest(t)
+	lockPath := filepath.Join(fixture.agentPath, ".wake.lock")
+	temporaryPath := filepath.Join(fixture.agentPath, ".wake.lock.tmp")
+
+	for iteration := 0; iteration < 8; iteration++ {
+		if err := os.WriteFile(temporaryPath, []byte("pending"), 0o600); err != nil {
+			t.Fatalf("write temporary wake lock at iteration %d: %v", iteration, err)
+		}
+		if err := os.Rename(temporaryPath, lockPath); err != nil {
+			t.Fatalf("atomically publish wake lock at iteration %d: %v", iteration, err)
+		}
+		if err := os.Remove(lockPath); err != nil {
+			t.Fatalf("remove wake lock at iteration %d: %v", iteration, err)
+		}
+	}
+
+	assertLinuxRetainedWakeWatcherQuiet(t, fixture.watcher, "agent child lifecycle churn")
+	writeLinuxRetainedWakeWatcherMessage(
+		t,
+		filepath.Join(fixture.inboxPath, "after-agent-churn.md"),
+		"after agent churn",
+	)
+	assertLinuxRetainedWakeWatcherEvent(t, fixture.watcher, fixture.inboxPath)
+}
+
+func TestLinuxRetainedWakeWatcherScansAfterInboxChildRenameOrRemove(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, string)
+	}{
+		{
+			name: "rename",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Rename(path, path+".renamed"); err != nil {
+					t.Fatalf("rename retained inbox child: %v", err)
+				}
+			},
+		},
+		{
+			name: "remove",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("remove retained inbox child: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pendingName := "pending-" + test.name + ".md"
+			fixture := newLinuxRetainedWakeWatcherForTestWithSetup(
+				t,
+				func(_, inboxPath string) {
+					writeLinuxRetainedWakeWatcherMessage(
+						t,
+						filepath.Join(inboxPath, pendingName),
+						"pending "+test.name,
+					)
+				},
+			)
+
+			test.mutate(t, filepath.Join(fixture.inboxPath, pendingName))
+			assertLinuxRetainedWakeWatcherEventsUntilQuiet(
+				t,
+				fixture.watcher,
+				fixture.inboxPath,
+			)
+
+			writeLinuxRetainedWakeWatcherMessage(
+				t,
+				filepath.Join(fixture.inboxPath, "after-"+test.name+".md"),
+				"after "+test.name,
+			)
+			assertLinuxRetainedWakeWatcherEvent(t, fixture.watcher, fixture.inboxPath)
+		})
+	}
+}
+
 func TestLinuxRetainedWakeWatcherFailsOnDirectInboxLossWithoutForwarding(t *testing.T) {
 	for _, test := range []struct {
 		name string
@@ -149,9 +229,22 @@ func TestLinuxRetainedWakeWatcherCloseIsIdempotentAndBounded(t *testing.T) {
 
 func newLinuxRetainedWakeWatcherForTest(t *testing.T) linuxRetainedWakeWatcherFixture {
 	t.Helper()
+	return newLinuxRetainedWakeWatcherForTestWithSetup(t, nil)
+}
+
+func newLinuxRetainedWakeWatcherForTestWithSetup(
+	t *testing.T,
+	setup func(agentPath, inboxPath string),
+) linuxRetainedWakeWatcherFixture {
+	t.Helper()
 	root := t.TempDir()
 	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
 		t.Fatal(err)
+	}
+	agentPath := fsq.AgentBase(root, "codex")
+	inboxPath := fsq.AgentInboxNew(root, "codex")
+	if setup != nil {
+		setup(agentPath, inboxPath)
 	}
 	agentDir, err := openWakeAgentDir(root, "codex")
 	if err != nil {
@@ -173,8 +266,8 @@ func newLinuxRetainedWakeWatcherForTest(t *testing.T) linuxRetainedWakeWatcherFi
 	return linuxRetainedWakeWatcherFixture{
 		watcher:   watcher,
 		root:      root,
-		agentPath: fsq.AgentBase(root, "codex"),
-		inboxPath: fsq.AgentInboxNew(root, "codex"),
+		agentPath: agentPath,
+		inboxPath: inboxPath,
 	}
 }
 
@@ -240,6 +333,62 @@ func assertLinuxRetainedWakeWatcherEvent(
 		t.Fatalf("retained watcher failed on canonical message create: %v ok=%v", err, ok)
 	case <-time.After(2 * time.Second):
 		t.Fatal("retained watcher did not forward a canonical message scan trigger")
+	}
+}
+
+func assertLinuxRetainedWakeWatcherQuiet(
+	t *testing.T,
+	watcher wakeEventWatcher,
+	action string,
+) {
+	t.Helper()
+	select {
+	case event, ok := <-watcher.Events():
+		t.Fatalf("%s produced message scan event = %#v ok=%v", action, event, ok)
+	case err, ok := <-watcher.Errors():
+		t.Fatalf("%s failed retained watcher: %v ok=%v", action, err, ok)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func assertLinuxRetainedWakeWatcherEventsUntilQuiet(
+	t *testing.T,
+	watcher wakeEventWatcher,
+	inboxPath string,
+) {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	seen := false
+	for {
+		select {
+		case event, ok := <-watcher.Events():
+			if !ok {
+				t.Fatal("retained watcher closed after inbox child mutation")
+			}
+			want := fsnotify.Event{
+				Name: filepath.Join(inboxPath, "retained-inbox-event.md"),
+				Op:   fsnotify.Write,
+			}
+			if event != want {
+				t.Fatalf("normalized retained event = %#v, want %#v", event, want)
+			}
+			seen = true
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(200 * time.Millisecond)
+		case err, ok := <-watcher.Errors():
+			t.Fatalf("inbox child mutation failed retained watcher: %v ok=%v", err, ok)
+		case <-timer.C:
+			if !seen {
+				t.Fatal("retained watcher did not scan after inbox child mutation")
+			}
+			return
+		}
 	}
 }
 

--- a/internal/cli/wake_repair_dirs_linux_test.go
+++ b/internal/cli/wake_repair_dirs_linux_test.go
@@ -1,0 +1,97 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestLinuxRetainedWakeInboxWatcherFailsOnRootLoss(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		lose func(*testing.T, string)
+	}{
+		{
+			name: "rename",
+			lose: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Rename(path, filepath.Join(filepath.Dir(path), "new-detached")); err != nil {
+					t.Fatalf("rename retained inbox: %v", err)
+				}
+			},
+		},
+		{
+			name: "delete",
+			lose: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("delete retained inbox: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			watcher, inboxPath := newLinuxRetainedWakeInboxWatcherForTest(t)
+			test.lose(t, inboxPath)
+			select {
+			case err, ok := <-watcher.Errors():
+				if !ok || err == nil || !strings.Contains(err.Error(), "renamed or deleted") {
+					t.Fatalf("root-loss error = %v ok=%v", err, ok)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("retained watcher continued blind after inbox root loss")
+			}
+		})
+	}
+}
+
+func TestLinuxRetainedWakeInboxWatcherNormalizesCreateToMessageScanTrigger(t *testing.T) {
+	watcher, inboxPath := newLinuxRetainedWakeInboxWatcherForTest(t)
+	if err := os.WriteFile(filepath.Join(inboxPath, "delivered.md"), []byte("message"), 0o600); err != nil {
+		t.Fatalf("create retained inbox message: %v", err)
+	}
+	select {
+	case event, ok := <-watcher.Events():
+		if !ok {
+			t.Fatal("retained watcher closed before forwarding message trigger")
+		}
+		if !strings.HasSuffix(event.Name, ".md") || event.Op&fsnotify.Write == 0 {
+			t.Fatalf("normalized retained event = %#v, want synthetic .md write", event)
+		}
+	case err := <-watcher.Errors():
+		t.Fatalf("retained watcher failed on message create: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("retained watcher did not forward a message scan trigger")
+	}
+}
+
+func newLinuxRetainedWakeInboxWatcherForTest(t *testing.T) (wakeEventWatcher, string) {
+	t.Helper()
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inboxDir.Close() })
+	watcher, err := inboxDir.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = watcher.Close() })
+	return watcher, fsq.AgentInboxNew(root, "codex")
+}

--- a/internal/cli/wake_repair_dirs_linux_test.go
+++ b/internal/cli/wake_repair_dirs_linux_test.go
@@ -9,11 +9,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"github.com/fsnotify/fsnotify"
 )
 
-func TestLinuxRetainedWakeInboxWatcherFailsOnRootLoss(t *testing.T) {
+type linuxRetainedWakeWatcherFixture struct {
+	watcher   wakeEventWatcher
+	root      string
+	agentPath string
+	inboxPath string
+}
+
+func TestLinuxRetainedWakeWatcherNormalizesCanonicalCreate(t *testing.T) {
+	fixture := newLinuxRetainedWakeWatcherForTest(t)
+	writeLinuxRetainedWakeWatcherMessage(
+		t,
+		filepath.Join(fixture.inboxPath, "delivered.md"),
+		"delivered",
+	)
+	assertLinuxRetainedWakeWatcherEvent(t, fixture.watcher, fixture.inboxPath)
+}
+
+func TestLinuxRetainedWakeWatcherFailsOnDirectInboxLossWithoutForwarding(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		lose func(*testing.T, string)
@@ -22,7 +40,7 @@ func TestLinuxRetainedWakeInboxWatcherFailsOnRootLoss(t *testing.T) {
 			name: "rename",
 			lose: func(t *testing.T, path string) {
 				t.Helper()
-				if err := os.Rename(path, filepath.Join(filepath.Dir(path), "new-detached")); err != nil {
+				if err := os.Rename(path, filepath.Join(filepath.Dir(path), "renamed-detached")); err != nil {
 					t.Fatalf("rename retained inbox: %v", err)
 				}
 			},
@@ -36,43 +54,100 @@ func TestLinuxRetainedWakeInboxWatcherFailsOnRootLoss(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "delete and recreate",
+			lose: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("delete retained inbox: %v", err)
+				}
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatalf("recreate retained inbox: %v", err)
+				}
+			},
+		},
+		{
+			name: "rename and recreate",
+			lose: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Rename(path, filepath.Join(filepath.Dir(path), "replaced-detached")); err != nil {
+					t.Fatalf("rename retained inbox: %v", err)
+				}
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatalf("recreate retained inbox: %v", err)
+				}
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			watcher, inboxPath := newLinuxRetainedWakeInboxWatcherForTest(t)
-			test.lose(t, inboxPath)
-			select {
-			case err, ok := <-watcher.Errors():
-				if !ok || err == nil || !strings.Contains(err.Error(), "renamed or deleted") {
-					t.Fatalf("root-loss error = %v ok=%v", err, ok)
-				}
-			case <-time.After(2 * time.Second):
-				t.Fatal("retained watcher continued blind after inbox root loss")
-			}
+			fixture := newLinuxRetainedWakeWatcherForTest(t)
+			test.lose(t, fixture.inboxPath)
+			assertLinuxRetainedWakeWatcherTerminalWithoutEvents(t, fixture.watcher)
 		})
 	}
 }
 
-func TestLinuxRetainedWakeInboxWatcherNormalizesCreateToMessageScanTrigger(t *testing.T) {
-	watcher, inboxPath := newLinuxRetainedWakeInboxWatcherForTest(t)
-	if err := os.WriteFile(filepath.Join(inboxPath, "delivered.md"), []byte("message"), 0o600); err != nil {
-		t.Fatalf("create retained inbox message: %v", err)
+func TestLinuxRetainedWakeWatcherFailsOnAncestorReplacementBeforeDetachedDelivery(t *testing.T) {
+	fixture := newLinuxRetainedWakeWatcherForTest(t)
+	detachedAgentPath := fixture.agentPath + ".detached"
+	if err := os.Rename(fixture.agentPath, detachedAgentPath); err != nil {
+		t.Fatalf("rename retained agent directory: %v", err)
 	}
+	if err := fsq.EnsureAgentDirs(fixture.root, "codex"); err != nil {
+		t.Fatalf("recreate canonical agent directory: %v", err)
+	}
+	writeLinuxRetainedWakeWatcherMessage(
+		t,
+		filepath.Join(detachedAgentPath, "inbox", "new", "late.md"),
+		"detached late delivery",
+	)
+	assertLinuxRetainedWakeWatcherTerminalWithoutEvents(t, fixture.watcher)
+}
+
+func TestLinuxRetainedWakeWatcherIgnoresAgentMetadata(t *testing.T) {
+	fixture := newLinuxRetainedWakeWatcherForTest(t)
+	if err := os.WriteFile(
+		filepath.Join(fixture.agentPath, "presence.json"),
+		[]byte(`{"status":"active"}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write agent metadata: %v", err)
+	}
+
 	select {
-	case event, ok := <-watcher.Events():
-		if !ok {
-			t.Fatal("retained watcher closed before forwarding message trigger")
+	case event, ok := <-fixture.watcher.Events():
+		t.Fatalf("agent metadata produced message scan event = %#v ok=%v", event, ok)
+	case err, ok := <-fixture.watcher.Errors():
+		t.Fatalf("agent metadata failed retained watcher: %v ok=%v", err, ok)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	writeLinuxRetainedWakeWatcherMessage(
+		t,
+		filepath.Join(fixture.inboxPath, "after-metadata.md"),
+		"after metadata",
+	)
+	assertLinuxRetainedWakeWatcherEvent(t, fixture.watcher, fixture.inboxPath)
+}
+
+func TestLinuxRetainedWakeWatcherCloseIsIdempotentAndBounded(t *testing.T) {
+	fixture := newLinuxRetainedWakeWatcherForTest(t)
+	results := make(chan [2]error, 1)
+	go func() {
+		results <- [2]error{fixture.watcher.Close(), fixture.watcher.Close()}
+	}()
+
+	select {
+	case result := <-results:
+		if result[0] != nil || result[1] != nil {
+			t.Fatalf("idempotent retained watcher close = (%v, %v)", result[0], result[1])
 		}
-		if !strings.HasSuffix(event.Name, ".md") || event.Op&fsnotify.Write == 0 {
-			t.Fatalf("normalized retained event = %#v, want synthetic .md write", event)
-		}
-	case err := <-watcher.Errors():
-		t.Fatalf("retained watcher failed on message create: %v", err)
 	case <-time.After(2 * time.Second):
-		t.Fatal("retained watcher did not forward a message scan trigger")
+		t.Fatal("idempotent retained watcher close did not finish")
 	}
 }
 
-func newLinuxRetainedWakeInboxWatcherForTest(t *testing.T) (wakeEventWatcher, string) {
+func newLinuxRetainedWakeWatcherForTest(t *testing.T) linuxRetainedWakeWatcherFixture {
 	t.Helper()
 	root := t.TempDir()
 	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
@@ -92,6 +167,121 @@ func newLinuxRetainedWakeInboxWatcherForTest(t *testing.T) (wakeEventWatcher, st
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = watcher.Close() })
-	return watcher, fsq.AgentInboxNew(root, "codex")
+	t.Cleanup(func() {
+		closeLinuxRetainedWakeWatcherBounded(t, watcher)
+	})
+	return linuxRetainedWakeWatcherFixture{
+		watcher:   watcher,
+		root:      root,
+		agentPath: fsq.AgentBase(root, "codex"),
+		inboxPath: fsq.AgentInboxNew(root, "codex"),
+	}
+}
+
+func closeLinuxRetainedWakeWatcherBounded(t *testing.T, watcher wakeEventWatcher) {
+	t.Helper()
+	result := make(chan error, 1)
+	go func() {
+		result <- watcher.Close()
+	}()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Errorf("close retained wake watcher: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("close retained wake watcher did not finish")
+	}
+}
+
+func writeLinuxRetainedWakeWatcherMessage(t *testing.T, path, subject string) {
+	t.Helper()
+	message := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       filepath.Base(path),
+			From:     "claude",
+			To:       []string{"codex"},
+			Thread:   "p2p/claude__codex",
+			Subject:  subject,
+			Created:  "2026-07-24T00:00:00Z",
+			Priority: "normal",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatalf("marshal retained watcher message: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write retained watcher message: %v", err)
+	}
+}
+
+func assertLinuxRetainedWakeWatcherEvent(
+	t *testing.T,
+	watcher wakeEventWatcher,
+	inboxPath string,
+) {
+	t.Helper()
+	select {
+	case event, ok := <-watcher.Events():
+		if !ok {
+			t.Fatal("retained watcher closed before forwarding message trigger")
+		}
+		want := fsnotify.Event{
+			Name: filepath.Join(inboxPath, "retained-inbox-event.md"),
+			Op:   fsnotify.Write,
+		}
+		if event != want {
+			t.Fatalf("normalized retained event = %#v, want %#v", event, want)
+		}
+	case err, ok := <-watcher.Errors():
+		t.Fatalf("retained watcher failed on canonical message create: %v ok=%v", err, ok)
+	case <-time.After(2 * time.Second):
+		t.Fatal("retained watcher did not forward a canonical message scan trigger")
+	}
+}
+
+func assertLinuxRetainedWakeWatcherTerminalWithoutEvents(
+	t *testing.T,
+	watcher wakeEventWatcher,
+) {
+	t.Helper()
+	events := watcher.Events()
+	errorsCh := watcher.Errors()
+	var terminalErr error
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+
+	for events != nil || errorsCh != nil {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				events = nil
+				continue
+			}
+			t.Fatalf("terminal retained watcher forwarded event: %#v", event)
+		case err, ok := <-errorsCh:
+			if !ok {
+				errorsCh = nil
+				continue
+			}
+			if err == nil {
+				t.Fatal("terminal retained watcher reported an empty error")
+			}
+			if terminalErr != nil {
+				t.Fatalf("terminal retained watcher reported multiple errors: %v and %v", terminalErr, err)
+			}
+			terminalErr = err
+		case <-timer.C:
+			t.Fatal("terminal retained watcher did not close its event and error channels")
+		}
+	}
+	if terminalErr == nil {
+		t.Fatal("retained watcher closed without a terminal namespace error")
+	}
+	if !strings.Contains(terminalErr.Error(), "retained wake") {
+		t.Fatalf("terminal retained watcher error = %v", terminalErr)
+	}
 }

--- a/internal/cli/wake_repair_dirs_unix.go
+++ b/internal/cli/wake_repair_dirs_unix.go
@@ -1,0 +1,337 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/presence"
+	"github.com/fsnotify/fsnotify"
+	"golang.org/x/sys/unix"
+)
+
+const wakeRepairInboxRelativePath = "inbox/new"
+
+type wakeRepairDirectoryIdentity struct {
+	device uint64
+	inode  uint64
+}
+
+type wakeInboxDir struct {
+	path   string
+	file   *os.File
+	mu     sync.RWMutex
+	closed bool
+}
+
+type wakeEventWatcher interface {
+	Events() <-chan fsnotify.Event
+	Errors() <-chan error
+	Close() error
+}
+
+func wakeRepairDirectoryIdentityForFile(file *os.File) (wakeRepairDirectoryIdentity, error) {
+	if file == nil {
+		return wakeRepairDirectoryIdentity{}, fmt.Errorf("wake repair directory descriptor is missing")
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return wakeRepairDirectoryIdentity{}, fmt.Errorf("stat wake repair directory descriptor: %w", err)
+	}
+	if !info.IsDir() {
+		return wakeRepairDirectoryIdentity{}, fmt.Errorf("wake repair directory descriptor is not a directory")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return wakeRepairDirectoryIdentity{}, fmt.Errorf("wake repair directory identity is unavailable")
+	}
+	identity := wakeRepairDirectoryIdentity{
+		device: uint64(stat.Dev),
+		inode:  uint64(stat.Ino),
+	}
+	if identity.device == 0 || identity.inode == 0 {
+		return wakeRepairDirectoryIdentity{}, fmt.Errorf("wake repair directory identity is invalid")
+	}
+	return identity, nil
+}
+
+func validateCanonicalWakeRepairDirectories(
+	root, me string,
+	source wakeRepairHandoffSource,
+) error {
+	if canonicalWakeRoot(source.Root()) != canonicalWakeRoot(root) || source.Agent() != me {
+		return fmt.Errorf("wake repair source namespace scope mismatch")
+	}
+	agentPath := fsq.AgentBase(root, me)
+	agentFD, err := unix.Open(
+		agentPath,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open canonical wake repair agent directory: %w", err)
+	}
+	agentFile := os.NewFile(uintptr(agentFD), agentPath)
+	defer func() { _ = agentFile.Close() }()
+	agentIdentity, err := wakeRepairDirectoryIdentityForFile(agentFile)
+	if err != nil {
+		return err
+	}
+	if agentIdentity.device != source.agentDirDevice ||
+		agentIdentity.inode != source.agentDirInode {
+		return fmt.Errorf("canonical wake repair agent directory no longer matches retained authority")
+	}
+
+	inboxPath := filepath.Join(agentPath, wakeRepairInboxRelativePath)
+	inboxFD, err := unix.Openat(
+		agentFD,
+		wakeRepairInboxRelativePath,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open canonical wake repair inbox directory: %w", err)
+	}
+	inboxFile := os.NewFile(uintptr(inboxFD), inboxPath)
+	defer func() { _ = inboxFile.Close() }()
+	inboxIdentity, err := wakeRepairDirectoryIdentityForFile(inboxFile)
+	if err != nil {
+		return err
+	}
+	if inboxIdentity.device != source.inboxDirDevice ||
+		inboxIdentity.inode != source.inboxDirInode {
+		return fmt.Errorf("canonical wake repair inbox directory no longer matches retained authority")
+	}
+	return nil
+}
+
+func openWakeRepairInboxDir(agentDir *wakeAgentDir) (*wakeInboxDir, error) {
+	if agentDir == nil {
+		return nil, fmt.Errorf("wake repair agent directory capability is missing")
+	}
+	var file *os.File
+	err := agentDir.withFD(func(dirfd int) error {
+		fd, err := unix.Openat(
+			dirfd,
+			wakeRepairInboxRelativePath,
+			unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		if err != nil {
+			return fmt.Errorf("open retained wake inbox directory: %w", err)
+		}
+		file = os.NewFile(uintptr(fd), filepath.Join(agentDir.path, wakeRepairInboxRelativePath))
+		info, err := file.Stat()
+		if err != nil {
+			_ = file.Close()
+			return fmt.Errorf("stat retained wake inbox directory: %w", err)
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			_ = file.Close()
+			return fmt.Errorf("retained wake inbox must be a directory")
+		}
+		if err := validateWakeTargetPathOwnership("retained wake inbox directory", file.Name(), info); err != nil {
+			_ = file.Close()
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &wakeInboxDir{path: file.Name(), file: file}, nil
+}
+
+func duplicateWakeRepairDirectoryFile(file *os.File, name string) (*os.File, error) {
+	if file == nil {
+		return nil, fmt.Errorf("%s is missing", name)
+	}
+	fd, err := unix.FcntlInt(file.Fd(), unix.F_DUPFD_CLOEXEC, 3)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate %s: %w", name, err)
+	}
+	duplicate := os.NewFile(uintptr(fd), name)
+	if _, err := wakeRepairDirectoryIdentityForFile(duplicate); err != nil {
+		_ = duplicate.Close()
+		return nil, err
+	}
+	return duplicate, nil
+}
+
+func openInheritedWakeRepairDirectories(
+	agentFile *os.File,
+	inboxFile *os.File,
+	source wakeRepairHandoffSource,
+) (*wakeAgentDir, *wakeInboxDir, error) {
+	closeBoth := func() {
+		_ = closeFile(agentFile)
+		_ = closeFile(inboxFile)
+	}
+	if err := source.validate(); err != nil {
+		closeBoth()
+		return nil, nil, err
+	}
+	agentIdentity, err := wakeRepairDirectoryIdentityForFile(agentFile)
+	if err != nil {
+		closeBoth()
+		return nil, nil, err
+	}
+	if agentIdentity.device != source.agentDirDevice ||
+		agentIdentity.inode != source.agentDirInode {
+		closeBoth()
+		return nil, nil, fmt.Errorf("inherited wake repair agent directory identity mismatch")
+	}
+	inboxIdentity, err := wakeRepairDirectoryIdentityForFile(inboxFile)
+	if err != nil {
+		closeBoth()
+		return nil, nil, err
+	}
+	if inboxIdentity.device != source.inboxDirDevice ||
+		inboxIdentity.inode != source.inboxDirInode {
+		closeBoth()
+		return nil, nil, fmt.Errorf("inherited wake repair inbox directory identity mismatch")
+	}
+	agentDir := &wakeAgentDir{
+		path: filepath.Join(source.root, "agents", source.agent),
+		file: agentFile,
+	}
+	inboxDir := &wakeInboxDir{
+		path: filepath.Join(agentDir.path, wakeRepairInboxRelativePath),
+		file: inboxFile,
+	}
+	return agentDir, inboxDir, nil
+}
+
+func (d *wakeInboxDir) withFD(fn func(int) error) error {
+	if d == nil {
+		return fmt.Errorf("wake inbox directory capability is missing")
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.closed {
+		return fmt.Errorf("wake inbox directory %s is closed", d.path)
+	}
+	return fn(int(d.file.Fd()))
+}
+
+func (d *wakeInboxDir) ReadDir() ([]os.DirEntry, error) {
+	var entries []os.DirEntry
+	err := d.withFD(func(dirfd int) error {
+		fd, err := unix.Openat(
+			dirfd,
+			".",
+			unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		if err != nil {
+			return fmt.Errorf("reopen retained wake inbox directory: %w", err)
+		}
+		scan := os.NewFile(uintptr(fd), d.path)
+		defer func() { _ = scan.Close() }()
+		entries, err = scan.ReadDir(-1)
+		return err
+	})
+	return entries, err
+}
+
+func (d *wakeInboxDir) ReadHeader(name string) (format.Header, error) {
+	if filepath.Base(name) != name || strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
+		return format.Header{}, fmt.Errorf("invalid wake message filename %q", name)
+	}
+	var header format.Header
+	err := d.withFD(func(dirfd int) error {
+		fd, err := unix.Openat(
+			dirfd,
+			name,
+			unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		if err != nil {
+			return err
+		}
+		file := os.NewFile(uintptr(fd), filepath.Join(d.path, name))
+		defer func() { _ = file.Close() }()
+		info, err := file.Stat()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("wake message %s must be a regular file", file.Name())
+		}
+		header, err = format.ReadHeader(file)
+		return err
+	})
+	return header, err
+}
+
+func (d *wakeInboxDir) NewWatcher() (wakeEventWatcher, error) {
+	var watcher wakeEventWatcher
+	err := d.withFD(func(dirfd int) error {
+		var err error
+		watcher, err = newRetainedWakeInboxWatcher(dirfd, d.path)
+		return err
+	})
+	return watcher, err
+}
+
+func (d *wakeInboxDir) Close() error {
+	if d == nil {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	return d.file.Close()
+}
+
+func touchWakePresenceInDir(agentDir *wakeAgentDir, me string) error {
+	if agentDir == nil {
+		return fmt.Errorf("wake repair agent directory capability is missing")
+	}
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		path := filepath.Join(agentDir.path, "presence.json")
+		data, _, exists, err := readWakeRepairMetadataAt(
+			dirfd,
+			"presence.json",
+			"wake presence",
+			path,
+			maxWakeMetadataFileBytes,
+		)
+		var value presence.Presence
+		switch {
+		case err != nil:
+			return err
+		case !exists:
+			value = presence.New(me, "active", "", time.Now())
+		default:
+			if err := json.Unmarshal(data, &value); err != nil {
+				return fmt.Errorf("parse wake presence: %w", err)
+			}
+			value.LastSeen = time.Now().UTC().Format(time.RFC3339Nano)
+		}
+		encoded, err := json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			return err
+		}
+		return writeWakeRepairMetadataAt(
+			dirfd,
+			agentDir,
+			"presence.json",
+			"wake presence",
+			append(encoded, '\n'),
+			maxWakeMetadataFileBytes,
+		)
+	})
+}

--- a/internal/cli/wake_repair_dirs_unix.go
+++ b/internal/cli/wake_repair_dirs_unix.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,16 +28,25 @@ type wakeRepairDirectoryIdentity struct {
 }
 
 type wakeInboxDir struct {
-	path   string
-	file   *os.File
-	mu     sync.RWMutex
-	closed bool
+	agentPath string
+	agentFile *os.File
+	path      string
+	file      *os.File
+	mu        sync.RWMutex
+	closed    bool
 }
 
 type wakeEventWatcher interface {
 	Events() <-chan fsnotify.Event
 	Errors() <-chan error
 	Close() error
+}
+
+type retainedWakeDirectoryAuthority struct {
+	agentPath     string
+	inboxPath     string
+	agentIdentity wakeRepairDirectoryIdentity
+	inboxIdentity wakeRepairDirectoryIdentity
 }
 
 func wakeRepairDirectoryIdentityForFile(file *os.File) (wakeRepairDirectoryIdentity, error) {
@@ -62,6 +72,103 @@ func wakeRepairDirectoryIdentityForFile(file *os.File) (wakeRepairDirectoryIdent
 		return wakeRepairDirectoryIdentity{}, fmt.Errorf("wake repair directory identity is invalid")
 	}
 	return identity, nil
+}
+
+func wakeRepairDirectoryIdentityForFD(
+	fd int,
+	label string,
+) (wakeRepairDirectoryIdentity, error) {
+	if fd < 0 {
+		return wakeRepairDirectoryIdentity{}, fmt.Errorf("%s descriptor is invalid", label)
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return wakeRepairDirectoryIdentity{}, fmt.Errorf("stat %s descriptor: %w", label, err)
+	}
+	identity := wakeRepairDirectoryIdentity{
+		device: uint64(stat.Dev),
+		inode:  uint64(stat.Ino),
+	}
+	if identity.device == 0 || identity.inode == 0 {
+		return wakeRepairDirectoryIdentity{}, fmt.Errorf("%s identity is invalid", label)
+	}
+	return identity, nil
+}
+
+func newRetainedWakeDirectoryAuthority(
+	agentFD, inboxFD int,
+	agentPath, inboxPath string,
+) (retainedWakeDirectoryAuthority, error) {
+	agentIdentity, err := wakeRepairDirectoryIdentityForFD(
+		agentFD,
+		"retained wake agent directory",
+	)
+	if err != nil {
+		return retainedWakeDirectoryAuthority{}, err
+	}
+	inboxIdentity, err := wakeRepairDirectoryIdentityForFD(
+		inboxFD,
+		"retained wake inbox directory",
+	)
+	if err != nil {
+		return retainedWakeDirectoryAuthority{}, err
+	}
+	return retainedWakeDirectoryAuthority{
+		agentPath:     agentPath,
+		inboxPath:     inboxPath,
+		agentIdentity: agentIdentity,
+		inboxIdentity: inboxIdentity,
+	}, nil
+}
+
+func (authority retainedWakeDirectoryAuthority) validateCanonical() error {
+	agentFD, err := unix.Open(
+		authority.agentPath,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"canonical wake repair agent directory no longer matches retained authority: %w",
+			err,
+		)
+	}
+	defer func() { _ = unix.Close(agentFD) }()
+	agentIdentity, err := wakeRepairDirectoryIdentityForFD(
+		agentFD,
+		"canonical wake repair agent directory",
+	)
+	if err != nil {
+		return err
+	}
+	if agentIdentity != authority.agentIdentity {
+		return fmt.Errorf("canonical wake repair agent directory no longer matches retained authority")
+	}
+
+	inboxFD, err := unix.Openat(
+		agentFD,
+		wakeRepairInboxRelativePath,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"canonical wake repair inbox directory no longer matches retained authority: %w",
+			err,
+		)
+	}
+	defer func() { _ = unix.Close(inboxFD) }()
+	inboxIdentity, err := wakeRepairDirectoryIdentityForFD(
+		inboxFD,
+		"canonical wake repair inbox directory",
+	)
+	if err != nil {
+		return err
+	}
+	if inboxIdentity != authority.inboxIdentity {
+		return fmt.Errorf("canonical wake repair inbox directory no longer matches retained authority")
+	}
+	return nil
 }
 
 func validateCanonicalWakeRepairDirectories(
@@ -118,8 +225,17 @@ func openWakeRepairInboxDir(agentDir *wakeAgentDir) (*wakeInboxDir, error) {
 	if agentDir == nil {
 		return nil, fmt.Errorf("wake repair agent directory capability is missing")
 	}
+	var agentFile *os.File
 	var file *os.File
 	err := agentDir.withFD(func(dirfd int) error {
+		var err error
+		agentFile, err = duplicateWakeRepairDirectoryFD(
+			dirfd,
+			"retained wake agent directory",
+		)
+		if err != nil {
+			return err
+		}
 		fd, err := unix.Openat(
 			dirfd,
 			wakeRepairInboxRelativePath,
@@ -127,20 +243,24 @@ func openWakeRepairInboxDir(agentDir *wakeAgentDir) (*wakeInboxDir, error) {
 			0,
 		)
 		if err != nil {
+			_ = agentFile.Close()
 			return fmt.Errorf("open retained wake inbox directory: %w", err)
 		}
 		file = os.NewFile(uintptr(fd), filepath.Join(agentDir.path, wakeRepairInboxRelativePath))
 		info, err := file.Stat()
 		if err != nil {
 			_ = file.Close()
+			_ = agentFile.Close()
 			return fmt.Errorf("stat retained wake inbox directory: %w", err)
 		}
 		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			_ = file.Close()
+			_ = agentFile.Close()
 			return fmt.Errorf("retained wake inbox must be a directory")
 		}
 		if err := validateWakeTargetPathOwnership("retained wake inbox directory", file.Name(), info); err != nil {
 			_ = file.Close()
+			_ = agentFile.Close()
 			return err
 		}
 		return nil
@@ -148,23 +268,32 @@ func openWakeRepairInboxDir(agentDir *wakeAgentDir) (*wakeInboxDir, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &wakeInboxDir{path: file.Name(), file: file}, nil
+	return &wakeInboxDir{
+		agentPath: agentDir.path,
+		agentFile: agentFile,
+		path:      file.Name(),
+		file:      file,
+	}, nil
+}
+
+func duplicateWakeRepairDirectoryFD(fd int, name string) (*os.File, error) {
+	duplicateFD, err := unix.FcntlInt(uintptr(fd), unix.F_DUPFD_CLOEXEC, 3)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate %s: %w", name, err)
+	}
+	duplicate := os.NewFile(uintptr(duplicateFD), name)
+	if _, err := wakeRepairDirectoryIdentityForFile(duplicate); err != nil {
+		_ = duplicate.Close()
+		return nil, err
+	}
+	return duplicate, nil
 }
 
 func duplicateWakeRepairDirectoryFile(file *os.File, name string) (*os.File, error) {
 	if file == nil {
 		return nil, fmt.Errorf("%s is missing", name)
 	}
-	fd, err := unix.FcntlInt(file.Fd(), unix.F_DUPFD_CLOEXEC, 3)
-	if err != nil {
-		return nil, fmt.Errorf("duplicate %s: %w", name, err)
-	}
-	duplicate := os.NewFile(uintptr(fd), name)
-	if _, err := wakeRepairDirectoryIdentityForFile(duplicate); err != nil {
-		_ = duplicate.Close()
-		return nil, err
-	}
-	return duplicate, nil
+	return duplicateWakeRepairDirectoryFD(int(file.Fd()), name)
 }
 
 func openInheritedWakeRepairDirectories(
@@ -200,13 +329,23 @@ func openInheritedWakeRepairDirectories(
 		closeBoth()
 		return nil, nil, fmt.Errorf("inherited wake repair inbox directory identity mismatch")
 	}
+	watcherAgentFile, err := duplicateWakeRepairDirectoryFile(
+		agentFile,
+		"retained wake watcher agent directory",
+	)
+	if err != nil {
+		closeBoth()
+		return nil, nil, err
+	}
 	agentDir := &wakeAgentDir{
 		path: filepath.Join(source.root, "agents", source.agent),
 		file: agentFile,
 	}
 	inboxDir := &wakeInboxDir{
-		path: filepath.Join(agentDir.path, wakeRepairInboxRelativePath),
-		file: inboxFile,
+		agentPath: agentDir.path,
+		agentFile: watcherAgentFile,
+		path:      filepath.Join(agentDir.path, wakeRepairInboxRelativePath),
+		file:      inboxFile,
 	}
 	return agentDir, inboxDir, nil
 }
@@ -221,6 +360,21 @@ func (d *wakeInboxDir) withFD(fn func(int) error) error {
 		return fmt.Errorf("wake inbox directory %s is closed", d.path)
 	}
 	return fn(int(d.file.Fd()))
+}
+
+func (d *wakeInboxDir) withWatcherFDs(fn func(agentFD, inboxFD int) error) error {
+	if d == nil {
+		return fmt.Errorf("wake inbox directory capability is missing")
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.closed {
+		return fmt.Errorf("wake inbox directory %s is closed", d.path)
+	}
+	if d.agentFile == nil || d.file == nil {
+		return fmt.Errorf("retained wake watcher directory capabilities are missing")
+	}
+	return fn(int(d.agentFile.Fd()), int(d.file.Fd()))
 }
 
 func (d *wakeInboxDir) ReadDir() ([]os.DirEntry, error) {
@@ -275,9 +429,14 @@ func (d *wakeInboxDir) ReadHeader(name string) (format.Header, error) {
 
 func (d *wakeInboxDir) NewWatcher() (wakeEventWatcher, error) {
 	var watcher wakeEventWatcher
-	err := d.withFD(func(dirfd int) error {
+	err := d.withWatcherFDs(func(agentFD, inboxFD int) error {
 		var err error
-		watcher, err = newRetainedWakeInboxWatcher(dirfd, d.path)
+		watcher, err = newRetainedWakeInboxWatcher(
+			agentFD,
+			inboxFD,
+			d.agentPath,
+			d.path,
+		)
 		return err
 	})
 	return watcher, err
@@ -293,7 +452,10 @@ func (d *wakeInboxDir) Close() error {
 		return nil
 	}
 	d.closed = true
-	return d.file.Close()
+	closeErr := errors.Join(closeFile(d.file), closeFile(d.agentFile))
+	d.file = nil
+	d.agentFile = nil
+	return closeErr
 }
 
 func touchWakePresenceInDir(agentDir *wakeAgentDir, me string) error {

--- a/internal/cli/wake_repair_floor_other.go
+++ b/internal/cli/wake_repair_floor_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !linux
+
+package cli
+
+import "fmt"
+
+func validateWakeRepairFloorAvailable(
+	root, me string,
+	inspection wakeLockInspection,
+	target wakeTarget,
+) error {
+	return fmt.Errorf("wake repair is not supported on this platform")
+}

--- a/internal/cli/wake_repair_floor_unix.go
+++ b/internal/cli/wake_repair_floor_unix.go
@@ -1,0 +1,429 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	wakeRepairFloorSchema       = 1
+	wakeRepairFloorFileName     = ".wake.repair-floor"
+	maxWakeRepairFloorFileBytes = 8 * 1024 * 1024
+)
+
+var currentWakeBootID = func() string {
+	return inspectWakeProcess(os.Getpid()).BootID
+}
+
+// wakeRepairFloor is private continuity state for one ownerless inject-via
+// lineage. Existing contains only the exact local file identities that the
+// running wake deliberately suppresses. It never records or compares message
+// IDs, so a DLQ retry written as a new file instance remains eligible.
+type wakeRepairFloor struct {
+	Schema            int                         `json:"schema"`
+	Root              string                      `json:"root"`
+	RootIdentity      string                      `json:"root_identity"`
+	Agent             string                      `json:"agent"`
+	Generation        string                      `json:"generation"`
+	SourceGeneration  string                      `json:"source_generation,omitempty"`
+	SourceFloorDigest string                      `json:"source_floor_digest,omitempty"`
+	TargetDigest      string                      `json:"target_digest"`
+	BootID            string                      `json:"boot_id"`
+	Owner             *wakeOwner                  `json:"owner,omitempty"`
+	Existing          map[string]wakeFileIdentity `json:"existing"`
+}
+
+type wakeRepairSource struct {
+	Root               string
+	RootIdentity       string
+	Agent              string
+	DeadGeneration     string
+	BootID             string
+	Owner              *wakeOwner
+	SourceTargetDigest string
+	SourceFloorDigest  string
+	AgentDirDevice     uint64
+	AgentDirInode      uint64
+	InboxDirDevice     uint64
+	InboxDirInode      uint64
+}
+
+type wakeRepairLineage struct {
+	source wakeRepairSource
+	floor  wakeRepairFloor
+}
+
+func wakeRepairFloorPath(root, me string) string {
+	return filepath.Join(fsq.AgentBase(root, me), wakeRepairFloorFileName)
+}
+
+func newWakeRepairFloor(
+	root, me string,
+	lock wakeLock,
+	target wakeTarget,
+	existing map[string]wakeFileIdentity,
+) (wakeRepairFloor, error) {
+	rootIdentity, err := resolveTreeIdentityToken(root)
+	if err != nil {
+		return wakeRepairFloor{}, fmt.Errorf("snapshot wake repair root identity: %w", err)
+	}
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		return wakeRepairFloor{}, err
+	}
+	floor := wakeRepairFloor{
+		Schema:       wakeRepairFloorSchema,
+		Root:         canonicalWakeRoot(root),
+		RootIdentity: rootIdentity,
+		Agent:        me,
+		Generation:   lock.Generation,
+		TargetDigest: targetDigest,
+		BootID:       lock.BootID,
+		Existing:     cloneWakeFileIdentities(existing),
+	}
+	if target.Owner != nil {
+		owner := *target.Owner
+		floor.Owner = &owner
+	}
+	if err := validateWakeRepairFloor(floor, root, me, lock, target); err != nil {
+		return wakeRepairFloor{}, err
+	}
+	return floor, nil
+}
+
+func newInheritedWakeRepairFloor(
+	source wakeRepairSource,
+	lock wakeLock,
+	target wakeTarget,
+	existing map[string]wakeFileIdentity,
+) (wakeRepairFloor, error) {
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		return wakeRepairFloor{}, err
+	}
+	if targetDigest != source.SourceTargetDigest {
+		return wakeRepairFloor{}, fmt.Errorf("wake repair inherited target digest mismatch")
+	}
+	floor := wakeRepairFloor{
+		Schema:            wakeRepairFloorSchema,
+		Root:              source.Root,
+		RootIdentity:      source.RootIdentity,
+		Agent:             source.Agent,
+		Generation:        lock.Generation,
+		SourceGeneration:  source.DeadGeneration,
+		SourceFloorDigest: source.SourceFloorDigest,
+		TargetDigest:      targetDigest,
+		BootID:            source.BootID,
+		Existing:          cloneWakeFileIdentities(existing),
+	}
+	if source.Owner != nil {
+		owner := *source.Owner
+		floor.Owner = &owner
+	}
+	if floor.Root == "" || floor.RootIdentity == "" || floor.Agent == "" ||
+		floor.Generation == "" || floor.SourceGeneration == "" ||
+		floor.SourceFloorDigest == "" {
+		return wakeRepairFloor{}, fmt.Errorf("wake repair inherited lineage is incomplete")
+	}
+	return floor, nil
+}
+
+func cloneWakeFileIdentities(existing map[string]wakeFileIdentity) map[string]wakeFileIdentity {
+	cloned := make(map[string]wakeFileIdentity, len(existing))
+	for name, identity := range existing {
+		cloned[name] = identity
+	}
+	return cloned
+}
+
+func wakeRepairFloorDigest(floor wakeRepairFloor) (string, error) {
+	data, err := json.Marshal(floor)
+	if err != nil {
+		return "", fmt.Errorf("marshal wake repair floor digest: %w", err)
+	}
+	return wakeMetadataDigest(data), nil
+}
+
+func wakeMetadataDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func sameWakeRepairSuppression(first, second wakeRepairFloor) bool {
+	if len(first.Existing) != len(second.Existing) {
+		return false
+	}
+	for name, identity := range first.Existing {
+		if second.Existing[name] != identity {
+			return false
+		}
+	}
+	return true
+}
+
+func writeWakeRepairFloor(root, me string, floor wakeRepairFloor) error {
+	data, err := json.MarshalIndent(floor, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal wake repair floor: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > maxWakeRepairFloorFileBytes {
+		return fmt.Errorf("wake repair floor has too many existing messages (%d-byte limit)", maxWakeRepairFloorFileBytes)
+	}
+	return writeWakeMetadataFile(wakeRepairFloorPath(root, me), data, "wake repair floor")
+}
+
+func readWakeRepairFloor(root, me string) (wakeRepairFloor, bool, error) {
+	path := wakeRepairFloorPath(root, me)
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return wakeRepairFloor{}, false, nil
+		}
+		return wakeRepairFloor{}, true, fmt.Errorf("stat wake repair floor: %w", err)
+	}
+	if err := validateWakeRepairFloorFile(path, info); err != nil {
+		return wakeRepairFloor{}, true, err
+	}
+	file, err := openWakeMetadataFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return wakeRepairFloor{}, false, nil
+		}
+		return wakeRepairFloor{}, true, fmt.Errorf("open wake repair floor: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return wakeRepairFloor{}, true, fmt.Errorf("stat wake repair floor: %w", err)
+	}
+	if err := validateWakeRepairFloorFile(path, openedInfo); err != nil {
+		return wakeRepairFloor{}, true, err
+	}
+	if !os.SameFile(info, openedInfo) {
+		return wakeRepairFloor{}, true, fmt.Errorf("wake repair floor %s changed while opening", path)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxWakeRepairFloorFileBytes+1))
+	if err != nil {
+		return wakeRepairFloor{}, true, fmt.Errorf("read wake repair floor: %w", err)
+	}
+	if len(data) > maxWakeRepairFloorFileBytes {
+		return wakeRepairFloor{}, true, fmt.Errorf("wake repair floor %s is too large", path)
+	}
+	var floor wakeRepairFloor
+	if err := json.Unmarshal(data, &floor); err != nil {
+		return wakeRepairFloor{}, true, fmt.Errorf("parse wake repair floor: %w", err)
+	}
+	return floor, true, nil
+}
+
+func validateWakeRepairFloorFile(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("wake repair floor %s must not be a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("wake repair floor %s must be a regular file", path)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return fmt.Errorf("wake repair floor %s mode is %o, want 0600", path, got)
+	}
+	if err := validateWakeTargetPathOwnership("wake repair floor", path, info); err != nil {
+		return err
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return fmt.Errorf("resolve wake repair floor: %w", err)
+	}
+	return validateWakeTargetParentDirs("wake repair floor", resolvedPath)
+}
+
+func validateWakeRepairFloor(
+	floor wakeRepairFloor,
+	root, me string,
+	lock wakeLock,
+	target wakeTarget,
+) error {
+	if floor.Schema != wakeRepairFloorSchema {
+		return fmt.Errorf("wake repair floor schema %d unsupported", floor.Schema)
+	}
+	if floor.Root != canonicalWakeRoot(root) {
+		return fmt.Errorf("wake repair floor root mismatch")
+	}
+	if verifyTreeIdentityToken(root, floor.RootIdentity) != TreeRelationSame {
+		return fmt.Errorf("wake repair floor root identity mismatch")
+	}
+	if floor.Agent != me {
+		return fmt.Errorf("wake repair floor agent mismatch")
+	}
+	if strings.TrimSpace(floor.Generation) == "" || floor.Generation != lock.Generation {
+		return fmt.Errorf("wake repair floor generation mismatch")
+	}
+	if (floor.SourceGeneration == "") != (floor.SourceFloorDigest == "") {
+		return fmt.Errorf("wake repair floor source lineage is incomplete")
+	}
+	if floor.SourceGeneration != "" {
+		if floor.SourceGeneration == floor.Generation {
+			return fmt.Errorf("wake repair floor source generation matches child generation")
+		}
+		if !strings.HasPrefix(floor.SourceFloorDigest, "sha256:") {
+			return fmt.Errorf("wake repair floor source digest is invalid")
+		}
+	}
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		return err
+	}
+	if floor.TargetDigest == "" || floor.TargetDigest != targetDigest || floor.TargetDigest != lock.TargetDigest {
+		return fmt.Errorf("wake repair floor target mismatch")
+	}
+	if floor.BootID == "" || lock.BootID == "" ||
+		compareWakeBootID(floor.BootID, wakeProcessInfo{BootID: lock.BootID}) != bootIDMatch {
+		return fmt.Errorf("wake repair floor boot identity mismatch")
+	}
+	if !sameWakeOwner(floor.Owner, target.Owner) || !sameWakeOwner(floor.Owner, lock.Owner) {
+		return fmt.Errorf("wake repair floor owner mismatch")
+	}
+	if floor.Existing == nil {
+		return fmt.Errorf("wake repair floor existing-message map is missing")
+	}
+	for name := range floor.Existing {
+		if filepath.Base(name) != name || strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
+			return fmt.Errorf("wake repair floor contains invalid message filename %q", name)
+		}
+	}
+	return nil
+}
+
+func validateWakeRepairFloorCurrentBoot(floor wakeRepairFloor) error {
+	currentBootID := currentWakeBootID()
+	if floor.BootID == "" || currentBootID == "" ||
+		compareWakeBootID(floor.BootID, wakeProcessInfo{BootID: currentBootID}) != bootIDMatch {
+		return fmt.Errorf("wake repair floor boot identity does not match the current boot")
+	}
+	return nil
+}
+
+func validateWakeRepairFloorAvailable(
+	root, me string,
+	inspection wakeLockInspection,
+	target wakeTarget,
+) error {
+	floor, exists, err := readWakeRepairFloor(root, me)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("wake repair floor is missing")
+	}
+	if err := validateWakeRepairFloor(floor, root, me, inspection.Lock, target); err != nil {
+		return err
+	}
+	return validateWakeRepairFloorCurrentBoot(floor)
+}
+
+func validateWakeRepairLineageGuarded(
+	root, me string,
+	target wakeTarget,
+	lineage *wakeRepairLineage,
+) error {
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = agentDir.Close() }()
+	return agentDir.withFD(func(dirfd int) error {
+		return validateWakeRepairLineageGuardedAt(
+			dirfd,
+			agentDir,
+			root,
+			me,
+			target,
+			lineage,
+		)
+	})
+}
+
+func validateWakeRepairLineageGuardedAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root, me string,
+	target wakeTarget,
+	lineage *wakeRepairLineage,
+) error {
+	if lineage == nil {
+		return nil
+	}
+	if lineage.source.Root != canonicalWakeRoot(root) ||
+		lineage.source.Agent != me ||
+		lineage.source.DeadGeneration != lineage.floor.Generation ||
+		lineage.source.RootIdentity != lineage.floor.RootIdentity ||
+		lineage.source.BootID != lineage.floor.BootID ||
+		!sameWakeOwner(lineage.source.Owner, lineage.floor.Owner) {
+		return fmt.Errorf("wake repair source lineage is inconsistent")
+	}
+	if err := revalidateWakeRepairRootIdentity(root, lineage.source.RootIdentity); err != nil {
+		return err
+	}
+	current, exists, err := readWakeRepairFloorAt(dirfd, agentDir)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("wake repair floor disappeared before acquisition")
+	}
+	proc := inspectWakeProcess(os.Getpid())
+	source := wakeLock{
+		Root:         canonicalWakeRoot(root),
+		Agent:        me,
+		Generation:   lineage.floor.Generation,
+		TargetDigest: lineage.floor.TargetDigest,
+		BootID:       proc.BootID,
+		Owner:        target.Owner,
+	}
+	if err := validateWakeRepairFloor(current, root, me, source, target); err != nil {
+		return err
+	}
+	digest, err := wakeRepairFloorDigest(current)
+	if err != nil {
+		return err
+	}
+	if digest != lineage.source.SourceFloorDigest {
+		return fmt.Errorf("wake repair floor changed before acquisition")
+	}
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		return err
+	}
+	if targetDigest != lineage.source.SourceTargetDigest {
+		return fmt.Errorf("wake repair target changed before acquisition")
+	}
+	return nil
+}
+
+func removeWakeRepairFloorGuarded(root, me string) error {
+	if err := os.Remove(wakeRepairFloorPath(root, me)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove wake repair floor: %w", err)
+	}
+	return nil
+}
+
+func removeWakeRepairFloorIfGenerationGuarded(root, me, generation string) error {
+	floor, exists, err := readWakeRepairFloor(root, me)
+	if err != nil {
+		return err
+	}
+	if !exists || floor.Generation != generation {
+		return nil
+	}
+	return removeWakeRepairFloorGuarded(root, me)
+}

--- a/internal/cli/wake_repair_floor_unix_test.go
+++ b/internal/cli/wake_repair_floor_unix_test.go
@@ -1,0 +1,499 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestWakeRepairFloorRoundTripPreservesExactFileIdentity(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	messagePath := filepath.Join(fsq.AgentInboxNew(root, "codex"), "startup.md")
+	if err := os.WriteFile(messagePath, []byte("startup"), 0o600); err != nil {
+		t.Fatalf("write startup message: %v", err)
+	}
+	existing, err := snapshotWakeExistingMessages(root, "codex")
+	if err != nil {
+		t.Fatalf("snapshot existing messages: %v", err)
+	}
+	injector := writeExecutableForTest(t, "repair-floor-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	lock := bindWakeLockToTarget(wakeLock{
+		Root:       canonicalWakeRoot(root),
+		Agent:      "codex",
+		Generation: "generation-one",
+		BootID:     wakeRepairTestBootID,
+	}, target)
+
+	floor, err := newWakeRepairFloor(root, "codex", lock, target, existing)
+	if err != nil {
+		t.Fatalf("newWakeRepairFloor: %v", err)
+	}
+	if err := writeWakeRepairFloor(root, "codex", floor); err != nil {
+		t.Fatalf("writeWakeRepairFloor: %v", err)
+	}
+	got, exists, err := readWakeRepairFloor(root, "codex")
+	if err != nil || !exists {
+		t.Fatalf("readWakeRepairFloor: exists=%v err=%v", exists, err)
+	}
+	if err := validateWakeRepairFloor(got, root, "codex", lock, target); err != nil {
+		t.Fatalf("validateWakeRepairFloor: %v", err)
+	}
+	if len(got.Existing) != 1 || got.Existing["startup.md"] != existing["startup.md"] {
+		t.Fatalf("persisted identities = %#v, want %#v", got.Existing, existing)
+	}
+	info, err := os.Stat(wakeRepairFloorPath(root, "codex"))
+	if err != nil {
+		t.Fatalf("stat wake repair floor: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("wake repair floor mode = %o, want 0600", got)
+	}
+}
+
+func TestWakeRepairFloorRejectsAuthorityMismatch(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	injector := writeExecutableForTest(t, "repair-floor-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	lock := bindWakeLockToTarget(wakeLock{
+		Root:       canonicalWakeRoot(root),
+		Agent:      "codex",
+		Generation: "generation-one",
+		BootID:     wakeRepairTestBootID,
+	}, target)
+	floor, err := newWakeRepairFloor(root, "codex", lock, target, nil)
+	if err != nil {
+		t.Fatalf("newWakeRepairFloor: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*wakeRepairFloor, *wakeLock, *wakeTarget)
+		want   string
+	}{
+		{
+			name:   "generation",
+			mutate: func(floor *wakeRepairFloor, _ *wakeLock, _ *wakeTarget) { floor.Generation = "generation-two" },
+			want:   "generation mismatch",
+		},
+		{
+			name:   "target",
+			mutate: func(_ *wakeRepairFloor, _ *wakeLock, target *wakeTarget) { target.InjectArgs = []string{"other"} },
+			want:   "target mismatch",
+		},
+		{
+			name: "boot",
+			mutate: func(_ *wakeRepairFloor, lock *wakeLock, _ *wakeTarget) {
+				lock.BootID = "22222222-2222-2222-2222-222222222222"
+			},
+			want: "boot identity mismatch",
+		},
+		{
+			name:   "root identity",
+			mutate: func(floor *wakeRepairFloor, _ *wakeLock, _ *wakeTarget) { floor.RootIdentity = "invalid" },
+			want:   "root identity mismatch",
+		},
+		{
+			name: "owner",
+			mutate: func(floor *wakeRepairFloor, _ *wakeLock, _ *wakeTarget) {
+				floor.Owner = &wakeOwner{PID: 42}
+			},
+			want: "owner mismatch",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			changedFloor := floor
+			changedFloor.Existing = cloneWakeFileIdentities(floor.Existing)
+			changedLock := lock
+			changedTarget := target
+			tc.mutate(&changedFloor, &changedLock, &changedTarget)
+			err := validateWakeRepairFloor(changedFloor, root, "codex", changedLock, changedTarget)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadWakeRepairFloorRejectsSymlink(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	target := filepath.Join(secureTempDirForTest(t), "floor")
+	if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	if err := os.Symlink(target, wakeRepairFloorPath(root, "codex")); err != nil {
+		t.Fatalf("symlink floor: %v", err)
+	}
+
+	_, exists, err := readWakeRepairFloor(root, "codex")
+	if !exists {
+		t.Fatal("symlink floor should be reported present")
+	}
+	if err == nil || !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("error = %v, want symlink refusal", err)
+	}
+}
+
+func TestFreshWakeWinsRepairGapWithoutReusingDeadFloor(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	injector := writeExecutableForTest(t, "repair-floor-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	sourceLock := bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Root:       canonicalWakeRoot(root),
+		Agent:      "codex",
+		Generation: "dead-generation",
+		BootID:     wakeRepairTestBootID,
+	}, target)
+	writeWakeLockForTest(t, root, "codex", sourceLock)
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	sourceFloor := writeWakeRepairFloorForTest(t, root, "codex", target, map[string]wakeFileIdentity{
+		"startup.md": {Device: 1, Inode: 2, CTimeSec: 3, CTimeNsec: 4},
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == os.Getpid() {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "self-start",
+				BootID:     wakeRepairTestBootID,
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+			}
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	if err := os.Remove(filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")); err != nil {
+		t.Fatalf("remove dead lock: %v", err)
+	}
+	digest, err := wakeRepairFloorDigest(sourceFloor)
+	if err != nil {
+		t.Fatalf("wakeRepairFloorDigest: %v", err)
+	}
+	lineage := &wakeRepairLineage{
+		source: wakeRepairSource{
+			Root:               sourceFloor.Root,
+			RootIdentity:       sourceFloor.RootIdentity,
+			Agent:              sourceFloor.Agent,
+			DeadGeneration:     sourceFloor.Generation,
+			BootID:             sourceFloor.BootID,
+			Owner:              sourceFloor.Owner,
+			SourceTargetDigest: sourceFloor.TargetDigest,
+			SourceFloorDigest:  digest,
+		},
+		floor: sourceFloor,
+	}
+
+	freshCleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err != nil {
+		t.Fatalf("fresh wake acquisition: %v", err)
+	}
+	defer freshCleanup()
+	if _, exists, err := readWakeRepairFloor(root, "codex"); err != nil || exists {
+		t.Fatalf("fresh acquisition must clear dead floor: exists=%v err=%v", exists, err)
+	}
+
+	repairCleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:        &target,
+		wakeMode:      wakeTargetInjectVia,
+		repairLineage: lineage,
+	})
+	if repairCleanup != nil {
+		repairCleanup()
+	}
+	if err == nil || !strings.Contains(err.Error(), "changed before repair acquisition") {
+		t.Fatalf("repair acquisition error = %v, want takeover refusal", err)
+	}
+}
+
+func TestAcquireWakeLockRejectsOwnerBearingRepairLineageBeforeAuthoritativeRouting(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "repair-floor-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &wakeOwner{PID: 4242}
+
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:        &target,
+		wakeMode:      wakeTargetInjectVia,
+		repairLineage: &wakeRepairLineage{},
+	})
+	if cleanup != nil {
+		cleanup()
+	}
+	if err == nil || !strings.Contains(err.Error(), "owner-bearing wake state requires") {
+		t.Fatalf("acquireWakeLockWithOptions error = %v, want owner-bearing repair refusal", err)
+	}
+}
+
+func TestValidateWakeRepairLineageGuardedRejectsMissingOrChangedFloor(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(t *testing.T, root string, floor wakeRepairFloor)
+		wantReason string
+	}{
+		{
+			name: "floor disappeared",
+			mutate: func(t *testing.T, root string, _ wakeRepairFloor) {
+				t.Helper()
+				if err := os.Remove(wakeRepairFloorPath(root, "codex")); err != nil {
+					t.Fatalf("remove repair floor: %v", err)
+				}
+			},
+			wantReason: "disappeared before acquisition",
+		},
+		{
+			name: "floor digest changed",
+			mutate: func(t *testing.T, root string, floor wakeRepairFloor) {
+				t.Helper()
+				floor.Existing["changed.md"] = wakeFileIdentity{Device: 5, Inode: 6, CTimeSec: 7, CTimeNsec: 8}
+				if err := writeWakeRepairFloor(root, "codex", floor); err != nil {
+					t.Fatalf("write changed repair floor: %v", err)
+				}
+			},
+			wantReason: "changed before acquisition",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "repair-floor-injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+			writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+				PID:        4242,
+				Generation: "dead-generation",
+				BootID:     wakeRepairTestBootID,
+			}, target))
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatalf("writeWakeTarget: %v", err)
+			}
+			floor := writeWakeRepairFloorForTest(t, root, "codex", target, map[string]wakeFileIdentity{
+				"startup.md": {Device: 1, Inode: 2, CTimeSec: 3, CTimeNsec: 4},
+			})
+			digest, err := wakeRepairFloorDigest(floor)
+			if err != nil {
+				t.Fatalf("wakeRepairFloorDigest: %v", err)
+			}
+			lineage := &wakeRepairLineage{
+				source: wakeRepairSource{
+					Root:               floor.Root,
+					RootIdentity:       floor.RootIdentity,
+					Agent:              floor.Agent,
+					DeadGeneration:     floor.Generation,
+					BootID:             floor.BootID,
+					Owner:              floor.Owner,
+					SourceTargetDigest: floor.TargetDigest,
+					SourceFloorDigest:  digest,
+				},
+				floor: floor,
+			}
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid == os.Getpid() {
+					return wakeProcessInfo{PID: pid, Running: true, BootID: wakeRepairTestBootID}
+				}
+				return wakeProcessInfo{PID: pid, Running: false}
+			})
+
+			tc.mutate(t, root, floor)
+			err = validateWakeRepairLineageGuarded(root, "codex", target, lineage)
+			if err == nil || !strings.Contains(err.Error(), tc.wantReason) {
+				t.Fatalf("validateWakeRepairLineageGuarded error = %v, want %q", err, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestWakeCleanupRemovesOnlyItsRepairFloorGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	injector := writeExecutableForTest(t, "repair-floor-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "self-start",
+			BootID:     wakeRepairTestBootID,
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	cleanup, err := acquireWakeLock(root, "codex", &target)
+	if err != nil {
+		t.Fatalf("acquireWakeLock: %v", err)
+	}
+	current := inspectWakeLock(root, "codex")
+	floor, err := newWakeRepairFloor(root, "codex", current.Lock, target, nil)
+	if err != nil {
+		t.Fatalf("newWakeRepairFloor: %v", err)
+	}
+	if err := writeWakeRepairFloor(root, "codex", floor); err != nil {
+		t.Fatalf("writeWakeRepairFloor: %v", err)
+	}
+	if err := removeWakeRepairFloorIfGenerationGuarded(root, "codex", "replacement-generation"); err != nil {
+		t.Fatalf("remove replacement generation: %v", err)
+	}
+	if _, exists, err := readWakeRepairFloor(root, "codex"); err != nil || !exists {
+		t.Fatalf("wrong generation removed floor: exists=%v err=%v", exists, err)
+	}
+
+	cleanup()
+	if _, err := os.Stat(filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")); !os.IsNotExist(err) {
+		t.Fatalf("wake lock survived cleanup: %v", err)
+	}
+	if _, err := os.Stat(wakeRepairFloorPath(root, "codex")); !os.IsNotExist(err) {
+		t.Fatalf("wake repair floor survived cleanup: %v", err)
+	}
+}
+
+func TestRepairWakeNormalCleanupPreservesFloorReplacedBeforeCleanup(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate bool
+	}{
+		{name: "byte-identical new inode"},
+		{name: "same generation and source digest changed bytes", mutate: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+			injector := writeExecutableForTest(t, "repair-cleanup-injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+			sourceLock := bindWakeLockToTarget(wakeLock{
+				PID:        4242,
+				Root:       canonicalWakeRoot(root),
+				Agent:      "codex",
+				Generation: "dead-generation",
+				BootID:     wakeRepairTestBootID,
+			}, target)
+			writeWakeLockForTest(t, root, "codex", sourceLock)
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatalf("writeWakeTarget: %v", err)
+			}
+			sourceFloor := writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+			sourceFloorDigest, err := wakeRepairFloorDigest(sourceFloor)
+			if err != nil {
+				t.Fatalf("digest source floor: %v", err)
+			}
+			lineage := &wakeRepairLineage{
+				source: wakeRepairSource{
+					Root:               sourceFloor.Root,
+					RootIdentity:       sourceFloor.RootIdentity,
+					Agent:              sourceFloor.Agent,
+					DeadGeneration:     sourceFloor.Generation,
+					BootID:             sourceFloor.BootID,
+					SourceTargetDigest: sourceFloor.TargetDigest,
+					SourceFloorDigest:  sourceFloorDigest,
+				},
+				floor: sourceFloor,
+			}
+			if err := os.Remove(filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")); err != nil {
+				t.Fatalf("remove dead wake lock: %v", err)
+			}
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid == os.Getpid() {
+					return wakeProcessInfo{
+						PID:        pid,
+						Running:    true,
+						StartToken: "self-start",
+						BootID:     wakeRepairTestBootID,
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+					}
+				}
+				return wakeProcessInfo{PID: pid, Running: false}
+			})
+
+			var authority wakeRepairFloorAuthority
+			cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+				target:               &target,
+				wakeMode:             wakeTargetInjectVia,
+				repairLineage:        lineage,
+				repairFloorAuthority: &authority,
+			})
+			if err != nil {
+				t.Fatalf("acquire repair wake lock: %v", err)
+			}
+			current := inspectWakeLock(root, "codex")
+			childFloor, err := newInheritedWakeRepairFloor(
+				lineage.source,
+				current.Lock,
+				target,
+				sourceFloor.Existing,
+			)
+			if err != nil {
+				t.Fatalf("new inherited child floor: %v", err)
+			}
+			agentDir, err := openWakeAgentDir(root, "codex")
+			if err != nil {
+				t.Fatalf("open child agent directory: %v", err)
+			}
+			err = agentDir.withFD(func(dirfd int) error {
+				var captureErr error
+				authority, captureErr = writeWakeRepairFloorAndCaptureAuthorityAt(
+					dirfd,
+					agentDir,
+					root,
+					childFloor,
+				)
+				return captureErr
+			})
+			_ = agentDir.Close()
+			if err != nil {
+				t.Fatalf("publish child floor: %v", err)
+			}
+			replacement := replaceWakeRepairFloorWithNewInodeForTest(
+				t,
+				root,
+				"codex",
+				tc.mutate,
+			)
+
+			cleanup()
+
+			if _, err := os.Lstat(filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")); !os.IsNotExist(err) {
+				t.Fatalf("repair child lock survived normal cleanup: %v", err)
+			}
+			got, err := os.ReadFile(wakeRepairFloorPath(root, "codex"))
+			if err != nil {
+				t.Fatalf("replacement wake repair floor was removed: %v", err)
+			}
+			if !bytes.Equal(got, replacement) {
+				t.Fatalf("replacement wake repair floor changed during cleanup")
+			}
+		})
+	}
+}

--- a/internal/cli/wake_repair_handoff_darwin.go
+++ b/internal/cli/wake_repair_handoff_darwin.go
@@ -1,0 +1,210 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	envWakeRepairChildControlFD  = "AMQ_WAKE_REPAIR_CHILD_CONTROL_FD"
+	wakeRepairChildControlStop   = "STOP"
+	wakeRepairChildControlDetach = "DETACH"
+)
+
+var (
+	writeWakeRepairDarwinChildControl = writeWakeRepairChildControl
+	closeWakeRepairDarwinChildControl = func(file *os.File) error { return file.Close() }
+	killWakeRepairDarwinChild         = func(process *os.Process) error { return process.Kill() }
+)
+
+func prepareWakeRepairChildCapabilityPlatform(cmd *exec.Cmd) (*wakeRepairChildCapability, error) {
+	if cmd == nil {
+		return nil, fmt.Errorf("wake repair child command is missing")
+	}
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create wake repair child control pipe: %w", err)
+	}
+	childFD := 3 + len(cmd.ExtraFiles)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, readEnd)
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = setEnvVar(unsetEnvVar(cmd.Env, envWakeRepairChildControlFD),
+		envWakeRepairChildControlFD, strconv.Itoa(childFD))
+
+	var mutex sync.Mutex
+	bound := false
+	detached := false
+	stopped := false
+	writeClosed := false
+	var process *os.Process
+	closeWrite := func() error {
+		if writeClosed {
+			return nil
+		}
+		if err := closeWakeRepairDarwinChildControl(writeEnd); err != nil {
+			return err
+		}
+		writeClosed = true
+		return nil
+	}
+	return &wakeRepairChildCapability{
+		bind: func(child *os.Process) error {
+			mutex.Lock()
+			defer mutex.Unlock()
+			if child == nil || child.Pid <= 0 {
+				return fmt.Errorf("wake repair child process is missing")
+			}
+			if bound || detached || stopped {
+				return fmt.Errorf("wake repair child control capability is already bound")
+			}
+			bound = true
+			process = child
+			if err := readEnd.Close(); err != nil {
+				return fmt.Errorf("close parent copy of wake repair child control fd: %w", err)
+			}
+			return nil
+		},
+		stop: func() error {
+			mutex.Lock()
+			defer mutex.Unlock()
+			if !bound || detached || stopped || process == nil {
+				return fmt.Errorf("wake repair child control capability is unavailable")
+			}
+			if !writeClosed {
+				_ = writeWakeRepairDarwinChildControl(writeEnd, wakeRepairChildControlStop)
+				_ = closeWrite()
+			}
+			if err := killWakeRepairDarwinChild(process); err != nil && !errors.Is(err, os.ErrProcessDone) {
+				return fmt.Errorf("kill exact wake repair child: %w", err)
+			}
+			stopped = true
+			return nil
+		},
+		detach: func() error {
+			// The caller is responsible for invoking this only after the exact
+			// admitted acknowledgement has been received.
+			mutex.Lock()
+			defer mutex.Unlock()
+			if !bound || detached || stopped || writeClosed {
+				return fmt.Errorf("wake repair child control capability is unavailable")
+			}
+			if err := writeWakeRepairDarwinChildControl(writeEnd, wakeRepairChildControlDetach); err != nil {
+				return err
+			}
+			// A complete DETACH frame is observable by the child immediately.
+			// Commit detachment before closing the writer: a later close error
+			// cannot restore exact stop authority after the child may already
+			// have disarmed STOP/EOF.
+			detached = true
+			// Closing is best-effort after that commit. Close may be retried by
+			// capability cleanup, but its error cannot make DETACH fail.
+			_ = closeWrite()
+			return nil
+		},
+		close: func() error {
+			mutex.Lock()
+			defer mutex.Unlock()
+			var readErr error
+			if !bound {
+				readErr = readEnd.Close()
+			}
+			// Closing without DETACH deliberately produces EOF in the child,
+			// which is fail-closed before admission.
+			writeErr := closeWrite()
+			return errors.Join(readErr, writeErr)
+		},
+	}, nil
+}
+
+func writeWakeRepairChildControl(writer io.Writer, command string) error {
+	if command != wakeRepairChildControlStop && command != wakeRepairChildControlDetach {
+		return fmt.Errorf("invalid wake repair child control %q", command)
+	}
+	data := []byte(command + "\n")
+	for len(data) > 0 {
+		n, err := writer.Write(data)
+		if err != nil {
+			return fmt.Errorf("write wake repair child control: %w", err)
+		}
+		if n <= 0 {
+			return fmt.Errorf("write wake repair child control: %w", io.ErrShortWrite)
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func wakeRepairChildStopFromEnv() (<-chan struct{}, func(), error) {
+	raw := strings.TrimSpace(os.Getenv(envWakeRepairChildControlFD))
+	if raw == "" {
+		return nil, func() {}, nil
+	}
+	fd, err := strconv.Atoi(raw)
+	if err != nil || fd < 3 {
+		return nil, nil, fmt.Errorf("%s is invalid", envWakeRepairChildControlFD)
+	}
+	// os/exec obtains ExtraFiles through File.Fd, which deliberately restores
+	// blocking mode. Restore nonblocking mode before os.NewFile so Go registers
+	// the inherited pipe with its poller; then a concurrent Close interrupts the
+	// startup read and cleanup can wait for the watcher without deadlocking.
+	if err := unix.SetNonblock(fd, true); err != nil {
+		_ = unix.Close(fd)
+		return nil, nil, fmt.Errorf("make wake repair child control fd nonblocking: %w", err)
+	}
+	if err := setWakeRepairFDCloseOnExec(fd, "child control"); err != nil {
+		_ = unix.Close(fd)
+		return nil, nil, err
+	}
+	file := os.NewFile(uintptr(fd), "wake-repair-child-control")
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, nil, fmt.Errorf("%s fd is unavailable", envWakeRepairChildControlFD)
+	}
+	stop, finished := watchWakeRepairDarwinChildControl(file)
+	cleanup := func() {
+		_ = file.Close()
+		<-finished
+	}
+	return stop, cleanup, nil
+}
+
+func watchWakeRepairDarwinChildControl(file *os.File) (<-chan struct{}, <-chan struct{}) {
+	stop := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		defer func() { _ = file.Close() }()
+		reader := bufio.NewReaderSize(file, 32)
+		line, err := reader.ReadString('\n')
+		switch {
+		case err == nil && line == wakeRepairChildControlDetach+"\n":
+			return
+		case err == nil && line == wakeRepairChildControlStop+"\n":
+			close(stop)
+			return
+		case errors.Is(err, io.EOF):
+			// EOF is authoritative only during startup, before a validated
+			// DETACH. Descendant-held descriptors are irrelevant after detach.
+			close(stop)
+			return
+		default:
+			// Malformed, partial, and failed control reads stop the unadmitted
+			// child rather than allowing it to scan or inject.
+			close(stop)
+		}
+	}()
+	return stop, finished
+}

--- a/internal/cli/wake_repair_handoff_darwin_test.go
+++ b/internal/cli/wake_repair_handoff_darwin_test.go
@@ -1,0 +1,355 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestDarwinWakeRepairChildControlStopsOnExplicitStop(t *testing.T) {
+	assertDarwinWakeRepairChildControl(t, wakeRepairChildControlStop, true)
+}
+
+func TestDarwinWakeRepairChildControlStopsOnEOFBeforeDetach(t *testing.T) {
+	assertDarwinWakeRepairChildControl(t, "", true)
+}
+
+func TestDarwinWakeRepairChildControlDetachDisarmsEOF(t *testing.T) {
+	assertDarwinWakeRepairChildControl(t, wakeRepairChildControlDetach, false)
+}
+
+func TestDarwinWakeRepairChildCleanupInterruptsBlockingControlRead(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer.Close() }()
+	childFD, err := unix.Dup(int(reader.Fd()))
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("duplicate blocking child control fd: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		_ = unix.Close(childFD)
+		t.Fatalf("close original child control reader: %v", err)
+	}
+	if err := unix.SetNonblock(childFD, false); err != nil {
+		_ = unix.Close(childFD)
+		t.Fatalf("force inherited child control fd blocking: %v", err)
+	}
+	flags, err := unix.FcntlInt(uintptr(childFD), unix.F_GETFL, 0)
+	if err != nil {
+		_ = unix.Close(childFD)
+		t.Fatalf("inspect blocking child control fd: %v", err)
+	}
+	if flags&unix.O_NONBLOCK != 0 {
+		_ = unix.Close(childFD)
+		t.Fatal("child control regression fixture is unexpectedly nonblocking")
+	}
+	t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(childFD))
+
+	stop, cleanup, err := wakeRepairChildStopFromEnv()
+	if err != nil {
+		_ = unix.Close(childFD)
+		t.Fatalf("start child control watcher: %v", err)
+	}
+	flags, err = unix.FcntlInt(uintptr(childFD), unix.F_GETFL, 0)
+	if err != nil {
+		cleanup()
+		t.Fatalf("inspect initialized child control fd: %v", err)
+	}
+	if flags&unix.O_NONBLOCK == 0 {
+		_ = writer.Close()
+		cleanup()
+		t.Fatal("inherited child control fd remained blocking")
+	}
+	fdFlags, err := unix.FcntlInt(uintptr(childFD), unix.F_GETFD, 0)
+	if err != nil {
+		_ = writer.Close()
+		cleanup()
+		t.Fatalf("inspect initialized child control descriptor flags: %v", err)
+	}
+	if fdFlags&unix.FD_CLOEXEC == 0 {
+		_ = writer.Close()
+		cleanup()
+		t.Fatal("inherited child control fd is not close-on-exec")
+	}
+	assertWakeRepairDescriptorsClosedInInjector(t, []int{childFD})
+	select {
+	case <-stop:
+		cleanup()
+		t.Fatal("absent child control byte stopped the child")
+	case <-time.After(50 * time.Millisecond):
+	}
+	finished := make(chan struct{})
+	go func() {
+		cleanup()
+		close(finished)
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(250 * time.Millisecond):
+		_ = writer.Close()
+		<-finished
+		t.Fatal("child control cleanup did not interrupt its blocked read")
+	}
+	select {
+	case <-stop:
+	default:
+		t.Fatal("interrupted pre-admission child control did not fail closed")
+	}
+}
+
+func assertDarwinWakeRepairChildControl(t *testing.T, command string, wantStop bool) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop, finished := watchWakeRepairDarwinChildControl(reader)
+	if command != "" {
+		if _, err := writer.Write([]byte(command + "\n")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("control watcher did not finish")
+	}
+	select {
+	case <-stop:
+		if !wantStop {
+			t.Fatal("detach unexpectedly stopped admitted child")
+		}
+	default:
+		if wantStop {
+			t.Fatal("stop was not signaled")
+		}
+	}
+}
+
+func TestDarwinWakeRepairChildCapabilityEmitsStopAndDetach(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		act  func(*wakeRepairChildCapability) error
+		want string
+	}{
+		{name: "stop", act: func(c *wakeRepairChildCapability) error { return c.Stop() }, want: wakeRepairChildControlStop},
+		{name: "detach", act: func(c *wakeRepairChildCapability) error { return c.Detach() }, want: wakeRepairChildControlDetach},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			oldKill := killWakeRepairDarwinChild
+			killWakeRepairDarwinChild = func(*os.Process) error { return nil }
+			t.Cleanup(func() { killWakeRepairDarwinChild = oldKill })
+
+			cmd := exec.Command("true")
+			capability, err := prepareWakeRepairChildCapabilityPlatform(cmd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = capability.Close() }()
+			if len(cmd.ExtraFiles) != 1 {
+				t.Fatalf("extra files = %d, want 1", len(cmd.ExtraFiles))
+			}
+			childFD, err := unix.Dup(int(cmd.ExtraFiles[0].Fd()))
+			if err != nil {
+				t.Fatalf("duplicate child control fd: %v", err)
+			}
+			childReader := os.NewFile(uintptr(childFD), "test-child-control")
+			defer func() { _ = childReader.Close() }()
+			if err := capability.Bind(&os.Process{Pid: 4242}); err != nil {
+				t.Fatal(err)
+			}
+			if err := test.act(capability); err != nil {
+				t.Fatal(err)
+			}
+			var line [16]byte
+			n, err := childReader.Read(line[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := string(line[:n]); got != test.want+"\n" {
+				t.Fatalf("control = %q, want %q", got, test.want+"\\n")
+			}
+		})
+	}
+}
+
+func TestDarwinWakeRepairChildCapabilityFullDetachWriteIsIrreversibleAcrossCloseFailure(t *testing.T) {
+	cmd := exec.Command("true")
+	capability, err := prepareWakeRepairChildCapabilityPlatform(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = capability.Close() }()
+	childFD, err := unix.Dup(int(cmd.ExtraFiles[0].Fd()))
+	if err != nil {
+		t.Fatalf("duplicate child control fd: %v", err)
+	}
+	childReader := os.NewFile(uintptr(childFD), "test-child-control")
+	defer func() { _ = childReader.Close() }()
+
+	oldClose := closeWakeRepairDarwinChildControl
+	oldKill := killWakeRepairDarwinChild
+	closeFailure := errors.New("injected child control close failure")
+	closeCalls := 0
+	closeWakeRepairDarwinChildControl = func(file *os.File) error {
+		closeCalls++
+		if closeCalls == 1 {
+			return closeFailure
+		}
+		return file.Close()
+	}
+	var killed *os.Process
+	killWakeRepairDarwinChild = func(process *os.Process) error {
+		killed = process
+		return nil
+	}
+	t.Cleanup(func() {
+		closeWakeRepairDarwinChildControl = oldClose
+		killWakeRepairDarwinChild = oldKill
+	})
+
+	child := &os.Process{Pid: 4242}
+	if err := capability.Bind(child); err != nil {
+		t.Fatal(err)
+	}
+	if err := capability.Detach(); err != nil {
+		t.Fatalf("detach after complete write and close failure: %v", err)
+	}
+	if err := capability.Stop(); err == nil {
+		t.Fatal("Stop unexpectedly retained authority after complete DETACH write")
+	}
+	if killed != nil {
+		t.Fatalf("killed process = %p, want no kill after complete DETACH write", killed)
+	}
+}
+
+func TestDarwinWakeRepairChildCapabilityPartialDetachWriteRetainsExactStopAuthority(t *testing.T) {
+	cmd := exec.Command("true")
+	capability, err := prepareWakeRepairChildCapabilityPlatform(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = capability.Close() }()
+
+	oldWrite := writeWakeRepairDarwinChildControl
+	oldKill := killWakeRepairDarwinChild
+	writeFailure := errors.New("injected partial DETACH write failure")
+	writeCalls := 0
+	writeWakeRepairDarwinChildControl = func(_ io.Writer, command string) error {
+		writeCalls++
+		if writeCalls == 1 {
+			if command != wakeRepairChildControlDetach {
+				t.Fatalf("first control command = %q, want DETACH", command)
+			}
+			return writeFailure
+		}
+		if command != wakeRepairChildControlStop {
+			t.Fatalf("fallback control command = %q, want STOP", command)
+		}
+		return nil
+	}
+	var killed *os.Process
+	killWakeRepairDarwinChild = func(process *os.Process) error {
+		killed = process
+		return nil
+	}
+	t.Cleanup(func() {
+		writeWakeRepairDarwinChildControl = oldWrite
+		killWakeRepairDarwinChild = oldKill
+	})
+
+	child := &os.Process{Pid: 4242}
+	if err := capability.Bind(child); err != nil {
+		t.Fatal(err)
+	}
+	if err := capability.Detach(); !errors.Is(err, writeFailure) {
+		t.Fatalf("detach error = %v, want %v", err, writeFailure)
+	}
+	if err := capability.Stop(); err != nil {
+		t.Fatalf("fallback exact-child stop: %v", err)
+	}
+	if killed != child {
+		t.Fatalf("killed process = %p, want exact bound child %p", killed, child)
+	}
+	if writeCalls != 2 {
+		t.Fatalf("control writes = %d, want DETACH failure then STOP", writeCalls)
+	}
+}
+
+func TestDarwinWakeRepairChildCapabilityStopsChildBlockedBeforeControlRead(t *testing.T) {
+	cmd := exec.Command("/bin/sleep", "30")
+	capability, err := prepareWakeRepairChildCapabilityPlatform(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = capability.Close() }()
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := capability.Bind(cmd.Process); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatal(err)
+	}
+	if err := capability.Stop(); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("stop child blocked before control read: %v", err)
+	}
+
+	waited := make(chan error, 1)
+	go func() { waited <- cmd.Wait() }()
+	select {
+	case err := <-waited:
+		if err == nil {
+			t.Fatal("blocked child exited successfully after exact stop; want signal termination")
+		}
+	case <-time.After(2 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("exact pre-admission child remained alive after stop")
+	}
+}
+
+func TestDarwinWakeRepairChildCapabilityStopAfterWaitCannotSignalReusedPID(t *testing.T) {
+	cmd := exec.Command("/usr/bin/true")
+	capability, err := prepareWakeRepairChildCapabilityPlatform(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = capability.Close() }()
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := capability.Bind(cmd.Process); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait direct child: %v", err)
+	}
+
+	// os.Process synchronizes Wait with Signal and returns ErrProcessDone
+	// without issuing a PID-based signal after the direct child is reaped.
+	if err := cmd.Process.Kill(); !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("kill reaped direct child = %v, want os.ErrProcessDone", err)
+	}
+	if err := capability.Stop(); err != nil {
+		t.Fatalf("capability stop after direct-child Wait: %v", err)
+	}
+}

--- a/internal/cli/wake_repair_handoff_linux.go
+++ b/internal/cli/wake_repair_handoff_linux.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+)
+
+var (
+	stopWakeRepairChildPidfd  = terminateWakePidfd
+	closeWakeRepairChildPidfd = linuxPidfdClose
+)
+
+func prepareWakeRepairChildCapabilityPlatform(cmd *exec.Cmd) (*wakeRepairChildCapability, error) {
+	if cmd == nil {
+		return nil, fmt.Errorf("wake repair child command is missing")
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	if cmd.SysProcAttr.PidFD != nil {
+		return nil, fmt.Errorf("wake repair child command already owns a pidfd request")
+	}
+
+	// os/exec fills this descriptor as part of child creation. Opening by PID
+	// after Start would allow a short-lived child to exit and the PID to be
+	// reused before the cleanup capability was acquired.
+	pidfd := -1
+	cmd.SysProcAttr.PidFD = &pidfd
+
+	var mutex sync.Mutex
+	bound := false
+	detached := false
+	return &wakeRepairChildCapability{
+		bind: func(process *os.Process) error {
+			mutex.Lock()
+			defer mutex.Unlock()
+			if process == nil || process.Pid <= 0 {
+				return fmt.Errorf("wake repair child process is missing")
+			}
+			if detached {
+				return fmt.Errorf("wake repair child capability is detached")
+			}
+			if pidfd < 0 {
+				return fmt.Errorf("wake repair child pidfd was not returned at process creation")
+			}
+			bound = true
+			return nil
+		},
+		stop: func() error {
+			mutex.Lock()
+			defer mutex.Unlock()
+			if !bound || pidfd < 0 || detached {
+				return fmt.Errorf("wake repair child pidfd is unavailable")
+			}
+			return stopWakeRepairChildPidfd(pidfd)
+		},
+		detach: func() error {
+			mutex.Lock()
+			defer mutex.Unlock()
+			if !bound || pidfd < 0 || detached {
+				return fmt.Errorf("wake repair child pidfd is unavailable")
+			}
+			fd := pidfd
+			// Linux releases the descriptor early in close(2), including when
+			// close later reports an error. Commit detachment before the attempt
+			// and never retain, retry, or signal through the numeric fd again.
+			pidfd = -1
+			detached = true
+			_ = closeWakeRepairChildPidfd(fd)
+			return nil
+		},
+		close: func() error {
+			mutex.Lock()
+			defer mutex.Unlock()
+			if pidfd < 0 {
+				return nil
+			}
+			fd := pidfd
+			pidfd = -1
+			return closeWakeRepairChildPidfd(fd)
+		},
+	}, nil
+}
+
+func wakeRepairChildStopFromEnv() (<-chan struct{}, func(), error) {
+	return nil, func() {}, nil
+}

--- a/internal/cli/wake_repair_handoff_linux_test.go
+++ b/internal/cli/wake_repair_handoff_linux_test.go
@@ -1,0 +1,143 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestLinuxWakeRepairChildCapabilityRetainsAtomicPidfd(t *testing.T) {
+	cmd := exec.Command("true")
+	capability, err := prepareWakeRepairChildCapabilityPlatform(cmd)
+	if err != nil {
+		t.Fatalf("prepare capability: %v", err)
+	}
+	defer func() { _ = capability.Close() }()
+	if cmd.SysProcAttr == nil || cmd.SysProcAttr.PidFD == nil {
+		t.Fatal("repair child did not request pidfd at process creation")
+	}
+	*cmd.SysProcAttr.PidFD = 91
+
+	oldStop := stopWakeRepairChildPidfd
+	oldClose := closeWakeRepairChildPidfd
+	var stopped, closed int
+	stopWakeRepairChildPidfd = func(fd int) error {
+		stopped = fd
+		return nil
+	}
+	closeWakeRepairChildPidfd = func(fd int) error {
+		closed = fd
+		return nil
+	}
+	t.Cleanup(func() {
+		stopWakeRepairChildPidfd = oldStop
+		closeWakeRepairChildPidfd = oldClose
+	})
+
+	if err := capability.Bind(&os.Process{Pid: 4242}); err != nil {
+		t.Fatalf("bind capability: %v", err)
+	}
+	if err := capability.Stop(); err != nil {
+		t.Fatalf("stop capability: %v", err)
+	}
+	if stopped != 91 {
+		t.Fatalf("stopped pidfd = %d, want 91", stopped)
+	}
+	if err := capability.Close(); err != nil {
+		t.Fatalf("close capability: %v", err)
+	}
+	if closed != 91 {
+		t.Fatalf("closed pidfd = %d, want 91", closed)
+	}
+}
+
+func TestLinuxWakeRepairChildCapabilityDetachClosesWithoutStopping(t *testing.T) {
+	cmd := exec.Command("true")
+	capability, err := prepareWakeRepairChildCapabilityPlatform(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	*cmd.SysProcAttr.PidFD = 92
+
+	oldStop := stopWakeRepairChildPidfd
+	oldClose := closeWakeRepairChildPidfd
+	stopWakeRepairChildPidfd = func(int) error {
+		t.Fatal("detach must not stop admitted child")
+		return nil
+	}
+	var closed int
+	closeWakeRepairChildPidfd = func(fd int) error {
+		closed = fd
+		return nil
+	}
+	t.Cleanup(func() {
+		stopWakeRepairChildPidfd = oldStop
+		closeWakeRepairChildPidfd = oldClose
+	})
+
+	if err := capability.Bind(&os.Process{Pid: 4242}); err != nil {
+		t.Fatal(err)
+	}
+	if err := capability.Detach(); err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	if closed != 92 {
+		t.Fatalf("closed pidfd = %d, want 92", closed)
+	}
+}
+
+func TestLinuxWakeRepairChildCapabilityDetachCloseFailureNeverReusesReleasedPidfd(t *testing.T) {
+	cmd := exec.Command("true")
+	capability, err := prepareWakeRepairChildCapabilityPlatform(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	*cmd.SysProcAttr.PidFD = 93
+
+	oldStop := stopWakeRepairChildPidfd
+	oldClose := closeWakeRepairChildPidfd
+	closeFailure := errors.New("injected pidfd close failure")
+	var stopped, closeCalls int
+	released := false
+	stopWakeRepairChildPidfd = func(fd int) error {
+		if released && fd == 93 {
+			t.Fatal("Stop targeted the released and potentially reused pidfd")
+		}
+		stopped = fd
+		return nil
+	}
+	closeWakeRepairChildPidfd = func(fd int) error {
+		if fd != 93 {
+			t.Fatalf("closed pidfd = %d, want 93", fd)
+		}
+		closeCalls++
+		released = true
+		return closeFailure
+	}
+	t.Cleanup(func() {
+		stopWakeRepairChildPidfd = oldStop
+		closeWakeRepairChildPidfd = oldClose
+	})
+
+	if err := capability.Bind(&os.Process{Pid: 4242}); err != nil {
+		t.Fatal(err)
+	}
+	if err := capability.Detach(); err != nil {
+		t.Fatalf("detach after Linux close failure: %v", err)
+	}
+	if err := capability.Stop(); err == nil {
+		t.Fatal("Stop unexpectedly retained authority after attempted pidfd close")
+	}
+	if stopped != 0 {
+		t.Fatalf("stopped pidfd = %d, want no signal through released fd", stopped)
+	}
+	if err := capability.Close(); err != nil {
+		t.Fatalf("close detached capability: %v", err)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("pidfd close calls = %d, want exactly one irrevocable attempt", closeCalls)
+	}
+}

--- a/internal/cli/wake_repair_handoff_unix.go
+++ b/internal/cli/wake_repair_handoff_unix.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"golang.org/x/sys/unix"
 )
@@ -23,12 +25,14 @@ import (
 var wakeRepairAdmitTimeout = wakeReadyTimeout
 
 const (
-	wakeRepairHandoffSchema        = 1
-	wakeRepairHandoffMaxFrameBytes = 64 * 1024
+	wakeRepairHandoffSchema         = 1
+	wakeRepairHandoffMaxFrameBytes  = 64 * 1024
+	wakeRepairHandoffMaxReasonBytes = 4 * 1024
 
 	wakeRepairHandoffKindSource   = "source"
 	wakeRepairHandoffKindPrepared = "prepared"
 	wakeRepairHandoffKindAdmit    = "admit"
+	wakeRepairHandoffKindReject   = "reject"
 	wakeRepairHandoffKindRelease  = "release"
 
 	envWakeRepairHandoffReadFD  = "AMQ_WAKE_REPAIR_HANDOFF_READ_FD"
@@ -76,6 +80,19 @@ type wakeRepairHandoffAdmit struct {
 	preparedDigest  string
 }
 
+type wakeRepairHandoffReject struct {
+	schema          int
+	childGeneration string
+	preparedDigest  string
+	reason          string
+}
+
+type wakeRepairHandoffAdmissionResult struct {
+	admit    wakeRepairHandoffAdmit
+	reject   wakeRepairHandoffReject
+	rejected bool
+}
+
 type wakeRepairHandoffRelease struct {
 	schema          int
 	childGeneration string
@@ -121,6 +138,22 @@ type wakeRepairHandoffAdmitWire struct {
 	Kind            string `json:"kind"`
 	ChildGeneration string `json:"child_generation"`
 	PreparedDigest  string `json:"prepared_digest"`
+}
+
+type wakeRepairHandoffRejectWire struct {
+	Schema          int    `json:"schema"`
+	Kind            string `json:"kind"`
+	ChildGeneration string `json:"child_generation"`
+	PreparedDigest  string `json:"prepared_digest"`
+	Reason          string `json:"reason"`
+}
+
+type wakeRepairHandoffAdmissionResultWire struct {
+	Schema          int             `json:"schema"`
+	Kind            string          `json:"kind"`
+	ChildGeneration string          `json:"child_generation"`
+	PreparedDigest  string          `json:"prepared_digest"`
+	Reason          json.RawMessage `json:"reason,omitempty"`
 }
 
 type wakeRepairHandoffReleaseWire struct {
@@ -534,6 +567,91 @@ func admitFromWire(wire wakeRepairHandoffAdmitWire) (wakeRepairHandoffAdmit, err
 	return admit, admit.validate()
 }
 
+func newWakeRepairHandoffReject(
+	admit wakeRepairHandoffAdmit,
+	cause error,
+) (wakeRepairHandoffReject, error) {
+	if err := admit.validate(); err != nil {
+		return wakeRepairHandoffReject{}, err
+	}
+	if cause == nil {
+		return wakeRepairHandoffReject{}, fmt.Errorf("wake repair handoff rejection reason is missing")
+	}
+	reject := wakeRepairHandoffReject{
+		schema:          wakeRepairHandoffSchema,
+		childGeneration: admit.childGeneration,
+		preparedDigest:  admit.preparedDigest,
+		reason:          cause.Error(),
+	}
+	return reject, reject.validate()
+}
+
+func (reject wakeRepairHandoffReject) validate() error {
+	if reject.schema != wakeRepairHandoffSchema {
+		return fmt.Errorf("wake repair handoff reject schema %d unsupported", reject.schema)
+	}
+	if err := validateWakeRepairHandoffToken(
+		"reject child generation",
+		reject.childGeneration,
+		1024,
+	); err != nil {
+		return err
+	}
+	if err := validateWakeRepairHandoffDigest("prepared", reject.preparedDigest); err != nil {
+		return err
+	}
+	return validateWakeRepairHandoffReason(reject.reason)
+}
+
+func (reject wakeRepairHandoffReject) validateAdmit(admit wakeRepairHandoffAdmit) error {
+	if err := reject.validate(); err != nil {
+		return err
+	}
+	if reject.childGeneration != admit.childGeneration ||
+		reject.preparedDigest != admit.preparedDigest {
+		return fmt.Errorf("wake repair rejection does not match exact admit")
+	}
+	return nil
+}
+
+func (reject wakeRepairHandoffReject) wire() wakeRepairHandoffRejectWire {
+	return wakeRepairHandoffRejectWire{
+		Schema:          reject.schema,
+		Kind:            wakeRepairHandoffKindReject,
+		ChildGeneration: reject.childGeneration,
+		PreparedDigest:  reject.preparedDigest,
+		Reason:          reject.reason,
+	}
+}
+
+func rejectFromWire(wire wakeRepairHandoffRejectWire) (wakeRepairHandoffReject, error) {
+	if wire.Kind != wakeRepairHandoffKindReject {
+		return wakeRepairHandoffReject{}, fmt.Errorf("wake repair handoff message kind %q, want reject", wire.Kind)
+	}
+	reject := wakeRepairHandoffReject{
+		schema:          wire.Schema,
+		childGeneration: wire.ChildGeneration,
+		preparedDigest:  wire.PreparedDigest,
+		reason:          wire.Reason,
+	}
+	return reject, reject.validate()
+}
+
+func validateWakeRepairHandoffReason(reason string) error {
+	if reason == "" || strings.TrimSpace(reason) != reason || !utf8.ValidString(reason) {
+		return fmt.Errorf("wake repair handoff rejection reason is invalid")
+	}
+	if len(reason) > wakeRepairHandoffMaxReasonBytes {
+		return fmt.Errorf("wake repair handoff rejection reason is too long")
+	}
+	for _, r := range reason {
+		if !unicode.IsGraphic(r) {
+			return fmt.Errorf("wake repair handoff rejection reason is invalid")
+		}
+	}
+	return nil
+}
+
 func newWakeRepairHandoffRelease(admit wakeRepairHandoffAdmit) (wakeRepairHandoffRelease, error) {
 	if err := admit.validate(); err != nil {
 		return wakeRepairHandoffRelease{}, err
@@ -624,19 +742,21 @@ type wakeRepairParentHandoff struct {
 	reader *bufio.Reader
 	writer io.Writer
 
-	source     wakeRepairHandoffSource
-	readFile   *os.File
-	writeFile  *os.File
-	childRead  *os.File
-	childWrite *os.File
-	childAgent *os.File
-	childInbox *os.File
-	stateMu    sync.Mutex
-	admitted   wakeRepairHandoffAdmit
-	hasAdmit   bool
-	released   bool
-	closeOnce  sync.Once
-	closeErr   error
+	source         wakeRepairHandoffSource
+	readFile       *os.File
+	writeFile      *os.File
+	childRead      *os.File
+	childWrite     *os.File
+	childAgent     *os.File
+	childInbox     *os.File
+	stateMu        sync.Mutex
+	admitted       wakeRepairHandoffAdmit
+	admitAttempted bool
+	hasAdmit       bool
+	hasReject      bool
+	released       bool
+	closeOnce      sync.Once
+	closeErr       error
 }
 
 type wakeRepairChildHandoff struct {
@@ -820,6 +940,16 @@ func (handoff *wakeRepairParentHandoff) Admit(prepared wakeRepairHandoffPrepared
 	if handoff.hasAdmit {
 		return fmt.Errorf("wake repair admission was already acknowledged")
 	}
+	if handoff.hasReject {
+		return fmt.Errorf("wake repair admission was already rejected")
+	}
+	if handoff.admitAttempted {
+		return fmt.Errorf("wake repair admission was already attempted")
+	}
+	admit, err := newWakeRepairHandoffAdmit(prepared)
+	if err != nil {
+		return err
+	}
 	deadline := time.Now().Add(wakeRepairAdmitTimeout)
 	if err := handoff.readFile.SetReadDeadline(deadline); err != nil {
 		return fmt.Errorf("set wake repair admitted acknowledgement deadline: %w", err)
@@ -829,18 +959,22 @@ func (handoff *wakeRepairParentHandoff) Admit(prepared wakeRepairHandoffPrepared
 		return fmt.Errorf("set wake repair admit write deadline: %w", err)
 	}
 	defer func() { _ = handoff.writeFile.SetWriteDeadline(time.Time{}) }()
-	admit, err := newWakeRepairHandoffAdmit(prepared)
-	if err != nil {
-		return err
-	}
+	handoff.admitAttempted = true
 	if err := writeWakeRepairHandoffAdmit(handoff.writer, admit); err != nil {
 		return err
 	}
-	ack, err := readWakeRepairHandoffAdmit(handoff.reader)
+	response, err := readWakeRepairHandoffAdmissionResult(handoff.reader)
 	if err != nil {
 		return fmt.Errorf("read wake repair admitted acknowledgement: %w", err)
 	}
-	if ack != admit {
+	if response.rejected {
+		if err := response.reject.validateAdmit(admit); err != nil {
+			return fmt.Errorf("read wake repair admitted acknowledgement: %w", err)
+		}
+		handoff.hasReject = true
+		return fmt.Errorf("wake repair child rejected admission: %s", response.reject.reason)
+	}
+	if response.admit != admit {
 		return fmt.Errorf("wake repair admitted acknowledgement does not match exact admit")
 	}
 	handoff.admitted = admit
@@ -1033,6 +1167,23 @@ func (handoff *wakeRepairChildHandoff) SendPrepared(prepared wakeRepairHandoffPr
 	return writeWakeRepairHandoffPrepared(handoff.writer, prepared)
 }
 
+func (handoff *wakeRepairChildHandoff) rejectAdmission(
+	admit wakeRepairHandoffAdmit,
+	cause error,
+) error {
+	reject, err := newWakeRepairHandoffReject(admit, cause)
+	if err == nil {
+		err = writeWakeRepairHandoffReject(handoff.writer, reject)
+	}
+	if err != nil {
+		return errors.Join(
+			cause,
+			fmt.Errorf("report wake repair admission rejection: %w", err),
+		)
+	}
+	return cause
+}
+
 // AwaitAdmitAcknowledgeAndRelease is the child admission gate. A repaired wake
 // must call it after publishing its prepared tuple and before scanning or
 // injecting. Acknowledgement alone is never authorization: only the exact
@@ -1053,10 +1204,16 @@ func (handoff *wakeRepairChildHandoff) AwaitAdmitAcknowledgeAndRelease(
 		return err
 	}
 	if beforeAcknowledge == nil {
-		return fmt.Errorf("wake repair admission validation is missing")
+		return handoff.rejectAdmission(
+			admit,
+			fmt.Errorf("wake repair admission validation is missing"),
+		)
 	}
 	if err := beforeAcknowledge(); err != nil {
-		return fmt.Errorf("wake repair admission validation failed: %w", err)
+		return handoff.rejectAdmission(
+			admit,
+			fmt.Errorf("wake repair admission validation failed: %w", err),
+		)
 	}
 	if err := writeWakeRepairHandoffAdmit(handoff.writer, admit); err != nil {
 		return fmt.Errorf("acknowledge wake repair admission: %w", err)
@@ -1170,6 +1327,72 @@ func readWakeRepairHandoffAdmit(reader io.Reader) (wakeRepairHandoffAdmit, error
 	return admitFromWire(wire)
 }
 
+func writeWakeRepairHandoffReject(writer io.Writer, reject wakeRepairHandoffReject) error {
+	if err := reject.validate(); err != nil {
+		return err
+	}
+	return writeWakeRepairHandoffFrame(writer, reject.wire())
+}
+
+func readWakeRepairHandoffAdmissionResult(
+	reader io.Reader,
+) (wakeRepairHandoffAdmissionResult, error) {
+	var wire wakeRepairHandoffAdmissionResultWire
+	if err := readWakeRepairHandoffFrame(reader, &wire); err != nil {
+		return wakeRepairHandoffAdmissionResult{}, err
+	}
+	switch wire.Kind {
+	case wakeRepairHandoffKindAdmit:
+		if wire.Reason != nil {
+			return wakeRepairHandoffAdmissionResult{}, fmt.Errorf(
+				"wake repair admitted acknowledgement contains a rejection reason",
+			)
+		}
+		admit, err := admitFromWire(wakeRepairHandoffAdmitWire{
+			Schema:          wire.Schema,
+			Kind:            wire.Kind,
+			ChildGeneration: wire.ChildGeneration,
+			PreparedDigest:  wire.PreparedDigest,
+		})
+		if err != nil {
+			return wakeRepairHandoffAdmissionResult{}, err
+		}
+		return wakeRepairHandoffAdmissionResult{admit: admit}, nil
+	case wakeRepairHandoffKindReject:
+		if wire.Reason == nil || bytes.Equal(bytes.TrimSpace(wire.Reason), []byte("null")) {
+			return wakeRepairHandoffAdmissionResult{}, fmt.Errorf(
+				"wake repair handoff rejection reason is missing",
+			)
+		}
+		var reason string
+		if err := json.Unmarshal(wire.Reason, &reason); err != nil {
+			return wakeRepairHandoffAdmissionResult{}, fmt.Errorf(
+				"decode wake repair handoff rejection reason: %w",
+				err,
+			)
+		}
+		reject, err := rejectFromWire(wakeRepairHandoffRejectWire{
+			Schema:          wire.Schema,
+			Kind:            wire.Kind,
+			ChildGeneration: wire.ChildGeneration,
+			PreparedDigest:  wire.PreparedDigest,
+			Reason:          reason,
+		})
+		if err != nil {
+			return wakeRepairHandoffAdmissionResult{}, err
+		}
+		return wakeRepairHandoffAdmissionResult{
+			reject:   reject,
+			rejected: true,
+		}, nil
+	default:
+		return wakeRepairHandoffAdmissionResult{}, fmt.Errorf(
+			"wake repair handoff admission response kind %q is invalid",
+			wire.Kind,
+		)
+	}
+}
+
 func writeWakeRepairHandoffRelease(writer io.Writer, release wakeRepairHandoffRelease) error {
 	if err := release.validate(); err != nil {
 		return err
@@ -1232,6 +1455,9 @@ func readWakeRepairHandoffFrame(reader io.Reader, value any) error {
 	}
 
 decode:
+	if !utf8.Valid(frame) {
+		return fmt.Errorf("decode wake repair handoff message: invalid UTF-8")
+	}
 	decoder := json.NewDecoder(bytes.NewReader(frame))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(value); err != nil {

--- a/internal/cli/wake_repair_handoff_unix.go
+++ b/internal/cli/wake_repair_handoff_unix.go
@@ -1,0 +1,1296 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+var wakeRepairAdmitTimeout = wakeReadyTimeout
+
+const (
+	wakeRepairHandoffSchema        = 1
+	wakeRepairHandoffMaxFrameBytes = 64 * 1024
+
+	wakeRepairHandoffKindSource   = "source"
+	wakeRepairHandoffKindPrepared = "prepared"
+	wakeRepairHandoffKindAdmit    = "admit"
+	wakeRepairHandoffKindRelease  = "release"
+
+	envWakeRepairHandoffReadFD  = "AMQ_WAKE_REPAIR_HANDOFF_READ_FD"
+	envWakeRepairHandoffWriteFD = "AMQ_WAKE_REPAIR_HANDOFF_WRITE_FD"
+	envWakeRepairAgentDirFD     = "AMQ_WAKE_REPAIR_AGENT_DIR_FD"
+	envWakeRepairInboxDirFD     = "AMQ_WAKE_REPAIR_INBOX_DIR_FD"
+)
+
+// The handoff values deliberately contain no maps, slices, or pointers. Once
+// constructed, copying one cannot alias mutable repair state held by either
+// process.
+type wakeRepairHandoffSource struct {
+	schema             int
+	root               string
+	rootIdentity       string
+	agent              string
+	sourceGeneration   string
+	sourceTargetDigest string
+	sourceFloorDigest  string
+	bootID             string
+	agentDirDevice     uint64
+	agentDirInode      uint64
+	inboxDirDevice     uint64
+	inboxDirInode      uint64
+	hasOwner           bool
+	ownerPID           int
+	ownerProcessStart  string
+	ownerBootID        string
+	ownerSessionID     int
+}
+
+type wakeRepairHandoffPrepared struct {
+	schema              int
+	sourceDigest        string
+	childPID            int
+	childGeneration     string
+	childTargetDigest   string
+	childFloorDigest    string
+	childFloorAuthority wakeRepairFloorAuthority
+}
+
+type wakeRepairHandoffAdmit struct {
+	schema          int
+	childGeneration string
+	preparedDigest  string
+}
+
+type wakeRepairHandoffRelease struct {
+	schema          int
+	childGeneration string
+	admitDigest     string
+}
+
+type wakeRepairHandoffSourceWire struct {
+	Schema             int    `json:"schema"`
+	Kind               string `json:"kind"`
+	Root               string `json:"root"`
+	RootIdentity       string `json:"root_identity"`
+	Agent              string `json:"agent"`
+	SourceGeneration   string `json:"source_generation"`
+	SourceTargetDigest string `json:"source_target_digest"`
+	SourceFloorDigest  string `json:"source_floor_digest"`
+	BootID             string `json:"boot_id"`
+	AgentDirDevice     uint64 `json:"agent_dir_device"`
+	AgentDirInode      uint64 `json:"agent_dir_inode"`
+	InboxDirDevice     uint64 `json:"inbox_dir_device"`
+	InboxDirInode      uint64 `json:"inbox_dir_inode"`
+	HasOwner           bool   `json:"has_owner,omitempty"`
+	OwnerPID           int    `json:"owner_pid,omitempty"`
+	OwnerProcessStart  string `json:"owner_process_start,omitempty"`
+	OwnerBootID        string `json:"owner_boot_id,omitempty"`
+	OwnerSessionID     int    `json:"owner_session_id,omitempty"`
+}
+
+type wakeRepairHandoffPreparedWire struct {
+	Schema                 int              `json:"schema"`
+	Kind                   string           `json:"kind"`
+	SourceDigest           string           `json:"source_digest"`
+	ChildPID               int              `json:"child_pid"`
+	ChildGeneration        string           `json:"child_generation"`
+	ChildTargetDigest      string           `json:"child_target_digest"`
+	ChildFloorDigest       string           `json:"child_floor_digest"`
+	ChildFloorSourceDigest string           `json:"child_floor_source_digest"`
+	ChildFloorRawDigest    string           `json:"child_floor_raw_digest"`
+	ChildFloorFileIdentity wakeFileIdentity `json:"child_floor_file_identity"`
+}
+
+type wakeRepairHandoffAdmitWire struct {
+	Schema          int    `json:"schema"`
+	Kind            string `json:"kind"`
+	ChildGeneration string `json:"child_generation"`
+	PreparedDigest  string `json:"prepared_digest"`
+}
+
+type wakeRepairHandoffReleaseWire struct {
+	Schema          int    `json:"schema"`
+	Kind            string `json:"kind"`
+	ChildGeneration string `json:"child_generation"`
+	AdmitDigest     string `json:"admit_digest"`
+}
+
+func newWakeRepairHandoffSource(
+	floor wakeRepairFloor,
+	target wakeTarget,
+	agentDir *wakeAgentDir,
+	inboxDir *wakeInboxDir,
+) (wakeRepairHandoffSource, error) {
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		return wakeRepairHandoffSource{}, err
+	}
+	floorDigest, err := wakeRepairFloorDigest(floor)
+	if err != nil {
+		return wakeRepairHandoffSource{}, err
+	}
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               floor.Root,
+		rootIdentity:       floor.RootIdentity,
+		agent:              floor.Agent,
+		sourceGeneration:   floor.Generation,
+		sourceTargetDigest: targetDigest,
+		sourceFloorDigest:  floorDigest,
+		bootID:             floor.BootID,
+	}
+	if floor.Owner != nil {
+		source.hasOwner = true
+		source.ownerPID = floor.Owner.PID
+		source.ownerProcessStart = floor.Owner.ProcessStart
+		source.ownerBootID = floor.Owner.BootID
+		source.ownerSessionID = floor.Owner.SessionID
+	}
+	if source.sourceTargetDigest != floor.TargetDigest {
+		return wakeRepairHandoffSource{}, fmt.Errorf("wake repair handoff source target digest mismatch")
+	}
+	if canonicalWakeRoot(target.Root) != canonicalWakeRoot(floor.Root) || target.Agent != floor.Agent {
+		return wakeRepairHandoffSource{}, fmt.Errorf("wake repair handoff source target scope mismatch")
+	}
+	if !sameWakeOwner(floor.Owner, target.Owner) {
+		return wakeRepairHandoffSource{}, fmt.Errorf("wake repair handoff source owner mismatch")
+	}
+	if err := source.bindRetainedDirectories(agentDir, inboxDir); err != nil {
+		return wakeRepairHandoffSource{}, err
+	}
+	return source, nil
+}
+
+func (source *wakeRepairHandoffSource) bindRetainedDirectories(
+	agentDir *wakeAgentDir,
+	inboxDir *wakeInboxDir,
+) error {
+	if source == nil || agentDir == nil || inboxDir == nil {
+		return fmt.Errorf("wake repair retained directory capability is missing")
+	}
+	agentIdentity, err := wakeRepairDirectoryIdentityForFile(agentDir.file)
+	if err != nil {
+		return err
+	}
+	inboxIdentity, err := wakeRepairDirectoryIdentityForFile(inboxDir.file)
+	if err != nil {
+		return err
+	}
+	source.agentDirDevice = agentIdentity.device
+	source.agentDirInode = agentIdentity.inode
+	source.inboxDirDevice = inboxIdentity.device
+	source.inboxDirInode = inboxIdentity.inode
+	return source.validate()
+}
+
+func (source wakeRepairHandoffSource) Owner() *wakeOwner {
+	if !source.hasOwner {
+		return nil
+	}
+	return &wakeOwner{
+		PID:          source.ownerPID,
+		ProcessStart: source.ownerProcessStart,
+		BootID:       source.ownerBootID,
+		SessionID:    source.ownerSessionID,
+	}
+}
+
+func (source wakeRepairHandoffSource) SourceGeneration() string {
+	return source.sourceGeneration
+}
+
+func (source wakeRepairHandoffSource) Root() string {
+	return source.root
+}
+
+func (source wakeRepairHandoffSource) Agent() string {
+	return source.agent
+}
+
+func (source wakeRepairHandoffSource) BootID() string {
+	return source.bootID
+}
+
+func (source wakeRepairHandoffSource) SourceTargetDigest() string {
+	return source.sourceTargetDigest
+}
+
+func (source wakeRepairHandoffSource) SourceFloorDigest() string {
+	return source.sourceFloorDigest
+}
+
+func (source wakeRepairHandoffSource) RootIdentity() string {
+	return source.rootIdentity
+}
+
+func (source wakeRepairHandoffSource) digest() (string, error) {
+	if err := source.validate(); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(source.wire())
+	if err != nil {
+		return "", fmt.Errorf("marshal wake repair handoff source digest: %w", err)
+	}
+	return wakeMetadataDigest(data), nil
+}
+
+func (source wakeRepairHandoffSource) validate() error {
+	if source.schema != wakeRepairHandoffSchema {
+		return fmt.Errorf("wake repair handoff source schema %d unsupported", source.schema)
+	}
+	for label, value := range map[string]string{
+		"root":                 source.root,
+		"root identity":        source.rootIdentity,
+		"agent":                source.agent,
+		"source generation":    source.sourceGeneration,
+		"source target digest": source.sourceTargetDigest,
+		"source floor digest":  source.sourceFloorDigest,
+		"boot id":              source.bootID,
+	} {
+		if err := validateWakeRepairHandoffToken(label, value, 1024); err != nil {
+			return err
+		}
+	}
+	if err := validateWakeRepairHandoffDigest("source target", source.sourceTargetDigest); err != nil {
+		return err
+	}
+	if err := validateWakeRepairHandoffDigest("source floor", source.sourceFloorDigest); err != nil {
+		return err
+	}
+	if source.agentDirDevice == 0 || source.agentDirInode == 0 ||
+		source.inboxDirDevice == 0 || source.inboxDirInode == 0 {
+		return fmt.Errorf("wake repair handoff retained directory identity is invalid")
+	}
+	if source.hasOwner {
+		if err := validateAuthoritativeWakeOwner(*source.Owner()); err != nil {
+			return fmt.Errorf("wake repair handoff source owner is invalid: %w", err)
+		}
+	} else if source.ownerPID != 0 || source.ownerProcessStart != "" ||
+		source.ownerBootID != "" || source.ownerSessionID != 0 {
+		return fmt.Errorf("wake repair handoff source owner fields require has_owner")
+	}
+	return nil
+}
+
+func (source wakeRepairHandoffSource) wire() wakeRepairHandoffSourceWire {
+	return wakeRepairHandoffSourceWire{
+		Schema:             source.schema,
+		Kind:               wakeRepairHandoffKindSource,
+		Root:               source.root,
+		RootIdentity:       source.rootIdentity,
+		Agent:              source.agent,
+		SourceGeneration:   source.sourceGeneration,
+		SourceTargetDigest: source.sourceTargetDigest,
+		SourceFloorDigest:  source.sourceFloorDigest,
+		BootID:             source.bootID,
+		AgentDirDevice:     source.agentDirDevice,
+		AgentDirInode:      source.agentDirInode,
+		InboxDirDevice:     source.inboxDirDevice,
+		InboxDirInode:      source.inboxDirInode,
+		HasOwner:           source.hasOwner,
+		OwnerPID:           source.ownerPID,
+		OwnerProcessStart:  source.ownerProcessStart,
+		OwnerBootID:        source.ownerBootID,
+		OwnerSessionID:     source.ownerSessionID,
+	}
+}
+
+func sourceFromWire(wire wakeRepairHandoffSourceWire) (wakeRepairHandoffSource, error) {
+	if wire.Kind != wakeRepairHandoffKindSource {
+		return wakeRepairHandoffSource{}, fmt.Errorf("wake repair handoff message kind %q, want source", wire.Kind)
+	}
+	source := wakeRepairHandoffSource{
+		schema:             wire.Schema,
+		root:               wire.Root,
+		rootIdentity:       wire.RootIdentity,
+		agent:              wire.Agent,
+		sourceGeneration:   wire.SourceGeneration,
+		sourceTargetDigest: wire.SourceTargetDigest,
+		sourceFloorDigest:  wire.SourceFloorDigest,
+		bootID:             wire.BootID,
+		agentDirDevice:     wire.AgentDirDevice,
+		agentDirInode:      wire.AgentDirInode,
+		inboxDirDevice:     wire.InboxDirDevice,
+		inboxDirInode:      wire.InboxDirInode,
+		hasOwner:           wire.HasOwner,
+		ownerPID:           wire.OwnerPID,
+		ownerProcessStart:  wire.OwnerProcessStart,
+		ownerBootID:        wire.OwnerBootID,
+		ownerSessionID:     wire.OwnerSessionID,
+	}
+	return source, source.validate()
+}
+
+func newWakeRepairHandoffPrepared(
+	source wakeRepairHandoffSource,
+	childPID int,
+	childGeneration string,
+	childTargetDigest string,
+	childFloorDigest string,
+	childFloorAuthority wakeRepairFloorAuthority,
+) (wakeRepairHandoffPrepared, error) {
+	sourceDigest, err := source.digest()
+	if err != nil {
+		return wakeRepairHandoffPrepared{}, err
+	}
+	prepared := wakeRepairHandoffPrepared{
+		schema:              wakeRepairHandoffSchema,
+		sourceDigest:        sourceDigest,
+		childPID:            childPID,
+		childGeneration:     childGeneration,
+		childTargetDigest:   childTargetDigest,
+		childFloorDigest:    childFloorDigest,
+		childFloorAuthority: childFloorAuthority,
+	}
+	if prepared.childTargetDigest != source.sourceTargetDigest {
+		return wakeRepairHandoffPrepared{}, fmt.Errorf("wake repair prepared target does not match exact source")
+	}
+	if prepared.childFloorAuthority.SourceFloorDigest != source.sourceFloorDigest {
+		return wakeRepairHandoffPrepared{}, fmt.Errorf("wake repair prepared floor authority does not match exact source")
+	}
+	return prepared, prepared.validate()
+}
+
+func (prepared wakeRepairHandoffPrepared) ChildPID() int {
+	return prepared.childPID
+}
+
+func (prepared wakeRepairHandoffPrepared) SourceDigest() string {
+	return prepared.sourceDigest
+}
+
+func (prepared wakeRepairHandoffPrepared) ChildGeneration() string {
+	return prepared.childGeneration
+}
+
+func (prepared wakeRepairHandoffPrepared) ChildTargetDigest() string {
+	return prepared.childTargetDigest
+}
+
+func (prepared wakeRepairHandoffPrepared) ChildFloorDigest() string {
+	return prepared.childFloorDigest
+}
+
+func (prepared wakeRepairHandoffPrepared) ChildFloorAuthority() wakeRepairFloorAuthority {
+	return prepared.childFloorAuthority
+}
+
+func (prepared wakeRepairHandoffPrepared) digest() (string, error) {
+	if err := prepared.validate(); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(prepared.wire())
+	if err != nil {
+		return "", fmt.Errorf("marshal wake repair handoff prepared digest: %w", err)
+	}
+	return wakeMetadataDigest(data), nil
+}
+
+func (prepared wakeRepairHandoffPrepared) validate() error {
+	if prepared.schema != wakeRepairHandoffSchema {
+		return fmt.Errorf("wake repair handoff prepared schema %d unsupported", prepared.schema)
+	}
+	if err := validateWakeRepairHandoffDigest("source", prepared.sourceDigest); err != nil {
+		return err
+	}
+	if prepared.childPID <= 0 {
+		return fmt.Errorf("wake repair handoff prepared child pid is invalid")
+	}
+	if err := validateWakeRepairHandoffToken("child generation", prepared.childGeneration, 1024); err != nil {
+		return err
+	}
+	if err := validateWakeRepairHandoffDigest("child target", prepared.childTargetDigest); err != nil {
+		return err
+	}
+	if err := validateWakeRepairHandoffDigest("child floor", prepared.childFloorDigest); err != nil {
+		return err
+	}
+	if err := prepared.childFloorAuthority.validate(); err != nil {
+		return err
+	}
+	if prepared.childFloorAuthority.ChildGeneration != prepared.childGeneration {
+		return fmt.Errorf("wake repair prepared floor authority generation mismatch")
+	}
+	return nil
+}
+
+func (prepared wakeRepairHandoffPrepared) validateSource(source wakeRepairHandoffSource) error {
+	digest, err := source.digest()
+	if err != nil {
+		return err
+	}
+	if prepared.sourceDigest != digest {
+		return fmt.Errorf("wake repair prepared message does not match exact source")
+	}
+	if prepared.childFloorAuthority.SourceFloorDigest != source.sourceFloorDigest {
+		return fmt.Errorf("wake repair prepared floor authority does not match exact source")
+	}
+	return nil
+}
+
+func (prepared wakeRepairHandoffPrepared) wire() wakeRepairHandoffPreparedWire {
+	return wakeRepairHandoffPreparedWire{
+		Schema:                 prepared.schema,
+		Kind:                   wakeRepairHandoffKindPrepared,
+		SourceDigest:           prepared.sourceDigest,
+		ChildPID:               prepared.childPID,
+		ChildGeneration:        prepared.childGeneration,
+		ChildTargetDigest:      prepared.childTargetDigest,
+		ChildFloorDigest:       prepared.childFloorDigest,
+		ChildFloorSourceDigest: prepared.childFloorAuthority.SourceFloorDigest,
+		ChildFloorRawDigest:    prepared.childFloorAuthority.RawDigest,
+		ChildFloorFileIdentity: prepared.childFloorAuthority.FileIdentity,
+	}
+}
+
+func preparedFromWire(wire wakeRepairHandoffPreparedWire) (wakeRepairHandoffPrepared, error) {
+	if wire.Kind != wakeRepairHandoffKindPrepared {
+		return wakeRepairHandoffPrepared{}, fmt.Errorf("wake repair handoff message kind %q, want prepared", wire.Kind)
+	}
+	prepared := wakeRepairHandoffPrepared{
+		schema:            wire.Schema,
+		sourceDigest:      wire.SourceDigest,
+		childPID:          wire.ChildPID,
+		childGeneration:   wire.ChildGeneration,
+		childTargetDigest: wire.ChildTargetDigest,
+		childFloorDigest:  wire.ChildFloorDigest,
+		childFloorAuthority: wakeRepairFloorAuthority{
+			ChildGeneration:   wire.ChildGeneration,
+			SourceFloorDigest: wire.ChildFloorSourceDigest,
+			RawDigest:         wire.ChildFloorRawDigest,
+			FileIdentity:      wire.ChildFloorFileIdentity,
+		},
+	}
+	return prepared, prepared.validate()
+}
+
+func newWakeRepairHandoffAdmit(prepared wakeRepairHandoffPrepared) (wakeRepairHandoffAdmit, error) {
+	digest, err := prepared.digest()
+	if err != nil {
+		return wakeRepairHandoffAdmit{}, err
+	}
+	admit := wakeRepairHandoffAdmit{
+		schema:          wakeRepairHandoffSchema,
+		childGeneration: prepared.childGeneration,
+		preparedDigest:  digest,
+	}
+	return admit, admit.validate()
+}
+
+func (admit wakeRepairHandoffAdmit) validate() error {
+	if admit.schema != wakeRepairHandoffSchema {
+		return fmt.Errorf("wake repair handoff admit schema %d unsupported", admit.schema)
+	}
+	if err := validateWakeRepairHandoffToken("admit child generation", admit.childGeneration, 1024); err != nil {
+		return err
+	}
+	return validateWakeRepairHandoffDigest("prepared", admit.preparedDigest)
+}
+
+func (admit wakeRepairHandoffAdmit) validatePrepared(prepared wakeRepairHandoffPrepared) error {
+	expected, err := newWakeRepairHandoffAdmit(prepared)
+	if err != nil {
+		return err
+	}
+	if admit != expected {
+		return fmt.Errorf("wake repair admit does not match exact prepared child")
+	}
+	return nil
+}
+
+func (admit wakeRepairHandoffAdmit) wire() wakeRepairHandoffAdmitWire {
+	return wakeRepairHandoffAdmitWire{
+		Schema:          admit.schema,
+		Kind:            wakeRepairHandoffKindAdmit,
+		ChildGeneration: admit.childGeneration,
+		PreparedDigest:  admit.preparedDigest,
+	}
+}
+
+func admitFromWire(wire wakeRepairHandoffAdmitWire) (wakeRepairHandoffAdmit, error) {
+	if wire.Kind != wakeRepairHandoffKindAdmit {
+		return wakeRepairHandoffAdmit{}, fmt.Errorf("wake repair handoff message kind %q, want admit", wire.Kind)
+	}
+	admit := wakeRepairHandoffAdmit{
+		schema:          wire.Schema,
+		childGeneration: wire.ChildGeneration,
+		preparedDigest:  wire.PreparedDigest,
+	}
+	return admit, admit.validate()
+}
+
+func newWakeRepairHandoffRelease(admit wakeRepairHandoffAdmit) (wakeRepairHandoffRelease, error) {
+	if err := admit.validate(); err != nil {
+		return wakeRepairHandoffRelease{}, err
+	}
+	data, err := json.Marshal(admit.wire())
+	if err != nil {
+		return wakeRepairHandoffRelease{}, fmt.Errorf("marshal wake repair admit digest: %w", err)
+	}
+	release := wakeRepairHandoffRelease{
+		schema:          wakeRepairHandoffSchema,
+		childGeneration: admit.childGeneration,
+		admitDigest:     wakeMetadataDigest(data),
+	}
+	return release, release.validate()
+}
+
+func (release wakeRepairHandoffRelease) validate() error {
+	if release.schema != wakeRepairHandoffSchema {
+		return fmt.Errorf("wake repair handoff release schema %d unsupported", release.schema)
+	}
+	if err := validateWakeRepairHandoffToken(
+		"release child generation",
+		release.childGeneration,
+		1024,
+	); err != nil {
+		return err
+	}
+	return validateWakeRepairHandoffDigest("admit", release.admitDigest)
+}
+
+func (release wakeRepairHandoffRelease) validateAdmit(admit wakeRepairHandoffAdmit) error {
+	expected, err := newWakeRepairHandoffRelease(admit)
+	if err != nil {
+		return err
+	}
+	if release != expected {
+		return fmt.Errorf("wake repair release does not match exact admit")
+	}
+	return nil
+}
+
+func (release wakeRepairHandoffRelease) wire() wakeRepairHandoffReleaseWire {
+	return wakeRepairHandoffReleaseWire{
+		Schema:          release.schema,
+		Kind:            wakeRepairHandoffKindRelease,
+		ChildGeneration: release.childGeneration,
+		AdmitDigest:     release.admitDigest,
+	}
+}
+
+func releaseFromWire(wire wakeRepairHandoffReleaseWire) (wakeRepairHandoffRelease, error) {
+	if wire.Kind != wakeRepairHandoffKindRelease {
+		return wakeRepairHandoffRelease{}, fmt.Errorf(
+			"wake repair handoff message kind %q, want release",
+			wire.Kind,
+		)
+	}
+	release := wakeRepairHandoffRelease{
+		schema:          wire.Schema,
+		childGeneration: wire.ChildGeneration,
+		admitDigest:     wire.AdmitDigest,
+	}
+	return release, release.validate()
+}
+
+func validateWakeRepairHandoffToken(label, value string, maxBytes int) error {
+	if value == "" || strings.TrimSpace(value) != value || strings.ContainsRune(value, 0) {
+		return fmt.Errorf("wake repair handoff %s is invalid", label)
+	}
+	if len(value) > maxBytes {
+		return fmt.Errorf("wake repair handoff %s is too long", label)
+	}
+	return nil
+}
+
+func validateWakeRepairHandoffDigest(label, value string) error {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+64 {
+		return fmt.Errorf("wake repair handoff %s digest is invalid", label)
+	}
+	if _, err := hex.DecodeString(strings.TrimPrefix(value, prefix)); err != nil {
+		return fmt.Errorf("wake repair handoff %s digest is invalid", label)
+	}
+	return nil
+}
+
+type wakeRepairParentHandoff struct {
+	reader *bufio.Reader
+	writer io.Writer
+
+	source     wakeRepairHandoffSource
+	readFile   *os.File
+	writeFile  *os.File
+	childRead  *os.File
+	childWrite *os.File
+	childAgent *os.File
+	childInbox *os.File
+	stateMu    sync.Mutex
+	admitted   wakeRepairHandoffAdmit
+	hasAdmit   bool
+	released   bool
+	closeOnce  sync.Once
+	closeErr   error
+}
+
+type wakeRepairChildHandoff struct {
+	reader *bufio.Reader
+	writer io.Writer
+
+	readFile  *os.File
+	writeFile *os.File
+	agentFile *os.File
+	inboxFile *os.File
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func prepareWakeRepairHandoff(
+	cmd *exec.Cmd,
+	source wakeRepairHandoffSource,
+	agentDir *wakeAgentDir,
+	inboxDir *wakeInboxDir,
+) (*wakeRepairParentHandoff, error) {
+	if cmd == nil {
+		return nil, fmt.Errorf("wake repair handoff command is missing")
+	}
+	if err := source.validate(); err != nil {
+		return nil, err
+	}
+	if agentDir == nil || inboxDir == nil {
+		return nil, fmt.Errorf("wake repair retained directory capability is missing")
+	}
+	agentIdentity, err := wakeRepairDirectoryIdentityForFile(agentDir.file)
+	if err != nil {
+		return nil, err
+	}
+	inboxIdentity, err := wakeRepairDirectoryIdentityForFile(inboxDir.file)
+	if err != nil {
+		return nil, err
+	}
+	if agentIdentity.device != source.agentDirDevice ||
+		agentIdentity.inode != source.agentDirInode ||
+		inboxIdentity.device != source.inboxDirDevice ||
+		inboxIdentity.inode != source.inboxDirInode {
+		return nil, fmt.Errorf("wake repair retained directory capability does not match exact source")
+	}
+	parentToChildRead, parentToChildWrite, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create wake repair source pipe: %w", err)
+	}
+	childToParentRead, childToParentWrite, err := os.Pipe()
+	if err != nil {
+		_ = parentToChildRead.Close()
+		_ = parentToChildWrite.Close()
+		return nil, fmt.Errorf("create wake repair response pipe: %w", err)
+	}
+	childAgent, err := duplicateWakeRepairDirectoryFile(agentDir.file, "wake-repair-agent-directory")
+	if err != nil {
+		_ = parentToChildRead.Close()
+		_ = parentToChildWrite.Close()
+		_ = childToParentRead.Close()
+		_ = childToParentWrite.Close()
+		return nil, err
+	}
+	childInbox, err := duplicateWakeRepairDirectoryFile(inboxDir.file, "wake-repair-inbox-directory")
+	if err != nil {
+		_ = parentToChildRead.Close()
+		_ = parentToChildWrite.Close()
+		_ = childToParentRead.Close()
+		_ = childToParentWrite.Close()
+		_ = childAgent.Close()
+		return nil, err
+	}
+	baseFD := 3 + len(cmd.ExtraFiles)
+	cmd.ExtraFiles = append(
+		cmd.ExtraFiles,
+		parentToChildRead,
+		childToParentWrite,
+		childAgent,
+		childInbox,
+	)
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = setEnvVar(unsetEnvVar(cmd.Env, envWakeRepairHandoffReadFD),
+		envWakeRepairHandoffReadFD, strconv.Itoa(baseFD))
+	cmd.Env = setEnvVar(unsetEnvVar(cmd.Env, envWakeRepairHandoffWriteFD),
+		envWakeRepairHandoffWriteFD, strconv.Itoa(baseFD+1))
+	cmd.Env = setEnvVar(unsetEnvVar(cmd.Env, envWakeRepairAgentDirFD),
+		envWakeRepairAgentDirFD, strconv.Itoa(baseFD+2))
+	cmd.Env = setEnvVar(unsetEnvVar(cmd.Env, envWakeRepairInboxDirFD),
+		envWakeRepairInboxDirFD, strconv.Itoa(baseFD+3))
+	return &wakeRepairParentHandoff{
+		reader:     bufio.NewReader(childToParentRead),
+		writer:     parentToChildWrite,
+		source:     source,
+		readFile:   childToParentRead,
+		writeFile:  parentToChildWrite,
+		childRead:  parentToChildRead,
+		childWrite: childToParentWrite,
+		childAgent: childAgent,
+		childInbox: childInbox,
+	}, nil
+}
+
+func newWakeRepairParentHandoffForFiles(
+	writer *os.File,
+	reader *os.File,
+) *wakeRepairParentHandoff {
+	return &wakeRepairParentHandoff{
+		reader:    bufio.NewReader(reader),
+		writer:    writer,
+		readFile:  reader,
+		writeFile: writer,
+	}
+}
+
+func (handoff *wakeRepairParentHandoff) Bind(process *os.Process) error {
+	if handoff == nil || process == nil || process.Pid <= 0 {
+		return fmt.Errorf("wake repair handoff child process is missing")
+	}
+	if handoff.childRead != nil {
+		if err := handoff.childRead.Close(); err != nil {
+			return fmt.Errorf("close parent copy of wake repair child read fd: %w", err)
+		}
+		handoff.childRead = nil
+	}
+	if handoff.childWrite != nil {
+		if err := handoff.childWrite.Close(); err != nil {
+			return fmt.Errorf("close parent copy of wake repair child write fd: %w", err)
+		}
+		handoff.childWrite = nil
+	}
+	if handoff.childAgent != nil {
+		if err := handoff.childAgent.Close(); err != nil {
+			return fmt.Errorf("close parent copy of inherited wake agent directory: %w", err)
+		}
+		handoff.childAgent = nil
+	}
+	if handoff.childInbox != nil {
+		if err := handoff.childInbox.Close(); err != nil {
+			return fmt.Errorf("close parent copy of inherited wake inbox directory: %w", err)
+		}
+		handoff.childInbox = nil
+	}
+	return handoff.SendSource(handoff.source)
+}
+
+func (handoff *wakeRepairParentHandoff) SendSource(source wakeRepairHandoffSource) error {
+	if handoff == nil || handoff.writer == nil {
+		return fmt.Errorf("wake repair parent handoff is unavailable")
+	}
+	return writeWakeRepairHandoffSource(handoff.writer, source)
+}
+
+func (handoff *wakeRepairParentHandoff) ReceivePrepared(
+	source wakeRepairHandoffSource,
+) (wakeRepairHandoffPrepared, error) {
+	if handoff == nil || handoff.reader == nil {
+		return wakeRepairHandoffPrepared{}, fmt.Errorf("wake repair parent handoff is unavailable")
+	}
+	prepared, err := readWakeRepairHandoffPrepared(handoff.reader)
+	if err != nil {
+		return wakeRepairHandoffPrepared{}, err
+	}
+	if err := prepared.validateSource(source); err != nil {
+		return wakeRepairHandoffPrepared{}, err
+	}
+	return prepared, nil
+}
+
+// Admit does not return until the child echoes the exact admit value. The
+// caller may detach its stable child capability only after this succeeds.
+func (handoff *wakeRepairParentHandoff) Admit(prepared wakeRepairHandoffPrepared) error {
+	if handoff == nil || handoff.reader == nil || handoff.writer == nil ||
+		handoff.readFile == nil || handoff.writeFile == nil {
+		return fmt.Errorf("wake repair parent handoff is unavailable")
+	}
+	if wakeRepairAdmitTimeout <= 0 {
+		return fmt.Errorf("wake repair admission timeout is invalid")
+	}
+	handoff.stateMu.Lock()
+	defer handoff.stateMu.Unlock()
+	if handoff.hasAdmit {
+		return fmt.Errorf("wake repair admission was already acknowledged")
+	}
+	deadline := time.Now().Add(wakeRepairAdmitTimeout)
+	if err := handoff.readFile.SetReadDeadline(deadline); err != nil {
+		return fmt.Errorf("set wake repair admitted acknowledgement deadline: %w", err)
+	}
+	defer func() { _ = handoff.readFile.SetReadDeadline(time.Time{}) }()
+	if err := handoff.writeFile.SetWriteDeadline(deadline); err != nil {
+		return fmt.Errorf("set wake repair admit write deadline: %w", err)
+	}
+	defer func() { _ = handoff.writeFile.SetWriteDeadline(time.Time{}) }()
+	admit, err := newWakeRepairHandoffAdmit(prepared)
+	if err != nil {
+		return err
+	}
+	if err := writeWakeRepairHandoffAdmit(handoff.writer, admit); err != nil {
+		return err
+	}
+	ack, err := readWakeRepairHandoffAdmit(handoff.reader)
+	if err != nil {
+		return fmt.Errorf("read wake repair admitted acknowledgement: %w", err)
+	}
+	if ack != admit {
+		return fmt.Errorf("wake repair admitted acknowledgement does not match exact admit")
+	}
+	handoff.admitted = admit
+	handoff.hasAdmit = true
+	return nil
+}
+
+// Release is the admission commit. The child remains blocked from scanning or
+// injecting after its admit acknowledgement until this exact frame is written.
+func (handoff *wakeRepairParentHandoff) Release(prepared wakeRepairHandoffPrepared) error {
+	if handoff == nil || handoff.writer == nil || handoff.writeFile == nil {
+		return fmt.Errorf("wake repair parent handoff is unavailable")
+	}
+	if wakeRepairAdmitTimeout <= 0 {
+		return fmt.Errorf("wake repair admission timeout is invalid")
+	}
+	handoff.stateMu.Lock()
+	defer handoff.stateMu.Unlock()
+	if !handoff.hasAdmit {
+		return fmt.Errorf("wake repair release requested before exact acknowledgement")
+	}
+	if handoff.released {
+		return fmt.Errorf("wake repair child was already released")
+	}
+	admit, err := newWakeRepairHandoffAdmit(prepared)
+	if err != nil {
+		return err
+	}
+	if admit != handoff.admitted {
+		return fmt.Errorf("wake repair release does not match exact acknowledged admit")
+	}
+	release, err := newWakeRepairHandoffRelease(admit)
+	if err != nil {
+		return err
+	}
+	deadline := time.Now().Add(wakeRepairAdmitTimeout)
+	if err := handoff.writeFile.SetWriteDeadline(deadline); err != nil {
+		return fmt.Errorf("set wake repair release write deadline: %w", err)
+	}
+	defer func() { _ = handoff.writeFile.SetWriteDeadline(time.Time{}) }()
+	if err := writeWakeRepairHandoffRelease(handoff.writer, release); err != nil {
+		return fmt.Errorf("release admitted wake repair child: %w", err)
+	}
+	handoff.released = true
+	return nil
+}
+
+func (handoff *wakeRepairParentHandoff) Close() error {
+	if handoff == nil {
+		return nil
+	}
+	handoff.closeOnce.Do(func() {
+		handoff.closeErr = errors.Join(
+			closeFile(handoff.writeFile),
+			closeFile(handoff.readFile),
+			closeFile(handoff.childRead),
+			closeFile(handoff.childWrite),
+			closeFile(handoff.childAgent),
+			closeFile(handoff.childInbox),
+		)
+		handoff.writer = nil
+		handoff.reader = nil
+		handoff.writeFile = nil
+		handoff.readFile = nil
+		handoff.childRead = nil
+		handoff.childWrite = nil
+		handoff.childAgent = nil
+		handoff.childInbox = nil
+	})
+	return handoff.closeErr
+}
+
+func wakeRepairChildHandoffFromEnv() (*wakeRepairChildHandoff, bool, error) {
+	readRaw := strings.TrimSpace(os.Getenv(envWakeRepairHandoffReadFD))
+	writeRaw := strings.TrimSpace(os.Getenv(envWakeRepairHandoffWriteFD))
+	agentRaw := strings.TrimSpace(os.Getenv(envWakeRepairAgentDirFD))
+	inboxRaw := strings.TrimSpace(os.Getenv(envWakeRepairInboxDirFD))
+	if readRaw == "" && writeRaw == "" && agentRaw == "" && inboxRaw == "" {
+		return nil, false, nil
+	}
+	if readRaw == "" || writeRaw == "" || agentRaw == "" || inboxRaw == "" {
+		return nil, true, fmt.Errorf("wake repair handoff descriptors are incomplete")
+	}
+	readFD, err := parseWakeRepairHandoffFD(envWakeRepairHandoffReadFD, readRaw)
+	if err != nil {
+		return nil, true, err
+	}
+	writeFD, err := parseWakeRepairHandoffFD(envWakeRepairHandoffWriteFD, writeRaw)
+	if err != nil {
+		return nil, true, err
+	}
+	if readFD == writeFD {
+		return nil, true, fmt.Errorf("wake repair handoff descriptors must be distinct")
+	}
+	agentFD, err := parseWakeRepairHandoffFD(envWakeRepairAgentDirFD, agentRaw)
+	if err != nil {
+		return nil, true, err
+	}
+	inboxFD, err := parseWakeRepairHandoffFD(envWakeRepairInboxDirFD, inboxRaw)
+	if err != nil {
+		return nil, true, err
+	}
+	if readFD == agentFD || readFD == inboxFD || writeFD == agentFD ||
+		writeFD == inboxFD || agentFD == inboxFD {
+		return nil, true, fmt.Errorf("wake repair handoff descriptors must be distinct")
+	}
+	inherited := []struct {
+		label string
+		fd    int
+	}{
+		{label: "read", fd: readFD},
+		{label: "write", fd: writeFD},
+		{label: "agent directory", fd: agentFD},
+		{label: "inbox directory", fd: inboxFD},
+	}
+	for _, descriptor := range inherited {
+		if err := setWakeRepairFDCloseOnExec(descriptor.fd, descriptor.label); err != nil {
+			for _, candidate := range inherited {
+				_ = unix.Close(candidate.fd)
+			}
+			return nil, true, err
+		}
+	}
+	// os/exec obtains ExtraFiles through File.Fd, which restores blocking mode.
+	// The child must remain cancellable while it waits for the final release
+	// frame, so make its inherited read end pollable before os.NewFile adopts it.
+	if err := unix.SetNonblock(readFD, true); err != nil {
+		for _, candidate := range inherited {
+			_ = unix.Close(candidate.fd)
+		}
+		return nil, true, fmt.Errorf("make wake repair handoff read fd nonblocking: %w", err)
+	}
+	readFile := os.NewFile(uintptr(readFD), "wake-repair-handoff-read")
+	writeFile := os.NewFile(uintptr(writeFD), "wake-repair-handoff-write")
+	agentFile := os.NewFile(uintptr(agentFD), "wake-repair-agent-directory")
+	inboxFile := os.NewFile(uintptr(inboxFD), "wake-repair-inbox-directory")
+	if readFile == nil || writeFile == nil || agentFile == nil || inboxFile == nil {
+		_ = closeFile(readFile)
+		_ = closeFile(writeFile)
+		_ = closeFile(agentFile)
+		_ = closeFile(inboxFile)
+		return nil, true, fmt.Errorf("wake repair handoff descriptor is unavailable")
+	}
+	return &wakeRepairChildHandoff{
+		reader:    bufio.NewReader(readFile),
+		writer:    writeFile,
+		readFile:  readFile,
+		writeFile: writeFile,
+		agentFile: agentFile,
+		inboxFile: inboxFile,
+	}, true, nil
+}
+
+func (handoff *wakeRepairChildHandoff) TakeRetainedDirectories(
+	source wakeRepairHandoffSource,
+) (*wakeAgentDir, *wakeInboxDir, error) {
+	if handoff == nil || handoff.agentFile == nil || handoff.inboxFile == nil {
+		return nil, nil, fmt.Errorf("wake repair inherited directory capability is unavailable")
+	}
+	agentFile := handoff.agentFile
+	inboxFile := handoff.inboxFile
+	handoff.agentFile = nil
+	handoff.inboxFile = nil
+	return openInheritedWakeRepairDirectories(agentFile, inboxFile, source)
+}
+
+func newWakeRepairChildHandoffForFiles(
+	reader *os.File,
+	writer *os.File,
+) *wakeRepairChildHandoff {
+	return &wakeRepairChildHandoff{
+		reader:    bufio.NewReader(reader),
+		writer:    writer,
+		readFile:  reader,
+		writeFile: writer,
+	}
+}
+
+func (handoff *wakeRepairChildHandoff) ReceiveSource() (wakeRepairHandoffSource, error) {
+	if handoff == nil || handoff.reader == nil {
+		return wakeRepairHandoffSource{}, fmt.Errorf("wake repair child handoff is unavailable")
+	}
+	return readWakeRepairHandoffSource(handoff.reader)
+}
+
+func (handoff *wakeRepairChildHandoff) SendPrepared(prepared wakeRepairHandoffPrepared) error {
+	if handoff == nil || handoff.writer == nil {
+		return fmt.Errorf("wake repair child handoff is unavailable")
+	}
+	return writeWakeRepairHandoffPrepared(handoff.writer, prepared)
+}
+
+// AwaitAdmitAcknowledgeAndRelease is the child admission gate. A repaired wake
+// must call it after publishing its prepared tuple and before scanning or
+// injecting. Acknowledgement alone is never authorization: only the exact
+// release frame commits admission.
+func (handoff *wakeRepairChildHandoff) AwaitAdmitAcknowledgeAndRelease(
+	prepared wakeRepairHandoffPrepared,
+	beforeAcknowledge func() error,
+) error {
+	if handoff == nil || handoff.reader == nil || handoff.writer == nil ||
+		handoff.readFile == nil {
+		return fmt.Errorf("wake repair child handoff is unavailable")
+	}
+	admit, err := readWakeRepairHandoffAdmit(handoff.reader)
+	if err != nil {
+		return fmt.Errorf("wait for wake repair admission: %w", err)
+	}
+	if err := admit.validatePrepared(prepared); err != nil {
+		return err
+	}
+	if beforeAcknowledge == nil {
+		return fmt.Errorf("wake repair admission validation is missing")
+	}
+	if err := beforeAcknowledge(); err != nil {
+		return fmt.Errorf("wake repair admission validation failed: %w", err)
+	}
+	if err := writeWakeRepairHandoffAdmit(handoff.writer, admit); err != nil {
+		return fmt.Errorf("acknowledge wake repair admission: %w", err)
+	}
+	if wakeRepairAdmitTimeout <= 0 {
+		return fmt.Errorf("wake repair release timeout is invalid")
+	}
+	deadline := time.Now().Add(wakeRepairAdmitTimeout)
+	if err := handoff.readFile.SetReadDeadline(deadline); err != nil {
+		return fmt.Errorf("set wake repair release deadline: %w", err)
+	}
+	defer func() { _ = handoff.readFile.SetReadDeadline(time.Time{}) }()
+	release, err := readWakeRepairHandoffRelease(handoff.reader)
+	if err != nil {
+		return fmt.Errorf("wait for wake repair release: %w", err)
+	}
+	if err := release.validateAdmit(admit); err != nil {
+		return err
+	}
+	if err := beforeAcknowledge(); err != nil {
+		return fmt.Errorf("wake repair post-release admission validation failed: %w", err)
+	}
+	return nil
+}
+
+func (handoff *wakeRepairChildHandoff) Close() error {
+	if handoff == nil {
+		return nil
+	}
+	handoff.closeOnce.Do(func() {
+		handoff.closeErr = errors.Join(
+			closeFile(handoff.readFile),
+			closeFile(handoff.writeFile),
+			closeFile(handoff.agentFile),
+			closeFile(handoff.inboxFile),
+		)
+		handoff.reader = nil
+		handoff.writer = nil
+		handoff.readFile = nil
+		handoff.writeFile = nil
+		handoff.agentFile = nil
+		handoff.inboxFile = nil
+	})
+	return handoff.closeErr
+}
+
+func parseWakeRepairHandoffFD(label, raw string) (int, error) {
+	fd, err := strconv.Atoi(raw)
+	if err != nil || fd < 3 {
+		return 0, fmt.Errorf("%s is invalid", label)
+	}
+	return fd, nil
+}
+
+func setWakeRepairFDCloseOnExec(fd int, label string) error {
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		return fmt.Errorf("inspect wake repair %s fd: %w", label, err)
+	}
+	if flags&unix.FD_CLOEXEC != 0 {
+		return nil
+	}
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, flags|unix.FD_CLOEXEC); err != nil {
+		return fmt.Errorf("make wake repair %s fd close-on-exec: %w", label, err)
+	}
+	return nil
+}
+
+func writeWakeRepairHandoffSource(writer io.Writer, source wakeRepairHandoffSource) error {
+	if err := source.validate(); err != nil {
+		return err
+	}
+	return writeWakeRepairHandoffFrame(writer, source.wire())
+}
+
+func readWakeRepairHandoffSource(reader io.Reader) (wakeRepairHandoffSource, error) {
+	var wire wakeRepairHandoffSourceWire
+	if err := readWakeRepairHandoffFrame(reader, &wire); err != nil {
+		return wakeRepairHandoffSource{}, err
+	}
+	return sourceFromWire(wire)
+}
+
+func writeWakeRepairHandoffPrepared(writer io.Writer, prepared wakeRepairHandoffPrepared) error {
+	if err := prepared.validate(); err != nil {
+		return err
+	}
+	return writeWakeRepairHandoffFrame(writer, prepared.wire())
+}
+
+func readWakeRepairHandoffPrepared(reader io.Reader) (wakeRepairHandoffPrepared, error) {
+	var wire wakeRepairHandoffPreparedWire
+	if err := readWakeRepairHandoffFrame(reader, &wire); err != nil {
+		return wakeRepairHandoffPrepared{}, err
+	}
+	return preparedFromWire(wire)
+}
+
+func writeWakeRepairHandoffAdmit(writer io.Writer, admit wakeRepairHandoffAdmit) error {
+	if err := admit.validate(); err != nil {
+		return err
+	}
+	return writeWakeRepairHandoffFrame(writer, admit.wire())
+}
+
+func readWakeRepairHandoffAdmit(reader io.Reader) (wakeRepairHandoffAdmit, error) {
+	var wire wakeRepairHandoffAdmitWire
+	if err := readWakeRepairHandoffFrame(reader, &wire); err != nil {
+		return wakeRepairHandoffAdmit{}, err
+	}
+	return admitFromWire(wire)
+}
+
+func writeWakeRepairHandoffRelease(writer io.Writer, release wakeRepairHandoffRelease) error {
+	if err := release.validate(); err != nil {
+		return err
+	}
+	return writeWakeRepairHandoffFrame(writer, release.wire())
+}
+
+func readWakeRepairHandoffRelease(reader io.Reader) (wakeRepairHandoffRelease, error) {
+	var wire wakeRepairHandoffReleaseWire
+	if err := readWakeRepairHandoffFrame(reader, &wire); err != nil {
+		return wakeRepairHandoffRelease{}, err
+	}
+	return releaseFromWire(wire)
+}
+
+func writeWakeRepairHandoffFrame(writer io.Writer, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal wake repair handoff message: %w", err)
+	}
+	data = append(data, '\n')
+	if len(data) > wakeRepairHandoffMaxFrameBytes {
+		return fmt.Errorf("wake repair handoff message is too large")
+	}
+	for len(data) > 0 {
+		n, writeErr := writer.Write(data)
+		if writeErr != nil {
+			return fmt.Errorf("write wake repair handoff message: %w", writeErr)
+		}
+		if n <= 0 {
+			return fmt.Errorf("write wake repair handoff message: %w", io.ErrShortWrite)
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func readWakeRepairHandoffFrame(reader io.Reader, value any) error {
+	buffered, ok := reader.(*bufio.Reader)
+	if !ok {
+		buffered = bufio.NewReader(reader)
+	}
+	var frame []byte
+	for {
+		part, err := buffered.ReadSlice('\n')
+		frame = append(frame, part...)
+		if len(frame) > wakeRepairHandoffMaxFrameBytes {
+			return fmt.Errorf("wake repair handoff message is too large")
+		}
+		switch {
+		case err == nil:
+			goto decode
+		case errors.Is(err, bufio.ErrBufferFull):
+			continue
+		case errors.Is(err, io.EOF):
+			return fmt.Errorf("read wake repair handoff message: %w", io.ErrUnexpectedEOF)
+		default:
+			return fmt.Errorf("read wake repair handoff message: %w", err)
+		}
+	}
+
+decode:
+	decoder := json.NewDecoder(bytes.NewReader(frame))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		return fmt.Errorf("decode wake repair handoff message: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("decode wake repair handoff message: trailing value")
+		}
+		return fmt.Errorf("decode wake repair handoff message: %w", err)
+	}
+	return nil
+}
+
+func closeFile(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	return file.Close()
+}
+
+type wakeRepairChildCapability struct {
+	bind   func(*os.Process) error
+	stop   func() error
+	detach func() error
+	close  func() error
+}
+
+func (capability *wakeRepairChildCapability) Bind(process *os.Process) error {
+	if capability == nil || capability.bind == nil {
+		return fmt.Errorf("wake repair child capability cannot bind")
+	}
+	return capability.bind(process)
+}
+
+func (capability *wakeRepairChildCapability) Stop() error {
+	if capability == nil || capability.stop == nil {
+		return fmt.Errorf("wake repair child capability cannot stop")
+	}
+	return capability.stop()
+}
+
+// Detach relinquishes the stable child capability after the admitted
+// acknowledgement. It must never be called merely because prepared was seen.
+func (capability *wakeRepairChildCapability) Detach() error {
+	if capability == nil || capability.detach == nil {
+		return fmt.Errorf("wake repair child capability cannot detach")
+	}
+	return capability.detach()
+}
+
+func (capability *wakeRepairChildCapability) Close() error {
+	if capability == nil || capability.close == nil {
+		return nil
+	}
+	closeFn := capability.close
+	capability.close = nil
+	return closeFn()
+}
+
+var prepareWakeRepairChildCapability = prepareWakeRepairChildCapabilityPlatform

--- a/internal/cli/wake_repair_handoff_unix_test.go
+++ b/internal/cli/wake_repair_handoff_unix_test.go
@@ -1144,8 +1144,9 @@ func TestWakeRepairChildHandoffDescriptorsDoNotLeakIntoInjector(t *testing.T) {
 
 func assertWakeRepairDescriptorsClosedInInjector(t *testing.T, fds []int) {
 	t.Helper()
-	output := filepath.Join(t.TempDir(), "open-fds")
-	inspector := filepath.Join(t.TempDir(), "fd-inspector")
+	dir := secureTempDirForTest(t)
+	output := filepath.Join(dir, "open-fds")
+	inspector := filepath.Join(dir, "fd-inspector")
 	script := "#!/bin/sh\n" + `output=$1; shift; count=$1; shift; : > "$output"; while [ "$count" -gt 0 ]; do fd=$1; shift; if [ -e "/dev/fd/$fd" ]; then printf '%s\n' "$fd" >> "$output"; fi; count=$((count - 1)); done` + "\n"
 	if err := os.WriteFile(inspector, []byte(script), 0o700); err != nil {
 		t.Fatalf("write user-owned injector inspector: %v", err)

--- a/internal/cli/wake_repair_handoff_unix_test.go
+++ b/internal/cli/wake_repair_handoff_unix_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -282,6 +283,404 @@ func TestWakeRepairPrivateHandoffRequiresExactAdmittedEcho(t *testing.T) {
 	if err := parent.Release(prepared); err == nil ||
 		!strings.Contains(err.Error(), "already released") {
 		t.Fatalf("duplicate release error = %v", err)
+	}
+}
+
+func TestWakeRepairChildReportsBoundAdmissionRejection(t *testing.T) {
+	tests := []struct {
+		name      string
+		validator func() error
+		want      string
+	}{
+		{
+			name: "validation error",
+			validator: func() error {
+				return errors.New("injected canonical validation failure")
+			},
+			want: "injected canonical validation failure",
+		},
+		{
+			name: "missing validator",
+			want: "wake repair admission validation is missing",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
+			parentToChildReader, parentToChildWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			childToParentReader, childToParentWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			parent := newWakeRepairParentHandoffForFiles(parentToChildWriter, childToParentReader)
+			child := newWakeRepairChildHandoffForFiles(parentToChildReader, childToParentWriter)
+			defer func() {
+				_ = parent.Close()
+				_ = child.Close()
+			}()
+
+			childResult := make(chan error, 1)
+			go func() {
+				childResult <- child.AwaitAdmitAcknowledgeAndRelease(
+					prepared,
+					test.validator,
+				)
+			}()
+
+			admitErr := parent.Admit(prepared)
+			if admitErr == nil ||
+				!strings.Contains(admitErr.Error(), "wake repair child rejected admission") ||
+				!strings.Contains(admitErr.Error(), test.want) {
+				t.Fatalf("parent admission rejection = %v, want %q", admitErr, test.want)
+			}
+			if parent.hasAdmit {
+				t.Fatal("rejected admission recorded an exact acknowledgement")
+			}
+			if !parent.hasReject {
+				t.Fatal("exact rejection did not make admission terminal")
+			}
+			if retryErr := parent.Admit(prepared); retryErr == nil ||
+				!strings.Contains(retryErr.Error(), "already rejected") {
+				t.Fatalf("second admission after rejection error = %v", retryErr)
+			}
+			if err := parent.Release(prepared); err == nil ||
+				!strings.Contains(err.Error(), "before exact acknowledgement") {
+				t.Fatalf("release after rejection error = %v", err)
+			}
+			select {
+			case childErr := <-childResult:
+				if childErr == nil || !strings.Contains(childErr.Error(), test.want) {
+					t.Fatalf("child admission rejection = %v, want %q", childErr, test.want)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("child did not return after reporting admission rejection")
+			}
+		})
+	}
+}
+
+func TestWakeRepairHandoffRejectReasonIsStrictAndBounded(t *testing.T) {
+	_, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
+	admit, err := newWakeRepairHandoffAdmit(prepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newWakeRepairHandoffReject(
+		admit,
+		errors.New("canonical wake repair agent directory no longer matches retained authority"),
+	); err != nil {
+		t.Fatalf("valid rejection reason: %v", err)
+	}
+	if _, err := newWakeRepairHandoffReject(
+		admit,
+		errors.New(strings.Repeat("x", wakeRepairHandoffMaxReasonBytes)),
+	); err != nil {
+		t.Fatalf("maximum rejection reason: %v", err)
+	}
+
+	for _, reason := range []string{
+		"",
+		" leading whitespace",
+		"trailing whitespace ",
+		"line\nbreak",
+		"carriage\rreturn",
+		"nul\x00byte",
+		"control\x7fbyte",
+		"line\u2028separator",
+		"paragraph\u2029separator",
+		"bidi\u202eoverride",
+		string([]byte{0xff}),
+		strings.Repeat("x", wakeRepairHandoffMaxReasonBytes+1),
+	} {
+		if _, err := newWakeRepairHandoffReject(admit, errors.New(reason)); err == nil {
+			t.Fatalf("invalid rejection reason accepted: %q", reason)
+		}
+	}
+}
+
+func TestWakeRepairChildAdmissionRejectionJoinsSendFailure(t *testing.T) {
+	_, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
+	admit, err := newWakeRepairHandoffAdmit(prepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reader.Close() }()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	handoff := &wakeRepairChildHandoff{writer: writer}
+	rejectionErr := handoff.rejectAdmission(
+		admit,
+		errors.New("injected canonical validation failure"),
+	)
+	for _, want := range []string{
+		"injected canonical validation failure",
+		"report wake repair admission rejection",
+		"write wake repair handoff message",
+	} {
+		if rejectionErr == nil || !strings.Contains(rejectionErr.Error(), want) {
+			t.Fatalf("joined rejection error = %v, want %q", rejectionErr, want)
+		}
+	}
+}
+
+func TestWakeRepairParentAdmissionResponsesFailClosed(t *testing.T) {
+	type responseFunc func(*os.File, wakeRepairHandoffAdmit) error
+	tests := []struct {
+		name    string
+		respond responseFunc
+		wants   []string
+		avoid   string
+	}{
+		{
+			name: "mismatched rejection generation",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				reject, err := newWakeRepairHandoffReject(
+					admit,
+					errors.New("untrusted mismatched rejection reason"),
+				)
+				if err != nil {
+					return err
+				}
+				reject.childGeneration = "other-generation"
+				return writeWakeRepairHandoffReject(writer, reject)
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "does not match exact admit"},
+			avoid: "untrusted mismatched rejection reason",
+		},
+		{
+			name: "mismatched rejection prepared digest",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				reject, err := newWakeRepairHandoffReject(
+					admit,
+					errors.New("untrusted mismatched rejection reason"),
+				)
+				if err != nil {
+					return err
+				}
+				reject.preparedDigest = "sha256:" + strings.Repeat("9", 64)
+				return writeWakeRepairHandoffReject(writer, reject)
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "does not match exact admit"},
+			avoid: "untrusted mismatched rejection reason",
+		},
+		{
+			name: "missing rejection reason",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, wakeRepairHandoffAdmissionResultWire{
+					Schema:          wakeRepairHandoffSchema,
+					Kind:            wakeRepairHandoffKindReject,
+					ChildGeneration: admit.childGeneration,
+					PreparedDigest:  admit.preparedDigest,
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "rejection reason is missing"},
+		},
+		{
+			name: "null rejection reason",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, wakeRepairHandoffAdmissionResultWire{
+					Schema:          wakeRepairHandoffSchema,
+					Kind:            wakeRepairHandoffKindReject,
+					ChildGeneration: admit.childGeneration,
+					PreparedDigest:  admit.preparedDigest,
+					Reason:          json.RawMessage("null"),
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "rejection reason is missing"},
+		},
+		{
+			name: "empty rejection reason",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, wakeRepairHandoffAdmissionResultWire{
+					Schema:          wakeRepairHandoffSchema,
+					Kind:            wakeRepairHandoffKindReject,
+					ChildGeneration: admit.childGeneration,
+					PreparedDigest:  admit.preparedDigest,
+					Reason:          json.RawMessage(`""`),
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "rejection reason is invalid"},
+		},
+		{
+			name: "invalid UTF-8 rejection",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				frame := []byte(
+					`{"schema":1,"kind":"reject","child_generation":"` +
+						admit.childGeneration +
+						`","prepared_digest":"` +
+						admit.preparedDigest +
+						`","reason":"`,
+				)
+				frame = append(frame, 0xff)
+				frame = append(frame, '"', '}', '\n')
+				_, err := writer.Write(frame)
+				return err
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "invalid UTF-8"},
+		},
+		{
+			name: "acknowledgement with nonempty reason",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, wakeRepairHandoffAdmissionResultWire{
+					Schema:          wakeRepairHandoffSchema,
+					Kind:            wakeRepairHandoffKindAdmit,
+					ChildGeneration: admit.childGeneration,
+					PreparedDigest:  admit.preparedDigest,
+					Reason:          json.RawMessage(`"untrusted acknowledgement reason"`),
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "contains a rejection reason"},
+			avoid: "untrusted acknowledgement reason",
+		},
+		{
+			name: "acknowledgement with empty reason",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, wakeRepairHandoffAdmissionResultWire{
+					Schema:          wakeRepairHandoffSchema,
+					Kind:            wakeRepairHandoffKindAdmit,
+					ChildGeneration: admit.childGeneration,
+					PreparedDigest:  admit.preparedDigest,
+					Reason:          json.RawMessage(`""`),
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "contains a rejection reason"},
+		},
+		{
+			name: "acknowledgement with null reason",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, wakeRepairHandoffAdmissionResultWire{
+					Schema:          wakeRepairHandoffSchema,
+					Kind:            wakeRepairHandoffKindAdmit,
+					ChildGeneration: admit.childGeneration,
+					PreparedDigest:  admit.preparedDigest,
+					Reason:          json.RawMessage("null"),
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "contains a rejection reason"},
+		},
+		{
+			name: "admission response with unknown field",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, map[string]any{
+					"schema":           wakeRepairHandoffSchema,
+					"kind":             wakeRepairHandoffKindAdmit,
+					"child_generation": admit.childGeneration,
+					"prepared_digest":  admit.preparedDigest,
+					"unknown":          true,
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "unknown field"},
+		},
+		{
+			name: "unknown kind",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, wakeRepairHandoffAdmissionResultWire{
+					Schema:          wakeRepairHandoffSchema,
+					Kind:            "unknown",
+					ChildGeneration: admit.childGeneration,
+					PreparedDigest:  admit.preparedDigest,
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "response kind"},
+		},
+		{
+			name: "unknown schema",
+			respond: func(writer *os.File, admit wakeRepairHandoffAdmit) error {
+				return writeWakeRepairHandoffFrame(writer, wakeRepairHandoffAdmissionResultWire{
+					Schema:          wakeRepairHandoffSchema + 1,
+					Kind:            wakeRepairHandoffKindReject,
+					ChildGeneration: admit.childGeneration,
+					PreparedDigest:  admit.preparedDigest,
+					Reason:          json.RawMessage(`"untrusted unknown schema reason"`),
+				})
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "schema"},
+			avoid: "untrusted unknown schema reason",
+		},
+		{
+			name: "response EOF",
+			respond: func(writer *os.File, _ wakeRepairHandoffAdmit) error {
+				return writer.Close()
+			},
+			wants: []string{"read wake repair admitted acknowledgement", "unexpected EOF"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
+			parentToChildReader, parentToChildWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			childToParentReader, childToParentWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			parent := newWakeRepairParentHandoffForFiles(parentToChildWriter, childToParentReader)
+			defer func() {
+				_ = parent.Close()
+				_ = parentToChildReader.Close()
+				_ = childToParentWriter.Close()
+			}()
+
+			responseResult := make(chan error, 1)
+			go func() {
+				admit, readErr := readWakeRepairHandoffAdmit(parentToChildReader)
+				if readErr != nil {
+					responseResult <- readErr
+					return
+				}
+				responseResult <- test.respond(childToParentWriter, admit)
+			}()
+
+			admitErr := parent.Admit(prepared)
+			if admitErr == nil {
+				t.Fatal("invalid admission response was accepted")
+			}
+			for _, want := range test.wants {
+				if !strings.Contains(admitErr.Error(), want) {
+					t.Fatalf("admission response error = %v, want %q", admitErr, want)
+				}
+			}
+			if test.avoid != "" && strings.Contains(admitErr.Error(), test.avoid) {
+				t.Fatalf("untrusted rejection reason surfaced before exact binding: %v", admitErr)
+			}
+			if parent.hasAdmit {
+				t.Fatal("invalid admission response recorded an exact acknowledgement")
+			}
+			if parent.hasReject {
+				t.Fatal("invalid admission response recorded an exact rejection")
+			}
+			if !parent.admitAttempted {
+				t.Fatal("invalid admission response did not make the exchange one-shot")
+			}
+			if retryErr := parent.Admit(prepared); retryErr == nil ||
+				!strings.Contains(retryErr.Error(), "already attempted") {
+				t.Fatalf("second admission after invalid response error = %v", retryErr)
+			}
+			if err := parent.Release(prepared); err == nil ||
+				!strings.Contains(err.Error(), "before exact acknowledgement") {
+				t.Fatalf("release after invalid response error = %v", err)
+			}
+			select {
+			case responseErr := <-responseResult:
+				if responseErr != nil {
+					t.Fatalf("write invalid admission response: %v", responseErr)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("invalid admission response writer did not finish")
+			}
+		})
 	}
 }
 
@@ -828,6 +1227,11 @@ func TestInheritedWakeRepairDirectoriesStayBoundAcrossAgentPathReplacement(t *te
 		_ = childInboxDir.Close()
 		_ = childAgentDir.Close()
 	}()
+	watcher, err := childInboxDir.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = watcher.Close() }()
 
 	detachedAgentPath := filepath.Join(filepath.Dir(sourceAgentPath), "codex-detached")
 	if err := os.Rename(sourceAgentPath, detachedAgentPath); err != nil {
@@ -884,28 +1288,49 @@ func TestInheritedWakeRepairDirectoriesStayBoundAcrossAgentPathReplacement(t *te
 		t.Fatalf("retained agent did not receive repair log: %v", err)
 	}
 
-	watcher, err := childInboxDir.NewWatcher()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = watcher.Close() }()
 	writeWakeRepairHandoffMessage(t, filepath.Join(replacementInboxPath, "replacement-event.md"), "replacement event")
-	select {
-	case event := <-watcher.Events():
-		t.Fatalf("replacement inbox reached retained watcher: %#v", event)
-	case err := <-watcher.Errors():
-		t.Fatalf("retained watcher error after replacement write: %v", err)
-	case <-time.After(150 * time.Millisecond):
-	}
-
 	detachedInboxPath := filepath.Join(detachedAgentPath, "inbox", "new")
 	writeWakeRepairHandoffMessage(t, filepath.Join(detachedInboxPath, "source-event.md"), "source event")
-	select {
-	case <-watcher.Events():
-	case err := <-watcher.Errors():
-		t.Fatalf("retained watcher error: %v", err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("retained watcher did not observe source inode write")
+	assertWakeRepairWatcherRejectsReplacementWithoutEvents(t, watcher)
+}
+
+func assertWakeRepairWatcherRejectsReplacementWithoutEvents(
+	t *testing.T,
+	watcher wakeEventWatcher,
+) {
+	t.Helper()
+	events := watcher.Events()
+	errorsC := watcher.Errors()
+	var watcherErr error
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+
+	for events != nil || errorsC != nil {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				events = nil
+				continue
+			}
+			t.Fatalf("retained watcher forwarded an event after namespace replacement: %#v", event)
+		case err, ok := <-errorsC:
+			if !ok {
+				errorsC = nil
+				continue
+			}
+			if err == nil {
+				t.Fatal("retained watcher reported an empty namespace replacement error")
+			}
+			if watcherErr != nil {
+				t.Fatalf("retained watcher reported multiple namespace replacement errors: %v; %v", watcherErr, err)
+			}
+			watcherErr = err
+		case <-timer.C:
+			t.Fatal("retained watcher did not terminate after namespace replacement and old-inode write")
+		}
+	}
+	if watcherErr == nil || !strings.Contains(watcherErr.Error(), "renamed or deleted") {
+		t.Fatalf("retained watcher namespace replacement error = %v", watcherErr)
 	}
 }
 

--- a/internal/cli/wake_repair_handoff_unix_test.go
+++ b/internal/cli/wake_repair_handoff_unix_test.go
@@ -1,0 +1,933 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+func wakeRepairFloorAuthorityForTest(
+	source wakeRepairHandoffSource,
+	generation string,
+) wakeRepairFloorAuthority {
+	return wakeRepairFloorAuthority{
+		ChildGeneration:   generation,
+		SourceFloorDigest: source.sourceFloorDigest,
+		RawDigest:         "sha256:" + strings.Repeat("5", 64),
+		FileIdentity: wakeFileIdentity{
+			Device:    1,
+			Inode:     2,
+			CTimeSec:  3,
+			CTimeNsec: 4,
+		},
+	}
+}
+
+func wakeRepairProtocolPreparedForTest(
+	t *testing.T,
+	generation string,
+) (wakeRepairHandoffSource, wakeRepairHandoffPrepared) {
+	t.Helper()
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               "/tmp/amq",
+		rootIdentity:       "v1:linux:1:2",
+		agent:              "codex",
+		sourceGeneration:   "source-generation",
+		sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+		sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+		bootID:             "boot-id",
+		agentDirDevice:     1,
+		agentDirInode:      2,
+		inboxDirDevice:     1,
+		inboxDirInode:      3,
+	}
+	prepared, err := newWakeRepairHandoffPrepared(
+		source,
+		os.Getpid(),
+		generation,
+		source.sourceTargetDigest,
+		"sha256:"+strings.Repeat("4", 64),
+		wakeRepairFloorAuthorityForTest(source, generation),
+	)
+	if err != nil {
+		t.Fatalf("new protocol prepared: %v", err)
+	}
+	return source, prepared
+}
+
+func TestWakeRepairHandoffMessagesBindExactSourcePreparedAndAdmit(t *testing.T) {
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               "/private/tmp/amq",
+		rootIdentity:       "v1:darwin:1:2",
+		agent:              "codex",
+		sourceGeneration:   "source-generation",
+		sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+		sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+		bootID:             "boot-id",
+		agentDirDevice:     1,
+		agentDirInode:      2,
+		inboxDirDevice:     1,
+		inboxDirInode:      3,
+	}
+	if err := source.validate(); err != nil {
+		t.Fatalf("validate source: %v", err)
+	}
+	sourceDigest, err := source.digest()
+	if err != nil {
+		t.Fatalf("digest source: %v", err)
+	}
+
+	prepared, err := newWakeRepairHandoffPrepared(
+		source,
+		4242,
+		"child-generation",
+		source.sourceTargetDigest,
+		"sha256:"+strings.Repeat("4", 64),
+		wakeRepairFloorAuthorityForTest(source, "child-generation"),
+	)
+	if err != nil {
+		t.Fatalf("new prepared: %v", err)
+	}
+	if prepared.sourceDigest != sourceDigest {
+		t.Fatalf("prepared source digest = %q, want %q", prepared.sourceDigest, sourceDigest)
+	}
+	admit, err := newWakeRepairHandoffAdmit(prepared)
+	if err != nil {
+		t.Fatalf("new admit: %v", err)
+	}
+	if admit.childGeneration != prepared.childGeneration {
+		t.Fatalf("admit generation = %q, want %q", admit.childGeneration, prepared.childGeneration)
+	}
+	preparedDigest, err := prepared.digest()
+	if err != nil {
+		t.Fatalf("digest prepared: %v", err)
+	}
+	if admit.preparedDigest != preparedDigest {
+		t.Fatalf("admit prepared digest = %q, want %q", admit.preparedDigest, preparedDigest)
+	}
+
+	replaced := prepared
+	replaced.childGeneration = "replacement"
+	if err := admit.validatePrepared(replaced); err == nil {
+		t.Fatal("admit accepted a different child generation")
+	}
+	release, err := newWakeRepairHandoffRelease(admit)
+	if err != nil {
+		t.Fatalf("new release: %v", err)
+	}
+	if err := release.validateAdmit(admit); err != nil {
+		t.Fatalf("validate exact release: %v", err)
+	}
+	replacedAdmit, err := newWakeRepairHandoffAdmit(replaced)
+	if err == nil {
+		if err := release.validateAdmit(replacedAdmit); err == nil {
+			t.Fatal("release accepted a different admitted child")
+		}
+	}
+}
+
+func TestWakeRepairHandoffFrameRoundTripIsStrictAndBounded(t *testing.T) {
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               "/tmp/amq",
+		rootIdentity:       "v1:linux:1:2",
+		agent:              "codex",
+		sourceGeneration:   "source-generation",
+		sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+		sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+		bootID:             "boot-id",
+		agentDirDevice:     1,
+		agentDirInode:      2,
+		inboxDirDevice:     1,
+		inboxDirInode:      3,
+	}
+	var encoded bytes.Buffer
+	if err := writeWakeRepairHandoffSource(&encoded, source); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	decoded, err := readWakeRepairHandoffSource(&encoded)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if decoded != source {
+		t.Fatalf("decoded source = %#v, want %#v", decoded, source)
+	}
+
+	unknown := bytes.NewBufferString(`{"schema":1,"kind":"source","unknown":true}` + "\n")
+	if _, err := readWakeRepairHandoffSource(unknown); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown-field error = %v", err)
+	}
+
+	oversized := bytes.NewBuffer(append(bytes.Repeat([]byte{'x'}, wakeRepairHandoffMaxFrameBytes+1), '\n'))
+	if _, err := readWakeRepairHandoffSource(oversized); err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("oversized-frame error = %v", err)
+	}
+}
+
+func TestWakeRepairPrivateHandoffRequiresExactAdmittedEcho(t *testing.T) {
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               "/tmp/amq",
+		rootIdentity:       "v1:linux:1:2",
+		agent:              "codex",
+		sourceGeneration:   "source-generation",
+		sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+		sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+		bootID:             "boot-id",
+		agentDirDevice:     1,
+		agentDirInode:      2,
+		inboxDirDevice:     1,
+		inboxDirInode:      3,
+	}
+	prepared, err := newWakeRepairHandoffPrepared(
+		source,
+		os.Getpid(),
+		"child-generation",
+		source.sourceTargetDigest,
+		"sha256:"+strings.Repeat("4", 64),
+		wakeRepairFloorAuthorityForTest(source, "child-generation"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parentToChildReader, parentToChildWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childToParentReader, childToParentWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = parentToChildReader.Close()
+		_ = parentToChildWriter.Close()
+		_ = childToParentReader.Close()
+		_ = childToParentWriter.Close()
+	}()
+	parent := newWakeRepairParentHandoffForFiles(parentToChildWriter, childToParentReader)
+	child := newWakeRepairChildHandoffForFiles(parentToChildReader, childToParentWriter)
+
+	var validationCalls atomic.Int32
+	errs := make(chan error, 1)
+	go func() {
+		gotSource, receiveErr := child.ReceiveSource()
+		if receiveErr != nil {
+			errs <- receiveErr
+			return
+		}
+		if gotSource != source {
+			errs <- io.ErrUnexpectedEOF
+			return
+		}
+		if sendErr := child.SendPrepared(prepared); sendErr != nil {
+			errs <- sendErr
+			return
+		}
+		errs <- child.AwaitAdmitAcknowledgeAndRelease(prepared, func() error {
+			validationCalls.Add(1)
+			return nil
+		})
+	}()
+
+	if err := parent.SendSource(source); err != nil {
+		t.Fatalf("send source: %v", err)
+	}
+	gotPrepared, err := parent.ReceivePrepared(source)
+	if err != nil {
+		t.Fatalf("receive prepared: %v", err)
+	}
+	if gotPrepared != prepared {
+		t.Fatalf("prepared = %#v, want %#v", gotPrepared, prepared)
+	}
+	if err := parent.Admit(prepared); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	if calls := validationCalls.Load(); calls != 1 {
+		t.Fatalf("validator calls after ACK = %d, want exactly 1", calls)
+	}
+	select {
+	case err := <-errs:
+		t.Fatalf("child passed admission before release: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if calls := validationCalls.Load(); calls != 1 {
+		t.Fatalf("validator calls before RELEASE = %d, want exactly 1", calls)
+	}
+	if err := parent.Release(prepared); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if err := <-errs; err != nil {
+		t.Fatalf("child handoff: %v", err)
+	}
+	if calls := validationCalls.Load(); calls != 2 {
+		t.Fatalf("validator calls after RELEASE = %d, want exactly 2", calls)
+	}
+	if err := parent.Release(prepared); err == nil ||
+		!strings.Contains(err.Error(), "already released") {
+		t.Fatalf("duplicate release error = %v", err)
+	}
+}
+
+func TestWakeRepairPostReleaseValidationFailureDoesNotPassGate(t *testing.T) {
+	_, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
+	parentToChildReader, parentToChildWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childToParentReader, childToParentWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = parentToChildReader.Close()
+		_ = parentToChildWriter.Close()
+		_ = childToParentReader.Close()
+		_ = childToParentWriter.Close()
+	}()
+	parent := newWakeRepairParentHandoffForFiles(parentToChildWriter, childToParentReader)
+	child := newWakeRepairChildHandoffForFiles(parentToChildReader, childToParentWriter)
+
+	outputPath := filepath.Join(t.TempDir(), "gate-effect")
+	var validationCalls atomic.Int32
+	result := make(chan error, 1)
+	go func() {
+		gateErr := child.AwaitAdmitAcknowledgeAndRelease(
+			prepared,
+			func() error {
+				if validationCalls.Add(1) == 2 {
+					return errors.New("injected post-release validation failure")
+				}
+				return nil
+			},
+		)
+		if gateErr == nil {
+			gateErr = os.WriteFile(outputPath, []byte("effect\n"), 0o600)
+		}
+		result <- gateErr
+	}()
+
+	if err := parent.Admit(prepared); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	if calls := validationCalls.Load(); calls != 1 {
+		t.Fatalf("validator calls after ACK = %d, want exactly 1", calls)
+	}
+	if err := parent.Release(prepared); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	select {
+	case err := <-result:
+		if err == nil ||
+			!strings.Contains(err.Error(), "post-release admission validation failed") ||
+			!strings.Contains(err.Error(), "injected post-release validation failure") {
+			t.Fatalf("post-release validation error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("post-release validation failure did not close the admission gate")
+	}
+	if calls := validationCalls.Load(); calls != 2 {
+		t.Fatalf("validator calls after RELEASE = %d, want exactly 2", calls)
+	}
+	if output, err := os.ReadFile(outputPath); err == nil {
+		t.Fatalf("post-release validation failure allowed gate effect: %q", output)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("inspect post-release gate effect: %v", err)
+	}
+}
+
+func TestWakeRepairChildCannotPassAdmissionGateOnParentEOF(t *testing.T) {
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               "/tmp/amq",
+		rootIdentity:       "v1:linux:1:2",
+		agent:              "codex",
+		sourceGeneration:   "source-generation",
+		sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+		sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+		bootID:             "boot-id",
+		agentDirDevice:     1,
+		agentDirInode:      2,
+		inboxDirDevice:     1,
+		inboxDirInode:      3,
+	}
+	prepared, err := newWakeRepairHandoffPrepared(
+		source,
+		os.Getpid(),
+		"child-generation",
+		source.sourceTargetDigest,
+		"sha256:"+strings.Repeat("4", 64),
+		wakeRepairFloorAuthorityForTest(source, "child-generation"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentToChildReader, parentToChildWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childToParentReader, childToParentWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = childToParentReader.Close() }()
+	child := newWakeRepairChildHandoffForFiles(parentToChildReader, childToParentWriter)
+	defer func() { _ = child.Close() }()
+
+	if err := parentToChildWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := child.AwaitAdmitAcknowledgeAndRelease(prepared, func() error { return nil }); err == nil ||
+		!strings.Contains(err.Error(), "admission") {
+		t.Fatalf("admission EOF error = %v", err)
+	}
+}
+
+func TestWakeRepairParentAdmissionAcknowledgementIsBounded(t *testing.T) {
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               "/tmp/amq",
+		rootIdentity:       "v1:linux:1:2",
+		agent:              "codex",
+		sourceGeneration:   "source-generation",
+		sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+		sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+		bootID:             "boot-id",
+		agentDirDevice:     1,
+		agentDirInode:      2,
+		inboxDirDevice:     1,
+		inboxDirInode:      3,
+	}
+	prepared, err := newWakeRepairHandoffPrepared(
+		source,
+		os.Getpid(),
+		"child-generation",
+		source.sourceTargetDigest,
+		"sha256:"+strings.Repeat("4", 64),
+		wakeRepairFloorAuthorityForTest(source, "child-generation"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentToChildReader, parentToChildWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childToParentReader, childToParentWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = parentToChildReader.Close()
+		_ = parentToChildWriter.Close()
+		_ = childToParentReader.Close()
+		_ = childToParentWriter.Close()
+	}()
+	parent := newWakeRepairParentHandoffForFiles(parentToChildWriter, childToParentReader)
+	defer func() { _ = parent.Close() }()
+
+	oldTimeout := wakeRepairAdmitTimeout
+	wakeRepairAdmitTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { wakeRepairAdmitTimeout = oldTimeout })
+	started := time.Now()
+	err = parent.Admit(prepared)
+	if err == nil {
+		t.Fatal("admission unexpectedly accepted a missing child acknowledgement")
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("admission acknowledgement timeout took %s", elapsed)
+	}
+	if !strings.Contains(err.Error(), "acknowledgement") {
+		t.Fatalf("admission timeout error = %v", err)
+	}
+}
+
+func TestWakeRepairParentReleaseRequiresExactAcknowledgement(t *testing.T) {
+	_, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
+	parentToChildReader, parentToChildWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childToParentReader, childToParentWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = parentToChildReader.Close()
+		_ = parentToChildWriter.Close()
+		_ = childToParentReader.Close()
+		_ = childToParentWriter.Close()
+	}()
+	parent := newWakeRepairParentHandoffForFiles(parentToChildWriter, childToParentReader)
+
+	if err := parent.Release(prepared); err == nil ||
+		!strings.Contains(err.Error(), "before exact acknowledgement") {
+		t.Fatalf("release-before-ack error = %v", err)
+	}
+	if err := parentToChildReader.SetReadDeadline(time.Now().Add(50 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	var unexpected [1]byte
+	if _, err := parentToChildReader.Read(unexpected[:]); err == nil {
+		t.Fatalf("release-before-ack wrote protocol bytes: %q", unexpected[:])
+	}
+}
+
+func TestWakeRepairChildReleaseFailuresFailClosed(t *testing.T) {
+	source, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
+	admit, err := newWakeRepairHandoffAdmit(prepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exactRelease, err := newWakeRepairHandoffRelease(admit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, mismatchedPrepared := wakeRepairProtocolPreparedForTest(t, "other-generation")
+	mismatchedAdmit, err := newWakeRepairHandoffAdmit(mismatchedPrepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mismatchedRelease, err := newWakeRepairHandoffRelease(mismatchedAdmit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		action func(*os.File) bool
+		wants  []string
+	}{
+		{
+			name:  "missing release times out",
+			wants: []string{"wait for wake repair release", "timeout"},
+		},
+		{
+			name: "release EOF",
+			action: func(writer *os.File) bool {
+				if err := writer.Close(); err != nil {
+					t.Fatalf("close release writer: %v", err)
+				}
+				return true
+			},
+			wants: []string{"wait for wake repair release", "EOF"},
+		},
+		{
+			name: "partial release",
+			action: func(writer *os.File) bool {
+				if _, err := io.WriteString(writer, `{"schema":1,"kind":"release"`); err != nil {
+					t.Fatalf("write partial release: %v", err)
+				}
+				if err := writer.Close(); err != nil {
+					t.Fatalf("close partial release writer: %v", err)
+				}
+				return true
+			},
+			wants: []string{"wait for wake repair release", "EOF"},
+		},
+		{
+			name: "admit replay where release required",
+			action: func(writer *os.File) bool {
+				wrongKind := exactRelease.wire()
+				wrongKind.Kind = wakeRepairHandoffKindAdmit
+				if err := writeWakeRepairHandoffFrame(writer, wrongKind); err != nil {
+					t.Fatalf("write replayed admit: %v", err)
+				}
+				return false
+			},
+			wants: []string{`want release`},
+		},
+		{
+			name: "release for different admit",
+			action: func(writer *os.File) bool {
+				if err := writeWakeRepairHandoffRelease(writer, mismatchedRelease); err != nil {
+					t.Fatalf("write mismatched release: %v", err)
+				}
+				return false
+			},
+			wants: []string{"release does not match exact admit"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parentToChildReader, parentToChildWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			childToParentReader, childToParentWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			writerClosed := false
+			defer func() {
+				_ = parentToChildReader.Close()
+				if !writerClosed {
+					_ = parentToChildWriter.Close()
+				}
+				_ = childToParentReader.Close()
+				_ = childToParentWriter.Close()
+			}()
+			child := newWakeRepairChildHandoffForFiles(
+				parentToChildReader,
+				childToParentWriter,
+			)
+
+			oldTimeout := wakeRepairAdmitTimeout
+			wakeRepairAdmitTimeout = 50 * time.Millisecond
+			defer func() { wakeRepairAdmitTimeout = oldTimeout }()
+
+			beforeAcknowledgeCalls := 0
+			result := make(chan error, 1)
+			go func() {
+				result <- child.AwaitAdmitAcknowledgeAndRelease(
+					prepared,
+					func() error {
+						beforeAcknowledgeCalls++
+						return nil
+					},
+				)
+			}()
+			if err := writeWakeRepairHandoffAdmit(parentToChildWriter, admit); err != nil {
+				t.Fatalf("write admit: %v", err)
+			}
+			ack, err := readWakeRepairHandoffAdmit(childToParentReader)
+			if err != nil {
+				t.Fatalf("read admitted acknowledgement: %v", err)
+			}
+			if ack != admit {
+				t.Fatalf("acknowledgement = %#v, want %#v", ack, admit)
+			}
+			if test.action != nil {
+				writerClosed = test.action(parentToChildWriter)
+			}
+
+			select {
+			case err := <-result:
+				if err == nil {
+					t.Fatal("child passed admission without an exact release")
+				}
+				for _, want := range test.wants {
+					if !strings.Contains(err.Error(), want) {
+						t.Fatalf("release failure error = %v, want %q", err, want)
+					}
+				}
+			case <-time.After(time.Second):
+				t.Fatal("child did not fail closed on invalid release")
+			}
+			if beforeAcknowledgeCalls != 1 {
+				t.Fatalf("before-ack validation calls = %d, want 1", beforeAcknowledgeCalls)
+			}
+			if err := source.validate(); err != nil {
+				t.Fatalf("source changed during protocol test: %v", err)
+			}
+		})
+	}
+}
+
+func TestPrepareWakeRepairHandoffUsesPrivateInheritedDescriptors(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = inboxDir.Close() }()
+
+	cmd := exec.Command("true")
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               canonicalWakeRoot(root),
+		rootIdentity:       "v1:linux:1:2",
+		agent:              "codex",
+		sourceGeneration:   "source-generation",
+		sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+		sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+		bootID:             "boot-id",
+	}
+	if err := source.bindRetainedDirectories(agentDir, inboxDir); err != nil {
+		t.Fatal(err)
+	}
+	handoff, err := prepareWakeRepairHandoff(cmd, source, agentDir, inboxDir)
+	if err != nil {
+		t.Fatalf("prepare handoff: %v", err)
+	}
+	defer func() { _ = handoff.Close() }()
+	if len(cmd.ExtraFiles) != 4 {
+		t.Fatalf("extra files = %d, want 4", len(cmd.ExtraFiles))
+	}
+	env := strings.Join(cmd.Env, "\n")
+	if !strings.Contains(env, envWakeRepairHandoffReadFD+"=3") ||
+		!strings.Contains(env, envWakeRepairHandoffWriteFD+"=4") ||
+		!strings.Contains(env, envWakeRepairAgentDirFD+"=5") ||
+		!strings.Contains(env, envWakeRepairInboxDirFD+"=6") {
+		t.Fatalf("handoff env = %q", env)
+	}
+	for index, label := range []string{"agent directory", "inbox directory"} {
+		fd := cmd.ExtraFiles[index+2].Fd()
+		flags, err := unix.FcntlInt(fd, unix.F_GETFD, 0)
+		if err != nil {
+			t.Fatalf("inspect duplicated %s fd: %v", label, err)
+		}
+		if flags&unix.FD_CLOEXEC == 0 {
+			t.Fatalf("duplicated %s fd %d is not close-on-exec in parent", label, fd)
+		}
+	}
+}
+
+func TestWakeRepairChildHandoffDescriptorsDoNotLeakIntoInjector(t *testing.T) {
+	fds := make([]int, 4)
+	for index := range fds {
+		reader, writer, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		fd, err := unix.Dup(int(reader.Fd()))
+		_ = reader.Close()
+		if err != nil {
+			_ = writer.Close()
+			t.Fatalf("duplicate inherited handoff fd: %v", err)
+		}
+		t.Cleanup(func() { _ = writer.Close() })
+		fds[index] = fd
+	}
+	t.Setenv(envWakeRepairHandoffReadFD, strconv.Itoa(fds[0]))
+	t.Setenv(envWakeRepairHandoffWriteFD, strconv.Itoa(fds[1]))
+	t.Setenv(envWakeRepairAgentDirFD, strconv.Itoa(fds[2]))
+	t.Setenv(envWakeRepairInboxDirFD, strconv.Itoa(fds[3]))
+
+	handoff, present, err := wakeRepairChildHandoffFromEnv()
+	if err != nil {
+		for _, fd := range fds {
+			_ = unix.Close(fd)
+		}
+		t.Fatalf("initialize inherited child handoff: %v", err)
+	}
+	if !present {
+		t.Fatal("inherited child handoff was not detected")
+	}
+	defer func() { _ = handoff.Close() }()
+
+	for _, fd := range fds {
+		flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+		if err != nil {
+			t.Fatalf("inspect initialized handoff fd %d: %v", fd, err)
+		}
+		if flags&unix.FD_CLOEXEC == 0 {
+			t.Fatalf("initialized handoff fd %d is not close-on-exec", fd)
+		}
+	}
+	assertWakeRepairDescriptorsClosedInInjector(t, fds)
+}
+
+func assertWakeRepairDescriptorsClosedInInjector(t *testing.T, fds []int) {
+	t.Helper()
+	output := filepath.Join(t.TempDir(), "open-fds")
+	inspector := filepath.Join(t.TempDir(), "fd-inspector")
+	script := "#!/bin/sh\n" + `output=$1; shift; count=$1; shift; : > "$output"; while [ "$count" -gt 0 ]; do fd=$1; shift; if [ -e "/dev/fd/$fd" ]; then printf '%s\n' "$fd" >> "$output"; fi; count=$((count - 1)); done` + "\n"
+	if err := os.WriteFile(inspector, []byte(script), 0o700); err != nil {
+		t.Fatalf("write user-owned injector inspector: %v", err)
+	}
+	inspector, err := filepath.EvalSymlinks(inspector)
+	if err != nil {
+		t.Fatalf("resolve user-owned injector inspector: %v", err)
+	}
+	args := []string{output, strconv.Itoa(len(fds))}
+	for _, fd := range fds {
+		args = append(args, strconv.Itoa(fd))
+	}
+	if err := injectVia(&wakeConfig{
+		injectVia:     inspector,
+		injectArgs:    args,
+		injectTimeout: 2 * time.Second,
+	}, "ignored wake payload"); err != nil {
+		t.Fatalf("run injector fd inspector: %v", err)
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read injector fd inspection: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("repair descriptors leaked into injector child: %s", data)
+	}
+}
+
+func TestInheritedWakeRepairDirectoriesStayBoundAcrossAgentPathReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	sourceAgentPath := fsq.AgentBase(root, "codex")
+	sourceInboxPath := fsq.AgentInboxNew(root, "codex")
+	writeWakeRepairHandoffMessage(t, filepath.Join(sourceInboxPath, "source.md"), "source")
+
+	parentAgentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = parentAgentDir.Close() }()
+	parentInboxDir, err := openWakeRepairInboxDir(parentAgentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = parentInboxDir.Close() }()
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               canonicalWakeRoot(root),
+		rootIdentity:       "v1:darwin:1:2",
+		agent:              "codex",
+		sourceGeneration:   "source-generation",
+		sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+		sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+		bootID:             "boot-id",
+	}
+	if err := source.bindRetainedDirectories(parentAgentDir, parentInboxDir); err != nil {
+		t.Fatal(err)
+	}
+	childAgentFile, err := duplicateWakeRepairDirectoryFile(parentAgentDir.file, "test inherited wake agent directory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	childInboxFile, err := duplicateWakeRepairDirectoryFile(parentInboxDir.file, "test inherited wake inbox directory")
+	if err != nil {
+		_ = childAgentFile.Close()
+		t.Fatal(err)
+	}
+	childAgentDir, childInboxDir, err := openInheritedWakeRepairDirectories(
+		childAgentFile,
+		childInboxFile,
+		source,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = childInboxDir.Close()
+		_ = childAgentDir.Close()
+	}()
+
+	detachedAgentPath := filepath.Join(filepath.Dir(sourceAgentPath), "codex-detached")
+	if err := os.Rename(sourceAgentPath, detachedAgentPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	replacementInboxPath := fsq.AgentInboxNew(root, "codex")
+	writeWakeRepairHandoffMessage(t, filepath.Join(replacementInboxPath, "replacement.md"), "replacement")
+
+	entries, err := childInboxDir.ReadDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	if strings.Join(names, ",") != "source.md" {
+		t.Fatalf("retained inbox entries = %v, want only source.md", names)
+	}
+	header, err := childInboxDir.ReadHeader("source.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if header.Subject != "source" {
+		t.Fatalf("retained header subject = %q, want source", header.Subject)
+	}
+	if err := touchWakePresenceInDir(childAgentDir, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(sourceAgentPath, "presence.json")); !os.IsNotExist(err) {
+		t.Fatalf("replacement agent received retained presence touch: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(detachedAgentPath, "presence.json")); err != nil {
+		t.Fatalf("retained agent did not receive presence touch: %v", err)
+	}
+	output, err := openWakeRepairOutputInDir(childAgentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := output.WriteString("retained\n"); err != nil {
+		_ = output.Close()
+		t.Fatal(err)
+	}
+	if err := output.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(sourceAgentPath, ".wake.repair.log")); !os.IsNotExist(err) {
+		t.Fatalf("replacement agent received retained repair log: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(detachedAgentPath, ".wake.repair.log")); err != nil {
+		t.Fatalf("retained agent did not receive repair log: %v", err)
+	}
+
+	watcher, err := childInboxDir.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = watcher.Close() }()
+	writeWakeRepairHandoffMessage(t, filepath.Join(replacementInboxPath, "replacement-event.md"), "replacement event")
+	select {
+	case event := <-watcher.Events():
+		t.Fatalf("replacement inbox reached retained watcher: %#v", event)
+	case err := <-watcher.Errors():
+		t.Fatalf("retained watcher error after replacement write: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	detachedInboxPath := filepath.Join(detachedAgentPath, "inbox", "new")
+	writeWakeRepairHandoffMessage(t, filepath.Join(detachedInboxPath, "source-event.md"), "source event")
+	select {
+	case <-watcher.Events():
+	case err := <-watcher.Errors():
+		t.Fatalf("retained watcher error: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("retained watcher did not observe source inode write")
+	}
+}
+
+func writeWakeRepairHandoffMessage(t *testing.T, path, subject string) {
+	t.Helper()
+	data, err := (format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       subject,
+			From:     "claude",
+			To:       []string{"codex"},
+			Thread:   "p2p/claude__codex",
+			Subject:  subject,
+			Created:  "2026-07-24T00:00:00Z",
+			Priority: "normal",
+		},
+		Body: "body",
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/wake_repair_handoff_unix_test.go
+++ b/internal/cli/wake_repair_handoff_unix_test.go
@@ -1146,21 +1146,27 @@ func assertWakeRepairDescriptorsClosedInInjector(t *testing.T, fds []int) {
 	t.Helper()
 	dir := secureTempDirForTest(t)
 	output := filepath.Join(dir, "open-fds")
-	inspector := filepath.Join(dir, "fd-inspector")
-	script := "#!/bin/sh\n" + `output=$1; shift; count=$1; shift; : > "$output"; while [ "$count" -gt 0 ]; do fd=$1; shift; if [ -e "/dev/fd/$fd" ]; then printf '%s\n' "$fd" >> "$output"; fi; count=$((count - 1)); done` + "\n"
-	if err := os.WriteFile(inspector, []byte(script), 0o700); err != nil {
-		t.Fatalf("write user-owned injector inspector: %v", err)
+	t.Setenv(injectViaHelperEnv, "1")
+	args := []string{
+		"-test.run=^TestWakeRepairFDInspectorHelperProcess$",
+		"--",
+		output,
+		strconv.Itoa(len(fds)),
 	}
-	inspector, err := filepath.EvalSymlinks(inspector)
-	if err != nil {
-		t.Fatalf("resolve user-owned injector inspector: %v", err)
-	}
-	args := []string{output, strconv.Itoa(len(fds))}
 	for _, fd := range fds {
-		args = append(args, strconv.Itoa(fd))
+		var stat unix.Stat_t
+		if err := unix.Fstat(fd, &stat); err != nil {
+			t.Fatalf("stat repair descriptor %d before injector exec: %v", fd, err)
+		}
+		args = append(
+			args,
+			strconv.Itoa(fd)+":"+
+				strconv.FormatUint(uint64(stat.Dev), 10)+":"+
+				strconv.FormatUint(uint64(stat.Ino), 10),
+		)
 	}
 	if err := injectVia(&wakeConfig{
-		injectVia:     inspector,
+		injectVia:     copyTestBinaryForInjectVia(t),
 		injectArgs:    args,
 		injectTimeout: 2 * time.Second,
 	}, "ignored wake payload"); err != nil {
@@ -1173,6 +1179,57 @@ func assertWakeRepairDescriptorsClosedInInjector(t *testing.T, fds []int) {
 	if len(data) != 0 {
 		t.Fatalf("repair descriptors leaked into injector child: %s", data)
 	}
+}
+
+func TestWakeRepairFDInspectorHelperProcess(t *testing.T) {
+	if os.Getenv(injectViaHelperEnv) != "1" {
+		return
+	}
+
+	separator := -1
+	for index, arg := range os.Args {
+		if arg == "--" {
+			separator = index
+			break
+		}
+	}
+	if separator < 0 || separator+2 >= len(os.Args) {
+		_, _ = os.Stderr.WriteString("missing repair descriptor inspector arguments\n")
+		os.Exit(2)
+	}
+	output := os.Args[separator+1]
+	count, err := strconv.Atoi(os.Args[separator+2])
+	if err != nil || count < 0 || separator+3+count > len(os.Args) {
+		_, _ = os.Stderr.WriteString("invalid repair descriptor inspector count\n")
+		os.Exit(2)
+	}
+
+	var leaked []string
+	for _, encoded := range os.Args[separator+3 : separator+3+count] {
+		parts := strings.Split(encoded, ":")
+		if len(parts) != 3 {
+			_, _ = os.Stderr.WriteString("invalid repair descriptor identity\n")
+			os.Exit(2)
+		}
+		fd, fdErr := strconv.Atoi(parts[0])
+		device, deviceErr := strconv.ParseUint(parts[1], 10, 64)
+		inode, inodeErr := strconv.ParseUint(parts[2], 10, 64)
+		if fdErr != nil || deviceErr != nil || inodeErr != nil {
+			_, _ = os.Stderr.WriteString("invalid repair descriptor identity\n")
+			os.Exit(2)
+		}
+		var stat unix.Stat_t
+		if statErr := unix.Fstat(fd, &stat); statErr == nil &&
+			uint64(stat.Dev) == device &&
+			uint64(stat.Ino) == inode {
+			leaked = append(leaked, strconv.Itoa(fd))
+		}
+	}
+	if err := os.WriteFile(output, []byte(strings.Join(leaked, "\n")), 0o600); err != nil {
+		_, _ = os.Stderr.WriteString("write repair descriptor inspection: " + err.Error() + "\n")
+		os.Exit(3)
+	}
+	os.Exit(0)
 }
 
 func TestInheritedWakeRepairDirectoriesStayBoundAcrossAgentPathReplacement(t *testing.T) {
@@ -1330,7 +1387,15 @@ func assertWakeRepairWatcherRejectsReplacementWithoutEvents(
 			t.Fatal("retained watcher did not terminate after namespace replacement and old-inode write")
 		}
 	}
-	if watcherErr == nil || !strings.Contains(watcherErr.Error(), "renamed or deleted") {
+	if watcherErr == nil {
+		t.Fatal("retained watcher closed without a namespace replacement error")
+	}
+	message := watcherErr.Error()
+	if !strings.Contains(message, "renamed or deleted") &&
+		!strings.Contains(
+			message,
+			"canonical wake repair agent directory no longer matches retained authority",
+		) {
 		t.Fatalf("retained watcher namespace replacement error = %v", watcherErr)
 	}
 }

--- a/internal/cli/wake_repair_namespace_unix_test.go
+++ b/internal/cli/wake_repair_namespace_unix_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -175,6 +176,7 @@ func TestRepairWakeChildAdmissionRejectsNamespaceReplacementAfterParentValidatio
 				}
 			},
 			wants: []string{
+				"wake watcher failed before admission: retained wake agent directory was renamed or deleted",
 				"canonical wake repair agent directory no longer matches retained authority",
 			},
 		},
@@ -224,29 +226,32 @@ func TestRepairWakeChildAdmissionRejectsNamespaceReplacementAfterParentValidatio
 			if result.Status == "repaired" {
 				t.Fatalf("detached namespace returned repaired: %#v", result)
 			}
+			returnedEvidence := result.Reason + "\n" + err.Error()
+			matched := false
+			for _, want := range test.wants {
+				if strings.Contains(returnedEvidence, want) {
+					matched = true
+					break
+				}
+			}
+			if matched {
+				assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+				return
+			}
+
 			diagnostics := wakeRepairLifecycleDiagnostics(fixture, child)
 			logAgentPath := fsq.AgentBase(fixture.root, "codex")
 			if test.name == "ancestor agent directory" {
 				logAgentPath += ".detached"
 			}
 			logData, _ := os.ReadFile(filepath.Join(logAgentPath, ".wake.repair.log"))
-			evidence := diagnostics + "\nretained repair log:\n" + string(logData)
-			matched := false
-			for _, want := range test.wants {
-				if strings.Contains(evidence, want) {
-					matched = true
-					break
-				}
-			}
-			if !matched {
-				t.Fatalf(
-					"child did not report final namespace validation failure\nresult=%#v err=%v\n%s",
-					result,
-					err,
-					evidence,
-				)
-			}
-			assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+			t.Fatalf(
+				"child did not return final namespace validation failure\nresult=%#v err=%v\n%s\nretained repair log:\n%s",
+				result,
+				err,
+				diagnostics,
+				logData,
+			)
 		})
 	}
 }
@@ -324,6 +329,201 @@ func TestRepairWakeParentRevalidatesNamespaceAfterChildAcknowledgement(t *testin
 			path := filepath.Join(directory.path, name)
 			if _, err := os.Lstat(path); !os.IsNotExist(err) {
 				t.Fatalf("%s claim residue %s remains: %v", directory.label, path, err)
+			}
+		}
+	}
+}
+
+func TestRepairedWakeExitsWithoutInjectingDetachedNamespaceMessages(t *testing.T) {
+	tests := []struct {
+		name    string
+		replace func(t *testing.T, root string) (string, []string)
+	}{
+		{
+			name: "ancestor agent replacement",
+			replace: func(t *testing.T, root string) (string, []string) {
+				t.Helper()
+				canonicalAgent := fsq.AgentBase(root, "codex")
+				detachedAgent := canonicalAgent + ".post-release-detached"
+				if err := os.Rename(canonicalAgent, detachedAgent); err != nil {
+					t.Fatalf("detach live repaired agent directory: %v", err)
+				}
+				if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+					t.Fatalf("create replacement live agent directory: %v", err)
+				}
+				return filepath.Join(detachedAgent, "inbox", "new"), []string{
+					canonicalAgent,
+					detachedAgent,
+				}
+			},
+		},
+		{
+			name: "direct inbox replacement",
+			replace: func(t *testing.T, root string) (string, []string) {
+				t.Helper()
+				canonicalAgent := fsq.AgentBase(root, "codex")
+				canonicalInbox := fsq.AgentInboxNew(root, "codex")
+				detachedInbox := canonicalInbox + ".post-release-detached"
+				if err := os.Rename(canonicalInbox, detachedInbox); err != nil {
+					t.Fatalf("detach live repaired inbox directory: %v", err)
+				}
+				if err := os.Mkdir(canonicalInbox, 0o700); err != nil {
+					t.Fatalf("create replacement live inbox directory: %v", err)
+				}
+				return detachedInbox, []string{
+					canonicalAgent,
+					detachedInbox,
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeRepairLifecycleFixture(t)
+			var child *wakeRepairChild
+			stubRealRepairStarter(
+				t,
+				func(started *wakeRepairChild, _ error) {
+					child = started
+					cleanupRepairLifecycleChild(t, started)
+				},
+				func(started *wakeRepairChild) {
+					stubRepairLifecycleChildInspectionWithoutLockMutation(t, fixture, started)
+				},
+			)
+
+			result, err := repairWake(fixture.root, "codex")
+			if err != nil || result.Status != "repaired" {
+				t.Fatalf("repair did not reach RELEASE: result=%#v err=%v", result, err)
+			}
+			if child == nil || child.Process == nil || child.Waiter == nil {
+				t.Fatal("successful repair did not retain its exact child and waiter")
+			}
+			if result.PID != child.Process.Pid {
+				t.Fatalf("repair result pid=%d, want captured child pid=%d", result.PID, child.Process.Pid)
+			}
+
+			releasedOutput := waitForWakeRepairOutputLine(t, fixture.outputPath)
+			if !bytes.Contains(releasedOutput, []byte("must wait for admission")) {
+				t.Fatalf("released wake output does not contain pending message: %q", releasedOutput)
+			}
+			releasedOutput = append([]byte(nil), releasedOutput...)
+
+			detachedInbox, authorities := test.replace(t, fixture.root)
+			writeWakeRepairHandoffMessage(
+				t,
+				filepath.Join(detachedInbox, "late-detached.md"),
+				"late detached message",
+			)
+
+			if err := child.Waiter.waitForExit(5 * time.Second); err != nil {
+				t.Fatalf("repaired wake did not exit after namespace replacement: %v", err)
+			}
+			if child.Waiter.state == nil {
+				t.Fatal("repaired wake exited without a process state")
+			}
+			if processAlive(child.Process.Pid) {
+				t.Fatalf("repaired wake pid %d remains alive after waiter exit", child.Process.Pid)
+			}
+
+			output, err := os.ReadFile(fixture.outputPath)
+			if err != nil {
+				t.Fatalf("read released wake output after child exit: %v", err)
+			}
+			if !bytes.Equal(output, releasedOutput) {
+				t.Fatalf(
+					"detached namespace message changed injector output:\nbefore=%q\nafter=%q",
+					releasedOutput,
+					output,
+				)
+			}
+			assertWakeRepairClaimResidueAbsent(t, authorities)
+		})
+	}
+}
+
+func stubRepairLifecycleChildInspectionWithoutLockMutation(
+	t *testing.T,
+	fixture wakeRepairLifecycleFixture,
+	child *wakeRepairChild,
+) {
+	t.Helper()
+	if child == nil || child.Process == nil {
+		t.Fatal("prepared repair child is missing")
+	}
+	inspection := inspectWakeLock(fixture.root, "codex")
+	if !inspection.Exists {
+		t.Fatal("prepared repair child did not publish a lock")
+	}
+	lock := inspection.Lock
+	previous := inspectWakeProcess
+	inspectWakeProcess = func(pid int) wakeProcessInfo {
+		if pid == child.Process.Pid {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: lock.ProcessStart,
+				BootID:     lock.BootID,
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"amq", "wake", "--root", fixture.root, "--me", "codex"},
+			}
+		}
+		return previous(pid)
+	}
+	t.Cleanup(func() {
+		inspectWakeProcess = previous
+	})
+	confirmed := inspectWakeLock(fixture.root, "codex")
+	if confirmed.Status != wakeLockValid || !confirmed.IdentityConfirmed {
+		t.Fatalf(
+			"stubbed prepared child inspection status=%q identity=%v reason=%q",
+			confirmed.Status,
+			confirmed.IdentityConfirmed,
+			confirmed.Reason,
+		)
+	}
+	if !sameWakeLockGeneration(inspection, confirmed) {
+		t.Fatal("process inspection stub changed exact child lock generation")
+	}
+}
+
+func waitForWakeRepairOutputLine(t *testing.T, path string) []byte {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
+	for {
+		output, err := os.ReadFile(path)
+		switch {
+		case err == nil && len(output) > 0 && output[len(output)-1] == '\n':
+			return output
+		case err != nil && !os.IsNotExist(err):
+			t.Fatalf("read released wake output: %v", err)
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			output, _ := os.ReadFile(path)
+			t.Fatalf("released wake did not produce a complete injector line: %q", output)
+		}
+	}
+}
+
+func assertWakeRepairClaimResidueAbsent(t *testing.T, authorities []string) {
+	t.Helper()
+	checked := make(map[string]struct{}, len(authorities))
+	for _, authority := range authorities {
+		if _, exists := checked[authority]; exists {
+			continue
+		}
+		checked[authority] = struct{}{}
+		for _, name := range []string{".wake.lock", wakeRepairFloorFileName} {
+			path := filepath.Join(authority, name)
+			if _, err := os.Lstat(path); !os.IsNotExist(err) {
+				t.Fatalf("wake repair claim residue remains at %s: %v", path, err)
 			}
 		}
 	}

--- a/internal/cli/wake_repair_namespace_unix_test.go
+++ b/internal/cli/wake_repair_namespace_unix_test.go
@@ -1,0 +1,343 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type fixedWakeAdmissionWatcher struct {
+	errors chan error
+}
+
+func (watcher fixedWakeAdmissionWatcher) Errors() <-chan error {
+	return watcher.errors
+}
+
+func TestValidateCanonicalWakeRepairDirectoriesRejectsNamespaceReplacement(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		replace func(t *testing.T, root string)
+		want    string
+	}{
+		{
+			name: "agent directory",
+			replace: func(t *testing.T, root string) {
+				t.Helper()
+				agentPath := fsq.AgentBase(root, "codex")
+				if err := os.Rename(agentPath, agentPath+".detached"); err != nil {
+					t.Fatalf("detach agent directory: %v", err)
+				}
+				if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+					t.Fatalf("create replacement agent directory: %v", err)
+				}
+			},
+			want: "agent directory no longer matches",
+		},
+		{
+			name: "inbox directory",
+			replace: func(t *testing.T, root string) {
+				t.Helper()
+				inboxPath := fsq.AgentInboxNew(root, "codex")
+				if err := os.Rename(inboxPath, inboxPath+".detached"); err != nil {
+					t.Fatalf("detach inbox directory: %v", err)
+				}
+				if err := os.Mkdir(inboxPath, 0o700); err != nil {
+					t.Fatalf("create replacement inbox directory: %v", err)
+				}
+			},
+			want: "inbox directory no longer matches",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			agentDir, err := openWakeAgentDir(root, "codex")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = agentDir.Close() }()
+			inboxDir, err := openWakeRepairInboxDir(agentDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = inboxDir.Close() }()
+			source := wakeRepairHandoffSource{
+				schema:             wakeRepairHandoffSchema,
+				root:               canonicalWakeRoot(root),
+				rootIdentity:       "v1:test:1:2",
+				agent:              "codex",
+				sourceGeneration:   "source-generation",
+				sourceTargetDigest: "sha256:" + strings.Repeat("1", 64),
+				sourceFloorDigest:  "sha256:" + strings.Repeat("2", 64),
+				bootID:             "boot-id",
+			}
+			if err := source.bindRetainedDirectories(agentDir, inboxDir); err != nil {
+				t.Fatal(err)
+			}
+			if err := validateCanonicalWakeRepairDirectories(root, "codex", source); err != nil {
+				t.Fatalf("initial canonical binding: %v", err)
+			}
+
+			test.replace(t, root)
+
+			err = validateCanonicalWakeRepairDirectories(root, "codex", source)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("replacement error = %v, want %q", err, test.want)
+			}
+			if _, statErr := os.Stat(filepath.Join(fsq.AgentBase(root, "codex"), "inbox", "new")); statErr != nil {
+				t.Fatalf("replacement namespace is unusable: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestValidateWakeRepairChildAdmissionRejectsPendingWatcherRootLoss(t *testing.T) {
+	watcherErrors := make(chan error, 1)
+	watcherErrors <- errors.New("retained wake inbox directory was renamed or deleted")
+	err := validateWakeRepairChildAdmission(
+		fixedWakeAdmissionWatcher{errors: watcherErrors},
+		"unused-root",
+		"codex",
+		wakeRepairHandoffSource{},
+	)
+	if err == nil ||
+		!strings.Contains(err.Error(), "wake watcher failed before admission") ||
+		!strings.Contains(err.Error(), "retained wake inbox directory was renamed or deleted") {
+		t.Fatalf("pending watcher root loss error = %v", err)
+	}
+}
+
+func TestRepairWakeRefusesCanonicalInboxReplacementBeforeAdmission(t *testing.T) {
+	fixture := newWakeRepairLifecycleFixture(t)
+	var child *wakeRepairChild
+	var startupDiagnostics string
+	stubRealRepairStarter(
+		t,
+		func(started *wakeRepairChild, startErr error) {
+			child = started
+			if startErr != nil {
+				startupDiagnostics = wakeRepairLifecycleDiagnostics(fixture, started)
+			}
+		},
+		func(started *wakeRepairChild) {
+			forceRepairLifecycleChildInspection(t, fixture, started)
+			inboxPath := fsq.AgentInboxNew(fixture.root, "codex")
+			if err := os.Rename(inboxPath, inboxPath+".detached"); err != nil {
+				t.Fatalf("detach prepared child inbox: %v", err)
+			}
+			if err := os.Mkdir(inboxPath, 0o700); err != nil {
+				t.Fatalf("create replacement child inbox: %v", err)
+			}
+		},
+	)
+
+	result, err := repairWake(fixture.root, "codex")
+	if err == nil || !strings.Contains(err.Error(), "inbox directory no longer matches retained authority") {
+		t.Fatalf(
+			"namespace replacement result=%#v err=%v\n%s",
+			result,
+			err,
+			startupDiagnostics,
+		)
+	}
+	if result.Status == "repaired" {
+		t.Fatalf("detached inbox was admitted: %#v", result)
+	}
+	assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+}
+
+func TestRepairWakeChildAdmissionRejectsNamespaceReplacementAfterParentValidation(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		replace func(t *testing.T, root string)
+		wants   []string
+	}{
+		{
+			name: "ancestor agent directory",
+			replace: func(t *testing.T, root string) {
+				t.Helper()
+				agentPath := fsq.AgentBase(root, "codex")
+				if err := os.Rename(agentPath, agentPath+".detached"); err != nil {
+					t.Fatalf("detach prepared child agent directory: %v", err)
+				}
+				if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+					t.Fatalf("create replacement agent directory: %v", err)
+				}
+			},
+			wants: []string{
+				"canonical wake repair agent directory no longer matches retained authority",
+			},
+		},
+		{
+			name: "direct inbox loss",
+			replace: func(t *testing.T, root string) {
+				t.Helper()
+				inboxPath := fsq.AgentInboxNew(root, "codex")
+				if err := os.Rename(inboxPath, inboxPath+".detached"); err != nil {
+					t.Fatalf("detach prepared child inbox: %v", err)
+				}
+				if err := os.Mkdir(inboxPath, 0o700); err != nil {
+					t.Fatalf("create replacement child inbox: %v", err)
+				}
+			},
+			wants: []string{
+				"wake watcher failed before admission: retained wake inbox directory was renamed or deleted",
+				"canonical wake repair inbox directory no longer matches retained authority",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeRepairLifecycleFixture(t)
+			var child *wakeRepairChild
+			stubRealRepairStarter(
+				t,
+				func(started *wakeRepairChild, _ error) {
+					child = started
+				},
+				func(started *wakeRepairChild) {
+					forceRepairLifecycleChildInspection(t, fixture, started)
+					admit := started.admit
+					started.admit = func() error {
+						// repairWake has completed its parent-side prepared
+						// validation when this closure runs. The child is still
+						// blocked waiting for the admit frame.
+						test.replace(t, fixture.root)
+						return admit()
+					}
+				},
+			)
+
+			result, err := repairWake(fixture.root, "codex")
+			if err == nil {
+				t.Fatalf("namespace replacement was admitted: %#v", result)
+			}
+			if result.Status == "repaired" {
+				t.Fatalf("detached namespace returned repaired: %#v", result)
+			}
+			diagnostics := wakeRepairLifecycleDiagnostics(fixture, child)
+			logAgentPath := fsq.AgentBase(fixture.root, "codex")
+			if test.name == "ancestor agent directory" {
+				logAgentPath += ".detached"
+			}
+			logData, _ := os.ReadFile(filepath.Join(logAgentPath, ".wake.repair.log"))
+			evidence := diagnostics + "\nretained repair log:\n" + string(logData)
+			matched := false
+			for _, want := range test.wants {
+				if strings.Contains(evidence, want) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				t.Fatalf(
+					"child did not report final namespace validation failure\nresult=%#v err=%v\n%s",
+					result,
+					err,
+					evidence,
+				)
+			}
+			assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+		})
+	}
+}
+
+func TestRepairWakeParentRevalidatesNamespaceAfterChildAcknowledgement(t *testing.T) {
+	fixture := newWakeRepairLifecycleFixture(t)
+	var child *wakeRepairChild
+	barrierReached := false
+	detachedAgentPath := fsq.AgentBase(fixture.root, "codex") + ".detached"
+	stubRealRepairStarter(
+		t,
+		func(started *wakeRepairChild, _ error) {
+			child = started
+		},
+		func(started *wakeRepairChild) {
+			forceRepairLifecycleChildInspection(t, fixture, started)
+			validate := started.validateAdmission
+			started.validateAdmission = func() error {
+				// The real admission closure invokes this only after the child
+				// has echoed the exact admit tuple and before RELEASE.
+				agentPath := fsq.AgentBase(fixture.root, "codex")
+				if err := os.Rename(agentPath, detachedAgentPath); err != nil {
+					return err
+				}
+				if err := fsq.EnsureAgentDirs(fixture.root, "codex"); err != nil {
+					return err
+				}
+				barrierReached = true
+				if _, suppressed := fixture.lineage.floor.Existing["pending.md"]; suppressed {
+					t.Fatal("pending lifecycle message is unexpectedly part of inherited suppression floor")
+				}
+				if _, err := os.Stat(filepath.Join(detachedAgentPath, "inbox", "new", "pending.md")); err != nil {
+					t.Fatalf("injectable retained backlog is missing at barrier: %v", err)
+				}
+				// Hold the parent after ACK. Without an exact RELEASE barrier,
+				// the child returns to the loop and injects this backlog.
+				time.Sleep(300 * time.Millisecond)
+				assertWakeRepairOutputAbsent(
+					t,
+					fixture.outputPath,
+					"while post-ACK RELEASE is withheld",
+				)
+				return validate()
+			}
+		},
+	)
+
+	result, err := repairWake(fixture.root, "codex")
+	if !barrierReached {
+		t.Fatal("repair did not reach post-ACK pre-RELEASE validation barrier")
+	}
+	if err == nil ||
+		!strings.Contains(err.Error(), "final wake repair admission validation") ||
+		!strings.Contains(err.Error(), "agent directory no longer matches retained authority") {
+		t.Fatalf(
+			"post-ack namespace replacement result=%#v err=%v\n%s",
+			result,
+			err,
+			wakeRepairLifecycleDiagnostics(fixture, child),
+		)
+	}
+	if result.Status == "repaired" {
+		t.Fatalf("post-ack detached namespace returned repaired: %#v", result)
+	}
+	assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
+	assertWakeRepairOutputAbsent(t, fixture.outputPath, "after rejected repair child reap")
+	for _, directory := range []struct {
+		label string
+		path  string
+	}{
+		{label: "canonical replacement", path: fsq.AgentBase(fixture.root, "codex")},
+		{label: "detached retained", path: detachedAgentPath},
+	} {
+		for _, name := range []string{".wake.lock", wakeRepairFloorFileName} {
+			path := filepath.Join(directory.path, name)
+			if _, err := os.Lstat(path); !os.IsNotExist(err) {
+				t.Fatalf("%s claim residue %s remains: %v", directory.label, path, err)
+			}
+		}
+	}
+}
+
+func assertWakeRepairOutputAbsent(t *testing.T, path, context string) {
+	t.Helper()
+	output, err := os.ReadFile(path)
+	switch {
+	case os.IsNotExist(err):
+		return
+	case err != nil:
+		t.Fatalf("read wake repair output %s: %v", context, err)
+	case len(output) != 0:
+		t.Fatalf("wake repair injected %s: %q", context, output)
+	}
+}

--- a/internal/cli/wake_repair_rename_darwin.go
+++ b/internal/cli/wake_repair_rename_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package cli
+
+import "golang.org/x/sys/unix"
+
+func renameWakeRepairNoReplaceAt(
+	fromDirFD int,
+	from string,
+	toDirFD int,
+	to string,
+) error {
+	return unix.RenameatxNp(fromDirFD, from, toDirFD, to, unix.RENAME_EXCL)
+}

--- a/internal/cli/wake_repair_rename_linux.go
+++ b/internal/cli/wake_repair_rename_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package cli
+
+import "golang.org/x/sys/unix"
+
+func renameWakeRepairNoReplaceAt(
+	fromDirFD int,
+	from string,
+	toDirFD int,
+	to string,
+) error {
+	return unix.Renameat2(fromDirFD, from, toDirFD, to, unix.RENAME_NOREPLACE)
+}

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -256,21 +257,59 @@ func TestWriteWakeTargetRejectsSymlink(t *testing.T) {
 func TestWriteWakeTargetSurvivesConcurrentCreate(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
-	start := make(chan struct{})
-	errs := make(chan error, 8)
+	const writerCount = 8
+	targets := make([]wakeTarget, writerCount)
+	for i := range targets {
+		targets[i] = mustNewWakeTargetForTest(
+			t,
+			root,
+			"codex",
+			injector,
+			[]string{fmt.Sprintf("exec-%d", i)},
+		)
+	}
 
-	for i := 0; i < cap(errs); i++ {
-		i := i
-		go func() {
-			<-start
-			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{fmt.Sprintf("exec-%d", i)})
-			errs <- writeWakeTarget(root, "codex", target)
-		}()
+	type writerResult struct {
+		index int
+		err   error
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	start := make(chan struct{})
+	results := make(chan writerResult, writerCount)
+
+	for i, target := range targets {
+		go func(index int, target wakeTarget) {
+			select {
+			case <-start:
+			case <-ctx.Done():
+				return
+			}
+			result := writerResult{
+				index: index,
+				err:   writeWakeTarget(root, "codex", target),
+			}
+			select {
+			case results <- result:
+			case <-ctx.Done():
+			}
+		}(i, target)
 	}
 	close(start)
-	for i := 0; i < cap(errs); i++ {
-		if err := <-errs; err != nil {
-			t.Fatalf("writeWakeTarget concurrent writer %d: %v", i, err)
+
+	for completed := 0; completed < writerCount; completed++ {
+		select {
+		case result := <-results:
+			if result.err != nil {
+				t.Errorf("writeWakeTarget concurrent writer %d: %v", result.index, result.err)
+			}
+		case <-ctx.Done():
+			t.Fatalf(
+				"writeWakeTarget concurrent writers completed %d/%d: %v",
+				completed,
+				writerCount,
+				ctx.Err(),
+			)
 		}
 	}
 

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -17,13 +17,185 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-func stubStartWakeFromTarget(t *testing.T, fn wakeRepairStarter) {
+const wakeRepairTestBootID = "11111111-1111-1111-1111-111111111111"
+
+type wakeRepairTestStarter func(
+	root, me string,
+	target wakeTarget,
+	floor wakeRepairFloor,
+) (int, error)
+
+func stubStartWakeFromTarget(t *testing.T, fn wakeRepairTestStarter) {
 	t.Helper()
 	old := startWakeFromTarget
-	startWakeFromTarget = fn
+	startWakeFromTarget = func(
+		agentDir *wakeAgentDir,
+		inboxDir *wakeInboxDir,
+		root, me string,
+		target wakeTarget,
+		lineage wakeRepairLineage,
+	) (*wakeRepairChild, error) {
+		pid, err := fn(root, me, target, lineage.floor)
+		if err != nil {
+			return nil, err
+		}
+		winner := inspectWakeLock(root, me)
+		floor, exists, err := readWakeRepairFloor(root, me)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			floor = lineage.floor
+		}
+		if exists && floor.SourceGeneration == "" && floor.SourceFloorDigest == "" {
+			floor.SourceGeneration = lineage.source.DeadGeneration
+			floor.SourceFloorDigest = lineage.source.SourceFloorDigest
+			if err := writeWakeRepairFloor(root, me, floor); err != nil {
+				return nil, err
+			}
+		}
+		if winner.Lock.SourceGeneration == "" && winner.Lock.SourceFloorDigest == "" {
+			winner.Lock.SourceGeneration = lineage.source.DeadGeneration
+			winner.Lock.SourceFloorDigest = lineage.source.SourceFloorDigest
+			data, err := json.Marshal(winner.Lock)
+			if err != nil {
+				return nil, err
+			}
+			if err := os.WriteFile(winner.LockPath, data, 0o600); err != nil {
+				return nil, err
+			}
+			winner = inspectWakeLock(root, me)
+		}
+		source, err := newWakeRepairHandoffSource(lineage.floor, target, agentDir, inboxDir)
+		if err != nil {
+			return nil, err
+		}
+		targetDigest, err := wakeTargetDigest(target)
+		if err != nil {
+			return nil, err
+		}
+		floorDigest, err := wakeRepairFloorDigest(floor)
+		if err != nil {
+			return nil, err
+		}
+		var floorAuthority wakeRepairFloorAuthority
+		if exists {
+			err = agentDir.withFD(func(dirfd int) error {
+				snapshot, snapshotExists, snapshotErr := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+				if snapshotErr != nil {
+					return snapshotErr
+				}
+				if !snapshotExists {
+					return fmt.Errorf("wake repair floor disappeared before test preparation")
+				}
+				floorAuthority, snapshotErr = newWakeRepairFloorAuthority(snapshot)
+				return snapshotErr
+			})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			floorAuthority = wakeRepairFloorAuthorityForTest(source, winner.Lock.Generation)
+		}
+		prepared, err := newWakeRepairHandoffPrepared(
+			source,
+			pid,
+			winner.Lock.Generation,
+			targetDigest,
+			floorDigest,
+			floorAuthority,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return &wakeRepairChild{
+			Process:      &os.Process{Pid: pid},
+			ProcessStart: winner.Lock.ProcessStart,
+			Source:       source,
+			Prepared:     prepared,
+			admit:        func() error { return nil },
+		}, nil
+	}
 	t.Cleanup(func() {
 		startWakeFromTarget = old
 	})
+}
+
+func stubCurrentWakeBootID(t *testing.T, bootID string) {
+	t.Helper()
+	old := currentWakeBootID
+	currentWakeBootID = func() string { return bootID }
+	t.Cleanup(func() {
+		currentWakeBootID = old
+	})
+}
+
+func ensureWakeRepairLockIdentityForTest(t *testing.T, root, me string) wakeLock {
+	t.Helper()
+	path := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read wake lock: %v", err)
+	}
+	var lock wakeLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		t.Fatalf("decode wake lock: %v", err)
+	}
+	changed := false
+	if lock.Generation == "" {
+		lock.Generation = "test-repair-generation"
+		changed = true
+	}
+	if lock.BootID == "" {
+		lock.BootID = wakeRepairTestBootID
+		changed = true
+	}
+	if changed {
+		data, err = json.Marshal(lock)
+		if err != nil {
+			t.Fatalf("marshal wake lock: %v", err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("rewrite wake lock: %v", err)
+		}
+	}
+	stubCurrentWakeBootID(t, lock.BootID)
+	return lock
+}
+
+func writeWakeRepairFloorForTest(
+	t *testing.T,
+	root, me string,
+	target wakeTarget,
+	existing map[string]wakeFileIdentity,
+) wakeRepairFloor {
+	t.Helper()
+	lock := ensureWakeRepairLockIdentityForTest(t, root, me)
+	floor, err := newWakeRepairFloor(root, me, lock, target, existing)
+	if err != nil {
+		t.Fatalf("newWakeRepairFloor: %v", err)
+	}
+	if err := writeWakeRepairFloor(root, me, floor); err != nil {
+		t.Fatalf("writeWakeRepairFloor: %v", err)
+	}
+	return floor
+}
+
+func writeWakeRepairWinnerFloorForTest(
+	t *testing.T,
+	root, me string,
+	target wakeTarget,
+	source wakeRepairFloor,
+) {
+	t.Helper()
+	lock := ensureWakeRepairLockIdentityForTest(t, root, me)
+	floor, err := newWakeRepairFloor(root, me, lock, target, source.Existing)
+	if err != nil {
+		t.Fatalf("new winner wake repair floor: %v", err)
+	}
+	if err := writeWakeRepairFloor(root, me, floor); err != nil {
+		t.Fatalf("write winner wake repair floor: %v", err)
+	}
 }
 
 func TestWakeTargetWriteReadRoundTripAndPermissions(t *testing.T) {
@@ -491,7 +663,7 @@ func TestRepairWakeRefusesTamperedTargetDigest(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", tampered); err != nil {
 		t.Fatalf("write tampered wake target: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run for tampered target")
 		return 0, nil
 	})
@@ -508,6 +680,110 @@ func TestRepairWakeRefusesTamperedTargetDigest(t *testing.T) {
 	}
 }
 
+func TestRunWakeRepairCLIRefusesMissingOrInvalidFloorAndPreservesLock(t *testing.T) {
+	tests := []struct {
+		name       string
+		floorBytes []byte
+		wantReason string
+	}{
+		{
+			name:       "missing",
+			wantReason: "wake repair floor is missing; restart wake manually",
+		},
+		{
+			name:       "corrupt JSON",
+			floorBytes: []byte(`{not-json}`),
+			wantReason: "parse wake repair floor",
+		},
+		{
+			name:       "truncated JSON",
+			floorBytes: []byte(`{"schema":1,"root":`),
+			wantReason: "parse wake repair floor",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+			lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+				PID:        4242,
+				Executable: "/opt/homebrew/bin/amq",
+				Generation: "dead-generation",
+				BootID:     wakeRepairTestBootID,
+			}, target))
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatalf("writeWakeTarget: %v", err)
+			}
+			if tc.floorBytes != nil {
+				if err := os.WriteFile(wakeRepairFloorPath(root, "codex"), tc.floorBytes, 0o600); err != nil {
+					t.Fatalf("write invalid floor: %v", err)
+				}
+			}
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				return wakeProcessInfo{PID: pid, Running: false}
+			})
+			stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
+				t.Fatal("startWakeFromTarget should not run without a valid repair floor")
+				return 0, nil
+			})
+
+			stdout, _, runErr := captureWakeRepairOutput(t, func() error {
+				return runWakeRepair([]string{"--root", root, "--me", "codex", "--json"})
+			})
+			if runErr == nil || !strings.Contains(runErr.Error(), tc.wantReason) {
+				t.Fatalf("runWakeRepair error = %v, want %q", runErr, tc.wantReason)
+			}
+			var result wakeRepairResult
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("unmarshal output: %v\nstdout: %s", err, stdout)
+			}
+			if result.Status != "refused" || !strings.Contains(result.Reason, tc.wantReason) {
+				t.Fatalf("unexpected result: %#v", result)
+			}
+			if _, err := os.Stat(lockPath); err != nil {
+				t.Fatalf("repair refusal removed stale lock: %v", err)
+			}
+		})
+	}
+}
+
+func TestRepairWakeRefusesPriorBootFloorBeforeRemovingLock(t *testing.T) {
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+		Generation: "dead-generation",
+		BootID:     wakeRepairTestBootID,
+	}, target))
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("writeWakeTarget: %v", err)
+	}
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+	stubCurrentWakeBootID(t, "22222222-2222-2222-2222-222222222222")
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
+		t.Fatal("startWakeFromTarget should not run for a prior-boot floor")
+		return 0, nil
+	})
+
+	result, err := repairWake(root, "codex")
+	if err == nil || !strings.Contains(err.Error(), "does not match the current boot") {
+		t.Fatalf("repairWake result=%#v err=%v, want current-boot refusal", result, err)
+	}
+	if result.Status != "refused" || result.RepairAvailable {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("cross-boot refusal removed stale lock: %v", err)
+	}
+}
+
 func TestRepairWakeRefusesStructurallyTamperedStaleLock(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
@@ -518,7 +794,7 @@ func TestRepairWakeRefusesStructurallyTamperedStaleLock(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run for structurally tampered lock")
 		return 0, nil
 	})
@@ -591,7 +867,7 @@ func TestRepairWakeRefusesRawTTYWithoutInjectTarget(t *testing.T) {
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		return wakeProcessInfo{PID: pid, Running: false}
 	})
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run without target")
 		return 0, nil
 	})
@@ -627,7 +903,7 @@ func TestRepairWakeRefusesUnverifiedLock(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", mustNewWakeTargetForTest(t, root, "codex", writeExecutableForTest(t, "injector"), nil)); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run for unverified lock")
 		return 0, nil
 	})
@@ -654,7 +930,7 @@ func TestRepairWakeRefusesCreatingLock(t *testing.T) {
 	if err := os.WriteFile(lockPath, []byte("{"), 0o600); err != nil {
 		t.Fatalf("write creating lock: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run for creating lock")
 		return 0, nil
 	})
@@ -693,7 +969,8 @@ func TestRepairWakeRefusesLockChangedBeforeRemoval(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run after lock changed")
 		return 0, nil
 	})
@@ -720,14 +997,15 @@ func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 	}, target))
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == 9876 {
-			return wakeProcessInfo{PID: pid, Running: true, StartToken: "new-start", Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "new-start", BootID: wakeRepairTestBootID, Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
 		}
 		return wakeProcessInfo{PID: pid, Running: false}
 	})
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget) (int, error) {
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget, source wakeRepairFloor) (int, error) {
 		if gotRoot != root || gotMe != "codex" {
 			t.Fatalf("start root/me = %q/%q", gotRoot, gotMe)
 		}
@@ -740,6 +1018,7 @@ func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 		writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
 			PID: 9876, ProcessStart: "new-start", Executable: "/opt/homebrew/bin/amq", Generation: "generation-new",
 		}, target))
+		writeWakeRepairWinnerFloorForTest(t, root, "codex", target, source)
 		return 9876, nil
 	})
 
@@ -749,6 +1028,86 @@ func TestRepairWakeRemovesProvenStaleAndStartsFromTarget(t *testing.T) {
 	}
 	if result.Status != "repaired" || result.PID != 9876 {
 		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestRepairWakeRejectsWinnerWithoutExactInheritedFloor(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(t *testing.T, root string, target wakeTarget, source wakeRepairFloor)
+		wantReason string
+	}{
+		{
+			name: "missing floor",
+			mutate: func(t *testing.T, root string, _ wakeTarget, _ wakeRepairFloor) {
+				t.Helper()
+				if err := os.Remove(wakeRepairFloorPath(root, "codex")); err != nil {
+					t.Fatalf("remove repair floor: %v", err)
+				}
+			},
+			wantReason: "repaired wake floor is missing",
+		},
+		{
+			name: "mutated suppression set",
+			mutate: func(t *testing.T, root string, target wakeTarget, source wakeRepairFloor) {
+				t.Helper()
+				writeWakeRepairWinnerFloorForTest(t, root, "codex", target, source)
+				floor, exists, err := readWakeRepairFloor(root, "codex")
+				if err != nil || !exists {
+					t.Fatalf("read winner floor: exists=%v err=%v", exists, err)
+				}
+				floor.Existing["mutated.md"] = wakeFileIdentity{Device: 9, Inode: 8, CTimeSec: 7, CTimeNsec: 6}
+				if err := writeWakeRepairFloor(root, "codex", floor); err != nil {
+					t.Fatalf("write mutated winner floor: %v", err)
+				}
+			},
+			wantReason: "changed the inherited suppression floor",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+			writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+				PID:        4242,
+				Executable: "/opt/homebrew/bin/amq",
+				Generation: "dead-generation",
+				BootID:     wakeRepairTestBootID,
+			}, target))
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatalf("writeWakeTarget: %v", err)
+			}
+			writeWakeRepairFloorForTest(t, root, "codex", target, map[string]wakeFileIdentity{
+				"startup.md": {Device: 1, Inode: 2, CTimeSec: 3, CTimeNsec: 4},
+			})
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid == 9876 {
+					return wakeProcessInfo{
+						PID: pid, Running: true, StartToken: "new-start", BootID: wakeRepairTestBootID,
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+					}
+				}
+				return wakeProcessInfo{PID: pid, Running: false}
+			})
+			stubStartWakeFromTarget(t, func(_ string, _ string, gotTarget wakeTarget, gotSource wakeRepairFloor) (int, error) {
+				writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+					PID: 9876, ProcessStart: "new-start", Executable: "/opt/homebrew/bin/amq", Generation: "winner-generation",
+				}, gotTarget))
+				tc.mutate(t, root, gotTarget, gotSource)
+				return 9876, nil
+			})
+
+			result, err := repairWake(root, "codex")
+			if err == nil || !strings.Contains(err.Error(), tc.wantReason) {
+				t.Fatalf("repairWake result=%#v err=%v, want %q", result, err, tc.wantReason)
+			}
+			if result.Status == "repaired" {
+				t.Fatalf("winner without exact inherited floor was accepted: %#v", result)
+			}
+		})
 	}
 }
 
@@ -762,13 +1121,14 @@ func TestRepairWakeRejectsConcurrentWinnerForExactTarget(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == 9876 {
-			return wakeProcessInfo{PID: pid, Running: true, StartToken: "winner-start", Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "winner-start", BootID: wakeRepairTestBootID, Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
 		}
 		return wakeProcessInfo{PID: pid, Running: false}
 	})
-	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget, _ wakeRepairFloor) (int, error) {
 		writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
 			PID: 9876, ProcessStart: "winner-start", Executable: "/opt/homebrew/bin/amq", Generation: "winner-generation",
 		}, gotTarget))
@@ -794,14 +1154,15 @@ func TestRepairWakeRefusesConcurrentWinnerForDifferentTarget(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == 9876 {
-			return wakeProcessInfo{PID: pid, Running: true, StartToken: "winner-start", Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "winner-start", BootID: wakeRepairTestBootID, Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
 		}
 		return wakeProcessInfo{PID: pid, Running: false}
 	})
 	var winnerPath string
-	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget, _ wakeRepairFloor) (int, error) {
 		winner := gotTarget
 		winner.InjectArgs = []string{"different"}
 		if err := writeWakeTarget(root, "codex", winner); err != nil {
@@ -835,7 +1196,7 @@ func TestRepairWakeRefusesStaleRawLockWithLeftoverTarget(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run for a target not bound to the lock")
 		return 0, nil
 	})
@@ -891,7 +1252,7 @@ func TestRepairWakeRefusesUnknownBootIdentityLock(t *testing.T) {
 				proc.Args = []string{"amq", "wake", "--root", root, "--me", "codex"}
 				return proc
 			})
-			stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+			stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 				t.Fatalf("startWakeFromTarget should not run for live identity mismatch")
 				return 0, nil
 			})
@@ -935,7 +1296,7 @@ func TestRepairWakeRefusesProvenStartMismatchAsNonRepairable(t *testing.T) {
 			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
 		}
 	})
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run for a non-repairable stale reason")
 		return 0, nil
 	})
@@ -1008,7 +1369,7 @@ func TestRunWakeRepairCLIRefusesValidLock(t *testing.T) {
 			Executable: "/opt/homebrew/bin/amq",
 		}
 	})
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		t.Fatalf("startWakeFromTarget should not run for an already-running wake")
 		return 0, nil
 	})
@@ -1037,14 +1398,15 @@ func TestRunWakeRepairCLIRepairsStaleWakeWithJSON(t *testing.T) {
 	}, target))
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == 9876 {
-			return wakeProcessInfo{PID: pid, Running: true, StartToken: "new-start", Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
+			return wakeProcessInfo{PID: pid, Running: true, StartToken: "new-start", BootID: wakeRepairTestBootID, Executable: "/opt/homebrew/bin/amq", Args: []string{"amq", "wake", "--root", root, "--me", "codex"}}
 		}
 		return wakeProcessInfo{PID: pid, Running: false}
 	})
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget) (int, error) {
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget, source wakeRepairFloor) (int, error) {
 		if gotRoot != root || gotMe != "codex" {
 			t.Fatalf("start root/me = %q/%q", gotRoot, gotMe)
 		}
@@ -1057,6 +1419,7 @@ func TestRunWakeRepairCLIRepairsStaleWakeWithJSON(t *testing.T) {
 		writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
 			PID: 9876, ProcessStart: "new-start", Executable: "/opt/homebrew/bin/amq", Generation: "generation-new",
 		}, target))
+		writeWakeRepairWinnerFloorForTest(t, root, "codex", target, source)
 		return 9876, nil
 	})
 
@@ -1090,7 +1453,8 @@ func TestRunWakeRepairClearsRepairAvailableAfterStartFailure(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget) (int, error) {
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, target wakeTarget, _ wakeRepairFloor) (int, error) {
 		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 			t.Fatalf("lock should be removed before start, stat=%v", err)
 		}
@@ -1160,9 +1524,9 @@ func TestBuildRepairWakeArgsIncludesReadyFileAndTarget(t *testing.T) {
 		InjectVia:  "/abs/injector",
 		InjectArgs: []string{"exec", "target"},
 	}
-	args := buildRepairWakeArgs("/tmp/root", "codex", target, "/tmp/ready")
+	args := buildRepairWakeArgs("/tmp/root", "codex", target, "dead-generation", "/tmp/ready")
 	got := strings.Join(args, "|")
-	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready"
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--repair-lineage|dead-generation|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready"
 	if got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -50,6 +50,12 @@ func sameWakeInjectorIdentity(first, second wakeTarget) bool {
 	return first.InjectVia == second.InjectVia && slices.Equal(first.InjectArgs, second.InjectArgs)
 }
 
+func sameWakeTarget(first, second wakeTarget) bool {
+	firstDigest, firstErr := wakeTargetDigest(first)
+	secondDigest, secondErr := wakeTargetDigest(second)
+	return firstErr == nil && secondErr == nil && firstDigest == secondDigest
+}
+
 func wakeTargetPath(root, me string) string {
 	return filepath.Join(fsq.AgentBase(root, me), wakeTargetFileName)
 }
@@ -198,13 +204,6 @@ func writeWakeTargetGuarded(root, me string, target wakeTarget) error {
 	}
 	data = append(data, '\n')
 	return writeWakeMetadataFile(wakeTargetPath(root, me), data, "wake target")
-}
-
-func removeWakeTargetGuarded(root, me string) error {
-	if err := os.Remove(wakeTargetPath(root, me)); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove wake target: %w", err)
-	}
-	return nil
 }
 
 func validateWakeTarget(target wakeTarget, root, me string) error {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -5,7 +5,6 @@ package cli
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -34,6 +33,22 @@ var (
 	wakeInputIsTTY       = func() bool { return tiocsti.IsTTY() }
 )
 
+type fsnotifyWakeEventWatcher struct {
+	watcher *fsnotify.Watcher
+}
+
+func (w *fsnotifyWakeEventWatcher) Events() <-chan fsnotify.Event {
+	return w.watcher.Events
+}
+
+func (w *fsnotifyWakeEventWatcher) Errors() <-chan error {
+	return w.watcher.Errors
+}
+
+func (w *fsnotifyWakeEventWatcher) Close() error {
+	return w.watcher.Close()
+}
+
 type wakeRepairResult struct {
 	Status          string `json:"status"`
 	Agent           string `json:"agent"`
@@ -45,18 +60,63 @@ type wakeRepairResult struct {
 	RepairAvailable bool   `json:"repair_available,omitempty"`
 }
 
-type wakeRepairStarter func(root, me string, target wakeTarget) (int, error)
+type wakeRepairChild struct {
+	Process            *os.Process
+	Waiter             *wakeProcessWaiter
+	ProcessStart       string
+	Source             wakeRepairHandoffSource
+	Prepared           wakeRepairHandoffPrepared
+	Capability         *wakeRepairChildCapability
+	Handoff            *wakeRepairParentHandoff
+	validateAdmission  func() error
+	admit              func() error
+	capabilityDetached bool
+}
+
+func (child *wakeRepairChild) Admit() error {
+	if child == nil || child.admit == nil {
+		return fmt.Errorf("wake repair child admission capability is missing")
+	}
+	return child.admit()
+}
 
 type wakeLockAcquireOptions struct {
-	acceptExistingValid bool
-	target              *wakeTarget
-	wakeMode            string
+	acceptExistingValid  bool
+	target               *wakeTarget
+	wakeMode             string
+	repairLineage        *wakeRepairLineage
+	repairFloorAuthority *wakeRepairFloorAuthority
 }
 
 type wakeLockCreatingError struct{}
 
 func (err *wakeLockCreatingError) Error() string {
 	return "wake lock is being created (retry shortly)"
+}
+
+func childRepairSource(lineage *wakeRepairLineage) wakeRepairHandoffSource {
+	source := wakeRepairHandoffSource{
+		schema:             wakeRepairHandoffSchema,
+		root:               lineage.source.Root,
+		rootIdentity:       lineage.source.RootIdentity,
+		agent:              lineage.source.Agent,
+		sourceGeneration:   lineage.source.DeadGeneration,
+		sourceTargetDigest: lineage.source.SourceTargetDigest,
+		sourceFloorDigest:  lineage.source.SourceFloorDigest,
+		bootID:             lineage.source.BootID,
+		agentDirDevice:     lineage.source.AgentDirDevice,
+		agentDirInode:      lineage.source.AgentDirInode,
+		inboxDirDevice:     lineage.source.InboxDirDevice,
+		inboxDirInode:      lineage.source.InboxDirInode,
+	}
+	if lineage.source.Owner != nil {
+		source.hasOwner = true
+		source.ownerPID = lineage.source.Owner.PID
+		source.ownerProcessStart = lineage.source.Owner.ProcessStart
+		source.ownerBootID = lineage.source.Owner.BootID
+		source.ownerSessionID = lineage.source.Owner.SessionID
+	}
+	return source
 }
 
 var startWakeFromTarget = startWakeFromTargetDefault
@@ -68,28 +128,49 @@ func acquireWakeLock(root, me string, target *wakeTarget) (cleanup func(), err e
 }
 
 func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions) (cleanup func(), err error) {
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return nil, err
+	}
+	innerCleanup, err := acquireWakeLockWithOptionsInDir(agentDir, root, me, options)
+	if err != nil {
+		_ = agentDir.Close()
+		return nil, err
+	}
+	return func() {
+		innerCleanup()
+		_ = agentDir.Close()
+	}, nil
+}
+
+func acquireWakeLockWithOptionsInDir(
+	agentDir *wakeAgentDir,
+	root, me string,
+	options wakeLockAcquireOptions,
+) (cleanup func(), err error) {
+	if agentDir == nil {
+		return nil, fmt.Errorf("wake agent directory capability is missing")
+	}
+	if options.repairLineage != nil && options.target != nil && options.target.Owner != nil {
+		return nil, fmt.Errorf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", me)
+	}
 	if options.target != nil && options.target.Owner != nil {
 		return acquireAuthoritativeWakeLockWithOptions(root, me, options)
-	}
-
-	agentBase := fsq.AgentBase(root, me)
-	lockPath := filepath.Join(agentBase, ".wake.lock")
-
-	// Ensure agent directory exists before attempting lock
-	if err := os.MkdirAll(agentBase, 0o700); err != nil {
-		return nil, fmt.Errorf("failed to create agent directory: %w", err)
 	}
 
 	for {
 		var replace wakeLockInspection
 		var created wakeLockInspection
-		err := withWakeLifecycleGuard(root, me, func() error {
-			inspection := inspectWakeLock(root, me)
+		err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+			inspection := inspectWakeLockAt(dirfd, agentDir, root, me)
+			if options.repairLineage != nil && inspection.Exists {
+				return fmt.Errorf("wake lock changed before repair acquisition")
+			}
 			if err := validateGenericWakeLifecycleTransition(inspection, wakeGenericRequestAcquire); err != nil {
 				return err
 			}
 			if inspection.Exists && inspection.Lock.TargetDigest != "" {
-				persisted, exists, readErr := readWakeTarget(root, me)
+				persisted, exists, readErr := readWakeTargetAt(dirfd, agentDir, root, me)
 				if readErr != nil {
 					return fmt.Errorf("persisted wake target for %s is unverified: %w", me, readErr)
 				}
@@ -132,18 +213,43 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 			if replace.Exists {
 				return nil
 			}
-			if orphan, exists, readErr := readWakeTarget(root, me); readErr != nil {
+			if orphan, exists, readErr := readWakeTargetAt(dirfd, agentDir, root, me); readErr != nil {
 				return fmt.Errorf("wake target for %s is unverified: %w", me, readErr)
 			} else if exists && orphan.Owner != nil {
 				return fmt.Errorf("wake handle %s has an owner-bearing orphan target; run 'amq wake recover-owner --me %s'", me, me)
 			}
+			if options.repairLineage != nil {
+				if options.target == nil {
+					return fmt.Errorf("wake repair lineage requires an inject-via target")
+				}
+				persisted, exists, readErr := readWakeTargetAt(dirfd, agentDir, root, me)
+				if readErr != nil {
+					return fmt.Errorf("wake repair target is unverified: %w", readErr)
+				}
+				if !exists {
+					return fmt.Errorf("wake repair target disappeared before acquisition")
+				}
+				if err := validateWakeTarget(persisted, root, me); err != nil {
+					return err
+				}
+				if !sameWakeTarget(persisted, *options.target) {
+					return fmt.Errorf("wake repair target changed before acquisition")
+				}
+				if err := validateWakeRepairLineageGuardedAt(
+					dirfd, agentDir, root, me, persisted, options.repairLineage,
+				); err != nil {
+					return err
+				}
+			} else if err := removeWakeRepairFloorGuardedAt(dirfd, agentDir); err != nil {
+				return err
+			}
 
 			// Stage target metadata first. The lock is the transaction commit point.
 			if options.target != nil {
-				if err := writeWakeTargetGuarded(root, me, *options.target); err != nil {
+				if err := writeWakeTargetGuardedAt(dirfd, agentDir, root, me, *options.target); err != nil {
 					return err
 				}
-			} else if err := removeWakeTargetGuarded(root, me); err != nil {
+			} else if err := removeWakeTargetGuardedAt(dirfd, agentDir); err != nil {
 				return err
 			}
 
@@ -151,21 +257,22 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 			if err != nil {
 				return err
 			}
-			lockData, _ := json.Marshal(lock)
-			f, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0o600)
+			if options.repairLineage != nil {
+				err = createWakeRepairLockAt(
+					dirfd,
+					agentDir,
+					root,
+					me,
+					options.repairLineage.source.RootIdentity,
+					lock,
+				)
+			} else {
+				err = createWakeLockAt(dirfd, agentDir, root, me, lock)
+			}
 			if err != nil {
-				return fmt.Errorf("failed to create wake lock: %w", err)
+				return err
 			}
-			_, writeErr := f.Write(lockData)
-			closeErr := f.Close()
-			if writeErr != nil || closeErr != nil {
-				_ = os.Remove(lockPath)
-				if writeErr != nil {
-					return fmt.Errorf("failed to write wake lock: %w", writeErr)
-				}
-				return fmt.Errorf("failed to close wake lock: %w", closeErr)
-			}
-			created = inspectWakeLock(root, me)
+			created = inspectWakeLockAt(dirfd, agentDir, root, me)
 			if !created.Exists || created.Lock.Generation != lock.Generation {
 				return fmt.Errorf("failed to verify created wake lock generation")
 			}
@@ -182,12 +289,29 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 		}
 
 		cleanup = func() {
-			_ = withWakeLifecycleGuard(root, me, func() error {
-				current := inspectWakeLock(root, me)
+			_ = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+				current := inspectWakeLockAt(dirfd, agentDir, root, me)
 				if !sameWakeLockGeneration(created, current) || !currentWakeLockMatches(current.Lock) {
 					return nil
 				}
-				return removeWakeLockIfUnchangedGuarded(current)
+				if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, current); err != nil {
+					return err
+				}
+				if options.repairLineage != nil {
+					if options.repairFloorAuthority == nil {
+						return fmt.Errorf("wake repair floor cleanup authority is missing")
+					}
+					return removeWakeRepairFloorIfGenerationGuardedAt(
+						dirfd,
+						agentDir,
+						*options.repairFloorAuthority,
+					)
+				}
+				floor, exists, err := readWakeRepairFloorAt(dirfd, agentDir)
+				if err != nil || !exists || floor.Generation != created.Lock.Generation {
+					return err
+				}
+				return removeWakeRepairFloorGuardedAt(dirfd, agentDir)
 			})
 		}
 		return cleanup, nil
@@ -226,6 +350,10 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 			lock.OwnerSchema = wakeOwnerLockSchema
 			lock.Owner = &owner
 		}
+	}
+	if options.repairLineage != nil {
+		lock.SourceGeneration = options.repairLineage.source.DeadGeneration
+		lock.SourceFloorDigest = options.repairLineage.source.SourceFloorDigest
 	}
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
@@ -476,10 +604,21 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 		result.Reason = err.Error()
 		return result, err
 	}
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		result.Status = "error"
+		result.Reason = err.Error()
+		return result, err
+	}
+	defer func() { _ = agentDir.Close() }()
 
 	var target wakeTarget
-	prepareErr := withWakeLifecycleGuard(root, me, func() error {
-		inspection := inspectWakeLock(root, me)
+	var repairFloor wakeRepairFloor
+	var lineage wakeRepairLineage
+	var inboxDir *wakeInboxDir
+	defer func() { _ = inboxDir.Close() }()
+	prepareErr := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		inspection := inspectWakeLockAt(dirfd, agentDir, root, me)
 		if !inspection.Exists {
 			result.Status = "refused"
 			result.Reason = "no wake lock present; start wake normally"
@@ -515,7 +654,7 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 
 		var exists bool
 		var err error
-		target, exists, err = readWakeTarget(root, me)
+		target, exists, err = readWakeTargetAt(dirfd, agentDir, root, me)
 		if err != nil {
 			result.Status = "refused"
 			result.Reason = err.Error()
@@ -542,11 +681,66 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 			result.Reason = err.Error()
 			return err
 		}
+		repairFloor, exists, err = readWakeRepairFloorAt(dirfd, agentDir)
+		if err != nil {
+			result.Status = "refused"
+			result.Reason = err.Error()
+			return err
+		}
+		if !exists {
+			result.Status = "refused"
+			result.Reason = "wake repair floor is missing; restart wake manually"
+			return errors.New(result.Reason)
+		}
+		if err := validateWakeRepairFloor(repairFloor, root, me, inspection.Lock, target); err != nil {
+			result.Status = "refused"
+			result.Reason = err.Error()
+			return err
+		}
+		if err := validateWakeRepairFloorCurrentBoot(repairFloor); err != nil {
+			result.Status = "refused"
+			result.Reason = err.Error()
+			return err
+		}
+		inboxDir, err = openWakeRepairInboxDir(agentDir)
+		if err != nil {
+			result.Status = "refused"
+			result.Reason = err.Error()
+			return err
+		}
+		handoffSource, err := newWakeRepairHandoffSource(
+			repairFloor,
+			target,
+			agentDir,
+			inboxDir,
+		)
+		if err != nil {
+			result.Status = "refused"
+			result.Reason = err.Error()
+			return err
+		}
+		lineage = wakeRepairLineage{
+			source: wakeRepairSource{
+				Root:               handoffSource.Root(),
+				RootIdentity:       handoffSource.RootIdentity(),
+				Agent:              handoffSource.Agent(),
+				DeadGeneration:     handoffSource.SourceGeneration(),
+				BootID:             handoffSource.BootID(),
+				Owner:              handoffSource.Owner(),
+				SourceTargetDigest: handoffSource.SourceTargetDigest(),
+				SourceFloorDigest:  handoffSource.SourceFloorDigest(),
+				AgentDirDevice:     handoffSource.agentDirDevice,
+				AgentDirInode:      handoffSource.agentDirInode,
+				InboxDirDevice:     handoffSource.inboxDirDevice,
+				InboxDirInode:      handoffSource.inboxDirInode,
+			},
+			floor: repairFloor,
+		}
 		result.RepairAvailable = true
-		if err := removeWakeLockIfUnchangedGuarded(inspection); err != nil {
+		if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, inspection); err != nil {
 			result.Status = "refused"
 			result.RepairAvailable = false
-			result.PID = inspectWakeLock(root, me).PID
+			result.PID = inspectWakeLockAt(dirfd, agentDir, root, me).PID
 			result.Reason = "wake lock changed before repair"
 			return errors.New(result.Reason)
 		}
@@ -556,38 +750,122 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 		return result, prepareErr
 	}
 
-	// Spawning and readiness waiting happen without the lifecycle guard.
-	startedPID, startErr := startWakeFromTarget(root, me, target)
+	// Spawning and the private prepared handshake happen without the lifecycle
+	// guard. The retained directory capability remains open across the wait.
+	child, startErr := startWakeFromTarget(agentDir, inboxDir, root, me, target, lineage)
 	if startErr != nil {
+		if child != nil {
+			_ = cleanupFailedWakeRepairChild(agentDir, root, me, child)
+		}
 		result.RepairAvailable = false
 		result.Status = "error"
 		result.Reason = startErr.Error()
 		return result, startErr
 	}
-	winner, winnerErr := validateRepairWakeWinner(root, me, target, startedPID)
-	if winnerErr == nil {
-		result.Status = "repaired"
-		result.PID = winner.PID
-		return result, nil
+	winner, winnerErr := validatePreparedRepairWakeWinnerInDir(
+		agentDir,
+		root,
+		me,
+		target,
+		lineage,
+		child,
+	)
+	if winnerErr != nil {
+		cleanupErr := cleanupFailedWakeRepairChild(agentDir, root, me, child)
+		result.RepairAvailable = false
+		result.Status = "error"
+		if child != nil && child.Process != nil {
+			result.PID = child.Process.Pid
+		}
+		result.Reason = fmt.Sprintf("repaired wake failed exact preparation validation: %v", winnerErr)
+		if cleanupErr != nil {
+			return result, fmt.Errorf("%s (cleanup: %v)", result.Reason, cleanupErr)
+		}
+		return result, errors.New(result.Reason)
 	}
-	result.RepairAvailable = false
-	result.Status = "error"
-	result.PID = startedPID
-	result.Reason = fmt.Sprintf("repaired wake failed exact readiness validation: %v", winnerErr)
-	return result, errors.New(result.Reason)
+	validateAfterAcknowledgement := child.validateAdmission
+	child.validateAdmission = func() error {
+		if validateAfterAcknowledgement == nil {
+			return fmt.Errorf("wake repair child final admission validation is missing")
+		}
+		if err := validateAfterAcknowledgement(); err != nil {
+			return err
+		}
+		_, err := validatePreparedRepairWakeWinnerInDir(
+			agentDir,
+			root,
+			me,
+			target,
+			lineage,
+			child,
+		)
+		return err
+	}
+	if err := child.Admit(); err != nil {
+		cleanupErr := cleanupFailedWakeRepairChild(agentDir, root, me, child)
+		result.RepairAvailable = false
+		result.Status = "error"
+		result.PID = winner.PID
+		result.Reason = fmt.Sprintf("repaired wake admission failed: %v", err)
+		if cleanupErr != nil {
+			return result, fmt.Errorf("%s (cleanup: %v)", result.Reason, cleanupErr)
+		}
+		return result, errors.New(result.Reason)
+	}
+	result.Status = "repaired"
+	result.PID = winner.PID
+	return result, nil
 }
 
-func validateRepairWakeWinner(root, me string, expected wakeTarget, startedPID int) (wakeLockInspection, error) {
+func validatePreparedRepairWakeWinnerInDir(
+	agentDir *wakeAgentDir,
+	root, me string,
+	expected wakeTarget,
+	lineage wakeRepairLineage,
+	child *wakeRepairChild,
+) (wakeLockInspection, error) {
 	var winner wakeLockInspection
-	err := withWakeLifecycleGuard(root, me, func() error {
-		winner = inspectWakeLock(root, me)
+	if child == nil || child.Process == nil || child.Process.Pid <= 0 {
+		return winner, fmt.Errorf("started wake repair child is missing")
+	}
+	if err := child.Prepared.validateSource(child.Source); err != nil {
+		return winner, err
+	}
+	if child.Source.SourceGeneration() != lineage.source.DeadGeneration ||
+		child.Source.SourceTargetDigest() != lineage.source.SourceTargetDigest ||
+		child.Source.SourceFloorDigest() != lineage.source.SourceFloorDigest ||
+		child.Source.RootIdentity() != lineage.source.RootIdentity {
+		return winner, fmt.Errorf("started wake repair child source lineage mismatch")
+	}
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		if err := revalidateWakeRepairRootIdentity(root, lineage.source.RootIdentity); err != nil {
+			return err
+		}
+		if err := validateCanonicalWakeRepairDirectories(root, me, child.Source); err != nil {
+			return err
+		}
+		winner = inspectWakeLockAt(dirfd, agentDir, root, me)
 		if winner.Status != wakeLockValid || !winner.IdentityConfirmed || winner.Lock.Generation == "" {
 			return fmt.Errorf("no confirmed generation-bound wake is ready")
 		}
-		if winner.PID != startedPID {
-			return fmt.Errorf("ready wake pid %d does not match started pid %d", winner.PID, startedPID)
+		if winner.PID != child.Process.Pid || winner.PID != child.Prepared.ChildPID() {
+			return fmt.Errorf(
+				"prepared wake pid %d does not match started pid %d",
+				winner.PID,
+				child.Process.Pid,
+			)
 		}
-		persisted, exists, err := readWakeTarget(root, me)
+		if winner.Lock.Generation != child.Prepared.ChildGeneration() {
+			return fmt.Errorf("prepared wake generation changed before admission")
+		}
+		if child.ProcessStart == "" || winner.Lock.ProcessStart != child.ProcessStart {
+			return fmt.Errorf("prepared wake process identity changed before admission")
+		}
+		if winner.Lock.SourceGeneration != lineage.source.DeadGeneration ||
+			winner.Lock.SourceFloorDigest != lineage.source.SourceFloorDigest {
+			return fmt.Errorf("prepared wake lock lineage mismatch")
+		}
+		persisted, exists, err := readWakeTargetAt(dirfd, agentDir, root, me)
 		if err != nil {
 			return err
 		}
@@ -600,76 +878,267 @@ func validateRepairWakeWinner(root, me string, expected wakeTarget, startedPID i
 		if err := validateWakeTargetMatchesLock(winner.Lock, persisted); err != nil {
 			return err
 		}
-		if !sameWakeInjectorIdentity(persisted, expected) {
-			return fmt.Errorf("concurrent wake uses a different injector path or fixed arguments")
+		targetDigest, err := wakeTargetDigest(persisted)
+		if err != nil {
+			return err
+		}
+		if !sameWakeTarget(persisted, expected) ||
+			targetDigest != lineage.source.SourceTargetDigest ||
+			targetDigest != child.Prepared.ChildTargetDigest() {
+			return fmt.Errorf("prepared wake uses a different exact target")
+		}
+		floorSnapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("repaired wake floor is missing")
+		}
+		floor := floorSnapshot.Floor
+		if err := validateWakeRepairFloor(floor, root, me, winner.Lock, persisted); err != nil {
+			return err
+		}
+		if floor.SourceGeneration != lineage.source.DeadGeneration ||
+			floor.SourceFloorDigest != lineage.source.SourceFloorDigest ||
+			floor.RootIdentity != lineage.source.RootIdentity {
+			return fmt.Errorf("prepared wake floor lineage mismatch")
+		}
+		floorDigest, err := wakeRepairFloorDigest(floor)
+		if err != nil {
+			return err
+		}
+		if floorDigest != child.Prepared.ChildFloorDigest() {
+			return fmt.Errorf("prepared wake floor digest changed before admission")
+		}
+		floorAuthority, err := newWakeRepairFloorAuthority(floorSnapshot)
+		if err != nil {
+			return err
+		}
+		if floorAuthority != child.Prepared.ChildFloorAuthority() {
+			return fmt.Errorf("prepared wake floor file changed before admission")
+		}
+		if !sameWakeRepairSuppression(floor, lineage.floor) {
+			return fmt.Errorf("repaired wake changed the inherited suppression floor")
 		}
 		return nil
 	})
 	return winner, err
 }
 
-func startWakeFromTargetDefault(root, me string, target wakeTarget) (int, error) {
+func cleanupFailedWakeRepairChild(
+	agentDir *wakeAgentDir,
+	root, me string,
+	child *wakeRepairChild,
+) error {
+	if child == nil {
+		return nil
+	}
+	var cleanupErr error
+	if child.capabilityDetached {
+		// Once stable stop authority is detached, close the unreleased handoff
+		// first so the blocked child observes EOF before we wait for its exit.
+		cleanupErr = errors.Join(cleanupErr, child.Handoff.Close(), child.Capability.Close())
+		if child.Waiter != nil {
+			cleanupErr = errors.Join(cleanupErr, child.Waiter.waitForExit(wakeProcessExitTimeout))
+		}
+	} else {
+		if child.Capability != nil {
+			cleanupErr = errors.Join(cleanupErr, child.Capability.Stop())
+		}
+		if child.Waiter != nil {
+			cleanupErr = errors.Join(cleanupErr, child.Waiter.waitForExit(wakeProcessExitTimeout))
+		}
+		cleanupErr = errors.Join(cleanupErr, child.Handoff.Close(), child.Capability.Close())
+	}
+
+	if child.Process == nil || child.Process.Pid <= 0 {
+		return cleanupErr
+	}
+	metadataErr := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !current.Exists {
+			return nil
+		}
+		if current.PID != child.Process.Pid ||
+			current.Lock.ProcessStart == "" ||
+			current.Lock.ProcessStart != child.ProcessStart ||
+			current.Lock.SourceGeneration != child.Source.SourceGeneration() ||
+			current.Lock.SourceFloorDigest != child.Source.SourceFloorDigest() ||
+			current.Lock.TargetDigest != child.Source.SourceTargetDigest() {
+			return nil
+		}
+		if generation := child.Prepared.ChildGeneration(); generation != "" &&
+			current.Lock.Generation != generation {
+			return nil
+		}
+		if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, current); err != nil {
+			return err
+		}
+		return removeWakeRepairFloorIfGenerationGuardedAt(
+			dirfd,
+			agentDir,
+			child.Prepared.ChildFloorAuthority(),
+		)
+	})
+	return errors.Join(cleanupErr, metadataErr)
+}
+
+func startWakeFromTargetDefault(
+	agentDir *wakeAgentDir,
+	inboxDir *wakeInboxDir,
+	root, me string,
+	target wakeTarget,
+	lineage wakeRepairLineage,
+) (*wakeRepairChild, error) {
 	amqBin, err := os.Executable()
 	if err != nil {
 		amqBin = "amq"
 	}
-	readyPath, cleanupReady, err := newWakeReadyFile()
+	source, err := newWakeRepairHandoffSource(lineage.floor, target, agentDir, inboxDir)
 	if err != nil {
-		return 0, fmt.Errorf("create wake readiness file: %w", err)
+		return nil, err
 	}
-	defer cleanupReady()
-	args := buildRepairWakeArgs(root, me, target, readyPath)
+	if source.SourceGeneration() != lineage.source.DeadGeneration ||
+		source.SourceTargetDigest() != lineage.source.SourceTargetDigest ||
+		source.SourceFloorDigest() != lineage.source.SourceFloorDigest ||
+		source.RootIdentity() != lineage.source.RootIdentity ||
+		source.agentDirDevice != lineage.source.AgentDirDevice ||
+		source.agentDirInode != lineage.source.AgentDirInode ||
+		source.inboxDirDevice != lineage.source.InboxDirDevice ||
+		source.inboxDirInode != lineage.source.InboxDirInode {
+		return nil, fmt.Errorf("wake repair child source does not match retained lineage")
+	}
+	args := buildRepairWakeArgs(root, me, target, lineage.source.DeadGeneration, "")
 	cmd := exec.Command(amqBin, args...)
 	env, err := wakeCommandEnv(os.Environ(), root, target.Owner)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	cmd.Env = env
-	output, err := openWakeRepairOutput(root, me)
+	output, err := openWakeRepairOutputInDir(agentDir)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	defer func() { _ = output.Close() }()
 	configureRepairWakeCommand(cmd, output)
+	handoff, err := prepareWakeRepairHandoff(cmd, source, agentDir, inboxDir)
+	if err != nil {
+		return nil, err
+	}
+	capability, err := prepareWakeRepairChildCapability(cmd)
+	if err != nil {
+		_ = handoff.Close()
+		return nil, err
+	}
 	if err := cmd.Start(); err != nil {
-		return 0, fmt.Errorf("start repaired amq wake: %w", err)
+		_ = handoff.Close()
+		_ = capability.Close()
+		return nil, fmt.Errorf("start repaired amq wake: %w", err)
 	}
 	waiter := newWakeProcessWaiter(cmd.Process)
-	if err := waitForWakeReadyWithWaiter(waiter, readyPath, root, me, wakeReadyTimeout); err != nil {
-		if cleanupErr := terminateWakeHelperProcess(cmd.Process, waiter, root, me); cleanupErr != nil {
-			return 0, fmt.Errorf("%w (cleanup: %v)", err, cleanupErr)
-		}
-		return 0, err
+	child := &wakeRepairChild{
+		Process:    cmd.Process,
+		Waiter:     waiter,
+		Source:     source,
+		Capability: capability,
+		Handoff:    handoff,
 	}
-	return cmd.Process.Pid, nil
+	if err := capability.Bind(cmd.Process); err != nil {
+		return child, fmt.Errorf("bind exact wake repair child capability: %w", err)
+	}
+	if err := handoff.Bind(cmd.Process); err != nil {
+		return child, fmt.Errorf("bind wake repair handoff: %w", err)
+	}
+	process := inspectWakeProcess(cmd.Process.Pid)
+	if !process.Running || process.StartToken == "" {
+		return child, fmt.Errorf("capture exact wake repair child process identity")
+	}
+	child.ProcessStart = process.StartToken
+
+	type preparedResult struct {
+		prepared wakeRepairHandoffPrepared
+		err      error
+	}
+	preparedCh := make(chan preparedResult, 1)
+	go func() {
+		prepared, receiveErr := handoff.ReceivePrepared(source)
+		preparedCh <- preparedResult{prepared: prepared, err: receiveErr}
+	}()
+	timer := time.NewTimer(wakeReadyTimeout)
+	defer timer.Stop()
+	select {
+	case prepared := <-preparedCh:
+		if prepared.err != nil {
+			return child, fmt.Errorf("receive wake repair prepared tuple: %w", prepared.err)
+		}
+		child.Prepared = prepared.prepared
+	case <-waiter.done:
+		return child, fmt.Errorf("repaired amq wake exited before preparation")
+	case <-timer.C:
+		return child, fmt.Errorf("repaired amq wake did not prepare within %s", wakeReadyTimeout)
+	}
+	child.admit = func() error {
+		if err := handoff.Admit(child.Prepared); err != nil {
+			return err
+		}
+		if child.validateAdmission == nil {
+			return fmt.Errorf("wake repair child final admission validation is missing")
+		}
+		if err := child.validateAdmission(); err != nil {
+			return fmt.Errorf("final wake repair admission validation: %w", err)
+		}
+		if err := capability.Detach(); err != nil {
+			return fmt.Errorf("detach admitted wake repair child capability: %w", err)
+		}
+		child.capabilityDetached = true
+		if err := handoff.Release(child.Prepared); err != nil {
+			return err
+		}
+		// A complete release frame is the irreversible admission commit. Cleanup
+		// errors after it cannot revoke authorization or safely stop the child.
+		_ = handoff.Close()
+		_ = capability.Close()
+		return nil
+	}
+	child.validateAdmission = func() error {
+		return validateCanonicalWakeRepairDirectories(root, me, child.Source)
+	}
+	return child, nil
 }
 
-func openWakeRepairOutput(root, me string) (*os.File, error) {
-	agentBase := fsq.AgentBase(root, me)
-	if err := os.MkdirAll(agentBase, 0o700); err != nil {
-		return nil, fmt.Errorf("create repair wake log directory: %w", err)
+func openWakeRepairOutputInDir(agentDir *wakeAgentDir) (*os.File, error) {
+	if agentDir == nil {
+		return nil, fmt.Errorf("wake repair agent directory capability is missing")
 	}
-	path := filepath.Join(agentBase, ".wake.repair.log")
-	if info, err := os.Lstat(path); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return nil, fmt.Errorf("repair wake log %s must not be a symlink", path)
+	var file *os.File
+	err := agentDir.withFD(func(dirfd int) error {
+		fd, err := unix.Openat(
+			dirfd,
+			".wake.repair.log",
+			unix.O_CREAT|unix.O_WRONLY|unix.O_APPEND|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+			0o600,
+		)
+		if err != nil {
+			if err == unix.ELOOP {
+				return fmt.Errorf("repair wake log %s must not be a symlink", filepath.Join(agentDir.path, ".wake.repair.log"))
+			}
+			if err == unix.ENXIO {
+				return fmt.Errorf("repair wake log %s must be a regular file", filepath.Join(agentDir.path, ".wake.repair.log"))
+			}
+			return fmt.Errorf("open repair wake log: %w", err)
 		}
-		if !info.Mode().IsRegular() {
-			return nil, fmt.Errorf("repair wake log %s must be a regular file", path)
-		}
-	} else if !os.IsNotExist(err) {
-		return nil, fmt.Errorf("stat repair wake log: %w", err)
-	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0o600)
+		file = os.NewFile(uintptr(fd), filepath.Join(agentDir.path, ".wake.repair.log"))
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("open repair wake log: %w", err)
+		return nil, err
 	}
 	if info, err := file.Stat(); err != nil {
 		_ = file.Close()
 		return nil, fmt.Errorf("stat repair wake log: %w", err)
 	} else if !info.Mode().IsRegular() {
 		_ = file.Close()
-		return nil, fmt.Errorf("repair wake log %s must be a regular file", path)
+		return nil, fmt.Errorf("repair wake log %s must be a regular file", file.Name())
 	}
 	return file, nil
 }
@@ -681,12 +1150,15 @@ func configureRepairWakeCommand(cmd *exec.Cmd, output *os.File) {
 	cmd.Stderr = output
 }
 
-func buildRepairWakeArgs(root, me string, target wakeTarget, readyPath string) []string {
-	args := []string{"--no-update-check", "wake", "--me", me, "--root", root, "--baseline-existing", "--inject-via", target.InjectVia}
+func buildRepairWakeArgs(root, me string, target wakeTarget, generation, readyPath string) []string {
+	args := []string{"--no-update-check", "wake", "--me", me, "--root", root, "--repair-lineage", generation, "--inject-via", target.InjectVia}
 	for _, arg := range target.InjectArgs {
 		args = append(args, "--inject-arg", arg)
 	}
-	return append(args, "--ready-file", readyPath)
+	if readyPath != "" {
+		args = append(args, "--ready-file", readyPath)
+	}
+	return args
 }
 
 func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
@@ -695,6 +1167,19 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return err
 	}
 	defer cleanupPrivateStop()
+	repairHandoff, repairHandoffPresent, err := wakeRepairChildHandoffFromEnv()
+	if err != nil {
+		return err
+	}
+	if repairHandoff != nil {
+		defer func() { _ = repairHandoff.Close() }()
+	}
+	repairPrivateStop, cleanupRepairPrivateStop, err := wakeRepairChildStopFromEnv()
+	if err != nil {
+		return err
+	}
+	defer cleanupRepairPrivateStop()
+	privateStop = mergeWakeStopChannels(privateStop, repairPrivateStop)
 
 	fs := flag.NewFlagSet("wake", flag.ContinueOnError)
 	common := addCommonFlags(fs)
@@ -720,10 +1205,11 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
 	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
+	repairLineageFlag := fs.String("repair-lineage", "", "Internal: inherit the suppression floor from an exact dead wake generation")
 	baselineExistingFlag := fs.Bool("baseline-existing", false, "Ignore messages already waiting when this wake starts")
 
 	usage := usageWithHiddenFlags(fs, "amq wake --me <agent> [options]",
-		[]string{"ready-file", "accept-existing-wake"},
+		[]string{"ready-file", "accept-existing-wake", "repair-lineage"},
 		"Background waker: injects terminal notification when messages arrive.",
 		"Run as background job before starting CLI: amq wake --me claude &",
 		"",
@@ -837,6 +1323,22 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	if *readyFileFlag != "" && readyFile == "" {
 		return UsageError("--ready-file must not be blank")
 	}
+	repairGeneration := strings.TrimSpace(*repairLineageFlag)
+	if *repairLineageFlag != "" && repairGeneration == "" {
+		return UsageError("--repair-lineage must not be blank")
+	}
+	if repairGeneration != "" && injectVia == "" {
+		return UsageError("--repair-lineage requires --inject-via")
+	}
+	if repairGeneration != "" && *baselineExistingFlag {
+		return UsageError("--repair-lineage cannot be combined with --baseline-existing")
+	}
+	if repairGeneration != "" && !repairHandoffPresent {
+		return fmt.Errorf("wake repair requires a private source/admission handoff")
+	}
+	if repairGeneration == "" && repairHandoffPresent {
+		return fmt.Errorf("wake repair handoff requires --repair-lineage")
+	}
 
 	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
 	if injectVia == "" && injectMode != wakeInjectModeNone {
@@ -856,6 +1358,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	}
 
 	var target *wakeTarget
+	var repairLineage *wakeRepairLineage
+	var repairAgentDir *wakeAgentDir
+	var repairInboxDir *wakeInboxDir
 	if injectVia != "" {
 		owner, err := wakeOwnerFromEnv()
 		if err != nil {
@@ -871,6 +1376,101 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		}
 		injectVia = value.InjectVia
 		target = &value
+		if repairGeneration != "" {
+			if owner != nil {
+				return fmt.Errorf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", me)
+			}
+			source, err := repairHandoff.ReceiveSource()
+			if err != nil {
+				return fmt.Errorf("receive wake repair source: %w", err)
+			}
+			if source.Root() != canonicalWakeRoot(root) ||
+				source.Agent() != me ||
+				source.SourceGeneration() != repairGeneration {
+				return fmt.Errorf("wake repair source does not match requested root, agent, and generation")
+			}
+			repairAgentDir, repairInboxDir, err = repairHandoff.TakeRetainedDirectories(source)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = repairAgentDir.Close() }()
+			defer func() { _ = repairInboxDir.Close() }()
+			var persisted wakeTarget
+			var floor wakeRepairFloor
+			err = withWakeLifecycleGuardInDir(repairAgentDir, func(dirfd int) error {
+				if err := revalidateWakeRepairRootIdentity(root, source.RootIdentity()); err != nil {
+					return err
+				}
+				var exists bool
+				persisted, exists, err = readWakeTargetAt(dirfd, repairAgentDir, root, me)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					return fmt.Errorf("wake repair target is missing")
+				}
+				floor, exists, err = readWakeRepairFloorAt(dirfd, repairAgentDir)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					return fmt.Errorf("wake repair floor is missing")
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			if value.Schema != persisted.Schema ||
+				value.Mode != persisted.Mode ||
+				value.Root != persisted.Root ||
+				value.Agent != persisted.Agent ||
+				!sameWakeInjectorIdentity(value, persisted) ||
+				!sameWakeOwner(value.Owner, persisted.Owner) {
+				return fmt.Errorf("wake repair target changed before child start")
+			}
+			// The repair CLI carries the requested injector behavior, not the
+			// persisted instance timestamp. Continue with the exact retained
+			// target whose digest is bound into the source handoff.
+			value = persisted
+			target = &value
+			targetDigest, err := wakeTargetDigest(persisted)
+			if err != nil {
+				return err
+			}
+			floorDigest, err := wakeRepairFloorDigest(floor)
+			if err != nil {
+				return err
+			}
+			if targetDigest != source.SourceTargetDigest() ||
+				floorDigest != source.SourceFloorDigest() ||
+				floor.Generation != source.SourceGeneration() ||
+				floor.RootIdentity != source.RootIdentity() ||
+				floor.BootID != source.BootID() ||
+				!sameWakeOwner(floor.Owner, source.Owner()) {
+				return fmt.Errorf("wake repair source lineage changed before child acquisition")
+			}
+			repairLineage = &wakeRepairLineage{
+				source: wakeRepairSource{
+					Root:               source.Root(),
+					RootIdentity:       source.RootIdentity(),
+					Agent:              source.Agent(),
+					DeadGeneration:     source.SourceGeneration(),
+					BootID:             source.BootID(),
+					Owner:              source.Owner(),
+					SourceTargetDigest: source.SourceTargetDigest(),
+					SourceFloorDigest:  source.SourceFloorDigest(),
+					AgentDirDevice:     source.agentDirDevice,
+					AgentDirInode:      source.agentDirInode,
+					InboxDirDevice:     source.inboxDirDevice,
+					InboxDirInode:      source.inboxDirInode,
+				},
+				floor: floor,
+			}
+			target = &persisted
+			injectVia = persisted.InjectVia
+			injectArgFlags = append(multiStringFlag(nil), persisted.InjectArgs...)
+		}
 	}
 
 	// Acquire lock to prevent duplicate wake processes
@@ -883,12 +1483,22 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	}
 	acceptExistingDeadline := time.Now().Add(wakeReadyTimeout)
 	var cleanup func()
+	var repairFloorAuthority wakeRepairFloorAuthority
 	for {
-		cleanup, err = acquireWakeLockWithOptions(root, me, wakeLockAcquireOptions{
+		options := wakeLockAcquireOptions{
 			acceptExistingValid: acceptExistingWake,
 			target:              target,
 			wakeMode:            lockWakeMode,
-		})
+			repairLineage:       repairLineage,
+		}
+		if repairLineage != nil {
+			options.repairFloorAuthority = &repairFloorAuthority
+		}
+		if repairAgentDir != nil {
+			cleanup, err = acquireWakeLockWithOptionsInDir(repairAgentDir, root, me, options)
+		} else {
+			cleanup, err = acquireWakeLockWithOptions(root, me, options)
+		}
 		if err == nil {
 			break
 		}
@@ -914,8 +1524,28 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	defer cleanup()
 	var controlStop <-chan struct{}
 	if injectVia != "" {
-		current := inspectWakeLock(root, me)
-		controlCleanup, stop, markStopped, controlErr := startWakeControlListener(root, me, current.Lock)
+		var current wakeLockInspection
+		if repairAgentDir != nil {
+			if err := repairAgentDir.withFD(func(dirfd int) error {
+				current = inspectWakeLockAt(dirfd, repairAgentDir, root, me)
+				return nil
+			}); err != nil {
+				return err
+			}
+		} else {
+			current = inspectWakeLock(root, me)
+		}
+		var controlCleanup func()
+		var stop <-chan struct{}
+		var markStopped func()
+		var controlErr error
+		if repairAgentDir != nil {
+			controlCleanup, stop, markStopped, controlErr = startWakeControlListenerInDir(
+				repairAgentDir, root, me, current.Lock,
+			)
+		} else {
+			controlCleanup, stop, markStopped, controlErr = startWakeControlListener(root, me, current.Lock)
+		}
 		if controlErr != nil {
 			return controlErr
 		}
@@ -931,7 +1561,17 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		}
 	}
 
-	currentWake := inspectWakeLock(root, me)
+	var currentWake wakeLockInspection
+	if repairAgentDir != nil {
+		if err := repairAgentDir.withFD(func(dirfd int) error {
+			currentWake = inspectWakeLockAt(dirfd, repairAgentDir, root, me)
+			return nil
+		}); err != nil {
+			return err
+		}
+	} else {
+		currentWake = inspectWakeLock(root, me)
+	}
 	cfg := wakeConfig{
 		me:                me,
 		root:              root,
@@ -959,13 +1599,157 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		interruptNotice:   strings.TrimSpace(*interruptNoticeFlag),
 		interruptCooldown: *interruptCooldownFlag,
 		controlStop:       controlStop,
-		baselineRequested: *baselineExistingFlag,
-		onPrepared: func() error {
+		baselineRequested: *baselineExistingFlag || repairLineage != nil,
+		baselineInherited: repairLineage != nil,
+		onPrepared: func(watcher wakeAdmissionWatcher) error {
+			if repairLineage != nil {
+				if err := writeWakePreparedFileInDir(
+					repairAgentDir,
+					root,
+					me,
+					currentWake,
+				); err != nil {
+					return err
+				}
+				var prepared wakeRepairHandoffPrepared
+				err := withWakeLifecycleGuardInDir(repairAgentDir, func(dirfd int) error {
+					if err := revalidateWakeRepairRootIdentity(
+						root,
+						repairLineage.source.RootIdentity,
+					); err != nil {
+						return err
+					}
+					current := inspectWakeLockAt(dirfd, repairAgentDir, root, me)
+					if !sameWakeLockGeneration(currentWake, current) ||
+						current.PID != os.Getpid() ||
+						current.Lock.SourceGeneration != repairLineage.source.DeadGeneration ||
+						current.Lock.SourceFloorDigest != repairLineage.source.SourceFloorDigest {
+						return fmt.Errorf("wake repair lock changed before preparation")
+					}
+					persisted, exists, err := readWakeTargetAt(
+						dirfd,
+						repairAgentDir,
+						root,
+						me,
+					)
+					if err != nil {
+						return err
+					}
+					if !exists || !sameWakeTarget(persisted, *target) {
+						return fmt.Errorf("wake repair target changed before preparation")
+					}
+					targetDigest, err := wakeTargetDigest(persisted)
+					if err != nil {
+						return err
+					}
+					floorSnapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, repairAgentDir)
+					if err != nil {
+						return err
+					}
+					floor := floorSnapshot.Floor
+					if !exists ||
+						floor.Generation != current.Lock.Generation ||
+						floor.SourceGeneration != repairLineage.source.DeadGeneration ||
+						floor.SourceFloorDigest != repairLineage.source.SourceFloorDigest ||
+						floor.RootIdentity != repairLineage.source.RootIdentity {
+						return fmt.Errorf("wake repair floor changed before preparation")
+					}
+					floorDigest, err := wakeRepairFloorDigest(floor)
+					if err != nil {
+						return err
+					}
+					floorAuthority, err := newWakeRepairFloorAuthority(floorSnapshot)
+					if err != nil {
+						return err
+					}
+					prepared, err = newWakeRepairHandoffPrepared(
+						childRepairSource(repairLineage),
+						os.Getpid(),
+						current.Lock.Generation,
+						targetDigest,
+						floorDigest,
+						floorAuthority,
+					)
+					return err
+				})
+				if err != nil {
+					return err
+				}
+				if err := repairHandoff.SendPrepared(prepared); err != nil {
+					return err
+				}
+				if err := repairHandoff.AwaitAdmitAcknowledgeAndRelease(
+					prepared,
+					func() error {
+						return validateWakeRepairChildAdmission(
+							watcher,
+							root,
+							me,
+							childRepairSource(repairLineage),
+						)
+					},
+				); err != nil {
+					return err
+				}
+				select {
+				case <-privateStop:
+					return fmt.Errorf("wake repair child stopped before admission completed")
+				default:
+				}
+				return nil
+			}
 			if err := writeWakePreparedFile(root, me, currentWake); err != nil {
 				return err
 			}
 			return writeWakeReadyFile(root, me, readyFile, currentWake)
 		},
+	}
+	if repairInboxDir != nil {
+		cfg.retainedInbox = repairInboxDir
+		cfg.touchPresence = func() error {
+			return touchWakePresenceInDir(repairAgentDir, me)
+		}
+	}
+	if repairLineage != nil {
+		cfg.baselineExisting = cloneWakeFileIdentities(repairLineage.floor.Existing)
+	}
+	if target != nil && target.Owner == nil {
+		persistedTarget := *target
+		cfg.onBaselineReady = func(existing map[string]wakeFileIdentity) error {
+			if repairLineage != nil {
+				floor, err := newInheritedWakeRepairFloor(
+					repairLineage.source,
+					currentWake.Lock,
+					persistedTarget,
+					existing,
+				)
+				if err != nil {
+					return err
+				}
+				return withWakeLifecycleGuardInDir(repairAgentDir, func(dirfd int) error {
+					current := inspectWakeLockAt(dirfd, repairAgentDir, root, me)
+					if !sameWakeLockGeneration(currentWake, current) {
+						return fmt.Errorf("wake repair lock changed before inherited floor publication")
+					}
+					authority, err := writeWakeRepairFloorAndCaptureAuthorityAt(
+						dirfd,
+						repairAgentDir,
+						root,
+						floor,
+					)
+					if err != nil {
+						return err
+					}
+					repairFloorAuthority = authority
+					return nil
+				})
+			}
+			floor, err := newWakeRepairFloor(root, me, currentWake.Lock, persistedTarget, existing)
+			if err != nil {
+				return err
+			}
+			return writeWakeRepairFloor(root, me, floor)
+		}
 	}
 
 	return loop(cfg)
@@ -1023,7 +1807,22 @@ func invalidateWakeBaselineEvent(cfg *wakeConfig, event fsnotify.Event) {
 // Linux/inotify provides an ordered marker fence; Darwin/kqueue uses the marker
 // plus a quiescence window, with watcher errors handled fail-closed.
 func prepareWakeBaseline(cfg *wakeConfig, watcher *fsnotify.Watcher, inboxNew string) error {
+	return prepareWakeBaselineEvents(cfg, watcher.Events, watcher.Errors, inboxNew)
+}
+
+func prepareWakeBaselineEvents(
+	cfg *wakeConfig,
+	events <-chan fsnotify.Event,
+	watcherErrors <-chan error,
+	inboxNew string,
+) error {
 	if !cfg.baselineRequested {
+		return nil
+	}
+	if cfg.baselineInherited {
+		if cfg.baselineExisting == nil {
+			cfg.baselineExisting = map[string]wakeFileIdentity{}
+		}
 		return nil
 	}
 	// Individual local-filesystem calls are intentionally not cancellable. Coop
@@ -1057,7 +1856,7 @@ func prepareWakeBaseline(cfg *wakeConfig, watcher *fsnotify.Watcher, inboxNew st
 	}()
 	for {
 		select {
-		case event, ok := <-watcher.Events:
+		case event, ok := <-events:
 			if !ok {
 				return failWakeOnWatcherError(cfg, "watcher closed while preparing wake baseline", nil)
 			}
@@ -1078,7 +1877,7 @@ func prepareWakeBaseline(cfg *wakeConfig, watcher *fsnotify.Watcher, inboxNew st
 				}
 				settleTimer.Reset(wakeBaselineSettle)
 			}
-		case err, ok := <-watcher.Errors:
+		case err, ok := <-watcherErrors:
 			if !ok {
 				return failWakeOnWatcherError(cfg, "watcher closed while preparing wake baseline", nil)
 			}
@@ -1101,6 +1900,35 @@ func failWakeOnWatcherError(cfg *wakeConfig, context string, cause error) error 
 	return fmt.Errorf("%s: %w", context, cause)
 }
 
+func pendingWakeWatcherError(watcher wakeAdmissionWatcher) error {
+	if watcher == nil {
+		return fmt.Errorf("wake watcher is unavailable at admission")
+	}
+	select {
+	case err, ok := <-watcher.Errors():
+		if !ok {
+			return fmt.Errorf("wake watcher closed before admission")
+		}
+		if err == nil {
+			return fmt.Errorf("wake watcher reported an empty error before admission")
+		}
+		return fmt.Errorf("wake watcher failed before admission: %w", err)
+	default:
+		return nil
+	}
+}
+
+func validateWakeRepairChildAdmission(
+	watcher wakeAdmissionWatcher,
+	root, me string,
+	source wakeRepairHandoffSource,
+) error {
+	if err := pendingWakeWatcherError(watcher); err != nil {
+		return err
+	}
+	return validateCanonicalWakeRepairDirectories(root, me, source)
+}
+
 func parseInterruptKey(raw string) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(raw))
 	if normalized == "" {
@@ -1119,25 +1947,38 @@ func parseInterruptKey(raw string) (string, error) {
 func runWakeLoop(cfg wakeConfig) error {
 	inboxNew := fsq.AgentInboxNew(cfg.root, cfg.me)
 
-	// Ensure inbox exists
-	if err := os.MkdirAll(inboxNew, 0o700); err != nil {
-		return err
-	}
-
-	// Set up watcher
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return fmt.Errorf("failed to create watcher: %w", err)
+	var watcher wakeEventWatcher
+	if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
+		var err error
+		watcher, err = retained.NewWatcher()
+		if err != nil {
+			return fmt.Errorf("failed to create retained watcher: %w", err)
+		}
+	} else {
+		if err := os.MkdirAll(inboxNew, 0o700); err != nil {
+			return err
+		}
+		native, err := fsnotify.NewWatcher()
+		if err != nil {
+			return fmt.Errorf("failed to create watcher: %w", err)
+		}
+		if err := native.Add(inboxNew); err != nil {
+			_ = native.Close()
+			return fmt.Errorf("failed to watch inbox: %w", err)
+		}
+		watcher = &fsnotifyWakeEventWatcher{watcher: native}
 	}
 	defer func() { _ = watcher.Close() }()
 
-	if err := watcher.Add(inboxNew); err != nil {
-		return fmt.Errorf("failed to watch inbox: %w", err)
-	}
 	// The startup boundary is watcher installation, not lock acquisition;
 	// messages delivered in between are intentionally treated as startup backlog.
-	if err := prepareWakeBaseline(&cfg, watcher, inboxNew); err != nil {
+	if err := prepareWakeBaselineEvents(&cfg, watcher.Events(), watcher.Errors(), inboxNew); err != nil {
 		return err
+	}
+	if cfg.onBaselineReady != nil {
+		if err := cfg.onBaselineReady(cloneWakeFileIdentities(cfg.baselineExisting)); err != nil {
+			return err
+		}
 	}
 	// This closes the already-pending stop case only; a stop or process death can
 	// still race immediately after readiness publication.
@@ -1147,9 +1988,14 @@ func runWakeLoop(cfg wakeConfig) error {
 	default:
 	}
 	if cfg.onPrepared != nil {
-		if err := cfg.onPrepared(); err != nil {
+		if err := cfg.onPrepared(watcher); err != nil {
 			return err
 		}
+	}
+	select {
+	case <-cfg.controlStop:
+		return nil
+	default:
 	}
 
 	// Ignore job control signals so background job can operate freely.
@@ -1174,7 +2020,11 @@ func runWakeLoop(cfg wakeConfig) error {
 	defer healthTicker.Stop()
 
 	// Touch presence immediately so `amq who` shows agent as active
-	_ = presence.Touch(cfg.root, cfg.me)
+	if cfg.touchPresence != nil {
+		_ = cfg.touchPresence()
+	} else {
+		_ = presence.Touch(cfg.root, cfg.me)
+	}
 
 	// Notify if messages already exist
 	if err := notifyNewMessages(&cfg); err != nil {
@@ -1194,7 +2044,7 @@ func runWakeLoop(cfg wakeConfig) error {
 			// Clean exit on SIGHUP/SIGTERM
 			return nil
 
-		case event, ok := <-watcher.Events:
+		case event, ok := <-watcher.Events():
 			if !ok {
 				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
 			}
@@ -1222,7 +2072,7 @@ func runWakeLoop(cfg wakeConfig) error {
 			}
 			debounceTimer.Reset(cfg.debounce)
 
-		case err, ok := <-watcher.Errors:
+		case err, ok := <-watcher.Errors():
 			if !ok {
 				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
 			}
@@ -1241,7 +2091,11 @@ func runWakeLoop(cfg wakeConfig) error {
 
 		case <-healthTicker.C:
 			// Keep presence alive so `amq who` reports the agent as active
-			_ = presence.Touch(cfg.root, cfg.me)
+			if cfg.touchPresence != nil {
+				_ = cfg.touchPresence()
+			} else {
+				_ = presence.Touch(cfg.root, cfg.me)
+			}
 
 			if err := wakeHealthCheck(cfg, ttyAvailable); err != nil {
 				return err

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -136,7 +136,7 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 		if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
 			t.Fatalf("ready file published before wake preparation: %v", statErr)
 		}
-		if err := cfg.onPrepared(); err != nil {
+		if err := cfg.onPrepared(nil); err != nil {
 			t.Fatalf("publish readiness: %v", err)
 		}
 		if _, statErr := os.Stat(readyPath); statErr != nil {
@@ -195,7 +195,7 @@ func TestRunWakeWithLoopBaselinesBeforeReadiness(t *testing.T) {
 		if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
 			t.Fatalf("ready file published before baseline preparation: %v", statErr)
 		}
-		if err := cfg.onPrepared(); err != nil {
+		if err := cfg.onPrepared(nil); err != nil {
 			t.Fatalf("publish readiness: %v", err)
 		}
 		if _, statErr := os.Stat(readyPath); statErr != nil {
@@ -303,7 +303,7 @@ func TestRunWakeLoopStopsBeforePublishingPreparedMarker(t *testing.T) {
 		root:        secureTempDirForTest(t),
 		me:          "orchestrator",
 		controlStop: stop,
-		onPrepared: func() error {
+		onPrepared: func(wakeAdmissionWatcher) error {
 			prepared = true
 			return nil
 		},
@@ -348,9 +348,30 @@ func TestBaselineDLQRetryWithSameFilenameRemainsNotifyEligible(t *testing.T) {
 	if err != nil {
 		t.Fatalf("snapshot baseline: %v", err)
 	}
-	cfg.baselineExisting = baseline
+	target := mustNewWakeTargetForTest(t, root, "alice", cfg.injectVia, cfg.injectArgs)
+	lock := bindWakeLockToTarget(wakeLock{
+		Root:       canonicalWakeRoot(root),
+		Agent:      "alice",
+		Generation: "dlq-retry-generation",
+		BootID:     wakeRepairTestBootID,
+	}, target)
+	floor, err := newWakeRepairFloor(root, "alice", lock, target, baseline)
+	if err != nil {
+		t.Fatalf("new wake repair floor: %v", err)
+	}
+	if err := writeWakeRepairFloor(root, "alice", floor); err != nil {
+		t.Fatalf("write wake repair floor: %v", err)
+	}
+	persisted, exists, err := readWakeRepairFloor(root, "alice")
+	if err != nil || !exists {
+		t.Fatalf("read wake repair floor: exists=%v err=%v", exists, err)
+	}
+	cfg.baselineExisting = persisted.Existing
 	if err := notifyNewMessages(cfg); err != nil {
 		t.Fatalf("notify stale baseline: %v", err)
+	}
+	if got, err := os.ReadFile(outputPath); err == nil || !os.IsNotExist(err) || len(got) != 0 {
+		t.Fatalf("baseline message notified before DLQ retry: bytes=%d err=%v", len(got), err)
 	}
 
 	rootIdentity, err := fsq.SnapshotDeliveryRoot(root)
@@ -397,7 +418,7 @@ func TestRunWakeWithLoopNoneSkipsTTYAndWritesReadyFile(t *testing.T) {
 		if cfg.injectMode != wakeInjectModeNone {
 			t.Fatalf("injectMode = %q, want none", cfg.injectMode)
 		}
-		if err := cfg.onPrepared(); err != nil {
+		if err := cfg.onPrepared(nil); err != nil {
 			t.Fatalf("publish readiness: %v", err)
 		}
 		if _, statErr := os.Stat(readyPath); statErr != nil {
@@ -464,7 +485,7 @@ func TestRunWakeHelpHidesInternalReadyFlags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runWake --help: %v", err)
 	}
-	for _, hidden := range []string{"ready-file", "accept-existing-wake"} {
+	for _, hidden := range []string{"ready-file", "accept-existing-wake", "repair-lineage"} {
 		if strings.Contains(stdout, hidden) {
 			t.Fatalf("wake help should hide %s:\n%s", hidden, stdout)
 		}
@@ -2923,7 +2944,7 @@ func TestConfigureRepairWakeCommandDetachesOutput(t *testing.T) {
 
 func TestOpenWakeRepairOutputCreatesPrivateLog(t *testing.T) {
 	root := secureTempDirForTest(t)
-	output, err := openWakeRepairOutput(root, "orchestrator")
+	output, err := openWakeRepairOutputForTest(root, "orchestrator")
 	if err != nil {
 		t.Fatalf("openWakeRepairOutput: %v", err)
 	}
@@ -2954,7 +2975,7 @@ func TestOpenWakeRepairOutputRejectsSymlinkLog(t *testing.T) {
 		t.Fatalf("symlink repair log: %v", err)
 	}
 
-	output, err := openWakeRepairOutput(root, "orchestrator")
+	output, err := openWakeRepairOutputForTest(root, "orchestrator")
 	if err == nil {
 		_ = output.Close()
 		t.Fatal("expected symlink repair log rejection")
@@ -2976,7 +2997,7 @@ func TestOpenWakeRepairOutputRejectsFIFOWithoutBlocking(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		output, err := openWakeRepairOutput(root, "orchestrator")
+		output, err := openWakeRepairOutputForTest(root, "orchestrator")
 		if output != nil {
 			_ = output.Close()
 		}
@@ -2993,6 +3014,15 @@ func TestOpenWakeRepairOutputRejectsFIFOWithoutBlocking(t *testing.T) {
 	}
 }
 
+func openWakeRepairOutputForTest(root, me string) (*os.File, error) {
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = agentDir.Close() }()
+	return openWakeRepairOutputInDir(agentDir)
+}
+
 func TestRunWakeRepairJSONRejectsFIFOLogWithoutBlocking(t *testing.T) {
 	root := secureTempDirForTest(t)
 	injector := writeExecutableForTest(t, "injector")
@@ -3007,6 +3037,7 @@ func TestRunWakeRepairJSONRejectsFIFOLogWithoutBlocking(t *testing.T) {
 	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
+	writeWakeRepairFloorForTest(t, root, "orchestrator", target, nil)
 	agentBase := fsq.AgentBase(root, "orchestrator")
 	if err := syscall.Mkfifo(filepath.Join(agentBase, ".wake.repair.log"), 0o600); err != nil {
 		t.Fatalf("mkfifo repair log: %v", err)
@@ -3041,6 +3072,60 @@ func TestRunWakeWithLoopRejectsInjectArgWithoutInjectVia(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--inject-arg requires --inject-via") {
 		t.Fatalf("expected inject-arg usage error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopRejectsInvalidRepairLineageFlags(t *testing.T) {
+	injector := writeExecutableForTest(t, "injector")
+	tests := []struct {
+		name     string
+		args     []string
+		ownerEnv string
+		want     string
+	}{
+		{
+			name: "blank lineage",
+			args: []string{"--repair-lineage= "},
+			want: "--repair-lineage must not be blank",
+		},
+		{
+			name: "requires inject via",
+			args: []string{"--repair-lineage", "dead-generation"},
+			want: "--repair-lineage requires --inject-via",
+		},
+		{
+			name: "conflicts with baseline existing",
+			args: []string{
+				"--repair-lineage", "dead-generation",
+				"--inject-via", injector,
+				"--baseline-existing",
+			},
+			want: "--repair-lineage cannot be combined with --baseline-existing",
+		},
+		{
+			name: "requires private handoff before owner inspection",
+			args: []string{
+				"--repair-lineage", "dead-generation",
+				"--inject-via", injector,
+			},
+			ownerEnv: `{"pid":4242}`,
+			want:     "wake repair requires a private source/admission handoff",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envWakeOwner, tc.ownerEnv)
+			args := []string{"--root", secureTempDirForTest(t), "--me", "orchestrator"}
+			args = append(args, tc.args...)
+			err := runWakeWithLoop(args, func(cfg wakeConfig) error {
+				t.Fatalf("loop should not run with invalid repair lineage: %#v", cfg)
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake_upgrade_race_unix_test.go
+++ b/internal/cli/wake_upgrade_race_unix_test.go
@@ -27,6 +27,7 @@ func TestWakeUpgradeRaceRepairRejectsConcurrentCurrentAcquire(t *testing.T) {
 	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("write legacy wake target: %v", err)
 	}
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
 
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == os.Getpid() {
@@ -43,7 +44,7 @@ func TestWakeUpgradeRaceRepairRejectsConcurrentCurrentAcquire(t *testing.T) {
 	})
 	repairStarted := make(chan struct{})
 	releaseRepair := make(chan struct{})
-	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget) (int, error) {
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget, _ wakeRepairFloor) (int, error) {
 		if gotRoot != root || gotMe != "codex" || !sameWakeInjectorIdentity(gotTarget, target) {
 			t.Fatalf("repair starter got root=%q me=%q target=%#v", gotRoot, gotMe, gotTarget)
 		}

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -83,10 +83,13 @@ Leader prepares commit -> user approves -> push
 - When starting a new wake after the agent owns its terminal, pass `amq wake
   --baseline-existing ...`. Existing `inbox/new` messages remain unread and
   emit no receipts; only later arrivals trigger that fresh wake. `coop exec`
-  and `wake repair` add the flag to wakes they start. Reuse requires
-  generation-bound proof that the live wake completed watcher preparation. It
-  does not retroactively baseline that wake, so pending backlog can still
-  notify; SessionStart draining mitigates that residual.
+  adds the flag to wakes it starts. `wake repair` instead inherits the dead
+  generation's private device/inode/ctime suppression floor; it does not
+  re-snapshot `inbox/new`, so messages delivered during notifier downtime
+  remain eligible. Reuse requires generation-bound proof that the live wake
+  completed watcher preparation. It does not retroactively baseline that wake,
+  so pending backlog can still notify; SessionStart draining mitigates that
+  residual.
 
 ## Message Handling
 


### PR DESCRIPTION
## Summary

- make wake repair identity-safe and lineage-bound across process death, namespace replacement, and concurrent repair
- keep repaired children effect-blocked through PREPARED, ADMIT/ACK, final parent revalidation, stable capability detach, and exact RELEASE
- retain exact target/floor/directory authority, restore CLOEXEC on inherited descriptors, and make Darwin cleanup/detach deterministic
- add operator diagnostics, repair continuity documentation, and cross-platform lifecycle/race coverage

## Root cause

A crashed injector could leave valid persisted repair state but an unusable raw wake. Repair previously lacked a private, linearizable admission protocol and stable retained namespace authority. During hardening we also found that Darwin inherited blocking pipes could deadlock cleanup, reconstructed target timestamps could reject the exact persisted target, ACK could release effects before final parent validation, and inherited repair descriptors could leak into injector descendants.

## Verification

- exact tree: 7dc07e6e78736a06f93dffaca36c1ec96f735f9c
- focused release/namespace/Darwin lifecycle: 20 iterations PASS
- focused race: 5 iterations PASS
- go test ./... -count=1 PASS
- go test -race ./internal/cli -count=1 PASS
- go vet ./... PASS
- golangci-lint run PASS, 0 issues
- Linux amd64 and Darwin arm64 test compilation PASS
- git diff --check, gofmt, and artifact scan PASS
- independent fresh exact-tree review PASS

## Holds

Merge and release remain held for exact-head CI and final production/runtime review.
