### PR TITLE
docs: fix first-hour setup guidance

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -162,7 +162,7 @@ Integration messages are self-delivered and carry `context.orchestrator` plus la
 
 `amq wake` uses TIOCSTI which may be unavailable on:
 - Hardened Linux (CONFIG_LEGACY_TIOCSTI=n)
-- Windows (use WSL)
+- Native Windows (`wake` is unavailable; use WSL with a Linux asset)
 
 If wake fails, configure the notify hook for desktop notifications:
 
@@ -279,6 +279,11 @@ add the flag to wakes they start. Reuse requires generation-bound proof that
 the live wake completed watcher preparation. It does not retroactively baseline
 that wake, so pending backlog can still notify; SessionStart draining mitigates
 that residual.
+
+For the first notification test, start both `coop exec` agents before sending
+the message. If a message was already waiting when the target wake started, it
+will not notify; it remains unread and visible to `amq drain --include-body`.
+
 For orchestrators or hardened environments without a controlling TTY, use an
 explicit external transport:
 
@@ -398,10 +403,11 @@ consumed a partially typed prompt and the user pauses longer than
 messages bypass this deferral. Use `none` when AMQ must guarantee zero synthetic
 input.
 
-**Platform support:**
-- macOS: Works
-- Linux: May be disabled by kernel hardening (CONFIG_LEGACY_TIOCSTI)
-- Windows: Not supported (use WSL)
+**Platform support:** `coop exec` and `wake` require macOS or Linux. Native
+Windows supports core queue commands and `coop init`, but not these two
+commands; use WSL with a Linux asset for the complete workflow. Linux raw TTY
+injection may be disabled by kernel hardening (`CONFIG_LEGACY_TIOCSTI`). See
+the [platform capability matrix](INSTALL.md#platform-capability-matrix).
 
 ## Message Format
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -112,7 +112,21 @@ Download from [Releases](https://github.com/avivsinai/agent-message-queue/releas
 | macOS (Intel) | `amq_*_darwin_amd64.tar.gz` |
 | Linux (x86_64) | `amq_*_linux_amd64.tar.gz` |
 | Linux (ARM64) | `amq_*_linux_arm64.tar.gz` |
-| Windows | `amq_*_windows_amd64.zip` (use in WSL) |
+| Native Windows (x86_64) | `amq_*_windows_amd64.zip` |
+| WSL (x86_64) | `amq_*_linux_amd64.tar.gz` |
+
+### Platform capability matrix
+
+| Platform | Core queue (`send`, `drain`, `read`, threads) | `coop init` | `coop exec` | `wake` notifications | Installer script |
+|----------|------------------------------------------------|-------------|-------------|----------------------|------------------|
+| macOS | Supported | Supported | Supported | Supported | Supported |
+| Linux | Supported | Supported | Supported | Supported; raw TTY injection may be disabled by kernel hardening | Supported |
+| WSL | Supported via the Linux binary | Supported | Supported | Same constraints as Linux | Supported |
+| Native Windows | Supported via the Windows ZIP | Supported | **Not supported natively** | **Not supported natively** | Rejects Windows; install the ZIP manually |
+
+WSL is a Linux environment: install a Linux asset there, not the Windows ZIP.
+On native Windows, `doctor --ops` can report wake lock files but cannot verify
+live wake process identity or auto-fix `unverified` locks.
 
 For manual installs, verify the selected asset against `checksums.txt` before extracting it:
 
@@ -306,9 +320,13 @@ mv amq ~/.local/bin/
 
 ### Binary: Install Script Options
 
+If the installer cannot query GitHub's latest-release API, choose a tag from
+the [Releases page](https://github.com/avivsinai/agent-message-queue/releases)
+and rerun with `VERSION=`:
+
 ```bash
-# Specific version
-curl -fsSL .../install.sh | VERSION=v0.8.0 bash
+# Specific version (replace vX.Y.Z)
+curl -fsSL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/scripts/install.sh | VERSION=vX.Y.Z bash
 
 # Custom directory
 curl -fsSL .../install.sh | INSTALL_DIR=~/bin bash

--- a/README.md
+++ b/README.md
@@ -84,35 +84,54 @@ amq coop init
 
 Creates `.amqrc`, mailboxes for `claude`, `codex`, and the reserved `user` operator handle, and updates `.gitignore`.
 
-Optionally add shell aliases (`amc` for Claude, `amx` for Codex, and `amg` for Grok CLI as an optional peer):
-```bash
-eval "$(amq shell-setup)"
-```
-
 ### 2. Start Agent Sessions
 
 ```bash
 # Terminal 1 — Claude Code
-amc
+amq coop exec claude
 
 # Terminal 2 — Codex CLI
-amx
+amq coop exec codex
 ```
 
-Each alias sets up the environment, starts wake notifications, and launches the agent. For isolated sessions (multiple pairs working on different features):
+Each command sets up the environment, starts wake notifications, and launches
+the agent.
+
+> **First-message check:** start both agents before sending the test message.
+> A newly started wake deliberately baselines messages that were already
+> waiting, so they remain unread but do not trigger a notification. If you sent
+> first, run `amq drain --include-body` in the target agent.
+
+For isolated sessions (multiple pairs working on different features):
 
 ```bash
-amc feature-a          # Claude in feature-a session
-amx feature-a          # Codex in feature-a session
-amg feature-a          # Grok CLI in feature-a session (optional third peer)
+amq coop exec --session feature-a claude
+amq coop exec --session feature-a codex
+amq coop exec --session feature-a grok     # Optional third peer
 ```
 
-Without aliases, use `amq coop exec` directly:
+Pass agent flags after `--`:
 ```bash
 amq coop exec claude -- --dangerously-skip-permissions
-amq coop exec --session feature-a codex
-amq coop exec grok     # Grok CLI as an optional peer; caller flags forwarded unchanged
+amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
 ```
+
+Optional aliases are a convenience, not part of the canonical quickstart.
+A bare `eval "$(amq shell-setup)"` affects only the current shell. To make
+aliases such as `amc`, `amx`, and `amg` available in future terminals, add the
+setup command to your shell startup file:
+
+```bash
+# zsh
+amq shell-setup --shell zsh >> ~/.zshrc
+
+# bash
+amq shell-setup --shell bash >> ~/.bashrc
+```
+
+Run the appropriate append command once, then open a new terminal or source
+that startup file. Use the bare `eval` only when you intentionally want aliases
+in one already-open shell.
 
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
 Managed launchers can add `--require-wake` to fail instead of launching the agent when the wake watcher cannot start.
@@ -495,7 +514,9 @@ Files are universal, debuggable, and work everywhere. No connection strings, no 
 Those require infrastructure. AMQ is for local inter-process communication where agents share a filesystem. No server to configure or keep running.
 
 **What about Windows?**
-The core queue works on Windows. The `amq wake` notification feature requires WSL. `doctor --ops` can still report wake lock files on unsupported platforms, but it cannot verify live wake process identity there and will not auto-fix `unverified` locks.
+Native Windows supports the core queue, but not `coop exec` or `wake`. Use WSL
+with the Linux binary for the complete co-op workflow. See the explicit
+[platform capability matrix](INSTALL.md#platform-capability-matrix).
 
 **Is this production-ready?**
 For local development workflows, yes. AMQ is intentionally simple—it's not trying to be a distributed message broker.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,8 +81,10 @@ esac
 case "$OS" in
     darwin|linux) ;;
     mingw*|msys*|cygwin*)
-        echo -e "${RED}Error: Windows detected. Please use WSL or download manually.${NC}"
-        echo "See: https://github.com/$REPO/releases"
+        echo -e "${RED}Error: The installer script does not support native Windows.${NC}"
+        echo "For the complete coop/wake workflow, use WSL with the Linux installer."
+        echo "For native core queue commands, download the Windows ZIP manually:"
+        echo "  https://github.com/$REPO/releases"
         exit 1
         ;;
     *)
@@ -99,6 +101,11 @@ if [ "$VERSION" = "latest" ]; then
     VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
     if [ -z "$VERSION" ]; then
         echo -e "${RED}Error: Could not determine latest version${NC}"
+        echo "The GitHub API may be unavailable, rate-limited, or blocked by a proxy."
+        echo "Try one of:"
+        echo "  Homebrew: brew install avivsinai/tap/amq"
+        echo "  Manual download: https://github.com/$REPO/releases"
+        echo "  Pinned rerun: curl -fsSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | VERSION=vX.Y.Z bash"
         exit 1
     fi
 fi
@@ -349,5 +356,7 @@ fi
 
 echo "Next steps:"
 echo "  1. Start agent: \"$INSTALLED_BINARY\" coop exec claude"
-echo "  Tip: eval \"\$(\"$INSTALLED_BINARY\" shell-setup)\" to add co-op aliases to your shell"
+echo "  Tip: eval \"\$(\"$INSTALLED_BINARY\" shell-setup)\" adds aliases to this shell only."
+echo "       Persist zsh aliases: \"$INSTALLED_BINARY\" shell-setup --shell zsh >> ~/.zshrc"
+echo "       Persist bash aliases: \"$INSTALLED_BINARY\" shell-setup --shell bash >> ~/.bashrc"
 echo ""


### PR DESCRIPTION
## Summary
- make full `amq coop exec` commands canonical and explain persistent aliases
- document first-message baselining and the recovery drain
- publish a native Windows/WSL capability matrix with correct assets
- make latest-version installer failures name Homebrew, manual, and pinned remedies

## Verification
- `git diff --check`
- `bash -n scripts/install.sh`
- `bash scripts/test_install_checksum.sh`
- peer-reviewed tree `29e940cb80d9e49dcfed879c136c27009301f27c` / diff `69964503ebcc215533380c68158791b1bb3b73ee1e808530b862f5b62f6eac5c`