### PR TITLE
fix(wake): preserve notification obligation across fallbacks

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -9,6 +9,7 @@
   "repository": "https://github.com/avivsinai/agent-message-queue",
   "license": "MIT",
   "skills": "./skills/",
+  "hooks": "./hooks/codex-hooks.json",
   "keywords": [
     "messaging",
     "agents",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,1 @@
+../hooks/codex-hooks.json

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ __pycache__/
 !.claude/skills/
 !.claude/skills/**
 .claude/skills/*-workspace/
-.codex/
+.codex/**
+!.codex/hooks.json
 .agents/**
 !.agents/skills/
 !.agents/skills/**

--- a/COOP.md
+++ b/COOP.md
@@ -302,20 +302,25 @@ For the first notification test, start both `coop exec` agents before sending
 the message. If a message was already waiting when the target wake started, it
 will not notify; it remains unread and visible to `amq drain --include-body`.
 
-For Codex raw/paste sessions, a terminal write is only a delivery attempt.
-While the same inbox cohort remains unread, wake retries a fixed, tokenized
-doorbell on its own capped backoff. Removing or replacing any message from that
-cohort is durable progress and immediately rearms the next notification.
-Retries do not repeat the out-of-band attention text.
+For owner-bound raw, paste, and `--wake-inject-via` sessions started by
+`amq coop exec`, wake treats one transport execution only as a delivery
+attempt. While the same inbox cohort remains unread, wake retries a fixed,
+tokenized doorbell on its own capped backoff. The delay starts after the prior
+injector process exits or times out. Because an external injector is arbitrary
+local code, retries can duplicate its side effects. Removing or replacing any
+message from that cohort is durable progress and immediately rearms the next
+notification. Retries do not repeat the out-of-band attention text. Standalone
+ownerless `amq wake` keeps its legacy one-shot notification behavior.
 
 On macOS, the bundled Codex `UserPromptSubmit` hook can observe the exact
 doorbell token and pause retries for a short, nonrenewable lease. Hook
 observation does not acknowledge, drain, or complete a message; only inbox
 progress does. Hook activation is therefore an optimization, not a liveness
-requirement. Use
-Codex's `/hooks` view to confirm activation in the current environment. If
-project hooks are unavailable or untrusted, wake continues retrying and the
-agent may see duplicate doorbells until it drains the inbox.
+requirement. Use Codex's `/hooks` view to confirm activation in the current
+environment. If project hooks are unavailable or untrusted, wake continues
+retrying and the agent may see duplicate doorbells until it drains the inbox.
+Linux co-op wakes have no prompt-observation lease; their retries continue on a
+capped backoff until the inbox makes durable progress.
 
 For orchestrators or hardened environments without a controlling TTY, use an
 explicit external transport:
@@ -348,12 +353,20 @@ amq wake --me claude --inject-mode none --bell &
 amq coop exec --require-wake --wake-inject-mode none claude
 ```
 
-`none` writes notification text (and the optional bell) to wake's stderr and
-never writes terminal input. Urgent interrupt messages degrade to one bell plus
-the stderr notice instead of Ctrl+C. Because `--inject-via` is arbitrary local
+`none` never writes terminal input. `coop exec` gives its wake child separate
+process capabilities: full stdout/stderr diagnostics append to the private
+`agents/<agent>/.wake.log`, while notification attention uses a dedicated
+terminal descriptor. Codex and Claude receive only terminal-safe title, bell,
+and supported desktop-notification sequences on that descriptor, so runtime,
+cleanup, and top-level fatal diagnostics cannot overwrite the active composer.
+Without a controlling terminal, attention is appended to the same durable log.
+Urgent interrupt messages degrade to terminal-safe attention instead of Ctrl+C.
+Because
+`--inject-via` is arbitrary local
 code and may itself inject terminal input, `none` rejects `--inject-via`,
-`--inject-arg`, and `--inject-cmd`. Stderr output shares the TUI terminal by
-default and may remain visible until the TUI redraws.
+`--inject-arg`, and `--inject-cmd`. A directly launched or externally
+supervised `amq wake` should likewise route stdout/stderr to a private log when
+it shares a terminal with an alternate-screen agent.
 
 ### Supervisor recipes
 

--- a/COOP.md
+++ b/COOP.md
@@ -308,10 +308,11 @@ doorbell on its own capped backoff. Removing or replacing any message from that
 cohort is durable progress and immediately rearms the next notification.
 Retries do not repeat the out-of-band attention text.
 
-The bundled Codex `UserPromptSubmit` hook can observe the exact doorbell token
-and pause retries for a short, nonrenewable lease. Hook observation does not
-acknowledge, drain, or complete a message; only inbox progress does. Hook
-activation is therefore an optimization, not a liveness requirement. Use
+On macOS, the bundled Codex `UserPromptSubmit` hook can observe the exact
+doorbell token and pause retries for a short, nonrenewable lease. Hook
+observation does not acknowledge, drain, or complete a message; only inbox
+progress does. Hook activation is therefore an optimization, not a liveness
+requirement. Use
 Codex's `/hooks` view to confirm activation in the current environment. If
 project hooks are unavailable or untrusted, wake continues retrying and the
 agent may see duplicate doorbells until it drains the inbox.

--- a/COOP.md
+++ b/COOP.md
@@ -302,6 +302,20 @@ For the first notification test, start both `coop exec` agents before sending
 the message. If a message was already waiting when the target wake started, it
 will not notify; it remains unread and visible to `amq drain --include-body`.
 
+For Codex raw/paste sessions, a terminal write is only a delivery attempt.
+While the same inbox cohort remains unread, wake retries a fixed, tokenized
+doorbell on its own capped backoff. Removing or replacing any message from that
+cohort is durable progress and immediately rearms the next notification.
+Retries do not repeat the out-of-band attention text.
+
+The bundled Codex `UserPromptSubmit` hook can observe the exact doorbell token
+and pause retries for a short, nonrenewable lease. Hook observation does not
+acknowledge, drain, or complete a message; only inbox progress does. Hook
+activation is therefore an optimization, not a liveness requirement. Use
+Codex's `/hooks` view to confirm activation in the current environment. If
+project hooks are unavailable or untrusted, wake continues retrying and the
+agent may see duplicate doorbells until it drains the inbox.
+
 For orchestrators or hardened environments without a controlling TTY, use an
 explicit external transport:
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,21 @@ amq coop exec codex
 ```
 
 Each command sets up the environment, starts wake notifications, and launches
-the agent.
+the agent. The wake child appends full diagnostics to the private
+`agents/<agent>/.wake.log`; a separate inherited descriptor carries only
+terminal-safe attention to the controlling terminal. This process boundary
+keeps runtime and fatal-error text out of Codex and Claude full-screen
+composers.
 
-Codex terminal notifications are retried until the inbox makes durable
-progress. The bundled prompt-observation hook only pauses duplicate retries for
-a short lease; it never acknowledges or drains a message.
+Owner-bound raw, paste, and external-injector wakes started by `amq coop exec`
+retry terminal notifications on a capped backoff until the inbox makes durable
+progress. The delay starts after the preceding injector process exits or times
+out. Because `--wake-inject-via` executes arbitrary local code, a retry can
+repeat injector-side effects. Standalone ownerless `amq wake` remains one-shot.
+On macOS, the bundled Codex prompt-observation hook can pause duplicate retries
+for a short lease; it never acknowledges or drains a message. Linux co-op wakes
+retain liveness through retries on that capped backoff, without an observation
+lease.
 
 > **First-message check:** start both agents before sending the test message.
 > A newly started wake deliberately baselines messages that were already

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ amq coop exec codex
 Each command sets up the environment, starts wake notifications, and launches
 the agent.
 
+Codex terminal notifications are retried until the inbox makes durable
+progress. The bundled prompt-observation hook only pauses duplicate retries for
+a short lease; it never acknowledges or drains a message.
+
 > **First-message check:** start both agents before sending the test message.
 > A newly started wake deliberately baselines messages that were already
 > waiting, so they remain unread but do not trigger a notification. If you sent

--- a/hooks/codex-hooks.json
+++ b/hooks/codex-hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HOOK_ROOT=\"${PLUGIN_ROOT:-}\"; if [ -z \"$HOOK_ROOT\" ]; then HOOK_ROOT=\"$(git rev-parse --show-toplevel 2>/dev/null || true)\"; fi; AMQ_HOOK=\"$HOOK_ROOT/hooks/codex-prompt-observed.py\"; if [ -n \"$HOOK_ROOT\" ] && [ -f \"$AMQ_HOOK\" ]; then /usr/bin/python3 \"$AMQ_HOOK\"; else /usr/bin/true; fi",
+            "timeout": 2
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/codex-prompt-observed.py
+++ b/hooks/codex-prompt-observed.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python3
+"""Observe one exact AMQ doorbell prompt without touching mailbox contents."""
+
+import json
+import os
+import re
+import socket
+import stat
+import sys
+
+
+MAX_HOOK_INPUT = 64 * 1024
+MAX_LOCK_INPUT = 16 * 1024
+PROMPT_RE = re.compile(
+    r": AMQ doorbell v1 token=([0-9a-f]{32}) "
+    r"run amq drain --include-body then act on it"
+)
+AGENT_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def _read_bounded(stream, limit):
+    data = stream.read(limit + 1)
+    if len(data) > limit:
+        raise ValueError("input too large")
+    return data
+
+
+def _owned_private_directory(path):
+    info = os.lstat(path)
+    return (
+        stat.S_ISDIR(info.st_mode)
+        and not stat.S_ISLNK(info.st_mode)
+        and info.st_uid == os.geteuid()
+        and info.st_mode & 0o077 == 0
+    )
+
+
+def _read_lock(path):
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags)
+    try:
+        info = os.fstat(fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_uid != os.geteuid()
+            or info.st_mode & 0o077 != 0
+        ):
+            raise ValueError("unsafe wake lock")
+        with os.fdopen(fd, "rb", closefd=False) as stream:
+            data = _read_bounded(stream, MAX_LOCK_INPUT)
+    finally:
+        os.close(fd)
+    value = json.loads(data)
+    if not isinstance(value, dict):
+        raise ValueError("invalid wake lock")
+    return value
+
+
+def _safe_socket(agent_dir, raw_path):
+    if not isinstance(raw_path, str) or not raw_path:
+        raise ValueError("missing control socket")
+    path = os.path.realpath(raw_path)
+    if os.path.dirname(path) != agent_dir:
+        raise ValueError("control socket outside agent directory")
+    info = os.lstat(path)
+    if (
+        not stat.S_ISSOCK(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or info.st_mode & 0o077 != 0
+    ):
+        raise ValueError("unsafe control socket")
+    return path
+
+
+def main():
+    event = json.loads(_read_bounded(sys.stdin.buffer, MAX_HOOK_INPUT))
+    if not isinstance(event, dict) or event.get("hook_event_name") != "UserPromptSubmit":
+        return
+    if event.get("agent_id") is not None or event.get("agent_type") is not None:
+        return
+    prompt = event.get("prompt")
+    if not isinstance(prompt, str):
+        return
+    match = PROMPT_RE.fullmatch(prompt)
+    if match is None:
+        return
+    token = match.group(1)
+
+    raw_root = os.environ.get("AM_ROOT", "")
+    agent = os.environ.get("AM_ME", "")
+    if not os.path.isabs(raw_root) or AGENT_RE.fullmatch(agent) is None:
+        return
+    root = os.path.realpath(raw_root)
+    agent_dir = os.path.join(root, "agents", agent)
+    if not _owned_private_directory(agent_dir):
+        return
+
+    lock = _read_lock(os.path.join(agent_dir, ".wake.lock"))
+    generation = lock.get("generation")
+    if (
+        lock.get("root") != root
+        or lock.get("agent") != agent
+        or lock.get("wake_mode") not in ("raw", "paste", "owner-inject-via-v1")
+        or not isinstance(generation, str)
+        or re.fullmatch(r"[0-9a-f]{32}", generation) is None
+    ):
+        return
+    control_socket = _safe_socket(agent_dir, lock.get("control_socket"))
+
+    request = {
+        "generation": generation,
+        "operation": "prompt_observed",
+        "token": token,
+    }
+    owner = lock.get("owner")
+    if isinstance(owner, dict):
+        request["owner"] = owner
+
+    payload = json.dumps(request, separators=(",", ":")).encode("ascii") + b"\n"
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(0.5)
+        client.connect(control_socket)
+        client.sendall(payload)
+        if client.recv(16).strip() != b"ACK":
+            return
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        pass

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
 )
 
 const wakeReadyTimeout = 25 * time.Second
@@ -23,6 +24,30 @@ const wakeProcessExitTimeout = 5 * time.Second
 var killWakeHelperProcess = func(proc *os.Process) error { return proc.Kill() }
 
 var coopExecProcess = syscall.Exec
+
+var openCoopWakeTTY = func() (*os.File, error) {
+	return os.OpenFile("/dev/tty", os.O_WRONLY|unix.O_CLOEXEC, 0)
+}
+
+func openCoopWakeAttention(output *os.File) (*os.File, error) {
+	if attention, err := openCoopWakeTTY(); err == nil {
+		return attention, nil
+	}
+	if output == nil {
+		return nil, fmt.Errorf("wake diagnostics are unavailable")
+	}
+	fd, err := unix.Dup(int(output.Fd()))
+	if err != nil {
+		return nil, fmt.Errorf("duplicate wake diagnostics for non-terminal attention: %w", err)
+	}
+	unix.CloseOnExec(fd)
+	attention := os.NewFile(uintptr(fd), output.Name())
+	if attention == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("adopt non-terminal wake attention descriptor")
+	}
+	return attention, nil
+}
 
 func runCoopExec(args []string) error {
 	// Split at "--" before flag parsing so agent flags aren't consumed.
@@ -288,7 +313,13 @@ func runCoopExec(args []string) error {
 	var wakeHelperClaim *wakeLockInspection
 	var cleanupWakeReady func()
 	var earlyOwner *wakeOwner
-	baseEnv := unsetEnvVar(unsetEnvVar(os.Environ(), envWakeOwner), envWakePrivateStopFD)
+	baseEnv := unsetEnvVar(
+		unsetEnvVar(
+			unsetEnvVar(os.Environ(), envWakeOwner),
+			envWakePrivateStopFD,
+		),
+		envWakeAttentionFD,
+	)
 	retainWakeHelperClaim := func(current wakeLockInspection) {
 		if retained := exactCoopWakeHelperClaim(wakeProc, current); retained != nil {
 			wakeHelperClaim = retained
@@ -335,8 +366,21 @@ func runCoopExec(args []string) error {
 			}
 			wakeCmd.Env = wakeEnv
 			wakeCmd.Stdin = os.Stdin
-			wakeCmd.Stdout = os.Stdout
-			wakeCmd.Stderr = os.Stderr
+			wakeOutput, outputErr := openCoopWakeOutput(root, agentHandle)
+			if outputErr != nil {
+				return fmt.Errorf("open durable coop wake diagnostics: %w", outputErr)
+			}
+			defer func() { _ = wakeOutput.Close() }()
+			wakeAttention, attentionErr := openCoopWakeAttention(wakeOutput)
+			if attentionErr != nil {
+				return fmt.Errorf("open isolated coop wake attention: %w", attentionErr)
+			}
+			defer func() { _ = wakeAttention.Close() }()
+			wakeCmd.Stdout = wakeOutput
+			wakeCmd.Stderr = wakeOutput
+			if err := attachWakeAttentionFD(wakeCmd, wakeAttention); err != nil {
+				return fmt.Errorf("attach isolated coop wake attention: %w", err)
+			}
 			wakeChildCapability, err = configureAuthoritativeWakeChild(wakeCmd)
 			if err == nil && wakeChildCapability == nil {
 				return fmt.Errorf("prepare exact-owner amq wake supervision returned nil capability")

--- a/internal/cli/coop_raw_injection_adversarial_unix_test.go
+++ b/internal/cli/coop_raw_injection_adversarial_unix_test.go
@@ -19,10 +19,7 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-const (
-	adversarialCoopDoorbell = ": AMQ doorbell run amq drain --include-body then act on it"
-	publicCoopPTYTimeout    = 12 * time.Second
-)
+const publicCoopPTYTimeout = 12 * time.Second
 
 func TestCoopRawDoorbellDoesNotContainMessageDerivedBytes(t *testing.T) {
 	root := secureTempDirForTest(t)
@@ -181,8 +178,9 @@ func TestPublicCoopRawPTYDoorbellAndOwnerCleanup(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read public PTY input: %v", err)
 		}
-		if got := strings.TrimSuffix(string(line), "\r"); got != adversarialCoopDoorbell {
-			t.Fatalf("public PTY input = %q, want fixed doorbell %q", got, adversarialCoopDoorbell)
+		got := strings.TrimSuffix(string(line), "\r")
+		if _, valid := parseCoopWakeDoorbell(got); !valid {
+			t.Fatalf("public PTY input = %q, want canonical tokenized doorbell", got)
 		}
 		for _, sentinel := range sentinels {
 			if bytes.Contains(line, []byte(sentinel)) {
@@ -225,9 +223,9 @@ func assertFixedASCIIOnlyCoopInjection(t *testing.T, chunks, forbidden []string)
 	if len(chunks) == 0 {
 		t.Fatal("coop raw wake injected no doorbell")
 	}
-	if chunks[0] != adversarialCoopDoorbell {
-		t.Fatalf("first coop injection chunk = %q, want %q; all chunks=%#v",
-			chunks[0], adversarialCoopDoorbell, chunks)
+	if _, valid := parseCoopWakeDoorbell(chunks[0]); !valid {
+		t.Fatalf("first coop injection chunk = %q, want canonical tokenized doorbell; all chunks=%#v",
+			chunks[0], chunks)
 	}
 	joined := strings.Join(chunks, "")
 	for index, value := range []byte(joined) {

--- a/internal/cli/coop_raw_injection_adversarial_unix_test.go
+++ b/internal/cli/coop_raw_injection_adversarial_unix_test.go
@@ -179,7 +179,7 @@ func TestPublicCoopRawPTYDoorbellAndOwnerCleanup(t *testing.T) {
 			t.Fatalf("read public PTY input: %v", err)
 		}
 		got := strings.TrimSuffix(string(line), "\r")
-		if _, valid := parseCoopWakeDoorbell(got); !valid {
+		if !validCoopWakeDoorbell(got) {
 			t.Fatalf("public PTY input = %q, want canonical tokenized doorbell", got)
 		}
 		for _, sentinel := range sentinels {
@@ -223,7 +223,7 @@ func assertFixedASCIIOnlyCoopInjection(t *testing.T, chunks, forbidden []string)
 	if len(chunks) == 0 {
 		t.Fatal("coop raw wake injected no doorbell")
 	}
-	if _, valid := parseCoopWakeDoorbell(chunks[0]); !valid {
+	if !validCoopWakeDoorbell(chunks[0]) {
 		t.Fatalf("first coop injection chunk = %q, want canonical tokenized doorbell; all chunks=%#v",
 			chunks[0], chunks)
 	}

--- a/internal/cli/coop_wake_owner_lifecycle_unix_test.go
+++ b/internal/cli/coop_wake_owner_lifecycle_unix_test.go
@@ -26,6 +26,65 @@ const (
 	coopWakePTYHelperEnv    = "AMQ_TEST_COOP_WAKE_PTY_HELPER"
 )
 
+func TestOpenCoopWakeAttentionPrefersControllingTTY(t *testing.T) {
+	attentionPath := filepath.Join(t.TempDir(), "attention")
+	originalOpen := openCoopWakeTTY
+	openCoopWakeTTY = func() (*os.File, error) {
+		return os.OpenFile(attentionPath, os.O_CREATE|os.O_WRONLY, 0o600)
+	}
+	t.Cleanup(func() { openCoopWakeTTY = originalOpen })
+
+	output, err := os.OpenFile(
+		filepath.Join(t.TempDir(), "diagnostics"),
+		os.O_CREATE|os.O_WRONLY,
+		0o600,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = output.Close() }()
+
+	attention, err := openCoopWakeAttention(output)
+	if err != nil {
+		t.Fatalf("openCoopWakeAttention: %v", err)
+	}
+	if attention.Name() != attentionPath {
+		t.Fatalf("attention path = %q, want %q", attention.Name(), attentionPath)
+	}
+	_ = attention.Close()
+}
+
+func TestOpenCoopWakeAttentionFallsBackToIndependentLogDescriptor(t *testing.T) {
+	originalOpen := openCoopWakeTTY
+	openCoopWakeTTY = func() (*os.File, error) {
+		return nil, errors.New("no controlling terminal")
+	}
+	t.Cleanup(func() { openCoopWakeTTY = originalOpen })
+
+	outputPath := filepath.Join(t.TempDir(), "diagnostics")
+	output, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attention, err := openCoopWakeAttention(output)
+	if err != nil {
+		t.Fatalf("openCoopWakeAttention: %v", err)
+	}
+	if err := attention.Close(); err != nil {
+		t.Fatalf("close attention duplicate: %v", err)
+	}
+	if _, err := output.WriteString("diagnostic survives attention close\n"); err != nil {
+		t.Fatalf("write original diagnostic descriptor: %v", err)
+	}
+	if err := output.Close(); err != nil {
+		t.Fatalf("close diagnostic output: %v", err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil || string(data) != "diagnostic survives attention close\n" {
+		t.Fatalf("diagnostic data = %q err=%v", data, err)
+	}
+}
+
 func TestCoopWakeArgsDisableInterruptInjection(t *testing.T) {
 	for _, mode := range []string{
 		wakeInjectModeAuto,
@@ -439,13 +498,18 @@ func TestOwnerDeathGatesTerminalInjection(t *testing.T) {
 				}
 				return nil
 			}
-			err := injectNotification(&wakeConfig{
+			cfg := &wakeConfig{
 				me:          "codex",
 				injectMode:  mode,
 				controlStop: stop,
-			}, "one in-flight write at most", false)
-			if err != nil {
-				t.Fatalf("mid-injection owner death: %v", err)
+			}
+			err := injectNotification(cfg, "one in-flight write at most", false)
+			var partial *wakeTerminalPartialProgressError
+			if !errors.As(err, &partial) {
+				t.Fatalf("mid-injection owner death error = %v, want retained partial progress", err)
+			}
+			if !cfg.inputDelivery.pending() {
+				t.Fatal("mid-injection owner death discarded retained delivery progress")
 			}
 			if len(calls) != 1 {
 				t.Fatalf("owner death allowed follow-up terminal injection: %#v", calls)
@@ -604,14 +668,19 @@ func TestCoopRawDoorbellRechecksGenerationBeforeEveryWrite(t *testing.T) {
 		}
 		return nil
 	}
-	err = injectNotification(&wakeConfig{
+	cfg := &wakeConfig{
 		me:          "codex",
 		root:        root,
 		injectMode:  wakeInjectModeRaw,
 		controlStop: stop,
-	}, "dynamic", false)
-	if err != nil {
-		t.Fatalf("generation change: %v", err)
+	}
+	err = injectNotification(cfg, "dynamic", false)
+	var partial *wakeTerminalPartialProgressError
+	if !errors.As(err, &partial) {
+		t.Fatalf("generation change error = %v, want retained partial progress", err)
+	}
+	if !cfg.inputDelivery.pending() {
+		t.Fatal("generation change discarded retained delivery progress")
 	}
 	if len(injected) != 1 {
 		t.Fatalf("replacement generation received follow-up LF/CR/rescue writes: %#v", injected)

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -50,7 +50,13 @@ type wakeConfig struct {
 	baselineRequested    bool
 	baselineInherited    bool
 	baselineExisting     map[string]wakeFileIdentity
-	announcedPending     map[string]wakeFileIdentity
+	rawSubmitPhase       rawSubmitPhase
+	rawSubmitPayload     string
+	doorbell             wakeDoorbellState
+	doorbellNow          func() time.Time
+	newDoorbellToken     func() (string, error)
+	promptObserved       <-chan string
+	suppressAttention    bool
 	onBaselineReady      func(map[string]wakeFileIdentity) error
 	onPrepared           func(wakeAdmissionWatcher) error
 	retainedInbox        wakeInboxReader
@@ -63,6 +69,14 @@ type wakeConfig struct {
 	attentionIsTTY       func() bool
 	attentionWrite       func([]byte) (int, error)
 }
+
+type rawSubmitPhase uint8
+
+const (
+	rawSubmitIdle rawSubmitPhase = iota
+	rawFirstSubmitQueued
+	rawRescueSubmitQueued
+)
 
 type wakeAdmissionWatcher interface {
 	Errors() <-chan error
@@ -80,7 +94,10 @@ const (
 	wakeInjectModePaste = "paste"
 	wakeInjectModeNone  = "none"
 
-	coopWakeDoorbell = ": AMQ doorbell run amq drain --include-body then act on it"
+	coopWakeDoorbellTokenForTests = "00000000000000000000000000000000"
+	coopWakeDoorbellPrefix        = ": AMQ doorbell v1 token="
+	coopWakeDoorbellSuffix        = " run amq drain --include-body then act on it"
+	coopWakeDoorbell              = coopWakeDoorbellPrefix + coopWakeDoorbellTokenForTests + coopWakeDoorbellSuffix
 
 	rawInjectDrainTimeout      = 2 * time.Second
 	rawInjectDrainPollInterval = 10 * time.Millisecond
@@ -152,6 +169,19 @@ func peerWakeNotification(output string) wakeNotification {
 			provenance: wakePayloadPeerHeaders,
 		},
 	}
+}
+
+func buildCoopWakeDoorbell(token string) string {
+	return coopWakeDoorbellPrefix + token + coopWakeDoorbellSuffix
+}
+
+func parseCoopWakeDoorbell(prompt string) (string, bool) {
+	if !strings.HasPrefix(prompt, coopWakeDoorbellPrefix) ||
+		!strings.HasSuffix(prompt, coopWakeDoorbellSuffix) {
+		return "", false
+	}
+	token := strings.TrimSuffix(strings.TrimPrefix(prompt, coopWakeDoorbellPrefix), coopWakeDoorbellSuffix)
+	return token, validWakeDoorbellToken(token)
 }
 
 func operatorWakeNotification(text string) wakeNotification {
@@ -333,6 +363,18 @@ func notifyNewMessages(cfg *wakeConfig) error {
 	}
 
 	if len(messages) == 0 {
+		if usesCoopDoorbell(cfg) {
+			if _, err := cfg.doorbell.plan(
+				cfg.wakeDoorbellNow(),
+				currentPending,
+				cfg.wakeDoorbellToken,
+			); err != nil {
+				return err
+			}
+			if err := reconcileRawSubmitAfterInboxDrain(cfg); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -406,31 +448,48 @@ func deliverNewMessageNotification(
 	currentPending map[string]os.FileInfo,
 ) error {
 	ownerBound := usesCoopDoorbell(cfg)
-	if ownerBound &&
-		cfg.injectMode != wakeInjectModeNone &&
-		announcedWakeStillPending(cfg.announcedPending, currentPending) {
-		emitWakeAttention(cfg, notice.output)
-		return nil
+	if ownerBound && cfg.injectMode != wakeInjectModeNone {
+		now := cfg.wakeDoorbellNow()
+		plan, err := cfg.doorbell.plan(now, currentPending, cfg.wakeDoorbellToken)
+		if err != nil {
+			return err
+		}
+		if !plan.attempt {
+			return nil
+		}
+		notice.input = wakePayload{
+			text:       plan.prompt,
+			provenance: wakePayloadSystemFixed,
+		}
+		cfg.suppressAttention = plan.retry
+		deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
+		cfg.suppressAttention = false
+		if deliveryErr == nil || !isWakeTerminalForegroundPGRPChanged(deliveryErr) {
+			cfg.doorbell.recordAttempt(now)
+		}
+		return deliveryErr
 	}
 
-	result, err := deliverWakeNotificationResult(cfg, notice, deferForInput)
-	if ownerBound && result.inputSubmitted {
-		cfg.announcedPending = snapshotWakeFileIdentities(currentPending)
-	}
-	return err
+	return deliverWakeNotification(cfg, notice, deferForInput)
 }
 
-func announcedWakeStillPending(
-	announced map[string]wakeFileIdentity,
-	current map[string]os.FileInfo,
-) bool {
-	for name, identity := range announced {
-		info, ok := current[name]
-		if ok && matchesWakeFileIdentity(identity, info) {
-			return true
-		}
+func (cfg *wakeConfig) wakeDoorbellNow() time.Time {
+	if cfg.doorbellNow != nil {
+		return cfg.doorbellNow()
 	}
-	return false
+	return time.Now()
+}
+
+func (cfg *wakeConfig) wakeDoorbellToken() (string, error) {
+	if cfg.newDoorbellToken != nil {
+		return cfg.newDoorbellToken()
+	}
+	// Internal direct-call tests do not carry a published wake generation.
+	// Production wake instances always do and receive a fresh random token.
+	if cfg.terminalGeneration == "" {
+		return coopWakeDoorbellTokenForTests, nil
+	}
+	return generateWakeDoorbellToken()
 }
 
 func snapshotWakeFileIdentities(current map[string]os.FileInfo) map[string]wakeFileIdentity {
@@ -606,31 +665,21 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 	)
 }
 
-type wakeDeliveryResult struct {
-	inputSubmitted bool
-}
-
 func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForInput bool) error {
-	_, err := deliverWakeNotificationResult(cfg, notice, deferForInput)
-	return err
-}
-
-func deliverWakeNotificationResult(
-	cfg *wakeConfig,
-	notice wakeNotification,
-	deferForInput bool,
-) (wakeDeliveryResult, error) {
-	var result wakeDeliveryResult
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound {
-		notice.input = wakePayload{
-			text:       coopWakeDoorbell,
-			provenance: wakePayloadSystemFixed,
+		if _, valid := parseCoopWakeDoorbell(notice.input.text); valid {
+			// Generation-token prompts are system-created before delivery.
+		} else {
+			notice.input = wakePayload{
+				text:       coopWakeDoorbell,
+				provenance: wakePayloadSystemFixed,
+			}
 		}
 	}
 	if cfg.injectMode == wakeInjectModeNone {
 		emitWakeAttention(cfg, notice.output)
-		return result, nil
+		return nil
 	}
 
 	inputText := notice.input.text
@@ -642,7 +691,7 @@ func deliverWakeNotificationResult(
 	if shouldDeferBeforeInject(cfg, deferForInput) {
 		if !waitForWakeInputQuiet(cfg) {
 			emitWakeAttention(cfg, notice.output)
-			return result, nil
+			return nil
 		}
 	}
 
@@ -651,10 +700,10 @@ func deliverWakeNotificationResult(
 	if cfg.injectVia != "" {
 		allowed, guardErr := authorizeTerminalWrite(cfg)
 		if guardErr != nil {
-			return result, guardErr
+			return guardErr
 		}
 		if !allowed {
-			return result, nil
+			return nil
 		}
 		if err := injectVia(cfg, plainText); err != nil {
 			if cfg.fallbackWarn {
@@ -663,10 +712,9 @@ func deliverWakeNotificationResult(
 				cfg.fallbackWarn = false
 			}
 			emitWakeAttention(cfg, notice.output)
-			return result, nil
+			return nil
 		}
-		result.inputSubmitted = true
-		return result, nil
+		return nil
 	}
 
 	mode := effectiveInjectMode(cfg)
@@ -683,7 +731,7 @@ func deliverWakeNotificationResult(
 		if cfg.bell && !ownerBound {
 			injectedText = "\a" + injectedText
 		}
-		result.inputSubmitted, injectErr = injectRawNotification(cfg, injectedText)
+		_, injectErr = injectRawNotification(cfg, injectedText)
 
 	case wakeInjectModePaste:
 		// Paste mode: bracketed paste with delayed CR
@@ -702,10 +750,7 @@ func deliverWakeNotificationResult(
 		} else if wrote {
 			// Small delay to ensure CR lands in separate read cycle
 			time.Sleep(25 * time.Millisecond)
-			submitted, err := writeTerminalChunk(cfg, "\r")
-			if err == nil {
-				result.inputSubmitted = submitted
-			}
+			_, err := writeTerminalChunk(cfg, "\r")
 			injectErr = err
 		}
 
@@ -716,10 +761,7 @@ func deliverWakeNotificationResult(
 			if err != nil {
 				injectErr = err
 			} else if wrote {
-				submitted, err := writeTerminalChunk(cfg, "\r")
-				if err == nil {
-					result.inputSubmitted = submitted
-				}
+				_, err := writeTerminalChunk(cfg, "\r")
 				injectErr = err
 			}
 		} else {
@@ -727,7 +769,7 @@ func deliverWakeNotificationResult(
 			if cfg.bell {
 				injectedText = "\a" + injectedText
 			}
-			result.inputSubmitted, injectErr = writeTerminalChunk(cfg, injectedText)
+			_, injectErr = writeTerminalChunk(cfg, injectedText)
 		}
 	}
 
@@ -749,11 +791,11 @@ func deliverWakeNotificationResult(
 			_ = writeStderr("amq wake: warning: %s\n", reason)
 			cfg.fallbackWarn = false
 			emitWakeAttention(cfg, notice.output)
-			return result, nil
+			return nil
 		}
 		var authorityErr *wakeTerminalAuthorityError
 		if errors.As(injectErr, &authorityErr) {
-			return result, injectErr
+			return injectErr
 		}
 		if cfg.fallbackWarn {
 			_ = writeStderr("amq wake: TIOCSTI injection failed: %v\n", injectErr)
@@ -762,10 +804,10 @@ func deliverWakeNotificationResult(
 		}
 		// Fallback: use the output-only attention tier; never retry input.
 		emitWakeAttention(cfg, notice.output)
-		return result, nil
+		return nil
 	}
 
-	return result, nil
+	return nil
 }
 
 func usesCoopDoorbell(cfg *wakeConfig) bool {
@@ -865,7 +907,79 @@ func rawSubmitPrelude(me string) string {
 	return ""
 }
 
+func clearRawSubmitState(cfg *wakeConfig) {
+	cfg.rawSubmitPhase = rawSubmitIdle
+	cfg.rawSubmitPayload = ""
+}
+
+func reconcileRawSubmitAfterInboxDrain(cfg *wakeConfig) error {
+	if cfg.rawSubmitPhase == rawSubmitIdle {
+		return nil
+	}
+	waited, drained, err := waitForRawInputDrained(
+		rawInjectCRDrainTimeout,
+		rawInjectDrainPollInterval,
+	)
+	if cfg.debug {
+		switch {
+		case err != nil:
+			_ = writeStderr("amq wake [debug]: empty-inbox submit drain check failed after %s: %v\n", waited, err)
+		case drained:
+			_ = writeStderr("amq wake [debug]: empty-inbox submit queue drained after %s\n", waited)
+		default:
+			_ = writeStderr("amq wake [debug]: empty-inbox submit key still queued after %s\n", waited)
+		}
+	}
+	if err != nil || !drained {
+		return nil
+	}
+	if cfg.rawSubmitPhase == rawFirstSubmitQueued {
+		_, err := injectRawRescueSubmit(cfg)
+		return err
+	}
+	clearRawSubmitState(cfg)
+	return nil
+}
+
 func injectRawNotification(cfg *wakeConfig, injectedText string) (bool, error) {
+	if cfg.rawSubmitPhase != rawSubmitIdle {
+		// A previous submit key is still in the terminal input queue. Never
+		// retype the notification: wait until the reader resumes, then send only
+		// the one permitted rescue Enter after the first submit. A drained
+		// rescue is final; it must not generate a third Enter.
+		pendingPhase := cfg.rawSubmitPhase
+		pendingPayload := cfg.rawSubmitPayload
+		waited, drained, err := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
+		if err != nil {
+			if cfg.debug {
+				_ = writeStderr("amq wake [debug]: pending submit drain check failed after %s: %v\n", waited, err)
+			}
+			return false, nil
+		}
+		if !drained {
+			if cfg.debug {
+				_ = writeStderr("amq wake [debug]: submit key still queued after %s; waiting for terminal reader\n", waited)
+			}
+			return false, nil
+		}
+		clearRawSubmitState(cfg)
+		if pendingPhase == rawFirstSubmitQueued {
+			cfg.rawSubmitPhase = rawFirstSubmitQueued
+			cfg.rawSubmitPayload = pendingPayload
+			if _, err := injectRawRescueSubmit(cfg); err != nil {
+				return false, err
+			}
+			if cfg.rawSubmitPhase != rawSubmitIdle {
+				return false, nil
+			}
+		}
+		if pendingPayload != "" && pendingPayload == injectedText {
+			return true, nil
+		}
+		// The old submit sequence is fully drained. It is now safe to type the
+		// current generation without stacking bytes behind stale terminal input.
+	}
+
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
 	}
@@ -933,6 +1047,7 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) (bool, error) {
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: submit key injected OK\n")
 	}
+	cfg.rawSubmitPayload = injectedText
 
 	// Rescue submit: if the first Enter was swallowed anyway (input buffer
 	// flush or a burst-window race), a repeat Enter submits the composer; if
@@ -944,31 +1059,80 @@ func injectRawNotification(cfg *wakeConfig, injectedText string) (bool, error) {
 	// paste-shaped chunk and both would be swallowed.
 	crWaited, crDrained, crErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
 	if crErr == nil && !crDrained {
+		cfg.rawSubmitPhase = rawFirstSubmitQueued
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", crWaited)
 		}
+		return false, nil
+	}
+	if crErr != nil {
+		// Without queue visibility, preserve the historical best-effort path:
+		// one spaced rescue Enter and no unbounded retries.
+		rawInjectSleep(rawInjectSettleDelay)
+		wrote, err = writeTerminalChunk(cfg, "\r")
+		if err != nil {
+			var authorityErr *wakeTerminalAuthorityError
+			if errors.As(err, &authorityErr) {
+				clearRawSubmitState(cfg)
+				return true, err
+			}
+			if cfg.debug {
+				_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
+			}
+			clearRawSubmitState(cfg)
+			return true, nil
+		}
+		if !wrote {
+			clearRawSubmitState(cfg)
+			return true, nil
+		}
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: rescue submit injected OK\n")
+		}
+		clearRawSubmitState(cfg)
 		return true, nil
 	}
+
+	cfg.rawSubmitPhase = rawFirstSubmitQueued
+	return injectRawRescueSubmit(cfg)
+}
+
+func injectRawRescueSubmit(cfg *wakeConfig) (bool, error) {
 	rawInjectSleep(rawInjectSettleDelay)
-	wrote, err = writeTerminalChunk(cfg, "\r")
+	wrote, err := writeTerminalChunk(cfg, "\r")
 	if err != nil {
 		// The text and first submit key were already delivered; the rescue is
 		// best-effort unless exact terminal authority was lost.
 		var authorityErr *wakeTerminalAuthorityError
 		if errors.As(err, &authorityErr) {
-			return true, err
+			return false, err
 		}
 		if cfg.debug {
 			_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
 		}
-		return true, nil
+		return false, nil
 	}
 	if !wrote {
-		return true, nil
+		return false, nil
 	}
 	if cfg.debug {
 		_ = writeStderr("amq wake [debug]: rescue submit injected OK\n")
 	}
+	waited, drained, drainErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
+	if drainErr != nil {
+		// Queue inspection is best-effort. A successful terminal write remains
+		// the strongest evidence available when the platform cannot inspect it.
+		clearRawSubmitState(cfg)
+		return true, nil
+	}
+	if !drained {
+		cfg.rawSubmitPhase = rawRescueSubmitQueued
+		if cfg.debug {
+			_ = writeStderr("amq wake [debug]: rescue submit still queued after %s; waiting for terminal reader\n", waited)
+		}
+		return false, nil
+	}
+	clearRawSubmitState(cfg)
 	return true, nil
 }
 

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -50,8 +50,7 @@ type wakeConfig struct {
 	baselineRequested    bool
 	baselineInherited    bool
 	baselineExisting     map[string]wakeFileIdentity
-	rawSubmitPhase       rawSubmitPhase
-	rawSubmitPayload     string
+	inputDelivery        wakeInputDeliveryState
 	doorbell             wakeDoorbellState
 	doorbellNow          func() time.Time
 	newDoorbellToken     func() (string, error)
@@ -59,32 +58,113 @@ type wakeConfig struct {
 	suppressAttention    bool
 	onBaselineReady      func(map[string]wakeFileIdentity) error
 	onPrepared           func(wakeAdmissionWatcher) error
+	retainedAgent        wakeRetainedAgent
 	retainedInbox        wakeInboxReader
 	touchPresence        func() error
 	maintenanceTicks     <-chan time.Time
 	preconditionCheck    func(*wakeConfig) error
+	onPendingNotify      func()
 	recordNotifierStatus func(status, mode, reason string) error
 	recordAttention      func(wakeAttentionEmission) error
 	attentionEnv         func(string) string
 	attentionIsTTY       func() bool
 	attentionWrite       func([]byte) (int, error)
+	diagnosticIsTTY      func() bool
 }
 
-type rawSubmitPhase uint8
+type wakeInputDeliveryPhase uint8
 
 const (
-	rawSubmitIdle rawSubmitPhase = iota
-	rawFirstSubmitQueued
-	rawRescueSubmitQueued
+	wakeInputDeliveryIdle wakeInputDeliveryPhase = iota
+	wakeInputPayloadPending
+	wakeInputRawPreludePending
+	wakeInputPrimarySubmitPending
+	wakeInputRawFirstSubmitQueued
+	wakeInputRawRescuePending
+	wakeInputRawRescueQueued
 )
+
+type wakeInputDeliveryState struct {
+	phase         wakeInputDeliveryPhase
+	mode          string
+	payload       string
+	acceptedBytes int
+}
+
+func (state *wakeInputDeliveryState) reset() {
+	*state = wakeInputDeliveryState{}
+}
+
+func (state wakeInputDeliveryState) pending() bool {
+	return state.phase != wakeInputDeliveryIdle
+}
+
+func (state wakeInputDeliveryState) confirmedInput() bool {
+	return state.acceptedBytes > 0 ||
+		(state.phase != wakeInputDeliveryIdle &&
+			state.phase != wakeInputPayloadPending)
+}
 
 type wakeAdmissionWatcher interface {
 	Errors() <-chan error
 }
 
+type wakeRetainedAgent interface {
+	isWakeRetainedAgent()
+}
+
 type wakeInboxReader interface {
 	ReadDir() ([]os.DirEntry, error)
 	ReadHeader(name string) (format.Header, error)
+}
+
+type wakeInboxFileInfoReader interface {
+	FileInfo(name string) (os.FileInfo, error)
+}
+
+type wakeInboxScanError struct {
+	err error
+}
+
+func (err *wakeInboxScanError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeInboxScanError) Unwrap() error {
+	return err.err
+}
+
+type wakeTerminalPartialProgressError struct {
+	err error
+}
+
+func (err *wakeTerminalPartialProgressError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeTerminalPartialProgressError) Unwrap() error {
+	return err.err
+}
+
+func isWakeTerminalPartialProgress(err error) bool {
+	var partial *wakeTerminalPartialProgressError
+	return errors.As(err, &partial)
+}
+
+type wakeTerminalProgressUncertainError struct {
+	err error
+}
+
+func (err *wakeTerminalProgressUncertainError) Error() string {
+	return "terminal input acceptance is uncertain; refusing to replay: " + err.err.Error()
+}
+
+func (err *wakeTerminalProgressUncertainError) Unwrap() error {
+	return err.err
+}
+
+type wakeTerminalAcceptedProgress interface {
+	wakeAcceptedBytes() int
 }
 
 const defaultInjectTimeout = 5 * time.Second
@@ -175,13 +255,13 @@ func buildCoopWakeDoorbell(token string) string {
 	return coopWakeDoorbellPrefix + token + coopWakeDoorbellSuffix
 }
 
-func parseCoopWakeDoorbell(prompt string) (string, bool) {
+func validCoopWakeDoorbell(prompt string) bool {
 	if !strings.HasPrefix(prompt, coopWakeDoorbellPrefix) ||
 		!strings.HasSuffix(prompt, coopWakeDoorbellSuffix) {
-		return "", false
+		return false
 	}
 	token := strings.TrimSuffix(strings.TrimPrefix(prompt, coopWakeDoorbellPrefix), coopWakeDoorbellSuffix)
-	return token, validWakeDoorbellToken(token)
+	return validWakeDoorbellToken(token)
 }
 
 func operatorWakeNotification(text string) wakeNotification {
@@ -290,10 +370,9 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		entries, err = os.ReadDir(inboxNew)
 	}
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+		return &wakeInboxScanError{
+			err: fmt.Errorf("read wake inbox %s: %w", inboxNew, err),
 		}
-		return err
 	}
 
 	var messages []wakeMsgInfo
@@ -309,7 +388,17 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		if strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".md") {
 			continue
 		}
-		fileInfo, infoErr := entry.Info()
+		var fileInfo os.FileInfo
+		var infoErr error
+		if retained, ok := cfg.retainedInbox.(wakeInboxFileInfoReader); ok {
+			fileInfo, infoErr = retained.FileInfo(name)
+		} else {
+			fileInfo, infoErr = entry.Info()
+		}
+		pendingInfo := fileInfo
+		if infoErr != nil {
+			pendingInfo = nil
+		}
 		if baselineIdentity, ignored := cfg.baselineExisting[name]; ignored {
 			if infoErr == nil && matchesWakeFileIdentity(baselineIdentity, fileInfo) {
 				continue
@@ -323,19 +412,14 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		} else {
 			header, err = format.ReadHeaderFile(filepath.Join(inboxNew, name))
 		}
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			// Count corrupt messages too
-			messages = append(messages, wakeMsgInfo{from: "unknown", subject: "(parse error)"})
-			if infoErr == nil {
-				currentPending[name] = fileInfo
-			}
+		if err != nil && os.IsNotExist(err) {
 			continue
 		}
-		if infoErr == nil {
-			currentPending[name] = fileInfo
+		currentPending[name] = pendingInfo
+		if err != nil {
+			// Count corrupt messages too
+			messages = append(messages, wakeMsgInfo{from: "unknown", subject: "(parse error)"})
+			continue
 		}
 
 		from := strings.TrimSpace(header.From)
@@ -363,19 +447,8 @@ func notifyNewMessages(cfg *wakeConfig) error {
 	}
 
 	if len(messages) == 0 {
-		if usesCoopDoorbell(cfg) {
-			if _, err := cfg.doorbell.plan(
-				cfg.wakeDoorbellNow(),
-				currentPending,
-				cfg.wakeDoorbellToken,
-			); err != nil {
-				return err
-			}
-			if err := reconcileRawSubmitAfterInboxDrain(cfg); err != nil {
-				return err
-			}
-		}
-		return nil
+		cfg.doorbell.reset()
+		return reconcileWakeInputAfterInboxDrain(cfg)
 	}
 
 	if cfg.interrupt && len(interruptMessages) > 0 {
@@ -447,6 +520,9 @@ func deliverNewMessageNotification(
 	deferForInput bool,
 	currentPending map[string]os.FileInfo,
 ) error {
+	if cfg.injectMode == wakeInjectModeNone {
+		clearWakeInputState(cfg)
+	}
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound && cfg.injectMode != wakeInjectModeNone {
 		now := cfg.wakeDoorbellNow()
@@ -464,13 +540,32 @@ func deliverNewMessageNotification(
 		cfg.suppressAttention = plan.retry
 		deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
 		cfg.suppressAttention = false
-		if deliveryErr == nil || !isWakeTerminalForegroundPGRPChanged(deliveryErr) {
-			cfg.doorbell.recordAttempt(now)
+		if cfg.injectMode == wakeInjectModeNone {
+			clearWakeInputState(cfg)
+			if plan.retry {
+				emitWakeAttention(cfg, notice.output)
+			}
+			if deliveryErr == nil {
+				cfg.doorbell.recordCohortDelivered(currentPending)
+			}
+			return deliveryErr
+		}
+		if deliveryErr == nil ||
+			(!isWakeTerminalForegroundPGRPChanged(deliveryErr) &&
+				!isWakeTerminalPartialProgress(deliveryErr)) {
+			cfg.doorbell.recordAttempt(cfg.wakeDoorbellNow())
 		}
 		return deliveryErr
 	}
 
-	return deliverWakeNotification(cfg, notice, deferForInput)
+	if !cfg.doorbell.planCohortDelivery(currentPending) {
+		return nil
+	}
+	deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
+	if deliveryErr == nil {
+		cfg.doorbell.recordCohortDelivered(currentPending)
+	}
+	return deliveryErr
 }
 
 func (cfg *wakeConfig) wakeDoorbellNow() time.Time {
@@ -492,14 +587,40 @@ func (cfg *wakeConfig) wakeDoorbellToken() (string, error) {
 	return generateWakeDoorbellToken()
 }
 
-func snapshotWakeFileIdentities(current map[string]os.FileInfo) map[string]wakeFileIdentity {
-	snapshot := make(map[string]wakeFileIdentity, len(current))
+func snapshotWakeFileIdentities(current map[string]os.FileInfo) map[string]*wakeFileIdentity {
+	snapshot := make(map[string]*wakeFileIdentity, len(current))
 	for name, info := range current {
-		if identity, ok := captureWakeFileIdentity(info); ok {
-			snapshot[name] = identity
+		if info == nil {
+			snapshot[name] = nil
+			continue
 		}
+		if identity, ok := captureWakeFileIdentity(info); ok {
+			snapshot[name] = &identity
+			continue
+		}
+		snapshot[name] = nil
 	}
 	return snapshot
+}
+
+func sameKnownWakeCohort(
+	previous map[string]*wakeFileIdentity,
+	current map[string]os.FileInfo,
+) bool {
+	if len(previous) == 0 || len(previous) != len(current) {
+		return false
+	}
+	for name, previousIdentity := range previous {
+		info, exists := current[name]
+		if !exists || previousIdentity == nil || info == nil {
+			return false
+		}
+		currentIdentity, known := captureWakeFileIdentity(info)
+		if !known || currentIdentity != *previousIdentity {
+			return false
+		}
+	}
+	return true
 }
 
 func buildNotificationText(session string, messages []wakeMsgInfo, previewLen int) string {
@@ -627,14 +748,18 @@ func effectiveInjectMode(cfg *wakeConfig) string {
 		// Enter swallowing in some CLIs. Paste mode remains available via flag.
 		// Claude Code's Ink framework has buggy bracketed paste handling where CR gets
 		// coalesced with the paste-end sequence and swallowed by the input parser.
-		meLower := strings.ToLower(cfg.me)
-		if strings.Contains(meLower, "claude") || strings.Contains(meLower, "codex") {
+		if wakeUsesAlternateScreenTUI(cfg.me) {
 			mode = wakeInjectModeRaw
 		} else {
 			mode = wakeInjectModePaste
 		}
 	}
 	return mode
+}
+
+func wakeUsesAlternateScreenTUI(me string) bool {
+	meLower := strings.ToLower(me)
+	return strings.Contains(meLower, "claude") || strings.Contains(meLower, "codex")
 }
 
 func normalizeWakeInjectMode(raw string) (string, error) {
@@ -668,7 +793,7 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForInput bool) error {
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound {
-		if _, valid := parseCoopWakeDoorbell(notice.input.text); valid {
+		if validCoopWakeDoorbell(notice.input.text) {
 			// Generation-token prompts are system-created before delivery.
 		} else {
 			notice.input = wakePayload{
@@ -707,8 +832,8 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		}
 		if err := injectVia(cfg, plainText); err != nil {
 			if cfg.fallbackWarn {
-				_ = writeStderr("amq wake: --inject-via failed: %v\n", err)
-				_ = writeStderr("amq wake: falling back to stderr notification\n")
+				_ = writeWakeDiagnostic(cfg, "amq wake: --inject-via failed: %v\n", err)
+				_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")
 				cfg.fallbackWarn = false
 			}
 			emitWakeAttention(cfg, notice.output)
@@ -719,7 +844,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 
 	mode := effectiveInjectMode(cfg)
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: mode=%s text_len=%d\n", mode, len(inputText))
+		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: mode=%s text_len=%d\n", mode, len(inputText))
 	}
 	var injectErr error
 	switch mode {
@@ -744,15 +869,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		if cfg.bell && !ownerBound {
 			pasteText = "\a" + pasteText
 		}
-		wrote, err := writeTerminalChunk(cfg, pasteText)
-		if err != nil {
-			injectErr = err
-		} else if wrote {
-			// Small delay to ensure CR lands in separate read cycle
-			time.Sleep(25 * time.Millisecond)
-			_, err := writeTerminalChunk(cfg, "\r")
-			injectErr = err
-		}
+		_, injectErr = injectTerminalNotification(cfg, wakeInjectModePaste, pasteText)
 
 	default:
 		// Unknown mode, fall back to raw
@@ -774,6 +891,17 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	}
 
 	if injectErr != nil {
+		if isWakeTerminalPartialProgress(injectErr) {
+			return injectErr
+		}
+		var uncertain *wakeTerminalProgressUncertainError
+		if errors.As(injectErr, &uncertain) {
+			disableWakeInput(cfg)
+			_ = writeWakeDiagnostic(cfg, "amq wake: warning: %v\n", uncertain)
+			cfg.fallbackWarn = false
+			emitWakeAttention(cfg, notice.output)
+			return nil
+		}
 		var unsupported *wakeInjectorUnsupportedError
 		if errors.As(injectErr, &unsupported) {
 			mode := effectiveInjectMode(cfg)
@@ -784,11 +912,11 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 					mode,
 					reason,
 				); err != nil {
-					_ = writeStderr("amq wake: record unsupported injector status: %v\n", err)
+					_ = writeWakeDiagnostic(cfg, "amq wake: record unsupported injector status: %v\n", err)
 				}
 			}
-			cfg.injectMode = wakeInjectModeNone
-			_ = writeStderr("amq wake: warning: %s\n", reason)
+			disableWakeInput(cfg)
+			_ = writeWakeDiagnostic(cfg, "amq wake: warning: %s\n", reason)
 			cfg.fallbackWarn = false
 			emitWakeAttention(cfg, notice.output)
 			return nil
@@ -798,8 +926,8 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 			return injectErr
 		}
 		if cfg.fallbackWarn {
-			_ = writeStderr("amq wake: TIOCSTI injection failed: %v\n", injectErr)
-			_ = writeStderr("amq wake: falling back to stderr notification\n")
+			_ = writeWakeDiagnostic(cfg, "amq wake: TIOCSTI injection failed: %v\n", injectErr)
+			_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")
 			cfg.fallbackWarn = false
 		}
 		// Fallback: use the output-only attention tier; never retry input.
@@ -887,6 +1015,72 @@ func writeTerminalChunk(cfg *wakeConfig, chunk string) (bool, error) {
 	return true, tiocstiInject(chunk)
 }
 
+func writePendingWakeInputChunk(
+	cfg *wakeConfig,
+	state *wakeInputDeliveryState,
+	chunk string,
+) (bool, error) {
+	if state.acceptedBytes < 0 || state.acceptedBytes > len(chunk) {
+		return false, &wakeTerminalProgressUncertainError{
+			err: fmt.Errorf(
+				"invalid retained input offset %d for %d-byte chunk",
+				state.acceptedBytes,
+				len(chunk),
+			),
+		}
+	}
+	remaining := chunk[state.acceptedBytes:]
+	wrote, err := writeTerminalChunk(cfg, remaining)
+	if err == nil {
+		if wrote {
+			state.acceptedBytes = 0
+		} else if state.confirmedInput() {
+			return false, &wakeTerminalPartialProgressError{
+				err: errors.New("terminal write authorization is temporarily unavailable"),
+			}
+		}
+		return wrote, nil
+	}
+
+	var unsupported *wakeInjectorUnsupportedError
+	if errors.As(err, &unsupported) {
+		return wrote, err
+	}
+	if !wrote {
+		if state.confirmedInput() {
+			return false, &wakeTerminalPartialProgressError{err: err}
+		}
+		return false, err
+	}
+
+	var progress wakeTerminalAcceptedProgress
+	if !errors.As(err, &progress) {
+		if isWakeTerminalAuthorityLoss(err) {
+			if state.confirmedInput() {
+				return true, &wakeTerminalPartialProgressError{err: err}
+			}
+			return true, err
+		}
+		return true, &wakeTerminalProgressUncertainError{err: err}
+	}
+	accepted := progress.wakeAcceptedBytes()
+	if accepted < 0 || accepted >= len(remaining) {
+		return true, &wakeTerminalProgressUncertainError{
+			err: fmt.Errorf(
+				"invalid terminal progress %d for %d-byte suffix: %w",
+				accepted,
+				len(remaining),
+				err,
+			),
+		}
+	}
+	state.acceptedBytes += accepted
+	if state.confirmedInput() {
+		return true, &wakeTerminalPartialProgressError{err: err}
+	}
+	return true, err
+}
+
 // rawSubmitPrelude returns the bytes injected between the drained notification
 // text and the settle delay. codex targets get a single LF: codex-tui maps a
 // raw 0x0A to Ctrl-J, whose editor binding routes through handle_input_basic,
@@ -907,232 +1101,255 @@ func rawSubmitPrelude(me string) string {
 	return ""
 }
 
-func clearRawSubmitState(cfg *wakeConfig) {
-	cfg.rawSubmitPhase = rawSubmitIdle
-	cfg.rawSubmitPayload = ""
+func clearWakeInputState(cfg *wakeConfig) {
+	cfg.inputDelivery.reset()
 }
 
-func reconcileRawSubmitAfterInboxDrain(cfg *wakeConfig) error {
-	if cfg.rawSubmitPhase == rawSubmitIdle {
+func retireWakeInputState(cfg *wakeConfig) {
+	cfg.doorbell.reset()
+	clearWakeInputState(cfg)
+}
+
+func disableWakeInput(cfg *wakeConfig) {
+	cfg.injectMode = wakeInjectModeNone
+	retireWakeInputState(cfg)
+}
+
+func reconcileWakeInputAfterInboxDrain(cfg *wakeConfig) error {
+	if !cfg.inputDelivery.pending() {
 		return nil
 	}
-	waited, drained, err := waitForRawInputDrained(
-		rawInjectCRDrainTimeout,
-		rawInjectDrainPollInterval,
-	)
-	if cfg.debug {
-		switch {
-		case err != nil:
-			_ = writeStderr("amq wake [debug]: empty-inbox submit drain check failed after %s: %v\n", waited, err)
-		case drained:
-			_ = writeStderr("amq wake [debug]: empty-inbox submit queue drained after %s\n", waited)
-		default:
-			_ = writeStderr("amq wake [debug]: empty-inbox submit key still queued after %s\n", waited)
+	if cfg.inputDelivery.phase == wakeInputPayloadPending {
+		if cfg.inputDelivery.acceptedBytes == 0 {
+			// No terminal byte was confirmed, so there is no stale composer input
+			// to finish after the inbox made progress.
+			clearWakeInputState(cfg)
+			return nil
 		}
 	}
-	if err != nil || !drained {
-		return nil
-	}
-	if cfg.rawSubmitPhase == rawFirstSubmitQueued {
-		_, err := injectRawRescueSubmit(cfg)
-		return err
-	}
-	clearRawSubmitState(cfg)
-	return nil
+	_, err := resumeWakeInputDelivery(cfg)
+	return err
 }
 
 func injectRawNotification(cfg *wakeConfig, injectedText string) (bool, error) {
-	if cfg.rawSubmitPhase != rawSubmitIdle {
-		// A previous submit key is still in the terminal input queue. Never
-		// retype the notification: wait until the reader resumes, then send only
-		// the one permitted rescue Enter after the first submit. A drained
-		// rescue is final; it must not generate a third Enter.
-		pendingPhase := cfg.rawSubmitPhase
-		pendingPayload := cfg.rawSubmitPayload
-		waited, drained, err := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
-		if err != nil {
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: pending submit drain check failed after %s: %v\n", waited, err)
-			}
-			return false, nil
-		}
-		if !drained {
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: submit key still queued after %s; waiting for terminal reader\n", waited)
-			}
-			return false, nil
-		}
-		clearRawSubmitState(cfg)
-		if pendingPhase == rawFirstSubmitQueued {
-			cfg.rawSubmitPhase = rawFirstSubmitQueued
-			cfg.rawSubmitPayload = pendingPayload
-			if _, err := injectRawRescueSubmit(cfg); err != nil {
-				return false, err
-			}
-			if cfg.rawSubmitPhase != rawSubmitIdle {
-				return false, nil
-			}
-		}
-		if pendingPayload != "" && pendingPayload == injectedText {
-			return true, nil
-		}
-		// The old submit sequence is fully drained. It is now safe to type the
-		// current generation without stacking bytes behind stale terminal input.
-	}
-
-	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: injecting %d bytes of text\n", len(injectedText))
-	}
-	wrote, err := writeTerminalChunk(cfg, injectedText)
-	if err != nil {
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: text inject failed: %v\n", err)
-		}
-		return false, err
-	}
-	if !wrote {
-		return false, nil
-	}
-	prelude := rawSubmitPrelude(cfg.me)
-
-	// The submit key must arrive in its own read() chunk; otherwise the TUI can
-	// treat text+Enter as pasted input instead of a keypress. Waiting for the
-	// text bytes to drain keeps the submit key out of a paste-shaped chunk even
-	// when the reader stalls (#208).
-	waited, drained, err := waitForRawInputDrained(rawInjectDrainTimeout, rawInjectDrainPollInterval)
-	if cfg.debug {
-		switch {
-		case err != nil:
-			_ = writeStderr("amq wake [debug]: input drain wait unavailable after %s: %v; continuing on timing alone\n", waited, err)
-		case drained:
-			_ = writeStderr("amq wake [debug]: input queue drained after %s\n", waited)
-		default:
-			_ = writeStderr("amq wake [debug]: input drain timeout after %s; injecting submit key anyway\n", waited)
-		}
-	}
-
-	// Prelude (codex: a lone LF) clears the TUI's paste-burst state while the
-	// injected text is fresh; its newline is trimmed from the submitted payload.
-	if prelude != "" {
-		wrote, err := writeTerminalChunk(cfg, prelude)
-		if err != nil {
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: prelude inject failed: %v\n", err)
-			}
-			return false, err
-		}
-		if !wrote {
-			return false, nil
-		}
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: prelude injected OK (%q)\n", prelude)
-		}
-	}
-
-	// Hold the submit CR past the TUI's paste-burst window (see
-	// rawInjectSettleDelay) so it is classified as a real Enter keypress, not a
-	// pasted newline.
-	rawInjectSleep(rawInjectSettleDelay)
-
-	wrote, err = writeTerminalChunk(cfg, "\r")
-	if err != nil {
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: submit key inject failed: %v\n", err)
-		}
-		return false, err
-	}
-	if !wrote {
-		return false, nil
-	}
-	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: submit key injected OK\n")
-	}
-	cfg.rawSubmitPayload = injectedText
-
-	// Rescue submit: if the first Enter was swallowed anyway (input buffer
-	// flush or a burst-window race), a repeat Enter submits the composer; if
-	// the first already submitted, Enter on an empty composer is a no-op. The
-	// rescue must be spaced a full settle delay after the first: a swallowed
-	// Enter re-extends codex-tui's 120ms suppress window, so a faster rescue
-	// would be swallowed too. Skip the rescue only when the first submit key is
-	// provably still queued — a second would coalesce with it into one
-	// paste-shaped chunk and both would be swallowed.
-	crWaited, crDrained, crErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
-	if crErr == nil && !crDrained {
-		cfg.rawSubmitPhase = rawFirstSubmitQueued
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", crWaited)
-		}
-		return false, nil
-	}
-	if crErr != nil {
-		// Without queue visibility, preserve the historical best-effort path:
-		// one spaced rescue Enter and no unbounded retries.
-		rawInjectSleep(rawInjectSettleDelay)
-		wrote, err = writeTerminalChunk(cfg, "\r")
-		if err != nil {
-			var authorityErr *wakeTerminalAuthorityError
-			if errors.As(err, &authorityErr) {
-				clearRawSubmitState(cfg)
-				return true, err
-			}
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
-			}
-			clearRawSubmitState(cfg)
-			return true, nil
-		}
-		if !wrote {
-			clearRawSubmitState(cfg)
-			return true, nil
-		}
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: rescue submit injected OK\n")
-		}
-		clearRawSubmitState(cfg)
-		return true, nil
-	}
-
-	cfg.rawSubmitPhase = rawFirstSubmitQueued
-	return injectRawRescueSubmit(cfg)
+	return injectTerminalNotification(cfg, wakeInjectModeRaw, injectedText)
 }
 
-func injectRawRescueSubmit(cfg *wakeConfig) (bool, error) {
-	rawInjectSleep(rawInjectSettleDelay)
-	wrote, err := writeTerminalChunk(cfg, "\r")
-	if err != nil {
-		// The text and first submit key were already delivered; the rescue is
-		// best-effort unless exact terminal authority was lost.
-		var authorityErr *wakeTerminalAuthorityError
-		if errors.As(err, &authorityErr) {
-			return false, err
+func injectTerminalNotification(
+	cfg *wakeConfig,
+	mode string,
+	payload string,
+) (bool, error) {
+	state := &cfg.inputDelivery
+	if state.pending() && (state.mode != mode || state.payload != payload) {
+		if state.phase == wakeInputPayloadPending && state.acceptedBytes == 0 {
+			// The previous payload never made confirmed progress.
+			state.reset()
+		} else {
+			completed, err := resumeWakeInputDelivery(cfg)
+			if err != nil || !completed {
+				return false, err
+			}
 		}
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: rescue submit inject failed: %v\n", err)
+	}
+	if !state.pending() {
+		*state = wakeInputDeliveryState{
+			phase:   wakeInputPayloadPending,
+			mode:    mode,
+			payload: payload,
 		}
-		return false, nil
 	}
-	if !wrote {
-		return false, nil
-	}
-	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: rescue submit injected OK\n")
-	}
-	waited, drained, drainErr := waitForRawInputDrained(rawInjectCRDrainTimeout, rawInjectDrainPollInterval)
-	if drainErr != nil {
-		// Queue inspection is best-effort. A successful terminal write remains
-		// the strongest evidence available when the platform cannot inspect it.
-		clearRawSubmitState(cfg)
-		return true, nil
-	}
-	if !drained {
-		cfg.rawSubmitPhase = rawRescueSubmitQueued
-		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: rescue submit still queued after %s; waiting for terminal reader\n", waited)
+	return resumeWakeInputDelivery(cfg)
+}
+
+func resumeWakeInputDelivery(cfg *wakeConfig) (bool, error) {
+	state := &cfg.inputDelivery
+	for state.pending() {
+		switch state.phase {
+		case wakeInputPayloadPending:
+			if cfg.debug {
+				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: injecting %d bytes of text\n", len(state.payload))
+			}
+			wrote, err := writePendingWakeInputChunk(cfg, state, state.payload)
+			if err != nil {
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: text inject failed: %v\n", err)
+				}
+				return false, err
+			}
+			if !wrote {
+				return false, nil
+			}
+			if state.mode == wakeInjectModePaste {
+				state.phase = wakeInputPrimarySubmitPending
+				continue
+			}
+			if state.mode != wakeInjectModeRaw {
+				return false, fmt.Errorf("unsupported pending wake input mode %q", state.mode)
+			}
+
+			// The submit key must arrive in its own read() chunk; otherwise the
+			// TUI can treat text+Enter as pasted input instead of a keypress.
+			waited, drained, err := waitForRawInputDrained(
+				rawInjectDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if cfg.debug {
+				switch {
+				case err != nil:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input drain wait unavailable after %s: %v; continuing on timing alone\n", waited, err)
+				case drained:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input queue drained after %s\n", waited)
+				default:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input drain timeout after %s; injecting submit key anyway\n", waited)
+				}
+			}
+			if rawSubmitPrelude(cfg.me) != "" {
+				state.phase = wakeInputRawPreludePending
+			} else {
+				state.phase = wakeInputPrimarySubmitPending
+			}
+
+		case wakeInputRawPreludePending:
+			prelude := rawSubmitPrelude(cfg.me)
+			if prelude == "" {
+				state.phase = wakeInputPrimarySubmitPending
+				continue
+			}
+			wrote, err := writePendingWakeInputChunk(cfg, state, prelude)
+			if err != nil {
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: prelude inject failed: %v\n", err)
+				}
+				return false, err
+			}
+			if !wrote {
+				return false, nil
+			}
+			if cfg.debug {
+				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: prelude injected OK (%q)\n", prelude)
+			}
+			state.phase = wakeInputPrimarySubmitPending
+
+		case wakeInputPrimarySubmitPending:
+			if state.mode == wakeInjectModePaste {
+				// Keep Enter in a separate read cycle from the paste payload.
+				time.Sleep(25 * time.Millisecond)
+			} else {
+				// Hold the submit CR past the TUI's paste-burst window.
+				rawInjectSleep(rawInjectSettleDelay)
+			}
+			wrote, err := writePendingWakeInputChunk(cfg, state, "\r")
+			if err != nil {
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key inject failed: %v\n", err)
+				}
+				return false, err
+			}
+			if !wrote {
+				return false, nil
+			}
+			if state.mode == wakeInjectModePaste {
+				state.reset()
+				return true, nil
+			}
+			if cfg.debug {
+				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key injected OK\n")
+			}
+
+			// A repeat Enter rescues a swallowed first submit. Skip it only when
+			// the first Enter is provably still queued.
+			waited, drained, drainErr := waitForRawInputDrained(
+				rawInjectCRDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if drainErr == nil && !drained {
+				state.phase = wakeInputRawFirstSubmitQueued
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; skipping rescue submit\n", waited)
+				}
+				return false, nil
+			}
+			// When queue inspection is unavailable, preserve the historical one
+			// spaced rescue, but retain this exact step across authority loss.
+			state.phase = wakeInputRawRescuePending
+
+		case wakeInputRawFirstSubmitQueued:
+			waited, drained, err := waitForRawInputDrained(
+				rawInjectCRDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if cfg.debug {
+				switch {
+				case err != nil:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: pending submit drain check failed after %s: %v\n", waited, err)
+				case !drained:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; waiting for terminal reader\n", waited)
+				}
+			}
+			if err != nil || !drained {
+				return false, nil
+			}
+			state.phase = wakeInputRawRescuePending
+
+		case wakeInputRawRescuePending:
+			rawInjectSleep(rawInjectSettleDelay)
+			wrote, err := writePendingWakeInputChunk(cfg, state, "\r")
+			if err != nil {
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit inject failed: %v\n", err)
+				}
+				return false, err
+			}
+			if !wrote {
+				return false, nil
+			}
+			if cfg.debug {
+				_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit injected OK\n")
+			}
+			waited, drained, drainErr := waitForRawInputDrained(
+				rawInjectCRDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if drainErr != nil {
+				// Queue inspection is best-effort. A successful write remains
+				// the strongest available completion evidence.
+				state.reset()
+				return true, nil
+			}
+			if !drained {
+				state.phase = wakeInputRawRescueQueued
+				if cfg.debug {
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: rescue submit still queued after %s; waiting for terminal reader\n", waited)
+				}
+				return false, nil
+			}
+			state.reset()
+			return true, nil
+
+		case wakeInputRawRescueQueued:
+			waited, drained, err := waitForRawInputDrained(
+				rawInjectCRDrainTimeout,
+				rawInjectDrainPollInterval,
+			)
+			if cfg.debug {
+				switch {
+				case err != nil:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: pending submit drain check failed after %s: %v\n", waited, err)
+				case !drained:
+					_ = writeWakeDiagnostic(cfg, "amq wake [debug]: submit key still queued after %s; waiting for terminal reader\n", waited)
+				}
+			}
+			if err != nil || !drained {
+				return false, nil
+			}
+			state.reset()
+			return true, nil
+
+		default:
+			return false, fmt.Errorf("invalid pending wake input phase %d", state.phase)
 		}
-		return false, nil
 	}
-	clearRawSubmitState(cfg)
 	return true, nil
 }
 
@@ -1176,7 +1393,7 @@ func waitForInputQueueDrain(
 
 func injectVia(cfg *wakeConfig, text string) error {
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: inject-via mode, running: %s %s <text>\n", cfg.injectVia, strings.Join(cfg.injectArgs, " "))
+		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via mode, running: %s %s <text>\n", cfg.injectVia, strings.Join(cfg.injectArgs, " "))
 	}
 
 	executable := strings.TrimSpace(cfg.injectVia)
@@ -1198,17 +1415,26 @@ func injectVia(cfg *wakeConfig, text string) error {
 	args := append([]string{}, cfg.injectArgs...)
 	args = append(args, text)
 	cmd := exec.CommandContext(ctx, executable, args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			if cfg.debug {
-				_ = writeStderr("amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, string(out))
-			}
-			return fmt.Errorf("inject-via timed out after %s", timeout)
-		}
+	waitDelay := timeout / 10
+	if waitDelay <= 0 {
+		waitDelay = time.Millisecond
+	}
+	if waitDelay > 100*time.Millisecond {
+		waitDelay = 100 * time.Millisecond
+	}
+	cmd.WaitDelay = waitDelay
+	out, runErr := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded || errors.Is(runErr, exec.ErrWaitDelay) {
 		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: inject-via failed: %v (%s)\n", err, string(out))
+			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via timed out after %s (%s)\n", timeout, string(out))
 		}
-		return err
+		return fmt.Errorf("inject-via timed out after %s", timeout)
+	}
+	if runErr != nil {
+		if cfg.debug {
+			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via failed: %v (%s)\n", runErr, string(out))
+		}
+		return runErr
 	}
 
 	return nil

--- a/internal/cli/wake_attention.go
+++ b/internal/cli/wake_attention.go
@@ -24,6 +24,24 @@ type wakeAttentionEmission struct {
 	OutputProvenance wakePayloadProvenance
 }
 
+// writeWakeDiagnostic preserves human-readable logs without writing printable
+// bytes over a Codex or Claude alternate-screen composer on the shared TTY.
+func writeWakeDiagnostic(cfg *wakeConfig, format string, args ...any) error {
+	if cfg != nil &&
+		wakeDiagnosticIsTerminal(cfg) &&
+		wakeUsesAlternateScreenTUI(cfg.me) {
+		return nil
+	}
+	return writeStderr(format, args...)
+}
+
+func wakeDiagnosticIsTerminal(cfg *wakeConfig) bool {
+	if cfg != nil && cfg.diagnosticIsTTY != nil {
+		return cfg.diagnosticIsTTY()
+	}
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
 // emitWakeAttention is the non-input destination for a wake notification.
 // Effects record only a complete write by AMQ; they do not assert that a
 // terminal rendered them or that a person observed them.
@@ -31,14 +49,21 @@ func emitWakeAttention(cfg *wakeConfig, payload wakePayload) {
 	if cfg != nil && cfg.suppressAttention {
 		return
 	}
-	effects := []string{wakeAttentionEffectOutput}
+	isTerminal := wakeAttentionIsTerminal(cfg)
+	writePlainOutput := !isTerminal || cfg == nil || !wakeUsesAlternateScreenTUI(cfg.me)
+	var effects []string
+	if writePlainOutput {
+		effects = append(effects, wakeAttentionEffectOutput)
+	}
 	var output strings.Builder
 
 	safeText := sanitizeForTTY(payload.text)
-	if wakeAttentionIsTerminal(cfg) {
+	if isTerminal {
 		effects = append(effects, wakeAttentionEffectBell, wakeAttentionEffectTitle)
 		// OSC 0 and a standalone BEL form the portable terminal-attention floor.
-		// The BEL terminating OSC 0 is not relied on to ring.
+		// The BEL terminating OSC 0 is not relied on to ring. Do not append plain
+		// text for alternate-screen agent TUIs: stderr shares their raw terminal
+		// and would overwrite or interleave with the active composer.
 		fmt.Fprintf(&output, "\x1b]0;%s\a\a", wakeAttentionTitle)
 
 		oscText := strings.ReplaceAll(safeText, ";", ",")
@@ -51,8 +76,10 @@ func emitWakeAttention(cfg *wakeConfig, payload wakePayload) {
 			effects = append(effects, wakeAttentionEffectOSC777)
 		}
 	}
-	output.WriteString(safeText)
-	output.WriteByte('\n')
+	if writePlainOutput {
+		output.WriteString(safeText)
+		output.WriteByte('\n')
+	}
 
 	write := func(data []byte) (int, error) {
 		return os.Stderr.Write(data)
@@ -66,7 +93,7 @@ func emitWakeAttention(cfg *wakeConfig, payload wakePayload) {
 		if err == nil {
 			err = io.ErrShortWrite
 		}
-		_ = writeStderr("amq wake: output attention write failed after %d/%d bytes: %v\n", n, len(data), err)
+		_ = writeWakeDiagnostic(cfg, "amq wake: output attention write failed after %d/%d bytes: %v\n", n, len(data), err)
 		return
 	}
 
@@ -76,7 +103,7 @@ func emitWakeAttention(cfg *wakeConfig, payload wakePayload) {
 			OutputProvenance: payload.provenance,
 		}
 		if err := cfg.recordAttention(emission); err != nil {
-			_ = writeStderr("amq wake: record output attention write: %v\n", err)
+			_ = writeWakeDiagnostic(cfg, "amq wake: record output attention write: %v\n", err)
 		}
 	}
 }
@@ -93,8 +120,8 @@ func supportedWakeAttentionNotification(cfg *wakeConfig) string {
 	if cfg != nil && cfg.attentionEnv != nil {
 		lookup = cfg.attentionEnv
 	}
-	// Keep this as a verified-upstream allowlist. Unknown terminals
-	// deliberately receive only the portable bell/title/output floor.
+	// Keep this as a verified-upstream allowlist. Unknown terminals receive the
+	// portable bell/title floor plus plain output when it is safe for the target.
 	switch lookup("TERM_PROGRAM") {
 	case "iTerm.app", "ghostty":
 		return wakeAttentionEffectOSC9

--- a/internal/cli/wake_attention.go
+++ b/internal/cli/wake_attention.go
@@ -28,6 +28,9 @@ type wakeAttentionEmission struct {
 // Effects record only a complete write by AMQ; they do not assert that a
 // terminal rendered them or that a person observed them.
 func emitWakeAttention(cfg *wakeConfig, payload wakePayload) {
+	if cfg != nil && cfg.suppressAttention {
+		return
+	}
 	effects := []string{wakeAttentionEffectOutput}
 	var output strings.Builder
 

--- a/internal/cli/wake_attention_fd_unix.go
+++ b/internal/cli/wake_attention_fd_unix.go
@@ -1,0 +1,87 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+const envWakeAttentionFD = "AMQ_WAKE_ATTENTION_FD"
+
+// attachWakeAttentionFD gives the wake child an isolated attention destination
+// without disturbing capabilities already assigned through ExtraFiles.
+func attachWakeAttentionFD(cmd *exec.Cmd, attention *os.File) error {
+	if cmd == nil {
+		return fmt.Errorf("wake attention command is missing")
+	}
+	if attention == nil {
+		return fmt.Errorf("wake attention file is missing")
+	}
+
+	childFD := 3 + len(cmd.ExtraFiles)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, attention)
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = setEnvVar(
+		unsetEnvVar(cmd.Env, envWakeAttentionFD),
+		envWakeAttentionFD,
+		strconv.Itoa(childFD),
+	)
+	return nil
+}
+
+// wakeAttentionFromEnv adopts the descriptor transferred by the coop parent.
+// A present environment value is authoritative: malformed or unavailable
+// descriptors fail closed instead of falling back to the diagnostic stream.
+func wakeAttentionFromEnv() (*os.File, error) {
+	raw, present := os.LookupEnv(envWakeAttentionFD)
+	if !present {
+		return nil, nil
+	}
+	if err := os.Unsetenv(envWakeAttentionFD); err != nil {
+		return nil, fmt.Errorf("clear %s after ingestion: %w", envWakeAttentionFD, err)
+	}
+
+	fd, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || fd < 3 {
+		return nil, fmt.Errorf("%s is invalid", envWakeAttentionFD)
+	}
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s fd: %w", envWakeAttentionFD, err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, flags|unix.FD_CLOEXEC); err != nil {
+			_ = unix.Close(fd)
+			return nil, fmt.Errorf("make %s fd close-on-exec: %w", envWakeAttentionFD, err)
+		}
+	}
+	sealedFlags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("verify %s fd flags: %w", envWakeAttentionFD, err)
+	}
+	if sealedFlags&unix.FD_CLOEXEC == 0 {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("%s fd is not close-on-exec", envWakeAttentionFD)
+	}
+
+	attention := os.NewFile(uintptr(fd), "amq-wake-attention")
+	if attention == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("%s fd is unavailable", envWakeAttentionFD)
+	}
+	return attention, nil
+}
+
+func wakeAttentionFileIsTerminal(attention *os.File) bool {
+	return attention != nil && term.IsTerminal(int(attention.Fd()))
+}

--- a/internal/cli/wake_attention_fd_unix_test.go
+++ b/internal/cli/wake_attention_fd_unix_test.go
@@ -1,0 +1,340 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+)
+
+func TestAttachWakeAttentionFDPreservesExistingExtraFilesAndReplacesEnv(t *testing.T) {
+	existingRead, existingWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = existingRead.Close() }()
+	defer func() { _ = existingWrite.Close() }()
+	attentionRead, attentionWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = attentionRead.Close() }()
+	defer func() { _ = attentionWrite.Close() }()
+
+	cmd := exec.Command("true")
+	cmd.ExtraFiles = []*os.File{existingWrite}
+	cmd.Env = []string{
+		"AMQ_TEST_KEEP=present",
+		envWakeAttentionFD + "=stale",
+		envWakeAttentionFD + "=duplicate",
+	}
+
+	if err := attachWakeAttentionFD(cmd, attentionWrite); err != nil {
+		t.Fatal(err)
+	}
+	if len(cmd.ExtraFiles) != 2 {
+		t.Fatalf("extra files = %d, want 2", len(cmd.ExtraFiles))
+	}
+	if cmd.ExtraFiles[0] != existingWrite {
+		t.Fatal("existing extra file was replaced")
+	}
+	if cmd.ExtraFiles[1] != attentionWrite {
+		t.Fatal("attention file was not appended")
+	}
+
+	wantEnv := envWakeAttentionFD + "=4"
+	var attentionEntries int
+	for _, entry := range cmd.Env {
+		if entry == wantEnv {
+			attentionEntries++
+		}
+	}
+	if attentionEntries != 1 {
+		t.Fatalf("%s entries = %d, want exactly one in %q", envWakeAttentionFD, attentionEntries, cmd.Env)
+	}
+	if !environmentContains(cmd.Env, "AMQ_TEST_KEEP=present") {
+		t.Fatalf("unrelated environment was not preserved: %q", cmd.Env)
+	}
+}
+
+func TestAttachWakeAttentionFDSeedsNilEnvironmentFromProcess(t *testing.T) {
+	t.Setenv("AMQ_TEST_ATTENTION_INHERITED", "present")
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = readEnd.Close() }()
+	defer func() { _ = writeEnd.Close() }()
+
+	cmd := exec.Command("true")
+	if err := attachWakeAttentionFD(cmd, writeEnd); err != nil {
+		t.Fatal(err)
+	}
+	if !environmentContains(cmd.Env, "AMQ_TEST_ATTENTION_INHERITED=present") {
+		t.Fatalf("process environment was not inherited: %q", cmd.Env)
+	}
+	if !environmentContains(cmd.Env, envWakeAttentionFD+"=3") {
+		t.Fatalf("attention descriptor environment is missing: %q", cmd.Env)
+	}
+}
+
+func TestAttachWakeAttentionFDRejectsMissingInputs(t *testing.T) {
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = readEnd.Close() }()
+	defer func() { _ = writeEnd.Close() }()
+
+	if err := attachWakeAttentionFD(nil, writeEnd); err == nil {
+		t.Fatal("nil command unexpectedly accepted")
+	}
+	if err := attachWakeAttentionFD(exec.Command("true"), nil); err == nil {
+		t.Fatal("nil attention file unexpectedly accepted")
+	}
+}
+
+func TestWakeAttentionFromEnvAdoptsOnlySuppliedFDAndSealsIt(t *testing.T) {
+	targetRead, targetWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = targetRead.Close() }()
+	decoyRead, decoyWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = decoyRead.Close() }()
+	defer func() { _ = decoyWrite.Close() }()
+
+	inheritedFD, err := unix.FcntlInt(targetWrite.Fd(), unix.F_DUPFD, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := targetWrite.Close(); err != nil {
+		_ = unix.Close(inheritedFD)
+		t.Fatal(err)
+	}
+	adopted := false
+	defer func() {
+		if !adopted {
+			_ = unix.Close(inheritedFD)
+		}
+	}()
+	flags, err := unix.FcntlInt(uintptr(inheritedFD), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := unix.FcntlInt(uintptr(inheritedFD), unix.F_SETFD, flags&^unix.FD_CLOEXEC); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(envWakeAttentionFD, strconv.Itoa(inheritedFD))
+	attention, err := wakeAttentionFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attention == nil {
+		t.Fatal("attention file is nil")
+	}
+	adopted = true
+	defer func() { _ = attention.Close() }()
+	if _, exists := os.LookupEnv(envWakeAttentionFD); exists {
+		t.Fatalf("%s was not cleared after ingestion", envWakeAttentionFD)
+	}
+
+	sealedFlags, err := unix.FcntlInt(attention.Fd(), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sealedFlags&unix.FD_CLOEXEC == 0 {
+		t.Fatal("inherited attention descriptor is not close-on-exec")
+	}
+	if got, want := wakeAttentionFileIsTerminal(attention), term.IsTerminal(int(attention.Fd())); got != want {
+		t.Fatalf("terminal predicate = %v, want %v", got, want)
+	}
+
+	payload := []byte("attention-only")
+	if n, err := attention.Write(payload); err != nil || n != len(payload) {
+		t.Fatalf("write = %d, %v; want %d, nil", n, err, len(payload))
+	}
+	got := make([]byte, len(payload))
+	if _, err := targetRead.Read(got); err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("target payload = %q, want %q", got, payload)
+	}
+
+	if err := decoyWrite.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var decoy [1]byte
+	if n, err := decoyRead.Read(decoy[:]); n != 0 || err != io.EOF {
+		t.Fatalf("decoy received %d bytes, want none", n)
+	}
+}
+
+func TestRunWakeWithLoopSeparatesInheritedAttentionFromDiagnostics(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatal(err)
+	}
+
+	attentionRead, attentionWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = attentionRead.Close() }()
+	inheritedFD, err := unix.FcntlInt(attentionWrite.Fd(), unix.F_DUPFD_CLOEXEC, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := attentionWrite.Close(); err != nil {
+		_ = unix.Close(inheritedFD)
+		t.Fatal(err)
+	}
+	descriptorOwnedByTest := true
+	defer func() {
+		if descriptorOwnedByTest {
+			_ = unix.Close(inheritedFD)
+		}
+	}()
+
+	t.Setenv(envWakeAttentionFD, strconv.Itoa(inheritedFD))
+	sentinel := errors.New("wake-loop-complete")
+	var runErr error
+	stderr := captureWakeStderr(t, func() {
+		runErr = runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "orchestrator",
+			"--inject-mode", wakeInjectModeNone,
+		}, func(cfg wakeConfig) error {
+			if cfg.attentionWrite == nil || cfg.attentionIsTTY == nil {
+				t.Fatal("inherited attention destination was not wired into wake config")
+			}
+			if cfg.attentionIsTTY() {
+				t.Fatal("pipe attention destination reported as a terminal")
+			}
+			if err := writeWakeDiagnostic(&cfg, "diagnostic-only\n"); err != nil {
+				t.Fatal(err)
+			}
+			emitWakeAttention(&cfg, wakePayload{
+				text:       "attention-only",
+				provenance: wakePayloadSystemFixed,
+			})
+			return sentinel
+		})
+	})
+
+	if !errors.Is(runErr, sentinel) {
+		t.Fatalf("runWakeWithLoop error = %v, want sentinel", runErr)
+	}
+	if _, exists := os.LookupEnv(envWakeAttentionFD); exists {
+		t.Fatalf("%s was not cleared by runWakeWithLoop", envWakeAttentionFD)
+	}
+	descriptorOwnedByTest = false
+	if stderr != "diagnostic-only\n" {
+		t.Fatalf("diagnostic stream = %q, want only diagnostic", stderr)
+	}
+	attentionOutput, err := io.ReadAll(attentionRead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(attentionOutput), "attention-only\n"; got != want {
+		t.Fatalf("attention stream = %q, want %q", got, want)
+	}
+}
+
+func TestWakeAttentionFromEnvMissingIsDisabled(t *testing.T) {
+	t.Setenv(envWakeAttentionFD, "restore-after-test")
+	if err := os.Unsetenv(envWakeAttentionFD); err != nil {
+		t.Fatal(err)
+	}
+
+	attention, err := wakeAttentionFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attention != nil {
+		_ = attention.Close()
+		t.Fatal("missing environment unexpectedly returned an attention file")
+	}
+}
+
+func TestWakeAttentionFromEnvRejectsInvalidValuesAndClearsEnv(t *testing.T) {
+	for _, raw := range []string{"", " ", "2", "-1", "not-a-number", "3x"} {
+		t.Run(strconv.Quote(raw), func(t *testing.T) {
+			t.Setenv(envWakeAttentionFD, raw)
+			attention, err := wakeAttentionFromEnv()
+			if attention != nil {
+				_ = attention.Close()
+				t.Fatal("invalid environment unexpectedly returned an attention file")
+			}
+			if err == nil {
+				t.Fatal("invalid environment unexpectedly accepted")
+			}
+			if _, exists := os.LookupEnv(envWakeAttentionFD); exists {
+				t.Fatalf("%s was not cleared after rejection", envWakeAttentionFD)
+			}
+		})
+	}
+}
+
+func TestWakeAttentionFromEnvRejectsUnavailableFDAndClearsEnv(t *testing.T) {
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = readEnd.Close() }()
+	fd, err := unix.FcntlInt(writeEnd.Fd(), unix.F_DUPFD_CLOEXEC, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeEnd.Close(); err != nil {
+		_ = unix.Close(fd)
+		t.Fatal(err)
+	}
+	if err := unix.Close(fd); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(envWakeAttentionFD, strconv.Itoa(fd))
+	attention, err := wakeAttentionFromEnv()
+	if attention != nil {
+		_ = attention.Close()
+		t.Fatal("closed descriptor unexpectedly returned an attention file")
+	}
+	if err == nil {
+		t.Fatal("closed descriptor unexpectedly accepted")
+	}
+	if _, exists := os.LookupEnv(envWakeAttentionFD); exists {
+		t.Fatalf("%s was not cleared after rejection", envWakeAttentionFD)
+	}
+}
+
+func TestWakeAttentionFileIsTerminalRejectsNil(t *testing.T) {
+	if wakeAttentionFileIsTerminal(nil) {
+		t.Fatal("nil attention file reported as terminal")
+	}
+}
+
+func environmentContains(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/wake_attention_test.go
+++ b/internal/cli/wake_attention_test.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 func testWakeNotification(input, output string, provenance wakePayloadProvenance) wakeNotification {
@@ -312,9 +315,274 @@ func TestWakeAttentionReportsOnlyFullyWrittenOutputEffectsAndProvenance(t *testi
 	}
 }
 
+func TestWakeAttentionAlternateScreenAgentOmitsPlainTerminalOutput(t *testing.T) {
+	for _, me := range []string{"codex", "codex2", "claude"} {
+		t.Run(me, func(t *testing.T) {
+			var recorded wakeAttentionEmission
+			var written strings.Builder
+			cfg := &wakeConfig{
+				me:             me,
+				attentionEnv:   func(string) string { return "" },
+				attentionIsTTY: func() bool { return true },
+				attentionWrite: func(data []byte) (int, error) {
+					return written.Write(data)
+				},
+				recordAttention: func(emission wakeAttentionEmission) error {
+					recorded = emission
+					return nil
+				},
+			}
+			payload := wakePayload{
+				text:       "AMQ [session1]: message from peer",
+				provenance: wakePayloadPeerHeaders,
+			}
+
+			emitWakeAttention(cfg, payload)
+
+			if got := written.String(); got != "\x1b]0;AMQ attention\a\a" {
+				t.Fatalf("alternate-screen attention = %q, want title and bell only", got)
+			}
+			wantEffects := []string{
+				wakeAttentionEffectBell,
+				wakeAttentionEffectTitle,
+			}
+			if !reflect.DeepEqual(recorded.Effects, wantEffects) {
+				t.Fatalf("effects = %#v, want %#v", recorded.Effects, wantEffects)
+			}
+			if recorded.OutputProvenance != wakePayloadPeerHeaders {
+				t.Fatalf("provenance = %q, want peer headers", recorded.OutputProvenance)
+			}
+		})
+	}
+}
+
+func TestWakeAttentionAlternateScreenAgentKeepsSupportedOSCNotification(t *testing.T) {
+	var recorded wakeAttentionEmission
+	var written strings.Builder
+	cfg := &wakeConfig{
+		me:             "codex",
+		attentionEnv:   func(key string) string { return map[string]string{"TERM_PROGRAM": "ghostty"}[key] },
+		attentionIsTTY: func() bool { return true },
+		attentionWrite: func(data []byte) (int, error) {
+			return written.Write(data)
+		},
+		recordAttention: func(emission wakeAttentionEmission) error {
+			recorded = emission
+			return nil
+		},
+	}
+	payload := wakePayload{
+		text:       "AMQ [session1]: safe;notice",
+		provenance: wakePayloadPeerHeaders,
+	}
+
+	emitWakeAttention(cfg, payload)
+
+	got := written.String()
+	if !strings.Contains(got, "\x1b]9;AMQ [session1]: safe,notice\a") {
+		t.Fatalf("supported OSC notification missing: %q", got)
+	}
+	if strings.HasSuffix(got, payload.text+"\n") {
+		t.Fatalf("alternate-screen attention appended plain text: %q", got)
+	}
+	if !reflect.DeepEqual(recorded.Effects, []string{
+		wakeAttentionEffectBell,
+		wakeAttentionEffectTitle,
+		wakeAttentionEffectOSC9,
+	}) {
+		t.Fatalf("effects = %#v", recorded.Effects)
+	}
+}
+
+func TestWakeDiagnosticAvoidsAlternateScreenTTYAndKeepsRedirectedLogs(t *testing.T) {
+	cfg := &wakeConfig{
+		me:              "codex",
+		diagnosticIsTTY: func() bool { return true },
+	}
+	stderr := captureWakeStderr(t, func() {
+		if err := writeWakeDiagnostic(cfg, "amq wake: warning: %s\n", "unsafe"); err != nil {
+			t.Fatalf("terminal diagnostic: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("alternate-screen diagnostic wrote plain text: %q", stderr)
+	}
+
+	cfg.diagnosticIsTTY = func() bool { return false }
+	stderr = captureWakeStderr(t, func() {
+		if err := writeWakeDiagnostic(cfg, "amq wake: warning: %s\n", "logged"); err != nil {
+			t.Fatalf("redirected diagnostic: %v", err)
+		}
+	})
+	if stderr != "amq wake: warning: logged\n" {
+		t.Fatalf("redirected diagnostic = %q", stderr)
+	}
+}
+
+func TestWakeDiagnosticUsesItsOwnSinkInsteadOfAttentionTerminal(t *testing.T) {
+	tests := []struct {
+		name            string
+		attentionIsTTY  bool
+		diagnosticIsTTY bool
+		wantDiagnostic  string
+	}{
+		{
+			name:            "terminal attention with durable diagnostic log",
+			attentionIsTTY:  true,
+			diagnosticIsTTY: false,
+			wantDiagnostic:  "durable diagnostic\n",
+		},
+		{
+			name:            "redirected attention with shared diagnostic terminal",
+			attentionIsTTY:  false,
+			diagnosticIsTTY: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &wakeConfig{
+				me:              "codex",
+				attentionIsTTY:  func() bool { return tc.attentionIsTTY },
+				diagnosticIsTTY: func() bool { return tc.diagnosticIsTTY },
+			}
+			stderr := captureWakeStderr(t, func() {
+				if err := writeWakeDiagnostic(cfg, "durable diagnostic\n"); err != nil {
+					t.Fatalf("writeWakeDiagnostic: %v", err)
+				}
+			})
+			if stderr != tc.wantDiagnostic {
+				t.Fatalf("diagnostic = %q, want %q", stderr, tc.wantDiagnostic)
+			}
+		})
+	}
+}
+
+func TestNotifyNewMessagesCodexMaxHoldUsesTerminalSafeAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	for index, sender := range []string{"codex2", "peer"} {
+		message := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      "attention-max-hold-" + sender,
+				From:    sender,
+				To:      []string{"codex"},
+				Thread:  "p2p/codex__" + sender,
+				Subject: "pending",
+				Created: "2026-07-30T08:00:00Z",
+			},
+		}
+		data, err := message.Marshal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		name := string(rune('a'+index)) + ".md"
+		if _, err := deliverToInboxForTest(t, root, "codex", name, data); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldWait := waitForWakeInputQuiet
+	waitForWakeInputQuiet = func(*wakeConfig) bool { return false }
+	t.Cleanup(func() { waitForWakeInputQuiet = oldWait })
+
+	var written strings.Builder
+	cfg := &wakeConfig{
+		me:              "codex",
+		root:            root,
+		session:         "session1",
+		wakeOwner:       &wakeOwner{},
+		injectMode:      wakeInjectModeRaw,
+		deferWhileInput: true,
+		attentionEnv:    func(string) string { return "" },
+		attentionIsTTY:  func() bool { return true },
+		attentionWrite: func(data []byte) (int, error) {
+			return written.Write(data)
+		},
+	}
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify max-hold messages: %v", err)
+	}
+	if got := written.String(); got != "\x1b]0;AMQ attention\a\a" {
+		t.Fatalf("max-hold attention = %q, want title and bell only", got)
+	}
+}
+
+func TestNotifyNewMessagesCodexInterruptFallbackUsesTerminalSafeAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	message := format.Message{
+		Header: format.Header{
+			Schema:   1,
+			ID:       "attention-interrupt",
+			From:     "peer",
+			To:       []string{"codex"},
+			Thread:   "p2p/codex__peer",
+			Subject:  "urgent",
+			Created:  "2026-07-30T08:00:00Z",
+			Priority: "urgent",
+			Labels:   []string{"interrupt"},
+		},
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "urgent.md", data); err != nil {
+		t.Fatal(err)
+	}
+
+	var written strings.Builder
+	cfg := &wakeConfig{
+		me:                "codex",
+		root:              root,
+		session:           "session1",
+		wakeOwner:         &wakeOwner{},
+		injectMode:        wakeInjectModeRaw,
+		fallbackWarn:      true,
+		interrupt:         true,
+		interruptLabel:    "interrupt",
+		interruptPriority: "urgent",
+		terminalWrite: func(string) error {
+			return newWakeInjectorUnsupportedError(syscall.EIO)
+		},
+		attentionEnv:   func(string) string { return "" },
+		attentionIsTTY: func() bool { return true },
+		diagnosticIsTTY: func() bool {
+			return true
+		},
+		attentionWrite: func(data []byte) (int, error) {
+			return written.Write(data)
+		},
+	}
+	stderr := captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("notify interrupt fallback: %v", err)
+		}
+	})
+	if stderr != "" {
+		t.Fatalf("interrupt fallback wrote plain diagnostic: %q", stderr)
+	}
+	if got := written.String(); got != "\x1b]0;AMQ attention\a\a" {
+		t.Fatalf("interrupt attention = %q, want title and bell only", got)
+	}
+}
+
 func TestWakeAttentionRedirectedOutputOmitsControls(t *testing.T) {
 	var recorded wakeAttentionEmission
 	cfg := &wakeConfig{
+		me:             "codex",
 		attentionIsTTY: func() bool { return false },
 		recordAttention: func(emission wakeAttentionEmission) error {
 			recorded = emission

--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -30,7 +31,11 @@ type wakeControlOwnerRequest struct {
 	Generation string     `json:"generation"`
 	Owner      *wakeOwner `json:"owner,omitempty"`
 	Rollback   bool       `json:"rollback,omitempty"`
+	Operation  string     `json:"operation,omitempty"`
+	Token      string     `json:"token,omitempty"`
 }
+
+const wakeControlPromptObserved = "prompt_observed"
 
 func wakeControlSocketPath(root, me, generation string) string {
 	sum := sha256.Sum256([]byte(canonicalWakeRoot(root) + "\x00" + me + "\x00" + generation))
@@ -422,7 +427,11 @@ func handleDarwinOwnerControl(
 	_, _ = conn.Write([]byte("ACK\n"))
 }
 
-func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan struct{}, func(), error) {
+func startWakeControlListener(
+	root, me string,
+	lock wakeLock,
+	promptObserved chan<- string,
+) (func(), <-chan struct{}, func(), error) {
 	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
 		return nil, nil, nil, err
@@ -433,6 +442,7 @@ func startWakeControlListener(root, me string, lock wakeLock) (func(), <-chan st
 		me,
 		lock,
 		true,
+		promptObserved,
 	)
 	if err != nil {
 		_ = agentDir.Close()
@@ -444,8 +454,9 @@ func startWakeControlListenerInDir(
 	agentDir *wakeAgentDir,
 	root, me string,
 	lock wakeLock,
+	promptObserved chan<- string,
 ) (func(), <-chan struct{}, func(), error) {
-	return startWakeControlListenerInDirOwned(agentDir, root, me, lock, false)
+	return startWakeControlListenerInDirOwned(agentDir, root, me, lock, false, promptObserved)
 }
 
 func startWakeControlListenerInDirOwned(
@@ -453,6 +464,7 @@ func startWakeControlListenerInDirOwned(
 	root, me string,
 	lock wakeLock,
 	closeAgentDir bool,
+	promptObserved chan<- string,
 ) (func(), <-chan struct{}, func(), error) {
 	path := lock.ControlSocket
 	if path == "" {
@@ -502,8 +514,8 @@ func startWakeControlListenerInDirOwned(
 				if err != nil || uid != uint32(os.Geteuid()) {
 					return
 				}
-				line, err := bufio.NewReader(conn).ReadString('\n')
-				if err != nil {
+				line, err := bufio.NewReader(io.LimitReader(conn, 4097)).ReadString('\n')
+				if err != nil || len(line) > 4096 {
 					return
 				}
 				if lock.WakeMode == wakeOwnerWakeMode {
@@ -513,6 +525,38 @@ func startWakeControlListenerInDirOwned(
 					}
 					peerPID, err := darwinPeerPID(conn)
 					if err != nil {
+						return
+					}
+					if request.Operation == wakeControlPromptObserved {
+						accepted := false
+						err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+							_, _, authErr := authorizeDarwinOwnerControlAt(
+								dirfd,
+								agentDir,
+								root,
+								me,
+								lock,
+								request,
+								peerPID,
+								uid,
+							)
+							if authErr != nil {
+								return authErr
+							}
+							accepted = true
+							return nil
+						})
+						if err != nil || !accepted || !validWakeDoorbellToken(request.Token) {
+							return
+						}
+						if promptObserved != nil {
+							select {
+							case promptObserved <- request.Token:
+							default:
+								return
+							}
+						}
+						_, _ = conn.Write([]byte("ACK\n"))
 						return
 					}
 					handleDarwinOwnerControl(
@@ -527,6 +571,39 @@ func startWakeControlListenerInDirOwned(
 						stopRequest,
 						loopStopped,
 					)
+					return
+				}
+				if lock.WakeMode == wakeInjectModeRaw || lock.WakeMode == wakeInjectModePaste {
+					var request wakeControlOwnerRequest
+					if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &request); err != nil ||
+						request.Operation != wakeControlPromptObserved ||
+						request.Generation != lock.Generation ||
+						!validWakeDoorbellToken(request.Token) {
+						return
+					}
+					accepted := false
+					err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+						current := inspectWakeLockAt(dirfd, agentDir, root, me)
+						if !current.Exists ||
+							current.Lock.Generation != lock.Generation ||
+							current.Lock.ControlSocket != path ||
+							current.Lock.WakeMode != lock.WakeMode {
+							return nil
+						}
+						accepted = true
+						return nil
+					})
+					if err != nil || !accepted {
+						return
+					}
+					if promptObserved != nil {
+						select {
+						case promptObserved <- request.Token:
+						default:
+							return
+						}
+					}
+					_, _ = conn.Write([]byte("ACK\n"))
 					return
 				}
 				if strings.TrimSpace(line) != lock.Generation {
@@ -598,7 +675,11 @@ func startWakeControlListenerInDirOwned(
 			}
 		})
 	}
-	return cleanup, stopRequest, markLoopStopped, nil
+	var exposedStop <-chan struct{} = stopRequest
+	if lock.WakeMode == wakeInjectModeRaw || lock.WakeMode == wakeInjectModePaste {
+		exposedStop = nil
+	}
+	return cleanup, exposedStop, markLoopStopped, nil
 }
 
 func cooperativeStopInjectVia(i wakeLockInspection) (bool, error) {

--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -299,7 +300,7 @@ func authorizeDarwinOwnerControlAt(
 	request wakeControlOwnerRequest,
 	peerPID int,
 	peerUID uint32,
-) (wakeLockInspection, *wakeTarget, error) {
+) (authorized wakeLockInspection, authorizedTarget *wakeTarget, retErr error) {
 	if peerUID != uint32(os.Geteuid()) {
 		return wakeLockInspection{}, nil, fmt.Errorf("wake control peer uid is not authorized")
 	}
@@ -318,7 +319,13 @@ func authorizeDarwinOwnerControlAt(
 		return wakeLockInspection{}, nil, err
 	}
 	observation, err := observeAuthoritativeWakeOwner(*current.Lock.Owner)
-	defer func() { _ = observation.Close() }()
+	defer func() {
+		if closeErr := observation.Close(); closeErr != nil {
+			authorized = wakeLockInspection{}
+			authorizedTarget = nil
+			retErr = errors.Join(retErr, closeErr)
+		}
+	}()
 	if err != nil {
 		return wakeLockInspection{}, nil, err
 	}
@@ -370,6 +377,7 @@ func handleDarwinOwnerControl(
 	peerUID uint32,
 	stopRequest chan<- struct{},
 	loopStopped <-chan struct{},
+	testHooks *darwinWakeControlTestHooks,
 ) {
 	authorized := false
 	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
@@ -399,6 +407,9 @@ func handleDarwinOwnerControl(
 	default:
 	}
 	<-loopStopped
+	if testHooks != nil && testHooks.afterLoopStopped != nil {
+		testHooks.afterLoopStopped()
+	}
 
 	removed := false
 	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
@@ -443,6 +454,7 @@ func startWakeControlListener(
 		lock,
 		true,
 		promptObserved,
+		nil,
 	)
 	if err != nil {
 		_ = agentDir.Close()
@@ -456,7 +468,11 @@ func startWakeControlListenerInDir(
 	lock wakeLock,
 	promptObserved chan<- string,
 ) (func(), <-chan struct{}, func(), error) {
-	return startWakeControlListenerInDirOwned(agentDir, root, me, lock, false, promptObserved)
+	return startWakeControlListenerInDirOwned(agentDir, root, me, lock, false, promptObserved, nil)
+}
+
+type darwinWakeControlTestHooks struct {
+	afterLoopStopped func()
 }
 
 func startWakeControlListenerInDirOwned(
@@ -465,6 +481,7 @@ func startWakeControlListenerInDirOwned(
 	lock wakeLock,
 	closeAgentDir bool,
 	promptObserved chan<- string,
+	testHooks *darwinWakeControlTestHooks,
 ) (func(), <-chan struct{}, func(), error) {
 	path := lock.ControlSocket
 	if path == "" {
@@ -501,13 +518,18 @@ func startWakeControlListenerInDirOwned(
 	loopStopped := make(chan struct{})
 	var loopStoppedOnce sync.Once
 	markLoopStopped := func() { loopStoppedOnce.Do(func() { close(loopStopped) }) }
+	acceptDone := make(chan struct{})
+	var handlers sync.WaitGroup
 	go func() {
+		defer close(acceptDone)
 		for {
 			conn, err := listener.AcceptUnix()
 			if err != nil {
 				return
 			}
+			handlers.Add(1)
 			go func(conn *net.UnixConn) {
+				defer handlers.Done()
 				defer func() { _ = conn.Close() }()
 				_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
 				uid, err := darwinPeerEUID(conn)
@@ -570,6 +592,7 @@ func startWakeControlListenerInDirOwned(
 						uid,
 						stopRequest,
 						loopStopped,
+						testHooks,
 					)
 					return
 				}
@@ -634,6 +657,9 @@ func startWakeControlListenerInDirOwned(
 				default:
 				}
 				<-loopStopped
+				if testHooks != nil && testHooks.afterLoopStopped != nil {
+					testHooks.afterLoopStopped()
+				}
 				removed := false
 				err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 					current := inspectWakeLockAt(dirfd, agentDir, root, me)
@@ -663,7 +689,10 @@ func startWakeControlListenerInDirOwned(
 	var cleanupOnce sync.Once
 	cleanup := func() {
 		cleanupOnce.Do(func() {
+			markLoopStopped()
 			_ = listener.Close()
+			<-acceptDone
+			handlers.Wait()
 			_ = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 				if cur := inspectWakeLockAt(dirfd, agentDir, root, me); cur.Exists && cur.Lock.Generation != lock.Generation {
 					return nil
@@ -691,6 +720,16 @@ func cooperativeStopInjectVia(i wakeLockInspection) (bool, error) {
 		return false, fmt.Errorf("cooperative wake stop unavailable: %w", err)
 	}
 	defer func() { _ = agentDir.Close() }()
+	return cooperativeStopInjectViaInDir(agentDir, i)
+}
+
+func cooperativeStopInjectViaInDir(
+	agentDir *wakeAgentDir,
+	i wakeLockInspection,
+) (bool, error) {
+	if agentDir == nil {
+		return false, fmt.Errorf("cooperative wake stop agent capability is missing")
+	}
 	name, err := darwinControlSocketName(agentDir, i.Lock.ControlSocket)
 	if err != nil {
 		return false, fmt.Errorf("cooperative wake stop unavailable: %w", err)

--- a/internal/cli/wake_control_darwin_test.go
+++ b/internal/cli/wake_control_darwin_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -265,6 +266,111 @@ func TestDarwinCooperativeStopACKAfterLockRemoval(t *testing.T) {
 	}
 }
 
+func assertDarwinControlCleanupWaitsForAcceptedHandler(
+	t *testing.T,
+	stopped <-chan struct{},
+	markStopped func(),
+	afterLoopStopped <-chan struct{},
+	releaseHandler chan struct{},
+	cleanup func(),
+	waitForHandler func(),
+) {
+	t.Helper()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("accepted handler did not request loop stop")
+	}
+	markStopped()
+	select {
+	case <-afterLoopStopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("accepted handler did not reach post-quiesce cleanup")
+	}
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		cleanup()
+		close(cleanupDone)
+	}()
+	cleanupReturnedEarly := false
+	select {
+	case <-cleanupDone:
+		cleanupReturnedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseHandler)
+	waitForHandler()
+	select {
+	case <-cleanupDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("control cleanup did not finish after accepted handler")
+	}
+	if cleanupReturnedEarly {
+		t.Fatal("control cleanup returned before accepted handler completed")
+	}
+}
+
+func TestDarwinControlCleanupWaitsForAcceptedInjectViaHandler(t *testing.T) {
+	root, agent, lock := testDarwinControlLock(t)
+	afterLoopStopped := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup, stopped, markStopped, err := startWakeControlListenerInDirOwned(
+		agentDir,
+		root,
+		agent,
+		lock,
+		true,
+		nil,
+		&darwinWakeControlTestHooks{
+			afterLoopStopped: func() {
+				close(afterLoopStopped)
+				<-releaseHandler
+			},
+		},
+	)
+	if err != nil {
+		_ = agentDir.Close()
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	type stopResult struct {
+		stopped bool
+		err     error
+	}
+	resultCh := make(chan stopResult, 1)
+	go func() {
+		stopped, err := cooperativeStopInjectVia(inspectWakeLock(root, agent))
+		resultCh <- stopResult{stopped: stopped, err: err}
+	}()
+	assertDarwinControlCleanupWaitsForAcceptedHandler(
+		t,
+		stopped,
+		markStopped,
+		afterLoopStopped,
+		releaseHandler,
+		cleanup,
+		func() {
+			select {
+			case got := <-resultCh:
+				if got.err != nil || !got.stopped {
+					t.Fatalf("stop=(%v,%v)", got.stopped, got.err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("cooperative stop did not finish")
+			}
+		},
+	)
+	if current := inspectWakeLock(root, agent); current.Exists {
+		t.Fatal("ACK arrived before lock removal")
+	}
+}
+
 func TestDarwinCooperativeStopACKWaitsForLoopExit(t *testing.T) {
 	root, agent, lock := testDarwinControlLock(t)
 	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
@@ -481,6 +587,39 @@ func TestDarwinOwnerControlRefusesGenerationOnlyAndWrongSessionBeforeQuiesce(t *
 	})
 }
 
+func TestDarwinOwnerControlObservationCloseFailureFailsBeforeQuiesce(t *testing.T) {
+	root, agent, owner, lock, _, _ := testDarwinOwnerControlLock(t)
+	monitorErr := errors.New("owner monitor failed")
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("observed owner = %#v, want %#v", got, owner)
+		}
+		monitor := newWakeOwnerObservationMonitor(nil)
+		monitor.finish(monitorErr)
+		return wakeOwnerObservation{State: wakeOwnerSame, monitor: monitor}, nil
+	}
+	cleanup, stopped, _, err := startWakeControlListener(root, agent, lock, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if got := sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+		Generation: lock.Generation,
+		Owner:      &owner,
+	}); got == "ACK" {
+		t.Fatal("owner monitor failure was acknowledged")
+	}
+	select {
+	case <-stopped:
+		t.Fatal("owner monitor failure quiesced notification work")
+	default:
+	}
+	if !inspectWakeLock(root, agent).Exists {
+		t.Fatal("owner monitor failure removed authoritative claim")
+	}
+}
+
 func TestDarwinOwnerControlAuthenticatedReleaseACKsAfterExactClaimRemoval(t *testing.T) {
 	root, agent, owner, lock, _, _ := testDarwinOwnerControlLock(t)
 	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
@@ -514,6 +653,125 @@ func TestDarwinOwnerControlAuthenticatedReleaseACKsAfterExactClaimRemoval(t *tes
 	case <-time.After(2 * time.Second):
 		t.Fatal("authenticated owner release did not acknowledge")
 	}
+	if inspectWakeLock(root, agent).Exists {
+		t.Fatal("authenticated owner release left the lock")
+	}
+	if _, exists, err := readWakeTarget(root, agent); err != nil || exists {
+		t.Fatalf("authenticated owner release target exists=%v err=%v", exists, err)
+	}
+}
+
+func TestDarwinOwnerControlCompletesAfterInheritedOutputInjectorTimeout(t *testing.T) {
+	root, agent, owner, lock, _, _ := testDarwinOwnerControlLock(t)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	result := make(chan string, 1)
+	go func() {
+		result <- sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+			Generation: lock.Generation,
+			Owner:      &owner,
+		})
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("authenticated owner request did not quiesce notification work")
+	}
+
+	scriptPath := filepath.Join(secureTempDirForTest(t), "background-output.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 2 &\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	injectDone := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		injectDone <- injectVia(&wakeConfig{
+			injectVia:     scriptPath,
+			injectTimeout: 50 * time.Millisecond,
+		}, "test")
+		markStopped()
+	}()
+	select {
+	case err := <-injectDone:
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("injector result = %v, want timeout", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("inherited-output injector exceeded bounded shutdown")
+	}
+	select {
+	case got := <-result:
+		if got != "ACK" {
+			t.Fatalf("owner release response = %q, want ACK", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("owner release remained blocked after injector timeout")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("owner release completed after %s", elapsed)
+	}
+	if inspectWakeLock(root, agent).Exists {
+		t.Fatal("owner release left the lock after bounded injector timeout")
+	}
+}
+
+func TestDarwinControlCleanupWaitsForAcceptedOwnerHandler(t *testing.T) {
+	root, agent, owner, lock, _, _ := testDarwinOwnerControlLock(t)
+	afterLoopStopped := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup, stopped, markStopped, err := startWakeControlListenerInDirOwned(
+		agentDir,
+		root,
+		agent,
+		lock,
+		true,
+		nil,
+		&darwinWakeControlTestHooks{
+			afterLoopStopped: func() {
+				close(afterLoopStopped)
+				<-releaseHandler
+			},
+		},
+	)
+	if err != nil {
+		_ = agentDir.Close()
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	resultCh := make(chan string, 1)
+	go func() {
+		resultCh <- sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+			Generation: lock.Generation,
+			Owner:      &owner,
+		})
+	}()
+	assertDarwinControlCleanupWaitsForAcceptedHandler(
+		t,
+		stopped,
+		markStopped,
+		afterLoopStopped,
+		releaseHandler,
+		cleanup,
+		func() {
+			select {
+			case response := <-resultCh:
+				if response != "ACK" {
+					t.Fatalf("authenticated owner release response = %q, want ACK", response)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("authenticated owner release did not finish")
+			}
+		},
+	)
 	if inspectWakeLock(root, agent).Exists {
 		t.Fatal("authenticated owner release left the lock")
 	}

--- a/internal/cli/wake_control_darwin_test.go
+++ b/internal/cli/wake_control_darwin_test.go
@@ -28,6 +28,69 @@ func testDarwinControlLock(t *testing.T) (string, string, wakeLock) {
 	return root, agent, lock
 }
 
+func testDarwinRawObservationLock(t *testing.T) (string, string, wakeLock) {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	lock := wakeLock{
+		PID:        os.Getpid(),
+		TTY:        "/dev/ttys999",
+		Root:       canonicalWakeRoot(root),
+		Agent:      agent,
+		Started:    "2026-07-29T00:00:00Z",
+		WakeMode:   wakeInjectModeRaw,
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	lock.ControlSocket = wakeControlSocketPath(root, agent, lock.Generation)
+	writeWakeLockExactForTest(t, root, agent, lock)
+	return root, agent, lock
+}
+
+func TestDarwinRawControlAcceptsOnlyPromptObservation(t *testing.T) {
+	root, agent, lock := testDarwinRawObservationLock(t)
+	observed := make(chan string, 1)
+	cleanup, stop, _, err := startWakeControlListener(root, agent, lock, observed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if stop != nil {
+		t.Fatal("raw prompt-observation control exposed a stop channel")
+	}
+
+	const token = "0123456789abcdef0123456789abcdef"
+	rejected := sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+		Generation: lock.Generation,
+		Operation:  wakeControlPromptObserved,
+		Token:      strings.ToUpper(token),
+	})
+	if rejected != "" {
+		t.Fatalf("noncanonical token response = %q", rejected)
+	}
+	select {
+	case got := <-observed:
+		t.Fatalf("noncanonical token was observed: %q", got)
+	default:
+	}
+
+	response := sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+		Generation: lock.Generation,
+		Operation:  wakeControlPromptObserved,
+		Token:      token,
+	})
+	if response != "ACK" {
+		t.Fatalf("prompt observation response = %q", response)
+	}
+	select {
+	case got := <-observed:
+		if got != token {
+			t.Fatalf("observed token = %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("prompt observation was not delivered")
+	}
+}
+
 func testDarwinOwnerControlLock(
 	t *testing.T,
 ) (string, string, wakeOwner, wakeLock, *wakeOwnerIdentityState, *int) {
@@ -186,7 +249,7 @@ func sendDarwinOwnerControlRequest(
 
 func TestDarwinCooperativeStopACKAfterLockRemoval(t *testing.T) {
 	root, agent, lock := testDarwinControlLock(t)
-	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +267,7 @@ func TestDarwinCooperativeStopACKAfterLockRemoval(t *testing.T) {
 
 func TestDarwinCooperativeStopACKWaitsForLoopExit(t *testing.T) {
 	root, agent, lock := testDarwinControlLock(t)
-	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +318,7 @@ func TestDarwinCooperativeStopKeepsGenerationPublishedUntilLoopExit(t *testing.T
 			Args:       []string{"amq", "wake", "--root", root, "--me", agent},
 		}
 	})
-	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +367,7 @@ func TestDarwinCooperativeStopKeepsGenerationPublishedUntilLoopExit(t *testing.T
 
 func TestDarwinCooperativeStopCompletionOutlivesAuthenticationDeadline(t *testing.T) {
 	root, agent, lock := testDarwinControlLock(t)
-	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +403,7 @@ func TestDarwinCooperativeStopCompletionOutlivesAuthenticationDeadline(t *testin
 
 func TestDarwinControlTokenMismatchRefused(t *testing.T) {
 	root, agent, lock := testDarwinControlLock(t)
-	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
+	cleanup, _, _, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +436,7 @@ func TestDarwinControlTokenMismatchRefused(t *testing.T) {
 func TestDarwinOwnerControlRefusesGenerationOnlyAndWrongSessionBeforeQuiesce(t *testing.T) {
 	t.Run("generation only", func(t *testing.T) {
 		root, agent, _, lock, _, _ := testDarwinOwnerControlLock(t)
-		cleanup, stopped, _, err := startWakeControlListener(root, agent, lock)
+		cleanup, stopped, _, err := startWakeControlListener(root, agent, lock, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -396,7 +459,7 @@ func TestDarwinOwnerControlRefusesGenerationOnlyAndWrongSessionBeforeQuiesce(t *
 	t.Run("wrong peer session", func(t *testing.T) {
 		root, agent, owner, lock, _, peerSession := testDarwinOwnerControlLock(t)
 		*peerSession = owner.SessionID + 1
-		cleanup, stopped, _, err := startWakeControlListener(root, agent, lock)
+		cleanup, stopped, _, err := startWakeControlListener(root, agent, lock, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -420,7 +483,7 @@ func TestDarwinOwnerControlRefusesGenerationOnlyAndWrongSessionBeforeQuiesce(t *
 
 func TestDarwinOwnerControlAuthenticatedReleaseACKsAfterExactClaimRemoval(t *testing.T) {
 	root, agent, owner, lock, _, _ := testDarwinOwnerControlLock(t)
-	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +524,7 @@ func TestDarwinOwnerControlAuthenticatedReleaseACKsAfterExactClaimRemoval(t *tes
 
 func TestDarwinOwnerControlReauthorizesAfterQuiesce(t *testing.T) {
 	root, agent, owner, lock, ownerState, _ := testDarwinOwnerControlLock(t)
-	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -571,7 +634,7 @@ func TestDarwinControlRemovesStaleSocketBeforeListen(t *testing.T) {
 	if err := os.WriteFile(lock.ControlSocket, []byte("stale"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
+	cleanup, _, _, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatalf("stale socket prevented listener: %v", err)
 	}
@@ -617,7 +680,7 @@ func TestDarwinControlStartPinsAuthorizedAgentDirectory(t *testing.T) {
 		}
 	})
 
-	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
+	cleanup, _, _, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatalf("start control listener: %v", err)
 	}
@@ -650,7 +713,7 @@ func TestDarwinControlCleanupPinsAuthorizedAgentDirectory(t *testing.T) {
 	lock.ControlSocket = wakeControlSocketPath(root, agent, lock.Generation)
 	writeWakeLockForTest(t, root, agent, lock)
 
-	cleanup, _, _, err := startWakeControlListener(root, agent, lock)
+	cleanup, _, _, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatalf("start control listener: %v", err)
 	}
@@ -718,7 +781,7 @@ func TestDarwinControlAuthenticationPinsAuthorizedAgentDirectory(t *testing.T) {
 		}
 	})
 
-	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock)
+	cleanup, stopped, markStopped, err := startWakeControlListener(root, agent, lock, nil)
 	if err != nil {
 		t.Fatalf("start control listener: %v", err)
 	}

--- a/internal/cli/wake_control_linux.go
+++ b/internal/cli/wake_control_linux.go
@@ -11,6 +11,7 @@ func startWakeControlListenerInDir(
 	string,
 	string,
 	wakeLock,
+	chan<- string,
 ) (func(), <-chan struct{}, func(), error) {
 	return func() {}, nil, func() {}, nil
 }

--- a/internal/cli/wake_control_other.go
+++ b/internal/cli/wake_control_other.go
@@ -3,6 +3,6 @@
 package cli
 
 func wakeControlSocketPath(string, string, string) string { return "" }
-func startWakeControlListener(string, string, wakeLock) (func(), <-chan struct{}, func(), error) {
+func startWakeControlListener(string, string, wakeLock, chan<- string) (func(), <-chan struct{}, func(), error) {
 	return func() {}, nil, func() {}, nil
 }

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+type wakeDoorbellPhase uint8
+
+const (
+	wakeDoorbellIdle wakeDoorbellPhase = iota
+	wakeDoorbellAwaitingToken
+	wakeDoorbellAwaitingObservation
+	wakeDoorbellObserved
+)
+
+const (
+	wakeDoorbellRetryBase       = 5 * time.Second
+	wakeDoorbellRetryMax        = 2 * time.Minute
+	wakeDoorbellObservationHold = 2 * time.Minute
+)
+
+type wakeDoorbellState struct {
+	phase            wakeDoorbellPhase
+	token            string
+	cohort           map[string]wakeFileIdentity
+	tokenFailures    uint
+	attempts         uint
+	nextAttempt      time.Time
+	observationUntil time.Time
+}
+
+type wakeDoorbellPlan struct {
+	attempt bool
+	retry   bool
+	prompt  string
+}
+
+func (state *wakeDoorbellState) plan(
+	now time.Time,
+	current map[string]os.FileInfo,
+	newToken func() (string, error),
+) (wakeDoorbellPlan, error) {
+	if len(current) == 0 {
+		state.reset()
+		return wakeDoorbellPlan{}, nil
+	}
+
+	if state.phase != wakeDoorbellIdle && wakeCohortProgressed(state.cohort, current) {
+		state.reset()
+	}
+	if state.phase == wakeDoorbellObserved && !now.Before(state.observationUntil) {
+		state.reset()
+	}
+	if state.phase == wakeDoorbellAwaitingToken && now.Before(state.nextAttempt) {
+		return wakeDoorbellPlan{}, nil
+	}
+	if state.phase == wakeDoorbellIdle || state.phase == wakeDoorbellAwaitingToken {
+		token, err := newToken()
+		if err != nil {
+			if state.phase == wakeDoorbellIdle {
+				state.cohort = snapshotWakeFileIdentities(current)
+			}
+			state.phase = wakeDoorbellAwaitingToken
+			state.tokenFailures++
+			state.nextAttempt = now.Add(wakeDoorbellRetryDelay(state.tokenFailures))
+			return wakeDoorbellPlan{}, err
+		}
+		state.phase = wakeDoorbellAwaitingObservation
+		state.token = token
+		state.cohort = snapshotWakeFileIdentities(current)
+		state.tokenFailures = 0
+		state.nextAttempt = time.Time{}
+	}
+	if state.phase == wakeDoorbellObserved || (state.attempts > 0 && now.Before(state.nextAttempt)) {
+		return wakeDoorbellPlan{}, nil
+	}
+
+	return wakeDoorbellPlan{
+		attempt: true,
+		retry:   state.attempts > 0,
+		prompt:  buildCoopWakeDoorbell(state.token),
+	}, nil
+}
+
+func (state *wakeDoorbellState) recordAttempt(now time.Time) {
+	state.attempts++
+	state.nextAttempt = now.Add(wakeDoorbellRetryDelay(state.attempts))
+}
+
+func (state *wakeDoorbellState) observe(token string, now time.Time) bool {
+	if state.phase != wakeDoorbellAwaitingObservation || token != state.token {
+		return false
+	}
+	state.phase = wakeDoorbellObserved
+	state.observationUntil = now.Add(wakeDoorbellObservationHold)
+	return true
+}
+
+func (state *wakeDoorbellState) nextDeadline() (time.Time, bool) {
+	switch state.phase {
+	case wakeDoorbellAwaitingToken:
+		return state.nextAttempt, !state.nextAttempt.IsZero()
+	case wakeDoorbellAwaitingObservation:
+		return state.nextAttempt, !state.nextAttempt.IsZero()
+	case wakeDoorbellObserved:
+		return state.observationUntil, !state.observationUntil.IsZero()
+	default:
+		return time.Time{}, false
+	}
+}
+
+func (state *wakeDoorbellState) reset() {
+	*state = wakeDoorbellState{}
+}
+
+func wakeDoorbellRetryDelay(attempt uint) time.Duration {
+	delay := wakeDoorbellRetryBase
+	for i := uint(1); i < attempt && delay < wakeDoorbellRetryMax; i++ {
+		delay *= 2
+		if delay >= wakeDoorbellRetryMax {
+			return wakeDoorbellRetryMax
+		}
+	}
+	return delay
+}
+
+func wakeCohortProgressed(
+	cohort map[string]wakeFileIdentity,
+	current map[string]os.FileInfo,
+) bool {
+	for name, identity := range cohort {
+		info, ok := current[name]
+		if !ok || !matchesWakeFileIdentity(identity, info) {
+			return true
+		}
+	}
+	return false
+}
+
+func generateWakeDoorbellToken() (string, error) {
+	var token [16]byte
+	if _, err := rand.Read(token[:]); err != nil {
+		return "", fmt.Errorf("generate wake doorbell token: %w", err)
+	}
+	return hex.EncodeToString(token[:]), nil
+}
+
+func validWakeDoorbellToken(token string) bool {
+	if len(token) != 32 || token != strings.ToLower(token) {
+		return false
+	}
+	_, err := hex.DecodeString(token)
+	return err == nil
+}

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -16,6 +16,7 @@ const (
 	wakeDoorbellAwaitingToken
 	wakeDoorbellAwaitingObservation
 	wakeDoorbellObserved
+	wakeDoorbellCohortDelivered
 )
 
 const (
@@ -27,11 +28,12 @@ const (
 type wakeDoorbellState struct {
 	phase            wakeDoorbellPhase
 	token            string
-	cohort           map[string]wakeFileIdentity
+	cohort           map[string]*wakeFileIdentity
 	tokenFailures    uint
 	attempts         uint
 	nextAttempt      time.Time
 	observationUntil time.Time
+	observationUsed  bool
 }
 
 type wakeDoorbellPlan struct {
@@ -50,11 +52,18 @@ func (state *wakeDoorbellState) plan(
 		return wakeDoorbellPlan{}, nil
 	}
 
+	if state.phase == wakeDoorbellCohortDelivered {
+		if sameKnownWakeCohort(state.cohort, current) {
+			return wakeDoorbellPlan{}, nil
+		}
+		state.reset()
+	}
 	if state.phase != wakeDoorbellIdle && wakeCohortProgressed(state.cohort, current) {
 		state.reset()
 	}
 	if state.phase == wakeDoorbellObserved && !now.Before(state.observationUntil) {
-		state.reset()
+		state.phase = wakeDoorbellAwaitingObservation
+		state.observationUntil = time.Time{}
 	}
 	if state.phase == wakeDoorbellAwaitingToken && now.Before(state.nextAttempt) {
 		return wakeDoorbellPlan{}, nil
@@ -92,20 +101,50 @@ func (state *wakeDoorbellState) recordAttempt(now time.Time) {
 	state.nextAttempt = now.Add(wakeDoorbellRetryDelay(state.attempts))
 }
 
+// planCohortDelivery gates non-doorbell delivery through the same obligation
+// state used by tokenized input. An unchanged delivered cohort has no remaining
+// obligation; any cohort change must be delivered and then recorded explicitly.
+func (state *wakeDoorbellState) planCohortDelivery(current map[string]os.FileInfo) bool {
+	if len(current) == 0 {
+		state.reset()
+		return false
+	}
+	return state.phase != wakeDoorbellCohortDelivered ||
+		!sameKnownWakeCohort(state.cohort, current)
+}
+
+func (state *wakeDoorbellState) recordCohortDelivered(current map[string]os.FileInfo) {
+	state.reset()
+	state.phase = wakeDoorbellCohortDelivered
+	state.cohort = snapshotWakeFileIdentities(current)
+}
+
+func (state wakeDoorbellState) pendingInput() bool {
+	switch state.phase {
+	case wakeDoorbellAwaitingToken,
+		wakeDoorbellAwaitingObservation,
+		wakeDoorbellObserved:
+		return true
+	default:
+		return false
+	}
+}
+
 func (state *wakeDoorbellState) observe(token string, now time.Time) bool {
-	if state.phase != wakeDoorbellAwaitingObservation || token != state.token {
+	if state.phase != wakeDoorbellAwaitingObservation ||
+		state.observationUsed ||
+		token != state.token {
 		return false
 	}
 	state.phase = wakeDoorbellObserved
 	state.observationUntil = now.Add(wakeDoorbellObservationHold)
+	state.observationUsed = true
 	return true
 }
 
 func (state *wakeDoorbellState) nextDeadline() (time.Time, bool) {
 	switch state.phase {
-	case wakeDoorbellAwaitingToken:
-		return state.nextAttempt, !state.nextAttempt.IsZero()
-	case wakeDoorbellAwaitingObservation:
+	case wakeDoorbellAwaitingToken, wakeDoorbellAwaitingObservation:
 		return state.nextAttempt, !state.nextAttempt.IsZero()
 	case wakeDoorbellObserved:
 		return state.observationUntil, !state.observationUntil.IsZero()
@@ -119,23 +158,46 @@ func (state *wakeDoorbellState) reset() {
 }
 
 func wakeDoorbellRetryDelay(attempt uint) time.Duration {
-	delay := wakeDoorbellRetryBase
-	for i := uint(1); i < attempt && delay < wakeDoorbellRetryMax; i++ {
+	return cappedExponentialBackoff(attempt, wakeDoorbellRetryBase, wakeDoorbellRetryMax)
+}
+
+func cappedExponentialBackoff(attempt uint, base, maximum time.Duration) time.Duration {
+	delay := base
+	if delay >= maximum {
+		return maximum
+	}
+	for i := uint(1); i < attempt && delay < maximum; i++ {
 		delay *= 2
-		if delay >= wakeDoorbellRetryMax {
-			return wakeDoorbellRetryMax
+		if delay >= maximum {
+			return maximum
 		}
 	}
 	return delay
 }
 
 func wakeCohortProgressed(
-	cohort map[string]wakeFileIdentity,
+	cohort map[string]*wakeFileIdentity,
 	current map[string]os.FileInfo,
 ) bool {
 	for name, identity := range cohort {
 		info, ok := current[name]
-		if !ok || !matchesWakeFileIdentity(identity, info) {
+		if !ok {
+			return true
+		}
+		if info == nil {
+			continue
+		}
+		currentIdentity, known := captureWakeFileIdentity(info)
+		if identity == nil {
+			if known {
+				return true
+			}
+			continue
+		}
+		if !known {
+			continue
+		}
+		if *identity != currentIdentity {
 			return true
 		}
 	}

--- a/internal/cli/wake_doorbell_test.go
+++ b/internal/cli/wake_doorbell_test.go
@@ -7,6 +7,17 @@ import (
 	"time"
 )
 
+type wakeIdentityUnavailableFileInfo struct {
+	name string
+}
+
+func (info wakeIdentityUnavailableFileInfo) Name() string  { return info.name }
+func (wakeIdentityUnavailableFileInfo) Size() int64        { return 0 }
+func (wakeIdentityUnavailableFileInfo) Mode() os.FileMode  { return 0o600 }
+func (wakeIdentityUnavailableFileInfo) ModTime() time.Time { return time.Time{} }
+func (wakeIdentityUnavailableFileInfo) IsDir() bool        { return false }
+func (wakeIdentityUnavailableFileInfo) Sys() any           { return nil }
+
 func wakeDoorbellTestFiles(t *testing.T, names ...string) map[string]os.FileInfo {
 	t.Helper()
 	dir := t.TempDir()
@@ -28,11 +39,13 @@ func wakeDoorbellTestFiles(t *testing.T, names ...string) map[string]os.FileInfo
 func TestWakeDoorbellStateRetriesUntilObserved(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0)
 	current := wakeDoorbellTestFiles(t, "a.md")
+	tokenCalls := 0
 	tokens := []string{
 		"11111111111111111111111111111111",
 		"22222222222222222222222222222222",
 	}
 	nextToken := func() (string, error) {
+		tokenCalls++
 		token := tokens[0]
 		tokens = tokens[1:]
 		return token, nil
@@ -70,8 +83,23 @@ func TestWakeDoorbellStateRetriesUntilObserved(t *testing.T) {
 		t.Fatalf("observed hold plan = %#v, err=%v", plan, err)
 	}
 	plan, err = state.plan(observedUntil, current, nextToken)
-	if err != nil || !plan.attempt || plan.prompt != buildCoopWakeDoorbell("22222222222222222222222222222222") {
+	if err != nil ||
+		!plan.attempt ||
+		!plan.retry ||
+		plan.prompt != buildCoopWakeDoorbell("11111111111111111111111111111111") {
 		t.Fatalf("expired observation plan = %#v, err=%v", plan, err)
+	}
+	if tokenCalls != 1 {
+		t.Fatalf("token generation calls = %d, want 1 without cohort progress", tokenCalls)
+	}
+	if state.attempts != 1 || len(state.cohort) != 1 {
+		t.Fatalf("expired observation state = %#v, want preserved attempt and cohort", state)
+	}
+	if state.observe(state.token, observedUntil.Add(time.Second)) {
+		t.Fatal("expired generation accepted a second observation lease")
+	}
+	if !state.observationUntil.IsZero() {
+		t.Fatalf("expired generation renewed observation until %s", state.observationUntil)
 	}
 }
 
@@ -108,6 +136,83 @@ func TestWakeDoorbellStateRearmsOnAnyCohortProgress(t *testing.T) {
 	}
 }
 
+func TestWakeDoorbellStateKeepsPendingMembershipWithoutFileIdentity(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := map[string]os.FileInfo{"readable.md": nil}
+	tokenCalls := 0
+	var state wakeDoorbellState
+
+	plan, err := state.plan(now, current, func() (string, error) {
+		tokenCalls++
+		return "11111111111111111111111111111111", nil
+	})
+	if err != nil || !plan.attempt || plan.retry {
+		t.Fatalf("identity-unavailable plan = %#v, err=%v", plan, err)
+	}
+	if tokenCalls != 1 || len(state.cohort) != 1 {
+		t.Fatalf("identity-unavailable state = %#v, token calls=%d", state, tokenCalls)
+	}
+	if _, ok := state.cohort["readable.md"]; !ok {
+		t.Fatal("readable pending filename was dropped from the doorbell cohort")
+	}
+}
+
+func TestWakeDoorbellStateRearmsWhenUnknownIdentityBecomesKnown(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := map[string]os.FileInfo{
+		"readable.md": wakeIdentityUnavailableFileInfo{name: "readable.md"},
+	}
+	tokens := []string{
+		"11111111111111111111111111111111",
+		"22222222222222222222222222222222",
+	}
+	tokenCalls := 0
+	nextToken := func() (string, error) {
+		token := tokens[tokenCalls]
+		tokenCalls++
+		return token, nil
+	}
+	var state wakeDoorbellState
+	if _, err := state.plan(now, current, nextToken); err != nil {
+		t.Fatal(err)
+	}
+
+	known := wakeDoorbellTestFiles(t, "readable.md")
+	plan, err := state.plan(now.Add(time.Second), known, nextToken)
+	if err != nil || !plan.attempt || plan.retry {
+		t.Fatalf("identity recovery plan = %#v, err=%v", plan, err)
+	}
+	if tokenCalls != 2 ||
+		plan.prompt != buildCoopWakeDoorbell("22222222222222222222222222222222") {
+		t.Fatalf("identity recovery plan = %#v, token calls=%d; want rearmed generation", plan, tokenCalls)
+	}
+}
+
+func TestWakeDoorbellStateKeepsGenerationWhenKnownIdentityBecomesUnavailable(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "readable.md")
+	tokenCalls := 0
+	nextToken := func() (string, error) {
+		tokenCalls++
+		return "11111111111111111111111111111111", nil
+	}
+	var state wakeDoorbellState
+	if _, err := state.plan(now, current, nextToken); err != nil {
+		t.Fatal(err)
+	}
+	state.recordAttempt(now)
+
+	temporarilyUnknown := map[string]os.FileInfo{"readable.md": nil}
+	plan, err := state.plan(now.Add(wakeDoorbellRetryBase), temporarilyUnknown, nextToken)
+	if err != nil || !plan.attempt || !plan.retry {
+		t.Fatalf("temporarily unknown plan = %#v, err=%v", plan, err)
+	}
+	if tokenCalls != 1 ||
+		plan.prompt != buildCoopWakeDoorbell("11111111111111111111111111111111") {
+		t.Fatalf("temporarily unknown plan = %#v, token calls=%d; want preserved generation", plan, tokenCalls)
+	}
+}
+
 func TestWakeDoorbellStateRetriesTokenGenerationFailure(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0)
 	current := wakeDoorbellTestFiles(t, "a.md")
@@ -136,6 +241,64 @@ func TestWakeDoorbellStateRetriesTokenGenerationFailure(t *testing.T) {
 	plan, err := state.plan(now.Add(wakeDoorbellRetryBase), current, nextToken)
 	if err != nil || !plan.attempt || plan.retry {
 		t.Fatalf("token retry plan = %#v, err=%v", plan, err)
+	}
+}
+
+func TestWakeDoorbellStateGatesDeliveredCohortAndRearmsOnChange(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "a.md")
+	var state wakeDoorbellState
+
+	if !state.planCohortDelivery(current) {
+		t.Fatal("initial cohort delivery was suppressed")
+	}
+	state.recordCohortDelivered(current)
+	if state.planCohortDelivery(current) {
+		t.Fatal("unchanged delivered cohort was redelivered")
+	}
+	if _, ok := state.nextDeadline(); ok {
+		t.Fatal("delivered cohort retained a retry deadline")
+	}
+	if state.observe("11111111111111111111111111111111", now) {
+		t.Fatal("delivered cohort accepted an input observation")
+	}
+
+	added := map[string]os.FileInfo{
+		"a.md": current["a.md"],
+		"b.md": wakeDoorbellTestFiles(t, "b.md")["b.md"],
+	}
+	if !state.planCohortDelivery(added) {
+		t.Fatal("cohort addition was suppressed")
+	}
+	state.recordCohortDelivered(added)
+	replacement := map[string]os.FileInfo{
+		"a.md": added["a.md"],
+		"b.md": wakeDoorbellTestFiles(t, "b.md")["b.md"],
+	}
+	if !state.planCohortDelivery(replacement) {
+		t.Fatal("cohort replacement was suppressed")
+	}
+
+	plan, err := state.plan(now, replacement, func() (string, error) {
+		return "22222222222222222222222222222222", nil
+	})
+	if err != nil || !plan.attempt || plan.retry {
+		t.Fatalf("re-entered token plan = %#v, err=%v", plan, err)
+	}
+	if plan.prompt != buildCoopWakeDoorbell("22222222222222222222222222222222") {
+		t.Fatalf("re-entered token prompt = %q", plan.prompt)
+	}
+}
+
+func TestWakeDoorbellStateDeliveredCohortFailsOpenWithoutIdentity(t *testing.T) {
+	current := map[string]os.FileInfo{
+		"pending.md": wakeIdentityUnavailableFileInfo{name: "pending.md"},
+	}
+	var state wakeDoorbellState
+	state.recordCohortDelivered(current)
+
+	if !state.planCohortDelivery(current) {
+		t.Fatal("identity-unavailable delivered cohort was treated as exact")
 	}
 }
 

--- a/internal/cli/wake_doorbell_test.go
+++ b/internal/cli/wake_doorbell_test.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func wakeDoorbellTestFiles(t *testing.T, names ...string) map[string]os.FileInfo {
+	t.Helper()
+	dir := t.TempDir()
+	current := make(map[string]os.FileInfo, len(names))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		current[name] = info
+	}
+	return current
+}
+
+func TestWakeDoorbellStateRetriesUntilObserved(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "a.md")
+	tokens := []string{
+		"11111111111111111111111111111111",
+		"22222222222222222222222222222222",
+	}
+	nextToken := func() (string, error) {
+		token := tokens[0]
+		tokens = tokens[1:]
+		return token, nil
+	}
+	var state wakeDoorbellState
+
+	plan, err := state.plan(now, current, nextToken)
+	if err != nil || !plan.attempt || plan.retry {
+		t.Fatalf("initial plan = %#v, err=%v", plan, err)
+	}
+	state.recordAttempt(now)
+
+	plan, err = state.plan(now.Add(wakeDoorbellRetryBase-time.Millisecond), current, nextToken)
+	if err != nil || plan.attempt {
+		t.Fatalf("early plan = %#v, err=%v", plan, err)
+	}
+	plan, err = state.plan(now.Add(wakeDoorbellRetryBase), current, nextToken)
+	if err != nil || !plan.attempt || !plan.retry || plan.prompt != buildCoopWakeDoorbell(state.token) {
+		t.Fatalf("retry plan = %#v, err=%v", plan, err)
+	}
+
+	if !state.observe(state.token, now.Add(wakeDoorbellRetryBase)) {
+		t.Fatal("valid prompt observation was ignored")
+	}
+	observedUntil := state.observationUntil
+	if state.observe(state.token, now.Add(time.Minute)) {
+		t.Fatal("duplicate observation renewed the hold")
+	}
+	if state.observationUntil != observedUntil {
+		t.Fatal("duplicate observation changed the deadline")
+	}
+
+	plan, err = state.plan(observedUntil.Add(-time.Millisecond), current, nextToken)
+	if err != nil || plan.attempt {
+		t.Fatalf("observed hold plan = %#v, err=%v", plan, err)
+	}
+	plan, err = state.plan(observedUntil, current, nextToken)
+	if err != nil || !plan.attempt || plan.prompt != buildCoopWakeDoorbell("22222222222222222222222222222222") {
+		t.Fatalf("expired observation plan = %#v, err=%v", plan, err)
+	}
+}
+
+func TestWakeDoorbellStateRearmsOnAnyCohortProgress(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "a.md", "b.md")
+	tokenNumber := 0
+	nextToken := func() (string, error) {
+		tokenNumber++
+		if tokenNumber == 1 {
+			return "11111111111111111111111111111111", nil
+		}
+		return "22222222222222222222222222222222", nil
+	}
+	var state wakeDoorbellState
+	if _, err := state.plan(now, current, nextToken); err != nil {
+		t.Fatal(err)
+	}
+	state.recordAttempt(now)
+	if !state.observe(state.token, now) {
+		t.Fatal("observe initial generation")
+	}
+
+	remaining := map[string]os.FileInfo{
+		"b.md": current["b.md"],
+		"c.md": wakeDoorbellTestFiles(t, "c.md")["c.md"],
+	}
+	plan, err := state.plan(now.Add(time.Second), remaining, nextToken)
+	if err != nil || !plan.attempt {
+		t.Fatalf("progress plan = %#v, err=%v", plan, err)
+	}
+	if plan.prompt != buildCoopWakeDoorbell("22222222222222222222222222222222") {
+		t.Fatalf("progress prompt = %q", plan.prompt)
+	}
+}
+
+func TestWakeDoorbellStateRetriesTokenGenerationFailure(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "a.md")
+	calls := 0
+	nextToken := func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "", os.ErrInvalid
+		}
+		return "11111111111111111111111111111111", nil
+	}
+	var state wakeDoorbellState
+
+	if plan, err := state.plan(now, current, nextToken); err == nil || plan.attempt {
+		t.Fatalf("token failure plan = %#v, err=%v", plan, err)
+	}
+	if state.phase != wakeDoorbellAwaitingToken {
+		t.Fatalf("token failure phase = %v, want awaiting token", state.phase)
+	}
+	if deadline, ok := state.nextDeadline(); !ok || deadline != now.Add(wakeDoorbellRetryBase) {
+		t.Fatalf("token retry deadline = %s, %v", deadline, ok)
+	}
+	if plan, err := state.plan(now.Add(wakeDoorbellRetryBase-time.Millisecond), current, nextToken); err != nil || plan.attempt {
+		t.Fatalf("early token retry plan = %#v, err=%v", plan, err)
+	}
+	plan, err := state.plan(now.Add(wakeDoorbellRetryBase), current, nextToken)
+	if err != nil || !plan.attempt || plan.retry {
+		t.Fatalf("token retry plan = %#v, err=%v", plan, err)
+	}
+}
+
+func TestWakeDoorbellRetryDelayCaps(t *testing.T) {
+	var previous time.Duration
+	for attempt := uint(1); attempt <= 20; attempt++ {
+		delay := wakeDoorbellRetryDelay(attempt)
+		if delay < previous || delay > wakeDoorbellRetryMax {
+			t.Fatalf("attempt %d delay = %s after %s", attempt, delay, previous)
+		}
+		previous = delay
+	}
+	if previous != wakeDoorbellRetryMax {
+		t.Fatalf("final delay = %s, want %s", previous, wakeDoorbellRetryMax)
+	}
+}
+
+func TestValidWakeDoorbellTokenRequiresCanonical128BitHex(t *testing.T) {
+	for _, token := range []string{
+		"",
+		"0123456789abcdef",
+		"0123456789abcdef0123456789abcdeg",
+		"0123456789ABCDEF0123456789ABCDEF",
+		"0123456789abcdef0123456789abcdef00",
+	} {
+		if validWakeDoorbellToken(token) {
+			t.Fatalf("accepted noncanonical token %q", token)
+		}
+	}
+	if !validWakeDoorbellToken("0123456789abcdef0123456789abcdef") {
+		t.Fatal("rejected canonical token")
+	}
+}

--- a/internal/cli/wake_inbox_capability_unix_test.go
+++ b/internal/cli/wake_inbox_capability_unix_test.go
@@ -1,0 +1,310 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestOpenWakeRepairInboxDirRejectsSymlinkedComponents(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		replace func(t *testing.T, agentPath, outsidePath string)
+	}{
+		{
+			name: "intermediate inbox",
+			replace: func(t *testing.T, agentPath, outsidePath string) {
+				t.Helper()
+				inboxPath := filepath.Join(agentPath, "inbox")
+				if err := os.RemoveAll(inboxPath); err != nil {
+					t.Fatalf("remove canonical inbox: %v", err)
+				}
+				if err := os.Symlink(outsidePath, inboxPath); err != nil {
+					t.Fatalf("symlink canonical inbox: %v", err)
+				}
+			},
+		},
+		{
+			name: "final new",
+			replace: func(t *testing.T, agentPath, outsidePath string) {
+				t.Helper()
+				newPath := filepath.Join(agentPath, "inbox", "new")
+				if err := os.Remove(newPath); err != nil {
+					t.Fatalf("remove canonical inbox/new: %v", err)
+				}
+				if err := os.Symlink(filepath.Join(outsidePath, "new"), newPath); err != nil {
+					t.Fatalf("symlink canonical inbox/new: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root, agentDir := newWakeInboxCapabilityForTest(t)
+			agentPath := fsq.AgentBase(root, "codex")
+			outsidePath := filepath.Join(t.TempDir(), "outside-inbox")
+			if err := os.MkdirAll(filepath.Join(outsidePath, "new"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			test.replace(t, agentPath, outsidePath)
+
+			inboxDir, err := openWakeRepairInboxDir(agentDir)
+			if inboxDir != nil {
+				_ = inboxDir.Close()
+				t.Fatal("symlinked mailbox returned a retained inbox capability")
+			}
+			if err == nil {
+				t.Fatal("symlinked mailbox was accepted")
+			}
+		})
+	}
+}
+
+func TestOpenWakeRepairInboxDirValidatesEveryComponentMode(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path func(string) string
+	}{
+		{
+			name: "intermediate inbox",
+			path: func(agentPath string) string {
+				return filepath.Join(agentPath, "inbox")
+			},
+		},
+		{
+			name: "final new",
+			path: func(agentPath string) string {
+				return filepath.Join(agentPath, "inbox", "new")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root, agentDir := newWakeInboxCapabilityForTest(t)
+			if err := os.Chmod(test.path(fsq.AgentBase(root, "codex")), 0o770); err != nil {
+				t.Fatal(err)
+			}
+
+			inboxDir, err := openWakeRepairInboxDir(agentDir)
+			if inboxDir != nil {
+				_ = inboxDir.Close()
+				t.Fatal("group-writable mailbox returned a retained inbox capability")
+			}
+			if err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+				t.Fatalf("group-writable mailbox error = %v", err)
+			}
+		})
+	}
+}
+
+func TestOpenWatchedWakeInboxDirRejectsCanonicalAgentReplacement(t *testing.T) {
+	root, agentDir := newWakeInboxCapabilityForTest(t)
+	agentPath := fsq.AgentBase(root, "codex")
+	if err := os.Rename(agentPath, agentPath+".detached"); err != nil {
+		t.Fatalf("detach retained agent: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("create replacement agent: %v", err)
+	}
+
+	inboxDir, watcher, err := openWatchedWakeInboxDir(agentDir)
+	if inboxDir != nil || watcher != nil {
+		if watcher != nil {
+			_ = watcher.Close()
+		}
+		if inboxDir != nil {
+			_ = inboxDir.Close()
+		}
+		t.Fatal("canonical agent replacement returned a watched inbox capability")
+	}
+	if err == nil || !strings.Contains(err.Error(), "agent directory no longer matches retained authority") {
+		t.Fatalf("canonical agent replacement error = %v", err)
+	}
+}
+
+func TestOpenWatchedWakeInboxDirReopensReplacementUnderPinnedAgent(t *testing.T) {
+	root, agentDir := newWakeInboxCapabilityForTest(t)
+	inboxPath := fsq.AgentInboxNew(root, "codex")
+	if err := os.Rename(inboxPath, inboxPath+".detached"); err != nil {
+		t.Fatalf("detach old inbox/new: %v", err)
+	}
+	if err := os.Mkdir(inboxPath, 0o700); err != nil {
+		t.Fatalf("create replacement inbox/new: %v", err)
+	}
+
+	inboxDir, watcher, err := openWatchedWakeInboxDir(agentDir)
+	if err != nil {
+		t.Fatalf("open watched replacement inbox: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = watcher.Close()
+		_ = inboxDir.Close()
+	})
+
+	messagePath := filepath.Join(inboxPath, "after-rearm.md")
+	if err := os.WriteFile(messagePath, []byte("message"), 0o600); err != nil {
+		t.Fatalf("write replacement inbox message: %v", err)
+	}
+	select {
+	case event, ok := <-watcher.Events():
+		if !ok {
+			t.Fatal("replacement watcher closed before observing message")
+		}
+		want := fsnotify.Event{
+			Name: filepath.Join(inboxPath, "retained-inbox-event.md"),
+			Op:   fsnotify.Write,
+		}
+		if event != want {
+			t.Fatalf("replacement watcher event = %#v, want %#v", event, want)
+		}
+	case err, ok := <-watcher.Errors():
+		t.Fatalf("replacement watcher failed: %v ok=%v", err, ok)
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement watcher did not observe message")
+	}
+}
+
+func TestWakeInboxCapabilityBaselineOperationsStayOnRetainedInode(t *testing.T) {
+	root, agentDir := newWakeInboxCapabilityForTest(t)
+	inboxPath := fsq.AgentInboxNew(root, "codex")
+	messagePath := filepath.Join(inboxPath, "retained.md")
+	if err := os.WriteFile(messagePath, []byte("retained"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inboxDir.Close() })
+
+	detachedPath := inboxPath + ".detached"
+	if err := os.Rename(inboxPath, detachedPath); err != nil {
+		t.Fatal(err)
+	}
+	outsidePath := filepath.Join(t.TempDir(), "outside")
+	if err := os.Mkdir(outsidePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsidePath, inboxPath); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot, err := inboxDir.SnapshotMessageIdentities()
+	if err != nil {
+		t.Fatalf("snapshot retained inbox: %v", err)
+	}
+	if _, ok := snapshot["retained.md"]; !ok {
+		t.Fatalf("retained snapshot = %#v, want retained.md", snapshot)
+	}
+
+	marker, err := inboxDir.CreateBaselineBarrier()
+	if err != nil {
+		t.Fatalf("create retained barrier: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(detachedPath, marker)); err != nil {
+		t.Fatalf("barrier missing from detached retained inode: %v", err)
+	}
+	outsideSentinel := filepath.Join(outsidePath, marker)
+	if err := os.WriteFile(outsideSentinel, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := inboxDir.UnlinkBaselineBarrier(marker); err != nil {
+		t.Fatalf("unlink retained barrier: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(detachedPath, marker)); !os.IsNotExist(err) {
+		t.Fatalf("retained barrier survived unlink: %v", err)
+	}
+	if got, err := os.ReadFile(outsideSentinel); err != nil || string(got) != "outside" {
+		t.Fatalf("outside same-name sentinel changed: data=%q err=%v", got, err)
+	}
+	if err := inboxDir.ValidateCanonical(); err == nil {
+		t.Fatal("detached inbox capability passed canonical validation")
+	}
+}
+
+func TestPrepareWakeBaselineRejectsInboxReplacementDuringSnapshot(t *testing.T) {
+	root, agentDir := newWakeInboxCapabilityForTest(t)
+	inboxPath := fsq.AgentInboxNew(root, "codex")
+	if err := os.WriteFile(filepath.Join(inboxPath, "existing.md"), []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inboxDir.Close() })
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = watcher.Close() })
+	if err := watcher.Add(inboxPath); err != nil {
+		t.Fatal(err)
+	}
+
+	detachedPath := inboxPath + ".detached"
+	outsidePath := filepath.Join(t.TempDir(), "outside")
+	if err := os.Mkdir(outsidePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	originalSnapshot := snapshotWakeRetainedFileInfo
+	swapped := false
+	snapshotWakeRetainedFileInfo = func(
+		inbox *wakeInboxDir,
+		name string,
+	) (os.FileInfo, error) {
+		if !swapped {
+			swapped = true
+			if err := os.Rename(inboxPath, detachedPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(outsidePath, inboxPath); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return originalSnapshot(inbox, name)
+	}
+	t.Cleanup(func() { snapshotWakeRetainedFileInfo = originalSnapshot })
+
+	cfg := wakeConfig{
+		root:              root,
+		me:                "codex",
+		baselineRequested: true,
+		retainedInbox:     inboxDir,
+	}
+	err = prepareWakeBaselineEvents(
+		&cfg,
+		watcher.Events,
+		watcher.Errors,
+		inboxPath,
+	)
+	if err == nil || !strings.Contains(err.Error(), "after baseline snapshot") {
+		t.Fatalf("baseline replacement error = %v", err)
+	}
+	entries, err := os.ReadDir(outsidePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("replacement symlink target mutated during baseline: %#v", entries)
+	}
+}
+
+func newWakeInboxCapabilityForTest(t *testing.T) (string, *wakeAgentDir) {
+	t.Helper()
+	root := t.TempDir()
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	return root, agentDir
+}

--- a/internal/cli/wake_lifecycle_guard_unix.go
+++ b/internal/cli/wake_lifecycle_guard_unix.go
@@ -33,33 +33,37 @@ func openWakeAgentDir(root, me string) (*wakeAgentDir, error) {
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		return nil, fmt.Errorf("create wake agent directory %s: %w", path, err)
 	}
+	return openWakeDirectory(path, "wake agent directory")
+}
+
+func openWakeDirectory(path, label string) (*wakeAgentDir, error) {
 	before, err := os.Lstat(path)
 	if err != nil {
-		return nil, fmt.Errorf("stat wake agent directory %s: %w", path, err)
+		return nil, fmt.Errorf("stat %s %s: %w", label, path, err)
 	}
-	if err := validateWakeAgentDir(path, before); err != nil {
+	if err := validateWakeDirectory(label, path, before); err != nil {
 		return nil, err
 	}
 	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
-		return nil, fmt.Errorf("open wake agent directory %s: %w", path, err)
+		return nil, fmt.Errorf("open %s %s: %w", label, path, err)
 	}
 	file := os.NewFile(uintptr(fd), path)
 	opened, err := file.Stat()
 	if err != nil {
 		_ = file.Close()
-		return nil, fmt.Errorf("stat opened wake agent directory %s: %w", path, err)
+		return nil, fmt.Errorf("stat opened %s %s: %w", label, path, err)
 	}
-	if err := validateWakeAgentDir(path, opened); err != nil {
+	if err := validateWakeDirectory(label, path, opened); err != nil {
 		_ = file.Close()
 		return nil, err
 	}
 	after, err := os.Lstat(path)
 	if err != nil {
 		_ = file.Close()
-		return nil, fmt.Errorf("re-stat wake agent directory %s: %w", path, err)
+		return nil, fmt.Errorf("re-stat %s %s: %w", label, path, err)
 	}
-	if err := validateWakeAgentDir(path, after); err != nil {
+	if err := validateWakeDirectory(label, path, after); err != nil {
 		_ = file.Close()
 		return nil, err
 	}
@@ -68,16 +72,20 @@ func openWakeAgentDir(root, me string) (*wakeAgentDir, error) {
 	// it retain the stricter ctime-aware generation checks.
 	if !os.SameFile(before, opened) || !os.SameFile(opened, after) {
 		_ = file.Close()
-		return nil, fmt.Errorf("wake agent directory %s changed while opening", path)
+		return nil, fmt.Errorf("%s %s changed while opening", label, path)
 	}
 	return &wakeAgentDir{path: path, file: file}, nil
 }
 
 func validateWakeAgentDir(path string, info os.FileInfo) error {
+	return validateWakeDirectory("wake agent directory", path, info)
+}
+
+func validateWakeDirectory(label, path string, info os.FileInfo) error {
 	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-		return fmt.Errorf("wake agent directory %s must be a directory, not a symlink", path)
+		return fmt.Errorf("%s %s must be a directory, not a symlink", label, path)
 	}
-	return validateWakeTargetPathOwnership("wake agent directory", path, info)
+	return validateWakeTargetPathOwnership(label, path, info)
 }
 
 func (d *wakeAgentDir) withFD(fn func(int) error) error {

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -319,13 +319,24 @@ func writeWakeGenerationFileAt(
 	label string,
 	marker wakeReady,
 ) error {
+	_, err := writeWakeGenerationFileAtWithSnapshot(dirfd, name, label, marker)
+	return err
+}
+
+func writeWakeGenerationFileAtWithSnapshot(
+	dirfd int,
+	name string,
+	label string,
+	marker wakeReady,
+) (wakeGenerationFileSnapshot, error) {
 	data, err := json.Marshal(marker)
 	if err != nil {
-		return fmt.Errorf("marshal %s: %w", label, err)
+		return wakeGenerationFileSnapshot{}, fmt.Errorf("marshal %s: %w", label, err)
 	}
-	temp, err := writeWakeOwnerTempAt(dirfd, "wake-generation", append(data, '\n'), 0o600)
+	raw := append(data, '\n')
+	temp, err := writeWakeOwnerTempAt(dirfd, "wake-generation", raw, 0o600)
 	if err != nil {
-		return err
+		return wakeGenerationFileSnapshot{}, err
 	}
 	tempPresent := true
 	defer func() {
@@ -333,12 +344,70 @@ func writeWakeGenerationFileAt(
 			_ = unix.Unlinkat(dirfd, temp, 0)
 		}
 	}()
+	tempFD, err := unix.Openat(
+		dirfd,
+		temp,
+		unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		return wakeGenerationFileSnapshot{}, fmt.Errorf("open %s temp file: %w", label, err)
+	}
+	tempFile := os.NewFile(uintptr(tempFD), temp)
+	tempInfo, statErr := tempFile.Stat()
+	_ = tempFile.Close()
+	if statErr != nil {
+		return wakeGenerationFileSnapshot{}, fmt.Errorf("stat %s temp file: %w", label, statErr)
+	}
+	if !tempInfo.Mode().IsRegular() || tempInfo.Mode().Perm() != 0o600 {
+		return wakeGenerationFileSnapshot{}, fmt.Errorf("%s temp must be a regular 0600 file", label)
+	}
+	if err := validateWakeTargetPathOwnership(label+" temp", temp, tempInfo); err != nil {
+		return wakeGenerationFileSnapshot{}, err
+	}
+	snapshot := wakeGenerationFileSnapshot{
+		Marker:   marker,
+		Raw:      bytes.Clone(raw),
+		FileInfo: tempInfo,
+	}
 	if err := unix.Renameat(dirfd, temp, dirfd, name); err != nil {
-		return fmt.Errorf("install %s: %w", label, err)
+		return wakeGenerationFileSnapshot{}, fmt.Errorf("install %s: %w", label, err)
 	}
 	tempPresent = false
-	if err := syncWakeOwnerDirFD(dirfd); err != nil {
-		return fmt.Errorf("sync %s directory: %w", label, err)
+	installedFD, err := unix.Openat(
+		dirfd,
+		name,
+		unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		return snapshot, fmt.Errorf("open installed %s: %w", label, err)
 	}
-	return nil
+	installedFile := os.NewFile(uintptr(installedFD), name)
+	installedInfo, statErr := installedFile.Stat()
+	if statErr != nil {
+		_ = installedFile.Close()
+		return snapshot, fmt.Errorf("stat installed %s: %w", label, statErr)
+	}
+	if !os.SameFile(tempInfo, installedInfo) {
+		_ = installedFile.Close()
+		return snapshot, fmt.Errorf("installed %s changed during publication; preserving it", label)
+	}
+	snapshot.FileInfo = installedInfo
+	if !installedInfo.Mode().IsRegular() || installedInfo.Mode().Perm() != 0o600 {
+		_ = installedFile.Close()
+		return snapshot, fmt.Errorf("installed %s must be a regular 0600 file", label)
+	}
+	installedRaw, readErr := readWakeMetadata(installedFile, label, name)
+	_ = installedFile.Close()
+	if readErr != nil {
+		return snapshot, readErr
+	}
+	if !bytes.Equal(installedRaw, raw) {
+		return snapshot, fmt.Errorf("installed %s content changed during publication; preserving it", label)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return snapshot, fmt.Errorf("sync %s directory: %w", label, err)
+	}
+	return snapshot, nil
 }

--- a/internal/cli/wake_owner_acquire_unix.go
+++ b/internal/cli/wake_owner_acquire_unix.go
@@ -113,10 +113,6 @@ func acquireAuthoritativeWakeLockWithOptions(
 	me string,
 	options wakeLockAcquireOptions,
 ) (func(), error) {
-	requested := *options.target
-	if err := validateAuthoritativeWakeTarget(requested, root, me); err != nil {
-		return nil, err
-	}
 	if err := os.MkdirAll(fsq.AgentBase(root, me), 0o700); err != nil {
 		return nil, fmt.Errorf("failed to create agent directory: %w", err)
 	}
@@ -125,7 +121,22 @@ func acquireAuthoritativeWakeLockWithOptions(
 		return nil, err
 	}
 	defer func() { _ = agentDir.Close() }()
+	return acquireAuthoritativeWakeLockWithOptionsInDir(agentDir, root, me, options)
+}
 
+func acquireAuthoritativeWakeLockWithOptionsInDir(
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	options wakeLockAcquireOptions,
+) (func(), error) {
+	if agentDir == nil {
+		return nil, fmt.Errorf("wake agent directory capability is missing")
+	}
+	requested := *options.target
+	if err := validateAuthoritativeWakeTarget(requested, root, me); err != nil {
+		return nil, err
+	}
 	for {
 		var created wakeLockInspection
 		var stopCapability *authoritativeWakeStopCapability
@@ -145,12 +156,17 @@ func acquireAuthoritativeWakeLockWithOptions(
 			}
 
 			requestedObservation, observeErr := observeAuthoritativeWakeOwner(*requested.Owner)
-			defer func() { _ = requestedObservation.Close() }()
 			if observeErr != nil {
-				return observeErr
+				return errors.Join(observeErr, requestedObservation.Close())
 			}
 			if requestedObservation.State != wakeOwnerSame {
-				return fmt.Errorf("requested wake owner is %s: %s", requestedObservation.State, requestedObservation.Reason)
+				return errors.Join(
+					fmt.Errorf("requested wake owner is %s: %s", requestedObservation.State, requestedObservation.Reason),
+					requestedObservation.Close(),
+				)
+			}
+			if err := requestedObservation.Close(); err != nil {
+				return err
 			}
 
 			if claimClass == wakeClaimAuthoritative {
@@ -162,12 +178,14 @@ func acquireAuthoritativeWakeLockWithOptions(
 				persistedReason := requestedObservation.Reason
 				if !sameWakeOwner(inspection.Lock.Owner, requested.Owner) {
 					persistedObservation, err := observeAuthoritativeWakeOwner(*inspection.Lock.Owner)
-					defer func() { _ = persistedObservation.Close() }()
 					if err != nil {
-						return err
+						return errors.Join(err, persistedObservation.Close())
 					}
 					persistedState = persistedObservation.State
 					persistedReason = persistedObservation.Reason
+					if err := persistedObservation.Close(); err != nil {
+						return err
+					}
 				}
 				ownersEqual := sameWakeOwner(inspection.Lock.Owner, requested.Owner)
 				wakeCapability, err := prepareAuthoritativeWakeStop(dirfd, agentDir, inspection)

--- a/internal/cli/wake_owner_lifecycle_unix_test.go
+++ b/internal/cli/wake_owner_lifecycle_unix_test.go
@@ -777,6 +777,53 @@ func TestConcurrentAuthoritativeAcquisitionPublishesOneGeneration(t *testing.T) 
 	}
 }
 
+func TestAuthoritativeAcquisitionSurfacesOwnerObservationCloseFailure(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	injector := writeExecutableForTest(t, "owner-close-failure-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	monitorErr := errors.New("owner monitor failed")
+	originalObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("owner = %#v, want %#v", got, owner)
+		}
+		monitor := newWakeOwnerObservationMonitor(nil)
+		monitor.finish(monitorErr)
+		return wakeOwnerObservation{State: wakeOwnerSame, monitor: monitor}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = originalObserve })
+
+	cleanup, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if cleanup != nil {
+		t.Fatal("observation close failure returned successful acquisition cleanup")
+	}
+	if !errors.Is(err, monitorErr) {
+		t.Fatalf("acquisition error = %v, want owner monitor failure", err)
+	}
+	if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+		t.Fatalf("owner monitor failure published wake claim: %#v", inspection)
+	}
+	if _, exists, err := readWakeTarget(root, "codex"); err != nil || exists {
+		t.Fatalf("owner monitor failure target exists=%v err=%v", exists, err)
+	}
+}
+
 func TestAcquireAuthoritativeWakeClaimReclaimsOnlyADeadOwnerWithAbsentWake(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -1255,6 +1302,78 @@ func TestRecoverOwnerRequiresExactTokenAndCallerSessionForLiveOwner(t *testing.T
 				t.Fatal("refused recovery removed owner lock")
 			}
 		})
+	}
+}
+
+func TestRecoverOwnerObservationCloseFailurePreservesClaim(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "owner-recover-close-failure-injector")
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          5151,
+		TTY:          "unknown",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Generation:   "owner-recover-close-failure",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+	lockBefore, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetPath := wakeTargetPath(root, "codex")
+	targetBefore, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid}
+	})
+	monitorErr := errors.New("owner monitor failed")
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("observed owner = %#v, want %#v", got, owner)
+		}
+		monitor := newWakeOwnerObservationMonitor(nil)
+		monitor.finish(monitorErr)
+		return wakeOwnerObservation{State: wakeOwnerDead, monitor: monitor}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+	result, err := recoverOwnerWake(root, "codex")
+	if !errors.Is(err, monitorErr) || result.Status != "refused" {
+		t.Fatalf("recover result = %#v err=%v, want monitor refusal", result, err)
+	}
+	lockAfter, err := os.ReadFile(lockPath)
+	if err != nil || !bytes.Equal(lockAfter, lockBefore) {
+		t.Fatalf("owner lock changed: err=%v before=%q after=%q", err, lockBefore, lockAfter)
+	}
+	targetAfter, err := os.ReadFile(targetPath)
+	if err != nil || !bytes.Equal(targetAfter, targetBefore) {
+		t.Fatalf("owner target changed: err=%v before=%q after=%q", err, targetBefore, targetAfter)
 	}
 }
 

--- a/internal/cli/wake_owner_recover_unix.go
+++ b/internal/cli/wake_owner_recover_unix.go
@@ -110,7 +110,7 @@ func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
 	for {
 		var stopCapability *authoritativeWakeStopCapability
 		var stopAuthorization wakeOwnerReleaseAuthorization
-		err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) (retErr error) {
 			inspection := inspectWakeLockForOwnerTransition(dirfd, agentDir, root, me)
 			result.PID = inspection.PID
 			switch classifyPersistedWakeClaim(inspection) {
@@ -159,7 +159,17 @@ func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
 			result.OwnerPID = owner.PID
 			result.OwnerSession = owner.SessionID
 			observation, err := observeAuthoritativeWakeOwner(owner)
-			defer func() { _ = observation.Close() }()
+			observationClosed := false
+			closeObservation := func() error {
+				if observationClosed {
+					return nil
+				}
+				observationClosed = true
+				return observation.Close()
+			}
+			defer func() {
+				retErr = errors.Join(retErr, closeObservation())
+			}()
 			if err != nil {
 				return refuse("wake owner is unknown: "+err.Error(), "retry after owner identity inspection is available")
 			}
@@ -198,6 +208,12 @@ func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
 					"wake owner is unknown: "+observation.Reason,
 					"retry after owner identity inspection is available",
 				)
+			}
+			if err := closeObservation(); err != nil {
+				return errors.Join(refuse(
+					"wake owner observation failed before recovery mutation: "+err.Error(),
+					"preserve the claim and retry after owner monitoring is healthy",
+				), err)
 			}
 			wakeCapability, err := prepareAuthoritativeWakeStop(dirfd, agentDir, inspection)
 			if err != nil {

--- a/internal/cli/wake_prepared_unix.go
+++ b/internal/cli/wake_prepared_unix.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -137,8 +138,35 @@ func writeWakeReadyFileForPreparedWake(root, me, path string, expected wakeLockI
 		return err
 	}
 	defer func() { _ = agentDir.Close() }()
+	publication, err := writeWakeReadyFileForPreparedWakeInDir(
+		agentDir,
+		root,
+		me,
+		path,
+		expected,
+		deadline,
+	)
+	if publication != nil {
+		_ = publication.Close()
+	}
+	return err
+}
+
+func writeWakeReadyFileForPreparedWakeInDir(
+	agentDir *wakeAgentDir,
+	root, me, path string,
+	expected wakeLockInspection,
+	deadline time.Time,
+) (*wakeReadyPublication, error) {
+	if agentDir == nil {
+		return nil, fmt.Errorf("wake agent directory capability is missing")
+	}
 	for {
+		if err := validateCanonicalWakeAgentDir(agentDir); err != nil {
+			return nil, err
+		}
 		prepared := false
+		var publication *wakeReadyPublication
 		err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 			current := inspectWakeLockAt(dirfd, agentDir, root, me)
 			if !sameWakeLockGeneration(expected, current) {
@@ -155,17 +183,13 @@ func writeWakeReadyFileForPreparedWake(root, me, path string, expected wakeLockI
 				return fmt.Errorf("existing amq wake became incompatible before preparation completed: %w", err)
 			}
 			var err error
-			if current.Lock.WakeMode == wakeOwnerWakeMode {
-				prepared, err = validateWakePreparedFileAgainstInspectionAt(
-					dirfd,
-					agentDir,
-					root,
-					me,
-					current,
-				)
-			} else {
-				prepared, err = validateWakePreparedFileAgainstInspection(root, me, current)
-			}
+			prepared, err = validateWakePreparedFileAgainstInspectionAt(
+				dirfd,
+				agentDir,
+				root,
+				me,
+				current,
+			)
 			if err != nil || !prepared {
 				return err
 			}
@@ -174,16 +198,22 @@ func writeWakeReadyFileForPreparedWake(root, me, path string, expected wakeLockI
 				Generation:   current.Lock.Generation,
 				TargetDigest: current.Lock.TargetDigest,
 			}
-			return writeWakeGenerationFile(path, "wake ready file", marker)
+			publication, err = publishWakeReadyFile(path, marker)
+			return err
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if prepared {
-			return nil
+			if err := validateCanonicalWakeAgentDir(agentDir); err != nil {
+				cleanupErr := publication.removeIfUnchanged()
+				closeErr := publication.Close()
+				return nil, errors.Join(err, cleanupErr, closeErr)
+			}
+			return publication, nil
 		}
 		if !waitForWakePreparedRetry(deadline) {
-			return fmt.Errorf("existing amq wake did not publish its prepared marker before the readiness deadline")
+			return nil, fmt.Errorf("existing amq wake did not publish its prepared marker before the readiness deadline")
 		}
 	}
 }

--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -3,9 +3,12 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 const wakeReadySchema = 1
@@ -35,6 +38,27 @@ func writeWakeReadyFileAgainstOwner(
 		return err
 	}
 	defer func() { _ = agentDir.Close() }()
+	return writeWakeReadyFileAgainstOwnerInDir(
+		agentDir,
+		root,
+		me,
+		path,
+		expected,
+		requestedOwner,
+	)
+}
+
+func writeWakeReadyFileAgainstOwnerInDir(
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	path string,
+	expected wakeLockInspection,
+	requestedOwner *wakeOwner,
+) error {
+	if agentDir == nil {
+		return fmt.Errorf("wake agent directory capability is missing")
+	}
 	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		current := inspectWakeLockAt(dirfd, agentDir, root, me)
 		if !sameWakeLockGeneration(expected, current) {
@@ -61,6 +85,96 @@ func writeWakeGenerationFile(path, label string, marker wakeReady) error {
 		return fmt.Errorf("marshal %s: %w", label, err)
 	}
 	return writeWakeMetadataFile(path, append(data, '\n'), label)
+}
+
+type wakeReadyPublication struct {
+	dir      *wakeAgentDir
+	name     string
+	snapshot wakeGenerationFileSnapshot
+}
+
+var beforeWakeReadyCleanupUnlink = func() {}
+var afterWakeReadyPublicationWrite = func() {}
+
+func publishWakeReadyFile(path string, marker wakeReady) (*wakeReadyPublication, error) {
+	parent, err := openWakeDirectory(filepath.Dir(path), "wake ready parent directory")
+	if err != nil {
+		return nil, err
+	}
+	name := filepath.Base(path)
+	var snapshot wakeGenerationFileSnapshot
+	err = parent.withFD(func(dirfd int) error {
+		var err error
+		snapshot, err = writeWakeGenerationFileAtWithSnapshot(
+			dirfd,
+			name,
+			"wake ready file",
+			marker,
+		)
+		if err != nil {
+			return err
+		}
+		afterWakeReadyPublicationWrite()
+		installed, exists, err := readWakeGenerationFileSnapshotAt(
+			dirfd,
+			parent,
+			name,
+			"wake ready file",
+		)
+		if err != nil {
+			return fmt.Errorf("validate installed wake ready file: %w", err)
+		}
+		if !exists {
+			return fmt.Errorf("installed wake ready file disappeared during publication")
+		}
+		if !os.SameFile(snapshot.FileInfo, installed.FileInfo) ||
+			!bytes.Equal(snapshot.Raw, installed.Raw) ||
+			snapshot.Marker != installed.Marker {
+			return fmt.Errorf("installed wake ready file changed during publication; preserving it")
+		}
+		snapshot = installed
+		return nil
+	})
+	publication := &wakeReadyPublication{
+		dir:      parent,
+		name:     name,
+		snapshot: snapshot,
+	}
+	if err != nil {
+		var cleanupErr error
+		if snapshot.FileInfo != nil {
+			cleanupErr = publication.removeIfUnchanged()
+		}
+		closeErr := publication.Close()
+		return nil, errors.Join(err, cleanupErr, closeErr)
+	}
+	return publication, nil
+}
+
+func (publication *wakeReadyPublication) Close() error {
+	if publication == nil || publication.dir == nil {
+		return nil
+	}
+	err := publication.dir.Close()
+	publication.dir = nil
+	return err
+}
+
+func (publication *wakeReadyPublication) removeIfUnchanged() error {
+	if publication == nil || publication.dir == nil {
+		return nil
+	}
+	beforeWakeReadyCleanupUnlink()
+	return publication.dir.withFD(func(dirfd int) error {
+		_, err := removeWakeGenerationFileIfSnapshotMatchesAt(
+			dirfd,
+			publication.dir,
+			publication.name,
+			"wake ready file",
+			publication.snapshot,
+		)
+		return err
+	})
 }
 
 func readWakeReadyFile(path string) (wakeReady, bool, error) {
@@ -236,13 +350,32 @@ func validateWakeReadyFileAgainstOwner(
 ) (bool, error) {
 	// A wake can still die immediately after this guarded validation; the local
 	// process notifier has no durable liveness lease beyond the lock generation.
-	ready := false
 	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
 		return false, err
 	}
 	defer func() { _ = agentDir.Close() }()
-	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+	return validateWakeReadyFileAgainstOwnerInDir(
+		agentDir,
+		root,
+		me,
+		path,
+		requestedOwner,
+	)
+}
+
+func validateWakeReadyFileAgainstOwnerInDir(
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	path string,
+	requestedOwner *wakeOwner,
+) (bool, error) {
+	if agentDir == nil {
+		return false, fmt.Errorf("wake agent directory capability is missing")
+	}
+	ready := false
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		published, exists, err := readWakeReadyFile(path)
 		if err != nil || !exists {
 			return err

--- a/internal/cli/wake_repair_child_lifecycle_unix_test.go
+++ b/internal/cli/wake_repair_child_lifecycle_unix_test.go
@@ -196,6 +196,102 @@ func TestWakeRepairAdmissionFailureStopsAndReapsPreparedChild(t *testing.T) {
 	assertRepairLifecycleChildReapedWithoutClaim(t, fixture, child)
 }
 
+func TestWakeRepairFailedChildCleanupPreservesExactClaimWithoutObservedExit(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		capabilityDetached bool
+	}{
+		{name: "pre-detach"},
+		{name: "capability-detached", capabilityDetached: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newWakeRepairLifecycleFixture(t)
+			if err := os.Remove(fixture.lockPath); err != nil {
+				t.Fatalf("remove dead source lock: %v", err)
+			}
+			child, err := startWakeFromTargetDefault(
+				fixture.agentDir,
+				fixture.inboxDir,
+				fixture.root,
+				"codex",
+				fixture.target,
+				fixture.lineage,
+			)
+			cleanupRepairLifecycleChild(t, child)
+			if err != nil {
+				t.Fatalf(
+					"start prepared repair child: %v\n%s",
+					err,
+					wakeRepairLifecycleDiagnostics(fixture, child),
+				)
+			}
+			forceRepairLifecycleChildInspection(t, fixture, child)
+
+			lockBefore, err := os.ReadFile(fixture.lockPath)
+			if err != nil {
+				t.Fatalf("read exact child lock: %v", err)
+			}
+			floorPath := wakeRepairFloorPath(fixture.root, "codex")
+			floorBefore, err := os.ReadFile(floorPath)
+			if err != nil {
+				t.Fatalf("read exact child floor: %v", err)
+			}
+
+			realHandoff := child.Handoff
+			realCapability := child.Capability
+			t.Cleanup(func() {
+				child.Handoff = realHandoff
+				child.Capability = realCapability
+			})
+			stopErr := errors.New("stop unavailable")
+			child.Handoff = &wakeRepairParentHandoff{}
+			child.Capability = &wakeRepairChildCapability{
+				stop: func() error { return stopErr },
+			}
+			child.capabilityDetached = tc.capabilityDetached
+
+			waitErr := errors.New("exit not observed")
+			oldWait := waitForWakeRepairChildExit
+			waitForWakeRepairChildExit = func(*wakeProcessWaiter) error {
+				return waitErr
+			}
+			t.Cleanup(func() {
+				waitForWakeRepairChildExit = oldWait
+			})
+
+			err = cleanupFailedWakeRepairChild(
+				fixture.agentDir,
+				fixture.root,
+				"codex",
+				child,
+			)
+			if !errors.Is(err, waitErr) {
+				t.Fatalf("cleanup error = %v, want exit-wait failure", err)
+			}
+			if !tc.capabilityDetached && !errors.Is(err, stopErr) {
+				t.Fatalf("cleanup error = %v, want stop failure", err)
+			}
+			if !processAlive(child.Process.Pid) {
+				t.Fatal("child exited without observed exit evidence")
+			}
+			lockAfter, err := os.ReadFile(fixture.lockPath)
+			if err != nil {
+				t.Fatalf("read preserved child lock: %v", err)
+			}
+			if !bytes.Equal(lockAfter, lockBefore) {
+				t.Fatalf("child lock changed without observed exit")
+			}
+			floorAfter, err := os.ReadFile(floorPath)
+			if err != nil {
+				t.Fatalf("read preserved child floor: %v", err)
+			}
+			if !bytes.Equal(floorAfter, floorBefore) {
+				t.Fatalf("child floor changed without observed exit")
+			}
+		})
+	}
+}
+
 func TestWakeRepairFailedChildCleanupPreservesFloorReplacedBeforeCleanup(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/cli/wake_repair_dirs_unix.go
+++ b/internal/cli/wake_repair_dirs_unix.go
@@ -3,6 +3,8 @@
 package cli
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,7 +22,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const wakeRepairInboxRelativePath = "inbox/new"
+const (
+	wakeInboxParentDirectoryName = "inbox"
+	wakeInboxNewDirectoryName    = "new"
+	wakeRepairInboxRelativePath  = wakeInboxParentDirectoryName + "/" + wakeInboxNewDirectoryName
+)
 
 type wakeRepairDirectoryIdentity struct {
 	device uint64
@@ -36,10 +42,19 @@ type wakeInboxDir struct {
 	closed    bool
 }
 
+func (*wakeAgentDir) isWakeRetainedAgent() {}
+
 type wakeEventWatcher interface {
 	Events() <-chan fsnotify.Event
 	Errors() <-chan error
 	Close() error
+}
+
+var snapshotWakeRetainedFileInfo = func(
+	inbox *wakeInboxDir,
+	name string,
+) (os.FileInfo, error) {
+	return inbox.FileInfo(name)
 }
 
 type retainedWakeDirectoryAuthority struct {
@@ -145,11 +160,10 @@ func (authority retainedWakeDirectoryAuthority) validateCanonical() error {
 		return fmt.Errorf("canonical wake repair agent directory no longer matches retained authority")
 	}
 
-	inboxFD, err := unix.Openat(
+	inboxFile, err := openWakeInboxNewDirectoryAt(
 		agentFD,
-		wakeRepairInboxRelativePath,
-		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
-		0,
+		authority.agentPath,
+		"canonical wake repair",
 	)
 	if err != nil {
 		return fmt.Errorf(
@@ -157,16 +171,78 @@ func (authority retainedWakeDirectoryAuthority) validateCanonical() error {
 			err,
 		)
 	}
-	defer func() { _ = unix.Close(inboxFD) }()
-	inboxIdentity, err := wakeRepairDirectoryIdentityForFD(
-		inboxFD,
-		"canonical wake repair inbox directory",
-	)
+	defer func() { _ = inboxFile.Close() }()
+	inboxIdentity, err := wakeRepairDirectoryIdentityForFile(inboxFile)
 	if err != nil {
 		return err
 	}
 	if inboxIdentity != authority.inboxIdentity {
 		return fmt.Errorf("canonical wake repair inbox directory no longer matches retained authority")
+	}
+	return nil
+}
+
+func validateCanonicalWakeAgentDir(agentDir *wakeAgentDir) error {
+	if agentDir == nil {
+		return fmt.Errorf("retained wake agent directory capability is missing")
+	}
+	var retainedIdentity wakeRepairDirectoryIdentity
+	if err := agentDir.withFD(func(agentFD int) error {
+		var err error
+		retainedIdentity, err = wakeRepairDirectoryIdentityForFD(
+			agentFD,
+			"retained wake agent directory",
+		)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	openCanonical := func() (*os.File, os.FileInfo, error) {
+		fd, err := unix.Open(
+			agentDir.path,
+			unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"canonical wake agent directory no longer matches retained authority: %w",
+				err,
+			)
+		}
+		file := os.NewFile(uintptr(fd), agentDir.path)
+		info, err := file.Stat()
+		if err != nil {
+			_ = file.Close()
+			return nil, nil, fmt.Errorf("stat canonical wake agent directory: %w", err)
+		}
+		if err := validateWakeAgentDir(agentDir.path, info); err != nil {
+			_ = file.Close()
+			return nil, nil, err
+		}
+		return file, info, nil
+	}
+
+	canonical, canonicalInfo, err := openCanonical()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = canonical.Close() }()
+	canonicalIdentity, err := wakeRepairDirectoryIdentityForFile(canonical)
+	if err != nil {
+		return err
+	}
+	if canonicalIdentity != retainedIdentity {
+		return fmt.Errorf("canonical wake agent directory no longer matches retained authority")
+	}
+
+	verification, verificationInfo, err := openCanonical()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = verification.Close() }()
+	if !os.SameFile(canonicalInfo, verificationInfo) {
+		return fmt.Errorf("canonical wake agent directory changed while validating retained authority")
 	}
 	return nil
 }
@@ -198,17 +274,14 @@ func validateCanonicalWakeRepairDirectories(
 		return fmt.Errorf("canonical wake repair agent directory no longer matches retained authority")
 	}
 
-	inboxPath := filepath.Join(agentPath, wakeRepairInboxRelativePath)
-	inboxFD, err := unix.Openat(
+	inboxFile, err := openWakeInboxNewDirectoryAt(
 		agentFD,
-		wakeRepairInboxRelativePath,
-		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
-		0,
+		agentPath,
+		"canonical wake repair",
 	)
 	if err != nil {
 		return fmt.Errorf("open canonical wake repair inbox directory: %w", err)
 	}
-	inboxFile := os.NewFile(uintptr(inboxFD), inboxPath)
 	defer func() { _ = inboxFile.Close() }()
 	inboxIdentity, err := wakeRepairDirectoryIdentityForFile(inboxFile)
 	if err != nil {
@@ -219,6 +292,85 @@ func validateCanonicalWakeRepairDirectories(
 		return fmt.Errorf("canonical wake repair inbox directory no longer matches retained authority")
 	}
 	return nil
+}
+
+func openValidatedWakeDirectoryAt(
+	parentFD int,
+	name string,
+	path string,
+	label string,
+) (*os.File, error) {
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+		return nil, fmt.Errorf("%s name %q must identify one direct child", label, name)
+	}
+	open := func() (*os.File, os.FileInfo, error) {
+		fd, err := unix.Openat(
+			parentFD,
+			name,
+			unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("open %s: %w", label, err)
+		}
+		file := os.NewFile(uintptr(fd), path)
+		info, err := file.Stat()
+		if err != nil {
+			_ = file.Close()
+			return nil, nil, fmt.Errorf("stat %s: %w", label, err)
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			_ = file.Close()
+			return nil, nil, fmt.Errorf("%s must be a directory, not a symlink", label)
+		}
+		if err := validateWakeTargetPathOwnership(label, path, info); err != nil {
+			_ = file.Close()
+			return nil, nil, err
+		}
+		return file, info, nil
+	}
+
+	file, openedInfo, err := open()
+	if err != nil {
+		return nil, err
+	}
+	verification, verificationInfo, err := open()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	defer func() { _ = verification.Close() }()
+	if !os.SameFile(openedInfo, verificationInfo) {
+		_ = file.Close()
+		return nil, fmt.Errorf("%s changed while opening", label)
+	}
+	return file, nil
+}
+
+func openWakeInboxNewDirectoryAt(
+	agentFD int,
+	agentPath string,
+	labelPrefix string,
+) (*os.File, error) {
+	inboxParentPath := filepath.Join(agentPath, wakeInboxParentDirectoryName)
+	inboxParent, err := openValidatedWakeDirectoryAt(
+		agentFD,
+		wakeInboxParentDirectoryName,
+		inboxParentPath,
+		labelPrefix+" inbox parent directory",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = inboxParent.Close() }()
+
+	inboxPath := filepath.Join(inboxParentPath, wakeInboxNewDirectoryName)
+	return openValidatedWakeDirectoryAt(
+		int(inboxParent.Fd()),
+		wakeInboxNewDirectoryName,
+		inboxPath,
+		labelPrefix+" inbox directory",
+	)
 }
 
 func openWakeRepairInboxDir(agentDir *wakeAgentDir) (*wakeInboxDir, error) {
@@ -236,30 +388,12 @@ func openWakeRepairInboxDir(agentDir *wakeAgentDir) (*wakeInboxDir, error) {
 		if err != nil {
 			return err
 		}
-		fd, err := unix.Openat(
+		file, err = openWakeInboxNewDirectoryAt(
 			dirfd,
-			wakeRepairInboxRelativePath,
-			unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
-			0,
+			agentDir.path,
+			"retained wake",
 		)
 		if err != nil {
-			_ = agentFile.Close()
-			return fmt.Errorf("open retained wake inbox directory: %w", err)
-		}
-		file = os.NewFile(uintptr(fd), filepath.Join(agentDir.path, wakeRepairInboxRelativePath))
-		info, err := file.Stat()
-		if err != nil {
-			_ = file.Close()
-			_ = agentFile.Close()
-			return fmt.Errorf("stat retained wake inbox directory: %w", err)
-		}
-		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-			_ = file.Close()
-			_ = agentFile.Close()
-			return fmt.Errorf("retained wake inbox must be a directory")
-		}
-		if err := validateWakeTargetPathOwnership("retained wake inbox directory", file.Name(), info); err != nil {
-			_ = file.Close()
 			_ = agentFile.Close()
 			return err
 		}
@@ -274,6 +408,21 @@ func openWakeRepairInboxDir(agentDir *wakeAgentDir) (*wakeInboxDir, error) {
 		path:      file.Name(),
 		file:      file,
 	}, nil
+}
+
+func openWatchedWakeInboxDir(
+	agentDir *wakeAgentDir,
+) (*wakeInboxDir, wakeEventWatcher, error) {
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	watcher, err := inboxDir.NewWatcher()
+	if err != nil {
+		closeErr := inboxDir.Close()
+		return nil, nil, errors.Join(err, closeErr)
+	}
+	return inboxDir, watcher, nil
 }
 
 func duplicateWakeRepairDirectoryFD(fd int, name string) (*os.File, error) {
@@ -427,6 +576,127 @@ func (d *wakeInboxDir) ReadHeader(name string) (format.Header, error) {
 	return header, err
 }
 
+func (d *wakeInboxDir) FileInfo(name string) (os.FileInfo, error) {
+	if filepath.Base(name) != name ||
+		strings.HasPrefix(name, ".") ||
+		!strings.HasSuffix(name, ".md") {
+		return nil, fmt.Errorf("invalid wake message filename %q", name)
+	}
+	var info os.FileInfo
+	err := d.withFD(func(dirfd int) error {
+		fd, err := unix.Openat(
+			dirfd,
+			name,
+			unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		if err != nil {
+			return err
+		}
+		file := os.NewFile(uintptr(fd), filepath.Join(d.path, name))
+		defer func() { _ = file.Close() }()
+		info, err = file.Stat()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("wake message %s must be a regular file", file.Name())
+		}
+		return nil
+	})
+	return info, err
+}
+
+func (d *wakeInboxDir) SnapshotMessageIdentities() (map[string]wakeFileIdentity, error) {
+	entries, err := d.ReadDir()
+	if err != nil {
+		return nil, err
+	}
+	baseline := make(map[string]wakeFileIdentity, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() ||
+			strings.HasPrefix(name, ".") ||
+			!strings.HasSuffix(name, ".md") {
+			continue
+		}
+		info, err := snapshotWakeRetainedFileInfo(d, name)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		identity, ok := captureWakeFileIdentity(info)
+		if !ok {
+			return nil, fmt.Errorf("capture identity for %s", name)
+		}
+		baseline[name] = identity
+	}
+	return baseline, nil
+}
+
+func (d *wakeInboxDir) CreateBaselineBarrier() (string, error) {
+	for attempt := 0; attempt < 16; attempt++ {
+		var random [16]byte
+		if _, err := rand.Read(random[:]); err != nil {
+			return "", fmt.Errorf("generate wake baseline barrier name: %w", err)
+		}
+		name := ".wake-baseline-barrier-" + hex.EncodeToString(random[:])
+		var created bool
+		err := d.withFD(func(dirfd int) error {
+			fd, err := unix.Openat(
+				dirfd,
+				name,
+				unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+				0o600,
+			)
+			if err != nil {
+				if errors.Is(err, syscall.EEXIST) {
+					return nil
+				}
+				return err
+			}
+			created = true
+			return unix.Close(fd)
+		})
+		if err != nil {
+			return "", fmt.Errorf("create retained wake baseline barrier: %w", err)
+		}
+		if created {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("create retained wake baseline barrier: name collision limit reached")
+}
+
+func (d *wakeInboxDir) UnlinkBaselineBarrier(name string) error {
+	if filepath.Base(name) != name || !strings.HasPrefix(name, ".wake-baseline-barrier-") {
+		return fmt.Errorf("invalid wake baseline barrier name %q", name)
+	}
+	return d.withFD(func(dirfd int) error {
+		if err := unix.Unlinkat(dirfd, name, 0); err != nil && !errors.Is(err, syscall.ENOENT) {
+			return fmt.Errorf("unlink retained wake baseline barrier: %w", err)
+		}
+		return nil
+	})
+}
+
+func (d *wakeInboxDir) ValidateCanonical() error {
+	return d.withWatcherFDs(func(agentFD, inboxFD int) error {
+		authority, err := newRetainedWakeDirectoryAuthority(
+			agentFD,
+			inboxFD,
+			d.agentPath,
+			d.path,
+		)
+		if err != nil {
+			return err
+		}
+		return authority.validateCanonical()
+	})
+}
+
 func (d *wakeInboxDir) NewWatcher() (wakeEventWatcher, error) {
 	var watcher wakeEventWatcher
 	err := d.withWatcherFDs(func(agentFD, inboxFD int) error {
@@ -483,6 +753,52 @@ func touchWakePresenceInDir(agentDir *wakeAgentDir, me string) error {
 			}
 			value.LastSeen = time.Now().UTC().Format(time.RFC3339Nano)
 		}
+		encoded, err := json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			return err
+		}
+		return writeWakeRepairMetadataAt(
+			dirfd,
+			agentDir,
+			"presence.json",
+			"wake presence",
+			append(encoded, '\n'),
+			maxWakeMetadataFileBytes,
+		)
+	})
+}
+
+func setWakeNotifierStatusInDir(
+	agentDir *wakeAgentDir,
+	me, status, mode, reason string,
+) error {
+	if agentDir == nil {
+		return fmt.Errorf("wake agent directory capability is missing")
+	}
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		path := filepath.Join(agentDir.path, "presence.json")
+		data, _, exists, err := readWakeRepairMetadataAt(
+			dirfd,
+			"presence.json",
+			"wake presence",
+			path,
+			maxWakeMetadataFileBytes,
+		)
+		var value presence.Presence
+		switch {
+		case err != nil:
+			return err
+		case !exists:
+			value = presence.New(me, "active", "", time.Now())
+		default:
+			if err := json.Unmarshal(data, &value); err != nil {
+				return fmt.Errorf("parse wake presence: %w", err)
+			}
+		}
+		value.NotifierStatus = status
+		value.NotifierMode = mode
+		value.NotifierReason = reason
+		value.LastSeen = time.Now().UTC().Format(time.RFC3339Nano)
 		encoded, err := json.MarshalIndent(value, "", "  ")
 		if err != nil {
 			return err

--- a/internal/cli/wake_repair_floor_unix.go
+++ b/internal/cli/wake_repair_floor_unix.go
@@ -172,15 +172,22 @@ func sameWakeRepairSuppression(first, second wakeRepairFloor) bool {
 }
 
 func writeWakeRepairFloor(root, me string, floor wakeRepairFloor) error {
-	data, err := json.MarshalIndent(floor, "", "  ")
+	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
-		return fmt.Errorf("marshal wake repair floor: %w", err)
+		return err
 	}
-	data = append(data, '\n')
-	if len(data) > maxWakeRepairFloorFileBytes {
-		return fmt.Errorf("wake repair floor has too many existing messages (%d-byte limit)", maxWakeRepairFloorFileBytes)
-	}
-	return writeWakeMetadataFile(wakeRepairFloorPath(root, me), data, "wake repair floor")
+	defer func() { _ = agentDir.Close() }()
+	return writeWakeRepairFloorInDir(agentDir, root, floor)
+}
+
+func writeWakeRepairFloorInDir(
+	agentDir *wakeAgentDir,
+	root string,
+	floor wakeRepairFloor,
+) error {
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return writeWakeRepairFloorAt(dirfd, agentDir, root, floor)
+	})
 }
 
 func readWakeRepairFloor(root, me string) (wakeRepairFloor, bool, error) {

--- a/internal/cli/wake_retire_darwin_test.go
+++ b/internal/cli/wake_retire_darwin_test.go
@@ -19,7 +19,7 @@ func TestRetireWakeUsesDarwinCooperativeControlAndPreservesTarget(t *testing.T) 
 		return matchingRetireWakeProcess(pid, root, "codex", injector)
 	})
 
-	cleanup, stopRequested, markStopped, err := startWakeControlListener(root, "codex", lock)
+	cleanup, stopRequested, markStopped, err := startWakeControlListener(root, "codex", lock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/wake_terminal_authority_other.go
+++ b/internal/cli/wake_terminal_authority_other.go
@@ -5,3 +5,7 @@ package cli
 func isWakeTerminalForegroundPGRPChanged(error) bool {
 	return false
 }
+
+func isWakeTerminalAuthorityLoss(error) bool {
+	return false
+}

--- a/internal/cli/wake_terminal_authority_other.go
+++ b/internal/cli/wake_terminal_authority_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package cli
+
+func isWakeTerminalForegroundPGRPChanged(error) bool {
+	return false
+}

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -21,6 +21,76 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	return terminateAndRemoveOrphanedWakeLockWithRawConsent(inspection, false)
 }
 
+func terminateAndRemoveOrphanedWakeLockInDir(
+	agentDir *wakeAgentDir,
+	inspection wakeLockInspection,
+) (bool, error) {
+	var recheck wakeLockInspection
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		recheck = inspectWakeLockAt(
+			dirfd,
+			agentDir,
+			inspection.Root,
+			inspection.Agent,
+		)
+		if !sameWakeLockInspection(inspection, recheck) {
+			return nil
+		}
+		return validateWakeLockOwnerlessMutation(recheck)
+	}); err != nil {
+		return false, err
+	}
+	if !sameWakeLockInspection(inspection, recheck) || !recheck.IdentityConfirmed {
+		return false, nil
+	}
+	if recheck.Process.Running &&
+		recheck.Lock.WakeMode != wakeTargetInjectVia &&
+		!wakeLockNeedsReplacement(recheck) {
+		return false, fmt.Errorf(
+			"live raw wake for %s (pid %d, start %s) is not eligible for automatic replacement; retry through amq coop exec to review and consent to takeover, or stop it from its owning session; refusing to signal without consent",
+			recheck.Agent,
+			recheck.PID,
+			recheck.Lock.ProcessStart,
+		)
+	}
+	if recheck.Process.Running && recheck.Lock.WakeMode == wakeTargetInjectVia {
+		return cooperativeStopInjectViaInDir(agentDir, recheck)
+	}
+	if recheck.Process.Running {
+		if err := terminateWakeProcessInDir(agentDir, recheck); err != nil {
+			if !sameConfirmedWakeLockInDir(agentDir, recheck) {
+				return true, nil
+			}
+			return false, err
+		}
+	}
+	removed := false
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(
+			dirfd,
+			agentDir,
+			inspection.Root,
+			inspection.Agent,
+		)
+		if !current.Exists {
+			removed = true
+			return nil
+		}
+		if !sameWakeLockGeneration(recheck, current) {
+			return nil
+		}
+		if err := validateWakeLockStaleRemoval(current); err != nil {
+			return err
+		}
+		if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, current); err != nil {
+			return err
+		}
+		removed = true
+		return nil
+	})
+	return removed, err
+}
+
 func retireLiveRawOrphan(inspection wakeLockInspection) (bool, error) {
 	return terminateAndRemoveOrphanedWakeLockWithRawConsent(inspection, true)
 }
@@ -115,6 +185,63 @@ func terminateWakeProcess(inspection wakeLockInspection) error {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+func terminateWakeProcessInDir(
+	agentDir *wakeAgentDir,
+	inspection wakeLockInspection,
+) error {
+	if !sameConfirmedWakeLockInDir(agentDir, inspection) {
+		return fmt.Errorf("wake process identity changed before SIGTERM")
+	}
+	if err := signalWakeProcess(inspection.PID, syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal wake process SIGTERM: %w", err)
+	}
+	time.Sleep(wakeTerminateGrace)
+	switch state := inspectWakeIdentity(inspection); state {
+	case wakeIdentityGoneOrDifferent:
+		return nil
+	case wakeIdentityUnknown:
+		return fmt.Errorf("wake process identity is unknown after SIGTERM; preserving wake lock")
+	}
+	if !sameConfirmedWakeLockInDir(agentDir, inspection) {
+		return fmt.Errorf("wake process identity changed before SIGKILL")
+	}
+	if err := signalWakeProcess(inspection.PID, syscall.SIGKILL); err != nil {
+		return fmt.Errorf("signal wake process SIGKILL: %w", err)
+	}
+	deadline := time.Now().Add(wakeTerminateGrace)
+	for {
+		switch state := inspectWakeIdentity(inspection); state {
+		case wakeIdentityGoneOrDifferent:
+			return nil
+		case wakeIdentityUnknown:
+			return fmt.Errorf("wake process identity is unknown after SIGKILL; preserving wake lock")
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("wake process still alive after SIGKILL")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func sameConfirmedWakeLockInDir(
+	agentDir *wakeAgentDir,
+	inspection wakeLockInspection,
+) bool {
+	confirmed := false
+	_ = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		recheck := inspectWakeLockAt(
+			dirfd,
+			agentDir,
+			inspection.Root,
+			inspection.Agent,
+		)
+		confirmed = sameWakeLockInspection(inspection, recheck) &&
+			recheck.IdentityConfirmed
+		return nil
+	})
+	return confirmed
 }
 
 func sameConfirmedWakeLock(inspection wakeLockInspection) bool {

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -35,6 +35,113 @@ func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, er
 	return terminateAndRemoveOrphanedWakeLockWithRawConsent(inspection, false)
 }
 
+func terminateAndRemoveOrphanedWakeLockInDir(
+	agentDir *wakeAgentDir,
+	inspection wakeLockInspection,
+) (bool, error) {
+	var locked wakeLockInspection
+	pidfd := -1
+	provenGone := false
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		locked = readWakeLockMetadataAt(
+			dirfd,
+			agentDir,
+			inspection.Root,
+			inspection.Agent,
+		)
+		if !sameWakeLockGeneration(inspection, locked) {
+			return nil
+		}
+		if err := validateWakeLockOwnerlessMutation(locked); err != nil {
+			return err
+		}
+		fd, err := linuxPidfdOpen(locked.PID, 0)
+		if err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				provenGone = true
+				return removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, locked)
+			}
+			return fmt.Errorf("pidfd_open wake process %d: %w", locked.PID, err)
+		}
+		pidfd = fd
+		locked.Process = inspectWakeProcess(locked.PID)
+		classifyWakeLock(locked.Root, locked.Agent, &locked)
+		if !sameWakeLockInspection(inspection, locked) || !locked.IdentityConfirmed {
+			return nil
+		}
+		return nil
+	}); err != nil {
+		if pidfd >= 0 {
+			_ = linuxPidfdClose(pidfd)
+		}
+		return false, err
+	}
+	if provenGone {
+		return true, nil
+	}
+	if pidfd < 0 || !locked.IdentityConfirmed {
+		if pidfd >= 0 {
+			_ = linuxPidfdClose(pidfd)
+		}
+		return false, nil
+	}
+	defer func() { _ = linuxPidfdClose(pidfd) }()
+
+	if locked.Process.Running && locked.Lock.WakeMode != wakeTargetInjectVia &&
+		!wakeLockNeedsReplacement(locked) {
+		return false, fmt.Errorf(
+			"live raw wake for %s (pid %d, start %s) is not eligible for automatic replacement; retry through amq coop exec to review and consent to takeover, or stop it from its owning session; refusing to signal without consent",
+			locked.Agent,
+			locked.PID,
+			locked.Lock.ProcessStart,
+		)
+	}
+	if err := terminateWakePidfd(pidfd); err != nil {
+		missing := false
+		_ = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+			current := inspectWakeLockAt(
+				dirfd,
+				agentDir,
+				inspection.Root,
+				inspection.Agent,
+			)
+			missing = !current.Exists ||
+				!sameWakeLockGeneration(locked, current)
+			return nil
+		})
+		if missing {
+			return true, nil
+		}
+		return false, err
+	}
+
+	removed := false
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(
+			dirfd,
+			agentDir,
+			inspection.Root,
+			inspection.Agent,
+		)
+		if !current.Exists {
+			removed = true
+			return nil
+		}
+		if !sameWakeLockGeneration(locked, current) {
+			return nil
+		}
+		if err := validateWakeLockStaleRemoval(current); err != nil {
+			return err
+		}
+		if err := removeWakeLockIfUnchangedGuardedAt(dirfd, agentDir, current); err != nil {
+			return err
+		}
+		removed = true
+		return nil
+	})
+	return removed, err
+}
+
 func terminateAndRemoveOrphanedWakeLockWithRawConsent(
 	inspection wakeLockInspection,
 	allowRawOrphan bool,

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -14,6 +14,50 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
+type wakeInfoErrorDirEntry struct {
+	os.DirEntry
+	err error
+}
+
+type wakeTestAcceptedProgressError struct {
+	err      error
+	accepted int
+}
+
+func (err *wakeTestAcceptedProgressError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeTestAcceptedProgressError) Unwrap() error {
+	return err.err
+}
+
+func (err *wakeTestAcceptedProgressError) wakeAcceptedBytes() int {
+	return err.accepted
+}
+
+func (entry wakeInfoErrorDirEntry) Info() (os.FileInfo, error) {
+	info, _ := entry.DirEntry.Info()
+	return info, entry.err
+}
+
+type wakeStaticInboxReader struct {
+	entries []os.DirEntry
+	headers map[string]format.Header
+}
+
+func (reader wakeStaticInboxReader) ReadDir() ([]os.DirEntry, error) {
+	return reader.entries, nil
+}
+
+func (reader wakeStaticInboxReader) ReadHeader(name string) (format.Header, error) {
+	header, ok := reader.headers[name]
+	if !ok {
+		return format.Header{}, os.ErrNotExist
+	}
+	return header, nil
+}
+
 func TestIsInterruptMessage(t *testing.T) {
 	cfg := &wakeConfig{
 		interrupt:         true,
@@ -261,25 +305,37 @@ func TestOwnerBoundNotificationUsesFixedDoorbellAndGuardsEveryChunk(t *testing.T
 	})
 
 	tests := []struct {
+		name string
+		me   string
 		mode string
 		want []string
 	}{
 		{
+			name: "codex-raw",
+			me:   "codex",
 			mode: wakeInjectModeRaw,
 			want: []string{coopWakeDoorbell, "\n", "\r", "\r"},
 		},
 		{
+			name: "claude-raw",
+			me:   "claude",
+			mode: wakeInjectModeRaw,
+			want: []string{coopWakeDoorbell, "\r", "\r"},
+		},
+		{
+			name: "grok-paste",
+			me:   "grok",
 			mode: wakeInjectModePaste,
 			want: []string{coopWakeDoorbell, "\r"},
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.mode, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			stop := make(chan struct{})
 			var writes []string
 			guardCalls := 0
 			cfg := &wakeConfig{
-				me:          "codex",
+				me:          tc.me,
 				injectMode:  tc.mode,
 				controlStop: stop,
 				bell:        true,
@@ -304,6 +360,28 @@ func TestOwnerBoundNotificationUsesFixedDoorbellAndGuardsEveryChunk(t *testing.T
 				t.Fatalf("guard calls = %d, want %d", guardCalls, len(tc.want))
 			}
 		})
+	}
+}
+
+func TestUsesCoopDoorbellIsOwnerBoundAcrossProviders(t *testing.T) {
+	for _, me := range []string{"claude", "codex", "grok", "orchestrator"} {
+		t.Run(me, func(t *testing.T) {
+			if !usesCoopDoorbell(&wakeConfig{
+				me:        me,
+				root:      "/explicit/amq/root",
+				wakeOwner: &wakeOwner{},
+			}) {
+				t.Fatalf("owner-bound %s wake is not eligible for co-op redelivery", me)
+			}
+		})
+	}
+
+	if usesCoopDoorbell(&wakeConfig{
+		me:          "codex",
+		root:        "/explicit/amq/root",
+		controlStop: make(chan struct{}),
+	}) {
+		t.Fatal("rooted ownerless wake is eligible for co-op redelivery")
 	}
 }
 
@@ -386,6 +464,27 @@ func TestInjectViaTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestInjectViaTimeoutBoundsInheritedDescendantOutput(t *testing.T) {
+	scriptPath := filepath.Join(secureTempDirForTest(t), "background-output.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 2 &\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cfg := &wakeConfig{
+		injectVia:     scriptPath,
+		injectTimeout: 50 * time.Millisecond,
+	}
+	start := time.Now()
+	err := injectVia(cfg, "test")
+	elapsed := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("inherited-output error = %v, want timeout", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("inherited-output timeout returned after %s", elapsed)
 	}
 }
 
@@ -606,6 +705,193 @@ func TestInjectNotificationUnsupportedDegradesOnceAndPersistsReason(t *testing.T
 	}
 	if strings.Contains(second, "warning:") || !strings.Contains(second, "second doorbell") {
 		t.Fatalf("second non-input output = %q", second)
+	}
+}
+
+func TestDeliverNewMessageNotificationRetiresInputStateAfterUnsupportedInjector(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	attention := make(chan string, 2)
+	cfg := &wakeConfig{
+		me:         "codex",
+		wakeOwner:  &wakeOwner{},
+		injectMode: wakeInjectModePaste,
+		doorbell: wakeDoorbellState{
+			phase:       wakeDoorbellAwaitingObservation,
+			token:       coopWakeDoorbellTokenForTests,
+			cohort:      snapshotWakeFileIdentities(current),
+			attempts:    1,
+			nextAttempt: now,
+		},
+		doorbellNow: func() time.Time { return now },
+		terminalWrite: func(string) error {
+			return newWakeInjectorUnsupportedError(errors.New("injector disabled"))
+		},
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attention <- string(data)
+			return len(data), nil
+		},
+	}
+
+	captureWakeStderr(t, func() {
+		err := deliverNewMessageNotification(
+			cfg,
+			peerWakeNotification("pending message"),
+			false,
+			current,
+		)
+		if err != nil {
+			t.Fatalf("deliver unsupported notification: %v", err)
+		}
+	})
+
+	if cfg.injectMode != wakeInjectModeNone {
+		t.Fatalf("inject mode = %q, want none", cfg.injectMode)
+	}
+	if cfg.doorbell.phase != wakeDoorbellCohortDelivered ||
+		cfg.doorbell.token != "" ||
+		!sameKnownWakeCohort(cfg.doorbell.cohort, current) ||
+		cfg.doorbell.attempts != 0 ||
+		!cfg.doorbell.nextAttempt.IsZero() ||
+		!cfg.doorbell.observationUntil.IsZero() ||
+		cfg.doorbell.observationUsed {
+		t.Fatalf("demoted cohort delivery state = %#v", cfg.doorbell)
+	}
+	if cfg.inputDelivery.pending() {
+		t.Fatalf("input delivery survived permanent injection demotion: %#v", cfg.inputDelivery)
+	}
+	select {
+	case got := <-attention:
+		if !strings.Contains(got, "pending message") {
+			t.Fatalf("demotion fallback = %q, want message-specific output", got)
+		}
+	default:
+		t.Fatal("unsupported retry demotion suppressed its output fallback")
+	}
+	select {
+	case duplicate := <-attention:
+		t.Fatalf("unsupported retry demotion emitted duplicate fallback: %q", duplicate)
+	default:
+	}
+
+	captureWakeStderr(t, func() {
+		err := deliverNewMessageNotification(
+			cfg,
+			peerWakeNotification("pending message"),
+			false,
+			current,
+		)
+		if err != nil {
+			t.Fatalf("redeliver unchanged demoted cohort: %v", err)
+		}
+	})
+	select {
+	case duplicate := <-attention:
+		t.Fatalf("unchanged demoted cohort emitted duplicate fallback: %q", duplicate)
+	default:
+	}
+}
+
+func TestDeliverNewMessageNotificationRecordsFirstAttemptDemotion(t *testing.T) {
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	attention := make(chan string, 2)
+	cfg := &wakeConfig{
+		me:         "codex",
+		wakeOwner:  &wakeOwner{},
+		injectMode: wakeInjectModePaste,
+		terminalWrite: func(string) error {
+			return newWakeInjectorUnsupportedError(errors.New("injector disabled"))
+		},
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attention <- string(data)
+			return len(data), nil
+		},
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		captureWakeStderr(t, func() {
+			if err := deliverNewMessageNotification(
+				cfg,
+				peerWakeNotification("pending message"),
+				false,
+				current,
+			); err != nil {
+				t.Fatalf("deliver attempt %d: %v", attempt, err)
+			}
+		})
+	}
+
+	if cfg.doorbell.phase != wakeDoorbellCohortDelivered ||
+		!sameKnownWakeCohort(cfg.doorbell.cohort, current) {
+		t.Fatalf("first-attempt demotion state = %#v", cfg.doorbell)
+	}
+	select {
+	case got := <-attention:
+		if !strings.Contains(got, "pending message") {
+			t.Fatalf("demotion fallback = %q", got)
+		}
+	default:
+		t.Fatal("first-attempt demotion did not emit fallback")
+	}
+	select {
+	case duplicate := <-attention:
+		t.Fatalf("unchanged first-attempt demotion emitted duplicate: %q", duplicate)
+	default:
+	}
+}
+
+func TestNotifyNewMessagesKeepsReadablePendingNameWhenInfoFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "readable.md")
+	if err := os.WriteFile(path, []byte("placeholder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := wakeStaticInboxReader{
+		entries: []os.DirEntry{
+			wakeInfoErrorDirEntry{
+				DirEntry: entries[0],
+				err:      errors.New("transient stat failure"),
+			},
+		},
+		headers: map[string]format.Header{
+			"readable.md": {
+				From:    "peer",
+				Subject: "readable despite stat failure",
+			},
+		},
+	}
+	token := "11111111111111111111111111111111"
+	var writes []string
+	cfg := &wakeConfig{
+		me:            "codex",
+		wakeOwner:     &wakeOwner{},
+		injectMode:    wakeInjectModePaste,
+		retainedInbox: reader,
+		doorbellNow:   func() time.Time { return time.Unix(1_800_000_000, 0) },
+		newDoorbellToken: func() (string, error) {
+			return token, nil
+		},
+		terminalWrite: func(text string) error {
+			writes = append(writes, text)
+			return nil
+		},
+		attentionIsTTY: func() bool { return false },
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify readable message with unavailable identity: %v", err)
+	}
+	if len(writes) == 0 || writes[0] != buildCoopWakeDoorbell(token) {
+		t.Fatalf("terminal writes = %#v, want tokenized doorbell", writes)
+	}
+	if identity, ok := cfg.doorbell.cohort["readable.md"]; !ok || identity != nil {
+		t.Fatalf("doorbell cohort dropped readable pending filename: %#v", cfg.doorbell.cohort)
 	}
 }
 
@@ -879,6 +1165,51 @@ func TestInjectNotificationRawInjectsBothCRsOnDrainError(t *testing.T) {
 	}
 }
 
+func TestNotifyNewMessagesMissingInboxReturnsScanErrorWithoutMutatingGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deadline := time.Unix(1_800_000_000, 0)
+	cfg := &wakeConfig{
+		root:       root,
+		me:         "codex",
+		injectMode: wakeInjectModePaste,
+		inputDelivery: wakeInputDeliveryState{
+			phase:   wakeInputRawRescueQueued,
+			mode:    wakeInjectModeRaw,
+			payload: coopWakeDoorbell,
+		},
+		doorbell: wakeDoorbellState{
+			phase:       wakeDoorbellAwaitingObservation,
+			token:       coopWakeDoorbellTokenForTests,
+			cohort:      map[string]*wakeFileIdentity{"pending.md": nil},
+			attempts:    2,
+			nextAttempt: deadline,
+		},
+	}
+	err := notifyNewMessages(cfg)
+	if err == nil {
+		t.Fatal("missing inbox scan returned success")
+	}
+	var scanErr *wakeInboxScanError
+	if !errors.As(err, &scanErr) {
+		t.Fatalf("missing inbox scan error = %T, want wakeInboxScanError", err)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing inbox scan error = %v, want not-exist cause", err)
+	}
+	if cfg.doorbell.phase != wakeDoorbellAwaitingObservation ||
+		cfg.doorbell.token != coopWakeDoorbellTokenForTests ||
+		cfg.doorbell.attempts != 2 ||
+		!cfg.doorbell.nextAttempt.Equal(deadline) ||
+		len(cfg.doorbell.cohort) != 1 {
+		t.Fatalf("missing inbox scan mutated doorbell generation: %#v", cfg.doorbell)
+	}
+	if cfg.inputDelivery.phase != wakeInputRawRescueQueued ||
+		cfg.inputDelivery.mode != wakeInjectModeRaw ||
+		cfg.inputDelivery.payload != coopWakeDoorbell {
+		t.Fatalf("missing inbox scan mutated input delivery: %#v", cfg.inputDelivery)
+	}
+}
+
 func TestNotifyNewMessages_InjectViaExitZeroAdvancesInterruptCooldown(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -943,7 +1274,7 @@ func TestNotifyNewMessages_InjectViaExitZeroAdvancesInterruptCooldown(t *testing
 		t.Fatalf("second notifyNewMessages: %v", err)
 	}
 
-	expected := "\x03\n" + coopWakeDoorbell + "\n" + coopWakeDoorbell + "\n"
+	expected := "\x03\n" + coopWakeDoorbell + "\n"
 
 	got, err := os.ReadFile(logPath)
 	if err != nil {
@@ -1406,6 +1737,322 @@ func TestNotifyNewMessagesRetriesCoopInputAfterOutputOnlyFallback(t *testing.T) 
 	}
 }
 
+func TestNotifyNewMessagesRecordsInjectViaRetryAfterCompletion(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "slow-injector",
+			From:    "peer",
+			To:      []string{"codex"},
+			Thread:  "p2p/codex__peer",
+			Subject: "slow injector",
+			Created: "2026-07-30T08:00:00Z",
+		},
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "slow.md", data); err != nil {
+		t.Fatal(err)
+	}
+
+	working, _ := injectViaCaptureConfig(t)
+	start := time.Unix(1_800_000_000, 0)
+	completed := start.Add(2 * wakeDoorbellRetryBase)
+	clockCalls := 0
+	cfg := &wakeConfig{
+		me:            "codex",
+		root:          root,
+		session:       "session1",
+		wakeOwner:     &wakeOwner{},
+		injectVia:     working.injectVia,
+		injectArgs:    working.injectArgs,
+		injectTimeout: working.injectTimeout,
+		doorbellNow: func() time.Time {
+			clockCalls++
+			if clockCalls == 1 {
+				return start
+			}
+			return completed
+		},
+	}
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	want := completed.Add(wakeDoorbellRetryBase)
+	if !cfg.doorbell.nextAttempt.Equal(want) {
+		t.Fatalf("next attempt = %s, want completion-relative %s", cfg.doorbell.nextAttempt, want)
+	}
+}
+
+func TestNotifyNewMessagesOwnerlessPhysicalCohortDeduplicates(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	write := func(subject string) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      subject,
+				From:    "peer",
+				To:      []string{"codex"},
+				Thread:  "p2p/codex__peer",
+				Subject: subject,
+				Created: "2026-07-30T08:00:00Z",
+			},
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(fsq.AgentInboxNew(root, "codex"), "same.md")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var writes []string
+	cfg := &wakeConfig{
+		me:         "codex",
+		root:       root,
+		session:    "session1",
+		injectMode: wakeInjectModeRaw,
+		terminalWrite: func(text string) error {
+			writes = append(writes, text)
+			return nil
+		},
+	}
+	write("first")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatal(err)
+	}
+	firstWriteCount := len(writes)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(writes) != firstWriteCount {
+		t.Fatalf(
+			"unchanged physical cohort added %d terminal chunks, want 0",
+			len(writes)-firstWriteCount,
+		)
+	}
+
+	path := filepath.Join(fsq.AgentInboxNew(root, "codex"), "same.md")
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	write("replacement")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(writes) <= firstWriteCount {
+		t.Fatal("same-name physical replacement did not emit a fresh notice")
+	}
+}
+
+func TestNotifyNewMessagesResumesExactTIOCSTISuffix(t *testing.T) {
+	for _, mode := range []string{wakeInjectModeRaw, wakeInjectModePaste} {
+		t.Run(mode, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			msg := format.Message{
+				Header: format.Header{
+					Schema:  1,
+					ID:      "partial-" + mode,
+					From:    "peer",
+					To:      []string{"codex"},
+					Thread:  "p2p/codex__peer",
+					Subject: "partial",
+					Created: "2026-07-30T08:00:00Z",
+				},
+			}
+			data, err := msg.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := deliverToInboxForTest(t, root, "codex", "partial.md", data); err != nil {
+				t.Fatal(err)
+			}
+			stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+				return 0, true, nil
+			})
+			stubRawInjectSleep(t)
+
+			var accepted strings.Builder
+			first := true
+			cfg := &wakeConfig{
+				me:         "codex",
+				root:       root,
+				session:    "session1",
+				wakeOwner:  &wakeOwner{},
+				injectMode: mode,
+				terminalWrite: func(text string) error {
+					if first {
+						first = false
+						progress := len(text) / 2
+						accepted.WriteString(text[:progress])
+						return &wakeTestAcceptedProgressError{
+							err:      syscall.EIO,
+							accepted: progress,
+						}
+					}
+					accepted.WriteString(text)
+					return nil
+				},
+			}
+			err = notifyNewMessages(cfg)
+			if !isWakeTerminalPartialProgress(err) {
+				t.Fatalf("first notify error = %v, want retryable partial progress", err)
+			}
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("suffix retry: %v", err)
+			}
+
+			want := coopWakeDoorbell + "\r"
+			if mode == wakeInjectModeRaw {
+				want = coopWakeDoorbell + "\n\r\r"
+			}
+			if got := accepted.String(); got != want {
+				t.Fatalf("accepted bytes = %q, want exact one-shot sequence %q", got, want)
+			}
+		})
+	}
+}
+
+func TestNotifyNewMessagesFinishesPartialPayloadAfterInboxDrain(t *testing.T) {
+	for _, mode := range []string{wakeInjectModeRaw, wakeInjectModePaste} {
+		t.Run(mode, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			msg := format.Message{
+				Header: format.Header{
+					Schema:  1,
+					ID:      "partial-drain-" + mode,
+					From:    "peer",
+					To:      []string{"codex"},
+					Thread:  "p2p/codex__peer",
+					Subject: "partial drain",
+					Created: "2026-07-30T08:00:00Z",
+				},
+			}
+			data, err := msg.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			path, err := deliverToInboxForTest(t, root, "codex", "partial.md", data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+				return 0, true, nil
+			})
+			stubRawInjectSleep(t)
+
+			var accepted strings.Builder
+			first := true
+			var firstPayload string
+			var laterWrites []string
+			collectLater := false
+			stubTIOCSTIInject(t, func(text string) error {
+				if collectLater {
+					laterWrites = append(laterWrites, text)
+				}
+				if first {
+					first = false
+					firstPayload = text
+					progress := len(text) / 2
+					accepted.WriteString(text[:progress])
+					return &wakeTestAcceptedProgressError{
+						err:      syscall.EIO,
+						accepted: progress,
+					}
+				}
+				accepted.WriteString(text)
+				return nil
+			})
+			cfg := &wakeConfig{
+				me:         "codex",
+				root:       root,
+				session:    "session1",
+				injectMode: mode,
+			}
+			if err := notifyNewMessages(cfg); !isWakeTerminalPartialProgress(err) {
+				t.Fatalf("first notify error = %v, want retryable partial progress", err)
+			}
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("empty-inbox reconciliation: %v", err)
+			}
+
+			want := firstPayload + "\r"
+			if mode == wakeInjectModeRaw {
+				want = firstPayload + "\n\r\r"
+			}
+			if got := accepted.String(); got != want {
+				t.Fatalf("accepted bytes = %q, want exact reconciled sequence %q", got, want)
+			}
+			if cfg.inputDelivery.pending() {
+				t.Fatalf("input delivery remained pending: %#v", cfg.inputDelivery)
+			}
+
+			later := format.Message{
+				Header: format.Header{
+					Schema:  1,
+					ID:      "later-" + mode,
+					From:    "other",
+					To:      []string{"codex"},
+					Thread:  "p2p/codex__other",
+					Subject: "later",
+					Created: "2026-07-30T08:01:00Z",
+				},
+			}
+			laterData, err := later.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := deliverToInboxForTest(t, root, "codex", "later.md", laterData); err != nil {
+				t.Fatal(err)
+			}
+			collectLater = true
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("later notify: %v", err)
+			}
+			if len(laterWrites) == 0 {
+				t.Fatal("later notify wrote no terminal input")
+			}
+			staleSuffix := firstPayload[len(firstPayload)/2:]
+			if strings.HasPrefix(strings.Join(laterWrites, ""), staleSuffix) {
+				t.Fatalf("later notify replayed stale suffix %q: %q", staleSuffix, laterWrites)
+			}
+		})
+	}
+}
+
 func TestNotifyNewMessagesDrainsStaleSubmitBeforeNewBatch(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -1490,29 +2137,29 @@ func TestNotifyNewMessagesDrainsStaleSubmitBeforeNewBatch(t *testing.T) {
 func TestNotifyNewMessagesReconcilesQueuedSubmitAfterInboxDrain(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
-		startPhase rawSubmitPhase
+		startPhase wakeInputDeliveryPhase
 		drained    bool
-		wantPhase  rawSubmitPhase
+		wantPhase  wakeInputDeliveryPhase
 		wantWrites string
 	}{
 		{
 			name:       "first submit consumed",
-			startPhase: rawFirstSubmitQueued,
+			startPhase: wakeInputRawFirstSubmitQueued,
 			drained:    true,
-			wantPhase:  rawSubmitIdle,
+			wantPhase:  wakeInputDeliveryIdle,
 			wantWrites: "\r",
 		},
 		{
 			name:       "first submit still stalled",
-			startPhase: rawFirstSubmitQueued,
+			startPhase: wakeInputRawFirstSubmitQueued,
 			drained:    false,
-			wantPhase:  rawFirstSubmitQueued,
+			wantPhase:  wakeInputRawFirstSubmitQueued,
 		},
 		{
 			name:       "rescue submit consumed",
-			startPhase: rawRescueSubmitQueued,
+			startPhase: wakeInputRawRescueQueued,
 			drained:    true,
-			wantPhase:  rawSubmitIdle,
+			wantPhase:  wakeInputDeliveryIdle,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1528,23 +2175,25 @@ func TestNotifyNewMessagesReconcilesQueuedSubmitAfterInboxDrain(t *testing.T) {
 			})
 			stubRawInjectSleep(t)
 			var writes []string
+			stubTIOCSTIInject(t, func(text string) error {
+				writes = append(writes, text)
+				return nil
+			})
 			cfg := &wakeConfig{
-				me:               "codex",
-				root:             root,
-				wakeOwner:        &wakeOwner{},
-				injectMode:       wakeInjectModeRaw,
-				rawSubmitPhase:   tc.startPhase,
-				rawSubmitPayload: coopWakeDoorbell,
-				terminalWrite: func(text string) error {
-					writes = append(writes, text)
-					return nil
+				me:         "codex",
+				root:       root,
+				injectMode: wakeInjectModeRaw,
+				inputDelivery: wakeInputDeliveryState{
+					phase:   tc.startPhase,
+					mode:    wakeInjectModeRaw,
+					payload: coopWakeDoorbell,
 				},
 			}
 			if err := notifyNewMessages(cfg); err != nil {
 				t.Fatalf("notify empty inbox: %v", err)
 			}
-			if cfg.rawSubmitPhase != tc.wantPhase {
-				t.Fatalf("raw submit phase = %v, want %v", cfg.rawSubmitPhase, tc.wantPhase)
+			if cfg.inputDelivery.phase != tc.wantPhase {
+				t.Fatalf("input delivery phase = %v, want %v", cfg.inputDelivery.phase, tc.wantPhase)
 			}
 			if got := strings.Join(writes, "|"); got != tc.wantWrites {
 				t.Fatalf("terminal writes = %q, want %q", got, tc.wantWrites)
@@ -1553,7 +2202,7 @@ func TestNotifyNewMessagesReconcilesQueuedSubmitAfterInboxDrain(t *testing.T) {
 	}
 }
 
-func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T) {
+func TestNotifyNewMessagesResumesCoopInputAfterPartialSubmitFailure(t *testing.T) {
 	tests := []struct {
 		name        string
 		mode        string
@@ -1564,13 +2213,13 @@ func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T
 			name:        "raw prelude",
 			mode:        wakeInjectModeRaw,
 			partialWant: coopWakeDoorbell + "|\n",
-			retryWant:   coopWakeDoorbell + "|\n|\r|\r",
+			retryWant:   "\n|\r|\r",
 		},
 		{
 			name:        "paste submit",
 			mode:        wakeInjectModePaste,
 			partialWant: coopWakeDoorbell + "|\r",
-			retryWant:   coopWakeDoorbell + "|\r",
+			retryWant:   "\r",
 		},
 	}
 
@@ -1615,7 +2264,10 @@ func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T
 			stubTIOCSTIInject(t, func(text string) error {
 				injected = append(injected, text)
 				if failSubmit && len(injected) == 2 {
-					return errors.New("submit stage failed")
+					return &wakeTestAcceptedProgressError{
+						err:      syscall.EIO,
+						accepted: 0,
+					}
 				}
 				return nil
 			})
@@ -1630,16 +2282,12 @@ func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T
 			}
 
 			writeMessage("first.md", "first")
-			stderr := captureWakeStderr(t, func() {
-				if err := notifyNewMessages(cfg); err != nil {
-					t.Fatalf("notify with partial %s failure: %v", tc.mode, err)
-				}
-			})
+			err := notifyNewMessages(cfg)
+			if !isWakeTerminalPartialProgress(err) {
+				t.Fatalf("notify with partial %s failure = %v, want retryable partial", tc.mode, err)
+			}
 			if got := strings.Join(injected, "|"); got != tc.partialWant {
 				t.Fatalf("partial %s injection = %q, want %q", tc.mode, got, tc.partialWant)
-			}
-			if !strings.Contains(stderr, "AMQ [session3]: message from peer") {
-				t.Fatalf("partial %s fallback missing output attention: %q", tc.mode, stderr)
 			}
 			if cfg.doorbell.phase != wakeDoorbellAwaitingObservation {
 				t.Fatalf("partial %s phase = %v, want awaiting observation", tc.mode, cfg.doorbell.phase)
@@ -1710,7 +2358,10 @@ func TestNotifyNewMessagesRetriesAfterRescueAuthorityError(t *testing.T) {
 		terminalWrite: func(text string) error {
 			injected = append(injected, text)
 			if failRescue && len(injected) == 4 {
-				return errors.New("foreground process group changed")
+				return &wakeTestAcceptedProgressError{
+					err:      errors.New("foreground process group changed"),
+					accepted: 0,
+				}
 			}
 			return nil
 		},
@@ -1718,9 +2369,8 @@ func TestNotifyNewMessagesRetriesAfterRescueAuthorityError(t *testing.T) {
 
 	writeMessage("first.md", "first")
 	err := notifyNewMessages(cfg)
-	var authorityErr *wakeTerminalAuthorityError
-	if !errors.As(err, &authorityErr) {
-		t.Fatalf("notify rescue error = %v, want wakeTerminalAuthorityError", err)
+	if !isWakeTerminalPartialProgress(err) {
+		t.Fatalf("notify rescue error = %v, want retryable partial progress", err)
 	}
 	if got := strings.Join(injected, "|"); got != coopWakeDoorbell+"|\n|\r|\r" {
 		t.Fatalf("raw injection before rescue error = %q, want submitted doorbell plus failed rescue", got)
@@ -1737,8 +2387,8 @@ func TestNotifyNewMessagesRetriesAfterRescueAuthorityError(t *testing.T) {
 			t.Fatalf("notify after rescue authority error: %v", err)
 		}
 	})
-	if len(injected) != 0 {
-		t.Fatalf("doorbell retried before deadline: %q", injected)
+	if got := strings.Join(injected, "|"); got != "\r" {
+		t.Fatalf("partial rescue retry = %q, want exact missing rescue CR", got)
 	}
 	if stderr != "" {
 		t.Fatalf("pending generation emitted output-only reminder: %q", stderr)
@@ -1748,11 +2398,12 @@ func TestNotifyNewMessagesRetriesAfterRescueAuthorityError(t *testing.T) {
 	if err := notifyNewMessages(cfg); err != nil {
 		t.Fatalf("retry after deadline: %v", err)
 	}
-	if got := strings.Join(injected, "|"); got != "\r" {
-		t.Fatalf("deadline retry = %q, want only the preserved rescue submit", got)
+	want := "\r|" + coopWakeDoorbell + "|\n|\r|\r"
+	if got := strings.Join(injected, "|"); got != want {
+		t.Fatalf("deadline retry = %q, want preserved rescue then one full retry %q", got, want)
 	}
-	if cfg.rawSubmitPhase != rawSubmitIdle {
-		t.Fatalf("raw submit phase = %v, want idle after rescue completion", cfg.rawSubmitPhase)
+	if cfg.inputDelivery.pending() {
+		t.Fatalf("input delivery = %#v, want idle after rescue completion", cfg.inputDelivery)
 	}
 }
 
@@ -1818,6 +2469,13 @@ func TestNotifyNewMessagesCustomInterruptUsesSanitizedOperatorPayloadForInputAnd
 		t.Fatalf("injected bytes = %q, want sanitized operator notice %q", got, safeNotice)
 	}
 	fail = true
+	path := filepath.Join(fsq.AgentInboxNew(root, "alice"), "msg-custom-interrupt.md")
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	stderr := captureWakeStderr(t, func() {
 		if err := notifyNewMessages(cfg); err != nil {
 			t.Fatalf("fallback notifyNewMessages: %v", err)

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -662,8 +662,12 @@ func TestInjectNotificationRawDrainsSettlesThenInjectsCRWithRescue(t *testing.T)
 	wantDrains := [][2]time.Duration{
 		{rawInjectDrainTimeout, rawInjectDrainPollInterval},
 		{rawInjectCRDrainTimeout, rawInjectDrainPollInterval},
+		{rawInjectCRDrainTimeout, rawInjectDrainPollInterval},
 	}
-	if len(drainCalls) != len(wantDrains) || drainCalls[0] != wantDrains[0] || drainCalls[1] != wantDrains[1] {
+	if len(drainCalls) != len(wantDrains) ||
+		drainCalls[0] != wantDrains[0] ||
+		drainCalls[1] != wantDrains[1] ||
+		drainCalls[2] != wantDrains[2] {
 		t.Fatalf("drain calls = %v, want %v", drainCalls, wantDrains)
 	}
 	if len(*slept) != 2 || (*slept)[0] != rawInjectSettleDelay || (*slept)[1] != rawInjectSettleDelay {
@@ -690,12 +694,18 @@ func TestInjectNotificationRawSkipsRescueCRWhenFirstCRStillQueued(t *testing.T) 
 	slept := stubRawInjectSleep(t)
 
 	cfg := &wakeConfig{injectMode: "raw", debug: true}
+	var submitted bool
 	stderr := captureWakeStderr(t, func() {
-		if err := injectNotification(cfg, "AMQ wake", true); err != nil {
-			t.Fatalf("injectNotification: %v", err)
+		var err error
+		submitted, err = injectRawNotification(cfg, "AMQ wake")
+		if err != nil {
+			t.Fatalf("injectRawNotification: %v", err)
 		}
 	})
 
+	if submitted {
+		t.Fatal("queued submit key reported as submitted")
+	}
 	if got := strings.Join(injected, "|"); got != "AMQ wake|\r" {
 		t.Fatalf("raw injection sequence = %q, want text then one CR", got)
 	}
@@ -732,12 +742,18 @@ func TestInjectNotificationRawSkipsRescueCROnTotalReaderStall(t *testing.T) {
 	slept := stubRawInjectSleep(t)
 
 	cfg := &wakeConfig{injectMode: "raw", debug: true}
+	var submitted bool
 	stderr := captureWakeStderr(t, func() {
-		if err := injectNotification(cfg, "AMQ wake", true); err != nil {
-			t.Fatalf("injectNotification: %v", err)
+		var err error
+		submitted, err = injectRawNotification(cfg, "AMQ wake")
+		if err != nil {
+			t.Fatalf("injectRawNotification: %v", err)
 		}
 	})
 
+	if submitted {
+		t.Fatal("stalled reader reported queued submit key as submitted")
+	}
 	if got := strings.Join(injected, "|"); got != "AMQ wake|\r" {
 		t.Fatalf("raw injection sequence = %q, want text then one CR", got)
 	}
@@ -749,6 +765,86 @@ func TestInjectNotificationRawSkipsRescueCROnTotalReaderStall(t *testing.T) {
 	}
 	if len(*slept) != 1 || (*slept)[0] != rawInjectSettleDelay {
 		t.Fatalf("settle sleeps = %v, want one of %s", *slept, rawInjectSettleDelay)
+	}
+}
+
+func TestInjectNotificationRawResumesQueuedSubmitWithoutRetyping(t *testing.T) {
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+	drainCall := 0
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		drainCall++
+		switch drainCall {
+		case 1:
+			return 5 * time.Millisecond, true, nil // notification text drained
+		case 2:
+			return timeout, false, nil // first submit remains queued
+		default:
+			return 5 * time.Millisecond, true, nil // reader resumed
+		}
+	})
+	stubRawInjectSleep(t)
+
+	cfg := &wakeConfig{injectMode: wakeInjectModeRaw}
+	submitted, err := injectRawNotification(cfg, "AMQ wake")
+	if err != nil {
+		t.Fatalf("initial injectRawNotification: %v", err)
+	}
+	if submitted {
+		t.Fatal("initial queued submit reported as submitted")
+	}
+
+	submitted, err = injectRawNotification(cfg, "AMQ wake")
+	if err != nil {
+		t.Fatalf("resumed injectRawNotification: %v", err)
+	}
+	if !submitted {
+		t.Fatal("drained rescue submit was not reported as submitted")
+	}
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\r|\r" {
+		t.Fatalf("raw injection sequence = %q, want text then queued CR then rescue CR", got)
+	}
+}
+
+func TestInjectNotificationRawStopsAfterQueuedRescueDrains(t *testing.T) {
+	var injected []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+	drainCall := 0
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		drainCall++
+		switch drainCall {
+		case 1:
+			return 5 * time.Millisecond, true, nil // notification text drained
+		case 2:
+			return timeout, false, nil // first submit remains queued
+		case 3:
+			return 5 * time.Millisecond, true, nil // first submit drained
+		case 4:
+			return timeout, false, nil // rescue remains queued
+		default:
+			return 5 * time.Millisecond, true, nil // rescue drained
+		}
+	})
+	stubRawInjectSleep(t)
+
+	cfg := &wakeConfig{injectMode: wakeInjectModeRaw}
+	for attempt := 1; attempt <= 3; attempt++ {
+		submitted, err := injectRawNotification(cfg, "AMQ wake")
+		if err != nil {
+			t.Fatalf("injectRawNotification attempt %d: %v", attempt, err)
+		}
+		if want := attempt == 3; submitted != want {
+			t.Fatalf("attempt %d submitted = %v, want %v", attempt, submitted, want)
+		}
+	}
+	if got := strings.Join(injected, "|"); got != "AMQ wake|\r|\r" {
+		t.Fatalf("raw injection sequence = %q, want at most the first and rescue CR", got)
 	}
 }
 
@@ -1069,7 +1165,7 @@ func TestNotifyNewMessagesNormalSuccessUsesFixedInputOnly(t *testing.T) {
 	}
 }
 
-func TestNotifyNewMessagesCoalescesCoopInputUntilAnnouncedBacklogDrains(t *testing.T) {
+func TestNotifyNewMessagesWaitsSilentlyUntilRetryOrProgress(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
@@ -1106,12 +1202,14 @@ func TestNotifyNewMessagesCoalescesCoopInputUntilAnnouncedBacklogDrains(t *testi
 	})
 	stubRawInjectSleep(t)
 	var injected []string
+	now := time.Unix(1_800_000_000, 0)
 	cfg := &wakeConfig{
 		me:             "codex",
 		root:           root,
 		session:        "session3",
 		wakeOwner:      &wakeOwner{},
 		injectMode:     wakeInjectModeRaw,
+		doorbellNow:    func() time.Time { return now },
 		attentionIsTTY: func() bool { return false },
 		terminalWrite: func(text string) error {
 			injected = append(injected, text)
@@ -1137,10 +1235,8 @@ func TestNotifyNewMessagesCoalescesCoopInputUntilAnnouncedBacklogDrains(t *testi
 	if len(injected) != 0 {
 		t.Fatalf("second pending message injected another user turn: %q", injected)
 	}
-	for _, want := range []string{"AMQ [session3]: 2 messages", "2 from peer"} {
-		if !strings.Contains(stderr, want) {
-			t.Fatalf("coalesced output %q missing %q", stderr, want)
-		}
+	if stderr != "" {
+		t.Fatalf("pending generation emitted output-only reminder: %q", stderr)
 	}
 
 	if drained := runDrainJSON(t, root, "codex", 1, false); drained.Count != 1 {
@@ -1164,12 +1260,12 @@ func TestNotifyNewMessagesCoalescesCoopInputUntilAnnouncedBacklogDrains(t *testi
 	if len(injected) != 0 {
 		t.Fatalf("re-armed backlog injected another user turn: %q", injected)
 	}
-	if !strings.Contains(stderr, "AMQ [session3]: 3 messages") {
-		t.Fatalf("re-armed coalesced output missing current count: %q", stderr)
+	if stderr != "" {
+		t.Fatalf("re-armed generation emitted output-only reminder: %q", stderr)
 	}
 }
 
-func TestNotifyNewMessagesCoalescesUrgentCoopInputToAttention(t *testing.T) {
+func TestNotifyNewMessagesDoesNotFloodAttentionForUrgentAddition(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
@@ -1239,10 +1335,8 @@ func TestNotifyNewMessagesCoalescesUrgentCoopInputToAttention(t *testing.T) {
 	if len(injected) != 0 {
 		t.Fatalf("urgent pending message injected another user turn: %q", injected)
 	}
-	for _, want := range []string{"AMQ interrupt [session3]", "urgent review"} {
-		if !strings.Contains(stderr, want) {
-			t.Fatalf("urgent coalesced output %q missing %q", stderr, want)
-		}
+	if stderr != "" {
+		t.Fatalf("urgent addition emitted periodic output attention: %q", stderr)
 	}
 }
 
@@ -1277,6 +1371,7 @@ func TestNotifyNewMessagesRetriesCoopInputAfterOutputOnlyFallback(t *testing.T) 
 	}
 
 	working, outputPath := injectViaCaptureConfig(t)
+	now := time.Unix(1_800_000_000, 0)
 	cfg := &wakeConfig{
 		me:             "codex",
 		root:           root,
@@ -1284,6 +1379,7 @@ func TestNotifyNewMessagesRetriesCoopInputAfterOutputOnlyFallback(t *testing.T) 
 		wakeOwner:      &wakeOwner{},
 		injectVia:      filepath.Join(root, "missing-injector"),
 		injectTimeout:  time.Second,
+		doorbellNow:    func() time.Time { return now },
 		attentionIsTTY: func() bool { return false },
 	}
 
@@ -1293,19 +1389,167 @@ func TestNotifyNewMessagesRetriesCoopInputAfterOutputOnlyFallback(t *testing.T) 
 			t.Fatalf("notify with unavailable input transport: %v", err)
 		}
 	})
-	if len(cfg.announcedPending) != 0 {
-		t.Fatalf("output-only fallback latched announced input: %#v", cfg.announcedPending)
+	if cfg.doorbell.phase != wakeDoorbellAwaitingObservation {
+		t.Fatalf("output-only fallback phase = %v, want awaiting observation", cfg.doorbell.phase)
 	}
 
 	cfg.injectVia = working.injectVia
 	cfg.injectArgs = working.injectArgs
 	cfg.injectTimeout = working.injectTimeout
+	now = now.Add(wakeDoorbellRetryBase)
 	writeMessage("second.md", "second")
 	if err := notifyNewMessages(cfg); err != nil {
 		t.Fatalf("retry after output-only fallback: %v", err)
 	}
 	if got, err := os.ReadFile(outputPath); err != nil || string(got) != coopWakeDoorbell {
 		t.Fatalf("retry injection = %q, err=%v; want fixed doorbell", got, err)
+	}
+}
+
+func TestNotifyNewMessagesDrainsStaleSubmitBeforeNewBatch(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	writeMessage := func(filename, id string) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      id,
+				From:    "peer",
+				To:      []string{"codex"},
+				Thread:  "p2p/codex__peer",
+				Subject: id,
+				Created: "2026-07-29T18:17:38Z",
+			},
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "codex", filename, data); err != nil {
+			t.Fatalf("deliver %s: %v", id, err)
+		}
+	}
+
+	drainCall := 0
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		drainCall++
+		if drainCall == 2 {
+			return timeout, false, nil // first message's submit remains queued
+		}
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+	var injected []string
+	tokens := []string{
+		"11111111111111111111111111111111",
+		"22222222222222222222222222222222",
+	}
+	cfg := &wakeConfig{
+		me:         "codex",
+		root:       root,
+		session:    "session3",
+		wakeOwner:  &wakeOwner{},
+		injectMode: wakeInjectModeRaw,
+		newDoorbellToken: func() (string, error) {
+			token := tokens[0]
+			tokens = tokens[1:]
+			return token, nil
+		},
+		attentionIsTTY: func() bool { return false },
+		terminalWrite: func(text string) error {
+			injected = append(injected, text)
+			return nil
+		},
+	}
+
+	writeMessage("first.md", "first")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify first message: %v", err)
+	}
+	if drained := runDrainJSON(t, root, "codex", 0, false); drained.Count != 1 {
+		t.Fatalf("drained count = %d, want 1", drained.Count)
+	}
+
+	injected = nil
+	writeMessage("second.md", "second")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify later message: %v", err)
+	}
+	want := "\r|" + buildCoopWakeDoorbell("22222222222222222222222222222222") + "|\n|\r|\r"
+	if got := strings.Join(injected, "|"); got != want {
+		t.Fatalf("later injection = %q, want old rescue before fresh fixed doorbell", got)
+	}
+}
+
+func TestNotifyNewMessagesReconcilesQueuedSubmitAfterInboxDrain(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		startPhase rawSubmitPhase
+		drained    bool
+		wantPhase  rawSubmitPhase
+		wantWrites string
+	}{
+		{
+			name:       "first submit consumed",
+			startPhase: rawFirstSubmitQueued,
+			drained:    true,
+			wantPhase:  rawSubmitIdle,
+			wantWrites: "\r",
+		},
+		{
+			name:       "first submit still stalled",
+			startPhase: rawFirstSubmitQueued,
+			drained:    false,
+			wantPhase:  rawFirstSubmitQueued,
+		},
+		{
+			name:       "rescue submit consumed",
+			startPhase: rawRescueSubmitQueued,
+			drained:    true,
+			wantPhase:  rawSubmitIdle,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatalf("EnsureRootDirs: %v", err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+			stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+				return 0, tc.drained, nil
+			})
+			stubRawInjectSleep(t)
+			var writes []string
+			cfg := &wakeConfig{
+				me:               "codex",
+				root:             root,
+				wakeOwner:        &wakeOwner{},
+				injectMode:       wakeInjectModeRaw,
+				rawSubmitPhase:   tc.startPhase,
+				rawSubmitPayload: coopWakeDoorbell,
+				terminalWrite: func(text string) error {
+					writes = append(writes, text)
+					return nil
+				},
+			}
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("notify empty inbox: %v", err)
+			}
+			if cfg.rawSubmitPhase != tc.wantPhase {
+				t.Fatalf("raw submit phase = %v, want %v", cfg.rawSubmitPhase, tc.wantPhase)
+			}
+			if got := strings.Join(writes, "|"); got != tc.wantWrites {
+				t.Fatalf("terminal writes = %q, want %q", got, tc.wantWrites)
+			}
+		})
 	}
 }
 
@@ -1367,6 +1611,7 @@ func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T
 			stubRawInjectSleep(t)
 			failSubmit := true
 			var injected []string
+			now := time.Unix(1_800_000_000, 0)
 			stubTIOCSTIInject(t, func(text string) error {
 				injected = append(injected, text)
 				if failSubmit && len(injected) == 2 {
@@ -1380,6 +1625,7 @@ func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T
 				session:        "session3",
 				wakeOwner:      &wakeOwner{},
 				injectMode:     tc.mode,
+				doorbellNow:    func() time.Time { return now },
 				attentionIsTTY: func() bool { return false },
 			}
 
@@ -1395,12 +1641,13 @@ func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T
 			if !strings.Contains(stderr, "AMQ [session3]: message from peer") {
 				t.Fatalf("partial %s fallback missing output attention: %q", tc.mode, stderr)
 			}
-			if len(cfg.announcedPending) != 0 {
-				t.Fatalf("partial %s failure latched announced input: %#v", tc.mode, cfg.announcedPending)
+			if cfg.doorbell.phase != wakeDoorbellAwaitingObservation {
+				t.Fatalf("partial %s phase = %v, want awaiting observation", tc.mode, cfg.doorbell.phase)
 			}
 
 			failSubmit = false
 			injected = nil
+			now = now.Add(wakeDoorbellRetryBase)
 			writeMessage("second.md", "second")
 			if err := notifyNewMessages(cfg); err != nil {
 				t.Fatalf("retry after partial %s failure: %v", tc.mode, err)
@@ -1408,14 +1655,14 @@ func TestNotifyNewMessagesRetriesCoopInputAfterPartialSubmitFailure(t *testing.T
 			if got := strings.Join(injected, "|"); got != tc.retryWant {
 				t.Fatalf("retry %s injection = %q, want %q", tc.mode, got, tc.retryWant)
 			}
-			if len(cfg.announcedPending) != 2 {
-				t.Fatalf("successful %s retry announced %d messages, want 2", tc.mode, len(cfg.announcedPending))
+			if len(cfg.doorbell.cohort) != 1 {
+				t.Fatalf("successful %s retry changed frozen cohort to %d messages, want 1", tc.mode, len(cfg.doorbell.cohort))
 			}
 		})
 	}
 }
 
-func TestNotifyNewMessagesLatchesRawSubmitBeforeRescueAuthorityError(t *testing.T) {
+func TestNotifyNewMessagesRetriesAfterRescueAuthorityError(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
@@ -1451,12 +1698,14 @@ func TestNotifyNewMessagesLatchesRawSubmitBeforeRescueAuthorityError(t *testing.
 	stubRawInjectSleep(t)
 	failRescue := true
 	var injected []string
+	now := time.Unix(1_800_000_000, 0)
 	cfg := &wakeConfig{
 		me:             "codex",
 		root:           root,
 		session:        "session3",
 		wakeOwner:      &wakeOwner{},
 		injectMode:     wakeInjectModeRaw,
+		doorbellNow:    func() time.Time { return now },
 		attentionIsTTY: func() bool { return false },
 		terminalWrite: func(text string) error {
 			injected = append(injected, text)
@@ -1476,8 +1725,8 @@ func TestNotifyNewMessagesLatchesRawSubmitBeforeRescueAuthorityError(t *testing.
 	if got := strings.Join(injected, "|"); got != coopWakeDoorbell+"|\n|\r|\r" {
 		t.Fatalf("raw injection before rescue error = %q, want submitted doorbell plus failed rescue", got)
 	}
-	if len(cfg.announcedPending) != 1 {
-		t.Fatalf("submitted doorbell announced %d pending messages after rescue error, want 1", len(cfg.announcedPending))
+	if len(cfg.doorbell.cohort) != 1 {
+		t.Fatalf("submitted doorbell cohort has %d pending messages after rescue error, want 1", len(cfg.doorbell.cohort))
 	}
 
 	failRescue = false
@@ -1489,12 +1738,21 @@ func TestNotifyNewMessagesLatchesRawSubmitBeforeRescueAuthorityError(t *testing.
 		}
 	})
 	if len(injected) != 0 {
-		t.Fatalf("pending submitted doorbell retried terminal input: %q", injected)
+		t.Fatalf("doorbell retried before deadline: %q", injected)
 	}
-	for _, want := range []string{"AMQ [session3]: 2 messages", "2 from peer"} {
-		if !strings.Contains(stderr, want) {
-			t.Fatalf("coalesced output %q missing %q", stderr, want)
-		}
+	if stderr != "" {
+		t.Fatalf("pending generation emitted output-only reminder: %q", stderr)
+	}
+
+	now = now.Add(wakeDoorbellRetryBase)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("retry after deadline: %v", err)
+	}
+	if got := strings.Join(injected, "|"); got != "\r" {
+		t.Fatalf("deadline retry = %q, want only the preserved rescue submit", got)
+	}
+	if cfg.rawSubmitPhase != rawSubmitIdle {
+		t.Fatalf("raw submit phase = %v, want idle after rescue completion", cfg.rawSubmitPhase)
 	}
 }
 

--- a/internal/cli/wake_tiocsti_unix.go
+++ b/internal/cli/wake_tiocsti_unix.go
@@ -42,6 +42,10 @@ func (err *tiocstiInjectionError) Unwrap() error {
 	return err.Err
 }
 
+func (err *tiocstiInjectionError) wakeAcceptedBytes() int {
+	return err.Progress
+}
+
 func tiocstiLegacyDisabledHint() bool {
 	data, err := readTIOCSTILegacySysctl()
 	return err == nil && strings.TrimSpace(string(data)) == "0"
@@ -108,7 +112,7 @@ func waitForTTYInputQuiet(cfg *wakeConfig) bool {
 	queueFD, err := unix.Open("/dev/tty", unix.O_RDONLY|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		if cfg.debug {
-			_ = writeStderr("amq wake [debug]: input deferral unavailable: open /dev/tty: %v\n", err)
+			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input deferral unavailable: open /dev/tty: %v\n", err)
 		}
 		return true
 	}
@@ -126,7 +130,7 @@ func waitForTTYInputQuiet(cfg *wakeConfig) bool {
 		atimeSource = "stdin"
 	}
 	if cfg.debug {
-		_ = writeStderr("amq wake [debug]: input deferral atime_source=%s\n", atimeSource)
+		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input deferral atime_source=%s\n", atimeSource)
 	}
 
 	allowInjection, activeReason, sampleErr := waitForInputQuiet(
@@ -136,7 +140,8 @@ func waitForTTYInputQuiet(cfg *wakeConfig) bool {
 		time.Now,
 		func(delay time.Duration, state ttyInputState, reason string) {
 			if cfg.debug {
-				_ = writeStderr(
+				_ = writeWakeDiagnostic(
+					cfg,
 					"amq wake [debug]: deferring injection for %s (%s, pending_bytes=%d)\n",
 					delay,
 					reason,
@@ -150,10 +155,10 @@ func waitForTTYInputQuiet(cfg *wakeConfig) bool {
 		cfg.inputPollInterval,
 	)
 	if sampleErr != nil && cfg.debug {
-		_ = writeStderr("amq wake [debug]: input deferral unavailable: %v\n", sampleErr)
+		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input deferral unavailable: %v\n", sampleErr)
 	}
 	if !allowInjection && cfg.debug {
-		_ = writeStderr("amq wake [debug]: input deferral max hold reached (%s)\n", activeReason)
+		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: input deferral max hold reached (%s)\n", activeReason)
 	}
 	return allowInjection
 }

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -28,6 +28,8 @@ var (
 	wakeBaselineTimeout             = 5 * time.Second
 	wakeBaselineSettle              = 50 * time.Millisecond
 	wakeTerminalAuthorityRetryDelay = 250 * time.Millisecond
+	wakeInboxScanRetryBase          = 250 * time.Millisecond
+	wakeInboxScanRetryMax           = 30 * time.Second
 	getWakeCurrentTTY               = getCurrentTTY
 	getWakeProcessSID               = unix.Getsid
 	wakeTIOCSTIAvailable            = func() bool { return tiocsti.Available() }
@@ -123,6 +125,10 @@ func childRepairSource(lineage *wakeRepairLineage) wakeRepairHandoffSource {
 }
 
 var startWakeFromTarget = startWakeFromTargetDefault
+var afterExistingWakeReadyPublication = func() {}
+var waitForWakeRepairChildExit = func(waiter *wakeProcessWaiter) error {
+	return waiter.waitForExit(wakeProcessExitTimeout)
+}
 
 // acquireWakeLock attempts to acquire the wake lock for an agent's inbox.
 // Returns cleanup function and error. If another wake is running, returns error.
@@ -131,19 +137,30 @@ func acquireWakeLock(root, me string, target *wakeTarget) (cleanup func(), err e
 }
 
 func acquireWakeLockWithOptions(root, me string, options wakeLockAcquireOptions) (cleanup func(), err error) {
-	agentDir, err := openWakeAgentDir(root, me)
+	agentDir, innerCleanup, err := acquireWakeLockWithOptionsRetained(root, me, options)
 	if err != nil {
-		return nil, err
-	}
-	innerCleanup, err := acquireWakeLockWithOptionsInDir(agentDir, root, me, options)
-	if err != nil {
-		_ = agentDir.Close()
 		return nil, err
 	}
 	return func() {
 		innerCleanup()
 		_ = agentDir.Close()
 	}, nil
+}
+
+func acquireWakeLockWithOptionsRetained(
+	root, me string,
+	options wakeLockAcquireOptions,
+) (agentDir *wakeAgentDir, cleanup func(), err error) {
+	agentDir, err = openWakeAgentDir(root, me)
+	if err != nil {
+		return nil, nil, err
+	}
+	innerCleanup, err := acquireWakeLockWithOptionsInDir(agentDir, root, me, options)
+	if err != nil {
+		_ = agentDir.Close()
+		return nil, nil, err
+	}
+	return agentDir, innerCleanup, nil
 }
 
 func supersedeUnverifiedGenericWakeAt(
@@ -192,7 +209,7 @@ func acquireWakeLockWithOptionsInDir(
 		return nil, fmt.Errorf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", me)
 	}
 	if options.target != nil && options.target.Owner != nil {
-		return acquireAuthoritativeWakeLockWithOptions(root, me, options)
+		return acquireAuthoritativeWakeLockWithOptionsInDir(agentDir, root, me, options)
 	}
 
 	for {
@@ -229,7 +246,11 @@ func acquireWakeLockWithOptionsInDir(
 					if err := validateWakeLockStaleRemoval(inspection); err != nil {
 						return err
 					}
-					if err := removeWakeLockIfUnchangedGuarded(inspection); err != nil {
+					if err := removeWakeLockIfUnchangedGuardedAt(
+						dirfd,
+						agentDir,
+						inspection,
+					); err != nil {
 						return err
 					}
 				case wakeLockCreating:
@@ -344,7 +365,10 @@ func acquireWakeLockWithOptionsInDir(
 			return nil, err
 		}
 		if replace.Exists {
-			if _, err := terminateAndRemoveOrphanedWakeLock(replace); err != nil {
+			if _, err := terminateAndRemoveOrphanedWakeLockInDir(
+				agentDir,
+				replace,
+			); err != nil {
 				return nil, err
 			}
 			continue
@@ -1142,21 +1166,21 @@ func cleanupFailedWakeRepairChild(
 		return nil
 	}
 	var cleanupErr error
-	if child.capabilityDetached {
-		// Once stable stop authority is detached, close the unreleased handoff
-		// first so the blocked child observes EOF before we wait for its exit.
-		cleanupErr = errors.Join(cleanupErr, child.Handoff.Close(), child.Capability.Close())
-		if child.Waiter != nil {
-			cleanupErr = errors.Join(cleanupErr, child.Waiter.waitForExit(wakeProcessExitTimeout))
-		}
-	} else {
-		if child.Capability != nil {
-			cleanupErr = errors.Join(cleanupErr, child.Capability.Stop())
-		}
-		if child.Waiter != nil {
-			cleanupErr = errors.Join(cleanupErr, child.Waiter.waitForExit(wakeProcessExitTimeout))
-		}
-		cleanupErr = errors.Join(cleanupErr, child.Handoff.Close(), child.Capability.Close())
+	if !child.capabilityDetached && child.Capability != nil {
+		cleanupErr = errors.Join(cleanupErr, child.Capability.Stop())
+	}
+	// Close the unreleased handoff before waiting so a child blocked on parent
+	// admission observes EOF and can terminate.
+	cleanupErr = errors.Join(cleanupErr, child.Handoff.Close(), child.Capability.Close())
+	if child.Waiter == nil {
+		return errors.Join(cleanupErr, errors.New("wake repair child exit waiter is missing"))
+	}
+	waitErr := waitForWakeRepairChildExit(child.Waiter)
+	cleanupErr = errors.Join(cleanupErr, waitErr)
+	if waitErr != nil {
+		// A stop request is not exit evidence. Preserve the exact lock and floor
+		// while the child may still be alive so no competing wake can take over.
+		return cleanupErr
 	}
 
 	if child.Process == nil || child.Process.Pid <= 0 {
@@ -1315,27 +1339,47 @@ func startWakeFromTargetDefault(
 }
 
 func openWakeRepairOutputInDir(agentDir *wakeAgentDir) (*os.File, error) {
+	return openWakeOutputInDir(
+		agentDir,
+		".wake.repair.log",
+		"repair wake log",
+	)
+}
+
+func openCoopWakeOutput(root, me string) (*os.File, error) {
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = agentDir.Close() }()
+	return openWakeOutputInDir(agentDir, ".wake.log", "wake log")
+}
+
+func openWakeOutputInDir(
+	agentDir *wakeAgentDir,
+	name, label string,
+) (*os.File, error) {
 	if agentDir == nil {
-		return nil, fmt.Errorf("wake repair agent directory capability is missing")
+		return nil, fmt.Errorf("%s agent directory capability is missing", label)
 	}
 	var file *os.File
 	err := agentDir.withFD(func(dirfd int) error {
 		fd, err := unix.Openat(
 			dirfd,
-			".wake.repair.log",
+			name,
 			unix.O_CREAT|unix.O_WRONLY|unix.O_APPEND|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
 			0o600,
 		)
 		if err != nil {
 			if err == unix.ELOOP {
-				return fmt.Errorf("repair wake log %s must not be a symlink", filepath.Join(agentDir.path, ".wake.repair.log"))
+				return fmt.Errorf("%s %s must not be a symlink", label, filepath.Join(agentDir.path, name))
 			}
 			if err == unix.ENXIO {
-				return fmt.Errorf("repair wake log %s must be a regular file", filepath.Join(agentDir.path, ".wake.repair.log"))
+				return fmt.Errorf("%s %s must be a regular file", label, filepath.Join(agentDir.path, name))
 			}
-			return fmt.Errorf("open repair wake log: %w", err)
+			return fmt.Errorf("open %s: %w", label, err)
 		}
-		file = os.NewFile(uintptr(fd), filepath.Join(agentDir.path, ".wake.repair.log"))
+		file = os.NewFile(uintptr(fd), filepath.Join(agentDir.path, name))
 		return nil
 	})
 	if err != nil {
@@ -1343,10 +1387,10 @@ func openWakeRepairOutputInDir(agentDir *wakeAgentDir) (*os.File, error) {
 	}
 	if info, err := file.Stat(); err != nil {
 		_ = file.Close()
-		return nil, fmt.Errorf("stat repair wake log: %w", err)
+		return nil, fmt.Errorf("stat %s: %w", label, err)
 	} else if !info.Mode().IsRegular() {
 		_ = file.Close()
-		return nil, fmt.Errorf("repair wake log %s must be a regular file", file.Name())
+		return nil, fmt.Errorf("%s %s must be a regular file", label, file.Name())
 	}
 	return file, nil
 }
@@ -1375,6 +1419,13 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		return err
 	}
 	defer cleanupPrivateStop()
+	attention, err := wakeAttentionFromEnv()
+	if err != nil {
+		return err
+	}
+	if attention != nil {
+		defer func() { _ = attention.Close() }()
+	}
 	repairHandoff, repairHandoffPresent, err := wakeRepairChildHandoffFromEnv()
 	if err != nil {
 		return err
@@ -1434,6 +1485,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		"  the TIOCSTI/stdin-TTY startup requirement. Fixed arguments use repeatable",
 		"  --inject-arg; AMQ appends the sanitized notification payload as the",
 		"  final argv element. The command is not run through a shell.",
+		"  Owner-bound co-op wakes retry after the prior command exits or times",
+		"  out; retries can repeat arbitrary injector-side effects. Standalone",
+		"  ownerless wakes execute the injector once per physical inbox cohort.",
 		"  Example: amq wake --me orchestrator --inject-via /path/to/ghostty-bridge \\",
 		"    --inject-arg exec --inject-arg \"$TERMINAL_ID\"",
 		"  Trust boundary: --inject-via executes local code, and the payload can",
@@ -1720,6 +1774,14 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			injectArgFlags = append(multiStringFlag(nil), persisted.InjectArgs...)
 		}
 	}
+	activeAgentDir := repairAgentDir
+	if activeAgentDir == nil {
+		activeAgentDir, err = openWakeAgentDir(root, me)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = activeAgentDir.Close() }()
+	}
 
 	// Acquire lock to prevent duplicate wake processes
 	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
@@ -1751,11 +1813,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		if repairLineage != nil {
 			options.repairFloorAuthority = &repairFloorAuthority
 		}
-		if repairAgentDir != nil {
-			cleanup, err = acquireWakeLockWithOptionsInDir(repairAgentDir, root, me, options)
-		} else {
-			cleanup, err = acquireWakeLockWithOptions(root, me, options)
-		}
+		cleanup, err = acquireWakeLockWithOptionsInDir(activeAgentDir, root, me, options)
 		if err == nil {
 			break
 		}
@@ -1775,22 +1833,39 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 				default:
 				}
 			}
-			if err := writeWakeReadyFileForPreparedWake(root, me, readyFile, alreadyRunning.Inspection, acceptExistingDeadline); err != nil {
+			publication, err := writeWakeReadyFileForPreparedWakeInDir(
+				activeAgentDir,
+				root,
+				me,
+				readyFile,
+				alreadyRunning.Inspection,
+				acceptExistingDeadline,
+			)
+			if err != nil {
 				return err
 			}
+			defer func() { _ = publication.Close() }()
+			cleanupReady := func(cause error) error {
+				return errors.Join(cause, publication.removeIfUnchanged())
+			}
+			afterExistingWakeReadyPublication()
 			if requestedOwner != nil {
-				ready, readyErr := validateWakeReadyFileAgainstOwner(
+				ready, readyErr := validateWakeReadyFileAgainstOwnerInDir(
+					activeAgentDir,
 					root,
 					me,
 					readyFile,
 					requestedOwner,
 				)
 				if readyErr != nil {
-					return readyErr
+					return cleanupReady(readyErr)
 				}
 				if !ready {
-					return fmt.Errorf("existing wake readiness disappeared before owner validation")
+					return cleanupReady(fmt.Errorf("existing wake readiness disappeared before owner validation"))
 				}
+			}
+			if err := validateCanonicalWakeAgentDir(activeAgentDir); err != nil {
+				return cleanupReady(err)
 			}
 			if *baselineExistingFlag {
 				_ = writeStderr("warning: reusing existing amq wake; this launch did not re-baseline it, so pending backlog may still notify\n")
@@ -1805,15 +1880,11 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		controlStop = mergeWakeStopChannels(controlStop, ownerObservation.Done())
 	}
 	var currentWake wakeLockInspection
-	if repairAgentDir != nil {
-		if err := repairAgentDir.withFD(func(dirfd int) error {
-			currentWake = inspectWakeLockAt(dirfd, repairAgentDir, root, me)
-			return nil
-		}); err != nil {
-			return err
-		}
-	} else {
-		currentWake = inspectWakeLock(root, me)
+	if err := activeAgentDir.withFD(func(dirfd int) error {
+		currentWake = inspectWakeLockAt(dirfd, activeAgentDir, root, me)
+		return nil
+	}); err != nil {
+		return err
 	}
 	promptObserved := make(chan string, 16)
 	if currentWake.Lock.ControlSocket != "" {
@@ -1821,15 +1892,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		var stop <-chan struct{}
 		var markStopped func()
 		var controlErr error
-		if repairAgentDir != nil {
-			controlCleanup, stop, markStopped, controlErr = startWakeControlListenerInDir(
-				repairAgentDir, root, me, currentWake.Lock, promptObserved,
-			)
-		} else {
-			controlCleanup, stop, markStopped, controlErr = startWakeControlListener(
-				root, me, currentWake.Lock, promptObserved,
-			)
-		}
+		controlCleanup, stop, markStopped, controlErr = startWakeControlListenerInDir(
+			activeAgentDir, root, me, currentWake.Lock, promptObserved,
+		)
 		if controlErr != nil {
 			return controlErr
 		}
@@ -1846,8 +1911,8 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		}
 	}
 
-	if err := presence.SetNotifierStatus(
-		root,
+	if err := setWakeNotifierStatusInDir(
+		activeAgentDir,
 		me,
 		initialNotifierStatus,
 		initialNotifierMode,
@@ -1901,8 +1966,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		promptObserved:     promptObserved,
 		baselineRequested:  *baselineExistingFlag || repairLineage != nil,
 		baselineInherited:  repairLineage != nil,
+		retainedAgent:      activeAgentDir,
 		recordNotifierStatus: func(status, mode, reason string) error {
-			return presence.SetNotifierStatus(root, me, status, mode, reason)
+			return setWakeNotifierStatusInDir(activeAgentDir, me, status, mode, reason)
 		},
 		onPrepared: func(watcher wakeAdmissionWatcher) error {
 			if repairLineage != nil {
@@ -2001,10 +2067,11 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 				}
 				return nil
 			}
-			if err := writeWakePreparedFile(root, me, currentWake); err != nil {
+			if err := writeWakePreparedFileInDir(activeAgentDir, root, me, currentWake); err != nil {
 				return err
 			}
-			return writeWakeReadyFileAgainstOwner(
+			return writeWakeReadyFileAgainstOwnerInDir(
+				activeAgentDir,
 				root,
 				me,
 				readyFile,
@@ -2012,6 +2079,12 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 				requestedOwner,
 			)
 		},
+	}
+	if attention != nil {
+		cfg.attentionWrite = attention.Write
+		cfg.attentionIsTTY = func() bool {
+			return wakeAttentionFileIsTerminal(attention)
+		}
 	}
 	if terminalAuthority != nil {
 		cfg.beforeTerminalWrite = terminalAuthority.BeforeWrite
@@ -2061,7 +2134,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			if err != nil {
 				return err
 			}
-			return writeWakeRepairFloor(root, me, floor)
+			return writeWakeRepairFloorInDir(activeAgentDir, root, floor)
 		}
 	}
 
@@ -2105,6 +2178,15 @@ func snapshotWakeExistingMessages(root, me string) (map[string]wakeFileIdentity,
 	return baseline, nil
 }
 
+func snapshotWakeExistingMessagesForConfig(
+	cfg *wakeConfig,
+) (map[string]wakeFileIdentity, error) {
+	if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
+		return retained.SnapshotMessageIdentities()
+	}
+	return snapshotWakeExistingMessages(cfg.root, cfg.me)
+}
+
 func invalidateWakeBaselineEvent(cfg *wakeConfig, event fsnotify.Event) {
 	if event.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Write|fsnotify.Remove) == 0 {
 		return
@@ -2138,25 +2220,49 @@ func prepareWakeBaselineEvents(
 		}
 		return nil
 	}
+	retained, retainedBaseline := cfg.retainedInbox.(*wakeInboxDir)
+	if retainedBaseline {
+		if err := retained.ValidateCanonical(); err != nil {
+			return fmt.Errorf("validate retained wake inbox before baseline snapshot: %w", err)
+		}
+	}
 	// Individual local-filesystem calls are intentionally not cancellable. Coop
 	// has an outer readiness timeout; standalone wake can wait on a stuck scan.
-	baseline, err := snapshotWakeExistingMessages(cfg.root, cfg.me)
+	baseline, err := snapshotWakeExistingMessagesForConfig(cfg)
 	if err != nil {
 		return fmt.Errorf("snapshot existing wake messages: %w", err)
 	}
+	if retainedBaseline {
+		if err := retained.ValidateCanonical(); err != nil {
+			return fmt.Errorf("validate retained wake inbox after baseline snapshot: %w", err)
+		}
+	}
 	cfg.baselineExisting = baseline
 
-	marker, err := os.CreateTemp(inboxNew, ".wake-baseline-barrier-")
-	if err != nil {
-		return fmt.Errorf("create wake baseline barrier: %w", err)
+	var markerName string
+	if retainedBaseline {
+		markerName, err = retained.CreateBaselineBarrier()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = retained.UnlinkBaselineBarrier(markerName) }()
+		if err := retained.ValidateCanonical(); err != nil {
+			return fmt.Errorf("validate retained wake inbox after baseline barrier: %w", err)
+		}
+	} else {
+		marker, createErr := os.CreateTemp(inboxNew, ".wake-baseline-barrier-")
+		if createErr != nil {
+			return fmt.Errorf("create wake baseline barrier: %w", createErr)
+		}
+		markerPath := marker.Name()
+		markerName = filepath.Base(markerPath)
+		if err := marker.Close(); err != nil {
+			_ = os.Remove(markerPath)
+			return fmt.Errorf("close wake baseline barrier: %w", err)
+		}
+		// A crash can leave this hidden marker behind; message scans ignore it.
+		defer func() { _ = os.Remove(markerPath) }()
 	}
-	markerPath := marker.Name()
-	if err := marker.Close(); err != nil {
-		_ = os.Remove(markerPath)
-		return fmt.Errorf("close wake baseline barrier: %w", err)
-	}
-	// A crash can leave this hidden marker behind; message scans ignore it.
-	defer func() { _ = os.Remove(markerPath) }()
 
 	timer := time.NewTimer(wakeBaselineTimeout)
 	defer timer.Stop()
@@ -2174,7 +2280,8 @@ func prepareWakeBaselineEvents(
 				return failWakeOnWatcherError(cfg, "watcher closed while preparing wake baseline", nil)
 			}
 			invalidateWakeBaselineEvent(cfg, event)
-			if filepath.Clean(event.Name) == filepath.Clean(markerPath) && event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
+			if filepath.Base(event.Name) == markerName &&
+				event.Op&(fsnotify.Create|fsnotify.Rename) != 0 {
 				if settleTimer == nil {
 					settleTimer = time.NewTimer(wakeBaselineSettle)
 				} else {
@@ -2198,6 +2305,11 @@ func prepareWakeBaselineEvents(
 		case <-timer.C:
 			return fmt.Errorf("wake baseline barrier was not observed within %s", wakeBaselineTimeout)
 		case <-settleC:
+			if retainedBaseline {
+				if err := retained.ValidateCanonical(); err != nil {
+					return fmt.Errorf("validate retained wake inbox before baseline completion: %w", err)
+				}
+			}
 			return nil
 		}
 	}
@@ -2245,7 +2357,7 @@ func validateWakeRepairChildAdmission(
 func parseInterruptKey(raw string) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(raw))
 	if normalized == "" {
-		normalized = "ctrl-c"
+		return "", fmt.Errorf("invalid interrupt-cmd %q (use ctrl-c or none)", raw)
 	}
 	switch normalized {
 	case "ctrl-c", "sigint":
@@ -2274,8 +2386,55 @@ func runWakeLoop(cfg wakeConfig) error {
 
 	inboxNew := fsq.AgentInboxNew(cfg.root, cfg.me)
 
+	ordinaryRecoverable := cfg.retainedInbox == nil
+	var ordinaryAgentDir *wakeAgentDir
+	ownsOrdinaryAgentDir := false
+	if retained, ok := cfg.retainedAgent.(*wakeAgentDir); ok {
+		ordinaryAgentDir = retained
+	}
+	var ordinaryInboxDir *wakeInboxDir
+	var startupBaselineWatcher wakeEventWatcher
 	var watcher wakeEventWatcher
-	if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
+	defer func() {
+		if startupBaselineWatcher != nil {
+			_ = startupBaselineWatcher.Close()
+		}
+		if watcher != nil {
+			_ = watcher.Close()
+		}
+		_ = ordinaryInboxDir.Close()
+		if ownsOrdinaryAgentDir && ordinaryAgentDir != nil {
+			_ = ordinaryAgentDir.Close()
+		}
+	}()
+	if ordinaryRecoverable {
+		if ordinaryAgentDir == nil {
+			// Direct loop tests and legacy in-process callers do not acquire the
+			// wake lock first. Provision only for those unowned invocations.
+			if err := os.MkdirAll(inboxNew, 0o700); err != nil {
+				return err
+			}
+			var err error
+			ordinaryAgentDir, err = openWakeAgentDir(cfg.root, cfg.me)
+			if err != nil {
+				return err
+			}
+			ownsOrdinaryAgentDir = true
+		} else if err := validateCanonicalWakeAgentDir(ordinaryAgentDir); err != nil {
+			return fmt.Errorf("validate acquired wake agent authority: %w", err)
+		}
+		var err error
+		ordinaryInboxDir, watcher, err = openWatchedWakeInboxDir(ordinaryAgentDir)
+		if err != nil {
+			return fmt.Errorf("failed to create ordinary wake inbox watcher: %w", err)
+		}
+		cfg.retainedInbox = ordinaryInboxDir
+		if cfg.touchPresence == nil {
+			cfg.touchPresence = func() error {
+				return touchWakePresenceInDir(ordinaryAgentDir, cfg.me)
+			}
+		}
+	} else if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
 		var err error
 		watcher, err = retained.NewWatcher()
 		if err != nil {
@@ -2295,12 +2454,56 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		watcher = &fsnotifyWakeEventWatcher{watcher: native}
 	}
-	defer func() { _ = watcher.Close() }()
+	if cfg.baselineRequested && !cfg.baselineInherited {
+		retained, ok := cfg.retainedInbox.(*wakeInboxDir)
+		if !ok {
+			return fmt.Errorf("wake baseline requires a retained inbox capability")
+		}
+		native, err := fsnotify.NewWatcher()
+		if err != nil {
+			return fmt.Errorf("failed to create startup baseline watcher: %w", err)
+		}
+		if err := native.Add(retained.path); err != nil {
+			_ = native.Close()
+			return fmt.Errorf("failed to watch retained startup baseline inbox: %w", err)
+		}
+		startupBaselineWatcher = &fsnotifyWakeEventWatcher{watcher: native}
+		if err := retained.ValidateCanonical(); err != nil {
+			_ = startupBaselineWatcher.Close()
+			startupBaselineWatcher = nil
+			return fmt.Errorf("validate startup baseline watcher authority: %w", err)
+		}
+	}
 
 	// The startup boundary is watcher installation, not lock acquisition;
 	// messages delivered in between are intentionally treated as startup backlog.
-	if err := prepareWakeBaselineEvents(&cfg, watcher.Events(), watcher.Errors(), inboxNew); err != nil {
+	baselineWatcher := watcher
+	if startupBaselineWatcher != nil {
+		baselineWatcher = startupBaselineWatcher
+	}
+	if err := prepareWakeBaselineEvents(
+		&cfg,
+		baselineWatcher.Events(),
+		baselineWatcher.Errors(),
+		inboxNew,
+	); err != nil {
 		return err
+	}
+	if startupBaselineWatcher != nil {
+		if err := startupBaselineWatcher.Close(); err != nil {
+			return fmt.Errorf("close startup baseline watcher: %w", err)
+		}
+		startupBaselineWatcher = nil
+	}
+	if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
+		if err := retained.ValidateCanonical(); err != nil {
+			return fmt.Errorf("validate wake inbox before admission publication: %w", err)
+		}
+	}
+	if ordinaryAgentDir != nil {
+		if err := validateCanonicalWakeAgentDir(ordinaryAgentDir); err != nil {
+			return fmt.Errorf("validate wake agent before admission publication: %w", err)
+		}
 	}
 	if cfg.onBaselineReady != nil {
 		if err := cfg.onBaselineReady(cloneWakeFileIdentities(cfg.baselineExisting)); err != nil {
@@ -2334,11 +2537,17 @@ func runWakeLoop(cfg wakeConfig) error {
 	pendingNotify := false
 	var terminalAuthorityRetryTimer *time.Timer
 	var terminalAuthorityRetryC <-chan time.Time
+	var inboxScanRetryTimer *time.Timer
+	var inboxScanRetryC <-chan time.Time
+	var inboxScanFailures uint
 	var doorbellTimer *time.Timer
 	var doorbellTimerC <-chan time.Time
 	defer func() {
 		if terminalAuthorityRetryTimer != nil {
 			terminalAuthorityRetryTimer.Stop()
+		}
+		if inboxScanRetryTimer != nil {
+			inboxScanRetryTimer.Stop()
 		}
 		if doorbellTimer != nil {
 			doorbellTimer.Stop()
@@ -2371,16 +2580,51 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		terminalAuthorityRetryC = terminalAuthorityRetryTimer.C
 	}
-	scheduleDoorbellDeadline := func() {
-		deadline, ok := cfg.doorbell.nextDeadline()
-		if !ok {
-			doorbellTimerC = nil
-			if doorbellTimer != nil && !doorbellTimer.Stop() {
+	clearInboxScanRetry := func() {
+		inboxScanRetryC = nil
+		if inboxScanRetryTimer == nil {
+			return
+		}
+		if !inboxScanRetryTimer.Stop() {
+			select {
+			case <-inboxScanRetryTimer.C:
+			default:
+			}
+		}
+	}
+	scheduleInboxScanRetry := func(delay time.Duration) {
+		if inboxScanRetryTimer == nil {
+			inboxScanRetryTimer = time.NewTimer(delay)
+		} else {
+			if !inboxScanRetryTimer.Stop() {
 				select {
-				case <-doorbellTimer.C:
+				case <-inboxScanRetryTimer.C:
 				default:
 				}
 			}
+			inboxScanRetryTimer.Reset(delay)
+		}
+		inboxScanRetryC = inboxScanRetryTimer.C
+	}
+	clearDoorbellDeadline := func() {
+		doorbellTimerC = nil
+		if doorbellTimer != nil && !doorbellTimer.Stop() {
+			select {
+			case <-doorbellTimer.C:
+			default:
+			}
+		}
+	}
+	scheduleDoorbellDeadline := func() {
+		if cfg.injectMode == wakeInjectModeNone ||
+			terminalAuthorityRetryC != nil ||
+			inboxScanRetryC != nil {
+			clearDoorbellDeadline()
+			return
+		}
+		deadline, ok := cfg.doorbell.nextDeadline()
+		if !ok {
+			clearDoorbellDeadline()
 			return
 		}
 		delay := deadline.Sub(cfg.wakeDoorbellNow())
@@ -2400,20 +2644,112 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		doorbellTimerC = doorbellTimer.C
 	}
+	var pendingPromptObservation string
+	commitPendingPromptObservation := func() {
+		if pendingPromptObservation == "" || cfg.inputDelivery.pending() {
+			return
+		}
+		token := pendingPromptObservation
+		pendingPromptObservation = ""
+		if cfg.doorbell.observe(token, cfg.wakeDoorbellNow()) {
+			scheduleDoorbellDeadline()
+		}
+	}
+	retryOrdinaryWatcher := func(context string, cause error) {
+		cfg.baselineExisting = nil
+		if watcher != nil {
+			_ = watcher.Close()
+			watcher = nil
+		}
+		_ = ordinaryInboxDir.Close()
+		ordinaryInboxDir = nil
+		cfg.retainedInbox = nil
+		pendingNotify = true
+		clearTerminalAuthorityRetry()
+		inboxScanFailures++
+		scheduleInboxScanRetry(wakeInboxScanRetryBackoff(inboxScanFailures))
+		clearDoorbellDeadline()
+		if cause == nil {
+			_ = writeWakeDiagnostic(&cfg, "amq wake: %s; retrying watcher setup\n", context)
+			return
+		}
+		_ = writeWakeDiagnostic(&cfg, "amq wake: %s: %v; retrying watcher setup\n", context, cause)
+	}
+	rebindOrdinaryWatcher := func() (bool, error) {
+		if !ordinaryRecoverable || watcher != nil {
+			return true, nil
+		}
+		if err := validateCanonicalWakeAgentDir(ordinaryAgentDir); err != nil {
+			return false, failWakeOnWatcherError(
+				&cfg,
+				"ordinary wake agent authority changed while rearming watcher",
+				err,
+			)
+		}
+		inboxDir, nextWatcher, err := openWatchedWakeInboxDir(ordinaryAgentDir)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return false, failWakeOnWatcherError(
+					&cfg,
+					"failed to rearm ordinary wake inbox watcher",
+					err,
+				)
+			}
+			pendingNotify = true
+			inboxScanFailures++
+			scheduleInboxScanRetry(wakeInboxScanRetryBackoff(inboxScanFailures))
+			clearDoorbellDeadline()
+			_ = writeWakeDiagnostic(
+				&cfg,
+				"amq wake: ordinary wake inbox is unavailable while rearming watcher: %v\n",
+				err,
+			)
+			return false, nil
+		}
+		ordinaryInboxDir = inboxDir
+		watcher = nextWatcher
+		cfg.retainedInbox = inboxDir
+		return true, nil
+	}
 	attemptNotification := func() error {
-		err := notifyNewMessages(&cfg)
-		scheduleDoorbellDeadline()
-		if err == nil {
-			pendingNotify = false
-			clearTerminalAuthorityRetry()
+		defer commitPendingPromptObservation()
+		if terminalAuthorityRetryC != nil || inboxScanRetryC != nil {
 			return nil
 		}
+		err := notifyNewMessages(&cfg)
+		var scanErr *wakeInboxScanError
+		if errors.As(err, &scanErr) {
+			pendingNotify = true
+			clearTerminalAuthorityRetry()
+			inboxScanFailures++
+			scheduleInboxScanRetry(wakeInboxScanRetryBackoff(inboxScanFailures))
+			clearDoorbellDeadline()
+			_ = writeWakeDiagnostic(&cfg, "amq wake: notify error: %v\n", err)
+			return nil
+		}
+		clearInboxScanRetry()
+		inboxScanFailures = 0
 		if isWakeTerminalForegroundPGRPChanged(err) {
 			pendingNotify = true
 			scheduleTerminalAuthorityRetry()
+			clearDoorbellDeadline()
 			if cfg.debug {
-				_ = writeStderr(
+				_ = writeWakeDiagnostic(
+					&cfg,
 					"amq wake [debug]: holding notification until foreground process group is restored: %v\n",
+					err,
+				)
+			}
+			return nil
+		}
+		if isWakeTerminalPartialProgress(err) {
+			pendingNotify = true
+			scheduleTerminalAuthorityRetry()
+			clearDoorbellDeadline()
+			if cfg.debug {
+				_ = writeWakeDiagnostic(
+					&cfg,
+					"amq wake [debug]: holding partial terminal delivery for exact suffix retry: %v\n",
 					err,
 				)
 			}
@@ -2421,11 +2757,23 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		pendingNotify = false
 		clearTerminalAuthorityRetry()
+		scheduleDoorbellDeadline()
+		if err == nil {
+			return nil
+		}
 		if isWakeTerminalAuthorityLoss(err) {
 			return err
 		}
-		_ = writeStderr("amq wake: notify error: %v\n", err)
+		_ = writeWakeDiagnostic(&cfg, "amq wake: notify error: %v\n", err)
 		return nil
+	}
+	emitFatalScanFallback := func() {
+		emitWakeAttention(&cfg, wakePayload{
+			text:       "AMQ messages may be pending; run amq drain --include-body",
+			provenance: wakePayloadSystemFixed,
+		})
+		pendingNotify = false
+		clearInboxScanRetry()
 	}
 
 	// Recheck non-invasive injection preconditions and silently reconcile
@@ -2462,6 +2810,12 @@ func runWakeLoop(cfg wakeConfig) error {
 		if debounceTimer != nil {
 			debounceC = debounceTimer.C
 		}
+		var watcherEvents <-chan fsnotify.Event
+		var watcherErrors <-chan error
+		if watcher != nil {
+			watcherEvents = watcher.Events()
+			watcherErrors = watcher.Errors()
+		}
 
 		select {
 		case <-cfg.controlStop:
@@ -2470,8 +2824,12 @@ func runWakeLoop(cfg wakeConfig) error {
 			// Clean exit on SIGHUP/SIGTERM
 			return nil
 
-		case event, ok := <-watcher.Events():
+		case event, ok := <-watcherEvents:
 			if !ok {
+				if ordinaryRecoverable {
+					retryOrdinaryWatcher("ordinary wake inbox watcher closed", nil)
+					continue
+				}
 				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
 			}
 			invalidateWakeBaselineEvent(&cfg, event)
@@ -2488,6 +2846,9 @@ func runWakeLoop(cfg wakeConfig) error {
 
 			// Start or reset debounce timer
 			pendingNotify = true
+			if cfg.onPendingNotify != nil {
+				cfg.onPendingNotify()
+			}
 			if debounceTimer == nil {
 				debounceTimer = time.NewTimer(cfg.debounce)
 			} else {
@@ -2500,9 +2861,17 @@ func runWakeLoop(cfg wakeConfig) error {
 			}
 			debounceTimer.Reset(cfg.debounce)
 
-		case err, ok := <-watcher.Errors():
+		case err, ok := <-watcherErrors:
 			if !ok {
+				if ordinaryRecoverable {
+					retryOrdinaryWatcher("ordinary wake inbox watcher closed", nil)
+					continue
+				}
 				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
+			}
+			if ordinaryRecoverable {
+				retryOrdinaryWatcher("ordinary wake inbox watcher failed", err)
+				continue
 			}
 			return failWakeOnWatcherError(&cfg, "amq wake: watcher error", err)
 
@@ -2525,6 +2894,19 @@ func runWakeLoop(cfg wakeConfig) error {
 				return err
 			}
 
+		case <-inboxScanRetryC:
+			inboxScanRetryC = nil
+			rebound, err := rebindOrdinaryWatcher()
+			if err != nil {
+				return err
+			}
+			if !rebound {
+				continue
+			}
+			if err := attemptNotification(); err != nil {
+				return err
+			}
+
 		case <-doorbellTimerC:
 			doorbellTimerC = nil
 			if err := attemptNotification(); err != nil {
@@ -2532,13 +2914,22 @@ func runWakeLoop(cfg wakeConfig) error {
 			}
 
 		case token := <-cfg.promptObserved:
+			if cfg.inputDelivery.pending() {
+				if cfg.doorbell.phase == wakeDoorbellAwaitingObservation &&
+					!cfg.doorbell.observationUsed &&
+					token == cfg.doorbell.token {
+					pendingPromptObservation = token
+				}
+				continue
+			}
 			if cfg.doorbell.observe(token, cfg.wakeDoorbellNow()) {
-				clearRawSubmitState(&cfg)
 				scheduleDoorbellDeadline()
 			}
 
 		case <-maintenanceTicks:
-			if cfg.doorbell.phase != wakeDoorbellIdle || cfg.rawSubmitPhase != rawSubmitIdle {
+			pendingInputWork := cfg.doorbell.pendingInput() || cfg.inputDelivery.pending()
+			hadPendingInputWork := pendingNotify || pendingInputWork
+			if pendingInputWork {
 				if err := attemptNotification(); err != nil {
 					return err
 				}
@@ -2551,11 +2942,41 @@ func runWakeLoop(cfg wakeConfig) error {
 				_ = presence.Touch(cfg.root, cfg.me)
 			}
 
-			if err := preconditionCheck(&cfg); err != nil {
-				return err
+			inputEnabledBeforeCheck := cfg.injectMode != wakeInjectModeNone
+			preconditionErr := preconditionCheck(&cfg)
+			if cfg.injectMode == wakeInjectModeNone {
+				if inputEnabledBeforeCheck {
+					retireWakeInputState(&cfg)
+				} else {
+					clearWakeInputState(&cfg)
+				}
+				clearTerminalAuthorityRetry()
+				if inputEnabledBeforeCheck && hadPendingInputWork {
+					pendingNotify = true
+					if preconditionErr != nil && inboxScanRetryC != nil {
+						emitFatalScanFallback()
+					} else {
+						if err := attemptNotification(); err != nil {
+							return err
+						}
+						if preconditionErr != nil && pendingNotify && inboxScanRetryC != nil {
+							emitFatalScanFallback()
+						}
+					}
+				} else if inputEnabledBeforeCheck {
+					pendingNotify = false
+				}
+			}
+			scheduleDoorbellDeadline()
+			if preconditionErr != nil {
+				return preconditionErr
 			}
 		}
 	}
+}
+
+func wakeInboxScanRetryBackoff(failures uint) time.Duration {
+	return cappedExponentialBackoff(failures, wakeInboxScanRetryBase, wakeInboxScanRetryMax)
 }
 
 func wakeInjectionPreconditionCheck(
@@ -2581,7 +3002,7 @@ func wakeInjectionPreconditionCheck(
 			mode,
 			fmt.Errorf("%s is 0 (observed after wake binding)", tiocstiLegacySysctlPath),
 		)
-		cfg.injectMode = wakeInjectModeNone
+		disableWakeInput(cfg)
 		cfg.fallbackWarn = false
 		if cfg.recordNotifierStatus != nil {
 			if err := cfg.recordNotifierStatus(
@@ -2595,7 +3016,7 @@ func wakeInjectionPreconditionCheck(
 				)
 			}
 		}
-		_ = writeStderr("amq wake: warning: injector capability changed since binding: %s\n", reason)
+		_ = writeWakeDiagnostic(cfg, "amq wake: warning: injector capability changed since binding: %s\n", reason)
 		return nil
 	}
 	if !controllingTerminalOpenableFn() {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -496,6 +496,10 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 			lock.OwnerSchema = wakeOwnerLockSchema
 			lock.Owner = &owner
 		}
+	} else if lock.WakeMode == wakeInjectModeRaw || lock.WakeMode == wakeInjectModePaste {
+		// Raw/paste wakes expose a narrow prompt-observation endpoint. It
+		// cannot stop, drain, or mutate mailbox state.
+		lock.ControlSocket = wakeControlSocketPath(root, me, lock.Generation)
 	}
 	if options.repairLineage != nil {
 		lock.SourceGeneration = options.repairLineage.source.DeadGeneration
@@ -1800,43 +1804,6 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	if requestedOwner != nil {
 		controlStop = mergeWakeStopChannels(controlStop, ownerObservation.Done())
 	}
-	if injectVia != "" {
-		var current wakeLockInspection
-		if repairAgentDir != nil {
-			if err := repairAgentDir.withFD(func(dirfd int) error {
-				current = inspectWakeLockAt(dirfd, repairAgentDir, root, me)
-				return nil
-			}); err != nil {
-				return err
-			}
-		} else {
-			current = inspectWakeLock(root, me)
-		}
-		var controlCleanup func()
-		var stop <-chan struct{}
-		var markStopped func()
-		var controlErr error
-		if repairAgentDir != nil {
-			controlCleanup, stop, markStopped, controlErr = startWakeControlListenerInDir(
-				repairAgentDir, root, me, current.Lock,
-			)
-		} else {
-			controlCleanup, stop, markStopped, controlErr = startWakeControlListener(root, me, current.Lock)
-		}
-		if controlErr != nil {
-			return controlErr
-		}
-		defer controlCleanup()
-		defer markStopped()
-		controlStop = mergeWakeStopChannels(controlStop, stop)
-	}
-
-	if injectVia != "" {
-		if err := validateResolvedWakeInjectViaPath(injectVia); err != nil {
-			return err
-		}
-	}
-
 	var currentWake wakeLockInspection
 	if repairAgentDir != nil {
 		if err := repairAgentDir.withFD(func(dirfd int) error {
@@ -1848,6 +1815,37 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	} else {
 		currentWake = inspectWakeLock(root, me)
 	}
+	promptObserved := make(chan string, 16)
+	if currentWake.Lock.ControlSocket != "" {
+		var controlCleanup func()
+		var stop <-chan struct{}
+		var markStopped func()
+		var controlErr error
+		if repairAgentDir != nil {
+			controlCleanup, stop, markStopped, controlErr = startWakeControlListenerInDir(
+				repairAgentDir, root, me, currentWake.Lock, promptObserved,
+			)
+		} else {
+			controlCleanup, stop, markStopped, controlErr = startWakeControlListener(
+				root, me, currentWake.Lock, promptObserved,
+			)
+		}
+		if controlErr != nil {
+			return controlErr
+		}
+		defer controlCleanup()
+		defer markStopped()
+		if stop != nil {
+			controlStop = mergeWakeStopChannels(controlStop, stop)
+		}
+	}
+
+	if injectVia != "" {
+		if err := validateResolvedWakeInjectViaPath(injectVia); err != nil {
+			return err
+		}
+	}
+
 	if err := presence.SetNotifierStatus(
 		root,
 		me,
@@ -1900,6 +1898,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		controlStop:        controlStop,
 		terminalGeneration: currentWake.Lock.Generation,
 		terminalTTY:        currentWake.Lock.TTY,
+		promptObserved:     promptObserved,
 		baselineRequested:  *baselineExistingFlag || repairLineage != nil,
 		baselineInherited:  repairLineage != nil,
 		recordNotifierStatus: func(status, mode, reason string) error {
@@ -2335,9 +2334,14 @@ func runWakeLoop(cfg wakeConfig) error {
 	pendingNotify := false
 	var terminalAuthorityRetryTimer *time.Timer
 	var terminalAuthorityRetryC <-chan time.Time
+	var doorbellTimer *time.Timer
+	var doorbellTimerC <-chan time.Time
 	defer func() {
 		if terminalAuthorityRetryTimer != nil {
 			terminalAuthorityRetryTimer.Stop()
+		}
+		if doorbellTimer != nil {
+			doorbellTimer.Stop()
 		}
 	}()
 
@@ -2367,8 +2371,38 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		terminalAuthorityRetryC = terminalAuthorityRetryTimer.C
 	}
+	scheduleDoorbellDeadline := func() {
+		deadline, ok := cfg.doorbell.nextDeadline()
+		if !ok {
+			doorbellTimerC = nil
+			if doorbellTimer != nil && !doorbellTimer.Stop() {
+				select {
+				case <-doorbellTimer.C:
+				default:
+				}
+			}
+			return
+		}
+		delay := deadline.Sub(cfg.wakeDoorbellNow())
+		if delay < 0 {
+			delay = 0
+		}
+		if doorbellTimer == nil {
+			doorbellTimer = time.NewTimer(delay)
+		} else {
+			if !doorbellTimer.Stop() {
+				select {
+				case <-doorbellTimer.C:
+				default:
+				}
+			}
+			doorbellTimer.Reset(delay)
+		}
+		doorbellTimerC = doorbellTimer.C
+	}
 	attemptNotification := func() error {
 		err := notifyNewMessages(&cfg)
+		scheduleDoorbellDeadline()
 		if err == nil {
 			pendingNotify = false
 			clearTerminalAuthorityRetry()
@@ -2394,9 +2428,9 @@ func runWakeLoop(cfg wakeConfig) error {
 		return nil
 	}
 
-	// Recheck non-invasive injection preconditions and re-announce durable
-	// pending work every 30s. Re-announcement stays output-only while an
-	// announced inbox identity remains pending, so it cannot stack user turns.
+	// Recheck non-invasive injection preconditions and silently reconcile
+	// durable pending work every 30s. Doorbell retries use finite generation
+	// deadlines and never emit periodic alternate-screen output.
 	maintenanceTicks := cfg.maintenanceTicks
 	var maintenanceTicker *time.Ticker
 	if maintenanceTicks == nil {
@@ -2441,8 +2475,10 @@ func runWakeLoop(cfg wakeConfig) error {
 				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
 			}
 			invalidateWakeBaselineEvent(&cfg, event)
-			// Only care about new files
-			if event.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Write) == 0 {
+			// Creates/additions can accelerate delivery; removals are durable
+			// progress and must rearm the generation without waiting for the
+			// maintenance reconciliation fallback.
+			if event.Op&(fsnotify.Create|fsnotify.Rename|fsnotify.Write|fsnotify.Remove) == 0 {
 				continue
 			}
 			// Skip non-.md files
@@ -2489,8 +2525,20 @@ func runWakeLoop(cfg wakeConfig) error {
 				return err
 			}
 
+		case <-doorbellTimerC:
+			doorbellTimerC = nil
+			if err := attemptNotification(); err != nil {
+				return err
+			}
+
+		case token := <-cfg.promptObserved:
+			if cfg.doorbell.observe(token, cfg.wakeDoorbellNow()) {
+				clearRawSubmitState(&cfg)
+				scheduleDoorbellDeadline()
+			}
+
 		case <-maintenanceTicks:
-			if len(cfg.announcedPending) > 0 {
+			if cfg.doorbell.phase != wakeDoorbellIdle || cfg.rawSubmitPhase != rawSubmitIdle {
 				if err := attemptNotification(); err != nil {
 					return err
 				}

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -578,7 +579,7 @@ func TestRunWakeLoopStopsBeforePublishingPreparedMarker(t *testing.T) {
 	}
 }
 
-func TestRunWakeLoopReannouncesPendingDoorbellWithoutStackingInput(t *testing.T) {
+func TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	message := format.Message{
@@ -608,20 +609,18 @@ func TestRunWakeLoopReannouncesPendingDoorbellWithoutStackingInput(t *testing.T)
 	firstDoorbell := make(chan struct{}, 1)
 	extraDoorbell := make(chan struct{}, 1)
 	attention := make(chan string, 1)
-	ticks := make(chan time.Time)
 	stop := make(chan struct{})
 	done := make(chan error, 1)
 	doorbells := 0
 
 	go func() {
 		done <- runWakeLoop(wakeConfig{
-			root:             root,
-			me:               "codex",
-			session:          "session1",
-			wakeOwner:        &wakeOwner{},
-			injectMode:       wakeInjectModeRaw,
-			controlStop:      stop,
-			maintenanceTicks: ticks,
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			wakeOwner:   &wakeOwner{},
+			injectMode:  wakeInjectModeRaw,
+			controlStop: stop,
 			preconditionCheck: func(*wakeConfig) error {
 				return nil
 			},
@@ -652,19 +651,12 @@ func TestRunWakeLoopReannouncesPendingDoorbellWithoutStackingInput(t *testing.T)
 		t.Fatal("wake loop did not submit initial doorbell")
 	}
 
-	// Model the operator clearing the TUI composer/queue: AMQ has no positive
-	// acknowledgement for that UI state, while the durable inbox item remains.
-	ticks <- time.Now()
 	select {
-	case output := <-attention:
-		if !strings.Contains(output, "AMQ [session1]: message from claude") ||
-			!strings.Contains(output, "amq drain --include-body") {
-			t.Fatalf("re-announcement = %q", output)
-		}
+	case <-extraDoorbell:
 	case err := <-done:
-		t.Fatalf("wake loop exited before re-announcement: %v", err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("pending doorbell was not re-announced")
+		t.Fatalf("wake loop exited before retry: %v", err)
+	case <-time.After(wakeDoorbellRetryBase + 2*time.Second):
+		t.Fatal("pending doorbell was not retried on its own deadline")
 	}
 	close(stop)
 	select {
@@ -676,8 +668,122 @@ func TestRunWakeLoopReannouncesPendingDoorbellWithoutStackingInput(t *testing.T)
 		t.Fatal("wake loop did not stop")
 	}
 	select {
-	case <-extraDoorbell:
-		t.Fatal("re-announcement stacked another synthetic input turn")
+	case output := <-attention:
+		t.Fatalf("retry emitted output-only attention: %q", output)
+	default:
+	}
+}
+
+func TestRunWakeLoopResumesQueuedSubmitWithoutRetypingDoorbell(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "queued-submit",
+			From:    "claude",
+			To:      []string{"codex"},
+			Thread:  "p2p/claude__codex",
+			Subject: "queued while codex is busy",
+			Created: "2026-07-29T18:17:38Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "queued-submit.md", data); err != nil {
+		t.Fatal(err)
+	}
+
+	var readerStalled atomic.Bool
+	readerStalled.Store(true)
+	stubRawInputDrained(t, func(timeout time.Duration, pollInterval time.Duration) (time.Duration, bool, error) {
+		if timeout == rawInjectDrainTimeout {
+			return 0, true, nil
+		}
+		return timeout, !readerStalled.Load(), nil
+	})
+	stubRawInjectSleep(t)
+	writes := make(chan string, 8)
+	ticks := make(chan time.Time)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	var nowNanos atomic.Int64
+	nowNanos.Store(time.Unix(1_800_000_000, 0).UnixNano())
+
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			session:          "session1",
+			wakeOwner:        &wakeOwner{},
+			injectMode:       wakeInjectModeRaw,
+			controlStop:      stop,
+			maintenanceTicks: ticks,
+			doorbellNow: func() time.Time {
+				return time.Unix(0, nowNanos.Load())
+			},
+			preconditionCheck: func(*wakeConfig) error {
+				return nil
+			},
+			terminalWrite: func(text string) error {
+				writes <- text
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+		})
+	}()
+
+	for _, want := range []string{coopWakeDoorbell, "\n", "\r"} {
+		select {
+		case got := <-writes:
+			if got != want {
+				t.Fatalf("initial write = %q, want %q", got, want)
+			}
+		case err := <-done:
+			t.Fatalf("wake loop exited during initial doorbell: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("wake loop did not write %q", want)
+		}
+	}
+
+	ticks <- time.Now()
+	select {
+	case got := <-writes:
+		t.Fatalf("stalled maintenance stacked terminal input %q", got)
+	case err := <-done:
+		t.Fatalf("wake loop exited while reader stalled: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	readerStalled.Store(false)
+	nowNanos.Add(int64(wakeDoorbellRetryBase))
+	ticks <- time.Now()
+	select {
+	case got := <-writes:
+		if got != "\r" {
+			t.Fatalf("resumed write = %q, want only rescue CR", got)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before reader resumed: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not resume queued submit")
+	}
+
+	close(stop)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop")
+	}
+	select {
+	case got := <-writes:
+		t.Fatalf("resumed submission retyped extra input %q", got)
 	default:
 	}
 }

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -22,6 +22,465 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+type wakeScriptedInboxReader struct {
+	readDir    func() ([]os.DirEntry, error)
+	readHeader func(string) (format.Header, error)
+}
+
+func (reader wakeScriptedInboxReader) ReadDir() ([]os.DirEntry, error) {
+	return reader.readDir()
+}
+
+func (reader wakeScriptedInboxReader) ReadHeader(name string) (format.Header, error) {
+	if reader.readHeader == nil {
+		return format.Header{}, os.ErrNotExist
+	}
+	return reader.readHeader(name)
+}
+
+func awaitWakeScan(t *testing.T, scans <-chan time.Time, done <-chan error) time.Time {
+	t.Helper()
+	select {
+	case at := <-scans:
+		return at
+	case err := <-done:
+		t.Fatalf("wake loop exited before inbox scan: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("wake loop did not scan inbox")
+	}
+	return time.Time{}
+}
+
+func deliverPartialWakeMessageForTest(t *testing.T, root, me, id string) {
+	t.Helper()
+	ensureCoopWakeMailboxForTest(t, root, me)
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      id,
+			From:    "peer",
+			To:      []string{me},
+			Thread:  "p2p/peer__" + me,
+			Subject: id,
+			Created: "2026-07-30T08:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, me, id+".md", data); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNotifyNewMessagesForegroundPGRPResumesAtFirstMissingChunk(t *testing.T) {
+	tests := []struct {
+		name      string
+		me        string
+		mode      string
+		failAt    int
+		firstWant []string
+		retryWant []string
+	}{
+		{
+			name:      "paste payload",
+			me:        "grok",
+			mode:      wakeInjectModePaste,
+			failAt:    1,
+			firstWant: nil,
+			retryWant: []string{coopWakeDoorbell, "\r"},
+		},
+		{
+			name:      "paste submit",
+			me:        "grok",
+			mode:      wakeInjectModePaste,
+			failAt:    2,
+			firstWant: []string{coopWakeDoorbell},
+			retryWant: []string{"\r"},
+		},
+		{
+			name:      "raw codex payload",
+			me:        "codex",
+			mode:      wakeInjectModeRaw,
+			failAt:    1,
+			firstWant: nil,
+			retryWant: []string{coopWakeDoorbell, "\n", "\r", "\r"},
+		},
+		{
+			name:      "raw codex prelude",
+			me:        "codex",
+			mode:      wakeInjectModeRaw,
+			failAt:    2,
+			firstWant: []string{coopWakeDoorbell},
+			retryWant: []string{"\n", "\r", "\r"},
+		},
+		{
+			name:      "raw codex first submit",
+			me:        "codex",
+			mode:      wakeInjectModeRaw,
+			failAt:    3,
+			firstWant: []string{coopWakeDoorbell, "\n"},
+			retryWant: []string{"\r", "\r"},
+		},
+		{
+			name:      "raw codex rescue submit",
+			me:        "codex",
+			mode:      wakeInjectModeRaw,
+			failAt:    4,
+			firstWant: []string{coopWakeDoorbell, "\n", "\r"},
+			retryWant: []string{"\r"},
+		},
+		{
+			name:      "raw claude first submit",
+			me:        "claude",
+			mode:      wakeInjectModeRaw,
+			failAt:    2,
+			firstWant: []string{coopWakeDoorbell},
+			retryWant: []string{"\r", "\r"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			deliverPartialWakeMessageForTest(t, root, tc.me, strings.ReplaceAll(tc.name, " ", "-"))
+			stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+				return 0, true, nil
+			})
+			stubRawInjectSleep(t)
+
+			var writes []string
+			guardCalls := 0
+			failed := false
+			cfg := &wakeConfig{
+				root:           root,
+				me:             tc.me,
+				session:        "session1",
+				wakeOwner:      &wakeOwner{},
+				injectMode:     tc.mode,
+				attentionIsTTY: func() bool { return false },
+				beforeTerminalWrite: func() error {
+					guardCalls++
+					if !failed && guardCalls == tc.failAt {
+						failed = true
+						return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+					}
+					return nil
+				},
+				terminalWrite: func(text string) error {
+					writes = append(writes, text)
+					return nil
+				},
+			}
+
+			err := notifyNewMessages(cfg)
+			if !isWakeTerminalForegroundPGRPChanged(err) {
+				t.Fatalf("first notify error = %T %v, want foreground-PGRP change", err, err)
+			}
+			if got := strings.Join(writes, "|"); got != strings.Join(tc.firstWant, "|") {
+				t.Fatalf("first writes = %q, want %q", got, strings.Join(tc.firstWant, "|"))
+			}
+			if cfg.doorbell.attempts != 0 {
+				t.Fatalf("attempts after foreground refusal = %d, want 0", cfg.doorbell.attempts)
+			}
+
+			writes = nil
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("retry notify: %v", err)
+			}
+			if got := strings.Join(writes, "|"); got != strings.Join(tc.retryWant, "|") {
+				t.Fatalf("retry writes = %q, want %q", got, strings.Join(tc.retryWant, "|"))
+			}
+			if cfg.doorbell.token != coopWakeDoorbellTokenForTests {
+				t.Fatalf("retry token = %q, want preserved token", cfg.doorbell.token)
+			}
+			if cfg.doorbell.attempts != 1 {
+				t.Fatalf("attempts after completed retry = %d, want 1", cfg.doorbell.attempts)
+			}
+		})
+	}
+}
+
+func TestNotifyNewMessagesTerminalWritePGRPDoesNotAdvanceResumePhase(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      string
+		failAt    int
+		firstWant []string
+		retryWant []string
+	}{
+		{
+			name:      "paste submit",
+			mode:      wakeInjectModePaste,
+			failAt:    2,
+			firstWant: []string{coopWakeDoorbell},
+			retryWant: []string{"\r"},
+		},
+		{
+			name:      "raw prelude",
+			mode:      wakeInjectModeRaw,
+			failAt:    2,
+			firstWant: []string{coopWakeDoorbell},
+			retryWant: []string{"\n", "\r", "\r"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			deliverPartialWakeMessageForTest(t, root, "codex", "terminal-write-"+strings.ReplaceAll(tc.name, " ", "-"))
+			stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+				return 0, true, nil
+			})
+			stubRawInjectSleep(t)
+
+			var writes []string
+			writeCalls := 0
+			failed := false
+			cfg := &wakeConfig{
+				root:           root,
+				me:             "codex",
+				session:        "session1",
+				wakeOwner:      &wakeOwner{},
+				injectMode:     tc.mode,
+				attentionIsTTY: func() bool { return false },
+				terminalWrite: func(text string) error {
+					writeCalls++
+					if !failed && writeCalls == tc.failAt {
+						failed = true
+						return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+					}
+					writes = append(writes, text)
+					return nil
+				},
+			}
+
+			err := notifyNewMessages(cfg)
+			if !isWakeTerminalForegroundPGRPChanged(err) {
+				t.Fatalf("first notify error = %T %v, want foreground-PGRP change", err, err)
+			}
+			if got := strings.Join(writes, "|"); got != strings.Join(tc.firstWant, "|") {
+				t.Fatalf("first writes = %q, want %q", got, strings.Join(tc.firstWant, "|"))
+			}
+
+			writes = nil
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("retry notify: %v", err)
+			}
+			if got := strings.Join(writes, "|"); got != strings.Join(tc.retryWant, "|") {
+				t.Fatalf("retry writes = %q, want %q", got, strings.Join(tc.retryWant, "|"))
+			}
+		})
+	}
+}
+
+func TestNotifyNewMessagesRawRescuePGRPAfterDrainInspectionErrorResumesRescueOnly(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "rescue-after-drain-error")
+	drainCalls := 0
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		drainCalls++
+		if drainCalls == 2 {
+			return 0, false, errors.New("queue inspection unavailable")
+		}
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	var writes []string
+	guardCalls := 0
+	failed := false
+	cfg := &wakeConfig{
+		root:           root,
+		me:             "codex",
+		session:        "session1",
+		wakeOwner:      &wakeOwner{},
+		injectMode:     wakeInjectModeRaw,
+		attentionIsTTY: func() bool { return false },
+		beforeTerminalWrite: func() error {
+			guardCalls++
+			if !failed && guardCalls == 4 {
+				failed = true
+				return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+			}
+			return nil
+		},
+		terminalWrite: func(text string) error {
+			writes = append(writes, text)
+			return nil
+		},
+	}
+
+	err := notifyNewMessages(cfg)
+	if !isWakeTerminalForegroundPGRPChanged(err) {
+		t.Fatalf("first notify error = %T %v, want foreground-PGRP change", err, err)
+	}
+	if got := strings.Join(writes, "|"); got != coopWakeDoorbell+"|\n|\r" {
+		t.Fatalf("first writes = %q, want payload, prelude, and first submit", got)
+	}
+
+	writes = nil
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("retry notify: %v", err)
+	}
+	if got := strings.Join(writes, "|"); got != "\r" {
+		t.Fatalf("retry writes = %q, want only rescue submit", got)
+	}
+}
+
+func TestNotifyNewMessagesReconcilesPartialDeliveryAfterInboxDrain(t *testing.T) {
+	tests := []struct {
+		name          string
+		mode          string
+		failAt        int
+		reconcileWant []string
+	}{
+		{
+			name:          "paste payload",
+			mode:          wakeInjectModePaste,
+			failAt:        1,
+			reconcileWant: nil,
+		},
+		{
+			name:          "paste submit",
+			mode:          wakeInjectModePaste,
+			failAt:        2,
+			reconcileWant: []string{"\r"},
+		},
+		{
+			name:          "raw prelude",
+			mode:          wakeInjectModeRaw,
+			failAt:        2,
+			reconcileWant: []string{"\n", "\r", "\r"},
+		},
+		{
+			name:          "raw first submit",
+			mode:          wakeInjectModeRaw,
+			failAt:        3,
+			reconcileWant: []string{"\r", "\r"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			deliverPartialWakeMessageForTest(t, root, "codex", "reconcile-"+strings.ReplaceAll(tc.name, " ", "-"))
+			stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+				return 0, true, nil
+			})
+			stubRawInjectSleep(t)
+
+			var writes []string
+			guardCalls := 0
+			failed := false
+			cfg := &wakeConfig{
+				root:           root,
+				me:             "codex",
+				session:        "session1",
+				wakeOwner:      &wakeOwner{},
+				injectMode:     tc.mode,
+				attentionIsTTY: func() bool { return false },
+				beforeTerminalWrite: func() error {
+					guardCalls++
+					if !failed && guardCalls == tc.failAt {
+						failed = true
+						return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+					}
+					return nil
+				},
+				terminalWrite: func(text string) error {
+					writes = append(writes, text)
+					return nil
+				},
+			}
+
+			err := notifyNewMessages(cfg)
+			if !isWakeTerminalForegroundPGRPChanged(err) {
+				t.Fatalf("first notify error = %T %v, want foreground-PGRP change", err, err)
+			}
+			if drained := runDrainJSON(t, root, "codex", 0, false); drained.Count != 1 {
+				t.Fatalf("drained count = %d, want 1", drained.Count)
+			}
+
+			writes = nil
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("empty-inbox reconciliation: %v", err)
+			}
+			if got := strings.Join(writes, "|"); got != strings.Join(tc.reconcileWant, "|") {
+				t.Fatalf("reconciliation writes = %q, want %q", got, strings.Join(tc.reconcileWant, "|"))
+			}
+		})
+	}
+}
+
+func TestRunWakeLoopAuthorityRetryResumesMissingPasteSubmitWithoutPayloadReplay(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "run-loop-partial-paste")
+
+	originalAuthorityRetryDelay := wakeTerminalAuthorityRetryDelay
+	wakeTerminalAuthorityRetryDelay = 20 * time.Millisecond
+	t.Cleanup(func() {
+		wakeTerminalAuthorityRetryDelay = originalAuthorityRetryDelay
+	})
+
+	var writes []string
+	failed := false
+	completed := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			wakeOwner:   &wakeOwner{},
+			injectMode:  wakeInjectModePaste,
+			controlStop: stop,
+			preconditionCheck: func(*wakeConfig) error {
+				return nil
+			},
+			terminalWrite: func(text string) error {
+				if text == "\r" && !failed {
+					failed = true
+					return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+				}
+				writes = append(writes, text)
+				if text == "\r" {
+					select {
+					case completed <- struct{}{}:
+					default:
+					}
+				}
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+		})
+	}()
+
+	select {
+	case <-completed:
+	case err := <-done:
+		t.Fatalf("wake loop exited before authority retry completed: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not complete missing paste submit")
+	}
+	close(stop)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop")
+	}
+
+	if got := strings.Join(writes, "|"); got != coopWakeDoorbell+"|\r" {
+		t.Fatalf("terminal writes = %q, want one payload and resumed submit", got)
+	}
+}
+
 func stubSignalWakeProcess(t *testing.T, fn func(pid int, sig os.Signal) error) {
 	t.Helper()
 	oldSignal := signalWakeProcess
@@ -378,6 +837,58 @@ func TestRunWakeWithLoopInterruptCommandDefaultsOffAndRemainsOptIn(t *testing.T)
 	}
 }
 
+func TestRunWakeWithLoopRejectsBlankInterruptCommand(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+	}{
+		{name: "equals empty", args: []string{"--interrupt-cmd="}},
+		{name: "separate empty", args: []string{"--interrupt-cmd", ""}},
+		{name: "whitespace", args: []string{"--interrupt-cmd", " \t "}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatalf("EnsureRootDirs: %v", err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+				t.Fatalf("EnsureAgentDirs: %v", err)
+			}
+
+			logPath := filepath.Join(root, "inject.log")
+			injector := filepath.Join(root, "inject.sh")
+			if err := os.WriteFile(
+				injector,
+				[]byte("#!/bin/sh\nprintf 'invoked\\n' >> "+logPath+"\n"),
+				0o755,
+			); err != nil {
+				t.Fatalf("write injector: %v", err)
+			}
+
+			args := []string{
+				"--root", root,
+				"--me", "alice",
+				"--inject-via", injector,
+			}
+			args = append(args, tt.args...)
+			loopCalled := false
+			err := runWakeWithLoop(args, func(wakeConfig) error {
+				loopCalled = true
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), "invalid interrupt-cmd") {
+				t.Fatalf("runWakeWithLoop error = %v, want invalid interrupt-cmd", err)
+			}
+			if loopCalled {
+				t.Fatal("wake loop ran for blank interrupt command")
+			}
+			if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+				t.Fatalf("injector log exists after rejected command: %v", err)
+			}
+		})
+	}
+}
+
 func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -480,6 +991,441 @@ func TestRunWakeWithLoopBaselinesBeforeReadiness(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopRejectsCanonicalAgentReplacementAfterAcquisition(t *testing.T) {
+	for _, ownerBound := range []bool{false, true} {
+		name := "ownerless"
+		if ownerBound {
+			name = "owner-bound"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			if ownerBound {
+				owner := wakeOwner{
+					PID:          4242,
+					ProcessStart: "12345",
+					BootID:       "11111111-1111-1111-1111-111111111111",
+					SessionID:    99,
+				}
+				encoded, err := encodeWakeOwnerEnv(owner)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv(envWakeOwner, encoded)
+				oldObserve := observeAuthoritativeWakeOwner
+				observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+					if got != owner {
+						t.Fatalf("owner = %#v, want %#v", got, owner)
+					}
+					return liveWakeOwnerObservationForTest(), nil
+				}
+				t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+			} else {
+				t.Setenv(envWakeOwner, "")
+			}
+
+			injector := writeExecutableForTest(t, "injector")
+			readyPath := filepath.Join(t.TempDir(), "wake.ready")
+			outside := filepath.Join(t.TempDir(), "outside")
+			if err := os.Mkdir(outside, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			agentPath := fsq.AgentBase(root, "codex")
+			detachedPath := agentPath + ".detached"
+			err := runWakeWithLoop([]string{
+				"--root", root,
+				"--me", "codex",
+				"--inject-via", injector,
+				"--ready-file", readyPath,
+			}, func(cfg wakeConfig) error {
+				if cfg.retainedAgent == nil {
+					t.Fatal("acquisition capability was not threaded into wake config")
+				}
+				if err := os.Rename(agentPath, detachedPath); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(agentPath, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(outside, filepath.Join(agentPath, "inbox")); err != nil {
+					t.Fatal(err)
+				}
+				return runWakeLoop(cfg)
+			})
+			if err == nil ||
+				!strings.Contains(err.Error(), "agent") ||
+				!strings.Contains(err.Error(), "retained authority") {
+				t.Fatalf("canonical replacement error = %v", err)
+			}
+			entries, readErr := os.ReadDir(outside)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("replacement symlink target mutated: %#v", entries)
+			}
+			if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+				t.Fatalf("ready file published after authority replacement: %v", statErr)
+			}
+			if _, statErr := os.Stat(filepath.Join(agentPath, wakePreparedFileName)); !os.IsNotExist(statErr) {
+				t.Fatalf("prepared marker published in replacement: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingRejectsCanonicalAgentReplacement(t *testing.T) {
+	for _, ownerBound := range []bool{false, true} {
+		name := "ownerless"
+		if ownerBound {
+			name = "owner-bound"
+		}
+		t.Run(name, func(t *testing.T) {
+			const wakePID = 4242
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "injector")
+			owner := wakeOwner{
+				PID:          4343,
+				ProcessStart: "12345",
+				BootID:       "11111111-1111-1111-1111-111111111111",
+				SessionID:    99,
+			}
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+			if ownerBound {
+				target.Owner = &owner
+				encoded, err := encodeWakeOwnerEnv(owner)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv(envWakeOwner, encoded)
+				oldObserve := observeAuthoritativeWakeOwner
+				observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+					if got != owner {
+						t.Fatalf("owner = %#v, want %#v", got, owner)
+					}
+					return liveWakeOwnerObservationForTest(), nil
+				}
+				t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+			} else {
+				t.Setenv(envWakeOwner, "")
+			}
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid == wakePID {
+					return wakeProcessInfo{
+						PID:        pid,
+						Running:    true,
+						StartToken: "67890",
+						BootID:     owner.BootID,
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "codex", "--inject-via", injector},
+					}
+				}
+				return wakeProcessInfo{PID: pid}
+			})
+			lock := bindWakeLockToTarget(wakeLock{
+				PID:          wakePID,
+				TTY:          "unknown",
+				ProcessStart: "67890",
+				BootID:       owner.BootID,
+				Executable:   "/opt/homebrew/bin/amq",
+				Generation:   "generation-1",
+			}, target)
+			if ownerBound {
+				lock.Owner = &owner
+				lock.OwnerSchema = wakeOwnerLockSchema
+				lock.WakeMode = wakeOwnerWakeMode
+			}
+			lockPath := writeWakeLockForTest(t, root, "codex", lock)
+			if ownerBound {
+				if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatal(err)
+			}
+
+			retryEntered := make(chan struct{}, 1)
+			originalRetry := waitForWakePreparedRetry
+			waitForWakePreparedRetry = func(time.Time) bool {
+				select {
+				case retryEntered <- struct{}{}:
+				default:
+				}
+				return true
+			}
+			t.Cleanup(func() { waitForWakePreparedRetry = originalRetry })
+
+			agentPath := fsq.AgentBase(root, "codex")
+			detachedPath := agentPath + ".detached"
+			readyPath := filepath.Join(t.TempDir(), "wake.ready")
+			done := make(chan error, 1)
+			go func() {
+				done <- runWakeWithLoop([]string{
+					"--root", root,
+					"--me", "codex",
+					"--inject-via", injector,
+					"--ready-file", readyPath,
+					"--accept-existing-wake",
+				}, func(cfg wakeConfig) error {
+					t.Errorf("loop should not run with an existing wake: %#v", cfg)
+					return nil
+				})
+			}()
+			select {
+			case <-retryEntered:
+			case err := <-done:
+				t.Fatalf("existing wake returned before replacement: %v", err)
+			case <-time.After(time.Second):
+				t.Fatal("existing wake did not poll for preparation")
+			}
+			if err := os.Rename(agentPath, detachedPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(agentPath, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			marker := wakeReady{
+				Schema:       wakeReadySchema,
+				Generation:   lock.Generation,
+				TargetDigest: lock.TargetDigest,
+			}
+			if err := writeWakeGenerationFile(
+				filepath.Join(detachedPath, wakePreparedFileName),
+				"wake prepared marker",
+				marker,
+			); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case err := <-done:
+				if err == nil ||
+					!strings.Contains(err.Error(), "canonical wake agent directory") ||
+					!strings.Contains(err.Error(), "retained authority") {
+					t.Fatalf("canonical replacement error = %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("existing wake did not reject replacement agent directory")
+			}
+			if _, err := os.Stat(readyPath); !os.IsNotExist(err) {
+				t.Fatalf("ready file published for detached wake: %v", err)
+			}
+		})
+	}
+}
+
+func TestWakeReadyCleanupPreservesReplacement(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	original := wakeReady{
+		Schema:       wakeReadySchema,
+		Generation:   "original",
+		TargetDigest: "original-target",
+	}
+	publication, err := publishWakeReadyFile(readyPath, original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = publication.Close() }()
+
+	replacement := wakeReady{
+		Schema:       wakeReadySchema,
+		Generation:   "replacement",
+		TargetDigest: "replacement-target",
+	}
+	originalHook := beforeWakeReadyCleanupUnlink
+	beforeWakeReadyCleanupUnlink = func() {
+		beforeWakeReadyCleanupUnlink = func() {}
+		if err := writeWakeGenerationFile(readyPath, "replacement wake ready file", replacement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { beforeWakeReadyCleanupUnlink = originalHook })
+
+	err = publication.removeIfUnchanged()
+	if err == nil || !strings.Contains(err.Error(), "changed before removal; preserving it") {
+		t.Fatalf("replacement cleanup error = %v, want preservation", err)
+	}
+	current, exists, err := readWakeReadyFile(readyPath)
+	if err != nil || !exists || current != replacement {
+		t.Fatalf("replacement wake ready file = %#v, exists=%v, err=%v", current, exists, err)
+	}
+}
+
+func TestWakeReadyPublicationCleansInstalledMarkerAfterSyncFailure(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	syncErr := errors.New("sync unavailable")
+	originalSync := syncWakeOwnerDirFD
+	syncWakeOwnerDirFD = func(int) error { return syncErr }
+	t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
+
+	publication, err := publishWakeReadyFile(readyPath, wakeReady{
+		Schema:     wakeReadySchema,
+		Generation: "sync-failure",
+	})
+	if publication != nil {
+		t.Fatalf("sync failure returned publication capability: %#v", publication)
+	}
+	if !errors.Is(err, syncErr) {
+		t.Fatalf("publication error = %v, want sync failure", err)
+	}
+	if _, err := os.Stat(readyPath); !os.IsNotExist(err) {
+		t.Fatalf("ready marker survived sync failure: %v", err)
+	}
+}
+
+func TestWakeReadyPublicationPreservesReplacementAfterValidationFailure(t *testing.T) {
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	replacement := wakeReady{
+		Schema:       wakeReadySchema,
+		Generation:   "replacement",
+		TargetDigest: "replacement-target",
+	}
+	originalHook := afterWakeReadyPublicationWrite
+	afterWakeReadyPublicationWrite = func() {
+		afterWakeReadyPublicationWrite = func() {}
+		if err := writeWakeGenerationFile(readyPath, "replacement wake ready file", replacement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { afterWakeReadyPublicationWrite = originalHook })
+
+	publication, err := publishWakeReadyFile(readyPath, wakeReady{
+		Schema:     wakeReadySchema,
+		Generation: "original",
+	})
+	if publication != nil {
+		t.Fatalf("validation failure returned publication capability: %#v", publication)
+	}
+	if err == nil || !strings.Contains(err.Error(), "changed during publication; preserving it") {
+		t.Fatalf("publication error = %v, want replacement validation failure", err)
+	}
+	current, exists, err := readWakeReadyFile(readyPath)
+	if err != nil || !exists || current != replacement {
+		t.Fatalf("replacement wake ready file = %#v, exists=%v, err=%v", current, exists, err)
+	}
+}
+
+func TestRunWakeWithLoopAcceptExistingRemovesReadyAfterOwnerLoss(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	owner := wakeOwner{
+		PID:          4343,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	target.Owner = &owner
+	encoded, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envWakeOwner, encoded)
+
+	ownerAlive := true
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("owner = %#v, want %#v", got, owner)
+		}
+		if !ownerAlive {
+			return wakeOwnerObservation{
+				State:  wakeOwnerDead,
+				Reason: "test owner exited after readiness publication",
+			}, nil
+		}
+		return liveWakeOwnerObservationForTest(), nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == wakePID {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: "67890",
+				BootID:     owner.BootID,
+				Executable: "/opt/homebrew/bin/amq",
+				Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "codex", "--inject-via", injector},
+			}
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		TTY:          "unknown",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Executable:   "/opt/homebrew/bin/amq",
+		Generation:   "generation-1",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	writeWakePreparedForTest(t, root, "codex")
+
+	originalHook := afterExistingWakeReadyPublication
+	afterExistingWakeReadyPublication = func() { ownerAlive = false }
+	t.Cleanup(func() { afterExistingWakeReadyPublication = originalHook })
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err = runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "codex",
+		"--inject-via", injector,
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run with an existing wake: %#v", cfg)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "owner is dead") {
+		t.Fatalf("owner loss error = %v", err)
+	}
+	if _, err := os.Stat(readyPath); !os.IsNotExist(err) {
+		t.Fatalf("ready file survived owner loss: %v", err)
+	}
+}
+
+func TestRunWakeWithLoopDoesNotRecreateMissingInboxAfterAcquisition(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	inboxPath := fsq.AgentInboxNew(root, "codex")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "codex",
+		"--inject-via", injector,
+	}, func(cfg wakeConfig) error {
+		if err := os.Remove(inboxPath); err != nil {
+			t.Fatal(err)
+		}
+		return runWakeLoop(cfg)
+	})
+	if err == nil {
+		t.Fatal("missing acquired inbox started a wake loop")
+	}
+	if _, statErr := os.Stat(inboxPath); !os.IsNotExist(statErr) {
+		t.Fatalf("missing acquired inbox was recreated: %v", statErr)
+	}
+}
+
 func TestBaselineFreshMailboxStillStarts(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -579,6 +1525,279 @@ func TestRunWakeLoopStopsBeforePublishingPreparedMarker(t *testing.T) {
 	}
 }
 
+func TestRunWakeLoopOwnerlessStartupScanAndQueuedEventEmitOnce(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	cleanup, err := acquireWakeLock(root, "codex", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	lock := inspectWakeLock(root, "codex")
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	first := make(chan struct{}, 1)
+	var notices atomic.Int64
+	stubTIOCSTIInject(t, func(text string) error {
+		if len(text) > 1 {
+			if notices.Add(1) == 1 {
+				first <- struct{}{}
+			}
+		}
+		return nil
+	})
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:               root,
+			me:                 "codex",
+			session:            "session1",
+			debounce:           5 * time.Millisecond,
+			injectMode:         wakeInjectModeRaw,
+			controlStop:        stop,
+			terminalGeneration: lock.Lock.Generation,
+			terminalTTY:        lock.Lock.TTY,
+			onPrepared: func(wakeAdmissionWatcher) error {
+				deliverWakeWatcherMessageForTest(t, root, "codex", "startup", "startup")
+				return nil
+			},
+			preconditionCheck: func(*wakeConfig) error { return nil },
+		})
+	}()
+	select {
+	case <-first:
+	case err := <-done:
+		t.Fatalf("wake loop exited before startup notice: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not emit startup notice")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("wake loop exited while checking queued event dedup: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(stop)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if got := notices.Load(); got != 1 {
+		t.Fatalf("startup scan plus queued event emitted %d notices, want 1", got)
+	}
+}
+
+func TestRunWakeLoopRearmsOrdinaryInboxWatcher(t *testing.T) {
+	originalScanRetryBase := wakeInboxScanRetryBase
+	originalScanRetryMax := wakeInboxScanRetryMax
+	wakeInboxScanRetryBase = 20 * time.Millisecond
+	wakeInboxScanRetryMax = 100 * time.Millisecond
+	t.Cleanup(func() {
+		wakeInboxScanRetryBase = originalScanRetryBase
+		wakeInboxScanRetryMax = originalScanRetryMax
+	})
+
+	for _, test := range []struct {
+		name    string
+		replace func(t *testing.T, inboxPath string)
+	}{
+		{
+			name: "remove and recreate",
+			replace: func(t *testing.T, inboxPath string) {
+				t.Helper()
+				if err := os.RemoveAll(inboxPath); err != nil {
+					t.Fatalf("remove inbox/new: %v", err)
+				}
+				if err := os.Mkdir(inboxPath, 0o700); err != nil {
+					t.Fatalf("recreate inbox/new: %v", err)
+				}
+			},
+		},
+		{
+			name: "rename and recreate",
+			replace: func(t *testing.T, inboxPath string) {
+				t.Helper()
+				if err := os.Rename(inboxPath, inboxPath+".detached"); err != nil {
+					t.Fatalf("rename inbox/new: %v", err)
+				}
+				if err := os.Mkdir(inboxPath, 0o700); err != nil {
+					t.Fatalf("recreate inbox/new: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			inboxPath := fsq.AgentInboxNew(root, "codex")
+			ready := make(chan struct{})
+			attention := make(chan string, 8)
+			stop := make(chan struct{})
+			done := make(chan error, 1)
+			go func() {
+				done <- runWakeLoop(wakeConfig{
+					root:        root,
+					me:          "codex",
+					session:     "session1",
+					wakeOwner:   &wakeOwner{},
+					debounce:    5 * time.Millisecond,
+					previewLen:  80,
+					injectMode:  wakeInjectModeNone,
+					controlStop: stop,
+					onPrepared: func(wakeAdmissionWatcher) error {
+						close(ready)
+						return nil
+					},
+					preconditionCheck: func(*wakeConfig) error { return nil },
+					attentionIsTTY:    func() bool { return false },
+					attentionWrite: func(data []byte) (int, error) {
+						attention <- string(data)
+						return len(data), nil
+					},
+				})
+			}()
+			t.Cleanup(func() {
+				close(stop)
+				select {
+				case <-done:
+				case <-time.After(2 * time.Second):
+					t.Error("wake loop did not stop")
+				}
+			})
+
+			select {
+			case <-ready:
+			case err := <-done:
+				t.Fatalf("wake loop exited before readiness: %v", err)
+			case <-time.After(2 * time.Second):
+				t.Fatal("wake loop did not publish readiness")
+			}
+
+			test.replace(t, inboxPath)
+			deliverWakeWatcherMessageForTest(t, root, "codex", "during-rearm", "during")
+			awaitWakeAttentionFrom(t, attention, done, "during")
+
+			if err := os.Remove(filepath.Join(inboxPath, "during-rearm.md")); err != nil {
+				t.Fatalf("remove rearm message: %v", err)
+			}
+			deliverWakeWatcherMessageForTest(t, root, "codex", "after-rearm", "after")
+			awaitWakeAttentionFrom(t, attention, done, "after")
+		})
+	}
+}
+
+func TestRunWakeLoopRejectsOrdinaryAgentReplacement(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	agentPath := fsq.AgentBase(root, "codex")
+	ready := make(chan struct{})
+	attention := make(chan string, 2)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			wakeOwner:   &wakeOwner{},
+			debounce:    5 * time.Millisecond,
+			previewLen:  80,
+			injectMode:  wakeInjectModeNone,
+			controlStop: stop,
+			onPrepared: func(wakeAdmissionWatcher) error {
+				close(ready)
+				return nil
+			},
+			preconditionCheck: func(*wakeConfig) error { return nil },
+			attentionIsTTY:    func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+
+	select {
+	case <-ready:
+	case err := <-done:
+		t.Fatalf("wake loop exited before readiness: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not publish readiness")
+	}
+	if err := os.Rename(agentPath, agentPath+".detached"); err != nil {
+		t.Fatalf("detach original agent directory: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("create replacement agent directory: %v", err)
+	}
+	deliverWakeWatcherMessageForTest(t, root, "codex", "replacement", "replacement")
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "agent directory no longer matches retained authority") {
+			t.Fatalf("agent replacement error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		close(stop)
+		t.Fatal("wake loop did not reject replacement agent directory")
+	}
+	select {
+	case output := <-attention:
+		t.Fatalf("wake loop read replacement-agent message: %q", output)
+	default:
+	}
+}
+
+func deliverWakeWatcherMessageForTest(
+	t *testing.T,
+	root, me, id, from string,
+) {
+	t.Helper()
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      id,
+			From:    from,
+			To:      []string{me},
+			Thread:  "p2p/" + from + "__" + me,
+			Subject: id,
+			Created: "2026-07-30T08:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, me, id+".md", data); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func awaitWakeAttentionFrom(
+	t *testing.T,
+	attention <-chan string,
+	done <-chan error,
+	from string,
+) {
+	t.Helper()
+	timeout := time.NewTimer(2 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case output := <-attention:
+			if strings.Contains(output, "from "+from) {
+				return
+			}
+		case err := <-done:
+			t.Fatalf("wake loop exited before attention from %s: %v", from, err)
+		case <-timeout.C:
+			t.Fatalf("wake loop did not emit attention from %s", from)
+		}
+	}
+}
+
 func TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
@@ -670,6 +1889,1512 @@ func TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood(t *testing.T) {
 	select {
 	case output := <-attention:
 		t.Fatalf("retry emitted output-only attention: %q", output)
+	default:
+	}
+}
+
+func TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "expired-foreground-retry",
+			From:    "claude",
+			To:      []string{"codex"},
+			Thread:  "p2p/claude__codex",
+			Subject: "foreground handoff",
+			Created: "2026-07-30T08:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "expired-foreground-retry.md", data); err != nil {
+		t.Fatal(err)
+	}
+
+	originalAuthorityRetryDelay := wakeTerminalAuthorityRetryDelay
+	wakeTerminalAuthorityRetryDelay = time.Hour
+	t.Cleanup(func() {
+		wakeTerminalAuthorityRetryDelay = originalAuthorityRetryDelay
+	})
+
+	start := time.Unix(1_800_000_000, 0)
+	var nowNanos atomic.Int64
+	nowNanos.Store(start.UnixNano())
+	var promptWrites atomic.Int64
+	initialSubmitted := make(chan struct{}, 1)
+	refused := make(chan struct{}, 1)
+	extra := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	stopped := false
+	stopLoop := func() {
+		if !stopped {
+			close(stop)
+			stopped = true
+		}
+	}
+	defer stopLoop()
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			wakeOwner:   &wakeOwner{},
+			debounce:    0,
+			injectMode:  wakeInjectModePaste,
+			controlStop: stop,
+			doorbellNow: func() time.Time {
+				return time.Unix(0, nowNanos.Load())
+			},
+			preconditionCheck: func(*wakeConfig) error {
+				return nil
+			},
+			terminalWrite: func(text string) error {
+				if strings.Contains(text, coopWakeDoorbellPrefix) {
+					switch promptWrites.Add(1) {
+					case 1:
+						return nil
+					case 2:
+						refused <- struct{}{}
+					default:
+						select {
+						case extra <- struct{}{}:
+						default:
+						}
+					}
+					return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+				}
+				if text == "\r" && promptWrites.Load() == 1 {
+					select {
+					case initialSubmitted <- struct{}{}:
+					default:
+					}
+				}
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+		})
+	}()
+
+	select {
+	case <-initialSubmitted:
+	case err := <-done:
+		t.Fatalf("wake loop exited before initial submit: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not submit initial doorbell")
+	}
+	nowNanos.Store(start.Add(wakeDoorbellRetryBase).UnixNano())
+	message.Header.ID = "trigger-expired-foreground-retry"
+	data, err = message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(
+		t,
+		root,
+		"codex",
+		"trigger-expired-foreground-retry.md",
+		data,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-refused:
+	case err := <-done:
+		t.Fatalf("wake loop exited before foreground refusal: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not reach expired foreground retry")
+	}
+
+	message.Header.ID = "debounce-during-foreground-retry"
+	data, err = message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(
+		t,
+		root,
+		"codex",
+		"debounce-during-foreground-retry.md",
+		data,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-extra:
+		t.Fatal("doorbell or debounce retried alongside terminal-authority timer")
+	case err := <-done:
+		t.Fatalf("wake loop exited while holding foreground retry: %v", err)
+	case <-time.After(75 * time.Millisecond):
+	}
+
+	stopLoop()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop")
+	}
+}
+
+func TestRunWakeLoopMaintenanceDemotionRetiresForegroundAuthorityHold(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "demote-foreground-retry",
+			From:    "claude",
+			To:      []string{"codex"},
+			Thread:  "p2p/claude__codex",
+			Subject: "demote foreground retry",
+			Created: "2026-07-30T08:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "demote-foreground-retry.md", data); err != nil {
+		t.Fatal(err)
+	}
+
+	originalAuthorityRetryDelay := wakeTerminalAuthorityRetryDelay
+	wakeTerminalAuthorityRetryDelay = 200 * time.Millisecond
+	t.Cleanup(func() {
+		wakeTerminalAuthorityRetryDelay = originalAuthorityRetryDelay
+	})
+
+	var promptWrites atomic.Int64
+	refused := make(chan struct{}, 1)
+	extra := make(chan struct{}, 1)
+	demoted := make(chan struct{}, 1)
+	attention := make(chan string, 1)
+	ticks := make(chan time.Time)
+	stop := make(chan struct{})
+	stopped := false
+	stopLoop := func() {
+		if !stopped {
+			close(stop)
+			stopped = true
+		}
+	}
+	defer stopLoop()
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			session:          "session1",
+			wakeOwner:        &wakeOwner{},
+			injectMode:       wakeInjectModePaste,
+			controlStop:      stop,
+			maintenanceTicks: ticks,
+			preconditionCheck: func(cfg *wakeConfig) error {
+				cfg.injectMode = wakeInjectModeNone
+				select {
+				case demoted <- struct{}{}:
+				default:
+				}
+				return nil
+			},
+			terminalWrite: func(text string) error {
+				if !strings.Contains(text, coopWakeDoorbellPrefix) {
+					return nil
+				}
+				if promptWrites.Add(1) == 1 {
+					refused <- struct{}{}
+				} else {
+					select {
+					case extra <- struct{}{}:
+					default:
+					}
+				}
+				return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				select {
+				case attention <- string(data):
+				default:
+				}
+				return len(data), nil
+			},
+		})
+	}()
+
+	select {
+	case <-refused:
+	case err := <-done:
+		t.Fatalf("wake loop exited before foreground refusal: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not establish foreground-authority hold")
+	}
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before maintenance demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance tick")
+	}
+	select {
+	case <-demoted:
+	case err := <-done:
+		t.Fatalf("wake loop exited during maintenance demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not complete maintenance demotion")
+	}
+
+	select {
+	case <-extra:
+		t.Fatal("maintenance bypassed the foreground-authority hold")
+	case err := <-done:
+		t.Fatalf("wake loop exited after maintenance demotion: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "message from claude") {
+			t.Fatalf("demotion fallback = %q, want pending message", output)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited after maintenance demotion: %v", err)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("maintenance demotion dropped foreground-held notification")
+	}
+	select {
+	case output := <-attention:
+		t.Fatalf("retired foreground-authority timer emitted duplicate attention: %q", output)
+	case err := <-done:
+		t.Fatalf("wake loop exited after maintenance demotion: %v", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	stopLoop()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop")
+	}
+}
+
+func TestRunWakeLoopDefersObservationUntilPartialInputCompletes(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "deferred-observation",
+			From:    "peer",
+			To:      []string{"codex"},
+			Thread:  "p2p/codex__peer",
+			Subject: "deferred observation",
+			Created: "2026-07-30T08:00:00Z",
+		},
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, err := deliverToInboxForTest(t, root, "codex", "pending.md", data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalRetryDelay := wakeTerminalAuthorityRetryDelay
+	wakeTerminalAuthorityRetryDelay = 50 * time.Millisecond
+	t.Cleanup(func() { wakeTerminalAuthorityRetryDelay = originalRetryDelay })
+
+	token := coopWakeDoorbellTokenForTests
+	payload := buildCoopWakeDoorbell(token)
+	const accepted = 7
+	promptObserved := make(chan string, 1)
+	firstBlocked := make(chan struct{}, 1)
+	writes := make(chan string, 4)
+	var calls atomic.Int64
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:           root,
+			me:             "codex",
+			session:        "session1",
+			wakeOwner:      &wakeOwner{},
+			injectMode:     wakeInjectModePaste,
+			controlStop:    stop,
+			promptObserved: promptObserved,
+			doorbell: wakeDoorbellState{
+				phase:       wakeDoorbellAwaitingObservation,
+				token:       token,
+				cohort:      snapshotWakeFileIdentities(map[string]os.FileInfo{"pending.md": info}),
+				attempts:    1,
+				nextAttempt: time.Now().Add(-time.Second),
+			},
+			inputDelivery: wakeInputDeliveryState{
+				phase:         wakeInputPayloadPending,
+				mode:          wakeInjectModePaste,
+				payload:       payload,
+				acceptedBytes: accepted,
+			},
+			preconditionCheck: func(*wakeConfig) error { return nil },
+			terminalWrite: func(text string) error {
+				if calls.Add(1) == 1 {
+					firstBlocked <- struct{}{}
+					return newWakeTerminalControlStoppedLoss()
+				}
+				writes <- text
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+		})
+	}()
+	defer func() {
+		close(stop)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	}()
+
+	select {
+	case <-firstBlocked:
+	case err := <-done:
+		t.Fatalf("wake loop exited before partial hold: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not retain partial input")
+	}
+	promptObserved <- token
+
+	select {
+	case got := <-writes:
+		if want := payload[accepted:]; got != want {
+			t.Fatalf("partial retry wrote %q, want exact suffix %q", got, want)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before suffix retry: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not retry retained suffix")
+	}
+	select {
+	case got := <-writes:
+		if got != "\r" {
+			t.Fatalf("submit retry wrote %q, want CR", got)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before submit retry: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not finish retained sequence")
+	}
+	select {
+	case got := <-writes:
+		t.Fatalf("deferred observation replayed terminal input: %q", got)
+	case <-time.After(2 * wakeTerminalAuthorityRetryDelay):
+	}
+}
+
+func TestRunWakeLoopMaintenanceDemotionTransfersPendingDebounce(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+
+	initialScan := make(chan struct{})
+	var scans atomic.Int64
+	inboxNew := fsq.AgentInboxNew(root, "codex")
+	reader := wakeScriptedInboxReader{
+		readDir: func() ([]os.DirEntry, error) {
+			entries, err := os.ReadDir(inboxNew)
+			if scans.Add(1) == 1 {
+				close(initialScan)
+			}
+			return entries, err
+		},
+		readHeader: func(name string) (format.Header, error) {
+			return format.ReadHeaderFile(filepath.Join(inboxNew, name))
+		},
+	}
+	pending := make(chan struct{}, 1)
+	demoted := make(chan struct{}, 1)
+	attention := make(chan string, 2)
+	ticks := make(chan time.Time)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	var terminalWrites atomic.Int64
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			session:          "session1",
+			wakeOwner:        &wakeOwner{},
+			debounce:         time.Hour,
+			injectMode:       wakeInjectModePaste,
+			controlStop:      stop,
+			maintenanceTicks: ticks,
+			retainedInbox:    reader,
+			onPendingNotify: func() {
+				select {
+				case pending <- struct{}{}:
+				default:
+				}
+			},
+			preconditionCheck: func(cfg *wakeConfig) error {
+				cfg.injectMode = wakeInjectModeNone
+				select {
+				case demoted <- struct{}{}:
+				default:
+				}
+				return nil
+			},
+			terminalWrite: func(string) error {
+				terminalWrites.Add(1)
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	select {
+	case <-initialScan:
+	case err := <-done:
+		t.Fatalf("wake loop exited before initial scan: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not complete initial scan")
+	}
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "demote-pending-debounce",
+			From:    "claude",
+			To:      []string{"codex"},
+			Thread:  "p2p/claude__codex",
+			Subject: "pending debounce",
+			Created: "2026-07-30T08:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "demote-pending-debounce.md", data); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-pending:
+	case err := <-done:
+		t.Fatalf("wake loop exited before pending debounce: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not observe pending debounce")
+	}
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before maintenance demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance tick")
+	}
+	select {
+	case <-demoted:
+	case err := <-done:
+		t.Fatalf("wake loop exited during maintenance demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not demote input")
+	}
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "message from claude") {
+			t.Fatalf("demotion fallback = %q, want pending message", output)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before demotion fallback: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("maintenance demotion dropped pending debounce")
+	}
+	if got := terminalWrites.Load(); got != 0 {
+		t.Fatalf("pending debounce reached terminal %d times before demotion", got)
+	}
+
+	ticks <- time.Now()
+	select {
+	case duplicate := <-attention:
+		t.Fatalf("maintenance emitted duplicate demotion fallback: %q", duplicate)
+	case err := <-done:
+		t.Fatalf("wake loop exited after demotion fallback: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestRunWakeLoopPacesPersistentInboxScanErrors(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+
+	originalScanRetryBase := wakeInboxScanRetryBase
+	originalScanRetryMax := wakeInboxScanRetryMax
+	wakeInboxScanRetryBase = 100 * time.Millisecond
+	wakeInboxScanRetryMax = time.Second
+	t.Cleanup(func() {
+		wakeInboxScanRetryBase = originalScanRetryBase
+		wakeInboxScanRetryMax = originalScanRetryMax
+	})
+
+	scans := make(chan time.Time, 4)
+	var scanCount atomic.Int64
+	reader := wakeScriptedInboxReader{
+		readDir: func() ([]os.DirEntry, error) {
+			count := scanCount.Add(1)
+			scans <- time.Now()
+			if count <= 3 {
+				return nil, syscall.EIO
+			}
+			return nil, nil
+		},
+	}
+	now := time.Unix(1_800_000_000, 0)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:          root,
+			me:            "codex",
+			session:       "session1",
+			wakeOwner:     &wakeOwner{},
+			injectMode:    wakeInjectModePaste,
+			controlStop:   stop,
+			retainedInbox: reader,
+			doorbellNow:   func() time.Time { return now },
+			doorbell: wakeDoorbellState{
+				phase:       wakeDoorbellAwaitingObservation,
+				token:       coopWakeDoorbellTokenForTests,
+				cohort:      map[string]*wakeFileIdentity{"pending.md": nil},
+				attempts:    1,
+				nextAttempt: now.Add(-time.Second),
+			},
+			preconditionCheck: func(*wakeConfig) error { return nil },
+			attentionIsTTY:    func() bool { return false },
+		})
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	first := awaitWakeScan(t, scans, done)
+	for attempt := 2; attempt <= 3; attempt++ {
+		at := awaitWakeScan(t, scans, done)
+		minimum := wakeInboxScanRetryBase
+		if attempt == 3 {
+			minimum += 2 * wakeInboxScanRetryBase
+		}
+		if elapsed := at.Sub(first); elapsed < minimum {
+			t.Fatalf(
+				"scan attempt %d arrived after %s, want paced retries of at least %s",
+				attempt,
+				elapsed,
+				minimum,
+			)
+		}
+	}
+}
+
+func TestRunWakeLoopRecoversAfterTransientInboxScanError(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+
+	originalScanRetryBase := wakeInboxScanRetryBase
+	originalScanRetryMax := wakeInboxScanRetryMax
+	wakeInboxScanRetryBase = 50 * time.Millisecond
+	wakeInboxScanRetryMax = time.Second
+	t.Cleanup(func() {
+		wakeInboxScanRetryBase = originalScanRetryBase
+		wakeInboxScanRetryMax = originalScanRetryMax
+	})
+
+	scans := make(chan time.Time, 3)
+	var scanCount atomic.Int64
+	reader := wakeScriptedInboxReader{
+		readDir: func() ([]os.DirEntry, error) {
+			count := scanCount.Add(1)
+			scans <- time.Now()
+			if count == 1 {
+				return nil, syscall.EIO
+			}
+			return nil, nil
+		},
+	}
+	now := time.Unix(1_800_000_000, 0)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:          root,
+			me:            "codex",
+			session:       "session1",
+			wakeOwner:     &wakeOwner{},
+			injectMode:    wakeInjectModePaste,
+			controlStop:   stop,
+			retainedInbox: reader,
+			doorbellNow:   func() time.Time { return now },
+			doorbell: wakeDoorbellState{
+				phase:       wakeDoorbellAwaitingObservation,
+				token:       coopWakeDoorbellTokenForTests,
+				cohort:      map[string]*wakeFileIdentity{"pending.md": nil},
+				attempts:    1,
+				nextAttempt: now.Add(-time.Second),
+			},
+			preconditionCheck: func(*wakeConfig) error { return nil },
+			attentionIsTTY:    func() bool { return false },
+		})
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	first := awaitWakeScan(t, scans, done)
+	second := awaitWakeScan(t, scans, done)
+	if elapsed := second.Sub(first); elapsed < wakeInboxScanRetryBase {
+		t.Fatalf("transient scan retried after %s, want at least %s", elapsed, wakeInboxScanRetryBase)
+	}
+	select {
+	case third := <-scans:
+		t.Fatalf("successful empty scan left a stale retry armed at %s", third)
+	case err := <-done:
+		t.Fatalf("wake loop exited after transient inbox scan recovery: %v", err)
+	case <-time.After(2 * wakeInboxScanRetryBase):
+	}
+}
+
+func TestRunWakeLoopDemotionPreservesPendingScanRetry(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "demote-scan-retry",
+			From:    "claude",
+			To:      []string{"codex"},
+			Thread:  "p2p/claude__codex",
+			Subject: "demote scan retry",
+			Created: "2026-07-30T08:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "demote-scan-retry.md", data); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalScanRetryBase := wakeInboxScanRetryBase
+	originalScanRetryMax := wakeInboxScanRetryMax
+	wakeInboxScanRetryBase = 100 * time.Millisecond
+	wakeInboxScanRetryMax = 200 * time.Millisecond
+	t.Cleanup(func() {
+		wakeInboxScanRetryBase = originalScanRetryBase
+		wakeInboxScanRetryMax = originalScanRetryMax
+	})
+
+	scans := make(chan int, 4)
+	var scanCount atomic.Int64
+	reader := wakeScriptedInboxReader{
+		readDir: func() ([]os.DirEntry, error) {
+			count := int(scanCount.Add(1))
+			scans <- count
+			if count <= 2 {
+				return nil, syscall.EIO
+			}
+			return entries, nil
+		},
+		readHeader: func(string) (format.Header, error) {
+			return message.Header, nil
+		},
+	}
+	demoted := make(chan struct{}, 1)
+	attention := make(chan string, 2)
+	ticks := make(chan time.Time)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	var terminalWrites atomic.Int64
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			session:          "session1",
+			wakeOwner:        &wakeOwner{},
+			injectMode:       wakeInjectModePaste,
+			controlStop:      stop,
+			maintenanceTicks: ticks,
+			retainedInbox:    reader,
+			preconditionCheck: func(cfg *wakeConfig) error {
+				cfg.injectMode = wakeInjectModeNone
+				select {
+				case demoted <- struct{}{}:
+				default:
+				}
+				return nil
+			},
+			terminalWrite: func(string) error {
+				terminalWrites.Add(1)
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	select {
+	case attempt := <-scans:
+		if attempt != 1 {
+			t.Fatalf("initial scan attempt = %d, want 1", attempt)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited on initial scan error: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not attempt initial scan")
+	}
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before scan-held demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance tick")
+	}
+	select {
+	case <-demoted:
+	case err := <-done:
+		t.Fatalf("wake loop exited during scan-held demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not demote during scan retry")
+	}
+	select {
+	case attempt := <-scans:
+		if attempt != 2 {
+			t.Fatalf("second scan attempt = %d, want 2", attempt)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited on repeated scan error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("wake loop did not retry failed scan")
+	}
+	select {
+	case output := <-attention:
+		t.Fatalf("failed demotion scan emitted early attention: %q", output)
+	default:
+	}
+	select {
+	case attempt := <-scans:
+		if attempt != 3 {
+			t.Fatalf("recovery scan attempt = %d, want 3", attempt)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before scan recovery: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("wake loop did not recover scan after demotion")
+	}
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "message from claude") {
+			t.Fatalf("scan recovery fallback = %q, want pending message", output)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before scan recovery fallback: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("successful demotion scan did not emit pending fallback")
+	}
+	if got := terminalWrites.Load(); got != 0 {
+		t.Fatalf("scan-held demotion wrote terminal input %d times", got)
+	}
+	select {
+	case duplicate := <-attention:
+		t.Fatalf("scan recovery emitted duplicate demotion fallback: %q", duplicate)
+	case err := <-done:
+		t.Fatalf("wake loop exited after scan recovery: %v", err)
+	case <-time.After(2 * wakeInboxScanRetryMax):
+	}
+}
+
+func TestRunWakeLoopPreservesForegroundRetryAcrossInboxScanError(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "foreground-scan-recovery",
+			From:    "claude",
+			To:      []string{"codex"},
+			Thread:  "p2p/claude__codex",
+			Subject: "foreground scan recovery",
+			Created: "2026-07-30T08:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "foreground-scan-recovery.md", data); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalAuthorityRetryDelay := wakeTerminalAuthorityRetryDelay
+	originalScanRetryBase := wakeInboxScanRetryBase
+	originalScanRetryMax := wakeInboxScanRetryMax
+	wakeTerminalAuthorityRetryDelay = 50 * time.Millisecond
+	wakeInboxScanRetryBase = 50 * time.Millisecond
+	wakeInboxScanRetryMax = time.Second
+	t.Cleanup(func() {
+		wakeTerminalAuthorityRetryDelay = originalAuthorityRetryDelay
+		wakeInboxScanRetryBase = originalScanRetryBase
+		wakeInboxScanRetryMax = originalScanRetryMax
+	})
+
+	var scanCount atomic.Int64
+	scanFailed := make(chan struct{}, 1)
+	reader := wakeScriptedInboxReader{
+		readDir: func() ([]os.DirEntry, error) {
+			if scanCount.Add(1) == 2 {
+				scanFailed <- struct{}{}
+				return nil, syscall.EIO
+			}
+			return entries, nil
+		},
+		readHeader: func(string) (format.Header, error) {
+			return message.Header, nil
+		},
+	}
+	var promptWrites atomic.Int64
+	firstPrompt := make(chan string, 1)
+	recoveredPrompt := make(chan string, 1)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:              root,
+			me:                "codex",
+			session:           "session1",
+			wakeOwner:         &wakeOwner{},
+			injectMode:        wakeInjectModePaste,
+			controlStop:       stop,
+			retainedInbox:     reader,
+			preconditionCheck: func(*wakeConfig) error { return nil },
+			terminalWrite: func(text string) error {
+				if !strings.Contains(text, coopWakeDoorbellPrefix) {
+					return nil
+				}
+				if promptWrites.Add(1) == 1 {
+					firstPrompt <- text
+					return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+				}
+				recoveredPrompt <- text
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+		})
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	var first string
+	select {
+	case first = <-firstPrompt:
+	case err := <-done:
+		t.Fatalf("wake loop exited before foreground refusal: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not establish foreground-authority hold")
+	}
+	select {
+	case <-scanFailed:
+	case err := <-done:
+		t.Fatalf("wake loop exited on transient inbox scan error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("authority retry did not encounter scripted inbox scan error")
+	}
+	select {
+	case recovered := <-recoveredPrompt:
+		if recovered != first {
+			t.Fatalf("recovered prompt = %q, want preserved token %q", recovered, first)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before scan recovery: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("wake loop did not resume foreground retry after scan recovery")
+	}
+}
+
+func TestWakeInboxScanRetryBackoffCaps(t *testing.T) {
+	tests := []struct {
+		failures uint
+		want     time.Duration
+	}{
+		{failures: 1, want: wakeInboxScanRetryBase},
+		{failures: 2, want: 2 * wakeInboxScanRetryBase},
+		{failures: 8, want: wakeInboxScanRetryMax},
+		{failures: 32, want: wakeInboxScanRetryMax},
+	}
+	for _, tc := range tests {
+		if got := wakeInboxScanRetryBackoff(tc.failures); got != tc.want {
+			t.Fatalf("failures %d backoff = %s, want %s", tc.failures, got, tc.want)
+		}
+	}
+	for _, tc := range []struct {
+		name    string
+		base    time.Duration
+		maximum time.Duration
+	}{
+		{name: "base-equals-maximum", base: time.Second, maximum: time.Second},
+		{name: "base-exceeds-maximum", base: 2 * time.Second, maximum: time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cappedExponentialBackoff(1, tc.base, tc.maximum); got != tc.maximum {
+				t.Fatalf("backoff = %s, want cap %s", got, tc.maximum)
+			}
+		})
+	}
+}
+
+func TestRunWakeLoopMaintenanceDemotionTransfersDormantDoorbellRetry(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "demoted-doorbell",
+			From:    "claude",
+			To:      []string{"codex"},
+			Thread:  "p2p/claude__codex",
+			Subject: "demote notifier",
+			Created: "2026-07-30T08:00:00Z",
+		},
+		Body: "body",
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "demoted-doorbell.md", data); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Unix(1_800_000_000, 0)
+	var nowNanos atomic.Int64
+	nowNanos.Store(start.UnixNano())
+	var promptWrites atomic.Int64
+	var initialSubmitted atomic.Bool
+	initial := make(chan struct{}, 1)
+	demoted := make(chan struct{}, 1)
+	attention := make(chan string, 1)
+	ticks := make(chan time.Time)
+	stop := make(chan struct{})
+	stopped := false
+	stopLoop := func() {
+		if !stopped {
+			close(stop)
+			stopped = true
+		}
+	}
+	defer stopLoop()
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			session:          "session1",
+			wakeOwner:        &wakeOwner{},
+			injectMode:       wakeInjectModePaste,
+			controlStop:      stop,
+			maintenanceTicks: ticks,
+			doorbellNow: func() time.Time {
+				return time.Unix(0, nowNanos.Load())
+			},
+			preconditionCheck: func(cfg *wakeConfig) error {
+				cfg.injectMode = wakeInjectModeNone
+				select {
+				case demoted <- struct{}{}:
+				default:
+				}
+				return nil
+			},
+			terminalWrite: func(text string) error {
+				if strings.Contains(text, coopWakeDoorbellPrefix) {
+					promptWrites.Add(1)
+				}
+				if text == "\r" &&
+					promptWrites.Load() == 1 &&
+					initialSubmitted.CompareAndSwap(false, true) {
+					nowNanos.Store(start.Add(wakeDoorbellRetryBase - 100*time.Millisecond).UnixNano())
+					initial <- struct{}{}
+				}
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				select {
+				case attention <- string(data):
+				default:
+				}
+				return len(data), nil
+			},
+		})
+	}()
+
+	select {
+	case <-initial:
+	case err := <-done:
+		t.Fatalf("wake loop exited before initial doorbell: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not submit initial doorbell")
+	}
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before capability check: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance tick")
+	}
+	select {
+	case <-demoted:
+	case err := <-done:
+		t.Fatalf("wake loop exited during capability demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not run capability demotion")
+	}
+
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "AMQ [session1]") {
+			t.Fatalf("demotion attention = %q, want pending AMQ message", output)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited after capability demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("capability demotion dropped dormant doorbell retry")
+	}
+	select {
+	case output := <-attention:
+		t.Fatalf("capability demotion emitted duplicate attention: %q", output)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before output-only maintenance tick: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept output-only maintenance tick")
+	}
+	select {
+	case <-demoted:
+	case err := <-done:
+		t.Fatalf("wake loop exited during output-only maintenance tick: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not complete output-only maintenance tick")
+	}
+
+	noisePath := filepath.Join(fsq.AgentInboxNew(root, "codex"), ".wake-test-noise.md")
+	if err := os.WriteFile(noisePath, []byte("noise"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case output := <-attention:
+		t.Fatalf("unchanged cohort redelivered after output-only maintenance: %q", output)
+	case err := <-done:
+		t.Fatalf("wake loop exited after output-only maintenance: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	stopLoop()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop")
+	}
+}
+
+func TestRunWakeLoopMaintenanceDemotionTransfersBeforePersistenceFailure(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "demotion-persistence",
+			From:    "peer",
+			To:      []string{"codex"},
+			Thread:  "p2p/codex__peer",
+			Subject: "preserve before exit",
+			Created: "2026-07-30T08:00:00Z",
+		},
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, err := deliverToInboxForTest(t, root, "codex", "pending.md", data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persistErr := errors.New("presence unavailable")
+	ticks := make(chan time.Time)
+	attention := make(chan string, 1)
+	done := make(chan error, 1)
+	var terminalWrites atomic.Int64
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			wakeOwner:   &wakeOwner{},
+			injectMode:  wakeInjectModePaste,
+			controlStop: make(chan struct{}),
+			doorbell: wakeDoorbellState{
+				phase:       wakeDoorbellAwaitingObservation,
+				token:       coopWakeDoorbellTokenForTests,
+				cohort:      snapshotWakeFileIdentities(map[string]os.FileInfo{"pending.md": info}),
+				attempts:    1,
+				nextAttempt: time.Now().Add(time.Hour),
+			},
+			maintenanceTicks: ticks,
+			preconditionCheck: func(cfg *wakeConfig) error {
+				cfg.injectMode = wakeInjectModeNone
+				return persistErr
+			},
+			terminalWrite: func(text string) error {
+				terminalWrites.Add(1)
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before maintenance: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance tick")
+	}
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "AMQ [session1]") {
+			t.Fatalf("fallback attention = %q", output)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before transferring fallback: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("persistence failure dropped pending attention")
+	}
+	select {
+	case err := <-done:
+		if !errors.Is(err, persistErr) {
+			t.Fatalf("wake loop error = %v, want persistence failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not surface persistence failure")
+	}
+	if got := terminalWrites.Load(); got != 0 {
+		t.Fatalf("dormant retry wrote %d terminal chunks", got)
+	}
+}
+
+func TestRunWakeLoopFatalDemotionTransfersDuringScanBackoff(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	persistErr := errors.New("presence unavailable")
+	originalScanRetryBase := wakeInboxScanRetryBase
+	originalScanRetryMax := wakeInboxScanRetryMax
+	wakeInboxScanRetryBase = time.Hour
+	wakeInboxScanRetryMax = time.Hour
+	t.Cleanup(func() {
+		wakeInboxScanRetryBase = originalScanRetryBase
+		wakeInboxScanRetryMax = originalScanRetryMax
+	})
+
+	scanned := make(chan struct{}, 1)
+	reader := wakeScriptedInboxReader{
+		readDir: func() ([]os.DirEntry, error) {
+			select {
+			case scanned <- struct{}{}:
+			default:
+			}
+			return nil, syscall.EIO
+		},
+	}
+	ticks := make(chan time.Time)
+	attention := make(chan string, 2)
+	done := make(chan error, 1)
+	var terminalWrites atomic.Int64
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			session:          "session1",
+			wakeOwner:        &wakeOwner{},
+			injectMode:       wakeInjectModePaste,
+			controlStop:      make(chan struct{}),
+			maintenanceTicks: ticks,
+			retainedInbox:    reader,
+			preconditionCheck: func(cfg *wakeConfig) error {
+				cfg.injectMode = wakeInjectModeNone
+				return persistErr
+			},
+			terminalWrite: func(string) error {
+				terminalWrites.Add(1)
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+	select {
+	case <-scanned:
+	case err := <-done:
+		t.Fatalf("wake loop exited before initial scan backoff: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not arm scan backoff")
+	}
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before fatal demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance tick")
+	}
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "run amq drain --include-body") {
+			t.Fatalf("fatal demotion fallback = %q", output)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before transferring generic fallback: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("fatal demotion dropped scan-held pending work")
+	}
+	select {
+	case err := <-done:
+		if !errors.Is(err, persistErr) {
+			t.Fatalf("wake loop error = %v, want persistence failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not surface fatal demotion")
+	}
+	if got := terminalWrites.Load(); got != 0 {
+		t.Fatalf("fatal demotion wrote %d terminal chunks", got)
+	}
+	select {
+	case output := <-attention:
+		t.Fatalf("fatal demotion emitted duplicate attention: %q", output)
+	default:
+	}
+}
+
+func TestRunWakeLoopFatalDemotionTransfersWhenScanBackoffStartsDuringTransfer(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	persistErr := errors.New("presence unavailable")
+	originalScanRetryBase := wakeInboxScanRetryBase
+	originalScanRetryMax := wakeInboxScanRetryMax
+	wakeInboxScanRetryBase = time.Hour
+	wakeInboxScanRetryMax = time.Hour
+	t.Cleanup(func() {
+		wakeInboxScanRetryBase = originalScanRetryBase
+		wakeInboxScanRetryMax = originalScanRetryMax
+	})
+
+	initialScan := make(chan struct{})
+	var scans atomic.Int64
+	inboxNew := fsq.AgentInboxNew(root, "codex")
+	reader := wakeScriptedInboxReader{
+		readDir: func() ([]os.DirEntry, error) {
+			if scans.Add(1) == 1 {
+				entries, err := os.ReadDir(inboxNew)
+				close(initialScan)
+				return entries, err
+			}
+			return nil, syscall.EIO
+		},
+		readHeader: func(name string) (format.Header, error) {
+			return format.ReadHeaderFile(filepath.Join(inboxNew, name))
+		},
+	}
+	pending := make(chan struct{}, 1)
+	ticks := make(chan time.Time)
+	attention := make(chan string, 2)
+	done := make(chan error, 1)
+	var terminalWrites atomic.Int64
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			session:          "session1",
+			wakeOwner:        &wakeOwner{},
+			debounce:         time.Hour,
+			injectMode:       wakeInjectModePaste,
+			controlStop:      make(chan struct{}),
+			maintenanceTicks: ticks,
+			retainedInbox:    reader,
+			onPendingNotify: func() {
+				select {
+				case pending <- struct{}{}:
+				default:
+				}
+			},
+			preconditionCheck: func(cfg *wakeConfig) error {
+				cfg.injectMode = wakeInjectModeNone
+				return persistErr
+			},
+			terminalWrite: func(string) error {
+				terminalWrites.Add(1)
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+
+	select {
+	case <-initialScan:
+	case err := <-done:
+		t.Fatalf("wake loop exited before initial scan: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not complete initial scan")
+	}
+	message := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "demote-new-scan-backoff",
+			From:    "claude",
+			To:      []string{"codex"},
+			Thread:  "p2p/claude__codex",
+			Subject: "pending debounce",
+			Created: "2026-07-30T08:00:00Z",
+		},
+	}
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "pending.md", data); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-pending:
+	case err := <-done:
+		t.Fatalf("wake loop exited before pending debounce: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not observe pending debounce")
+	}
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before fatal demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance tick")
+	}
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "run amq drain --include-body") {
+			t.Fatalf("fatal demotion fallback = %q", output)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before transferring generic fallback: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("fatal demotion dropped pending work after transfer scan failed")
+	}
+	select {
+	case err := <-done:
+		if !errors.Is(err, persistErr) {
+			t.Fatalf("wake loop error = %v, want persistence failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not surface fatal demotion")
+	}
+	if got := terminalWrites.Load(); got != 0 {
+		t.Fatalf("fatal demotion wrote %d terminal chunks", got)
+	}
+	select {
+	case output := <-attention:
+		t.Fatalf("fatal demotion emitted duplicate attention: %q", output)
 	default:
 	}
 }
@@ -3769,6 +6494,59 @@ func TestOpenWakeRepairOutputCreatesPrivateLog(t *testing.T) {
 	}
 }
 
+func TestOpenCoopWakeOutputCreatesPrivateDurableLog(t *testing.T) {
+	root := secureTempDirForTest(t)
+	output, err := openCoopWakeOutput(root, "orchestrator")
+	if err != nil {
+		t.Fatalf("openCoopWakeOutput: %v", err)
+	}
+	path := output.Name()
+	if _, err := output.WriteString("fatal wake diagnostic\n"); err != nil {
+		t.Fatalf("write wake output: %v", err)
+	}
+	if err := output.Close(); err != nil {
+		t.Fatalf("close wake output: %v", err)
+	}
+	if filepath.Base(path) != ".wake.log" {
+		t.Fatalf("wake output path = %q, want .wake.log", path)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat wake output: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("wake output mode = %o, want 0600", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "fatal wake diagnostic\n" {
+		t.Fatalf("wake output data = %q err=%v", data, err)
+	}
+}
+
+func TestOpenCoopWakeOutputRejectsSymlinkLog(t *testing.T) {
+	root := secureTempDirForTest(t)
+	agentBase := fsq.AgentBase(root, "orchestrator")
+	if err := os.MkdirAll(agentBase, 0o700); err != nil {
+		t.Fatalf("mkdir agent base: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "wake.log")
+	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
+		t.Fatalf("write target log: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(agentBase, ".wake.log")); err != nil {
+		t.Fatalf("symlink wake log: %v", err)
+	}
+
+	output, err := openCoopWakeOutput(root, "orchestrator")
+	if err == nil {
+		_ = output.Close()
+		t.Fatal("expected symlink wake log rejection")
+	}
+	if !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
 func TestOpenWakeRepairOutputRejectsSymlinkLog(t *testing.T) {
 	root := secureTempDirForTest(t)
 	agentBase := fsq.AgentBase(root, "orchestrator")
@@ -4136,6 +6914,18 @@ func TestWakeInjectionPreconditionCheckSurfacesLegacyCapabilityChangeWithoutInje
 	cfg := wakeConfig{
 		me:         "codex",
 		injectMode: wakeInjectModePaste,
+		inputDelivery: wakeInputDeliveryState{
+			phase:   wakeInputRawRescueQueued,
+			mode:    wakeInjectModeRaw,
+			payload: "stale doorbell",
+		},
+		doorbell: wakeDoorbellState{
+			phase:            wakeDoorbellObserved,
+			token:            "11111111111111111111111111111111",
+			attempts:         2,
+			nextAttempt:      time.Unix(1_800_000_000, 0),
+			observationUntil: time.Unix(1_800_000_100, 0),
+		},
 		recordNotifierStatus: func(gotStatus, gotMode, gotReason string) error {
 			status, mode, reason = gotStatus, gotMode, gotReason
 			return nil
@@ -4162,6 +6952,17 @@ func TestWakeInjectionPreconditionCheckSurfacesLegacyCapabilityChangeWithoutInje
 	}
 	if cfg.injectMode != wakeInjectModeNone {
 		t.Fatalf("inject mode = %q, want none", cfg.injectMode)
+	}
+	if cfg.doorbell.phase != wakeDoorbellIdle ||
+		cfg.doorbell.token != "" ||
+		cfg.doorbell.attempts != 0 ||
+		!cfg.doorbell.nextAttempt.IsZero() ||
+		!cfg.doorbell.observationUntil.IsZero() ||
+		cfg.doorbell.observationUsed {
+		t.Fatalf("doorbell state survived capability demotion: %#v", cfg.doorbell)
+	}
+	if cfg.inputDelivery.pending() {
+		t.Fatalf("input delivery survived capability demotion: %#v", cfg.inputDelivery)
 	}
 	if status != wakeInjectorUnsupportedStatus || mode != wakeInjectModePaste {
 		t.Fatalf("status/mode = %q/%q, want %q/%q", status, mode, wakeInjectorUnsupportedStatus, wakeInjectModePaste)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -337,5 +337,6 @@ echo "claude-session-start.sh hook test ok"
 
 bash scripts/test_install_checksum.sh
 AMQ_TEST_BIN="$BIN" bash scripts/test_stop_hook.sh
+python3 scripts/test_codex_prompt_observed.py
 
 echo "smoke test ok"

--- a/scripts/test_codex_prompt_observed.py
+++ b/scripts/test_codex_prompt_observed.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "hooks" / "codex-prompt-observed.py"
+TOKEN = "0123456789abcdef0123456789abcdef"
+PROMPT = (
+    f": AMQ doorbell v1 token={TOKEN} "
+    "run amq drain --include-body then act on it"
+)
+
+
+def invoke(root, prompt):
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "test-session",
+        "turn_id": "test-turn",
+        "prompt": prompt,
+    }
+    env = dict(os.environ, AM_ROOT=str(root), AM_ME="codex")
+    return subprocess.run(
+        ["/usr/bin/python3", str(HOOK)],
+        input=json.dumps(event),
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=3,
+        check=False,
+    )
+
+
+def fixture():
+    temp = tempfile.TemporaryDirectory()
+    root = Path(temp.name) / "queue"
+    agent_dir = root / "agents" / "codex"
+    agent_dir.mkdir(parents=True, mode=0o700)
+    os.chmod(agent_dir, 0o700)
+    socket_path = agent_dir / ".w.test"
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(socket_path))
+    os.chmod(socket_path, 0o600)
+    server.listen(1)
+    server.settimeout(1)
+    lock = {
+        "pid": os.getpid(),
+        "tty": "/dev/ttys999",
+        "root": str(root.resolve()),
+        "agent": "codex",
+        "started": "2026-07-29T00:00:00Z",
+        "wake_mode": "raw",
+        "generation": "11111111111111111111111111111111",
+        "control_socket": str(socket_path),
+    }
+    lock_path = agent_dir / ".wake.lock"
+    lock_path.write_text(json.dumps(lock), encoding="utf-8")
+    os.chmod(lock_path, 0o600)
+    return temp, root, server
+
+
+def test_valid_prompt():
+    temp, root, server = fixture()
+    received = []
+
+    def accept():
+        connection, _ = server.accept()
+        with connection:
+            received.append(connection.recv(4096))
+            connection.sendall(b"ACK\n")
+
+    thread = threading.Thread(target=accept)
+    thread.start()
+    result = invoke(root, PROMPT)
+    thread.join(timeout=2)
+    server.close()
+    temp.cleanup()
+
+    assert result.returncode == 0, result
+    assert result.stdout == "" and result.stderr == "", result
+    assert len(received) == 1, received
+    request = json.loads(received[0])
+    assert request == {
+        "generation": "11111111111111111111111111111111",
+        "operation": "prompt_observed",
+        "token": TOKEN,
+    }, request
+
+
+def test_nonmatching_prompts_do_nothing():
+    variants = [
+        PROMPT + " ",
+        " " + PROMPT,
+        PROMPT.replace("token=", "TOKEN="),
+        PROMPT.replace(TOKEN, TOKEN.upper()),
+        PROMPT.replace(" then act on it", "; rm -rf /"),
+        "ordinary user prompt",
+    ]
+    for prompt in variants:
+        temp, root, server = fixture()
+        server.settimeout(0.1)
+        result = invoke(root, prompt)
+        try:
+            server.accept()
+            raise AssertionError(f"nonmatching prompt connected: {prompt!r}")
+        except TimeoutError:
+            pass
+        finally:
+            server.close()
+            temp.cleanup()
+        assert result.returncode == 0, result
+        assert result.stdout == "" and result.stderr == "", result
+
+
+def test_real_codex_hook():
+    if os.environ.get("AMQ_RUN_CODEX_HOOK_E2E") != "1":
+        return
+    temp, root, server = fixture()
+    checkout = tempfile.TemporaryDirectory()
+    checkout_root = Path(checkout.name)
+    (checkout_root / ".codex").mkdir()
+    (checkout_root / "hooks").mkdir()
+    shutil.copy2(REPO / "hooks" / "codex-hooks.json", checkout_root / "hooks" / "codex-hooks.json")
+    os.symlink("../hooks/codex-hooks.json", checkout_root / ".codex" / "hooks.json")
+    shutil.copy2(HOOK, checkout_root / "hooks" / HOOK.name)
+    subprocess.run(
+        ["git", "init", "--quiet", str(checkout_root)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    env = dict(os.environ, AM_ROOT=str(root), AM_ME="codex")
+    process = subprocess.Popen(
+        [
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--dangerously-bypass-hook-trust",
+            "--json",
+            "-C",
+            str(checkout_root),
+            PROMPT,
+        ],
+        cwd=checkout_root,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        server.settimeout(30)
+        connection, _ = server.accept()
+        with connection:
+            request = json.loads(connection.recv(4096))
+            connection.sendall(b"ACK\n")
+        assert request["operation"] == "prompt_observed", request
+        assert request["token"] == TOKEN, request
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=3)
+        server.close()
+        temp.cleanup()
+        checkout.cleanup()
+
+
+if __name__ == "__main__":
+    test_valid_prompt()
+    test_nonmatching_prompts_do_nothing()
+    test_real_codex_hook()
+    print("codex prompt-observed hook tests ok")


### PR DESCRIPTION
Fixes the AMQ wake failures reproduced in live Codex sessions:

- retries unobserved tokenized doorbells without replaying partial terminal input
- isolates printable diagnostics from alternate-screen TUI attention
- preserves exact lifecycle and terminal capabilities across retries and repairs
- transfers input obligations exactly once on permanent output fallback
- records Codex prompt observation through the packaged hook

Verification:

- ChatGPT Pro via Yoetz: ARCHITECTURE PASS on exact tree b3b27f81a837ab65a7d915ea38cc498656bff550
- independent exact-tree review: PASS, including RED on the prior broken maintenance path and GREEN on this tree
- go test ./... -count=1 -timeout=3m
- go test -race ./internal/cli -count=1
- go vet ./...
- make ci (lint 0 issues)
- cross-compile all test-bearing packages for Linux/amd64, Darwin/arm64, and FreeBSD/amd64

BEGIN_COMMIT_OVERRIDE
fix(wake): retry unobserved Codex doorbells

feat(codex): report accepted AMQ doorbells
END_COMMIT_OVERRIDE