### PR TITLE
fix(doctor): add discovered mailbox remedies

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -435,8 +435,30 @@ func inspectDoctorMailboxes(root string, repair bool) ([]fsq.MailboxInspection, 
 			return nil, nil, check
 		}
 	}
+	applyDoctorMailboxRemedies(&inventory)
 	check = checkMailboxInventory(inventory, result)
 	return inventory.Mailboxes, result, check
+}
+
+func applyDoctorMailboxRemedies(inventory *fsq.MailboxInventory) {
+	for i := range inventory.Mailboxes {
+		mailbox := &inventory.Mailboxes[i]
+		if mailbox.Provenance != fsq.MailboxDiscovered || len(mailbox.Issues) == 0 {
+			continue
+		}
+		if err := fsq.ValidateHandle(mailbox.Handle); err != nil {
+			mailbox.Remedy = fmt.Sprintf(
+				"preserve any messages, then rename or remove invalid entry %q under agents/",
+				mailbox.Handle,
+			)
+			continue
+		}
+		mailbox.Remedy = fmt.Sprintf(
+			"add %q to agents in meta/config.json, then run 'amq doctor --fix-mailboxes'; or preserve any messages and remove agents/%s if abandoned",
+			mailbox.Handle,
+			mailbox.Handle,
+		)
+	}
 }
 
 func checkMailboxInventory(inventory fsq.MailboxInventory, repair *fsq.MailboxRepairResult) doctorCheck {
@@ -457,7 +479,11 @@ func checkMailboxInventory(inventory fsq.MailboxInventory, repair *fsq.MailboxRe
 			check.Status = "warn"
 		}
 		if len(mailbox.Issues) > 0 {
-			issues = append(issues, mailbox.Handle+": "+strings.Join(mailbox.Issues, ", "))
+			detail := mailbox.Handle + ": " + strings.Join(mailbox.Issues, ", ")
+			if mailbox.Remedy != "" {
+				detail += "; next: " + mailbox.Remedy
+			}
+			issues = append(issues, detail)
 		}
 	}
 	if repair != nil && repair.Failure != nil {

--- a/internal/cli/doctor_mailboxes_test.go
+++ b/internal/cli/doctor_mailboxes_test.go
@@ -18,6 +18,7 @@ type doctorMailboxJSON struct {
 	Status         string   `json:"status"`
 	Issues         []string `json:"issues"`
 	RepairEligible bool     `json:"repair_eligible"`
+	Remedy         string   `json:"remedy"`
 }
 
 func TestDoctorIssue289ConfiguredOnlyMailboxIsReported(t *testing.T) {
@@ -140,6 +141,39 @@ func TestDoctorIssue289DiscoveredOnlyMailboxIsNotRepairEligible(t *testing.T) {
 	orphan := findDoctorMailboxTestEntry(t, result.Mailboxes, "orphan")
 	if orphan.Provenance != "discovered" || orphan.Status != "warn" || orphan.RepairEligible {
 		t.Fatalf("discovered-only mailbox = %#v", orphan)
+	}
+	for _, want := range []string{"meta/config.json", "amq doctor --fix-mailboxes", "agents/orphan", "preserve"} {
+		if !strings.Contains(orphan.Remedy, want) {
+			t.Fatalf("orphan remedy missing %q: %q", want, orphan.Remedy)
+		}
+	}
+}
+
+func TestDoctorDiscoveredOnlyMailboxKeepsRemedyAfterConfiguredRepair(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "claude")
+	if err := os.Remove(fsq.AgentInboxCur(root, "claude")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "agents", "orphan"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result := runDoctorMailboxJSONArgs(t, root, "--fix-mailboxes", "--json")
+
+	if result.MailboxRepair == nil ||
+		len(result.MailboxRepair.CreatedPaths) != 1 ||
+		result.MailboxRepair.CreatedPaths[0] != "agents/claude/inbox/cur" {
+		t.Fatalf("repair = %#v", result.MailboxRepair)
+	}
+	orphan := findDoctorMailboxTestEntry(t, result.Mailboxes, "orphan")
+	if orphan.Status != "warn" || orphan.RepairEligible || orphan.Remedy == "" {
+		t.Fatalf("orphan = %#v", orphan)
+	}
+	check := findDoctorCheck(t, result.Checks, "Mailboxes")
+	for _, want := range []string{"orphan:", "next:", "meta/config.json"} {
+		if !strings.Contains(check.Message, want) {
+			t.Fatalf("mailbox check missing %q: %q", want, check.Message)
+		}
 	}
 }
 
@@ -408,4 +442,15 @@ func doctorCheckStatus(checks []doctorCheck, name string) string {
 		}
 	}
 	return ""
+}
+
+func findDoctorCheck(t *testing.T, checks []doctorCheck, name string) doctorCheck {
+	t.Helper()
+	for _, check := range checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	t.Fatalf("doctor check %q missing: %#v", name, checks)
+	return doctorCheck{}
 }

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -167,6 +167,7 @@ type MailboxInspection struct {
 	Issues         []string                `json:"issues"`
 	Paths          []MailboxPathInspection `json:"paths,omitempty"`
 	RepairEligible bool                    `json:"repair_eligible"`
+	Remedy         string                  `json:"remedy,omitempty"`
 	CreatedPaths   []string                `json:"created_paths,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- add an explicit machine-readable remedy for malformed discovered-only mailboxes
- include the remedy as a next step in human-readable doctor output
- keep discovered-only mailboxes ineligible for automatic repair and preserve their contents

## Verification
- go test ./... -count=1 on the working tree and clean archive
- go vet ./... on Darwin, Linux, and Windows
- make check-skills
- runtime repair created only the configured missing directory while leaving the discovered-only mailbox unchanged

Peer-reviewed exact tree: 261555be5a0c22de5bf8534b2728fc4ddaca4732