### PR TITLE
docs(wake): clarify injector identity contract

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -300,6 +300,12 @@ as the final argv element. This executes a local process for each notification,
 and the payload can include sanitized but message-derived header content such as
 sender and subject.
 
+The resolved executable plus the ordered fixed arguments are the injector's
+saved identity. Put any target identity needed to distinguish a pane, window,
+or session in `--inject-arg`. Ambient environment variables and provider
+configuration are invisible to repair and retire, so changing only those
+channels cannot select a different target safely.
+
 For permission-prompt workflows, use AMQ's fail-closed zero-input mode:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ use `amq wake recover-owner` instead of the ownerless repair path. When a
 required owner capability is conclusively unsupported before any claim exists,
 AMQ warns and starts one ownerless wake instead.
 
+AMQ identifies an external injector by its resolved executable and ordered
+fixed arguments. Put any provider target identity needed to distinguish a pane,
+window, or session in `--wake-inject-arg` (`--inject-arg` when starting
+`amq wake` directly). Ambient environment variables and provider configuration
+are not part of this identity, so repair, recovery, and retirement cannot
+detect target changes made only through those channels.
+
 ### 3. Send & Receive
 
 ```bash

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -345,6 +345,12 @@ func notifyNewMessages(cfg *wakeConfig) error {
 					return guardErr
 				}
 				if allowed {
+					// Exit zero is the strongest acceptance evidence the v0
+					// external transport exposes. It cannot prove the provider
+					// delivered the key, but advancing the cooldown bounds
+					// duplicate control-key injection. A false-success provider
+					// may therefore suppress one genuine interrupt until the
+					// next window; stronger evidence needs a structured protocol.
 					if err := injectVia(cfg, cfg.interruptKey); err == nil {
 						cfg.lastInterrupt = now
 						time.Sleep(50 * time.Millisecond)
@@ -358,6 +364,8 @@ func notifyNewMessages(cfg *wakeConfig) error {
 						return writeErr
 					}
 				}
+				// The raw path can require positive terminal-write evidence
+				// instead of inferring acceptance from a process exit status.
 				if writeErr == nil && wrote {
 					cfg.lastInterrupt = now
 					time.Sleep(50 * time.Millisecond)

--- a/internal/cli/wake_target.go
+++ b/internal/cli/wake_target.go
@@ -44,8 +44,11 @@ type wakeTarget struct {
 	Owner      *wakeOwner `json:"owner,omitempty"`
 }
 
-// sameWakeInjectorIdentity compares the behavior fixed at launch. Created and
-// owner metadata describe an instance, not the injector semantics it provides.
+// sameWakeInjectorIdentity compares the behavior fixed at launch: the resolved
+// executable and ordered fixed arguments. Provider target identity must
+// therefore be encoded in InjectArgs; ambient environment or provider config is
+// intentionally invisible. Created and owner metadata describe an instance,
+// not the injector semantics it provides.
 func sameWakeInjectorIdentity(first, second wakeTarget) bool {
 	return first.InjectVia == second.InjectVia && slices.Equal(first.InjectArgs, second.InjectArgs)
 }

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -783,7 +783,7 @@ func TestInjectNotificationRawInjectsBothCRsOnDrainError(t *testing.T) {
 	}
 }
 
-func TestNotifyNewMessages_InjectViaInterruptInjectsKeyAndHonorsCooldown(t *testing.T) {
+func TestNotifyNewMessages_InjectViaExitZeroAdvancesInterruptCooldown(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)


### PR DESCRIPTION
## Summary
- document why v0 external-injector exit zero advances the interrupt cooldown without proving delivery
- state that injector target identity is the resolved executable plus ordered fixed arguments
- rename the existing cooldown test to match the evidence it actually proves

This is a documentation/comment-only contract clarification; runtime behavior is unchanged. The filed provider-v1 design remains archive-only in #334 and is not implemented here.

## Verification
- `go test ./internal/cli -run 'TestNotifyNewMessages_(InjectViaExitZeroAdvancesInterruptCooldown|InjectViaInterruptFailureDoesNotUpdateCooldown)|TestSameWakeInjectorIdentityUsesOnlyPathAndOrderedArgs|TestRetireWakeRefusesDifferentInjectTarget|TestBuildCoopWakeArgsIncludesInjectViaTarget' -count=1`
- `make ci`

Peer review PASS on tree `5a39f0858640b827ddc6824ced0f95fce7361972`, diff SHA-256 `286048742f7359ae16b826466a0d8c11920e1ac30701f9637542c9c60105e645`.