### PR TITLE
test(wake): make namespace replacement induction atomic

### DIFF
--- a/internal/cli/wake_repair_namespace_darwin_test.go
+++ b/internal/cli/wake_repair_namespace_darwin_test.go
@@ -1,0 +1,15 @@
+//go:build darwin
+
+package cli
+
+import "golang.org/x/sys/unix"
+
+func exchangeWakeRepairDirectoriesForTest(first, second string) error {
+	return unix.RenameatxNp(
+		unix.AT_FDCWD,
+		first,
+		unix.AT_FDCWD,
+		second,
+		unix.RENAME_SWAP,
+	)
+}

--- a/internal/cli/wake_repair_namespace_linux_test.go
+++ b/internal/cli/wake_repair_namespace_linux_test.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package cli
+
+import "golang.org/x/sys/unix"
+
+func exchangeWakeRepairDirectoriesForTest(first, second string) error {
+	return unix.Renameat2(
+		unix.AT_FDCWD,
+		first,
+		unix.AT_FDCWD,
+		second,
+		unix.RENAME_EXCHANGE,
+	)
+}

--- a/internal/cli/wake_repair_namespace_unix_test.go
+++ b/internal/cli/wake_repair_namespace_unix_test.go
@@ -46,13 +46,7 @@ func TestValidateCanonicalWakeRepairDirectoriesRejectsNamespaceReplacement(t *te
 			name: "inbox directory",
 			replace: func(t *testing.T, root string) {
 				t.Helper()
-				inboxPath := fsq.AgentInboxNew(root, "codex")
-				if err := os.Rename(inboxPath, inboxPath+".detached"); err != nil {
-					t.Fatalf("detach inbox directory: %v", err)
-				}
-				if err := os.Mkdir(inboxPath, 0o700); err != nil {
-					t.Fatalf("create replacement inbox directory: %v", err)
-				}
+				replaceWakeRepairInboxDirectoryAtomicallyForTest(t, root, "codex")
 			},
 			want: "inbox directory no longer matches",
 		},
@@ -132,13 +126,7 @@ func TestRepairWakeRefusesCanonicalInboxReplacementBeforeAdmission(t *testing.T)
 		},
 		func(started *wakeRepairChild) {
 			forceRepairLifecycleChildInspection(t, fixture, started)
-			inboxPath := fsq.AgentInboxNew(fixture.root, "codex")
-			if err := os.Rename(inboxPath, inboxPath+".detached"); err != nil {
-				t.Fatalf("detach prepared child inbox: %v", err)
-			}
-			if err := os.Mkdir(inboxPath, 0o700); err != nil {
-				t.Fatalf("create replacement child inbox: %v", err)
-			}
+			replaceWakeRepairInboxDirectoryAtomicallyForTest(t, fixture.root, "codex")
 		},
 	)
 
@@ -184,13 +172,7 @@ func TestRepairWakeChildAdmissionRejectsNamespaceReplacementAfterParentValidatio
 			name: "direct inbox loss",
 			replace: func(t *testing.T, root string) {
 				t.Helper()
-				inboxPath := fsq.AgentInboxNew(root, "codex")
-				if err := os.Rename(inboxPath, inboxPath+".detached"); err != nil {
-					t.Fatalf("detach prepared child inbox: %v", err)
-				}
-				if err := os.Mkdir(inboxPath, 0o700); err != nil {
-					t.Fatalf("create replacement child inbox: %v", err)
-				}
+				replaceWakeRepairInboxDirectoryAtomicallyForTest(t, root, "codex")
 			},
 			wants: []string{
 				"wake watcher failed before admission: retained wake inbox directory was renamed or deleted",
@@ -210,6 +192,10 @@ func TestRepairWakeChildAdmissionRejectsNamespaceReplacementAfterParentValidatio
 					forceRepairLifecycleChildInspection(t, fixture, started)
 					admit := started.admit
 					started.admit = func() error {
+						// Admission failure is fail-closed: repairWake reaps
+						// this prepared child without a claim. If admission
+						// ever retries, a transient namespace observation could
+						// leave a child running against detached authority.
 						// repairWake has completed its parent-side prepared
 						// validation when this closure runs. The child is still
 						// blocked waiting for the admit frame.
@@ -253,6 +239,18 @@ func TestRepairWakeChildAdmissionRejectsNamespaceReplacementAfterParentValidatio
 				logData,
 			)
 		})
+	}
+}
+
+func replaceWakeRepairInboxDirectoryAtomicallyForTest(t *testing.T, root, me string) {
+	t.Helper()
+	inboxPath := fsq.AgentInboxNew(root, me)
+	replacementPath := inboxPath + ".replacement"
+	if err := os.Mkdir(replacementPath, 0o700); err != nil {
+		t.Fatalf("create replacement inbox directory: %v", err)
+	}
+	if err := exchangeWakeRepairDirectoriesForTest(replacementPath, inboxPath); err != nil {
+		t.Fatalf("atomically replace inbox directory: %v", err)
 	}
 }
 

--- a/internal/cli/wake_repair_namespace_unix_test.go
+++ b/internal/cli/wake_repair_namespace_unix_test.go
@@ -249,6 +249,9 @@ func replaceWakeRepairInboxDirectoryAtomicallyForTest(t *testing.T, root, me str
 	if err := os.Mkdir(replacementPath, 0o700); err != nil {
 		t.Fatalf("create replacement inbox directory: %v", err)
 	}
+	// A plain os.Rename cannot replace inbox/new once it contains handoff
+	// messages. The platform exchange remains atomic and preserves the
+	// original directory at replacementPath for post-condition checks.
 	if err := exchangeWakeRepairDirectoriesForTest(replacementPath, inboxPath); err != nil {
 		t.Fatalf("atomically replace inbox directory: %v", err)
 	}


### PR DESCRIPTION
## Summary

- replace direct-inbox namespace test setup with an atomic directory exchange
- use the native Darwin and Linux exchange primitives under build tags
- retain conclusive-only ownership-loss assertions and document why admission remains fail-closed

## Why

The release CI exposed a race in the test induction: `rename` followed by `mkdir` created a real ENOENT window. The wake correctly failed admission and reaped the prepared child, but the test sampled that transient observation instead of the completed inode replacement it claimed to exercise. Atomic exchange removes the gap without weakening production delivery or its safety assertions.

## Verification

- focused namespace/lifecycle tests `-count=100`
- focused namespace/lifecycle tests under `-race -count=20`
- Linux amd64 CGO-disabled test cross-compile
- `go test ./... -count=1 -timeout=12m`
- `go vet ./...`
- `git diff --check`
- fresh independent exact-diff review: PASS

Release PR #373 remains held until this PR is green and merged.
