### PR TITLE
fix(wake): use fixed standalone doorbell

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -221,7 +221,6 @@ func notifyNewMessages(cfg *wakeConfig) error {
 	}
 
 	var messages []wakeMsgInfo
-	senderCounts := make(map[string]int)
 	var interruptMessages []wakeMsgInfo
 	interruptCounts := make(map[string]int)
 
@@ -253,7 +252,6 @@ func notifyNewMessages(cfg *wakeConfig) error {
 			}
 			// Count corrupt messages too
 			messages = append(messages, wakeMsgInfo{from: "unknown", subject: "(parse error)"})
-			senderCounts["unknown"]++
 			continue
 		}
 
@@ -274,7 +272,6 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		}
 
 		messages = append(messages, info)
-		senderCounts[from]++
 
 		if cfg.interrupt && isInterruptMessage(info, cfg) {
 			interruptMessages = append(interruptMessages, info)
@@ -326,57 +323,30 @@ func notifyNewMessages(cfg *wakeConfig) error {
 				}
 			}
 		}
-		return injectNotification(cfg, interruptText, false)
+		notificationText := coopWakeDoorbell
+		if cfg.interruptNotice != "" {
+			notificationText = interruptText
+		}
+		return injectNotification(cfg, notificationText, false)
 	}
 
 	// Build notification text
 	var text string
 	if cfg.injectCmd != "" {
 		// Power user mode: inject actual command
-		text = "\n" + cfg.injectCmd + "\n"
+		text = "\n" + sanitizeForTTY(cfg.injectCmd) + "\n"
 	} else {
-		// Default: informational notice
-		text = buildNotificationText(cfg.session, messages, senderCounts, cfg.previewLen)
+		// Peer-derived headers never enter terminal input. The fixed prefix is
+		// shell-inert if a standalone wake lands at a shell prompt.
+		text = coopWakeDoorbell
 	}
 
 	return injectNotification(cfg, text, true)
 }
 
-func buildNotificationText(session string, messages []wakeMsgInfo, senderCounts map[string]int, previewLen int) string {
-	count := len(messages)
-	prefix := notificationPrefix("AMQ", session)
-
-	if count == 1 {
-		// Single message: show from + truncated subject
-		msg := messages[0]
-		subject := msg.subject
-		if subject == "" {
-			subject = "(no subject)"
-		}
-		subject = truncateSubject(subject, previewLen)
-		return fmt.Sprintf("%s: message from %s - %s. Drain with: amq drain --include-body — then act on it", prefix, msg.from, subject)
-	}
-
-	// Multiple messages: show counts by sender
-	var parts []string
-	senders := make([]string, 0, len(senderCounts))
-	for s := range senderCounts {
-		senders = append(senders, s)
-	}
-	sort.Strings(senders)
-
-	for _, sender := range senders {
-		c := senderCounts[sender]
-		parts = append(parts, fmt.Sprintf("%d from %s", c, sender))
-	}
-
-	return fmt.Sprintf("%s: %d messages - %s. Drain with: amq drain --include-body — then act on it",
-		prefix, count, strings.Join(parts, ", "))
-}
-
 func buildInterruptText(session string, messages []wakeMsgInfo, senderCounts map[string]int, previewLen int, custom string) string {
 	if custom != "" {
-		return custom
+		return sanitizeForTTY(custom)
 	}
 
 	count := len(messages)

--- a/internal/cli/wake_repair_continuity_unix_test.go
+++ b/internal/cli/wake_repair_continuity_unix_test.go
@@ -122,9 +122,10 @@ func TestWakeRepairNotifiesMessageDeliveredDuringDowntime(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		data, readErr := os.ReadFile(injectedPath)
-		if readErr == nil && strings.Contains(string(data), "urgent message delivered during downtime") {
-			if strings.Contains(string(data), "startup backlog") {
-				t.Fatalf("repaired wake re-notified the startup backlog: %q", data)
+		if readErr == nil && strings.Contains(string(data), coopWakeDoorbell) {
+			if strings.Contains(string(data), "urgent message delivered during downtime") ||
+				strings.Contains(string(data), "startup backlog") {
+				t.Fatalf("repaired wake injected peer-derived message text: %q", data)
 			}
 			return
 		}

--- a/internal/cli/wake_repair_namespace_unix_test.go
+++ b/internal/cli/wake_repair_namespace_unix_test.go
@@ -405,8 +405,11 @@ func TestRepairedWakeExitsWithoutInjectingDetachedNamespaceMessages(t *testing.T
 			}
 
 			releasedOutput := waitForWakeRepairOutputLine(t, fixture.outputPath)
-			if !bytes.Contains(releasedOutput, []byte("must wait for admission")) {
-				t.Fatalf("released wake output does not contain pending message: %q", releasedOutput)
+			if !bytes.Contains(releasedOutput, []byte(coopWakeDoorbell)) {
+				t.Fatalf("released wake output does not contain fixed doorbell: %q", releasedOutput)
+			}
+			if bytes.Contains(releasedOutput, []byte("must wait for admission")) {
+				t.Fatalf("released wake output contains peer-derived message text: %q", releasedOutput)
 			}
 			releasedOutput = append([]byte(nil), releasedOutput...)
 

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -43,44 +43,6 @@ func TestBuildInterruptText_DefaultSingle(t *testing.T) {
 	}
 }
 
-func TestBuildNotificationText_NoSession(t *testing.T) {
-	msg := wakeMsgInfo{from: "codex", subject: "review done"}
-	text := buildNotificationText("", []wakeMsgInfo{msg}, map[string]int{"codex": 1}, 48)
-	if !strings.HasPrefix(text, "AMQ: ") {
-		t.Fatalf("expected 'AMQ: ' prefix without session, got: %s", text)
-	}
-	if strings.Contains(text, "[") {
-		t.Fatalf("expected no brackets without session, got: %s", text)
-	}
-}
-
-func TestBuildNotificationText_WithSession(t *testing.T) {
-	msg := wakeMsgInfo{from: "codex", subject: "review done"}
-	text := buildNotificationText("stream3", []wakeMsgInfo{msg}, map[string]int{"codex": 1}, 48)
-	if !strings.HasPrefix(text, "AMQ [stream3]: ") {
-		t.Fatalf("expected 'AMQ [stream3]: ' prefix, got: %s", text)
-	}
-	if !strings.Contains(text, "codex") {
-		t.Fatalf("expected sender in text, got: %s", text)
-	}
-}
-
-func TestBuildNotificationText_MultipleWithSession(t *testing.T) {
-	messages := []wakeMsgInfo{
-		{from: "codex", subject: "a"},
-		{from: "codex", subject: "b"},
-		{from: "alice", subject: "c"},
-	}
-	counts := map[string]int{"codex": 2, "alice": 1}
-	text := buildNotificationText("collab", messages, counts, 48)
-	if !strings.HasPrefix(text, "AMQ [collab]: ") {
-		t.Fatalf("expected 'AMQ [collab]: ' prefix, got: %s", text)
-	}
-	if !strings.Contains(text, "3 messages") {
-		t.Fatalf("expected message count, got: %s", text)
-	}
-}
-
 func TestBuildInterruptText_WithSession(t *testing.T) {
 	msg := wakeMsgInfo{from: "alice", subject: "help"}
 	text := buildInterruptText("stream2", []wakeMsgInfo{msg}, map[string]int{"alice": 1}, 48, "")
@@ -91,8 +53,8 @@ func TestBuildInterruptText_WithSession(t *testing.T) {
 
 func TestBuildInterruptText_CustomOverride(t *testing.T) {
 	msg := wakeMsgInfo{from: "alice", subject: "help"}
-	text := buildInterruptText("stream2", []wakeMsgInfo{msg}, map[string]int{"alice": 1}, 48, "custom notice")
-	if text != "custom notice" {
+	text := buildInterruptText("stream2", []wakeMsgInfo{msg}, map[string]int{"alice": 1}, 48, "custom\x1b[31m\nnotice")
+	if text != "custom [31m notice" {
 		t.Fatalf("expected custom override, got: %s", text)
 	}
 }
@@ -861,14 +823,7 @@ func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *test
 		t.Fatalf("second notifyNewMessages: %v", err)
 	}
 
-	expectedText := buildInterruptText(
-		"collab",
-		[]wakeMsgInfo{{from: "codex", subject: "help needed", priority: "urgent", labels: []string{"interrupt"}}},
-		map[string]int{"codex": 1},
-		48,
-		"",
-	)
-	expected := "\x03\n" + expectedText + "\n" + expectedText + "\n"
+	expected := "\x03\n" + coopWakeDoorbell + "\n" + coopWakeDoorbell + "\n"
 
 	got, err := os.ReadFile(logPath)
 	if err != nil {
@@ -1013,7 +968,7 @@ func TestNotifyNewMessages_InjectViaInjectCmdPayload(t *testing.T) {
 		me:         "alice",
 		root:       root,
 		injectVia:  scriptPath,
-		injectCmd:  "amq drain --include-body",
+		injectCmd:  "amq drain\x1b[31m\n--include-body",
 		previewLen: 48,
 	}
 
@@ -1025,7 +980,7 @@ func TestNotifyNewMessages_InjectViaInjectCmdPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read log: %v", err)
 	}
-	expected := "\namq drain --include-body\n"
+	expected := "\namq drain [31m --include-body\n"
 	if string(got) != expected {
 		t.Fatalf("expected inject-cmd payload %q, got %q", expected, string(got))
 	}
@@ -1103,8 +1058,8 @@ func TestNotifyNewMessagesSkipsBaselineWithoutDraining(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read injection output: %v", err)
 	}
-	if !strings.Contains(string(got), "fresh subject") || strings.Contains(string(got), "stale subject") {
-		t.Fatalf("injected payload = %q, want fresh message only", string(got))
+	if string(got) != coopWakeDoorbell {
+		t.Fatalf("injected payload = %q, want fixed doorbell %q", string(got), coopWakeDoorbell)
 	}
 }
 

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -369,19 +369,7 @@ func TestRunWakeWithLoopInterruptCommandDefaultsOffAndRemainsOptIn(t *testing.T)
 			if err != nil {
 				t.Fatalf("read injector log: %v", err)
 			}
-			notice := buildInterruptText(
-				"",
-				[]wakeMsgInfo{{
-					from:     "codex",
-					subject:  "help needed",
-					priority: "urgent",
-					labels:   []string{"interrupt"},
-				}},
-				map[string]int{"codex": 1},
-				48,
-				"",
-			)
-			want := tt.wantPrefix + notice + "\n"
+			want := tt.wantPrefix + coopWakeDoorbell + "\n"
 			if string(got) != want {
 				t.Fatalf("injector log = %q, want %q", string(got), want)
 			}


### PR DESCRIPTION
## Summary

- route default standalone normal and urgent tty input through the fixed shell-inert doorbell
- remove peer-derived sender and subject text from every synthetic-input path
- preserve explicit operator `--interrupt-notice` and `--inject-cmd` payloads while sanitizing control bytes
- remove the obsolete dynamic notification builder and sender-count plumbing

## Verification

- focused provenance and sanitization tests
- repair-continuity and repaired-namespace tests
- `make test`
- `make smoke`
- `make fmt-check`
- `go vet ./...`
- Windows and FreeBSD cross-builds

## Frozen review identity

- reviewed diff SHA-256: `48f2d7f46c24fb8eb1f98a3052718133409617407eb44ab3152af87dd8a6b84e`
- rebased parent: `468d712c0e083c2ec1f3335b776f50b38c9f848f`
- head: `1f25513b515e40369ea1aa1d415c3630ac2ff580`
- rebased tree: `3dcee850d304e9a99209b17484c86867846a88bc`
- peer verdict: PASS

The tree changed only because main advanced through #315 and #316; the reviewed full-index diff is byte-identical.
