### PR TITLE
feat(wake): add versioned check schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ amq doctor --ops
 amq doctor --ops --json
 amq wake check --me codex
 amq wake check --me codex --json
+amq wake check --me codex --json --json-schema=2
+amq doctor --ops --json --json-schema=2
 amq doctor --ops --fix-wake-locks
 amq wake repair --me codex
 amq wake recover-owner --me codex
@@ -311,6 +313,16 @@ with an exact `next_action`. Automated agents may act only on `agent_safe`.
 They must leave a live wake running for `operator_only`, and must never turn a
 TIOCSTI refusal into an attention-only downgrade. `doctor --ops` exposes the
 same image and restart fields for every discovered wake lock.
+
+JSON schema 1 remains the byte-compatible default. Schema 2 is explicit with
+`--json-schema=2` and is available only with `--json`. It replaces prose
+parsing with a closed action kind, actor, reason code, and an argv command
+object when one action is directly executable. Missing evidence is an explicit
+JSON `null`; `image.status="unknown"` remains a real classification. In doctor
+schema 2, each wake-lock entry contains the same decision under `wake_check`
+rather than duplicating the wake advice as flat fields. Check output is advice,
+not authority: every advertised mutating command revalidates current wake state
+before changing it.
 
 Wake locks reported by `doctor --ops` can be `stale`, `unverified`, or, in JSON
 output, any current lock state. With `--fix-wake-locks`, fixed and error states

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -42,6 +42,7 @@ func wakeCheckTextValue(value string) string {
 func runDoctor(args []string) error {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	jsonFlag := fs.Bool("json", false, "Output as JSON")
+	jsonSchemaFlag := addJSONSchemaFlag(fs)
 	opsFlag := fs.Bool("ops", false, "Include runtime operational checks")
 	fixWakeLocksFlag := fs.Bool("fix-wake-locks", false, "With --ops, remove stale wake lock files")
 	fixMailboxesFlag := fs.Bool("fix-mailboxes", false, "Create missing required directories for configured mailboxes")
@@ -73,6 +74,9 @@ func runDoctor(args []string) error {
 		return err
 	} else if handled {
 		return nil
+	}
+	if err := validateJSONSchemaFlag(fs, *jsonFlag, *jsonSchemaFlag); err != nil {
+		return err
 	}
 	if *fixWakeLocksFlag && !*opsFlag {
 		return UsageError("--fix-wake-locks requires --ops")
@@ -186,7 +190,13 @@ func runDoctor(args []string) error {
 				fixWakeLocks = false
 			}
 		}
-		result.Ops = runOpsChecks(root, string(source), fixWakeLocks, baseRoot)
+		result.Ops = runOpsChecksWithSchema(
+			root,
+			string(source),
+			fixWakeLocks,
+			*jsonSchemaFlag,
+			baseRoot,
+		)
 	}
 
 	// Calculate summary
@@ -202,6 +212,9 @@ func runDoctor(args []string) error {
 	}
 
 	if *jsonFlag {
+		if *jsonSchemaFlag == wakeCheckSchemaV2 {
+			return writeJSON(os.Stdout, renderDoctorResultV2(result))
+		}
 		return writeJSON(os.Stdout, result)
 	}
 

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -98,9 +98,27 @@ type opsWakeLock struct {
 	OperatorTerminalRequired bool   `json:"operator_terminal_required"`
 	NextAction               string `json:"next_action,omitempty"`
 	CurrentTerminal          bool   `json:"-"`
+
+	WakeCheckDecision *wakeCheckDecision `json:"-"`
 }
 
 func runOpsChecks(root string, rootSource string, fixWakeLocks bool, explicitBaseRoot ...string) *doctorOpsResult {
+	return runOpsChecksWithSchema(
+		root,
+		rootSource,
+		fixWakeLocks,
+		wakeCheckSchemaV1,
+		explicitBaseRoot...,
+	)
+}
+
+func runOpsChecksWithSchema(
+	root string,
+	rootSource string,
+	fixWakeLocks bool,
+	jsonSchema int,
+	explicitBaseRoot ...string,
+) *doctorOpsResult {
 	result := &doctorOpsResult{}
 	now := time.Now()
 
@@ -121,10 +139,11 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool, explicitBas
 			Message: fmt.Sprintf("Cannot load config: %v", err),
 		})
 		var wakeHints []opsHint
-		result.WakeLocks, wakeHints = checkWakeLocksWithHints(
+		result.WakeLocks, wakeHints = checkWakeLocksWithHintsSchema(
 			root,
 			discoveredWakeLockAgents(root, nil),
 			fixWakeLocks,
+			jsonSchema,
 		)
 		result.Hints = append(result.Hints, wakeHints...)
 		return result
@@ -210,10 +229,11 @@ func runOpsChecks(root string, rootSource string, fixWakeLocks bool, explicitBas
 	// retains legacy-safe on-disk handles for read-only wake diagnostics;
 	// checkWakeLocks repeats that inspection boundary for untrusted callers.
 	var wakeHints []opsHint
-	result.WakeLocks, wakeHints = checkWakeLocksWithHints(
+	result.WakeLocks, wakeHints = checkWakeLocksWithHintsSchema(
 		root,
 		discoveredWakeLockAgents(root, validatedAgents),
 		fixWakeLocks,
+		jsonSchema,
 	)
 
 	// Operational and integration hints
@@ -399,10 +419,25 @@ func assessWakeRepair(
 }
 
 func checkWakeLocksWithHints(root string, agents []string, fix bool) ([]opsWakeLock, []opsHint) {
+	return checkWakeLocksWithHintsSchema(root, agents, fix, wakeCheckSchemaV1)
+}
+
+func checkWakeLocksWithHintsSchema(
+	root string,
+	agents []string,
+	fix bool,
+	jsonSchema int,
+) ([]opsWakeLock, []opsHint) {
 	var locks []opsWakeLock
 	var hints []opsHint
 	appendLock := func(lock opsWakeLock, inspection wakeLockInspection, staleBinary bool) {
-		decorateOpsWakeLockWithWakeCheck(root, &lock, inspection, staleBinary)
+		decorateOpsWakeLockWithWakeCheck(
+			root,
+			&lock,
+			inspection,
+			staleBinary,
+			jsonSchema == wakeCheckSchemaV2,
+		)
 		locks = append(locks, lock)
 	}
 	for _, agent := range agents {

--- a/internal/cli/doctor_schema_v2.go
+++ b/internal/cli/doctor_schema_v2.go
@@ -1,0 +1,90 @@
+package cli
+
+import "github.com/avivsinai/agent-message-queue/internal/fsq"
+
+type doctorResultV2 struct {
+	Checks               []doctorCheck               `json:"checks"`
+	Mailboxes            []fsq.MailboxInspection     `json:"mailboxes,omitempty"`
+	MailboxRepair        *fsq.MailboxRepairResult    `json:"mailbox_repair,omitempty"`
+	ExtensionManifests   []doctorExtensionManifest   `json:"extension_manifests,omitempty"`
+	ExtensionDiagnostics []doctorExtensionDiagnostic `json:"extension_diagnostics,omitempty"`
+	Summary              doctorSummaryV2             `json:"summary"`
+	Ops                  *doctorOpsResultV2          `json:"ops,omitempty"`
+}
+
+type doctorSummaryV2 struct {
+	OK    int `json:"ok"`
+	Warn  int `json:"warn"`
+	Error int `json:"error"`
+}
+
+type doctorOpsResultV2 struct {
+	Root         opsRoot          `json:"root"`
+	Agents       []opsAgent       `json:"agents"`
+	OperatorGate *opsOperatorGate `json:"operator_gate,omitempty"`
+	WakeLocks    []opsWakeLockV2  `json:"wake_locks,omitempty"`
+	Hints        []opsHint        `json:"hints"`
+}
+
+type opsWakeLockV2 struct {
+	Status        string             `json:"status"`
+	Agent         string             `json:"agent"`
+	Root          string             `json:"root"`
+	Lock          string             `json:"lock"`
+	PID           int                `json:"pid,omitempty"`
+	TTY           string             `json:"tty,omitempty"`
+	Started       string             `json:"started,omitempty"`
+	Reason        string             `json:"reason,omitempty"`
+	Removed       bool               `json:"removed,omitempty"`
+	Target        string             `json:"target,omitempty"`
+	TargetPresent bool               `json:"target_present,omitempty"`
+	TargetReason  string             `json:"target_reason,omitempty"`
+	WakeCheck     *wakeCheckResultV2 `json:"wake_check"`
+}
+
+func renderDoctorResultV2(result doctorResult) doctorResultV2 {
+	v2 := doctorResultV2{
+		Checks:               result.Checks,
+		Mailboxes:            result.Mailboxes,
+		MailboxRepair:        result.MailboxRepair,
+		ExtensionManifests:   result.ExtensionManifests,
+		ExtensionDiagnostics: result.ExtensionDiagnostics,
+		Summary: doctorSummaryV2{
+			OK:    result.Summary.OK,
+			Warn:  result.Summary.Warn,
+			Error: result.Summary.Error,
+		},
+	}
+	if result.Ops == nil {
+		return v2
+	}
+	v2.Ops = &doctorOpsResultV2{
+		Root:         result.Ops.Root,
+		Agents:       result.Ops.Agents,
+		OperatorGate: result.Ops.OperatorGate,
+		Hints:        result.Ops.Hints,
+		WakeLocks:    make([]opsWakeLockV2, 0, len(result.Ops.WakeLocks)),
+	}
+	for _, lock := range result.Ops.WakeLocks {
+		v2Lock := opsWakeLockV2{
+			Status:        lock.Status,
+			Agent:         lock.Agent,
+			Root:          lock.Root,
+			Lock:          lock.Lock,
+			PID:           lock.PID,
+			TTY:           lock.TTY,
+			Started:       lock.Started,
+			Reason:        lock.Reason,
+			Removed:       lock.Removed,
+			Target:        lock.Target,
+			TargetPresent: lock.TargetPresent,
+			TargetReason:  lock.TargetReason,
+		}
+		if lock.WakeCheckDecision != nil {
+			wakeCheck := renderWakeCheckV2(*lock.WakeCheckDecision)
+			v2Lock.WakeCheck = &wakeCheck
+		}
+		v2.Ops.WakeLocks = append(v2.Ops.WakeLocks, v2Lock)
+	}
+	return v2
+}

--- a/internal/cli/wake_check_other.go
+++ b/internal/cli/wake_check_other.go
@@ -2,10 +2,56 @@
 
 package cli
 
+import (
+	"errors"
+	"flag"
+	"os"
+)
+
 func decorateOpsWakeLockWithWakeCheck(
-	string,
-	*opsWakeLock,
-	wakeLockInspection,
-	bool,
+	root string,
+	lock *opsWakeLock,
+	_ wakeLockInspection,
+	_ bool,
+	includeV2 bool,
 ) {
+	if !includeV2 {
+		return
+	}
+	decision := unsupportedWakeCheckDecision(root, lock.Agent)
+	lock.WakeCheckDecision = &decision
+}
+
+func runWakeCheckUnsupported(args []string) error {
+	fs := flag.NewFlagSet("wake check", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	jsonSchema := addJSONSchemaFlag(fs)
+	usage := usageWithFlags(
+		fs,
+		"amq wake check --me <agent> [options]",
+		"Inspect wake start and restart capability without mutation.",
+	)
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if err := validateJSONSchemaFlag(fs, common.JSON, *jsonSchema); err != nil {
+		return err
+	}
+	if !common.JSON || *jsonSchema == wakeCheckSchemaV1 {
+		return errors.New("amq wake is not supported on this platform (requires macOS or Linux)")
+	}
+	if err := requireMe(common.Me); err != nil {
+		return err
+	}
+	me, err := normalizeHandle(common.Me)
+	if err != nil {
+		return UsageError("--me: %v", err)
+	}
+	root := resolveRoot(common.Root)
+	if err := validateKnownHandles(root, common.Strict, me); err != nil {
+		return err
+	}
+	return writeJSON(os.Stdout, renderWakeCheckV2(unsupportedWakeCheckDecision(root, me)))
 }

--- a/internal/cli/wake_check_schema.go
+++ b/internal/cli/wake_check_schema.go
@@ -1,0 +1,369 @@
+package cli
+
+import (
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	wakeCheckSchemaV1 = 1
+	wakeCheckSchemaV2 = 2
+
+	wakeRestartAgentSafe    = "agent_safe"
+	wakeRestartOperatorOnly = "operator_only"
+	wakeRestartUnavailable  = "unavailable"
+
+	wakeImageCurrent   = "current"
+	wakeImageDifferent = "different"
+	wakeImageUnknown   = "unknown"
+
+	wakeCheckUnknown = "unknown"
+)
+
+const (
+	wakeActionStartWake          = "start_wake"
+	wakeActionRepairWake         = "repair_wake"
+	wakeActionRecoverOwner       = "recover_owner"
+	wakeActionPreserveLiveWake   = "preserve_live_wake"
+	wakeActionInspectUnverified  = "inspect_unverified"
+	wakeActionRetryCheck         = "retry_check"
+	wakeActionConfigureInjector  = "configure_injector"
+	wakeActionManualStaleCleanup = "manual_stale_cleanup"
+	wakeActionWaitForStableState = "wait_for_stable_state"
+	wakeActionUnsupported        = "unsupported"
+
+	wakeActionActorAgent    = "agent"
+	wakeActionActorOperator = "operator"
+	wakeActionActorNone     = "none"
+)
+
+const (
+	wakeReasonMissingStartAvailable      = "wake_missing_start_available"
+	wakeReasonFullStrengthUnavailable    = "full_strength_injector_unavailable"
+	wakeReasonOwningTerminalRequired     = "owning_terminal_required"
+	wakeReasonStaleRepairAvailable       = "stale_inject_via_repair_available"
+	wakeReasonLiveWakePreserve           = "live_wake_preserve"
+	wakeReasonOwnerRecoveryRequired      = "owner_bound_stale_recovery_required"
+	wakeReasonStaleManualCleanupRequired = "stale_lock_manual_cleanup_required"
+	wakeReasonWakeStateCreating          = "wake_state_creating"
+	wakeReasonWakeStateUnverified        = "wake_state_unverified"
+	wakeReasonObservationChanged         = "observation_changed"
+	wakeReasonExecutableUnavailable      = "executable_identity_unavailable"
+	wakeReasonPlatformUnsupported        = "platform_unsupported"
+	wakeRepairReasonNoLock               = "no_wake_lock"
+	wakeRepairReasonOwnerBound           = "owner_bound"
+	wakeRepairReasonLive                 = "wake_live"
+	wakeRepairReasonNotStale             = "wake_not_stale"
+	wakeRepairReasonExactEvidenceMissing = "exact_repair_evidence_unavailable"
+)
+
+type wakeCheckDecision struct {
+	Agent                   string
+	Root                    string
+	Platform                wakeCheckPlatformDecision
+	Start                   wakeCheckStartDecision
+	Wake                    wakeCheckWakeDecision
+	Image                   wakeCheckImageDecision
+	Repair                  wakeCheckRepairDecision
+	RestartCapability       string
+	Action                  wakeCheckActionDecision
+	legacyRestartCapability string
+	legacyTerminalRequired  bool
+	legacyActionMessage     string
+}
+
+type wakeCheckPlatformDecision struct {
+	OS            string
+	WakeSupported bool
+	ReasonCode    *string
+}
+
+type wakeCheckStartDecision struct {
+	Available  bool
+	Mode       string
+	ReasonCode *string
+	Detail     *string
+}
+
+type wakeCheckWakeDecision struct {
+	Status     string
+	Live       bool
+	PID        *int
+	Mode       *string
+	OwnerBound bool
+}
+
+type wakeCheckImageDecision struct {
+	Running wakeCheckImageEvidenceDecision
+	Current wakeCheckImageEvidenceDecision
+	Status  string
+}
+
+type wakeCheckImageEvidenceDecision struct {
+	Path    *string
+	Version *string
+}
+
+type wakeCheckRepairDecision struct {
+	InjectViaAvailable bool
+	ReasonCode         *string
+	Detail             *string
+	legacyReason       string
+}
+
+type wakeCheckActionDecision struct {
+	Kind             string
+	Actor            string
+	ReasonCode       string
+	Command          *wakeCheckCommand
+	TerminalRequired bool
+	Message          string
+}
+
+type wakeCheckCommand struct {
+	Program string   `json:"program"`
+	Args    []string `json:"args"`
+}
+
+type wakeCheckResultV2 struct {
+	Schema            int                 `json:"schema"`
+	Agent             string              `json:"agent"`
+	Root              string              `json:"root"`
+	Platform          wakeCheckPlatformV2 `json:"platform"`
+	Start             wakeCheckStartV2    `json:"start"`
+	Wake              wakeCheckWakeV2     `json:"wake"`
+	Image             wakeCheckImageV2    `json:"image"`
+	Repair            wakeCheckRepairV2   `json:"repair"`
+	RestartCapability string              `json:"restart_capability"`
+	Action            wakeCheckActionV2   `json:"action"`
+}
+
+type wakeCheckPlatformV2 struct {
+	OS            string  `json:"os"`
+	WakeSupported bool    `json:"wake_supported"`
+	ReasonCode    *string `json:"reason_code"`
+}
+
+type wakeCheckStartV2 struct {
+	Available  bool    `json:"available"`
+	Mode       string  `json:"mode"`
+	ReasonCode *string `json:"reason_code"`
+	Detail     *string `json:"detail"`
+}
+
+type wakeCheckWakeV2 struct {
+	Status     string  `json:"status"`
+	Live       bool    `json:"live"`
+	PID        *int    `json:"pid"`
+	Mode       *string `json:"mode"`
+	OwnerBound bool    `json:"owner_bound"`
+}
+
+type wakeCheckImageV2 struct {
+	Running wakeCheckImageEvidenceV2 `json:"running"`
+	Current wakeCheckImageEvidenceV2 `json:"current"`
+	Status  string                   `json:"status"`
+}
+
+type wakeCheckImageEvidenceV2 struct {
+	Path    *string `json:"path"`
+	Version *string `json:"version"`
+}
+
+type wakeCheckRepairV2 struct {
+	InjectViaAvailable bool    `json:"inject_via_available"`
+	ReasonCode         *string `json:"reason_code"`
+	Detail             *string `json:"detail"`
+}
+
+type wakeCheckActionV2 struct {
+	Kind             string            `json:"kind"`
+	Actor            string            `json:"actor"`
+	ReasonCode       string            `json:"reason_code"`
+	Command          *wakeCheckCommand `json:"command"`
+	TerminalRequired bool              `json:"terminal_required"`
+	Message          string            `json:"message"`
+}
+
+var wakeCheckExecutable = os.Executable
+
+func renderWakeCheckV2(decision wakeCheckDecision) wakeCheckResultV2 {
+	return wakeCheckResultV2{
+		Schema: wakeCheckSchemaV2,
+		Agent:  decision.Agent,
+		Root:   decision.Root,
+		Platform: wakeCheckPlatformV2{
+			OS:            decision.Platform.OS,
+			WakeSupported: decision.Platform.WakeSupported,
+			ReasonCode:    decision.Platform.ReasonCode,
+		},
+		Start: wakeCheckStartV2{
+			Available:  decision.Start.Available,
+			Mode:       decision.Start.Mode,
+			ReasonCode: decision.Start.ReasonCode,
+			Detail:     decision.Start.Detail,
+		},
+		Wake: wakeCheckWakeV2{
+			Status:     decision.Wake.Status,
+			Live:       decision.Wake.Live,
+			PID:        decision.Wake.PID,
+			Mode:       decision.Wake.Mode,
+			OwnerBound: decision.Wake.OwnerBound,
+		},
+		Image: wakeCheckImageV2{
+			Running: wakeCheckImageEvidenceV2(decision.Image.Running),
+			Current: wakeCheckImageEvidenceV2(decision.Image.Current),
+			Status:  decision.Image.Status,
+		},
+		Repair: wakeCheckRepairV2{
+			InjectViaAvailable: decision.Repair.InjectViaAvailable,
+			ReasonCode:         decision.Repair.ReasonCode,
+			Detail:             decision.Repair.Detail,
+		},
+		RestartCapability: decision.RestartCapability,
+		Action: wakeCheckActionV2{
+			Kind:             decision.Action.Kind,
+			Actor:            decision.Action.Actor,
+			ReasonCode:       decision.Action.ReasonCode,
+			Command:          decision.Action.Command,
+			TerminalRequired: decision.Action.TerminalRequired,
+			Message:          decision.Action.Message,
+		},
+	}
+}
+
+func addJSONSchemaFlag(fs *flag.FlagSet) *int {
+	return fs.Int("json-schema", wakeCheckSchemaV1, "JSON schema version: 1 or 2 (requires --json)")
+}
+
+func validateJSONSchemaFlag(fs *flag.FlagSet, jsonOutput bool, schema int) error {
+	if flagWasVisited(fs, "json-schema") && !jsonOutput {
+		return UsageError("--json-schema requires --json")
+	}
+	if schema != wakeCheckSchemaV1 && schema != wakeCheckSchemaV2 {
+		return UsageError("--json-schema must be 1 or 2")
+	}
+	return nil
+}
+
+func wakeCheckV2OptInPresent(args []string) bool {
+	fs := flag.NewFlagSet("wake check v2 opt-in", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "")
+	jsonSchema := fs.Int("json-schema", wakeCheckSchemaV1, "")
+	_ = fs.String("root", "", "")
+	_ = fs.String("me", "", "")
+	_ = fs.Bool("strict", false, "")
+	if err := fs.Parse(args); err != nil {
+		return false
+	}
+	return *jsonOutput && *jsonSchema == wakeCheckSchemaV2
+}
+
+func wakeCheckActionProgram() string {
+	path, err := wakeCheckExecutable()
+	if err != nil {
+		return ""
+	}
+	path = strings.TrimSpace(path)
+	if path == "" || !filepath.IsAbs(path) {
+		return ""
+	}
+	return filepath.Clean(path)
+}
+
+func wakeCheckActionCommand(args ...string) *wakeCheckCommand {
+	program := wakeCheckActionProgram()
+	if program == "" {
+		return nil
+	}
+	return &wakeCheckCommand{Program: program, Args: append([]string(nil), args...)}
+}
+
+func finalizeWakeCheckDecision(decision *wakeCheckDecision) {
+	decision.legacyRestartCapability = decision.RestartCapability
+	decision.legacyTerminalRequired = decision.Action.TerminalRequired
+	decision.legacyActionMessage = decision.Action.Message
+	if !wakeCheckActionRequiresExecutable(decision.Action) || decision.Action.Command != nil {
+		return
+	}
+	decision.RestartCapability = wakeRestartUnavailable
+	decision.Action = wakeCheckActionDecision{
+		Kind:       wakeActionRetryCheck,
+		Actor:      wakeActionActorAgent,
+		ReasonCode: wakeReasonExecutableUnavailable,
+		Message:    "rerun amq wake check from a valid installed AMQ image; executable identity is unavailable",
+	}
+}
+
+func wakeCheckActionRequiresExecutable(action wakeCheckActionDecision) bool {
+	switch action.Kind {
+	case wakeActionStartWake, wakeActionRepairWake, wakeActionRecoverOwner:
+		return true
+	case wakeActionRetryCheck:
+		return action.ReasonCode == wakeReasonObservationChanged
+	default:
+		return false
+	}
+}
+
+func wakeCheckOptionalString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" || value == wakeCheckUnknown {
+		return nil
+	}
+	return &value
+}
+
+func wakeCheckOptionalInt(value int) *int {
+	if value == 0 {
+		return nil
+	}
+	return &value
+}
+
+func unsupportedWakeCheckDecision(root, agent string) wakeCheckDecision {
+	reason := wakeReasonPlatformUnsupported
+	detail := "amq wake is not supported on this platform"
+	return wakeCheckDecision{
+		Agent: agent,
+		Root:  canonicalWakeRoot(root),
+		Platform: wakeCheckPlatformDecision{
+			OS:            runtime.GOOS,
+			WakeSupported: false,
+			ReasonCode:    &reason,
+		},
+		Start: wakeCheckStartDecision{
+			Available:  false,
+			Mode:       wakeInjectModeNone,
+			ReasonCode: &reason,
+			Detail:     &detail,
+		},
+		Wake: wakeCheckWakeDecision{
+			Status: string(wakeLockMissing),
+		},
+		Image: wakeCheckImageDecision{
+			Current: wakeCheckImageEvidenceDecision{
+				Path:    wakeCheckOptionalString(wakeCheckActionProgram()),
+				Version: wakeCheckOptionalString(cliVersion),
+			},
+			Status: wakeImageUnknown,
+		},
+		Repair: wakeCheckRepairDecision{
+			ReasonCode:   &reason,
+			Detail:       &detail,
+			legacyReason: detail,
+		},
+		RestartCapability: wakeRestartUnavailable,
+		Action: wakeCheckActionDecision{
+			Kind:       wakeActionUnsupported,
+			Actor:      wakeActionActorNone,
+			ReasonCode: reason,
+			Message:    detail,
+		},
+	}
+}

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -851,7 +851,7 @@ func TestWakeCheckV2AdvertisedStartRevalidatesChangedWakeState(t *testing.T) {
 
 	writeWakeLockForTest(t, root, "codex", wakeLock{
 		PID:          4242,
-		TTY:          "/dev/ttys005",
+		TTY:          "unknown",
 		Root:         canonicalWakeRoot(root),
 		Agent:        "codex",
 		ProcessStart: "12345",

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -1,0 +1,944 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestWakeCheckJSONSchemaV1GoldenBytes(t *testing.T) {
+	result := wakeCheckResult{
+		Schema:                   1,
+		Agent:                    "codex",
+		Root:                     "/queue",
+		CanStartHere:             false,
+		StartMode:                "raw",
+		StartReason:              "owning terminal required",
+		LiveWake:                 true,
+		WakeStatus:               "valid",
+		WakePID:                  42,
+		WakeMode:                 "raw",
+		OwnerBound:               false,
+		RunningImagePath:         "/running/amq",
+		RunningVersion:           "0.50.0",
+		CurrentImagePath:         "/current/amq",
+		CurrentVersion:           "0.50.1",
+		ImageStatus:              "different",
+		CanRepairInjectVia:       false,
+		RepairReason:             "wake is live",
+		RestartCapability:        "operator_only",
+		OperatorTerminalRequired: true,
+		NextAction:               "leave the live wake running",
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return writeJSON(os.Stdout, result)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "{\n" +
+		"  \"schema\": 1,\n" +
+		"  \"agent\": \"codex\",\n" +
+		"  \"root\": \"/queue\",\n" +
+		"  \"can_start_here\": false,\n" +
+		"  \"start_mode\": \"raw\",\n" +
+		"  \"start_reason\": \"owning terminal required\",\n" +
+		"  \"live_wake\": true,\n" +
+		"  \"wake_status\": \"valid\",\n" +
+		"  \"wake_pid\": 42,\n" +
+		"  \"wake_mode\": \"raw\",\n" +
+		"  \"owner_bound\": false,\n" +
+		"  \"running_image_path\": \"/running/amq\",\n" +
+		"  \"running_version\": \"0.50.0\",\n" +
+		"  \"current_image_path\": \"/current/amq\",\n" +
+		"  \"current_version\": \"0.50.1\",\n" +
+		"  \"image_status\": \"different\",\n" +
+		"  \"can_repair_inject_via\": false,\n" +
+		"  \"repair_reason\": \"wake is live\",\n" +
+		"  \"restart_capability\": \"operator_only\",\n" +
+		"  \"operator_terminal_required\": true,\n" +
+		"  \"next_action\": \"leave the live wake running\"\n" +
+		"}\n"
+	if output != want {
+		t.Fatalf("v1 wake-check bytes changed:\n--- got ---\n%s--- want ---\n%s", output, want)
+	}
+}
+
+func TestDoctorOpsJSONSchemaV1GoldenBytes(t *testing.T) {
+	result := doctorResult{
+		Checks: []doctorCheck{{Name: "Binary", Status: "ok", Message: "ok"}},
+		Ops: &doctorOpsResult{
+			Root: opsRoot{Path: "/queue", Source: "flag"},
+			WakeLocks: []opsWakeLock{{
+				Status:                   "missing",
+				Agent:                    "codex",
+				Root:                     "/queue",
+				Lock:                     "/queue/.wake.lock",
+				CanStartHere:             false,
+				OperatorTerminalRequired: false,
+			}},
+		},
+	}
+	result.Summary.OK = 1
+
+	output, err := captureEnvStdout(t, func() error {
+		return writeJSON(os.Stdout, result)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "{\n" +
+		"  \"checks\": [\n" +
+		"    {\n" +
+		"      \"name\": \"Binary\",\n" +
+		"      \"status\": \"ok\",\n" +
+		"      \"message\": \"ok\"\n" +
+		"    }\n" +
+		"  ],\n" +
+		"  \"summary\": {\n" +
+		"    \"ok\": 1,\n" +
+		"    \"warn\": 0,\n" +
+		"    \"error\": 0\n" +
+		"  },\n" +
+		"  \"ops\": {\n" +
+		"    \"root\": {\n" +
+		"      \"path\": \"/queue\",\n" +
+		"      \"source\": \"flag\"\n" +
+		"    },\n" +
+		"    \"agents\": null,\n" +
+		"    \"wake_locks\": [\n" +
+		"      {\n" +
+		"        \"status\": \"missing\",\n" +
+		"        \"agent\": \"codex\",\n" +
+		"        \"root\": \"/queue\",\n" +
+		"        \"lock\": \"/queue/.wake.lock\",\n" +
+		"        \"can_start_here\": false,\n" +
+		"        \"operator_terminal_required\": false\n" +
+		"      }\n" +
+		"    ],\n" +
+		"    \"hints\": null\n" +
+		"  }\n" +
+		"}\n"
+	if output != want {
+		t.Fatalf("v1 doctor bytes changed:\n--- got ---\n%s--- want ---\n%s", output, want)
+	}
+}
+
+func TestJSONSchemaOneMatchesDefaultBytes(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.50.1")
+
+	wakeDefault, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wakeExplicit, err := captureEnvStdout(t, func() error {
+		return runWake([]string{
+			"check", "--root", root, "--me", "codex", "--json", "--json-schema=1",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wakeExplicit != wakeDefault {
+		t.Fatalf("explicit wake schema 1 changed bytes:\n--- default ---\n%s--- explicit ---\n%s", wakeDefault, wakeExplicit)
+	}
+
+	doctorDefault, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--root", root, "--json"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doctorExplicit, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--root", root, "--json", "--json-schema=1"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doctorExplicit != doctorDefault {
+		t.Fatalf("explicit doctor schema 1 changed bytes:\n--- default ---\n%s--- explicit ---\n%s", doctorDefault, doctorExplicit)
+	}
+}
+
+func TestWakeCheckJSONSchemaV2DirectStartUsesExplicitNullsAndArgv(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.50.1")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{
+			"check", "--root", root, "--me", "codex",
+			"--json", "--json-schema=2",
+		})
+	})
+	if err != nil {
+		t.Fatalf("wake check v2: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check v2: %v\n%s", err, output)
+	}
+	if got["schema"] != float64(2) || got["agent"] != "codex" || got["root"] != canonicalWakeRoot(root) {
+		t.Fatalf("identity = %#v", got)
+	}
+	platform := requireJSONObject(t, got, "platform")
+	if platform["wake_supported"] != true || platform["reason_code"] != nil {
+		t.Fatalf("platform = %#v", platform)
+	}
+	start := requireJSONObject(t, got, "start")
+	if start["available"] != true || start["mode"] != wakeInjectModeRaw ||
+		start["reason_code"] != nil || start["detail"] != nil {
+		t.Fatalf("start = %#v", start)
+	}
+	wake := requireJSONObject(t, got, "wake")
+	if wake["status"] != string(wakeLockMissing) || wake["live"] != false ||
+		wake["pid"] != nil || wake["mode"] != nil || wake["owner_bound"] != false {
+		t.Fatalf("wake = %#v", wake)
+	}
+	image := requireJSONObject(t, got, "image")
+	running := requireJSONObject(t, image, "running")
+	if running["path"] != nil || running["version"] != nil || image["status"] != wakeImageUnknown {
+		t.Fatalf("image = %#v", image)
+	}
+	repair := requireJSONObject(t, got, "repair")
+	if repair["inject_via_available"] != false || repair["reason_code"] != "no_wake_lock" || repair["detail"] != nil {
+		t.Fatalf("repair = %#v", repair)
+	}
+	if got["restart_capability"] != wakeRestartAgentSafe {
+		t.Fatalf("restart_capability = %#v", got["restart_capability"])
+	}
+	action := requireJSONObject(t, got, "action")
+	if action["kind"] != "start_wake" || action["actor"] != "agent" ||
+		action["reason_code"] != "wake_missing_start_available" || action["terminal_required"] != false {
+		t.Fatalf("action = %#v", action)
+	}
+	command := requireJSONObject(t, action, "command")
+	program, ok := command["program"].(string)
+	if !ok || !filepath.IsAbs(program) {
+		t.Fatalf("action command program = %#v", command["program"])
+	}
+	wantArgs := []any{"wake", "--root", canonicalWakeRoot(root), "--me", "codex"}
+	if !reflect.DeepEqual(command["args"], wantArgs) {
+		t.Fatalf("action command args = %#v, want %#v", command["args"], wantArgs)
+	}
+}
+
+func TestDoctorOpsJSONSchemaV2NestsSingleWakeDecision(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"codex"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "12345",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "doctor-v2-generation",
+		ImagePath:    "/opt/homebrew/bin/amq",
+		ImageVersion: "0.50.1",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID: pid, Running: true, StartToken: "12345", BootID: "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.50.1")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{
+			"--root", root, "--ops", "--json", "--json-schema=2",
+		})
+	})
+	if err != nil {
+		t.Fatalf("doctor ops v2: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode doctor v2: %v\n%s", err, output)
+	}
+	ops := requireJSONObject(t, got, "ops")
+	locks, ok := ops["wake_locks"].([]any)
+	if !ok || len(locks) != 1 {
+		t.Fatalf("wake_locks = %#v", ops["wake_locks"])
+	}
+	lock, ok := locks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("wake lock = %#v", locks[0])
+	}
+	wakeCheck := requireJSONObject(t, lock, "wake_check")
+	if wakeCheck["schema"] != float64(2) || wakeCheck["agent"] != "codex" ||
+		wakeCheck["restart_capability"] != wakeRestartOperatorOnly {
+		t.Fatalf("nested wake_check = %#v", wakeCheck)
+	}
+	for _, duplicate := range []string{
+		"can_start_here", "start_mode", "start_reason", "running_image_path",
+		"running_version", "current_image_path", "current_version", "image_status",
+		"restart_capability", "operator_terminal_required", "next_action",
+	} {
+		if _, exists := lock[duplicate]; exists {
+			t.Fatalf("doctor v2 wake lock duplicated %q: %#v", duplicate, lock)
+		}
+	}
+}
+
+func TestJSONSchemaRequiresJSONAndKnownVersion(t *testing.T) {
+	root := t.TempDir()
+	tests := []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{
+			name: "wake check schema requires JSON",
+			run: func() error {
+				return runWake([]string{"check", "--root", root, "--me", "codex", "--json-schema=2"})
+			},
+			want: "--json-schema requires --json",
+		},
+		{
+			name: "doctor schema requires JSON",
+			run: func() error {
+				return runDoctor([]string{"--root", root, "--json-schema=2"})
+			},
+			want: "--json-schema requires --json",
+		},
+		{
+			name: "wake check rejects schema 3",
+			run: func() error {
+				return runWake([]string{"check", "--root", root, "--me", "codex", "--json", "--json-schema=3"})
+			},
+			want: "--json-schema must be 1 or 2",
+		},
+		{
+			name: "doctor rejects schema 3",
+			run: func() error {
+				return runDoctor([]string{"--root", root, "--json", "--json-schema=3"})
+			},
+			want: "--json-schema must be 1 or 2",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.run()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestWakeCheckV2ClassifierActions(t *testing.T) {
+	baseDecision := func() wakeCheckDecision {
+		return wakeCheckDecision{
+			Agent: "codex",
+			Root:  "/queue with spaces",
+			Platform: wakeCheckPlatformDecision{
+				OS:            "darwin",
+				WakeSupported: true,
+			},
+			Start: wakeCheckStartDecision{Available: true, Mode: wakeInjectModeRaw},
+			Wake:  wakeCheckWakeDecision{Status: string(wakeLockMissing)},
+			Image: wakeCheckImageDecision{Status: wakeImageUnknown},
+		}
+	}
+	tests := []struct {
+		name      string
+		configure func(*wakeCheckDecision) (wakeLockInspection, *opsWakeLock)
+		kind      string
+		actor     string
+		reason    string
+		restart   string
+		args      []string
+		terminal  bool
+	}{
+		{
+			name: "missing direct start",
+			configure: func(*wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				return wakeLockInspection{}, nil
+			},
+			kind: wakeActionStartWake, actor: wakeActionActorAgent,
+			reason: wakeReasonMissingStartAvailable, restart: wakeRestartAgentSafe,
+			args: []string{"wake", "--root", "/queue with spaces", "--me", "codex"},
+		},
+		{
+			name: "missing full strength unavailable",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Start.Available = false
+				d.Start.Mode = wakeInjectModeNone
+				return wakeLockInspection{}, nil
+			},
+			kind: wakeActionConfigureInjector, actor: wakeActionActorOperator,
+			reason: wakeReasonFullStrengthUnavailable, restart: wakeRestartUnavailable,
+		},
+		{
+			name: "missing owning terminal",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Start.Available = false
+				return wakeLockInspection{}, nil
+			},
+			kind: wakeActionStartWake, actor: wakeActionActorOperator,
+			reason: wakeReasonOwningTerminalRequired, restart: wakeRestartOperatorOnly,
+			args:     []string{"wake", "--root", "/queue with spaces", "--me", "codex"},
+			terminal: true,
+		},
+		{
+			name: "stale inject-via repair",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockStale)
+				d.Wake.Mode = wakeCheckOptionalString(wakeTargetInjectVia)
+				d.Repair.InjectViaAvailable = true
+				return wakeLockInspection{Exists: true, Status: wakeLockStale}, &opsWakeLock{
+					Repair: wakeRepairCommand(d.Root, d.Agent),
+				}
+			},
+			kind: wakeActionRepairWake, actor: wakeActionActorAgent,
+			reason: wakeReasonStaleRepairAvailable, restart: wakeRestartAgentSafe,
+			args: []string{"wake", "repair", "--root", "/queue with spaces", "--me", "codex"},
+		},
+		{
+			name: "live raw wake",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockValid)
+				d.Wake.Live = true
+				d.Wake.Mode = wakeCheckOptionalString(wakeInjectModeRaw)
+				return wakeLockInspection{Exists: true, Status: wakeLockValid}, nil
+			},
+			kind: wakeActionPreserveLiveWake, actor: wakeActionActorOperator,
+			reason: wakeReasonLiveWakePreserve, restart: wakeRestartOperatorOnly,
+			terminal: true,
+		},
+		{
+			name: "live inject-via wake",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockValid)
+				d.Wake.Live = true
+				d.Wake.Mode = wakeCheckOptionalString(wakeTargetInjectVia)
+				return wakeLockInspection{Exists: true, Status: wakeLockValid}, nil
+			},
+			kind: wakeActionPreserveLiveWake, actor: wakeActionActorOperator,
+			reason: wakeReasonLiveWakePreserve, restart: wakeRestartOperatorOnly,
+		},
+		{
+			name: "stale owner-bound wake",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockStale)
+				d.Wake.OwnerBound = true
+				return wakeLockInspection{Exists: true, Status: wakeLockStale}, nil
+			},
+			kind: wakeActionRecoverOwner, actor: wakeActionActorOperator,
+			reason: wakeReasonOwnerRecoveryRequired, restart: wakeRestartUnavailable,
+			args: []string{"wake", "recover-owner", "--root", "/queue with spaces", "--me", "codex"},
+		},
+		{
+			name: "stale inject-via without repair",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockStale)
+				d.Wake.Mode = wakeCheckOptionalString(wakeTargetInjectVia)
+				return wakeLockInspection{Exists: true, Status: wakeLockStale}, nil
+			},
+			kind: wakeActionConfigureInjector, actor: wakeActionActorOperator,
+			reason: wakeReasonFullStrengthUnavailable, restart: wakeRestartUnavailable,
+		},
+		{
+			name: "stale generic without full strength injector",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Start.Available = false
+				d.Start.Mode = wakeInjectModeNone
+				d.Wake.Status = string(wakeLockStale)
+				d.Wake.Mode = wakeCheckOptionalString(wakeInjectModeRaw)
+				return wakeLockInspection{Exists: true, Status: wakeLockStale}, nil
+			},
+			kind: wakeActionConfigureInjector, actor: wakeActionActorOperator,
+			reason: wakeReasonFullStrengthUnavailable, restart: wakeRestartUnavailable,
+		},
+		{
+			name: "stale generic manual cleanup",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockStale)
+				d.Wake.Mode = wakeCheckOptionalString(wakeInjectModeRaw)
+				return wakeLockInspection{Exists: true, Status: wakeLockStale}, nil
+			},
+			kind: wakeActionManualStaleCleanup, actor: wakeActionActorOperator,
+			reason: wakeReasonStaleManualCleanupRequired, restart: wakeRestartOperatorOnly,
+			terminal: true,
+		},
+		{
+			name: "creating wake",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockCreating)
+				return wakeLockInspection{Exists: true, Status: wakeLockCreating}, nil
+			},
+			kind: wakeActionWaitForStableState, actor: wakeActionActorNone,
+			reason: wakeReasonWakeStateCreating, restart: wakeRestartUnavailable,
+		},
+		{
+			name: "unverified wake",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockUnverified)
+				return wakeLockInspection{Exists: true, Status: wakeLockUnverified}, nil
+			},
+			kind: wakeActionInspectUnverified, actor: wakeActionActorOperator,
+			reason: wakeReasonWakeStateUnverified, restart: wakeRestartUnavailable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := baseDecision()
+			inspection, opsLock := test.configure(&decision)
+			classifyWakeCheckRestart(&decision, inspection, opsLock)
+
+			if decision.Action.Kind != test.kind || decision.Action.Actor != test.actor ||
+				decision.Action.ReasonCode != test.reason ||
+				decision.RestartCapability != test.restart ||
+				decision.Action.TerminalRequired != test.terminal {
+				t.Fatalf("decision = %#v", decision)
+			}
+			if decision.Action.Message == "" {
+				t.Fatal("action message is empty")
+			}
+			if test.args == nil {
+				if decision.Action.Command != nil {
+					t.Fatalf("command = %#v, want null", decision.Action.Command)
+				}
+			} else {
+				if decision.Action.Command == nil ||
+					!filepath.IsAbs(decision.Action.Command.Program) ||
+					!reflect.DeepEqual(decision.Action.Command.Args, test.args) {
+					t.Fatalf("command = %#v, want args %#v", decision.Action.Command, test.args)
+				}
+			}
+
+			v1 := renderWakeCheckV1(decision)
+			v2 := renderWakeCheckV2(decision)
+			if v1.RestartCapability != v2.RestartCapability ||
+				v1.NextAction != v2.Action.Message {
+				t.Fatalf("cross-schema mismatch: v1=%#v v2=%#v", v1, v2)
+			}
+		})
+	}
+}
+
+func TestWakeCheckV2ObservationChangedIsRetryOnly(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.50.1")
+
+	decision := unstableWakeCheckDecision(root, "codex", wakeLockInspection{})
+	if decision.RestartCapability != wakeRestartUnavailable ||
+		decision.Action.Kind != wakeActionRetryCheck ||
+		decision.Action.Actor != wakeActionActorAgent ||
+		decision.Action.ReasonCode != wakeReasonObservationChanged ||
+		decision.Action.Command == nil ||
+		!reflect.DeepEqual(decision.Action.Command.Args, []string{
+			"wake", "check", "--root", canonicalWakeRoot(root), "--me", "codex",
+			"--json", "--json-schema=2",
+		}) {
+		t.Fatalf("observation-changed decision = %#v", decision)
+	}
+	for _, mutating := range []string{wakeActionStartWake, wakeActionRepairWake, wakeActionRecoverOwner} {
+		if decision.Action.Kind == mutating {
+			t.Fatalf("observation change advertised mutating action %q", mutating)
+		}
+	}
+}
+
+func TestWakeCheckV2RetryActionIsReadOnly(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.50.1")
+	decision := unstableWakeCheckDecision(root, "codex", wakeLockInspection{})
+	if decision.Action.Command == nil {
+		t.Fatal("retry action has no command")
+	}
+	before := snapshotWakeCheckTree(t, root)
+	if _, err := captureEnvStdout(t, func() error {
+		return runWake(decision.Action.Command.Args[1:])
+	}); err != nil {
+		t.Fatalf("execute retry action: %v", err)
+	}
+	assertWakeCheckTreeUnchanged(t, root, before)
+}
+
+func TestWakeCheckV2ActionProgramKeepsPublicExecutableAndLiteralArgv(t *testing.T) {
+	dir := t.TempDir()
+	cellar := filepath.Join(dir, "Cellar", "amq", "0.50.1", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(cellar), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cellar, []byte("binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	public := filepath.Join(dir, "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(public), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(cellar, public); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutable := wakeCheckExecutable
+	wakeCheckExecutable = func() (string, error) { return public, nil }
+	t.Cleanup(func() { wakeCheckExecutable = oldExecutable })
+
+	root := "/queue with spaces/and ' quotes"
+	command := wakeCheckActionCommand("wake", "--root", root, "--me", "codex")
+	if command == nil || command.Program != public {
+		t.Fatalf("program = %#v, want unresolved public path %q", command, public)
+	}
+	wantArgs := []string{"wake", "--root", root, "--me", "codex"}
+	if !reflect.DeepEqual(command.Args, wantArgs) {
+		t.Fatalf("args = %#v, want literal %#v", command.Args, wantArgs)
+	}
+}
+
+func TestWakeCheckV2WithholdsAdviceWhenExecutableIdentityIsUnavailable(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.50.1")
+	baselineV1, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		stub func() (string, error)
+	}{
+		{name: "executable lookup failed", stub: func() (string, error) {
+			return "", errors.New("executable unavailable")
+		}},
+		{name: "executable path is relative", stub: func() (string, error) {
+			return "bin/amq", nil
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oldExecutable := wakeCheckExecutable
+			wakeCheckExecutable = test.stub
+			t.Cleanup(func() { wakeCheckExecutable = oldExecutable })
+
+			v1, err := captureEnvStdout(t, func() error {
+				return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v1 != baselineV1 {
+				t.Fatalf("v1 bytes changed when executable identity was unavailable:\n--- baseline ---\n%s--- got ---\n%s", baselineV1, v1)
+			}
+
+			output, err := captureEnvStdout(t, func() error {
+				return runWake([]string{
+					"check", "--root", root, "--me", "codex",
+					"--json", "--json-schema=2",
+				})
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got wakeCheckResultV2
+			if err := json.Unmarshal([]byte(output), &got); err != nil {
+				t.Fatal(err)
+			}
+			if got.RestartCapability != wakeRestartUnavailable ||
+				got.Action.Kind != wakeActionRetryCheck ||
+				got.Action.Actor != wakeActionActorAgent ||
+				got.Action.ReasonCode != wakeReasonExecutableUnavailable ||
+				got.Action.Command != nil || got.Action.TerminalRequired {
+				t.Fatalf("unavailable executable decision = %#v", got)
+			}
+		})
+	}
+}
+
+func TestWakeCheckV2UnsupportedPlatformClassification(t *testing.T) {
+	got := renderWakeCheckV2(unsupportedWakeCheckDecision("/queue", "codex"))
+	if got.Schema != wakeCheckSchemaV2 || got.Platform.WakeSupported ||
+		got.Platform.ReasonCode == nil || *got.Platform.ReasonCode != wakeReasonPlatformUnsupported ||
+		got.RestartCapability != wakeRestartUnavailable ||
+		got.Action.Kind != wakeActionUnsupported || got.Action.Actor != wakeActionActorNone ||
+		got.Action.ReasonCode != wakeReasonPlatformUnsupported || got.Action.Command != nil {
+		t.Fatalf("unsupported classification = %#v", got)
+	}
+}
+
+func TestUnsupportedWakeDispatchRequiresExplicitV2OptIn(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "legacy default", args: []string{"--json"}},
+		{name: "legacy explicit one", args: []string{"--json", "--json-schema=1"}},
+		{name: "help stays legacy", args: []string{"--help"}},
+		{name: "schema without JSON stays legacy", args: []string{"--json-schema=2"}},
+		{name: "v2 equals", args: []string{"--json", "--json-schema=2"}, want: true},
+		{name: "v2 separate", args: []string{"--json", "--json-schema", "2"}, want: true},
+		{name: "single dash", args: []string{"-json", "-json-schema=2"}, want: true},
+		{name: "bool one", args: []string{"--json=1", "--json-schema=2"}, want: true},
+		{name: "bool t", args: []string{"--json=t", "--json-schema=2"}, want: true},
+		{name: "bool uppercase", args: []string{"--json=TRUE", "--json-schema=2"}, want: true},
+		{name: "last bool disables", args: []string{"--json", "--json=false", "--json-schema=2"}},
+		{name: "last bool enables", args: []string{"--json=false", "--json=1", "--json-schema=2"}, want: true},
+		{name: "last schema disables", args: []string{"--json", "--json-schema=2", "--json-schema=1"}},
+		{name: "last schema enables", args: []string{"--json", "--json-schema=1", "--json-schema=2"}, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := wakeCheckV2OptInPresent(test.args); got != test.want {
+				t.Fatalf("wakeCheckV2OptInPresent(%#v) = %t, want %t", test.args, got, test.want)
+			}
+		})
+	}
+}
+
+func TestDoctorOpsV2UsesSameNestedDecisionAsWakeCheck(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"codex"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "12345",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "shared-v2-generation",
+		ImagePath:    "/opt/homebrew/bin/amq",
+		ImageVersion: "0.50.1",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID: pid, Running: true, StartToken: "12345", BootID: "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.50.1")
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return wakeBinaryStaleness{
+			Method:   wakeBinaryComparisonExactIdentity,
+			Evidence: stableWakeBinaryEvidenceForTest(),
+		}, nil
+	})
+
+	wakeCheck := renderWakeCheckV2(inspectWakeCheckDecision(root, "codex"))
+	doctor := runOpsChecksWithSchema(root, "test", false, wakeCheckSchemaV2)
+	if len(doctor.WakeLocks) != 1 || doctor.WakeLocks[0].WakeCheckDecision == nil {
+		t.Fatalf("doctor wake locks = %#v", doctor.WakeLocks)
+	}
+	doctorWakeCheck := renderWakeCheckV2(*doctor.WakeLocks[0].WakeCheckDecision)
+	if !reflect.DeepEqual(doctorWakeCheck, wakeCheck) {
+		t.Fatalf("doctor and wake check decisions differ:\ndoctor=%#v\nwake=%#v", doctorWakeCheck, wakeCheck)
+	}
+}
+
+func TestDoctorOpsV2UsesOneStableSnapshotAfterEarlierDoctorStateChanged(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	lock := wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "12345",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "doctor-first-generation",
+	}
+	writeWakeLockForTest(t, root, "codex", lock)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		startToken := "12345"
+		if pid == 5252 {
+			startToken = "54321"
+		}
+		return wakeProcessInfo{
+			PID: pid, Running: true, StartToken: startToken, BootID: "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.50.1")
+
+	initial := inspectWakeLock(root, "codex")
+	if initial.Status != wakeLockValid {
+		t.Fatalf("initial inspection = %#v", initial)
+	}
+	lock.PID = 5252
+	lock.ProcessStart = "54321"
+	lock.Generation = "doctor-replacement-generation"
+	writeWakeLockExactForTest(t, root, "codex", lock)
+
+	opsLock := opsWakeLock{
+		Status: string(initial.Status),
+		Agent:  "codex",
+		Root:   initial.Root,
+		Lock:   initial.LockPath,
+		PID:    initial.PID,
+	}
+	decorateOpsWakeLockWithWakeCheck(root, &opsLock, initial, false, true)
+	if opsLock.WakeCheckDecision == nil {
+		t.Fatal("doctor v2 wake decision is missing")
+	}
+	decision := *opsLock.WakeCheckDecision
+	if opsLock.PID != lock.PID || decision.Wake.PID == nil || *decision.Wake.PID != lock.PID ||
+		opsLock.Status != "live-raw-orphan" || decision.Action.Kind != wakeActionPreserveLiveWake {
+		t.Fatalf("mixed doctor snapshots: outer=%#v decision=%#v", opsLock, decision)
+	}
+}
+
+func TestWakeCheckV2AdvertisedStartRevalidatesChangedWakeState(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	stubWakeCheckRuntime(t, true, "0.50.1")
+	decision := inspectWakeCheckDecision(root, "codex")
+	if decision.Action.Kind != wakeActionStartWake ||
+		decision.Action.Actor != wakeActionActorAgent ||
+		decision.Action.Command == nil {
+		t.Fatalf("advertised start = %#v", decision)
+	}
+
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          4242,
+		TTY:          "/dev/ttys005",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "12345",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "arrived-after-check",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID: pid, Running: true, StartToken: "12345", BootID: "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	lockPath := filepath.Join(fsq.AgentBase(root, "codex"), ".wake.lock")
+	before, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loopCalled := false
+	err = runWakeWithLoop(decision.Action.Command.Args[1:], func(wakeConfig) error {
+		loopCalled = true
+		return nil
+	})
+	if err == nil || loopCalled {
+		t.Fatalf("changed-state start: err=%v loop_called=%t", err, loopCalled)
+	}
+	after, readErr := os.ReadFile(lockPath)
+	if readErr != nil || !reflect.DeepEqual(after, before) {
+		t.Fatalf("changed-state start altered wake lock: err=%v before=%q after=%q", readErr, before, after)
+	}
+}
+
+func TestWakeCheckV2AdvertisedRepairRevalidatesChangedGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec"})
+	targetDigest, err := wakeTargetDigest(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock := wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-31T01:00:00Z",
+		ProcessStart: "12345",
+		BootID:       wakeRepairTestBootID,
+		Executable:   "amq",
+		WakeMode:     wakeTargetInjectVia,
+		TargetDigest: targetDigest,
+		Generation:   "advertised-generation",
+	}
+	writeWakeLockForTest(t, root, "codex", lock)
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeRepairFloorForTest(t, root, "codex", target, nil)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo { return wakeProcessInfo{PID: pid} })
+	stubWakeCheckRuntime(t, false, "0.50.1")
+
+	decision := inspectWakeCheckDecision(root, "codex")
+	if decision.Action.Kind != wakeActionRepairWake ||
+		decision.Action.Actor != wakeActionActorAgent ||
+		decision.Action.Command == nil {
+		t.Fatalf("advertised repair = %#v", decision)
+	}
+	lock.Generation = "replacement-generation"
+	writeWakeLockExactForTest(t, root, "codex", lock)
+	before := snapshotWakeCheckTree(t, root)
+
+	err = runWake(decision.Action.Command.Args[1:])
+	if err == nil {
+		t.Fatal("repair unexpectedly accepted changed generation")
+	}
+	assertWakeCheckTreeUnchanged(t, root, before)
+}
+
+func requireJSONObject(t *testing.T, object map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := object[key].(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want object", key, object[key])
+	}
+	return value
+}

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -13,20 +13,6 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
-const (
-	wakeCheckSchema = 1
-
-	wakeRestartAgentSafe    = "agent_safe"
-	wakeRestartOperatorOnly = "operator_only"
-	wakeRestartUnavailable  = "unavailable"
-
-	wakeImageCurrent   = "current"
-	wakeImageDifferent = "different"
-	wakeImageUnknown   = "unknown"
-
-	wakeCheckUnknown = "unknown"
-)
-
 type wakeCheckResult struct {
 	Schema                   int    `json:"schema"`
 	Agent                    string `json:"agent"`
@@ -57,6 +43,17 @@ type wakeStartCapability struct {
 	Reason   string
 }
 
+func wakeCheckStartReason(start wakeStartCapability) (*string, *string) {
+	if start.CanStart {
+		return nil, nil
+	}
+	reason := wakeReasonOwningTerminalRequired
+	if start.Mode == wakeInjectModeNone {
+		reason = wakeReasonFullStrengthUnavailable
+	}
+	return &reason, wakeCheckOptionalString(start.Reason)
+}
+
 type wakeCheckMetadataFingerprint struct {
 	Exists   bool
 	Identity wakeFileIdentity
@@ -70,9 +67,15 @@ type wakeCheckObservation struct {
 	Repair     wakeRepairAssessment
 }
 
+type wakeCheckSnapshot struct {
+	OpsLock  *opsWakeLock
+	Decision wakeCheckDecision
+}
+
 func runWakeCheck(args []string) error {
 	fs := flag.NewFlagSet("wake check", flag.ContinueOnError)
 	common := addCommonFlags(fs)
+	jsonSchema := addJSONSchemaFlag(fs)
 	usage := usageWithFlags(
 		fs,
 		"amq wake check --me <agent> [options]",
@@ -89,6 +92,9 @@ func runWakeCheck(args []string) error {
 	} else if handled {
 		return nil
 	}
+	if err := validateJSONSchemaFlag(fs, common.JSON, *jsonSchema); err != nil {
+		return err
+	}
 	if err := requireMe(common.Me); err != nil {
 		return err
 	}
@@ -104,25 +110,45 @@ func runWakeCheck(args []string) error {
 		return fmt.Errorf("inspect wake for %s: %w", me, err)
 	}
 
-	result := inspectWakeCheck(root, me)
+	decision := inspectWakeCheckDecision(root, me)
 	if common.JSON {
-		return writeJSON(os.Stdout, result)
+		if *jsonSchema == wakeCheckSchemaV2 {
+			return writeJSON(os.Stdout, renderWakeCheckV2(decision))
+		}
+		return writeJSON(os.Stdout, renderWakeCheckV1(decision))
 	}
-	return writeWakeCheckText(result)
+	return writeWakeCheckText(renderWakeCheckV1(decision))
 }
 
 func inspectWakeCheck(root, me string) wakeCheckResult {
+	return renderWakeCheckV1(inspectWakeCheckDecision(root, me))
+}
+
+func inspectWakeCheckDecision(root, me string) wakeCheckDecision {
+	return inspectWakeCheckSnapshot(root, me).Decision
+}
+
+func inspectWakeCheckSnapshot(root, me string) wakeCheckSnapshot {
 	root = canonicalWakeRoot(root)
 	first, firstErr := observeWakeCheck(root, me)
 	if firstErr != nil {
-		return unstableWakeCheckResult(root, me, first.Inspection)
+		return wakeCheckSnapshot{
+			OpsLock:  opsWakeLockFromWakeCheckObservation(root, me, first),
+			Decision: unstableWakeCheckDecision(root, me, first.Inspection),
+		}
 	}
 	second, secondErr := observeWakeCheck(root, me)
 	if secondErr != nil || !sameWakeCheckObservation(first, second) {
-		return unstableWakeCheckResult(root, me, second.Inspection)
+		return wakeCheckSnapshot{
+			OpsLock:  opsWakeLockFromWakeCheckObservation(root, me, second),
+			Decision: unstableWakeCheckDecision(root, me, second.Inspection),
+		}
 	}
 	opsLock := opsWakeLockFromWakeCheckObservation(root, me, second)
-	return buildWakeCheckResult(root, me, second.Inspection, opsLock, true)
+	return wakeCheckSnapshot{
+		OpsLock:  opsLock,
+		Decision: buildWakeCheckDecision(root, me, second.Inspection, opsLock, true),
+	}
 }
 
 func observeWakeCheck(root, me string) (wakeCheckObservation, error) {
@@ -232,31 +258,62 @@ func opsWakeLockFromWakeCheckObservation(
 	root, me string,
 	observation wakeCheckObservation,
 ) *opsWakeLock {
-	if !observation.Inspection.Exists {
-		return nil
+	inspection := observation.Inspection
+	status := string(inspection.Status)
+	if !inspection.Exists {
+		status = string(wakeLockMissing)
+	}
+	lockPath := inspection.LockPath
+	if lockPath == "" {
+		lockPath = filepath.Join(fsq.AgentBase(root, me), ".wake.lock")
 	}
 	opsLock := &opsWakeLock{
+		Status:          status,
 		Agent:           me,
+		Root:            canonicalWakeRoot(root),
+		Lock:            lockPath,
+		PID:             inspection.PID,
+		TTY:             strings.TrimSpace(inspection.Lock.TTY),
+		Started:         strings.TrimSpace(inspection.Lock.Started),
+		Reason:          inspection.Reason,
 		TargetPresent:   observation.Repair.TargetPresent,
 		TargetReason:    observation.Repair.TargetReason,
 		RepairAvailable: observation.Repair.RepairAvailable,
 		RepairReason:    observation.Repair.RepairReason,
 		Repair:          observation.Repair.Repair,
+		CurrentTerminal: doctorWakeLockOnCurrentTerminal(inspection),
 	}
 	if opsLock.TargetPresent {
 		opsLock.Target = wakeTargetPath(root, me)
 	}
+	if isLiveRawOrphan(inspection) {
+		opsLock.Status = "live-raw-orphan"
+		opsLock.Reason = "live raw wake orphan; stop the owning terminal or launchd supervisor"
+	}
 	return opsLock
 }
 
-func unstableWakeCheckResult(root, me string, inspection wakeLockInspection) wakeCheckResult {
-	result := buildWakeCheckResult(root, me, inspection, nil, true)
-	result.CanRepairInjectVia = false
-	result.RepairReason = "wake state changed during inspection"
-	result.RestartCapability = wakeRestartUnavailable
-	result.OperatorTerminalRequired = false
-	result.NextAction = "wake state changed during inspection; retry amq wake check"
-	return result
+func unstableWakeCheckDecision(root, me string, inspection wakeLockInspection) wakeCheckDecision {
+	decision := buildWakeCheckDecision(root, me, inspection, nil, true)
+	detail := "wake state changed during inspection"
+	reason := wakeRepairReasonExactEvidenceMissing
+	decision.Repair.InjectViaAvailable = false
+	decision.Repair.ReasonCode = &reason
+	decision.Repair.Detail = &detail
+	decision.Repair.legacyReason = detail
+	decision.RestartCapability = wakeRestartUnavailable
+	decision.Action = wakeCheckActionDecision{
+		Kind:       wakeActionRetryCheck,
+		Actor:      wakeActionActorAgent,
+		ReasonCode: wakeReasonObservationChanged,
+		Command: wakeCheckActionCommand(
+			"wake", "check", "--root", decision.Root, "--me", decision.Agent,
+			"--json", "--json-schema=2",
+		),
+		Message: "wake state changed during inspection; retry amq wake check",
+	}
+	finalizeWakeCheckDecision(&decision)
+	return decision
 }
 
 func sameWakeCheckInspection(first, second wakeLockInspection) bool {
@@ -269,60 +326,172 @@ func sameWakeCheckInspection(first, second wakeLockInspection) bool {
 		sameWakeBinaryProcessEvidence(first.Process, second.Process)
 }
 
-func buildWakeCheckResult(
+func buildWakeCheckDecision(
 	root, me string,
 	inspection wakeLockInspection,
 	opsLock *opsWakeLock,
 	probeImage bool,
-) wakeCheckResult {
+) wakeCheckDecision {
 	// probeImage is intentionally enabled only for the single-target wake
 	// check. Fleet doctor scans stay cheap and conservative: they reuse already
 	// validated "different" evidence but never claim "current" from versions
 	// alone.
 	start := inspectWakeStartCapability(me)
-	result := wakeCheckResult{
-		Schema:           wakeCheckSchema,
-		Agent:            me,
-		Root:             root,
-		CanStartHere:     start.CanStart,
-		StartMode:        start.Mode,
-		StartReason:      start.Reason,
-		WakeStatus:       string(inspection.Status),
-		WakePID:          inspection.PID,
-		WakeMode:         strings.TrimSpace(inspection.Lock.WakeMode),
-		OwnerBound:       classifyWakeClaimForGenericTransition(inspection) == wakeClaimAuthoritative,
-		RunningImagePath: wakeCheckUnknown,
-		RunningVersion:   wakeCheckUnknown,
-		CurrentImagePath: wakeCheckCurrentImagePath(),
-		CurrentVersion:   wakeCheckVersion(cliVersion),
-		ImageStatus:      wakeImageUnknown,
-	}
+	startReason, startDetail := wakeCheckStartReason(start)
+	ownerBound := classifyWakeClaimForGenericTransition(inspection) == wakeClaimAuthoritative
+	wakeStatus := string(inspection.Status)
 	if !inspection.Exists {
-		result.WakeStatus = string(wakeLockMissing)
+		wakeStatus = string(wakeLockMissing)
 	}
-	result.LiveWake = inspection.Exists &&
+	decision := wakeCheckDecision{
+		Agent: me,
+		Root:  root,
+		Platform: wakeCheckPlatformDecision{
+			OS:            runtime.GOOS,
+			WakeSupported: true,
+		},
+		Start: wakeCheckStartDecision{
+			Available:  start.CanStart,
+			Mode:       start.Mode,
+			ReasonCode: startReason,
+			Detail:     startDetail,
+		},
+		Wake: wakeCheckWakeDecision{
+			Status:     wakeStatus,
+			PID:        wakeCheckOptionalInt(inspection.PID),
+			Mode:       wakeCheckOptionalString(inspection.Lock.WakeMode),
+			OwnerBound: ownerBound,
+		},
+		Image: wakeCheckImageDecision{
+			Current: wakeCheckImageEvidenceDecision{
+				Path:    wakeCheckOptionalString(wakeCheckCurrentImagePath()),
+				Version: wakeCheckOptionalString(wakeCheckVersion(cliVersion)),
+			},
+			Status: wakeImageUnknown,
+		},
+	}
+	decision.Wake.Live = inspection.Exists &&
 		inspection.Status == wakeLockValid &&
 		inspection.IdentityConfirmed &&
 		inspection.Process.Running
-	if result.LiveWake {
-		result.RunningImagePath = wakeCheckRunningImagePath(inspection)
-		result.RunningVersion = wakeCheckVersion(inspection.Lock.ImageVersion)
+	if decision.Wake.Live {
+		decision.Image.Running.Path = wakeCheckOptionalString(wakeCheckRunningImagePath(inspection))
+		decision.Image.Running.Version = wakeCheckOptionalString(wakeCheckVersion(inspection.Lock.ImageVersion))
 		if opsLock != nil && opsLock.ImageStatus == wakeImageDifferent {
-			result.ImageStatus = opsLock.ImageStatus
+			decision.Image.Status = opsLock.ImageStatus
 		} else if probeImage {
-			result.ImageStatus = inspectWakeCheckImageStatus(inspection, result)
+			decision.Image.Status = inspectWakeCheckImageStatus(
+				inspection,
+				renderWakeCheckV1(decision),
+			)
 		}
 	}
 
+	legacyRepairReason := ""
 	if opsLock != nil {
-		result.CanRepairInjectVia = opsLock.RepairAvailable
-		result.RepairReason = opsLock.RepairReason
+		decision.Repair.InjectViaAvailable = opsLock.RepairAvailable
+		legacyRepairReason = opsLock.RepairReason
 	}
-	if !result.CanRepairInjectVia && result.RepairReason == "" {
-		result.RepairReason = wakeCheckRepairIneligibility(inspection, result.OwnerBound)
+	if !decision.Repair.InjectViaAvailable && legacyRepairReason == "" {
+		legacyRepairReason = wakeCheckRepairIneligibility(inspection, decision.Wake.OwnerBound)
 	}
-	classifyWakeCheckRestart(&result, inspection, opsLock)
-	return result
+	decision.Repair.legacyReason = legacyRepairReason
+	decision.Repair.ReasonCode, decision.Repair.Detail = wakeCheckRepairReason(
+		inspection,
+		decision.Wake.OwnerBound,
+		decision.Repair.InjectViaAvailable,
+		legacyRepairReason,
+	)
+	classifyWakeCheckRestart(&decision, inspection, opsLock)
+	finalizeWakeCheckDecision(&decision)
+	return decision
+}
+
+func renderWakeCheckV1(decision wakeCheckDecision) wakeCheckResult {
+	return wakeCheckResult{
+		Schema:                   wakeCheckSchemaV1,
+		Agent:                    decision.Agent,
+		Root:                     decision.Root,
+		CanStartHere:             decision.Start.Available,
+		StartMode:                decision.Start.Mode,
+		StartReason:              wakeCheckStringValue(decision.Start.Detail, ""),
+		LiveWake:                 decision.Wake.Live,
+		WakeStatus:               decision.Wake.Status,
+		WakePID:                  wakeCheckIntValue(decision.Wake.PID),
+		WakeMode:                 wakeCheckStringValue(decision.Wake.Mode, ""),
+		OwnerBound:               decision.Wake.OwnerBound,
+		RunningImagePath:         wakeCheckStringValue(decision.Image.Running.Path, wakeCheckUnknown),
+		RunningVersion:           wakeCheckStringValue(decision.Image.Running.Version, wakeCheckUnknown),
+		CurrentImagePath:         wakeCheckStringValue(decision.Image.Current.Path, wakeCheckUnknown),
+		CurrentVersion:           wakeCheckStringValue(decision.Image.Current.Version, wakeCheckUnknown),
+		ImageStatus:              decision.Image.Status,
+		CanRepairInjectVia:       decision.Repair.InjectViaAvailable,
+		RepairReason:             decision.Repair.legacyReason,
+		RestartCapability:        wakeCheckLegacyRestartCapability(decision),
+		OperatorTerminalRequired: wakeCheckLegacyTerminalRequired(decision),
+		NextAction:               wakeCheckLegacyActionMessage(decision),
+	}
+}
+
+func wakeCheckLegacyRestartCapability(decision wakeCheckDecision) string {
+	if decision.legacyRestartCapability != "" {
+		return decision.legacyRestartCapability
+	}
+	return decision.RestartCapability
+}
+
+func wakeCheckLegacyTerminalRequired(decision wakeCheckDecision) bool {
+	if decision.legacyRestartCapability != "" {
+		return decision.legacyTerminalRequired
+	}
+	return decision.Action.TerminalRequired
+}
+
+func wakeCheckLegacyActionMessage(decision wakeCheckDecision) string {
+	if decision.legacyRestartCapability != "" {
+		return decision.legacyActionMessage
+	}
+	return decision.Action.Message
+}
+
+func wakeCheckStringValue(value *string, fallback string) string {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func wakeCheckIntValue(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func wakeCheckRepairReason(
+	inspection wakeLockInspection,
+	ownerBound bool,
+	available bool,
+	legacyReason string,
+) (*string, *string) {
+	if available {
+		return nil, nil
+	}
+	var reason string
+	switch {
+	case !inspection.Exists:
+		reason = wakeRepairReasonNoLock
+		return &reason, nil
+	case ownerBound:
+		reason = wakeRepairReasonOwnerBound
+	case inspection.Status == wakeLockValid:
+		reason = wakeRepairReasonLive
+	case inspection.Status != wakeLockStale:
+		reason = wakeRepairReasonNotStale
+	default:
+		reason = wakeRepairReasonExactEvidenceMissing
+	}
+	return &reason, wakeCheckOptionalString(legacyReason)
 }
 
 func decorateOpsWakeLockWithWakeCheck(
@@ -330,8 +499,24 @@ func decorateOpsWakeLockWithWakeCheck(
 	lock *opsWakeLock,
 	inspection wakeLockInspection,
 	staleBinary bool,
+	includeV2 bool,
 ) {
 	root = canonicalWakeRoot(root)
+	if includeV2 {
+		removed := lock.Removed
+		removedStatus := lock.Status
+		removedReason := lock.Reason
+		snapshot := inspectWakeCheckSnapshot(root, lock.Agent)
+		opsLock := snapshot.OpsLock
+		if removed {
+			opsLock.Status = removedStatus
+			opsLock.Reason = removedReason
+			opsLock.Removed = true
+		}
+		opsLock.WakeCheckDecision = &snapshot.Decision
+		*lock = *opsLock
+		return
+	}
 	runningVersion := wakeCheckVersion(inspection.Lock.ImageVersion)
 	currentVersion := wakeCheckVersion(cliVersion)
 	switch {
@@ -344,7 +529,8 @@ func decorateOpsWakeLockWithWakeCheck(
 	default:
 		lock.ImageStatus = wakeImageUnknown
 	}
-	check := buildWakeCheckResult(root, lock.Agent, inspection, lock, false)
+	legacyDecision := buildWakeCheckDecision(root, lock.Agent, inspection, lock, false)
+	check := renderWakeCheckV1(legacyDecision)
 	lock.CanStartHere = check.CanStartHere
 	lock.StartMode = check.StartMode
 	lock.StartReason = check.StartReason
@@ -382,71 +568,138 @@ func inspectWakeStartCapability(me string) wakeStartCapability {
 }
 
 func classifyWakeCheckRestart(
-	result *wakeCheckResult,
+	decision *wakeCheckDecision,
 	inspection wakeLockInspection,
 	opsLock *opsWakeLock,
 ) {
-	startCommand := wakeStartCommand(result.Root, result.Agent)
+	startCommand := wakeStartCommand(decision.Root, decision.Agent)
+	startArgv := wakeCheckActionCommand(
+		"wake", "--root", decision.Root, "--me", decision.Agent,
+	)
 	if !inspection.Exists {
 		switch {
-		case result.CanStartHere && result.StartMode != wakeInjectModeNone:
-			result.RestartCapability = wakeRestartAgentSafe
-			result.NextAction = startCommand
-		case result.StartMode == wakeInjectModeNone:
-			result.RestartCapability = wakeRestartUnavailable
-			result.NextAction = "restore a supported full-strength injector or configure --inject-via; do not accept an attention-only downgrade"
+		case decision.Start.Available && decision.Start.Mode != wakeInjectModeNone:
+			decision.RestartCapability = wakeRestartAgentSafe
+			decision.Action = wakeCheckActionDecision{
+				Kind:       wakeActionStartWake,
+				Actor:      wakeActionActorAgent,
+				ReasonCode: wakeReasonMissingStartAvailable,
+				Command:    startArgv,
+				Message:    startCommand,
+			}
+		case decision.Start.Mode == wakeInjectModeNone:
+			decision.RestartCapability = wakeRestartUnavailable
+			decision.Action = wakeCheckActionDecision{
+				Kind:       wakeActionConfigureInjector,
+				Actor:      wakeActionActorOperator,
+				ReasonCode: wakeReasonFullStrengthUnavailable,
+				Message:    "restore a supported full-strength injector or configure --inject-via; do not accept an attention-only downgrade",
+			}
 		default:
-			result.RestartCapability = wakeRestartOperatorOnly
-			result.OperatorTerminalRequired = true
-			result.NextAction = "from the owning terminal, run " + startCommand
+			decision.RestartCapability = wakeRestartOperatorOnly
+			decision.Action = wakeCheckActionDecision{
+				Kind:             wakeActionStartWake,
+				Actor:            wakeActionActorOperator,
+				ReasonCode:       wakeReasonOwningTerminalRequired,
+				Command:          startArgv,
+				TerminalRequired: true,
+				Message:          "from the owning terminal, run " + startCommand,
+			}
 		}
 		return
 	}
-	if result.CanRepairInjectVia && opsLock != nil {
-		result.RestartCapability = wakeRestartAgentSafe
-		result.NextAction = opsLock.Repair
+	if decision.Repair.InjectViaAvailable && opsLock != nil {
+		decision.RestartCapability = wakeRestartAgentSafe
+		decision.Action = wakeCheckActionDecision{
+			Kind:       wakeActionRepairWake,
+			Actor:      wakeActionActorAgent,
+			ReasonCode: wakeReasonStaleRepairAvailable,
+			Command: wakeCheckActionCommand(
+				"wake", "repair", "--root", decision.Root, "--me", decision.Agent,
+			),
+			Message: opsLock.Repair,
+		}
 		return
 	}
-	if result.LiveWake {
-		result.RestartCapability = wakeRestartOperatorOnly
-		result.OperatorTerminalRequired =
-			result.WakeMode != wakeTargetInjectVia &&
-				result.WakeMode != wakeOwnerWakeMode
-		result.NextAction = "leave the live wake running; restart it from its owning terminal or supervisor after verifying replacement readiness"
+	if decision.Wake.Live {
+		decision.RestartCapability = wakeRestartOperatorOnly
+		terminalRequired :=
+			wakeCheckStringValue(decision.Wake.Mode, "") != wakeTargetInjectVia &&
+				wakeCheckStringValue(decision.Wake.Mode, "") != wakeOwnerWakeMode
+		decision.Action = wakeCheckActionDecision{
+			Kind:             wakeActionPreserveLiveWake,
+			Actor:            wakeActionActorOperator,
+			ReasonCode:       wakeReasonLiveWakePreserve,
+			TerminalRequired: terminalRequired,
+			Message:          "leave the live wake running; restart it from its owning terminal or supervisor after verifying replacement readiness",
+		}
 		return
 	}
 	switch inspection.Status {
 	case wakeLockStale:
-		if result.OwnerBound {
-			result.RestartCapability = wakeRestartUnavailable
-			result.NextAction = wakeRecoverOwnerCommand(result.Root, result.Agent)
+		if decision.Wake.OwnerBound {
+			message := wakeRecoverOwnerCommand(decision.Root, decision.Agent)
+			decision.RestartCapability = wakeRestartUnavailable
+			decision.Action = wakeCheckActionDecision{
+				Kind:       wakeActionRecoverOwner,
+				Actor:      wakeActionActorOperator,
+				ReasonCode: wakeReasonOwnerRecoveryRequired,
+				Command: wakeCheckActionCommand(
+					"wake", "recover-owner", "--root", decision.Root, "--me", decision.Agent,
+				),
+				Message: message,
+			}
 			return
 		}
-		if result.WakeMode == wakeTargetInjectVia {
-			result.RestartCapability = wakeRestartUnavailable
-			result.OperatorTerminalRequired = false
-			result.NextAction = "restore the configured --inject-via supervisor or reconfigure a supported full-strength injector before replacing this stale wake; do not fall back to raw terminal injection"
+		if wakeCheckStringValue(decision.Wake.Mode, "") == wakeTargetInjectVia {
+			decision.RestartCapability = wakeRestartUnavailable
+			decision.Action = wakeCheckActionDecision{
+				Kind:       wakeActionConfigureInjector,
+				Actor:      wakeActionActorOperator,
+				ReasonCode: wakeReasonFullStrengthUnavailable,
+				Message:    "restore the configured --inject-via supervisor or reconfigure a supported full-strength injector before replacing this stale wake; do not fall back to raw terminal injection",
+			}
 			return
 		}
-		if result.StartMode == wakeInjectModeNone {
-			result.RestartCapability = wakeRestartUnavailable
-			result.OperatorTerminalRequired = false
-			result.NextAction = "restore a supported full-strength injector or configure --inject-via; do not accept an attention-only downgrade"
+		if decision.Start.Mode == wakeInjectModeNone {
+			decision.RestartCapability = wakeRestartUnavailable
+			decision.Action = wakeCheckActionDecision{
+				Kind:       wakeActionConfigureInjector,
+				Actor:      wakeActionActorOperator,
+				ReasonCode: wakeReasonFullStrengthUnavailable,
+				Message:    "restore a supported full-strength injector or configure --inject-via; do not accept an attention-only downgrade",
+			}
 			return
 		}
-		result.RestartCapability = wakeRestartOperatorOnly
-		result.OperatorTerminalRequired = true
-		result.NextAction = fmt.Sprintf(
+		message := fmt.Sprintf(
 			"from the owning terminal, remove the proven-stale lock with %s, then run %s",
-			doctorRootCommandForOS(result.Root, "", runtime.GOOS, "--ops", "--fix-wake-locks"),
+			doctorRootCommandForOS(decision.Root, "", runtime.GOOS, "--ops", "--fix-wake-locks"),
 			startCommand,
 		)
+		decision.RestartCapability = wakeRestartOperatorOnly
+		decision.Action = wakeCheckActionDecision{
+			Kind:             wakeActionManualStaleCleanup,
+			Actor:            wakeActionActorOperator,
+			ReasonCode:       wakeReasonStaleManualCleanupRequired,
+			TerminalRequired: true,
+			Message:          message,
+		}
 	case wakeLockCreating:
-		result.RestartCapability = wakeRestartUnavailable
-		result.NextAction = "leave wake state unchanged and retry after lock creation finishes"
+		decision.RestartCapability = wakeRestartUnavailable
+		decision.Action = wakeCheckActionDecision{
+			Kind:       wakeActionWaitForStableState,
+			Actor:      wakeActionActorNone,
+			ReasonCode: wakeReasonWakeStateCreating,
+			Message:    "leave wake state unchanged and retry after lock creation finishes",
+		}
 	default:
-		result.RestartCapability = wakeRestartUnavailable
-		result.NextAction = "preserve the unverified wake state and inspect it with amq doctor --ops"
+		decision.RestartCapability = wakeRestartUnavailable
+		decision.Action = wakeCheckActionDecision{
+			Kind:       wakeActionInspectUnverified,
+			Actor:      wakeActionActorOperator,
+			ReasonCode: wakeReasonWakeStateUnverified,
+			Message:    "preserve the unverified wake state and inspect it with amq doctor --ops",
+		}
 	}
 }
 

--- a/internal/cli/wake_other.go
+++ b/internal/cli/wake_other.go
@@ -5,5 +5,8 @@ package cli
 import "errors"
 
 func runWake(args []string) error {
+	if len(args) > 0 && args[0] == "check" && wakeCheckV2OptInPresent(args[1:]) {
+		return runWakeCheckUnsupported(args[1:])
+	}
 	return errors.New("amq wake is not supported on this platform (requires macOS or Linux)")
 }


### PR DESCRIPTION
## Summary

Adds explicit JSON schema selection for amq wake check and amq doctor --ops. Schema 1 remains the default. Schema 2 provides a typed, closed-vocabulary decision with structured argv actions, explicit null evidence, fail-closed observation handling, and one nested doctor wake_check decision rather than duplicate advice fields.

Doctor schema 2 builds its outer lock fields and nested decision from one double-observed snapshot. The motivating RED reproduced the literal incoherence on the old tree: the outer entry retained PID 4242 while the nested decision read replacement PID 5252. The new tree replaces the full outer struct from the same snapshot used for the nested decision; successful removal overlays only status, reason, and removed as operation-result metadata.

## Compatibility evidence and limits

- The hand-written schema-1 goldens prove struct-serialization stability. They do not by themselves prove compatibility with the base binary.
- TestJSONSchemaOneMatchesDefaultBytes proves explicit schema 1 equals the staged binary default. External base-binary versus staged-binary comparisons provide the cross-version proof; peer review reproduced byte identity across 9/9 fixtures, and the final rm-then-copy binary check matched wake-check and doctor default/explicit schema-1 bytes.
- wake_check_other.go is read-verified only: current CI has no non-Darwin/non-Linux runtime runner. Windows production cross-build passes. The reviewer confirmed the inherited Windows vet failure is identical on base and branch; our Windows test cross-compile likewise fails on both at the existing deliverPartialWakeMessageForTest build-tag gap.

## Verification

- Exact-tree schema review PASS on d6b2113725ede521a1269b3e49c567c0603a6e51.
- Mechanical post-main integration PASS on tree 31c8db107004b29d99d992baa92fca26d4e00baa; the schema diff digest stayed byte-identical and the absorbed Wave 1 delta hashed identically on both sides.
- Final integrated make ci PASS.
- Independent simplify/scope review PASS.
- Windows production cross-build PASS.
- git diff --check PASS.

Design contract SHA: ed82b2ed604d8aefaab4fd5a839f36f5b86e24d3f073f516f0427cc3eabca4fa.