### PR TITLE
feat(wake): expose restart capability probe

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -289,6 +289,23 @@ amq reply --id "msg_123" --kind review_response --body "LGTM with minor suggesti
 
 > Co-op works without wake. `coop exec` starts it automatically.
 
+Before replacing or repairing a wake, inspect its exact capability:
+
+```bash
+amq wake check --me codex
+amq wake check --me codex --json
+```
+
+This command never changes wake state. `restart_capability=agent_safe` is the
+only result an automated agent may act on, using the returned `next_action`.
+For `operator_only`, leave the live wake running and hand the action to its
+owning terminal or supervisor. For `unavailable`, preserve the state and
+diagnose it. A process without a controlling TTY must not kill or replace a
+live raw wake, and TIOCSTI refusal must not be treated as permission to weaken
+delivery to attention-only. The result includes both the running wake image and
+the currently invoked AMQ image; legacy locks may report unknown image fields.
+`amq doctor --ops` shares these fields for discovered locks.
+
 `amq wake` uses TIOCSTI to inject notifications into your terminal by default.
 Pass `--baseline-existing` when starting a new wake after the agent already
 owns its terminal. Messages already present in `inbox/new` remain unread and do

--- a/README.md
+++ b/README.md
@@ -294,12 +294,23 @@ silently select a different project's mailbox.
 amq doctor
 amq doctor --ops
 amq doctor --ops --json
+amq wake check --me codex
+amq wake check --me codex --json
 amq doctor --ops --fix-wake-locks
 amq wake repair --me codex
 amq wake recover-owner --me codex
 amq wake retire --me codex --inject-via /absolute/injector \
   --inject-arg exec --inject-arg terminal-id
 ```
+
+`amq wake check` is read-only. It reports whether the current process can start
+a full-strength wake, whether a saved inject-via target can repair the exact
+stale wake, and the running and current AMQ image path and version. Its
+`restart_capability` is one of `agent_safe`, `operator_only`, or `unavailable`,
+with an exact `next_action`. Automated agents may act only on `agent_safe`.
+They must leave a live wake running for `operator_only`, and must never turn a
+TIOCSTI refusal into an attention-only downgrade. `doctor --ops` exposes the
+same image and restart fields for every discovered wake lock.
 
 Wake locks reported by `doctor --ops` can be `stale`, `unverified`, or, in JSON
 output, any current lock state. With `--fix-wake-locks`, fixed and error states
@@ -528,7 +539,7 @@ Common command groups:
 | Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `trace`, `watch`, `monitor`, `receipts` |
 | Collaboration | `coop init`, `coop exec`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
-| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake repair`, `wake recover-owner`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
+| Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake check`, `wake repair`, `wake recover-owner`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 
 ### Exit codes
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -32,6 +32,13 @@ type doctorResult struct {
 	Ops *doctorOpsResult `json:"ops,omitempty"`
 }
 
+func wakeCheckTextValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "none"
+	}
+	return value
+}
+
 func runDoctor(args []string) error {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	jsonFlag := fs.Bool("json", false, "Output as JSON")
@@ -276,9 +283,6 @@ func runDoctor(args []string) error {
 		}
 		for _, wl := range result.Ops.WakeLocks {
 			if wl.Status == string(wakeLockValid) {
-				if wl.CurrentTerminal {
-					continue
-				}
 				tty := wl.TTY
 				if tty == "" {
 					tty = "unknown"
@@ -287,14 +291,36 @@ func runDoctor(args []string) error {
 				if started == "" {
 					started = "unknown"
 				}
-				line := fmt.Sprintf(
-					"  wake for %s is owned by a live process: pid=%d tty=%s started=%s root=%s; "+
-						"no AMQ command can safely take over this live wake",
-					wl.Agent,
-					wl.PID,
-					tty,
-					started,
-					wl.Root,
+				var line string
+				if wl.CurrentTerminal {
+					line = fmt.Sprintf(
+						"  wake for %s is live on the current terminal: pid=%d tty=%s started=%s root=%s",
+						wl.Agent,
+						wl.PID,
+						tty,
+						started,
+						wl.Root,
+					)
+				} else {
+					line = fmt.Sprintf(
+						"  wake for %s is owned by a live process: pid=%d tty=%s started=%s root=%s; "+
+							"no AMQ command can safely take over this live wake",
+						wl.Agent,
+						wl.PID,
+						tty,
+						started,
+						wl.Root,
+					)
+				}
+				line += fmt.Sprintf(
+					" running_image=%s running_version=%s current_image=%s current_version=%s image_status=%s restart=%s next=%s",
+					wakeCheckTextValue(wl.RunningImagePath),
+					wakeCheckTextValue(wl.RunningVersion),
+					wakeCheckTextValue(wl.CurrentImagePath),
+					wakeCheckTextValue(wl.CurrentVersion),
+					wakeCheckTextValue(wl.ImageStatus),
+					wakeCheckTextValue(wl.RestartCapability),
+					wakeCheckTextValue(wl.NextAction),
 				)
 				if err := writeStdoutLine(line); err != nil {
 					return err
@@ -330,6 +356,18 @@ func runDoctor(args []string) error {
 			}
 			if wl.RepairAvailable && wl.Status == string(wakeLockStale) {
 				line += " repair=" + wl.Repair
+			}
+			if wl.RestartCapability != "" {
+				line += fmt.Sprintf(
+					" running_image=%s running_version=%s current_image=%s current_version=%s image_status=%s restart=%s next=%s",
+					wakeCheckTextValue(wl.RunningImagePath),
+					wakeCheckTextValue(wl.RunningVersion),
+					wakeCheckTextValue(wl.CurrentImagePath),
+					wakeCheckTextValue(wl.CurrentVersion),
+					wakeCheckTextValue(wl.ImageStatus),
+					wl.RestartCapability,
+					wakeCheckTextValue(wl.NextAction),
+				)
 			}
 			if err := writeStdoutLine(line); err != nil {
 				return err

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -70,23 +70,34 @@ type opsWakeBinaryHint struct {
 }
 
 type opsWakeLock struct {
-	Status          string `json:"status"`
-	Agent           string `json:"agent"`
-	Root            string `json:"root"`
-	Lock            string `json:"lock"`
-	PID             int    `json:"pid,omitempty"`
-	TTY             string `json:"tty,omitempty"`
-	Started         string `json:"started,omitempty"`
-	Reason          string `json:"reason,omitempty"`
-	Fix             string `json:"fix,omitempty"`
-	Removed         bool   `json:"removed,omitempty"`
-	Target          string `json:"target,omitempty"`
-	TargetPresent   bool   `json:"target_present,omitempty"`
-	TargetReason    string `json:"target_reason,omitempty"`
-	Repair          string `json:"repair,omitempty"`
-	RepairAvailable bool   `json:"repair_available,omitempty"`
-	RepairReason    string `json:"repair_reason,omitempty"`
-	CurrentTerminal bool   `json:"-"`
+	Status                   string `json:"status"`
+	Agent                    string `json:"agent"`
+	Root                     string `json:"root"`
+	Lock                     string `json:"lock"`
+	PID                      int    `json:"pid,omitempty"`
+	TTY                      string `json:"tty,omitempty"`
+	Started                  string `json:"started,omitempty"`
+	Reason                   string `json:"reason,omitempty"`
+	Fix                      string `json:"fix,omitempty"`
+	Removed                  bool   `json:"removed,omitempty"`
+	Target                   string `json:"target,omitempty"`
+	TargetPresent            bool   `json:"target_present,omitempty"`
+	TargetReason             string `json:"target_reason,omitempty"`
+	Repair                   string `json:"repair,omitempty"`
+	RepairAvailable          bool   `json:"repair_available,omitempty"`
+	RepairReason             string `json:"repair_reason,omitempty"`
+	CanStartHere             bool   `json:"can_start_here"`
+	StartMode                string `json:"start_mode,omitempty"`
+	StartReason              string `json:"start_reason,omitempty"`
+	RunningImagePath         string `json:"running_image_path,omitempty"`
+	RunningVersion           string `json:"running_version,omitempty"`
+	CurrentImagePath         string `json:"current_image_path,omitempty"`
+	CurrentVersion           string `json:"current_version,omitempty"`
+	ImageStatus              string `json:"image_status,omitempty"`
+	RestartCapability        string `json:"restart_capability,omitempty"`
+	OperatorTerminalRequired bool   `json:"operator_terminal_required"`
+	NextAction               string `json:"next_action,omitempty"`
+	CurrentTerminal          bool   `json:"-"`
 }
 
 func runOpsChecks(root string, rootSource string, fixWakeLocks bool, explicitBaseRoot ...string) *doctorOpsResult {
@@ -345,6 +356,10 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeLock, []opsHint) {
 	var locks []opsWakeLock
 	var hints []opsHint
+	appendLock := func(lock opsWakeLock, inspection wakeLockInspection, staleBinary bool) {
+		decorateOpsWakeLockWithWakeCheck(root, &lock, inspection, staleBinary)
+		locks = append(locks, lock)
+	}
 	for _, agent := range agents {
 		if validateWakeLockAgentForInspection(root, agent) != nil {
 			continue
@@ -354,8 +369,10 @@ func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeL
 		if !inspection.Exists {
 			continue
 		}
+		staleBinary := false
 		if hint, ok := checkStaleWakeBinaryHint(inspection); ok {
 			hints = append(hints, hint)
+			staleBinary = true
 		}
 
 		lock := opsWakeLock{
@@ -378,7 +395,7 @@ func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeL
 			lock.Reason = "live raw wake orphan; stop the owning terminal or launchd supervisor"
 		}
 		if !mutationAuthorized {
-			locks = append(locks, lock)
+			appendLock(lock, inspection, staleBinary)
 			continue
 		}
 		target, exists, targetErr := readWakeTarget(root, agent)
@@ -395,7 +412,7 @@ func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeL
 		}
 		if inspection.Status == wakeLockStale {
 			if ownerBound {
-				locks = append(locks, lock)
+				appendLock(lock, inspection, staleBinary)
 				continue
 			}
 			lock.Fix = doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
@@ -434,7 +451,11 @@ func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeL
 				}
 			}
 		}
-		locks = append(locks, lock)
+		if lock.Removed {
+			inspection = inspectWakeLock(root, agent)
+			staleBinary = false
+		}
+		appendLock(lock, inspection, staleBinary)
 	}
 	return locks, hints
 }

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -536,6 +536,17 @@ func TestDoctorOpsTextReportsForeignLiveWakeAndSilencesCurrentTTY(t *testing.T) 
 	if strings.Contains(output, "owned by a live process") {
 		t.Fatalf("current-terminal wake was reported as foreign:\n%s", output)
 	}
+	for _, want := range []string{
+		"wake for codex is live on the current terminal",
+		"running_image=",
+		"current_image=",
+		"restart=operator_only",
+		"next=",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("current-terminal wake output missing %q:\n%s", want, output)
+		}
+	}
 }
 
 func TestRunOpsChecksFixRemovesProvenStartMismatch(t *testing.T) {
@@ -564,6 +575,9 @@ func TestRunOpsChecksFixRemovesProvenStartMismatch(t *testing.T) {
 	got := result.WakeLocks[0]
 	if got.Status != "fixed" || !got.Removed {
 		t.Fatalf("unexpected wake lock fix result: %#v", got)
+	}
+	if strings.Contains(got.NextAction, "remove the proven-stale lock") {
+		t.Fatalf("fixed wake advertised stale-lock removal again: %#v", got)
 	}
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Fatalf("proven stale lock still exists: %v", err)

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -69,6 +69,7 @@ func init() {
 			Summary: "Background waker (TIOCSTI injection, experimental)",
 			Handler: runWake,
 			Children: []CommandInfo{
+				{Name: "check", Summary: "Inspect wake start and restart capability without mutation", Handler: runWake},
 				{Name: "repair", Summary: "Restart a proven-stale wake from a saved inject-via target", Handler: runWake},
 				{Name: "recover-owner", Summary: "Recover an exact owner-bound wake claim", Handler: runWake},
 				{Name: "retire", Summary: "Stop an exact managed inject-via wake", Handler: runWake},

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -85,7 +85,7 @@ func TestChildNames(t *testing.T) {
 	}{
 		{name: "presence", want: []string{"set", "list"}},
 		{name: "dlq", want: []string{"list", "read", "retry", "purge"}},
-		{name: "wake", want: []string{"repair", "recover-owner", "retire"}},
+		{name: "wake", want: []string{"check", "repair", "recover-owner", "retire"}},
 		{name: "coop", want: []string{"init", "exec"}},
 		{name: "swarm", want: []string{"list", "join", "leave", "tasks", "claim", "complete", "fail", "block", "bridge"}},
 		{name: "receipts", want: []string{"list", "wait"}},
@@ -187,6 +187,9 @@ func TestGroupUsageLinesWakeIncludesLifecycleCommands(t *testing.T) {
 	lines, err := groupUsageLines(wake)
 	if err != nil {
 		t.Fatalf("groupUsageLines(wake): %v", err)
+	}
+	if !containsLine(lines, "check          Inspect wake start and restart capability without mutation") {
+		t.Fatal("groupUsageLines(wake) missing check subcommand")
 	}
 	if !containsLine(lines, "repair         Restart a proven-stale wake from a saved inject-via target") {
 		t.Fatal("groupUsageLines(wake) missing repair subcommand")

--- a/internal/cli/wake_check_other.go
+++ b/internal/cli/wake_check_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux
+
+package cli
+
+func decorateOpsWakeLockWithWakeCheck(
+	string,
+	*opsWakeLock,
+	wakeLockInspection,
+	bool,
+) {
+}

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -1,0 +1,433 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	wakeCheckSchema = 1
+
+	wakeRestartAgentSafe    = "agent_safe"
+	wakeRestartOperatorOnly = "operator_only"
+	wakeRestartUnavailable  = "unavailable"
+
+	wakeImageCurrent   = "current"
+	wakeImageDifferent = "different"
+	wakeImageUnknown   = "unknown"
+
+	wakeCheckUnknown = "unknown"
+)
+
+type wakeCheckResult struct {
+	Schema                   int    `json:"schema"`
+	Agent                    string `json:"agent"`
+	Root                     string `json:"root"`
+	CanStartHere             bool   `json:"can_start_here"`
+	StartMode                string `json:"start_mode"`
+	StartReason              string `json:"start_reason,omitempty"`
+	LiveWake                 bool   `json:"live_wake"`
+	WakeStatus               string `json:"wake_status"`
+	WakePID                  int    `json:"wake_pid,omitempty"`
+	WakeMode                 string `json:"wake_mode,omitempty"`
+	OwnerBound               bool   `json:"owner_bound"`
+	RunningImagePath         string `json:"running_image_path"`
+	RunningVersion           string `json:"running_version"`
+	CurrentImagePath         string `json:"current_image_path"`
+	CurrentVersion           string `json:"current_version"`
+	ImageStatus              string `json:"image_status"`
+	CanRepairInjectVia       bool   `json:"can_repair_inject_via"`
+	RepairReason             string `json:"repair_reason,omitempty"`
+	RestartCapability        string `json:"restart_capability"`
+	OperatorTerminalRequired bool   `json:"operator_terminal_required"`
+	NextAction               string `json:"next_action"`
+}
+
+type wakeStartCapability struct {
+	CanStart bool
+	Mode     string
+	Reason   string
+}
+
+func runWakeCheck(args []string) error {
+	fs := flag.NewFlagSet("wake check", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	usage := usageWithFlags(
+		fs,
+		"amq wake check --me <agent> [options]",
+		"Inspect wake start and restart capability without mutation.",
+		"",
+		"Reports whether this process can start a full-strength terminal wake,",
+		"whether an existing wake is live or repairable, the running and current",
+		"AMQ images, and the exact non-destructive next action.",
+		"",
+		"Only restart_capability=agent_safe authorizes an agent-side action.",
+	)
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if err := requireMe(common.Me); err != nil {
+		return err
+	}
+	me, err := normalizeHandle(common.Me)
+	if err != nil {
+		return UsageError("--me: %v", err)
+	}
+	root := resolveRoot(common.Root)
+	if err := validateKnownHandles(root, common.Strict, me); err != nil {
+		return err
+	}
+	if err := validateWakeLockAgent(root, me); err != nil {
+		return fmt.Errorf("inspect wake for %s: %w", me, err)
+	}
+
+	result := inspectWakeCheck(root, me)
+	if common.JSON {
+		return writeJSON(os.Stdout, result)
+	}
+	return writeWakeCheckText(result)
+}
+
+func inspectWakeCheck(root, me string) wakeCheckResult {
+	root = canonicalWakeRoot(root)
+	before := inspectWakeLock(root, me)
+	checked := checkWakeLocks(root, []string{me}, false)
+	inspection := inspectWakeLock(root, me)
+	var opsLock *opsWakeLock
+	if sameWakeCheckInspection(before, inspection) &&
+		inspection.Exists &&
+		len(checked) == 1 &&
+		checked[0].Agent == me {
+		opsLock = &checked[0]
+	}
+	result := buildWakeCheckResult(root, me, inspection, opsLock, true)
+	after := inspectWakeLock(root, me)
+	stable := sameWakeCheckInspection(before, inspection) &&
+		sameWakeCheckInspection(inspection, after)
+	if !stable {
+		result.CanRepairInjectVia = false
+		result.RepairReason = "wake state changed during inspection"
+		result.RestartCapability = wakeRestartUnavailable
+		result.OperatorTerminalRequired = false
+		result.NextAction = "wake state changed during inspection; retry amq wake check"
+	}
+	return result
+}
+
+func sameWakeCheckInspection(first, second wakeLockInspection) bool {
+	if !first.Exists || !second.Exists {
+		return !first.Exists && !second.Exists
+	}
+	return first.Status == second.Status &&
+		first.IdentityConfirmed == second.IdentityConfirmed &&
+		sameWakeLockGeneration(first, second) &&
+		sameWakeBinaryProcessEvidence(first.Process, second.Process)
+}
+
+func buildWakeCheckResult(
+	root, me string,
+	inspection wakeLockInspection,
+	opsLock *opsWakeLock,
+	probeImage bool,
+) wakeCheckResult {
+	// probeImage is intentionally enabled only for the single-target wake
+	// check. Fleet doctor scans stay cheap and conservative: they reuse already
+	// validated "different" evidence but never claim "current" from versions
+	// alone.
+	start := inspectWakeStartCapability(me)
+	result := wakeCheckResult{
+		Schema:           wakeCheckSchema,
+		Agent:            me,
+		Root:             root,
+		CanStartHere:     start.CanStart,
+		StartMode:        start.Mode,
+		StartReason:      start.Reason,
+		WakeStatus:       string(inspection.Status),
+		WakePID:          inspection.PID,
+		WakeMode:         strings.TrimSpace(inspection.Lock.WakeMode),
+		OwnerBound:       classifyWakeClaimForGenericTransition(inspection) == wakeClaimAuthoritative,
+		RunningImagePath: wakeCheckUnknown,
+		RunningVersion:   wakeCheckUnknown,
+		CurrentImagePath: wakeCheckCurrentImagePath(),
+		CurrentVersion:   wakeCheckVersion(cliVersion),
+		ImageStatus:      wakeImageUnknown,
+	}
+	if !inspection.Exists {
+		result.WakeStatus = string(wakeLockMissing)
+	}
+	result.LiveWake = inspection.Exists &&
+		inspection.Status == wakeLockValid &&
+		inspection.IdentityConfirmed &&
+		inspection.Process.Running
+	if result.LiveWake {
+		result.RunningImagePath = wakeCheckRunningImagePath(inspection)
+		result.RunningVersion = wakeCheckVersion(inspection.Lock.ImageVersion)
+		if opsLock != nil && opsLock.ImageStatus == wakeImageDifferent {
+			result.ImageStatus = opsLock.ImageStatus
+		} else if probeImage {
+			result.ImageStatus = inspectWakeCheckImageStatus(inspection, result)
+		}
+	}
+
+	if opsLock != nil {
+		result.CanRepairInjectVia = opsLock.RepairAvailable
+		result.RepairReason = opsLock.RepairReason
+	}
+	if !result.CanRepairInjectVia && result.RepairReason == "" {
+		result.RepairReason = wakeCheckRepairIneligibility(inspection, result.OwnerBound)
+	}
+	classifyWakeCheckRestart(&result, inspection, opsLock)
+	return result
+}
+
+func decorateOpsWakeLockWithWakeCheck(
+	root string,
+	lock *opsWakeLock,
+	inspection wakeLockInspection,
+	staleBinary bool,
+) {
+	root = canonicalWakeRoot(root)
+	runningVersion := wakeCheckVersion(inspection.Lock.ImageVersion)
+	currentVersion := wakeCheckVersion(cliVersion)
+	switch {
+	case runningVersion != wakeCheckUnknown &&
+		currentVersion != wakeCheckUnknown &&
+		runningVersion != currentVersion:
+		lock.ImageStatus = wakeImageDifferent
+	case staleBinary:
+		lock.ImageStatus = wakeImageDifferent
+	default:
+		lock.ImageStatus = wakeImageUnknown
+	}
+	check := buildWakeCheckResult(root, lock.Agent, inspection, lock, false)
+	lock.CanStartHere = check.CanStartHere
+	lock.StartMode = check.StartMode
+	lock.StartReason = check.StartReason
+	lock.RunningImagePath = check.RunningImagePath
+	lock.RunningVersion = check.RunningVersion
+	lock.CurrentImagePath = check.CurrentImagePath
+	lock.CurrentVersion = check.CurrentVersion
+	lock.ImageStatus = check.ImageStatus
+	lock.RestartCapability = check.RestartCapability
+	lock.OperatorTerminalRequired = check.OperatorTerminalRequired
+	lock.NextAction = check.NextAction
+}
+
+func inspectWakeStartCapability(me string) wakeStartCapability {
+	mode := effectiveInjectMode(&wakeConfig{me: me, injectMode: wakeInjectModeAuto})
+	if !wakeTIOCSTIAvailable() {
+		return wakeStartCapability{
+			Mode:   wakeInjectModeNone,
+			Reason: "TIOCSTI is unavailable; a full-strength terminal wake cannot start here",
+		}
+	}
+	if tiocstiLegacyDisabledHint() {
+		return wakeStartCapability{
+			Mode:   wakeInjectModeNone,
+			Reason: "TIOCSTI is disabled; a full-strength terminal wake cannot start here",
+		}
+	}
+	if !wakeInputIsTTY() {
+		return wakeStartCapability{
+			Mode:   mode,
+			Reason: "stdin is not a TTY; start the wake from its owning terminal",
+		}
+	}
+	return wakeStartCapability{CanStart: true, Mode: mode}
+}
+
+func classifyWakeCheckRestart(
+	result *wakeCheckResult,
+	inspection wakeLockInspection,
+	opsLock *opsWakeLock,
+) {
+	startCommand := wakeStartCommand(result.Root, result.Agent)
+	if !inspection.Exists {
+		switch {
+		case result.CanStartHere && result.StartMode != wakeInjectModeNone:
+			result.RestartCapability = wakeRestartAgentSafe
+			result.NextAction = startCommand
+		case result.StartMode == wakeInjectModeNone:
+			result.RestartCapability = wakeRestartUnavailable
+			result.NextAction = "restore a supported full-strength injector or configure --inject-via; do not accept an attention-only downgrade"
+		default:
+			result.RestartCapability = wakeRestartOperatorOnly
+			result.OperatorTerminalRequired = true
+			result.NextAction = "from the owning terminal, run " + startCommand
+		}
+		return
+	}
+	if result.CanRepairInjectVia && opsLock != nil {
+		result.RestartCapability = wakeRestartAgentSafe
+		result.NextAction = opsLock.Repair
+		return
+	}
+	if result.LiveWake {
+		result.RestartCapability = wakeRestartOperatorOnly
+		result.OperatorTerminalRequired =
+			result.WakeMode != wakeTargetInjectVia &&
+				result.WakeMode != wakeOwnerWakeMode
+		result.NextAction = "leave the live wake running; restart it from its owning terminal or supervisor after verifying replacement readiness"
+		return
+	}
+	switch inspection.Status {
+	case wakeLockStale:
+		if result.OwnerBound {
+			result.RestartCapability = wakeRestartUnavailable
+			result.NextAction = wakeRecoverOwnerCommand(result.Root, result.Agent)
+			return
+		}
+		result.RestartCapability = wakeRestartOperatorOnly
+		result.OperatorTerminalRequired = true
+		result.NextAction = fmt.Sprintf(
+			"from the owning terminal, remove the proven-stale lock with %s, then run %s",
+			doctorRootCommandForOS(result.Root, "", runtime.GOOS, "--ops", "--fix-wake-locks"),
+			startCommand,
+		)
+	case wakeLockCreating:
+		result.RestartCapability = wakeRestartUnavailable
+		result.NextAction = "leave wake state unchanged and retry after lock creation finishes"
+	default:
+		result.RestartCapability = wakeRestartUnavailable
+		result.NextAction = "preserve the unverified wake state and inspect it with amq doctor --ops"
+	}
+}
+
+func inspectWakeCheckImageStatus(
+	inspection wakeLockInspection,
+	result wakeCheckResult,
+) string {
+	if result.RunningVersion != wakeCheckUnknown &&
+		result.CurrentVersion != wakeCheckUnknown &&
+		result.RunningVersion != result.CurrentVersion {
+		return wakeImageDifferent
+	}
+	comparison, err := inspectWakeBinaryStaleness(inspection)
+	if err != nil {
+		return wakeImageUnknown
+	}
+	if comparison.Stale {
+		return wakeImageDifferent
+	}
+	if comparison.Method == wakeBinaryComparisonExactIdentity ||
+		(result.RunningVersion != wakeCheckUnknown &&
+			result.CurrentVersion != wakeCheckUnknown &&
+			result.RunningVersion == result.CurrentVersion) {
+		return wakeImageCurrent
+	}
+	return wakeImageUnknown
+}
+
+func wakeCheckCurrentImagePath() string {
+	path, resolved, err := resolveWakeExecutablePath()
+	if err != nil {
+		return wakeCheckUnknown
+	}
+	if strings.TrimSpace(resolved) != "" {
+		path = resolved
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return wakeCheckUnknown
+	}
+	return filepath.Clean(path)
+}
+
+func wakeCheckRunningImagePath(inspection wakeLockInspection) string {
+	for _, candidate := range []string{
+		inspection.Lock.ImagePath,
+		inspection.Process.Executable,
+		inspection.Lock.Executable,
+	} {
+		candidate = strings.TrimSpace(candidate)
+		if candidate != "" && filepath.IsAbs(candidate) {
+			return filepath.Clean(candidate)
+		}
+	}
+	return wakeCheckUnknown
+}
+
+func wakeCheckVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return wakeCheckUnknown
+	}
+	return version
+}
+
+func wakeCheckRepairIneligibility(inspection wakeLockInspection, ownerBound bool) string {
+	switch {
+	case !inspection.Exists:
+		return "no wake lock is present"
+	case ownerBound:
+		return "owner-bound wake state cannot use inject-via repair"
+	case inspection.Status == wakeLockValid:
+		return "wake is live; repair only accepts proven-stale or eligible unverified inject-via state"
+	case inspection.Status != wakeLockStale:
+		return "wake state is not proven repairable"
+	default:
+		return "no exact inject-via target and continuity floor are available"
+	}
+}
+
+func wakeStartCommand(root, me string) string {
+	return fmt.Sprintf(
+		"amq wake --root %s --me %s",
+		shellQuoteArg(root),
+		shellQuoteArg(me),
+	)
+}
+
+func writeWakeCheckText(result wakeCheckResult) error {
+	lines := []string{
+		"AMQ Wake Check",
+		fmt.Sprintf("  Agent: %s", result.Agent),
+		fmt.Sprintf("  Root: %s", result.Root),
+		fmt.Sprintf(
+			"  Direct start: %t (mode=%s reason=%s)",
+			result.CanStartHere,
+			result.StartMode,
+			wakeCheckTextValue(result.StartReason),
+		),
+		fmt.Sprintf(
+			"  Live wake: %t (status=%s pid=%d mode=%s owner_bound=%t)",
+			result.LiveWake,
+			result.WakeStatus,
+			result.WakePID,
+			wakeCheckTextValue(result.WakeMode),
+			result.OwnerBound,
+		),
+		fmt.Sprintf(
+			"  Running image: %s (version=%s status=%s)",
+			result.RunningImagePath,
+			result.RunningVersion,
+			result.ImageStatus,
+		),
+		fmt.Sprintf(
+			"  Current image: %s (version=%s)",
+			result.CurrentImagePath,
+			result.CurrentVersion,
+		),
+		fmt.Sprintf(
+			"  Inject-via repair: %t (reason=%s)",
+			result.CanRepairInjectVia,
+			wakeCheckTextValue(result.RepairReason),
+		),
+		fmt.Sprintf("  Restart capability: %s", result.RestartCapability),
+		fmt.Sprintf("  Next action: %s", result.NextAction),
+	}
+	for _, line := range lines {
+		if err := writeStdoutLine(line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cli/wake_check_unix_test.go
+++ b/internal/cli/wake_check_unix_test.go
@@ -1,0 +1,601 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type wakeCheckWire struct {
+	Schema                   int    `json:"schema"`
+	Agent                    string `json:"agent"`
+	Root                     string `json:"root"`
+	CanStartHere             bool   `json:"can_start_here"`
+	StartMode                string `json:"start_mode"`
+	StartReason              string `json:"start_reason"`
+	LiveWake                 bool   `json:"live_wake"`
+	WakeStatus               string `json:"wake_status"`
+	WakePID                  int    `json:"wake_pid"`
+	WakeMode                 string `json:"wake_mode"`
+	OwnerBound               bool   `json:"owner_bound"`
+	RunningImagePath         string `json:"running_image_path"`
+	RunningVersion           string `json:"running_version"`
+	CurrentImagePath         string `json:"current_image_path"`
+	CurrentVersion           string `json:"current_version"`
+	ImageStatus              string `json:"image_status"`
+	CanRepairInjectVia       bool   `json:"can_repair_inject_via"`
+	RepairReason             string `json:"repair_reason"`
+	RestartCapability        string `json:"restart_capability"`
+	OperatorTerminalRequired bool   `json:"operator_terminal_required"`
+	NextAction               string `json:"next_action"`
+}
+
+func TestWakeCheckReportsAgentSafeDirectStartFromTTYWithoutMutation(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.49.14")
+	before := snapshotWakeCheckTree(t, root)
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("wake check: %v", err)
+	}
+	var got wakeCheckWire
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check JSON: %v\n%s", err, output)
+	}
+	if got.Schema != 1 || got.Agent != "codex" || got.Root != canonicalWakeRoot(root) {
+		t.Fatalf("identity = %#v", got)
+	}
+	if !got.CanStartHere || got.StartMode != wakeInjectModeRaw || got.LiveWake {
+		t.Fatalf("direct start capability = %#v", got)
+	}
+	if got.RestartCapability != "agent_safe" || got.OperatorTerminalRequired {
+		t.Fatalf("restart capability = %#v", got)
+	}
+	wantAction := "amq wake --root " + shellQuoteArg(canonicalWakeRoot(root)) + " --me codex"
+	if got.NextAction != wantAction {
+		t.Fatalf("next_action = %q, want %q", got.NextAction, wantAction)
+	}
+	assertWakeCheckTreeUnchanged(t, root, before)
+}
+
+func TestWakeCheckReportsLiveStaleRawImageAndRequiresOwningTerminal(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	const (
+		pid            = 4242
+		runningPath    = "/opt/homebrew/Cellar/amq/0.49.12/bin/amq"
+		runningVersion = "0.49.12"
+	)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          pid,
+		TTY:          "/dev/ttys005",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-31T01:00:00Z",
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		Executable:   "amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "live-raw-generation",
+		ImagePath:    runningPath,
+		ImageVersion: runningVersion,
+	})
+	lockBefore, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        gotPID,
+			Running:    true,
+			StartToken: "12345",
+			BootID:     "11111111-1111-1111-1111-111111111111",
+			Executable: "amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return wakeBinaryStaleness{
+			Stale:    true,
+			Method:   wakeBinaryComparisonStartedMTime,
+			Evidence: stableWakeBinaryEvidenceForTest(),
+		}, nil
+	})
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("wake check: %v", err)
+	}
+	var got wakeCheckWire
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check JSON: %v\n%s", err, output)
+	}
+	if got.CanStartHere || !got.LiveWake || got.WakeStatus != string(wakeLockValid) ||
+		got.WakePID != pid || got.WakeMode != wakeInjectModeRaw || got.OwnerBound {
+		t.Fatalf("live wake = %#v", got)
+	}
+	if got.RunningImagePath != runningPath || got.RunningVersion != runningVersion ||
+		got.CurrentVersion != "0.49.14" || got.ImageStatus != "different" {
+		t.Fatalf("image evidence = %#v", got)
+	}
+	if got.RestartCapability != "operator_only" || !got.OperatorTerminalRequired {
+		t.Fatalf("restart capability = %#v", got)
+	}
+	for _, want := range []string{"leave the live wake running", "owning terminal"} {
+		if !strings.Contains(got.NextAction, want) {
+			t.Fatalf("next_action missing %q: %q", want, got.NextAction)
+		}
+	}
+	lockAfter, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(lockBefore, lockAfter) {
+		t.Fatal("wake check changed the live lock")
+	}
+}
+
+func TestWakeCheckReportsLegacyLiveImageEvidenceAsUnknown(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		TTY:          "/dev/ttys005",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-31T01:00:00Z",
+		ProcessStart: "12345",
+		BootID:       "legacy-boot",
+		Executable:   "amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "legacy-live-generation",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "12345",
+			BootID:     "legacy-boot",
+			Executable: "amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return wakeBinaryStaleness{}, errors.New("legacy lock has no binary identity evidence")
+	})
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("wake check: %v", err)
+	}
+	var got wakeCheckWire
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check JSON: %v\n%s", err, output)
+	}
+	if !got.LiveWake || got.WakeStatus != string(wakeLockValid) {
+		t.Fatalf("legacy live wake = %#v", got)
+	}
+	if got.RunningImagePath != wakeCheckUnknown ||
+		got.RunningVersion != wakeCheckUnknown ||
+		got.ImageStatus != wakeImageUnknown {
+		t.Fatalf("legacy image evidence = %#v, want unknown", got)
+	}
+}
+
+func TestDoctorOpsSharesWakeRestartAndImageEvidence(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"codex"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		TTY:          "/dev/ttys005",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-31T01:00:00Z",
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		Executable:   "amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "doctor-live-raw-generation",
+		ImagePath:    "/opt/homebrew/Cellar/amq/0.49.12/bin/amq",
+		ImageVersion: "0.49.12",
+	})
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        gotPID,
+			Running:    true,
+			StartToken: "12345",
+			BootID:     "11111111-1111-1111-1111-111111111111",
+			Executable: "amq",
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return wakeBinaryStaleness{
+			Stale:    true,
+			Method:   wakeBinaryComparisonStartedMTime,
+			Evidence: stableWakeBinaryEvidenceForTest(),
+		}, nil
+	})
+
+	result := runOpsChecks(root, "test", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake locks = %#v", result.WakeLocks)
+	}
+	got := result.WakeLocks[0]
+	if got.RunningImagePath != "/opt/homebrew/Cellar/amq/0.49.12/bin/amq" ||
+		got.RunningVersion != "0.49.12" ||
+		got.CurrentVersion != "0.49.14" ||
+		got.ImageStatus != wakeImageDifferent {
+		t.Fatalf("doctor image evidence = %#v", got)
+	}
+	if got.RestartCapability != wakeRestartOperatorOnly ||
+		!got.OperatorTerminalRequired ||
+		!strings.Contains(got.NextAction, "leave the live wake running") {
+		t.Fatalf("doctor restart capability = %#v", got)
+	}
+}
+
+func TestDoctorOpsDoesNotClaimCurrentImageFromVersionAlone(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"codex"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "12345",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "same-version-generation",
+		ImagePath:    "/opt/homebrew/bin/amq",
+		ImageVersion: "0.49.14",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "12345",
+			BootID:     "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return wakeBinaryStaleness{}, errors.New("binary evidence unavailable")
+	})
+
+	result := runOpsChecks(root, "test", false)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("wake locks = %#v", result.WakeLocks)
+	}
+	if got := result.WakeLocks[0].ImageStatus; got != wakeImageUnknown {
+		t.Fatalf("image_status = %q, want %q without binary identity evidence", got, wakeImageUnknown)
+	}
+}
+
+func TestWakeCheckReportsEligibleInjectViaRepairAsAgentSafe(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-31T01:00:00Z",
+		ProcessStart: "12345",
+		BootID:       wakeRepairTestBootID,
+		Executable:   "amq",
+		WakeMode:     wakeTargetInjectVia,
+		TargetDigest: targetDigest,
+		Generation:   "stale-inject-via-generation",
+	})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+	stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+		return wakeProcessInfo{PID: gotPID}
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("wake check: %v", err)
+	}
+	var got wakeCheckWire
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check JSON: %v\n%s", err, output)
+	}
+	if !got.CanRepairInjectVia || got.RestartCapability != wakeRestartAgentSafe {
+		t.Fatalf("repair capability = %#v", got)
+	}
+	wantAction := wakeRepairCommand(canonicalWakeRoot(root), "codex")
+	if got.NextAction != wantAction {
+		t.Fatalf("next_action = %q, want %q", got.NextAction, wantAction)
+	}
+}
+
+func TestWakeCheckPreservesUnverifiedWakeState(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		ProcessStart: "same-start",
+		BootID:       "recorded-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		Generation:   "unverified-generation",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "same-start",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, true, "0.49.14")
+	before := snapshotWakeCheckTree(t, root)
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("wake check: %v", err)
+	}
+	var got wakeCheckWire
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check JSON: %v\n%s", err, output)
+	}
+	if got.WakeStatus != string(wakeLockUnverified) ||
+		got.RestartCapability != wakeRestartUnavailable ||
+		got.NextAction != "preserve the unverified wake state and inspect it with amq doctor --ops" {
+		t.Fatalf("unverified capability = %#v", got)
+	}
+	assertWakeCheckTreeUnchanged(t, root, before)
+}
+
+func TestWakeCheckRefusesAttentionOnlyDowngrade(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.49.14")
+	readTIOCSTILegacySysctl = func() ([]byte, error) { return []byte("0\n"), nil }
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("wake check: %v", err)
+	}
+	var got wakeCheckWire
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check JSON: %v\n%s", err, output)
+	}
+	if got.CanStartHere || got.StartMode != wakeInjectModeNone ||
+		got.RestartCapability != wakeRestartUnavailable ||
+		!strings.Contains(got.NextAction, "do not accept an attention-only downgrade") {
+		t.Fatalf("attention-only capability = %#v", got)
+	}
+}
+
+func TestWakeCheckRefusesCapabilityFromChangingWakeState(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	baseLock := wakeLock{
+		PID:          4242,
+		TTY:          "/dev/ttys005",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-31T01:00:00Z",
+		ProcessStart: "same-start",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "first-generation",
+	}
+	writeWakeLockForTest(t, root, "codex", baseLock)
+	inspections := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspections++
+		if inspections == 2 {
+			replacement := baseLock
+			replacement.Generation = "replacement-generation"
+			writeWakeLockExactForTest(t, root, "codex", replacement)
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "same-start",
+			BootID:     "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return wakeBinaryStaleness{}, nil
+	})
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("wake check: %v", err)
+	}
+	var got wakeCheckWire
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check JSON: %v\n%s", err, output)
+	}
+	if got.RestartCapability != wakeRestartUnavailable ||
+		got.CanRepairInjectVia ||
+		got.NextAction != "wake state changed during inspection; retry amq wake check" {
+		t.Fatalf("changing wake capability = %#v", got)
+	}
+}
+
+func TestWakeCheckTextPrintsExactClassifiedAction(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.49.14")
+	result := inspectWakeCheck(root, "codex")
+
+	output, err := captureEnvStdout(t, func() error {
+		return writeWakeCheckText(result)
+	})
+	if err != nil {
+		t.Fatalf("write wake check text: %v", err)
+	}
+	for _, want := range []string{
+		"Restart capability: " + result.RestartCapability,
+		"Next action: " + result.NextAction,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("wake check text missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestNewWakeLockCapturesRunningImageEvidence(t *testing.T) {
+	root := secureTempDirForTest(t)
+	oldVersion := cliVersion
+	cliVersion = "0.49.14-test"
+	t.Cleanup(func() { cliVersion = oldVersion })
+
+	lock, err := newWakeLock(root, "codex", wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeRaw,
+	})
+	if err != nil {
+		t.Fatalf("new wake lock: %v", err)
+	}
+	if lock.ImagePath == "" || !filepath.IsAbs(lock.ImagePath) {
+		t.Fatalf("image_path = %q, want absolute path", lock.ImagePath)
+	}
+	if lock.ImageVersion != "0.49.14-test" {
+		t.Fatalf("image_version = %q", lock.ImageVersion)
+	}
+}
+
+func stubWakeCheckRuntime(t *testing.T, tty bool, version string) {
+	t.Helper()
+	oldAvailable := wakeTIOCSTIAvailable
+	oldTTY := wakeInputIsTTY
+	oldRead := readTIOCSTILegacySysctl
+	oldVersion := cliVersion
+	oldResolve := resolveWakeExecutablePath
+	currentPath := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(currentPath, []byte("current"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	wakeTIOCSTIAvailable = func() bool { return true }
+	wakeInputIsTTY = func() bool { return tty }
+	readTIOCSTILegacySysctl = func() ([]byte, error) { return nil, os.ErrNotExist }
+	cliVersion = version
+	resolveWakeExecutablePath = func() (string, string, error) {
+		return currentPath, currentPath, nil
+	}
+	t.Cleanup(func() {
+		wakeTIOCSTIAvailable = oldAvailable
+		wakeInputIsTTY = oldTTY
+		readTIOCSTILegacySysctl = oldRead
+		cliVersion = oldVersion
+		resolveWakeExecutablePath = oldResolve
+	})
+}
+
+func snapshotWakeCheckTree(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	snapshot := map[string][]byte{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		snapshot[path] = append([]byte(nil), data...)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func assertWakeCheckTreeUnchanged(t *testing.T, root string, before map[string][]byte) {
+	t.Helper()
+	after := snapshotWakeCheckTree(t, root)
+	if len(after) != len(before) {
+		t.Fatalf("wake check changed file count: before=%d after=%d", len(before), len(after))
+	}
+	for path, want := range before {
+		got, ok := after[path]
+		if !ok || !bytes.Equal(got, want) {
+			t.Fatalf("wake check changed %s", path)
+		}
+	}
+}

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -25,6 +25,8 @@ type wakeLock struct {
 	BootID            string     `json:"boot_id,omitempty"`             // Boot identity paired with ProcessStart when available
 	Executable        string     `json:"executable,omitempty"`          // Diagnostic process executable basename/path
 	Args              []string   `json:"args,omitempty"`                // Diagnostic argv when available
+	ImagePath         string     `json:"image_path,omitempty"`          // Resolved executable path captured by the wake itself
+	ImageVersion      string     `json:"image_version,omitempty"`       // AMQ version embedded in the running wake image
 	WakeMode          string     `json:"wake_mode,omitempty"`           // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
 	TargetDigest      string     `json:"target_digest,omitempty"`       // Binds .wake.target to this lock instance
 	Generation        string     `json:"generation,omitempty"`          // Random nonce binding readiness and exact cleanup to this instance

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -519,6 +519,18 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 		Generation: hex.EncodeToString(generationBytes),
 		WakeMode:   options.wakeMode,
 	}
+	if imagePath, imageErr := os.Executable(); imageErr == nil {
+		imagePath = strings.TrimSpace(imagePath)
+		if imagePath != "" {
+			if resolved, resolveErr := filepath.EvalSymlinks(imagePath); resolveErr == nil {
+				imagePath = resolved
+			}
+			if filepath.IsAbs(imagePath) {
+				lock.ImagePath = filepath.Clean(imagePath)
+			}
+		}
+	}
+	lock.ImageVersion = strings.TrimSpace(cliVersion)
 	if options.target != nil {
 		targetDigest, err := wakeTargetDigest(*options.target)
 		if err != nil {
@@ -759,6 +771,8 @@ type wakeLoopFunc func(wakeConfig) error
 func runWake(args []string) error {
 	if len(args) > 0 {
 		switch args[0] {
+		case "check":
+			return runWakeCheck(args[1:])
 		case "repair":
 			return runWakeRepair(args[1:])
 		case "retire":

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -219,6 +219,8 @@ amq integration kanban bridge --me codex --workspace-id my-workspace
 amq doctor --ops
 amq doctor --ops --json
 amq doctor --root <exact-root> --ops
+amq wake check --me <agent>
+amq wake check --me <agent> --json
 
 # Base-config-only session repair outside the current pin
 amq doctor --root <session-root> --base-root <base-root> \
@@ -278,6 +280,15 @@ notification, not message consumption. `recent_activity` means only that
 `last_seen` is fresh. Use `drain` or `monitor` when consumption is required;
 run long-lived wake/monitor commands under launchd, systemd, or another
 supervisor rather than treating AMQ itself as a daemon.
+
+Before replacing a wake, run `amq wake check --me <agent> --json`. It is
+read-only and reports the running/current image path and version plus an exact
+`next_action`. An automated agent may act only when
+`restart_capability=agent_safe`. For `operator_only`, leave the live wake
+running and hand off to its owning terminal or supervisor. For `unavailable`,
+preserve the state and diagnose it. Never kill a live raw wake from a non-TTY
+process, and never accept an attention-only fallback as a replacement for
+full-strength input delivery.
 
 Those consuming commands, `watch`, and all DLQ commands refuse a raw
 target that conflicts with a complete `AM_BASE_ROOT`/`AM_SESSION` pin before


### PR DESCRIPTION
## Summary
- add mutation-free `amq wake check --me <agent> [--json]`
- expose direct-start, live-wake, image, repair, and restart capability evidence in `doctor --ops`
- capture running image path/version in new wake locks while preserving legacy-lock honesty
- document the non-TTY safety rule: never stop a live wake unless the probe reports `agent_safe`

This advances #356 Phase 1 only. It is a probe, not agent-safe restart. Existing wakes remain `operator_only` until Phase 2 ships, and current pre-protocol wakes require one operator/supervisor restart before they can adopt a future restart protocol.

## Verification
- peer approval bound to staged tree `e29c136ddda847de88ae4e6623fbc3cad3469c75`
- `make ci`
- focused legacy live-lock and image-evidence tests
- darwin/linux/freebsd/windows amd64 builds
- manual live-root check against a legacy raw wake

## Follow-ups
- extract the duplicated human `doctor --ops` wake-evidence suffix into a helper
- consider folding overlapping repair-ineligibility and restart-classification switches while preserving their current readable failure reasons

Advances #356
