### PR TITLE
test(coop): pin auto-init fixture isolation

### DIFF
--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -1355,6 +1355,39 @@ func TestCoopInitNoGitignore(t *testing.T) {
 }
 
 func TestCoopExecAutoInitNoGitignore(t *testing.T) {
+	runCoopExecAutoInitNoGitignoreFixture(t)
+}
+
+func TestCoopExecAutoInitNoGitignoreLeavesInheritedCoopTreeUnchanged(t *testing.T) {
+	ambientBase, ambientRoot := makeCoopAmbientSessionForTest(t, "current")
+	rootID, baseRootID := treeIdentityTokens(ambientRoot, ambientBase)
+	if rootID == "" || baseRootID == "" {
+		t.Fatal("ambient fixture did not produce complete identity tokens")
+	}
+	t.Setenv(envRoot, ambientRoot)
+	t.Setenv(envRootID, rootID)
+	t.Setenv(envBaseRoot, ambientBase)
+	t.Setenv(envBaseRootID, baseRootID)
+	t.Setenv(envSession, "current")
+	t.Setenv(envGlobalRoot, ambientBase)
+	before := snapshotTreeDigest(t, ambientBase)
+
+	projectDir := runCoopExecAutoInitNoGitignoreFixture(t)
+
+	if after := snapshotTreeDigest(t, ambientBase); after != before {
+		t.Fatalf("inherited AMQ tree mutated: before=%s after=%s", before, after)
+	}
+	fixtureAgent := fsq.AgentBase(
+		filepath.Join(projectDir, defaultCoopRoot, defaultSessionName),
+		"definitely-missing-amq-test-binary",
+	)
+	if info, err := os.Stat(fixtureAgent); err != nil || !info.IsDir() {
+		t.Fatalf("isolated fixture mailbox missing: info=%v err=%v", info, err)
+	}
+}
+
+func runCoopExecAutoInitNoGitignoreFixture(t *testing.T) string {
+	t.Helper()
 	clearCoopSessionPinForTest(t)
 	setOptionalEnv(t, envRoot, "", false)
 	setOptionalEnv(t, envGlobalRoot, "", false)
@@ -1394,6 +1427,7 @@ func TestCoopExecAutoInitNoGitignore(t *testing.T) {
 	if string(gitignoreAfter) != gitignoreBefore {
 		t.Fatalf(".gitignore changed with coop exec --no-gitignore:\n%s", gitignoreAfter)
 	}
+	return projectDir
 }
 
 func TestInitExplicitAgentsDoesNotInjectUser(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a direct regression tripwire for coop auto-init fixture isolation under a complete valid inherited AMQ session tuple
- assert the ambient base tree digest is unchanged after the fixture runs
- assert the fixture mailbox exists only beneath the test-owned temporary project

## Scope

This is regression coverage for containment already fixed by #346. It does not claim a new production behavior fix: the existing test-harness sanitation is moved into the shared fixture helper so the new hostile-context regression pins it directly.

## RED / GREEN

Controlled RED was produced after extracting the helper without moving the existing sanitation: the fixture followed the ambient base and the temporary project `.amqrc` was absent. Moving the same sanitation into the helper made the new regression green.

## Verification

- focused regression 100x PASS on the integrated tree
- full `internal/cli` race suite PASS
- exact `make ci` PASS
- independent review PASS
- Claude exact-tree gate PASS

Closes #376