### PR TITLE
fix(wake): retry torn lock reads during acquisition

### DIFF
--- a/internal/cli/wake_lifecycle_guard_unix.go
+++ b/internal/cli/wake_lifecycle_guard_unix.go
@@ -21,6 +21,28 @@ type wakeAgentDir struct {
 	closed bool
 }
 
+// wakeSnapshotReadChangedError marks an observation that could not bind one
+// stable file identity. It is retryable only when the caller can restart the
+// complete read-only decision without reusing evidence from the failed read.
+type wakeSnapshotReadChangedError struct {
+	err error
+}
+
+func (err *wakeSnapshotReadChangedError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeSnapshotReadChangedError) Unwrap() error {
+	return err.err
+}
+
+func newWakeSnapshotReadChangedError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &wakeSnapshotReadChangedError{err: err}
+}
+
 func wakeLifecycleGuardPath(root, me string) string {
 	return filepath.Join(fsq.AgentBase(root, me), wakeLifecycleGuardFileName)
 }
@@ -72,7 +94,9 @@ func openWakeDirectory(path, label string) (*wakeAgentDir, error) {
 	// it retain the stricter ctime-aware generation checks.
 	if !os.SameFile(before, opened) || !os.SameFile(opened, after) {
 		_ = file.Close()
-		return nil, fmt.Errorf("%s %s changed while opening", label, path)
+		return nil, newWakeSnapshotReadChangedError(
+			fmt.Errorf("%s %s changed while opening", label, path),
+		)
 	}
 	return &wakeAgentDir{path: path, file: file}, nil
 }

--- a/internal/cli/wake_lifecycle_guard_unix.go
+++ b/internal/cli/wake_lifecycle_guard_unix.go
@@ -21,28 +21,6 @@ type wakeAgentDir struct {
 	closed bool
 }
 
-// wakeSnapshotReadChangedError marks an observation that could not bind one
-// stable file identity. It is retryable only when the caller can restart the
-// complete read-only decision without reusing evidence from the failed read.
-type wakeSnapshotReadChangedError struct {
-	err error
-}
-
-func (err *wakeSnapshotReadChangedError) Error() string {
-	return err.err.Error()
-}
-
-func (err *wakeSnapshotReadChangedError) Unwrap() error {
-	return err.err
-}
-
-func newWakeSnapshotReadChangedError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return &wakeSnapshotReadChangedError{err: err}
-}
-
 func wakeLifecycleGuardPath(root, me string) string {
 	return filepath.Join(fsq.AgentBase(root, me), wakeLifecycleGuardFileName)
 }

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -122,6 +122,7 @@ type wakeLockInspection struct {
 	IdentityConfirmed bool
 	raw               []byte
 	fileInfo          os.FileInfo
+	observationErr    error
 }
 
 var inspectWakeProcess = inspectWakeProcessPlatform
@@ -172,6 +173,7 @@ func readWakeLockMetadataWithReader(root, me, lockPath string, read wakeLockFile
 		inspection.Exists = true
 		inspection.Status = wakeLockUnverified
 		inspection.Reason = fmt.Sprintf("cannot read lock: %v", err)
+		inspection.observationErr = err
 		return inspection
 	}
 
@@ -221,7 +223,9 @@ func readWakeLockFileWithInfo(path string) ([]byte, os.FileInfo, error) {
 		return nil, nil, err
 	}
 	if !os.SameFile(info, openedInfo) {
-		return nil, nil, fmt.Errorf("wake lock %s changed while opening", path)
+		return nil, nil, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake lock %s changed while opening", path),
+		)
 	}
 	data, err := readWakeMetadata(file, "wake lock", path)
 	return data, openedInfo, err

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var afterWakeLockAtRead = func() {}
+
 func readWakeLockFileAt(dirfd int, path string) ([]byte, os.FileInfo, error) {
 	open := func() (*os.File, error) {
 		fd, err := unix.Openat(dirfd, ".wake.lock", unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
@@ -38,6 +40,7 @@ func readWakeLockFileAt(dirfd int, path string) ([]byte, os.FileInfo, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	afterWakeLockAtRead()
 	pathFile, err := open()
 	if err != nil {
 		return nil, nil, err
@@ -51,7 +54,9 @@ func readWakeLockFileAt(dirfd int, path string) ([]byte, os.FileInfo, error) {
 		return nil, nil, err
 	}
 	if !sameWakeFileIdentity(info, pathInfo) {
-		return nil, nil, fmt.Errorf("wake lock %s changed while opening", path)
+		return nil, nil, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake lock %s changed while opening", path),
+		)
 	}
 	return data, info, nil
 }
@@ -240,7 +245,9 @@ func readWakeGenerationFileSnapshotAt(
 		return wakeGenerationFileSnapshot{}, true, err
 	}
 	if !sameWakeFileIdentity(info, pathInfo) {
-		return wakeGenerationFileSnapshot{}, true, fmt.Errorf("%s changed while opening", label)
+		return wakeGenerationFileSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("%s changed while opening", label),
+		)
 	}
 	var marker wakeReady
 	if err := json.Unmarshal(data, &marker); err != nil {

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -403,7 +403,9 @@ func readWakeTargetSnapshotAt(
 		return wakeTargetSnapshot{}, true, fmt.Errorf("re-stat wake target: %w", statErr)
 	}
 	if !sameWakeFileIdentity(info, pathInfo) {
-		return wakeTargetSnapshot{}, true, fmt.Errorf("wake target changed while opening")
+		return wakeTargetSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake target changed while opening"),
+		)
 	}
 	var target wakeTarget
 	if err := json.Unmarshal(data, &target); err != nil {

--- a/internal/cli/wake_owner_transition.go
+++ b/internal/cli/wake_owner_transition.go
@@ -140,6 +140,14 @@ func validateGenericWakeLifecycleTransition(
 	if reason == "" {
 		reason = "persisted wake claim is not a valid ownerless generation"
 	}
+	if inspection.observationErr != nil {
+		return fmt.Errorf(
+			"wake state for %s is unverified; refusing generic %s: cannot read lock: %w",
+			inspection.Agent,
+			operation,
+			inspection.observationErr,
+		)
+	}
 	return fmt.Errorf(
 		"wake state for %s is unverified; refusing generic %s: %s",
 		inspection.Agent,

--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -205,7 +205,9 @@ func readWakeGenerationFile(path, label string) (wakeReady, bool, error) {
 		return wakeReady{}, true, err
 	}
 	if !os.SameFile(info, openedInfo) {
-		return wakeReady{}, true, fmt.Errorf("%s %s changed while opening", label, path)
+		return wakeReady{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("%s %s changed while opening", label, path),
+		)
 	}
 	data, err := readWakeMetadata(file, label, path)
 	if err != nil {

--- a/internal/cli/wake_repair_at_unix.go
+++ b/internal/cli/wake_repair_at_unix.go
@@ -513,7 +513,9 @@ func readWakeRepairMetadataAt(
 		return nil, nil, true, fmt.Errorf("re-stat %s: %w", label, statErr)
 	}
 	if !sameWakeFileIdentity(info, pathInfo) {
-		return nil, nil, true, fmt.Errorf("%s changed while opening", label)
+		return nil, nil, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("%s changed while opening", label),
+		)
 	}
 	return data, info, true, nil
 }

--- a/internal/cli/wake_repair_floor_unix.go
+++ b/internal/cli/wake_repair_floor_unix.go
@@ -218,7 +218,9 @@ func readWakeRepairFloor(root, me string) (wakeRepairFloor, bool, error) {
 		return wakeRepairFloor{}, true, err
 	}
 	if !os.SameFile(info, openedInfo) {
-		return wakeRepairFloor{}, true, fmt.Errorf("wake repair floor %s changed while opening", path)
+		return wakeRepairFloor{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake repair floor %s changed while opening", path),
+		)
 	}
 	data, err := io.ReadAll(io.LimitReader(file, maxWakeRepairFloorFileBytes+1))
 	if err != nil {

--- a/internal/cli/wake_snapshot_error.go
+++ b/internal/cli/wake_snapshot_error.go
@@ -1,0 +1,23 @@
+package cli
+
+// wakeSnapshotReadChangedError marks an observation that could not bind one
+// stable file identity. It is retryable only when the caller can restart the
+// complete read-only decision without reusing evidence from the failed read.
+type wakeSnapshotReadChangedError struct {
+	err error
+}
+
+func (err *wakeSnapshotReadChangedError) Error() string {
+	return err.err.Error()
+}
+
+func (err *wakeSnapshotReadChangedError) Unwrap() error {
+	return err.err
+}
+
+func newWakeSnapshotReadChangedError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &wakeSnapshotReadChangedError{err: err}
+}

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1957,6 +1957,17 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			}
 			continue
 		}
+		var snapshotChanged *wakeSnapshotReadChangedError
+		if acceptExistingWake && errors.As(err, &snapshotChanged) {
+			if !waitForWakePreparedRetry(acceptExistingDeadline) {
+				return fmt.Errorf(
+					"wake lock did not stabilize within %s: %w",
+					wakeReadyTimeout,
+					err,
+				)
+			}
+			continue
+		}
 		var alreadyRunning *wakeAlreadyRunningError
 		if acceptExistingWake && errors.As(err, &alreadyRunning) {
 			if requestedOwner != nil {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -5998,6 +5998,159 @@ func TestRunWakeWithLoopRetriesCreatingWakeUntilPrepared(t *testing.T) {
 	}
 }
 
+func TestRunWakeWithLoopRetriesWakeLockChangedWhileOpening(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		retryAllowed    bool
+		wantDeadlineErr bool
+	}{
+		{name: "stabilizes", retryAllowed: true},
+		{name: "deadline expires", wantDeadlineErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const wakePID = 4242
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				if pid == wakePID {
+					return wakeProcessInfo{
+						PID: pid, Running: true, StartToken: "start-1", BootID: "boot-1",
+						Executable: "/opt/homebrew/bin/amq",
+						Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "orchestrator"},
+					}
+				}
+				return wakeProcessInfo{PID: pid}
+			})
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "injector")
+			target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, nil)
+			lock := bindWakeLockToTarget(wakeLock{
+				PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1",
+				Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
+			}, target)
+			if err := writeWakeTarget(root, "orchestrator", target); err != nil {
+				t.Fatalf("writeWakeTarget: %v", err)
+			}
+			writeWakeLockForTest(t, root, "orchestrator", lock)
+			writeWakePreparedForTest(t, root, "orchestrator")
+
+			originalAfterRead := afterWakeLockAtRead
+			replaced := false
+			afterWakeLockAtRead = func() {
+				if replaced {
+					return
+				}
+				replaced = true
+				afterWakeLockAtRead = func() {}
+				writeWakeLockForTest(t, root, "orchestrator", lock)
+			}
+			t.Cleanup(func() { afterWakeLockAtRead = originalAfterRead })
+			originalRetry := waitForWakePreparedRetry
+			retryCalls := 0
+			waitForWakePreparedRetry = func(time.Time) bool {
+				retryCalls++
+				return tc.retryAllowed
+			}
+			t.Cleanup(func() { waitForWakePreparedRetry = originalRetry })
+
+			readyPath := filepath.Join(t.TempDir(), "wake.ready")
+			err := runWakeWithLoop([]string{
+				"--root", root,
+				"--me", "orchestrator",
+				"--inject-via", injector,
+				"--ready-file", readyPath,
+				"--accept-existing-wake",
+			}, func(cfg wakeConfig) error {
+				t.Fatalf("loop should not run with an existing wake: %#v", cfg)
+				return nil
+			})
+			if !tc.wantDeadlineErr {
+				if err != nil {
+					t.Fatalf("torn wake-lock read did not retry: %v", err)
+				}
+				if _, err := os.Stat(readyPath); err != nil {
+					t.Fatalf("ready file missing: %v", err)
+				}
+			} else {
+				wantPrefix := fmt.Sprintf("wake lock did not stabilize within %s:", wakeReadyTimeout)
+				if err == nil || !strings.HasPrefix(err.Error(), wantPrefix) {
+					t.Fatalf("deadline error = %v, want prefix %q", err, wantPrefix)
+				}
+				var snapshotChanged *wakeSnapshotReadChangedError
+				if !errors.As(err, &snapshotChanged) {
+					t.Fatalf("deadline error lost typed torn-read cause: %v", err)
+				}
+				if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+					t.Fatalf("ready file should not exist, statErr=%v", statErr)
+				}
+			}
+			if !replaced {
+				t.Fatal("wake-lock read interleave did not run")
+			}
+			if retryCalls != 1 {
+				t.Fatalf("torn wake-lock read retry calls = %d, want 1", retryCalls)
+			}
+		})
+	}
+}
+
+func TestWakeSnapshotReadChangedErrorRequiresTypedCause(t *testing.T) {
+	cause := errors.New("wake lock changed while opening")
+	err := newWakeSnapshotReadChangedError(cause)
+	if !errors.Is(err, cause) {
+		t.Fatalf("typed snapshot error does not unwrap to its cause: %v", err)
+	}
+	var changed *wakeSnapshotReadChangedError
+	if !errors.As(fmt.Errorf("inspect wake snapshot: %w", err), &changed) {
+		t.Fatalf("wrapped typed snapshot error was not classified: %v", err)
+	}
+	changed = nil
+	if errors.As(errors.New(err.Error()), &changed) {
+		t.Fatal("equivalent error text was classified without the typed cause")
+	}
+}
+
+func TestRunWakeWithLoopCreatingWakeDeadlineExpires(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	lockPath := filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock")
+	if err := os.WriteFile(lockPath, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write creating lock: %v", err)
+	}
+
+	originalRetry := waitForWakePreparedRetry
+	retryCalls := 0
+	waitForWakePreparedRetry = func(time.Time) bool {
+		retryCalls++
+		return false
+	}
+	t.Cleanup(func() { waitForWakePreparedRetry = originalRetry })
+
+	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-mode", "none",
+		"--ready-file", readyPath,
+		"--accept-existing-wake",
+	}, func(cfg wakeConfig) error {
+		t.Fatalf("loop should not run while the wake lock is being created: %#v", cfg)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "wake lock did not finish creation") {
+		t.Fatalf("creation deadline error = %v", err)
+	}
+	if retryCalls != 1 {
+		t.Fatalf("creation deadline retry calls = %d, want 1", retryCalls)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("creating lock was not preserved: %v", statErr)
+	}
+	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+}
+
 func TestRunWakeWithLoopNoneRejectsExistingInputWake(t *testing.T) {
 	const wakePID = 4242
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
@@ -6412,6 +6565,13 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsDifferentInjector(t *testing.T)
 	if err := writeWakeTarget(root, "orchestrator", existingTarget); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
 	}
+	originalRetry := waitForWakePreparedRetry
+	retryCalls := 0
+	waitForWakePreparedRetry = func(time.Time) bool {
+		retryCalls++
+		return false
+	}
+	t.Cleanup(func() { waitForWakePreparedRetry = originalRetry })
 
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
 	err := runWakeWithLoop([]string{
@@ -6431,6 +6591,9 @@ func TestRunWakeWithLoopAcceptExistingWakeRejectsDifferentInjector(t *testing.T)
 	}
 	if _, statErr := os.Stat(readyPath); !os.IsNotExist(statErr) {
 		t.Fatalf("ready file should not exist, statErr=%v", statErr)
+	}
+	if retryCalls != 0 {
+		t.Fatalf("conclusive injector mismatch retried %d times", retryCalls)
 	}
 }
 


### PR DESCRIPTION
A wake lock read during its own atomic replacement is an inconclusive observation, not a conflicting owner — but the guard returned an untyped error, so one torn read ended accept-existing acquisition (~6% failure under load at count=100). Per the fatality table, inconclusive observations retry.

- Typed marker at the source (one constructor, Unwrap); display Reason string unchanged, classification carried separately so `errors.As` reaches the consumer without text sniffing
- Only accept-existing generic acquisition consumes it: discard failed observation, retry under the existing readiness deadline with the same paced backoff (no new timeout/flag; no hot spin)
- Distinct terminal message preserves the typed cause chain (`%w`); test pins it with an `errors.As` assertion so the chain can't be silently flattened
- Owner-bound and post-acquisition paths remain fail-closed; sibling audit enumerated 8 inconclusive sites and the conclusive cases that stay terminal
- RED-first at base for the mid-publication torn read (replacing accidental coverage removed by #401); deadline-expiry branch now tested

Implemented by codex; reviewed and bound by claude (tree 994f0c42, focused matrix 80/80).

🤖 Generated with [Claude Code](https://claude.com/claude-code)