### PR TITLE
test(wake): reap detached test children unconditionally

### DIFF
--- a/internal/cli/coop_raw_injection_adversarial_unix_test.go
+++ b/internal/cli/coop_raw_injection_adversarial_unix_test.go
@@ -264,17 +264,19 @@ func deliverAdversarialWakeMessage(t *testing.T, root, me string, message format
 }
 
 type publicCoopPTYFixture struct {
-	root          string
-	ownerPath     string
-	linePath      string
-	interruptPath string
-	cmd           *exec.Cmd
-	done          chan error
-	output        *bytes.Buffer
-	stdin         *os.File
-	ownerPID      int
-	wakeClaim     *wakeLockInspection
-	waited        bool
+	root           string
+	ownerPath      string
+	linePath       string
+	interruptPath  string
+	cmd            *exec.Cmd
+	processGroup   int
+	commandPIDPath string
+	done           chan error
+	output         *bytes.Buffer
+	stdin          *os.File
+	ownerPID       int
+	wakeClaim      *wakeLockInspection
+	waited         bool
 }
 
 func startPublicCoopPTYFixture(t *testing.T, mode string) *publicCoopPTYFixture {
@@ -286,6 +288,7 @@ func startPublicCoopPTYFixture(t *testing.T, mode string) *publicCoopPTYFixture 
 	linePath := filepath.Join(dir, "terminal-line")
 	interruptPath := filepath.Join(dir, "interrupt")
 	agentPath := filepath.Join(dir, "agent.sh")
+	commandPIDPath := filepath.Join(dir, "command.pid")
 	agentScript := `#!/bin/sh
 set -eu
 owner_path=$1
@@ -323,8 +326,13 @@ done
 	if err := os.WriteFile(amqBinary, testData, 0o700); err != nil {
 		t.Fatalf("write hermetic amq binary: %v", err)
 	}
+	commandScript := `printf '%s\n' "$$" > "$1"
+shift
+exec "$@"
+`
 	args := []string{
 		"-q", "/dev/null",
+		"/bin/sh", "-c", commandScript, "amq-command", commandPIDPath,
 		amqBinary,
 		"--no-update-check",
 		"coop", "exec",
@@ -340,6 +348,7 @@ done
 	}
 	output := &bytes.Buffer{}
 	cmd := exec.Command("/usr/bin/script", args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Env = append(os.Environ(), cliHelperEnv+"=1", "AMQ_NO_UPDATE_CHECK=1")
 	cmd.Stdout = output
 	cmd.Stderr = output
@@ -353,20 +362,17 @@ done
 		_ = stdinWriter.Close()
 		t.Fatalf("start public coop PTY: %v", err)
 	}
-	if err := stdinReader.Close(); err != nil {
-		_ = stdinWriter.Close()
-		_ = cmd.Process.Kill()
-		t.Fatalf("close parent PTY stdin reader: %v", err)
-	}
 	fixture := &publicCoopPTYFixture{
-		root:          root,
-		ownerPath:     ownerPath,
-		linePath:      linePath,
-		interruptPath: interruptPath,
-		cmd:           cmd,
-		done:          make(chan error, 1),
-		output:        output,
-		stdin:         stdinWriter,
+		root:           root,
+		ownerPath:      ownerPath,
+		linePath:       linePath,
+		interruptPath:  interruptPath,
+		cmd:            cmd,
+		processGroup:   cmd.Process.Pid,
+		commandPIDPath: commandPIDPath,
+		done:           make(chan error, 1),
+		output:         output,
+		stdin:          stdinWriter,
 	}
 	go func() { fixture.done <- cmd.Wait() }()
 	t.Cleanup(func() {
@@ -375,13 +381,23 @@ done
 			fixture.stdin = nil
 		}
 		if !fixture.waited && fixture.cmd.Process != nil {
+			if fixture.processGroup > 1 {
+				_ = syscall.Kill(-fixture.processGroup, syscall.SIGKILL)
+			}
+			if data, err := os.ReadFile(fixture.commandPIDPath); err == nil {
+				if commandPID, parseErr := strconv.Atoi(strings.TrimSpace(string(data))); parseErr == nil && commandPID > 1 {
+					_ = syscall.Kill(-commandPID, syscall.SIGKILL)
+				}
+			}
 			if fixture.ownerPID > 1 {
 				_ = syscall.Kill(fixture.ownerPID, syscall.SIGKILL)
 			}
 			_ = fixture.cmd.Process.Kill()
 			select {
 			case <-fixture.done:
+				fixture.waited = true
 			case <-time.After(3 * time.Second):
+				t.Errorf("public coop PTY cleanup did not join process group %d after SIGKILL", fixture.processGroup)
 			}
 		}
 		if fixture.wakeClaim != nil {
@@ -392,6 +408,9 @@ done
 			}
 		}
 	})
+	if err := stdinReader.Close(); err != nil {
+		t.Fatalf("close parent PTY stdin reader: %v", err)
+	}
 	return fixture
 }
 

--- a/internal/cli/coop_wake_owner_lifecycle_unix_test.go
+++ b/internal/cli/coop_wake_owner_lifecycle_unix_test.go
@@ -365,17 +365,19 @@ exit 0
 `
 			cmd := exec.Command("/bin/sh", "-c", script, "sh", descendantPath, exitGate, exitKind)
 			cmd.ExtraFiles = []*os.File{writeEnd}
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 			if err := cmd.Start(); err != nil {
 				_ = writeEnd.Close()
 				t.Fatalf("start owner: %v", err)
 			}
-			_ = writeEnd.Close()
+			ownerProcessGroup := cmd.Process.Pid
 			t.Cleanup(func() {
+				_ = syscall.Kill(-ownerProcessGroup, syscall.SIGKILL)
 				if cmd.Process != nil && cmd.ProcessState == nil {
-					_ = cmd.Process.Kill()
 					_, _ = cmd.Process.Wait()
 				}
 			})
+			_ = writeEnd.Close()
 
 			waitForCoopWakePathForTest(t, descendantPath, 3*time.Second)
 			owner := authoritativeOwnerForPIDForCoopWakeTest(t, cmd.Process.Pid)
@@ -407,9 +409,6 @@ exit 0
 			if err != nil {
 				t.Fatalf("find descendant: %v", err)
 			}
-			t.Cleanup(func() {
-				_ = descendant.Kill()
-			})
 			if err := descendant.Signal(syscall.Signal(0)); err != nil {
 				t.Fatalf("FD-inheriting descendant is not alive: %v", err)
 			}
@@ -801,10 +800,12 @@ func TestWakeSignalIsCapturedBeforeReadinessPublication(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start signal helper: %v", err)
 	}
+	waiter := newWakeProcessWaiter(cmd.Process)
 	t.Cleanup(func() {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
+		_ = waiter.waitForExit(time.Second)
 	})
 	waitForCoopWakePathForTest(t, marker, 3*time.Second)
 
@@ -815,13 +816,11 @@ func TestWakeSignalIsCapturedBeforeReadinessPublication(t *testing.T) {
 	if err := os.WriteFile(release, []byte("continue\n"), 0o600); err != nil {
 		t.Fatalf("release preparation: %v", err)
 	}
-	waitDone := make(chan error, 1)
-	go func() { waitDone <- cmd.Wait() }()
 	select {
-	case err := <-waitDone:
+	case <-waiter.done:
 		cmd.Process = nil
-		if err != nil {
-			t.Fatalf("pre-readiness SIGTERM was not handled gracefully: %v", err)
+		if waiter.err != nil {
+			t.Fatalf("pre-readiness SIGTERM was not handled gracefully: %v", waiter.err)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("signal helper did not exit")

--- a/internal/cli/wake_control_darwin_test.go
+++ b/internal/cli/wake_control_darwin_test.go
@@ -821,11 +821,15 @@ func TestDarwinOwnerWakeChildStopsThroughInheritedPrivateFD(t *testing.T) {
 		_ = capability.Close()
 		t.Fatal(err)
 	}
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 	if err := capability.Bind(cmd.Process); err != nil {
 		_ = capability.Close()
 		t.Fatal(err)
 	}
-	waiter := newWakeProcessWaiter(cmd.Process)
 	if err := capability.Stop(); err != nil {
 		_ = capability.Close()
 		t.Fatal(err)
@@ -850,11 +854,15 @@ func TestDarwinOwnerWakeChildAlreadyExitedStillClosesStableCapability(t *testing
 		_ = capability.Close()
 		t.Fatal(err)
 	}
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 	if err := capability.Bind(cmd.Process); err != nil {
 		_ = capability.Close()
 		t.Fatal(err)
 	}
-	waiter := newWakeProcessWaiter(cmd.Process)
 	if err := waiter.waitForExit(2 * time.Second); err != nil {
 		_ = capability.Close()
 		t.Fatal(err)

--- a/internal/cli/wake_owner_observation_darwin_test.go
+++ b/internal/cli/wake_owner_observation_darwin_test.go
@@ -275,20 +275,15 @@ while [ ! -e "$3" ]; do sleep 0.01; done
 exit 0
 `
 	cmd := exec.Command("/bin/sh", "-c", script, "sh", descendantPath, ready, release)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start owner: %v", err)
 	}
+	ownerProcessGroup := cmd.Process.Pid
 	t.Cleanup(func() {
+		_ = syscall.Kill(-ownerProcessGroup, syscall.SIGKILL)
 		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
 			_, _ = cmd.Process.Wait()
-		}
-		if data, err := os.ReadFile(descendantPath); err == nil {
-			if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
-				if descendant, err := os.FindProcess(pid); err == nil {
-					_ = descendant.Kill()
-				}
-			}
 		}
 	})
 	waitForDarwinWakeObservationPath(t, ready)

--- a/internal/cli/wake_repair_continuity_unix_test.go
+++ b/internal/cli/wake_repair_continuity_unix_test.go
@@ -90,18 +90,12 @@ func TestWakeRepairNotifiesMessageDeliveredDuringDowntime(t *testing.T) {
 		"--json",
 	)
 	repair.Env = wakeContinuityCLIEnv()
-	output, err := repair.CombinedOutput()
-	if err != nil {
-		t.Fatalf("repair wake: %v\noutput: %s", err, output)
-	}
 	var result wakeRepairResult
-	if err := json.Unmarshal(output, &result); err != nil {
-		t.Fatalf("decode repair result: %v\noutput: %s", err, output)
-	}
-	if result.Status != "repaired" {
-		t.Fatalf("repair result = %#v", result)
-	}
 	t.Cleanup(func() {
+		pid := result.PID
+		if pid <= 0 {
+			pid = inspectWakeLock(root, "codex").PID
+		}
 		retire := exec.Command(
 			helper,
 			"--no-update-check",
@@ -114,11 +108,20 @@ func TestWakeRepairNotifiesMessageDeliveredDuringDowntime(t *testing.T) {
 		)
 		retire.Env = wakeContinuityCLIEnv()
 		retireOutput, retireErr := retire.CombinedOutput()
-		if stopped := stopWakeContinuityHelper(result.PID, helper, root, "codex"); !stopped && retireErr != nil {
+		if stopped := stopWakeContinuityHelper(pid, helper, root, "codex"); !stopped && retireErr != nil {
 			t.Logf("stop repaired wake: retire=%v output=%s", retireErr, retireOutput)
 		}
 	})
-
+	output, err := repair.CombinedOutput()
+	if err != nil {
+		t.Fatalf("repair wake: %v\noutput: %s", err, output)
+	}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("decode repair result: %v\noutput: %s", err, output)
+	}
+	if result.Status != "repaired" {
+		t.Fatalf("repair result = %#v", result)
+	}
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		data, readErr := os.ReadFile(injectedPath)
@@ -139,6 +142,9 @@ func TestWakeRepairNotifiesMessageDeliveredDuringDowntime(t *testing.T) {
 }
 
 func stopWakeContinuityHelper(pid int, helper, root, me string) bool {
+	if pid <= 0 {
+		return true
+	}
 	proc := inspectWakeProcessPlatform(pid)
 	if !proc.Running {
 		return true

--- a/internal/cli/wake_repair_handoff_darwin_test.go
+++ b/internal/cli/wake_repair_handoff_darwin_test.go
@@ -301,26 +301,27 @@ func TestDarwinWakeRepairChildCapabilityStopsChildBlockedBeforeControlRead(t *te
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	if err := capability.Bind(cmd.Process); err != nil {
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
+		_ = waiter.waitForExit(time.Second)
+	})
+	if err := capability.Bind(cmd.Process); err != nil {
 		t.Fatal(err)
 	}
 	if err := capability.Stop(); err != nil {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
 		t.Fatalf("stop child blocked before control read: %v", err)
 	}
 
-	waited := make(chan error, 1)
-	go func() { waited <- cmd.Wait() }()
 	select {
-	case err := <-waited:
-		if err == nil {
+	case <-waiter.done:
+		if waiter.err != nil {
+			t.Fatalf("wait for exact-stop child: %v", waiter.err)
+		}
+		if waiter.state == nil || waiter.state.Success() {
 			t.Fatal("blocked child exited successfully after exact stop; want signal termination")
 		}
 	case <-time.After(2 * time.Second):
-		_ = cmd.Process.Kill()
 		t.Fatal("exact pre-admission child remained alive after stop")
 	}
 }
@@ -335,13 +336,16 @@ func TestDarwinWakeRepairChildCapabilityStopAfterWaitCannotSignalReusedPID(t *te
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	if err := capability.Bind(cmd.Process); err != nil {
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
+		_ = waiter.waitForExit(time.Second)
+	})
+	if err := capability.Bind(cmd.Process); err != nil {
 		t.Fatal(err)
 	}
-	if err := cmd.Wait(); err != nil {
-		t.Fatalf("wait direct child: %v", err)
+	if err := waiter.waitForExit(time.Second); err != nil || waiter.err != nil {
+		t.Fatalf("wait direct child: wait=%v child=%v", err, waiter.err)
 	}
 
 	// os.Process synchronizes Wait with Signal and returns ErrProcessDone

--- a/internal/cli/wake_terminate_linux_test.go
+++ b/internal/cli/wake_terminate_linux_test.go
@@ -69,6 +69,14 @@ func TestRetireDoesNotSignalRecycledPID(t *testing.T) {
 	if err := old.Start(); err != nil {
 		t.Fatalf("start old child: %v", err)
 	}
+	oldWaited := false
+	t.Cleanup(func() {
+		if oldWaited {
+			return
+		}
+		_ = old.Process.Kill()
+		_ = old.Wait()
+	})
 	pidfd, err := linuxPidfdOpen(old.Process.Pid, 0)
 	if err != nil {
 		_ = old.Process.Kill()
@@ -83,6 +91,7 @@ func TestRetireDoesNotSignalRecycledPID(t *testing.T) {
 		t.Fatalf("poll old child exit = (%v, %v), want exited", exited, err)
 	}
 	_, _ = old.Process.Wait()
+	oldWaited = true
 
 	replacement := exec.Command("sleep", "30")
 	if err := replacement.Start(); err != nil {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -7709,26 +7709,43 @@ func TestWaitForWakeReadyReturnsWhenReadyFileAppears(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
+	waiter := newWakeProcessWaiter(cmd.Process)
 	t.Cleanup(func() {
 		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
 	})
 
 	if err := writeWakeReadyFile(root, "orchestrator", readyPath, inspection); err != nil {
 		t.Fatalf("writeWakeReadyFile: %v", err)
 	}
-	if err := waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second); err != nil {
+	if err := waitForWakeReadyWithWaiter(waiter, readyPath, root, "orchestrator", time.Second); err != nil {
 		t.Fatalf("waitForWakeReady: %v", err)
 	}
 }
 
 func TestWaitForWakeReadyFailsWhenWakeExitsBeforeReady(t *testing.T) {
 	readyPath := filepath.Join(t.TempDir(), "wake.ready")
+	root := t.TempDir()
 	cmd := exec.Command("sh", "-c", "exit 7")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
+	result := make(chan error, 1)
+	waitDone := make(chan struct{})
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		select {
+		case <-waitDone:
+		case <-time.After(time.Second):
+			t.Errorf("waitForWakeReady wrapper did not join helper")
+		}
+	})
+	go func() {
+		defer close(waitDone)
+		result <- waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	}()
 
-	err := waitForWakeReady(cmd.Process, readyPath, t.TempDir(), "orchestrator", time.Second)
+	err := <-result
 	if err == nil {
 		t.Fatal("expected readiness failure")
 	}
@@ -7752,8 +7769,13 @@ func TestWaitForWakeReadyAcceptsReadyFileWrittenBeforeExit(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 
-	if err := waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second); err != nil {
+	if err := waitForWakeReadyWithWaiter(waiter, readyPath, root, "orchestrator", time.Second); err != nil {
 		t.Fatalf("waitForWakeReady should accept ready file written before exit: %v", err)
 	}
 }
@@ -7768,9 +7790,13 @@ func TestWaitForWakeReadyRefusesLegacyReadyFile(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
-	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 
-	err := waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	err := waitForWakeReadyWithWaiter(waiter, readyPath, root, "orchestrator", time.Second)
 	if err == nil || !strings.Contains(err.Error(), "legacy") {
 		t.Fatalf("expected legacy readiness refusal, got %v", err)
 	}
@@ -7786,9 +7812,13 @@ func TestWaitForWakeReadyRefusesEmptyReadyFile(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
-	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 
-	err := waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	err := waitForWakeReadyWithWaiter(waiter, readyPath, root, "orchestrator", time.Second)
 	if err == nil || !strings.Contains(err.Error(), "legacy") {
 		t.Fatalf("expected empty readiness refusal, got %v", err)
 	}
@@ -7882,7 +7912,11 @@ func TestTerminateWakeHelperProcessKillsWaitsAndRemovesCapturedLock(t *testing.T
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
-	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 	wakePID := cmd.Process.Pid
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid != wakePID {
@@ -7900,7 +7934,6 @@ func TestTerminateWakeHelperProcessKillsWaitsAndRemovesCapturedLock(t *testing.T
 		PID: wakePID, ProcessStart: "start-1", BootID: "boot-1",
 		Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
 	})
-	waiter := newWakeProcessWaiter(cmd.Process)
 	if err := terminateWakeHelperProcess(cmd.Process, waiter, root, "orchestrator"); err != nil {
 		t.Fatalf("terminateWakeHelperProcess: %v", err)
 	}
@@ -7917,7 +7950,11 @@ func TestTerminateWakeHelperProcessRemovesLockCommittedAfterFirstInspection(t *t
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
-	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 	root := secureTempDirForTest(t)
 	lockPath := filepath.Join(fsq.AgentBase(root, "orchestrator"), ".wake.lock")
 	originalKill := killWakeHelperProcess
@@ -7929,7 +7966,6 @@ func TestTerminateWakeHelperProcessRemovesLockCommittedAfterFirstInspection(t *t
 	}
 	t.Cleanup(func() { killWakeHelperProcess = originalKill })
 
-	waiter := newWakeProcessWaiter(cmd.Process)
 	if err := terminateWakeHelperProcess(cmd.Process, waiter, root, "orchestrator"); err != nil {
 		t.Fatalf("terminateWakeHelperProcess: %v", err)
 	}
@@ -7967,9 +8003,13 @@ func TestWaitForWakeReadyRefusesLockReplacement(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
-	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 
-	err = waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	err = waitForWakeReadyWithWaiter(waiter, readyPath, root, "orchestrator", time.Second)
 	if err == nil || !strings.Contains(err.Error(), "generation") {
 		t.Fatalf("expected replacement generation refusal, got %v", err)
 	}
@@ -7998,9 +8038,13 @@ func TestWaitForWakeReadyRefusesTargetReplacement(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
-	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 
-	err = waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	err = waitForWakeReadyWithWaiter(waiter, readyPath, root, "orchestrator", time.Second)
 	if err == nil || !strings.Contains(err.Error(), "does not match wake lock") {
 		t.Fatalf("expected replacement target refusal, got %v", err)
 	}
@@ -8027,9 +8071,13 @@ func TestWaitForWakeReadyRefusesStrayTargetForTargetlessLock(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start helper: %v", err)
 	}
-	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	waiter := newWakeProcessWaiter(cmd.Process)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = waiter.waitForExit(time.Second)
+	})
 
-	err = waitForWakeReady(cmd.Process, readyPath, root, "orchestrator", time.Second)
+	err = waitForWakeReadyWithWaiter(waiter, readyPath, root, "orchestrator", time.Second)
 	if err == nil || !strings.Contains(err.Error(), "target does not match current wake lock") {
 		t.Fatalf("expected stray target refusal for targetless lock, got %v", err)
 	}

--- a/internal/fsq/dlq_retry_lock_test.go
+++ b/internal/fsq/dlq_retry_lock_test.go
@@ -77,6 +77,14 @@ func TestRetryFromDLQSerializesAcrossProcessesAndCrashReleases(t *testing.T) {
 	if err := child.Start(); err != nil {
 		t.Fatalf("start retry helper: %v", err)
 	}
+	childWaited := false
+	t.Cleanup(func() {
+		if childWaited {
+			return
+		}
+		_ = child.Process.Kill()
+		_ = child.Wait()
+	})
 	waitForTestFile(t, ready)
 	parentDone := make(chan error, 1)
 	go func() { parentDone <- RetryFromDLQ(openDeliveryRootForTest(t, rootPath), agent, dlqFilename, false) }()
@@ -91,6 +99,7 @@ func TestRetryFromDLQSerializesAcrossProcessesAndCrashReleases(t *testing.T) {
 	if err := child.Wait(); err != nil {
 		t.Fatalf("child retry: %v", err)
 	}
+	childWaited = true
 	if err := <-parentDone; err == nil || !strings.Contains(err.Error(), "retry already delivered") {
 		t.Fatalf("parent retry result = %v, want already-delivered refusal", err)
 	}
@@ -100,10 +109,19 @@ func TestRetryFromDLQSerializesAcrossProcessesAndCrashReleases(t *testing.T) {
 	if err := crash.Start(); err != nil {
 		t.Fatalf("start crash helper: %v", err)
 	}
+	crashWaited := false
+	t.Cleanup(func() {
+		if crashWaited {
+			return
+		}
+		_ = crash.Process.Kill()
+		_ = crash.Wait()
+	})
 	waitForTestFile(t, crashReady)
 	if err := crash.Wait(); err != nil {
 		t.Fatalf("crash helper: %v", err)
 	}
+	crashWaited = true
 	// The completed retry remains present, so this proves the post-crash lock
 	// is acquirable by reaching the normal already-delivered state.
 	if err := RetryFromDLQ(openDeliveryRootForTest(t, rootPath), agent, dlqFilename, false); err == nil || !strings.Contains(err.Error(), "retry already delivered") {


### PR DESCRIPTION
## Summary
- make detached and potentially long-running test children kill-and-join unconditionally
- use private process groups where descendants exist, including the Darwin `script` PTY command PID shim
- register repair/DLQ cleanup before assertions so early failures cannot orphan helpers

## Verification
- macOS focused CLI/FSQ tests PASS
- Linux Docker focused CLI/FSQ tests PASS (Darwin-only public PTY test is skipped by its existing guard)
- `make ci` PASS: vet, golangci-lint (0 issues), full Go tests, smoke suite
- Darwin public raw PTY tests PASS at count=3 with survivor sweep clean

## Scope
Tests only; synchronous Run/Output/CombinedOutput and bounded PTY/self-helper cases remain explicit exclusions.