### PR TITLE
test(wake): stabilize timing barriers

### DIFF
--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -2669,6 +2669,7 @@ func TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell(t 
 	nowNanos.Store(start.UnixNano())
 	var promptWrites atomic.Int64
 	initialSubmitted := make(chan struct{}, 1)
+	initialAttemptClockSampled := make(chan struct{}, 1)
 	refused := make(chan struct{}, 1)
 	extra := make(chan struct{}, 1)
 	stop := make(chan struct{})
@@ -2692,7 +2693,14 @@ func TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell(t 
 			injectMode:  wakeInjectModePaste,
 			controlStop: stop,
 			doorbellNow: func() time.Time {
-				return time.Unix(0, nowNanos.Load())
+				now := time.Unix(0, nowNanos.Load())
+				if promptWrites.Load() == 1 && now.Equal(start) {
+					select {
+					case initialAttemptClockSampled <- struct{}{}:
+					default:
+					}
+				}
+				return now
 			},
 			preconditionCheck: func(*wakeConfig) error {
 				return nil
@@ -2730,6 +2738,16 @@ func TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell(t 
 		t.Fatalf("wake loop exited before initial submit: %v", err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("wake loop did not submit initial doorbell")
+	}
+	// terminalWrite reports the submit before deliverNewMessageNotification
+	// records the attempt. Wait until that record has sampled the old clock;
+	// the loop completes the state update before it can handle another event.
+	select {
+	case <-initialAttemptClockSampled:
+	case err := <-done:
+		t.Fatalf("wake loop exited before recording initial attempt: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not sample the initial attempt clock")
 	}
 	nowNanos.Store(start.Add(wakeDoorbellRetryBase).UnixNano())
 	message.Header.ID = "trigger-expired-foreground-retry"
@@ -5922,13 +5940,23 @@ func TestRunWakeWithLoopRetriesCreatingWakeUntilPrepared(t *testing.T) {
 	target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, nil)
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	retryEntered := make(chan struct{}, 1)
+	retryRelease := make(chan struct{})
+	releaseRetry := func() {
+		select {
+		case <-retryRelease:
+		default:
+			close(retryRelease)
+		}
+	}
+	t.Cleanup(releaseRetry)
 	originalRetry := waitForWakePreparedRetry
-	waitForWakePreparedRetry = func(deadline time.Time) bool {
+	waitForWakePreparedRetry = func(time.Time) bool {
 		select {
 		case retryEntered <- struct{}{}:
 		default:
 		}
-		return originalRetry(deadline)
+		<-retryRelease
+		return true
 	}
 	t.Cleanup(func() { waitForWakePreparedRetry = originalRetry })
 	done := make(chan error, 1)
@@ -5959,6 +5987,9 @@ func TestRunWakeWithLoopRetriesCreatingWakeUntilPrepared(t *testing.T) {
 		Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
 	}, target))
 	writeWakePreparedForTest(t, root, "orchestrator")
+	// The retry must observe the complete target/lock/prepared publication, not
+	// an accidental mid-replacement snapshot created by the test goroutine.
+	releaseRetry()
 	if err := <-done; err != nil {
 		t.Fatalf("creating wake did not become reusable: %v", err)
 	}


### PR DESCRIPTION
## Summary

- wait until the initial doorbell attempt samples the pre-advance fake clock before moving time forward
- hold the creating-wake retry until the test has published the complete target/lock/prepared state
- remove two scheduler/load-dependent test-harness races without changing product code or extending timeouts

## Root causes

`TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell` signaled submission inside the terminal write, before the attempt timestamp was recorded. A losing interleaving advanced the fake clock first, so the initial attempt was legitimately recorded at +5s and the trigger at +5s was not due until +10s.

`TestRunWakeWithLoopRetriesCreatingWakeUntilPrepared` signaled before its real poll sleep, then published three files. Under load the retry could inspect the lock during atomic replacement and correctly fail closed on `changed while opening`.

The latter also exposed a separate product availability defect: an inconclusive torn read terminates accept-existing acquisition. That fix is deliberately excluded from this test-only PR and will follow with explicit RED coverage and typed retry classification.

## Evidence

Pre-fix on `eb6c1039c38dfffd981dfe1a685615aac9186c72`:

- expired-doorbell test: 99/100 normal and 19/20 race; no race-detector report
- creating-wake test: 94/100 normal and 99/100 race; no race-detector report

Post-fix on `fd4b5be25f9071512009df28b3b54d2bd6a81346` / tree `c58af167e22d259a548620f12e19542a29438dbf`:

- combined normal: 500/500 twice locally; complete final run output retained at SHA-256 `894bbc026e6d6a69e42961aea5b311f26139a5064886f99f10b9bd248bc0a640`
- combined race: 100/100 locally
- independent review: 200/200 normal and 50/50 race
- full `make ci`: PASS
- bound peer review: PASS

Reviewer disclosure: an earlier combined normal `-count=150` run failed, but its detail was lost by a tail pipeline. Subsequent exact-tree evidence is 1,220 clean normal iterations plus 150 clean race iterations, including a load-average-50 run and the evidence-preserving 500-count run above. The unexplained failure is recorded here rather than silently discarded.
