### PR TITLE
test(wake): pin crash-interleaving contract at publication boundaries

### DIFF
--- a/internal/cli/wake_crash_contract_linux_test.go
+++ b/internal/cli/wake_crash_contract_linux_test.go
@@ -1,0 +1,147 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCrashContractLifecycleGuardIsReleasedBeforePidfdWait(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID: wakePID, TTY: "/dev/amq-crash-contract-missing-tty",
+		ProcessStart: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
+	})
+	releasePoll := make(chan struct{})
+	inspectCalls := 0
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		inspectCalls++
+		if inspectCalls > 1 {
+			select {
+			case <-releasePoll:
+				return wakeProcessInfo{PID: pid, Running: false}
+			default:
+			}
+		}
+		return matchingLinuxWakeProcess(pid, root)
+	})
+	pollEntered := make(chan struct{})
+	stubLinuxPidfd(
+		t,
+		func(int, int) (int, error) { return 99, nil },
+		func(int, unix.Signal, *unix.Siginfo, int) error { return nil },
+		func(int, time.Duration) (bool, error) {
+			close(pollEntered)
+			<-releasePoll
+			return true, nil
+		},
+	)
+
+	inspection := inspectWakeLock(root, "codex")
+	done := make(chan error, 1)
+	go func() {
+		_, err := terminateAndRemoveOrphanedWakeLock(inspection)
+		done <- err
+	}()
+	select {
+	case <-pollEntered:
+	case <-time.After(time.Second):
+		t.Fatal("pidfd wait was not reached")
+	}
+
+	guardResult := make(chan error, 1)
+	go func() {
+		guardResult <- withWakeLifecycleGuard(root, "codex", func() error { return nil })
+	}()
+	select {
+	case err := <-guardResult:
+		if err != nil {
+			t.Fatalf("acquire lifecycle guard during wait: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pidfd wait retained lifecycle guard")
+	}
+	close(releasePoll)
+	if err := <-done; err != nil {
+		t.Fatalf("terminate after releasing pidfd wait: %v", err)
+	}
+}
+
+func TestCrashContractReloadEndpointRejectsGenerationMismatch(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = endpoint.Close() }()
+
+	request := fixture.request()
+	request.Generation = "1123456789abcdef0123456789abcdef"
+	response, err := sendLinuxWakeReloadTransportRequest(t, fixture, endpoint, request)
+	requireLinuxWakeReloadSilentRefusal(t, response, err)
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if !sameWakeLockGeneration(fixture.expected, current) {
+		t.Fatalf("generation-mismatch request changed lock: %#v", current)
+	}
+	if err := syscall.Kill(fixture.owner.PID, 0); err != nil {
+		t.Fatalf("generation-mismatch request signaled owner: %v", err)
+	}
+}
+
+func TestCrashContractReloadPublicationFailureLeavesNoEndpoint(t *testing.T) {
+	fixture := newLinuxWakeReloadTransportFixture(t)
+	path := linuxWakeReloadTransportPath(
+		fixture.root,
+		fixture.agent,
+		fixture.expected.Lock.Generation,
+	)
+	publicationFailure := errors.New("crash before reload endpoint publication")
+	originalBeforePublish := linuxWakeReloadBeforePublish
+	linuxWakeReloadBeforePublish = func(int, string, string) error {
+		return publicationFailure
+	}
+	t.Cleanup(func() { linuxWakeReloadBeforePublish = originalBeforePublish })
+
+	endpoint, err := startLinuxWakeReloadTransport(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.expected,
+		fixture.owner,
+		500*time.Millisecond,
+	)
+	if endpoint != nil || !errors.Is(err, publicationFailure) {
+		t.Fatalf("reload publication failure endpoint=%#v err=%v", endpoint, err)
+	}
+	var unavailable *wakeReloadTransportUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("reload publication failure was not classified unavailable: %v", err)
+	}
+	if _, statErr := os.Lstat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("reload publication failure left public endpoint: %v", statErr)
+	}
+	entries, readErr := os.ReadDir(fixture.agentDir.path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".wr.stage.") {
+			t.Fatalf("reload publication failure left staging endpoint %q", entry.Name())
+		}
+	}
+}

--- a/internal/cli/wake_crash_contract_unix_test.go
+++ b/internal/cli/wake_crash_contract_unix_test.go
@@ -1,0 +1,291 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestCrashContractTargetPublicationFailureBeforeLockPreservesInstalledTarget(t *testing.T) {
+	root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+	originalLink := publishAuthoritativeWakeLinkAt
+	publishAuthoritativeWakeLinkAt = func(int, string, int, string, int) error {
+		return syscall.EIO
+	}
+	t.Cleanup(func() { publishAuthoritativeWakeLinkAt = originalLink })
+
+	_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if !errors.Is(err, syscall.EIO) {
+		t.Fatalf("target-before-lock publication error = %v, want EIO", err)
+	}
+	if inspection := inspectWakeLock(root, "codex"); inspection.Exists {
+		t.Fatalf("target-before-lock failure left lock: %#v", inspection)
+	}
+	persisted, exists, readErr := readWakeTarget(root, "codex")
+	if readErr != nil || !exists || !sameWakeTarget(persisted, target) {
+		t.Fatalf("target-before-lock failure target=%#v exists=%v err=%v", persisted, exists, readErr)
+	}
+}
+
+func TestCrashContractLockReplacementIsRejectedByEveryFDReader(t *testing.T) {
+	readers := []struct {
+		name string
+		read func(int, *wakeAgentDir, string, string) wakeLockInspection
+	}{
+		{name: "inspection", read: inspectWakeLockAt},
+		{name: "metadata", read: readWakeLockMetadataAt},
+	}
+	for _, reader := range readers {
+		t.Run(reader.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			lock := wakeLock{PID: 4242, Generation: "reader-generation"}
+			lockPath := writeWakeLockForTest(t, root, "codex", lock)
+			agentDir, err := openWakeAgentDir(root, "codex")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = agentDir.Close() }()
+
+			originalAfterRead := afterWakeLockAtRead
+			afterWakeLockAtRead = func() {
+				afterWakeLockAtRead = func() {}
+				data, marshalErr := json.Marshal(lock)
+				if marshalErr != nil {
+					t.Fatal(marshalErr)
+				}
+				replacement := lockPath + ".replacement"
+				if writeErr := os.WriteFile(replacement, data, 0o600); writeErr != nil {
+					t.Fatal(writeErr)
+				}
+				if renameErr := os.Rename(replacement, lockPath); renameErr != nil {
+					t.Fatal(renameErr)
+				}
+			}
+			t.Cleanup(func() { afterWakeLockAtRead = originalAfterRead })
+
+			var inspection wakeLockInspection
+			if err := agentDir.withFD(func(dirfd int) error {
+				inspection = reader.read(dirfd, agentDir, root, "codex")
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			var changed *wakeSnapshotReadChangedError
+			if inspection.Status != wakeLockUnverified ||
+				!errors.As(inspection.observationErr, &changed) {
+				t.Fatalf("replacement reader result = %#v, want typed unverified snapshot", inspection)
+			}
+		})
+	}
+}
+
+func TestCrashContractPreparedMarkerDistinguishesStaleAndCurrentGeneration(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := os.MkdirAll(filepath.Dir(wakePreparedPath(root, "codex")), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	current := wakeLockInspection{
+		Exists:            true,
+		Status:            wakeLockValid,
+		IdentityConfirmed: true,
+		Root:              canonicalWakeRoot(root),
+		Agent:             "codex",
+		Lock: wakeLock{
+			Root:       canonicalWakeRoot(root),
+			Agent:      "codex",
+			Generation: "current-generation",
+		},
+	}
+	for _, test := range []struct {
+		name       string
+		generation string
+		wantReady  bool
+	}{
+		{name: "stale", generation: "stale-generation"},
+		{name: "current", generation: current.Lock.Generation, wantReady: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := writeWakeGenerationFile(
+				wakePreparedPath(root, "codex"),
+				"wake prepared marker",
+				wakeReady{Schema: wakeReadySchema, Generation: test.generation},
+			); err != nil {
+				t.Fatal(err)
+			}
+			ready, err := validateWakePreparedFileAgainstInspection(root, "codex", current)
+			if err != nil || ready != test.wantReady {
+				t.Fatalf("prepared generation %q ready=%v err=%v, want %v", test.generation, ready, err, test.wantReady)
+			}
+		})
+	}
+}
+
+func TestCrashContractReadinessCleanupPreservesReplacement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wake.ready")
+	publication, err := publishWakeReadyFile(path, wakeReady{
+		Schema: wakeReadySchema, Generation: "original-generation",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = publication.Close() }()
+	replacement := wakeReady{Schema: wakeReadySchema, Generation: "replacement-generation"}
+	originalBeforeCleanup := beforeWakeReadyCleanupUnlink
+	beforeWakeReadyCleanupUnlink = func() {
+		beforeWakeReadyCleanupUnlink = func() {}
+		if err := writeWakeGenerationFile(path, "replacement wake ready file", replacement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { beforeWakeReadyCleanupUnlink = originalBeforeCleanup })
+
+	err = publication.removeIfUnchanged()
+	if err == nil || !strings.Contains(err.Error(), "preserving") {
+		t.Fatalf("replacement readiness cleanup error = %v, want preservation", err)
+	}
+	got, exists, readErr := readWakeReadyFile(path)
+	if readErr != nil || !exists || got != replacement {
+		t.Fatalf("replacement readiness = %#v exists=%v err=%v", got, exists, readErr)
+	}
+}
+
+func TestCrashContractPublicationHooksLeaveRecoverableVisibleStates(t *testing.T) {
+	t.Run("target renamed before lock", func(t *testing.T) {
+		root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+		crash := errors.New("crash after target publication")
+		original := publishAuthoritativeWakeAfterTargetRename
+		publishAuthoritativeWakeAfterTargetRename = func() { panic(crash) }
+		t.Cleanup(func() { publishAuthoritativeWakeAfterTargetRename = original })
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != crash {
+					t.Fatalf("target publication panic = %v, want crash sentinel", recovered)
+				}
+			}()
+			_, _ = acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+				target: &target, wakeMode: wakeTargetInjectVia,
+			})
+		}()
+		if inspectWakeLock(root, "codex").Exists {
+			t.Fatal("target-publication crash exposed a lock")
+		}
+		persisted, exists, err := readWakeTarget(root, "codex")
+		if err != nil || !exists || !sameWakeTarget(persisted, target) {
+			t.Fatalf("target-publication crash target=%#v exists=%v err=%v", persisted, exists, err)
+		}
+	})
+
+	t.Run("lock linked before directory sync", func(t *testing.T) {
+		root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+		crash := errors.New("crash after lock publication")
+		originalLink := publishAuthoritativeWakeLinkAt
+		publishAuthoritativeWakeLinkAt = func(
+			oldDirFD int,
+			oldPath string,
+			newDirFD int,
+			newPath string,
+			flags int,
+		) error {
+			if err := originalLink(oldDirFD, oldPath, newDirFD, newPath, flags); err != nil {
+				return err
+			}
+			panic(crash)
+		}
+		t.Cleanup(func() { publishAuthoritativeWakeLinkAt = originalLink })
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != crash {
+					t.Fatalf("lock publication panic = %v, want crash sentinel", recovered)
+				}
+			}()
+			_, _ = acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+				target: &target, wakeMode: wakeTargetInjectVia,
+			})
+		}()
+		inspection := inspectWakeLock(root, "codex")
+		if !inspection.Exists || classifyPersistedWakeClaim(inspection) != wakeClaimAuthoritative {
+			t.Fatalf("lock-publication crash claim = %#v, want authoritative", inspection)
+		}
+		persisted, exists, err := readWakeTarget(root, "codex")
+		if err != nil || !exists || !sameWakeTarget(persisted, target) {
+			t.Fatalf("lock-publication crash target=%#v exists=%v err=%v", persisted, exists, err)
+		}
+	})
+
+	t.Run("target directory sync fails", func(t *testing.T) {
+		root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+		syncFailure := errors.New("crash at target directory sync")
+		originalSync := syncWakeOwnerDirFD
+		syncWakeOwnerDirFD = func(int) error { return syncFailure }
+		t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
+
+		_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+			target: &target, wakeMode: wakeTargetInjectVia,
+		})
+		if !errors.Is(err, syncFailure) || inspectWakeLock(root, "codex").Exists {
+			t.Fatalf("target-sync failure err=%v lock=%#v", err, inspectWakeLock(root, "codex"))
+		}
+		persisted, exists, readErr := readWakeTarget(root, "codex")
+		if readErr != nil || !exists || !sameWakeTarget(persisted, target) {
+			t.Fatalf("target-sync failure target=%#v exists=%v err=%v", persisted, exists, readErr)
+		}
+	})
+
+	t.Run("final lock directory sync fails", func(t *testing.T) {
+		root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+		syncFailure := errors.New("crash at final lock directory sync")
+		originalSync := syncWakeOwnerDirFD
+		syncCalls := 0
+		syncWakeOwnerDirFD = func(fd int) error {
+			syncCalls++
+			if syncCalls == 2 {
+				return syncFailure
+			}
+			return originalSync(fd)
+		}
+		t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
+
+		_, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+			target: &target, wakeMode: wakeTargetInjectVia,
+		})
+		inspection := inspectWakeLock(root, "codex")
+		if !errors.Is(err, syncFailure) ||
+			!inspection.Exists || classifyPersistedWakeClaim(inspection) != wakeClaimAuthoritative {
+			t.Fatalf("final-sync failure err=%v claim=%#v", err, inspection)
+		}
+		persisted, exists, readErr := readWakeTarget(root, "codex")
+		if readErr != nil || !exists || !sameWakeTarget(persisted, target) {
+			t.Fatalf("final-sync failure target=%#v exists=%v err=%v", persisted, exists, readErr)
+		}
+	})
+
+	t.Run("ready written before validation", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "wake.ready")
+		marker := wakeReady{Schema: wakeReadySchema, Generation: "ready-generation"}
+		crash := errors.New("crash after ready publication")
+		original := afterWakeReadyPublicationWrite
+		afterWakeReadyPublicationWrite = func() { panic(crash) }
+		t.Cleanup(func() { afterWakeReadyPublicationWrite = original })
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != crash {
+					t.Fatalf("ready publication panic = %v, want crash sentinel", recovered)
+				}
+			}()
+			_, _ = publishWakeReadyFile(path, marker)
+		}()
+		persisted, exists, err := readWakeReadyFile(path)
+		if err != nil || !exists || persisted != marker {
+			t.Fatalf("ready-publication crash marker=%#v exists=%v err=%v", persisted, exists, err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add deterministic crash/interleaving contract tests at current wake publication boundaries
- cover target-before-lock, lock replacement readers, prepared generations, ready cleanup, guard release before pidfd wait, reload generation refusal, and publication crash states
- establish W0 as the P2a acceptance floor for any lifecycle-state consolidation

## Verification
- Claude exact-tree bind: tree 75c1933b / delta 0e285db9
- macOS focused suite: PASS
- real Linux Docker focused suite: PASS
- GOOS Linux and Windows builds: PASS
- full `make ci`: PASS on second run; first run exposed baseline issue #408, then isolated 5/5 and full rerun passed

## Explicit seam boundaries
These current-behavior interleavings remain unsupported until P2a adds deliberate seams; they are recorded rather than silently approximated:

- target reader: `internal/cli/wake_owner_storage_unix.go:360-419`
- prepared/ready FD reader: `internal/cli/wake_lock_at_unix.go:196-264`
- public ready reader: `internal/cli/wake_ready_unix.go:184-223`
- temp creation/write/fsync: `internal/cli/wake_owner_storage_unix.go:242-282`
- lock-temp removal: `internal/cli/wake_owner_storage_unix.go:166`

P2a must add seams before changing those reader/publication boundaries.