### PR TITLE
feat(wake): add inert .wake.state document primitives

### DIFF
--- a/internal/cli/wake_state.go
+++ b/internal/cli/wake_state.go
@@ -1,0 +1,379 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// In this file, "state document" means the .wake.state artifact. Existing
+// wake-check reason codes use "wake state" for notifier status vocabulary.
+
+const (
+	wakeStateSchema         = 1
+	wakeStateSectionSchema  = 1
+	wakeStatePreparedSchema = 1
+	wakeStateFileName       = ".wake.state"
+)
+
+type wakeState struct {
+	Schema   int                `json:"schema"`
+	Target   wakeStateTarget    `json:"target"`
+	Prepared *wakeStatePrepared `json:"prepared"`
+}
+
+type wakeStateTarget struct {
+	Schema        int        `json:"schema"`
+	Mode          string     `json:"mode"`
+	Root          string     `json:"root"`
+	Agent         string     `json:"agent"`
+	Created       string     `json:"created"`
+	InjectVia     string     `json:"inject_via"`
+	InjectArgs    []string   `json:"inject_args,omitempty"`
+	Owner         *wakeOwner `json:"owner,omitempty"`
+	LegacyPresent bool       `json:"legacy_present"`
+	TargetDigest  string     `json:"target_digest"`
+	LegacyDigest  string     `json:"legacy_digest"`
+}
+
+type wakeStatePrepared struct {
+	Schema        int    `json:"schema"`
+	Generation    string `json:"generation"`
+	LegacyPresent bool   `json:"legacy_present"`
+	TargetDigest  string `json:"target_digest"`
+	LegacyDigest  string `json:"legacy_digest"`
+}
+
+type wakeStateLegacyPrepared struct {
+	Schema       int
+	Generation   string
+	TargetDigest string
+}
+
+type wakeStateLegacy struct {
+	Target      *wakeTarget
+	TargetRaw   []byte
+	Prepared    *wakeStateLegacyPrepared
+	PreparedRaw []byte
+}
+
+type wakeStateLegacyMismatchError struct {
+	reason string
+}
+
+func (err *wakeStateLegacyMismatchError) Error() string {
+	if err == nil {
+		return "wake state legacy mismatch"
+	}
+	return "wake state legacy mismatch: " + err.reason
+}
+
+type wakeStatePreparedObservation string
+
+const (
+	wakeStatePreparedAbsent  wakeStatePreparedObservation = "absent"
+	wakeStatePreparedStale   wakeStatePreparedObservation = "stale"
+	wakeStatePreparedCurrent wakeStatePreparedObservation = "current"
+	wakeStatePreparedRefused wakeStatePreparedObservation = "refused"
+)
+
+func newWakeState(legacy wakeStateLegacy) (wakeState, error) {
+	if legacy.Target == nil {
+		return wakeState{}, fmt.Errorf("wake state target is missing")
+	}
+	if len(legacy.TargetRaw) == 0 {
+		return wakeState{}, fmt.Errorf("wake state target legacy bytes are missing")
+	}
+	targetDigest, err := wakeTargetDigest(*legacy.Target)
+	if err != nil {
+		return wakeState{}, err
+	}
+	state := wakeState{
+		Schema: wakeStateSchema,
+		Target: wakeStateTarget{
+			Schema:        legacy.Target.Schema,
+			Mode:          legacy.Target.Mode,
+			Root:          legacy.Target.Root,
+			Agent:         legacy.Target.Agent,
+			Created:       legacy.Target.Created,
+			InjectVia:     legacy.Target.InjectVia,
+			InjectArgs:    append([]string(nil), legacy.Target.InjectArgs...),
+			Owner:         cloneWakeStateOwner(legacy.Target.Owner),
+			LegacyPresent: true,
+			TargetDigest:  targetDigest,
+			LegacyDigest:  wakeLegacyDigest(legacy.TargetRaw),
+		},
+	}
+	if legacy.Prepared != nil {
+		if len(legacy.PreparedRaw) == 0 {
+			return wakeState{}, fmt.Errorf("wake state prepared legacy bytes are missing")
+		}
+		state.Prepared = &wakeStatePrepared{
+			Schema:        legacy.Prepared.Schema,
+			Generation:    legacy.Prepared.Generation,
+			LegacyPresent: true,
+			TargetDigest:  legacy.Prepared.TargetDigest,
+			LegacyDigest:  wakeLegacyDigest(legacy.PreparedRaw),
+		}
+	} else if len(legacy.PreparedRaw) != 0 {
+		return wakeState{}, fmt.Errorf("wake state prepared existence is inconsistent")
+	}
+	if err := validateWakeState(state); err != nil {
+		return wakeState{}, err
+	}
+	return state, nil
+}
+
+func encodeWakeState(state wakeState) ([]byte, error) {
+	if err := validateWakeState(state); err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return nil, fmt.Errorf("marshal wake state: %w", err)
+	}
+	return data, nil
+}
+
+func decodeWakeState(data []byte) (wakeState, error) {
+	if len(data) == 0 || len(data) > maxWakeMetadataFileBytes {
+		return wakeState{}, fmt.Errorf("wake state size is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var state wakeState
+	if err := decoder.Decode(&state); err != nil {
+		return wakeState{}, fmt.Errorf("decode wake state: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return wakeState{}, fmt.Errorf("decode wake state: trailing JSON value")
+		}
+		return wakeState{}, fmt.Errorf("decode wake state trailing bytes: %w", err)
+	}
+	if err := validateWakeState(state); err != nil {
+		return wakeState{}, err
+	}
+	canonical, err := json.Marshal(state)
+	if err != nil {
+		return wakeState{}, fmt.Errorf("re-encode wake state: %w", err)
+	}
+	if !bytes.Equal(canonical, data) {
+		return wakeState{}, fmt.Errorf("wake state is not canonical")
+	}
+	return state, nil
+}
+
+func validateWakeState(state wakeState) error {
+	if state.Schema != wakeStateSchema {
+		return fmt.Errorf("wake state schema %d unsupported", state.Schema)
+	}
+	if err := validateWakeStateTarget(state.Target); err != nil {
+		return err
+	}
+	if state.Prepared != nil {
+		if err := validateWakeStatePrepared(*state.Prepared); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateWakeStateTarget(target wakeStateTarget) error {
+	if target.Schema != wakeStateSectionSchema {
+		return fmt.Errorf("wake state target schema %d unsupported", target.Schema)
+	}
+	if target.Mode != wakeTargetInjectVia {
+		return fmt.Errorf("wake state target mode %q unsupported", target.Mode)
+	}
+	if target.Root == "" || target.Root != strings.TrimSpace(target.Root) ||
+		strings.ContainsRune(target.Root, 0) || !filepath.IsAbs(target.Root) ||
+		filepath.Clean(target.Root) != target.Root || canonicalWakeRoot(target.Root) != target.Root {
+		return fmt.Errorf("wake state target root is invalid")
+	}
+	if err := fsq.ValidateHandle(target.Agent); err != nil {
+		return fmt.Errorf("wake state target agent is invalid: %w", err)
+	}
+	created, err := time.Parse(time.RFC3339, target.Created)
+	if err != nil || created.UTC().Format(time.RFC3339) != target.Created {
+		return fmt.Errorf("wake state target created timestamp is invalid")
+	}
+	if target.InjectVia == "" || target.InjectVia != strings.TrimSpace(target.InjectVia) ||
+		strings.ContainsRune(target.InjectVia, 0) || !filepath.IsAbs(target.InjectVia) ||
+		filepath.Clean(target.InjectVia) != target.InjectVia {
+		return fmt.Errorf("wake state target inject_via is invalid")
+	}
+	for _, arg := range target.InjectArgs {
+		if strings.ContainsRune(arg, 0) {
+			return fmt.Errorf("wake state target inject arg contains NUL")
+		}
+	}
+	if target.Owner != nil {
+		if err := validateAuthoritativeWakeOwner(*target.Owner); err != nil {
+			return fmt.Errorf("wake state target owner is invalid: %w", err)
+		}
+	}
+	if !target.LegacyPresent {
+		return fmt.Errorf("wake state target legacy presence is false")
+	}
+	if !validWakeStateDigest(target.TargetDigest) {
+		return fmt.Errorf("wake state target semantic digest is invalid")
+	}
+	if !validWakeStateDigest(target.LegacyDigest) {
+		return fmt.Errorf("wake state target legacy digest is invalid")
+	}
+	semantic, err := wakeTargetDigest(target.wakeTarget())
+	if err != nil {
+		return err
+	}
+	if semantic != target.TargetDigest {
+		return fmt.Errorf("wake state target semantic digest mismatch")
+	}
+	return nil
+}
+
+func validateWakeStatePrepared(prepared wakeStatePrepared) error {
+	if prepared.Schema != wakeStatePreparedSchema {
+		return fmt.Errorf("wake state prepared schema %d unsupported", prepared.Schema)
+	}
+	if !validWakeStateGeneration(prepared.Generation) {
+		return fmt.Errorf("wake state prepared generation is invalid")
+	}
+	if !prepared.LegacyPresent {
+		return fmt.Errorf("wake state prepared legacy presence is false")
+	}
+	if !validWakeStateDigest(prepared.TargetDigest) {
+		return fmt.Errorf("wake state prepared target digest is invalid")
+	}
+	if !validWakeStateDigest(prepared.LegacyDigest) {
+		return fmt.Errorf("wake state prepared legacy digest is invalid")
+	}
+	return nil
+}
+
+func validateWakeStateAgainstLegacy(state wakeState, legacy wakeStateLegacy) error {
+	if err := validateWakeState(state); err != nil {
+		return err
+	}
+	if legacy.Target == nil {
+		return newWakeStateLegacyMismatch("target exists in state but not legacy")
+	}
+	if len(legacy.TargetRaw) == 0 {
+		return newWakeStateLegacyMismatch("target legacy bytes are missing")
+	}
+	wantTarget, err := wakeTargetDigest(*legacy.Target)
+	if err != nil {
+		return err
+	}
+	if state.Target.TargetDigest != wantTarget {
+		return newWakeStateLegacyMismatch("target semantic digest mismatch")
+	}
+	if state.Target.LegacyDigest != wakeLegacyDigest(legacy.TargetRaw) {
+		return newWakeStateLegacyMismatch("target legacy digest mismatch")
+	}
+	if (state.Prepared == nil) != (legacy.Prepared == nil) {
+		return newWakeStateLegacyMismatch("prepared existence mismatch")
+	}
+	if state.Prepared == nil {
+		if len(legacy.PreparedRaw) != 0 {
+			return newWakeStateLegacyMismatch("prepared raw existence mismatch")
+		}
+		return nil
+	}
+	if len(legacy.PreparedRaw) == 0 {
+		return newWakeStateLegacyMismatch("prepared legacy bytes are missing")
+	}
+	if state.Prepared.Schema != legacy.Prepared.Schema ||
+		state.Prepared.Generation != legacy.Prepared.Generation ||
+		state.Prepared.TargetDigest != legacy.Prepared.TargetDigest {
+		return newWakeStateLegacyMismatch("prepared semantics mismatch")
+	}
+	if state.Prepared.LegacyDigest != wakeLegacyDigest(legacy.PreparedRaw) {
+		return newWakeStateLegacyMismatch("prepared legacy digest mismatch")
+	}
+	return nil
+}
+
+func classifyWakeStatePrepared(
+	prepared *wakeStatePrepared,
+	currentGeneration string,
+	currentTargetDigest string,
+) wakeStatePreparedObservation {
+	if prepared == nil {
+		return wakeStatePreparedAbsent
+	}
+	if prepared.Generation != currentGeneration {
+		return wakeStatePreparedStale
+	}
+	if prepared.TargetDigest != currentTargetDigest {
+		return wakeStatePreparedRefused
+	}
+	return wakeStatePreparedCurrent
+}
+
+func wakeLegacyDigest(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func wakeCanonicalStateDigest(data []byte) (string, error) {
+	if _, err := decodeWakeState(data); err != nil {
+		return "", err
+	}
+	return wakeLegacyDigest(data), nil
+}
+
+func validWakeStateDigest(value string) bool {
+	const prefix = "sha256:"
+	if len(value) != len(prefix)+sha256.Size*2 || !strings.HasPrefix(value, prefix) {
+		return false
+	}
+	encoded := value[len(prefix):]
+	if encoded != strings.ToLower(encoded) {
+		return false
+	}
+	decoded, err := hex.DecodeString(encoded)
+	return err == nil && len(decoded) == sha256.Size
+}
+
+func validWakeStateGeneration(value string) bool {
+	if len(value) != 32 || value != strings.ToLower(value) {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == 16
+}
+
+func (target wakeStateTarget) wakeTarget() wakeTarget {
+	return wakeTarget{
+		Schema:     target.Schema,
+		Mode:       target.Mode,
+		Root:       target.Root,
+		Agent:      target.Agent,
+		Created:    target.Created,
+		InjectVia:  target.InjectVia,
+		InjectArgs: append([]string(nil), target.InjectArgs...),
+		Owner:      cloneWakeStateOwner(target.Owner),
+	}
+}
+
+func cloneWakeStateOwner(owner *wakeOwner) *wakeOwner {
+	if owner == nil {
+		return nil
+	}
+	cloned := *owner
+	return &cloned
+}
+
+func newWakeStateLegacyMismatch(reason string) error {
+	return &wakeStateLegacyMismatchError{reason: reason}
+}

--- a/internal/cli/wake_state_test.go
+++ b/internal/cli/wake_state_test.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWakeStateRefusesEverySchemaExceptExactlyOne(t *testing.T) {
+	state, _ := validWakeStateFixture(t, true)
+
+	tests := []struct {
+		name   string
+		mutate func(*wakeState)
+	}{
+		{name: "older document", mutate: func(state *wakeState) { state.Schema = 0 }},
+		{name: "newer document", mutate: func(state *wakeState) { state.Schema = 2 }},
+		{name: "older target", mutate: func(state *wakeState) { state.Target.Schema = 0 }},
+		{name: "newer target", mutate: func(state *wakeState) { state.Target.Schema = 2 }},
+		{name: "older prepared", mutate: func(state *wakeState) { state.Prepared.Schema = 0 }},
+		{name: "newer prepared", mutate: func(state *wakeState) { state.Prepared.Schema = 2 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := state
+			prepared := *state.Prepared
+			candidate.Prepared = &prepared
+			test.mutate(&candidate)
+			data, err := json.Marshal(candidate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := decodeWakeState(data); err == nil || !strings.Contains(err.Error(), "schema") {
+				t.Fatalf("decode error = %v, want exact-schema refusal", err)
+			}
+		})
+	}
+}
+
+func TestWakeStateRefusesUnknownFieldsAndNonCanonicalBytes(t *testing.T) {
+	state, _ := validWakeStateFixture(t, true)
+	canonical, err := encodeWakeState(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unknownDocument := bytes.Replace(canonical, []byte(`{"schema":1,`), []byte(`{"schema":1,"unknown":true,`), 1)
+	unknownTarget := bytes.Replace(canonical, []byte(`"target":{"schema":1,`), []byte(`"target":{"schema":1,"unknown":true,`), 1)
+	unknownPrepared := bytes.Replace(canonical, []byte(`"prepared":{"schema":1,`), []byte(`"prepared":{"schema":1,"unknown":true,`), 1)
+	var indented bytes.Buffer
+	if err := json.Indent(&indented, canonical, "", "  "); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "unknown document field", data: unknownDocument},
+		{name: "unknown target field", data: unknownTarget},
+		{name: "unknown prepared field", data: unknownPrepared},
+		{name: "leading whitespace", data: append([]byte(" "), canonical...)},
+		{name: "indented", data: indented.Bytes()},
+		{name: "trailing newline", data: append(bytes.Clone(canonical), '\n')},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := decodeWakeState(test.data); err == nil {
+				t.Fatal("non-canonical state was accepted")
+			}
+		})
+	}
+}
+
+func TestWakeStateCanonicalEncodingIsDeterministic(t *testing.T) {
+	state, _ := validWakeStateFixture(t, true)
+	first, err := encodeWakeState(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeWakeState(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := encodeWakeState(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("canonical encodings differ:\nfirst  %s\nsecond %s", first, second)
+	}
+	if bytes.HasSuffix(first, []byte("\n")) {
+		t.Fatal("canonical state has a trailing newline")
+	}
+}
+
+func TestWakeStateDigestDomainsRemainSeparated(t *testing.T) {
+	state, legacy := validWakeStateFixture(t, true)
+	wantTargetDigest, err := wakeTargetDigest(*legacy.Target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Target.TargetDigest != wantTargetDigest {
+		t.Fatalf("target digest = %q, want wakeTargetDigest %q", state.Target.TargetDigest, wantTargetDigest)
+	}
+
+	compactTarget, err := json.Marshal(*legacy.Target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wakeLegacyDigest(compactTarget) == wakeLegacyDigest(legacy.TargetRaw) {
+		t.Fatal("raw legacy digest ignored formatting differences")
+	}
+	if got := wakeLegacyDigest(legacy.TargetRaw); got != state.Target.LegacyDigest {
+		t.Fatalf("target legacy digest = %q, want %q", state.Target.LegacyDigest, got)
+	}
+
+	canonical, err := encodeWakeState(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := wakeCanonicalStateDigest(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest == state.Target.TargetDigest || digest == state.Target.LegacyDigest {
+		t.Fatal("canonical-state digest was conflated with a target digest domain")
+	}
+	if _, err := wakeCanonicalStateDigest(append(canonical, '\n')); err == nil {
+		t.Fatal("canonical-state digest accepted non-canonical bytes")
+	}
+}
+
+func TestWakeStatePreparedFourWayClassification(t *testing.T) {
+	state, _ := validWakeStateFixture(t, true)
+	currentGeneration := state.Prepared.Generation
+	currentTarget := state.Prepared.TargetDigest
+
+	tests := []struct {
+		name     string
+		prepared *wakeStatePrepared
+		want     wakeStatePreparedObservation
+	}{
+		{name: "absent", prepared: nil, want: wakeStatePreparedAbsent},
+		{name: "stale generation", prepared: func() *wakeStatePrepared {
+			candidate := *state.Prepared
+			candidate.Generation = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+			return &candidate
+		}(), want: wakeStatePreparedStale},
+		{name: "current generation and digest", prepared: state.Prepared, want: wakeStatePreparedCurrent},
+		{name: "current generation wrong digest", prepared: func() *wakeStatePrepared {
+			candidate := *state.Prepared
+			candidate.TargetDigest = "sha256:" + strings.Repeat("f", 64)
+			return &candidate
+		}(), want: wakeStatePreparedRefused},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := classifyWakeStatePrepared(test.prepared, currentGeneration, currentTarget); got != test.want {
+				t.Fatalf("classification = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWakeStateMirrorRefusesBidirectionalExistenceMismatch(t *testing.T) {
+	withPrepared, legacyWithPrepared := validWakeStateFixture(t, true)
+	withoutPrepared, legacyWithoutPrepared := validWakeStateFixture(t, false)
+
+	tests := []struct {
+		name   string
+		state  wakeState
+		legacy wakeStateLegacy
+	}{
+		{name: "legacy present state absent", state: withoutPrepared, legacy: legacyWithPrepared},
+		{name: "state present legacy absent", state: withPrepared, legacy: legacyWithoutPrepared},
+		{name: "target state present legacy absent", state: withPrepared, legacy: wakeStateLegacy{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateWakeStateAgainstLegacy(test.state, test.legacy)
+			var mismatch *wakeStateLegacyMismatchError
+			if !errors.As(err, &mismatch) {
+				t.Fatalf("error = %v, want typed legacy mismatch", err)
+			}
+		})
+	}
+}
+
+func TestWakeStateMirrorClassifiesDigestMismatch(t *testing.T) {
+	state, legacy := validWakeStateFixture(t, true)
+	legacy.TargetRaw = append(bytes.Clone(legacy.TargetRaw), ' ')
+
+	err := validateWakeStateAgainstLegacy(state, legacy)
+	var mismatch *wakeStateLegacyMismatchError
+	if !errors.As(err, &mismatch) || !strings.Contains(err.Error(), "digest") {
+		t.Fatalf("error = %v, want typed digest mismatch", err)
+	}
+}
+
+func TestWakeStateRefusesMissingTargetAndPreparedWithoutTarget(t *testing.T) {
+	tests := [][]byte{
+		[]byte(`{"schema":1,"prepared":null}`),
+		[]byte(`{"schema":1,"prepared":{"schema":1,"generation":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","legacy_present":true,"target_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","legacy_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}`),
+	}
+	for _, data := range tests {
+		if _, err := decodeWakeState(data); err == nil || !strings.Contains(err.Error(), "target") {
+			t.Fatalf("decode error = %v, want missing-target refusal", err)
+		}
+	}
+}
+
+func validWakeStateFixture(t *testing.T, prepared bool) (wakeState, wakeStateLegacy) {
+	t.Helper()
+	root := canonicalWakeRoot(t.TempDir())
+	target := wakeTarget{
+		Schema:     wakeTargetSchema,
+		Mode:       wakeTargetInjectVia,
+		Root:       root,
+		Agent:      "codex",
+		Created:    "2026-08-02T00:00:00Z",
+		InjectVia:  filepath.Join(root, "injector"),
+		InjectArgs: []string{"--fixture"},
+	}
+	targetRaw, err := json.MarshalIndent(target, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := wakeStateLegacy{
+		Target:    &target,
+		TargetRaw: append(targetRaw, '\n'),
+	}
+	if prepared {
+		legacy.Prepared = &wakeStateLegacyPrepared{
+			Schema:       wakeStatePreparedSchema,
+			Generation:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			TargetDigest: mustWakeTargetDigest(target),
+		}
+		preparedRaw, err := json.Marshal(legacy.Prepared)
+		if err != nil {
+			t.Fatal(err)
+		}
+		legacy.PreparedRaw = append(preparedRaw, '\n')
+	}
+	state, err := newWakeState(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state, legacy
+}

--- a/internal/cli/wake_state_unix.go
+++ b/internal/cli/wake_state_unix.go
@@ -1,0 +1,457 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+type wakeStatePublicationBoundary string
+
+const (
+	wakeStateAfterTempWrite         wakeStatePublicationBoundary = "after-temp-write"
+	wakeStateAfterFileSync          wakeStatePublicationBoundary = "after-file-sync"
+	wakeStateAfterPreRenameDirSync  wakeStatePublicationBoundary = "after-pre-rename-dir-sync"
+	wakeStateAfterRename            wakeStatePublicationBoundary = "after-rename"
+	wakeStateAfterPostRenameDirSync wakeStatePublicationBoundary = "after-post-rename-dir-sync"
+	wakeStateAfterVerify            wakeStatePublicationBoundary = "after-verify"
+)
+
+var afterWakeStatePublicationBoundary = func(wakeStatePublicationBoundary) error { return nil }
+var afterWakeStateSnapshotRead = func() {}
+
+type wakeStateLegacySnapshot struct {
+	Target          wakeTargetSnapshot
+	TargetPresent   bool
+	Prepared        wakeGenerationFileSnapshot
+	PreparedPresent bool
+}
+
+type wakeStateFileSnapshot struct {
+	State    wakeState
+	Raw      []byte
+	FileInfo os.FileInfo
+}
+
+func (snapshot wakeStateLegacySnapshot) legacy() wakeStateLegacy {
+	legacy := wakeStateLegacy{}
+	if snapshot.TargetPresent {
+		target := snapshot.Target.Target
+		legacy.Target = &target
+		legacy.TargetRaw = bytes.Clone(snapshot.Target.Raw)
+	}
+	if snapshot.PreparedPresent {
+		legacy.Prepared = &wakeStateLegacyPrepared{
+			Schema:       snapshot.Prepared.Marker.Schema,
+			Generation:   snapshot.Prepared.Marker.Generation,
+			TargetDigest: snapshot.Prepared.Marker.TargetDigest,
+		}
+		legacy.PreparedRaw = bytes.Clone(snapshot.Prepared.Raw)
+	}
+	return legacy
+}
+
+func captureWakeStateLegacySnapshotAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) (wakeStateLegacySnapshot, error) {
+	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
+		return wakeStateLegacySnapshot{}, err
+	}
+	target, targetPresent, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return wakeStateLegacySnapshot{}, err
+	}
+	if !targetPresent {
+		return wakeStateLegacySnapshot{}, fmt.Errorf("wake state target is missing")
+	}
+	if err := validateWakeTarget(target.Target, root, me); err != nil {
+		return wakeStateLegacySnapshot{}, err
+	}
+	prepared, preparedPresent, err := readWakeGenerationFileSnapshotAt(
+		dirfd,
+		agentDir,
+		wakePreparedFileName,
+		"wake prepared marker",
+	)
+	if err != nil {
+		return wakeStateLegacySnapshot{}, err
+	}
+	snapshot := wakeStateLegacySnapshot{
+		Target:          target,
+		TargetPresent:   true,
+		Prepared:        prepared,
+		PreparedPresent: preparedPresent,
+	}
+	if _, err := newWakeState(snapshot.legacy()); err != nil {
+		return wakeStateLegacySnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func publishWakeStateAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	expected wakeStateLegacySnapshot,
+) (wakeStateFileSnapshot, error) {
+	// Precondition: the caller holds this agent directory's lifecycle guard.
+	// The guard closes the check-to-rename windows against legitimate writers;
+	// the fd-bound checks below detect bypassers and preserve replacements.
+	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	current, err := captureWakeStateLegacySnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if !sameWakeStateLegacySnapshot(expected, current) {
+		return wakeStateFileSnapshot{}, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake legacy state changed before state publication"),
+		)
+	}
+	state, err := newWakeState(expected.legacy())
+	if err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	raw, err := encodeWakeState(state)
+	if err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if err := validateWakeStateDestinationAt(dirfd, agentDir); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+
+	tempName, tempFile, err := createWakeStateTempAt(dirfd)
+	if err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	tempPresent := true
+	defer func() {
+		_ = tempFile.Close()
+		if tempPresent {
+			_ = unix.Unlinkat(dirfd, tempName, 0)
+		}
+	}()
+	if err := tempFile.Chmod(0o600); err != nil {
+		return wakeStateFileSnapshot{}, fmt.Errorf("chmod wake state temp: %w", err)
+	}
+	n, err := tempFile.Write(raw)
+	if err != nil {
+		return wakeStateFileSnapshot{}, fmt.Errorf("write wake state temp: %w", err)
+	}
+	if n != len(raw) {
+		return wakeStateFileSnapshot{}, fmt.Errorf("write wake state temp: %w", io.ErrShortWrite)
+	}
+	if err := runWakeStatePublicationBoundary(wakeStateAfterTempWrite); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if err := tempFile.Sync(); err != nil {
+		return wakeStateFileSnapshot{}, fmt.Errorf("sync wake state temp: %w", err)
+	}
+	if err := runWakeStatePublicationBoundary(wakeStateAfterFileSync); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	tempInfo, err := tempFile.Stat()
+	if err != nil {
+		return wakeStateFileSnapshot{}, fmt.Errorf("stat wake state temp: %w", err)
+	}
+	if err := validateWakeStateFileInfo(tempName, tempInfo); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if err := tempFile.Close(); err != nil {
+		return wakeStateFileSnapshot{}, fmt.Errorf("close wake state temp: %w", err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return wakeStateFileSnapshot{}, fmt.Errorf("sync wake state directory before install: %w", err)
+	}
+	if err := runWakeStatePublicationBoundary(wakeStateAfterPreRenameDirSync); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+
+	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	current, err = captureWakeStateLegacySnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if !sameWakeStateLegacySnapshot(expected, current) {
+		return wakeStateFileSnapshot{}, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake legacy state changed before state install"),
+		)
+	}
+	if err := validateWakeStateDestinationAt(dirfd, agentDir); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if err := unix.Renameat(dirfd, tempName, dirfd, wakeStateFileName); err != nil {
+		return wakeStateFileSnapshot{}, fmt.Errorf("install wake state: %w", err)
+	}
+	tempPresent = false
+	if err := runWakeStatePublicationBoundary(wakeStateAfterRename); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return wakeStateFileSnapshot{}, fmt.Errorf("sync wake state directory after install: %w", err)
+	}
+	if err := runWakeStatePublicationBoundary(wakeStateAfterPostRenameDirSync); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	installed, exists, err := readWakeStateSnapshotAt(dirfd, agentDir)
+	if err != nil {
+		return wakeStateFileSnapshot{}, err
+	}
+	if !exists {
+		return wakeStateFileSnapshot{}, fmt.Errorf("installed wake state disappeared")
+	}
+	if !os.SameFile(tempInfo, installed.FileInfo) || !bytes.Equal(raw, installed.Raw) {
+		return installed, fmt.Errorf("installed wake state changed during publication; preserving it")
+	}
+	current, err = captureWakeStateLegacySnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return installed, err
+	}
+	if !sameWakeStateLegacySnapshot(expected, current) {
+		return installed, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake legacy state changed during state verification"),
+		)
+	}
+	if err := validateWakeStateAgainstLegacy(installed.State, current.legacy()); err != nil {
+		return installed, err
+	}
+	if err := runWakeStatePublicationBoundary(wakeStateAfterVerify); err != nil {
+		return installed, err
+	}
+	return installed, nil
+}
+
+func readWakeStateSnapshotAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+) (wakeStateFileSnapshot, bool, error) {
+	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
+		return wakeStateFileSnapshot{}, false, err
+	}
+	path := filepath.Join(agentDir.path, wakeStateFileName)
+	open := func() (*os.File, error) {
+		fd, err := unix.Openat(
+			dirfd,
+			wakeStateFileName,
+			unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+			0,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return os.NewFile(uintptr(fd), path), nil
+	}
+	file, err := open()
+	if err != nil {
+		if err == unix.ENOENT {
+			return wakeStateFileSnapshot{}, false, nil
+		}
+		return wakeStateFileSnapshot{}, true, fmt.Errorf("open wake state: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return wakeStateFileSnapshot{}, true, fmt.Errorf("stat wake state: %w", err)
+	}
+	if err := validateWakeStateFileInfo(path, info); err != nil {
+		return wakeStateFileSnapshot{}, true, err
+	}
+	raw, err := readWakeMetadata(file, "wake state", path)
+	if err != nil {
+		return wakeStateFileSnapshot{}, true, err
+	}
+	afterWakeStateSnapshotRead()
+	pathFile, err := open()
+	if err != nil {
+		return wakeStateFileSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake state changed while reopening: %w", err),
+		)
+	}
+	pathInfo, statErr := pathFile.Stat()
+	_ = pathFile.Close()
+	if statErr != nil {
+		return wakeStateFileSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake state changed while restating: %w", statErr),
+		)
+	}
+	if !sameWakeFileIdentity(info, pathInfo) {
+		return wakeStateFileSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake state changed while opening"),
+		)
+	}
+	if err := validateWakeStateFileInfo(path, pathInfo); err != nil {
+		return wakeStateFileSnapshot{}, true, err
+	}
+	state, err := decodeWakeState(raw)
+	if err != nil {
+		return wakeStateFileSnapshot{}, true, err
+	}
+	return wakeStateFileSnapshot{
+		State:    state,
+		Raw:      bytes.Clone(raw),
+		FileInfo: info,
+	}, true, nil
+}
+
+func removeWakeStateIfSnapshotMatchesAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeStateFileSnapshot,
+) (bool, error) {
+	// Precondition: the caller holds this agent directory's lifecycle guard.
+	// The guard closes the check-to-unlink window against legitimate writers;
+	// the exact fd-bound snapshot check preserves bypassing replacements.
+	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
+		return false, err
+	}
+	current, exists, err := readWakeStateSnapshotAt(dirfd, agentDir)
+	if err != nil {
+		return false, fmt.Errorf("re-read wake state before removal: %w", err)
+	}
+	if !exists {
+		return false, nil
+	}
+	if expected.FileInfo == nil || current.FileInfo == nil ||
+		!sameWakeFileIdentity(expected.FileInfo, current.FileInfo) ||
+		!bytes.Equal(expected.Raw, current.Raw) {
+		return false, fmt.Errorf("wake state changed before removal; preserving it")
+	}
+	if err := unix.Unlinkat(dirfd, wakeStateFileName, 0); err != nil {
+		if err == unix.ENOENT {
+			return false, nil
+		}
+		return false, fmt.Errorf("remove wake state: %w", err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return true, fmt.Errorf("sync wake state removal: %w", err)
+	}
+	return true, nil
+}
+
+func sameWakeStateLegacySnapshot(first, second wakeStateLegacySnapshot) bool {
+	if first.TargetPresent != second.TargetPresent ||
+		first.PreparedPresent != second.PreparedPresent {
+		return false
+	}
+	if first.TargetPresent {
+		if first.Target.FileInfo == nil || second.Target.FileInfo == nil ||
+			!sameWakeFileIdentity(first.Target.FileInfo, second.Target.FileInfo) ||
+			!bytes.Equal(first.Target.Raw, second.Target.Raw) ||
+			!sameWakeTarget(first.Target.Target, second.Target.Target) {
+			return false
+		}
+	}
+	if first.PreparedPresent {
+		if first.Prepared.FileInfo == nil || second.Prepared.FileInfo == nil ||
+			!sameWakeFileIdentity(first.Prepared.FileInfo, second.Prepared.FileInfo) ||
+			!bytes.Equal(first.Prepared.Raw, second.Prepared.Raw) ||
+			first.Prepared.Marker != second.Prepared.Marker {
+			return false
+		}
+	}
+	return true
+}
+
+func validateWakeStateDestinationAt(dirfd int, agentDir *wakeAgentDir) error {
+	path := filepath.Join(agentDir.path, wakeStateFileName)
+	fd, err := unix.Openat(
+		dirfd,
+		wakeStateFileName,
+		unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0,
+	)
+	if err != nil {
+		if err == unix.ENOENT {
+			return nil
+		}
+		return fmt.Errorf("open wake state destination: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat wake state destination: %w", err)
+	}
+	return validateWakeStateFileInfo(path, info)
+}
+
+func validateWakeStateFileInfo(path string, info os.FileInfo) error {
+	if info == nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		return fmt.Errorf("wake state %s must be a regular 0600 file", path)
+	}
+	return validateWakeTargetPathOwnership("wake state", path, info)
+}
+
+func validateWakeStateAgentDirAt(dirfd int, agentDir *wakeAgentDir) error {
+	if agentDir == nil || agentDir.file == nil || dirfd != int(agentDir.file.Fd()) {
+		return fmt.Errorf("wake state agent directory capability is missing")
+	}
+	retainedInfo, err := agentDir.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat retained wake agent directory: %w", err)
+	}
+	fd, err := unix.Open(
+		agentDir.path,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("canonical wake agent directory no longer matches retained authority: %w", err)
+	}
+	canonical := os.NewFile(uintptr(fd), agentDir.path)
+	defer func() { _ = canonical.Close() }()
+	canonicalInfo, err := canonical.Stat()
+	if err != nil {
+		return fmt.Errorf("stat canonical wake agent directory: %w", err)
+	}
+	if err := validateWakeAgentDir(agentDir.path, canonicalInfo); err != nil {
+		return err
+	}
+	if !os.SameFile(retainedInfo, canonicalInfo) {
+		return fmt.Errorf("canonical wake agent directory no longer matches retained authority")
+	}
+	return nil
+}
+
+func createWakeStateTempAt(dirfd int) (string, *os.File, error) {
+	var nonce [12]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", nil, fmt.Errorf("generate wake state temp name: %w", err)
+	}
+	name := fmt.Sprintf(".wake-state.tmp.%d.%s", os.Getpid(), hex.EncodeToString(nonce[:]))
+	fd, err := unix.Openat(
+		dirfd,
+		name,
+		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC,
+		0o600,
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("create wake state temp: %w", err)
+	}
+	return name, os.NewFile(uintptr(fd), name), nil
+}
+
+func runWakeStatePublicationBoundary(boundary wakeStatePublicationBoundary) error {
+	if err := afterWakeStatePublicationBoundary(boundary); err != nil {
+		return fmt.Errorf("wake state publication %s: %w", boundary, err)
+	}
+	return nil
+}

--- a/internal/cli/wake_state_unix_test.go
+++ b/internal/cli/wake_state_unix_test.go
@@ -1,0 +1,421 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPublishWakeStateInstallsCanonical0600Snapshot(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "initial")
+	expected := captureWakeStateLegacyForTest(t, fixture)
+	snapshot, err := publishWakeStateForTest(fixture, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := snapshot.FileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state mode = %o, want 0600", got)
+	}
+	canonical, err := encodeWakeState(snapshot.State)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(snapshot.Raw, canonical) {
+		t.Fatalf("installed bytes = %q, want canonical %q", snapshot.Raw, canonical)
+	}
+	if err := validateWakeStateAgainstLegacy(snapshot.State, expected.legacy()); err != nil {
+		t.Fatalf("installed state does not mirror captured legacy: %v", err)
+	}
+}
+
+func TestPublishWakeStateRefusesSymlinkDestination(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "initial")
+	expected := captureWakeStateLegacyForTest(t, fixture)
+	target := filepath.Join(fixture.root, "outside-state")
+	if err := os.WriteFile(target, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := publishWakeStateForTest(fixture, expected); err == nil {
+		t.Fatal("symlink state destination was accepted")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("symlink destination was removed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("symlink destination was replaced")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != "outside" {
+		t.Fatalf("symlink target changed: bytes=%q error=%v", got, err)
+	}
+}
+
+func TestPublishWakeStateCrashSeamsExposeOnlyOldOrNewState(t *testing.T) {
+	tests := []struct {
+		boundary wakeStatePublicationBoundary
+		wantArg  string
+	}{
+		{boundary: wakeStateAfterTempWrite, wantArg: "old"},
+		{boundary: wakeStateAfterFileSync, wantArg: "old"},
+		{boundary: wakeStateAfterPreRenameDirSync, wantArg: "old"},
+		{boundary: wakeStateAfterRename, wantArg: "new"},
+		{boundary: wakeStateAfterPostRenameDirSync, wantArg: "new"},
+		{boundary: wakeStateAfterVerify, wantArg: "new"},
+	}
+	for _, test := range tests {
+		t.Run(string(test.boundary), func(t *testing.T) {
+			fixture := newWakeStateUnixFixture(t, "old")
+			oldLegacy := captureWakeStateLegacyForTest(t, fixture)
+			if _, err := publishWakeStateForTest(fixture, oldLegacy); err != nil {
+				t.Fatal(err)
+			}
+
+			writeWakeStateTargetForTest(t, fixture, "new")
+			newLegacy := captureWakeStateLegacyForTest(t, fixture)
+			injected := errors.New("simulated publication crash")
+			originalHook := afterWakeStatePublicationBoundary
+			afterWakeStatePublicationBoundary = func(boundary wakeStatePublicationBoundary) error {
+				if boundary == test.boundary {
+					return injected
+				}
+				return nil
+			}
+			t.Cleanup(func() { afterWakeStatePublicationBoundary = originalHook })
+
+			if _, err := publishWakeStateForTest(fixture, newLegacy); !errors.Is(err, injected) {
+				t.Fatalf("publication error = %v, want injected crash", err)
+			}
+			afterWakeStatePublicationBoundary = originalHook
+
+			current := readWakeStateForTest(t, fixture)
+			if got := current.State.Target.InjectArgs[0]; got != test.wantArg {
+				t.Fatalf("visible state arg = %q, want %q", got, test.wantArg)
+			}
+			assertNoWakeStateTemps(t, fixture.agentDir.path)
+		})
+	}
+}
+
+func TestReadWakeStateSnapshotClassifiesReplacementAsTypedChange(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "initial")
+	expected := captureWakeStateLegacyForTest(t, fixture)
+	snapshot, err := publishWakeStateForTest(fixture, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalHook := afterWakeStateSnapshotRead
+	replaced := false
+	afterWakeStateSnapshotRead = func() {
+		if replaced {
+			return
+		}
+		replaced = true
+		temp := filepath.Join(fixture.agentDir.path, ".wake-state-replacement")
+		if err := os.WriteFile(temp, snapshot.Raw, 0o600); err != nil {
+			t.Errorf("write replacement: %v", err)
+			return
+		}
+		if err := os.Rename(temp, filepath.Join(fixture.agentDir.path, wakeStateFileName)); err != nil {
+			t.Errorf("install replacement: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterWakeStateSnapshotRead = originalHook })
+
+	var readErr error
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		_, _, readErr = readWakeStateSnapshotAt(dirfd, fixture.agentDir)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var changed *wakeSnapshotReadChangedError
+	if !errors.As(readErr, &changed) {
+		t.Fatalf("read error = %v, want typed snapshot change", readErr)
+	}
+	if _, err := os.Stat(filepath.Join(fixture.agentDir.path, wakeStateFileName)); err != nil {
+		t.Fatalf("replacement was not preserved: %v", err)
+	}
+}
+
+func TestReadInvalidWakeStateDoesNotMutateArtifact(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  func(*testing.T) []byte
+	}{
+		{name: "invalid", raw: func(*testing.T) []byte { return []byte("{}\n") }},
+		{name: "newer schema", raw: func(t *testing.T) []byte {
+			state, _ := validWakeStateFixture(t, true)
+			state.Schema = 2
+			raw, err := json.Marshal(state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return raw
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeStateUnixFixture(t, "initial")
+			path := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+			invalid := test.raw(t)
+			if err := os.WriteFile(path, invalid, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var readErr error
+			if err := fixture.agentDir.withFD(func(dirfd int) error {
+				_, _, readErr = readWakeStateSnapshotAt(dirfd, fixture.agentDir)
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if readErr == nil {
+				t.Fatal("invalid wake state was accepted")
+			}
+			after, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("invalid state was removed: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !os.SameFile(before, after) || !bytes.Equal(got, invalid) {
+				t.Fatal("invalid state was rewritten or replaced by a read")
+			}
+		})
+	}
+}
+
+func TestRemoveWakeStateIfSnapshotMatchesRemovesExactSnapshot(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "initial")
+	expected := captureWakeStateLegacyForTest(t, fixture)
+	snapshot, err := publishWakeStateForTest(fixture, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var removed bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var err error
+		removed, err = removeWakeStateIfSnapshotMatchesAt(dirfd, fixture.agentDir, snapshot)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !removed {
+		t.Fatal("exact wake state snapshot was not removed")
+	}
+	if _, err := os.Stat(filepath.Join(fixture.agentDir.path, wakeStateFileName)); !os.IsNotExist(err) {
+		t.Fatalf("removed wake state stat error = %v, want not exist", err)
+	}
+}
+
+func TestRemoveWakeStateIfSnapshotMatchesPreservesReplacement(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "initial")
+	expected := captureWakeStateLegacyForTest(t, fixture)
+	snapshot, err := publishWakeStateForTest(fixture, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	replacementRaw := bytes.Clone(snapshot.Raw)
+	temp := filepath.Join(fixture.agentDir.path, ".wake-state-replacement")
+	if err := os.WriteFile(temp, replacementRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(temp, path); err != nil {
+		t.Fatal(err)
+	}
+	replacementInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var removed bool
+	var removeErr error
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		removed, removeErr = removeWakeStateIfSnapshotMatchesAt(dirfd, fixture.agentDir, snapshot)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if removed || removeErr == nil || !strings.Contains(removeErr.Error(), "preserving") {
+		t.Fatalf("removed=%v error=%v, want replacement preservation", removed, removeErr)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("replacement was removed: %v", err)
+	}
+	if !os.SameFile(replacementInfo, after) {
+		t.Fatal("replacement identity changed during refused cleanup")
+	}
+}
+
+func TestRemoveWakeStatePreservesReboundSiblingDirectory(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "initial")
+	expected := captureWakeStateLegacyForTest(t, fixture)
+	snapshot, err := publishWakeStateForTest(fixture, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalPath := fixture.agentDir.path
+	detachedPath := originalPath + ".detached"
+	if err := os.Rename(originalPath, detachedPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(originalPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	siblingRaw := []byte("sibling")
+	siblingPath := filepath.Join(originalPath, wakeStateFileName)
+	if err := os.WriteFile(siblingPath, siblingRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var removeErr error
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		_, removeErr = removeWakeStateIfSnapshotMatchesAt(dirfd, fixture.agentDir, snapshot)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if removeErr == nil || !strings.Contains(removeErr.Error(), "canonical wake agent directory") {
+		t.Fatalf("rebound cleanup error = %v, want canonical-directory refusal", removeErr)
+	}
+	got, err := os.ReadFile(siblingPath)
+	if err != nil {
+		t.Fatalf("rebound sibling was removed: %v", err)
+	}
+	if !bytes.Equal(got, siblingRaw) {
+		t.Fatalf("rebound sibling bytes = %q, want %q", got, siblingRaw)
+	}
+	if _, err := os.Stat(filepath.Join(detachedPath, wakeStateFileName)); err != nil {
+		t.Fatalf("detached original state was removed: %v", err)
+	}
+}
+
+type wakeStateUnixFixture struct {
+	root     string
+	agent    string
+	injector string
+	agentDir *wakeAgentDir
+}
+
+func newWakeStateUnixFixture(t *testing.T, arg string) wakeStateUnixFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	injector := filepath.Join(root, "injector")
+	if err := os.WriteFile(injector, []byte("fixture"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fixture := wakeStateUnixFixture{root: root, agent: "codex", injector: injector}
+	writeWakeStateTargetForTest(t, fixture, arg)
+	agentDir, err := openWakeAgentDir(root, fixture.agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.agentDir = agentDir
+	t.Cleanup(func() { _ = agentDir.Close() })
+	return fixture
+}
+
+func writeWakeStateTargetForTest(t *testing.T, fixture wakeStateUnixFixture, arg string) {
+	t.Helper()
+	target := wakeTarget{
+		Schema:     wakeTargetSchema,
+		Mode:       wakeTargetInjectVia,
+		Root:       canonicalWakeRoot(fixture.root),
+		Agent:      fixture.agent,
+		Created:    "2026-08-02T00:00:00Z",
+		InjectVia:  fixture.injector,
+		InjectArgs: []string{arg},
+	}
+	if err := writeWakeTarget(fixture.root, fixture.agent, target); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func captureWakeStateLegacyForTest(t *testing.T, fixture wakeStateUnixFixture) wakeStateLegacySnapshot {
+	t.Helper()
+	var snapshot wakeStateLegacySnapshot
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		var err error
+		snapshot, err = captureWakeStateLegacySnapshotAt(
+			dirfd,
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+		)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func publishWakeStateForTest(
+	fixture wakeStateUnixFixture,
+	expected wakeStateLegacySnapshot,
+) (wakeStateFileSnapshot, error) {
+	var snapshot wakeStateFileSnapshot
+	err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		var err error
+		snapshot, err = publishWakeStateAt(
+			dirfd,
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			expected,
+		)
+		return err
+	})
+	return snapshot, err
+}
+
+func readWakeStateForTest(t *testing.T, fixture wakeStateUnixFixture) wakeStateFileSnapshot {
+	t.Helper()
+	var snapshot wakeStateFileSnapshot
+	var exists bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var err error
+		snapshot, exists, err = readWakeStateSnapshotAt(dirfd, fixture.agentDir)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("wake state is missing")
+	}
+	return snapshot
+}
+
+func assertNoWakeStateTemps(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".wake-state.tmp.") {
+			t.Fatalf("publication temp survived: %s", entry.Name())
+		}
+	}
+}


### PR DESCRIPTION
INERT / FORWARD-ONLY — this PR adds no runtime wiring and creates no state document in production.

Implements W3.2 from docs/wake-lifecycle.md:
- closed schema-1 canonical state codec and three separate digest domains
- legacy mirror mismatch and four-way prepared classification
- fd-bound 0600 no-follow publication, crash seams, typed torn-read evidence, and exact-snapshot removal
- zero production references outside the new implementation files

Verification:
- Claude exact-tree W3.2 BOUND PASS on tree ef2f0158 / delta 5b73d45c
- go test ./... -count=1
- go vet ./...
- focused race suite
- Linux and Windows production cross-builds
- independent Darwin and real Linux count=3 matrix

Activation is deferred to W3.3 guarded legacy-first dual-write wiring. This PR does not authorize release, deploy, migration, or P2b activation.