### PR TITLE
fix(send): refuse ambiguous self-delivery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ When `--kind` is set but `--priority` is not, priority defaults to `normal`.
 
 ```bash
 amq init --root <path> --agents a,b,c [--force]
-amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--refs <ids>] [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--session <target-session>] [--from-session <source-session>] [--project <project>] [--ignore-session-pin] [--wait-for <stage>] [--wait-timeout <duration>]
+amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--refs <ids>] [--body <str|@file|-|stdin>] [--allow-empty] [--allow-self] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--session <target-session>] [--from-session <source-session>] [--project <project>] [--ignore-session-pin] [--wait-for <stage>] [--wait-timeout <duration>]
 amq list --me <agent> [--session <name>] [--new | --cur] [--priority <p>] [--from <h>] [--kind <k>] [--label <l>...] [--limit N] [--offset N] [--json]
 amq read --me <agent> --id <msg_id> [--session <name>] [--ignore-session-pin] [--json]
 amq drain --me <agent> [--session <name>] [--ignore-session-pin] [--limit N] [--include-body] [--json]

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -26,6 +26,7 @@ func runSend(args []string) error {
 	threadFlag := fs.String("thread", "", "Thread id (required for multiple recipients; default p2p/<a>__<b> for single-recipient sends)")
 	bodyFlag := fs.String("body", "", "Body string, @file, or - / empty to read stdin")
 	allowEmptyFlag := fs.Bool("allow-empty", false, "Allow sending a blank body (otherwise an empty body is rejected)")
+	allowSelfFlag := fs.Bool("allow-self", false, "Allow an intentional same-root send to the sender's own handle")
 	refsFlag := fs.String("refs", "", "Comma-separated related message ids")
 	waitForFlag := fs.String("wait-for", "", "Wait for receipt stage after send (drained, dlq)")
 	waitTimeoutFlag := fs.Duration("wait-timeout", 120*time.Second, "Timeout for --wait-for (0 = wait forever)")
@@ -181,6 +182,18 @@ func runSend(args []string) error {
 	if fromSession == "" && (!pin.Present || !pin.IdentityPin) {
 		if err := guardPinnedSourceContext("send", sourceRoot, targetProject != "", *ignoreSessionPinFlag, common.rootExplicit()); err != nil {
 			return err
+		}
+	}
+	if !routed && !*allowSelfFlag {
+		for _, recipient := range recipients {
+			if recipient == me {
+				return UsageError(
+					"refusing send: recipient %q matches the sender and no routing dimension was given. "+
+						"Use --project <peer> or --session <name> to reach another instance, "+
+						"or pass --allow-self to confirm an intentional same-root self-send.",
+					me,
+				)
+			}
 		}
 	}
 	sourceProject := ""

--- a/internal/cli/send_cross_root_test.go
+++ b/internal/cli/send_cross_root_test.go
@@ -113,6 +113,109 @@ func TestSend_AllowsBareRootWithoutIdentity(t *testing.T) {
 	}
 }
 
+func TestSend_RefusesUnroutedSameRootSelfAddress(t *testing.T) {
+	root := sessionRoot(t, t.TempDir(), "collab", "claude")
+
+	err := runSend([]string{
+		"--root", root,
+		"--me", "claude",
+		"--to", "claude",
+		"--body", "ambiguous self-send",
+	})
+	if err == nil {
+		t.Fatal("expected self-send refusal, got nil")
+	}
+	if code := GetExitCode(err); code != ExitUsage {
+		t.Fatalf("exit code = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(err.Error(), "--allow-self") {
+		t.Fatalf("error should name the explicit escape hatch, got: %v", err)
+	}
+	if n := inboxCount(t, root, "claude"); n != 0 {
+		t.Fatalf("self-send refusal delivered %d message(s)", n)
+	}
+}
+
+func TestSend_AllowSelfConfirmsUnroutedSameRootSelfAddress(t *testing.T) {
+	root := sessionRoot(t, t.TempDir(), "collab", "claude")
+
+	if err := runSend([]string{
+		"--root", root,
+		"--me", "claude",
+		"--to", "claude",
+		"--body", "intentional self-send",
+		"--allow-self",
+	}); err != nil {
+		t.Fatalf("intentional self-send: %v", err)
+	}
+	header := soleDeliveredHeader(t, root, "claude")
+	if header.From != "claude" || len(header.To) != 1 || header.To[0] != "claude" {
+		t.Fatalf("unexpected self-send header: %+v", header)
+	}
+}
+
+func TestSend_RefusesSelfRecipientBeforeMultiRecipientDelivery(t *testing.T) {
+	root := sessionRoot(t, t.TempDir(), "collab", "claude", "codex")
+
+	err := runSend([]string{
+		"--root", root,
+		"--me", "claude",
+		"--to", "codex,claude",
+		"--thread", "topic/ambiguous-self-send",
+		"--body", "must not deliver partially",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--allow-self") {
+		t.Fatalf("expected self-recipient refusal, got: %v", err)
+	}
+	for _, agent := range []string{"claude", "codex"} {
+		if n := inboxCount(t, root, agent); n != 0 {
+			t.Fatalf("self-recipient refusal delivered %d message(s) to %s", n, agent)
+		}
+	}
+}
+
+func TestSend_AllowsRoutedSameHandleWithoutAllowSelf(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, ".agent-mail")
+	sourceRoot := sessionRoot(t, tmp, "collab", "claude")
+	targetRoot := sessionRoot(t, tmp, "auth", "claude")
+	pinSendSessionForTest(t, base, sourceRoot, "collab")
+
+	if err := runSend([]string{
+		"--me", "claude",
+		"--to", "claude",
+		"--session", "auth",
+		"--body", "routed same-handle message",
+	}); err != nil {
+		t.Fatalf("routed same-handle send: %v", err)
+	}
+	header := soleDeliveredHeader(t, targetRoot, "claude")
+	if header.ReplyTo != "claude@collab" {
+		t.Fatalf("reply_to = %q, want %q", header.ReplyTo, "claude@collab")
+	}
+}
+
+func TestSend_AllowSelfDoesNotBypassCrossTreeGuard(t *testing.T) {
+	tmp := t.TempDir()
+	sourceRoot := sessionRoot(t, filepath.Join(tmp, "projA"), "collab", "claude")
+	targetRoot := sessionRoot(t, filepath.Join(tmp, "projB"), "collab", "claude")
+	t.Setenv("AM_ROOT", sourceRoot)
+
+	err := runSend([]string{
+		"--root", targetRoot,
+		"--me", "claude",
+		"--to", "claude",
+		"--body", "must stay local",
+		"--allow-self",
+	})
+	if err == nil || !strings.Contains(err.Error(), "different AMQ tree") {
+		t.Fatalf("--allow-self bypassed the cross-tree guard: %v", err)
+	}
+	if n := inboxCount(t, targetRoot, "claude"); n != 0 {
+		t.Fatalf("cross-tree refusal delivered %d message(s)", n)
+	}
+}
+
 // TestSend_AllowsRedundantSameTreeRoot: an explicit --root equal to (or within)
 // the caller's own tree is not a crossing and must be allowed.
 func TestSend_AllowsRedundantSameTreeRoot(t *testing.T) {

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -450,6 +450,8 @@ echo "evidence: tests green" | amq send --to codex --subject "done" --body -   #
 
 **Body is fail-closed.** `--body -` (or `--body @-`, or omitting `--body`) reads stdin; a literal string or `@file` is used as-is. A send whose resolved body is empty/whitespace is **rejected** with a usage error instead of delivering a blank message — so `--body -` with nothing piped fails loudly rather than shipping an empty body. Pass `--allow-empty` only when you truly want a blank body (subject carries everything).
 
+**Unrouted self-addressing is fail-closed.** When `--to` resolves to your own handle and no `--project`, `--session`, or `--from-session` routing dimension is present, `amq send` refuses the ambiguous same-root send. Use routing to reach another instance of the same handle. Pass `--allow-self` only to confirm an intentional same-root self-send; it does not bypass cross-tree or session-pin guards.
+
 **Send file paths, not file contents.** When attaching source code, configs, or large text for review, send the file path in the message body, not the contents inline. The receiver can open the file with their local tools. If the receiver cannot access that worktree, send a short diff instead of the full source.
 
 ### Filter

--- a/skills/amq-cli/references/cross-project.md
+++ b/skills/amq-cli/references/cross-project.md
@@ -39,6 +39,22 @@ amq send --to codex@proj-b:auth --body "to specific session"
 
 Flags take precedence over inline syntax.
 
+## Same-Handle Messages
+
+A matching sender and recipient handle has three distinct meanings:
+
+| Route | Meaning |
+|---|---|
+| `--project` is present | A different agent instance in another project. AMQ stamps `from_project` and reply routing metadata. |
+| `--session` or `--from-session` is present | A different agent instance in another session. AMQ stamps session reply routing metadata. |
+| No routing dimension is present | A same-root self-send with no provenance beyond the handle. `amq send` refuses it by default. |
+
+Use `--allow-self` only to confirm an intentional same-root self-send. The flag
+does not make `--root` a routing dimension, add reply metadata, or bypass the
+cross-tree and session-pin guards. To reach another instance of your handle,
+use `--project` or `--session` instead; routed same-handle sends do not require
+`--allow-self`.
+
 ## Session Defaults
 
 `--project proj-b` without `--session` delivers to the **same session name** in the peer project. If your source root is `.agent-mail/collab`, the message goes to `proj-b's .agent-mail/collab`. Override with explicit `--session`.


### PR DESCRIPTION
## Summary
- refuse an unrouted send whose recipient resolves to the sender's own handle
- add narrow `--allow-self` confirmation for intentional same-root self-delivery
- preserve routed same-handle delivery through `--project`, `--session`, and `--from-session`
- keep cross-tree/session-pin guards and reply routing unchanged

For multi-recipient sends, an unrouted self-recipient refuses the whole send before delivery, so no recipient receives a partial send.

## Verification
- peer approval bound to staged tree `f3fb5cfbb3fe79d904ffb70f4421d2c7add912a6`
- `make ci`
- real CLI execution of unrouted refusal, project/session/from-session routing, allow-self delivery, and cross-project reply
- darwin/linux/freebsd/windows amd64 builds

Closes #357
