### PR TITLE
feat(wake): add self-resume protocol foundation

### DIFF
--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -15,26 +15,29 @@ import (
 
 // wakeLock represents the lock file content for wake process deduplication.
 type wakeLock struct {
-	PID               int        `json:"pid"`
-	TTY               string     `json:"tty"`
-	Root              string     `json:"root"`                          // Absolute path to disambiguate relative AM_ROOT
-	Agent             string     `json:"agent,omitempty"`               // Agent handle that owns this lock
-	Hostname          string     `json:"hostname,omitempty"`            // Host that created the lock
-	Started           string     `json:"started"`                       // Wall-clock diagnostic timestamp
-	ProcessStart      string     `json:"process_start,omitempty"`       // Kernel process start token, guards PID reuse
-	BootID            string     `json:"boot_id,omitempty"`             // Boot identity paired with ProcessStart when available
-	Executable        string     `json:"executable,omitempty"`          // Diagnostic process executable basename/path
-	Args              []string   `json:"args,omitempty"`                // Diagnostic argv when available
-	ImagePath         string     `json:"image_path,omitempty"`          // Resolved executable path captured by the wake itself
-	ImageVersion      string     `json:"image_version,omitempty"`       // AMQ version embedded in the running wake image
-	WakeMode          string     `json:"wake_mode,omitempty"`           // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
-	TargetDigest      string     `json:"target_digest,omitempty"`       // Binds .wake.target to this lock instance
-	Generation        string     `json:"generation,omitempty"`          // Random nonce binding readiness and exact cleanup to this instance
-	SourceGeneration  string     `json:"source_generation,omitempty"`   // Dead generation inherited by a repaired wake
-	SourceFloorDigest string     `json:"source_floor_digest,omitempty"` // Exact repair floor inherited by a repaired wake
-	ControlSocket     string     `json:"control_socket,omitempty"`      // Darwin cooperative shutdown endpoint
-	OwnerSchema       int        `json:"owner_schema,omitempty"`        // Non-zero only for an authoritative owner-bound lock
-	Owner             *wakeOwner `json:"owner,omitempty"`               // Exact owner identity for an authoritative owner-bound lock
+	PID                  int                  `json:"pid"`
+	TTY                  string               `json:"tty"`
+	Root                 string               `json:"root"`                             // Absolute path to disambiguate relative AM_ROOT
+	Agent                string               `json:"agent,omitempty"`                  // Agent handle that owns this lock
+	Hostname             string               `json:"hostname,omitempty"`               // Host that created the lock
+	Started              string               `json:"started"`                          // Wall-clock diagnostic timestamp
+	ProcessStart         string               `json:"process_start,omitempty"`          // Kernel process start token, guards PID reuse
+	BootID               string               `json:"boot_id,omitempty"`                // Boot identity paired with ProcessStart when available
+	Executable           string               `json:"executable,omitempty"`             // Diagnostic process executable basename/path
+	Args                 []string             `json:"args,omitempty"`                   // Diagnostic argv when available
+	ImagePath            string               `json:"image_path,omitempty"`             // Resolved executable path captured by the wake itself
+	ImageVersion         string               `json:"image_version,omitempty"`          // AMQ version embedded in the running wake image
+	WakeMode             string               `json:"wake_mode,omitempty"`              // none, raw, paste, or inject-via; empty means a legacy pre-v0.44 lock
+	TargetDigest         string               `json:"target_digest,omitempty"`          // Binds .wake.target to this lock instance
+	Generation           string               `json:"generation,omitempty"`             // Random nonce binding readiness and exact cleanup to this instance
+	SourceGeneration     string               `json:"source_generation,omitempty"`      // Dead generation inherited by a repaired wake
+	SourceFloorDigest    string               `json:"source_floor_digest,omitempty"`    // Exact repair floor inherited by a repaired wake
+	ControlSocket        string               `json:"control_socket,omitempty"`         // Generation-derived cooperative control endpoint
+	OwnerSchema          int                  `json:"owner_schema,omitempty"`           // Non-zero only for an authoritative owner-bound lock
+	Owner                *wakeOwner           `json:"owner,omitempty"`                  // Exact owner identity for an authoritative owner-bound lock
+	ResumeSchema         int                  `json:"resume_schema,omitempty"`          // Agent-safe self-exec protocol; independent of OwnerSchema
+	ResumeOwner          *wakeOwner           `json:"resume_owner,omitempty"`           // Exact coop owner used only for reload authentication/lifetime
+	RunningImageEvidence *wakeImageEvidenceV1 `json:"running_image_evidence,omitempty"` // Serialized running-image authority
 }
 
 const (

--- a/internal/cli/wake_resume_image_unix.go
+++ b/internal/cli/wake_resume_image_unix.go
@@ -1,0 +1,105 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var captureCurrentWakeImageEvidence = captureCurrentWakeImageEvidenceDefault
+
+func captureCurrentWakeImageEvidenceDefault() (wakeImageEvidenceV1, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("resolve current wake executable: %w", err)
+	}
+	path = strings.TrimSpace(path)
+	if path == "" || !filepath.IsAbs(path) {
+		return wakeImageEvidenceV1{}, fmt.Errorf("current wake executable path is not absolute")
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("resolve current wake executable symlinks: %w", err)
+	}
+	return captureWakeImageEvidence(filepath.Clean(resolved), strings.TrimSpace(cliVersion))
+}
+
+func captureWakeImageEvidence(path, embeddedVersion string) (wakeImageEvidenceV1, error) {
+	path = strings.TrimSpace(path)
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image path must be a canonical absolute path")
+	}
+	lstat, err := os.Lstat(path)
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("stat wake image: %w", err)
+	}
+	if lstat.Mode()&os.ModeSymlink != 0 {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image must not be a symlink")
+	}
+	file, err := openWakeMetadataFile(path)
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("open wake image: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	before, err := file.Stat()
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("stat opened wake image: %w", err)
+	}
+	if !os.SameFile(lstat, before) {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image changed while opening")
+	}
+	if !before.Mode().IsRegular() {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image must be a regular file")
+	}
+	if before.Mode().Perm()&0o111 == 0 {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image is not executable")
+	}
+	if err := validateWakeTargetPathOwnership("wake image", path, before); err != nil {
+		return wakeImageEvidenceV1{}, err
+	}
+	identity, ok := captureWakeFileIdentity(before)
+	if !ok {
+		return wakeImageEvidenceV1{}, fmt.Errorf("capture wake image identity")
+	}
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("digest wake image: %w", err)
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("re-stat wake image: %w", err)
+	}
+	if !sameWakeFileIdentity(before, after) || before.Size() != after.Size() {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image changed while hashing")
+	}
+
+	method := wakeImageMethodFDExec
+	if runtime.GOOS == "darwin" {
+		method = wakeImageMethodPathnameExecVerified
+	}
+	evidence := wakeImageEvidenceV1{
+		Schema:          wakeImageEvidenceSchemaV1,
+		Platform:        runtime.GOOS,
+		Method:          method,
+		ExecutionPath:   path,
+		Device:          identity.Device,
+		Inode:           identity.Inode,
+		Size:            after.Size(),
+		CTimeNS:         identity.CTimeSec*1_000_000_000 + identity.CTimeNsec,
+		SHA256:          "sha256:" + hex.EncodeToString(hasher.Sum(nil)),
+		EmbeddedVersion: embeddedVersion,
+	}
+	if err := validateWakeImageEvidence(evidence); err != nil {
+		return wakeImageEvidenceV1{}, err
+	}
+	return evidence, nil
+}

--- a/internal/cli/wake_resume_protocol.go
+++ b/internal/cli/wake_resume_protocol.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	wakeResumeSchemaV2        = 2
+	wakeImageEvidenceSchemaV1 = 1
+
+	wakeImageMethodFDExec               = "fd_exec"
+	wakeImageMethodPathnameExecVerified = "pathname_execve_verified"
+)
+
+// wakeImageEvidenceV1 is serialized execution evidence, not a path/version
+// hint. Later waves use Method to preserve the honest platform asymmetry:
+// Linux retains an fd authority; Darwin immediately re-verifies the resolved
+// versioned pathname before execve.
+type wakeImageEvidenceV1 struct {
+	Schema          int    `json:"schema"`
+	Platform        string `json:"platform"`
+	Method          string `json:"method"`
+	ExecutionPath   string `json:"execution_path"`
+	Device          uint64 `json:"device"`
+	Inode           uint64 `json:"inode"`
+	Size            int64  `json:"size"`
+	CTimeNS         int64  `json:"ctime_ns"`
+	SHA256          string `json:"sha256"`
+	EmbeddedVersion string `json:"embedded_version"`
+}
+
+func validateWakeResumeAdvertisement(lock wakeLock) error {
+	if lock.ResumeSchema != wakeResumeSchemaV2 {
+		if lock.ResumeSchema == 0 {
+			return fmt.Errorf("wake resume schema is missing")
+		}
+		return fmt.Errorf("wake resume schema %d unsupported", lock.ResumeSchema)
+	}
+	if lock.ResumeOwner == nil {
+		return fmt.Errorf("wake resume owner is missing")
+	}
+	if err := validateAuthoritativeWakeOwner(*lock.ResumeOwner); err != nil {
+		return fmt.Errorf("wake resume owner is invalid: %w", err)
+	}
+	if strings.TrimSpace(lock.Generation) == "" {
+		return fmt.Errorf("wake resume generation is missing")
+	}
+	if err := validateAuthoritativeWakeProcessIdentity(lock); err != nil {
+		return fmt.Errorf("wake resume process identity is invalid: %w", err)
+	}
+	if strings.TrimSpace(lock.ControlSocket) == "" {
+		return fmt.Errorf("wake resume control endpoint is missing")
+	}
+	if lock.SourceGeneration != "" || lock.SourceFloorDigest != "" {
+		return fmt.Errorf("wake repair lineage is not resumable")
+	}
+	if lock.RunningImageEvidence == nil {
+		return fmt.Errorf("wake running image evidence is missing")
+	}
+	if err := validateWakeImageEvidence(*lock.RunningImageEvidence); err != nil {
+		return err
+	}
+	if lock.WakeMode == wakeOwnerWakeMode {
+		if lock.OwnerSchema != wakeOwnerLockSchema || lock.Owner == nil {
+			return fmt.Errorf("authoritative wake owner is incomplete")
+		}
+		if !sameWakeOwner(lock.Owner, lock.ResumeOwner) {
+			return fmt.Errorf("wake resume owner does not match authoritative wake owner")
+		}
+	}
+	return nil
+}
+
+func validateWakeImageEvidence(evidence wakeImageEvidenceV1) error {
+	if evidence.Schema != wakeImageEvidenceSchemaV1 {
+		return fmt.Errorf("wake image evidence schema %d unsupported", evidence.Schema)
+	}
+	if evidence.Platform != runtime.GOOS {
+		return fmt.Errorf("wake image platform %q does not match %q", evidence.Platform, runtime.GOOS)
+	}
+	expectedMethod := wakeImageMethodFDExec
+	if runtime.GOOS == "darwin" {
+		expectedMethod = wakeImageMethodPathnameExecVerified
+	}
+	if evidence.Method != expectedMethod {
+		return fmt.Errorf("wake image method %q does not match platform method %q", evidence.Method, expectedMethod)
+	}
+	path := strings.TrimSpace(evidence.ExecutionPath)
+	if path == "" || strings.ContainsRune(path, 0) || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return fmt.Errorf("wake image execution path must be a canonical absolute path")
+	}
+	if evidence.Device == 0 {
+		return fmt.Errorf("wake image device is missing")
+	}
+	if evidence.Inode == 0 {
+		return fmt.Errorf("wake image inode is missing")
+	}
+	if evidence.Size <= 0 {
+		return fmt.Errorf("wake image size must be positive")
+	}
+	if evidence.CTimeNS <= 0 {
+		return fmt.Errorf("wake image ctime is missing")
+	}
+	if !validWakeImageSHA256(evidence.SHA256) {
+		return fmt.Errorf("wake image sha256 is malformed")
+	}
+	version := strings.TrimSpace(evidence.EmbeddedVersion)
+	if version == "" || strings.ContainsRune(version, 0) || version != evidence.EmbeddedVersion {
+		return fmt.Errorf("wake image embedded version is missing or non-canonical")
+	}
+	return nil
+}
+
+func validWakeImageSHA256(value string) bool {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+64 {
+		return false
+	}
+	digest := value[len(prefix):]
+	if strings.ToLower(digest) != digest {
+		return false
+	}
+	decoded, err := hex.DecodeString(digest)
+	return err == nil && len(decoded) == 32
+}
+
+func wakeResumeStartupEligible(
+	owner *wakeOwner,
+	repairLineage bool,
+	injectCmd string,
+	interruptKey string,
+	wakeMode string,
+) bool {
+	if owner == nil || validateAuthoritativeWakeOwner(*owner) != nil || repairLineage ||
+		strings.TrimSpace(injectCmd) != "" || interruptKey != "" {
+		return false
+	}
+	switch wakeMode {
+	case wakeInjectModeRaw, wakeInjectModePaste, wakeInjectModeNone, wakeTargetInjectVia:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cli/wake_resume_protocol_unix_test.go
+++ b/internal/cli/wake_resume_protocol_unix_test.go
@@ -1,0 +1,354 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestCaptureWakeImageEvidenceBindsStableRegularExecutable(t *testing.T) {
+	dir := secureTempDirForTest(t)
+	path := filepath.Join(dir, "amq-0.50.2")
+	content := []byte("test executable image\n")
+	if err := os.WriteFile(path, content, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	evidence, err := captureWakeImageEvidence(path, "0.50.2")
+	if err != nil {
+		t.Fatalf("capture image evidence: %v", err)
+	}
+	wantDigest := sha256.Sum256(content)
+	if evidence.ExecutionPath != path || evidence.Size != int64(len(content)) ||
+		evidence.SHA256 != "sha256:"+hex.EncodeToString(wantDigest[:]) ||
+		evidence.EmbeddedVersion != "0.50.2" || evidence.Device == 0 ||
+		evidence.Inode == 0 || evidence.CTimeNS <= 0 {
+		t.Fatalf("evidence = %#v", evidence)
+	}
+	if err := validateWakeImageEvidence(evidence); err != nil {
+		t.Fatalf("captured evidence is invalid: %v", err)
+	}
+}
+
+func TestCaptureWakeImageEvidenceRejectsUnsafeFinalObject(t *testing.T) {
+	dir := secureTempDirForTest(t)
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("image"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(dir, "amq-link")
+	if err := os.Symlink(target, symlink); err != nil {
+		t.Fatal(err)
+	}
+	nonExecutable := filepath.Join(dir, "amq-non-executable")
+	if err := os.WriteFile(nonExecutable, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writable := filepath.Join(dir, "amq-writable")
+	if err := os.WriteFile(writable, []byte("image"), 0o722); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(writable, 0o722); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "final symlink", path: symlink, want: "symlink"},
+		{name: "not executable", path: nonExecutable, want: "not executable"},
+		{name: "group or world writable", path: writable, want: "group/world-writable"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := captureWakeImageEvidence(test.path, "0.50.2")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func validWakeResumeOwnerForTest() wakeOwner {
+	return wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+}
+
+func validWakeImageEvidenceForTest() wakeImageEvidenceV1 {
+	method := wakeImageMethodFDExec
+	path := "/opt/amq/0.50.2/bin/amq"
+	if runtime.GOOS == "darwin" {
+		method = wakeImageMethodPathnameExecVerified
+		path = "/opt/homebrew/Cellar/amq/0.50.2/bin/amq"
+	}
+	return wakeImageEvidenceV1{
+		Schema:          wakeImageEvidenceSchemaV1,
+		Platform:        runtime.GOOS,
+		Method:          method,
+		ExecutionPath:   path,
+		Device:          1,
+		Inode:           2,
+		Size:            3,
+		CTimeNS:         4,
+		SHA256:          "sha256:" + strings.Repeat("a", 64),
+		EmbeddedVersion: "0.50.2",
+	}
+}
+
+func validWakeResumeLockForTest() wakeLock {
+	owner := validWakeResumeOwnerForTest()
+	evidence := validWakeImageEvidenceForTest()
+	return wakeLock{
+		PID:                  5151,
+		TTY:                  "/dev/ttys001",
+		Root:                 "/queue",
+		Agent:                "codex",
+		ProcessStart:         "67890",
+		BootID:               owner.BootID,
+		WakeMode:             wakeInjectModeRaw,
+		Generation:           "resume-generation",
+		ControlSocket:        "/queue/agents/codex/.w.0123456789abcdef",
+		ResumeSchema:         wakeResumeSchemaV2,
+		ResumeOwner:          &owner,
+		RunningImageEvidence: &evidence,
+	}
+}
+
+func TestValidateWakeResumeAdvertisementAcceptsOnlyCompleteExactV2(t *testing.T) {
+	if err := validateWakeResumeAdvertisement(validWakeResumeLockForTest()); err != nil {
+		t.Fatalf("valid resume advertisement rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*wakeLock)
+		want   string
+	}{
+		{name: "missing schema", mutate: func(l *wakeLock) { l.ResumeSchema = 0 }, want: "schema"},
+		{name: "future schema", mutate: func(l *wakeLock) { l.ResumeSchema = wakeResumeSchemaV2 + 1 }, want: "unsupported"},
+		{name: "missing owner", mutate: func(l *wakeLock) { l.ResumeOwner = nil }, want: "owner"},
+		{name: "invalid owner", mutate: func(l *wakeLock) { l.ResumeOwner.SessionID = 0 }, want: "session"},
+		{name: "missing generation", mutate: func(l *wakeLock) { l.Generation = "" }, want: "generation"},
+		{name: "missing wake process start", mutate: func(l *wakeLock) { l.ProcessStart = "" }, want: "process start"},
+		{name: "missing wake boot id", mutate: func(l *wakeLock) { l.BootID = "" }, want: "boot id"},
+		{name: "missing control endpoint", mutate: func(l *wakeLock) { l.ControlSocket = "" }, want: "control"},
+		{name: "repair lineage", mutate: func(l *wakeLock) { l.SourceGeneration = "dead-generation" }, want: "repair"},
+		{name: "missing evidence", mutate: func(l *wakeLock) { l.RunningImageEvidence = nil }, want: "image evidence"},
+		{name: "wrong evidence schema", mutate: func(l *wakeLock) { l.RunningImageEvidence.Schema++ }, want: "image evidence schema"},
+		{name: "wrong platform", mutate: func(l *wakeLock) { l.RunningImageEvidence.Platform = "plan9" }, want: "platform"},
+		{name: "wrong method", mutate: func(l *wakeLock) { l.RunningImageEvidence.Method = "pathname" }, want: "method"},
+		{name: "relative execution path", mutate: func(l *wakeLock) { l.RunningImageEvidence.ExecutionPath = "bin/amq" }, want: "absolute"},
+		{name: "missing device", mutate: func(l *wakeLock) { l.RunningImageEvidence.Device = 0 }, want: "device"},
+		{name: "missing inode", mutate: func(l *wakeLock) { l.RunningImageEvidence.Inode = 0 }, want: "inode"},
+		{name: "empty image", mutate: func(l *wakeLock) { l.RunningImageEvidence.Size = 0 }, want: "size"},
+		{name: "missing ctime", mutate: func(l *wakeLock) { l.RunningImageEvidence.CTimeNS = 0 }, want: "ctime"},
+		{name: "malformed digest", mutate: func(l *wakeLock) { l.RunningImageEvidence.SHA256 = "sha256:abc" }, want: "sha256"},
+		{name: "missing version", mutate: func(l *wakeLock) { l.RunningImageEvidence.EmbeddedVersion = "" }, want: "version"},
+		{
+			name: "authoritative owner mismatch",
+			mutate: func(l *wakeLock) {
+				l.WakeMode = wakeOwnerWakeMode
+				l.OwnerSchema = wakeOwnerLockSchema
+				other := *l.ResumeOwner
+				other.PID++
+				l.Owner = &other
+			},
+			want: "does not match",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lock := validWakeResumeLockForTest()
+			test.mutate(&lock)
+			err := validateWakeResumeAdvertisement(lock)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestWakeResumeMetadataRoundTripsWithoutChangingGenericClaim(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	lock := validWakeResumeLockForTest()
+	lock.Root = canonicalWakeRoot(root)
+	writeWakeLockForTest(t, root, "codex", lock)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: lock.ProcessStart,
+			BootID:     lock.BootID,
+			Executable: lock.RunningImageEvidence.ExecutionPath,
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+		t.Fatalf("inspection = status %q reason %q", inspection.Status, inspection.Reason)
+	}
+	if got := classifyWakeClaimForGenericTransition(inspection); got != wakeClaimGeneric {
+		t.Fatalf("claim = %v, want generic", got)
+	}
+	if err := validateWakeResumeAdvertisement(inspection.Lock); err != nil {
+		t.Fatalf("round-tripped advertisement invalid: %v", err)
+	}
+
+	data, err := json.Marshal(inspection.Lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"resume_schema", "resume_owner", "running_image_evidence"} {
+		if !strings.Contains(string(data), `"`+field+`"`) {
+			t.Fatalf("lock JSON missing %q: %s", field, data)
+		}
+	}
+}
+
+func TestMalformedOrFutureResumeMetadataDoesNotPoisonLiveNotifier(t *testing.T) {
+	for _, schema := range []int{wakeResumeSchemaV2, wakeResumeSchemaV2 + 1} {
+		t.Run(strconv.Itoa(schema), func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			lock := validWakeResumeLockForTest()
+			lock.Root = canonicalWakeRoot(root)
+			lock.ResumeSchema = schema
+			lock.RunningImageEvidence = nil
+			writeWakeLockForTest(t, root, "codex", lock)
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				return wakeProcessInfo{
+					PID: pid, Running: true, StartToken: lock.ProcessStart, BootID: lock.BootID,
+					Executable: "/opt/amq", Args: []string{"amq", "wake"},
+				}
+			})
+
+			inspection := inspectWakeLock(root, "codex")
+			if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
+				t.Fatalf("resume metadata poisoned notifier: status=%q reason=%q", inspection.Status, inspection.Reason)
+			}
+			if err := validateWakeResumeAdvertisement(inspection.Lock); err == nil {
+				t.Fatal("invalid resume metadata unexpectedly authorized reload")
+			}
+		})
+	}
+}
+
+func TestNewWakeLockAdvertisesResumeOnlyWhenTheProtocolIsComplete(t *testing.T) {
+	owner := validWakeResumeOwnerForTest()
+	evidence := validWakeImageEvidenceForTest()
+	oldCapture := captureCurrentWakeImageEvidence
+	captureCurrentWakeImageEvidence = func() (wakeImageEvidenceV1, error) { return evidence, nil }
+	t.Cleanup(func() { captureCurrentWakeImageEvidence = oldCapture })
+
+	lock, err := newWakeLock("/queue", "codex", wakeLockAcquireOptions{
+		wakeMode:       wakeInjectModeRaw,
+		requestedOwner: &owner,
+		resumeEligible: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS == "linux" {
+		// Wave 1 deliberately does not advertise the protocol before Wave 2
+		// supplies Linux's authenticated control endpoint.
+		if lock.ResumeSchema != 0 || lock.ResumeOwner != nil || lock.RunningImageEvidence != nil {
+			t.Fatalf("Linux advertised resume before its control transport exists: %#v", lock)
+		}
+		return
+	}
+	if lock.ResumeSchema != wakeResumeSchemaV2 || !sameWakeOwner(lock.ResumeOwner, &owner) ||
+		lock.RunningImageEvidence == nil || *lock.RunningImageEvidence != evidence {
+		t.Fatalf("resume advertisement = %#v", lock)
+	}
+	if lock.ControlSocket == "" {
+		t.Fatal("Darwin resume advertisement has no control endpoint")
+	}
+	if err := validateWakeResumeAdvertisement(lock); err != nil {
+		t.Fatalf("new lock advertisement invalid: %v", err)
+	}
+
+	notEligible, err := newWakeLock("/queue", "codex", wakeLockAcquireOptions{
+		wakeMode:       wakeInjectModeRaw,
+		requestedOwner: &owner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notEligible.ResumeSchema != 0 || notEligible.ResumeOwner != nil || notEligible.RunningImageEvidence != nil {
+		t.Fatalf("ineligible wake advertised resume: %#v", notEligible)
+	}
+
+	captureCurrentWakeImageEvidence = func() (wakeImageEvidenceV1, error) {
+		return wakeImageEvidenceV1{}, errors.New("image unavailable")
+	}
+	missingEvidence, err := newWakeLock("/queue", "codex", wakeLockAcquireOptions{
+		wakeMode:       wakeInjectModeRaw,
+		requestedOwner: &owner,
+		resumeEligible: true,
+	})
+	if err != nil {
+		t.Fatalf("image evidence failure blocked notifier startup: %v", err)
+	}
+	if missingEvidence.ResumeSchema != 0 || missingEvidence.ResumeOwner != nil || missingEvidence.RunningImageEvidence != nil {
+		t.Fatalf("incomplete evidence advertised resume: %#v", missingEvidence)
+	}
+}
+
+func TestWakeResumeStartupEligibilityIsNarrowAndOwnerBound(t *testing.T) {
+	owner := validWakeResumeOwnerForTest()
+	tests := []struct {
+		name         string
+		owner        *wakeOwner
+		repair       bool
+		injectCmd    string
+		interruptKey string
+		mode         string
+		want         bool
+	}{
+		{name: "raw coop", owner: &owner, mode: wakeInjectModeRaw, want: true},
+		{name: "paste coop", owner: &owner, mode: wakeInjectModePaste, want: true},
+		{name: "none coop", owner: &owner, mode: wakeInjectModeNone, want: true},
+		{name: "ordinary inject via", owner: &owner, mode: wakeTargetInjectVia, want: true},
+		{name: "ownerless", mode: wakeInjectModeRaw},
+		{name: "repair lineage", owner: &owner, mode: wakeTargetInjectVia, repair: true},
+		{name: "arbitrary inject command", owner: &owner, mode: wakeInjectModeRaw, injectCmd: "helper"},
+		{name: "destructive interrupt", owner: &owner, mode: wakeInjectModeRaw, interruptKey: "\x03"},
+		{name: "unknown mode", owner: &owner, mode: "future-mode"},
+		{name: "authoritative persisted mode is not a startup mode", owner: &owner, mode: wakeOwnerWakeMode},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := wakeResumeStartupEligible(
+				test.owner,
+				test.repair,
+				test.injectCmd,
+				test.interruptKey,
+				test.mode,
+			); got != test.want {
+				t.Fatalf("wakeResumeStartupEligible() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/cli/wake_resume_quiescence.go
+++ b/internal/cli/wake_resume_quiescence.go
@@ -1,0 +1,175 @@
+//go:build darwin || linux
+
+package cli
+
+type wakeResumeDisposition uint8
+
+const (
+	wakeResumeReady wakeResumeDisposition = iota
+	wakeResumeDefer
+	wakeResumeRefuse
+)
+
+type wakeResumeLifecycle uint8
+
+const (
+	wakeResumeLifecycleStarting wakeResumeLifecycle = iota
+	wakeResumeLifecycleAdmitted
+)
+
+type wakeResumeScan uint8
+
+const (
+	wakeResumeScanTransientFailure wakeResumeScan = iota
+	wakeResumeScanComplete
+)
+
+const (
+	wakeResumeReasonNotAdmitted           = "wake_not_admitted"
+	wakeResumeReasonInputDelivery         = "input_delivery_in_progress"
+	wakeResumeReasonInputProgress         = "input_progress_confirmed"
+	wakeResumeReasonInputUncertain        = "input_acceptance_uncertain"
+	wakeResumeReasonInputRecovery         = "input_recovery_required"
+	wakeResumeReasonRepairState           = "repair_state_active"
+	wakeResumeReasonArbitraryInjector     = "arbitrary_inject_command"
+	wakeResumeReasonDestructiveInterrupt  = "destructive_interrupt"
+	wakeResumeReasonInjectorActive        = "external_injector_active"
+	wakeResumeReasonInjectorCleanup       = "injector_cleanup_pending"
+	wakeResumeReasonTerminalRetry         = "terminal_suffix_retry_pending"
+	wakeResumeReasonScanRetry             = "inbox_scan_retry_pending"
+	wakeResumeReasonWatcherUnarmed        = "watcher_unarmed"
+	wakeResumeReasonWatcherError          = "watcher_error"
+	wakeResumeReasonWatcherRebind         = "watcher_rebind_pending"
+	wakeResumeReasonGenerationRecovery    = "unreadable_generation_recovery"
+	wakeResumeReasonDebounceActive        = "debounce_callback_active"
+	wakeResumeReasonControlHandlers       = "control_handlers_active"
+	wakeResumeReasonControlListener       = "control_listener_unavailable"
+	wakeResumeReasonOwnerUnavailable      = "owner_unavailable"
+	wakeResumeReasonAuthorityUnverified   = "wake_authority_unverified"
+	wakeResumeReasonDirectoriesUnverified = "wake_directories_unverified"
+	wakeResumeReasonFinalScanIncomplete   = "final_inbox_scan_incomplete"
+)
+
+type wakeResumeQuiescence struct {
+	Lifecycle wakeResumeLifecycle
+	Delivery  wakeInputDeliveryState
+
+	RecoveryRequired      bool
+	RepairLineage         bool
+	RepairHandoff         bool
+	RepairPrepared        bool
+	RepairFloorTransition bool
+	BaselineInherited     bool
+
+	InjectViaActive        bool
+	InjectorCleanupPending bool
+	ArbitraryInjectCmd     bool
+	DestructiveInterrupt   bool
+
+	TerminalSuffixRetry          bool
+	ScanRetry                    bool
+	WatcherArmed                 bool
+	WatcherError                 bool
+	WatcherRebindRetry           bool
+	UnreadableGenerationRecovery bool
+
+	DebounceExecuting    bool
+	ControlHandlers      uint
+	ControlListenerReady bool
+	OwnerLive            bool
+	AuthorityExact       bool
+	CanonicalDirs        bool
+	FinalScan            wakeResumeScan
+
+	// These fields are deliberately not gates. Durable unread work and old
+	// doorbell/backoff state become an immediately-due fresh cohort after resume.
+	FinalScanMessages int
+	PendingDoorbell   bool
+}
+
+type wakeResumeQuiescenceDecision struct {
+	Disposition wakeResumeDisposition
+	Reason      string
+}
+
+func classifyWakeResumeQuiescence(state wakeResumeQuiescence) wakeResumeQuiescenceDecision {
+	refuse := func(reason string) wakeResumeQuiescenceDecision {
+		return wakeResumeQuiescenceDecision{Disposition: wakeResumeRefuse, Reason: reason}
+	}
+	deferReload := func(reason string) wakeResumeQuiescenceDecision {
+		return wakeResumeQuiescenceDecision{Disposition: wakeResumeDefer, Reason: reason}
+	}
+
+	switch {
+	case state.Lifecycle != wakeResumeLifecycleAdmitted:
+		return refuse(wakeResumeReasonNotAdmitted)
+	case state.RecoveryRequired:
+		return refuse(wakeResumeReasonInputRecovery)
+	case state.RepairLineage || state.RepairHandoff || state.RepairPrepared ||
+		state.RepairFloorTransition || state.BaselineInherited:
+		return refuse(wakeResumeReasonRepairState)
+	case state.ArbitraryInjectCmd:
+		return refuse(wakeResumeReasonArbitraryInjector)
+	case state.DestructiveInterrupt:
+		return refuse(wakeResumeReasonDestructiveInterrupt)
+	case state.Delivery.acceptanceUncertain:
+		return refuse(wakeResumeReasonInputUncertain)
+	case state.Delivery.acceptedBytes > 0:
+		return refuse(wakeResumeReasonInputProgress)
+	case state.Delivery.phase != wakeInputDeliveryIdle:
+		return refuse(wakeResumeReasonInputDelivery)
+	case state.InjectViaActive:
+		return deferReload(wakeResumeReasonInjectorActive)
+	case state.InjectorCleanupPending:
+		return deferReload(wakeResumeReasonInjectorCleanup)
+	case state.TerminalSuffixRetry:
+		return deferReload(wakeResumeReasonTerminalRetry)
+	case state.ScanRetry:
+		return deferReload(wakeResumeReasonScanRetry)
+	case !state.WatcherArmed:
+		return deferReload(wakeResumeReasonWatcherUnarmed)
+	case state.WatcherError:
+		return deferReload(wakeResumeReasonWatcherError)
+	case state.WatcherRebindRetry:
+		return deferReload(wakeResumeReasonWatcherRebind)
+	case state.UnreadableGenerationRecovery:
+		return deferReload(wakeResumeReasonGenerationRecovery)
+	case state.DebounceExecuting:
+		return deferReload(wakeResumeReasonDebounceActive)
+	case state.ControlHandlers > 0:
+		return deferReload(wakeResumeReasonControlHandlers)
+	case !state.ControlListenerReady:
+		return deferReload(wakeResumeReasonControlListener)
+	case !state.OwnerLive:
+		return deferReload(wakeResumeReasonOwnerUnavailable)
+	case !state.AuthorityExact:
+		return deferReload(wakeResumeReasonAuthorityUnverified)
+	case !state.CanonicalDirs:
+		return deferReload(wakeResumeReasonDirectoriesUnverified)
+	case state.FinalScan != wakeResumeScanComplete:
+		return deferReload(wakeResumeReasonFinalScanIncomplete)
+	default:
+		return wakeResumeQuiescenceDecision{Disposition: wakeResumeReady}
+	}
+}
+
+func wakeInputDeliveryPhaseName(phase wakeInputDeliveryPhase) string {
+	switch phase {
+	case wakeInputDeliveryIdle:
+		return "idle"
+	case wakeInputPayloadPending:
+		return "payload_pending"
+	case wakeInputRawPreludePending:
+		return "raw_prelude_pending"
+	case wakeInputPrimarySubmitPending:
+		return "primary_submit_pending"
+	case wakeInputRawFirstSubmitQueued:
+		return "raw_first_submit_queued"
+	case wakeInputRawRescuePending:
+		return "raw_rescue_pending"
+	case wakeInputRawRescueQueued:
+		return "raw_rescue_queued"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/cli/wake_resume_quiescence_test.go
+++ b/internal/cli/wake_resume_quiescence_test.go
@@ -1,0 +1,204 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func readyWakeResumeQuiescenceForTest() wakeResumeQuiescence {
+	return wakeResumeQuiescence{
+		Lifecycle:            wakeResumeLifecycleAdmitted,
+		WatcherArmed:         true,
+		ControlListenerReady: true,
+		OwnerLive:            true,
+		AuthorityExact:       true,
+		CanonicalDirs:        true,
+		FinalScan:            wakeResumeScanComplete,
+		FinalScanMessages:    3,
+		PendingDoorbell:      true,
+	}
+}
+
+func TestWakeResumeQuiescenceRefusesUntransferableStateWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*wakeResumeQuiescence)
+		reason string
+	}{
+		{
+			name: "startup not admitted",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.Lifecycle = wakeResumeLifecycleStarting
+			},
+			reason: wakeResumeReasonNotAdmitted,
+		},
+		{
+			name: "input recovery required",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.RecoveryRequired = true
+			},
+			reason: wakeResumeReasonInputRecovery,
+		},
+		{
+			name: "repair lineage",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.RepairLineage = true
+			},
+			reason: wakeResumeReasonRepairState,
+		},
+		{
+			name: "repair handoff",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.RepairHandoff = true
+			},
+			reason: wakeResumeReasonRepairState,
+		},
+		{
+			name: "repair prepared",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.RepairPrepared = true
+			},
+			reason: wakeResumeReasonRepairState,
+		},
+		{
+			name: "repair floor transition",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.RepairFloorTransition = true
+			},
+			reason: wakeResumeReasonRepairState,
+		},
+		{
+			name: "inherited repair baseline",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.BaselineInherited = true
+			},
+			reason: wakeResumeReasonRepairState,
+		},
+		{
+			name: "arbitrary inject command",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.ArbitraryInjectCmd = true
+			},
+			reason: wakeResumeReasonArbitraryInjector,
+		},
+		{
+			name: "destructive interrupt",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.DestructiveInterrupt = true
+			},
+			reason: wakeResumeReasonDestructiveInterrupt,
+		},
+	}
+
+	for phase := wakeInputPayloadPending; phase <= wakeInputRawRescueQueued; phase++ {
+		phase := phase
+		tests = append(tests, struct {
+			name   string
+			mutate func(*wakeResumeQuiescence)
+			reason string
+		}{
+			name: "input phase " + wakeInputDeliveryPhaseName(phase),
+			mutate: func(state *wakeResumeQuiescence) {
+				state.Delivery.phase = phase
+			},
+			reason: wakeResumeReasonInputDelivery,
+		})
+	}
+	tests = append(tests,
+		struct {
+			name   string
+			mutate func(*wakeResumeQuiescence)
+			reason string
+		}{
+			name: "accepted input bytes",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.Delivery.acceptedBytes = 1
+			},
+			reason: wakeResumeReasonInputProgress,
+		},
+		struct {
+			name   string
+			mutate func(*wakeResumeQuiescence)
+			reason string
+		}{
+			name: "uncertain input acceptance",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.Delivery.acceptanceUncertain = true
+			},
+			reason: wakeResumeReasonInputUncertain,
+		},
+	)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := readyWakeResumeQuiescenceForTest()
+			test.mutate(&state)
+			before := state
+
+			decision := classifyWakeResumeQuiescence(state)
+
+			if decision.Disposition != wakeResumeRefuse || decision.Reason != test.reason {
+				t.Fatalf("decision = %#v, want refuse reason %q", decision, test.reason)
+			}
+			if !reflect.DeepEqual(state, before) {
+				t.Fatalf("classifier mutated input:\nbefore=%#v\nafter=%#v", before, state)
+			}
+		})
+	}
+}
+
+func TestWakeResumeQuiescenceDefersTransientStateWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*wakeResumeQuiescence)
+		reason string
+	}{
+		{name: "injector active", mutate: func(s *wakeResumeQuiescence) { s.InjectViaActive = true }, reason: wakeResumeReasonInjectorActive},
+		{name: "injector cleanup", mutate: func(s *wakeResumeQuiescence) { s.InjectorCleanupPending = true }, reason: wakeResumeReasonInjectorCleanup},
+		{name: "terminal suffix retry", mutate: func(s *wakeResumeQuiescence) { s.TerminalSuffixRetry = true }, reason: wakeResumeReasonTerminalRetry},
+		{name: "scan retry", mutate: func(s *wakeResumeQuiescence) { s.ScanRetry = true }, reason: wakeResumeReasonScanRetry},
+		{name: "watcher unarmed", mutate: func(s *wakeResumeQuiescence) { s.WatcherArmed = false }, reason: wakeResumeReasonWatcherUnarmed},
+		{name: "watcher error", mutate: func(s *wakeResumeQuiescence) { s.WatcherError = true }, reason: wakeResumeReasonWatcherError},
+		{name: "watcher rebind", mutate: func(s *wakeResumeQuiescence) { s.WatcherRebindRetry = true }, reason: wakeResumeReasonWatcherRebind},
+		{name: "unreadable generation recovery", mutate: func(s *wakeResumeQuiescence) { s.UnreadableGenerationRecovery = true }, reason: wakeResumeReasonGenerationRecovery},
+		{name: "debounce executing", mutate: func(s *wakeResumeQuiescence) { s.DebounceExecuting = true }, reason: wakeResumeReasonDebounceActive},
+		{name: "one control handler", mutate: func(s *wakeResumeQuiescence) { s.ControlHandlers = 1 }, reason: wakeResumeReasonControlHandlers},
+		{name: "two control handlers", mutate: func(s *wakeResumeQuiescence) { s.ControlHandlers = 2 }, reason: wakeResumeReasonControlHandlers},
+		{name: "control listener unavailable", mutate: func(s *wakeResumeQuiescence) { s.ControlListenerReady = false }, reason: wakeResumeReasonControlListener},
+		{name: "owner unavailable", mutate: func(s *wakeResumeQuiescence) { s.OwnerLive = false }, reason: wakeResumeReasonOwnerUnavailable},
+		{name: "authority drift", mutate: func(s *wakeResumeQuiescence) { s.AuthorityExact = false }, reason: wakeResumeReasonAuthorityUnverified},
+		{name: "directories unverified", mutate: func(s *wakeResumeQuiescence) { s.CanonicalDirs = false }, reason: wakeResumeReasonDirectoriesUnverified},
+		{name: "full scan incomplete", mutate: func(s *wakeResumeQuiescence) { s.FinalScan = wakeResumeScanTransientFailure }, reason: wakeResumeReasonFinalScanIncomplete},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := readyWakeResumeQuiescenceForTest()
+			test.mutate(&state)
+			before := state
+
+			decision := classifyWakeResumeQuiescence(state)
+
+			if decision.Disposition != wakeResumeDefer || decision.Reason != test.reason {
+				t.Fatalf("decision = %#v, want defer reason %q", decision, test.reason)
+			}
+			if !reflect.DeepEqual(state, before) {
+				t.Fatalf("classifier mutated input:\nbefore=%#v\nafter=%#v", before, state)
+			}
+		})
+	}
+}
+
+func TestWakeResumeQuiescenceAllowsUnreadCohortAndExistingBackoff(t *testing.T) {
+	state := readyWakeResumeQuiescenceForTest()
+	state.FinalScanMessages = 7
+	state.PendingDoorbell = true
+
+	decision := classifyWakeResumeQuiescence(state)
+
+	if decision.Disposition != wakeResumeReady || decision.Reason != "" {
+		t.Fatalf("decision = %#v, want ready", decision)
+	}
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -104,6 +104,9 @@ type wakeLockAcquireOptions struct {
 	requestedOwner          *wakeOwner
 	repairLineage           *wakeRepairLineage
 	repairFloorAuthority    *wakeRepairFloorAuthority
+	// resumeEligible is startup policy, not authority. newWakeLock still requires
+	// the complete owner/process/control/image advertisement below.
+	resumeEligible bool
 }
 
 type wakeLockCreatingError struct{}
@@ -558,6 +561,26 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 		lock.BootID = proc.BootID
 		lock.Executable = proc.Executable
 		lock.Args = proc.Args
+	}
+	if options.resumeEligible && options.requestedOwner != nil && options.repairLineage == nil {
+		// Resume metadata is additive capability. Missing or inconsistent evidence
+		// keeps the ordinary notifier usable without advertising agent-safe reload.
+		candidate := lock
+		if candidate.ControlSocket == "" {
+			candidate.ControlSocket = wakeControlSocketPath(root, me, candidate.Generation)
+		}
+		evidence, evidenceErr := captureCurrentWakeImageEvidence()
+		if evidenceErr == nil {
+			owner := *options.requestedOwner
+			candidate.ResumeSchema = wakeResumeSchemaV2
+			candidate.ResumeOwner = &owner
+			candidate.RunningImageEvidence = &evidence
+			candidate.ImagePath = evidence.ExecutionPath
+			candidate.ImageVersion = evidence.EmbeddedVersion
+			if validateWakeResumeAdvertisement(candidate) == nil {
+				lock = candidate
+			}
+		}
 	}
 	return lock, nil
 }
@@ -1895,6 +1918,13 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			wakeMode:                lockWakeMode,
 			requestedOwner:          requestedOwner,
 			repairLineage:           repairLineage,
+			resumeEligible: wakeResumeStartupEligible(
+				requestedOwner,
+				repairLineage != nil,
+				*injectCmdFlag,
+				interruptKey,
+				lockWakeMode,
+			),
 		}
 		if repairLineage != nil {
 			options.repairFloorAuthority = &repairFloorAuthority


### PR DESCRIPTION
## Scope

Phase 2 Wave 1 only: protocol types, additive lock advertisement, exact running-image evidence, and a pure quiescence model with RED/GREEN coverage. This wave adds no reload endpoint, exec path, one-use marker, bootstrap path, or classifier/action integration. It is inert until Wave 2 supplies the authenticated control transport.

Linux deliberately does not advertise resume_schema in Wave 1 because its authenticated control endpoint does not exist yet. The approved design now states that cross-platform endpoint advertisement is delivered by the end of Wave 3.

## Review carry-forwards

- Wave 2 must decompose the provisional AuthorityExact aggregate into distinct live-owner, terminal-identity, generation, and lock/target observations before real state is wired.
- Phase 2 design SHA: 71394734ddb2424f31b3d835f8c476d19af74d8f83e03fa0e78a0de13b0732d2.

## Verification

- Exact-tree peer review PASS on staged tree e02169723c52bb31acf90574ad152f584edf0a4c with zero blockers.
- Independent simplification review PASS.
- go test ./internal/cli -count=1 PASS.
- Real Linux suite PASS in the peer gate; not a GOOS cross-compile proxy.
- Darwin/Linux production cross-builds PASS.

No schema-v2 classifier code is included; that disjoint tree remains under its own gate.