### PR TITLE
test(cli): neutralize host platform probes by default

### DIFF
--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,6 +19,10 @@ var cliSecureTempRoot string
 // dir look like refused cross-tree sends. Tests that need these signals set them
 // explicitly via t.Setenv, which overrides and restores around this clean baseline.
 func TestMain(m *testing.M) {
+	readTIOCSTILegacySysctl = func() ([]byte, error) {
+		return nil, os.ErrNotExist
+	}
+
 	if os.Getenv(cliHelperEnv) == "1" {
 		if err := Run(os.Args[1:], "test"); err != nil {
 			_, _ = fmt.Fprintln(os.Stderr, err)
@@ -62,4 +67,14 @@ func TestMain(m *testing.M) {
 		exitCode = 1
 	}
 	os.Exit(exitCode)
+}
+
+func TestTIOCSTILegacySysctlTestDefaultIsNotReadableZero(t *testing.T) {
+	data, err := readTIOCSTILegacySysctl()
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("default error = %v, want os.ErrNotExist", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("default data = %q, want empty", data)
+	}
 }

--- a/internal/cli/wake_tiocsti_stub.go
+++ b/internal/cli/wake_tiocsti_stub.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"errors"
+	"os"
 	"time"
 )
 
@@ -11,6 +12,10 @@ import (
 var tiocsti = tiocstiFuncs{}
 
 type tiocstiFuncs struct{}
+
+var readTIOCSTILegacySysctl = func() ([]byte, error) {
+	return nil, os.ErrNotExist
+}
 
 // Available returns false on non-Unix systems.
 func (t tiocstiFuncs) Available() bool {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -3801,14 +3801,6 @@ func TestWakeCommandEnvCarriesOwnerToken(t *testing.T) {
 }
 
 func TestWakeInjectionPreconditionCheckReportsOnlyOpenability(t *testing.T) {
-	oldRead := readTIOCSTILegacySysctl
-	readTIOCSTILegacySysctl = func() ([]byte, error) {
-		return []byte("1\n"), nil
-	}
-	t.Cleanup(func() {
-		readTIOCSTILegacySysctl = oldRead
-	})
-
 	cfg := wakeConfig{}
 	err := wakeInjectionPreconditionCheck(&cfg, func() bool {
 		return false


### PR DESCRIPTION
## Summary
- neutralize the legacy TIOCSTI sysctl probe before any `TestMain` helper exit
- expose the same safe seam on non-Darwin/non-Linux test builds
- assert the package default cannot become a readable zero
- remove the redundant test-local stub

## Verification
- focused tests and race detector
- Linux and Windows test-package compile
- `make test` / `make fmt-check` / `go vet ./...` / `make lint`
- `make smoke`
- Claude exact-tree PASS: `820502a3a107c11f716e1330ede35166cc2ba137`