### PR TITLE
fix(wake): retry held notifications after pgrp handoff

### DIFF
--- a/internal/cli/wake_terminal_authority_unix.go
+++ b/internal/cli/wake_terminal_authority_unix.go
@@ -17,6 +17,7 @@ type wakeTerminalAuthorityLossKind uint8
 const (
 	wakeTerminalAuthorityLossUnknown wakeTerminalAuthorityLossKind = iota
 	wakeTerminalAuthorityLossControlStopped
+	wakeTerminalAuthorityLossForegroundPGRPChanged
 )
 
 type wakeTerminalAuthorityLossError struct {
@@ -45,6 +46,12 @@ func isWakeTerminalControlStopped(err error) bool {
 	var loss *wakeTerminalAuthorityLossError
 	return errors.As(err, &loss) &&
 		loss.Kind == wakeTerminalAuthorityLossControlStopped
+}
+
+func isWakeTerminalForegroundPGRPChanged(err error) bool {
+	var loss *wakeTerminalAuthorityLossError
+	return errors.As(err, &loss) &&
+		loss.Kind == wakeTerminalAuthorityLossForegroundPGRPChanged
 }
 
 var (
@@ -251,13 +258,9 @@ func (authority *wakeTerminalAuthority) validateLocked() error {
 		return newWakeTerminalAuthorityLoss("recheck controlling-terminal foreground process group", err)
 	}
 	if foregroundPGRP != authority.foregroundPGRP {
-		return newWakeTerminalAuthorityLoss(
-			fmt.Sprintf(
-				"controlling-terminal foreground process group changed from %d to %d",
-				authority.foregroundPGRP,
-				foregroundPGRP,
-			),
-			nil,
+		return newWakeTerminalForegroundPGRPChangedLoss(
+			authority.foregroundPGRP,
+			foregroundPGRP,
 		)
 	}
 	return nil
@@ -293,5 +296,16 @@ func newWakeTerminalControlStoppedLoss() error {
 	return &wakeTerminalAuthorityLossError{
 		Kind:   wakeTerminalAuthorityLossControlStopped,
 		Reason: "wake control stopped",
+	}
+}
+
+func newWakeTerminalForegroundPGRPChangedLoss(expected, current int) error {
+	return &wakeTerminalAuthorityLossError{
+		Kind: wakeTerminalAuthorityLossForegroundPGRPChanged,
+		Reason: fmt.Sprintf(
+			"controlling-terminal foreground process group changed from %d to %d",
+			expected,
+			current,
+		),
 	}
 }

--- a/internal/cli/wake_terminal_authority_unix_test.go
+++ b/internal/cli/wake_terminal_authority_unix_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 type wakeTerminalInjection struct {
@@ -431,6 +432,7 @@ func TestWakeTerminalAuthorityRefusesSamePathForegroundPGRPHandoff(t *testing.T)
 	fixture.foregroundPGRP++
 	err = authority.Inject("must-not-arrive")
 	if !isWakeTerminalAuthorityLoss(err) ||
+		!isWakeTerminalForegroundPGRPChanged(err) ||
 		!strings.Contains(err.Error(), "foreground process group changed") {
 		t.Fatalf("same-path foreground-pgrp handoff error = %v", err)
 	}
@@ -702,8 +704,108 @@ func TestRunWakeLoopTerminatesOnTerminalAuthorityLoss(t *testing.T) {
 	if !isWakeTerminalAuthorityLoss(err) || !errors.Is(err, loss) {
 		t.Fatalf("wake loop authority-loss result = %v", err)
 	}
+	if isWakeTerminalForegroundPGRPChanged(err) {
+		t.Fatalf("generic authority loss classified as foreground-pgrp change: %v", err)
+	}
 	if terminalWriteCalled {
 		t.Fatal("wake loop wrote after terminal authority loss")
+	}
+}
+
+func TestRunWakeLoopHoldsNotificationDuringForegroundPGRPMismatch(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "foreground-pgrp-mismatch",
+			From:    "sender",
+			To:      []string{"codex"},
+			Thread:  "p2p/sender__codex",
+			Subject: "wake",
+			Created: time.Now().UTC().Format(time.RFC3339),
+		},
+		Body: "durable body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	messagePath := filepath.Join(
+		fsq.AgentInboxNew(root, "codex"),
+		"foreground-pgrp-mismatch.md",
+	)
+	if err := os.WriteFile(messagePath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	firstRefused := make(chan struct{}, 1)
+	restored := make(chan struct{})
+	delivered := make(chan struct{}, 1)
+	controlStop := make(chan struct{})
+	runDone := make(chan error, 1)
+
+	go func() {
+		runDone <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			injectMode:  wakeInjectModeRaw,
+			controlStop: controlStop,
+			beforeTerminalWrite: func() error {
+				select {
+				case <-restored:
+					return nil
+				default:
+					select {
+					case firstRefused <- struct{}{}:
+					default:
+					}
+					return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+				}
+			},
+			terminalWrite: func(string) error {
+				select {
+				case delivered <- struct{}{}:
+				default:
+				}
+				return nil
+			},
+		})
+	}()
+
+	select {
+	case <-firstRefused:
+	case err := <-runDone:
+		t.Fatalf("wake loop exited on foreground-pgrp mismatch: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not attempt held notification")
+	}
+
+	select {
+	case <-delivered:
+		t.Fatal("wake loop wrote while foreground pgrp mismatched")
+	case err := <-runDone:
+		t.Fatalf("wake loop exited while foreground pgrp mismatched: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(restored)
+	select {
+	case <-delivered:
+	case err := <-runDone:
+		t.Fatalf("wake loop exited before delivering held notification: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("held notification was not delivered after foreground pgrp restored")
+	}
+
+	close(controlStop)
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("wake loop after restored delivery: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop")
 	}
 }
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -24,13 +24,14 @@ import (
 )
 
 var (
-	wakeTerminateGrace   = 100 * time.Millisecond
-	wakeBaselineTimeout  = 5 * time.Second
-	wakeBaselineSettle   = 50 * time.Millisecond
-	getWakeCurrentTTY    = getCurrentTTY
-	getWakeProcessSID    = unix.Getsid
-	wakeTIOCSTIAvailable = func() bool { return tiocsti.Available() }
-	wakeInputIsTTY       = func() bool { return tiocsti.IsTTY() }
+	wakeTerminateGrace              = 100 * time.Millisecond
+	wakeBaselineTimeout             = 5 * time.Second
+	wakeBaselineSettle              = 50 * time.Millisecond
+	wakeTerminalAuthorityRetryDelay = 250 * time.Millisecond
+	getWakeCurrentTTY               = getCurrentTTY
+	getWakeProcessSID               = unix.Getsid
+	wakeTIOCSTIAvailable            = func() bool { return tiocsti.Available() }
+	wakeInputIsTTY                  = func() bool { return tiocsti.IsTTY() }
 )
 
 type fsnotifyWakeEventWatcher struct {
@@ -2270,6 +2271,66 @@ func runWakeLoop(cfg wakeConfig) error {
 	// Debounce timer
 	var debounceTimer *time.Timer
 	pendingNotify := false
+	var terminalAuthorityRetryTimer *time.Timer
+	var terminalAuthorityRetryC <-chan time.Time
+	defer func() {
+		if terminalAuthorityRetryTimer != nil {
+			terminalAuthorityRetryTimer.Stop()
+		}
+	}()
+
+	clearTerminalAuthorityRetry := func() {
+		terminalAuthorityRetryC = nil
+		if terminalAuthorityRetryTimer == nil {
+			return
+		}
+		if !terminalAuthorityRetryTimer.Stop() {
+			select {
+			case <-terminalAuthorityRetryTimer.C:
+			default:
+			}
+		}
+	}
+	scheduleTerminalAuthorityRetry := func() {
+		if terminalAuthorityRetryTimer == nil {
+			terminalAuthorityRetryTimer = time.NewTimer(wakeTerminalAuthorityRetryDelay)
+		} else {
+			if !terminalAuthorityRetryTimer.Stop() {
+				select {
+				case <-terminalAuthorityRetryTimer.C:
+				default:
+				}
+			}
+			terminalAuthorityRetryTimer.Reset(wakeTerminalAuthorityRetryDelay)
+		}
+		terminalAuthorityRetryC = terminalAuthorityRetryTimer.C
+	}
+	attemptNotification := func() error {
+		err := notifyNewMessages(&cfg)
+		if err == nil {
+			pendingNotify = false
+			clearTerminalAuthorityRetry()
+			return nil
+		}
+		if isWakeTerminalForegroundPGRPChanged(err) {
+			pendingNotify = true
+			scheduleTerminalAuthorityRetry()
+			if cfg.debug {
+				_ = writeStderr(
+					"amq wake [debug]: holding notification until foreground process group is restored: %v\n",
+					err,
+				)
+			}
+			return nil
+		}
+		pendingNotify = false
+		clearTerminalAuthorityRetry()
+		if isWakeTerminalAuthorityLoss(err) {
+			return err
+		}
+		_ = writeStderr("amq wake: notify error: %v\n", err)
+		return nil
+	}
 
 	// TTY health check timer - verify we can still inject every 30s
 	healthTicker := time.NewTicker(30 * time.Second)
@@ -2283,11 +2344,8 @@ func runWakeLoop(cfg wakeConfig) error {
 	}
 
 	// Notify if messages already exist
-	if err := notifyNewMessages(&cfg); err != nil {
-		if isWakeTerminalAuthorityLoss(err) {
-			return err
-		}
-		_ = writeStderr("amq wake: notify error: %v\n", err)
+	if err := attemptNotification(); err != nil {
+		return err
 	}
 
 	for {
@@ -2341,14 +2399,19 @@ func runWakeLoop(cfg wakeConfig) error {
 			if !pendingNotify {
 				continue
 			}
-			pendingNotify = false
 
 			// Collect and notify
-			if err := notifyNewMessages(&cfg); err != nil {
-				if isWakeTerminalAuthorityLoss(err) {
-					return err
-				}
-				_ = writeStderr("amq wake: notify error: %v\n", err)
+			if err := attemptNotification(); err != nil {
+				return err
+			}
+
+		case <-terminalAuthorityRetryC:
+			terminalAuthorityRetryC = nil
+			if !pendingNotify {
+				continue
+			}
+			if err := attemptNotification(); err != nil {
+				return err
 			}
 
 		case <-healthTicker.C:


### PR DESCRIPTION
## Summary

- distinguish temporary foreground-process-group handoff from permanent terminal-authority loss
- hold pending wake notifications and retry without requiring another inbox event
- deliver the held doorbell after the original foreground process group returns
- retain fatal behavior for generation drift, TTY identity loss, control stop, and other unknown authority loss

## Why

In the default coop path, suspending the agent temporarily changes the
terminal's foreground process group. If a message arrives during that window,
the authority check correctly refuses injection but `runWakeLoop` treated the
temporary mismatch as fatal and exited permanently. Returning to the agent left
the session without a notifier.

This change gives only the foreground-PGRP mismatch its own typed outcome and
retries it on a bounded timer. It does not widen recovery for permanent
authority loss.

## Verification

- `go test -race ./internal/cli -run 'Test(WakeTerminalAuthority|RunWakeLoop)' -count=1`
- `go test ./internal/cli -run Wake -count=1`
- `make test`
- `make smoke`
- `make fmt-check`
- `go vet ./...`
- `make build`
- `git diff --check`

Frozen tree: `096d929cef048f4c64a9b6903fd0b5bf96e706bf`

Full-index binary diff SHA-256:
`1f5aa7e9acde461298d1a6da11a8969b09b1049c0c85d2dc5eb15d6ccbc5b62e`

Claude reviewed the immutable tree and returned PASS. A live PTY handoff remains
an explicit post-merge smoke because it could not be driven from the
non-interactive review shell; the regression uses the real loop and inbox with
a controlled PGRP source.
