### PR TITLE
fix(hooks): guard Stop blocks by message content

### DIFF
--- a/scripts/amq-stop-hook.sh
+++ b/scripts/amq-stop-hook.sh
@@ -1,60 +1,66 @@
 #!/bin/bash
-# AMQ Co-op Stop Hook
-# Blocks stop if there are pending messages in inbox
-# Safe fallback: approves if amq unavailable or co-op not configured
+# AMQ Co-op Stop Hook. Allows silently on unavailable/invalid context.
+set -u
 
-DEFAULT_ROOT=".agent-mail"
-if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
-    DEFAULT_ROOT="${CLAUDE_PROJECT_DIR}/.agent-mail"
-fi
-ROOT="${AM_ROOT:-$DEFAULT_ROOT}"
+payload="$(cat)"
+command -v amq >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+active="$(printf '%s' "$payload" | python3 -c \
+  'import json,sys; print("1" if json.load(sys.stdin).get("stop_hook_active") is True else "0")' 2>/dev/null)" ||
+  exit 0
+
 ME="${AM_ME:-claude}"
-
-# Fast path: approve immediately if co-op not set up
-if [ ! -d "$ROOT/agents/$ME/inbox/new" ]; then
-    echo '{"decision": "approve"}'
-    exit 0
+env_args=(env --me "$ME" --json)
+if [ -n "${AM_SESSION:-}" ]; then
+  env_args+=(--session "$AM_SESSION")
 fi
+env_json="$(cd "${CLAUDE_PROJECT_DIR:-.}" && amq "${env_args[@]}" 2>/dev/null)" || exit 0
+resolved="$(printf '%s' "$env_json" | python3 -c \
+  'import json,sys; d=json.load(sys.stdin); print("\x1f".join((d["root"],d.get("session_name",""),d["me"])))' 2>/dev/null)" ||
+  exit 0
+IFS=$'\x1f' read -r ROOT SESSION ME <<<"$resolved"
 
-# Fast path: if inbox/new has no message files, approve without invoking amq
-inbox_new="$ROOT/agents/$ME/inbox/new"
-shopt -s nullglob
-files=("$inbox_new"/*.md)
-shopt -u nullglob
-if [ ${#files[@]} -eq 0 ]; then
-    echo '{"decision": "approve"}'
-    exit 0
+list_json="$(cd "${CLAUDE_PROJECT_DIR:-.}" &&
+  amq list --root "$ROOT" --me "$ME" --new --json 2>/dev/null)" || exit 0
+state="$ROOT/agents/$ME/.stop-hook-state.json"
+decision="$(printf '%s' "$list_json" | python3 -c '
+import json,os,sys
+state,active,root,session=sys.argv[1:]
+session=session or "(none)"
+ids=sorted({x["id"] for x in json.load(sys.stdin) if x.get("id")})
+old={"blocked_ids":[],"chain_blocks":0}
+try:
+  with open(state,encoding="utf-8") as f: old=json.load(f)
+except (OSError,ValueError,TypeError): pass
+blocked=sorted(set(old.get("blocked_ids",[])) & set(ids))
+blocks=int(old.get("chain_blocks",0)) if active=="1" else 0
+fresh=sorted(set(ids)-set(blocked))
+out=None
+if not ids: blocks=0
+# Five local blocks leave a three-block reserve below the harness limit of eight.
+if fresh and blocks >= 5:
+  blocks=0
+  out={"systemMessage":f"AMQ stop-hook block budget exhausted; allowing stop and resetting the guard with {len(fresh)} fresh message(s) still at root={root} session={session}."}
+elif fresh:
+  blocked=sorted(set(blocked)|set(fresh)); blocks+=1
+  out={"decision":"block","reason":f"You have {len(ids)} pending AMQ message(s), including {len(fresh)} not previously reported. Drain before stopping. root={root} session={session}."}
+data=(json.dumps({"schema":1,"blocked_ids":blocked,"chain_blocks":blocks},separators=(",",":"))+"\n").encode()
+tmp=f"{state}.tmp"
+try:
+  try: os.unlink(tmp)
+  except FileNotFoundError: pass
+  fd=os.open(tmp,os.O_WRONLY|os.O_CREAT|os.O_EXCL,0o600)
+  with os.fdopen(fd,"wb") as f: f.write(data); f.flush(); os.fsync(f.fileno())
+  os.replace(tmp,state)
+  dfd=os.open(os.path.dirname(state),os.O_RDONLY)
+  try: os.fsync(dfd)
+  finally: os.close(dfd)
+finally:
+  try: os.unlink(tmp)
+  except FileNotFoundError: pass
+if out is not None: print(json.dumps(out,separators=(",",":")))
+' "$state" "$active" "$ROOT" "$SESSION" 2>/dev/null)" || exit 0
+
+if [ -n "$decision" ]; then
+  printf '%s\n' "$decision"
 fi
-
-# Safe fallback if dependencies missing
-if ! command -v amq &> /dev/null; then
-    echo '{"decision": "approve"}'
-    exit 0
-fi
-
-if command -v jq &> /dev/null; then
-    # Check for pending messages (safe fallback on any error)
-    COUNT=$(amq list --root "$ROOT" --me "$ME" --new --json 2>/dev/null | jq -r 'length // 0' 2>/dev/null || echo "0")
-
-    # Sanitize COUNT to ensure it's a number
-    if ! [[ "$COUNT" =~ ^[0-9]+$ ]]; then
-        COUNT=0
-    fi
-
-    if [ "$COUNT" -gt 0 ]; then
-        echo '{"decision": "block", "reason": "You have '"$COUNT"' pending message(s). Ask me to drain the inbox before stopping."}'
-        exit 0
-    fi
-else
-    OUT=$(amq list --root "$ROOT" --me "$ME" --new 2>/dev/null || true)
-    if echo "$OUT" | grep -q "^No messages\\.$"; then
-        echo '{"decision": "approve"}'
-        exit 0
-    fi
-    if [ -n "$OUT" ]; then
-        echo '{"decision": "block", "reason": "You have pending message(s). Ask me to drain the inbox before stopping."}'
-        exit 0
-    fi
-fi
-
-echo '{"decision": "approve"}'

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -332,5 +332,6 @@ echo "  hook log rotation: small log left in place"
 echo "claude-session-start.sh hook test ok"
 
 bash scripts/test_install_checksum.sh
+AMQ_TEST_BIN="$BIN" bash scripts/test_stop_hook.sh
 
 echo "smoke test ok"

--- a/scripts/test_stop_hook.sh
+++ b/scripts/test_stop_hook.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN="${AMQ_TEST_BIN:?AMQ_TEST_BIN is required}"
+HOOK="${AMQ_STOP_HOOK:-scripts/amq-stop-hook.sh}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+BASE="$TMP/agent-mail"
+ROOT="$BASE/session1"
+"$BIN" init --root "$ROOT" --agents claude,codex >/dev/null
+
+send() {
+  "$BIN" send --root "$ROOT" --me codex --to claude --body "$1" --json |
+    awk -F'"' '/"id":/ {print $4; exit}'
+}
+run_hook() {
+  local active="$1"
+  printf '{"stop_hook_active":%s}\n' "$active" |
+    env -u AM_ROOT AM_BASE_ROOT="$BASE" AM_SESSION=session1 AM_ME=claude \
+      AMQ_NO_UPDATE_CHECK=1 PATH="$(dirname "$BIN"):$PATH" \
+      CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK"
+}
+
+test "$(run_hook false)" = ""
+id1="$(send one)"
+first="$(run_hook false)"
+python3 - "$first" "$ROOT" <<'PY'
+import json, sys
+d=json.loads(sys.argv[1]); assert d["decision"]=="block"
+assert sys.argv[2] in d["reason"] and "session1" in d["reason"]
+PY
+test "$(run_hook true)" = ""
+test "$("$BIN" list --root "$ROOT" --me claude --new --json | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" = 1
+
+for n in 2 3 4 5; do
+  send "$n" >/dev/null
+  out="$(run_hook true)"
+  python3 -c 'import json,sys; assert json.loads(sys.argv[1])["decision"]=="block"' "$out"
+  test "$(run_hook true)" = ""
+done
+send six >/dev/null
+exhausted="$(run_hook true)"
+python3 - "$exhausted" <<'PY'
+import json, sys
+d=json.loads(sys.argv[1]); assert "decision" not in d
+assert "budget" in d["systemMessage"].lower() and "reset" in d["systemMessage"].lower()
+PY
+
+# A new, non-active stop chain can block the still-fresh sixth message.
+healed="$(run_hook false)"
+python3 -c 'import json,sys; assert json.loads(sys.argv[1])["decision"]=="block"' "$healed"
+test "$(run_hook true)" = ""
+
+state="$ROOT/agents/claude/.stop-hook-state.json"
+test "$(stat -f '%Lp' "$state" 2>/dev/null || stat -c '%a' "$state")" = 600
+test ! -e "$state.tmp"
+"$BIN" read --root "$ROOT" --me claude --id "$id1" >/dev/null
+test "$(run_hook true)" = ""
+python3 - "$state" "$id1" <<'PY'
+import json, sys
+d=json.load(open(sys.argv[1])); assert sys.argv[2] not in d["blocked_ids"]
+PY
+echo "stop hook tests ok"

--- a/scripts/test_stop_hook.sh
+++ b/scripts/test_stop_hook.sh
@@ -21,7 +21,20 @@ run_hook() {
       CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK"
 }
 
-test "$(run_hook false)" = ""
+assert_eq() { # want got label
+  if [ "$1" != "$2" ]; then
+    printf 'FAIL %s: want %s got %s\n' "$3" "$1" "$2" >&2
+    exit 1
+  fi
+}
+assert_absent() { # path label
+  if [ -e "$1" ]; then
+    printf 'FAIL %s: unexpected path exists: %s\n' "$2" "$1" >&2
+    exit 1
+  fi
+}
+
+assert_eq "" "$(run_hook false)" "ordinary allow output"
 id1="$(send one)"
 first="$(run_hook false)"
 python3 - "$first" "$ROOT" <<'PY'
@@ -29,14 +42,14 @@ import json, sys
 d=json.loads(sys.argv[1]); assert d["decision"]=="block"
 assert sys.argv[2] in d["reason"] and "session1" in d["reason"]
 PY
-test "$(run_hook true)" = ""
-test "$("$BIN" list --root "$ROOT" --me claude --new --json | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" = 1
+assert_eq "" "$(run_hook true)" "active repeat output"
+assert_eq 1 "$("$BIN" list --root "$ROOT" --me claude --new --json | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" "message remains unread"
 
 for n in 2 3 4 5; do
   send "$n" >/dev/null
   out="$(run_hook true)"
   python3 -c 'import json,sys; assert json.loads(sys.argv[1])["decision"]=="block"' "$out"
-  test "$(run_hook true)" = ""
+  assert_eq "" "$(run_hook true)" "active repeat output after message $n"
 done
 send six >/dev/null
 exhausted="$(run_hook true)"
@@ -49,13 +62,14 @@ PY
 # A new, non-active stop chain can block the still-fresh sixth message.
 healed="$(run_hook false)"
 python3 -c 'import json,sys; assert json.loads(sys.argv[1])["decision"]=="block"' "$healed"
-test "$(run_hook true)" = ""
+assert_eq "" "$(run_hook true)" "active repeat output after budget reset"
 
 state="$ROOT/agents/claude/.stop-hook-state.json"
-test "$(stat -f '%Lp' "$state" 2>/dev/null || stat -c '%a' "$state")" = 600
-test ! -e "$state.tmp"
+mode="$(python3 -c 'import os,sys; print(oct(os.stat(sys.argv[1]).st_mode & 0o777)[2:])' "$state")"
+assert_eq 600 "$mode" "state file mode"
+assert_absent "$state.tmp" "atomic state temporary file"
 "$BIN" read --root "$ROOT" --me claude --id "$id1" >/dev/null
-test "$(run_hook true)" = ""
+assert_eq "" "$(run_hook true)" "read message output"
 python3 - "$state" "$id1" <<'PY'
 import json, sys
 d=json.load(open(sys.argv[1])); assert sys.argv[2] not in d["blocked_ids"]


### PR DESCRIPTION
## Summary

- block once per fresh AMQ message content instead of once per Stop-hook retry
- consume `stop_hook_active` only as a chain-budget reset signal
- delegate mailbox root/session resolution to `amq env`
- persist a bounded, pruned 0600 block guard atomically without draining mail
- allow silently under ordinary no-mail conditions and expose budget exhaustion with `systemMessage`
- add dedicated end-to-end Stop-hook smoke coverage

## Verification

- dedicated RED→GREEN Stop-hook E2E test
- `make smoke`
- `make test`
- `make fmt-check`
- `go vet ./...`
- `shellcheck scripts/amq-stop-hook.sh scripts/test_stop_hook.sh`
- `bash -n` on hook and smoke scripts

## Frozen review identity

- head: `51fb149edb95cf2b128f4197c2ae484417e09e17`
- tree: `c2c06d7a7629c63d55fe9f1b027ba63488263d44`
- full-index diff SHA-256: `af269b7571ce879949181d7979091f074f7d006a15d63330eb6dce71ef12cce2`
- peer verdict: PASS
