### PR TITLE
fix(wake): surface owner lifecycle failures

### DIFF
--- a/internal/cli/wake_owner_lifecycle_unix_test.go
+++ b/internal/cli/wake_owner_lifecycle_unix_test.go
@@ -1307,6 +1307,137 @@ func TestRecoverOwnerUsesAuthoritativeLockEvidenceWhenTargetIsMissing(t *testing
 	}
 }
 
+func TestRecoverOwnerPreservesClaimWhenTargetIsMissingWithMatchingPreparedMarker(t *testing.T) {
+	testRecoverOwnerPreservesClaimWhenTargetIsMissingWithPreparedMarker(
+		t,
+		false,
+		"target snapshot is unavailable",
+	)
+}
+
+func TestRecoverOwnerPreservesClaimWhenTargetIsMissingAndPreparedSnapshotFails(t *testing.T) {
+	testRecoverOwnerPreservesClaimWhenTargetIsMissingWithPreparedMarker(
+		t,
+		true,
+		"wake prepared marker must be a regular 0600 file",
+	)
+}
+
+func testRecoverOwnerPreservesClaimWhenTargetIsMissingWithPreparedMarker(
+	t *testing.T,
+	failPreparedSnapshot bool,
+	wantReason string,
+) {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-missing-target-prepared-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Generation:   "owner-missing-target-prepared-generation",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+	preparedPath := wakePreparedPath(root, "codex")
+	prepared := wakeReady{
+		Schema:       wakeReadySchema,
+		Generation:   lock.Generation,
+		TargetDigest: lock.TargetDigest,
+	}
+	if err := writeWakeGenerationFile(preparedPath, "wake prepared marker", prepared); err != nil {
+		t.Fatal(err)
+	}
+	if failPreparedSnapshot {
+		if err := os.Chmod(preparedPath, 0o400); err != nil {
+			t.Fatal(err)
+		}
+	}
+	beforeLock := inspectWakeLock(root, "codex")
+	if !beforeLock.Exists {
+		t.Fatal("authoritative lock is missing before recovery")
+	}
+	preparedInfo, err := os.Lstat(preparedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparedData, err := os.ReadFile(preparedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid}
+	})
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+		return wakeOwnerObservation{State: wakeOwnerDead}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+	originalSync := syncWakeOwnerDirFD
+	syncCalls := 0
+	syncWakeOwnerDirFD = func(int) error {
+		syncCalls++
+		return nil
+	}
+	t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		result, err := recoverOwnerWake(root, "codex")
+		if err == nil || result.Status != "error" ||
+			!strings.Contains(result.Reason, wantReason) {
+			t.Fatalf("attempt %d result = %#v err=%v, want unchanged-state validation error", attempt, result, err)
+		}
+		if !sameWakeLockGeneration(beforeLock, inspectWakeLock(root, "codex")) {
+			t.Fatalf("attempt %d changed authoritative lock", attempt)
+		}
+		gotPreparedInfo, statErr := os.Lstat(preparedPath)
+		if statErr != nil {
+			t.Fatalf("attempt %d stat prepared marker: %v", attempt, statErr)
+		}
+		gotPreparedData, readErr := os.ReadFile(preparedPath)
+		if readErr != nil {
+			t.Fatalf("attempt %d read prepared marker: %v", attempt, readErr)
+		}
+		if !sameWakeFileIdentity(preparedInfo, gotPreparedInfo) ||
+			!bytes.Equal(preparedData, gotPreparedData) {
+			t.Fatalf("attempt %d changed prepared marker", attempt)
+		}
+		if _, exists, readErr := readWakeTarget(root, "codex"); readErr != nil || exists {
+			t.Fatalf("attempt %d missing target = exists=%v err=%v", attempt, exists, readErr)
+		}
+		tempMatches, globErr := filepath.Glob(filepath.Join(fsq.AgentBase(root, "codex"), ".wake*.tmp.*"))
+		if globErr != nil {
+			t.Fatal(globErr)
+		}
+		if len(tempMatches) != 0 {
+			t.Fatalf("attempt %d left temporary wake files: %v", attempt, tempMatches)
+		}
+	}
+	if syncCalls != 0 {
+		t.Fatalf("failed recoveries synced the wake owner directory %d times", syncCalls)
+	}
+}
+
 func TestRecoverOwnerPreservesMalformedAuthoritativeLockEnvelope(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -467,17 +467,19 @@ func removeAuthoritativeWakeClaimAt(
 	)
 	if err != nil {
 		preparedSnapshotErr = fmt.Errorf("snapshot released wake prepared marker: %w", err)
+		if releaseTargetSnapshot == nil {
+			return preparedSnapshotErr
+		}
 	} else if preparedExists &&
 		preparedSnapshot.Marker.Schema == wakeReadySchema &&
 		preparedSnapshot.Marker.Generation == current.Lock.Generation &&
 		preparedSnapshot.Marker.TargetDigest == current.Lock.TargetDigest {
-		if current.Lock.TargetDigest != "" && releaseTargetSnapshot == nil {
-			preparedSnapshotErr = fmt.Errorf(
+		if releaseTargetSnapshot == nil {
+			return fmt.Errorf(
 				"validate released wake prepared marker: authoritative wake target snapshot is unavailable",
 			)
-		} else {
-			releasePreparedSnapshot = &preparedSnapshot
 		}
+		releasePreparedSnapshot = &preparedSnapshot
 	}
 
 	if err := unix.Unlinkat(dirfd, ".wake.lock", 0); err != nil {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1365,7 +1365,7 @@ func buildRepairWakeArgs(root, me string, target wakeTarget, generation, readyPa
 	return args
 }
 
-func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
+func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	privateStop, cleanupPrivateStop, err := authoritativeWakePrivateStopFromEnv()
 	if err != nil {
 		return err
@@ -1566,7 +1566,14 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		if err != nil {
 			return err
 		}
-		defer func() { _ = ownerObservation.Close() }()
+		defer func() {
+			if err := ownerObservation.Close(); err != nil {
+				returnErr = errors.Join(
+					returnErr,
+					fmt.Errorf("requested wake owner observation failed: %w", err),
+				)
+			}
+		}()
 	}
 
 	var initialNotifierStatus string
@@ -1725,7 +1732,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 		if requestedOwner != nil {
 			select {
 			case <-ownerObservation.Done():
-				return fmt.Errorf("requested wake owner exited before lock acquisition")
+				return fmt.Errorf("requested wake owner observation ended before lock acquisition")
 			default:
 			}
 		}
@@ -1760,7 +1767,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) error {
 			if requestedOwner != nil {
 				select {
 				case <-ownerObservation.Done():
-					return fmt.Errorf("requested wake owner exited before existing-wake readiness")
+					return fmt.Errorf("requested wake owner observation ended before existing-wake readiness")
 				default:
 				}
 			}

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1075,6 +1075,92 @@ func TestRunWakeWithLoopSupervisesOwnerBeforeGenericLockAndMergesDone(t *testing
 	}
 }
 
+func TestRunWakeWithLoopDistinguishesOwnerExitFromMonitorFailure(t *testing.T) {
+	monitorFailure := errors.New("owner monitor failed")
+	loopFailure := errors.New("wake loop failed")
+	tests := []struct {
+		name       string
+		monitorErr error
+		loopErr    error
+	}{
+		{
+			name: "owner exit is a normal stop",
+		},
+		{
+			name:       "monitor failure is returned",
+			monitorErr: monitorFailure,
+		},
+		{
+			name:       "monitor and loop failures are both returned",
+			monitorErr: monitorFailure,
+			loopErr:    loopFailure,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+				t.Fatal(err)
+			}
+			owner := wakeOwner{
+				PID:          4242,
+				ProcessStart: "12345",
+				BootID:       "11111111-1111-1111-1111-111111111111",
+				SessionID:    99,
+			}
+			encoded, err := encodeWakeOwnerEnv(owner)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv(envWakeOwner, encoded)
+
+			monitor := newWakeOwnerObservationMonitor(nil)
+			oldObserve := observeAuthoritativeWakeOwner
+			observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+				if got != owner {
+					t.Fatalf("observed owner = %#v, want %#v", got, owner)
+				}
+				return wakeOwnerObservation{
+					State:   wakeOwnerSame,
+					monitor: monitor,
+				}, nil
+			}
+			t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+			err = runWakeWithLoop([]string{
+				"--root", root,
+				"--me", "orchestrator",
+				"--inject-mode", wakeInjectModeNone,
+			}, func(cfg wakeConfig) error {
+				monitor.finish(test.monitorErr)
+				select {
+				case <-cfg.controlStop:
+					return test.loopErr
+				case <-time.After(time.Second):
+					t.Fatal("owner observation did not stop the wake loop")
+					return nil
+				}
+			})
+			if test.monitorErr == nil {
+				if err != nil {
+					t.Fatalf("normal owner exit returned error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, test.monitorErr) {
+				t.Fatalf("monitor failure result = %v, want %v", err, test.monitorErr)
+			}
+			if test.loopErr != nil && !errors.Is(err, test.loopErr) {
+				t.Fatalf("joined result = %v, want loop failure %v", err, test.loopErr)
+			}
+		})
+	}
+}
+
 func TestRunWakeWithLoopRejectsSameOwnerWithoutLifetimeSignalBeforeLock(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {


### PR DESCRIPTION
## Summary
Surface pidfd/kqueue owner-monitor failures instead of treating them as a clean owner exit.

Make recover-owner fail closed before unlinking the authoritative lock when the target is missing and a matching prepared marker, or a prepared-marker snapshot error, prevents safe cleanup.

## Changes
- Join owner-observation close failures with any wake-loop error.
- Preserve the authoritative lock and prepared marker across unsafe recovery retries.
- Add regressions for normal exit, monitor failure, concurrent errors, matching markers, and snapshot failures.

## Testing
- [x] make ci
- [x] go test -race ./internal/cli
- [x] Cross-compile internal/cli for linux/amd64, linux/arm64, freebsd/amd64, and windows/amd64
- [x] Independent Codex review: PASS
- [x] GPT-5.6 Sol Pro review via Yoetz: PASS

## Related Issues
Reported by Ohad; no GitHub issue.