### PR TITLE
fix(wake): make interrupt injection opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,7 +423,7 @@ Commands below assume `AM_ME` is set (e.g., `export AM_ME=claude`).
 | Waiting for reply | `amq watch --timeout 60s` | Blocks until message |
 | Quick peek only | `amq list --new` | Non-blocking, no side effects |
 | Filter messages | `amq list --new --priority urgent` | Show only urgent messages |
-| Background wake | `amq wake --me <agent> &` | Injects notification via TIOCSTI with best-effort input deferral, or via explicit external transport (experimental) |
+| Background wake | `amq wake --me <agent> --interrupt-cmd none &` | Injects notification via TIOCSTI with best-effort input deferral, or via explicit external transport (experimental), without Ctrl+C injection |
 | Reply to message | `amq reply --id <msg_id>` | Auto thread/refs handling |
 
 ## Co-op Mode (Claude <-> Codex, optional peers)
@@ -549,8 +549,12 @@ See `.claude/skills/amq-cli/SKILL.md` for the agent-facing workflow.
 **Wake compatibility**: bridge notifications are standard AMQ inbox messages, so `amq wake` will detect them automatically. If you want swarm notifications to trigger wake interrupts, configure wake to match the bridge label and priority:
 
 ```bash
-amq wake --me codex --interrupt-label swarm --interrupt-priority normal &
+amq wake --me codex --interrupt-label swarm --interrupt-priority normal --interrupt-cmd ctrl-c &
 ```
+
+`--interrupt-cmd ctrl-c` is an explicit destructive opt-in: it sends a real
+SIGINT to the foreground process group and can interrupt or crash the agent.
+Omit it to keep the notice and bell without injecting Ctrl+C.
 
 **Direct messaging (A2A)**: the bridge only emits task lifecycle notifications.
 
@@ -564,7 +568,7 @@ amq send --me codex --to claude --thread swarm/my-team --labels swarm \
   --body "..."
 ```
 
-Leader loop options: periodic `amq drain --include-body`, tighter `amq monitor --include-body` (watch+drain), or `amq wake --me claude &` for terminal notifications.
+Leader loop options: periodic `amq drain --include-body`, tighter `amq monitor --include-body` (watch+drain), or `amq wake --me claude --interrupt-cmd none &` for terminal notifications.
 
 ## Testing
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1292,7 +1292,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	interruptFlag := fs.Bool("interrupt", true, "Enable interrupt injection for urgent interrupt messages")
 	interruptLabelFlag := fs.String("interrupt-label", "interrupt", "Label required to trigger interrupt")
 	interruptPriorityFlag := fs.String("interrupt-priority", "urgent", "Priority required to trigger interrupt")
-	interruptCmdFlag := fs.String("interrupt-cmd", "ctrl-c", "Interrupt command to inject (ctrl-c or none)")
+	interruptCmdFlag := fs.String("interrupt-cmd", "none", "Interrupt command to inject: none (default) or ctrl-c (sends real SIGINT to the foreground process group and can interrupt or crash the agent)")
 	interruptNoticeFlag := fs.String("interrupt-notice", "", "Custom interrupt notice (default: auto)")
 	interruptCooldownFlag := fs.Duration("interrupt-cooldown", 7*time.Second, "Minimum time between interrupts")
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
@@ -1304,7 +1304,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	usage := usageWithHiddenFlags(fs, "amq wake --me <agent> [options]",
 		[]string{"ready-file", "accept-existing-wake", "repair-lineage"},
 		"Background waker: injects terminal notification when messages arrive.",
-		"Run as background job before starting CLI: amq wake --me claude &",
+		"Run as background job before starting CLI: amq wake --me claude --interrupt-cmd none &",
 		"",
 		"Inject modes:",
 		"  auto  - Detect CLI type: raw for Claude Code/Codex, paste for others",
@@ -1332,10 +1332,12 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		"  Linux tty atime is updated at ~8s granularity, so quiet windows",
 		"  shorter than that are advisory.",
 		"",
-		"Interrupts (default on): urgent messages tagged with label \"interrupt\"",
-		"  trigger Ctrl+C injection + an interrupt notice except in none mode.",
+		"Interrupt notices (default on): urgent messages tagged with label \"interrupt\"",
+		"  trigger an interrupt notice. Ctrl+C injection is opt-in with",
+		"  --interrupt-cmd ctrl-c; it sends real SIGINT to the foreground process",
+		"  group and can interrupt or crash the agent.",
 		"",
-		"Safety: raw, paste, --inject-cmd, --inject-via, and interrupt Ctrl+C",
+		"Safety: raw, paste, --inject-cmd, --inject-via, and opt-in interrupt Ctrl+C",
 		"  can activate a focused permission/approval dialog. Use none when AMQ",
 		"  must enforce zero synthetic input; stderr output may scribble until redraw.",
 		"",

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -127,6 +127,106 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopInterruptCommandDefaultsOffAndRemainsOptIn(t *testing.T) {
+	tests := []struct {
+		name             string
+		interruptCmdArgs []string
+		wantPrefix       string
+	}{
+		{
+			name:       "default emits notice without ctrl-c",
+			wantPrefix: "",
+		},
+		{
+			name:             "explicit ctrl-c injects before notice",
+			interruptCmdArgs: []string{"--interrupt-cmd", "ctrl-c"},
+			wantPrefix:       "\x03\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatalf("EnsureRootDirs: %v", err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+
+			msg := format.Message{
+				Header: format.Header{
+					Schema:   1,
+					ID:       "msg-urgent",
+					From:     "codex",
+					To:       []string{"alice"},
+					Thread:   "p2p/alice__codex",
+					Subject:  "help needed",
+					Created:  "2026-07-26T12:00:00Z",
+					Priority: "urgent",
+					Labels:   []string{"interrupt"},
+				},
+				Body: "urgent body",
+			}
+			data, err := msg.Marshal()
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if _, err := deliverToInboxForTest(t, root, "alice", "msg-urgent.md", data); err != nil {
+				t.Fatalf("deliver: %v", err)
+			}
+
+			logPath := filepath.Join(root, "inject.log")
+			injector := filepath.Join(root, "inject.sh")
+			if err := os.WriteFile(
+				injector,
+				[]byte("#!/bin/sh\nprintf '%s\\n' \"$1\" >> "+logPath+"\n"),
+				0o755,
+			); err != nil {
+				t.Fatalf("write injector: %v", err)
+			}
+
+			errDone := errors.New("done")
+			args := []string{
+				"--root", root,
+				"--me", "alice",
+				"--inject-via", injector,
+			}
+			args = append(args, tt.interruptCmdArgs...)
+			err = runWakeWithLoop(args, func(cfg wakeConfig) error {
+				if err := notifyNewMessages(&cfg); err != nil {
+					t.Fatalf("notifyNewMessages: %v", err)
+				}
+				return errDone
+			})
+			if !errors.Is(err, errDone) {
+				t.Fatalf("runWakeWithLoop error = %v, want sentinel", err)
+			}
+
+			got, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("read injector log: %v", err)
+			}
+			notice := buildInterruptText(
+				"",
+				[]wakeMsgInfo{{
+					from:     "codex",
+					subject:  "help needed",
+					priority: "urgent",
+					labels:   []string{"interrupt"},
+				}},
+				map[string]int{"codex": 1},
+				48,
+				"",
+			)
+			want := tt.wantPrefix + notice + "\n"
+			if string(got) != want {
+				t.Fatalf("injector log = %q, want %q", string(got), want)
+			}
+		})
+	}
+}
+
 func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -510,6 +610,10 @@ func TestRunWakeHelpHidesInternalReadyFlags(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "none") || !strings.Contains(stdout, "zero terminal input") {
 		t.Fatalf("wake help should document none as zero-input mode:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "real SIGINT to the foreground process group") ||
+		!strings.Contains(stdout, "can interrupt or crash the agent") {
+		t.Fatalf("wake help should explain the destructive ctrl-c opt-in:\n%s", stdout)
 	}
 }
 

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -121,6 +121,23 @@ Without `--session` or `--root`, `coop exec` defaults to `--session collab`.
 
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
 
+### Standalone wake interrupt safety
+
+Standalone wake keeps urgent interrupt notices and the bell without injecting
+Ctrl+C by default:
+```bash
+amq wake --me claude --interrupt-cmd none &
+```
+
+Real Ctrl+C injection is a destructive opt-in:
+```bash
+amq wake --me codex --interrupt-label swarm --interrupt-priority normal --interrupt-cmd ctrl-c &
+```
+
+`--interrupt-cmd ctrl-c` sends a real SIGINT to the foreground process group
+and can interrupt or crash the agent. Use it only when that process-level
+interruption is intentional.
+
 ## Statusline (Claude Code)
 
 To show the current AMQ session in your Claude Code status bar, add this snippet to your statusline script (e.g., `~/.claude/statusline.sh`):


### PR DESCRIPTION
## Summary
- default standalone wake interrupt commands to `none` so urgent labelled messages cannot inject Ctrl+C implicitly
- preserve interrupt notices and explicit `--interrupt-cmd ctrl-c` behavior
- document that Ctrl+C sends real SIGINT and can interrupt or crash the foreground agent

## Verification
- RED on base: `go test ./internal/cli -run '^TestRunWakeWithLoopInterruptCommandDefaultsOffAndRemainsOptIn$' -count=1`\n- focused regression + help tests pass\n- `make check-skills`\n- `go test ./internal/cli/...`\n- `make ci`\n\nExact approved tree: `36c3c6d04bf4c054c59052227da0301485626772`.