### PR TITLE
fix(upgrade): refuse Homebrew-managed binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ For manual installation or troubleshooting, see [INSTALL.md](INSTALL.md).
 
 ### Updating
 
+For Homebrew installations:
+```bash
+brew upgrade amq
+```
+
+For installations made with the install script or another manual binary install:
 ```bash
 amq upgrade
 ```

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -8,9 +8,15 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/update"
+)
+
+var (
+	executablePathForUpgrade = update.ExecutablePath
+	fetchLatestTagForUpgrade = update.FetchLatestTag
 )
 
 func runUpgrade(args []string, currentVersion string) error {
@@ -22,12 +28,21 @@ func runUpgrade(args []string, currentVersion string) error {
 		return nil
 	}
 
+	path, resolved, err := executablePathForUpgrade()
+	if err != nil {
+		return err
+	}
+	destPath, err := selectUpgradeDestination(path, resolved, upgradeDestinationWritable)
+	if err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	client := &http.Client{Timeout: 30 * time.Second}
 
-	latestTag, err := update.FetchLatestTag(ctx, client)
+	latestTag, err := fetchLatestTagForUpgrade(ctx, client)
 	if err != nil {
 		return err
 	}
@@ -82,18 +97,6 @@ func runUpgrade(args []string, currentVersion string) error {
 		return err
 	}
 
-	path, resolved, err := update.ExecutablePath()
-	if err != nil {
-		return err
-	}
-	destPath := resolved
-	if destPath == "" {
-		destPath = path
-	}
-	if destPath == "" {
-		return fmt.Errorf("unable to resolve executable path")
-	}
-
 	scheduled, err := update.ReplaceBinary(binaryPath, destPath)
 	if err != nil {
 		return err
@@ -110,4 +113,23 @@ func runUpgrade(args []string, currentVersion string) error {
 		return writeStdoutLine("Upgrade scheduled; it will complete after this process exits.")
 	}
 	return writeStdoutLine("Upgrade complete.")
+}
+
+func selectUpgradeDestination(path, resolved string, writable func(string) error) (string, error) {
+	destPath := resolved
+	if destPath == "" {
+		destPath = path
+	}
+	if destPath == "" {
+		return "", fmt.Errorf("unable to resolve executable path")
+	}
+	destPath = filepath.Clean(destPath)
+
+	if strings.Contains(filepath.ToSlash(destPath), "/Cellar/") {
+		return "", fmt.Errorf("amq is installed via Homebrew; run brew upgrade amq instead")
+	}
+	if err := writable(destPath); err != nil {
+		return "", fmt.Errorf("cannot write the amq install location %s: %w", destPath, err)
+	}
+	return destPath, nil
 }

--- a/internal/cli/upgrade_destination_non_unix.go
+++ b/internal/cli/upgrade_destination_non_unix.go
@@ -1,0 +1,34 @@
+//go:build !unix
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func upgradeDestinationWritable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0o222 == 0 {
+		return &os.PathError{Op: "access", Path: path, Err: os.ErrPermission}
+	}
+
+	dir := filepath.Dir(path)
+	probe, err := os.CreateTemp(dir, ".amq-update-access-*")
+	if err != nil {
+		return err
+	}
+	probePath := probe.Name()
+	if err := probe.Close(); err != nil {
+		_ = os.Remove(probePath)
+		return err
+	}
+	if err := os.Remove(probePath); err != nil {
+		return fmt.Errorf("remove writability probe: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/upgrade_destination_unix.go
+++ b/internal/cli/upgrade_destination_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func upgradeDestinationWritable(path string) error {
+	if err := unix.Access(path, unix.W_OK); err != nil {
+		return &os.PathError{Op: "access", Path: path, Err: err}
+	}
+	dir := filepath.Dir(path)
+	if err := unix.Access(dir, unix.W_OK); err != nil {
+		return &os.PathError{Op: "access", Path: dir, Err: err}
+	}
+	return nil
+}

--- a/internal/cli/upgrade_destination_unix_test.go
+++ b/internal/cli/upgrade_destination_unix_test.go
@@ -1,0 +1,60 @@
+//go:build unix
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUpgradeDestinationWritableRejectsReadOnlyFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses Unix permission checks")
+	}
+	path := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(path, []byte("manual"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	if err := os.Chmod(path, 0o555); err != nil {
+		t.Fatalf("chmod binary: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o755) })
+
+	err := upgradeDestinationWritable(path)
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("upgradeDestinationWritable error = %v, want permission error", err)
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) || pathErr.Path != path {
+		t.Fatalf("upgradeDestinationWritable path error = %#v, want path %q", pathErr, path)
+	}
+}
+
+func TestUpgradeDestinationWritableRejectsReadOnlyDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses Unix permission checks")
+	}
+	dir := filepath.Join(t.TempDir(), "bin")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("mkdir binary directory: %v", err)
+	}
+	path := filepath.Join(dir, "amq")
+	if err := os.WriteFile(path, []byte("manual"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod binary directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := upgradeDestinationWritable(path)
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("upgradeDestinationWritable error = %v, want permission error", err)
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) || pathErr.Path != dir {
+		t.Fatalf("upgradeDestinationWritable path error = %#v, want directory %q", pathErr, dir)
+	}
+}

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -1,0 +1,167 @@
+//go:build unix
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunUpgradeRefusesHomebrewSymlinkBeforeDownload(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "homebrew", "Cellar", "amq", "0.49.6", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir Cellar layout: %v", err)
+	}
+	const original = "homebrew-owned"
+	if err := os.WriteFile(target, []byte(original), 0o755); err != nil {
+		t.Fatalf("write Cellar binary: %v", err)
+	}
+	link := filepath.Join(base, "homebrew", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatalf("mkdir Homebrew bin: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink Homebrew binary: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatalf("resolve Homebrew symlink: %v", err)
+	}
+
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) {
+		return link, resolved, nil
+	}
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldFetchLatestTag := fetchLatestTagForUpgrade
+	fetchCalls := 0
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
+		fetchCalls++
+		return "", errors.New("unexpected release lookup")
+	}
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetchLatestTag })
+
+	err = runUpgrade(nil, "v0.0.0")
+	const want = "amq is installed via Homebrew; run brew upgrade amq instead"
+	if err == nil || err.Error() != want {
+		t.Fatalf("runUpgrade error = %v, want %q", err, want)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read Cellar binary after refusal: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("Cellar binary mutated: got %q, want %q", got, original)
+	}
+	if fetchCalls != 0 {
+		t.Fatalf("release lookups = %d, want 0 before Homebrew refusal", fetchCalls)
+	}
+}
+
+func TestRunUpgradeRefusesUnwritableDestinationBeforeDownload(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses Unix permission checks")
+	}
+	path := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(path, []byte("manual"), 0o755); err != nil {
+		t.Fatalf("write manual binary: %v", err)
+	}
+	if err := os.Chmod(path, 0o555); err != nil {
+		t.Fatalf("chmod manual binary: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o755) })
+
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) {
+		return path, path, nil
+	}
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldFetchLatestTag := fetchLatestTagForUpgrade
+	fetchCalls := 0
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
+		fetchCalls++
+		return "", errors.New("unexpected release lookup")
+	}
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetchLatestTag })
+
+	err := runUpgrade(nil, "v0.0.0")
+	if !errors.Is(err, os.ErrPermission) ||
+		!strings.Contains(err.Error(), "cannot write the amq install location") {
+		t.Fatalf("runUpgrade error = %v, want clean permission refusal", err)
+	}
+	if fetchCalls != 0 {
+		t.Fatalf("release lookups = %d, want 0 before writability refusal", fetchCalls)
+	}
+}
+
+func TestSelectUpgradeDestinationPreservesManualSymlink(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "versions", "0.49.6", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir manual layout: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("manual"), 0o755); err != nil {
+		t.Fatalf("write manual binary: %v", err)
+	}
+	link := filepath.Join(base, "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatalf("mkdir manual bin: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink manual binary: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatalf("resolve manual symlink: %v", err)
+	}
+
+	var checked string
+	got, err := selectUpgradeDestination(link, resolved, func(path string) error {
+		checked = path
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("selectUpgradeDestination: %v", err)
+	}
+	if got != resolved {
+		t.Fatalf("destination = %q, want resolved target %q", got, resolved)
+	}
+	if checked != resolved {
+		t.Fatalf("writability checked at %q, want resolved target %q", checked, resolved)
+	}
+}
+
+func TestSelectUpgradeDestinationRequiresExactCellarComponent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "NotCellar", "amq")
+	got, err := selectUpgradeDestination(path, path, func(string) error { return nil })
+	if err != nil {
+		t.Fatalf("selectUpgradeDestination false positive: %v", err)
+	}
+	if got != path {
+		t.Fatalf("destination = %q, want %q", got, path)
+	}
+}
+
+func TestSelectUpgradeDestinationRefusesUnwritableResolvedPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bin", "amq")
+	permissionErr := &os.PathError{Op: "access", Path: path, Err: os.ErrPermission}
+
+	_, err := selectUpgradeDestination(path, path, func(got string) error {
+		if got != path {
+			t.Fatalf("writability path = %q, want %q", got, path)
+		}
+		return permissionErr
+	})
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("selectUpgradeDestination error = %v, want permission error", err)
+	}
+	if !strings.Contains(err.Error(), "cannot write the amq install location") {
+		t.Fatalf("selectUpgradeDestination error = %q, want clean writability refusal", err)
+	}
+}


### PR DESCRIPTION
Closes #312.

Refuses amq upgrade before any release lookup when the resolved executable is inside an exact case-sensitive /Cellar/ path, with the recovery command brew upgrade amq. It also preflights both the resolved binary and its parent install directory so replacement fails cleanly before download when either location is unwritable.

The portability layer uses an exhaustive unix versus non-unix partition, avoiding the supported-platform compile gap found during review rather than adding one more GOOS to a partial list.

Detection limits:
- Only a resolved path with an exact case-sensitive /Cellar/ component is recognized as Homebrew.
- MacPorts, apt/dpkg, rpm, Nix, Snap, Scoop, Chocolatey, WinGet, and other managers without that signal are not detected.
- An unrelated resolved path containing a component named Cellar can false-positive into the Homebrew refusal; the failure is recoverable and does not mutate the binary.

Validation:
- Built-binary Homebrew, plain manual, read-only file, and read-only directory arms
- Homebrew target remained byte-identical and symlink remained intact
- go test ./... -count=1
- go vet ./...
- make fmt-check check-skills lint smoke
- CI FreeBSD and Windows cross-builds
- Review cross-builds: Darwin, Linux, FreeBSD, Windows, OpenBSD, NetBSD

Peer review PASS on frozen tree c8fc0600d47a5f2efde38be92ec78ff07a6a4350.