### PR TITLE
fix(wake): bind resume advertisements to trusted agent

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -437,9 +437,10 @@ func checkWakeLocksWithHintsSchema(
 ) ([]opsWakeLock, []opsHint) {
 	var locks []opsWakeLock
 	var hints []opsHint
-	appendLock := func(lock opsWakeLock, inspection wakeLockInspection, staleBinary bool) {
+	appendLock := func(agent string, lock opsWakeLock, inspection wakeLockInspection, staleBinary bool) {
 		decorateOpsWakeLockWithWakeCheck(
 			root,
+			agent,
 			&lock,
 			inspection,
 			staleBinary,
@@ -482,7 +483,7 @@ func checkWakeLocksWithHintsSchema(
 			lock.Reason = "live raw wake orphan; stop the owning terminal or launchd supervisor"
 		}
 		if !mutationAuthorized {
-			appendLock(lock, inspection, staleBinary)
+			appendLock(agent, lock, inspection, staleBinary)
 			continue
 		}
 		assessment := assessWakeRepair(
@@ -501,7 +502,7 @@ func checkWakeLocksWithHintsSchema(
 		}
 		if inspection.Status == wakeLockStale {
 			if ownerBound {
-				appendLock(lock, inspection, staleBinary)
+				appendLock(agent, lock, inspection, staleBinary)
 				continue
 			}
 			lock.Fix = doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
@@ -533,13 +534,18 @@ func checkWakeLocksWithHintsSchema(
 					lock.Status = "error"
 					lock.Reason = guardErr.Error()
 				}
+				lock.Mutation = &opsWakeMutation{
+					Status:  lock.Status,
+					Reason:  lock.Reason,
+					Removed: lock.Removed,
+				}
 			}
 		}
 		if lock.Removed {
 			inspection = inspectWakeLock(root, agent)
 			staleBinary = false
 		}
-		appendLock(lock, inspection, staleBinary)
+		appendLock(agent, lock, inspection, staleBinary)
 	}
 	return locks, hints
 }

--- a/internal/cli/wake_check_other.go
+++ b/internal/cli/wake_check_other.go
@@ -9,7 +9,7 @@ import (
 )
 
 func decorateOpsWakeLockWithWakeCheck(
-	root string,
+	root, agent string,
 	lock *opsWakeLock,
 	_ wakeLockInspection,
 	_ bool,
@@ -18,7 +18,7 @@ func decorateOpsWakeLockWithWakeCheck(
 	if !includeV2 {
 		return
 	}
-	decision := unsupportedWakeCheckDecision(root, lock.Agent)
+	decision := unsupportedWakeCheckDecision(root, agent)
 	lock.WakeCheckDecision = &decision
 }
 

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -711,7 +711,7 @@ func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.
 			if test.mutate != nil {
 				test.mutate(&inspection)
 			}
-			got := classifyWakeCheckReload(inspection)
+			got := classifyWakeCheckReload("/queue", "codex", inspection)
 			if got.Status != test.wantStatus || got.ReasonCode != test.wantReason {
 				t.Fatalf("reload decision = %#v, want status=%q reason=%q", got, test.wantStatus, test.wantReason)
 			}
@@ -731,6 +731,108 @@ func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.
 	if rendered.Reload.Status != validStatus ||
 		rendered.Reload.ReasonCode != validReason {
 		t.Fatalf("advertised reload output = %#v", rendered.Reload)
+	}
+}
+
+func TestWakeCheckV2RejectsResumeAdvertisementBoundOnlyToArtifactAgent(t *testing.T) {
+	for _, artifactAgent := range []string{"", "claude"} {
+		name := artifactAgent
+		if name == "" {
+			name = "omitted"
+		}
+		t.Run(name, func(t *testing.T) {
+			lock := validWakeResumeLockForTest()
+			lock.Agent = artifactAgent
+			lock.ControlSocket = wakeControlSocketPath(lock.Root, artifactAgent, lock.Generation)
+			inspection := wakeLockInspection{
+				Exists:            true,
+				Status:            wakeLockValid,
+				PID:               lock.PID,
+				Lock:              lock,
+				Process:           wakeProcessInfo{PID: lock.PID, Running: true},
+				IdentityConfirmed: true,
+			}
+
+			decision := buildWakeCheckDecision(lock.Root, "codex", inspection, &opsWakeLock{}, false)
+			if decision.Reload.Status != wakeReloadUnavailable ||
+				decision.Reload.ReasonCode != wakeReloadReasonAdvertisementInvalid {
+				t.Fatalf("artifact-bound reload decision = %#v, want invalid advertisement", decision.Reload)
+			}
+		})
+	}
+}
+
+func TestDoctorOpsV2RejectsResumeAdvertisementBoundOnlyToArtifactAgent(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		artifactAgent string
+		wantReason    string
+	}{
+		{name: "omitted", wantReason: wakeReloadReasonAdvertisementInvalid},
+		{name: "mismatched", artifactAgent: "claude", wantReason: wakeReloadReasonNotLive},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			lock := validWakeResumeLockForTest()
+			lock.Root = canonicalWakeRoot(root)
+			lock.Agent = test.artifactAgent
+			lock.ControlSocket = wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
+			writeWakeLockExactForTest(t, root, "codex", lock)
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				return wakeProcessInfo{
+					PID: pid, Running: true, StartToken: lock.ProcessStart, BootID: lock.BootID,
+					Executable: lock.RunningImageEvidence.ExecutionPath,
+					Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+				}
+			})
+
+			locks, _ := checkWakeLocksWithHintsSchema(root, []string{"codex"}, false, wakeCheckSchemaV2)
+			if len(locks) != 1 || locks[0].WakeCheckDecision == nil {
+				t.Fatalf("doctor wake locks = %#v", locks)
+			}
+			reload := locks[0].WakeCheckDecision.Reload
+			if reload.Status != wakeReloadUnavailable || reload.ReasonCode != test.wantReason {
+				t.Fatalf("doctor artifact-bound reload decision = %#v, want reason %q", reload, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestDoctorOpsV2UsesTrustedRosterAgentInsteadOfOuterRecord(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	lock := validWakeResumeLockForTest()
+	lock.Root = canonicalWakeRoot(root)
+	lock.ControlSocket = wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
+	writeWakeLockExactForTest(t, root, "codex", lock)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID: pid, Running: true, StartToken: lock.ProcessStart, BootID: lock.BootID,
+			Executable: lock.RunningImageEvidence.ExecutionPath,
+			Args:       []string{"amq", "wake", "--root", root, "--me", "codex"},
+		}
+	})
+	stubWakeCheckRuntime(t, false, "0.50.1")
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockValid {
+		t.Fatalf("initial inspection = %#v", inspection)
+	}
+	opsLock := opsWakeLock{Agent: "claude"}
+	decorateOpsWakeLockWithWakeCheck(root, "codex", &opsLock, inspection, false, true)
+	if opsLock.Agent != "codex" || opsLock.WakeCheckDecision == nil {
+		t.Fatalf("doctor trusted-agent snapshot = %#v", opsLock)
+	}
+	wantStatus := wakeReloadAdvertised
+	wantReason := wakeReloadReasonCommandUnavailable
+	if runtime.GOOS == "linux" {
+		wantStatus = wakeReloadUnavailable
+		wantReason = wakeReloadReasonPlatformUnsupported
+	}
+	if reload := opsLock.WakeCheckDecision.Reload; reload.Status != wantStatus || reload.ReasonCode != wantReason {
+		t.Fatalf("doctor trusted-agent reload = %#v, want status=%q reason=%q", reload, wantStatus, wantReason)
 	}
 }
 
@@ -1006,7 +1108,7 @@ func TestDoctorOpsV2UsesOneStableSnapshotAfterEarlierDoctorStateChanged(t *testi
 		Lock:   initial.LockPath,
 		PID:    initial.PID,
 	}
-	decorateOpsWakeLockWithWakeCheck(root, &opsLock, initial, false, true)
+	decorateOpsWakeLockWithWakeCheck(root, "codex", &opsLock, initial, false, true)
 	if opsLock.WakeCheckDecision == nil {
 		t.Fatal("doctor v2 wake decision is missing")
 	}
@@ -1062,9 +1164,15 @@ func TestDoctorOpsV2DoesNotMixRemovedOutcomeWithReplacementSnapshot(t *testing.T
 		PID:     removedInspection.PID,
 		Reason:  "removed stale wake lock",
 		Removed: true,
+		Mutation: &opsWakeMutation{
+			Status:  "fixed",
+			Reason:  "removed stale wake lock",
+			Removed: true,
+		},
 	}}}}
 	decorateOpsWakeLockWithWakeCheck(
 		root,
+		"codex",
 		&result.Ops.WakeLocks[0],
 		removedInspection,
 		false,
@@ -1082,6 +1190,123 @@ func TestDoctorOpsV2DoesNotMixRemovedOutcomeWithReplacementSnapshot(t *testing.T
 	if got.Status != "live-raw-orphan" || got.PID != replacement.PID || got.Mutation == nil ||
 		got.Mutation.Status != "fixed" || !got.Mutation.Removed {
 		t.Fatalf("replacement snapshot and removal outcome were not separated: %#v", got)
+	}
+}
+
+func TestDoctorOpsV2PreservesFailedRemovalMutation(t *testing.T) {
+	root := secureTempDirForTest(t)
+	original := wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "12345",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "failed-removal-generation",
+	}
+	writeWakeLockExactForTest(t, root, "codex", original)
+	replacement := original
+	replacement.PID = 5252
+	replacement.ProcessStart = "54321"
+	replacement.Generation = "replacement-after-recheck"
+	inspectCalls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspectCalls++
+		if inspectCalls == 2 {
+			writeWakeLockExactForTest(t, root, "codex", replacement)
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	locks, _ := checkWakeLocksWithHintsSchema(root, []string{"codex"}, true, wakeCheckSchemaV2)
+	if len(locks) != 1 {
+		t.Fatalf("doctor wake locks = %#v", locks)
+	}
+	got := locks[0]
+	if got.Status == "error" {
+		t.Fatalf("failed mutation leaked into fresh snapshot: %#v", got)
+	}
+	if got.Mutation == nil || got.Mutation.Status != "error" || got.Mutation.Removed ||
+		!strings.Contains(got.Mutation.Reason, "wake lock changed while cleaning stale lock") {
+		t.Fatalf("failed removal mutation = %#v", got.Mutation)
+	}
+	rendered := renderDoctorResultV2(doctorResult{Ops: &doctorOpsResult{WakeLocks: locks}})
+	renderedMutation := rendered.Ops.WakeLocks[0].Mutation
+	if renderedMutation == nil || renderedMutation.Status != "error" || renderedMutation.Removed {
+		t.Fatalf("rendered failed removal mutation = %#v", renderedMutation)
+	}
+	encoded, err := json.Marshal(rendered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"mutation":{"status":"error","reason":`) ||
+		!strings.Contains(string(encoded), `"removed":false`) {
+		t.Fatalf("rendered mutation bytes = %s", encoded)
+	}
+}
+
+func TestDoctorOpsV2PreservesGenerationChangeMutation(t *testing.T) {
+	root := secureTempDirForTest(t)
+	original := wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        "codex",
+		ProcessStart: "12345",
+		BootID:       "same-boot",
+		Executable:   "/opt/homebrew/bin/amq",
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "initial-generation",
+	}
+	writeWakeLockExactForTest(t, root, "codex", original)
+	replacement := original
+	replacement.PID = 5252
+	replacement.ProcessStart = "54321"
+	replacement.Generation = "changed-before-fix"
+	inspected := make(chan struct{}, 1)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		select {
+		case inspected <- struct{}{}:
+		default:
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	guardEntered := make(chan struct{})
+	releaseGuard := make(chan struct{})
+	guardDone := make(chan error, 1)
+	go func() {
+		guardDone <- withWakeLifecycleGuard(root, "codex", func() error {
+			close(guardEntered)
+			<-releaseGuard
+			return nil
+		})
+	}()
+	<-guardEntered
+
+	locksDone := make(chan []opsWakeLock, 1)
+	go func() {
+		locks, _ := checkWakeLocksWithHintsSchema(root, []string{"codex"}, true, wakeCheckSchemaV2)
+		locksDone <- locks
+	}()
+	<-inspected
+	writeWakeLockExactForTest(t, root, "codex", replacement)
+	close(releaseGuard)
+	if err := <-guardDone; err != nil {
+		t.Fatalf("release lifecycle guard: %v", err)
+	}
+
+	locks := <-locksDone
+	if len(locks) != 1 {
+		t.Fatalf("doctor wake locks = %#v", locks)
+	}
+	got := locks[0]
+	if got.Reason == "wake lock changed before fix" {
+		t.Fatalf("guarded-skip mutation leaked into fresh snapshot: %#v", got)
+	}
+	if got.Mutation == nil || got.Mutation.Status != string(wakeLockStale) ||
+		got.Mutation.Reason != "wake lock changed before fix" || got.Mutation.Removed {
+		t.Fatalf("generation-change mutation = %#v", got.Mutation)
 	}
 }
 

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -385,7 +386,7 @@ func buildWakeCheckDecision(
 			},
 			Status: wakeImageUnknown,
 		},
-		Reload: classifyWakeCheckReload(inspection),
+		Reload: classifyWakeCheckReload(root, me, inspection),
 	}
 	decision.Wake.Live = inspection.Exists &&
 		inspection.Status == wakeLockValid &&
@@ -424,7 +425,7 @@ func buildWakeCheckDecision(
 	return decision
 }
 
-func classifyWakeCheckReload(inspection wakeLockInspection) wakeCheckReloadDecision {
+func classifyWakeCheckReload(root, agent string, inspection wakeLockInspection) wakeCheckReloadDecision {
 	unavailable := func(reason string) wakeCheckReloadDecision {
 		return wakeCheckReloadDecision{Status: wakeReloadUnavailable, ReasonCode: reason}
 	}
@@ -438,14 +439,10 @@ func classifyWakeCheckReload(inspection wakeLockInspection) wakeCheckReloadDecis
 	if inspection.Lock.ResumeSchema != wakeResumeSchemaV2 {
 		return unavailable(wakeReloadReasonSchemaUnsupported)
 	}
-	if wakeControlSocketPath(
-		inspection.Lock.Root,
-		inspection.Lock.Agent,
-		inspection.Lock.Generation,
-	) == "" {
-		return unavailable(wakeReloadReasonPlatformUnsupported)
-	}
-	if validateWakeResumeAdvertisement(inspection.Lock) != nil {
+	if err := validateWakeResumeAdvertisement(inspection.Lock, root, agent); err != nil {
+		if errors.Is(err, errWakeResumeControlEndpointUnsupported) {
+			return unavailable(wakeReloadReasonPlatformUnsupported)
+		}
 		return unavailable(wakeReloadReasonAdvertisementInvalid)
 	}
 	return wakeCheckReloadDecision{
@@ -542,7 +539,7 @@ func wakeCheckRepairReason(
 }
 
 func decorateOpsWakeLockWithWakeCheck(
-	root string,
+	root, agent string,
 	lock *opsWakeLock,
 	inspection wakeLockInspection,
 	staleBinary bool,
@@ -550,15 +547,8 @@ func decorateOpsWakeLockWithWakeCheck(
 ) {
 	root = canonicalWakeRoot(root)
 	if includeV2 {
-		var mutation *opsWakeMutation
-		if lock.Removed {
-			mutation = &opsWakeMutation{
-				Status:  lock.Status,
-				Reason:  lock.Reason,
-				Removed: true,
-			}
-		}
-		snapshot := inspectWakeCheckSnapshot(root, lock.Agent)
+		mutation := lock.Mutation
+		snapshot := inspectWakeCheckSnapshot(root, agent)
 		opsLock := snapshot.OpsLock
 		opsLock.Mutation = mutation
 		opsLock.WakeCheckDecision = &snapshot.Decision
@@ -577,7 +567,7 @@ func decorateOpsWakeLockWithWakeCheck(
 	default:
 		lock.ImageStatus = wakeImageUnknown
 	}
-	legacyDecision := buildWakeCheckDecision(root, lock.Agent, inspection, lock, false)
+	legacyDecision := buildWakeCheckDecision(root, agent, inspection, lock, false)
 	check := renderWakeCheckV1(legacyDecision)
 	lock.CanStartHere = check.CanStartHere
 	lock.StartMode = check.StartMode

--- a/internal/cli/wake_resume_protocol.go
+++ b/internal/cli/wake_resume_protocol.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 const (
@@ -34,7 +37,29 @@ type wakeImageEvidenceV1 struct {
 	EmbeddedVersion string `json:"embedded_version"`
 }
 
-func validateWakeResumeAdvertisement(lock wakeLock) error {
+var errWakeResumeControlEndpointUnsupported = errors.New("wake resume control endpoint is unsupported")
+
+func validateWakeResumeAdvertisement(lock wakeLock, expectedRoot, expectedAgent string) error {
+	if strings.TrimSpace(expectedRoot) == "" {
+		return fmt.Errorf("trusted wake resume root is empty")
+	}
+	if err := fsq.ValidateHandle(expectedAgent); err != nil {
+		return fmt.Errorf("trusted wake resume agent is invalid: %w", err)
+	}
+	expectedRoot = canonicalWakeRoot(expectedRoot)
+	if lock.Root != expectedRoot {
+		return fmt.Errorf("wake resume root does not match the trusted root")
+	}
+	if err := fsq.ValidateHandle(lock.Agent); err != nil {
+		return fmt.Errorf("wake resume agent is invalid: %w", err)
+	}
+	if lock.Agent != expectedAgent {
+		return fmt.Errorf("wake resume agent does not match the trusted agent")
+	}
+	expectedControlSocket := wakeControlSocketPath(expectedRoot, expectedAgent, lock.Generation)
+	if expectedControlSocket == "" {
+		return fmt.Errorf("%w on %s", errWakeResumeControlEndpointUnsupported, runtime.GOOS)
+	}
 	if lock.ResumeSchema != wakeResumeSchemaV2 {
 		if lock.ResumeSchema == 0 {
 			return fmt.Errorf("wake resume schema is missing")
@@ -52,10 +77,6 @@ func validateWakeResumeAdvertisement(lock wakeLock) error {
 	}
 	if err := validateAuthoritativeWakeProcessIdentity(lock); err != nil {
 		return fmt.Errorf("wake resume process identity is invalid: %w", err)
-	}
-	expectedControlSocket := wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
-	if expectedControlSocket == "" {
-		return fmt.Errorf("wake resume control endpoint is unsupported on %s", runtime.GOOS)
 	}
 	if strings.TrimSpace(lock.ControlSocket) == "" {
 		return fmt.Errorf("wake resume control endpoint is missing")

--- a/internal/cli/wake_resume_protocol_unix_test.go
+++ b/internal/cli/wake_resume_protocol_unix_test.go
@@ -144,15 +144,59 @@ func validWakeResumeLockForTest() wakeLock {
 	}
 }
 
+func TestValidateWakeResumeAdvertisementBindsTrustedRootAndAgent(t *testing.T) {
+	tests := []struct {
+		name          string
+		expectedRoot  string
+		expectedAgent string
+		mutate        func(*wakeLock)
+		want          string
+	}{
+		{name: "empty trusted root", expectedAgent: "codex", want: "trusted wake resume root is empty"},
+		{name: "invalid trusted agent", expectedRoot: "/queue", expectedAgent: "-codex", want: "trusted wake resume agent is invalid"},
+		{name: "mismatched root", expectedRoot: "/queue", expectedAgent: "codex", mutate: func(lock *wakeLock) {
+			lock.Root = canonicalWakeRoot("/other-queue")
+			lock.ControlSocket = wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
+		}, want: "does not match the trusted root"},
+		{name: "omitted agent", expectedRoot: "/queue", expectedAgent: "codex", mutate: func(lock *wakeLock) {
+			lock.Agent = ""
+			lock.ControlSocket = wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
+		}, want: "wake resume agent is invalid"},
+		{name: "mismatched agent", expectedRoot: "/queue", expectedAgent: "codex", mutate: func(lock *wakeLock) {
+			lock.Agent = "claude"
+			lock.ControlSocket = wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
+		}, want: "does not match the trusted agent"},
+		{name: "invalid artifact agent", expectedRoot: "/queue", expectedAgent: "codex", mutate: func(lock *wakeLock) {
+			lock.Agent = "-legacy"
+			lock.ControlSocket = wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
+		}, want: "wake resume agent is invalid"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lock := validWakeResumeLockForTest()
+			if test.mutate != nil {
+				test.mutate(&lock)
+			}
+			err := validateWakeResumeAdvertisement(lock, test.expectedRoot, test.expectedAgent)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestValidateWakeResumeAdvertisementAcceptsOnlyCompleteExactV2(t *testing.T) {
 	if runtime.GOOS != "darwin" {
-		err := validateWakeResumeAdvertisement(validWakeResumeLockForTest())
+		lock := validWakeResumeLockForTest()
+		err := validateWakeResumeAdvertisement(lock, lock.Root, lock.Agent)
 		if err == nil || !strings.Contains(err.Error(), "unsupported") {
 			t.Fatalf("non-Darwin resume advertisement error = %v, want unsupported", err)
 		}
 		return
 	}
-	if err := validateWakeResumeAdvertisement(validWakeResumeLockForTest()); err != nil {
+	lock := validWakeResumeLockForTest()
+	if err := validateWakeResumeAdvertisement(lock, lock.Root, lock.Agent); err != nil {
 		t.Fatalf("valid resume advertisement rejected: %v", err)
 	}
 
@@ -220,7 +264,7 @@ func TestValidateWakeResumeAdvertisementAcceptsOnlyCompleteExactV2(t *testing.T)
 		t.Run(test.name, func(t *testing.T) {
 			lock := validWakeResumeLockForTest()
 			test.mutate(&lock)
-			err := validateWakeResumeAdvertisement(lock)
+			err := validateWakeResumeAdvertisement(lock, "/queue", "codex")
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("error = %v, want substring %q", err, test.want)
 			}
@@ -255,7 +299,7 @@ func TestWakeResumeMetadataRoundTripsWithoutChangingGenericClaim(t *testing.T) {
 	if got := classifyWakeClaimForGenericTransition(inspection); got != wakeClaimGeneric {
 		t.Fatalf("claim = %v, want generic", got)
 	}
-	if err := validateWakeResumeAdvertisement(inspection.Lock); runtime.GOOS == "darwin" {
+	if err := validateWakeResumeAdvertisement(inspection.Lock, root, "codex"); runtime.GOOS == "darwin" {
 		if err != nil {
 			t.Fatalf("round-tripped advertisement invalid: %v", err)
 		}
@@ -294,7 +338,7 @@ func TestMalformedOrFutureResumeMetadataDoesNotPoisonLiveNotifier(t *testing.T) 
 			if inspection.Status != wakeLockValid || !inspection.IdentityConfirmed {
 				t.Fatalf("resume metadata poisoned notifier: status=%q reason=%q", inspection.Status, inspection.Reason)
 			}
-			if err := validateWakeResumeAdvertisement(inspection.Lock); err == nil {
+			if err := validateWakeResumeAdvertisement(inspection.Lock, root, "codex"); err == nil {
 				t.Fatal("invalid resume metadata unexpectedly authorized reload")
 			}
 		})
@@ -331,7 +375,7 @@ func TestNewWakeLockAdvertisesResumeOnlyWhenTheProtocolIsComplete(t *testing.T) 
 	if lock.ControlSocket == "" {
 		t.Fatal("Darwin resume advertisement has no control endpoint")
 	}
-	if err := validateWakeResumeAdvertisement(lock); err != nil {
+	if err := validateWakeResumeAdvertisement(lock, "/queue", "codex"); err != nil {
 		t.Fatalf("new lock advertisement invalid: %v", err)
 	}
 

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -594,7 +594,7 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 			candidate.RunningImageEvidence = evidence
 			candidate.ImagePath = evidence.ExecutionPath
 			candidate.ImageVersion = evidence.EmbeddedVersion
-			if validateWakeResumeAdvertisement(candidate) == nil {
+			if validateWakeResumeAdvertisement(candidate, root, me) == nil {
 				lock = candidate
 			}
 		}


### PR DESCRIPTION
## Summary

- bind resume advertisements to the trusted canonical root and roster agent
- derive the control endpoint only from trusted context
- preserve every attempted schema-2 doctor fix outcome separately from the fresh snapshot
- keep schema 1 and the v0.51.0 changelog unchanged

## Verification

- `make ci`
- full `internal/cli` suite on macOS
- full `internal/cli` suite in `golang:1.25.12` Linux
- focused behavior and race suites, including 10 consecutive runs
- Claude binding PASS on exact tree `cd482a1e8dd17e859093e92b1c80c6a42057c6f7`
