### PR TITLE
fix(wake): restore rate-limited attention retries

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -306,13 +306,17 @@ Wake treats one transport execution only as a delivery attempt. While the same
 inbox cohort remains unread, it retries on its own capped backoff. The first
 notification is immediate. Attempts that inject the fixed doorbell start at 5
 seconds because they drive the agent; attention-only attempts start at 30
-seconds because they alert a human. Both double to a 2-minute cap. Contextual
-peer headers appear only in terminal output or attention; terminal input always
-uses the fixed doorbell. The delay starts after the prior injector process exits
-or times out. Because an external injector is arbitrary local code, retries can
-duplicate its side effects. Removing or replacing any message from that cohort
-is durable progress and immediately rearms the next notification. Owner-bound
-retries do not repeat the out-of-band attention text.
+seconds because they alert a human. Input attempts double to a 2-minute cap;
+attention-only attempts continue through 4 and 8 minutes to a 15-minute cap.
+Retries never give up while the cohort remains unread. Contextual peer headers
+appear only in terminal output or attention; terminal input always uses the
+fixed doorbell. The delay starts after the prior injector process exits or times
+out. Because an external injector is arbitrary local code, retries can duplicate
+its side effects. Removing or replacing any message from that cohort is durable
+progress and immediately rearms the next notification. Owner-bound retries do
+not emit attention when terminal input succeeds; when input is unavailable or
+fails, attention becomes the delivered channel and repeats on its slower
+cadence.
 
 For orchestrators or hardened environments without a controlling TTY, use an
 explicit external transport:

--- a/README.md
+++ b/README.md
@@ -112,11 +112,15 @@ Wake treats terminal notification as an attempt, not delivery, and retries on
 a capped backoff until the inbox makes durable progress. The first notification
 is immediate. Attempts that inject the fixed doorbell start at 5 seconds because
 they drive the agent; attention-only attempts start at 30 seconds because they
-alert a human. Both double to a 2-minute cap. Contextual peer headers appear
-only in terminal output or attention; terminal input always uses the fixed
-doorbell. The delay starts after the preceding injector process exits or times
-out. Because `--wake-inject-via` executes arbitrary local code, a retry can
-repeat injector-side effects.
+alert a human. Input attempts double to a 2-minute cap; attention-only attempts
+continue through 4 and 8 minutes to a 15-minute cap. Retries never give up while
+the cohort remains unread. Contextual peer headers appear only in terminal
+output or attention; terminal input always uses the fixed doorbell. The delay
+starts after the preceding injector process exits or times out. Because
+`--wake-inject-via` executes arbitrary local code, a retry can repeat
+injector-side effects. A successful input attempt does not also emit attention;
+when input is unavailable or fails, attention becomes the delivered channel and
+repeats on its slower cadence.
 
 > **First-message check:** start both agents before sending the test message.
 > A newly started wake deliberately baselines messages that were already

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -54,7 +54,6 @@ type wakeConfig struct {
 	inputRecoveryRequired bool
 	doorbell              wakeDoorbellState
 	doorbellNow           func() time.Time
-	suppressAttention     bool
 	lastAttemptAttention  bool
 	onBaselineReady       func(map[string]wakeFileIdentity) error
 	onPrepared            func(wakeAdmissionWatcher) error
@@ -574,23 +573,12 @@ func deliverNewMessageNotification(
 			text:       plan.prompt,
 			provenance: wakePayloadSystemFixed,
 		}
-		deliveryErr := deliverPlannedWakeNotification(
-			cfg,
-			notice,
-			deferForInput,
-			plan.retry,
-		)
+		deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
 		if isWakeInputDemotionBlocked(deliveryErr) {
 			return enterWakeInputRecovery(cfg, currentPending, deliveryErr)
 		}
 		if cfg.injectMode == wakeInjectModeNone {
 			clearWakeInputState(cfg)
-			if plan.retry {
-				deliveryErr = errors.Join(
-					deliveryErr,
-					emitWakeAttention(cfg, notice.output),
-				)
-			}
 			if deliveryErr == nil {
 				// Permanent input demotion retires the old doorbell state.
 				// Re-arm the unread cohort before recording the fallback.
@@ -605,12 +593,7 @@ func deliverNewMessageNotification(
 		return deliveryErr
 	}
 
-	deliveryErr := deliverPlannedWakeNotification(
-		cfg,
-		notice,
-		deferForInput,
-		plan.retry,
-	)
+	deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
 	if isWakeInputDemotionBlocked(deliveryErr) {
 		return enterWakeInputRecovery(cfg, currentPending, deliveryErr)
 	}
@@ -620,19 +603,8 @@ func deliverNewMessageNotification(
 	return deliveryErr
 }
 
-func deliverPlannedWakeNotification(
-	cfg *wakeConfig,
-	notice wakeNotification,
-	deferForInput, retry bool,
-) error {
-	previous := cfg.suppressAttention
-	cfg.suppressAttention = previous || retry
-	err := deliverWakeNotification(cfg, notice, deferForInput)
-	cfg.suppressAttention = previous
-	return err
-}
-
 func recordWakeAttempt(cfg *wakeConfig, now time.Time) {
+	cfg.doorbell.phase = wakeDoorbellRetrying
 	if cfg.lastAttemptAttention {
 		cfg.doorbell.recordAttentionAttempt(now)
 		return
@@ -945,10 +917,14 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	if cfg.injectVia != "" {
 		allowed, guardErr := authorizeTerminalWrite(cfg)
 		if guardErr != nil {
-			return guardErr
+			return deliverWakeAttentionAfterInputRefusal(
+				cfg,
+				notice.output,
+				guardErr,
+			)
 		}
 		if !allowed {
-			return nil
+			return deliverWakeAttentionOnly(cfg, notice.output)
 		}
 		if err := injectVia(cfg, plainText); err != nil {
 			if cfg.fallbackWarn {
@@ -966,6 +942,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		_ = writeWakeDiagnostic(cfg, "amq wake [debug]: mode=%s text_len=%d\n", mode, len(inputText))
 	}
 	var injectErr error
+	inputAccepted := false
 	switch mode {
 	case wakeInjectModeRaw:
 		// Raw mode: inject text and CR separately to avoid paste detection.
@@ -975,7 +952,8 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		if cfg.bell && !ownerBound {
 			injectedText = "\a" + injectedText
 		}
-		_, injectErr = injectRawNotification(cfg, injectedText)
+		inputAccepted, injectErr = injectRawNotification(cfg, injectedText)
+		inputAccepted = inputAccepted || cfg.inputDelivery.confirmedInput()
 
 	case wakeInjectModePaste:
 		// Paste mode: bracketed paste with delayed CR
@@ -988,16 +966,23 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		if cfg.bell && !ownerBound {
 			pasteText = "\a" + pasteText
 		}
-		_, injectErr = injectTerminalNotification(cfg, wakeInjectModePaste, pasteText)
+		inputAccepted, injectErr = injectTerminalNotification(
+			cfg,
+			wakeInjectModePaste,
+			pasteText,
+		)
+		inputAccepted = inputAccepted || cfg.inputDelivery.confirmedInput()
 
 	default:
 		// Unknown mode, fall back to raw
 		if ownerBound {
 			wrote, err := writeTerminalChunk(cfg, inputText)
+			inputAccepted = wrote
 			if err != nil {
 				injectErr = err
 			} else if wrote {
-				_, err := writeTerminalChunk(cfg, "\r")
+				submitted, err := writeTerminalChunk(cfg, "\r")
+				inputAccepted = inputAccepted || submitted
 				injectErr = err
 			}
 		} else {
@@ -1005,7 +990,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 			if cfg.bell {
 				injectedText = "\a" + injectedText
 			}
-			_, injectErr = writeTerminalChunk(cfg, injectedText)
+			inputAccepted, injectErr = writeTerminalChunk(cfg, injectedText)
 		}
 	}
 
@@ -1045,6 +1030,13 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		}
 		var authorityErr *wakeTerminalAuthorityError
 		if errors.As(injectErr, &authorityErr) {
+			if !cfg.inputDelivery.confirmedInput() {
+				return deliverWakeAttentionAfterInputRefusal(
+					cfg,
+					notice.output,
+					injectErr,
+				)
+			}
 			return injectErr
 		}
 		if cfg.fallbackWarn {
@@ -1055,13 +1047,37 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		// Fallback: use the output-only attention tier; never retry input.
 		return deliverWakeAttentionOnly(cfg, notice.output)
 	}
+	if !inputAccepted {
+		return deliverWakeAttentionOnly(cfg, notice.output)
+	}
 
 	return nil
 }
 
+func deliverWakeAttentionAfterInputRefusal(
+	cfg *wakeConfig,
+	payload wakePayload,
+	cause error,
+) error {
+	if err := deliverWakeAttentionOnly(cfg, payload); err != nil {
+		return errors.Join(cause, err)
+	}
+	if isWakeTerminalAuthorityLoss(cause) &&
+		!isWakeTerminalForegroundPGRPChanged(cause) {
+		// Loss of the retained terminal or wake generation is fatal even when
+		// the final attention write succeeds. A replacement wake, not this
+		// stale owner, must retry the inbox cohort.
+		return cause
+	}
+	return nil
+}
+
 func deliverWakeAttentionOnly(cfg *wakeConfig, payload wakePayload) error {
+	if err := emitWakeAttention(cfg, payload); err != nil {
+		return err
+	}
 	cfg.lastAttemptAttention = true
-	return emitWakeAttention(cfg, payload)
+	return nil
 }
 
 func usesCoopDoorbell(cfg *wakeConfig) bool {

--- a/internal/cli/wake_attention.go
+++ b/internal/cli/wake_attention.go
@@ -65,9 +65,6 @@ func wakeDiagnosticIsTerminal(cfg *wakeConfig) bool {
 // Effects record only a complete write by AMQ; they do not assert that a
 // terminal rendered them or that a person observed them.
 func emitWakeAttention(cfg *wakeConfig, payload wakePayload) error {
-	if cfg != nil && cfg.suppressAttention {
-		return nil
-	}
 	isTerminal := wakeAttentionIsTerminal(cfg)
 	writePlainOutput := !isTerminal || cfg == nil || !wakeUsesAlternateScreenTUI(cfg.me)
 	var effects []string

--- a/internal/cli/wake_attention_test.go
+++ b/internal/cli/wake_attention_test.go
@@ -359,6 +359,45 @@ func TestWakeAttentionReportsOnlyFullyWrittenOutputEffectsAndProvenance(t *testi
 	}
 }
 
+func TestDeliverWakeAttentionOnlyMarksAttemptAfterCompleteWrite(t *testing.T) {
+	payload := wakePayload{
+		text:       "safe notice",
+		provenance: wakePayloadSystemFixed,
+	}
+
+	t.Run("complete", func(t *testing.T) {
+		cfg := &wakeConfig{
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				return len(data), nil
+			},
+		}
+		if err := deliverWakeAttentionOnly(cfg, payload); err != nil {
+			t.Fatalf("deliver complete attention: %v", err)
+		}
+		if !cfg.lastAttemptAttention {
+			t.Fatal("complete attention was not recorded as the delivered channel")
+		}
+	})
+
+	t.Run("short", func(t *testing.T) {
+		cfg := &wakeConfig{
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				return len(data) - 1, nil
+			},
+		}
+		captureWakeStderr(t, func() {
+			if err := deliverWakeAttentionOnly(cfg, payload); err == nil {
+				t.Fatal("short attention write succeeded")
+			}
+		})
+		if cfg.lastAttemptAttention {
+			t.Fatal("short attention write was recorded as the delivered channel")
+		}
+	})
+}
+
 func TestWakeAttentionAlternateScreenAgentOmitsPlainTerminalOutput(t *testing.T) {
 	for _, me := range []string{"codex", "codex2", "claude"} {
 		t.Run(me, func(t *testing.T) {

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -17,6 +17,7 @@ const (
 	wakeDoorbellRetryBase          = 5 * time.Second
 	wakeDoorbellAttentionRetryBase = 30 * time.Second
 	wakeDoorbellRetryMax           = 2 * time.Minute
+	wakeDoorbellAttentionRetryMax  = 15 * time.Minute
 )
 
 type wakeDoorbellState struct {
@@ -29,7 +30,6 @@ type wakeDoorbellState struct {
 
 type wakeDoorbellPlan struct {
 	attempt  bool
-	retry    bool
 	prompt   string
 	progress bool
 }
@@ -56,7 +56,6 @@ func (state *wakeDoorbellState) plan(
 
 	return wakeDoorbellPlan{
 		attempt:  true,
-		retry:    state.attempts > 0,
 		prompt:   coopWakeDoorbell,
 		progress: progress,
 	}
@@ -68,19 +67,26 @@ func (state *wakeDoorbellState) arm(current map[string]os.FileInfo) {
 }
 
 func (state *wakeDoorbellState) recordAttempt(now time.Time) {
-	state.recordAttemptWithBase(now, wakeDoorbellRetryBase)
+	state.recordAttemptWithBase(now, wakeDoorbellRetryBase, wakeDoorbellRetryMax)
 }
 
 func (state *wakeDoorbellState) recordAttentionAttempt(now time.Time) {
-	state.recordAttemptWithBase(now, wakeDoorbellAttentionRetryBase)
+	state.recordAttemptWithBase(
+		now,
+		wakeDoorbellAttentionRetryBase,
+		wakeDoorbellAttentionRetryMax,
+	)
 }
 
-func (state *wakeDoorbellState) recordAttemptWithBase(now time.Time, base time.Duration) {
+func (state *wakeDoorbellState) recordAttemptWithBase(
+	now time.Time,
+	base, maximum time.Duration,
+) {
 	state.attempts++
 	state.nextAttempt = now.Add(cappedExponentialBackoff(
 		state.attempts,
 		base,
-		wakeDoorbellRetryMax,
+		maximum,
 	))
 }
 
@@ -150,10 +156,6 @@ func (state *wakeDoorbellState) nextDeadline() (time.Time, bool) {
 
 func (state *wakeDoorbellState) reset() {
 	*state = wakeDoorbellState{}
-}
-
-func wakeDoorbellRetryDelay(attempt uint) time.Duration {
-	return cappedExponentialBackoff(attempt, wakeDoorbellRetryBase, wakeDoorbellRetryMax)
 }
 
 func cappedExponentialBackoff(attempt uint, base, maximum time.Duration) time.Duration {

--- a/internal/cli/wake_doorbell_test.go
+++ b/internal/cli/wake_doorbell_test.go
@@ -42,7 +42,7 @@ func TestWakeDoorbellStateRetriesUntilInboxProgress(t *testing.T) {
 	var state wakeDoorbellState
 
 	plan := state.plan(now, current)
-	if !plan.attempt || plan.retry || plan.prompt != coopWakeDoorbell {
+	if !plan.attempt || plan.prompt != coopWakeDoorbell {
 		t.Fatalf("initial plan = %#v", plan)
 	}
 	state.recordAttempt(now)
@@ -52,13 +52,13 @@ func TestWakeDoorbellStateRetriesUntilInboxProgress(t *testing.T) {
 		t.Fatalf("early retry plan = %#v", plan)
 	}
 	plan = state.plan(now.Add(wakeDoorbellRetryBase), current)
-	if !plan.attempt || !plan.retry || plan.prompt != coopWakeDoorbell {
+	if !plan.attempt || plan.prompt != coopWakeDoorbell {
 		t.Fatalf("due retry plan = %#v", plan)
 	}
 
 	remaining := map[string]os.FileInfo{"b.md": current["b.md"]}
 	plan = state.plan(now.Add(wakeDoorbellRetryBase+time.Millisecond), remaining)
-	if !plan.attempt || plan.retry {
+	if !plan.attempt {
 		t.Fatalf("progress plan = %#v", plan)
 	}
 	if state.attempts != 0 || len(state.cohort) != 1 {
@@ -89,7 +89,7 @@ func TestWakeDoorbellStateRearmsWhenUnknownIdentityBecomesKnown(t *testing.T) {
 
 	known := wakeDoorbellTestFiles(t, "readable.md")
 	plan := state.plan(now.Add(time.Second), known)
-	if !plan.attempt || plan.retry {
+	if !plan.attempt {
 		t.Fatalf("identity recovery plan = %#v", plan)
 	}
 }
@@ -105,7 +105,7 @@ func TestWakeDoorbellStateKeepsRetryWhenKnownIdentityBecomesUnavailable(t *testi
 
 	temporarilyUnknown := map[string]os.FileInfo{"readable.md": nil}
 	plan := state.plan(now.Add(wakeDoorbellRetryBase), temporarilyUnknown)
-	if !plan.attempt || !plan.retry {
+	if !plan.attempt {
 		t.Fatalf("temporarily unknown plan = %#v", plan)
 	}
 }
@@ -154,20 +154,58 @@ func TestWakeDoorbellRecoveryAttentionIsCohortBoundedAndRateLimited(t *testing.T
 	}
 }
 
-func TestWakeDoorbellRetryDelayCaps(t *testing.T) {
-	cases := []struct {
-		attempt uint
-		want    time.Duration
+func TestWakeDoorbellRetryCadenceCapsPerDeliveredChannel(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	tests := []struct {
+		name   string
+		record func(*wakeDoorbellState, time.Time)
+		wants  []time.Duration
 	}{
-		{attempt: 1, want: 5 * time.Second},
-		{attempt: 2, want: 10 * time.Second},
-		{attempt: 5, want: 80 * time.Second},
-		{attempt: 6, want: 2 * time.Minute},
-		{attempt: 1000, want: 2 * time.Minute},
+		{
+			name: "input",
+			record: func(state *wakeDoorbellState, attemptAt time.Time) {
+				state.recordAttempt(attemptAt)
+			},
+			wants: []time.Duration{
+				5 * time.Second,
+				10 * time.Second,
+				20 * time.Second,
+				40 * time.Second,
+				80 * time.Second,
+				2 * time.Minute,
+				2 * time.Minute,
+			},
+		},
+		{
+			name: "attention",
+			record: func(state *wakeDoorbellState, attemptAt time.Time) {
+				state.recordAttentionAttempt(attemptAt)
+			},
+			wants: []time.Duration{
+				30 * time.Second,
+				time.Minute,
+				2 * time.Minute,
+				4 * time.Minute,
+				8 * time.Minute,
+				15 * time.Minute,
+				15 * time.Minute,
+			},
+		},
 	}
-	for _, tc := range cases {
-		if got := wakeDoorbellRetryDelay(tc.attempt); got != tc.want {
-			t.Fatalf("attempt %d delay = %s, want %s", tc.attempt, got, tc.want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var state wakeDoorbellState
+			for attempt, want := range tt.wants {
+				tt.record(&state, now)
+				if got := state.nextAttempt.Sub(now); got != want {
+					t.Fatalf(
+						"attempt %d delay = %s, want %s",
+						attempt+1,
+						got,
+						want,
+					)
+				}
+			}
+		})
 	}
 }

--- a/internal/cli/wake_terminal_authority_unix_test.go
+++ b/internal/cli/wake_terminal_authority_unix_test.go
@@ -678,11 +678,19 @@ func TestRunWakeLoopTerminatesOnTerminalAuthorityLoss(t *testing.T) {
 	}
 	loss := newWakeTerminalAuthorityLoss("test authority loss", nil)
 	terminalWriteCalled := false
+	attentionWrites := 0
 	err = runWakeLoop(wakeConfig{
 		root:        root,
 		me:          "codex",
 		injectMode:  wakeInjectModeRaw,
 		controlStop: make(chan struct{}),
+		attentionIsTTY: func() bool {
+			return false
+		},
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
 		beforeTerminalWrite: func() error {
 			return loss
 		},
@@ -710,9 +718,12 @@ func TestRunWakeLoopTerminatesOnTerminalAuthorityLoss(t *testing.T) {
 	if terminalWriteCalled {
 		t.Fatal("wake loop wrote after terminal authority loss")
 	}
+	if attentionWrites != 1 {
+		t.Fatalf("wake loop authority-loss attention writes = %d, want 1", attentionWrites)
+	}
 }
 
-func TestRunWakeLoopHoldsNotificationDuringForegroundPGRPMismatch(t *testing.T) {
+func TestRunWakeLoopUsesAttentionCadenceAfterZeroProgressForegroundPGRPMismatch(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	message := format.Message{
@@ -740,8 +751,8 @@ func TestRunWakeLoopHoldsNotificationDuringForegroundPGRPMismatch(t *testing.T) 
 	}
 
 	firstRefused := make(chan struct{}, 1)
-	restored := make(chan struct{})
 	delivered := make(chan struct{}, 1)
+	attention := make(chan struct{}, 1)
 	controlStop := make(chan struct{})
 	runDone := make(chan error, 1)
 
@@ -751,17 +762,22 @@ func TestRunWakeLoopHoldsNotificationDuringForegroundPGRPMismatch(t *testing.T) 
 			me:          "codex",
 			injectMode:  wakeInjectModeRaw,
 			controlStop: controlStop,
+			attentionIsTTY: func() bool {
+				return false
+			},
+			attentionWrite: func(data []byte) (int, error) {
+				select {
+				case attention <- struct{}{}:
+				default:
+				}
+				return len(data), nil
+			},
 			beforeTerminalWrite: func() error {
 				select {
-				case <-restored:
-					return nil
+				case firstRefused <- struct{}{}:
 				default:
-					select {
-					case firstRefused <- struct{}{}:
-					default:
-					}
-					return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
 				}
+				return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
 			},
 			terminalWrite: func(string) error {
 				select {
@@ -780,29 +796,27 @@ func TestRunWakeLoopHoldsNotificationDuringForegroundPGRPMismatch(t *testing.T) 
 	case <-time.After(2 * time.Second):
 		t.Fatal("wake loop did not attempt held notification")
 	}
+	select {
+	case <-attention:
+	case err := <-runDone:
+		t.Fatalf("wake loop exited before authority attention: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop emitted no attention for zero-progress authority refusal")
+	}
 
 	select {
 	case <-delivered:
 		t.Fatal("wake loop wrote while foreground pgrp mismatched")
 	case err := <-runDone:
 		t.Fatalf("wake loop exited while foreground pgrp mismatched: %v", err)
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	close(restored)
-	select {
-	case <-delivered:
-	case err := <-runDone:
-		t.Fatalf("wake loop exited before delivering held notification: %v", err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("held notification was not delivered after foreground pgrp restored")
+	case <-time.After(wakeTerminalAuthorityRetryDelay + 100*time.Millisecond):
 	}
 
 	close(controlStop)
 	select {
 	case err := <-runDone:
 		if err != nil {
-			t.Fatalf("wake loop after restored delivery: %v", err)
+			t.Fatalf("wake loop stop: %v", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("wake loop did not stop")

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -2136,6 +2136,12 @@ func TestNotifyNewMessagesOwnerlessRefusedWriteRemainsRetryEligible(t *testing.T
 	controlStop := make(chan struct{})
 	close(controlStop)
 	now := time.Unix(1_800_000_000, 0)
+	writtenBytes := 0
+	attentionWrites := 0
+	stubTIOCSTIInject(t, func(text string) error {
+		writtenBytes += len(text)
+		return nil
+	})
 	cfg := &wakeConfig{
 		me:          "codex",
 		root:        root,
@@ -2143,26 +2149,93 @@ func TestNotifyNewMessagesOwnerlessRefusedWriteRemainsRetryEligible(t *testing.T
 		injectMode:  wakeInjectModeRaw,
 		controlStop: controlStop,
 		doorbellNow: func() time.Time { return now },
+		attentionIsTTY: func() bool {
+			return false
+		},
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
 	}
 
 	if err := notifyNewMessages(cfg); err != nil {
 		t.Fatalf("notify refused write: %v", err)
 	}
+	if writtenBytes != 0 {
+		t.Fatalf("refused write injected %d bytes, want 0", writtenBytes)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("refused write attention writes = %d, want 1", attentionWrites)
+	}
 	if cfg.doorbell.attempts != 1 {
 		t.Fatalf("attempts after refused write = %d, want 1", cfg.doorbell.attempts)
 	}
 	if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
-		!deadline.Equal(now.Add(wakeDoorbellRetryBase)) {
+		!deadline.Equal(now.Add(wakeDoorbellAttentionRetryBase)) {
 		t.Fatalf(
 			"deadline after refused write = %s, ok=%v; want %s",
 			deadline,
 			ok,
-			now.Add(wakeDoorbellRetryBase),
+			now.Add(wakeDoorbellAttentionRetryBase),
 		)
 	}
 }
 
-func TestNotifyNewMessagesOwnerlessRetrySuppressesRepeatedPeerAttention(t *testing.T) {
+func TestNotifyNewMessagesOwnerlessAuthorityErrorBeforeInputUsesAttentionCadence(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "authority-refused")
+
+	now := time.Unix(1_800_000_000, 0)
+	authorityErr := errors.New("terminal authority changed")
+	inputWrites := 0
+	attentionWrites := 0
+	cfg := &wakeConfig{
+		me:          "codex",
+		root:        root,
+		session:     "session1",
+		injectMode:  wakeInjectModeRaw,
+		controlStop: make(chan struct{}),
+		doorbellNow: func() time.Time { return now },
+		beforeTerminalWrite: func() error {
+			return authorityErr
+		},
+		terminalWrite: func(string) error {
+			inputWrites++
+			return nil
+		},
+		attentionIsTTY: func() bool {
+			return false
+		},
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify authority refusal: %v", err)
+	}
+	if inputWrites != 0 {
+		t.Fatalf("authority refusal wrote %d input chunks, want 0", inputWrites)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("authority refusal attention writes = %d, want 1", attentionWrites)
+	}
+	if cfg.doorbell.attempts != 1 {
+		t.Fatalf("attempts after authority refusal = %d, want 1", cfg.doorbell.attempts)
+	}
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
+		!deadline.Equal(now.Add(wakeDoorbellAttentionRetryBase)) {
+		t.Fatalf(
+			"deadline after authority refusal = %s, ok=%v; want %s",
+			deadline,
+			ok,
+			now.Add(wakeDoorbellAttentionRetryBase),
+		)
+	}
+}
+
+func TestNotifyNewMessagesOwnerlessFallbackRateLimitsRepeatedPeerAttention(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatal(err)
@@ -2217,15 +2290,113 @@ func TestNotifyNewMessagesOwnerlessRetrySuppressesRepeatedPeerAttention(t *testi
 	if len(attentions) != 1 || !strings.Contains(attentions[0], "review the retry") {
 		t.Fatalf("first ownerless attention = %#v, want one peer notice", attentions)
 	}
-	now = now.Add(wakeDoorbellAttentionRetryBase)
+	now = now.Add(wakeDoorbellAttentionRetryBase - time.Millisecond)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("ownerless early retry: %v", err)
+	}
+	if len(attentions) != 1 {
+		t.Fatalf("ownerless fallback repeated before deadline: %#v", attentions)
+	}
+	now = now.Add(time.Millisecond)
 	if err := notifyNewMessages(cfg); err != nil {
 		t.Fatalf("ownerless retry: %v", err)
 	}
 	if cfg.doorbell.attempts != 2 {
 		t.Fatalf("ownerless attempts = %d, want 2", cfg.doorbell.attempts)
 	}
-	if len(attentions) != 1 {
-		t.Fatalf("ownerless retry repeated peer attention: %#v", attentions)
+	if len(attentions) != 2 || !strings.Contains(attentions[1], "review the retry") {
+		t.Fatalf("ownerless fallback attention = %#v, want two rate-limited peer notices", attentions)
+	}
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
+		!deadline.Equal(now.Add(time.Minute)) {
+		t.Fatalf(
+			"attention fallback deadline = %s, ok=%v; want %s",
+			deadline,
+			ok,
+			now.Add(time.Minute),
+		)
+	}
+}
+
+func TestNotifyNewMessagesOwnerlessSuccessfulInputRetryEmitsNoAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "ownerless-input")
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	now := time.Unix(1_800_000_000, 0)
+	var injected, attentions []string
+	stubTIOCSTIInject(t, func(text string) error {
+		injected = append(injected, text)
+		return nil
+	})
+	cfg := &wakeConfig{
+		me:             "codex",
+		root:           root,
+		session:        "session1",
+		injectMode:     wakeInjectModeRaw,
+		doorbellNow:    func() time.Time { return now },
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentions = append(attentions, string(data))
+			return len(data), nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first ownerless input attempt: %v", err)
+	}
+	firstInputChunks := len(injected)
+	if firstInputChunks == 0 {
+		t.Fatal("first ownerless attempt injected no input")
+	}
+	now = now.Add(wakeDoorbellRetryBase)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("ownerless input retry: %v", err)
+	}
+	if len(injected) <= firstInputChunks {
+		t.Fatal("ownerless retry injected no additional input")
+	}
+	if len(attentions) != 0 {
+		t.Fatalf("successful ownerless input attempts emitted attention: %#v", attentions)
+	}
+}
+
+func TestRecordWakeAttemptForcesRetryPhase(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	tests := []struct {
+		name  string
+		phase wakeDoorbellPhase
+	}{
+		{name: "idle", phase: wakeDoorbellIdle},
+		{name: "recovery required", phase: wakeDoorbellRecoveryRequired},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &wakeConfig{
+				doorbell: wakeDoorbellState{phase: tt.phase},
+			}
+
+			recordWakeAttempt(cfg, now)
+
+			if cfg.doorbell.phase != wakeDoorbellRetrying {
+				t.Fatalf(
+					"recorded phase = %d, want retrying",
+					cfg.doorbell.phase,
+				)
+			}
+			if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
+				!deadline.Equal(now.Add(wakeDoorbellRetryBase)) {
+				t.Fatalf(
+					"recorded deadline = %s, ok=%v; want %s",
+					deadline,
+					ok,
+					now.Add(wakeDoorbellRetryBase),
+				)
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -2815,8 +2815,8 @@ func runWakeLoop(cfg wakeConfig) error {
 	}
 
 	// Recheck non-invasive injection preconditions and silently reconcile
-	// durable pending work every 30s. Doorbell retries use finite generation
-	// deadlines and never emit periodic alternate-screen output.
+	// durable pending work every 30s. Independent doorbell deadlines keep
+	// re-notifying unread cohorts, with separate input and attention cadences.
 	maintenanceTicks := cfg.maintenanceTicks
 	var maintenanceTicker *time.Ticker
 	if maintenanceTicks == nil {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -154,13 +154,20 @@ func TestNotifyNewMessagesForegroundPGRPResumesAtFirstMissingChunk(t *testing.T)
 			var writes []string
 			guardCalls := 0
 			failed := false
+			now := time.Unix(1_800_000_000, 0)
+			attentionWrites := 0
 			cfg := &wakeConfig{
 				root:           root,
 				me:             tc.me,
 				session:        "session1",
 				wakeOwner:      &wakeOwner{},
 				injectMode:     tc.mode,
+				doorbellNow:    func() time.Time { return now },
 				attentionIsTTY: func() bool { return false },
+				attentionWrite: func(data []byte) (int, error) {
+					attentionWrites++
+					return len(data), nil
+				},
 				beforeTerminalWrite: func() error {
 					guardCalls++
 					if !failed && guardCalls == tc.failAt {
@@ -176,25 +183,59 @@ func TestNotifyNewMessagesForegroundPGRPResumesAtFirstMissingChunk(t *testing.T)
 			}
 
 			err := notifyNewMessages(cfg)
-			if !isWakeTerminalForegroundPGRPChanged(err) {
+			if tc.failAt == 1 {
+				if err != nil {
+					t.Fatalf("zero-progress refusal = %v, want attention fallback", err)
+				}
+				if attentionWrites != 1 {
+					t.Fatalf("zero-progress attention writes = %d, want 1", attentionWrites)
+				}
+			} else if !isWakeTerminalForegroundPGRPChanged(err) {
 				t.Fatalf("first notify error = %T %v, want foreground-PGRP change", err, err)
 			}
 			if got := strings.Join(writes, "|"); got != strings.Join(tc.firstWant, "|") {
 				t.Fatalf("first writes = %q, want %q", got, strings.Join(tc.firstWant, "|"))
 			}
-			if cfg.doorbell.attempts != 0 {
-				t.Fatalf("attempts after foreground refusal = %d, want 0", cfg.doorbell.attempts)
+			wantAttempts := uint(0)
+			if tc.failAt == 1 {
+				wantAttempts = 1
+			}
+			if cfg.doorbell.attempts != wantAttempts {
+				t.Fatalf(
+					"attempts after foreground refusal = %d, want %d",
+					cfg.doorbell.attempts,
+					wantAttempts,
+				)
 			}
 
 			writes = nil
+			if tc.failAt == 1 {
+				now = now.Add(wakeDoorbellAttentionRetryBase)
+			}
 			if err := notifyNewMessages(cfg); err != nil {
 				t.Fatalf("retry notify: %v", err)
 			}
 			if got := strings.Join(writes, "|"); got != strings.Join(tc.retryWant, "|") {
 				t.Fatalf("retry writes = %q, want %q", got, strings.Join(tc.retryWant, "|"))
 			}
-			if cfg.doorbell.attempts != 1 {
-				t.Fatalf("attempts after completed retry = %d, want 1", cfg.doorbell.attempts)
+			wantAttempts++
+			if cfg.doorbell.attempts != wantAttempts {
+				t.Fatalf(
+					"attempts after completed retry = %d, want %d",
+					cfg.doorbell.attempts,
+					wantAttempts,
+				)
+			}
+			wantAttentionWrites := 0
+			if tc.failAt == 1 {
+				wantAttentionWrites = 1
+			}
+			if attentionWrites != wantAttentionWrites {
+				t.Fatalf(
+					"attention writes after input retry = %d, want %d",
+					attentionWrites,
+					wantAttentionWrites,
+				)
 			}
 		})
 	}
@@ -372,6 +413,7 @@ func TestNotifyNewMessagesReconcilesPartialDeliveryAfterInboxDrain(t *testing.T)
 			var writes []string
 			guardCalls := 0
 			failed := false
+			attentionWrites := 0
 			cfg := &wakeConfig{
 				root:           root,
 				me:             "codex",
@@ -379,6 +421,10 @@ func TestNotifyNewMessagesReconcilesPartialDeliveryAfterInboxDrain(t *testing.T)
 				wakeOwner:      &wakeOwner{},
 				injectMode:     tc.mode,
 				attentionIsTTY: func() bool { return false },
+				attentionWrite: func(data []byte) (int, error) {
+					attentionWrites++
+					return len(data), nil
+				},
 				beforeTerminalWrite: func() error {
 					guardCalls++
 					if !failed && guardCalls == tc.failAt {
@@ -394,7 +440,17 @@ func TestNotifyNewMessagesReconcilesPartialDeliveryAfterInboxDrain(t *testing.T)
 			}
 
 			err := notifyNewMessages(cfg)
-			if !isWakeTerminalForegroundPGRPChanged(err) {
+			if tc.failAt == 1 {
+				if err != nil {
+					t.Fatalf("zero-progress refusal = %v, want attention fallback", err)
+				}
+				if attentionWrites != 1 {
+					t.Fatalf("zero-progress attention writes = %d, want 1", attentionWrites)
+				}
+				if cfg.inputDelivery.confirmedInput() {
+					t.Fatalf("zero-progress refusal retained confirmed input: %#v", cfg.inputDelivery)
+				}
+			} else if !isWakeTerminalForegroundPGRPChanged(err) {
 				t.Fatalf("first notify error = %T %v, want foreground-PGRP change", err, err)
 			}
 			if drained := runDrainJSON(t, root, "codex", 0, false); drained.Count != 1 {
@@ -407,6 +463,9 @@ func TestNotifyNewMessagesReconcilesPartialDeliveryAfterInboxDrain(t *testing.T)
 			}
 			if got := strings.Join(writes, "|"); got != strings.Join(tc.reconcileWant, "|") {
 				t.Fatalf("reconciliation writes = %q, want %q", got, strings.Join(tc.reconcileWant, "|"))
+			}
+			if cfg.inputDelivery.pending() {
+				t.Fatalf("reconciliation retained input state: %#v", cfg.inputDelivery)
 			}
 		})
 	}
@@ -1913,14 +1972,22 @@ func TestNotifyNewMessagesAttentionOnlyRetryCadence(t *testing.T) {
 		30 * time.Second,
 		time.Minute,
 		2 * time.Minute,
-		2 * time.Minute,
+		4 * time.Minute,
+		8 * time.Minute,
+		15 * time.Minute,
+		15 * time.Minute,
 	}
 	for attempt, wantDelay := range wantDelays {
 		if err := notifyNewMessages(cfg); err != nil {
 			t.Fatalf("attention attempt %d: %v", attempt+1, err)
 		}
-		if writes != 1 {
-			t.Fatalf("attention writes after attempt %d = %d, want 1", attempt+1, writes)
+		if writes != attempt+1 {
+			t.Fatalf(
+				"attention writes after attempt %d = %d, want %d",
+				attempt+1,
+				writes,
+				attempt+1,
+			)
 		}
 		if cfg.doorbell.attempts != uint(attempt+1) {
 			t.Fatalf(
@@ -1943,7 +2010,7 @@ func TestNotifyNewMessagesAttentionOnlyRetryCadence(t *testing.T) {
 		if err := notifyNewMessages(cfg); err != nil {
 			t.Fatalf("early attention check %d: %v", attempt+1, err)
 		}
-		if writes != 1 {
+		if writes != attempt+1 {
 			t.Fatalf("attention repeated before deadline %d: writes=%d", attempt+1, writes)
 		}
 		now = wantDeadline
@@ -2054,21 +2121,24 @@ func TestRunWakeLoopHonorsAttentionOnlyDoorbellDeadline(t *testing.T) {
 	if got := afterDeadlineCalls.Load(); got != 0 {
 		t.Fatalf("doorbell deadline evaluated early %d times", got)
 	}
-	deadline := time.After(2 * time.Second)
-	for afterDeadlineCalls.Load() == 0 {
-		select {
-		case err := <-done:
-			t.Fatalf("wake loop exited before attention retry: %v", err)
-		case <-deadline:
-			t.Fatal("attention-only retry deadline was ignored")
-		case <-time.After(10 * time.Millisecond):
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "AMQ") {
+			t.Fatalf("attention retry output = %q, want AMQ notice", output)
 		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before attention retry: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("attention-only retry deadline was ignored")
 	}
 	time.Sleep(25 * time.Millisecond)
 	callsAfterRetry := afterDeadlineCalls.Load()
+	if callsAfterRetry == 0 {
+		t.Fatal("attention retry did not evaluate the expired deadline")
+	}
 	select {
 	case output := <-attention:
-		t.Fatalf("attention retry repeated peer output: %q", output)
+		t.Fatalf("attention retry hot-looped output: %q", output)
 	case err := <-done:
 		t.Fatalf("wake loop exited after attention retry: %v", err)
 	case <-time.After(200 * time.Millisecond):
@@ -2972,14 +3042,11 @@ func TestRunWakeLoopPreservesForegroundRetryAcrossInboxScanError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	originalAuthorityRetryDelay := wakeTerminalAuthorityRetryDelay
 	originalScanRetryBase := wakeInboxScanRetryBase
 	originalScanRetryMax := wakeInboxScanRetryMax
-	wakeTerminalAuthorityRetryDelay = 50 * time.Millisecond
 	wakeInboxScanRetryBase = 50 * time.Millisecond
 	wakeInboxScanRetryMax = time.Second
 	t.Cleanup(func() {
-		wakeTerminalAuthorityRetryDelay = originalAuthorityRetryDelay
 		wakeInboxScanRetryBase = originalScanRetryBase
 		wakeInboxScanRetryMax = originalScanRetryMax
 	})
@@ -3001,17 +3068,25 @@ func TestRunWakeLoopPreservesForegroundRetryAcrossInboxScanError(t *testing.T) {
 	var promptWrites atomic.Int64
 	firstPrompt := make(chan string, 1)
 	recoveredPrompt := make(chan string, 1)
+	attention := make(chan struct{}, 1)
+	maintenanceTicks := make(chan time.Time, 1)
+	var fakeNow atomic.Int64
+	fakeNow.Store(time.Unix(1_800_000_000, 0).UnixNano())
 	stop := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
 		done <- runWakeLoop(wakeConfig{
-			root:              root,
-			me:                "codex",
-			session:           "session1",
-			wakeOwner:         &wakeOwner{},
-			injectMode:        wakeInjectModePaste,
-			controlStop:       stop,
-			retainedInbox:     reader,
+			root:             root,
+			me:               "codex",
+			session:          "session1",
+			wakeOwner:        &wakeOwner{},
+			injectMode:       wakeInjectModePaste,
+			controlStop:      stop,
+			retainedInbox:    reader,
+			maintenanceTicks: maintenanceTicks,
+			doorbellNow: func() time.Time {
+				return time.Unix(0, fakeNow.Load())
+			},
 			preconditionCheck: func(*wakeConfig) error { return nil },
 			terminalWrite: func(text string) error {
 				if !strings.Contains(text, coopWakeDoorbell) {
@@ -3025,6 +3100,13 @@ func TestRunWakeLoopPreservesForegroundRetryAcrossInboxScanError(t *testing.T) {
 				return nil
 			},
 			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				select {
+				case attention <- struct{}{}:
+				default:
+				}
+				return len(data), nil
+			},
 		})
 	}()
 	t.Cleanup(func() {
@@ -3044,6 +3126,15 @@ func TestRunWakeLoopPreservesForegroundRetryAcrossInboxScanError(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("wake loop did not establish foreground-authority hold")
 	}
+	select {
+	case <-attention:
+	case err := <-done:
+		t.Fatalf("wake loop exited before zero-progress attention: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("foreground refusal emitted no attention")
+	}
+	fakeNow.Add(int64(wakeDoorbellAttentionRetryBase))
+	maintenanceTicks <- time.Now()
 	select {
 	case <-scanFailed:
 	case err := <-done:


### PR DESCRIPTION
## Summary

- retry attention-only delivery at 30s, 1m, 2m, 4m, 8m, then every 15m while the inbox cohort remains unread
- keep input delivery on its 5s-to-2m ladder and classify each attempt by the channel that actually accepted output
- fall back to attention when terminal authority refuses before accepting input, while preserving exact-suffix recovery after confirmed partial input and fail-stop behavior for fatal authority loss
- remove obsolete suppression/dead retry plumbing, force recorded attempts into retry state, and document the two cadences

## Verification

- `make ci`
- `go test -race ./... -count=1`
- `GOOS={linux,darwin,freebsd,windows} GOARCH=amd64 go build ./...`
- exact uncommitted diff `3f2a754b01aa078ab489e24dac8b64af5f2115e5a13f89e782df9c7f0515c908` independently reviewed: PASS, no findings
- Fable Max review findings addressed with zero-progress, partial-progress, short-attention-write, cadence, and run-loop regressions