### PR TITLE
docs: correct wake interrupt and repair guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,10 @@ amq who [--json]
 amq doctor [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json]
 ```
 
-Common flags: `--root`, `--json`, `--strict` (error instead of warn on unknown handles or unreadable/corrupt config). Global option: `--no-update-check`. Note: `init` has its own flags and doesn't accept these.
+`--root` is accepted only where it is listed above. Participating commands may
+also accept `--json` and `--strict` (error instead of warn on unknown handles or
+unreadable/corrupt config). Global option: `--no-update-check`. Note: `init` has
+its own flags and doesn't accept these.
 
 **Body resolution (`send`/`reply`)**: `--body` resolves from `@file`, a literal string, or stdin. A bare `--body -`, `--body @-`, or an omitted `--body` reads stdin (standard CLI convention). A send whose resolved body is empty or whitespace-only **fails closed** with a usage error rather than delivering a blank message — pass `--allow-empty` to send a blank body intentionally. This prevents a dropped or mistyped body (e.g. `--body -` with nothing piped) from silently shipping an empty message.
 
@@ -367,10 +370,11 @@ Wake lock states are intentionally conservative:
 - `stale`: AMQ proved the recorded PID is gone, mismatched, or not the same `amq wake`; `amq doctor --ops --fix-wake-locks` re-inspects and removes only these locks.
 - `unverified`: AMQ could not prove either ownership or staleness, so startup fails closed and doctor leaves the lock in place. Confirm the PID/root/agent manually before removing the `.wake.lock`.
 
-Live wake repair is explicit: `amq wake repair --me <agent>` may remove a
-proven-stale lock and start a fresh wake only when the stale lock was created
-for `--inject-via`, and `agents/<agent>/.wake.target` exists with a digest that
-matches the lock's repair metadata. `.wake.target` is mode `0600` and stores
+Live wake repair is explicit: `amq wake repair --me <agent>` may replace a
+proven-stale lock or supersede an unverified ownerless generic lock and start a
+fresh wake only when the lock was created for `--inject-via`, and
+`agents/<agent>/.wake.target` exists with a digest that matches the lock's
+repair metadata. `.wake.target` is mode `0600` and stores
 schema metadata, root, agent, creation time, `mode:"inject-via"`, an absolute
 executable path, and fixed argv. The private mode-`0600` `.wake.repair-floor`
 must also match the exact generation, target, physical root, boot, and owner
@@ -379,7 +383,9 @@ that wake, never message IDs. Repair hands that floor to the replacement rather
 than re-snapshotting `inbox/new`, so downtime arrivals and same-name DLQ retries
 remain eligible. Missing, corrupt, or mismatched floor state requires a normal
 wake restart. Raw TTY wake has no repair target; repair must refuse raw locks,
-leftover targets from old locks, and `unverified` locks.
+leftover targets from old locks, and unverified owner-bound or invalid claims.
+An unverified ownerless generic claim is superseded only after its target and
+continuity state pass the same fail-closed validation.
 Repaired wake stdout/stderr goes to
 `agents/<agent>/.wake.repair.log`; repair itself must not keep stdout/stderr
 pipes open after its JSON/text output exits. `doctor --ops` may report
@@ -483,7 +489,8 @@ amq coop init && eval "$(amq env --me claude)"
 ### Message Priority Handling
 
 When you see a notification, run `amq drain --include-body`:
-- **urgent** → Interrupt current work, respond immediately (label `interrupt` enables wake Ctrl+C)
+- **urgent** → Interrupt current work and respond immediately. Label
+  `interrupt` enables an interrupt notice; it never enables Ctrl+C by itself.
 - **normal** → Add to TodoWrite, respond when current task done
 - **low** → Batch for end of session
 
@@ -556,15 +563,19 @@ See `.claude/skills/amq-cli/SKILL.md` for the agent-facing workflow.
 - **Task workflow**: `amq swarm join`, `amq swarm tasks`, `amq swarm claim`, `amq swarm complete`, `amq swarm fail`, `amq swarm block`
 - **Notifications**: `amq swarm bridge` watches the shared task list and delivers AMQ messages labeled `swarm` into the agent's inbox
 
-**Wake compatibility**: bridge notifications are standard AMQ inbox messages, so `amq wake` will detect them automatically. If you want swarm notifications to trigger wake interrupts, configure wake to match the bridge label and priority:
+**Wake compatibility**: bridge notifications are standard AMQ inbox messages,
+so `amq wake` detects them automatically. Bridge lifecycle events are hardcoded
+`priority=normal` plus label `swarm`; do not bind that combination to Ctrl+C.
+Use ordinary non-destructive wake:
 
 ```bash
-amq wake --me codex --interrupt-label swarm --interrupt-priority normal --interrupt-cmd ctrl-c &
+amq wake --me codex --interrupt-cmd none &
 ```
 
 `--interrupt-cmd ctrl-c` is an explicit destructive opt-in: it sends a real
-SIGINT to the foreground process group and can interrupt or crash the agent.
-Omit it to keep the notice and bell without injecting Ctrl+C.
+SIGINT to the foreground process group and can interrupt or crash the agent. If
+process-level interruption is intentional, match a separate operator-controlled
+label/priority that the swarm bridge does not emit.
 
 **Direct messaging (A2A)**: the bridge only emits task lifecycle notifications.
 

--- a/README.md
+++ b/README.md
@@ -223,11 +223,12 @@ an unsupported platform. AMQ leaves `unverified` locks in place; inspect the PID
 and remove the named `.wake.lock` manually only after confirming no matching
 `amq wake` still owns that agent/root.
 
-`amq wake repair` is an explicit live-session repair path. It only runs when
-the lock is proven `stale`, the lock was created for `--inject-via`, and the
-agent has a saved `agents/<agent>/.wake.target` whose digest matches the lock's
-repair metadata. It also requires AMQ's private `.wake.repair-floor` to match
-the exact dead generation, boot, physical queue root, owner state, and target.
+`amq wake repair` is an explicit live-session repair path. It runs when the lock
+is proven `stale` or is an unverified ownerless generic claim, the lock was
+created for `--inject-via`, and the agent has a saved
+`agents/<agent>/.wake.target` whose digest matches the lock's repair metadata.
+It also requires AMQ's private `.wake.repair-floor` to match the exact dead
+generation, boot, physical queue root, owner state, and target.
 That floor carries only the existing-message identities already suppressed by
 the dead wake (device, inode, and ctime), never message IDs. A repaired wake
 inherits it instead of re-snapshotting `inbox/new`, so messages delivered while
@@ -235,8 +236,9 @@ the notifier was down remain eligible to notify and same-name DLQ retries
 remain eligible when their file identity changes. Missing, corrupt, or
 mismatched continuity state fails closed and requires a normal wake restart.
 Repair refuses raw terminal wake targets, leftover targets from old locks, and
-`unverified` locks to avoid double-injecting into an active session or injecting
-into the wrong terminal. Repaired wake output goes to
+unverified owner-bound or invalid claims. It supersedes an unverified ownerless
+generic claim only after the saved target and continuity state pass the same
+fail-closed validation. Repaired wake output goes to
 `agents/<agent>/.wake.repair.log`; `doctor --ops` can report whether repair is
 available, but it never starts a wake process.
 

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -1574,6 +1574,21 @@ func TestBuildCoopWakeArgsIncludesInjectViaTarget(t *testing.T) {
 	}
 }
 
+func TestWakeRepairHelpDescribesUnverifiedGenericSupersession(t *testing.T) {
+	stdout, _, err := captureWakeRepairOutput(t, func() error {
+		return runWakeRepair([]string{"--help"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "unverified ownerless generic locks") {
+		t.Fatalf("wake repair help omits generic supersession contract:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "Refuses unverified locks") {
+		t.Fatalf("wake repair help retains obsolete blanket refusal:\n%s", stdout)
+	}
+}
+
 func captureWakeRepairOutput(t *testing.T, fn func() error) (stdout, stderr string, runErr error) {
 	t.Helper()
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -688,10 +688,11 @@ func runWakeRepair(args []string) error {
 	fs := flag.NewFlagSet("wake repair", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	usage := usageWithFlags(fs, "amq wake repair --me <agent> [options]",
-		"Repair a proven-stale wake by restarting it from a saved inject-via target.",
+		"Repair an eligible wake by restarting it from a saved inject-via target.",
 		"",
-		"Refuses unverified locks and raw terminal wake targets. This command only",
-		"uses .wake.target files created for --inject-via wake processes.")
+		"Accepts proven-stale or unverified ownerless generic locks. Refuses",
+		"owner-bound or invalid unverified claims and raw terminal wake targets.",
+		"This command only uses .wake.target files created for --inject-via wakes.")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -129,14 +129,16 @@ Ctrl+C by default:
 amq wake --me claude --interrupt-cmd none &
 ```
 
-Real Ctrl+C injection is a destructive opt-in:
+Swarm bridge events are hardcoded `priority=normal` plus label `swarm`, so do
+not bind that combination to Ctrl+C. Use ordinary non-destructive wake:
 ```bash
-amq wake --me codex --interrupt-label swarm --interrupt-priority normal --interrupt-cmd ctrl-c &
+amq wake --me codex --interrupt-cmd none &
 ```
 
 `--interrupt-cmd ctrl-c` sends a real SIGINT to the foreground process group
-and can interrupt or crash the agent. Use it only when that process-level
-interruption is intentional.
+and can interrupt or crash the agent. Use it only with a separate,
+operator-controlled label/priority when process-level interruption is
+intentional; the `interrupt` label alone never enables Ctrl+C.
 
 ## Statusline (Claude Code)
 

--- a/skills/amq-cli/references/coop-mode.md
+++ b/skills/amq-cli/references/coop-mode.md
@@ -70,7 +70,9 @@ Leader prepares commit -> user approves -> push
 
 ## Interrupts
 
-- Urgent messages labeled `interrupt` trigger wake Ctrl+C injection + an interrupt notice (when wake is running).
+- Urgent messages labeled `interrupt` trigger an interrupt notice when wake is
+  running. The label never enables Ctrl+C by itself; real SIGINT requires the
+  explicit destructive opt-in `--interrupt-cmd ctrl-c`.
 - Input injection can activate a focused permission or approval dialog. Payload
   text alone may match single-key shortcuts, so removing Enter is not safe.
 - `--defer-while-input` reduces collisions with recent typing but cannot detect


### PR DESCRIPTION
## Summary

- state clearly that the `interrupt` label enables a notice, never Ctrl+C by itself
- remove the dangerous normal+swarm→SIGINT recommendation from agent guidance
- reserve destructive Ctrl+C for a separate operator-controlled label/priority
- correct wake-repair help/docs for unverified ownerless generic supersession
- stop presenting `--root` as universal when `doctor` does not accept it
- add a two-sided regression for the executable repair-help contract

## Why

The previous swarm recipe matched every bridge lifecycle message and opted into
real SIGINT, limited only by cooldown. Separately, wake-repair help claimed all
unverified locks were refused even though current code safely supersedes
unverified ownerless generic claims after continuity validation.

These are agent-facing correctness defects: one can interrupt a live agent, and
the other causes agents to reject a supported recovery path.

## Verification

- focused wake-repair help regression
- `make test`
- `make smoke`
- `make fmt-check`
- `go vet ./...`
- `make check-skills`
- literal-safe stale-text audit
- `git diff --check`

Frozen tree: `98341bddf5e137ad1cfafd00df4219c47302b6e5`

Full-index binary diff SHA-256:
`fb3c699c66b2f12827dc697bd243cb50d3302fd9019a52bbee88eff158d0dd62`

Claude reviewed the immutable tree and returned PASS.
