### PR TITLE
fix(wake): corroborate Darwin process image

### DIFF
--- a/internal/cli/doctor_stale_wake_binary.go
+++ b/internal/cli/doctor_stale_wake_binary.go
@@ -11,8 +11,9 @@ import (
 type wakeBinaryComparisonMethod string
 
 const (
-	wakeBinaryComparisonExactIdentity wakeBinaryComparisonMethod = "device_inode"
-	wakeBinaryComparisonStartedMTime  wakeBinaryComparisonMethod = "started_mtime_heuristic"
+	wakeBinaryComparisonExactIdentity      wakeBinaryComparisonMethod = "device_inode"
+	wakeBinaryComparisonDarwinProcessImage wakeBinaryComparisonMethod = "darwin_process_image"
+	wakeBinaryComparisonStartedMTime       wakeBinaryComparisonMethod = "started_mtime_heuristic"
 )
 
 type wakeBinaryStaleness struct {
@@ -83,6 +84,7 @@ func checkStaleWakeBinaryHint(inspection wakeLockInspection) (opsHint, bool) {
 		return opsHint{}, false
 	}
 	if comparison.Method != wakeBinaryComparisonExactIdentity &&
+		comparison.Method != wakeBinaryComparisonDarwinProcessImage &&
 		comparison.Method != wakeBinaryComparisonStartedMTime {
 		return opsHint{}, false
 	}
@@ -146,6 +148,7 @@ func sameWakeBinaryEvidence(first, second wakeBinaryEvidence) bool {
 func sameWakeBinaryProcessEvidence(first, second wakeProcessInfo) bool {
 	return sameWakeOwnerProcessSnapshot(first, second) &&
 		first.Executable == second.Executable &&
+		first.ExecutablePath == second.ExecutablePath &&
 		slices.Equal(first.Args, second.Args)
 }
 

--- a/internal/cli/doctor_stale_wake_binary_darwin.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin.go
@@ -3,7 +3,12 @@
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -25,18 +30,141 @@ func inspectWakeBinaryStalenessPlatform(
 		return wakeBinaryStaleness{}, fmt.Errorf("current amq executable identity unavailable")
 	}
 
-	// Started is currently written with RFC3339 second precision. Require the
-	// binary mtime to be strictly beyond that full uncertainty window. This is
-	// only a timestamp heuristic: package extraction can preserve or alter mtime.
+	staleByStarted := current.Info.ModTime().After(started.Add(wakeStartedTimestampUncertainty))
+	comparisonEvidence := wakeBinaryEvidence{
+		Available:      true,
+		Current:        wakeBinaryFileEvidenceFromIdentity(currentIdentity),
+		CurrentModTime: current.Info.ModTime().UnixNano(),
+	}
+
+	// Legacy locks have no serialized execution identity. Preserve the positive
+	// timestamp warning, but never use this heuristic to claim a current image.
+	if inspection.Lock.RunningImageEvidence == nil {
+		return wakeBinaryStaleness{
+			Stale:    staleByStarted,
+			Method:   wakeBinaryComparisonStartedMTime,
+			Evidence: comparisonEvidence,
+		}, nil
+	}
+
+	recorded := *inspection.Lock.RunningImageEvidence
+	if err := validateWakeImageEvidence(recorded); err != nil {
+		return wakeBinaryStaleness{}, fmt.Errorf("validate recorded wake image evidence: %w", err)
+	}
+	if inspection.Lock.ImagePath != recorded.ExecutionPath ||
+		inspection.Lock.ImageVersion != recorded.EmbeddedVersion {
+		return wakeBinaryStaleness{}, fmt.Errorf("recorded wake image path or version disagrees with image evidence")
+	}
+
+	running, err := inspectDarwinWakeProcessImage(inspection.PID)
+	if err != nil {
+		return wakeBinaryStaleness{}, err
+	}
+	if !darwinRecordedImageMatches(recorded, running) {
+		return wakeBinaryStaleness{}, fmt.Errorf("live wake image disagrees with recorded image evidence")
+	}
+	comparisonEvidence.Running = wakeBinaryFileEvidenceFromIdentity(running.Identity)
+
+	if running.Identity.Device != currentIdentity.Device || running.Identity.Inode != currentIdentity.Inode {
+		return wakeBinaryStaleness{
+			Stale:    true,
+			Method:   wakeBinaryComparisonDarwinProcessImage,
+			Evidence: comparisonEvidence,
+		}, nil
+	}
+	if running.Identity != currentIdentity || running.Info.Size() != current.Info.Size() {
+		return wakeBinaryStaleness{}, fmt.Errorf("current wake image changed during comparison")
+	}
+	if staleByStarted {
+		// Started has second precision. A strictly newer current file remains a
+		// conservative different-image proof even when its inode was preserved.
+		return wakeBinaryStaleness{
+			Stale:    true,
+			Method:   wakeBinaryComparisonStartedMTime,
+			Evidence: comparisonEvidence,
+		}, nil
+	}
 	return wakeBinaryStaleness{
-		Stale:  current.Info.ModTime().After(started.Add(wakeStartedTimestampUncertainty)),
-		Method: wakeBinaryComparisonStartedMTime,
-		Evidence: wakeBinaryEvidence{
-			Available:      true,
-			Current:        wakeBinaryFileEvidenceFromIdentity(currentIdentity),
-			CurrentModTime: current.Info.ModTime().UnixNano(),
-		},
+		Method:   wakeBinaryComparisonDarwinProcessImage,
+		Evidence: comparisonEvidence,
 	}, nil
+}
+
+type darwinWakeProcessImage struct {
+	Path     string
+	Info     os.FileInfo
+	Identity wakeFileIdentity
+	SHA256   string
+}
+
+func inspectDarwinWakeProcessImage(pid int) (darwinWakeProcessImage, error) {
+	path, err := readDarwinProcessExecutablePath(pid)
+	if err != nil {
+		return darwinWakeProcessImage{}, fmt.Errorf("resolve wake process executable: %w", err)
+	}
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable path is not canonical and absolute")
+	}
+
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return darwinWakeProcessImage{}, fmt.Errorf("stat wake process executable path: %w", err)
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.Mode().IsRegular() {
+		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable path is not a regular non-symlink file")
+	}
+	file, err := openWakeMetadataFile(path)
+	if err != nil {
+		return darwinWakeProcessImage{}, fmt.Errorf("open wake process executable: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return darwinWakeProcessImage{}, fmt.Errorf("stat opened wake process executable: %w", err)
+	}
+	if !sameWakeFileIdentity(pathInfo, openedInfo) || pathInfo.Size() != openedInfo.Size() {
+		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable changed while opening")
+	}
+	identity, ok := captureWakeFileIdentity(openedInfo)
+	if !ok || identity.Device == 0 || identity.Inode == 0 {
+		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable identity unavailable")
+	}
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return darwinWakeProcessImage{}, fmt.Errorf("digest wake process executable: %w", err)
+	}
+	hashedInfo, err := file.Stat()
+	if err != nil || !sameWakeFileIdentity(openedInfo, hashedInfo) || openedInfo.Size() != hashedInfo.Size() {
+		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable changed while hashing")
+	}
+
+	confirmedPath, err := readDarwinProcessExecutablePath(pid)
+	if err != nil || confirmedPath != path {
+		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable path changed during inspection")
+	}
+	confirmedInfo, err := os.Lstat(path)
+	if err != nil || !sameWakeFileIdentity(hashedInfo, confirmedInfo) || hashedInfo.Size() != confirmedInfo.Size() {
+		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable changed during inspection")
+	}
+	return darwinWakeProcessImage{
+		Path:     path,
+		Info:     hashedInfo,
+		Identity: identity,
+		SHA256:   "sha256:" + hex.EncodeToString(hasher.Sum(nil)),
+	}, nil
+}
+
+func darwinRecordedImageMatches(
+	recorded wakeImageEvidenceV1,
+	running darwinWakeProcessImage,
+) bool {
+	return recorded.ExecutionPath == running.Path &&
+		recorded.Device == running.Identity.Device &&
+		recorded.Inode == running.Identity.Inode &&
+		recorded.Size == running.Info.Size() &&
+		recorded.CTimeNS == running.Identity.CTimeSec*1_000_000_000+running.Identity.CTimeNsec &&
+		recorded.SHA256 == running.SHA256
 }
 
 func wakeBinaryFileEvidenceFromIdentity(identity wakeFileIdentity) wakeBinaryFileEvidence {

--- a/internal/cli/doctor_stale_wake_binary_darwin_test.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin_test.go
@@ -3,11 +3,223 @@
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+const testDarwinCorroboratedImageMethod wakeBinaryComparisonMethod = "darwin_process_image"
+
+func TestDarwinProcessExecutablePathMatchesCurrentProcess(t *testing.T) {
+	got, err := readDarwinProcessExecutablePath(os.Getpid())
+	if err != nil {
+		t.Fatalf("read current process executable: %v", err)
+	}
+	if !filepath.IsAbs(got) || filepath.Clean(got) != got {
+		t.Fatalf("process executable path = %q, want canonical absolute path", got)
+	}
+
+	want, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err = filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantInfo, err := os.Stat(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatalf("process executable %q is not current executable %q", got, want)
+	}
+}
+
+func TestDarwinWakeBinaryComparisonReportsCurrentFromCorroboratedLiveImage(t *testing.T) {
+	path, err := readDarwinProcessExecutablePath(os.Getpid())
+	if err != nil {
+		t.Fatalf("read current process executable: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := darwinWakeImageEvidenceForTest(t, path, info)
+	started := time.Now().UTC().Add(time.Second).Truncate(time.Second)
+
+	got, err := inspectWakeBinaryStalenessPlatform(
+		wakeLockInspection{
+			PID: os.Getpid(),
+			Lock: wakeLock{
+				Started:              started.Format(time.RFC3339),
+				ImagePath:            path,
+				ImageVersion:         evidence.EmbeddedVersion,
+				RunningImageEvidence: &evidence,
+			},
+		},
+		resolvedWakeBinary{Info: info},
+	)
+	if err != nil {
+		t.Fatalf("compare corroborated current image: %v", err)
+	}
+	if got.Stale || got.Method != testDarwinCorroboratedImageMethod {
+		t.Fatalf("corroborated current comparison = %#v", got)
+	}
+	if !got.Evidence.Available || got.Evidence.Running != got.Evidence.Current {
+		t.Fatalf("corroborated evidence = %#v", got.Evidence)
+	}
+}
+
+func TestDarwinWakeBinaryComparisonReportsHomebrewReplacementDifferent(t *testing.T) {
+	started := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	dir := t.TempDir()
+	runningPath := filepath.Join(dir, "Cellar", "amq", "0.50.1", "bin", "amq")
+	currentPath := filepath.Join(dir, "Cellar", "amq", "0.51.0", "bin", "amq")
+	for _, path := range []string{runningPath, currentPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chtimes(runningPath, started.Add(-time.Minute), started.Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(currentPath, started.Add(time.Minute), started.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	runningInfo, err := os.Stat(runningPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentInfo, err := os.Stat(currentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
+	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return runningPath, nil })
+
+	got, err := inspectWakeBinaryStalenessPlatform(
+		wakeLockInspection{
+			PID: 4242,
+			Lock: wakeLock{
+				Started:              started.Format(time.RFC3339),
+				ImagePath:            runningPath,
+				ImageVersion:         evidence.EmbeddedVersion,
+				RunningImageEvidence: &evidence,
+			},
+		},
+		resolvedWakeBinary{Info: currentInfo},
+	)
+	if err != nil {
+		t.Fatalf("compare Homebrew replacement: %v", err)
+	}
+	if !got.Stale {
+		t.Fatalf("Homebrew replacement comparison = %#v, want different", got)
+	}
+}
+
+func TestDarwinWakeBinaryComparisonRejectsRecordedEvidenceDisagreement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := darwinWakeImageEvidenceForTest(t, path, info)
+	evidence.Inode++
+	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return path, nil })
+
+	got, err := inspectWakeBinaryStalenessPlatform(
+		wakeLockInspection{
+			PID: 4242,
+			Lock: wakeLock{
+				Started:              time.Now().UTC().Format(time.RFC3339),
+				ImagePath:            path,
+				ImageVersion:         evidence.EmbeddedVersion,
+				RunningImageEvidence: &evidence,
+			},
+		},
+		resolvedWakeBinary{Info: info},
+	)
+	if err == nil {
+		t.Fatalf("disagreeing recorded evidence returned %#v, want unknown error", got)
+	}
+}
+
+func TestDarwinWakeBinaryComparisonRejectsRecordedDigestDisagreement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := darwinWakeImageEvidenceForTest(t, path, info)
+	evidence.SHA256 = "sha256:" + strings.Repeat("f", 64)
+	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return path, nil })
+
+	got, err := inspectWakeBinaryStalenessPlatform(
+		wakeLockInspection{
+			PID: 4242,
+			Lock: wakeLock{
+				Started:              time.Now().UTC().Format(time.RFC3339),
+				ImagePath:            path,
+				ImageVersion:         evidence.EmbeddedVersion,
+				RunningImageEvidence: &evidence,
+			},
+		},
+		resolvedWakeBinary{Info: info},
+	)
+	if err == nil {
+		t.Fatalf("disagreeing recorded digest returned %#v, want unknown error", got)
+	}
+}
+
+func darwinWakeImageEvidenceForTest(t *testing.T, path string, info os.FileInfo) wakeImageEvidenceV1 {
+	t.Helper()
+	identity, ok := captureWakeFileIdentity(info)
+	if !ok {
+		t.Fatal("capture test image identity")
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(content)
+	return wakeImageEvidenceV1{
+		Schema:          wakeImageEvidenceSchemaV1,
+		Platform:        "darwin",
+		Method:          wakeImageMethodPathnameExecVerified,
+		ExecutionPath:   filepath.Clean(path),
+		Device:          identity.Device,
+		Inode:           identity.Inode,
+		Size:            info.Size(),
+		CTimeNS:         identity.CTimeSec*1_000_000_000 + identity.CTimeNsec,
+		SHA256:          "sha256:" + hex.EncodeToString(digest[:]),
+		EmbeddedVersion: "test-version",
+	}
+}
+
+func stubDarwinProcessExecutablePath(t *testing.T, fn func(int) (string, error)) {
+	t.Helper()
+	old := readDarwinProcessExecutablePath
+	readDarwinProcessExecutablePath = fn
+	t.Cleanup(func() { readDarwinProcessExecutablePath = old })
+}
 
 func TestDarwinWakeBinaryComparisonUsesStrictStartedMTimeHeuristic(t *testing.T) {
 	started := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -145,10 +145,20 @@ func inspectWakeCheckSnapshot(root, me string) wakeCheckSnapshot {
 		}
 	}
 	opsLock := opsWakeLockFromWakeCheckObservation(root, me, second)
-	return wakeCheckSnapshot{
+	snapshot := wakeCheckSnapshot{
 		OpsLock:  opsLock,
 		Decision: buildWakeCheckDecision(root, me, second.Inspection, opsLock, true),
 	}
+	// Image probing occurs while building the decision. Re-observe afterwards
+	// so a PID reuse or lock generation change cannot inherit that conclusion.
+	third, thirdErr := observeWakeCheck(root, me)
+	if thirdErr != nil || !sameWakeCheckObservation(second, third) {
+		return wakeCheckSnapshot{
+			OpsLock:  opsWakeLockFromWakeCheckObservation(root, me, third),
+			Decision: unstableWakeCheckDecision(root, me, third.Inspection),
+		}
+	}
+	return snapshot
 }
 
 func observeWakeCheck(root, me string) (wakeCheckObservation, error) {
@@ -294,7 +304,9 @@ func opsWakeLockFromWakeCheckObservation(
 }
 
 func unstableWakeCheckDecision(root, me string, inspection wakeLockInspection) wakeCheckDecision {
-	decision := buildWakeCheckDecision(root, me, inspection, nil, true)
+	// Unstable state cannot authorize an image conclusion, and probing again
+	// would widen the observation window after instability is already known.
+	decision := buildWakeCheckDecision(root, me, inspection, nil, false)
 	detail := "wake state changed during inspection"
 	reason := wakeRepairReasonExactEvidenceMissing
 	decision.Repair.InjectViaAvailable = false
@@ -754,7 +766,8 @@ func inspectWakeCheckImageStatus(
 	if comparison.Stale {
 		return wakeImageDifferent
 	}
-	if comparison.Method == wakeBinaryComparisonExactIdentity {
+	if comparison.Method == wakeBinaryComparisonExactIdentity ||
+		comparison.Method == wakeBinaryComparisonDarwinProcessImage {
 		return wakeImageCurrent
 	}
 	return wakeImageUnknown

--- a/internal/cli/wake_check_unix_test.go
+++ b/internal/cli/wake_check_unix_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -882,6 +883,12 @@ func TestNewWakeLockCapturesRunningImageEvidence(t *testing.T) {
 	}
 	if lock.ImageVersion != "0.49.14-test" {
 		t.Fatalf("image_version = %q", lock.ImageVersion)
+	}
+	if runtime.GOOS != "darwin" {
+		if lock.RunningImageEvidence != nil {
+			t.Fatalf("non-Darwin wake lock unexpectedly has running image evidence: %#v", lock.RunningImageEvidence)
+		}
+		return
 	}
 	if lock.RunningImageEvidence == nil {
 		t.Fatal("new wake lock is missing running image evidence")

--- a/internal/cli/wake_check_unix_test.go
+++ b/internal/cli/wake_check_unix_test.go
@@ -228,6 +228,22 @@ func TestWakeCheckImageStatusRequiresCompleteExactEvidence(t *testing.T) {
 			want: wakeImageUnknown,
 		},
 		{
+			name: "complete lock with corroborated Darwin comparison is current",
+			lock: wakeLock{
+				ImagePath:    "/opt/homebrew/bin/amq",
+				ImageVersion: "0.49.14",
+			},
+			result: wakeCheckResult{
+				RunningVersion: "0.49.14",
+				CurrentVersion: "0.49.14",
+			},
+			comparison: wakeBinaryStaleness{
+				Method:   wakeBinaryComparisonMethod("darwin_process_image"),
+				Evidence: stableWakeBinaryEvidenceForTest(),
+			},
+			want: wakeImageCurrent,
+		},
+		{
 			name: "legacy lock stays unknown despite exact comparison",
 			result: wakeCheckResult{
 				RunningVersion: wakeCheckUnknown,
@@ -775,6 +791,54 @@ func TestWakeCheckRefusesCapabilityFromChangingWakeState(t *testing.T) {
 	assertWakeCheckTreeUnchanged(t, root, expectedAfterChange)
 }
 
+func TestWakeCheckRefusesImageStatusWhenWakeChangesDuringImageProbe(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	baseLock := wakeLock{
+		PID:          4242,
+		TTY:          "/dev/ttys005",
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		Started:      "2026-07-31T01:00:00Z",
+		ProcessStart: "same-start",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "probe-generation",
+		ImagePath:    "/opt/homebrew/bin/amq",
+		ImageVersion: "0.49.14",
+	}
+	writeWakeLockForTest(t, root, "codex", baseLock)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "same-start",
+			BootID:     "same-boot",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		replacement := baseLock
+		replacement.Generation = "replacement-during-probe"
+		writeWakeLockExactForTest(t, root, "codex", replacement)
+		return wakeBinaryStaleness{
+			Method:   wakeBinaryComparisonExactIdentity,
+			Evidence: stableWakeBinaryEvidenceForTest(),
+		}, nil
+	})
+
+	got := inspectWakeCheck(root, "codex")
+	if got.ImageStatus != wakeImageUnknown ||
+		got.NextAction != "wake state changed during inspection; retry amq wake check" {
+		t.Fatalf("wake changed during image probe = %#v", got)
+	}
+}
+
 func TestWakeCheckTextPrintsExactClassifiedAction(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
@@ -818,6 +882,13 @@ func TestNewWakeLockCapturesRunningImageEvidence(t *testing.T) {
 	}
 	if lock.ImageVersion != "0.49.14-test" {
 		t.Fatalf("image_version = %q", lock.ImageVersion)
+	}
+	if lock.RunningImageEvidence == nil {
+		t.Fatal("new wake lock is missing running image evidence")
+	}
+	if lock.RunningImageEvidence.ExecutionPath != lock.ImagePath ||
+		lock.RunningImageEvidence.EmbeddedVersion != lock.ImageVersion {
+		t.Fatalf("running image evidence does not bind path/version: %#v", lock)
 	}
 }
 

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -53,6 +53,7 @@ type wakeProcessInfo struct {
 	BootID                    string
 	LegacyBootID              string
 	Executable                string
+	ExecutablePath            string
 	Args                      []string
 	ControllingTerminalKnown  bool
 	HasControllingTerminal    bool

--- a/internal/cli/wake_process_darwin.go
+++ b/internal/cli/wake_process_darwin.go
@@ -3,8 +3,12 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -14,9 +18,19 @@ import (
 const darwinProcessStateZombie int8 = 5
 const darwinNoControllingTerminal int32 = -1
 
+// Values from Apple's XNU proc_info interface. proc_pidpath in libproc is a
+// wrapper around this exact CGO-free syscall.
+const (
+	darwinSysProcInfo            = 336
+	darwinProcInfoCallPIDInfo    = 0x2
+	darwinProcPIDPathInfo        = 11
+	darwinProcPIDPathInfoMaxSize = 4 * unix.PathMax
+)
+
 var (
-	readDarwinKinfoProc       = unix.SysctlKinfoProc
-	readDarwinBootSessionUUID = func() (string, error) {
+	readDarwinKinfoProc             = unix.SysctlKinfoProc
+	readDarwinProcessExecutablePath = readDarwinProcessExecutablePathDefault
+	readDarwinBootSessionUUID       = func() (string, error) {
 		return unix.Sysctl("kern.bootsessionuuid")
 	}
 	readDarwinBootTime = func() (*unix.Timeval, error) {
@@ -48,6 +62,9 @@ func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
 	sec, nsec := kp.Proc.P_starttime.Unix()
 	info.StartToken = fmt.Sprintf("%d.%09d", sec, nsec)
 	info.Executable = nulTerminatedString(kp.Proc.P_comm[:])
+	if path, pathErr := readDarwinProcessExecutablePath(pid); pathErr == nil {
+		info.ExecutablePath = path
+	}
 	info.ControllingTerminalKnown = true
 	info.HasControllingTerminal = kp.Eproc.Tdev != darwinNoControllingTerminal
 	info.ControllingTerminalDevice = kp.Eproc.Tdev
@@ -55,6 +72,35 @@ func inspectWakeProcessPlatform(pid int) wakeProcessInfo {
 	info.BootID, info.LegacyBootID = darwinBootIdentity()
 
 	return info
+}
+
+func readDarwinProcessExecutablePathDefault(pid int) (string, error) {
+	if pid <= 0 {
+		return "", fmt.Errorf("invalid process id %d", pid)
+	}
+	buffer := make([]byte, darwinProcPIDPathInfoMaxSize)
+	_, _, errno := unix.Syscall6(
+		darwinSysProcInfo,
+		darwinProcInfoCallPIDInfo,
+		uintptr(pid),
+		darwinProcPIDPathInfo,
+		0,
+		uintptr(unsafe.Pointer(&buffer[0])),
+		uintptr(len(buffer)),
+	)
+	runtime.KeepAlive(buffer)
+	if errno != 0 {
+		return "", fmt.Errorf("proc_pidpath pid %d: %w", pid, errno)
+	}
+	end := bytes.IndexByte(buffer, 0)
+	if end <= 0 {
+		return "", fmt.Errorf("proc_pidpath pid %d returned an unterminated path", pid)
+	}
+	path := string(buffer[:end])
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return "", fmt.Errorf("proc_pidpath pid %d returned a non-canonical absolute path", pid)
+	}
+	return path, nil
 }
 
 func darwinBootIdentity() (bootID, legacyBootID string) {

--- a/internal/cli/wake_resume_protocol_unix_test.go
+++ b/internal/cli/wake_resume_protocol_unix_test.go
@@ -295,8 +295,11 @@ func TestNewWakeLockAdvertisesResumeOnlyWhenTheProtocolIsComplete(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if notEligible.ResumeSchema != 0 || notEligible.ResumeOwner != nil || notEligible.RunningImageEvidence != nil {
+	if notEligible.ResumeSchema != 0 || notEligible.ResumeOwner != nil {
 		t.Fatalf("ineligible wake advertised resume: %#v", notEligible)
+	}
+	if notEligible.RunningImageEvidence == nil || *notEligible.RunningImageEvidence != evidence {
+		t.Fatalf("ordinary Darwin wake omitted additive image evidence: %#v", notEligible)
 	}
 
 	captureCurrentWakeImageEvidence = func() (wakeImageEvidenceV1, error) {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -534,6 +535,16 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 		}
 	}
 	lock.ImageVersion = strings.TrimSpace(cliVersion)
+	if runtime.GOOS == "darwin" {
+		// Darwin has no retained executable FD. Capture the verified pathname
+		// identity for every new lock so later proc_pidpath evidence can be
+		// corroborated without making notifier startup depend on this metadata.
+		if evidence, evidenceErr := captureCurrentWakeImageEvidence(); evidenceErr == nil {
+			lock.RunningImageEvidence = &evidence
+			lock.ImagePath = evidence.ExecutionPath
+			lock.ImageVersion = evidence.EmbeddedVersion
+		}
+	}
 	if options.target != nil {
 		targetDigest, err := wakeTargetDigest(*options.target)
 		if err != nil {
@@ -569,12 +580,18 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 		if candidate.ControlSocket == "" {
 			candidate.ControlSocket = wakeControlSocketPath(root, me, candidate.Generation)
 		}
-		evidence, evidenceErr := captureCurrentWakeImageEvidence()
-		if evidenceErr == nil {
+		evidence := lock.RunningImageEvidence
+		if evidence == nil {
+			captured, evidenceErr := captureCurrentWakeImageEvidence()
+			if evidenceErr == nil {
+				evidence = &captured
+			}
+		}
+		if evidence != nil {
 			owner := *options.requestedOwner
 			candidate.ResumeSchema = wakeResumeSchemaV2
 			candidate.ResumeOwner = &owner
-			candidate.RunningImageEvidence = &evidence
+			candidate.RunningImageEvidence = evidence
 			candidate.ImagePath = evidence.ExecutionPath
 			candidate.ImageVersion = evidence.EmbeddedVersion
 			if validateWakeResumeAdvertisement(candidate) == nil {


### PR DESCRIPTION
## Summary

- capture additive Darwin running-image evidence for newly written wake locks without making startup depend on it
- corroborate recorded evidence against the live no-follow executable and the currently resolved binary before classifying an image as current
- return unknown on missing, malformed, disagreeing, or unstable evidence, and re-observe the lock/process after probing
- preserve the legacy positive timestamp warning without claiming current-image identity

## Verification

- real-current-process Darwin raw syscall test
- corroborated-current, replaced-image, metadata-disagreement, digest-disagreement, and post-probe-instability cases
- focused tests and focused race tests
- full internal/cli tests, including CGO_ENABLED=0
- Darwin arm64 and amd64 CGO-free builds
- make ci
- independent review PASS
- Claude exact-tree gate PASS

Reviewed patch SHA-256: `c446c51fccd65c46832fab82c28c9242b5e807dd75e916d0f4256ef64424010e`
Integrated commit: `562f0262a0d0dcc36b5d24d3a75756d8e90db309`