### PR TITLE
fix(wake): admit wake when an unverified generic lock cannot be proven

### DIFF
--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -923,12 +923,16 @@ func TestRepairWakeRefusesRawTTYWithoutInjectTarget(t *testing.T) {
 	}
 }
 
-func TestRepairWakeRefusesUnverifiedLock(t *testing.T) {
+func TestRepairWakeSupersedesUnverifiedGenericLockWithoutSignal(t *testing.T) {
 	root := secureTempDirForTest(t)
-	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	lockPath := writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
 		PID:        4242,
 		Executable: "/opt/homebrew/bin/amq",
-	})
+		Generation: "unverified-generation",
+		BootID:     wakeRepairTestBootID,
+	}, target))
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == 4242 {
 			return wakeProcessInfo{
@@ -937,25 +941,70 @@ func TestRepairWakeRefusesUnverifiedLock(t *testing.T) {
 				Executable: "/opt/homebrew/bin/amq",
 			}
 		}
+		if pid == 9876 {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "new-start",
+				BootID:     wakeRepairTestBootID,
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+			}
+		}
 		return wakeProcessInfo{PID: pid}
 	})
-	if err := writeWakeTarget(root, "codex", mustNewWakeTargetForTest(t, root, "codex", writeExecutableForTest(t, "injector"), nil)); err != nil {
+	var signals []os.Signal
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
-	stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
-		t.Fatalf("startWakeFromTarget should not run for unverified lock")
-		return 0, nil
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+	stubStartWakeFromTarget(t, func(gotRoot, gotMe string, gotTarget wakeTarget, source wakeRepairFloor) (int, error) {
+		if gotRoot != root || gotMe != "codex" || !sameWakeTarget(gotTarget, target) {
+			t.Fatalf("unexpected repair start: root=%q me=%q target=%#v", gotRoot, gotMe, gotTarget)
+		}
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatalf("unverified lock should be removed before start: %v", err)
+		}
+		writeWakeLockForTest(t, root, "codex", bindWakeLockToTarget(wakeLock{
+			PID:          9876,
+			ProcessStart: "new-start",
+			Executable:   "/opt/homebrew/bin/amq",
+			Generation:   "generation-new",
+		}, target))
+		writeWakeRepairWinnerFloorForTest(t, root, "codex", target, source)
+		return 9876, nil
 	})
 
-	result, err := repairWake(root, "codex")
-	if err == nil {
-		t.Fatal("expected unverified repair refusal")
+	var result wakeRepairResult
+	var repairErr error
+	stderr := captureWakeStderr(t, func() {
+		result, repairErr = repairWake(root, "codex")
+	})
+	if repairErr != nil {
+		t.Fatalf("repairWake: %v", repairErr)
 	}
-	if result.Status != "refused" || !strings.Contains(result.Reason, "unverified") {
-		t.Fatalf("unexpected result: %#v err=%v", result, err)
+	if result.Status != "repaired" || result.PID != 9876 {
+		t.Fatalf("unexpected result: %#v", result)
 	}
-	if _, statErr := os.Stat(lockPath); statErr != nil {
-		t.Fatalf("unverified lock should remain: %v", statErr)
+	if len(signals) != 0 {
+		t.Fatalf("unverified helper was signaled: %v", signals)
+	}
+	if count := strings.Count(stderr, "warning:"); count != 1 {
+		t.Fatalf("warning count = %d, want 1:\n%s", count, stderr)
+	}
+	for _, want := range []string{
+		"unidentified wake helper",
+		"pid 4242",
+		"duplicate notifications",
+		"stop that helper if duplicates persist",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("warning missing %q:\n%s", want, stderr)
+		}
 	}
 }
 
@@ -1252,7 +1301,7 @@ func TestRepairWakeRefusesStaleRawLockWithLeftoverTarget(t *testing.T) {
 	}
 }
 
-func TestRepairWakeRefusesUnknownBootIdentityLock(t *testing.T) {
+func TestRepairWakeUnknownBootIdentityContinuesToFloorValidation(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		lock       wakeLock
@@ -1292,7 +1341,7 @@ func TestRepairWakeRefusesUnknownBootIdentityLock(t *testing.T) {
 				return proc
 			})
 			stubStartWakeFromTarget(t, func(root, me string, target wakeTarget, _ wakeRepairFloor) (int, error) {
-				t.Fatalf("startWakeFromTarget should not run for live identity mismatch")
+				t.Fatalf("startWakeFromTarget should not run without a repair floor")
 				return 0, nil
 			})
 
@@ -1301,12 +1350,12 @@ func TestRepairWakeRefusesUnknownBootIdentityLock(t *testing.T) {
 				t.Fatal("expected repair refusal")
 			}
 			if result.Status != "refused" ||
-				!strings.Contains(result.Reason, "unverified") ||
-				!strings.Contains(err.Error(), tc.wantReason) {
+				!strings.Contains(result.Reason, "repair floor is missing") ||
+				!strings.Contains(err.Error(), "repair floor is missing") {
 				t.Fatalf("unexpected result: %#v err=%v", result, err)
 			}
 			if _, statErr := os.Stat(lockPath); statErr != nil {
-				t.Fatalf("lock should remain on refused live identity mismatch: %v", statErr)
+				t.Fatalf("%s lock should remain until repair can start: %v", tc.wantReason, statErr)
 			}
 		})
 	}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -144,6 +144,40 @@ func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions)
 	}, nil
 }
 
+func supersedeUnverifiedGenericWakeAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+) error {
+	current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
+	if !sameWakeLockGeneration(expected, current) {
+		return fmt.Errorf("unverified wake changed before supersession; retry")
+	}
+	if current.Status != wakeLockUnverified ||
+		classifyPersistedWakeClaim(current) != wakeClaimGeneric {
+		return fmt.Errorf(
+			"wake state for %s is not an unverified ownerless generic claim; use 'amq wake recover-owner --me %s' for an owner-bound claim",
+			expected.Agent,
+			expected.Agent,
+		)
+	}
+	if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, current); err != nil {
+		return fmt.Errorf("supersede exact unverified wake claim: %w", err)
+	}
+
+	tty := strings.TrimSpace(current.Lock.TTY)
+	if tty == "" {
+		tty = "unknown"
+	}
+	_ = writeStderr(
+		"warning: superseded unidentified wake helper for %s (pid %d on %s) without signaling it; fresh wake is starting, but duplicate notifications may continue until the old helper exits; stop that helper if duplicates persist\n",
+		current.Agent,
+		current.Lock.PID,
+		tty,
+	)
+	return nil
+}
+
 func acquireWakeLockWithOptionsInDir(
 	agentDir *wakeAgentDir,
 	root, me string,
@@ -166,6 +200,14 @@ func acquireWakeLockWithOptionsInDir(
 			inspection := inspectWakeLockAt(dirfd, agentDir, root, me)
 			if options.repairLineage != nil && inspection.Exists {
 				return fmt.Errorf("wake lock changed before repair acquisition")
+			}
+			if inspection.Status == wakeLockUnverified && wakeLockHasOwnerMarkers(inspection) {
+				return fmt.Errorf(
+					"wake state for %s is unverified: %s; run 'amq wake recover-owner --me %s'",
+					me,
+					inspection.Reason,
+					me,
+				)
 			}
 			if err := validateGenericWakeLifecycleTransition(inspection, wakeGenericRequestAcquire); err != nil {
 				return err
@@ -215,8 +257,9 @@ func acquireWakeLockWithOptionsInDir(
 					}
 					return wakeLockAlreadyRunningError(me, inspection)
 				case wakeLockUnverified:
-					return fmt.Errorf("wake lock for %s is unverified (pid %d on %s since %s): %s; run 'amq doctor --ops' for details",
-						me, inspection.Lock.PID, inspection.Lock.TTY, inspection.Lock.Started, inspection.Reason)
+					if err := supersedeUnverifiedGenericWakeAt(dirfd, agentDir, inspection); err != nil {
+						return err
+					}
 				}
 			}
 			if replace.Exists {
@@ -708,6 +751,7 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 	var target wakeTarget
 	var repairFloor wakeRepairFloor
 	var lineage wakeRepairLineage
+	var unverifiedSupersession wakeLockInspection
 	var inboxDir *wakeInboxDir
 	defer func() { _ = inboxDir.Close() }()
 	prepareErr := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
@@ -735,10 +779,16 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 			result.Reason = "wake lock is being created; retry shortly"
 			return errors.New(result.Reason)
 		case wakeLockUnverified:
-			result.Status = "refused"
-			result.PID = inspection.PID
-			result.Reason = "wake lock is unverified; refusing to start a second injector"
-			return fmt.Errorf("%s: %s", result.Reason, inspection.Reason)
+			if classifyPersistedWakeClaim(inspection) != wakeClaimGeneric {
+				result.Status = "refused"
+				result.PID = inspection.PID
+				result.Reason = fmt.Sprintf(
+					"unverified wake is not an ownerless generic claim; use 'amq wake recover-owner --me %s' for an owner-bound claim",
+					me,
+				)
+				return errors.New(result.Reason)
+			}
+			unverifiedSupersession = inspection
 		default:
 			result.Status = "refused"
 			result.Reason = fmt.Sprintf("wake lock status %q is not repairable", inspection.Status)
@@ -830,7 +880,17 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 			floor: repairFloor,
 		}
 		result.RepairAvailable = true
-		if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, inspection); err != nil {
+		var removeErr error
+		if unverifiedSupersession.Exists {
+			removeErr = supersedeUnverifiedGenericWakeAt(
+				dirfd,
+				agentDir,
+				unverifiedSupersession,
+			)
+		} else {
+			removeErr = removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, inspection)
+		}
+		if removeErr != nil {
 			result.Status = "refused"
 			result.RepairAvailable = false
 			result.PID = inspectWakeLockAt(dirfd, agentDir, root, me).PID

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,6 +89,21 @@ func writeExecutableForTest(t *testing.T, name string) string {
 		t.Fatalf("write executable: %v", err)
 	}
 	return path
+}
+
+func assertWakeLockOwnedByCurrentProcess(t *testing.T, lockPath string) {
+	t.Helper()
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read replacement lock: %v", err)
+	}
+	var got wakeLock
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal replacement lock: %v", err)
+	}
+	if got.PID != os.Getpid() {
+		t.Fatalf("replacement pid = %d, want %d", got.PID, os.Getpid())
+	}
 }
 
 func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
@@ -1839,7 +1855,7 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsSameTTYDifferentSession(t *test
 	}
 }
 
-func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
+func TestRunWakeWithLoopSupersedesUnverifiedGenericWakeWithoutSignal(t *testing.T) {
 	const wakePID = 4242
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid == wakePID {
@@ -1852,6 +1868,11 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
 		}
 		return wakeProcessInfo{PID: pid}
 	})
+	var signals []os.Signal
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		signals = append(signals, sig)
+		return nil
+	})
 	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "orchestrator", wakeLock{
 		PID:          wakePID,
@@ -1863,24 +1884,82 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsUnverifiedWake(t *testing.T) {
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	injector := writeExecutableForTest(t, "injector")
-	err := runWakeWithLoop([]string{
-		"--root", root,
-		"--me", "orchestrator",
-		"--inject-via", injector,
-		"--ready-file", readyPath,
-		"--accept-existing-wake",
-	}, func(cfg wakeConfig) error {
-		t.Fatalf("loop should not run with an unverified wake lock: %#v", cfg)
-		return nil
+	errDone := errors.New("done")
+	stderr := captureWakeStderr(t, func() {
+		err := runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-via", injector,
+			"--ready-file", readyPath,
+			"--accept-existing-wake",
+		}, func(cfg wakeConfig) error {
+			inspection := inspectWakeLock(root, "orchestrator")
+			if !inspection.Exists || inspection.Lock.PID != os.Getpid() {
+				t.Fatalf("fresh wake was not admitted: %#v", inspection)
+			}
+			return errDone
+		})
+		if !errors.Is(err, errDone) {
+			t.Fatalf("runWakeWithLoop error = %v, want sentinel", err)
+		}
 	})
-	if err == nil {
-		t.Fatal("expected unverified wake lock error")
+	if len(signals) != 0 {
+		t.Fatalf("unverified helper was signaled: %v", signals)
 	}
-	if !strings.Contains(err.Error(), "unverified") {
-		t.Fatalf("unexpected error: %v", err)
+	if count := strings.Count(stderr, "warning:"); count != 1 {
+		t.Fatalf("warning count = %d, want 1:\n%s", count, stderr)
 	}
-	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
-		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	for _, want := range []string{
+		"unidentified wake helper",
+		"pid 4242",
+		"duplicate notifications",
+		"stop that helper if duplicates persist",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("warning missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
+func TestRunWakeWithLoopPreservesUnverifiedMode0400Claim(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatalf("chmod owner-bound claim: %v", err)
+	}
+	before, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read owner-bound claim: %v", err)
+	}
+
+	injector := writeExecutableForTest(t, "injector")
+	stderr := captureWakeStderr(t, func() {
+		err := runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-via", injector,
+		}, func(cfg wakeConfig) error {
+			t.Fatalf("loop should not run for an owner-bound claim: %#v", cfg)
+			return nil
+		})
+		if err == nil ||
+			!strings.Contains(err.Error(), "unverified") ||
+			!strings.Contains(err.Error(), "wake recover-owner") {
+			t.Fatalf("error = %v, want owner-bound refusal", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("owner-bound refusal emitted supersession warning: %q", stderr)
+	}
+	after, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read preserved owner-bound claim: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("owner-bound claim changed: got %q want %q", after, before)
 	}
 }
 
@@ -1939,7 +2018,7 @@ func TestAcquireWakeLockSelfHealsPIDReusedByNonAMQ(t *testing.T) {
 	}
 }
 
-func TestAcquireWakeLockTreatsUnknownBootIdentityAsUnverified(t *testing.T) {
+func TestAcquireWakeLockSupersedesUnknownBootIdentity(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		lock       wakeLock
@@ -1978,15 +2057,11 @@ func TestAcquireWakeLockTreatsUnknownBootIdentityAsUnverified(t *testing.T) {
 			})
 
 			cleanup, err := acquireWakeLock(root, "orchestrator", nil)
-			if cleanup != nil {
-				defer cleanup()
+			if err != nil {
+				t.Fatalf("acquireWakeLock should supersede %s: %v", tc.wantReason, err)
 			}
-			if err == nil || !strings.Contains(err.Error(), tc.wantReason) || !strings.Contains(err.Error(), "unverified") {
-				t.Fatalf("expected identity-mismatch unverified refusal, got %v", err)
-			}
-			if _, statErr := os.Stat(lockPath); statErr != nil {
-				t.Fatalf("identity-mismatch lock should remain, stat=%v", statErr)
-			}
+			defer cleanup()
+			assertWakeLockOwnedByCurrentProcess(t, lockPath)
 		})
 	}
 }
@@ -2031,7 +2106,7 @@ func TestAcquireWakeLockReplacesProvenStartMismatchWhenBootMatches(t *testing.T)
 	}
 }
 
-func TestAcquireWakeLockPreservesStartMismatchWhenBootIsUnknown(t *testing.T) {
+func TestAcquireWakeLockSupersedesStartMismatchWhenBootIsUnknown(t *testing.T) {
 	const reusedPID = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
@@ -2056,18 +2131,14 @@ func TestAcquireWakeLockPreservesStartMismatchWhenBootIsUnknown(t *testing.T) {
 	})
 
 	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
-	if cleanup != nil {
-		defer cleanup()
+	if err != nil {
+		t.Fatalf("acquireWakeLock should supersede unknown boot identity: %v", err)
 	}
-	if err == nil || !strings.Contains(err.Error(), "boot id mismatch") || !strings.Contains(err.Error(), "unverified") {
-		t.Fatalf("expected unknown-boot refusal, got %v", err)
-	}
-	if _, statErr := os.Stat(lockPath); statErr != nil {
-		t.Fatalf("lock should remain when boot identity is unknown, stat=%v", statErr)
-	}
+	defer cleanup()
+	assertWakeLockOwnedByCurrentProcess(t, lockPath)
 }
 
-func TestAcquireWakeLockPreservesStartMismatchWithoutBootIdentity(t *testing.T) {
+func TestAcquireWakeLockSupersedesStartMismatchWithoutBootIdentity(t *testing.T) {
 	const reusedPID = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
@@ -2089,18 +2160,14 @@ func TestAcquireWakeLockPreservesStartMismatchWithoutBootIdentity(t *testing.T) 
 	})
 
 	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
-	if cleanup != nil {
-		defer cleanup()
+	if err != nil {
+		t.Fatalf("acquireWakeLock should supersede missing boot identity: %v", err)
 	}
-	if err == nil || !strings.Contains(err.Error(), "process start time mismatch") || !strings.Contains(err.Error(), "unverified") {
-		t.Fatalf("expected missing-boot refusal, got %v", err)
-	}
-	if _, statErr := os.Stat(lockPath); statErr != nil {
-		t.Fatalf("lock should remain without comparable boot identity, stat=%v", statErr)
-	}
+	defer cleanup()
+	assertWakeLockOwnedByCurrentProcess(t, lockPath)
 }
 
-func TestAcquireWakeLockStartReadFailureIsUnverifiedNotMismatch(t *testing.T) {
+func TestAcquireWakeLockSupersedesStartReadFailure(t *testing.T) {
 	const pid = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
@@ -2121,21 +2188,14 @@ func TestAcquireWakeLockStartReadFailureIsUnverifiedNotMismatch(t *testing.T) {
 	})
 
 	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
-	if cleanup != nil {
-		defer cleanup()
+	if err != nil {
+		t.Fatalf("acquireWakeLock should supersede process inspection failure: %v", err)
 	}
-	if err == nil {
-		t.Fatal("expected unverified lock error")
-	}
-	if !strings.Contains(err.Error(), "unverified") {
-		t.Fatalf("expected unverified error, got %v", err)
-	}
-	if _, statErr := os.Stat(lockPath); statErr != nil {
-		t.Fatalf("unverified lock should remain, stat=%v", statErr)
-	}
+	defer cleanup()
+	assertWakeLockOwnedByCurrentProcess(t, lockPath)
 }
 
-func TestAcquireWakeLockLegacyLiveLockDoesNotAutoDelete(t *testing.T) {
+func TestAcquireWakeLockSupersedesLegacyLiveLock(t *testing.T) {
 	const pid = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "orchestrator", wakeLock{
@@ -2154,18 +2214,11 @@ func TestAcquireWakeLockLegacyLiveLockDoesNotAutoDelete(t *testing.T) {
 	})
 
 	cleanup, err := acquireWakeLock(root, "orchestrator", nil)
-	if cleanup != nil {
-		defer cleanup()
+	if err != nil {
+		t.Fatalf("acquireWakeLock should supersede legacy live lock: %v", err)
 	}
-	if err == nil {
-		t.Fatal("expected legacy unverified lock error")
-	}
-	if !strings.Contains(err.Error(), "unverified") {
-		t.Fatalf("expected unverified error, got %v", err)
-	}
-	if _, statErr := os.Stat(lockPath); statErr != nil {
-		t.Fatalf("legacy unverified lock should remain, stat=%v", statErr)
-	}
+	defer cleanup()
+	assertWakeLockOwnedByCurrentProcess(t, lockPath)
 }
 
 func TestRemoveWakeLockIfUnchangedRefusesChangedLock(t *testing.T) {


### PR DESCRIPTION
## Summary
- admit wake startup when a generic owner lock is unverified but not provably live
- preserve fail-closed behavior for verified live or malformed owner claims
- surface both the inspection cause and recover-owner remediation

## Verification
- exact reviewed diff SHA-256: `1d9b7acce343b63981c83c87a35774a765a50d6a8044ab9eabf1555368e93054`
- `go test ./... -count=1`
- `go vet ./...`
- `GOOS=linux go vet ./...`