### PR TITLE
fix(coop): reconcile coop session mailbox routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,12 @@ A missing mailbox is an error, not an empty inbox. When `drain` or `list --new`
 finds an actually empty inbox, it prints a stderr-only note if the same handle
 has pending messages in a sibling session, including an exact non-destructive
 `amq list --session <name> --me <handle> --new` command. `doctor --ops` reports
-the same condition as a `sibling_backlog` warning. The pin is an operational
-safety check, not access control: a local process can still repin the
-environment or use the explicit override.
+the same condition as a `sibling_backlog` warning. When the active root is a
+session, an empty `drain` or `list --new` also notes unread mail for the same
+handle in the base root, while `doctor --ops` reports it as a `base_backlog`
+warning. Both include an exact non-destructive `amq list --root ...` command.
+The pin is an operational safety check, not access control: a local process can
+still repin the environment or use the explicit override.
 
 Git worktrees are isolated by default when the project root is relative (for
 example `{"root":".agent-mail"}`): the same session name resolves beneath each
@@ -366,11 +369,12 @@ eval "$(amq env --session auth --me claude --export)"
 ```
 
 Every shell-mode `amq env` output replaces the complete context: `AM_ROOT`,
-`AM_ME`, `AM_BASE_ROOT`, and `AM_SESSION`. Sessionless output sets
-`AM_BASE_ROOT` to the exact root and writes an empty `AM_SESSION`, so changing
-to another sessionless root is detectable. `--export` additionally prints a
-stderr note that the terminal is pinned. Treat this as one terminal, one
-session.
+`AM_ROOT_ID`, `AM_ME`, `AM_BASE_ROOT`, `AM_BASE_ROOT_ID`, and `AM_SESSION`.
+The two `_ID` values are opaque physical-identity tokens emitted or unset by
+AMQ; do not set them manually. Sessionless output sets `AM_BASE_ROOT` to the
+exact root and writes an empty `AM_SESSION`, so changing to another sessionless
+root is detectable. `--export` additionally prints a stderr note that the
+terminal is pinned. Treat this as one terminal, one session.
 
 Auto-detect covers the default `.agent-mail` layout, including `.agent-mail/<session>` session roots without `.amqrc`. Custom root names and peer config still require `.amqrc` or explicit flags/env.
 This same chain is used by `amq env`, `amq doctor`, and the integration commands, so Symphony and Kanban-launched agents can find the correct queue even when they are not started from the project directory.

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -160,16 +160,18 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 		agents = parsedAgents
 	}
 
-	// Create root directories
+	// Keep the shared config at the base root, but provision the roster in the
+	// default session that coop exec actually selects.
 	if err := fsq.EnsureRootDirs(queueRoot); err != nil {
 		return fmt.Errorf("failed to create root directories: %w", err)
 	}
-
-	// Create agent mailboxes under the session subdirectory
 	for _, agent := range agents {
 		if err := fsq.EnsureAgentDirs(queueRoot, agent); err != nil {
-			return fmt.Errorf("failed to create mailbox for %s: %w", agent, err)
+			return fmt.Errorf("failed to create compatibility base mailbox for %s: %w", agent, err)
 		}
+	}
+	if _, err := provisionCoopSession(queueRoot, defaultSessionName, agents, "", ""); err != nil {
+		return fmt.Errorf("failed to create default session root: %w", err)
 	}
 
 	configWritten := false
@@ -270,6 +272,69 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 		}
 	}
 	return nil
+}
+
+// provisionCoopSession creates or validates one named session as a direct,
+// non-symlink child of a pinned base capability, then creates every requested
+// mailbox through the pinned child capability. No provisioning write reopens
+// the session through its ambient lexical path.
+func provisionCoopSession(base, session string, agents []string, execAgent, execCommand string) (string, error) {
+	if err := validateSessionName(session); err != nil {
+		return "", err
+	}
+	base, err := absoluteSessionRoot(base)
+	if err != nil {
+		return "", err
+	}
+	if !dirExists(base) {
+		return "", NotFoundError("base root not found at %s", base)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(base)
+	if err != nil {
+		return "", err
+	}
+	baseRoot, err := fsq.OpenDeliveryRoot(base, identity)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = baseRoot.Close() }()
+
+	sessionRoot, err := baseRoot.OpenOrCreateDirectChild(session, 0o700)
+	if err != nil {
+		sessionPath := filepath.Join(base, session)
+		if info, lstatErr := os.Lstat(sessionPath); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+			message := fmt.Sprintf(
+				"session root %s is a symlink; refusing to provision through it; remove it to use the named session",
+				sessionPath,
+			)
+			if target, resolveErr := filepath.EvalSymlinks(sessionPath); resolveErr == nil &&
+				execAgent != "" && execCommand != "" {
+				message += fmt.Sprintf(
+					"; for intentional relocation, use: amq coop exec --root %s --me %s %s",
+					shellQuoteArg(target),
+					shellQuoteArg(execAgent),
+					shellQuoteArg(execCommand),
+				)
+			}
+			return "", ContextMismatchError("%s", message)
+		}
+		return "", ContextMismatchError(
+			"refusing session %q: path %s is not a stable direct directory under base: %v",
+			session,
+			sessionPath,
+			err,
+		)
+	}
+	defer func() { _ = sessionRoot.Close() }()
+	if err := sessionRoot.EnsureRootDirs(); err != nil {
+		return "", err
+	}
+	for _, agent := range agents {
+		if err := sessionRoot.EnsureAgentDirs(agent); err != nil {
+			return "", fmt.Errorf("failed to create mailbox for %s: %w", agent, err)
+		}
+	}
+	return sessionRoot.Base(), nil
 }
 
 func parseCoopInitAgents(raw string) ([]string, error) {

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -636,6 +636,199 @@ func TestCoopExecSessionInvalidName(t *testing.T) {
 	}
 }
 
+func TestCoopInitProvisionsDefaultExecSession(t *testing.T) {
+	baseRoot := initCoopProjectForTest(t, "alice,bob")
+	sessionRoot := filepath.Join(baseRoot, defaultSessionName)
+
+	for _, agent := range []string{"alice", "bob"} {
+		for _, leaf := range fsq.RequiredMailboxLeaves() {
+			path := fsq.AgentMailboxPath(sessionRoot, agent, leaf)
+			if info, err := os.Stat(path); err != nil || !info.IsDir() {
+				t.Fatalf("coop init did not provision %s where default coop exec reads: info=%v err=%v", path, info, err)
+			}
+		}
+		if info, err := os.Stat(fsq.AgentInboxNew(baseRoot, agent)); err != nil || !info.IsDir() {
+			t.Fatalf("coop init did not preserve compatibility base mailbox for %q: info=%v err=%v", agent, info, err)
+		}
+	}
+
+	sentinel := errors.New("exec sentinel")
+	var execEnv []string
+	oldExec := coopExecProcess
+	coopExecProcess = func(_ string, _ []string, env []string) error {
+		execEnv = append([]string(nil), env...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err := runCoopExec([]string{"--no-wake", "--me", "alice", "sh"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want sentinel", err)
+	}
+	if got := envValue(execEnv, envRoot); !sameTreeIdentity(got, sessionRoot) {
+		t.Fatalf("coop exec AM_ROOT = %q, want provisioned session root %q", got, sessionRoot)
+	}
+}
+
+func TestCoopInitBareSendListAndDrainAgree(t *testing.T) {
+	initCoopProjectForTest(t, "alice,bob")
+
+	sendOut, _, err := captureEnvOutput(t, func() error {
+		return runSend([]string{
+			"--me", "bob",
+			"--to", "alice",
+			"--subject", "first-run agreement",
+			"--body", "must remain readable",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("bare send after coop init: %v", err)
+	}
+	if !strings.Contains(sendOut, `"id"`) {
+		t.Fatalf("bare send did not report success JSON: %q", sendOut)
+	}
+
+	listOut, _, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--new", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("bare list after successful send: %v", err)
+	}
+	if !strings.Contains(listOut, `"subject": "first-run agreement"`) {
+		t.Fatalf("bare list did not return sent message: %q", listOut)
+	}
+
+	drainOut, _, err := captureEnvOutput(t, func() error {
+		return runDrain([]string{"--me", "alice", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("bare drain after successful send: %v", err)
+	}
+	if !strings.Contains(drainOut, `"count": 1`) {
+		t.Fatalf("bare drain did not consume sent message: %q", drainOut)
+	}
+}
+
+func TestCoopInitRejectsPreexistingDefaultSessionSymlink(t *testing.T) {
+	projectDir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside target")
+	if err := os.Mkdir(outside, 0o700); err != nil {
+		t.Fatalf("create outside target: %v", err)
+	}
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+		resetAmqrcCache()
+	})
+	resetAmqrcCache()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	baseRoot := filepath.Join(projectDir, defaultCoopRoot)
+	if err := os.Mkdir(baseRoot, 0o700); err != nil {
+		t.Fatalf("create base root: %v", err)
+	}
+	sessionRoot := filepath.Join(baseRoot, defaultSessionName)
+	if err := os.Symlink(outside, sessionRoot); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	_, err = captureEnvStdout(t, func() error {
+		return runCoopInitInternal([]string{"--agents", "alice,bob", "--json", "--no-gitignore"}, false)
+	})
+	if err == nil ||
+		!strings.Contains(err.Error(), "is a symlink") ||
+		!strings.Contains(err.Error(), sessionRoot) ||
+		!strings.Contains(err.Error(), "remove it") {
+		t.Fatalf("coop init result = %v, want actionable session symlink refusal", err)
+	}
+	entries, readErr := os.ReadDir(outside)
+	if readErr != nil {
+		t.Fatalf("read outside target: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("coop init followed collab symlink and mutated outside target: %v", entries)
+	}
+	info, lstatErr := os.Lstat(sessionRoot)
+	if lstatErr != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("collab symlink was changed: info=%v err=%v", info, lstatErr)
+	}
+}
+
+func TestCoopExecRejectsPreexistingDefaultSessionSymlink(t *testing.T) {
+	projectDir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside target")
+	if err := os.Mkdir(outside, 0o700); err != nil {
+		t.Fatalf("create outside target: %v", err)
+	}
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+		resetAmqrcCache()
+	})
+	resetAmqrcCache()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	baseRoot := filepath.Join(projectDir, defaultCoopRoot)
+	if err := fsq.EnsureRootDirs(baseRoot); err != nil {
+		t.Fatalf("create base root: %v", err)
+	}
+	cfg := config.Config{Version: 1, Agents: []string{"alice", "bob"}}
+	if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), cfg, false); err != nil {
+		t.Fatalf("write base config: %v", err)
+	}
+	amqrcData, err := json.Marshal(amqrc{Root: defaultCoopRoot})
+	if err != nil {
+		t.Fatalf("marshal .amqrc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, ".amqrc"), amqrcData, 0o644); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+	sessionRoot := filepath.Join(baseRoot, defaultSessionName)
+	if err := os.Symlink(outside, sessionRoot); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	resolvedOutside, err := filepath.EvalSymlinks(outside)
+	if err != nil {
+		t.Fatalf("resolve outside target: %v", err)
+	}
+
+	execCalled := false
+	oldExec := coopExecProcess
+	coopExecProcess = func(string, []string, []string) error {
+		execCalled = true
+		return errors.New("unexpected exec")
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err = runCoopExec([]string{"--no-wake", "--me", "alice", "sh"})
+	if err == nil ||
+		!strings.Contains(err.Error(), "is a symlink") ||
+		!strings.Contains(err.Error(), sessionRoot) ||
+		!strings.Contains(err.Error(), "use: amq coop exec --root "+shellQuoteArg(resolvedOutside)+" --me alice sh") {
+		t.Fatalf("coop exec result = %v, want actionable session symlink refusal", err)
+	}
+	if execCalled {
+		t.Fatal("coop exec reached process replacement after session symlink refusal")
+	}
+	entries, readErr := os.ReadDir(outside)
+	if readErr != nil {
+		t.Fatalf("read outside target: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("coop exec followed collab symlink and mutated outside target: %v", entries)
+	}
+}
+
 func TestCoopInitDefaultIncludesUser(t *testing.T) {
 	projectDir := t.TempDir()
 	oldDir, err := os.Getwd()
@@ -675,7 +868,7 @@ func TestCoopInitDefaultIncludesUser(t *testing.T) {
 	if !reflect.DeepEqual(cfg.Agents, want) {
 		t.Fatalf("config agents = %#v, want %#v", cfg.Agents, want)
 	}
-	if _, err := os.Stat(filepath.Join(projectDir, defaultCoopRoot, "agents", "user", "inbox", "new")); err != nil {
+	if _, err := os.Stat(filepath.Join(projectDir, defaultCoopRoot, defaultSessionName, "agents", "user", "inbox", "new")); err != nil {
 		t.Fatalf("user inbox should be created: %v", err)
 	}
 }
@@ -687,7 +880,7 @@ func TestCoopInitRerunUsesConfiguredAgents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read initial config: %v", err)
 	}
-	if err := os.RemoveAll(filepath.Join(root, "agents")); err != nil {
+	if err := os.RemoveAll(filepath.Join(root, defaultSessionName, "agents")); err != nil {
 		t.Fatalf("remove initial mailboxes: %v", err)
 	}
 	resetAmqrcCache()
@@ -712,12 +905,12 @@ func TestCoopInitRerunUsesConfiguredAgents(t *testing.T) {
 		t.Fatalf("rerun agents = %#v, want configured %#v", result.Agents, want)
 	}
 	for _, agent := range want {
-		if _, err := os.Stat(filepath.Join(root, "agents", agent, "inbox", "new")); err != nil {
+		if _, err := os.Stat(filepath.Join(root, defaultSessionName, "agents", agent, "inbox", "new")); err != nil {
 			t.Fatalf("%s inbox was not restored: %v", agent, err)
 		}
 	}
 	for _, agent := range []string{"claude", "codex", "user"} {
-		if _, err := os.Stat(filepath.Join(root, "agents", agent)); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(root, defaultSessionName, "agents", agent)); !os.IsNotExist(err) {
 			t.Fatalf("rerun created default agent %q, stat err=%v", agent, err)
 		}
 	}
@@ -755,11 +948,11 @@ func TestCoopInitRerunWarnsWhenRequestedAgentsDifferWithoutForce(t *testing.T) {
 	if !reflect.DeepEqual(result.Agents, want) || result.ConfigWritten {
 		t.Fatalf("non-force result = %#v, want configured agents %#v without config rewrite", result, want)
 	}
-	if _, err := os.Stat(filepath.Join(root, "agents", "alice", "inbox", "new")); err != nil {
+	if _, err := os.Stat(filepath.Join(root, defaultSessionName, "agents", "alice", "inbox", "new")); err != nil {
 		t.Fatalf("non-force rerun did not retain configured mailbox: %v", err)
 	}
 	for _, agent := range []string{"carol", "dave"} {
-		if _, err := os.Stat(filepath.Join(root, "agents", agent)); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(root, defaultSessionName, "agents", agent)); !os.IsNotExist(err) {
 			t.Fatalf("non-force rerun created requested agent %q, stat err=%v", agent, err)
 		}
 	}
@@ -793,7 +986,7 @@ func TestCoopInitRerunDoesNotWarnWhenRequestedAgentsMatch(t *testing.T) {
 
 func TestCoopInitRerunRejectsInvalidExplicitAgentsBeforeMailboxMutation(t *testing.T) {
 	root := initCoopProjectForTest(t, "alice,bob")
-	if err := os.RemoveAll(filepath.Join(root, "agents")); err != nil {
+	if err := os.RemoveAll(filepath.Join(root, defaultSessionName, "agents")); err != nil {
 		t.Fatalf("remove initial mailboxes: %v", err)
 	}
 	resetAmqrcCache()
@@ -804,7 +997,7 @@ func TestCoopInitRerunRejectsInvalidExplicitAgentsBeforeMailboxMutation(t *testi
 	if err == nil || !strings.Contains(err.Error(), "slashes not allowed") {
 		t.Fatalf("invalid explicit agents result = %v", err)
 	}
-	if _, statErr := os.Stat(filepath.Join(root, "agents")); !os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(filepath.Join(root, defaultSessionName, "agents")); !os.IsNotExist(statErr) {
 		t.Fatalf("invalid explicit agents mutated mailboxes, stat err=%v", statErr)
 	}
 }
@@ -815,7 +1008,7 @@ func TestCoopInitRerunWithoutConfigUsesRequestedAgents(t *testing.T) {
 	if err := os.Remove(cfgPath); err != nil {
 		t.Fatalf("remove initial config: %v", err)
 	}
-	if err := os.RemoveAll(filepath.Join(root, "agents")); err != nil {
+	if err := os.RemoveAll(filepath.Join(root, defaultSessionName, "agents")); err != nil {
 		t.Fatalf("remove initial mailboxes: %v", err)
 	}
 	resetAmqrcCache()
@@ -874,7 +1067,7 @@ func TestCoopInitForceUsesRequestedAgents(t *testing.T) {
 		t.Fatalf("forced config agents = %#v, want %#v", cfg.Agents, want)
 	}
 	for _, agent := range want {
-		if _, err := os.Stat(filepath.Join(root, "agents", agent, "inbox", "new")); err != nil {
+		if _, err := os.Stat(filepath.Join(root, defaultSessionName, "agents", agent, "inbox", "new")); err != nil {
 			t.Fatalf("%s inbox was not created: %v", agent, err)
 		}
 	}
@@ -887,7 +1080,7 @@ func TestCoopInitRerunRejectsMalformedConfigBeforeMailboxMutation(t *testing.T) 
 	if err := os.WriteFile(cfgPath, []byte(malformed), 0o600); err != nil {
 		t.Fatalf("write malformed config: %v", err)
 	}
-	if err := os.RemoveAll(filepath.Join(root, "agents")); err != nil {
+	if err := os.RemoveAll(filepath.Join(root, defaultSessionName, "agents")); err != nil {
 		t.Fatalf("remove initial mailboxes: %v", err)
 	}
 	resetAmqrcCache()
@@ -898,7 +1091,7 @@ func TestCoopInitRerunRejectsMalformedConfigBeforeMailboxMutation(t *testing.T) 
 	if err == nil || !strings.Contains(err.Error(), "failed to load existing config") {
 		t.Fatalf("malformed config result = %v", err)
 	}
-	if _, statErr := os.Stat(filepath.Join(root, "agents")); !os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(filepath.Join(root, defaultSessionName, "agents")); !os.IsNotExist(statErr) {
 		t.Fatalf("malformed rerun mutated mailboxes, stat err=%v", statErr)
 	}
 	data, readErr := os.ReadFile(cfgPath)
@@ -933,7 +1126,7 @@ func TestCoopInitRerunRejectsInvalidConfiguredAgentsBeforeMailboxMutation(t *tes
 			if err := config.WriteConfig(cfgPath, cfg, true); err != nil {
 				t.Fatalf("write invalid agents config: %v", err)
 			}
-			if err := os.RemoveAll(filepath.Join(root, "agents")); err != nil {
+			if err := os.RemoveAll(filepath.Join(root, defaultSessionName, "agents")); err != nil {
 				t.Fatalf("remove initial mailboxes: %v", err)
 			}
 			resetAmqrcCache()
@@ -944,7 +1137,7 @@ func TestCoopInitRerunRejectsInvalidConfiguredAgentsBeforeMailboxMutation(t *tes
 			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
 				t.Fatalf("invalid agents config result = %v, want %q", err, test.wantErr)
 			}
-			if _, statErr := os.Stat(filepath.Join(root, "agents")); !os.IsNotExist(statErr) {
+			if _, statErr := os.Stat(filepath.Join(root, defaultSessionName, "agents")); !os.IsNotExist(statErr) {
 				t.Fatalf("invalid agents rerun mutated mailboxes, stat err=%v", statErr)
 			}
 		})
@@ -960,7 +1153,7 @@ func TestCoopInitRerunRejectsUnreadableConfigBeforeMailboxMutation(t *testing.T)
 	if err := os.Mkdir(cfgPath, 0o700); err != nil {
 		t.Fatalf("replace config with unreadable shape: %v", err)
 	}
-	if err := os.RemoveAll(filepath.Join(root, "agents")); err != nil {
+	if err := os.RemoveAll(filepath.Join(root, defaultSessionName, "agents")); err != nil {
 		t.Fatalf("remove initial mailboxes: %v", err)
 	}
 	resetAmqrcCache()
@@ -971,7 +1164,7 @@ func TestCoopInitRerunRejectsUnreadableConfigBeforeMailboxMutation(t *testing.T)
 	if err == nil || !strings.Contains(err.Error(), "failed to load existing config") {
 		t.Fatalf("unreadable config result = %v", err)
 	}
-	if _, statErr := os.Stat(filepath.Join(root, "agents")); !os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(filepath.Join(root, defaultSessionName, "agents")); !os.IsNotExist(statErr) {
 		t.Fatalf("unreadable rerun mutated mailboxes, stat err=%v", statErr)
 	}
 }
@@ -1008,7 +1201,7 @@ func TestCoopInitRerunRejectsDanglingConfigSymlinkBeforeMailboxMutation(t *testi
 		t.Fatalf("dangling config result = %v", err)
 	}
 	for _, path := range []string{
-		filepath.Join(root, "agents"),
+		filepath.Join(root, defaultSessionName),
 		filepath.Join(root, "threads"),
 		filepath.Join(projectDir, ".amqrc"),
 		filepath.Join(projectDir, ".gitignore"),

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -135,6 +135,7 @@ func runCoopExec(args []string) error {
 
 	// Resolve root: --root flag (or --session-derived) > .amqrc > default.
 	root := *rootFlag
+	sessionProvisioned := false
 	if root == "" {
 		existing, existingErr := findAndLoadAmqrc()
 		switch existingErr {
@@ -148,6 +149,27 @@ func runCoopExec(args []string) error {
 		default:
 			return fmt.Errorf("invalid .amqrc: %w", existingErr)
 		}
+	}
+
+	// Explicit named sessions use the same direct-child creation boundary as
+	// coop init/default exec. In particular, never let MkdirAll traverse a
+	// pre-existing session symlink.
+	if *sessionFlag != "" {
+		if *noInitFlag && !dirExists(root) {
+			return fmt.Errorf("root %q does not exist; run 'amq coop init' first or remove --no-init", root)
+		}
+		base := filepath.Dir(root)
+		if !dirExists(base) {
+			if err := fsq.EnsureRootDirs(base); err != nil {
+				return fmt.Errorf("failed to create base root %q: %w", base, err)
+			}
+		}
+		requestedRoot := root
+		root, err = provisionCoopSession(base, *sessionFlag, []string{agentHandle}, agentHandle, cmdName)
+		if err != nil {
+			return fmt.Errorf("failed to create session root %q: %w", requestedRoot, err)
+		}
+		sessionProvisioned = true
 	}
 
 	// Auto-init if needed (before session defaulting so full init fires on fresh projects).
@@ -203,14 +225,11 @@ func runCoopExec(args []string) error {
 	// This runs after auto-init so .amqrc exists and resolveBaseRoot() works.
 	if *sessionFlag == "" && *rootFlag == "" {
 		base := root // root is the literal .amqrc root (e.g., .agent-mail)
-		root = filepath.Join(base, defaultSessionName)
-		// Ensure session root + agent dirs exist.
-		if err := fsq.EnsureRootDirs(root); err != nil {
-			return fmt.Errorf("failed to create session root %q: %w", root, err)
+		root, err = provisionCoopSession(base, defaultSessionName, []string{agentHandle}, agentHandle, cmdName)
+		if err != nil {
+			return fmt.Errorf("failed to create session root %q: %w", filepath.Join(base, defaultSessionName), err)
 		}
-		if err := fsq.EnsureAgentDirs(root, agentHandle); err != nil {
-			return fmt.Errorf("failed to create mailbox for %s at %q: %w", agentHandle, root, err)
-		}
+		sessionProvisioned = true
 	}
 
 	// Pin the session root to an absolute path before it reaches the wake
@@ -224,8 +243,10 @@ func runCoopExec(args []string) error {
 	}
 
 	// Ensure agent mailbox exists.
-	if err := fsq.EnsureAgentDirs(root, agentHandle); err != nil {
-		return fmt.Errorf("failed to ensure mailbox for %s: %w", agentHandle, err)
+	if !sessionProvisioned {
+		if err := fsq.EnsureAgentDirs(root, agentHandle); err != nil {
+			return fmt.Errorf("failed to ensure mailbox for %s: %w", agentHandle, err)
+		}
 	}
 
 	// Resolve command binary.

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -179,6 +179,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 
 	// Operational and integration hints
 	result.Hints = append(result.Hints, checkSiblingBacklogHints(root, agents)...)
+	result.Hints = append(result.Hints, checkBaseBacklogHints(root, agents)...)
 	result.Hints = append(result.Hints, checkWorktreeDivergenceHints(root, agents)...)
 	result.Hints = append(result.Hints, checkGlobalRootHint()...)
 	result.Hints = append(result.Hints, checkKanbanHint()...)
@@ -221,6 +222,18 @@ func checkSiblingBacklogHints(root string, agents []string) []opsHint {
 				Message: formatSiblingBacklogHint(backlog, agent, current),
 			})
 		}
+	}
+	return hints
+}
+
+func checkBaseBacklogHints(root string, agents []string) []opsHint {
+	var hints []opsHint
+	for _, backlog := range findBaseBacklogs(root, agents) {
+		hints = append(hints, opsHint{
+			Code:    "base_backlog",
+			Status:  "warn",
+			Message: formatBaseBacklogHint(backlog),
+		})
 	}
 	return hints
 }

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -45,7 +45,21 @@ func loadSessionPin() (sessionPin, error) {
 	}
 
 	if pin.BaseRoot == "" {
-		return sessionPin{}, ContextMismatchError("incomplete AMQ session pin: %s=%q requires an exact %s", envSession, pin.Session, envBaseRoot)
+		evidence := make([]string, 0, 3)
+		if present {
+			evidence = append(evidence, envSession)
+		}
+		if rootIDPresent {
+			evidence = append(evidence, envRootID)
+		}
+		if baseRootIDPresent {
+			evidence = append(evidence, envBaseRootID)
+		}
+		return sessionPin{}, ContextMismatchError(
+			"incomplete AMQ session pin: evidence from %s requires an exact %s; re-run amq env with explicit --root <path> to replace the complete context, or clear stale pin variables before using --session <name>",
+			strings.Join(evidence, ", "),
+			envBaseRoot,
+		)
 	}
 	if pin.Session != "" {
 		pin.ExpectedRoot = filepath.Join(pin.BaseRoot, pin.Session)

--- a/internal/cli/session_guard_followup_test.go
+++ b/internal/cli/session_guard_followup_test.go
@@ -80,14 +80,92 @@ func TestSessionlessEnvOutputPinsExactRoot(t *testing.T) {
 	}
 }
 
-func TestLoadSessionPinRejectsEmptySessionWithoutBaseRoot(t *testing.T) {
-	t.Setenv(envSession, "")
-	setOptionalEnv(t, envBaseRoot, "", false)
-
-	_, err := loadSessionPin()
-	if err == nil || GetExitCode(err) != ExitContextMismatch {
-		t.Fatalf("empty session without exact base pin should be context mismatch, got %v", err)
+func TestLoadSessionPinNamesIncompletePinEvidence(t *testing.T) {
+	tests := []struct {
+		name        string
+		session     *string
+		rootID      *string
+		baseRootID  *string
+		wantNames   []string
+		secretValue string
+	}{
+		{
+			name:      "named session only",
+			session:   pointerTo("collab"),
+			wantNames: []string{envSession, envBaseRoot},
+		},
+		{
+			name:      "empty session only",
+			session:   pointerTo(""),
+			wantNames: []string{envSession, envBaseRoot},
+		},
+		{
+			name:        "root identity only",
+			rootID:      pointerTo("v1:secret-root-token"),
+			wantNames:   []string{envRootID, envBaseRoot},
+			secretValue: "v1:secret-root-token",
+		},
+		{
+			name:        "base identity only",
+			baseRootID:  pointerTo("v1:secret-base-token"),
+			wantNames:   []string{envBaseRootID, envBaseRoot},
+			secretValue: "v1:secret-base-token",
+		},
+		{
+			name:        "identity pair",
+			rootID:      pointerTo("v1:secret-root-token"),
+			baseRootID:  pointerTo("v1:secret-base-token"),
+			wantNames:   []string{envRootID, envBaseRootID, envBaseRoot},
+			secretValue: "secret-",
+		},
 	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setOptionalEnv(t, envSession, optionalString(tc.session), tc.session != nil)
+			setOptionalEnv(t, envRootID, optionalString(tc.rootID), tc.rootID != nil)
+			setOptionalEnv(t, envBaseRootID, optionalString(tc.baseRootID), tc.baseRootID != nil)
+			setOptionalEnv(t, envBaseRoot, "", false)
+
+			_, err := loadSessionPin()
+			if err == nil || GetExitCode(err) != ExitContextMismatch {
+				t.Fatalf("incomplete pin should be context mismatch, got %v", err)
+			}
+			for _, name := range tc.wantNames {
+				if !strings.Contains(err.Error(), name) {
+					t.Fatalf("error must name evidence %s: %v", name, err)
+				}
+			}
+			presentEvidence := map[string]bool{
+				envSession:    tc.session != nil,
+				envRootID:     tc.rootID != nil,
+				envBaseRootID: tc.baseRootID != nil,
+			}
+			for name, shouldAppear := range presentEvidence {
+				if strings.Contains(err.Error(), name) != shouldAppear {
+					t.Fatalf("error evidence name %s presence = %t, want %t: %v", name, strings.Contains(err.Error(), name), shouldAppear, err)
+				}
+			}
+			if !strings.Contains(err.Error(), "--root <path>") ||
+				!strings.Contains(err.Error(), "clear stale pin variables before using --session <name>") {
+				t.Fatalf("error must distinguish direct repin from clearing stale evidence first: %v", err)
+			}
+			if tc.secretValue != "" && strings.Contains(err.Error(), tc.secretValue) {
+				t.Fatalf("error leaked opaque identity token: %v", err)
+			}
+		})
+	}
+}
+
+func pointerTo(value string) *string {
+	return &value
+}
+
+func optionalString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 func TestEnvSessionFlagUsesPinnedCustomBaseFromForeignCWD(t *testing.T) {

--- a/internal/cli/sibling_backlog.go
+++ b/internal/cli/sibling_backlog.go
@@ -14,6 +14,13 @@ type siblingBacklog struct {
 	Pending int
 }
 
+type baseBacklog struct {
+	Root    string
+	Session string
+	Agent   string
+	Pending int
+}
+
 // findSiblingBacklogs performs a shallow, best-effort scan under the current
 // base root. It counts message-shaped files only; parsing headers here would
 // turn an empty-inbox diagnostic into an expensive second validation path.
@@ -51,6 +58,72 @@ func findSiblingBacklogs(root, me string) []siblingBacklog {
 	return backlogs
 }
 
+func findBaseBacklogs(root string, agents []string) []baseBacklog {
+	root = absPath(resolveRoot(root))
+	base := classifyRoot(root)
+	if base == "" {
+		return nil
+	}
+	base = absPath(resolveRoot(base))
+	if base == root {
+		return nil
+	}
+	session := sessionName(root)
+	if validateSessionName(session) != nil {
+		return nil
+	}
+	resolvedSession, err := resolveSessionRoot(base, session)
+	if err != nil || resolvedSession != root {
+		return nil
+	}
+
+	identity, err := fsq.SnapshotDeliveryRoot(base)
+	if err != nil {
+		return nil
+	}
+	baseRoot, err := fsq.OpenDeliveryRoot(base, identity)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = baseRoot.Close() }()
+
+	inventory, err := fsq.InspectMailboxLayout(baseRoot)
+	if err != nil {
+		return nil
+	}
+	healthy := make(map[string]bool, len(inventory.Mailboxes))
+	for _, mailbox := range inventory.Mailboxes {
+		if len(mailbox.Issues) == 0 {
+			healthy[mailbox.Handle] = true
+		}
+	}
+
+	seen := make(map[string]bool, len(agents))
+	var backlogs []baseBacklog
+	for _, agent := range agents {
+		normalized, err := normalizeHandle(agent)
+		if err != nil || seen[normalized] || !healthy[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		entries, err := baseRoot.ReadDir(filepath.Join("agents", normalized, "inbox", "new"))
+		if err != nil {
+			continue
+		}
+		pending := countPendingMessageEntries(entries)
+		if pending == 0 {
+			continue
+		}
+		backlogs = append(backlogs, baseBacklog{
+			Root:    base,
+			Session: session,
+			Agent:   normalized,
+			Pending: pending,
+		})
+	}
+	return backlogs
+}
+
 func countPendingMessageFiles(dir string) (int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -59,6 +132,10 @@ func countPendingMessageFiles(dir string) (int, error) {
 		}
 		return 0, err
 	}
+	return countPendingMessageEntries(entries), nil
+}
+
+func countPendingMessageEntries(entries []os.DirEntry) int {
 	count := 0
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -69,7 +146,7 @@ func countPendingMessageFiles(dir string) (int, error) {
 			count++
 		}
 	}
-	return count, nil
+	return count
 }
 
 func emitSiblingBacklogHintsIfInboxEmpty(root, me string) {
@@ -80,6 +157,9 @@ func emitSiblingBacklogHintsIfInboxEmpty(root, me string) {
 	current := siblingContext(root)
 	for _, backlog := range findSiblingBacklogs(root, me) {
 		_ = writeStderr("note: %s\n", formatSiblingBacklogHint(backlog, me, current))
+	}
+	for _, backlog := range findBaseBacklogs(root, []string{me}) {
+		_ = writeStderr("note: %s\n", formatBaseBacklogHint(backlog))
 	}
 }
 
@@ -94,4 +174,10 @@ func formatSiblingBacklogHint(backlog siblingBacklog, me, current string) string
 	return fmt.Sprintf("%d pending for %q in sibling session %q (current: %s); use: "+
 		"amq list --session %s --me %s --new",
 		backlog.Pending, me, backlog.Session, current, backlog.Session, me)
+}
+
+func formatBaseBacklogHint(backlog baseBacklog) string {
+	return fmt.Sprintf("%d pending for %q in base root %q (current: %s); use: "+
+		"amq list --root %s --me %s --new",
+		backlog.Pending, backlog.Agent, backlog.Root, backlog.Session, shellQuoteArg(backlog.Root), backlog.Agent)
 }

--- a/internal/cli/sibling_backlog_test.go
+++ b/internal/cli/sibling_backlog_test.go
@@ -64,6 +64,76 @@ func TestListEmptyJSONHintsSiblingBacklogWithoutCorruptingJSON(t *testing.T) {
 	assertSiblingHint(t, stderr, 1, "alice", "session1")
 }
 
+func TestDrainEmptyHintsBaseBacklogWithoutCorruptingJSON(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "project with space")
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	if err := fsq.EnsureAgentDirs(baseRoot, "alice"); err != nil {
+		t.Fatalf("ensure base mailbox: %v", err)
+	}
+	deliverGuardMessage(t, baseRoot, "alice", "waiting-at-base")
+
+	t.Setenv("AM_ROOT", currentRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "collab")
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runDrain([]string{"--me", "alice", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runDrain: %v", err)
+	}
+	if !strings.Contains(stdout, `"count": 0`) {
+		t.Fatalf("stdout must remain valid empty drain JSON, got %q", stdout)
+	}
+	assertBaseHint(t, stderr, 1, "alice", baseRoot, "collab")
+}
+
+func TestListEmptyJSONHintsBaseBacklogWithoutCorruptingJSON(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "project with space")
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	if err := fsq.EnsureAgentDirs(baseRoot, "alice"); err != nil {
+		t.Fatalf("ensure base mailbox: %v", err)
+	}
+	deliverGuardMessage(t, baseRoot, "alice", "waiting-at-base")
+
+	t.Setenv("AM_ROOT", currentRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "collab")
+
+	stdout, stderr, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--new", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+	if strings.TrimSpace(stdout) != "[]" {
+		t.Fatalf("stdout must remain valid empty-list JSON, got %q", stdout)
+	}
+	assertBaseHint(t, stderr, 1, "alice", baseRoot, "collab")
+}
+
+func TestListEmptySessionWithoutBaseBacklogStaysQuiet(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+
+	t.Setenv("AM_ROOT", currentRoot)
+	t.Setenv("AM_BASE_ROOT", baseRoot)
+	t.Setenv("AM_SESSION", "collab")
+
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runList([]string{"--me", "alice", "--new", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+	if strings.Contains(stderr, "base root") {
+		t.Fatalf("empty base root must stay quiet: %q", stderr)
+	}
+}
+
 func TestListEmptyBaseRootHintsSiblingBacklog(t *testing.T) {
 	parent := t.TempDir()
 	baseRoot := filepath.Join(parent, ".agent-mail")
@@ -211,6 +281,221 @@ func TestDoctorOpsReportsSiblingBacklogMismatch(t *testing.T) {
 	t.Fatalf("doctor ops missing sibling_backlog hint: %#v", result.Hints)
 }
 
+func TestDoctorOpsReportsBaseBacklogMismatch(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "project with space")
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	if err := fsq.EnsureAgentDirs(baseRoot, "alice"); err != nil {
+		t.Fatalf("ensure base mailbox: %v", err)
+	}
+	deliverGuardMessage(t, baseRoot, "alice", "waiting-at-base")
+	if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result := runOpsChecks(currentRoot, "env", false)
+	if len(result.Agents) != 1 || result.Agents[0].Handle != "alice" || result.Agents[0].UnreadCount != 0 {
+		t.Fatalf("active-session stats = %#v, want alice with zero unread", result.Agents)
+	}
+	var matches []opsHint
+	for _, hint := range result.Hints {
+		if hint.Code == "base_backlog" {
+			matches = append(matches, hint)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("base_backlog hints = %#v, want exactly one", matches)
+	}
+	hint := matches[0]
+	if hint.Status != "warn" {
+		t.Fatalf("base backlog status = %q, want warn", hint.Status)
+	}
+	for _, want := range []string{
+		`1 pending for "alice" in base root "` + baseRoot + `"`,
+		"current: collab",
+		"amq list --root '" + baseRoot + "' --me alice --new",
+	} {
+		if !strings.Contains(hint.Message, want) {
+			t.Fatalf("base backlog hint missing %q: %q", want, hint.Message)
+		}
+	}
+}
+
+func TestDoctorOpsBaseBacklogHintRequiresSessionAndPendingMessage(t *testing.T) {
+	tests := []struct {
+		name         string
+		sessionRoot  bool
+		baseEntry    string
+		baseEntryDir bool
+	}{
+		{name: "base root is current", baseEntry: "waiting.md"},
+		{name: "session with empty base", sessionRoot: true},
+		{name: "session ignores dotfile", sessionRoot: true, baseEntry: ".ignored.md"},
+		{name: "session ignores non-message", sessionRoot: true, baseEntry: "ignored.txt"},
+		{name: "session ignores message-shaped directory", sessionRoot: true, baseEntry: "queued.md", baseEntryDir: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parent := t.TempDir()
+			baseRoot := filepath.Join(parent, ".agent-mail")
+			if err := fsq.EnsureAgentDirs(baseRoot, "alice"); err != nil {
+				t.Fatalf("ensure base mailbox: %v", err)
+			}
+			if test.baseEntry != "" {
+				entryPath := filepath.Join(fsq.AgentInboxNew(baseRoot, "alice"), test.baseEntry)
+				if test.baseEntryDir {
+					if err := os.Mkdir(entryPath, 0o700); err != nil {
+						t.Fatalf("mkdir base entry: %v", err)
+					}
+				} else if err := os.WriteFile(entryPath, []byte("test"), 0o600); err != nil {
+					t.Fatalf("write base entry: %v", err)
+				}
+			}
+			if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), config.Config{
+				Version: 1,
+				Agents:  []string{"alice"},
+			}, true); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			root := baseRoot
+			if test.sessionRoot {
+				root = sessionRoot(t, parent, "collab", "alice")
+			}
+			result := runOpsChecks(root, "env", false)
+			for _, hint := range result.Hints {
+				if hint.Code == "base_backlog" {
+					t.Fatalf("unexpected base_backlog hint: %#v", hint)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorOpsBaseBacklogHintIgnoresInvalidBaseInbox(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	if err := os.MkdirAll(filepath.Join(baseRoot, "meta"), 0o700); err != nil {
+		t.Fatalf("mkdir base meta: %v", err)
+	}
+	if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(baseRoot, "agents"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write invalid base agents path: %v", err)
+	}
+
+	result := runOpsChecks(currentRoot, "env", false)
+	for _, hint := range result.Hints {
+		if hint.Code == "base_backlog" {
+			t.Fatalf("invalid base inbox produced base_backlog hint: %#v", hint)
+		}
+	}
+}
+
+func TestDoctorOpsBaseBacklogHintRequiresAuthoritativeSessionClassification(t *testing.T) {
+	baseRoot := filepath.Join(t.TempDir(), "custom-root")
+	currentRoot := filepath.Join(baseRoot, "collab")
+	siblingRoot := filepath.Join(baseRoot, "session1")
+	for _, root := range []string{currentRoot, siblingRoot} {
+		if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+			t.Fatalf("ensure session mailbox at %s: %v", root, err)
+		}
+	}
+	if err := fsq.EnsureAgentDirs(baseRoot, "alice"); err != nil {
+		t.Fatalf("ensure base mailbox: %v", err)
+	}
+	deliverGuardMessage(t, baseRoot, "alice", "waiting-at-ambiguous-base")
+	if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result := runOpsChecks(currentRoot, "env", false)
+	for _, hint := range result.Hints {
+		if hint.Code == "base_backlog" {
+			t.Fatalf("heuristic-only custom layout produced base_backlog hint: %#v", hint)
+		}
+	}
+}
+
+func TestDoctorOpsBaseBacklogHintRejectsSymlinkSession(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	realRoot := filepath.Join(parent, "real-session")
+	if err := fsq.EnsureAgentDirs(realRoot, "alice"); err != nil {
+		t.Fatalf("ensure real session mailbox: %v", err)
+	}
+	currentRoot := filepath.Join(baseRoot, "collab")
+	if err := os.MkdirAll(baseRoot, 0o700); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+	if err := os.Symlink(realRoot, currentRoot); err != nil {
+		t.Skipf("symlink session unsupported: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(baseRoot, "alice"); err != nil {
+		t.Fatalf("ensure base mailbox: %v", err)
+	}
+	deliverGuardMessage(t, baseRoot, "alice", "waiting-at-base")
+	if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result := runOpsChecks(currentRoot, "env", false)
+	for _, hint := range result.Hints {
+		if hint.Code == "base_backlog" {
+			t.Fatalf("symlink session produced base_backlog hint: %#v", hint)
+		}
+	}
+}
+
+func TestDoctorOpsBaseBacklogHintRejectsEscapingMailboxSymlink(t *testing.T) {
+	parent := t.TempDir()
+	baseRoot := filepath.Join(parent, ".agent-mail")
+	currentRoot := sessionRoot(t, parent, "collab", "alice")
+	if err := fsq.EnsureRootDirs(baseRoot); err != nil {
+		t.Fatalf("ensure base root: %v", err)
+	}
+	if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"alice"},
+	}, true); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	outsideAgent := filepath.Join(parent, "outside-alice")
+	outsideInbox := filepath.Join(outsideAgent, "inbox", "new")
+	if err := os.MkdirAll(outsideInbox, 0o700); err != nil {
+		t.Fatalf("mkdir outside inbox: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideInbox, "outside.md"), []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write outside message: %v", err)
+	}
+	if err := os.Symlink(outsideAgent, filepath.Join(baseRoot, "agents", "alice")); err != nil {
+		t.Skipf("mailbox symlink unsupported: %v", err)
+	}
+
+	result := runOpsChecks(currentRoot, "env", false)
+	for _, hint := range result.Hints {
+		if hint.Code == "base_backlog" {
+			t.Fatalf("escaping mailbox symlink produced base_backlog hint: %#v", hint)
+		}
+	}
+}
+
 func assertSiblingHint(t *testing.T, stderr string, count int, handle, session string) {
 	t.Helper()
 	wantSummary := strings.Join([]string{
@@ -225,5 +510,23 @@ func assertSiblingHint(t *testing.T, stderr string, count int, handle, session s
 	wantCommand := "amq list --session " + session + " --me " + handle + " --new"
 	if !strings.Contains(stderr, wantCommand) {
 		t.Fatalf("stderr missing exact inspection command %q: %q", wantCommand, stderr)
+	}
+}
+
+func assertBaseHint(t *testing.T, stderr string, count int, handle, baseRoot, session string) {
+	t.Helper()
+	wantSummary := strings.Join([]string{
+		"note:",
+		strconv.Itoa(count),
+		"pending for \"" + handle + "\"",
+		"in base root \"" + baseRoot + "\"",
+		"(current: " + session + ")",
+	}, " ")
+	if !strings.Contains(stderr, wantSummary) {
+		t.Fatalf("stderr missing base summary %q: %q", wantSummary, stderr)
+	}
+	wantCommand := "amq list --root " + shellQuoteArg(baseRoot) + " --me " + handle + " --new"
+	if !strings.Contains(stderr, wantCommand) {
+		t.Fatalf("stderr missing exact base inspection command %q: %q", wantCommand, stderr)
 	}
 }

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -98,6 +98,92 @@ func (r *DeliveryRoot) Base() string {
 	return r.base
 }
 
+// OpenOrCreateDirectChild pins one direct, non-symlink child directory beneath
+// the authorized root. The before/open/after identity checks prevent a child
+// swapped during validation from redirecting later writes through a symlink.
+func (r *DeliveryRoot) OpenOrCreateDirectChild(name string, perm os.FileMode) (*DeliveryRoot, error) {
+	if r == nil || r.root == nil {
+		return nil, fmt.Errorf("delivery root is closed")
+	}
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+		return nil, fmt.Errorf("invalid direct child name %q", name)
+	}
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+
+	before, err := r.root.Lstat(name)
+	if os.IsNotExist(err) {
+		if err := r.root.Mkdir(name, perm); err != nil {
+			return nil, err
+		}
+		before, err = r.root.Lstat(name)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !before.IsDir() || before.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%q is not a direct directory under delivery root", name)
+	}
+
+	childRoot, err := r.root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	opened, err := childRoot.Stat(".")
+	if err != nil {
+		_ = childRoot.Close()
+		return nil, err
+	}
+	after, err := r.root.Lstat(name)
+	if err != nil {
+		_ = childRoot.Close()
+		return nil, err
+	}
+	if !after.IsDir() || after.Mode()&os.ModeSymlink != 0 ||
+		!os.SameFile(before, after) || !os.SameFile(after, opened) {
+		_ = childRoot.Close()
+		return nil, fmt.Errorf("direct child %q changed while opening", name)
+	}
+
+	return &DeliveryRoot{
+		base:     filepath.Join(r.base, name),
+		root:     childRoot,
+		identity: opened,
+	}, nil
+}
+
+// EnsureRootDirs creates the queue-level layout through the pinned root
+// capability.
+func (r *DeliveryRoot) EnsureRootDirs() error {
+	if err := r.VerifyBase(); err != nil {
+		return err
+	}
+	for _, dir := range []string{"agents", "threads", "meta"} {
+		if err := r.root.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnsureAgentDirs creates one agent's mailbox layout through the pinned root
+// capability.
+func (r *DeliveryRoot) EnsureAgentDirs(agent string) error {
+	if err := ValidateHandle(agent); err != nil {
+		return err
+	}
+	if err := r.VerifyBase(); err != nil {
+		return err
+	}
+	for _, leaf := range requiredMailboxLeaves {
+		if err := r.root.MkdirAll(MailboxRootRelativePath(agent, leaf), 0o700); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // VerifyBase reports a lexical alias change after authorization. The open root
 // remains the security boundary even if an alias changes immediately after
 // this check; this verification makes a detected swap fail closed instead of

--- a/internal/fsq/delivery_root_child_test.go
+++ b/internal/fsq/delivery_root_child_test.go
@@ -1,0 +1,78 @@
+package fsq
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeliveryRootOpenOrCreateDirectChildRejectsSymlink(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(base, "collab")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+
+	if child, err := root.OpenOrCreateDirectChild("collab", 0o700); err == nil {
+		_ = child.Close()
+		t.Fatal("expected direct-child symlink refusal")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("direct-child open mutated symlink target: %v", entries)
+	}
+}
+
+func TestDeliveryRootDirectChildProvisioningFailsClosedAfterAliasSwap(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "collab"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	child, err := root.OpenOrCreateDirectChild("collab", 0o700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = child.Close() }()
+
+	if err := os.Rename(filepath.Join(base, "collab"), filepath.Join(base, "parked")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(base, "collab")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	if err := child.EnsureAgentDirs("alice"); err == nil {
+		t.Fatal("expected changed child alias to fail closed")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("pinned child provisioning mutated swapped symlink target: %v", entries)
+	}
+}


### PR DESCRIPTION
## Summary

- keep compatibility mailboxes at the base root and provision the full configured roster in the default `collab` session that `coop exec` reads
- create named sessions through a pinned direct-child filesystem capability and refuse session symlinks instead of following them, with an actionable explicit-`--root` remedy
- surface base-root unread mail from empty `list --new` / `drain` and as structured `doctor --ops` `base_backlog` hints with exact inspection commands
- name `AM_ROOT_ID` / `AM_BASE_ROOT_ID` when they are the evidence for an incomplete session pin, without exposing token values

B5 sender-side divergence warnings are intentionally omitted: the consumer-path and doctor diagnostics close the observed gap without a racy duplicate source.

## Verification

- `go test ./... -count=1`
- focused `-race` coverage for B3, B4, C-item, and filesystem direct-child capability
- external B3+B4 harness: ARM1 base+collab provisioned; ARM2 PASS; ARM3 list/drain/doctor 1/1/1 with runnable command; ARM4 0/0
- strengthened symlink harness: ARM5 PASS, exit 1, zero redirected writes, symlink preserved, actionable remedy
- fresh first-run regression: bare send succeeds, bare list returns the message, bare drain consumes it

## Release notes

- Coop init now provisions the default session where coop exec reads while retaining legacy base mailboxes.
- Session symlinks are refused instead of followed, preventing mailbox writes from being redirected.
- Doctor and empty consumer paths now report unread base-root backlog from inside a session.