### PR TITLE
fix(wake): coalesce pending co-op doorbells

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -50,6 +50,7 @@ type wakeConfig struct {
 	baselineRequested    bool
 	baselineInherited    bool
 	baselineExisting     map[string]wakeFileIdentity
+	announcedPending     map[string]wakeFileIdentity
 	onBaselineReady      func(map[string]wakeFileIdentity) error
 	onPrepared           func(wakeAdmissionWatcher) error
 	retainedInbox        wakeInboxReader
@@ -266,6 +267,7 @@ func notifyNewMessages(cfg *wakeConfig) error {
 	var messages []wakeMsgInfo
 	var interruptMessages []wakeMsgInfo
 	interruptCounts := make(map[string]int)
+	currentPending := make(map[string]os.FileInfo)
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -275,9 +277,9 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
 			continue
 		}
+		fileInfo, infoErr := entry.Info()
 		if baselineIdentity, ignored := cfg.baselineExisting[name]; ignored {
-			info, infoErr := entry.Info()
-			if infoErr == nil && matchesWakeFileIdentity(baselineIdentity, info) {
+			if infoErr == nil && matchesWakeFileIdentity(baselineIdentity, fileInfo) {
 				continue
 			}
 			delete(cfg.baselineExisting, name)
@@ -295,7 +297,13 @@ func notifyNewMessages(cfg *wakeConfig) error {
 			}
 			// Count corrupt messages too
 			messages = append(messages, wakeMsgInfo{from: "unknown", subject: "(parse error)"})
+			if infoErr == nil {
+				currentPending[name] = fileInfo
+			}
 			continue
+		}
+		if infoErr == nil {
+			currentPending[name] = fileInfo
 		}
 
 		from := strings.TrimSpace(header.From)
@@ -333,7 +341,7 @@ func notifyNewMessages(cfg *wakeConfig) error {
 			notice = operatorWakeNotification(interruptText)
 		}
 		if cfg.injectMode == wakeInjectModeNone {
-			return deliverWakeNotification(cfg, notice, false)
+			return deliverNewMessageNotification(cfg, notice, false, currentPending)
 		}
 		now := time.Now()
 		if !usesCoopDoorbell(cfg) &&
@@ -372,7 +380,7 @@ func notifyNewMessages(cfg *wakeConfig) error {
 				}
 			}
 		}
-		return deliverWakeNotification(cfg, notice, false)
+		return deliverNewMessageNotification(cfg, notice, false, currentPending)
 	}
 
 	var notice wakeNotification
@@ -386,7 +394,51 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		)
 	}
 
-	return deliverWakeNotification(cfg, notice, true)
+	return deliverNewMessageNotification(cfg, notice, true, currentPending)
+}
+
+func deliverNewMessageNotification(
+	cfg *wakeConfig,
+	notice wakeNotification,
+	deferForInput bool,
+	currentPending map[string]os.FileInfo,
+) error {
+	ownerBound := usesCoopDoorbell(cfg)
+	if ownerBound &&
+		cfg.injectMode != wakeInjectModeNone &&
+		announcedWakeStillPending(cfg.announcedPending, currentPending) {
+		emitWakeAttention(cfg, notice.output)
+		return nil
+	}
+
+	result, err := deliverWakeNotificationResult(cfg, notice, deferForInput)
+	if err == nil && ownerBound && result.inputSubmitted {
+		cfg.announcedPending = snapshotWakeFileIdentities(currentPending)
+	}
+	return err
+}
+
+func announcedWakeStillPending(
+	announced map[string]wakeFileIdentity,
+	current map[string]os.FileInfo,
+) bool {
+	for name, identity := range announced {
+		info, ok := current[name]
+		if ok && matchesWakeFileIdentity(identity, info) {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotWakeFileIdentities(current map[string]os.FileInfo) map[string]wakeFileIdentity {
+	snapshot := make(map[string]wakeFileIdentity, len(current))
+	for name, info := range current {
+		if identity, ok := captureWakeFileIdentity(info); ok {
+			snapshot[name] = identity
+		}
+	}
+	return snapshot
 }
 
 func buildNotificationText(session string, messages []wakeMsgInfo, previewLen int) string {
@@ -552,7 +604,21 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	)
 }
 
+type wakeDeliveryResult struct {
+	inputSubmitted bool
+}
+
 func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForInput bool) error {
+	_, err := deliverWakeNotificationResult(cfg, notice, deferForInput)
+	return err
+}
+
+func deliverWakeNotificationResult(
+	cfg *wakeConfig,
+	notice wakeNotification,
+	deferForInput bool,
+) (wakeDeliveryResult, error) {
+	var result wakeDeliveryResult
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound {
 		notice.input = wakePayload{
@@ -562,7 +628,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	}
 	if cfg.injectMode == wakeInjectModeNone {
 		emitWakeAttention(cfg, notice.output)
-		return nil
+		return result, nil
 	}
 
 	inputText := notice.input.text
@@ -574,7 +640,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	if shouldDeferBeforeInject(cfg, deferForInput) {
 		if !waitForWakeInputQuiet(cfg) {
 			emitWakeAttention(cfg, notice.output)
-			return nil
+			return result, nil
 		}
 	}
 
@@ -583,10 +649,10 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	if cfg.injectVia != "" {
 		allowed, guardErr := authorizeTerminalWrite(cfg)
 		if guardErr != nil {
-			return guardErr
+			return result, guardErr
 		}
 		if !allowed {
-			return nil
+			return result, nil
 		}
 		if err := injectVia(cfg, plainText); err != nil {
 			if cfg.fallbackWarn {
@@ -595,8 +661,10 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 				cfg.fallbackWarn = false
 			}
 			emitWakeAttention(cfg, notice.output)
+			return result, nil
 		}
-		return nil
+		result.inputSubmitted = true
+		return result, nil
 	}
 
 	mode := effectiveInjectMode(cfg)
@@ -613,7 +681,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		if cfg.bell && !ownerBound {
 			injectedText = "\a" + injectedText
 		}
-		injectErr = injectRawNotification(cfg, injectedText)
+		result.inputSubmitted, injectErr = injectRawNotification(cfg, injectedText)
 
 	case wakeInjectModePaste:
 		// Paste mode: bracketed paste with delayed CR
@@ -632,7 +700,11 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		} else if wrote {
 			// Small delay to ensure CR lands in separate read cycle
 			time.Sleep(25 * time.Millisecond)
-			_, injectErr = writeTerminalChunk(cfg, "\r")
+			submitted, err := writeTerminalChunk(cfg, "\r")
+			if err == nil {
+				result.inputSubmitted = submitted
+			}
+			injectErr = err
 		}
 
 	default:
@@ -642,14 +714,18 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 			if err != nil {
 				injectErr = err
 			} else if wrote {
-				_, injectErr = writeTerminalChunk(cfg, "\r")
+				submitted, err := writeTerminalChunk(cfg, "\r")
+				if err == nil {
+					result.inputSubmitted = submitted
+				}
+				injectErr = err
 			}
 		} else {
 			injectedText := inputText + "\r"
 			if cfg.bell {
 				injectedText = "\a" + injectedText
 			}
-			_, injectErr = writeTerminalChunk(cfg, injectedText)
+			result.inputSubmitted, injectErr = writeTerminalChunk(cfg, injectedText)
 		}
 	}
 
@@ -671,11 +747,11 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 			_ = writeStderr("amq wake: warning: %s\n", reason)
 			cfg.fallbackWarn = false
 			emitWakeAttention(cfg, notice.output)
-			return nil
+			return result, nil
 		}
 		var authorityErr *wakeTerminalAuthorityError
 		if errors.As(injectErr, &authorityErr) {
-			return injectErr
+			return result, injectErr
 		}
 		if cfg.fallbackWarn {
 			_ = writeStderr("amq wake: TIOCSTI injection failed: %v\n", injectErr)
@@ -684,10 +760,10 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		}
 		// Fallback: use the output-only attention tier; never retry input.
 		emitWakeAttention(cfg, notice.output)
-		return nil
+		return result, nil
 	}
 
-	return nil
+	return result, nil
 }
 
 func usesCoopDoorbell(cfg *wakeConfig) bool {
@@ -787,7 +863,7 @@ func rawSubmitPrelude(me string) string {
 	return ""
 }
 
-func injectRawNotification(cfg *wakeConfig, injectedText string) error {
+func injectRawNotification(cfg *wakeConfig, injectedText string) (bool, error) {
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
 	}
@@ -796,10 +872,10 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: text inject failed: %v\n", err)
 		}
-		return err
+		return false, err
 	}
 	if !wrote {
-		return nil
+		return false, nil
 	}
 	prelude := rawSubmitPrelude(cfg.me)
 
@@ -827,10 +903,10 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 			if cfg.debug {
 				_ = writeStderr("amq wake [debug]: prelude inject failed: %v\n", err)
 			}
-			return err
+			return false, err
 		}
 		if !wrote {
-			return nil
+			return false, nil
 		}
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: prelude injected OK (%q)\n", prelude)
@@ -847,10 +923,10 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: submit key inject failed: %v\n", err)
 		}
-		return err
+		return false, err
 	}
 	if !wrote {
-		return nil
+		return false, nil
 	}
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: submit key injected OK\n")
@@ -869,7 +945,7 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", crWaited)
 		}
-		return nil
+		return true, nil
 	}
 	rawInjectSleep(rawInjectSettleDelay)
 	wrote, err = writeTerminalChunk(cfg, "\r")
@@ -878,20 +954,20 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) error {
 		// best-effort unless exact terminal authority was lost.
 		var authorityErr *wakeTerminalAuthorityError
 		if errors.As(err, &authorityErr) {
-			return err
+			return true, err
 		}
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
 		}
-		return nil
+		return true, nil
 	}
 	if !wrote {
-		return nil
+		return true, nil
 	}
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: rescue submit injected OK\n")
 	}
-	return nil
+	return true, nil
 }
 
 func waitForInputQueueDrain(

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -412,7 +412,7 @@ func deliverNewMessageNotification(
 	}
 
 	result, err := deliverWakeNotificationResult(cfg, notice, deferForInput)
-	if err == nil && ownerBound && result.inputSubmitted {
+	if ownerBound && result.inputSubmitted {
 		cfg.announcedPending = snapshotWakeFileIdentities(currentPending)
 	}
 	return err

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -1069,6 +1069,352 @@ func TestNotifyNewMessagesNormalSuccessUsesFixedInputOnly(t *testing.T) {
 	}
 }
 
+func TestNotifyNewMessagesCoalescesCoopInputUntilAnnouncedBacklogDrains(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	writeMessage := func(filename, id, subject string) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      id,
+				From:    "peer",
+				To:      []string{"codex"},
+				Thread:  "p2p/codex__peer",
+				Subject: subject,
+				Created: "2026-07-28T15:00:00Z",
+			},
+			Body: "body",
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "codex", filename, data); err != nil {
+			t.Fatalf("deliver %s: %v", id, err)
+		}
+	}
+
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+	var injected []string
+	cfg := &wakeConfig{
+		me:             "codex",
+		root:           root,
+		session:        "session3",
+		wakeOwner:      &wakeOwner{},
+		injectMode:     wakeInjectModeRaw,
+		attentionIsTTY: func() bool { return false },
+		terminalWrite: func(text string) error {
+			injected = append(injected, text)
+			return nil
+		},
+	}
+
+	writeMessage("first.md", "first", "first review")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify first message: %v", err)
+	}
+	if got := strings.Join(injected, "|"); got != coopWakeDoorbell+"|\n|\r|\r" {
+		t.Fatalf("first raw injection = %q, want one fixed doorbell submission", got)
+	}
+	injected = nil
+
+	writeMessage("second.md", "second", "second review")
+	stderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notify second message: %v", err)
+		}
+	})
+	if len(injected) != 0 {
+		t.Fatalf("second pending message injected another user turn: %q", injected)
+	}
+	for _, want := range []string{"AMQ [session3]: 2 messages", "2 from peer"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("coalesced output %q missing %q", stderr, want)
+		}
+	}
+
+	if drained := runDrainJSON(t, root, "codex", 1, false); drained.Count != 1 {
+		t.Fatalf("drained count = %d, want 1", drained.Count)
+	}
+	writeMessage("third.md", "third", "third review")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify after drain: %v", err)
+	}
+	if got := strings.Join(injected, "|"); got != coopWakeDoorbell+"|\n|\r|\r" {
+		t.Fatalf("post-drain raw injection = %q, want a fresh fixed doorbell submission", got)
+	}
+	injected = nil
+
+	writeMessage("fourth.md", "fourth", "fourth review")
+	stderr = captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notify after re-armed doorbell: %v", err)
+		}
+	})
+	if len(injected) != 0 {
+		t.Fatalf("re-armed backlog injected another user turn: %q", injected)
+	}
+	if !strings.Contains(stderr, "AMQ [session3]: 3 messages") {
+		t.Fatalf("re-armed coalesced output missing current count: %q", stderr)
+	}
+}
+
+func TestNotifyNewMessagesCoalescesUrgentCoopInputToAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	writeMessage := func(filename, id, subject, priority string, labels []string) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:   1,
+				ID:       id,
+				From:     "peer",
+				To:       []string{"codex"},
+				Thread:   "p2p/codex__peer",
+				Subject:  subject,
+				Created:  "2026-07-28T15:00:00Z",
+				Priority: priority,
+				Labels:   labels,
+			},
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "codex", filename, data); err != nil {
+			t.Fatalf("deliver %s: %v", id, err)
+		}
+	}
+
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+	var injected []string
+	cfg := &wakeConfig{
+		me:                "codex",
+		root:              root,
+		session:           "session3",
+		wakeOwner:         &wakeOwner{},
+		injectMode:        wakeInjectModeRaw,
+		previewLen:        48,
+		interrupt:         true,
+		interruptKey:      "\x03",
+		interruptLabel:    "interrupt",
+		interruptPriority: "urgent",
+		attentionIsTTY:    func() bool { return false },
+		terminalWrite: func(text string) error {
+			injected = append(injected, text)
+			return nil
+		},
+	}
+
+	writeMessage("first.md", "first", "first review", "", nil)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify first message: %v", err)
+	}
+	injected = nil
+
+	writeMessage("urgent.md", "urgent", "urgent review", "urgent", []string{"interrupt"})
+	stderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notify urgent message: %v", err)
+		}
+	})
+	if len(injected) != 0 {
+		t.Fatalf("urgent pending message injected another user turn: %q", injected)
+	}
+	for _, want := range []string{"AMQ interrupt [session3]", "urgent review"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("urgent coalesced output %q missing %q", stderr, want)
+		}
+	}
+}
+
+func TestNotifyNewMessagesRetriesCoopInputAfterOutputOnlyFallback(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	writeMessage := func(filename, id string) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      id,
+				From:    "peer",
+				To:      []string{"codex"},
+				Thread:  "p2p/codex__peer",
+				Subject: id,
+				Created: "2026-07-28T15:00:00Z",
+			},
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "codex", filename, data); err != nil {
+			t.Fatalf("deliver %s: %v", id, err)
+		}
+	}
+
+	working, outputPath := injectViaCaptureConfig(t)
+	cfg := &wakeConfig{
+		me:             "codex",
+		root:           root,
+		session:        "session3",
+		wakeOwner:      &wakeOwner{},
+		injectVia:      filepath.Join(root, "missing-injector"),
+		injectTimeout:  time.Second,
+		attentionIsTTY: func() bool { return false },
+	}
+
+	writeMessage("first.md", "first")
+	captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notify with unavailable input transport: %v", err)
+		}
+	})
+	if len(cfg.announcedPending) != 0 {
+		t.Fatalf("output-only fallback latched announced input: %#v", cfg.announcedPending)
+	}
+
+	cfg.injectVia = working.injectVia
+	cfg.injectArgs = working.injectArgs
+	cfg.injectTimeout = working.injectTimeout
+	writeMessage("second.md", "second")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("retry after output-only fallback: %v", err)
+	}
+	if got, err := os.ReadFile(outputPath); err != nil || string(got) != coopWakeDoorbell {
+		t.Fatalf("retry injection = %q, err=%v; want fixed doorbell", got, err)
+	}
+}
+
+func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        string
+		partialWant string
+		retryWant   string
+	}{
+		{
+			name:        "raw prelude",
+			mode:        wakeInjectModeRaw,
+			partialWant: coopWakeDoorbell + "|\n",
+			retryWant:   coopWakeDoorbell + "|\n|\r|\r",
+		},
+		{
+			name:        "paste submit",
+			mode:        wakeInjectModePaste,
+			partialWant: coopWakeDoorbell + "|\r",
+			retryWant:   coopWakeDoorbell + "|\r",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatalf("EnsureRootDirs: %v", err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+			writeMessage := func(filename, id string) {
+				t.Helper()
+				msg := format.Message{
+					Header: format.Header{
+						Schema:  1,
+						ID:      id,
+						From:    "peer",
+						To:      []string{"codex"},
+						Thread:  "p2p/codex__peer",
+						Subject: id,
+						Created: "2026-07-28T15:00:00Z",
+					},
+				}
+				data, err := msg.Marshal()
+				if err != nil {
+					t.Fatalf("marshal %s: %v", id, err)
+				}
+				if _, err := deliverToInboxForTest(t, root, "codex", filename, data); err != nil {
+					t.Fatalf("deliver %s: %v", id, err)
+				}
+			}
+
+			stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+				return 0, true, nil
+			})
+			stubRawInjectSleep(t)
+			failSubmit := true
+			var injected []string
+			stubTIOCSTIInject(t, func(text string) error {
+				injected = append(injected, text)
+				if failSubmit && len(injected) == 2 {
+					return errors.New("submit stage failed")
+				}
+				return nil
+			})
+			cfg := &wakeConfig{
+				me:             "codex",
+				root:           root,
+				session:        "session3",
+				wakeOwner:      &wakeOwner{},
+				injectMode:     tc.mode,
+				attentionIsTTY: func() bool { return false },
+			}
+
+			writeMessage("first.md", "first")
+			stderr := captureWakeStderr(t, func() {
+				if err := notifyNewMessages(cfg); err != nil {
+					t.Fatalf("notify with partial %s failure: %v", tc.mode, err)
+				}
+			})
+			if got := strings.Join(injected, "|"); got != tc.partialWant {
+				t.Fatalf("partial %s injection = %q, want %q", tc.mode, got, tc.partialWant)
+			}
+			if !strings.Contains(stderr, "AMQ [session3]: message from peer") {
+				t.Fatalf("partial %s fallback missing output attention: %q", tc.mode, stderr)
+			}
+			if len(cfg.announcedPending) != 0 {
+				t.Fatalf("partial %s failure latched announced input: %#v", tc.mode, cfg.announcedPending)
+			}
+
+			failSubmit = false
+			injected = nil
+			writeMessage("second.md", "second")
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("retry after partial %s failure: %v", tc.mode, err)
+			}
+			if got := strings.Join(injected, "|"); got != tc.retryWant {
+				t.Fatalf("retry %s injection = %q, want %q", tc.mode, got, tc.retryWant)
+			}
+			if len(cfg.announcedPending) != 2 {
+				t.Fatalf("successful %s retry announced %d messages, want 2", tc.mode, len(cfg.announcedPending))
+			}
+		})
+	}
+}
+
 func TestNotifyNewMessagesCustomInterruptUsesSanitizedOperatorPayloadForInputAndFallback(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -1415,6 +1415,89 @@ func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T
 	}
 }
 
+func TestNotifyNewMessagesLatchesRawSubmitBeforeRescueAuthorityError(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	writeMessage := func(filename, id string) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      id,
+				From:    "peer",
+				To:      []string{"codex"},
+				Thread:  "p2p/codex__peer",
+				Subject: id,
+				Created: "2026-07-28T15:00:00Z",
+			},
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "codex", filename, data); err != nil {
+			t.Fatalf("deliver %s: %v", id, err)
+		}
+	}
+
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+	failRescue := true
+	var injected []string
+	cfg := &wakeConfig{
+		me:             "codex",
+		root:           root,
+		session:        "session3",
+		wakeOwner:      &wakeOwner{},
+		injectMode:     wakeInjectModeRaw,
+		attentionIsTTY: func() bool { return false },
+		terminalWrite: func(text string) error {
+			injected = append(injected, text)
+			if failRescue && len(injected) == 4 {
+				return errors.New("foreground process group changed")
+			}
+			return nil
+		},
+	}
+
+	writeMessage("first.md", "first")
+	err := notifyNewMessages(cfg)
+	var authorityErr *wakeTerminalAuthorityError
+	if !errors.As(err, &authorityErr) {
+		t.Fatalf("notify rescue error = %v, want wakeTerminalAuthorityError", err)
+	}
+	if got := strings.Join(injected, "|"); got != coopWakeDoorbell+"|\n|\r|\r" {
+		t.Fatalf("raw injection before rescue error = %q, want submitted doorbell plus failed rescue", got)
+	}
+	if len(cfg.announcedPending) != 1 {
+		t.Fatalf("submitted doorbell announced %d pending messages after rescue error, want 1", len(cfg.announcedPending))
+	}
+
+	failRescue = false
+	injected = nil
+	writeMessage("second.md", "second")
+	stderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notify after rescue authority error: %v", err)
+		}
+	})
+	if len(injected) != 0 {
+		t.Fatalf("pending submitted doorbell retried terminal input: %q", injected)
+	}
+	for _, want := range []string{"AMQ [session3]: 2 messages", "2 from peer"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("coalesced output %q missing %q", stderr, want)
+		}
+	}
+}
+
 func TestNotifyNewMessagesCustomInterruptUsesSanitizedOperatorPayloadForInputAndFallback(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {


### PR DESCRIPTION
## Summary
- coalesce owner-bound wake input while an announced inbox identity remains pending
- keep current and urgent message counts visible as output-only attention without stacking synthetic user turns
- retry transports that fail before submit, while retaining positive submit evidence across a rescue-only terminal authority error

## Root cause
Each new inbox arrival injected another fixed AMQ doorbell even when a previously announced message was still pending. During long-running foreground tools, those synthetic user turns queued behind the active tool call and made the terminal look frozen.

## Verification
- go test ./...
- make fmt-check
- go vet ./...
- make smoke
- Windows amd64 internal/cli test compile
- FreeBSD amd64 internal/cli test compile
- Fable exact-tree review: PASS
- GPT-5.6 Sol Pro final exact-tree review: PASS

Not merged or installed; this PR preserves the authorization boundary.