### PR TITLE
fix(wake): close wake terminal descriptors on exec

### DIFF
--- a/internal/cli/wake_repair_dirs_darwin.go
+++ b/internal/cli/wake_repair_dirs_darwin.go
@@ -41,6 +41,16 @@ func newRetainedWakeInboxWatcher(
 	if err != nil {
 		return nil, fmt.Errorf("create retained wake directory kqueue: %w", err)
 	}
+	if err := setDarwinWakeOwnerObservationCloseOnExec(
+		kqueueFD,
+		"retained wake directory kqueue",
+	); err != nil {
+		closeErr := unix.Close(kqueueFD)
+		if closeErr != nil {
+			return nil, fmt.Errorf("%w (close kqueue: %v)", err, closeErr)
+		}
+		return nil, err
+	}
 	flags := uint32(
 		unix.NOTE_WRITE |
 			unix.NOTE_EXTEND |

--- a/internal/cli/wake_tiocsti_unix.go
+++ b/internal/cli/wake_tiocsti_unix.go
@@ -78,7 +78,7 @@ func waitForTTYInputQuiet(cfg *wakeConfig) {
 		return
 	}
 
-	queueFD, err := unix.Open("/dev/tty", unix.O_RDONLY|unix.O_NOCTTY, 0)
+	queueFD, err := unix.Open("/dev/tty", unix.O_RDONLY|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: input deferral unavailable: open /dev/tty: %v\n", err)
@@ -136,7 +136,7 @@ func waitForTTYInputQuiet(cfg *wakeConfig) {
 }
 
 func waitForTTYInputDrain(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
-	queueFD, err := unix.Open("/dev/tty", unix.O_RDONLY|unix.O_NOCTTY, 0)
+	queueFD, err := unix.Open("/dev/tty", unix.O_RDONLY|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return 0, false, err
 	}


### PR DESCRIPTION
## Summary
- open both wake `/dev/tty` descriptors with `O_CLOEXEC` atomically
- defensively apply the same close-on-exec verification to the Darwin retained-directory kqueue

## Verification
- exact reviewed tree: `5b678d0c0cf1df4f3b54b93ccabe1606255e864e`
- `go test ./... -count=1`
- `gofmt -l .`
- `go vet ./...`
- `GOOS=linux go vet ./...`