### PR TITLE
fix(release): reconcile labels after attestation failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,7 @@ jobs:
           )
           PY
       - name: Release
+        id: publish_release
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
@@ -187,7 +188,7 @@ jobs:
           subject-path: ${{ steps.attestation_subjects.outputs.subjects }}
 
       - name: Mark release pull request as tagged
-        if: github.event_name == 'push'
+        if: always() && steps.publish_release.outcome == 'success'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/test_release_please_config.py
+++ b/scripts/test_release_please_config.py
@@ -74,7 +74,8 @@ def test_release_workflow_marks_published_release_pr_as_tagged() -> None:
     assert publish < attest < mark_tagged
 
     mark_step = release_job[mark_tagged:]
-    assert "if: github.event_name == 'push'" in mark_step
+    assert "if: always() && steps.publish_release.outcome == 'success'" in mark_step
+    assert "if: github.event_name == 'push'" not in mark_step
     assert "RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}" in mark_step
     assert "VERSION: ${{ needs.prepare.outputs.version }}" in mark_step
     assert 'commits/${RELEASE_SHA}/pulls' in mark_step


### PR DESCRIPTION
## Summary

- reconcile release-please labels even when artifact attestation or a later step fails
- allow workflow-dispatch recovery of a stranded `autorelease: pending` label
- require successful GoReleaser publication before claiming the PR is tagged
- pin the condition in the release workflow regression test

## Why

The label reconciliation step previously used default success semantics and was
push-only. If artifact attestation failed after GoReleaser published the
release, reconciliation was skipped and the merged release PR retained
`autorelease: pending`; release-please can then stop producing release PRs
without surfacing a workflow failure.

Bare `always()` would create the opposite false positive by marking a failed
publication as tagged. The named `publish_release` step makes successful
publication the evidence gate.

## Verification

- `python3 scripts/test_release_please_config.py`
- `make test`
- `make smoke`
- `git diff --check`

Frozen tree: `f392ed58ba1ebcab388b04e69d40a6b9ddbe3851`

Reviewed by Claude against the pre-commit content; PASS.
