### PR TITLE
fix(wake): require consecutive quiet samples

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -80,6 +80,10 @@ const (
 	// rawInjectCRDrainTimeout bounds the wait for the submit CR itself to be
 	// consumed before deciding whether the second rescue CR is safe to send.
 	rawInjectCRDrainTimeout = 1 * time.Second
+	// Three samples require two follow-up confirmations after the first quiet
+	// observation, while adding at most two poll intervals to a real idle
+	// transition. Any active sample resets the evidence.
+	requiredInputQuietSamples = 3
 	// codexTUIEnterSuppressWindow mirrors codex-tui's
 	// PASTE_ENTER_SUPPRESS_WINDOW (codex-rs/tui/src/bottom_pane/paste_burst.rs,
 	// verified at rust-v0.144.1 and main): an Enter arriving within this window
@@ -165,6 +169,7 @@ func waitForInputQuiet(
 	}
 
 	deadline := nowFn().Add(maxHold)
+	quietSamples := 0
 	for {
 		now := nowFn()
 		state, sampleErr := sample()
@@ -173,8 +178,14 @@ func waitForInputQuiet(
 		}
 
 		active, reason := state.active(now, quietFor)
-		if !active {
-			return true, "", nil
+		if active {
+			quietSamples = 0
+		} else {
+			quietSamples++
+			if quietSamples >= requiredInputQuietSamples {
+				return true, "", nil
+			}
+			reason = "quiet confirmation incomplete"
 		}
 		if !now.Before(deadline) {
 			return false, reason, nil

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -1354,6 +1354,64 @@ func TestWaitForInputQuietSamplingFailureKeepsBestEffortInjection(t *testing.T) 
 	}
 }
 
+func TestWaitForInputQuietRequiresThreeConsecutiveQuietSamples(t *testing.T) {
+	now := time.Date(2026, 7, 26, 18, 0, 0, 0, time.UTC)
+	states := []ttyInputState{
+		{},
+		{},
+		{pendingBytes: 1},
+		{},
+		{},
+		{},
+	}
+	sampleCalls := 0
+
+	allowInjection, reason, err := waitForInputQuiet(
+		func() (ttyInputState, error) {
+			state := states[sampleCalls]
+			sampleCalls++
+			return state, nil
+		},
+		func() time.Time { return now },
+		func(delay time.Duration, _ ttyInputState, _ string) {
+			now = now.Add(delay)
+		},
+		time.Second,
+		time.Second,
+		10*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowInjection || reason != "" {
+		t.Fatalf("quiet result allow=%v reason=%q", allowInjection, reason)
+	}
+	if sampleCalls != len(states) {
+		t.Fatalf("sample calls = %d, want %d", sampleCalls, len(states))
+	}
+}
+
+func TestWaitForInputQuietDemotesBeforeThreeQuietSamplesAtDeadline(t *testing.T) {
+	now := time.Date(2026, 7, 26, 18, 0, 0, 0, time.UTC)
+
+	allowInjection, reason, err := waitForInputQuiet(
+		func() (ttyInputState, error) { return ttyInputState{}, nil },
+		func() time.Time { return now },
+		func(delay time.Duration, _ ttyInputState, _ string) {
+			now = now.Add(delay)
+		},
+		time.Second,
+		5*time.Millisecond,
+		10*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowInjection || reason != "quiet confirmation incomplete" {
+		t.Fatalf("deadline result allow=%v reason=%q", allowInjection, reason)
+	}
+}
+
 func TestShouldDeferBeforeInject(t *testing.T) {
 	cfg := &wakeConfig{deferWhileInput: true}
 	if !shouldDeferBeforeInject(cfg, true) {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1348,7 +1348,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	previewLenFlag := fs.Int("preview-len", 48, "Max subject preview length")
 	injectModeFlag := fs.String("inject-mode", wakeInjectModeAuto, "Injection mode: auto, raw, paste, none (auto detects CLI type)")
 	deferWhileInputFlag := fs.Bool("defer-while-input", true, "Best-effort: defer non-interrupt injection while terminal input appears active")
-	inputQuietForFlag := fs.Duration("input-quiet-for", 1200*time.Millisecond, "Quiet window before deferred injection (best-effort; Linux tty atime granularity is ~8s)")
+	inputQuietForFlag := fs.Duration("input-quiet-for", 1200*time.Millisecond, "Quiet window before deferred injection (advisory only on Linux; tty atime granularity is ~8s)")
 	inputPollIntervalFlag := fs.Duration("input-poll-interval", 200*time.Millisecond, "Polling interval while waiting for quiet terminal input")
 	inputMaxHoldFlag := fs.Duration("input-max-hold", 15*time.Second, "Maximum time to defer one wake injection (0 = no hold)")
 	interruptFlag := fs.Bool("interrupt", true, "Enable interrupt injection for urgent interrupt messages")
@@ -1394,8 +1394,8 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		"  sampling is unavailable, injection remains best-effort. Interrupt",
 		"  messages bypass deferral.",
 		"  Atime sampling uses stdin (when a TTY) for cross-platform fidelity;",
-		"  Linux tty atime is updated at ~8s granularity, so quiet windows",
-		"  shorter than that are advisory.",
+		"  Linux tty atime is updated at ~8s granularity, so it cannot establish",
+		"  a precise 1200ms idle window. On Linux this heuristic is advisory.",
 		"",
 		"Interrupt notices (default on): urgent messages tagged with label \"interrupt\"",
 		"  trigger an interrupt notice. Ctrl+C injection is opt-in with",

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -41,7 +41,8 @@ func TestWakeHelpDocumentsMaxHoldDemotion(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !strings.Contains(output, "input remains active through --input-max-hold") ||
-		!strings.Contains(output, "skips synthetic input") {
+		!strings.Contains(output, "skips synthetic input") ||
+		!strings.Contains(output, "heuristic is advisory") {
 		t.Fatalf("wake help omits max-hold demotion:\n%s", output)
 	}
 }


### PR DESCRIPTION
## Summary

- require three consecutive quiet samples before treating terminal input as idle
- reset quiet evidence on any active observation
- preserve max-hold demotion when quiet confirmation is incomplete
- state Linux tty-atime limitations explicitly in wake help

## Verification

- focused and race tests for Lane A × Lane E behavior
- `make test`
- `make smoke`
- `make fmt-check`
- `go vet ./...`
- Windows and FreeBSD cross-builds

## Frozen review identity

- head: `b342592c51e21fd6689a9d9efaff9c3535c7b401`
- tree: `af8f3737eb186ac8e403516c2b484c9dd1edc875`
- full-index diff SHA-256: `cd545d46c4c155084eeadcdb0bd4e74b3b365c52e6308ef5230c35377c6d68b9`
- peer verdict: PASS
