### PR TITLE
fix(wake): validate private bootstrap fds atomically

### DIFF
--- a/internal/cli/wake_owner_child_darwin.go
+++ b/internal/cli/wake_owner_child_darwin.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"sync"
 
 	"golang.org/x/sys/unix"
@@ -77,34 +76,84 @@ func validateDarwinWakeOwnerStartupRollbackFD(writeEnd *os.File) error {
 }
 
 func authoritativeWakePrivateStopFromEnv() (<-chan struct{}, func(), error) {
-	raw := strings.TrimSpace(os.Getenv(envWakePrivateStopFD))
-	if raw == "" {
-		return nil, func() {}, nil
+	bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+	if err != nil {
+		return nil, nil, err
 	}
-	if err := os.Unsetenv(envWakePrivateStopFD); err != nil {
-		return nil, nil, fmt.Errorf("clear %s after ingestion: %w", envWakePrivateStopFD, err)
+	handoff, err := parseWakeRepairChildHandoffDescriptors(bootstrap)
+	if err != nil {
+		return nil, nil, err
+	}
+	repairStop, err := parseWakeRepairChildStopDescriptor(bootstrap)
+	if err != nil {
+		return nil, nil, err
+	}
+	if handoff.present || repairStop.present {
+		return nil, nil, fmt.Errorf(
+			"repair descriptors are not valid without the complete private bootstrap transaction",
+		)
+	}
+	descriptor, err := parseAuthoritativeWakePrivateStopDescriptor(bootstrap)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := prepareAuthoritativeWakePrivateStopDescriptor(descriptor); err != nil {
+		if descriptor.present {
+			_ = unix.Close(descriptor.fd)
+		}
+		return nil, nil, err
+	}
+	return adoptAuthoritativeWakePrivateStopDescriptor(descriptor)
+}
+
+func parseAuthoritativeWakePrivateStopDescriptor(
+	bootstrap wakeRepairBootstrapEnv,
+) (wakePrivateStopDescriptor, error) {
+	raw := bootstrap.value(envWakePrivateStopFD)
+	if raw == "" {
+		return wakePrivateStopDescriptor{}, nil
 	}
 	fd, err := strconv.Atoi(raw)
 	if err != nil || fd < 3 {
-		return nil, nil, fmt.Errorf("%s is invalid", envWakePrivateStopFD)
+		return wakePrivateStopDescriptor{}, fmt.Errorf("%s is invalid", envWakePrivateStopFD)
 	}
-	file := os.NewFile(uintptr(fd), "authoritative-wake-private-stop")
+	return wakePrivateStopDescriptor{
+		fd:      fd,
+		name:    envWakePrivateStopFD,
+		present: true,
+	}, nil
+}
+
+func prepareAuthoritativeWakePrivateStopDescriptor(descriptor wakePrivateStopDescriptor) error {
+	if !descriptor.present {
+		return nil
+	}
+	// The inherited descriptor arrives as a raw numeric fd. Make it pollable
+	// before os.NewFile adopts it so cleanup can interrupt and join the startup
+	// read without relying on Darwin closing a blocking syscall from another
+	// goroutine.
+	if err := unix.SetNonblock(descriptor.fd, true); err != nil {
+		return fmt.Errorf("make %s fd nonblocking: %w", envWakePrivateStopFD, err)
+	}
+	return sealDarwinWakePrivateStopFDNumber(uintptr(descriptor.fd))
+}
+
+func adoptAuthoritativeWakePrivateStopDescriptor(
+	descriptor wakePrivateStopDescriptor,
+) (<-chan struct{}, func(), error) {
+	if !descriptor.present {
+		return nil, func() {}, nil
+	}
+	file := os.NewFile(uintptr(descriptor.fd), "authoritative-wake-private-stop")
 	if file == nil {
+		_ = unix.Close(descriptor.fd)
 		return nil, nil, fmt.Errorf("%s fd is unavailable", envWakePrivateStopFD)
-	}
-	if err := sealDarwinWakePrivateStopFD(file); err != nil {
-		_ = file.Close()
-		return nil, nil, err
 	}
 	stop, cleanup := watchAuthoritativeWakePrivateStop(file)
 	return stop, cleanup, nil
 }
 
-func sealDarwinWakePrivateStopFD(file *os.File) error {
-	if file == nil {
-		return fmt.Errorf("%s fd is unavailable", envWakePrivateStopFD)
-	}
-	fd := file.Fd()
+func sealDarwinWakePrivateStopFDNumber(fd uintptr) error {
 	flags, err := unix.FcntlInt(fd, unix.F_GETFD, 0)
 	if err != nil {
 		return fmt.Errorf("inspect %s fd flags: %w", envWakePrivateStopFD, err)

--- a/internal/cli/wake_owner_child_linux.go
+++ b/internal/cli/wake_owner_child_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"syscall"
 )
 
@@ -66,6 +67,26 @@ func prepareAuthoritativeWakeChildPlatform(cmd *exec.Cmd) (*authoritativeWakeChi
 	}, nil
 }
 
-func authoritativeWakePrivateStopFromEnv() (<-chan struct{}, func(), error) {
+func parseAuthoritativeWakePrivateStopDescriptor(
+	bootstrap wakeRepairBootstrapEnv,
+) (wakePrivateStopDescriptor, error) {
+	raw := bootstrap.value(envWakePrivateStopFD)
+	if raw == "" {
+		return wakePrivateStopDescriptor{}, nil
+	}
+	fd, err := strconv.Atoi(raw)
+	if err != nil || fd < 3 {
+		return wakePrivateStopDescriptor{}, fmt.Errorf("%s is invalid", envWakePrivateStopFD)
+	}
+	return wakePrivateStopDescriptor{}, fmt.Errorf("%s is unsupported on linux", envWakePrivateStopFD)
+}
+
+func prepareAuthoritativeWakePrivateStopDescriptor(wakePrivateStopDescriptor) error {
+	return nil
+}
+
+func adoptAuthoritativeWakePrivateStopDescriptor(
+	wakePrivateStopDescriptor,
+) (<-chan struct{}, func(), error) {
 	return nil, func() {}, nil
 }

--- a/internal/cli/wake_owner_child_unix.go
+++ b/internal/cli/wake_owner_child_unix.go
@@ -10,6 +10,12 @@ import (
 
 const envWakePrivateStopFD = "AMQ_WAKE_PRIVATE_STOP_FD"
 
+type wakePrivateStopDescriptor struct {
+	fd      int
+	name    string
+	present bool
+}
+
 type wakeOwnerChildCapabilityUnsupportedError struct {
 	Err error
 }

--- a/internal/cli/wake_repair_bootstrap_env_darwin_test.go
+++ b/internal/cli/wake_repair_bootstrap_env_darwin_test.go
@@ -1,0 +1,679 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestDarwinWakeRepairBootstrapRejectsCrossCapabilityAliasesAtomically(t *testing.T) {
+	commonNames := []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	}
+	for aliasIndex, aliasName := range commonNames {
+		t.Run(aliasName, func(t *testing.T) {
+			fds := openWakeRepairBootstrapDescriptors(t, 4)
+			setWakeRepairBootstrapDescriptors(t, commonNames, fds)
+			t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[aliasIndex]))
+
+			bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+			if err != nil {
+				t.Fatalf("capture repair bootstrap: %v", err)
+			}
+			handoff, present, stop, cleanup, err := wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+			if cleanup != nil {
+				cleanup()
+			}
+			if handoff != nil || present || stop != nil {
+				t.Fatalf("alias returned partial capabilities: handoff=%v present=%v stop=%v", handoff, present, stop)
+			}
+			want := fmt.Sprintf(
+				"%s aliases %s",
+				envWakeRepairChildControlFD,
+				aliasName,
+			)
+			if err == nil || err.Error() != want {
+				t.Fatalf("alias error = %v, want %q", err, want)
+			}
+			assertWakeRepairBootstrapDescriptorsUnchanged(t, fds)
+			assertWakeRepairBootstrapEnvironmentAbsent(t)
+		})
+	}
+}
+
+func TestDarwinWakeRepairBootstrapRejectsEveryCommonAliasPairBeforeMutation(t *testing.T) {
+	commonNames := []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	}
+	pairs := []struct {
+		first  int
+		second int
+	}{
+		{first: 0, second: 1},
+		{first: 0, second: 2},
+		{first: 0, second: 3},
+		{first: 1, second: 2},
+		{first: 1, second: 3},
+		{first: 2, second: 3},
+	}
+	for _, pair := range pairs {
+		name := commonNames[pair.first] + "__" + commonNames[pair.second]
+		t.Run(name, func(t *testing.T) {
+			fds := openWakeRepairBootstrapDescriptors(t, 5)
+			commonFDs := make([]int, len(commonNames))
+			nextUnique := 1
+			for index := range commonFDs {
+				if index == pair.first || index == pair.second {
+					commonFDs[index] = fds[0]
+					continue
+				}
+				commonFDs[index] = fds[nextUnique]
+				nextUnique++
+			}
+			setWakeRepairBootstrapDescriptors(t, commonNames, commonFDs)
+			t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[3]))
+			t.Setenv(envWakePrivateStopFD, strconv.Itoa(fds[4]))
+
+			bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+			if err != nil {
+				t.Fatalf("capture aliased private bootstrap: %v", err)
+			}
+			handoff, present, stop, cleanup, err :=
+				wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+			if cleanup != nil {
+				cleanup()
+			}
+			if handoff != nil {
+				_ = handoff.Close()
+			}
+			if handoff != nil || present || stop != nil {
+				t.Fatalf(
+					"common alias returned capabilities: handoff=%v present=%v stop=%v",
+					handoff,
+					present,
+					stop,
+				)
+			}
+			const want = "wake repair handoff descriptors must be distinct"
+			if err == nil || err.Error() != want {
+				t.Fatalf("common alias error = %v, want %q", err, want)
+			}
+			assertWakeRepairBootstrapDescriptorsUnchanged(t, fds)
+			assertWakeRepairBootstrapEnvironmentAbsent(t)
+
+			setWakeRepairBootstrapDescriptors(t, commonNames, commonFDs)
+			t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[3]))
+			t.Setenv(envWakePrivateStopFD, strconv.Itoa(fds[4]))
+			loopCalled := false
+			err = runWakeWithLoop(nil, func(wakeConfig) error {
+				loopCalled = true
+				return nil
+			})
+			if err == nil || err.Error() != want {
+				t.Fatalf("common alias loop error = %v, want %q", err, want)
+			}
+			if loopCalled {
+				t.Fatal("wake loop ran with common bootstrap aliases")
+			}
+			assertWakeRepairBootstrapDescriptorsUnchanged(t, fds)
+			assertWakeRepairBootstrapEnvironmentAbsent(t)
+		})
+	}
+}
+
+func TestDarwinWakePrivateBootstrapPreparationFailureRollsBackWholeTuple(t *testing.T) {
+	commonNames := []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	}
+	t.Run("transaction capabilities", func(t *testing.T) {
+		fds := openWakeRepairBootstrapDescriptors(t, 6)
+		setWakeRepairBootstrapDescriptors(t, commonNames, fds[:4])
+		t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[4]))
+		t.Setenv(envWakePrivateStopFD, strconv.Itoa(fds[5]))
+		if err := unix.Close(fds[4]); err != nil {
+			t.Fatalf("close later child control descriptor: %v", err)
+		}
+
+		bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+		if err != nil {
+			t.Fatalf("capture preparation-failure bootstrap: %v", err)
+		}
+		handoff, present, stop, cleanup, err :=
+			wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+		if cleanup != nil {
+			cleanup()
+		}
+		if handoff != nil {
+			_ = handoff.Close()
+		}
+		if handoff != nil || present || stop != nil {
+			t.Fatalf(
+				"preparation failure returned capabilities: handoff=%v present=%v stop=%v",
+				handoff,
+				present,
+				stop,
+			)
+		}
+		if err == nil || !strings.HasPrefix(
+			err.Error(),
+			"make wake repair child control fd nonblocking:",
+		) {
+			t.Fatalf("preparation failure error = %v", err)
+		}
+		assertWakeRepairBootstrapDescriptorsClosed(t, fds)
+		assertWakeRepairBootstrapEnvironmentAbsent(t)
+	})
+
+	t.Run("wake loop", func(t *testing.T) {
+		fds := openWakeRepairBootstrapDescriptors(t, 6)
+		setWakeRepairBootstrapDescriptors(t, commonNames, fds[:4])
+		t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[4]))
+		t.Setenv(envWakePrivateStopFD, strconv.Itoa(fds[5]))
+		if err := unix.Close(fds[4]); err != nil {
+			t.Fatalf("close later child control descriptor: %v", err)
+		}
+
+		loopCalled := false
+		err := runWakeWithLoop(nil, func(wakeConfig) error {
+			loopCalled = true
+			return nil
+		})
+		if err == nil || !strings.HasPrefix(
+			err.Error(),
+			"make wake repair child control fd nonblocking:",
+		) {
+			t.Fatalf("preparation failure loop error = %v", err)
+		}
+		if loopCalled {
+			t.Fatal("wake loop ran after private bootstrap preparation failed")
+		}
+		assertWakeRepairBootstrapDescriptorsClosed(t, fds)
+		assertWakeRepairBootstrapEnvironmentAbsent(t)
+	})
+}
+
+func TestDarwinWakePrivateStopRejectsEveryBootstrapAliasAtomically(t *testing.T) {
+	otherNames := []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+		envWakeRepairChildControlFD,
+	}
+	commonNames := otherNames[:4]
+	for aliasIndex, aliasName := range otherNames {
+		t.Run(aliasName, func(t *testing.T) {
+			fds := openWakeRepairBootstrapDescriptors(t, 5)
+			setWakeRepairBootstrapDescriptors(t, commonNames, fds[:4])
+			t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[4]))
+			t.Setenv(envWakePrivateStopFD, strconv.Itoa(fds[aliasIndex]))
+
+			bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+			if err != nil {
+				t.Fatalf("capture private bootstrap: %v", err)
+			}
+			handoff, present, stop, cleanup, err :=
+				wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+			if cleanup != nil {
+				cleanup()
+			}
+			if handoff != nil {
+				_ = handoff.Close()
+			}
+			if handoff != nil || present || stop != nil {
+				t.Fatalf(
+					"owner alias returned partial capabilities: handoff=%v present=%v stop=%v",
+					handoff,
+					present,
+					stop,
+				)
+			}
+			want := fmt.Sprintf("%s aliases %s", envWakePrivateStopFD, aliasName)
+			if err == nil || err.Error() != want {
+				t.Fatalf("owner alias error = %v, want %q", err, want)
+			}
+			assertWakeRepairBootstrapDescriptorsUnchanged(t, fds)
+			assertWakeRepairBootstrapEnvironmentAbsent(t)
+		})
+	}
+}
+
+func TestDarwinWakePrivateStopMalformedFailsBeforeAdoption(t *testing.T) {
+	t.Setenv(envWakePrivateStopFD, "not-a-descriptor")
+
+	bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+	if err != nil {
+		t.Fatalf("capture private bootstrap: %v", err)
+	}
+	handoff, present, stop, cleanup, err :=
+		wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+	if cleanup != nil {
+		cleanup()
+	}
+	if handoff != nil {
+		_ = handoff.Close()
+	}
+	if handoff != nil || present || stop != nil {
+		t.Fatalf(
+			"malformed owner returned partial capabilities: handoff=%v present=%v stop=%v",
+			handoff,
+			present,
+			stop,
+		)
+	}
+	want := envWakePrivateStopFD + " is invalid"
+	if err == nil || err.Error() != want {
+		t.Fatalf("malformed owner error = %v, want %q", err, want)
+	}
+	if value, present := os.LookupEnv(envWakePrivateStopFD); present {
+		t.Fatalf("%s remained in the process environment as %q", envWakePrivateStopFD, value)
+	}
+}
+
+func TestDarwinWakePrivateBootstrapAdoptsDistinctSixDescriptorTuple(t *testing.T) {
+	commonNames := []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	}
+	fds := openWakeRepairBootstrapDescriptors(t, 6)
+	setWakeRepairBootstrapDescriptors(t, commonNames, fds[:4])
+	t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[4]))
+	t.Setenv(envWakePrivateStopFD, strconv.Itoa(fds[5]))
+
+	bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+	if err != nil {
+		t.Fatalf("capture private bootstrap: %v", err)
+	}
+	handoff, present, stop, cleanup, err :=
+		wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+	if err != nil {
+		t.Fatalf("adopt distinct private bootstrap tuple: %v", err)
+	}
+	if handoff == nil || !present || stop == nil || cleanup == nil {
+		t.Fatalf(
+			"complete tuple capabilities: handoff=%v present=%v stop=%v cleanup-present=%v",
+			handoff,
+			present,
+			stop,
+			cleanup != nil,
+		)
+	}
+	defer cleanup()
+	defer func() { _ = handoff.Close() }()
+	assertWakeRepairBootstrapEnvironmentAbsent(t)
+	select {
+	case <-stop:
+		t.Fatal("complete private bootstrap stopped before either writer closed")
+	default:
+	}
+}
+
+func TestDarwinWakePrivateStopBootstrapDoesNotReachDescendants(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer.Close() }()
+	fd, err := unix.Dup(int(reader.Fd()))
+	_ = reader.Close()
+	if err != nil {
+		t.Fatalf("duplicate inherited private stop fd: %v", err)
+	}
+	t.Setenv(envWakePrivateStopFD, strconv.Itoa(fd))
+
+	bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+	if err != nil {
+		_ = unix.Close(fd)
+		t.Fatalf("capture private bootstrap: %v", err)
+	}
+	handoff, present, stop, cleanup, err :=
+		wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+	if err != nil {
+		_ = unix.Close(fd)
+		t.Fatalf("initialize private stop bootstrap: %v", err)
+	}
+	if handoff != nil || present {
+		t.Fatalf("owner-only bootstrap returned repair handoff: handoff=%v present=%v", handoff, present)
+	}
+	defer cleanup()
+	if stop == nil {
+		t.Fatal("owner-only bootstrap did not return a stop channel")
+	}
+	assertWakeRepairBootstrapEnvironmentAbsent(t)
+	assertWakeRepairDescriptorsClosedInInjector(t, []int{fd})
+	assertWakeRepairBootstrapEnvironmentAbsentInInjectorAndNestedProcess(t)
+	select {
+	case <-stop:
+		t.Fatal("private owner stop fired before its writer closed")
+	default:
+	}
+}
+
+func TestDarwinWakeRepairBootstrapRejectsMalformedTupleBeforeAdoption(t *testing.T) {
+	commonNames := []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	}
+	tests := []struct {
+		name        string
+		common      []string
+		control     string
+		owner       string
+		wantError   string
+		expectedFDs int
+	}{
+		{
+			name:        "incomplete handoff with valid control",
+			common:      []string{"fd", "", "", ""},
+			control:     "fd",
+			owner:       "fd",
+			wantError:   "wake repair handoff descriptors are incomplete",
+			expectedFDs: 3,
+		},
+		{
+			name:        "malformed handoff with valid control",
+			common:      []string{"invalid", "fd", "fd", "fd"},
+			control:     "fd",
+			owner:       "fd",
+			wantError:   envWakeRepairHandoffReadFD + " is invalid",
+			expectedFDs: 5,
+		},
+		{
+			name:        "valid handoff with malformed control",
+			common:      []string{"fd", "fd", "fd", "fd"},
+			control:     "invalid",
+			owner:       "fd",
+			wantError:   envWakeRepairChildControlFD + " is invalid",
+			expectedFDs: 5,
+		},
+		{
+			name:        "valid repair tuple with malformed owner stop",
+			common:      []string{"fd", "fd", "fd", "fd"},
+			control:     "fd",
+			owner:       "invalid",
+			wantError:   envWakePrivateStopFD + " is invalid",
+			expectedFDs: 5,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fds := openWakeRepairBootstrapDescriptors(t, test.expectedFDs)
+			nextFD := 0
+			for index, value := range test.common {
+				switch value {
+				case "":
+					t.Setenv(commonNames[index], "")
+				case "invalid":
+					t.Setenv(commonNames[index], "not-a-descriptor")
+				case "fd":
+					t.Setenv(commonNames[index], strconv.Itoa(fds[nextFD]))
+					nextFD++
+				}
+			}
+			switch test.control {
+			case "invalid":
+				t.Setenv(envWakeRepairChildControlFD, "not-a-descriptor")
+			case "fd":
+				t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[nextFD]))
+				nextFD++
+			}
+			switch test.owner {
+			case "fd":
+				t.Setenv(envWakePrivateStopFD, strconv.Itoa(fds[nextFD]))
+			case "invalid":
+				t.Setenv(envWakePrivateStopFD, "not-a-descriptor")
+			}
+
+			bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+			if err != nil {
+				t.Fatalf("capture repair bootstrap: %v", err)
+			}
+			handoff, present, stop, cleanup, err := wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+			if cleanup != nil {
+				cleanup()
+			}
+			if handoff != nil || present || stop != nil {
+				t.Fatalf("invalid tuple returned partial capabilities: handoff=%v present=%v stop=%v", handoff, present, stop)
+			}
+			if err == nil || err.Error() != test.wantError {
+				t.Fatalf("bootstrap error = %v, want %q", err, test.wantError)
+			}
+			assertWakeRepairBootstrapDescriptorsUnchanged(t, fds)
+			assertWakeRepairBootstrapEnvironmentAbsent(t)
+		})
+	}
+}
+
+func TestDarwinWakeRepairBootstrapRequiresCompletePlatformTuple(t *testing.T) {
+	commonNames := []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	}
+	tests := []struct {
+		name           string
+		includeHandoff bool
+		includeControl bool
+	}{
+		{
+			name:           "handoff without control",
+			includeHandoff: true,
+		},
+		{
+			name:           "control without handoff",
+			includeControl: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			count := 1
+			if test.includeHandoff {
+				count = 4
+			}
+			fds := openWakeRepairBootstrapDescriptors(t, count)
+			if test.includeHandoff {
+				setWakeRepairBootstrapDescriptors(t, commonNames, fds)
+			}
+			if test.includeControl {
+				t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[0]))
+			}
+
+			bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+			if err != nil {
+				t.Fatalf("capture repair bootstrap: %v", err)
+			}
+			handoff, present, stop, cleanup, err :=
+				wakeRepairChildCapabilitiesFromBootstrap(bootstrap)
+			if cleanup != nil {
+				cleanup()
+			}
+			if handoff != nil || present || stop != nil {
+				t.Fatalf(
+					"incomplete tuple returned partial capabilities: handoff=%v present=%v stop=%v",
+					handoff,
+					present,
+					stop,
+				)
+			}
+			const want = "wake repair bootstrap descriptors are incomplete"
+			if err == nil || err.Error() != want {
+				t.Fatalf("tuple validation error = %v, want %q", err, want)
+			}
+			assertWakeRepairBootstrapDescriptorsUnchanged(t, fds)
+			assertWakeRepairBootstrapEnvironmentAbsent(t)
+		})
+	}
+}
+
+func TestDarwinWakeRepairBootstrapAliasDoesNotEnterWakeLoop(t *testing.T) {
+	commonNames := []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	}
+	fds := openWakeRepairBootstrapDescriptors(t, 4)
+	setWakeRepairBootstrapDescriptors(t, commonNames, fds)
+	t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(fds[0]))
+
+	loopCalled := false
+	err := runWakeWithLoop(nil, func(wakeConfig) error {
+		loopCalled = true
+		return nil
+	})
+	want := envWakeRepairChildControlFD + " aliases " + envWakeRepairHandoffReadFD
+	if err == nil || err.Error() != want {
+		t.Fatalf("alias error = %v, want %q", err, want)
+	}
+	if loopCalled {
+		t.Fatal("wake loop ran with an aliased repair bootstrap")
+	}
+	assertWakeRepairBootstrapDescriptorsUnchanged(t, fds)
+	assertWakeRepairBootstrapEnvironmentAbsent(t)
+}
+
+func openWakeRepairBootstrapDescriptors(t *testing.T, count int) []int {
+	t.Helper()
+	fds := make([]int, 0, count)
+	for range count {
+		reader, writer, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		fd, err := unix.Dup(int(reader.Fd()))
+		_ = reader.Close()
+		if err != nil {
+			_ = writer.Close()
+			t.Fatalf("duplicate repair bootstrap descriptor: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = unix.Close(fd)
+			_ = writer.Close()
+		})
+		fds = append(fds, fd)
+	}
+	return fds
+}
+
+func setWakeRepairBootstrapDescriptors(t *testing.T, names []string, fds []int) {
+	t.Helper()
+	for index, name := range names {
+		t.Setenv(name, strconv.Itoa(fds[index]))
+	}
+}
+
+func assertWakeRepairBootstrapDescriptorsUnchanged(t *testing.T, fds []int) {
+	t.Helper()
+	for _, fd := range fds {
+		fdFlags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+		if err != nil {
+			t.Errorf("descriptor %d was closed before bootstrap admission: %v", fd, err)
+			continue
+		}
+		if fdFlags&unix.FD_CLOEXEC != 0 {
+			t.Errorf("descriptor %d became close-on-exec before bootstrap admission", fd)
+		}
+		statusFlags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFL, 0)
+		if err != nil {
+			t.Errorf("inspect descriptor %d status: %v", fd, err)
+			continue
+		}
+		if statusFlags&unix.O_NONBLOCK != 0 {
+			t.Errorf("descriptor %d became nonblocking before bootstrap admission", fd)
+		}
+	}
+}
+
+func assertWakeRepairBootstrapDescriptorsClosed(t *testing.T, fds []int) {
+	t.Helper()
+	for _, fd := range fds {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); !errors.Is(err, unix.EBADF) {
+			t.Errorf("descriptor %d remained open after transaction rollback: %v", fd, err)
+		}
+	}
+}
+
+func TestDarwinWakeRepairControlEnvironmentScrubbedBeforeHandoffValidation(t *testing.T) {
+	t.Setenv(envWakeRepairHandoffReadFD, "3")
+	t.Setenv(envWakeRepairHandoffWriteFD, "")
+	t.Setenv(envWakeRepairAgentDirFD, "")
+	t.Setenv(envWakeRepairInboxDirFD, "")
+	t.Setenv(envWakeRepairChildControlFD, "not-a-descriptor")
+
+	err := runWakeWithLoop(nil, func(wakeConfig) error {
+		t.Fatal("wake loop ran with an invalid repair bootstrap")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("invalid repair bootstrap unexpectedly succeeded")
+	}
+	if value, present := os.LookupEnv(envWakeRepairChildControlFD); present {
+		t.Fatalf("%s remained in the process environment as %q", envWakeRepairChildControlFD, value)
+	}
+}
+
+func TestDarwinWakeRepairEnvironmentScrubbedBeforeOwnerValidation(t *testing.T) {
+	t.Setenv(envWakePrivateStopFD, "not-a-descriptor")
+	t.Setenv(envWakeRepairChildControlFD, "also-not-a-descriptor")
+
+	err := runWakeWithLoop(nil, func(wakeConfig) error {
+		t.Fatal("wake loop ran with an invalid private owner bootstrap")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("invalid private owner bootstrap unexpectedly succeeded")
+	}
+	if value, present := os.LookupEnv(envWakeRepairChildControlFD); present {
+		t.Fatalf("%s remained in the process environment as %q", envWakeRepairChildControlFD, value)
+	}
+}
+
+func TestDarwinWakeRepairControlEnvironmentDoesNotReachDescendants(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer.Close() }()
+	childFD, err := unix.Dup(int(reader.Fd()))
+	_ = reader.Close()
+	if err != nil {
+		t.Fatalf("duplicate inherited child control fd: %v", err)
+	}
+	t.Setenv(envWakeRepairChildControlFD, strconv.Itoa(childFD))
+
+	stop, cleanup, err := wakeRepairChildStopFromEnv()
+	if err != nil {
+		_ = unix.Close(childFD)
+		t.Fatalf("initialize child control: %v", err)
+	}
+	defer cleanup()
+	assertWakeRepairBootstrapEnvironmentAbsent(t)
+	assertWakeRepairDescriptorsClosedInInjector(t, []int{childFD})
+	assertWakeRepairBootstrapEnvironmentAbsentInInjectorAndNestedProcess(t)
+	select {
+	case <-stop:
+		t.Fatal("child control stopped before its writer closed")
+	default:
+	}
+}

--- a/internal/cli/wake_repair_bootstrap_env_linux_test.go
+++ b/internal/cli/wake_repair_bootstrap_env_linux_test.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLinuxUnsupportedPrivateBootstrapDescriptorsAreScrubbed(t *testing.T) {
+	tests := []string{
+		envWakePrivateStopFD,
+		envWakeRepairChildControlFD,
+	}
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(name, "9")
+
+			loopCalled := false
+			err := runWakeWithLoop(nil, func(wakeConfig) error {
+				loopCalled = true
+				return nil
+			})
+			want := name + " is unsupported on linux"
+			if err == nil || err.Error() != want {
+				t.Fatalf("unsupported descriptor error = %v, want %q", err, want)
+			}
+			if loopCalled {
+				t.Fatal("wake loop ran with an unsupported private bootstrap descriptor")
+			}
+			if value, present := os.LookupEnv(name); present {
+				t.Fatalf("%s remained in the process environment as %q", name, value)
+			}
+		})
+	}
+}

--- a/internal/cli/wake_repair_bootstrap_env_unix.go
+++ b/internal/cli/wake_repair_bootstrap_env_unix.go
@@ -1,0 +1,57 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type wakeRepairBootstrapEnv struct {
+	values map[string]string
+}
+
+var unsetWakeRepairBootstrapEnv = os.Unsetenv
+
+func wakeRepairBootstrapEnvNames() []string {
+	names := []string{
+		envWakePrivateStopFD,
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	}
+	return append(names, wakeRepairBootstrapPlatformEnvNames()...)
+}
+
+func captureAndScrubWakeRepairBootstrapEnv() (wakeRepairBootstrapEnv, error) {
+	bootstrap := wakeRepairBootstrapEnv{
+		values: make(map[string]string),
+	}
+	names := wakeRepairBootstrapEnvNames()
+	for _, name := range names {
+		if value, present := os.LookupEnv(name); present {
+			bootstrap.values[name] = value
+		}
+	}
+
+	var scrubErr error
+	for _, name := range names {
+		if err := unsetWakeRepairBootstrapEnv(name); err != nil {
+			scrubErr = errors.Join(
+				scrubErr,
+				fmt.Errorf("unset private wake repair bootstrap environment %s: %w", name, err),
+			)
+		}
+	}
+	if scrubErr != nil {
+		return wakeRepairBootstrapEnv{}, scrubErr
+	}
+	return bootstrap, nil
+}
+
+func (bootstrap wakeRepairBootstrapEnv) value(name string) string {
+	return strings.TrimSpace(bootstrap.values[name])
+}

--- a/internal/cli/wake_repair_bootstrap_env_unix_test.go
+++ b/internal/cli/wake_repair_bootstrap_env_unix_test.go
@@ -1,0 +1,244 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const wakeRepairBootstrapEnvHelper = "AMQ_TEST_WAKE_REPAIR_BOOTSTRAP_ENV_HELPER"
+
+func TestWakeRepairBootstrapEnvironmentScrubbedBeforeHandoffValidation(t *testing.T) {
+	t.Setenv(envWakeRepairHandoffReadFD, "3")
+	t.Setenv(envWakeRepairHandoffWriteFD, "")
+	t.Setenv(envWakeRepairAgentDirFD, "")
+	t.Setenv(envWakeRepairInboxDirFD, "")
+
+	loopCalled := false
+	err := runWakeWithLoop(nil, func(wakeConfig) error {
+		loopCalled = true
+		return nil
+	})
+	if err == nil {
+		t.Fatal("incomplete repair handoff unexpectedly succeeded")
+	}
+	if loopCalled {
+		t.Fatal("wake loop ran with an invalid repair bootstrap")
+	}
+	for _, name := range []string{
+		envWakeRepairHandoffReadFD,
+		envWakeRepairHandoffWriteFD,
+		envWakeRepairAgentDirFD,
+		envWakeRepairInboxDirFD,
+	} {
+		if value, present := os.LookupEnv(name); present {
+			t.Errorf("%s remained in the process environment as %q", name, value)
+		}
+	}
+}
+
+func TestWakePrivateStopEnvironmentScrubbedOnEveryPlatform(t *testing.T) {
+	t.Setenv(envWakePrivateStopFD, "not-a-descriptor")
+
+	loopCalled := false
+	err := runWakeWithLoop(nil, func(wakeConfig) error {
+		loopCalled = true
+		return nil
+	})
+	if err == nil {
+		t.Fatal("unsupported or malformed private stop bootstrap unexpectedly succeeded")
+	}
+	if loopCalled {
+		t.Fatal("wake loop ran with an invalid private stop bootstrap")
+	}
+	if value, present := os.LookupEnv(envWakePrivateStopFD); present {
+		t.Fatalf("%s remained in the process environment as %q", envWakePrivateStopFD, value)
+	}
+}
+
+func TestWakeRepairBootstrapEnvironmentDoesNotReachInjectorOrNestedProcess(t *testing.T) {
+	fds := make([]int, 4)
+	for index := range fds {
+		reader, writer, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		fd, err := unix.Dup(int(reader.Fd()))
+		_ = reader.Close()
+		if err != nil {
+			_ = writer.Close()
+			t.Fatalf("duplicate inherited handoff fd: %v", err)
+		}
+		t.Cleanup(func() { _ = writer.Close() })
+		fds[index] = fd
+	}
+	t.Setenv(envWakeRepairHandoffReadFD, strconv.Itoa(fds[0]))
+	t.Setenv(envWakeRepairHandoffWriteFD, strconv.Itoa(fds[1]))
+	t.Setenv(envWakeRepairAgentDirFD, strconv.Itoa(fds[2]))
+	t.Setenv(envWakeRepairInboxDirFD, strconv.Itoa(fds[3]))
+
+	handoff, present, err := wakeRepairChildHandoffFromEnv()
+	if err != nil {
+		for _, fd := range fds {
+			_ = unix.Close(fd)
+		}
+		t.Fatalf("initialize inherited child handoff: %v", err)
+	}
+	if !present {
+		t.Fatal("inherited child handoff was not detected")
+	}
+	defer func() { _ = handoff.Close() }()
+
+	assertWakeRepairBootstrapEnvironmentAbsent(t)
+	assertWakeRepairDescriptorsClosedInInjector(t, fds)
+	assertWakeRepairBootstrapEnvironmentAbsentInInjectorAndNestedProcess(t)
+}
+
+func TestWakeRepairBootstrapUnsetFailureFailsClosedAndAttemptsEveryScrub(t *testing.T) {
+	names := wakeRepairBootstrapEnvNames()
+	originalUnset := unsetWakeRepairBootstrapEnv
+	t.Cleanup(func() { unsetWakeRepairBootstrapEnv = originalUnset })
+	for _, failedName := range names {
+		t.Run(failedName, func(t *testing.T) {
+			for _, name := range names {
+				t.Setenv(name, "9")
+			}
+
+			calls := make(map[string]int)
+			unsetWakeRepairBootstrapEnv = func(name string) error {
+				calls[name]++
+				if name == failedName {
+					return errors.New("injected unset failure")
+				}
+				return os.Unsetenv(name)
+			}
+			t.Cleanup(func() { unsetWakeRepairBootstrapEnv = originalUnset })
+
+			loopCalled := false
+			err := runWakeWithLoop(nil, func(wakeConfig) error {
+				loopCalled = true
+				return nil
+			})
+			if err == nil {
+				t.Fatal("wake bootstrap proceeded after an environment scrub failure")
+			}
+			if !strings.Contains(err.Error(), failedName) {
+				t.Fatalf("scrub failure did not identify %s: %v", failedName, err)
+			}
+			if loopCalled {
+				t.Fatal("wake loop ran after an environment scrub failure")
+			}
+			for _, name := range names {
+				if calls[name] != 1 {
+					t.Errorf("unset %s called %d times, want 1", name, calls[name])
+				}
+				if name == failedName {
+					continue
+				}
+				if value, present := os.LookupEnv(name); present {
+					t.Errorf("%s remained after another variable failed to unset: %q", name, value)
+				}
+			}
+		})
+		unsetWakeRepairBootstrapEnv = originalUnset
+	}
+}
+
+func assertWakeRepairBootstrapEnvironmentAbsent(t *testing.T) {
+	t.Helper()
+	for _, name := range wakeRepairBootstrapEnvNames() {
+		if value, present := os.LookupEnv(name); present {
+			t.Errorf("%s remained in the process environment as %q", name, value)
+		}
+	}
+}
+
+func assertWakeRepairBootstrapEnvironmentAbsentInInjectorAndNestedProcess(t *testing.T) {
+	t.Helper()
+	dir := secureTempDirForTest(t)
+	output := filepath.Join(dir, "inherited-repair-environment")
+	if err := os.WriteFile(output, nil, 0o600); err != nil {
+		t.Fatalf("create repair environment inspection output: %v", err)
+	}
+	t.Setenv(injectViaHelperEnv, "1")
+	t.Setenv(wakeRepairBootstrapEnvHelper, "injector")
+	if err := injectVia(&wakeConfig{
+		injectVia: copyTestBinaryForInjectVia(t),
+		injectArgs: []string{
+			"-test.run=^TestWakeRepairBootstrapEnvironmentInspectorHelperProcess$",
+			"--",
+			output,
+		},
+		injectTimeout: 10 * time.Second,
+	}, "ignored wake payload"); err != nil {
+		t.Fatalf("run repair environment inspector: %v", err)
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read repair environment inspection: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("private repair bootstrap environment leaked to a descendant:\n%s", data)
+	}
+}
+
+func TestWakeRepairBootstrapEnvironmentInspectorHelperProcess(t *testing.T) {
+	mode := os.Getenv(wakeRepairBootstrapEnvHelper)
+	if mode == "" {
+		return
+	}
+	separator := -1
+	for index, arg := range os.Args {
+		if arg == "--" {
+			separator = index
+			break
+		}
+	}
+	if separator < 0 || separator+1 >= len(os.Args) {
+		_, _ = os.Stderr.WriteString("missing repair environment inspector output\n")
+		os.Exit(2)
+	}
+	output := os.Args[separator+1]
+	var leaked []string
+	for _, name := range wakeRepairBootstrapEnvNames() {
+		if _, present := os.LookupEnv(name); present {
+			leaked = append(leaked, mode+":"+name)
+		}
+	}
+	if len(leaked) > 0 {
+		file, err := os.OpenFile(output, os.O_WRONLY|os.O_APPEND, 0)
+		if err != nil {
+			_, _ = os.Stderr.WriteString("open repair environment inspection: " + err.Error() + "\n")
+			os.Exit(3)
+		}
+		_, writeErr := file.WriteString(strings.Join(leaked, "\n") + "\n")
+		closeErr := file.Close()
+		if writeErr != nil || closeErr != nil {
+			_, _ = os.Stderr.WriteString("write repair environment inspection\n")
+			os.Exit(3)
+		}
+	}
+	if mode == "injector" {
+		cmd := exec.Command(
+			os.Args[0],
+			"-test.run=^TestWakeRepairBootstrapEnvironmentInspectorHelperProcess$",
+			"--",
+			output,
+		)
+		cmd.Env = setEnvVar(os.Environ(), wakeRepairBootstrapEnvHelper, "nested")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			_, _ = os.Stderr.WriteString("run nested repair environment inspector: " + err.Error() + ": " + string(out) + "\n")
+			os.Exit(4)
+		}
+	}
+	os.Exit(0)
+}

--- a/internal/cli/wake_repair_handoff_darwin.go
+++ b/internal/cli/wake_repair_handoff_darwin.go
@@ -10,14 +10,12 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"sync"
 
 	"golang.org/x/sys/unix"
 )
 
 const (
-	envWakeRepairChildControlFD  = "AMQ_WAKE_REPAIR_CHILD_CONTROL_FD"
 	wakeRepairChildControlStop   = "STOP"
 	wakeRepairChildControlDetach = "DETACH"
 )
@@ -148,29 +146,93 @@ func writeWakeRepairChildControl(writer io.Writer, command string) error {
 }
 
 func wakeRepairChildStopFromEnv() (<-chan struct{}, func(), error) {
-	raw := strings.TrimSpace(os.Getenv(envWakeRepairChildControlFD))
+	bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+	if err != nil {
+		return nil, nil, err
+	}
+	handoffDescriptors, err := parseWakeRepairChildHandoffDescriptors(bootstrap)
+	if err != nil {
+		return nil, nil, err
+	}
+	if handoffDescriptors.present {
+		return nil, nil, fmt.Errorf(
+			"wake repair handoff descriptors are not valid without the complete bootstrap transaction",
+		)
+	}
+	ownerStopDescriptor, err := parseAuthoritativeWakePrivateStopDescriptor(bootstrap)
+	if err != nil {
+		return nil, nil, err
+	}
+	if ownerStopDescriptor.present {
+		return nil, nil, fmt.Errorf(
+			"%s is not valid without the complete private bootstrap transaction",
+			ownerStopDescriptor.name,
+		)
+	}
+	return wakeRepairChildStopFromBootstrap(bootstrap)
+}
+
+func wakeRepairBootstrapPlatformEnvNames() []string {
+	return []string{envWakeRepairChildControlFD}
+}
+
+func parseWakeRepairChildStopDescriptor(
+	bootstrap wakeRepairBootstrapEnv,
+) (wakeRepairChildStopDescriptor, error) {
+	raw := bootstrap.value(envWakeRepairChildControlFD)
 	if raw == "" {
-		return nil, func() {}, nil
+		return wakeRepairChildStopDescriptor{}, nil
 	}
 	fd, err := strconv.Atoi(raw)
 	if err != nil || fd < 3 {
-		return nil, nil, fmt.Errorf("%s is invalid", envWakeRepairChildControlFD)
+		return wakeRepairChildStopDescriptor{}, fmt.Errorf(
+			"%s is invalid",
+			envWakeRepairChildControlFD,
+		)
+	}
+	return wakeRepairChildStopDescriptor{
+		fd:      fd,
+		name:    envWakeRepairChildControlFD,
+		present: true,
+	}, nil
+}
+
+func prepareWakeRepairChildStopDescriptor(descriptor wakeRepairChildStopDescriptor) error {
+	if !descriptor.present {
+		return nil
 	}
 	// os/exec obtains ExtraFiles through File.Fd, which deliberately restores
 	// blocking mode. Restore nonblocking mode before os.NewFile so Go registers
 	// the inherited pipe with its poller; then a concurrent Close interrupts the
 	// startup read and cleanup can wait for the watcher without deadlocking.
-	if err := unix.SetNonblock(fd, true); err != nil {
-		_ = unix.Close(fd)
-		return nil, nil, fmt.Errorf("make wake repair child control fd nonblocking: %w", err)
+	if err := unix.SetNonblock(descriptor.fd, true); err != nil {
+		return fmt.Errorf("make wake repair child control fd nonblocking: %w", err)
 	}
-	if err := setWakeRepairFDCloseOnExec(fd, "child control"); err != nil {
-		_ = unix.Close(fd)
-		return nil, nil, err
+	if err := setWakeRepairFDCloseOnExec(descriptor.fd, "child control"); err != nil {
+		return err
 	}
-	file := os.NewFile(uintptr(fd), "wake-repair-child-control")
+	return nil
+}
+
+func validateWakeRepairChildPlatformDescriptorTuple(
+	handoff wakeRepairChildHandoffDescriptors,
+	stop wakeRepairChildStopDescriptor,
+) error {
+	if handoff.present != stop.present {
+		return fmt.Errorf("wake repair bootstrap descriptors are incomplete")
+	}
+	return nil
+}
+
+func adoptWakeRepairChildStopDescriptor(
+	descriptor wakeRepairChildStopDescriptor,
+) (<-chan struct{}, func(), error) {
+	if !descriptor.present {
+		return nil, func() {}, nil
+	}
+	file := os.NewFile(uintptr(descriptor.fd), "wake-repair-child-control")
 	if file == nil {
-		_ = unix.Close(fd)
+		_ = unix.Close(descriptor.fd)
 		return nil, nil, fmt.Errorf("%s fd is unavailable", envWakeRepairChildControlFD)
 	}
 	stop, finished := watchWakeRepairDarwinChildControl(file)
@@ -179,6 +241,22 @@ func wakeRepairChildStopFromEnv() (<-chan struct{}, func(), error) {
 		<-finished
 	}
 	return stop, cleanup, nil
+}
+
+func wakeRepairChildStopFromBootstrap(
+	bootstrap wakeRepairBootstrapEnv,
+) (<-chan struct{}, func(), error) {
+	descriptor, err := parseWakeRepairChildStopDescriptor(bootstrap)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := prepareWakeRepairChildStopDescriptor(descriptor); err != nil {
+		if descriptor.present {
+			_ = unix.Close(descriptor.fd)
+		}
+		return nil, nil, err
+	}
+	return adoptWakeRepairChildStopDescriptor(descriptor)
 }
 
 func watchWakeRepairDarwinChildControl(file *os.File) (<-chan struct{}, <-chan struct{}) {

--- a/internal/cli/wake_repair_handoff_linux.go
+++ b/internal/cli/wake_repair_handoff_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
 	"syscall"
 )
@@ -87,6 +88,43 @@ func prepareWakeRepairChildCapabilityPlatform(cmd *exec.Cmd) (*wakeRepairChildCa
 	}, nil
 }
 
-func wakeRepairChildStopFromEnv() (<-chan struct{}, func(), error) {
+func wakeRepairBootstrapPlatformEnvNames() []string {
+	return []string{envWakeRepairChildControlFD}
+}
+
+func parseWakeRepairChildStopDescriptor(
+	bootstrap wakeRepairBootstrapEnv,
+) (wakeRepairChildStopDescriptor, error) {
+	raw := bootstrap.value(envWakeRepairChildControlFD)
+	if raw == "" {
+		return wakeRepairChildStopDescriptor{}, nil
+	}
+	fd, err := strconv.Atoi(raw)
+	if err != nil || fd < 3 {
+		return wakeRepairChildStopDescriptor{}, fmt.Errorf(
+			"%s is invalid",
+			envWakeRepairChildControlFD,
+		)
+	}
+	return wakeRepairChildStopDescriptor{}, fmt.Errorf(
+		"%s is unsupported on linux",
+		envWakeRepairChildControlFD,
+	)
+}
+
+func prepareWakeRepairChildStopDescriptor(wakeRepairChildStopDescriptor) error {
+	return nil
+}
+
+func validateWakeRepairChildPlatformDescriptorTuple(
+	wakeRepairChildHandoffDescriptors,
+	wakeRepairChildStopDescriptor,
+) error {
+	return nil
+}
+
+func adoptWakeRepairChildStopDescriptor(
+	wakeRepairChildStopDescriptor,
+) (<-chan struct{}, func(), error) {
 	return nil, func() {}, nil
 }

--- a/internal/cli/wake_repair_handoff_unix.go
+++ b/internal/cli/wake_repair_handoff_unix.go
@@ -39,6 +39,7 @@ const (
 	envWakeRepairHandoffWriteFD = "AMQ_WAKE_REPAIR_HANDOFF_WRITE_FD"
 	envWakeRepairAgentDirFD     = "AMQ_WAKE_REPAIR_AGENT_DIR_FD"
 	envWakeRepairInboxDirFD     = "AMQ_WAKE_REPAIR_INBOX_DIR_FD"
+	envWakeRepairChildControlFD = "AMQ_WAKE_REPAIR_CHILD_CONTROL_FD"
 )
 
 // The handoff values deliberately contain no maps, slices, or pointers. Once
@@ -1048,75 +1049,308 @@ func (handoff *wakeRepairParentHandoff) Close() error {
 }
 
 func wakeRepairChildHandoffFromEnv() (*wakeRepairChildHandoff, bool, error) {
-	readRaw := strings.TrimSpace(os.Getenv(envWakeRepairHandoffReadFD))
-	writeRaw := strings.TrimSpace(os.Getenv(envWakeRepairHandoffWriteFD))
-	agentRaw := strings.TrimSpace(os.Getenv(envWakeRepairAgentDirFD))
-	inboxRaw := strings.TrimSpace(os.Getenv(envWakeRepairInboxDirFD))
+	bootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
+	if err != nil {
+		return nil, false, err
+	}
+	stopDescriptor, err := parseWakeRepairChildStopDescriptor(bootstrap)
+	if err != nil {
+		return nil, false, err
+	}
+	if stopDescriptor.present {
+		return nil, false, fmt.Errorf(
+			"%s is not valid without the complete wake repair bootstrap transaction",
+			stopDescriptor.name,
+		)
+	}
+	ownerStopDescriptor, err := parseAuthoritativeWakePrivateStopDescriptor(bootstrap)
+	if err != nil {
+		return nil, false, err
+	}
+	if ownerStopDescriptor.present {
+		return nil, false, fmt.Errorf(
+			"%s is not valid without the complete private bootstrap transaction",
+			ownerStopDescriptor.name,
+		)
+	}
+	return wakeRepairChildHandoffFromBootstrap(bootstrap)
+}
+
+type wakeRepairChildHandoffDescriptors struct {
+	readFD  int
+	writeFD int
+	agentFD int
+	inboxFD int
+	present bool
+}
+
+type wakeRepairChildStopDescriptor struct {
+	fd      int
+	name    string
+	present bool
+}
+
+func parseWakeRepairChildHandoffDescriptors(
+	bootstrap wakeRepairBootstrapEnv,
+) (wakeRepairChildHandoffDescriptors, error) {
+	readRaw := bootstrap.value(envWakeRepairHandoffReadFD)
+	writeRaw := bootstrap.value(envWakeRepairHandoffWriteFD)
+	agentRaw := bootstrap.value(envWakeRepairAgentDirFD)
+	inboxRaw := bootstrap.value(envWakeRepairInboxDirFD)
 	if readRaw == "" && writeRaw == "" && agentRaw == "" && inboxRaw == "" {
-		return nil, false, nil
+		return wakeRepairChildHandoffDescriptors{}, nil
 	}
 	if readRaw == "" || writeRaw == "" || agentRaw == "" || inboxRaw == "" {
-		return nil, true, fmt.Errorf("wake repair handoff descriptors are incomplete")
+		return wakeRepairChildHandoffDescriptors{}, fmt.Errorf(
+			"wake repair handoff descriptors are incomplete",
+		)
 	}
 	readFD, err := parseWakeRepairHandoffFD(envWakeRepairHandoffReadFD, readRaw)
 	if err != nil {
-		return nil, true, err
+		return wakeRepairChildHandoffDescriptors{}, err
 	}
 	writeFD, err := parseWakeRepairHandoffFD(envWakeRepairHandoffWriteFD, writeRaw)
 	if err != nil {
-		return nil, true, err
+		return wakeRepairChildHandoffDescriptors{}, err
 	}
 	if readFD == writeFD {
-		return nil, true, fmt.Errorf("wake repair handoff descriptors must be distinct")
+		return wakeRepairChildHandoffDescriptors{}, fmt.Errorf(
+			"wake repair handoff descriptors must be distinct",
+		)
 	}
 	agentFD, err := parseWakeRepairHandoffFD(envWakeRepairAgentDirFD, agentRaw)
 	if err != nil {
-		return nil, true, err
+		return wakeRepairChildHandoffDescriptors{}, err
 	}
 	inboxFD, err := parseWakeRepairHandoffFD(envWakeRepairInboxDirFD, inboxRaw)
 	if err != nil {
-		return nil, true, err
+		return wakeRepairChildHandoffDescriptors{}, err
 	}
 	if readFD == agentFD || readFD == inboxFD || writeFD == agentFD ||
 		writeFD == inboxFD || agentFD == inboxFD {
-		return nil, true, fmt.Errorf("wake repair handoff descriptors must be distinct")
+		return wakeRepairChildHandoffDescriptors{}, fmt.Errorf(
+			"wake repair handoff descriptors must be distinct",
+		)
+	}
+	return wakeRepairChildHandoffDescriptors{
+		readFD:  readFD,
+		writeFD: writeFD,
+		agentFD: agentFD,
+		inboxFD: inboxFD,
+		present: true,
+	}, nil
+}
+
+func wakeRepairChildCapabilitiesFromBootstrap(
+	bootstrap wakeRepairBootstrapEnv,
+) (
+	*wakeRepairChildHandoff,
+	bool,
+	<-chan struct{},
+	func(),
+	error,
+) {
+	handoffDescriptors, err := parseWakeRepairChildHandoffDescriptors(bootstrap)
+	if err != nil {
+		return nil, false, nil, nil, err
+	}
+	stopDescriptor, err := parseWakeRepairChildStopDescriptor(bootstrap)
+	if err != nil {
+		return nil, false, nil, nil, err
+	}
+	ownerStopDescriptor, err := parseAuthoritativeWakePrivateStopDescriptor(bootstrap)
+	if err != nil {
+		return nil, false, nil, nil, err
+	}
+	if err := validateWakeRepairChildDescriptorTuple(
+		handoffDescriptors,
+		stopDescriptor,
+		ownerStopDescriptor,
+	); err != nil {
+		return nil, false, nil, nil, err
+	}
+
+	if err := prepareWakeRepairChildHandoffDescriptors(handoffDescriptors); err != nil {
+		closeWakeRepairChildDescriptorTuple(
+			handoffDescriptors,
+			stopDescriptor,
+			ownerStopDescriptor,
+		)
+		return nil, false, nil, nil, err
+	}
+	if err := prepareAuthoritativeWakePrivateStopDescriptor(ownerStopDescriptor); err != nil {
+		closeWakeRepairChildDescriptorTuple(
+			handoffDescriptors,
+			stopDescriptor,
+			ownerStopDescriptor,
+		)
+		return nil, false, nil, nil, err
+	}
+	if err := prepareWakeRepairChildStopDescriptor(stopDescriptor); err != nil {
+		closeWakeRepairChildDescriptorTuple(
+			handoffDescriptors,
+			stopDescriptor,
+			ownerStopDescriptor,
+		)
+		return nil, false, nil, nil, err
+	}
+
+	handoff, err := adoptWakeRepairChildHandoffDescriptors(handoffDescriptors)
+	if err != nil {
+		if stopDescriptor.present {
+			_ = unix.Close(stopDescriptor.fd)
+		}
+		if ownerStopDescriptor.present {
+			_ = unix.Close(ownerStopDescriptor.fd)
+		}
+		return nil, false, nil, nil, err
+	}
+	ownerStop, cleanupOwnerStop, err :=
+		adoptAuthoritativeWakePrivateStopDescriptor(ownerStopDescriptor)
+	if err != nil {
+		_ = handoff.Close()
+		if stopDescriptor.present {
+			_ = unix.Close(stopDescriptor.fd)
+		}
+		return nil, false, nil, nil, err
+	}
+	repairStop, cleanupRepairStop, err := adoptWakeRepairChildStopDescriptor(stopDescriptor)
+	if err != nil {
+		cleanupOwnerStop()
+		_ = handoff.Close()
+		return nil, false, nil, nil, err
+	}
+	privateStop, cleanupMergedStop := mergeWakeBootstrapStopChannels(ownerStop, repairStop)
+	var cleanupOnce sync.Once
+	cleanup := func() {
+		cleanupOnce.Do(func() {
+			cleanupMergedStop()
+			cleanupRepairStop()
+			cleanupOwnerStop()
+		})
+	}
+	return handoff, handoffDescriptors.present, privateStop, cleanup, nil
+}
+
+func mergeWakeBootstrapStopChannels(
+	first, second <-chan struct{},
+) (<-chan struct{}, func()) {
+	if first == nil {
+		return second, func() {}
+	}
+	if second == nil {
+		return first, func() {}
+	}
+	merged := make(chan struct{})
+	cancel := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		select {
+		case <-first:
+			close(merged)
+		case <-second:
+			close(merged)
+		case <-cancel:
+		}
+	}()
+	var cancelOnce sync.Once
+	return merged, func() {
+		cancelOnce.Do(func() {
+			close(cancel)
+			<-finished
+		})
+	}
+}
+
+func validateWakeRepairChildDescriptorTuple(
+	handoff wakeRepairChildHandoffDescriptors,
+	stop wakeRepairChildStopDescriptor,
+	ownerStop wakePrivateStopDescriptor,
+) error {
+	if err := validateWakeRepairChildPlatformDescriptorTuple(handoff, stop); err != nil {
+		return err
+	}
+	if !handoff.present || !stop.present {
+		return nil
+	}
+	common := []struct {
+		name string
+		fd   int
+	}{
+		{name: envWakeRepairHandoffReadFD, fd: handoff.readFD},
+		{name: envWakeRepairHandoffWriteFD, fd: handoff.writeFD},
+		{name: envWakeRepairAgentDirFD, fd: handoff.agentFD},
+		{name: envWakeRepairInboxDirFD, fd: handoff.inboxFD},
+	}
+	for _, descriptor := range common {
+		if stop.fd == descriptor.fd {
+			return fmt.Errorf("%s aliases %s", stop.name, descriptor.name)
+		}
+	}
+	if !ownerStop.present {
+		return nil
+	}
+	otherDescriptors := common
+	if stop.present {
+		otherDescriptors = append(otherDescriptors, struct {
+			name string
+			fd   int
+		}{name: stop.name, fd: stop.fd})
+	}
+	for _, descriptor := range otherDescriptors {
+		if ownerStop.fd == descriptor.fd {
+			return fmt.Errorf("%s aliases %s", ownerStop.name, descriptor.name)
+		}
+	}
+	return nil
+}
+
+func prepareWakeRepairChildHandoffDescriptors(
+	descriptors wakeRepairChildHandoffDescriptors,
+) error {
+	if !descriptors.present {
+		return nil
 	}
 	inherited := []struct {
 		label string
 		fd    int
 	}{
-		{label: "read", fd: readFD},
-		{label: "write", fd: writeFD},
-		{label: "agent directory", fd: agentFD},
-		{label: "inbox directory", fd: inboxFD},
+		{label: "read", fd: descriptors.readFD},
+		{label: "write", fd: descriptors.writeFD},
+		{label: "agent directory", fd: descriptors.agentFD},
+		{label: "inbox directory", fd: descriptors.inboxFD},
 	}
 	for _, descriptor := range inherited {
 		if err := setWakeRepairFDCloseOnExec(descriptor.fd, descriptor.label); err != nil {
-			for _, candidate := range inherited {
-				_ = unix.Close(candidate.fd)
-			}
-			return nil, true, err
+			return err
 		}
 	}
 	// os/exec obtains ExtraFiles through File.Fd, which restores blocking mode.
 	// The child must remain cancellable while it waits for the final release
 	// frame, so make its inherited read end pollable before os.NewFile adopts it.
-	if err := unix.SetNonblock(readFD, true); err != nil {
-		for _, candidate := range inherited {
-			_ = unix.Close(candidate.fd)
-		}
-		return nil, true, fmt.Errorf("make wake repair handoff read fd nonblocking: %w", err)
+	if err := unix.SetNonblock(descriptors.readFD, true); err != nil {
+		return fmt.Errorf("make wake repair handoff read fd nonblocking: %w", err)
 	}
-	readFile := os.NewFile(uintptr(readFD), "wake-repair-handoff-read")
-	writeFile := os.NewFile(uintptr(writeFD), "wake-repair-handoff-write")
-	agentFile := os.NewFile(uintptr(agentFD), "wake-repair-agent-directory")
-	inboxFile := os.NewFile(uintptr(inboxFD), "wake-repair-inbox-directory")
+	return nil
+}
+
+func adoptWakeRepairChildHandoffDescriptors(
+	descriptors wakeRepairChildHandoffDescriptors,
+) (*wakeRepairChildHandoff, error) {
+	if !descriptors.present {
+		return nil, nil
+	}
+	readFile := os.NewFile(uintptr(descriptors.readFD), "wake-repair-handoff-read")
+	writeFile := os.NewFile(uintptr(descriptors.writeFD), "wake-repair-handoff-write")
+	agentFile := os.NewFile(uintptr(descriptors.agentFD), "wake-repair-agent-directory")
+	inboxFile := os.NewFile(uintptr(descriptors.inboxFD), "wake-repair-inbox-directory")
 	if readFile == nil || writeFile == nil || agentFile == nil || inboxFile == nil {
 		_ = closeFile(readFile)
 		_ = closeFile(writeFile)
 		_ = closeFile(agentFile)
 		_ = closeFile(inboxFile)
-		return nil, true, fmt.Errorf("wake repair handoff descriptor is unavailable")
+		return nil, fmt.Errorf("wake repair handoff descriptor is unavailable")
 	}
 	return &wakeRepairChildHandoff{
 		reader:    bufio.NewReader(readFile),
@@ -1125,7 +1359,48 @@ func wakeRepairChildHandoffFromEnv() (*wakeRepairChildHandoff, bool, error) {
 		writeFile: writeFile,
 		agentFile: agentFile,
 		inboxFile: inboxFile,
-	}, true, nil
+	}, nil
+}
+
+func closeWakeRepairChildDescriptorTuple(
+	handoff wakeRepairChildHandoffDescriptors,
+	stop wakeRepairChildStopDescriptor,
+	ownerStop wakePrivateStopDescriptor,
+) {
+	if handoff.present {
+		_ = unix.Close(handoff.readFD)
+		_ = unix.Close(handoff.writeFD)
+		_ = unix.Close(handoff.agentFD)
+		_ = unix.Close(handoff.inboxFD)
+	}
+	if stop.present {
+		_ = unix.Close(stop.fd)
+	}
+	if ownerStop.present {
+		_ = unix.Close(ownerStop.fd)
+	}
+}
+
+func wakeRepairChildHandoffFromBootstrap(
+	bootstrap wakeRepairBootstrapEnv,
+) (*wakeRepairChildHandoff, bool, error) {
+	descriptors, err := parseWakeRepairChildHandoffDescriptors(bootstrap)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := prepareWakeRepairChildHandoffDescriptors(descriptors); err != nil {
+		closeWakeRepairChildDescriptorTuple(
+			descriptors,
+			wakeRepairChildStopDescriptor{},
+			wakePrivateStopDescriptor{},
+		)
+		return nil, false, err
+	}
+	handoff, err := adoptWakeRepairChildHandoffDescriptors(descriptors)
+	if err != nil {
+		return nil, false, err
+	}
+	return handoff, descriptors.present, nil
 }
 
 func (handoff *wakeRepairChildHandoff) TakeRetainedDirectories(

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1255,24 +1255,19 @@ func buildRepairWakeArgs(root, me string, target wakeTarget, generation, readyPa
 }
 
 func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
-	privateStop, cleanupPrivateStop, err := authoritativeWakePrivateStopFromEnv()
+	repairBootstrap, err := captureAndScrubWakeRepairBootstrapEnv()
 	if err != nil {
 		return err
 	}
-	defer cleanupPrivateStop()
-	repairHandoff, repairHandoffPresent, err := wakeRepairChildHandoffFromEnv()
+	repairHandoff, repairHandoffPresent, privateStop, cleanupPrivateStop, err :=
+		wakeRepairChildCapabilitiesFromBootstrap(repairBootstrap)
 	if err != nil {
 		return err
 	}
 	if repairHandoff != nil {
 		defer func() { _ = repairHandoff.Close() }()
 	}
-	repairPrivateStop, cleanupRepairPrivateStop, err := wakeRepairChildStopFromEnv()
-	if err != nil {
-		return err
-	}
-	defer cleanupRepairPrivateStop()
-	privateStop = mergeWakeStopChannels(privateStop, repairPrivateStop)
+	defer cleanupPrivateStop()
 
 	fs := flag.NewFlagSet("wake", flag.ContinueOnError)
 	common := addCommonFlags(fs)


### PR DESCRIPTION
## Summary
- capture and scrub every private wake bootstrap environment value before parsing
- validate the complete Darwin six-FD transaction, including pairwise alias rejection, before adoption
- prepare all descriptor semantics before creating file owners, watchers, goroutines, or the wake loop
- roll back the whole validated inherited tuple on preparation failure
- scrub and reject unsupported private descriptor state on Linux

## Verification
- focused tests x10 and focused race tests
- full suite and full race suite
- vet, formatting, native and Linux lint
- Darwin arm64 and Linux amd64 test cross-builds

Merge is held for exact-head ChatGPT Pro review.