### PR TITLE
fix(wake): guard readiness publication on the capability path

### DIFF
--- a/internal/cli/wake_ready_unix.go
+++ b/internal/cli/wake_ready_unix.go
@@ -30,9 +30,6 @@ func writeWakeReadyFileAgainstOwner(
 	expected wakeLockInspection,
 	requestedOwner *wakeOwner,
 ) error {
-	if path == "" {
-		return nil
-	}
 	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
 		return err
@@ -56,6 +53,14 @@ func writeWakeReadyFileAgainstOwnerInDir(
 	expected wakeLockInspection,
 	requestedOwner *wakeOwner,
 ) error {
+	// No readiness path means no supervising parent is waiting on the
+	// handshake — a bare `amq wake` rather than a repair child or a
+	// `coop exec` launch. Publishing is then a no-op, and this is the one
+	// place every caller passes through, so the rule cannot be bypassed by
+	// entering with an already-open agent directory capability.
+	if path == "" {
+		return nil
+	}
 	if agentDir == nil {
 		return fmt.Errorf("wake agent directory capability is missing")
 	}

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -991,6 +991,42 @@ func TestRunWakeWithLoopWritesReadyFileAfterLock(t *testing.T) {
 	}
 }
 
+// A bare `amq wake` — the invocation an orchestrator spawns directly, with no
+// supervising parent waiting on a readiness handshake — carries no
+// --ready-file. Preparation must still complete: readiness publication is the
+// handshake's side of the contract, not a precondition for owning the wake.
+func TestRunWakeWithLoopPreparesWithoutReadyFile(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "orchestrator"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	injector := writeExecutableForTest(t, "injector")
+	errDone := errors.New("done")
+	err := runWakeWithLoop([]string{
+		"--root", root,
+		"--me", "orchestrator",
+		"--inject-via", injector,
+	}, func(cfg wakeConfig) error {
+		if err := cfg.onPrepared(nil); err != nil {
+			t.Fatalf("prepare wake without --ready-file: %v", err)
+		}
+		if _, exists, preparedErr := readWakeGenerationFile(
+			wakePreparedPath(root, "orchestrator"),
+			"wake prepared marker",
+		); preparedErr != nil || !exists {
+			t.Fatalf("generation-bound prepared marker missing: exists=%v err=%v", exists, preparedErr)
+		}
+		return errDone
+	})
+	if !errors.Is(err, errDone) {
+		t.Fatalf("expected loop sentinel error, got %v", err)
+	}
+}
+
 func TestRunWakeWithLoopBaselinesBeforeReadiness(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {


### PR DESCRIPTION
Fixes #419.

## What was broken

A bare `amq wake` — no `--ready-file` — died within ~300ms of start:

```
install wake ready file: rename .wake-metadata.tmp.<pid>.<nanos>.0 : no such file or directory
```

The rename destination is the empty string. Regression bisected to v0.49.11;
v0.49.10 and earlier are fine.

## Why

`onPrepared` publishes readiness through the agent-dir-capability variant:

```go
return writeWakeReadyFileAgainstOwnerInDir(
        activeAgentDir, root, me, readyFile, currentWake, requestedOwner)
```

but the `if path == "" { return nil }` guard lived only in the outer
`writeWakeReadyFileAgainstOwner`. `27923be9` moved this call site onto the
capability variant to reuse the already-open agent directory, and the guard
stayed behind in the wrapper. An empty `readyFile` then reached
`os.Rename(tmp, "")`.

`writeWakeReadyFileAgainstOwner` and `writeWakeReadyFile` have no remaining
non-test callers, so the guard was sitting on a path production no longer
takes.

`--ready-file` is supplied only by the repair-wake child and by `coop exec`, so
anything launched through `amq coop exec` never reached it. Consumers that
spawn `amq wake` directly — the `--inject-via` orchestrator invocation in the
README — lost notification delivery entirely, with the failure visible only in
the wake log.

## The change

The guard moves to `writeWakeReadyFileAgainstOwnerInDir`, which is the one
point every caller passes through, so entering with an already-open capability
cannot bypass it. Nothing else about publication, validation, or ownership
changes.

## Test

`TestRunWakeWithLoopPreparesWithoutReadyFile`, at the same `runWakeWithLoop`
seam as the existing `TestRunWakeWithLoopWritesReadyFileAfterLock`: bare wake
must complete `onPrepared` and still publish its generation-bound prepared
marker.

Red before the fix, with the production error verbatim:

```
--- FAIL: TestRunWakeWithLoopPreparesWithoutReadyFile (0.04s)
    wake_unix_test.go:1015: prepare wake without --ready-file: install wake ready file: rename .wake-metadata.tmp.65885.1785730150077823000.0 : no such file or directory
```

Also verified end to end on the built binary: the repro command from #419 exits
immediately before the change and stays alive with clean stderr after it.

## Gates

macOS 27.0 arm64, go1.26.5. `check-skills`, `fmt-check`, `vet`, `lint`
(0 issues) and `smoke` all pass.

`make test` has three failures on my machine, all in
`internal/cli/worktree_divergence_test.go` and all reproducing identically on
an unmodified checkout of this commit's parent: their fixtures run
`git add .amqrc`, and my global `core.excludesfile` ignores `.amqrc`, so the
add is refused. Environment-specific and unrelated to this change — flagging it
rather than touching those tests.
