### PR TITLE
test(smoke): isolate inherited AMQ context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,16 @@ lint:
 	@command -v golangci-lint >/dev/null 2>&1 || { echo "golangci-lint not installed. Install from https://golangci-lint.run/usage/install/"; exit 1; }
 	GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" golangci-lint run
 
+# Keep this hostile AMQ context tuple aligned with smoke-test.sh's startup scrub.
 smoke:
+	AM_ROOT=/smoke/inherited/root \
+	AM_ROOT_ID=smoke-inherited-root-id \
+	AM_ME=smoke-caller \
+	AM_BASE_ROOT=/smoke/inherited/base \
+	AM_BASE_ROOT_ID=smoke-inherited-base-root-id \
+	AM_SESSION=smoke-session \
+	AMQ_GLOBAL_ROOT=/smoke/inherited/global \
+	AMQ_WAKE_OWNER=smoke-inherited-wake-owner \
 	./scripts/smoke-test.sh
 
 ci: check-skills fmt-check vet lint test smoke

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Clear env vars that could interfere with explicit --root/--me flags. The
-# session guards treat AM_BASE_ROOT/AM_SESSION as positive caller context, so an
-# ambient coop session would otherwise make the temp queue look foreign.
-unset AM_ROOT AM_ME AM_BASE_ROOT AM_SESSION AMQ_GLOBAL_ROOT 2>/dev/null || true
+# Clear env vars that could interfere with explicit --root/--me flags. Session
+# identity tokens and wake ownership are one context with their path fields, so
+# retaining any of them would mix the caller's coop session into the temp queue.
+# Keep this list aligned with the hostile AMQ context tuple in Makefile's smoke target.
+unset AM_ROOT AM_ROOT_ID AM_ME AM_BASE_ROOT AM_BASE_ROOT_ID AM_SESSION \
+  AMQ_GLOBAL_ROOT AMQ_WAKE_OWNER 2>/dev/null || true
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
   GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE 2>/dev/null || true
 


### PR DESCRIPTION
## Summary
- scrub the complete inherited AMQ root/session/identity tuple before the smoke harness creates temporary roots
- permanently poison that tuple in the `make smoke` recipe so future omissions fail the real workflow
- cross-link the poison and scrub lists to prevent silent drift

The scrub is limited to ambient routing/identity authority. Behavior toggles and child-only private FDs remain untouched.

## Evidence
- RED on base with a real live coop environment: exit 5, incomplete session pin
- GREEN on the exact same ambient environment after the change: full smoke workflow exit 0
- peer approval bound to post-main tree `13d056c958eeb43767a71498634990e70cdded5b`
- full `make ci` on the exact combined tree
- poisoned `make smoke`
- `bash -n scripts/smoke-test.sh`
- diff check

A pre-existing unrelated strict-config replacement test flake observed during review is tracked separately in #381.

Closes #353
