### PR TITLE
docs(wake): distinguish input-delivery and attention-only retry floors

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -330,9 +330,11 @@ appear only in terminal output or attention; terminal input always uses the
 fixed doorbell. The delay starts after the prior injector process exits or times
 out. Because an external injector is arbitrary local code, retries can duplicate
 its side effects. Added messages join the pending cohort and share its next
-notification without resetting the retry ladder. If that ladder had decayed,
-new information pulls the deadline forward to the channel's 5- or 30-second
-delivery floor; bursts within the debounce window remain consolidated.
+notification without resetting the retry ladder. Input-delivery additions may
+pull a decayed deadline forward to the delivery floor 5 seconds after the last
+input attempt, or immediately if that floor has already passed; attention-only
+additions retain the cohort's current decayed deadline. Bursts within the
+debounce window remain consolidated.
 Removing or replacing any message is durable progress and immediately rearms
 the next notification.
 Owner-bound retries do not emit attention when terminal input succeeds.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ output or attention; terminal input always uses the fixed doorbell. The delay
 starts after the preceding injector process exits or times out. Because
 `--wake-inject-via` executes arbitrary local code, a retry can repeat
 injector-side effects. Added messages join the pending cohort and share its next
-notification without resetting the retry ladder; if that ladder had decayed,
-new information pulls the deadline forward to the channel's 5- or 30-second
-delivery floor. Bursts within the debounce window remain one notification.
+notification without resetting the retry ladder. Input-delivery additions may
+pull a decayed deadline forward to the delivery floor 5 seconds after the last
+input attempt, or immediately if that floor has already passed; attention-only
+additions retain the cohort's current decayed deadline. Bursts within the
+debounce window remain one notification.
 Removals or replacements immediately rearm the cohort.
 A successful input attempt does not also emit attention. Transient foreground
 authority or input-quiet refusals keep the input retry armed while rate-limiting


### PR DESCRIPTION
Pro's v0.51.0 SHOULD-FIX: README/COOP still claimed any addition pulls a decayed deadline to the 5-or-30s floor, which predates #393. Both contracts now state the true behavior: input-delivery additions may pull forward to the delivery floor 5s after the last input attempt (or immediately if already past); attention-only additions retain the cohort's decayed deadline.

Docs-only. Reviewed and bound by claude at tree 5a588478 (verified against code: recordAttemptWithBase / recordAttentionAttempt / pullForwardForAddition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)