### PR TITLE
fix(wake): bind resume claims to exact evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ amq dlq read --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin
 amq dlq retry --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--all] [--force]
 amq dlq purge --me <agent> [--session <name>] [--ignore-session-pin] [--older-than <duration>] [--dry-run] [--yes]
 amq wake --me <agent> [--baseline-existing] [--inject-cmd <cmd>] [--inject-mode <auto|raw|paste|none>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>] [--interrupt] [--interrupt-label <label>] [--interrupt-priority <p>] [--interrupt-cmd <ctrl-c|none>] [--interrupt-notice <str>] [--interrupt-cooldown <duration>] [--debug]
-amq wake check --me <agent> [--root <path>] [--strict] [--json]
+amq wake check --me <agent> [--root <path>] [--strict] [--json] [--json-schema <1|2>]
 amq wake repair --me <agent> [--root <path>] [--json]
 amq wake retire --me <agent> --inject-via <absolute-executable> [--inject-arg <arg>...] [--root <path>] [--json]
 amq upgrade
@@ -219,13 +219,13 @@ amq integration symphony init [--workflow <path>] --me <agent> [--root <path>] [
 amq integration symphony emit --event <after_create|before_run|after_run|before_remove> --me <agent> [--root <path>] [--workspace <path>] [--identifier <key>] [--json]
 amq integration kanban bridge --me <agent> [--root <path>] [--url <ws://...>] [--workspace-id <id>] [--reconnect <duration>] [--json]
 amq who [--json]
-amq doctor [--root <path>] [--base-root <path>] [--ignore-session-pin] [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json]
+amq doctor [--root <path>] [--base-root <path>] [--ignore-session-pin] [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json] [--json-schema <1|2>]
 ```
 
 `--root` is accepted only where it is listed above. Participating commands may
 also accept `--json` and `--strict` (error instead of warn on unknown handles or
 unreadable/corrupt config). Global option: `--no-update-check`. Note: `init` has
-its own flags and doesn't accept these.
+its own flags and doesn't accept these. `--json-schema` requires `--json`.
 
 **Body resolution (`send`/`reply`)**: `--body` resolves from `@file`, a literal string, or stdin. A bare `--body -`, `--body @-`, or an omitted `--body` reads stdin (standard CLI convention). A send whose resolved body is empty or whitespace-only **fails closed** with a usage error rather than delivering a blank message — pass `--allow-empty` to send a blank body intentionally. This prevents a dropped or mistyped body (e.g. `--body -` with nothing piped) from silently shipping an empty message.
 

--- a/README.md
+++ b/README.md
@@ -556,6 +556,15 @@ Common command groups:
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
 | Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake check`, `wake repair`, `wake recover-owner`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 
+Canonical schema-selecting diagnostic forms:
+
+```text
+amq wake check --me <agent> [--root <path>] [--strict] [--json] [--json-schema <1|2>]
+amq doctor [--root <path>] [--base-root <path>] [--ignore-session-pin] [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json] [--json-schema <1|2>]
+```
+
+`--json-schema` requires `--json`.
+
 ### Exit codes
 
 AMQ exposes stable process exit codes for scripts and agent consumers:

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -100,6 +100,13 @@ type opsWakeLock struct {
 	CurrentTerminal          bool   `json:"-"`
 
 	WakeCheckDecision *wakeCheckDecision `json:"-"`
+	Mutation          *opsWakeMutation   `json:"-"`
+}
+
+type opsWakeMutation struct {
+	Status  string
+	Reason  string
+	Removed bool
 }
 
 func runOpsChecks(root string, rootSource string, fixWakeLocks bool, explicitBaseRoot ...string) *doctorOpsResult {

--- a/internal/cli/doctor_schema_v2.go
+++ b/internal/cli/doctor_schema_v2.go
@@ -39,7 +39,14 @@ type opsWakeLockV2 struct {
 	Target        string             `json:"target,omitempty"`
 	TargetPresent bool               `json:"target_present,omitempty"`
 	TargetReason  string             `json:"target_reason,omitempty"`
+	Mutation      *opsWakeMutationV2 `json:"mutation,omitempty"`
 	WakeCheck     *wakeCheckResultV2 `json:"wake_check"`
+}
+
+type opsWakeMutationV2 struct {
+	Status  string `json:"status"`
+	Reason  string `json:"reason,omitempty"`
+	Removed bool   `json:"removed"`
 }
 
 func renderDoctorResultV2(result doctorResult) doctorResultV2 {
@@ -79,6 +86,13 @@ func renderDoctorResultV2(result doctorResult) doctorResultV2 {
 			Target:        lock.Target,
 			TargetPresent: lock.TargetPresent,
 			TargetReason:  lock.TargetReason,
+		}
+		if lock.Mutation != nil {
+			v2Lock.Mutation = &opsWakeMutationV2{
+				Status:  lock.Mutation.Status,
+				Reason:  lock.Mutation.Reason,
+				Removed: lock.Mutation.Removed,
+			}
 		}
 		if lock.WakeCheckDecision != nil {
 			wakeCheck := renderWakeCheckV2(*lock.WakeCheckDecision)

--- a/internal/cli/doctor_stale_wake_binary_darwin_test.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin_test.go
@@ -3,9 +3,13 @@
 package cli
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13,6 +17,200 @@ import (
 )
 
 const testDarwinCorroboratedImageMethod wakeBinaryComparisonMethod = "darwin_process_image"
+
+const (
+	testDarwinImageCaptureHelperEnv = "AMQ_TEST_DARWIN_IMAGE_CAPTURE_HELPER"
+	testDarwinImageReadyEnv         = "AMQ_TEST_DARWIN_IMAGE_READY"
+	testDarwinImageCaptureGateEnv   = "AMQ_TEST_DARWIN_IMAGE_CAPTURE_GATE"
+	testDarwinImageCaptureResultEnv = "AMQ_TEST_DARWIN_IMAGE_CAPTURE_RESULT"
+	testDarwinImageReleaseEnv       = "AMQ_TEST_DARWIN_IMAGE_RELEASE"
+)
+
+type testDarwinImageCaptureResult struct {
+	Started  string              `json:"started"`
+	Evidence wakeImageEvidenceV1 `json:"evidence"`
+	Error    string              `json:"error,omitempty"`
+}
+
+func TestDarwinSameVersionPathReplacementCannotReportCurrent(t *testing.T) {
+	if os.Getenv(testDarwinImageCaptureHelperEnv) == "1" {
+		runDarwinImageCaptureHelper(t)
+		return
+	}
+
+	dir := t.TempDir()
+	testImage, err := os.ReadFile(os.Args[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	executionPath := filepath.Join(dir, "amq-test")
+	replacementPath := filepath.Join(dir, "amq-replacement")
+	for _, path := range []string{executionPath, replacementPath} {
+		if err := os.WriteFile(path, testImage, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		old := time.Now().Add(-time.Hour)
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+	loadedInfo, err := os.Stat(executionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readyPath := filepath.Join(dir, "ready")
+	captureGatePath := filepath.Join(dir, "capture")
+	resultPath := filepath.Join(dir, "result.json")
+	releasePath := filepath.Join(dir, "release")
+	var childOutput bytes.Buffer
+	cmd := exec.Command(executionPath, "-test.run=^TestDarwinSameVersionPathReplacementCannotReportCurrent$")
+	cmd.Env = append(os.Environ(),
+		testDarwinImageCaptureHelperEnv+"=1",
+		testDarwinImageReadyEnv+"="+readyPath,
+		testDarwinImageCaptureGateEnv+"="+captureGatePath,
+		testDarwinImageCaptureResultEnv+"="+resultPath,
+		testDarwinImageReleaseEnv+"="+releasePath,
+	)
+	cmd.Stdout = &childOutput
+	cmd.Stderr = &childOutput
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	finished := false
+	t.Cleanup(func() {
+		if finished {
+			return
+		}
+		_ = os.WriteFile(releasePath, []byte("release\n"), 0o600)
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	if err := waitForDarwinImageTestPath(readyPath); err != nil {
+		t.Fatalf("wait for running image A: %v\n%s", err, childOutput.String())
+	}
+
+	if err := os.Rename(replacementPath, executionPath); err != nil {
+		t.Fatal(err)
+	}
+	replacementInfo, err := os.Stat(executionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(loadedInfo, replacementInfo) {
+		t.Fatal("replacement did not change the executable pathname vnode")
+	}
+	if err := os.WriteFile(captureGatePath, []byte("capture\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitForDarwinImageTestPath(resultPath); err != nil {
+		t.Fatalf("wait for replacement evidence: %v\n%s", err, childOutput.String())
+	}
+	payload, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var captured testDarwinImageCaptureResult
+	if err := json.Unmarshal(payload, &captured); err != nil {
+		t.Fatalf("decode child result: %v\n%s", err, payload)
+	}
+	if captured.Error != "" {
+		t.Fatalf("child capture failed: %s", captured.Error)
+	}
+	if captured.Evidence.Inode == 0 || captured.Evidence.Inode == wakeFileInodeForTest(t, loadedInfo) {
+		t.Fatalf("capture did not bind replacement vnode: %#v", captured.Evidence)
+	}
+	currentInfo, err := os.Stat(captured.Evidence.ExecutionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspection := wakeLockInspection{
+		PID: cmd.Process.Pid,
+		Lock: wakeLock{
+			Started:              captured.Started,
+			ImagePath:            captured.Evidence.ExecutionPath,
+			ImageVersion:         captured.Evidence.EmbeddedVersion,
+			RunningImageEvidence: &captured.Evidence,
+		},
+	}
+	comparison, err := inspectWakeBinaryStalenessPlatform(
+		inspection,
+		resolvedWakeBinary{Info: currentInfo},
+	)
+	if err != nil {
+		t.Fatalf("compare post-exec replacement: %v", err)
+	}
+	if comparison.Stale || comparison.Method != wakeBinaryComparisonDarwinProcessImage {
+		t.Fatalf("pathname evidence did not reproduce false agreement: %#v", comparison)
+	}
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return comparison, nil
+	})
+	if got := inspectWakeCheckImageStatus(inspection, wakeCheckResult{
+		RunningVersion: captured.Evidence.EmbeddedVersion,
+		CurrentVersion: captured.Evidence.EmbeddedVersion,
+	}); got != wakeImageUnknown {
+		t.Fatalf("post-exec pathname replacement image status = %q, want %q", got, wakeImageUnknown)
+	}
+
+	if err := os.WriteFile(releasePath, []byte("release\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("capture helper: %v\n%s", err, childOutput.String())
+	}
+	finished = true
+}
+
+func runDarwinImageCaptureHelper(t *testing.T) {
+	t.Helper()
+	result := testDarwinImageCaptureResult{Started: time.Now().UTC().Format(time.RFC3339Nano)}
+	if err := os.WriteFile(os.Getenv(testDarwinImageReadyEnv), []byte("ready\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitForDarwinImageTestPath(os.Getenv(testDarwinImageCaptureGateEnv)); err != nil {
+		result.Error = err.Error()
+	} else {
+		result.Evidence, err = captureCurrentWakeImageEvidence()
+		if err != nil {
+			result.Error = err.Error()
+		}
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(os.Getenv(testDarwinImageCaptureResultEnv), payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitForDarwinImageTestPath(os.Getenv(testDarwinImageReleaseEnv)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForDarwinImageTestPath(path string) error {
+	// Starting a copied, ad-hoc-signed Go test binary can be delayed by macOS
+	// validation when race builds are running concurrently. Keep the causal
+	// handshake bounded, but leave enough headroom for that startup work.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for %s", filepath.Base(path))
+}
+
+func wakeFileInodeForTest(t *testing.T, info os.FileInfo) uint64 {
+	t.Helper()
+	identity, ok := captureWakeFileIdentity(info)
+	if !ok {
+		t.Fatal("capture test file identity")
+	}
+	return identity.Inode
+}
 
 func TestDarwinProcessExecutablePathMatchesCurrentProcess(t *testing.T) {
 	got, err := readDarwinProcessExecutablePath(os.Getpid())

--- a/internal/cli/wake_check_schema.go
+++ b/internal/cli/wake_check_schema.go
@@ -294,11 +294,11 @@ func wakeCheckActionProgram() string {
 	if err != nil {
 		return ""
 	}
-	path = strings.TrimSpace(path)
-	if path == "" || !filepath.IsAbs(path) {
+	if path == "" || strings.TrimSpace(path) != path || strings.ContainsRune(path, 0) ||
+		!filepath.IsAbs(path) || filepath.Clean(path) != path {
 		return ""
 	}
-	return filepath.Clean(path)
+	return path
 }
 
 func wakeCheckActionCommand(args ...string) *wakeCheckCommand {

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -633,6 +634,14 @@ func TestWakeCheckV2ReloadObservationChangeUsesExistingSnapshotRetry(t *testing.
 
 func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.T) {
 	validLock := validWakeResumeLockForTest()
+	validStatus := wakeReloadAdvertised
+	validReason := wakeReloadReasonCommandUnavailable
+	invalidAdvertisementReason := wakeReloadReasonAdvertisementInvalid
+	if runtime.GOOS != "darwin" {
+		validStatus = wakeReloadUnavailable
+		validReason = wakeReloadReasonPlatformUnsupported
+		invalidAdvertisementReason = wakeReloadReasonPlatformUnsupported
+	}
 	validInspection := wakeLockInspection{
 		Exists:            true,
 		Status:            wakeLockValid,
@@ -679,7 +688,7 @@ func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.
 				inspection.Lock.RunningImageEvidence = nil
 			},
 			wantStatus: wakeReloadUnavailable,
-			wantReason: wakeReloadReasonAdvertisementInvalid,
+			wantReason: invalidAdvertisementReason,
 		},
 		{
 			name: "repair lineage",
@@ -687,12 +696,12 @@ func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.
 				inspection.Lock.SourceGeneration = "repaired-generation"
 			},
 			wantStatus: wakeReloadUnavailable,
-			wantReason: wakeReloadReasonAdvertisementInvalid,
+			wantReason: invalidAdvertisementReason,
 		},
 		{
 			name:       "valid advertisement",
-			wantStatus: wakeReloadAdvertised,
-			wantReason: wakeReloadReasonCommandUnavailable,
+			wantStatus: validStatus,
+			wantReason: validReason,
 		},
 	}
 
@@ -711,16 +720,16 @@ func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.
 
 	stubWakeCheckRuntime(t, false, "0.50.1")
 	decision := buildWakeCheckDecision("/queue", "codex", validInspection, &opsWakeLock{}, false)
-	if decision.Reload.Status != wakeReloadAdvertised ||
-		decision.Reload.ReasonCode != wakeReloadReasonCommandUnavailable ||
+	if decision.Reload.Status != validStatus ||
+		decision.Reload.ReasonCode != validReason ||
 		decision.RestartCapability != wakeRestartOperatorOnly ||
 		decision.Action.Kind != wakeActionPreserveLiveWake ||
 		decision.Action.Command != nil {
 		t.Fatalf("advertised reload changed executable action semantics: %#v", decision)
 	}
 	rendered := renderWakeCheckV2(decision)
-	if rendered.Reload.Status != wakeReloadAdvertised ||
-		rendered.Reload.ReasonCode != wakeReloadReasonCommandUnavailable {
+	if rendered.Reload.Status != validStatus ||
+		rendered.Reload.ReasonCode != validReason {
 		t.Fatalf("advertised reload output = %#v", rendered.Reload)
 	}
 }
@@ -810,6 +819,15 @@ func TestWakeCheckV2WithholdsAdviceWhenExecutableIdentityIsUnavailable(t *testin
 		}},
 		{name: "executable path is relative", stub: func() (string, error) {
 			return "bin/amq", nil
+		}},
+		{name: "executable path has leading whitespace", stub: func() (string, error) {
+			return " " + filepath.Join(root, "bin", "amq"), nil
+		}},
+		{name: "executable path has trailing whitespace", stub: func() (string, error) {
+			return filepath.Join(root, "bin", "amq") + " ", nil
+		}},
+		{name: "executable path is not clean", stub: func() (string, error) {
+			return filepath.Join(root, "bin") + "/../amq", nil
 		}},
 	}
 	for _, test := range tests {
@@ -996,6 +1014,74 @@ func TestDoctorOpsV2UsesOneStableSnapshotAfterEarlierDoctorStateChanged(t *testi
 	if opsLock.PID != lock.PID || decision.Wake.PID == nil || *decision.Wake.PID != lock.PID ||
 		opsLock.Status != "live-raw-orphan" || decision.Action.Kind != wakeActionPreserveLiveWake {
 		t.Fatalf("mixed doctor snapshots: outer=%#v decision=%#v", opsLock, decision)
+	}
+}
+
+func TestDoctorOpsV2DoesNotMixRemovedOutcomeWithReplacementSnapshot(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	removed := wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "12345",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "removed-generation",
+	}
+	writeWakeLockForTest(t, root, "codex", removed)
+	replacement := removed
+	replacement.PID = 5252
+	replacement.ProcessStart = "54321"
+	replacement.Generation = "replacement-generation"
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == replacement.PID {
+			return wakeProcessInfo{
+				PID: pid, Running: true, StartToken: replacement.ProcessStart,
+				BootID: replacement.BootID, Executable: replacement.Executable,
+				Args: []string{"amq", "wake", "--root", root, "--me", "codex"},
+			}
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	stubWakeCheckRuntime(t, false, "0.50.1")
+
+	removedInspection := inspectWakeLock(root, "codex")
+	if removedInspection.PID != removed.PID || removedInspection.Status != wakeLockStale {
+		t.Fatalf("removed inspection = %#v", removedInspection)
+	}
+	writeWakeLockExactForTest(t, root, "codex", replacement)
+	result := doctorResult{Ops: &doctorOpsResult{WakeLocks: []opsWakeLock{{
+		Status:  "fixed",
+		Agent:   "codex",
+		Root:    removedInspection.Root,
+		Lock:    removedInspection.LockPath,
+		PID:     removedInspection.PID,
+		Reason:  "removed stale wake lock",
+		Removed: true,
+	}}}}
+	decorateOpsWakeLockWithWakeCheck(
+		root,
+		&result.Ops.WakeLocks[0],
+		removedInspection,
+		false,
+		true,
+	)
+
+	rendered := renderDoctorResultV2(result)
+	if len(rendered.Ops.WakeLocks) != 1 {
+		t.Fatalf("rendered wake locks = %#v", rendered.Ops.WakeLocks)
+	}
+	got := rendered.Ops.WakeLocks[0]
+	if got.Removed && got.PID == replacement.PID {
+		t.Fatalf("removed outcome was combined with replacement snapshot: %#v", got)
+	}
+	if got.Status != "live-raw-orphan" || got.PID != replacement.PID || got.Mutation == nil ||
+		got.Mutation.Status != "fixed" || !got.Mutation.Removed {
+		t.Fatalf("replacement snapshot and removal outcome were not separated: %#v", got)
 	}
 }
 

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -438,6 +438,13 @@ func classifyWakeCheckReload(inspection wakeLockInspection) wakeCheckReloadDecis
 	if inspection.Lock.ResumeSchema != wakeResumeSchemaV2 {
 		return unavailable(wakeReloadReasonSchemaUnsupported)
 	}
+	if wakeControlSocketPath(
+		inspection.Lock.Root,
+		inspection.Lock.Agent,
+		inspection.Lock.Generation,
+	) == "" {
+		return unavailable(wakeReloadReasonPlatformUnsupported)
+	}
 	if validateWakeResumeAdvertisement(inspection.Lock) != nil {
 		return unavailable(wakeReloadReasonAdvertisementInvalid)
 	}
@@ -543,16 +550,17 @@ func decorateOpsWakeLockWithWakeCheck(
 ) {
 	root = canonicalWakeRoot(root)
 	if includeV2 {
-		removed := lock.Removed
-		removedStatus := lock.Status
-		removedReason := lock.Reason
+		var mutation *opsWakeMutation
+		if lock.Removed {
+			mutation = &opsWakeMutation{
+				Status:  lock.Status,
+				Reason:  lock.Reason,
+				Removed: true,
+			}
+		}
 		snapshot := inspectWakeCheckSnapshot(root, lock.Agent)
 		opsLock := snapshot.OpsLock
-		if removed {
-			opsLock.Status = removedStatus
-			opsLock.Reason = removedReason
-			opsLock.Removed = true
-		}
+		opsLock.Mutation = mutation
 		opsLock.WakeCheckDecision = &snapshot.Decision
 		*lock = *opsLock
 		return
@@ -766,8 +774,7 @@ func inspectWakeCheckImageStatus(
 	if comparison.Stale {
 		return wakeImageDifferent
 	}
-	if comparison.Method == wakeBinaryComparisonExactIdentity ||
-		comparison.Method == wakeBinaryComparisonDarwinProcessImage {
+	if comparison.Method == wakeBinaryComparisonExactIdentity {
 		return wakeImageCurrent
 	}
 	return wakeImageUnknown

--- a/internal/cli/wake_check_unix_test.go
+++ b/internal/cli/wake_check_unix_test.go
@@ -229,7 +229,7 @@ func TestWakeCheckImageStatusRequiresCompleteExactEvidence(t *testing.T) {
 			want: wakeImageUnknown,
 		},
 		{
-			name: "complete lock with corroborated Darwin comparison is current",
+			name: "complete lock with post-exec Darwin pathname agreement stays unknown",
 			lock: wakeLock{
 				ImagePath:    "/opt/homebrew/bin/amq",
 				ImageVersion: "0.49.14",
@@ -242,7 +242,7 @@ func TestWakeCheckImageStatusRequiresCompleteExactEvidence(t *testing.T) {
 				Method:   wakeBinaryComparisonMethod("darwin_process_image"),
 				Evidence: stableWakeBinaryEvidenceForTest(),
 			},
-			want: wakeImageCurrent,
+			want: wakeImageUnknown,
 		},
 		{
 			name: "legacy lock stays unknown despite exact comparison",

--- a/internal/cli/wake_resume_image_unix.go
+++ b/internal/cli/wake_resume_image_unix.go
@@ -84,7 +84,7 @@ func captureWakeImageEvidence(path, embeddedVersion string) (wakeImageEvidenceV1
 
 	method := wakeImageMethodFDExec
 	if runtime.GOOS == "darwin" {
-		method = wakeImageMethodPathnameExecVerified
+		method = wakeImageMethodPathnameObserved
 	}
 	evidence := wakeImageEvidenceV1{
 		Schema:          wakeImageEvidenceSchemaV1,

--- a/internal/cli/wake_resume_protocol.go
+++ b/internal/cli/wake_resume_protocol.go
@@ -13,13 +13,14 @@ const (
 	wakeImageEvidenceSchemaV1 = 1
 
 	wakeImageMethodFDExec               = "fd_exec"
+	wakeImageMethodPathnameObserved     = "pathname_observed"
 	wakeImageMethodPathnameExecVerified = "pathname_execve_verified"
 )
 
-// wakeImageEvidenceV1 is serialized execution evidence, not a path/version
-// hint. Later waves use Method to preserve the honest platform asymmetry:
-// Linux retains an fd authority; Darwin immediately re-verifies the resolved
-// versioned pathname before execve.
+// wakeImageEvidenceV1 records image metadata and its authority method. Ordinary
+// Darwin wakes can observe only a mutable pathname after exec; the stronger
+// pathname_execve_verified method is reserved for a path authenticated
+// immediately before the corresponding execve.
 type wakeImageEvidenceV1 struct {
 	Schema          int    `json:"schema"`
 	Platform        string `json:"platform"`
@@ -52,8 +53,15 @@ func validateWakeResumeAdvertisement(lock wakeLock) error {
 	if err := validateAuthoritativeWakeProcessIdentity(lock); err != nil {
 		return fmt.Errorf("wake resume process identity is invalid: %w", err)
 	}
+	expectedControlSocket := wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
+	if expectedControlSocket == "" {
+		return fmt.Errorf("wake resume control endpoint is unsupported on %s", runtime.GOOS)
+	}
 	if strings.TrimSpace(lock.ControlSocket) == "" {
 		return fmt.Errorf("wake resume control endpoint is missing")
+	}
+	if lock.ControlSocket != expectedControlSocket {
+		return fmt.Errorf("wake resume control endpoint does not match the exact root, agent, and generation")
 	}
 	if lock.SourceGeneration != "" || lock.SourceFloorDigest != "" {
 		return fmt.Errorf("wake repair lineage is not resumable")
@@ -63,6 +71,16 @@ func validateWakeResumeAdvertisement(lock wakeLock) error {
 	}
 	if err := validateWakeImageEvidence(*lock.RunningImageEvidence); err != nil {
 		return err
+	}
+	if runtime.GOOS == "darwin" &&
+		lock.RunningImageEvidence.Method != wakeImageMethodPathnameExecVerified {
+		return fmt.Errorf("wake running image evidence is not bound immediately before execve")
+	}
+	if lock.ImagePath != lock.RunningImageEvidence.ExecutionPath {
+		return fmt.Errorf("wake image path does not match running image evidence")
+	}
+	if lock.ImageVersion != lock.RunningImageEvidence.EmbeddedVersion {
+		return fmt.Errorf("wake image version does not match running image evidence")
 	}
 	if lock.WakeMode == wakeOwnerWakeMode {
 		if lock.OwnerSchema != wakeOwnerLockSchema || lock.Owner == nil {
@@ -82,15 +100,17 @@ func validateWakeImageEvidence(evidence wakeImageEvidenceV1) error {
 	if evidence.Platform != runtime.GOOS {
 		return fmt.Errorf("wake image platform %q does not match %q", evidence.Platform, runtime.GOOS)
 	}
-	expectedMethod := wakeImageMethodFDExec
 	if runtime.GOOS == "darwin" {
-		expectedMethod = wakeImageMethodPathnameExecVerified
-	}
-	if evidence.Method != expectedMethod {
-		return fmt.Errorf("wake image method %q does not match platform method %q", evidence.Method, expectedMethod)
+		if evidence.Method != wakeImageMethodPathnameObserved &&
+			evidence.Method != wakeImageMethodPathnameExecVerified {
+			return fmt.Errorf("wake image method %q does not match a Darwin pathname evidence method", evidence.Method)
+		}
+	} else if evidence.Method != wakeImageMethodFDExec {
+		return fmt.Errorf("wake image method %q does not match platform method %q", evidence.Method, wakeImageMethodFDExec)
 	}
 	path := strings.TrimSpace(evidence.ExecutionPath)
-	if path == "" || strings.ContainsRune(path, 0) || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+	if path == "" || path != evidence.ExecutionPath || strings.ContainsRune(path, 0) ||
+		!filepath.IsAbs(path) || filepath.Clean(path) != path {
 		return fmt.Errorf("wake image execution path must be a canonical absolute path")
 	}
 	if evidence.Device == 0 {

--- a/internal/cli/wake_resume_protocol_unix_test.go
+++ b/internal/cli/wake_resume_protocol_unix_test.go
@@ -112,19 +112,32 @@ func validWakeImageEvidenceForTest() wakeImageEvidenceV1 {
 	}
 }
 
+func TestValidateWakeImageEvidenceRejectsNonCanonicalExecutionPath(t *testing.T) {
+	evidence := validWakeImageEvidenceForTest()
+	evidence.ExecutionPath = " " + evidence.ExecutionPath
+	if err := validateWakeImageEvidence(evidence); err == nil || !strings.Contains(err.Error(), "canonical") {
+		t.Fatalf("non-canonical execution path error = %v, want canonical", err)
+	}
+}
+
 func validWakeResumeLockForTest() wakeLock {
 	owner := validWakeResumeOwnerForTest()
 	evidence := validWakeImageEvidenceForTest()
+	root := canonicalWakeRoot("/queue")
+	agent := "codex"
+	generation := "resume-generation"
 	return wakeLock{
 		PID:                  5151,
 		TTY:                  "/dev/ttys001",
-		Root:                 "/queue",
-		Agent:                "codex",
+		Root:                 root,
+		Agent:                agent,
 		ProcessStart:         "67890",
 		BootID:               owner.BootID,
 		WakeMode:             wakeInjectModeRaw,
-		Generation:           "resume-generation",
-		ControlSocket:        "/queue/agents/codex/.w.0123456789abcdef",
+		Generation:           generation,
+		ControlSocket:        wakeControlSocketPath(root, agent, generation),
+		ImagePath:            evidence.ExecutionPath,
+		ImageVersion:         evidence.EmbeddedVersion,
 		ResumeSchema:         wakeResumeSchemaV2,
 		ResumeOwner:          &owner,
 		RunningImageEvidence: &evidence,
@@ -132,6 +145,13 @@ func validWakeResumeLockForTest() wakeLock {
 }
 
 func TestValidateWakeResumeAdvertisementAcceptsOnlyCompleteExactV2(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		err := validateWakeResumeAdvertisement(validWakeResumeLockForTest())
+		if err == nil || !strings.Contains(err.Error(), "unsupported") {
+			t.Fatalf("non-Darwin resume advertisement error = %v, want unsupported", err)
+		}
+		return
+	}
 	if err := validateWakeResumeAdvertisement(validWakeResumeLockForTest()); err != nil {
 		t.Fatalf("valid resume advertisement rejected: %v", err)
 	}
@@ -149,18 +169,40 @@ func TestValidateWakeResumeAdvertisementAcceptsOnlyCompleteExactV2(t *testing.T)
 		{name: "missing wake process start", mutate: func(l *wakeLock) { l.ProcessStart = "" }, want: "process start"},
 		{name: "missing wake boot id", mutate: func(l *wakeLock) { l.BootID = "" }, want: "boot id"},
 		{name: "missing control endpoint", mutate: func(l *wakeLock) { l.ControlSocket = "" }, want: "control"},
+		{name: "relative control endpoint", mutate: func(l *wakeLock) { l.ControlSocket = ".w.relative" }, want: "control"},
+		{name: "outside-agent control endpoint", mutate: func(l *wakeLock) {
+			l.ControlSocket = filepath.Join(l.Root, ".w.outside")
+		}, want: "control"},
+		{name: "wrong-prefix control endpoint", mutate: func(l *wakeLock) {
+			l.ControlSocket = filepath.Join(fsq.AgentBase(l.Root, l.Agent), ".wake.sock")
+		}, want: "control"},
+		{name: "wrong-generation control endpoint", mutate: func(l *wakeLock) {
+			l.ControlSocket = wakeControlSocketPath(l.Root, l.Agent, "other-generation")
+		}, want: "control"},
+		{name: "wrong-agent control endpoint", mutate: func(l *wakeLock) {
+			l.ControlSocket = wakeControlSocketPath(l.Root, "other", l.Generation)
+		}, want: "control"},
+		{name: "wrong-root control endpoint", mutate: func(l *wakeLock) {
+			l.ControlSocket = wakeControlSocketPath(filepath.Join(l.Root, "other"), l.Agent, l.Generation)
+		}, want: "control"},
 		{name: "repair lineage", mutate: func(l *wakeLock) { l.SourceGeneration = "dead-generation" }, want: "repair"},
 		{name: "missing evidence", mutate: func(l *wakeLock) { l.RunningImageEvidence = nil }, want: "image evidence"},
 		{name: "wrong evidence schema", mutate: func(l *wakeLock) { l.RunningImageEvidence.Schema++ }, want: "image evidence schema"},
 		{name: "wrong platform", mutate: func(l *wakeLock) { l.RunningImageEvidence.Platform = "plan9" }, want: "platform"},
 		{name: "wrong method", mutate: func(l *wakeLock) { l.RunningImageEvidence.Method = "pathname" }, want: "method"},
 		{name: "relative execution path", mutate: func(l *wakeLock) { l.RunningImageEvidence.ExecutionPath = "bin/amq" }, want: "absolute"},
+		{name: "non-canonical execution path", mutate: func(l *wakeLock) {
+			l.RunningImageEvidence.ExecutionPath = " " + l.RunningImageEvidence.ExecutionPath
+			l.ImagePath = l.RunningImageEvidence.ExecutionPath
+		}, want: "canonical"},
 		{name: "missing device", mutate: func(l *wakeLock) { l.RunningImageEvidence.Device = 0 }, want: "device"},
 		{name: "missing inode", mutate: func(l *wakeLock) { l.RunningImageEvidence.Inode = 0 }, want: "inode"},
 		{name: "empty image", mutate: func(l *wakeLock) { l.RunningImageEvidence.Size = 0 }, want: "size"},
 		{name: "missing ctime", mutate: func(l *wakeLock) { l.RunningImageEvidence.CTimeNS = 0 }, want: "ctime"},
 		{name: "malformed digest", mutate: func(l *wakeLock) { l.RunningImageEvidence.SHA256 = "sha256:abc" }, want: "sha256"},
 		{name: "missing version", mutate: func(l *wakeLock) { l.RunningImageEvidence.EmbeddedVersion = "" }, want: "version"},
+		{name: "image path disagreement", mutate: func(l *wakeLock) { l.ImagePath += ".other" }, want: "image path"},
+		{name: "image version disagreement", mutate: func(l *wakeLock) { l.ImageVersion += ".other" }, want: "image version"},
 		{
 			name: "authoritative owner mismatch",
 			mutate: func(l *wakeLock) {
@@ -193,6 +235,7 @@ func TestWakeResumeMetadataRoundTripsWithoutChangingGenericClaim(t *testing.T) {
 	}
 	lock := validWakeResumeLockForTest()
 	lock.Root = canonicalWakeRoot(root)
+	lock.ControlSocket = wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
 	writeWakeLockForTest(t, root, "codex", lock)
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		return wakeProcessInfo{
@@ -212,8 +255,12 @@ func TestWakeResumeMetadataRoundTripsWithoutChangingGenericClaim(t *testing.T) {
 	if got := classifyWakeClaimForGenericTransition(inspection); got != wakeClaimGeneric {
 		t.Fatalf("claim = %v, want generic", got)
 	}
-	if err := validateWakeResumeAdvertisement(inspection.Lock); err != nil {
-		t.Fatalf("round-tripped advertisement invalid: %v", err)
+	if err := validateWakeResumeAdvertisement(inspection.Lock); runtime.GOOS == "darwin" {
+		if err != nil {
+			t.Fatalf("round-tripped advertisement invalid: %v", err)
+		}
+	} else if err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("non-Darwin round-tripped advertisement error = %v, want unsupported", err)
 	}
 
 	data, err := json.Marshal(inspection.Lock)

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -536,9 +536,9 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 	}
 	lock.ImageVersion = strings.TrimSpace(cliVersion)
 	if runtime.GOOS == "darwin" {
-		// Darwin has no retained executable FD. Capture the verified pathname
-		// identity for every new lock so later proc_pidpath evidence can be
-		// corroborated without making notifier startup depend on this metadata.
+		// Darwin has no retained executable FD. Capture the observed pathname
+		// identity for diagnostics, but do not treat it as agent-safe resume
+		// authority after exec.
 		if evidence, evidenceErr := captureCurrentWakeImageEvidence(); evidenceErr == nil {
 			lock.RunningImageEvidence = &evidence
 			lock.ImagePath = evidence.ExecutionPath


### PR DESCRIPTION
## Summary

- keep Darwin post-exec pathname evidence observational, so image_status remains unknown without exact retained identity
- bind resume advertisements to the exact derived control endpoint and serialized image evidence; reject non-canonical evidence paths
- preserve exact executable paths and separate completed doctor mutations from the fresh wake snapshot
- document the schema-selecting diagnostic forms and their JSON requirement

## Verification

- make ci
- full internal/cli suite on Darwin
- full internal/cli suite in a Go 1.25.12 Linux container
- focused causal guards repeated 100x and under the race detector
- binding Claude PASS on tree 6191c4c32d8dceeba0b906e53bcd58457889ef3a

## Release gate

v0.51.0 remains held until this PR lands, release notes are corrected, and the Pro review returns GO. Darwin mapped-vnode identity remains tracked separately in #398.