### PR TITLE
fix(wake): recover partial takeovers with duplicate warning

### DIFF
--- a/internal/cli/coop_wake_reclaim_darwin_test.go
+++ b/internal/cli/coop_wake_reclaim_darwin_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"syscall"
@@ -61,6 +62,108 @@ func TestPrepareCoopWakeLockConsentedWakeSelfCleanupIsSuccess(t *testing.T) {
 		ControllingTerminalKnown: true,
 		HasControllingTerminal:   true,
 	}, "running, and still attached to a terminal — this may be a live session in another window", true)
+}
+
+func TestPrepareCoopWakeLockConsentedWakeSelfCleanupWithoutProvenExitWarnsAndProceeds(t *testing.T) {
+	tests := []struct {
+		name        string
+		afterSignal wakeProcessInfo
+	}{
+		{
+			name: "same identity",
+			afterSignal: wakeProcessInfo{
+				Running:    true,
+				StartToken: "start",
+				BootID:     "boot",
+				Executable: "/opt/homebrew/bin/amq",
+			},
+		},
+		{
+			name: "unknown identity",
+			afterSignal: wakeProcessInfo{
+				Running:      true,
+				InspectError: errors.New("test identity inspection failure"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const (
+				pid = 66121
+				tty = "/dev/null"
+			)
+			root := secureTempDirForTest(t)
+			args := []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}
+			lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+				PID:          pid,
+				TTY:          tty,
+				ProcessStart: "start",
+				BootID:       "boot",
+				Executable:   "/opt/homebrew/bin/amq",
+				Args:         args,
+				Generation:   "live-raw-partial-takeover",
+			})
+			signaled := false
+			stubInspectWakeProcess(t, func(got int) wakeProcessInfo {
+				if signaled {
+					info := test.afterSignal
+					info.PID = got
+					return info
+				}
+				return wakeProcessInfo{
+					PID:                      got,
+					Running:                  true,
+					StartToken:               "start",
+					BootID:                   "boot",
+					Executable:               "/opt/homebrew/bin/amq",
+					Args:                     args,
+					ControllingTerminalKnown: true,
+					HasControllingTerminal:   true,
+				}
+			})
+			var signals []os.Signal
+			stubSignalWakeProcess(t, func(got int, signal os.Signal) error {
+				signals = append(signals, signal)
+				if got != pid || signal != syscall.SIGTERM {
+					t.Fatalf("signal = (%d, %v), want (%d, SIGTERM)", got, signal, pid)
+				}
+				signaled = true
+				if err := os.Remove(lockPath); err != nil {
+					t.Fatalf("simulate old wake self-cleanup: %v", err)
+				}
+				return nil
+			})
+
+			var prepareErr error
+			stderr := captureWakeStderr(t, func() {
+				prepareErr = prepareCoopWakeLock(root, "codex", true, "unused")
+			})
+			if prepareErr != nil {
+				t.Fatalf("approved takeover after partial old-wake cleanup: %v", prepareErr)
+			}
+			if len(signals) != 1 || signals[0] != syscall.SIGTERM {
+				t.Fatalf("signals = %v, want [SIGTERM]", signals)
+			}
+			if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+				t.Fatalf("self-cleaned live raw lock exists after takeover: %v", err)
+			}
+			for _, want := range []string{
+				"superseded wake helper",
+				"pid 66121",
+				tty,
+				"without a confirmed exit",
+				"duplicate notifications may continue",
+			} {
+				if !strings.Contains(stderr, want) {
+					t.Fatalf("partial-takeover output %q missing %q", stderr, want)
+				}
+			}
+			if got := strings.Count(stderr, "duplicate notifications may continue"); got != 1 {
+				t.Fatalf("duplicate warning count = %d, want 1 in %q", got, stderr)
+			}
+		})
+	}
 }
 
 func TestPrepareCoopWakeLockSameTerminalDifferentSessionDefersToSilentReplacement(t *testing.T) {

--- a/internal/cli/coop_wake_reclaim_linux_test.go
+++ b/internal/cli/coop_wake_reclaim_linux_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -178,5 +179,107 @@ func TestPrepareCoopWakeLockLiveRawSelfCleanupAfterPidfdExitSucceeds(t *testing.
 	}
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Errorf("self-cleaned live raw lock exists after successful takeover: %v", err)
+	}
+}
+
+func TestPrepareCoopWakeLockLiveRawPartialTakeoverWarnsAndSucceeds(t *testing.T) {
+	const (
+		pid   = 4242
+		pidfd = 99
+		tty   = "unknown"
+	)
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          tty,
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/usr/bin/amq",
+		Args:         []string{"/usr/bin/amq", "wake", "--root", root, "--me", "codex"},
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "live-raw-partial-takeover",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		if gotPID != pid {
+			t.Fatalf("inspect pid = %d, want %d", gotPID, pid)
+		}
+		// The lock mutation cannot be rolled back even though the exact helper
+		// remains identity-same and live after the termination error.
+		return matchingLinuxWakeProcess(gotPID, root)
+	})
+
+	var signals []unix.Signal
+	pollCalls := 0
+	stubLinuxPidfd(
+		t,
+		func(gotPID, flags int) (int, error) {
+			if gotPID != pid || flags != 0 {
+				t.Fatalf("pidfd_open = (%d, %d), want (%d, 0)", gotPID, flags, pid)
+			}
+			return pidfd, nil
+		},
+		func(gotFD int, signal unix.Signal, _ *unix.Siginfo, flags int) error {
+			if gotFD != pidfd || flags != 0 {
+				t.Fatalf("pidfd_send_signal = (%d, %v, %d), want fd %d and flags 0", gotFD, signal, flags, pidfd)
+			}
+			signals = append(signals, signal)
+			switch signal {
+			case unix.SIGTERM:
+				if err := os.Remove(lockPath); err != nil {
+					t.Fatalf("simulate exact wake lock self-removal after SIGTERM: %v", err)
+				}
+				return nil
+			case unix.SIGKILL:
+				return syscall.EPERM
+			default:
+				t.Fatalf("unexpected wake signal: %v", signal)
+				return nil
+			}
+		},
+		func(gotFD int, timeout time.Duration) (bool, error) {
+			pollCalls++
+			if gotFD != pidfd {
+				t.Fatalf("pidfd poll fd = %d, want %d", gotFD, pidfd)
+			}
+			if timeout <= 0 {
+				t.Fatalf("pidfd poll timeout = %s, want positive", timeout)
+			}
+			return false, nil
+		},
+	)
+
+	var prepareErr error
+	stderr := captureWakeStderr(t, func() {
+		prepareErr = prepareCoopWakeLock(root, "codex", true, "unused")
+	})
+	if prepareErr != nil {
+		t.Errorf("partially applied approved takeover = %v, want success with warning", prepareErr)
+	}
+	if len(signals) != 2 || signals[0] != unix.SIGTERM || signals[1] != unix.SIGKILL {
+		t.Errorf("guarded pidfd signals = %v, want [SIGTERM SIGKILL]", signals)
+	}
+	if pollCalls != 1 {
+		t.Errorf("pidfd poll calls = %d, want 1 before SIGKILL failure", pollCalls)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Errorf("self-removed wake lock exists after partial takeover: %v", err)
+	}
+	if got := strings.Count(stderr, "duplicate notifications may continue"); got != 1 {
+		t.Errorf("duplicate warning count = %d, want exactly 1; stderr: %q", got, stderr)
+	}
+	warningAt := strings.Index(stderr, "warning:")
+	if warningAt < 0 {
+		return
+	}
+	warning := stderr[warningAt:]
+	for _, want := range []string{
+		"4242",
+		tty,
+		"fresh wake is starting, but duplicate notifications may continue until the old helper exits",
+		"stop that helper if duplicates persist",
+	} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("partial-takeover warning %q does not contain %q", warning, want)
+		}
 	}
 }

--- a/internal/cli/coop_wake_reclaim_unix.go
+++ b/internal/cli/coop_wake_reclaim_unix.go
@@ -163,6 +163,35 @@ func coopWakeTTYDisplay(inspection wakeLockInspection) string {
 	return tty
 }
 
+// resolveMissingWakeLockAfterTermination handles the irreversible half of a
+// takeover: the exact old helper's lock disappeared during termination, but
+// the process path could not prove that the helper exited. With no lock left to
+// preserve, proceeding is safer than returning a false retry; warn that the old
+// helper may still emit duplicate notifications.
+func resolveMissingWakeLockAfterTermination(
+	inspection wakeLockInspection,
+	terminationErr error,
+) (bool, error) {
+	current := inspectWakeLock(inspection.Root, inspection.Agent)
+	if current.Exists && !sameWakeLockGeneration(inspection, current) {
+		return false, nil
+	}
+	if current.Exists {
+		return false, terminationErr
+	}
+	// This PID-based inspection only decides whether to print the warning. Both
+	// outcomes proceed identically, so PID reuse cannot authorize an action.
+	if inspectWakeIdentity(inspection) != wakeIdentityGoneOrDifferent {
+		_ = writeStderr(
+			"warning: superseded wake helper for %s (pid %d on %s) after its lock disappeared during termination without a confirmed exit; fresh wake is starting, but duplicate notifications may continue until the old helper exits; stop that helper if duplicates persist\n",
+			inspection.Agent,
+			inspection.PID,
+			coopWakeTTYDisplay(inspection),
+		)
+	}
+	return true, nil
+}
+
 func coopWakeRemedy(inspection wakeLockInspection, state, command string) string {
 	return fmt.Sprintf("wake for %s is blocking startup and cannot notify you.\n  lock: %s\n  state: %s\n\nRe-run with -y to clear it and start a fresh wake:\n  %s\n\nTo inspect first:\n  AM_ROOT=%s amq doctor --ops", inspection.Agent, inspection.LockPath, state, command, inspection.Root)
 }

--- a/internal/cli/coop_wake_reclaim_unix_test.go
+++ b/internal/cli/coop_wake_reclaim_unix_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -38,6 +39,52 @@ func TestPrepareCoopWakeLockUnverifiedYesRemovesMetadataWithoutSignal(t *testing
 	}
 	if got := strings.Count(stderr, "duplicate notifications may continue"); got != 1 {
 		t.Fatalf("duplicate-notification warning count = %d, want 1: %q", got, stderr)
+	}
+}
+
+func TestResolveMissingWakeLockAfterTerminationPreservesPresentGenerationError(t *testing.T) {
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        66121,
+		Generation: "same-generation",
+	})
+	inspection := inspectWakeLock(root, "codex")
+	terminationErr := errors.New("test termination failure")
+
+	retired, err := resolveMissingWakeLockAfterTermination(inspection, terminationErr)
+	if retired {
+		t.Fatal("present exact generation reported retired")
+	}
+	if !errors.Is(err, terminationErr) {
+		t.Fatalf("present exact generation error = %v, want %v", err, terminationErr)
+	}
+}
+
+func TestResolveMissingWakeLockAfterTerminationReturnsRetryForReplacementGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        66121,
+		Generation: "old-generation",
+	})
+	inspection := inspectWakeLock(root, "codex")
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        77121,
+		Generation: "replacement-generation",
+	})
+
+	retired, err := resolveMissingWakeLockAfterTermination(
+		inspection,
+		errors.New("test termination failure"),
+	)
+	if err != nil {
+		t.Fatalf("replacement-generation result = %v, want caller retry", err)
+	}
+	if retired {
+		t.Fatal("replacement generation reported retired")
+	}
+	current := inspectWakeLock(root, "codex")
+	if !current.Exists || current.Lock.Generation != "replacement-generation" {
+		t.Fatalf("replacement lock changed at %s: %#v", lockPath, current)
 	}
 }
 

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -57,7 +57,7 @@ func terminateAndRemoveOrphanedWakeLockWithRawConsent(
 	// Process termination can wait. It must happen after releasing the guard.
 	if recheck.Process.Running {
 		if err := terminateWakeProcess(recheck); err != nil {
-			return false, err
+			return resolveMissingWakeLockAfterTermination(recheck, err)
 		}
 	}
 	removed := false

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -100,7 +100,7 @@ func terminateAndRemoveOrphanedWakeLockWithRawConsent(
 	// Signaling and both waits happen without the lifecycle guard. The retained
 	// pidfd cannot retarget a recycled numeric PID.
 	if err := terminateWakePidfd(pidfd); err != nil {
-		return false, err
+		return resolveMissingWakeLockAfterTermination(locked, err)
 	}
 
 	removed := false


### PR DESCRIPTION
## Summary
- continue an already-mutated wake takeover when the exact old lock disappears during a termination error
- warn once with agent, PID, and TTY when the old helper exit cannot be confirmed and duplicate notifications may continue
- preserve the original failure for a present exact generation and return retry for a replacement-generation race
- keep Darwin and Linux outcomes symmetric without weakening foreign-process, inject-via, or pidfd guards

## Verification
- exact-tree peer PASS: 9f1b7d52807c91786671a9e5d37bb5d84eede88b
- native make ci
- full read-only Linux CLI suite in golang:1.25
- causal Darwin same/unknown identity REDs and Linux pidfd SIGKILL-failure RED

The conventional squash title intentionally gives Release Please a searchable duplicate-warning changelog entry.