### PR TITLE
fix(send): make mailbox recovery self-healing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,11 @@ Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and do
 
 **Cross-tree send guard**: A direct `--root` is root *selection*, not federation routing. `send` refuses an explicit `--root` that targets a different base tree than the caller's own active session (`AM_ROOT`/`AM_BASE_ROOT`) when no routing dimension (`--project`/`--session`/`--from-session`) is given — such a message carries no sender-origin metadata, so the recipient could not reply and a naive reply would loop into their own tree. Replyable cross-tree messaging must use `--project`/`--session`, which stamp the routing headers. With no session env set (bare-root scripts/CI), the guard does not fire; a direct `--root` cross-tree send in that case can still produce an unreplyable message — the documented cost of keeping bare-root sends working.
 
-**Session-root guard**: `read`, `drain`, `monitor`, `watch`, and mutating DLQ commands compare their resolved target against the exact context pinned by `AM_BASE_ROOT`/`AM_SESSION` before inspecting or moving mailbox state; `send` and `reply` apply the same check to their local source. For named sessions `AM_BASE_ROOT` is the authorized parent; for sessionless contexts it is the exact root and `AM_SESSION` is empty. A mismatch exits with code 5; use `--session <name>` as the deliberate routing dimension. The raw-root escape hatch is `--ignore-session-pin`, which requires a non-empty explicit `--root`; explicitly blank `--root`/`--session` values are usage errors. Target routing never authorizes a mismatched source. `list` warns instead of refusing so it remains a non-destructive inspection path; the exact base-backlog inspection command is quiet only when its explicit root is the current pin's own base root, identity-authenticated when tokens are present. With no positive session/tree evidence, scripts and CI remain fail-open. A missing mailbox is a not-found error. Empty `drain` and `list --new` results perform a shallow sibling-session scan and write exact `amq list --session <name> --me <handle> --new` inspection commands to stderr; `doctor --ops` reports the same condition as `sibling_backlog` hints. `doctor --ops --json` adds a structured `backlog` object to `base_backlog` hints with the target root, current session, agent, pending count, and exact command. Known limitation: `send --from-session` remains a double-explicit legacy route from its supplied raw base; callers must ensure that base is intentional until the follow-up resolver work lands.
+**Session-root guard**: `read`, `drain`, `monitor`, `watch`, and mutating DLQ commands compare their resolved target against the exact context pinned by `AM_BASE_ROOT`/`AM_SESSION` before inspecting or moving mailbox state; `send` and `reply` apply the same check to their local source. For named sessions `AM_BASE_ROOT` is the authorized parent; for sessionless contexts it is the exact root and `AM_SESSION` is empty. A mismatch exits with code 5; use `--session <name>` as the deliberate routing dimension. The raw-root escape hatch is `--ignore-session-pin`, which requires a non-empty explicit `--root`; explicitly blank `--root`/`--session` values are usage errors. Target routing never authorizes a mismatched source. `list` warns instead of refusing so it remains a non-destructive inspection path. `doctor --root` likewise selects an exact inspection target without repinning the shell: inspection continues with a mismatch warning, while `--fix-mailboxes` refuses mutation unless the pin matches or the caller also supplies `--ignore-session-pin`. `--base-root` supplies config authority only and never waives the pin. The exact base-backlog inspection command is quiet only when its explicit root is the current pin's own base root, identity-authenticated when tokens are present. With no positive session/tree evidence, scripts and CI remain fail-open. A missing mailbox is a not-found error. Empty `drain` and `list --new` results perform a shallow sibling-session scan and write exact `amq list --session <name> --me <handle> --new` inspection commands to stderr; `doctor --ops` reports the same condition as `sibling_backlog` hints. `doctor --ops --json` adds a structured `backlog` object to `base_backlog` hints with the target root, current session, agent, pending count, and exact command. Known limitation: `send --from-session` remains a double-explicit legacy route from its supplied raw base; callers must ensure that base is intentional until the follow-up resolver work lands.
+
+The same doctor mutation rule applies to `--ops --fix-wake-locks`: a
+mismatched target is inspected but its wake locks are not changed without
+`--ignore-session-pin`.
 
 **Environment context replacement**: Every shell-mode `amq env` output replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`, and `AM_SESSION` as one context. Sessionless output pins `AM_BASE_ROOT` to the exact root and emits an empty `AM_SESSION`; `--export` additionally prints a pin note. An ambient root that conflicts with an existing pin is rejected unless a non-empty `--root` or `--session` explicitly repins it. `amq env --session` routes from a valid existing pin base before consulting cwd configuration.
 
@@ -208,7 +212,7 @@ amq integration symphony init [--workflow <path>] --me <agent> [--root <path>] [
 amq integration symphony emit --event <after_create|before_run|after_run|before_remove> --me <agent> [--root <path>] [--workspace <path>] [--identifier <key>] [--json]
 amq integration kanban bridge --me <agent> [--root <path>] [--url <ws://...>] [--workspace-id <id>] [--reconnect <duration>] [--json]
 amq who [--json]
-amq doctor [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json]
+amq doctor [--root <path>] [--base-root <path>] [--ignore-session-pin] [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json]
 ```
 
 `--root` is accepted only where it is listed above. Participating commands may
@@ -347,13 +351,26 @@ Use `--force` with retry to override the max retry limit.
 `amq doctor` verifies installation, root configuration, permissions, config, and skill setup.
 
 `amq doctor --fix-mailboxes` repairs the base mailbox layout without requiring
-`--ops`: it creates only missing required directories for agents listed in
-`config.json`. Filesystem-discovered mailboxes that are not configured are
+`--ops`: it creates only missing required directories for the effective
+configured roster (`config.json` agents plus the reserved human handle
+`user`). Filesystem-discovered mailboxes outside that effective roster are
 reported but are never repair eligible. Repair never edits, moves, overwrites,
-or deletes existing message files; symlinks, non-directories, unreadable paths,
-and concurrent layout changes fail closed. Inspection remains available when
-the target differs from the active session pin (reported separately as a
-warning); repair requires the target to match any populated session pin.
+or deletes existing message files; symlinks, non-directories, unreadable
+paths, and concurrent layout changes fail closed. Inspection remains
+available when the target differs from the active session pin (reported
+separately as a warning); without the explicit override, repair requires the
+target to match any populated session pin.
+
+`amq doctor --root <path>` selects the exact inspection or repair target; it
+does not repin the shell or bypass an inherited session pin. Read-only
+inspection still runs on a mismatch and reports a `Session identity pin`
+warning. Mailbox repair refuses a mismatched target unless the command also
+uses `--ignore-session-pin`, which requires an explicit non-empty `--root`.
+For a base-config-only session, use
+`amq doctor --root <session> --base-root <base> --ignore-session-pin --fix-mailboxes`.
+`--base-root` requires `--root`, is used only as the retained config authority,
+and must be the same tree or the direct parent of the target; it never waives
+the session pin.
 
 `amq doctor --ops` adds runtime checks:
 

--- a/COOP.md
+++ b/COOP.md
@@ -122,7 +122,11 @@ When a terminal has a complete `AM_BASE_ROOT`/`AM_SESSION` pin, `read`, `drain`,
 <name>` for sibling routing. For deliberate raw-root access,
 `--ignore-session-pin` requires a non-empty explicit `--root`; it never blesses
 an inherited `AM_ROOT`. `list` warns on a mismatch but remains available for
-non-destructive inspection. A missing mailbox is an error, not an empty inbox.
+non-destructive inspection. `doctor --root` also keeps inspection available
+with a mismatch warning, but `--fix-mailboxes` and
+`--ops --fix-wake-locks` require a matching pin unless that explicit root is
+paired with `--ignore-session-pin`. `--base-root` selects config authority and
+never waives the pin. A missing mailbox is an error, not an empty inbox.
 
 ### For Scripts/CI
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ identity-authenticated when identity tokens are present). Implicit, sibling,
 foreign, stale, and malformed contexts still warn. Unpinned scripts and CI
 retain the existing fail-open behavior.
 
+`amq doctor --root <path>` follows the same inspection-versus-mutation split:
+the explicit root selects the exact target but does not repin the shell or
+waive its session pin. Read-only inspection continues with a mismatch warning.
+`--fix-mailboxes` and `--ops --fix-wake-locks` refuse a mismatched target unless
+`--ignore-session-pin` is also supplied; that override requires an explicit
+non-empty `--root`. For a session whose roster lives only in its base, use
+`amq doctor --root <session> --base-root <base> --ignore-session-pin --fix-mailboxes`.
+`--base-root` is config authority only, must be the target itself or its direct
+parent, and never overrides the session pin.
+
 A missing mailbox is an error, not an empty inbox. When `drain` or `list --new`
 finds an actually empty inbox, it prints a stderr-only note if the same handle
 has pending messages in a sibling session, including an exact non-destructive

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -470,9 +470,6 @@ func loadKnownAgentsWithRead(strict bool, read func() ([]byte, error)) ([]string
 }
 
 func withReservedHumanHandle(agents []string) []string {
-	if len(agents) == 0 {
-		return agents
-	}
 	for _, agent := range agents {
 		if agent == reservedHumanHandle {
 			return agents

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -149,7 +149,7 @@ func TestValidateKnownHandlesAllowsReservedUserWithConfig(t *testing.T) {
 	}
 }
 
-func TestLoadKnownAgentsDoesNotReserveUserWithoutConfiguredAgents(t *testing.T) {
+func TestLoadKnownAgentsDistinguishesAbsentFromPresentEmptyConfig(t *testing.T) {
 	root := t.TempDir()
 
 	agents, err := loadKnownAgents(root, true)
@@ -172,8 +172,18 @@ func TestLoadKnownAgentsDoesNotReserveUserWithoutConfiguredAgents(t *testing.T) 
 	if err != nil {
 		t.Fatalf("loadKnownAgents with empty config: %v", err)
 	}
-	if len(agents) != 0 {
-		t.Fatalf("empty configured agents should not synthesize user, got %#v", agents)
+	if len(agents) != 1 || agents[0] != reservedHumanHandle {
+		t.Fatalf("empty configured agents = %#v, want reserved user", agents)
+	}
+	known, err = loadKnownAgentSet(root, true)
+	if err != nil {
+		t.Fatalf("loadKnownAgentSet with empty config: %v", err)
+	}
+	if len(known) != 1 {
+		t.Fatalf("empty configured known set = %#v, want reserved user only", known)
+	}
+	if _, ok := known[reservedHumanHandle]; !ok {
+		t.Fatalf("empty configured known set = %#v, want reserved user", known)
 	}
 }
 

--- a/internal/cli/coop_wake_reclaim_unix.go
+++ b/internal/cli/coop_wake_reclaim_unix.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -193,7 +194,7 @@ func resolveMissingWakeLockAfterTermination(
 }
 
 func coopWakeRemedy(inspection wakeLockInspection, state, command string) string {
-	return fmt.Sprintf("wake for %s is blocking startup and cannot notify you.\n  lock: %s\n  state: %s\n\nRe-run with -y to clear it and start a fresh wake:\n  %s\n\nTo inspect first:\n  AM_ROOT=%s amq doctor --ops", inspection.Agent, inspection.LockPath, state, command, inspection.Root)
+	return fmt.Sprintf("wake for %s is blocking startup and cannot notify you.\n  lock: %s\n  state: %s\n\nRe-run with -y to clear it and start a fresh wake:\n  %s\n\nTo inspect first:\n  %s", inspection.Agent, inspection.LockPath, state, command, doctorRootCommandForOS(inspection.Root, "", runtime.GOOS, "--ops"))
 }
 
 func coopWakeRemedyForCommand(root, agent, command string, commandArgs []string) string {

--- a/internal/cli/coop_wake_reclaim_unix_test.go
+++ b/internal/cli/coop_wake_reclaim_unix_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"errors"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -124,11 +125,25 @@ func TestPrepareCoopWakeLockHeadlessPrintsRemedyWithoutPrompt(t *testing.T) {
 		strings.Contains(stderr, "Clear it and start a fresh wake?") {
 		t.Fatalf("headless cleanup printed an unanswerable prompt: stdout=%q stderr=%q", stdout, stderr)
 	}
-	if !strings.Contains(stderr, remedy) || !strings.Contains(stderr, "AM_ROOT=") {
+	inspectCommand := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops")
+	if !strings.Contains(stderr, remedy) || !strings.Contains(stderr, inspectCommand) || strings.Contains(stderr, "AM_ROOT=") {
 		t.Fatalf("remedy missing: %q", stderr)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("headless cleanup changed lock: %v", err)
+	}
+}
+
+func TestCoopWakeRemedyQuotesExplicitDoctorRoot(t *testing.T) {
+	root := `/tmp/AMQ & peer's $root`
+	got := coopWakeRemedy(wakeLockInspection{
+		Agent:    "codex",
+		LockPath: "/tmp/wake.lock",
+		Root:     root,
+	}, "unverified", "amq coop exec -y")
+	want := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops")
+	if !strings.Contains(got, want) || strings.Contains(got, "AM_ROOT=") {
+		t.Fatalf("wake remedy = %q, want explicit command %q", got, want)
 	}
 }
 

--- a/internal/cli/cross_project_test.go
+++ b/internal/cli/cross_project_test.go
@@ -4,9 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 func TestParseInlineRecipient(t *testing.T) {
@@ -327,11 +331,8 @@ func TestCrossProjectSendFromOutsideTree(t *testing.T) {
 	peerBaseRoot := filepath.Join(peerProjectDir, ".agent-mail")
 	peerSessionRoot := filepath.Join(peerBaseRoot, "collab")
 	for _, agent := range []string{"claude", "codex"} {
-		for _, sub := range []string{"tmp", "new", "cur"} {
-			dir := filepath.Join(peerSessionRoot, "agents", agent, "inbox", sub)
-			if err := os.MkdirAll(dir, 0o700); err != nil {
-				t.Fatal(err)
-			}
+		if err := fsq.EnsureAgentDirs(peerSessionRoot, agent); err != nil {
+			t.Fatal(err)
 		}
 		// outbox/sent for sender
 		if err := os.MkdirAll(filepath.Join(srcSessionRoot, "agents", agent, "outbox", "sent"), 0o700); err != nil {
@@ -435,5 +436,249 @@ func TestCrossProjectSendRejectsMultipleRecipients(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--project supports exactly one recipient") {
 		t.Fatalf("error = %q, want explicit cross-project multi-recipient rejection", err)
+	}
+}
+
+func TestCrossProjectSendReportsIncompleteMailboxCauseAndPeerRepair(t *testing.T) {
+	clearSendMailboxTestEnv(t)
+	srcProjectDir := t.TempDir()
+	srcRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+	peerBase := filepath.Join(t.TempDir(), "custom peer base")
+	peerRoot := filepath.Join(peerBase, "collab")
+	if err := fsq.EnsureAgentDirs(srcRoot, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(peerRoot, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	configureSendTestRoot(t, peerBase, "bob")
+	missing := fsq.AgentDLQCur(peerRoot, "bob")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	rcData, err := json.Marshal(map[string]any{
+		"root":    ".agent-mail",
+		"project": "source",
+		"peers":   map[string]string{"peer": peerBase},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcProjectDir, ".amqrc"), rcData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err = runSend([]string{
+		"--root", srcRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--project", "peer",
+		"--body", "no partial peer delivery",
+	})
+	if err == nil {
+		t.Fatal("incomplete peer send succeeded")
+	}
+	for _, want := range []string{"dlq/cur", "incomplete", "amq doctor", "--root", "--base-root", "--fix-mailboxes", peerRoot, peerBase} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("peer error missing %q: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "AM_ROOT=") {
+		t.Fatalf("peer error advertised environment-specific recovery: %v", err)
+	}
+	if strings.Contains(err.Error(), `agent "bob" not found`) {
+		t.Fatalf("incomplete mailbox was misreported as missing agent: %v", err)
+	}
+	entries, readErr := os.ReadDir(fsq.AgentInboxNew(peerRoot, "bob"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("incomplete peer received message: %#v", entries)
+	}
+	if _, statErr := os.Lstat(missing); !os.IsNotExist(statErr) {
+		t.Fatalf("cross-project send repaired peer mailbox: %v", statErr)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("exact printed command execution uses the POSIX test shell")
+	}
+	repairCommand := advertisedPeerRepairCommand(t, err)
+	if strings.Contains(repairCommand, "--ignore-session-pin") {
+		t.Fatalf("unpinned repair command advertised escape hatch: %q", repairCommand)
+	}
+	executeAdvertisedAMQCommand(t, repairCommand)
+	if err := fsq.ValidateExistingMailboxLayout(openDeliveryRootForCLITest(t, peerRoot), "bob"); err != nil {
+		t.Fatalf("advertised peer recovery left mailbox incomplete: %v", err)
+	}
+}
+
+func TestCrossProjectRepairCommandUsesSessionConfigAuthorityWhenBaseHasNoConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exact printed command execution uses the POSIX test shell")
+	}
+	clearSendMailboxTestEnv(t)
+	srcProjectDir := t.TempDir()
+	srcRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+	peerBase := filepath.Join(t.TempDir(), "peer base without config")
+	peerRoot := filepath.Join(peerBase, "collab")
+	if err := fsq.EnsureAgentDirs(srcRoot, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(peerRoot, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	configureSendTestRoot(t, peerRoot, "bob")
+	missing := fsq.AgentDLQCur(peerRoot, "bob")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	rcData, err := json.Marshal(map[string]any{
+		"root":    ".agent-mail",
+		"project": "source",
+		"peers":   map[string]string{"peer": peerBase},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcProjectDir, ".amqrc"), rcData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sendErr := runSend([]string{
+		"--root", srcRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--project", "peer",
+		"--body", "repair from effective authority",
+	})
+	if sendErr == nil {
+		t.Fatal("incomplete peer send succeeded")
+	}
+	command := advertisedPeerRepairCommand(t, sendErr)
+	if strings.Contains(command, "--base-root") {
+		t.Fatalf("session-authorized repair command named config-less base: %q", command)
+	}
+	if strings.Contains(command, "--ignore-session-pin") {
+		t.Fatalf("unpinned repair command advertised a session-pin escape hatch: %q", command)
+	}
+	executeAdvertisedAMQCommand(t, command)
+	if err := fsq.ValidateExistingMailboxLayout(openDeliveryRootForCLITest(t, peerRoot), "bob"); err != nil {
+		t.Fatalf("advertised session-authorized repair left mailbox incomplete: %v", err)
+	}
+}
+
+func advertisedPeerRepairCommand(t *testing.T, err error) string {
+	t.Helper()
+	const marker = "run: "
+	parts := strings.SplitN(err.Error(), marker, 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[1]) == "" {
+		t.Fatalf("peer error has no advertised command: %v", err)
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+func executeAdvertisedAMQCommand(t *testing.T, commandText string) {
+	t.Helper()
+	binDir := t.TempDir()
+	helperBinary, absErr := filepath.Abs(os.Args[0])
+	if absErr != nil {
+		t.Fatal(absErr)
+	}
+	if linkErr := os.Symlink(helperBinary, filepath.Join(binDir, "amq")); linkErr != nil {
+		t.Fatal(linkErr)
+	}
+	command := exec.Command("/bin/sh", "-c", commandText)
+	command.Env = append(os.Environ(),
+		cliHelperEnv+"=1",
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	if output, commandErr := command.CombinedOutput(); commandErr != nil {
+		t.Fatalf("execute exact advertised peer recovery %q: %v\n%s", commandText, commandErr, output)
+	}
+}
+
+func TestCrossProjectSendValidatesPeerRosterBeforeMailboxLayout(t *testing.T) {
+	for _, strict := range []bool{true, false} {
+		t.Run(map[bool]string{true: "strict", false: "non-strict"}[strict], func(t *testing.T) {
+			clearSendMailboxTestEnv(t)
+			srcProjectDir := t.TempDir()
+			srcRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+			peerBase := filepath.Join(t.TempDir(), "peer base")
+			peerRoot := filepath.Join(peerBase, "collab")
+			if err := fsq.EnsureAgentDirs(srcRoot, "alice"); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(peerRoot, "mallory"); err != nil {
+				t.Fatal(err)
+			}
+			configureSendTestRoot(t, peerBase, "bob")
+			missing := fsq.AgentDLQCur(peerRoot, "mallory")
+			if err := os.Remove(missing); err != nil {
+				t.Fatal(err)
+			}
+			rcData, err := json.Marshal(map[string]any{
+				"root":    ".agent-mail",
+				"project": "source",
+				"peers":   map[string]string{"peer": peerBase},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(srcProjectDir, ".amqrc"), rcData, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			args := []string{
+				"--root", srcRoot,
+				"--me", "alice",
+				"--to", "mallory",
+				"--project", "peer",
+				"--body", "no delivery",
+			}
+			if strict {
+				args = append(args, "--strict")
+			}
+			_, stderr, sendErr := captureEnvOutput(t, func() error { return runSend(args) })
+			if sendErr == nil {
+				t.Fatal("unconfigured incomplete peer send succeeded")
+			}
+			if strict {
+				if !strings.Contains(sendErr.Error(), `handle "mallory" not in config.json`) {
+					t.Fatalf("strict error = %v, want roster refusal", sendErr)
+				}
+				if strings.Contains(sendErr.Error(), "incomplete") || strings.Contains(sendErr.Error(), "--fix-mailboxes") {
+					t.Fatalf("strict roster refusal leaked layout remedy: %v", sendErr)
+				}
+			} else {
+				if !strings.Contains(stderr, `warning: handle "mallory" not in config.json`) {
+					t.Fatalf("non-strict warning = %q", stderr)
+				}
+				for _, want := range []string{"incomplete", "missing:dlq/cur", "add", "config.json", "--fix-mailboxes"} {
+					if !strings.Contains(sendErr.Error(), want) {
+						t.Fatalf("non-strict error missing %q: %v", want, sendErr)
+					}
+				}
+			}
+			if entries, readErr := os.ReadDir(fsq.AgentInboxNew(peerRoot, "mallory")); readErr != nil || len(entries) != 0 {
+				t.Fatalf("peer inbox changed: entries=%#v err=%v", entries, readErr)
+			}
+		})
+	}
+}
+
+func TestPeerMailboxRepairCommandUsesNativeWindowsArguments(t *testing.T) {
+	clearDoctorSessionPin(t)
+	got := peerMailboxRepairCommandForOS(
+		`C:\AMQ & Data\peer's $collab`,
+		`C:\AMQ & Data\peer's`,
+		"windows",
+	)
+	want := `amq doctor --root 'C:\AMQ & Data\peer''s $collab' --base-root 'C:\AMQ & Data\peer''s' --fix-mailboxes`
+	if got != want {
+		t.Fatalf("Windows peer repair command = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "AM_ROOT=") {
+		t.Fatalf("Windows peer repair command used POSIX semantics: %q", got)
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
@@ -37,6 +38,9 @@ func runDoctor(args []string) error {
 	opsFlag := fs.Bool("ops", false, "Include runtime operational checks")
 	fixWakeLocksFlag := fs.Bool("fix-wake-locks", false, "With --ops, remove stale wake lock files")
 	fixMailboxesFlag := fs.Bool("fix-mailboxes", false, "Create missing required directories for configured mailboxes")
+	rootFlag := fs.String("root", "", "Exact AMQ root to inspect or repair")
+	baseRootFlag := fs.String("base-root", "", "Config-authority root for an explicit session --root")
+	ignoreSessionPinFlag := fs.Bool("ignore-session-pin", false, "With explicit --root, allow repair outside the pinned session context")
 
 	usage := usageWithFlags(fs, "amq doctor [options]",
 		"Verify AMQ installation and configuration.",
@@ -66,6 +70,20 @@ func runDoctor(args []string) error {
 	if *fixWakeLocksFlag && !*opsFlag {
 		return UsageError("--fix-wake-locks requires --ops")
 	}
+	rootExplicit := flagWasVisited(fs, "root")
+	baseRootExplicit := flagWasVisited(fs, "base-root")
+	if rootExplicit && strings.TrimSpace(*rootFlag) == "" {
+		return UsageError("--root cannot be empty")
+	}
+	if baseRootExplicit && strings.TrimSpace(*baseRootFlag) == "" {
+		return UsageError("--base-root cannot be empty")
+	}
+	if baseRootExplicit && !rootExplicit {
+		return UsageError("--base-root requires an explicit --root")
+	}
+	if *ignoreSessionPinFlag && !rootExplicit {
+		return UsageError("--ignore-session-pin requires an explicit --root")
+	}
 
 	result := doctorResult{}
 
@@ -74,6 +92,23 @@ func runDoctor(args []string) error {
 
 	// Check 2: .amqrc
 	amqrcCheck, root := checkAmqrc()
+	if rootExplicit {
+		root = resolveRoot(*rootFlag)
+		amqrcCheck = doctorCheck{
+			Name:    "Root config",
+			Status:  "ok",
+			Message: fmt.Sprintf("queue root=%s (source: flag)", root),
+		}
+	}
+	baseRoot := ""
+	if baseRootExplicit {
+		baseRoot = resolveRoot(*baseRootFlag)
+	}
+	if baseRoot != "" {
+		if err := validateDoctorExplicitBaseRoot(root, baseRoot); err != nil {
+			return UsageError("%v", err)
+		}
+	}
 	result.Checks = append(result.Checks, amqrcCheck)
 
 	// Check 3: Root directory
@@ -89,12 +124,16 @@ func runDoctor(args []string) error {
 
 	// Check 4: Config.json
 	if root != "" {
-		result.Checks = append(result.Checks, checkConfig(root))
+		configRoot := root
+		if baseRoot != "" {
+			configRoot = baseRoot
+		}
+		result.Checks = append(result.Checks, checkConfig(configRoot))
 	}
 
 	// Check 5: Mailbox permissions
 	if root != "" {
-		mailboxes, repair, check := inspectDoctorMailboxes(root, *fixMailboxesFlag)
+		mailboxes, repair, check := inspectDoctorMailboxes(root, baseRoot, *fixMailboxesFlag, *ignoreSessionPinFlag)
 		result.Mailboxes = mailboxes
 		result.MailboxRepair = repair
 		result.Checks = append(result.Checks, check)
@@ -117,8 +156,30 @@ func runDoctor(args []string) error {
 	// Ops checks (runtime health)
 	if *opsFlag && root != "" {
 		// Resolve root source once here; avoids re-resolving with empty flags in runOpsChecks.
-		_, source, _, _ := resolveEnvConfigWithSource("", "")
-		result.Ops = runOpsChecks(root, string(source), *fixWakeLocksFlag)
+		source := rootSourceFlag
+		if !rootExplicit {
+			_, source, _, _ = resolveEnvConfigWithSource("", "")
+		}
+		fixWakeLocks := *fixWakeLocksFlag
+		if fixWakeLocks && !*ignoreSessionPinFlag {
+			mismatch, pinErr := sessionPinMismatch(root)
+			if pinErr != nil {
+				result.Checks = append(result.Checks, doctorCheck{
+					Name:    "Wake lock repair",
+					Status:  "error",
+					Message: fmt.Sprintf("refusing to repair %s: invalid AMQ session context: %v", root, pinErr),
+				})
+				fixWakeLocks = false
+			} else if mismatch != nil && !isPinnedBaseRoot(root) {
+				result.Checks = append(result.Checks, doctorCheck{
+					Name:    "Wake lock repair",
+					Status:  "error",
+					Message: fmt.Sprintf("refusing to repair %s because it does not match the pinned session context: %s", root, mismatch.Message),
+				})
+				fixWakeLocks = false
+			}
+		}
+		result.Ops = runOpsChecks(root, string(source), fixWakeLocks, baseRoot)
 	}
 
 	// Calculate summary
@@ -262,6 +323,30 @@ func runDoctor(args []string) error {
 	return nil
 }
 
+func validateDoctorExplicitBaseRoot(root, baseRoot string) error {
+	if relateTrees(root, baseRoot) == TreeRelationSame {
+		return nil
+	}
+	if !isSessionRootUnderBase(root, baseRoot) {
+		return fmt.Errorf("explicit --root %s must be the base root or one direct child of --base-root %s", root, baseRoot)
+	}
+	baseIdentity, err := fsq.SnapshotDeliveryRoot(baseRoot)
+	if err != nil {
+		return fmt.Errorf("open explicit --base-root: %w", err)
+	}
+	baseCapability, err := fsq.OpenDeliveryRoot(baseRoot, baseIdentity)
+	if err != nil {
+		return fmt.Errorf("open explicit --base-root: %w", err)
+	}
+	defer func() { _ = baseCapability.Close() }()
+	child, err := baseCapability.OpenDirectChild(filepath.Base(resolveRoot(root)))
+	if err != nil {
+		return fmt.Errorf("open explicit --root under --base-root: %w", err)
+	}
+	defer func() { _ = child.Close() }()
+	return child.VerifyBase()
+}
+
 func checkSessionPinIdentity(root string) doctorCheck {
 	check := doctorCheck{Name: "Session identity pin"}
 	pin, err := loadSessionPin()
@@ -282,6 +367,11 @@ func checkSessionPinIdentity(root string) doctorCheck {
 		return check
 	}
 	if mismatch != nil {
+		if isPinnedBaseRoot(root) {
+			check.Status = "ok"
+			check.Message = "verified pinned base root"
+			return check
+		}
 		check.Status = "warn"
 		check.Message = mismatch.Error()
 		return check
@@ -382,15 +472,9 @@ func checkConfig(root string) doctorCheck {
 	return check
 }
 
-func inspectDoctorMailboxes(root string, repair bool) ([]fsq.MailboxInspection, *fsq.MailboxRepairResult, doctorCheck) {
+func inspectDoctorMailboxes(root, explicitBaseRoot string, repair, ignoreSessionPins bool) ([]fsq.MailboxInspection, *fsq.MailboxRepairResult, doctorCheck) {
 	check := doctorCheck{Name: "Mailboxes"}
-	identity, err := fsq.SnapshotDeliveryRoot(root)
-	if err != nil {
-		check.Status = "error"
-		check.Message = err.Error()
-		return nil, nil, check
-	}
-	if repair {
+	if repair && !ignoreSessionPins {
 		mismatch, pinErr := sessionPinMismatch(root)
 		if pinErr != nil {
 			check.Status = "error"
@@ -401,7 +485,7 @@ func inspectDoctorMailboxes(root string, repair bool) ([]fsq.MailboxInspection, 
 			)
 			return nil, nil, check
 		}
-		if mismatch != nil {
+		if mismatch != nil && !isPinnedBaseRoot(root) {
 			check.Status = "error"
 			check.Message = fmt.Sprintf(
 				"refusing to repair %s because it does not match the pinned session context: %s; re-run from the intended session",
@@ -411,36 +495,133 @@ func inspectDoctorMailboxes(root string, repair bool) ([]fsq.MailboxInspection, 
 			return nil, nil, check
 		}
 	}
-	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
-	if err != nil {
-		check.Status = "error"
-		check.Message = err.Error()
-		return nil, nil, check
-	}
-	defer func() { _ = deliveryRoot.Close() }()
 
-	var (
-		inventory fsq.MailboxInventory
-		result    *fsq.MailboxRepairResult
-	)
-	if repair {
-		repairResult := fsq.RepairMailboxLayout(deliveryRoot)
-		result = &repairResult
-		inventory = repairResult.Inventory
+	var deliveryRoot, explicitConfigRoot *fsq.DeliveryRoot
+	if explicitBaseRoot != "" {
+		baseIdentity, err := fsq.SnapshotDeliveryRoot(explicitBaseRoot)
+		if err != nil {
+			check.Status = "error"
+			check.Message = fmt.Sprintf("open explicit base root: %v", err)
+			return nil, nil, check
+		}
+		explicitConfigRoot, err = fsq.OpenDeliveryRoot(explicitBaseRoot, baseIdentity)
+		if err != nil {
+			check.Status = "error"
+			check.Message = fmt.Sprintf("open explicit base root: %v", err)
+			return nil, nil, check
+		}
+		defer func() { _ = explicitConfigRoot.Close() }()
+		if relateTrees(root, explicitBaseRoot) == TreeRelationSame {
+			deliveryRoot = explicitConfigRoot
+		} else {
+			if !isSessionRootUnderBase(root, explicitBaseRoot) {
+				check.Status = "error"
+				check.Message = fmt.Sprintf("explicit --root %s must be the base root or one direct child of --base-root %s", root, explicitBaseRoot)
+				return nil, nil, check
+			}
+			deliveryRoot, err = explicitConfigRoot.OpenDirectChild(filepath.Base(resolveRoot(root)))
+			if err != nil {
+				check.Status = "error"
+				check.Message = fmt.Sprintf("open explicit session root: %v", err)
+				return nil, nil, check
+			}
+			defer func() { _ = deliveryRoot.Close() }()
+		}
 	} else {
-		inventory, err = fsq.InspectMailboxLayout(deliveryRoot)
+		identity, err := fsq.SnapshotDeliveryRoot(root)
 		if err != nil {
 			check.Status = "error"
 			check.Message = err.Error()
 			return nil, nil, check
 		}
+		deliveryRoot, err = fsq.OpenDeliveryRoot(root, identity)
+		if err != nil {
+			check.Status = "error"
+			check.Message = err.Error()
+			return nil, nil, check
+		}
+		defer func() { _ = deliveryRoot.Close() }()
 	}
-	applyDoctorMailboxRemedies(&inventory)
-	check = checkMailboxInventory(inventory, result)
+
+	var (
+		inventory fsq.MailboxInventory
+		result    *fsq.MailboxRepairResult
+	)
+	configRoot := deliveryRoot
+	var baseConfigRoot *fsq.DeliveryRoot
+	repairBaseRoot := explicitBaseRoot
+	if explicitConfigRoot != nil {
+		configRoot = explicitConfigRoot
+	} else if _, configErr := deliveryRoot.ReadRegularNoFollow(filepath.Join("meta", "config.json")); os.IsNotExist(configErr) {
+		if base := classifyRoot(root); base != "" {
+			repairBaseRoot = base
+			baseIdentity, baseErr := fsq.SnapshotDeliveryRoot(base)
+			if baseErr != nil {
+				check.Status = "error"
+				check.Message = fmt.Sprintf("open base config root: %v", baseErr)
+				return nil, nil, check
+			}
+			baseConfigRoot, baseErr = fsq.OpenDeliveryRoot(base, baseIdentity)
+			if baseErr != nil {
+				check.Status = "error"
+				check.Message = fmt.Sprintf("open base config root: %v", baseErr)
+				return nil, nil, check
+			}
+			defer func() { _ = baseConfigRoot.Close() }()
+			configRoot = baseConfigRoot
+		}
+	}
+
+	authorization, authorizationInventory, authorizationErr := fsq.OpenMailboxConfigAuthorization(configRoot)
+	if authorizationErr != nil {
+		if repair {
+			repairResult := fsq.MailboxRepairResult{
+				Status: "failed",
+				Failure: &fsq.MailboxRepairFailure{
+					Code:    "preflight_failed",
+					Stage:   "authorization",
+					Message: authorizationInventory.ActiveConfigIssue,
+				},
+				Inventory: authorizationInventory,
+			}
+			result = &repairResult
+			inventory = repairResult.Inventory
+			repairCommand := doctorMailboxRepairCommandForOS(root, repairBaseRoot, runtime.GOOS)
+			applyDoctorMailboxRemedies(&inventory, repairCommand)
+			check = checkMailboxInventory(inventory, result, repairCommand)
+			return inventory.Mailboxes, result, check
+		}
+		check.Status = "error"
+		check.Message = authorizationInventory.ActiveConfigIssue
+		return nil, nil, check
+	}
+	defer func() { _ = authorization.Close() }()
+	effectiveAgents := withReservedHumanHandle(authorization.ConfiguredAgents())
+
+	if repair {
+		repairResult := fsq.RepairMailboxLayoutForConfiguredAgentsWithAuthorization(
+			deliveryRoot,
+			authorization,
+			effectiveAgents,
+		)
+		result = &repairResult
+		inventory = repairResult.Inventory
+	} else {
+		inspected, err := fsq.InspectMailboxLayoutWithAuthorization(deliveryRoot, authorization, effectiveAgents...)
+		if err != nil {
+			check.Status = "error"
+			check.Message = err.Error()
+			return nil, nil, check
+		}
+		inventory = inspected
+	}
+	repairCommand := doctorMailboxRepairCommandForOS(root, repairBaseRoot, runtime.GOOS)
+	applyDoctorMailboxRemedies(&inventory, repairCommand)
+	check = checkMailboxInventory(inventory, result, repairCommand)
 	return inventory.Mailboxes, result, check
 }
 
-func applyDoctorMailboxRemedies(inventory *fsq.MailboxInventory) {
+func applyDoctorMailboxRemedies(inventory *fsq.MailboxInventory, repairCommand string) {
 	for i := range inventory.Mailboxes {
 		mailbox := &inventory.Mailboxes[i]
 		if mailbox.Provenance != fsq.MailboxDiscovered || len(mailbox.Issues) == 0 {
@@ -454,14 +635,15 @@ func applyDoctorMailboxRemedies(inventory *fsq.MailboxInventory) {
 			continue
 		}
 		mailbox.Remedy = fmt.Sprintf(
-			"add %q to agents in meta/config.json, then run 'amq doctor --fix-mailboxes'; or preserve any messages and remove agents/%s if abandoned",
+			"add %q to agents in meta/config.json, then run %s; or preserve any messages and remove agents/%s if abandoned",
 			mailbox.Handle,
+			repairCommand,
 			mailbox.Handle,
 		)
 	}
 }
 
-func checkMailboxInventory(inventory fsq.MailboxInventory, repair *fsq.MailboxRepairResult) doctorCheck {
+func checkMailboxInventory(inventory fsq.MailboxInventory, repair *fsq.MailboxRepairResult, repairCommand string) doctorCheck {
 	check := doctorCheck{Name: "Mailboxes", Status: "ok"}
 	var issues []string
 	if inventory.ActiveConfigStatus != "ok" {
@@ -502,7 +684,7 @@ func checkMailboxInventory(inventory fsq.MailboxInventory, repair *fsq.MailboxRe
 	if repair == nil {
 		for _, mailbox := range inventory.Mailboxes {
 			if mailbox.RepairEligible {
-				check.Message += "; repair: amq doctor --fix-mailboxes"
+				check.Message += "; repair: " + repairCommand
 				break
 			}
 		}

--- a/internal/cli/doctor_mailboxes_test.go
+++ b/internal/cli/doctor_mailboxes_test.go
@@ -43,12 +43,226 @@ func TestDoctorIssue289ConfiguredOnlyMailboxIsReported(t *testing.T) {
 	}
 }
 
+func TestDoctorRepairIncludesReservedHumanMailboxOutsideRawRoster(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "alice")
+	if err := fsq.EnsureAgentDirs(root, reservedHumanHandle); err != nil {
+		t.Fatal(err)
+	}
+	missing := fsq.AgentDLQCur(root, reservedHumanHandle)
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	clearDoctorSessionPin(t)
+
+	mailboxes, repair, check := inspectDoctorMailboxes(root, "", true, false)
+
+	if check.Status != "ok" {
+		t.Fatalf("mailbox check = %#v", check)
+	}
+	if repair == nil || repair.Status != "repaired" {
+		t.Fatalf("repair = %#v", repair)
+	}
+	if _, err := os.Stat(missing); err != nil {
+		t.Fatalf("doctor did not repair reserved human mailbox: %v; mailboxes=%#v", err, mailboxes)
+	}
+}
+
+func TestDoctorMailboxRepairRemedyNeverAdvertisesPinOverride(t *testing.T) {
+	target := healthyDoctorMailboxRoot(t, "bob")
+	if err := os.Remove(fsq.AgentInboxCur(target, "bob")); err != nil {
+		t.Fatal(err)
+	}
+
+	setDoctorIdentityPin(t, target)
+	_, _, matchingCheck := inspectDoctorMailboxes(target, "", false, false)
+	if strings.Contains(matchingCheck.Message, "--ignore-session-pin") {
+		t.Fatalf("matching-pin remedy advertised escape hatch: %q", matchingCheck.Message)
+	}
+	wantMatching := doctorRootCommandForOS(target, "", runtime.GOOS, "--fix-mailboxes")
+	if !strings.Contains(matchingCheck.Message, wantMatching) {
+		t.Fatalf("matching-pin remedy missing exact command %q: %q", wantMatching, matchingCheck.Message)
+	}
+
+	foreignPin := healthyDoctorMailboxRoot(t, "alice")
+	setDoctorIdentityPin(t, foreignPin)
+	_, _, crossPinCheck := inspectDoctorMailboxes(target, "", false, false)
+	wantCrossPin := doctorRootCommandForOS(target, "", runtime.GOOS, "--fix-mailboxes")
+	if !strings.Contains(crossPinCheck.Message, wantCrossPin) {
+		t.Fatalf("cross-pin remedy missing exact non-bypass command %q: %q", wantCrossPin, crossPinCheck.Message)
+	}
+	if strings.Contains(crossPinCheck.Message, "--ignore-session-pin") {
+		t.Fatalf("cross-pin remedy advertised escape hatch: %q", crossPinCheck.Message)
+	}
+}
+
+func TestDoctorSessionLocalConfigRemedyExecutesWithoutConfiglessBase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exact printed command execution uses the POSIX test shell")
+	}
+	base := filepath.Join(secureTempDirForTest(t), ".agent-mail")
+	root := filepath.Join(base, "collab")
+	if err := fsq.EnsureRootDirs(base); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	configureSendTestRoot(t, root, "bob")
+	missing := fsq.AgentDLQCur(root, "bob")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	clearDoctorSessionPin(t)
+
+	_, _, check := inspectDoctorMailboxes(root, "", false, false)
+	command := advertisedDoctorMailboxRepairCommand(t, check)
+	if strings.Contains(command, "--base-root") {
+		t.Fatalf("session-local remedy named config-less parent: %q", command)
+	}
+	if strings.Contains(command, "--ignore-session-pin") {
+		t.Fatalf("session-local remedy advertised pin escape: %q", command)
+	}
+	executeAdvertisedAMQCommand(t, command)
+	if err := fsq.ValidateExistingMailboxLayout(openDeliveryRootForCLITest(t, root), "bob"); err != nil {
+		t.Fatalf("advertised doctor remedy left mailbox incomplete: %v", err)
+	}
+}
+
+func TestDoctorImplicitUserUsesEffectiveConfiguredRoster(t *testing.T) {
+	for _, authority := range []string{"session_local", "base"} {
+		for _, state := range []string{"absent", "incomplete"} {
+			t.Run(authority+"/"+state, func(t *testing.T) {
+				base := filepath.Join(secureTempDirForTest(t), ".agent-mail")
+				root := filepath.Join(base, "collab")
+				if err := fsq.EnsureRootDirs(base); err != nil {
+					t.Fatal(err)
+				}
+				if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+					t.Fatal(err)
+				}
+				configRoot := root
+				explicitBase := ""
+				if authority == "base" {
+					configRoot = base
+					explicitBase = base
+				}
+				configureSendTestRoot(t, configRoot, "alice")
+				if state == "incomplete" {
+					if err := fsq.EnsureAgentDirs(root, reservedHumanHandle); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Remove(fsq.AgentDLQCur(root, reservedHumanHandle)); err != nil {
+						t.Fatal(err)
+					}
+				}
+				clearDoctorSessionPin(t)
+
+				mailboxes, repair, check := inspectDoctorMailboxes(root, explicitBase, false, false)
+				if repair != nil {
+					t.Fatalf("inspection returned repair: %#v", repair)
+				}
+				user := findDoctorMailboxInspection(t, mailboxes, reservedHumanHandle)
+				wantProvenance := fsq.MailboxConfigured
+				if state == "incomplete" {
+					wantProvenance = fsq.MailboxConfiguredAndDiscovered
+				}
+				if user.Provenance != wantProvenance || !user.RepairEligible || user.Status != "error" {
+					t.Fatalf("implicit user inspection = %#v, want provenance=%s repairable error", user, wantProvenance)
+				}
+				if strings.Contains(user.Remedy, "add") || strings.Contains(check.Message, `add "user"`) {
+					t.Fatalf("implicit user was treated as unconfigured: entry=%#v check=%q", user, check.Message)
+				}
+
+				_, repaired, repairedCheck := inspectDoctorMailboxes(root, explicitBase, true, false)
+				if repaired == nil || repaired.Status != "repaired" || repairedCheck.Status != "ok" {
+					t.Fatalf("repair=%#v check=%#v", repaired, repairedCheck)
+				}
+				if err := fsq.ValidateExistingMailboxLayout(openDeliveryRootForCLITest(t, root), reservedHumanHandle); err != nil {
+					t.Fatalf("doctor did not repair implicit user: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestDoctorImplicitUserUsesPresentEmptyEffectiveRoster(t *testing.T) {
+	for _, authority := range []string{"session_local", "base"} {
+		for _, state := range []string{"absent", "incomplete"} {
+			t.Run(authority+"/"+state, func(t *testing.T) {
+				base := filepath.Join(secureTempDirForTest(t), ".agent-mail")
+				root := filepath.Join(base, "collab")
+				configRoot := root
+				explicitBase := ""
+				if authority == "base" {
+					configRoot = base
+					explicitBase = base
+				}
+				configureSendTestRoot(t, configRoot)
+				if err := fsq.EnsureRootDirs(root); err != nil {
+					t.Fatal(err)
+				}
+				if state == "incomplete" {
+					if err := fsq.EnsureAgentDirs(root, reservedHumanHandle); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Remove(fsq.AgentDLQCur(root, reservedHumanHandle)); err != nil {
+						t.Fatal(err)
+					}
+				}
+				clearDoctorSessionPin(t)
+
+				mailboxes, repair, check := inspectDoctorMailboxes(root, explicitBase, false, false)
+				if repair != nil {
+					t.Fatalf("inspection returned repair: %#v", repair)
+				}
+				user := findDoctorMailboxInspection(t, mailboxes, reservedHumanHandle)
+				wantProvenance := fsq.MailboxConfigured
+				if state == "incomplete" {
+					wantProvenance = fsq.MailboxConfiguredAndDiscovered
+				}
+				if user.Provenance != wantProvenance || !user.RepairEligible || user.Status != "error" {
+					t.Fatalf("empty-roster user inspection = %#v, want provenance=%s repairable error; check=%#v", user, wantProvenance, check)
+				}
+
+				_, repaired, repairedCheck := inspectDoctorMailboxes(root, explicitBase, true, false)
+				if repaired == nil || repaired.Status != "repaired" || repairedCheck.Status != "ok" {
+					t.Fatalf("repair=%#v check=%#v", repaired, repairedCheck)
+				}
+				if err := fsq.ValidateExistingMailboxLayout(openDeliveryRootForCLITest(t, root), reservedHumanHandle); err != nil {
+					t.Fatalf("doctor did not repair empty-roster user: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func advertisedDoctorMailboxRepairCommand(t *testing.T, check doctorCheck) string {
+	t.Helper()
+	const marker = "repair: "
+	parts := strings.SplitN(check.Message, marker, 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[1]) == "" {
+		t.Fatalf("doctor check has no repair command: %#v", check)
+	}
+	return strings.TrimSpace(strings.SplitN(parts[1], ";", 2)[0])
+}
+
+func findDoctorMailboxInspection(t *testing.T, mailboxes []fsq.MailboxInspection, handle string) fsq.MailboxInspection {
+	t.Helper()
+	for _, mailbox := range mailboxes {
+		if mailbox.Handle == handle {
+			return mailbox
+		}
+	}
+	t.Fatalf("mailbox %q not found in %#v", handle, mailboxes)
+	return fsq.MailboxInspection{}
+}
+
 func TestDoctorIssue289InspectionIgnoresMismatchedSessionPin(t *testing.T) {
 	root := healthyDoctorMailboxRoot(t, "healthy")
 	pinnedRoot := healthyDoctorMailboxRoot(t, "pinned")
 	setDoctorIdentityPin(t, pinnedRoot)
 
-	mailboxes, repair, check := inspectDoctorMailboxes(root, false)
+	mailboxes, repair, check := inspectDoctorMailboxes(root, "", false, false)
 
 	if check.Status != "ok" {
 		t.Fatalf("mailbox check = %#v", check)
@@ -56,7 +270,9 @@ func TestDoctorIssue289InspectionIgnoresMismatchedSessionPin(t *testing.T) {
 	if repair != nil {
 		t.Fatalf("inspection returned repair result: %#v", repair)
 	}
-	if len(mailboxes) != 1 || mailboxes[0].Handle != "healthy" {
+	if len(mailboxes) != 2 ||
+		findDoctorMailboxInspection(t, mailboxes, "healthy").Status != "ok" ||
+		findDoctorMailboxInspection(t, mailboxes, reservedHumanHandle).Status != "ok" {
 		t.Fatalf("mailboxes = %#v", mailboxes)
 	}
 }
@@ -65,7 +281,7 @@ func TestDoctorIssue289InspectionWithoutSessionPinFailsOpen(t *testing.T) {
 	root := healthyDoctorMailboxRoot(t, "healthy")
 	clearDoctorSessionPin(t)
 
-	mailboxes, repair, check := inspectDoctorMailboxes(root, false)
+	mailboxes, repair, check := inspectDoctorMailboxes(root, "", false, false)
 
 	if check.Status != "ok" {
 		t.Fatalf("mailbox check = %#v", check)
@@ -73,7 +289,9 @@ func TestDoctorIssue289InspectionWithoutSessionPinFailsOpen(t *testing.T) {
 	if repair != nil {
 		t.Fatalf("inspection returned repair result: %#v", repair)
 	}
-	if len(mailboxes) != 1 || mailboxes[0].Handle != "healthy" {
+	if len(mailboxes) != 2 ||
+		findDoctorMailboxInspection(t, mailboxes, "healthy").Status != "ok" ||
+		findDoctorMailboxInspection(t, mailboxes, reservedHumanHandle).Status != "ok" {
 		t.Fatalf("mailboxes = %#v", mailboxes)
 	}
 }
@@ -91,7 +309,9 @@ func TestDoctorIssue289RunDoctorInspectsOutsidePopulatedSessionPin(t *testing.T)
 	if got := doctorCheckStatus(result.Checks, "Session identity pin"); got != "warn" {
 		t.Fatalf("Session identity pin status = %q, want warn", got)
 	}
-	if len(result.Mailboxes) != 1 || result.Mailboxes[0].Handle != "healthy" {
+	if len(result.Mailboxes) != 2 ||
+		findDoctorMailboxTestEntry(t, result.Mailboxes, "healthy").Status != "ok" ||
+		findDoctorMailboxTestEntry(t, result.Mailboxes, reservedHumanHandle).Status != "ok" {
 		t.Fatalf("mailboxes = %#v", result.Mailboxes)
 	}
 }
@@ -104,7 +324,7 @@ func TestDoctorIssue289RepairRefusesMismatchedSessionPinWithRemedy(t *testing.T)
 		t.Fatal(err)
 	}
 
-	_, repair, check := inspectDoctorMailboxes(root, true)
+	_, repair, check := inspectDoctorMailboxes(root, "", true, false)
 
 	if repair != nil {
 		t.Fatalf("refused repair returned result: %#v", repair)
@@ -116,6 +336,212 @@ func TestDoctorIssue289RepairRefusesMismatchedSessionPinWithRemedy(t *testing.T)
 	}
 	if _, err := os.Stat(fsq.AgentInboxCur(root, "healthy")); !os.IsNotExist(err) {
 		t.Fatalf("refused repair mutated missing directory: %v", err)
+	}
+}
+
+func TestDoctorExplicitRootRepairRequiresPinMatchOrOverride(t *testing.T) {
+	baseRoot := filepath.Join(secureTempDirForTest(t), "custom base")
+	sessionRoot := filepath.Join(baseRoot, "collab")
+	if err := fsq.EnsureAgentDirs(sessionRoot, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureRootDirs(baseRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(filepath.Join(baseRoot, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"bob"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	missing := fsq.AgentDLQCur(sessionRoot, "bob")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	unrelated := healthyDoctorMailboxRoot(t, "source")
+	setDoctorIdentityPin(t, unrelated)
+	t.Setenv(envRoot, unrelated)
+	t.Setenv(envSession, "source-session")
+
+	inspectionOutput, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{
+			"--root", sessionRoot,
+			"--base-root", baseRoot,
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("explicit doctor inspection: %v", err)
+	}
+	var inspection doctorMailboxResultJSON
+	if err := json.Unmarshal([]byte(inspectionOutput), &inspection); err != nil {
+		t.Fatal(err)
+	}
+	if got := doctorCheckStatus(inspection.Checks, "Session identity pin"); got != "warn" {
+		t.Fatalf("explicit inspection pin status = %q, want warn", got)
+	}
+	if _, err := os.Lstat(missing); !os.IsNotExist(err) {
+		t.Fatalf("explicit inspection mutated mailbox: %v", err)
+	}
+
+	refusedOutput, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{
+			"--root", sessionRoot,
+			"--base-root", baseRoot,
+			"--fix-mailboxes",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("mismatched repair command: %v", err)
+	}
+	var refused doctorMailboxResultJSON
+	if err := json.Unmarshal([]byte(refusedOutput), &refused); err != nil {
+		t.Fatal(err)
+	}
+	refusedCheck := findDoctorCheck(t, refused.Checks, "Mailboxes")
+	if refused.MailboxRepair != nil || refusedCheck.Status != "error" ||
+		!strings.Contains(refusedCheck.Message, "pinned session context") {
+		t.Fatalf("mismatched repair was not refused: repair=%#v check=%#v", refused.MailboxRepair, refusedCheck)
+	}
+	if _, err := os.Lstat(missing); !os.IsNotExist(err) {
+		t.Fatalf("mismatched explicit repair mutated mailbox: %v", err)
+	}
+
+	overrideOutput, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{
+			"--root", sessionRoot,
+			"--base-root", baseRoot,
+			"--ignore-session-pin",
+			"--fix-mailboxes",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("explicit override repair: %v", err)
+	}
+	var repaired doctorMailboxResultJSON
+	if err := json.Unmarshal([]byte(overrideOutput), &repaired); err != nil {
+		t.Fatal(err)
+	}
+	if repaired.MailboxRepair == nil || repaired.MailboxRepair.Status != "repaired" {
+		t.Fatalf("override repair = %#v checks=%#v", repaired.MailboxRepair, repaired.Checks)
+	}
+	if err := fsq.ValidateExistingMailboxLayout(openDeliveryRootForCLITest(t, sessionRoot), "bob"); err != nil {
+		t.Fatalf("override doctor repair left mailbox incomplete: %v", err)
+	}
+}
+
+func TestDoctorExplicitBaseRequiresRootAndDirectRelationship(t *testing.T) {
+	baseRoot := healthyDoctorMailboxRoot(t, "bob")
+	if err := runDoctor([]string{"--base-root", baseRoot, "--fix-mailboxes"}); err == nil ||
+		!strings.Contains(err.Error(), "--base-root requires an explicit --root") {
+		t.Fatalf("base without root error = %v", err)
+	}
+	if err := runDoctor([]string{"--ignore-session-pin", "--fix-mailboxes"}); err == nil ||
+		!strings.Contains(err.Error(), "--ignore-session-pin requires an explicit --root") {
+		t.Fatalf("pin override without root error = %v", err)
+	}
+	if err := runDoctor([]string{"--root=", "--ignore-session-pin", "--fix-mailboxes"}); err == nil ||
+		!strings.Contains(err.Error(), "--root cannot be empty") {
+		t.Fatalf("pin override with blank root error = %v", err)
+	}
+
+	outsideRoot := healthyDoctorMailboxRoot(t, "bob")
+	missing := fsq.AgentInboxCur(outsideRoot, "bob")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	err := runDoctor([]string{
+		"--root", outsideRoot,
+		"--base-root", baseRoot,
+		"--fix-mailboxes",
+		"--json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "one direct child") {
+		t.Fatalf("outside base error = %v", err)
+	}
+	if _, err := os.Lstat(missing); !os.IsNotExist(err) {
+		t.Fatalf("outside-base refusal mutated mailbox: %v", err)
+	}
+}
+
+func TestDoctorExplicitPinnedBaseRepairIsAuthorized(t *testing.T) {
+	baseRoot := filepath.Join(secureTempDirForTest(t), ".agent-mail")
+	sessionRoot := filepath.Join(baseRoot, "collab")
+	configureSendTestRoot(t, baseRoot, "alice", "bob")
+	if err := fsq.EnsureAgentDirs(sessionRoot, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(baseRoot, "agents", "bob")); err != nil {
+		t.Fatal(err)
+	}
+	pinSendSessionForTest(t, baseRoot, sessionRoot, "collab")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{
+			"--root", baseRoot,
+			"--fix-mailboxes",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result doctorMailboxResultJSON
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.MailboxRepair == nil || result.MailboxRepair.Status != "repaired" {
+		t.Fatalf("pinned base repair = %#v checks=%#v", result.MailboxRepair, result.Checks)
+	}
+	if err := fsq.ValidateExistingMailboxLayout(openDeliveryRootForCLITest(t, baseRoot), "bob"); err != nil {
+		t.Fatalf("pinned base repair left mailbox incomplete: %v", err)
+	}
+}
+
+func TestDoctorOpsUsesExplicitBaseConfigAuthority(t *testing.T) {
+	baseRoot := filepath.Join(secureTempDirForTest(t), "custom base")
+	sessionRoot := filepath.Join(baseRoot, "collab")
+	configureSendTestRoot(t, baseRoot, "bob")
+	if err := fsq.EnsureAgentDirs(sessionRoot, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(sessionRoot, reservedHumanHandle); err != nil {
+		t.Fatal(err)
+	}
+	clearDoctorSessionPin(t)
+
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{
+			"--root", sessionRoot,
+			"--base-root", baseRoot,
+			"--ops",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result doctorMailboxResultJSON
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Ops == nil || len(result.Ops.Agents) != 1 || result.Ops.Agents[0].Handle != "bob" {
+		t.Fatalf("explicit-base ops = %#v", result.Ops)
+	}
+	mailbox := findDoctorMailboxTestEntry(t, result.Mailboxes, "bob")
+	if mailbox.Provenance != "configured_and_discovered" || mailbox.Status != "ok" ||
+		len(mailbox.Issues) != 0 || mailbox.Remedy != "" {
+		t.Fatalf("explicit-base mailbox classification = %#v", mailbox)
+	}
+	if check := findDoctorCheck(t, result.Checks, "Mailboxes"); check.Status != "ok" {
+		t.Fatalf("explicit-base mailbox check = %#v", check)
+	}
+	for _, hint := range result.Ops.Hints {
+		if hint.Code == "config_error" {
+			t.Fatalf("explicit-base ops emitted config error: %#v", hint)
+		}
 	}
 }
 
@@ -142,10 +568,13 @@ func TestDoctorIssue289DiscoveredOnlyMailboxIsNotRepairEligible(t *testing.T) {
 	if orphan.Provenance != "discovered" || orphan.Status != "warn" || orphan.RepairEligible {
 		t.Fatalf("discovered-only mailbox = %#v", orphan)
 	}
-	for _, want := range []string{"meta/config.json", "amq doctor --fix-mailboxes", "agents/orphan", "preserve"} {
+	for _, want := range []string{"meta/config.json", "amq doctor --root", "--fix-mailboxes", "agents/orphan", "preserve"} {
 		if !strings.Contains(orphan.Remedy, want) {
 			t.Fatalf("orphan remedy missing %q: %q", want, orphan.Remedy)
 		}
+	}
+	if strings.Contains(orphan.Remedy, "--ignore-session-pin") {
+		t.Fatalf("unpinned orphan remedy advertised escape hatch: %q", orphan.Remedy)
 	}
 }
 
@@ -161,9 +590,11 @@ func TestDoctorDiscoveredOnlyMailboxKeepsRemedyAfterConfiguredRepair(t *testing.
 	result := runDoctorMailboxJSONArgs(t, root, "--fix-mailboxes", "--json")
 
 	if result.MailboxRepair == nil ||
-		len(result.MailboxRepair.CreatedPaths) != 1 ||
-		result.MailboxRepair.CreatedPaths[0] != "agents/claude/inbox/cur" {
+		!doctorMailboxContains(result.MailboxRepair.CreatedPaths, "agents/claude/inbox/cur") {
 		t.Fatalf("repair = %#v", result.MailboxRepair)
+	}
+	if doctorMailboxContains(result.MailboxRepair.CreatedPaths, "agents/orphan/inbox") {
+		t.Fatalf("repair completed discovered-only orphan: %#v", result.MailboxRepair.CreatedPaths)
 	}
 	orphan := findDoctorMailboxTestEntry(t, result.Mailboxes, "orphan")
 	if orphan.Status != "warn" || orphan.RepairEligible || orphan.Remedy == "" {
@@ -211,8 +642,8 @@ func TestDoctorIssue289RepairCreatesOnlyMissingDirsAndIsIdempotent(t *testing.T)
 		}
 		t.Fatalf("repair = %#v failure=%#v", first.MailboxRepair, failure)
 	}
-	if len(first.MailboxRepair.CreatedPaths) != 1 ||
-		first.MailboxRepair.CreatedPaths[0] != "agents/legacy/inbox/cur" {
+	if !doctorMailboxContains(first.MailboxRepair.CreatedPaths, "agents/legacy/inbox/cur") ||
+		!doctorMailboxContains(first.MailboxRepair.CreatedPaths, "agents/user/receipts") {
 		t.Fatalf("created_paths = %#v", first.MailboxRepair.CreatedPaths)
 	}
 	after, err := os.Stat(messagePath)
@@ -315,6 +746,9 @@ func healthyDoctorMailboxRoot(t *testing.T, handle string) string {
 		t.Fatal(err)
 	}
 	if err := fsq.EnsureAgentDirs(root, handle); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, reservedHumanHandle); err != nil {
 		t.Fatal(err)
 	}
 	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -85,9 +86,7 @@ type opsWakeLock struct {
 	RepairReason    string `json:"repair_reason,omitempty"`
 }
 
-const fixWakeLocksCommand = "amq doctor --ops --fix-wake-locks"
-
-func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsResult {
+func runOpsChecks(root string, rootSource string, fixWakeLocks bool, explicitBaseRoot ...string) *doctorOpsResult {
 	result := &doctorOpsResult{}
 	now := time.Now()
 
@@ -100,7 +99,7 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 
 	// Load the active root's config, falling back to the base config for normal
 	// session layouts where coop init owns the single config.json.
-	agents, err := loadOpsAgents(root, fixWakeLocks)
+	agents, err := loadOpsAgents(root, fixWakeLocks, explicitBaseRoot...)
 	if err != nil {
 		result.Hints = append(result.Hints, opsHint{
 			Code:    "config_error",
@@ -216,7 +215,14 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool) *doctorOpsR
 	return result
 }
 
-func loadOpsAgents(root string, fixWakeLocks bool) ([]string, error) {
+func loadOpsAgents(root string, fixWakeLocks bool, explicitBaseRoot ...string) ([]string, error) {
+	if len(explicitBaseRoot) > 0 && strings.TrimSpace(explicitBaseRoot[0]) != "" {
+		cfg, err := config.LoadConfig(filepath.Join(explicitBaseRoot[0], "meta", "config.json"))
+		if err != nil {
+			return nil, err
+		}
+		return cfg.Agents, nil
+	}
 	cfg, err := config.LoadConfig(filepath.Join(root, "meta", "config.json"))
 	if err == nil {
 		return cfg.Agents, nil
@@ -382,7 +388,7 @@ func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeL
 				locks = append(locks, lock)
 				continue
 			}
-			lock.Fix = fixWakeLocksCommand
+			lock.Fix = doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
 			if lock.TargetPresent && lock.TargetReason == "" && validateWakeLockRepairable(inspection) == nil {
 				if err := validateWakeRepairFloorAvailable(root, agent, inspection, target); err != nil {
 					lock.RepairReason = err.Error()

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -299,8 +300,12 @@ func TestRunOpsChecks_ReportsAndFixesStaleWakeLockWithoutConfig(t *testing.T) {
 	if got.Agent != "alice" {
 		t.Fatalf("agent = %q, want alice", got.Agent)
 	}
-	if got.Fix != fixWakeLocksCommand {
-		t.Fatalf("fix = %q, want %q", got.Fix, fixWakeLocksCommand)
+	wantFix := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
+	if got.Fix != wantFix {
+		t.Fatalf("fix = %q, want %q", got.Fix, wantFix)
+	}
+	if strings.Contains(got.Fix, "--ignore-session-pin") {
+		t.Fatalf("fix advice bypasses session pin: %q", got.Fix)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("lock should not be removed without fix flag: %v", err)
@@ -329,6 +334,167 @@ func TestRunOpsChecks_ReportsAndFixesStaleWakeLockWithoutConfig(t *testing.T) {
 	}
 	if !foundConfigError {
 		t.Fatalf("expected config_error hint, got: %+v", result.Hints)
+	}
+}
+
+func TestDoctorStaleWakeLockFixAdviceRespectsSessionPin(t *testing.T) {
+	tests := []struct {
+		name         string
+		configurePin func(t *testing.T, root string)
+		wantRemoved  bool
+	}{
+		{
+			name: "unpinned",
+			configurePin: func(t *testing.T, _ string) {
+				clearDoctorSessionPin(t)
+			},
+			wantRemoved: true,
+		},
+		{
+			name: "matching pin",
+			configurePin: func(t *testing.T, root string) {
+				setDoctorIdentityPin(t, root)
+				t.Setenv(envRoot, root)
+			},
+			wantRemoved: true,
+		},
+		{
+			name: "cross pin",
+			configurePin: func(t *testing.T, _ string) {
+				pinnedRoot := healthyDoctorMailboxRoot(t, "source")
+				setDoctorIdentityPin(t, pinnedRoot)
+				t.Setenv(envRoot, pinnedRoot)
+			},
+			wantRemoved: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := healthyDoctorMailboxRoot(t, "alice")
+			lockPath := writeWakeLockForTest(t, root, "alice", wakeLock{
+				PID:        999999999,
+				Executable: "/opt/homebrew/bin/amq",
+			})
+			test.configurePin(t, root)
+
+			result := runOpsChecks(root, "test_source", false)
+			if len(result.WakeLocks) != 1 {
+				t.Fatalf("wake lock count = %d, want 1", len(result.WakeLocks))
+			}
+			wantFix := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
+			if got := result.WakeLocks[0].Fix; got != wantFix {
+				t.Fatalf("fix = %q, want %q", got, wantFix)
+			}
+			if strings.Contains(result.WakeLocks[0].Fix, "--ignore-session-pin") {
+				t.Fatalf("fix advice bypasses session pin: %q", result.WakeLocks[0].Fix)
+			}
+
+			output, err := captureEnvStdout(t, func() error {
+				return runDoctor([]string{
+					"--root", root,
+					"--ops",
+					"--fix-wake-locks",
+					"--json",
+				})
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var doctor doctorMailboxResultJSON
+			if err := json.Unmarshal([]byte(output), &doctor); err != nil {
+				t.Fatal(err)
+			}
+
+			_, statErr := os.Stat(lockPath)
+			if test.wantRemoved {
+				if !os.IsNotExist(statErr) {
+					t.Fatalf("generated fix command did not remove stale lock: %v", statErr)
+				}
+				return
+			}
+			if statErr != nil {
+				t.Fatalf("cross-pin generated fix command changed stale lock: %v", statErr)
+			}
+			check := findDoctorCheck(t, doctor.Checks, "Wake lock repair")
+			if check.Status != "error" || !strings.Contains(check.Message, "pinned session context") {
+				t.Fatalf("cross-pin authority check = %#v", check)
+			}
+		})
+	}
+}
+
+func TestDoctorExplicitRootWakeRepairRequiresPinMatchOrOverride(t *testing.T) {
+	pinnedRoot := healthyDoctorMailboxRoot(t, "source")
+	foreignRoot := healthyDoctorMailboxRoot(t, "alice")
+	lockPath := writeWakeLockForTest(t, foreignRoot, "alice", wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	setDoctorIdentityPin(t, pinnedRoot)
+	t.Setenv(envRoot, pinnedRoot)
+
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{
+			"--root", foreignRoot,
+			"--ops",
+			"--fix-wake-locks",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var refused doctorMailboxResultJSON
+	if err := json.Unmarshal([]byte(output), &refused); err != nil {
+		t.Fatal(err)
+	}
+	check := findDoctorCheck(t, refused.Checks, "Wake lock repair")
+	if check.Status != "error" || !strings.Contains(check.Message, "pinned session context") {
+		t.Fatalf("wake repair authority check = %#v", check)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("mismatched doctor removed wake lock: %v", err)
+	}
+
+	if _, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{
+			"--root", foreignRoot,
+			"--ignore-session-pin",
+			"--ops",
+			"--fix-wake-locks",
+			"--json",
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("explicit wake repair override did not remove lock: %v", err)
+	}
+}
+
+func TestDoctorInvalidBaseRootPreflightPreventsWakeRepair(t *testing.T) {
+	targetRoot := healthyDoctorMailboxRoot(t, "alice")
+	unrelatedBase := healthyDoctorMailboxRoot(t, "alice")
+	lockPath := writeWakeLockForTest(t, targetRoot, "alice", wakeLock{
+		PID:        999999999,
+		Executable: "/opt/homebrew/bin/amq",
+	})
+	clearDoctorSessionPin(t)
+
+	err := runDoctor([]string{
+		"--root", targetRoot,
+		"--base-root", unrelatedBase,
+		"--ignore-session-pin",
+		"--ops",
+		"--fix-wake-locks",
+		"--json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "one direct child") {
+		t.Fatalf("invalid base relationship error = %v", err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("invalid base relationship mutated wake lock: %v", err)
 	}
 }
 
@@ -388,8 +554,12 @@ func TestRunOpsChecks_ReportsStaleWakeLock(t *testing.T) {
 	if got.Reason != "pid not running" {
 		t.Fatalf("reason = %q, want pid not running", got.Reason)
 	}
-	if got.Fix != fixWakeLocksCommand {
-		t.Fatalf("fix = %q, want %q", got.Fix, fixWakeLocksCommand)
+	wantFix := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
+	if got.Fix != wantFix {
+		t.Fatalf("fix = %q, want %q", got.Fix, wantFix)
+	}
+	if strings.Contains(got.Fix, "--ignore-session-pin") {
+		t.Fatalf("fix advice bypasses session pin: %q", got.Fix)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("lock should not be removed without fix flag: %v", err)

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/presence"
 	"github.com/avivsinai/agent-message-queue/internal/receipt"
 )
+
+var deliverToExistingInbox = fsq.DeliverToExistingInbox
 
 func runSend(args []string) error {
 	fs := flag.NewFlagSet("send", flag.ContinueOnError)
@@ -111,6 +114,7 @@ func runSend(args []string) error {
 
 	// Determine delivery root: local, cross-session, or cross-project.
 	deliveryRoot := root
+	peerBaseRoot := ""
 	targetSession := strings.TrimSpace(*sessionFlag)
 	// Inline session from @project:session takes effect only when not overridden.
 	if targetSession == "" && inlineSession != "" {
@@ -193,7 +197,7 @@ func runSend(args []string) error {
 	}
 	if targetProject != "" {
 		// Cross-project delivery.
-		peerBaseRoot, err := resolvePeer(root, targetProject)
+		peerBaseRoot, err = resolvePeer(root, targetProject)
 		if err != nil {
 			return err
 		}
@@ -283,39 +287,115 @@ func runSend(args []string) error {
 		}
 		defer func() { _ = sourceFS.Close() }()
 	}
+	configFS := deliveryFS
+	sharedConfig := false
+	peerConfigBaseRoot := ""
+	configAuthorityBaseRoot := ""
+	configBase := ""
+	switch {
+	case targetProject != "":
+		configBase = peerBaseRoot
+	case fromSession != "":
+		configBase = root
+	case pin.Present && pin.Session != "" && !*ignoreSessionPinFlag:
+		configBase = pin.BaseRoot
+	}
+	if configBase != "" && filepath.Clean(configBase) != filepath.Clean(deliveryRoot) {
+		configIdentity, err := fsq.SnapshotDeliveryRoot(configBase)
+		if err != nil {
+			return err
+		}
+		if targetProject == "" && pin.IdentityPin && verifyTreeIdentityInfo(configIdentity.FileInfo(), pin.BaseRootID) != TreeRelationSame {
+			return ContextMismatchError("authorized base root identity changed before config capability open")
+		}
+		baseConfigFS, err := fsq.OpenDeliveryRoot(configBase, configIdentity)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = baseConfigFS.Close() }()
+		if _, configErr := baseConfigFS.ReadRegularNoFollow(filepath.Join("meta", "config.json")); configErr == nil {
+			configFS = baseConfigFS
+			sharedConfig = true
+			if targetProject != "" {
+				peerConfigBaseRoot = peerBaseRoot
+			}
+		} else if os.IsNotExist(configErr) {
+			configFS = deliveryFS
+		} else {
+			configFS = baseConfigFS
+			sharedConfig = true
+			if targetProject != "" {
+				peerConfigBaseRoot = peerBaseRoot
+			}
+		}
+	}
+	if sharedConfig {
+		configAuthorityBaseRoot = configBase
+	}
+	var mailboxAuthorization *fsq.MailboxConfigAuthorization
+	if targetProject == "" {
+		var inventory fsq.MailboxInventory
+		mailboxAuthorization, inventory, err = fsq.OpenMailboxConfigAuthorization(configFS)
+		if err != nil {
+			return sendMailboxAuthorizationError(deliveryRoot, inventory)
+		}
+		defer func() { _ = mailboxAuthorization.Close() }()
+	}
 
 	if fromSession != "" && !deliveryAgentExists(sourceFS, me) {
 		return fmt.Errorf("agent %q not found in source session %q", me, fromSession)
 	}
+	peerRecipientConfigured := false
+	peerConfigPresent := false
 	if targetProject != "" {
+		peerAgents, configPresent, peerAgentsErr := loadPeerAgentsForSend(configFS, common.Strict)
+		if err := validateKnownHandlesFromAgents(peerAgents, peerAgentsErr, common.Strict, recipients...); err != nil {
+			return err
+		}
+		peerConfigPresent = configPresent
+		peerRecipientConfigured = handleConfigured(peerAgents, recipients[0])
 		for _, recipient := range recipients {
-			if deliveryInboxExists(deliveryFS, recipient) {
+			layoutErr := fsq.ValidateExistingMailboxLayout(deliveryFS, recipient)
+			if layoutErr == nil {
 				continue
 			}
-			if targetSession != "" {
-				return fmt.Errorf("agent %q not found in peer %q session %q", recipient, targetProject, targetSession)
-			}
-			return fmt.Errorf("agent %q not found in peer %q", recipient, targetProject)
+			return peerMailboxIncompleteError(
+				targetProject,
+				targetSession,
+				recipient,
+				layoutErr,
+				deliveryRoot,
+				peerConfigBaseRoot,
+				peerRecipientConfigured,
+			)
 		}
 	}
 
 	// Validate sender in source root and recipients in target root through the
 	// same capabilities that will perform delivery.
 	if targetProject != "" || targetSession != "" {
-		if err := validateKnownHandlesDeliveryRoot(sourceFS, common.Strict, me); err != nil {
+		var sourceAgents []string
+		var sourceAgentsErr error
+		if targetProject == "" && sharedConfig {
+			sourceAgents = withReservedHumanHandle(mailboxAuthorization.ConfiguredAgents())
+		} else if targetProject == "" {
+			sourceAgents, sourceAgentsErr = loadKnownAgentsDeliveryRoot(sourceFS, common.Strict)
+		} else {
+			sourceAgents, sourceAgentsErr = loadKnownAgentsDeliveryRoot(sourceFS, common.Strict)
+		}
+		if err := validateKnownHandlesFromAgents(sourceAgents, sourceAgentsErr, common.Strict, me); err != nil {
 			return err
 		}
-		if err := validateKnownHandlesDeliveryRoot(deliveryFS, common.Strict, recipients...); err != nil {
-			return err
+		if targetProject == "" {
+			targetAgents := withReservedHumanHandle(mailboxAuthorization.ConfiguredAgents())
+			if err := validateKnownHandlesFromAgents(targetAgents, nil, common.Strict, recipients...); err != nil {
+				return err
+			}
 		}
 	} else {
 		allHandles := append([]string{me}, recipients...)
-		if err := validateKnownHandlesDeliveryRoot(deliveryFS, common.Strict, allHandles...); err != nil {
-			return err
-		}
-	}
-	if targetProject == "" {
-		if err := prepareLocalSendMailboxes(deliveryFS, deliveryRoot, recipients); err != nil {
+		agents := withReservedHumanHandle(mailboxAuthorization.ConfiguredAgents())
+		if err := validateKnownHandlesFromAgents(agents, nil, common.Strict, allHandles...); err != nil {
 			return err
 		}
 	}
@@ -432,12 +512,43 @@ func runSend(args []string) error {
 	if err != nil {
 		return err
 	}
+	if targetProject == "" {
+		if err := prepareLocalSendMailboxes(deliveryFS, mailboxAuthorization, deliveryRoot, recipients); err != nil {
+			return err
+		}
+		if err := mailboxAuthorization.Verify(); err != nil {
+			return fmt.Errorf("destination mailbox authorization changed before delivery: %w", err)
+		}
+	}
 
 	filename := id + ".md"
 	if targetProject != "" {
+		currentPeerAgents, currentPeerAgentsErr := revalidatePeerAgentsForSend(configFS, peerConfigPresent, common.Strict)
+		if err := validateKnownHandlesFromAgents(currentPeerAgents, currentPeerAgentsErr, common.Strict, recipients...); err != nil {
+			return err
+		}
 		// Cross-project: use DeliverToExistingInbox (never creates dirs in peer).
 		for _, r := range recipients {
-			if _, err := fsq.DeliverToExistingInbox(deliveryFS, r, filename, data); err != nil {
+			if _, err := deliverToExistingInbox(deliveryFS, r, filename, data); err != nil {
+				var committed *fsq.CommittedDurabilityError
+				if errors.As(err, &committed) {
+					return reportDeliveryError(id, err)
+				}
+				if layoutErr := fsq.ValidateExistingMailboxLayout(deliveryFS, r); layoutErr != nil {
+					currentPeerAgents, currentPeerAgentsErr := revalidatePeerAgentsForSend(configFS, peerConfigPresent, common.Strict)
+					if rosterErr := validateKnownHandlesFromAgents(currentPeerAgents, currentPeerAgentsErr, common.Strict, r); rosterErr != nil {
+						return rosterErr
+					}
+					return peerMailboxIncompleteError(
+						targetProject,
+						targetSession,
+						r,
+						layoutErr,
+						deliveryRoot,
+						peerConfigBaseRoot,
+						handleConfigured(currentPeerAgents, r),
+					)
+				}
 				return reportDeliveryError(id, err)
 			}
 		}
@@ -477,7 +588,8 @@ func runSend(args []string) error {
 		r, err := receipt.WaitForDeliveryRoot(deliveryFS, id, consumer, waitFor, *waitTimeoutFlag, 1*time.Second)
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			waitResult = &waitForResult{Event: "timeout", Stage: waitFor, Timeout: waitTimeoutFlag.String()}
-			waitErr = TimeoutError("send --wait-for %s timed out after %s (delivery session %s, root %s); run 'amq doctor --ops' to diagnose mailbox divergence", waitFor, *waitTimeoutFlag, targetDisplay, deliveryRoot)
+			diagnosticCommand := doctorRootCommandForOS(deliveryRoot, configAuthorityBaseRoot, runtime.GOOS, "--ops")
+			waitErr = TimeoutError("send --wait-for %s timed out after %s (delivery session %s, root %s); run %s to diagnose mailbox divergence", waitFor, *waitTimeoutFlag, targetDisplay, deliveryRoot, diagnosticCommand)
 		} else if err != nil {
 			waitResult = &waitForResult{Event: "error", Stage: waitFor, Detail: err.Error()}
 			waitErr = fmt.Errorf("send --wait-for: %w", err)
@@ -542,6 +654,106 @@ func runSend(args []string) error {
 		}
 	}
 	return nil
+}
+
+func loadPeerAgentsForSend(root *fsq.DeliveryRoot, strict bool) ([]string, bool, error) {
+	configPresent := true
+	agents, err := loadKnownAgentsWithRead(strict, func() ([]byte, error) {
+		data, readErr := root.ReadRegularNoFollow(filepath.Join("meta", "config.json"))
+		if os.IsNotExist(readErr) {
+			configPresent = false
+		}
+		return data, readErr
+	})
+	return agents, configPresent, err
+}
+
+func revalidatePeerAgentsForSend(root *fsq.DeliveryRoot, configInitiallyPresent, strict bool) ([]string, error) {
+	agents, configPresent, err := loadPeerAgentsForSend(root, strict)
+	if err != nil {
+		return nil, err
+	}
+	if !configInitiallyPresent || configPresent {
+		return agents, nil
+	}
+	const transition = "selected peer config.json disappeared after initial validation"
+	if strict {
+		return nil, errors.New(transition)
+	}
+	_ = writeStderr("warning: %s\n", transition)
+	return agents, nil
+}
+
+func handleConfigured(agents []string, handle string) bool {
+	for _, configured := range agents {
+		if configured == handle {
+			return true
+		}
+	}
+	return false
+}
+
+func peerMailboxIncompleteError(project, session, recipient string, layoutErr error, root, baseRoot string, configured bool) error {
+	peerContext := fmt.Sprintf("peer %q", project)
+	if session != "" {
+		peerContext += fmt.Sprintf(" session %q", session)
+	}
+	command := peerMailboxRepairCommandForOS(root, baseRoot, runtime.GOOS)
+	runInstruction := "run"
+	if runtime.GOOS == "windows" {
+		runInstruction = "run in PowerShell"
+	}
+	if !configured {
+		configRoot := baseRoot
+		if configRoot == "" {
+			configRoot = root
+		}
+		return fmt.Errorf(
+			"%s mailbox for %q is incomplete: %w; add %q to agents in peer config %s, then %s: %s",
+			peerContext,
+			recipient,
+			layoutErr,
+			recipient,
+			filepath.Join(configRoot, "meta", "config.json"),
+			runInstruction,
+			command,
+		)
+	}
+	return fmt.Errorf(
+		"%s mailbox for %q is incomplete: %w; ask the peer owner to %s: %s",
+		peerContext,
+		recipient,
+		layoutErr,
+		runInstruction,
+		command,
+	)
+}
+
+func peerMailboxRepairCommandForOS(root, baseRoot, goos string) string {
+	return doctorMailboxRepairCommandForOS(root, baseRoot, goos)
+}
+
+func doctorMailboxRepairCommandForOS(root, baseRoot, goos string) string {
+	return doctorRootCommandForOS(root, baseRoot, goos, "--fix-mailboxes")
+}
+
+func doctorRootCommandForOS(root, baseRoot, goos string, trailingArgs ...string) string {
+	quote := shellQuoteArg
+	if goos == "windows" {
+		quote = quotePowerShellCommandArg
+	}
+	command := "amq doctor --root " + quote(root)
+	if baseRoot != "" && filepath.Clean(baseRoot) != filepath.Clean(root) {
+		command += " --base-root " + quote(baseRoot)
+	}
+	for _, arg := range trailingArgs {
+		command += " " + arg
+	}
+	return command
+}
+
+func quotePowerShellCommandArg(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 type waitForResult struct {

--- a/internal/cli/send_delivery_root_unix_test.go
+++ b/internal/cli/send_delivery_root_unix_test.go
@@ -3,6 +3,9 @@
 package cli
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
@@ -101,6 +105,494 @@ func TestSendRejectsSymlinkSwapAfterGuard(t *testing.T) {
 		t.Fatalf("ReadDir original inbox: %v", err)
 	} else if len(entries) != 0 {
 		t.Fatalf("refused send wrote %d message(s) into moved authorized root", len(entries))
+	}
+}
+
+func TestSendStrictConfigReplacementBeforeRepairDoesNotCreateOrDeliver(t *testing.T) {
+	root := initializedSendMailboxRoot(t, "alice", "bob")
+	missing := fsq.AgentDLQCur(root, "bob")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(root, "meta", "config.json")
+	bodyFIFO := filepath.Join(secureTempDirForTest(t), "strict-body.fifo")
+	if err := syscall.Mkfifo(bodyFIFO, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	type openResult struct {
+		file *os.File
+		err  error
+	}
+	writerCh := make(chan openResult, 1)
+	go func() {
+		file, err := os.OpenFile(bodyFIFO, os.O_WRONLY, 0)
+		writerCh <- openResult{file: file, err: err}
+	}()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runSend([]string{
+			"--root", root,
+			"--me", "alice",
+			"--to", "bob",
+			"--strict",
+			"--body", "@" + bodyFIFO,
+		})
+	}()
+
+	var writer *os.File
+	select {
+	case result := <-writerCh:
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		writer = result.file
+	case err := <-errCh:
+		t.Fatalf("send returned before body read: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("send did not reach body read after strict validation")
+	}
+	original := configPath + ".original"
+	if err := os.Rename(configPath, original); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"version":1,"agents":["alice"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write([]byte("must not deliver")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "config") {
+			t.Fatalf("send error = %v, want retained-config refusal", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("send did not return")
+	}
+	if _, err := os.Lstat(missing); !os.IsNotExist(err) {
+		t.Fatalf("strict send repaired after roster removal: %v", err)
+	}
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, "bob"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("strict send delivered after roster removal: %#v", entries)
+	}
+}
+
+func TestCrossProjectSendReportsRepairWhenMailboxBecomesIncompleteAtDelivery(t *testing.T) {
+	clearDeliveryRootTestEnv(t)
+	srcProjectDir := secureTempDirForTest(t)
+	srcRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+	peerBase := filepath.Join(secureTempDirForTest(t), "peer base")
+	peerRoot := filepath.Join(peerBase, "collab")
+	if err := fsq.EnsureAgentDirs(srcRoot, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(peerRoot, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	configureSendTestRoot(t, peerBase, "bob")
+	rcData, err := json.Marshal(map[string]any{
+		"root":    ".agent-mail",
+		"project": "source",
+		"peers":   map[string]string{"peer": peerBase},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcProjectDir, ".amqrc"), rcData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bodyFIFO := filepath.Join(secureTempDirForTest(t), "peer-body.fifo")
+	if err := syscall.Mkfifo(bodyFIFO, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	type openResult struct {
+		file *os.File
+		err  error
+	}
+	writerCh := make(chan openResult, 1)
+	go func() {
+		file, err := os.OpenFile(bodyFIFO, os.O_WRONLY, 0)
+		writerCh <- openResult{file: file, err: err}
+	}()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runSend([]string{
+			"--root", srcRoot,
+			"--me", "alice",
+			"--to", "bob",
+			"--project", "peer",
+			"--body", "@" + bodyFIFO,
+		})
+	}()
+
+	var writer *os.File
+	select {
+	case result := <-writerCh:
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		writer = result.file
+	case err := <-errCh:
+		t.Fatalf("send returned before body read: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("send did not reach body read after peer validation")
+	}
+	if err := config.WriteConfig(filepath.Join(peerBase, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"carol"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+	missing := fsq.AgentDLQCur(peerRoot, "bob")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write([]byte("must not deliver")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case sendErr := <-errCh:
+		if sendErr == nil {
+			t.Fatal("send succeeded after peer mailbox became incomplete")
+		}
+		for _, want := range []string{"incomplete", "missing:dlq/cur", `add "bob"`, "peer config", "--root", "--base-root", "--fix-mailboxes"} {
+			if !strings.Contains(sendErr.Error(), want) {
+				t.Fatalf("delivery-time peer error missing %q: %v", want, sendErr)
+			}
+		}
+		if err := config.WriteConfig(filepath.Join(peerBase, "meta", "config.json"), config.Config{
+			Version: 1,
+			Agents:  []string{"bob"},
+		}, true); err != nil {
+			t.Fatal(err)
+		}
+		executeAdvertisedAMQCommand(t, advertisedPeerRepairCommand(t, sendErr))
+		if err := fsq.ValidateExistingMailboxLayout(openDeliveryRootForCLITest(t, peerRoot), "bob"); err != nil {
+			t.Fatalf("delivery-time advertised remedy left mailbox incomplete: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("send did not return")
+	}
+	if entries, err := os.ReadDir(fsq.AgentInboxNew(peerRoot, "bob")); err != nil || len(entries) != 0 {
+		t.Fatalf("incomplete peer received message: entries=%#v err=%v", entries, err)
+	}
+}
+
+func TestCrossProjectSendRevalidatesRosterAfterBlockingBodyRead(t *testing.T) {
+	for _, strict := range []bool{true, false} {
+		t.Run(map[bool]string{true: "strict_refuses", false: "non_strict_warns"}[strict], func(t *testing.T) {
+			clearDeliveryRootTestEnv(t)
+			srcProjectDir := secureTempDirForTest(t)
+			srcRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+			peerBase := filepath.Join(secureTempDirForTest(t), "peer")
+			peerRoot := filepath.Join(peerBase, "collab")
+			if err := fsq.EnsureAgentDirs(srcRoot, "alice"); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(peerRoot, "bob"); err != nil {
+				t.Fatal(err)
+			}
+			configureSendTestRoot(t, peerBase, "bob")
+			rcData, err := json.Marshal(map[string]any{
+				"root":    ".agent-mail",
+				"project": "source",
+				"peers":   map[string]string{"peer": peerBase},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(srcProjectDir, ".amqrc"), rcData, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			bodyFIFO := filepath.Join(secureTempDirForTest(t), "peer-roster-body.fifo")
+			if err := syscall.Mkfifo(bodyFIFO, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			type openResult struct {
+				file *os.File
+				err  error
+			}
+			writerCh := make(chan openResult, 1)
+			go func() {
+				file, err := os.OpenFile(bodyFIFO, os.O_WRONLY, 0)
+				writerCh <- openResult{file: file, err: err}
+			}()
+
+			oldStderr := os.Stderr
+			stderrReader, stderrWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stderr = stderrWriter
+			t.Cleanup(func() { os.Stderr = oldStderr })
+
+			args := []string{
+				"--root", srcRoot,
+				"--me", "alice",
+				"--to", "bob",
+				"--project", "peer",
+				"--body", "@" + bodyFIFO,
+			}
+			if strict {
+				args = append(args, "--strict")
+			}
+			errCh := make(chan error, 1)
+			go func() { errCh <- runSend(args) }()
+
+			var writer *os.File
+			select {
+			case result := <-writerCh:
+				if result.err != nil {
+					t.Fatal(result.err)
+				}
+				writer = result.file
+			case sendErr := <-errCh:
+				t.Fatalf("send returned before body read: %v", sendErr)
+			case <-time.After(2 * time.Second):
+				t.Fatal("send did not reach body read after peer roster validation")
+			}
+			if err := config.WriteConfig(filepath.Join(peerBase, "meta", "config.json"), config.Config{
+				Version: 1,
+				Agents:  []string{"carol"},
+			}, true); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := writer.Write([]byte("fresh roster required")); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			sendErr := <-errCh
+			_ = stderrWriter.Close()
+			os.Stderr = oldStderr
+			stderr, readErr := io.ReadAll(stderrReader)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			entries, readErr := os.ReadDir(fsq.AgentInboxNew(peerRoot, "bob"))
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if strict {
+				if sendErr == nil || !strings.Contains(sendErr.Error(), `handle "bob" not in config.json`) {
+					t.Fatalf("strict send error = %v, want fresh roster refusal", sendErr)
+				}
+				if len(entries) != 0 {
+					t.Fatalf("strict send delivered after roster removal: %#v", entries)
+				}
+			} else {
+				if sendErr != nil {
+					t.Fatalf("non-strict send failed: %v", sendErr)
+				}
+				if !strings.Contains(string(stderr), `warning: handle "bob" not in config.json`) {
+					t.Fatalf("non-strict stderr = %q, want fresh roster warning", stderr)
+				}
+				if len(entries) != 1 {
+					t.Fatalf("non-strict send delivered %d messages, want 1", len(entries))
+				}
+			}
+		})
+	}
+}
+
+func TestCrossProjectSendRevalidatesDisappearedConfigAfterBlockingBodyRead(t *testing.T) {
+	for _, strict := range []bool{true, false} {
+		t.Run(map[bool]string{true: "strict_refuses", false: "non_strict_warns"}[strict], func(t *testing.T) {
+			clearDeliveryRootTestEnv(t)
+			srcProjectDir := secureTempDirForTest(t)
+			srcRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+			peerBase := filepath.Join(secureTempDirForTest(t), "peer")
+			peerRoot := filepath.Join(peerBase, "collab")
+			if err := fsq.EnsureAgentDirs(srcRoot, "alice"); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(peerRoot, "bob"); err != nil {
+				t.Fatal(err)
+			}
+			configureSendTestRoot(t, peerBase, "bob")
+			rcData, err := json.Marshal(map[string]any{
+				"root":    ".agent-mail",
+				"project": "source",
+				"peers":   map[string]string{"peer": peerBase},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(srcProjectDir, ".amqrc"), rcData, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			bodyFIFO := filepath.Join(secureTempDirForTest(t), "peer-config-removal-body.fifo")
+			if err := syscall.Mkfifo(bodyFIFO, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			type openResult struct {
+				file *os.File
+				err  error
+			}
+			writerCh := make(chan openResult, 1)
+			go func() {
+				file, err := os.OpenFile(bodyFIFO, os.O_WRONLY, 0)
+				writerCh <- openResult{file: file, err: err}
+			}()
+
+			oldStderr := os.Stderr
+			stderrReader, stderrWriter, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stderr = stderrWriter
+			t.Cleanup(func() { os.Stderr = oldStderr })
+
+			args := []string{
+				"--root", srcRoot,
+				"--me", "alice",
+				"--to", "bob",
+				"--project", "peer",
+				"--body", "@" + bodyFIFO,
+			}
+			if strict {
+				args = append(args, "--strict")
+			}
+			errCh := make(chan error, 1)
+			go func() { errCh <- runSend(args) }()
+
+			var writer *os.File
+			select {
+			case result := <-writerCh:
+				if result.err != nil {
+					t.Fatal(result.err)
+				}
+				writer = result.file
+			case sendErr := <-errCh:
+				t.Fatalf("send returned before body read: %v", sendErr)
+			case <-time.After(2 * time.Second):
+				t.Fatal("send did not reach body read after peer roster validation")
+			}
+			configPath := filepath.Join(peerBase, "meta", "config.json")
+			if err := os.Rename(configPath, configPath+".removed"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := writer.Write([]byte("fresh config authority required")); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			sendErr := <-errCh
+			_ = stderrWriter.Close()
+			os.Stderr = oldStderr
+			stderr, readErr := io.ReadAll(stderrReader)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			entries, readErr := os.ReadDir(fsq.AgentInboxNew(peerRoot, "bob"))
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			const transition = "selected peer config.json disappeared after initial validation"
+			if strict {
+				if sendErr == nil || !strings.Contains(sendErr.Error(), transition) {
+					t.Fatalf("strict send error = %v, want disappeared-config refusal", sendErr)
+				}
+				if len(entries) != 0 {
+					t.Fatalf("strict send delivered after selected config disappeared: %#v", entries)
+				}
+			} else {
+				if sendErr != nil {
+					t.Fatalf("non-strict send failed: %v", sendErr)
+				}
+				if !strings.Contains(string(stderr), "warning: "+transition) {
+					t.Fatalf("non-strict stderr = %q, want fresh disappeared-config warning", stderr)
+				}
+				if len(entries) != 1 {
+					t.Fatalf("non-strict send delivered %d messages, want 1", len(entries))
+				}
+			}
+		})
+	}
+}
+
+func TestCrossProjectSendPreservesCommittedDeliveryWhenLayoutAlsoChanges(t *testing.T) {
+	clearDeliveryRootTestEnv(t)
+	srcProjectDir := secureTempDirForTest(t)
+	srcRoot := filepath.Join(srcProjectDir, ".agent-mail", "collab")
+	peerBase := filepath.Join(secureTempDirForTest(t), "peer")
+	peerRoot := filepath.Join(peerBase, "collab")
+	if err := fsq.EnsureAgentDirs(srcRoot, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(peerRoot, "bob"); err != nil {
+		t.Fatal(err)
+	}
+	configureSendTestRoot(t, peerBase, "bob")
+	rcData, err := json.Marshal(map[string]any{
+		"root":    ".agent-mail",
+		"project": "source",
+		"peers":   map[string]string{"peer": peerBase},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcProjectDir, ".amqrc"), rcData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalDeliver := deliverToExistingInbox
+	deliverToExistingInbox = func(root *fsq.DeliveryRoot, agent, filename string, data []byte) (string, error) {
+		path, deliverErr := originalDeliver(root, agent, filename, data)
+		if deliverErr != nil {
+			return path, deliverErr
+		}
+		if removeErr := os.Remove(fsq.AgentDLQCur(peerRoot, agent)); removeErr != nil {
+			return path, removeErr
+		}
+		return path, &fsq.CommittedDurabilityError{
+			FinalPath: path,
+			Recipient: agent,
+			Err:       errors.New("injected post-rename directory sync failure"),
+		}
+	}
+	t.Cleanup(func() { deliverToExistingInbox = originalDeliver })
+
+	sendErr := runSend([]string{
+		"--root", srcRoot,
+		"--me", "alice",
+		"--to", "bob",
+		"--project", "peer",
+		"--body", "already visible",
+	})
+	if sendErr == nil {
+		t.Fatal("send error = nil, want committed durability warning")
+	}
+	var committed *fsq.CommittedDurabilityError
+	if !errors.As(sendErr, &committed) {
+		t.Fatalf("send error lost committed classification after layout change: %T %v", sendErr, sendErr)
+	}
+	if !strings.Contains(sendErr.Error(), "retrying may duplicate") {
+		t.Fatalf("send error = %v, want explicit duplicate warning", sendErr)
+	}
+	entries, readErr := os.ReadDir(fsq.AgentInboxNew(peerRoot, "bob"))
+	if readErr != nil || len(entries) != 1 {
+		t.Fatalf("committed inbox state = %#v, err=%v", entries, readErr)
 	}
 }
 

--- a/internal/cli/send_mailbox.go
+++ b/internal/cli/send_mailbox.go
@@ -6,75 +6,30 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-func prepareLocalSendMailboxes(root *fsq.DeliveryRoot, displayRoot string, recipients []string) error {
-	inventory, err := fsq.InspectMailboxLayout(root)
-	if err != nil {
-		return fmt.Errorf("inspect destination mailbox layout: %w", err)
-	}
-	if inventory.ActiveConfigStatus != "ok" {
-		if inventory.ActiveConfigStatus == string(fsq.MailboxPathMissing) {
-			return NotFoundError(
-				"AMQ root %s is not initialized (%s); run 'amq init --root %s --agents <agents>' or 'amq coop init --root %s'",
-				displayRoot,
-				inventory.ActiveConfigIssue,
-				displayRoot,
-				displayRoot,
-			)
-		}
-		return fmt.Errorf(
-			"cannot prepare destination mailbox layout at %s: active config %s (%s)",
-			displayRoot,
-			inventory.ActiveConfigStatus,
-			inventory.ActiveConfigIssue,
-		)
-	}
-
-	configured := make(map[string]bool, len(inventory.ConfiguredAgents))
-	for _, handle := range inventory.ConfiguredAgents {
-		configured[handle] = true
-	}
-	status := make(map[string]string, len(inventory.Mailboxes))
-	for _, mailbox := range inventory.Mailboxes {
-		status[mailbox.Handle] = mailbox.Status
-	}
-
-	repairConfigured := false
-	additional := make([]string, 0, len(recipients))
-	for _, recipient := range recipients {
-		if configured[recipient] {
-			if status[recipient] != "ok" {
-				repairConfigured = true
-			}
-			continue
-		}
-		additional = append(additional, recipient)
-	}
-
-	if repairConfigured {
-		if result := fsq.RepairMailboxLayout(root); result.Status != "repaired" {
-			return sendMailboxRepairError(displayRoot, result)
-		}
-	}
-	if len(additional) > 0 {
-		if result := fsq.RepairMailboxLayoutForAgents(root, additional); result.Status != "repaired" {
-			return sendMailboxRepairError(displayRoot, result)
-		}
-	}
-
-	verified, err := fsq.InspectMailboxLayout(root)
-	if err != nil {
-		return fmt.Errorf("verify destination mailbox layout: %w", err)
-	}
-	verifiedStatus := make(map[string]string, len(verified.Mailboxes))
-	for _, mailbox := range verified.Mailboxes {
-		verifiedStatus[mailbox.Handle] = mailbox.Status
-	}
-	for _, recipient := range recipients {
-		if verifiedStatus[recipient] != "ok" {
-			return fmt.Errorf("destination mailbox for %q is incomplete at root %s", recipient, displayRoot)
-		}
+func prepareLocalSendMailboxes(root *fsq.DeliveryRoot, authorization *fsq.MailboxConfigAuthorization, displayRoot string, recipients []string) error {
+	result := fsq.RepairMailboxLayoutForAgentsWithAuthorization(root, authorization, recipients)
+	if result.Status != "repaired" {
+		return sendMailboxRepairError(displayRoot, result)
 	}
 	return nil
+}
+
+func sendMailboxAuthorizationError(displayRoot string, inventory fsq.MailboxInventory) error {
+	if inventory.ActiveConfigStatus == string(fsq.MailboxPathMissing) {
+		return NotFoundError(
+			"AMQ root %s is not initialized (%s); run 'amq init --root %s --agents <agents>' or 'amq coop init --root %s'",
+			displayRoot,
+			inventory.ActiveConfigIssue,
+			displayRoot,
+			displayRoot,
+		)
+	}
+	return fmt.Errorf(
+		"cannot authorize destination mailbox layout at %s: active config %s (%s)",
+		displayRoot,
+		inventory.ActiveConfigStatus,
+		inventory.ActiveConfigIssue,
+	)
 }
 
 func sendMailboxRepairError(displayRoot string, result fsq.MailboxRepairResult) error {

--- a/internal/cli/send_mailbox_test.go
+++ b/internal/cli/send_mailbox_test.go
@@ -108,6 +108,26 @@ func TestSendStrictUnknownDestinationDoesNotCreateMailbox(t *testing.T) {
 	}
 }
 
+func TestSendStrictPresentEmptyConfigStillValidatesEffectiveRoster(t *testing.T) {
+	root := initializedSendMailboxRoot(t)
+
+	_, _, err := captureEnvOutput(t, func() error {
+		return runSend([]string{
+			"--root", root,
+			"--me", reservedHumanHandle,
+			"--to", "typo",
+			"--strict",
+			"--body", "hello",
+		})
+	})
+	if err == nil || !strings.Contains(err.Error(), `handle "typo" not in config.json`) {
+		t.Fatalf("strict empty-config send error = %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(root, "agents", "typo")); !os.IsNotExist(statErr) {
+		t.Fatalf("strict empty-config send created typo mailbox: %v", statErr)
+	}
+}
+
 func TestSendRefusesUninitializedRootWithoutWriting(t *testing.T) {
 	root := t.TempDir()
 	clearSendMailboxTestEnv(t)
@@ -214,6 +234,214 @@ func TestSendUnknownMailboxRepairRefusesSymlinkWithoutDelivery(t *testing.T) {
 	if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
 		t.Fatalf("repair changed symlink: info=%v err=%v", info, statErr)
 	}
+}
+
+func TestSendRepairsBaseOnlyCoopMailboxAcrossSessionRoutes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args func(base string) []string
+		pin  bool
+	}{
+		{
+			name: "same session",
+			args: func(string) []string {
+				return []string{"--me", "alice", "--to", "bob", "--body", "same"}
+			},
+			pin: true,
+		},
+		{
+			name: "target session",
+			args: func(string) []string {
+				return []string{"--me", "alice", "--to", "bob", "--session", "qa", "--body", "target"}
+			},
+			pin: true,
+		},
+		{
+			name: "from session",
+			args: func(base string) []string {
+				return []string{"--root", base, "--from-session", "collab", "--me", "alice", "--to", "bob", "--session", "qa", "--body", "from"}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearSendMailboxTestEnv(t)
+			base := filepath.Join(t.TempDir(), ".agent-mail")
+			source := filepath.Join(base, "collab")
+			target := source
+			if tc.name != "same session" {
+				target = filepath.Join(base, "qa")
+			}
+			configureSendTestRoot(t, base, "alice", "bob")
+			configPath := filepath.Join(base, "meta", "config.json")
+			configBefore, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, root := range dedupeStrings([]string{source, target}) {
+				if err := fsq.EnsureRootDirs(root); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := fsq.EnsureAgentDirs(source, "alice"); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(target, "bob"); err != nil {
+				t.Fatal(err)
+			}
+			missing := fsq.AgentDLQCur(target, "bob")
+			if err := os.Remove(missing); err != nil {
+				t.Fatal(err)
+			}
+			if tc.pin {
+				pinSendSessionForTest(t, base, source, "collab")
+			}
+
+			if _, _, err := captureEnvOutput(t, func() error {
+				return runSend(tc.args(base))
+			}); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+			assertCompleteSendMailbox(t, target, "bob")
+			if _, err := os.Lstat(filepath.Join(target, "meta", "config.json")); !os.IsNotExist(err) {
+				t.Fatalf("send copied config into session: %v", err)
+			}
+			configAfter, err := os.ReadFile(configPath)
+			if err != nil || string(configAfter) != string(configBefore) {
+				t.Fatalf("send changed base config: err=%v before=%q after=%q", err, configBefore, configAfter)
+			}
+			entries, err := os.ReadDir(fsq.AgentInboxNew(target, "bob"))
+			if err != nil || len(entries) != 1 {
+				t.Fatalf("delivered entries = %d, err=%v", len(entries), err)
+			}
+		})
+	}
+}
+
+func TestSendInvalidMessageDoesNotRepairMailbox(t *testing.T) {
+	root := initializedSendMailboxRoot(t, "alice", "bob")
+	missing := fsq.AgentDLQCur(root, "bob")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := captureEnvOutput(t, func() error {
+		return runSend([]string{
+			"--root", root,
+			"--me", "alice",
+			"--to", "bob",
+			"--priority", "not-a-priority",
+			"--body", "invalid",
+		})
+	})
+	if err == nil {
+		t.Fatal("invalid send succeeded")
+	}
+	if _, statErr := os.Lstat(missing); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid send repaired mailbox: %v", statErr)
+	}
+}
+
+func TestSendBaseOnlyCoopConfigPreservesUnknownHandleModes(t *testing.T) {
+	clearSendMailboxTestEnv(t)
+	base := filepath.Join(t.TempDir(), ".agent-mail")
+	session := filepath.Join(base, "collab")
+	configureSendTestRoot(t, base, "alice", "bob")
+	if err := fsq.EnsureAgentDirs(session, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	pinSendSessionForTest(t, base, session, "collab")
+
+	_, _, err := captureEnvOutput(t, func() error {
+		return runSend([]string{"--me", "alice", "--to", "typo", "--strict", "--body", "strict"})
+	})
+	if err == nil || !strings.Contains(err.Error(), `handle "typo" not in config.json`) {
+		t.Fatalf("strict base-config error = %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(session, "agents", "typo")); !os.IsNotExist(statErr) {
+		t.Fatalf("strict base-config send created mailbox: %v", statErr)
+	}
+
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runSend([]string{"--me", "alice", "--to", "typo", "--body", "warn"})
+	})
+	if err != nil {
+		t.Fatalf("non-strict base-config send: %v", err)
+	}
+	if !strings.Contains(stderr, `warning: handle "typo" not in config.json`) {
+		t.Fatalf("non-strict warning changed: %q", stderr)
+	}
+	assertCompleteSendMailbox(t, session, "typo")
+}
+
+func TestSendRepairsOnlyRequestedRecipients(t *testing.T) {
+	root := initializedSendMailboxRoot(t, "alice", "bob", "carol")
+	bobMissing := fsq.AgentDLQCur(root, "bob")
+	carolMissing := fsq.AgentDLQCur(root, "carol")
+	for _, path := range []string{bobMissing, carolMissing} {
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, _, err := captureEnvOutput(t, func() error {
+		return runSend([]string{"--root", root, "--me", "alice", "--to", "bob", "--body", "targeted"})
+	}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if info, err := os.Stat(bobMissing); err != nil || !info.IsDir() {
+		t.Fatalf("requested mailbox was not repaired: info=%v err=%v", info, err)
+	}
+	if _, err := os.Lstat(carolMissing); !os.IsNotExist(err) {
+		t.Fatalf("unrequested mailbox was repaired: %v", err)
+	}
+}
+
+func TestSendMixedRecipientRepairPreflightsAsOneTransaction(t *testing.T) {
+	root := initializedSendMailboxRoot(t, "alice", "bob")
+	bobMissing := fsq.AgentDLQCur(root, "bob")
+	if err := os.Remove(bobMissing); err != nil {
+		t.Fatal(err)
+	}
+	carolInbox := filepath.Join(root, "agents", "carol", "inbox")
+	if err := os.MkdirAll(filepath.Dir(carolInbox), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(carolInbox, []byte("unsafe"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := captureEnvOutput(t, func() error {
+		return runSend([]string{
+			"--root", root,
+			"--me", "alice",
+			"--to", "bob,carol,bob",
+			"--thread", "transactional",
+			"--body", "must not partially repair",
+		})
+	})
+	if err == nil {
+		t.Fatal("mixed unsafe send succeeded")
+	}
+	if _, statErr := os.Lstat(bobMissing); !os.IsNotExist(statErr) {
+		t.Fatalf("failed transaction repaired safe recipient first: %v", statErr)
+	}
+}
+
+func pinSendSessionForTest(t *testing.T, base, root, session string) {
+	t.Helper()
+	baseID, err := resolveTreeIdentityToken(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootID, err := resolveTreeIdentityToken(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envBaseRoot, base)
+	t.Setenv(envRoot, root)
+	t.Setenv(envSession, session)
+	t.Setenv(envBaseRootID, baseID)
+	t.Setenv(envRootID, rootID)
 }
 
 func initializedSendMailboxRoot(t *testing.T, agents ...string) string {

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -128,11 +129,55 @@ func TestSendWaitTimeoutNamesDeliveryContextAndDoctor(t *testing.T) {
 	if err == nil || GetExitCode(err) != ExitTimeout {
 		t.Fatalf("send wait should time out, got %v", err)
 	}
-	for _, want := range []string{root, "collab", "amq doctor --ops"} {
+	for _, want := range []string{root, "collab", "amq doctor --root", "--ops"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("timeout hint missing %q: %v", want, err)
 		}
 	}
+}
+
+func TestSendWaitTimeoutUsesSessionLocalConfigAuthority(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exact printed command execution uses the POSIX test shell")
+	}
+	base := filepath.Join(secureTempDirForTest(t), ".agent-mail")
+	root := filepath.Join(base, "collab")
+	if err := fsq.EnsureRootDirs(base); err != nil {
+		t.Fatal(err)
+	}
+	for _, agent := range []string{"alice", "bob"} {
+		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+			t.Fatal(err)
+		}
+	}
+	configureSendTestRoot(t, root, "alice", "bob")
+	pinSendSessionForTest(t, base, root, "collab")
+
+	_, _, err := captureEnvOutput(t, func() error {
+		return runSend([]string{
+			"--me", "alice",
+			"--to", "bob",
+			"--body", "timeout hint uses effective authority",
+			"--wait-for", "drained",
+			"--wait-timeout", "1ms",
+		})
+	})
+	if err == nil || GetExitCode(err) != ExitTimeout {
+		t.Fatalf("send wait should time out, got %v", err)
+	}
+	const prefix = "; run "
+	_, commandAndSuffix, ok := strings.Cut(err.Error(), prefix)
+	if !ok {
+		t.Fatalf("timeout error has no diagnostic command: %v", err)
+	}
+	command, _, ok := strings.Cut(commandAndSuffix, " to diagnose mailbox divergence")
+	if !ok || strings.TrimSpace(command) == "" {
+		t.Fatalf("timeout error has malformed diagnostic command: %v", err)
+	}
+	if strings.Contains(command, "--base-root") {
+		t.Fatalf("session-local diagnostic forced config-less base authority: %q", command)
+	}
+	executeAdvertisedAMQCommand(t, command)
 }
 
 func TestReply_RejectsPositionalArgs(t *testing.T) {

--- a/internal/cli/session_context.go
+++ b/internal/cli/session_context.go
@@ -154,6 +154,10 @@ func isExplicitOwnBaseRootInspection(common *commonFlags, target string) bool {
 	if common == nil || !common.rootExplicit() {
 		return false
 	}
+	return isPinnedBaseRoot(target)
+}
+
+func isPinnedBaseRoot(target string) bool {
 	pin, err := loadSessionPin()
 	if err != nil || !pin.Present {
 		return false

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -153,6 +153,51 @@ func (r *DeliveryRoot) OpenOrCreateDirectChild(name string, perm os.FileMode) (*
 	}, nil
 }
 
+// OpenDirectChild pins one existing direct, non-symlink child directory beneath
+// the authorized root without creating it.
+func (r *DeliveryRoot) OpenDirectChild(name string) (*DeliveryRoot, error) {
+	if r == nil || r.root == nil {
+		return nil, fmt.Errorf("delivery root is closed")
+	}
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+		return nil, fmt.Errorf("invalid direct child name %q", name)
+	}
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+	before, err := r.root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if !before.IsDir() || before.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%q is not a direct directory under delivery root", name)
+	}
+	childRoot, err := r.root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	opened, err := childRoot.Stat(".")
+	if err != nil {
+		_ = childRoot.Close()
+		return nil, err
+	}
+	after, err := r.root.Lstat(name)
+	if err != nil {
+		_ = childRoot.Close()
+		return nil, err
+	}
+	if !after.IsDir() || after.Mode()&os.ModeSymlink != 0 ||
+		!os.SameFile(before, after) || !os.SameFile(after, opened) {
+		_ = childRoot.Close()
+		return nil, fmt.Errorf("direct child %q changed while opening", name)
+	}
+	return &DeliveryRoot{
+		base:     filepath.Join(r.base, name),
+		root:     childRoot,
+		identity: opened,
+	}, nil
+}
+
 // EnsureRootDirs creates the queue-level layout through the pinned root
 // capability.
 func (r *DeliveryRoot) EnsureRootDirs() error {

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -1,9 +1,11 @@
 package fsq
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -200,6 +202,20 @@ type mailboxActiveConfig struct {
 	Agents []string `json:"agents"`
 }
 
+type mailboxConfigPin struct {
+	root *DeliveryRoot
+	file *os.File
+	info os.FileInfo
+	data []byte
+	cfg  mailboxActiveConfig
+}
+
+// MailboxConfigAuthorization retains the exact config descriptor and content
+// used to authorize mailbox repair. Callers must close it.
+type MailboxConfigAuthorization struct {
+	pin *mailboxConfigPin
+}
+
 type mailboxLayoutNode struct {
 	state MailboxPathState
 	mode  os.FileMode
@@ -212,8 +228,9 @@ type mailboxLayoutPlan struct {
 }
 
 type mailboxRepairHooks struct {
-	afterPreflight func()
-	fail           func(stage, path string) error
+	afterPreflight       func()
+	afterFinalInspection func()
+	fail                 func(stage, path string) error
 }
 
 var errLayoutIdentityChanged = errors.New("layout component changed during inspection")
@@ -299,6 +316,125 @@ func readActiveMailboxConfig(root *layoutDirCapability) (mailboxActiveConfig, st
 	return cfg, "ok", ""
 }
 
+func pinActiveMailboxConfig(root *DeliveryRoot) (*mailboxConfigPin, string, string) {
+	const configPath = "meta/config.json"
+	file, info, err := root.OpenRegularNoFollow(configPath)
+	if err != nil {
+		state := MailboxPathUnreadable
+		if errors.Is(err, fs.ErrNotExist) {
+			state = MailboxPathMissing
+		}
+		issue := mailboxIssue(state, configPath)
+		if state != MailboxPathMissing {
+			issue += ":" + err.Error()
+		}
+		return nil, string(state), issue
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		_ = file.Close()
+		return nil, string(MailboxPathUnreadable), mailboxIssue(MailboxPathUnreadable, configPath)
+	}
+	var cfg mailboxActiveConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		_ = file.Close()
+		return nil, "malformed", fmt.Sprintf("malformed:%s:%v", configPath, err)
+	}
+	for _, handle := range cfg.Agents {
+		if err := ValidateHandle(handle); err != nil {
+			_ = file.Close()
+			return nil, "invalid_handles", fmt.Sprintf("invalid_handle:%s:%v", handle, err)
+		}
+	}
+	return &mailboxConfigPin{
+		root: root,
+		file: file,
+		info: info,
+		data: append([]byte(nil), data...),
+		cfg:  cfg,
+	}, "ok", ""
+}
+
+func (p *mailboxConfigPin) verify() error {
+	if p == nil || p.file == nil || p.info == nil {
+		return fmt.Errorf("mailbox config authorization is closed")
+	}
+	if err := p.root.VerifyBase(); err != nil {
+		return err
+	}
+	info, err := p.file.Stat()
+	if err != nil || !os.SameFile(p.info, info) {
+		return fmt.Errorf("mailbox config descriptor identity changed")
+	}
+	if _, err := p.file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind mailbox config descriptor: %w", err)
+	}
+	pinnedData, err := io.ReadAll(p.file)
+	if err != nil {
+		return fmt.Errorf("re-read mailbox config descriptor: %w", err)
+	}
+	if !bytes.Equal(pinnedData, p.data) {
+		return fmt.Errorf("mailbox config content changed")
+	}
+
+	current, currentInfo, err := p.root.OpenRegularNoFollow("meta/config.json")
+	if err != nil {
+		return fmt.Errorf("re-open mailbox config: %w", err)
+	}
+	defer func() { _ = current.Close() }()
+	if !os.SameFile(p.info, currentInfo) {
+		return fmt.Errorf("mailbox config path identity changed")
+	}
+	currentData, err := io.ReadAll(current)
+	if err != nil {
+		return fmt.Errorf("re-read current mailbox config: %w", err)
+	}
+	if !bytes.Equal(currentData, p.data) {
+		return fmt.Errorf("mailbox config path content changed")
+	}
+	return nil
+}
+
+// OpenMailboxConfigAuthorization pins the active config through configRoot.
+func OpenMailboxConfigAuthorization(configRoot *DeliveryRoot) (*MailboxConfigAuthorization, MailboxInventory, error) {
+	pin, status, issue := pinActiveMailboxConfig(configRoot)
+	inventory := MailboxInventory{
+		ActiveConfigStatus: status,
+		ActiveConfigIssue:  issue,
+		RepairAuthorized:   pin != nil,
+	}
+	if pin == nil {
+		return nil, inventory, errors.New(issue)
+	}
+	inventory.ConfiguredAgents = append([]string(nil), pin.cfg.Agents...)
+	return &MailboxConfigAuthorization{pin: pin}, inventory, nil
+}
+
+// Close releases the retained config descriptor.
+func (a *MailboxConfigAuthorization) Close() error {
+	if a == nil || a.pin == nil || a.pin.file == nil {
+		return nil
+	}
+	return a.pin.file.Close()
+}
+
+// ConfiguredAgents returns the roster bound to this authorization.
+func (a *MailboxConfigAuthorization) ConfiguredAgents() []string {
+	if a == nil || a.pin == nil {
+		return nil
+	}
+	return append([]string(nil), a.pin.cfg.Agents...)
+}
+
+// Verify confirms the retained descriptor, its content, and its current path
+// still identify the exact config that authorized this operation.
+func (a *MailboxConfigAuthorization) Verify() error {
+	if a == nil || a.pin == nil {
+		return fmt.Errorf("mailbox config authorization is missing")
+	}
+	return a.pin.verify()
+}
+
 func inspectMailboxLayout(root *DeliveryRoot, additionalHandles ...string) (mailboxLayoutPlan, error) {
 	if err := root.VerifyBase(); err != nil {
 		return mailboxLayoutPlan{}, err
@@ -310,6 +446,22 @@ func inspectMailboxLayout(root *DeliveryRoot, additionalHandles ...string) (mail
 	defer rootCap.close()
 
 	cfg, configStatus, configIssue := readActiveMailboxConfig(rootCap)
+	return inspectMailboxLayoutCapability(rootCap, cfg, configStatus, configIssue, additionalHandles...)
+}
+
+func inspectMailboxLayoutWithConfig(root *DeliveryRoot, cfg mailboxActiveConfig, additionalHandles ...string) (mailboxLayoutPlan, error) {
+	if err := root.VerifyBase(); err != nil {
+		return mailboxLayoutPlan{}, err
+	}
+	rootCap, err := openLayoutRootCapability(root)
+	if err != nil {
+		return mailboxLayoutPlan{}, err
+	}
+	defer rootCap.close()
+	return inspectMailboxLayoutCapability(rootCap, cfg, "ok", "", additionalHandles...)
+}
+
+func inspectMailboxLayoutCapability(rootCap *layoutDirCapability, cfg mailboxActiveConfig, configStatus, configIssue string, additionalHandles ...string) (mailboxLayoutPlan, error) {
 	inventory := MailboxInventory{
 		ActiveConfigStatus: configStatus,
 		ActiveConfigIssue:  configIssue,
@@ -478,6 +630,83 @@ func InspectMailboxLayout(root *DeliveryRoot) (MailboxInventory, error) {
 	return plan.inventory, err
 }
 
+// InspectMailboxLayoutWithAuthorization inventories root using the exact
+// retained config capability supplied by the caller. effectiveAgents are
+// treated as configured for callers whose roster includes implicit handles.
+func InspectMailboxLayoutWithAuthorization(root *DeliveryRoot, authorization *MailboxConfigAuthorization, effectiveAgents ...string) (MailboxInventory, error) {
+	if authorization == nil || authorization.pin == nil {
+		return MailboxInventory{}, fmt.Errorf("mailbox config authorization is missing")
+	}
+	if err := authorization.Verify(); err != nil {
+		return MailboxInventory{}, fmt.Errorf("verify mailbox config authorization: %w", err)
+	}
+	cfg, err := mailboxConfigWithEffectiveAgents(authorization.pin.cfg, effectiveAgents)
+	if err != nil {
+		return MailboxInventory{}, err
+	}
+	plan, err := inspectMailboxLayoutWithConfig(root, cfg)
+	if err != nil {
+		return plan.inventory, err
+	}
+	if err := authorization.Verify(); err != nil {
+		return plan.inventory, fmt.Errorf("mailbox config authorization changed during inspection: %w", err)
+	}
+	return plan.inventory, nil
+}
+
+func mailboxConfigWithEffectiveAgents(cfg mailboxActiveConfig, effectiveAgents []string) (mailboxActiveConfig, error) {
+	cfg.Agents = append([]string(nil), cfg.Agents...)
+	seen := make(map[string]bool, len(cfg.Agents)+len(effectiveAgents))
+	for _, handle := range cfg.Agents {
+		seen[handle] = true
+	}
+	for _, handle := range effectiveAgents {
+		if err := ValidateHandle(handle); err != nil {
+			return mailboxActiveConfig{}, err
+		}
+		if !seen[handle] {
+			seen[handle] = true
+			cfg.Agents = append(cfg.Agents, handle)
+		}
+	}
+	return cfg, nil
+}
+
+// ValidateExistingMailboxLayout requires the complete mailbox contract for each
+// requested handle without creating or changing any path.
+func ValidateExistingMailboxLayout(root *DeliveryRoot, handles ...string) error {
+	unique := make([]string, 0, len(handles))
+	seen := make(map[string]bool, len(handles))
+	for _, handle := range handles {
+		if err := ValidateHandle(handle); err != nil {
+			return err
+		}
+		if !seen[handle] {
+			seen[handle] = true
+			unique = append(unique, handle)
+		}
+	}
+	plan, err := inspectMailboxLayout(root, unique...)
+	if err != nil {
+		return err
+	}
+	byHandle := make(map[string]MailboxInspection, len(plan.inventory.Mailboxes))
+	for _, mailbox := range plan.inventory.Mailboxes {
+		byHandle[mailbox.Handle] = mailbox
+	}
+	for _, handle := range unique {
+		mailbox, ok := byHandle[handle]
+		if !ok || len(mailbox.Issues) != 0 {
+			issues := mailbox.Issues
+			if !ok {
+				issues = []string{"missing:."}
+			}
+			return fmt.Errorf("mailbox for %q is incomplete: %s", handle, strings.Join(issues, ","))
+		}
+	}
+	return nil
+}
+
 func preflightHazard(plan mailboxLayoutPlan, repairHandles []string) (string, bool) {
 	if !plan.inventory.RepairAuthorized {
 		return plan.inventory.ActiveConfigIssue, true
@@ -527,8 +756,9 @@ func repairComponentPaths(repairHandles []string) []string {
 	return paths
 }
 
-func repairFailure(code, stage, path string, err error, created []string, root *DeliveryRoot) MailboxRepairResult {
-	inventory, inspectErr := InspectMailboxLayout(root)
+func repairFailure(code, stage, path string, err error, created []string, root *DeliveryRoot, cfg mailboxActiveConfig) MailboxRepairResult {
+	plan, inspectErr := inspectMailboxLayoutWithConfig(root, cfg)
+	inventory := plan.inventory
 	if inspectErr != nil {
 		err = fmt.Errorf("%w; re-inspection failed: %v", err, inspectErr)
 	}
@@ -568,8 +798,65 @@ func mergeCreatedPaths(inventory *MailboxInventory, created []string) {
 	}
 }
 
-func repairMailboxLayoutHandles(root *DeliveryRoot, requestedHandles []string, configuredSet bool, hooks mailboxRepairHooks) MailboxRepairResult {
-	plan, err := inspectMailboxLayout(root, requestedHandles...)
+func repairMailboxLayoutHandles(root, configRoot *DeliveryRoot, requestedHandles []string, configuredSet bool, hooks mailboxRepairHooks) MailboxRepairResult {
+	authorization, inventory, err := OpenMailboxConfigAuthorization(configRoot)
+	if err != nil {
+		return MailboxRepairResult{
+			Status: "failed",
+			Failure: &MailboxRepairFailure{
+				Code:    "preflight_failed",
+				Stage:   "authorization",
+				Message: inventory.ActiveConfigIssue,
+			},
+			Inventory: inventory,
+		}
+	}
+	defer func() { _ = authorization.Close() }()
+	return repairMailboxLayoutHandlesAuthorized(root, authorization, requestedHandles, configuredSet, hooks)
+}
+
+func repairMailboxLayoutHandlesAuthorized(root *DeliveryRoot, authorization *MailboxConfigAuthorization, requestedHandles []string, configuredSet bool, hooks mailboxRepairHooks) MailboxRepairResult {
+	if authorization == nil || authorization.pin == nil {
+		return MailboxRepairResult{
+			Status:  "failed",
+			Failure: &MailboxRepairFailure{Code: "preflight_failed", Stage: "authorization", Message: "mailbox config authorization is missing"},
+		}
+	}
+	return repairMailboxLayoutHandlesAuthorizedWithConfig(
+		root,
+		authorization,
+		requestedHandles,
+		configuredSet,
+		authorization.pin.cfg,
+		hooks,
+	)
+}
+
+func repairMailboxLayoutHandlesAuthorizedWithConfig(root *DeliveryRoot, authorization *MailboxConfigAuthorization, requestedHandles []string, configuredSet bool, inspectionConfig mailboxActiveConfig, hooks mailboxRepairHooks) MailboxRepairResult {
+	if authorization == nil || authorization.pin == nil {
+		return MailboxRepairResult{
+			Status:  "failed",
+			Failure: &MailboxRepairFailure{Code: "preflight_failed", Stage: "authorization", Message: "mailbox config authorization is missing"},
+		}
+	}
+	configPin := authorization.pin
+	if err := configPin.verify(); err != nil {
+		return MailboxRepairResult{
+			Status: "failed",
+			Failure: &MailboxRepairFailure{
+				Code:    "authorization_changed",
+				Stage:   "authorization",
+				Path:    "meta/config.json",
+				Message: err.Error(),
+			},
+			Inventory: MailboxInventory{
+				ActiveConfigStatus: "changed",
+				ActiveConfigIssue:  err.Error(),
+				ConfiguredAgents:   append([]string(nil), inspectionConfig.Agents...),
+			},
+		}
+	}
+	plan, err := inspectMailboxLayoutWithConfig(root, inspectionConfig, requestedHandles...)
 	if err != nil {
 		return MailboxRepairResult{
 			Status:  "failed",
@@ -590,10 +877,17 @@ func repairMailboxLayoutHandles(root *DeliveryRoot, requestedHandles []string, c
 	if hooks.afterPreflight != nil {
 		hooks.afterPreflight()
 	}
+	if err := configPin.verify(); err != nil {
+		return MailboxRepairResult{
+			Status:    "failed",
+			Failure:   &MailboxRepairFailure{Code: "authorization_changed", Stage: "authorization", Path: "meta/config.json", Message: err.Error()},
+			Inventory: plan.inventory,
+		}
+	}
 
 	rootCap, err := openLayoutRootCapability(root)
 	if err != nil {
-		return repairFailure("unsafe_root", "open", ".", err, nil, root)
+		return repairFailure("unsafe_root", "open", ".", err, nil, root, inspectionConfig)
 	}
 	defer rootCap.close()
 	caps := map[string]*layoutDirCapability{"": rootCap}
@@ -613,7 +907,7 @@ func repairMailboxLayoutHandles(root *DeliveryRoot, requestedHandles []string, c
 		}
 		parent := caps[parentPath]
 		if parent == nil {
-			return repairFailure("concurrent_change", "open", path, errLayoutIdentityChanged, created, root)
+			return repairFailure("concurrent_change", "open", path, errLayoutIdentityChanged, created, root, inspectionConfig)
 		}
 		name := filepath.Base(path)
 		before := plan.nodes[path]
@@ -622,14 +916,14 @@ func repairMailboxLayoutHandles(root *DeliveryRoot, requestedHandles []string, c
 		switch before.state {
 		case MailboxPathMissing:
 			if statErr == nil {
-				return repairFailure("concurrent_race", "create", path, fmt.Errorf("%s appeared after preflight", path), created, root)
+				return repairFailure("concurrent_race", "create", path, fmt.Errorf("%s appeared after preflight", path), created, root, inspectionConfig)
 			}
 			if !errors.Is(statErr, fs.ErrNotExist) {
-				return repairFailure("create_failed", "create", path, statErr, created, root)
+				return repairFailure("create_failed", "create", path, statErr, created, root, inspectionConfig)
 			}
 			if hooks.fail != nil {
 				if failErr := hooks.fail("mkdir", path); failErr != nil {
-					return repairFailure("create_failed", "mkdir", path, failErr, created, root)
+					return repairFailure("create_failed", "mkdir", path, failErr, created, root, inspectionConfig)
 				}
 			}
 			if err := mkdirLayoutDirectory(parent, name, 0o700); err != nil {
@@ -637,77 +931,83 @@ func repairMailboxLayoutHandles(root *DeliveryRoot, requestedHandles []string, c
 				if errors.Is(err, fs.ErrExist) {
 					code = "concurrent_race"
 				}
-				return repairFailure(code, "mkdir", path, err, created, root)
+				return repairFailure(code, "mkdir", path, err, created, root, inspectionConfig)
 			}
 			created = append(created, filepath.ToSlash(path))
 			current, statErr = lstatLayoutNode(parent, name)
 			if statErr != nil {
-				return repairFailure("create_failed", "lstat", path, statErr, created, root)
+				return repairFailure("create_failed", "lstat", path, statErr, created, root, inspectionConfig)
 			}
 			if current.kind != layoutNodeDirectory {
-				return repairFailure("concurrent_race", "identity", path, fmt.Errorf("created path is not a directory"), created, root)
+				return repairFailure("concurrent_race", "identity", path, fmt.Errorf("created path is not a directory"), created, root, inspectionConfig)
 			}
 			if hooks.fail != nil {
 				if failErr := hooks.fail("open", path); failErr != nil {
-					return repairFailure("create_failed", "open", path, failErr, created, root)
+					return repairFailure("create_failed", "open", path, failErr, created, root, inspectionConfig)
 				}
 			}
 			child, openErr := openLayoutDirectory(parent, name, current)
 			if openErr != nil {
-				return repairFailure("create_failed", "open", path, openErr, created, root)
+				return repairFailure("create_failed", "open", path, openErr, created, root, inspectionConfig)
 			}
 			caps[path] = child
 			if hooks.fail != nil {
 				if failErr := hooks.fail("chmod", path); failErr != nil {
-					return repairFailure("create_failed", "chmod", path, failErr, created, root)
+					return repairFailure("create_failed", "chmod", path, failErr, created, root, inspectionConfig)
 				}
 			}
 			if err := child.chmod(0o700); err != nil {
-				return repairFailure("create_failed", "chmod", path, err, created, root)
+				return repairFailure("create_failed", "chmod", path, err, created, root, inspectionConfig)
 			}
 			mode, err := child.mode()
 			if err != nil {
-				return repairFailure("create_failed", "fstat", path, err, created, root)
+				return repairFailure("create_failed", "fstat", path, err, created, root, inspectionConfig)
 			}
 			if !layoutModeSupported(mode) {
-				return repairFailure("create_failed", "mode", path, fmt.Errorf("created directory mode is %04o, want 0700", mode.Perm()), created, root)
+				return repairFailure("create_failed", "mode", path, fmt.Errorf("created directory mode is %04o, want 0700", mode.Perm()), created, root, inspectionConfig)
 			}
 			if hooks.fail != nil {
 				if failErr := hooks.fail("child_sync", path); failErr != nil {
-					return repairFailure("durability_failed", "child_sync", path, failErr, created, root)
+					return repairFailure("durability_failed", "child_sync", path, failErr, created, root, inspectionConfig)
 				}
 			}
 			if err := child.sync(); err != nil {
-				return repairFailure("durability_failed", "child_sync", path, err, created, root)
+				return repairFailure("durability_failed", "child_sync", path, err, created, root, inspectionConfig)
 			}
 			if hooks.fail != nil {
 				if failErr := hooks.fail("parent_sync", path); failErr != nil {
-					return repairFailure("durability_failed", "parent_sync", path, failErr, created, root)
+					return repairFailure("durability_failed", "parent_sync", path, failErr, created, root, inspectionConfig)
 				}
 			}
 			if err := parent.sync(); err != nil {
-				return repairFailure("durability_failed", "parent_sync", path, err, created, root)
+				return repairFailure("durability_failed", "parent_sync", path, err, created, root, inspectionConfig)
 			}
 		case MailboxPathDirectory:
 			if statErr != nil || !sameLayoutNode(before.info, current) {
 				if statErr == nil {
 					statErr = errLayoutIdentityChanged
 				}
-				return repairFailure("concurrent_change", "identity", path, statErr, created, root)
+				return repairFailure("concurrent_change", "identity", path, statErr, created, root, inspectionConfig)
 			}
 			child, openErr := openLayoutDirectory(parent, name, current)
 			if openErr != nil {
-				return repairFailure("concurrent_change", "open", path, openErr, created, root)
+				return repairFailure("concurrent_change", "open", path, openErr, created, root, inspectionConfig)
 			}
 			caps[path] = child
 		default:
-			return repairFailure("preflight_failed", "preflight", path, fmt.Errorf("unsafe preflight state %s", before.state), created, root)
+			return repairFailure("preflight_failed", "preflight", path, fmt.Errorf("unsafe preflight state %s", before.state), created, root, inspectionConfig)
 		}
 	}
 
-	verifiedPlan, inspectErr := inspectMailboxLayout(root, repairHandles...)
+	if err := configPin.verify(); err != nil {
+		return repairFailure("authorization_changed", "verify", "meta/config.json", err, created, root, inspectionConfig)
+	}
+	verifiedPlan, inspectErr := inspectMailboxLayoutWithConfig(root, inspectionConfig, repairHandles...)
 	if inspectErr != nil {
-		return repairFailure("verification_failed", "verify", ".", inspectErr, created, root)
+		return repairFailure("verification_failed", "verify", ".", inspectErr, created, root, inspectionConfig)
+	}
+	if hooks.afterFinalInspection != nil {
+		hooks.afterFinalInspection()
 	}
 	inventory := verifiedPlan.inventory
 	mergeCreatedPaths(&inventory, created)
@@ -723,9 +1023,12 @@ func repairMailboxLayoutHandles(root *DeliveryRoot, requestedHandles []string, c
 			switch path.State {
 			case MailboxPathDirectory:
 			default:
-				return repairFailure("verification_failed", "verify", filepath.Join("agents", mailbox.Handle, path.Path), fmt.Errorf("post-repair state %s", path.State), created, root)
+				return repairFailure("verification_failed", "verify", filepath.Join("agents", mailbox.Handle, path.Path), fmt.Errorf("post-repair state %s", path.State), created, root, inspectionConfig)
 			}
 		}
+	}
+	if err := authorization.Verify(); err != nil {
+		return repairFailure("authorization_changed", "verify", "meta/config.json", err, created, root, inspectionConfig)
 	}
 	return MailboxRepairResult{
 		Status:       "repaired",
@@ -735,7 +1038,7 @@ func repairMailboxLayoutHandles(root *DeliveryRoot, requestedHandles []string, c
 }
 
 func repairMailboxLayout(root *DeliveryRoot, hooks mailboxRepairHooks) MailboxRepairResult {
-	return repairMailboxLayoutHandles(root, nil, true, hooks)
+	return repairMailboxLayoutHandles(root, root, nil, true, hooks)
 }
 
 // RepairMailboxLayout validates the complete configured set before creating
@@ -749,6 +1052,27 @@ func RepairMailboxLayout(root *DeliveryRoot) MailboxRepairResult {
 // as RepairMailboxLayout. A valid active config is still required, but the
 // requested handles do not need to be listed in it.
 func RepairMailboxLayoutForAgents(root *DeliveryRoot, agents []string) MailboxRepairResult {
+	return RepairMailboxLayoutForAgentsAuthorized(root, root, agents)
+}
+
+// RepairMailboxLayoutForAgentsAuthorized validates and completes only agents in
+// root while taking initialization and roster authority from configRoot.
+func RepairMailboxLayoutForAgentsAuthorized(root, configRoot *DeliveryRoot, agents []string) MailboxRepairResult {
+	authorization, inventory, err := OpenMailboxConfigAuthorization(configRoot)
+	if err != nil {
+		return MailboxRepairResult{
+			Status:    "failed",
+			Failure:   &MailboxRepairFailure{Code: "preflight_failed", Stage: "authorization", Message: inventory.ActiveConfigIssue},
+			Inventory: inventory,
+		}
+	}
+	defer func() { _ = authorization.Close() }()
+	return RepairMailboxLayoutForAgentsWithAuthorization(root, authorization, agents)
+}
+
+// RepairMailboxLayoutForAgentsWithAuthorization repairs only agents using the
+// exact retained config authorization previously used for roster validation.
+func RepairMailboxLayoutForAgentsWithAuthorization(root *DeliveryRoot, authorization *MailboxConfigAuthorization, agents []string) MailboxRepairResult {
 	handles := make([]string, 0, len(agents))
 	seen := make(map[string]bool, len(agents))
 	for _, handle := range agents {
@@ -763,5 +1087,32 @@ func RepairMailboxLayoutForAgents(root *DeliveryRoot, agents []string) MailboxRe
 			handles = append(handles, handle)
 		}
 	}
-	return repairMailboxLayoutHandles(root, handles, false, mailboxRepairHooks{})
+	return repairMailboxLayoutHandlesAuthorized(root, authorization, handles, false, mailboxRepairHooks{})
+}
+
+// RepairMailboxLayoutForConfiguredAgentsWithAuthorization repairs an effective
+// configured roster, including caller-owned implicit handles, while retaining
+// the exact on-disk config authorization for mutation checks.
+func RepairMailboxLayoutForConfiguredAgentsWithAuthorization(root *DeliveryRoot, authorization *MailboxConfigAuthorization, effectiveAgents []string) MailboxRepairResult {
+	if authorization == nil || authorization.pin == nil {
+		return MailboxRepairResult{
+			Status:  "failed",
+			Failure: &MailboxRepairFailure{Code: "preflight_failed", Stage: "authorization", Message: "mailbox config authorization is missing"},
+		}
+	}
+	cfg, err := mailboxConfigWithEffectiveAgents(authorization.pin.cfg, effectiveAgents)
+	if err != nil {
+		return MailboxRepairResult{
+			Status:  "failed",
+			Failure: &MailboxRepairFailure{Code: "preflight_failed", Stage: "preflight", Message: err.Error()},
+		}
+	}
+	return repairMailboxLayoutHandlesAuthorizedWithConfig(
+		root,
+		authorization,
+		cfg.Agents,
+		false,
+		cfg,
+		mailboxRepairHooks{},
+	)
 }

--- a/internal/fsq/layout_mailbox_test.go
+++ b/internal/fsq/layout_mailbox_test.go
@@ -107,6 +107,78 @@ func TestMailboxLayoutRepairRefusesNonDirectoryPreflight(t *testing.T) {
 	}
 }
 
+func TestMailboxLayoutRepairRefusesConfigReplacementBeforeFirstMkdir(t *testing.T) {
+	rootPath := mailboxLayoutTestRoot(t, "legacy")
+	if err := EnsureAgentDirs(rootPath, "legacy"); err != nil {
+		t.Fatal(err)
+	}
+	missing := AgentDLQCur(rootPath, "legacy")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	root := openMailboxLayoutTestRoot(t, rootPath)
+	configPath := filepath.Join(rootPath, "meta", "config.json")
+	originalPath := configPath + ".original"
+
+	result := repairMailboxLayout(root, mailboxRepairHooks{
+		afterPreflight: func() {
+			if err := os.Rename(configPath, originalPath); err != nil {
+				t.Fatalf("rename config: %v", err)
+			}
+			if err := os.WriteFile(configPath, []byte(`{"version":1,"agents":["attacker"]}`), 0o600); err != nil {
+				t.Fatalf("replace config: %v", err)
+			}
+		},
+	})
+	if result.Status == "repaired" {
+		t.Fatalf("repair accepted replaced authorization config: %#v", result)
+	}
+	if len(result.CreatedPaths) != 0 {
+		t.Fatalf("repair mutated before rejecting config replacement: %#v", result.CreatedPaths)
+	}
+	if _, err := os.Lstat(missing); !os.IsNotExist(err) {
+		t.Fatalf("repair created path after config replacement: %v", err)
+	}
+}
+
+func TestMailboxLayoutRepairRefusesConfigReplacementAfterFinalInspectionBeforeDelivery(t *testing.T) {
+	rootPath := mailboxLayoutTestRoot(t, "legacy")
+	if err := EnsureAgentDirs(rootPath, "legacy"); err != nil {
+		t.Fatal(err)
+	}
+	root := openMailboxLayoutTestRoot(t, rootPath)
+	configPath := filepath.Join(rootPath, "meta", "config.json")
+	authorization, _, err := OpenMailboxConfigAuthorization(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = authorization.Close() }()
+
+	result := repairMailboxLayoutHandlesAuthorized(root, authorization, []string{"legacy"}, false, mailboxRepairHooks{
+		afterFinalInspection: func() {
+			if err := os.Rename(configPath, configPath+".original"); err != nil {
+				t.Fatalf("rename config: %v", err)
+			}
+			if err := os.WriteFile(configPath, []byte(`{"version":1,"agents":[]}`), 0o600); err != nil {
+				t.Fatalf("replace config: %v", err)
+			}
+		},
+	})
+	if result.Status == "repaired" {
+		t.Fatalf("repair accepted config replacement during final inspection: %#v", result)
+	}
+	if result.Failure == nil || result.Failure.Code != "authorization_changed" {
+		t.Fatalf("failure = %#v", result.Failure)
+	}
+	entries, readErr := os.ReadDir(AgentInboxNew(rootPath, "legacy"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("authorization failure allowed delivery: %#v", entries)
+	}
+}
+
 func mailboxLayoutTestRoot(t *testing.T, agents ...string) string {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -144,6 +144,9 @@ func DeliverToExistingInbox(root *DeliveryRoot, agent, filename string, data []b
 	if err := root.VerifyBase(); err != nil {
 		return "", err
 	}
+	if err := ValidateExistingMailboxLayout(root, agent); err != nil {
+		return "", err
+	}
 	tmpDir := filepath.Join("agents", agent, "inbox", "tmp")
 	newDir := filepath.Join("agents", agent, "inbox", "new")
 

--- a/internal/fsq/maildir_test.go
+++ b/internal/fsq/maildir_test.go
@@ -107,6 +107,32 @@ func TestDeliverToExistingInboxNoDir(t *testing.T) {
 	}
 }
 
+func TestDeliverToExistingInboxRejectsIncompleteMailboxWithoutMutation(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	missing := AgentDLQCur(root, "codex")
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := DeliverToExistingInbox(openDeliveryRootForTest(t, root), "codex", "test.md", []byte("nope"))
+	if err == nil {
+		t.Fatal("DeliverToExistingInbox accepted incomplete mailbox")
+	}
+	entries, readErr := os.ReadDir(AgentInboxNew(root, "codex"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("incomplete peer received messages: %#v", entries)
+	}
+	if _, statErr := os.Lstat(missing); !os.IsNotExist(statErr) {
+		t.Fatalf("cross-project delivery created missing leaf: %v", statErr)
+	}
+}
+
 func TestDeliverToExistingInboxPostRenameSyncFailureReportsCommittedResult(t *testing.T) {
 	root := t.TempDir()
 	if err := EnsureAgentDirs(root, "codex"); err != nil {

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -186,6 +186,11 @@ amq integration kanban bridge --me codex --workspace-id my-workspace
 # Runtime diagnostics
 amq doctor --ops
 amq doctor --ops --json
+amq doctor --root <exact-root> --ops
+
+# Base-config-only session repair outside the current pin
+amq doctor --root <session-root> --base-root <base-root> \
+  --ignore-session-pin --fix-mailboxes
 ```
 
 ## Exit Codes
@@ -246,6 +251,13 @@ has pending messages in a sibling session; follow the exact `amq list --session
 <name> --me <handle> --new` command in that note.
 This is an operational safety check, not an authorization boundary; a local
 process can deliberately repin or override it.
+
+For `doctor`, `--root` selects the exact target but does not waive the active
+pin. Read-only inspection continues and reports a mismatch warning.
+`--fix-mailboxes` and `--ops --fix-wake-locks` require a matching pin unless an explicit non-empty
+`--root` is paired with `--ignore-session-pin`. `--base-root` requires
+`--root`, supplies retained config authority for the target or one direct
+child, and never waives the pin.
 
 ## Session Layout
 

--- a/skills/amq-cli/references/integrations.md
+++ b/skills/amq-cli/references/integrations.md
@@ -68,12 +68,20 @@ Defaults:
 ```bash
 amq doctor --ops
 amq doctor --ops --json
+amq doctor --root <exact-root> --ops
 ```
 
 `doctor --ops` adds queue depth, sibling-session backlog hints, oldest unread
 age, DLQ state, presence freshness, and integration hints on top of the base
 `doctor` checks. A `sibling_backlog` hint includes an exact non-destructive
 `amq list --session <name> --me <handle> --new` inspection command.
+
+An explicit doctor root selects the inspected tree without changing the
+terminal pin. Inspection continues with a mismatch warning. Mutating doctor
+operations (`--fix-mailboxes` or `--ops --fix-wake-locks`) require the target
+to match the pin unless the command uses an explicit non-empty `--root`
+together with `--ignore-session-pin`. `--base-root` supplies config authority
+for the target or one direct child and never waives the pin.
 
 ## Message Shape
 


### PR DESCRIPTION
## Summary
- complete missing destination mailbox layouts safely for configured recipients
- retain and revalidate the effective config authority immediately before delivery
- add explicit Doctor root/base-root repair controls with pin-safe generated guidance
- preserve absent-config compatibility while treating present empty rosters as reserved-user authority

## Verification
- `golangci-lint run`
- `make ci`
- `go test -race ./... -count=1`
- focused race/authority/Doctor arms
- exact-tree subagent review: PASS
- GPT-5.6 Sol Pro follow-up: PASS

Exact commit: `610412d3c016518a1bc3e33b1532f1cc7c973253`
Exact tree: `8ebdd02df47caf6af979fdc8fbfae31159ceea6b`