### PR TITLE
feat(trace): join message lifecycle evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ amq list --me <agent> [--session <name>] [--new | --cur] [--priority <p>] [--fro
 amq read --me <agent> --id <msg_id> [--session <name>] [--ignore-session-pin] [--json]
 amq drain --me <agent> [--session <name>] [--ignore-session-pin] [--limit N] [--include-body] [--json]
 amq thread --id <thread_id> [--agents <a,b,c>] [--limit N] [--include-body] [--json]
+amq trace <message-id> [--root <path>] [--json]
 amq receipts list --me <agent> [--msg-id <id>] [--stage <stage>] [--json]
 amq receipts wait --me <agent> --msg-id <id> [--stage <stage>] [--timeout <duration>] [--poll-interval <duration>] [--json]
 amq presence set --me <agent> --status <busy|idle|...> [--note <str>]

--- a/README.md
+++ b/README.md
@@ -420,12 +420,13 @@ Common command groups:
 
 | Area | Commands |
 |------|----------|
-| Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `watch`, `monitor`, `receipts` |
+| Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `trace`, `watch`, `monitor`, `receipts` |
 | Collaboration | `coop init`, `coop exec`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
 | Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake repair`, `wake recover-owner`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 
 For the full CLI syntax, examples, and message schema, see [CLAUDE.md](CLAUDE.md).
+For the read-only trace contract and its evidence limits, see [docs/trace.md](docs/trace.md).
 
 ## How It Works
 

--- a/docs/trace.md
+++ b/docs/trace.md
@@ -1,0 +1,77 @@
+# Message trace
+
+`amq trace <message-id> [--root <path>] [--json]` performs a read-only join over
+evidence already present in one AMQ root. It does not run a daemon, repair a
+mailbox, retry delivery, or infer an event that has no durable artifact.
+
+Phase A inspects:
+
+- message copies in inboxes and sender outboxes;
+- addressing fields persisted in message headers;
+- current inbox and DLQ file visibility;
+- DLQ envelopes and their embedded original messages;
+- drained and DLQ delivery receipts;
+- messages connected by `refs`;
+- notification history, which is explicitly `no_evidence` until AMQ has a
+  durable notification-attempt ledger.
+
+## JSON contract
+
+The top-level schema is `amq/trace/v1`:
+
+```json
+{
+  "schema": "amq/trace/v1",
+  "message_id": "2026-07-26T12-00-00.000Z_pid1_example",
+  "status": "found",
+  "root": "/path/to/.agent-mail/session",
+  "root_identity": "opaque-platform-token",
+  "legs": {
+    "message": {
+      "status": "evidence",
+      "evidence": []
+    },
+    "notification": {
+      "status": "no_evidence",
+      "evidence": [],
+      "detail": "notification attempt history is unavailable because Phase A has no durable attempt ledger",
+      "next_step": "run 'amq doctor --ops' for current wake health; do not infer historical notification success"
+    }
+  }
+}
+```
+
+`legs` always contains `message`, `route`, `delivery`, `dlq`, `receipts`,
+`thread`, and `notification`. Every leg has one of these statuses:
+
+- `evidence` — one or more durable artifacts support the leg;
+- `no_evidence` — no supporting artifact was found;
+- `error` — a candidate path could not be inspected safely.
+
+Every `no_evidence` or `error` leg includes `detail` and `next_step`.
+`evidence` is always an array, including when it is empty.
+
+The top-level status is:
+
+- `found` when at least one non-notification leg has evidence;
+- `partial` when evidence exists but at least one leg encountered an inspection
+  error;
+- `not_found` when no non-notification evidence exists.
+
+`not_found` still emits the complete text or JSON result, then exits with code
+3. This lets a human see the next steps while scripts receive the existing AMQ
+not-found signal.
+
+## Evidence limits
+
+A message header records resulting addressing metadata. It is not a historical
+record of the resolver decision made at send time. `route` states that limit and
+points to `amq route explain` only as a view of current routing.
+
+An inbox or DLQ file proves current visibility. It does not prove the historical
+directory-sync result from the original delivery. The delivery evidence marks
+durability as `no_evidence`; do not infer retry safety from current file
+presence.
+
+Notification success is never inferred from wake state, a mailbox file, or a
+delivery receipt. Phase A reports the notification leg as `no_evidence`.

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -29,6 +29,7 @@ func init() {
 		{Name: "list", Summary: "List inbox messages", Handler: runList},
 		{Name: "read", Summary: "Read a message by id", Handler: runRead},
 		{Name: "thread", Summary: "View a thread", Handler: runThread},
+		{Name: "trace", Summary: "Join current evidence for a message", Handler: runTrace},
 		{
 			Name:        "presence",
 			Summary:     "Set or list presence",

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -15,6 +15,7 @@ func TestCommandNames(t *testing.T) {
 		"list",
 		"read",
 		"thread",
+		"trace",
 		"presence",
 		"cleanup",
 		"watch",

--- a/internal/cli/trace.go
+++ b/internal/cli/trace.go
@@ -1,0 +1,674 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/receipt"
+)
+
+const traceSchema = "amq/trace/v1"
+
+var traceLegOrder = []string{
+	"message",
+	"route",
+	"delivery",
+	"dlq",
+	"receipts",
+	"thread",
+	"notification",
+}
+
+type traceResult struct {
+	Schema       string              `json:"schema"`
+	MessageID    string              `json:"message_id"`
+	Status       string              `json:"status"`
+	Root         string              `json:"root"`
+	RootIdentity string              `json:"root_identity,omitempty"`
+	Legs         map[string]traceLeg `json:"legs"`
+}
+
+type traceLeg struct {
+	Status   string          `json:"status"`
+	Evidence []traceEvidence `json:"evidence"`
+	Detail   string          `json:"detail,omitempty"`
+	NextStep string          `json:"next_step,omitempty"`
+}
+
+type traceEvidence struct {
+	Authority  string              `json:"authority"`
+	Path       string              `json:"path,omitempty"`
+	Agent      string              `json:"agent,omitempty"`
+	Area       string              `json:"area,omitempty"`
+	Box        string              `json:"box,omitempty"`
+	Message    *traceMessage       `json:"message,omitempty"`
+	Route      *traceRouteEvidence `json:"route,omitempty"`
+	DLQ        *fsq.DLQEnvelope    `json:"dlq,omitempty"`
+	Receipt    *receipt.Receipt    `json:"receipt,omitempty"`
+	Relation   *traceRelation      `json:"relation,omitempty"`
+	State      string              `json:"state,omitempty"`
+	Durability string              `json:"durability,omitempty"`
+	Limitation string              `json:"limitation,omitempty"`
+}
+
+type traceMessage struct {
+	ID      string   `json:"id"`
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Thread  string   `json:"thread"`
+	Created string   `json:"created"`
+	Refs    []string `json:"refs"`
+}
+
+type traceRouteEvidence struct {
+	From         string   `json:"from"`
+	To           []string `json:"to"`
+	Thread       string   `json:"thread"`
+	ReplyTo      string   `json:"reply_to,omitempty"`
+	ReplyProject string   `json:"reply_project,omitempty"`
+	FromProject  string   `json:"from_project,omitempty"`
+}
+
+type traceRelation struct {
+	MessageID string `json:"message_id"`
+	Relation  string `json:"relation"`
+	Thread    string `json:"thread,omitempty"`
+}
+
+type traceLocatedHeader struct {
+	header format.Header
+	path   string
+	agent  string
+	area   string
+	box    string
+}
+
+type traceCollector struct {
+	root         string
+	deliveryRoot *fsq.DeliveryRoot
+	messageID    string
+	agents       []string
+	headers      []traceLocatedHeader
+	targets      []traceLocatedHeader
+	legs         map[string]traceLeg
+	legErrors    map[string][]string
+	seenRoutes   map[string]bool
+	seenThread   map[string]bool
+}
+
+func runTrace(args []string) error {
+	fs := flag.NewFlagSet("trace", flag.ContinueOnError)
+	common := &commonFlags{flagSet: fs}
+	fs.StringVar(&common.Root, "root", defaultRoot(), "Root directory for the queue")
+	fs.BoolVar(&common.JSON, "json", false, "Emit JSON output")
+	usage := usageWithFlags(fs, "amq trace <message-id> [options]",
+		"Join current on-disk evidence for one message without mutating the queue.",
+		"",
+		"Phase A reports message copies, route fields, visible delivery artifacts, DLQ entries,",
+		"delivery receipts, thread references, and explicit no_evidence for notification attempts.",
+	)
+
+	messageID := ""
+	flagArgs := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		messageID = strings.TrimSpace(args[0])
+		flagArgs = args[1:]
+	}
+	if handled, err := parseFlags(fs, flagArgs, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if messageID == "" {
+		if fs.NArg() != 1 {
+			return UsageError("exactly one message id is required")
+		}
+		messageID = strings.TrimSpace(fs.Arg(0))
+	} else if fs.NArg() != 0 {
+		return UsageError("trace accepts exactly one message id")
+	}
+	if messageID == "" {
+		return UsageError("message id must not be blank")
+	}
+	if strings.ContainsAny(messageID, `/\`) || messageID == "." || messageID == ".." {
+		return UsageError("invalid message id %q", messageID)
+	}
+
+	root := resolveRoot(common.Root)
+	common.warnRootOverride()
+	result := collectTrace(root, messageID)
+	if identity, err := resolveTreeIdentityToken(root); err == nil {
+		result.RootIdentity = identity
+	}
+
+	if common.JSON {
+		if err := writeJSON(os.Stdout, result); err != nil {
+			return err
+		}
+	} else if err := writeTraceText(result); err != nil {
+		return err
+	}
+	if result.Status == "not_found" {
+		return NotFoundError("message evidence not found: %s; verify the message id and AM_ROOT", messageID)
+	}
+	return nil
+}
+
+func collectTrace(root, messageID string) traceResult {
+	collector := &traceCollector{
+		root:       root,
+		messageID:  messageID,
+		legs:       make(map[string]traceLeg, len(traceLegOrder)),
+		legErrors:  make(map[string][]string),
+		seenRoutes: map[string]bool{},
+		seenThread: map[string]bool{},
+	}
+	for _, name := range traceLegOrder {
+		collector.legs[name] = traceLeg{Evidence: []traceEvidence{}}
+	}
+
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		collector.addRootError(err)
+		collector.finishLegs()
+		return collector.result()
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		collector.addRootError(err)
+		collector.finishLegs()
+		return collector.result()
+	}
+	collector.deliveryRoot = deliveryRoot
+	defer func() { _ = deliveryRoot.Close() }()
+
+	collector.agents = collector.listAgents()
+	collector.scanMessages()
+	collector.scanDLQ()
+	collector.scanReceipts()
+	collector.joinHeaders()
+	collector.finishLegs()
+	return collector.result()
+}
+
+func (c *traceCollector) result() traceResult {
+	status := "found"
+	hasEvidence := false
+	hasErrors := false
+	for name, leg := range c.legs {
+		if name != "notification" && len(leg.Evidence) > 0 {
+			hasEvidence = true
+		}
+		if leg.Status == "error" {
+			hasErrors = true
+		}
+	}
+	if !hasEvidence {
+		status = "not_found"
+	} else if hasErrors {
+		status = "partial"
+	}
+
+	return traceResult{
+		Schema:    traceSchema,
+		MessageID: c.messageID,
+		Status:    status,
+		Root:      c.root,
+		Legs:      c.legs,
+	}
+}
+
+func (c *traceCollector) listAgents() []string {
+	dir := "agents"
+	entries, err := c.readDir(dir)
+	if err != nil {
+		c.addError("message", fmt.Sprintf("scan agents: %v", err))
+		c.addError("dlq", fmt.Sprintf("scan agents: %v", err))
+		c.addError("receipts", fmt.Sprintf("scan agents: %v", err))
+		c.addError("thread", fmt.Sprintf("scan agents: %v", err))
+		return []string{}
+	}
+	agents := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			agents = append(agents, entry.Name())
+		}
+	}
+	sort.Strings(agents)
+	return agents
+}
+
+func (c *traceCollector) scanMessages() {
+	for _, agent := range c.agents {
+		locations := []struct {
+			area string
+			box  string
+			dir  string
+		}{
+			{area: "inbox", box: "new", dir: filepath.Join("agents", agent, "inbox", "new")},
+			{area: "inbox", box: "cur", dir: filepath.Join("agents", agent, "inbox", "cur")},
+			{area: "outbox", box: "sent", dir: filepath.Join("agents", agent, "outbox", "sent")},
+		}
+		for _, location := range locations {
+			entries, err := c.readDir(location.dir)
+			if err != nil {
+				c.addError("message", fmt.Sprintf("scan %s: %v", c.relative(location.dir), err))
+				c.addError("thread", fmt.Sprintf("scan %s: %v", c.relative(location.dir), err))
+				continue
+			}
+			for _, entry := range entries {
+				if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || !strings.HasSuffix(entry.Name(), ".md") {
+					continue
+				}
+				path := filepath.Join(location.dir, entry.Name())
+				header, err := c.readHeader(path)
+				if err != nil {
+					c.addError("thread", fmt.Sprintf("parse %s: %v", c.relative(path), err))
+					if entry.Name() == c.messageID+".md" {
+						c.addError("message", fmt.Sprintf("parse candidate %s: %v", c.relative(path), err))
+						if location.area == "inbox" {
+							c.addEvidence("delivery", traceEvidence{
+								Authority:  "filesystem",
+								Path:       c.relative(path),
+								Agent:      agent,
+								Area:       location.area,
+								Box:        location.box,
+								State:      "present",
+								Durability: "no_evidence",
+								Limitation: "file presence does not establish the original directory sync result",
+							})
+						}
+					}
+					continue
+				}
+				located := traceLocatedHeader{
+					header: header,
+					path:   c.relative(path),
+					agent:  agent,
+					area:   location.area,
+					box:    location.box,
+				}
+				c.headers = append(c.headers, located)
+				if header.ID == c.messageID {
+					c.addTarget(located, "message_file")
+				}
+			}
+		}
+	}
+}
+
+func (c *traceCollector) scanDLQ() {
+	for _, agent := range c.agents {
+		for _, box := range []string{"new", "cur"} {
+			dir := filepath.Join("agents", agent, "dlq", "new")
+			if box == "cur" {
+				dir = filepath.Join("agents", agent, "dlq", "cur")
+			}
+			entries, err := c.readDir(dir)
+			if err != nil {
+				c.addError("dlq", fmt.Sprintf("scan %s: %v", c.relative(dir), err))
+				continue
+			}
+			for _, entry := range entries {
+				if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || !strings.HasSuffix(entry.Name(), ".md") {
+					continue
+				}
+				path := filepath.Join(dir, entry.Name())
+				envelope, original, err := fsq.ReadDLQEnvelope(c.deliveryRoot, path)
+				if err != nil {
+					c.addError("dlq", fmt.Sprintf("parse %s: %v", c.relative(path), err))
+					continue
+				}
+				if envelope.OriginalID != c.messageID {
+					continue
+				}
+				envelopeCopy := *envelope
+				relative := c.relative(path)
+				c.addEvidence("dlq", traceEvidence{
+					Authority: "dlq_envelope",
+					Path:      relative,
+					Agent:     agent,
+					Area:      "dlq",
+					Box:       box,
+					DLQ:       &envelopeCopy,
+				})
+				c.addEvidence("delivery", traceEvidence{
+					Authority:  "dlq_envelope",
+					Path:       relative,
+					Agent:      agent,
+					Area:       "dlq",
+					Box:        box,
+					State:      "present",
+					Durability: "no_evidence",
+					Limitation: "DLQ presence does not establish the original directory sync result",
+				})
+				header, parseErr := format.ParseHeader(original)
+				if parseErr != nil {
+					continue
+				}
+				if header.ID == c.messageID {
+					located := traceLocatedHeader{
+						header: header,
+						path:   relative,
+						agent:  agent,
+						area:   "dlq",
+						box:    box,
+					}
+					c.headers = append(c.headers, located)
+					c.addTarget(located, "dlq_original")
+				}
+			}
+		}
+	}
+}
+
+func (c *traceCollector) scanReceipts() {
+	for _, agent := range c.agents {
+		dir := filepath.Join("agents", agent, "receipts")
+		entries, err := c.readDir(dir)
+		if err != nil {
+			c.addError("receipts", fmt.Sprintf("scan %s: %v", c.relative(dir), err))
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasPrefix(entry.Name(), c.messageID+"__") || !strings.HasSuffix(entry.Name(), ".json") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			item, err := receipt.ReadDeliveryRoot(c.deliveryRoot, path)
+			if err != nil {
+				c.addError("receipts", fmt.Sprintf("parse candidate %s: %v", c.relative(path), err))
+				continue
+			}
+			if item.MsgID != c.messageID {
+				continue
+			}
+			itemCopy := item
+			c.addEvidence("receipts", traceEvidence{
+				Authority: "delivery_receipt",
+				Path:      c.relative(path),
+				Agent:     agent,
+				Receipt:   &itemCopy,
+			})
+		}
+	}
+}
+
+func (c *traceCollector) addTarget(located traceLocatedHeader, authority string) {
+	c.targets = append(c.targets, located)
+	header := located.header
+	c.addEvidence("message", traceEvidence{
+		Authority: authority,
+		Path:      located.path,
+		Agent:     located.agent,
+		Area:      located.area,
+		Box:       located.box,
+		Message: &traceMessage{
+			ID:      header.ID,
+			From:    header.From,
+			To:      append([]string{}, header.To...),
+			Thread:  header.Thread,
+			Created: header.Created,
+			Refs:    append([]string{}, header.Refs...),
+		},
+	})
+	if located.area == "inbox" {
+		c.addEvidence("delivery", traceEvidence{
+			Authority:  "message_file",
+			Path:       located.path,
+			Agent:      located.agent,
+			Area:       located.area,
+			Box:        located.box,
+			State:      "present",
+			Durability: "no_evidence",
+			Limitation: "file presence proves current visibility, not the original directory sync result",
+		})
+	}
+
+	routeKey := strings.Join([]string{
+		header.From,
+		strings.Join(header.To, ","),
+		header.Thread,
+		header.ReplyTo,
+		header.ReplyProject,
+		header.FromProject,
+	}, "\x00")
+	if !c.seenRoutes[routeKey] {
+		c.seenRoutes[routeKey] = true
+		c.addEvidence("route", traceEvidence{
+			Authority: "message_header",
+			Path:      located.path,
+			Route: &traceRouteEvidence{
+				From:         header.From,
+				To:           append([]string{}, header.To...),
+				Thread:       header.Thread,
+				ReplyTo:      header.ReplyTo,
+				ReplyProject: header.ReplyProject,
+				FromProject:  header.FromProject,
+			},
+			Limitation: "header fields record the resulting addressing metadata, not a persisted send-time resolver decision",
+		})
+	}
+}
+
+func (c *traceCollector) joinHeaders() {
+	targetRefs := map[string]bool{}
+	for _, target := range c.targets {
+		for _, ref := range target.header.Refs {
+			targetRefs[ref] = true
+			key := "target_references\x00" + ref
+			if c.seenThread[key] {
+				continue
+			}
+			c.seenThread[key] = true
+			c.addEvidence("thread", traceEvidence{
+				Authority: "message_refs",
+				Path:      target.path,
+				Agent:     target.agent,
+				Area:      target.area,
+				Box:       target.box,
+				Relation: &traceRelation{
+					MessageID: ref,
+					Relation:  "target_references",
+					Thread:    target.header.Thread,
+				},
+			})
+		}
+	}
+	for _, located := range c.headers {
+		relation := ""
+		switch {
+		case located.header.ID != c.messageID && containsTraceString(located.header.Refs, c.messageID):
+			relation = "references_target"
+		case located.header.ID != c.messageID && targetRefs[located.header.ID]:
+			relation = "referenced_by_target"
+		}
+		if relation == "" {
+			continue
+		}
+		key := relation + "\x00" + located.header.ID
+		if c.seenThread[key] {
+			continue
+		}
+		c.seenThread[key] = true
+		c.addEvidence("thread", traceEvidence{
+			Authority: "message_refs",
+			Path:      located.path,
+			Agent:     located.agent,
+			Area:      located.area,
+			Box:       located.box,
+			Relation: &traceRelation{
+				MessageID: located.header.ID,
+				Relation:  relation,
+				Thread:    located.header.Thread,
+			},
+		})
+	}
+}
+
+func (c *traceCollector) finishLegs() {
+	noEvidence := map[string]struct {
+		detail string
+		next   string
+	}{
+		"message": {
+			detail: "no parsable message copy or matching DLQ original was found",
+			next:   "verify the message id and AM_ROOT; run 'amq who --json' to inspect available sessions",
+		},
+		"route": {
+			detail: "no message header is available to establish addressing metadata",
+			next:   "locate a parsable message copy; Phase A does not persist send-time route resolver decisions",
+		},
+		"delivery": {
+			detail: "no current message or DLQ file establishes visible delivery state",
+			next:   "verify the target root and inspect sender output if it was retained; do not retry from this trace alone",
+		},
+		"dlq": {
+			detail: "no matching DLQ envelope was found",
+			next:   "if a DLQ transition was expected, run 'amq dlq list --me <consumer> --json' in the target root",
+		},
+		"receipts": {
+			detail: "no drained or dlq delivery receipt was found",
+			next:   "run 'amq receipts list --me <consumer> --msg-id " + c.messageID + " --json' for the expected consumer",
+		},
+		"thread": {
+			detail: "no message refs connect another message to this id",
+			next:   "inspect the message thread with 'amq thread --id <thread-id> --json' when a parsable header is available",
+		},
+		"notification": {
+			detail: "notification attempt history is unavailable because Phase A has no durable attempt ledger",
+			next:   "run 'amq doctor --ops' for current wake health; do not infer historical notification success",
+		},
+	}
+	for _, name := range traceLegOrder {
+		leg := c.legs[name]
+		if errorsForLeg := c.legErrors[name]; len(errorsForLeg) > 0 {
+			leg.Status = "error"
+			leg.Detail = strings.Join(errorsForLeg, "; ")
+			leg.NextStep = "fix the reported path or permission problem, then rerun the trace"
+		} else if len(leg.Evidence) > 0 {
+			leg.Status = "evidence"
+			switch name {
+			case "route":
+				leg.Detail = "addressing metadata found; persisted send-time resolver decisions are no_evidence"
+				leg.NextStep = "use 'amq route explain' only to inspect current routing; do not treat it as historical evidence"
+			case "delivery":
+				leg.Detail = "current file visibility found; original directory sync durability is no_evidence"
+				leg.NextStep = "inspect retained send output before retrying; do not infer retry safety from current file presence"
+			}
+		} else {
+			leg.Status = "no_evidence"
+			leg.Detail = noEvidence[name].detail
+			leg.NextStep = noEvidence[name].next
+		}
+		c.legs[name] = leg
+	}
+}
+
+func (c *traceCollector) addEvidence(legName string, evidence traceEvidence) {
+	leg := c.legs[legName]
+	leg.Evidence = append(leg.Evidence, evidence)
+	c.legs[legName] = leg
+}
+
+func (c *traceCollector) addError(legName, detail string) {
+	c.legErrors[legName] = append(c.legErrors[legName], detail)
+}
+
+func (c *traceCollector) addRootError(err error) {
+	for _, name := range []string{"message", "dlq", "receipts", "thread"} {
+		c.addError(name, fmt.Sprintf("open root: %v", err))
+	}
+}
+
+func (c *traceCollector) relative(path string) string {
+	return filepath.ToSlash(path)
+}
+
+func (c *traceCollector) readDir(path string) ([]os.DirEntry, error) {
+	return c.deliveryRoot.ReadDir(path)
+}
+
+func (c *traceCollector) readHeader(path string) (format.Header, error) {
+	file, _, err := c.deliveryRoot.OpenRegularNoFollow(path)
+	if err != nil {
+		return format.Header{}, err
+	}
+	defer func() { _ = file.Close() }()
+	return format.ReadHeader(file)
+}
+
+func containsTraceString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func writeTraceText(result traceResult) error {
+	if err := writeStdout("Trace %s: %s\n", result.MessageID, result.Status); err != nil {
+		return err
+	}
+	for _, name := range traceLegOrder {
+		leg := result.Legs[name]
+		line := fmt.Sprintf("  %-12s %s", name, leg.Status)
+		if len(leg.Evidence) > 0 {
+			line += fmt.Sprintf(" (%d)", len(leg.Evidence))
+		}
+		if leg.Detail != "" {
+			line += ": " + leg.Detail
+		}
+		if err := writeStdoutLine(line); err != nil {
+			return err
+		}
+		for _, evidence := range leg.Evidence {
+			if summary := traceEvidenceText(name, evidence); summary != "" {
+				if err := writeStdout("    - %s\n", summary); err != nil {
+					return err
+				}
+			}
+		}
+		if leg.NextStep != "" {
+			if err := writeStdout("    next: %s\n", leg.NextStep); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func traceEvidenceText(legName string, evidence traceEvidence) string {
+	switch legName {
+	case "message":
+		if evidence.Message != nil {
+			return fmt.Sprintf("%s: %s -> %s", evidence.Path, evidence.Message.From, strings.Join(evidence.Message.To, ","))
+		}
+	case "route":
+		if evidence.Route != nil {
+			return fmt.Sprintf("%s -> %s; thread %s", evidence.Route.From, strings.Join(evidence.Route.To, ","), evidence.Route.Thread)
+		}
+	case "delivery":
+		return fmt.Sprintf("%s visible; durability %s", evidence.Path, evidence.Durability)
+	case "dlq":
+		if evidence.DLQ != nil {
+			return fmt.Sprintf("%s: %s (%s)", evidence.Path, evidence.DLQ.FailureReason, evidence.DLQ.FailureDetail)
+		}
+	case "receipts":
+		if evidence.Receipt != nil {
+			return fmt.Sprintf("%s by %s at %s", evidence.Receipt.Stage, evidence.Receipt.Consumer, evidence.Receipt.EmittedAt)
+		}
+	case "thread":
+		if evidence.Relation != nil {
+			return fmt.Sprintf("%s %s", evidence.Relation.Relation, evidence.Relation.MessageID)
+		}
+	}
+	return ""
+}

--- a/internal/cli/trace_test.go
+++ b/internal/cli/trace_test.go
@@ -1,0 +1,338 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type traceResultJSON struct {
+	Schema    string                  `json:"schema"`
+	MessageID string                  `json:"message_id"`
+	Status    string                  `json:"status"`
+	Legs      map[string]traceLegJSON `json:"legs"`
+}
+
+type traceLegJSON struct {
+	Status   string            `json:"status"`
+	Evidence []json.RawMessage `json:"evidence"`
+	NextStep string            `json:"next_step"`
+}
+
+func TestTraceCommandEntryPointJoinsCurrentEvidence(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+
+	sent := runSendJSONForTest(t,
+		"--root", root,
+		"--me", "alice",
+		"--to", "bob",
+		"--subject", "trace target",
+		"--body", "please trace this",
+		"--json",
+	)
+	messageID, _ := sent["id"].(string)
+	if messageID == "" {
+		t.Fatalf("send result has no id: %#v", sent)
+	}
+	if _, _, err := captureEnvOutput(t, func() error {
+		return runReply([]string{
+			"--root", root,
+			"--me", "bob",
+			"--id", messageID,
+			"--body", "reply evidence",
+			"--json",
+		})
+	}); err != nil {
+		t.Fatalf("runReply: %v", err)
+	}
+
+	if _, err := deliverToInboxForTest(t, root, "alice", messageID+".md", []byte("malformed trace fixture")); err != nil {
+		t.Fatalf("deliver malformed message: %v", err)
+	}
+	drainCmd := exec.Command(os.Args[0], "drain", "--me", "alice", "--root", root, "--json")
+	drainCmd.Env = append(os.Environ(), cliHelperEnv+"=1", "AMQ_NO_UPDATE_CHECK=1")
+	if output, err := drainCmd.CombinedOutput(); err != nil {
+		t.Fatalf("drain malformed message: %v\noutput: %s", err, output)
+	}
+
+	cmd := exec.Command(os.Args[0], "trace", messageID, "--root", root, "--json")
+	cmd.Env = append(os.Environ(), cliHelperEnv+"=1", "AMQ_NO_UPDATE_CHECK=1")
+	stdout, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("trace command failed: %v\nstderr: %s", err, exitErr.Stderr)
+		}
+		t.Fatalf("trace command failed: %v", err)
+	}
+
+	var result traceResultJSON
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		t.Fatalf("unmarshal trace JSON: %v\nstdout: %s", err, stdout)
+	}
+	if result.Schema != "amq/trace/v1" || result.MessageID != messageID || result.Status != "found" {
+		t.Fatalf("trace identity/status = %#v", result)
+	}
+	for _, name := range []string{"message", "route", "delivery", "dlq", "receipts", "thread"} {
+		leg := result.Legs[name]
+		if leg.Status != "evidence" || len(leg.Evidence) == 0 {
+			t.Fatalf("%s leg = %#v", name, leg)
+		}
+	}
+	deliveryEvidence := decodeTraceEvidence(t, result.Legs["delivery"].Evidence[0])
+	if deliveryEvidence["authority"] == "" || deliveryEvidence["durability"] != "no_evidence" {
+		t.Fatalf("delivery evidence contract = %#v", deliveryEvidence)
+	}
+	dlqEvidence := decodeTraceEvidence(t, result.Legs["dlq"].Evidence[0])
+	dlq, _ := dlqEvidence["dlq"].(map[string]any)
+	if dlq["original_id"] != messageID {
+		t.Fatalf("dlq evidence contract = %#v", dlqEvidence)
+	}
+	receiptEvidence := decodeTraceEvidence(t, result.Legs["receipts"].Evidence[0])
+	receiptRecord, _ := receiptEvidence["receipt"].(map[string]any)
+	if receiptRecord["msg_id"] != messageID || receiptRecord["stage"] == "" {
+		t.Fatalf("receipt evidence contract = %#v", receiptEvidence)
+	}
+	threadEvidence := decodeTraceEvidence(t, result.Legs["thread"].Evidence[0])
+	relation, _ := threadEvidence["relation"].(map[string]any)
+	if relation["message_id"] == "" || relation["relation"] == "" {
+		t.Fatalf("thread evidence contract = %#v", threadEvidence)
+	}
+	notification := result.Legs["notification"]
+	if notification.Status != "no_evidence" || notification.NextStep == "" {
+		t.Fatalf("notification leg = %#v", notification)
+	}
+
+	textOutput, _ := captureOutput(t, func() error {
+		return runTrace([]string{messageID, "--root", root})
+	})
+	for _, want := range []string{"parse_error", "dlq by alice", "references_target", "durability no_evidence"} {
+		if !strings.Contains(textOutput, want) {
+			t.Fatalf("trace text missing %q:\n%s", want, textOutput)
+		}
+	}
+}
+
+func TestTraceMissingMessageEmitsContractAndNotFoundExit(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _ := captureOutput(t, func() error {
+		err := runTrace([]string{"missing-message", "--root", root, "--json"})
+		if err == nil || GetExitCode(err) != ExitNotFound {
+			t.Fatalf("trace missing error = %v, exit = %d", err, GetExitCode(err))
+		}
+		return nil
+	})
+
+	var result traceResultJSON
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal trace JSON: %v\nstdout: %s", err, stdout)
+	}
+	if result.Status != "not_found" {
+		t.Fatalf("status = %q, want not_found", result.Status)
+	}
+	for name, leg := range result.Legs {
+		if leg.Status != "no_evidence" {
+			t.Fatalf("%s status = %q, want no_evidence", name, leg.Status)
+		}
+		if leg.NextStep == "" {
+			t.Fatalf("%s no_evidence leg has no next_step", name)
+		}
+	}
+}
+
+func TestTraceOutboxCopyDoesNotEstablishDelivery(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	sent := runSendJSONForTest(t,
+		"--root", root,
+		"--me", "alice",
+		"--to", "bob",
+		"--body", "outbox is not delivery proof",
+		"--json",
+	)
+	messageID, _ := sent["id"].(string)
+	if err := os.Remove(filepath.Join(fsq.AgentInboxNew(root, "bob"), messageID+".md")); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _ := captureOutput(t, func() error {
+		return runTrace([]string{messageID, "--root", root, "--json"})
+	})
+	var result traceResultJSON
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal trace JSON: %v\nstdout: %s", err, stdout)
+	}
+	if result.Status != "found" {
+		t.Fatalf("status = %q, want found from message evidence", result.Status)
+	}
+	if leg := result.Legs["message"]; leg.Status != "evidence" || len(leg.Evidence) == 0 {
+		t.Fatalf("message leg = %#v", leg)
+	}
+	delivery := result.Legs["delivery"]
+	if delivery.Status != "no_evidence" || delivery.NextStep == "" {
+		t.Fatalf("outbox incorrectly established delivery: %#v", delivery)
+	}
+}
+
+func TestTraceInboxCurWithoutReceiptDoesNotInferDrain(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	sent := runSendJSONForTest(t,
+		"--root", root,
+		"--me", "alice",
+		"--to", "bob",
+		"--body", "legacy cur fixture",
+		"--json",
+	)
+	messageID, _ := sent["id"].(string)
+	if err := fsq.MoveNewToCur(openDeliveryRootForCLITest(t, root), "bob", messageID+".md"); err != nil {
+		t.Fatalf("MoveNewToCur: %v", err)
+	}
+
+	stdout, _ := captureOutput(t, func() error {
+		return runTrace([]string{messageID, "--root", root, "--json"})
+	})
+	var result traceResultJSON
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("unmarshal trace JSON: %v\nstdout: %s", err, stdout)
+	}
+	if delivery := result.Legs["delivery"]; delivery.Status != "evidence" || len(delivery.Evidence) != 1 {
+		t.Fatalf("delivery leg = %#v", delivery)
+	}
+	receiptLeg := result.Legs["receipts"]
+	if receiptLeg.Status != "no_evidence" || receiptLeg.NextStep == "" {
+		t.Fatalf("receipt leg inferred a drain: %#v", receiptLeg)
+	}
+
+	textOutput, _ := captureOutput(t, func() error {
+		return runTrace([]string{messageID, "--root", root})
+	})
+	if strings.Contains(textOutput, "drained by") {
+		t.Fatalf("trace inferred drain from inbox/cur:\n%s", textOutput)
+	}
+}
+
+func TestTraceDegradesOnIncompleteMailboxLayout(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "agents", "orphan"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	result := collectTrace(root, "absent")
+	for _, name := range []string{"message", "dlq", "receipts", "thread"} {
+		leg := result.Legs[name]
+		if leg.Status != "error" || leg.Detail == "" || leg.NextStep == "" {
+			t.Fatalf("%s leg hid missing mailbox components: %#v", name, leg)
+		}
+	}
+
+	stdout, _ := captureOutput(t, func() error {
+		err := runTrace([]string{"absent", "--root", root})
+		if err == nil || GetExitCode(err) != ExitNotFound {
+			t.Fatalf("trace incomplete root error = %v, exit = %d", err, GetExitCode(err))
+		}
+		return nil
+	})
+	for _, want := range []string{"Trace absent: not_found", "no_evidence", "next:"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("trace text missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestTraceDoesNotFollowAgentsSymlinkOutsidePinnedRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(outside, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	sent := runSendJSONForTest(t,
+		"--root", outside,
+		"--me", "alice",
+		"--to", "bob",
+		"--body", "must stay outside",
+		"--json",
+	)
+	messageID, _ := sent["id"].(string)
+	if err := os.Symlink(filepath.Join(outside, "agents"), filepath.Join(root, "agents")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	result := collectTrace(root, messageID)
+	if result.Status != "not_found" {
+		t.Fatalf("status = %q, want not_found", result.Status)
+	}
+	message := result.Legs["message"]
+	if message.Status != "error" || len(message.Evidence) != 0 || message.NextStep == "" {
+		t.Fatalf("message leg followed outside root or hid error: %#v", message)
+	}
+}
+
+func TestTraceReportsUnreadableJoinInputsInsteadOfNoEvidence(t *testing.T) {
+	root := t.TempDir()
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatalf("EnsureAgentDirs(%s): %v", agent, err)
+		}
+	}
+	sent := runSendJSONForTest(t,
+		"--root", root,
+		"--me", "alice",
+		"--to", "bob",
+		"--body", "valid target",
+		"--json",
+	)
+	messageID, _ := sent["id"].(string)
+	deliveryRoot := openDeliveryRootForCLITest(t, root)
+	for _, dir := range []string{
+		filepath.Join("agents", "bob", "inbox", "new"),
+		filepath.Join("agents", "bob", "dlq", "new"),
+	} {
+		if _, err := deliveryRoot.WriteFileAtomic(dir, "broken.md", []byte("not an envelope"), 0o600); err != nil {
+			t.Fatalf("write corrupt join input: %v", err)
+		}
+	}
+
+	result := collectTrace(root, messageID)
+	if result.Status != "partial" {
+		t.Fatalf("status = %q, want partial", result.Status)
+	}
+	for _, name := range []string{"thread", "dlq"} {
+		leg := result.Legs[name]
+		if leg.Status != "error" || leg.NextStep == "" {
+			t.Fatalf("%s leg hid unreadable input: %#v", name, leg)
+		}
+	}
+}
+
+func decodeTraceEvidence(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var evidence map[string]any
+	if err := json.Unmarshal(raw, &evidence); err != nil {
+		t.Fatalf("unmarshal trace evidence: %v\nraw: %s", err, raw)
+	}
+	return evidence
+}

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -235,30 +235,44 @@ func (r *DeliveryRoot) SyncDir(name string) error {
 // ReadRegularNoFollow reads a root-relative regular file while refusing an
 // initially symlinked artifact and detecting replacement between lstat/open.
 func (r *DeliveryRoot) ReadRegularNoFollow(name string) ([]byte, error) {
-	if err := r.VerifyBase(); err != nil {
-		return nil, err
-	}
-	before, err := r.root.Lstat(name)
-	if err != nil {
-		return nil, err
-	}
-	if err := validateRegularNoFollowFile(r.displayPath(name), before); err != nil {
-		return nil, err
-	}
-	file, err := openRegularNoFollowRoot(r.root, name)
+	file, _, err := r.OpenRegularNoFollow(name)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = file.Close() }()
+	return io.ReadAll(file)
+}
+
+// OpenRegularNoFollow opens a root-relative regular file through the pinned
+// capability while refusing symlinks and detecting replacement during open.
+// The caller must close the returned file.
+func (r *DeliveryRoot) OpenRegularNoFollow(name string) (*os.File, os.FileInfo, error) {
+	if err := r.VerifyBase(); err != nil {
+		return nil, nil, err
+	}
+	before, err := r.root.Lstat(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateRegularNoFollowFile(r.displayPath(name), before); err != nil {
+		return nil, nil, err
+	}
+	file, err := openRegularNoFollowRoot(r.root, name)
+	if err != nil {
+		return nil, nil, err
+	}
 	after, err := file.Stat()
 	if err != nil {
-		return nil, err
+		_ = file.Close()
+		return nil, nil, err
 	}
 	if err := validateRegularNoFollowFile(r.displayPath(name), after); err != nil {
-		return nil, err
+		_ = file.Close()
+		return nil, nil, err
 	}
 	if !os.SameFile(before, after) {
-		return nil, fmt.Errorf("queue artifact changed while opening: %s", r.displayPath(name))
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("queue artifact changed while opening: %s", r.displayPath(name))
 	}
-	return io.ReadAll(file)
+	return file, after, nil
 }

--- a/internal/fsq/delivery_root_regular_test.go
+++ b/internal/fsq/delivery_root_regular_test.go
@@ -1,0 +1,32 @@
+package fsq
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeliveryRootOpenRegularNoFollow(t *testing.T) {
+	base := t.TempDir()
+	if err := os.WriteFile(filepath.Join(base, "message.md"), []byte("header only"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := openDeliveryRootForTest(t, base)
+	file, info, err := root.OpenRegularNoFollow("message.md")
+	if err != nil {
+		t.Fatalf("OpenRegularNoFollow: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	if !info.Mode().IsRegular() {
+		t.Fatalf("mode = %v, want regular", info.Mode())
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "header only" {
+		t.Fatalf("data = %q", data)
+	}
+}

--- a/internal/receipt/receipt.go
+++ b/internal/receipt/receipt.go
@@ -142,6 +142,15 @@ func Read(path string) (Receipt, error) {
 	return parseReceipt(data)
 }
 
+// ReadDeliveryRoot reads a receipt through an already authorized queue root.
+func ReadDeliveryRoot(root *fsq.DeliveryRoot, path string) (Receipt, error) {
+	data, err := root.ReadRegularNoFollow(path)
+	if err != nil {
+		return Receipt{}, err
+	}
+	return parseReceipt(data)
+}
+
 func parseReceipt(data []byte) (Receipt, error) {
 	var r Receipt
 	if err := json.Unmarshal(data, &r); err != nil {


### PR DESCRIPTION
## Summary
- add a read-only amq trace command with stable amq/trace/v1 JSON and concise evidence text
- join message copies, addressing metadata, visible delivery artifacts, DLQ envelopes, receipts, and directional thread refs by message ID
- report explicit no_evidence and actionable next steps without inferring route history, fsync durability, retry safety, or notification success
- keep all reads pinned to one physical queue root and distinguish missing mailbox paths from empty evidence

Advances #283 with standalone Phase A. The future notification-attempt ledger remains out of scope and is reported explicitly as no_evidence.

## Verification
- full Go suite on working tree and clean archive
- go vet on Darwin, Linux, and Windows
- golangci-lint and skill-link checks
- actual CLI E2E sends malformed input through real drain, then traces its DLQ envelope and receipt
- frozen binary exercised on full-chain, cross-session outbox-only, legacy cur-without-receipt, malformed session2, and nonexistent-ID cases

Peer-reviewed exact tree: 018f3546588308d1d71d2028fc7e23006d19165f