### PR TITLE
test(cli): scrub wake ownership from package environment

### DIFF
--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
-	for _, k := range []string{"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION", "AMQ_GLOBAL_ROOT"} {
+	for _, k := range []string{"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION", "AMQ_GLOBAL_ROOT", envWakeOwner, "AMQ_WAKE_PRIVATE_STOP_FD"} {
 		_ = os.Unsetenv(k)
 	}
 


### PR DESCRIPTION
## Summary
- clear inherited `AMQ_WAKE_OWNER` and `AMQ_WAKE_PRIVATE_STOP_FD` at the CLI package test boundary
- keep helper-mode early returns and production behavior unchanged
- prevent a developer or supervised-wake shell from contaminating unrelated package tests

## Causal evidence
Before this change, inherited wake ownership state made the package gate fail hard:

```bash
AMQ_WAKE_OWNER='{"pid":1}' AMQ_WAKE_PRIVATE_STOP_FD=999 go test ./internal/cli -count=1
# exit 143; JSON rerun ended package FAIL after 34.883s
```

After this change, with the same inherited environment:

```bash
go test ./internal/cli -run '^(TestRunWakeWithLoopRejectsInvalidRepairLineageFlags|TestCoopExecAlwaysOverwritesOwnerTokenImmediatelyBeforeExec|TestDarwinWakeOwnerPrivateStopIsSealedFromDescendantExec)$' -count=1
# PASS (0.475s)

go test ./internal/cli -count=1
# PASS (30.148s)

go test -race ./internal/cli -run '^(TestRunWakeWithLoopRejectsInvalidRepairLineageFlags|TestCoopExecAlwaysOverwritesOwnerTokenImmediatelyBeforeExec|TestDarwinWakeOwnerPrivateStopIsSealedFromDescendantExec)$' -count=1
# PASS (2.540s)
```

## Cross-platform rationale
`envWakeOwner` is the canonical package-wide constant, so TestMain uses it directly. The private stop descriptor constant is declared only in `wake_owner_child_unix.go`; TestMain uses the literal `AMQ_WAKE_PRIVATE_STOP_FD` so the package test boundary continues to compile on Windows and other non-Unix targets while scrubbing the same runtime variable.

Frozen reviewed tree: `f67e119f20235e8970499efe28e21b820683f89b`  
Commit: `602a37d7bbaf71ef761665f1a293cc8a5b1a9a17`