### PR TITLE
fix(install): verify release checksums fail closed

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ Installs to user-local directory (no sudo required):
 - `~/.local/bin` if exists
 - `~/go/bin` if exists
 - `~/.local/bin` (created if needed)
-The installer verifies release checksums when possible.
+The installer requires a readable `checksums.txt` with exactly one valid entry for the selected asset. It uses `sha256sum` or `shasum` and stops before extraction if verification cannot be completed.
 
 ### 2. Skill
 
@@ -114,16 +114,60 @@ Download from [Releases](https://github.com/avivsinai/agent-message-queue/releas
 | Linux (ARM64) | `amq_*_linux_arm64.tar.gz` |
 | Windows | `amq_*_windows_amd64.zip` (use in WSL) |
 
-```bash
-tar xzf amq_*.tar.gz
-mkdir -p ~/.local/bin
-mv amq ~/.local/bin/
-```
-
-Optionally verify checksums:
+For manual installs, verify the selected asset against `checksums.txt` before extracting it:
 
 ```bash
-curl -fsSL https://github.com/avivsinai/agent-message-queue/releases/download/<TAG>/checksums.txt | grep amq_<VERSION>_<OS>_<ARCH>
+# Replace X.Y.Z and darwin_arm64 with the release and platform you downloaded.
+TAG=vX.Y.Z
+ASSET=amq_X.Y.Z_darwin_arm64.tar.gz
+curl -fsSL "https://github.com/avivsinai/agent-message-queue/releases/download/$TAG/checksums.txt" -o checksums.txt
+CHECKSUM_LINE=$(
+  awk -v asset="$ASSET" '
+    {
+      field = $2
+      candidate = field
+      sub(/^\*/, "", candidate)
+      last = $NF
+      sub(/^\*/, "", last)
+      if (candidate == asset) {
+        count++
+        if (NF != 2 ||
+            length($1) != 64 ||
+            $1 !~ /^[0-9A-Fa-f]+$/ ||
+            (field != asset && field != "*" asset)) {
+          malformed = 1
+        }
+        line = $0
+      } else if (last == asset) {
+        count++
+        malformed = 1
+      }
+    }
+    END {
+      if (count != 1 || malformed) exit 1
+      print line
+    }
+  ' checksums.txt
+) || { echo "Expected exactly one well-formed checksum entry for $ASSET" >&2; exit 1; }
+printf '%s\n' "$CHECKSUM_LINE" > "$ASSET.sha256"
+verify_amq_checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$ASSET.sha256" || return 1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "$ASSET.sha256" || return 1
+  else
+    echo "sha256sum or shasum is required" >&2
+    return 1
+  fi
+}
+if verify_amq_checksum; then
+  tar xzf "$ASSET"
+  mkdir -p ~/.local/bin
+  mv amq ~/.local/bin/
+else
+  echo "Checksum verification failed; archive was not extracted." >&2
+  false
+fi
 ```
 
 ### Binary: Build from Source

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -117,13 +117,63 @@ Download from [Releases](https://github.com/avivsinai/agent-message-queue/releas
 For manual installs, verify the selected asset against `checksums.txt` before extracting it:
 
 ```bash
+# AMQ_MANUAL_INSTALL_BEGIN
+(
 # Replace X.Y.Z and darwin_arm64 with the release and platform you downloaded.
 TAG=vX.Y.Z
 ASSET=amq_X.Y.Z_darwin_arm64.tar.gz
-curl -fsSL "https://github.com/avivsinai/agent-message-queue/releases/download/$TAG/checksums.txt" -o checksums.txt
-CHECKSUM_LINE=$(
+TARGET_DIR="$HOME/.local/bin"
+ARCHIVE_SOURCE="$PWD/$ASSET"
+DOWNLOAD_DIR=""
+EXTRACT_DIR=""
+STAGE_DIR=""
+
+cleanup_manual_install() {
+  if [ -n "$STAGE_DIR" ]; then
+    rm -rf "$STAGE_DIR" || true
+  fi
+  if [ -n "$EXTRACT_DIR" ]; then
+    rm -rf "$EXTRACT_DIR" || true
+  fi
+  if [ -n "$DOWNLOAD_DIR" ]; then
+    rm -rf "$DOWNLOAD_DIR" || true
+  fi
+}
+trap cleanup_manual_install EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+[ -f "$ARCHIVE_SOURCE" ] && [ -r "$ARCHIVE_SOURCE" ] || {
+  echo "Archive is missing, unreadable, or not a regular file: $ARCHIVE_SOURCE" >&2
+  exit 1
+}
+DOWNLOAD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/.amq.download.XXXXXX") || {
+  echo "Could not create a private download directory" >&2
+  exit 1
+}
+EXTRACT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/.amq.extract.XXXXXX") || {
+  echo "Could not create a private extraction directory" >&2
+  exit 1
+}
+cp "$ARCHIVE_SOURCE" "$DOWNLOAD_DIR/$ASSET" || {
+  echo "Could not snapshot $ASSET" >&2
+  exit 1
+}
+curl -fsSL \
+  "https://github.com/avivsinai/agent-message-queue/releases/download/$TAG/checksums.txt" \
+  -o "$DOWNLOAD_DIR/checksums.txt" || {
+  echo "Could not download checksums.txt" >&2
+  exit 1
+}
+[ -r "$DOWNLOAD_DIR/checksums.txt" ] || {
+  echo "Downloaded checksums.txt is unreadable" >&2
+  exit 1
+}
+
+CHECKSUM_RESULT=$(
   awk -v asset="$ASSET" '
     {
+      sub(/\r$/, "")
       field = $2
       candidate = field
       sub(/^\*/, "", candidate)
@@ -137,37 +187,109 @@ CHECKSUM_LINE=$(
             (field != asset && field != "*" asset)) {
           malformed = 1
         }
-        line = $0
+        hash = $1
       } else if (last == asset) {
         count++
         malformed = 1
       }
     }
     END {
-      if (count != 1 || malformed) exit 1
-      print line
+      if (count == 0) {
+        print "missing"
+      } else if (count > 1) {
+        print "duplicate"
+      } else if (malformed) {
+        print "malformed"
+      } else {
+        print "ok:" hash
+      }
     }
-  ' checksums.txt
-) || { echo "Expected exactly one well-formed checksum entry for $ASSET" >&2; exit 1; }
-printf '%s\n' "$CHECKSUM_LINE" > "$ASSET.sha256"
-verify_amq_checksum() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum -c "$ASSET.sha256" || return 1
-  elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 -c "$ASSET.sha256" || return 1
-  else
-    echo "sha256sum or shasum is required" >&2
-    return 1
-  fi
+  ' "$DOWNLOAD_DIR/checksums.txt"
+) || {
+  echo "Could not read checksums.txt" >&2
+  exit 1
 }
-if verify_amq_checksum; then
-  tar xzf "$ASSET"
-  mkdir -p ~/.local/bin
-  mv amq ~/.local/bin/
+case "$CHECKSUM_RESULT" in
+  ok:*) EXPECTED="${CHECKSUM_RESULT#ok:}" ;;
+  *)
+    echo "Expected exactly one well-formed checksum entry for $ASSET" >&2
+    exit 1
+    ;;
+esac
+
+RECORD_FILE="$DOWNLOAD_DIR/selected.sha256"
+printf '%s  %s\n' "$EXPECTED" "$ASSET" >"$RECORD_FILE" || {
+  echo "Could not create the private verifier record" >&2
+  exit 1
+}
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$DOWNLOAD_DIR" && sha256sum -c "$RECORD_FILE") || {
+    echo "Checksum verification failed" >&2
+    exit 1
+  }
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$DOWNLOAD_DIR" && shasum -a 256 -c "$RECORD_FILE") || {
+    echo "Checksum verification failed" >&2
+    exit 1
+  }
 else
-  echo "Checksum verification failed; archive was not extracted." >&2
-  false
+  echo "sha256sum or shasum is required" >&2
+  exit 1
 fi
+
+tar xzf "$DOWNLOAD_DIR/$ASSET" -C "$EXTRACT_DIR" || {
+  echo "Archive extraction failed" >&2
+  exit 1
+}
+[ ! -L "$EXTRACT_DIR/amq" ] && [ -f "$EXTRACT_DIR/amq" ] &&
+  [ -s "$EXTRACT_DIR/amq" ] && [ -x "$EXTRACT_DIR/amq" ] || {
+  echo "Archive did not contain a regular executable amq binary" >&2
+  exit 1
+}
+mkdir -p "$TARGET_DIR" || {
+  echo "Could not create $TARGET_DIR" >&2
+  exit 1
+}
+STAGE_DIR=$(mktemp -d "$TARGET_DIR/.amq.install.XXXXXX") || {
+  echo "Could not create a staged install directory" >&2
+  exit 1
+}
+install -m 0755 "$EXTRACT_DIR/amq" "$STAGE_DIR/amq" || {
+  echo "Could not stage amq" >&2
+  exit 1
+}
+chmod 0755 "$STAGE_DIR/amq" || {
+  echo "Could not set staged amq permissions" >&2
+  exit 1
+}
+[ ! -L "$STAGE_DIR/amq" ] && [ -f "$STAGE_DIR/amq" ] &&
+  [ -s "$STAGE_DIR/amq" ] && [ -x "$STAGE_DIR/amq" ] || {
+  echo "Staged amq validation failed" >&2
+  exit 1
+}
+"$STAGE_DIR/amq" --version >/dev/null || {
+  echo "Staged amq failed its version check" >&2
+  exit 1
+}
+mv -f "$STAGE_DIR/amq" "$TARGET_DIR/" || {
+  echo "Could not publish amq" >&2
+  exit 1
+}
+[ ! -e "$STAGE_DIR/amq" ] && [ ! -L "$STAGE_DIR/amq" ] &&
+  [ ! -L "$TARGET_DIR/amq" ] && [ -f "$TARGET_DIR/amq" ] &&
+  [ -s "$TARGET_DIR/amq" ] && [ -x "$TARGET_DIR/amq" ] &&
+  cmp -s "$EXTRACT_DIR/amq" "$TARGET_DIR/amq" || {
+  echo "Published amq validation failed" >&2
+  exit 1
+}
+rmdir "$STAGE_DIR" 2>/dev/null || true
+STAGE_DIR=""
+"$TARGET_DIR/amq" --version || {
+  echo "Installed amq failed its version check" >&2
+  exit 1
+}
+)
+# AMQ_MANUAL_INSTALL_END
 ```
 
 ### Binary: Build from Source

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Installs to `~/.local/bin` or `~/go/bin` (no sudo required). Verify: `amq --vers
 curl -fsSL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/scripts/install.sh | bash -s -- --skill
 ```
 
-Review the script before running; it verifies release checksums when possible.
+Review the script before running. Installation fails unless `checksums.txt` has exactly one valid entry for the selected asset and `sha256sum` or `shasum` verifies it before extraction.
 
 ### 2. Install Skill
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,7 +110,14 @@ echo "Downloading: $ASSET"
 
 # Create temp directory
 TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
+STAGED_BINARY=""
+cleanup() {
+    if [ -n "$STAGED_BINARY" ]; then
+        rm -f "$STAGED_BINARY" || true
+    fi
+    rm -rf "$TMP_DIR" || true
+}
+trap cleanup EXIT
 
 # Download (curl -f fails on HTTP errors like 404)
 if ! curl -fsSL "$URL" -o "$TMP_DIR/$ASSET"; then
@@ -120,29 +127,97 @@ if ! curl -fsSL "$URL" -o "$TMP_DIR/$ASSET"; then
     exit 1
 fi
 
-# Verify checksums when possible
+# Verify the selected release asset before extracting or installing it.
 CHECKSUMS_FILE="$TMP_DIR/checksums.txt"
-if curl -fsSL "$CHECKSUMS_URL" -o "$CHECKSUMS_FILE"; then
-    CHECKSUM_LINE=$(grep " $ASSET$" "$CHECKSUMS_FILE" || true)
-    if [ -z "$CHECKSUM_LINE" ]; then
-        echo -e "${YELLOW}Warning: checksum entry not found for $ASSET${NC}"
-    elif command -v sha256sum &> /dev/null; then
-        (cd "$TMP_DIR" && echo "$CHECKSUM_LINE" | sha256sum -c -) || {
-            echo -e "${RED}Error: checksum verification failed${NC}"
-            exit 1
+if ! curl -fsSL "$CHECKSUMS_URL" -o "$CHECKSUMS_FILE"; then
+    echo -e "${RED}Error: failed to download checksums${NC}"
+    exit 1
+fi
+if [ ! -r "$CHECKSUMS_FILE" ]; then
+    echo -e "${RED}Error: checksums.txt is missing or unreadable${NC}"
+    exit 1
+fi
+
+if ! CHECKSUM_RESULT=$(awk -v asset="$ASSET" '
+    {
+        field = $2
+        candidate = field
+        sub(/^\*/, "", candidate)
+        last = $NF
+        sub(/^\*/, "", last)
+
+        if (candidate == asset) {
+            count++
+            if (NF != 2 ||
+                length($1) != 64 ||
+                $1 !~ /^[0-9A-Fa-f]+$/ ||
+                (field != asset && field != "*" asset)) {
+                malformed = 1
+            }
+            hash = $1
+        } else if (last == asset) {
+            count++
+            malformed = 1
         }
-    elif command -v shasum &> /dev/null; then
-        EXPECTED=$(echo "$CHECKSUM_LINE" | awk '{print $1}')
-        ACTUAL=$(shasum -a 256 "$TMP_DIR/$ASSET" | awk '{print $1}')
-        if [ "$EXPECTED" != "$ACTUAL" ]; then
-            echo -e "${RED}Error: checksum verification failed${NC}"
-            exit 1
-        fi
-    else
-        echo -e "${YELLOW}Warning: sha256 tool not found; skipping checksum verification${NC}"
+    }
+    END {
+        if (count == 0) {
+            print "missing"
+        } else if (count > 1) {
+            print "duplicate"
+        } else if (malformed) {
+            print "malformed"
+        } else {
+            print "ok:" hash
+        }
+    }
+' "$CHECKSUMS_FILE"); then
+    echo -e "${RED}Error: checksums.txt is unreadable${NC}"
+    exit 1
+fi
+
+case "$CHECKSUM_RESULT" in
+    missing)
+        echo -e "${RED}Error: checksum entry not found for $ASSET${NC}"
+        exit 1
+        ;;
+    duplicate)
+        echo -e "${RED}Error: duplicate checksum entries found for $ASSET${NC}"
+        exit 1
+        ;;
+    malformed)
+        echo -e "${RED}Error: malformed checksum entry for $ASSET${NC}"
+        exit 1
+        ;;
+    ok:*)
+        EXPECTED="${CHECKSUM_RESULT#ok:}"
+        ;;
+    *)
+        echo -e "${RED}Error: could not parse checksum entry for $ASSET${NC}"
+        exit 1
+        ;;
+esac
+
+if command -v sha256sum &> /dev/null; then
+    (cd "$TMP_DIR" && printf '%s  %s\n' "$EXPECTED" "$ASSET" | sha256sum -c -) || {
+        echo -e "${RED}Error: checksum verification failed${NC}"
+        exit 1
+    }
+elif command -v shasum &> /dev/null; then
+    if ! ACTUAL_LINE=$(shasum -a 256 "$TMP_DIR/$ASSET"); then
+        echo -e "${RED}Error: checksum verification failed${NC}"
+        exit 1
+    fi
+    ACTUAL="${ACTUAL_LINE%%[[:space:]]*}"
+    EXPECTED_NORMALIZED=$(printf '%s' "$EXPECTED" | tr '[:upper:]' '[:lower:]')
+    ACTUAL_NORMALIZED=$(printf '%s' "$ACTUAL" | tr '[:upper:]' '[:lower:]')
+    if [ "$EXPECTED_NORMALIZED" != "$ACTUAL_NORMALIZED" ]; then
+        echo -e "${RED}Error: checksum verification failed${NC}"
+        exit 1
     fi
 else
-    echo -e "${YELLOW}Warning: failed to download checksums; skipping verification${NC}"
+    echo -e "${RED}Error: sha256sum or shasum is required to verify the download${NC}"
+    exit 1
 fi
 
 cd "$TMP_DIR"
@@ -162,8 +237,27 @@ echo "Installing to: $INSTALL_DIR/amq"
 # Ensure install directory exists
 mkdir -p "$INSTALL_DIR"
 
-# Install binary with correct permissions
-install -m 0755 amq "$INSTALL_DIR/amq"
+# Build the replacement beside the target, then atomically publish it.
+if ! STAGED_BINARY=$(mktemp "$INSTALL_DIR/.amq.install.XXXXXX"); then
+    echo -e "${RED}Error: could not create staged install file${NC}"
+    exit 1
+fi
+if ! install -m 0755 amq "$STAGED_BINARY"; then
+    echo -e "${RED}Error: failed to stage binary${NC}"
+    exit 1
+fi
+if ! chmod 0755 "$STAGED_BINARY" ||
+   [ ! -f "$STAGED_BINARY" ] ||
+   [ ! -s "$STAGED_BINARY" ] ||
+   [ ! -x "$STAGED_BINARY" ]; then
+    echo -e "${RED}Error: staged binary validation failed${NC}"
+    exit 1
+fi
+if ! mv -f "$STAGED_BINARY" "$INSTALL_DIR/amq"; then
+    echo -e "${RED}Error: failed to publish binary${NC}"
+    exit 1
+fi
+STAGED_BINARY=""
 
 echo ""
 echo -e "${GREEN}Installation complete!${NC}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ set -e
 REPO="avivsinai/agent-message-queue"
 VERSION="${VERSION:-latest}"
 INSTALL_SKILL=false
+CALLER_PWD=$PWD
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -50,6 +51,10 @@ determine_install_dir() {
 }
 
 INSTALL_DIR=$(determine_install_dir)
+case "$INSTALL_DIR" in
+    /*) ;;
+    *) INSTALL_DIR="$CALLER_PWD/$INSTALL_DIR" ;;
+esac
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -109,15 +114,21 @@ CHECKSUMS_URL="https://github.com/$REPO/releases/download/$VERSION/checksums.txt
 echo "Downloading: $ASSET"
 
 # Create temp directory
-TMP_DIR=$(mktemp -d)
+TMP_DIR=""
+STAGE_DIR=""
 STAGED_BINARY=""
 cleanup() {
-    if [ -n "$STAGED_BINARY" ]; then
-        rm -f "$STAGED_BINARY" || true
+    if [ -n "$STAGE_DIR" ]; then
+        rm -rf "$STAGE_DIR" || true
     fi
-    rm -rf "$TMP_DIR" || true
+    if [ -n "$TMP_DIR" ]; then
+        rm -rf "$TMP_DIR" || true
+    fi
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+TMP_DIR=$(mktemp -d)
 
 # Download (curl -f fails on HTTP errors like 404)
 if ! curl -fsSL "$URL" -o "$TMP_DIR/$ASSET"; then
@@ -140,6 +151,7 @@ fi
 
 if ! CHECKSUM_RESULT=$(awk -v asset="$ASSET" '
     {
+        sub(/\r$/, "")
         field = $2
         candidate = field
         sub(/^\*/, "", candidate)
@@ -220,14 +232,16 @@ else
     exit 1
 fi
 
-cd "$TMP_DIR"
-if ! tar xzf "$ASSET" 2>/dev/null; then
+if ! tar xzf "$TMP_DIR/$ASSET" -C "$TMP_DIR" 2>/dev/null; then
     echo -e "${RED}Error: Failed to extract archive (corrupted download?)${NC}"
     exit 1
 fi
 
-if [ ! -f "amq" ]; then
-    echo -e "${RED}Error: Binary not found in archive${NC}"
+if [ -L "$TMP_DIR/amq" ] ||
+   [ ! -f "$TMP_DIR/amq" ] ||
+   [ ! -s "$TMP_DIR/amq" ] ||
+   [ ! -x "$TMP_DIR/amq" ]; then
+    echo -e "${RED}Error: archive did not contain a regular executable amq binary${NC}"
     exit 1
 fi
 
@@ -238,11 +252,12 @@ echo "Installing to: $INSTALL_DIR/amq"
 mkdir -p "$INSTALL_DIR"
 
 # Build the replacement beside the target, then atomically publish it.
-if ! STAGED_BINARY=$(mktemp "$INSTALL_DIR/.amq.install.XXXXXX"); then
-    echo -e "${RED}Error: could not create staged install file${NC}"
+if ! STAGE_DIR=$(mktemp -d "$INSTALL_DIR/.amq.install.XXXXXX"); then
+    echo -e "${RED}Error: could not create staged install directory${NC}"
     exit 1
 fi
-if ! install -m 0755 amq "$STAGED_BINARY"; then
+STAGED_BINARY="$STAGE_DIR/amq"
+if ! install -m 0755 "$TMP_DIR/amq" "$STAGED_BINARY"; then
     echo -e "${RED}Error: failed to stage binary${NC}"
     exit 1
 fi
@@ -253,21 +268,43 @@ if ! chmod 0755 "$STAGED_BINARY" ||
     echo -e "${RED}Error: staged binary validation failed${NC}"
     exit 1
 fi
-if ! mv -f "$STAGED_BINARY" "$INSTALL_DIR/amq"; then
+if ! "$STAGED_BINARY" --version >/dev/null; then
+    echo -e "${RED}Error: staged binary failed its version check${NC}"
+    exit 1
+fi
+if ! mv -f "$STAGED_BINARY" "$INSTALL_DIR/"; then
     echo -e "${RED}Error: failed to publish binary${NC}"
     exit 1
 fi
+if [ -e "$STAGED_BINARY" ] ||
+   [ -L "$STAGED_BINARY" ] ||
+   [ -L "$INSTALL_DIR/amq" ] ||
+   [ ! -f "$INSTALL_DIR/amq" ] ||
+   [ ! -s "$INSTALL_DIR/amq" ] ||
+   [ ! -x "$INSTALL_DIR/amq" ] ||
+   ! cmp -s "$TMP_DIR/amq" "$INSTALL_DIR/amq"; then
+    echo -e "${RED}Error: published binary validation failed${NC}"
+    exit 1
+fi
+rmdir "$STAGE_DIR" 2>/dev/null || true
+STAGE_DIR=""
 STAGED_BINARY=""
+
+# Verify the exact installed binary, never an older PATH entry.
+INSTALLED_BINARY="$INSTALL_DIR/amq"
+if INSTALLED_VERSION=$("$INSTALLED_BINARY" --version); then
+    echo "Installed: $INSTALLED_VERSION"
+else
+    echo -e "${RED}Error: installed binary failed its version check${NC}"
+    exit 1
+fi
 
 echo ""
 echo -e "${GREEN}Installation complete!${NC}"
 echo ""
 
-# Verify installation
-if command -v amq &> /dev/null; then
-    echo "Installed: $(amq --version)"
-else
-    echo -e "${RED}Warning: $INSTALL_DIR is not in your PATH${NC}"
+if ! PATH_AMQ=$(command -v amq 2>/dev/null); then
+    echo -e "${YELLOW}Warning: $INSTALL_DIR is not in your PATH${NC}"
     echo ""
     echo "Add it to your shell config:"
     if [ -n "$ZSH_VERSION" ] || [ -f "$HOME/.zshrc" ]; then
@@ -275,8 +312,20 @@ else
     else
         echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.bashrc && source ~/.bashrc"
     fi
-    echo ""
-    echo "Or run directly: $INSTALL_DIR/amq --version"
+else
+    case "$PATH_AMQ" in
+        /*) ;;
+        */*) PATH_AMQ="$CALLER_PWD/$PATH_AMQ" ;;
+    esac
+    if [[ ! "$PATH_AMQ" -ef "$INSTALLED_BINARY" ]]; then
+        echo -e "${YELLOW}Warning: PATH resolves amq to a different executable${NC}"
+        echo "  PATH-selected: $PATH_AMQ"
+        echo "  Verified install: $INSTALLED_BINARY"
+        echo ""
+        echo "Use the verified binary directly, or select it first in this shell:"
+        echo "  \"$INSTALLED_BINARY\" --version"
+        echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    fi
 fi
 
 echo ""
@@ -299,6 +348,6 @@ if [ "$INSTALL_SKILL" = true ]; then
 fi
 
 echo "Next steps:"
-echo "  1. Start agent: amq coop exec claude"
-echo "  Tip: eval \"\$(amq shell-setup)\" to add co-op aliases to your shell"
+echo "  1. Start agent: \"$INSTALLED_BINARY\" coop exec claude"
+echo "  Tip: eval \"\$(\"$INSTALLED_BINARY\" shell-setup)\" to add co-op aliases to your shell"
 echo ""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -331,4 +331,6 @@ echo "  hook log rotation: small log left in place"
 
 echo "claude-session-start.sh hook test ok"
 
+bash scripts/test_install_checksum.sh
+
 echo "smoke test ok"

--- a/scripts/test_install_checksum.sh
+++ b/scripts/test_install_checksum.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+INSTALL_SCRIPT="$SCRIPT_DIR/install.sh"
+INSTALL_DOC="$SCRIPT_DIR/../INSTALL.md"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+VERSION=v1.2.3
+ASSET=amq_1.2.3_linux_amd64.tar.gz
+GOOD_HASH=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+BAD_HASH=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+link_command() {
+  local bin_dir=$1
+  local name=$2
+  local path
+
+  path=$(command -v "$name")
+  ln -s "$path" "$bin_dir/$name"
+}
+
+write_common_tools() {
+  local bin_dir=$1
+
+  for command_name in awk chmod cp cut grep mkdir mktemp mv rm touch tr; do
+    link_command "$bin_dir" "$command_name"
+  done
+
+  cat >"$bin_dir/uname" <<'EOF'
+#!/bin/bash
+case "${1:-}" in
+  -s) printf 'Linux\n' ;;
+  -m) printf 'x86_64\n' ;;
+  *) exit 2 ;;
+esac
+EOF
+
+  cat >"$bin_dir/curl" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+output=
+url=
+while (($#)); do
+  case "$1" in
+    -o)
+      output=$2
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url=$1
+      shift
+      ;;
+  esac
+done
+
+case "$url" in
+  */checksums.txt)
+    case "$TEST_SCENARIO" in
+      checksum-download-failure)
+        exit 22
+        ;;
+      missing-checksums)
+        :
+        ;;
+      unreadable)
+        printf '%s  %s\n' "$GOOD_HASH" "$ASSET" >"$output"
+        chmod 000 "$output"
+        ;;
+      missing-entry)
+        printf '%s  other_asset.tar.gz\n' "$GOOD_HASH" >"$output"
+        ;;
+      duplicate)
+        printf '%s  %s\n%s  %s\n' \
+          "$GOOD_HASH" "$ASSET" "$GOOD_HASH" "$ASSET" >"$output"
+        ;;
+      malformed)
+        printf 'not-a-sha256  %s\n' "$ASSET" >"$output"
+        ;;
+      *)
+        printf '%s  %s\n' "$GOOD_HASH" "$ASSET" >"$output"
+        ;;
+    esac
+    ;;
+  *)
+    printf 'archive-data\n' >"$output"
+    ;;
+esac
+EOF
+
+  cat >"$bin_dir/tar" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+touch "$TEST_STATE_DIR/tar.called"
+case "$TEST_SCENARIO" in
+  tar-failure)
+    exit 1
+    ;;
+  missing-archive-binary)
+    exit 0
+    ;;
+  *)
+    printf '%s\n' 'new-binary' >amq
+    chmod 0755 amq
+    ;;
+esac
+EOF
+
+  cat >"$bin_dir/install" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+touch "$TEST_STATE_DIR/install.called"
+source_path=${@: -2:1}
+target_path=${@: -1}
+if [[ "$TEST_SCENARIO" == install-partial-failure ]]; then
+  printf '%s\n' 'partial-write' >"$target_path"
+  chmod 0600 "$target_path"
+  exit 1
+fi
+cp "$source_path" "$target_path"
+chmod 0755 "$target_path"
+EOF
+
+  chmod +x "$bin_dir/uname" "$bin_dir/curl" "$bin_dir/tar" "$bin_dir/install"
+}
+
+write_sha256sum() {
+  local bin_dir=$1
+
+  cat >"$bin_dir/sha256sum" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ "$#" -eq 2 && "$1" == "-c" && "$2" == "-" ]]
+record=
+IFS= read -r record
+case "$TEST_SCENARIO" in
+  sha256sum-mismatch)
+    exit 1
+    ;;
+  *)
+    [[ "$record" == "$GOOD_HASH  $ASSET" ]]
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/sha256sum"
+}
+
+write_shasum() {
+  local bin_dir=$1
+
+  cat >"$bin_dir/shasum" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+[[ "$#" -eq 3 && "$1" == "-a" && "$2" == "256" && "$3" == */"$ASSET" ]]
+case "$TEST_SCENARIO" in
+  shasum-mismatch)
+    printf '%s  %s\n' "$BAD_HASH" "${3:-}"
+    ;;
+  *)
+    printf '%s  %s\n' "$GOOD_HASH" "${3:-}"
+    ;;
+esac
+EOF
+  chmod +x "$bin_dir/shasum"
+}
+
+file_mode() {
+  local path=$1
+
+  if stat -c '%a' "$path" >/dev/null 2>&1; then
+    stat -c '%a' "$path"
+  else
+    stat -f '%Lp' "$path"
+  fi
+}
+
+run_case() {
+  local scenario=$1
+  local expected=$2
+  local hash_tool=${3:-none}
+  local expected_tar=${4:-no}
+  local expected_install=${5:-no}
+  local case_root="$TEST_ROOT/$scenario"
+  local bin_dir="$case_root/bin"
+  local install_dir="$case_root/install"
+  local state_dir="$case_root/state"
+  local home_dir="$case_root/home"
+  local output_file="$case_root/output"
+  local status
+
+  mkdir -p "$bin_dir" "$install_dir" "$state_dir" "$home_dir"
+  printf '%s\n' 'existing-binary' >"$install_dir/amq"
+  chmod 0711 "$install_dir/amq"
+  write_common_tools "$bin_dir"
+
+  case "$hash_tool" in
+    sha256sum) write_sha256sum "$bin_dir" ;;
+    shasum) write_shasum "$bin_dir" ;;
+    none) ;;
+    *) printf 'unknown hash tool: %s\n' "$hash_tool" >&2; exit 2 ;;
+  esac
+
+  set +e
+  PATH="$bin_dir" \
+    HOME="$home_dir" \
+    VERSION="$VERSION" \
+    INSTALL_DIR="$install_dir" \
+    TEST_SCENARIO="$scenario" \
+    TEST_STATE_DIR="$state_dir" \
+    GOOD_HASH="$GOOD_HASH" \
+    BAD_HASH="$BAD_HASH" \
+    ASSET="$ASSET" \
+    /bin/bash "$INSTALL_SCRIPT" >"$output_file" 2>&1
+  status=$?
+  set -e
+
+  if [[ "$expected" == failure ]]; then
+    if ((status == 0)); then
+      printf 'FAIL %s: expected nonzero exit\n' "$scenario" >&2
+      sed -n '1,120p' "$output_file" >&2
+      return 1
+    fi
+    [[ $(<"$install_dir/amq") == existing-binary ]] || {
+      printf 'FAIL %s: existing target changed\n' "$scenario" >&2
+      return 1
+    }
+    [[ $(file_mode "$install_dir/amq") == 711 ]] || {
+      printf 'FAIL %s: existing target mode changed\n' "$scenario" >&2
+      return 1
+    }
+  else
+    if ((status != 0)); then
+      printf 'FAIL %s: expected zero exit, got %s\n' "$scenario" "$status" >&2
+      sed -n '1,120p' "$output_file" >&2
+      return 1
+    fi
+    [[ $(<"$install_dir/amq") == new-binary ]] || {
+      printf 'FAIL %s: target was not replaced\n' "$scenario" >&2
+      return 1
+    }
+    [[ $(file_mode "$install_dir/amq") == 755 ]] || {
+      printf 'FAIL %s: installed target mode is not 0755\n' "$scenario" >&2
+      return 1
+    }
+  fi
+
+  if [[ "$expected_tar" == yes ]]; then
+    [[ -e "$state_dir/tar.called" ]] || {
+      printf 'FAIL %s: extraction did not occur\n' "$scenario" >&2
+      return 1
+    }
+  else
+    [[ ! -e "$state_dir/tar.called" ]] || {
+      printf 'FAIL %s: extraction occurred\n' "$scenario" >&2
+      return 1
+    }
+  fi
+
+  if [[ "$expected_install" == yes ]]; then
+    [[ -e "$state_dir/install.called" ]] || {
+      printf 'FAIL %s: install did not occur\n' "$scenario" >&2
+      return 1
+    }
+  else
+    [[ ! -e "$state_dir/install.called" ]] || {
+      printf 'FAIL %s: install occurred\n' "$scenario" >&2
+      return 1
+    }
+  fi
+
+  if compgen -G "$install_dir/.amq.install.*" >/dev/null; then
+    printf 'FAIL %s: staged install file leaked\n' "$scenario" >&2
+    return 1
+  fi
+
+  printf 'PASS %s\n' "$scenario"
+}
+
+manual_install_snippet() {
+  awk '
+    /^TAG=vX[.]Y[.]Z$/ { capture = 1 }
+    capture {
+      if ($0 == "```") exit
+      print
+    }
+  ' "$INSTALL_DOC"
+}
+
+run_manual_verifier_failure_case() {
+  local hash_tool=$1
+  local case_root="$TEST_ROOT/manual-$hash_tool-mismatch"
+  local bin_dir="$case_root/bin"
+  local state_dir="$case_root/state"
+  local home_dir="$case_root/home"
+  local output_file="$case_root/output"
+  local snippet
+  local status
+
+  mkdir -p "$bin_dir" "$state_dir" "$home_dir"
+  for command_name in awk mkdir mv touch; do
+    link_command "$bin_dir" "$command_name"
+  done
+
+  cat >"$bin_dir/curl" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+output=
+while (($#)); do
+  case "$1" in
+    -o)
+      output=$2
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+printf '%s  amq_X.Y.Z_darwin_arm64.tar.gz\n' \
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' >"$output"
+EOF
+
+  cat >"$bin_dir/$hash_tool" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+
+  cat >"$bin_dir/tar" <<'EOF'
+#!/bin/bash
+touch "$TEST_STATE_DIR/tar.called"
+exit 0
+EOF
+
+  chmod +x "$bin_dir/curl" "$bin_dir/$hash_tool" "$bin_dir/tar"
+  snippet=$(manual_install_snippet)
+  [[ -n "$snippet" ]] || {
+    printf 'FAIL manual-%s-mismatch: INSTALL.md snippet not found\n' "$hash_tool" >&2
+    return 1
+  }
+
+  set +e
+  (
+    cd "$case_root"
+    PATH="$bin_dir" \
+      HOME="$home_dir" \
+      TEST_STATE_DIR="$state_dir" \
+      /bin/bash -c "$snippet"
+  ) >"$output_file" 2>&1
+  status=$?
+  set -e
+
+  if ((status == 0)); then
+    printf 'FAIL manual-%s-mismatch: expected nonzero exit\n' "$hash_tool" >&2
+    sed -n '1,120p' "$output_file" >&2
+    return 1
+  fi
+  if [[ -e "$state_dir/tar.called" ]]; then
+    printf 'FAIL manual-%s-mismatch: extraction occurred after verifier failure\n' "$hash_tool" >&2
+    return 1
+  fi
+
+  printf 'PASS manual-%s-mismatch\n' "$hash_tool"
+}
+
+run_case checksum-download-failure failure sha256sum
+run_case missing-checksums failure sha256sum
+run_case unreadable failure sha256sum
+run_case missing-entry failure sha256sum
+run_case duplicate failure sha256sum
+run_case malformed failure sha256sum
+run_case no-tool failure
+run_case sha256sum-mismatch failure sha256sum
+run_case shasum-mismatch failure shasum
+run_case tar-failure failure sha256sum yes no
+run_case missing-archive-binary failure sha256sum yes no
+run_case install-partial-failure failure sha256sum yes yes
+run_case sha256sum-valid success sha256sum yes yes
+run_case shasum-valid success shasum yes yes
+run_manual_verifier_failure_case sha256sum
+run_manual_verifier_failure_case shasum

--- a/scripts/test_install_checksum.sh
+++ b/scripts/test_install_checksum.sh
@@ -24,9 +24,18 @@ link_command() {
 write_common_tools() {
   local bin_dir=$1
 
-  for command_name in awk chmod cp cut grep mkdir mktemp mv rm touch tr; do
+  for command_name in chmod cmp cp cut grep ln mkdir mktemp rm touch tr; do
     link_command "$bin_dir" "$command_name"
   done
+
+  cat >"$bin_dir/awk" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ "$TEST_SCENARIO" == parser-failure ]]; then
+  exit 2
+fi
+exec "$TEST_REAL_AWK" "$@"
+EOF
 
   cat >"$bin_dir/uname" <<'EOF'
 #!/bin/bash
@@ -69,8 +78,7 @@ case "$url" in
         :
         ;;
       unreadable)
-        printf '%s  %s\n' "$GOOD_HASH" "$ASSET" >"$output"
-        chmod 000 "$output"
+        ln -s "$TEST_STATE_DIR/does-not-exist" "$output"
         ;;
       missing-entry)
         printf '%s  other_asset.tar.gz\n' "$GOOD_HASH" >"$output"
@@ -81,6 +89,9 @@ case "$url" in
         ;;
       malformed)
         printf 'not-a-sha256  %s\n' "$ASSET" >"$output"
+        ;;
+      checksum-crlf)
+        printf '%s  %s\r\n' "$GOOD_HASH" "$ASSET" >"$output"
         ;;
       *)
         printf '%s  %s\n' "$GOOD_HASH" "$ASSET" >"$output"
@@ -97,16 +108,49 @@ EOF
 #!/bin/bash
 set -euo pipefail
 touch "$TEST_STATE_DIR/tar.called"
+output_dir=$PWD
+while (($#)); do
+  case "$1" in
+    -C)
+      output_dir=$2
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
 case "$TEST_SCENARIO" in
   tar-failure)
+    exit 1
+    ;;
+  tar-partial-failure)
+    printf '%s\n' 'partial-archive-binary' >"$output_dir/amq"
+    chmod 0755 "$output_dir/amq"
     exit 1
     ;;
   missing-archive-binary)
     exit 0
     ;;
+  version-check-failure)
+    printf '%s\n' \
+      '#!/bin/bash' \
+      'touch "$TEST_STATE_DIR/prepublish-staged.called"' \
+      'exit 42' >"$output_dir/amq"
+    chmod 0755 "$output_dir/amq"
+    ;;
   *)
-    printf '%s\n' 'new-binary' >amq
-    chmod 0755 amq
+    printf '%s\n' \
+      '#!/bin/bash' \
+      'if [[ "$0" == "$TEST_INSTALL_DIR/amq" ]]; then' \
+      '  touch "$TEST_STATE_DIR/postinstall-final.called"' \
+      'elif [[ "$0" == *"/.amq.install."*"/amq" ]]; then' \
+      '  touch "$TEST_STATE_DIR/prepublish-staged.called"' \
+      'else' \
+      '  touch "$TEST_STATE_DIR/postinstall-wrong-path.called"' \
+      'fi' \
+      "printf '%s\\n' 'amq test-version'" >"$output_dir/amq"
+    chmod 0755 "$output_dir/amq"
     ;;
 esac
 EOF
@@ -122,11 +166,67 @@ if [[ "$TEST_SCENARIO" == install-partial-failure ]]; then
   chmod 0600 "$target_path"
   exit 1
 fi
+if [[ "$TEST_SCENARIO" == staged-binary-empty ]]; then
+  : >"$target_path"
+  chmod 0755 "$target_path"
+  exit 0
+fi
+if [[ "$TEST_SCENARIO" == signal-int ]]; then
+  kill -INT "$PPID"
+  /bin/sleep 0.1
+  exit 1
+fi
+if [[ "$TEST_SCENARIO" == signal-term ]]; then
+  kill -TERM "$PPID"
+  /bin/sleep 0.1
+  exit 1
+fi
 cp "$source_path" "$target_path"
 chmod 0755 "$target_path"
 EOF
 
-  chmod +x "$bin_dir/uname" "$bin_dir/curl" "$bin_dir/tar" "$bin_dir/install"
+  cat >"$bin_dir/mv" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+case "$TEST_SCENARIO" in
+  publish-failure)
+    exit 1
+    ;;
+  target-shape-change)
+    rm -f "$TEST_INSTALL_DIR/amq"
+    mkdir "$TEST_INSTALL_DIR/amq"
+    exec "$TEST_REAL_MV" "$@"
+    ;;
+  *)
+    exec "$TEST_REAL_MV" "$@"
+    ;;
+esac
+EOF
+
+  cat >"$bin_dir/rmdir" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ "$TEST_SCENARIO" == postpublish-rmdir-failure ]]; then
+  exit 1
+fi
+exec "$TEST_REAL_RMDIR" "$@"
+EOF
+
+  cat >"$bin_dir/amq" <<'EOF'
+#!/bin/bash
+touch "$TEST_STATE_DIR/path-amq.called"
+printf '%s\n' 'wrong PATH amq'
+EOF
+
+  chmod +x \
+    "$bin_dir/awk" \
+    "$bin_dir/uname" \
+    "$bin_dir/curl" \
+    "$bin_dir/tar" \
+    "$bin_dir/install" \
+    "$bin_dir/mv" \
+    "$bin_dir/rmdir" \
+    "$bin_dir/amq"
 }
 
 write_sha256sum() {
@@ -185,18 +285,70 @@ run_case() {
   local hash_tool=${3:-none}
   local expected_tar=${4:-no}
   local expected_install=${5:-no}
+  local target_shape=${6:-regular}
   local case_root="$TEST_ROOT/$scenario"
   local bin_dir="$case_root/bin"
+  local caller_dir="$case_root/caller"
   local install_dir="$case_root/install"
+  local install_arg="$install_dir"
   local state_dir="$case_root/state"
   local home_dir="$case_root/home"
+  local temp_dir="$case_root/tmp"
+  local referent_file="$case_root/referent-amq"
+  local referent_dir="$case_root/referent-dir"
   local output_file="$case_root/output"
+  local leaks
+  local real_awk
+  local real_mv
+  local real_rmdir
   local status
 
-  mkdir -p "$bin_dir" "$install_dir" "$state_dir" "$home_dir"
-  printf '%s\n' 'existing-binary' >"$install_dir/amq"
-  chmod 0711 "$install_dir/amq"
+  real_awk=$(command -v awk)
+  real_mv=$(command -v mv)
+  real_rmdir=$(command -v rmdir)
+  if [[ "$scenario" == relative-install-dir ]]; then
+    install_dir="$caller_dir/relative-bin"
+    install_arg=relative-bin
+  fi
+
+  mkdir -p \
+    "$bin_dir" \
+    "$install_dir" \
+    "$state_dir" \
+    "$home_dir" \
+    "$caller_dir" \
+    "$temp_dir"
+  case "$target_shape" in
+    absent)
+      ;;
+    regular|target-shape-change)
+      printf '%s\n' 'existing-binary' >"$install_dir/amq"
+      chmod 0711 "$install_dir/amq"
+      ;;
+    symlink-file)
+      printf '%s\n' 'referent-binary' >"$referent_file"
+      chmod 0711 "$referent_file"
+      ln -s "$referent_file" "$install_dir/amq"
+      ;;
+    directory)
+      mkdir "$install_dir/amq"
+      printf '%s\n' 'directory-sentinel' >"$install_dir/amq/sentinel"
+      ;;
+    symlink-dir)
+      mkdir "$referent_dir"
+      printf '%s\n' 'directory-sentinel' >"$referent_dir/sentinel"
+      ln -s "$referent_dir" "$install_dir/amq"
+      ;;
+    *)
+      printf 'unknown target shape: %s\n' "$target_shape" >&2
+      exit 2
+      ;;
+  esac
   write_common_tools "$bin_dir"
+  if [[ "$scenario" == path-same-symlink ]]; then
+    rm -f "$bin_dir/amq"
+    ln -s "$install_dir/amq" "$bin_dir/amq"
+  fi
 
   case "$hash_tool" in
     sha256sum) write_sha256sum "$bin_dir" ;;
@@ -206,16 +358,24 @@ run_case() {
   esac
 
   set +e
-  PATH="$bin_dir" \
-    HOME="$home_dir" \
-    VERSION="$VERSION" \
-    INSTALL_DIR="$install_dir" \
-    TEST_SCENARIO="$scenario" \
-    TEST_STATE_DIR="$state_dir" \
-    GOOD_HASH="$GOOD_HASH" \
-    BAD_HASH="$BAD_HASH" \
-    ASSET="$ASSET" \
-    /bin/bash "$INSTALL_SCRIPT" >"$output_file" 2>&1
+  (
+    cd "$caller_dir"
+    PATH="$bin_dir" \
+      HOME="$home_dir" \
+      TMPDIR="$temp_dir" \
+      VERSION="$VERSION" \
+      INSTALL_DIR="$install_arg" \
+      TEST_SCENARIO="$scenario" \
+      TEST_STATE_DIR="$state_dir" \
+      TEST_INSTALL_DIR="$install_dir" \
+      TEST_REAL_AWK="$real_awk" \
+      TEST_REAL_MV="$real_mv" \
+      TEST_REAL_RMDIR="$real_rmdir" \
+      GOOD_HASH="$GOOD_HASH" \
+      BAD_HASH="$BAD_HASH" \
+      ASSET="$ASSET" \
+      /bin/bash "$INSTALL_SCRIPT"
+  ) >"$output_file" 2>&1
   status=$?
   set -e
 
@@ -225,26 +385,101 @@ run_case() {
       sed -n '1,120p' "$output_file" >&2
       return 1
     fi
-    [[ $(<"$install_dir/amq") == existing-binary ]] || {
-      printf 'FAIL %s: existing target changed\n' "$scenario" >&2
-      return 1
-    }
-    [[ $(file_mode "$install_dir/amq") == 711 ]] || {
-      printf 'FAIL %s: existing target mode changed\n' "$scenario" >&2
-      return 1
-    }
+    case "$target_shape" in
+      absent)
+        [[ ! -e "$install_dir/amq" && ! -L "$install_dir/amq" ]] || {
+          printf 'FAIL %s: absent target was created\n' "$scenario" >&2
+          return 1
+        }
+        ;;
+      regular)
+        [[ $(<"$install_dir/amq") == existing-binary ]] || {
+          printf 'FAIL %s: existing target changed\n' "$scenario" >&2
+          return 1
+        }
+        [[ $(file_mode "$install_dir/amq") == 711 ]] || {
+          printf 'FAIL %s: existing target mode changed\n' "$scenario" >&2
+          return 1
+        }
+        ;;
+      target-shape-change)
+        [[ -d "$install_dir/amq" && ! -L "$install_dir/amq" ]] || {
+          printf 'FAIL %s: target shape-change fixture was not retained\n' "$scenario" >&2
+          return 1
+        }
+        ;;
+      directory)
+        [[ -d "$install_dir/amq" && ! -L "$install_dir/amq" ]] || {
+          printf 'FAIL %s: target directory changed type\n' "$scenario" >&2
+          return 1
+        }
+        [[ $(<"$install_dir/amq/sentinel") == directory-sentinel ]] || {
+          printf 'FAIL %s: target directory sentinel changed\n' "$scenario" >&2
+          return 1
+        }
+        ;;
+      symlink-dir)
+        [[ -L "$install_dir/amq" && $(readlink "$install_dir/amq") == "$referent_dir" ]] || {
+          printf 'FAIL %s: target directory symlink changed\n' "$scenario" >&2
+          return 1
+        }
+        [[ $(<"$referent_dir/sentinel") == directory-sentinel ]] || {
+          printf 'FAIL %s: directory referent changed\n' "$scenario" >&2
+          return 1
+        }
+        ;;
+      symlink-file)
+        [[ -L "$install_dir/amq" ]] || {
+          printf 'FAIL %s: target file symlink changed\n' "$scenario" >&2
+          return 1
+        }
+        ;;
+    esac
   else
     if ((status != 0)); then
       printf 'FAIL %s: expected zero exit, got %s\n' "$scenario" "$status" >&2
       sed -n '1,120p' "$output_file" >&2
       return 1
     fi
-    [[ $(<"$install_dir/amq") == new-binary ]] || {
-      printf 'FAIL %s: target was not replaced\n' "$scenario" >&2
+    [[ ! -L "$install_dir/amq" && -f "$install_dir/amq" ]] || {
+      printf 'FAIL %s: target is not a regular non-symlink file\n' "$scenario" >&2
       return 1
     }
     [[ $(file_mode "$install_dir/amq") == 755 ]] || {
       printf 'FAIL %s: installed target mode is not 0755\n' "$scenario" >&2
+      return 1
+    }
+    [[ $(TEST_STATE_DIR="$state_dir" TEST_INSTALL_DIR="$install_dir" \
+      "$install_dir/amq" --version) == "amq test-version" ]] || {
+      printf 'FAIL %s: installed target did not execute\n' "$scenario" >&2
+      return 1
+    }
+  fi
+
+  if [[ "$scenario" == version-check-failure ]]; then
+    if grep -F "Installation complete!" "$output_file" >/dev/null; then
+      printf 'FAIL %s: success banner printed before version validation\n' "$scenario" >&2
+      return 1
+    fi
+  fi
+
+  if [[ "$target_shape" == symlink-file ]]; then
+    [[ $(<"$referent_file") == referent-binary ]] || {
+      printf 'FAIL %s: symlink referent bytes changed\n' "$scenario" >&2
+      return 1
+    }
+    [[ $(file_mode "$referent_file") == 711 ]] || {
+      printf 'FAIL %s: symlink referent mode changed\n' "$scenario" >&2
+      return 1
+    }
+  fi
+  if [[ "$target_shape" == symlink-dir ]]; then
+    [[ $(<"$referent_dir/sentinel") == directory-sentinel ]] || {
+      printf 'FAIL %s: directory symlink referent changed\n' "$scenario" >&2
+      return 1
+    }
+    [[ $(find "$referent_dir" -mindepth 1 -maxdepth 1 | wc -l | tr -d '[:space:]') == 1 ]] || {
+      printf 'FAIL %s: publication descended into directory symlink referent\n' "$scenario" >&2
       return 1
     }
   fi
@@ -273,38 +508,165 @@ run_case() {
     }
   fi
 
-  if compgen -G "$install_dir/.amq.install.*" >/dev/null; then
+  leaks=$(find "$case_root" -name '.amq.install.*' -print -quit)
+  if [[ -n "$leaks" && "$scenario" != postpublish-rmdir-failure ]]; then
     printf 'FAIL %s: staged install file leaked\n' "$scenario" >&2
     return 1
   fi
+  leaks=$(find "$temp_dir" -mindepth 1 -print -quit)
+  if [[ -n "$leaks" ]]; then
+    printf 'FAIL %s: temporary download state leaked\n' "$scenario" >&2
+    return 1
+  fi
+
+  if [[ "$expected" == success ]]; then
+    [[ -e "$state_dir/prepublish-staged.called" ]] || {
+      printf 'FAIL %s: staged binary was not verified before publication\n' "$scenario" >&2
+      return 1
+    }
+    [[ -e "$state_dir/postinstall-final.called" ]] || {
+      printf 'FAIL %s: exact installed binary was not verified\n' "$scenario" >&2
+      return 1
+    }
+  elif [[ "$scenario" == version-check-failure ]]; then
+    [[ -e "$state_dir/prepublish-staged.called" ]] || {
+      printf 'FAIL %s: failing staged binary was not executed before publication\n' "$scenario" >&2
+      return 1
+    }
+  else
+    [[ ! -e "$state_dir/postinstall-final.called" ]] || {
+      printf 'FAIL %s: postinstall verification ran after failure\n' "$scenario" >&2
+      return 1
+    }
+  fi
+  [[ ! -e "$state_dir/postinstall-wrong-path.called" ]] || {
+    printf 'FAIL %s: postinstall verification used a non-final path\n' "$scenario" >&2
+    return 1
+  }
+  [[ ! -e "$state_dir/path-amq.called" ]] || {
+    printf 'FAIL %s: postinstall verification resolved amq through PATH\n' "$scenario" >&2
+    return 1
+  }
+
+  case "$scenario" in
+    stale-path)
+      grep -F "Warning: PATH resolves amq to a different executable" "$output_file" >/dev/null || {
+        printf 'FAIL %s: stale PATH warning missing\n' "$scenario" >&2
+        return 1
+      }
+      grep -F "  PATH-selected: $bin_dir/amq" "$output_file" >/dev/null || {
+        printf 'FAIL %s: stale PATH warning omitted selected executable\n' "$scenario" >&2
+        return 1
+      }
+      grep -F "  Verified install: $install_dir/amq" "$output_file" >/dev/null || {
+        printf 'FAIL %s: stale PATH warning omitted verified executable\n' "$scenario" >&2
+        return 1
+      }
+      grep -F "  export PATH=\"$install_dir:\$PATH\"" "$output_file" >/dev/null || {
+        printf 'FAIL %s: stale PATH warning omitted concrete repair\n' "$scenario" >&2
+        return 1
+      }
+      ;;
+    path-same-symlink)
+      if grep -F "Warning: PATH resolves amq to a different executable" "$output_file" >/dev/null; then
+        printf 'FAIL %s: same-file PATH symlink was reported as stale\n' "$scenario" >&2
+        return 1
+      fi
+      ;;
+  esac
+  case "$scenario" in
+    stale-path|path-same-symlink)
+      grep -F "  1. Start agent: \"$install_dir/amq\" coop exec claude" "$output_file" >/dev/null || {
+        printf 'FAIL %s: immediate next step did not use verified binary\n' "$scenario" >&2
+        return 1
+      }
+      if grep -F "  1. Start agent: amq coop exec claude" "$output_file" >/dev/null; then
+        printf 'FAIL %s: immediate next step retained stale PATH lookup\n' "$scenario" >&2
+        return 1
+      fi
+      ;;
+  esac
 
   printf 'PASS %s\n' "$scenario"
 }
 
 manual_install_snippet() {
   awk '
-    /^TAG=vX[.]Y[.]Z$/ { capture = 1 }
-    capture {
-      if ($0 == "```") exit
-      print
-    }
+    /^For manual installs, verify / { armed = 1 }
+    armed && /^```bash$/ { capture = 1; next }
+    capture && /^```$/ { exit }
+    capture { print }
   ' "$INSTALL_DOC"
 }
 
-run_manual_verifier_failure_case() {
-  local hash_tool=$1
-  local case_root="$TEST_ROOT/manual-$hash_tool-mismatch"
+run_manual_case() {
+  local scenario=$1
+  local expected=$2
+  local hash_tool=${3:-none}
+  local expected_tar=${4:-no}
+  local expected_publish=${5:-no}
+  local archive_shape=${6:-regular}
+  local case_root="$TEST_ROOT/$scenario"
   local bin_dir="$case_root/bin"
   local state_dir="$case_root/state"
   local home_dir="$case_root/home"
+  local caller_dir="$case_root/caller"
+  local temp_dir="$case_root/tmp"
+  local target_dir="$home_dir/.local/bin"
+  local archive_referent="$case_root/archive-referent"
+  local sidecar_sentinel="$case_root/sidecar-sentinel"
   local output_file="$case_root/output"
+  local leaks
+  local real_awk
+  local real_mkdir
+  local real_mktemp
+  local real_mv
+  local real_rmdir
   local snippet
   local status
 
-  mkdir -p "$bin_dir" "$state_dir" "$home_dir"
-  for command_name in awk mkdir mv touch; do
+  real_awk=$(command -v awk)
+  real_mkdir=$(command -v mkdir)
+  real_mktemp=$(command -v mktemp)
+  real_mv=$(command -v mv)
+  real_rmdir=$(command -v rmdir)
+  mkdir -p "$bin_dir" "$state_dir" "$target_dir" "$caller_dir" "$temp_dir"
+  printf '%s\n' 'old-installed-binary' >"$target_dir/amq"
+  chmod 0711 "$target_dir/amq"
+  printf '%s\n' 'stale-caller-amq' >"$caller_dir/amq"
+  chmod 0755 "$caller_dir/amq"
+  if [[ "$archive_shape" == symlink ]]; then
+    printf '%s\n' 'archive-data' >"$archive_referent"
+    ln -s "$archive_referent" \
+      "$caller_dir/amq_X.Y.Z_darwin_arm64.tar.gz"
+  else
+    printf '%s\n' 'archive-data' \
+      >"$caller_dir/amq_X.Y.Z_darwin_arm64.tar.gz"
+  fi
+  printf '%s  amq_X.Y.Z_darwin_arm64.tar.gz\n' "$GOOD_HASH" \
+    >"$caller_dir/checksums.txt"
+  printf '%s\n' 'sidecar-sentinel' >"$sidecar_sentinel"
+  if [[ "$scenario" == manual-record-write-failure ]]; then
+    mkdir "$case_root/sidecar-directory"
+    ln -s "$case_root/sidecar-directory" \
+      "$caller_dir/amq_X.Y.Z_darwin_arm64.tar.gz.sha256"
+  else
+    ln -s "$sidecar_sentinel" \
+      "$caller_dir/amq_X.Y.Z_darwin_arm64.tar.gz.sha256"
+  fi
+
+  for command_name in chmod cmp cp install ln rm touch tr; do
     link_command "$bin_dir" "$command_name"
   done
+
+  cat >"$bin_dir/awk" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ "$TEST_SCENARIO" == manual-parser-failure ]]; then
+  exit 2
+fi
+exec "$TEST_REAL_AWK" "$@"
+EOF
 
   cat >"$bin_dir/curl" <<'EOF'
 #!/bin/bash
@@ -321,65 +683,297 @@ while (($#)); do
       ;;
   esac
 done
-printf '%s  amq_X.Y.Z_darwin_arm64.tar.gz\n' \
-  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' >"$output"
+if [[ "$TEST_SCENARIO" == manual-curl-stale-failure ]]; then
+  exit 22
+fi
+if [[ "$TEST_SCENARIO" == manual-checksum-crlf ]]; then
+  printf '%s  amq_X.Y.Z_darwin_arm64.tar.gz\r\n' "$GOOD_HASH" >"$output"
+else
+  printf '%s  amq_X.Y.Z_darwin_arm64.tar.gz\n' "$GOOD_HASH" >"$output"
+fi
 EOF
 
-  cat >"$bin_dir/$hash_tool" <<'EOF'
+  if [[ "$hash_tool" != none ]]; then
+    cat >"$bin_dir/$hash_tool" <<'EOF'
 #!/bin/bash
-exit 1
+set -euo pipefail
+touch "$TEST_STATE_DIR/hash.called"
+case "$TEST_SCENARIO" in
+  manual-sha256sum-mismatch|manual-shasum-mismatch)
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
 EOF
+    chmod +x "$bin_dir/$hash_tool"
+  fi
 
   cat >"$bin_dir/tar" <<'EOF'
 #!/bin/bash
+set -euo pipefail
 touch "$TEST_STATE_DIR/tar.called"
-exit 0
+output_dir=$PWD
+while (($#)); do
+  case "$1" in
+    -C)
+      output_dir=$2
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+case "$TEST_SCENARIO" in
+  manual-tar-failure)
+    exit 1
+    ;;
+  manual-tar-partial-failure)
+    printf '%s\n' 'partial-extracted-amq' >"$output_dir/amq"
+    chmod 0755 "$output_dir/amq"
+    exit 1
+    ;;
+  manual-missing-extracted-amq)
+    exit 0
+    ;;
+  manual-version-check-failure)
+    printf '%s\n' '#!/bin/bash' 'exit 42' >"$output_dir/amq"
+    chmod 0755 "$output_dir/amq"
+    ;;
+  *)
+    printf '%s\n' \
+      '#!/bin/bash' \
+      "printf '%s\\n' 'amq manual-test-version'" >"$output_dir/amq"
+    chmod 0755 "$output_dir/amq"
+    ;;
+esac
 EOF
 
-  chmod +x "$bin_dir/curl" "$bin_dir/$hash_tool" "$bin_dir/tar"
+  cat >"$bin_dir/mkdir" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ "$TEST_SCENARIO" == manual-mkdir-failure &&
+      "${*: -1}" == "$HOME/.local/bin" ]]; then
+  exit 1
+fi
+exec "$TEST_REAL_MKDIR" "$@"
+EOF
+
+  cat >"$bin_dir/mktemp" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+result=$("$TEST_REAL_MKTEMP" "$@")
+count=0
+if [[ -f "$TEST_STATE_DIR/mktemp.count" ]]; then
+  count=$(<"$TEST_STATE_DIR/mktemp.count")
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$TEST_STATE_DIR/mktemp.count"
+if [[ "$TEST_SCENARIO" == manual-record-write-failure && "$count" -eq 1 ]]; then
+  "$TEST_REAL_MKDIR" "$result/selected.sha256"
+fi
+printf '%s\n' "$result"
+if [[ "$count" -eq 1 ]]; then
+  case "$TEST_SCENARIO" in
+    manual-signal-int)
+      kill -INT "$PPID"
+      ;;
+    manual-signal-term)
+      kill -TERM "$PPID"
+      ;;
+  esac
+fi
+EOF
+
+  cat >"$bin_dir/mv" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+touch "$TEST_STATE_DIR/publish.called"
+if [[ "$TEST_SCENARIO" == manual-publish-failure ]]; then
+  exit 1
+fi
+exec "$TEST_REAL_MV" "$@"
+EOF
+
+  cat >"$bin_dir/rmdir" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ "$TEST_SCENARIO" == manual-postpublish-rmdir-failure ]]; then
+  exit 1
+fi
+exec "$TEST_REAL_RMDIR" "$@"
+EOF
+
+  chmod +x \
+    "$bin_dir/awk" \
+    "$bin_dir/curl" \
+    "$bin_dir/tar" \
+    "$bin_dir/mkdir" \
+    "$bin_dir/mktemp" \
+    "$bin_dir/mv" \
+    "$bin_dir/rmdir"
   snippet=$(manual_install_snippet)
   [[ -n "$snippet" ]] || {
-    printf 'FAIL manual-%s-mismatch: INSTALL.md snippet not found\n' "$hash_tool" >&2
+    printf 'FAIL %s: INSTALL.md snippet not found\n' "$scenario" >&2
     return 1
   }
 
   set +e
   (
-    cd "$case_root"
+    cd "$caller_dir"
     PATH="$bin_dir" \
       HOME="$home_dir" \
+      TMPDIR="$temp_dir" \
+      TEST_SCENARIO="$scenario" \
       TEST_STATE_DIR="$state_dir" \
-      /bin/bash -c "$snippet"
+      TEST_REAL_AWK="$real_awk" \
+      TEST_REAL_MKDIR="$real_mkdir" \
+      TEST_REAL_MKTEMP="$real_mktemp" \
+      TEST_REAL_MV="$real_mv" \
+      TEST_REAL_RMDIR="$real_rmdir" \
+      GOOD_HASH="$GOOD_HASH" \
+      /bin/bash -c "
+$snippet
+snippet_status=\$?
+printf '%s\n' survived >'$state_dir/shell-survived'
+exit \"\$snippet_status\"
+"
   ) >"$output_file" 2>&1
   status=$?
   set -e
 
-  if ((status == 0)); then
-    printf 'FAIL manual-%s-mismatch: expected nonzero exit\n' "$hash_tool" >&2
+  if [[ "$expected" == failure ]]; then
+    if ((status == 0)); then
+      printf 'FAIL %s: expected nonzero exit\n' "$scenario" >&2
+      sed -n '1,120p' "$output_file" >&2
+      return 1
+    fi
+  elif ((status != 0)); then
+    printf 'FAIL %s: expected zero exit, got %s\n' "$scenario" "$status" >&2
     sed -n '1,120p' "$output_file" >&2
     return 1
   fi
-  if [[ -e "$state_dir/tar.called" ]]; then
-    printf 'FAIL manual-%s-mismatch: extraction occurred after verifier failure\n' "$hash_tool" >&2
+  [[ -e "$state_dir/shell-survived" ]] || {
+    printf 'FAIL %s: documentation failure exited the caller shell\n' "$scenario" >&2
     return 1
+  }
+
+  if [[ "$expected_tar" == yes ]]; then
+    [[ -e "$state_dir/tar.called" ]] || {
+      printf 'FAIL %s: extraction did not reach the intended failure\n' "$scenario" >&2
+      return 1
+    }
+  else
+    [[ ! -e "$state_dir/tar.called" ]] || {
+      printf 'FAIL %s: extraction occurred after an earlier failure\n' "$scenario" >&2
+      return 1
+    }
+  fi
+  if [[ "$expected_publish" == yes ]]; then
+    [[ -e "$state_dir/publish.called" ]] || {
+      printf 'FAIL %s: publication did not reach the intended failure\n' "$scenario" >&2
+      return 1
+    }
+  else
+    [[ ! -e "$state_dir/publish.called" ]] || {
+      printf 'FAIL %s: publication occurred after an earlier failure\n' "$scenario" >&2
+      return 1
+    }
   fi
 
-  printf 'PASS manual-%s-mismatch\n' "$hash_tool"
+  if [[ "$expected" == failure ]]; then
+    [[ $(<"$target_dir/amq") == old-installed-binary ]] || {
+      printf 'FAIL %s: existing installed binary changed\n' "$scenario" >&2
+      return 1
+    }
+    [[ $(file_mode "$target_dir/amq") == 711 ]] || {
+      printf 'FAIL %s: existing installed mode changed\n' "$scenario" >&2
+      return 1
+    }
+  else
+    [[ ! -L "$target_dir/amq" && -f "$target_dir/amq" ]] || {
+      printf 'FAIL %s: installed target is not a regular file\n' "$scenario" >&2
+      return 1
+    }
+    [[ $(file_mode "$target_dir/amq") == 755 ]] || {
+      printf 'FAIL %s: installed target mode is not 0755\n' "$scenario" >&2
+      return 1
+    }
+    [[ $("$target_dir/amq" --version) == "amq manual-test-version" ]] || {
+      printf 'FAIL %s: installed target did not execute\n' "$scenario" >&2
+      return 1
+    }
+  fi
+  [[ $(<"$caller_dir/amq") == stale-caller-amq ]] || {
+    printf 'FAIL %s: stale caller amq was consumed or changed\n' "$scenario" >&2
+    return 1
+  }
+  if [[ "$scenario" != manual-record-write-failure ]]; then
+    [[ -L "$caller_dir/amq_X.Y.Z_darwin_arm64.tar.gz.sha256" ]] || {
+      printf 'FAIL %s: caller sidecar symlink was replaced\n' "$scenario" >&2
+      return 1
+    }
+    [[ $(<"$sidecar_sentinel") == sidecar-sentinel ]] || {
+      printf 'FAIL %s: caller sidecar symlink referent changed\n' "$scenario" >&2
+      return 1
+    }
+  fi
+  leaks=$(find "$temp_dir" "$target_dir" -name '.amq.*' -print -quit)
+  [[ -z "$leaks" || "$scenario" == manual-postpublish-rmdir-failure ]] || {
+    printf 'FAIL %s: private manual install state leaked\n' "$scenario" >&2
+    return 1
+  }
+
+  printf 'PASS %s\n' "$scenario"
 }
 
 run_case checksum-download-failure failure sha256sum
 run_case missing-checksums failure sha256sum
 run_case unreadable failure sha256sum
+run_case parser-failure failure sha256sum
 run_case missing-entry failure sha256sum
 run_case duplicate failure sha256sum
 run_case malformed failure sha256sum
+run_case checksum-crlf success sha256sum yes yes
 run_case no-tool failure
 run_case sha256sum-mismatch failure sha256sum
 run_case shasum-mismatch failure shasum
 run_case tar-failure failure sha256sum yes no
+run_case tar-partial-failure failure sha256sum yes no
 run_case missing-archive-binary failure sha256sum yes no
 run_case install-partial-failure failure sha256sum yes yes
-run_case sha256sum-valid success sha256sum yes yes
-run_case shasum-valid success shasum yes yes
-run_manual_verifier_failure_case sha256sum
-run_manual_verifier_failure_case shasum
+run_case staged-binary-empty failure sha256sum yes yes
+run_case version-check-failure failure sha256sum yes yes
+run_case signal-int failure sha256sum yes yes
+run_case signal-term failure sha256sum yes yes
+run_case publish-failure failure sha256sum yes yes
+run_case postpublish-rmdir-failure success sha256sum yes yes
+run_case target-directory failure sha256sum yes yes directory
+run_case target-symlink-dir success sha256sum yes yes symlink-dir
+run_case target-shape-change failure sha256sum yes yes target-shape-change
+run_case target-absent success sha256sum yes yes absent
+run_case target-regular success sha256sum yes yes regular
+run_case target-symlink-file success sha256sum yes yes symlink-file
+run_case relative-install-dir success sha256sum yes yes regular
+run_case shasum-valid success shasum yes yes regular
+run_case stale-path success sha256sum yes yes regular
+run_case path-same-symlink success sha256sum yes yes regular
+run_manual_case manual-curl-stale-failure failure sha256sum no no
+run_manual_case manual-record-write-failure failure sha256sum no no
+run_manual_case manual-parser-failure failure sha256sum no no
+run_manual_case manual-no-hash failure none no no
+run_manual_case manual-sha256sum-mismatch failure sha256sum no no
+run_manual_case manual-shasum-mismatch failure shasum no no
+run_manual_case manual-tar-failure failure sha256sum yes no
+run_manual_case manual-tar-partial-failure failure sha256sum yes no
+run_manual_case manual-missing-extracted-amq failure sha256sum yes no
+run_manual_case manual-mkdir-failure failure sha256sum yes no
+run_manual_case manual-publish-failure failure sha256sum yes yes
+run_manual_case manual-version-check-failure failure sha256sum yes no
+run_manual_case manual-signal-term failure sha256sum no no
+run_manual_case manual-success success sha256sum yes yes
+run_manual_case manual-checksum-crlf success sha256sum yes yes
+run_manual_case manual-archive-symlink success sha256sum yes yes symlink
+run_manual_case manual-postpublish-rmdir-failure success sha256sum yes yes


### PR DESCRIPTION
## Summary
- require SHA-256 verification before extracting release archives
- stage validated binaries beside the target and atomically replace only after all checks pass
- preserve an existing install on download, checksum, extraction, or validation failure
- make the documented manual install flow fail closed in ordinary interactive shells

## Verification
- installer harness: 16/16
- shellcheck and bash syntax checks
- `make ci`

Merge is held for exact-head ChatGPT Pro review.