### PR TITLE
fix(wake): harden coop owner lifecycle

### DIFF
--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -201,6 +202,38 @@ func TestCoopExecAlwaysOverwritesOwnerTokenImmediatelyBeforeExec(t *testing.T) {
 	}
 }
 
+func TestCoopExecRejectsExecReturningNil(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	oldExec := coopExecProcess
+	coopExecProcess = func(string, []string, []string) error { return nil }
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err := runCoopExec([]string{"--root", root, "--me", "codex", "--no-wake", "sh"})
+	if err == nil || !strings.Contains(err.Error(), "exec returned without replacing process") {
+		t.Fatalf("coop exec error = %v, want nil-return refusal", err)
+	}
+}
+
+func TestCoopExecRejectsNilWakeChildCapability(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	oldPrepare := prepareAuthoritativeWakeChild
+	prepareAuthoritativeWakeChild = func(*exec.Cmd) (*authoritativeWakeChildCapability, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() { prepareAuthoritativeWakeChild = oldPrepare })
+
+	err := runCoopExec([]string{"--root", root, "--me", "codex", "sh"})
+	if err == nil || !strings.Contains(err.Error(), "returned nil capability") {
+		t.Fatalf("coop exec error = %v, want nil-capability refusal", err)
+	}
+}
+
 func TestCoopWakeReadinessTempFailureDegradesOnlyWithoutRequiredOrLiveWake(t *testing.T) {
 	cause := errors.New("TMPDIR unavailable")
 	confirmedLive := wakeLockInspection{
@@ -314,11 +347,228 @@ func TestCoopExecWakeInjectModeValidation(t *testing.T) {
 	}
 }
 
-func TestBuildCoopWakeArgsIncludesNoneMode(t *testing.T) {
+func TestBuildCoopWakeArgsDisablesInterruptAndGenericReuse(t *testing.T) {
 	got := buildCoopWakeArgs("codex", "/tmp/root", "none", "", nil, "/tmp/ready")
-	want := []string{"--no-update-check", "wake", "--me", "codex", "--root", "/tmp/root", "--baseline-existing", "--inject-mode", "none", "--ready-file", "/tmp/ready", "--accept-existing-wake"}
+	want := []string{
+		"--no-update-check",
+		"wake",
+		"--me", "codex",
+		"--root", "/tmp/root",
+		"--baseline-existing",
+		"--interrupt-cmd", "none",
+		"--inject-mode", "none",
+		"--ready-file", "/tmp/ready",
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildCoopWakeArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildCoopWakeArgsNeverAcceptsExistingGenericWake(t *testing.T) {
+	for _, mode := range []string{
+		wakeInjectModeAuto,
+		wakeInjectModeRaw,
+		wakeInjectModePaste,
+		wakeInjectModeNone,
+	} {
+		t.Run(mode, func(t *testing.T) {
+			args := buildCoopWakeArgs("codex", "/tmp/root", mode, "", nil, "/tmp/ready")
+			for _, arg := range args {
+				if arg == "--accept-existing-wake" {
+					t.Fatalf("generic mode %q permits ownerless wake reuse: %#v", mode, args)
+				}
+			}
+		})
+	}
+}
+
+func TestCleanupCoopWakeStartupHelperPreservesReusedClaim(t *testing.T) {
+	root := t.TempDir()
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        5151,
+		Generation: "reused-generation",
+	})
+	before, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stopped := false
+	closed := false
+	capability := &authoritativeWakeChildCapability{
+		stop: func() error {
+			stopped = true
+			return nil
+		},
+		close: func() error {
+			closed = true
+			return nil
+		},
+	}
+	waiter := &wakeProcessWaiter{done: make(chan struct{})}
+	close(waiter.done)
+
+	if err := cleanupCoopWakeStartupHelper(
+		&os.Process{Pid: 5252},
+		waiter,
+		capability,
+		nil,
+		root,
+		"codex",
+		true,
+		nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !stopped || !closed {
+		t.Fatalf("startup helper cleanup stopped=%v closed=%v", stopped, closed)
+	}
+	after, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("reused claim changed during startup-helper cleanup:\nbefore=%s\nafter=%s", before, after)
+	}
+}
+
+func TestCleanupCoopWakeStartupHelperSurfacesCapabilityFailures(t *testing.T) {
+	stopErr := errors.New("stop failed")
+	closeErr := errors.New("close failed")
+	capability := &authoritativeWakeChildCapability{
+		stop: func() error { return stopErr },
+		close: func() error {
+			return closeErr
+		},
+	}
+	waiter := &wakeProcessWaiter{done: make(chan struct{})}
+	close(waiter.done)
+
+	err := cleanupCoopWakeStartupHelper(
+		&os.Process{Pid: 5252},
+		waiter,
+		capability,
+		nil,
+		t.TempDir(),
+		"codex",
+		true,
+		nil,
+	)
+	if !errors.Is(err, stopErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("cleanup error = %v, want joined stop and close failures", err)
+	}
+}
+
+func TestFreshWakeHelperCleanupAttemptsStopWaitAndClose(t *testing.T) {
+	stopErr := errors.New("stop failed")
+	closeErr := errors.New("close failed")
+	stopped := false
+	closed := false
+	capability := &authoritativeWakeChildCapability{
+		stop: func() error {
+			stopped = true
+			return stopErr
+		},
+		close: func() error {
+			closed = true
+			return closeErr
+		},
+	}
+
+	err := terminateAuthoritativeWakeHelperProcessForClaim(
+		&os.Process{Pid: 5252},
+		nil,
+		capability,
+		t.TempDir(),
+		"codex",
+		wakeOwner{},
+		nil,
+	)
+	if !stopped || !closed {
+		t.Fatalf("fresh cleanup stopped=%v closed=%v", stopped, closed)
+	}
+	if !errors.Is(err, stopErr) || !errors.Is(err, closeErr) ||
+		!strings.Contains(err.Error(), "waiter is missing") {
+		t.Fatalf("cleanup error = %v, want joined stop, wait, and close failures", err)
+	}
+}
+
+func TestFreshWakeHelperCleanupPreservesChangedGeneration(t *testing.T) {
+	root := t.TempDir()
+	const wakePID = 5252
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        wakePID,
+		Generation: "helper-generation",
+	})
+	expected := inspectWakeLock(root, "codex")
+	capability := &authoritativeWakeChildCapability{
+		stop: func() error {
+			writeWakeLockForTest(t, root, "codex", wakeLock{
+				PID:        wakePID,
+				Generation: "replacement-generation",
+			})
+			return nil
+		},
+	}
+	waiter := &wakeProcessWaiter{done: make(chan struct{})}
+	close(waiter.done)
+
+	if err := terminateAuthoritativeWakeHelperProcessForClaim(
+		&os.Process{Pid: wakePID},
+		waiter,
+		capability,
+		root,
+		"codex",
+		wakeOwner{},
+		&expected,
+	); err != nil {
+		t.Fatal(err)
+	}
+	current := inspectWakeLock(root, "codex")
+	if current.Lock.Generation != "replacement-generation" {
+		t.Fatalf("changed generation was mutated during cleanup: %#v", current)
+	}
+}
+
+func TestFreshWakeHelperCleanupRetainsStalePublishedGeneration(t *testing.T) {
+	root := t.TempDir()
+	const wakePID = 5252
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid}
+	})
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        wakePID,
+		Generation: "published-before-exit",
+	})
+	current := inspectWakeLock(root, "codex")
+	if current.Status != wakeLockStale {
+		t.Fatalf("published helper fixture is %s, want stale: %#v", current.Status, current)
+	}
+	claim := exactCoopWakeHelperClaim(&os.Process{Pid: wakePID}, current)
+	if claim == nil {
+		t.Fatal("same-helper stale generation was not retained for exact cleanup")
+	}
+	capability := &authoritativeWakeChildCapability{
+		stop:  func() error { return nil },
+		close: func() error { return nil },
+	}
+	waiter := &wakeProcessWaiter{done: make(chan struct{})}
+	close(waiter.done)
+	owner := wakeOwner{}
+	if err := cleanupCoopWakeStartupHelper(
+		&os.Process{Pid: wakePID},
+		waiter,
+		capability,
+		&owner,
+		root,
+		"codex",
+		false,
+		claim,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale same-helper generation survived exact cleanup: %v", err)
 	}
 }
 

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -62,10 +62,10 @@ func runCoopExec(args []string) error {
 		"  amq coop exec --wake-inject-via /path/to/injector codex",
 		"  amq coop exec --me myagent bash                   # Debug shell with AMQ env",
 		"",
-		"Zero-input readiness:",
-		"  --wake-inject-mode none never reuses an existing wake unless its lock",
-		"  proves it was also started in none mode; stop an older wake and retry.",
-		"  A default request remains transport-agnostic and may reuse a none wake.",
+		"Wake readiness:",
+		"  Coop never reuses a generic wake because it has no persisted",
+		"  exact-owner identity. Only an exact owner-bound inject-via wake can be",
+		"  reused; stop an older generic wake before retrying coop exec.",
 	)
 
 	if handled, err := parseFlags(fs, amqArgs, usage); err != nil {
@@ -234,30 +234,44 @@ func runCoopExec(args []string) error {
 		return fmt.Errorf("command not found: %s", cmdName)
 	}
 
-	// Start amq wake in background (unless --no-wake).
-	// On successful Exec, wake is orphaned (reparented to init/launchd) — intended.
-	// On failed Exec, deferred kill cleans up the wake process.
+	// Start amq wake in background (unless --no-wake). Every coop-started wake
+	// is bound to this exact process identity and exits when the exec-replaced
+	// agent exits. On failed Exec, stable child cleanup stops it immediately.
 	var wakeProc *os.Process
 	var wakeWaiter *wakeProcessWaiter
 	var wakeChildCapability *authoritativeWakeChildCapability
+	var wakeHelperClaim *wakeLockInspection
 	var cleanupWakeReady func()
 	var earlyOwner *wakeOwner
 	baseEnv := unsetEnvVar(unsetEnvVar(os.Environ(), envWakeOwner), envWakePrivateStopFD)
+	retainWakeHelperClaim := func(current wakeLockInspection) {
+		if retained := exactCoopWakeHelperClaim(wakeProc, current); retained != nil {
+			wakeHelperClaim = retained
+		}
+	}
+	cleanupWakeHelper := func(preservePersistedClaim bool) error {
+		return cleanupCoopWakeStartupHelper(
+			wakeProc,
+			wakeWaiter,
+			wakeChildCapability,
+			earlyOwner,
+			root,
+			agentHandle,
+			preservePersistedClaim,
+			wakeHelperClaim,
+		)
+	}
 	if !*noWakeFlag {
 		amqBin, binErr := os.Executable()
 		if binErr != nil {
 			amqBin = "amq"
 		}
 
-		var wakeOwner *wakeOwner
-		if wakeInjectVia != "" {
-			captured, ownerErr := captureAuthoritativeCurrentWakeOwner()
-			if ownerErr != nil {
-				return ownerErr
-			}
-			earlyOwner = &captured
-			wakeOwner = earlyOwner
+		captured, ownerErr := captureAuthoritativeCurrentWakeOwner()
+		if ownerErr != nil {
+			return fmt.Errorf("capture exact coop wake owner: %w", ownerErr)
 		}
+		earlyOwner = &captured
 		readyPath, cleanupReady, readyErr := newWakeReadyFile()
 		if readyErr != nil {
 			inspection := inspectWakeLock(root, agentHandle)
@@ -270,7 +284,7 @@ func runCoopExec(args []string) error {
 			wakeCmd := exec.Command(amqBin, buildCoopWakeArgs(agentHandle, root, wakeInjectMode, wakeInjectVia, []string(wakeInjectArgFlags), readyPath)...)
 			// Set AM_ROOT in wake's env so the helper process resolves the same
 			// session root even if the parent shell inherited a different value.
-			wakeEnv, wakeEnvErr := wakeCommandEnv(baseEnv, root, wakeOwner)
+			wakeEnv, wakeEnvErr := wakeCommandEnv(baseEnv, root, earlyOwner)
 			if wakeEnvErr != nil {
 				return wakeEnvErr
 			}
@@ -278,29 +292,45 @@ func runCoopExec(args []string) error {
 			wakeCmd.Stdin = os.Stdin
 			wakeCmd.Stdout = os.Stdout
 			wakeCmd.Stderr = os.Stderr
-			if earlyOwner != nil {
-				wakeChildCapability, err = configureAuthoritativeWakeChild(wakeCmd)
-				if err != nil {
-					var unsupported *wakeOwnerChildCapabilityUnsupportedError
-					if !errors.As(err, &unsupported) {
-						return fmt.Errorf("prepare owner-bound wake child: %w", err)
-					}
-					_ = writeStderr("warning: owner-bound wake child capability is unsupported; starting one ownerless inject-via wake\n")
-					earlyOwner = nil
-					wakeCmd.Env, wakeEnvErr = wakeCommandEnv(baseEnv, root, nil)
-					if wakeEnvErr != nil {
-						return wakeEnvErr
-					}
-				}
+			wakeChildCapability, err = configureAuthoritativeWakeChild(wakeCmd)
+			if err == nil && wakeChildCapability == nil {
+				return fmt.Errorf("prepare exact-owner amq wake supervision returned nil capability")
 			}
-
-			if err := wakeCmd.Start(); err != nil {
+			if err != nil {
+				var closeErr error
 				if wakeChildCapability != nil {
-					_ = wakeChildCapability.Close()
+					closeErr = wakeChildCapability.Close()
 					wakeChildCapability = nil
 				}
+				if closeErr != nil {
+					return errors.Join(
+						fmt.Errorf("prepare exact-owner amq wake supervision: %w", err),
+						fmt.Errorf("cleanup unstarted coop wake capability: %w", closeErr),
+					)
+				}
 				inspection := inspectWakeLock(root, agentHandle)
-				if err := handleCoopWakeSetupFailure(*requireWakeFlag, inspection, "start amq wake baseline helper", err); err != nil {
+				if setupErr := handleCoopWakeSetupFailure(
+					*requireWakeFlag,
+					inspection,
+					"prepare exact-owner amq wake supervision",
+					err,
+				); setupErr != nil {
+					return setupErr
+				}
+			} else if err := wakeCmd.Start(); err != nil {
+				var closeErr error
+				if wakeChildCapability != nil {
+					closeErr = wakeChildCapability.Close()
+					wakeChildCapability = nil
+				}
+				if closeErr != nil {
+					return errors.Join(
+						fmt.Errorf("start exact-owner amq wake helper: %w", err),
+						fmt.Errorf("cleanup unstarted coop wake capability: %w", closeErr),
+					)
+				}
+				inspection := inspectWakeLock(root, agentHandle)
+				if err := handleCoopWakeSetupFailure(*requireWakeFlag, inspection, "start exact-owner amq wake helper", err); err != nil {
 					return err
 				}
 			} else {
@@ -308,51 +338,79 @@ func runCoopExec(args []string) error {
 				wakeWaiter = newWakeProcessWaiter(wakeProc)
 				if wakeChildCapability != nil {
 					if err := wakeChildCapability.Bind(wakeProc); err != nil {
-						stopErr := wakeChildCapability.Stop()
-						if stopErr == nil {
-							_ = wakeWaiter.waitForExit(wakeProcessExitTimeout)
+						current := inspectWakeLock(root, agentHandle)
+						retainWakeHelperClaim(current)
+						cleanupErr := cleanupWakeHelper(current.Exists && current.PID != wakeProc.Pid)
+						bindErr := fmt.Errorf("bind stable owner-bound wake child: %w", err)
+						if cleanupErr == nil {
+							return bindErr
 						}
-						_ = wakeChildCapability.Close()
-						if stopErr != nil {
-							return fmt.Errorf("bind stable owner-bound wake child: %w (stable cleanup unavailable: %v)", err, stopErr)
-						}
-						return fmt.Errorf("bind stable owner-bound wake child: %w", err)
+						return errors.Join(bindErr, fmt.Errorf("cleanup exact coop wake startup helper: %w", cleanupErr))
 					}
 				}
-				if err := waitForWakeReadyWithOwner(
+				readyErr := waitForWakeReadyWithOwner(
 					wakeWaiter,
 					readyPath,
 					root,
 					agentHandle,
 					earlyOwner,
 					wakeReadyTimeout,
-				); err != nil {
-					cleanupErr := cleanupStartedWakeHelper(
-						wakeProc,
-						wakeWaiter,
-						wakeChildCapability,
-						earlyOwner,
-						root,
-						agentHandle,
-					)
-					inspection := inspectWakeLock(root, agentHandle)
-					otherLiveWake := confirmedLiveWake(inspection) && inspection.PID != wakeProc.Pid
-					if *requireWakeFlag || otherLiveWake {
-						if cleanupErr != nil {
-							return fmt.Errorf("%w (cleanup: %v)", err, cleanupErr)
-						}
-						return err
-					}
+				)
+				current := inspectWakeLock(root, agentHandle)
+				retainWakeHelperClaim(current)
+				otherWake := current.Exists && current.PID != wakeProc.Pid
+				if readyErr != nil {
+					cleanupErr := cleanupWakeHelper(otherWake)
 					if cleanupErr != nil {
-						_ = writeStderr("warning: failed to prepare amq wake: %v (cleanup: %v)\n", err, cleanupErr)
-					} else {
-						_ = writeStderr("warning: failed to prepare amq wake: %v\n", err)
+						return errors.Join(
+							readyErr,
+							fmt.Errorf("cleanup exact coop wake startup helper: %w", cleanupErr),
+						)
 					}
+					if otherWake || *requireWakeFlag {
+						return readyErr
+					}
+					_ = writeStderr("warning: failed to prepare amq wake: %v\n", readyErr)
 					wakeProc = nil
 					wakeWaiter = nil
 					wakeChildCapability = nil
 				} else {
-					_ = writeStderr("%s\n", wakeReadyMessage(root, agentHandle, wakeProc.Pid))
+					current, claimErr := validatePreparedCoopWakeClaim(
+						root,
+						agentHandle,
+						wakeInjectVia,
+						[]string(wakeInjectArgFlags),
+						*earlyOwner,
+						wakeProc.Pid,
+					)
+					reused := current.Exists && current.PID != wakeProc.Pid
+					if !reused {
+						retainWakeHelperClaim(current)
+					}
+					if claimErr != nil {
+						cleanupErr := cleanupWakeHelper(reused)
+						if cleanupErr != nil {
+							return errors.Join(
+								claimErr,
+								fmt.Errorf("cleanup exact coop wake startup helper: %w", cleanupErr),
+							)
+						}
+						return claimErr
+					}
+					if reused {
+						if cleanupErr := cleanupWakeHelper(true); cleanupErr != nil {
+							return fmt.Errorf(
+								"finish exact reused-wake startup helper: %w",
+								cleanupErr,
+							)
+						}
+						_ = writeStderr("%s\n", wakeReadyMessage(root, agentHandle, current.PID))
+						wakeProc = nil
+						wakeWaiter = nil
+						wakeChildCapability = nil
+					} else {
+						_ = writeStderr("%s\n", wakeReadyMessage(root, agentHandle, wakeProc.Pid))
+					}
 				}
 			}
 		}
@@ -371,32 +429,143 @@ func runCoopExec(args []string) error {
 	if cleanupWakeReady != nil {
 		cleanupWakeReady()
 	}
+	cleanupAfterError := func(cause error) error {
+		cleanupErr := cleanupWakeHelper(false)
+		if cleanupErr == nil {
+			return cause
+		}
+		return errors.Join(
+			cause,
+			fmt.Errorf("cleanup exact coop wake helper: %w", cleanupErr),
+		)
+	}
 	finalOwner, ownerErr := captureAuthoritativeCurrentWakeOwner()
 	if ownerErr != nil {
-		if wakeProc != nil {
-			_ = cleanupStartedWakeHelper(wakeProc, wakeWaiter, wakeChildCapability, earlyOwner, root, agentHandle)
-		}
-		return ownerErr
+		return cleanupAfterError(fmt.Errorf("capture final coop wake owner: %w", ownerErr))
 	}
 	if earlyOwner != nil && *earlyOwner != finalOwner {
-		if wakeProc != nil {
-			_ = cleanupStartedWakeHelper(wakeProc, wakeWaiter, wakeChildCapability, earlyOwner, root, agentHandle)
-		}
-		return fmt.Errorf("coop exec process identity changed after owner-bound wake start")
+		return cleanupAfterError(fmt.Errorf("coop exec process identity changed after owner-bound wake start"))
 	}
 	encodedOwner, ownerErr := encodeWakeOwnerEnv(finalOwner)
 	if ownerErr != nil {
-		if wakeProc != nil {
-			_ = cleanupStartedWakeHelper(wakeProc, wakeWaiter, wakeChildCapability, earlyOwner, root, agentHandle)
-		}
-		return fmt.Errorf("encode final wake owner: %w", ownerErr)
+		return cleanupAfterError(fmt.Errorf("encode final wake owner: %w", ownerErr))
 	}
 	env = setEnvVar(unsetEnvVar(env, envWakeOwner), envWakeOwner, encodedOwner)
 	execErr := coopExecProcess(binaryPath, argv, env)
-	if wakeProc != nil {
-		_ = cleanupStartedWakeHelper(wakeProc, wakeWaiter, wakeChildCapability, earlyOwner, root, agentHandle)
+	if execErr == nil {
+		execErr = fmt.Errorf("exec returned without replacing process")
 	}
-	return execErr
+	return cleanupAfterError(execErr)
+}
+
+func exactCoopWakeHelperClaim(
+	proc *os.Process,
+	current wakeLockInspection,
+) *wakeLockInspection {
+	if proc == nil ||
+		!current.Exists ||
+		current.PID != proc.Pid ||
+		current.Lock.Generation == "" {
+		return nil
+	}
+	switch current.Status {
+	case wakeLockValid, wakeLockStale:
+	default:
+		return nil
+	}
+	switch classifyPersistedWakeClaim(current) {
+	case wakeClaimGeneric, wakeClaimAuthoritative:
+		retained := current
+		return &retained
+	default:
+		return nil
+	}
+}
+
+func validatePreparedCoopWakeClaim(
+	root string,
+	me string,
+	injectVia string,
+	injectArgs []string,
+	owner wakeOwner,
+	helperPID int,
+) (wakeLockInspection, error) {
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return wakeLockInspection{}, err
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	var current wakeLockInspection
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current = inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !confirmedLiveWake(current) {
+			return fmt.Errorf("prepared coop wake is not a confirmed live wake")
+		}
+		if current.PID != helperPID && injectVia == "" {
+			return fmt.Errorf(
+				"generic coop wake readiness resolved to unrelated pid %d",
+				current.PID,
+			)
+		}
+		if injectVia == "" {
+			return nil
+		}
+		if classifyPersistedWakeClaim(current) != wakeClaimAuthoritative {
+			return fmt.Errorf("prepared inject-via wake is not an authoritative owner claim")
+		}
+		target, err := validateAuthoritativeWakeClaimPairAt(dirfd, agentDir, current)
+		if err != nil {
+			return fmt.Errorf("validate prepared inject-via owner claim: %w", err)
+		}
+		if !sameWakeOwner(current.Lock.Owner, &owner) ||
+			!sameWakeOwner(target.Owner, &owner) {
+			return fmt.Errorf("prepared inject-via wake belongs to a different exact owner")
+		}
+		requested, err := newWakeTarget(root, me, injectVia, injectArgs)
+		if err != nil {
+			return fmt.Errorf("rebuild requested inject-via target: %w", err)
+		}
+		requested.Owner = &owner
+		if !sameWakeInjectorIdentity(target, requested) {
+			return fmt.Errorf("prepared inject-via wake uses a different injector path or fixed arguments")
+		}
+		return nil
+	})
+	return current, err
+}
+
+func cleanupCoopWakeStartupHelper(
+	proc *os.Process,
+	waiter *wakeProcessWaiter,
+	capability *authoritativeWakeChildCapability,
+	owner *wakeOwner,
+	root string,
+	me string,
+	preservePersistedClaim bool,
+	helperClaim *wakeLockInspection,
+) error {
+	if proc == nil {
+		if capability == nil {
+			return nil
+		}
+		return capability.Close()
+	}
+	if !preservePersistedClaim {
+		return cleanupStartedWakeHelper(proc, waiter, capability, owner, root, me, helperClaim)
+	}
+	if waiter == nil {
+		return fmt.Errorf("coop wake startup helper waiter is missing")
+	}
+	if capability == nil {
+		return fmt.Errorf("coop wake startup helper capability is missing")
+	}
+	// The persisted claim belongs to another exact process. Stop and join only
+	// this startup helper; never run claim cleanup against the reused generation.
+	stopErr := capability.Stop()
+	waitErr := waiter.waitForExit(wakeProcessExitTimeout)
+	closeErr := capability.Close()
+	return errors.Join(stopErr, waitErr, closeErr)
 }
 
 func confirmedLiveWake(inspection wakeLockInspection) bool {
@@ -415,7 +584,14 @@ func handleCoopWakeSetupFailure(requireWake bool, inspection wakeLockInspection,
 }
 
 func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectArgs []string, readyFile string) []string {
-	args := []string{"--no-update-check", "wake", "--me", agentHandle, "--root", root, "--baseline-existing"}
+	args := []string{
+		"--no-update-check",
+		"wake",
+		"--me", agentHandle,
+		"--root", root,
+		"--baseline-existing",
+		"--interrupt-cmd", "none",
+	}
 	if injectMode != "" && injectMode != wakeInjectModeAuto {
 		args = append(args, "--inject-mode", injectMode)
 	}
@@ -426,7 +602,12 @@ func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectAr
 		}
 	}
 	if readyFile != "" {
-		args = append(args, "--ready-file", readyFile, "--accept-existing-wake")
+		args = append(args, "--ready-file", readyFile)
+		if injectVia != "" {
+			// Only an exact owner-bound inject-via claim has persisted owner
+			// metadata that can prove reuse belongs to this coop process.
+			args = append(args, "--accept-existing-wake")
+		}
 	}
 	return args
 }
@@ -544,11 +725,20 @@ func cleanupStartedWakeHelper(
 	owner *wakeOwner,
 	root string,
 	me string,
+	helperClaim *wakeLockInspection,
 ) error {
 	if owner == nil {
 		return terminateWakeHelperProcess(proc, waiter, root, me)
 	}
-	return terminateAuthoritativeWakeHelperProcess(proc, waiter, capability, root, me, *owner)
+	return terminateAuthoritativeWakeHelperProcessForClaim(
+		proc,
+		waiter,
+		capability,
+		root,
+		me,
+		*owner,
+		helperClaim,
+	)
 }
 
 func terminateAuthoritativeWakeHelperProcess(
@@ -559,43 +749,68 @@ func terminateAuthoritativeWakeHelperProcess(
 	me string,
 	owner wakeOwner,
 ) error {
-	if proc == nil || waiter == nil {
-		if capability != nil {
-			_ = capability.Close()
-		}
-		return nil
-	}
+	expected := inspectWakeLock(root, me)
+	return terminateAuthoritativeWakeHelperProcessForClaim(
+		proc,
+		waiter,
+		capability,
+		root,
+		me,
+		owner,
+		&expected,
+	)
+}
+
+func terminateAuthoritativeWakeHelperProcessForClaim(
+	proc *os.Process,
+	waiter *wakeProcessWaiter,
+	capability *authoritativeWakeChildCapability,
+	root string,
+	me string,
+	owner wakeOwner,
+	helperClaim *wakeLockInspection,
+) error {
 	if capability == nil {
 		return fmt.Errorf("stable owner-bound wake child capability is missing")
 	}
-	if err := capability.Stop(); err != nil {
-		_ = capability.Close()
-		return err
-	}
-	if err := waiter.waitForExit(wakeProcessExitTimeout); err != nil {
-		_ = capability.Close()
-		return err
-	}
-	if err := capability.Close(); err != nil {
-		return err
-	}
-	current := inspectWakeLock(root, me)
-	switch classifyPersistedWakeClaim(current) {
-	case wakeClaimAbsent:
-		return nil
-	case wakeClaimAuthoritative:
-		return rollbackAuthoritativeWakeClaim(root, me, owner)
-	case wakeClaimGeneric:
-		if current.PID != proc.Pid {
-			return fmt.Errorf("ownerless fallback wake generation changed before cleanup")
-		}
-		return cleanupTerminatedWakeLock(current)
+	stopErr := capability.Stop()
+	var waitErr error
+	switch {
+	case proc == nil:
+		waitErr = fmt.Errorf("stable owner-bound wake child process is missing")
+	case waiter == nil:
+		waitErr = fmt.Errorf("stable owner-bound wake child waiter is missing")
 	default:
-		return fmt.Errorf("wake claim is unverified after exact helper stop; preserving it")
+		waitErr = waiter.waitForExit(wakeProcessExitTimeout)
 	}
+	closeErr := capability.Close()
+
+	var claimErr error
+	if waitErr == nil && helperClaim != nil {
+		switch classifyPersistedWakeClaim(*helperClaim) {
+		case wakeClaimAuthoritative:
+			claimErr = rollbackAuthoritativeWakeClaimForInspection(root, me, owner, *helperClaim)
+		case wakeClaimGeneric:
+			claimErr = cleanupTerminatedWakeLock(*helperClaim)
+		case wakeClaimAbsent:
+		default:
+			claimErr = fmt.Errorf("retained helper wake claim is unverified; preserving it")
+		}
+	}
+	return errors.Join(stopErr, waitErr, closeErr, claimErr)
 }
 
 func rollbackAuthoritativeWakeClaim(root, me string, owner wakeOwner) error {
+	expected := inspectWakeLock(root, me)
+	return rollbackAuthoritativeWakeClaimForInspection(root, me, owner, expected)
+}
+
+func rollbackAuthoritativeWakeClaimForInspection(
+	root string,
+	me string,
+	owner wakeOwner,
+	expected wakeLockInspection,
+) error {
 	currentOwner, err := captureAuthoritativeCurrentWakeOwner()
 	if err != nil {
 		return err
@@ -611,6 +826,9 @@ func rollbackAuthoritativeWakeClaim(root, me string, owner wakeOwner) error {
 	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		current := inspectWakeLockAt(dirfd, agentDir, root, me)
 		if !current.Exists {
+			return nil
+		}
+		if !sameWakeLockGeneration(expected, current) {
 			return nil
 		}
 		if classifyPersistedWakeClaim(current) != wakeClaimAuthoritative ||

--- a/internal/cli/coop_raw_injection_adversarial_unix_test.go
+++ b/internal/cli/coop_raw_injection_adversarial_unix_test.go
@@ -1,0 +1,508 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	adversarialCoopDoorbell = ": AMQ doorbell run amq drain --include-body then act on it"
+	publicCoopPTYTimeout    = 12 * time.Second
+)
+
+func TestCoopRawDoorbellDoesNotContainMessageDerivedBytes(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureAdversarialCoopMailbox(t, root, "codex")
+
+	sentinels := []string{
+		"SESSION_SENTINEL_$(touch /tmp/amq-session-pwned)",
+		"HEADER_SENTINEL_\x1b[31m",
+		"SUBJECT_SENTINEL_`id`",
+		"BODY_SENTINEL_\x03_é",
+	}
+	message := format.Message{
+		Header: format.Header{
+			Schema:   format.CurrentSchema,
+			ID:       "adversarial-terminal-payload",
+			From:     sentinels[1],
+			To:       []string{"codex"},
+			Thread:   "p2p/attacker__codex",
+			Subject:  sentinels[2],
+			Created:  "2026-07-25T00:00:00Z",
+			Priority: format.PriorityNormal,
+		},
+		Body: sentinels[3],
+	}
+	messagePath := deliverAdversarialWakeMessage(t, root, "codex", message)
+	cleanupWake, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeRaw,
+	})
+	if err != nil {
+		t.Fatalf("acquire adversarial raw wake: %v", err)
+	}
+	defer cleanupWake()
+
+	oldWait := waitForRawInputDrained
+	oldSleep := rawInjectSleep
+	t.Cleanup(func() {
+		waitForRawInputDrained = oldWait
+		rawInjectSleep = oldSleep
+	})
+	waitForRawInputDrained = func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	}
+	rawInjectSleep = func(time.Duration) {}
+
+	var injected []string
+	cfg := &wakeConfig{
+		me:          "codex",
+		root:        root,
+		session:     sentinels[0],
+		injectMode:  wakeInjectModeRaw,
+		controlStop: make(chan struct{}),
+		terminalWrite: func(chunk string) error {
+			injected = append(injected, chunk)
+			return nil
+		},
+		previewLen: 4096,
+	}
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify adversarial pending message: %v", err)
+	}
+
+	assertFixedASCIIOnlyCoopInjection(t, injected, sentinels)
+	if _, err := os.Stat(messagePath); err != nil {
+		t.Fatalf("wake notification consumed durable message: %v", err)
+	}
+}
+
+func TestCoopUrgentRefusalInjectsNoCtrlCAndKeepsMessagePending(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureAdversarialCoopMailbox(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:   format.CurrentSchema,
+			ID:       "urgent-refused-adversarial",
+			From:     "CTRL_C_SENTINEL_\x03",
+			To:       []string{"codex"},
+			Thread:   "p2p/attacker__codex",
+			Subject:  "URGENT_SENTINEL_$(kill -INT $$)",
+			Created:  "2026-07-25T00:00:00Z",
+			Priority: format.PriorityUrgent,
+			Labels:   []string{"interrupt"},
+		},
+		Body: "BODY_SENTINEL_must_remain_pending",
+	}
+	messagePath := deliverAdversarialWakeMessage(t, root, "codex", message)
+
+	var injected []string
+
+	stop := make(chan struct{})
+	close(stop)
+	cfg := &wakeConfig{
+		me:                "codex",
+		root:              root,
+		session:           "SESSION_SENTINEL",
+		injectMode:        wakeInjectModeRaw,
+		controlStop:       stop,
+		previewLen:        4096,
+		interrupt:         true,
+		interruptKey:      "\x03",
+		interruptLabel:    "interrupt",
+		interruptPriority: format.PriorityUrgent,
+		terminalWrite: func(chunk string) error {
+			injected = append(injected, chunk)
+			return nil
+		},
+	}
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify refused urgent message: %v", err)
+	}
+	if len(injected) != 0 {
+		t.Fatalf("refused urgent wake injected terminal chunks: %#v", injected)
+	}
+	if strings.Contains(strings.Join(injected, ""), "\x03") {
+		t.Fatalf("refused urgent wake injected Ctrl-C: %#v", injected)
+	}
+	if _, err := os.Stat(messagePath); err != nil {
+		t.Fatalf("refused urgent notification consumed durable message: %v", err)
+	}
+}
+
+func TestPublicCoopRawPTYDoorbellAndOwnerCleanup(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("the hermetic public raw PTY oracle currently uses Darwin /usr/bin/script argv semantics")
+	}
+	if _, err := os.Stat("/usr/bin/script"); err != nil {
+		t.Skipf("public raw PTY oracle requires /usr/bin/script: %v", err)
+	}
+
+	t.Run("normal owner exit", func(t *testing.T) {
+		fixture := startPublicCoopPTYFixture(t, "capture")
+		inspection := waitForPublicCoopWakeReady(t, fixture)
+
+		sentinels := []string{
+			"PUBLIC_SESSION_SENTINEL",
+			"PUBLIC_HEADER_SENTINEL_\x1b[31m",
+			"PUBLIC_SUBJECT_SENTINEL_$(touch /tmp/amq-public-pwned)",
+			"PUBLIC_BODY_SENTINEL_\x03_é",
+		}
+		message := format.Message{
+			Header: format.Header{
+				Schema:   format.CurrentSchema,
+				ID:       "public-raw-adversarial",
+				From:     sentinels[1],
+				To:       []string{"codex"},
+				Thread:   "p2p/attacker__codex",
+				Subject:  sentinels[2],
+				Created:  "2026-07-25T00:00:00Z",
+				Priority: format.PriorityNormal,
+			},
+			Body: sentinels[3],
+		}
+		messagePath := deliverAdversarialWakeMessage(t, fixture.root, "codex", message)
+
+		waitForAdversarialPath(t, fixture.linePath, publicCoopPTYTimeout)
+		line, err := os.ReadFile(fixture.linePath)
+		if err != nil {
+			t.Fatalf("read public PTY input: %v", err)
+		}
+		if got := strings.TrimSuffix(string(line), "\r"); got != adversarialCoopDoorbell {
+			t.Fatalf("public PTY input = %q, want fixed doorbell %q", got, adversarialCoopDoorbell)
+		}
+		for _, sentinel := range sentinels {
+			if bytes.Contains(line, []byte(sentinel)) {
+				t.Fatalf("public PTY input leaked %q: %q", sentinel, line)
+			}
+		}
+		if bytes.Contains(line, []byte{0x03}) {
+			t.Fatalf("public PTY input contains Ctrl-C: %q", line)
+		}
+		if _, err := os.Stat(fixture.interruptPath); !os.IsNotExist(err) {
+			t.Fatalf("public coop owner received SIGINT: %v", err)
+		}
+		if _, err := os.Stat(messagePath); err != nil {
+			t.Fatalf("public wake consumed durable message: %v", err)
+		}
+
+		if err := fixture.wait(); err != nil {
+			t.Fatalf("public coop normal exit: %v\n%s", err, fixture.output.String())
+		}
+		assertPublicWakeCleaned(t, fixture.root, "codex", inspection.PID)
+	})
+
+	t.Run("SIGKILL owner exit", func(t *testing.T) {
+		fixture := startPublicCoopPTYFixture(t, "hold")
+		inspection := waitForPublicCoopWakeReady(t, fixture)
+		ownerPID := fixture.ownerPID
+
+		if err := syscall.Kill(ownerPID, syscall.SIGKILL); err != nil {
+			t.Fatalf("SIGKILL public coop owner %d: %v", ownerPID, err)
+		}
+		// The PTY wrapper reports the killed child as a non-zero exit. The wake
+		// cleanup, not the wrapper exit code, is the public contract under test.
+		_ = fixture.wait()
+		assertPublicWakeCleaned(t, fixture.root, "codex", inspection.PID)
+	})
+}
+
+func assertFixedASCIIOnlyCoopInjection(t *testing.T, chunks, forbidden []string) {
+	t.Helper()
+	if len(chunks) == 0 {
+		t.Fatal("coop raw wake injected no doorbell")
+	}
+	if chunks[0] != adversarialCoopDoorbell {
+		t.Fatalf("first coop injection chunk = %q, want %q; all chunks=%#v",
+			chunks[0], adversarialCoopDoorbell, chunks)
+	}
+	joined := strings.Join(chunks, "")
+	for index, value := range []byte(joined) {
+		if value > 0x7f {
+			t.Fatalf("coop injection byte %d = %#x, want fixed ASCII only: %#v", index, value, chunks)
+		}
+	}
+	for _, sentinel := range forbidden {
+		if strings.Contains(joined, sentinel) {
+			t.Fatalf("coop injection leaked message-derived sentinel %q: %#v", sentinel, chunks)
+		}
+	}
+}
+
+func ensureAdversarialCoopMailbox(t *testing.T, root, me string) {
+	t.Helper()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure adversarial root: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, me); err != nil {
+		t.Fatalf("ensure adversarial mailbox: %v", err)
+	}
+}
+
+func deliverAdversarialWakeMessage(t *testing.T, root, me string, message format.Message) string {
+	t.Helper()
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatalf("marshal adversarial message: %v", err)
+	}
+	path, err := deliverToInboxForTest(t, root, me, message.Header.ID+".md", data)
+	if err != nil {
+		t.Fatalf("deliver adversarial message: %v", err)
+	}
+	return path
+}
+
+type publicCoopPTYFixture struct {
+	root          string
+	ownerPath     string
+	linePath      string
+	interruptPath string
+	cmd           *exec.Cmd
+	done          chan error
+	output        *bytes.Buffer
+	stdin         *os.File
+	ownerPID      int
+	wakeClaim     *wakeLockInspection
+	waited        bool
+}
+
+func startPublicCoopPTYFixture(t *testing.T, mode string) *publicCoopPTYFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	ensureAdversarialCoopMailbox(t, root, "codex")
+	dir := secureTempDirForTest(t)
+	ownerPath := filepath.Join(dir, "owner.pid")
+	linePath := filepath.Join(dir, "terminal-line")
+	interruptPath := filepath.Join(dir, "interrupt")
+	agentPath := filepath.Join(dir, "agent.sh")
+	agentScript := `#!/bin/sh
+set -eu
+owner_path=$1
+line_path=$2
+interrupt_path=$3
+mode=$4
+printf '%s\n' "$$" > "$owner_path"
+trap 'printf "SIGINT\n" > "$interrupt_path"; exit 97' INT
+if [ "$mode" = capture ]; then
+	IFS= read -r line
+	line_tmp="${line_path}.tmp.$$"
+	printf '%s' "$line" > "$line_tmp"
+	mv "$line_tmp" "$line_path"
+	exit 0
+fi
+while :; do
+	sleep 1
+done
+`
+	if err := os.WriteFile(agentPath, []byte(agentScript), 0o700); err != nil {
+		t.Fatalf("write public coop agent: %v", err)
+	}
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	// Wake identity validation intentionally requires an executable named amq.
+	// Preserve the compiled package-test entry point while giving the public
+	// subprocess the same executable identity as a shipped binary.
+	amqBinary := filepath.Join(dir, "amq")
+	testData, err := os.ReadFile(testBinary)
+	if err != nil {
+		t.Fatalf("read compiled test binary: %v", err)
+	}
+	if err := os.WriteFile(amqBinary, testData, 0o700); err != nil {
+		t.Fatalf("write hermetic amq binary: %v", err)
+	}
+	args := []string{
+		"-q", "/dev/null",
+		amqBinary,
+		"--no-update-check",
+		"coop", "exec",
+		"--root", root,
+		"--me", "codex",
+		"--require-wake",
+		"--wake-inject-mode", wakeInjectModeRaw,
+		agentPath,
+		ownerPath,
+		linePath,
+		interruptPath,
+		mode,
+	}
+	output := &bytes.Buffer{}
+	cmd := exec.Command("/usr/bin/script", args...)
+	cmd.Env = append(os.Environ(), cliHelperEnv+"=1", "AMQ_NO_UPDATE_CHECK=1")
+	cmd.Stdout = output
+	cmd.Stderr = output
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create public coop PTY stdin: %v", err)
+	}
+	cmd.Stdin = stdinReader
+	if err := cmd.Start(); err != nil {
+		_ = stdinReader.Close()
+		_ = stdinWriter.Close()
+		t.Fatalf("start public coop PTY: %v", err)
+	}
+	if err := stdinReader.Close(); err != nil {
+		_ = stdinWriter.Close()
+		_ = cmd.Process.Kill()
+		t.Fatalf("close parent PTY stdin reader: %v", err)
+	}
+	fixture := &publicCoopPTYFixture{
+		root:          root,
+		ownerPath:     ownerPath,
+		linePath:      linePath,
+		interruptPath: interruptPath,
+		cmd:           cmd,
+		done:          make(chan error, 1),
+		output:        output,
+		stdin:         stdinWriter,
+	}
+	go func() { fixture.done <- cmd.Wait() }()
+	t.Cleanup(func() {
+		if fixture.stdin != nil {
+			_ = fixture.stdin.Close()
+			fixture.stdin = nil
+		}
+		if !fixture.waited && fixture.cmd.Process != nil {
+			if fixture.ownerPID > 1 {
+				_ = syscall.Kill(fixture.ownerPID, syscall.SIGKILL)
+			}
+			_ = fixture.cmd.Process.Kill()
+			select {
+			case <-fixture.done:
+			case <-time.After(3 * time.Second):
+			}
+		}
+		if fixture.wakeClaim != nil {
+			current := inspectWakeLock(fixture.root, "codex")
+			if sameWakeLockGeneration(*fixture.wakeClaim, current) &&
+				current.PID == fixture.wakeClaim.PID {
+				_ = syscall.Kill(current.PID, syscall.SIGTERM)
+			}
+		}
+	})
+	return fixture
+}
+
+func waitForPublicCoopWakeReady(t *testing.T, fixture *publicCoopPTYFixture) wakeLockInspection {
+	t.Helper()
+	deadline := time.Now().Add(publicCoopPTYTimeout)
+	for time.Now().Before(deadline) {
+		inspection := inspectWakeLock(fixture.root, "codex")
+		if confirmedLiveWake(inspection) {
+			fixture.ownerPID = waitForPIDFile(t, fixture.ownerPath, publicCoopPTYTimeout)
+			retained := inspection
+			fixture.wakeClaim = &retained
+			return inspection
+		}
+		select {
+		case err := <-fixture.done:
+			fixture.waited = true
+			output := fixture.output.String()
+			if strings.Contains(output, "TIOCSTI not available") ||
+				strings.Contains(output, "amq wake requires a real terminal") {
+				t.Skipf("public raw PTY runtime unavailable on this host: %v\n%s", err, output)
+			}
+			t.Fatalf("public coop exited before wake readiness: %v\n%s", err, output)
+		default:
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if fixture.cmd.Process != nil {
+		_ = fixture.cmd.Process.Kill()
+	}
+	t.Fatalf("public coop wake did not become ready within %s\n%s", publicCoopPTYTimeout, fixture.output.String())
+	return wakeLockInspection{}
+}
+
+func (fixture *publicCoopPTYFixture) wait() error {
+	if fixture.waited {
+		return nil
+	}
+	if fixture.stdin != nil {
+		_ = fixture.stdin.Close()
+		fixture.stdin = nil
+	}
+	timer := time.NewTimer(publicCoopPTYTimeout)
+	defer timer.Stop()
+	select {
+	case err := <-fixture.done:
+		fixture.waited = true
+		return err
+	case <-timer.C:
+		if fixture.cmd.Process != nil {
+			_ = fixture.cmd.Process.Kill()
+		}
+		select {
+		case <-fixture.done:
+			fixture.waited = true
+		case <-time.After(3 * time.Second):
+		}
+		return fmt.Errorf("public coop PTY did not exit within %s", publicCoopPTYTimeout)
+	}
+}
+
+func assertPublicWakeCleaned(t *testing.T, root, me string, wakePID int) {
+	t.Helper()
+	deadline := time.Now().Add(publicCoopPTYTimeout)
+	for time.Now().Before(deadline) {
+		inspection := inspectWakeLock(root, me)
+		process := inspectWakeProcess(wakePID)
+		if !inspection.Exists && !process.Running {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("public coop wake survived owner exit: lock=%#v process=%#v",
+		inspectWakeLock(root, me), inspectWakeProcess(wakePID))
+}
+
+func waitForAdversarialPath(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("path %s did not appear within %s", path, timeout)
+}
+
+func waitForPIDFile(t *testing.T, path string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastData []byte
+	var lastErr error
+	for time.Now().Before(deadline) {
+		lastData, lastErr = os.ReadFile(path)
+		if lastErr == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(lastData)))
+			if parseErr == nil && pid > 1 {
+				return pid
+			}
+			lastErr = parseErr
+		} else if !os.IsNotExist(lastErr) {
+			t.Fatalf("read PID file %s: %v", path, lastErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("PID file %s did not contain a safe PID within %s: data=%q err=%v",
+		path, timeout, lastData, lastErr)
+	return 0
+}

--- a/internal/cli/coop_raw_injection_adversarial_unix_test.go
+++ b/internal/cli/coop_raw_injection_adversarial_unix_test.go
@@ -461,13 +461,86 @@ func assertPublicWakeCleaned(t *testing.T, root, me string, wakePID int) {
 	for time.Now().Before(deadline) {
 		inspection := inspectWakeLock(root, me)
 		process := inspectWakeProcess(wakePID)
-		if !inspection.Exists && !process.Running {
+		residue, err := publicWakeLifecycleResidue(root, me)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !inspection.Exists && !process.Running && len(residue) == 0 {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("public coop wake survived owner exit: lock=%#v process=%#v",
-		inspectWakeLock(root, me), inspectWakeProcess(wakePID))
+	residue, residueErr := publicWakeLifecycleResidue(root, me)
+	t.Fatalf("public coop wake survived owner exit: lock=%#v process=%#v residue=%q residue_error=%v",
+		inspectWakeLock(root, me), inspectWakeProcess(wakePID), residue, residueErr)
+}
+
+func publicWakeLifecycleResidue(root, me string) ([]string, error) {
+	agentBase := fsq.AgentBase(root, me)
+	paths := []string{
+		wakeTargetPath(root, me),
+		wakePreparedPath(root, me),
+		wakeRepairFloorPath(root, me),
+	}
+	var residue []string
+	for _, path := range paths {
+		if _, err := os.Lstat(path); err == nil {
+			residue = append(residue, path)
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("inspect public wake lifecycle residue %s: %w", path, err)
+		}
+	}
+	tempPaths, err := filepath.Glob(filepath.Join(agentBase, ".wake*.tmp.*"))
+	if err != nil {
+		return nil, fmt.Errorf("inspect public wake lifecycle temp residue: %w", err)
+	}
+	controlPaths, err := filepath.Glob(filepath.Join(agentBase, ".w.*"))
+	if err != nil {
+		return nil, fmt.Errorf("inspect public wake control socket residue: %w", err)
+	}
+	quarantinePaths, err := filepath.Glob(filepath.Join(
+		agentBase,
+		wakeRepairFloorQuarantinePrefix+"*",
+	))
+	if err != nil {
+		return nil, fmt.Errorf("inspect public wake repair-floor quarantine residue: %w", err)
+	}
+	residue = append(residue, tempPaths...)
+	residue = append(residue, controlPaths...)
+	return append(residue, quarantinePaths...), nil
+}
+
+func TestPublicWakeLifecycleResidueIncludesControlAndQuarantineArtifacts(t *testing.T) {
+	root := secureTempDirForTest(t)
+	const me = "codex"
+	ensureAdversarialCoopMailbox(t, root, me)
+	agentBase := fsq.AgentBase(root, me)
+	paths := []string{
+		filepath.Join(agentBase, ".w.regression"),
+		filepath.Join(agentBase, wakeRepairFloorQuarantinePrefix+"regression"),
+	}
+	for _, path := range paths {
+		if err := os.WriteFile(path, []byte("residue"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	residue, err := publicWakeLifecycleResidue(root, me)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range paths {
+		found := false
+		for _, got := range residue {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("public wake residue = %q, want %q", residue, want)
+		}
+	}
 }
 
 func waitForAdversarialPath(t *testing.T, path string, timeout time.Duration) {

--- a/internal/cli/coop_wake_owner_lifecycle_unix_test.go
+++ b/internal/cli/coop_wake_owner_lifecycle_unix_test.go
@@ -1,0 +1,976 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	coopWakeSignalHelperEnv = "AMQ_TEST_COOP_WAKE_SIGNAL_HELPER"
+	coopWakePTYHelperEnv    = "AMQ_TEST_COOP_WAKE_PTY_HELPER"
+)
+
+func TestCoopWakeArgsDisableInterruptInjection(t *testing.T) {
+	for _, mode := range []string{
+		wakeInjectModeAuto,
+		wakeInjectModeRaw,
+		wakeInjectModePaste,
+		wakeInjectModeNone,
+	} {
+		t.Run(mode, func(t *testing.T) {
+			args := buildCoopWakeArgs("codex", "/tmp/root", mode, "", nil, "/tmp/ready")
+			found := false
+			for i := 0; i+1 < len(args); i++ {
+				if args[i] == "--interrupt-cmd" && args[i+1] == "none" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("coop wake args permit Ctrl-C injection: %#v", args)
+			}
+		})
+	}
+}
+
+func TestCoopWakeAllModesInstallExactOwnerSupervisor(t *testing.T) {
+	owner := currentAuthoritativeOwnerForCoopWakeTest(t)
+	encoded, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatalf("encode owner: %v", err)
+	}
+
+	oldAvailable := wakeTIOCSTIAvailable
+	oldIsTTY := wakeInputIsTTY
+	oldBindTerminalAuthority := bindWakeTerminalAuthorityForWake
+	wakeTIOCSTIAvailable = func() bool { return true }
+	wakeInputIsTTY = func() bool { return true }
+	bindWakeTerminalAuthorityForWake = func(
+		generation wakeLockInspection,
+		stop <-chan struct{},
+	) (*wakeTerminalAuthority, error) {
+		if !generation.Exists || generation.Lock.Generation == "" {
+			return nil, errors.New("test terminal authority received no exact generation")
+		}
+		return &wakeTerminalAuthority{
+			generation:  generation,
+			controlStop: stop,
+		}, nil
+	}
+	t.Cleanup(func() {
+		wakeTIOCSTIAvailable = oldAvailable
+		wakeInputIsTTY = oldIsTTY
+		bindWakeTerminalAuthorityForWake = oldBindTerminalAuthority
+	})
+
+	for _, mode := range []string{
+		wakeInjectModeAuto,
+		wakeInjectModeRaw,
+		wakeInjectModePaste,
+		wakeInjectModeNone,
+	} {
+		t.Run(mode, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			t.Setenv(envWakeOwner, encoded)
+			t.Setenv(envWakePrivateStopFD, "")
+
+			loopCalled := false
+			err := runWakeWithLoop(
+				[]string{
+					"--root", root,
+					"--me", "codex",
+					"--inject-mode", mode,
+					"--interrupt=false",
+				},
+				func(cfg wakeConfig) error {
+					loopCalled = true
+					if cfg.controlStop == nil {
+						return errors.New("coop-owned wake reached its loop without an exact owner supervisor")
+					}
+					select {
+					case <-cfg.controlStop:
+						return errors.New("live exact owner supervisor was already stopped")
+					default:
+					}
+					return nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("mode %s: %v", mode, err)
+			}
+			if !loopCalled {
+				t.Fatalf("mode %s: wake loop was not reached", mode)
+			}
+		})
+	}
+}
+
+func TestCoopWakeOwnerMetadataFailureNeverStartsOwnerlessWake(t *testing.T) {
+	tests := []struct {
+		name       string
+		ownerEnv   string
+		observeErr error
+	}{
+		{
+			name:     "malformed owner metadata",
+			ownerEnv: `{"pid":`,
+		},
+		{
+			name:     "unsupported exact owner observer",
+			ownerEnv: mustEncodedCurrentOwnerForCoopWakeTest(t),
+			observeErr: &wakeOwnerChildCapabilityUnsupportedError{
+				Err: syscall.ENOSYS,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			t.Setenv(envWakeOwner, test.ownerEnv)
+			t.Setenv(envWakePrivateStopFD, "")
+
+			if test.observeErr != nil {
+				oldObserve := observeAuthoritativeWakeOwner
+				observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+					return wakeOwnerObservation{
+						State:                 wakeOwnerUnknown,
+						Reason:                "test observer unavailable",
+						CapabilityUnsupported: true,
+					}, test.observeErr
+				}
+				t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+			}
+
+			loopCalled := false
+			childErr := runWakeWithLoop(
+				[]string{
+					"--root", root,
+					"--me", "codex",
+					"--inject-mode", wakeInjectModeNone,
+					"--interrupt=false",
+				},
+				func(wakeConfig) error {
+					loopCalled = true
+					return errors.New("ownerless wake loop ran")
+				},
+			)
+			if childErr == nil {
+				t.Fatal("owner supervision failure started an ownerless wake")
+			}
+			if loopCalled {
+				t.Fatal("owner supervision failure reached the wake loop")
+			}
+			if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+				t.Fatalf("owner supervision failure published a wake lock: %#v", inspection)
+			}
+
+			if err := handleCoopWakeSetupFailure(false, wakeLockInspection{}, "start coop-owned wake", childErr); err != nil {
+				t.Fatalf("optional wake should continue with no wake, got %v", err)
+			}
+			if err := handleCoopWakeSetupFailure(true, wakeLockInspection{}, "start coop-owned wake", childErr); err == nil {
+				t.Fatal("--require-wake accepted an unavailable exact owner observer")
+			}
+		})
+	}
+}
+
+func TestCoopWakeNeverReusesPreparedOwnerlessWake(t *testing.T) {
+	ownerEnv := mustEncodedCurrentOwnerForCoopWakeTest(t)
+
+	oldAvailable := wakeTIOCSTIAvailable
+	oldIsTTY := wakeInputIsTTY
+	wakeTIOCSTIAvailable = func() bool { return true }
+	wakeInputIsTTY = func() bool { return true }
+	t.Cleanup(func() {
+		wakeTIOCSTIAvailable = oldAvailable
+		wakeInputIsTTY = oldIsTTY
+	})
+
+	for _, mode := range []string{
+		wakeInjectModeRaw,
+		wakeInjectModePaste,
+		wakeInjectModeNone,
+	} {
+		t.Run(mode, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			oldTTY := getWakeCurrentTTY
+			getWakeCurrentTTY = func() string { return "test-tty" }
+			t.Cleanup(func() { getWakeCurrentTTY = oldTTY })
+			realProcess := inspectWakeProcess(os.Getpid())
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid != os.Getpid() {
+					return wakeProcessInfo{PID: pid}
+				}
+				return wakeProcessInfo{
+					PID:        pid,
+					Running:    true,
+					StartToken: realProcess.StartToken,
+					BootID:     realProcess.BootID,
+					Executable: "amq",
+					Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+				}
+			})
+
+			cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+				wakeMode: mode,
+			})
+			if err != nil {
+				t.Fatalf("install unsupervised wake: %v", err)
+			}
+			defer cleanup()
+			existing := inspectWakeLock(root, "codex")
+			if !confirmedLiveWake(existing) {
+				t.Fatalf("unsupervised fixture is not a prepared live wake: %#v", existing)
+			}
+			writeWakePreparedForTest(t, root, "codex")
+
+			t.Setenv(envWakeOwner, ownerEnv)
+			t.Setenv(envWakePrivateStopFD, "")
+			readyPath := filepath.Join(t.TempDir(), "ready")
+			loopCalled := false
+			err = runWakeWithLoop(
+				[]string{
+					"--root", root,
+					"--me", "codex",
+					"--inject-mode", mode,
+					"--ready-file", readyPath,
+					"--accept-existing-wake",
+					"--interrupt=false",
+				},
+				func(wakeConfig) error {
+					loopCalled = true
+					return nil
+				},
+			)
+			if err == nil {
+				t.Fatal("prepared ownerless wake satisfied a coop-owned launch")
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), "owner") {
+				t.Fatalf("ownerless reuse refusal = %v, want exact owner reason", err)
+			}
+			if loopCalled {
+				t.Fatal("second coop-owned wake unexpectedly acquired the existing generation")
+			}
+			if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+				t.Fatalf("ownerless generation published coop readiness: %v", statErr)
+			}
+			current := inspectWakeLock(root, "codex")
+			if !sameWakeLockGeneration(existing, current) {
+				t.Fatalf("rejected reuse changed the existing wake: before=%#v after=%#v", existing, current)
+			}
+		})
+	}
+}
+
+func TestKernelOwnerObserverIgnoresDescendantInheritedFDs(t *testing.T) {
+	for _, exitKind := range []string{"normal", "crash"} {
+		t.Run(exitKind, func(t *testing.T) {
+			dir := t.TempDir()
+			descendantPath := filepath.Join(dir, "descendant.pid")
+			exitGate := filepath.Join(dir, "owner-exit")
+
+			readEnd, writeEnd, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("pipe: %v", err)
+			}
+			defer func() { _ = readEnd.Close() }()
+
+			script := `
+sleep 30 &
+printf '%s\n' "$!" > "$1"
+while [ ! -e "$2" ]; do sleep 0.01; done
+if [ "$3" = crash ]; then
+	kill -KILL $$
+fi
+exit 0
+`
+			cmd := exec.Command("/bin/sh", "-c", script, "sh", descendantPath, exitGate, exitKind)
+			cmd.ExtraFiles = []*os.File{writeEnd}
+			if err := cmd.Start(); err != nil {
+				_ = writeEnd.Close()
+				t.Fatalf("start owner: %v", err)
+			}
+			_ = writeEnd.Close()
+			t.Cleanup(func() {
+				if cmd.Process != nil && cmd.ProcessState == nil {
+					_ = cmd.Process.Kill()
+					_, _ = cmd.Process.Wait()
+				}
+			})
+
+			waitForCoopWakePathForTest(t, descendantPath, 3*time.Second)
+			owner := authoritativeOwnerForPIDForCoopWakeTest(t, cmd.Process.Pid)
+			observation, err := observeAuthoritativeWakeOwner(owner)
+			if err != nil {
+				t.Fatalf("observe exact owner: %v", err)
+			}
+			defer func() { _ = observation.Close() }()
+			if observation.State != wakeOwnerSame {
+				t.Fatalf("owner observation = %#v, want live exact owner", observation)
+			}
+			if observation.Done() == nil {
+				t.Fatal("kernel owner observation has no death signal")
+			}
+
+			if err := os.WriteFile(exitGate, []byte("exit\n"), 0o600); err != nil {
+				t.Fatalf("release owner: %v", err)
+			}
+			waitErr := cmd.Wait()
+			if exitKind == "normal" && waitErr != nil {
+				t.Fatalf("normal owner exit: %v", waitErr)
+			}
+			if exitKind == "crash" && waitErr == nil {
+				t.Fatal("crashing owner exited successfully")
+			}
+
+			descendantPID := readPIDForCoopWakeTest(t, descendantPath)
+			descendant, err := os.FindProcess(descendantPID)
+			if err != nil {
+				t.Fatalf("find descendant: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = descendant.Kill()
+			})
+			if err := descendant.Signal(syscall.Signal(0)); err != nil {
+				t.Fatalf("FD-inheriting descendant is not alive: %v", err)
+			}
+
+			if err := readEnd.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+				t.Fatalf("set pipe deadline: %v", err)
+			}
+			var one [1]byte
+			_, pipeErr := readEnd.Read(one[:])
+			var netErr net.Error
+			if !errors.As(pipeErr, &netErr) || !netErr.Timeout() {
+				t.Fatalf("ordinary inherited pipe reported owner death while descendant lived: %v", pipeErr)
+			}
+
+			select {
+			case <-observation.Done():
+			case <-time.After(3 * time.Second):
+				t.Fatal("kernel-bound observation did not report exact owner exit")
+			}
+		})
+	}
+}
+
+func TestKernelOwnerObserverRegistrationRejectsChangedIdentity(t *testing.T) {
+	owner := currentAuthoritativeOwnerForCoopWakeTest(t)
+	owner.ProcessStart = differentProcessStartForCoopWakeTest(owner.ProcessStart)
+
+	observation, err := observeAuthoritativeWakeOwner(owner)
+	if err != nil {
+		t.Fatalf("observe changed identity: %v", err)
+	}
+	defer func() { _ = observation.Close() }()
+	if observation.State != wakeOwnerDead {
+		t.Fatalf("changed identity state = %s (%s), want dead exact owner", observation.State, observation.Reason)
+	}
+	select {
+	case <-observation.Done():
+	default:
+		t.Fatal("registration identity change left readiness-capable owner observation open")
+	}
+}
+
+func TestOwnerDeathGatesTerminalInjection(t *testing.T) {
+	oldInject := tiocstiInject
+	oldWait := waitForRawInputDrained
+	oldSleep := rawInjectSleep
+	t.Cleanup(func() {
+		tiocstiInject = oldInject
+		waitForRawInputDrained = oldWait
+		rawInjectSleep = oldSleep
+	})
+	waitForRawInputDrained = func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	}
+	rawInjectSleep = func(time.Duration) {}
+
+	for _, mode := range []string{wakeInjectModeRaw, wakeInjectModePaste} {
+		t.Run(mode+"/already-dead", func(t *testing.T) {
+			stop := make(chan struct{})
+			close(stop)
+			calls := 0
+			tiocstiInject = func(string) error {
+				calls++
+				return nil
+			}
+			err := injectNotification(&wakeConfig{
+				me:          "codex",
+				injectMode:  mode,
+				controlStop: stop,
+			}, "must not inject", false)
+			if err != nil {
+				t.Fatalf("closed owner gate: %v", err)
+			}
+			if calls != 0 {
+				t.Fatalf("closed owner gate allowed %d terminal injection(s)", calls)
+			}
+		})
+
+		t.Run(mode+"/dies-during-injection", func(t *testing.T) {
+			stop := make(chan struct{})
+			var calls []string
+			tiocstiInject = func(text string) error {
+				calls = append(calls, text)
+				if len(calls) == 1 {
+					close(stop)
+				}
+				return nil
+			}
+			err := injectNotification(&wakeConfig{
+				me:          "codex",
+				injectMode:  mode,
+				controlStop: stop,
+			}, "one in-flight write at most", false)
+			if err != nil {
+				t.Fatalf("mid-injection owner death: %v", err)
+			}
+			if len(calls) != 1 {
+				t.Fatalf("owner death allowed follow-up terminal injection: %#v", calls)
+			}
+		})
+	}
+}
+
+func TestCoopRawDoorbellIsFixedASCIIAndShellInert(t *testing.T) {
+	oldInject := tiocstiInject
+	oldWait := waitForRawInputDrained
+	oldSleep := rawInjectSleep
+	t.Cleanup(func() {
+		tiocstiInject = oldInject
+		waitForRawInputDrained = oldWait
+		rawInjectSleep = oldSleep
+	})
+	waitForRawInputDrained = func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	}
+	rawInjectSleep = func(time.Duration) {}
+
+	stop := make(chan struct{})
+	var injected []string
+	tiocstiInject = func(text string) error {
+		injected = append(injected, text)
+		return nil
+	}
+	dynamic := "AMQ [session/a]; sender=$(touch /tmp/pwned) subject='approve?' count=999 custom=\x1b[31m"
+	err := injectNotification(&wakeConfig{
+		me:          "codex",
+		injectMode:  wakeInjectModeRaw,
+		controlStop: stop,
+	}, dynamic, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(injected) == 0 || injected[0] != coopWakeDoorbell {
+		t.Fatalf("coop text injection = %#v, want fixed first chunk %q", injected, coopWakeDoorbell)
+	}
+	for _, chunk := range injected {
+		for _, value := range []byte(chunk) {
+			if value > 0x7f {
+				t.Fatalf("coop injection contains non-ASCII byte %#x: %#v", value, injected)
+			}
+		}
+	}
+	if strings.Contains(strings.Join(injected, ""), "session/a") ||
+		strings.Contains(strings.Join(injected, ""), "sender=") ||
+		strings.Contains(strings.Join(injected, ""), "approve") ||
+		strings.Contains(strings.Join(injected, ""), "999") ||
+		strings.Contains(strings.Join(injected, ""), "\x1b") {
+		t.Fatalf("coop injection leaked message-derived bytes: %#v", injected)
+	}
+}
+
+func TestCoopUrgentDoorbellNeverInjectsCtrlCAndRefusalKeepsPending(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	msg := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       "urgent-owner-death",
+			From:     "attacker-controlled-sender",
+			To:       []string{"codex"},
+			Thread:   "p2p/attacker__codex",
+			Subject:  "dynamic subject must not enter terminal",
+			Created:  "2026-07-24T00:00:00Z",
+			Priority: "urgent",
+			Labels:   []string{"interrupt"},
+		},
+		Body: "durable pending body",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal urgent message: %v", err)
+	}
+	path, err := deliverToInboxForTest(t, root, "codex", "urgent-owner-death.md", data)
+	if err != nil {
+		t.Fatalf("deliver urgent message: %v", err)
+	}
+
+	stop := make(chan struct{})
+	close(stop)
+	oldInject := tiocstiInject
+	var injected []string
+	tiocstiInject = func(text string) error {
+		injected = append(injected, text)
+		return nil
+	}
+	t.Cleanup(func() { tiocstiInject = oldInject })
+	cfg := &wakeConfig{
+		me:                "codex",
+		root:              root,
+		session:           "dynamic-session",
+		injectMode:        wakeInjectModeRaw,
+		controlStop:       stop,
+		previewLen:        48,
+		interrupt:         true,
+		interruptKey:      "",
+		interruptLabel:    "interrupt",
+		interruptPriority: "urgent",
+	}
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify urgent pending item: %v", err)
+	}
+	if len(injected) != 0 {
+		t.Fatalf("refused urgent doorbell injected terminal bytes: %#v", injected)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("refused doorbell consumed durable pending item: %v", err)
+	}
+}
+
+func TestCoopRawDoorbellRechecksGenerationBeforeEveryWrite(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeRaw,
+	})
+	if err != nil {
+		t.Fatalf("acquire wake: %v", err)
+	}
+	defer cleanup()
+	original := inspectWakeLock(root, "codex")
+
+	oldInject := tiocstiInject
+	oldWait := waitForRawInputDrained
+	oldSleep := rawInjectSleep
+	t.Cleanup(func() {
+		tiocstiInject = oldInject
+		waitForRawInputDrained = oldWait
+		rawInjectSleep = oldSleep
+	})
+	waitForRawInputDrained = func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	}
+	rawInjectSleep = func(time.Duration) {}
+
+	stop := make(chan struct{})
+	var injected []string
+	tiocstiInject = func(text string) error {
+		injected = append(injected, text)
+		if len(injected) == 1 {
+			replacement := original.Lock
+			replacement.Generation = "replacement-during-injection"
+			data, marshalErr := json.Marshal(replacement)
+			if marshalErr != nil {
+				return marshalErr
+			}
+			return os.WriteFile(
+				filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock"),
+				append(data, '\n'),
+				0o600,
+			)
+		}
+		return nil
+	}
+	err = injectNotification(&wakeConfig{
+		me:          "codex",
+		root:        root,
+		injectMode:  wakeInjectModeRaw,
+		controlStop: stop,
+	}, "dynamic", false)
+	if err != nil {
+		t.Fatalf("generation change: %v", err)
+	}
+	if len(injected) != 1 {
+		t.Fatalf("replacement generation received follow-up LF/CR/rescue writes: %#v", injected)
+	}
+	if current := inspectWakeLock(root, "codex"); current.Lock.Generation != "replacement-during-injection" {
+		t.Fatalf("replacement generation changed: %#v", current)
+	}
+}
+
+func TestCoopRawDoorbellRefusesChangedForegroundTTYBeforeText(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	oldTTY := getWakeCurrentTTY
+	const originalTTY = "/dev/ttys111"
+	currentTTY := originalTTY
+	getWakeCurrentTTY = func() string { return currentTTY }
+	t.Cleanup(func() { getWakeCurrentTTY = oldTTY })
+
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeRaw,
+	})
+	if err != nil {
+		t.Fatalf("acquire wake: %v", err)
+	}
+	defer cleanup()
+	original := inspectWakeLock(root, "codex")
+	lock := original.Lock
+	lock.TTY = originalTTY
+	lockData, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatalf("encode TTY-bound lock: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock"),
+		append(lockData, '\n'),
+		0o600,
+	); err != nil {
+		t.Fatalf("write TTY-bound lock: %v", err)
+	}
+	currentTTY = "/dev/ttys222"
+
+	oldInject := tiocstiInject
+	var injected []string
+	tiocstiInject = func(text string) error {
+		injected = append(injected, text)
+		return nil
+	}
+	t.Cleanup(func() { tiocstiInject = oldInject })
+	stop := make(chan struct{})
+	err = injectNotification(&wakeConfig{
+		me:          "codex",
+		root:        root,
+		injectMode:  wakeInjectModeRaw,
+		controlStop: stop,
+	}, "dynamic", false)
+	if err != nil {
+		t.Fatalf("foreground TTY refusal: %v", err)
+	}
+	if len(injected) != 0 {
+		t.Fatalf("changed foreground TTY received terminal bytes: %#v", injected)
+	}
+	// The production guard must bind both this exact TTY identity and its
+	// foreground process group. A same-path PGRP handoff is the same refusal
+	// class and must be rechecked at text, LF, CR, and rescue boundaries.
+}
+
+func TestWakeSignalIsCapturedBeforeReadinessPublication(t *testing.T) {
+	if os.Getenv(coopWakeSignalHelperEnv) != "" {
+		root := os.Getenv("AMQ_TEST_COOP_WAKE_ROOT")
+		marker := os.Getenv("AMQ_TEST_COOP_WAKE_MARKER")
+		release := os.Getenv("AMQ_TEST_COOP_WAKE_RELEASE")
+		ensureCoopWakeMailboxForTest(t, root, "codex")
+
+		cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+			wakeMode: wakeInjectModeNone,
+		})
+		if err != nil {
+			t.Fatalf("helper acquire wake: %v", err)
+		}
+		defer cleanup()
+		err = runWakeLoop(wakeConfig{
+			root:         root,
+			me:           "codex",
+			injectMode:   wakeInjectModeNone,
+			debounce:     time.Millisecond,
+			controlStop:  make(chan struct{}),
+			interruptKey: "",
+			onPrepared: func(wakeAdmissionWatcher) error {
+				if err := os.WriteFile(marker, []byte("entered\n"), 0o600); err != nil {
+					return err
+				}
+				waitForCoopWakePathForTest(t, release, 3*time.Second)
+				return nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("helper wake loop: %v", err)
+		}
+		return
+	}
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "preparing")
+	release := filepath.Join(dir, "release")
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("test executable: %v", err)
+	}
+	cmd := exec.Command(testBinary, "-test.run=^TestWakeSignalIsCapturedBeforeReadinessPublication$")
+	cmd.Env = append(os.Environ(),
+		coopWakeSignalHelperEnv+"=1",
+		"AMQ_TEST_COOP_WAKE_ROOT="+root,
+		"AMQ_TEST_COOP_WAKE_MARKER="+marker,
+		"AMQ_TEST_COOP_WAKE_RELEASE="+release,
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start signal helper: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	waitForCoopWakePathForTest(t, marker, 3*time.Second)
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signal helper before readiness: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if err := os.WriteFile(release, []byte("continue\n"), 0o600); err != nil {
+		t.Fatalf("release preparation: %v", err)
+	}
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+	select {
+	case err := <-waitDone:
+		cmd.Process = nil
+		if err != nil {
+			t.Fatalf("pre-readiness SIGTERM was not handled gracefully: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("signal helper did not exit")
+	}
+	if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+		t.Fatalf("pre-readiness signal bypassed exact wake cleanup: %#v", inspection)
+	}
+}
+
+func TestExactWakeCleanupPreservesReplacementGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeRaw,
+	})
+	if err != nil {
+		t.Fatalf("acquire original wake: %v", err)
+	}
+	defer cleanup()
+	original := inspectWakeLock(root, "codex")
+	if !original.Exists || original.Lock.Generation == "" {
+		t.Fatalf("original wake = %#v", original)
+	}
+
+	replacement := original.Lock
+	replacement.Generation = "replacement-generation"
+	data, err := json.Marshal(replacement)
+	if err != nil {
+		t.Fatalf("encode replacement: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock"), append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("publish replacement: %v", err)
+	}
+
+	if err := cleanupTerminatedWakeLock(original); err != nil {
+		t.Fatalf("old generation cleanup: %v", err)
+	}
+	current := inspectWakeLock(root, "codex")
+	if !current.Exists || current.Lock.Generation != replacement.Generation {
+		t.Fatalf("old cleanup removed replacement generation: %#v", current)
+	}
+}
+
+func TestStandaloneWakeRemainsOwnerless(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	t.Setenv(envWakeOwner, "")
+	t.Setenv(envWakePrivateStopFD, "")
+
+	loopCalled := false
+	err := runWakeWithLoop(
+		[]string{
+			"--root", root,
+			"--me", "codex",
+			"--inject-mode", wakeInjectModeNone,
+			"--interrupt=false",
+		},
+		func(cfg wakeConfig) error {
+			loopCalled = true
+			if cfg.controlStop != nil {
+				return errors.New("standalone wake unexpectedly gained a coop owner supervisor")
+			}
+			inspection := inspectWakeLock(root, "codex")
+			if inspection.Lock.Owner != nil || inspection.Lock.OwnerSchema != 0 {
+				return fmt.Errorf("standalone wake became owner-bound: %#v", inspection.Lock)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loopCalled {
+		t.Fatal("standalone wake loop was not reached")
+	}
+}
+
+func TestDarwinCoopWakeUsesConcretePTYOwnerPath(t *testing.T) {
+	if os.Getenv(coopWakePTYHelperEnv) != "" {
+		if runtime.GOOS != "darwin" {
+			t.Skip("Darwin PTY helper")
+		}
+		if !wakeInputIsTTY() {
+			t.Fatal("script helper did not provide a concrete stdin PTY")
+		}
+		root := os.Getenv("AMQ_TEST_COOP_WAKE_ROOT")
+		ensureCoopWakeMailboxForTest(t, root, "codex")
+		owner := authoritativeOwnerForPIDForCoopWakeTest(t, os.Getppid())
+		encoded, err := encodeWakeOwnerEnv(owner)
+		if err != nil {
+			t.Fatalf("encode PTY owner: %v", err)
+		}
+		t.Setenv(envWakeOwner, encoded)
+		t.Setenv(envWakePrivateStopFD, "")
+
+		err = runWakeWithLoop(
+			[]string{
+				"--root", root,
+				"--me", "codex",
+				"--inject-mode", wakeInjectModeRaw,
+				"--interrupt=false",
+			},
+			func(cfg wakeConfig) error {
+				if cfg.controlStop == nil {
+					return errors.New("PTY raw wake has no exact owner supervisor")
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if runtime.GOOS != "darwin" {
+		t.Skip("Darwin concrete PTY regression")
+	}
+
+	root := secureTempDirForTest(t)
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatalf("test executable: %v", err)
+	}
+	cmd := exec.Command(
+		"/usr/bin/script",
+		"-q",
+		"/dev/null",
+		testBinary,
+		"-test.run=^TestDarwinCoopWakeUsesConcretePTYOwnerPath$",
+	)
+	cmd.Env = append(os.Environ(),
+		coopWakePTYHelperEnv+"=1",
+		"AMQ_TEST_COOP_WAKE_ROOT="+root,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Darwin PTY coop wake: %v\n%s", err, output)
+	}
+}
+
+func currentAuthoritativeOwnerForCoopWakeTest(t *testing.T) wakeOwner {
+	t.Helper()
+	return authoritativeOwnerForPIDForCoopWakeTest(t, os.Getpid())
+}
+
+func authoritativeOwnerForPIDForCoopWakeTest(t *testing.T, pid int) wakeOwner {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		proc := inspectWakeProcess(pid)
+		sessionID, sessionErr := getWakeProcessSID(pid)
+		owner := wakeOwner{
+			PID:          pid,
+			ProcessStart: proc.StartToken,
+			BootID:       proc.BootID,
+			SessionID:    sessionID,
+		}
+		if proc.Running && sessionErr == nil && validateAuthoritativeWakeOwner(owner) == nil {
+			return owner
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("capture authoritative owner pid %d: proc=%#v sid=%d sidErr=%v", pid, proc, sessionID, sessionErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func mustEncodedCurrentOwnerForCoopWakeTest(t *testing.T) string {
+	t.Helper()
+	encoded, err := encodeWakeOwnerEnv(currentAuthoritativeOwnerForCoopWakeTest(t))
+	if err != nil {
+		t.Fatalf("encode current owner: %v", err)
+	}
+	return encoded
+}
+
+func differentProcessStartForCoopWakeTest(current string) string {
+	if current == "1" {
+		return "2"
+	}
+	return "1"
+}
+
+func ensureCoopWakeMailboxForTest(t *testing.T, root, me string) {
+	t.Helper()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("ensure root: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, me); err != nil {
+		t.Fatalf("ensure mailbox: %v", err)
+	}
+}
+
+func waitForCoopWakePathForTest(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func readPIDForCoopWakeTest(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read descendant pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("parse descendant pid %q: %v", data, err)
+	}
+	return pid
+}

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,40 +16,44 @@ import (
 )
 
 type wakeConfig struct {
-	me                string
-	root              string
-	session           string
-	injectCmd         string
-	injectVia         string // external command for injection (replaces TIOCSTI)
-	injectArgs        []string
-	wakeOwner         *wakeOwner
-	injectTimeout     time.Duration
-	bell              bool
-	debounce          time.Duration
-	previewLen        int
-	strict            bool
-	fallbackWarn      bool
-	injectMode        string // auto, raw, paste
-	debug             bool
-	deferWhileInput   bool
-	inputQuietFor     time.Duration
-	inputPollInterval time.Duration
-	inputMaxHold      time.Duration
-	interrupt         bool
-	interruptLabel    string
-	interruptPriority string
-	interruptKey      string
-	interruptNotice   string
-	interruptCooldown time.Duration
-	lastInterrupt     time.Time
-	controlStop       <-chan struct{}
-	baselineRequested bool
-	baselineInherited bool
-	baselineExisting  map[string]wakeFileIdentity
-	onBaselineReady   func(map[string]wakeFileIdentity) error
-	onPrepared        func(wakeAdmissionWatcher) error
-	retainedInbox     wakeInboxReader
-	touchPresence     func() error
+	me                  string
+	root                string
+	session             string
+	injectCmd           string
+	injectVia           string // external command for injection (replaces TIOCSTI)
+	injectArgs          []string
+	wakeOwner           *wakeOwner
+	injectTimeout       time.Duration
+	bell                bool
+	debounce            time.Duration
+	previewLen          int
+	strict              bool
+	fallbackWarn        bool
+	injectMode          string // auto, raw, paste
+	debug               bool
+	deferWhileInput     bool
+	inputQuietFor       time.Duration
+	inputPollInterval   time.Duration
+	inputMaxHold        time.Duration
+	interrupt           bool
+	interruptLabel      string
+	interruptPriority   string
+	interruptKey        string
+	interruptNotice     string
+	interruptCooldown   time.Duration
+	lastInterrupt       time.Time
+	controlStop         <-chan struct{}
+	beforeTerminalWrite func() error
+	terminalWrite       func(string) error
+	terminalGeneration  string
+	terminalTTY         string
+	baselineRequested   bool
+	baselineInherited   bool
+	baselineExisting    map[string]wakeFileIdentity
+	onBaselineReady     func(map[string]wakeFileIdentity) error
+	onPrepared          func(wakeAdmissionWatcher) error
+	retainedInbox       wakeInboxReader
+	touchPresence       func() error
 }
 
 type wakeAdmissionWatcher interface {
@@ -66,6 +71,8 @@ const (
 	wakeInjectModeRaw   = "raw"
 	wakeInjectModePaste = "paste"
 	wakeInjectModeNone  = "none"
+
+	coopWakeDoorbell = ": AMQ doorbell run amq drain --include-body then act on it"
 
 	rawInjectDrainTimeout      = 2 * time.Second
 	rawInjectDrainPollInterval = 10 * time.Millisecond
@@ -232,6 +239,13 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		return nil
 	}
 
+	// A supervised/co-op wake is only a fixed doorbell. Message headers,
+	// session names, custom notices, commands, and urgency never become
+	// terminal input.
+	if usesCoopDoorbell(cfg) {
+		return injectNotification(cfg, coopWakeDoorbell, len(interruptMessages) == 0)
+	}
+
 	if cfg.interrupt && len(interruptMessages) > 0 {
 		interruptText := buildInterruptText(cfg.session, interruptMessages, interruptCounts, cfg.previewLen, cfg.interruptNotice)
 		if cfg.injectMode == wakeInjectModeNone {
@@ -241,13 +255,28 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		now := time.Now()
 		if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
 			if cfg.injectVia != "" {
-				if err := injectVia(cfg, cfg.interruptKey); err == nil {
+				allowed, guardErr := authorizeTerminalWrite(cfg)
+				if guardErr != nil {
+					return guardErr
+				}
+				if allowed {
+					if err := injectVia(cfg, cfg.interruptKey); err == nil {
+						cfg.lastInterrupt = now
+						time.Sleep(50 * time.Millisecond)
+					}
+				}
+			} else {
+				wrote, writeErr := writeTerminalChunk(cfg, cfg.interruptKey)
+				if writeErr != nil {
+					var authorityErr *wakeTerminalAuthorityError
+					if errors.As(writeErr, &authorityErr) {
+						return writeErr
+					}
+				}
+				if writeErr == nil && wrote {
 					cfg.lastInterrupt = now
 					time.Sleep(50 * time.Millisecond)
 				}
-			} else if err := tiocsti.Inject(cfg.interruptKey); err == nil {
-				cfg.lastInterrupt = now
-				time.Sleep(50 * time.Millisecond)
 			}
 		}
 		return injectNotification(cfg, interruptText, false)
@@ -416,14 +445,18 @@ func writeWakeOutput(text string, bell bool) {
 }
 
 func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error {
+	ownerBound := usesCoopDoorbell(cfg)
+	if ownerBound {
+		text = coopWakeDoorbell
+	}
 	if cfg.injectMode == wakeInjectModeNone {
-		writeWakeOutput(text, cfg.bell)
+		writeWakeOutput(text, cfg.bell && !ownerBound)
 		return nil
 	}
 
 	// Keep plain text for stderr fallback
 	plainText := text
-	if cfg.bell {
+	if cfg.bell && !ownerBound {
 		plainText = "\a" + plainText
 	}
 
@@ -434,6 +467,13 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	// External injection: delegate to user-specified command instead of TIOCSTI.
 	// The command receives the notification text as its last argument.
 	if cfg.injectVia != "" {
+		allowed, guardErr := authorizeTerminalWrite(cfg)
+		if guardErr != nil {
+			return guardErr
+		}
+		if !allowed {
+			return nil
+		}
 		if err := injectVia(cfg, plainText); err != nil {
 			if cfg.fallbackWarn {
 				_ = writeStderr("amq wake: --inject-via failed: %v\n", err)
@@ -456,7 +496,7 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		// Ink treats multi-char input as paste, not keypresses. Sending text+CR
 		// as one chunk makes Ink see pasted text, not an Enter keypress.
 		injectedText := text
-		if cfg.bell {
+		if cfg.bell && !ownerBound {
 			injectedText = "\a" + injectedText
 		}
 		injectErr = injectRawNotification(cfg, injectedText)
@@ -465,28 +505,45 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		// Paste mode: bracketed paste with delayed CR
 		// Works with crossterm/ratatui apps
 		// Send paste content first, then CR after short delay to avoid coalescing
-		pasteText := "\x1b[200~" + text + "\x1b[201~"
-		if cfg.bell {
+		pasteText := text
+		if !ownerBound {
+			pasteText = "\x1b[200~" + text + "\x1b[201~"
+		}
+		if cfg.bell && !ownerBound {
 			pasteText = "\a" + pasteText
 		}
-		if err := tiocstiInject(pasteText); err != nil {
+		wrote, err := writeTerminalChunk(cfg, pasteText)
+		if err != nil {
 			injectErr = err
-		} else {
+		} else if wrote {
 			// Small delay to ensure CR lands in separate read cycle
 			time.Sleep(25 * time.Millisecond)
-			injectErr = tiocstiInject("\r")
+			_, injectErr = writeTerminalChunk(cfg, "\r")
 		}
 
 	default:
 		// Unknown mode, fall back to raw
-		injectedText := text + "\r"
-		if cfg.bell {
-			injectedText = "\a" + injectedText
+		if ownerBound {
+			wrote, err := writeTerminalChunk(cfg, text)
+			if err != nil {
+				injectErr = err
+			} else if wrote {
+				_, injectErr = writeTerminalChunk(cfg, "\r")
+			}
+		} else {
+			injectedText := text + "\r"
+			if cfg.bell {
+				injectedText = "\a" + injectedText
+			}
+			_, injectErr = writeTerminalChunk(cfg, injectedText)
 		}
-		injectErr = tiocstiInject(injectedText)
 	}
 
 	if injectErr != nil {
+		var authorityErr *wakeTerminalAuthorityError
+		if errors.As(injectErr, &authorityErr) {
+			return injectErr
+		}
 		if cfg.fallbackWarn {
 			_ = writeStderr("amq wake: TIOCSTI injection failed: %v\n", injectErr)
 			_ = writeStderr("amq wake: falling back to stderr notification\n")
@@ -498,6 +555,79 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	}
 
 	return nil
+}
+
+func usesCoopDoorbell(cfg *wakeConfig) bool {
+	if cfg.wakeOwner != nil {
+		return true
+	}
+	if cfg.controlStop == nil {
+		return false
+	}
+	// Direct guarded-write tests and injected terminal authorities do not need
+	// to synthesize a complete process owner merely to exercise the doorbell.
+	// A normal ownerless repair has a rooted control channel but no retained
+	// terminal writer and must keep its legacy notification payload.
+	return cfg.root == "" ||
+		cfg.beforeTerminalWrite != nil ||
+		cfg.terminalWrite != nil
+}
+
+type wakeTerminalAuthorityError struct {
+	err error
+}
+
+func (err *wakeTerminalAuthorityError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeTerminalAuthorityError) Unwrap() error {
+	return err.err
+}
+
+func authorizeTerminalWrite(cfg *wakeConfig) (bool, error) {
+	if cfg.controlStop != nil {
+		select {
+		case <-cfg.controlStop:
+			return false, nil
+		default:
+		}
+	}
+	if cfg.controlStop != nil &&
+		cfg.beforeTerminalWrite == nil &&
+		cfg.terminalWrite == nil &&
+		cfg.root != "" &&
+		cfg.me != "" {
+		if !authorizeTerminalWritePlatform(cfg) {
+			return false, nil
+		}
+	}
+	if cfg.beforeTerminalWrite != nil {
+		if err := cfg.beforeTerminalWrite(); err != nil {
+			if isWakeTerminalControlStopped(err) {
+				return false, nil
+			}
+			return false, &wakeTerminalAuthorityError{err: err}
+		}
+	}
+	return true, nil
+}
+
+func writeTerminalChunk(cfg *wakeConfig, chunk string) (bool, error) {
+	allowed, err := authorizeTerminalWrite(cfg)
+	if err != nil || !allowed {
+		return false, err
+	}
+	if cfg.terminalWrite != nil {
+		if err := cfg.terminalWrite(chunk); err != nil {
+			if isWakeTerminalControlStopped(err) {
+				return false, nil
+			}
+			return true, &wakeTerminalAuthorityError{err: err}
+		}
+		return true, nil
+	}
+	return true, tiocstiInject(chunk)
 }
 
 // rawSubmitPrelude returns the bytes injected between the drained notification
@@ -524,11 +654,15 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
 	}
-	if err := tiocstiInject(injectedText); err != nil {
+	wrote, err := writeTerminalChunk(cfg, injectedText)
+	if err != nil {
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: text inject failed: %v\n", err)
 		}
 		return err
+	}
+	if !wrote {
+		return nil
 	}
 	prelude := rawSubmitPrelude(cfg.me)
 
@@ -551,11 +685,15 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 	// Prelude (codex: a lone LF) clears the TUI's paste-burst state while the
 	// injected text is fresh; its newline is trimmed from the submitted payload.
 	if prelude != "" {
-		if err := tiocstiInject(prelude); err != nil {
+		wrote, err := writeTerminalChunk(cfg, prelude)
+		if err != nil {
 			if cfg.debug {
 				_ = writeStderr("amq wake [debug]: prelude inject failed: %v\n", err)
 			}
 			return err
+		}
+		if !wrote {
+			return nil
 		}
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: prelude injected OK (%q)\n", prelude)
@@ -567,11 +705,15 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 	// pasted newline.
 	rawInjectSleep(rawInjectSettleDelay)
 
-	if err := tiocstiInject("\r"); err != nil {
+	wrote, err = writeTerminalChunk(cfg, "\r")
+	if err != nil {
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: submit key inject failed: %v\n", err)
 		}
 		return err
+	}
+	if !wrote {
+		return nil
 	}
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: submit key injected OK\n")
@@ -593,12 +735,20 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		return nil
 	}
 	rawInjectSleep(rawInjectSettleDelay)
-	if err := tiocstiInject("\r"); err != nil {
+	wrote, err = writeTerminalChunk(cfg, "\r")
+	if err != nil {
 		// The text and first submit key were already delivered; the rescue is
-		// best-effort.
+		// best-effort unless exact terminal authority was lost.
+		var authorityErr *wakeTerminalAuthorityError
+		if errors.As(err, &authorityErr) {
+			return err
+		}
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
 		}
+		return nil
+	}
+	if !wrote {
 		return nil
 	}
 	if cfg.debug {

--- a/internal/cli/wake_generation_snapshot_unix_test.go
+++ b/internal/cli/wake_generation_snapshot_unix_test.go
@@ -1,0 +1,218 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testWakeGenerationSnapshotName = ".wake.prepared.snapshot-test"
+
+type wakeGenerationSnapshotFixture struct {
+	agentDir *wakeAgentDir
+	label    string
+	marker   wakeReady
+	snapshot wakeGenerationFileSnapshot
+}
+
+func TestRemoveWakeGenerationFileIfSnapshotMatchesRemovesOwnSnapshot(t *testing.T) {
+	fixture := newWakeGenerationSnapshotFixture(t)
+	removed, err := removeWakeGenerationSnapshotForTest(t, fixture, fixture.snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Fatal("exact generation snapshot was not removed")
+	}
+	if _, err := os.Stat(filepath.Join(fixture.agentDir.path, testWakeGenerationSnapshotName)); !os.IsNotExist(err) {
+		t.Fatalf("removed generation file stat error = %v, want not exist", err)
+	}
+}
+
+func TestRemoveWakeGenerationFileIfSnapshotMatchesMissingIsNoop(t *testing.T) {
+	fixture := newWakeGenerationSnapshotFixture(t)
+	path := filepath.Join(fixture.agentDir.path, testWakeGenerationSnapshotName)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := removeWakeGenerationSnapshotForTest(t, fixture, fixture.snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed {
+		t.Fatal("missing generation file reported removal")
+	}
+}
+
+func TestRemoveWakeGenerationFileIfSnapshotMatchesPreservesNewInodeReplacement(t *testing.T) {
+	fixture := newWakeGenerationSnapshotFixture(t)
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		return writeWakeGenerationFileAt(
+			dirfd,
+			testWakeGenerationSnapshotName,
+			fixture.label,
+			fixture.marker,
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	currentInfo, err := os.Stat(filepath.Join(fixture.agentDir.path, testWakeGenerationSnapshotName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(fixture.snapshot.FileInfo, currentInfo) {
+		t.Fatal("replacement unexpectedly retained the original inode")
+	}
+
+	removed, err := removeWakeGenerationSnapshotForTest(t, fixture, fixture.snapshot)
+	if err == nil || !strings.Contains(err.Error(), "preserving") {
+		t.Fatalf("new-inode replacement removal error = %v, want preservation", err)
+	}
+	if removed {
+		t.Fatal("new-inode replacement was removed")
+	}
+	assertWakeGenerationMarkerForTest(t, fixture, fixture.marker)
+}
+
+func TestRemoveWakeGenerationFileIfSnapshotMatchesPreservesSameInodeRawMutation(t *testing.T) {
+	fixture := newWakeGenerationSnapshotFixture(t)
+	replacement := fixture.marker
+	replacement.Generation = "replacement-generation"
+	data, err := json.Marshal(replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(fixture.agentDir.path, testWakeGenerationSnapshotName)
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	currentInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(fixture.snapshot.FileInfo, currentInfo) {
+		t.Fatal("raw mutation replaced the inode instead of mutating it")
+	}
+
+	removed, err := removeWakeGenerationSnapshotForTest(t, fixture, fixture.snapshot)
+	if err == nil || !strings.Contains(err.Error(), "preserving") {
+		t.Fatalf("same-inode mutation removal error = %v, want preservation", err)
+	}
+	if removed {
+		t.Fatal("same-inode raw mutation was removed")
+	}
+	assertWakeGenerationMarkerForTest(t, fixture, replacement)
+}
+
+func TestRemoveWakeGenerationFileIfSnapshotMatchesPreservesSemanticDigestMismatch(t *testing.T) {
+	fixture := newWakeGenerationSnapshotFixture(t)
+	mismatched := fixture.snapshot
+	mismatched.Marker.TargetDigest = "sha256:" + strings.Repeat("b", 64)
+
+	removed, err := removeWakeGenerationSnapshotForTest(t, fixture, mismatched)
+	if err == nil || !strings.Contains(err.Error(), "semantics changed") {
+		t.Fatalf("semantic digest mismatch removal error = %v, want semantic preservation", err)
+	}
+	if removed {
+		t.Fatal("semantic digest mismatch was removed")
+	}
+	assertWakeGenerationMarkerForTest(t, fixture, fixture.marker)
+}
+
+func newWakeGenerationSnapshotFixture(t *testing.T) wakeGenerationSnapshotFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	fixture := wakeGenerationSnapshotFixture{
+		agentDir: agentDir,
+		label:    "wake prepared snapshot test",
+		marker: wakeReady{
+			Schema:       wakeReadySchema,
+			Generation:   "snapshot-generation",
+			TargetDigest: "sha256:" + strings.Repeat("a", 64),
+		},
+	}
+	if err := agentDir.withFD(func(dirfd int) error {
+		return writeWakeGenerationFileAt(
+			dirfd,
+			testWakeGenerationSnapshotName,
+			fixture.label,
+			fixture.marker,
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		fixture.snapshot, _, readErr = readWakeGenerationFileSnapshotAt(
+			dirfd,
+			agentDir,
+			testWakeGenerationSnapshotName,
+			fixture.label,
+		)
+		return readErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.snapshot.FileInfo == nil {
+		t.Fatal("generation snapshot file identity is missing")
+	}
+	return fixture
+}
+
+func removeWakeGenerationSnapshotForTest(
+	t *testing.T,
+	fixture wakeGenerationSnapshotFixture,
+	expected wakeGenerationFileSnapshot,
+) (bool, error) {
+	t.Helper()
+	var removed bool
+	var removeErr error
+	err := fixture.agentDir.withFD(func(dirfd int) error {
+		removed, removeErr = removeWakeGenerationFileIfSnapshotMatchesAt(
+			dirfd,
+			fixture.agentDir,
+			testWakeGenerationSnapshotName,
+			fixture.label,
+			expected,
+		)
+		return removeErr
+	})
+	if err != nil && removeErr == nil {
+		return false, err
+	}
+	return removed, removeErr
+}
+
+func assertWakeGenerationMarkerForTest(
+	t *testing.T,
+	fixture wakeGenerationSnapshotFixture,
+	want wakeReady,
+) {
+	t.Helper()
+	var marker wakeReady
+	var exists bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		marker, exists, readErr = readWakeGenerationFileAt(
+			dirfd,
+			fixture.agentDir,
+			testWakeGenerationSnapshotName,
+			fixture.label,
+		)
+		return readErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !exists || marker != want {
+		t.Fatalf("preserved marker = %#v exists=%v, want %#v", marker, exists, want)
+	}
+}

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -182,12 +182,18 @@ func removeWakeLockIfUnchangedGuardedAt(
 	)
 }
 
-func readWakeGenerationFileAt(
+type wakeGenerationFileSnapshot struct {
+	Marker   wakeReady
+	Raw      []byte
+	FileInfo os.FileInfo
+}
+
+func readWakeGenerationFileSnapshotAt(
 	dirfd int,
 	agentDir *wakeAgentDir,
 	name string,
 	label string,
-) (wakeReady, bool, error) {
+) (wakeGenerationFileSnapshot, bool, error) {
 	path := filepath.Join(agentDir.path, name)
 	open := func() (*os.File, error) {
 		fd, err := unix.Openat(dirfd, name, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
@@ -199,45 +205,112 @@ func readWakeGenerationFileAt(
 	file, err := open()
 	if err != nil {
 		if err == unix.ENOENT {
-			return wakeReady{}, false, nil
+			return wakeGenerationFileSnapshot{}, false, nil
 		}
-		return wakeReady{}, true, err
+		return wakeGenerationFileSnapshot{}, true, err
 	}
 	defer func() { _ = file.Close() }()
 	info, err := file.Stat()
 	if err != nil {
-		return wakeReady{}, true, err
+		return wakeGenerationFileSnapshot{}, true, err
 	}
 	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
-		return wakeReady{}, true, fmt.Errorf("%s must be a regular 0600 file", label)
+		return wakeGenerationFileSnapshot{}, true, fmt.Errorf("%s must be a regular 0600 file", label)
 	}
 	if err := validateWakeTargetPathOwnership(label, path, info); err != nil {
-		return wakeReady{}, true, err
+		return wakeGenerationFileSnapshot{}, true, err
 	}
 	data, err := readWakeMetadata(file, label, path)
 	if err != nil {
-		return wakeReady{}, true, err
+		return wakeGenerationFileSnapshot{}, true, err
 	}
 	pathFile, err := open()
 	if err != nil {
-		return wakeReady{}, true, err
+		return wakeGenerationFileSnapshot{}, true, err
 	}
 	pathInfo, statErr := pathFile.Stat()
 	_ = pathFile.Close()
 	if statErr != nil {
-		return wakeReady{}, true, statErr
+		return wakeGenerationFileSnapshot{}, true, statErr
+	}
+	if !pathInfo.Mode().IsRegular() || pathInfo.Mode().Perm() != 0o600 {
+		return wakeGenerationFileSnapshot{}, true, fmt.Errorf("%s must be a regular 0600 file", label)
+	}
+	if err := validateWakeTargetPathOwnership(label, path, pathInfo); err != nil {
+		return wakeGenerationFileSnapshot{}, true, err
 	}
 	if !sameWakeFileIdentity(info, pathInfo) {
-		return wakeReady{}, true, fmt.Errorf("%s changed while opening", label)
+		return wakeGenerationFileSnapshot{}, true, fmt.Errorf("%s changed while opening", label)
 	}
 	var marker wakeReady
 	if err := json.Unmarshal(data, &marker); err != nil {
-		return wakeReady{}, true, err
+		return wakeGenerationFileSnapshot{}, true, err
 	}
 	if marker.Schema != wakeReadySchema || marker.Generation == "" {
-		return wakeReady{}, true, fmt.Errorf("%s schema is unsupported", label)
+		return wakeGenerationFileSnapshot{}, true, fmt.Errorf("%s schema is unsupported", label)
 	}
-	return marker, true, nil
+	return wakeGenerationFileSnapshot{
+		Marker:   marker,
+		Raw:      bytes.Clone(data),
+		FileInfo: info,
+	}, true, nil
+}
+
+func readWakeGenerationFileAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	name string,
+	label string,
+) (wakeReady, bool, error) {
+	snapshot, exists, err := readWakeGenerationFileSnapshotAt(
+		dirfd,
+		agentDir,
+		name,
+		label,
+	)
+	return snapshot.Marker, exists, err
+}
+
+func removeWakeGenerationFileIfSnapshotMatchesAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	name string,
+	label string,
+	expected wakeGenerationFileSnapshot,
+) (bool, error) {
+	current, exists, err := readWakeGenerationFileSnapshotAt(
+		dirfd,
+		agentDir,
+		name,
+		label,
+	)
+	if err != nil {
+		return false, fmt.Errorf("re-read %s before removal: %w", label, err)
+	}
+	if !exists {
+		return false, nil
+	}
+	if expected.FileInfo == nil ||
+		current.FileInfo == nil ||
+		!sameWakeFileIdentity(expected.FileInfo, current.FileInfo) ||
+		!bytes.Equal(expected.Raw, current.Raw) {
+		return false, fmt.Errorf("%s changed before removal; preserving it", label)
+	}
+	if expected.Marker.Schema != current.Marker.Schema ||
+		expected.Marker.Generation != current.Marker.Generation ||
+		expected.Marker.TargetDigest != current.Marker.TargetDigest {
+		return false, fmt.Errorf("%s semantics changed before removal; preserving it", label)
+	}
+	if err := unix.Unlinkat(dirfd, name, 0); err != nil {
+		if err == unix.ENOENT {
+			return false, nil
+		}
+		return false, fmt.Errorf("remove %s: %w", label, err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return true, fmt.Errorf("sync %s removal: %w", label, err)
+	}
+	return true, nil
 }
 
 func writeWakeGenerationFileAt(

--- a/internal/cli/wake_owner_acquire_publication_unix_test.go
+++ b/internal/cli/wake_owner_acquire_publication_unix_test.go
@@ -1,0 +1,222 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestOwnerAcquisitionUnsupportedPublicationRemovesItsInstalledTarget(t *testing.T) {
+	root, target, owner := newOwnerAcquisitionPublicationFixture(t)
+
+	originalLink := publishAuthoritativeWakeLinkAt
+	publishAuthoritativeWakeLinkAt = func(int, string, int, string, int) error {
+		return syscall.EOPNOTSUPP
+	}
+	t.Cleanup(func() { publishAuthoritativeWakeLinkAt = originalLink })
+
+	_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if !errors.Is(err, syscall.EOPNOTSUPP) {
+		t.Fatalf("owner acquisition error = %v, want unsupported publication", err)
+	}
+	if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+		t.Fatalf("unsupported publication left a wake lock: %#v", inspection)
+	}
+	if _, exists, readErr := readWakeTarget(root, "codex"); readErr != nil || exists {
+		t.Fatalf("unsupported publication target exists=%v err=%v", exists, readErr)
+	}
+	if !sameWakeOwner(target.Owner, &owner) {
+		t.Fatalf("unsupported publication mutated caller owner: %#v", target.Owner)
+	}
+}
+
+func TestOwnerAcquisitionUnsupportedPublicationPreservesChangedTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		replace func(t *testing.T, path string, replacement wakeTarget)
+	}{
+		{
+			name: "new inode",
+			replace: func(t *testing.T, path string, replacement wakeTarget) {
+				t.Helper()
+				data, err := json.MarshalIndent(replacement, "", "  ")
+				if err != nil {
+					t.Fatal(err)
+				}
+				temp := filepath.Join(filepath.Dir(path), ".replacement-target")
+				if err := os.WriteFile(temp, append(data, '\n'), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Rename(temp, path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "same inode mutated content",
+			replace: func(t *testing.T, path string, replacement wakeTarget) {
+				t.Helper()
+				data, err := json.MarshalIndent(replacement, "", "  ")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, target, owner := newOwnerAcquisitionPublicationFixture(t)
+			replacement := target
+			replacement.Created = "2026-07-25T12:34:56Z"
+
+			originalLink := publishAuthoritativeWakeLinkAt
+			publishAuthoritativeWakeLinkAt = func(int, string, int, string, int) error {
+				tc.replace(t, wakeTargetPath(root, "codex"), replacement)
+				return syscall.EOPNOTSUPP
+			}
+			t.Cleanup(func() { publishAuthoritativeWakeLinkAt = originalLink })
+
+			_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+				target:   &target,
+				wakeMode: wakeTargetInjectVia,
+			})
+			if !errors.Is(err, syscall.EOPNOTSUPP) || !strings.Contains(err.Error(), "changed before cleanup") {
+				t.Fatalf("owner acquisition error = %v, want unsupported publication plus preservation", err)
+			}
+			if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+				t.Fatalf("unsupported publication left a wake lock: %#v", inspection)
+			}
+			persisted, exists, readErr := readWakeTarget(root, "codex")
+			if readErr != nil || !exists || !sameWakeTarget(persisted, replacement) {
+				t.Fatalf("replacement target = %#v exists=%v err=%v", persisted, exists, readErr)
+			}
+			if !sameWakeOwner(target.Owner, &owner) {
+				t.Fatalf("unsupported publication mutated caller owner: %#v", target.Owner)
+			}
+		})
+	}
+}
+
+func TestOwnerPublicationPreservesReplacementInstalledImmediatelyAfterRename(t *testing.T) {
+	root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+	replacement := target
+	replacement.Created = "2026-07-25T13:45:00Z"
+
+	originalAfterRename := publishAuthoritativeWakeAfterTargetRename
+	publishAuthoritativeWakeAfterTargetRename = func() {
+		data, err := json.MarshalIndent(replacement, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := wakeTargetPath(root, "codex")
+		temp := filepath.Join(filepath.Dir(path), ".rename-window-replacement")
+		if err := os.WriteFile(temp, append(data, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(temp, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { publishAuthoritativeWakeAfterTargetRename = originalAfterRename })
+
+	_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err == nil || !strings.Contains(err.Error(), "changed during publication") {
+		t.Fatalf("owner acquisition error = %v, want rename-window replacement refusal", err)
+	}
+	if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+		t.Fatalf("rename-window replacement published a wake lock: %#v", inspection)
+	}
+	persisted, exists, readErr := readWakeTarget(root, "codex")
+	if readErr != nil || !exists || !sameWakeTarget(persisted, replacement) {
+		t.Fatalf("rename-window replacement = %#v exists=%v err=%v", persisted, exists, readErr)
+	}
+}
+
+func TestOwnerAcquisitionCommittedPublicationFailurePreservesExactClaim(t *testing.T) {
+	root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+
+	originalSync := syncWakeOwnerDirFD
+	syncCalls := 0
+	syncWakeOwnerDirFD = func(fd int) error {
+		syncCalls++
+		if syncCalls == 2 {
+			return syscall.EIO
+		}
+		return originalSync(fd)
+	}
+	t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
+
+	_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if !errors.Is(err, syscall.EIO) || !strings.Contains(err.Error(), "exact owner claim is visible and was preserved") {
+		t.Fatalf("owner acquisition error = %v, want committed preservation", err)
+	}
+	inspection := inspectWakeLock(root, "codex")
+	if !inspection.Exists || classifyPersistedWakeClaim(inspection) != wakeClaimAuthoritative {
+		t.Fatalf("committed publication claim = %#v", inspection)
+	}
+	persisted, exists, readErr := readWakeTarget(root, "codex")
+	if readErr != nil || !exists || !sameWakeTarget(persisted, target) {
+		t.Fatalf("committed target = %#v exists=%v err=%v", persisted, exists, readErr)
+	}
+	agentDir, openErr := openWakeAgentDir(root, "codex")
+	if openErr != nil {
+		t.Fatal(openErr)
+	}
+	defer func() { _ = agentDir.Close() }()
+	if verifyErr := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		_, pairErr := validateAuthoritativeWakeClaimPairAt(dirfd, agentDir, inspection)
+		return pairErr
+	}); verifyErr != nil {
+		t.Fatalf("committed claim pair is invalid: %v", verifyErr)
+	}
+}
+
+func newOwnerAcquisitionPublicationFixture(t *testing.T) (string, wakeTarget, wakeOwner) {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-publication-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+
+	originalObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if !sameWakeOwner(&got, &owner) {
+			t.Fatalf("observed owner = %#v, want %#v", got, owner)
+		}
+		return liveWakeOwnerObservationForTest(), nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = originalObserve })
+	return root, target, owner
+}

--- a/internal/cli/wake_owner_acquire_unix.go
+++ b/internal/cli/wake_owner_acquire_unix.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
-	"golang.org/x/sys/unix"
 )
 
 func classifyPersistedWakeClaim(inspection wakeLockInspection) wakeClaimClass {
@@ -130,7 +129,6 @@ func acquireAuthoritativeWakeLockWithOptions(
 	for {
 		var created wakeLockInspection
 		var stopCapability *authoritativeWakeStopCapability
-		fallbackOwnerless := false
 		retry := false
 		err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 			inspection := inspectWakeLockForOwnerTransition(dirfd, agentDir, root, me)
@@ -149,10 +147,6 @@ func acquireAuthoritativeWakeLockWithOptions(
 			requestedObservation, observeErr := observeAuthoritativeWakeOwner(*requested.Owner)
 			defer func() { _ = requestedObservation.Close() }()
 			if observeErr != nil {
-				if requestedObservation.CapabilityUnsupported && claimClass == wakeClaimAbsent {
-					fallbackOwnerless = true
-					return nil
-				}
 				return observeErr
 			}
 			if requestedObservation.State != wakeOwnerSame {
@@ -269,14 +263,25 @@ func acquireAuthoritativeWakeLockWithOptions(
 					if !publicationErr.Unsupported || publicationErr.Committed {
 						return err
 					}
-					if unlinkErr := unix.Unlinkat(dirfd, wakeTargetFileName, 0); unlinkErr != nil && unlinkErr != unix.ENOENT {
-						return fmt.Errorf("%w (remove uncommitted owner target: %v)", err, unlinkErr)
+					if publicationErr.InstalledTarget == nil {
+						return fmt.Errorf("%w (installed owner target identity is unavailable; preserving it)", err)
 					}
-					if syncErr := syncWakeOwnerDirFD(dirfd); syncErr != nil {
-						return fmt.Errorf("%w (sync ownerless fallback cleanup: %v)", err, syncErr)
+					removed, removeErr := removeWakeTargetIfSnapshotMatchesAt(
+						dirfd,
+						agentDir,
+						root,
+						me,
+						*publicationErr.InstalledTarget,
+					)
+					if removeErr != nil {
+						return fmt.Errorf("%w (uncommitted owner target cleanup refused: %v)", err, removeErr)
 					}
-					fallbackOwnerless = true
-					return nil
+					if removed {
+						if syncErr := syncWakeOwnerDirFD(dirfd); syncErr != nil {
+							return fmt.Errorf("%w (sync uncommitted owner target cleanup: %v)", err, syncErr)
+						}
+					}
+					return err
 				}
 				return err
 			}
@@ -310,17 +315,6 @@ func acquireAuthoritativeWakeLockWithOptions(
 		}
 		if retry {
 			continue
-		}
-		if fallbackOwnerless {
-			ownerless := requested
-			ownerless.Owner = nil
-			_ = writeStderr("warning: owner-bound wake capabilities are unavailable; starting one ownerless inject-via wake\n")
-			// Reflect the degradation in the caller's target too. The wake loop
-			// must not keep applying owner-health semantics to a claim that was
-			// deliberately published through the ownerless protocol.
-			*options.target = ownerless
-			options.wakeMode = wakeTargetInjectVia
-			return acquireWakeLockWithOptions(root, me, options)
 		}
 		if !created.Exists {
 			return nil, fmt.Errorf("authoritative wake acquisition produced no claim")

--- a/internal/cli/wake_owner_child_darwin.go
+++ b/internal/cli/wake_owner_child_darwin.go
@@ -31,20 +31,13 @@ func prepareAuthoritativeWakeChildPlatform(cmd *exec.Cmd) (*authoritativeWakeChi
 			if process == nil || process.Pid <= 0 {
 				return fmt.Errorf("authoritative wake child process is missing")
 			}
-			bound = true
+			if err := validateDarwinWakeOwnerStartupRollbackFD(writeEnd); err != nil {
+				return err
+			}
 			if err := readEnd.Close(); err != nil {
 				return err
 			}
-			// Keep the owner-side stop capability across the later TUI exec,
-			// but only after the wake child has spawned so the child cannot
-			// inherit its own writer and defeat EOF-based owner-exit cleanup.
-			flags, err := unix.FcntlInt(writeEnd.Fd(), unix.F_GETFD, 0)
-			if err != nil {
-				return fmt.Errorf("inspect authoritative wake owner stop fd: %w", err)
-			}
-			if _, err := unix.FcntlInt(writeEnd.Fd(), unix.F_SETFD, flags&^unix.FD_CLOEXEC); err != nil {
-				return fmt.Errorf("retain authoritative wake owner stop fd across exec: %w", err)
-			}
+			bound = true
 			return nil
 		},
 		stop: func() error {
@@ -72,10 +65,24 @@ func prepareAuthoritativeWakeChildPlatform(cmd *exec.Cmd) (*authoritativeWakeChi
 	}, nil
 }
 
+func validateDarwinWakeOwnerStartupRollbackFD(writeEnd *os.File) error {
+	flags, err := unix.FcntlInt(writeEnd.Fd(), unix.F_GETFD, 0)
+	if err != nil {
+		return fmt.Errorf("inspect authoritative wake owner startup rollback fd: %w", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		return fmt.Errorf("authoritative wake owner startup rollback fd is not close-on-exec")
+	}
+	return nil
+}
+
 func authoritativeWakePrivateStopFromEnv() (<-chan struct{}, func(), error) {
 	raw := strings.TrimSpace(os.Getenv(envWakePrivateStopFD))
 	if raw == "" {
 		return nil, func() {}, nil
+	}
+	if err := os.Unsetenv(envWakePrivateStopFD); err != nil {
+		return nil, nil, fmt.Errorf("clear %s after ingestion: %w", envWakePrivateStopFD, err)
 	}
 	fd, err := strconv.Atoi(raw)
 	if err != nil || fd < 3 {
@@ -85,11 +92,54 @@ func authoritativeWakePrivateStopFromEnv() (<-chan struct{}, func(), error) {
 	if file == nil {
 		return nil, nil, fmt.Errorf("%s fd is unavailable", envWakePrivateStopFD)
 	}
+	if err := sealDarwinWakePrivateStopFD(file); err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	stop, cleanup := watchAuthoritativeWakePrivateStop(file)
+	return stop, cleanup, nil
+}
+
+func sealDarwinWakePrivateStopFD(file *os.File) error {
+	if file == nil {
+		return fmt.Errorf("%s fd is unavailable", envWakePrivateStopFD)
+	}
+	fd := file.Fd()
+	flags, err := unix.FcntlInt(fd, unix.F_GETFD, 0)
+	if err != nil {
+		return fmt.Errorf("inspect %s fd flags: %w", envWakePrivateStopFD, err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		if _, err := unix.FcntlInt(fd, unix.F_SETFD, flags|unix.FD_CLOEXEC); err != nil {
+			return fmt.Errorf("seal %s fd across exec: %w", envWakePrivateStopFD, err)
+		}
+	}
+	flags, err = unix.FcntlInt(fd, unix.F_GETFD, 0)
+	if err != nil {
+		return fmt.Errorf("verify %s fd flags: %w", envWakePrivateStopFD, err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		return fmt.Errorf("%s fd is not close-on-exec", envWakePrivateStopFD)
+	}
+	return nil
+}
+
+func watchAuthoritativeWakePrivateStop(file *os.File) (<-chan struct{}, func()) {
 	stop := make(chan struct{})
+	finished := make(chan struct{})
 	go func() {
+		defer close(finished)
+		defer func() { _ = file.Close() }()
 		var one [1]byte
-		_, _ = file.Read(one[:])
-		close(stop)
+		if count, _ := file.Read(one[:]); count == 1 {
+			close(stop)
+		}
 	}()
-	return stop, func() { _ = file.Close() }, nil
+	var cleanupOnce sync.Once
+	return stop, func() {
+		cleanupOnce.Do(func() {
+			_ = file.Close()
+			<-finished
+		})
+	}
 }

--- a/internal/cli/wake_owner_child_darwin_test.go
+++ b/internal/cli/wake_owner_child_darwin_test.go
@@ -1,0 +1,221 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	darwinWakeOwnerDescendantHelperEnv  = "AMQ_TEST_DARWIN_WAKE_OWNER_DESCENDANT"
+	darwinWakeOwnerDescendantProbeFDEnv = "AMQ_TEST_DARWIN_WAKE_OWNER_PROBE_FD"
+)
+
+func TestDarwinWakeOwnerChildWriterRemainsCloseOnExecAfterBind(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "sleep 30")
+	cmd.Env = os.Environ()
+	capability, err := configureAuthoritativeWakeChild(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = capability.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+		_ = capability.Close()
+	})
+	if err := capability.Bind(cmd.Process); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bind validates the actual retained writer after the child has spawned.
+	// A missing FD_CLOEXEC is a hard error because this pipe authorizes startup
+	// rollback only; it must disappear when coop exec replaces the parent.
+	if err := capability.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDarwinWakeOwnerPrivateStopRequiresExplicitByte(t *testing.T) {
+	t.Run("explicit rollback byte stops", func(t *testing.T) {
+		readEnd, writeEnd, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stop, cleanup := watchAuthoritativeWakePrivateStop(readEnd)
+		defer cleanup()
+		if _, err := writeEnd.Write([]byte{1}); err != nil {
+			_ = writeEnd.Close()
+			t.Fatal(err)
+		}
+		_ = writeEnd.Close()
+		select {
+		case <-stop:
+		case <-time.After(2 * time.Second):
+			t.Fatal("explicit startup rollback byte did not stop the wake child")
+		}
+	})
+
+	t.Run("successful exec EOF does not stop", func(t *testing.T) {
+		readEnd, writeEnd, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stop, cleanup := watchAuthoritativeWakePrivateStop(readEnd)
+		if err := writeEnd.Close(); err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+		cleanup()
+		select {
+		case <-stop:
+			t.Fatal("writer EOF was misclassified as exact owner death")
+		default:
+		}
+	})
+}
+
+func TestDarwinWakeOwnerPrivateStopCleanupInterruptsAndJoinsRead(t *testing.T) {
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writeEnd.Close() }()
+	stop, cleanup := watchAuthoritativeWakePrivateStop(readEnd)
+
+	finished := make(chan struct{})
+	go func() {
+		cleanup()
+		close(finished)
+	}()
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("private-stop cleanup did not interrupt and join the blocking read")
+	}
+	select {
+	case <-stop:
+		t.Fatal("cleanup was misclassified as explicit startup rollback")
+	default:
+	}
+}
+
+func TestDarwinWakeOwnerPrivateStopIsSealedFromDescendantExec(t *testing.T) {
+	if os.Getenv(darwinWakeOwnerDescendantHelperEnv) != "" {
+		if raw := os.Getenv(envWakePrivateStopFD); raw != "" {
+			t.Fatalf("descendant inherited %s=%q", envWakePrivateStopFD, raw)
+		}
+		fd, err := strconv.Atoi(os.Getenv(darwinWakeOwnerDescendantProbeFDEnv))
+		if err != nil {
+			t.Fatalf("parse descendant probe fd: %v", err)
+		}
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); !errors.Is(err, unix.EBADF) {
+			t.Fatalf("descendant probe fd %d = %v, want EBADF", fd, err)
+		}
+		return
+	}
+
+	var pipeFDs [2]int
+	if err := unix.Pipe(pipeFDs[:]); err != nil {
+		t.Fatal(err)
+	}
+	readFD, writeFD := pipeFDs[0], pipeFDs[1]
+	defer func() { _ = unix.Close(writeFD) }()
+	t.Setenv(envWakePrivateStopFD, strconv.Itoa(readFD))
+	stop, cleanup, err := authoritativeWakePrivateStopFromEnv()
+	if err != nil {
+		_ = unix.Close(readFD)
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if raw := os.Getenv(envWakePrivateStopFD); raw != "" {
+		t.Fatalf("%s survived ingestion as %q", envWakePrivateStopFD, raw)
+	}
+
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(
+		testBinary,
+		"-test.run=^TestDarwinWakeOwnerPrivateStopIsSealedFromDescendantExec$",
+	)
+	cmd.Env = append(
+		os.Environ(),
+		darwinWakeOwnerDescendantHelperEnv+"=1",
+		darwinWakeOwnerDescendantProbeFDEnv+"="+strconv.Itoa(readFD),
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("descendant capability probe: %v\n%s", err, output)
+	}
+
+	if _, err := unix.Write(writeFD, []byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-stop:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sealed private-stop descriptor did not receive rollback byte")
+	}
+}
+
+func TestDarwinWakeOwnerPrivateStopInvalidEnvFailsClosed(t *testing.T) {
+	for _, raw := range []string{"not-an-fd", "1073741824"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv(envWakePrivateStopFD, raw)
+			stop, cleanup, err := authoritativeWakePrivateStopFromEnv()
+			if err == nil {
+				if cleanup != nil {
+					cleanup()
+				}
+				t.Fatalf("%s=%q was accepted", envWakePrivateStopFD, raw)
+			}
+			if stop != nil || cleanup != nil {
+				t.Fatalf(
+					"invalid private-stop capability returned stop=%t cleanup=%t",
+					stop != nil,
+					cleanup != nil,
+				)
+			}
+			if got := os.Getenv(envWakePrivateStopFD); got != "" {
+				t.Fatalf("%s survived failed ingestion as %q", envWakePrivateStopFD, got)
+			}
+		})
+	}
+}
+
+func TestDarwinWakeOwnerChildWriterStartsCloseOnExec(t *testing.T) {
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = readEnd.Close()
+		_ = writeEnd.Close()
+	}()
+	if err := validateDarwinWakeOwnerStartupRollbackFD(writeEnd); err != nil {
+		t.Fatal(err)
+	}
+	flags, err := unix.FcntlInt(writeEnd.Fd(), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := unix.FcntlInt(writeEnd.Fd(), unix.F_SETFD, flags&^unix.FD_CLOEXEC); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateDarwinWakeOwnerStartupRollbackFD(writeEnd); err == nil {
+		t.Fatal("startup rollback writer accepted without close-on-exec")
+	}
+}

--- a/internal/cli/wake_owner_lifecycle_linux_test.go
+++ b/internal/cli/wake_owner_lifecycle_linux_test.go
@@ -4,9 +4,11 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -57,6 +59,11 @@ func TestLinuxOwnerObservationRetainsPidfdAcrossStableDoubleSnapshot(t *testing.
 		BootID:       "11111111-1111-1111-1111-111111111111",
 		SessionID:    99,
 	}
+	pidfdPipe := make([]int, 2)
+	if err := unix.Pipe2(pidfdPipe, unix.O_CLOEXEC); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = unix.Close(pidfdPipe[1]) })
 	var events []string
 	oldOpen := linuxPidfdOpen
 	oldPoll := linuxPidfdPoll
@@ -66,21 +73,21 @@ func TestLinuxOwnerObservationRetainsPidfdAcrossStableDoubleSnapshot(t *testing.
 		if pid != owner.PID || flags != 0 {
 			t.Fatalf("pidfd_open(%d,%d)", pid, flags)
 		}
-		return 77, nil
+		return pidfdPipe[0], nil
 	}
 	linuxPidfdPoll = func(fd int, _ time.Duration) (bool, error) {
 		events = append(events, "poll")
-		if fd != 77 {
+		if fd != pidfdPipe[0] {
 			t.Fatalf("poll fd = %d", fd)
 		}
 		return false, nil
 	}
 	linuxPidfdClose = func(fd int) error {
 		events = append(events, "close")
-		if fd != 77 {
-			t.Fatalf("close fd = %d", fd)
+		if fd != pidfdPipe[0] {
+			return fmt.Errorf("close fd = %d, want %d", fd, pidfdPipe[0])
 		}
-		return nil
+		return unix.Close(fd)
 	}
 	t.Cleanup(func() {
 		linuxPidfdOpen = oldOpen
@@ -105,6 +112,15 @@ func TestLinuxOwnerObservationRetainsPidfdAcrossStableDoubleSnapshot(t *testing.
 	if err != nil || observation.State != wakeOwnerSame {
 		t.Fatalf("observation = %#v err=%v", observation, err)
 	}
+	t.Cleanup(func() { _ = observation.Close() })
+	if observation.Done() == nil {
+		t.Fatal("same-owner observation has no lifetime signal")
+	}
+	select {
+	case <-observation.Done():
+		t.Fatal("same-owner observation ended before owner exit or explicit disposal")
+	default:
+	}
 	if len(events) == 0 || events[0] != "open" {
 		t.Fatalf("events before close = %v, want pidfd open first", events)
 	}
@@ -116,6 +132,11 @@ func TestLinuxOwnerObservationRetainsPidfdAcrossStableDoubleSnapshot(t *testing.
 	}
 	if got := events[len(events)-1]; got != "close" {
 		t.Fatalf("last event = %q, events=%v", got, events)
+	}
+	select {
+	case <-observation.Done():
+	default:
+		t.Fatal("same-owner observation did not end after explicit disposal")
 	}
 }
 
@@ -176,12 +197,208 @@ func TestLinuxOwnerObservationTreatsPidfdConfirmedMidSnapshotExitAsDead(t *testi
 	if observation.State != wakeOwnerDead {
 		t.Fatalf("observation = %#v, want pidfd-confirmed dead", observation)
 	}
+	select {
+	case <-observation.Done():
+	default:
+		t.Fatal("dead-owner observation Done is not already closed")
+	}
 	if inspections != 1 || polls != 2 {
 		t.Fatalf("mid-snapshot exit inspected=%d polled=%d, want 1 and 2", inspections, polls)
 	}
 }
 
-func TestLinuxUnsupportedPidfdStillCapturesCurrentOwnerForOwnerlessFallback(t *testing.T) {
+func TestLinuxOwnerObservationESRCHIsDeadAndAlreadyDone(t *testing.T) {
+	oldOpen := linuxPidfdOpen
+	linuxPidfdOpen = func(int, int) (int, error) {
+		return -1, syscall.ESRCH
+	}
+	t.Cleanup(func() { linuxPidfdOpen = oldOpen })
+
+	observation, err := observeAuthoritativeWakeOwnerPlatform(wakeOwner{PID: 4242})
+	if err != nil || observation.State != wakeOwnerDead {
+		t.Fatalf("observation = %#v err=%v, want dead", observation, err)
+	}
+	select {
+	case <-observation.Done():
+	default:
+		t.Fatal("ESRCH observation Done is not already closed")
+	}
+}
+
+func TestLinuxOwnerObservationUnsupportedHasNoDoneSignal(t *testing.T) {
+	oldOpen := linuxPidfdOpen
+	linuxPidfdOpen = func(int, int) (int, error) {
+		return -1, syscall.ENOSYS
+	}
+	t.Cleanup(func() { linuxPidfdOpen = oldOpen })
+
+	observation, err := observeAuthoritativeWakeOwnerPlatform(wakeOwner{PID: 4242})
+	if err == nil || observation.State != wakeOwnerUnknown || !observation.CapabilityUnsupported {
+		t.Fatalf("observation = %#v err=%v, want unsupported unknown", observation, err)
+	}
+	if observation.Done() != nil {
+		t.Fatal("unsupported owner observation exposed a false lifetime signal")
+	}
+}
+
+func TestLinuxOwnerObservationStableUnknownReturnsErrorAndNoDoneSignal(t *testing.T) {
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	const pidfd = 77
+	oldOpen := linuxPidfdOpen
+	oldPoll := linuxPidfdPoll
+	oldClose := linuxPidfdClose
+	linuxPidfdOpen = func(pid, flags int) (int, error) {
+		if pid != owner.PID || flags != 0 {
+			t.Fatalf("pidfd_open(%d,%d)", pid, flags)
+		}
+		return pidfd, nil
+	}
+	polls := 0
+	linuxPidfdPoll = func(fd int, _ time.Duration) (bool, error) {
+		if fd != pidfd {
+			t.Fatalf("poll fd = %d", fd)
+		}
+		polls++
+		return false, nil
+	}
+	closes := 0
+	linuxPidfdClose = func(fd int) error {
+		if fd != pidfd {
+			t.Fatalf("close fd = %d", fd)
+		}
+		closes++
+		return nil
+	}
+	t.Cleanup(func() {
+		linuxPidfdOpen = oldOpen
+		linuxPidfdPoll = oldPoll
+		linuxPidfdClose = oldClose
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: owner.ProcessStart,
+			BootID:     owner.BootID,
+		}
+	})
+	sessionErr := errors.New("session inspection denied")
+	stubWakeProcessSID(t, func(int) (int, error) {
+		return 0, sessionErr
+	})
+
+	observation, err := observeAuthoritativeWakeOwnerPlatform(owner)
+	if err == nil || !strings.Contains(err.Error(), sessionErr.Error()) {
+		t.Fatalf("unknown observation error = %v", err)
+	}
+	if observation.State != wakeOwnerUnknown {
+		t.Fatalf("observation = %#v, want unknown", observation)
+	}
+	if observation.Done() != nil {
+		t.Fatal("stable unknown observation exposed a false lifetime signal")
+	}
+	if polls != 3 || closes != 1 {
+		t.Fatalf("stable unknown polled=%d closed=%d, want 3 and 1", polls, closes)
+	}
+}
+
+func TestLinuxOwnerObservationMonitorClosesDoneOnOwnerExit(t *testing.T) {
+	pidfdPipe := make([]int, 2)
+	if err := unix.Pipe2(pidfdPipe, unix.O_CLOEXEC); err != nil {
+		t.Fatal(err)
+	}
+	monitor, err := startLinuxWakeOwnerObservationMonitor(pidfdPipe[0])
+	if err != nil {
+		_ = unix.Close(pidfdPipe[0])
+		_ = unix.Close(pidfdPipe[1])
+		t.Fatal(err)
+	}
+	observation := wakeOwnerObservation{
+		State:   wakeOwnerSame,
+		monitor: monitor,
+	}
+	t.Cleanup(func() { _ = observation.Close() })
+	if _, err := unix.Write(pidfdPipe[1], []byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	_ = unix.Close(pidfdPipe[1])
+
+	select {
+	case <-observation.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("owner terminal event did not close observation Done")
+	}
+	if err := observation.Close(); err != nil {
+		t.Fatalf("close terminal observation: %v", err)
+	}
+}
+
+func TestLinuxOwnerObservationCloseIsConcurrentAndIdempotent(t *testing.T) {
+	pidfdPipe := make([]int, 2)
+	if err := unix.Pipe2(pidfdPipe, unix.O_CLOEXEC); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = unix.Close(pidfdPipe[1]) })
+	monitor, err := startLinuxWakeOwnerObservationMonitor(pidfdPipe[0])
+	if err != nil {
+		_ = unix.Close(pidfdPipe[0])
+		t.Fatal(err)
+	}
+	observation := wakeOwnerObservation{
+		State:   wakeOwnerSame,
+		monitor: monitor,
+	}
+
+	const callers = 16
+	errs := make(chan error, callers)
+	var wait sync.WaitGroup
+	wait.Add(callers)
+	for range callers {
+		go func() {
+			defer wait.Done()
+			errs <- observation.Close()
+		}()
+	}
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent close: %v", err)
+		}
+	}
+	select {
+	case <-observation.Done():
+	default:
+		t.Fatal("explicit disposal did not close observation Done")
+	}
+}
+
+func TestLinuxOwnerObservationMonitorFailureClosesDone(t *testing.T) {
+	const invalidFD = 1 << 20
+	monitor, err := startLinuxWakeOwnerObservationMonitor(invalidFD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := wakeOwnerObservation{
+		State:   wakeOwnerSame,
+		monitor: monitor,
+	}
+	select {
+	case <-observation.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("monitor failure did not close observation Done")
+	}
+	if err := observation.Close(); err == nil {
+		t.Fatal("monitor failure was not surfaced by Close")
+	}
+}
+
+func TestLinuxUnsupportedPidfdStillCapturesCurrentOwnerButRejectsChildSupervision(t *testing.T) {
 	oldOpen := linuxPidfdOpen
 	linuxPidfdOpen = func(int, int) (int, error) {
 		return -1, syscall.ENOSYS
@@ -219,11 +436,11 @@ func TestLinuxUnsupportedPidfdStillCapturesCurrentOwnerForOwnerlessFallback(t *t
 	_, err = prepareAuthoritativeWakeChildPlatform(exec.Command("true"))
 	var unsupported *wakeOwnerChildCapabilityUnsupportedError
 	if !errors.As(err, &unsupported) {
-		t.Fatalf("child capability error = %v, want ownerless-fallback signal", err)
+		t.Fatalf("child capability error = %v, want unsupported supervision error", err)
 	}
 }
 
-func TestLinuxFreshUnsupportedOwnerPidfdFallsBackWithoutPublishingOwnerMarkers(t *testing.T) {
+func TestLinuxFreshUnsupportedOwnerPidfdRefusesOwnerAcquisition(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatal(err)
@@ -260,37 +477,29 @@ func TestLinuxFreshUnsupportedOwnerPidfdFallsBackWithoutPublishingOwnerMarkers(t
 		}
 	})
 
-	var cleanup func()
 	var acquireErr error
 	stderr := captureWakeStderr(t, func() {
-		cleanup, acquireErr = acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		_, acquireErr = acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
 			target:   &target,
 			wakeMode: wakeTargetInjectVia,
 		})
 	})
-	if acquireErr != nil {
-		t.Fatalf("ownerless fallback acquisition: %v", acquireErr)
+	if acquireErr == nil || !strings.Contains(acquireErr.Error(), "pidfd_open") {
+		t.Fatalf("owner acquisition error = %v, want unsupported observer refusal", acquireErr)
 	}
-	defer cleanup()
-	if !strings.Contains(stderr, "ownerless") {
-		t.Fatalf("fallback warning = %q", stderr)
+	if stderr != "" {
+		t.Fatalf("owner acquisition emitted degradation warning: %q", stderr)
 	}
 	inspection := inspectWakeLock(root, "codex")
-	if inspection.fileInfo.Mode().Perm() != 0o600 ||
-		inspection.Lock.OwnerSchema != 0 ||
-		inspection.Lock.Owner != nil ||
-		inspection.Lock.WakeMode != wakeTargetInjectVia {
-		t.Fatalf("fallback lock published owner markers: %#v", inspection)
+	if inspection.Exists {
+		t.Fatalf("unsupported owner observation published a wake claim: %#v", inspection)
 	}
 	persisted, exists, err := readWakeTarget(root, "codex")
-	if err != nil || !exists {
-		t.Fatalf("fallback target = %#v exists=%v err=%v", persisted, exists, err)
+	if err != nil || exists {
+		t.Fatalf("unsupported owner observation target = %#v exists=%v err=%v", persisted, exists, err)
 	}
-	if persisted.Owner != nil {
-		t.Fatalf("fallback target retained owner: %#v", persisted.Owner)
-	}
-	if target.Owner != nil {
-		t.Fatalf("caller target retained owner-health semantics after fallback: %#v", target.Owner)
+	if !sameWakeOwner(target.Owner, &owner) {
+		t.Fatalf("owner acquisition mutated caller target owner: %#v", target.Owner)
 	}
 }
 

--- a/internal/cli/wake_owner_lifecycle_unix_test.go
+++ b/internal/cli/wake_owner_lifecycle_unix_test.go
@@ -260,6 +260,73 @@ func TestAuthoritativeOwnerLockRequiresTheSameStrictOwnerInTarget(t *testing.T) 
 	}
 }
 
+func TestOwnerAcquisitionNeverDegradesUnsupportedOrUnknownObservation(t *testing.T) {
+	tests := []struct {
+		name        string
+		observation wakeOwnerObservation
+		observeErr  error
+		want        string
+	}{
+		{
+			name: "unsupported observer",
+			observation: wakeOwnerObservation{
+				State:                 wakeOwnerUnknown,
+				Reason:                "kernel owner observation unsupported",
+				CapabilityUnsupported: true,
+			},
+			observeErr: errors.New("owner observation unsupported"),
+			want:       "owner observation unsupported",
+		},
+		{
+			name:        "unknown observer",
+			observation: wakeOwnerObservation{State: wakeOwnerUnknown, Reason: "identity incomplete"},
+			want:        "requested wake owner is unknown",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			owner := wakeOwner{
+				PID:          4242,
+				ProcessStart: "12345",
+				BootID:       "11111111-1111-1111-1111-111111111111",
+				SessionID:    99,
+			}
+			injector := writeExecutableForTest(t, "owner-observation-refusal-injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+			target.Owner = &owner
+			oldObserve := observeAuthoritativeWakeOwner
+			observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+				return tc.observation, tc.observeErr
+			}
+			t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+			_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+				target:   &target,
+				wakeMode: wakeTargetInjectVia,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("owner acquisition error = %v, want %q", err, tc.want)
+			}
+			if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+				t.Fatalf("refused owner acquisition published wake lock: %#v", inspection)
+			}
+			if _, exists, err := readWakeTarget(root, "codex"); err != nil || exists {
+				t.Fatalf("refused owner acquisition target exists=%v err=%v", exists, err)
+			}
+			if !sameWakeOwner(target.Owner, &owner) {
+				t.Fatalf("refused owner acquisition mutated requested owner: %#v", target.Owner)
+			}
+		})
+	}
+}
+
 func TestPublishAuthoritativeWakeClaimCommitsACompleteReadOnlyGeneration(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -501,6 +568,11 @@ func TestAcquireAuthoritativeWakeClaimPublishesOwnerAndCleanupPreservesLifetime(
 	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
 		if err := validateAuthoritativeWakeOwner(got); err != nil {
 			t.Fatalf("observed invalid owner %#v: %v", got, err)
+		}
+		if ownerState == wakeOwnerSame {
+			observation := liveWakeOwnerObservationForTest()
+			observation.Reason = "test owner evidence"
+			return observation, nil
 		}
 		return wakeOwnerObservation{State: ownerState, Reason: "test owner evidence"}, nil
 	}

--- a/internal/cli/wake_owner_observation_darwin.go
+++ b/internal/cli/wake_owner_observation_darwin.go
@@ -3,11 +3,36 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
+type darwinWakeOwnerObservationCapability struct {
+	mu            sync.Mutex
+	kqueueFD      int
+	cancelReadFD  int
+	cancelWriteFD int
+}
+
+var writeDarwinWakeOwnerObservationCancel = unix.Write
+
 func observeAuthoritativeWakeOwnerPlatform(owner wakeOwner) (wakeOwnerObservation, error) {
+	capability, err := openDarwinWakeOwnerObservationCapability(owner.PID)
+	if err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return deadWakeOwnerObservation("owner process is not running"), nil
+		}
+		return wakeOwnerObservation{
+			State:  wakeOwnerUnknown,
+			Reason: fmt.Sprintf("owner process kqueue unavailable: %v", err),
+		}, fmt.Errorf("observe owner process %d with kqueue: %w", owner.PID, err)
+	}
+
 	first := inspectWakeProcess(owner.PID)
 	firstSessionID, firstSessionErr := getWakeProcessSID(owner.PID)
 	second := inspectWakeProcess(owner.PID)
@@ -17,7 +42,289 @@ func observeAuthoritativeWakeOwnerPlatform(owner wakeOwner) (wakeOwnerObservatio
 		first, firstSessionID, firstSessionErr,
 		second, secondSessionID, secondSessionErr,
 	)
-	return wakeOwnerObservation{State: state, Reason: reason}, nil
+
+	exited, drainErr := drainDarwinWakeOwnerObservation(capability, owner.PID)
+	if drainErr != nil {
+		closeErr := capability.close()
+		return wakeOwnerObservation{
+				State:  wakeOwnerUnknown,
+				Reason: fmt.Sprintf("owner process kqueue drain failed: %v", drainErr),
+			}, errors.Join(
+				fmt.Errorf("drain owner process %d kqueue before observation: %w", owner.PID, drainErr),
+				closeErr,
+			)
+	}
+	if exited || state == wakeOwnerDead {
+		closeErr := capability.close()
+		if closeErr != nil {
+			return wakeOwnerObservation{
+				State:  wakeOwnerUnknown,
+				Reason: fmt.Sprintf("close dead owner process kqueue: %v", closeErr),
+			}, closeErr
+		}
+		if exited {
+			reason = "owner process is not running"
+		} else if reason == "" {
+			reason = "owner process is not running"
+		}
+		return deadWakeOwnerObservation(reason), nil
+	}
+	if state != wakeOwnerSame {
+		closeErr := capability.close()
+		unknownErr := fmt.Errorf("owner process identity is %s: %s", state, reason)
+		return wakeOwnerObservation{
+			State:  wakeOwnerUnknown,
+			Reason: reason,
+		}, errors.Join(unknownErr, closeErr)
+	}
+
+	monitor := newWakeOwnerObservationMonitor(capability.cancel)
+	go func() {
+		monitorErr := monitorDarwinWakeOwnerObservation(capability, owner.PID)
+		monitor.finish(errors.Join(monitorErr, capability.close()))
+	}()
+	return wakeOwnerObservation{
+		State:   wakeOwnerSame,
+		Reason:  reason,
+		monitor: monitor,
+	}, nil
+}
+
+func openDarwinWakeOwnerObservationCapability(pid int) (*darwinWakeOwnerObservationCapability, error) {
+	kqueueFD, err := unix.Kqueue()
+	if err != nil {
+		return nil, fmt.Errorf("create owner process kqueue: %w", err)
+	}
+	capability := &darwinWakeOwnerObservationCapability{
+		kqueueFD:      kqueueFD,
+		cancelReadFD:  -1,
+		cancelWriteFD: -1,
+	}
+	cleanupOnError := func(cause error) (*darwinWakeOwnerObservationCapability, error) {
+		return nil, errors.Join(cause, capability.close())
+	}
+	if err := setDarwinWakeOwnerObservationCloseOnExec(kqueueFD, "owner process kqueue"); err != nil {
+		return cleanupOnError(err)
+	}
+
+	cancelFDs := make([]int, 2)
+	if err := unix.Pipe(cancelFDs); err != nil {
+		return cleanupOnError(fmt.Errorf("create owner observation cancellation pipe: %w", err))
+	}
+	capability.cancelReadFD = cancelFDs[0]
+	capability.cancelWriteFD = cancelFDs[1]
+	for _, descriptor := range []struct {
+		fd    int
+		label string
+	}{
+		{fd: capability.cancelReadFD, label: "owner observation cancellation read descriptor"},
+		{fd: capability.cancelWriteFD, label: "owner observation cancellation write descriptor"},
+	} {
+		if err := setDarwinWakeOwnerObservationCloseOnExec(descriptor.fd, descriptor.label); err != nil {
+			return cleanupOnError(err)
+		}
+	}
+
+	changes := []unix.Kevent_t{
+		{
+			Ident:  uint64(pid),
+			Filter: unix.EVFILT_PROC,
+			Flags:  unix.EV_ADD | unix.EV_ENABLE | unix.EV_ONESHOT,
+			Fflags: unix.NOTE_EXIT,
+		},
+		{
+			Ident:  uint64(capability.cancelReadFD),
+			Filter: unix.EVFILT_READ,
+			Flags:  unix.EV_ADD | unix.EV_ENABLE | unix.EV_ONESHOT,
+		},
+	}
+	if _, err := unix.Kevent(capability.kqueueFD, changes, nil, nil); err != nil {
+		return cleanupOnError(fmt.Errorf("register owner process and cancellation kqueue filters: %w", err))
+	}
+	return capability, nil
+}
+
+func setDarwinWakeOwnerObservationCloseOnExec(fd int, label string) error {
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		return fmt.Errorf("inspect %s flags: %w", label, err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, flags|unix.FD_CLOEXEC); err != nil {
+			return fmt.Errorf("set close-on-exec on %s: %w", label, err)
+		}
+		flags, err = unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+		if err != nil {
+			return fmt.Errorf("verify %s flags: %w", label, err)
+		}
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		return fmt.Errorf("%s is not close-on-exec", label)
+	}
+	return nil
+}
+
+func drainDarwinWakeOwnerObservation(
+	capability *darwinWakeOwnerObservationCapability,
+	pid int,
+) (bool, error) {
+	events := make([]unix.Kevent_t, 2)
+	timeout := unix.Timespec{}
+	for {
+		count, err := unix.Kevent(capability.kqueueFD, nil, events, &timeout)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		exited, terminalErr, cancelled := classifyDarwinWakeOwnerObservationEvents(
+			events[:count],
+			pid,
+			capability.cancelReadFD,
+		)
+		switch {
+		case exited:
+			return true, nil
+		case terminalErr != nil:
+			return false, terminalErr
+		case cancelled:
+			return false, fmt.Errorf("owner observation cancelled before monitor start")
+		default:
+			return false, nil
+		}
+	}
+}
+
+func monitorDarwinWakeOwnerObservation(
+	capability *darwinWakeOwnerObservationCapability,
+	pid int,
+) error {
+	events := make([]unix.Kevent_t, 2)
+	for {
+		count, err := unix.Kevent(capability.kqueueFD, nil, events, nil)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("wait for owner process exit: %w", err)
+		}
+		exited, terminalErr, cancelled := classifyDarwinWakeOwnerObservationEvents(
+			events[:count],
+			pid,
+			capability.cancelReadFD,
+		)
+		switch {
+		case exited:
+			return nil
+		case terminalErr != nil:
+			return terminalErr
+		case cancelled:
+			return nil
+		case count == 0:
+			continue
+		default:
+			return fmt.Errorf("owner process kqueue returned no recognized terminal event")
+		}
+	}
+}
+
+func classifyDarwinWakeOwnerObservationEvents(
+	events []unix.Kevent_t,
+	pid int,
+	cancelReadFD int,
+) (exited bool, terminalErr error, cancelled bool) {
+	// An exact process-exit event wins over a concurrent cancellation or error.
+	for _, event := range events {
+		if event.Filter == unix.EVFILT_PROC &&
+			event.Ident == uint64(pid) &&
+			event.Fflags&unix.NOTE_EXIT != 0 {
+			return true, nil, false
+		}
+	}
+	for _, event := range events {
+		if event.Flags&unix.EV_ERROR != 0 && event.Data != 0 {
+			return false, fmt.Errorf(
+				"owner process kqueue event failed: %w",
+				syscall.Errno(event.Data),
+			), false
+		}
+	}
+	for _, event := range events {
+		if event.Filter == unix.EVFILT_READ && event.Ident == uint64(cancelReadFD) {
+			return false, nil, true
+		}
+	}
+	return false, nil, false
+}
+
+func (capability *darwinWakeOwnerObservationCapability) cancel() error {
+	if capability == nil {
+		return nil
+	}
+	capability.mu.Lock()
+	defer capability.mu.Unlock()
+	if capability.cancelWriteFD < 0 {
+		return nil
+	}
+	for {
+		count, err := writeDarwinWakeOwnerObservationCancel(
+			capability.cancelWriteFD,
+			[]byte{1},
+		)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if errors.Is(err, syscall.EBADF) || errors.Is(err, syscall.EPIPE) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("signal owner observation cancellation: %w", err)
+		}
+		switch count {
+		case 1:
+			return nil
+		case 0:
+			continue
+		default:
+			return fmt.Errorf(
+				"signal owner observation cancellation wrote %d bytes, want 1",
+				count,
+			)
+		}
+	}
+}
+
+func (capability *darwinWakeOwnerObservationCapability) close() error {
+	if capability == nil {
+		return nil
+	}
+	capability.mu.Lock()
+	kqueueFD := capability.kqueueFD
+	cancelReadFD := capability.cancelReadFD
+	cancelWriteFD := capability.cancelWriteFD
+	capability.kqueueFD = -1
+	capability.cancelReadFD = -1
+	capability.cancelWriteFD = -1
+	capability.mu.Unlock()
+
+	var errs []error
+	for _, descriptor := range []struct {
+		fd    int
+		label string
+	}{
+		{fd: cancelWriteFD, label: "owner observation cancellation write descriptor"},
+		{fd: cancelReadFD, label: "owner observation cancellation read descriptor"},
+		{fd: kqueueFD, label: "owner process kqueue"},
+	} {
+		if descriptor.fd < 0 {
+			continue
+		}
+		if err := unix.Close(descriptor.fd); err != nil && !errors.Is(err, syscall.EBADF) {
+			errs = append(errs, fmt.Errorf("close %s: %w", descriptor.label, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func captureAuthoritativeCurrentWakeOwnerPlatform() (wakeOwner, error) {

--- a/internal/cli/wake_owner_observation_darwin_test.go
+++ b/internal/cli/wake_owner_observation_darwin_test.go
@@ -1,0 +1,340 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestDarwinWakeOwnerObservationSignalsExactOwnerExitWithLiveDescendant(t *testing.T) {
+	for _, exitKind := range []string{"normal", "crash"} {
+		t.Run(exitKind, func(t *testing.T) {
+			cmd, owner, descendantPID, release := startDarwinWakeObservationOwner(t)
+			observation, err := observeAuthoritativeWakeOwnerPlatform(owner)
+			if err != nil {
+				t.Fatalf("observe exact owner: %v", err)
+			}
+			defer func() {
+				if err := observation.Close(); err != nil {
+					t.Errorf("close owner observation: %v", err)
+				}
+			}()
+			if observation.State != wakeOwnerSame {
+				t.Fatalf("owner observation = %#v, want live exact owner", observation)
+			}
+			if observation.Done() == nil {
+				t.Fatal("live owner observation has no death signal")
+			}
+
+			if exitKind == "normal" {
+				if err := os.WriteFile(release, []byte("exit\n"), 0o600); err != nil {
+					t.Fatalf("release owner: %v", err)
+				}
+			} else if err := cmd.Process.Kill(); err != nil {
+				t.Fatalf("crash owner: %v", err)
+			}
+			waitErr := cmd.Wait()
+			cmd.Process = nil
+			if exitKind == "normal" && waitErr != nil {
+				t.Fatalf("wait for normal owner exit: %v", waitErr)
+			}
+			if exitKind == "crash" && waitErr == nil {
+				t.Fatal("crashed owner exited successfully")
+			}
+
+			descendant, err := os.FindProcess(descendantPID)
+			if err != nil {
+				t.Fatalf("find descendant: %v", err)
+			}
+			if err := descendant.Signal(syscall.Signal(0)); err != nil {
+				t.Fatalf("descendant did not outlive exact owner: %v", err)
+			}
+			select {
+			case <-observation.Done():
+			case <-time.After(3 * time.Second):
+				t.Fatal("exact owner exit was prolonged by a live descendant")
+			}
+		})
+	}
+}
+
+func TestDarwinWakeOwnerObservationDeadHasClosedDone(t *testing.T) {
+	cmd, owner, _, _ := startDarwinWakeObservationOwner(t)
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill owner: %v", err)
+	}
+	_ = cmd.Wait()
+	cmd.Process = nil
+
+	observation, err := observeAuthoritativeWakeOwnerPlatform(owner)
+	if err != nil {
+		t.Fatalf("observe dead owner: %v", err)
+	}
+	defer func() {
+		if err := observation.Close(); err != nil {
+			t.Errorf("close dead observation: %v", err)
+		}
+	}()
+	if observation.State != wakeOwnerDead {
+		t.Fatalf("dead owner observation = %#v", observation)
+	}
+	if observation.Done() == nil {
+		t.Fatal("dead owner observation has nil Done")
+	}
+	select {
+	case <-observation.Done():
+	default:
+		t.Fatal("dead owner observation Done is not already closed")
+	}
+}
+
+func TestDarwinWakeOwnerObservationCloseCancelsAndJoins(t *testing.T) {
+	cmd, owner, _, _ := startDarwinWakeObservationOwner(t)
+	observation, err := observeAuthoritativeWakeOwnerPlatform(owner)
+	if err != nil {
+		t.Fatalf("observe exact owner: %v", err)
+	}
+	if observation.State != wakeOwnerSame || observation.Done() == nil {
+		t.Fatalf("live owner observation = %#v", observation)
+	}
+
+	const callers = 8
+	var wait sync.WaitGroup
+	errs := make(chan error, callers)
+	wait.Add(callers)
+	for range callers {
+		go func() {
+			defer wait.Done()
+			errs <- observation.Close()
+		}()
+	}
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent close: %v", err)
+		}
+	}
+	select {
+	case <-observation.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close did not cancel and join Darwin owner monitor")
+	}
+	if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Fatalf("observation Close terminated the owner: %v", err)
+	}
+}
+
+func TestDarwinWakeOwnerObservationCloseRetriesInterruptedCancellation(t *testing.T) {
+	_, owner, _, _ := startDarwinWakeObservationOwner(t)
+	observation, err := observeAuthoritativeWakeOwnerPlatform(owner)
+	if err != nil {
+		t.Fatalf("observe exact owner: %v", err)
+	}
+	if observation.State != wakeOwnerSame || observation.Done() == nil {
+		t.Fatalf("live owner observation = %#v", observation)
+	}
+
+	oldWrite := writeDarwinWakeOwnerObservationCancel
+	attempts := 0
+	writeDarwinWakeOwnerObservationCancel = func(fd int, data []byte) (int, error) {
+		attempts++
+		if attempts == 1 {
+			return 0, syscall.EINTR
+		}
+		return unix.Write(fd, data)
+	}
+	t.Cleanup(func() {
+		writeDarwinWakeOwnerObservationCancel = oldWrite
+	})
+
+	if err := observation.Close(); err != nil {
+		t.Fatalf("close after interrupted cancellation: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("cancellation writes = %d, want interrupted attempt plus retry", attempts)
+	}
+	select {
+	case <-observation.Done():
+	default:
+		t.Fatal("interrupted cancellation retry did not join the monitor")
+	}
+}
+
+func TestDarwinWakeOwnerObservationUnknownHasNilDone(t *testing.T) {
+	_, owner, _, _ := startDarwinWakeObservationOwner(t)
+	sidErr := errors.New("session identity unavailable")
+	stubWakeProcessSID(t, func(int) (int, error) {
+		return 0, sidErr
+	})
+
+	observation, err := observeAuthoritativeWakeOwnerPlatform(owner)
+	if err == nil || !strings.Contains(err.Error(), sidErr.Error()) {
+		t.Fatalf("unknown owner observation error = %v", err)
+	}
+	if observation.State != wakeOwnerUnknown {
+		t.Fatalf("unknown owner observation = %#v", observation)
+	}
+	if observation.Done() != nil {
+		t.Fatal("unknown owner observation published a death signal")
+	}
+	if err := observation.Close(); err != nil {
+		t.Fatalf("close unknown observation: %v", err)
+	}
+}
+
+func TestDarwinWakeOwnerObservationDescriptorsAreCloseOnExec(t *testing.T) {
+	capability, err := openDarwinWakeOwnerObservationCapability(os.Getpid())
+	if err != nil {
+		t.Fatalf("open owner observation capability: %v", err)
+	}
+	defer func() {
+		if err := capability.close(); err != nil {
+			t.Errorf("close owner observation capability: %v", err)
+		}
+	}()
+	for _, descriptor := range []struct {
+		fd    int
+		label string
+	}{
+		{fd: capability.kqueueFD, label: "kqueue"},
+		{fd: capability.cancelReadFD, label: "cancel read"},
+		{fd: capability.cancelWriteFD, label: "cancel write"},
+	} {
+		flags, err := unix.FcntlInt(uintptr(descriptor.fd), unix.F_GETFD, 0)
+		if err != nil {
+			t.Fatalf("inspect %s flags: %v", descriptor.label, err)
+		}
+		if flags&unix.FD_CLOEXEC == 0 {
+			t.Fatalf("%s descriptor %d is not close-on-exec", descriptor.label, descriptor.fd)
+		}
+	}
+}
+
+func TestDarwinWakeOwnerEventClassificationPrioritizesExitThenError(t *testing.T) {
+	const (
+		pid      = 4242
+		cancelFD = 17
+	)
+	cancel := unix.Kevent_t{
+		Ident:  cancelFD,
+		Filter: unix.EVFILT_READ,
+	}
+	failed := unix.Kevent_t{
+		Flags: unix.EV_ERROR,
+		Data:  int64(syscall.EBADF),
+	}
+	exited := unix.Kevent_t{
+		Ident:  pid,
+		Filter: unix.EVFILT_PROC,
+		Fflags: unix.NOTE_EXIT,
+	}
+
+	gotExit, gotErr, gotCancel := classifyDarwinWakeOwnerObservationEvents(
+		[]unix.Kevent_t{cancel, failed, exited},
+		pid,
+		cancelFD,
+	)
+	if !gotExit || gotErr != nil || gotCancel {
+		t.Fatalf("exit priority = (%v, %v, %v)", gotExit, gotErr, gotCancel)
+	}
+	gotExit, gotErr, gotCancel = classifyDarwinWakeOwnerObservationEvents(
+		[]unix.Kevent_t{cancel, failed},
+		pid,
+		cancelFD,
+	)
+	if gotExit || !errors.Is(gotErr, syscall.EBADF) || gotCancel {
+		t.Fatalf("error priority = (%v, %v, %v)", gotExit, gotErr, gotCancel)
+	}
+}
+
+func startDarwinWakeObservationOwner(
+	t *testing.T,
+) (*exec.Cmd, wakeOwner, int, string) {
+	t.Helper()
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	release := filepath.Join(dir, "release")
+	descendantPath := filepath.Join(dir, "descendant.pid")
+	script := `
+sleep 30 &
+printf '%s\n' "$!" > "$1"
+: > "$2"
+while [ ! -e "$3" ]; do sleep 0.01; done
+exit 0
+`
+	cmd := exec.Command("/bin/sh", "-c", script, "sh", descendantPath, ready, release)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start owner: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+		if data, err := os.ReadFile(descendantPath); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+				if descendant, err := os.FindProcess(pid); err == nil {
+					_ = descendant.Kill()
+				}
+			}
+		}
+	})
+	waitForDarwinWakeObservationPath(t, ready)
+	owner := authoritativeOwnerForDarwinWakeObservationTest(t, cmd.Process.Pid)
+	data, err := os.ReadFile(descendantPath)
+	if err != nil {
+		t.Fatalf("read descendant pid: %v", err)
+	}
+	descendantPID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || descendantPID <= 0 {
+		t.Fatalf("parse descendant pid %q: %v", data, err)
+	}
+	return cmd, owner, descendantPID, release
+}
+
+func authoritativeOwnerForDarwinWakeObservationTest(t *testing.T, pid int) wakeOwner {
+	t.Helper()
+	process := inspectWakeProcess(pid)
+	sessionID, sessionErr := getWakeProcessSID(pid)
+	owner := wakeOwner{
+		PID:          pid,
+		ProcessStart: process.StartToken,
+		BootID:       process.BootID,
+		SessionID:    sessionID,
+	}
+	if !process.Running || sessionErr != nil {
+		t.Fatalf("capture owner pid %d: process=%#v sessionErr=%v", pid, process, sessionErr)
+	}
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		t.Fatalf("validate owner pid %d: %v", pid, err)
+	}
+	return owner
+}
+
+func waitForDarwinWakeObservationPath(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/cli/wake_owner_observation_linux.go
+++ b/internal/cli/wake_owner_observation_linux.go
@@ -7,16 +7,15 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func observeAuthoritativeWakeOwnerPlatform(owner wakeOwner) (wakeOwnerObservation, error) {
 	pidfd, err := linuxPidfdOpen(owner.PID, 0)
 	if err != nil {
 		if errors.Is(err, syscall.ESRCH) {
-			return wakeOwnerObservation{
-				State:  wakeOwnerDead,
-				Reason: "owner process is not running",
-			}, nil
+			return deadWakeOwnerObservation("owner process is not running"), nil
 		}
 		unsupported := wakeOwnerCapabilityUnsupported(err)
 		return wakeOwnerObservation{
@@ -25,51 +24,147 @@ func observeAuthoritativeWakeOwnerPlatform(owner wakeOwner) (wakeOwnerObservatio
 			CapabilityUnsupported: unsupported,
 		}, fmt.Errorf("pidfd_open owner process %d: %w", owner.PID, err)
 	}
-	observation := wakeOwnerObservation{
-		State: wakeOwnerUnknown,
-		close: func() error { return linuxPidfdClose(pidfd) },
-	}
 	exited, err := linuxPidfdPoll(pidfd, 0)
 	if err != nil {
-		_ = observation.Close()
-		return wakeOwnerObservation{}, fmt.Errorf("poll owner pidfd before inspection: %w", err)
+		return closeLinuxOwnerObservationPidfd(
+			pidfd,
+			wakeOwnerObservation{},
+			fmt.Errorf("poll owner pidfd before inspection: %w", err),
+		)
 	}
 	if exited {
-		observation.State = wakeOwnerDead
-		observation.Reason = "owner process is not running"
-		return observation, nil
+		return closeLinuxOwnerObservationPidfd(
+			pidfd,
+			deadWakeOwnerObservation("owner process is not running"),
+			nil,
+		)
 	}
 
 	first := inspectWakeProcess(owner.PID)
 	firstSessionID, firstSessionErr := getWakeProcessSID(owner.PID)
 	exited, err = linuxPidfdPoll(pidfd, 0)
 	if err != nil {
-		_ = observation.Close()
-		return wakeOwnerObservation{}, fmt.Errorf("poll owner pidfd during inspection: %w", err)
+		return closeLinuxOwnerObservationPidfd(
+			pidfd,
+			wakeOwnerObservation{},
+			fmt.Errorf("poll owner pidfd during inspection: %w", err),
+		)
 	}
 	if exited {
-		observation.State = wakeOwnerDead
-		observation.Reason = "owner process is not running"
-		return observation, nil
+		return closeLinuxOwnerObservationPidfd(
+			pidfd,
+			deadWakeOwnerObservation("owner process is not running"),
+			nil,
+		)
 	}
 	second := inspectWakeProcess(owner.PID)
 	secondSessionID, secondSessionErr := getWakeProcessSID(owner.PID)
 	exitedAfter, err := linuxPidfdPoll(pidfd, 0)
 	if err != nil {
-		_ = observation.Close()
-		return wakeOwnerObservation{}, fmt.Errorf("poll owner pidfd after inspection: %w", err)
+		return closeLinuxOwnerObservationPidfd(
+			pidfd,
+			wakeOwnerObservation{},
+			fmt.Errorf("poll owner pidfd after inspection: %w", err),
+		)
 	}
 	if exitedAfter {
-		observation.State = wakeOwnerDead
-		observation.Reason = "owner process is not running"
-		return observation, nil
+		return closeLinuxOwnerObservationPidfd(
+			pidfd,
+			deadWakeOwnerObservation("owner process is not running"),
+			nil,
+		)
 	}
+	observation := wakeOwnerObservation{}
 	observation.State, observation.Reason = classifyStableAuthoritativeWakeOwner(
 		owner,
 		first, firstSessionID, firstSessionErr,
 		second, secondSessionID, secondSessionErr,
 	)
-	return observation, nil
+	switch observation.State {
+	case wakeOwnerSame:
+		monitor, monitorErr := startLinuxWakeOwnerObservationMonitor(pidfd)
+		if monitorErr != nil {
+			return wakeOwnerObservation{
+				State:  wakeOwnerUnknown,
+				Reason: fmt.Sprintf("owner pidfd monitor unavailable: %v", monitorErr),
+			}, monitorErr
+		}
+		observation.monitor = monitor
+		return observation, nil
+	case wakeOwnerDead:
+		observation.done = wakeOwnerObservationAlreadyDone
+	case wakeOwnerUnknown:
+		return closeLinuxOwnerObservationPidfd(
+			pidfd,
+			observation,
+			fmt.Errorf("owner process identity is unknown: %s", observation.Reason),
+		)
+	}
+	return closeLinuxOwnerObservationPidfd(pidfd, observation, nil)
+}
+
+func closeLinuxOwnerObservationPidfd(
+	pidfd int,
+	observation wakeOwnerObservation,
+	cause error,
+) (wakeOwnerObservation, error) {
+	closeErr := linuxPidfdClose(pidfd)
+	if closeErr != nil {
+		closeErr = fmt.Errorf("close owner pidfd: %w", closeErr)
+	}
+	return observation, errors.Join(cause, closeErr)
+}
+
+func startLinuxWakeOwnerObservationMonitor(pidfd int) (*wakeOwnerObservationMonitor, error) {
+	cancelRead, cancelWrite, err := os.Pipe()
+	if err != nil {
+		_, closeErr := closeLinuxOwnerObservationPidfd(pidfd, wakeOwnerObservation{}, nil)
+		return nil, errors.Join(
+			fmt.Errorf("create owner pidfd monitor cancellation pipe: %w", err),
+			closeErr,
+		)
+	}
+	monitor := newWakeOwnerObservationMonitor(cancelWrite.Close)
+	go func() {
+		waitErr := waitLinuxWakeOwnerObservation(pidfd, int(cancelRead.Fd()))
+		closeErr := errors.Join(
+			linuxPidfdClose(pidfd),
+			cancelRead.Close(),
+		)
+		monitor.finish(errors.Join(waitErr, closeErr))
+	}()
+	return monitor, nil
+}
+
+func waitLinuxWakeOwnerObservation(pidfd, cancelFD int) error {
+	pollFDs := []unix.PollFd{
+		{Fd: int32(pidfd), Events: unix.POLLIN},
+		{Fd: int32(cancelFD), Events: unix.POLLIN},
+	}
+	for {
+		pollFDs[0].Revents = 0
+		pollFDs[1].Revents = 0
+		_, err := unix.Poll(pollFDs, -1)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("poll retained owner pidfd: %w", err)
+		}
+
+		ownerEvents := pollFDs[0].Revents
+		if ownerEvents&(unix.POLLIN|unix.POLLHUP) != 0 {
+			return nil
+		}
+		if ownerEvents&(unix.POLLERR|unix.POLLNVAL) != 0 {
+			return fmt.Errorf("retained owner pidfd poll failed with events %#x", ownerEvents)
+		}
+
+		cancelEvents := pollFDs[1].Revents
+		if cancelEvents&(unix.POLLIN|unix.POLLHUP|unix.POLLERR|unix.POLLNVAL) != 0 {
+			return nil
+		}
+	}
 }
 
 func wakeOwnerCapabilityUnsupported(err error) bool {

--- a/internal/cli/wake_owner_observation_unix.go
+++ b/internal/cli/wake_owner_observation_unix.go
@@ -2,22 +2,94 @@
 
 package cli
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var wakeOwnerObservationAlreadyDone = func() <-chan struct{} {
+	done := make(chan struct{})
+	close(done)
+	return done
+}()
+
+type wakeOwnerObservationMonitor struct {
+	done       chan struct{}
+	joined     chan struct{}
+	cancel     func() error
+	closeOnce  sync.Once
+	closeErr   error
+	monitorErr error
+}
+
+func newWakeOwnerObservationMonitor(cancel func() error) *wakeOwnerObservationMonitor {
+	return &wakeOwnerObservationMonitor{
+		done:   make(chan struct{}),
+		joined: make(chan struct{}),
+		cancel: cancel,
+	}
+}
+
+func (monitor *wakeOwnerObservationMonitor) finish(err error) {
+	monitor.monitorErr = err
+	close(monitor.done)
+	close(monitor.joined)
+}
+
+func (monitor *wakeOwnerObservationMonitor) Done() <-chan struct{} {
+	if monitor == nil {
+		return nil
+	}
+	return monitor.done
+}
+
+func (monitor *wakeOwnerObservationMonitor) Close() error {
+	if monitor == nil {
+		return nil
+	}
+	monitor.closeOnce.Do(func() {
+		var cancelErr error
+		if monitor.cancel != nil {
+			cancelErr = monitor.cancel()
+		}
+		<-monitor.joined
+		monitor.closeErr = errors.Join(cancelErr, monitor.monitorErr)
+	})
+	return monitor.closeErr
+}
 
 type wakeOwnerObservation struct {
 	State                 wakeOwnerIdentityState
 	Reason                string
 	CapabilityUnsupported bool
-	close                 func() error
+	monitor               *wakeOwnerObservationMonitor
+	done                  <-chan struct{}
+}
+
+func deadWakeOwnerObservation(reason string) wakeOwnerObservation {
+	return wakeOwnerObservation{
+		State:  wakeOwnerDead,
+		Reason: reason,
+		done:   wakeOwnerObservationAlreadyDone,
+	}
+}
+
+func (observation *wakeOwnerObservation) Done() <-chan struct{} {
+	if observation == nil {
+		return nil
+	}
+	if observation.monitor != nil {
+		return observation.monitor.Done()
+	}
+	return observation.done
 }
 
 func (observation *wakeOwnerObservation) Close() error {
-	if observation == nil || observation.close == nil {
+	if observation == nil {
 		return nil
 	}
-	closeFn := observation.close
-	observation.close = nil
-	return closeFn()
+	return observation.monitor.Close()
 }
 
 var observeAuthoritativeWakeOwner = observeAuthoritativeWakeOwnerPlatform

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -17,12 +17,15 @@ import (
 )
 
 type wakeOwnerPublicationError struct {
-	Err         error
-	Committed   bool
-	Unsupported bool
+	Err             error
+	Committed       bool
+	Unsupported     bool
+	InstalledTarget *wakeTargetSnapshot
 }
 
 var errWakeOwnerLockExists = errors.New("wake lock already exists")
+var publishAuthoritativeWakeLinkAt = unix.Linkat
+var publishAuthoritativeWakeAfterTargetRename = func() {}
 
 func (err *wakeOwnerPublicationError) Error() string {
 	return err.Err.Error()
@@ -76,13 +79,66 @@ func publishAuthoritativeWakeClaimAt(
 			_ = unix.Unlinkat(dirfd, targetTemp, 0)
 		}
 	}()
+	targetFD, err := unix.Openat(
+		dirfd,
+		targetTemp,
+		unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open authoritative wake target temp: %w", err)
+	}
+	targetFile := os.NewFile(uintptr(targetFD), targetTemp)
+	defer func() { _ = targetFile.Close() }()
+	targetInfo, err := targetFile.Stat()
+	if err != nil {
+		return fmt.Errorf("stat authoritative wake target temp: %w", err)
+	}
+	if !targetInfo.Mode().IsRegular() || targetInfo.Mode().Perm() != 0o600 {
+		return fmt.Errorf("authoritative wake target temp must be a regular 0600 file")
+	}
+	if err := validateWakeTargetPathOwnership("authoritative wake target temp", targetTemp, targetInfo); err != nil {
+		return err
+	}
+	targetRaw, err := readWakeMetadata(targetFile, "authoritative wake target temp", targetTemp)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(targetRaw, targetData) {
+		return fmt.Errorf("authoritative wake target temp changed before publication")
+	}
+	targetTempSnapshot := wakeTargetSnapshot{
+		Target:   target,
+		Raw:      bytes.Clone(targetRaw),
+		FileInfo: targetInfo,
+	}
 	if err := unix.Renameat(dirfd, targetTemp, dirfd, wakeTargetFileName); err != nil {
 		return fmt.Errorf("install authoritative wake target: %w", err)
 	}
 	targetInstalled = true
+	publishAuthoritativeWakeAfterTargetRename()
+	visibleTarget, exists, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return &wakeOwnerPublicationError{
+			Err: fmt.Errorf("installed authoritative wake target changed during publication: %w", err),
+		}
+	}
+	if !exists {
+		return &wakeOwnerPublicationError{
+			Err: fmt.Errorf("installed authoritative wake target changed during publication: target disappeared"),
+		}
+	}
+	if !os.SameFile(targetTempSnapshot.FileInfo, visibleTarget.FileInfo) ||
+		!bytes.Equal(targetTempSnapshot.Raw, visibleTarget.Raw) {
+		return &wakeOwnerPublicationError{
+			Err: fmt.Errorf("installed authoritative wake target changed during publication; preserving it"),
+		}
+	}
+	installedTarget := visibleTarget
 	if err := syncWakeOwnerDirFD(dirfd); err != nil {
 		return &wakeOwnerPublicationError{
-			Err: fmt.Errorf("sync authoritative wake target directory: %w", err),
+			Err:             fmt.Errorf("sync authoritative wake target directory: %w", err),
+			InstalledTarget: &installedTarget,
 		}
 	}
 
@@ -96,26 +152,29 @@ func publishAuthoritativeWakeClaimAt(
 			_ = unix.Unlinkat(dirfd, lockTemp, 0)
 		}
 	}()
-	if err := unix.Linkat(dirfd, lockTemp, dirfd, ".wake.lock", 0); err != nil {
+	if err := publishAuthoritativeWakeLinkAt(dirfd, lockTemp, dirfd, ".wake.lock", 0); err != nil {
 		if err == unix.EEXIST {
 			return errWakeOwnerLockExists
 		}
 		return &wakeOwnerPublicationError{
-			Err:         fmt.Errorf("publish authoritative wake lock: %w", err),
-			Unsupported: wakeOwnerStorageUnsupported(err),
+			Err:             fmt.Errorf("publish authoritative wake lock: %w", err),
+			Unsupported:     wakeOwnerStorageUnsupported(err),
+			InstalledTarget: &installedTarget,
 		}
 	}
 	if err := unix.Unlinkat(dirfd, lockTemp, 0); err != nil {
 		return &wakeOwnerPublicationError{
-			Err:       fmt.Errorf("remove authoritative wake lock temp after commit: %w", err),
-			Committed: true,
+			Err:             fmt.Errorf("remove authoritative wake lock temp after commit: %w", err),
+			Committed:       true,
+			InstalledTarget: &installedTarget,
 		}
 	}
 	lockTempPresent = false
 	if err := syncWakeOwnerDirFD(dirfd); err != nil {
 		return &wakeOwnerPublicationError{
-			Err:       fmt.Errorf("sync authoritative wake lock directory after commit: %w", err),
-			Committed: true,
+			Err:             fmt.Errorf("sync authoritative wake lock directory after commit: %w", err),
+			Committed:       true,
+			InstalledTarget: &installedTarget,
 		}
 	}
 	_ = agentDir

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -26,6 +26,7 @@ type wakeOwnerPublicationError struct {
 var errWakeOwnerLockExists = errors.New("wake lock already exists")
 var publishAuthoritativeWakeLinkAt = unix.Linkat
 var publishAuthoritativeWakeAfterTargetRename = func() {}
+var removeAuthoritativeWakeAfterLockRelease = func() {}
 
 func (err *wakeOwnerPublicationError) Error() string {
 	return err.Err.Error()
@@ -455,27 +456,62 @@ func removeAuthoritativeWakeClaimAt(
 		}
 		releaseTargetSnapshot = &currentTarget
 	}
+
+	var releasePreparedSnapshot *wakeGenerationFileSnapshot
+	var preparedSnapshotErr error
+	preparedSnapshot, preparedExists, err := readWakeGenerationFileSnapshotAt(
+		dirfd,
+		agentDir,
+		wakePreparedFileName,
+		"wake prepared marker",
+	)
+	if err != nil {
+		preparedSnapshotErr = fmt.Errorf("snapshot released wake prepared marker: %w", err)
+	} else if preparedExists &&
+		preparedSnapshot.Marker.Schema == wakeReadySchema &&
+		preparedSnapshot.Marker.Generation == current.Lock.Generation &&
+		preparedSnapshot.Marker.TargetDigest == current.Lock.TargetDigest {
+		if current.Lock.TargetDigest != "" && releaseTargetSnapshot == nil {
+			preparedSnapshotErr = fmt.Errorf(
+				"validate released wake prepared marker: authoritative wake target snapshot is unavailable",
+			)
+		} else {
+			releasePreparedSnapshot = &preparedSnapshot
+		}
+	}
+
 	if err := unix.Unlinkat(dirfd, ".wake.lock", 0); err != nil {
 		if err == unix.ENOENT {
-			return nil
+			return preparedSnapshotErr
 		}
-		return fmt.Errorf("unlink authoritative wake lock: %w", err)
+		return errors.Join(
+			preparedSnapshotErr,
+			fmt.Errorf("unlink authoritative wake lock: %w", err),
+		)
 	}
 	if err := syncWakeOwnerDirFD(dirfd); err != nil {
-		return fmt.Errorf("sync authoritative wake lock release: %w", err)
+		return errors.Join(
+			preparedSnapshotErr,
+			fmt.Errorf("sync authoritative wake lock release: %w", err),
+		)
 	}
+	removeAuthoritativeWakeAfterLockRelease()
 
 	// A replacement is never selected or cleaned. Cooperative writers cannot
 	// install one while this guard is held; this check also catches bypassers.
 	replacement, err := unix.Openat(dirfd, ".wake.lock", unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err == nil {
 		_ = unix.Close(replacement)
-		return nil
+		return preparedSnapshotErr
 	}
 	if err != unix.ENOENT {
-		return fmt.Errorf("check replacement wake lock after release: %w", err)
+		return errors.Join(
+			preparedSnapshotErr,
+			fmt.Errorf("check replacement wake lock after release: %w", err),
+		)
 	}
 
+	cleanupErr := preparedSnapshotErr
 	cleaned := false
 	if releaseTargetSnapshot != nil {
 		removed, err := removeWakeTargetIfSnapshotMatchesAt(
@@ -486,39 +522,47 @@ func removeAuthoritativeWakeClaimAt(
 			*releaseTargetSnapshot,
 		)
 		if err != nil {
-			return err
+			cleanupErr = errors.Join(cleanupErr, err)
+		} else if removed {
+			cleaned = true
 		}
-		cleaned = removed
 	}
-	if marker, exists, markerErr := readWakeGenerationFileAt(
-		dirfd,
-		agentDir,
-		wakePreparedFileName,
-		"wake prepared marker",
-	); markerErr == nil && exists && marker.Generation == expected.Lock.Generation {
-		if err := unix.Unlinkat(dirfd, wakePreparedFileName, 0); err != nil && err != unix.ENOENT {
-			return fmt.Errorf("remove released wake prepared marker: %w", err)
+	if releasePreparedSnapshot != nil {
+		_, err := removeWakeGenerationFileIfSnapshotMatchesAt(
+			dirfd,
+			agentDir,
+			wakePreparedFileName,
+			"wake prepared marker",
+			*releasePreparedSnapshot,
+		)
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
 		}
-		cleaned = true
 	}
 	if expected.Lock.ControlSocket != "" {
 		name, nameErr := darwinControlSocketBasenameForCleanup(agentDir, expected.Lock.ControlSocket)
 		if nameErr != nil {
-			return nameErr
-		}
-		if name != "" {
+			cleanupErr = errors.Join(cleanupErr, nameErr)
+		} else if name != "" {
 			if err := unix.Unlinkat(dirfd, name, 0); err != nil && err != unix.ENOENT {
-				return fmt.Errorf("remove released wake control socket: %w", err)
+				cleanupErr = errors.Join(
+					cleanupErr,
+					fmt.Errorf("remove released wake control socket: %w", err),
+				)
+			} else {
+				cleaned = true
 			}
-			cleaned = true
 		}
 	}
 	if cleaned {
 		if err := syncWakeOwnerDirFD(dirfd); err != nil {
-			return fmt.Errorf("sync authoritative wake claim cleanup: %w", err)
+			cleanupErr = errors.Join(
+				cleanupErr,
+				fmt.Errorf("sync authoritative wake claim cleanup: %w", err),
+			)
 		}
 	}
-	return nil
+	return cleanupErr
 }
 
 func removeWakeTargetIfSnapshotMatchesAt(

--- a/internal/cli/wake_prepared_cleanup_authoritative_unix_test.go
+++ b/internal/cli/wake_prepared_cleanup_authoritative_unix_test.go
@@ -1,0 +1,502 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type authoritativeWakePreparedCleanupFixture struct {
+	root           string
+	me             string
+	agentDir       *wakeAgentDir
+	target         wakeTarget
+	inspection     wakeLockInspection
+	lockPath       string
+	targetPath     string
+	preparedPath   string
+	preparedMarker wakeReady
+	preparedRaw    []byte
+}
+
+func TestAuthoritativeWakeCleanupRemovesExactPreparedMarker(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+
+	if err := fixture.release(); err != nil {
+		t.Fatal(err)
+	}
+
+	fixture.assertReleasedClaimMissing(t)
+	assertPathMissingForTest(t, fixture.preparedPath)
+	fixture.assertControlSocketMissing(t)
+}
+
+func TestAuthoritativeWakeCleanupDeadOwnerExactPreparedAllowsFirstReacquire(t *testing.T) {
+	root := secureTempDirForTest(t)
+	const me = "codex"
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, me); err != nil {
+		t.Fatal(err)
+	}
+	oldOwner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	injector := writeExecutableForTest(t, "dead-owner-prepared-cleanup-injector")
+	oldTarget := mustNewWakeTargetForTest(t, root, me, injector, nil)
+	oldTarget.Owner = &oldOwner
+	oldLock, err := newWakeLock(root, me, wakeLockAcquireOptions{
+		target:   &oldTarget,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		if err := publishAuthoritativeWakeClaimAt(
+			dirfd,
+			agentDir,
+			root,
+			me,
+			oldTarget,
+			oldLock,
+		); err != nil {
+			return err
+		}
+		return writeWakeGenerationFileAt(
+			dirfd,
+			wakePreparedFileName,
+			"wake prepared marker",
+			wakeReady{
+				Schema:       wakeReadySchema,
+				Generation:   oldLock.Generation,
+				TargetDigest: oldLock.TargetDigest,
+			},
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	inspection := inspectWakeLock(root, me)
+	if classifyPersistedWakeClaim(inspection) != wakeClaimAuthoritative {
+		t.Fatalf("old owner wake claim = %#v, want authoritative", inspection)
+	}
+
+	originalObserve := observeAuthoritativeWakeOwner
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = originalObserve })
+	observeCalls := 0
+	observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+		observeCalls++
+		return deadWakeOwnerObservation("old owner is dead"), nil
+	}
+	releaseErr := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return removeAuthoritativeWakeClaimAt(
+			dirfd,
+			agentDir,
+			inspection,
+			&oldTarget,
+		)
+	})
+	observeAuthoritativeWakeOwner = originalObserve
+	if releaseErr != nil {
+		t.Fatal(releaseErr)
+	}
+	if observeCalls != 0 {
+		t.Fatalf("authoritative release observed old owner liveness %d times", observeCalls)
+	}
+	assertPathMissingForTest(t, wakePreparedPath(root, me))
+
+	newOwner, err := captureAuthoritativeCurrentWakeOwner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	newTarget := mustNewWakeTargetForTest(t, root, me, injector, nil)
+	newTarget.Owner = &newOwner
+	cleanup, err := acquireAuthoritativeWakeLockWithOptions(
+		root,
+		me,
+		wakeLockAcquireOptions{
+			target:   &newTarget,
+			wakeMode: wakeTargetInjectVia,
+		},
+	)
+	if err != nil {
+		t.Fatalf("first reacquire after dead-owner release: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("first reacquire returned no cleanup authority")
+	}
+	reacquired := inspectWakeLock(root, me)
+	if classifyPersistedWakeClaim(reacquired) != wakeClaimAuthoritative ||
+		!sameWakeOwner(reacquired.Lock.Owner, &newOwner) {
+		t.Fatalf("first reacquired wake claim = %#v", reacquired)
+	}
+	cleanup()
+}
+
+func TestAuthoritativeWakeCleanupPreservesWrongPreparedMarker(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		change func(*wakeReady)
+	}{
+		{
+			name: "generation",
+			change: func(marker *wakeReady) {
+				marker.Generation = "wrong-generation"
+			},
+		},
+		{
+			name: "target digest",
+			change: func(marker *wakeReady) {
+				marker.TargetDigest = "sha256:" + strings.Repeat("f", 64)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+			replacement := fixture.preparedMarker
+			test.change(&replacement)
+			replacementRaw := writeAuthoritativePreparedMarkerForTest(
+				t,
+				fixture.preparedPath,
+				replacement,
+			)
+
+			if err := fixture.release(); err != nil {
+				t.Fatal(err)
+			}
+
+			fixture.assertReleasedClaimMissing(t)
+			assertFileRawForTest(t, fixture.preparedPath, replacementRaw)
+			fixture.assertControlSocketMissing(t)
+		})
+	}
+}
+
+func TestAuthoritativeWakeCleanupPreservesChangedPreparedMarker(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	replacementRaw := append([]byte(" \n"), fixture.preparedRaw...)
+	installAuthoritativeWakeCleanupInterleave(t, func() {
+		if err := os.WriteFile(fixture.preparedPath, replacementRaw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err := fixture.release()
+	if err == nil || !strings.Contains(err.Error(), "preserving") {
+		t.Fatalf("changed prepared cleanup error = %v, want preservation", err)
+	}
+	fixture.assertReleasedClaimMissing(t)
+	assertFileRawForTest(t, fixture.preparedPath, replacementRaw)
+	fixture.assertControlSocketMissing(t)
+}
+
+func TestAuthoritativeWakeCleanupPreservesNewInodePreparedReplacement(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	replacementPath := fixture.preparedPath + ".replacement"
+	if err := os.WriteFile(replacementPath, fixture.preparedRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(fixture.preparedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installAuthoritativeWakeCleanupInterleave(t, func() {
+		if err := os.Rename(replacementPath, fixture.preparedPath); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err = fixture.release()
+	if err == nil || !strings.Contains(err.Error(), "preserving") {
+		t.Fatalf("new-inode prepared cleanup error = %v, want preservation", err)
+	}
+	after, statErr := os.Stat(fixture.preparedPath)
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if os.SameFile(before, after) {
+		t.Fatal("prepared replacement unexpectedly retained the released inode")
+	}
+	fixture.assertReleasedClaimMissing(t)
+	assertFileRawForTest(t, fixture.preparedPath, fixture.preparedRaw)
+	fixture.assertControlSocketMissing(t)
+}
+
+func TestAuthoritativeWakeCleanupPreservesSameInodePreparedReplacement(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	replacement := fixture.preparedMarker
+	replacement.Generation = "same-inode-replacement"
+	replacementRaw, err := json.Marshal(replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementRaw = append(replacementRaw, '\n')
+	before, err := os.Stat(fixture.preparedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installAuthoritativeWakeCleanupInterleave(t, func() {
+		if err := os.WriteFile(fixture.preparedPath, replacementRaw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	err = fixture.release()
+	if err == nil || !strings.Contains(err.Error(), "preserving") {
+		t.Fatalf("same-inode prepared cleanup error = %v, want preservation", err)
+	}
+	after, statErr := os.Stat(fixture.preparedPath)
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("same-inode prepared mutation unexpectedly replaced its inode")
+	}
+	fixture.assertReleasedClaimMissing(t)
+	assertFileRawForTest(t, fixture.preparedPath, replacementRaw)
+	fixture.assertControlSocketMissing(t)
+}
+
+func TestAuthoritativeWakeCleanupReplacementLockPreservesPreparedAndTarget(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	replacement := fixture.inspection.Lock
+	replacement.Generation = "replacement-lock-generation"
+	replacementRaw, err := json.Marshal(replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementRaw = append(replacementRaw, '\n')
+	installAuthoritativeWakeCleanupInterleave(t, func() {
+		if err := os.WriteFile(fixture.lockPath, replacementRaw, wakeOwnerLockFileMode); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if err := fixture.release(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertFileRawForTest(t, fixture.lockPath, replacementRaw)
+	assertFileRawForTest(t, fixture.preparedPath, fixture.preparedRaw)
+	if _, err := os.Stat(fixture.targetPath); err != nil {
+		t.Fatalf("replacement lock did not preserve wake target: %v", err)
+	}
+	fixture.assertControlSocketPresent(t)
+}
+
+func TestAuthoritativeWakeCleanupInvalidPreparedStillCleansExactClaim(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	invalid := []byte("{not-json\n")
+	if err := os.WriteFile(fixture.preparedPath, invalid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := fixture.release()
+	if err == nil || !strings.Contains(err.Error(), "snapshot released wake prepared marker") {
+		t.Fatalf("invalid prepared cleanup error = %v, want snapshot error", err)
+	}
+	fixture.assertReleasedClaimMissing(t)
+	assertFileRawForTest(t, fixture.preparedPath, invalid)
+	fixture.assertControlSocketMissing(t)
+}
+
+func TestAuthoritativeWakeCleanupPreparedSyncFailureContinuesCleanup(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	originalSync := syncWakeOwnerDirFD
+	syncCalls := 0
+	syncWakeOwnerDirFD = func(int) error {
+		syncCalls++
+		if syncCalls == 2 {
+			return syscall.ENOSYS
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
+
+	err := fixture.release()
+	if err == nil || !strings.Contains(err.Error(), "sync wake prepared marker removal") {
+		t.Fatalf("prepared sync cleanup error = %v, want durability error", err)
+	}
+	if syncCalls != 3 {
+		t.Fatalf("directory sync calls = %d, want 3", syncCalls)
+	}
+	fixture.assertReleasedClaimMissing(t)
+	assertPathMissingForTest(t, fixture.preparedPath)
+	fixture.assertControlSocketMissing(t)
+}
+
+func TestAuthoritativeWakeCleanupFinalSyncFailureIsReported(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	originalSync := syncWakeOwnerDirFD
+	syncCalls := 0
+	syncWakeOwnerDirFD = func(int) error {
+		syncCalls++
+		if syncCalls == 3 {
+			return syscall.ENOSYS
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
+
+	err := fixture.release()
+	if err == nil || !strings.Contains(err.Error(), "sync authoritative wake claim cleanup") {
+		t.Fatalf("final sync cleanup error = %v, want durability error", err)
+	}
+	if syncCalls != 3 {
+		t.Fatalf("directory sync calls = %d, want 3", syncCalls)
+	}
+	fixture.assertReleasedClaimMissing(t)
+	assertPathMissingForTest(t, fixture.preparedPath)
+	fixture.assertControlSocketMissing(t)
+}
+
+func newAuthoritativeWakePreparedCleanupFixture(
+	t *testing.T,
+) *authoritativeWakePreparedCleanupFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const me = "codex"
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, me); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := captureAuthoritativeCurrentWakeOwner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "authoritative-prepared-cleanup-injector")
+	target := mustNewWakeTargetForTest(t, root, me, injector, nil)
+	target.Owner = &owner
+	lock, err := newWakeLock(root, me, wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return publishAuthoritativeWakeClaimAt(dirfd, agentDir, root, me, target, lock)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	inspection := inspectWakeLock(root, me)
+	if classifyPersistedWakeClaim(inspection) != wakeClaimAuthoritative {
+		t.Fatalf("published wake claim = %#v, want authoritative", inspection)
+	}
+	if err := writeWakePreparedFile(root, me, inspection); err != nil {
+		t.Fatal(err)
+	}
+	preparedPath := wakePreparedPath(root, me)
+	preparedRaw, err := os.ReadFile(preparedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var marker wakeReady
+	if err := json.Unmarshal(preparedRaw, &marker); err != nil {
+		t.Fatal(err)
+	}
+	if lock.ControlSocket != "" {
+		if err := os.WriteFile(lock.ControlSocket, []byte("socket"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &authoritativeWakePreparedCleanupFixture{
+		root:           root,
+		me:             me,
+		agentDir:       agentDir,
+		target:         target,
+		inspection:     inspection,
+		lockPath:       filepath.Join(fsq.AgentBase(root, me), ".wake.lock"),
+		targetPath:     wakeTargetPath(root, me),
+		preparedPath:   preparedPath,
+		preparedMarker: marker,
+		preparedRaw:    preparedRaw,
+	}
+}
+
+func (fixture *authoritativeWakePreparedCleanupFixture) release() error {
+	return withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return removeAuthoritativeWakeClaimAt(
+			dirfd,
+			fixture.agentDir,
+			fixture.inspection,
+			&fixture.target,
+		)
+	})
+}
+
+func (fixture *authoritativeWakePreparedCleanupFixture) assertReleasedClaimMissing(t *testing.T) {
+	t.Helper()
+	assertPathMissingForTest(t, fixture.lockPath)
+	assertPathMissingForTest(t, fixture.targetPath)
+}
+
+func (fixture *authoritativeWakePreparedCleanupFixture) assertControlSocketMissing(t *testing.T) {
+	t.Helper()
+	if path := fixture.inspection.Lock.ControlSocket; path != "" {
+		assertPathMissingForTest(t, path)
+	}
+}
+
+func (fixture *authoritativeWakePreparedCleanupFixture) assertControlSocketPresent(t *testing.T) {
+	t.Helper()
+	if path := fixture.inspection.Lock.ControlSocket; path != "" {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("replacement lock did not preserve control socket: %v", err)
+		}
+	}
+}
+
+func installAuthoritativeWakeCleanupInterleave(t *testing.T, fn func()) {
+	t.Helper()
+	original := removeAuthoritativeWakeAfterLockRelease
+	removeAuthoritativeWakeAfterLockRelease = fn
+	t.Cleanup(func() { removeAuthoritativeWakeAfterLockRelease = original })
+}
+
+func writeAuthoritativePreparedMarkerForTest(
+	t *testing.T,
+	path string,
+	marker wakeReady,
+) []byte {
+	t.Helper()
+	data, err := json.Marshal(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func assertPathMissingForTest(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("%s stat error = %v, want not exist", path, err)
+	}
+}

--- a/internal/cli/wake_prepared_cleanup_generic_unix_test.go
+++ b/internal/cli/wake_prepared_cleanup_generic_unix_test.go
@@ -1,0 +1,476 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type genericWakePreparedCleanupFixture struct {
+	root           string
+	me             string
+	agentDir       *wakeAgentDir
+	created        wakeLockInspection
+	options        wakeLockAcquireOptions
+	target         *wakeTarget
+	preparedPath   string
+	preparedMarker wakeReady
+	preparedRaw    []byte
+}
+
+func TestGenericWakeCleanupRemovesOwnPreparedMarker(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, false)
+	if err := fixture.cleanupNow(); err != nil {
+		t.Fatal(err)
+	}
+	fixture.assertLockMissing(t)
+	if _, err := os.Stat(fixture.preparedPath); !os.IsNotExist(err) {
+		t.Fatalf("own prepared marker survived cleanup: %v", err)
+	}
+}
+
+func TestGenericWakeCleanupMissingAndWrongGenerationPreparedAreSafe(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		fixture := newGenericWakePreparedCleanupFixture(t, false)
+		if err := os.Remove(fixture.preparedPath); err != nil {
+			t.Fatal(err)
+		}
+		if err := fixture.cleanupNow(); err != nil {
+			t.Fatal(err)
+		}
+		fixture.assertLockMissing(t)
+		if _, err := os.Stat(fixture.preparedPath); !os.IsNotExist(err) {
+			t.Fatalf("missing prepared marker was recreated: %v", err)
+		}
+	})
+
+	t.Run("wrong generation", func(t *testing.T) {
+		fixture := newGenericWakePreparedCleanupFixture(t, false)
+		replacement := fixture.preparedMarker
+		replacement.Generation = "replacement-generation"
+		replacementRaw := writeGenericPreparedMarkerForTest(
+			t,
+			fixture.preparedPath,
+			replacement,
+		)
+		if err := fixture.cleanupNow(); err != nil {
+			t.Fatal(err)
+		}
+		fixture.assertLockMissing(t)
+		assertFileRawForTest(t, fixture.preparedPath, replacementRaw)
+	})
+}
+
+func TestGenericWakeCleanupInvalidPreparedStillRemovesExactLock(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, false)
+	invalid := []byte("{not-json\n")
+	if err := os.WriteFile(fixture.preparedPath, invalid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := fixture.cleanupNow()
+	if err == nil || !strings.Contains(err.Error(), "snapshot wake prepared marker") {
+		t.Fatalf("invalid prepared cleanup error = %v, want snapshot error", err)
+	}
+	fixture.assertLockMissing(t)
+	assertFileRawForTest(t, fixture.preparedPath, invalid)
+}
+
+func TestGenericWakeCleanupAlwaysSyncsExactLockRemoval(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *genericWakePreparedCleanupFixture)
+	}{
+		{
+			name: "missing prepared",
+			mutate: func(t *testing.T, fixture *genericWakePreparedCleanupFixture) {
+				t.Helper()
+				if err := os.Remove(fixture.preparedPath); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "wrong generation prepared",
+			mutate: func(t *testing.T, fixture *genericWakePreparedCleanupFixture) {
+				t.Helper()
+				replacement := fixture.preparedMarker
+				replacement.Generation = "replacement-generation"
+				writeGenericPreparedMarkerForTest(t, fixture.preparedPath, replacement)
+			},
+		},
+		{
+			name: "malformed prepared",
+			mutate: func(t *testing.T, fixture *genericWakePreparedCleanupFixture) {
+				t.Helper()
+				if err := os.WriteFile(fixture.preparedPath, []byte("{not-json\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newGenericWakePreparedCleanupFixture(t, false)
+			test.mutate(t, fixture)
+			syncCalls := installGenericWakeCleanupDirSync(t, nil)
+
+			err := fixture.cleanupNow()
+			if test.name == "malformed prepared" {
+				if err == nil || !strings.Contains(err.Error(), "snapshot wake prepared marker") {
+					t.Fatalf("malformed prepared cleanup error = %v, want snapshot error", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if *syncCalls != 1 {
+				t.Fatalf("directory sync calls = %d, want exact lock-removal sync", *syncCalls)
+			}
+			fixture.assertLockMissing(t)
+		})
+	}
+}
+
+func TestGenericWakeCleanupLockSyncFailureContinuesPreparedAndFloorCleanup(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, true)
+	floor, err := newWakeRepairFloor(
+		fixture.root,
+		fixture.me,
+		fixture.created.Lock,
+		*fixture.target,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWakeRepairFloor(fixture.root, fixture.me, floor); err != nil {
+		t.Fatal(err)
+	}
+	syncCalls := installGenericWakeCleanupDirSync(t, func(call int) error {
+		if call == 1 {
+			return syscall.ENOSYS
+		}
+		return nil
+	})
+
+	err = fixture.cleanupNow()
+	if err == nil || !strings.Contains(err.Error(), "sync exact generic wake lock removal") {
+		t.Fatalf("lock sync cleanup error = %v, want durability error", err)
+	}
+	if *syncCalls != 3 {
+		t.Fatalf("directory sync calls = %d, want lock, prepared, and floor syncs", *syncCalls)
+	}
+	fixture.assertLockMissing(t)
+	assertPathMissingForTest(t, fixture.preparedPath)
+	assertPathMissingForTest(t, wakeRepairFloorPath(fixture.root, fixture.me))
+}
+
+func TestGenericWakeCleanupPreservesPreparedMarkerMutations(t *testing.T) {
+	t.Run("new inode", func(t *testing.T) {
+		fixture := newGenericWakePreparedCleanupFixture(t, false)
+		replacementPath := fixture.preparedPath + ".replacement"
+		if err := os.WriteFile(replacementPath, fixture.preparedRaw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		installGenericWakeCleanupInterleave(t, func(int, *wakeAgentDir) error {
+			return os.Rename(replacementPath, fixture.preparedPath)
+		})
+
+		err := fixture.cleanupNow()
+		if err == nil || !strings.Contains(err.Error(), "preserving") {
+			t.Fatalf("new-inode prepared cleanup error = %v, want preservation", err)
+		}
+		fixture.assertLockMissing(t)
+		assertFileRawForTest(t, fixture.preparedPath, fixture.preparedRaw)
+	})
+
+	t.Run("same inode raw mutation", func(t *testing.T) {
+		fixture := newGenericWakePreparedCleanupFixture(t, false)
+		before, err := os.Stat(fixture.preparedPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		replacement := fixture.preparedMarker
+		replacement.Generation = "same-inode-replacement"
+		replacementRaw, err := json.Marshal(replacement)
+		if err != nil {
+			t.Fatal(err)
+		}
+		replacementRaw = append(replacementRaw, '\n')
+		installGenericWakeCleanupInterleave(t, func(int, *wakeAgentDir) error {
+			return os.WriteFile(fixture.preparedPath, replacementRaw, 0o600)
+		})
+
+		err = fixture.cleanupNow()
+		if err == nil || !strings.Contains(err.Error(), "preserving") {
+			t.Fatalf("same-inode prepared cleanup error = %v, want preservation", err)
+		}
+		fixture.assertLockMissing(t)
+		after, err := os.Stat(fixture.preparedPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !os.SameFile(before, after) {
+			t.Fatal("same-inode mutation unexpectedly replaced the marker inode")
+		}
+		assertFileRawForTest(t, fixture.preparedPath, replacementRaw)
+	})
+}
+
+func TestGenericWakeCleanupReplacementLockPreservesReplacementAndCleansOldFloor(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, true)
+	floor, err := newWakeRepairFloor(
+		fixture.root,
+		fixture.me,
+		fixture.created.Lock,
+		*fixture.target,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWakeRepairFloor(fixture.root, fixture.me, floor); err != nil {
+		t.Fatal(err)
+	}
+
+	replacementLock := fixture.created.Lock
+	replacementLock.Generation = "replacement-lock-generation"
+	replacementLock.Started = time.Now().UTC().Format(time.RFC3339)
+	replacementLockRaw, err := json.Marshal(replacementLock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementLockRaw = append(replacementLockRaw, '\n')
+	replacementMarker := fixture.preparedMarker
+	replacementMarker.Generation = replacementLock.Generation
+	replacementMarkerRaw, err := json.Marshal(replacementMarker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementMarkerRaw = append(replacementMarkerRaw, '\n')
+	lockPath := filepath.Join(fsq.AgentBase(fixture.root, fixture.me), ".wake.lock")
+	installGenericWakeCleanupInterleave(t, func(int, *wakeAgentDir) error {
+		if err := os.WriteFile(lockPath, replacementLockRaw, 0o600); err != nil {
+			return err
+		}
+		replacementPath := fixture.preparedPath + ".replacement"
+		if err := os.WriteFile(replacementPath, replacementMarkerRaw, 0o600); err != nil {
+			return err
+		}
+		return os.Rename(replacementPath, fixture.preparedPath)
+	})
+
+	err = fixture.cleanupNow()
+	if err == nil || !strings.Contains(err.Error(), "replacement wake lock appeared") {
+		t.Fatalf("replacement cleanup error = %v, want replacement preservation", err)
+	}
+	assertFileRawForTest(t, lockPath, replacementLockRaw)
+	assertFileRawForTest(t, fixture.preparedPath, replacementMarkerRaw)
+	if _, err := os.Stat(wakeRepairFloorPath(fixture.root, fixture.me)); !os.IsNotExist(err) {
+		t.Fatalf("old exact repair floor survived replacement interleaving: %v", err)
+	}
+}
+
+func TestGenericWakeCleanupAcceptExistingNeverAcquiresCleanupAuthority(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, false)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != os.Getpid() {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: fixture.created.Lock.ProcessStart,
+			BootID:     fixture.created.Lock.BootID,
+			Executable: "amq",
+			Args: []string{
+				"amq",
+				"wake",
+				"--root", fixture.root,
+				"--me", fixture.me,
+			},
+		}
+	})
+
+	reusedCleanup, err := acquireWakeLockWithOptions(
+		fixture.root,
+		fixture.me,
+		wakeLockAcquireOptions{
+			acceptExistingValid: true,
+			wakeMode:            fixture.created.Lock.WakeMode,
+		},
+	)
+	var alreadyRunning *wakeAlreadyRunningError
+	if !errors.As(err, &alreadyRunning) {
+		t.Fatalf("accept-existing result = %v, want already running", err)
+	}
+	if reusedCleanup != nil {
+		t.Fatal("accept-existing caller received cleanup authority")
+	}
+	current := inspectWakeLock(fixture.root, fixture.me)
+	if !sameWakeLockGeneration(fixture.created, current) {
+		t.Fatalf("accept-existing changed wake lock: before=%#v after=%#v", fixture.created, current)
+	}
+	assertFileRawForTest(t, fixture.preparedPath, fixture.preparedRaw)
+
+	if err := fixture.cleanupNow(); err != nil {
+		t.Fatal(err)
+	}
+	fixture.assertLockMissing(t)
+	if _, err := os.Stat(fixture.preparedPath); !os.IsNotExist(err) {
+		t.Fatalf("own cleanup left prepared marker after accept-existing refusal: %v", err)
+	}
+}
+
+func newGenericWakePreparedCleanupFixture(
+	t *testing.T,
+	withTarget bool,
+) *genericWakePreparedCleanupFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const me = "codex"
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, me); err != nil {
+		t.Fatal(err)
+	}
+	options := wakeLockAcquireOptions{wakeMode: wakeInjectModeNone}
+	var target *wakeTarget
+	if withTarget {
+		injectorPath := filepath.Join(root, "test-injector")
+		if err := os.WriteFile(injectorPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		value, err := newWakeTarget(root, me, injectorPath, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		target = &value
+		options.target = target
+	}
+	fallbackCleanup, err := acquireWakeLockWithOptions(root, me, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(fallbackCleanup)
+	created := inspectWakeLock(root, me)
+	if !created.Exists || created.Lock.Generation == "" {
+		t.Fatalf("created wake lock = %#v", created)
+	}
+	if err := writeWakePreparedFile(root, me, created); err != nil {
+		t.Fatal(err)
+	}
+	preparedPath := wakePreparedPath(root, me)
+	preparedRaw, err := os.ReadFile(preparedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var marker wakeReady
+	if err := json.Unmarshal(preparedRaw, &marker); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	return &genericWakePreparedCleanupFixture{
+		root:           root,
+		me:             me,
+		agentDir:       agentDir,
+		created:        created,
+		options:        options,
+		target:         target,
+		preparedPath:   preparedPath,
+		preparedMarker: marker,
+		preparedRaw:    preparedRaw,
+	}
+}
+
+func (fixture *genericWakePreparedCleanupFixture) cleanupNow() error {
+	return withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return cleanupGenericWakeGenerationAt(
+			dirfd,
+			fixture.agentDir,
+			fixture.root,
+			fixture.me,
+			fixture.created,
+			fixture.options,
+		)
+	})
+}
+
+func (fixture *genericWakePreparedCleanupFixture) assertLockMissing(t *testing.T) {
+	t.Helper()
+	lockPath := filepath.Join(fsq.AgentBase(fixture.root, fixture.me), ".wake.lock")
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("exact generic wake lock survived cleanup: %v", err)
+	}
+}
+
+func installGenericWakeCleanupInterleave(
+	t *testing.T,
+	fn func(int, *wakeAgentDir) error,
+) {
+	t.Helper()
+	original := afterGenericWakeLockRemoval
+	afterGenericWakeLockRemoval = fn
+	t.Cleanup(func() { afterGenericWakeLockRemoval = original })
+}
+
+func installGenericWakeCleanupDirSync(
+	t *testing.T,
+	fail func(call int) error,
+) *int {
+	t.Helper()
+	original := syncWakeOwnerDirFD
+	calls := 0
+	syncWakeOwnerDirFD = func(int) error {
+		calls++
+		if fail != nil {
+			return fail(calls)
+		}
+		return nil
+	}
+	t.Cleanup(func() { syncWakeOwnerDirFD = original })
+	return &calls
+}
+
+func writeGenericPreparedMarkerForTest(
+	t *testing.T,
+	path string,
+	marker wakeReady,
+) []byte {
+	t.Helper()
+	data, err := json.Marshal(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func assertFileRawForTest(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("%s raw = %q, want %q", path, got, want)
+	}
+}

--- a/internal/cli/wake_prepared_unix.go
+++ b/internal/cli/wake_prepared_unix.go
@@ -15,6 +15,7 @@ const wakePreparedFileName = ".wake.prepared"
 const wakePreparedPollInterval = 25 * time.Millisecond
 
 var waitForWakePreparedRetry = sleepUntilWakePreparedRetry
+var afterGenericWakeLockRemoval = func(int, *wakeAgentDir) error { return nil }
 
 func wakePreparedPath(root, me string) string {
 	return filepath.Join(fsq.AgentBase(root, me), wakePreparedFileName)
@@ -50,10 +51,40 @@ func writeWakePreparedFileInDir(
 		if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, marker); err != nil {
 			return err
 		}
-		// The marker intentionally persists after exit; its generation binding
-		// makes stale files unusable by later wake instances.
 		return writeWakeGenerationFileAt(dirfd, wakePreparedFileName, "wake prepared marker", marker)
 	})
+}
+
+func freezeGenericWakePreparedCleanupAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	current wakeLockInspection,
+) (*wakeGenerationFileSnapshot, error) {
+	snapshot, exists, err := readWakeGenerationFileSnapshotAt(
+		dirfd,
+		agentDir,
+		wakePreparedFileName,
+		"wake prepared marker",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot wake prepared marker before cleanup: %w", err)
+	}
+	if !exists || snapshot.Marker.Generation != current.Lock.Generation {
+		return nil, nil
+	}
+	if err := validateWakeReadyLockAndTargetAt(
+		dirfd,
+		agentDir,
+		root,
+		me,
+		current,
+		snapshot.Marker,
+	); err != nil {
+		return nil, fmt.Errorf("validate wake prepared marker before cleanup: %w", err)
+	}
+	return &snapshot, nil
 }
 
 func validateWakePreparedFileAgainstInspection(root, me string, current wakeLockInspection) (bool, error) {

--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -17,6 +17,16 @@ type wakeReady struct {
 }
 
 func writeWakeReadyFile(root, me, path string, expected wakeLockInspection) error {
+	return writeWakeReadyFileAgainstOwner(root, me, path, expected, nil)
+}
+
+func writeWakeReadyFileAgainstOwner(
+	root string,
+	me string,
+	path string,
+	expected wakeLockInspection,
+	requestedOwner *wakeOwner,
+) error {
 	if path == "" {
 		return nil
 	}
@@ -36,6 +46,9 @@ func writeWakeReadyFile(root, me, path string, expected wakeLockInspection) erro
 			TargetDigest: current.Lock.TargetDigest,
 		}
 		if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, ready); err != nil {
+			return err
+		}
+		if err := validateRequestedWakeOwnerForReadiness(current, requestedOwner); err != nil {
 			return err
 		}
 		return writeWakeGenerationFile(path, "wake ready file", ready)
@@ -177,14 +190,40 @@ func validateWakeReadyTargetAndOwner(current wakeLockInspection, target wakeTarg
 		return err
 	}
 	if current.Lock.WakeMode == wakeOwnerWakeMode {
-		observation, err := observeAuthoritativeWakeOwner(*current.Lock.Owner)
-		defer func() { _ = observation.Close() }()
+		observation, err := observeLiveWakeOwner(
+			*current.Lock.Owner,
+			"inspect persisted wake owner during readiness validation",
+		)
 		if err != nil {
-			return fmt.Errorf("inspect wake owner during readiness validation: %w", err)
+			return err
 		}
-		if observation.State != wakeOwnerSame {
-			return fmt.Errorf("wake owner is %s during readiness validation: %s", observation.State, observation.Reason)
+		if closeErr := observation.Close(); closeErr != nil {
+			return fmt.Errorf("close persisted wake owner readiness observation: %w", closeErr)
 		}
+	}
+	return nil
+}
+
+func validateRequestedWakeOwnerForReadiness(
+	current wakeLockInspection,
+	requestedOwner *wakeOwner,
+) error {
+	if requestedOwner == nil {
+		return nil
+	}
+	if current.Lock.WakeMode == wakeOwnerWakeMode &&
+		!sameWakeOwner(current.Lock.Owner, requestedOwner) {
+		return fmt.Errorf("wake readiness owner does not match the requested owner")
+	}
+	observation, err := observeLiveWakeOwner(
+		*requestedOwner,
+		"inspect requested wake owner immediately before readiness",
+	)
+	if err != nil {
+		return err
+	}
+	if closeErr := observation.Close(); closeErr != nil {
+		return fmt.Errorf("close requested wake owner readiness observation: %w", closeErr)
 	}
 	return nil
 }
@@ -212,10 +251,8 @@ func validateWakeReadyFileAgainstOwner(
 		if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, published); err != nil {
 			return err
 		}
-		if requestedOwner != nil &&
-			current.Lock.WakeMode == wakeOwnerWakeMode &&
-			!sameWakeOwner(current.Lock.Owner, requestedOwner) {
-			return fmt.Errorf("wake readiness owner does not match the requested owner")
+		if err := validateRequestedWakeOwnerForReadiness(current, requestedOwner); err != nil {
+			return err
 		}
 		ready = true
 		return nil

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -1519,7 +1519,7 @@ func TestRunWakeRepairClearsRepairAvailableAfterStartFailure(t *testing.T) {
 func TestBuildCoopWakeArgsIncludesInjectViaTarget(t *testing.T) {
 	args := buildCoopWakeArgs("codex", "/tmp/root", wakeInjectModeAuto, "/abs/injector", []string{"exec", "target"}, "/tmp/ready")
 	got := strings.Join(args, "|")
-	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready|--accept-existing-wake"
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--interrupt-cmd|none|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready|--accept-existing-wake"
 	if got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}

--- a/internal/cli/wake_terminal_authority_unix.go
+++ b/internal/cli/wake_terminal_authority_unix.go
@@ -1,0 +1,262 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+type wakeTerminalAuthorityLossKind uint8
+
+const (
+	wakeTerminalAuthorityLossUnknown wakeTerminalAuthorityLossKind = iota
+	wakeTerminalAuthorityLossControlStopped
+)
+
+type wakeTerminalAuthorityLossError struct {
+	Kind   wakeTerminalAuthorityLossKind
+	Reason string
+	Err    error
+}
+
+func (err *wakeTerminalAuthorityLossError) Error() string {
+	if err.Err != nil {
+		return fmt.Sprintf("wake terminal authority lost: %s: %v", err.Reason, err.Err)
+	}
+	return "wake terminal authority lost: " + err.Reason
+}
+
+func (err *wakeTerminalAuthorityLossError) Unwrap() error {
+	return err.Err
+}
+
+func isWakeTerminalAuthorityLoss(err error) bool {
+	var loss *wakeTerminalAuthorityLossError
+	return errors.As(err, &loss)
+}
+
+func isWakeTerminalControlStopped(err error) bool {
+	var loss *wakeTerminalAuthorityLossError
+	return errors.As(err, &loss) &&
+		loss.Kind == wakeTerminalAuthorityLossControlStopped
+}
+
+var (
+	openWakeControllingTerminal = func() (*os.File, error) {
+		fd, err := unix.Open(
+			"/dev/tty",
+			unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC,
+			0,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(uintptr(fd), "/dev/tty"), nil
+	}
+	wakeTerminalForegroundPGRP = func(fd uintptr) (int, error) {
+		return unix.IoctlGetInt(int(fd), unix.TIOCGPGRP)
+	}
+	inspectWakeTerminalGeneration = inspectWakeLock
+	injectWakeTerminalFD          = func(fd uintptr, text string) error {
+		return tiocsti.InjectFD(fd, text)
+	}
+	bindWakeTerminalAuthorityForWake = bindWakeTerminalAuthority
+)
+
+type wakeTerminalAuthority struct {
+	mu sync.Mutex
+
+	tty            *os.File
+	fd             uintptr
+	identity       wakeFileIdentity
+	foregroundPGRP int
+	generation     wakeLockInspection
+	controlStop    <-chan struct{}
+	closed         bool
+}
+
+func bindWakeTerminalAuthority(
+	generation wakeLockInspection,
+	controlStop <-chan struct{},
+) (*wakeTerminalAuthority, error) {
+	if controlStop == nil {
+		return nil, newWakeTerminalAuthorityLoss("control-stop capability is missing", nil)
+	}
+	select {
+	case <-controlStop:
+		return nil, newWakeTerminalAuthorityLoss("control-stop capability is already closed", nil)
+	default:
+	}
+	if !generation.Exists ||
+		generation.fileInfo == nil ||
+		generation.Lock.Generation == "" ||
+		generation.Root == "" ||
+		generation.Agent == "" {
+		return nil, newWakeTerminalAuthorityLoss("exact wake generation is unavailable", nil)
+	}
+	current := inspectWakeTerminalGeneration(generation.Root, generation.Agent)
+	if !sameWakeLockGeneration(generation, current) {
+		return nil, newWakeTerminalAuthorityLoss("wake generation changed before terminal binding", nil)
+	}
+
+	tty, err := openWakeControllingTerminal()
+	if err != nil {
+		return nil, newWakeTerminalAuthorityLoss("open controlling terminal", err)
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			_ = tty.Close()
+		}
+	}()
+
+	info, err := tty.Stat()
+	if err != nil {
+		return nil, newWakeTerminalAuthorityLoss("inspect retained controlling terminal", err)
+	}
+	identity, ok := captureWakeFileIdentity(info)
+	if !ok {
+		return nil, newWakeTerminalAuthorityLoss("capture retained controlling-terminal identity", nil)
+	}
+	fd := tty.Fd()
+	foregroundPGRP, err := wakeTerminalForegroundPGRP(fd)
+	if err != nil {
+		return nil, newWakeTerminalAuthorityLoss("inspect controlling-terminal foreground process group", err)
+	}
+	if foregroundPGRP <= 0 {
+		return nil, newWakeTerminalAuthorityLoss("controlling-terminal foreground process group is invalid", nil)
+	}
+
+	keep = true
+	return &wakeTerminalAuthority{
+		tty:            tty,
+		fd:             fd,
+		identity:       identity,
+		foregroundPGRP: foregroundPGRP,
+		generation:     generation,
+		controlStop:    controlStop,
+	}, nil
+}
+
+func (authority *wakeTerminalAuthority) BeforeWrite() error {
+	if authority == nil {
+		return newWakeTerminalAuthorityLoss("terminal capability is missing", nil)
+	}
+	authority.mu.Lock()
+	defer authority.mu.Unlock()
+	return authority.validateLocked()
+}
+
+func (authority *wakeTerminalAuthority) Inject(text string) error {
+	if authority == nil {
+		return newWakeTerminalAuthorityLoss("terminal capability is missing", nil)
+	}
+	authority.mu.Lock()
+	defer authority.mu.Unlock()
+	if err := authority.validateLocked(); err != nil {
+		return err
+	}
+	if err := injectWakeTerminalFD(authority.fd, text); err != nil {
+		return newWakeTerminalAuthorityLoss("inject through retained controlling terminal", err)
+	}
+	return nil
+}
+
+func (authority *wakeTerminalAuthority) validateLocked() error {
+	if authority.closed || authority.tty == nil {
+		return newWakeTerminalAuthorityLoss("retained controlling terminal is closed", nil)
+	}
+	select {
+	case <-authority.controlStop:
+		return newWakeTerminalControlStoppedLoss()
+	default:
+	}
+
+	currentGeneration := inspectWakeTerminalGeneration(
+		authority.generation.Root,
+		authority.generation.Agent,
+	)
+	if !sameWakeLockGeneration(authority.generation, currentGeneration) {
+		return newWakeTerminalAuthorityLoss("wake generation changed", nil)
+	}
+	if authority.tty.Fd() != authority.fd {
+		return newWakeTerminalAuthorityLoss("retained controlling-terminal descriptor changed", nil)
+	}
+	retainedInfo, err := authority.tty.Stat()
+	if err != nil {
+		return newWakeTerminalAuthorityLoss("inspect retained controlling terminal", err)
+	}
+	if !matchesWakeFileIdentity(authority.identity, retainedInfo) {
+		return newWakeTerminalAuthorityLoss("retained controlling-terminal identity changed", nil)
+	}
+
+	currentTTY, err := openWakeControllingTerminal()
+	if err != nil {
+		return newWakeTerminalAuthorityLoss("re-open current controlling terminal", err)
+	}
+	currentInfo, statErr := currentTTY.Stat()
+	closeErr := currentTTY.Close()
+	if statErr != nil {
+		return newWakeTerminalAuthorityLoss("inspect current controlling terminal", statErr)
+	}
+	if closeErr != nil {
+		return newWakeTerminalAuthorityLoss("close current controlling-terminal check", closeErr)
+	}
+	if !matchesWakeFileIdentity(authority.identity, currentInfo) {
+		return newWakeTerminalAuthorityLoss("current controlling-terminal identity changed", nil)
+	}
+
+	foregroundPGRP, err := wakeTerminalForegroundPGRP(authority.fd)
+	if err != nil {
+		return newWakeTerminalAuthorityLoss("recheck controlling-terminal foreground process group", err)
+	}
+	if foregroundPGRP != authority.foregroundPGRP {
+		return newWakeTerminalAuthorityLoss(
+			fmt.Sprintf(
+				"controlling-terminal foreground process group changed from %d to %d",
+				authority.foregroundPGRP,
+				foregroundPGRP,
+			),
+			nil,
+		)
+	}
+	return nil
+}
+
+func (authority *wakeTerminalAuthority) Close() error {
+	if authority == nil {
+		return nil
+	}
+	authority.mu.Lock()
+	defer authority.mu.Unlock()
+	if authority.closed {
+		return nil
+	}
+	authority.closed = true
+	if authority.tty == nil {
+		return nil
+	}
+	err := authority.tty.Close()
+	authority.tty = nil
+	return err
+}
+
+func newWakeTerminalAuthorityLoss(reason string, err error) error {
+	return &wakeTerminalAuthorityLossError{
+		Kind:   wakeTerminalAuthorityLossUnknown,
+		Reason: reason,
+		Err:    err,
+	}
+}
+
+func newWakeTerminalControlStoppedLoss() error {
+	return &wakeTerminalAuthorityLossError{
+		Kind:   wakeTerminalAuthorityLossControlStopped,
+		Reason: "wake control stopped",
+	}
+}

--- a/internal/cli/wake_terminal_authority_unix_test.go
+++ b/internal/cli/wake_terminal_authority_unix_test.go
@@ -1,0 +1,387 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+)
+
+type wakeTerminalInjection struct {
+	fd   uintptr
+	text string
+}
+
+type wakeTerminalAuthorityFixture struct {
+	generation     wakeLockInspection
+	current        wakeLockInspection
+	currentTTYPath string
+	foregroundPGRP int
+	injections     []wakeTerminalInjection
+}
+
+func TestWakeTerminalAuthorityInjectsThroughRetainedFD(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	stop := make(chan struct{})
+	authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retainedFD := authority.fd
+	t.Cleanup(func() { _ = authority.Close() })
+
+	if err := authority.BeforeWrite(); err != nil {
+		t.Fatalf("validate retained terminal authority: %v", err)
+	}
+	if err := authority.Inject("doorbell"); err != nil {
+		t.Fatalf("inject through retained terminal authority: %v", err)
+	}
+	if len(fixture.injections) != 1 ||
+		fixture.injections[0].fd != retainedFD ||
+		fixture.injections[0].text != "doorbell" {
+		t.Fatalf("retained-fd injections = %#v, want fd=%d text=doorbell", fixture.injections, retainedFD)
+	}
+	if err := authority.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := authority.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+}
+
+func TestWakeTerminalAuthorityRefusesSamePathForegroundPGRPHandoff(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+
+	fixture.foregroundPGRP++
+	err = authority.Inject("must-not-arrive")
+	if !isWakeTerminalAuthorityLoss(err) ||
+		!strings.Contains(err.Error(), "foreground process group changed") {
+		t.Fatalf("same-path foreground-pgrp handoff error = %v", err)
+	}
+	if len(fixture.injections) != 0 {
+		t.Fatalf("same-path foreground-pgrp handoff injected: %#v", fixture.injections)
+	}
+}
+
+func TestWakeTerminalAuthorityRefusesChangedRetainedFDIdentity(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+
+	replacementPath := filepath.Join(t.TempDir(), "replacement-tty")
+	if err := os.WriteFile(replacementPath, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := authority.tty.Close(); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := os.OpenFile(replacementPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority.tty = replacement
+	fixture.currentTTYPath = replacementPath
+
+	err = authority.Inject("must-not-arrive")
+	if !isWakeTerminalAuthorityLoss(err) ||
+		(!strings.Contains(err.Error(), "descriptor changed") &&
+			!strings.Contains(err.Error(), "identity changed")) {
+		t.Fatalf("changed retained-fd identity error = %v", err)
+	}
+	if len(fixture.injections) != 0 {
+		t.Fatalf("changed retained-fd identity injected: %#v", fixture.injections)
+	}
+}
+
+func TestWakeTerminalAuthorityRefusesChangedCurrentTTYIdentity(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+
+	replacementPath := filepath.Join(t.TempDir(), "replacement-current-tty")
+	if err := os.WriteFile(replacementPath, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture.currentTTYPath = replacementPath
+
+	err = authority.Inject("must-not-arrive")
+	if !isWakeTerminalAuthorityLoss(err) ||
+		!strings.Contains(err.Error(), "current controlling-terminal identity changed") {
+		t.Fatalf("changed current tty identity error = %v", err)
+	}
+	if len(fixture.injections) != 0 {
+		t.Fatalf("changed current tty identity injected: %#v", fixture.injections)
+	}
+}
+
+func TestWakeTerminalAuthorityRefusesChangedGenerationAndStoppedControl(t *testing.T) {
+	t.Run("generation", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = authority.Close() })
+
+		fixture.current.Lock.Generation = "replacement-generation"
+		err = authority.Inject("must-not-arrive")
+		if !isWakeTerminalAuthorityLoss(err) ||
+			!strings.Contains(err.Error(), "wake generation changed") {
+			t.Fatalf("changed generation error = %v", err)
+		}
+		if len(fixture.injections) != 0 {
+			t.Fatalf("changed generation injected: %#v", fixture.injections)
+		}
+	})
+
+	t.Run("control stopped", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		stop := make(chan struct{})
+		authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = authority.Close() })
+
+		close(stop)
+		err = authority.Inject("must-not-arrive")
+		var loss *wakeTerminalAuthorityLossError
+		if !errors.As(err, &loss) || !strings.Contains(loss.Reason, "control stopped") {
+			t.Fatalf("closed control-stop error = %v", err)
+		}
+		if len(fixture.injections) != 0 {
+			t.Fatalf("closed control-stop injected: %#v", fixture.injections)
+		}
+	})
+}
+
+func TestWakeTerminalControlStoppedClassificationIsStructural(t *testing.T) {
+	stopped := newWakeTerminalControlStoppedLoss()
+	if !isWakeTerminalControlStopped(stopped) {
+		t.Fatalf("typed stopped-control loss was not classified: %v", stopped)
+	}
+
+	sameReasonOnly := newWakeTerminalAuthorityLoss("wake control stopped", nil)
+	if isWakeTerminalControlStopped(sameReasonOnly) {
+		t.Fatalf("reason-only authority loss was classified as stopped control: %v", sameReasonOnly)
+	}
+	if !isWakeTerminalAuthorityLoss(sameReasonOnly) {
+		t.Fatalf("reason-only loss stopped being an authority loss: %v", sameReasonOnly)
+	}
+}
+
+func TestWakeTerminalAuthorityStopClosingAtWriteBoundariesIsNonfatal(t *testing.T) {
+	oldWait := waitForRawInputDrained
+	oldSleep := rawInjectSleep
+	waitForRawInputDrained = func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	}
+	rawInjectSleep = func(time.Duration) {}
+	t.Cleanup(func() {
+		waitForRawInputDrained = oldWait
+		rawInjectSleep = oldSleep
+	})
+
+	t.Run("between outer stop check and before-write validation", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		stop := make(chan struct{})
+		authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = authority.Close() })
+
+		beforeCalls := 0
+		err = injectNotification(&wakeConfig{
+			me:          "codex",
+			injectMode:  wakeInjectModeRaw,
+			controlStop: stop,
+			beforeTerminalWrite: func() error {
+				beforeCalls++
+				close(stop)
+				return authority.BeforeWrite()
+			},
+			terminalWrite: authority.Inject,
+		}, "dynamic", false)
+		if err != nil {
+			t.Fatalf("stop before retained validation: %v", err)
+		}
+		if beforeCalls != 1 {
+			t.Fatalf("before-write calls = %d, want 1", beforeCalls)
+		}
+		if len(fixture.injections) != 0 {
+			t.Fatalf("stopped authority injected terminal bytes: %#v", fixture.injections)
+		}
+	})
+
+	t.Run("between before-write validation and retained inject", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		stop := make(chan struct{})
+		authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = authority.Close() })
+
+		beforeCalls := 0
+		injectCalls := 0
+		err = injectNotification(&wakeConfig{
+			me:          "codex",
+			injectMode:  wakeInjectModeRaw,
+			controlStop: stop,
+			beforeTerminalWrite: func() error {
+				beforeCalls++
+				if err := authority.BeforeWrite(); err != nil {
+					return err
+				}
+				close(stop)
+				return nil
+			},
+			terminalWrite: func(chunk string) error {
+				injectCalls++
+				return authority.Inject(chunk)
+			},
+		}, "dynamic", false)
+		if err != nil {
+			t.Fatalf("stop before retained inject: %v", err)
+		}
+		if beforeCalls != 1 || injectCalls != 1 {
+			t.Fatalf("boundary calls before=%d inject=%d, want 1/1", beforeCalls, injectCalls)
+		}
+		if len(fixture.injections) != 0 {
+			t.Fatalf("stopped authority injected terminal bytes: %#v", fixture.injections)
+		}
+	})
+}
+
+func TestRunWakeLoopTerminatesOnTerminalAuthorityLoss(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "terminal-authority-loss",
+			From:    "sender",
+			To:      []string{"codex"},
+			Thread:  "p2p/sender__codex",
+			Subject: "wake",
+			Created: time.Now().UTC().Format(time.RFC3339),
+		},
+		Body: "durable body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	loss := newWakeTerminalAuthorityLoss("test authority loss", nil)
+	terminalWriteCalled := false
+	err = runWakeLoop(wakeConfig{
+		root:        root,
+		me:          "codex",
+		injectMode:  wakeInjectModeRaw,
+		controlStop: make(chan struct{}),
+		beforeTerminalWrite: func() error {
+			return loss
+		},
+		terminalWrite: func(string) error {
+			terminalWriteCalled = true
+			return nil
+		},
+		onPrepared: func(wakeAdmissionWatcher) error {
+			_, deliverErr := deliverToInboxForTest(
+				t,
+				root,
+				"codex",
+				"terminal-authority-loss.md",
+				data,
+			)
+			return deliverErr
+		},
+	})
+	if !isWakeTerminalAuthorityLoss(err) || !errors.Is(err, loss) {
+		t.Fatalf("wake loop authority-loss result = %v", err)
+	}
+	if terminalWriteCalled {
+		t.Fatal("wake loop wrote after terminal authority loss")
+	}
+}
+
+func installWakeTerminalAuthorityFixture(t *testing.T) *wakeTerminalAuthorityFixture {
+	t.Helper()
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".wake.lock")
+	lockRaw := []byte(`{"generation":"terminal-authority-generation"}`)
+	if err := os.WriteFile(lockPath, lockRaw, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	lockInfo, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ttyPath := filepath.Join(dir, "tty")
+	if err := os.WriteFile(ttyPath, []byte("tty"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	generation := wakeLockInspection{
+		Exists:   true,
+		Root:     dir,
+		Agent:    "codex",
+		LockPath: lockPath,
+		Lock: wakeLock{
+			Generation: "terminal-authority-generation",
+		},
+		raw:      lockRaw,
+		fileInfo: lockInfo,
+	}
+	fixture := &wakeTerminalAuthorityFixture{
+		generation:     generation,
+		current:        generation,
+		currentTTYPath: ttyPath,
+		foregroundPGRP: 4242,
+	}
+
+	originalOpen := openWakeControllingTerminal
+	originalPGRP := wakeTerminalForegroundPGRP
+	originalInspect := inspectWakeTerminalGeneration
+	originalInject := injectWakeTerminalFD
+	openWakeControllingTerminal = func() (*os.File, error) {
+		return os.OpenFile(fixture.currentTTYPath, os.O_RDWR, 0)
+	}
+	wakeTerminalForegroundPGRP = func(uintptr) (int, error) {
+		return fixture.foregroundPGRP, nil
+	}
+	inspectWakeTerminalGeneration = func(root, agent string) wakeLockInspection {
+		if root != generation.Root || agent != generation.Agent {
+			t.Fatalf("inspect generation root=%q agent=%q", root, agent)
+		}
+		return fixture.current
+	}
+	injectWakeTerminalFD = func(fd uintptr, text string) error {
+		fixture.injections = append(fixture.injections, wakeTerminalInjection{fd: fd, text: text})
+		return nil
+	}
+	t.Cleanup(func() {
+		openWakeControllingTerminal = originalOpen
+		wakeTerminalForegroundPGRP = originalPGRP
+		inspectWakeTerminalGeneration = originalInspect
+		injectWakeTerminalFD = originalInject
+	})
+	return fixture
+}

--- a/internal/cli/wake_terminal_guard_other.go
+++ b/internal/cli/wake_terminal_guard_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux
+
+package cli
+
+func authorizeTerminalWritePlatform(*wakeConfig) bool {
+	return true
+}
+
+func isWakeTerminalControlStopped(error) bool {
+	return false
+}

--- a/internal/cli/wake_terminal_guard_unix.go
+++ b/internal/cli/wake_terminal_guard_unix.go
@@ -1,0 +1,22 @@
+//go:build darwin || linux
+
+package cli
+
+import "strings"
+
+func authorizeTerminalWritePlatform(cfg *wakeConfig) bool {
+	current := inspectWakeLock(cfg.root, cfg.me)
+	if !current.Exists || current.Lock.Generation == "" {
+		return false
+	}
+	if cfg.terminalGeneration == "" {
+		cfg.terminalGeneration = current.Lock.Generation
+		cfg.terminalTTY = current.Lock.TTY
+	}
+	if current.Lock.Generation != cfg.terminalGeneration ||
+		current.Lock.TTY != cfg.terminalTTY {
+		return false
+	}
+	return !strings.HasPrefix(cfg.terminalTTY, "/dev/") ||
+		getWakeCurrentTTY() == cfg.terminalTTY
+}

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -261,6 +261,127 @@ func TestInjectNotificationNoneDoesNotInvokeInjectVia(t *testing.T) {
 	}
 }
 
+func TestOwnerBoundNotificationUsesFixedDoorbellAndGuardsEveryChunk(t *testing.T) {
+	oldWait := waitForRawInputDrained
+	oldSleep := rawInjectSleep
+	waitForRawInputDrained = func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	}
+	rawInjectSleep = func(time.Duration) {}
+	t.Cleanup(func() {
+		waitForRawInputDrained = oldWait
+		rawInjectSleep = oldSleep
+	})
+
+	tests := []struct {
+		mode string
+		want []string
+	}{
+		{
+			mode: wakeInjectModeRaw,
+			want: []string{coopWakeDoorbell, "\n", "\r", "\r"},
+		},
+		{
+			mode: wakeInjectModePaste,
+			want: []string{coopWakeDoorbell, "\r"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.mode, func(t *testing.T) {
+			stop := make(chan struct{})
+			var writes []string
+			guardCalls := 0
+			cfg := &wakeConfig{
+				me:          "codex",
+				injectMode:  tc.mode,
+				controlStop: stop,
+				bell:        true,
+				beforeTerminalWrite: func() error {
+					guardCalls++
+					return nil
+				},
+				terminalWrite: func(chunk string) error {
+					writes = append(writes, chunk)
+					return nil
+				},
+			}
+
+			dynamic := "session=$(touch /tmp/pwned) subject=\x1b[31m body=untrusted"
+			if err := injectNotification(cfg, dynamic, false); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Join(writes, "|") != strings.Join(tc.want, "|") {
+				t.Fatalf("owner-bound chunks = %#v, want %#v", writes, tc.want)
+			}
+			if guardCalls != len(tc.want) {
+				t.Fatalf("guard calls = %d, want %d", guardCalls, len(tc.want))
+			}
+		})
+	}
+}
+
+func TestOwnerBoundNotificationAuthorityRefusalStopsLaterChunks(t *testing.T) {
+	oldWait := waitForRawInputDrained
+	oldSleep := rawInjectSleep
+	waitForRawInputDrained = func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	}
+	rawInjectSleep = func(time.Duration) {}
+	t.Cleanup(func() {
+		waitForRawInputDrained = oldWait
+		rawInjectSleep = oldSleep
+	})
+
+	authorityErr := errors.New("terminal authority changed")
+	stop := make(chan struct{})
+	guardCalls := 0
+	var writes []string
+	cfg := &wakeConfig{
+		me:          "codex",
+		injectMode:  wakeInjectModeRaw,
+		controlStop: stop,
+		beforeTerminalWrite: func() error {
+			guardCalls++
+			if guardCalls == 2 {
+				return authorityErr
+			}
+			return nil
+		},
+		terminalWrite: func(chunk string) error {
+			writes = append(writes, chunk)
+			return nil
+		},
+	}
+
+	err := injectNotification(cfg, "dynamic", false)
+	if !errors.Is(err, authorityErr) {
+		t.Fatalf("authority error = %v, want %v", err, authorityErr)
+	}
+	if len(writes) != 1 || writes[0] != coopWakeDoorbell {
+		t.Fatalf("writes after authority refusal = %#v", writes)
+	}
+}
+
+func TestStandaloneNotificationPreservesDynamicLegacyPayload(t *testing.T) {
+	var writes []string
+	cfg := &wakeConfig{
+		injectMode: wakeInjectModePaste,
+		terminalWrite: func(chunk string) error {
+			writes = append(writes, chunk)
+			return nil
+		},
+	}
+
+	const dynamic = "legacy dynamic notice"
+	if err := injectNotification(cfg, dynamic, false); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"\x1b[200~" + dynamic + "\x1b[201~", "\r"}
+	if strings.Join(writes, "|") != strings.Join(want, "|") {
+		t.Fatalf("standalone chunks = %#v, want %#v", writes, want)
+	}
+}
+
 func TestInjectViaTimeout(t *testing.T) {
 	scriptPath := filepath.Join(secureTempDirForTest(t), "sleep.sh")
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 2\n"), 0o755); err != nil {

--- a/internal/cli/wake_tiocsti_unix.go
+++ b/internal/cli/wake_tiocsti_unix.go
@@ -40,8 +40,12 @@ func (t tiocstiFuncs) Inject(text string) error {
 	}
 	defer func() { _ = tty.Close() }()
 
-	fd := tty.Fd()
+	return t.InjectFD(tty.Fd(), text)
+}
 
+// InjectFD injects text through an already-retained controlling-terminal
+// descriptor. Callers own the descriptor and its lifecycle.
+func (t tiocstiFuncs) InjectFD(fd uintptr, text string) error {
 	// Inject each character using TIOCSTI
 	for _, ch := range []byte(text) {
 		if err := ioctlTIOCSTI(fd, ch); err != nil {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -84,6 +84,7 @@ type wakeLockAcquireOptions struct {
 	acceptExistingValid  bool
 	target               *wakeTarget
 	wakeMode             string
+	requestedOwner       *wakeOwner
 	repairLineage        *wakeRepairLineage
 	repairFloorAuthority *wakeRepairFloorAuthority
 }
@@ -191,6 +192,14 @@ func acquireWakeLockWithOptionsInDir(
 					return &wakeLockCreatingError{}
 				case wakeLockValid:
 					if options.acceptExistingValid {
+						if options.requestedOwner != nil &&
+							(inspection.Lock.WakeMode != wakeOwnerWakeMode ||
+								!sameWakeOwner(inspection.Lock.Owner, options.requestedOwner)) {
+							return fmt.Errorf(
+								"existing wake for %s is not bound to the requested exact owner; refusing readiness reuse",
+								me,
+							)
+						}
 						if err := requireWakeLockUsable(inspection, options.wakeMode, options.target); err != nil {
 							return err
 						}
@@ -445,11 +454,11 @@ func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string, r
 		}
 	}
 	if !wakeLockHasUsableNotificationPath(inspection) {
-		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
+		return fmt.Errorf("existing wake lock for %s is not usable for requested wake readiness (pid %d on %s since %s)",
 			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
 	}
 	if wakeLockNeedsReplacement(inspection) {
-		return fmt.Errorf("existing wake lock for %s is not usable for --require-wake (pid %d on %s since %s)",
+		return fmt.Errorf("existing wake lock for %s is not usable for requested wake readiness (pid %d on %s since %s)",
 			inspection.Agent, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started)
 	}
 	if requiredMode == wakeTargetInjectVia {
@@ -1340,6 +1349,25 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return fmt.Errorf("wake repair handoff requires --repair-lineage")
 	}
 
+	requestedOwner, err := wakeOwnerFromEnv()
+	if err != nil {
+		return err
+	}
+	if repairGeneration != "" && requestedOwner != nil {
+		return fmt.Errorf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", me)
+	}
+	var ownerObservation wakeOwnerObservation
+	if requestedOwner != nil {
+		ownerObservation, err = observeLiveWakeOwner(
+			*requestedOwner,
+			"inspect requested wake owner before lock acquisition",
+		)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = ownerObservation.Close() }()
+	}
+
 	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
 	if injectVia == "" && injectMode != wakeInjectModeNone {
 		if !wakeTIOCSTIAvailable() {
@@ -1362,24 +1390,17 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	var repairAgentDir *wakeAgentDir
 	var repairInboxDir *wakeInboxDir
 	if injectVia != "" {
-		owner, err := wakeOwnerFromEnv()
-		if err != nil {
-			return err
-		}
 		value, err := newWakeTarget(root, me, injectVia, []string(injectArgFlags))
 		if err != nil {
 			return err
 		}
-		value.Owner = owner
+		value.Owner = requestedOwner
 		if err := validateWakeTarget(value, root, me); err != nil {
 			return err
 		}
 		injectVia = value.InjectVia
 		target = &value
 		if repairGeneration != "" {
-			if owner != nil {
-				return fmt.Errorf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", me)
-			}
 			source, err := repairHandoff.ReceiveSource()
 			if err != nil {
 				return fmt.Errorf("receive wake repair source: %w", err)
@@ -1485,10 +1506,18 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	var cleanup func()
 	var repairFloorAuthority wakeRepairFloorAuthority
 	for {
+		if requestedOwner != nil {
+			select {
+			case <-ownerObservation.Done():
+				return fmt.Errorf("requested wake owner exited before lock acquisition")
+			default:
+			}
+		}
 		options := wakeLockAcquireOptions{
 			acceptExistingValid: acceptExistingWake,
 			target:              target,
 			wakeMode:            lockWakeMode,
+			requestedOwner:      requestedOwner,
 			repairLineage:       repairLineage,
 		}
 		if repairLineage != nil {
@@ -1511,8 +1540,29 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		}
 		var alreadyRunning *wakeAlreadyRunningError
 		if acceptExistingWake && errors.As(err, &alreadyRunning) {
+			if requestedOwner != nil {
+				select {
+				case <-ownerObservation.Done():
+					return fmt.Errorf("requested wake owner exited before existing-wake readiness")
+				default:
+				}
+			}
 			if err := writeWakeReadyFileForPreparedWake(root, me, readyFile, alreadyRunning.Inspection, acceptExistingDeadline); err != nil {
 				return err
+			}
+			if requestedOwner != nil {
+				ready, readyErr := validateWakeReadyFileAgainstOwner(
+					root,
+					me,
+					readyFile,
+					requestedOwner,
+				)
+				if readyErr != nil {
+					return readyErr
+				}
+				if !ready {
+					return fmt.Errorf("existing wake readiness disappeared before owner validation")
+				}
 			}
 			if *baselineExistingFlag {
 				_ = writeStderr("warning: reusing existing amq wake; this launch did not re-baseline it, so pending backlog may still notify\n")
@@ -1522,7 +1572,10 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		return err
 	}
 	defer cleanup()
-	var controlStop <-chan struct{}
+	controlStop := privateStop
+	if requestedOwner != nil {
+		controlStop = mergeWakeStopChannels(controlStop, ownerObservation.Done())
+	}
 	if injectVia != "" {
 		var current wakeLockInspection
 		if repairAgentDir != nil {
@@ -1551,9 +1604,8 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		}
 		defer controlCleanup()
 		defer markStopped()
-		controlStop = stop
+		controlStop = mergeWakeStopChannels(controlStop, stop)
 	}
-	controlStop = mergeWakeStopChannels(controlStop, privateStop)
 
 	if injectVia != "" {
 		if err := validateResolvedWakeInjectViaPath(injectVia); err != nil {
@@ -1572,35 +1624,48 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	} else {
 		currentWake = inspectWakeLock(root, me)
 	}
+	var terminalAuthority *wakeTerminalAuthority
+	effectiveMode := effectiveInjectMode(&wakeConfig{me: me, injectMode: injectMode})
+	if requestedOwner != nil &&
+		injectVia == "" &&
+		(effectiveMode == wakeInjectModeRaw || effectiveMode == wakeInjectModePaste) {
+		terminalAuthority, err = bindWakeTerminalAuthorityForWake(currentWake, controlStop)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = terminalAuthority.Close() }()
+	}
 	cfg := wakeConfig{
-		me:                me,
-		root:              root,
-		session:           resolveSessionName(root),
-		injectCmd:         *injectCmdFlag,
-		injectVia:         injectVia,
-		injectArgs:        []string(injectArgFlags),
-		wakeOwner:         targetOwner(target),
-		injectTimeout:     *injectTimeoutFlag,
-		bell:              *bellFlag,
-		debounce:          *debounceFlag,
-		previewLen:        *previewLenFlag,
-		strict:            common.Strict,
-		fallbackWarn:      true,
-		injectMode:        injectMode,
-		debug:             *debugFlag,
-		deferWhileInput:   *deferWhileInputFlag,
-		inputQuietFor:     *inputQuietForFlag,
-		inputPollInterval: *inputPollIntervalFlag,
-		inputMaxHold:      *inputMaxHoldFlag,
-		interrupt:         *interruptFlag,
-		interruptLabel:    interruptLabel,
-		interruptPriority: interruptPriority,
-		interruptKey:      interruptKey,
-		interruptNotice:   strings.TrimSpace(*interruptNoticeFlag),
-		interruptCooldown: *interruptCooldownFlag,
-		controlStop:       controlStop,
-		baselineRequested: *baselineExistingFlag || repairLineage != nil,
-		baselineInherited: repairLineage != nil,
+		me:                 me,
+		root:               root,
+		session:            resolveSessionName(root),
+		injectCmd:          *injectCmdFlag,
+		injectVia:          injectVia,
+		injectArgs:         []string(injectArgFlags),
+		wakeOwner:          requestedOwner,
+		injectTimeout:      *injectTimeoutFlag,
+		bell:               *bellFlag,
+		debounce:           *debounceFlag,
+		previewLen:         *previewLenFlag,
+		strict:             common.Strict,
+		fallbackWarn:       true,
+		injectMode:         injectMode,
+		debug:              *debugFlag,
+		deferWhileInput:    *deferWhileInputFlag,
+		inputQuietFor:      *inputQuietForFlag,
+		inputPollInterval:  *inputPollIntervalFlag,
+		inputMaxHold:       *inputMaxHoldFlag,
+		interrupt:          *interruptFlag,
+		interruptLabel:     interruptLabel,
+		interruptPriority:  interruptPriority,
+		interruptKey:       interruptKey,
+		interruptNotice:    strings.TrimSpace(*interruptNoticeFlag),
+		interruptCooldown:  *interruptCooldownFlag,
+		controlStop:        controlStop,
+		terminalGeneration: currentWake.Lock.Generation,
+		terminalTTY:        currentWake.Lock.TTY,
+		baselineRequested:  *baselineExistingFlag || repairLineage != nil,
+		baselineInherited:  repairLineage != nil,
 		onPrepared: func(watcher wakeAdmissionWatcher) error {
 			if repairLineage != nil {
 				if err := writeWakePreparedFileInDir(
@@ -1701,8 +1766,18 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 			if err := writeWakePreparedFile(root, me, currentWake); err != nil {
 				return err
 			}
-			return writeWakeReadyFile(root, me, readyFile, currentWake)
+			return writeWakeReadyFileAgainstOwner(
+				root,
+				me,
+				readyFile,
+				currentWake,
+				requestedOwner,
+			)
 		},
+	}
+	if terminalAuthority != nil {
+		cfg.beforeTerminalWrite = terminalAuthority.BeforeWrite
+		cfg.terminalWrite = terminalAuthority.Inject
 	}
 	if repairInboxDir != nil {
 		cfg.retainedInbox = repairInboxDir
@@ -1945,6 +2020,20 @@ func parseInterruptKey(raw string) (string, error) {
 }
 
 func runWakeLoop(cfg wakeConfig) error {
+	// Register shutdown handling before any watcher setup, baseline work, or
+	// readiness callback so an early parent death cannot be lost.
+	signal.Ignore(syscall.SIGTTOU, syscall.SIGTSTP, syscall.SIGTTIN)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	select {
+	case <-cfg.controlStop:
+		return nil
+	case <-sigCh:
+		return nil
+	default:
+	}
+
 	inboxNew := fsq.AgentInboxNew(cfg.root, cfg.me)
 
 	var watcher wakeEventWatcher
@@ -1985,6 +2074,8 @@ func runWakeLoop(cfg wakeConfig) error {
 	select {
 	case <-cfg.controlStop:
 		return nil
+	case <-sigCh:
+		return nil
 	default:
 	}
 	if cfg.onPrepared != nil {
@@ -1995,21 +2086,10 @@ func runWakeLoop(cfg wakeConfig) error {
 	select {
 	case <-cfg.controlStop:
 		return nil
+	case <-sigCh:
+		return nil
 	default:
 	}
-
-	// Ignore job control signals so background job can operate freely.
-	// Note: This also affects foreground mode (Ctrl+Z won't suspend), but wake
-	// is designed to run as a background job (amq wake &) so this is intentional.
-	// - SIGTTOU: allow writing to TTY from background
-	// - SIGTSTP: prevent Ctrl+Z or shell from suspending us
-	// - SIGTTIN: prevent suspension if stdin is accidentally read
-	signal.Ignore(syscall.SIGTTOU, syscall.SIGTSTP, syscall.SIGTTIN)
-
-	// Handle signals gracefully
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
 
 	// Debounce timer
 	var debounceTimer *time.Timer
@@ -2028,6 +2108,9 @@ func runWakeLoop(cfg wakeConfig) error {
 
 	// Notify if messages already exist
 	if err := notifyNewMessages(&cfg); err != nil {
+		if isWakeTerminalAuthorityLoss(err) {
+			return err
+		}
 		_ = writeStderr("amq wake: notify error: %v\n", err)
 	}
 
@@ -2086,6 +2169,9 @@ func runWakeLoop(cfg wakeConfig) error {
 
 			// Collect and notify
 			if err := notifyNewMessages(&cfg); err != nil {
+				if isWakeTerminalAuthorityLoss(err) {
+					return err
+				}
 				_ = writeStderr("amq wake: notify error: %v\n", err)
 			}
 
@@ -2120,12 +2206,47 @@ func wakeHealthCheck(cfg wakeConfig, ttyAvailableFn func() bool) error {
 	return nil
 }
 
-func targetOwner(target *wakeTarget) *wakeOwner {
-	if target == nil || target.Owner == nil {
-		return nil
+func observeLiveWakeOwner(owner wakeOwner, context string) (wakeOwnerObservation, error) {
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		return wakeOwnerObservation{}, fmt.Errorf("%s: %w", context, err)
 	}
-	owner := *target.Owner
-	return &owner
+	observation, err := observeAuthoritativeWakeOwner(owner)
+	if err != nil {
+		closeErr := observation.Close()
+		return wakeOwnerObservation{}, errors.Join(
+			fmt.Errorf("%s: %w", context, err),
+			closeErr,
+		)
+	}
+	if observation.State != wakeOwnerSame {
+		closeErr := observation.Close()
+		return wakeOwnerObservation{}, errors.Join(
+			fmt.Errorf(
+				"%s: owner is %s: %s",
+				context,
+				observation.State,
+				observation.Reason,
+			),
+			closeErr,
+		)
+	}
+	if observation.Done() == nil {
+		closeErr := observation.Close()
+		return wakeOwnerObservation{}, errors.Join(
+			fmt.Errorf("%s: live owner observation has no lifetime signal", context),
+			closeErr,
+		)
+	}
+	select {
+	case <-observation.Done():
+		closeErr := observation.Close()
+		return wakeOwnerObservation{}, errors.Join(
+			fmt.Errorf("%s: owner exited during observation", context),
+			closeErr,
+		)
+	default:
+	}
+	return observation, nil
 }
 
 func wakeCommandEnv(base []string, root string, owner *wakeOwner) ([]string, error) {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -298,33 +298,117 @@ func acquireWakeLockWithOptionsInDir(
 		}
 
 		cleanup = func() {
-			_ = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
-				current := inspectWakeLockAt(dirfd, agentDir, root, me)
-				if !sameWakeLockGeneration(created, current) || !currentWakeLockMatches(current.Lock) {
-					return nil
-				}
-				if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, current); err != nil {
-					return err
-				}
-				if options.repairLineage != nil {
-					if options.repairFloorAuthority == nil {
-						return fmt.Errorf("wake repair floor cleanup authority is missing")
-					}
-					return removeWakeRepairFloorIfGenerationGuardedAt(
-						dirfd,
-						agentDir,
-						*options.repairFloorAuthority,
-					)
-				}
-				floor, exists, err := readWakeRepairFloorAt(dirfd, agentDir)
-				if err != nil || !exists || floor.Generation != created.Lock.Generation {
-					return err
-				}
-				return removeWakeRepairFloorGuardedAt(dirfd, agentDir)
-			})
+			if cleanupErr := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+				return cleanupGenericWakeGenerationAt(
+					dirfd,
+					agentDir,
+					root,
+					me,
+					created,
+					options,
+				)
+			}); cleanupErr != nil {
+				_ = writeStderr("amq wake: cleanup failed: %v\n", cleanupErr)
+			}
 		}
 		return cleanup, nil
 	}
+}
+
+func cleanupGenericWakeGenerationAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	created wakeLockInspection,
+	options wakeLockAcquireOptions,
+) error {
+	current := inspectWakeLockAt(dirfd, agentDir, root, me)
+	if !sameWakeLockGeneration(created, current) || !currentWakeLockMatches(current.Lock) {
+		return nil
+	}
+
+	preparedSnapshot, preparedSnapshotErr := freezeGenericWakePreparedCleanupAt(
+		dirfd,
+		agentDir,
+		root,
+		me,
+		current,
+	)
+	if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, current); err != nil {
+		return errors.Join(
+			preparedSnapshotErr,
+			fmt.Errorf("remove exact generic wake lock: %w", err),
+		)
+	}
+	var lockSyncErr error
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		lockSyncErr = fmt.Errorf("sync exact generic wake lock removal: %w", err)
+	}
+
+	interleaveErr := afterGenericWakeLockRemoval(dirfd, agentDir)
+	replacement := inspectWakeLockAt(dirfd, agentDir, root, me)
+	var replacementErr error
+	if replacement.Exists {
+		replacementErr = fmt.Errorf(
+			"replacement wake lock appeared during generic wake cleanup; preserving prepared marker",
+		)
+	}
+
+	var preparedCleanupErr error
+	if !replacement.Exists && preparedSnapshot != nil {
+		_, preparedCleanupErr = removeWakeGenerationFileIfSnapshotMatchesAt(
+			dirfd,
+			agentDir,
+			wakePreparedFileName,
+			"wake prepared marker",
+			*preparedSnapshot,
+		)
+		if preparedCleanupErr != nil {
+			preparedCleanupErr = fmt.Errorf(
+				"remove exact generic wake prepared marker: %w",
+				preparedCleanupErr,
+			)
+		}
+	}
+
+	floorCleanupErr := cleanupGenericWakeRepairFloorAt(
+		dirfd,
+		agentDir,
+		created,
+		options,
+	)
+	return errors.Join(
+		preparedSnapshotErr,
+		lockSyncErr,
+		interleaveErr,
+		replacementErr,
+		preparedCleanupErr,
+		floorCleanupErr,
+	)
+}
+
+func cleanupGenericWakeRepairFloorAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	created wakeLockInspection,
+	options wakeLockAcquireOptions,
+) error {
+	if options.repairLineage != nil {
+		if options.repairFloorAuthority == nil {
+			return fmt.Errorf("wake repair floor cleanup authority is missing")
+		}
+		return removeWakeRepairFloorIfGenerationGuardedAt(
+			dirfd,
+			agentDir,
+			*options.repairFloorAuthority,
+		)
+	}
+	floor, exists, err := readWakeRepairFloorAt(dirfd, agentDir)
+	if err != nil || !exists || floor.Generation != created.Lock.Generation {
+		return err
+	}
+	return removeWakeRepairFloorGuardedAt(dirfd, agentDir)
 }
 
 func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, error) {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -69,6 +69,18 @@ func stubWakeTTYSupport(t *testing.T) {
 	})
 }
 
+func liveWakeOwnerObservationForTest() wakeOwnerObservation {
+	var monitor *wakeOwnerObservationMonitor
+	monitor = newWakeOwnerObservationMonitor(func() error {
+		monitor.finish(nil)
+		return nil
+	})
+	return wakeOwnerObservation{
+		State:   wakeOwnerSame,
+		monitor: monitor,
+	}
+}
+
 func writeExecutableForTest(t *testing.T, name string) string {
 	t.Helper()
 	path := filepath.Join(secureTempDirForTest(t), name)
@@ -566,7 +578,7 @@ func TestRunWakeWithLoopPersistsInjectViaWakeOwnerFromEnv(t *testing.T) {
 		if got != owner {
 			t.Fatalf("observed owner = %#v, want %#v", got, owner)
 		}
-		return wakeOwnerObservation{State: wakeOwnerSame}, nil
+		return liveWakeOwnerObservationForTest(), nil
 	}
 	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
 
@@ -594,6 +606,162 @@ func TestRunWakeWithLoopPersistsInjectViaWakeOwnerFromEnv(t *testing.T) {
 	})
 	if !errors.Is(err, errDone) {
 		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
+func TestRunWakeWithLoopSupervisesOwnerBeforeGenericLockAndMergesDone(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatal(err)
+	}
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	encoded, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envWakeOwner, encoded)
+	ownerDone := make(chan struct{})
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("observed owner = %#v, want %#v", got, owner)
+		}
+		if inspection := inspectWakeLock(root, "orchestrator"); inspection.Exists {
+			t.Fatalf("owner observation happened after lock publication: %#v", inspection)
+		}
+		return wakeOwnerObservation{
+			State: wakeOwnerSame,
+			done:  ownerDone,
+		}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+	errDone := errors.New("done")
+	err = runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-mode", wakeInjectModeNone,
+	}, func(cfg wakeConfig) error {
+		if cfg.wakeOwner == nil || *cfg.wakeOwner != owner {
+			t.Fatalf("cfg.wakeOwner = %#v, want %#v", cfg.wakeOwner, owner)
+		}
+		if cfg.controlStop == nil {
+			t.Fatal("owner observation Done was not merged into controlStop")
+		}
+		close(ownerDone)
+		select {
+		case <-cfg.controlStop:
+		case <-time.After(time.Second):
+			t.Fatal("owner exit did not stop the generic wake")
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("wake result = %v, want loop sentinel", err)
+	}
+}
+
+func TestRunWakeWithLoopRejectsSameOwnerWithoutLifetimeSignalBeforeLock(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatal(err)
+	}
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	encoded, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envWakeOwner, encoded)
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+		return wakeOwnerObservation{State: wakeOwnerSame}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+	loopCalled := false
+	err = runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-mode", wakeInjectModeNone,
+	}, func(wakeConfig) error {
+		loopCalled = true
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "lifetime signal") {
+		t.Fatalf("wake result = %v, want missing-lifetime refusal", err)
+	}
+	if loopCalled {
+		t.Fatal("missing owner lifetime signal reached wake loop")
+	}
+	if inspection := inspectWakeLock(root, "orchestrator"); inspection.Exists {
+		t.Fatalf("missing owner lifetime signal published lock: %#v", inspection)
+	}
+}
+
+func TestValidateWakeReadyFileAgainstOwnerReobservesGenericOwner(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatal(err)
+	}
+	cleanup, err := acquireWakeLockWithOptions(root, "orchestrator", wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeNone,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	inspection := inspectWakeLock(root, "orchestrator")
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	if err := writeWakeReadyFile(root, "orchestrator", readyPath, inspection); err != nil {
+		t.Fatal(err)
+	}
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	observations := 0
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		observations++
+		if got != owner {
+			t.Fatalf("observed owner = %#v, want %#v", got, owner)
+		}
+		return liveWakeOwnerObservationForTest(), nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+	ready, err := validateWakeReadyFileAgainstOwner(
+		root,
+		"orchestrator",
+		readyPath,
+		&owner,
+	)
+	if err != nil || !ready {
+		t.Fatalf("generic owner readiness = %v, err=%v", ready, err)
+	}
+	if observations != 1 {
+		t.Fatalf("generic readiness owner observations = %d, want 1", observations)
 	}
 }
 
@@ -1326,7 +1494,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsMissingTTY(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unusable wake lock error")
 	}
-	if !strings.Contains(err.Error(), "not usable for --require-wake") {
+	if !strings.Contains(err.Error(), "not usable for requested wake readiness") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
@@ -1385,7 +1553,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsBlankOrUnknownTTY(t *testing.T)
 			if err == nil {
 				t.Fatal("expected unusable wake lock error")
 			}
-			if !strings.Contains(err.Error(), "not usable for --require-wake") {
+			if !strings.Contains(err.Error(), "not usable for requested wake readiness") {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
@@ -1553,7 +1721,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *test
 	if err == nil {
 		t.Fatal("expected unusable wake lock error")
 	}
-	if !strings.Contains(err.Error(), "not usable for --require-wake") {
+	if !strings.Contains(err.Error(), "not usable for requested wake readiness") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {


### PR DESCRIPTION
## Summary

- bind coop wake lifetime to the exact launched owner on Darwin and Linux
- remove Ctrl-C wake interruption and inject one fixed shell-inert doorbell through retained terminal authority
- make owner-loss cleanup replacement-safe and crash-durable, including exact prepared-marker retirement
- preserve standalone wake behavior while refusing ownerless fallback for supervised coop wakes

## Verification

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `make ci`
- exact-head CI run 30133429454
- Darwin real-PTY raw normal/SIGKILL count 10
- Darwin real-PTY paste/none normal/SIGKILL plus same-agent restart across 8 lifecycles
- zero lock, target, prepared, floor, control-socket, temp, or quarantine residue
