### PR TITLE
ci(release): validate commit override blocks in PR bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: python3 scripts/check_pr_title.py "$PR_TITLE"
+      - name: Check commit overrides
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 scripts/check_commit_overrides.py
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,9 @@ AMQ owns agent-to-agent messaging, thread continuity, cross-project/session rout
 - PR titles must follow `type(scope): description`; the repository uses
   squash-only merges so the title becomes the conventional commit on `main`.
   Use `BEGIN_COMMIT_OVERRIDE` in a merged PR body or edit the release PR when a
-  change needs multiple or richer release-note entries.
+  change needs multiple or richer release-note entries. Each override entry
+  must be one conventional header of at most 72 characters, separated from
+  adjacent entries by a blank line.
 
 ## Operational Constraints
 

--- a/scripts/check_commit_overrides.py
+++ b/scripts/check_commit_overrides.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Validate release-note commit overrides embedded in a PR body."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import check_pr_title
+
+
+BEGIN_MARKER = "BEGIN_COMMIT_OVERRIDE"
+END_MARKER = "END_COMMIT_OVERRIDE"
+MAX_HEADER_LENGTH = 72
+
+
+def marker_matches(body: str, marker: str) -> list[re.Match[str]]:
+    marker_line = rf"(?:{marker}|<!--[ \t]*{marker}[ \t]*-->)"
+    return list(re.finditer(rf"(?m)^[ \t]*{marker_line}[ \t]*$", body))
+
+
+def validate_body(body: str) -> list[str]:
+    begin_count = body.count(BEGIN_MARKER)
+    end_count = body.count(END_MARKER)
+    if begin_count == 0 and end_count == 0:
+        return []
+    if begin_count != 1 or end_count != 1:
+        return [
+            "commit override markers must appear exactly once as a pair; if you "
+            'are only referencing a marker in prose, write "commit override block" '
+            "instead of the literal marker text"
+        ]
+
+    begin_matches = marker_matches(body, BEGIN_MARKER)
+    end_matches = marker_matches(body, END_MARKER)
+    if len(begin_matches) != 1 or len(end_matches) != 1:
+        return [
+            "commit override markers must occupy their own plain or HTML-comment "
+            'lines; if you are only referencing a marker in prose, write "commit '
+            'override block" instead of the literal marker text'
+        ]
+
+    begin = begin_matches[0]
+    end = end_matches[0]
+    if begin.start() >= end.start():
+        return ["commit override end marker must follow its begin marker"]
+
+    content = body[begin.end() : end.start()].strip()
+    if not content:
+        return ["commit override block must contain at least one entry"]
+
+    errors: list[str] = []
+    entries = re.split(r"\n[ \t]*\n", content)
+    for index, entry in enumerate(entries, start=1):
+        lines = entry.splitlines()
+        if len(lines) != 1:
+            errors.append(f"commit override entry {index} must be a single line")
+            continue
+
+        header = lines[0]
+        if len(header) > MAX_HEADER_LENGTH:
+            errors.append(
+                f"commit override entry {index} exceeds {MAX_HEADER_LENGTH} characters"
+            )
+        if not check_pr_title.is_valid_title(header):
+            errors.append(
+                f"commit override entry {index} is not a conventional header: {header!r}"
+            )
+    return errors
+
+
+def main() -> int:
+    body = os.environ.get("PR_BODY", "")
+    errors = validate_body(body)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print("PR commit overrides are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -129,6 +129,7 @@ if command -v python3 >/dev/null 2>&1; then
   python3 scripts/test_session_name.py
   echo "python session-name tests ok"
   python3 scripts/test_check_pr_title.py
+  python3 scripts/test_check_commit_overrides.py
   python3 scripts/test_release_changelog_section.py
   python3 scripts/test_release_please_config.py
   bash scripts/test_release_metadata.sh

--- a/scripts/test_check_commit_overrides.py
+++ b/scripts/test_check_commit_overrides.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Tests for the commit-override PR-body gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+
+SCRIPT = pathlib.Path(__file__).with_name("check_commit_overrides.py")
+spec = importlib.util.spec_from_file_location("check_commit_overrides", SCRIPT)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"cannot load {SCRIPT}")
+check_commit_overrides = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_commit_overrides)
+
+
+def test_valid_bodies() -> None:
+    bodies = [
+        "",
+        "No release-note overrides.",
+        """## Release notes
+BEGIN_COMMIT_OVERRIDE
+fix(upgrade): report stale wakes after upgrade
+
+fix(wake): preserve usable legacy raw wakes
+END_COMMIT_OVERRIDE
+""",
+        """## Release notes
+<!-- BEGIN_COMMIT_OVERRIDE -->
+fix(upgrade): report stale wakes after upgrade
+
+fix(wake): preserve usable legacy raw wakes
+<!-- END_COMMIT_OVERRIDE -->
+""",
+    ]
+    for body in bodies:
+        assert check_commit_overrides.validate_body(body) == [], body
+
+
+def test_invalid_marker_shapes() -> None:
+    bodies = [
+        "BEGIN_COMMIT_OVERRIDE\nfix: one\n",
+        "fix: one\nEND_COMMIT_OVERRIDE",
+        """BEGIN_COMMIT_OVERRIDE
+fix: one
+BEGIN_COMMIT_OVERRIDE
+fix: two
+END_COMMIT_OVERRIDE
+""",
+        """BEGIN_COMMIT_OVERRIDE
+END_COMMIT_OVERRIDE
+""",
+    ]
+    for body in bodies:
+        assert check_commit_overrides.validate_body(body), body
+
+
+def test_prose_marker_mention_has_actionable_remedy() -> None:
+    bodies = [
+        "This prose mentions BEGIN_COMMIT_OVERRIDE support.",
+        """This prose mentions BEGIN_COMMIT_OVERRIDE.
+It later mentions END_COMMIT_OVERRIDE too.
+""",
+    ]
+    for body in bodies:
+        errors = check_commit_overrides.validate_body(body)
+        assert len(errors) == 1
+        assert (
+            'write "commit override block" instead of the literal marker text'
+            in errors[0]
+        )
+
+
+def test_invalid_entries() -> None:
+    bodies = [
+        """BEGIN_COMMIT_OVERRIDE
+not a conventional header
+END_COMMIT_OVERRIDE
+""",
+        """BEGIN_COMMIT_OVERRIDE
+fix(upgrade): report stale wakes across the active AMQ base tree after
+upgrade
+END_COMMIT_OVERRIDE
+""",
+        """BEGIN_COMMIT_OVERRIDE
+fix(upgrade): report stale wakes across the active AMQ base tree after upgrade
+END_COMMIT_OVERRIDE
+""",
+    ]
+    for body in bodies:
+        assert check_commit_overrides.validate_body(body), body
+
+
+if __name__ == "__main__":
+    test_valid_bodies()
+    test_invalid_marker_shapes()
+    test_prose_marker_mention_has_actionable_remedy()
+    test_invalid_entries()
+    print("commit override tests ok")


### PR DESCRIPTION
## Summary
- validate release-note commit override blocks during pull-request CI
- require each entry to be one conventional header no longer than 72 characters
- accept both upstream plain marker lines and the repository HTML-comment form
- give an actionable rewrite when marker tokens are mentioned only as prose

## Why
GitHub hard-wraps the squash body at 72 columns. Rejecting longer override headers before merge prevents Release Please from silently dropping wrapped entries, which is earlier and safer than detecting the malformed commit after it reaches main.

## Verification
- focused override checker tests, including PR #351 regression and prose-only cases
- `make ci`
- independent fresh-context review
- Claude exact-tree review and approved final delta

Closes #354