### PR TITLE
fix(release): reconcile published labels idempotently

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,53 +16,75 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: release-please-${{ github.ref }}
-  cancel-in-progress: false
+  group: >-
+    release-please-${{
+      github.event_name == 'workflow_dispatch' &&
+      github.ref != 'refs/heads/main' &&
+      format('rejected-{0}', github.run_id) ||
+      github.repository
+    }}
+  cancel-in-progress: true
 
 jobs:
   release-please:
+    if: >-
+      ${{
+        github.event_name != 'workflow_dispatch' ||
+        github.ref == 'refs/heads/main'
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: refs/heads/main
+          fetch-depth: 0
 
       - name: Check published release state
         id: release_state
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          version="$(jq -er '."." | select(type == "string" and length > 0)' .release-please-manifest.json)"
-          tag="v${version}"
-          published_tags="$(
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
-              --jq '.[] | select(.draft == false and .published_at != null) | .tag_name'
-          )"
-          released=false
-          if grep -Fxq "$tag" <<<"$published_tags"; then
-            released=true
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "released=${released}" >> "$GITHUB_OUTPUT"
+        run: ./scripts/check-release-please-state.sh
 
       - name: Defer until matching release is published
         if: ${{ steps.release_state.outputs.released != 'true' }}
         run: echo "::notice::Release v${{ steps.release_state.outputs.version }} is not published yet; release-please is deferred."
+
+      - name: Revalidate current main
+        id: main_state
+        if: ${{ steps.release_state.outputs.released == 'true' }}
+        env:
+          EXPECTED_MAIN_SHA: ${{ steps.release_state.outputs.main_sha }}
+        run: ./scripts/revalidate-release-please-main.sh
+
+      - name: Defer stale main snapshot
+        if: ${{ steps.main_state.outputs.current == 'false' }}
+        run: echo "::notice::Main changed during this run; the newer repository event owns reconciliation."
+
+      - name: Reconcile published release pull request
+        if: ${{ steps.release_state.outputs.released == 'true' && steps.main_state.outputs.current == 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release_state.outputs.version }}
+          EXPECTED_MAIN_SHA: ${{ steps.release_state.outputs.main_sha }}
+        run: ./scripts/reconcile-release-please-labels.sh
 
       - name: Await release-please credential
         if: ${{ env.RELEASE_PLEASE_TOKEN == '' }}
         run: echo "::notice::RELEASE_PLEASE_TOKEN is not configured; add it, then dispatch this workflow."
 
       - name: Open or update release pull request
-        if: ${{ env.RELEASE_PLEASE_TOKEN != '' && steps.release_state.outputs.released == 'true' }}
+        if: ${{ env.RELEASE_PLEASE_TOKEN != '' && steps.release_state.outputs.released == 'true' && steps.main_state.outputs.current == 'true' }}
+        # The pinned release-please 17.6.0 aborts before PR mutation while a merged release PR is pending.
+        # release.yml removes that explicit pending label only after GoReleaser publication succeeds.
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,36 +194,117 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
           VERSION: ${{ needs.prepare.outputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
-          release_prs="$(
-            gh api \
+          pull_pages="$(
+            gh api --paginate --slurp \
               --header "Accept: application/vnd.github+json" \
-              "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/pulls" \
-              --jq ".[] | select(.merged_at != null and .base.ref == \"main\" and .title == \"chore(release): v${VERSION}\") | .number"
+              "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/pulls?per_page=100"
           )"
-          release_pr_count="$(printf '%s\n' "$release_prs" | awk 'NF { count++ } END { print count + 0 }')"
-          if [[ "$release_pr_count" != "1" ]]; then
-            echo "::error::Expected one merged release PR for v${VERSION} at ${RELEASE_SHA}; found ${release_pr_count}: ${release_prs:-none}."
+          pull_state="$(
+            jq -e --arg version "$VERSION" --arg release_sha "$RELEASE_SHA" '
+              if type == "array" and all(.[]; type == "array") and
+                  all(.[][]; type == "object")
+              then
+                [.[][]] as $associated |
+                [
+                  $associated[] |
+                  .number as $number |
+                  select(
+                    .merged_at != null and
+                    .base.ref == "main" and
+                    .title == ("chore(release): v" + $version) and
+                    .merge_commit_sha == $release_sha and
+                    ($number | type == "number" and . > 0 and floor == .)
+                  ) |
+                  $number
+                ] as $exact |
+                {associated_count: ($associated | length), exact: $exact}
+              else error("malformed commit pulls response")
+              end
+            ' <<<"$pull_pages"
+          )"
+          associated_count="$(jq -er '.associated_count' <<<"$pull_state")"
+          release_pr_count="$(jq -er '.exact | length' <<<"$pull_state")"
+
+          if [[ "$associated_count" == "0" && "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "Historical dispatch has no associated release PR; label reconciliation is not applicable."
+            exit 0
+          fi
+          if [[ "$associated_count" != "1" || "$release_pr_count" != "1" ]]; then
+            echo "::error::Expected one unambiguous merged release PR for v${VERSION} at ${RELEASE_SHA}; found ${associated_count} associated and ${release_pr_count} exact."
             exit 1
           fi
-          release_pr="$(printf '%s\n' "$release_prs" | awk 'NF { print; exit }')"
+          release_pr="$(jq -er '.exact[0] | select(type == "number" and . > 0 and floor == .)' <<<"$pull_state")"
 
-          labels="$(gh pr view "$release_pr" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name')"
-          edit_args=()
-          if printf '%s\n' "$labels" | grep -Fxq 'autorelease: pending'; then
-            edit_args+=(--remove-label 'autorelease: pending')
-          fi
-          if ! printf '%s\n' "$labels" | grep -Fxq 'autorelease: tagged'; then
-            edit_args+=(--add-label 'autorelease: tagged')
+          read_labels() {
+            local response
+            if ! response="$(
+              gh api \
+                --header "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/issues/${release_pr}"
+            )"; then
+              return 1
+            fi
+            jq -e '
+              if type == "object" and (.labels | type == "array") and
+                  all(.labels[]; type == "object" and (.name | type == "string"))
+              then [.labels[].name]
+              else error("malformed labels response")
+              end
+            ' <<<"$response"
+          }
+
+          labels="$(read_labels)"
+          jq -e '
+            ([.[] | select(. == "autorelease: tagged")] | length) <= 1 and
+            ([.[] | select(. == "autorelease: pending")] | length) <= 1
+          ' >/dev/null <<<"$labels" || {
+            echo "::error::Release PR has duplicate lifecycle labels."
+            exit 1
+          }
+          if ! jq -e 'index("autorelease: tagged") != null' >/dev/null <<<"$labels"; then
+            if ! printf '%s\n' '{"labels":["autorelease: tagged"]}' |
+              gh api \
+                --method POST \
+                --header "Accept: application/vnd.github+json" \
+                --input - \
+                "repos/${GITHUB_REPOSITORY}/issues/${release_pr}/labels" \
+                >/dev/null; then
+              echo "::warning::Tagged label mutation returned nonzero; checking authoritative state."
+            fi
+            labels="$(read_labels)"
+            jq -e '
+              ([.[] | select(. == "autorelease: tagged")] | length) == 1 and
+              ([.[] | select(. == "autorelease: pending")] | length) <= 1
+            ' >/dev/null <<<"$labels" || {
+              echo "::error::Tagged label was not confirmed; pending label remains untouched."
+              exit 1
+            }
           fi
 
-          if [[ ${#edit_args[@]} -gt 0 ]]; then
-            gh pr edit "$release_pr" --repo "$GITHUB_REPOSITORY" "${edit_args[@]}"
+          if jq -e 'index("autorelease: pending") != null' >/dev/null <<<"$labels"; then
+            if ! gh api \
+              --method DELETE \
+              --header "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/issues/${release_pr}/labels/autorelease%3A%20pending" \
+              >/dev/null; then
+              echo "::warning::Pending label mutation returned nonzero; checking authoritative state."
+            fi
           else
             echo "Release PR #${release_pr} is already tagged."
           fi
+
+          labels="$(read_labels)"
+          jq -e '
+            ([.[] | select(. == "autorelease: tagged")] | length) == 1 and
+            ([.[] | select(. == "autorelease: pending")] | length) == 0
+          ' >/dev/null <<<"$labels" || {
+            echo "::error::Release PR lifecycle labels did not converge."
+            exit 1
+          }
 
   skill-publish:
     needs: [prepare, release]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,8 @@
   "include-component-in-tag": false,
   "skip-github-release": true,
   "pull-request-title-pattern": "chore(release): v${version}",
+  "label": "autorelease: pending",
+  "release-label": "autorelease: tagged",
   "changelog-sections": [
     {
       "type": "feat",

--- a/scripts/check-release-please-state.sh
+++ b/scripts/check-release-please-state.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+github_output="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+github_repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+manifest_path="${RELEASE_PLEASE_MANIFEST:-.release-please-manifest.json}"
+
+RELEASE_VERSION_PATTERN='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?'
+
+version="$(
+  jq -er \
+    --arg pattern "\\A${RELEASE_VERSION_PATTERN}\\z" \
+    '."." | select(type == "string" and test($pattern))' \
+    "$manifest_path"
+)" || {
+  echo "::error::Release manifest version must be one canonical X.Y.Z or X.Y.Z-prerelease line."
+  exit 1
+}
+if [[ ! "$version" =~ ^${RELEASE_VERSION_PATTERN}$ ]]; then
+  echo "::error::Release manifest version must be one canonical X.Y.Z or X.Y.Z-prerelease line."
+  exit 1
+fi
+
+main_sha="$(git rev-parse --verify 'HEAD^{commit}')"
+if [[ ! "$main_sha" =~ ^[0-9a-f]{40}([0-9a-f]{24})?$ ]]; then
+  echo "::error::Checked-out main commit has an invalid object ID."
+  exit 1
+fi
+
+tag="v${version}"
+release_pages="$(
+  gh api --paginate --slurp \
+    "repos/${github_repository}/releases?per_page=100"
+)"
+released=false
+if jq -e --arg tag "$tag" \
+  'any(.[][]; .draft == false and .published_at != null and
+    (.tag_name | type == "string") and .tag_name == $tag)' \
+  >/dev/null <<<"$release_pages"; then
+  released=true
+else
+  jq_status=$?
+  if [[ "$jq_status" != "1" ]]; then
+    echo "::error::GitHub releases response was not valid paginated JSON."
+    exit "$jq_status"
+  fi
+fi
+
+{
+  printf 'version=%s\n' "$version"
+  printf 'released=%s\n' "$released"
+  printf 'main_sha=%s\n' "$main_sha"
+} >>"$github_output"

--- a/scripts/reconcile-release-please-labels.sh
+++ b/scripts/reconcile-release-please-labels.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+github_repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+release_version="${RELEASE_VERSION:?RELEASE_VERSION is required}"
+expected_main_sha="${EXPECTED_MAIN_SHA:?EXPECTED_MAIN_SHA is required}"
+manifest_path="${RELEASE_PLEASE_MANIFEST:-.release-please-manifest.json}"
+
+RELEASE_VERSION_PATTERN='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?'
+
+if [[ ! "$release_version" =~ ^${RELEASE_VERSION_PATTERN}$ ]]; then
+  echo "::error::Release version is not canonical."
+  exit 1
+fi
+if [[ ! "$expected_main_sha" =~ ^[0-9a-f]{40}([0-9a-f]{24})?$ ]]; then
+  echo "::error::Expected main commit has an invalid object ID."
+  exit 1
+fi
+
+manifest_version="$(
+  jq -er \
+    --arg pattern "\\A${RELEASE_VERSION_PATTERN}\\z" \
+    '."." | select(type == "string" and test($pattern))' \
+    "$manifest_path"
+)" || {
+  echo "::error::Checked-out main manifest is malformed."
+  exit 1
+}
+if [[ "$manifest_version" != "$release_version" ]]; then
+  echo "::error::Release version does not match the checked-out main manifest."
+  exit 1
+fi
+
+main_sha="$(git rev-parse --verify 'HEAD^{commit}')"
+if [[ "$main_sha" != "$expected_main_sha" ]]; then
+  echo "::error::Checked-out main does not match the bound main commit."
+  exit 1
+fi
+
+tag="v${release_version}"
+if ! git fetch --no-tags origin "refs/tags/${tag}:refs/tags/${tag}"; then
+  echo "::error::Canonical release tag ${tag} is missing or conflicts with local state."
+  exit 1
+fi
+tag_sha="$(git rev-parse --verify "refs/tags/${tag}^{commit}")" || {
+  echo "::error::Canonical release tag ${tag} does not peel to a commit."
+  exit 1
+}
+if [[ ! "$tag_sha" =~ ^[0-9a-f]{40}([0-9a-f]{24})?$ ]]; then
+  echo "::error::Canonical release tag has an invalid commit object ID."
+  exit 1
+fi
+if ! git merge-base --is-ancestor "$tag_sha" "$main_sha"; then
+  echo "::error::Canonical release tag is not an ancestor of checked-out main."
+  exit 1
+fi
+
+tag_manifest="$(
+  git show "${tag_sha}:${manifest_path}"
+)" || {
+  echo "::error::Canonical release tag commit has no release manifest."
+  exit 1
+}
+tag_manifest_version="$(
+  jq -er \
+    --arg pattern "\\A${RELEASE_VERSION_PATTERN}\\z" \
+    '."." | select(type == "string" and test($pattern))' \
+    <<<"$tag_manifest"
+)" || {
+  echo "::error::Canonical release tag commit manifest is malformed."
+  exit 1
+}
+if [[ "$tag_manifest_version" != "$release_version" ]]; then
+  echo "::error::Canonical release tag commit manifest does not match ${release_version}."
+  exit 1
+fi
+
+release_title="chore(release): v${release_version}"
+pull_pages="$(
+  gh api --paginate --slurp \
+    --header "Accept: application/vnd.github+json" \
+    "repos/${github_repository}/commits/${tag_sha}/pulls?per_page=100"
+)"
+release_prs="$(
+  jq -ce \
+    --arg title "$release_title" \
+    --arg tag_sha "$tag_sha" \
+    '
+      if type == "array" and all(.[]; type == "array") and
+          all(.[][]; type == "object")
+      then [
+        .[][] |
+        select(
+          .merged_at != null and
+          .base.ref == "main" and
+          .title == $title and
+          .merge_commit_sha == $tag_sha and
+          (.number | type == "number" and . > 0 and floor == .)
+        ) |
+        .number
+      ]
+      else error("malformed commit pulls response")
+      end
+    ' \
+    <<<"$pull_pages"
+)" || {
+  echo "::error::Commit pull request response was malformed."
+  exit 1
+}
+release_pr_count="$(jq -r 'length' <<<"$release_prs")"
+if [[ "$release_pr_count" != "1" ]]; then
+  echo "::error::Expected one exact merged main release PR for ${tag}; found ${release_pr_count}."
+  exit 1
+fi
+release_pr="$(jq -er '.[0] | select(type == "number" and . > 0 and floor == .)' <<<"$release_prs")"
+
+read_labels() {
+  local response
+  if ! response="$(
+    gh api \
+      --header "Accept: application/vnd.github+json" \
+      "repos/${github_repository}/issues/${release_pr}"
+  )"; then
+    return 1
+  fi
+  jq -ce \
+    '
+      if type == "object" and (.labels | type == "array") and
+          all(.labels[]; type == "object" and (.name | type == "string"))
+      then [.labels[].name]
+      else error("malformed labels response")
+      end
+    ' \
+    <<<"$response"
+}
+
+validate_target_labels() {
+  local labels="$1"
+  local pending_count tagged_count
+  pending_count="$(jq -r '[.[] | select(. == "autorelease: pending")] | length' <<<"$labels")"
+  tagged_count="$(jq -r '[.[] | select(. == "autorelease: tagged")] | length' <<<"$labels")"
+  if [[ "$pending_count" -gt 1 || "$tagged_count" -gt 1 ]]; then
+    echo "::error::Release PR has duplicate lifecycle labels."
+    exit 1
+  fi
+  printf '%s %s\n' "$pending_count" "$tagged_count"
+}
+
+labels="$(read_labels)" || {
+  echo "::error::Unable to read release PR labels safely."
+  exit 1
+}
+read -r pending_count tagged_count < <(validate_target_labels "$labels")
+
+if [[ "$pending_count" == "0" && "$tagged_count" == "1" ]]; then
+  echo "Release PR #${release_pr} is already reconciled."
+  exit 0
+fi
+if [[ "$pending_count" == "0" && "$tagged_count" == "0" ]]; then
+  echo "::error::Release PR has neither pending nor tagged lifecycle state."
+  exit 1
+fi
+
+if [[ "$tagged_count" == "0" ]]; then
+  if ! printf '%s\n' '{"labels":["autorelease: tagged"]}' |
+    gh api \
+        --method POST \
+        --header "Accept: application/vnd.github+json" \
+        --input - \
+        "repos/${github_repository}/issues/${release_pr}/labels" \
+        >/dev/null; then
+    echo "::warning::Tagged label mutation returned nonzero; checking authoritative state."
+  fi
+
+  labels="$(read_labels)" || {
+    echo "::error::Unable to confirm tagged label after adding it."
+    exit 1
+  }
+  read -r pending_count tagged_count < <(validate_target_labels "$labels")
+  if [[ "$tagged_count" != "1" ]]; then
+    echo "::error::Tagged label was not confirmed; pending label remains untouched."
+    exit 1
+  fi
+fi
+
+if [[ "$pending_count" == "1" ]]; then
+  if ! gh api \
+    --method DELETE \
+    --header "Accept: application/vnd.github+json" \
+    "repos/${github_repository}/issues/${release_pr}/labels/autorelease%3A%20pending" \
+    >/dev/null; then
+    echo "::warning::Pending label mutation returned nonzero; checking authoritative state."
+  fi
+fi
+
+labels="$(read_labels)" || {
+  echo "::error::Unable to confirm reconciled release PR labels."
+  exit 1
+}
+read -r pending_count tagged_count < <(validate_target_labels "$labels")
+if [[ "$pending_count" != "0" || "$tagged_count" != "1" ]]; then
+  echo "::error::Release PR lifecycle labels did not converge."
+  exit 1
+fi
+
+echo "Reconciled published release PR #${release_pr} for ${tag}."

--- a/scripts/revalidate-release-please-main.sh
+++ b/scripts/revalidate-release-please-main.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_main_sha="${EXPECTED_MAIN_SHA:?EXPECTED_MAIN_SHA is required}"
+github_output="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+if [[ ! "$expected_main_sha" =~ ^[0-9a-f]{40}([0-9a-f]{24})?$ ]]; then
+  echo "::error::Expected main commit has an invalid object ID."
+  exit 1
+fi
+
+git fetch --no-tags origin refs/heads/main
+current_main_sha="$(git rev-parse --verify 'FETCH_HEAD^{commit}')"
+if [[ ! "$current_main_sha" =~ ^[0-9a-f]{40}([0-9a-f]{24})?$ ]]; then
+  echo "::error::Current main commit has an invalid object ID."
+  exit 1
+fi
+
+current=false
+if [[ "$current_main_sha" == "$expected_main_sha" ]]; then
+  current=true
+else
+  echo "::notice::Main advanced from ${expected_main_sha} to ${current_main_sha}; this run is deferred to the newer trigger."
+fi
+printf 'current=%s\n' "$current" >>"$github_output"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -132,6 +132,9 @@ if command -v python3 >/dev/null 2>&1; then
   python3 scripts/test_release_changelog_section.py
   python3 scripts/test_release_please_config.py
   bash scripts/test_release_metadata.sh
+  bash scripts/test_release_please_state.sh
+  bash scripts/test_reconcile_release_please_labels.sh
+  bash scripts/test_release_workflow_labels.sh
   bash scripts/test_git_env_sanitization.sh
 fi
 

--- a/scripts/test_reconcile_release_please_labels.sh
+++ b/scripts/test_reconcile_release_please_labels.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
+
+ROOT="$(git rev-parse --show-toplevel)"
+TEST_TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TEST_TMPDIR"
+}
+trap cleanup EXIT
+
+FAKE_BIN="$TEST_TMPDIR/bin"
+SOURCE_REPO="$TEST_TMPDIR/source"
+REMOTE_REPO="$TEST_TMPDIR/remote.git"
+RUNNER_REPO="$TEST_TMPDIR/runner"
+mkdir -p "$FAKE_BIN"
+
+cat >"$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${GH_CALL_LOG:?}"
+[[ "$1" == "api" ]]
+
+if [[ "$*" == *"/commits/"*"/pulls?"* ]]; then
+  case "${FAKE_PR_MODE:?}" in
+    api-failure)
+      exit 1
+      ;;
+    malformed)
+      printf 'not json\n'
+      ;;
+    zero)
+      printf '[[]]\n'
+      ;;
+    exact)
+      jq -cn --arg sha "${FAKE_TAG_SHA:?}" \
+        '[[{number: 17, merged_at: "2026-07-27", base: {ref: "main"},
+            title: "chore(release): v1.2.3", merge_commit_sha: $sha}]]'
+      ;;
+    multiple)
+      jq -cn --arg sha "${FAKE_TAG_SHA:?}" \
+        '[[{number: 17, merged_at: "2026-07-27", base: {ref: "main"},
+            title: "chore(release): v1.2.3", merge_commit_sha: $sha},
+           {number: 18, merged_at: "2026-07-27", base: {ref: "main"},
+            title: "chore(release): v1.2.3", merge_commit_sha: $sha}]]'
+      ;;
+    wrong-base)
+      jq -cn --arg sha "${FAKE_TAG_SHA:?}" \
+        '[[{number: 17, merged_at: "2026-07-27", base: {ref: "release"},
+            title: "chore(release): v1.2.3", merge_commit_sha: $sha}]]'
+      ;;
+    wrong-title)
+      jq -cn --arg sha "${FAKE_TAG_SHA:?}" \
+        '[[{number: 17, merged_at: "2026-07-27", base: {ref: "main"},
+            title: "release 1.2.3", merge_commit_sha: $sha}]]'
+      ;;
+    wrong-sha)
+      jq -cn \
+        '[[{number: 17, merged_at: "2026-07-27", base: {ref: "main"},
+            title: "chore(release): v1.2.3",
+            merge_commit_sha: "0000000000000000000000000000000000000000"}]]'
+      ;;
+  esac
+  exit
+fi
+
+if [[ "$*" == *"/issues/17/labels"* && " $* " == *" --method POST "* ]]; then
+  jq -e '.labels == ["autorelease: tagged"]' >/dev/null
+  case "${FAKE_POST_BEHAVIOR:-success}" in
+    success|apply-fail)
+      if ! grep -Fxq 'autorelease: tagged' "${FAKE_LABEL_STATE:?}"; then
+        printf 'autorelease: tagged\n' >>"$FAKE_LABEL_STATE"
+      fi
+      ;;
+    fail)
+      ;;
+  esac
+  printf '[]\n'
+  [[ "${FAKE_POST_BEHAVIOR:-success}" != "apply-fail" &&
+     "${FAKE_POST_BEHAVIOR:-success}" != "fail" ]]
+  exit
+fi
+
+if [[ "$*" == *"/issues/17/labels/autorelease%3A%20pending"* ]]; then
+  case "${FAKE_DELETE_BEHAVIOR:-success}" in
+    success|apply-fail|peer-404)
+      grep -Fxv 'autorelease: pending' "$FAKE_LABEL_STATE" >"${FAKE_LABEL_STATE}.next" || true
+      mv "${FAKE_LABEL_STATE}.next" "$FAKE_LABEL_STATE"
+      ;;
+    fail)
+      ;;
+  esac
+  [[ "${FAKE_DELETE_BEHAVIOR:-success}" != "apply-fail" &&
+     "${FAKE_DELETE_BEHAVIOR:-success}" != "peer-404" &&
+     "${FAKE_DELETE_BEHAVIOR:-success}" != "fail" ]]
+  exit
+fi
+
+if [[ "$*" == *"/issues/17"* ]]; then
+  reads="$(cat "${FAKE_LABEL_READS:?}")"
+  reads="$((reads + 1))"
+  printf '%s\n' "$reads" >"$FAKE_LABEL_READS"
+  if [[ "${FAKE_FAIL_LABEL_READ_AT:-0}" -eq "$reads" ]]; then
+    exit 1
+  fi
+  if [[ "${FAKE_MALFORMED_LABEL_READ_AT:-0}" -eq "$reads" ]]; then
+    printf 'not json\n'
+    exit
+  fi
+  jq -Rsc '{labels: (split("\n") | map(select(length > 0) | {name: .}))}' \
+    <"${FAKE_LABEL_STATE:?}"
+  if [[ "${FAKE_NONZERO_LABEL_READ_AT:-0}" -eq "$reads" ]]; then
+    exit 1
+  fi
+  exit
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+git init -q -b main "$SOURCE_REPO"
+git -C "$SOURCE_REPO" config user.email test@example.com
+git -C "$SOURCE_REPO" config user.name "Release Reconcile Test"
+printf '{".":"1.2.2"}\n' >"$SOURCE_REPO/.release-please-manifest.json"
+git -C "$SOURCE_REPO" add .release-please-manifest.json
+git -C "$SOURCE_REPO" commit -qm "initial"
+OLD_SHA="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+printf '{".":"1.2.3"}\n' >"$SOURCE_REPO/.release-please-manifest.json"
+git -C "$SOURCE_REPO" add .release-please-manifest.json
+git -C "$SOURCE_REPO" commit -qm "chore(release): v1.2.3"
+TAG_SHA="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+git -C "$SOURCE_REPO" tag v1.2.3
+printf 'after\n' >"$SOURCE_REPO/after"
+git -C "$SOURCE_REPO" add after
+git -C "$SOURCE_REPO" commit -qm "after release"
+git init -q --bare "$REMOTE_REPO"
+git -C "$SOURCE_REPO" remote add origin "$REMOTE_REPO"
+git -C "$SOURCE_REPO" push -q -u origin main --tags
+git clone -q --depth=1 --branch main "file://${REMOTE_REPO}" "$RUNNER_REPO"
+MAIN_SHA="$(git -C "$RUNNER_REPO" rev-parse HEAD)"
+
+# actions/checkout defaults to a grafted depth-1 HEAD. Merely fetching the old
+# tag cannot prove ancestry; fetch-depth: 0 must restore the connecting chain.
+[[ "$(git -C "$RUNNER_REPO" rev-parse --is-shallow-repository)" == "true" ]]
+git -C "$RUNNER_REPO" fetch -q --no-tags origin \
+  refs/tags/v1.2.3:refs/tags/v1.2.3
+if git -C "$RUNNER_REPO" merge-base --is-ancestor "$TAG_SHA" "$MAIN_SHA"; then
+  echo "depth-1 checkout unexpectedly proved old tag ancestry" >&2
+  exit 1
+fi
+git -C "$RUNNER_REPO" fetch -q --unshallow origin
+[[ "$(git -C "$RUNNER_REPO" rev-parse --is-shallow-repository)" == "false" ]]
+git -C "$RUNNER_REPO" merge-base --is-ancestor "$TAG_SHA" "$MAIN_SHA"
+
+LABEL_STATE="$TEST_TMPDIR/labels"
+CALL_LOG="$TEST_TMPDIR/calls"
+LABEL_READS="$TEST_TMPDIR/label-reads"
+
+reset_case() {
+  : >"$CALL_LOG"
+  printf '0\n' >"$LABEL_READS"
+  unset FAKE_FAIL_LABEL_READ_AT
+  unset FAKE_MALFORMED_LABEL_READ_AT
+  unset FAKE_NONZERO_LABEL_READ_AT
+  unset FAKE_POST_BEHAVIOR
+  unset FAKE_DELETE_BEHAVIOR
+}
+
+set_labels() {
+  : >"$LABEL_STATE"
+  for label in "$@"; do
+    printf '%s\n' "$label" >>"$LABEL_STATE"
+  done
+}
+
+run_reconcile() {
+  local mode="$1"
+  (
+    cd "$RUNNER_REPO"
+    PATH="$FAKE_BIN:$PATH" \
+      GH_CALL_LOG="$CALL_LOG" \
+      FAKE_PR_MODE="$mode" \
+      FAKE_TAG_SHA="$TAG_SHA" \
+      FAKE_LABEL_STATE="$LABEL_STATE" \
+      FAKE_LABEL_READS="$LABEL_READS" \
+      FAKE_POST_BEHAVIOR="${FAKE_POST_BEHAVIOR:-success}" \
+      FAKE_DELETE_BEHAVIOR="${FAKE_DELETE_BEHAVIOR:-success}" \
+      FAKE_FAIL_LABEL_READ_AT="${FAKE_FAIL_LABEL_READ_AT:-0}" \
+      FAKE_MALFORMED_LABEL_READ_AT="${FAKE_MALFORMED_LABEL_READ_AT:-0}" \
+      FAKE_NONZERO_LABEL_READ_AT="${FAKE_NONZERO_LABEL_READ_AT:-0}" \
+      GITHUB_REPOSITORY="example/amq" \
+      RELEASE_VERSION="${RUN_VERSION:-1.2.3}" \
+      EXPECTED_MAIN_SHA="${RUN_MAIN_SHA:-$MAIN_SHA}" \
+      "$ROOT/scripts/reconcile-release-please-labels.sh"
+  )
+}
+
+# Hostile version/output payloads and stale main bindings fail before any API.
+for RUN_VERSION in $'1.2.3\npending=false' '1.2.3+build' '01.2.3'; do
+  reset_case
+  set_labels 'autorelease: pending'
+  if run_reconcile exact; then
+    echo "hostile reconcile version unexpectedly accepted" >&2
+    exit 1
+  fi
+  [[ ! -s "$CALL_LOG" ]]
+done
+unset RUN_VERSION
+RUN_MAIN_SHA="$OLD_SHA"
+reset_case
+if run_reconcile exact; then
+  echo "stale bound main unexpectedly accepted" >&2
+  exit 1
+fi
+[[ ! -s "$CALL_LOG" ]]
+unset RUN_MAIN_SHA
+
+# 1. Canonical pending-only state adds tagged, confirms it, then removes pending.
+reset_case
+set_labels 'autorelease: pending'
+run_reconcile exact
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+post_line="$(grep -n -- '--method POST' "$CALL_LOG" | cut -d: -f1)"
+delete_line="$(grep -n -- '--method DELETE' "$CALL_LOG" | cut -d: -f1)"
+[[ "$post_line" -lt "$delete_line" ]]
+
+# 2. Failure after add and before delete leaves both; retry converges.
+reset_case
+set_labels 'autorelease: pending'
+export FAKE_FAIL_LABEL_READ_AT=2
+if run_reconcile exact; then
+  echo "post-add confirmation failure unexpectedly succeeded" >&2
+  exit 1
+fi
+grep -Fxq 'autorelease: pending' "$LABEL_STATE"
+grep -Fxq 'autorelease: tagged' "$LABEL_STATE"
+if grep -q -- '--method DELETE' "$CALL_LOG"; then
+  echo "pending label was removed before tagged confirmation" >&2
+  exit 1
+fi
+reset_case
+run_reconcile exact
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+
+# 3. A peer may remove pending before our DELETE returns 404. The authoritative
+# final read proves tagged-only convergence, so the run succeeds.
+reset_case
+set_labels 'autorelease: pending' 'autorelease: tagged'
+export FAKE_DELETE_BEHAVIOR=peer-404
+run_reconcile exact
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+
+# 4. The server may apply POST or DELETE while the client loses the response.
+# Authoritative rereads prove the mutations took effect.
+reset_case
+set_labels 'autorelease: pending'
+export FAKE_POST_BEHAVIOR=apply-fail
+run_reconcile exact
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+
+reset_case
+set_labels 'autorelease: pending' 'autorelease: tagged'
+export FAKE_DELETE_BEHAVIOR=apply-fail
+run_reconcile exact
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+
+# 5. Nonzero mutations remain fail-closed when reread is unreadable or does
+# not prove the expected state.
+reset_case
+set_labels 'autorelease: pending'
+export FAKE_POST_BEHAVIOR=fail
+if run_reconcile exact; then
+  echo "failed POST with nonconverged reread unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q -- '--method DELETE' "$CALL_LOG"; then
+  echo "pending label was removed without tagged convergence" >&2
+  exit 1
+fi
+
+reset_case
+set_labels 'autorelease: pending' 'autorelease: tagged'
+export FAKE_DELETE_BEHAVIOR=fail
+if run_reconcile exact; then
+  echo "failed DELETE with nonconverged reread unexpectedly succeeded" >&2
+  exit 1
+fi
+
+reset_case
+set_labels 'autorelease: pending' 'autorelease: tagged'
+export FAKE_DELETE_BEHAVIOR=apply-fail
+export FAKE_FAIL_LABEL_READ_AT=2
+if run_reconcile exact; then
+  echo "failed DELETE with unreadable reread unexpectedly succeeded" >&2
+  exit 1
+fi
+
+reset_case
+set_labels 'autorelease: pending'
+export FAKE_POST_BEHAVIOR=apply-fail
+export FAKE_NONZERO_LABEL_READ_AT=2
+if run_reconcile exact; then
+  echo "nonzero tagged reread with valid-looking JSON unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q -- '--method DELETE' "$CALL_LOG"; then
+  echo "pending label was removed after a failed authoritative tagged reread" >&2
+  exit 1
+fi
+
+# 6. Tagged-only is already converged and performs zero mutation.
+reset_case
+set_labels 'autorelease: tagged'
+run_reconcile exact
+if grep -Eq -- '--method (POST|DELETE)' "$CALL_LOG"; then
+  echo "already-converged labels were mutated" >&2
+  exit 1
+fi
+
+# 7. Both labels removes pending only.
+reset_case
+set_labels 'autorelease: pending' 'autorelease: tagged'
+run_reconcile exact
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+if grep -q -- '--method POST' "$CALL_LOG"; then
+  echo "existing tagged label was redundantly added" >&2
+  exit 1
+fi
+grep -q -- '--method DELETE' "$CALL_LOG"
+
+# Malformed initial label state fails before either label mutation.
+reset_case
+set_labels 'autorelease: pending'
+export FAKE_MALFORMED_LABEL_READ_AT=1
+if run_reconcile exact; then
+  echo "malformed labels response unexpectedly accepted" >&2
+  exit 1
+fi
+if grep -Eq -- '--method (POST|DELETE)' "$CALL_LOG"; then
+  echo "malformed labels response caused mutation" >&2
+  exit 1
+fi
+
+# Duplicate lifecycle labels fail before either label mutation.
+reset_case
+set_labels 'autorelease: pending' 'autorelease: tagged' 'autorelease: tagged'
+if run_reconcile exact; then
+  echo "duplicate tagged labels unexpectedly accepted" >&2
+  exit 1
+fi
+if grep -Eq -- '--method (POST|DELETE)' "$CALL_LOG"; then
+  echo "duplicate tagged labels caused mutation" >&2
+  exit 1
+fi
+
+# 8. Missing or mismatched tag identity fails before label API calls.
+reset_case
+set_labels 'autorelease: pending'
+git -C "$RUNNER_REPO" tag -d v1.2.3 >/dev/null
+saved_origin="$(git -C "$RUNNER_REPO" remote get-url origin)"
+empty_remote="$TEST_TMPDIR/empty.git"
+git init -q --bare "$empty_remote"
+git -C "$RUNNER_REPO" remote set-url origin "$empty_remote"
+if run_reconcile exact; then
+  echo "missing tag unexpectedly accepted" >&2
+  exit 1
+fi
+if grep -q 'issues/' "$CALL_LOG"; then
+  echo "missing tag reached label API" >&2
+  exit 1
+fi
+git -C "$RUNNER_REPO" remote set-url origin "$saved_origin"
+git -C "$RUNNER_REPO" fetch -q --no-tags origin \
+  refs/tags/v1.2.3:refs/tags/v1.2.3
+
+git -C "$SOURCE_REPO" tag -f v1.2.3 "$OLD_SHA" >/dev/null
+git -C "$SOURCE_REPO" push -q --force origin refs/tags/v1.2.3
+git -C "$RUNNER_REPO" tag -d v1.2.3 >/dev/null
+if run_reconcile exact; then
+  echo "tag manifest mismatch unexpectedly accepted" >&2
+  exit 1
+fi
+if grep -q 'issues/' "$CALL_LOG"; then
+  echo "tag manifest mismatch reached label API" >&2
+  exit 1
+fi
+
+git -C "$SOURCE_REPO" switch -q --orphan side
+printf '{".":"1.2.3"}\n' >"$SOURCE_REPO/.release-please-manifest.json"
+git -C "$SOURCE_REPO" add .release-please-manifest.json
+git -C "$SOURCE_REPO" commit -qm "side"
+SIDE_SHA="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+git -C "$SOURCE_REPO" tag -f v1.2.3 "$SIDE_SHA" >/dev/null
+git -C "$SOURCE_REPO" push -q --force origin refs/tags/v1.2.3
+git -C "$RUNNER_REPO" tag -d v1.2.3 >/dev/null
+if run_reconcile exact; then
+  echo "non-ancestor tag unexpectedly accepted" >&2
+  exit 1
+fi
+if grep -q 'issues/' "$CALL_LOG"; then
+  echo "non-ancestor tag reached label API" >&2
+  exit 1
+fi
+git -C "$SOURCE_REPO" tag -f v1.2.3 "$TAG_SHA" >/dev/null
+git -C "$SOURCE_REPO" push -q --force origin refs/tags/v1.2.3
+git -C "$RUNNER_REPO" tag -d v1.2.3 >/dev/null
+
+# 9-10. Ambiguous, mismatched, malformed, and failing PR APIs fail closed.
+for mode in zero multiple wrong-base wrong-title wrong-sha malformed api-failure; do
+  reset_case
+  set_labels 'autorelease: pending'
+  if run_reconcile "$mode"; then
+    echo "$mode PR response unexpectedly accepted" >&2
+    exit 1
+  fi
+  if grep -q 'issues/' "$CALL_LOG"; then
+    echo "$mode PR response reached label API" >&2
+    exit 1
+  fi
+  [[ "$(cat "$LABEL_STATE")" == "autorelease: pending" ]]
+done
+
+printf 'release-please reconciliation tests ok\n'

--- a/scripts/test_release_please_config.py
+++ b/scripts/test_release_please_config.py
@@ -19,6 +19,10 @@ def test_release_please_config() -> None:
     assert config["include-component-in-tag"] is False
     assert config["skip-github-release"] is True
     assert config["pull-request-title-pattern"] == "chore(release): v${version}"
+    assert config["label"] == "autorelease: pending"
+    assert config["release-label"] == "autorelease: tagged"
+    assert "labels" not in config
+    assert "release-labels" not in config
 
     assert package["extra-files"] == [
         {"type": "json", "path": ".claude-plugin/plugin.json", "jsonpath": "$.version"},
@@ -43,8 +47,15 @@ def test_release_please_workflow_is_pr_only_and_staged() -> None:
     assert "skip-github-release: true" in workflow
     assert "RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}" in workflow
     assert "if: ${{ env.RELEASE_PLEASE_TOKEN == '' }}" in workflow
+    assert "github.event_name == 'workflow_dispatch' &&" in workflow
+    assert "github.ref != 'refs/heads/main' &&" in workflow
+    assert "format('rejected-{0}', github.run_id) ||" in workflow
+    assert "github.repository" in workflow
+    assert "cancel-in-progress: true" in workflow
 
     release_job = workflow[workflow.index("  release-please:\n") :]
+    assert "github.event_name != 'workflow_dispatch' ||" in release_job
+    assert "github.ref == 'refs/heads/main'" in release_job
     assert "github.event.head_commit.message" not in release_job
     assert 'workflows: ["Release"]' in workflow
     assert "types: [completed]" in workflow
@@ -52,28 +63,85 @@ def test_release_please_workflow_is_pr_only_and_staged() -> None:
     assert "github.event.workflow_run.conclusion" not in workflow
     assert "github.event.workflow_run.head_sha" not in workflow
 
+    checkout_step = release_job[
+        release_job.index("      - uses: actions/checkout@") :
+        release_job.index("      - name: Check published release state\n")
+    ]
+    assert "ref: refs/heads/main" in checkout_step
+    assert "fetch-depth: 0" in checkout_step
+
     state_step = release_job[
         release_job.index("      - name: Check published release state\n") :
+        release_job.index("      - name: Revalidate current main\n")
+    ]
+    assert "run: ./scripts/check-release-please-state.sh" in state_step
+
+    revalidate_step = release_job[
+        release_job.index("      - name: Revalidate current main\n") :
+        release_job.index("      - name: Reconcile published release pull request\n")
+    ]
+    assert "if: ${{ steps.release_state.outputs.released == 'true' }}" in revalidate_step
+    assert "EXPECTED_MAIN_SHA: ${{ steps.release_state.outputs.main_sha }}" in revalidate_step
+    assert "run: ./scripts/revalidate-release-please-main.sh" in revalidate_step
+
+    reconcile_step = release_job[
+        release_job.index("      - name: Reconcile published release pull request\n") :
         release_job.index("      - name: Await release-please credential\n")
     ]
-    assert 'jq -er \'.\".\"' in state_step
-    assert 'tag="v${version}"' in state_step
-    assert 'repos/${GITHUB_REPOSITORY}/releases?per_page=100' in state_step
-    assert "select(.draft == false and .published_at != null)" in state_step
-    assert 'grep -Fxq "$tag"' in state_step
-    assert 'echo "released=${released}" >> "$GITHUB_OUTPUT"' in state_step
+    assert "GH_TOKEN: ${{ github.token }}" in reconcile_step
+    assert "RELEASE_VERSION: ${{ steps.release_state.outputs.version }}" in reconcile_step
+    assert "EXPECTED_MAIN_SHA: ${{ steps.release_state.outputs.main_sha }}" in reconcile_step
+    assert "steps.release_state.outputs.released == 'true'" in reconcile_step
+    assert "steps.main_state.outputs.current == 'true'" in reconcile_step
+    assert "RELEASE_PLEASE_TOKEN" not in reconcile_step
+    assert "run: ./scripts/reconcile-release-please-labels.sh" in reconcile_step
 
     action_step = release_job[
         release_job.index("      - name: Open or update release pull request\n") :
     ]
     assert (
         "if: ${{ env.RELEASE_PLEASE_TOKEN != '' && "
-        "steps.release_state.outputs.released == 'true' }}"
+        "steps.release_state.outputs.released == 'true' && "
+        "steps.main_state.outputs.current == 'true' }}"
     ) in action_step
+    assert "target-branch: main" in action_step
+    assert "aborts before PR mutation while a merged release PR is pending" in action_step
+    assert "release-please 17.6.0" in action_step
 
     release_workflow = (ROOT / ".github/workflows/release.yml").read_text()
     assert "predates scripts/release_changelog_section.py" in release_workflow
     assert "python3 scripts/release_changelog_section.py" not in release_workflow
+
+
+def test_release_state_scripts_are_injection_safe() -> None:
+    state = (ROOT / "scripts/check-release-please-state.sh").read_text()
+    assert "RELEASE_VERSION_PATTERN=" in state
+    assert 'jq -e --arg tag "$tag"' in state
+    assert ".tag_name == $tag" in state
+    assert "grep " not in state
+    assert "printf 'version=%s\\n'" in state
+    assert "printf 'released=%s\\n'" in state
+    assert "printf 'main_sha=%s\\n'" in state
+    assert 'echo "version=' not in state
+
+    revalidate = (ROOT / "scripts/revalidate-release-please-main.sh").read_text()
+    assert "git fetch --no-tags origin refs/heads/main" in revalidate
+    assert "git rev-parse --verify 'FETCH_HEAD^{commit}'" in revalidate
+    assert "printf 'current=%s\\n'" in revalidate
+
+    reconcile = (ROOT / "scripts/reconcile-release-please-labels.sh").read_text()
+    assert 'refs/tags/${tag}^{commit}' in reconcile
+    assert 'git merge-base --is-ancestor "$tag_sha" "$main_sha"' in reconcile
+    assert 'git show "${tag_sha}:${manifest_path}"' in reconcile
+    assert 'commits/${tag_sha}/pulls?per_page=100' in reconcile
+    assert '.base.ref == "main"' in reconcile
+    assert ".title == $title" in reconcile
+    assert ".merge_commit_sha == $tag_sha" in reconcile
+    add_tagged = reconcile.index("--method POST")
+    confirm_tagged = reconcile.index("Tagged label was not confirmed")
+    remove_pending = reconcile.index("--method DELETE")
+    assert add_tagged < confirm_tagged < remove_pending
+    assert "RELEASE_PLEASE_TOKEN" not in reconcile
 
 
 def test_release_workflow_marks_published_release_pr_as_tagged() -> None:
@@ -95,7 +163,13 @@ def test_release_workflow_marks_published_release_pr_as_tagged() -> None:
     assert "RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}" in mark_step
     assert "VERSION: ${{ needs.prepare.outputs.version }}" in mark_step
     assert 'commits/${RELEASE_SHA}/pulls' in mark_step
-    assert 'chore(release): v${VERSION}' in mark_step
+    assert '.title == ("chore(release): v" + $version)' in mark_step
+    assert "EVENT_NAME: ${{ github.event_name }}" in mark_step
+    assert '"$EVENT_NAME" == "workflow_dispatch"' in mark_step
+    assert "merge_commit_sha == $release_sha" in mark_step
+    assert '($number | type == "number" and . > 0' in mark_step
+    assert "jq -e --arg version" in mark_step
+    assert "Historical dispatch" in mark_step
     assert "autorelease: pending" in mark_step
     assert "autorelease: tagged" in mark_step
 
@@ -126,6 +200,7 @@ def test_version_files_and_replacement_gates() -> None:
 if __name__ == "__main__":
     test_release_please_config()
     test_release_please_workflow_is_pr_only_and_staged()
+    test_release_state_scripts_are_injection_safe()
     test_release_workflow_marks_published_release_pr_as_tagged()
     test_version_files_and_replacement_gates()
     print("release-please config tests ok")

--- a/scripts/test_release_please_state.sh
+++ b/scripts/test_release_please_state.sh
@@ -140,6 +140,11 @@ git -C "$SOURCE_REPO" commit -qm "one"
 git init -q --bare "$REMOTE_REPO"
 git -C "$SOURCE_REPO" remote add origin "$REMOTE_REPO"
 git -C "$SOURCE_REPO" push -q -u origin main
+# Bare repositories inherit the host's default branch name. Bind the remote
+# HEAD to the branch this fixture created so clones are deterministic even
+# when the host default is not "main".
+git -C "$REMOTE_REPO" symbolic-ref HEAD refs/heads/main
+[[ "$(git -C "$REMOTE_REPO" symbolic-ref HEAD)" == "refs/heads/main" ]]
 git clone -q "$REMOTE_REPO" "$RUNNER_REPO"
 
 BOUND_SHA="$(git -C "$RUNNER_REPO" rev-parse HEAD)"

--- a/scripts/test_release_please_state.sh
+++ b/scripts/test_release_please_state.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
+
+ROOT="$(git rev-parse --show-toplevel)"
+TEST_TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TEST_TMPDIR"
+}
+trap cleanup EXIT
+
+FAKE_BIN="$TEST_TMPDIR/bin"
+STATE_REPO="$TEST_TMPDIR/state-repo"
+mkdir -p "$FAKE_BIN" "$STATE_REPO"
+
+cat >"$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${GH_CALL_LOG:?}"
+[[ "$1" == "api" ]]
+[[ " $* " == *" --paginate "* ]]
+[[ " $* " == *" --slurp "* ]]
+
+if [[ "${FAKE_RELEASE_MODE:?}" == "api-failure" ]]; then
+  exit 1
+fi
+
+python3 - "${FAKE_RELEASE_MODE:?}" "${FAKE_RELEASE_TAG:-}" <<'PY'
+import json
+import sys
+
+mode, tag = sys.argv[1:]
+if mode == "invalid-json":
+    print("not json")
+elif mode == "exact":
+    print(json.dumps([[{"draft": False, "published_at": "2026-07-27", "tag_name": tag}]]))
+elif mode == "draft":
+    print(json.dumps([[{"draft": True, "published_at": None, "tag_name": tag}]]))
+elif mode == "similar":
+    print(json.dumps([[{"draft": False, "published_at": "2026-07-27", "tag_name": tag + "0"}]]))
+else:
+    print(json.dumps([[]]))
+PY
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+git -C "$STATE_REPO" init -q -b main
+git -C "$STATE_REPO" config user.email test@example.com
+git -C "$STATE_REPO" config user.name "Release State Test"
+printf 'state\n' >"$STATE_REPO/state.txt"
+git -C "$STATE_REPO" add state.txt
+git -C "$STATE_REPO" commit -qm "state"
+STATE_SHA="$(git -C "$STATE_REPO" rev-parse HEAD)"
+
+write_manifest() {
+  local version="$1"
+  python3 - "$version" >"$STATE_REPO/.release-please-manifest.json" <<'PY'
+import json
+import sys
+
+json.dump({".": sys.argv[1]}, sys.stdout)
+sys.stdout.write("\n")
+PY
+}
+
+run_state_check() {
+  local mode="$1"
+  local tag="$2"
+  local output="$TEST_TMPDIR/state-output"
+  : >"$output"
+  (
+    cd "$STATE_REPO"
+    PATH="$FAKE_BIN:$PATH" \
+      FAKE_RELEASE_MODE="$mode" \
+      FAKE_RELEASE_TAG="$tag" \
+      GH_CALL_LOG="$TEST_TMPDIR/gh-calls" \
+      GITHUB_OUTPUT="$output" \
+      GITHUB_REPOSITORY="example/amq" \
+      "$ROOT/scripts/check-release-please-state.sh"
+  )
+}
+
+write_manifest "1.2.3"
+: >"$TEST_TMPDIR/gh-calls"
+run_state_check similar "v1.2.3"
+grep -Fx "version=1.2.3" "$TEST_TMPDIR/state-output" >/dev/null
+grep -Fx "released=false" "$TEST_TMPDIR/state-output" >/dev/null
+grep -Fx "main_sha=$STATE_SHA" "$TEST_TMPDIR/state-output" >/dev/null
+
+write_manifest "1.2.3-rc.1"
+run_state_check exact "v1.2.3-rc.1"
+grep -Fx "released=true" "$TEST_TMPDIR/state-output" >/dev/null
+
+write_manifest "1.2.3"
+run_state_check draft "v1.2.3"
+grep -Fx "released=false" "$TEST_TMPDIR/state-output" >/dev/null
+
+write_manifest "1.2.3"
+: >"$TEST_TMPDIR/gh-calls"
+if run_state_check invalid-json "v1.2.3"; then
+  echo "invalid releases JSON unexpectedly accepted" >&2
+  exit 1
+fi
+[[ ! -s "$TEST_TMPDIR/state-output" ]]
+
+: >"$TEST_TMPDIR/gh-calls"
+if run_state_check api-failure "v1.2.3"; then
+  echo "releases API failure unexpectedly accepted" >&2
+  exit 1
+fi
+[[ ! -s "$TEST_TMPDIR/state-output" ]]
+
+for hostile_version in \
+  $'1.2.3\nreleased=true' \
+  '1.2.3.*' \
+  '01.2.3' \
+  '1.2.3+build'; do
+  write_manifest "$hostile_version"
+  : >"$TEST_TMPDIR/gh-calls"
+  if run_state_check exact "v1.2.3"; then
+    printf 'hostile version unexpectedly accepted: %q\n' "$hostile_version" >&2
+    exit 1
+  fi
+  [[ ! -s "$TEST_TMPDIR/state-output" ]]
+  [[ ! -s "$TEST_TMPDIR/gh-calls" ]]
+done
+
+SOURCE_REPO="$TEST_TMPDIR/source"
+REMOTE_REPO="$TEST_TMPDIR/remote.git"
+RUNNER_REPO="$TEST_TMPDIR/runner"
+git init -q -b main "$SOURCE_REPO"
+git -C "$SOURCE_REPO" config user.email test@example.com
+git -C "$SOURCE_REPO" config user.name "Release State Test"
+printf 'one\n' >"$SOURCE_REPO/value"
+git -C "$SOURCE_REPO" add value
+git -C "$SOURCE_REPO" commit -qm "one"
+git init -q --bare "$REMOTE_REPO"
+git -C "$SOURCE_REPO" remote add origin "$REMOTE_REPO"
+git -C "$SOURCE_REPO" push -q -u origin main
+git clone -q "$REMOTE_REPO" "$RUNNER_REPO"
+
+BOUND_SHA="$(git -C "$RUNNER_REPO" rev-parse HEAD)"
+CURRENT_OUTPUT="$TEST_TMPDIR/current-output"
+(
+  cd "$RUNNER_REPO"
+  EXPECTED_MAIN_SHA="$BOUND_SHA" \
+    GITHUB_OUTPUT="$CURRENT_OUTPUT" \
+    "$ROOT/scripts/revalidate-release-please-main.sh"
+)
+grep -Fx "current=true" "$CURRENT_OUTPUT" >/dev/null
+
+printf 'two\n' >>"$SOURCE_REPO/value"
+git -C "$SOURCE_REPO" add value
+git -C "$SOURCE_REPO" commit -qm "two"
+git -C "$SOURCE_REPO" push -q origin main
+: >"$CURRENT_OUTPUT"
+(
+  cd "$RUNNER_REPO"
+  EXPECTED_MAIN_SHA="$BOUND_SHA" \
+    GITHUB_OUTPUT="$CURRENT_OUTPUT" \
+    "$ROOT/scripts/revalidate-release-please-main.sh"
+)
+grep -Fx "current=false" "$CURRENT_OUTPUT" >/dev/null
+
+: >"$CURRENT_OUTPUT"
+if (
+  cd "$RUNNER_REPO"
+  EXPECTED_MAIN_SHA=$'bad\ncurrent=true' \
+    GITHUB_OUTPUT="$CURRENT_OUTPUT" \
+    "$ROOT/scripts/revalidate-release-please-main.sh"
+); then
+  echo "hostile expected main SHA unexpectedly accepted" >&2
+  exit 1
+fi
+[[ ! -s "$CURRENT_OUTPUT" ]]
+
+printf 'release-please state tests ok\n'

--- a/scripts/test_release_workflow_labels.sh
+++ b/scripts/test_release_workflow_labels.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+TEST_TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TEST_TMPDIR"
+}
+trap cleanup EXIT
+
+MARK_SCRIPT="$TEST_TMPDIR/mark-release-pr.sh"
+python3 - "$ROOT/.github/workflows/release.yml" "$MARK_SCRIPT" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text()
+step = workflow.split("      - name: Mark release pull request as tagged\n", 1)[1]
+body = step.split("        run: |\n", 1)[1].split("\n  skill-publish:\n", 1)[0]
+lines = []
+for line in body.splitlines():
+    if line and not line.startswith("          "):
+        raise SystemExit(f"unexpected workflow indentation: {line!r}")
+    lines.append(line[10:] if line else "")
+pathlib.Path(sys.argv[2]).write_text(
+    "#!/usr/bin/env bash\n" + "\n".join(lines) + "\n"
+)
+PY
+chmod +x "$MARK_SCRIPT"
+
+FAKE_BIN="$TEST_TMPDIR/bin"
+mkdir -p "$FAKE_BIN"
+cat >"$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${GH_CALL_LOG:?}"
+[[ "$1" == "api" ]]
+
+if [[ "$*" == *"/commits/"*"/pulls?"* ]]; then
+  case "${FAKE_PR_MODE:?}" in
+    zero)
+      printf '[[]]\n'
+      ;;
+    exact)
+      jq -cn --arg sha "${RELEASE_SHA:?}" \
+        '[[{number: 23, merged_at: "2026-07-27", base: {ref: "main"},
+            title: "chore(release): v1.2.3", merge_commit_sha: $sha}]]'
+      ;;
+    multiple)
+      jq -cn --arg sha "${RELEASE_SHA:?}" \
+        '[[{number: 23, merged_at: "2026-07-27", base: {ref: "main"},
+            title: "chore(release): v1.2.3", merge_commit_sha: $sha},
+           {number: 24, merged_at: "2026-07-27", base: {ref: "main"},
+            title: "chore(release): v1.2.3", merge_commit_sha: $sha}]]'
+      ;;
+    wrong)
+      jq -cn --arg sha "${RELEASE_SHA:?}" \
+        '[[{number: 23, merged_at: "2026-07-27", base: {ref: "other"},
+            title: "chore(release): v1.2.3", merge_commit_sha: $sha}]]'
+      ;;
+  esac
+  exit
+fi
+
+if [[ "$*" == *"/issues/23/labels"* && " $* " == *" --method POST "* ]]; then
+  jq -e '.labels == ["autorelease: tagged"]' >/dev/null
+  case "${FAKE_POST_BEHAVIOR:-success}" in
+    success|apply-fail)
+      if ! grep -Fxq 'autorelease: tagged' "${FAKE_LABEL_STATE:?}"; then
+        printf 'autorelease: tagged\n' >>"$FAKE_LABEL_STATE"
+      fi
+      ;;
+    fail)
+      ;;
+  esac
+  printf '[]\n'
+  [[ "${FAKE_POST_BEHAVIOR:-success}" != "apply-fail" &&
+     "${FAKE_POST_BEHAVIOR:-success}" != "fail" ]]
+  exit
+fi
+
+if [[ "$*" == *"/issues/23/labels/autorelease%3A%20pending"* ]]; then
+  case "${FAKE_DELETE_BEHAVIOR:-success}" in
+    success|apply-fail|peer-404)
+      grep -Fxv 'autorelease: pending' "$FAKE_LABEL_STATE" >"${FAKE_LABEL_STATE}.next" || true
+      mv "${FAKE_LABEL_STATE}.next" "$FAKE_LABEL_STATE"
+      ;;
+    fail)
+      ;;
+  esac
+  [[ "${FAKE_DELETE_BEHAVIOR:-success}" != "apply-fail" &&
+     "${FAKE_DELETE_BEHAVIOR:-success}" != "peer-404" &&
+     "${FAKE_DELETE_BEHAVIOR:-success}" != "fail" ]]
+  exit
+fi
+
+if [[ "$*" == *"/issues/23"* ]]; then
+  reads="$(cat "${FAKE_LABEL_READS:?}")"
+  reads="$((reads + 1))"
+  printf '%s\n' "$reads" >"$FAKE_LABEL_READS"
+  if [[ "${FAKE_FAIL_LABEL_READ_AT:-0}" -eq "$reads" ]]; then
+    exit 1
+  fi
+  jq -Rsc '{labels: (split("\n") | map(select(length > 0) | {name: .}))}' \
+    <"${FAKE_LABEL_STATE:?}"
+  if [[ "${FAKE_NONZERO_LABEL_READ_AT:-0}" -eq "$reads" ]]; then
+    exit 1
+  fi
+  exit
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+CALL_LOG="$TEST_TMPDIR/calls"
+LABEL_STATE="$TEST_TMPDIR/labels"
+LABEL_READS="$TEST_TMPDIR/label-reads"
+RELEASE_SHA="1111111111111111111111111111111111111111"
+
+run_mark() {
+  local mode="$1"
+  local event="$2"
+  PATH="$FAKE_BIN:$PATH" \
+    GH_CALL_LOG="$CALL_LOG" \
+    FAKE_PR_MODE="$mode" \
+    FAKE_LABEL_STATE="$LABEL_STATE" \
+    FAKE_LABEL_READS="$LABEL_READS" \
+    FAKE_POST_BEHAVIOR="${FAKE_POST_BEHAVIOR:-success}" \
+    FAKE_DELETE_BEHAVIOR="${FAKE_DELETE_BEHAVIOR:-success}" \
+    FAKE_FAIL_LABEL_READ_AT="${FAKE_FAIL_LABEL_READ_AT:-0}" \
+    FAKE_NONZERO_LABEL_READ_AT="${FAKE_NONZERO_LABEL_READ_AT:-0}" \
+    GITHUB_REPOSITORY="example/amq" \
+    RELEASE_SHA="$RELEASE_SHA" \
+    VERSION="1.2.3" \
+    EVENT_NAME="$event" \
+    "$MARK_SCRIPT"
+}
+
+reset_case() {
+  : >"$CALL_LOG"
+  printf '0\n' >"$LABEL_READS"
+  unset FAKE_POST_BEHAVIOR
+  unset FAKE_DELETE_BEHAVIOR
+  unset FAKE_FAIL_LABEL_READ_AT
+  unset FAKE_NONZERO_LABEL_READ_AT
+}
+
+# Historical manual re-release with no associated PR is a successful no-op.
+reset_case
+: >"$LABEL_STATE"
+run_mark zero workflow_dispatch
+if grep -q '/issues/' "$CALL_LOG"; then
+  echo "historical zero-PR dispatch mutated labels" >&2
+  exit 1
+fi
+
+# Canonical push still requires a bound PR.
+reset_case
+if run_mark zero push; then
+  echo "canonical release without a PR unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q '/issues/' "$CALL_LOG"; then
+  echo "canonical zero-PR release reached label API" >&2
+  exit 1
+fi
+
+# One exact canonical PR converges in safe label order.
+reset_case
+printf 'autorelease: pending\n' >"$LABEL_STATE"
+run_mark exact push
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+post_line="$(grep -n -- '--method POST' "$CALL_LOG" | cut -d: -f1)"
+delete_line="$(grep -n -- '--method DELETE' "$CALL_LOG" | cut -d: -f1)"
+[[ "$post_line" -lt "$delete_line" ]]
+
+# Duplicate tagged state must fail before DELETE; exact tagged convergence is
+# a precondition for removing pending, not merely a final-state check.
+reset_case
+printf 'autorelease: pending\nautorelease: tagged\nautorelease: tagged\n' >"$LABEL_STATE"
+if run_mark exact push; then
+  echo "duplicate inline tagged labels unexpectedly accepted" >&2
+  exit 1
+fi
+if grep -Eq -- '--method (POST|DELETE)' "$CALL_LOG"; then
+  echo "duplicate inline tagged labels caused mutation" >&2
+  exit 1
+fi
+
+# A peer DELETE/404 and lost successful POST/DELETE responses stay successful
+# when the authoritative reread proves tagged-only convergence. This is the
+# inline release step's success result that keeps skill-publish eligible.
+reset_case
+printf 'autorelease: pending\nautorelease: tagged\n' >"$LABEL_STATE"
+export FAKE_DELETE_BEHAVIOR=peer-404
+run_mark exact push
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+
+reset_case
+printf 'autorelease: pending\n' >"$LABEL_STATE"
+export FAKE_POST_BEHAVIOR=apply-fail
+run_mark exact push
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+
+reset_case
+printf 'autorelease: pending\nautorelease: tagged\n' >"$LABEL_STATE"
+export FAKE_DELETE_BEHAVIOR=apply-fail
+run_mark exact push
+[[ "$(cat "$LABEL_STATE")" == "autorelease: tagged" ]]
+
+# Nonzero mutations still fail closed without readable, exact convergence.
+reset_case
+printf 'autorelease: pending\n' >"$LABEL_STATE"
+export FAKE_POST_BEHAVIOR=fail
+if run_mark exact push; then
+  echo "failed inline POST with nonconverged reread unexpectedly succeeded" >&2
+  exit 1
+fi
+
+reset_case
+printf 'autorelease: pending\nautorelease: tagged\n' >"$LABEL_STATE"
+export FAKE_DELETE_BEHAVIOR=fail
+if run_mark exact push; then
+  echo "failed inline DELETE with nonconverged reread unexpectedly succeeded" >&2
+  exit 1
+fi
+
+reset_case
+printf 'autorelease: pending\nautorelease: tagged\n' >"$LABEL_STATE"
+export FAKE_DELETE_BEHAVIOR=apply-fail
+export FAKE_FAIL_LABEL_READ_AT=2
+if run_mark exact push; then
+  echo "failed inline DELETE with unreadable reread unexpectedly succeeded" >&2
+  exit 1
+fi
+
+reset_case
+printf 'autorelease: pending\n' >"$LABEL_STATE"
+export FAKE_POST_BEHAVIOR=apply-fail
+export FAKE_NONZERO_LABEL_READ_AT=2
+if run_mark exact push; then
+  echo "nonzero inline tagged reread with valid-looking JSON unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q -- '--method DELETE' "$CALL_LOG"; then
+  echo "inline pending label was removed after a failed authoritative tagged reread" >&2
+  exit 1
+fi
+
+# Associated ambiguity or a non-exact sole PR fails closed, even on dispatch.
+for mode in multiple wrong; do
+  reset_case
+  printf 'autorelease: pending\n' >"$LABEL_STATE"
+  if run_mark "$mode" workflow_dispatch; then
+    echo "$mode dispatch binding unexpectedly succeeded" >&2
+    exit 1
+  fi
+  if grep -q '/issues/' "$CALL_LOG"; then
+    echo "$mode dispatch binding reached label API" >&2
+    exit 1
+  fi
+  [[ "$(cat "$LABEL_STATE")" == "autorelease: pending" ]]
+done
+
+printf 'release workflow label tests ok\n'


### PR DESCRIPTION
## Summary
- reconcile published release PR labels idempotently after durable publication
- bind recovery to the exact canonical tag, manifest, main ancestry, and merged release PR
- preserve historical manual re-release success without false label failures or skill-publish suppression
- treat mutation responses as attempts and authoritative rereads as truth, including peer 404/lost-response races

## Verification
- exact pushed tree: `4ec232b63faa2df7d180a3122f3dc633a2e9dbd6`
- ChatGPT Pro: PASS
- independent current-main peer review: PASS
- Claude current-main review: PASS
- focused release/reconciliation suites: PASS
- ShellCheck + pinned actionlint: PASS on byte-identical reviewed paths
- `make ci`: PASS
