### PR TITLE
fix: safely reclaim blocking coop wake locks

### DIFF
--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -387,6 +387,7 @@ func TestBuildCoopWakeArgsDisablesInterruptAndGenericReuse(t *testing.T) {
 		"--root", "/tmp/root",
 		"--baseline-existing",
 		"--interrupt-cmd", "none",
+		"--refuse-unverified-wake",
 		"--inject-mode", "none",
 		"--ready-file", "/tmp/ready",
 	}

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -40,7 +40,7 @@ func runCoopExec(args []string) error {
 	wakeInjectViaFlag := fs.String("wake-inject-via", "", "Start wake with this absolute --inject-via executable, enabling later amq wake repair")
 	var wakeInjectArgFlags multiStringFlag
 	fs.Var(&wakeInjectArgFlags, "wake-inject-arg", "Fixed argument for wake --inject-via before the payload (repeatable)")
-	yesFlag := fs.Bool("y", false, "Skip confirmation prompts")
+	yesFlag := fs.Bool("y", false, "Skip confirmation prompts (including clearing a blocking wake)")
 
 	usage := usageWithFlags(fs, "amq coop exec [options] <command> [-- <command-flags>]",
 		"Set up co-op mode and exec into the agent (replaces this process).",
@@ -232,6 +232,16 @@ func runCoopExec(args []string) error {
 	binaryPath, err := exec.LookPath(cmdName)
 	if err != nil {
 		return fmt.Errorf("command not found: %s", cmdName)
+	}
+	if !*noWakeFlag {
+		if err := prepareCoopWakeLock(
+			root,
+			agentHandle,
+			*yesFlag,
+			coopWakeRemedyForCommand(root, agentHandle, cmdName, agentArgs),
+		); err != nil {
+			return err
+		}
 	}
 
 	// Start amq wake in background (unless --no-wake). Every coop-started wake
@@ -591,6 +601,7 @@ func buildCoopWakeArgs(agentHandle, root, injectMode, injectVia string, injectAr
 		"--root", root,
 		"--baseline-existing",
 		"--interrupt-cmd", "none",
+		"--refuse-unverified-wake",
 	}
 	if injectMode != "" && injectMode != wakeInjectModeAuto {
 		args = append(args, "--inject-mode", injectMode)

--- a/internal/cli/coop_wake_reclaim_darwin_test.go
+++ b/internal/cli/coop_wake_reclaim_darwin_test.go
@@ -1,0 +1,38 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestPrepareCoopWakeLockLiveRawOrphanYesSignalsWaitsAndRemoves(t *testing.T) {
+	const pid = 66121
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: pid, ProcessStart: "start", BootID: "boot", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}, Generation: "raw"})
+	stopped := false
+	stubInspectWakeProcess(t, func(got int) wakeProcessInfo {
+		if stopped {
+			return wakeProcessInfo{PID: got}
+		}
+		return wakeProcessInfo{PID: got, Running: true, StartToken: "start", BootID: "boot", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}, ControllingTerminalKnown: true}
+	})
+	stubSignalWakeProcess(t, func(got int, signal os.Signal) error {
+		if got != pid || signal != syscall.SIGTERM {
+			t.Fatalf("signal %d %v", got, signal)
+		}
+		stopped = true
+		return nil
+	})
+	oldGrace := wakeTerminateGrace
+	wakeTerminateGrace = 0
+	t.Cleanup(func() { wakeTerminateGrace = oldGrace })
+	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
+		t.Fatalf("retire raw orphan: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("raw orphan lock remains: %v", err)
+	}
+}

--- a/internal/cli/coop_wake_reclaim_unix.go
+++ b/internal/cli/coop_wake_reclaim_unix.go
@@ -1,0 +1,182 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+func prepareCoopWakeLock(root, agent string, yes bool, remedy string) error {
+	inspection := inspectWakeLock(root, agent)
+	if !inspection.Exists {
+		return nil
+	}
+	// A live process that affirmative process inspection proves is not this wake
+	// must never be signaled or have its lock removed by a coop retry.
+	if inspection.Process.Running && wakeProcessProvenNotWake(inspection.Process) {
+		return fmt.Errorf("wake lock for %s names a running process proven not to be this wake; refusing to signal or remove it; lock: %s; root: %s; reason: %s", agent, inspection.LockPath, inspection.Root, inspection.Reason)
+	}
+	if inspection.Status == wakeLockStale {
+		if err := removeWakeLockIfUnchanged(inspection); err != nil {
+			return fmt.Errorf("remove exact stale wake lock: %w", err)
+		}
+		return nil
+	}
+
+	if isLiveRawOrphan(inspection) {
+		state := "running, but its terminal is gone"
+		proceed, err := confirmCoopBadWake(
+			inspection,
+			state,
+			"gone",
+			yes,
+			coopWakeRemedy(inspection, state, remedy),
+		)
+		if err != nil || !proceed {
+			return err
+		}
+		retired, err := retireLiveRawOrphan(inspection)
+		if err != nil {
+			return fmt.Errorf("retire identity-confirmed live raw orphan: %w", err)
+		}
+		if !retired {
+			return fmt.Errorf("wake changed before live raw orphan retirement; retry")
+		}
+		return nil
+	}
+
+	if inspection.Status != wakeLockUnverified {
+		// Valid non-orphans and creating locks retain their existing fail-closed
+		// behavior in the wake acquisition path.
+		return nil
+	}
+	state := "cannot confirm whether it is running"
+	proceed, err := confirmCoopBadWake(
+		inspection,
+		state,
+		coopWakeTTYDisplay(inspection),
+		yes,
+		coopWakeRemedy(inspection, state, remedy),
+	)
+	if err != nil || !proceed {
+		return err
+	}
+
+	if err := removeWakeLockIfUnchanged(inspection); err != nil {
+		return fmt.Errorf("remove exact unverified wake lock: %w", err)
+	}
+	_ = writeStderr(
+		"warning: superseded unidentified wake helper for %s (pid %d on %s) without signaling it; fresh wake is starting, but duplicate notifications may continue until the old helper exits; stop that helper if duplicates persist\n",
+		agent,
+		inspection.PID,
+		coopWakeTTYDisplay(inspection),
+	)
+	return nil
+}
+
+func confirmCoopBadWake(
+	inspection wakeLockInspection,
+	state string,
+	tty string,
+	yes bool,
+	remedy string,
+) (bool, error) {
+	_ = writeStderr(
+		"wake for %s is blocking startup and cannot notify you\n"+
+			"  lock:    %s\n"+
+			"  pid:     %d\n"+
+			"  tty:     %s\n"+
+			"  age:     %s\n"+
+			"  state:   %s\n"+
+			"  root:    %s\n",
+		inspection.Agent,
+		inspection.LockPath,
+		inspection.PID,
+		tty,
+		formatCoopWakeLockAge(inspection.Lock.Started, time.Now()),
+		state,
+		inspection.Root,
+	)
+	ok, err := consentToClearWake(yes, remedy)
+	if err != nil {
+		return false, fmt.Errorf("confirm wake cleanup: %w", err)
+	}
+	if !ok {
+		return false, errors.New("wake cleanup declined")
+	}
+	return true, nil
+}
+
+// consentToClearWake reports whether the caller has authorised clearing a
+// blocking wake. Headless callers must pass -y; a prompt nobody can answer
+// is never shown, and never silently answered.
+func consentToClearWake(yes bool, remedy string) (bool, error) {
+	if yes {
+		return true, nil
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		_ = writeStderr("amq coop exec: %s\n", remedy)
+		return false, nil
+	}
+	return confirmPrompt("Clear it and start a fresh wake?")
+}
+
+func coopWakeTTYDisplay(inspection wakeLockInspection) string {
+	tty := strings.TrimSpace(inspection.Lock.TTY)
+	if tty == "" {
+		return "unknown"
+	}
+	return tty
+}
+
+func coopWakeRemedy(inspection wakeLockInspection, state, command string) string {
+	return fmt.Sprintf("wake for %s is blocking startup and cannot notify you.\n  lock: %s\n  state: %s\n\nRe-run with -y to clear it and start a fresh wake:\n  %s\n\nTo inspect first:\n  AM_ROOT=%s amq doctor --ops", inspection.Agent, inspection.LockPath, state, command, inspection.Root)
+}
+
+func coopWakeRemedyForCommand(root, agent, command string, commandArgs []string) string {
+	quoted := []string{"amq", "coop", "exec", "-y", "--root", root, "--me", agent, command}
+	for _, arg := range commandArgs {
+		quoted = append(quoted, arg)
+	}
+	parts := make([]string, 0, len(quoted))
+	for _, arg := range quoted {
+		parts = append(parts, shellQuoteArg(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatCoopWakeLockAge(started string, now time.Time) string {
+	startedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(started))
+	if err != nil || startedAt.After(now) {
+		return "unknown"
+	}
+	age := now.Sub(startedAt)
+	switch {
+	case age >= 24*time.Hour:
+		days := int(age / (24 * time.Hour))
+		if days == 1 {
+			return "1 day"
+		}
+		return fmt.Sprintf("%d days", days)
+	case age >= time.Hour:
+		hours := int(age / time.Hour)
+		if hours == 1 {
+			return "1 hour"
+		}
+		return fmt.Sprintf("%d hours", hours)
+	case age >= time.Minute:
+		minutes := int(age / time.Minute)
+		if minutes == 1 {
+			return "1 minute"
+		}
+		return fmt.Sprintf("%d minutes", minutes)
+	default:
+		return "less than a minute"
+	}
+}

--- a/internal/cli/coop_wake_reclaim_unix.go
+++ b/internal/cli/coop_wake_reclaim_unix.go
@@ -141,9 +141,7 @@ func coopWakeRemedy(inspection wakeLockInspection, state, command string) string
 
 func coopWakeRemedyForCommand(root, agent, command string, commandArgs []string) string {
 	quoted := []string{"amq", "coop", "exec", "-y", "--root", root, "--me", agent, command}
-	for _, arg := range commandArgs {
-		quoted = append(quoted, arg)
-	}
+	quoted = append(quoted, commandArgs...)
 	parts := make([]string, 0, len(quoted))
 	for _, arg := range quoted {
 		parts = append(parts, shellQuoteArg(arg))

--- a/internal/cli/coop_wake_reclaim_unix_test.go
+++ b/internal/cli/coop_wake_reclaim_unix_test.go
@@ -1,0 +1,91 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrepareCoopWakeLockRemovesProvenStaleWithoutPrompt(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: 66121, Generation: "stale"})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo { return wakeProcessInfo{PID: pid} })
+
+	if err := prepareCoopWakeLock(root, "codex", false, "unused"); err != nil {
+		t.Fatalf("prepare stale wake lock: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale lock remains: %v", err)
+	}
+}
+
+func TestPrepareCoopWakeLockUnverifiedYesRemovesMetadataWithoutSignal(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeUnverifiedCoopWakeLock(t, root)
+	stderr := captureWakeStderr(t, func() {
+		if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
+			t.Fatalf("approved cleanup: %v", err)
+		}
+	})
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("unverified lock remains: %v", err)
+	}
+	if !strings.Contains(stderr, "without signaling it") || !strings.Contains(stderr, "duplicate notifications may continue") {
+		t.Fatalf("warning missing safety facts: %q", stderr)
+	}
+}
+
+func TestPrepareCoopWakeLockProvenForeignProcessRefusesWithoutMutation(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: 66121, ProcessStart: "start", BootID: "boot", Executable: "/opt/homebrew/bin/amq", Generation: "foreign"})
+	before, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: true, StartToken: "start", BootID: "boot", Executable: "/bin/sleep", Args: []string{"/bin/sleep", "100"}}
+	})
+	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err == nil || !strings.Contains(err.Error(), "proven not to be this wake") {
+		t.Fatalf("foreign process result = %v", err)
+	}
+	after, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("foreign process lock changed")
+	}
+}
+
+func TestPrepareCoopWakeLockHeadlessPrintsRemedyWithoutPrompt(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeUnverifiedCoopWakeLock(t, root)
+	remedy := "amq coop exec -y --root /resolved/session --me codex codex"
+	var got error
+	stderr := captureWakeStderr(t, func() { got = prepareCoopWakeLock(root, "codex", false, remedy) })
+	if got == nil || !strings.Contains(got.Error(), "declined") {
+		t.Fatalf("headless result = %v", got)
+	}
+	if !strings.Contains(stderr, remedy) || !strings.Contains(stderr, "AM_ROOT=") {
+		t.Fatalf("remedy missing: %q", stderr)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("headless cleanup changed lock: %v", err)
+	}
+}
+
+func TestCoopWakeRemedyForCommandUsesResolvedRootAndYes(t *testing.T) {
+	got := coopWakeRemedyForCommand("/resolved/session", "codex", "codex", []string{"--dangerously-bypass-approvals-and-sandbox"})
+	want := "amq coop exec -y --root /resolved/session --me codex codex --dangerously-bypass-approvals-and-sandbox"
+	if got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func writeUnverifiedCoopWakeLock(t *testing.T, root string) string {
+	t.Helper()
+	return writeWakeLockForTest(t, root, "codex", wakeLock{PID: 66121, TTY: "", Hostname: "definitely-not-this-host", Started: time.Now().Add(-8 * 24 * time.Hour).UTC().Format(time.RFC3339), Generation: "unverified"})
+}

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -42,14 +42,16 @@ const (
 )
 
 type wakeProcessInfo struct {
-	PID          int
-	Running      bool
-	StartToken   string
-	BootID       string
-	LegacyBootID string
-	Executable   string
-	Args         []string
-	InspectError error
+	PID                      int
+	Running                  bool
+	StartToken               string
+	BootID                   string
+	LegacyBootID             string
+	Executable               string
+	Args                     []string
+	ControllingTerminalKnown bool
+	HasControllingTerminal   bool
+	InspectError             error
 }
 
 type wakeLockStatus string

--- a/internal/cli/wake_process_darwin.go
+++ b/internal/cli/wake_process_darwin.go
@@ -12,6 +12,7 @@ import (
 // SZOMB from <sys/proc.h>: the process has exited and is waiting for its
 // parent to reap it. kill(pid, 0) still succeeds for this state.
 const darwinProcessStateZombie int8 = 5
+const darwinNoControllingTerminal int32 = -1
 
 var (
 	readDarwinKinfoProc       = unix.SysctlKinfoProc
@@ -47,6 +48,8 @@ func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
 	sec, nsec := kp.Proc.P_starttime.Unix()
 	info.StartToken = fmt.Sprintf("%d.%09d", sec, nsec)
 	info.Executable = nulTerminatedString(kp.Proc.P_comm[:])
+	info.ControllingTerminalKnown = true
+	info.HasControllingTerminal = kp.Eproc.Tdev != darwinNoControllingTerminal
 
 	info.BootID, info.LegacyBootID = darwinBootIdentity()
 

--- a/internal/cli/wake_process_darwin_test.go
+++ b/internal/cli/wake_process_darwin_test.go
@@ -42,6 +42,34 @@ func TestInspectWakeProcessPlatformPreservesAliveStateWhenKinfoFails(t *testing.
 	}
 }
 
+func TestInspectWakeProcessPlatformReportsControllingTerminalState(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tdev int32
+		has  bool
+	}{
+		{name: "terminal gone", tdev: darwinNoControllingTerminal, has: false},
+		{name: "terminal present", tdev: 1234, has: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := readDarwinKinfoProc
+			readDarwinKinfoProc = func(string, ...int) (*unix.KinfoProc, error) {
+				return &unix.KinfoProc{
+					Proc:  unix.ExternProc{P_stat: 1},
+					Eproc: unix.Eproc{Tdev: tc.tdev},
+				}, nil
+			}
+			t.Cleanup(func() { readDarwinKinfoProc = old })
+
+			info := inspectWakeProcessPlatform(os.Getpid())
+			if !info.ControllingTerminalKnown || info.HasControllingTerminal != tc.has {
+				t.Fatalf("terminal state = known:%v has:%v, want known:true has:%v",
+					info.ControllingTerminalKnown, info.HasControllingTerminal, tc.has)
+			}
+		})
+	}
+}
+
 func stubDarwinBootIdentityReaders(
 	t *testing.T,
 	session func() (string, error),

--- a/internal/cli/wake_raw_orphan_darwin_test.go
+++ b/internal/cli/wake_raw_orphan_darwin_test.go
@@ -5,7 +5,15 @@ package cli
 import "testing"
 
 func TestLiveRawOrphanState(t *testing.T) {
-	i := wakeLockInspection{IdentityConfirmed: true, Process: wakeProcessInfo{Running: true}, Lock: wakeLock{WakeMode: "raw"}}
+	i := wakeLockInspection{
+		IdentityConfirmed: true,
+		Process: wakeProcessInfo{
+			Running:                  true,
+			ControllingTerminalKnown: true,
+			HasControllingTerminal:   false,
+		},
+		Lock: wakeLock{WakeMode: "raw"},
+	}
 	if !isLiveRawOrphan(i) {
 		t.Fatal("expected live raw orphan")
 	}
@@ -24,5 +32,38 @@ func TestLiveRawOrphanState(t *testing.T) {
 	i.Process.Running = false
 	if isLiveRawOrphan(i) {
 		t.Fatal("dead process is not a live raw orphan")
+	}
+}
+
+func TestDoctorReportsLiveRawOrphan(t *testing.T) {
+	const pid = 66121
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          "unknown",
+		ProcessStart: "recorded-start",
+		BootID:       "recorded-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		Generation:   "live-raw-orphan",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:                      gotPID,
+			Running:                  true,
+			StartToken:               "recorded-start",
+			BootID:                   "recorded-boot",
+			Executable:               "/opt/homebrew/bin/amq",
+			ControllingTerminalKnown: true,
+			HasControllingTerminal:   false,
+		}
+	})
+
+	locks := checkWakeLocks(root, []string{"codex"}, false)
+	if len(locks) != 1 {
+		t.Fatalf("wake locks = %#v", locks)
+	}
+	got := locks[0]
+	if got.Status != "live-raw-orphan" {
+		t.Fatalf("status = %q", got.Status)
 	}
 }

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -1568,7 +1568,7 @@ func TestRunWakeRepairClearsRepairAvailableAfterStartFailure(t *testing.T) {
 func TestBuildCoopWakeArgsIncludesInjectViaTarget(t *testing.T) {
 	args := buildCoopWakeArgs("codex", "/tmp/root", wakeInjectModeAuto, "/abs/injector", []string{"exec", "target"}, "/tmp/ready")
 	got := strings.Join(args, "|")
-	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--interrupt-cmd|none|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready|--accept-existing-wake"
+	want := "--no-update-check|wake|--me|codex|--root|/tmp/root|--baseline-existing|--interrupt-cmd|none|--refuse-unverified-wake|--inject-via|/abs/injector|--inject-arg|exec|--inject-arg|target|--ready-file|/tmp/ready|--accept-existing-wake"
 	if got != want {
 		t.Fatalf("args = %q, want %q", got, want)
 	}

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -18,6 +18,17 @@ var signalWakeProcess = func(pid int, sig os.Signal) error {
 }
 
 func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
+	return terminateAndRemoveOrphanedWakeLockWithRawConsent(inspection, false)
+}
+
+func retireLiveRawOrphan(inspection wakeLockInspection) (bool, error) {
+	return terminateAndRemoveOrphanedWakeLockWithRawConsent(inspection, true)
+}
+
+func terminateAndRemoveOrphanedWakeLockWithRawConsent(
+	inspection wakeLockInspection,
+	allowRawOrphan bool,
+) (bool, error) {
 	var recheck wakeLockInspection
 	if err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
 		recheck = inspectWakeLock(inspection.Root, inspection.Agent)
@@ -32,7 +43,9 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 		return false, nil
 	}
 	if recheck.Process.Running && recheck.Lock.WakeMode != wakeTargetInjectVia {
-		return false, fmt.Errorf("live raw wake orphan for %s (pid %d, start %s); stop the owning terminal/launchd supervisor; manual kill is non-identity-safe — recheck before running; see doctor --ops", recheck.Agent, recheck.PID, recheck.Lock.ProcessStart)
+		if !allowRawOrphan || !isLiveRawOrphan(recheck) {
+			return false, fmt.Errorf("live raw wake orphan for %s (pid %d, start %s); stop the owning terminal/launchd supervisor; manual kill is non-identity-safe — recheck before running; see doctor --ops", recheck.Agent, recheck.PID, recheck.Lock.ProcessStart)
+		}
 	}
 	if recheck.Process.Running && recheck.Lock.WakeMode == wakeTargetInjectVia {
 		return cooperativeStopInjectVia(recheck)
@@ -65,7 +78,8 @@ func isLiveRawOrphan(inspection wakeLockInspection) bool {
 	return inspection.Process.Running &&
 		inspection.IdentityConfirmed &&
 		inspection.Lock.WakeMode != wakeTargetInjectVia &&
-		!wakeLockHasOwnerMarkers(inspection)
+		!wakeLockHasOwnerMarkers(inspection) &&
+		wakeLockTerminalGone(inspection)
 }
 
 func terminateWakeProcess(inspection wakeLockInspection) error {

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -104,6 +104,13 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	return removed, err
 }
 
+func retireLiveRawOrphan(inspection wakeLockInspection) (bool, error) {
+	if !isLiveRawOrphan(inspection) {
+		return false, fmt.Errorf("wake is not an identity-confirmed live raw orphan")
+	}
+	return terminateAndRemoveOrphanedWakeLock(inspection)
+}
+
 func terminateWakePidfd(pidfd int) error {
 	if err := linuxPidfdSendSignal(pidfd, unix.SIGTERM, nil, 0); err != nil {
 		if errors.Is(err, syscall.ESRCH) {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -82,12 +82,13 @@ func (child *wakeRepairChild) Admit() error {
 }
 
 type wakeLockAcquireOptions struct {
-	acceptExistingValid  bool
-	target               *wakeTarget
-	wakeMode             string
-	requestedOwner       *wakeOwner
-	repairLineage        *wakeRepairLineage
-	repairFloorAuthority *wakeRepairFloorAuthority
+	acceptExistingValid     bool
+	refuseUnverifiedGeneric bool
+	target                  *wakeTarget
+	wakeMode                string
+	requestedOwner          *wakeOwner
+	repairLineage           *wakeRepairLineage
+	repairFloorAuthority    *wakeRepairFloorAuthority
 }
 
 type wakeLockCreatingError struct{}
@@ -258,6 +259,14 @@ func acquireWakeLockWithOptionsInDir(
 					}
 					return wakeLockAlreadyRunningError(me, inspection)
 				case wakeLockUnverified:
+					if options.refuseUnverifiedGeneric {
+						return fmt.Errorf(
+							"wake lock for %s cannot be verified; lock: %s; root: %s; retry coop exec with -y",
+							me,
+							inspection.LockPath,
+							inspection.Root,
+						)
+					}
 					if err := supersedeUnverifiedGenericWakeAt(dirfd, agentDir, inspection); err != nil {
 						return err
 					}
@@ -543,10 +552,8 @@ func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
 
 	// Process is a confirmed matching amq wake. If its TTY disappeared, stop
 	// that orphan before taking over; never signal an unconfirmed PID.
-	if strings.HasPrefix(existing.TTY, "/dev/") {
-		if _, statErr := os.Stat(existing.TTY); os.IsNotExist(statErr) {
-			return true
-		}
+	if wakeLockTerminalGone(inspection) {
+		return true
 	}
 
 	currentTTY := getWakeCurrentTTY()
@@ -564,6 +571,17 @@ func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
 		}
 	}
 	return false
+}
+
+func wakeLockTerminalGone(inspection wakeLockInspection) bool {
+	tty := strings.TrimSpace(inspection.Lock.TTY)
+	if strings.HasPrefix(tty, "/dev/") {
+		if _, statErr := os.Stat(tty); os.IsNotExist(statErr) {
+			return true
+		}
+	}
+	return inspection.Process.ControllingTerminalKnown &&
+		!inspection.Process.HasControllingTerminal
 }
 
 func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string, requestedTarget *wakeTarget) error {
@@ -1360,11 +1378,12 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 	readyFileFlag := fs.String("ready-file", "", "Internal: write this file after wake lock acquisition")
 	debugFlag := fs.Bool("debug", false, "Log injection diagnostics to stderr")
 	acceptExistingWakeFlag := fs.Bool("accept-existing-wake", false, "Internal: allow a usable existing wake to satisfy readiness")
+	refuseUnverifiedWakeFlag := fs.Bool("refuse-unverified-wake", false, "Internal: refuse unverified wake locks instead of superseding them")
 	repairLineageFlag := fs.String("repair-lineage", "", "Internal: inherit the suppression floor from an exact dead wake generation")
 	baselineExistingFlag := fs.Bool("baseline-existing", false, "Ignore messages already waiting when this wake starts")
 
 	usage := usageWithHiddenFlags(fs, "amq wake --me <agent> [options]",
-		[]string{"ready-file", "accept-existing-wake", "repair-lineage"},
+		[]string{"ready-file", "accept-existing-wake", "refuse-unverified-wake", "repair-lineage"},
 		"Background waker: injects terminal notification when messages arrive.",
 		"Run as background job before starting CLI: amq wake --me claude --interrupt-cmd none &",
 		"",
@@ -1680,11 +1699,12 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 			}
 		}
 		options := wakeLockAcquireOptions{
-			acceptExistingValid: acceptExistingWake,
-			target:              target,
-			wakeMode:            lockWakeMode,
-			requestedOwner:      requestedOwner,
-			repairLineage:       repairLineage,
+			acceptExistingValid:     acceptExistingWake,
+			refuseUnverifiedGeneric: *refuseUnverifiedWakeFlag,
+			target:                  target,
+			wakeMode:                lockWakeMode,
+			requestedOwner:          requestedOwner,
+			repairLineage:           repairLineage,
 		}
 		if repairLineage != nil {
 			options.repairFloorAuthority = &repairFloorAuthority


### PR DESCRIPTION
## Summary
- let `coop exec -y` clear blocking unverified wake metadata without signaling ambiguous PIDs
- refuse proven foreign processes and guard live raw-orphan takeover behind exact identity plus terminal-loss evidence
- preserve stale cleanup and prevent the spawned wake from racing a newly unverified generation

## Verification
- `go test ./internal/cli -count=1`
- peer-reviewed staged tree `00024c25cbd9edb98dda9848cfc61a6e4333a483` / diff `37fdb369bdb49bd7d335e9edc8f3f7812da441be7df0154664722d4419f985d1`