### PR TITLE
fix(hooks): recover incomplete session context

### DIFF
--- a/scripts/amq-stop-hook.sh
+++ b/scripts/amq-stop-hook.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# AMQ Co-op Stop Hook. Allows silently on unavailable/invalid context.
+# AMQ Co-op Stop Hook. Allows on unavailable/invalid context.
 set -u
 
 payload="$(cat)"
@@ -10,18 +10,36 @@ active="$(printf '%s' "$payload" | python3 -c \
   exit 0
 
 ME="${AM_ME:-claude}"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+SESSION="${AM_SESSION:-}"
 env_args=(env --me "$ME" --json)
-if [ -n "${AM_SESSION:-}" ]; then
-  env_args+=(--session "$AM_SESSION")
+if [ -n "$SESSION" ]; then
+  env_args+=(--session "$SESSION")
 fi
-env_json="$(cd "${CLAUDE_PROJECT_DIR:-.}" && amq "${env_args[@]}" 2>/dev/null)" || exit 0
+if ! env_json="$(cd "$PROJECT_DIR" && amq "${env_args[@]}" 2>/dev/null)"; then
+  unset AM_SESSION
+  retry_args=(env --me "$ME" --json)
+  if [ -n "$SESSION" ]; then
+    retry_args+=(--session "$SESSION")
+  fi
+  if ! env_json="$(cd "$PROJECT_DIR" && amq "${retry_args[@]}" 2>/dev/null)"; then
+    if [ -n "${CLAUDE_PROJECT_DIR:-}" ] &&
+      { [ -f "$PROJECT_DIR/.amqrc" ] || [ -d "$PROJECT_DIR/.agent-mail" ]; }; then
+      printf '%s\n' '{"systemMessage":"AMQ context unresolved; pending messages may exist. Resolve the project/session context and drain before stopping."}'
+    fi
+    exit 0
+  fi
+fi
 resolved="$(printf '%s' "$env_json" | python3 -c \
   'import json,sys; d=json.load(sys.stdin); print("\x1f".join((d["root"],d.get("session_name",""),d["me"])))' 2>/dev/null)" ||
   exit 0
 IFS=$'\x1f' read -r ROOT SESSION ME <<<"$resolved"
 
 list_json="$(cd "${CLAUDE_PROJECT_DIR:-.}" &&
-  amq list --root "$ROOT" --me "$ME" --new --json 2>/dev/null)" || exit 0
+  amq list --root "$ROOT" --me "$ME" --new --json 2>/dev/null)" || {
+  python3 -c 'import json,sys; print(json.dumps({"systemMessage":f"AMQ mailbox unreadable at {sys.argv[1]}; pending messages may exist."},separators=(",",":")))' "$ROOT"
+  exit 0
+}
 state="$ROOT/agents/$ME/.stop-hook-state.json"
 decision="$(printf '%s' "$list_json" | python3 -c '
 import json,os,sys

--- a/scripts/test_stop_hook.sh
+++ b/scripts/test_stop_hook.sh
@@ -20,6 +20,22 @@ run_hook() {
       AMQ_NO_UPDATE_CHECK=1 PATH="$(dirname "$BIN"):$PATH" \
       CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK"
 }
+run_hook_with_incomplete_pin() {
+  local project_dir="$1"
+  printf '{"stop_hook_active":false}\n' |
+    env -u AM_ROOT -u AM_BASE_ROOT -u AMQ_GLOBAL_ROOT \
+      AM_SESSION=session1 AM_ME=claude HOME="$TMP/empty-home" \
+      AMQ_NO_UPDATE_CHECK=1 PATH="$(dirname "$BIN"):$PATH" \
+      CLAUDE_PROJECT_DIR="$project_dir" bash "$HOOK"
+}
+run_hook_without_pin() {
+  local project_dir="$1"
+  printf '{"stop_hook_active":false}\n' |
+    env -u AM_ROOT -u AM_BASE_ROOT -u AM_SESSION -u AMQ_GLOBAL_ROOT \
+      AM_ME=claude HOME="$TMP/empty-home" \
+      AMQ_NO_UPDATE_CHECK=1 PATH="$(dirname "$BIN"):$PATH" \
+      CLAUDE_PROJECT_DIR="$project_dir" bash "$HOOK"
+}
 
 assert_eq() { # want got label
   if [ "$1" != "$2" ]; then
@@ -34,14 +50,41 @@ assert_absent() { # path label
   fi
 }
 
+mkdir -p "$TMP/empty-home" "$TMP/pinned-project"
+printf '{"root":"%s"}\n' "$BASE" >"$TMP/pinned-project/.amqrc"
 assert_eq "" "$(run_hook false)" "ordinary allow output"
 id1="$(send one)"
-first="$(run_hook false)"
-python3 - "$first" "$ROOT" <<'PY'
+fallback="$(run_hook_with_incomplete_pin "$TMP/pinned-project")"
+python3 - "$fallback" "$ROOT" <<'PY'
 import json, sys
 d=json.loads(sys.argv[1]); assert d["decision"]=="block"
-assert sys.argv[2] in d["reason"] and "session1" in d["reason"]
+assert sys.argv[2] in d["reason"]
 PY
+
+mkdir -p "$TMP/unresolved-project"
+printf '{invalid\n' >"$TMP/unresolved-project/.amqrc"
+unresolved="$(run_hook_with_incomplete_pin "$TMP/unresolved-project")"
+python3 - "$unresolved" <<'PY'
+import json, sys
+d=json.loads(sys.argv[1]); assert "decision" not in d
+message=d["systemMessage"].lower()
+assert "context" in message and "pending messages may exist" in message
+PY
+
+mkdir -p "$TMP/unreadable-project" "$TMP/unreadable-mailbox"
+printf '{"root":"%s"}\n' "$TMP/unreadable-mailbox" >"$TMP/unreadable-project/.amqrc"
+unreadable="$(run_hook_without_pin "$TMP/unreadable-project")"
+python3 - "$unreadable" "$TMP/unreadable-mailbox" <<'PY'
+import json, sys
+d=json.loads(sys.argv[1]); assert "decision" not in d
+message=d["systemMessage"]
+assert "mailbox unreadable" in message.lower() and sys.argv[2] in message
+assert "pending messages may exist" in message.lower()
+PY
+
+mkdir -p "$TMP/no-amq-project"
+assert_eq "" "$(run_hook_with_incomplete_pin "$TMP/no-amq-project")" "unconfigured project output"
+
 assert_eq "" "$(run_hook true)" "active repeat output"
 assert_eq 1 "$("$BIN" list --root "$ROOT" --me claude --new --json | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" "message remains unread"
 


### PR DESCRIPTION
## Summary
- preserve the requested session while retrying an incomplete ambient pin
- warn when configured AMQ context or a resolved mailbox cannot be read
- keep genuine non-AMQ contexts silent

## Verification
- `bash -n scripts/amq-stop-hook.sh scripts/test_stop_hook.sh`
- `AMQ_TEST_BIN=<built amq> bash scripts/test_stop_hook.sh`
- `make smoke`
- Claude exact-tree PASS: `a728771dcfb8c89f51a103467ac4334fc939f2e1`