### PR TITLE
fix(cli): reject stray leaf arguments

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -722,6 +722,14 @@ func isHelp(arg string) bool {
 }
 
 func parseFlags(fs *flag.FlagSet, args []string, usage func()) (bool, error) {
+	return parseFlagsWithPositionals(fs, args, usage, false)
+}
+
+func parseFlagsAllowPositionals(fs *flag.FlagSet, args []string, usage func()) (bool, error) {
+	return parseFlagsWithPositionals(fs, args, usage, true)
+}
+
+func parseFlagsWithPositionals(fs *flag.FlagSet, args []string, usage func(), allowPositionals bool) (bool, error) {
 	fs.SetOutput(io.Discard)
 	if usage != nil {
 		fs.Usage = usage
@@ -735,6 +743,15 @@ func parseFlags(fs *flag.FlagSet, args []string, usage func()) (bool, error) {
 	for _, name := range []string{"root", "session"} {
 		if fl := fs.Lookup(name); fl != nil && flagWasVisited(fs, name) && strings.TrimSpace(fl.Value.String()) == "" {
 			return false, UsageError("--%s cannot be empty", name)
+		}
+	}
+	if !allowPositionals {
+		if remaining := fs.Args(); len(remaining) > 0 {
+			message := fmt.Sprintf("%s does not accept positional arguments (got %q)", fs.Name(), strings.Join(remaining, " "))
+			if fs.Lookup("body") != nil {
+				message += "; use --body to pass message text"
+			}
+			return false, UsageError("%s", message)
 		}
 	}
 	return false, nil
@@ -751,16 +768,6 @@ func flagWasVisited(fs *flag.FlagSet, name string) bool {
 		}
 	})
 	return visited
-}
-
-// rejectPositionalArgs returns a UsageError if the flag set has any remaining
-// positional arguments after parsing. Commands that don't accept positional
-// args should call this immediately after parseFlags to prevent silent drops.
-func rejectPositionalArgs(fs *flag.FlagSet, cmdName string) error {
-	if remaining := fs.Args(); len(remaining) > 0 {
-		return UsageError("%s does not accept positional arguments (got %q); use --body to pass message text", cmdName, strings.Join(remaining, " "))
-	}
-	return nil
 }
 
 func usageWithFlags(fs *flag.FlagSet, usage string, notes ...string) func() {

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -2,13 +2,74 @@ package cli
 
 import (
 	"encoding/json"
+	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 )
+
+func TestParseFlagsRejectsPositionals(t *testing.T) {
+	fs := flag.NewFlagSet("route explain", flag.ContinueOnError)
+	laterFlag := fs.String("later", "", "test flag")
+
+	handled, err := parseFlags(fs, []string{"stray", "--later", "value"}, nil)
+	if handled {
+		t.Fatal("positional rejection was reported as handled")
+	}
+	if err == nil {
+		t.Fatal("expected positional arguments to be rejected")
+	}
+	if code := GetExitCode(err); code != ExitUsage {
+		t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(err.Error(), `route explain does not accept positional arguments (got "stray --later value")`) {
+		t.Fatalf("error does not use flag set name and remaining arguments: %v", err)
+	}
+	if strings.Contains(err.Error(), "--body") {
+		t.Fatalf("error suggests unavailable --body flag: %v", err)
+	}
+	if *laterFlag != "" {
+		t.Fatalf("flag after positional was parsed as %q, want empty", *laterFlag)
+	}
+}
+
+func TestParseFlagsPositionalBodyHint(t *testing.T) {
+	fs := flag.NewFlagSet("send", flag.ContinueOnError)
+	fs.String("body", "", "message body")
+
+	_, err := parseFlags(fs, []string{"message text"}, nil)
+	if err == nil {
+		t.Fatal("expected positional arguments to be rejected")
+	}
+	if !strings.Contains(err.Error(), "--body") {
+		t.Fatalf("error should suggest registered --body flag: %v", err)
+	}
+}
+
+func TestParseFlagsAllowPositionalsRetainsArguments(t *testing.T) {
+	fs := flag.NewFlagSet("coop exec", flag.ContinueOnError)
+	rootFlag := fs.String("root", "", "queue root")
+
+	handled, err := parseFlagsAllowPositionals(fs, []string{"--root", "/tmp/queue", "codex", "--agent-flag"}, nil)
+	if err != nil {
+		t.Fatalf("parseFlagsAllowPositionals: %v", err)
+	}
+	if handled {
+		t.Fatal("ordinary parse was reported as handled")
+	}
+	if *rootFlag != "/tmp/queue" {
+		t.Fatalf("root = %q, want /tmp/queue", *rootFlag)
+	}
+	got := fs.Args()
+	want := []string{"codex", "--agent-flag"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("remaining args = %#v, want %#v", got, want)
+	}
+}
 
 func TestNormalizeHandle(t *testing.T) {
 	if got, err := normalizeHandle("codex"); err != nil || got != "codex" {

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -115,6 +115,37 @@ func TestCoopExecUsageError(t *testing.T) {
 	}
 }
 
+func TestCoopExecForwardsCommandArguments(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+
+	sentinel := errors.New("exec sentinel")
+	var gotArgv []string
+	oldExec := coopExecProcess
+	coopExecProcess = func(_ string, argv []string, _ []string) error {
+		gotArgv = append([]string{}, argv...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err := runCoopExec([]string{
+		"--root", root,
+		"--me", "codex",
+		"--no-wake",
+		"sh", "-c", "echo ok",
+		"--", "--tail-flag",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want sentinel", err)
+	}
+	wantArgv := []string{"sh", "-c", "echo ok", "--tail-flag"}
+	if !reflect.DeepEqual(gotArgv, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", gotArgv, wantArgv)
+	}
+}
+
 func TestCoopExecSessionRootMutuallyExclusive(t *testing.T) {
 	err := runCoopExec([]string{"--session", "feat", "--root", "/tmp/q", "claude"})
 	if err == nil {

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -68,7 +68,7 @@ func runCoopExec(args []string) error {
 		"  reused; stop an older generic wake before retrying coop exec.",
 	)
 
-	if handled, err := parseFlags(fs, amqArgs, usage); err != nil {
+	if handled, err := parseFlagsAllowPositionals(fs, amqArgs, usage); err != nil {
 		return err
 	} else if handled {
 		return nil

--- a/internal/cli/reply.go
+++ b/internal/cli/reply.go
@@ -44,9 +44,6 @@ func runReply(args []string) error {
 	} else if handled {
 		return nil
 	}
-	if err := rejectPositionalArgs(fs, "reply"); err != nil {
-		return err
-	}
 	if err := requireMe(common.Me); err != nil {
 		return err
 	}

--- a/internal/cli/route.go
+++ b/internal/cli/route.go
@@ -58,9 +58,6 @@ func runRouteExplain(args []string) error {
 	} else if handled {
 		return nil
 	}
-	if fs.NArg() > 0 {
-		return UsageError("route explain does not accept positional arguments (got %q)", strings.Join(fs.Args(), " "))
-	}
 	if !*jsonFlag {
 		return UsageError("route explain requires --json")
 	}

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -59,9 +59,6 @@ func runSend(args []string) error {
 	} else if handled {
 		return nil
 	}
-	if err := rejectPositionalArgs(fs, "send"); err != nil {
-		return err
-	}
 	if err := requireMe(common.Me); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- reject leftover positional arguments for flag-only leaf commands
- keep a private explicit allow-positionals parser used only by `coop exec`
- preserve help/ExitUsage and command-specific body diagnostics
- remove redundant positional guards now owned by the common parser

## Verification
- focused parser, coop, send, reply, help, and ExitUsage tests
- full suite and CLI race suite
- lint, vet, formatting, skills, smoke, and diff checks
- real binary rejection/forwarding checks

Merge is held for exact-head ChatGPT Pro review.