### PR TITLE
fix(wake): recover live raw coop takeovers

### DIFF
--- a/internal/cli/coop_wake_reclaim_darwin_test.go
+++ b/internal/cli/coop_wake_reclaim_darwin_test.go
@@ -4,35 +4,240 @@ package cli
 
 import (
 	"os"
+	"strings"
 	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
-func TestPrepareCoopWakeLockLiveRawOrphanYesSignalsWaitsAndRemoves(t *testing.T) {
+func TestPrepareCoopWakeLockTerminalGoneDefersToSilentReplacement(t *testing.T) {
 	const pid = 66121
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: pid, ProcessStart: "start", BootID: "boot", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}, Generation: "raw"})
+	stubInspectWakeProcess(t, func(got int) wakeProcessInfo {
+		return wakeProcessInfo{PID: got, Running: true, StartToken: "start", BootID: "boot", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}, ControllingTerminalKnown: true}
+	})
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("coop preflight must leave terminal-gone replacement to wake acquisition")
+		return nil
+	})
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return prepareCoopWakeLock(root, "codex", false, "unused")
+	})
+	if err != nil {
+		t.Fatalf("prepare terminal-gone replacement: %v", err)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("terminal-gone preflight output: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("preflight changed lock reserved for wake acquisition: %v", err)
+	}
+}
+
+func TestPrepareCoopWakeLockLiveRawAttachedYesTakesOverWithWarning(t *testing.T) {
+	testPrepareCoopWakeLockLiveRawTakeover(t, "/dev/null", wakeProcessInfo{
+		ControllingTerminalKnown: true,
+		HasControllingTerminal:   true,
+	}, "running, and still attached to a terminal — this may be a live session in another window", false)
+}
+
+func TestPrepareCoopWakeLockLiveRawUnknownTTYAttachedYesTakesOverWithWarning(t *testing.T) {
+	testPrepareCoopWakeLockLiveRawTakeover(t, "unknown", wakeProcessInfo{
+		ControllingTerminalKnown: true,
+		HasControllingTerminal:   true,
+	}, "running, and still attached to a terminal — this may be a live session in another window", false)
+}
+
+func TestPrepareCoopWakeLockLiveRawUndeterminableYesTakesOverWithWarning(t *testing.T) {
+	testPrepareCoopWakeLockLiveRawTakeover(t, "unknown", wakeProcessInfo{},
+		"running; cannot determine whether its terminal is still attached", false)
+}
+
+func TestPrepareCoopWakeLockConsentedWakeSelfCleanupIsSuccess(t *testing.T) {
+	testPrepareCoopWakeLockLiveRawTakeover(t, "/dev/null", wakeProcessInfo{
+		ControllingTerminalKnown: true,
+		HasControllingTerminal:   true,
+	}, "running, and still attached to a terminal — this may be a live session in another window", true)
+}
+
+func TestPrepareCoopWakeLockSameTerminalDifferentSessionDefersToSilentReplacement(t *testing.T) {
+	const (
+		pid  = 66121
+		tdev = 268435464
+	)
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          "unknown",
+		ProcessStart: "start",
+		BootID:       "boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		Generation:   "silent-replacement",
+	})
+	stubInspectWakeProcess(t, func(got int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:                       got,
+			Running:                   true,
+			StartToken:                "start",
+			BootID:                    "boot",
+			Executable:                "/opt/homebrew/bin/amq",
+			Args:                      []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+			ControllingTerminalKnown:  true,
+			HasControllingTerminal:    true,
+			ControllingTerminalDevice: tdev,
+		}
+	})
+	oldKinfo := readDarwinKinfoProc
+	readDarwinKinfoProc = func(string, ...int) (*unix.KinfoProc, error) {
+		return &unix.KinfoProc{
+			Proc:  unix.ExternProc{P_stat: 1},
+			Eproc: unix.Eproc{Tdev: tdev},
+		}, nil
+	}
+	t.Cleanup(func() { readDarwinKinfoProc = oldKinfo })
+	stubWakeProcessSID(t, func(got int) (int, error) {
+		if got == pid {
+			return 100, nil
+		}
+		return 200, nil
+	})
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("coop preflight must leave silent replacement to wake acquisition")
+		return nil
+	})
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return prepareCoopWakeLock(root, "codex", false, "unused")
+	})
+	if err != nil {
+		t.Fatalf("prepare silent replacement candidate: %v", err)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("silent replacement preflight output: stdout=%q stderr=%q", stdout, stderr)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("preflight changed lock reserved for wake acquisition: %v", err)
+	}
+}
+
+func TestPrepareCoopWakeLockInjectViaNeverSignalsThroughTakeover(t *testing.T) {
+	const pid = 66121
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          "unknown",
+		ProcessStart: "start",
+		BootID:       "boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex", "--inject-via", "/bin/echo"},
+		WakeMode:     wakeTargetInjectVia,
+		Generation:   "inject-via",
+	})
+	stubInspectWakeProcess(t, func(got int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        got,
+			Running:    true,
+			StartToken: "start",
+			BootID:     "boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex", "--inject-via", "/bin/echo"},
+		}
+	})
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("inject-via wake must not be signaled through coop takeover")
+		return nil
+	})
+
+	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
+		t.Fatalf("prepare inject-via wake: %v", err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("inject-via lock changed: %v", err)
+	}
+}
+
+func TestPrepareCoopWakeLockUnverifiedNeverSignals(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeUnverifiedCoopWakeLock(t, root)
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("unverified wake must never be signaled")
+		return nil
+	})
+
+	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
+		t.Fatalf("prepare unverified wake: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("unverified metadata remains: %v", err)
+	}
+}
+
+func testPrepareCoopWakeLockLiveRawTakeover(
+	t *testing.T,
+	tty string,
+	terminal wakeProcessInfo,
+	wantState string,
+	selfRemoves bool,
+) {
+	t.Helper()
+
+	const pid = 66121
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          tty,
+		ProcessStart: "start",
+		BootID:       "boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		Generation:   "live-raw-takeover",
+	})
 	stopped := false
 	stubInspectWakeProcess(t, func(got int) wakeProcessInfo {
 		if stopped {
 			return wakeProcessInfo{PID: got}
 		}
-		return wakeProcessInfo{PID: got, Running: true, StartToken: "start", BootID: "boot", Executable: "/opt/homebrew/bin/amq", Args: []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}, ControllingTerminalKnown: true}
+		terminal.PID = got
+		terminal.Running = true
+		terminal.StartToken = "start"
+		terminal.BootID = "boot"
+		terminal.Executable = "/opt/homebrew/bin/amq"
+		terminal.Args = []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}
+		return terminal
 	})
 	stubSignalWakeProcess(t, func(got int, signal os.Signal) error {
 		if got != pid || signal != syscall.SIGTERM {
 			t.Fatalf("signal %d %v", got, signal)
 		}
 		stopped = true
+		if selfRemoves {
+			if err := os.Remove(lockPath); err != nil {
+				t.Fatalf("old wake self-remove lock: %v", err)
+			}
+		}
 		return nil
 	})
-	oldGrace := wakeTerminateGrace
-	wakeTerminateGrace = 0
-	t.Cleanup(func() { wakeTerminateGrace = oldGrace })
-	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
-		t.Fatalf("retire raw orphan: %v", err)
-	}
+
+	stderr := captureWakeStderr(t, func() {
+		if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
+			t.Fatalf("take over live raw wake: %v", err)
+		}
+	})
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Fatalf("raw orphan lock remains: %v", err)
+		t.Fatalf("live raw lock remains: %v", err)
+	}
+	for _, want := range []string{
+		wantState,
+		"warning: took over blocking wake for codex",
+		"pid 66121",
+		"on " + tty,
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("takeover output %q missing %q", stderr, want)
+		}
 	}
 }

--- a/internal/cli/coop_wake_reclaim_linux_test.go
+++ b/internal/cli/coop_wake_reclaim_linux_test.go
@@ -1,0 +1,182 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestPrepareCoopWakeLockLiveRawUnknownTerminalYesSignalsAndRemoves(t *testing.T) {
+	const (
+		pid   = 4242
+		pidfd = 99
+		tty   = "unknown"
+		state = "running; cannot determine whether its terminal is still attached"
+	)
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          tty,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/usr/bin/amq",
+		Args:         []string{"/usr/bin/amq", "wake", "--root", root, "--me", "codex"},
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "live-raw-unknown-terminal",
+	})
+
+	stopped := false
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID != pid {
+			t.Fatalf("inspect pid = %d, want %d", gotPID, pid)
+		}
+		if stopped {
+			return wakeProcessInfo{PID: gotPID}
+		}
+		return matchingLinuxWakeProcess(gotPID, root)
+	})
+
+	openCalls := 0
+	signalCalls := 0
+	pollCalls := 0
+	stubLinuxPidfd(
+		t,
+		func(gotPID, flags int) (int, error) {
+			openCalls++
+			if gotPID != pid || flags != 0 {
+				t.Fatalf("pidfd_open = (%d, %d), want (%d, 0)", gotPID, flags, pid)
+			}
+			return pidfd, nil
+		},
+		func(gotFD int, signal unix.Signal, _ *unix.Siginfo, flags int) error {
+			signalCalls++
+			if gotFD != pidfd || signal != unix.SIGTERM || flags != 0 {
+				t.Fatalf("pidfd_send_signal = (%d, %v, %d), want (%d, SIGTERM, 0)", gotFD, signal, flags, pidfd)
+			}
+			return nil
+		},
+		func(gotFD int, timeout time.Duration) (bool, error) {
+			pollCalls++
+			if gotFD != pidfd {
+				t.Fatalf("pidfd poll fd = %d, want %d", gotFD, pidfd)
+			}
+			if timeout <= 0 {
+				t.Fatalf("pidfd poll timeout = %s, want positive", timeout)
+			}
+			stopped = true
+			return true, nil
+		},
+	)
+
+	var prepareErr error
+	stderr := captureWakeStderr(t, func() {
+		prepareErr = prepareCoopWakeLock(root, "codex", true, "unused")
+	})
+	if prepareErr != nil {
+		t.Fatalf("approved live raw takeover: %v", prepareErr)
+	}
+	if openCalls != 1 {
+		t.Errorf("pidfd open calls = %d, want 1", openCalls)
+	}
+	if signalCalls != 1 {
+		t.Errorf("pidfd signal calls = %d, want 1 exact SIGTERM", signalCalls)
+	}
+	if pollCalls != 1 {
+		t.Errorf("pidfd poll calls = %d, want 1", pollCalls)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Errorf("live raw lock remains after approved takeover: %v", err)
+	}
+
+	warningAt := strings.LastIndex(stderr, "warning:")
+	if warningAt < 0 {
+		t.Errorf("takeover warning missing from stderr: %q", stderr)
+		return
+	}
+	warning := stderr[warningAt:]
+	for _, want := range []string{"4242", tty, state} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("takeover warning %q does not name %q", warning, want)
+		}
+	}
+}
+
+func TestPrepareCoopWakeLockLiveRawSelfCleanupAfterPidfdExitSucceeds(t *testing.T) {
+	const (
+		pid   = 4242
+		pidfd = 99
+	)
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          "unknown",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/usr/bin/amq",
+		Args:         []string{"/usr/bin/amq", "wake", "--root", root, "--me", "codex"},
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "live-raw-self-cleanup",
+	})
+
+	stopped := false
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID != pid {
+			t.Fatalf("inspect pid = %d, want %d", gotPID, pid)
+		}
+		if stopped {
+			return wakeProcessInfo{PID: gotPID}
+		}
+		return matchingLinuxWakeProcess(gotPID, root)
+	})
+
+	signalCalls := 0
+	pollCalls := 0
+	stubLinuxPidfd(
+		t,
+		func(gotPID, flags int) (int, error) {
+			if gotPID != pid || flags != 0 {
+				t.Fatalf("pidfd_open = (%d, %d), want (%d, 0)", gotPID, flags, pid)
+			}
+			return pidfd, nil
+		},
+		func(gotFD int, signal unix.Signal, _ *unix.Siginfo, flags int) error {
+			signalCalls++
+			if gotFD != pidfd || signal != unix.SIGTERM || flags != 0 {
+				t.Fatalf("pidfd_send_signal = (%d, %v, %d), want (%d, SIGTERM, 0)", gotFD, signal, flags, pidfd)
+			}
+			return nil
+		},
+		func(gotFD int, timeout time.Duration) (bool, error) {
+			pollCalls++
+			if gotFD != pidfd {
+				t.Fatalf("pidfd poll fd = %d, want %d", gotFD, pidfd)
+			}
+			if timeout <= 0 {
+				t.Fatalf("pidfd poll timeout = %s, want positive", timeout)
+			}
+			stopped = true
+			if err := os.Remove(lockPath); err != nil {
+				t.Fatalf("simulate exact wake self-cleanup: %v", err)
+			}
+			return true, nil
+		},
+	)
+
+	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
+		t.Errorf("approved takeover after exact wake self-cleanup = %v, want success", err)
+	}
+	if signalCalls != 1 {
+		t.Errorf("pidfd signal calls = %d, want 1 exact SIGTERM", signalCalls)
+	}
+	if pollCalls != 1 {
+		t.Errorf("pidfd poll calls = %d, want 1 proven exit", pollCalls)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Errorf("self-cleaned live raw lock exists after successful takeover: %v", err)
+	}
+}

--- a/internal/cli/coop_wake_reclaim_unix.go
+++ b/internal/cli/coop_wake_reclaim_unix.go
@@ -29,12 +29,20 @@ func prepareCoopWakeLock(root, agent string, yes bool, remedy string) error {
 		return nil
 	}
 
+	// Wake acquisition already performs exact-identity retirement for this
+	// designed automatic case. Do not turn it into an interactive preflight.
+	if isLiveRawOrphan(inspection) &&
+		wakeLockNeedsReplacement(inspection) {
+		return nil
+	}
+
 	if isLiveRawOrphan(inspection) {
-		state := "running, but its terminal is gone"
+		terminal := wakeLockTerminalAttachment(inspection)
+		state := coopWakeTerminalState(terminal)
 		proceed, err := confirmCoopBadWake(
 			inspection,
 			state,
-			"gone",
+			coopWakeTTYDisplay(inspection),
 			yes,
 			coopWakeRemedy(inspection, state, remedy),
 		)
@@ -47,6 +55,15 @@ func prepareCoopWakeLock(root, agent string, yes bool, remedy string) error {
 		}
 		if !retired {
 			return fmt.Errorf("wake changed before live raw orphan retirement; retry")
+		}
+		if terminal != wakeTerminalGone {
+			_ = writeStderr(
+				"warning: took over blocking wake for %s (pid %d on %s): %s\n",
+				agent,
+				inspection.PID,
+				coopWakeTTYDisplay(inspection),
+				state,
+			)
 		}
 		return nil
 	}
@@ -125,6 +142,17 @@ func consentToClearWake(yes bool, remedy string) (bool, error) {
 		return false, nil
 	}
 	return confirmPrompt("Clear it and start a fresh wake?")
+}
+
+func coopWakeTerminalState(terminal wakeTerminalAttachment) string {
+	switch terminal {
+	case wakeTerminalGone:
+		return "running, but its terminal is gone"
+	case wakeTerminalAttached:
+		return "running, and still attached to a terminal — this may be a live session in another window"
+	default:
+		return "running; cannot determine whether its terminal is still attached"
+	}
 }
 
 func coopWakeTTYDisplay(inspection wakeLockInspection) string {

--- a/internal/cli/coop_wake_reclaim_unix_test.go
+++ b/internal/cli/coop_wake_reclaim_unix_test.go
@@ -36,6 +36,9 @@ func TestPrepareCoopWakeLockUnverifiedYesRemovesMetadataWithoutSignal(t *testing
 	if !strings.Contains(stderr, "without signaling it") || !strings.Contains(stderr, "duplicate notifications may continue") {
 		t.Fatalf("warning missing safety facts: %q", stderr)
 	}
+	if got := strings.Count(stderr, "duplicate notifications may continue"); got != 1 {
+		t.Fatalf("duplicate-notification warning count = %d, want 1: %q", got, stderr)
+	}
 }
 
 func TestPrepareCoopWakeLockProvenForeignProcessRefusesWithoutMutation(t *testing.T) {
@@ -64,10 +67,15 @@ func TestPrepareCoopWakeLockHeadlessPrintsRemedyWithoutPrompt(t *testing.T) {
 	root := secureTempDirForTest(t)
 	lockPath := writeUnverifiedCoopWakeLock(t, root)
 	remedy := "amq coop exec -y --root /resolved/session --me codex codex"
-	var got error
-	stderr := captureWakeStderr(t, func() { got = prepareCoopWakeLock(root, "codex", false, remedy) })
+	stdout, stderr, got := captureEnvOutput(t, func() error {
+		return prepareCoopWakeLock(root, "codex", false, remedy)
+	})
 	if got == nil || !strings.Contains(got.Error(), "declined") {
 		t.Fatalf("headless result = %v", got)
+	}
+	if strings.Contains(stdout, "Clear it and start a fresh wake?") ||
+		strings.Contains(stderr, "Clear it and start a fresh wake?") {
+		t.Fatalf("headless cleanup printed an unanswerable prompt: stdout=%q stderr=%q", stdout, stderr)
 	}
 	if !strings.Contains(stderr, remedy) || !strings.Contains(stderr, "AM_ROOT=") {
 		t.Fatalf("remedy missing: %q", stderr)
@@ -82,6 +90,35 @@ func TestCoopWakeRemedyForCommandUsesResolvedRootAndYes(t *testing.T) {
 	want := "amq coop exec -y --root /resolved/session --me codex codex --dangerously-bypass-approvals-and-sandbox"
 	if got != want {
 		t.Fatalf("command = %q, want %q", got, want)
+	}
+}
+
+func TestWakeLockHasUsableNotificationPathChoosesExplicitTerminalFailDirection(t *testing.T) {
+	tests := []struct {
+		name       string
+		tty        string
+		known      bool
+		has        bool
+		wantUsable bool
+	}{
+		{name: "attached legacy unknown is usable", tty: "unknown", known: true, has: true, wantUsable: true},
+		{name: "undeterminable legacy unknown fails closed", tty: "unknown"},
+		{name: "undeterminable concrete path preserves Linux evidence", tty: "/dev/null", wantUsable: true},
+		{name: "proven gone fails closed", tty: "/dev/amq-missing-notification-tty", known: true, has: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inspection := wakeLockInspection{
+				Lock: wakeLock{TTY: tt.tty, WakeMode: wakeInjectModeRaw},
+				Process: wakeProcessInfo{
+					ControllingTerminalKnown: tt.known,
+					HasControllingTerminal:   tt.has,
+				},
+			}
+			if got := wakeLockHasUsableNotificationPath(inspection); got != tt.wantUsable {
+				t.Fatalf("usable = %v, want %v", got, tt.wantUsable)
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake_auto_replace_darwin_test.go
+++ b/internal/cli/wake_auto_replace_darwin_test.go
@@ -1,0 +1,190 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestAcquireWakeLockAutomaticallyReplacesTerminalGoneRawWake(t *testing.T) {
+	testAcquireWakeLockAutomaticallyReplacesRawWake(t, wakeProcessInfo{
+		ControllingTerminalKnown: true,
+	})
+}
+
+func TestAcquireWakeLockAutomaticallyReplacesSameTerminalDifferentSessionRawWake(t *testing.T) {
+	const (
+		wakePID = 66121
+		tdev    = 268435464
+	)
+	oldKinfo := readDarwinKinfoProc
+	readDarwinKinfoProc = func(name string, args ...int) (*unix.KinfoProc, error) {
+		if name != "kern.proc.pid" || len(args) != 1 || args[0] != os.Getpid() {
+			t.Fatalf("unexpected current-process lookup: name=%q args=%v", name, args)
+		}
+		return &unix.KinfoProc{
+			Proc:  unix.ExternProc{P_stat: 1},
+			Eproc: unix.Eproc{Tdev: tdev},
+		}, nil
+	}
+	t.Cleanup(func() { readDarwinKinfoProc = oldKinfo })
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		switch pid {
+		case wakePID:
+			return 100, nil
+		case 0:
+			return 200, nil
+		default:
+			t.Fatalf("unexpected SID lookup for pid %d", pid)
+			return 0, nil
+		}
+	})
+
+	testAcquireWakeLockAutomaticallyReplacesRawWake(t, wakeProcessInfo{
+		ControllingTerminalKnown:  true,
+		HasControllingTerminal:    true,
+		ControllingTerminalDevice: tdev,
+	})
+}
+
+func TestAcquireWakeLockRefusesDifferentLiveTerminalRawWakeWithoutSignal(t *testing.T) {
+	const (
+		wakePID         = 66121
+		wakeTerminal    = 268435464
+		currentTerminal = 268435465
+	)
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "start",
+		BootID:       "boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "different-live-terminal",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:                       pid,
+			Running:                   true,
+			StartToken:                "start",
+			BootID:                    "boot",
+			Executable:                "/opt/homebrew/bin/amq",
+			Args:                      []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+			ControllingTerminalKnown:  true,
+			HasControllingTerminal:    true,
+			ControllingTerminalDevice: wakeTerminal,
+		}
+	})
+	oldKinfo := readDarwinKinfoProc
+	readDarwinKinfoProc = func(string, ...int) (*unix.KinfoProc, error) {
+		return &unix.KinfoProc{
+			Proc:  unix.ExternProc{P_stat: 1},
+			Eproc: unix.Eproc{Tdev: currentTerminal},
+		}, nil
+	}
+	t.Cleanup(func() { readDarwinKinfoProc = oldKinfo })
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("different-terminal wake must not be signaled without consent")
+		return nil
+	})
+
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeRaw,
+	})
+	if cleanup != nil {
+		cleanup()
+		t.Fatal("different-terminal wake unexpectedly returned cleanup")
+	}
+	var alreadyRunning *wakeAlreadyRunningError
+	if !errors.As(err, &alreadyRunning) {
+		t.Fatalf("different-terminal acquisition error = %v, want wake already running", err)
+	}
+	current := inspectWakeLock(root, "codex")
+	if !current.Exists || current.Lock.Generation != "different-live-terminal" {
+		t.Fatalf("different-terminal lock changed: %#v", current)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("different-terminal lock removed: %v", statErr)
+	}
+}
+
+func testAcquireWakeLockAutomaticallyReplacesRawWake(
+	t *testing.T,
+	terminal wakeProcessInfo,
+) {
+	t.Helper()
+
+	const wakePID = 66121
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "start",
+		BootID:       "boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "automatic-replacement",
+	})
+	stopped := false
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		if stopped {
+			return wakeProcessInfo{PID: pid}
+		}
+		terminal.PID = pid
+		terminal.Running = true
+		terminal.StartToken = "start"
+		terminal.BootID = "boot"
+		terminal.Executable = "/opt/homebrew/bin/amq"
+		terminal.Args = []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}
+		return terminal
+	})
+	var signals []os.Signal
+	stubSignalWakeProcess(t, func(pid int, signal os.Signal) error {
+		if pid != wakePID {
+			t.Fatalf("signal pid = %d, want %d", pid, wakePID)
+		}
+		signals = append(signals, signal)
+		if signal == syscall.SIGTERM {
+			stopped = true
+		}
+		return nil
+	})
+
+	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeRaw,
+	})
+	if err != nil {
+		t.Fatalf("automatic raw-wake replacement: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("automatic raw-wake replacement returned nil cleanup")
+	}
+	if len(signals) != 1 || signals[0] != syscall.SIGTERM {
+		t.Fatalf("signals = %v, want exact SIGTERM", signals)
+	}
+	current := inspectWakeLock(root, "codex")
+	if !current.Exists ||
+		current.Lock.PID != os.Getpid() ||
+		current.Lock.Generation == "automatic-replacement" {
+		t.Fatalf("replacement lock = %#v", current)
+	}
+
+	cleanup()
+	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
+		t.Fatalf("replacement cleanup left lock: %v", statErr)
+	}
+}

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -42,16 +42,17 @@ const (
 )
 
 type wakeProcessInfo struct {
-	PID                      int
-	Running                  bool
-	StartToken               string
-	BootID                   string
-	LegacyBootID             string
-	Executable               string
-	Args                     []string
-	ControllingTerminalKnown bool
-	HasControllingTerminal   bool
-	InspectError             error
+	PID                       int
+	Running                   bool
+	StartToken                string
+	BootID                    string
+	LegacyBootID              string
+	Executable                string
+	Args                      []string
+	ControllingTerminalKnown  bool
+	HasControllingTerminal    bool
+	ControllingTerminalDevice int32
+	InspectError              error
 }
 
 type wakeLockStatus string

--- a/internal/cli/wake_process_darwin.go
+++ b/internal/cli/wake_process_darwin.go
@@ -50,6 +50,7 @@ func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
 	info.Executable = nulTerminatedString(kp.Proc.P_comm[:])
 	info.ControllingTerminalKnown = true
 	info.HasControllingTerminal = kp.Eproc.Tdev != darwinNoControllingTerminal
+	info.ControllingTerminalDevice = kp.Eproc.Tdev
 
 	info.BootID, info.LegacyBootID = darwinBootIdentity()
 

--- a/internal/cli/wake_process_darwin_test.go
+++ b/internal/cli/wake_process_darwin_test.go
@@ -66,6 +66,9 @@ func TestInspectWakeProcessPlatformReportsControllingTerminalState(t *testing.T)
 				t.Fatalf("terminal state = known:%v has:%v, want known:true has:%v",
 					info.ControllingTerminalKnown, info.HasControllingTerminal, tc.has)
 			}
+			if info.ControllingTerminalDevice != tc.tdev {
+				t.Fatalf("terminal device = %d, want %d", info.ControllingTerminalDevice, tc.tdev)
+			}
 		})
 	}
 }

--- a/internal/cli/wake_raw_orphan_darwin_test.go
+++ b/internal/cli/wake_raw_orphan_darwin_test.go
@@ -2,7 +2,12 @@
 
 package cli
 
-import "testing"
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
 
 func TestLiveRawOrphanState(t *testing.T) {
 	i := wakeLockInspection{
@@ -32,6 +37,91 @@ func TestLiveRawOrphanState(t *testing.T) {
 	i.Process.Running = false
 	if isLiveRawOrphan(i) {
 		t.Fatal("dead process is not a live raw orphan")
+	}
+}
+
+func TestLiveRawOrphanDoesNotDependOnTerminalEvidence(t *testing.T) {
+	tests := []struct {
+		name string
+		tty  string
+		proc wakeProcessInfo
+	}{
+		{
+			name: "attached",
+			tty:  "/dev/null",
+			proc: wakeProcessInfo{
+				ControllingTerminalKnown: true,
+				HasControllingTerminal:   true,
+			},
+		},
+		{
+			name: "attached with unknown saved tty",
+			tty:  "unknown",
+			proc: wakeProcessInfo{
+				ControllingTerminalKnown: true,
+				HasControllingTerminal:   true,
+			},
+		},
+		{name: "undeterminable", tty: "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.proc.Running = true
+			i := wakeLockInspection{
+				IdentityConfirmed: true,
+				Process:           tt.proc,
+				Lock:              wakeLock{WakeMode: "raw", TTY: tt.tty},
+			}
+			if !isLiveRawOrphan(i) {
+				t.Fatal("live identity-confirmed ownerless raw wake must be a takeover candidate")
+			}
+		})
+	}
+}
+
+func TestWakeLockNeedsReplacementDarwinUsesLiveTerminalDevice(t *testing.T) {
+	const (
+		wakePID = 66121
+		tdev    = 268435464
+	)
+	oldKinfo := readDarwinKinfoProc
+	readDarwinKinfoProc = func(name string, args ...int) (*unix.KinfoProc, error) {
+		if name != "kern.proc.pid" || len(args) != 1 || args[0] != os.Getpid() {
+			t.Fatalf("unexpected current-process lookup: name=%q args=%v", name, args)
+		}
+		return &unix.KinfoProc{
+			Proc:  unix.ExternProc{P_stat: 1},
+			Eproc: unix.Eproc{Tdev: tdev},
+		}, nil
+	}
+	t.Cleanup(func() { readDarwinKinfoProc = oldKinfo })
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		if pid == wakePID {
+			return 100, nil
+		}
+		if pid == 0 {
+			return 200, nil
+		}
+		t.Fatalf("unexpected SID lookup for pid %d", pid)
+		return 0, nil
+	})
+
+	inspection := wakeLockInspection{
+		IdentityConfirmed: true,
+		Lock: wakeLock{
+			PID: wakePID,
+			TTY: "unknown",
+		},
+		Process: wakeProcessInfo{
+			PID:                       wakePID,
+			Running:                   true,
+			ControllingTerminalKnown:  true,
+			HasControllingTerminal:    true,
+			ControllingTerminalDevice: tdev,
+		},
+	}
+	if !wakeLockNeedsReplacement(inspection) {
+		t.Fatal("same terminal device in a different session must trigger automatic replacement")
 	}
 }
 

--- a/internal/cli/wake_raw_orphan_other.go
+++ b/internal/cli/wake_raw_orphan_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package cli
 

--- a/internal/cli/wake_raw_orphan_unix.go
+++ b/internal/cli/wake_raw_orphan_unix.go
@@ -1,0 +1,10 @@
+//go:build darwin || linux
+
+package cli
+
+func isLiveRawOrphan(inspection wakeLockInspection) bool {
+	return inspection.Process.Running &&
+		inspection.IdentityConfirmed &&
+		inspection.Lock.WakeMode != wakeTargetInjectVia &&
+		!wakeLockHasOwnerMarkers(inspection)
+}

--- a/internal/cli/wake_terminal_guard_unix.go
+++ b/internal/cli/wake_terminal_guard_unix.go
@@ -17,6 +17,19 @@ func authorizeTerminalWritePlatform(cfg *wakeConfig) bool {
 		current.Lock.TTY != cfg.terminalTTY {
 		return false
 	}
-	return !strings.HasPrefix(cfg.terminalTTY, "/dev/") ||
-		getWakeCurrentTTY() == cfg.terminalTTY
+	switch wakeLockTerminalAttachment(current) {
+	case wakeTerminalGone:
+		// The retained terminal capability may outlive controlling-terminal
+		// attachment. Preserve the legacy unknown-name fail-open policy; a
+		// concrete path still fails because it can no longer match current.
+		return !strings.HasPrefix(cfg.terminalTTY, "/dev/")
+	case wakeTerminalAttached, wakeTerminalUndeterminable:
+		// A concrete path must still name this process's current terminal.
+		// Legacy "unknown" locks retain the prior fail-open behavior because
+		// writes use the wake's already-bound controlling-terminal capability.
+		return !strings.HasPrefix(cfg.terminalTTY, "/dev/") ||
+			getWakeCurrentTTY() == cfg.terminalTTY
+	default:
+		return false
+	}
 }

--- a/internal/cli/wake_terminal_match_linux.go
+++ b/internal/cli/wake_terminal_match_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package cli
+
+func sameWakeTerminalAsCurrent(inspection wakeLockInspection) bool {
+	return sameWakeTTYPathAsCurrent(inspection)
+}

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -43,8 +43,12 @@ func terminateAndRemoveOrphanedWakeLockWithRawConsent(
 		return false, nil
 	}
 	if recheck.Process.Running && recheck.Lock.WakeMode != wakeTargetInjectVia {
-		if !allowRawOrphan || !isLiveRawOrphan(recheck) {
-			return false, fmt.Errorf("live raw wake orphan for %s (pid %d, start %s); stop the owning terminal/launchd supervisor; manual kill is non-identity-safe — recheck before running; see doctor --ops", recheck.Agent, recheck.PID, recheck.Lock.ProcessStart)
+		allowed := wakeLockNeedsReplacement(recheck)
+		if allowRawOrphan {
+			allowed = isLiveRawOrphan(recheck)
+		}
+		if !allowed {
+			return false, fmt.Errorf("live raw wake for %s (pid %d, start %s) is not eligible for automatic replacement; retry through amq coop exec to review and consent to takeover, or stop it from its owning session; refusing to signal without consent", recheck.Agent, recheck.PID, recheck.Lock.ProcessStart)
 		}
 	}
 	if recheck.Process.Running && recheck.Lock.WakeMode == wakeTargetInjectVia {
@@ -59,6 +63,10 @@ func terminateAndRemoveOrphanedWakeLockWithRawConsent(
 	removed := false
 	err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
 		current := inspectWakeLock(inspection.Root, inspection.Agent)
+		if !current.Exists {
+			removed = true
+			return nil
+		}
 		if !sameWakeLockGeneration(recheck, current) {
 			return nil
 		}
@@ -72,14 +80,6 @@ func terminateAndRemoveOrphanedWakeLockWithRawConsent(
 		return nil
 	})
 	return removed, err
-}
-
-func isLiveRawOrphan(inspection wakeLockInspection) bool {
-	return inspection.Process.Running &&
-		inspection.IdentityConfirmed &&
-		inspection.Lock.WakeMode != wakeTargetInjectVia &&
-		!wakeLockHasOwnerMarkers(inspection) &&
-		wakeLockTerminalGone(inspection)
 }
 
 func terminateWakeProcess(inspection wakeLockInspection) error {

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -32,6 +32,13 @@ func readWakeLockMetadata(root, me string) wakeLockInspection {
 }
 
 func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
+	return terminateAndRemoveOrphanedWakeLockWithRawConsent(inspection, false)
+}
+
+func terminateAndRemoveOrphanedWakeLockWithRawConsent(
+	inspection wakeLockInspection,
+	allowRawOrphan bool,
+) (bool, error) {
 	var locked wakeLockInspection
 	pidfd := -1
 	provenGone := false
@@ -80,6 +87,16 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	}
 	defer func() { _ = linuxPidfdClose(pidfd) }()
 
+	if locked.Process.Running && locked.Lock.WakeMode != wakeTargetInjectVia {
+		allowed := wakeLockNeedsReplacement(locked)
+		if allowRawOrphan {
+			allowed = isLiveRawOrphan(locked)
+		}
+		if !allowed {
+			return false, fmt.Errorf("live raw wake for %s (pid %d, start %s) is not eligible for automatic replacement; retry through amq coop exec to review and consent to takeover, or stop it from its owning session; refusing to signal without consent", locked.Agent, locked.PID, locked.Lock.ProcessStart)
+		}
+	}
+
 	// Signaling and both waits happen without the lifecycle guard. The retained
 	// pidfd cannot retarget a recycled numeric PID.
 	if err := terminateWakePidfd(pidfd); err != nil {
@@ -89,6 +106,10 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	removed := false
 	err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {
 		current := inspectWakeLock(inspection.Root, inspection.Agent)
+		if !current.Exists {
+			removed = true
+			return nil
+		}
 		if !sameWakeLockGeneration(locked, current) {
 			return nil
 		}
@@ -108,7 +129,7 @@ func retireLiveRawOrphan(inspection wakeLockInspection) (bool, error) {
 	if !isLiveRawOrphan(inspection) {
 		return false, fmt.Errorf("wake is not an identity-confirmed live raw orphan")
 	}
-	return terminateAndRemoveOrphanedWakeLock(inspection)
+	return terminateAndRemoveOrphanedWakeLockWithRawConsent(inspection, true)
 }
 
 func terminateWakePidfd(pidfd int) error {

--- a/internal/cli/wake_terminate_linux_test.go
+++ b/internal/cli/wake_terminate_linux_test.go
@@ -176,7 +176,7 @@ func TestTerminateOpensPidfdBeforeIdentityInspectionAndReleasesGuardBeforeWait(t
 	const wakePID = 4242
 	root := secureTempDirForTest(t)
 	writeWakeLockForTest(t, root, "codex", wakeLock{
-		PID: wakePID, TTY: "missing", ProcessStart: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
+		PID: wakePID, TTY: "/dev/amq-missing-auto-replacement-tty", ProcessStart: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
 	})
 	var mu sync.Mutex
 	var events []string
@@ -243,6 +243,81 @@ func TestTerminateOpensPidfdBeforeIdentityInspectionAndReleasesGuardBeforeWait(t
 	defer mu.Unlock()
 	if len(events) < 2 || events[0] != "open" || events[1] != "inspect" {
 		t.Fatalf("pre-signal events = %v, want pidfd open before identity inspection", events)
+	}
+}
+
+func TestTerminateRefusesLiveRawUnknownTerminalBeforePidfdSignal(t *testing.T) {
+	const (
+		wakePID = 4242
+		pidfd   = 99
+	)
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/usr/bin/amq",
+		Args:         []string{"/usr/bin/amq", "wake", "--root", root, "--me", "codex"},
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "live-raw-unknown-terminal",
+	})
+	before, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read original lock: %v", err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingLinuxWakeProcess(pid, root)
+	})
+
+	openCalls := 0
+	signalCalls := 0
+	pollCalls := 0
+	stubLinuxPidfd(
+		t,
+		func(pid, flags int) (int, error) {
+			openCalls++
+			if pid != wakePID || flags != 0 {
+				t.Fatalf("pidfd_open = (%d, %d), want (%d, 0)", pid, flags, wakePID)
+			}
+			return pidfd, nil
+		},
+		func(gotFD int, signal unix.Signal, _ *unix.Siginfo, flags int) error {
+			signalCalls++
+			return nil
+		},
+		func(gotFD int, timeout time.Duration) (bool, error) {
+			pollCalls++
+			return true, nil
+		},
+	)
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+		t.Fatalf("initial inspection = %#v, want identity-confirmed valid wake", inspection)
+	}
+	replaced, err := terminateAndRemoveOrphanedWakeLock(inspection)
+	if err == nil || !strings.Contains(err.Error(), "refusing to signal without consent") {
+		t.Errorf("termination error = %v, want live-raw refusal", err)
+	}
+	if replaced {
+		t.Error("live raw wake without replacement evidence was replaced")
+	}
+	if openCalls != 1 {
+		t.Errorf("pidfd open calls = %d, want 1 identity capability acquisition", openCalls)
+	}
+	if signalCalls != 0 {
+		t.Errorf("pidfd signal calls = %d, want 0", signalCalls)
+	}
+	if pollCalls != 0 {
+		t.Errorf("pidfd poll calls = %d, want 0", pollCalls)
+	}
+	after, readErr := os.ReadFile(lockPath)
+	if readErr != nil {
+		t.Fatalf("read preserved lock: %v", readErr)
+	}
+	if string(after) != string(before) {
+		t.Error("live raw refusal changed the exact wake lock")
 	}
 }
 

--- a/internal/cli/wake_tty_path_darwin.go
+++ b/internal/cli/wake_tty_path_darwin.go
@@ -1,0 +1,58 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func currentTTYPath(_ *os.File) string {
+	tdev, ok := currentDarwinControllingTerminalDevice()
+	if !ok {
+		return ""
+	}
+	paths, err := filepath.Glob("/dev/ttys*")
+	if err != nil {
+		return ""
+	}
+	paths = append(paths, "/dev/console")
+	return findDarwinTTYPath(tdev, paths, unix.Stat)
+}
+
+func sameWakeTerminalAsCurrent(inspection wakeLockInspection) bool {
+	if inspection.Process.ControllingTerminalKnown &&
+		inspection.Process.HasControllingTerminal {
+		if current, ok := currentDarwinControllingTerminalDevice(); ok {
+			return current == inspection.Process.ControllingTerminalDevice
+		}
+	}
+	return sameWakeTTYPathAsCurrent(inspection)
+}
+
+func currentDarwinControllingTerminalDevice() (int32, bool) {
+	process, err := readDarwinKinfoProc("kern.proc.pid", os.Getpid())
+	if err != nil || process == nil || process.Eproc.Tdev == darwinNoControllingTerminal {
+		return 0, false
+	}
+	return process.Eproc.Tdev, true
+}
+
+func findDarwinTTYPath(
+	rdev int32,
+	paths []string,
+	stat func(string, *unix.Stat_t) error,
+) string {
+	for _, path := range paths {
+		var candidate unix.Stat_t
+		if err := stat(path, &candidate); err != nil {
+			continue
+		}
+		if candidate.Mode&unix.S_IFMT == unix.S_IFCHR && candidate.Rdev == rdev {
+			return path
+		}
+	}
+	return ""
+}

--- a/internal/cli/wake_tty_path_darwin_test.go
+++ b/internal/cli/wake_tty_path_darwin_test.go
@@ -1,0 +1,158 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestFindDarwinTTYPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		rdev  int32
+		stats map[string]unix.Stat_t
+		want  string
+	}{
+		{
+			name: "matches ttys device",
+			rdev: 42,
+			stats: map[string]unix.Stat_t{
+				"/dev/ttys001": {Mode: unix.S_IFCHR, Rdev: 7},
+				"/dev/ttys002": {Mode: unix.S_IFCHR, Rdev: 42},
+				"/dev/console": {Mode: unix.S_IFCHR, Rdev: 9},
+			},
+			want: "/dev/ttys002",
+		},
+		{
+			name: "matches console fallback",
+			rdev: 9,
+			stats: map[string]unix.Stat_t{
+				"/dev/ttys001": {Mode: unix.S_IFCHR, Rdev: 7},
+				"/dev/console": {Mode: unix.S_IFCHR, Rdev: 9},
+			},
+			want: "/dev/console",
+		},
+		{
+			name: "rejects non character device",
+			rdev: 42,
+			stats: map[string]unix.Stat_t{
+				"/dev/ttys001": {Mode: unix.S_IFREG, Rdev: 42},
+			},
+		},
+		{name: "no device match", rdev: 42},
+	}
+	paths := []string{"/dev/ttys001", "/dev/ttys002", "/dev/console"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findDarwinTTYPath(tt.rdev, paths, func(path string, stat *unix.Stat_t) error {
+				value, ok := tt.stats[path]
+				if !ok {
+					return os.ErrNotExist
+				}
+				*stat = value
+				return nil
+			})
+			if got != tt.want {
+				t.Fatalf("path = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewWakeLockRecordsDarwinControllingTTYUnderRealPTY(t *testing.T) {
+	const helperEnv = "AMQ_TEST_DARWIN_CURRENT_TTY_PTY"
+	if os.Getenv(helperEnv) == "1" {
+		lock, err := newWakeLock(t.TempDir(), "codex", wakeLockAcquireOptions{wakeMode: wakeInjectModeRaw})
+		if err != nil {
+			t.Fatalf("create wake lock metadata: %v", err)
+		}
+		if !strings.HasPrefix(lock.TTY, "/dev/ttys") {
+			t.Fatalf("wake lock tty = %q, want /dev/ttys*", lock.TTY)
+		}
+		info, err := os.Stat(lock.TTY)
+		if err != nil {
+			t.Fatalf("stat recorded tty %q: %v", lock.TTY, err)
+		}
+		if info.Mode()&os.ModeCharDevice == 0 {
+			t.Fatalf("recorded tty %q mode = %v, want character device", lock.TTY, info.Mode())
+		}
+		return
+	}
+
+	if _, err := os.Stat("/usr/bin/script"); err != nil {
+		t.Skipf("Darwin PTY regression requires /usr/bin/script: %v", err)
+	}
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(
+		ctx,
+		"/usr/bin/script",
+		"-q",
+		"/dev/null",
+		testBinary,
+		"-test.run=^TestNewWakeLockRecordsDarwinControllingTTYUnderRealPTY$",
+	)
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 2 * time.Second
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	err = cmd.Run()
+	evidencePath := filepath.Join(t.TempDir(), "darwin-current-tty-pty.log")
+	if writeErr := os.WriteFile(evidencePath, output.Bytes(), 0o600); writeErr != nil {
+		t.Fatalf("write PTY evidence: %v", writeErr)
+	}
+	t.Logf("PTY evidence: %s", evidencePath)
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("Darwin current-TTY regression timed out; evidence=%s\n%s", evidencePath, output.String())
+	}
+	if err != nil {
+		t.Fatalf("Darwin current-TTY regression: %v; evidence=%s\n%s", err, evidencePath, output.String())
+	}
+}
+
+func TestGetCurrentTTYDarwinReturnsEmptyWithoutControllingTerminal(t *testing.T) {
+	const helperEnv = "AMQ_TEST_DARWIN_NO_CURRENT_TTY"
+	if os.Getenv(helperEnv) == "1" {
+		if tty := getCurrentTTY(); tty != "" {
+			t.Fatalf("detached process current tty = %q, want empty", tty)
+		}
+		return
+	}
+
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(testBinary, "-test.run=^TestGetCurrentTTYDarwinReturnsEmptyWithoutControllingTerminal$")
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("detached current-TTY regression: %v\n%s", err, output.String())
+	}
+}

--- a/internal/cli/wake_tty_path_linux.go
+++ b/internal/cli/wake_tty_path_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func currentTTYPath(tty *os.File) string {
+	link, err := os.Readlink(fmt.Sprintf("/dev/fd/%d", tty.Fd()))
+	if err != nil {
+		return ""
+	}
+	if real, err := filepath.EvalSymlinks(link); err == nil {
+		return real
+	}
+	return link
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -548,7 +548,6 @@ func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
 	if !inspection.IdentityConfirmed {
 		return false
 	}
-	existing := inspection.Lock
 
 	// Process is a confirmed matching amq wake. If its TTY disappeared, stop
 	// that orphan before taking over; never signal an unconfirmed PID.
@@ -556,32 +555,55 @@ func wakeLockNeedsReplacement(inspection wakeLockInspection) bool {
 		return true
 	}
 
+	return wakeLockSharesCurrentTerminalDifferentSession(inspection)
+}
+
+func wakeLockSharesCurrentTerminalDifferentSession(inspection wakeLockInspection) bool {
+	if !sameWakeTerminalAsCurrent(inspection) {
+		return false
+	}
+	existingSID, existingErr := getWakeProcessSID(inspection.Lock.PID)
+	currentSID, currentErr := getWakeProcessSID(0)
+	return existingErr == nil && currentErr == nil && existingSID != currentSID
+}
+
+func sameWakeTTYPathAsCurrent(inspection wakeLockInspection) bool {
 	currentTTY := getWakeCurrentTTY()
-	existingTTY := existing.TTY
+	existingTTY := inspection.Lock.TTY
 	if strings.HasPrefix(existingTTY, "/dev/") {
 		if real, err := filepath.EvalSymlinks(existingTTY); err == nil {
 			existingTTY = real
 		}
 	}
-	if currentTTY != "" && currentTTY == existingTTY {
-		existingSid, sidErr := getWakeProcessSID(existing.PID)
-		currentSid, _ := getWakeProcessSID(0)
-		if sidErr == nil && existingSid != currentSid {
-			return true
-		}
-	}
-	return false
+	return currentTTY != "" && currentTTY == existingTTY
 }
 
-func wakeLockTerminalGone(inspection wakeLockInspection) bool {
+type wakeTerminalAttachment uint8
+
+const (
+	wakeTerminalUndeterminable wakeTerminalAttachment = iota
+	wakeTerminalGone
+	wakeTerminalAttached
+)
+
+func wakeLockTerminalAttachment(inspection wakeLockInspection) wakeTerminalAttachment {
 	tty := strings.TrimSpace(inspection.Lock.TTY)
 	if strings.HasPrefix(tty, "/dev/") {
 		if _, statErr := os.Stat(tty); os.IsNotExist(statErr) {
-			return true
+			return wakeTerminalGone
 		}
 	}
-	return inspection.Process.ControllingTerminalKnown &&
-		!inspection.Process.HasControllingTerminal
+	if inspection.Process.ControllingTerminalKnown {
+		if inspection.Process.HasControllingTerminal {
+			return wakeTerminalAttached
+		}
+		return wakeTerminalGone
+	}
+	return wakeTerminalUndeterminable
+}
+
+func wakeLockTerminalGone(inspection wakeLockInspection) bool {
+	return wakeLockTerminalAttachment(inspection) == wakeTerminalGone
 }
 
 func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string, requestedTarget *wakeTarget) error {
@@ -639,6 +661,15 @@ func wakeLockHasUsableNotificationPath(inspection wakeLockInspection) bool {
 		inspection.Lock.TargetDigest != "") || wakeArgsUseInjectVia(inspection.Process.Args) {
 		return true
 	}
+	switch wakeLockTerminalAttachment(inspection) {
+	case wakeTerminalGone:
+		return false
+	case wakeTerminalAttached:
+		return true
+	}
+	// Linux cannot currently inspect controlling-terminal attachment. Preserve
+	// its concrete-path evidence while treating an absent/legacy unknown name
+	// as unusable when attachment is undeterminable.
 	tty := strings.TrimSpace(inspection.Lock.TTY)
 	return tty != "" && tty != "unknown"
 }
@@ -2606,12 +2637,5 @@ func getCurrentTTY() string {
 		return ""
 	}
 	defer func() { _ = tty.Close() }()
-	if link, err := os.Readlink(fmt.Sprintf("/dev/fd/%d", tty.Fd())); err == nil {
-		// Normalize symlinks for reliable comparison
-		if real, err := filepath.EvalSymlinks(link); err == nil {
-			return real
-		}
-		return link
-	}
-	return ""
+	return currentTTYPath(tty)
 }

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -2694,17 +2694,22 @@ func TestShouldReplaceOrphanedWakeLockKeepsLockWhenKillDoesNotTerminate(t *testi
 		}
 		return wakeProcessInfo{PID: pid}
 	})
+	var signals []os.Signal
 	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		signals = append(signals, sig)
 		return nil
 	})
 
 	inspection := inspectWakeLock(root, "orchestrator")
 	replaced, err := shouldReplaceOrphanedWakeLock(inspection)
-	if err == nil || !strings.Contains(err.Error(), "live raw wake orphan") {
-		t.Fatalf("expected live raw orphan refusal, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "still alive after SIGKILL") {
+		t.Fatalf("expected failed automatic termination, got %v", err)
 	}
 	if replaced {
 		t.Fatal("should not replace lock when old wake remains alive")
+	}
+	if len(signals) != 2 || signals[0] != syscall.SIGTERM || signals[1] != syscall.SIGKILL {
+		t.Fatalf("signals = %v, want SIGTERM then SIGKILL", signals)
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
 		t.Fatalf("lock should remain after failed kill, stat=%v", statErr)


### PR DESCRIPTION
## Summary
- resolve the current controlling TTY on Darwin from process metadata instead of readlink on /dev/fd
- automatically replace identity-confirmed raw wakes when their terminal is gone or the same terminal belongs to a different session
- require explicit consent for remaining live raw takeovers while refusing proven-foreign and inject-via processes
- make Darwin and Linux termination guards symmetric and treat exact self-cleanup after proven exit as success

## Safety tradeoff
A second coop exec for the same agent and root can take over a first raw wake after showing its PID, TTY, and live-terminal state. Different-terminal takeovers require explicit consent; declining leaves the existing wake untouched. Automatic replacement is limited to identity-confirmed cases with terminal-gone or same-terminal/different-session evidence.

## Verification
- peer review PASS on staged tree 8c0cbc0d311067e710822bddf8890e35a4031408, including real-PTY arms
- make ci
- docker run --rm -v "$PWD:/src:ro" -w /src golang:1.25 go test ./internal/cli -count=1

Release Please will generate the committed changelog entry from this conventional squash title.