### PR TITLE
fix(wake): reject incoherent repair observations

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -353,6 +353,51 @@ func checkWakeLocks(root string, agents []string, fix bool) []opsWakeLock {
 	return locks
 }
 
+type wakeRepairAssessment struct {
+	TargetPresent   bool
+	TargetReason    string
+	RepairAvailable bool
+	RepairReason    string
+	Repair          string
+}
+
+type wakeTargetReader func() (wakeTarget, bool, error)
+type wakeRepairFloorValidator func(wakeTarget) error
+
+func assessWakeRepair(
+	root, agent string,
+	inspection wakeLockInspection,
+	readTarget wakeTargetReader,
+	validateFloor wakeRepairFloorValidator,
+) wakeRepairAssessment {
+	var assessment wakeRepairAssessment
+	target, exists, targetErr := readTarget()
+	assessment.TargetPresent = exists
+	if exists {
+		if targetErr != nil {
+			assessment.TargetReason = targetErr.Error()
+		} else if err := validateWakeTarget(target, root, agent); err != nil {
+			assessment.TargetReason = err.Error()
+		} else if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
+			assessment.TargetReason = err.Error()
+		}
+	}
+
+	ownerBound := classifyWakeClaimForGenericTransition(inspection) == wakeClaimAuthoritative
+	if inspection.Status != wakeLockStale || ownerBound ||
+		!assessment.TargetPresent || assessment.TargetReason != "" ||
+		validateWakeLockRepairable(inspection) != nil {
+		return assessment
+	}
+	if err := validateFloor(target); err != nil {
+		assessment.RepairReason = err.Error()
+		return assessment
+	}
+	assessment.RepairAvailable = true
+	assessment.Repair = wakeRepairCommand(root, agent)
+	return assessment
+}
+
 func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeLock, []opsHint) {
 	var locks []opsWakeLock
 	var hints []opsHint
@@ -398,17 +443,19 @@ func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeL
 			appendLock(lock, inspection, staleBinary)
 			continue
 		}
-		target, exists, targetErr := readWakeTarget(root, agent)
-		if exists {
+		assessment := assessWakeRepair(
+			root,
+			agent,
+			inspection,
+			func() (wakeTarget, bool, error) { return readWakeTarget(root, agent) },
+			func(target wakeTarget) error {
+				return validateWakeRepairFloorAvailable(root, agent, inspection, target)
+			},
+		)
+		if assessment.TargetPresent {
 			lock.Target = wakeTargetPath(root, agent)
 			lock.TargetPresent = true
-			if targetErr != nil {
-				lock.TargetReason = targetErr.Error()
-			} else if err := validateWakeTarget(target, root, agent); err != nil {
-				lock.TargetReason = err.Error()
-			} else if err := validateWakeTargetMatchesLock(inspection.Lock, target); err != nil {
-				lock.TargetReason = err.Error()
-			}
+			lock.TargetReason = assessment.TargetReason
 		}
 		if inspection.Status == wakeLockStale {
 			if ownerBound {
@@ -416,14 +463,9 @@ func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeL
 				continue
 			}
 			lock.Fix = doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
-			if lock.TargetPresent && lock.TargetReason == "" && validateWakeLockRepairable(inspection) == nil {
-				if err := validateWakeRepairFloorAvailable(root, agent, inspection, target); err != nil {
-					lock.RepairReason = err.Error()
-				} else {
-					lock.RepairAvailable = true
-					lock.Repair = wakeRepairCommand(root, agent)
-				}
-			}
+			lock.RepairAvailable = assessment.RepairAvailable
+			lock.RepairReason = assessment.RepairReason
+			lock.Repair = assessment.Repair
 			if fix {
 				guardErr := withWakeLifecycleGuard(root, agent, func() error {
 					recheck := inspectWakeLock(root, agent)

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 const (
@@ -55,6 +57,19 @@ type wakeStartCapability struct {
 	Reason   string
 }
 
+type wakeCheckMetadataFingerprint struct {
+	Exists   bool
+	Identity wakeFileIdentity
+	Digest   string
+}
+
+type wakeCheckObservation struct {
+	Inspection wakeLockInspection
+	Target     wakeCheckMetadataFingerprint
+	Floor      wakeCheckMetadataFingerprint
+	Repair     wakeRepairAssessment
+}
+
 func runWakeCheck(args []string) error {
 	fs := flag.NewFlagSet("wake check", flag.ContinueOnError)
 	common := addCommonFlags(fs)
@@ -98,27 +113,149 @@ func runWakeCheck(args []string) error {
 
 func inspectWakeCheck(root, me string) wakeCheckResult {
 	root = canonicalWakeRoot(root)
-	before := inspectWakeLock(root, me)
-	checked := checkWakeLocks(root, []string{me}, false)
-	inspection := inspectWakeLock(root, me)
-	var opsLock *opsWakeLock
-	if sameWakeCheckInspection(before, inspection) &&
-		inspection.Exists &&
-		len(checked) == 1 &&
-		checked[0].Agent == me {
-		opsLock = &checked[0]
+	first, firstErr := observeWakeCheck(root, me)
+	if firstErr != nil {
+		return unstableWakeCheckResult(root, me, first.Inspection)
 	}
-	result := buildWakeCheckResult(root, me, inspection, opsLock, true)
-	after := inspectWakeLock(root, me)
-	stable := sameWakeCheckInspection(before, inspection) &&
-		sameWakeCheckInspection(inspection, after)
-	if !stable {
-		result.CanRepairInjectVia = false
-		result.RepairReason = "wake state changed during inspection"
-		result.RestartCapability = wakeRestartUnavailable
-		result.OperatorTerminalRequired = false
-		result.NextAction = "wake state changed during inspection; retry amq wake check"
+	second, secondErr := observeWakeCheck(root, me)
+	if secondErr != nil || !sameWakeCheckObservation(first, second) {
+		return unstableWakeCheckResult(root, me, second.Inspection)
 	}
+	opsLock := opsWakeLockFromWakeCheckObservation(root, me, second)
+	return buildWakeCheckResult(root, me, second.Inspection, opsLock, true)
+}
+
+func observeWakeCheck(root, me string) (wakeCheckObservation, error) {
+	var observation wakeCheckObservation
+	agentPath := fsq.AgentBase(root, me)
+	if _, err := os.Lstat(agentPath); err != nil {
+		if os.IsNotExist(err) {
+			observation.Inspection = inspectWakeLock(root, me)
+			return observation, nil
+		}
+		return observation, fmt.Errorf("stat wake agent directory: %w", err)
+	}
+
+	agentDir, err := openWakeDirectory(agentPath, "wake agent directory")
+	if err != nil {
+		return observation, err
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	err = agentDir.withFD(func(dirfd int) error {
+		observation.Inspection = inspectWakeLockAt(dirfd, agentDir, root, me)
+		observation.Repair = assessWakeRepair(
+			root,
+			me,
+			observation.Inspection,
+			func() (wakeTarget, bool, error) {
+				snapshot, exists, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
+				observation.Target.Exists = exists
+				if err != nil || !exists {
+					return snapshot.Target, exists, err
+				}
+				fingerprint, err := newWakeCheckMetadataFingerprint(exists, snapshot.Raw, snapshot.FileInfo)
+				if err != nil {
+					return snapshot.Target, exists, err
+				}
+				observation.Target = fingerprint
+				return snapshot.Target, true, nil
+			},
+			func(target wakeTarget) error {
+				snapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)
+				observation.Floor.Exists = exists
+				if err != nil {
+					return err
+				}
+				if !exists {
+					return fmt.Errorf("wake repair floor is missing")
+				}
+				fingerprint, err := newWakeCheckMetadataFingerprint(exists, snapshot.Raw, snapshot.FileInfo)
+				if err != nil {
+					return err
+				}
+				observation.Floor = fingerprint
+				if err := validateWakeRepairFloor(
+					snapshot.Floor,
+					root,
+					me,
+					observation.Inspection.Lock,
+					target,
+				); err != nil {
+					return err
+				}
+				return validateWakeRepairFloorCurrentBoot(snapshot.Floor)
+			},
+		)
+		confirmed := inspectWakeLockAt(dirfd, agentDir, root, me)
+		// Catch a lock change that reverts before the outer observation comparison.
+		if !sameWakeCheckInspection(observation.Inspection, confirmed) {
+			return fmt.Errorf("wake state changed during inspection")
+		}
+		return nil
+	})
+	if err != nil {
+		return observation, err
+	}
+	if err := validateCanonicalWakeAgentDir(agentDir); err != nil {
+		return observation, err
+	}
+	return observation, nil
+}
+
+func newWakeCheckMetadataFingerprint(
+	exists bool,
+	raw []byte,
+	info os.FileInfo,
+) (wakeCheckMetadataFingerprint, error) {
+	fingerprint := wakeCheckMetadataFingerprint{Exists: exists}
+	if !exists {
+		return fingerprint, nil
+	}
+	identity, ok := captureWakeFileIdentity(info)
+	if !ok {
+		return fingerprint, fmt.Errorf("capture wake metadata file identity")
+	}
+	fingerprint.Identity = identity
+	fingerprint.Digest = wakeMetadataDigest(raw)
+	return fingerprint, nil
+}
+
+func sameWakeCheckObservation(first, second wakeCheckObservation) bool {
+	return sameWakeCheckInspection(first.Inspection, second.Inspection) &&
+		first.Target == second.Target &&
+		first.Floor == second.Floor &&
+		first.Repair == second.Repair
+}
+
+func opsWakeLockFromWakeCheckObservation(
+	root, me string,
+	observation wakeCheckObservation,
+) *opsWakeLock {
+	if !observation.Inspection.Exists {
+		return nil
+	}
+	opsLock := &opsWakeLock{
+		Agent:           me,
+		TargetPresent:   observation.Repair.TargetPresent,
+		TargetReason:    observation.Repair.TargetReason,
+		RepairAvailable: observation.Repair.RepairAvailable,
+		RepairReason:    observation.Repair.RepairReason,
+		Repair:          observation.Repair.Repair,
+	}
+	if opsLock.TargetPresent {
+		opsLock.Target = wakeTargetPath(root, me)
+	}
+	return opsLock
+}
+
+func unstableWakeCheckResult(root, me string, inspection wakeLockInspection) wakeCheckResult {
+	result := buildWakeCheckResult(root, me, inspection, nil, true)
+	result.CanRepairInjectVia = false
+	result.RepairReason = "wake state changed during inspection"
+	result.RestartCapability = wakeRestartUnavailable
+	result.OperatorTerminalRequired = false
+	result.NextAction = "wake state changed during inspection; retry amq wake check"
 	return result
 }
 

--- a/internal/cli/wake_check_unix_test.go
+++ b/internal/cli/wake_check_unix_test.go
@@ -368,6 +368,84 @@ func TestWakeCheckReportsEligibleInjectViaRepairAsAgentSafe(t *testing.T) {
 	}
 }
 
+func TestWakeCheckRefusesCapabilityFromChangingRepairMetadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, string, wakeTarget, wakeRepairFloor)
+	}{
+		{
+			name: "target changed",
+			mutate: func(t *testing.T, root string, target wakeTarget, _ wakeRepairFloor) {
+				t.Helper()
+				target.InjectArgs = append(target.InjectArgs, "changed-during-check")
+				if err := writeWakeTarget(root, "codex", target); err != nil {
+					t.Fatalf("replace wake target: %v", err)
+				}
+			},
+		},
+		{
+			name: "repair floor changed",
+			mutate: func(t *testing.T, root string, _ wakeTarget, floor wakeRepairFloor) {
+				t.Helper()
+				floor.Existing["changed-during-check.md"] = wakeFileIdentity{
+					Device: 1, Inode: 2, CTimeSec: 3, CTimeNsec: 4,
+				}
+				if err := writeWakeRepairFloor(root, "codex", floor); err != nil {
+					t.Fatalf("replace wake repair floor: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			injector := writeExecutableForTest(t, "injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+			targetDigest, err := wakeTargetDigest(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeWakeLockForTest(t, root, "codex", wakeLock{
+				PID:          4242,
+				Root:         canonicalWakeRoot(root),
+				Agent:        "codex",
+				Started:      "2026-07-31T01:00:00Z",
+				ProcessStart: "12345",
+				BootID:       wakeRepairTestBootID,
+				Executable:   "amq",
+				WakeMode:     wakeTargetInjectVia,
+				TargetDigest: targetDigest,
+				Generation:   "stale-inject-via-generation",
+			})
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatal(err)
+			}
+			floor := writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+
+			inspections := 0
+			stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+				inspections++
+				if inspections == 3 {
+					test.mutate(t, root, target, floor)
+				}
+				return wakeProcessInfo{PID: gotPID}
+			})
+			stubWakeCheckRuntime(t, false, "0.49.14")
+
+			got := inspectWakeCheck(root, "codex")
+			if got.RestartCapability != wakeRestartUnavailable ||
+				got.CanRepairInjectVia ||
+				got.NextAction != "wake state changed during inspection; retry amq wake check" {
+				t.Fatalf("changing repair metadata capability = %#v", got)
+			}
+		})
+	}
+}
+
 func TestWakeCheckPreservesUnverifiedWakeState(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {


### PR DESCRIPTION
## Why

`amq wake check` could combine a stable lock snapshot with repair metadata read at a different instant. Executed RED cases replaced either `.wake.target` or the repair floor while leaving the lock stable; both still returned `restart_capability=agent_safe` and `can_repair_inject_via=true` with the repair command.

## What changed

- Observe lock/process, target identity+digest, repair-floor identity+digest, and the shared repair verdict through a retained agent-directory descriptor.
- Require two equal complete observations before returning repair authority.
- Re-read the lock inside each repair-assessment window so a transient lock change cannot revert before the outer comparison.
- Share the existing repair classification with `doctor --ops` rather than duplicating it.

Any observation error or drift now returns `unavailable` with an explicit retry action. Stable repair-eligible state remains `agent_safe`.

No JSON/text schema or field-shape changed; unchanged `doctor --ops` states preserve the existing field values.

## Verification

- RED/GREEN: target-file drift and repair-floor drift
- `go test ./internal/cli -run "^(TestWakeCheck|TestDoctorOps|TestSend_)" -count=1`
- `go test ./internal/cli -count=1 -timeout=5m`
- `make ci`
- Linux/Darwin `go vet ./internal/cli`
- Linux/Darwin/FreeBSD/Windows `go build ./...`

Exact-tree peer gate PASS, zero blocking findings. Fresh-context verifier PASS, zero findings. Post-rebase commit `95d67e0a780d3837dbfa4e939cdb726ea3394c00`, tree `7fac6699a8dc5bd2d4091e5df3418242dc94bfae`, diff SHA-256 `b9108e2d627814c9f12237b2546a87c5346459cb3ff357c8297b69591ad5e8e0`.