### PR TITLE
fix(doctor): report and repair malformed mailbox layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ amq integration symphony init [--workflow <path>] --me <agent> [--root <path>] [
 amq integration symphony emit --event <after_create|before_run|after_run|before_remove> --me <agent> [--root <path>] [--workspace <path>] [--identifier <key>] [--json]
 amq integration kanban bridge --me <agent> [--root <path>] [--url <ws://...>] [--workspace-id <id>] [--reconnect <duration>] [--json]
 amq who [--json]
-amq doctor [--ops] [--fix-wake-locks] [--json]
+amq doctor [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json]
 ```
 
 Common flags: `--root`, `--json`, `--strict` (error instead of warn on unknown handles or unreadable/corrupt config). Global option: `--no-update-check`. Note: `init` has its own flags and doesn't accept these.
@@ -341,6 +341,13 @@ Use `--force` with retry to override the max retry limit.
 ## Doctor / Ops
 
 `amq doctor` verifies installation, root configuration, permissions, config, and skill setup.
+
+`amq doctor --fix-mailboxes` repairs the base mailbox layout without requiring
+`--ops`: it creates only missing required directories for agents listed in
+`config.json`. Filesystem-discovered mailboxes that are not configured are
+reported but are never repair eligible. Repair never edits, moves, overwrites,
+or deletes existing message files; symlinks, non-directories, unreadable paths,
+and concurrent layout changes fail closed.
 
 `amq doctor --ops` adds runtime checks:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,9 @@ Use `--force` with retry to override the max retry limit.
 `config.json`. Filesystem-discovered mailboxes that are not configured are
 reported but are never repair eligible. Repair never edits, moves, overwrites,
 or deletes existing message files; symlinks, non-directories, unreadable paths,
-and concurrent layout changes fail closed.
+and concurrent layout changes fail closed. Inspection remains available when
+the target differs from the active session pin (reported separately as a
+warning); repair requires the target to match any populated session pin.
 
 `amq doctor --ops` adds runtime checks:
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -384,11 +384,32 @@ func checkConfig(root string) doctorCheck {
 
 func inspectDoctorMailboxes(root string, repair bool) ([]fsq.MailboxInspection, *fsq.MailboxRepairResult, doctorCheck) {
 	check := doctorCheck{Name: "Mailboxes"}
-	identity, err := snapshotMailboxDeliveryRoot(root, false, false)
+	identity, err := fsq.SnapshotDeliveryRoot(root)
 	if err != nil {
 		check.Status = "error"
 		check.Message = err.Error()
 		return nil, nil, check
+	}
+	if repair {
+		mismatch, pinErr := sessionPinMismatch(root)
+		if pinErr != nil {
+			check.Status = "error"
+			check.Message = fmt.Sprintf(
+				"refusing to repair %s: invalid AMQ session context: %v; re-run with a complete session context",
+				root,
+				pinErr,
+			)
+			return nil, nil, check
+		}
+		if mismatch != nil {
+			check.Status = "error"
+			check.Message = fmt.Sprintf(
+				"refusing to repair %s because it does not match the pinned session context: %s; re-run from the intended session",
+				root,
+				mismatch.Message,
+			)
+			return nil, nil, check
+		}
 	}
 	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
 	if err != nil {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -18,6 +19,8 @@ type doctorCheck struct {
 
 type doctorResult struct {
 	Checks               []doctorCheck               `json:"checks"`
+	Mailboxes            []fsq.MailboxInspection     `json:"mailboxes,omitempty"`
+	MailboxRepair        *fsq.MailboxRepairResult    `json:"mailbox_repair,omitempty"`
 	ExtensionManifests   []doctorExtensionManifest   `json:"extension_manifests,omitempty"`
 	ExtensionDiagnostics []doctorExtensionDiagnostic `json:"extension_diagnostics,omitempty"`
 	Summary              struct {
@@ -33,6 +36,7 @@ func runDoctor(args []string) error {
 	jsonFlag := fs.Bool("json", false, "Output as JSON")
 	opsFlag := fs.Bool("ops", false, "Include runtime operational checks")
 	fixWakeLocksFlag := fs.Bool("fix-wake-locks", false, "With --ops, remove stale wake lock files")
+	fixMailboxesFlag := fs.Bool("fix-mailboxes", false, "Create missing required directories for configured mailboxes")
 
 	usage := usageWithFlags(fs, "amq doctor [options]",
 		"Verify AMQ installation and configuration.",
@@ -90,7 +94,10 @@ func runDoctor(args []string) error {
 
 	// Check 5: Mailbox permissions
 	if root != "" {
-		result.Checks = append(result.Checks, checkMailboxes(root))
+		mailboxes, repair, check := inspectDoctorMailboxes(root, *fixMailboxesFlag)
+		result.Mailboxes = mailboxes
+		result.MailboxRepair = repair
+		result.Checks = append(result.Checks, check)
 	}
 
 	// Check 6: Extension metadata
@@ -375,53 +382,86 @@ func checkConfig(root string) doctorCheck {
 	return check
 }
 
-func checkMailboxes(root string) doctorCheck {
+func inspectDoctorMailboxes(root string, repair bool) ([]fsq.MailboxInspection, *fsq.MailboxRepairResult, doctorCheck) {
 	check := doctorCheck{Name: "Mailboxes"}
-
-	agentsDir := filepath.Join(root, "agents")
-	entries, err := os.ReadDir(agentsDir)
-	if os.IsNotExist(err) {
-		check.Status = "warn"
-		check.Message = "no agents directory"
-		return check
-	}
+	identity, err := snapshotMailboxDeliveryRoot(root, false, false)
 	if err != nil {
 		check.Status = "error"
-		check.Message = fmt.Sprintf("cannot read agents: %v", err)
-		return check
+		check.Message = err.Error()
+		return nil, nil, check
 	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		check.Status = "error"
+		check.Message = err.Error()
+		return nil, nil, check
+	}
+	defer func() { _ = deliveryRoot.Close() }()
 
-	var agents []string
+	var (
+		inventory fsq.MailboxInventory
+		result    *fsq.MailboxRepairResult
+	)
+	if repair {
+		repairResult := fsq.RepairMailboxLayout(deliveryRoot)
+		result = &repairResult
+		inventory = repairResult.Inventory
+	} else {
+		inventory, err = fsq.InspectMailboxLayout(deliveryRoot)
+		if err != nil {
+			check.Status = "error"
+			check.Message = err.Error()
+			return nil, nil, check
+		}
+	}
+	check = checkMailboxInventory(inventory, result)
+	return inventory.Mailboxes, result, check
+}
+
+func checkMailboxInventory(inventory fsq.MailboxInventory, repair *fsq.MailboxRepairResult) doctorCheck {
+	check := doctorCheck{Name: "Mailboxes", Status: "ok"}
 	var issues []string
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
+	if inventory.ActiveConfigStatus != "ok" {
+		check.Status = "error"
+		issues = append(issues, inventory.ActiveConfigIssue)
+	}
+	if inventory.AgentsIssue != "" {
+		check.Status = "error"
+		issues = append(issues, inventory.AgentsIssue)
+	}
+	for _, mailbox := range inventory.Mailboxes {
+		if mailbox.Status == "error" {
+			check.Status = "error"
+		} else if mailbox.Status == "warn" && check.Status == "ok" {
+			check.Status = "warn"
 		}
-		agent := entry.Name()
-		agents = append(agents, agent)
-
-		// Check inbox directories exist
-		inboxNew := fsq.AgentInboxNew(root, agent)
-		if _, err := os.Stat(inboxNew); os.IsNotExist(err) {
-			issues = append(issues, fmt.Sprintf("%s: inbox/new missing", agent))
+		if len(mailbox.Issues) > 0 {
+			issues = append(issues, mailbox.Handle+": "+strings.Join(mailbox.Issues, ", "))
 		}
 	}
-
-	if len(agents) == 0 {
+	if repair != nil && repair.Failure != nil {
+		check.Status = "error"
+		issues = append(issues, "repair "+repair.Failure.Code+": "+repair.Failure.Message)
+	}
+	if len(inventory.Mailboxes) == 0 && len(issues) == 0 {
 		check.Status = "warn"
-		check.Message = "no agent mailboxes"
+		check.Message = "no configured or discovered mailboxes"
 		return check
 	}
-
+	check.Message = fmt.Sprintf("%d mailboxes", len(inventory.Mailboxes))
 	if len(issues) > 0 {
-		check.Status = "warn"
-		check.Message = fmt.Sprintf("%d agents, issues: %v", len(agents), issues)
-		return check
+		check.Message += "; " + strings.Join(issues, "; ")
 	}
-
-	check.Status = "ok"
-	check.Message = fmt.Sprintf("%d agents configured", len(agents))
+	if repair == nil {
+		for _, mailbox := range inventory.Mailboxes {
+			if mailbox.RepairEligible {
+				check.Message += "; repair: amq doctor --fix-mailboxes"
+				break
+			}
+		}
+	} else if len(repair.CreatedPaths) > 0 {
+		check.Message += "; created: " + strings.Join(repair.CreatedPaths, ", ")
+	}
 	return check
 }
 

--- a/internal/cli/doctor_mailboxes_test.go
+++ b/internal/cli/doctor_mailboxes_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
@@ -38,6 +39,82 @@ func TestDoctorIssue289ConfiguredOnlyMailboxIsReported(t *testing.T) {
 	}
 	if !doctorMailboxContains(missing.Issues, "missing:.") {
 		t.Fatalf("issues = %#v, want missing mailbox root", missing.Issues)
+	}
+}
+
+func TestDoctorIssue289InspectionIgnoresMismatchedSessionPin(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "healthy")
+	pinnedRoot := healthyDoctorMailboxRoot(t, "pinned")
+	setDoctorIdentityPin(t, pinnedRoot)
+
+	mailboxes, repair, check := inspectDoctorMailboxes(root, false)
+
+	if check.Status != "ok" {
+		t.Fatalf("mailbox check = %#v", check)
+	}
+	if repair != nil {
+		t.Fatalf("inspection returned repair result: %#v", repair)
+	}
+	if len(mailboxes) != 1 || mailboxes[0].Handle != "healthy" {
+		t.Fatalf("mailboxes = %#v", mailboxes)
+	}
+}
+
+func TestDoctorIssue289InspectionWithoutSessionPinFailsOpen(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "healthy")
+	clearDoctorSessionPin(t)
+
+	mailboxes, repair, check := inspectDoctorMailboxes(root, false)
+
+	if check.Status != "ok" {
+		t.Fatalf("mailbox check = %#v", check)
+	}
+	if repair != nil {
+		t.Fatalf("inspection returned repair result: %#v", repair)
+	}
+	if len(mailboxes) != 1 || mailboxes[0].Handle != "healthy" {
+		t.Fatalf("mailboxes = %#v", mailboxes)
+	}
+}
+
+func TestDoctorIssue289RunDoctorInspectsOutsidePopulatedSessionPin(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "healthy")
+	pinnedRoot := healthyDoctorMailboxRoot(t, "pinned")
+	setDoctorIdentityPin(t, pinnedRoot)
+
+	result := runDoctorMailboxJSON(t, root)
+
+	if got := doctorCheckStatus(result.Checks, "Mailboxes"); got != "ok" {
+		t.Fatalf("Mailboxes status = %q, checks=%#v", got, result.Checks)
+	}
+	if got := doctorCheckStatus(result.Checks, "Session identity pin"); got != "warn" {
+		t.Fatalf("Session identity pin status = %q, want warn", got)
+	}
+	if len(result.Mailboxes) != 1 || result.Mailboxes[0].Handle != "healthy" {
+		t.Fatalf("mailboxes = %#v", result.Mailboxes)
+	}
+}
+
+func TestDoctorIssue289RepairRefusesMismatchedSessionPinWithRemedy(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "healthy")
+	pinnedRoot := healthyDoctorMailboxRoot(t, "pinned")
+	setDoctorIdentityPin(t, pinnedRoot)
+	if err := os.Remove(fsq.AgentInboxCur(root, "healthy")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, repair, check := inspectDoctorMailboxes(root, true)
+
+	if repair != nil {
+		t.Fatalf("refused repair returned result: %#v", repair)
+	}
+	for _, want := range []string{"refusing to repair", "pinned session context", "re-run from the intended session"} {
+		if !strings.Contains(check.Message, want) {
+			t.Fatalf("repair error missing %q: %#v", want, check)
+		}
+	}
+	if _, err := os.Stat(fsq.AgentInboxCur(root, "healthy")); !os.IsNotExist(err) {
+		t.Fatalf("refused repair mutated missing directory: %v", err)
 	}
 }
 
@@ -195,6 +272,43 @@ func runDoctorMailboxJSONArgs(t *testing.T, root string, args ...string) doctorM
 		t.Fatalf("unmarshal doctor JSON: %v\n%s", err, output)
 	}
 	return result
+}
+
+func healthyDoctorMailboxRoot(t *testing.T, handle string) string {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, handle); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{handle},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func setDoctorIdentityPin(t *testing.T, root string) {
+	t.Helper()
+	token, err := resolveTreeIdentityToken(root)
+	if err != nil {
+		t.Fatalf("resolveTreeIdentityToken(%s): %v", root, err)
+	}
+	t.Setenv(envBaseRoot, root)
+	t.Setenv(envSession, "")
+	t.Setenv(envRootID, token)
+	t.Setenv(envBaseRootID, token)
+}
+
+func clearDoctorSessionPin(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{envRootID, envBaseRoot, envBaseRootID, envSession} {
+		setOptionalEnv(t, key, "", false)
+	}
 }
 
 func TestDoctorIssue289ConfiguredDiscoveredLegacyMailbox(t *testing.T) {

--- a/internal/cli/doctor_mailboxes_test.go
+++ b/internal/cli/doctor_mailboxes_test.go
@@ -1,0 +1,297 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type doctorMailboxJSON struct {
+	Handle         string   `json:"handle"`
+	Provenance     string   `json:"provenance"`
+	Status         string   `json:"status"`
+	Issues         []string `json:"issues"`
+	RepairEligible bool     `json:"repair_eligible"`
+}
+
+func TestDoctorIssue289ConfiguredOnlyMailboxIsReported(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"missing"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	result := runDoctorMailboxJSON(t, root)
+	missing := findDoctorMailboxTestEntry(t, result.Mailboxes, "missing")
+	if missing.Provenance != "configured" || missing.Status != "error" || !missing.RepairEligible {
+		t.Fatalf("configured-only mailbox = %#v", missing)
+	}
+	if !doctorMailboxContains(missing.Issues, "missing:.") {
+		t.Fatalf("issues = %#v, want missing mailbox root", missing.Issues)
+	}
+}
+
+func TestDoctorIssue289DiscoveredOnlyMailboxIsNotRepairEligible(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"healthy"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "healthy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "agents", "orphan"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result := runDoctorMailboxJSON(t, root)
+	orphan := findDoctorMailboxTestEntry(t, result.Mailboxes, "orphan")
+	if orphan.Provenance != "discovered" || orphan.Status != "warn" || orphan.RepairEligible {
+		t.Fatalf("discovered-only mailbox = %#v", orphan)
+	}
+}
+
+func TestDoctorIssue289RepairCreatesOnlyMissingDirsAndIsIdempotent(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "legacy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"legacy"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	messagePath := filepath.Join(fsq.AgentInboxNew(root, "legacy"), "sentinel.md")
+	if err := os.WriteFile(messagePath, []byte("do not touch"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(messagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fsq.AgentInboxCur(root, "legacy")); err != nil {
+		t.Fatal(err)
+	}
+
+	first := runDoctorMailboxJSONArgs(t, root, "--fix-mailboxes", "--json")
+	if first.MailboxRepair == nil || first.MailboxRepair.Status != "repaired" {
+		var failure *fsq.MailboxRepairFailure
+		if first.MailboxRepair != nil {
+			failure = first.MailboxRepair.Failure
+		}
+		t.Fatalf("repair = %#v failure=%#v", first.MailboxRepair, failure)
+	}
+	if len(first.MailboxRepair.CreatedPaths) != 1 ||
+		first.MailboxRepair.CreatedPaths[0] != "agents/legacy/inbox/cur" {
+		t.Fatalf("created_paths = %#v", first.MailboxRepair.CreatedPaths)
+	}
+	after, err := os.Stat(messagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) || before.Mode() != after.Mode() {
+		t.Fatalf("existing message identity or mode changed: before=%v after=%v", before, after)
+	}
+	data, err := os.ReadFile(messagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "do not touch" {
+		t.Fatalf("existing message changed: %q", data)
+	}
+
+	second := runDoctorMailboxJSONArgs(t, root, "--fix-mailboxes", "--json")
+	if second.MailboxRepair == nil || len(second.MailboxRepair.CreatedPaths) != 0 {
+		t.Fatalf("idempotent repair = %#v", second.MailboxRepair)
+	}
+}
+
+func TestDoctorIssue289RepairRefusesSymlinkWithoutMutation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires platform privileges")
+	}
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "legacy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"legacy"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	sentinel := filepath.Join(outside, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fsq.AgentInboxCur(root, "legacy")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, fsq.AgentInboxCur(root, "legacy")); err != nil {
+		t.Fatal(err)
+	}
+
+	result := runDoctorMailboxJSONArgs(t, root, "--fix-mailboxes", "--json")
+	if result.MailboxRepair == nil || result.MailboxRepair.Failure == nil ||
+		result.MailboxRepair.Failure.Code != "preflight_failed" {
+		t.Fatalf("repair = %#v", result.MailboxRepair)
+	}
+	data, err := os.ReadFile(sentinel)
+	if err != nil || string(data) != "outside" {
+		t.Fatalf("outside sentinel changed: data=%q err=%v", data, err)
+	}
+	info, err := os.Lstat(fsq.AgentInboxCur(root, "legacy"))
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink was changed: info=%v err=%v", info, err)
+	}
+}
+
+type doctorMailboxResultJSON struct {
+	Checks        []doctorCheck            `json:"checks"`
+	Mailboxes     []doctorMailboxJSON      `json:"mailboxes"`
+	MailboxRepair *fsq.MailboxRepairResult `json:"mailbox_repair"`
+	Ops           *doctorOpsResult         `json:"ops"`
+}
+
+func runDoctorMailboxJSON(t *testing.T, root string) doctorMailboxResultJSON {
+	t.Helper()
+	return runDoctorMailboxJSONArgs(t, root, "--json")
+}
+
+func runDoctorMailboxJSONArgs(t *testing.T, root string, args ...string) doctorMailboxResultJSON {
+	t.Helper()
+	t.Setenv(envRoot, root)
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor(args)
+	})
+	if err != nil {
+		t.Fatalf("runDoctor: %v", err)
+	}
+	var result doctorMailboxResultJSON
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("unmarshal doctor JSON: %v\n%s", err, output)
+	}
+	return result
+}
+
+func TestDoctorIssue289ConfiguredDiscoveredLegacyMailbox(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	for _, handle := range []string{"healthy", "legacy"} {
+		if err := fsq.EnsureAgentDirs(root, handle); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"healthy", "legacy"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(root, "legacy"), "unread.md"), []byte("sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fsq.AgentInboxCur(root, "legacy")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(envRoot, root)
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--ops", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runDoctor: %v", err)
+	}
+
+	var result struct {
+		Checks    []doctorCheck       `json:"checks"`
+		Mailboxes []doctorMailboxJSON `json:"mailboxes"`
+		Ops       *doctorOpsResult    `json:"ops"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("unmarshal doctor JSON: %v\n%s", err, output)
+	}
+
+	legacy := findDoctorMailboxTestEntry(t, result.Mailboxes, "legacy")
+	if legacy.Provenance != "configured_and_discovered" {
+		t.Fatalf("legacy provenance = %q", legacy.Provenance)
+	}
+	if legacy.Status != "error" {
+		t.Fatalf("legacy status = %q, want error", legacy.Status)
+	}
+	if !legacy.RepairEligible {
+		t.Fatal("legacy should be repair eligible")
+	}
+	if !doctorMailboxContains(legacy.Issues, "missing:inbox/cur") {
+		t.Fatalf("legacy issues = %#v", legacy.Issues)
+	}
+	if got := doctorCheckStatus(result.Checks, "Mailboxes"); got != "error" {
+		t.Fatalf("Mailboxes status = %q, want error", got)
+	}
+	if result.Ops == nil {
+		t.Fatal("ops result missing")
+	}
+	for _, agent := range result.Ops.Agents {
+		if agent.Handle == "legacy" {
+			if agent.UnreadCount != 1 {
+				t.Fatalf("legacy unread_count = %d, want 1", agent.UnreadCount)
+			}
+			return
+		}
+	}
+	t.Fatal("legacy missing from ops")
+}
+
+func findDoctorMailboxTestEntry(t *testing.T, entries []doctorMailboxJSON, handle string) doctorMailboxJSON {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Handle == handle {
+			return entry
+		}
+	}
+	t.Fatalf("mailbox %q missing: %#v", handle, entries)
+	return doctorMailboxJSON{}
+}
+
+func doctorMailboxContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorCheckStatus(checks []doctorCheck, name string) string {
+	for _, check := range checks {
+		if check.Name == name {
+			return check.Status
+		}
+	}
+	return ""
+}

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -1,10 +1,14 @@
 package fsq
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -26,6 +30,48 @@ func ValidateHandle(agent string) error {
 	return nil
 }
 
+// MailboxLeaf identifies one required per-agent mailbox leaf.
+type MailboxLeaf string
+
+const (
+	MailboxInboxTmp   MailboxLeaf = "inbox/tmp"
+	MailboxInboxNew   MailboxLeaf = "inbox/new"
+	MailboxInboxCur   MailboxLeaf = "inbox/cur"
+	MailboxOutboxSent MailboxLeaf = "outbox/sent"
+	MailboxDLQTmp     MailboxLeaf = "dlq/tmp"
+	MailboxDLQNew     MailboxLeaf = "dlq/new"
+	MailboxDLQCur     MailboxLeaf = "dlq/cur"
+	MailboxReceipts   MailboxLeaf = "receipts"
+)
+
+var requiredMailboxLeaves = [...]MailboxLeaf{
+	MailboxInboxTmp,
+	MailboxInboxNew,
+	MailboxInboxCur,
+	MailboxOutboxSent,
+	MailboxDLQTmp,
+	MailboxDLQNew,
+	MailboxDLQCur,
+	MailboxReceipts,
+}
+
+// RequiredMailboxLeaves returns the one ordered mailbox-layout contract.
+func RequiredMailboxLeaves() []MailboxLeaf {
+	leaves := make([]MailboxLeaf, len(requiredMailboxLeaves))
+	copy(leaves, requiredMailboxLeaves[:])
+	return leaves
+}
+
+// AgentMailboxPath returns one required leaf below an agent mailbox.
+func AgentMailboxPath(root, agent string, leaf MailboxLeaf) string {
+	return filepath.Join(root, "agents", agent, filepath.FromSlash(string(leaf)))
+}
+
+// MailboxRootRelativePath returns one required leaf relative to a queue root.
+func MailboxRootRelativePath(agent string, leaf MailboxLeaf) string {
+	return filepath.Join("agents", agent, filepath.FromSlash(string(leaf)))
+}
+
 // Path helpers for standard mailbox directories.
 
 func AgentBase(root, agent string) string {
@@ -33,35 +79,35 @@ func AgentBase(root, agent string) string {
 }
 
 func AgentInboxTmp(root, agent string) string {
-	return filepath.Join(root, "agents", agent, "inbox", "tmp")
+	return AgentMailboxPath(root, agent, MailboxInboxTmp)
 }
 
 func AgentInboxNew(root, agent string) string {
-	return filepath.Join(root, "agents", agent, "inbox", "new")
+	return AgentMailboxPath(root, agent, MailboxInboxNew)
 }
 
 func AgentInboxCur(root, agent string) string {
-	return filepath.Join(root, "agents", agent, "inbox", "cur")
+	return AgentMailboxPath(root, agent, MailboxInboxCur)
 }
 
 func AgentOutboxSent(root, agent string) string {
-	return filepath.Join(root, "agents", agent, "outbox", "sent")
+	return AgentMailboxPath(root, agent, MailboxOutboxSent)
 }
 
 func AgentDLQTmp(root, agent string) string {
-	return filepath.Join(root, "agents", agent, "dlq", "tmp")
+	return AgentMailboxPath(root, agent, MailboxDLQTmp)
 }
 
 func AgentDLQNew(root, agent string) string {
-	return filepath.Join(root, "agents", agent, "dlq", "new")
+	return AgentMailboxPath(root, agent, MailboxDLQNew)
 }
 
 func AgentDLQCur(root, agent string) string {
-	return filepath.Join(root, "agents", agent, "dlq", "cur")
+	return AgentMailboxPath(root, agent, MailboxDLQCur)
 }
 
 func AgentReceipts(root, agent string) string {
-	return filepath.Join(root, "agents", agent, "receipts")
+	return AgentMailboxPath(root, agent, MailboxReceipts)
 }
 
 func EnsureRootDirs(root string) error {
@@ -81,20 +127,598 @@ func EnsureAgentDirs(root, agent string) error {
 	if err := ValidateHandle(agent); err != nil {
 		return err
 	}
-	dirs := []string{
-		AgentInboxTmp(root, agent),
-		AgentInboxNew(root, agent),
-		AgentInboxCur(root, agent),
-		AgentOutboxSent(root, agent),
-		AgentDLQTmp(root, agent),
-		AgentDLQNew(root, agent),
-		AgentDLQCur(root, agent),
-		AgentReceipts(root, agent),
-	}
-	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0o700); err != nil {
+	for _, leaf := range requiredMailboxLeaves {
+		if err := os.MkdirAll(AgentMailboxPath(root, agent, leaf), 0o700); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+type MailboxProvenance string
+
+const (
+	MailboxConfigured              MailboxProvenance = "configured"
+	MailboxDiscovered              MailboxProvenance = "discovered"
+	MailboxConfiguredAndDiscovered MailboxProvenance = "configured_and_discovered"
+)
+
+type MailboxPathState string
+
+const (
+	MailboxPathDirectory               MailboxPathState = "directory"
+	MailboxPathMissing                 MailboxPathState = "missing"
+	MailboxPathSymlink                 MailboxPathState = "symlink"
+	MailboxPathNonDirectory            MailboxPathState = "non_directory"
+	MailboxPathUnreadable              MailboxPathState = "unreadable"
+	MailboxPathChangedDuringInspection MailboxPathState = "changed_during_inspection"
+)
+
+type MailboxPathInspection struct {
+	Path  string           `json:"path"`
+	State MailboxPathState `json:"state"`
+	Mode  string           `json:"mode,omitempty"`
+}
+
+type MailboxInspection struct {
+	Handle         string                  `json:"handle"`
+	Provenance     MailboxProvenance       `json:"provenance"`
+	Status         string                  `json:"status"`
+	Issues         []string                `json:"issues"`
+	Paths          []MailboxPathInspection `json:"paths,omitempty"`
+	RepairEligible bool                    `json:"repair_eligible"`
+	CreatedPaths   []string                `json:"created_paths,omitempty"`
+}
+
+type MailboxInventory struct {
+	Mailboxes          []MailboxInspection
+	ActiveConfigStatus string
+	ActiveConfigIssue  string
+	ConfiguredAgents   []string
+	AgentsState        MailboxPathState
+	AgentsIssue        string
+	RepairAuthorized   bool
+}
+
+type MailboxRepairFailure struct {
+	Code                    string `json:"code"`
+	Stage                   string `json:"stage"`
+	Path                    string `json:"path,omitempty"`
+	Message                 string `json:"message"`
+	DurabilityIndeterminate bool   `json:"durability_indeterminate,omitempty"`
+}
+
+type MailboxRepairResult struct {
+	Status       string                `json:"status"`
+	CreatedPaths []string              `json:"created_paths,omitempty"`
+	Failure      *MailboxRepairFailure `json:"failure,omitempty"`
+	Inventory    MailboxInventory      `json:"-"`
+}
+
+type mailboxActiveConfig struct {
+	Agents []string `json:"agents"`
+}
+
+type mailboxLayoutNode struct {
+	state MailboxPathState
+	mode  os.FileMode
+	info  layoutNodeInfo
+}
+
+type mailboxLayoutPlan struct {
+	inventory MailboxInventory
+	nodes     map[string]mailboxLayoutNode
+}
+
+type mailboxRepairHooks struct {
+	afterPreflight func()
+	fail           func(stage, path string) error
+}
+
+var errLayoutIdentityChanged = errors.New("layout component changed during inspection")
+
+// mailboxComponentPaths is parent-first and includes every unique intermediate
+// plus the eight required leaves. "." is the per-agent directory itself.
+func mailboxComponentPaths() []string {
+	seen := map[string]bool{".": true}
+	paths := []string{"."}
+	for _, leaf := range requiredMailboxLeaves {
+		parts := strings.Split(string(leaf), "/")
+		for i := range parts {
+			path := filepath.Join(parts[:i+1]...)
+			if !seen[path] {
+				seen[path] = true
+				paths = append(paths, path)
+			}
+		}
+	}
+	return paths
+}
+
+func mailboxIssue(state MailboxPathState, path string) string {
+	return string(state) + ":" + filepath.ToSlash(path)
+}
+
+func inspectDirectoryComponent(parent *layoutDirCapability, name, display string) (mailboxLayoutNode, *layoutDirCapability) {
+	info, err := lstatLayoutNode(parent, name)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return mailboxLayoutNode{state: MailboxPathMissing}, nil
+		}
+		return mailboxLayoutNode{state: MailboxPathUnreadable}, nil
+	}
+	node := mailboxLayoutNode{mode: info.mode, info: info}
+	switch info.kind {
+	case layoutNodeSymlink:
+		node.state = MailboxPathSymlink
+		return node, nil
+	case layoutNodeDirectory:
+		child, err := openLayoutDirectory(parent, name, info)
+		if err != nil {
+			if errors.Is(err, errLayoutIdentityChanged) {
+				node.state = MailboxPathChangedDuringInspection
+			} else {
+				node.state = MailboxPathUnreadable
+			}
+			return node, nil
+		}
+		node.state = MailboxPathDirectory
+		return node, child
+	default:
+		node.state = MailboxPathNonDirectory
+		return node, nil
+	}
+}
+
+func readActiveMailboxConfig(root *layoutDirCapability) (mailboxActiveConfig, string, string) {
+	metaNode, meta := inspectDirectoryComponent(root, "meta", "meta")
+	if meta != nil {
+		defer meta.close()
+	}
+	if metaNode.state != MailboxPathDirectory {
+		status := string(metaNode.state)
+		return mailboxActiveConfig{}, status, mailboxIssue(metaNode.state, "meta")
+	}
+	data, state, err := readLayoutRegularFile(meta, "config.json")
+	if err != nil {
+		if state == "" {
+			state = MailboxPathUnreadable
+		}
+		return mailboxActiveConfig{}, string(state), mailboxIssue(state, "meta/config.json")
+	}
+	var cfg mailboxActiveConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return mailboxActiveConfig{}, "malformed", fmt.Sprintf("malformed:meta/config.json:%v", err)
+	}
+	for _, handle := range cfg.Agents {
+		if err := ValidateHandle(handle); err != nil {
+			return cfg, "invalid_handles", fmt.Sprintf("invalid_handle:%s:%v", handle, err)
+		}
+	}
+	return cfg, "ok", ""
+}
+
+func inspectMailboxLayout(root *DeliveryRoot) (mailboxLayoutPlan, error) {
+	if err := root.VerifyBase(); err != nil {
+		return mailboxLayoutPlan{}, err
+	}
+	rootCap, err := openLayoutRootCapability(root)
+	if err != nil {
+		return mailboxLayoutPlan{}, err
+	}
+	defer rootCap.close()
+
+	cfg, configStatus, configIssue := readActiveMailboxConfig(rootCap)
+	inventory := MailboxInventory{
+		ActiveConfigStatus: configStatus,
+		ActiveConfigIssue:  configIssue,
+		ConfiguredAgents:   append([]string(nil), cfg.Agents...),
+		RepairAuthorized:   configStatus == "ok",
+	}
+
+	configured := make(map[string]bool, len(cfg.Agents))
+	for _, handle := range cfg.Agents {
+		configured[handle] = true
+	}
+
+	agentsNode, agentsCap := inspectDirectoryComponent(rootCap, "agents", "agents")
+	if agentsCap != nil {
+		defer agentsCap.close()
+	}
+	inventory.AgentsState = agentsNode.state
+	if agentsNode.state != MailboxPathDirectory && agentsNode.state != MailboxPathMissing {
+		inventory.AgentsIssue = mailboxIssue(agentsNode.state, "agents")
+	}
+
+	discovered := map[string]bool{}
+	if agentsCap != nil {
+		names, err := agentsCap.readDirNames()
+		if err != nil {
+			inventory.AgentsState = MailboxPathUnreadable
+			inventory.AgentsIssue = mailboxIssue(MailboxPathUnreadable, "agents")
+		} else {
+			for _, name := range names {
+				discovered[name] = true
+			}
+		}
+	}
+
+	handleSet := make(map[string]bool, len(configured)+len(discovered))
+	for handle := range configured {
+		handleSet[handle] = true
+	}
+	for handle := range discovered {
+		handleSet[handle] = true
+	}
+	handles := make([]string, 0, len(handleSet))
+	for handle := range handleSet {
+		handles = append(handles, handle)
+	}
+	sort.Strings(handles)
+
+	plan := mailboxLayoutPlan{
+		inventory: inventory,
+		nodes:     map[string]mailboxLayoutNode{"agents": agentsNode},
+	}
+	for _, handle := range handles {
+		entry := MailboxInspection{Handle: handle}
+		switch {
+		case configured[handle] && discovered[handle]:
+			entry.Provenance = MailboxConfiguredAndDiscovered
+		case configured[handle]:
+			entry.Provenance = MailboxConfigured
+		default:
+			entry.Provenance = MailboxDiscovered
+		}
+		if err := ValidateHandle(handle); err != nil {
+			entry.Status = mailboxSeverity(entry.Provenance)
+			entry.Issues = []string{"invalid_handle"}
+			plan.inventory.Mailboxes = append(plan.inventory.Mailboxes, entry)
+			continue
+		}
+		inspectOneMailbox(&plan, agentsCap, handle, &entry)
+		entry.RepairEligible = configured[handle] &&
+			plan.inventory.RepairAuthorized &&
+			mailboxIssuesRepairable(entry.Issues)
+		plan.inventory.Mailboxes = append(plan.inventory.Mailboxes, entry)
+	}
+	return plan, nil
+}
+
+func mailboxIssuesRepairable(issues []string) bool {
+	if len(issues) == 0 {
+		return false
+	}
+	for _, issue := range issues {
+		if !strings.HasPrefix(issue, string(MailboxPathMissing)+":") {
+			return false
+		}
+	}
+	return true
+}
+
+func inspectOneMailbox(plan *mailboxLayoutPlan, agentsCap *layoutDirCapability, handle string, entry *MailboxInspection) {
+	caps := map[string]*layoutDirCapability{}
+	defer func() {
+		for _, cap := range caps {
+			cap.close()
+		}
+	}()
+
+	for _, rel := range mailboxComponentPaths() {
+		rootRel := filepath.Join("agents", handle)
+		parentRel := ""
+		name := handle
+		if rel != "." {
+			rootRel = filepath.Join(rootRel, rel)
+			parentRel = filepath.Dir(rel)
+			name = filepath.Base(rel)
+		}
+
+		var node mailboxLayoutNode
+		var child *layoutDirCapability
+		parent := agentsCap
+		parentState := plan.inventory.AgentsState
+		if rel != "." {
+			parent = caps[parentRel]
+			parentRootRel := filepath.Join("agents", handle)
+			if parentRel != "." {
+				parentRootRel = filepath.Join(parentRootRel, parentRel)
+			}
+			parentState = plan.nodes[parentRootRel].state
+		}
+		switch {
+		case parent != nil:
+			node, child = inspectDirectoryComponent(parent, name, rootRel)
+		case parentState == MailboxPathMissing:
+			node.state = MailboxPathMissing
+		default:
+			node.state = MailboxPathUnreadable
+		}
+		plan.nodes[rootRel] = node
+
+		pathResult := MailboxPathInspection{Path: filepath.ToSlash(rel), State: node.state}
+		if node.state != MailboxPathMissing && node.mode != 0 {
+			pathResult.Mode = fmt.Sprintf("%04o", node.mode.Perm())
+		}
+		entry.Paths = append(entry.Paths, pathResult)
+
+		if node.state != MailboxPathDirectory {
+			entry.Issues = append(entry.Issues, mailboxIssue(node.state, rel))
+		} else if !layoutModeSupported(node.mode) {
+			entry.Issues = append(entry.Issues, "permissive_mode:"+filepath.ToSlash(rel))
+		}
+
+		if child != nil {
+			caps[rel] = child
+		}
+	}
+	if len(entry.Issues) == 0 {
+		entry.Status = "ok"
+	} else {
+		entry.Status = mailboxSeverity(entry.Provenance)
+	}
+}
+
+func mailboxSeverity(provenance MailboxProvenance) string {
+	if provenance == MailboxDiscovered {
+		return "warn"
+	}
+	return "error"
+}
+
+// InspectMailboxLayout builds the configured+discovered mailbox inventory
+// through the pinned root capability without changing the filesystem.
+func InspectMailboxLayout(root *DeliveryRoot) (MailboxInventory, error) {
+	plan, err := inspectMailboxLayout(root)
+	return plan.inventory, err
+}
+
+func preflightHazard(plan mailboxLayoutPlan) (string, bool) {
+	if !plan.inventory.RepairAuthorized {
+		return plan.inventory.ActiveConfigIssue, true
+	}
+	if plan.inventory.AgentsState != MailboxPathDirectory && plan.inventory.AgentsState != MailboxPathMissing {
+		return plan.inventory.AgentsIssue, true
+	}
+	for _, mailbox := range plan.inventory.Mailboxes {
+		if mailbox.Provenance == MailboxDiscovered {
+			continue
+		}
+		if len(mailbox.Issues) > 0 && !mailbox.RepairEligible {
+			return mailbox.Handle + ":" + strings.Join(mailbox.Issues, ","), true
+		}
+		for _, path := range mailbox.Paths {
+			switch path.State {
+			case MailboxPathDirectory, MailboxPathMissing:
+			default:
+				return mailbox.Handle + ":" + mailboxIssue(path.State, path.Path), true
+			}
+		}
+	}
+	return "", false
+}
+
+func repairComponentPaths(plan mailboxLayoutPlan) []string {
+	paths := []string{"agents"}
+	seen := map[string]bool{"agents": true}
+	handles := append([]string(nil), plan.inventory.ConfiguredAgents...)
+	sort.Strings(handles)
+	for _, handle := range handles {
+		for _, rel := range mailboxComponentPaths() {
+			path := filepath.Join("agents", handle)
+			if rel != "." {
+				path = filepath.Join(path, rel)
+			}
+			if !seen[path] {
+				seen[path] = true
+				paths = append(paths, path)
+			}
+		}
+	}
+	return paths
+}
+
+func repairFailure(code, stage, path string, err error, created []string, root *DeliveryRoot) MailboxRepairResult {
+	inventory, inspectErr := InspectMailboxLayout(root)
+	if inspectErr != nil {
+		err = fmt.Errorf("%w; re-inspection failed: %v", err, inspectErr)
+	}
+	mergeCreatedPaths(&inventory, created)
+	return MailboxRepairResult{
+		Status:       "partial",
+		CreatedPaths: append([]string(nil), created...),
+		Failure: &MailboxRepairFailure{
+			Code:                    code,
+			Stage:                   stage,
+			Path:                    filepath.ToSlash(path),
+			Message:                 err.Error(),
+			DurabilityIndeterminate: stage == "child_sync" || stage == "parent_sync",
+		},
+		Inventory: inventory,
+	}
+}
+
+func mergeCreatedPaths(inventory *MailboxInventory, created []string) {
+	for _, path := range created {
+		slash := filepath.ToSlash(path)
+		parts := strings.Split(slash, "/")
+		if len(parts) < 2 || parts[0] != "agents" {
+			continue
+		}
+		handle := parts[1]
+		relative := "."
+		if len(parts) > 2 {
+			relative = strings.Join(parts[2:], "/")
+		}
+		for i := range inventory.Mailboxes {
+			if inventory.Mailboxes[i].Handle == handle {
+				inventory.Mailboxes[i].CreatedPaths = append(inventory.Mailboxes[i].CreatedPaths, relative)
+				break
+			}
+		}
+	}
+}
+
+func repairMailboxLayout(root *DeliveryRoot, hooks mailboxRepairHooks) MailboxRepairResult {
+	plan, err := inspectMailboxLayout(root)
+	if err != nil {
+		return MailboxRepairResult{
+			Status:  "failed",
+			Failure: &MailboxRepairFailure{Code: "unsafe_root", Stage: "preflight", Message: err.Error()},
+		}
+	}
+	if issue, hazard := preflightHazard(plan); hazard {
+		return MailboxRepairResult{
+			Status:    "failed",
+			Failure:   &MailboxRepairFailure{Code: "preflight_failed", Stage: "preflight", Message: issue},
+			Inventory: plan.inventory,
+		}
+	}
+	if hooks.afterPreflight != nil {
+		hooks.afterPreflight()
+	}
+
+	rootCap, err := openLayoutRootCapability(root)
+	if err != nil {
+		return repairFailure("unsafe_root", "open", ".", err, nil, root)
+	}
+	defer rootCap.close()
+	caps := map[string]*layoutDirCapability{"": rootCap}
+	created := []string{}
+	defer func() {
+		for path, cap := range caps {
+			if path != "" {
+				cap.close()
+			}
+		}
+	}()
+
+	for _, path := range repairComponentPaths(plan) {
+		parentPath := filepath.Dir(path)
+		if parentPath == "." {
+			parentPath = ""
+		}
+		parent := caps[parentPath]
+		if parent == nil {
+			return repairFailure("concurrent_change", "open", path, errLayoutIdentityChanged, created, root)
+		}
+		name := filepath.Base(path)
+		before := plan.nodes[path]
+
+		current, statErr := lstatLayoutNode(parent, name)
+		switch before.state {
+		case MailboxPathMissing:
+			if statErr == nil {
+				return repairFailure("concurrent_race", "create", path, fmt.Errorf("%s appeared after preflight", path), created, root)
+			}
+			if !errors.Is(statErr, fs.ErrNotExist) {
+				return repairFailure("create_failed", "create", path, statErr, created, root)
+			}
+			if hooks.fail != nil {
+				if failErr := hooks.fail("mkdir", path); failErr != nil {
+					return repairFailure("create_failed", "mkdir", path, failErr, created, root)
+				}
+			}
+			if err := mkdirLayoutDirectory(parent, name, 0o700); err != nil {
+				code := "create_failed"
+				if errors.Is(err, fs.ErrExist) {
+					code = "concurrent_race"
+				}
+				return repairFailure(code, "mkdir", path, err, created, root)
+			}
+			created = append(created, filepath.ToSlash(path))
+			current, statErr = lstatLayoutNode(parent, name)
+			if statErr != nil {
+				return repairFailure("create_failed", "lstat", path, statErr, created, root)
+			}
+			if current.kind != layoutNodeDirectory {
+				return repairFailure("concurrent_race", "identity", path, fmt.Errorf("created path is not a directory"), created, root)
+			}
+			if hooks.fail != nil {
+				if failErr := hooks.fail("open", path); failErr != nil {
+					return repairFailure("create_failed", "open", path, failErr, created, root)
+				}
+			}
+			child, openErr := openLayoutDirectory(parent, name, current)
+			if openErr != nil {
+				return repairFailure("create_failed", "open", path, openErr, created, root)
+			}
+			caps[path] = child
+			if hooks.fail != nil {
+				if failErr := hooks.fail("chmod", path); failErr != nil {
+					return repairFailure("create_failed", "chmod", path, failErr, created, root)
+				}
+			}
+			if err := child.chmod(0o700); err != nil {
+				return repairFailure("create_failed", "chmod", path, err, created, root)
+			}
+			mode, err := child.mode()
+			if err != nil {
+				return repairFailure("create_failed", "fstat", path, err, created, root)
+			}
+			if !layoutModeSupported(mode) {
+				return repairFailure("create_failed", "mode", path, fmt.Errorf("created directory mode is %04o, want 0700", mode.Perm()), created, root)
+			}
+			if hooks.fail != nil {
+				if failErr := hooks.fail("child_sync", path); failErr != nil {
+					return repairFailure("durability_failed", "child_sync", path, failErr, created, root)
+				}
+			}
+			if err := child.sync(); err != nil {
+				return repairFailure("durability_failed", "child_sync", path, err, created, root)
+			}
+			if hooks.fail != nil {
+				if failErr := hooks.fail("parent_sync", path); failErr != nil {
+					return repairFailure("durability_failed", "parent_sync", path, failErr, created, root)
+				}
+			}
+			if err := parent.sync(); err != nil {
+				return repairFailure("durability_failed", "parent_sync", path, err, created, root)
+			}
+		case MailboxPathDirectory:
+			if statErr != nil || !sameLayoutNode(before.info, current) {
+				if statErr == nil {
+					statErr = errLayoutIdentityChanged
+				}
+				return repairFailure("concurrent_change", "identity", path, statErr, created, root)
+			}
+			child, openErr := openLayoutDirectory(parent, name, current)
+			if openErr != nil {
+				return repairFailure("concurrent_change", "open", path, openErr, created, root)
+			}
+			caps[path] = child
+		default:
+			return repairFailure("preflight_failed", "preflight", path, fmt.Errorf("unsafe preflight state %s", before.state), created, root)
+		}
+	}
+
+	inventory, inspectErr := InspectMailboxLayout(root)
+	if inspectErr != nil {
+		return repairFailure("verification_failed", "verify", ".", inspectErr, created, root)
+	}
+	mergeCreatedPaths(&inventory, created)
+	for _, mailbox := range inventory.Mailboxes {
+		if mailbox.Provenance == MailboxDiscovered {
+			continue
+		}
+		for _, path := range mailbox.Paths {
+			switch path.State {
+			case MailboxPathDirectory:
+			default:
+				return repairFailure("verification_failed", "verify", filepath.Join("agents", mailbox.Handle, path.Path), fmt.Errorf("post-repair state %s", path.State), created, root)
+			}
+		}
+	}
+	return MailboxRepairResult{
+		Status:       "repaired",
+		CreatedPaths: append([]string(nil), created...),
+		Inventory:    inventory,
+	}
+}
+
+// RepairMailboxLayout validates the complete configured set before creating
+// any directory and returns exact partial results if creation later fails.
+func RepairMailboxLayout(root *DeliveryRoot) MailboxRepairResult {
+	return repairMailboxLayout(root, mailboxRepairHooks{})
 }

--- a/internal/fsq/layout_cap_other.go
+++ b/internal/fsq/layout_cap_other.go
@@ -1,0 +1,183 @@
+//go:build !darwin && !linux
+
+package fsq
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"sort"
+)
+
+type layoutNodeKind uint8
+
+const (
+	layoutNodeOther layoutNodeKind = iota
+	layoutNodeDirectory
+	layoutNodeRegular
+	layoutNodeSymlink
+)
+
+type layoutNodeIdentity struct {
+	info os.FileInfo
+}
+
+type layoutNodeInfo struct {
+	kind     layoutNodeKind
+	mode     os.FileMode
+	identity layoutNodeIdentity
+}
+
+type layoutDirCapability struct {
+	root *os.Root
+	file *os.File
+}
+
+func openLayoutRootCapability(delivery *DeliveryRoot) (*layoutDirCapability, error) {
+	root, err := delivery.root.OpenRoot(".")
+	if err != nil {
+		return nil, err
+	}
+	file, err := root.Open(".")
+	if err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	return &layoutDirCapability{root: root, file: file}, nil
+}
+
+func (c *layoutDirCapability) close() {
+	if c == nil {
+		return
+	}
+	if c.file != nil {
+		_ = c.file.Close()
+	}
+	if c.root != nil {
+		_ = c.root.Close()
+	}
+}
+
+func fileInfoLayoutNode(info os.FileInfo) layoutNodeInfo {
+	kind := layoutNodeOther
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		kind = layoutNodeSymlink
+	case info.IsDir():
+		kind = layoutNodeDirectory
+	case info.Mode().IsRegular():
+		kind = layoutNodeRegular
+	}
+	return layoutNodeInfo{kind: kind, mode: info.Mode(), identity: layoutNodeIdentity{info: info}}
+}
+
+func lstatLayoutNode(parent *layoutDirCapability, name string) (layoutNodeInfo, error) {
+	info, err := parent.root.Lstat(name)
+	if err != nil {
+		return layoutNodeInfo{}, err
+	}
+	return fileInfoLayoutNode(info), nil
+}
+
+func sameLayoutNode(left, right layoutNodeInfo) bool {
+	return left.identity.info != nil && right.identity.info != nil &&
+		os.SameFile(left.identity.info, right.identity.info)
+}
+
+func openLayoutDirectory(parent *layoutDirCapability, name string, before layoutNodeInfo) (*layoutDirCapability, error) {
+	root, err := parent.root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	file, err := root.Open(".")
+	if err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		_ = root.Close()
+		return nil, err
+	}
+	after := fileInfoLayoutNode(info)
+	if after.kind != layoutNodeDirectory || !sameLayoutNode(before, after) {
+		_ = file.Close()
+		_ = root.Close()
+		return nil, errLayoutIdentityChanged
+	}
+	return &layoutDirCapability{root: root, file: file}, nil
+}
+
+func readLayoutRegularFile(parent *layoutDirCapability, name string) ([]byte, MailboxPathState, error) {
+	before, err := lstatLayoutNode(parent, name)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, MailboxPathMissing, err
+		}
+		return nil, MailboxPathUnreadable, err
+	}
+	switch before.kind {
+	case layoutNodeSymlink:
+		return nil, MailboxPathSymlink, fs.ErrInvalid
+	case layoutNodeRegular:
+	default:
+		return nil, MailboxPathNonDirectory, fs.ErrInvalid
+	}
+	file, err := parent.root.OpenFile(name, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, MailboxPathUnreadable, err
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, MailboxPathUnreadable, err
+	}
+	after := fileInfoLayoutNode(info)
+	if after.kind != layoutNodeRegular || !sameLayoutNode(before, after) {
+		return nil, MailboxPathChangedDuringInspection, errLayoutIdentityChanged
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, MailboxPathUnreadable, err
+	}
+	return data, MailboxPathDirectory, nil
+}
+
+func (c *layoutDirCapability) readDirNames() ([]string, error) {
+	entries, err := c.file.ReadDir(-1)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func mkdirLayoutDirectory(parent *layoutDirCapability, name string, mode os.FileMode) error {
+	return parent.root.Mkdir(name, mode)
+}
+
+func (c *layoutDirCapability) chmod(mode os.FileMode) error {
+	return c.file.Chmod(mode)
+}
+
+func (c *layoutDirCapability) mode() (os.FileMode, error) {
+	info, err := c.file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return info.Mode(), nil
+}
+
+func (c *layoutDirCapability) sync() error {
+	return nil
+}
+
+func layoutModeSupported(_ os.FileMode) bool {
+	return true
+}

--- a/internal/fsq/layout_cap_unix.go
+++ b/internal/fsq/layout_cap_unix.go
@@ -1,0 +1,194 @@
+//go:build darwin || linux
+
+package fsq
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"sort"
+
+	"golang.org/x/sys/unix"
+)
+
+type layoutNodeKind uint8
+
+const (
+	layoutNodeOther layoutNodeKind = iota
+	layoutNodeDirectory
+	layoutNodeRegular
+	layoutNodeSymlink
+)
+
+type layoutNodeIdentity struct {
+	dev  uint64
+	ino  uint64
+	kind uint32
+}
+
+type layoutNodeInfo struct {
+	kind     layoutNodeKind
+	mode     os.FileMode
+	identity layoutNodeIdentity
+}
+
+type layoutDirCapability struct {
+	file *os.File
+}
+
+func unixLayoutOpenFlags() int {
+	return unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC | unix.O_NOFOLLOW
+}
+
+func openLayoutRootCapability(root *DeliveryRoot) (*layoutDirCapability, error) {
+	file, err := root.root.OpenFile(".", unixLayoutOpenFlags(), 0)
+	if err != nil {
+		return nil, err
+	}
+	return &layoutDirCapability{file: file}, nil
+}
+
+func (c *layoutDirCapability) close() {
+	if c != nil && c.file != nil {
+		_ = c.file.Close()
+	}
+}
+
+func unixLayoutKind(mode uint32) layoutNodeKind {
+	switch mode & unix.S_IFMT {
+	case unix.S_IFDIR:
+		return layoutNodeDirectory
+	case unix.S_IFREG:
+		return layoutNodeRegular
+	case unix.S_IFLNK:
+		return layoutNodeSymlink
+	default:
+		return layoutNodeOther
+	}
+}
+
+func unixLayoutInfo(stat unix.Stat_t) layoutNodeInfo {
+	rawMode := uint32(stat.Mode)
+	return layoutNodeInfo{
+		kind: unixLayoutKind(rawMode),
+		mode: os.FileMode(rawMode & 0o777),
+		identity: layoutNodeIdentity{
+			dev:  uint64(stat.Dev),
+			ino:  uint64(stat.Ino),
+			kind: rawMode & unix.S_IFMT,
+		},
+	}
+}
+
+func lstatLayoutNode(parent *layoutDirCapability, name string) (layoutNodeInfo, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstatat(int(parent.file.Fd()), name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return layoutNodeInfo{}, err
+	}
+	return unixLayoutInfo(stat), nil
+}
+
+func sameLayoutNode(left, right layoutNodeInfo) bool {
+	return left.identity == right.identity
+}
+
+func openLayoutDirectory(parent *layoutDirCapability, name string, before layoutNodeInfo) (*layoutDirCapability, error) {
+	fd, err := unix.Openat(int(parent.file.Fd()), name, unixLayoutOpenFlags(), 0)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fs.ErrInvalid
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	after := unixLayoutInfo(stat)
+	if after.kind != layoutNodeDirectory || !sameLayoutNode(before, after) {
+		_ = file.Close()
+		return nil, errLayoutIdentityChanged
+	}
+	return &layoutDirCapability{file: file}, nil
+}
+
+func readLayoutRegularFile(parent *layoutDirCapability, name string) ([]byte, MailboxPathState, error) {
+	before, err := lstatLayoutNode(parent, name)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, MailboxPathMissing, err
+		}
+		return nil, MailboxPathUnreadable, err
+	}
+	switch before.kind {
+	case layoutNodeSymlink:
+		return nil, MailboxPathSymlink, fs.ErrInvalid
+	case layoutNodeRegular:
+	default:
+		return nil, MailboxPathNonDirectory, fs.ErrInvalid
+	}
+	fd, err := unix.Openat(int(parent.file.Fd()), name, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, MailboxPathUnreadable, err
+	}
+	file := os.NewFile(uintptr(fd), name)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, MailboxPathUnreadable, fs.ErrInvalid
+	}
+	defer func() { _ = file.Close() }()
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return nil, MailboxPathUnreadable, err
+	}
+	after := unixLayoutInfo(stat)
+	if after.kind != layoutNodeRegular || !sameLayoutNode(before, after) {
+		return nil, MailboxPathChangedDuringInspection, errLayoutIdentityChanged
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, MailboxPathUnreadable, err
+	}
+	return data, MailboxPathDirectory, nil
+}
+
+func (c *layoutDirCapability) readDirNames() ([]string, error) {
+	names, err := c.file.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func mkdirLayoutDirectory(parent *layoutDirCapability, name string, mode os.FileMode) error {
+	return unix.Mkdirat(int(parent.file.Fd()), name, uint32(mode.Perm()))
+}
+
+func (c *layoutDirCapability) chmod(mode os.FileMode) error {
+	return c.file.Chmod(mode)
+}
+
+func (c *layoutDirCapability) mode() (os.FileMode, error) {
+	info, err := c.file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return info.Mode(), nil
+}
+
+func (c *layoutDirCapability) sync() error {
+	err := c.file.Sync()
+	if isSyncUnsupported(err) {
+		return nil
+	}
+	return err
+}
+
+func layoutModeSupported(mode os.FileMode) bool {
+	return mode.Perm() == 0o700
+}

--- a/internal/fsq/layout_mailbox_test.go
+++ b/internal/fsq/layout_mailbox_test.go
@@ -1,0 +1,142 @@
+package fsq
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMailboxLayoutRepairReportsConcurrentAppearanceWithoutMutation(t *testing.T) {
+	rootPath := mailboxLayoutTestRoot(t, "legacy")
+	root := openMailboxLayoutTestRoot(t, rootPath)
+
+	result := repairMailboxLayout(root, mailboxRepairHooks{
+		afterPreflight: func() {
+			if err := os.Mkdir(filepath.Join(rootPath, "agents", "legacy"), 0o700); err != nil {
+				t.Fatalf("create concurrent mailbox: %v", err)
+			}
+		},
+	})
+
+	if result.Status != "partial" || result.Failure == nil {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Failure.Code != "concurrent_race" ||
+		result.Failure.Path != "agents/legacy" ||
+		len(result.CreatedPaths) != 0 {
+		t.Fatalf("result = %#v failure=%#v", result, result.Failure)
+	}
+	entries, err := os.ReadDir(filepath.Join(rootPath, "agents", "legacy"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("concurrent mailbox mutated: %#v", entries)
+	}
+}
+
+func TestMailboxLayoutRepairReportsExactPartialProgress(t *testing.T) {
+	rootPath := mailboxLayoutTestRoot(t, "legacy")
+	if err := EnsureAgentDirs(rootPath, "legacy"); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		AgentInboxCur(rootPath, "legacy"),
+		AgentDLQCur(rootPath, "legacy"),
+	} {
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := openMailboxLayoutTestRoot(t, rootPath)
+	injected := errors.New("injected mkdir failure")
+
+	result := repairMailboxLayout(root, mailboxRepairHooks{
+		fail: func(stage, path string) error {
+			if stage == "mkdir" && filepath.ToSlash(path) == "agents/legacy/dlq/cur" {
+				return injected
+			}
+			return nil
+		},
+	})
+
+	if result.Status != "partial" || result.Failure == nil {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Failure.Code != "create_failed" ||
+		result.Failure.Path != "agents/legacy/dlq/cur" ||
+		result.Failure.Message != injected.Error() {
+		t.Fatalf("failure = %#v", result.Failure)
+	}
+	if len(result.CreatedPaths) != 1 ||
+		result.CreatedPaths[0] != "agents/legacy/inbox/cur" {
+		t.Fatalf("created_paths = %#v", result.CreatedPaths)
+	}
+	if info, err := os.Stat(AgentInboxCur(rootPath, "legacy")); err != nil || !info.IsDir() {
+		t.Fatalf("created directory missing: info=%v err=%v", info, err)
+	}
+	if _, err := os.Stat(AgentDLQCur(rootPath, "legacy")); !os.IsNotExist(err) {
+		t.Fatalf("failed directory unexpectedly exists: %v", err)
+	}
+}
+
+func TestMailboxLayoutRepairRefusesNonDirectoryPreflight(t *testing.T) {
+	rootPath := mailboxLayoutTestRoot(t, "legacy")
+	if err := EnsureAgentDirs(rootPath, "legacy"); err != nil {
+		t.Fatal(err)
+	}
+	cur := AgentInboxCur(rootPath, "legacy")
+	if err := os.Remove(cur); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cur, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := openMailboxLayoutTestRoot(t, rootPath)
+
+	result := RepairMailboxLayout(root)
+
+	if result.Status != "failed" || result.Failure == nil ||
+		result.Failure.Code != "preflight_failed" {
+		t.Fatalf("result = %#v failure=%#v", result, result.Failure)
+	}
+	data, err := os.ReadFile(cur)
+	if err != nil || string(data) != "not a directory" {
+		t.Fatalf("non-directory changed: data=%q err=%v", data, err)
+	}
+}
+
+func mailboxLayoutTestRoot(t *testing.T, agents ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{"version":1,"agents":[]}`
+	if len(agents) == 1 {
+		configJSON = `{"version":1,"agents":["` + agents[0] + `"]}`
+	}
+	if err := os.WriteFile(filepath.Join(root, "meta", "config.json"), []byte(configJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func openMailboxLayoutTestRoot(t *testing.T, rootPath string) *DeliveryRoot {
+	t.Helper()
+	identity, err := SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close delivery root: %v", err)
+		}
+	})
+	return root
+}


### PR DESCRIPTION
## Summary
- report configured and filesystem-discovered mailboxes with exact malformed or missing components
- add an explicit configured-agent-only repair path that creates missing directories and fails closed on unsafe state
- preserve existing messages and expose structured repair diagnostics
- document the mutating flag and its safety invariants

Closes #289.

## Verification
- exact reviewed commit: f731b366f3be3bea1933bb2f5779e5b6b1e6f475
- parent: ac89fa566985eb5b5d5817ddce8b172fb68d1934
- tree: 5aa1e9d15ecd6a63bb7af717936993d4a2d85f09
- diff SHA-256: dc4f9733f26b7320c27026aade095fa3ea93f50ce2483fffedcbe7805f0af72d
- go test ./... -count=1
- go vet ./...
- GOOS=linux go vet ./...
- GOOS=windows go vet ./...
- make check-skills