### PR TITLE
fix(wake): restore self-healing delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: python3 scripts/check_commit_overrides.py
+      - name: Check wake test changes
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 scripts/check_wake_test_changes.py
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/COOP.md
+++ b/COOP.md
@@ -312,11 +312,20 @@ Retries never give up while the cohort remains unread. Contextual peer headers
 appear only in terminal output or attention; terminal input always uses the
 fixed doorbell. The delay starts after the prior injector process exits or times
 out. Because an external injector is arbitrary local code, retries can duplicate
-its side effects. Removing or replacing any message from that cohort is durable
-progress and immediately rearms the next notification. Owner-bound retries do
-not emit attention when terminal input succeeds; when input is unavailable or
-fails, attention becomes the delivered channel and repeats on its slower
-cadence.
+its side effects. Added messages join the pending cohort and share its next
+notification without resetting the retry ladder. If that ladder had decayed,
+new information pulls the deadline forward to the channel's 5- or 30-second
+delivery floor; bursts within the debounce window remain consolidated.
+Removing or replacing any message is durable progress and immediately rearms
+the next notification.
+Owner-bound retries do not emit attention when terminal input succeeds.
+Transient foreground authority or input-quiet refusals keep the input retry
+armed while rate-limiting their separate attention output. Output-only delivery
+repeats on its slower cadence, and a short or failed attention write stays
+pending on that cadence instead of terminating the notifier. Recovery-required
+state never retries uncertain terminal input; it repeats the manual
+drain-and-restart notice on that same attention cadence until the unread cohort
+drains.
 
 For orchestrators or hardened environments without a controlling TTY, use an
 explicit external transport:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ the agent. The wake child appends full diagnostics to the private
 terminal-safe attention to the controlling terminal. This process boundary
 keeps runtime and fatal-error text out of Codex and Claude full-screen
 composers. Accumulated diagnostics are truncated when a new wake starts after
-the log reaches 1 MiB; a single long-lived wake can exceed that launch bound.
+the log reaches 1 MiB and checked again on the wake's 30-second maintenance
+tick, so long-lived ordinary and repair wakes bound their own logs.
 
 Wake treats terminal notification as an attempt, not delivery, and retries on
 a capped backoff until the inbox makes durable progress. The first notification
@@ -118,9 +119,18 @@ the cohort remains unread. Contextual peer headers appear only in terminal
 output or attention; terminal input always uses the fixed doorbell. The delay
 starts after the preceding injector process exits or times out. Because
 `--wake-inject-via` executes arbitrary local code, a retry can repeat
-injector-side effects. A successful input attempt does not also emit attention;
-when input is unavailable or fails, attention becomes the delivered channel and
-repeats on its slower cadence.
+injector-side effects. Added messages join the pending cohort and share its next
+notification without resetting the retry ladder; if that ladder had decayed,
+new information pulls the deadline forward to the channel's 5- or 30-second
+delivery floor. Bursts within the debounce window remain one notification.
+Removals or replacements immediately rearm the cohort.
+A successful input attempt does not also emit attention. Transient foreground
+authority or input-quiet refusals keep the input retry armed while rate-limiting
+their separate attention output. Output-only delivery repeats on its slower
+cadence, and a short or failed attention write stays pending on that cadence
+instead of terminating the notifier. Recovery-required state never retries
+uncertain terminal input; it repeats the manual drain-and-restart notice on that
+same attention cadence until the unread cohort drains.
 
 > **First-message check:** start both agents before sending the test message.
 > A newly started wake deliberately baselines messages that were already

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -449,15 +449,19 @@ func runCoopExec(args []string) error {
 				retainWakeHelperClaim(current)
 				otherWake := current.Exists && current.PID != wakeProc.Pid
 				if readyErr != nil {
+					startupErr := readyErr
+					if otherWake {
+						startupErr = coopWakeStartupConflictError(current, readyErr)
+					}
 					cleanupErr := cleanupWakeHelper(otherWake)
 					if cleanupErr != nil {
 						return errors.Join(
-							readyErr,
+							startupErr,
 							fmt.Errorf("cleanup exact coop wake startup helper: %w", cleanupErr),
 						)
 					}
 					if otherWake || *requireWakeFlag {
-						return readyErr
+						return startupErr
 					}
 					_ = writeStderr("warning: failed to prepare amq wake: %v\n", readyErr)
 					wakeProc = nil

--- a/internal/cli/coop_wake_reclaim_darwin_test.go
+++ b/internal/cli/coop_wake_reclaim_darwin_test.go
@@ -38,15 +38,15 @@ func TestPrepareCoopWakeLockTerminalGoneDefersToSilentReplacement(t *testing.T) 
 	}
 }
 
-func TestPrepareCoopWakeLockLiveRawAttachedIsPreserved(t *testing.T) {
-	testPrepareCoopWakeLockHealthyRawPreserved(t, "/dev/null", wakeProcessInfo{
+func TestPrepareCoopWakeLockLiveRawAttachedIsRefusedWithoutMutation(t *testing.T) {
+	testPrepareCoopWakeLockHealthyRawRefused(t, "/dev/null", wakeProcessInfo{
 		ControllingTerminalKnown: true,
 		HasControllingTerminal:   true,
 	})
 }
 
-func TestPrepareCoopWakeLockLiveRawUnknownTTYAttachedIsPreserved(t *testing.T) {
-	testPrepareCoopWakeLockHealthyRawPreserved(t, "unknown", wakeProcessInfo{
+func TestPrepareCoopWakeLockLiveRawUnknownTTYAttachedIsRefusedWithoutMutation(t *testing.T) {
+	testPrepareCoopWakeLockHealthyRawRefused(t, "unknown", wakeProcessInfo{
 		ControllingTerminalKnown: true,
 		HasControllingTerminal:   true,
 	})
@@ -223,7 +223,7 @@ func TestPrepareCoopWakeLockSameTerminalDifferentSessionDefersToSilentReplacemen
 	}
 }
 
-func TestPrepareCoopWakeLockInjectViaNeverSignalsThroughTakeover(t *testing.T) {
+func TestPrepareCoopWakeLockLiveGenericInjectViaRefusesWithoutMutation(t *testing.T) {
 	const pid = 66121
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
@@ -251,8 +251,9 @@ func TestPrepareCoopWakeLockInjectViaNeverSignalsThroughTakeover(t *testing.T) {
 		return nil
 	})
 
-	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
-		t.Fatalf("prepare inject-via wake: %v", err)
+	err := prepareCoopWakeLock(root, "codex", true, "unused")
+	if err == nil || !strings.Contains(err.Error(), "owned by a live process") {
+		t.Fatalf("prepare live generic inject-via wake = %v, want live-owner refusal", err)
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("inject-via lock changed: %v", err)
@@ -275,7 +276,7 @@ func TestPrepareCoopWakeLockUnverifiedNeverSignals(t *testing.T) {
 	}
 }
 
-func testPrepareCoopWakeLockHealthyRawPreserved(
+func testPrepareCoopWakeLockHealthyRawRefused(
 	t *testing.T,
 	tty string,
 	terminal wakeProcessInfo,
@@ -310,8 +311,23 @@ func testPrepareCoopWakeLockHealthyRawPreserved(
 	stdout, stderr, err := captureEnvOutput(t, func() error {
 		return prepareCoopWakeLock(root, "codex", true, "unused")
 	})
-	if err != nil {
-		t.Fatalf("prepare healthy raw wake: %v", err)
+	if err == nil {
+		t.Fatal("healthy raw wake in another terminal was accepted")
+	}
+	for _, want := range []string{
+		"owned by a live process",
+		"pid:     66121",
+		"tty:     " + tty,
+		"started: ",
+		"use that terminal",
+		"stop process 66121",
+	} {
+		if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(want)) {
+			t.Fatalf("live conflict error missing %q: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "doctor") {
+		t.Fatalf("live conflict incorrectly recommends doctor: %v", err)
 	}
 	if stdout != "" || stderr != "" {
 		t.Fatalf("healthy raw wake emitted output: stdout=%q stderr=%q", stdout, stderr)

--- a/internal/cli/coop_wake_reclaim_unix.go
+++ b/internal/cli/coop_wake_reclaim_unix.go
@@ -69,6 +69,23 @@ func prepareCoopWakeLock(root, agent string, yes bool, remedy string) error {
 		return nil
 	}
 
+	if confirmedLiveWake(inspection) {
+		switch classifyPersistedWakeClaim(inspection) {
+		case wakeClaimAuthoritative:
+			// Owner-bound claims belong to a specific coop session. A new
+			// session cannot reuse or replace one while its wake is live.
+			return coopWakeStartupConflictError(inspection, nil)
+		case wakeClaimGeneric:
+			replaceNeeded, err := wakeLockReplacementNeeded(inspection)
+			if err != nil {
+				return err
+			}
+			if !replaceNeeded {
+				return coopWakeStartupConflictError(inspection, nil)
+			}
+		}
+	}
+
 	if inspection.Status != wakeLockUnverified {
 		// Valid non-orphans and creating locks retain their existing fail-closed
 		// behavior in the wake acquisition path.
@@ -205,6 +222,80 @@ func coopWakeRemedyForCommand(root, agent, command string, commandArgs []string)
 		parts = append(parts, shellQuoteArg(arg))
 	}
 	return strings.Join(parts, " ")
+}
+
+func coopWakeStartupConflictError(inspection wakeLockInspection, cause error) error {
+	var message string
+	switch {
+	case confirmedLiveWake(inspection):
+		started := strings.TrimSpace(inspection.Lock.Started)
+		if started == "" {
+			started = "unknown"
+		}
+		message = fmt.Sprintf(
+			"wake for %s is owned by a live process\n"+
+				"  pid:     %d\n"+
+				"  tty:     %s\n"+
+				"  started: %s\n"+
+				"  root:    %s\n\n"+
+				"No AMQ command can safely take over this live wake; use that terminal, "+
+				"or stop process %d and retry amq coop exec.",
+			inspection.Agent,
+			inspection.PID,
+			coopWakeTTYDisplay(inspection),
+			started,
+			inspection.Root,
+			inspection.PID,
+		)
+	case inspection.Status == wakeLockStale:
+		repair := doctorRootCommandForOS(
+			inspection.Root,
+			"",
+			runtime.GOOS,
+			"--ops",
+			"--fix-wake-locks",
+		)
+		action := "Remove only the proven-stale session lock, then retry:\n  " + repair
+		if wakeLockHasOwnerMarkers(inspection) {
+			action = "Recover the exact owner-bound claim, then retry:\n  " +
+				wakeRecoverOwnerCommand(inspection.Root, inspection.Agent)
+		}
+		message = fmt.Sprintf(
+			"a proven-stale wake lock is blocking startup for %s\n"+
+				"  lock:   %s\n"+
+				"  pid:    %d\n"+
+				"  reason: %s\n"+
+				"  root:   %s\n\n%s",
+			inspection.Agent,
+			inspection.LockPath,
+			inspection.PID,
+			inspection.Reason,
+			inspection.Root,
+			action,
+		)
+	case inspection.Exists:
+		message = fmt.Sprintf(
+			"wake state for %s could not be verified and was preserved\n"+
+				"  lock:   %s\n"+
+				"  pid:    %d\n"+
+				"  reason: %s\n"+
+				"  root:   %s\n\n"+
+				"Inspect the exact session before changing it:\n  %s",
+			inspection.Agent,
+			inspection.LockPath,
+			inspection.PID,
+			inspection.Reason,
+			inspection.Root,
+			doctorRootCommandForOS(inspection.Root, "", runtime.GOOS, "--ops"),
+		)
+	}
+	if message == "" {
+		return cause
+	}
+	if cause == nil {
+		return errors.New(message)
+	}
+	return fmt.Errorf("%s\nstartup detail: %w", message, cause)
 }
 
 func formatCoopWakeLockAge(started string, now time.Time) string {

--- a/internal/cli/coop_wake_reclaim_unix_test.go
+++ b/internal/cli/coop_wake_reclaim_unix_test.go
@@ -11,6 +11,63 @@ import (
 	"time"
 )
 
+func TestCoopWakeStartupConflictGivesExactStaleSessionRepair(t *testing.T) {
+	root := `/tmp/AMQ & stale's $session`
+	inspection := wakeLockInspection{
+		Exists:   true,
+		Status:   wakeLockStale,
+		Reason:   "process is not running",
+		Root:     root,
+		Agent:    "codex",
+		LockPath: root + "/agents/codex/.wake.lock",
+		Lock: wakeLock{
+			PID:     66121,
+			TTY:     "/dev/ttys042",
+			Started: "2026-07-30T17:00:00Z",
+		},
+	}
+	err := coopWakeStartupConflictError(
+		inspection,
+		errors.New("amq wake exited before becoming ready"),
+	)
+	if err == nil {
+		t.Fatal("stale startup conflict returned nil")
+	}
+	want := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("stale conflict = %v, want exact repair %q", err, want)
+	}
+	if strings.Contains(err.Error(), "use that terminal") {
+		t.Fatalf("stale conflict rendered live-owner advice: %v", err)
+	}
+}
+
+func TestCoopWakeStartupConflictPreservesUnverifiedState(t *testing.T) {
+	root := secureTempDirForTest(t)
+	inspection := wakeLockInspection{
+		Exists:   true,
+		Status:   wakeLockUnverified,
+		Reason:   "owner identity unavailable",
+		Root:     root,
+		Agent:    "codex",
+		LockPath: root + "/agents/codex/.wake.lock",
+		Lock:     wakeLock{PID: 66121},
+	}
+	err := coopWakeStartupConflictError(
+		inspection,
+		errors.New("amq wake exited before becoming ready"),
+	)
+	if err == nil {
+		t.Fatal("unverified startup conflict returned nil")
+	}
+	inspect := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops")
+	if !strings.Contains(err.Error(), inspect) ||
+		strings.Contains(err.Error(), "--fix-wake-locks") ||
+		!strings.Contains(err.Error(), "preserved") {
+		t.Fatalf("unverified conflict is not an inspect-only refusal: %v", err)
+	}
+}
+
 func TestPrepareCoopWakeLockRemovesProvenStaleWithoutPrompt(t *testing.T) {
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: 66121, Generation: "stale"})
@@ -108,6 +165,92 @@ func TestPrepareCoopWakeLockProvenForeignProcessRefusesWithoutMutation(t *testin
 	}
 	if string(after) != string(before) {
 		t.Fatal("foreign process lock changed")
+	}
+}
+
+func TestPrepareCoopWakeLockLiveAuthoritativeRefusesWithoutMutation(t *testing.T) {
+	const wakePID = 66121
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "authoritative-coop-conflict-injector")
+	owner := currentAuthoritativeOwnerForCoopWakeTest(t)
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	target.Owner = &owner
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatalf("write wake target: %v", err)
+	}
+	wakeArgs := []string{
+		"/opt/homebrew/bin/amq",
+		"wake",
+		"--root",
+		root,
+		"--me",
+		"codex",
+		"--inject-via",
+		injector,
+	}
+	lock := bindWakeLockToTarget(wakeLock{
+		PID:          wakePID,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		TTY:          "/dev/ttys042",
+		ProcessStart: owner.ProcessStart,
+		BootID:       owner.BootID,
+		Executable:   wakeArgs[0],
+		Args:         wakeArgs,
+		Generation:   "authoritative-conflict",
+		OwnerSchema:  wakeOwnerLockSchema,
+		Owner:        &owner,
+	}, target)
+	lock.WakeMode = wakeOwnerWakeMode
+	lockPath := writeWakeLockExactForTest(t, root, "codex", lock)
+	if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+		t.Fatal(err)
+	}
+	targetPath := wakeTargetPath(root, "codex")
+	beforeLock, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeTarget, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: owner.ProcessStart,
+			BootID:     owner.BootID,
+			Executable: wakeArgs[0],
+			Args:       wakeArgs,
+		}
+	})
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("authoritative wake must not be signaled through coop startup")
+		return nil
+	})
+
+	err = prepareCoopWakeLock(root, "codex", true, "unused")
+	if err == nil || !strings.Contains(err.Error(), "owned by a live process") {
+		t.Fatalf("prepare live authoritative wake = %v, want live-owner refusal", err)
+	}
+	afterLock, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("authoritative lock changed: %v", err)
+	}
+	afterTarget, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("authoritative target changed: %v", err)
+	}
+	if string(afterLock) != string(beforeLock) || string(afterTarget) != string(beforeTarget) {
+		t.Fatal("authoritative claim changed during startup refusal")
+	}
+	info, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != wakeOwnerLockFileMode {
+		t.Fatalf("authoritative lock mode = %o, want %o", got, wakeOwnerLockFileMode)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -276,6 +276,29 @@ func runDoctor(args []string) error {
 		}
 		for _, wl := range result.Ops.WakeLocks {
 			if wl.Status == string(wakeLockValid) {
+				if wl.CurrentTerminal {
+					continue
+				}
+				tty := wl.TTY
+				if tty == "" {
+					tty = "unknown"
+				}
+				started := wl.Started
+				if started == "" {
+					started = "unknown"
+				}
+				line := fmt.Sprintf(
+					"  wake for %s is owned by a live process: pid=%d tty=%s started=%s root=%s; "+
+						"no AMQ command can safely take over this live wake",
+					wl.Agent,
+					wl.PID,
+					tty,
+					started,
+					wl.Root,
+				)
+				if err := writeStdoutLine(line); err != nil {
+					return err
+				}
 				continue
 			}
 			icon := statusIcons["warn"]

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -75,6 +75,8 @@ type opsWakeLock struct {
 	Root            string `json:"root"`
 	Lock            string `json:"lock"`
 	PID             int    `json:"pid,omitempty"`
+	TTY             string `json:"tty,omitempty"`
+	Started         string `json:"started,omitempty"`
 	Reason          string `json:"reason,omitempty"`
 	Fix             string `json:"fix,omitempty"`
 	Removed         bool   `json:"removed,omitempty"`
@@ -84,6 +86,7 @@ type opsWakeLock struct {
 	Repair          string `json:"repair,omitempty"`
 	RepairAvailable bool   `json:"repair_available,omitempty"`
 	RepairReason    string `json:"repair_reason,omitempty"`
+	CurrentTerminal bool   `json:"-"`
 }
 
 func runOpsChecks(root string, rootSource string, fixWakeLocks bool, explicitBaseRoot ...string) *doctorOpsResult {
@@ -356,12 +359,15 @@ func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeL
 		}
 
 		lock := opsWakeLock{
-			Status: string(inspection.Status),
-			Agent:  agent,
-			Root:   inspection.Root,
-			Lock:   inspection.LockPath,
-			PID:    inspection.PID,
-			Reason: inspection.Reason,
+			Status:          string(inspection.Status),
+			Agent:           agent,
+			Root:            inspection.Root,
+			Lock:            inspection.LockPath,
+			PID:             inspection.PID,
+			TTY:             strings.TrimSpace(inspection.Lock.TTY),
+			Started:         strings.TrimSpace(inspection.Lock.Started),
+			Reason:          inspection.Reason,
+			CurrentTerminal: doctorWakeLockOnCurrentTerminal(inspection),
 		}
 		ownerBound := classifyWakeClaimForGenericTransition(inspection) == wakeClaimAuthoritative
 		if ownerBound && mutationAuthorized {

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -469,6 +469,75 @@ func TestRunOpsChecksReportsProvenStartMismatchAsStale(t *testing.T) {
 	}
 }
 
+func TestDoctorOpsTextReportsForeignLiveWakeAndSilencesCurrentTTY(t *testing.T) {
+	const (
+		pid     = 66121
+		lockTTY = "/dev/null"
+		started = "2026-07-30T18:13:25Z"
+	)
+	root := healthyDoctorMailboxRoot(t, "codex")
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          lockTTY,
+		Started:      started,
+		ProcessStart: "same-start",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		Generation:   "live-generation",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        gotPID,
+			Running:    true,
+			StartToken: "same-start",
+			BootID:     "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+
+	oldCurrentTTY := getWakeCurrentTTY
+	currentTTY := "/dev/ttys099"
+	getWakeCurrentTTY = func() string { return currentTTY }
+	t.Cleanup(func() { getWakeCurrentTTY = oldCurrentTTY })
+	t.Setenv(envRoot, root)
+	t.Setenv(envBaseRoot, root)
+	t.Setenv(envSession, "")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--root", root, "--ops"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"wake for codex is owned by a live process",
+		"pid=66121",
+		"tty=" + lockTTY,
+		"started=" + started,
+		"root=" + root,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("foreign live wake output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "fix=") {
+		t.Fatalf("healthy foreign live wake advertised a repair:\n%s", output)
+	}
+
+	currentTTY = lockTTY
+	output, err = captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--root", root, "--ops"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(output, "owned by a live process") {
+		t.Fatalf("current-terminal wake was reported as foreign:\n%s", output)
+	}
+}
+
 func TestRunOpsChecksFixRemovesProvenStartMismatch(t *testing.T) {
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{

--- a/internal/cli/doctor_wake_lock_other.go
+++ b/internal/cli/doctor_wake_lock_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package cli
+
+func doctorWakeLockOnCurrentTerminal(wakeLockInspection) bool {
+	return false
+}

--- a/internal/cli/doctor_wake_lock_unix.go
+++ b/internal/cli/doctor_wake_lock_unix.go
@@ -1,0 +1,7 @@
+//go:build darwin || linux
+
+package cli
+
+func doctorWakeLockOnCurrentTerminal(inspection wakeLockInspection) bool {
+	return sameWakeTTYPathAsCurrent(inspection)
+}

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -16,60 +16,64 @@ import (
 )
 
 type wakeConfig struct {
-	me                    string
-	root                  string
-	session               string
-	injectCmd             string
-	injectVia             string // external command for injection (replaces TIOCSTI)
-	injectArgs            []string
-	wakeOwner             *wakeOwner
-	injectTimeout         time.Duration
-	bell                  bool
-	debounce              time.Duration
-	previewLen            int
-	strict                bool
-	fallbackWarn          bool
-	injectMode            string // auto, raw, paste
-	debug                 bool
-	deferWhileInput       bool
-	inputQuietFor         time.Duration
-	inputPollInterval     time.Duration
-	inputMaxHold          time.Duration
-	interrupt             bool
-	interruptLabel        string
-	interruptPriority     string
-	interruptKey          string
-	interruptNotice       string
-	interruptCooldown     time.Duration
-	lastInterrupt         time.Time
-	controlStop           <-chan struct{}
-	beforeTerminalWrite   func() error
-	terminalWrite         func(string) error
-	terminalGeneration    string
-	terminalTTY           string
-	baselineRequested     bool
-	baselineInherited     bool
-	baselineExisting      map[string]wakeFileIdentity
-	inputDelivery         wakeInputDeliveryState
-	inputRecoveryRequired bool
-	doorbell              wakeDoorbellState
-	doorbellNow           func() time.Time
-	lastAttemptAttention  bool
-	onBaselineReady       func(map[string]wakeFileIdentity) error
-	onPrepared            func(wakeAdmissionWatcher) error
-	retainedAgent         wakeRetainedAgent
-	retainedInbox         wakeInboxReader
-	touchPresence         func() error
-	maintenanceTicks      <-chan time.Time
-	preconditionCheck     func(*wakeConfig) error
-	onPendingNotify       func()
-	recordNotifierStatus  func(status, mode, reason string) error
-	recordAttention       func(wakeAttentionEmission) error
-	attentionEnv          func(string) string
-	attentionIsTTY        func() bool
-	attentionWrite        func([]byte) (int, error)
-	diagnosticIsTTY       func() bool
+	me                            string
+	root                          string
+	session                       string
+	injectCmd                     string
+	injectVia                     string // external command for injection (replaces TIOCSTI)
+	injectArgs                    []string
+	wakeOwner                     *wakeOwner
+	injectTimeout                 time.Duration
+	bell                          bool
+	debounce                      time.Duration
+	previewLen                    int
+	strict                        bool
+	fallbackWarn                  bool
+	injectMode                    string // auto, raw, paste
+	debug                         bool
+	deferWhileInput               bool
+	inputQuietFor                 time.Duration
+	inputPollInterval             time.Duration
+	inputMaxHold                  time.Duration
+	interrupt                     bool
+	interruptLabel                string
+	interruptPriority             string
+	interruptKey                  string
+	interruptNotice               string
+	interruptCooldown             time.Duration
+	lastInterrupt                 time.Time
+	controlStop                   <-chan struct{}
+	beforeTerminalWrite           func() error
+	terminalWrite                 func(string) error
+	terminalGeneration            string
+	terminalTTY                   string
+	baselineRequested             bool
+	baselineInherited             bool
+	baselineExisting              map[string]wakeFileIdentity
+	inputDelivery                 wakeInputDeliveryState
+	inputRecoveryRequired         bool
+	doorbell                      wakeDoorbellState
+	doorbellNow                   func() time.Time
+	lastAttemptAttention          bool
+	lastAttemptTransientAttention bool
+	onBaselineReady               func(map[string]wakeFileIdentity) error
+	onPrepared                    func(wakeAdmissionWatcher) error
+	retainedAgent                 wakeRetainedAgent
+	retainedInbox                 wakeInboxReader
+	touchPresence                 func() error
+	maintenanceTicks              <-chan time.Time
+	maintenanceOutputs            []*os.File
+	preconditionCheck             func(*wakeConfig) error
+	onPendingNotify               func()
+	recordNotifierStatus          func(status, mode, reason string) error
+	recordAttention               func(wakeAttentionEmission) error
+	attentionEnv                  func(string) string
+	attentionIsTTY                func() bool
+	attentionWrite                func([]byte) (int, error)
+	diagnosticIsTTY               func() bool
 }
+
+const maxWakeNotificationSenderClauses = 8
 
 type wakeInputDeliveryPhase uint8
 
@@ -464,8 +468,10 @@ func notifyNewMessages(cfg *wakeConfig) error {
 
 	if len(messages) == 0 {
 		if cfg.inputRecoveryRequired {
-			cfg.doorbell.noteRecoveryInboxEmpty()
-			return nil
+			return deliverWakeInputRecoveryAttention(
+				cfg,
+				currentPending,
+			)
 		}
 		cfg.doorbell.reset()
 		return reconcileWakeInputAfterInboxDrain(cfg)
@@ -579,16 +585,23 @@ func deliverNewMessageNotification(
 		}
 		if cfg.injectMode == wakeInjectModeNone {
 			clearWakeInputState(cfg)
-			if deliveryErr == nil {
-				// Permanent input demotion retires the old doorbell state.
-				// Re-arm the unread cohort before recording the fallback.
-				cfg.doorbell.arm(currentPending)
-				recordWakeAttempt(cfg, cfg.wakeDoorbellNow())
+			if shouldRecordWakeAttempt(deliveryErr) {
+				recordWakeAttempt(
+					cfg,
+					cfg.wakeDoorbellNow(),
+					currentPending,
+					deliveryErr,
+				)
 			}
 			return deliveryErr
 		}
 		if shouldRecordWakeAttempt(deliveryErr) {
-			recordWakeAttempt(cfg, cfg.wakeDoorbellNow())
+			recordWakeAttempt(
+				cfg,
+				cfg.wakeDoorbellNow(),
+				currentPending,
+				deliveryErr,
+			)
 		}
 		return deliveryErr
 	}
@@ -598,14 +611,31 @@ func deliverNewMessageNotification(
 		return enterWakeInputRecovery(cfg, currentPending, deliveryErr)
 	}
 	if shouldRecordWakeAttempt(deliveryErr) {
-		recordWakeAttempt(cfg, cfg.wakeDoorbellNow())
+		recordWakeAttempt(
+			cfg,
+			cfg.wakeDoorbellNow(),
+			currentPending,
+			deliveryErr,
+		)
 	}
 	return deliveryErr
 }
 
-func recordWakeAttempt(cfg *wakeConfig, now time.Time) {
-	cfg.doorbell.phase = wakeDoorbellRetrying
-	if cfg.lastAttemptAttention {
+func recordWakeAttempt(
+	cfg *wakeConfig,
+	now time.Time,
+	currentPending map[string]os.FileInfo,
+	deliveryErr error,
+) {
+	if len(cfg.doorbell.cohort) == 0 {
+		cfg.doorbell.arm(currentPending)
+	}
+	var attentionErr *wakeAttentionDeliveryError
+	if cfg.lastAttemptTransientAttention {
+		cfg.doorbell.recordAttempt(now)
+		return
+	}
+	if cfg.lastAttemptAttention || errors.As(deliveryErr, &attentionErr) {
 		cfg.doorbell.recordAttentionAttempt(now)
 		return
 	}
@@ -616,9 +646,7 @@ func shouldRecordWakeAttempt(err error) bool {
 	if err == nil {
 		return true
 	}
-	var attentionErr *wakeAttentionDeliveryError
-	return !errors.As(err, &attentionErr) &&
-		!isWakeTerminalForegroundPGRPChanged(err) &&
+	return !isWakeTerminalAuthorityLoss(err) &&
 		!isWakeTerminalPartialProgress(err) &&
 		!isWakeInputDemotionBlocked(err) &&
 		!isWakeTerminalProgressUncertain(err)
@@ -632,13 +660,17 @@ func deliverWakeInputRecoveryAttention(
 	if !cfg.doorbell.planRecoveryAttention(now, currentPending) {
 		return nil
 	}
+	cfg.doorbell.recordRecoveryRequired(now, currentPending)
 	if err := emitWakeAttention(cfg, wakePayload{
 		text:       wakeInputRecoveryNotice,
 		provenance: wakePayloadSystemFixed,
 	}); err != nil {
 		return err
 	}
-	cfg.doorbell.recordRecoveryRequired(now, currentPending)
+	cfg.doorbell.recordRecoveryAttentionDelivered()
+	if len(currentPending) == 0 {
+		cfg.doorbell.noteRecoveryInboxEmpty()
+	}
 	return nil
 }
 
@@ -742,15 +774,11 @@ func buildNotificationText(session string, messages []wakeMsgInfo, previewLen in
 		senders = append(senders, sender)
 	}
 	sort.Strings(senders)
-	parts := make([]string, 0, len(senders))
-	for _, sender := range senders {
-		parts = append(parts, fmt.Sprintf("%d from %s", senderCounts[sender], sender))
-	}
 	return fmt.Sprintf(
 		"%s: %d messages - %s. Drain with: amq drain --include-body — then act on it",
 		prefix,
 		count,
-		strings.Join(parts, ", "),
+		strings.Join(buildWakeSenderClauses(senders, senderCounts), ", "),
 	)
 }
 
@@ -773,18 +801,30 @@ func buildInterruptText(session string, messages []wakeMsgInfo, senderCounts map
 			prefix, msg.from, subject)
 	}
 
-	var parts []string
 	senders := make([]string, 0, len(senderCounts))
 	for s := range senderCounts {
 		senders = append(senders, s)
 	}
 	sort.Strings(senders)
-	for _, sender := range senders {
-		c := senderCounts[sender]
-		parts = append(parts, fmt.Sprintf("%d from %s", c, sender))
-	}
+	parts := buildWakeSenderClauses(senders, senderCounts)
 	return fmt.Sprintf("%s: %d urgent messages - %s. Drain with: amq drain --include-body — then act on it",
 		prefix, count, strings.Join(parts, ", "))
+}
+
+func buildWakeSenderClauses(senders []string, senderCounts map[string]int) []string {
+	limit := min(len(senders), maxWakeNotificationSenderClauses)
+	parts := make([]string, 0, limit+1)
+	for _, sender := range senders[:limit] {
+		parts = append(parts, fmt.Sprintf("%d from %s", senderCounts[sender], sender))
+	}
+	if omitted := len(senders) - limit; omitted > 0 {
+		label := "senders"
+		if omitted == 1 {
+			label = "sender"
+		}
+		parts = append(parts, fmt.Sprintf("%d other %s", omitted, label))
+	}
+	return parts
 }
 
 // notificationPrefix builds "AMQ [session]" or just "AMQ" when session is empty.
@@ -885,6 +925,7 @@ func injectNotification(cfg *wakeConfig, text string, deferForInput bool) error 
 
 func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForInput bool) error {
 	cfg.lastAttemptAttention = false
+	cfg.lastAttemptTransientAttention = false
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound {
 		if validCoopWakeDoorbell(notice.input.text) {
@@ -908,7 +949,7 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 
 	if shouldDeferBeforeInject(cfg, deferForInput) {
 		if !waitForWakeInputQuiet(cfg) {
-			return deliverWakeAttentionOnly(cfg, notice.output)
+			return deliverWakeTransientAttention(cfg, notice.output, nil)
 		}
 	}
 
@@ -1059,17 +1100,36 @@ func deliverWakeAttentionAfterInputRefusal(
 	payload wakePayload,
 	cause error,
 ) error {
+	if isWakeTerminalForegroundPGRPChanged(cause) {
+		return deliverWakeTransientAttention(cfg, payload, cause)
+	}
 	if err := deliverWakeAttentionOnly(cfg, payload); err != nil {
 		return errors.Join(cause, err)
 	}
-	if isWakeTerminalAuthorityLoss(cause) &&
-		!isWakeTerminalForegroundPGRPChanged(cause) {
+	if isWakeTerminalAuthorityLoss(cause) {
 		// Loss of the retained terminal or wake generation is fatal even when
 		// the final attention write succeeds. A replacement wake, not this
 		// stale owner, must retry the inbox cohort.
 		return cause
 	}
 	return nil
+}
+
+func deliverWakeTransientAttention(
+	cfg *wakeConfig,
+	payload wakePayload,
+	cause error,
+) error {
+	now := cfg.wakeDoorbellNow()
+	if !cfg.doorbell.transientAttentionDue(now) {
+		return cause
+	}
+	cfg.lastAttemptTransientAttention = true
+	cfg.doorbell.recordTransientAttentionAttempt(now)
+	if err := emitWakeAttention(cfg, payload); err != nil {
+		return errors.Join(cause, err)
+	}
+	return cause
 }
 
 func deliverWakeAttentionOnly(cfg *wakeConfig, payload wakePayload) error {

--- a/internal/cli/wake_attention_test.go
+++ b/internal/cli/wake_attention_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -396,6 +397,52 @@ func TestDeliverWakeAttentionOnlyMarksAttemptAfterCompleteWrite(t *testing.T) {
 			t.Fatal("short attention write was recorded as the delivered channel")
 		}
 	})
+}
+
+func TestDeliverWakeTransientAttentionAdvancesOnlyAfterCompleteWrite(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	writes := 0
+	cfg := &wakeConfig{
+		doorbellNow:    func() time.Time { return now },
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			writes++
+			if writes == 1 {
+				return len(data) - 1, nil
+			}
+			return len(data), nil
+		},
+	}
+	payload := wakePayload{
+		text:       "safe notice",
+		provenance: wakePayloadSystemFixed,
+	}
+
+	captureWakeStderr(t, func() {
+		if err := deliverWakeTransientAttention(cfg, payload, nil); err == nil {
+			t.Fatal("short transient attention write succeeded")
+		}
+	})
+	if cfg.doorbell.transientAttentionAttempts != 1 ||
+		!cfg.doorbell.nextTransientAttention.Equal(now.Add(wakeDoorbellAttentionRetryBase)) {
+		t.Fatalf("short transient attention did not arm output retry: %#v", cfg.doorbell)
+	}
+
+	if err := deliverWakeTransientAttention(cfg, payload, nil); err != nil {
+		t.Fatalf("suppressed transient attention retry: %v", err)
+	}
+	if writes != 1 {
+		t.Fatalf("transient attention retried before output deadline: writes=%d", writes)
+	}
+
+	now = now.Add(wakeDoorbellAttentionRetryBase)
+	if err := deliverWakeTransientAttention(cfg, payload, nil); err != nil {
+		t.Fatalf("due transient attention retry: %v", err)
+	}
+	if cfg.doorbell.transientAttentionAttempts != 2 ||
+		!cfg.doorbell.nextTransientAttention.Equal(now.Add(2*wakeDoorbellAttentionRetryBase)) {
+		t.Fatalf("complete transient attention did not advance cadence: %#v", cfg.doorbell)
+	}
 }
 
 func TestWakeAttentionAlternateScreenAgentOmitsPlainTerminalOutput(t *testing.T) {

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -21,11 +21,15 @@ const (
 )
 
 type wakeDoorbellState struct {
-	phase           wakeDoorbellPhase
-	cohort          map[string]*wakeFileIdentity
-	attempts        uint
-	nextAttempt     time.Time
-	recoveryPending bool
+	phase                        wakeDoorbellPhase
+	cohort                       map[string]*wakeFileIdentity
+	attempts                     uint
+	nextAttempt                  time.Time
+	additionAttemptFloor         time.Time
+	transientAttentionAttempts   uint
+	nextTransientAttention       time.Time
+	recoveryPending              bool
+	recoveryAttentionUndelivered bool
 }
 
 type wakeDoorbellPlan struct {
@@ -46,6 +50,14 @@ func (state *wakeDoorbellState) plan(
 	progress := state.phase != wakeDoorbellIdle && wakeCohortProgressed(state.cohort, current)
 	if progress {
 		state.reset()
+	} else if state.phase != wakeDoorbellIdle && wakeCohortExpanded(state.cohort, current) {
+		// Additions extend the pending obligation without resetting its retry
+		// ladder, but pull its deadline forward to the delivery floor because
+		// the new information has not been announced yet. One outstanding
+		// "drain everything" doorbell covers the whole current cohort, so N
+		// unread messages do not need N doorbells.
+		state.arm(current)
+		state.pullForwardForAddition(now)
 	}
 	if state.phase == wakeDoorbellIdle {
 		state.arm(current)
@@ -78,11 +90,26 @@ func (state *wakeDoorbellState) recordAttentionAttempt(now time.Time) {
 	)
 }
 
+func (state *wakeDoorbellState) transientAttentionDue(now time.Time) bool {
+	return state.nextTransientAttention.IsZero() ||
+		!now.Before(state.nextTransientAttention)
+}
+
+func (state *wakeDoorbellState) recordTransientAttentionAttempt(now time.Time) {
+	state.transientAttentionAttempts++
+	state.nextTransientAttention = now.Add(cappedExponentialBackoff(
+		state.transientAttentionAttempts,
+		wakeDoorbellAttentionRetryBase,
+		wakeDoorbellAttentionRetryMax,
+	))
+}
+
 func (state *wakeDoorbellState) recordAttemptWithBase(
 	now time.Time,
 	base, maximum time.Duration,
 ) {
 	state.attempts++
+	state.additionAttemptFloor = now.Add(base)
 	state.nextAttempt = now.Add(cappedExponentialBackoff(
 		state.attempts,
 		base,
@@ -90,23 +117,37 @@ func (state *wakeDoorbellState) recordAttemptWithBase(
 	))
 }
 
+func (state *wakeDoorbellState) pullForwardForAddition(now time.Time) {
+	if state.additionAttemptFloor.IsZero() {
+		return
+	}
+	deadline := state.additionAttemptFloor
+	if deadline.Before(now) {
+		deadline = now
+	}
+	if state.nextAttempt.IsZero() || deadline.Before(state.nextAttempt) {
+		state.nextAttempt = deadline
+	}
+}
+
 func (state *wakeDoorbellState) planRecoveryAttention(
 	now time.Time,
 	current map[string]os.FileInfo,
 ) bool {
 	if len(current) == 0 {
+		if state.phase == wakeDoorbellRecoveryRequired &&
+			state.recoveryAttentionUndelivered {
+			return state.nextAttempt.IsZero() ||
+				!now.Before(state.nextAttempt)
+		}
 		state.noteRecoveryInboxEmpty()
 		return false
 	}
 	if state.phase != wakeDoorbellRecoveryRequired {
 		return true
 	}
-	if sameKnownWakeCohort(state.cohort, current) {
-		state.recoveryPending = false
-		return false
-	}
+	state.recoveryPending = true
 	if !state.nextAttempt.IsZero() && now.Before(state.nextAttempt) {
-		state.recoveryPending = true
 		return false
 	}
 	return true
@@ -116,10 +157,14 @@ func (state *wakeDoorbellState) recordRecoveryRequired(
 	now time.Time,
 	current map[string]os.FileInfo,
 ) {
-	state.reset()
+	if state.phase != wakeDoorbellRecoveryRequired {
+		state.reset()
+	}
 	state.phase = wakeDoorbellRecoveryRequired
 	state.cohort = snapshotWakeFileIdentities(current)
-	state.nextAttempt = now.Add(wakeDoorbellRetryBase)
+	state.recoveryPending = true
+	state.recoveryAttentionUndelivered = true
+	state.recordAttentionAttempt(now)
 }
 
 func (state *wakeDoorbellState) retainRecoveryRequired(now time.Time) {
@@ -127,7 +172,13 @@ func (state *wakeDoorbellState) retainRecoveryRequired(now time.Time) {
 	state.reset()
 	state.phase = wakeDoorbellRecoveryRequired
 	state.cohort = cohort
-	state.nextAttempt = now.Add(wakeDoorbellRetryBase)
+	state.recoveryPending = true
+	state.recoveryAttentionUndelivered = true
+	state.recordAttentionAttempt(now)
+}
+
+func (state *wakeDoorbellState) recordRecoveryAttentionDelivered() {
+	state.recoveryAttentionUndelivered = false
 }
 
 func (state *wakeDoorbellState) noteRecoveryInboxEmpty() {
@@ -136,6 +187,7 @@ func (state *wakeDoorbellState) noteRecoveryInboxEmpty() {
 		state.phase = wakeDoorbellRecoveryRequired
 	}
 	state.recoveryPending = false
+	state.recoveryAttentionUndelivered = false
 }
 
 func (state wakeDoorbellState) pendingInput() bool {
@@ -195,6 +247,18 @@ func wakeCohortProgressed(
 			continue
 		}
 		if *identity != currentIdentity {
+			return true
+		}
+	}
+	return false
+}
+
+func wakeCohortExpanded(
+	cohort map[string]*wakeFileIdentity,
+	current map[string]os.FileInfo,
+) bool {
+	for name := range current {
+		if _, exists := cohort[name]; !exists {
 			return true
 		}
 	}

--- a/internal/cli/wake_doorbell_test.go
+++ b/internal/cli/wake_doorbell_test.go
@@ -73,6 +73,82 @@ func TestWakeDoorbellStateRetriesUntilInboxProgress(t *testing.T) {
 	}
 }
 
+func TestWakeDoorbellStateCoalescesAddedMessageUntilExistingDeadline(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	first := wakeDoorbellTestFiles(t, "a.md")
+	var state wakeDoorbellState
+
+	if plan := state.plan(now, first); !plan.attempt {
+		t.Fatalf("initial plan = %#v", plan)
+	}
+	state.recordAttempt(now)
+	lastAttempt := now
+	for state.attempts < 6 {
+		lastAttempt = state.nextAttempt
+		if plan := state.plan(lastAttempt, first); !plan.attempt {
+			t.Fatalf("ladder attempt %d plan = %#v", state.attempts+1, plan)
+		}
+		state.recordAttempt(lastAttempt)
+	}
+	decayedDeadline := state.nextAttempt
+
+	added := wakeDoorbellTestFiles(t, "b.md", "c.md", "d.md")
+	current := map[string]os.FileInfo{
+		"a.md": first["a.md"],
+		"b.md": added["b.md"],
+		"c.md": added["c.md"],
+	}
+	additionScannedAt := lastAttempt.Add(time.Second)
+	plan := state.plan(additionScannedAt, current)
+	if plan.attempt || plan.progress {
+		t.Fatalf("addition emitted before delivery floor: %#v", plan)
+	}
+	if state.attempts != 6 || !sameKnownWakeCohort(state.cohort, current) {
+		t.Fatalf("addition did not extend the pending cohort: %#v", state)
+	}
+	floorDeadline := lastAttempt.Add(wakeDoorbellRetryBase)
+	if !state.nextAttempt.Equal(floorDeadline) {
+		t.Fatalf(
+			"addition deadline = %s, want floor %s instead of decayed %s",
+			state.nextAttempt,
+			floorDeadline,
+			decayedDeadline,
+		)
+	}
+
+	burst := map[string]os.FileInfo{
+		"a.md": first["a.md"],
+		"b.md": added["b.md"],
+		"c.md": added["c.md"],
+		"d.md": added["d.md"],
+	}
+	plan = state.plan(additionScannedAt.Add(time.Millisecond), burst)
+	if plan.attempt || plan.progress {
+		t.Fatalf("same-burst addition emitted another doorbell: %#v", plan)
+	}
+	if state.attempts != 6 || !state.nextAttempt.Equal(floorDeadline) {
+		t.Fatalf("same-burst addition changed retry ladder: %#v", state)
+	}
+
+	plan = state.plan(floorDeadline, burst)
+	if !plan.attempt || plan.progress || plan.prompt != coopWakeDoorbell {
+		t.Fatalf("consolidated floor plan = %#v", plan)
+	}
+	state.recordAttempt(floorDeadline)
+	if plan = state.plan(floorDeadline.Add(time.Millisecond), burst); plan.attempt {
+		t.Fatalf("coalesced burst emitted more than one doorbell: %#v", plan)
+	}
+
+	remaining := map[string]os.FileInfo{"d.md": burst["d.md"]}
+	plan = state.plan(floorDeadline.Add(2*time.Millisecond), remaining)
+	if !plan.attempt || !plan.progress || plan.prompt != coopWakeDoorbell {
+		t.Fatalf("post-expansion drain plan = %#v", plan)
+	}
+	if state.attempts != 0 || !sameKnownWakeCohort(state.cohort, remaining) {
+		t.Fatalf("post-expansion drain did not rearm remaining cohort: %#v", state)
+	}
+}
+
 func TestWakeDoorbellStateRearmsWhenUnknownIdentityBecomesKnown(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0)
 	current := map[string]os.FileInfo{
@@ -123,17 +199,18 @@ func TestWakeDoorbellRecoveryAttentionIsCohortBoundedAndRateLimited(t *testing.T
 		t.Fatal("initial recovery cohort was suppressed")
 	}
 	state.recordRecoveryRequired(now, first)
+	state.recordRecoveryAttentionDelivered()
 	if state.phase != wakeDoorbellRecoveryRequired {
 		t.Fatalf("recovery phase = %v", state.phase)
 	}
 	if state.planRecoveryAttention(now.Add(time.Millisecond), first) {
 		t.Fatal("unchanged recovery cohort was repeated")
 	}
-	if state.planRecoveryAttention(now.Add(wakeDoorbellRetryBase-time.Millisecond), second) {
+	if state.planRecoveryAttention(now.Add(wakeDoorbellAttentionRetryBase-time.Millisecond), second) {
 		t.Fatal("changed recovery cohort bypassed output rate bound")
 	}
 	if deadline, ok := state.nextDeadline(); !ok ||
-		!deadline.Equal(now.Add(wakeDoorbellRetryBase)) {
+		!deadline.Equal(now.Add(wakeDoorbellAttentionRetryBase)) {
 		t.Fatalf("recovery deadline = %s, ok=%v", deadline, ok)
 	}
 	if state.planRecoveryAttention(now.Add(time.Millisecond), nil) {
@@ -145,11 +222,11 @@ func TestWakeDoorbellRecoveryAttentionIsCohortBoundedAndRateLimited(t *testing.T
 	if state.planRecoveryAttention(now.Add(2*time.Millisecond), second) {
 		t.Fatal("drain-and-arrive recovery flap bypassed output rate bound")
 	}
-	if !state.planRecoveryAttention(now.Add(wakeDoorbellRetryBase), second) {
+	if !state.planRecoveryAttention(now.Add(wakeDoorbellAttentionRetryBase), second) {
 		t.Fatal("changed recovery cohort was not emitted after rate bound")
 	}
-	state.recordRecoveryRequired(now.Add(wakeDoorbellRetryBase), second)
-	if state.planRecoveryAttention(now.Add(2*wakeDoorbellRetryBase), second) {
+	state.recordRecoveryRequired(now.Add(wakeDoorbellAttentionRetryBase), second)
+	if state.planRecoveryAttention(now.Add(2*wakeDoorbellAttentionRetryBase), second) {
 		t.Fatal("recorded recovery cohort repeated")
 	}
 }

--- a/internal/cli/wake_owner_child_darwin.go
+++ b/internal/cli/wake_owner_child_darwin.go
@@ -88,6 +88,13 @@ func authoritativeWakePrivateStopFromEnv() (<-chan struct{}, func(), error) {
 	if err != nil || fd < 3 {
 		return nil, nil, fmt.Errorf("%s is invalid", envWakePrivateStopFD)
 	}
+	// ExtraFiles are inherited as blocking descriptors. Restore nonblocking
+	// mode before os.NewFile so Go registers the pipe with its poller and a
+	// concurrent Close can interrupt the startup read during early failure.
+	if err := unix.SetNonblock(fd, true); err != nil {
+		_ = unix.Close(fd)
+		return nil, nil, fmt.Errorf("make authoritative wake private-stop fd nonblocking: %w", err)
+	}
 	file := os.NewFile(uintptr(fd), "authoritative-wake-private-stop")
 	if file == nil {
 		return nil, nil, fmt.Errorf("%s fd is unavailable", envWakePrivateStopFD)

--- a/internal/cli/wake_owner_child_darwin_test.go
+++ b/internal/cli/wake_owner_child_darwin_test.go
@@ -112,6 +112,41 @@ func TestDarwinWakeOwnerPrivateStopCleanupInterruptsAndJoinsRead(t *testing.T) {
 	}
 }
 
+func TestDarwinWakeOwnerPrivateStopCleanupInterruptsInheritedBlockingRead(t *testing.T) {
+	var pipeFDs [2]int
+	if err := unix.Pipe(pipeFDs[:]); err != nil {
+		t.Fatal(err)
+	}
+	readFD, writeFD := pipeFDs[0], pipeFDs[1]
+	defer func() { _ = unix.Close(writeFD) }()
+	if err := unix.SetNonblock(readFD, false); err != nil {
+		_ = unix.Close(readFD)
+		t.Fatal(err)
+	}
+	t.Setenv(envWakePrivateStopFD, strconv.Itoa(readFD))
+
+	stop, cleanup, err := authoritativeWakePrivateStopFromEnv()
+	if err != nil {
+		_ = unix.Close(readFD)
+		t.Fatal(err)
+	}
+	finished := make(chan struct{})
+	go func() {
+		cleanup()
+		close(finished)
+	}()
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("private-stop cleanup did not interrupt inherited blocking read")
+	}
+	select {
+	case <-stop:
+		t.Fatal("cleanup was misclassified as explicit startup rollback")
+	default:
+	}
+}
+
 func TestDarwinWakeOwnerPrivateStopIsSealedFromDescendantExec(t *testing.T) {
 	if os.Getenv(darwinWakeOwnerDescendantHelperEnv) != "" {
 		if raw := os.Getenv(envWakePrivateStopFD); raw != "" {

--- a/internal/cli/wake_repair_handoff_unix.go
+++ b/internal/cli/wake_repair_handoff_unix.go
@@ -912,12 +912,20 @@ func (handoff *wakeRepairParentHandoff) SendSource(source wakeRepairHandoffSourc
 func (handoff *wakeRepairParentHandoff) ReceivePrepared(
 	source wakeRepairHandoffSource,
 ) (wakeRepairHandoffPrepared, error) {
-	if handoff == nil || handoff.reader == nil {
+	if handoff == nil || handoff.reader == nil || handoff.readFile == nil {
 		return wakeRepairHandoffPrepared{}, fmt.Errorf("wake repair parent handoff is unavailable")
 	}
+	if wakeRepairAdmitTimeout <= 0 {
+		return wakeRepairHandoffPrepared{}, fmt.Errorf("wake repair preparation timeout is invalid")
+	}
+	deadline := time.Now().Add(wakeRepairAdmitTimeout)
+	if err := handoff.readFile.SetReadDeadline(deadline); err != nil {
+		return wakeRepairHandoffPrepared{}, fmt.Errorf("set wake repair prepared tuple deadline: %w", err)
+	}
+	defer func() { _ = handoff.readFile.SetReadDeadline(time.Time{}) }()
 	prepared, err := readWakeRepairHandoffPrepared(handoff.reader)
 	if err != nil {
-		return wakeRepairHandoffPrepared{}, err
+		return wakeRepairHandoffPrepared{}, fmt.Errorf("wait for wake repair prepared tuple: %w", err)
 	}
 	if err := prepared.validateSource(source); err != nil {
 		return wakeRepairHandoffPrepared{}, err
@@ -1196,6 +1204,14 @@ func (handoff *wakeRepairChildHandoff) AwaitAdmitAcknowledgeAndRelease(
 		handoff.readFile == nil {
 		return fmt.Errorf("wake repair child handoff is unavailable")
 	}
+	if wakeRepairAdmitTimeout <= 0 {
+		return fmt.Errorf("wake repair admission timeout is invalid")
+	}
+	deadline := time.Now().Add(wakeRepairAdmitTimeout)
+	if err := handoff.readFile.SetReadDeadline(deadline); err != nil {
+		return fmt.Errorf("set wake repair admission deadline: %w", err)
+	}
+	defer func() { _ = handoff.readFile.SetReadDeadline(time.Time{}) }()
 	admit, err := readWakeRepairHandoffAdmit(handoff.reader)
 	if err != nil {
 		return fmt.Errorf("wait for wake repair admission: %w", err)
@@ -1218,10 +1234,7 @@ func (handoff *wakeRepairChildHandoff) AwaitAdmitAcknowledgeAndRelease(
 	if err := writeWakeRepairHandoffAdmit(handoff.writer, admit); err != nil {
 		return fmt.Errorf("acknowledge wake repair admission: %w", err)
 	}
-	if wakeRepairAdmitTimeout <= 0 {
-		return fmt.Errorf("wake repair release timeout is invalid")
-	}
-	deadline := time.Now().Add(wakeRepairAdmitTimeout)
+	deadline = time.Now().Add(wakeRepairAdmitTimeout)
 	if err := handoff.readFile.SetReadDeadline(deadline); err != nil {
 		return fmt.Errorf("set wake repair release deadline: %w", err)
 	}

--- a/internal/cli/wake_repair_handoff_unix_test.go
+++ b/internal/cli/wake_repair_handoff_unix_test.go
@@ -857,6 +857,86 @@ func TestWakeRepairParentAdmissionAcknowledgementIsBounded(t *testing.T) {
 	}
 }
 
+func TestWakeRepairParentPreparedReadIsBounded(t *testing.T) {
+	source, _ := wakeRepairProtocolPreparedForTest(t, "child-generation")
+	parentToChildReader, parentToChildWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childToParentReader, childToParentWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = parentToChildReader.Close()
+		_ = parentToChildWriter.Close()
+		_ = childToParentReader.Close()
+		_ = childToParentWriter.Close()
+	}()
+	parent := newWakeRepairParentHandoffForFiles(parentToChildWriter, childToParentReader)
+
+	oldTimeout := wakeRepairAdmitTimeout
+	wakeRepairAdmitTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { wakeRepairAdmitTimeout = oldTimeout })
+
+	result := make(chan error, 1)
+	go func() {
+		_, receiveErr := parent.ReceivePrepared(source)
+		result <- receiveErr
+	}()
+	select {
+	case err := <-result:
+		if err == nil ||
+			!strings.Contains(err.Error(), "prepared") ||
+			!strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("prepared read timeout = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("parent prepared read remained blocked past its deadline")
+	}
+}
+
+func TestWakeRepairChildAdmissionReadIsBounded(t *testing.T) {
+	_, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
+	parentToChildReader, parentToChildWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childToParentReader, childToParentWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = parentToChildReader.Close()
+		_ = parentToChildWriter.Close()
+		_ = childToParentReader.Close()
+		_ = childToParentWriter.Close()
+	}()
+	child := newWakeRepairChildHandoffForFiles(parentToChildReader, childToParentWriter)
+
+	oldTimeout := wakeRepairAdmitTimeout
+	wakeRepairAdmitTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { wakeRepairAdmitTimeout = oldTimeout })
+
+	result := make(chan error, 1)
+	go func() {
+		result <- child.AwaitAdmitAcknowledgeAndRelease(
+			prepared,
+			func() error { return nil },
+		)
+	}()
+	select {
+	case err := <-result:
+		if err == nil ||
+			!strings.Contains(err.Error(), "admission") ||
+			!strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("admission read timeout = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("child admission read remained blocked past its deadline")
+	}
+}
+
 func TestWakeRepairParentReleaseRequiresExactAcknowledgement(t *testing.T) {
 	_, prepared := wakeRepairProtocolPreparedForTest(t, "child-generation")
 	parentToChildReader, parentToChildWriter, err := os.Pipe()

--- a/internal/cli/wake_terminal_authority_unix_test.go
+++ b/internal/cli/wake_terminal_authority_unix_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -723,7 +724,7 @@ func TestRunWakeLoopTerminatesOnTerminalAuthorityLoss(t *testing.T) {
 	}
 }
 
-func TestRunWakeLoopUsesAttentionCadenceAfterZeroProgressForegroundPGRPMismatch(t *testing.T) {
+func TestRunWakeLoopRetriesForegroundPGRPMismatchWithoutAttentionFlood(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	message := format.Message{
@@ -750,9 +751,11 @@ func TestRunWakeLoopUsesAttentionCadenceAfterZeroProgressForegroundPGRPMismatch(
 		t.Fatal(err)
 	}
 
-	firstRefused := make(chan struct{}, 1)
+	refused := make(chan struct{}, 4)
+	restored := make(chan struct{})
 	delivered := make(chan struct{}, 1)
-	attention := make(chan struct{}, 1)
+	attention := make(chan struct{}, 4)
+	var attentionWrites atomic.Int64
 	controlStop := make(chan struct{})
 	runDone := make(chan error, 1)
 
@@ -770,14 +773,22 @@ func TestRunWakeLoopUsesAttentionCadenceAfterZeroProgressForegroundPGRPMismatch(
 				case attention <- struct{}{}:
 				default:
 				}
+				if attentionWrites.Add(1) == 1 {
+					return len(data) - 1, nil
+				}
 				return len(data), nil
 			},
 			beforeTerminalWrite: func() error {
 				select {
-				case firstRefused <- struct{}{}:
+				case refused <- struct{}{}:
 				default:
 				}
-				return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+				select {
+				case <-restored:
+					return nil
+				default:
+					return newWakeTerminalForegroundPGRPChangedLoss(101, 202)
+				}
 			},
 			terminalWrite: func(string) error {
 				select {
@@ -790,7 +801,7 @@ func TestRunWakeLoopUsesAttentionCadenceAfterZeroProgressForegroundPGRPMismatch(
 	}()
 
 	select {
-	case <-firstRefused:
+	case <-refused:
 	case err := <-runDone:
 		t.Fatalf("wake loop exited on foreground-pgrp mismatch: %v", err)
 	case <-time.After(2 * time.Second):
@@ -805,11 +816,33 @@ func TestRunWakeLoopUsesAttentionCadenceAfterZeroProgressForegroundPGRPMismatch(
 	}
 
 	select {
-	case <-delivered:
-		t.Fatal("wake loop wrote while foreground pgrp mismatched")
+	case <-refused:
 	case err := <-runDone:
 		t.Fatalf("wake loop exited while foreground pgrp mismatched: %v", err)
-	case <-time.After(wakeTerminalAuthorityRetryDelay + 100*time.Millisecond):
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not retry foreground pgrp promptly")
+	}
+	select {
+	case <-attention:
+		t.Fatal("foreground pgrp retry repeated attention before its deadline")
+	default:
+	}
+	if got := attentionWrites.Load(); got != 1 {
+		t.Fatalf("foreground pgrp attention writes = %d, want one short write", got)
+	}
+	select {
+	case <-delivered:
+		t.Fatal("wake loop wrote while foreground pgrp mismatched")
+	default:
+	}
+
+	close(restored)
+	select {
+	case <-delivered:
+	case err := <-runDone:
+		t.Fatalf("wake loop exited before foreground pgrp recovery: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not deliver promptly after foreground pgrp recovery")
 	}
 
 	close(controlStop)

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -117,6 +118,45 @@ func TestBuildNotificationTextRestoresPeerHeadersForOutput(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("notification output %q missing %q", text, want)
 		}
+	}
+}
+
+func TestWakeNotificationTextCapsDistinctSenderClauses(t *testing.T) {
+	var messages []wakeMsgInfo
+	senderCounts := make(map[string]int)
+	for i := maxWakeNotificationSenderClauses + 1; i >= 0; i-- {
+		sender := fmt.Sprintf("sender-%02d", i)
+		messages = append(messages, wakeMsgInfo{from: sender})
+		senderCounts[sender]++
+	}
+
+	notification := buildNotificationText("session1", messages, 48)
+	interrupt := buildInterruptText("session1", messages, senderCounts, 48, "")
+	for name, text := range map[string]string{
+		"notification": notification,
+		"interrupt":    interrupt,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(text, fmt.Sprintf("%d ", len(messages))) {
+				t.Fatalf("aggregate count missing from %q", text)
+			}
+			if !strings.Contains(text, "1 from sender-00") ||
+				!strings.Contains(text, fmt.Sprintf(
+					"1 from sender-%02d",
+					maxWakeNotificationSenderClauses-1,
+				)) {
+				t.Fatalf("bounded sender clauses missing from %q", text)
+			}
+			if strings.Contains(text, fmt.Sprintf(
+				"1 from sender-%02d",
+				maxWakeNotificationSenderClauses,
+			)) {
+				t.Fatalf("omitted sender leaked into %q", text)
+			}
+			if !strings.Contains(text, "2 other senders") {
+				t.Fatalf("omitted sender count missing from %q", text)
+			}
+		})
 	}
 }
 
@@ -839,11 +879,66 @@ func TestDeliverNewMessageNotificationRecordsFirstAttemptDemotion(t *testing.T) 
 	}
 }
 
+func TestDeliverNewMessageNotificationOwnerlessDemotionRearmsOnPartialDrain(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "first.md", "second.md")
+	remaining := map[string]os.FileInfo{"second.md": current["second.md"]}
+	attentionWrites := 0
+	cfg := &wakeConfig{
+		me:         "codex",
+		injectMode: wakeInjectModePaste,
+		doorbellNow: func() time.Time {
+			return now
+		},
+		terminalWrite: func(string) error {
+			return newWakeInjectorUnsupportedError(errors.New("injector disabled"))
+		},
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
+	}
+
+	if err := deliverNewMessageNotification(
+		cfg,
+		peerWakeNotification("two pending messages"),
+		false,
+		current,
+	); err != nil {
+		t.Fatalf("ownerless demotion: %v", err)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("ownerless demotion attention writes = %d, want 1", attentionWrites)
+	}
+	if !sameKnownWakeCohort(cfg.doorbell.cohort, current) {
+		t.Fatalf("ownerless demotion lost cohort: %#v", cfg.doorbell)
+	}
+
+	now = now.Add(time.Second)
+	if err := deliverNewMessageNotification(
+		cfg,
+		peerWakeNotification("one pending message"),
+		false,
+		remaining,
+	); err != nil {
+		t.Fatalf("ownerless partial-drain rearm: %v", err)
+	}
+	if attentionWrites != 2 {
+		t.Fatalf("partial drain did not immediately rearm attention: writes=%d", attentionWrites)
+	}
+	if !sameKnownWakeCohort(cfg.doorbell.cohort, remaining) {
+		t.Fatalf("partial drain did not snapshot remaining cohort: %#v", cfg.doorbell)
+	}
+}
+
 func TestDeliverNewMessageNotificationRetriesCohortAfterShortOutputAttention(t *testing.T) {
 	current := wakeDoorbellTestFiles(t, "pending.md")
+	now := time.Unix(1_800_000_000, 0)
 	writes := 0
 	cfg := &wakeConfig{
 		injectMode:     wakeInjectModeNone,
+		doorbellNow:    func() time.Time { return now },
 		attentionIsTTY: func() bool { return false },
 		attentionWrite: func(data []byte) (int, error) {
 			writes++
@@ -864,8 +959,9 @@ func TestDeliverNewMessageNotificationRetriesCohortAfterShortOutputAttention(t *
 	if !errors.As(err, &attentionErr) {
 		t.Fatalf("first delivery error = %v, want typed attention failure", err)
 	}
-	if cfg.doorbell.attempts != 0 {
-		t.Fatalf("short output write advanced retry state: %#v", cfg.doorbell)
+	if cfg.doorbell.attempts != 1 ||
+		!cfg.doorbell.nextAttempt.Equal(now.Add(wakeDoorbellAttentionRetryBase)) {
+		t.Fatalf("short output write did not arm attention retry: %#v", cfg.doorbell)
 	}
 
 	if err := deliverNewMessageNotification(
@@ -874,14 +970,27 @@ func TestDeliverNewMessageNotificationRetriesCohortAfterShortOutputAttention(t *
 		false,
 		current,
 	); err != nil {
-		t.Fatalf("retry after short output write: %v", err)
+		t.Fatalf("suppressed retry after short output write: %v", err)
+	}
+	if writes != 1 {
+		t.Fatalf("attention retried before output deadline: writes=%d", writes)
+	}
+
+	now = now.Add(wakeDoorbellAttentionRetryBase)
+	if err := deliverNewMessageNotification(
+		cfg,
+		peerWakeNotification("pending message"),
+		false,
+		current,
+	); err != nil {
+		t.Fatalf("due retry after short output write: %v", err)
 	}
 	if writes != 2 {
-		t.Fatalf("attention writes = %d, want failed write plus retry", writes)
+		t.Fatalf("attention writes = %d, want failed write plus due retry", writes)
 	}
 	if cfg.doorbell.phase != wakeDoorbellRetrying ||
 		!sameKnownWakeCohort(cfg.doorbell.cohort, current) ||
-		cfg.doorbell.attempts != 1 {
+		cfg.doorbell.attempts != 2 {
 		t.Fatalf("successful output retry did not arm backoff: %#v", cfg.doorbell)
 	}
 }
@@ -1735,7 +1844,7 @@ func TestNotifyNewMessagesNormalSuccessUsesFixedInputOnly(t *testing.T) {
 	}
 }
 
-func TestNotifyNewMessagesWaitsSilentlyUntilRetryOrProgress(t *testing.T) {
+func TestNotifyNewMessagesCoalescesAdditionsUntilRetryOrProgress(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
@@ -1809,6 +1918,15 @@ func TestNotifyNewMessagesWaitsSilentlyUntilRetryOrProgress(t *testing.T) {
 		t.Fatalf("pending generation emitted output-only reminder: %q", stderr)
 	}
 
+	now = now.Add(wakeDoorbellRetryBase)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("notify at consolidated retry deadline: %v", err)
+	}
+	if got := strings.Join(injected, "|"); got != coopWakeDoorbell+"|\n|\r|\r" {
+		t.Fatalf("consolidated raw injection = %q, want one fixed doorbell", got)
+	}
+	injected = nil
+
 	if drained := runDrainJSON(t, root, "codex", 1, false); drained.Count != 1 {
 		t.Fatalf("drained count = %d, want 1", drained.Count)
 	}
@@ -1828,14 +1946,14 @@ func TestNotifyNewMessagesWaitsSilentlyUntilRetryOrProgress(t *testing.T) {
 		}
 	})
 	if len(injected) != 0 {
-		t.Fatalf("re-armed backlog injected another user turn: %q", injected)
+		t.Fatalf("fourth pending message injected another user turn: %q", injected)
 	}
 	if stderr != "" {
 		t.Fatalf("re-armed generation emitted output-only reminder: %q", stderr)
 	}
 }
 
-func TestNotifyNewMessagesDoesNotFloodAttentionForUrgentAddition(t *testing.T) {
+func TestNotifyNewMessagesCoalescesUrgentAdditionWithoutOutputAttention(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatalf("EnsureRootDirs: %v", err)
@@ -1904,6 +2022,9 @@ func TestNotifyNewMessagesDoesNotFloodAttentionForUrgentAddition(t *testing.T) {
 	})
 	if len(injected) != 0 {
 		t.Fatalf("urgent pending message injected another user turn: %q", injected)
+	}
+	if len(cfg.doorbell.cohort) != 2 {
+		t.Fatalf("urgent addition was not retained in the cohort: %#v", cfg.doorbell)
 	}
 	if stderr != "" {
 		t.Fatalf("urgent addition emitted periodic output attention: %q", stderr)
@@ -2364,39 +2485,27 @@ func TestNotifyNewMessagesOwnerlessSuccessfulInputRetryEmitsNoAttention(t *testi
 	}
 }
 
-func TestRecordWakeAttemptForcesRetryPhase(t *testing.T) {
+func TestRecordWakeAttemptArmsMissingCohort(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0)
-	tests := []struct {
-		name  string
-		phase wakeDoorbellPhase
-	}{
-		{name: "idle", phase: wakeDoorbellIdle},
-		{name: "recovery required", phase: wakeDoorbellRecoveryRequired},
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	cfg := &wakeConfig{}
+
+	recordWakeAttempt(cfg, now, current, nil)
+
+	if cfg.doorbell.phase != wakeDoorbellRetrying {
+		t.Fatalf("recorded phase = %d, want retrying", cfg.doorbell.phase)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &wakeConfig{
-				doorbell: wakeDoorbellState{phase: tt.phase},
-			}
-
-			recordWakeAttempt(cfg, now)
-
-			if cfg.doorbell.phase != wakeDoorbellRetrying {
-				t.Fatalf(
-					"recorded phase = %d, want retrying",
-					cfg.doorbell.phase,
-				)
-			}
-			if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
-				!deadline.Equal(now.Add(wakeDoorbellRetryBase)) {
-				t.Fatalf(
-					"recorded deadline = %s, ok=%v; want %s",
-					deadline,
-					ok,
-					now.Add(wakeDoorbellRetryBase),
-				)
-			}
-		})
+	if !sameKnownWakeCohort(cfg.doorbell.cohort, current) {
+		t.Fatalf("recorded attempt did not retain current cohort: %#v", cfg.doorbell)
+	}
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
+		!deadline.Equal(now.Add(wakeDoorbellRetryBase)) {
+		t.Fatalf(
+			"recorded deadline = %s, ok=%v; want %s",
+			deadline,
+			ok,
+			now.Add(wakeDoorbellRetryBase),
+		)
 	}
 }
 
@@ -2829,10 +2938,10 @@ func TestNotifyNewMessagesResumesCoopInputAfterPartialSubmitFailure(t *testing.T
 				t.Fatalf("retry after partial %s failure: %v", tc.mode, err)
 			}
 			if got := strings.Join(injected, "|"); got != tc.retryWant {
-				t.Fatalf("retry %s injection = %q, want %q", tc.mode, got, tc.retryWant)
+				t.Fatalf("coalesced %s retry injection = %q, want %q", tc.mode, got, tc.retryWant)
 			}
-			if len(cfg.doorbell.cohort) != 1 {
-				t.Fatalf("successful %s retry changed frozen cohort to %d messages, want 1", tc.mode, len(cfg.doorbell.cohort))
+			if len(cfg.doorbell.cohort) != 2 {
+				t.Fatalf("successful %s addition rearm retained %d messages, want 2", tc.mode, len(cfg.doorbell.cohort))
 			}
 		})
 	}
@@ -2916,19 +3025,20 @@ func TestNotifyNewMessagesRetriesAfterRescueAuthorityError(t *testing.T) {
 		}
 	})
 	if got := strings.Join(injected, "|"); got != "\r" {
-		t.Fatalf("partial rescue retry = %q, want exact missing rescue CR", got)
+		t.Fatalf("coalesced rescue retry = %q, want exact missing rescue CR", got)
 	}
 	if stderr != "" {
 		t.Fatalf("pending generation emitted output-only reminder: %q", stderr)
 	}
 
 	now = now.Add(wakeDoorbellRetryBase)
+	injected = nil
 	if err := notifyNewMessages(cfg); err != nil {
 		t.Fatalf("retry after deadline: %v", err)
 	}
-	want := "\r|" + coopWakeDoorbell + "|\n|\r|\r"
+	want := coopWakeDoorbell + "|\n|\r|\r"
 	if got := strings.Join(injected, "|"); got != want {
-		t.Fatalf("deadline retry = %q, want preserved rescue then one full retry %q", got, want)
+		t.Fatalf("deadline retry = %q, want one full retry %q", got, want)
 	}
 	if cfg.inputDelivery.pending() {
 		t.Fatalf("input delivery = %#v, want idle after rescue completion", cfg.inputDelivery)

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1351,12 +1351,44 @@ func openCoopWakeOutput(root, me string) (*os.File, error) {
 	return openWakeOutputInDir(agentDir, ".wake.log", "wake log")
 }
 
-// wakeOutputMaxBytes bounds diagnostics accumulated across wake launches.
-// Children inherit the descriptor directly, so one long-lived child can exceed
-// the threshold; the next launch truncates that same hardened regular file.
+// wakeOutputMaxBytes bounds accumulated diagnostics both at launch and on the
+// existing wake maintenance tick.
 const wakeOutputMaxBytes int64 = 1 << 20
 
 var truncateWakeOutput = unix.Ftruncate
+
+func maintainWakeOutputBounds(outputs ...*os.File) error {
+	var bounded []os.FileInfo
+	var errs []error
+	for _, output := range outputs {
+		if output == nil {
+			continue
+		}
+		info, err := output.Stat()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("stat wake output %s: %w", output.Name(), err))
+			continue
+		}
+		if !info.Mode().IsRegular() || info.Size() < wakeOutputMaxBytes {
+			continue
+		}
+		duplicate := false
+		for _, prior := range bounded {
+			if os.SameFile(prior, info) {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		bounded = append(bounded, info)
+		if err := truncateWakeOutput(int(output.Fd()), 0); err != nil {
+			errs = append(errs, fmt.Errorf("truncate wake output %s: %w", output.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
 
 func openWakeOutputInDir(
 	agentDir *wakeAgentDir,
@@ -2725,16 +2757,16 @@ func runWakeLoop(cfg wakeConfig) error {
 	}
 	enterRetainedInputRecovery := func(cause error) error {
 		markWakeInputRecoveryRequired(&cfg, cause)
-		if err := emitWakeAttention(&cfg, wakePayload{
-			text:       wakeInputRecoveryNotice,
-			provenance: wakePayloadSystemFixed,
-		}); err != nil {
-			return errors.Join(cause, err)
-		}
 		cfg.doorbell.retainRecoveryRequired(cfg.wakeDoorbellNow())
 		pendingNotify = false
 		clearTerminalAuthorityRetry()
-		clearDoorbellDeadline()
+		if err := emitWakeAttention(&cfg, wakePayload{
+			text:       wakeInputRecoveryNotice,
+			provenance: wakePayloadSystemFixed,
+		}); err == nil {
+			cfg.doorbell.recordRecoveryAttentionDelivered()
+		}
+		scheduleDoorbellDeadline()
 		return nil
 	}
 	attemptNotification := func() error {
@@ -2751,16 +2783,6 @@ func runWakeLoop(cfg wakeConfig) error {
 			clearDoorbellDeadline()
 			_ = writeWakeDiagnostic(&cfg, "amq wake: notify error: %v\n", err)
 			return nil
-		}
-		var attentionErr *wakeAttentionDeliveryError
-		if errors.As(err, &attentionErr) {
-			pendingNotify = true
-			clearDoorbellDeadline()
-			return err
-		}
-		if isWakeInputDemotionBlocked(err) ||
-			isWakeTerminalProgressUncertain(err) {
-			return enterRetainedInputRecovery(err)
 		}
 		clearInboxScanRetry()
 		inboxScanFailures = 0
@@ -2789,6 +2811,18 @@ func runWakeLoop(cfg wakeConfig) error {
 				)
 			}
 			return nil
+		}
+		var attentionErr *wakeAttentionDeliveryError
+		if errors.As(err, &attentionErr) &&
+			!isWakeTerminalAuthorityLoss(err) {
+			pendingNotify = false
+			clearTerminalAuthorityRetry()
+			scheduleDoorbellDeadline()
+			return nil
+		}
+		if isWakeInputDemotionBlocked(err) ||
+			isWakeTerminalProgressUncertain(err) {
+			return enterRetainedInputRecovery(err)
 		}
 		pendingNotify = false
 		clearTerminalAuthorityRetry()
@@ -2823,6 +2857,10 @@ func runWakeLoop(cfg wakeConfig) error {
 		maintenanceTicker = time.NewTicker(30 * time.Second)
 		maintenanceTicks = maintenanceTicker.C
 		defer maintenanceTicker.Stop()
+	}
+	maintenanceOutputs := cfg.maintenanceOutputs
+	if maintenanceOutputs == nil {
+		maintenanceOutputs = []*os.File{os.Stdout, os.Stderr}
 	}
 	preconditionCheck := cfg.preconditionCheck
 	if preconditionCheck == nil {
@@ -2952,6 +2990,13 @@ func runWakeLoop(cfg wakeConfig) error {
 			}
 
 		case <-maintenanceTicks:
+			if err := maintainWakeOutputBounds(maintenanceOutputs...); err != nil {
+				_ = writeWakeDiagnostic(
+					&cfg,
+					"amq wake: maintain output bound: %v; continuing without truncation\n",
+					err,
+				)
+			}
 			pendingInputWork := !cfg.inputRecoveryRequired &&
 				(cfg.doorbell.pendingInput() || cfg.inputDelivery.pending())
 			hadPendingInputWork := pendingNotify || pendingInputWork

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -184,8 +184,8 @@ func TestNotifyNewMessagesForegroundPGRPResumesAtFirstMissingChunk(t *testing.T)
 
 			err := notifyNewMessages(cfg)
 			if tc.failAt == 1 {
-				if err != nil {
-					t.Fatalf("zero-progress refusal = %v, want attention fallback", err)
+				if !isWakeTerminalForegroundPGRPChanged(err) {
+					t.Fatalf("zero-progress refusal = %T %v, want foreground-PGRP change", err, err)
 				}
 				if attentionWrites != 1 {
 					t.Fatalf("zero-progress attention writes = %d, want 1", attentionWrites)
@@ -197,9 +197,6 @@ func TestNotifyNewMessagesForegroundPGRPResumesAtFirstMissingChunk(t *testing.T)
 				t.Fatalf("first writes = %q, want %q", got, strings.Join(tc.firstWant, "|"))
 			}
 			wantAttempts := uint(0)
-			if tc.failAt == 1 {
-				wantAttempts = 1
-			}
 			if cfg.doorbell.attempts != wantAttempts {
 				t.Fatalf(
 					"attempts after foreground refusal = %d, want %d",
@@ -207,11 +204,14 @@ func TestNotifyNewMessagesForegroundPGRPResumesAtFirstMissingChunk(t *testing.T)
 					wantAttempts,
 				)
 			}
+			if !cfg.doorbell.nextAttempt.IsZero() {
+				t.Fatalf(
+					"foreground refusal armed delivery ladder: %#v",
+					cfg.doorbell,
+				)
+			}
 
 			writes = nil
-			if tc.failAt == 1 {
-				now = now.Add(wakeDoorbellAttentionRetryBase)
-			}
 			if err := notifyNewMessages(cfg); err != nil {
 				t.Fatalf("retry notify: %v", err)
 			}
@@ -441,8 +441,8 @@ func TestNotifyNewMessagesReconcilesPartialDeliveryAfterInboxDrain(t *testing.T)
 
 			err := notifyNewMessages(cfg)
 			if tc.failAt == 1 {
-				if err != nil {
-					t.Fatalf("zero-progress refusal = %v, want attention fallback", err)
+				if !isWakeTerminalForegroundPGRPChanged(err) {
+					t.Fatalf("zero-progress refusal = %T %v, want foreground-PGRP change", err, err)
 				}
 				if attentionWrites != 1 {
 					t.Fatalf("zero-progress attention writes = %d, want 1", attentionWrites)
@@ -2017,6 +2017,282 @@ func TestNotifyNewMessagesAttentionOnlyRetryCadence(t *testing.T) {
 	}
 }
 
+func TestNotifyNewMessagesMaxHoldRetriesInputWithoutAttentionFlood(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "max-hold-retry")
+
+	oldWait := waitForWakeInputQuiet
+	waitForWakeInputQuiet = func(*wakeConfig) bool { return false }
+	t.Cleanup(func() { waitForWakeInputQuiet = oldWait })
+
+	now := time.Unix(1_800_000_000, 0)
+	attentionWrites := 0
+	cfg := &wakeConfig{
+		root:            root,
+		me:              "codex",
+		session:         "session1",
+		wakeOwner:       &wakeOwner{},
+		injectMode:      wakeInjectModeRaw,
+		deferWhileInput: true,
+		doorbellNow:     func() time.Time { return now },
+		attentionIsTTY:  func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("initial max-hold notification: %v", err)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("initial max-hold attention writes = %d, want 1", attentionWrites)
+	}
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
+		!deadline.Equal(now.Add(wakeDoorbellRetryBase)) {
+		t.Fatalf(
+			"max-hold input deadline = %s, ok=%v; want %s",
+			deadline,
+			ok,
+			now.Add(wakeDoorbellRetryBase),
+		)
+	}
+
+	now = now.Add(wakeDoorbellRetryBase)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("max-hold input retry: %v", err)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("max-hold retry flooded attention: writes=%d", attentionWrites)
+	}
+}
+
+func TestNotifyNewMessagesMaxHoldShortAttentionKeepsInputRetryCadence(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "max-hold-short-attention")
+
+	oldWait := waitForWakeInputQuiet
+	waitForWakeInputQuiet = func(*wakeConfig) bool { return false }
+	t.Cleanup(func() { waitForWakeInputQuiet = oldWait })
+
+	now := time.Unix(1_800_000_000, 0)
+	attentionWrites := 0
+	cfg := &wakeConfig{
+		root:            root,
+		me:              "codex",
+		session:         "session1",
+		wakeOwner:       &wakeOwner{},
+		injectMode:      wakeInjectModeRaw,
+		deferWhileInput: true,
+		doorbellNow:     func() time.Time { return now },
+		attentionIsTTY:  func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data) - 1, nil
+		},
+	}
+
+	err := notifyNewMessages(cfg)
+	var attentionErr *wakeAttentionDeliveryError
+	if !errors.As(err, &attentionErr) {
+		t.Fatalf("max-hold short attention = %v, want typed output failure", err)
+	}
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
+		!deadline.Equal(now.Add(wakeDoorbellRetryBase)) {
+		t.Fatalf(
+			"max-hold short-attention input deadline = %s, ok=%v; want %s",
+			deadline,
+			ok,
+			now.Add(wakeDoorbellRetryBase),
+		)
+	}
+	if !cfg.doorbell.nextTransientAttention.Equal(
+		now.Add(wakeDoorbellAttentionRetryBase),
+	) {
+		t.Fatalf("max-hold output retry was not rate-limited: %#v", cfg.doorbell)
+	}
+
+	now = now.Add(wakeDoorbellRetryBase)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("max-hold input retry after short attention: %v", err)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("max-hold input retry flooded failed attention: writes=%d", attentionWrites)
+	}
+}
+
+func TestNotifyNewMessagesRecoveryAttentionRetriesOnAttentionCadence(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "recovery-retry")
+
+	now := time.Unix(1_800_000_000, 0)
+	attentionWrites := 0
+	cfg := &wakeConfig{
+		root:                  root,
+		me:                    "codex",
+		inputRecoveryRequired: true,
+		doorbellNow:           func() time.Time { return now },
+		attentionIsTTY:        func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("initial recovery attention: %v", err)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("initial recovery attention writes = %d, want 1", attentionWrites)
+	}
+	firstDeadline := now.Add(wakeDoorbellAttentionRetryBase)
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
+		!deadline.Equal(firstDeadline) {
+		t.Fatalf("recovery deadline = %s, ok=%v; want %s", deadline, ok, firstDeadline)
+	}
+
+	now = firstDeadline.Add(-time.Millisecond)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("early recovery retry: %v", err)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("recovery attention repeated early: writes=%d", attentionWrites)
+	}
+
+	now = firstDeadline
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("due recovery retry: %v", err)
+	}
+	if attentionWrites != 2 {
+		t.Fatalf("due recovery attention writes = %d, want 2", attentionWrites)
+	}
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok ||
+		!deadline.Equal(now.Add(time.Minute)) {
+		t.Fatalf(
+			"second recovery deadline = %s, ok=%v; want %s",
+			deadline,
+			ok,
+			now.Add(time.Minute),
+		)
+	}
+}
+
+func TestRunWakeLoopCoalescesAdditionThenRearmsAfterDrain(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "a", "claude")
+	aPath := filepath.Join(fsq.AgentInboxNew(root, "codex"), "a.md")
+	aInfo, err := os.Stat(aPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	startedAt := time.Now()
+	floorAt := startedAt.Add(500 * time.Millisecond)
+	lastAttempt := floorAt.Add(-wakeDoorbellRetryBase)
+	decayedRetryAt := startedAt.Add(15 * time.Minute)
+	doorbells := make(chan struct{}, 3)
+	pending := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			wakeOwner:   &wakeOwner{},
+			injectMode:  wakeInjectModeRaw,
+			controlStop: stop,
+			debounce:    10 * time.Millisecond,
+			doorbell: wakeDoorbellState{
+				phase:                wakeDoorbellRetrying,
+				cohort:               snapshotWakeFileIdentities(map[string]os.FileInfo{"a.md": aInfo}),
+				attempts:             6,
+				nextAttempt:          decayedRetryAt,
+				additionAttemptFloor: lastAttempt.Add(wakeDoorbellRetryBase),
+			},
+			preconditionCheck: func(*wakeConfig) error { return nil },
+			terminalWrite: func(text string) error {
+				if strings.Contains(text, coopWakeDoorbell) {
+					doorbells <- struct{}{}
+				}
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			onPendingNotify: func() {
+				select {
+				case pending <- struct{}{}:
+				default:
+				}
+			},
+		})
+	}()
+	defer func() {
+		close(stop)
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("wake loop stop: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	}()
+
+	deliverWakeWatcherMessageForTest(t, root, "codex", "b", "claude")
+	select {
+	case <-pending:
+	case err := <-done:
+		t.Fatalf("wake loop exited before observing addition: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not observe first addition")
+	}
+	deliverWakeWatcherMessageForTest(t, root, "codex", "c", "claude")
+
+	if earlyWait := time.Until(floorAt) / 2; earlyWait > 0 {
+		select {
+		case <-doorbells:
+			t.Fatal("added-message burst emitted before the delivery floor")
+		case err := <-done:
+			t.Fatalf("wake loop exited before delivery floor: %v", err)
+		case <-time.After(earlyWait):
+		}
+	}
+	select {
+	case <-doorbells:
+	case err := <-done:
+		t.Fatalf("wake loop exited before delivery floor: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("coalesced cohort waited for the decayed retry deadline")
+	}
+	select {
+	case <-doorbells:
+		t.Fatal("one debounce burst emitted more than one doorbell")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if drained := runDrainJSON(t, root, "codex", 1, false); drained.Count != 1 {
+		t.Fatalf("drained count = %d, want 1", drained.Count)
+	}
+	select {
+	case <-doorbells:
+	case err := <-done:
+		t.Fatalf("wake loop exited before post-drain rearm: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("draining one coalesced message did not immediately rearm the remainder")
+	}
+	select {
+	case <-doorbells:
+		t.Fatal("post-drain rearm emitted more than one consolidated doorbell")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestNotifyNewMessagesInjectionFallbackUsesAttentionRetryCadence(t *testing.T) {
 	root := secureTempDirForTest(t)
 	deliverPartialWakeMessageForTest(t, root, "codex", "attention-fallback")
@@ -2145,6 +2421,75 @@ func TestRunWakeLoopHonorsAttentionOnlyDoorbellDeadline(t *testing.T) {
 	}
 	if got := afterDeadlineCalls.Load(); got != callsAfterRetry {
 		t.Fatalf("attention retry hot-looped: deadline calls %d -> %d", callsAfterRetry, got)
+	}
+}
+
+func TestRunWakeLoopRetriesShortOutputAttentionWithoutExit(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "short-output-attention")
+
+	start := time.Unix(1_800_000_000, 0)
+	nowCalls := 0
+	var attentionWrites atomic.Int64
+	retried := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			injectMode:  wakeInjectModeNone,
+			controlStop: stop,
+			doorbellNow: func() time.Time {
+				nowCalls++
+				if nowCalls >= 3 {
+					return start.Add(wakeDoorbellAttentionRetryBase)
+				}
+				return start
+			},
+			attentionIsTTY: func() bool {
+				return false
+			},
+			attentionWrite: func(data []byte) (int, error) {
+				if attentionWrites.Add(1) == 1 {
+					return len(data) - 1, nil
+				}
+				select {
+				case retried <- struct{}{}:
+				default:
+				}
+				return len(data), nil
+			},
+		})
+	}()
+
+	select {
+	case <-retried:
+	case err := <-done:
+		t.Fatalf("wake loop exited on short output attention: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("wake loop did not retry short output attention: writes=%d", attentionWrites.Load())
+	}
+	if got := attentionWrites.Load(); got != 2 {
+		t.Fatalf("attention writes = %d, want short write plus retry", got)
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("wake loop exited after output retry: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if got := attentionWrites.Load(); got != 2 {
+		t.Fatalf("output attention hot-looped after retry: writes=%d", got)
+	}
+	close(stop)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop")
 	}
 }
 
@@ -3639,7 +3984,7 @@ func TestRunWakeLoopKeepsWatchingAfterConfirmedInputBecomesUnsupported(t *testin
 	case <-time.After(200 * time.Millisecond):
 	}
 
-	nowNanos.Store(start.Add(wakeDoorbellRetryBase).UnixNano())
+	nowNanos.Store(start.Add(wakeDoorbellAttentionRetryBase).UnixNano())
 	writeMessage("second.md", "second")
 	select {
 	case output := <-attention:
@@ -3663,7 +4008,7 @@ func TestRunWakeLoopKeepsWatchingAfterConfirmedInputBecomesUnsupported(t *testin
 	}
 }
 
-func TestRunWakeLoopMessageRecoveryAttentionFailureIsFatalWithoutRetry(t *testing.T) {
+func TestRunWakeLoopMessageRecoveryAttentionFailureRetriesWithoutExit(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	message := format.Message{
@@ -3692,6 +4037,8 @@ func TestRunWakeLoopMessageRecoveryAttentionFailureIsFatalWithoutRetry(t *testin
 
 	attentionSinkErr := errors.New("attention sink unavailable")
 	var attentionWrites atomic.Int64
+	now := time.Unix(1_800_000_000, 0)
+	retried := make(chan struct{}, 1)
 	stop := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
@@ -3711,13 +4058,19 @@ func TestRunWakeLoopMessageRecoveryAttentionFailureIsFatalWithoutRetry(t *testin
 				phase:  wakeDoorbellRetrying,
 				cohort: snapshotWakeFileIdentities(map[string]os.FileInfo{"message.md": info}),
 			},
+			doorbellNow: func() time.Time { return now },
 			terminalWrite: func(string) error {
 				return newWakeInjectorUnsupportedError(errors.New("injector disabled"))
 			},
 			attentionIsTTY: func() bool { return false },
 			attentionWrite: func(data []byte) (int, error) {
 				if attentionWrites.Add(1) == 1 {
+					now = now.Add(wakeDoorbellAttentionRetryBase)
 					return 0, attentionSinkErr
+				}
+				select {
+				case retried <- struct{}{}:
+				default:
 				}
 				return len(data), nil
 			},
@@ -3725,23 +4078,31 @@ func TestRunWakeLoopMessageRecoveryAttentionFailureIsFatalWithoutRetry(t *testin
 	}()
 
 	select {
+	case <-retried:
 	case err := <-done:
-		var attentionErr *wakeAttentionDeliveryError
-		if !errors.As(err, &attentionErr) ||
-			!errors.Is(err, attentionSinkErr) ||
-			!isWakeInputDemotionBlocked(err) {
-			t.Fatalf("wake loop error = %v, want blocked input plus attention failure", err)
+		t.Fatalf("wake loop exited on recovery attention failure: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("wake loop did not retry recovery attention: writes=%d", attentionWrites.Load())
+	}
+	if got := attentionWrites.Load(); got != 2 {
+		t.Fatalf("recovery attention writes = %d, want failed write plus retry", got)
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("wake loop exited after successful recovery attention retry: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if got := attentionWrites.Load(); got != 2 {
+		t.Fatalf("recovery attention hot-looped after retry: writes=%d", got)
+	}
+	close(stop)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
 		}
 	case <-time.After(2 * time.Second):
-		close(stop)
-		<-done
-		t.Fatalf(
-			"wake loop retried or masked recovery attention failure; writes=%d",
-			attentionWrites.Load(),
-		)
-	}
-	if got := attentionWrites.Load(); got != 1 {
-		t.Fatalf("recovery attention writes = %d, want exactly 1", got)
+		t.Fatal("wake loop did not stop")
 	}
 }
 
@@ -3825,10 +4186,14 @@ func TestRunWakeLoopKeepsWatchingWhenDrainedInboxReconciliationBecomesUncertain(
 	}
 }
 
-func TestRunWakeLoopDrainedInboxRecoveryAttentionFailureIsFatal(t *testing.T) {
+func TestRunWakeLoopDrainedInboxRecoveryAttentionFailureRetriesWithoutExit(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	attentionSinkErr := errors.New("attention sink unavailable")
+	now := time.Unix(1_800_000_000, 0)
+	var attentionWrites atomic.Int64
+	retried := make(chan struct{}, 1)
+	stop := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
 		done <- runWakeLoop(wakeConfig{
@@ -3837,7 +4202,8 @@ func TestRunWakeLoopDrainedInboxRecoveryAttentionFailureIsFatal(t *testing.T) {
 			session:     "session1",
 			wakeOwner:   &wakeOwner{},
 			injectMode:  wakeInjectModePaste,
-			controlStop: make(chan struct{}),
+			controlStop: stop,
+			doorbellNow: func() time.Time { return now },
 			inputDelivery: wakeInputDeliveryState{
 				phase:   wakeInputPrimarySubmitPending,
 				mode:    wakeInjectModePaste,
@@ -3850,23 +4216,38 @@ func TestRunWakeLoopDrainedInboxRecoveryAttentionFailureIsFatal(t *testing.T) {
 				}
 			},
 			attentionIsTTY: func() bool { return false },
-			attentionWrite: func([]byte) (int, error) {
-				return 0, attentionSinkErr
+			attentionWrite: func(data []byte) (int, error) {
+				if attentionWrites.Add(1) == 1 {
+					now = now.Add(wakeDoorbellAttentionRetryBase)
+					return 0, attentionSinkErr
+				}
+				select {
+				case retried <- struct{}{}:
+				default:
+				}
+				return len(data), nil
 			},
 		})
 	}()
 
 	select {
+	case <-retried:
 	case err := <-done:
-		var uncertainErr *wakeTerminalProgressUncertainError
-		var attentionErr *wakeAttentionDeliveryError
-		if !errors.As(err, &uncertainErr) ||
-			!errors.As(err, &attentionErr) ||
-			!errors.Is(err, attentionSinkErr) {
-			t.Fatalf("wake loop error = %v, want uncertain input plus attention failure", err)
+		t.Fatalf("wake loop exited on drained-inbox recovery attention failure: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("wake loop did not retry drained-inbox recovery attention: writes=%d", attentionWrites.Load())
+	}
+	if got := attentionWrites.Load(); got != 2 {
+		t.Fatalf("drained recovery attention writes = %d, want failed write plus retry", got)
+	}
+	close(stop)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("wake loop did not fail after recovery attention failure")
+		t.Fatal("wake loop did not stop")
 	}
 }
 
@@ -7448,6 +7829,117 @@ func TestOpenWakeOutputsBoundAccumulatedLogsAtLaunch(t *testing.T) {
 				t.Fatalf("unexpected rotated sibling: %v", err)
 			}
 		})
+	}
+}
+
+func TestMaintainWakeOutputBoundsTruncatesOnceAndPreservesAppend(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wake.log")
+	output, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = output.Close() }()
+	if _, err := output.Write(bytes.Repeat([]byte("x"), 2<<20)); err != nil {
+		t.Fatal(err)
+	}
+
+	originalTruncate := truncateWakeOutput
+	truncations := 0
+	truncateWakeOutput = func(fd int, size int64) error {
+		truncations++
+		return originalTruncate(fd, size)
+	}
+	t.Cleanup(func() { truncateWakeOutput = originalTruncate })
+
+	if err := maintainWakeOutputBounds(output, output); err != nil {
+		t.Fatalf("maintain output bounds: %v", err)
+	}
+	if truncations != 1 {
+		t.Fatalf("same wake output truncated %d times, want 1", truncations)
+	}
+	if _, err := output.WriteString("fresh\n"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "fresh\n" {
+		t.Fatalf("post-truncation append = %q, want fresh log", data)
+	}
+}
+
+func TestRunWakeLoopOutputBoundFailureDoesNotBlockMaintenance(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	output, err := os.OpenFile(
+		filepath.Join(t.TempDir(), "wake.log"),
+		os.O_CREATE|os.O_RDWR|os.O_APPEND,
+		0o600,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = output.Close() }()
+	if _, err := output.Write(bytes.Repeat([]byte("x"), 2<<20)); err != nil {
+		t.Fatal(err)
+	}
+
+	truncateErr := errors.New("truncate denied")
+	originalTruncate := truncateWakeOutput
+	truncateWakeOutput = func(int, int64) error { return truncateErr }
+	t.Cleanup(func() { truncateWakeOutput = originalTruncate })
+
+	ticks := make(chan time.Time)
+	touched := make(chan struct{}, 2)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:               root,
+			me:                 "codex",
+			injectMode:         wakeInjectModeNone,
+			controlStop:        stop,
+			maintenanceTicks:   ticks,
+			maintenanceOutputs: []*os.File{output},
+			touchPresence: func() error {
+				touched <- struct{}{}
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+		})
+	}()
+
+	select {
+	case <-touched:
+	case err := <-done:
+		t.Fatalf("wake loop exited before initial presence: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not touch initial presence")
+	}
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before maintenance tick: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance tick")
+	}
+	select {
+	case <-touched:
+	case err := <-done:
+		t.Fatalf("wake loop exited on output truncation failure: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("output truncation failure blocked maintenance")
+	}
+
+	close(stop)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop after output truncation failure: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop after output truncation failure")
 	}
 }
 

--- a/scripts/check_wake_test_changes.py
+++ b/scripts/check_wake_test_changes.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Require PR-body justification before removing or renaming wake tests."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Mapping
+
+
+BEGIN_MARKER = "BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION"
+END_MARKER = "END_WAKE_TEST_CHANGE_JUSTIFICATION"
+TEST_FUNCTION = re.compile(
+    r"(?m)^func\s+(?:\([^\n)]*\)\s+)?(Test[A-Za-z0-9_]+)\s*\("
+)
+COMMIT_SHA = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?")
+
+
+def marker_matches(body: str, marker: str) -> list[re.Match[str]]:
+    marker_line = rf"(?:{marker}|<!--[ \t]*{marker}[ \t]*-->)"
+    return list(re.finditer(rf"(?m)^[ \t]*{marker_line}[ \t]*$", body))
+
+
+def wake_test_names(files: Mapping[str, str]) -> set[str]:
+    return {
+        match.group(1)
+        for path, source in files.items()
+        if re.fullmatch(r"internal/cli/wake[^/]*_test\.go", path)
+        for match in TEST_FUNCTION.finditer(source)
+    }
+
+
+def parse_justifications(body: str) -> tuple[dict[str, str], list[str]]:
+    begin_count = body.count(BEGIN_MARKER)
+    end_count = body.count(END_MARKER)
+    if begin_count == 0 and end_count == 0:
+        return {}, []
+    if begin_count != 1 or end_count != 1:
+        return {}, [
+            "wake test justification markers must appear exactly once as a pair"
+        ]
+
+    begins = marker_matches(body, BEGIN_MARKER)
+    ends = marker_matches(body, END_MARKER)
+    if len(begins) != 1 or len(ends) != 1:
+        return {}, [
+            "wake test justification markers must occupy their own plain or "
+            "HTML-comment lines"
+        ]
+    begin, end = begins[0], ends[0]
+    if begin.start() >= end.start():
+        return {}, ["wake test justification end marker must follow its begin marker"]
+
+    entries: dict[str, str] = {}
+    errors: list[str] = []
+    for line in body[begin.end() : end.start()].strip().splitlines():
+        if not line.strip():
+            continue
+        name, separator, reason = line.partition(":")
+        name, reason = name.strip(), reason.strip()
+        if not separator or not re.fullmatch(r"Test[A-Za-z0-9_]+", name):
+            errors.append(
+                "wake test justification entries must be 'TestName: reason' lines"
+            )
+            continue
+        if not reason:
+            errors.append(f"wake test justification for {name} must include a reason")
+            continue
+        if name in entries:
+            errors.append(f"wake test justification for {name} is duplicated")
+            continue
+        entries[name] = reason
+    if not entries and not errors:
+        errors.append("wake test justification block must contain at least one entry")
+    return entries, errors
+
+
+def validate_change(
+    before: Mapping[str, str], after: Mapping[str, str], body: str
+) -> list[str]:
+    removed = sorted(wake_test_names(before) - wake_test_names(after))
+    if not removed:
+        return []
+
+    justifications, errors = parse_justifications(body)
+    if not justifications and not errors:
+        return [
+            "removed or renamed wake tests require a WAKE_TEST_CHANGE_JUSTIFICATION "
+            f"block: {', '.join(removed)}"
+        ]
+    errors.extend(
+        f"wake test justification is missing for removed or renamed test {name}"
+        for name in removed
+        if name not in justifications
+    )
+    errors.extend(
+        f"wake test justification names unchanged test {name}"
+        for name in sorted(justifications)
+        if name not in removed
+    )
+    return errors
+
+
+def git_output(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, text=True, capture_output=True
+    ).stdout
+
+
+def files_at(revision: str) -> dict[str, str]:
+    paths = git_output("ls-tree", "-r", "--name-only", revision).splitlines()
+    return {
+        path: git_output("show", f"{revision}:{path}")
+        for path in paths
+        if re.fullmatch(r"internal/cli/wake[^/]*_test\.go", path)
+    }
+
+
+def main() -> int:
+    base = os.environ.get("PR_BASE_SHA", "")
+    head = os.environ.get("PR_HEAD_SHA", "HEAD")
+    if not COMMIT_SHA.fullmatch(base):
+        print("error: PR_BASE_SHA must be a commit SHA", file=sys.stderr)
+        return 1
+    if head != "HEAD" and not COMMIT_SHA.fullmatch(head):
+        print("error: PR_HEAD_SHA must be a commit SHA", file=sys.stderr)
+        return 1
+    try:
+        git_output("rev-parse", "--verify", f"{base}^{{commit}}")
+        git_output("rev-parse", "--verify", f"{head}^{{commit}}")
+        errors = validate_change(files_at(base), files_at(head), os.environ.get("PR_BODY", ""))
+    except subprocess.CalledProcessError as error:
+        print(error.stderr.strip() or "error: unable to inspect wake test changes", file=sys.stderr)
+        return 1
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+    print("wake test removals and renames are justified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -130,6 +130,7 @@ if command -v python3 >/dev/null 2>&1; then
   echo "python session-name tests ok"
   python3 scripts/test_check_pr_title.py
   python3 scripts/test_check_commit_overrides.py
+  python3 scripts/test_check_wake_test_changes.py
   python3 scripts/test_release_changelog_section.py
   python3 scripts/test_release_please_config.py
   bash scripts/test_release_metadata.sh

--- a/scripts/test_check_wake_test_changes.py
+++ b/scripts/test_check_wake_test_changes.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Tests for the wake-test deletion PR-body gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+
+SCRIPT = pathlib.Path(__file__).with_name("check_wake_test_changes.py")
+spec = importlib.util.spec_from_file_location("check_wake_test_changes", SCRIPT)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"cannot load {SCRIPT}")
+check_wake_test_changes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_wake_test_changes)
+
+
+def test_no_removed_wake_tests_needs_no_justification() -> None:
+    errors = check_wake_test_changes.validate_change(
+        {"internal/cli/wake_test.go": "func TestWakeStillHere(t *testing.T) {}\n"},
+        {"internal/cli/wake_test.go": "func TestWakeStillHere(t *testing.T) {}\n"},
+        "",
+    )
+    assert errors == [], errors
+
+
+def test_ci_revisions_must_be_commit_shas() -> None:
+    assert check_wake_test_changes.COMMIT_SHA.fullmatch("a" * 40)
+    assert check_wake_test_changes.COMMIT_SHA.fullmatch("a" * 64)
+    assert not check_wake_test_changes.COMMIT_SHA.fullmatch("main")
+
+
+def test_removed_wake_test_requires_named_justification() -> None:
+    before = {"internal/cli/wake_test.go": "func TestWakeRetired(t *testing.T) {}\n"}
+    after = {"internal/cli/wake_test.go": ""}
+
+    errors = check_wake_test_changes.validate_change(before, after, "")
+
+    assert errors == [
+        "removed or renamed wake tests require a WAKE_TEST_CHANGE_JUSTIFICATION block: TestWakeRetired"
+    ], errors
+
+
+def test_rename_requires_the_old_test_name_to_be_justified() -> None:
+    before = {"internal/cli/wake_test.go": "func TestWakeOldName(t *testing.T) {}\n"}
+    after = {"internal/cli/wake_test.go": "func TestWakeNewName(t *testing.T) {}\n"}
+    body = """BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
+TestWakeOldName: renamed to describe the retained behavior
+END_WAKE_TEST_CHANGE_JUSTIFICATION
+"""
+
+    assert check_wake_test_changes.validate_change(before, after, body) == []
+
+
+def test_justification_must_cover_every_removed_test_and_have_a_reason() -> None:
+    before = {
+        "internal/cli/wake_test.go": (
+            "func TestWakeFirst(t *testing.T) {}\n"
+            "func (suite *wakeSuite) TestWakeSecond() {}\n"
+        )
+    }
+    after = {"internal/cli/wake_test.go": ""}
+    body = """<!-- BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION -->
+TestWakeFirst:
+<!-- END_WAKE_TEST_CHANGE_JUSTIFICATION -->
+"""
+
+    errors = check_wake_test_changes.validate_change(before, after, body)
+
+    assert any("TestWakeFirst" in error and "reason" in error for error in errors), errors
+    assert any("TestWakeSecond" in error for error in errors), errors
+
+
+def test_ci_runs_the_wake_test_change_gate_on_pull_requests() -> None:
+    ci = (SCRIPT.parent.parent / ".github" / "workflows" / "ci.yml").read_text()
+
+    assert "Check wake test changes" in ci
+    assert "python3 scripts/check_wake_test_changes.py" in ci
+    assert "PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}" in ci
+    assert "PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in ci
+    assert "PR_BODY: ${{ github.event.pull_request.body }}" in ci
+
+    smoke = (SCRIPT.parent / "smoke-test.sh").read_text()
+    assert "python3 scripts/test_check_wake_test_changes.py" in smoke
+
+
+if __name__ == "__main__":
+    test_no_removed_wake_tests_needs_no_justification()
+    test_ci_revisions_must_be_commit_shas()
+    test_removed_wake_test_requires_named_justification()
+    test_rename_requires_the_old_test_name_to_be_justified()
+    test_justification_must_cover_every_removed_test_and_have_a_reason()
+    test_ci_runs_the_wake_test_change_gate_on_pull_requests()
+    print("wake test change checks ok")


### PR DESCRIPTION
## What changed

- Keeps unread wake obligations retrying forever at bounded input and attention cadences; terminal writes remain attempts, while durable inbox progress remains delivery authority.
- Treats foreground process-group loss and short or failed attention writes as retryable, commits recovery state before output effects, and coalesces arrival bursts without delaying new information behind a decayed retry deadline.
- Refuses confirmed live generic and owner-bound wake conflicts immediately with actionable owner facts, while preserving the incumbent lock and target.
- Reports foreign live wake ownership in doctor output, bounds live wake logs, bounds repair handoff reads, caps sender clauses, and makes the Darwin inherited stop descriptor interruptible.
- Adds a CI guard requiring explicit PR justification when wake tests are removed or renamed.

## Verification

- `make ci`
- `go test -race ./... -count=1`
- `go build ./...` for linux, darwin, freebsd, and windows on amd64
- Focused cadence and debounce tests repeated ten times; focused race tests repeated three times
- Amit live-conflict reproduction refused in 0.04 seconds and left the live lock byte-for-byte and inode-for-inode unchanged
- Isolated PTY wake became ready in 0.14 seconds and a controlled owner exit removed both the wake process and lock

## Known follow-up

Confirmed live conflicts now fail immediately. Other non-conflict child startup failures still use the existing 25-second readiness timeout; broader startup self-healing and the fatality-classification work are deliberately deferred from this release.

The Darwin inherited private-stop change passed the full race suite and Darwin cross-build, but did not receive a dedicated adversarial trace before landing.

## Release note entries

BEGIN_COMMIT_OVERRIDE
fix(wake): keep transient delivery failures retryable

fix(coop): refuse live wake conflicts immediately

fix(doctor): report foreign live wake ownership

fix(ci): require justification for removed wake tests
END_COMMIT_OVERRIDE

## Wake test changes

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestNotifyNewMessagesDoesNotFloodAttentionForUrgentAddition: renamed to describe coalescing while preserving the no-attention assertion
TestNotifyNewMessagesWaitsSilentlyUntilRetryOrProgress: renamed because additions now use the delivery floor instead of a decayed deadline
TestRecordWakeAttemptForcesRetryPhase: renamed after phase ownership moved to the planner; coverage now asserts cohort arming
TestRunWakeLoopDrainedInboxRecoveryAttentionFailureIsFatal: renamed because the recovery attention failure now retries without exit
TestRunWakeLoopMessageRecoveryAttentionFailureIsFatalWithoutRetry: renamed because the recovery attention failure now retries without exit
TestRunWakeLoopUsesAttentionCadenceAfterZeroProgressForegroundPGRPMismatch: renamed because foreground authority refusal is not an attempt and retains input cadence
END_WAKE_TEST_CHANGE_JUSTIFICATION
