### PR TITLE
ci(release): gate release-please on published state

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -17,24 +21,45 @@ concurrency:
 
 jobs:
   release-please:
-    # Release PRs squash to this prefix. Skip that push so release.yml can create
-    # the tag before the next conventional commit or manual dispatch scans again.
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        !startsWith(github.event.head_commit.message, 'chore(release): v')
-      }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check published release state
+        id: release_state
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          version="$(jq -er '."." | select(type == "string" and length > 0)' .release-please-manifest.json)"
+          tag="v${version}"
+          published_tags="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq '.[] | select(.draft == false and .published_at != null) | .tag_name'
+          )"
+          released=false
+          if grep -Fxq "$tag" <<<"$published_tags"; then
+            released=true
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "released=${released}" >> "$GITHUB_OUTPUT"
+
+      - name: Defer until matching release is published
+        if: ${{ steps.release_state.outputs.released != 'true' }}
+        run: echo "::notice::Release v${{ steps.release_state.outputs.version }} is not published yet; release-please is deferred."
+
       - name: Await release-please credential
         if: ${{ env.RELEASE_PLEASE_TOKEN == '' }}
         run: echo "::notice::RELEASE_PLEASE_TOKEN is not configured; add it, then dispatch this workflow."
 
       - name: Open or update release pull request
-        if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
+        if: ${{ env.RELEASE_PLEASE_TOKEN != '' && steps.release_state.outputs.released == 'true' }}
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/scripts/test_release_please_config.py
+++ b/scripts/test_release_please_config.py
@@ -42,18 +42,34 @@ def test_release_please_workflow_is_pr_only_and_staged() -> None:
     assert "token: ${{ secrets.RELEASE_PLEASE_TOKEN }}" in workflow
     assert "skip-github-release: true" in workflow
     assert "RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}" in workflow
-    assert "if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}" in workflow
     assert "if: ${{ env.RELEASE_PLEASE_TOKEN == '' }}" in workflow
 
-    release_commit_guard = """\
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        !startsWith(github.event.head_commit.message, 'chore(release): v')
-      }}
-"""
     release_job = workflow[workflow.index("  release-please:\n") :]
-    assert release_commit_guard in release_job
+    assert "github.event.head_commit.message" not in release_job
+    assert 'workflows: ["Release"]' in workflow
+    assert "types: [completed]" in workflow
+    assert "branches: [main]" in workflow
+    assert "github.event.workflow_run.conclusion" not in workflow
+    assert "github.event.workflow_run.head_sha" not in workflow
+
+    state_step = release_job[
+        release_job.index("      - name: Check published release state\n") :
+        release_job.index("      - name: Await release-please credential\n")
+    ]
+    assert 'jq -er \'.\".\"' in state_step
+    assert 'tag="v${version}"' in state_step
+    assert 'repos/${GITHUB_REPOSITORY}/releases?per_page=100' in state_step
+    assert "select(.draft == false and .published_at != null)" in state_step
+    assert 'grep -Fxq "$tag"' in state_step
+    assert 'echo "released=${released}" >> "$GITHUB_OUTPUT"' in state_step
+
+    action_step = release_job[
+        release_job.index("      - name: Open or update release pull request\n") :
+    ]
+    assert (
+        "if: ${{ env.RELEASE_PLEASE_TOKEN != '' && "
+        "steps.release_state.outputs.released == 'true' }}"
+    ) in action_step
 
     release_workflow = (ROOT / ".github/workflows/release.yml").read_text()
     assert "predates scripts/release_changelog_section.py" in release_workflow


### PR DESCRIPTION
Closes #273.

Replaces squash-title detection with published GitHub release state and wakes again after Release completes. The workflow fails loudly on malformed manifest state and only invokes release-please when the matching non-draft release is published.

Intentional operator consequence: workflow_dispatch no longer bypasses the published-state gate. A bypass would recreate the release race. Recovery is to fix or rerun Release; its workflow_run completion wakes this state check again.

Validation:
- python3 scripts/test_release_please_config.py
- make ci
- git diff --check
- Ruby YAML parse

Peer review PASS on frozen tree 9d3374e20024d9a0492312991da77e04b4004c0f.