### PR TITLE
fix(wake): preserve attention retry decay

### DIFF
--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -88,6 +88,10 @@ func (state *wakeDoorbellState) recordAttentionAttempt(now time.Time) {
 		wakeDoorbellAttentionRetryBase,
 		wakeDoorbellAttentionRetryMax,
 	)
+	// Additions join the continuously unread cohort and are rendered at its
+	// existing attention deadline. Pulling every decayed retry back to the
+	// 30-second floor lets a steady arrival stream defeat the attention ladder.
+	state.additionAttemptFloor = time.Time{}
 }
 
 func (state *wakeDoorbellState) transientAttentionDue(now time.Time) bool {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -2097,6 +2097,68 @@ func TestNotifyNewMessagesAttentionOnlyRetryCadence(t *testing.T) {
 	}
 }
 
+func TestNotifyNewMessagesAttentionAdditionsPreserveRetryDecay(t *testing.T) {
+	root := secureTempDirForTest(t)
+	now := time.Unix(1_800_000_000, 0)
+	type emission struct {
+		at      time.Time
+		payload string
+	}
+	var emissions []emission
+	cfg := &wakeConfig{
+		root:           root,
+		me:             "codex",
+		session:        "session1",
+		injectMode:     wakeInjectModeNone,
+		doorbellNow:    func() time.Time { return now },
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			emissions = append(emissions, emission{at: now, payload: string(data)})
+			return len(data), nil
+		},
+	}
+
+	deliverPartialWakeMessageForTest(t, root, "codex", "first")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("initial attention: %v", err)
+	}
+	now = now.Add(wakeDoorbellAttentionRetryBase)
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first bounded retry: %v", err)
+	}
+	decayedDeadline := now.Add(2 * wakeDoorbellAttentionRetryBase)
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok || !deadline.Equal(decayedDeadline) {
+		t.Fatalf("decayed deadline = %s, ok=%v; want %s", deadline, ok, decayedDeadline)
+	}
+
+	now = now.Add(time.Second)
+	deliverPartialWakeMessageForTest(t, root, "codex", "second")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first spaced addition: %v", err)
+	}
+	if deadline, ok := cfg.doorbell.nextDeadline(); !ok || !deadline.Equal(decayedDeadline) {
+		t.Fatalf("addition collapsed retry decay: deadline=%s ok=%v want=%s", deadline, ok, decayedDeadline)
+	}
+
+	now = now.Add(wakeDoorbellAttentionRetryBase)
+	deliverPartialWakeMessageForTest(t, root, "codex", "third")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("second spaced addition: %v", err)
+	}
+	if len(emissions) != 2 {
+		t.Fatalf("spaced additions emitted %d notices before decayed deadline: %#v", len(emissions), emissions)
+	}
+
+	now = decayedDeadline
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("decayed retry: %v", err)
+	}
+	if len(emissions) != 3 || !emissions[2].at.Equal(decayedDeadline) ||
+		!strings.Contains(emissions[2].payload, "3 messages - 3 from peer") {
+		t.Fatalf("decayed retry did not render the current collapsed cohort: %#v", emissions)
+	}
+}
+
 func TestNotifyNewMessagesMaxHoldRetriesInputWithoutAttentionFlood(t *testing.T) {
 	root := secureTempDirForTest(t)
 	deliverPartialWakeMessageForTest(t, root, "codex", "max-hold-retry")


### PR DESCRIPTION
## Summary

- keep a continuously unread attention cohort on its existing exponential retry deadline when new messages arrive
- render additions from the current collapsed cohort at that deadline instead of pulling every retry back to the 30-second floor
- leave input-channel first notice, 5-second addition pull-forward, bounded redelivery, partial-progress rearm, and recovery behavior unchanged

One outstanding `drain everything` announcement now covers the whole durable unread cohort on both channels. The input channel already had this property; this change applies it to attention without weakening idle-to-nonempty first notice or the bounded 30s-to-15m re-announce ladder.

## Root cause and RED

After attention attempts at t0 and t30, the next retry correctly decayed to t90. An addition at t31 reused the shared addition floor and pulled that deadline to t60. Repeated arrivals could therefore hold attention at a 30-second cadence indefinitely.

The controlled real-filesystem RED reproduced t90 -> t60. With this change, additions at t31 and t61 emit nothing early, the deadline remains t90, and the t90 notice renders the current collapsed three-message cohort.

## Issue closure

This closes the second and final half of #377:

- generation exclusivity was closed by #383 and #385
- cadence accumulation is closed here

Closes #377

## Verification

- focused input, attention, recovery, partial-progress, and coalescing tests
- `go test ./internal/cli -count=1`
- `make ci`
- real Linux `golang:1.25.12` focused cadence/recovery tests
- fresh verifier and simplify PASS on tree `ab595b30e3cc5302186385044d2d1cb55da4aa4b`
- peer direct staged-diff spot-check PASS
