### PR TITLE
fix(wake): fence cohort attention by generation

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -1187,6 +1187,9 @@ func deliverWakeTransientAttention(
 	payload wakePayload,
 	cause error,
 ) error {
+	if err := authorizePeerWakeAttention(cfg, payload); err != nil {
+		return err
+	}
 	now := cfg.wakeDoorbellNow()
 	if !cfg.doorbell.transientAttentionDue(now) {
 		return cause
@@ -1200,11 +1203,32 @@ func deliverWakeTransientAttention(
 }
 
 func deliverWakeAttentionOnly(cfg *wakeConfig, payload wakePayload) error {
+	if err := authorizePeerWakeAttention(cfg, payload); err != nil {
+		return err
+	}
 	if err := emitWakeAttention(cfg, payload); err != nil {
 		return err
 	}
 	cfg.lastAttemptAttention = true
 	return nil
+}
+
+func authorizePeerWakeAttention(cfg *wakeConfig, payload wakePayload) error {
+	if cfg == nil ||
+		payload.provenance == wakePayloadSystemFixed ||
+		cfg.root == "" ||
+		cfg.me == "" ||
+		strings.TrimSpace(cfg.terminalGeneration) == "" {
+		return nil
+	}
+	// Fence notifications fired by mailbox-cohort state, including
+	// operator-authored interrupt text. System-fixed notices describe this
+	// process's own state and remain available for diagnostics.
+	// The platform layer owns the single generation classifier. Its typed
+	// error is reserved for a missing or readable-different retained
+	// generation; false with no error parks input but keeps attention alive.
+	_, _, err := classifyWakeGenerationPlatformState(cfg)
+	return err
 }
 
 func usesCoopDoorbell(cfg *wakeConfig) bool {

--- a/internal/cli/wake_attention_reannounce_unix_test.go
+++ b/internal/cli/wake_attention_reannounce_unix_test.go
@@ -138,6 +138,130 @@ func TestRetainedAuthorityLossCannotEmitPeerAttention(t *testing.T) {
 	}
 }
 
+func TestSameGenerationTTYDriftKeepsPeerAttention(t *testing.T) {
+	tests := []struct {
+		name    string
+		lockTTY string
+		cfgTTY  string
+	}{
+		{
+			name:    "different TTY",
+			lockTTY: "replacement-tty",
+			cfgTTY:  "incumbent-tty",
+		},
+		{
+			name:    "empty lock TTY evidence",
+			lockTTY: "",
+			cfgTTY:  "incumbent-tty",
+		},
+		{
+			name:    "empty retained TTY evidence",
+			lockTTY: "incumbent-tty",
+			cfgTTY:  "",
+		},
+		{
+			name:    "both TTY fields empty",
+			lockTTY: "",
+			cfgTTY:  "",
+		},
+		{
+			name:    "both TTY fields whitespace",
+			lockTTY: " ",
+			cfgTTY:  " ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			writeWakeLockForTest(t, root, "codex", wakeLock{
+				Generation: "incumbent",
+				TTY:        test.lockTTY,
+			})
+			deliverPartialWakeMessageForTest(t, root, "codex", "same-generation")
+
+			inputWrites := 0
+			var attention []string
+			cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+			cfg.terminalWrite = nil
+			cfg.terminalGeneration = "incumbent"
+			cfg.terminalTTY = test.cfgTTY
+			stubTIOCSTIInject(t, func(string) error {
+				inputWrites++
+				return nil
+			})
+
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("same-generation TTY drift result = %v, want attention retry", err)
+			}
+			if inputWrites != 0 {
+				t.Fatalf("same-generation TTY drift injected %d terminal chunks", inputWrites)
+			}
+			if len(attention) != 1 ||
+				!strings.Contains(attention[0], "message from peer - same-generation") {
+				t.Fatalf(
+					"same-generation TTY drift attention = %#v, want one notice",
+					attention,
+				)
+			}
+		})
+	}
+}
+
+func TestWhitespaceWakeGenerationCannotAuthorizeInputOrSilenceAttention(t *testing.T) {
+	tests := []struct {
+		name        string
+		lockGen     string
+		retainedGen string
+	}{
+		{
+			name:        "whitespace lock generation",
+			lockGen:     " ",
+			retainedGen: "incumbent",
+		},
+		{
+			name:        "both generations whitespace",
+			lockGen:     " ",
+			retainedGen: " ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			writeWakeLockForTest(t, root, "codex", wakeLock{
+				Generation: test.lockGen,
+				TTY:        "unknown",
+			})
+			deliverPartialWakeMessageForTest(t, root, "codex", "whitespace-generation")
+
+			inputWrites := 0
+			var attention []string
+			cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+			cfg.terminalWrite = nil
+			cfg.terminalGeneration = test.retainedGen
+			cfg.terminalTTY = "unknown"
+			stubTIOCSTIInject(t, func(string) error {
+				inputWrites++
+				return nil
+			})
+
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("whitespace generation result = %v, want attention retry", err)
+			}
+			if inputWrites != 0 {
+				t.Fatalf("whitespace generation injected %d terminal chunks", inputWrites)
+			}
+			if len(attention) != 1 ||
+				!strings.Contains(attention[0], "message from peer - whitespace-generation") {
+				t.Fatalf("whitespace generation attention = %#v", attention)
+			}
+		})
+	}
+}
+
 func TestInconclusiveWakeGenerationKeepsPeerAttention(t *testing.T) {
 	root := secureTempDirForTest(t)
 	deliverPartialWakeMessageForTest(t, root, "codex", "inconclusive-generation")
@@ -180,7 +304,6 @@ func TestUnboundWakeAttentionDoesNotRequireGeneration(t *testing.T) {
 			name: "explicit output-only",
 			configure: func(_ *testing.T, _ string, cfg *wakeConfig) {
 				cfg.injectMode = wakeInjectModeNone
-				cfg.terminalGeneration = "missing"
 			},
 		},
 		{
@@ -226,6 +349,270 @@ func TestUnboundWakeAttentionDoesNotRequireGeneration(t *testing.T) {
 				t.Fatalf("unbound attention = %#v", attention)
 			}
 		})
+	}
+}
+
+func TestBoundOutputOnlyWakeStopsAfterGenerationSupersession(t *testing.T) {
+	modes := []struct {
+		name      string
+		configure func(*testing.T, *wakeConfig)
+	}{
+		{
+			name: "explicit output-only",
+			configure: func(_ *testing.T, cfg *wakeConfig) {
+				cfg.injectMode = wakeInjectModeNone
+			},
+		},
+		{
+			name: "input-demoted",
+			configure: func(t *testing.T, cfg *wakeConfig) {
+				t.Helper()
+				if err := disableWakeInput(cfg, nil); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	supersessions := []struct {
+		name  string
+		setup func(*testing.T, string)
+	}{
+		{
+			name: "generation disappeared",
+			setup: func(*testing.T, string) {
+				// A retained prior generation plus ENOENT is conclusive.
+			},
+		},
+		{
+			name: "generation replaced",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				writeWakeLockForTest(t, root, "codex", wakeLock{
+					Generation: "replacement",
+					TTY:        "unknown",
+				})
+			},
+		},
+	}
+
+	for _, mode := range modes {
+		for _, supersession := range supersessions {
+			t.Run(mode.name+"/"+supersession.name, func(t *testing.T) {
+				root := secureTempDirForTest(t)
+				ensureCoopWakeMailboxForTest(t, root, "codex")
+				supersession.setup(t, root)
+				deliverPartialWakeMessageForTest(t, root, "codex", "superseded-output")
+
+				inputWrites := 0
+				var attention []string
+				cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+				cfg.terminalGeneration = "incumbent"
+				cfg.terminalTTY = "unknown"
+				mode.configure(t, cfg)
+
+				err := notifyNewMessages(cfg)
+				if !isWakeTerminalAuthorityLoss(err) {
+					t.Fatalf(
+						"bound output-only supersession result = %v, want typed loss",
+						err,
+					)
+				}
+				if inputWrites != 0 {
+					t.Fatalf("bound output-only wake injected %d terminal chunks", inputWrites)
+				}
+				if len(attention) != 0 {
+					t.Fatalf(
+						"bound output-only wake emitted peer attention: %#v",
+						attention,
+					)
+				}
+				if got := classifyWakeFailure(err); got != wakeFailureFatal {
+					t.Fatalf("supersession disposition = %d, want fatal", got)
+				}
+			})
+		}
+	}
+}
+
+func TestBoundOutputOnlyWakeKeepsAttentionOnInconclusiveGeneration(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string)
+	}{
+		{
+			name: "empty generation",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				writeWakeLockForTest(t, root, "codex", wakeLock{
+					TTY: "unknown",
+				})
+			},
+		},
+		{
+			name: "malformed lock",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+				if err := os.WriteFile(lockPath, []byte("{"), wakeOwnerLockFileMode); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "same generation TTY drift",
+			setup: func(t *testing.T, root string) {
+				t.Helper()
+				writeWakeLockForTest(t, root, "codex", wakeLock{
+					Generation: "incumbent",
+					TTY:        "replacement-tty",
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			ensureCoopWakeMailboxForTest(t, root, "codex")
+			test.setup(t, root)
+			deliverPartialWakeMessageForTest(t, root, "codex", "inconclusive-output")
+
+			inputWrites := 0
+			var attention []string
+			cfg := newGuardedWakeAttentionConfig(root, &inputWrites, &attention)
+			cfg.injectMode = wakeInjectModeNone
+			cfg.terminalGeneration = "incumbent"
+			cfg.terminalTTY = "unknown"
+
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("inconclusive output-only result = %v", err)
+			}
+			if inputWrites != 0 {
+				t.Fatalf("inconclusive output-only wake injected %d chunks", inputWrites)
+			}
+			if len(attention) != 1 ||
+				!strings.Contains(attention[0], "message from peer - inconclusive-output") {
+				t.Fatalf("inconclusive output-only attention = %#v", attention)
+			}
+		})
+	}
+}
+
+func TestRunWakeLoopBoundOutputOnlyExitsAfterGenerationSupersession(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	attentionWrites := 0
+
+	err := runWakeLoop(wakeConfig{
+		root:               root,
+		me:                 "codex",
+		session:            "session1",
+		injectMode:         wakeInjectModeNone,
+		controlStop:        make(chan struct{}),
+		terminalGeneration: "incumbent",
+		terminalTTY:        "unknown",
+		attentionIsTTY:     func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
+		onPrepared: func(wakeAdmissionWatcher) error {
+			deliverPartialWakeMessageForTest(
+				t,
+				root,
+				"codex",
+				"superseded-output-loop",
+			)
+			return nil
+		},
+	})
+	if !isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("bound output-only wake exit = %v, want typed authority loss", err)
+	}
+	if attentionWrites != 0 {
+		t.Fatalf("superseded output-only loop emitted %d peer notices", attentionWrites)
+	}
+}
+
+func TestBoundWakeSelfDiagnosticAttentionIgnoresGenerationFence(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	var attention []string
+	cfg := newGuardedWakeAttentionConfig(root, new(int), &attention)
+	cfg.injectMode = wakeInjectModeNone
+	cfg.terminalGeneration = "missing"
+	cfg.terminalTTY = "unknown"
+
+	if err := deliverWakeAttentionOnly(cfg, wakePayload{
+		text:       "wake lock unreadable; injection paused",
+		provenance: wakePayloadSystemFixed,
+	}); err != nil {
+		t.Fatalf("self-diagnostic attention: %v", err)
+	}
+	if len(attention) != 1 ||
+		!strings.Contains(attention[0], "wake lock unreadable; injection paused") {
+		t.Fatalf("self-diagnostic attention = %#v", attention)
+	}
+}
+
+func TestWhitespaceRetainedGenerationDoesNotFenceOutputOnlyAttention(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	deliverPartialWakeMessageForTest(t, root, "codex", "no-prior-generation")
+
+	var attention []string
+	cfg := newGuardedWakeAttentionConfig(root, new(int), &attention)
+	cfg.injectMode = wakeInjectModeNone
+	cfg.terminalGeneration = " "
+	cfg.terminalTTY = "unknown"
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("whitespace retained generation result = %v", err)
+	}
+	if len(attention) != 1 ||
+		!strings.Contains(attention[0], "message from peer - no-prior-generation") {
+		t.Fatalf("whitespace retained generation attention = %#v", attention)
+	}
+}
+
+func TestBoundWakeOperatorAttentionStopsAfterGenerationSupersession(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	var attention []string
+	cfg := newGuardedWakeAttentionConfig(root, new(int), &attention)
+	cfg.injectMode = wakeInjectModeNone
+	cfg.terminalGeneration = "missing"
+	cfg.terminalTTY = "unknown"
+
+	err := deliverWakeAttentionOnly(cfg, wakePayload{
+		text:       "operator-authored interrupt notice",
+		provenance: wakePayloadOperatorFlag,
+	})
+	if !isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("operator attention result = %v, want typed authority loss", err)
+	}
+	if len(attention) != 0 {
+		t.Fatalf("superseded wake emitted operator attention: %#v", attention)
+	}
+}
+
+func TestBoundTransientPeerAttentionStopsAfterGenerationSupersession(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	var attention []string
+	cfg := newGuardedWakeAttentionConfig(root, new(int), &attention)
+	cfg.terminalGeneration = "missing"
+	cfg.terminalTTY = "unknown"
+
+	err := deliverWakeTransientAttention(cfg, wakePayload{
+		text:       "message from peer - transient",
+		provenance: wakePayloadPeerHeaders,
+	}, nil)
+	if !isWakeTerminalAuthorityLoss(err) {
+		t.Fatalf("transient peer attention result = %v, want typed authority loss", err)
+	}
+	if len(attention) != 0 {
+		t.Fatalf("superseded wake emitted transient peer attention: %#v", attention)
 	}
 }
 

--- a/internal/cli/wake_terminal_guard_other.go
+++ b/internal/cli/wake_terminal_guard_other.go
@@ -10,6 +10,12 @@ func authorizeTerminalWritePlatformState(*wakeConfig) (bool, error) {
 	return true, nil
 }
 
+func classifyWakeGenerationPlatformState(
+	*wakeConfig,
+) (wakeLockInspection, bool, error) {
+	return wakeLockInspection{}, true, nil
+}
+
 func isWakeTerminalControlStopped(error) bool {
 	return false
 }

--- a/internal/cli/wake_terminal_guard_unix.go
+++ b/internal/cli/wake_terminal_guard_unix.go
@@ -9,20 +9,24 @@ func authorizeTerminalWritePlatform(cfg *wakeConfig) bool {
 	return allowed
 }
 
-func authorizeTerminalWritePlatformState(cfg *wakeConfig) (bool, error) {
+func classifyWakeGenerationPlatformState(
+	cfg *wakeConfig,
+) (wakeLockInspection, bool, error) {
 	current := inspectWakeLock(cfg.root, cfg.me)
 	if !current.Exists {
-		if cfg.terminalGeneration != "" {
-			return false, newWakeTerminalAuthorityLoss("wake generation disappeared")
+		if strings.TrimSpace(cfg.terminalGeneration) != "" {
+			return current, false, newWakeTerminalAuthorityLoss(
+				"wake generation disappeared",
+			)
 		}
-		return false, nil
+		return current, false, nil
 	}
-	if current.Lock.Generation == "" {
+	if strings.TrimSpace(current.Lock.Generation) == "" {
 		// An empty or unreadable generation is not owner-identity evidence.
 		// Park input without silencing attention while ownership is inconclusive.
-		return false, nil
+		return current, false, nil
 	}
-	if cfg.terminalGeneration == "" {
+	if strings.TrimSpace(cfg.terminalGeneration) == "" {
 		cfg.terminalGeneration = current.Lock.Generation
 		cfg.terminalTTY = current.Lock.TTY
 	}
@@ -30,10 +34,30 @@ func authorizeTerminalWritePlatformState(cfg *wakeConfig) (bool, error) {
 		// A readable different generation is positive replacement evidence even
 		// when a newer lock schema is otherwise unverified. Mixed-version
 		// upgrades must supersede the old narrator instead of preserving it.
-		return false, newWakeTerminalAuthorityLoss("wake generation changed")
+		return current, false, newWakeTerminalAuthorityLoss(
+			"wake generation changed",
+		)
+	}
+	return current, true, nil
+}
+
+func authorizeTerminalWritePlatformState(cfg *wakeConfig) (bool, error) {
+	current, generationCurrent, err := classifyWakeGenerationPlatformState(cfg)
+	if err != nil || !generationCurrent {
+		return false, err
+	}
+	if strings.TrimSpace(current.Lock.TTY) == "" ||
+		strings.TrimSpace(cfg.terminalTTY) == "" {
+		// Absent TTY metadata cannot authorize input even when both missing
+		// values compare equal. The literal legacy value "unknown" remains a
+		// deliberate non-empty fail-open capability.
+		return false, nil
 	}
 	if current.Lock.TTY != cfg.terminalTTY {
-		return false, newWakeTerminalAuthorityLoss("wake terminal changed")
+		// The generation still belongs to this wake, so changed or absent TTY
+		// metadata cannot prove that a replacement narrator exists. Park input
+		// while keeping bounded attention alive.
+		return false, nil
 	}
 	switch wakeLockTerminalAttachment(current) {
 	case wakeTerminalGone:


### PR DESCRIPTION
## What this fixes

At base `2e9883c`, a bound output-only wake whose retained generation had disappeared did not fail a loop test—it hung indefinitely in the wake-loop select. Explicit output-only and input-demoted wakes bypassed generation classification before peer attention, so an old wake could keep narrating the unread cohort beside its replacement.

This follow-up to #383:

- uses one shared generation classifier for both terminal-input authorization and cohort-triggered attention;
- makes bound output-only and demoted wakes exit with typed authority loss when their prior generation is missing or readably different;
- fences both peer-header and operator-authored cohort notices, while keeping system-fixed self-diagnostics available;
- treats unreadable, malformed, empty, or whitespace-only generation evidence as inconclusive, preserving bounded attention;
- keeps same-generation TTY drift inconclusive for attention while barring terminal input;
- prevents equal empty or whitespace TTY fields from authorizing input (the base RED injected four terminal chunks).

No-prior-generation wakes continue narrating. Durable inbox progress remains the only delivery-completion authority, and retry/attention cadence is unchanged.

## Reachability

The same-generation TTY edge is latent: current code does not rewrite a lock's TTY while retaining its random generation. The output-only/demoted fence is operationally reachable on hardened hosts and during lane restarts, where an old demoted wake can overlap a replacement generation.

This closes the generation-fence gaps found after #383. The cadence-accumulation half of #377 remains open.

## Verification

- RED against `2e9883c`: superseded output-only loop hung; missing/replaced bound output-only and demoted wakes emitted attention; equal empty/whitespace TTY authorized four input chunks; whitespace generation either silenced attention or authorized input
- `make ci`
- focused final race suite covering bound/unbound, explicit-none/demoted, missing/replaced/inconclusive generations, TTY absence/drift, operator/transient attention, loop exit, and system-fixed diagnostics
- `GOOS=linux|darwin|freebsd|windows GOARCH=amd64 go build ./...`
- two independent fresh-context exact-tree reviews of commit `02372b3894b88fbca1ebce1949260317d17edbb2` / tree `4f29d58c6e0271a003de975042dd123ad24ffb3b`: PASS, zero findings

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestUnboundWakeAttentionDoesNotRequireGeneration: the explicit output-only case now represents a truly unbound wake with no prior generation; bound missing-generation behavior is covered by the new fatal supersession matrix
END_WAKE_TEST_CHANGE_JUSTIFICATION
