### PR TITLE
feat(wake): prefer state document on validated dual-read

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -490,7 +490,7 @@ func checkWakeLocksWithHintsSchema(
 			root,
 			agent,
 			inspection,
-			func() (wakeTarget, bool, error) { return readWakeTarget(root, agent) },
+			func() (wakeTarget, bool, error) { return readWakeTargetFromState(root, agent) },
 			func(target wakeTarget) error {
 				return validateWakeRepairFloorAvailable(root, agent, inspection, target)
 			},

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -186,17 +186,23 @@ func observeWakeCheck(root, me string) (wakeCheckObservation, error) {
 			me,
 			observation.Inspection,
 			func() (wakeTarget, bool, error) {
-				snapshot, exists, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
-				observation.Target.Exists = exists
-				if err != nil || !exists {
-					return snapshot.Target, exists, err
+				selection, err := readWakeStateSelectionAt(dirfd, agentDir, root, me)
+				observation.Target.Exists = selection.TargetPresent
+				if err != nil || !selection.TargetPresent {
+					return selection.Target, selection.TargetPresent, err
 				}
-				fingerprint, err := newWakeCheckMetadataFingerprint(exists, snapshot.Raw, snapshot.FileInfo)
+				// Keep the public observation bound to legacy authority. Shadow-state
+				// replacement must not create diagnostic or retry drift in P2a.
+				fingerprint, err := newWakeCheckMetadataFingerprint(
+					selection.legacy.TargetPresent,
+					selection.legacy.Target.Raw,
+					selection.legacy.Target.FileInfo,
+				)
 				if err != nil {
-					return snapshot.Target, exists, err
+					return selection.Target, selection.TargetPresent, err
 				}
 				observation.Target = fingerprint
-				return snapshot.Target, true, nil
+				return selection.Target, true, nil
 			},
 			func(target wakeTarget) error {
 				snapshot, exists, err := readWakeRepairFloorSnapshotAt(dirfd, agentDir)

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -5,11 +5,14 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -191,7 +194,73 @@ type wakeGenerationFileSnapshot struct {
 	Marker   wakeReady
 	Raw      []byte
 	FileInfo os.FileInfo
+	Failure  *wakeGenerationFileFailureSnapshot
 }
+
+type wakeGenerationFileFailureSnapshot struct {
+	Stage         string
+	Class         string
+	Identity      wakeFileIdentity
+	IdentityKnown bool
+	Mode          uint32
+	Size          int64
+}
+
+func wakeGenerationFileFailureClass(err error) string {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return "errno:" + strconv.FormatUint(uint64(errno), 10)
+	}
+	return err.Error()
+}
+
+func captureWakeGenerationFileIdentityAt(
+	dirfd int,
+	name string,
+) (wakeFileIdentity, uint32, int64, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstatat(dirfd, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return wakeFileIdentity{}, 0, 0, err
+	}
+	return wakeFileIdentity{
+		Device:    uint64(stat.Dev),
+		Inode:     uint64(stat.Ino),
+		CTimeSec:  int64(stat.Ctim.Sec),
+		CTimeNsec: int64(stat.Ctim.Nsec),
+	}, uint32(stat.Mode), stat.Size, nil
+}
+
+func recordWakeGenerationFileFailureAt(
+	dirfd int,
+	name string,
+	stage string,
+	err error,
+	snapshot wakeGenerationFileSnapshot,
+) wakeGenerationFileSnapshot {
+	failure := &wakeGenerationFileFailureSnapshot{
+		Stage: stage,
+		Class: wakeGenerationFileFailureClass(err),
+	}
+	if snapshot.FileInfo != nil {
+		failure.Identity, failure.IdentityKnown = captureWakeFileIdentity(snapshot.FileInfo)
+		failure.Mode = uint32(snapshot.FileInfo.Mode())
+		failure.Size = snapshot.FileInfo.Size()
+	} else if stage == "open" {
+		identity, mode, size, statErr := captureWakeGenerationFileIdentityAt(dirfd, name)
+		if statErr != nil {
+			snapshot.Failure = failure
+			return snapshot
+		}
+		failure.Identity = identity
+		failure.IdentityKnown = true
+		failure.Mode = mode
+		failure.Size = size
+	}
+	snapshot.Failure = failure
+	return snapshot
+}
+
+var afterWakeGenerationFileSnapshotDataRead = func(string) {}
 
 func readWakeGenerationFileSnapshotAt(
 	dirfd int,
@@ -212,31 +281,50 @@ func readWakeGenerationFileSnapshotAt(
 		if err == unix.ENOENT {
 			return wakeGenerationFileSnapshot{}, false, nil
 		}
-		return wakeGenerationFileSnapshot{}, true, err
+		snapshot := recordWakeGenerationFileFailureAt(
+			dirfd, name, "open", err, wakeGenerationFileSnapshot{},
+		)
+		return snapshot, true, err
 	}
 	defer func() { _ = file.Close() }()
 	info, err := file.Stat()
 	if err != nil {
-		return wakeGenerationFileSnapshot{}, true, err
+		snapshot := recordWakeGenerationFileFailureAt(
+			dirfd, name, "stat", err, wakeGenerationFileSnapshot{},
+		)
+		return snapshot, true, err
 	}
+	snapshot := wakeGenerationFileSnapshot{FileInfo: info}
 	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
-		return wakeGenerationFileSnapshot{}, true, fmt.Errorf("%s must be a regular 0600 file", label)
+		err := fmt.Errorf("%s must be a regular 0600 file", label)
+		return recordWakeGenerationFileFailureAt(dirfd, name, "shape", err, snapshot), true, err
 	}
 	if err := validateWakeTargetPathOwnership(label, path, info); err != nil {
-		return wakeGenerationFileSnapshot{}, true, err
+		return recordWakeGenerationFileFailureAt(dirfd, name, "ownership", err, snapshot), true, err
 	}
 	data, err := readWakeMetadata(file, label, path)
 	if err != nil {
-		return wakeGenerationFileSnapshot{}, true, err
+		return recordWakeGenerationFileFailureAt(dirfd, name, "read", err, snapshot), true, err
 	}
+	snapshot.Raw = bytes.Clone(data)
+	afterWakeGenerationFileSnapshotDataRead(name)
 	pathFile, err := open()
 	if err != nil {
-		return wakeGenerationFileSnapshot{}, true, err
+		return wakeGenerationFileSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("%s changed while reopening: %w", label, err),
+		)
 	}
 	pathInfo, statErr := pathFile.Stat()
 	_ = pathFile.Close()
 	if statErr != nil {
-		return wakeGenerationFileSnapshot{}, true, statErr
+		return wakeGenerationFileSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("%s changed while restating: %w", label, statErr),
+		)
+	}
+	if !sameWakeFileIdentity(info, pathInfo) {
+		return wakeGenerationFileSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("%s changed while opening", label),
+		)
 	}
 	if !pathInfo.Mode().IsRegular() || pathInfo.Mode().Perm() != 0o600 {
 		return wakeGenerationFileSnapshot{}, true, fmt.Errorf("%s must be a regular 0600 file", label)
@@ -244,23 +332,16 @@ func readWakeGenerationFileSnapshotAt(
 	if err := validateWakeTargetPathOwnership(label, path, pathInfo); err != nil {
 		return wakeGenerationFileSnapshot{}, true, err
 	}
-	if !sameWakeFileIdentity(info, pathInfo) {
-		return wakeGenerationFileSnapshot{}, true, newWakeSnapshotReadChangedError(
-			fmt.Errorf("%s changed while opening", label),
-		)
-	}
 	var marker wakeReady
 	if err := json.Unmarshal(data, &marker); err != nil {
-		return wakeGenerationFileSnapshot{}, true, err
+		return recordWakeGenerationFileFailureAt(dirfd, name, "parse", err, snapshot), true, err
 	}
 	if marker.Schema != wakeReadySchema || marker.Generation == "" {
-		return wakeGenerationFileSnapshot{}, true, fmt.Errorf("%s schema is unsupported", label)
+		err := fmt.Errorf("%s schema is unsupported", label)
+		return recordWakeGenerationFileFailureAt(dirfd, name, "schema", err, snapshot), true, err
 	}
-	return wakeGenerationFileSnapshot{
-		Marker:   marker,
-		Raw:      bytes.Clone(data),
-		FileInfo: info,
-	}, true, nil
+	snapshot.Marker = marker
+	return snapshot, true, nil
 }
 
 func readWakeGenerationFileAt(

--- a/internal/cli/wake_owner_mixed_version_test.go
+++ b/internal/cli/wake_owner_mixed_version_test.go
@@ -188,6 +188,78 @@ func TestLegacyWriterPreservesNewerWakeStateDocument(t *testing.T) {
 		t.Fatalf("legacy writer did not commit orphan target cleanup: %v", err)
 	}
 	assertWakeStateSnapshotUnchangedForTest(t, statePath, stateRaw, stateInfo)
+	selection, err := readWakeStateSelection(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selection.TargetPresent || selection.StatePreferred {
+		t.Fatalf("new reader did not fall back after legacy-only mutation: %#v", selection)
+	}
+	assertWakeStateSnapshotUnchangedForTest(t, statePath, stateRaw, stateInfo)
+}
+
+func TestWakeStateDualReadMixedVersionMatrix(t *testing.T) {
+	legacyBinary := buildHistoricalAMQForWakeStateTest(t, wakeStateLegacyWriterCommit)
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	injector := writeExecutableForTest(t, "mixed-version-dual-read-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"legacy"})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	fixture := wakeStateUnixFixture{root: root, agent: "codex", agentDir: agentDir}
+
+	selection, err := readWakeStateSelectionForTest(t, fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selection.StatePreferred || !selection.TargetPresent || !sameWakeTarget(selection.Target, target) {
+		t.Fatalf("legacy-only selection = %#v", selection)
+	}
+	statePath := filepath.Join(fsq.AgentBase(root, "codex"), wakeStateFileName)
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("legacy-only read created state: %v", err)
+	}
+
+	legacyBefore := runHistoricalWakeCheckForStateTest(t, legacyBinary, root)
+	publishWakeStateForDualReadTest(t, fixture)
+	selection, err = readWakeStateSelectionForTest(t, fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !selection.StatePreferred || !sameWakeTarget(selection.Target, target) {
+		t.Fatalf("projected selection = %#v", selection)
+	}
+	legacyAfter := runHistoricalWakeCheckForStateTest(t, legacyBinary, root)
+	if !bytes.Equal(legacyBefore, legacyAfter) {
+		t.Fatalf("historical reader changed after state projection:\nbefore=%s\nafter=%s", legacyBefore, legacyAfter)
+	}
+}
+
+func runHistoricalWakeCheckForStateTest(t *testing.T, binary, root string) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, binary, "wake", "check", "--root", root, "--me", "codex", "--json")
+	command.Env = ownerFenceCommandEnv(root)
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("historical wake check timed out: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("historical wake check failed: %v\n%s", err, output)
+	}
+	return output
 }
 
 func buildHistoricalAMQForWakeStateTest(t *testing.T, commit string) string {

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -27,6 +27,7 @@ var errWakeOwnerLockExists = errors.New("wake lock already exists")
 var publishAuthoritativeWakeLinkAt = unix.Linkat
 var publishAuthoritativeWakeAfterTargetRename = func() {}
 var removeAuthoritativeWakeAfterLockRelease = func() {}
+var afterWakeTargetSnapshotDataRead = func() {}
 
 func (err *wakeOwnerPublicationError) Error() string {
 	return err.Err.Error()
@@ -392,8 +393,11 @@ func readWakeTargetSnapshotAt(
 	if err != nil {
 		return wakeTargetSnapshot{}, true, fmt.Errorf("stat wake target: %w", err)
 	}
-	if !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
-		return wakeTargetSnapshot{}, true, fmt.Errorf("wake target must be a regular 0600 file")
+	if !info.Mode().IsRegular() {
+		return wakeTargetSnapshot{}, true, fmt.Errorf("wake target must be a regular file")
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return wakeTargetSnapshot{}, true, fmt.Errorf("wake target mode is %o, want 0600", got)
 	}
 	if err := validateWakeTargetPathOwnership("wake target", path, info); err != nil {
 		return wakeTargetSnapshot{}, true, err
@@ -402,30 +406,36 @@ func readWakeTargetSnapshotAt(
 	if err != nil {
 		return wakeTargetSnapshot{}, true, err
 	}
+	afterWakeTargetSnapshotDataRead()
 	pathFile, err := open()
 	if err != nil {
-		return wakeTargetSnapshot{}, true, fmt.Errorf("re-open wake target: %w", err)
+		return wakeTargetSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake target changed while reopening: %w", err),
+		)
 	}
 	pathInfo, statErr := pathFile.Stat()
 	_ = pathFile.Close()
 	if statErr != nil {
-		return wakeTargetSnapshot{}, true, fmt.Errorf("re-stat wake target: %w", statErr)
+		return wakeTargetSnapshot{}, true, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake target changed while restating: %w", statErr),
+		)
 	}
 	if !sameWakeFileIdentity(info, pathInfo) {
 		return wakeTargetSnapshot{}, true, newWakeSnapshotReadChangedError(
 			fmt.Errorf("wake target changed while opening"),
 		)
 	}
-	var target wakeTarget
-	if err := json.Unmarshal(data, &target); err != nil {
-		return wakeTargetSnapshot{}, true, fmt.Errorf("parse wake target: %w", err)
-	}
-	_ = agentDir
-	return wakeTargetSnapshot{
-		Target:   target,
+	snapshot := wakeTargetSnapshot{
 		Raw:      data,
 		FileInfo: info,
-	}, true, nil
+	}
+	var target wakeTarget
+	if err := json.Unmarshal(data, &target); err != nil {
+		return snapshot, true, fmt.Errorf("parse wake target: %w", err)
+	}
+	_ = agentDir
+	snapshot.Target = target
+	return snapshot, true, nil
 }
 
 func removeAuthoritativeWakeClaimAt(

--- a/internal/cli/wake_p0_golden_abi_unix_test.go
+++ b/internal/cli/wake_p0_golden_abi_unix_test.go
@@ -260,6 +260,182 @@ func TestWakeP0BinaryV1DefaultCheckSchemaBytes(t *testing.T) {
 	}
 }
 
+func TestWakeP0BinaryDiagnosticsIgnoreP2aStatePresenceAndValidity(t *testing.T) {
+	binary, repoRoot := buildWakeABIBinary(t)
+	root := t.TempDir()
+	initializeWakeABIRoot(t, binary, repoRoot, root)
+	injector := writeExecutableForTest(t, "wake-p0-dual-read-injector")
+	target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"p2a"})
+	if err := writeWakeTarget(root, "codex", target); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	fixture := wakeStateUnixFixture{root: root, agent: "codex", agentDir: agentDir}
+
+	absent := runWakeP0StateDiagnostics(t, binary, repoRoot, root)
+	publishWakeStateForDualReadTest(t, fixture)
+	present := runWakeP0StateDiagnostics(t, binary, repoRoot, root)
+	assertWakeP0StateDiagnosticsEqual(t, absent, present, "eligible state")
+	statePath := filepath.Join(agentDir.path, wakeStateFileName)
+	if err := os.WriteFile(statePath, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	malformed := runWakeP0StateDiagnostics(t, binary, repoRoot, root)
+	assertWakeP0StateDiagnosticsEqual(t, absent, malformed, "malformed state")
+}
+
+func TestWakeP0BinaryDiagnosticsPreserveStableInvalidPreparedEvidence(t *testing.T) {
+	binary, repoRoot := buildWakeABIBinary(t)
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, string)
+	}{
+		{
+			name: "mode-0640",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Chmod(path, 0o640); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "symlink",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				target := path + ".symlink-target"
+				if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "oversized",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, bytes.Repeat([]byte("x"), maxWakeMetadataFileBytes+1), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			initializeWakeABIRoot(t, binary, repoRoot, root)
+			injector := writeExecutableForTest(t, "wake-p0-invalid-prepared-injector")
+			target := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"p2a"})
+			if err := writeWakeTarget(root, "codex", target); err != nil {
+				t.Fatal(err)
+			}
+			digest, err := wakeTargetDigest(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			preparedPath := wakePreparedPath(root, "codex")
+			if err := writeWakeGenerationFile(preparedPath, "wake prepared marker", wakeReady{
+				Schema:       wakeReadySchema,
+				Generation:   "11111111111111111111111111111111",
+				TargetDigest: digest,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			agentDir, err := openWakeAgentDir(root, "codex")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = agentDir.Close() })
+			fixture := wakeStateUnixFixture{root: root, agent: "codex", agentDir: agentDir}
+			publishWakeStateForDualReadTest(t, fixture)
+			statePath := filepath.Join(agentDir.path, wakeStateFileName)
+			stateRaw, err := os.ReadFile(statePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(statePath); err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(t, preparedPath)
+
+			legacy := runWakeP0StateDiagnostics(t, binary, repoRoot, root)
+			assertWakeP0DiagnosticsHaveNoFalseSnapshotChange(t, legacy, "legacy-only")
+			if err := os.WriteFile(statePath, stateRaw, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			projected := runWakeP0StateDiagnostics(t, binary, repoRoot, root)
+			assertWakeP0StateDiagnosticsEqual(t, legacy, projected, "stable invalid prepared")
+			assertWakeP0DiagnosticsHaveNoFalseSnapshotChange(t, projected, "state present")
+		})
+	}
+}
+
+func assertWakeP0DiagnosticsHaveNoFalseSnapshotChange(
+	t *testing.T,
+	runs [2]wakeABIRun,
+	label string,
+) {
+	t.Helper()
+	for index, name := range []string{"wake check", "doctor ops"} {
+		combined := append(bytes.Clone(runs[index].stdout), runs[index].stderr...)
+		if bytes.Contains(combined, []byte("wake legacy state changed")) ||
+			bytes.Contains(combined, []byte("observation changed")) {
+			t.Fatalf("%s %s falsely reported a stable snapshot change: %s", label, name, combined)
+		}
+	}
+}
+
+func runWakeP0StateDiagnostics(
+	t *testing.T,
+	binary string,
+	repoRoot string,
+	root string,
+) [2]wakeABIRun {
+	t.Helper()
+	env := wakeABICleanEnv()
+	return [2]wakeABIRun{
+		runWakeABIBinary(t, binary, repoRoot, env,
+			"wake", "check", "--root", root, "--me", "codex", "--json", "--json-schema=2"),
+		runWakeABIBinary(t, binary, repoRoot, env,
+			"doctor", "--root", root, "--ops", "--json", "--json-schema=2"),
+	}
+}
+
+func assertWakeP0StateDiagnosticsEqual(
+	t *testing.T,
+	want [2]wakeABIRun,
+	got [2]wakeABIRun,
+	label string,
+) {
+	t.Helper()
+	for index, name := range []string{"wake check", "doctor ops"} {
+		if want[index].code != got[index].code ||
+			!bytes.Equal(want[index].stdout, got[index].stdout) ||
+			!bytes.Equal(want[index].stderr, got[index].stderr) {
+			t.Fatalf(
+				"%s changed %s process bytes:\nwant code=%d stdout=%s stderr=%s\ngot code=%d stdout=%s stderr=%s",
+				label,
+				name,
+				want[index].code,
+				want[index].stdout,
+				want[index].stderr,
+				got[index].code,
+				got[index].stdout,
+				got[index].stderr,
+			)
+		}
+	}
+}
+
 func wakeABIBinaryVersion(t *testing.T, binary, repoRoot string) string {
 	t.Helper()
 	run := runWakeABIBinary(t, binary, repoRoot, wakeABICleanEnv(), "--version")

--- a/internal/cli/wake_prepared_unix.go
+++ b/internal/cli/wake_prepared_unix.go
@@ -98,22 +98,11 @@ func freezeGenericWakePreparedCleanupAt(
 }
 
 func validateWakePreparedFileAgainstInspection(root, me string, current wakeLockInspection) (bool, error) {
-	marker, exists, err := readWakeGenerationFile(wakePreparedPath(root, me), "wake prepared marker")
+	selection, err := readWakeStateSelection(root, me)
 	if err != nil {
 		return false, err
 	}
-	if !exists {
-		return false, nil
-	}
-	if marker.Generation != current.Lock.Generation {
-		// Persistent marker from the previous wake generation: this exact wake
-		// has not published preparation yet, so its caller should keep polling.
-		return false, nil
-	}
-	if err := validateWakeReadyLockAndTarget(root, me, current, marker); err != nil {
-		return false, fmt.Errorf("existing amq wake prepared marker is not valid: %w", err)
-	}
-	return true, nil
+	return validateWakePreparedSelection(current, selection)
 }
 
 func validateWakePreparedFileAgainstInspectionAt(
@@ -123,22 +112,46 @@ func validateWakePreparedFileAgainstInspectionAt(
 	me string,
 	current wakeLockInspection,
 ) (bool, error) {
-	marker, exists, err := readWakeGenerationFileAt(
-		dirfd,
-		agentDir,
-		wakePreparedFileName,
-		"wake prepared marker",
-	)
+	selection, err := readWakeStateSelectionAt(dirfd, agentDir, root, me)
 	if err != nil {
 		return false, err
 	}
-	if !exists || marker.Generation != current.Lock.Generation {
+	return validateWakePreparedSelection(current, selection)
+}
+
+func validateWakePreparedSelection(
+	current wakeLockInspection,
+	selection wakeStateReadSelection,
+) (bool, error) {
+	if selection.PreparedErr != nil {
+		return false, selection.PreparedErr
+	}
+	var prepared *wakeStatePrepared
+	if selection.PreparedPresent {
+		prepared = &wakeStatePrepared{
+			Schema:       selection.Prepared.Schema,
+			Generation:   selection.Prepared.Generation,
+			TargetDigest: selection.Prepared.TargetDigest,
+		}
+	}
+	observation := classifyWakeStatePrepared(
+		prepared,
+		current.Lock.Generation,
+		current.Lock.TargetDigest,
+	)
+	if observation == wakeStatePreparedAbsent || observation == wakeStatePreparedStale {
+		// A missing marker or one from a previous generation is not preparation.
 		return false, nil
 	}
-	if err := validateWakeReadyLockAndTargetAt(dirfd, agentDir, root, me, current, marker); err != nil {
+	if err := validateWakeReadyLockAndSelectedTarget(
+		current,
+		selection.Prepared,
+		selection.Target,
+		selection.TargetPresent,
+	); err != nil {
 		return false, fmt.Errorf("existing amq wake prepared marker is not valid: %w", err)
 	}
-	return true, nil
+	return observation == wakeStatePreparedCurrent, nil
 }
 
 func writeWakeReadyFileForPreparedWake(root, me, path string, expected wakeLockInspection, deadline time.Time) error {

--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -236,25 +236,22 @@ func validateWakeGenerationFile(path, label string, info os.FileInfo) error {
 	return validateWakeTargetPathOwnership(label, path, info)
 }
 
-func validateWakeReadyLockAndTarget(root, me string, current wakeLockInspection, ready wakeReady) error {
+func validateWakeReadyLockAndSelectedTarget(
+	current wakeLockInspection,
+	ready wakeReady,
+	target wakeTarget,
+	targetExists bool,
+) error {
 	if err := validateWakeReadyAgainstLock(current, ready); err != nil {
 		return err
 	}
 	if current.Lock.TargetDigest == "" {
-		_, exists, err := readWakeTarget(root, me)
-		if err != nil {
-			return err
-		}
-		if exists {
+		if targetExists {
 			return fmt.Errorf("wake readiness target does not match current wake lock")
 		}
 		return nil
 	}
-	target, exists, err := readWakeTarget(root, me)
-	if err != nil {
-		return err
-	}
-	if !exists {
+	if !targetExists {
 		return fmt.Errorf("wake readiness target is missing")
 	}
 	return validateWakeReadyTargetAndOwner(current, target)
@@ -268,23 +265,16 @@ func validateWakeReadyLockAndTargetAt(
 	current wakeLockInspection,
 	ready wakeReady,
 ) error {
-	if err := validateWakeReadyAgainstLock(current, ready); err != nil {
-		return err
-	}
-	target, exists, err := readWakeTargetAt(dirfd, agentDir, root, me)
+	selection, err := readWakeStateSelectionAt(dirfd, agentDir, root, me)
 	if err != nil {
 		return err
 	}
-	if current.Lock.TargetDigest == "" {
-		if exists {
-			return fmt.Errorf("wake readiness target does not match current wake lock")
-		}
-		return nil
-	}
-	if !exists {
-		return fmt.Errorf("wake readiness target is missing")
-	}
-	return validateWakeReadyTargetAndOwner(current, target)
+	return validateWakeReadyLockAndSelectedTarget(
+		current,
+		ready,
+		selection.Target,
+		selection.TargetPresent,
+	)
 }
 
 func validateWakeReadyAgainstLock(current wakeLockInspection, ready wakeReady) error {

--- a/internal/cli/wake_state.go
+++ b/internal/cli/wake_state.go
@@ -219,6 +219,8 @@ func newerWakeStateSchema(data []byte) (component string, schema int, ok bool) {
 	if err := json.Unmarshal(data, &document); err != nil {
 		return "", 0, false
 	}
+	// A missing or malformed schema is invalid/healable state, not evidence of
+	// a recognizable newer document that must be preserved specially.
 	documentSchema, valid := wakeStateSchemaNumber(document["schema"])
 	if valid && documentSchema > wakeStateSchema {
 		return "", documentSchema, true
@@ -357,6 +359,8 @@ func validateWakeStateAgainstLegacy(state wakeState, legacy wakeStateLegacy) err
 	if err != nil {
 		return err
 	}
+	// The semantic digest covers the complete wakeTarget, including Root and
+	// Agent; validateWakeStateTarget has already enforced their canonical shape.
 	if state.Target.TargetDigest != wantTarget {
 		return newWakeStateLegacyMismatch("target semantic digest mismatch")
 	}

--- a/internal/cli/wake_state_dual_read_other.go
+++ b/internal/cli/wake_state_dual_read_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package cli
+
+func readWakeTargetFromState(root, me string) (wakeTarget, bool, error) {
+	return readWakeTarget(root, me)
+}

--- a/internal/cli/wake_state_dual_read_unix.go
+++ b/internal/cli/wake_state_dual_read_unix.go
@@ -1,0 +1,167 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// afterWakeStateDualReadDocument is a test seam between the shadow-document
+// observation and the closing legacy observation.
+var afterWakeStateDualReadDocument = func() {}
+
+type wakeStateReadSelection struct {
+	Target          wakeTarget
+	TargetPresent   bool
+	Prepared        wakeReady
+	PreparedPresent bool
+	PreparedErr     error
+	StatePreferred  bool
+	legacy          wakeStateLegacySnapshot
+}
+
+func readWakeStateSelection(root, me string) (wakeStateReadSelection, error) {
+	if err := fsq.ValidateHandle(me); err != nil {
+		return wakeStateReadSelection{}, err
+	}
+	agentDir, err := openWakeDirectory(fsq.AgentBase(root, me), "wake agent directory")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return wakeStateReadSelection{}, nil
+		}
+		return wakeStateReadSelection{}, err
+	}
+	defer func() { _ = agentDir.Close() }()
+	var selection wakeStateReadSelection
+	err = agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		selection, readErr = readWakeStateSelectionAt(dirfd, agentDir, root, me)
+		return readErr
+	})
+	if err != nil {
+		return selection, err
+	}
+	if err := validateCanonicalWakeAgentDir(agentDir); err != nil {
+		return wakeStateReadSelection{}, err
+	}
+	return selection, nil
+}
+
+func readWakeStateSelectionAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) (wakeStateReadSelection, error) {
+	before, beforePreparedErr, err := readWakeStateLegacyPairAt(dirfd, agentDir, root, me)
+	if err != nil {
+		return wakeStateSelectionFromLegacy(before), err
+	}
+	state, stateExists, stateErr := readWakeStateSnapshotAt(dirfd, agentDir)
+	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
+		return wakeStateReadSelection{}, err
+	}
+	afterWakeStateDualReadDocument()
+	after, afterPreparedErr, err := readWakeStateLegacyPairAt(dirfd, agentDir, root, me)
+	if err != nil {
+		changed := newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake legacy state changed during closing observation: %w", err),
+		)
+		if after.TargetPresent || !before.TargetPresent {
+			return wakeStateSelectionFromLegacy(after), changed
+		}
+		return wakeStateSelectionFromLegacy(before), changed
+	}
+	if !sameWakeStateLegacySnapshot(before, after) {
+		return wakeStateReadSelection{}, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake legacy state changed during state selection"),
+		)
+	}
+
+	selection := wakeStateSelectionFromLegacy(after)
+	selection.PreparedErr = afterPreparedErr
+	if stateErr != nil || !stateExists || !after.TargetPresent ||
+		beforePreparedErr != nil || afterPreparedErr != nil {
+		return selection, nil
+	}
+	if err := validateWakeStateAgainstLegacy(state.State, after.legacy()); err != nil {
+		return selection, nil
+	}
+	selection.Target = state.State.Target.wakeTarget()
+	selection.TargetPresent = true
+	selection.PreparedPresent = state.State.Prepared != nil
+	if state.State.Prepared != nil {
+		selection.Prepared = wakeReady{
+			Schema:       state.State.Prepared.Schema,
+			Generation:   state.State.Prepared.Generation,
+			TargetDigest: state.State.Prepared.TargetDigest,
+		}
+	}
+	selection.StatePreferred = true
+	return selection, nil
+}
+
+func wakeStateSelectionFromLegacy(legacy wakeStateLegacySnapshot) wakeStateReadSelection {
+	return wakeStateReadSelection{
+		Target:          legacy.Target.Target,
+		TargetPresent:   legacy.TargetPresent,
+		Prepared:        legacy.Prepared.Marker,
+		PreparedPresent: legacy.PreparedPresent,
+		legacy:          legacy,
+	}
+}
+
+func readWakeStateLegacyPairAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) (wakeStateLegacySnapshot, error, error) {
+	if err := validateWakeStateAgentDirAt(dirfd, agentDir); err != nil {
+		return wakeStateLegacySnapshot{}, nil, err
+	}
+	target, targetPresent, err := readWakeTargetSnapshotAt(dirfd, agentDir, root, me)
+	snapshot := wakeStateLegacySnapshot{
+		Target:        target,
+		TargetPresent: targetPresent,
+	}
+	if err != nil {
+		return snapshot, nil, err
+	}
+	if targetPresent {
+		if err := validateWakeTarget(target.Target, root, me); err != nil {
+			return snapshot, nil, err
+		}
+	}
+	prepared, preparedPresent, err := readWakeGenerationFileSnapshotAt(
+		dirfd,
+		agentDir,
+		wakePreparedFileName,
+		"wake prepared marker",
+	)
+	snapshot.Prepared = prepared
+	snapshot.PreparedPresent = preparedPresent
+	if err != nil {
+		return snapshot, err, nil
+	}
+	return snapshot, nil, nil
+}
+
+func readWakeTargetFromState(root, me string) (wakeTarget, bool, error) {
+	selection, err := readWakeStateSelection(root, me)
+	return selection.Target, selection.TargetPresent, err
+}
+
+func readWakeTargetFromStateAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+) (wakeTarget, bool, error) {
+	selection, err := readWakeStateSelectionAt(dirfd, agentDir, root, me)
+	return selection.Target, selection.TargetPresent, err
+}

--- a/internal/cli/wake_state_dual_read_unix_test.go
+++ b/internal/cli/wake_state_dual_read_unix_test.go
@@ -1,0 +1,817 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWakeStateDualReadPrefersExactState(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "legacy")
+	publishWakeStateForDualReadTest(t, fixture)
+
+	selection, err := readWakeStateSelectionForTest(t, fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !selection.StatePreferred {
+		t.Fatal("exact state was not preferred")
+	}
+	if got := selection.Target.InjectArgs; len(got) != 1 || got[0] != "legacy" {
+		t.Fatalf("target args = %v", got)
+	}
+}
+
+func TestWakeStateDualReadPrefersDocumentWithoutExtraLegacyParse(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "legacy")
+	publishWakeStateForDualReadTest(t, fixture)
+	original := afterWakeTargetSnapshotDataRead
+	captures := 0
+	afterWakeTargetSnapshotDataRead = func() { captures++ }
+	t.Cleanup(func() { afterWakeTargetSnapshotDataRead = original })
+
+	selection, err := readWakeStateSelectionForTest(t, fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !selection.StatePreferred {
+		t.Fatal("exact state was not preferred")
+	}
+	if captures != 2 {
+		t.Fatalf("legacy target reads = %d, want exactly 2", captures)
+	}
+}
+
+func TestWakeStateDualReadFallsBackWithoutMutatingDocument(t *testing.T) {
+	tests := []struct {
+		name   string
+		absent bool
+		mutate func(t *testing.T, raw []byte) []byte
+	}{
+		{name: "absent", absent: true},
+		{name: "malformed", mutate: func(_ *testing.T, _ []byte) []byte { return []byte("{") }},
+		{name: "noncanonical", mutate: func(_ *testing.T, raw []byte) []byte { return append(raw, '\n') }},
+		{name: "newer", mutate: func(t *testing.T, raw []byte) []byte {
+			return newerWakeStateRawForTest(t, raw, "document")
+		}},
+		{name: "newer target", mutate: func(t *testing.T, raw []byte) []byte {
+			return newerWakeStateRawForTest(t, raw, "target")
+		}},
+		{name: "schema less", mutate: func(t *testing.T, raw []byte) []byte {
+			var document map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &document); err != nil {
+				t.Fatal(err)
+			}
+			delete(document, "schema")
+			changed, err := json.Marshal(document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return changed
+		}},
+		{name: "target schema less", mutate: func(t *testing.T, raw []byte) []byte {
+			var document map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &document); err != nil {
+				t.Fatal(err)
+			}
+			var target map[string]json.RawMessage
+			if err := json.Unmarshal(document["target"], &target); err != nil {
+				t.Fatal(err)
+			}
+			delete(target, "schema")
+			document["target"], _ = json.Marshal(target)
+			changed, err := json.Marshal(document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return changed
+		}},
+		{name: "target missing from state", mutate: func(t *testing.T, raw []byte) []byte {
+			var document map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &document); err != nil {
+				t.Fatal(err)
+			}
+			delete(document, "target")
+			changed, err := json.Marshal(document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return changed
+		}},
+		{name: "prepared exists only in state", mutate: func(t *testing.T, raw []byte) []byte {
+			var state wakeState
+			if err := json.Unmarshal(raw, &state); err != nil {
+				t.Fatal(err)
+			}
+			state.Prepared = &wakeStatePrepared{
+				Schema:        wakeStatePreparedSchema,
+				Generation:    "11111111111111111111111111111111",
+				LegacyPresent: true,
+				TargetDigest:  state.Target.TargetDigest,
+				LegacyDigest:  "sha256:" + string(bytes.Repeat([]byte{'0'}, 64)),
+			}
+			changed, err := json.Marshal(state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return changed
+		}},
+		{name: "legacy digest mismatch", mutate: func(t *testing.T, raw []byte) []byte {
+			var state wakeState
+			if err := json.Unmarshal(raw, &state); err != nil {
+				t.Fatal(err)
+			}
+			state.Target.LegacyDigest = "sha256:" + string(bytes.Repeat([]byte{'0'}, 64))
+			changed, err := json.Marshal(state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return changed
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeStateUnixFixture(t, "legacy")
+			publishWakeStateForDualReadTest(t, fixture)
+			path := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var installed []byte
+			if test.absent {
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				installed = test.mutate(t, raw)
+				if err := os.WriteFile(path, installed, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before := snapshotWakeCheckTree(t, fixture.root)
+			var selection wakeStateReadSelection
+			var readErr error
+			stderr := captureWakeStderr(t, func() {
+				selection, readErr = readWakeStateSelectionForTest(t, fixture)
+			})
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want silent fallback", stderr)
+			}
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if selection.StatePreferred {
+				t.Fatal("invalid state was preferred")
+			}
+			assertWakeCheckTreeUnchanged(t, fixture.root, before)
+			if !test.absent {
+				got, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, installed) {
+					t.Fatalf("read mutated state: got %q want %q", got, installed)
+				}
+			}
+		})
+	}
+}
+
+func TestWakePreparedDualReadFourWay(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(t *testing.T, fixture *authoritativeWakePreparedCleanupFixture)
+		wantReady bool
+		wantError bool
+	}{
+		{name: "absent", configure: func(t *testing.T, fixture *authoritativeWakePreparedCleanupFixture) {
+			if err := os.Remove(fixture.preparedPath); err != nil {
+				t.Fatal(err)
+			}
+			republishWakeStateForPreparedTest(t, fixture)
+		}},
+		{name: "stale generation", configure: func(t *testing.T, fixture *authoritativeWakePreparedCleanupFixture) {
+			marker := fixture.preparedMarker
+			marker.Generation = "11111111111111111111111111111111"
+			if err := writeWakeGenerationFile(fixture.preparedPath, "wake prepared marker", marker); err != nil {
+				t.Fatal(err)
+			}
+			republishWakeStateForPreparedTest(t, fixture)
+		}},
+		{name: "current", wantReady: true},
+		{name: "wrong target digest", wantError: true, configure: func(t *testing.T, fixture *authoritativeWakePreparedCleanupFixture) {
+			marker := fixture.preparedMarker
+			marker.TargetDigest = "sha256:" + string(bytes.Repeat([]byte{'0'}, 64))
+			if err := writeWakeGenerationFile(fixture.preparedPath, "wake prepared marker", marker); err != nil {
+				t.Fatal(err)
+			}
+			republishWakeStateForPreparedTest(t, fixture)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+			if test.configure != nil {
+				test.configure(t, fixture)
+			}
+			before := snapshotWakeCheckTree(t, fixture.root)
+			ready, err := validateWakePreparedFileAgainstInspection(
+				fixture.root,
+				fixture.me,
+				fixture.inspection,
+			)
+			assertPreparedDualReadResult(t, ready, err, test.wantReady, test.wantError)
+
+			var readyAt bool
+			errAt := fixture.agentDir.withFD(func(dirfd int) error {
+				var err error
+				readyAt, err = validateWakePreparedFileAgainstInspectionAt(
+					dirfd,
+					fixture.agentDir,
+					fixture.root,
+					fixture.me,
+					fixture.inspection,
+				)
+				return err
+			})
+			assertPreparedDualReadResult(t, readyAt, errAt, test.wantReady, test.wantError)
+			assertWakeCheckTreeUnchanged(t, fixture.root, before)
+		})
+	}
+}
+
+func TestWakePreparedDualReadFallsBackFromIneligiblePreparedState(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, raw []byte) []byte
+	}{
+		{name: "newer prepared", mutate: func(t *testing.T, raw []byte) []byte {
+			return newerWakeStateRawForTest(t, raw, "prepared")
+		}},
+		{name: "prepared missing from state", mutate: func(t *testing.T, raw []byte) []byte {
+			var state wakeState
+			if err := json.Unmarshal(raw, &state); err != nil {
+				t.Fatal(err)
+			}
+			state.Prepared = nil
+			changed, err := json.Marshal(state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return changed
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+			statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+			raw, err := os.ReadFile(statePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			installed := test.mutate(t, raw)
+			if err := os.WriteFile(statePath, installed, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before := snapshotWakeCheckTree(t, fixture.root)
+			var ready bool
+			var readErr error
+			stderr := captureWakeStderr(t, func() {
+				ready, readErr = validateWakePreparedFileAgainstInspection(
+					fixture.root,
+					fixture.me,
+					fixture.inspection,
+				)
+			})
+			if readErr != nil || !ready {
+				t.Fatalf("legacy prepared fallback ready=%v err=%v", ready, readErr)
+			}
+			if stderr != "" {
+				t.Fatalf("stderr = %q, want silent fallback", stderr)
+			}
+			assertWakeCheckTreeUnchanged(t, fixture.root, before)
+		})
+	}
+}
+
+func TestWakeStateDualReadPreservesPreparedErrorWithoutBreakingTargetRead(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	if err := os.WriteFile(fixture.preparedPath, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotWakeCheckTree(t, fixture.root)
+	target, exists, err := readWakeTargetFromState(fixture.root, fixture.me)
+	if err != nil || !exists || !sameWakeTarget(target, fixture.target) {
+		t.Fatalf("target read exists=%v target=%#v err=%v", exists, target, err)
+	}
+	ready, err := validateWakePreparedFileAgainstInspection(
+		fixture.root,
+		fixture.me,
+		fixture.inspection,
+	)
+	if err == nil || ready {
+		t.Fatalf("prepared read ready=%v err=%v, want legacy parse error", ready, err)
+	}
+	assertWakeCheckTreeUnchanged(t, fixture.root, before)
+}
+
+func TestWakeStateDualReadPreservesTargetForStableInvalidPrepared(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, string)
+	}{
+		{
+			name: "mode-0640",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Chmod(path, 0o640); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "symlink",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				target := path + ".symlink-target"
+				if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "oversized",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, bytes.Repeat([]byte("x"), maxWakeMetadataFileBytes+1), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+			test.mutate(t, fixture.preparedPath)
+			before := snapshotWakeCheckTree(t, fixture.root)
+
+			selection, err := readWakeStateSelection(fixture.root, fixture.me)
+			if err != nil {
+				var changed *wakeSnapshotReadChangedError
+				if errors.As(err, &changed) {
+					t.Fatalf("stable invalid prepared was typed as changed: %v", err)
+				}
+				t.Fatal(err)
+			}
+			if !selection.TargetPresent || !sameWakeTarget(selection.Target, fixture.target) {
+				t.Fatalf("selection target present=%v target=%#v", selection.TargetPresent, selection.Target)
+			}
+			if selection.PreparedErr == nil {
+				t.Fatal("selection lost stable prepared error")
+			}
+			if selection.StatePreferred {
+				t.Fatal("state was preferred despite invalid legacy prepared evidence")
+			}
+			if selection.legacy.Prepared.Failure == nil ||
+				!selection.legacy.Prepared.Failure.IdentityKnown {
+				t.Fatalf("stable prepared failure fingerprint = %#v", selection.legacy.Prepared.Failure)
+			}
+
+			target, exists, err := readWakeTargetFromState(fixture.root, fixture.me)
+			if err != nil || !exists || !sameWakeTarget(target, fixture.target) {
+				t.Fatalf("target read exists=%v target=%#v err=%v", exists, target, err)
+			}
+			ready, err := validateWakePreparedFileAgainstInspection(
+				fixture.root,
+				fixture.me,
+				fixture.inspection,
+			)
+			if err == nil || ready {
+				t.Fatalf("prepared read ready=%v err=%v, want stable validation error", ready, err)
+			}
+			assertWakeCheckTreeUnchanged(t, fixture.root, before)
+		})
+	}
+}
+
+func TestWakeCheckAndDoctorGoldenBytesUnaffectedByWakeStatePresence(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	wakeBefore := wakeCheckPublicBytesForDualReadTest(t, fixture.root, fixture.me)
+	locksBefore, hintsBefore := checkWakeLocksWithHintsSchema(
+		fixture.root,
+		[]string{fixture.me},
+		false,
+		wakeCheckSchemaV2,
+	)
+	doctorBefore, err := json.Marshal(struct {
+		Locks []opsWakeLock `json:"locks"`
+		Hints []opsHint     `json:"hints"`
+	}{locksBefore, hintsBefore})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if err := os.Remove(statePath); err != nil {
+		t.Fatal(err)
+	}
+	absentTree := snapshotWakeCheckTree(t, fixture.root)
+	wakeAfter := wakeCheckPublicBytesForDualReadTest(t, fixture.root, fixture.me)
+	locksAfter, hintsAfter := checkWakeLocksWithHintsSchema(
+		fixture.root,
+		[]string{fixture.me},
+		false,
+		wakeCheckSchemaV2,
+	)
+	doctorAfter, err := json.Marshal(struct {
+		Locks []opsWakeLock `json:"locks"`
+		Hints []opsHint     `json:"hints"`
+	}{locksAfter, hintsAfter})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(wakeBefore, wakeAfter) {
+		t.Fatalf("wake-check decision drifted:\nbefore=%s\nafter=%s", wakeBefore, wakeAfter)
+	}
+	if !bytes.Equal(doctorBefore, doctorAfter) {
+		t.Fatalf("doctor decision drifted:\nbefore=%s\nafter=%s", doctorBefore, doctorAfter)
+	}
+	assertWakeCheckTreeUnchanged(t, fixture.root, absentTree)
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("read-only diagnostics recreated state: %v", err)
+	}
+}
+
+func wakeCheckPublicBytesForDualReadTest(t *testing.T, root, me string) []byte {
+	t.Helper()
+	decision := inspectWakeCheckDecision(root, me)
+	v1, err := json.Marshal(renderWakeCheckV1(decision))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := json.Marshal(renderWakeCheckV2(decision))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(append(v1, '\n'), v2...)
+}
+
+func TestNewCLIDualReadNeverCreatesStateFromReadOnlyPath(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "legacy-only")
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("fixture unexpectedly has state: %v", err)
+	}
+	before := snapshotWakeCheckTree(t, fixture.root)
+	if _, exists, err := readWakeTargetFromState(fixture.root, fixture.agent); err != nil || !exists {
+		t.Fatalf("semantic target read exists=%v err=%v", exists, err)
+	}
+	_ = inspectWakeCheckDecision(fixture.root, fixture.agent)
+	_, _ = checkWakeLocksWithHintsSchema(
+		fixture.root,
+		[]string{fixture.agent},
+		false,
+		wakeCheckSchemaV2,
+	)
+	assertWakeCheckTreeUnchanged(t, fixture.root, before)
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("read-only path created state: %v", err)
+	}
+}
+
+func TestWakeStateDualReadMissingAgentDirectoryIsReadOnly(t *testing.T) {
+	root := secureTempDirForTest(t)
+	agentPath := filepath.Join(root, "agents", "codex")
+	before := snapshotWakeCheckTree(t, root)
+	_, exists, err := readWakeTargetFromState(root, "codex")
+	if err != nil || exists {
+		t.Fatalf("missing-agent target exists=%v err=%v", exists, err)
+	}
+	assertWakeCheckTreeUnchanged(t, root, before)
+	if _, err := os.Stat(agentPath); !os.IsNotExist(err) {
+		t.Fatalf("read-only selector created agent directory: %v", err)
+	}
+}
+
+func TestWakeCheckFingerprintAnchoredToLegacyNotState(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	selection, err := readWakeStateSelection(fixture.root, fixture.me)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !selection.StatePreferred {
+		t.Fatal("fixture state was not preferred")
+	}
+	want, err := newWakeCheckMetadataFingerprint(
+		selection.legacy.TargetPresent,
+		selection.legacy.Target.Raw,
+		selection.legacy.Target.FileInfo,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := observeWakeCheck(fixture.root, fixture.me)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Target != want {
+		t.Fatalf("target fingerprint = %#v, want legacy %#v", first.Target, want)
+	}
+
+	statePath := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := statePath + ".replacement"
+	if err := os.WriteFile(replacement, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, statePath); err != nil {
+		t.Fatal(err)
+	}
+	second, err := observeWakeCheck(fixture.root, fixture.me)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Target != want {
+		t.Fatalf("state replacement changed target fingerprint: got %#v want %#v", second.Target, want)
+	}
+}
+
+func TestWakeStateDualReadFallsBackWhenStateIsReplaced(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "legacy")
+	publishWakeStateForDualReadTest(t, fixture)
+	path := filepath.Join(fixture.agentDir.path, wakeStateFileName)
+	replacement := filepath.Join(fixture.agentDir.path, ".wake-state-replacement")
+	if err := os.WriteFile(replacement, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	original := afterWakeStateSnapshotRead
+	afterWakeStateSnapshotRead = func() {
+		afterWakeStateSnapshotRead = func() {}
+		if err := os.Rename(replacement, path); err != nil {
+			t.Errorf("replace state: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterWakeStateSnapshotRead = original })
+
+	selection, err := readWakeStateSelectionForTest(t, fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selection.StatePreferred {
+		t.Fatal("replaced state was preferred")
+	}
+}
+
+func TestWakeStateDualReadReturnsTypedErrorWhenLegacyChanges(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "before")
+	publishWakeStateForDualReadTest(t, fixture)
+	original := afterWakeStateDualReadDocument
+	afterWakeStateDualReadDocument = func() {
+		afterWakeStateDualReadDocument = func() {}
+		target, exists, err := readWakeTarget(fixture.root, fixture.agent)
+		if err != nil || !exists {
+			t.Errorf("read replacement target: exists=%v err=%v", exists, err)
+			return
+		}
+		target.InjectArgs = []string{"after"}
+		data, err := json.MarshalIndent(target, "", "  ")
+		if err != nil {
+			t.Errorf("marshal replacement target: %v", err)
+			return
+		}
+		if err := os.WriteFile(wakeTargetPath(fixture.root, fixture.agent), append(data, '\n'), 0o600); err != nil {
+			t.Errorf("replace legacy target: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterWakeStateDualReadDocument = original })
+
+	_, err := readWakeStateSelectionForTest(t, fixture)
+	var changed *wakeSnapshotReadChangedError
+	if !errors.As(err, &changed) {
+		t.Fatalf("error = %v, want wakeSnapshotReadChangedError", err)
+	}
+}
+
+func TestWakeStateDualReadReturnsTypedErrorWhenClosingLegacyIsMalformed(t *testing.T) {
+	fixture := newWakeStateUnixFixture(t, "before")
+	publishWakeStateForDualReadTest(t, fixture)
+	original := afterWakeStateDualReadDocument
+	afterWakeStateDualReadDocument = func() {
+		afterWakeStateDualReadDocument = func() {}
+		if err := os.WriteFile(wakeTargetPath(fixture.root, fixture.agent), []byte("{"), 0o600); err != nil {
+			t.Errorf("replace legacy target: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterWakeStateDualReadDocument = original })
+
+	_, err := readWakeStateSelectionForTest(t, fixture)
+	var changed *wakeSnapshotReadChangedError
+	if !errors.As(err, &changed) {
+		t.Fatalf("error = %v, want wakeSnapshotReadChangedError", err)
+	}
+}
+
+func TestWakeStateDualReadReturnsTypedErrorWhenPreparedMarkerChanges(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	original := afterWakeStateDualReadDocument
+	afterWakeStateDualReadDocument = func() {
+		afterWakeStateDualReadDocument = func() {}
+		marker := fixture.preparedMarker
+		marker.Generation = "11111111111111111111111111111111"
+		if err := writeWakeGenerationFile(fixture.preparedPath, "wake prepared marker", marker); err != nil {
+			t.Errorf("replace prepared marker: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterWakeStateDualReadDocument = original })
+
+	_, err := readWakeStateSelection(fixture.root, fixture.me)
+	var changed *wakeSnapshotReadChangedError
+	if !errors.As(err, &changed) {
+		t.Fatalf("error = %v, want wakeSnapshotReadChangedError", err)
+	}
+}
+
+func TestWakeStateDualReadReturnsTypedErrorWhenInvalidPreparedMarkerIsReplaced(t *testing.T) {
+	fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+	if err := os.Chmod(fixture.preparedPath, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	original := afterWakeStateDualReadDocument
+	afterWakeStateDualReadDocument = func() {
+		afterWakeStateDualReadDocument = func() {}
+		replacement := fixture.preparedPath + ".replacement"
+		if err := os.WriteFile(replacement, []byte("replacement"), 0o640); err != nil {
+			t.Errorf("write invalid replacement prepared marker: %v", err)
+			return
+		}
+		if err := os.Rename(replacement, fixture.preparedPath); err != nil {
+			t.Errorf("replace invalid prepared marker: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterWakeStateDualReadDocument = original })
+
+	_, err := readWakeStateSelection(fixture.root, fixture.me)
+	var changed *wakeSnapshotReadChangedError
+	if !errors.As(err, &changed) {
+		t.Fatalf("error = %v, want wakeSnapshotReadChangedError", err)
+	}
+}
+
+func TestWakeTargetAndPreparedReopenFailuresAreTypedSnapshotChanges(t *testing.T) {
+	t.Run("target", func(t *testing.T) {
+		fixture := newWakeStateUnixFixture(t, "legacy")
+		original := afterWakeTargetSnapshotDataRead
+		afterWakeTargetSnapshotDataRead = func() {
+			afterWakeTargetSnapshotDataRead = func() {}
+			if err := os.Remove(wakeTargetPath(fixture.root, fixture.agent)); err != nil {
+				t.Errorf("remove target: %v", err)
+			}
+		}
+		t.Cleanup(func() { afterWakeTargetSnapshotDataRead = original })
+
+		var readErr error
+		if err := fixture.agentDir.withFD(func(dirfd int) error {
+			_, _, readErr = readWakeTargetSnapshotAt(
+				dirfd,
+				fixture.agentDir,
+				fixture.root,
+				fixture.agent,
+			)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		var changed *wakeSnapshotReadChangedError
+		if !errors.As(readErr, &changed) {
+			t.Fatalf("error = %v, want wakeSnapshotReadChangedError", readErr)
+		}
+	})
+
+	t.Run("prepared", func(t *testing.T) {
+		fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+		original := afterWakeGenerationFileSnapshotDataRead
+		afterWakeGenerationFileSnapshotDataRead = func(name string) {
+			if name != wakePreparedFileName {
+				return
+			}
+			afterWakeGenerationFileSnapshotDataRead = func(string) {}
+			if err := os.Remove(fixture.preparedPath); err != nil {
+				t.Errorf("remove prepared marker: %v", err)
+			}
+		}
+		t.Cleanup(func() { afterWakeGenerationFileSnapshotDataRead = original })
+
+		var readErr error
+		if err := fixture.agentDir.withFD(func(dirfd int) error {
+			_, _, readErr = readWakeGenerationFileSnapshotAt(
+				dirfd,
+				fixture.agentDir,
+				wakePreparedFileName,
+				"wake prepared marker",
+			)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		var changed *wakeSnapshotReadChangedError
+		if !errors.As(readErr, &changed) {
+			t.Fatalf("error = %v, want wakeSnapshotReadChangedError", readErr)
+		}
+	})
+
+	t.Run("prepared mode change", func(t *testing.T) {
+		fixture := newAuthoritativeWakePreparedCleanupFixture(t)
+		original := afterWakeGenerationFileSnapshotDataRead
+		afterWakeGenerationFileSnapshotDataRead = func(name string) {
+			if name != wakePreparedFileName {
+				return
+			}
+			afterWakeGenerationFileSnapshotDataRead = func(string) {}
+			if err := os.Chmod(fixture.preparedPath, 0o640); err != nil {
+				t.Errorf("chmod prepared marker: %v", err)
+			}
+		}
+		t.Cleanup(func() {
+			afterWakeGenerationFileSnapshotDataRead = original
+			_ = os.Chmod(fixture.preparedPath, 0o600)
+		})
+
+		var readErr error
+		if err := fixture.agentDir.withFD(func(dirfd int) error {
+			_, _, readErr = readWakeGenerationFileSnapshotAt(
+				dirfd,
+				fixture.agentDir,
+				wakePreparedFileName,
+				"wake prepared marker",
+			)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		var changed *wakeSnapshotReadChangedError
+		if !errors.As(readErr, &changed) {
+			t.Fatalf("error = %v, want wakeSnapshotReadChangedError", readErr)
+		}
+	})
+}
+
+func readWakeStateSelectionForTest(t *testing.T, fixture wakeStateUnixFixture) (wakeStateReadSelection, error) {
+	t.Helper()
+	var selection wakeStateReadSelection
+	err := fixture.agentDir.withFD(func(dirfd int) error {
+		var err error
+		selection, err = readWakeStateSelectionAt(
+			dirfd,
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+		)
+		return err
+	})
+	return selection, err
+}
+
+func publishWakeStateForDualReadTest(t *testing.T, fixture wakeStateUnixFixture) {
+	t.Helper()
+	expected := captureWakeStateLegacyForTest(t, fixture)
+	if _, err := publishWakeStateForTest(fixture, expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func republishWakeStateForPreparedTest(t *testing.T, fixture *authoritativeWakePreparedCleanupFixture) {
+	t.Helper()
+	stateFixture := wakeStateUnixFixture{
+		root:     fixture.root,
+		agent:    fixture.me,
+		agentDir: fixture.agentDir,
+	}
+	publishWakeStateForDualReadTest(t, stateFixture)
+}
+
+func assertPreparedDualReadResult(t *testing.T, ready bool, err error, wantReady, wantError bool) {
+	t.Helper()
+	if (err != nil) != wantError {
+		t.Fatalf("ready=%v error=%v, wantReady=%v wantError=%v", ready, err, wantReady, wantError)
+	}
+	if ready != wantReady {
+		t.Fatalf("ready=%v error=%v, wantReady=%v", ready, err, wantReady)
+	}
+}

--- a/internal/cli/wake_state_unix.go
+++ b/internal/cli/wake_state_unix.go
@@ -436,6 +436,13 @@ func sameWakeStateLegacySnapshot(first, second wakeStateLegacySnapshot) bool {
 		}
 	}
 	if first.PreparedPresent {
+		if first.Prepared.Failure != nil || second.Prepared.Failure != nil {
+			if first.Prepared.Failure == nil || second.Prepared.Failure == nil ||
+				*first.Prepared.Failure != *second.Prepared.Failure {
+				return false
+			}
+			return true
+		}
 		if first.Prepared.FileInfo == nil || second.Prepared.FileInfo == nil ||
 			!sameWakeFileIdentity(first.Prepared.FileInfo, second.Prepared.FileInfo) ||
 			!bytes.Equal(first.Prepared.Raw, second.Prepared.Raw) ||

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -743,7 +743,7 @@ func requireWakeLockUsable(inspection wakeLockInspection, requiredMode string, r
 		if requestedTarget == nil {
 			return fmt.Errorf("existing inject-via wake for %s cannot be reused without a requested wake target", inspection.Agent)
 		}
-		persistedTarget, exists, err := readWakeTarget(inspection.Root, inspection.Agent)
+		persistedTarget, exists, err := readWakeTargetFromState(inspection.Root, inspection.Agent)
 		if err != nil {
 			return fmt.Errorf("existing inject-via wake target for %s is not usable: %w", inspection.Agent, err)
 		}
@@ -960,7 +960,7 @@ func repairWake(root, me string) (wakeRepairResult, error) {
 
 		var exists bool
 		var err error
-		target, exists, err = readWakeTargetAt(dirfd, agentDir, root, me)
+		target, exists, err = readWakeTargetFromStateAt(dirfd, agentDir, root, me)
 		if err != nil {
 			result.Status = "refused"
 			result.Reason = err.Error()


### PR DESCRIPTION
## Summary

- add an FD-bound semantic dual-read selector that accepts `.wake.state` only when it is canonical and exactly matches stable before/after legacy target and prepared snapshots
- fall back silently to legacy state when the projection is absent, malformed, noncanonical, newer, mismatched, or changes during capture
- route semantic wake-check, doctor, readiness, reuse, repair, and prepared polling reads through the selector while keeping mutation, authority, cleanup, and lineage paths legacy-only
- preserve legacy ABI bytes and mixed-version behavior across process boundaries and Linux, Windows, and FreeBSD production builds

## Invariants

- read paths do not create the agent directory or mutate wake artifacts
- all closing legacy capture failures are typed as snapshot-change failures
- target evidence remains available when prepared evidence is malformed
- stable prepared failures carry an exact observation fingerprint, while real replacements remain typed as snapshot changes
- prepared reopen validation is identity-first
- a replacement state document is never treated as authority
- absent `.wake.state` is a behavioral no-op, but incurs two legacy captures plus one failed state open per semantic read

## Verification

- `make ci`
- focused W3.4 dual-read, prepared-state, mixed-version, and process-boundary ABI tests
- `GOOS=linux go build ./cmd/amq`
- `GOOS=windows go build ./cmd/amq`
- `GOOS=freebsd go build ./cmd/amq`
- static read-path mutation search: no create, publish, reconcile, rename, or unlink operations in the dual-read implementation
- required simplify review: PASS
- independent exact-tree review: PASS
- Claude exact-tree review: PASS
- ChatGPT Pro integrated-tree gate: GO

## Frozen review identity

- staged tree: `d9f8dd97e08682c2f6e9dc1bd6c0ed2903e42cd8`
- staged binary diff SHA-256: `e4b572eb6a3e132c4ad276085fd2566de0c5ea87f14c013d4bf715e1d431ad53`

## Out of scope

- W3.5/P2b state binding
- public state-selection reason fields
- the pre-existing orphan recovery target semantic-only unlink race; drafted separately and not posted
