### PR TITLE
fix(wake): silence superseded attention

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -1170,14 +1170,14 @@ func deliverWakeAttentionAfterInputRefusal(
 	if isWakeTerminalForegroundPGRPChanged(cause) {
 		return deliverWakeTransientAttention(cfg, payload, cause)
 	}
+	if isWakeTerminalAuthorityLoss(cause) {
+		// A replacement wake owns both terminal input and peer-rich attention.
+		// Let an inconclusive authority check continue narrating, but never let
+		// a conclusively stale driver speak alongside its replacement.
+		return cause
+	}
 	if err := deliverWakeAttentionOnly(cfg, payload); err != nil {
 		return errors.Join(cause, err)
-	}
-	if isWakeTerminalAuthorityLoss(cause) {
-		// Loss of the retained terminal or wake generation is fatal even when
-		// the final attention write succeeds. A replacement wake, not this
-		// stale owner, must retry the inbox cohort.
-		return cause
 	}
 	return nil
 }
@@ -1248,7 +1248,11 @@ func authorizeTerminalWrite(cfg *wakeConfig) (bool, error) {
 		cfg.terminalWrite == nil &&
 		cfg.root != "" &&
 		cfg.me != "" {
-		if !authorizeTerminalWritePlatform(cfg) {
+		allowed, err := authorizeTerminalWritePlatformState(cfg)
+		if err != nil {
+			return false, &wakeTerminalAuthorityError{err: err}
+		}
+		if !allowed {
 			return false, nil
 		}
 	}

--- a/internal/cli/wake_attention_fd_unix_test.go
+++ b/internal/cli/wake_attention_fd_unix_test.go
@@ -191,6 +191,7 @@ func TestRunWakeWithLoopSeparatesInheritedAttentionFromDiagnostics(t *testing.T)
 	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
 		t.Fatal(err)
 	}
+	deliverPartialWakeMessageForTest(t, root, "orchestrator", "attention-fd")
 
 	attentionRead, attentionWrite, err := os.Pipe()
 	if err != nil {
@@ -214,6 +215,7 @@ func TestRunWakeWithLoopSeparatesInheritedAttentionFromDiagnostics(t *testing.T)
 
 	t.Setenv(envWakeAttentionFD, strconv.Itoa(inheritedFD))
 	sentinel := errors.New("wake-loop-complete")
+	inputWrites := 0
 	var runErr error
 	stderr := captureWakeStderr(t, func() {
 		runErr = runWakeWithLoop([]string{
@@ -236,6 +238,15 @@ func TestRunWakeWithLoopSeparatesInheritedAttentionFromDiagnostics(t *testing.T)
 			}); err != nil {
 				t.Fatalf("emit inherited-FD attention: %v", err)
 			}
+			cfg.session = "session1"
+			cfg.previewLen = 80
+			cfg.terminalWrite = func(string) error {
+				inputWrites++
+				return nil
+			}
+			if err := notifyNewMessages(&cfg); err != nil {
+				t.Fatalf("emit peer notice to inherited attention FD: %v", err)
+			}
 			return sentinel
 		})
 	})
@@ -250,11 +261,17 @@ func TestRunWakeWithLoopSeparatesInheritedAttentionFromDiagnostics(t *testing.T)
 	if stderr != "diagnostic-only\n" {
 		t.Fatalf("diagnostic stream = %q, want only diagnostic", stderr)
 	}
+	if inputWrites != 0 {
+		t.Fatalf("output-only inherited attention wrote %d input chunks", inputWrites)
+	}
 	attentionOutput, err := io.ReadAll(attentionRead)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(attentionOutput), "attention-only\n"; got != want {
+	wantAttention := "attention-only\n" +
+		"AMQ [session1]: message from peer - attention-fd. " +
+		"Drain with: amq drain --include-body — then act on it\n"
+	if got, want := string(attentionOutput), wantAttention; got != want {
 		t.Fatalf("attention stream = %q, want %q", got, want)
 	}
 }

--- a/internal/cli/wake_attention_reannounce_unix_test.go
+++ b/internal/cli/wake_attention_reannounce_unix_test.go
@@ -1,0 +1,258 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func newGuardedWakeAttentionConfig(
+	root string,
+	inputWrites *int,
+	attention *[]string,
+) *wakeConfig {
+	return &wakeConfig{
+		root:          root,
+		me:            "codex",
+		session:       "session1",
+		injectMode:    wakeInjectModeRaw,
+		previewLen:    80,
+		controlStop:   make(chan struct{}),
+		doorbellNow:   func() time.Time { return time.Unix(1_800_000_000, 0) },
+		terminalWrite: func(string) error { *inputWrites++; return nil },
+		attentionIsTTY: func() bool {
+			return false
+		},
+		attentionWrite: func(data []byte) (int, error) {
+			*attention = append(*attention, string(data))
+			return len(data), nil
+		},
+	}
+}
+
+func TestSupersededWakeCannotEmitPeerAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		Generation: "incumbent",
+		TTY:        "unknown",
+	})
+
+	inputWrites := 0
+	var attention []string
+	cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+	cfg.terminalWrite = nil
+	cfg.terminalGeneration = "incumbent"
+	cfg.terminalTTY = "unknown"
+	if !authorizeTerminalWritePlatform(cfg) {
+		t.Fatal("test precondition: incumbent lock did not authorize terminal input")
+	}
+
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		Generation: "replacement",
+		TTY:        "unknown",
+	})
+	if authorizeTerminalWritePlatform(cfg) {
+		t.Fatal("test precondition: replacement lock still authorized terminal input")
+	}
+	stubTIOCSTIInject(t, func(string) error {
+		inputWrites++
+		return nil
+	})
+	deliverPartialWakeMessageForTest(t, root, "codex", "replacement-race")
+
+	err := notifyNewMessages(cfg)
+	if !isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("superseded wake result = %v, want terminal authority loss", err)
+	}
+	if inputWrites != 0 {
+		t.Fatalf("superseded wake injected %d terminal chunks", inputWrites)
+	}
+	if len(attention) != 0 {
+		t.Fatalf("superseded wake emitted peer attention: %#v", attention)
+	}
+	pending, readErr := os.ReadDir(fsq.AgentInboxNew(root, "codex"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := len(pending); got != 1 {
+		t.Fatalf("superseded wake changed durable inbox: %d messages", got)
+	}
+}
+
+func TestMissingWakeGenerationCannotEmitPeerAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverPartialWakeMessageForTest(t, root, "codex", "missing-generation")
+
+	inputWrites := 0
+	var attention []string
+	cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+	cfg.terminalWrite = nil
+	cfg.terminalGeneration = "missing"
+	cfg.terminalTTY = "unknown"
+	stubTIOCSTIInject(t, func(string) error {
+		inputWrites++
+		return nil
+	})
+
+	err := notifyNewMessages(cfg)
+	if !isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("missing-generation result = %v, want terminal authority loss", err)
+	}
+	if inputWrites != 0 {
+		t.Fatalf("missing-generation wake injected %d terminal chunks", inputWrites)
+	}
+	if len(attention) != 0 {
+		t.Fatalf("missing-generation wake emitted peer attention: %#v", attention)
+	}
+}
+
+func TestRetainedAuthorityLossCannotEmitPeerAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "retained-loss")
+
+	inputWrites := 0
+	var attention []string
+	cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+	cfg.beforeTerminalWrite = func() error {
+		return newWakeTerminalAuthorityLoss("wake generation changed")
+	}
+
+	err := notifyNewMessages(cfg)
+	if !isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("retained-authority result = %v, want terminal authority loss", err)
+	}
+	if inputWrites != 0 {
+		t.Fatalf("lost retained authority wrote %d terminal chunks", inputWrites)
+	}
+	if len(attention) != 0 {
+		t.Fatalf("lost retained authority emitted peer attention: %#v", attention)
+	}
+}
+
+func TestInconclusiveWakeGenerationKeepsPeerAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "inconclusive-generation")
+
+	inputWrites := 0
+	var attention []string
+	cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+	cfg.beforeTerminalWrite = func() error {
+		return newWakeTerminalTransientFailure(
+			"inspect current wake generation",
+			syscall.EMFILE,
+		)
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if inputWrites != 0 ||
+		len(attention) != 1 ||
+		!strings.Contains(attention[0], "message from peer - inconclusive-generation") ||
+		cfg.doorbell.attempts != 1 ||
+		!cfg.doorbell.nextAttempt.Equal(
+			cfg.doorbellNow().Add(wakeDoorbellAttentionRetryBase),
+		) {
+		t.Fatalf(
+			"inconclusive ownership silenced or mixed channels: input=%d attention=%#v state=%#v",
+			inputWrites,
+			attention,
+			cfg.doorbell,
+		)
+	}
+}
+
+func TestUnboundWakeAttentionDoesNotRequireGeneration(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*testing.T, string, *wakeConfig)
+	}{
+		{
+			name: "explicit output-only",
+			configure: func(_ *testing.T, _ string, cfg *wakeConfig) {
+				cfg.injectMode = wakeInjectModeNone
+				cfg.terminalGeneration = "missing"
+			},
+		},
+		{
+			name: "ownerless legacy without lock",
+			configure: func(_ *testing.T, _ string, cfg *wakeConfig) {
+				cfg.terminalWrite = nil
+			},
+		},
+		{
+			name: "malformed present lock",
+			configure: func(t *testing.T, root string, cfg *wakeConfig) {
+				t.Helper()
+				cfg.terminalWrite = nil
+				cfg.terminalGeneration = "incumbent"
+				cfg.terminalTTY = "unknown"
+				lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+				if err := os.WriteFile(lockPath, []byte("{"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			deliverPartialWakeMessageForTest(t, root, "codex", "attention")
+
+			inputWrites := 0
+			var attention []string
+			cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+			test.configure(t, root, cfg)
+
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("unbound attention result = %v", err)
+			}
+			if inputWrites != 0 {
+				t.Fatalf("unbound attention wrote %d terminal chunks", inputWrites)
+			}
+			if len(attention) != 1 ||
+				!strings.Contains(attention[0], "message from peer - attention") {
+				t.Fatalf("unbound attention = %#v", attention)
+			}
+		})
+	}
+}
+
+func TestParseableNewerOwnerGenerationIsConclusiveForLegacyGate(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+	if err := os.WriteFile(
+		lockPath,
+		[]byte(`{"generation":"newer","owner_schema":2}`),
+		wakeOwnerLockFileMode,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockUnverified ||
+		inspection.Lock.Generation != "newer" {
+		t.Fatalf("newer owner inspection = %#v", inspection)
+	}
+	allowed, err := authorizeTerminalWritePlatformState(&wakeConfig{
+		root:               root,
+		me:                 "codex",
+		terminalGeneration: "incumbent",
+		terminalTTY:        "unknown",
+	})
+	if allowed || !isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("newer owner authorization = (%t, %v), want conclusive loss", allowed, err)
+	}
+}

--- a/internal/cli/wake_terminal_authority_unix_test.go
+++ b/internal/cli/wake_terminal_authority_unix_test.go
@@ -989,8 +989,10 @@ func TestRunWakeLoopTerminatesOnTerminalAuthorityLoss(t *testing.T) {
 	if terminalWriteCalled {
 		t.Fatal("wake loop wrote after terminal authority loss")
 	}
-	if attentionWrites != 1 {
-		t.Fatalf("wake loop authority-loss attention writes = %d, want 1", attentionWrites)
+	// Conclusive authority loss means the terminal is no longer ours. Preserve
+	// the typed fatal exit without narrating into the lost destination.
+	if attentionWrites != 0 {
+		t.Fatalf("wake loop authority-loss attention writes = %d, want 0", attentionWrites)
 	}
 }
 

--- a/internal/cli/wake_terminal_guard_other.go
+++ b/internal/cli/wake_terminal_guard_other.go
@@ -6,6 +6,10 @@ func authorizeTerminalWritePlatform(*wakeConfig) bool {
 	return true
 }
 
+func authorizeTerminalWritePlatformState(*wakeConfig) (bool, error) {
+	return true, nil
+}
+
 func isWakeTerminalControlStopped(error) bool {
 	return false
 }

--- a/internal/cli/wake_terminal_guard_unix.go
+++ b/internal/cli/wake_terminal_guard_unix.go
@@ -5,31 +5,49 @@ package cli
 import "strings"
 
 func authorizeTerminalWritePlatform(cfg *wakeConfig) bool {
+	allowed, _ := authorizeTerminalWritePlatformState(cfg)
+	return allowed
+}
+
+func authorizeTerminalWritePlatformState(cfg *wakeConfig) (bool, error) {
 	current := inspectWakeLock(cfg.root, cfg.me)
-	if !current.Exists || current.Lock.Generation == "" {
-		return false
+	if !current.Exists {
+		if cfg.terminalGeneration != "" {
+			return false, newWakeTerminalAuthorityLoss("wake generation disappeared")
+		}
+		return false, nil
+	}
+	if current.Lock.Generation == "" {
+		// An empty or unreadable generation is not owner-identity evidence.
+		// Park input without silencing attention while ownership is inconclusive.
+		return false, nil
 	}
 	if cfg.terminalGeneration == "" {
 		cfg.terminalGeneration = current.Lock.Generation
 		cfg.terminalTTY = current.Lock.TTY
 	}
-	if current.Lock.Generation != cfg.terminalGeneration ||
-		current.Lock.TTY != cfg.terminalTTY {
-		return false
+	if current.Lock.Generation != cfg.terminalGeneration {
+		// A readable different generation is positive replacement evidence even
+		// when a newer lock schema is otherwise unverified. Mixed-version
+		// upgrades must supersede the old narrator instead of preserving it.
+		return false, newWakeTerminalAuthorityLoss("wake generation changed")
+	}
+	if current.Lock.TTY != cfg.terminalTTY {
+		return false, newWakeTerminalAuthorityLoss("wake terminal changed")
 	}
 	switch wakeLockTerminalAttachment(current) {
 	case wakeTerminalGone:
 		// The retained terminal capability may outlive controlling-terminal
 		// attachment. Preserve the legacy unknown-name fail-open policy; a
 		// concrete path still fails because it can no longer match current.
-		return !strings.HasPrefix(cfg.terminalTTY, "/dev/")
+		return !strings.HasPrefix(cfg.terminalTTY, "/dev/"), nil
 	case wakeTerminalAttached, wakeTerminalUndeterminable:
 		// A concrete path must still name this process's current terminal.
 		// Legacy "unknown" locks retain the prior fail-open behavior because
 		// writes use the wake's already-bound controlling-terminal capability.
 		return !strings.HasPrefix(cfg.terminalTTY, "/dev/") ||
-			getWakeCurrentTTY() == cfg.terminalTTY
+			getWakeCurrentTTY() == cfg.terminalTTY, nil
 	default:
-		return false
+		return false, nil
 	}
 }


### PR DESCRIPTION
## Summary

AMQ wake has two delivery channels: terminal input and peer-rich attention. The input channel already stopped when retained terminal authority was conclusively superseded, but the attention fallback could still narrate the same unread cohort from the stale wake alongside its replacement.

This change makes both channels obey the same retained-authority decision:

- suppress attention only when the wake has positive supersession evidence: its previously known generation disappeared, a readable different generation replaced it, or the terminal identity changed;
- keep input parked but continue bounded attention when authority evidence is inconclusive, including an empty or unreadable generation;
- treat a readable different generation as replacement evidence even when a newer lock schema is otherwise unverified, so mixed-version upgrades do not preserve an obsolete narrator.

No input retry, attention cadence, backoff, or durable inbox-completion semantics change.

## Scope

This closes the generation-exclusivity half of #377. The cadence-accumulation half—attention ladder behavior and pull-forward while messages are still arriving or not draining—remains open in #377.

## Verification

- `make ci`
- focused eight-test race run covering superseded, missing, malformed, empty, unreadable, output-only, and inherited-FD cases
- `GOOS=linux|darwin|freebsd|windows GOARCH=amd64 go build ./...`
- exact-tree peer review against commit `b1b7882c09182b0dfa191538dc92b722bbf340b6` / tree `99efef2862f854ce3b5c452bcfdbed1fb513bf6a`: PASS, zero findings

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestRunWakeLoopTerminatesOnTerminalAuthorityLoss: conclusive authority loss now suppresses attention to a terminal the wake no longer owns while preserving the typed fatal exit
END_WAKE_TEST_CHANGE_JUSTIFICATION
