### PR TITLE
fix: deliver wake attention in Ghostty

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -55,6 +55,10 @@ type wakeConfig struct {
 	retainedInbox        wakeInboxReader
 	touchPresence        func() error
 	recordNotifierStatus func(status, mode, reason string) error
+	recordAttention      func(wakeAttentionEmission) error
+	attentionEnv         func(string) string
+	attentionIsTTY       func() bool
+	attentionWrite       func([]byte) (int, error)
 }
 
 type wakeAdmissionWatcher interface {
@@ -114,6 +118,45 @@ type wakeMsgInfo struct {
 	subject  string
 	priority string
 	labels   []string
+}
+
+type wakePayloadProvenance string
+
+const (
+	wakePayloadSystemFixed  wakePayloadProvenance = "system_fixed"
+	wakePayloadPeerHeaders  wakePayloadProvenance = "peer_headers"
+	wakePayloadOperatorFlag wakePayloadProvenance = "operator_flag"
+)
+
+type wakePayload struct {
+	text       string
+	provenance wakePayloadProvenance
+}
+
+type wakeNotification struct {
+	input  wakePayload
+	output wakePayload
+}
+
+func peerWakeNotification(output string) wakeNotification {
+	return wakeNotification{
+		input: wakePayload{
+			text:       coopWakeDoorbell,
+			provenance: wakePayloadSystemFixed,
+		},
+		output: wakePayload{
+			text:       output,
+			provenance: wakePayloadPeerHeaders,
+		},
+	}
+}
+
+func operatorWakeNotification(text string) wakeNotification {
+	payload := wakePayload{
+		text:       text,
+		provenance: wakePayloadOperatorFlag,
+	}
+	return wakeNotification{input: payload, output: payload}
 }
 
 type ttyInputState struct {
@@ -283,21 +326,19 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		return nil
 	}
 
-	// A supervised/co-op wake is only a fixed doorbell. Message headers,
-	// session names, custom notices, commands, and urgency never become
-	// terminal input.
-	if usesCoopDoorbell(cfg) {
-		return injectNotification(cfg, coopWakeDoorbell, len(interruptMessages) == 0)
-	}
-
 	if cfg.interrupt && len(interruptMessages) > 0 {
 		interruptText := buildInterruptText(cfg.session, interruptMessages, interruptCounts, cfg.previewLen, cfg.interruptNotice)
+		notice := peerWakeNotification(interruptText)
+		if cfg.interruptNotice != "" {
+			notice = operatorWakeNotification(interruptText)
+		}
 		if cfg.injectMode == wakeInjectModeNone {
-			writeWakeOutput(interruptText, true)
-			return nil
+			return deliverWakeNotification(cfg, notice, false)
 		}
 		now := time.Now()
-		if cfg.interruptKey != "" && shouldInterruptNow(cfg, now) {
+		if !usesCoopDoorbell(cfg) &&
+			cfg.interruptKey != "" &&
+			shouldInterruptNow(cfg, now) {
 			if cfg.injectVia != "" {
 				allowed, guardErr := authorizeTerminalWrite(cfg)
 				if guardErr != nil {
@@ -323,25 +364,59 @@ func notifyNewMessages(cfg *wakeConfig) error {
 				}
 			}
 		}
-		notificationText := coopWakeDoorbell
-		if cfg.interruptNotice != "" {
-			notificationText = interruptText
-		}
-		return injectNotification(cfg, notificationText, false)
+		return deliverWakeNotification(cfg, notice, false)
 	}
 
-	// Build notification text
-	var text string
+	var notice wakeNotification
 	if cfg.injectCmd != "" {
-		// Power user mode: inject actual command
-		text = "\n" + sanitizeForTTY(cfg.injectCmd) + "\n"
+		// Power user mode: inject the operator-authored command.
+		text := "\n" + sanitizeForTTY(cfg.injectCmd) + "\n"
+		notice = operatorWakeNotification(text)
 	} else {
-		// Peer-derived headers never enter terminal input. The fixed prefix is
-		// shell-inert if a standalone wake lands at a shell prompt.
-		text = coopWakeDoorbell
+		notice = peerWakeNotification(
+			buildNotificationText(cfg.session, messages, cfg.previewLen),
+		)
 	}
 
-	return injectNotification(cfg, text, true)
+	return deliverWakeNotification(cfg, notice, true)
+}
+
+func buildNotificationText(session string, messages []wakeMsgInfo, previewLen int) string {
+	count := len(messages)
+	prefix := notificationPrefix("AMQ", session)
+	if count == 1 {
+		msg := messages[0]
+		subject := msg.subject
+		if subject == "" {
+			subject = "(no subject)"
+		}
+		return fmt.Sprintf(
+			"%s: message from %s - %s. Drain with: amq drain --include-body — then act on it",
+			prefix,
+			msg.from,
+			truncateSubject(subject, previewLen),
+		)
+	}
+
+	senderCounts := make(map[string]int)
+	for _, msg := range messages {
+		senderCounts[msg.from]++
+	}
+	senders := make([]string, 0, len(senderCounts))
+	for sender := range senderCounts {
+		senders = append(senders, sender)
+	}
+	sort.Strings(senders)
+	parts := make([]string, 0, len(senders))
+	for _, sender := range senders {
+		parts = append(parts, fmt.Sprintf("%d from %s", senderCounts[sender], sender))
+	}
+	return fmt.Sprintf(
+		"%s: %d messages - %s. Drain with: amq drain --include-body — then act on it",
+		prefix,
+		count,
+		strings.Join(parts, ", "),
+	)
 }
 
 func buildInterruptText(session string, messages []wakeMsgInfo, senderCounts map[string]int, previewLen int, custom string) string {
@@ -454,32 +529,43 @@ func normalizeWakeInjectMode(raw string) (string, error) {
 	}
 }
 
-func writeWakeOutput(text string, bell bool) {
-	if bell {
-		text = "\a" + text
+// injectNotification preserves the legacy test/internal string helper. New
+// production routing uses deliverWakeNotification so input and output sources
+// remain explicit.
+func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error {
+	payload := wakePayload{
+		text:       text,
+		provenance: wakePayloadSystemFixed,
 	}
-	_, _ = fmt.Fprint(os.Stderr, text+"\n")
+	return deliverWakeNotification(
+		cfg,
+		wakeNotification{input: payload, output: payload},
+		deferForInput,
+	)
 }
 
-func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error {
+func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForInput bool) error {
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound {
-		text = coopWakeDoorbell
+		notice.input = wakePayload{
+			text:       coopWakeDoorbell,
+			provenance: wakePayloadSystemFixed,
+		}
 	}
 	if cfg.injectMode == wakeInjectModeNone {
-		writeWakeOutput(text, cfg.bell && !ownerBound)
+		emitWakeAttention(cfg, notice.output)
 		return nil
 	}
 
-	// Keep plain text for stderr fallback
-	plainText := text
+	inputText := notice.input.text
+	plainText := inputText
 	if cfg.bell && !ownerBound {
 		plainText = "\a" + plainText
 	}
 
 	if shouldDeferBeforeInject(cfg, deferForInput) {
 		if !waitForWakeInputQuiet(cfg) {
-			writeWakeOutput(text, cfg.bell && !ownerBound)
+			emitWakeAttention(cfg, notice.output)
 			return nil
 		}
 	}
@@ -500,14 +586,14 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 				_ = writeStderr("amq wake: falling back to stderr notification\n")
 				cfg.fallbackWarn = false
 			}
-			_, _ = fmt.Fprint(os.Stderr, plainText+"\n")
+			emitWakeAttention(cfg, notice.output)
 		}
 		return nil
 	}
 
 	mode := effectiveInjectMode(cfg)
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: mode=%s text_len=%d\n", mode, len(text))
+		_ = writeStderr("amq wake [debug]: mode=%s text_len=%d\n", mode, len(inputText))
 	}
 	var injectErr error
 	switch mode {
@@ -515,7 +601,7 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		// Raw mode: inject text and CR separately to avoid paste detection.
 		// Ink treats multi-char input as paste, not keypresses. Sending text+CR
 		// as one chunk makes Ink see pasted text, not an Enter keypress.
-		injectedText := text
+		injectedText := inputText
 		if cfg.bell && !ownerBound {
 			injectedText = "\a" + injectedText
 		}
@@ -525,9 +611,9 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 		// Paste mode: bracketed paste with delayed CR
 		// Works with crossterm/ratatui apps
 		// Send paste content first, then CR after short delay to avoid coalescing
-		pasteText := text
+		pasteText := inputText
 		if !ownerBound {
-			pasteText = "\x1b[200~" + text + "\x1b[201~"
+			pasteText = "\x1b[200~" + inputText + "\x1b[201~"
 		}
 		if cfg.bell && !ownerBound {
 			pasteText = "\a" + pasteText
@@ -544,14 +630,14 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	default:
 		// Unknown mode, fall back to raw
 		if ownerBound {
-			wrote, err := writeTerminalChunk(cfg, text)
+			wrote, err := writeTerminalChunk(cfg, inputText)
 			if err != nil {
 				injectErr = err
 			} else if wrote {
 				_, injectErr = writeTerminalChunk(cfg, "\r")
 			}
 		} else {
-			injectedText := text + "\r"
+			injectedText := inputText + "\r"
 			if cfg.bell {
 				injectedText = "\a" + injectedText
 			}
@@ -576,7 +662,7 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 			cfg.injectMode = wakeInjectModeNone
 			_ = writeStderr("amq wake: warning: %s\n", reason)
 			cfg.fallbackWarn = false
-			_, _ = fmt.Fprint(os.Stderr, plainText+"\n")
+			emitWakeAttention(cfg, notice.output)
 			return nil
 		}
 		var authorityErr *wakeTerminalAuthorityError
@@ -588,8 +674,8 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 			_ = writeStderr("amq wake: falling back to stderr notification\n")
 			cfg.fallbackWarn = false
 		}
-		// Fallback: print plain text to stderr (no escape sequences)
-		_, _ = fmt.Fprint(os.Stderr, plainText+"\n")
+		// Fallback: use the output-only attention tier; never retry input.
+		emitWakeAttention(cfg, notice.output)
 		return nil
 	}
 

--- a/internal/cli/wake_attention.go
+++ b/internal/cli/wake_attention.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+const (
+	wakeAttentionEffectOutput = "stderr_output_written"
+	wakeAttentionEffectBell   = "bell_byte_written"
+	wakeAttentionEffectTitle  = "title_sequence_written"
+	wakeAttentionEffectOSC9   = "osc9_sequence_written"
+	wakeAttentionEffectOSC777 = "osc777_sequence_written"
+
+	wakeAttentionTitle = "AMQ attention"
+)
+
+type wakeAttentionEmission struct {
+	Effects          []string
+	OutputProvenance wakePayloadProvenance
+}
+
+// emitWakeAttention is the non-input destination for a wake notification.
+// Effects record only a complete write by AMQ; they do not assert that a
+// terminal rendered them or that a person observed them.
+func emitWakeAttention(cfg *wakeConfig, payload wakePayload) {
+	effects := []string{wakeAttentionEffectOutput}
+	var output strings.Builder
+
+	safeText := sanitizeForTTY(payload.text)
+	if wakeAttentionIsTerminal(cfg) {
+		effects = append(effects, wakeAttentionEffectBell, wakeAttentionEffectTitle)
+		// OSC 0 and a standalone BEL form the portable terminal-attention floor.
+		// The BEL terminating OSC 0 is not relied on to ring.
+		fmt.Fprintf(&output, "\x1b]0;%s\a\a", wakeAttentionTitle)
+
+		oscText := strings.ReplaceAll(safeText, ";", ",")
+		switch supportedWakeAttentionNotification(cfg) {
+		case wakeAttentionEffectOSC9:
+			fmt.Fprintf(&output, "\x1b]9;%s\a", oscText)
+			effects = append(effects, wakeAttentionEffectOSC9)
+		case wakeAttentionEffectOSC777:
+			fmt.Fprintf(&output, "\x1b]777;notify;AMQ;%s\a", oscText)
+			effects = append(effects, wakeAttentionEffectOSC777)
+		}
+	}
+	output.WriteString(safeText)
+	output.WriteByte('\n')
+
+	write := func(data []byte) (int, error) {
+		return os.Stderr.Write(data)
+	}
+	if cfg != nil && cfg.attentionWrite != nil {
+		write = cfg.attentionWrite
+	}
+	data := []byte(output.String())
+	n, err := write(data)
+	if err != nil || n != len(data) {
+		if err == nil {
+			err = io.ErrShortWrite
+		}
+		_ = writeStderr("amq wake: output attention write failed after %d/%d bytes: %v\n", n, len(data), err)
+		return
+	}
+
+	if cfg != nil && cfg.recordAttention != nil {
+		emission := wakeAttentionEmission{
+			Effects:          append([]string(nil), effects...),
+			OutputProvenance: payload.provenance,
+		}
+		if err := cfg.recordAttention(emission); err != nil {
+			_ = writeStderr("amq wake: record output attention write: %v\n", err)
+		}
+	}
+}
+
+func wakeAttentionIsTerminal(cfg *wakeConfig) bool {
+	if cfg != nil && cfg.attentionIsTTY != nil {
+		return cfg.attentionIsTTY()
+	}
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+func supportedWakeAttentionNotification(cfg *wakeConfig) string {
+	lookup := os.Getenv
+	if cfg != nil && cfg.attentionEnv != nil {
+		lookup = cfg.attentionEnv
+	}
+	// Keep this as a verified-upstream allowlist. Unknown terminals
+	// deliberately receive only the portable bell/title/output floor.
+	switch lookup("TERM_PROGRAM") {
+	case "iTerm.app", "ghostty":
+		return wakeAttentionEffectOSC9
+	}
+	if isPositiveDecimal(lookup("VTE_VERSION")) {
+		return wakeAttentionEffectOSC777
+	}
+	return ""
+}
+
+func isPositiveDecimal(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return strings.TrimLeft(value, "0") != ""
+}

--- a/internal/cli/wake_attention_test.go
+++ b/internal/cli/wake_attention_test.go
@@ -1,0 +1,434 @@
+package cli
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func testWakeNotification(input, output string, provenance wakePayloadProvenance) wakeNotification {
+	return wakeNotification{
+		input: wakePayload{
+			text:       input,
+			provenance: wakePayloadSystemFixed,
+		},
+		output: wakePayload{
+			text:       output,
+			provenance: provenance,
+		},
+	}
+}
+
+func testOutputAttentionConfig(recorded *wakeAttentionEmission) *wakeConfig {
+	return &wakeConfig{
+		attentionEnv:   func(string) string { return "" },
+		attentionIsTTY: func() bool { return true },
+		recordAttention: func(emission wakeAttentionEmission) error {
+			*recorded = emission
+			return nil
+		},
+	}
+}
+
+func TestDeliverWakeNotificationSuccessUsesOnlyInput(t *testing.T) {
+	var writes []string
+	cfg := &wakeConfig{
+		injectMode: wakeInjectModePaste,
+		terminalWrite: func(chunk string) error {
+			writes = append(writes, chunk)
+			return nil
+		},
+	}
+	notice := testWakeNotification(
+		coopWakeDoorbell,
+		"AMQ: message from peer - output only",
+		wakePayloadPeerHeaders,
+	)
+
+	stderr := captureWakeStderr(t, func() {
+		if err := deliverWakeNotification(cfg, notice, false); err != nil {
+			t.Fatalf("deliverWakeNotification: %v", err)
+		}
+	})
+
+	if stderr != "" {
+		t.Fatalf("successful input delivery wrote output: %q", stderr)
+	}
+	got := strings.Join(writes, "|")
+	if !strings.Contains(got, coopWakeDoorbell) {
+		t.Fatalf("input chunks = %#v, missing fixed doorbell", writes)
+	}
+	if strings.Contains(got, "peer") || strings.Contains(got, "output only") {
+		t.Fatalf("peer-derived output entered terminal input: %#v", writes)
+	}
+}
+
+func TestDeliverWakeNotificationNonInputOutcomesUseOnlyOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, *wakeConfig)
+	}{
+		{
+			name: "none",
+			setup: func(_ *testing.T, cfg *wakeConfig) {
+				cfg.injectMode = wakeInjectModeNone
+			},
+		},
+		{
+			name: "max hold",
+			setup: func(t *testing.T, cfg *wakeConfig) {
+				old := waitForWakeInputQuiet
+				waitForWakeInputQuiet = func(*wakeConfig) bool { return false }
+				t.Cleanup(func() { waitForWakeInputQuiet = old })
+				cfg.injectMode = wakeInjectModeRaw
+				cfg.deferWhileInput = true
+			},
+		},
+		{
+			name: "unsupported",
+			setup: func(_ *testing.T, cfg *wakeConfig) {
+				cfg.injectMode = wakeInjectModeRaw
+				cfg.terminalWrite = func(string) error {
+					return newWakeInjectorUnsupportedError(syscall.EIO)
+				}
+			},
+		},
+		{
+			name: "generic failure",
+			setup: func(t *testing.T, cfg *wakeConfig) {
+				cfg.injectMode = wakeInjectModeRaw
+				stubTIOCSTIInject(t, func(string) error {
+					return errors.New("terminal write failed")
+				})
+			},
+		},
+		{
+			name: "inject via failure",
+			setup: func(_ *testing.T, cfg *wakeConfig) {
+				cfg.injectVia = "/nonexistent/amq-output-attention-injector"
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var emission wakeAttentionEmission
+			cfg := testOutputAttentionConfig(&emission)
+			tc.setup(t, cfg)
+			notice := testWakeNotification(
+				coopWakeDoorbell,
+				"AMQ: message from peer - output only",
+				wakePayloadPeerHeaders,
+			)
+
+			stderr := captureWakeStderr(t, func() {
+				if err := deliverWakeNotification(cfg, notice, true); err != nil {
+					t.Fatalf("deliverWakeNotification: %v", err)
+				}
+			})
+
+			if !strings.Contains(stderr, "message from peer - output only") {
+				t.Fatalf("fallback output = %q, missing peer output", stderr)
+			}
+			if strings.Contains(stderr, coopWakeDoorbell) {
+				t.Fatalf("fallback output leaked input payload: %q", stderr)
+			}
+			if emission.OutputProvenance != wakePayloadPeerHeaders {
+				t.Fatalf("output provenance = %q, want peer headers", emission.OutputProvenance)
+			}
+		})
+	}
+}
+
+func TestDeliverWakeNotificationOwnerBoundForcesOnlyInput(t *testing.T) {
+	stop := make(chan struct{})
+	var writes []string
+	cfg := &wakeConfig{
+		injectMode:  wakeInjectModePaste,
+		controlStop: stop,
+		beforeTerminalWrite: func() error {
+			return nil
+		},
+		terminalWrite: func(chunk string) error {
+			writes = append(writes, chunk)
+			return nil
+		},
+	}
+	notice := wakeNotification{
+		input: wakePayload{
+			text:       "operator input",
+			provenance: wakePayloadOperatorFlag,
+		},
+		output: wakePayload{
+			text:       "operator output",
+			provenance: wakePayloadOperatorFlag,
+		},
+	}
+
+	if err := deliverWakeNotification(cfg, notice, false); err != nil {
+		t.Fatalf("deliverWakeNotification: %v", err)
+	}
+	if got := strings.Join(writes, "|"); !strings.Contains(got, coopWakeDoorbell) ||
+		strings.Contains(got, "operator input") ||
+		strings.Contains(got, "operator output") {
+		t.Fatalf("owner-bound input chunks = %#v", writes)
+	}
+
+	cfg.injectMode = wakeInjectModeNone
+	var emission wakeAttentionEmission
+	cfg.attentionEnv = func(string) string { return "" }
+	cfg.attentionIsTTY = func() bool { return true }
+	cfg.recordAttention = func(got wakeAttentionEmission) error {
+		emission = got
+		return nil
+	}
+	stderr := captureWakeStderr(t, func() {
+		if err := deliverWakeNotification(cfg, notice, false); err != nil {
+			t.Fatalf("none-mode deliverWakeNotification: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "operator output") || strings.Contains(stderr, coopWakeDoorbell) {
+		t.Fatalf("owner-bound output = %q", stderr)
+	}
+	if emission.OutputProvenance != wakePayloadOperatorFlag {
+		t.Fatalf("output provenance = %q, want operator", emission.OutputProvenance)
+	}
+
+	emission = wakeAttentionEmission{}
+	peerNotice := peerWakeNotification("peer output")
+	stderr = captureWakeStderr(t, func() {
+		if err := deliverWakeNotification(cfg, peerNotice, false); err != nil {
+			t.Fatalf("peer none-mode deliverWakeNotification: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "peer output") || strings.Contains(stderr, coopWakeDoorbell) {
+		t.Fatalf("owner-bound peer output = %q", stderr)
+	}
+	if emission.OutputProvenance != wakePayloadPeerHeaders {
+		t.Fatalf("peer output provenance = %q, want peer headers", emission.OutputProvenance)
+	}
+}
+
+func TestDeliverWakeNotificationUnsupportedDemotionUsesEachCurrentOutput(t *testing.T) {
+	writes := 0
+	var provenances []wakePayloadProvenance
+	cfg := &wakeConfig{
+		injectMode: wakeInjectModeRaw,
+		terminalWrite: func(string) error {
+			writes++
+			return newWakeInjectorUnsupportedError(syscall.EIO)
+		},
+		attentionIsTTY: func() bool { return false },
+		recordAttention: func(emission wakeAttentionEmission) error {
+			provenances = append(provenances, emission.OutputProvenance)
+			return nil
+		},
+	}
+
+	first := captureWakeStderr(t, func() {
+		if err := deliverWakeNotification(
+			cfg,
+			peerWakeNotification("first peer output"),
+			false,
+		); err != nil {
+			t.Fatalf("first delivery: %v", err)
+		}
+	})
+	second := captureWakeStderr(t, func() {
+		if err := deliverWakeNotification(
+			cfg,
+			peerWakeNotification("second peer output"),
+			false,
+		); err != nil {
+			t.Fatalf("second delivery: %v", err)
+		}
+	})
+
+	if writes != 1 {
+		t.Fatalf("terminal writes = %d, want one failed attempt before demotion", writes)
+	}
+	if !strings.Contains(first, "first peer output") ||
+		strings.Contains(first, "second peer output") {
+		t.Fatalf("first output = %q", first)
+	}
+	if !strings.Contains(second, "second peer output") ||
+		strings.Contains(second, "first peer output") {
+		t.Fatalf("second output = %q", second)
+	}
+	if !reflect.DeepEqual(provenances, []wakePayloadProvenance{
+		wakePayloadPeerHeaders,
+		wakePayloadPeerHeaders,
+	}) {
+		t.Fatalf("output provenances = %#v", provenances)
+	}
+}
+
+func TestWakeAttentionReportsOnlyFullyWrittenOutputEffectsAndProvenance(t *testing.T) {
+	payload := wakePayload{
+		text:       "safe notice",
+		provenance: wakePayloadPeerHeaders,
+	}
+	var recorded wakeAttentionEmission
+	cfg := testOutputAttentionConfig(&recorded)
+
+	stderr := captureWakeStderr(t, func() {
+		emitWakeAttention(cfg, payload)
+	})
+	for _, want := range []string{
+		"\x1b]0;AMQ attention\a",
+		"\a",
+		"safe notice\n",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr %q does not contain %q", stderr, want)
+		}
+	}
+	if recorded.OutputProvenance != wakePayloadPeerHeaders {
+		t.Fatalf("provenance = %q, want peer headers", recorded.OutputProvenance)
+	}
+	wantEffects := []string{
+		wakeAttentionEffectOutput,
+		wakeAttentionEffectBell,
+		wakeAttentionEffectTitle,
+	}
+	if !reflect.DeepEqual(recorded.Effects, wantEffects) {
+		t.Fatalf("effects = %#v, want %#v", recorded.Effects, wantEffects)
+	}
+
+	recorded = wakeAttentionEmission{}
+	cfg.attentionWrite = func(data []byte) (int, error) {
+		return len(data) - 1, nil
+	}
+	stderr = captureWakeStderr(t, func() {
+		emitWakeAttention(cfg, payload)
+	})
+	if recorded.OutputProvenance != "" || recorded.Effects != nil {
+		t.Fatalf("partial write recorded emission: %#v", recorded)
+	}
+	if !strings.Contains(stderr, "output attention write failed") {
+		t.Fatalf("partial-write diagnostic missing: %q", stderr)
+	}
+}
+
+func TestWakeAttentionRedirectedOutputOmitsControls(t *testing.T) {
+	var recorded wakeAttentionEmission
+	cfg := &wakeConfig{
+		attentionIsTTY: func() bool { return false },
+		recordAttention: func(emission wakeAttentionEmission) error {
+			recorded = emission
+			return nil
+		},
+	}
+	payload := wakePayload{
+		text:       "peer\x1b]2;spoof\a",
+		provenance: wakePayloadPeerHeaders,
+	}
+
+	stderr := captureWakeStderr(t, func() {
+		emitWakeAttention(cfg, payload)
+	})
+	if stderr != "peer ]2;spoof \n" {
+		t.Fatalf("redirected output = %q", stderr)
+	}
+	if !reflect.DeepEqual(recorded.Effects, []string{wakeAttentionEffectOutput}) {
+		t.Fatalf("redirected effects = %#v", recorded.Effects)
+	}
+}
+
+func TestWakeAttentionOptionalOSCRequiresPositiveTerminalSupport(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        map[string]string
+		wantEffect string
+		wantBytes  string
+	}{
+		{
+			name: "unknown terminal",
+			env:  map[string]string{"TERM_PROGRAM": "unknown"},
+		},
+		{
+			name:       "iterm osc9",
+			env:        map[string]string{"TERM_PROGRAM": "iTerm.app"},
+			wantEffect: wakeAttentionEffectOSC9,
+			wantBytes:  "\x1b]9;safe,notice\a",
+		},
+		{
+			name:       "ghostty osc9",
+			env:        map[string]string{"TERM_PROGRAM": "ghostty"},
+			wantEffect: wakeAttentionEffectOSC9,
+			wantBytes:  "\x1b]9;safe,notice\a",
+		},
+		{
+			name:       "vte osc777",
+			env:        map[string]string{"VTE_VERSION": "7600"},
+			wantEffect: wakeAttentionEffectOSC777,
+			wantBytes:  "\x1b]777;notify;AMQ;safe,notice\a",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var recorded wakeAttentionEmission
+			cfg := &wakeConfig{
+				attentionIsTTY: func() bool { return true },
+				attentionEnv: func(key string) string {
+					return tc.env[key]
+				},
+				recordAttention: func(emission wakeAttentionEmission) error {
+					recorded = emission
+					return nil
+				},
+			}
+			stderr := captureWakeStderr(t, func() {
+				emitWakeAttention(cfg, wakePayload{
+					text:       "safe;notice",
+					provenance: wakePayloadPeerHeaders,
+				})
+			})
+			if tc.wantBytes == "" {
+				if strings.Contains(stderr, "\x1b]9;") ||
+					strings.Contains(stderr, "\x1b]777;") {
+					t.Fatalf("unknown terminal received optional OSC: %q", stderr)
+				}
+				for _, effect := range recorded.Effects {
+					if effect == wakeAttentionEffectOSC9 ||
+						effect == wakeAttentionEffectOSC777 {
+						t.Fatalf("unknown terminal recorded optional OSC effect: %#v", recorded.Effects)
+					}
+				}
+			} else if !strings.Contains(stderr, tc.wantBytes) {
+				t.Fatalf("stderr %q does not contain %q", stderr, tc.wantBytes)
+			}
+			if tc.wantEffect != "" &&
+				recorded.Effects[len(recorded.Effects)-1] != tc.wantEffect {
+				t.Fatalf("effects = %#v, want final %q", recorded.Effects, tc.wantEffect)
+			}
+		})
+	}
+}
+
+func TestWakeAttentionDoesNotInferOperatorProvenanceFromPayloadText(t *testing.T) {
+	var recorded wakeAttentionEmission
+	cfg := &wakeConfig{
+		attentionIsTTY: func() bool { return false },
+		recordAttention: func(emission wakeAttentionEmission) error {
+			recorded = emission
+			return nil
+		},
+	}
+	payload := wakePayload{
+		text:       coopWakeDoorbell,
+		provenance: wakePayloadOperatorFlag,
+	}
+
+	stderr := captureWakeStderr(t, func() {
+		emitWakeAttention(cfg, payload)
+	})
+	if stderr != coopWakeDoorbell+"\n" {
+		t.Fatalf("operator output was content-normalized: %q", stderr)
+	}
+	if recorded.OutputProvenance != wakePayloadOperatorFlag {
+		t.Fatalf("provenance = %q, want operator", recorded.OutputProvenance)
+	}
+}

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -59,6 +59,23 @@ func TestBuildInterruptText_CustomOverride(t *testing.T) {
 	}
 }
 
+func TestBuildNotificationTextRestoresPeerHeadersForOutput(t *testing.T) {
+	text := buildNotificationText(
+		"collab",
+		[]wakeMsgInfo{{from: "codex", subject: "review ready"}},
+		48,
+	)
+	for _, want := range []string{
+		"AMQ [collab]",
+		"message from codex",
+		"review ready",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("notification output %q missing %q", text, want)
+		}
+	}
+}
+
 func TestNotificationPrefix(t *testing.T) {
 	if got := notificationPrefix("AMQ", ""); got != "AMQ" {
 		t.Fatalf("expected 'AMQ', got: %s", got)
@@ -191,7 +208,12 @@ func TestInjectNotificationNoneWritesOutputWithoutTIOCSTI(t *testing.T) {
 	})
 
 	stderr := captureWakeStderr(t, func() {
-		cfg := &wakeConfig{injectMode: wakeInjectModeNone, bell: true}
+		cfg := &wakeConfig{
+			injectMode:     wakeInjectModeNone,
+			bell:           true,
+			attentionEnv:   func(string) string { return "" },
+			attentionIsTTY: func() bool { return true },
+		}
 		if err := injectNotification(cfg, "safe notice", true); err != nil {
 			t.Fatalf("injectNotification: %v", err)
 		}
@@ -200,8 +222,8 @@ func TestInjectNotificationNoneWritesOutputWithoutTIOCSTI(t *testing.T) {
 	if len(injected) != 0 {
 		t.Fatalf("none mode injected terminal input: %q", injected)
 	}
-	if stderr != "\asafe notice\n" {
-		t.Fatalf("stderr = %q, want bell + notice", stderr)
+	if stderr != "\x1b]0;AMQ attention\a\asafe notice\n" {
+		t.Fatalf("stderr = %q, want title + bell + notice", stderr)
 	}
 }
 
@@ -209,6 +231,8 @@ func TestInjectNotificationNoneDoesNotInvokeInjectVia(t *testing.T) {
 	cfg, outputPath := injectViaCaptureConfig(t)
 	cfg.injectMode = wakeInjectModeNone
 	cfg.bell = true
+	cfg.attentionEnv = func(string) string { return "" }
+	cfg.attentionIsTTY = func() bool { return true }
 
 	stderr := captureWakeStderr(t, func() {
 		if err := injectNotification(cfg, "safe notice", true); err != nil {
@@ -219,8 +243,8 @@ func TestInjectNotificationNoneDoesNotInvokeInjectVia(t *testing.T) {
 	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
 		t.Fatalf("none mode invoked inject-via; output stat error = %v", err)
 	}
-	if stderr != "\asafe notice\n" {
-		t.Fatalf("stderr = %q, want bell + notice", stderr)
+	if stderr != "\x1b]0;AMQ attention\a\asafe notice\n" {
+		t.Fatalf("stderr = %q, want title + bell + notice", stderr)
 	}
 }
 
@@ -882,6 +906,8 @@ func TestNotifyNewMessagesNoneUrgentUsesOutputBellWithoutInput(t *testing.T) {
 		interruptLabel:    "interrupt",
 		interruptPriority: "urgent",
 		interruptCooldown: 7 * time.Second,
+		attentionEnv:      func(string) string { return "" },
+		attentionIsTTY:    func() bool { return true },
 	}
 	stderr := captureWakeStderr(t, func() {
 		if err := notifyNewMessages(cfg); err != nil {
@@ -902,8 +928,9 @@ func TestNotifyNewMessagesNoneUrgentUsesOutputBellWithoutInput(t *testing.T) {
 		48,
 		"",
 	)
-	if stderr != "\a"+expectedText+"\n" {
-		t.Fatalf("stderr = %q, want one bell + urgent notice %q", stderr, expectedText)
+	expectedOutput := "\x1b]0;AMQ attention\a\a" + expectedText + "\n"
+	if stderr != expectedOutput {
+		t.Fatalf("stderr = %q, want title + bell + urgent notice %q", stderr, expectedText)
 	}
 
 	externalCfg, outputPath := injectViaCaptureConfig(t)
@@ -916,6 +943,8 @@ func TestNotifyNewMessagesNoneUrgentUsesOutputBellWithoutInput(t *testing.T) {
 	externalCfg.interruptKey = "\x03"
 	externalCfg.interruptLabel = "interrupt"
 	externalCfg.interruptPriority = "urgent"
+	externalCfg.attentionEnv = func(string) string { return "" }
+	externalCfg.attentionIsTTY = func() bool { return true }
 	externalStderr := captureWakeStderr(t, func() {
 		if err := notifyNewMessages(externalCfg); err != nil {
 			t.Fatalf("notifyNewMessages with inject-via config: %v", err)
@@ -924,8 +953,253 @@ func TestNotifyNewMessagesNoneUrgentUsesOutputBellWithoutInput(t *testing.T) {
 	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
 		t.Fatalf("none mode invoked inject-via for urgent notice; output stat error = %v", err)
 	}
-	if externalStderr != "\a"+expectedText+"\n" {
-		t.Fatalf("external stderr = %q, want one bell + urgent notice %q", externalStderr, expectedText)
+	if externalStderr != expectedOutput {
+		t.Fatalf("external stderr = %q, want title + bell + urgent notice %q", externalStderr, expectedText)
+	}
+}
+
+func TestNotifyNewMessagesNoneNormalUsesPeerOutput(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "msg-normal-output",
+			From:    "codex",
+			To:      []string{"alice"},
+			Thread:  "p2p/alice__codex",
+			Subject: "review ready",
+			Created: "2026-07-27T05:00:00Z",
+		},
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-normal-output.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	var emission wakeAttentionEmission
+	cfg := &wakeConfig{
+		me:             "alice",
+		root:           root,
+		session:        "collab",
+		injectMode:     wakeInjectModeNone,
+		previewLen:     48,
+		attentionIsTTY: func() bool { return false },
+		recordAttention: func(got wakeAttentionEmission) error {
+			emission = got
+			return nil
+		},
+	}
+	stderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notifyNewMessages: %v", err)
+		}
+	})
+	for _, want := range []string{"message from codex", "review ready"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("normal output %q missing %q", stderr, want)
+		}
+	}
+	if strings.Contains(stderr, coopWakeDoorbell) {
+		t.Fatalf("normal output leaked fixed input payload: %q", stderr)
+	}
+	if emission.OutputProvenance != wakePayloadPeerHeaders {
+		t.Fatalf("provenance = %q, want peer headers", emission.OutputProvenance)
+	}
+}
+
+func TestNotifyNewMessagesNormalSuccessUsesFixedInputOnly(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "msg-normal-input",
+			From:    "untrusted-sender",
+			To:      []string{"alice"},
+			Thread:  "p2p/alice__untrusted-sender",
+			Subject: "untrusted-subject",
+			Created: "2026-07-27T05:10:00Z",
+		},
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-normal-input.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+	cfg := &wakeConfig{
+		me:         "alice",
+		root:       root,
+		injectMode: wakeInjectModeRaw,
+		previewLen: 48,
+	}
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notifyNewMessages: %v", err)
+	}
+
+	got := strings.Join(injected, "|")
+	if !strings.Contains(got, coopWakeDoorbell) {
+		t.Fatalf("injected bytes = %q, missing fixed doorbell", got)
+	}
+	for _, forbidden := range []string{"untrusted-sender", "untrusted-subject"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("peer header %q entered terminal input: %q", forbidden, got)
+		}
+	}
+}
+
+func TestNotifyNewMessagesCustomInterruptUsesSanitizedOperatorPayloadForInputAndFallback(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	msg := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       "msg-custom-interrupt",
+			From:     "peer",
+			To:       []string{"alice"},
+			Thread:   "p2p/alice__peer",
+			Subject:  "peer subject",
+			Created:  "2026-07-27T05:20:00Z",
+			Priority: "urgent",
+			Labels:   []string{"interrupt"},
+		},
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-custom-interrupt.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+
+	fail := false
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		if fail {
+			return errors.New("injection unavailable")
+		}
+		injected = append(injected, text)
+		return nil
+	})
+	var emission wakeAttentionEmission
+	cfg := &wakeConfig{
+		me:                "alice",
+		root:              root,
+		injectMode:        wakeInjectModeRaw,
+		interrupt:         true,
+		interruptPriority: "urgent",
+		interruptLabel:    "interrupt",
+		interruptNotice:   "operator\x1b[31m\nnotice",
+		attentionIsTTY:    func() bool { return false },
+		recordAttention: func(got wakeAttentionEmission) error {
+			emission = got
+			return nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("successful notifyNewMessages: %v", err)
+	}
+	safeNotice := sanitizeForTTY(cfg.interruptNotice)
+	if got := strings.Join(injected, "|"); !strings.Contains(got, safeNotice) {
+		t.Fatalf("injected bytes = %q, want sanitized operator notice %q", got, safeNotice)
+	}
+	fail = true
+	stderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("fallback notifyNewMessages: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, safeNotice) || strings.Contains(stderr, "peer subject") {
+		t.Fatalf("fallback output = %q, want only sanitized operator notice", stderr)
+	}
+	if emission.OutputProvenance != wakePayloadOperatorFlag {
+		t.Fatalf("fallback provenance = %q, want operator", emission.OutputProvenance)
+	}
+}
+
+func TestNotifyNewMessagesOperatorFailurePreservesOperatorOutputProvenance(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "msg-operator-output",
+			From:    "codex",
+			To:      []string{"alice"},
+			Thread:  "p2p/alice__codex",
+			Subject: "must remain peer-only",
+			Created: "2026-07-27T05:00:00Z",
+		},
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "alice", "msg-operator-output.md", data); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	stubTIOCSTIInject(t, func(string) error {
+		return errors.New("injection unavailable")
+	})
+
+	var emission wakeAttentionEmission
+	cfg := &wakeConfig{
+		me:             "alice",
+		root:           root,
+		injectMode:     wakeInjectModeRaw,
+		injectCmd:      "amq drain\x1b[31m\n--include-body",
+		previewLen:     48,
+		attentionIsTTY: func() bool { return false },
+		recordAttention: func(got wakeAttentionEmission) error {
+			emission = got
+			return nil
+		},
+	}
+	stderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notifyNewMessages: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "amq drain [31m --include-body") {
+		t.Fatalf("operator output missing sanitized command: %q", stderr)
+	}
+	if strings.Contains(stderr, "must remain peer-only") {
+		t.Fatalf("operator output replaced by peer headers: %q", stderr)
+	}
+	if emission.OutputProvenance != wakePayloadOperatorFlag {
+		t.Fatalf("provenance = %q, want operator", emission.OutputProvenance)
 	}
 }
 


### PR DESCRIPTION
## Summary
- separate fixed terminal input from human-readable output attention
- emit a portable bell/title/output floor and verified terminal-specific desktop notifications
- allowlist Ghostty for OSC 9 based on its upstream VT documentation
- record only fully written output effects without claiming the terminal rendered them

## Verification
- `go test ./... -count=1`
- `golangci-lint run ./...`
- peer-reviewed tree `2aa3682986be3d4af21f18ae280d5b4479754bcf` / diff `c9f98bcfa3332650ccaa9f932b4070553f09be21ae07bb47e15b7e4428bf6674`

## Limit
- exact OSC bytes are tested and Ghostty support is upstream-documented; a desktop banner was not observed in a real Ghostty TTY during this lane