### PR TITLE
fix(wake): retry the retained-inbox kqueue wait on EINTR

### DIFF
--- a/internal/cli/wake_repair_dirs_darwin.go
+++ b/internal/cli/wake_repair_dirs_darwin.go
@@ -3,13 +3,21 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
+	"syscall"
 
 	"github.com/fsnotify/fsnotify"
 	"golang.org/x/sys/unix"
 )
+
+// waitRetainedWakeInboxEvent is a seam so tests can inject the interrupts the
+// Go runtime delivers in production.
+var waitRetainedWakeInboxEvent = func(kqueueFD int, events []unix.Kevent_t) (int, error) {
+	return unix.Kevent(kqueueFD, nil, events, nil)
+}
 
 type retainedWakeInboxKqueueWatcher struct {
 	kqueueFD  int
@@ -113,15 +121,18 @@ func (w *retainedWakeInboxKqueueWatcher) run() {
 	eventName := filepath.Join(w.authority.inboxPath, "retained-inbox-event.md")
 	for {
 		events := make([]unix.Kevent_t, 2)
-		count, err := unix.Kevent(w.kqueueFD, nil, events, nil)
+		count, err := waitRetainedWakeInboxEvent(w.kqueueFD, events)
 		if err != nil {
 			select {
 			case <-w.closing:
 				return
 			default:
-				w.fail(fmt.Errorf("wait for retained wake directory event: %w", err))
-				return
 			}
+			if errors.Is(err, syscall.EINTR) {
+				continue
+			}
+			w.fail(fmt.Errorf("wait for retained wake directory event: %w", err))
+			return
 		}
 		if count == 0 {
 			continue

--- a/internal/cli/wake_repair_dirs_darwin_test.go
+++ b/internal/cli/wake_repair_dirs_darwin_test.go
@@ -6,12 +6,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"github.com/fsnotify/fsnotify"
+	"golang.org/x/sys/unix"
 )
 
 type darwinRetainedWakeWatcherFixture struct {
@@ -257,5 +260,29 @@ func assertDarwinRetainedWakeWatcherTerminalWithoutEvents(
 	}
 	if !strings.Contains(terminalErr.Error(), "retained wake") {
 		t.Fatalf("terminal retained watcher error = %v", terminalErr)
+	}
+}
+
+func TestDarwinRetainedWakeWatcherRetriesInterruptedWait(t *testing.T) {
+	var waits atomic.Int32
+	previousWait := waitRetainedWakeInboxEvent
+	waitRetainedWakeInboxEvent = func(kqueueFD int, events []unix.Kevent_t) (int, error) {
+		if waits.Add(1) == 1 {
+			return 0, syscall.EINTR
+		}
+		return previousWait(kqueueFD, events)
+	}
+	t.Cleanup(func() { waitRetainedWakeInboxEvent = previousWait })
+
+	fixture := newDarwinRetainedWakeWatcherForTest(t)
+	writeDarwinRetainedWakeWatcherMessage(
+		t,
+		filepath.Join(fixture.inboxPath, "delivered.md"),
+		"delivered",
+	)
+	assertDarwinRetainedWakeWatcherEvent(t, fixture.watcher, fixture.inboxPath)
+
+	if got := waits.Load(); got < 2 {
+		t.Fatalf("retained watcher waits = %d, want at least 2 after an interrupted wait", got)
 	}
 }


### PR DESCRIPTION
## Summary

The retained-inbox kqueue watcher treated every `unix.Kevent` error as fatal, so
an `EINTR` killed the watcher goroutine. Since the Go runtime delivers `SIGURG`
for asynchronous preemption and `x/sys/unix.Kevent` does not retry, a long-lived
blocking wait gets interrupted as a matter of course — the watcher dies for a
reason that is not an error.

`retryWatcher` then does the right thing for a genuine watcher failure (clear the
baseline, set `pendingNotify`, re-scan and notify), which turns each spurious
death into a spurious doorbell. In the run that surfaced this, one delivered
message injected three wake notifications, the last one after the recipient had
already drained the mailbox.

I deliberately did **not** touch `retryWatcher`. Re-notifying after a watcher
restart is the correct fail-open choice on its own; it was only pathological
because EINTR made restarts constant.

Darwin only — the Linux watcher is a separate implementation.

## Changes

- `wake_repair_dirs_darwin.go`: retry the retained-inbox wait on `EINTR`, matching
  the six existing call sites in this package. The closest one,
  `monitorDarwinWakeOwnerObservation`, is the same `unix.Kevent` loop shape and
  already handles it — this loop was the outlier.
- The wait goes through a package-level `waitRetainedWakeInboxEvent` seam so the
  interrupt can be injected deterministically, following the
  `writeDarwinWakeOwnerObservationCancel` precedent in
  `wake_owner_observation_darwin_test.go`.
- Preserved the existing precedence: a wait error during `Close()` still returns
  through the `w.closing` branch before the retry is considered.

## Testing

- [x] New test added: `TestDarwinRetainedWakeWatcherRetriesInterruptedWait`
  injects `EINTR` on the first wait, then asserts the watcher survives, still
  forwards the normalized inbox event, and performed at least two waits.
- [x] Reverse-probed. Reverting to the exact pre-fix state (retry removed, both
  imports dropped) fails the new test with `retained watcher closed before
  forwarding message trigger` — the same channel-close the production bug causes.
  It passes again after restoration.
- [x] `go test ./internal/cli/ -run TestDarwinRetainedWakeWatcher -count=1` — all
  5 tests pass.
- [x] `go vet ./internal/cli/`, `gofmt -l internal/cli/`, `go build ./...` — all
  clean.
- [ ] `make ci` — not clean in my environment, but not because of this change:
  `TestDoctorOpsHintsPerWorktreeSessionForLocalRootSources`,
  `TestDoctorOpsWarnsWhenPeerPresenceIsFresherInSameSessionOtherWorktree`, and
  `TestDoctorOpsDoesNotWarnForOlderPeerOrFresherCallerPresence` fail identically
  on a clean `origin/main` tree here (verified by stashing this change and
  re-running), and they appear to be sensitive to local git configuration —
  the run emits git's `advice.addIgnoredFile` hint. Flagging rather than
  claiming a green I did not get.

## Related Issues

Fixes #421
