### PR TITLE
feat(wake): decompose resume authority and add reload endpoint

### DIFF
--- a/internal/cli/wake_lifecycle_guard_unix.go
+++ b/internal/cli/wake_lifecycle_guard_unix.go
@@ -124,6 +124,14 @@ func withWakeLifecycleGuard(root, me string, fn func() error) error {
 }
 
 func withWakeLifecycleGuardInDir(agentDir *wakeAgentDir, fn func(int) error) error {
+	return withWakeLifecycleGuardModeInDir(agentDir, unix.LOCK_EX, fn)
+}
+
+func withWakeLifecycleGuardModeInDir(
+	agentDir *wakeAgentDir,
+	lockMode int,
+	fn func(int) error,
+) error {
 	return agentDir.withFD(func(dirfd int) error {
 		path := filepath.Join(agentDir.path, wakeLifecycleGuardFileName)
 		file, err := openWakeLifecycleGuardAt(dirfd, path)
@@ -132,7 +140,7 @@ func withWakeLifecycleGuardInDir(agentDir *wakeAgentDir, fn func(int) error) err
 		}
 		defer func() { _ = file.Close() }()
 
-		if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		if err := unix.Flock(int(file.Fd()), lockMode); err != nil {
 			return fmt.Errorf("acquire wake lifecycle guard %s: %w", path, err)
 		}
 		defer func() { _ = unix.Flock(int(file.Fd()), unix.LOCK_UN) }()

--- a/internal/cli/wake_reload_transport.go
+++ b/internal/cli/wake_reload_transport.go
@@ -34,6 +34,27 @@ type wakeReloadTransportResponse struct {
 	ReasonCode string `json:"reason_code"`
 }
 
+// wakeReloadTransportUnavailableError marks failures that occur only while
+// creating the optional endpoint. Authority and lifecycle failures remain
+// ordinary errors and must still stop wake startup.
+type wakeReloadTransportUnavailableError struct {
+	err error
+}
+
+func (err *wakeReloadTransportUnavailableError) Error() string {
+	if err == nil || err.err == nil {
+		return "wake reload transport unavailable"
+	}
+	return err.err.Error()
+}
+
+func (err *wakeReloadTransportUnavailableError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.err
+}
+
 func decodeWakeReloadTransportRequest(payload []byte) (wakeReloadTransportRequest, error) {
 	if len(payload) == 0 || len(payload) > wakeReloadTransportMaxRequestBytes {
 		return wakeReloadTransportRequest{}, fmt.Errorf("wake reload request size is invalid")

--- a/internal/cli/wake_reload_transport.go
+++ b/internal/cli/wake_reload_transport.go
@@ -1,0 +1,113 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	wakeReloadTransportSchemaV1        = 1
+	wakeReloadTransportOperation       = "reload"
+	wakeReloadTransportMaxRequestBytes = 16 * 1024
+)
+
+type wakeReloadTransportRequest struct {
+	Schema     int                 `json:"schema"`
+	Operation  string              `json:"operation"`
+	Root       string              `json:"root"`
+	Agent      string              `json:"agent"`
+	Generation string              `json:"generation"`
+	Owner      wakeOwner           `json:"owner"`
+	Candidate  wakeImageEvidenceV1 `json:"candidate"`
+}
+
+type wakeReloadTransportResponse struct {
+	Status     string `json:"status"`
+	ReasonCode string `json:"reason_code"`
+}
+
+func decodeWakeReloadTransportRequest(payload []byte) (wakeReloadTransportRequest, error) {
+	if len(payload) == 0 || len(payload) > wakeReloadTransportMaxRequestBytes {
+		return wakeReloadTransportRequest{}, fmt.Errorf("wake reload request size is invalid")
+	}
+	if payload[len(payload)-1] != '\n' || bytes.ContainsAny(payload[:len(payload)-1], "\r\n") {
+		return wakeReloadTransportRequest{}, fmt.Errorf("wake reload request must be one terminated line")
+	}
+
+	var request wakeReloadTransportRequest
+	if err := json.Unmarshal(payload[:len(payload)-1], &request); err != nil {
+		return wakeReloadTransportRequest{}, fmt.Errorf("decode wake reload request: %w", err)
+	}
+	canonical, err := json.Marshal(request)
+	if err != nil {
+		return wakeReloadTransportRequest{}, fmt.Errorf("re-encode wake reload request: %w", err)
+	}
+	if !bytes.Equal(canonical, payload[:len(payload)-1]) {
+		return wakeReloadTransportRequest{}, fmt.Errorf("wake reload request is not canonical")
+	}
+	if err := validateWakeReloadTransportRequest(request); err != nil {
+		return wakeReloadTransportRequest{}, err
+	}
+	return request, nil
+}
+
+func validateWakeReloadTransportRequest(request wakeReloadTransportRequest) error {
+	if request.Schema != wakeReloadTransportSchemaV1 {
+		return fmt.Errorf("wake reload request schema is unsupported")
+	}
+	if request.Operation != wakeReloadTransportOperation {
+		return fmt.Errorf("wake reload operation is unsupported")
+	}
+	if request.Root == "" || request.Root != strings.TrimSpace(request.Root) ||
+		strings.ContainsRune(request.Root, 0) || !filepath.IsAbs(request.Root) ||
+		filepath.Clean(request.Root) != request.Root || canonicalWakeRoot(request.Root) != request.Root {
+		return fmt.Errorf("wake reload root is not canonical")
+	}
+	if err := fsq.ValidateHandle(request.Agent); err != nil {
+		return fmt.Errorf("wake reload agent is invalid: %w", err)
+	}
+	if !validWakeReloadTransportGeneration(request.Generation) {
+		return fmt.Errorf("wake reload generation is invalid")
+	}
+	if err := validateAuthoritativeWakeOwner(request.Owner); err != nil {
+		return fmt.Errorf("wake reload owner is invalid: %w", err)
+	}
+	if err := validateWakeImageEvidence(request.Candidate); err != nil {
+		return fmt.Errorf("wake reload candidate is invalid: %w", err)
+	}
+	return nil
+}
+
+func validWakeReloadTransportGeneration(generation string) bool {
+	if len(generation) != 32 || generation != strings.ToLower(generation) {
+		return false
+	}
+	decoded, err := hex.DecodeString(generation)
+	return err == nil && len(decoded) == 16
+}
+
+func wakeReloadTransportUnavailableResponse() wakeReloadTransportResponse {
+	return wakeReloadTransportResponse{
+		Status:     wakeReloadUnavailable,
+		ReasonCode: wakeReloadReasonCommandUnavailable,
+	}
+}
+
+func encodeWakeReloadTransportResponse(response wakeReloadTransportResponse) ([]byte, error) {
+	if response != wakeReloadTransportUnavailableResponse() {
+		return nil, fmt.Errorf("wake reload transport response is not a closed refusal")
+	}
+	payload, err := json.Marshal(response)
+	if err != nil {
+		return nil, err
+	}
+	return append(payload, '\n'), nil
+}

--- a/internal/cli/wake_reload_transport_darwin.go
+++ b/internal/cli/wake_reload_transport_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package cli
+
+func startWakeReloadTransportInDir(
+	_ *wakeAgentDir,
+	_ string,
+	_ string,
+	_ wakeLockInspection,
+	_ wakeOwner,
+) (func(), error) {
+	return func() {}, nil
+}

--- a/internal/cli/wake_reload_transport_linux.go
+++ b/internal/cli/wake_reload_transport_linux.go
@@ -139,7 +139,7 @@ func startLinuxWakeReloadTransport(
 	}
 	listener, identity, err := listenLinuxWakeReloadTransportAt(agentDir, socketName, path)
 	if err != nil {
-		return nil, err
+		return nil, &wakeReloadTransportUnavailableError{err: err}
 	}
 	transport := &linuxWakeReloadTransport{
 		agentDir:       agentDir,

--- a/internal/cli/wake_reload_transport_linux.go
+++ b/internal/cli/wake_reload_transport_linux.go
@@ -1,0 +1,774 @@
+//go:build linux
+
+package cli
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	linuxWakeReloadDefaultHandlerTimeout = 2 * time.Second
+	linuxWakeReloadMaxHandlerTimeout     = 5 * time.Second
+	linuxWakeReloadMaxHandlers           = 4
+	linuxWakeReloadListenBacklog         = 8
+	linuxWakeReloadMaxReceivedFDs        = 16
+)
+
+var (
+	closeWakeReloadReceivedFD  = unix.Close
+	linuxWakeReloadGetPeerSID  = getWakeProcessSID
+	linuxWakeReloadPeerProcess = func(pid int) wakeProcessInfo {
+		return inspectWakeProcess(pid)
+	}
+	linuxWakeReloadGetPeerCred   = getLinuxWakeReloadPeerCred
+	linuxWakeReloadBeforePublish func(dirfd int, stagingName, publicName string) error
+	linuxWakeReloadAfterRetire   func(dirfd int, retiredName, publicName string) error
+	linuxWakeReloadBeforeGuard   func()
+)
+
+type linuxWakeReloadSocketIdentity struct {
+	device    uint64
+	inode     uint64
+	ctimeSec  int64
+	ctimeNsec int64
+	mode      uint32
+	uid       uint32
+}
+
+type linuxWakeReloadTransport struct {
+	agentDir       *wakeAgentDir
+	root           string
+	agent          string
+	expected       wakeLockInspection
+	owner          wakeOwner
+	path           string
+	socketName     string
+	socketIdentity linuxWakeReloadSocketIdentity
+	handlerTimeout time.Duration
+	listener       *net.UnixListener
+	handlerSlots   chan struct{}
+	handlers       sync.WaitGroup
+	acceptDone     chan struct{}
+	closeOnce      sync.Once
+	closeErr       error
+}
+
+// linuxWakeReloadTransportPath is deliberately not wakeControlSocketPath.
+// Sharing that advertised endpoint would publish resume schema 2 on Linux
+// using pathname-reopened evidence mislabeled as fd_exec before execution-bound
+// image authority exists. This listener remains an unadvertised refusal-only
+// seam until that authority is available.
+func linuxWakeReloadTransportPath(root, agent, generation string) string {
+	sum := sha256.Sum256([]byte(canonicalWakeRoot(root) + "\x00" + agent + "\x00" + generation))
+	return filepath.Join(fsq.AgentBase(root, agent), ".wr."+hex.EncodeToString(sum[:8]))
+}
+
+func startWakeReloadTransportInDir(
+	agentDir *wakeAgentDir,
+	root string,
+	agent string,
+	expected wakeLockInspection,
+	owner wakeOwner,
+) (func(), error) {
+	transport, err := startLinuxWakeReloadTransport(
+		agentDir,
+		root,
+		agent,
+		expected,
+		owner,
+		linuxWakeReloadDefaultHandlerTimeout,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return func() { _ = transport.Close() }, nil
+}
+
+func startLinuxWakeReloadTransport(
+	agentDir *wakeAgentDir,
+	root string,
+	agent string,
+	expected wakeLockInspection,
+	owner wakeOwner,
+	handlerTimeout time.Duration,
+) (*linuxWakeReloadTransport, error) {
+	root = canonicalWakeRoot(root)
+	if err := validateLinuxWakeReloadTransportStart(
+		agentDir,
+		root,
+		agent,
+		expected,
+		owner,
+		handlerTimeout,
+	); err != nil {
+		return nil, err
+	}
+
+	var current wakeLockInspection
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current = inspectWakeLockAt(dirfd, agentDir, root, agent)
+		return validateLinuxWakeReloadCurrentLock(expected, current, root, agent, owner)
+	}); err != nil {
+		return nil, err
+	}
+	if err := validateLinuxWakeReloadOwnerLive(owner); err != nil {
+		return nil, err
+	}
+
+	path := linuxWakeReloadTransportPath(root, agent, expected.Lock.Generation)
+	socketName := filepath.Base(path)
+	if filepath.Dir(path) != filepath.Clean(agentDir.path) ||
+		!strings.HasPrefix(socketName, ".wr.") || strings.ContainsRune(socketName, '/') {
+		return nil, fmt.Errorf("wake reload endpoint escaped retained agent directory")
+	}
+	listener, identity, err := listenLinuxWakeReloadTransportAt(agentDir, socketName, path)
+	if err != nil {
+		return nil, err
+	}
+	transport := &linuxWakeReloadTransport{
+		agentDir:       agentDir,
+		root:           root,
+		agent:          agent,
+		expected:       current,
+		owner:          owner,
+		path:           path,
+		socketName:     socketName,
+		socketIdentity: identity,
+		handlerTimeout: handlerTimeout,
+		listener:       listener,
+		handlerSlots:   make(chan struct{}, linuxWakeReloadMaxHandlers),
+		acceptDone:     make(chan struct{}),
+	}
+	go transport.acceptLoop()
+	return transport, nil
+}
+
+func validateLinuxWakeReloadTransportStart(
+	agentDir *wakeAgentDir,
+	root string,
+	agent string,
+	expected wakeLockInspection,
+	owner wakeOwner,
+	handlerTimeout time.Duration,
+) error {
+	if agentDir == nil {
+		return fmt.Errorf("wake reload agent directory capability is missing")
+	}
+	if root == "" || !filepath.IsAbs(root) || canonicalWakeRoot(root) != root {
+		return fmt.Errorf("wake reload root is not canonical")
+	}
+	if err := fsq.ValidateHandle(agent); err != nil {
+		return fmt.Errorf("wake reload agent is invalid: %w", err)
+	}
+	if handlerTimeout <= 0 || handlerTimeout > linuxWakeReloadMaxHandlerTimeout {
+		return fmt.Errorf("wake reload handler timeout is outside the bounded range")
+	}
+	return validateLinuxWakeReloadIdentity(root, agent, expected, owner)
+}
+
+func validateLinuxWakeReloadIdentity(
+	root string,
+	agent string,
+	expected wakeLockInspection,
+	owner wakeOwner,
+) error {
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		return fmt.Errorf("wake reload owner is invalid: %w", err)
+	}
+	if !expected.Exists || expected.Status != wakeLockValid || !expected.IdentityConfirmed {
+		return fmt.Errorf("wake reload lock identity is not confirmed")
+	}
+	if expected.Root != root || expected.Agent != agent ||
+		expected.Lock.Root != root || expected.Lock.Agent != agent {
+		return fmt.Errorf("wake reload lock scope does not match")
+	}
+	if !validWakeReloadTransportGeneration(expected.Lock.Generation) {
+		return fmt.Errorf("wake reload generation is invalid")
+	}
+	if expected.PID != os.Getpid() || expected.Lock.PID != os.Getpid() {
+		return fmt.Errorf("wake reload lock is not owned by this process")
+	}
+	if expected.Lock.ProcessStart != expected.Process.StartToken ||
+		compareWakeBootID(expected.Lock.BootID, expected.Process) != bootIDMatch {
+		return fmt.Errorf("wake reload lock process identity does not match the running wake")
+	}
+	if expected.Lock.Owner != nil && !sameWakeOwner(expected.Lock.Owner, &owner) {
+		return fmt.Errorf("wake reload persisted owner does not match")
+	}
+	if expected.Lock.ResumeOwner != nil && !sameWakeOwner(expected.Lock.ResumeOwner, &owner) {
+		return fmt.Errorf("wake reload persisted resume owner does not match")
+	}
+	return nil
+}
+
+func validateLinuxWakeReloadCurrentLock(
+	expected wakeLockInspection,
+	current wakeLockInspection,
+	root string,
+	agent string,
+	owner wakeOwner,
+) error {
+	if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed ||
+		current.Status != wakeLockValid {
+		return fmt.Errorf("wake reload lock changed")
+	}
+	return validateLinuxWakeReloadIdentity(root, agent, current, owner)
+}
+
+func validateLinuxWakeReloadOwnerLive(owner wakeOwner) (retErr error) {
+	observation, err := observeAuthoritativeWakeOwner(owner)
+	defer func() {
+		retErr = errors.Join(retErr, observation.Close())
+	}()
+	if err != nil {
+		return err
+	}
+	if observation.State != wakeOwnerSame {
+		return fmt.Errorf("wake reload owner identity is %s: %s", observation.State, observation.Reason)
+	}
+	select {
+	case <-observation.Done():
+		return fmt.Errorf("wake reload owner exited during authentication")
+	default:
+		return nil
+	}
+}
+
+func listenLinuxWakeReloadTransportAt(
+	agentDir *wakeAgentDir,
+	name string,
+	path string,
+) (*net.UnixListener, linuxWakeReloadSocketIdentity, error) {
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, linuxWakeReloadSocketIdentity{}, err
+	}
+	ownedFD := true
+	defer func() {
+		if ownedFD {
+			_ = unix.Close(fd)
+		}
+	}()
+
+	var identity linuxWakeReloadSocketIdentity
+	err = agentDir.withFD(func(dirfd int) error {
+		stagingName, err := randomLinuxWakeReloadPrivateName("stage")
+		if err != nil {
+			return err
+		}
+		procPath := linuxWakeReloadProcFDPath(dirfd, stagingName)
+		if err := unix.Bind(fd, &unix.SockaddrUnix{Name: procPath}); err != nil {
+			return fmt.Errorf("bind wake reload endpoint %s: %w", path, err)
+		}
+		if err := unix.Fchmodat(dirfd, stagingName, 0o600, 0); err != nil {
+			return fmt.Errorf("chmod wake reload endpoint %s: %w", path, err)
+		}
+		stagedIdentity, err := inspectLinuxWakeReloadSocketAt(dirfd, stagingName, path)
+		if err != nil {
+			return err
+		}
+		cleanupName := stagingName
+		complete := false
+		defer func() {
+			if !complete {
+				_ = removeLinuxWakeReloadSocketIfSameAt(dirfd, agentDir.path, cleanupName, stagedIdentity)
+			}
+		}()
+		if err := unix.Listen(fd, linuxWakeReloadListenBacklog); err != nil {
+			return fmt.Errorf("listen on wake reload endpoint %s: %w", path, err)
+		}
+		if linuxWakeReloadBeforePublish != nil {
+			if err := linuxWakeReloadBeforePublish(dirfd, stagingName, name); err != nil {
+				return err
+			}
+		}
+		if err := unix.Renameat2(dirfd, stagingName, dirfd, name, unix.RENAME_NOREPLACE); err != nil {
+			return fmt.Errorf("publish wake reload endpoint %s: %w", path, err)
+		}
+		cleanupName = name
+		captured, err := inspectLinuxWakeReloadSocketAt(dirfd, name, path)
+		if err != nil {
+			return err
+		}
+		if !sameLinuxWakeReloadStableSocketIdentity(stagedIdentity, captured) {
+			return fmt.Errorf("wake reload endpoint identity changed during publication")
+		}
+		identity = captured
+		complete = true
+		return nil
+	})
+	if err != nil {
+		if identity != (linuxWakeReloadSocketIdentity{}) {
+			_ = removeLinuxWakeReloadSocketIfSame(agentDir, name, identity)
+		}
+		return nil, linuxWakeReloadSocketIdentity{}, err
+	}
+
+	file := os.NewFile(uintptr(fd), "wake-reload-listener")
+	listenerAny, err := net.FileListener(file)
+	_ = file.Close()
+	ownedFD = false
+	if err != nil {
+		_ = removeLinuxWakeReloadSocketIfSame(agentDir, name, identity)
+		return nil, linuxWakeReloadSocketIdentity{}, err
+	}
+	listener, ok := listenerAny.(*net.UnixListener)
+	if !ok {
+		_ = listenerAny.Close()
+		_ = removeLinuxWakeReloadSocketIfSame(agentDir, name, identity)
+		return nil, linuxWakeReloadSocketIdentity{}, fmt.Errorf("wake reload listener is not unix")
+	}
+	listener.SetUnlinkOnClose(false)
+	return listener, identity, nil
+}
+
+func randomLinuxWakeReloadPrivateName(purpose string) (string, error) {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", fmt.Errorf("generate wake reload %s name: %w", purpose, err)
+	}
+	return ".wr." + purpose + "." + hex.EncodeToString(nonce[:]), nil
+}
+
+func sameLinuxWakeReloadStableSocketIdentity(
+	first linuxWakeReloadSocketIdentity,
+	second linuxWakeReloadSocketIdentity,
+) bool {
+	return first.device == second.device && first.inode == second.inode &&
+		first.mode == second.mode && first.uid == second.uid
+}
+
+func linuxWakeReloadProcFDPath(dirfd int, name string) string {
+	return fmt.Sprintf("/proc/self/fd/%d/%s", dirfd, name)
+}
+
+func inspectLinuxWakeReloadSocketAt(
+	dirfd int,
+	name string,
+	path string,
+) (linuxWakeReloadSocketIdentity, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstatat(dirfd, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return linuxWakeReloadSocketIdentity{}, fmt.Errorf("stat wake reload endpoint %s: %w", path, err)
+	}
+	identity := linuxWakeReloadSocketIdentity{
+		device:    uint64(stat.Dev),
+		inode:     stat.Ino,
+		ctimeSec:  stat.Ctim.Sec,
+		ctimeNsec: stat.Ctim.Nsec,
+		mode:      stat.Mode,
+		uid:       stat.Uid,
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFSOCK {
+		return linuxWakeReloadSocketIdentity{}, fmt.Errorf("wake reload endpoint %s is not a socket", path)
+	}
+	if stat.Mode&0o777 != 0o600 {
+		return linuxWakeReloadSocketIdentity{}, fmt.Errorf(
+			"wake reload endpoint %s mode is %o, want 0600",
+			path,
+			stat.Mode&0o777,
+		)
+	}
+	if stat.Uid != uint32(os.Geteuid()) {
+		return linuxWakeReloadSocketIdentity{}, fmt.Errorf(
+			"wake reload endpoint %s is owned by uid %d, want %d",
+			path,
+			stat.Uid,
+			os.Geteuid(),
+		)
+	}
+	return identity, nil
+}
+
+func removeLinuxWakeReloadSocketIfSame(
+	agentDir *wakeAgentDir,
+	name string,
+	expected linuxWakeReloadSocketIdentity,
+) error {
+	return agentDir.withFD(func(dirfd int) error {
+		return removeLinuxWakeReloadSocketIfSameAt(dirfd, agentDir.path, name, expected)
+	})
+}
+
+func removeLinuxWakeReloadSocketIfSameAt(
+	dirfd int,
+	dirPath string,
+	name string,
+	expected linuxWakeReloadSocketIdentity,
+) error {
+	retiredName, err := randomLinuxWakeReloadPrivateName("retired")
+	if err != nil {
+		return err
+	}
+	if err := unix.Renameat2(dirfd, name, dirfd, retiredName, unix.RENAME_NOREPLACE); errors.Is(err, syscall.ENOENT) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if linuxWakeReloadAfterRetire != nil {
+		if err := linuxWakeReloadAfterRetire(dirfd, retiredName, name); err != nil {
+			return err
+		}
+	}
+	retired, inspectErr := inspectLinuxWakeReloadSocketAt(
+		dirfd,
+		retiredName,
+		filepath.Join(dirPath, retiredName),
+	)
+	if inspectErr == nil && sameLinuxWakeReloadStableSocketIdentity(retired, expected) {
+		if err := unix.Unlinkat(dirfd, retiredName, 0); err != nil && !errors.Is(err, syscall.ENOENT) {
+			return err
+		}
+		return nil
+	}
+	// A non-matching retired object is never unlinked. Restore it only if
+	// no successor claimed the public name; otherwise preserve both names.
+	restoreErr := unix.Renameat2(dirfd, retiredName, dirfd, name, unix.RENAME_NOREPLACE)
+	identityErr := fmt.Errorf("wake reload endpoint identity changed; refused cleanup")
+	if restoreErr == nil {
+		return errors.Join(inspectErr, identityErr)
+	}
+	if errors.Is(restoreErr, syscall.EEXIST) {
+		return errors.Join(
+			inspectErr,
+			identityErr,
+			fmt.Errorf("preserved retired endpoint %s because public name %s is occupied", retiredName, name),
+		)
+	}
+	return errors.Join(inspectErr, identityErr, restoreErr)
+}
+
+func (transport *linuxWakeReloadTransport) Close() error {
+	if transport == nil {
+		return nil
+	}
+	transport.closeOnce.Do(func() {
+		listenerErr := transport.listener.Close()
+		if errors.Is(listenerErr, net.ErrClosed) {
+			listenerErr = nil
+		}
+		<-transport.acceptDone
+		transport.handlers.Wait()
+		removeErr := removeLinuxWakeReloadSocketIfSame(
+			transport.agentDir,
+			transport.socketName,
+			transport.socketIdentity,
+		)
+		transport.closeErr = errors.Join(listenerErr, removeErr)
+	})
+	return transport.closeErr
+}
+
+func (transport *linuxWakeReloadTransport) acceptLoop() {
+	defer close(transport.acceptDone)
+	for {
+		conn, err := transport.listener.AcceptUnix()
+		if err != nil {
+			return
+		}
+		select {
+		case transport.handlerSlots <- struct{}{}:
+			transport.handlers.Add(1)
+			go transport.handle(conn)
+		default:
+			_ = conn.Close()
+		}
+	}
+}
+
+func (transport *linuxWakeReloadTransport) handle(conn *net.UnixConn) {
+	defer transport.handlers.Done()
+	defer func() { <-transport.handlerSlots }()
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(transport.handlerTimeout))
+
+	peer, err := captureLinuxWakeReloadPeer(conn)
+	if err != nil {
+		return
+	}
+	defer func() { _ = peer.Close() }()
+	if peer.uid != uint32(os.Geteuid()) || peer.owner.SessionID != transport.owner.SessionID {
+		return
+	}
+	if err := transport.validateSocketIdentity(); err != nil {
+		return
+	}
+	payload, ancillary, err := readLinuxWakeReloadTransportRequest(conn)
+	if err != nil || ancillary {
+		return
+	}
+	request, err := decodeWakeReloadTransportRequest(payload)
+	if err != nil {
+		return
+	}
+	if err := peer.Revalidate(); err != nil {
+		return
+	}
+	if err := transport.authorize(request); err != nil {
+		return
+	}
+	if err := peer.Revalidate(); err != nil {
+		return
+	}
+	response, err := encodeWakeReloadTransportResponse(wakeReloadTransportUnavailableResponse())
+	if err != nil {
+		return
+	}
+	_, _ = conn.Write(response)
+}
+
+func (transport *linuxWakeReloadTransport) validateSocketIdentity() error {
+	return transport.agentDir.withFD(func(dirfd int) error {
+		current, err := inspectLinuxWakeReloadSocketAt(
+			dirfd,
+			transport.socketName,
+			transport.path,
+		)
+		if err != nil {
+			return err
+		}
+		if current != transport.socketIdentity {
+			return fmt.Errorf("wake reload endpoint identity changed")
+		}
+		return nil
+	})
+}
+
+func (transport *linuxWakeReloadTransport) authorize(request wakeReloadTransportRequest) error {
+	if request.Root != transport.root || request.Agent != transport.agent ||
+		request.Generation != transport.expected.Lock.Generation || request.Owner != transport.owner {
+		return fmt.Errorf("wake reload request identity does not match")
+	}
+	if err := transport.validateSocketIdentity(); err != nil {
+		return err
+	}
+	observation, observeErr := observeAuthoritativeWakeOwner(transport.owner)
+	if observeErr != nil {
+		return errors.Join(observeErr, observation.Close())
+	}
+	if observation.State != wakeOwnerSame {
+		return errors.Join(
+			fmt.Errorf("wake reload owner identity is %s: %s", observation.State, observation.Reason),
+			observation.Close(),
+		)
+	}
+	if linuxWakeReloadBeforeGuard != nil {
+		linuxWakeReloadBeforeGuard()
+	}
+	authErr := withWakeLifecycleGuardModeInDir(transport.agentDir, unix.LOCK_EX|unix.LOCK_NB, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, transport.agentDir, transport.root, transport.agent)
+		return validateLinuxWakeReloadCurrentLock(
+			transport.expected,
+			current,
+			transport.root,
+			transport.agent,
+			transport.owner,
+		)
+	})
+	if authErr == nil {
+		select {
+		case <-observation.Done():
+			authErr = fmt.Errorf("wake reload owner exited during authentication")
+		default:
+		}
+	}
+	return errors.Join(authErr, observation.Close())
+}
+
+type linuxWakeReloadPeer struct {
+	pidfd int
+	uid   uint32
+	owner wakeOwner
+}
+
+func captureLinuxWakeReloadPeer(conn *net.UnixConn) (*linuxWakeReloadPeer, error) {
+	cred, err := linuxWakeReloadGetPeerCred(conn)
+	if err != nil {
+		return nil, err
+	}
+	if cred.Pid <= 0 || cred.Uid != uint32(os.Geteuid()) {
+		return nil, fmt.Errorf("wake reload peer credentials are not authorized")
+	}
+	pid := int(cred.Pid)
+	pidfd, err := linuxPidfdOpen(pid, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open wake reload peer pidfd: %w", err)
+	}
+	peer := &linuxWakeReloadPeer{pidfd: pidfd, uid: cred.Uid}
+	if err := peer.captureStableOwner(pid); err != nil {
+		_ = peer.Close()
+		return nil, err
+	}
+	return peer, nil
+}
+
+func (peer *linuxWakeReloadPeer) captureStableOwner(pid int) error {
+	exited, err := linuxPidfdPoll(peer.pidfd, 0)
+	if err != nil || exited {
+		return fmt.Errorf("wake reload peer is not live: %w", err)
+	}
+	first := linuxWakeReloadPeerProcess(pid)
+	firstSID, firstSIDErr := linuxWakeReloadGetPeerSID(pid)
+	owner := wakeOwner{
+		PID:          pid,
+		ProcessStart: first.StartToken,
+		BootID:       first.BootID,
+		SessionID:    firstSID,
+	}
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		return fmt.Errorf("wake reload peer identity is incomplete: %w", err)
+	}
+	second := linuxWakeReloadPeerProcess(pid)
+	secondSID, secondSIDErr := linuxWakeReloadGetPeerSID(pid)
+	exited, err = linuxPidfdPoll(peer.pidfd, 0)
+	if err != nil || exited {
+		return fmt.Errorf("wake reload peer changed during inspection: %w", err)
+	}
+	state, reason := classifyStableAuthoritativeWakeOwner(
+		owner,
+		first,
+		firstSID,
+		firstSIDErr,
+		second,
+		secondSID,
+		secondSIDErr,
+	)
+	if state != wakeOwnerSame {
+		return fmt.Errorf("wake reload peer identity is %s: %s", state, reason)
+	}
+	peer.owner = owner
+	return nil
+}
+
+func (peer *linuxWakeReloadPeer) Revalidate() error {
+	if peer == nil || peer.pidfd < 0 {
+		return fmt.Errorf("wake reload peer capability is missing")
+	}
+	exited, err := linuxPidfdPoll(peer.pidfd, 0)
+	if err != nil || exited {
+		return fmt.Errorf("wake reload peer is not live: %w", err)
+	}
+	first := linuxWakeReloadPeerProcess(peer.owner.PID)
+	firstSID, firstSIDErr := linuxWakeReloadGetPeerSID(peer.owner.PID)
+	second := linuxWakeReloadPeerProcess(peer.owner.PID)
+	secondSID, secondSIDErr := linuxWakeReloadGetPeerSID(peer.owner.PID)
+	state, reason := classifyStableAuthoritativeWakeOwner(
+		peer.owner,
+		first,
+		firstSID,
+		firstSIDErr,
+		second,
+		secondSID,
+		secondSIDErr,
+	)
+	if state != wakeOwnerSame {
+		return fmt.Errorf("wake reload peer changed: %s", reason)
+	}
+	exited, err = linuxPidfdPoll(peer.pidfd, 0)
+	if err != nil || exited {
+		return fmt.Errorf("wake reload peer changed after inspection: %w", err)
+	}
+	return nil
+}
+
+func (peer *linuxWakeReloadPeer) Close() error {
+	if peer == nil || peer.pidfd < 0 {
+		return nil
+	}
+	fd := peer.pidfd
+	peer.pidfd = -1
+	return linuxPidfdClose(fd)
+}
+
+func getLinuxWakeReloadPeerCred(conn *net.UnixConn) (*unix.Ucred, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+	var cred *unix.Ucred
+	var sockErr error
+	if err := raw.Control(func(fd uintptr) {
+		cred, sockErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	}); err != nil {
+		return nil, err
+	}
+	if sockErr != nil {
+		return nil, sockErr
+	}
+	return cred, nil
+}
+
+func readLinuxWakeReloadTransportRequest(conn *net.UnixConn) ([]byte, bool, error) {
+	var payload bytes.Buffer
+	ancillary := false
+	buffer := make([]byte, 4096)
+	oob := make([]byte, unix.CmsgSpace(4*linuxWakeReloadMaxReceivedFDs))
+	for {
+		n, oobn, flags, _, err := conn.ReadMsgUnix(buffer, oob)
+		if oobn > 0 {
+			hadAncillary, closeErr := closeLinuxWakeReloadAncillary(oob[:oobn])
+			ancillary = ancillary || hadAncillary
+			if closeErr != nil {
+				return nil, true, closeErr
+			}
+		}
+		if flags&(unix.MSG_TRUNC|unix.MSG_CTRUNC) != 0 {
+			return nil, true, fmt.Errorf("wake reload request was truncated")
+		}
+		if n > 0 {
+			if payload.Len()+n > wakeReloadTransportMaxRequestBytes {
+				return nil, ancillary, fmt.Errorf("wake reload request exceeds size bound")
+			}
+			_, _ = payload.Write(buffer[:n])
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, ancillary, err
+		}
+		if n == 0 && oobn == 0 {
+			return nil, ancillary, io.ErrNoProgress
+		}
+	}
+	return payload.Bytes(), ancillary, nil
+}
+
+func closeLinuxWakeReloadAncillary(oob []byte) (bool, error) {
+	messages, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return true, err
+	}
+	var closeErr error
+	for _, message := range messages {
+		if message.Header.Level != unix.SOL_SOCKET || message.Header.Type != unix.SCM_RIGHTS {
+			closeErr = errors.Join(closeErr, fmt.Errorf("wake reload ancillary data is unsupported"))
+			continue
+		}
+		fds, err := unix.ParseUnixRights(&message)
+		if err != nil {
+			closeErr = errors.Join(closeErr, err)
+			continue
+		}
+		for _, fd := range fds {
+			closeErr = errors.Join(closeErr, closeWakeReloadReceivedFD(fd))
+		}
+	}
+	return len(messages) > 0, closeErr
+}

--- a/internal/cli/wake_reload_transport_linux_test.go
+++ b/internal/cli/wake_reload_transport_linux_test.go
@@ -25,6 +25,8 @@ import (
 
 const linuxWakeReloadExternalHelperEnv = "AMQ_TEST_WAKE_RELOAD_EXTERNAL_HELPER"
 
+const linuxWakeReloadExternalAllowEarlyRefusalEnv = "AMQ_TEST_WAKE_RELOAD_ALLOW_EARLY_REFUSAL"
+
 const linuxWakeReloadExternalResponsePrefix = "AMQ_TEST_WAKE_RELOAD_RESPONSE_BASE64="
 
 type linuxWakeReloadTransportFixture struct {
@@ -318,20 +320,34 @@ func TestLinuxWakeReloadExternalHelperProcess(t *testing.T) {
 		t.Fatal("external helper connection is not unix")
 	}
 	defer func() { _ = unixConn.Close() }()
-	if _, err := unixConn.Write(payload); err != nil {
-		t.Fatal(err)
+	allowEarlyRefusal := os.Getenv(linuxWakeReloadExternalAllowEarlyRefusalEnv) == "1"
+	written, writeErr := unixConn.Write(payload)
+	writeTeardown := linuxWakeReloadSilentTeardownError(writeErr)
+	if writeErr != nil && !writeTeardown {
+		t.Fatal(writeErr)
 	}
-	if err := unixConn.CloseWrite(); err != nil {
-		t.Fatal(err)
+	if written != len(payload) && !(allowEarlyRefusal && writeTeardown) {
+		t.Fatalf("external helper wrote %d/%d request bytes", written, len(payload))
 	}
-	response, err := io.ReadAll(unixConn)
-	if err != nil && !(len(response) == 0 && errors.Is(err, syscall.ECONNRESET)) {
-		t.Fatal(err)
+	closeWriteErr := unixConn.CloseWrite()
+	if closeWriteErr != nil && !linuxWakeReloadSilentTeardownError(closeWriteErr) {
+		t.Fatal(closeWriteErr)
+	}
+	response, readErr := io.ReadAll(unixConn)
+	if readErr != nil && !(len(response) == 0 && linuxWakeReloadSilentTeardownError(readErr)) {
+		t.Fatal(readErr)
+	}
+	if len(response) != 0 && (writeErr != nil || closeWriteErr != nil) {
+		t.Fatalf("external helper received %d response bytes after connection teardown", len(response))
 	}
 	_, _ = fmt.Fprintln(
 		os.Stdout,
 		linuxWakeReloadExternalResponsePrefix+base64.StdEncoding.EncodeToString(response),
 	)
+}
+
+func linuxWakeReloadSilentTeardownError(err error) bool {
+	return errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET)
 }
 
 func runLinuxWakeReloadExternalHelper(
@@ -348,12 +364,24 @@ func runLinuxWakeReloadExternalHelper(
 		"AMQ_TEST_WAKE_RELOAD_PATH="+endpoint.Path(),
 		"AMQ_TEST_WAKE_RELOAD_PAYLOAD="+base64.StdEncoding.EncodeToString(payload),
 	)
+	allowEarlyRefusal := "0"
 	if setsid {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		allowEarlyRefusal = "1"
 	}
+	cmd.Env = append(cmd.Env, linuxWakeReloadExternalAllowEarlyRefusalEnv+"="+allowEarlyRefusal)
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf(
+				"external helper failed: %w (stdout=%q stderr=%q)",
+				err,
+				output,
+				exitErr.Stderr,
+			)
+		}
+		return nil, fmt.Errorf("start external helper: %w", err)
 	}
 	for _, line := range strings.Split(string(output), "\n") {
 		if !strings.HasPrefix(line, linuxWakeReloadExternalResponsePrefix) {

--- a/internal/cli/wake_reload_transport_linux_test.go
+++ b/internal/cli/wake_reload_transport_linux_test.go
@@ -1,0 +1,1242 @@
+//go:build linux
+
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const linuxWakeReloadExternalHelperEnv = "AMQ_TEST_WAKE_RELOAD_EXTERNAL_HELPER"
+
+const linuxWakeReloadExternalResponsePrefix = "AMQ_TEST_WAKE_RELOAD_RESPONSE_BASE64="
+
+type linuxWakeReloadTransportFixture struct {
+	root     string
+	agent    string
+	owner    wakeOwner
+	expected wakeLockInspection
+	agentDir *wakeAgentDir
+}
+
+func (transport *linuxWakeReloadTransport) Path() string {
+	if transport == nil {
+		return ""
+	}
+	return transport.path
+}
+
+func (transport *linuxWakeReloadTransport) ActiveHandlers() int {
+	if transport == nil {
+		return 0
+	}
+	return len(transport.handlerSlots)
+}
+
+func writeWakeReloadTransportRequest(
+	conn *net.UnixConn,
+	request wakeReloadTransportRequest,
+	fds []int,
+) error {
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	if len(payload) > wakeReloadTransportMaxRequestBytes {
+		return fmt.Errorf("wake reload request exceeds size bound")
+	}
+	var rights []byte
+	if len(fds) > 0 {
+		rights = unix.UnixRights(fds...)
+	}
+	n, _, err := conn.WriteMsgUnix(payload, rights, nil)
+	if err != nil {
+		return err
+	}
+	if n < len(payload) {
+		if _, err := conn.Write(payload[n:]); err != nil {
+			return err
+		}
+	}
+	return conn.CloseWrite()
+}
+
+func dialLinuxWakeReloadTransport(
+	agentDir *wakeAgentDir,
+	name string,
+	timeout time.Duration,
+) (*net.UnixConn, error) {
+	if agentDir == nil || timeout <= 0 || !strings.HasPrefix(name, ".wr.") ||
+		filepath.Base(name) != name {
+		return nil, fmt.Errorf("wake reload dial target is invalid")
+	}
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	ownedFD := true
+	defer func() {
+		if ownedFD {
+			_ = unix.Close(fd)
+		}
+	}()
+	err = agentDir.withFD(func(dirfd int) error {
+		return unix.Connect(fd, &unix.SockaddrUnix{Name: linuxWakeReloadProcFDPath(dirfd, name)})
+	})
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), "wake-reload-client")
+	connAny, err := net.FileConn(file)
+	_ = file.Close()
+	ownedFD = false
+	if err != nil {
+		return nil, err
+	}
+	conn, ok := connAny.(*net.UnixConn)
+	if !ok {
+		_ = connAny.Close()
+		return nil, fmt.Errorf("wake reload connection is not unix")
+	}
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	return conn, nil
+}
+
+func snapshotLinuxWakeReloadTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	snapshot := make(map[string]string)
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		value := info.Mode().String()
+		if info.Mode().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			value += "\x00" + string(data)
+		}
+		snapshot[relative] = value
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func requireLinuxWakeReloadTreeUnchanged(
+	t *testing.T,
+	before map[string]string,
+	after map[string]string,
+) {
+	t.Helper()
+	if len(before) != len(after) {
+		t.Fatalf("wake reload changed tree entry count: before=%d after=%d", len(before), len(after))
+	}
+	for path, want := range before {
+		if got, ok := after[path]; !ok || got != want {
+			t.Fatalf("wake reload changed %q: before=%q after=%q exists=%t", path, want, got, ok)
+		}
+	}
+}
+
+func newLinuxWakeReloadTransportFixture(t *testing.T) linuxWakeReloadTransportFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	ownerProcess := exec.Command("sleep", "30")
+	if err := ownerProcess.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = ownerProcess.Process.Kill()
+		_ = ownerProcess.Wait()
+	})
+	sessionID, err := getWakeProcessSID(ownerProcess.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner := wakeOwner{
+		PID:          ownerProcess.Process.Pid,
+		ProcessStart: "67890",
+		BootID:       "22222222-2222-2222-2222-222222222222",
+		SessionID:    sessionID,
+	}
+	wakeProcess := wakeProcessInfo{
+		PID:        os.Getpid(),
+		Running:    true,
+		StartToken: "12345",
+		BootID:     "11111111-1111-1111-1111-111111111111",
+		Executable: "/usr/local/bin/amq",
+		Args:       []string{"amq", "wake", "--root", root, "--me", agent},
+	}
+	ownerInfo := wakeProcessInfo{
+		PID:        owner.PID,
+		Running:    true,
+		StartToken: owner.ProcessStart,
+		BootID:     owner.BootID,
+		Executable: "/usr/local/bin/amq",
+		Args:       []string{"amq", "coop", "exec"},
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		switch pid {
+		case os.Getpid():
+			return wakeProcess
+		case owner.PID:
+			return ownerInfo
+		default:
+			return wakeProcessInfo{PID: pid}
+		}
+	})
+	lock := wakeLock{
+		PID:          os.Getpid(),
+		TTY:          "unknown",
+		Root:         canonicalWakeRoot(root),
+		Agent:        agent,
+		Started:      "2026-08-01T00:00:00Z",
+		ProcessStart: wakeProcess.StartToken,
+		BootID:       wakeProcess.BootID,
+		Executable:   wakeProcess.Executable,
+		Args:         append([]string(nil), wakeProcess.Args...),
+		WakeMode:     wakeInjectModeNone,
+		Generation:   "0123456789abcdef0123456789abcdef",
+	}
+	writeWakeLockExactForTest(t, root, agent, lock)
+	expected := inspectWakeLock(root, agent)
+	if expected.Status != wakeLockValid || !expected.IdentityConfirmed {
+		t.Fatalf("fixture wake lock = %#v", expected)
+	}
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	return linuxWakeReloadTransportFixture{
+		root: root, agent: agent, owner: owner, expected: expected, agentDir: agentDir,
+	}
+}
+
+func newRealLinuxWakeReloadTransportFixture(t *testing.T) linuxWakeReloadTransportFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	ownerProcess := exec.Command("sleep", "30")
+	if err := ownerProcess.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = ownerProcess.Process.Kill()
+		_ = ownerProcess.Wait()
+	})
+	ownerInfo := inspectWakeProcessPlatform(ownerProcess.Process.Pid)
+	ownerSID, err := getWakeProcessSID(ownerProcess.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner := wakeOwner{
+		PID: ownerProcess.Process.Pid, ProcessStart: ownerInfo.StartToken,
+		BootID: ownerInfo.BootID, SessionID: ownerSID,
+	}
+	if err := validateAuthoritativeWakeOwner(owner); err != nil {
+		t.Fatalf("real owner identity: %v", err)
+	}
+	wakeProcess := inspectWakeProcessPlatform(os.Getpid())
+	wakeProcess.Executable = "/usr/local/bin/amq"
+	wakeProcess.Args = []string{"amq", "wake", "--root", root, "--me", agent}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == os.Getpid() {
+			return wakeProcess
+		}
+		return inspectWakeProcessPlatform(pid)
+	})
+	originalPeerProcess := linuxWakeReloadPeerProcess
+	linuxWakeReloadPeerProcess = inspectWakeProcessPlatform
+	t.Cleanup(func() { linuxWakeReloadPeerProcess = originalPeerProcess })
+	lock := wakeLock{
+		PID: os.Getpid(), TTY: "unknown", Root: canonicalWakeRoot(root), Agent: agent,
+		Started: time.Now().UTC().Format(time.RFC3339Nano), ProcessStart: wakeProcess.StartToken,
+		BootID: wakeProcess.BootID, Executable: wakeProcess.Executable,
+		Args: append([]string(nil), wakeProcess.Args...), WakeMode: wakeInjectModeNone,
+		Generation: "0123456789abcdef0123456789abcdef",
+	}
+	writeWakeLockExactForTest(t, root, agent, lock)
+	expected := inspectWakeLock(root, agent)
+	if expected.Status != wakeLockValid || !expected.IdentityConfirmed {
+		t.Fatalf("real fixture wake lock = %#v", expected)
+	}
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	return linuxWakeReloadTransportFixture{
+		root: root, agent: agent, owner: owner, expected: expected, agentDir: agentDir,
+	}
+}
+
+func TestLinuxWakeReloadExternalHelperProcess(t *testing.T) {
+	if os.Getenv(linuxWakeReloadExternalHelperEnv) != "1" {
+		return
+	}
+	payload, err := base64.StdEncoding.DecodeString(os.Getenv("AMQ_TEST_WAKE_RELOAD_PAYLOAD"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.DialTimeout("unix", os.Getenv("AMQ_TEST_WAKE_RELOAD_PATH"), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatal("external helper connection is not unix")
+	}
+	defer func() { _ = unixConn.Close() }()
+	if _, err := unixConn.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := unixConn.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	response, err := io.ReadAll(unixConn)
+	if err != nil && !(len(response) == 0 && errors.Is(err, syscall.ECONNRESET)) {
+		t.Fatal(err)
+	}
+	_, _ = fmt.Fprintln(
+		os.Stdout,
+		linuxWakeReloadExternalResponsePrefix+base64.StdEncoding.EncodeToString(response),
+	)
+}
+
+func runLinuxWakeReloadExternalHelper(
+	t *testing.T,
+	endpoint *linuxWakeReloadTransport,
+	request wakeReloadTransportRequest,
+	setsid bool,
+) ([]byte, error) {
+	t.Helper()
+	payload := encodeWakeReloadTransportRequestForTest(t, request)
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLinuxWakeReloadExternalHelperProcess$")
+	cmd.Env = append(os.Environ(),
+		linuxWakeReloadExternalHelperEnv+"=1",
+		"AMQ_TEST_WAKE_RELOAD_PATH="+endpoint.Path(),
+		"AMQ_TEST_WAKE_RELOAD_PAYLOAD="+base64.StdEncoding.EncodeToString(payload),
+	)
+	if setsid {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	}
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		if !strings.HasPrefix(line, linuxWakeReloadExternalResponsePrefix) {
+			continue
+		}
+		return base64.StdEncoding.DecodeString(strings.TrimPrefix(line, linuxWakeReloadExternalResponsePrefix))
+	}
+	return nil, fmt.Errorf("external helper response marker missing from %q", output)
+}
+
+func (fixture linuxWakeReloadTransportFixture) request() wakeReloadTransportRequest {
+	request := validWakeReloadTransportRequestForTest()
+	request.Root = canonicalWakeRoot(fixture.root)
+	request.Agent = fixture.agent
+	request.Generation = fixture.expected.Lock.Generation
+	request.Owner = fixture.owner
+	return request
+}
+
+func sendLinuxWakeReloadTransportRequest(
+	t *testing.T,
+	fixture linuxWakeReloadTransportFixture,
+	endpoint *linuxWakeReloadTransport,
+	request wakeReloadTransportRequest,
+	fds ...int,
+) (string, error) {
+	t.Helper()
+	conn, err := dialLinuxWakeReloadTransport(
+		fixture.agentDir,
+		endpoint.socketName,
+		time.Second,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = conn.Close() }()
+	if err := writeWakeReloadTransportRequest(conn, request, fds); err != nil {
+		return "", err
+	}
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	return strings.TrimSpace(line), err
+}
+
+func sendRawLinuxWakeReloadTransportRequest(
+	t *testing.T,
+	fixture linuxWakeReloadTransportFixture,
+	endpoint *linuxWakeReloadTransport,
+	payload []byte,
+) (string, error) {
+	t.Helper()
+	conn, err := dialLinuxWakeReloadTransport(
+		fixture.agentDir,
+		endpoint.socketName,
+		time.Second,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.Write(payload); err != nil {
+		return "", err
+	}
+	if err := conn.CloseWrite(); err != nil {
+		return "", err
+	}
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	return strings.TrimSpace(line), err
+}
+
+func requireLinuxWakeReloadSilentRefusal(t *testing.T, response string, err error) {
+	t.Helper()
+	if err == nil || response != "" {
+		t.Fatalf("wake reload refusal response = %q, err=%v", response, err)
+	}
+}
+
+func linuxOpenFDCount(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(entries)
+}
+
+func TestLinuxWakeReloadTransportAuthenticatesAndOnlyRefusesUnavailable(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	for path, data := range map[string]string{
+		filepath.Join(fixture.agentDir.path, "inbox", "new", "message.md"): "queued-message",
+		filepath.Join(fixture.agentDir.path, "inbox", "cur", "claimed.md"): "claimed-message",
+		filepath.Join(fixture.agentDir.path, ".wake.prepared"):             "prepared-sentinel",
+		filepath.Join(fixture.agentDir.path, ".wake.ready"):                "ready-sentinel",
+		filepath.Join(fixture.agentDir.path, ".wake.notifier"):             "notifier-sentinel",
+		filepath.Join(fixture.agentDir.path, ".wake.status"):               "status-sentinel",
+		filepath.Join(fixture.agentDir.path, ".wake.marker"):               "marker-sentinel",
+		filepath.Join(fixture.agentDir.path, "terminal-output.sentinel"):   "terminal-unchanged",
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lockPath := filepath.Join(fixture.agentDir.path, ".wake.lock")
+	lockBefore, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+	treeBefore := snapshotLinuxWakeReloadTree(t, fixture.root)
+
+	info, err := os.Lstat(endpoint.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 {
+		t.Fatalf("reload endpoint mode = %v", info.Mode())
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Uid != uint32(os.Geteuid()) {
+		t.Fatalf("reload endpoint owner = %#v", info.Sys())
+	}
+	if filepath.Dir(endpoint.Path()) != filepath.Clean(fixture.agentDir.path) ||
+		!strings.HasPrefix(filepath.Base(endpoint.Path()), ".wr.") {
+		t.Fatalf("reload endpoint path = %q", endpoint.Path())
+	}
+
+	response, err := sendLinuxWakeReloadTransportRequest(
+		t,
+		fixture,
+		endpoint,
+		fixture.request(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response != `{"status":"unavailable","reason_code":"reload_command_unavailable"}` {
+		t.Fatalf("response = %q", response)
+	}
+	if strings.Contains(response, "ACK") || strings.Contains(response, "QUEUED") {
+		t.Fatalf("reload-only refusal exposed a mutation acknowledgement: %q", response)
+	}
+	handlerDeadline := time.Now().Add(time.Second)
+	for endpoint.ActiveHandlers() != 0 && time.Now().Before(handlerDeadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if endpoint.ActiveHandlers() != 0 {
+		t.Fatalf("active handlers = %d", endpoint.ActiveHandlers())
+	}
+	lockAfter, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(lockBefore, lockAfter) {
+		t.Fatal("reload transport mutated the wake lock")
+	}
+	requireLinuxWakeReloadTreeUnchanged(
+		t,
+		treeBefore,
+		snapshotLinuxWakeReloadTree(t, fixture.root),
+	)
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if current.Lock.ResumeSchema != 0 || current.Lock.ControlSocket != "" ||
+		wakeControlSocketPath(fixture.root, fixture.agent, current.Lock.Generation) != "" {
+		t.Fatalf("reload transport enabled Linux advertisement: %#v", current.Lock)
+	}
+}
+
+func TestLinuxWakeReloadTransportClosesEveryReceivedFD(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+
+	var closed atomic.Int32
+	originalClose := closeWakeReloadReceivedFD
+	closeWakeReloadReceivedFD = func(fd int) error {
+		closed.Add(1)
+		return unix.Close(fd)
+	}
+	t.Cleanup(func() { closeWakeReloadReceivedFD = originalClose })
+
+	first := make([]int, 2)
+	second := make([]int, 2)
+	if err := unix.Pipe2(first, unix.O_CLOEXEC); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Pipe2(second, unix.O_CLOEXEC); err != nil {
+		_ = unix.Close(first[0])
+		_ = unix.Close(first[1])
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = unix.Close(first[0])
+		_ = unix.Close(first[1])
+		_ = unix.Close(second[0])
+		_ = unix.Close(second[1])
+	}()
+
+	response, err := sendLinuxWakeReloadTransportRequest(
+		t,
+		fixture,
+		endpoint,
+		fixture.request(),
+		first[0],
+		second[0],
+	)
+	requireLinuxWakeReloadSilentRefusal(t, response, err)
+	if got := closed.Load(); got != 2 {
+		t.Fatalf("received descriptor closes = %d, want 2", got)
+	}
+}
+
+func TestLinuxWakeReloadTransportClosesParsedFDsOnControlTruncationWithoutLeaks(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+
+	var closed atomic.Int32
+	originalClose := closeWakeReloadReceivedFD
+	closeWakeReloadReceivedFD = func(fd int) error {
+		closed.Add(1)
+		return unix.Close(fd)
+	}
+	t.Cleanup(func() { closeWakeReloadReceivedFD = originalClose })
+
+	fdCount := linuxWakeReloadMaxReceivedFDs + 4
+	pipes := make([][2]int, fdCount)
+	rights := make([]int, 0, fdCount)
+	for index := range pipes {
+		if err := unix.Pipe2(pipes[index][:], unix.O_CLOEXEC); err != nil {
+			t.Fatal(err)
+		}
+		rights = append(rights, pipes[index][0])
+	}
+	defer func() {
+		for _, pipe := range pipes {
+			_ = unix.Close(pipe[0])
+			_ = unix.Close(pipe[1])
+		}
+	}()
+	before := linuxOpenFDCount(t)
+	response, err := sendLinuxWakeReloadTransportRequest(
+		t,
+		fixture,
+		endpoint,
+		fixture.request(),
+		rights...,
+	)
+	requireLinuxWakeReloadSilentRefusal(t, response, err)
+	deadline := time.Now().Add(time.Second)
+	for endpoint.ActiveHandlers() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := endpoint.ActiveHandlers(); got != 0 {
+		t.Fatalf("truncated ancillary handler count = %d", got)
+	}
+	if got := closed.Load(); got == 0 || got > int32(linuxWakeReloadMaxReceivedFDs) {
+		t.Fatalf("parsed truncated descriptor closes = %d", got)
+	}
+	if after := linuxOpenFDCount(t); after != before {
+		t.Fatalf("descriptor count after truncated control = %d, want %d", after, before)
+	}
+}
+
+func TestLinuxWakeReloadTransportRejectsWrongCredentialProcessAndRequestIdentity(t *testing.T) {
+	t.Run("uid", func(t *testing.T) {
+		fixture := newLinuxWakeReloadTransportFixture(t)
+		originalCred := linuxWakeReloadGetPeerCred
+		linuxWakeReloadGetPeerCred = func(conn *net.UnixConn) (*unix.Ucred, error) {
+			cred, err := originalCred(conn)
+			if cred != nil {
+				copy := *cred
+				copy.Uid++
+				cred = &copy
+			}
+			return cred, err
+		}
+		t.Cleanup(func() { linuxWakeReloadGetPeerCred = originalCred })
+		endpoint, err := startLinuxWakeReloadTransport(
+			fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+			500*time.Millisecond,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = endpoint.Close() }()
+		response, err := sendLinuxWakeReloadTransportRequest(t, fixture, endpoint, fixture.request())
+		requireLinuxWakeReloadSilentRefusal(t, response, err)
+	})
+
+	t.Run("process", func(t *testing.T) {
+		fixture := newLinuxWakeReloadTransportFixture(t)
+		originalProcess := linuxWakeReloadPeerProcess
+		var snapshots atomic.Int32
+		linuxWakeReloadPeerProcess = func(pid int) wakeProcessInfo {
+			process := originalProcess(pid)
+			if snapshots.Add(1)%2 == 0 {
+				process.StartToken = "54321"
+			}
+			return process
+		}
+		t.Cleanup(func() { linuxWakeReloadPeerProcess = originalProcess })
+		endpoint, err := startLinuxWakeReloadTransport(
+			fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+			500*time.Millisecond,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = endpoint.Close() }()
+		response, err := sendLinuxWakeReloadTransportRequest(t, fixture, endpoint, fixture.request())
+		requireLinuxWakeReloadSilentRefusal(t, response, err)
+	})
+
+	for _, mutate := range []struct {
+		name string
+		fn   func(*wakeReloadTransportRequest)
+	}{
+		{name: "zero schema", fn: func(request *wakeReloadTransportRequest) { request.Schema = 0 }},
+		{name: "future schema", fn: func(request *wakeReloadTransportRequest) { request.Schema = 2 }},
+		{name: "owner", fn: func(request *wakeReloadTransportRequest) { request.Owner.ProcessStart = "54321" }},
+		{name: "generation", fn: func(request *wakeReloadTransportRequest) { request.Generation = "1123456789abcdef0123456789abcdef" }},
+	} {
+		t.Run(mutate.name, func(t *testing.T) {
+			fixture := newLinuxWakeReloadTransportFixture(t)
+			endpoint, err := startLinuxWakeReloadTransport(
+				fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+				500*time.Millisecond,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = endpoint.Close() }()
+			request := fixture.request()
+			mutate.fn(&request)
+			response, err := sendLinuxWakeReloadTransportRequest(t, fixture, endpoint, request)
+			requireLinuxWakeReloadSilentRefusal(t, response, err)
+		})
+	}
+}
+
+func TestLinuxWakeReloadTransportRejectsNonCanonicalLiveFraming(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+
+	canonical := encodeWakeReloadTransportRequestForTest(t, fixture.request())
+	for _, test := range []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "trailing object", payload: append(append([]byte(nil), canonical...), []byte("{}\n")...)},
+		{name: "unterminated", payload: append([]byte(nil), canonical[:len(canonical)-1]...)},
+		{name: "leading whitespace", payload: append([]byte(" "), canonical...)},
+		{name: "legacy plaintext generation", payload: []byte(fixture.expected.Lock.Generation + "\n")},
+		{name: "crlf", payload: append(append([]byte(nil), canonical[:len(canonical)-1]...), '\r', '\n')},
+		{name: "oversized", payload: bytes.Repeat([]byte{'x'}, wakeReloadTransportMaxRequestBytes+1)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := sendRawLinuxWakeReloadTransportRequest(t, fixture, endpoint, test.payload)
+			requireLinuxWakeReloadSilentRefusal(t, response, err)
+		})
+	}
+}
+
+func TestLinuxWakeReloadTransportRejectsChangedLockAndWrongSession(t *testing.T) {
+	t.Run("changed lock", func(t *testing.T) {
+		fixture := newLinuxWakeReloadTransportFixture(t)
+		endpoint, err := startLinuxWakeReloadTransport(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			fixture.expected,
+			fixture.owner,
+			500*time.Millisecond,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = endpoint.Close() }()
+
+		lockPath := filepath.Join(fixture.agentDir.path, ".wake.lock")
+		parked := lockPath + ".parked"
+		if err := os.Rename(lockPath, parked); err != nil {
+			t.Fatal(err)
+		}
+		writeWakeLockExactForTest(t, fixture.root, fixture.agent, fixture.expected.Lock)
+		response, err := sendLinuxWakeReloadTransportRequest(
+			t,
+			fixture,
+			endpoint,
+			fixture.request(),
+		)
+		if !errors.Is(err, os.ErrClosed) && err == nil {
+			t.Fatalf("changed-lock request response = %q, want silent refusal", response)
+		}
+		if response != "" {
+			t.Fatalf("changed-lock request response = %q, want empty", response)
+		}
+	})
+
+	t.Run("wrong peer session", func(t *testing.T) {
+		fixture := newLinuxWakeReloadTransportFixture(t)
+		originalSID := linuxWakeReloadGetPeerSID
+		linuxWakeReloadGetPeerSID = func(int) (int, error) {
+			return fixture.owner.SessionID + 1, nil
+		}
+		t.Cleanup(func() { linuxWakeReloadGetPeerSID = originalSID })
+		endpoint, err := startLinuxWakeReloadTransport(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			fixture.expected,
+			fixture.owner,
+			500*time.Millisecond,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = endpoint.Close() }()
+
+		response, err := sendLinuxWakeReloadTransportRequest(
+			t,
+			fixture,
+			endpoint,
+			fixture.request(),
+		)
+		if err == nil || response != "" {
+			t.Fatalf("wrong-session response = %q, err=%v", response, err)
+		}
+	})
+}
+
+func TestLinuxWakeReloadTransportDeadlineDrainsSilentHandler(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		100*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+	conn, err := dialLinuxWakeReloadTransport(
+		fixture.agentDir,
+		endpoint.socketName,
+		time.Second,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := bufio.NewReader(conn).ReadByte(); err == nil {
+		t.Fatal("silent handler produced a response")
+	}
+	deadline := time.Now().Add(time.Second)
+	for endpoint.ActiveHandlers() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if endpoint.ActiveHandlers() != 0 {
+		t.Fatalf("timed-out active handlers = %d", endpoint.ActiveHandlers())
+	}
+}
+
+func TestLinuxWakeReloadTransportBoundsHandlersAndAccountsEveryExit(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+
+	clients := make([]*net.UnixConn, 0, linuxWakeReloadMaxHandlers)
+	defer func() {
+		for _, conn := range clients {
+			_ = conn.Close()
+		}
+	}()
+	for range linuxWakeReloadMaxHandlers {
+		conn, err := dialLinuxWakeReloadTransport(
+			fixture.agentDir,
+			endpoint.socketName,
+			time.Second,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		clients = append(clients, conn)
+	}
+	deadline := time.Now().Add(time.Second)
+	for endpoint.ActiveHandlers() != linuxWakeReloadMaxHandlers && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := endpoint.ActiveHandlers(); got != linuxWakeReloadMaxHandlers {
+		t.Fatalf("active handlers = %d, want %d", got, linuxWakeReloadMaxHandlers)
+	}
+
+	overflow, err := dialLinuxWakeReloadTransport(
+		fixture.agentDir,
+		endpoint.socketName,
+		time.Second,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = overflow.Close() }()
+	_ = overflow.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := bufio.NewReader(overflow).ReadByte(); err == nil {
+		t.Fatal("overflow handler was not refused")
+	}
+	if got := endpoint.ActiveHandlers(); got > linuxWakeReloadMaxHandlers {
+		t.Fatalf("active handlers exceeded bound: %d", got)
+	}
+
+	for _, conn := range clients {
+		_ = conn.Close()
+	}
+	deadline = time.Now().Add(time.Second)
+	for endpoint.ActiveHandlers() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := endpoint.ActiveHandlers(); got != 0 {
+		t.Fatalf("active handlers after client close = %d", got)
+	}
+}
+
+func TestLinuxWakeReloadTransportRejectsReboundSocketIdentity(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := endpoint.Path()
+	conn, err := dialLinuxWakeReloadTransport(
+		fixture.agentDir,
+		endpoint.socketName,
+		time.Second,
+	)
+	if err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if err := os.Remove(path); err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	sibling, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	sibling.SetUnlinkOnClose(false)
+	defer func() {
+		_ = sibling.Close()
+		_ = os.Remove(path)
+	}()
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	writeErr := writeWakeReloadTransportRequest(conn, fixture.request(), nil)
+	response, readErr := bufio.NewReader(conn).ReadString('\n')
+	if writeErr == nil {
+		requireLinuxWakeReloadSilentRefusal(t, strings.TrimSpace(response), readErr)
+	} else if response != "" || readErr == nil {
+		t.Fatalf("rebound endpoint write err=%v, response=%q, read err=%v", writeErr, response, readErr)
+	}
+	if err := endpoint.Close(); err == nil || !strings.Contains(err.Error(), "identity changed") {
+		t.Fatalf("rebound cleanup error = %v", err)
+	}
+	if _, err := os.Lstat(path); err != nil {
+		t.Fatalf("rebound sibling was removed: %v", err)
+	}
+}
+
+func TestLinuxWakeReloadTransportCleanupPreservesReboundSiblingIdentity(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := endpoint.Path()
+	if err := os.Remove(path); err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	sibling, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	sibling.SetUnlinkOnClose(false)
+	defer func() {
+		_ = sibling.Close()
+		_ = os.Remove(path)
+	}()
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	if err := endpoint.Close(); err == nil || !strings.Contains(err.Error(), "identity changed") {
+		t.Fatalf("rebound cleanup error = %v", err)
+	}
+	after, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("rebound sibling was removed: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("cleanup replaced or removed rebound sibling identity")
+	}
+}
+
+func TestLinuxWakeReloadTransportCloseDoesNotWaitForeverForLifecycleGuard(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guard, err := os.OpenFile(
+		wakeLifecycleGuardPath(fixture.root, fixture.agent),
+		os.O_RDWR|syscall.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	defer func() { _ = guard.Close() }()
+	if err := unix.Flock(int(guard.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			_ = unix.Flock(int(guard.Fd()), unix.LOCK_UN)
+		}
+	}()
+	reachedGuard := make(chan struct{})
+	originalHook := linuxWakeReloadBeforeGuard
+	var reached atomic.Bool
+	linuxWakeReloadBeforeGuard = func() {
+		if reached.CompareAndSwap(false, true) {
+			close(reachedGuard)
+		}
+	}
+	t.Cleanup(func() { linuxWakeReloadBeforeGuard = originalHook })
+
+	conn, err := dialLinuxWakeReloadTransport(fixture.agentDir, endpoint.socketName, time.Second)
+	if err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if err := writeWakeReloadTransportRequest(conn, fixture.request(), nil); err != nil {
+		_ = endpoint.Close()
+		t.Fatal(err)
+	}
+	select {
+	case <-reachedGuard:
+	case <-time.After(time.Second):
+		_ = endpoint.Close()
+		t.Fatal("request handler did not reach lifecycle authorization")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- endpoint.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		_ = unix.Flock(int(guard.Fd()), unix.LOCK_UN)
+		locked = false
+		<-closed
+		t.Fatal("transport.Close blocked on the wake lifecycle guard")
+	}
+}
+
+func TestLinuxWakeReloadTransportUsesRealPeerCredentialsAndSessions(t *testing.T) {
+	fixture := newRealLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+
+	t.Run("same session authenticated unavailable", func(t *testing.T) {
+		response, err := runLinuxWakeReloadExternalHelper(t, endpoint, fixture.request(), false)
+		if err != nil {
+			t.Fatalf("external helper: %v", err)
+		}
+		if got, want := strings.TrimSpace(string(response)),
+			`{"status":"unavailable","reason_code":"reload_command_unavailable"}`; got != want {
+			t.Fatalf("same-session response = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("new session silently refused", func(t *testing.T) {
+		response, err := runLinuxWakeReloadExternalHelper(t, endpoint, fixture.request(), true)
+		if err != nil {
+			t.Fatalf("setsid helper: %v", err)
+		}
+		if len(response) != 0 {
+			t.Fatalf("wrong-session response = %q, want empty", response)
+		}
+	})
+}
+
+func TestLinuxWakeReloadTransportRejectedMutationDoesNotSignalOwner(t *testing.T) {
+	fixture := newRealLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+	request := fixture.request()
+	request.Operation = "recover"
+	response, err := runLinuxWakeReloadExternalHelper(t, endpoint, request, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response) != 0 {
+		t.Fatalf("mutation response = %q, want empty", response)
+	}
+	if err := syscall.Kill(fixture.owner.PID, 0); err != nil {
+		t.Fatalf("cooperative owner was signaled or exited: %v", err)
+	}
+}
+
+func TestLinuxWakeReloadTransportPublishRefusesConcurrentPublicEntry(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	path := linuxWakeReloadTransportPath(
+		fixture.root, fixture.agent, fixture.expected.Lock.Generation,
+	)
+	originalHook := linuxWakeReloadBeforePublish
+	linuxWakeReloadBeforePublish = func(dirfd int, stagingName, publicName string) error {
+		return unix.Symlinkat("attacker-owned", dirfd, publicName)
+	}
+	t.Cleanup(func() { linuxWakeReloadBeforePublish = originalHook })
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+		500*time.Millisecond,
+	)
+	if err == nil {
+		_ = endpoint.Close()
+		t.Fatal("concurrent public entry was overwritten")
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "attacker-owned" {
+		t.Fatalf("concurrent public entry = %q", target)
+	}
+}
+
+func TestLinuxWakeReloadTransportCleanupRetiresBeforeExactUnlink(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := endpoint.Path()
+	originalHook := linuxWakeReloadAfterRetire
+	linuxWakeReloadAfterRetire = func(dirfd int, retiredName, publicName string) error {
+		return unix.Symlinkat("replacement", dirfd, publicName)
+	}
+	t.Cleanup(func() { linuxWakeReloadAfterRetire = originalHook })
+	if err := endpoint.Close(); err != nil {
+		t.Fatal(err)
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "replacement" {
+		t.Fatalf("replacement public entry = %q", target)
+	}
+}
+
+func TestLinuxWakeReloadTransportDoesNotAdvertisePathnameEvidence(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir, fixture.root, fixture.agent, fixture.expected, fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+	inspection := fixture.expected
+	evidence := validWakeReloadTransportRequestForTest().Candidate
+	evidence.Platform = "linux"
+	evidence.Method = wakeImageMethodPathnameObserved
+	inspection.Lock.RunningImageEvidence = &evidence
+	inspection.Lock.ImagePath = evidence.ExecutionPath
+	inspection.Lock.ImageVersion = evidence.EmbeddedVersion
+	decision := classifyWakeCheckReload(fixture.root, fixture.agent, inspection)
+	if decision.Status != wakeReloadUnavailable || decision.ReasonCode != wakeReloadReasonNotAdvertised {
+		t.Fatalf("listening observational endpoint classification = %#v", decision)
+	}
+}

--- a/internal/cli/wake_reload_transport_linux_test.go
+++ b/internal/cli/wake_reload_transport_linux_test.go
@@ -326,16 +326,20 @@ func TestLinuxWakeReloadExternalHelperProcess(t *testing.T) {
 	if writeErr != nil && !writeTeardown {
 		t.Fatal(writeErr)
 	}
-	if written != len(payload) && !(allowEarlyRefusal && writeTeardown) {
-		t.Fatalf("external helper wrote %d/%d request bytes", written, len(payload))
+	if written != len(payload) {
+		if !allowEarlyRefusal || !writeTeardown {
+			t.Fatalf("external helper wrote %d/%d request bytes", written, len(payload))
+		}
 	}
 	closeWriteErr := unixConn.CloseWrite()
 	if closeWriteErr != nil && !linuxWakeReloadSilentTeardownError(closeWriteErr) {
 		t.Fatal(closeWriteErr)
 	}
 	response, readErr := io.ReadAll(unixConn)
-	if readErr != nil && !(len(response) == 0 && linuxWakeReloadSilentTeardownError(readErr)) {
-		t.Fatal(readErr)
+	if readErr != nil {
+		if len(response) != 0 || !linuxWakeReloadSilentTeardownError(readErr) {
+			t.Fatal(readErr)
+		}
 	}
 	if len(response) != 0 && (writeErr != nil || closeWriteErr != nil) {
 		t.Fatalf("external helper received %d response bytes after connection teardown", len(response))

--- a/internal/cli/wake_reload_transport_test.go
+++ b/internal/cli/wake_reload_transport_test.go
@@ -1,0 +1,125 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func validWakeReloadTransportRequestForTest() wakeReloadTransportRequest {
+	method := wakeImageMethodFDExec
+	if runtime.GOOS == "darwin" {
+		method = wakeImageMethodPathnameExecVerified
+	}
+	return wakeReloadTransportRequest{
+		Schema:     wakeReloadTransportSchemaV1,
+		Operation:  wakeReloadTransportOperation,
+		Root:       canonicalWakeRoot("/queue"),
+		Agent:      "codex",
+		Generation: "0123456789abcdef0123456789abcdef",
+		Owner: wakeOwner{
+			PID:          4242,
+			ProcessStart: "12345",
+			BootID:       "11111111-1111-1111-1111-111111111111",
+			SessionID:    99,
+		},
+		Candidate: wakeImageEvidenceV1{
+			Schema:          wakeImageEvidenceSchemaV1,
+			Platform:        runtime.GOOS,
+			Method:          method,
+			ExecutionPath:   "/usr/local/bin/amq",
+			Device:          1,
+			Inode:           2,
+			Size:            3,
+			CTimeNS:         4,
+			SHA256:          "sha256:" + strings.Repeat("0", 64),
+			EmbeddedVersion: "0.0.0-test",
+		},
+	}
+}
+
+func encodeWakeReloadTransportRequestForTest(t *testing.T, request wakeReloadTransportRequest) []byte {
+	t.Helper()
+	payload, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(payload, '\n')
+}
+
+func TestDecodeWakeReloadTransportRequestIsStrictAndReloadOnly(t *testing.T) {
+	valid := validWakeReloadTransportRequestForTest()
+	if got, err := decodeWakeReloadTransportRequest(
+		encodeWakeReloadTransportRequestForTest(t, valid),
+	); err != nil || got != valid {
+		t.Fatalf("valid request = %#v, %v", got, err)
+	}
+	for _, schema := range []int{0, 2} {
+		request := valid
+		request.Schema = schema
+		if _, err := decodeWakeReloadTransportRequest(
+			encodeWakeReloadTransportRequestForTest(t, request),
+		); err == nil {
+			t.Fatalf("schema %d was accepted", schema)
+		}
+	}
+
+	for _, operation := range []string{"", "stop", "recover", "Reload", "reload ", "arbitrary-unknown-operation"} {
+		t.Run("operation_"+operation, func(t *testing.T) {
+			request := valid
+			request.Operation = operation
+			if _, err := decodeWakeReloadTransportRequest(
+				encodeWakeReloadTransportRequestForTest(t, request),
+			); err == nil {
+				t.Fatalf("operation %q was accepted", operation)
+			}
+		})
+	}
+
+	unknown := []byte(`{"schema":1,"operation":"reload","root":"/queue","agent":"codex","generation":"0123456789abcdef0123456789abcdef","owner":{"pid":4242},"candidate":{},"unknown":true}` + "\n")
+	if _, err := decodeWakeReloadTransportRequest(unknown); err == nil {
+		t.Fatal("unknown request field was accepted")
+	}
+	duplicateSchema := encodeWakeReloadTransportRequestForTest(t, valid)
+	duplicateSchema = []byte(strings.Replace(
+		string(duplicateSchema),
+		`"schema":1,`,
+		`"schema":1,"schema":1,`,
+		1,
+	))
+	if _, err := decodeWakeReloadTransportRequest(duplicateSchema); err == nil {
+		t.Fatal("duplicate request field was accepted")
+	}
+	if _, err := decodeWakeReloadTransportRequest(
+		append(encodeWakeReloadTransportRequestForTest(t, valid), []byte("{}\n")...),
+	); err == nil {
+		t.Fatal("trailing request object was accepted")
+	}
+	withoutTerminator := encodeWakeReloadTransportRequestForTest(t, valid)
+	withoutTerminator = withoutTerminator[:len(withoutTerminator)-1]
+	if _, err := decodeWakeReloadTransportRequest(withoutTerminator); err == nil {
+		t.Fatal("unterminated request was accepted")
+	}
+	oversized := make([]byte, wakeReloadTransportMaxRequestBytes+1)
+	if _, err := decodeWakeReloadTransportRequest(oversized); err == nil {
+		t.Fatal("oversized request was accepted")
+	}
+}
+
+func TestWakeReloadTransportResponseIsOnlyUnavailable(t *testing.T) {
+	response := wakeReloadTransportUnavailableResponse()
+	if response.Status != wakeReloadUnavailable ||
+		response.ReasonCode != wakeReloadReasonCommandUnavailable {
+		t.Fatalf("response = %#v", response)
+	}
+	payload, err := encodeWakeReloadTransportResponse(response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(payload), "{\"status\":\"unavailable\",\"reason_code\":\"reload_command_unavailable\"}\n"; got != want {
+		t.Fatalf("response wire = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/wake_reload_wiring_linux_test.go
+++ b/internal/cli/wake_reload_wiring_linux_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -101,6 +102,148 @@ func TestRunWakeWithLoopStartsUnadvertisedLinuxReloadTransportForOrdinaryOwner(t
 	}
 }
 
+func TestRunWakeWithLoopClassifiesOptionalLinuxReloadTransportStartFailures(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	ownerProcess := exec.Command("/bin/sh", "-c", "exec sleep 30")
+	if err := ownerProcess.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = ownerProcess.Process.Kill()
+		_ = ownerProcess.Wait()
+	})
+	owner := authoritativeOwnerForPIDForCoopWakeTest(t, ownerProcess.Process.Pid)
+	inspectProcess := inspectWakeProcess
+	wakeProcess := inspectProcess(os.Getpid())
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != os.Getpid() {
+			return inspectProcess(pid)
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: wakeProcess.StartToken,
+			BootID:     wakeProcess.BootID,
+			Executable: "/usr/local/bin/amq",
+			Args: []string{
+				"amq", "wake", "--root", root, "--me", "codex",
+				"--inject-mode", wakeInjectModeNone, "--interrupt=false",
+			},
+		}
+	})
+	encoded, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envWakeOwner, encoded)
+
+	startCalled := false
+	startFailure := errors.New("test reload bind failure")
+	oldStart := startWakeReloadTransportForWake
+	startWakeReloadTransportForWake = func(
+		_ *wakeAgentDir,
+		gotRoot string,
+		gotAgent string,
+		inspection wakeLockInspection,
+		gotOwner wakeOwner,
+	) (func(), error) {
+		startCalled = true
+		if gotRoot != canonicalWakeRoot(root) || gotAgent != "codex" || gotOwner != owner {
+			t.Fatalf("reload start identity = root %q agent %q owner %#v", gotRoot, gotAgent, gotOwner)
+		}
+		if !inspection.IdentityConfirmed {
+			t.Fatal("reload start did not receive confirmed lock identity")
+		}
+		return nil, &wakeReloadTransportUnavailableError{err: startFailure}
+	}
+	t.Cleanup(func() { startWakeReloadTransportForWake = oldStart })
+
+	loopCalled := false
+	var runErr error
+	stderr := captureWakeStderr(t, func() {
+		runErr = runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "codex",
+			"--inject-mode", wakeInjectModeNone,
+			"--interrupt=false",
+		}, func(wakeConfig) error {
+			loopCalled = true
+			if paths := linuxWakeReloadSocketPathsForTest(t, root, "codex"); len(paths) != 0 {
+				t.Fatalf("failed Linux reload endpoint paths = %#v", paths)
+			}
+			return nil
+		})
+	})
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	if !startCalled || !loopCalled {
+		t.Fatalf("reload start called = %v, loop called = %v", startCalled, loopCalled)
+	}
+	if !strings.Contains(stderr, "reload transport unavailable: "+startFailure.Error()) ||
+		!strings.Contains(stderr, "continuing without reload transport") {
+		t.Fatalf("reload transport degradation note = %q", stderr)
+	}
+
+	authorityFailure := errors.New("wake reload owner exited during startup")
+	startCalled = false
+	loopCalled = false
+	startWakeReloadTransportForWake = func(
+		_ *wakeAgentDir,
+		_ string,
+		_ string,
+		_ wakeLockInspection,
+		_ wakeOwner,
+	) (func(), error) {
+		startCalled = true
+		return nil, authorityFailure
+	}
+	stderr = captureWakeStderr(t, func() {
+		runErr = runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "codex",
+			"--inject-mode", wakeInjectModeNone,
+			"--interrupt=false",
+		}, func(wakeConfig) error {
+			loopCalled = true
+			return nil
+		})
+	})
+	if !errors.Is(runErr, authorityFailure) || !startCalled || loopCalled {
+		t.Fatalf("authority failure result = %v, start called = %v, loop called = %v", runErr, startCalled, loopCalled)
+	}
+	if strings.Contains(stderr, "continuing without reload transport") {
+		t.Fatalf("authority failure was narrated as degradable: %q", stderr)
+	}
+
+	startCalled = false
+	loopCalled = false
+	startWakeReloadTransportForWake = func(
+		_ *wakeAgentDir,
+		_ string,
+		_ string,
+		_ wakeLockInspection,
+		_ wakeOwner,
+	) (func(), error) {
+		startCalled = true
+		return nil, nil
+	}
+	runErr = runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "codex",
+		"--inject-mode", wakeInjectModeNone,
+		"--interrupt=false",
+	}, func(wakeConfig) error {
+		loopCalled = true
+		return nil
+	})
+	if runErr == nil || !strings.Contains(runErr.Error(), "returned no cleanup") ||
+		!startCalled || loopCalled {
+		t.Fatalf("nil cleanup result = %v, start called = %v, loop called = %v", runErr, startCalled, loopCalled)
+	}
+}
+
 func TestRunWakeWithLoopDoesNotStartLinuxReloadTransportOutsideOrdinaryOwner(t *testing.T) {
 	t.Run("ownerless", func(t *testing.T) {
 		root := secureTempDirForTest(t)
@@ -147,6 +290,71 @@ func TestRunWakeWithLoopDoesNotStartLinuxReloadTransportOutsideOrdinaryOwner(t *
 		})
 		if err != nil {
 			t.Fatal(err)
+		}
+	})
+
+	t.Run("unconfirmed lock identity", func(t *testing.T) {
+		root := secureTempDirForTest(t)
+		ensureCoopWakeMailboxForTest(t, root, "codex")
+		owner := currentAuthoritativeOwnerForCoopWakeTest(t)
+		encoded, err := encodeWakeOwnerEnv(owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(envWakeOwner, encoded)
+
+		ownerDone := make(chan struct{})
+		oldObserve := observeAuthoritativeWakeOwner
+		observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+			if got != owner {
+				t.Fatalf("observed owner = %#v, want %#v", got, owner)
+			}
+			return wakeOwnerObservation{State: wakeOwnerSame, done: ownerDone}, nil
+		}
+		t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+
+		process := inspectWakeProcess(os.Getpid())
+		stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+			if pid != os.Getpid() {
+				return inspectWakeProcessPlatform(pid)
+			}
+			process.Executable = "/tmp/not-amq"
+			return process
+		})
+		startCalled := false
+		oldStart := startWakeReloadTransportForWake
+		startWakeReloadTransportForWake = func(
+			_ *wakeAgentDir,
+			_ string,
+			_ string,
+			_ wakeLockInspection,
+			_ wakeOwner,
+		) (func(), error) {
+			startCalled = true
+			return nil, errors.New("reload transport must not start for unconfirmed identity")
+		}
+		t.Cleanup(func() { startWakeReloadTransportForWake = oldStart })
+
+		err = runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "codex",
+			"--inject-mode", wakeInjectModeNone,
+			"--interrupt=false",
+		}, func(wakeConfig) error {
+			inspection := inspectWakeLock(root, "codex")
+			if inspection.IdentityConfirmed {
+				t.Fatal("test lock identity unexpectedly confirmed")
+			}
+			if paths := linuxWakeReloadSocketPathsForTest(t, root, "codex"); len(paths) != 0 {
+				t.Fatalf("unconfirmed-identity Linux reload endpoint paths = %#v", paths)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if startCalled {
+			t.Fatal("reload transport start was attempted for unconfirmed identity")
 		}
 	})
 }

--- a/internal/cli/wake_reload_wiring_linux_test.go
+++ b/internal/cli/wake_reload_wiring_linux_test.go
@@ -1,0 +1,152 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func linuxWakeReloadSocketPathsForTest(t *testing.T, root, agent string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(fsq.AgentBase(root, agent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := make([]string, 0, 1)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".wr.") {
+			paths = append(paths, filepath.Join(fsq.AgentBase(root, agent), entry.Name()))
+		}
+	}
+	return paths
+}
+
+func TestRunWakeWithLoopStartsUnadvertisedLinuxReloadTransportForOrdinaryOwner(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	ownerProcess := exec.Command("/bin/sh", "-c", "exec sleep 30")
+	if err := ownerProcess.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = ownerProcess.Process.Kill()
+		_ = ownerProcess.Wait()
+	})
+	owner := authoritativeOwnerForPIDForCoopWakeTest(t, ownerProcess.Process.Pid)
+	inspectProcess := inspectWakeProcess
+	wakeProcess := inspectProcess(os.Getpid())
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != os.Getpid() {
+			return inspectProcess(pid)
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: wakeProcess.StartToken,
+			BootID:     wakeProcess.BootID,
+			Executable: "/usr/local/bin/amq",
+			Args: []string{
+				"amq", "wake", "--root", root, "--me", "codex",
+				"--inject-mode", wakeInjectModeNone, "--interrupt=false",
+			},
+		}
+	})
+	encoded, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envWakeOwner, encoded)
+
+	var endpointPath string
+	err = runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "codex",
+		"--inject-mode", wakeInjectModeNone,
+		"--interrupt=false",
+	}, func(wakeConfig) error {
+		paths := linuxWakeReloadSocketPathsForTest(t, root, "codex")
+		if len(paths) != 1 {
+			t.Fatalf("Linux reload endpoint paths = %#v, want exactly one", paths)
+		}
+		endpointPath = paths[0]
+		info, err := os.Lstat(endpointPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 {
+			t.Fatalf("Linux reload endpoint mode = %v", info.Mode())
+		}
+
+		inspection := inspectWakeLock(root, "codex")
+		if inspection.Lock.ResumeSchema != 0 || inspection.Lock.ResumeOwner != nil ||
+			inspection.Lock.ControlSocket != "" || inspection.Lock.RunningImageEvidence != nil {
+			t.Fatalf("Linux reload endpoint advertised resume metadata: %#v", inspection.Lock)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if endpointPath == "" {
+		t.Fatal("Linux reload endpoint was not observed")
+	}
+	if _, err := os.Lstat(endpointPath); !os.IsNotExist(err) {
+		t.Fatalf("Linux reload endpoint survived wake cleanup: %v", err)
+	}
+}
+
+func TestRunWakeWithLoopDoesNotStartLinuxReloadTransportOutsideOrdinaryOwner(t *testing.T) {
+	t.Run("ownerless", func(t *testing.T) {
+		root := secureTempDirForTest(t)
+		ensureCoopWakeMailboxForTest(t, root, "codex")
+		t.Setenv(envWakeOwner, "")
+
+		err := runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "codex",
+			"--inject-mode", wakeInjectModeNone,
+			"--interrupt=false",
+		}, func(wakeConfig) error {
+			if paths := linuxWakeReloadSocketPathsForTest(t, root, "codex"); len(paths) != 0 {
+				t.Fatalf("ownerless Linux reload endpoint paths = %#v", paths)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("inject-via", func(t *testing.T) {
+		root := secureTempDirForTest(t)
+		ensureCoopWakeMailboxForTest(t, root, "codex")
+		owner := currentAuthoritativeOwnerForCoopWakeTest(t)
+		encoded, err := encodeWakeOwnerEnv(owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(envWakeOwner, encoded)
+		injector := writeExecutableForTest(t, "linux-reload-injector")
+
+		err = runWakeWithLoop([]string{
+			"--root", root,
+			"--me", "codex",
+			"--inject-via", injector,
+			"--interrupt=false",
+		}, func(wakeConfig) error {
+			if paths := linuxWakeReloadSocketPathsForTest(t, root, "codex"); len(paths) != 0 {
+				t.Fatalf("inject-via Linux reload endpoint paths = %#v", paths)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/internal/cli/wake_resume_image_unix.go
+++ b/internal/cli/wake_resume_image_unix.go
@@ -28,6 +28,8 @@ func captureCurrentWakeImageEvidenceDefault() (wakeImageEvidenceV1, error) {
 	if err != nil {
 		return wakeImageEvidenceV1{}, fmt.Errorf("resolve current wake executable symlinks: %w", err)
 	}
+	// Resolving the process-reported pathname does not bind this open to the
+	// image actually executing. Keep it diagnostic on every platform.
 	return captureWakeImageEvidence(filepath.Clean(resolved), strings.TrimSpace(cliVersion))
 }
 
@@ -82,14 +84,10 @@ func captureWakeImageEvidence(path, embeddedVersion string) (wakeImageEvidenceV1
 		return wakeImageEvidenceV1{}, fmt.Errorf("wake image changed while hashing")
 	}
 
-	method := wakeImageMethodFDExec
-	if runtime.GOOS == "darwin" {
-		method = wakeImageMethodPathnameObserved
-	}
 	evidence := wakeImageEvidenceV1{
 		Schema:          wakeImageEvidenceSchemaV1,
 		Platform:        runtime.GOOS,
-		Method:          method,
+		Method:          wakeImageMethodPathnameObserved,
 		ExecutionPath:   path,
 		Device:          identity.Device,
 		Inode:           identity.Inode,

--- a/internal/cli/wake_resume_protocol.go
+++ b/internal/cli/wake_resume_protocol.go
@@ -20,10 +20,10 @@ const (
 	wakeImageMethodPathnameExecVerified = "pathname_execve_verified"
 )
 
-// wakeImageEvidenceV1 records image metadata and its authority method. Ordinary
-// Darwin wakes can observe only a mutable pathname after exec; the stronger
-// pathname_execve_verified method is reserved for a path authenticated
-// immediately before the corresponding execve.
+// wakeImageEvidenceV1 records image metadata and its authority method.
+// pathname_observed is diagnostic on every platform. Darwin reserves
+// pathname_execve_verified for a path authenticated immediately before execve;
+// Linux resume authority requires fd_exec evidence from the executing image.
 type wakeImageEvidenceV1 struct {
 	Schema          int    `json:"schema"`
 	Platform        string `json:"platform"`
@@ -40,6 +40,22 @@ type wakeImageEvidenceV1 struct {
 var errWakeResumeControlEndpointUnsupported = errors.New("wake resume control endpoint is unsupported")
 
 func validateWakeResumeAdvertisement(lock wakeLock, expectedRoot, expectedAgent string) error {
+	return validateWakeResumeAdvertisementWithContext(
+		lock,
+		expectedRoot,
+		expectedAgent,
+		runtime.GOOS,
+		wakeControlSocketPath(expectedRoot, expectedAgent, lock.Generation),
+	)
+}
+
+func validateWakeResumeAdvertisementWithContext(
+	lock wakeLock,
+	expectedRoot string,
+	expectedAgent string,
+	platform string,
+	expectedControlSocket string,
+) error {
 	if strings.TrimSpace(expectedRoot) == "" {
 		return fmt.Errorf("trusted wake resume root is empty")
 	}
@@ -56,9 +72,8 @@ func validateWakeResumeAdvertisement(lock wakeLock, expectedRoot, expectedAgent 
 	if lock.Agent != expectedAgent {
 		return fmt.Errorf("wake resume agent does not match the trusted agent")
 	}
-	expectedControlSocket := wakeControlSocketPath(expectedRoot, expectedAgent, lock.Generation)
 	if expectedControlSocket == "" {
-		return fmt.Errorf("%w on %s", errWakeResumeControlEndpointUnsupported, runtime.GOOS)
+		return fmt.Errorf("%w on %s", errWakeResumeControlEndpointUnsupported, platform)
 	}
 	if lock.ResumeSchema != wakeResumeSchemaV2 {
 		if lock.ResumeSchema == 0 {
@@ -90,12 +105,18 @@ func validateWakeResumeAdvertisement(lock wakeLock, expectedRoot, expectedAgent 
 	if lock.RunningImageEvidence == nil {
 		return fmt.Errorf("wake running image evidence is missing")
 	}
-	if err := validateWakeImageEvidence(*lock.RunningImageEvidence); err != nil {
+	if err := validateWakeImageEvidenceForPlatform(*lock.RunningImageEvidence, platform); err != nil {
 		return err
 	}
-	if runtime.GOOS == "darwin" &&
-		lock.RunningImageEvidence.Method != wakeImageMethodPathnameExecVerified {
-		return fmt.Errorf("wake running image evidence is not bound immediately before execve")
+	switch platform {
+	case "darwin":
+		if lock.RunningImageEvidence.Method != wakeImageMethodPathnameExecVerified {
+			return fmt.Errorf("wake running image evidence is not bound immediately before execve")
+		}
+	case "linux":
+		if lock.RunningImageEvidence.Method != wakeImageMethodFDExec {
+			return fmt.Errorf("wake running image evidence is not kernel-bound to the executing image")
+		}
 	}
 	if lock.ImagePath != lock.RunningImageEvidence.ExecutionPath {
 		return fmt.Errorf("wake image path does not match running image evidence")
@@ -115,16 +136,25 @@ func validateWakeResumeAdvertisement(lock wakeLock, expectedRoot, expectedAgent 
 }
 
 func validateWakeImageEvidence(evidence wakeImageEvidenceV1) error {
+	return validateWakeImageEvidenceForPlatform(evidence, runtime.GOOS)
+}
+
+func validateWakeImageEvidenceForPlatform(evidence wakeImageEvidenceV1, platform string) error {
 	if evidence.Schema != wakeImageEvidenceSchemaV1 {
 		return fmt.Errorf("wake image evidence schema %d unsupported", evidence.Schema)
 	}
-	if evidence.Platform != runtime.GOOS {
-		return fmt.Errorf("wake image platform %q does not match %q", evidence.Platform, runtime.GOOS)
+	if evidence.Platform != platform {
+		return fmt.Errorf("wake image platform %q does not match %q", evidence.Platform, platform)
 	}
-	if runtime.GOOS == "darwin" {
+	if platform == "darwin" {
 		if evidence.Method != wakeImageMethodPathnameObserved &&
 			evidence.Method != wakeImageMethodPathnameExecVerified {
 			return fmt.Errorf("wake image method %q does not match a Darwin pathname evidence method", evidence.Method)
+		}
+	} else if platform == "linux" {
+		if evidence.Method != wakeImageMethodPathnameObserved &&
+			evidence.Method != wakeImageMethodFDExec {
+			return fmt.Errorf("wake image method %q does not match a Linux image evidence method", evidence.Method)
 		}
 	} else if evidence.Method != wakeImageMethodFDExec {
 		return fmt.Errorf("wake image method %q does not match platform method %q", evidence.Method, wakeImageMethodFDExec)

--- a/internal/cli/wake_resume_protocol_unix_test.go
+++ b/internal/cli/wake_resume_protocol_unix_test.go
@@ -36,8 +36,50 @@ func TestCaptureWakeImageEvidenceBindsStableRegularExecutable(t *testing.T) {
 		evidence.Inode == 0 || evidence.CTimeNS <= 0 {
 		t.Fatalf("evidence = %#v", evidence)
 	}
+	if evidence.Method != wakeImageMethodPathnameObserved {
+		t.Fatalf("path-opened image method = %q, want observational evidence", evidence.Method)
+	}
 	if err := validateWakeImageEvidence(evidence); err != nil {
 		t.Fatalf("captured evidence is invalid: %v", err)
+	}
+}
+
+func TestLinuxFabricatedPathEvidenceCannotAuthorizeResume(t *testing.T) {
+	dir := secureTempDirForTest(t)
+	path := filepath.Join(dir, "fabricated-amq")
+	if err := os.WriteFile(path, []byte("not the running image\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	evidence, err := captureWakeImageEvidence(path, "0.50.2")
+	if err != nil {
+		t.Fatalf("capture fabricated path evidence: %v", err)
+	}
+	evidence.Platform = "linux"
+	if evidence.Method != wakeImageMethodPathnameObserved {
+		t.Fatalf("fabricated path evidence method = %q, want observational evidence", evidence.Method)
+	}
+	if err := validateWakeImageEvidenceForPlatform(evidence, "linux"); err != nil {
+		t.Fatalf("Linux observational image evidence should remain valid diagnostics: %v", err)
+	}
+
+	lock := validWakeResumeLockForTest()
+	lock.Root = canonicalWakeRoot("/queue")
+	lock.RunningImageEvidence = &evidence
+	lock.ImagePath = evidence.ExecutionPath
+	lock.ImageVersion = evidence.EmbeddedVersion
+	controlSocket := filepath.Join(fsq.AgentBase(lock.Root, lock.Agent), ".w.test-linux-resume")
+	lock.ControlSocket = controlSocket
+
+	err = validateWakeResumeAdvertisementWithContext(
+		lock,
+		lock.Root,
+		lock.Agent,
+		"linux",
+		controlSocket,
+	)
+	if err == nil || !strings.Contains(err.Error(), "kernel-bound") {
+		t.Fatalf("Linux fabricated path advertisement error = %v, want kernel-bound refusal", err)
 	}
 }
 

--- a/internal/cli/wake_resume_quiescence.go
+++ b/internal/cli/wake_resume_quiescence.go
@@ -5,7 +5,7 @@ package cli
 type wakeResumeDisposition uint8
 
 const (
-	wakeResumeReady wakeResumeDisposition = iota
+	wakeResumeProceed wakeResumeDisposition = iota
 	wakeResumeDefer
 	wakeResumeRefuse
 )
@@ -22,6 +22,15 @@ type wakeResumeScan uint8
 const (
 	wakeResumeScanTransientFailure wakeResumeScan = iota
 	wakeResumeScanComplete
+)
+
+type wakeResumeAuthorityObservation uint8
+
+const (
+	// The zero value is inconclusive so a partially populated proof cannot proceed.
+	wakeResumeAuthorityInconclusive wakeResumeAuthorityObservation = iota
+	wakeResumeAuthorityExact
+	wakeResumeAuthorityLost
 )
 
 const (
@@ -44,10 +53,19 @@ const (
 	wakeResumeReasonDebounceActive        = "debounce_callback_active"
 	wakeResumeReasonControlHandlers       = "control_handlers_active"
 	wakeResumeReasonControlListener       = "control_listener_unavailable"
-	wakeResumeReasonOwnerUnavailable      = "owner_unavailable"
-	wakeResumeReasonAuthorityUnverified   = "wake_authority_unverified"
 	wakeResumeReasonDirectoriesUnverified = "wake_directories_unverified"
 	wakeResumeReasonFinalScanIncomplete   = "final_inbox_scan_incomplete"
+)
+
+const (
+	wakeResumeReasonOwnerInconclusive            = "owner_observation_inconclusive"
+	wakeResumeReasonOwnerLost                    = "owner_identity_lost"
+	wakeResumeReasonTerminalIdentityInconclusive = "terminal_identity_inconclusive"
+	wakeResumeReasonTerminalIdentityLost         = "terminal_identity_lost"
+	wakeResumeReasonGenerationInconclusive       = "wake_generation_inconclusive"
+	wakeResumeReasonGenerationLost               = "wake_generation_lost"
+	wakeResumeReasonLockTargetInconclusive       = "wake_lock_target_inconclusive"
+	wakeResumeReasonLockTargetLost               = "wake_lock_target_lost"
 )
 
 type wakeResumeQuiescence struct {
@@ -73,13 +91,15 @@ type wakeResumeQuiescence struct {
 	WatcherRebindRetry           bool
 	UnreadableGenerationRecovery bool
 
-	DebounceExecuting    bool
-	ControlHandlers      uint
-	ControlListenerReady bool
-	OwnerLive            bool
-	AuthorityExact       bool
-	CanonicalDirs        bool
-	FinalScan            wakeResumeScan
+	DebounceExecuting           bool
+	ControlHandlers             uint
+	ControlListenerReady        bool
+	OwnerObservation            wakeResumeAuthorityObservation
+	TerminalIdentityObservation wakeResumeAuthorityObservation
+	GenerationObservation       wakeResumeAuthorityObservation
+	LockTargetObservation       wakeResumeAuthorityObservation
+	CanonicalDirs               bool
+	FinalScan                   wakeResumeScan
 
 	// These fields are deliberately not gates. Durable unread work and old
 	// doorbell/backoff state become an immediately-due fresh cohort after resume.
@@ -118,6 +138,14 @@ func classifyWakeResumeQuiescence(state wakeResumeQuiescence) wakeResumeQuiescen
 		return refuse(wakeResumeReasonInputProgress)
 	case state.Delivery.phase != wakeInputDeliveryIdle:
 		return refuse(wakeResumeReasonInputDelivery)
+	case state.OwnerObservation == wakeResumeAuthorityLost:
+		return refuse(wakeResumeReasonOwnerLost)
+	case state.TerminalIdentityObservation == wakeResumeAuthorityLost:
+		return refuse(wakeResumeReasonTerminalIdentityLost)
+	case state.GenerationObservation == wakeResumeAuthorityLost:
+		return refuse(wakeResumeReasonGenerationLost)
+	case state.LockTargetObservation == wakeResumeAuthorityLost:
+		return refuse(wakeResumeReasonLockTargetLost)
 	case state.InjectViaActive:
 		return deferReload(wakeResumeReasonInjectorActive)
 	case state.InjectorCleanupPending:
@@ -140,16 +168,20 @@ func classifyWakeResumeQuiescence(state wakeResumeQuiescence) wakeResumeQuiescen
 		return deferReload(wakeResumeReasonControlHandlers)
 	case !state.ControlListenerReady:
 		return deferReload(wakeResumeReasonControlListener)
-	case !state.OwnerLive:
-		return deferReload(wakeResumeReasonOwnerUnavailable)
-	case !state.AuthorityExact:
-		return deferReload(wakeResumeReasonAuthorityUnverified)
+	case state.OwnerObservation != wakeResumeAuthorityExact:
+		return deferReload(wakeResumeReasonOwnerInconclusive)
+	case state.TerminalIdentityObservation != wakeResumeAuthorityExact:
+		return deferReload(wakeResumeReasonTerminalIdentityInconclusive)
+	case state.GenerationObservation != wakeResumeAuthorityExact:
+		return deferReload(wakeResumeReasonGenerationInconclusive)
+	case state.LockTargetObservation != wakeResumeAuthorityExact:
+		return deferReload(wakeResumeReasonLockTargetInconclusive)
 	case !state.CanonicalDirs:
 		return deferReload(wakeResumeReasonDirectoriesUnverified)
 	case state.FinalScan != wakeResumeScanComplete:
 		return deferReload(wakeResumeReasonFinalScanIncomplete)
 	default:
-		return wakeResumeQuiescenceDecision{Disposition: wakeResumeReady}
+		return wakeResumeQuiescenceDecision{Disposition: wakeResumeProceed}
 	}
 }
 

--- a/internal/cli/wake_resume_quiescence_test.go
+++ b/internal/cli/wake_resume_quiescence_test.go
@@ -9,15 +9,24 @@ import (
 
 func readyWakeResumeQuiescenceForTest() wakeResumeQuiescence {
 	return wakeResumeQuiescence{
-		Lifecycle:            wakeResumeLifecycleAdmitted,
-		WatcherArmed:         true,
-		ControlListenerReady: true,
-		OwnerLive:            true,
-		AuthorityExact:       true,
-		CanonicalDirs:        true,
-		FinalScan:            wakeResumeScanComplete,
-		FinalScanMessages:    3,
-		PendingDoorbell:      true,
+		Lifecycle:                   wakeResumeLifecycleAdmitted,
+		WatcherArmed:                true,
+		ControlListenerReady:        true,
+		OwnerObservation:            wakeResumeAuthorityExact,
+		TerminalIdentityObservation: wakeResumeAuthorityExact,
+		GenerationObservation:       wakeResumeAuthorityExact,
+		LockTargetObservation:       wakeResumeAuthorityExact,
+		CanonicalDirs:               true,
+		FinalScan:                   wakeResumeScanComplete,
+		FinalScanMessages:           3,
+		PendingDoorbell:             true,
+	}
+}
+
+func TestWakeResumeAuthorityObservationZeroIsInconclusive(t *testing.T) {
+	var observation wakeResumeAuthorityObservation
+	if observation != wakeResumeAuthorityInconclusive {
+		t.Fatalf("zero observation = %v, want inconclusive", observation)
 	}
 }
 
@@ -89,6 +98,34 @@ func TestWakeResumeQuiescenceRefusesUntransferableStateWithoutMutation(t *testin
 				state.DestructiveInterrupt = true
 			},
 			reason: wakeResumeReasonDestructiveInterrupt,
+		},
+		{
+			name: "owner identity lost",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.OwnerObservation = wakeResumeAuthorityLost
+			},
+			reason: wakeResumeReasonOwnerLost,
+		},
+		{
+			name: "terminal identity lost",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.TerminalIdentityObservation = wakeResumeAuthorityLost
+			},
+			reason: wakeResumeReasonTerminalIdentityLost,
+		},
+		{
+			name: "generation lost",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.GenerationObservation = wakeResumeAuthorityLost
+			},
+			reason: wakeResumeReasonGenerationLost,
+		},
+		{
+			name: "lock or target lost",
+			mutate: func(state *wakeResumeQuiescence) {
+				state.LockTargetObservation = wakeResumeAuthorityLost
+			},
+			reason: wakeResumeReasonLockTargetLost,
 		},
 	}
 
@@ -167,8 +204,10 @@ func TestWakeResumeQuiescenceDefersTransientStateWithoutMutation(t *testing.T) {
 		{name: "one control handler", mutate: func(s *wakeResumeQuiescence) { s.ControlHandlers = 1 }, reason: wakeResumeReasonControlHandlers},
 		{name: "two control handlers", mutate: func(s *wakeResumeQuiescence) { s.ControlHandlers = 2 }, reason: wakeResumeReasonControlHandlers},
 		{name: "control listener unavailable", mutate: func(s *wakeResumeQuiescence) { s.ControlListenerReady = false }, reason: wakeResumeReasonControlListener},
-		{name: "owner unavailable", mutate: func(s *wakeResumeQuiescence) { s.OwnerLive = false }, reason: wakeResumeReasonOwnerUnavailable},
-		{name: "authority drift", mutate: func(s *wakeResumeQuiescence) { s.AuthorityExact = false }, reason: wakeResumeReasonAuthorityUnverified},
+		{name: "owner observation inconclusive", mutate: func(s *wakeResumeQuiescence) { s.OwnerObservation = wakeResumeAuthorityInconclusive }, reason: wakeResumeReasonOwnerInconclusive},
+		{name: "terminal identity inconclusive", mutate: func(s *wakeResumeQuiescence) { s.TerminalIdentityObservation = wakeResumeAuthorityInconclusive }, reason: wakeResumeReasonTerminalIdentityInconclusive},
+		{name: "generation inconclusive", mutate: func(s *wakeResumeQuiescence) { s.GenerationObservation = wakeResumeAuthorityInconclusive }, reason: wakeResumeReasonGenerationInconclusive},
+		{name: "lock or target inconclusive", mutate: func(s *wakeResumeQuiescence) { s.LockTargetObservation = wakeResumeAuthorityInconclusive }, reason: wakeResumeReasonLockTargetInconclusive},
 		{name: "directories unverified", mutate: func(s *wakeResumeQuiescence) { s.CanonicalDirs = false }, reason: wakeResumeReasonDirectoriesUnverified},
 		{name: "full scan incomplete", mutate: func(s *wakeResumeQuiescence) { s.FinalScan = wakeResumeScanTransientFailure }, reason: wakeResumeReasonFinalScanIncomplete},
 	}
@@ -198,7 +237,45 @@ func TestWakeResumeQuiescenceAllowsUnreadCohortAndExistingBackoff(t *testing.T) 
 
 	decision := classifyWakeResumeQuiescence(state)
 
-	if decision.Disposition != wakeResumeReady || decision.Reason != "" {
-		t.Fatalf("decision = %#v, want ready", decision)
+	if decision.Disposition != wakeResumeProceed || decision.Reason != "" {
+		t.Fatalf("decision = %#v, want proceed", decision)
 	}
+}
+
+func TestWakeResumeQuiescencePreservesRefuseAndDeferPrecedence(t *testing.T) {
+	t.Run("existing refusal precedes authority loss", func(t *testing.T) {
+		state := readyWakeResumeQuiescenceForTest()
+		state.RecoveryRequired = true
+		state.OwnerObservation = wakeResumeAuthorityLost
+
+		decision := classifyWakeResumeQuiescence(state)
+
+		if decision.Disposition != wakeResumeRefuse || decision.Reason != wakeResumeReasonInputRecovery {
+			t.Fatalf("decision = %#v, want input-recovery refusal", decision)
+		}
+	})
+
+	t.Run("authority loss precedes transient deferral", func(t *testing.T) {
+		state := readyWakeResumeQuiescenceForTest()
+		state.OwnerObservation = wakeResumeAuthorityLost
+		state.InjectViaActive = true
+
+		decision := classifyWakeResumeQuiescence(state)
+
+		if decision.Disposition != wakeResumeRefuse || decision.Reason != wakeResumeReasonOwnerLost {
+			t.Fatalf("decision = %#v, want owner-loss refusal", decision)
+		}
+	})
+
+	t.Run("existing transient deferral precedes inconclusive authority", func(t *testing.T) {
+		state := readyWakeResumeQuiescenceForTest()
+		state.InjectViaActive = true
+		state.OwnerObservation = wakeResumeAuthorityInconclusive
+
+		decision := classifyWakeResumeQuiescence(state)
+
+		if decision.Disposition != wakeResumeDefer || decision.Reason != wakeResumeReasonInjectorActive {
+			t.Fatalf("decision = %#v, want injector-active deferral", decision)
+		}
+	})
 }

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -142,6 +142,7 @@ func childRepairSource(lineage *wakeRepairLineage) wakeRepairHandoffSource {
 }
 
 var startWakeFromTarget = startWakeFromTargetDefault
+var startWakeReloadTransportForWake = startWakeReloadTransportInDir
 var afterExistingWakeReadyPublication = func() {}
 var waitForWakeRepairChildExit = func(waiter *wakeProcessWaiter) error {
 	return waiter.waitForExit(wakeProcessExitTimeout)
@@ -2286,7 +2287,10 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		}
 	}
 
-	if reloadTransportEligible {
+	// Reload transport is additive capability. If this process cannot confirm
+	// the freshly published lock identity, keep the ordinary notifier running
+	// without opening the unadvertised endpoint.
+	if reloadTransportEligible && currentWake.IdentityConfirmed {
 		if requestedOwner == nil {
 			return fmt.Errorf("wake reload transport requires an exact owner")
 		}
@@ -2295,17 +2299,28 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			return fmt.Errorf("requested wake owner observation ended before reload transport startup")
 		default:
 		}
-		cleanupReloadTransport, err := startWakeReloadTransportInDir(
+		stopReloadTransport, startErr := startWakeReloadTransportForWake(
 			activeAgentDir,
 			root,
 			me,
 			currentWake,
 			*requestedOwner,
 		)
-		if err != nil {
-			return err
+		if startErr != nil {
+			var unavailable *wakeReloadTransportUnavailableError
+			if !errors.As(startErr, &unavailable) {
+				return startErr
+			}
+			_ = writeStderr(
+				"amq wake: reload transport unavailable: %v; continuing without reload transport\n",
+				startErr,
+			)
+		} else {
+			if stopReloadTransport == nil {
+				return fmt.Errorf("wake reload transport returned no cleanup")
+			}
+			defer stopReloadTransport()
 		}
-		defer cleanupReloadTransport()
 	}
 
 	return loop(cfg)

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -1918,6 +1918,14 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		lockWakeMode = effectiveInjectMode(&wakeConfig{me: me, injectMode: lockWakeMode})
 	}
 	acceptExistingDeadline := time.Now().Add(wakeReadyTimeout)
+	resumeEligible := wakeResumeStartupEligible(
+		requestedOwner,
+		repairLineage != nil,
+		*injectCmdFlag,
+		interruptKey,
+		lockWakeMode,
+	)
+	reloadTransportEligible := resumeEligible && target == nil
 	var cleanup func()
 	var repairFloorAuthority wakeRepairFloorAuthority
 	for {
@@ -1935,13 +1943,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			wakeMode:                lockWakeMode,
 			requestedOwner:          requestedOwner,
 			repairLineage:           repairLineage,
-			resumeEligible: wakeResumeStartupEligible(
-				requestedOwner,
-				repairLineage != nil,
-				*injectCmdFlag,
-				interruptKey,
-				lockWakeMode,
-			),
+			resumeEligible:          resumeEligible,
 		}
 		if repairLineage != nil {
 			options.repairFloorAuthority = &repairFloorAuthority
@@ -2282,6 +2284,28 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			}
 			return writeWakeRepairFloorInDir(activeAgentDir, root, floor)
 		}
+	}
+
+	if reloadTransportEligible {
+		if requestedOwner == nil {
+			return fmt.Errorf("wake reload transport requires an exact owner")
+		}
+		select {
+		case <-ownerObservation.Done():
+			return fmt.Errorf("requested wake owner observation ended before reload transport startup")
+		default:
+		}
+		cleanupReloadTransport, err := startWakeReloadTransportInDir(
+			activeAgentDir,
+			root,
+			me,
+			currentWake,
+			*requestedOwner,
+		)
+		if err != nil {
+			return err
+		}
+		defer cleanupReloadTransport()
 	}
 
 	return loop(cfg)


### PR DESCRIPTION
## Summary

- decompose provisional resume authority into independent owner, terminal, generation, and lock/target observations
- add an authenticated, unadvertised Linux reload-only endpoint that can return only `unavailable/reload_command_unavailable`
- keep Linux pathname image evidence diagnostic-only and preserve the hard schema-v2/public-ready fence
- share the canonical lifecycle-guard verification path while using nonblocking acquisition for request authentication

## Verification

- `make ci`
- Windows amd64, Darwin arm64, Linux amd64, and FreeBSD amd64 builds
- focused Darwin authority/image/transport/lifecycle suites
- real Linux ARM64 Docker endpoint and runtime-wiring suite, including SO_PEERCRED, pidfd, same-session/setsid, FD/OOB closure, bounded shutdown, substitution/publication/retirement races, and advertisement fences
- independent exact-tree peer execution: Darwin 99 PASS / 0 FAIL; Linux 38 PASS / 0 FAIL (count=2)

## Explicit non-goals

- no `amq wake reload` command, pending-request channel, attempt allocation, or main-loop event
- no accepted/transferred candidate FD and no `/proc/self/exe` running-image authority
- no marker/status records, preflight, exec backend/rollback, argv/environment builder, resume bootstrap, image revision, full rescan, or cohort reset
- no Linux legacy cooperative stop/recover, inject-via widening, or Darwin stop-wire refactor
- no persisted partial Linux resume metadata, `agent_safe` claim, or public `ready` status

## Review binding

Peer `BOUND PASS` was reproduced against staged tree `7885719c2b06b14b3e11988f7200aa371a236012` and patch SHA256 `fe0a995db32f21b99a029c7b9c51c8cdd9ac8071dd1d5c8523bba3e129b9ea5e` before commit.

Linux cleanup is sound under the repository's cooperative same-UID model. It preserves mismatched objects and successors, but does not claim uninterrupted public-path ownership against a hostile same-UID replacer.
