### PR TITLE
test(send): make strict replacement race deterministic

### DIFF
--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -19,6 +19,10 @@ import (
 var deliverToExistingInbox = fsq.DeliverToExistingInbox
 
 func runSend(args []string) error {
+	return runSendWithAfterBodyRead(args, nil)
+}
+
+func runSendWithAfterBodyRead(args []string, afterBodyRead func()) error {
 	fs := flag.NewFlagSet("send", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	toFlag := fs.String("to", "", "Receiver handle (comma-separated)")
@@ -398,6 +402,9 @@ func runSend(args []string) error {
 	body, err := readBody(*bodyFlag, *allowEmptyFlag)
 	if err != nil {
 		return err
+	}
+	if afterBodyRead != nil {
+		afterBodyRead()
 	}
 
 	// Validate and process co-op mode fields

--- a/internal/cli/send_delivery_root_unix_test.go
+++ b/internal/cli/send_delivery_root_unix_test.go
@@ -175,64 +175,26 @@ func TestSendStrictConfigReplacementBeforeRepairDoesNotCreateOrDeliver(t *testin
 		t.Fatal(err)
 	}
 	configPath := filepath.Join(root, "meta", "config.json")
-	bodyFIFO := filepath.Join(secureTempDirForTest(t), "strict-body.fifo")
-	if err := syscall.Mkfifo(bodyFIFO, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	type openResult struct {
-		file *os.File
-		err  error
-	}
-	writerCh := make(chan openResult, 1)
-	go func() {
-		file, err := os.OpenFile(bodyFIFO, os.O_WRONLY, 0)
-		writerCh <- openResult{file: file, err: err}
-	}()
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- runSend([]string{
+	err := runSendWithAfterBodyRead(
+		[]string{
 			"--root", root,
 			"--me", "alice",
 			"--to", "bob",
 			"--strict",
-			"--body", "@" + bodyFIFO,
-		})
-	}()
-
-	var writer *os.File
-	select {
-	case result := <-writerCh:
-		if result.err != nil {
-			t.Fatal(result.err)
-		}
-		writer = result.file
-	case err := <-errCh:
-		t.Fatalf("send returned before body read: %v", err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("send did not reach body read after strict validation")
-	}
-	original := configPath + ".original"
-	if err := os.Rename(configPath, original); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(configPath, []byte(`{"version":1,"agents":["alice"]}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := writer.Write([]byte("must not deliver")); err != nil {
-		t.Fatal(err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case err := <-errCh:
-		if err == nil || !strings.Contains(err.Error(), "config") {
-			t.Fatalf("send error = %v, want retained-config refusal", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("send did not return")
+			"--body", "must not deliver",
+		},
+		func() {
+			original := configPath + ".original"
+			if err := os.Rename(configPath, original); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(configPath, []byte(`{"version":1,"agents":["alice"]}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "config") {
+		t.Fatalf("send error = %v, want retained-config refusal", err)
 	}
 	if _, err := os.Lstat(missing); !os.IsNotExist(err) {
 		t.Fatalf("strict send repaired after roster removal: %v", err)


### PR DESCRIPTION
## Summary

- replace the FIFO/goroutine/2-second timing approximation with an exact nil-default callback after body resolution
- keep production send behavior unchanged while placing the config replacement deterministically between strict validation and mailbox repair
- preserve assertions that no missing directory is repaired and no inbox delivery occurs

## Evidence

The same `send did not return` signature appeared once in the original schema review gate and once again in the later classifier review gate, isolating clean both times. During this fix it reproduced once under a 100-run focused stress command; 500 later repetitions, parallel process stress, and race stress were clean, confirming the wall-clock FIFO barrier was the nondiagnostic part rather than evidence of weakened production delivery checks.

Final exact-tree gates:

- focused test: 100 repetitions PASS
- focused race test: 100 repetitions PASS
- lower-level FSQ replacement invariants: 100 repetitions PASS
- full `internal/cli` suite PASS
- `make ci` PASS
- independent review and peer review PASS

Closes #381