### PR TITLE
fix(wake): keep admitted delivery self-healing

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -47,6 +47,7 @@ type wakeConfig struct {
 	controlStop                   <-chan struct{}
 	beforeTerminalWrite           func() error
 	terminalWrite                 func(string) error
+	inspectTerminalGeneration     func() wakeLockInspection
 	terminalGeneration            string
 	terminalTTY                   string
 	baselineRequested             bool

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -30,6 +30,8 @@ type wakeConfig struct {
 	strict                        bool
 	fallbackWarn                  bool
 	injectMode                    string // auto, raw, paste
+	requestedInjectMode           string
+	legacyTIOCSTIDemoted          bool
 	debug                         bool
 	deferWhileInput               bool
 	inputQuietFor                 time.Duration
@@ -66,11 +68,18 @@ type wakeConfig struct {
 	preconditionCheck             func(*wakeConfig) error
 	onPendingNotify               func()
 	recordNotifierStatus          func(status, mode, reason string) error
+	pendingNotifierStatus         *wakeNotifierStatus
 	recordAttention               func(wakeAttentionEmission) error
 	attentionEnv                  func(string) string
 	attentionIsTTY                func() bool
 	attentionWrite                func([]byte) (int, error)
 	diagnosticIsTTY               func() bool
+}
+
+type wakeNotifierStatus struct {
+	status string
+	mode   string
+	reason string
 }
 
 const maxWakeNotificationSenderClauses = 8
@@ -466,6 +475,11 @@ func notifyNewMessages(cfg *wakeConfig) error {
 		}
 	}
 
+	if cfg.inputRecoveryRequired &&
+		dischargeWakeInputRecoveryAfterProgress(cfg, currentPending) &&
+		len(messages) == 0 {
+		return nil
+	}
 	if len(messages) == 0 {
 		if cfg.inputRecoveryRequired {
 			return deliverWakeInputRecoveryAttention(
@@ -550,7 +564,12 @@ func deliverNewMessageNotification(
 	currentPending map[string]os.FileInfo,
 ) error {
 	if cfg.inputRecoveryRequired {
-		return deliverWakeInputRecoveryAttention(cfg, currentPending)
+		if !dischargeWakeInputRecoveryAfterProgress(cfg, currentPending) {
+			return deliverWakeInputRecoveryAttention(cfg, currentPending)
+		}
+		if len(currentPending) == 0 {
+			return nil
+		}
 	}
 	if cfg.injectMode == wakeInjectModeNone {
 		if cfg.inputDelivery.blocksDemotion() {
@@ -688,21 +707,69 @@ func enterWakeInputRecovery(
 
 func markWakeInputRecoveryRequired(cfg *wakeConfig, cause error) {
 	cfg.inputRecoveryRequired = true
-	if cfg.recordNotifierStatus == nil {
-		return
-	}
 	mode := effectiveInjectMode(cfg)
 	reason := wakeInputRecoveryNotice
 	if cause != nil {
 		reason += ": " + cause.Error()
 	}
-	if err := cfg.recordNotifierStatus(
+	if err := persistWakeNotifierStatus(
+		cfg,
 		wakeInputRecoveryRequiredStatus,
 		mode,
 		reason,
 	); err != nil {
 		_ = writeWakeDiagnostic(cfg, "amq wake: record input recovery-required status: %v\n", err)
 	}
+}
+
+func dischargeWakeInputRecoveryAfterProgress(
+	cfg *wakeConfig,
+	currentPending map[string]os.FileInfo,
+) bool {
+	if cfg == nil || !cfg.inputRecoveryRequired {
+		return false
+	}
+	progressed := len(currentPending) == 0
+	if !progressed && cfg.doorbell.phase == wakeDoorbellRecoveryRequired {
+		progressed = wakeCohortProgressed(cfg.doorbell.cohort, currentPending)
+	}
+	if !progressed {
+		return false
+	}
+
+	// Durable consumer progress proves that the composer state changed after
+	// the uncertain write. Never resume the old suffix: discard that debt and
+	// let any remaining cohort start with one fresh, complete doorbell. This
+	// accepts bounded composer noise over a permanently undriven session, while
+	// preserving the no-stacking rule for the old partial payload.
+	cfg.inputRecoveryRequired = false
+	clearWakeInputState(cfg)
+	cfg.doorbell.reset()
+	if err := persistWakeNotifierStatus(cfg, "", effectiveInjectMode(cfg), ""); err != nil {
+		_ = writeWakeDiagnostic(cfg, "amq wake: clear input recovery-required status: %v\n", err)
+	}
+	return true
+}
+
+func persistWakeNotifierStatus(cfg *wakeConfig, status, mode, reason string) error {
+	if cfg == nil || cfg.recordNotifierStatus == nil {
+		return nil
+	}
+	desired := &wakeNotifierStatus{status: status, mode: mode, reason: reason}
+	if err := cfg.recordNotifierStatus(status, mode, reason); err != nil {
+		cfg.pendingNotifierStatus = desired
+		return err
+	}
+	cfg.pendingNotifierStatus = nil
+	return nil
+}
+
+func retryPendingWakeNotifierStatus(cfg *wakeConfig) error {
+	if cfg == nil || cfg.pendingNotifierStatus == nil {
+		return nil
+	}
+	pending := cfg.pendingNotifierStatus
+	return persistWakeNotifierStatus(cfg, pending.status, pending.mode, pending.reason)
 }
 
 func (cfg *wakeConfig) wakeDoorbellNow() time.Time {
@@ -1053,14 +1120,13 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		if errors.As(injectErr, &unsupported) {
 			mode := effectiveInjectMode(cfg)
 			reason := wakeInjectorUnsupportedReason(mode, injectErr)
-			if cfg.recordNotifierStatus != nil {
-				if err := cfg.recordNotifierStatus(
-					wakeInjectorUnsupportedStatus,
-					mode,
-					reason,
-				); err != nil {
-					_ = writeWakeDiagnostic(cfg, "amq wake: record unsupported injector status: %v\n", err)
-				}
+			if err := persistWakeNotifierStatus(
+				cfg,
+				wakeInjectorUnsupportedStatus,
+				mode,
+				reason,
+			); err != nil {
+				_ = writeWakeDiagnostic(cfg, "amq wake: record unsupported injector status: %v\n", err)
 			}
 			if err := disableWakeInput(cfg, injectErr); err != nil {
 				return err
@@ -1331,11 +1397,32 @@ func retireWakeInputState(cfg *wakeConfig, cause error) error {
 }
 
 func disableWakeInput(cfg *wakeConfig, cause error) error {
+	rememberRequestedWakeInputMode(cfg)
 	if err := retireWakeInputState(cfg, cause); err != nil {
 		return err
 	}
 	cfg.injectMode = wakeInjectModeNone
+	cfg.legacyTIOCSTIDemoted = false
 	return nil
+}
+
+func disableWakeInputForLegacyTIOCSTI(cfg *wakeConfig, cause error) error {
+	rememberRequestedWakeInputMode(cfg)
+	if err := retireWakeInputState(cfg, cause); err != nil {
+		return err
+	}
+	cfg.injectMode = wakeInjectModeNone
+	cfg.legacyTIOCSTIDemoted = true
+	return nil
+}
+
+func rememberRequestedWakeInputMode(cfg *wakeConfig) {
+	if cfg.requestedInjectMode != "" ||
+		cfg.injectMode == "" ||
+		cfg.injectMode == wakeInjectModeNone {
+		return
+	}
+	cfg.requestedInjectMode = cfg.injectMode
 }
 
 func reconcileWakeInputAfterInboxDrain(cfg *wakeConfig) error {

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -182,12 +182,14 @@ func (state *wakeDoorbellState) recordRecoveryAttentionDelivered() {
 }
 
 func (state *wakeDoorbellState) noteRecoveryInboxEmpty() {
-	if state.phase != wakeDoorbellRecoveryRequired {
-		state.reset()
-		state.phase = wakeDoorbellRecoveryRequired
+	state.reset()
+}
+
+func (state *wakeDoorbellState) makeDue(now time.Time) {
+	if state.phase != wakeDoorbellRetrying || len(state.cohort) == 0 {
+		return
 	}
-	state.recoveryPending = false
-	state.recoveryAttentionUndelivered = false
+	state.nextAttempt = now
 }
 
 func (state wakeDoorbellState) pendingInput() bool {

--- a/internal/cli/wake_doorbell_test.go
+++ b/internal/cli/wake_doorbell_test.go
@@ -219,14 +219,18 @@ func TestWakeDoorbellRecoveryAttentionIsCohortBoundedAndRateLimited(t *testing.T
 	if _, ok := state.nextDeadline(); ok {
 		t.Fatal("empty recovery inbox retained a pending alert deadline")
 	}
-	if state.planRecoveryAttention(now.Add(2*time.Millisecond), second) {
-		t.Fatal("drain-and-arrive recovery flap bypassed output rate bound")
+	if state.phase != wakeDoorbellIdle {
+		t.Fatalf("empty recovery inbox phase = %v, want idle", state.phase)
 	}
-	if !state.planRecoveryAttention(now.Add(wakeDoorbellAttentionRetryBase), second) {
-		t.Fatal("changed recovery cohort was not emitted after rate bound")
+	if !state.planRecoveryAttention(now.Add(2*time.Millisecond), second) {
+		t.Fatal("new recovery cohort inherited the drained cohort's rate bound")
 	}
-	state.recordRecoveryRequired(now.Add(wakeDoorbellAttentionRetryBase), second)
-	if state.planRecoveryAttention(now.Add(2*wakeDoorbellAttentionRetryBase), second) {
+	recordedAt := now.Add(2 * time.Millisecond)
+	state.recordRecoveryRequired(recordedAt, second)
+	if state.planRecoveryAttention(
+		recordedAt.Add(wakeDoorbellAttentionRetryBase-time.Millisecond),
+		second,
+	) {
 		t.Fatal("recorded recovery cohort repeated")
 	}
 }

--- a/internal/cli/wake_driver_exclusivity_unix_test.go
+++ b/internal/cli/wake_driver_exclusivity_unix_test.go
@@ -1,0 +1,185 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// An unreadable lock parks the incumbent without surrendering its admitted
+// backlog. The first conclusive read either resumes the same generation or,
+// as exercised here, proves replacement and terminates the stale driver.
+func TestUnreadableWakeLockParksIncumbentUntilConclusiveReplacement(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	stop := make(chan struct{})
+	authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+
+	var injections atomic.Int64
+	injectWakeTerminalFD = func(uintptr, string) error {
+		injections.Add(1)
+		return nil
+	}
+
+	unreadable := wakeLockInspection{
+		Exists:   true,
+		Status:   wakeLockUnverified,
+		Reason:   "cannot read lock: too many open files",
+		Root:     fixture.generation.Root,
+		Agent:    fixture.generation.Agent,
+		LockPath: fixture.generation.LockPath,
+	}
+	fixture.current = unreadable
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "during-outage", "claude")
+
+	attention := make(chan string, 4)
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:                root,
+			me:                  "codex",
+			session:             "session1",
+			wakeOwner:           &wakeOwner{},
+			debounce:            5 * time.Millisecond,
+			injectMode:          wakeInjectModeRaw,
+			controlStop:         stop,
+			beforeTerminalWrite: authority.BeforeWrite,
+			terminalWrite:       authority.Inject,
+			attentionIsTTY:      func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				select {
+				case attention <- string(data):
+				default:
+				}
+				return len(data), nil
+			},
+		})
+	}()
+	var exited atomic.Bool
+	t.Cleanup(func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		if exited.Load() {
+			return
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	select {
+	case <-attention:
+	case err := <-done:
+		t.Fatalf("unreadable lock killed the wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("parked wake emitted no attention during lock outage")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("unreadable lock killed the wake loop: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	if got := injections.Load(); got != 0 {
+		t.Fatalf("incumbent injected %d chunks while its lock was unreadable", got)
+	}
+
+	if err := os.Remove(filepath.Join(
+		fsq.AgentInboxNew(root, "codex"), "during-outage.md",
+	)); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	lockPath := fixture.generation.LockPath
+	replacementRaw := []byte(`{"generation":"replacement-generation"}`)
+	if err := os.WriteFile(lockPath+".replacement", replacementRaw, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	replacementInfo, err := os.Stat(lockPath + ".replacement")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.current = wakeLockInspection{
+		Exists:   true,
+		Root:     fixture.generation.Root,
+		Agent:    fixture.generation.Agent,
+		LockPath: lockPath,
+		Lock:     wakeLock{Generation: "replacement-generation"},
+		raw:      replacementRaw,
+		fileInfo: replacementInfo,
+	}
+	deliverWakeWatcherMessageForTest(t, root, "codex", "after-recovery", "claude")
+
+	select {
+	case err := <-done:
+		exited.Store(true)
+		if !isWakeTerminalAuthorityLoss(err) ||
+			!strings.Contains(err.Error(), "wake generation changed") {
+			t.Fatalf("incumbent exit = %v, want positive generation-changed loss", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf(
+			"first successful read of replacement lock did not converge the incumbent (injections=%d)",
+			injections.Load(),
+		)
+	}
+	if got := injections.Load(); got != 0 {
+		t.Fatalf("incumbent injected %d chunks alongside the replacement", got)
+	}
+}
+
+// Paths without a bound terminal authority still fail closed at each write:
+// neither an unreadable lock nor a proven replacement can authorize input.
+func TestPlatformWriteGateRejectsUnreadableAndReplacedWakeLock(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	lockPath := filepath.Join(root, "agents", "codex", ".wake.lock")
+	if err := os.WriteFile(lockPath, []byte(`{"generation":"mine","tty":"unknown"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &wakeConfig{
+		root:               root,
+		me:                 "codex",
+		terminalGeneration: "mine",
+		terminalTTY:        "unknown",
+	}
+	if !authorizeTerminalWritePlatform(cfg) {
+		t.Fatal("gate refused the incumbent's own readable lock")
+	}
+
+	if err := os.Chmod(lockPath, 0); err != nil {
+		t.Fatal(err)
+	}
+	if authorizeTerminalWritePlatform(cfg) {
+		t.Fatal("gate authorized a write with an unreadable lock")
+	}
+	if err := os.Chmod(lockPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(lockPath, []byte(`{"generation":"replacement","tty":"unknown"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if authorizeTerminalWritePlatform(cfg) {
+		t.Fatal("gate authorized a write against a replacement's lock")
+	}
+}

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -547,6 +547,7 @@ func inspectWakeIdentity(inspection wakeLockInspection) wakeIdentityState {
 
 func classifyWakeIdentity(inspection wakeLockInspection, proc wakeProcessInfo) (wakeIdentityState, string) {
 	lock := inspection.Lock
+	strongProcessIdentityMatched := false
 	if lock.WakeMode == wakeOwnerWakeMode {
 		if err := validateAuthoritativeWakeProcessIdentity(lock); err != nil {
 			return wakeIdentityUnknown, err.Error()
@@ -578,11 +579,16 @@ func classifyWakeIdentity(inspection wakeLockInspection, proc wakeProcessInfo) (
 			}
 			return wakeIdentityGoneOrDifferent, "process start time mismatch"
 		}
+		strongProcessIdentityMatched =
+			lock.BootID != "" && bootComparison == bootIDMatch
 	}
-	if proc.Executable == "" || !processLooksLikeAMQ(proc) {
-		if proc.Executable == "" {
-			return wakeIdentityUnknown, inspectionReason("process identity unavailable", proc.InspectError)
-		}
+	if proc.Executable == "" {
+		return wakeIdentityUnknown, inspectionReason("process identity unavailable", proc.InspectError)
+	}
+	if strongProcessIdentityMatched && !isAMQExecutable(proc.Executable) {
+		return wakeIdentityUnknown, "matching process identity has a non-amq executable name"
+	}
+	if !processLooksLikeAMQ(proc) {
 		return wakeIdentityGoneOrDifferent, "pid is not amq"
 	}
 	if len(proc.Args) > 0 && !processArgsLookLikeWake(proc.Args) {

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -219,6 +219,44 @@ func TestInspectWakeLockAcceptsLegacyDarwinBootIDForProvenWake(t *testing.T) {
 	}
 }
 
+func TestInspectWakeLockDoesNotProveLiveRenamedBinaryStale(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/amq-dev",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "start-1",
+			BootID:     "boot-1",
+			Executable: "/opt/amq-dev",
+			Args: []string{
+				"amq",
+				"wake",
+				"--root",
+				root,
+				"--me",
+				"codex",
+			},
+		}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockUnverified {
+		t.Fatalf(
+			"matching live renamed binary status = %s (%s), want unverified",
+			inspection.Status,
+			inspection.Reason,
+		)
+	}
+}
+
 func TestInspectWakeLockTreatsUnavailableCurrentBootIdentityAsUnverified(t *testing.T) {
 	const wakePID = 4343
 	root := secureTempDirForTest(t)

--- a/internal/cli/wake_real_fd_pressure_unix_test.go
+++ b/internal/cli/wake_real_fd_pressure_unix_test.go
@@ -1,0 +1,184 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+func exhaustWakeTestFileDescriptors() (release func(), ok bool) {
+	noop := func() {}
+	var original unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &original); err != nil {
+		return noop, false
+	}
+	limited := original
+	limited.Cur = 96
+	if original.Cur < limited.Cur {
+		limited.Cur = original.Cur
+	}
+	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &limited); err != nil {
+		return noop, false
+	}
+
+	var held []*os.File
+	for range 8192 {
+		file, err := os.Open(os.DevNull)
+		if err != nil {
+			break
+		}
+		held = append(held, file)
+	}
+	probe, probeErr := os.Open(os.DevNull)
+	release = func() {
+		for _, file := range held {
+			_ = file.Close()
+		}
+		_ = unix.Setrlimit(unix.RLIMIT_NOFILE, &original)
+	}
+	if probeErr == nil {
+		_ = probe.Close()
+		release()
+		return noop, false
+	}
+	if !errors.Is(probeErr, syscall.EMFILE) {
+		release()
+		return noop, false
+	}
+	return release, true
+}
+
+func writeWakeGenerationForFDPressureTest(
+	t *testing.T,
+	root, agent, generation string,
+) string {
+	t.Helper()
+	base := fsq.AgentBase(root, agent)
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(base, ".wake.lock")
+	if err := os.WriteFile(
+		path,
+		[]byte(`{"generation":"`+generation+`"}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestInspectWakeLockRealEMFILEIsUnreadableNotMissing(t *testing.T) {
+	root := secureTempDirForTest(t)
+	writeWakeGenerationForFDPressureTest(t, root, "codex", "real-emfile")
+	baseline := inspectWakeLock(root, "codex")
+	if !baseline.Exists ||
+		baseline.fileInfo == nil ||
+		baseline.Lock.Generation != "real-emfile" {
+		t.Fatalf("baseline inspection = %+v", baseline)
+	}
+
+	release, ok := exhaustWakeTestFileDescriptors()
+	if !ok {
+		t.Skip("could not materialize file-descriptor exhaustion")
+	}
+	underPressure := inspectWakeLock(root, "codex")
+	release()
+
+	if !underPressure.Exists ||
+		underPressure.fileInfo != nil ||
+		underPressure.Status != wakeLockUnverified ||
+		!strings.Contains(underPressure.Reason, "too many open files") {
+		t.Fatalf("real EMFILE inspection shape = %+v", underPressure)
+	}
+	if after := inspectWakeLock(root, "codex"); !sameWakeLockGeneration(baseline, after) {
+		t.Fatal("wake lock changed during file-descriptor pressure")
+	}
+}
+
+func TestWakeTerminalAuthorityRealEMFILERetriesUnchangedGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeGenerationForFDPressureTest(
+		t,
+		root,
+		"codex",
+		"real-authority-emfile",
+	)
+	baseline := inspectWakeLock(root, "codex")
+	tty, err := os.Open(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = tty.Close() })
+	info, err := tty.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, ok := captureWakeTerminalIdentity(info)
+	if !ok {
+		t.Fatal("capture retained descriptor identity")
+	}
+	authority := &wakeTerminalAuthority{
+		tty:            tty,
+		fd:             tty.Fd(),
+		identity:       identity,
+		foregroundPGRP: 4242,
+		generation:     baseline,
+		controlStop:    make(chan struct{}),
+	}
+
+	release, ok := exhaustWakeTestFileDescriptors()
+	if !ok {
+		t.Skip("could not materialize file-descriptor exhaustion")
+	}
+	validationErr := authority.BeforeWrite()
+	release()
+
+	var transient *wakeTerminalTransientError
+	if !errors.As(validationErr, &transient) ||
+		isWakeTerminalAuthorityLoss(validationErr) ||
+		classifyWakeFailure(validationErr) != wakeFailureRetry {
+		t.Fatalf("real EMFILE validation = %T %v, want retryable transient", validationErr, validationErr)
+	}
+	if after := inspectWakeLock(root, "codex"); !sameWakeLockGeneration(baseline, after) {
+		t.Fatal("wake lock changed during file-descriptor pressure")
+	}
+}
+
+func TestRetainedWakeInboxRealEMFILERetriesSameDirectory(t *testing.T) {
+	_, agentDir := newWakeInboxCapabilityForTest(t)
+	inbox, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inbox.Close() })
+	if err := inbox.ValidateCanonical(); err != nil {
+		t.Fatalf("healthy retained inbox validation: %v", err)
+	}
+
+	release, ok := exhaustWakeTestFileDescriptors()
+	if !ok {
+		t.Skip("could not materialize file-descriptor exhaustion")
+	}
+	validationErr := inbox.ValidateCanonical()
+	release()
+
+	var ownershipLoss *wakeOwnershipLossError
+	if validationErr == nil ||
+		!errors.Is(validationErr, syscall.EMFILE) ||
+		errors.As(validationErr, &ownershipLoss) ||
+		classifyWakeFailure(validationErr) != wakeFailureRetry {
+		t.Fatalf("real EMFILE inbox validation = %T %v, want retryable transient", validationErr, validationErr)
+	}
+	if err := inbox.ValidateCanonical(); err != nil {
+		t.Fatalf("post-pressure retained inbox validation: %v", err)
+	}
+}

--- a/internal/cli/wake_repair_dirs_unix.go
+++ b/internal/cli/wake_repair_dirs_unix.go
@@ -68,6 +68,32 @@ type retainedWakeDirectoryAuthority struct {
 	inboxIdentity wakeRepairDirectoryIdentity
 }
 
+type wakeDirectoryTransientError struct {
+	Reason string
+	Err    error
+}
+
+func (err *wakeDirectoryTransientError) Error() string {
+	return fmt.Sprintf("wake directory temporarily unavailable: %s: %v", err.Reason, err.Err)
+}
+
+func (err *wakeDirectoryTransientError) Unwrap() error {
+	return err.Err
+}
+
+func newWakeDirectoryTransientFailure(reason string, err error) error {
+	return &wakeDirectoryTransientError{Reason: reason, Err: err}
+}
+
+func classifyWakeDirectoryOpenFailure(reason string, err error) error {
+	// An open failure, including ENOENT, ENOTDIR, ELOOP, EACCES, or EMFILE,
+	// cannot compare the canonical path with the retained descriptor and
+	// therefore cannot prove ownership loss. A permanently unavailable lock or
+	// agent directory retries indefinitely, with bounded diagnostics, until it
+	// recovers or a later successful open proves an identity change.
+	return newWakeDirectoryTransientFailure(reason, err)
+}
+
 func wakeRepairDirectoryIdentityForFile(file *os.File) (wakeRepairDirectoryIdentity, error) {
 	if file == nil {
 		return wakeRepairDirectoryIdentity{}, fmt.Errorf("wake repair directory descriptor is missing")
@@ -147,8 +173,8 @@ func (authority retainedWakeDirectoryAuthority) validateCanonical() error {
 		0,
 	)
 	if err != nil {
-		return fmt.Errorf(
-			"canonical wake repair agent directory no longer matches retained authority: %w",
+		return classifyWakeDirectoryOpenFailure(
+			"canonical wake repair agent directory no longer matches retained authority",
 			err,
 		)
 	}
@@ -158,10 +184,13 @@ func (authority retainedWakeDirectoryAuthority) validateCanonical() error {
 		"canonical wake repair agent directory",
 	)
 	if err != nil {
-		return err
+		return newWakeDirectoryTransientFailure(
+			"inspect canonical wake repair agent directory",
+			err,
+		)
 	}
 	if agentIdentity != authority.agentIdentity {
-		return fmt.Errorf("canonical wake repair agent directory no longer matches retained authority")
+		return newWakeOwnershipLoss("canonical wake repair agent directory no longer matches retained authority")
 	}
 
 	inboxFile, err := openWakeInboxNewDirectoryAt(
@@ -170,25 +199,25 @@ func (authority retainedWakeDirectoryAuthority) validateCanonical() error {
 		"canonical wake repair",
 	)
 	if err != nil {
-		return fmt.Errorf(
-			"canonical wake repair inbox directory no longer matches retained authority: %w",
-			err,
-		)
+		return err
 	}
 	defer func() { _ = inboxFile.Close() }()
 	inboxIdentity, err := wakeRepairDirectoryIdentityForFile(inboxFile)
 	if err != nil {
-		return err
+		return newWakeDirectoryTransientFailure(
+			"inspect canonical wake repair inbox directory",
+			err,
+		)
 	}
 	if inboxIdentity != authority.inboxIdentity {
-		return fmt.Errorf("canonical wake repair inbox directory no longer matches retained authority")
+		return newWakeOwnershipLoss("canonical wake repair inbox directory no longer matches retained authority")
 	}
 	return nil
 }
 
 func validateCanonicalWakeAgentDir(agentDir *wakeAgentDir) error {
 	if agentDir == nil {
-		return fmt.Errorf("retained wake agent directory capability is missing")
+		return newWakeOwnershipLoss("retained wake agent directory capability is missing")
 	}
 	var retainedIdentity wakeRepairDirectoryIdentity
 	if err := agentDir.withFD(func(agentFD int) error {
@@ -199,7 +228,10 @@ func validateCanonicalWakeAgentDir(agentDir *wakeAgentDir) error {
 		)
 		return err
 	}); err != nil {
-		return err
+		return newWakeDirectoryTransientFailure(
+			"inspect retained wake agent directory",
+			err,
+		)
 	}
 
 	openCanonical := func() (*os.File, os.FileInfo, error) {
@@ -209,8 +241,8 @@ func validateCanonicalWakeAgentDir(agentDir *wakeAgentDir) error {
 			0,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf(
-				"canonical wake agent directory no longer matches retained authority: %w",
+			return nil, nil, classifyWakeDirectoryOpenFailure(
+				"canonical wake agent directory no longer matches retained authority",
 				err,
 			)
 		}
@@ -218,11 +250,14 @@ func validateCanonicalWakeAgentDir(agentDir *wakeAgentDir) error {
 		info, err := file.Stat()
 		if err != nil {
 			_ = file.Close()
-			return nil, nil, fmt.Errorf("stat canonical wake agent directory: %w", err)
+			return nil, nil, newWakeDirectoryTransientFailure(
+				"stat canonical wake agent directory",
+				err,
+			)
 		}
 		if err := validateWakeAgentDir(agentDir.path, info); err != nil {
 			_ = file.Close()
-			return nil, nil, err
+			return nil, nil, newWakeOwnershipLoss(err.Error())
 		}
 		return file, info, nil
 	}
@@ -234,10 +269,13 @@ func validateCanonicalWakeAgentDir(agentDir *wakeAgentDir) error {
 	defer func() { _ = canonical.Close() }()
 	canonicalIdentity, err := wakeRepairDirectoryIdentityForFile(canonical)
 	if err != nil {
-		return err
+		return newWakeDirectoryTransientFailure(
+			"inspect canonical wake agent directory identity",
+			err,
+		)
 	}
 	if canonicalIdentity != retainedIdentity {
-		return fmt.Errorf("canonical wake agent directory no longer matches retained authority")
+		return newWakeOwnershipLoss("canonical wake agent directory no longer matches retained authority")
 	}
 
 	verification, verificationInfo, err := openCanonical()
@@ -246,7 +284,7 @@ func validateCanonicalWakeAgentDir(agentDir *wakeAgentDir) error {
 	}
 	defer func() { _ = verification.Close() }()
 	if !os.SameFile(canonicalInfo, verificationInfo) {
-		return fmt.Errorf("canonical wake agent directory changed while validating retained authority")
+		return newWakeOwnershipLoss("canonical wake agent directory changed while validating retained authority")
 	}
 	return nil
 }
@@ -315,21 +353,29 @@ func openValidatedWakeDirectoryAt(
 			0,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("open %s: %w", label, err)
+			return nil, nil, classifyWakeDirectoryOpenFailure(
+				"open "+label,
+				err,
+			)
 		}
 		file := os.NewFile(uintptr(fd), path)
 		info, err := file.Stat()
 		if err != nil {
 			_ = file.Close()
-			return nil, nil, fmt.Errorf("stat %s: %w", label, err)
+			return nil, nil, newWakeDirectoryTransientFailure(
+				"stat "+label,
+				err,
+			)
 		}
 		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			_ = file.Close()
-			return nil, nil, fmt.Errorf("%s must be a directory, not a symlink", label)
+			return nil, nil, newWakeOwnershipLoss(
+				fmt.Sprintf("%s must be a directory, not a symlink", label),
+			)
 		}
 		if err := validateWakeTargetPathOwnership(label, path, info); err != nil {
 			_ = file.Close()
-			return nil, nil, err
+			return nil, nil, newWakeOwnershipLoss(err.Error())
 		}
 		return file, info, nil
 	}
@@ -346,7 +392,7 @@ func openValidatedWakeDirectoryAt(
 	defer func() { _ = verification.Close() }()
 	if !os.SameFile(openedInfo, verificationInfo) {
 		_ = file.Close()
-		return nil, fmt.Errorf("%s changed while opening", label)
+		return nil, newWakeOwnershipLoss(fmt.Sprintf("%s changed while opening", label))
 	}
 	return file, nil
 }
@@ -695,7 +741,10 @@ func (d *wakeInboxDir) ValidateCanonical() error {
 			d.path,
 		)
 		if err != nil {
-			return err
+			return newWakeDirectoryTransientFailure(
+				"inspect retained wake watcher directories",
+				err,
+			)
 		}
 		return authority.validateCanonical()
 	})

--- a/internal/cli/wake_repair_dirs_unix.go
+++ b/internal/cli/wake_repair_dirs_unix.go
@@ -42,6 +42,10 @@ type wakeInboxDir struct {
 	closed    bool
 }
 
+var newWakeInboxEventWatcher = func(inbox *wakeInboxDir) (wakeEventWatcher, error) {
+	return inbox.NewWatcher()
+}
+
 func (*wakeAgentDir) isWakeRetainedAgent() {}
 
 type wakeEventWatcher interface {
@@ -417,7 +421,7 @@ func openWatchedWakeInboxDir(
 	if err != nil {
 		return nil, nil, err
 	}
-	watcher, err := inboxDir.NewWatcher()
+	watcher, err := newWakeInboxEventWatcher(inboxDir)
 	if err != nil {
 		closeErr := inboxDir.Close()
 		return nil, nil, errors.Join(err, closeErr)

--- a/internal/cli/wake_self_healing_unix_test.go
+++ b/internal/cli/wake_self_healing_unix_test.go
@@ -1,0 +1,786 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/fsnotify/fsnotify"
+)
+
+type scriptedWakeEventWatcher struct {
+	events chan fsnotify.Event
+	errs   chan error
+}
+
+func (watcher *scriptedWakeEventWatcher) Events() <-chan fsnotify.Event {
+	return watcher.events
+}
+
+func (watcher *scriptedWakeEventWatcher) Errors() <-chan error {
+	return watcher.errs
+}
+
+func (watcher *scriptedWakeEventWatcher) Close() error {
+	return nil
+}
+
+func stubFastWakeInboxRetry(t *testing.T) {
+	t.Helper()
+	originalBase := wakeInboxScanRetryBase
+	originalMax := wakeInboxScanRetryMax
+	wakeInboxScanRetryBase = 10 * time.Millisecond
+	wakeInboxScanRetryMax = 20 * time.Millisecond
+	t.Cleanup(func() {
+		wakeInboxScanRetryBase = originalBase
+		wakeInboxScanRetryMax = originalMax
+	})
+}
+
+func requireWakePrepared(t *testing.T, cfg wakeConfig, failure string) {
+	t.Helper()
+	prepared := make(chan struct{})
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	cfg.controlStop = stop
+	cfg.onPrepared = func(wakeAdmissionWatcher) error {
+		close(prepared)
+		return nil
+	}
+	go func() {
+		done <- runWakeLoop(cfg)
+	}()
+
+	select {
+	case <-prepared:
+	case err := <-done:
+		t.Fatalf("%s: %v", failure, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal(failure)
+	}
+	close(stop)
+	if err := <-done; err != nil {
+		t.Fatalf("wake loop stop: %v", err)
+	}
+}
+
+func TestClassifyWakeFailureDefaultsToRetryAndPreservesFatalDominance(t *testing.T) {
+	unknown := errors.New("unclassified effect failure")
+	if got := classifyWakeFailure(unknown); got != wakeFailureRetry {
+		t.Fatalf("unknown failure disposition = %v, want retry", got)
+	}
+	if got := classifyWakeFailure(newWakeTerminalForegroundPGRPChangedLoss(1, 2)); got != wakeFailureRetry {
+		t.Fatalf("foreground handoff disposition = %v, want retry", got)
+	}
+	fatal := newWakeTerminalAuthorityLoss("wake generation superseded", nil)
+	if got := classifyWakeFailure(errors.Join(unknown, fatal)); got != wakeFailureFatal {
+		t.Fatalf("joined ownership loss disposition = %v, want fatal", got)
+	}
+}
+
+func TestWakeStartupRetryBackoffRemainsWithinCoopReadinessBudget(t *testing.T) {
+	got := wakeStartupRetryBackoff(64)
+	want := wakeReadyTimeout / 10
+	if got != want {
+		t.Fatalf("startup retry backoff = %s, want readiness-derived cap %s", got, want)
+	}
+	if got*2 >= wakeReadyTimeout {
+		t.Fatalf("startup retry cap %s leaves too little readiness budget %s", got, wakeReadyTimeout)
+	}
+}
+
+func TestRunWakeLoopFatalOwnershipLossDominatesJoinedMaintenanceFailure(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	generic := errors.New("status persistence failed")
+	fatal := newWakeTerminalAuthorityLoss("wake generation superseded", nil)
+	ticks := make(chan time.Time)
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			injectMode:       wakeInjectModeNone,
+			controlStop:      make(chan struct{}),
+			maintenanceTicks: ticks,
+			preconditionCheck: func(*wakeConfig) error {
+				return errors.Join(generic, fatal)
+			},
+		})
+	}()
+
+	ticks <- time.Now()
+	select {
+	case err := <-done:
+		if !errors.Is(err, generic) || !errors.Is(err, fatal) {
+			t.Fatalf("fatal joined maintenance error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("proven ownership loss did not terminate wake loop")
+	}
+}
+
+func TestRunWakeLoopRetriesTransientBaselineWatcherFailureBeforeReadiness(t *testing.T) {
+	stubFastWakeInboxRetry(t)
+	originalFactory := newWakeBaselineEventWatcher
+	var calls atomic.Int64
+	newWakeBaselineEventWatcher = func(path string) (wakeEventWatcher, error) {
+		if calls.Add(1) == 1 {
+			errs := make(chan error, 1)
+			errs <- errors.New("temporary baseline watcher overflow")
+			return &scriptedWakeEventWatcher{
+				events: make(chan fsnotify.Event),
+				errs:   errs,
+			}, nil
+		}
+		return originalFactory(path)
+	}
+	t.Cleanup(func() {
+		newWakeBaselineEventWatcher = originalFactory
+	})
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	requireWakePrepared(t, wakeConfig{
+		root:              root,
+		me:                "codex",
+		injectMode:        wakeInjectModeNone,
+		baselineRequested: true,
+	}, "transient baseline watcher did not recover before readiness")
+	if got := calls.Load(); got < 2 {
+		t.Fatalf("baseline watcher factory calls = %d, want rearm", got)
+	}
+}
+
+func TestRunWakeLoopRetriesTransientMainWatcherCreationBeforeReadiness(t *testing.T) {
+	stubFastWakeInboxRetry(t)
+	originalFactory := newWakeInboxEventWatcher
+	var calls atomic.Int64
+	newWakeInboxEventWatcher = func(inbox *wakeInboxDir) (wakeEventWatcher, error) {
+		if calls.Add(1) == 1 {
+			return nil, syscall.EMFILE
+		}
+		return originalFactory(inbox)
+	}
+	t.Cleanup(func() {
+		newWakeInboxEventWatcher = originalFactory
+	})
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	requireWakePrepared(t, wakeConfig{
+		root:       root,
+		me:         "codex",
+		injectMode: wakeInjectModeNone,
+	}, "transient main watcher creation did not recover before readiness")
+	if got := calls.Load(); got < 2 {
+		t.Fatalf("main watcher factory calls = %d, want retry", got)
+	}
+}
+
+func TestRunWakeLoopRearmsFailedMainWatcherBeforeReadiness(t *testing.T) {
+	originalFactory := newWakeInboxEventWatcher
+	var calls atomic.Int64
+	newWakeInboxEventWatcher = func(inbox *wakeInboxDir) (wakeEventWatcher, error) {
+		if calls.Add(1) == 1 {
+			errs := make(chan error, 1)
+			errs <- errors.New("main watcher failed before admission")
+			return &scriptedWakeEventWatcher{
+				events: make(chan fsnotify.Event),
+				errs:   errs,
+			}, nil
+		}
+		return originalFactory(inbox)
+	}
+	t.Cleanup(func() {
+		newWakeInboxEventWatcher = originalFactory
+	})
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	requireWakePrepared(t, wakeConfig{
+		root:       root,
+		me:         "codex",
+		injectMode: wakeInjectModeNone,
+	}, "failed main watcher was not rearmed before readiness")
+	if got := calls.Load(); got < 2 {
+		t.Fatalf("main watcher factory calls = %d, want rearm", got)
+	}
+}
+
+func TestRunWakeLoopRetriesUnknownMaintenanceFailureByDefault(t *testing.T) {
+	originalRead := readTIOCSTILegacySysctl
+	readTIOCSTILegacySysctl = func() ([]byte, error) {
+		return []byte("1\n"), nil
+	}
+	t.Cleanup(func() {
+		readTIOCSTILegacySysctl = originalRead
+	})
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+
+	ticks := make(chan time.Time)
+	checked := make(chan int, 2)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	checks := 0
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:                root,
+			me:                  "codex",
+			injectMode:          wakeInjectModeRaw,
+			requestedInjectMode: wakeInjectModeRaw,
+			controlStop:         stop,
+			maintenanceTicks:    ticks,
+			preconditionCheck: func(cfg *wakeConfig) error {
+				checks++
+				checked <- checks
+				return wakeInjectionPreconditionCheck(
+					cfg,
+					func() bool { return checks > 1 },
+				)
+			},
+		})
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	ticks <- time.Now()
+	select {
+	case got := <-checked:
+		if got != 1 {
+			t.Fatalf("first maintenance check = %d", got)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before first maintenance check: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not run first maintenance check")
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("unknown maintenance failure killed wake loop: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	ticks <- time.Now()
+	select {
+	case got := <-checked:
+		if got != 2 {
+			t.Fatalf("recovery maintenance check = %d", got)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before recovery maintenance check: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not retry maintenance after transient failure")
+	}
+}
+
+func TestRunWakeLoopRetriesPendingNotifierStatusPersistence(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+
+	persistErr := errors.New("presence unavailable")
+	attempted := make(chan wakeNotifierStatus, 2)
+	var calls atomic.Int64
+	ticks := make(chan time.Time)
+	stop := make(chan struct{})
+	cfg := wakeConfig{
+		root:             root,
+		me:               "codex",
+		injectMode:       wakeInjectModeNone,
+		controlStop:      stop,
+		maintenanceTicks: ticks,
+		recordNotifierStatus: func(status, mode, reason string) error {
+			attempted <- wakeNotifierStatus{status: status, mode: mode, reason: reason}
+			if calls.Add(1) == 1 {
+				return persistErr
+			}
+			return nil
+		},
+	}
+	if err := persistWakeNotifierStatus(
+		&cfg,
+		wakeInputRecoveryRequiredStatus,
+		wakeInjectModeRaw,
+		"retry exact status",
+	); !errors.Is(err, persistErr) {
+		t.Fatalf("initial notifier status persistence = %v, want %v", err, persistErr)
+	}
+	<-attempted
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(cfg)
+	}()
+	ticks <- time.Now()
+	select {
+	case got := <-attempted:
+		want := (wakeNotifierStatus{
+			status: wakeInputRecoveryRequiredStatus,
+			mode:   wakeInjectModeRaw,
+			reason: "retry exact status",
+		})
+		if got != want {
+			t.Fatalf("retried notifier status = %#v, want %#v", got, want)
+		}
+	case err := <-done:
+		t.Fatalf("pending notifier status failure killed wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending notifier status was not retried on maintenance")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("wake loop exited after notifier status recovered: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(stop)
+	if err := <-done; err != nil {
+		t.Fatalf("wake loop stop: %v", err)
+	}
+}
+
+func TestRunWakeLoopRearmsRetainedWatcherAfterTransientClosure(t *testing.T) {
+	stubFastWakeInboxRetry(t)
+
+	root, agentDir := newWakeInboxCapabilityForTest(t)
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inboxDir.Close() })
+
+	closed := make(chan struct{})
+	attention := make(chan string, 2)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:           root,
+			me:             "codex",
+			session:        "session1",
+			injectMode:     wakeInjectModeNone,
+			controlStop:    stop,
+			retainedAgent:  agentDir,
+			retainedInbox:  inboxDir,
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+			onPrepared: func(watcher wakeAdmissionWatcher) error {
+				closer, ok := watcher.(interface{ Close() error })
+				if !ok {
+					return errors.New("wake watcher is not closeable")
+				}
+				if err := closer.Close(); err != nil {
+					return err
+				}
+				close(closed)
+				return nil
+			},
+		})
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	select {
+	case <-closed:
+	case err := <-done:
+		t.Fatalf("wake loop exited before retained watcher closure: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not close retained watcher")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("retained watcher closure killed wake loop: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	deliverWakeWatcherMessageForTest(t, root, "codex", "after-retained-rearm", "claude")
+	awaitWakeAttentionFrom(t, attention, done, "claude")
+}
+
+func TestRunWakeLoopRetriesUnknownTIOCSTIErrnoWithValidAuthority(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	stop := make(chan struct{})
+	authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+	injectWakeTerminalFD = func(uintptr, string) error {
+		return &tiocstiInjectionError{Err: syscall.EINVAL, Progress: 0}
+	}
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "unknown-errno", "claude")
+
+	attention := make(chan string, 2)
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:                root,
+			me:                  "codex",
+			session:             "session1",
+			wakeOwner:           &wakeOwner{},
+			injectMode:          wakeInjectModeRaw,
+			controlStop:         stop,
+			beforeTerminalWrite: authority.BeforeWrite,
+			terminalWrite:       authority.Inject,
+			attentionIsTTY:      func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	select {
+	case output := <-attention:
+		if !strings.Contains(output, "from claude") {
+			t.Fatalf("unknown-errno attention = %q", output)
+		}
+	case err := <-done:
+		t.Fatalf("unknown TIOCSTI errno killed wake loop before attention: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("unknown TIOCSTI errno emitted no attention")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("unknown TIOCSTI errno killed wake loop: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestRunWakeLoopRecoveryProgressStartsFreshDoorbell(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "first", "claude")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "second", "claude")
+
+	firstPath := filepath.Join(fsq.AgentInboxNew(root, "codex"), "first.md")
+	secondPath := filepath.Join(fsq.AgentInboxNew(root, "codex"), "second.md")
+	firstInfo, err := os.Stat(firstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondInfo, err := os.Stat(secondPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cohort := map[string]os.FileInfo{
+		"first.md":  firstInfo,
+		"second.md": secondInfo,
+	}
+
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	writes := make(chan string, 8)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:                  root,
+			me:                    "codex",
+			session:               "session1",
+			wakeOwner:             &wakeOwner{},
+			debounce:              5 * time.Millisecond,
+			injectMode:            wakeInjectModeRaw,
+			controlStop:           stop,
+			inputRecoveryRequired: true,
+			inputDelivery: wakeInputDeliveryState{
+				phase:         wakeInputPayloadPending,
+				mode:          wakeInjectModeRaw,
+				payload:       coopWakeDoorbell,
+				acceptedBytes: 7,
+			},
+			doorbell: wakeDoorbellState{
+				phase:       wakeDoorbellRecoveryRequired,
+				cohort:      snapshotWakeFileIdentities(cohort),
+				attempts:    1,
+				nextAttempt: time.Now().Add(time.Hour),
+			},
+			terminalWrite: func(data string) error {
+				writes <- data
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+		})
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	if err := os.Remove(firstPath); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case write := <-writes:
+		if write != coopWakeDoorbell {
+			t.Fatalf("post-progress write = %q, want fresh complete doorbell", write)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before fresh recovery doorbell: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumer progress left wake permanently recovery-required")
+	}
+}
+
+func TestRunWakeLoopRepromotesRuntimeLegacyTIOCSTIDemotion(t *testing.T) {
+	originalRead := readTIOCSTILegacySysctl
+	var disabled atomic.Bool
+	disabled.Store(true)
+	readTIOCSTILegacySysctl = func() ([]byte, error) {
+		if disabled.Load() {
+			return []byte("0\n"), nil
+		}
+		return []byte("1\n"), nil
+	}
+	t.Cleanup(func() {
+		readTIOCSTILegacySysctl = originalRead
+	})
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	ticks := make(chan time.Time)
+	statuses := make(chan string, 4)
+	attention := make(chan string, 2)
+	writes := make(chan string, 8)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:                root,
+			me:                  "codex",
+			session:             "session1",
+			wakeOwner:           &wakeOwner{},
+			debounce:            5 * time.Millisecond,
+			injectMode:          wakeInjectModeRaw,
+			requestedInjectMode: wakeInjectModeRaw,
+			controlStop:         stop,
+			maintenanceTicks:    ticks,
+			preconditionCheck: func(cfg *wakeConfig) error {
+				return wakeInjectionPreconditionCheck(cfg, func() bool { return true })
+			},
+			recordNotifierStatus: func(status, _, _ string) error {
+				statuses <- status
+				return nil
+			},
+			terminalWrite: func(data string) error {
+				writes <- data
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+
+	t.Cleanup(func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	ticks <- time.Now()
+	select {
+	case status := <-statuses:
+		if status != wakeInjectorUnsupportedStatus {
+			t.Fatalf("demotion status = %q", status)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited during runtime demotion: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("runtime capability loss did not demote")
+	}
+
+	deliverWakeWatcherMessageForTest(t, root, "codex", "while-demoted", "claude")
+	select {
+	case <-attention:
+	case err := <-done:
+		t.Fatalf("wake loop exited before demoted attention: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("demoted wake emitted no attention")
+	}
+
+	disabled.Store(false)
+	ticks <- time.Now()
+	select {
+	case write := <-writes:
+		if write != coopWakeDoorbell {
+			t.Fatalf("restored input write = %q, want complete doorbell", write)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited during input restoration: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("restored capability did not immediately drive pending cohort")
+	}
+	select {
+	case status := <-statuses:
+		if status != "" {
+			t.Fatalf("restored notifier status = %q, want clear", status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("restored capability did not clear notifier status")
+	}
+}
+
+func TestRunWakeLoopExplicitNoneNeverPromotes(t *testing.T) {
+	originalRead := readTIOCSTILegacySysctl
+	readTIOCSTILegacySysctl = func() ([]byte, error) {
+		return []byte("1\n"), nil
+	}
+	t.Cleanup(func() {
+		readTIOCSTILegacySysctl = originalRead
+	})
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "explicit-none", "claude")
+	ticks := make(chan time.Time)
+	attention := make(chan string, 2)
+	writes := make(chan string, 1)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:                root,
+			me:                  "codex",
+			injectMode:          wakeInjectModeNone,
+			requestedInjectMode: wakeInjectModeNone,
+			controlStop:         stop,
+			maintenanceTicks:    ticks,
+			preconditionCheck: func(cfg *wakeConfig) error {
+				return wakeInjectionPreconditionCheck(cfg, func() bool { return true })
+			},
+			terminalWrite: func(data string) error {
+				writes <- data
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+
+	select {
+	case <-attention:
+	case err := <-done:
+		t.Fatalf("explicit-none wake exited before attention: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("explicit-none wake emitted no attention")
+	}
+	ticks <- time.Now()
+	select {
+	case write := <-writes:
+		t.Fatalf("explicit none promoted and wrote %q", write)
+	case err := <-done:
+		t.Fatalf("explicit-none wake exited on maintenance: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(stop)
+	if err := <-done; err != nil {
+		t.Fatalf("wake loop stop: %v", err)
+	}
+}
+
+func TestNotifyNewMessagesEmptyInboxClearsInputRecovery(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	cfg := &wakeConfig{
+		root:                  root,
+		me:                    "codex",
+		injectMode:            wakeInjectModeRaw,
+		inputRecoveryRequired: true,
+		inputDelivery: wakeInputDeliveryState{
+			phase:               wakeInputPayloadPending,
+			mode:                wakeInjectModeRaw,
+			payload:             coopWakeDoorbell,
+			acceptanceUncertain: true,
+		},
+		doorbell: wakeDoorbellState{
+			phase: wakeDoorbellRecoveryRequired,
+			cohort: snapshotWakeFileIdentities(
+				wakeDoorbellTestFiles(t, "already-drained.md"),
+			),
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("empty recovery inbox: %v", err)
+	}
+	if cfg.inputRecoveryRequired || cfg.inputDelivery.pending() ||
+		cfg.doorbell.phase != wakeDoorbellIdle {
+		t.Fatalf("empty inbox retained recovery state: %#v %#v", cfg.inputDelivery, cfg.doorbell)
+	}
+}

--- a/internal/cli/wake_self_healing_unix_test.go
+++ b/internal/cli/wake_self_healing_unix_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,9 +81,33 @@ func TestClassifyWakeFailureDefaultsToRetryAndPreservesFatalDominance(t *testing
 	if got := classifyWakeFailure(newWakeTerminalForegroundPGRPChangedLoss(1, 2)); got != wakeFailureRetry {
 		t.Fatalf("foreground handoff disposition = %v, want retry", got)
 	}
-	fatal := newWakeTerminalAuthorityLoss("wake generation superseded", nil)
+	fatal := newWakeTerminalAuthorityLoss("wake generation superseded")
 	if got := classifyWakeFailure(errors.Join(unknown, fatal)); got != wakeFailureFatal {
 		t.Fatalf("joined ownership loss disposition = %v, want fatal", got)
+	}
+}
+
+func TestWakeTerminalAuthorityLossReasonCannotSmuggleTransientErrno(t *testing.T) {
+	loss := newWakeTerminalAuthorityLoss(
+		fmt.Sprintf("wake generation inspection failed: %v", syscall.EMFILE),
+	)
+	if errors.Is(loss, syscall.EMFILE) {
+		t.Fatalf("reason-only authority loss unexpectedly unwraps EMFILE: %v", loss)
+	}
+	if got := classifyWakeFailure(loss); got != wakeFailureFatal {
+		t.Fatalf("reason-only authority loss disposition = %v, want fatal", got)
+	}
+}
+
+func TestWakeOwnershipLossReasonCannotSmuggleTransientErrno(t *testing.T) {
+	loss := newWakeOwnershipLoss(
+		fmt.Sprintf("wake owner inspection failed: %v", syscall.ESRCH),
+	)
+	if errors.Is(loss, syscall.ESRCH) {
+		t.Fatalf("reason-only ownership loss unexpectedly unwraps ESRCH: %v", loss)
+	}
+	if got := classifyWakeFailure(loss); got != wakeFailureFatal {
+		t.Fatalf("reason-only ownership loss disposition = %v, want fatal", got)
 	}
 }
 
@@ -101,7 +126,7 @@ func TestRunWakeLoopFatalOwnershipLossDominatesJoinedMaintenanceFailure(t *testi
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	generic := errors.New("status persistence failed")
-	fatal := newWakeTerminalAuthorityLoss("wake generation superseded", nil)
+	fatal := newWakeTerminalAuthorityLoss("wake generation superseded")
 	ticks := make(chan time.Time)
 	done := make(chan error, 1)
 	go func() {
@@ -125,6 +150,162 @@ func TestRunWakeLoopFatalOwnershipLossDominatesJoinedMaintenanceFailure(t *testi
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("proven ownership loss did not terminate wake loop")
+	}
+}
+
+func TestRunWakeLoopTerminatesOnProvenTerminalIdentityLoss(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "fatal-terminal-loss", "claude")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			wakeOwner:   &wakeOwner{},
+			injectMode:  wakeInjectModeRaw,
+			controlStop: make(chan struct{}),
+			terminalWrite: func(string) error {
+				return newWakeTerminalAuthorityLoss(
+					"retained controlling-terminal identity changed",
+				)
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				return len(data), nil
+			},
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if !isWakeTerminalAuthorityLoss(err) ||
+			classifyWakeFailure(err) != wakeFailureFatal {
+			t.Fatalf("loop exit = %v, want fatal terminal authority loss", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("proven terminal identity loss did not terminate wake loop")
+	}
+}
+
+func TestRunWakeLoopTerminatesOnOwnerESRCH(t *testing.T) {
+	const ownerPID = 4242
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != ownerPID {
+			t.Fatalf("inspected owner pid = %d, want %d", pid, ownerPID)
+		}
+		return wakeProcessInfo{
+			PID:          pid,
+			Running:      false,
+			InspectError: syscall.ESRCH,
+		}
+	})
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	ticks := make(chan time.Time)
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:             root,
+			me:               "codex",
+			injectMode:       wakeInjectModeRaw,
+			injectVia:        "/unused/test-injector",
+			wakeOwner:        &wakeOwner{PID: ownerPID},
+			controlStop:      make(chan struct{}),
+			maintenanceTicks: ticks,
+		})
+	}()
+
+	ticks <- time.Now()
+	select {
+	case err := <-done:
+		if classifyWakeFailure(err) != wakeFailureFatal ||
+			!strings.Contains(err.Error(), "owner pid 4242 is not running") {
+			t.Fatalf("owner ESRCH loop exit = %v, want fatal owner death", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("proven owner ESRCH did not terminate wake loop")
+	}
+}
+
+func TestRunWakeLoopTerminatesOnConclusiveGenerationLoss(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*wakeLockInspection)
+		wantReason string
+	}{
+		{
+			name: "missing lock",
+			mutate: func(current *wakeLockInspection) {
+				current.Exists = false
+				current.Status = wakeLockMissing
+				current.Lock = wakeLock{}
+				current.fileInfo = nil
+			},
+			wantReason: "wake generation disappeared",
+		},
+		{
+			name: "positive generation mismatch",
+			mutate: func(current *wakeLockInspection) {
+				current.Lock.Generation = "replacement-generation"
+			},
+			wantReason: "wake generation changed",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := installWakeTerminalAuthorityFixture(t)
+			stop := make(chan struct{})
+			authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = authority.Close() })
+			test.mutate(&fixture.current)
+
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			deliverWakeWatcherMessageForTest(
+				t,
+				root,
+				"codex",
+				"conclusive-generation-loss",
+				"claude",
+			)
+			done := make(chan error, 1)
+			go func() {
+				done <- runWakeLoop(wakeConfig{
+					root:                root,
+					me:                  "codex",
+					session:             "session1",
+					injectMode:          wakeInjectModeRaw,
+					controlStop:         stop,
+					beforeTerminalWrite: authority.BeforeWrite,
+					terminalWrite:       authority.Inject,
+					attentionIsTTY:      func() bool { return false },
+					attentionWrite: func(data []byte) (int, error) {
+						return len(data), nil
+					},
+				})
+			}()
+
+			select {
+			case err := <-done:
+				if !isWakeTerminalAuthorityLoss(err) ||
+					classifyWakeFailure(err) != wakeFailureFatal ||
+					!strings.Contains(err.Error(), test.wantReason) {
+					t.Fatalf("conclusive generation loop exit = %v", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("%s did not terminate wake loop", test.name)
+			}
+			if len(fixture.injections) != 0 {
+				t.Fatalf("%s injected terminal input: %#v", test.name, fixture.injections)
+			}
+		})
 	}
 }
 
@@ -432,6 +613,594 @@ func TestRunWakeLoopRearmsRetainedWatcherAfterTransientClosure(t *testing.T) {
 	awaitWakeAttentionFrom(t, attention, done, "claude")
 }
 
+func TestRunWakeLoopRetriesTransientCanonicalAgentValidationWhileRearming(t *testing.T) {
+	stubFastWakeInboxRetry(t)
+
+	root, agentDir := newWakeInboxCapabilityForTest(t)
+	parentPath := filepath.Dir(agentDir.path)
+	parentInfo, err := os.Stat(parentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentMode := parentInfo.Mode().Perm()
+	t.Cleanup(func() {
+		if err := os.Chmod(parentPath, parentMode); err != nil {
+			t.Errorf("restore wake agent parent permissions: %v", err)
+		}
+	})
+
+	closed := make(chan struct{})
+	attention := make(chan string, 2)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:           root,
+			me:             "codex",
+			session:        "session1",
+			injectMode:     wakeInjectModeNone,
+			controlStop:    stop,
+			retainedAgent:  agentDir,
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+			onPrepared: func(watcher wakeAdmissionWatcher) error {
+				if err := os.Chmod(parentPath, 0); err != nil {
+					return err
+				}
+				closer, ok := watcher.(interface{ Close() error })
+				if !ok {
+					return errors.New("wake watcher is not closeable")
+				}
+				if err := closer.Close(); err != nil {
+					return err
+				}
+				close(closed)
+				return nil
+			},
+		})
+	}()
+
+	loopFinished := false
+	t.Cleanup(func() {
+		if loopFinished {
+			return
+		}
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	select {
+	case <-closed:
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("wake loop exited before transient canonical validation: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not close watcher for canonical validation")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if err := os.Chmod(parentPath, parentMode); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("transient canonical validation killed wake loop: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	deliverWakeWatcherMessageForTest(t, root, "codex", "after-canonical-retry", "claude")
+	awaitWakeAttentionFrom(t, attention, done, "claude")
+
+	close(stop)
+	if err := <-done; err != nil {
+		loopFinished = true
+		t.Fatalf("wake loop stop: %v", err)
+	}
+	loopFinished = true
+}
+
+func TestCanonicalWakeAgentMissingPathRetriesUntilRestored(t *testing.T) {
+	_, agentDir := newWakeInboxCapabilityForTest(t)
+	movedPath := agentDir.path + ".temporarily-missing"
+	if err := os.Rename(agentDir.path, movedPath); err != nil {
+		t.Fatal(err)
+	}
+	restored := false
+	t.Cleanup(func() {
+		if restored {
+			return
+		}
+		if err := os.Rename(movedPath, agentDir.path); err != nil {
+			t.Errorf("restore canonical wake agent directory: %v", err)
+		}
+	})
+
+	err := validateCanonicalWakeAgentDir(agentDir)
+	if err == nil ||
+		!errors.Is(err, syscall.ENOENT) ||
+		classifyWakeFailure(err) != wakeFailureRetry {
+		t.Fatalf("missing canonical wake agent = %T %v, want retryable ENOENT", err, err)
+	}
+	var ownershipLoss *wakeOwnershipLossError
+	if errors.As(err, &ownershipLoss) {
+		t.Fatalf("missing canonical wake agent became ownership loss: %v", err)
+	}
+
+	if err := os.Rename(movedPath, agentDir.path); err != nil {
+		t.Fatal(err)
+	}
+	restored = true
+	if err := validateCanonicalWakeAgentDir(agentDir); err != nil {
+		t.Fatalf("restored canonical wake agent did not self-heal: %v", err)
+	}
+}
+
+func TestRunWakeLoopRetriesTransientWakeGenerationReadFailure(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	stop := make(chan struct{})
+	authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+
+	var inspections atomic.Int64
+	var allowRecovery atomic.Bool
+	failureObserved := make(chan struct{}, 1)
+	inspectWakeTerminalGeneration = func(root, agent string) wakeLockInspection {
+		return inspectWakeLockWithReader(
+			root,
+			agent,
+			fixture.generation.LockPath,
+			func() ([]byte, os.FileInfo, error) {
+				inspections.Add(1)
+				if !allowRecovery.Load() {
+					select {
+					case failureObserved <- struct{}{}:
+					default:
+					}
+					return nil, nil, syscall.EMFILE
+				}
+				return readWakeLockFileWithInfo(fixture.generation.LockPath)
+			},
+		)
+	}
+	injected := make(chan struct{}, 1)
+	injectWakeTerminalFD = func(uintptr, string) error {
+		select {
+		case injected <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "transient-generation-read", "claude")
+	done := make(chan error, 1)
+	ticks := make(chan time.Time)
+	maintenanceObserved := make(chan struct{}, 8)
+	maintenanceRelease := make(chan struct{})
+	statuses := make(chan wakeNotifierStatus, 4)
+	attention := make(chan string, 8)
+	var maintenanceInspections atomic.Int64
+	var deliveryValidations atomic.Int64
+	var doorbellNow atomic.Int64
+	start := time.Now()
+	doorbellNow.Store(start.UnixNano())
+	loopFinished := false
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:        root,
+			me:          "codex",
+			session:     "session1",
+			injectMode:  wakeInjectModeRaw,
+			controlStop: stop,
+			beforeTerminalWrite: func() error {
+				deliveryValidations.Add(1)
+				return authority.BeforeWrite()
+			},
+			terminalWrite:    authority.Inject,
+			maintenanceTicks: ticks,
+			doorbellNow: func() time.Time {
+				return time.Unix(0, doorbellNow.Load())
+			},
+			inspectTerminalGeneration: func() wakeLockInspection {
+				maintenanceInspections.Add(1)
+				return inspectWakeTerminalGeneration(
+					fixture.generation.Root,
+					fixture.generation.Agent,
+				)
+			},
+			preconditionCheck: func(*wakeConfig) error {
+				maintenanceObserved <- struct{}{}
+				select {
+				case <-maintenanceRelease:
+				case <-stop:
+				}
+				return nil
+			},
+			recordNotifierStatus: func(status, mode, reason string) error {
+				statuses <- wakeNotifierStatus{status: status, mode: mode, reason: reason}
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				attention <- string(data)
+				return len(data), nil
+			},
+		})
+	}()
+	t.Cleanup(func() {
+		if loopFinished {
+			return
+		}
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	select {
+	case <-failureObserved:
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("wake loop exited before transient generation-read failure: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not exercise transient generation-read failure")
+	}
+	if got := maintenanceInspections.Load(); got != 0 {
+		t.Fatalf("delivery attempt performed %d maintenance inspections, want 0", got)
+	}
+
+	for observation := 1; observation < wakeUnreadableGenerationNoticeThreshold; observation++ {
+		doorbellNow.Store(
+			start.Add(time.Duration(observation) * wakeDoorbellAttentionRetryMax).UnixNano(),
+		)
+		ticks <- time.Now()
+		select {
+		case <-maintenanceObserved:
+		case err := <-done:
+			loopFinished = true
+			t.Fatalf("transient generation-read failure killed wake loop: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("wake loop did not complete pre-threshold maintenance")
+		}
+		if observation == wakeUnreadableGenerationNoticeThreshold-1 {
+			select {
+			case status := <-statuses:
+				t.Fatalf(
+					"unreadable lock reported after %d maintenance observations: %#v",
+					observation,
+					status,
+				)
+			default:
+			}
+		}
+		maintenanceRelease <- struct{}{}
+	}
+
+	doorbellNow.Store(
+		start.Add(wakeUnreadableGenerationNoticeThreshold * wakeDoorbellAttentionRetryMax).UnixNano(),
+	)
+	ticks <- time.Now()
+	select {
+	case <-maintenanceObserved:
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("transient generation-read failure killed wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not begin threshold maintenance")
+	}
+	select {
+	case status := <-statuses:
+		t.Fatalf(
+			"unreadable lock reported before %d maintenance observations: %#v",
+			wakeUnreadableGenerationNoticeThreshold,
+			status,
+		)
+	default:
+	}
+	maintenanceRelease <- struct{}{}
+
+	select {
+	case status := <-statuses:
+		want := (wakeNotifierStatus{
+			status: "degraded",
+			mode:   wakeInjectModeRaw,
+			reason: "wake lock unreadable",
+		})
+		if status != want {
+			t.Fatalf("unreadable-lock status = %#v, want %#v", status, want)
+		}
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("wake loop exited before unreadable-lock status: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("five maintenance observations emitted no unreadable-lock status")
+	}
+	if got := maintenanceInspections.Load(); got != wakeUnreadableGenerationNoticeThreshold {
+		t.Fatalf(
+			"maintenance inspections at status = %d, want %d",
+			got,
+			wakeUnreadableGenerationNoticeThreshold,
+		)
+	}
+	for {
+		select {
+		case output := <-attention:
+			if strings.Contains(
+				output,
+				"wake lock unreadable; injection paused; will resume automatically",
+			) {
+				goto attentionObserved
+			}
+		case err := <-done:
+			loopFinished = true
+			t.Fatalf("wake loop exited before unreadable-lock attention: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("five maintenance observations emitted no unreadable-lock attention")
+		}
+	}
+
+attentionObserved:
+	allowRecovery.Store(true)
+	doorbellNow.Store(
+		start.Add((wakeUnreadableGenerationNoticeThreshold + 1) * wakeDoorbellAttentionRetryMax).UnixNano(),
+	)
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("transient generation-read failure killed wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance retry")
+	}
+	select {
+	case <-injected:
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("transient generation-read failure killed wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf(
+			"wake loop did not retry after transient generation-read failure (delivery validations=%d, inspections=%d, maintenance inspections=%d)",
+			deliveryValidations.Load(),
+			inspections.Load(),
+			maintenanceInspections.Load(),
+		)
+	}
+	select {
+	case <-maintenanceObserved:
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("wake loop exited before recovery maintenance observation: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not reach recovery maintenance observation")
+	}
+	maintenanceRelease <- struct{}{}
+	select {
+	case status := <-statuses:
+		if status.status != "" || status.reason != "" {
+			t.Fatalf("recovered unreadable-lock status = %#v, want clear", status)
+		}
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("wake loop exited before clearing unreadable-lock status: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("same-generation validation did not clear unreadable-lock status")
+	}
+	if got := maintenanceInspections.Load(); got != wakeUnreadableGenerationNoticeThreshold+1 {
+		t.Fatalf(
+			"maintenance inspections after recovery = %d, want %d",
+			got,
+			wakeUnreadableGenerationNoticeThreshold+1,
+		)
+	}
+	close(stop)
+	if err := <-done; err != nil {
+		loopFinished = true
+		t.Fatalf("wake loop stop: %v", err)
+	}
+	loopFinished = true
+	if got := inspections.Load(); got < 2 {
+		t.Fatalf("wake generation inspections = %d, want retry after EMFILE", got)
+	}
+}
+
+func TestUnreadableGenerationNoticeUsesMaintenanceObservationThreshold(t *testing.T) {
+	statuses := make(chan wakeNotifierStatus, 2)
+	attention := make(chan string, 1)
+	unreadable := true
+	cfg := wakeConfig{
+		me:         "codex",
+		injectMode: wakeInjectModeRaw,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			inspection := wakeLockInspection{Exists: true}
+			if !unreadable {
+				inspection.fileInfo = wakeIdentityUnavailableFileInfo{name: ".wake.lock"}
+			}
+			return inspection
+		},
+		recordNotifierStatus: func(status, mode, reason string) error {
+			statuses <- wakeNotifierStatus{status: status, mode: mode, reason: reason}
+			return nil
+		},
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attention <- string(data)
+			return len(data), nil
+		},
+	}
+	var state wakeUnreadableGenerationNoticeState
+
+	for observation := 1; observation < wakeUnreadableGenerationNoticeThreshold; observation++ {
+		state.observe(&cfg)
+		select {
+		case status := <-statuses:
+			t.Fatalf(
+				"pre-threshold unreadable status after %d observations = %#v",
+				observation,
+				status,
+			)
+		default:
+		}
+	}
+
+	state.observe(&cfg)
+	select {
+	case status := <-statuses:
+		want := (wakeNotifierStatus{
+			status: "degraded",
+			mode:   wakeInjectModeRaw,
+			reason: "wake lock unreadable",
+		})
+		if status != want {
+			t.Fatalf("threshold unreadable status = %#v, want %#v", status, want)
+		}
+	default:
+		t.Fatal("maintenance threshold did not activate unreadable-lock status")
+	}
+	select {
+	case output := <-attention:
+		if !strings.Contains(
+			output,
+			"wake lock unreadable; injection paused; will resume automatically",
+		) {
+			t.Fatalf("threshold unreadable attention = %q", output)
+		}
+	default:
+		t.Fatal("maintenance threshold did not emit unreadable-lock attention")
+	}
+
+	unreadable = false
+	state.observe(&cfg)
+	select {
+	case status := <-statuses:
+		if status.status != "" || status.reason != "" {
+			t.Fatalf("recovered unreadable status = %#v, want clear", status)
+		}
+	default:
+		t.Fatal("readable validation did not clear degraded status")
+	}
+}
+
+func TestUnreadableGenerationNoticeRetriesFailedStatusWrites(t *testing.T) {
+	unreadable := true
+	setFailures := 1
+	clearFailures := 1
+	var statusAttempts []wakeNotifierStatus
+	cfg := wakeConfig{
+		me:         "codex",
+		injectMode: wakeInjectModeRaw,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			inspection := wakeLockInspection{Exists: true}
+			if !unreadable {
+				inspection.fileInfo = wakeIdentityUnavailableFileInfo{name: ".wake.lock"}
+			}
+			return inspection
+		},
+		recordNotifierStatus: func(status, mode, reason string) error {
+			statusAttempts = append(statusAttempts, wakeNotifierStatus{
+				status: status,
+				mode:   mode,
+				reason: reason,
+			})
+			if status != "" && setFailures > 0 {
+				setFailures--
+				return errors.New("temporary degraded-status write failure")
+			}
+			if status == "" && clearFailures > 0 {
+				clearFailures--
+				return errors.New("temporary status-clear failure")
+			}
+			return nil
+		},
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			return len(data), nil
+		},
+		diagnosticIsTTY: func() bool { return false },
+	}
+	var state wakeUnreadableGenerationNoticeState
+
+	for range wakeUnreadableGenerationNoticeThreshold {
+		state.observe(&cfg)
+	}
+	if state.statusActive {
+		t.Fatal("failed degraded-status write was recorded as active")
+	}
+	state.observe(&cfg)
+	if !state.statusActive {
+		t.Fatal("degraded status was not retried after a transient write failure")
+	}
+
+	unreadable = false
+	state.observe(&cfg)
+	if !state.statusActive {
+		t.Fatal("failed status clear was recorded as successful")
+	}
+	state.observe(&cfg)
+	if state.statusActive {
+		t.Fatal("status clear was not retried after a transient write failure")
+	}
+
+	if got, want := len(statusAttempts), 4; got != want {
+		t.Fatalf("status write attempts = %d, want %d", got, want)
+	}
+}
+
+func TestUnreadableGenerationNoticeRelinquishesWithoutOverwritingRecoveryStatus(t *testing.T) {
+	var inspected atomic.Bool
+	cfg := wakeConfig{
+		injectMode:            wakeInjectModeRaw,
+		inputRecoveryRequired: true,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			inspected.Store(true)
+			return wakeLockInspection{Exists: true}
+		},
+		recordNotifierStatus: func(_, _, _ string) error {
+			t.Fatal("relinquished unreadable-lock observer overwrote recovery status")
+			return nil
+		},
+	}
+	state := wakeUnreadableGenerationNoticeState{
+		consecutiveFailures: wakeUnreadableGenerationNoticeThreshold - 1,
+		statusActive:        true,
+		attentionDelivered:  true,
+	}
+
+	state.observe(&cfg)
+
+	if inspected.Load() {
+		t.Fatal("recovery-owned status performed an unreadable-lock inspection")
+	}
+	if state != (wakeUnreadableGenerationNoticeState{}) {
+		t.Fatalf("relinquished unreadable-lock state = %#v, want reset", state)
+	}
+}
+
 func TestRunWakeLoopRetriesUnknownTIOCSTIErrnoWithValidAuthority(t *testing.T) {
 	fixture := installWakeTerminalAuthorityFixture(t)
 	stop := make(chan struct{})
@@ -706,8 +1475,11 @@ func TestRunWakeLoopExplicitNoneNeverPromotes(t *testing.T) {
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	deliverWakeWatcherMessageForTest(t, root, "codex", "explicit-none", "claude")
 	ticks := make(chan time.Time)
+	maintenanceObserved := make(chan struct{}, 5)
 	attention := make(chan string, 2)
+	statuses := make(chan string, 1)
 	writes := make(chan string, 1)
+	var generationReads atomic.Int64
 	stop := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
@@ -718,8 +1490,17 @@ func TestRunWakeLoopExplicitNoneNeverPromotes(t *testing.T) {
 			requestedInjectMode: wakeInjectModeNone,
 			controlStop:         stop,
 			maintenanceTicks:    ticks,
+			inspectTerminalGeneration: func() wakeLockInspection {
+				generationReads.Add(1)
+				return wakeLockInspection{Exists: true}
+			},
 			preconditionCheck: func(cfg *wakeConfig) error {
+				maintenanceObserved <- struct{}{}
 				return wakeInjectionPreconditionCheck(cfg, func() bool { return true })
+			},
+			recordNotifierStatus: func(status, _, _ string) error {
+				statuses <- status
+				return nil
 			},
 			terminalWrite: func(data string) error {
 				writes <- data
@@ -740,13 +1521,27 @@ func TestRunWakeLoopExplicitNoneNeverPromotes(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("explicit-none wake emitted no attention")
 	}
-	ticks <- time.Now()
+	for range 5 {
+		ticks <- time.Now()
+		select {
+		case <-maintenanceObserved:
+		case err := <-done:
+			t.Fatalf("explicit-none wake exited on maintenance: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("explicit-none wake did not complete maintenance")
+		}
+	}
 	select {
 	case write := <-writes:
 		t.Fatalf("explicit none promoted and wrote %q", write)
+	case status := <-statuses:
+		t.Fatalf("explicit none reported unreadable-lock status %q", status)
 	case err := <-done:
 		t.Fatalf("explicit-none wake exited on maintenance: %v", err)
 	case <-time.After(100 * time.Millisecond):
+	}
+	if got := generationReads.Load(); got != 0 {
+		t.Fatalf("explicit none performed %d terminal-generation reads, want 0", got)
 	}
 	close(stop)
 	if err := <-done; err != nil {

--- a/internal/cli/wake_terminal_authority_unix.go
+++ b/internal/cli/wake_terminal_authority_unix.go
@@ -23,7 +23,6 @@ const (
 type wakeTerminalAuthorityLossError struct {
 	Kind   wakeTerminalAuthorityLossKind
 	Reason string
-	Err    error
 }
 
 type wakeTerminalTransientError struct {
@@ -43,14 +42,7 @@ func (err *wakeTerminalTransientError) Unwrap() error {
 }
 
 func (err *wakeTerminalAuthorityLossError) Error() string {
-	if err.Err != nil {
-		return fmt.Sprintf("wake terminal authority lost: %s: %v", err.Reason, err.Err)
-	}
 	return "wake terminal authority lost: " + err.Reason
-}
-
-func (err *wakeTerminalAuthorityLossError) Unwrap() error {
-	return err.Err
 }
 
 func isWakeTerminalAuthorityLoss(err error) bool {
@@ -130,11 +122,11 @@ func bindWakeTerminalAuthority(
 	controlStop <-chan struct{},
 ) (*wakeTerminalAuthority, error) {
 	if controlStop == nil {
-		return nil, newWakeTerminalAuthorityLoss("control-stop capability is missing", nil)
+		return nil, fmt.Errorf("bind wake terminal authority: control-stop capability is missing")
 	}
 	select {
 	case <-controlStop:
-		return nil, newWakeTerminalAuthorityLoss("control-stop capability is already closed", nil)
+		return nil, fmt.Errorf("bind wake terminal authority: control-stop capability is already closed")
 	default:
 	}
 	if !generation.Exists ||
@@ -142,16 +134,25 @@ func bindWakeTerminalAuthority(
 		generation.Lock.Generation == "" ||
 		generation.Root == "" ||
 		generation.Agent == "" {
-		return nil, newWakeTerminalAuthorityLoss("exact wake generation is unavailable", nil)
+		return nil, fmt.Errorf("bind wake terminal authority: exact wake generation is unavailable")
 	}
 	current := inspectWakeTerminalGeneration(generation.Root, generation.Agent)
+	if !current.Exists {
+		return nil, fmt.Errorf("bind wake terminal authority: wake generation disappeared")
+	}
+	if current.fileInfo == nil {
+		return nil, fmt.Errorf(
+			"inspect wake generation before terminal binding: %w",
+			wakeTerminalGenerationInspectionError(current),
+		)
+	}
 	if !sameWakeLockGeneration(generation, current) {
-		return nil, newWakeTerminalAuthorityLoss("wake generation changed before terminal binding", nil)
+		return nil, fmt.Errorf("bind wake terminal authority: wake generation changed")
 	}
 
 	tty, err := openWakeControllingTerminal()
 	if err != nil {
-		return nil, newWakeTerminalAuthorityLoss("open controlling terminal", err)
+		return nil, fmt.Errorf("open controlling terminal for wake binding: %w", err)
 	}
 	keep := false
 	defer func() {
@@ -162,19 +163,19 @@ func bindWakeTerminalAuthority(
 
 	info, err := tty.Stat()
 	if err != nil {
-		return nil, newWakeTerminalAuthorityLoss("inspect retained controlling terminal", err)
+		return nil, fmt.Errorf("inspect retained controlling terminal for wake binding: %w", err)
 	}
 	identity, ok := captureWakeTerminalIdentity(info)
 	if !ok {
-		return nil, newWakeTerminalAuthorityLoss("capture retained controlling-terminal identity", nil)
+		return nil, fmt.Errorf("capture retained controlling-terminal identity for wake binding")
 	}
 	fd := tty.Fd()
 	foregroundPGRP, err := wakeTerminalForegroundPGRP(fd)
 	if err != nil {
-		return nil, newWakeTerminalAuthorityLoss("inspect controlling-terminal foreground process group", err)
+		return nil, fmt.Errorf("inspect controlling-terminal foreground process group for wake binding: %w", err)
 	}
 	if foregroundPGRP <= 0 {
-		return nil, newWakeTerminalAuthorityLoss("controlling-terminal foreground process group is invalid", nil)
+		return nil, fmt.Errorf("bind wake terminal authority: controlling-terminal foreground process group is invalid")
 	}
 
 	keep = true
@@ -190,7 +191,7 @@ func bindWakeTerminalAuthority(
 
 func (authority *wakeTerminalAuthority) BeforeWrite() error {
 	if authority == nil {
-		return newWakeTerminalAuthorityLoss("terminal capability is missing", nil)
+		return newWakeTerminalAuthorityLoss("terminal capability is missing")
 	}
 	authority.mu.Lock()
 	defer authority.mu.Unlock()
@@ -199,7 +200,7 @@ func (authority *wakeTerminalAuthority) BeforeWrite() error {
 
 func (authority *wakeTerminalAuthority) Inject(text string) error {
 	if authority == nil {
-		return newWakeTerminalAuthorityLoss("terminal capability is missing", nil)
+		return newWakeTerminalAuthorityLoss("terminal capability is missing")
 	}
 	authority.mu.Lock()
 	defer authority.mu.Unlock()
@@ -229,7 +230,7 @@ func (authority *wakeTerminalAuthority) Inject(text string) error {
 
 func (authority *wakeTerminalAuthority) validateLocked() error {
 	if authority.closed || authority.tty == nil {
-		return newWakeTerminalAuthorityLoss("retained controlling terminal is closed", nil)
+		return newWakeTerminalAuthorityLoss("retained controlling terminal is closed")
 	}
 	select {
 	case <-authority.controlStop:
@@ -241,18 +242,27 @@ func (authority *wakeTerminalAuthority) validateLocked() error {
 		authority.generation.Root,
 		authority.generation.Agent,
 	)
+	if !currentGeneration.Exists {
+		return newWakeTerminalAuthorityLoss("wake generation disappeared")
+	}
+	if currentGeneration.fileInfo == nil {
+		return newWakeTerminalTransientFailure(
+			"inspect current wake generation",
+			wakeTerminalGenerationInspectionError(currentGeneration),
+		)
+	}
 	if !sameWakeLockGeneration(authority.generation, currentGeneration) {
-		return newWakeTerminalAuthorityLoss("wake generation changed", nil)
+		return newWakeTerminalAuthorityLoss("wake generation changed")
 	}
 	if authority.tty.Fd() != authority.fd {
-		return newWakeTerminalAuthorityLoss("retained controlling-terminal descriptor changed", nil)
+		return newWakeTerminalAuthorityLoss("retained controlling-terminal descriptor changed")
 	}
 	retainedInfo, err := authority.tty.Stat()
 	if err != nil {
 		return newWakeTerminalTransientFailure("inspect retained controlling terminal", err)
 	}
 	if !matchesWakeTerminalIdentity(authority.identity, retainedInfo) {
-		return newWakeTerminalAuthorityLoss("retained controlling-terminal identity changed", nil)
+		return newWakeTerminalAuthorityLoss("retained controlling-terminal identity changed")
 	}
 
 	currentTTY, err := openWakeControllingTerminal()
@@ -268,7 +278,7 @@ func (authority *wakeTerminalAuthority) validateLocked() error {
 		return newWakeTerminalTransientFailure("close current controlling-terminal check", closeErr)
 	}
 	if !matchesWakeTerminalIdentity(authority.identity, currentInfo) {
-		return newWakeTerminalAuthorityLoss("current controlling-terminal identity changed", nil)
+		return newWakeTerminalAuthorityLoss("current controlling-terminal identity changed")
 	}
 
 	foregroundPGRP, err := wakeTerminalForegroundPGRP(authority.fd)
@@ -305,11 +315,20 @@ func (authority *wakeTerminalAuthority) Close() error {
 	return err
 }
 
-func newWakeTerminalAuthorityLoss(reason string, err error) error {
+func wakeTerminalGenerationInspectionError(inspection wakeLockInspection) error {
+	if inspection.Reason != "" {
+		return errors.New(inspection.Reason)
+	}
+	return fmt.Errorf(
+		"wake lock status %q has no readable file identity",
+		inspection.Status,
+	)
+}
+
+func newWakeTerminalAuthorityLoss(reason string) error {
 	return &wakeTerminalAuthorityLossError{
 		Kind:   wakeTerminalAuthorityLossUnknown,
 		Reason: reason,
-		Err:    err,
 	}
 }
 

--- a/internal/cli/wake_terminal_authority_unix.go
+++ b/internal/cli/wake_terminal_authority_unix.go
@@ -26,6 +26,22 @@ type wakeTerminalAuthorityLossError struct {
 	Err    error
 }
 
+type wakeTerminalTransientError struct {
+	Reason string
+	Err    error
+}
+
+func (err *wakeTerminalTransientError) Error() string {
+	if err.Err != nil {
+		return fmt.Sprintf("wake terminal temporarily unavailable: %s: %v", err.Reason, err.Err)
+	}
+	return "wake terminal temporarily unavailable: " + err.Reason
+}
+
+func (err *wakeTerminalTransientError) Unwrap() error {
+	return err.Err
+}
+
 func (err *wakeTerminalAuthorityLossError) Error() string {
 	if err.Err != nil {
 		return fmt.Sprintf("wake terminal authority lost: %s: %v", err.Reason, err.Err)
@@ -192,19 +208,21 @@ func (authority *wakeTerminalAuthority) Inject(text string) error {
 	}
 	if err := injectWakeTerminalFD(authority.fd, text); err != nil {
 		var injectionErr *tiocstiInjectionError
-		if errors.As(err, &injectionErr) &&
-			injectionErr.Progress == 0 &&
-			(errors.Is(err, syscall.EIO) || errors.Is(err, syscall.EPERM)) {
-			// EIO and EPERM are ambiguous: the kernel may reject TIOCSTI, or
-			// the terminal authority may have changed. Only classify the
-			// injector after every retained/current identity and PGRP check
-			// still passes after the failed zero-progress ioctl.
+		if errors.As(err, &injectionErr) {
+			// Every TIOCSTI error is ambiguous until the retained authority is
+			// revalidated. Once authority still holds, preserve unclassified
+			// errors and accepted-byte progress for the loop's bounded retry
+			// policy instead of relabeling an effect failure as ownership loss.
 			if validateErr := authority.validateLocked(); validateErr != nil {
 				return validateErr
 			}
+		}
+		if injectionErr != nil &&
+			injectionErr.Progress == 0 &&
+			(errors.Is(err, syscall.EIO) || errors.Is(err, syscall.EPERM)) {
 			return newWakeInjectorUnsupportedError(err)
 		}
-		return newWakeTerminalAuthorityLoss("inject through retained controlling terminal", err)
+		return err
 	}
 	return nil
 }
@@ -231,7 +249,7 @@ func (authority *wakeTerminalAuthority) validateLocked() error {
 	}
 	retainedInfo, err := authority.tty.Stat()
 	if err != nil {
-		return newWakeTerminalAuthorityLoss("inspect retained controlling terminal", err)
+		return newWakeTerminalTransientFailure("inspect retained controlling terminal", err)
 	}
 	if !matchesWakeTerminalIdentity(authority.identity, retainedInfo) {
 		return newWakeTerminalAuthorityLoss("retained controlling-terminal identity changed", nil)
@@ -239,15 +257,15 @@ func (authority *wakeTerminalAuthority) validateLocked() error {
 
 	currentTTY, err := openWakeControllingTerminal()
 	if err != nil {
-		return newWakeTerminalAuthorityLoss("re-open current controlling terminal", err)
+		return newWakeTerminalTransientFailure("re-open current controlling terminal", err)
 	}
 	currentInfo, statErr := currentTTY.Stat()
 	closeErr := currentTTY.Close()
 	if statErr != nil {
-		return newWakeTerminalAuthorityLoss("inspect current controlling terminal", statErr)
+		return newWakeTerminalTransientFailure("inspect current controlling terminal", statErr)
 	}
 	if closeErr != nil {
-		return newWakeTerminalAuthorityLoss("close current controlling-terminal check", closeErr)
+		return newWakeTerminalTransientFailure("close current controlling-terminal check", closeErr)
 	}
 	if !matchesWakeTerminalIdentity(authority.identity, currentInfo) {
 		return newWakeTerminalAuthorityLoss("current controlling-terminal identity changed", nil)
@@ -255,7 +273,10 @@ func (authority *wakeTerminalAuthority) validateLocked() error {
 
 	foregroundPGRP, err := wakeTerminalForegroundPGRP(authority.fd)
 	if err != nil {
-		return newWakeTerminalAuthorityLoss("recheck controlling-terminal foreground process group", err)
+		return newWakeTerminalTransientFailure(
+			"recheck controlling-terminal foreground process group",
+			err,
+		)
 	}
 	if foregroundPGRP != authority.foregroundPGRP {
 		return newWakeTerminalForegroundPGRPChangedLoss(
@@ -287,6 +308,13 @@ func (authority *wakeTerminalAuthority) Close() error {
 func newWakeTerminalAuthorityLoss(reason string, err error) error {
 	return &wakeTerminalAuthorityLossError{
 		Kind:   wakeTerminalAuthorityLossUnknown,
+		Reason: reason,
+		Err:    err,
+	}
+}
+
+func newWakeTerminalTransientFailure(reason string, err error) error {
+	return &wakeTerminalTransientError{
 		Reason: reason,
 		Err:    err,
 	}

--- a/internal/cli/wake_terminal_authority_unix_test.go
+++ b/internal/cli/wake_terminal_authority_unix_test.go
@@ -63,6 +63,36 @@ func TestWakeTerminalAuthorityInjectsThroughRetainedFD(t *testing.T) {
 	}
 }
 
+func TestWakeTerminalAuthorityTreatsCurrentTTYOpenFailureAsTransient(t *testing.T) {
+	fixture := installWakeTerminalAuthorityFixture(t)
+	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = authority.Close() })
+
+	stableOpen := openWakeControllingTerminal
+	var calls atomic.Int64
+	openWakeControllingTerminal = func() (*os.File, error) {
+		if calls.Add(1) == 1 {
+			return nil, syscall.EMFILE
+		}
+		return stableOpen()
+	}
+
+	err = authority.BeforeWrite()
+	var transient *wakeTerminalTransientError
+	if !errors.As(err, &transient) || !errors.Is(err, syscall.EMFILE) {
+		t.Fatalf("BeforeWrite error = %T %v, want transient EMFILE", err, err)
+	}
+	if isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("transient current-tty open failure became authority loss: %v", err)
+	}
+	if err := authority.BeforeWrite(); err != nil {
+		t.Fatalf("BeforeWrite did not recover after transient open failure: %v", err)
+	}
+}
+
 func TestWakeTerminalAuthorityClassifiesUnsupportedOnlyAfterZeroProgressAndRevalidation(t *testing.T) {
 	for _, errno := range []error{syscall.EIO, syscall.EPERM} {
 		t.Run(errno.Error(), func(t *testing.T) {
@@ -112,7 +142,7 @@ func TestWakeTerminalAuthorityEIOWithInvalidCurrentKeepsAuthorityOutcome(t *test
 	}
 }
 
-func TestWakeTerminalAuthorityEIOAfterPartialProgressIsUncertain(t *testing.T) {
+func TestWakeTerminalAuthorityEIOAfterPartialProgressPreservesProgress(t *testing.T) {
 	fixture := installWakeTerminalAuthorityFixture(t)
 	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
 	if err != nil {
@@ -128,9 +158,12 @@ func TestWakeTerminalAuthorityEIOAfterPartialProgressIsUncertain(t *testing.T) {
 	if errors.As(err, &unsupported) {
 		t.Fatalf("partial progress misclassified as injector unsupported: %v", err)
 	}
-	var authorityLoss *wakeTerminalAuthorityLossError
-	if !errors.As(err, &authorityLoss) {
-		t.Fatalf("Inject error = %T %v, want uncertain authority outcome", err, err)
+	var progress *tiocstiInjectionError
+	if !errors.As(err, &progress) || progress.Progress != 1 {
+		t.Fatalf("Inject error = %T %v, want one accepted byte", err, err)
+	}
+	if isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("valid retained authority misclassified partial progress as ownership loss: %v", err)
 	}
 }
 

--- a/internal/cli/wake_terminal_authority_unix_test.go
+++ b/internal/cli/wake_terminal_authority_unix_test.go
@@ -65,32 +65,241 @@ func TestWakeTerminalAuthorityInjectsThroughRetainedFD(t *testing.T) {
 
 func TestWakeTerminalAuthorityTreatsCurrentTTYOpenFailureAsTransient(t *testing.T) {
 	fixture := installWakeTerminalAuthorityFixture(t)
-	authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+	stop := make(chan struct{})
+	authority, err := bindWakeTerminalAuthority(fixture.generation, stop)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = authority.Close() })
 
+	inspectWakeTerminalGeneration = func(root, agent string) wakeLockInspection {
+		return inspectWakeLockWithReader(
+			root,
+			agent,
+			fixture.generation.LockPath,
+			func() ([]byte, os.FileInfo, error) {
+				return readWakeLockFileWithInfo(fixture.generation.LockPath)
+			},
+		)
+	}
 	stableOpen := openWakeControllingTerminal
 	var calls atomic.Int64
+	failureObserved := make(chan struct{}, 1)
 	openWakeControllingTerminal = func() (*os.File, error) {
 		if calls.Add(1) == 1 {
+			failureObserved <- struct{}{}
 			return nil, syscall.EMFILE
 		}
 		return stableOpen()
 	}
+	injected := make(chan struct{}, 1)
+	injectWakeTerminalFD = func(uintptr, string) error {
+		select {
+		case injected <- struct{}{}:
+		default:
+		}
+		return nil
+	}
 
-	err = authority.BeforeWrite()
-	var transient *wakeTerminalTransientError
-	if !errors.As(err, &transient) || !errors.Is(err, syscall.EMFILE) {
-		t.Fatalf("BeforeWrite error = %T %v, want transient EMFILE", err, err)
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverWakeWatcherMessageForTest(t, root, "codex", "transient-current-tty-open", "claude")
+	done := make(chan error, 1)
+	ticks := make(chan time.Time)
+	maintenanceObserved := make(chan struct{}, 2)
+	var doorbellNow atomic.Int64
+	doorbellNow.Store(time.Now().UnixNano())
+	loopFinished := false
+	go func() {
+		done <- runWakeLoop(wakeConfig{
+			root:                root,
+			me:                  "codex",
+			session:             "session1",
+			injectMode:          wakeInjectModeRaw,
+			controlStop:         stop,
+			beforeTerminalWrite: authority.BeforeWrite,
+			terminalWrite:       authority.Inject,
+			maintenanceTicks:    ticks,
+			doorbellNow: func() time.Time {
+				return time.Unix(0, doorbellNow.Load())
+			},
+			preconditionCheck: func(*wakeConfig) error {
+				maintenanceObserved <- struct{}{}
+				return nil
+			},
+			attentionIsTTY: func() bool { return false },
+			attentionWrite: func(data []byte) (int, error) {
+				return len(data), nil
+			},
+		})
+	}()
+	t.Cleanup(func() {
+		if loopFinished {
+			return
+		}
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop")
+		}
+	})
+
+	select {
+	case <-failureObserved:
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("wake loop exited before transient current-tty open failure: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not exercise transient current-tty open failure")
 	}
-	if isWakeTerminalAuthorityLoss(err) {
-		t.Fatalf("transient current-tty open failure became authority loss: %v", err)
+	// Let the failed attempt finish recording its retry deadline before
+	// advancing the fake clock. Signalling from the failing open itself races
+	// that bookkeeping under the race detector.
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("transient current-tty open failure killed wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept maintenance retry")
 	}
-	if err := authority.BeforeWrite(); err != nil {
-		t.Fatalf("BeforeWrite did not recover after transient open failure: %v", err)
+	select {
+	case <-maintenanceObserved:
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("transient current-tty open failure killed wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not finish maintenance synchronization")
 	}
+	doorbellNow.Add(int64(2 * wakeDoorbellAttentionRetryBase))
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("transient current-tty open failure killed wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept due maintenance retry")
+	}
+	select {
+	case <-injected:
+	case err := <-done:
+		loopFinished = true
+		t.Fatalf("transient current-tty open failure killed wake loop: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not retry after transient current-tty open failure")
+	}
+	close(stop)
+	if err := <-done; err != nil {
+		loopFinished = true
+		t.Fatalf("wake loop stop: %v", err)
+	}
+	loopFinished = true
+	if got := calls.Load(); got < 2 {
+		t.Fatalf("current-tty open calls = %d, want retry after EMFILE", got)
+	}
+}
+
+func TestBindWakeTerminalAuthorityKeepsSetupFailuresOutOfRuntimeLossType(t *testing.T) {
+	t.Run("generation disappeared", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		fixture.current = wakeLockInspection{
+			Exists:   false,
+			Status:   wakeLockMissing,
+			Root:     fixture.generation.Root,
+			Agent:    fixture.generation.Agent,
+			LockPath: fixture.generation.LockPath,
+		}
+
+		authority, err := bindWakeTerminalAuthority(
+			fixture.generation,
+			make(chan struct{}),
+		)
+		if authority != nil {
+			_ = authority.Close()
+			t.Fatal("missing generation returned terminal authority")
+		}
+		if err == nil || isWakeTerminalAuthorityLoss(err) {
+			t.Fatalf("bind-time generation disappearance = %T %v, want ordinary setup error", err, err)
+		}
+	})
+
+	t.Run("generation changed", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		fixture.current.Lock.Generation = "replacement-generation"
+
+		authority, err := bindWakeTerminalAuthority(
+			fixture.generation,
+			make(chan struct{}),
+		)
+		if authority != nil {
+			_ = authority.Close()
+			t.Fatal("changed generation returned terminal authority")
+		}
+		if err == nil || isWakeTerminalAuthorityLoss(err) {
+			t.Fatalf("bind-time generation change = %T %v, want ordinary setup error", err, err)
+		}
+	})
+
+	t.Run("generation read", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		inspectWakeTerminalGeneration = func(root, agent string) wakeLockInspection {
+			return inspectWakeLockWithReader(
+				root,
+				agent,
+				fixture.generation.LockPath,
+				func() ([]byte, os.FileInfo, error) {
+					return nil, nil, syscall.EMFILE
+				},
+			)
+		}
+
+		authority, err := bindWakeTerminalAuthority(
+			fixture.generation,
+			make(chan struct{}),
+		)
+		if authority != nil {
+			_ = authority.Close()
+			t.Fatal("generation-read failure returned terminal authority")
+		}
+		if err == nil {
+			t.Fatal("generation-read failure returned nil error")
+		}
+		if isWakeTerminalAuthorityLoss(err) {
+			t.Fatalf("startup generation-read failure became runtime authority loss: %v", err)
+		}
+	})
+
+	t.Run("open controlling terminal", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		openWakeControllingTerminal = func() (*os.File, error) {
+			return nil, syscall.EMFILE
+		}
+
+		authority, err := bindWakeTerminalAuthority(
+			fixture.generation,
+			make(chan struct{}),
+		)
+		if authority != nil {
+			_ = authority.Close()
+			t.Fatal("terminal-open failure returned terminal authority")
+		}
+		if !errors.Is(err, syscall.EMFILE) {
+			t.Fatalf("terminal-open error = %v, want wrapped EMFILE", err)
+		}
+		if isWakeTerminalAuthorityLoss(err) {
+			t.Fatalf("startup terminal-open failure became runtime authority loss: %v", err)
+		}
+	})
 }
 
 func TestWakeTerminalAuthorityClassifiesUnsupportedOnlyAfterZeroProgressAndRevalidation(t *testing.T) {
@@ -137,8 +346,8 @@ func TestWakeTerminalAuthorityEIOWithInvalidCurrentKeepsAuthorityOutcome(t *test
 	}
 	var authorityLoss *wakeTerminalAuthorityLossError
 	if !errors.As(err, &authorityLoss) ||
-		!strings.Contains(err.Error(), "generation changed") {
-		t.Fatalf("Inject error = %T %v, want generation authority loss", err, err)
+		!strings.Contains(err.Error(), "generation disappeared") {
+		t.Fatalf("Inject error = %T %v, want missing-generation authority loss", err, err)
 	}
 }
 
@@ -552,6 +761,33 @@ func TestWakeTerminalAuthorityRefusesChangedCurrentTTYIdentity(t *testing.T) {
 }
 
 func TestWakeTerminalAuthorityRefusesChangedGenerationAndStoppedControl(t *testing.T) {
+	t.Run("generation missing", func(t *testing.T) {
+		fixture := installWakeTerminalAuthorityFixture(t)
+		authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = authority.Close() })
+
+		fixture.current = wakeLockInspection{
+			Exists:   false,
+			Status:   wakeLockMissing,
+			Reason:   "wake lock does not exist",
+			Root:     fixture.generation.Root,
+			Agent:    fixture.generation.Agent,
+			LockPath: fixture.generation.LockPath,
+		}
+		err = authority.Inject("must-not-arrive")
+		if !isWakeTerminalAuthorityLoss(err) ||
+			classifyWakeFailure(err) != wakeFailureFatal ||
+			!strings.Contains(err.Error(), "wake generation disappeared") {
+			t.Fatalf("missing generation error = %v, want fatal disappearance", err)
+		}
+		if len(fixture.injections) != 0 {
+			t.Fatalf("missing generation injected: %#v", fixture.injections)
+		}
+	})
+
 	t.Run("generation", func(t *testing.T) {
 		fixture := installWakeTerminalAuthorityFixture(t)
 		authority, err := bindWakeTerminalAuthority(fixture.generation, make(chan struct{}))
@@ -563,6 +799,7 @@ func TestWakeTerminalAuthorityRefusesChangedGenerationAndStoppedControl(t *testi
 		fixture.current.Lock.Generation = "replacement-generation"
 		err = authority.Inject("must-not-arrive")
 		if !isWakeTerminalAuthorityLoss(err) ||
+			classifyWakeFailure(err) != wakeFailureFatal ||
 			!strings.Contains(err.Error(), "wake generation changed") {
 			t.Fatalf("changed generation error = %v", err)
 		}
@@ -598,7 +835,7 @@ func TestWakeTerminalControlStoppedClassificationIsStructural(t *testing.T) {
 		t.Fatalf("typed stopped-control loss was not classified: %v", stopped)
 	}
 
-	sameReasonOnly := newWakeTerminalAuthorityLoss("wake control stopped", nil)
+	sameReasonOnly := newWakeTerminalAuthorityLoss("wake control stopped")
 	if isWakeTerminalControlStopped(sameReasonOnly) {
 		t.Fatalf("reason-only authority loss was classified as stopped control: %v", sameReasonOnly)
 	}
@@ -710,7 +947,7 @@ func TestRunWakeLoopTerminatesOnTerminalAuthorityLoss(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loss := newWakeTerminalAuthorityLoss("test authority loss", nil)
+	loss := newWakeTerminalAuthorityLoss("test authority loss")
 	terminalWriteCalled := false
 	attentionWrites := 0
 	err = runWakeLoop(wakeConfig{

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -34,6 +34,7 @@ var (
 	getWakeProcessSID               = unix.Getsid
 	wakeTIOCSTIAvailable            = func() bool { return tiocsti.Available() }
 	wakeInputIsTTY                  = func() bool { return tiocsti.IsTTY() }
+	newWakeBaselineEventWatcher     = newWakePathEventWatcher
 )
 
 type fsnotifyWakeEventWatcher struct {
@@ -50,6 +51,18 @@ func (w *fsnotifyWakeEventWatcher) Errors() <-chan error {
 
 func (w *fsnotifyWakeEventWatcher) Close() error {
 	return w.watcher.Close()
+}
+
+func newWakePathEventWatcher(path string) (wakeEventWatcher, error) {
+	native, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if err := native.Add(path); err != nil {
+		_ = native.Close()
+		return nil, err
+	}
+	return &fsnotifyWakeEventWatcher{watcher: native}, nil
 }
 
 type wakeRepairResult struct {
@@ -1604,6 +1617,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	if err != nil {
 		return UsageError("%v", err)
 	}
+	requestedInjectMode := injectMode
 
 	interruptLabel := strings.TrimSpace(*interruptLabelFlag)
 	interruptPriority := strings.ToLower(strings.TrimSpace(*interruptPriorityFlag))
@@ -1992,37 +2006,38 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		defer func() { _ = terminalAuthority.Close() }()
 	}
 	cfg := wakeConfig{
-		me:                 me,
-		root:               root,
-		session:            resolveSessionName(root),
-		injectCmd:          *injectCmdFlag,
-		injectVia:          injectVia,
-		injectArgs:         []string(injectArgFlags),
-		wakeOwner:          requestedOwner,
-		injectTimeout:      *injectTimeoutFlag,
-		bell:               *bellFlag,
-		debounce:           *debounceFlag,
-		previewLen:         *previewLenFlag,
-		strict:             common.Strict,
-		fallbackWarn:       true,
-		injectMode:         injectMode,
-		debug:              *debugFlag,
-		deferWhileInput:    *deferWhileInputFlag,
-		inputQuietFor:      *inputQuietForFlag,
-		inputPollInterval:  *inputPollIntervalFlag,
-		inputMaxHold:       *inputMaxHoldFlag,
-		interrupt:          *interruptFlag,
-		interruptLabel:     interruptLabel,
-		interruptPriority:  interruptPriority,
-		interruptKey:       interruptKey,
-		interruptNotice:    strings.TrimSpace(*interruptNoticeFlag),
-		interruptCooldown:  *interruptCooldownFlag,
-		controlStop:        controlStop,
-		terminalGeneration: currentWake.Lock.Generation,
-		terminalTTY:        currentWake.Lock.TTY,
-		baselineRequested:  *baselineExistingFlag || repairLineage != nil,
-		baselineInherited:  repairLineage != nil,
-		retainedAgent:      activeAgentDir,
+		me:                  me,
+		root:                root,
+		session:             resolveSessionName(root),
+		injectCmd:           *injectCmdFlag,
+		injectVia:           injectVia,
+		injectArgs:          []string(injectArgFlags),
+		wakeOwner:           requestedOwner,
+		injectTimeout:       *injectTimeoutFlag,
+		bell:                *bellFlag,
+		debounce:            *debounceFlag,
+		previewLen:          *previewLenFlag,
+		strict:              common.Strict,
+		fallbackWarn:        true,
+		injectMode:          injectMode,
+		requestedInjectMode: requestedInjectMode,
+		debug:               *debugFlag,
+		deferWhileInput:     *deferWhileInputFlag,
+		inputQuietFor:       *inputQuietForFlag,
+		inputPollInterval:   *inputPollIntervalFlag,
+		inputMaxHold:        *inputMaxHoldFlag,
+		interrupt:           *interruptFlag,
+		interruptLabel:      interruptLabel,
+		interruptPriority:   interruptPriority,
+		interruptKey:        interruptKey,
+		interruptNotice:     strings.TrimSpace(*interruptNoticeFlag),
+		interruptCooldown:   *interruptCooldownFlag,
+		controlStop:         controlStop,
+		terminalGeneration:  currentWake.Lock.Generation,
+		terminalTTY:         currentWake.Lock.TTY,
+		baselineRequested:   *baselineExistingFlag || repairLineage != nil,
+		baselineInherited:   repairLineage != nil,
+		retainedAgent:       activeAgentDir,
 		recordNotifierStatus: func(status, mode, reason string) error {
 			return setWakeNotifierStatusInDir(activeAgentDir, me, status, mode, reason)
 		},
@@ -2381,6 +2396,48 @@ func failWakeOnWatcherError(cfg *wakeConfig, context string, cause error) error 
 	return fmt.Errorf("%s: %w", context, cause)
 }
 
+type wakeFailureDisposition uint8
+
+const (
+	// Unknown failures retry by default. An admitted wake may abandon its
+	// durable inbox obligation only after proven ownership transfer.
+	wakeFailureRetry wakeFailureDisposition = iota
+	wakeFailureDegrade
+	wakeFailureFatal
+)
+
+type wakeOwnershipLossError struct {
+	err error
+}
+
+func (err *wakeOwnershipLossError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeOwnershipLossError) Unwrap() error {
+	return err.err
+}
+
+func classifyWakeFailure(err error) wakeFailureDisposition {
+	if err == nil {
+		return wakeFailureRetry
+	}
+	var ownershipLoss *wakeOwnershipLossError
+	if errors.As(err, &ownershipLoss) ||
+		(isWakeTerminalAuthorityLoss(err) &&
+			!isWakeTerminalForegroundPGRPChanged(err) &&
+			!isWakeTerminalControlStopped(err)) {
+		return wakeFailureFatal
+	}
+	var unsupported *wakeInjectorUnsupportedError
+	if isWakeInputDemotionBlocked(err) ||
+		isWakeTerminalProgressUncertain(err) ||
+		errors.As(err, &unsupported) {
+		return wakeFailureDegrade
+	}
+	return wakeFailureRetry
+}
+
 func pendingWakeWatcherError(watcher wakeAdmissionWatcher) error {
 	if watcher == nil {
 		return fmt.Errorf("wake watcher is unavailable at admission")
@@ -2422,6 +2479,23 @@ func parseInterruptKey(raw string) (string, error) {
 		return "", nil
 	default:
 		return "", fmt.Errorf("invalid interrupt-cmd %q (use ctrl-c or none)", raw)
+	}
+}
+
+func waitWakeRetry(
+	controlStop <-chan struct{},
+	signals <-chan os.Signal,
+	delay time.Duration,
+) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-controlStop:
+		return false
+	case <-signals:
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 
@@ -2479,77 +2553,191 @@ func runWakeLoop(cfg wakeConfig) error {
 		} else if err := validateCanonicalWakeAgentDir(ordinaryAgentDir); err != nil {
 			return fmt.Errorf("validate acquired wake agent authority: %w", err)
 		}
-		var err error
-		ordinaryInboxDir, watcher, err = openWatchedWakeInboxDir(ordinaryAgentDir)
-		if err != nil {
-			return fmt.Errorf("failed to create ordinary wake inbox watcher: %w", err)
-		}
-		cfg.retainedInbox = ordinaryInboxDir
 		if cfg.touchPresence == nil {
 			cfg.touchPresence = func() error {
 				return touchWakePresenceInDir(ordinaryAgentDir, cfg.me)
 			}
 		}
-	} else if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
-		var err error
-		watcher, err = retained.NewWatcher()
-		if err != nil {
-			return fmt.Errorf("failed to create retained watcher: %w", err)
-		}
-	} else {
+	} else if _, ok := cfg.retainedInbox.(*wakeInboxDir); !ok {
 		if err := os.MkdirAll(inboxNew, 0o700); err != nil {
 			return err
 		}
-		native, err := fsnotify.NewWatcher()
-		if err != nil {
-			return fmt.Errorf("failed to create watcher: %w", err)
+	}
+
+	openMainWatcher := func() error {
+		if ordinaryRecoverable {
+			inboxDir, err := openWakeRepairInboxDir(ordinaryAgentDir)
+			if err != nil {
+				if validateErr := validateCanonicalWakeAgentDir(ordinaryAgentDir); validateErr != nil {
+					return &wakeOwnershipLossError{err: fmt.Errorf(
+						"validate acquired wake agent authority after inbox failure: %w",
+						validateErr,
+					)}
+				}
+				return &wakeOwnershipLossError{err: fmt.Errorf(
+					"open acquired wake inbox capability: %w",
+					err,
+				)}
+			}
+			nextWatcher, err := newWakeInboxEventWatcher(inboxDir)
+			if err != nil {
+				return errors.Join(err, inboxDir.Close())
+			}
+			ordinaryInboxDir = inboxDir
+			watcher = nextWatcher
+			cfg.retainedInbox = inboxDir
+			return nil
 		}
-		if err := native.Add(inboxNew); err != nil {
-			_ = native.Close()
-			return fmt.Errorf("failed to watch inbox: %w", err)
+		if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
+			nextWatcher, err := newWakeInboxEventWatcher(retained)
+			if err != nil {
+				if validateErr := retained.ValidateCanonical(); validateErr != nil {
+					return &wakeOwnershipLossError{err: fmt.Errorf(
+						"validate retained wake inbox authority after watcher failure: %w",
+						validateErr,
+					)}
+				}
+				return err
+			}
+			watcher = nextWatcher
+			return nil
 		}
-		watcher = &fsnotifyWakeEventWatcher{watcher: native}
+
+		nextWatcher, err := newWakePathEventWatcher(inboxNew)
+		if err == nil {
+			watcher = nextWatcher
+		}
+		return err
+	}
+	armMainWatcher := func() (bool, error) {
+		for failures := uint(1); ; failures++ {
+			err := openMainWatcher()
+			if err == nil {
+				return true, nil
+			}
+			if classifyWakeFailure(err) == wakeFailureFatal {
+				return false, err
+			}
+			delay := wakeStartupRetryBackoff(failures)
+			_ = writeWakeDiagnostic(
+				&cfg,
+				"amq wake: create wake inbox watcher: %v; retrying in %s\n",
+				err,
+				delay,
+			)
+			if !waitWakeRetry(cfg.controlStop, sigCh, delay) {
+				return false, nil
+			}
+		}
+	}
+	armed, err := armMainWatcher()
+	if err != nil {
+		return err
+	}
+	if !armed {
+		return nil
 	}
 	if cfg.baselineRequested && !cfg.baselineInherited {
 		retained, ok := cfg.retainedInbox.(*wakeInboxDir)
 		if !ok {
 			return fmt.Errorf("wake baseline requires a retained inbox capability")
 		}
-		native, err := fsnotify.NewWatcher()
-		if err != nil {
-			return fmt.Errorf("failed to create startup baseline watcher: %w", err)
+		var failures uint
+		historyUncertain := false
+		for {
+			var prepareErr error
+			startupBaselineWatcher, prepareErr = newWakeBaselineEventWatcher(retained.path)
+			if prepareErr == nil {
+				prepareErr = retained.ValidateCanonical()
+			}
+			if prepareErr == nil {
+				// The startup boundary is watcher installation, not lock
+				// acquisition; messages delivered in between are intentionally
+				// treated as startup backlog.
+				prepareErr = prepareWakeBaselineEvents(
+					&cfg,
+					startupBaselineWatcher.Events(),
+					startupBaselineWatcher.Errors(),
+					inboxNew,
+				)
+			}
+			if startupBaselineWatcher != nil {
+				closeErr := startupBaselineWatcher.Close()
+				startupBaselineWatcher = nil
+				if prepareErr == nil && closeErr != nil {
+					_ = writeWakeDiagnostic(
+						&cfg,
+						"amq wake: close startup baseline watcher: %v; continuing\n",
+						closeErr,
+					)
+				}
+			}
+			if prepareErr == nil {
+				if historyUncertain {
+					// The original watcher lost event history. Reaching a new
+					// barrier proves readiness, but treating all backlog as new
+					// is the only lossless delivery fallback.
+					cfg.baselineExisting = nil
+				}
+				break
+			}
+			cfg.baselineExisting = nil
+			if err := retained.ValidateCanonical(); err != nil {
+				return &wakeOwnershipLossError{err: fmt.Errorf(
+					"validate startup baseline watcher authority: %w",
+					err,
+				)}
+			}
+			historyUncertain = true
+			failures++
+			delay := wakeStartupRetryBackoff(failures)
+			_ = writeWakeDiagnostic(
+				&cfg,
+				"amq wake: startup baseline watcher failed: %v; retrying in %s\n",
+				prepareErr,
+				delay,
+			)
+			if !waitWakeRetry(cfg.controlStop, sigCh, delay) {
+				return nil
+			}
 		}
-		if err := native.Add(retained.path); err != nil {
-			_ = native.Close()
-			return fmt.Errorf("failed to watch retained startup baseline inbox: %w", err)
-		}
-		startupBaselineWatcher = &fsnotifyWakeEventWatcher{watcher: native}
-		if err := retained.ValidateCanonical(); err != nil {
-			_ = startupBaselineWatcher.Close()
-			startupBaselineWatcher = nil
-			return fmt.Errorf("validate startup baseline watcher authority: %w", err)
-		}
-	}
-
-	// The startup boundary is watcher installation, not lock acquisition;
-	// messages delivered in between are intentionally treated as startup backlog.
-	baselineWatcher := watcher
-	if startupBaselineWatcher != nil {
-		baselineWatcher = startupBaselineWatcher
-	}
-	if err := prepareWakeBaselineEvents(
+	} else if err := prepareWakeBaselineEvents(
 		&cfg,
-		baselineWatcher.Events(),
-		baselineWatcher.Errors(),
+		watcher.Events(),
+		watcher.Errors(),
 		inboxNew,
 	); err != nil {
 		return err
 	}
-	if startupBaselineWatcher != nil {
-		if err := startupBaselineWatcher.Close(); err != nil {
-			return fmt.Errorf("close startup baseline watcher: %w", err)
+	// A separate baseline watcher can take long enough for the main watcher to
+	// fail before admission. Rearm it and discard startup tombstones so messages
+	// from the uncertain interval are delivered instead of publishing false
+	// readiness with an already-dead watcher.
+	for {
+		if err := pendingWakeWatcherError(watcher); err == nil {
+			break
+		} else {
+			cfg.baselineExisting = nil
+			_ = watcher.Close()
+			watcher = nil
+			if ordinaryRecoverable {
+				_ = ordinaryInboxDir.Close()
+				ordinaryInboxDir = nil
+				cfg.retainedInbox = nil
+			}
+			_ = writeWakeDiagnostic(
+				&cfg,
+				"amq wake: main watcher failed before admission: %v; rearming\n",
+				err,
+			)
 		}
-		startupBaselineWatcher = nil
+		armed, err := armMainWatcher()
+		if err != nil {
+			return err
+		}
+		if !armed {
+			return nil
+		}
 	}
 	if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
 		if err := retained.ValidateCanonical(); err != nil {
@@ -2699,15 +2887,17 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		doorbellTimerC = doorbellTimer.C
 	}
-	retryOrdinaryWatcher := func(context string, cause error) {
+	retryWatcher := func(context string, cause error) {
 		cfg.baselineExisting = nil
 		if watcher != nil {
 			_ = watcher.Close()
 			watcher = nil
 		}
-		_ = ordinaryInboxDir.Close()
-		ordinaryInboxDir = nil
-		cfg.retainedInbox = nil
+		if ordinaryRecoverable {
+			_ = ordinaryInboxDir.Close()
+			ordinaryInboxDir = nil
+			cfg.retainedInbox = nil
+		}
 		pendingNotify = true
 		clearTerminalAuthorityRetry()
 		inboxScanFailures++
@@ -2719,40 +2909,73 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		_ = writeWakeDiagnostic(&cfg, "amq wake: %s: %v; retrying watcher setup\n", context, cause)
 	}
-	rebindOrdinaryWatcher := func() (bool, error) {
-		if !ordinaryRecoverable || watcher != nil {
+	scheduleWatcherRebindFailure := func(context string, cause error) {
+		pendingNotify = true
+		inboxScanFailures++
+		scheduleInboxScanRetry(wakeInboxScanRetryBackoff(inboxScanFailures))
+		clearDoorbellDeadline()
+		_ = writeWakeDiagnostic(
+			&cfg,
+			"amq wake: %s: %v; retrying watcher setup\n",
+			context,
+			cause,
+		)
+	}
+	rebindWatcher := func() (bool, error) {
+		if watcher != nil {
 			return true, nil
 		}
-		if err := validateCanonicalWakeAgentDir(ordinaryAgentDir); err != nil {
-			return false, failWakeOnWatcherError(
-				&cfg,
-				"ordinary wake agent authority changed while rearming watcher",
-				err,
-			)
-		}
-		inboxDir, nextWatcher, err := openWatchedWakeInboxDir(ordinaryAgentDir)
-		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				return false, failWakeOnWatcherError(
+		if ordinaryRecoverable {
+			if err := validateCanonicalWakeAgentDir(ordinaryAgentDir); err != nil {
+				return false, &wakeOwnershipLossError{err: failWakeOnWatcherError(
 					&cfg,
-					"failed to rearm ordinary wake inbox watcher",
+					"ordinary wake agent authority changed while rearming watcher",
+					err,
+				)}
+			}
+			inboxDir, nextWatcher, err := openWatchedWakeInboxDir(ordinaryAgentDir)
+			if err != nil {
+				scheduleWatcherRebindFailure(
+					"ordinary wake inbox is unavailable while rearming watcher",
 					err,
 				)
+				return false, nil
 			}
-			pendingNotify = true
-			inboxScanFailures++
-			scheduleInboxScanRetry(wakeInboxScanRetryBackoff(inboxScanFailures))
-			clearDoorbellDeadline()
-			_ = writeWakeDiagnostic(
-				&cfg,
-				"amq wake: ordinary wake inbox is unavailable while rearming watcher: %v\n",
+			ordinaryInboxDir = inboxDir
+			watcher = nextWatcher
+			cfg.retainedInbox = inboxDir
+			return true, nil
+		}
+
+		if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
+			if err := retained.ValidateCanonical(); err != nil {
+				return false, &wakeOwnershipLossError{err: failWakeOnWatcherError(
+					&cfg,
+					"retained wake inbox authority changed while rearming watcher",
+					err,
+				)}
+			}
+			nextWatcher, err := newWakeInboxEventWatcher(retained)
+			if err != nil {
+				scheduleWatcherRebindFailure(
+					"retained wake inbox watcher is unavailable while rearming",
+					err,
+				)
+				return false, nil
+			}
+			watcher = nextWatcher
+			return true, nil
+		}
+
+		nextWatcher, err := newWakePathEventWatcher(inboxNew)
+		if err != nil {
+			scheduleWatcherRebindFailure(
+				"wake inbox watcher is unavailable while rearming",
 				err,
 			)
 			return false, nil
 		}
-		ordinaryInboxDir = inboxDir
 		watcher = nextWatcher
-		cfg.retainedInbox = inboxDir
 		return true, nil
 	}
 	enterRetainedInputRecovery := func(cause error) error {
@@ -2786,6 +3009,10 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		clearInboxScanRetry()
 		inboxScanFailures = 0
+		disposition := classifyWakeFailure(err)
+		if disposition == wakeFailureFatal {
+			return err
+		}
 		if isWakeTerminalForegroundPGRPChanged(err) {
 			pendingNotify = true
 			scheduleTerminalAuthorityRetry()
@@ -2820,8 +3047,7 @@ func runWakeLoop(cfg wakeConfig) error {
 			scheduleDoorbellDeadline()
 			return nil
 		}
-		if isWakeInputDemotionBlocked(err) ||
-			isWakeTerminalProgressUncertain(err) {
+		if disposition == wakeFailureDegrade {
 			return enterRetainedInputRecovery(err)
 		}
 		pendingNotify = false
@@ -2830,13 +3056,10 @@ func runWakeLoop(cfg wakeConfig) error {
 		if err == nil {
 			return nil
 		}
-		if isWakeTerminalAuthorityLoss(err) {
-			return err
-		}
 		_ = writeWakeDiagnostic(&cfg, "amq wake: notify error: %v\n", err)
 		return nil
 	}
-	emitFatalScanFallback := func() error {
+	emitScanFallback := func() error {
 		if err := emitWakeAttention(&cfg, wakePayload{
 			text:       "AMQ messages may be pending; run amq drain --include-body",
 			provenance: wakePayloadSystemFixed,
@@ -2902,11 +3125,8 @@ func runWakeLoop(cfg wakeConfig) error {
 
 		case event, ok := <-watcherEvents:
 			if !ok {
-				if ordinaryRecoverable {
-					retryOrdinaryWatcher("ordinary wake inbox watcher closed", nil)
-					continue
-				}
-				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
+				retryWatcher("wake inbox watcher closed", nil)
+				continue
 			}
 			invalidateWakeBaselineEvent(&cfg, event)
 			// Creates/additions can accelerate delivery; removals are durable
@@ -2939,17 +3159,11 @@ func runWakeLoop(cfg wakeConfig) error {
 
 		case err, ok := <-watcherErrors:
 			if !ok {
-				if ordinaryRecoverable {
-					retryOrdinaryWatcher("ordinary wake inbox watcher closed", nil)
-					continue
-				}
-				return failWakeOnWatcherError(&cfg, "watcher closed", nil)
-			}
-			if ordinaryRecoverable {
-				retryOrdinaryWatcher("ordinary wake inbox watcher failed", err)
+				retryWatcher("wake inbox watcher closed", nil)
 				continue
 			}
-			return failWakeOnWatcherError(&cfg, "amq wake: watcher error", err)
+			retryWatcher("wake inbox watcher failed", err)
+			continue
 
 		case <-debounceC:
 			if !pendingNotify {
@@ -2972,9 +3186,16 @@ func runWakeLoop(cfg wakeConfig) error {
 
 		case <-inboxScanRetryC:
 			inboxScanRetryC = nil
-			rebound, err := rebindOrdinaryWatcher()
+			rebound, err := rebindWatcher()
 			if err != nil {
-				return err
+				if classifyWakeFailure(err) == wakeFailureFatal {
+					return err
+				}
+				scheduleWatcherRebindFailure(
+					"wake inbox watcher rearm failed",
+					err,
+				)
+				continue
 			}
 			if !rebound {
 				continue
@@ -3012,6 +3233,13 @@ func runWakeLoop(cfg wakeConfig) error {
 			} else {
 				_ = presence.Touch(cfg.root, cfg.me)
 			}
+			if err := retryPendingWakeNotifierStatus(&cfg); err != nil {
+				_ = writeWakeDiagnostic(
+					&cfg,
+					"amq wake: persist notifier status: %v; retrying\n",
+					err,
+				)
+			}
 			if cfg.inputRecoveryRequired {
 				scheduleDoorbellDeadline()
 				continue
@@ -3041,6 +3269,13 @@ func runWakeLoop(cfg wakeConfig) error {
 				}
 				continue
 			}
+			if !inputEnabledBeforeCheck && cfg.injectMode != wakeInjectModeNone {
+				cfg.doorbell.makeDue(cfg.wakeDoorbellNow())
+				pendingNotify = true
+				if err := attemptNotification(); err != nil {
+					return err
+				}
+			}
 			if cfg.injectMode == wakeInjectModeNone {
 				if inputEnabledBeforeCheck {
 					if err := retireWakeInputState(
@@ -3061,7 +3296,7 @@ func runWakeLoop(cfg wakeConfig) error {
 					if preconditionErr != nil && inboxScanRetryC != nil {
 						preconditionErr = errors.Join(
 							preconditionErr,
-							emitFatalScanFallback(),
+							emitScanFallback(),
 						)
 					} else {
 						if err := attemptNotification(); err != nil {
@@ -3070,7 +3305,7 @@ func runWakeLoop(cfg wakeConfig) error {
 						if preconditionErr != nil && pendingNotify && inboxScanRetryC != nil {
 							preconditionErr = errors.Join(
 								preconditionErr,
-								emitFatalScanFallback(),
+								emitScanFallback(),
 							)
 						}
 					}
@@ -3080,7 +3315,14 @@ func runWakeLoop(cfg wakeConfig) error {
 			}
 			scheduleDoorbellDeadline()
 			if preconditionErr != nil {
-				return preconditionErr
+				if classifyWakeFailure(preconditionErr) == wakeFailureFatal {
+					return preconditionErr
+				}
+				_ = writeWakeDiagnostic(
+					&cfg,
+					"amq wake: maintenance precondition failed: %v; retrying\n",
+					preconditionErr,
+				)
 			}
 		}
 	}
@@ -3090,16 +3332,50 @@ func wakeInboxScanRetryBackoff(failures uint) time.Duration {
 	return cappedExponentialBackoff(failures, wakeInboxScanRetryBase, wakeInboxScanRetryMax)
 }
 
+func wakeStartupRetryBackoff(failures uint) time.Duration {
+	// Keep several retry opportunities inside the coop parent's readiness
+	// budget. Deriving the ceiling prevents startup backoff from drifting past
+	// the timeout that supervises this child.
+	const readinessSlices = 10
+	return cappedExponentialBackoff(
+		failures,
+		wakeInboxScanRetryBase,
+		wakeReadyTimeout/readinessSlices,
+	)
+}
+
 func wakeInjectionPreconditionCheck(
 	cfg *wakeConfig,
 	controllingTerminalOpenableFn func() bool,
 ) error {
 	if cfg.injectMode == wakeInjectModeNone {
+		if !cfg.legacyTIOCSTIDemoted ||
+			cfg.requestedInjectMode == "" ||
+			cfg.requestedInjectMode == wakeInjectModeNone ||
+			tiocstiLegacyDisabledHint() {
+			return nil
+		}
+		if !controllingTerminalOpenableFn() {
+			return errors.New("controlling terminal is not yet openable while restoring TIOCSTI input")
+		}
+		cfg.injectMode = cfg.requestedInjectMode
+		cfg.legacyTIOCSTIDemoted = false
+		cfg.fallbackWarn = true
+		if err := persistWakeNotifierStatus(
+			cfg,
+			"",
+			effectiveInjectMode(cfg),
+			"",
+		); err != nil {
+			return fmt.Errorf("clear restored injector status: %w", err)
+		}
 		return nil
 	}
 	if cfg.injectVia != "" {
 		if cfg.wakeOwner != nil {
-			return wakeOwnerHealthCheck(*cfg.wakeOwner)
+			if err := wakeOwnerHealthCheck(*cfg.wakeOwner); err != nil {
+				return &wakeOwnershipLossError{err: err}
+			}
 		}
 		return nil
 	}
@@ -3117,23 +3393,22 @@ func wakeInjectionPreconditionCheck(
 			mode,
 			capabilityErr,
 		)
-		demotionErr := disableWakeInput(
+		demotionErr := disableWakeInputForLegacyTIOCSTI(
 			cfg,
 			newWakeInjectorUnsupportedError(capabilityErr),
 		)
 		cfg.fallbackWarn = false
 		var statusErr error
-		if cfg.recordNotifierStatus != nil {
-			if err := cfg.recordNotifierStatus(
-				wakeInjectorUnsupportedStatus,
-				mode,
-				reason,
-			); err != nil {
-				statusErr = fmt.Errorf(
-					"record changed injector capability after safety demotion: %w",
-					err,
-				)
-			}
+		if err := persistWakeNotifierStatus(
+			cfg,
+			wakeInjectorUnsupportedStatus,
+			mode,
+			reason,
+		); err != nil {
+			statusErr = fmt.Errorf(
+				"record changed injector capability after safety demotion: %w",
+				err,
+			)
 		}
 		_ = writeWakeDiagnostic(cfg, "amq wake: warning: injector capability changed since binding: %s\n", reason)
 		return errors.Join(demotionErr, statusErr)

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -2033,11 +2033,14 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		interruptNotice:     strings.TrimSpace(*interruptNoticeFlag),
 		interruptCooldown:   *interruptCooldownFlag,
 		controlStop:         controlStop,
-		terminalGeneration:  currentWake.Lock.Generation,
-		terminalTTY:         currentWake.Lock.TTY,
-		baselineRequested:   *baselineExistingFlag || repairLineage != nil,
-		baselineInherited:   repairLineage != nil,
-		retainedAgent:       activeAgentDir,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeTerminalGeneration(root, me)
+		},
+		terminalGeneration: currentWake.Lock.Generation,
+		terminalTTY:        currentWake.Lock.TTY,
+		baselineRequested:  *baselineExistingFlag || repairLineage != nil,
+		baselineInherited:  repairLineage != nil,
+		retainedAgent:      activeAgentDir,
 		recordNotifierStatus: func(status, mode, reason string) error {
 			return setWakeNotifierStatusInDir(activeAgentDir, me, status, mode, reason)
 		},
@@ -2407,15 +2410,30 @@ const (
 )
 
 type wakeOwnershipLossError struct {
-	err error
+	reason string
+}
+
+type wakeUnreadableGenerationNoticeState struct {
+	consecutiveFailures uint
+	statusActive        bool
+	attentionDelivered  bool
+}
+
+const wakeUnreadableGenerationNoticeThreshold = 5
+
+func (state *wakeUnreadableGenerationNoticeState) resetWithoutStatusWrite() {
+	if state == nil {
+		return
+	}
+	*state = wakeUnreadableGenerationNoticeState{}
 }
 
 func (err *wakeOwnershipLossError) Error() string {
-	return err.err.Error()
+	return err.reason
 }
 
-func (err *wakeOwnershipLossError) Unwrap() error {
-	return err.err
+func newWakeOwnershipLoss(reason string) error {
+	return &wakeOwnershipLossError{reason: reason}
 }
 
 func classifyWakeFailure(err error) wakeFailureDisposition {
@@ -2436,6 +2454,86 @@ func classifyWakeFailure(err error) wakeFailureDisposition {
 		return wakeFailureDegrade
 	}
 	return wakeFailureRetry
+}
+
+func (state *wakeUnreadableGenerationNoticeState) observe(
+	cfg *wakeConfig,
+) {
+	if state == nil || cfg == nil {
+		return
+	}
+	if cfg.inspectTerminalGeneration == nil ||
+		cfg.injectMode == wakeInjectModeNone ||
+		cfg.inputRecoveryRequired {
+		state.resetWithoutStatusWrite()
+		return
+	}
+	inspection := cfg.inspectTerminalGeneration()
+	if inspection.Exists && inspection.fileInfo == nil {
+		state.consecutiveFailures++
+		// This threshold counts the loop's fixed maintenance observations. It
+		// gates operator visibility only; delivery authorization and retry
+		// scheduling remain owned by the per-write validation path.
+		if state.consecutiveFailures < wakeUnreadableGenerationNoticeThreshold {
+			return
+		}
+		if !state.statusActive {
+			if err := persistWakeNotifierStatus(
+				cfg,
+				"degraded",
+				effectiveInjectMode(cfg),
+				"wake lock unreadable",
+			); err != nil {
+				_ = writeWakeDiagnostic(
+					cfg,
+					"amq wake: record unreadable wake-lock status: %v; retrying\n",
+					err,
+				)
+			} else {
+				state.statusActive = true
+			}
+		}
+		if state.attentionDelivered {
+			return
+		}
+		if err := emitWakeAttention(cfg, wakePayload{
+			text:       "wake lock unreadable; injection paused; will resume automatically",
+			provenance: wakePayloadSystemFixed,
+		}); err != nil {
+			_ = writeWakeDiagnostic(
+				cfg,
+				"amq wake: emit unreadable wake-lock attention: %v; retrying\n",
+				err,
+			)
+			return
+		}
+		state.attentionDelivered = true
+		return
+	}
+
+	if !inspection.Exists {
+		state.resetWithoutStatusWrite()
+		return
+	}
+	state.consecutiveFailures = 0
+	state.attentionDelivered = false
+	if !state.statusActive {
+		return
+	}
+	if err := persistWakeNotifierStatus(
+		cfg,
+		"",
+		effectiveInjectMode(cfg),
+		"",
+	); err != nil {
+		_ = writeWakeDiagnostic(
+			cfg,
+			"amq wake: clear recovered wake-lock status: %v; retrying\n",
+			err,
+		)
+	} else {
+		state.statusActive = false
+	}
 }
 
 func pendingWakeWatcherError(watcher wakeAdmissionWatcher) error {
@@ -2482,7 +2580,7 @@ func parseInterruptKey(raw string) (string, error) {
 	}
 }
 
-func waitWakeRetry(
+var waitWakeRetry = func(
 	controlStop <-chan struct{},
 	signals <-chan os.Signal,
 	delay time.Duration,
@@ -2569,15 +2667,18 @@ func runWakeLoop(cfg wakeConfig) error {
 			inboxDir, err := openWakeRepairInboxDir(ordinaryAgentDir)
 			if err != nil {
 				if validateErr := validateCanonicalWakeAgentDir(ordinaryAgentDir); validateErr != nil {
-					return &wakeOwnershipLossError{err: fmt.Errorf(
-						"validate acquired wake agent authority after inbox failure: %w",
-						validateErr,
-					)}
+					return errors.Join(
+						fmt.Errorf("open acquired wake inbox capability: %w", err),
+						fmt.Errorf(
+							"validate acquired wake agent authority after inbox failure: %w",
+							validateErr,
+						),
+					)
 				}
-				return &wakeOwnershipLossError{err: fmt.Errorf(
+				return fmt.Errorf(
 					"open acquired wake inbox capability: %w",
 					err,
-				)}
+				)
 			}
 			nextWatcher, err := newWakeInboxEventWatcher(inboxDir)
 			if err != nil {
@@ -2592,10 +2693,13 @@ func runWakeLoop(cfg wakeConfig) error {
 			nextWatcher, err := newWakeInboxEventWatcher(retained)
 			if err != nil {
 				if validateErr := retained.ValidateCanonical(); validateErr != nil {
-					return &wakeOwnershipLossError{err: fmt.Errorf(
-						"validate retained wake inbox authority after watcher failure: %w",
-						validateErr,
-					)}
+					return errors.Join(
+						err,
+						fmt.Errorf(
+							"validate retained wake inbox authority after watcher failure: %w",
+							validateErr,
+						),
+					)
 				}
 				return err
 			}
@@ -2683,10 +2787,14 @@ func runWakeLoop(cfg wakeConfig) error {
 			}
 			cfg.baselineExisting = nil
 			if err := retained.ValidateCanonical(); err != nil {
-				return &wakeOwnershipLossError{err: fmt.Errorf(
+				validationErr := fmt.Errorf(
 					"validate startup baseline watcher authority: %w",
 					err,
-				)}
+				)
+				if classifyWakeFailure(validationErr) == wakeFailureFatal {
+					return validationErr
+				}
+				prepareErr = errors.Join(prepareErr, validationErr)
 			}
 			historyUncertain = true
 			failures++
@@ -2927,11 +3035,11 @@ func runWakeLoop(cfg wakeConfig) error {
 		}
 		if ordinaryRecoverable {
 			if err := validateCanonicalWakeAgentDir(ordinaryAgentDir); err != nil {
-				return false, &wakeOwnershipLossError{err: failWakeOnWatcherError(
+				return false, failWakeOnWatcherError(
 					&cfg,
 					"ordinary wake agent authority changed while rearming watcher",
 					err,
-				)}
+				)
 			}
 			inboxDir, nextWatcher, err := openWatchedWakeInboxDir(ordinaryAgentDir)
 			if err != nil {
@@ -2949,11 +3057,11 @@ func runWakeLoop(cfg wakeConfig) error {
 
 		if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
 			if err := retained.ValidateCanonical(); err != nil {
-				return false, &wakeOwnershipLossError{err: failWakeOnWatcherError(
+				return false, failWakeOnWatcherError(
 					&cfg,
 					"retained wake inbox authority changed while rearming watcher",
 					err,
-				)}
+				)
 			}
 			nextWatcher, err := newWakeInboxEventWatcher(retained)
 			if err != nil {
@@ -2992,6 +3100,7 @@ func runWakeLoop(cfg wakeConfig) error {
 		scheduleDoorbellDeadline()
 		return nil
 	}
+	var unreadableGenerationNotice wakeUnreadableGenerationNoticeState
 	attemptNotification := func() error {
 		if terminalAuthorityRetryC != nil || inboxScanRetryC != nil {
 			return nil
@@ -3241,6 +3350,7 @@ func runWakeLoop(cfg wakeConfig) error {
 				)
 			}
 			if cfg.inputRecoveryRequired {
+				unreadableGenerationNotice.resetWithoutStatusWrite()
 				scheduleDoorbellDeadline()
 				continue
 			}
@@ -3264,6 +3374,7 @@ func runWakeLoop(cfg wakeConfig) error {
 				)
 			}
 			if isWakeInputDemotionBlocked(preconditionErr) {
+				unreadableGenerationNotice.resetWithoutStatusWrite()
 				if err := enterRetainedInputRecovery(preconditionErr); err != nil {
 					return err
 				}
@@ -3324,6 +3435,7 @@ func runWakeLoop(cfg wakeConfig) error {
 					preconditionErr,
 				)
 			}
+			unreadableGenerationNotice.observe(&cfg)
 		}
 	}
 }
@@ -3374,7 +3486,7 @@ func wakeInjectionPreconditionCheck(
 	if cfg.injectVia != "" {
 		if cfg.wakeOwner != nil {
 			if err := wakeOwnerHealthCheck(*cfg.wakeOwner); err != nil {
-				return &wakeOwnershipLossError{err: err}
+				return err
 			}
 		}
 		return nil
@@ -3481,18 +3593,49 @@ func wakeOwnerHealthCheck(owner wakeOwner) error {
 	}
 	proc := inspectWakeProcess(owner.PID)
 	if !proc.Running {
-		return fmt.Errorf("inject-via wake owner pid %d is not running", owner.PID)
+		return newWakeOwnershipLoss(
+			fmt.Sprintf("inject-via wake owner pid %d is not running", owner.PID),
+		)
 	}
 	if owner.ProcessStart != "" {
 		if proc.StartToken == "" {
-			return fmt.Errorf("inject-via wake owner process start unavailable for pid %d: %v", owner.PID, proc.InspectError)
+			if proc.InspectError != nil {
+				return fmt.Errorf(
+					"inject-via wake owner process start unavailable for pid %d: %w",
+					owner.PID,
+					proc.InspectError,
+				)
+			}
+			return fmt.Errorf(
+				"inject-via wake owner process start unavailable for pid %d",
+				owner.PID,
+			)
 		}
 		if proc.StartToken != owner.ProcessStart {
-			return fmt.Errorf("inject-via wake owner process start changed for pid %d", owner.PID)
+			return newWakeOwnershipLoss(
+				fmt.Sprintf("inject-via wake owner process start changed for pid %d", owner.PID),
+			)
 		}
 	}
-	if owner.BootID != "" && proc.BootID != "" && proc.BootID != owner.BootID {
-		return fmt.Errorf("inject-via wake owner boot id changed for pid %d", owner.PID)
+	if owner.BootID != "" {
+		switch compareWakeBootID(owner.BootID, proc) {
+		case bootIDMismatch:
+			return newWakeOwnershipLoss(
+				fmt.Sprintf("inject-via wake owner boot id changed for pid %d", owner.PID),
+			)
+		case bootIDUnknown:
+			if proc.InspectError != nil {
+				return fmt.Errorf(
+					"inject-via wake owner boot id unavailable or incomparable for pid %d: %w",
+					owner.PID,
+					proc.InspectError,
+				)
+			}
+			return fmt.Errorf(
+				"inject-via wake owner boot id unavailable or incomparable for pid %d",
+				owner.PID,
+			)
+		}
 	}
 	if owner.SessionID != 0 {
 		sid, err := getWakeProcessSID(owner.PID)
@@ -3500,7 +3643,9 @@ func wakeOwnerHealthCheck(owner wakeOwner) error {
 			return fmt.Errorf("inject-via wake owner session unavailable for pid %d: %w", owner.PID, err)
 		}
 		if sid != owner.SessionID {
-			return fmt.Errorf("inject-via wake owner session changed for pid %d", owner.PID)
+			return newWakeOwnershipLoss(
+				fmt.Sprintf("inject-via wake owner session changed for pid %d", owner.PID),
+			)
 		}
 	}
 	return nil

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -4555,6 +4555,7 @@ func TestRunWakeLoopScanFallbackAttentionFailureKeepsWatching(t *testing.T) {
 	stop := make(chan struct{})
 	done := make(chan error, 1)
 	var attentionWrites atomic.Int64
+	attentionAttempted := make(chan struct{}, 1)
 	attentionSinkErr := errors.New("attention sink unavailable")
 	go func() {
 		done <- runWakeLoop(wakeConfig{
@@ -4573,6 +4574,10 @@ func TestRunWakeLoopScanFallbackAttentionFailureKeepsWatching(t *testing.T) {
 			attentionIsTTY: func() bool { return false },
 			attentionWrite: func(data []byte) (int, error) {
 				attentionWrites.Add(1)
+				select {
+				case attentionAttempted <- struct{}{}:
+				default:
+				}
 				return 0, attentionSinkErr
 			},
 		})
@@ -4593,9 +4598,11 @@ func TestRunWakeLoopScanFallbackAttentionFailureKeepsWatching(t *testing.T) {
 		t.Fatal("wake loop did not accept maintenance tick")
 	}
 	select {
+	case <-attentionAttempted:
 	case err := <-done:
 		t.Fatalf("persistence plus attention failure killed wake loop: %v", err)
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(2 * time.Second):
+		t.Fatal("scan fallback did not attempt output attention")
 	}
 	if got := attentionWrites.Load(); got != 1 {
 		t.Fatalf("attention writes = %d, want one failed fallback", got)

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -660,6 +660,7 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 	}
 
 	var got wakeConfig
+	var maintenanceInspection wakeLockInspection
 	errDone := errors.New("done")
 	injector := writeExecutableForTest(t, "inject tool")
 	err := runWakeWithLoop([]string{
@@ -671,6 +672,9 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 		"--inject-timeout", "250ms",
 	}, func(cfg wakeConfig) error {
 		got = cfg
+		if cfg.inspectTerminalGeneration != nil {
+			maintenanceInspection = cfg.inspectTerminalGeneration()
+		}
 		return errDone
 	})
 	if !errors.Is(err, errDone) {
@@ -684,6 +688,14 @@ func TestRunWakeWithLoopInjectViaSkipsTTYStartupRequirement(t *testing.T) {
 	}
 	if got.injectTimeout != 250*time.Millisecond {
 		t.Fatalf("expected inject timeout 250ms, got %s", got.injectTimeout)
+	}
+	if got.inspectTerminalGeneration == nil {
+		t.Fatal("--inject-via wake has no maintenance lock-health inspection")
+	}
+	if !maintenanceInspection.Exists ||
+		maintenanceInspection.fileInfo == nil ||
+		maintenanceInspection.Lock.Generation == "" {
+		t.Fatalf("--inject-via maintenance lock inspection = %+v", maintenanceInspection)
 	}
 	if sysctlReads != 0 {
 		t.Fatalf("--inject-via read TIOCSTI sysctl %d times, want 0", sysctlReads)
@@ -1454,7 +1466,23 @@ func TestRunWakeWithLoopAcceptExistingRemovesReadyAfterOwnerLoss(t *testing.T) {
 	}
 }
 
-func TestRunWakeWithLoopDoesNotRecreateMissingInboxAfterAcquisition(t *testing.T) {
+func TestRunWakeWithLoopWaitsForAcquiredInboxToReturnWithoutRecreatingIt(t *testing.T) {
+	stubFastWakeInboxRetry(t)
+	retryObserved := make(chan struct{}, 1)
+	originalWaitWakeRetry := waitWakeRetry
+	waitWakeRetry = func(
+		controlStop <-chan struct{},
+		signals <-chan os.Signal,
+		delay time.Duration,
+	) bool {
+		select {
+		case retryObserved <- struct{}{}:
+		default:
+		}
+		return originalWaitWakeRetry(controlStop, signals, delay)
+	}
+	t.Cleanup(func() { waitWakeRetry = originalWaitWakeRetry })
+
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatal(err)
@@ -1464,21 +1492,73 @@ func TestRunWakeWithLoopDoesNotRecreateMissingInboxAfterAcquisition(t *testing.T
 	}
 	injector := writeExecutableForTest(t, "injector")
 	inboxPath := fsq.AgentInboxNew(root, "codex")
+	heldInboxPath := inboxPath + ".held"
+	errDone := errors.New("done")
 	err := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "codex",
 		"--inject-via", injector,
 	}, func(cfg wakeConfig) error {
-		if err := os.Remove(inboxPath); err != nil {
+		if err := os.Rename(inboxPath, heldInboxPath); err != nil {
 			t.Fatal(err)
 		}
-		return runWakeLoop(cfg)
+		inboxHeld := true
+		t.Cleanup(func() {
+			if inboxHeld {
+				_ = os.Rename(heldInboxPath, inboxPath)
+			}
+		})
+
+		stop := make(chan struct{})
+		stopClosed := false
+		defer func() {
+			if !stopClosed {
+				close(stop)
+			}
+		}()
+		prepared := make(chan struct{})
+		done := make(chan error, 1)
+		cfg.controlStop = stop
+		cfg.onPrepared = func(wakeAdmissionWatcher) error {
+			close(prepared)
+			return nil
+		}
+		go func() {
+			done <- runWakeLoop(cfg)
+		}()
+
+		select {
+		case <-retryObserved:
+		case loopErr := <-done:
+			t.Fatalf("wake loop exited while the acquired inbox was unavailable: %v", loopErr)
+		case <-time.After(2 * time.Second):
+			t.Fatal("wake loop did not retry while the acquired inbox was unavailable")
+		}
+		if _, statErr := os.Stat(inboxPath); !os.IsNotExist(statErr) {
+			t.Fatalf("missing acquired inbox was recreated: %v", statErr)
+		}
+
+		if err := os.Rename(heldInboxPath, inboxPath); err != nil {
+			t.Fatal(err)
+		}
+		inboxHeld = false
+		select {
+		case <-prepared:
+		case loopErr := <-done:
+			t.Fatalf("wake loop exited instead of recovering its acquired inbox: %v", loopErr)
+		case <-time.After(2 * time.Second):
+			t.Fatal("wake loop did not recover after its acquired inbox returned")
+		}
+
+		close(stop)
+		stopClosed = true
+		if loopErr := <-done; loopErr != nil {
+			t.Fatalf("wake loop stop: %v", loopErr)
+		}
+		return errDone
 	})
-	if err == nil {
-		t.Fatal("missing acquired inbox started a wake loop")
-	}
-	if _, statErr := os.Stat(inboxPath); !os.IsNotExist(statErr) {
-		t.Fatalf("missing acquired inbox was recreated: %v", statErr)
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
 	}
 }
 
@@ -8295,6 +8375,9 @@ func TestWakeInjectionPreconditionCheckExitsWhenInjectViaOwnerGone(t *testing.T)
 	if !strings.Contains(err.Error(), "owner pid 4242 is not running") {
 		t.Fatalf("unexpected owner liveness error: %v", err)
 	}
+	if got := classifyWakeFailure(err); got != wakeFailureFatal {
+		t.Fatalf("owner death disposition = %v, want fatal", got)
+	}
 }
 
 func TestWakeInjectionPreconditionCheckExitsWhenInjectViaOwnerIdentityChanges(t *testing.T) {
@@ -8318,6 +8401,111 @@ func TestWakeInjectionPreconditionCheckExitsWhenInjectViaOwnerIdentityChanges(t 
 	if !strings.Contains(err.Error(), "owner process start changed") {
 		t.Fatalf("unexpected owner identity error: %v", err)
 	}
+	if got := classifyWakeFailure(err); got != wakeFailureFatal {
+		t.Fatalf("owner identity-change disposition = %v, want fatal", got)
+	}
+}
+
+func TestWakeInjectionPreconditionCheckExitsOnConclusiveOwnerBootChange(t *testing.T) {
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "owner-start",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: owner.ProcessStart,
+			BootID:     "22222222-2222-2222-2222-222222222222",
+		}
+	})
+
+	cfg := wakeConfig{injectVia: "/tmp/injector", wakeOwner: &owner}
+	err := wakeInjectionPreconditionCheck(&cfg, func() bool { return false })
+	if err == nil || !strings.Contains(err.Error(), "owner boot id changed") {
+		t.Fatalf("conclusive owner boot change = %v, want fatal mismatch", err)
+	}
+	if got := classifyWakeFailure(err); got != wakeFailureFatal {
+		t.Fatalf("conclusive owner boot change disposition = %v, want fatal", got)
+	}
+}
+
+func TestWakeInjectionPreconditionCheckRetriesInconclusiveOwnerInspection(t *testing.T) {
+	t.Run("process identity unreadable", func(t *testing.T) {
+		owner := wakeOwner{PID: 4242, ProcessStart: "owner-start", BootID: "boot-1"}
+		stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+			return wakeProcessInfo{
+				PID:          pid,
+				Running:      true,
+				InspectError: syscall.EMFILE,
+			}
+		})
+
+		cfg := wakeConfig{injectVia: "/tmp/injector", wakeOwner: &owner}
+		err := wakeInjectionPreconditionCheck(&cfg, func() bool { return false })
+		if err == nil || !errors.Is(err, syscall.EMFILE) {
+			t.Fatalf("inconclusive process inspection = %v, want EMFILE", err)
+		}
+		if got := classifyWakeFailure(err); got != wakeFailureRetry {
+			t.Fatalf("inconclusive process inspection disposition = %v, want retry", got)
+		}
+	})
+
+	t.Run("session identity unreadable", func(t *testing.T) {
+		owner := wakeOwner{
+			PID:          4242,
+			ProcessStart: "owner-start",
+			BootID:       "boot-1",
+			SessionID:    99,
+		}
+		stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: owner.ProcessStart,
+				BootID:     owner.BootID,
+			}
+		})
+		stubWakeProcessSID(t, func(int) (int, error) {
+			return 0, syscall.EMFILE
+		})
+
+		cfg := wakeConfig{injectVia: "/tmp/injector", wakeOwner: &owner}
+		err := wakeInjectionPreconditionCheck(&cfg, func() bool { return false })
+		if err == nil || !errors.Is(err, syscall.EMFILE) {
+			t.Fatalf("inconclusive session inspection = %v, want EMFILE", err)
+		}
+		if got := classifyWakeFailure(err); got != wakeFailureRetry {
+			t.Fatalf("inconclusive session inspection disposition = %v, want retry", got)
+		}
+	})
+
+	t.Run("boot identity representation incomparable", func(t *testing.T) {
+		owner := wakeOwner{
+			PID:          4242,
+			ProcessStart: "owner-start",
+			BootID:       "11111111-1111-1111-1111-111111111111",
+		}
+		stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+			return wakeProcessInfo{
+				PID:        pid,
+				Running:    true,
+				StartToken: owner.ProcessStart,
+				BootID:     "legacy-boottime-identity",
+			}
+		})
+
+		cfg := wakeConfig{injectVia: "/tmp/injector", wakeOwner: &owner}
+		err := wakeInjectionPreconditionCheck(&cfg, func() bool { return false })
+		if err == nil ||
+			!strings.Contains(err.Error(), "boot id unavailable or incomparable") {
+			t.Fatalf("incomparable boot identity = %v, want retryable uncertainty", err)
+		}
+		if got := classifyWakeFailure(err); got != wakeFailureRetry {
+			t.Fatalf("incomparable boot identity disposition = %v, want retry", got)
+		}
+	})
 }
 
 func TestWakeInjectionPreconditionCheckKeepsInjectViaWhenOwnerMatches(t *testing.T) {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -3692,7 +3692,7 @@ func TestRunWakeLoopMaintenanceDemotionTransfersDormantDoorbellRetry(t *testing.
 	}
 }
 
-func TestRunWakeLoopMaintenanceDemotionTransfersBeforePersistenceFailure(t *testing.T) {
+func TestRunWakeLoopMaintenanceDemotionTransfersDespitePersistenceFailure(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	message := format.Message{
@@ -3721,6 +3721,7 @@ func TestRunWakeLoopMaintenanceDemotionTransfersBeforePersistenceFailure(t *test
 	persistErr := errors.New("presence unavailable")
 	ticks := make(chan time.Time)
 	attention := make(chan string, 1)
+	stop := make(chan struct{})
 	done := make(chan error, 1)
 	var terminalWrites atomic.Int64
 	go func() {
@@ -3730,7 +3731,7 @@ func TestRunWakeLoopMaintenanceDemotionTransfersBeforePersistenceFailure(t *test
 			session:     "session1",
 			wakeOwner:   &wakeOwner{},
 			injectMode:  wakeInjectModePaste,
-			controlStop: make(chan struct{}),
+			controlStop: stop,
 			doorbell: wakeDoorbellState{
 				phase:       wakeDoorbellRetrying,
 				cohort:      snapshotWakeFileIdentities(map[string]os.FileInfo{"pending.md": info}),
@@ -3772,14 +3773,15 @@ func TestRunWakeLoopMaintenanceDemotionTransfersBeforePersistenceFailure(t *test
 	}
 	select {
 	case err := <-done:
-		if !errors.Is(err, persistErr) {
-			t.Fatalf("wake loop error = %v, want persistence failure", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("wake loop did not surface persistence failure")
+		t.Fatalf("persistence failure killed wake loop: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 	if got := terminalWrites.Load(); got != 0 {
 		t.Fatalf("dormant retry wrote %d terminal chunks", got)
+	}
+	close(stop)
+	if err := <-done; err != nil {
+		t.Fatalf("wake loop stop: %v", err)
 	}
 }
 
@@ -4186,13 +4188,13 @@ func TestRunWakeLoopKeepsWatchingWhenDrainedInboxReconciliationBecomesUncertain(
 	}
 }
 
-func TestRunWakeLoopDrainedInboxRecoveryAttentionFailureRetriesWithoutExit(t *testing.T) {
+func TestRunWakeLoopDrainedInboxRecoveryAttentionFailureClearsWithoutExit(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	attentionSinkErr := errors.New("attention sink unavailable")
 	now := time.Unix(1_800_000_000, 0)
 	var attentionWrites atomic.Int64
-	retried := make(chan struct{}, 1)
+	attempted := make(chan struct{}, 1)
 	stop := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
@@ -4217,28 +4219,31 @@ func TestRunWakeLoopDrainedInboxRecoveryAttentionFailureRetriesWithoutExit(t *te
 			},
 			attentionIsTTY: func() bool { return false },
 			attentionWrite: func(data []byte) (int, error) {
-				if attentionWrites.Add(1) == 1 {
-					now = now.Add(wakeDoorbellAttentionRetryBase)
-					return 0, attentionSinkErr
-				}
 				select {
-				case retried <- struct{}{}:
+				case attempted <- struct{}{}:
 				default:
 				}
-				return len(data), nil
+				attentionWrites.Add(1)
+				now = now.Add(wakeDoorbellAttentionRetryBase)
+				return 0, attentionSinkErr
 			},
 		})
 	}()
 
 	select {
-	case <-retried:
+	case <-attempted:
 	case err := <-done:
 		t.Fatalf("wake loop exited on drained-inbox recovery attention failure: %v", err)
 	case <-time.After(2 * time.Second):
-		t.Fatalf("wake loop did not retry drained-inbox recovery attention: writes=%d", attentionWrites.Load())
+		t.Fatal("wake loop did not attempt drained-inbox recovery attention")
 	}
-	if got := attentionWrites.Load(); got != 2 {
-		t.Fatalf("drained recovery attention writes = %d, want failed write plus retry", got)
+	select {
+	case err := <-done:
+		t.Fatalf("wake loop exited while clearing drained recovery: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	if got := attentionWrites.Load(); got != 1 {
+		t.Fatalf("drained recovery attention writes = %d, want one failed attempt before discharge", got)
 	}
 	close(stop)
 	select {
@@ -4347,7 +4352,7 @@ func TestRunWakeLoopBuiltInMaintenanceKeepsWatchingAfterConfirmedInputDemotion(t
 	}
 }
 
-func TestRunWakeLoopFatalDemotionTransfersDuringScanBackoff(t *testing.T) {
+func TestRunWakeLoopDemotionPersistenceFailureKeepsWatchingDuringScanBackoff(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	persistErr := errors.New("presence unavailable")
@@ -4372,6 +4377,7 @@ func TestRunWakeLoopFatalDemotionTransfersDuringScanBackoff(t *testing.T) {
 	}
 	ticks := make(chan time.Time)
 	attention := make(chan string, 2)
+	stop := make(chan struct{})
 	done := make(chan error, 1)
 	var terminalWrites atomic.Int64
 	go func() {
@@ -4381,7 +4387,7 @@ func TestRunWakeLoopFatalDemotionTransfersDuringScanBackoff(t *testing.T) {
 			session:          "session1",
 			wakeOwner:        &wakeOwner{},
 			injectMode:       wakeInjectModePaste,
-			controlStop:      make(chan struct{}),
+			controlStop:      stop,
 			maintenanceTicks: ticks,
 			retainedInbox:    reader,
 			preconditionCheck: func(cfg *wakeConfig) error {
@@ -4425,11 +4431,8 @@ func TestRunWakeLoopFatalDemotionTransfersDuringScanBackoff(t *testing.T) {
 	}
 	select {
 	case err := <-done:
-		if !errors.Is(err, persistErr) {
-			t.Fatalf("wake loop error = %v, want persistence failure", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("wake loop did not surface fatal demotion")
+		t.Fatalf("persistence failure killed wake loop: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 	if got := terminalWrites.Load(); got != 0 {
 		t.Fatalf("fatal demotion wrote %d terminal chunks", got)
@@ -4439,9 +4442,13 @@ func TestRunWakeLoopFatalDemotionTransfersDuringScanBackoff(t *testing.T) {
 		t.Fatalf("fatal demotion emitted duplicate attention: %q", output)
 	default:
 	}
+	close(stop)
+	if err := <-done; err != nil {
+		t.Fatalf("wake loop stop: %v", err)
+	}
 }
 
-func TestRunWakeLoopFatalScanFallbackSurfacesAttentionWriteFailure(t *testing.T) {
+func TestRunWakeLoopScanFallbackAttentionFailureKeepsWatching(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	persistErr := errors.New("presence unavailable")
@@ -4465,6 +4472,7 @@ func TestRunWakeLoopFatalScanFallbackSurfacesAttentionWriteFailure(t *testing.T)
 		},
 	}
 	ticks := make(chan time.Time)
+	stop := make(chan struct{})
 	done := make(chan error, 1)
 	var attentionWrites atomic.Int64
 	attentionSinkErr := errors.New("attention sink unavailable")
@@ -4475,7 +4483,7 @@ func TestRunWakeLoopFatalScanFallbackSurfacesAttentionWriteFailure(t *testing.T)
 			session:          "session1",
 			wakeOwner:        &wakeOwner{},
 			injectMode:       wakeInjectModePaste,
-			controlStop:      make(chan struct{}),
+			controlStop:      stop,
 			maintenanceTicks: ticks,
 			retainedInbox:    reader,
 			preconditionCheck: func(cfg *wakeConfig) error {
@@ -4506,21 +4514,19 @@ func TestRunWakeLoopFatalScanFallbackSurfacesAttentionWriteFailure(t *testing.T)
 	}
 	select {
 	case err := <-done:
-		var attentionErr *wakeAttentionDeliveryError
-		if !errors.Is(err, persistErr) ||
-			!errors.As(err, &attentionErr) ||
-			!errors.Is(err, attentionSinkErr) {
-			t.Fatalf("wake loop error = %v, want persistence plus attention sink failure", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("wake loop did not surface failed fatal fallback")
+		t.Fatalf("persistence plus attention failure killed wake loop: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 	if got := attentionWrites.Load(); got != 1 {
 		t.Fatalf("attention writes = %d, want one failed fallback", got)
 	}
+	close(stop)
+	if err := <-done; err != nil {
+		t.Fatalf("wake loop stop: %v", err)
+	}
 }
 
-func TestRunWakeLoopFatalDemotionTransfersWhenScanBackoffStartsDuringTransfer(t *testing.T) {
+func TestRunWakeLoopDemotionPersistenceFailureKeepsWatchingWhenScanBackoffStartsDuringTransfer(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	persistErr := errors.New("presence unavailable")
@@ -4552,6 +4558,7 @@ func TestRunWakeLoopFatalDemotionTransfersWhenScanBackoffStartsDuringTransfer(t 
 	pending := make(chan struct{}, 1)
 	ticks := make(chan time.Time)
 	attention := make(chan string, 2)
+	stop := make(chan struct{})
 	done := make(chan error, 1)
 	var terminalWrites atomic.Int64
 	go func() {
@@ -4562,7 +4569,7 @@ func TestRunWakeLoopFatalDemotionTransfersWhenScanBackoffStartsDuringTransfer(t 
 			wakeOwner:        &wakeOwner{},
 			debounce:         time.Hour,
 			injectMode:       wakeInjectModePaste,
-			controlStop:      make(chan struct{}),
+			controlStop:      stop,
 			maintenanceTicks: ticks,
 			retainedInbox:    reader,
 			onPendingNotify: func() {
@@ -4638,11 +4645,8 @@ func TestRunWakeLoopFatalDemotionTransfersWhenScanBackoffStartsDuringTransfer(t 
 	}
 	select {
 	case err := <-done:
-		if !errors.Is(err, persistErr) {
-			t.Fatalf("wake loop error = %v, want persistence failure", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("wake loop did not surface fatal demotion")
+		t.Fatalf("persistence failure killed wake loop: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 	if got := terminalWrites.Load(); got != 0 {
 		t.Fatalf("fatal demotion wrote %d terminal chunks", got)
@@ -4651,6 +4655,10 @@ func TestRunWakeLoopFatalDemotionTransfersWhenScanBackoffStartsDuringTransfer(t 
 	case output := <-attention:
 		t.Fatalf("fatal demotion emitted duplicate attention: %q", output)
 	default:
+	}
+	close(stop)
+	if err := <-done; err != nil {
+		t.Fatalf("wake loop stop: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

The main defect is broader than the original readiness symptom: transient failures while proving terminal, owner, or retained-directory identity were force-wrapped as fatal. On main, a real temporary chmod/EACCES or EMFILE during identity inspection permanently kills an admitted wake even though ownership was never proven lost.

This change keeps inconclusive ownership failures retryable and self-healing while preserving fail-stop behavior for conclusive generation, process-start, boot, session, terminal-identity, and directory-identity loss.

## Changes

- Retry transient startup/runtime watcher, terminal-authority, owner-inspection, directory-open, attention, and notifier-status failures without abandoning durable delivery.
- Keep bounded retry pacing interruptible by controlStop, SIGTERM, and SIGHUP.
- Treat directory open failures, including permanent EACCES, ENOENT, ENOTDIR, ELOOP, and EMFILE, as inconclusive and retry forever with bounded diagnostics; only a successful identity comparison can prove replacement.
- Surface five consecutive maintenance-only unreadable-lock observations as degraded with the message: wake lock unreadable; injection paused; will resume automatically. This threshold changes operator visibility only and never delivery authorization or retry cadence.
- Retry both setting and clearing notifier status after transient persistence failures.
- Preserve exact partial-write progress and retry unknown zero-progress TIOCSTI failures only after authority revalidation.
- Recover a temporarily unavailable retained inbox without recreating it; preparation resumes when the same retained directory returns.
- Keep a live renamed/wrapped executable with matching ProcessStart and BootID unverified instead of allowing argv[0] to prove it stale.
- Make fatal loss types reason-only: both Unwrap methods are deleted, and seven scattered ownership-loss constructions funnel through one constructor. Accidentally attaching an errno to a fatal classification is now a compile-time design violation rather than a review convention.

## Honest scope and provenance

- Neither B1 nor B2 is a regression. B2 is byte-identical on main, where all injection errors were more lethal because they were fatal without classification. B1's specific mislabelling is new, but main also terminated on any such error. The net change is less lethal on both paths while preserving proven-loss exits.
- Two removed loss-wrap sites were executed directly with adversarial fixtures; roughly seven others were reviewed structurally, not executed individually. They follow the same inner transient/conclusive split, but this PR does not claim execution coverage for all of them.
- The shipped renamed-binary test proves the new guard against argv over-trust. It does not reproduce the literal over-removal story with both executable and argv renamed; that adversarial variant remains a follow-up.
- The missing-generation RED on main is wording-only because main was already fatal through the generic path. The owner-ESRCH real-loop test also passes on main and is a non-regression guard, not newly introduced behavior coverage.

## Verification on certified tree b02e546adce2174e1347482cc43ee91b1c9fecb7

- go test ./... -count=1 -timeout=12m
- go test ./internal/cli -run Wake|Coop -count=1 -timeout=10m
- focused fatal/self-healing tests x20
- focused race-detector tests x10
- go vet ./...
- CGO_ENABLED=0 go build ./... for Darwin, Linux, FreeBSD, and Windows amd64
- independent exact-tree certification of commits 253d451 and 70cf27e, full diff SHA-256 3571ae9a1cc9e3c613721c473ef95bb31e80507293e240b9a06ce7a3bc74b942

Linux CI is a required merge gate.

## Wake test change justification

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestRunWakeLoopDrainedInboxRecoveryAttentionFailureRetriesWithoutExit: Renamed because durable inbox drain now discharges recovery after one bounded failed attention attempt instead of retaining a stale recovery retry.
TestRunWakeLoopFatalDemotionTransfersDuringScanBackoff: Renamed because notifier-status persistence failure is now retried while the admitted wake keeps watching rather than terminating.
TestRunWakeLoopFatalDemotionTransfersWhenScanBackoffStartsDuringTransfer: Renamed because concurrent scan backoff plus status persistence failure now preserves the admitted wake and retries instead of exiting.
TestRunWakeLoopFatalScanFallbackSurfacesAttentionWriteFailure: Renamed because a failed output-attention effect no longer abandons the durable inbox obligation; the watcher remains alive.
TestRunWakeLoopMaintenanceDemotionTransfersBeforePersistenceFailure: Renamed because maintenance completes the safe output-only transfer and retries persistence without terminating the wake.
TestWakeTerminalAuthorityEIOAfterPartialProgressIsUncertain: Renamed because valid retained authority now preserves exact accepted-byte progress for suffix retry instead of relabeling the effect failure as authority uncertainty.
TestRunWakeWithLoopDoesNotRecreateMissingInboxAfterAcquisition: Renamed to TestRunWakeWithLoopWaitsForAcquiredInboxToReturnWithoutRecreatingIt because temporary retained-inbox disappearance is now retryable; the test synchronizes on the failed open, proves no recreation, restores the same inode, and requires preparation.
END_WAKE_TEST_CHANGE_JUSTIFICATION

## Follow-ups

1. Adopt the adversarial renamed-everywhere test for the literal over-removal case, plus both mismatched-start-token removability tests.
2. Execute the remaining removed-wrap sites with tailored fixtures.
3. Pin the wall-clock relationship between wakeUnreadableGenerationNoticeThreshold and the maintenance interval; the threshold is status-only and non-blocking for this change.

