### PR TITLE
feat(wake): dual-write state from legacy mutations

### DIFF
--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -173,6 +173,9 @@ exception: a new bound claim may publish and verify the target section before
 the lock link, as section 7.1 specifies, but that state projection never
 authorizes the link. A state write that fails MUST NOT make a legacy operation
 appear committed when it was not.
+This guard requirement binds writers of every document schema generation; a
+writer that mutates state without the guard is out of contract regardless of
+schema.
 
 The state document uses a private 0600 temporary file in the agent directory.
 The required state publication sequence is:

--- a/internal/cli/wake_owner_acquire_unix.go
+++ b/internal/cli/wake_owner_acquire_unix.go
@@ -284,6 +284,11 @@ func acquireAuthoritativeWakeLockWithOptionsInDir(
 					if publicationErr.InstalledTarget == nil {
 						return fmt.Errorf("%w (installed owner target identity is unavailable; preserving it)", err)
 					}
+					stateSnapshot, stateExists, stateErr := readWakeStateRawSnapshotAt(dirfd, agentDir)
+					if stateErr != nil {
+						continueAfterWakeStateProjectionError(newWakeStateProjectionError(stateErr))
+						stateExists = false
+					}
 					removed, removeErr := removeWakeTargetIfSnapshotMatchesAt(
 						dirfd,
 						agentDir,
@@ -297,6 +302,16 @@ func acquireAuthoritativeWakeLockWithOptionsInDir(
 					if removed {
 						if syncErr := syncWakeOwnerDirFD(dirfd); syncErr != nil {
 							return fmt.Errorf("%w (sync uncommitted owner target cleanup: %v)", err, syncErr)
+						}
+						if _, stateRemoveErr := removeWakeStateIfTargetAbsentAt(
+							dirfd,
+							agentDir,
+							stateSnapshot,
+							stateExists,
+						); stateRemoveErr != nil {
+							if !continueAfterWakeStateProjectionError(stateRemoveErr) {
+								return fmt.Errorf("%w (uncommitted owner state cleanup refused: %v)", err, stateRemoveErr)
+							}
 						}
 					}
 					return err

--- a/internal/cli/wake_owner_mixed_version_test.go
+++ b/internal/cli/wake_owner_mixed_version_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 const ownerFenceLegacyCommit = "e37067a91b4447c3ed99bf647b71e7ec9dbf3824"
+const wakeStateLegacyWriterCommit = "fbc574a8d2b26b2526dfae5d9c5c87408007ac39"
 
 func TestOwnerFencePreservesClaimAgainstExactE370Binary(t *testing.T) {
 	repoRootCommand := exec.Command("git", "rev-parse", "--show-toplevel")
@@ -145,6 +146,71 @@ func TestOwnerFencePreservesClaimAgainstExactE370Binary(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLegacyWriterPreservesNewerWakeStateDocument(t *testing.T) {
+	legacyBinary := buildHistoricalAMQForWakeStateTest(t, wakeStateLegacyWriterCommit)
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "mixed-version-state-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+
+	statePath := filepath.Join(fsq.AgentBase(root, "codex"), wakeStateFileName)
+	stateRaw := []byte(`{"schema":2,"future_field":{"preserve":"exactly"}}`)
+	if err := os.WriteFile(statePath, stateRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stateInfo, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, legacyBinary, "wake", "recover-owner", "--root", root, "--me", "codex")
+	command.Env = ownerFenceCommandEnv(root)
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("legacy recover-owner timed out: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("legacy recover-owner failed: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(wakeTargetPath(root, "codex")); !os.IsNotExist(err) {
+		t.Fatalf("legacy writer did not commit orphan target cleanup: %v", err)
+	}
+	assertWakeStateSnapshotUnchangedForTest(t, statePath, stateRaw, stateInfo)
+}
+
+func buildHistoricalAMQForWakeStateTest(t *testing.T, commit string) string {
+	t.Helper()
+	repoRootOutput, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	if err != nil {
+		t.Skipf("mixed-version git history unavailable: %v", err)
+	}
+	repoRoot := strings.TrimSpace(string(repoRootOutput))
+	if output, err := exec.Command("git", "-C", repoRoot, "cat-file", "-e", commit+"^{commit}").CombinedOutput(); err != nil {
+		t.Skipf("mixed-version commit %s unavailable: %v\n%s", commit, err, output)
+	}
+	buildRoot := t.TempDir()
+	sourceRoot := filepath.Join(buildRoot, "source")
+	if err := os.Mkdir(sourceRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	archivePath := filepath.Join(buildRoot, "legacy.tar")
+	commandOutputForOwnerFence(t, repoRoot, "git", "archive", "--format=tar", "--output="+archivePath, commit)
+	commandOutputForOwnerFence(t, "", "tar", "-xf", archivePath, "-C", sourceRoot)
+	binary := filepath.Join(buildRoot, "amq-legacy-state-writer")
+	commandOutputForOwnerFence(t, sourceRoot, "go", "build", "-o", binary, "./cmd/amq")
+	return binary
 }
 
 func commandOutputForOwnerFence(t *testing.T, dir, name string, args ...string) string {

--- a/internal/cli/wake_owner_recover_unix.go
+++ b/internal/cli/wake_owner_recover_unix.go
@@ -119,6 +119,11 @@ func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
 				if err != nil {
 					return refuse("orphan wake target is unverified: "+err.Error(), "inspect the target and retry")
 				}
+				stateSnapshot, stateExists, stateErr := readWakeStateRawSnapshotAt(dirfd, agentDir)
+				if stateErr != nil {
+					continueAfterWakeStateProjectionError(newWakeStateProjectionError(stateErr))
+					stateExists = false
+				}
 				if exists {
 					digest, err := wakeTargetDigest(target)
 					if err != nil {
@@ -140,6 +145,16 @@ func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
 					}
 					if err := syncWakeOwnerDirFD(dirfd); err != nil {
 						return fmt.Errorf("sync orphan wake target removal: %w", err)
+					}
+				}
+				if _, err := removeWakeStateIfTargetAbsentAt(
+					dirfd,
+					agentDir,
+					stateSnapshot,
+					stateExists,
+				); err != nil {
+					if !continueAfterWakeStateProjectionError(err) {
+						return fmt.Errorf("remove orphan wake state: %w", err)
 					}
 				}
 				result.Status = "recovered"

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -178,7 +178,16 @@ func publishAuthoritativeWakeClaimAt(
 			InstalledTarget: &installedTarget,
 		}
 	}
-	_ = agentDir
+	if err := reconcileWakeStateAfterLegacyMutationAt(dirfd, agentDir, root, me); err != nil {
+		if continueAfterWakeStateProjectionError(err) {
+			return nil
+		}
+		return &wakeOwnerPublicationError{
+			Err:             fmt.Errorf("publish wake state after authoritative wake commit: %w", err),
+			Committed:       true,
+			InstalledTarget: &installedTarget,
+		}
+	}
 	return nil
 }
 
@@ -483,6 +492,13 @@ func removeAuthoritativeWakeClaimAt(
 		}
 		releasePreparedSnapshot = &preparedSnapshot
 	}
+	releaseStateSnapshot, releaseStateExists, stateSnapshotErr := readWakeStateRawSnapshotAt(dirfd, agentDir)
+	if stateSnapshotErr != nil {
+		continueAfterWakeStateProjectionError(newWakeStateProjectionError(
+			fmt.Errorf("snapshot wake state before release: %w", stateSnapshotErr),
+		))
+		releaseStateExists = false
+	}
 
 	if err := unix.Unlinkat(dirfd, ".wake.lock", 0); err != nil {
 		if err == unix.ENOENT {
@@ -530,6 +546,19 @@ func removeAuthoritativeWakeClaimAt(
 		} else if removed {
 			cleaned = true
 		}
+	}
+	stateRemoved, stateErr := removeWakeStateIfTargetAbsentAt(
+		dirfd,
+		agentDir,
+		releaseStateSnapshot,
+		releaseStateExists,
+	)
+	if stateErr != nil {
+		if !continueAfterWakeStateProjectionError(stateErr) {
+			cleanupErr = errors.Join(cleanupErr, stateErr)
+		}
+	} else if stateRemoved {
+		cleaned = true
 	}
 	if releasePreparedSnapshot != nil {
 		_, err := removeWakeGenerationFileIfSnapshotMatchesAt(

--- a/internal/cli/wake_prepared_cleanup_authoritative_unix_test.go
+++ b/internal/cli/wake_prepared_cleanup_authoritative_unix_test.go
@@ -322,7 +322,7 @@ func TestAuthoritativeWakeCleanupPreparedSyncFailureContinuesCleanup(t *testing.
 	syncCalls := 0
 	syncWakeOwnerDirFD = func(int) error {
 		syncCalls++
-		if syncCalls == 2 {
+		if syncCalls == 3 {
 			return syscall.ENOSYS
 		}
 		return nil
@@ -333,8 +333,8 @@ func TestAuthoritativeWakeCleanupPreparedSyncFailureContinuesCleanup(t *testing.
 	if err == nil || !strings.Contains(err.Error(), "sync wake prepared marker removal") {
 		t.Fatalf("prepared sync cleanup error = %v, want durability error", err)
 	}
-	if syncCalls != 3 {
-		t.Fatalf("directory sync calls = %d, want 3", syncCalls)
+	if syncCalls != 4 {
+		t.Fatalf("directory sync calls = %d, want 4", syncCalls)
 	}
 	fixture.assertReleasedClaimMissing(t)
 	assertPathMissingForTest(t, fixture.preparedPath)
@@ -347,7 +347,7 @@ func TestAuthoritativeWakeCleanupFinalSyncFailureIsReported(t *testing.T) {
 	syncCalls := 0
 	syncWakeOwnerDirFD = func(int) error {
 		syncCalls++
-		if syncCalls == 3 {
+		if syncCalls == 4 {
 			return syscall.ENOSYS
 		}
 		return nil
@@ -358,8 +358,8 @@ func TestAuthoritativeWakeCleanupFinalSyncFailureIsReported(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "sync authoritative wake claim cleanup") {
 		t.Fatalf("final sync cleanup error = %v, want durability error", err)
 	}
-	if syncCalls != 3 {
-		t.Fatalf("directory sync calls = %d, want 3", syncCalls)
+	if syncCalls != 4 {
+		t.Fatalf("directory sync calls = %d, want 4", syncCalls)
 	}
 	fixture.assertReleasedClaimMissing(t)
 	assertPathMissingForTest(t, fixture.preparedPath)

--- a/internal/cli/wake_prepared_cleanup_generic_unix_test.go
+++ b/internal/cli/wake_prepared_cleanup_generic_unix_test.go
@@ -167,8 +167,8 @@ func TestGenericWakeCleanupLockSyncFailureContinuesPreparedAndFloorCleanup(t *te
 	if err == nil || !strings.Contains(err.Error(), "sync exact generic wake lock removal") {
 		t.Fatalf("lock sync cleanup error = %v, want durability error", err)
 	}
-	if *syncCalls != 3 {
-		t.Fatalf("directory sync calls = %d, want lock, prepared, and floor syncs", *syncCalls)
+	if *syncCalls != 5 {
+		t.Fatalf("directory sync calls = %d, want lock, prepared, state pre/post-install, and floor syncs", *syncCalls)
 	}
 	fixture.assertLockMissing(t)
 	assertPathMissingForTest(t, fixture.preparedPath)

--- a/internal/cli/wake_prepared_unix.go
+++ b/internal/cli/wake_prepared_unix.go
@@ -52,7 +52,16 @@ func writeWakePreparedFileInDir(
 		if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, marker); err != nil {
 			return err
 		}
-		return writeWakeGenerationFileAt(dirfd, wakePreparedFileName, "wake prepared marker", marker)
+		if err := writeWakeGenerationFileAt(dirfd, wakePreparedFileName, "wake prepared marker", marker); err != nil {
+			return err
+		}
+		if err := reconcileWakeStateAfterLegacyMutationAt(dirfd, agentDir, root, me); err != nil {
+			if continueAfterWakeStateProjectionError(err) {
+				return nil
+			}
+			return fmt.Errorf("wake prepared marker committed; refresh wake state: %w", err)
+		}
+		return nil
 	})
 }
 

--- a/internal/cli/wake_repair_at_unix.go
+++ b/internal/cli/wake_repair_at_unix.go
@@ -372,16 +372,32 @@ func writeWakeTargetGuardedAt(
 }
 
 func removeWakeTargetGuardedAt(dirfd int, agentDir *wakeAgentDir) error {
-	if err := unix.Unlinkat(dirfd, wakeTargetFileName, 0); err != nil {
-		if err == unix.ENOENT {
-			return nil
-		}
+	stateSnapshot, stateExists, err := readWakeStateRawSnapshotAt(dirfd, agentDir)
+	if err != nil {
+		continueAfterWakeStateProjectionError(newWakeStateProjectionError(err))
+		stateExists = false
+	}
+	removedTarget := false
+	if err := unix.Unlinkat(dirfd, wakeTargetFileName, 0); err != nil && err != unix.ENOENT {
 		return fmt.Errorf("remove wake target: %w", err)
+	} else if err == nil {
+		removedTarget = true
 	}
-	if err := syncWakeOwnerDirFD(dirfd); err != nil {
-		return fmt.Errorf("sync wake target removal: %w", err)
+	if removedTarget {
+		if err := syncWakeOwnerDirFD(dirfd); err != nil {
+			return fmt.Errorf("sync wake target removal: %w", err)
+		}
 	}
-	_ = agentDir
+	if _, err := removeWakeStateIfTargetAbsentAt(
+		dirfd,
+		agentDir,
+		stateSnapshot,
+		stateExists,
+	); err != nil {
+		if !continueAfterWakeStateProjectionError(err) {
+			return fmt.Errorf("remove wake state after target removal: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/cli/wake_state.go
+++ b/internal/cli/wake_state.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -67,6 +68,40 @@ type wakeStateLegacy struct {
 
 type wakeStateLegacyMismatchError struct {
 	reason string
+}
+
+type wakeStateProjectionError struct {
+	Err error
+}
+
+func newWakeStateProjectionError(err error) *wakeStateProjectionError {
+	return &wakeStateProjectionError{Err: err}
+}
+
+func (err *wakeStateProjectionError) Error() string {
+	if err == nil || err.Err == nil {
+		return "wake state projection failed"
+	}
+	return "wake state projection failed: " + err.Err.Error()
+}
+
+func (err *wakeStateProjectionError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.Err
+}
+
+func continueAfterWakeStateProjectionError(err error) bool {
+	var projection *wakeStateProjectionError
+	if !errors.As(err, &projection) {
+		return false
+	}
+	_ = writeStderr(
+		"warning: %v; continuing with legacy wake state\n",
+		projection,
+	)
+	return true
 }
 
 func (err *wakeStateLegacyMismatchError) Error() string {
@@ -147,6 +182,12 @@ func decodeWakeState(data []byte) (wakeState, error) {
 	if len(data) == 0 || len(data) > maxWakeMetadataFileBytes {
 		return wakeState{}, fmt.Errorf("wake state size is invalid")
 	}
+	if component, schema, ok := newerWakeStateSchema(data); ok {
+		if component == "" {
+			return wakeState{}, fmt.Errorf("wake state schema %d unsupported", schema)
+		}
+		return wakeState{}, fmt.Errorf("wake state %s schema %d unsupported", component, schema)
+	}
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	var state wakeState
@@ -171,6 +212,48 @@ func decodeWakeState(data []byte) (wakeState, error) {
 		return wakeState{}, fmt.Errorf("wake state is not canonical")
 	}
 	return state, nil
+}
+
+func newerWakeStateSchema(data []byte) (component string, schema int, ok bool) {
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(data, &document); err != nil {
+		return "", 0, false
+	}
+	documentSchema, valid := wakeStateSchemaNumber(document["schema"])
+	if valid && documentSchema > wakeStateSchema {
+		return "", documentSchema, true
+	}
+	if !valid || documentSchema != wakeStateSchema {
+		return "", 0, false
+	}
+	for _, section := range []struct {
+		name    string
+		current int
+	}{
+		{name: "target", current: wakeStateSectionSchema},
+		{name: "prepared", current: wakeStatePreparedSchema},
+	} {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(document[section.name], &fields); err == nil {
+			if schema, ok := wakeStateSchemaAbove(fields["schema"], section.current); ok {
+				return section.name, schema, true
+			}
+		}
+	}
+	return "", 0, false
+}
+
+func wakeStateSchemaAbove(raw json.RawMessage, current int) (int, bool) {
+	schema, ok := wakeStateSchemaNumber(raw)
+	if !ok || schema <= current {
+		return 0, false
+	}
+	return schema, true
+}
+
+func wakeStateSchemaNumber(raw json.RawMessage) (int, bool) {
+	var schema int
+	return schema, json.Unmarshal(raw, &schema) == nil
 }
 
 func validateWakeState(state wakeState) error {

--- a/internal/cli/wake_state_dual_write_unix_test.go
+++ b/internal/cli/wake_state_dual_write_unix_test.go
@@ -1,0 +1,834 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestAuthoritativeWakeAcquisitionPublishesLegacyFirstState(t *testing.T) {
+	root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+	cleanup, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+
+	state := readWakeStateAtPathForTest(t, root, "codex")
+	if !sameWakeTarget(state.State.Target.wakeTarget(), target) {
+		t.Fatalf("state target = %#v, want %#v", state.State.Target, target)
+	}
+	if state.State.Prepared != nil {
+		t.Fatalf("new acquisition state prepared = %#v, want nil", state.State.Prepared)
+	}
+}
+
+func TestAuthoritativeWakeAcquisitionStateFailurePreservesCommittedLegacy(t *testing.T) {
+	root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+	injected := errors.New("state projection failed after owner commit")
+	installWakeStatePublicationFailure(t, wakeStateAfterTempWrite, injected)
+
+	var cleanup func()
+	var err error
+	stderr := captureWakeStderr(t, func() {
+		cleanup, err = acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+			target:   &target,
+			wakeMode: wakeTargetInjectVia,
+		})
+	})
+	if err != nil || cleanup == nil {
+		t.Fatalf("acquisition cleanup=%v err=%v, want success", cleanup != nil, err)
+	}
+	if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, injected.Error()) {
+		t.Fatalf("projection warning = %q", stderr)
+	}
+	inspection := inspectWakeLock(root, "codex")
+	if classifyPersistedWakeClaim(inspection) != wakeClaimAuthoritative {
+		t.Fatalf("legacy lock was not committed: %#v", inspection)
+	}
+	persisted, exists, readErr := readWakeTarget(root, "codex")
+	if readErr != nil || !exists || !sameWakeTarget(persisted, target) {
+		t.Fatalf("legacy target = %#v exists=%v err=%v", persisted, exists, readErr)
+	}
+	afterWakeStatePublicationBoundary = func(wakeStatePublicationBoundary) error { return nil }
+	if err := writeWakePreparedFile(root, "codex", inspection); err != nil {
+		t.Fatalf("next guarded mutation did not heal state: %v", err)
+	}
+	state := readWakeStateAtPathForTest(t, root, "codex")
+	if state.State.Prepared == nil || state.State.Prepared.Generation != inspection.Lock.Generation {
+		t.Fatalf("healed state prepared = %#v", state.State.Prepared)
+	}
+}
+
+func TestAuthoritativeWakeAcquisitionStateCrashSeamsKeepCommittedLegacy(t *testing.T) {
+	for _, test := range []struct {
+		boundary  wakeStatePublicationBoundary
+		wantState bool
+	}{
+		{boundary: wakeStateAfterTempWrite},
+		{boundary: wakeStateAfterFileSync},
+		{boundary: wakeStateAfterPreRenameDirSync},
+		{boundary: wakeStateAfterRename, wantState: true},
+		{boundary: wakeStateAfterPostRenameDirSync, wantState: true},
+		{boundary: wakeStateAfterVerify, wantState: true},
+	} {
+		t.Run(string(test.boundary), func(t *testing.T) {
+			root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+			injected := errors.New("owner state crash seam")
+			installWakeStatePublicationFailure(t, test.boundary, injected)
+
+			var cleanup func()
+			var err error
+			stderr := captureWakeStderr(t, func() {
+				cleanup, err = acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+					target:   &target,
+					wakeMode: wakeTargetInjectVia,
+				})
+			})
+			if err != nil || cleanup == nil {
+				t.Fatalf("acquisition cleanup=%v err=%v, want success", cleanup != nil, err)
+			}
+			if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, injected.Error()) {
+				t.Fatalf("projection warning = %q", stderr)
+			}
+			if inspection := inspectWakeLock(root, "codex"); classifyPersistedWakeClaim(inspection) != wakeClaimAuthoritative {
+				t.Fatalf("legacy lock was not committed: %#v", inspection)
+			}
+			_, stateExists := readOptionalWakeStateAtPathForTest(t, root, "codex")
+			if stateExists != test.wantState {
+				t.Fatalf("state exists=%v, want %v", stateExists, test.wantState)
+			}
+		})
+	}
+}
+
+func TestWakePreparedPublicationRefreshesStateLegacyFirst(t *testing.T) {
+	root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+	cleanup, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	inspection := inspectWakeLock(root, "codex")
+
+	injected := errors.New("state refresh failed after prepared commit")
+	installWakeStatePublicationFailure(t, wakeStateAfterTempWrite, injected)
+	var preparedErr error
+	stderr := captureWakeStderr(t, func() {
+		preparedErr = writeWakePreparedFile(root, "codex", inspection)
+	})
+	if preparedErr != nil {
+		t.Fatalf("prepared publication error = %v, want success", preparedErr)
+	}
+	if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, injected.Error()) {
+		t.Fatalf("projection warning = %q", stderr)
+	}
+	if _, exists, err := readWakeGenerationFile(wakePreparedPath(root, "codex"), "wake prepared marker"); err != nil || !exists {
+		t.Fatalf("legacy prepared marker exists=%v err=%v", exists, err)
+	}
+	state := readWakeStateAtPathForTest(t, root, "codex")
+	if state.State.Prepared != nil {
+		t.Fatalf("failed refresh changed visible state prepared = %#v", state.State.Prepared)
+	}
+
+	afterWakeStatePublicationBoundary = func(wakeStatePublicationBoundary) error { return nil }
+	if err := writeWakePreparedFile(root, "codex", inspection); err != nil {
+		t.Fatal(err)
+	}
+	state = readWakeStateAtPathForTest(t, root, "codex")
+	if state.State.Prepared == nil || state.State.Prepared.Generation != inspection.Lock.Generation {
+		t.Fatalf("refreshed state prepared = %#v, want generation %q", state.State.Prepared, inspection.Lock.Generation)
+	}
+}
+
+func TestWakePreparedStateCrashSeamsLeaveLegacyPreparedAuthoritative(t *testing.T) {
+	for _, test := range []struct {
+		boundary            wakeStatePublicationBoundary
+		wantPreparedInState bool
+	}{
+		{boundary: wakeStateAfterTempWrite},
+		{boundary: wakeStateAfterFileSync},
+		{boundary: wakeStateAfterPreRenameDirSync},
+		{boundary: wakeStateAfterRename, wantPreparedInState: true},
+		{boundary: wakeStateAfterPostRenameDirSync, wantPreparedInState: true},
+		{boundary: wakeStateAfterVerify, wantPreparedInState: true},
+	} {
+		t.Run(string(test.boundary), func(t *testing.T) {
+			root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+			cleanup, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+				target:   &target,
+				wakeMode: wakeTargetInjectVia,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(cleanup)
+			inspection := inspectWakeLock(root, "codex")
+			injected := errors.New("prepared state crash seam")
+			installWakeStatePublicationFailure(t, test.boundary, injected)
+
+			var preparedErr error
+			stderr := captureWakeStderr(t, func() {
+				preparedErr = writeWakePreparedFile(root, "codex", inspection)
+			})
+			if preparedErr != nil {
+				t.Fatalf("prepared publication error = %v, want success", preparedErr)
+			}
+			if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, injected.Error()) {
+				t.Fatalf("projection warning = %q", stderr)
+			}
+			if _, exists, err := readWakeGenerationFile(wakePreparedPath(root, "codex"), "wake prepared marker"); err != nil || !exists {
+				t.Fatalf("legacy prepared marker exists=%v err=%v", exists, err)
+			}
+			state := readWakeStateAtPathForTest(t, root, "codex")
+			gotPrepared := state.State.Prepared != nil
+			if gotPrepared != test.wantPreparedInState {
+				t.Fatalf("state prepared exists=%v, want %v", gotPrepared, test.wantPreparedInState)
+			}
+		})
+	}
+}
+
+func TestGenericWakeTargetAndPreparedMutationsRefreshState(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, true)
+	state := readWakeStateAtPathForTest(t, fixture.root, fixture.me)
+	if state.State.Prepared == nil || state.State.Prepared.Generation != fixture.created.Lock.Generation {
+		t.Fatalf("generic prepared state = %#v", state.State.Prepared)
+	}
+
+	if err := fixture.cleanupNow(); err != nil {
+		t.Fatal(err)
+	}
+	state = readWakeStateAtPathForTest(t, fixture.root, fixture.me)
+	if state.State.Prepared != nil {
+		t.Fatalf("generic cleanup state prepared = %#v, want nil", state.State.Prepared)
+	}
+}
+
+func TestGenericWakeCleanupProjectionFailureKeepsLegacyCleanupCommitted(t *testing.T) {
+	for _, boundary := range []wakeStatePublicationBoundary{
+		wakeStateAfterTempWrite,
+		wakeStateAfterFileSync,
+		wakeStateAfterPreRenameDirSync,
+		wakeStateAfterRename,
+		wakeStateAfterPostRenameDirSync,
+		wakeStateAfterVerify,
+	} {
+		t.Run(string(boundary), func(t *testing.T) {
+			fixture := newGenericWakePreparedCleanupFixture(t, true)
+			injected := errors.New("state projection failed after generic cleanup")
+			installWakeStatePublicationFailure(t, boundary, injected)
+
+			var cleanupErr error
+			stderr := captureWakeStderr(t, func() {
+				cleanupErr = fixture.cleanupNow()
+			})
+			if cleanupErr != nil {
+				t.Fatalf("generic cleanup error = %v, want success", cleanupErr)
+			}
+			if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, injected.Error()) {
+				t.Fatalf("generic cleanup projection warning = %q", stderr)
+			}
+			if inspection := inspectWakeLock(fixture.root, fixture.me); inspection.Exists {
+				t.Fatalf("generic lock survived committed cleanup: %#v", inspection)
+			}
+			assertPathMissingForTest(t, fixture.preparedPath)
+			if _, exists, err := readWakeTarget(fixture.root, fixture.me); err != nil || !exists {
+				t.Fatalf("generic target exists=%v err=%v after cleanup", exists, err)
+			}
+
+			afterWakeStatePublicationBoundary = func(wakeStatePublicationBoundary) error { return nil }
+			cleanup, err := acquireWakeLockWithOptions(fixture.root, fixture.me, fixture.options)
+			if err != nil {
+				t.Fatalf("next guarded acquisition did not heal state: %v", err)
+			}
+			t.Cleanup(cleanup)
+			state := readWakeStateAtPathForTest(t, fixture.root, fixture.me)
+			if state.State.Prepared != nil {
+				t.Fatalf("healed generic cleanup state prepared = %#v, want nil", state.State.Prepared)
+			}
+		})
+	}
+}
+
+func TestGenericWakeStateCrashSeamsKeepCommittedLegacy(t *testing.T) {
+	for _, test := range []struct {
+		boundary  wakeStatePublicationBoundary
+		wantState bool
+	}{
+		{boundary: wakeStateAfterTempWrite},
+		{boundary: wakeStateAfterFileSync},
+		{boundary: wakeStateAfterPreRenameDirSync},
+		{boundary: wakeStateAfterRename, wantState: true},
+		{boundary: wakeStateAfterPostRenameDirSync, wantState: true},
+		{boundary: wakeStateAfterVerify, wantState: true},
+	} {
+		t.Run(string(test.boundary), func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			injector := writeExecutableForTest(t, "generic-state-gap-injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+			injected := errors.New("state projection failed after generic lock commit")
+			installWakeStatePublicationFailure(t, test.boundary, injected)
+
+			var cleanup func()
+			var err error
+			stderr := captureWakeStderr(t, func() {
+				cleanup, err = acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+					target:   &target,
+					wakeMode: wakeTargetInjectVia,
+				})
+			})
+			if err != nil || cleanup == nil {
+				t.Fatalf("generic acquisition cleanup=%v err=%v, want success", cleanup != nil, err)
+			}
+			if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, injected.Error()) {
+				t.Fatalf("projection warning = %q", stderr)
+			}
+			inspection := inspectWakeLock(root, "codex")
+			if !inspection.Exists {
+				t.Fatal("projection failure did not preserve committed generic lock")
+			}
+			persisted, exists, readErr := readWakeTarget(root, "codex")
+			if readErr != nil || !exists || !sameWakeTarget(persisted, target) {
+				t.Fatalf("committed target = %#v exists=%v err=%v", persisted, exists, readErr)
+			}
+			_, stateExists := readOptionalWakeStateAtPathForTest(t, root, "codex")
+			if stateExists != test.wantState {
+				t.Fatalf("state exists=%v, want %v", stateExists, test.wantState)
+			}
+			afterWakeStatePublicationBoundary = func(wakeStatePublicationBoundary) error { return nil }
+			if err := writeWakePreparedFile(root, "codex", inspection); err != nil {
+				t.Fatalf("next guarded mutation did not heal state: %v", err)
+			}
+			state := readWakeStateAtPathForTest(t, root, "codex")
+			if state.State.Prepared == nil || state.State.Prepared.Generation != inspection.Lock.Generation {
+				t.Fatalf("healed generic state prepared = %#v", state.State.Prepared)
+			}
+		})
+	}
+}
+
+func TestGenericWakeWithoutTargetRemovesStaleState(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, true)
+	if err := fixture.cleanupNow(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(wakeTargetPath(fixture.root, fixture.me)); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("stale state missing before targetless acquisition: %v", err)
+	}
+
+	cleanup, err := acquireWakeLockWithOptions(fixture.root, fixture.me, wakeLockAcquireOptions{
+		wakeMode: wakeInjectModeNone,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	assertPathMissingForTest(t, statePath)
+}
+
+func TestRecoverOwnerRemovesOrphanTargetAndExactState(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, true)
+	if err := fixture.cleanupNow(); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state missing before orphan recovery: %v", err)
+	}
+
+	result, err := recoverOwnerWake(fixture.root, fixture.me)
+	if err != nil || result.Status != "recovered" {
+		t.Fatalf("orphan recovery = %#v err=%v", result, err)
+	}
+	assertPathMissingForTest(t, wakeTargetPath(fixture.root, fixture.me))
+	assertPathMissingForTest(t, statePath)
+}
+
+func TestRecoverOwnerWithoutTargetConvergesExactState(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, true)
+	if err := fixture.cleanupNow(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(wakeTargetPath(fixture.root, fixture.me)); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state missing before recovery retry: %v", err)
+	}
+
+	result, err := recoverOwnerWake(fixture.root, fixture.me)
+	if err != nil || result.Status != "recovered" {
+		t.Fatalf("targetless recovery = %#v err=%v", result, err)
+	}
+	assertPathMissingForTest(t, statePath)
+}
+
+func TestRecoverOwnerStateRemovalFailureKeepsTargetlessRecoveryCommitted(t *testing.T) {
+	fixture := newGenericWakePreparedCleanupFixture(t, true)
+	if err := fixture.cleanupNow(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(wakeTargetPath(fixture.root, fixture.me)); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	stateRaw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementPath := statePath + ".replacement"
+	if err := os.WriteFile(replacementPath, stateRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalHook := afterWakeStateSnapshotRead
+	reads := 0
+	afterWakeStateSnapshotRead = func() {
+		reads++
+		if reads == 2 {
+			if err := os.Rename(replacementPath, statePath); err != nil {
+				t.Fatalf("install recovery state replacement: %v", err)
+			}
+		}
+	}
+	t.Cleanup(func() { afterWakeStateSnapshotRead = originalHook })
+
+	var result wakeOwnerRecoverResult
+	stderr := captureWakeStderr(t, func() {
+		result, err = recoverOwnerWake(fixture.root, fixture.me)
+	})
+	if err != nil || result.Status != "recovered" {
+		t.Fatalf("targetless recovery = %#v err=%v", result, err)
+	}
+	if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, "wake state changed") {
+		t.Fatalf("targetless recovery projection warning = %q", stderr)
+	}
+	got, readErr := os.ReadFile(statePath)
+	if readErr != nil || !bytes.Equal(got, stateRaw) {
+		t.Fatalf("preserved recovery state bytes=%q err=%v", got, readErr)
+	}
+}
+
+func TestUnsupportedOwnerPublicationRemovesStateAfterExactTargetCleanup(t *testing.T) {
+	root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	fixture := wakeStateUnixFixture{root: root, agent: "codex", agentDir: agentDir}
+	if _, err := publishWakeStateForTest(fixture, captureWakeStateLegacyForTest(t, fixture)); err != nil {
+		t.Fatal(err)
+	}
+
+	originalLink := publishAuthoritativeWakeLinkAt
+	publishAuthoritativeWakeLinkAt = func(int, string, int, string, int) error {
+		return syscall.EOPNOTSUPP
+	}
+	t.Cleanup(func() { publishAuthoritativeWakeLinkAt = originalLink })
+
+	if _, err := acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+		target:   &target,
+		wakeMode: wakeTargetInjectVia,
+	}); !errors.Is(err, syscall.EOPNOTSUPP) {
+		t.Fatalf("unsupported publication error=%v", err)
+	}
+	assertPathMissingForTest(t, wakeTargetPath(root, "codex"))
+	assertPathMissingForTest(t, filepath.Join(agentDir.path, wakeStateFileName))
+}
+
+func TestUnsupportedOwnerPublicationStateRemovalFailureKeepsTargetCleanupCommitted(t *testing.T) {
+	root, target, _ := newOwnerAcquisitionPublicationFixture(t)
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	fixture := wakeStateUnixFixture{root: root, agent: "codex", agentDir: agentDir}
+	state, err := publishWakeStateForTest(fixture, captureWakeStateLegacyForTest(t, fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(agentDir.path, wakeStateFileName)
+	replacementPath := statePath + ".replacement"
+	if err := os.WriteFile(replacementPath, state.Raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalLink := publishAuthoritativeWakeLinkAt
+	publishAuthoritativeWakeLinkAt = func(int, string, int, string, int) error {
+		return syscall.EOPNOTSUPP
+	}
+	t.Cleanup(func() { publishAuthoritativeWakeLinkAt = originalLink })
+	originalReadHook := afterWakeStateSnapshotRead
+	reads := 0
+	afterWakeStateSnapshotRead = func() {
+		reads++
+		if reads == 2 {
+			if err := os.Rename(replacementPath, statePath); err != nil {
+				t.Fatalf("install unsupported-cleanup state replacement: %v", err)
+			}
+		}
+	}
+	t.Cleanup(func() { afterWakeStateSnapshotRead = originalReadHook })
+
+	var acquireErr error
+	stderr := captureWakeStderr(t, func() {
+		_, acquireErr = acquireAuthoritativeWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+			target:   &target,
+			wakeMode: wakeTargetInjectVia,
+		})
+	})
+	if !errors.Is(acquireErr, syscall.EOPNOTSUPP) {
+		t.Fatalf("unsupported publication error=%v", acquireErr)
+	}
+	if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, "wake state changed") {
+		t.Fatalf("unsupported cleanup projection warning = %q", stderr)
+	}
+	assertPathMissingForTest(t, wakeTargetPath(root, "codex"))
+	got, readErr := os.ReadFile(statePath)
+	if readErr != nil || !bytes.Equal(got, state.Raw) {
+		t.Fatalf("preserved unsupported state bytes=%q err=%v", got, readErr)
+	}
+}
+
+func TestAuthoritativeWakeReleaseRemovesStateAfterTarget(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state missing before release: %v", err)
+	}
+	if err := fixture.release(); err != nil {
+		t.Fatal(err)
+	}
+	fixture.assertReleasedClaimMissing(t)
+	assertPathMissingForTest(t, statePath)
+}
+
+func TestAuthoritativeWakeReleaseRemovesInvalidStateAfterTarget(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if err := os.WriteFile(statePath, []byte("{not-json\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.release(); err != nil {
+		t.Fatal(err)
+	}
+	fixture.assertReleasedClaimMissing(t)
+	assertPathMissingForTest(t, statePath)
+}
+
+func TestAuthoritativeWakeReleaseStateSnapshotFailureKeepsLegacyCleanupCommitted(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	stateRaw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(statePath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var releaseErr error
+	stderr := captureWakeStderr(t, func() {
+		releaseErr = fixture.release()
+	})
+	if releaseErr != nil {
+		t.Fatalf("release error = %v, want successful legacy release", releaseErr)
+	}
+	if !strings.Contains(stderr, "continuing with legacy wake state") ||
+		!strings.Contains(stderr, "must be a regular 0600 file") {
+		t.Fatalf("state snapshot warning = %q", stderr)
+	}
+	fixture.assertReleasedClaimMissing(t)
+	got, readErr := os.ReadFile(statePath)
+	if readErr != nil || !bytes.Equal(got, stateRaw) {
+		t.Fatalf("preserved unreadable state bytes=%q err=%v", got, readErr)
+	}
+}
+
+func TestGuardedPreparedMutationPreservesNewerWakeStateSchemas(t *testing.T) {
+	for _, component := range []string{"document", "target", "prepared"} {
+		t.Run(component, func(t *testing.T) {
+			fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+			statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+			stateRaw, stateInfo := installNewerWakeStateSchemaForTest(t, statePath, component)
+
+			var writeErr error
+			stderr := captureWakeStderr(t, func() {
+				writeErr = writeWakePreparedFile(fixture.root, fixture.me, fixture.inspection)
+			})
+			if writeErr != nil {
+				t.Fatalf("prepared mutation error = %v, want successful legacy commit", writeErr)
+			}
+			assertSingleWakeStateProjectionWarning(t, stderr)
+			assertWakeStateSnapshotUnchangedForTest(t, statePath, stateRaw, stateInfo)
+			marker, exists, err := readWakeGenerationFile(fixture.preparedPath, "wake prepared marker")
+			if err != nil || !exists || marker.Generation != fixture.inspection.Lock.Generation {
+				t.Fatalf("legacy prepared marker = %#v exists=%v err=%v", marker, exists, err)
+			}
+		})
+	}
+}
+
+func TestGuardedPreparedMutationPreservesNewerWakeStateInstalledBeforeRename(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	currentRaw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newerRaw := newerWakeStateRawForTest(t, currentRaw, "document")
+	replacementPath := statePath + ".newer"
+	if err := os.WriteFile(replacementPath, newerRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	originalBoundary := afterWakeStatePublicationBoundary
+	replaced := false
+	var installedInfo os.FileInfo
+	afterWakeStatePublicationBoundary = func(boundary wakeStatePublicationBoundary) error {
+		if boundary == wakeStateAfterPreRenameDirSync && !replaced {
+			replaced = true
+			if err := os.Rename(replacementPath, statePath); err != nil {
+				return err
+			}
+			var err error
+			installedInfo, err = os.Stat(statePath)
+			return err
+		}
+		return nil
+	}
+	t.Cleanup(func() { afterWakeStatePublicationBoundary = originalBoundary })
+
+	var writeErr error
+	stderr := captureWakeStderr(t, func() {
+		writeErr = writeWakePreparedFile(fixture.root, fixture.me, fixture.inspection)
+	})
+	if writeErr != nil {
+		t.Fatalf("prepared mutation error = %v, want successful legacy commit", writeErr)
+	}
+	if !replaced {
+		t.Fatal("newer state interleave did not run")
+	}
+	assertSingleWakeStateProjectionWarning(t, stderr)
+	assertWakeStateSnapshotUnchangedForTest(t, statePath, newerRaw, installedInfo)
+}
+
+func TestAuthoritativeReleasePreservesNewerWakeStateSchemas(t *testing.T) {
+	for _, component := range []string{"document", "target", "prepared"} {
+		t.Run(component, func(t *testing.T) {
+			fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+			statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+			stateRaw, stateInfo := installNewerWakeStateSchemaForTest(t, statePath, component)
+
+			var releaseErr error
+			stderr := captureWakeStderr(t, func() {
+				releaseErr = fixture.release()
+			})
+			if releaseErr != nil {
+				t.Fatalf("release error = %v, want successful legacy release", releaseErr)
+			}
+			assertSingleWakeStateProjectionWarning(t, stderr)
+			fixture.assertReleasedClaimMissing(t)
+			assertPathMissingForTest(t, fixture.preparedPath)
+			assertWakeStateSnapshotUnchangedForTest(t, statePath, stateRaw, stateInfo)
+		})
+	}
+}
+
+func TestAuthoritativeWakeReleaseRemovesStateWhenTargetAlreadyMissing(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	if err := os.Remove(fixture.preparedPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fixture.targetPath); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return removeAuthoritativeWakeClaimAt(
+			dirfd,
+			fixture.agentDir,
+			fixture.inspection,
+			nil,
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertPathMissingForTest(t, fixture.lockPath)
+	assertPathMissingForTest(t, statePath)
+}
+
+func TestAuthoritativeWakeReleasePreservesStateReplacement(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	originalRaw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementPath := statePath + ".replacement"
+	if err := os.WriteFile(replacementPath, originalRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	originalHook := removeAuthoritativeWakeAfterLockRelease
+	removeAuthoritativeWakeAfterLockRelease = func() {
+		if err := os.Rename(replacementPath, statePath); err != nil {
+			t.Errorf("install state replacement: %v", err)
+		}
+	}
+	t.Cleanup(func() { removeAuthoritativeWakeAfterLockRelease = originalHook })
+
+	var releaseErr error
+	stderr := captureWakeStderr(t, func() {
+		releaseErr = fixture.release()
+	})
+	if releaseErr != nil {
+		t.Fatalf("release error = %v, want successful legacy release", releaseErr)
+	}
+	if !strings.Contains(stderr, "continuing with legacy wake state") || !strings.Contains(stderr, "preserving") {
+		t.Fatalf("replacement preservation warning = %q", stderr)
+	}
+	fixture.assertReleasedClaimMissing(t)
+	got, readErr := os.ReadFile(statePath)
+	if readErr != nil || !bytes.Equal(got, originalRaw) {
+		t.Fatalf("replacement state bytes=%q err=%v", got, readErr)
+	}
+}
+
+func readWakeStateAtPathForTest(t *testing.T, root, me string) wakeStateFileSnapshot {
+	t.Helper()
+	snapshot, exists := readOptionalWakeStateAtPathForTest(t, root, me)
+	if !exists {
+		t.Fatal("wake state is missing")
+	}
+	return snapshot
+}
+
+func readOptionalWakeStateAtPathForTest(t *testing.T, root, me string) (wakeStateFileSnapshot, bool) {
+	t.Helper()
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	var snapshot wakeStateFileSnapshot
+	var exists bool
+	if err := agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		snapshot, exists, readErr = readWakeStateSnapshotAt(dirfd, agentDir)
+		return readErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return snapshot, exists
+}
+
+func installWakeStatePublicationFailure(t *testing.T, boundary wakeStatePublicationBoundary, injected error) {
+	t.Helper()
+	original := afterWakeStatePublicationBoundary
+	afterWakeStatePublicationBoundary = func(current wakeStatePublicationBoundary) error {
+		if current == boundary {
+			return injected
+		}
+		return nil
+	}
+	t.Cleanup(func() { afterWakeStatePublicationBoundary = original })
+}
+
+func installNewerWakeStateSchemaForTest(t *testing.T, path, component string) ([]byte, os.FileInfo) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = newerWakeStateRawForTest(t, raw, component)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw, info
+}
+
+func newerWakeStateRawForTest(t *testing.T, raw []byte, component string) []byte {
+	t.Helper()
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	newerSchema, err := json.Marshal(wakeStateSchema + 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if component == "document" {
+		document["schema"] = newerSchema
+		document["future_field"] = json.RawMessage("true")
+	} else {
+		var section map[string]json.RawMessage
+		if err := json.Unmarshal(document[component], &section); err != nil {
+			t.Fatal(err)
+		}
+		section["schema"] = newerSchema
+		section["future_field"] = json.RawMessage("true")
+		document[component], err = json.Marshal(section)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, err = json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func assertSingleWakeStateProjectionWarning(t *testing.T, stderr string) {
+	t.Helper()
+	if count := strings.Count(stderr, "warning: wake state projection failed:"); count != 1 ||
+		!strings.Contains(stderr, "newer schema") ||
+		!strings.Contains(stderr, "continuing with legacy wake state") {
+		t.Fatalf("projection warning count=%d stderr=%q", count, stderr)
+	}
+}
+
+func assertWakeStateSnapshotUnchangedForTest(t *testing.T, path string, raw []byte, info os.FileInfo) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(got, raw) {
+		t.Fatalf("preserved wake state bytes=%q err=%v", got, err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameWakeFileIdentity(info, after) {
+		t.Fatal("preserved wake state identity changed")
+	}
+}

--- a/internal/cli/wake_state_test.go
+++ b/internal/cli/wake_state_test.go
@@ -40,6 +40,58 @@ func TestWakeStateRefusesEverySchemaExceptExactlyOne(t *testing.T) {
 	}
 }
 
+func TestNewerWakeStateSchemaProbeSharesReaderClassification(t *testing.T) {
+	tests := []struct {
+		name          string
+		data          string
+		wantComponent string
+		wantSchema    int
+		wantNewer     bool
+	}{
+		{
+			name:          "newer document before unknown fields",
+			data:          `{"schema":2,"future":true,"target":"unknown"}`,
+			wantComponent: "",
+			wantSchema:    2,
+			wantNewer:     true,
+		},
+		{
+			name:          "newer target inside current document",
+			data:          `{"schema":1,"target":{"schema":2,"future":true},"prepared":null}`,
+			wantComponent: "target",
+			wantSchema:    2,
+			wantNewer:     true,
+		},
+		{
+			name:          "newer prepared inside current document",
+			data:          `{"schema":1,"target":{},"prepared":{"schema":2,"future":true}}`,
+			wantComponent: "prepared",
+			wantSchema:    2,
+			wantNewer:     true,
+		},
+		{
+			name: "section schema does not rescue older document",
+			data: `{"schema":0,"target":{"schema":2},"prepared":null}`,
+		},
+		{name: "current document with unknown field", data: `{"schema":1,"future":true,"target":{},"prepared":null}`},
+		{name: "current document with null prepared", data: `{"schema":1,"target":{},"prepared":null}`},
+		{name: "malformed current document", data: `{"schema":1`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			component, schema, newer := newerWakeStateSchema([]byte(test.data))
+			if component != test.wantComponent || schema != test.wantSchema || newer != test.wantNewer {
+				t.Fatalf("probe = (%q, %d, %v), want (%q, %d, %v)", component, schema, newer, test.wantComponent, test.wantSchema, test.wantNewer)
+			}
+			if test.wantNewer {
+				if _, err := decodeWakeState([]byte(test.data)); err == nil || !strings.Contains(err.Error(), "schema") {
+					t.Fatalf("reader error = %v, want shared newer-schema refusal", err)
+				}
+			}
+		})
+	}
+}
+
 func TestWakeStateRefusesUnknownFieldsAndNonCanonicalBytes(t *testing.T) {
 	state, _ := validWakeStateFixture(t, true)
 	canonical, err := encodeWakeState(state)

--- a/internal/cli/wake_state_unix.go
+++ b/internal/cli/wake_state_unix.go
@@ -41,6 +41,64 @@ type wakeStateFileSnapshot struct {
 	FileInfo os.FileInfo
 }
 
+func reconcileWakeStateAfterLegacyMutationAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) (retErr error) {
+	// Precondition: the caller holds this agent directory's lifecycle guard and
+	// has already committed the authorized legacy mutation.
+	defer func() {
+		if retErr != nil {
+			retErr = newWakeStateProjectionError(retErr)
+		}
+	}()
+	_, exists, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		state, stateExists, err := readWakeStateRawSnapshotAt(dirfd, agentDir)
+		if err != nil || !stateExists {
+			return err
+		}
+		_, err = removeWakeStateIfSnapshotMatchesAt(dirfd, agentDir, state)
+		return err
+	}
+	expected, err := captureWakeStateLegacySnapshotAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return err
+	}
+	_, err = publishWakeStateAt(dirfd, agentDir, root, me, expected)
+	return err
+}
+
+func removeWakeStateIfTargetAbsentAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeStateFileSnapshot,
+	expectedExists bool,
+) (removed bool, retErr error) {
+	// Precondition: the caller holds this agent directory's lifecycle guard and
+	// captured expected before removing the target.
+	defer func() {
+		if retErr != nil {
+			retErr = newWakeStateProjectionError(retErr)
+		}
+	}()
+	var targetInfo unix.Stat_t
+	err := unix.Fstatat(dirfd, wakeTargetFileName, &targetInfo, unix.AT_SYMLINK_NOFOLLOW)
+	targetExists := err == nil
+	if err != nil && err != unix.ENOENT {
+		return false, fmt.Errorf("verify wake target absence before state removal: %w", err)
+	}
+	if targetExists || !expectedExists {
+		return false, nil
+	}
+	return removeWakeStateIfSnapshotMatchesAt(dirfd, agentDir, expected)
+}
+
 func (snapshot wakeStateLegacySnapshot) legacy() wakeStateLegacy {
 	legacy := wakeStateLegacy{}
 	if snapshot.TargetPresent {
@@ -107,8 +165,9 @@ func publishWakeStateAt(
 	expected wakeStateLegacySnapshot,
 ) (wakeStateFileSnapshot, error) {
 	// Precondition: the caller holds this agent directory's lifecycle guard.
-	// The guard closes the check-to-rename windows against legitimate writers;
-	// the fd-bound checks below detect bypassers and preserve replacements.
+	// Every schema generation uses that guard, which excludes legitimate writers
+	// across the final destination validation-to-rename window. The fd-bound
+	// checks below detect bypassers outside that window and preserve replacements.
 	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
 		return wakeStateFileSnapshot{}, err
 	}
@@ -243,6 +302,22 @@ func readWakeStateSnapshotAt(
 	dirfd int,
 	agentDir *wakeAgentDir,
 ) (wakeStateFileSnapshot, bool, error) {
+	snapshot, exists, err := readWakeStateRawSnapshotAt(dirfd, agentDir)
+	if err != nil || !exists {
+		return snapshot, exists, err
+	}
+	state, err := decodeWakeState(snapshot.Raw)
+	if err != nil {
+		return wakeStateFileSnapshot{}, true, err
+	}
+	snapshot.State = state
+	return snapshot, true, nil
+}
+
+func readWakeStateRawSnapshotAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+) (wakeStateFileSnapshot, bool, error) {
 	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
 		return wakeStateFileSnapshot{}, false, err
 	}
@@ -300,12 +375,7 @@ func readWakeStateSnapshotAt(
 	if err := validateWakeStateFileInfo(path, pathInfo); err != nil {
 		return wakeStateFileSnapshot{}, true, err
 	}
-	state, err := decodeWakeState(raw)
-	if err != nil {
-		return wakeStateFileSnapshot{}, true, err
-	}
 	return wakeStateFileSnapshot{
-		State:    state,
 		Raw:      bytes.Clone(raw),
 		FileInfo: info,
 	}, true, nil
@@ -322,7 +392,13 @@ func removeWakeStateIfSnapshotMatchesAt(
 	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
 		return false, err
 	}
-	current, exists, err := readWakeStateSnapshotAt(dirfd, agentDir)
+	if _, _, newer := newerWakeStateSchema(expected.Raw); newer {
+		// A newer reader will reject this now-stale projection by its legacy
+		// digest, so preserving it cannot authorize state while retaining data
+		// that only the newer reader or an operator can interpret.
+		return false, fmt.Errorf("wake state uses a newer schema; preserving it")
+	}
+	current, exists, err := readWakeStateRawSnapshotAt(dirfd, agentDir)
 	if err != nil {
 		return false, fmt.Errorf("re-read wake state before removal: %w", err)
 	}
@@ -371,26 +447,16 @@ func sameWakeStateLegacySnapshot(first, second wakeStateLegacySnapshot) bool {
 }
 
 func validateWakeStateDestinationAt(dirfd int, agentDir *wakeAgentDir) error {
-	path := filepath.Join(agentDir.path, wakeStateFileName)
-	fd, err := unix.Openat(
-		dirfd,
-		wakeStateFileName,
-		unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC,
-		0,
-	)
-	if err != nil {
-		if err == unix.ENOENT {
-			return nil
-		}
-		return fmt.Errorf("open wake state destination: %w", err)
+	current, exists, err := readWakeStateRawSnapshotAt(dirfd, agentDir)
+	if err != nil || !exists {
+		return err
 	}
-	file := os.NewFile(uintptr(fd), path)
-	defer func() { _ = file.Close() }()
-	info, err := file.Stat()
-	if err != nil {
-		return fmt.Errorf("stat wake state destination: %w", err)
+	if _, _, newer := newerWakeStateSchema(current.Raw); newer {
+		// The authorized legacy mutation has already committed. Preserve newer
+		// state; its legacy digest becomes stale and therefore non-authoritative.
+		return fmt.Errorf("wake state uses a newer schema; preserving it")
 	}
-	return validateWakeStateFileInfo(path, info)
+	return nil
 }
 
 func validateWakeStateFileInfo(path string, info os.FileInfo) error {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -377,6 +377,14 @@ func acquireWakeLockWithOptionsInDir(
 			if !created.Exists || created.Lock.Generation != lock.Generation {
 				return fmt.Errorf("failed to verify created wake lock generation")
 			}
+			if options.target != nil {
+				if err := reconcileWakeStateAfterLegacyMutationAt(dirfd, agentDir, root, me); err != nil {
+					if continueAfterWakeStateProjectionError(err) {
+						return nil
+					}
+					return err
+				}
+			}
 			return nil
 		})
 		if err != nil {
@@ -466,6 +474,17 @@ func cleanupGenericWakeGenerationAt(
 			)
 		}
 	}
+	var stateRefreshErr error
+	if !replacement.Exists {
+		stateRefreshErr = reconcileWakeStateAfterLegacyMutationAt(dirfd, agentDir, root, me)
+		if stateRefreshErr != nil {
+			if continueAfterWakeStateProjectionError(stateRefreshErr) {
+				stateRefreshErr = nil
+			} else {
+				stateRefreshErr = fmt.Errorf("refresh wake state after generic cleanup: %w", stateRefreshErr)
+			}
+		}
+	}
 
 	floorCleanupErr := cleanupGenericWakeRepairFloorAt(
 		dirfd,
@@ -479,6 +498,7 @@ func cleanupGenericWakeGenerationAt(
 		interleaveErr,
 		replacementErr,
 		preparedCleanupErr,
+		stateRefreshErr,
 		floorCleanupErr,
 	)
 }

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1430,7 +1430,7 @@ func TestRunWakeWithLoopAcceptExistingRemovesReadyAfterOwnerLoss(t *testing.T) {
 		ProcessStart: "67890",
 		BootID:       owner.BootID,
 		Executable:   "/opt/homebrew/bin/amq",
-		Generation:   "generation-1",
+		Generation:   "11111111111111111111111111111111",
 		OwnerSchema:  wakeOwnerLockSchema,
 		Owner:        &owner,
 	}, target)
@@ -5845,7 +5845,7 @@ func TestRunWakeWithLoopWaitsForCurrentPreparedMarkerPastStaleGeneration(t *test
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
-		Generation:   "generation-1",
+		Generation:   "11111111111111111111111111111111",
 	}, target))
 	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)
@@ -5984,7 +5984,7 @@ func TestRunWakeWithLoopRetriesCreatingWakeUntilPrepared(t *testing.T) {
 	}
 	writeWakeLockForTest(t, root, "orchestrator", bindWakeLockToTarget(wakeLock{
 		PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1",
-		Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
+		Executable: "/opt/homebrew/bin/amq", Generation: "11111111111111111111111111111111",
 	}, target))
 	writeWakePreparedForTest(t, root, "orchestrator")
 	// The retry must observe the complete target/lock/prepared publication, not
@@ -6024,7 +6024,7 @@ func TestRunWakeWithLoopRetriesWakeLockChangedWhileOpening(t *testing.T) {
 			target := mustNewWakeTargetForTest(t, root, "orchestrator", injector, nil)
 			lock := bindWakeLockToTarget(wakeLock{
 				PID: wakePID, TTY: "tty", ProcessStart: "start-1", BootID: "boot-1",
-				Executable: "/opt/homebrew/bin/amq", Generation: "generation-1",
+				Executable: "/opt/homebrew/bin/amq", Generation: "11111111111111111111111111111111",
 			}, target)
 			if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 				t.Fatalf("writeWakeTarget: %v", err)
@@ -6509,7 +6509,7 @@ func TestRunWakeWithLoopAcceptExistingWakeAcceptsInjectViaUnknownTTY(t *testing.
 		ProcessStart: "start-1",
 		BootID:       "boot-1",
 		Executable:   "/opt/homebrew/bin/amq",
-		Generation:   "generation-1",
+		Generation:   "11111111111111111111111111111111",
 	}, target))
 	if err := writeWakeTarget(root, "orchestrator", target); err != nil {
 		t.Fatalf("writeWakeTarget: %v", err)


### PR DESCRIPTION
## Summary
- implement W3.3 / P2a shadow dual-write of `.wake.state` from guarded legacy target/prepared mutations
- keep legacy artifacts authoritative; projection failures warn once and continue after the legacy commit
- preserve recognizable newer document/section schemas and self-heal stale current-schema projections
- clarify that the lifecycle guard contract binds writers of every document schema generation

## Scope
- no dual-read activation
- no P2b lock binding
- no lock ABI or public diagnostic/reason-code changes
- no repair-floor format changes

## Exact-tree evidence
- base: `fbc574a8d2b26b2526dfae5d9c5c87408007ac39`
- commit: `ece8fff`
- tree: `11eb81bc14c867a02634f45123a774a0c55ae2b2`
- cached delta SHA-256: `15325aea7a356852e38dbcd18db81d7320852479e794dab7838d362e8f418921`
- full-index delta SHA-256: `37a527c278c7190b10dc1fad5b963bb28db7527f85e58f92740bc1bbf5c8420f`

## Verification
- `make ci`
- P0 binary ABI suite
- Linux Docker newer-schema/mixed-version coverage
- two independent exact-tree reviews: PASS
- Claude exact-tree bound gate: PASS
- ChatGPT Pro complete-packet gate: GO

The adversarial classifier matrix confirms document, target, and prepared schema bumps are preserved. Absence of the top-level schema discriminator is intentionally classified as malformed and therefore healable, not as a recognizable newer document. Concurrent writers that bypass the lifecycle guard are out of contract for every schema generation; adding exchange/quarantine for that hypothetical would introduce a real crash transaction.
