### PR TITLE
feat(wake): classify reload advertisement

### DIFF
--- a/internal/cli/wake_check_schema.go
+++ b/internal/cli/wake_check_schema.go
@@ -21,7 +21,9 @@ const (
 	wakeImageDifferent = "different"
 	wakeImageUnknown   = "unknown"
 
-	wakeCheckUnknown = "unknown"
+	wakeCheckUnknown      = "unknown"
+	wakeReloadAdvertised  = "advertised"
+	wakeReloadUnavailable = "unavailable"
 )
 
 const (
@@ -59,6 +61,13 @@ const (
 	wakeRepairReasonLive                 = "wake_live"
 	wakeRepairReasonNotStale             = "wake_not_stale"
 	wakeRepairReasonExactEvidenceMissing = "exact_repair_evidence_unavailable"
+	wakeReloadReasonNotLive              = "reload_not_live"
+	wakeReloadReasonNotAdvertised        = "reload_not_advertised"
+	wakeReloadReasonSchemaUnsupported    = "reload_schema_unsupported"
+	wakeReloadReasonAdvertisementInvalid = "reload_advertisement_invalid"
+	wakeReloadReasonObservationChanged   = "reload_observation_changed"
+	wakeReloadReasonPlatformUnsupported  = "reload_platform_unsupported"
+	wakeReloadReasonCommandUnavailable   = "reload_command_unavailable"
 )
 
 type wakeCheckDecision struct {
@@ -69,6 +78,7 @@ type wakeCheckDecision struct {
 	Wake                    wakeCheckWakeDecision
 	Image                   wakeCheckImageDecision
 	Repair                  wakeCheckRepairDecision
+	Reload                  wakeCheckReloadDecision
 	RestartCapability       string
 	Action                  wakeCheckActionDecision
 	legacyRestartCapability string
@@ -115,6 +125,11 @@ type wakeCheckRepairDecision struct {
 	legacyReason       string
 }
 
+type wakeCheckReloadDecision struct {
+	Status     string
+	ReasonCode string
+}
+
 type wakeCheckActionDecision struct {
 	Kind             string
 	Actor            string
@@ -138,6 +153,7 @@ type wakeCheckResultV2 struct {
 	Wake              wakeCheckWakeV2     `json:"wake"`
 	Image             wakeCheckImageV2    `json:"image"`
 	Repair            wakeCheckRepairV2   `json:"repair"`
+	Reload            wakeCheckReloadV2   `json:"reload"`
 	RestartCapability string              `json:"restart_capability"`
 	Action            wakeCheckActionV2   `json:"action"`
 }
@@ -178,6 +194,11 @@ type wakeCheckRepairV2 struct {
 	InjectViaAvailable bool    `json:"inject_via_available"`
 	ReasonCode         *string `json:"reason_code"`
 	Detail             *string `json:"detail"`
+}
+
+type wakeCheckReloadV2 struct {
+	Status     string `json:"status"`
+	ReasonCode string `json:"reason_code"`
 }
 
 type wakeCheckActionV2 struct {
@@ -223,6 +244,10 @@ func renderWakeCheckV2(decision wakeCheckDecision) wakeCheckResultV2 {
 			InjectViaAvailable: decision.Repair.InjectViaAvailable,
 			ReasonCode:         decision.Repair.ReasonCode,
 			Detail:             decision.Repair.Detail,
+		},
+		Reload: wakeCheckReloadV2{
+			Status:     decision.Reload.Status,
+			ReasonCode: decision.Reload.ReasonCode,
 		},
 		RestartCapability: decision.RestartCapability,
 		Action: wakeCheckActionV2{
@@ -357,6 +382,10 @@ func unsupportedWakeCheckDecision(root, agent string) wakeCheckDecision {
 			ReasonCode:   &reason,
 			Detail:       &detail,
 			legacyReason: detail,
+		},
+		Reload: wakeCheckReloadDecision{
+			Status:     wakeReloadUnavailable,
+			ReasonCode: wakeReloadReasonPlatformUnsupported,
 		},
 		RestartCapability: wakeRestartUnavailable,
 		Action: wakeCheckActionDecision{

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -568,10 +568,173 @@ func TestWakeCheckV2ObservationChangedIsRetryOnly(t *testing.T) {
 		}) {
 		t.Fatalf("observation-changed decision = %#v", decision)
 	}
+	if decision.Reload.Status != wakeReloadUnavailable ||
+		decision.Reload.ReasonCode != wakeReloadReasonObservationChanged {
+		t.Fatalf("observation-changed reload = %#v", decision.Reload)
+	}
 	for _, mutating := range []string{wakeActionStartWake, wakeActionRepairWake, wakeActionRecoverOwner} {
 		if decision.Action.Kind == mutating {
 			t.Fatalf("observation change advertised mutating action %q", mutating)
 		}
+	}
+}
+
+func TestWakeCheckV2ReloadObservationChangeUsesExistingSnapshotRetry(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	lock := validWakeResumeLockForTest()
+	lock.Root = canonicalWakeRoot(root)
+	lock.Agent = "codex"
+	lock.Generation = "first-resume-generation"
+	writeWakeLockForTest(t, root, "codex", lock)
+	inspections := 0
+	var expectedAfterChange map[string]wakeCheckTreeEntry
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspections++
+		if inspections == 2 {
+			replacement := lock
+			replacement.Generation = "replacement-resume-generation"
+			writeWakeLockExactForTest(t, root, "codex", replacement)
+			expectedAfterChange = snapshotWakeCheckTree(t, root)
+		}
+		return wakeProcessInfo{
+			PID: pid, Running: true, StartToken: lock.ProcessStart, BootID: lock.BootID,
+			Executable: lock.RunningImageEvidence.ExecutionPath,
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.50.1")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{
+			"check", "--root", root, "--me", "codex", "--json", "--json-schema=2",
+		})
+	})
+	if err != nil {
+		t.Fatalf("wake check v2: %v", err)
+	}
+	var got wakeCheckResultV2
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode wake check v2: %v\n%s", err, output)
+	}
+	if got.Reload.Status != wakeReloadUnavailable ||
+		got.Reload.ReasonCode != wakeReloadReasonObservationChanged ||
+		got.RestartCapability != wakeRestartUnavailable ||
+		got.Action.Kind != wakeActionRetryCheck {
+		t.Fatalf("changing reload observation = %#v", got)
+	}
+	if expectedAfterChange == nil {
+		t.Fatal("test did not inject the lock change")
+	}
+	assertWakeCheckTreeUnchanged(t, root, expectedAfterChange)
+}
+
+func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.T) {
+	validLock := validWakeResumeLockForTest()
+	validInspection := wakeLockInspection{
+		Exists:            true,
+		Status:            wakeLockValid,
+		PID:               validLock.PID,
+		Lock:              validLock,
+		Process:           wakeProcessInfo{PID: validLock.PID, Running: true},
+		IdentityConfirmed: true,
+	}
+	tests := []struct {
+		name       string
+		mutate     func(*wakeLockInspection)
+		wantStatus string
+		wantReason string
+	}{
+		{
+			name: "not live",
+			mutate: func(inspection *wakeLockInspection) {
+				inspection.Process.Running = false
+			},
+			wantStatus: wakeReloadUnavailable,
+			wantReason: wakeReloadReasonNotLive,
+		},
+		{
+			name: "legacy not advertised",
+			mutate: func(inspection *wakeLockInspection) {
+				inspection.Lock.ResumeSchema = 0
+				inspection.Lock.ResumeOwner = nil
+				inspection.Lock.RunningImageEvidence = nil
+			},
+			wantStatus: wakeReloadUnavailable,
+			wantReason: wakeReloadReasonNotAdvertised,
+		},
+		{
+			name: "future schema",
+			mutate: func(inspection *wakeLockInspection) {
+				inspection.Lock.ResumeSchema = wakeResumeSchemaV2 + 1
+			},
+			wantStatus: wakeReloadUnavailable,
+			wantReason: wakeReloadReasonSchemaUnsupported,
+		},
+		{
+			name: "malformed advertisement",
+			mutate: func(inspection *wakeLockInspection) {
+				inspection.Lock.RunningImageEvidence = nil
+			},
+			wantStatus: wakeReloadUnavailable,
+			wantReason: wakeReloadReasonAdvertisementInvalid,
+		},
+		{
+			name: "repair lineage",
+			mutate: func(inspection *wakeLockInspection) {
+				inspection.Lock.SourceGeneration = "repaired-generation"
+			},
+			wantStatus: wakeReloadUnavailable,
+			wantReason: wakeReloadReasonAdvertisementInvalid,
+		},
+		{
+			name:       "valid advertisement",
+			wantStatus: wakeReloadAdvertised,
+			wantReason: wakeReloadReasonCommandUnavailable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inspection := validInspection
+			if test.mutate != nil {
+				test.mutate(&inspection)
+			}
+			got := classifyWakeCheckReload(inspection)
+			if got.Status != test.wantStatus || got.ReasonCode != test.wantReason {
+				t.Fatalf("reload decision = %#v, want status=%q reason=%q", got, test.wantStatus, test.wantReason)
+			}
+		})
+	}
+
+	stubWakeCheckRuntime(t, false, "0.50.1")
+	decision := buildWakeCheckDecision("/queue", "codex", validInspection, &opsWakeLock{}, false)
+	if decision.Reload.Status != wakeReloadAdvertised ||
+		decision.Reload.ReasonCode != wakeReloadReasonCommandUnavailable ||
+		decision.RestartCapability != wakeRestartOperatorOnly ||
+		decision.Action.Kind != wakeActionPreserveLiveWake ||
+		decision.Action.Command != nil {
+		t.Fatalf("advertised reload changed executable action semantics: %#v", decision)
+	}
+	rendered := renderWakeCheckV2(decision)
+	if rendered.Reload.Status != wakeReloadAdvertised ||
+		rendered.Reload.ReasonCode != wakeReloadReasonCommandUnavailable {
+		t.Fatalf("advertised reload output = %#v", rendered.Reload)
+	}
+}
+
+func TestWakeCheckV2UnsupportedPlatformReloadIsUnavailable(t *testing.T) {
+	decision := unsupportedWakeCheckDecision("/queue", "codex")
+	if decision.Reload.Status != wakeReloadUnavailable ||
+		decision.Reload.ReasonCode != wakeReloadReasonPlatformUnsupported {
+		t.Fatalf("unsupported reload decision = %#v", decision.Reload)
+	}
+	reload := renderWakeCheckV2(decision).Reload
+	if reload.Status != wakeReloadUnavailable ||
+		reload.ReasonCode != wakeReloadReasonPlatformUnsupported {
+		t.Fatalf("unsupported reload output = %#v", reload)
 	}
 }
 

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -312,6 +312,10 @@ func unstableWakeCheckDecision(root, me string, inspection wakeLockInspection) w
 		),
 		Message: "wake state changed during inspection; retry amq wake check",
 	}
+	decision.Reload = wakeCheckReloadDecision{
+		Status:     wakeReloadUnavailable,
+		ReasonCode: wakeReloadReasonObservationChanged,
+	}
 	finalizeWakeCheckDecision(&decision)
 	return decision
 }
@@ -369,6 +373,7 @@ func buildWakeCheckDecision(
 			},
 			Status: wakeImageUnknown,
 		},
+		Reload: classifyWakeCheckReload(inspection),
 	}
 	decision.Wake.Live = inspection.Exists &&
 		inspection.Status == wakeLockValid &&
@@ -405,6 +410,29 @@ func buildWakeCheckDecision(
 	classifyWakeCheckRestart(&decision, inspection, opsLock)
 	finalizeWakeCheckDecision(&decision)
 	return decision
+}
+
+func classifyWakeCheckReload(inspection wakeLockInspection) wakeCheckReloadDecision {
+	unavailable := func(reason string) wakeCheckReloadDecision {
+		return wakeCheckReloadDecision{Status: wakeReloadUnavailable, ReasonCode: reason}
+	}
+	if !inspection.Exists || inspection.Status != wakeLockValid ||
+		!inspection.IdentityConfirmed || !inspection.Process.Running {
+		return unavailable(wakeReloadReasonNotLive)
+	}
+	if inspection.Lock.ResumeSchema == 0 {
+		return unavailable(wakeReloadReasonNotAdvertised)
+	}
+	if inspection.Lock.ResumeSchema != wakeResumeSchemaV2 {
+		return unavailable(wakeReloadReasonSchemaUnsupported)
+	}
+	if validateWakeResumeAdvertisement(inspection.Lock) != nil {
+		return unavailable(wakeReloadReasonAdvertisementInvalid)
+	}
+	return wakeCheckReloadDecision{
+		Status:     wakeReloadAdvertised,
+		ReasonCode: wakeReloadReasonCommandUnavailable,
+	}
 }
 
 func renderWakeCheckV1(decision wakeCheckDecision) wakeCheckResult {


### PR DESCRIPTION
## Summary

- add a schema-v2-only `reload` decision with the closed Wave 1 status and reason vocabulary
- classify only stable, live, structurally valid resume advertisements as `advertised`; keep the command unavailable
- preserve existing restart capability, action, command, and all v1/default output semantics
- reuse the existing two-observation snapshot for direct wake check and nested doctor output

## Compatibility

Schema v2 is merged on main but has not shipped in a release. This is an additive pre-release field, not a breaking change to a released wire contract. Schema v1 and default JSON bytes remain unchanged.

## Safety

No reload command, transport, owner-liveness claim, quiescence claim, or execution permission is introduced. Observation changes and unsupported platforms fail closed with explicit reasons.

## Verification

- RED: focused tests failed to compile before the reload decision, constants, and classifier existed
- `go test ./internal/cli -count=1`
- `make ci`
- Linux `golang:1.25.12` focused classifier, observation-change, and doctor-parity tests
- exact staged tree `6632aa69355cff12fa9026b0f5f434bd2d525a5b`
- simplify review PASS and peer exact-tree gate PASS with zero blockers
