### PR TITLE
fix(wake): preserve authoritative recovery

### DIFF
--- a/internal/cli/coop_wake_reclaim_unix.go
+++ b/internal/cli/coop_wake_reclaim_unix.go
@@ -24,6 +24,7 @@ func prepareCoopWakeLock(root, agent string, yes bool, remedy string) error {
 		return fmt.Errorf("wake lock for %s names a running process proven not to be this wake; refusing to signal or remove it; lock: %s; root: %s; reason: %s", agent, inspection.LockPath, inspection.Root, inspection.Reason)
 	}
 	if inspection.Status == wakeLockStale {
+		// This returns before stale owner-bound recovery advice is rendered below.
 		if err := removeWakeLockIfUnchanged(inspection); err != nil {
 			return fmt.Errorf("remove exact stale wake lock: %w", err)
 		}
@@ -72,6 +73,26 @@ func prepareCoopWakeLock(root, agent string, yes bool, remedy string) error {
 	if confirmedLiveWake(inspection) {
 		switch classifyPersistedWakeClaim(inspection) {
 		case wakeClaimAuthoritative:
+			if inspection.Lock.Owner == nil {
+				return coopWakeStartupConflictError(
+					inspection,
+					errors.New("authoritative wake owner is missing"),
+				)
+			}
+			ownerObservation, err := observeAuthoritativeWakeOwner(*inspection.Lock.Owner)
+			if err != nil {
+				return coopWakeStartupConflictError(
+					inspection,
+					errors.Join(err, ownerObservation.Close()),
+				)
+			}
+			ownerState := ownerObservation.State
+			if err := ownerObservation.Close(); err != nil {
+				return coopWakeStartupConflictError(inspection, err)
+			}
+			if ownerState == wakeOwnerDead {
+				break
+			}
 			// Owner-bound claims belong to a specific coop session. A new
 			// session cannot reuse or replace one while its wake is live.
 			return coopWakeStartupConflictError(inspection, nil)
@@ -290,6 +311,9 @@ func coopWakeStartupConflictError(inspection wakeLockInspection, cause error) er
 		)
 	}
 	if message == "" {
+		if cause == nil {
+			return errors.New("wake startup conflict could not be classified")
+		}
 		return cause
 	}
 	if cause == nil {

--- a/internal/cli/coop_wake_reclaim_unix_test.go
+++ b/internal/cli/coop_wake_reclaim_unix_test.go
@@ -68,6 +68,12 @@ func TestCoopWakeStartupConflictPreservesUnverifiedState(t *testing.T) {
 	}
 }
 
+func TestCoopWakeStartupConflictNeverReturnsNil(t *testing.T) {
+	if err := coopWakeStartupConflictError(wakeLockInspection{}, nil); err == nil {
+		t.Fatal("unclassified startup conflict returned nil")
+	}
+}
+
 func TestPrepareCoopWakeLockRemovesProvenStaleWithoutPrompt(t *testing.T) {
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{PID: 66121, Generation: "stale"})
@@ -229,10 +235,36 @@ func TestPrepareCoopWakeLockLiveAuthoritativeRefusesWithoutMutation(t *testing.T
 		t.Fatal("authoritative wake must not be signaled through coop startup")
 		return nil
 	})
+	ownerState := wakeOwnerSame
+	var observeErr error
+	observationClosed := false
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if !sameWakeOwner(&got, &owner) {
+			t.Fatalf("observed owner = %#v, want %#v", got, owner)
+		}
+		if observeErr != nil {
+			monitor := newWakeOwnerObservationMonitor(func() error {
+				observationClosed = true
+				return nil
+			})
+			monitor.finish(nil)
+			return wakeOwnerObservation{State: wakeOwnerUnknown, monitor: monitor}, observeErr
+		}
+		return wakeOwnerObservation{State: ownerState}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
 
 	err = prepareCoopWakeLock(root, "codex", true, "unused")
 	if err == nil || !strings.Contains(err.Error(), "owned by a live process") {
 		t.Fatalf("prepare live authoritative wake = %v, want live-owner refusal", err)
+	}
+	if strings.Contains(err.Error(), "doctor") ||
+		strings.Contains(err.Error(), "wake retire") ||
+		!strings.Contains(err.Error(), "pid:") ||
+		!strings.Contains(err.Error(), "tty:") ||
+		!strings.Contains(err.Error(), "started:") {
+		t.Fatalf("live-owner refusal has unsafe or incomplete remedy: %v", err)
 	}
 	afterLock, err := os.ReadFile(lockPath)
 	if err != nil {
@@ -251,6 +283,31 @@ func TestPrepareCoopWakeLockLiveAuthoritativeRefusesWithoutMutation(t *testing.T
 	}
 	if got := info.Mode().Perm(); got != wakeOwnerLockFileMode {
 		t.Fatalf("authoritative lock mode = %o, want %o", got, wakeOwnerLockFileMode)
+	}
+
+	ownerState = wakeOwnerDead
+	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
+		t.Fatalf("dead-owner authoritative wake blocked automatic takeover: %v", err)
+	}
+	afterDeadOwnerLock, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("dead-owner preflight changed authoritative lock: %v", err)
+	}
+	afterDeadOwnerTarget, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("dead-owner preflight changed authoritative target: %v", err)
+	}
+	if string(afterDeadOwnerLock) != string(beforeLock) ||
+		string(afterDeadOwnerTarget) != string(beforeTarget) {
+		t.Fatal("dead-owner preflight mutated authoritative claim before acquisition")
+	}
+
+	observeErr = errors.New("owner observer failed")
+	if err := prepareCoopWakeLock(root, "codex", true, "unused"); err == nil {
+		t.Fatal("owner observation failure did not block startup")
+	}
+	if !observationClosed {
+		t.Fatal("owner observation failure leaked its returned capability")
 	}
 }
 

--- a/scripts/check_wake_test_changes.py
+++ b/scripts/check_wake_test_changes.py
@@ -16,6 +16,7 @@ TEST_FUNCTION = re.compile(
     r"(?m)^func\s+(?:\([^\n)]*\)\s+)?(Test[A-Za-z0-9_]+)\s*\("
 )
 COMMIT_SHA = re.compile(r"[0-9a-f]{40}(?:[0-9a-f]{24})?")
+WAKE_TEST_PATH = re.compile(r"internal/cli/[^/]*wake[^/]*_test\.go")
 
 
 def marker_matches(body: str, marker: str) -> list[re.Match[str]]:
@@ -27,7 +28,7 @@ def wake_test_names(files: Mapping[str, str]) -> set[str]:
     return {
         match.group(1)
         for path, source in files.items()
-        if re.fullmatch(r"internal/cli/wake[^/]*_test\.go", path)
+        if WAKE_TEST_PATH.fullmatch(path)
         for match in TEST_FUNCTION.finditer(source)
     }
 
@@ -114,7 +115,7 @@ def files_at(revision: str) -> dict[str, str]:
     return {
         path: git_output("show", f"{revision}:{path}")
         for path in paths
-        if re.fullmatch(r"internal/cli/wake[^/]*_test\.go", path)
+        if WAKE_TEST_PATH.fullmatch(path)
     }
 
 
@@ -130,7 +131,12 @@ def main() -> int:
     try:
         git_output("rev-parse", "--verify", f"{base}^{{commit}}")
         git_output("rev-parse", "--verify", f"{head}^{{commit}}")
-        errors = validate_change(files_at(base), files_at(head), os.environ.get("PR_BODY", ""))
+        comparison_base = git_output("merge-base", base, head).strip()
+        errors = validate_change(
+            files_at(comparison_base),
+            files_at(head),
+            os.environ.get("PR_BODY", ""),
+        )
     except subprocess.CalledProcessError as error:
         print(error.stderr.strip() or "error: unable to inspect wake test changes", file=sys.stderr)
         return 1

--- a/scripts/test_check_wake_test_changes.py
+++ b/scripts/test_check_wake_test_changes.py
@@ -4,7 +4,12 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
 
 
 SCRIPT = pathlib.Path(__file__).with_name("check_wake_test_changes.py")
@@ -13,6 +18,61 @@ if spec is None or spec.loader is None:
     raise RuntimeError(f"cannot load {SCRIPT}")
 check_wake_test_changes = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(check_wake_test_changes)
+
+
+def run_git(repo: pathlib.Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def write_wake_test(repo: pathlib.Path, name: str | None) -> None:
+    path = repo / "internal" / "cli" / "wake_test.go"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if name is None:
+        path.unlink(missing_ok=True)
+        return
+    path.write_text(
+        f"package cli\n\nfunc {name}(t *testing.T) {{}}\n",
+        encoding="utf-8",
+    )
+
+
+def commit_all(repo: pathlib.Path, message: str) -> str:
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-m", message)
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+def run_checker(
+    repo: pathlib.Path,
+    base: str,
+    head: str,
+    body: str = "",
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(PR_BASE_SHA=base, PR_HEAD_SHA=head, PR_BODY=body)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def initialized_repo() -> pathlib.Path:
+    repo = pathlib.Path(tempfile.mkdtemp(prefix="wake-test-change-gate-"))
+    run_git(repo, "init", "-b", "main")
+    run_git(repo, "config", "user.name", "AMQ Test")
+    run_git(repo, "config", "user.email", "amq-test@example.invalid")
+    write_wake_test(repo, "TestWakeOriginal")
+    commit_all(repo, "base")
+    return repo
 
 
 def test_no_removed_wake_tests_needs_no_justification() -> None:
@@ -71,6 +131,70 @@ TestWakeFirst:
     assert any("TestWakeSecond" in error for error in errors), errors
 
 
+def test_wake_paths_include_coop_and_doctor_tests() -> None:
+    before = {
+        "internal/cli/coop_wake_reclaim_unix_test.go": (
+            "func TestCoopWakeConflict(t *testing.T) {}\n"
+        ),
+        "internal/cli/doctor_stale_wake_binary_test.go": (
+            "func TestDoctorWakeBinary(t *testing.T) {}\n"
+        ),
+    }
+    after = {path: "" for path in before}
+
+    errors = check_wake_test_changes.validate_change(before, after, "")
+
+    assert errors == [
+        "removed or renamed wake tests require a WAKE_TEST_CHANGE_JUSTIFICATION "
+        "block: TestCoopWakeConflict, TestDoctorWakeBinary"
+    ], errors
+
+
+def test_checker_compares_topic_to_merge_base() -> None:
+    repo = initialized_repo()
+    try:
+        topic = run_git(repo, "rev-parse", "HEAD")
+        write_wake_test(repo, "TestWakeBaseOnly")
+        base_tip = commit_all(repo, "rename on base")
+
+        result = run_checker(repo, base_tip, topic)
+
+        assert result.returncode == 0, result.stderr
+    finally:
+        shutil.rmtree(repo)
+
+
+def test_checker_detects_topic_deletion_also_made_on_base() -> None:
+    repo = initialized_repo()
+    try:
+        fork = run_git(repo, "rev-parse", "HEAD")
+        run_git(repo, "switch", "-c", "topic")
+        write_wake_test(repo, None)
+        topic = commit_all(repo, "delete on topic")
+        run_git(repo, "switch", "main")
+        run_git(repo, "reset", "--hard", fork)
+        write_wake_test(repo, None)
+        base_tip = commit_all(repo, "delete on base")
+
+        result = run_checker(repo, base_tip, topic)
+
+        assert result.returncode != 0, result.stdout
+        assert "TestWakeOriginal" in result.stderr, result.stderr
+
+        justified = run_checker(
+            repo,
+            base_tip,
+            topic,
+            """BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
+TestWakeOriginal: removed from the topic branch
+END_WAKE_TEST_CHANGE_JUSTIFICATION
+""",
+        )
+        assert justified.returncode == 0, justified.stderr
+    finally:
+        shutil.rmtree(repo)
+
+
 def test_ci_runs_the_wake_test_change_gate_on_pull_requests() -> None:
     ci = (SCRIPT.parent.parent / ".github" / "workflows" / "ci.yml").read_text()
 
@@ -90,5 +214,8 @@ if __name__ == "__main__":
     test_removed_wake_test_requires_named_justification()
     test_rename_requires_the_old_test_name_to_be_justified()
     test_justification_must_cover_every_removed_test_and_have_a_reason()
+    test_wake_paths_include_coop_and_doctor_tests()
+    test_checker_compares_topic_to_merge_base()
+    test_checker_detects_topic_deletion_also_made_on_base()
     test_ci_runs_the_wake_test_change_gate_on_pull_requests()
     print("wake test change checks ok")


### PR DESCRIPTION
## What changed

- Observes an authoritative coop owner before fast-refusing a confirmed-live wake. Proven-dead and recycled-PID owners now continue into the existing exact stop-and-release takeover path; live, unknown, and observation-error states remain fail-closed.
- Closes any owner-observation capability returned alongside an error and joins close failures into the reported conflict.
- Makes the startup-conflict helper fail closed even for an unclassifiable internal call.
- Compares wake-test changes from the pull request merge base rather than the current base-branch tip, avoiding false positives on non-rebased branches and false negatives when both tips removed a test.
- Extends the wake-test guard to all `internal/cli/*wake*_test.go` files, including coop and doctor coverage.

## Verification

- `make ci`
- `go test -race ./... -count=1`
- `go build ./...` for linux, darwin, freebsd, and windows on amd64
- Focused coop wake reclaim tests repeated twenty times, including the returned-capability close regression
- Real divergent Git histories proving base-only changes do not affect a topic, while topic deletions remain detected even if the base tip made the same deletion
- Independent real-kernel-observer execution on Darwin for live, dead, and recycled-PID owner paths

## Required follow-up

The first post-v0.49.12 code change must permanently adopt the real-observer regression used during certification. The committed unit test intentionally isolates preflight policy with an observer stub; the certification additionally ran a real reaped child, a real live owner monitor, and a process-start mismatch, but that kernel-level coverage must become durable repository coverage before other post-release wake work.

## Deferred ownership question

Proven-stale authoritative locks currently take the older automatic-removal path before the later recovery advice can render. This release documents that control flow without changing it. Before changing the policy, trace what `recover-owner` protects for a proven-dead owner and decide whether automatic takeover or explicit recovery is the correct invariant.
