### PR TITLE
feat(wake): probe TIOCSTI capability and degrade to a non-input notifier

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -185,6 +185,14 @@ func runDoctor(args []string) error {
 			if a.PresenceSource != "" {
 				line += ", source " + a.PresenceSource
 			}
+			if a.NotifierStatus == wakeInjectorUnsupportedStatus {
+				line += fmt.Sprintf(
+					", ⚠ %s mode=%s reason=%s",
+					a.NotifierStatus,
+					a.NotifierMode,
+					a.NotifierReason,
+				)
+			}
 			if err := writeStdoutLine(line); err != nil {
 				return err
 			}

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -36,6 +36,9 @@ type opsAgent struct {
 	PresenceStatus         string  `json:"presence_status"`
 	PresenceAgeSeconds     float64 `json:"presence_age_seconds"`
 	PresenceSource         string  `json:"presence_source,omitempty"`
+	NotifierStatus         string  `json:"notifier_status,omitempty"`
+	NotifierMode           string  `json:"notifier_mode,omitempty"`
+	NotifierReason         string  `json:"notifier_reason,omitempty"`
 }
 
 type opsOperatorGate struct {
@@ -148,6 +151,9 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 		p, err := presence.Read(root, handle)
 		if err == nil {
 			agent.PresenceStatus = p.Status
+			agent.NotifierStatus = p.NotifierStatus
+			agent.NotifierMode = p.NotifierMode
+			agent.NotifierReason = p.NotifierReason
 			if t, err := time.Parse(time.RFC3339Nano, p.LastSeen); err == nil {
 				agent.PresenceAgeSeconds = now.Sub(t).Seconds()
 				recentActivity = agent.PresenceAgeSeconds < (10 * time.Minute).Seconds()

--- a/internal/cli/presence_source_test.go
+++ b/internal/cli/presence_source_test.go
@@ -129,6 +129,97 @@ func TestDoctorOpsDistinguishesNotifierLiveFromRecentActivity(t *testing.T) {
 	}
 }
 
+func TestDoctorOpsReportsLiveUnsupportedInjectorAsDegraded(t *testing.T) {
+	root := setupPresenceSourceFixture(t)
+	p, err := presence.Read(root, "notifier")
+	if err != nil {
+		t.Fatalf("read notifier presence: %v", err)
+	}
+	p.NotifierStatus = wakeInjectorUnsupportedStatus
+	p.NotifierMode = wakeInjectModeRaw
+	p.NotifierReason = tiocstiLegacySysctlPath + " is 0; use --inject-via"
+	if err := presence.Write(root, p); err != nil {
+		t.Fatalf("write notifier presence: %v", err)
+	}
+
+	result := runOpsChecks(root, "test", false)
+	var got opsAgent
+	for _, agent := range result.Agents {
+		if agent.Handle == "notifier" {
+			got = agent
+			break
+		}
+	}
+	if got.PresenceSource != presenceSourceNotifierLive {
+		t.Fatalf("presence source = %q, want live notifier", got.PresenceSource)
+	}
+	if got.NotifierStatus != wakeInjectorUnsupportedStatus ||
+		got.NotifierMode != wakeInjectModeRaw ||
+		!strings.Contains(got.NotifierReason, tiocstiLegacySysctlPath) {
+		t.Fatalf("ops agent = %#v", got)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal ops result: %v", err)
+	}
+	for _, want := range []string{
+		`"presence_source":"notifier_live"`,
+		`"notifier_status":"injector_unsupported"`,
+		tiocstiLegacySysctlPath,
+		"--inject-via",
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("doctor JSON missing %q: %s", want, data)
+		}
+	}
+
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", "")
+	t.Setenv("AM_SESSION", "")
+	text, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--ops"})
+	})
+	if err != nil {
+		t.Fatalf("runDoctor text: %v", err)
+	}
+	line := lineWithPrefix(text, "  notifier:")
+	for _, want := range []string{
+		"⚠ injector_unsupported",
+		tiocstiLegacySysctlPath,
+		"--inject-via",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("doctor line missing %q: %q\n%s", want, line, text)
+		}
+	}
+
+	whoJSON, err := captureEnvStdout(t, func() error {
+		return runWho([]string{"--root", root, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runWho json: %v", err)
+	}
+	for _, want := range []string{
+		`"presence_source": "notifier_live"`,
+		`"notifier_status": "injector_unsupported"`,
+		tiocstiLegacySysctlPath,
+	} {
+		if !strings.Contains(whoJSON, want) {
+			t.Fatalf("who JSON missing %q: %s", want, whoJSON)
+		}
+	}
+	whoText, err := captureEnvStdout(t, func() error {
+		return runWho([]string{"--root", root})
+	})
+	if err != nil {
+		t.Fatalf("runWho text: %v", err)
+	}
+	if line := lineWithPrefix(whoText, "    notifier  "); !strings.Contains(line, "injector_unsupported") {
+		t.Fatalf("who text hides degraded notifier: %q\n%s", line, whoText)
+	}
+}
+
 func lineWithPrefix(text, prefix string) string {
 	for _, line := range strings.Split(text, "\n") {
 		if strings.HasPrefix(line, prefix) {

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -16,44 +16,45 @@ import (
 )
 
 type wakeConfig struct {
-	me                  string
-	root                string
-	session             string
-	injectCmd           string
-	injectVia           string // external command for injection (replaces TIOCSTI)
-	injectArgs          []string
-	wakeOwner           *wakeOwner
-	injectTimeout       time.Duration
-	bell                bool
-	debounce            time.Duration
-	previewLen          int
-	strict              bool
-	fallbackWarn        bool
-	injectMode          string // auto, raw, paste
-	debug               bool
-	deferWhileInput     bool
-	inputQuietFor       time.Duration
-	inputPollInterval   time.Duration
-	inputMaxHold        time.Duration
-	interrupt           bool
-	interruptLabel      string
-	interruptPriority   string
-	interruptKey        string
-	interruptNotice     string
-	interruptCooldown   time.Duration
-	lastInterrupt       time.Time
-	controlStop         <-chan struct{}
-	beforeTerminalWrite func() error
-	terminalWrite       func(string) error
-	terminalGeneration  string
-	terminalTTY         string
-	baselineRequested   bool
-	baselineInherited   bool
-	baselineExisting    map[string]wakeFileIdentity
-	onBaselineReady     func(map[string]wakeFileIdentity) error
-	onPrepared          func(wakeAdmissionWatcher) error
-	retainedInbox       wakeInboxReader
-	touchPresence       func() error
+	me                   string
+	root                 string
+	session              string
+	injectCmd            string
+	injectVia            string // external command for injection (replaces TIOCSTI)
+	injectArgs           []string
+	wakeOwner            *wakeOwner
+	injectTimeout        time.Duration
+	bell                 bool
+	debounce             time.Duration
+	previewLen           int
+	strict               bool
+	fallbackWarn         bool
+	injectMode           string // auto, raw, paste
+	debug                bool
+	deferWhileInput      bool
+	inputQuietFor        time.Duration
+	inputPollInterval    time.Duration
+	inputMaxHold         time.Duration
+	interrupt            bool
+	interruptLabel       string
+	interruptPriority    string
+	interruptKey         string
+	interruptNotice      string
+	interruptCooldown    time.Duration
+	lastInterrupt        time.Time
+	controlStop          <-chan struct{}
+	beforeTerminalWrite  func() error
+	terminalWrite        func(string) error
+	terminalGeneration   string
+	terminalTTY          string
+	baselineRequested    bool
+	baselineInherited    bool
+	baselineExisting     map[string]wakeFileIdentity
+	onBaselineReady      func(map[string]wakeFileIdentity) error
+	onPrepared           func(wakeAdmissionWatcher) error
+	retainedInbox        wakeInboxReader
+	touchPresence        func() error
+	recordNotifierStatus func(status, mode, reason string) error
 }
 
 type wakeAdmissionWatcher interface {
@@ -540,6 +541,25 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	}
 
 	if injectErr != nil {
+		var unsupported *wakeInjectorUnsupportedError
+		if errors.As(injectErr, &unsupported) {
+			mode := effectiveInjectMode(cfg)
+			reason := wakeInjectorUnsupportedReason(mode, injectErr)
+			if cfg.recordNotifierStatus != nil {
+				if err := cfg.recordNotifierStatus(
+					wakeInjectorUnsupportedStatus,
+					mode,
+					reason,
+				); err != nil {
+					_ = writeStderr("amq wake: record unsupported injector status: %v\n", err)
+				}
+			}
+			cfg.injectMode = wakeInjectModeNone
+			_ = writeStderr("amq wake: warning: %s\n", reason)
+			cfg.fallbackWarn = false
+			_, _ = fmt.Fprint(os.Stderr, plainText+"\n")
+			return nil
+		}
 		var authorityErr *wakeTerminalAuthorityError
 		if errors.As(injectErr, &authorityErr) {
 			return injectErr
@@ -622,6 +642,10 @@ func writeTerminalChunk(cfg *wakeConfig, chunk string) (bool, error) {
 		if err := cfg.terminalWrite(chunk); err != nil {
 			if isWakeTerminalControlStopped(err) {
 				return false, nil
+			}
+			var unsupported *wakeInjectorUnsupportedError
+			if errors.As(err, &unsupported) {
+				return true, err
 			}
 			return true, &wakeTerminalAuthorityError{err: err}
 		}

--- a/internal/cli/wake_injector_status.go
+++ b/internal/cli/wake_injector_status.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"fmt"
+)
+
+const (
+	wakeInjectorUnsupportedStatus = "injector_unsupported"
+	tiocstiLegacySysctlPath       = "/proc/sys/dev/tty/legacy_tiocsti"
+)
+
+type wakeInjectorUnsupportedError struct {
+	err error
+}
+
+func (err *wakeInjectorUnsupportedError) Error() string {
+	return fmt.Sprintf("TIOCSTI injector unsupported: %v", err.err)
+}
+
+func (err *wakeInjectorUnsupportedError) Unwrap() error {
+	return err.err
+}
+
+func newWakeInjectorUnsupportedError(err error) error {
+	return &wakeInjectorUnsupportedError{err: err}
+}
+
+func wakeInjectorUnsupportedReason(mode string, err error) string {
+	return fmt.Sprintf(
+		"TIOCSTI injection mode %s is unsupported (%v); on Linux check %s; use --inject-via for synthetic input or --inject-mode none for a non-input notifier",
+		mode,
+		err,
+		tiocstiLegacySysctlPath,
+	)
+}

--- a/internal/cli/wake_terminal_authority_unix.go
+++ b/internal/cli/wake_terminal_authority_unix.go
@@ -184,6 +184,19 @@ func (authority *wakeTerminalAuthority) Inject(text string) error {
 		return err
 	}
 	if err := injectWakeTerminalFD(authority.fd, text); err != nil {
+		var injectionErr *tiocstiInjectionError
+		if errors.As(err, &injectionErr) &&
+			injectionErr.Progress == 0 &&
+			(errors.Is(err, syscall.EIO) || errors.Is(err, syscall.EPERM)) {
+			// EIO and EPERM are ambiguous: the kernel may reject TIOCSTI, or
+			// the terminal authority may have changed. Only classify the
+			// injector after every retained/current identity and PGRP check
+			// still passes after the failed zero-progress ioctl.
+			if validateErr := authority.validateLocked(); validateErr != nil {
+				return validateErr
+			}
+			return newWakeInjectorUnsupportedError(err)
+		}
 		return newWakeTerminalAuthorityLoss("inject through retained controlling terminal", err)
 	}
 	return nil

--- a/internal/cli/wake_terminal_authority_unix_test.go
+++ b/internal/cli/wake_terminal_authority_unix_test.go
@@ -61,6 +61,77 @@ func TestWakeTerminalAuthorityInjectsThroughRetainedFD(t *testing.T) {
 	}
 }
 
+func TestWakeTerminalAuthorityClassifiesUnsupportedOnlyAfterZeroProgressAndRevalidation(t *testing.T) {
+	for _, errno := range []error{syscall.EIO, syscall.EPERM} {
+		t.Run(errno.Error(), func(t *testing.T) {
+			fixture := installWakeTerminalAuthorityFixture(t)
+			authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+			if err != nil {
+				t.Fatalf("bindWakeTerminalAuthority: %v", err)
+			}
+			t.Cleanup(func() { _ = authority.Close() })
+
+			injectWakeTerminalFD = func(uintptr, string) error {
+				return &tiocstiInjectionError{Err: errno, Progress: 0}
+			}
+			err = authority.Inject("doorbell")
+			var unsupported *wakeInjectorUnsupportedError
+			if !errors.As(err, &unsupported) {
+				t.Fatalf("Inject error = %T %v, want injector unsupported", err, err)
+			}
+			if !errors.Is(err, errno) {
+				t.Fatalf("Inject error = %v, want wrapped %v", err, errno)
+			}
+		})
+	}
+}
+
+func TestWakeTerminalAuthorityEIOWithInvalidCurrentKeepsAuthorityOutcome(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+	if err != nil {
+		t.Fatalf("bindWakeTerminalAuthority: %v", err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+
+	injectWakeTerminalFD = func(uintptr, string) error {
+		fixture.current = wakeLockInspection{}
+		return &tiocstiInjectionError{Err: syscall.EIO, Progress: 0}
+	}
+	err = authority.Inject("doorbell")
+	var unsupported *wakeInjectorUnsupportedError
+	if errors.As(err, &unsupported) {
+		t.Fatalf("invalid current misclassified as injector unsupported: %v", err)
+	}
+	var authorityLoss *wakeTerminalAuthorityLossError
+	if !errors.As(err, &authorityLoss) ||
+		!strings.Contains(err.Error(), "generation changed") {
+		t.Fatalf("Inject error = %T %v, want generation authority loss", err, err)
+	}
+}
+
+func TestWakeTerminalAuthorityEIOAfterPartialProgressIsUncertain(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+	if err != nil {
+		t.Fatalf("bindWakeTerminalAuthority: %v", err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+
+	injectWakeTerminalFD = func(uintptr, string) error {
+		return &tiocstiInjectionError{Err: syscall.EIO, Progress: 1}
+	}
+	err = authority.Inject("doorbell")
+	var unsupported *wakeInjectorUnsupportedError
+	if errors.As(err, &unsupported) {
+		t.Fatalf("partial progress misclassified as injector unsupported: %v", err)
+	}
+	var authorityLoss *wakeTerminalAuthorityLossError
+	if !errors.As(err, &authorityLoss) {
+		t.Fatalf("Inject error = %T %v, want uncertain authority outcome", err, err)
+	}
+}
+
 func TestWakeTerminalAuthorityAllowsSameTerminalCTimeMutation(t *testing.T) {
 	fixture := installWakeTerminalAuthorityFixture(t)
 	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -558,6 +559,67 @@ func TestInjectNotificationRawInjectsLFPreludeForCodex(t *testing.T) {
 	}
 	if len(*slept) != 2 {
 		t.Fatalf("settle sleeps = %v, want two settle delays", *slept)
+	}
+}
+
+func TestInjectNotificationUnsupportedDegradesOnceAndPersistsReason(t *testing.T) {
+	writes := 0
+	var statuses []struct {
+		status string
+		mode   string
+		reason string
+	}
+	cfg := &wakeConfig{
+		injectMode:   wakeInjectModeRaw,
+		fallbackWarn: true,
+		terminalWrite: func(string) error {
+			writes++
+			return newWakeInjectorUnsupportedError(syscall.EIO)
+		},
+		recordNotifierStatus: func(status, mode, reason string) error {
+			statuses = append(statuses, struct {
+				status string
+				mode   string
+				reason string
+			}{status: status, mode: mode, reason: reason})
+			return nil
+		},
+	}
+
+	first := captureWakeStderr(t, func() {
+		if err := injectNotification(cfg, "first doorbell", true); err != nil {
+			t.Fatalf("first injectNotification: %v", err)
+		}
+	})
+	if cfg.injectMode != wakeInjectModeNone {
+		t.Fatalf("inject mode = %q, want degraded non-input", cfg.injectMode)
+	}
+	if writes != 1 {
+		t.Fatalf("terminal writes = %d, want 1", writes)
+	}
+	if len(statuses) != 1 ||
+		statuses[0].status != wakeInjectorUnsupportedStatus ||
+		statuses[0].mode != wakeInjectModeRaw ||
+		!strings.Contains(statuses[0].reason, "--inject-via") {
+		t.Fatalf("recorded statuses = %#v", statuses)
+	}
+	if count := strings.Count(first, "warning:"); count != 1 {
+		t.Fatalf("first warning count = %d, want 1:\n%s", count, first)
+	}
+	if !strings.Contains(first, "first doorbell") {
+		t.Fatalf("first fallback missing doorbell:\n%s", first)
+	}
+
+	second := captureWakeStderr(t, func() {
+		if err := injectNotification(cfg, "second doorbell", true); err != nil {
+			t.Fatalf("second injectNotification: %v", err)
+		}
+	})
+	if writes != 1 {
+		t.Fatalf("degraded notifier retried terminal injection: writes=%d", writes)
+	}
+	if strings.Contains(second, "warning:") || !strings.Contains(second, "second doorbell") {
+		t.Fatalf("second non-input output = %q", second)
 	}
 }
 

--- a/internal/cli/wake_tiocsti_unix.go
+++ b/internal/cli/wake_tiocsti_unix.go
@@ -4,6 +4,8 @@ package cli
 
 import (
 	"os"
+	"runtime"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -18,6 +20,31 @@ var tiocsti = tiocstiFuncs{
 
 type tiocstiFuncs struct {
 	available bool
+}
+
+var readTIOCSTILegacySysctl = func() ([]byte, error) {
+	if runtime.GOOS != "linux" {
+		return nil, os.ErrNotExist
+	}
+	return os.ReadFile(tiocstiLegacySysctlPath)
+}
+
+type tiocstiInjectionError struct {
+	Err      error
+	Progress int
+}
+
+func (err *tiocstiInjectionError) Error() string {
+	return err.Err.Error()
+}
+
+func (err *tiocstiInjectionError) Unwrap() error {
+	return err.Err
+}
+
+func tiocstiLegacyDisabledHint() bool {
+	data, err := readTIOCSTILegacySysctl()
+	return err == nil && strings.TrimSpace(string(data)) == "0"
 }
 
 // Available returns true if TIOCSTI is supported on this platform.
@@ -47,9 +74,9 @@ func (t tiocstiFuncs) Inject(text string) error {
 // descriptor. Callers own the descriptor and its lifecycle.
 func (t tiocstiFuncs) InjectFD(fd uintptr, text string) error {
 	// Inject each character using TIOCSTI
-	for _, ch := range []byte(text) {
+	for progress, ch := range []byte(text) {
 		if err := ioctlTIOCSTI(fd, ch); err != nil {
-			return err
+			return &tiocstiInjectionError{Err: err, Progress: progress}
 		}
 	}
 

--- a/internal/cli/wake_tiocsti_unix_test.go
+++ b/internal/cli/wake_tiocsti_unix_test.go
@@ -1,0 +1,39 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTIOCSTILegacySysctlHintOnlyTreatsReadableZeroAsUnsupported(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		err      error
+		disabled bool
+	}{
+		{name: "zero", data: []byte("0\n"), disabled: true},
+		{name: "one", data: []byte("1\n")},
+		{name: "other", data: []byte("disabled\n")},
+		{name: "absent", err: errors.New("not found")},
+		{name: "unreadable", err: errors.New("permission denied")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oldRead := readTIOCSTILegacySysctl
+			readTIOCSTILegacySysctl = func() ([]byte, error) {
+				return test.data, test.err
+			}
+			t.Cleanup(func() {
+				readTIOCSTILegacySysctl = oldRead
+			})
+
+			if got := tiocstiLegacyDisabledHint(); got != test.disabled {
+				t.Fatalf("tiocstiLegacyDisabledHint() = %v, want %v", got, test.disabled)
+			}
+		})
+	}
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1514,14 +1514,29 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		defer func() { _ = ownerObservation.Close() }()
 	}
 
-	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead)
+	var initialNotifierStatus string
+	var initialNotifierMode string
+	var initialNotifierReason string
+
+	// Verify TIOCSTI is available (skip in inject-via mode — uses external command instead).
+	// Linux's legacy_tiocsti sysctl is advisory: a readable zero degrades this
+	// wake to a useful non-input notifier, while absence, read errors, and every
+	// other value remain unknown and do not block startup.
 	if injectVia == "" && injectMode != wakeInjectModeNone {
 		if !wakeTIOCSTIAvailable() {
 			return errors.New("TIOCSTI not available on this platform; use tmux send-keys or terminal-specific injection")
 		}
 
-		// Verify we have a real TTY
-		if !wakeInputIsTTY() {
+		if tiocstiLegacyDisabledHint() {
+			initialNotifierStatus = wakeInjectorUnsupportedStatus
+			initialNotifierMode = effectiveInjectMode(&wakeConfig{me: me, injectMode: injectMode})
+			initialNotifierReason = wakeInjectorUnsupportedReason(
+				initialNotifierMode,
+				fmt.Errorf("%s is 0", tiocstiLegacySysctlPath),
+			)
+			injectMode = wakeInjectModeNone
+		} else if !wakeInputIsTTY() {
+			// Verify we have a real TTY when synthetic input remains enabled.
 			return errors.New("amq wake requires a real terminal (run in foreground or as background job in same terminal, or use --inject-via for external injection)")
 		}
 	}
@@ -1770,6 +1785,18 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	} else {
 		currentWake = inspectWakeLock(root, me)
 	}
+	if err := presence.SetNotifierStatus(
+		root,
+		me,
+		initialNotifierStatus,
+		initialNotifierMode,
+		initialNotifierReason,
+	); err != nil {
+		return fmt.Errorf("record wake notifier status: %w", err)
+	}
+	if initialNotifierStatus == wakeInjectorUnsupportedStatus {
+		_ = writeStderr("amq wake: warning: %s\n", initialNotifierReason)
+	}
 	var terminalAuthority *wakeTerminalAuthority
 	effectiveMode := effectiveInjectMode(&wakeConfig{me: me, injectMode: injectMode})
 	if requestedOwner != nil &&
@@ -1812,6 +1839,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		terminalTTY:        currentWake.Lock.TTY,
 		baselineRequested:  *baselineExistingFlag || repairLineage != nil,
 		baselineInherited:  repairLineage != nil,
+		recordNotifierStatus: func(status, mode, reason string) error {
+			return presence.SetNotifierStatus(root, me, status, mode, reason)
+		},
 		onPrepared: func(watcher wakeAdmissionWatcher) error {
 			if repairLineage != nil {
 				if err := writeWakePreparedFileInDir(

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/presence"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -107,6 +108,16 @@ func assertWakeLockOwnedByCurrentProcess(t *testing.T, lockPath string) {
 }
 
 func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
+	oldRead := readTIOCSTILegacySysctl
+	sysctlReads := 0
+	readTIOCSTILegacySysctl = func() ([]byte, error) {
+		sysctlReads++
+		return []byte("0\n"), nil
+	}
+	t.Cleanup(func() {
+		readTIOCSTILegacySysctl = oldRead
+	})
+
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
@@ -140,6 +151,124 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 	}
 	if got.injectTimeout != 250*time.Millisecond {
 		t.Fatalf("expected inject timeout 250ms, got %s", got.injectTimeout)
+	}
+	if sysctlReads != 0 {
+		t.Fatalf("--inject-via read TIOCSTI sysctl %d times, want 0", sysctlReads)
+	}
+}
+
+func TestRunWakeWithLoopReadableDisabledTIOCSTIDegradesToNonInput(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	oldRead := readTIOCSTILegacySysctl
+	oldTTY := wakeInputIsTTY
+	readTIOCSTILegacySysctl = func() ([]byte, error) {
+		return []byte("0\n"), nil
+	}
+	ttyChecks := 0
+	wakeInputIsTTY = func() bool {
+		ttyChecks++
+		return false
+	}
+	t.Cleanup(func() {
+		readTIOCSTILegacySysctl = oldRead
+		wakeInputIsTTY = oldTTY
+	})
+
+	errDone := errors.New("done")
+	stderr := captureWakeStderr(t, func() {
+		err := runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-mode", "raw",
+		}, func(cfg wakeConfig) error {
+			if cfg.injectMode != wakeInjectModeNone {
+				t.Fatalf("inject mode = %q, want non-input", cfg.injectMode)
+			}
+			p, err := presence.Read(root, "orchestrator")
+			if err != nil {
+				t.Fatalf("read durable notifier status: %v", err)
+			}
+			if p.NotifierStatus != wakeInjectorUnsupportedStatus ||
+				p.NotifierMode != wakeInjectModeRaw ||
+				!strings.Contains(p.NotifierReason, tiocstiLegacySysctlPath) {
+				t.Fatalf("durable notifier status = %#v", p)
+			}
+			return errDone
+		})
+		if !errors.Is(err, errDone) {
+			t.Fatalf("runWakeWithLoop error = %v, want sentinel", err)
+		}
+	})
+	if ttyChecks != 0 {
+		t.Fatalf("TTY checks = %d, want 0 after advisory downgrade", ttyChecks)
+	}
+	if count := strings.Count(stderr, "warning:"); count != 1 {
+		t.Fatalf("warning count = %d, want 1:\n%s", count, stderr)
+	}
+	for _, want := range []string{
+		tiocstiLegacySysctlPath,
+		"--inject-via",
+		"non-input",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("warning missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
+func TestRunWakeWithLoopUnknownTIOCSTIHintDoesNotChangeMode(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		err  error
+	}{
+		{name: "absent", err: os.ErrNotExist},
+		{name: "unreadable", err: os.ErrPermission},
+		{name: "enabled", data: []byte("1\n")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatalf("EnsureRootDirs: %v", err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+
+			oldRead := readTIOCSTILegacySysctl
+			oldTTY := wakeInputIsTTY
+			readTIOCSTILegacySysctl = func() ([]byte, error) {
+				return test.data, test.err
+			}
+			wakeInputIsTTY = func() bool { return true }
+			t.Cleanup(func() {
+				readTIOCSTILegacySysctl = oldRead
+				wakeInputIsTTY = oldTTY
+			})
+
+			errDone := errors.New("done")
+			err := runWakeWithLoop([]string{
+				"--root", root,
+				"--me", "orchestrator",
+				"--inject-mode", "raw",
+			}, func(cfg wakeConfig) error {
+				if cfg.injectMode != wakeInjectModeRaw {
+					t.Fatalf("inject mode = %q, want raw", cfg.injectMode)
+				}
+				return errDone
+			})
+			if !errors.Is(err, errDone) {
+				t.Fatalf("runWakeWithLoop error = %v, want sentinel", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -63,11 +63,14 @@ func stubWakeTTYSupport(t *testing.T) {
 	t.Helper()
 	oldAvailable := wakeTIOCSTIAvailable
 	oldIsTTY := wakeInputIsTTY
+	oldRead := readTIOCSTILegacySysctl
 	wakeTIOCSTIAvailable = func() bool { return true }
 	wakeInputIsTTY = func() bool { return true }
+	readTIOCSTILegacySysctl = func() ([]byte, error) { return nil, os.ErrNotExist }
 	t.Cleanup(func() {
 		wakeTIOCSTIAvailable = oldAvailable
 		wakeInputIsTTY = oldIsTTY
+		readTIOCSTILegacySysctl = oldRead
 	})
 }
 
@@ -732,6 +735,54 @@ func TestRunWakeWithLoopPersistsEffectiveAutoMode(t *testing.T) {
 				t.Fatalf("expected loop sentinel error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestRunWakeWithLoopDisabledTIOCSTIPersistsEffectiveAutoModeNone(t *testing.T) {
+	stubWakeTTYSupport(t)
+	readTIOCSTILegacySysctl = func() ([]byte, error) {
+		return []byte("0\n"), nil
+	}
+
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "claude"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "claude",
+		"--inject-mode", "auto",
+	}, func(cfg wakeConfig) error {
+		lockPath := filepath.Join(fsq.AgentBase(root, "claude"), ".wake.lock")
+		data, readErr := os.ReadFile(lockPath)
+		if readErr != nil {
+			t.Fatalf("read wake lock: %v", readErr)
+		}
+		var lock wakeLock
+		if unmarshalErr := json.Unmarshal(data, &lock); unmarshalErr != nil {
+			t.Fatalf("unmarshal wake lock: %v", unmarshalErr)
+		}
+		if lock.WakeMode != wakeInjectModeNone {
+			t.Fatalf("WakeMode = %q, want none", lock.WakeMode)
+		}
+		p, readErr := presence.Read(root, "claude")
+		if readErr != nil {
+			t.Fatalf("read durable notifier status: %v", readErr)
+		}
+		if p.NotifierStatus != wakeInjectorUnsupportedStatus ||
+			p.NotifierMode != wakeInjectModeRaw ||
+			!strings.Contains(p.NotifierReason, tiocstiLegacySysctlPath) {
+			t.Fatalf("durable notifier status = %#v", p)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
 	}
 }
 

--- a/internal/cli/who.go
+++ b/internal/cli/who.go
@@ -49,6 +49,9 @@ func runWho(args []string) error {
 		PresenceApplicable bool   `json:"presence_applicable"`
 		Active             bool   `json:"active"`
 		PresenceSource     string `json:"presence_source,omitempty"`
+		NotifierStatus     string `json:"notifier_status,omitempty"`
+		NotifierMode       string `json:"notifier_mode,omitempty"`
+		NotifierReason     string `json:"notifier_reason,omitempty"`
 		Note               string `json:"note,omitempty"`
 	}
 	type sessionInfo struct {
@@ -103,6 +106,9 @@ func runWho(args []string) error {
 					recentActivity = time.Since(t) < 10*time.Minute
 				}
 				ai.Note = p.Note
+				ai.NotifierStatus = p.NotifierStatus
+				ai.NotifierMode = p.NotifierMode
+				ai.NotifierReason = p.NotifierReason
 			}
 			ai.PresenceSource = resolvePresenceSource(sessDir, ae.Name(), recentActivity)
 			ai.Active = recentActivity || ai.PresenceSource == presenceSourceNotifierLive
@@ -152,6 +158,9 @@ func runWho(args []string) error {
 				status = "active"
 				if a.PresenceSource != "" {
 					status += " (" + a.PresenceSource + ")"
+				}
+				if a.NotifierStatus == wakeInjectorUnsupportedStatus {
+					status += "; " + a.NotifierStatus
 				}
 			}
 			note := ""

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -11,11 +11,14 @@ import (
 
 // Presence captures the current presence for an agent handle.
 type Presence struct {
-	Schema   int    `json:"schema"`
-	Handle   string `json:"handle"`
-	Status   string `json:"status"`
-	LastSeen string `json:"last_seen"`
-	Note     string `json:"note,omitempty"`
+	Schema         int    `json:"schema"`
+	Handle         string `json:"handle"`
+	Status         string `json:"status"`
+	LastSeen       string `json:"last_seen"`
+	Note           string `json:"note,omitempty"`
+	NotifierStatus string `json:"notifier_status,omitempty"`
+	NotifierMode   string `json:"notifier_mode,omitempty"`
+	NotifierReason string `json:"notifier_reason,omitempty"`
 }
 
 func New(handle, status, note string, now time.Time) Presence {
@@ -67,6 +70,24 @@ func Touch(root, handle string) error {
 	} else {
 		p.LastSeen = time.Now().UTC().Format(time.RFC3339Nano)
 	}
+	return Write(root, p)
+}
+
+// SetNotifierStatus records notifier capability without overwriting the
+// agent's own presence status or note. Empty values clear a stale notifier
+// diagnosis when a later wake starts with a usable injector.
+func SetNotifierStatus(root, handle, status, mode, reason string) error {
+	p, err := Read(root, handle)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		p = New(handle, "active", "", time.Now())
+	}
+	p.NotifierStatus = status
+	p.NotifierMode = mode
+	p.NotifierReason = reason
+	p.LastSeen = time.Now().UTC().Format(time.RFC3339Nano)
 	return Write(root, p)
 }
 

--- a/internal/presence/presence_test.go
+++ b/internal/presence/presence_test.go
@@ -1,6 +1,7 @@
 package presence
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -61,5 +62,37 @@ func TestTouchPreservesExisting(t *testing.T) {
 	}
 	if time.Since(ts) > 5*time.Second {
 		t.Fatalf("LastSeen not updated: %s", got.LastSeen)
+	}
+}
+
+func TestSetNotifierStatusPreservesAgentPresenceAndTouchPreservesNotifierStatus(t *testing.T) {
+	root := t.TempDir()
+	p := New("codex", "busy", "reviewing", time.Now().Add(-time.Hour))
+	if err := Write(root, p); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := SetNotifierStatus(
+		root,
+		"codex",
+		"injector_unsupported",
+		"raw",
+		"dev.tty.legacy_tiocsti=0; use --inject-via",
+	); err != nil {
+		t.Fatalf("SetNotifierStatus: %v", err)
+	}
+	if err := Touch(root, "codex"); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+	got, err := Read(root, "codex")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Status != "busy" || got.Note != "reviewing" {
+		t.Fatalf("agent presence was clobbered: %#v", got)
+	}
+	if got.NotifierStatus != "injector_unsupported" ||
+		got.NotifierMode != "raw" ||
+		!strings.Contains(got.NotifierReason, "--inject-via") {
+		t.Fatalf("notifier status was not preserved: %#v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- probe Linux legacy TIOCSTI capability and degrade safely when disabled
- classify runtime EIO/EPERM as unsupported only after zero progress and renewed terminal-authority validation
- persist notifier capability diagnostics for doctor and who without changing user presence

## Verification
- independently reviewed rebased commit: 671b4598d5d405677a01706d62eda620b000110a
- parent: d1779485f982c73f257ce6db2372e242ef909fcb
- diff SHA-256: 9f35693995257f92408d4ac71efc28a5c3f8f522ffcb8e61e09a8d7b66561af8
- go test ./... -count=1
- go vet ./...
- GOOS=linux go vet ./...
- GOOS=windows go vet ./...