### PR TITLE
fix(wake): bound doorbell reminders per undrained cohort

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -40,6 +40,8 @@ type opsAgent struct {
 	NotifierStatus         string  `json:"notifier_status,omitempty"`
 	NotifierMode           string  `json:"notifier_mode,omitempty"`
 	NotifierReason         string  `json:"notifier_reason,omitempty"`
+	DoorbellParked         bool    `json:"doorbell_parked,omitempty"`
+	DoorbellAttempts       uint    `json:"doorbell_attempts,omitempty"`
 }
 
 type opsOperatorGate struct {
@@ -215,6 +217,8 @@ func runOpsChecksWithSchema(
 			agent.NotifierStatus = p.NotifierStatus
 			agent.NotifierMode = p.NotifierMode
 			agent.NotifierReason = p.NotifierReason
+			agent.DoorbellParked = p.DoorbellParked
+			agent.DoorbellAttempts = p.DoorbellAttempts
 			if t, err := time.Parse(time.RFC3339Nano, p.LastSeen); err == nil {
 				agent.PresenceAgeSeconds = now.Sub(t).Seconds()
 				recentActivity = agent.PresenceAgeSeconds < (10 * time.Minute).Seconds()
@@ -230,6 +234,18 @@ func runOpsChecksWithSchema(
 		agent.PresenceAgeSeconds = math.Round(agent.PresenceAgeSeconds)
 
 		result.Agents = append(result.Agents, agent)
+		if agent.DoorbellParked && agent.UnreadCount > 0 {
+			result.Hints = append(result.Hints, opsHint{
+				Code:   "doorbell_parked",
+				Status: "warn",
+				Message: fmt.Sprintf(
+					"Agent %s doorbell is parked after %d attempts with unread messages (oldest unread %.0fs)",
+					agent.Handle,
+					agent.DoorbellAttempts,
+					agent.OldestUnreadAgeSeconds,
+				),
+			})
+		}
 	}
 
 	// Configured live agents require canonical handles. Discovery additionally

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -108,6 +108,65 @@ func TestRunOpsChecks_BasicAgentStats(t *testing.T) {
 
 }
 
+func TestRunOpsChecks_DoorbellParkedHintRequiresUnreadBacklog(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(filepath.Join(root, "meta", "config.json"), config.Config{
+		Version: 1,
+		Agents:  []string{"codex"},
+	}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	presencePath := filepath.Join(fsq.AgentBase(root, "codex"), "presence.json")
+	parkedPresence := `{"schema":1,"handle":"codex","status":"active","last_seen":"2026-08-04T12:00:00Z","doorbell_parked":true,"doorbell_attempts":4}`
+	if err := os.WriteFile(presencePath, []byte(parkedPresence), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if hint, ok := findOpsHint(runOpsChecks(root, "test", false).Hints, "doorbell_parked"); ok {
+		t.Fatalf("empty inbox reported parked hint: %#v", hint)
+	}
+
+	messagePath := filepath.Join(fsq.AgentInboxNew(root, "codex"), "pending.md")
+	if err := os.WriteFile(messagePath, []byte("pending"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(messagePath, time.Now().Add(-90*time.Second), time.Now().Add(-90*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	parkedResult := runOpsChecks(root, "test", false)
+	hint, ok := findOpsHint(parkedResult.Hints, "doorbell_parked")
+	if !ok {
+		t.Fatal("parked doorbell with unread backlog emitted no ops hint")
+	}
+	if hint.Status != "warn" ||
+		!strings.Contains(hint.Message, "codex") ||
+		!strings.Contains(hint.Message, "4 attempts") ||
+		!strings.Contains(hint.Message, "90s") {
+		t.Fatalf("parked hint = %#v", hint)
+	}
+	if len(parkedResult.Agents) != 1 ||
+		!parkedResult.Agents[0].DoorbellParked ||
+		parkedResult.Agents[0].DoorbellAttempts != 4 {
+		t.Fatalf("parked agent state = %#v", parkedResult.Agents)
+	}
+
+	activePresence := `{"schema":1,"handle":"codex","status":"active","last_seen":"2026-08-04T12:00:00Z"}`
+	if err := os.WriteFile(presencePath, []byte(activePresence), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if hint, ok := findOpsHint(runOpsChecks(root, "test", false).Hints, "doorbell_parked"); ok {
+		t.Fatalf("unparked notifier reported parked hint: %#v", hint)
+	}
+}
+
 func TestRunOpsChecks_NoConfig(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -70,6 +70,9 @@ type wakeConfig struct {
 	onPendingNotify               func()
 	recordNotifierStatus          func(status, mode, reason string) error
 	pendingNotifierStatus         *wakeNotifierStatus
+	recordDoorbellStatus          func(parked bool, attempts uint) error
+	pendingDoorbellStatus         *wakeDoorbellStatus
+	reportedDoorbellStatus        wakeDoorbellStatus
 	recordAttention               func(wakeAttentionEmission) error
 	attentionEnv                  func(string) string
 	attentionIsTTY                func() bool
@@ -81,6 +84,11 @@ type wakeNotifierStatus struct {
 	status string
 	mode   string
 	reason string
+}
+
+type wakeDoorbellStatus struct {
+	parked   bool
+	attempts uint
 }
 
 const maxWakeNotificationSenderClauses = 8
@@ -489,6 +497,7 @@ func notifyNewMessages(cfg *wakeConfig) error {
 			)
 		}
 		cfg.doorbell.reset()
+		persistWakeDoorbellStatusBestEffort(cfg)
 		return reconcileWakeInputAfterInboxDrain(cfg)
 	}
 
@@ -582,6 +591,7 @@ func deliverNewMessageNotification(
 	}
 	now := cfg.wakeDoorbellNow()
 	plan := cfg.doorbell.plan(now, currentPending)
+	persistWakeDoorbellStatusBestEffort(cfg)
 	if !plan.attempt {
 		return nil
 	}
@@ -652,14 +662,15 @@ func recordWakeAttempt(
 	}
 	var attentionErr *wakeAttentionDeliveryError
 	if cfg.lastAttemptTransientAttention {
-		cfg.doorbell.recordAttempt(now)
-		return
-	}
-	if cfg.lastAttemptAttention || errors.As(deliveryErr, &attentionErr) {
+		// Input deferral emitted attention but made no synthetic-input attempt,
+		// so it advances cadence without consuming the finite injection budget.
+		cfg.doorbell.recordDeferredInputAttempt(now)
+	} else if cfg.lastAttemptAttention || errors.As(deliveryErr, &attentionErr) {
 		cfg.doorbell.recordAttentionAttempt(now)
-		return
+	} else {
+		cfg.doorbell.recordAttempt(now)
 	}
-	cfg.doorbell.recordAttempt(now)
+	persistWakeDoorbellStatusBestEffort(cfg)
 }
 
 func shouldRecordWakeAttempt(err error) bool {
@@ -681,6 +692,7 @@ func deliverWakeInputRecoveryAttention(
 		return nil
 	}
 	cfg.doorbell.recordRecoveryRequired(now, currentPending)
+	persistWakeDoorbellStatusBestEffort(cfg)
 	if err := emitWakeAttention(cfg, wakePayload{
 		text:       wakeInputRecoveryNotice,
 		provenance: wakePayloadSystemFixed,
@@ -746,6 +758,7 @@ func dischargeWakeInputRecoveryAfterProgress(
 	cfg.inputRecoveryRequired = false
 	clearWakeInputState(cfg)
 	cfg.doorbell.reset()
+	persistWakeDoorbellStatusBestEffort(cfg)
 	if err := persistWakeNotifierStatus(cfg, "", effectiveInjectMode(cfg), ""); err != nil {
 		_ = writeWakeDiagnostic(cfg, "amq wake: clear input recovery-required status: %v\n", err)
 	}
@@ -771,6 +784,46 @@ func retryPendingWakeNotifierStatus(cfg *wakeConfig) error {
 	}
 	pending := cfg.pendingNotifierStatus
 	return persistWakeNotifierStatus(cfg, pending.status, pending.mode, pending.reason)
+}
+
+func persistWakeDoorbellStatusBestEffort(cfg *wakeConfig) {
+	if err := persistWakeDoorbellStatus(cfg); err != nil {
+		_ = writeWakeDiagnostic(cfg, "amq wake: persist doorbell parked status: %v; retrying\n", err)
+	}
+}
+
+func persistWakeDoorbellStatus(cfg *wakeConfig) error {
+	if cfg == nil || cfg.recordDoorbellStatus == nil {
+		return nil
+	}
+	attempts, parked := cfg.doorbell.parkedReminderAttempts()
+	desired := wakeDoorbellStatus{parked: parked, attempts: attempts}
+	if !parked {
+		desired.attempts = 0
+	}
+	if cfg.pendingDoorbellStatus == nil && desired == cfg.reportedDoorbellStatus {
+		return nil
+	}
+	if err := cfg.recordDoorbellStatus(desired.parked, desired.attempts); err != nil {
+		cfg.pendingDoorbellStatus = &desired
+		return err
+	}
+	cfg.reportedDoorbellStatus = desired
+	cfg.pendingDoorbellStatus = nil
+	return nil
+}
+
+func retryPendingWakeDoorbellStatus(cfg *wakeConfig) error {
+	if cfg == nil || cfg.pendingDoorbellStatus == nil || cfg.recordDoorbellStatus == nil {
+		return nil
+	}
+	pending := *cfg.pendingDoorbellStatus
+	if err := cfg.recordDoorbellStatus(pending.parked, pending.attempts); err != nil {
+		return err
+	}
+	cfg.reportedDoorbellStatus = pending
+	cfg.pendingDoorbellStatus = nil
+	return nil
 }
 
 func (cfg *wakeConfig) wakeDoorbellNow() time.Time {
@@ -1421,6 +1474,7 @@ func retireWakeInputState(cfg *wakeConfig, cause error) error {
 		return &wakeInputDemotionBlockedError{err: cause}
 	}
 	cfg.doorbell.reset()
+	persistWakeDoorbellStatusBestEffort(cfg)
 	clearWakeInputState(cfg)
 	return nil
 }

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -10,6 +10,7 @@ type wakeDoorbellPhase uint8
 const (
 	wakeDoorbellIdle wakeDoorbellPhase = iota
 	wakeDoorbellRetrying
+	wakeDoorbellParked
 	wakeDoorbellRecoveryRequired
 )
 
@@ -18,12 +19,21 @@ const (
 	wakeDoorbellAttentionRetryBase = 30 * time.Second
 	wakeDoorbellRetryMax           = 2 * time.Minute
 	wakeDoorbellAttentionRetryMax  = 15 * time.Minute
+
+	// Repeated synthetic input is not consumer-safe: queueing consumers may
+	// retain every identical reminder and flush them as one later turn. Bound
+	// an unchanged cohort, while leaving additions a small finite chance to
+	// announce genuinely new work.
+	wakeDoorbellInitialAttemptBudget = uint(4)
+	wakeDoorbellLifetimeAttemptCap   = uint(8)
 )
 
 type wakeDoorbellState struct {
 	phase                        wakeDoorbellPhase
 	cohort                       map[string]*wakeFileIdentity
 	attempts                     uint
+	reminderAttempts             uint
+	attemptBudget                uint
 	nextAttempt                  time.Time
 	additionAttemptFloor         time.Time
 	transientAttentionAttempts   uint
@@ -56,11 +66,23 @@ func (state *wakeDoorbellState) plan(
 		// the new information has not been announced yet. One outstanding
 		// "drain everything" doorbell covers the whole current cohort, so N
 		// unread messages do not need N doorbells.
-		state.arm(current)
-		state.pullForwardForAddition(now)
+		if state.phase == wakeDoorbellParked {
+			state.cohort = snapshotWakeFileIdentities(current)
+			if state.attemptBudget < wakeDoorbellLifetimeAttemptCap {
+				state.attemptBudget++
+				state.phase = wakeDoorbellRetrying
+				state.pullForwardForAddition(now)
+			}
+		} else {
+			state.arm(current)
+			state.pullForwardForAddition(now)
+		}
 	}
 	if state.phase == wakeDoorbellIdle {
 		state.arm(current)
+	}
+	if state.phase == wakeDoorbellParked {
+		return wakeDoorbellPlan{}
 	}
 	if state.attempts > 0 && now.Before(state.nextAttempt) {
 		return wakeDoorbellPlan{}
@@ -76,10 +98,31 @@ func (state *wakeDoorbellState) plan(
 func (state *wakeDoorbellState) arm(current map[string]os.FileInfo) {
 	state.phase = wakeDoorbellRetrying
 	state.cohort = snapshotWakeFileIdentities(current)
+	if state.attemptBudget == 0 {
+		state.attemptBudget = wakeDoorbellInitialAttemptBudget
+	}
 }
 
 func (state *wakeDoorbellState) recordAttempt(now time.Time) {
+	if state.attemptBudget == 0 {
+		state.attemptBudget = wakeDoorbellInitialAttemptBudget
+	}
 	state.recordAttemptWithBase(now, wakeDoorbellRetryBase, wakeDoorbellRetryMax)
+	state.reminderAttempts++
+	if state.reminderAttempts >= state.attemptBudget {
+		state.parkCurrentCohort()
+	}
+}
+
+func (state *wakeDoorbellState) recordDeferredInputAttempt(now time.Time) {
+	state.recordAttemptWithBase(now, wakeDoorbellRetryBase, wakeDoorbellRetryMax)
+}
+
+// parkCurrentCohort is the acknowledgement seam: a future injected-ack policy
+// can park the acknowledged cohort here without changing the budget model.
+func (state *wakeDoorbellState) parkCurrentCohort() {
+	state.phase = wakeDoorbellParked
+	state.nextAttempt = time.Time{}
 }
 
 func (state *wakeDoorbellState) recordAttentionAttempt(now time.Time) {
@@ -198,6 +241,10 @@ func (state *wakeDoorbellState) makeDue(now time.Time) {
 
 func (state wakeDoorbellState) pendingInput() bool {
 	return state.phase == wakeDoorbellRetrying
+}
+
+func (state wakeDoorbellState) parkedReminderAttempts() (uint, bool) {
+	return state.reminderAttempts, state.phase == wakeDoorbellParked
 }
 
 func (state *wakeDoorbellState) nextDeadline() (time.Time, bool) {

--- a/internal/cli/wake_doorbell_test.go
+++ b/internal/cli/wake_doorbell_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,7 +84,7 @@ func TestWakeDoorbellStateCoalescesAddedMessageUntilExistingDeadline(t *testing.
 	}
 	state.recordAttempt(now)
 	lastAttempt := now
-	for state.attempts < 6 {
+	for state.attempts < 3 {
 		lastAttempt = state.nextAttempt
 		if plan := state.plan(lastAttempt, first); !plan.attempt {
 			t.Fatalf("ladder attempt %d plan = %#v", state.attempts+1, plan)
@@ -103,7 +104,7 @@ func TestWakeDoorbellStateCoalescesAddedMessageUntilExistingDeadline(t *testing.
 	if plan.attempt || plan.progress {
 		t.Fatalf("addition emitted before delivery floor: %#v", plan)
 	}
-	if state.attempts != 6 || !sameKnownWakeCohort(state.cohort, current) {
+	if state.attempts != 3 || !sameKnownWakeCohort(state.cohort, current) {
 		t.Fatalf("addition did not extend the pending cohort: %#v", state)
 	}
 	floorDeadline := lastAttempt.Add(wakeDoorbellRetryBase)
@@ -126,7 +127,7 @@ func TestWakeDoorbellStateCoalescesAddedMessageUntilExistingDeadline(t *testing.
 	if plan.attempt || plan.progress {
 		t.Fatalf("same-burst addition emitted another doorbell: %#v", plan)
 	}
-	if state.attempts != 6 || !state.nextAttempt.Equal(floorDeadline) {
+	if state.attempts != 3 || !state.nextAttempt.Equal(floorDeadline) {
 		t.Fatalf("same-burst addition changed retry ladder: %#v", state)
 	}
 
@@ -146,6 +147,132 @@ func TestWakeDoorbellStateCoalescesAddedMessageUntilExistingDeadline(t *testing.
 	}
 	if state.attempts != 0 || !sameKnownWakeCohort(state.cohort, remaining) {
 		t.Fatalf("post-expansion drain did not rearm remaining cohort: %#v", state)
+	}
+}
+
+func TestWakeDoorbellStateParksUnchangedCohortAfterFourAttempts(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "a.md")
+	var state wakeDoorbellState
+
+	wantAttempts := []time.Time{
+		now,
+		now.Add(5 * time.Second),
+		now.Add(15 * time.Second),
+		now.Add(35 * time.Second),
+	}
+	for attempt, attemptAt := range wantAttempts {
+		plan := state.plan(attemptAt, current)
+		if !plan.attempt {
+			t.Fatalf("attempt %d plan = %#v", attempt+1, plan)
+		}
+		state.recordAttempt(attemptAt)
+	}
+
+	if plan := state.plan(now.Add(24*time.Hour), current); plan.attempt {
+		t.Fatalf("unchanged cohort exceeded four-attempt budget: %#v", plan)
+	}
+}
+
+func TestWakeDoorbellStateParkedAdditionTopsUpOneAttemptToLifetimeCap(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "a.md")
+	var state wakeDoorbellState
+
+	for attempt := 0; attempt < 4; attempt++ {
+		attemptAt := now
+		if attempt > 0 {
+			attemptAt = state.nextAttempt
+		}
+		if plan := state.plan(attemptAt, current); !plan.attempt {
+			t.Fatalf("initial attempt %d plan = %#v", attempt+1, plan)
+		}
+		state.recordAttempt(attemptAt)
+		now = attemptAt
+	}
+	if plan := state.plan(now.Add(time.Hour), current); plan.attempt {
+		t.Fatalf("initial cohort did not park: %#v", plan)
+	}
+
+	for addition := 1; addition <= 4; addition++ {
+		name := fmt.Sprintf("added-%d.md", addition)
+		current[name] = wakeDoorbellTestFiles(t, name)[name]
+		scannedAt := now.Add(time.Second)
+		if plan := state.plan(scannedAt, current); plan.attempt {
+			t.Fatalf("addition %d bypassed delivery floor: %#v", addition, plan)
+		}
+		attemptAt := state.nextAttempt
+		if plan := state.plan(attemptAt, current); !plan.attempt {
+			t.Fatalf("addition %d did not receive one top-up attempt: %#v", addition, plan)
+		}
+		state.recordAttempt(attemptAt)
+		now = attemptAt
+		if plan := state.plan(now.Add(time.Hour), current); plan.attempt {
+			t.Fatalf("addition %d received more than one top-up: %#v", addition, plan)
+		}
+	}
+
+	name := "beyond-lifetime-cap.md"
+	current[name] = wakeDoorbellTestFiles(t, name)[name]
+	if plan := state.plan(now.Add(time.Hour), current); plan.attempt {
+		t.Fatalf("addition exceeded eight-attempt lifetime cap: %#v", plan)
+	}
+}
+
+func TestWakeDoorbellStateDrainResetsReminderBudget(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "a.md")
+	var state wakeDoorbellState
+
+	for attempt := 0; attempt < 4; attempt++ {
+		attemptAt := now
+		if attempt > 0 {
+			attemptAt = state.nextAttempt
+		}
+		if plan := state.plan(attemptAt, current); !plan.attempt {
+			t.Fatalf("first cohort attempt %d plan = %#v", attempt+1, plan)
+		}
+		state.recordAttempt(attemptAt)
+		now = attemptAt
+	}
+	if plan := state.plan(now.Add(time.Hour), nil); plan.attempt {
+		t.Fatalf("drain plan = %#v", plan)
+	}
+
+	fresh := wakeDoorbellTestFiles(t, "fresh.md")
+	if plan := state.plan(now.Add(time.Hour+time.Second), fresh); !plan.attempt {
+		t.Fatalf("fresh cohort inherited exhausted budget: %#v", plan)
+	}
+	if state.attempts != 0 {
+		t.Fatalf("fresh cohort attempts = %d, want 0 before first record", state.attempts)
+	}
+}
+
+func TestWakeDoorbellParkedStatusPublishesAndClears(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	current := wakeDoorbellTestFiles(t, "a.md")
+	var statuses []wakeDoorbellStatus
+	cfg := wakeConfig{
+		recordDoorbellStatus: func(parked bool, attempts uint) error {
+			statuses = append(statuses, wakeDoorbellStatus{parked: parked, attempts: attempts})
+			return nil
+		},
+	}
+	cfg.doorbell.arm(current)
+	for attempt := 0; attempt < 4; attempt++ {
+		recordWakeAttempt(&cfg, now, current, nil)
+		now = cfg.doorbell.nextAttempt
+	}
+	if len(statuses) != 1 || statuses[0] != (wakeDoorbellStatus{parked: true, attempts: 4}) {
+		t.Fatalf("parked statuses = %#v", statuses)
+	}
+
+	cfg.doorbell.reset()
+	if err := persistWakeDoorbellStatus(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(statuses) != 2 || statuses[1] != (wakeDoorbellStatus{}) {
+		t.Fatalf("cleared statuses = %#v", statuses)
 	}
 }
 
@@ -235,58 +362,27 @@ func TestWakeDoorbellRecoveryAttentionIsCohortBoundedAndRateLimited(t *testing.T
 	}
 }
 
-func TestWakeDoorbellRetryCadenceCapsPerDeliveredChannel(t *testing.T) {
+func TestWakeDoorbellAttentionRetryCadenceCaps(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0)
-	tests := []struct {
-		name   string
-		record func(*wakeDoorbellState, time.Time)
-		wants  []time.Duration
-	}{
-		{
-			name: "input",
-			record: func(state *wakeDoorbellState, attemptAt time.Time) {
-				state.recordAttempt(attemptAt)
-			},
-			wants: []time.Duration{
-				5 * time.Second,
-				10 * time.Second,
-				20 * time.Second,
-				40 * time.Second,
-				80 * time.Second,
-				2 * time.Minute,
-				2 * time.Minute,
-			},
-		},
-		{
-			name: "attention",
-			record: func(state *wakeDoorbellState, attemptAt time.Time) {
-				state.recordAttentionAttempt(attemptAt)
-			},
-			wants: []time.Duration{
-				30 * time.Second,
-				time.Minute,
-				2 * time.Minute,
-				4 * time.Minute,
-				8 * time.Minute,
-				15 * time.Minute,
-				15 * time.Minute,
-			},
-		},
+	wants := []time.Duration{
+		30 * time.Second,
+		time.Minute,
+		2 * time.Minute,
+		4 * time.Minute,
+		8 * time.Minute,
+		15 * time.Minute,
+		15 * time.Minute,
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var state wakeDoorbellState
-			for attempt, want := range tt.wants {
-				tt.record(&state, now)
-				if got := state.nextAttempt.Sub(now); got != want {
-					t.Fatalf(
-						"attempt %d delay = %s, want %s",
-						attempt+1,
-						got,
-						want,
-					)
-				}
-			}
-		})
+	var state wakeDoorbellState
+	for attempt, want := range wants {
+		state.recordAttentionAttempt(now)
+		if got := state.nextAttempt.Sub(now); got != want {
+			t.Fatalf(
+				"attempt %d delay = %s, want %s",
+				attempt+1,
+				got,
+				want,
+			)
+		}
 	}
 }

--- a/internal/cli/wake_repair_dirs_unix.go
+++ b/internal/cli/wake_repair_dirs_unix.go
@@ -825,6 +825,33 @@ func setWakeNotifierStatusInDir(
 	agentDir *wakeAgentDir,
 	me, status, mode, reason string,
 ) error {
+	return updateWakePresenceInDir(agentDir, me, func(value *presence.Presence) {
+		value.NotifierStatus = status
+		value.NotifierMode = mode
+		value.NotifierReason = reason
+	})
+}
+
+func setWakeDoorbellStatusInDir(
+	agentDir *wakeAgentDir,
+	me string,
+	parked bool,
+	attempts uint,
+) error {
+	return updateWakePresenceInDir(agentDir, me, func(value *presence.Presence) {
+		value.DoorbellParked = parked
+		value.DoorbellAttempts = attempts
+		if !parked {
+			value.DoorbellAttempts = 0
+		}
+	})
+}
+
+func updateWakePresenceInDir(
+	agentDir *wakeAgentDir,
+	me string,
+	update func(*presence.Presence),
+) error {
 	if agentDir == nil {
 		return fmt.Errorf("wake agent directory capability is missing")
 	}
@@ -848,9 +875,7 @@ func setWakeNotifierStatusInDir(
 				return fmt.Errorf("parse wake presence: %w", err)
 			}
 		}
-		value.NotifierStatus = status
-		value.NotifierMode = mode
-		value.NotifierReason = reason
+		update(&value)
 		value.LastSeen = time.Now().UTC().Format(time.RFC3339Nano)
 		encoded, err := json.MarshalIndent(value, "", "  ")
 		if err != nil {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -2086,6 +2086,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	); err != nil {
 		return fmt.Errorf("record wake notifier status: %w", err)
 	}
+	if err := setWakeDoorbellStatusInDir(activeAgentDir, me, false, 0); err != nil {
+		return fmt.Errorf("clear wake doorbell status: %w", err)
+	}
 	if initialNotifierStatus == wakeInjectorUnsupportedStatus {
 		_ = writeStderr("amq wake: warning: %s\n", initialNotifierReason)
 	}
@@ -2138,6 +2141,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		retainedAgent:      activeAgentDir,
 		recordNotifierStatus: func(status, mode, reason string) error {
 			return setWakeNotifierStatusInDir(activeAgentDir, me, status, mode, reason)
+		},
+		recordDoorbellStatus: func(parked bool, attempts uint) error {
+			return setWakeDoorbellStatusInDir(activeAgentDir, me, parked, attempts)
 		},
 		onPrepared: func(watcher wakeAdmissionWatcher) error {
 			if repairLineage != nil {
@@ -2343,6 +2349,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		}
 	}
 
+	defer func() {
+		_ = setWakeDoorbellStatusInDir(activeAgentDir, me, false, 0)
+	}()
 	return loop(cfg)
 }
 
@@ -3477,6 +3486,13 @@ func runWakeLoop(cfg wakeConfig) error {
 				_ = writeWakeDiagnostic(
 					&cfg,
 					"amq wake: persist notifier status: %v; retrying\n",
+					err,
+				)
+			}
+			if err := retryPendingWakeDoorbellStatus(&cfg); err != nil {
+				_ = writeWakeDiagnostic(
+					&cfg,
+					"amq wake: persist doorbell parked status: %v; retrying\n",
 					err,
 				)
 			}

--- a/internal/presence/presence.go
+++ b/internal/presence/presence.go
@@ -11,14 +11,16 @@ import (
 
 // Presence captures the current presence for an agent handle.
 type Presence struct {
-	Schema         int    `json:"schema"`
-	Handle         string `json:"handle"`
-	Status         string `json:"status"`
-	LastSeen       string `json:"last_seen"`
-	Note           string `json:"note,omitempty"`
-	NotifierStatus string `json:"notifier_status,omitempty"`
-	NotifierMode   string `json:"notifier_mode,omitempty"`
-	NotifierReason string `json:"notifier_reason,omitempty"`
+	Schema           int    `json:"schema"`
+	Handle           string `json:"handle"`
+	Status           string `json:"status"`
+	LastSeen         string `json:"last_seen"`
+	Note             string `json:"note,omitempty"`
+	NotifierStatus   string `json:"notifier_status,omitempty"`
+	NotifierMode     string `json:"notifier_mode,omitempty"`
+	NotifierReason   string `json:"notifier_reason,omitempty"`
+	DoorbellParked   bool   `json:"doorbell_parked,omitempty"`
+	DoorbellAttempts uint   `json:"doorbell_attempts,omitempty"`
 }
 
 func New(handle, status, note string, now time.Time) Presence {


### PR DESCRIPTION
## Summary

Fixes #426. `amq wake`'s doorbell re-fired the identical reminder on a capped
backoff for as long as an inbox stayed undrained, and every new arrival pulled
the next reminder forward. Consumers that queue injected input without
deduplication (observed: Cursor CLI's `cursor-agent`, which queues each
bracketed-paste injection as a discrete follow-up and flushes all of them as
one batched turn) accumulated 15+ identical queued prompts.

The doorbell now has a per-cohort reminder budget: after 4 injection attempts
for one unchanged undrained cohort it parks and stays silent. A new arrival
while parked re-snapshots the cohort and grants exactly one more attempt, up to
a hard lifetime cap of 8 per cohort. A drain fully resets the budget. Worst
case for a never-draining consumer drops from unbounded (~15 observed in 35
minutes) to at most 4 identical injections for an unchanged inbox.

## Design notes

- Input-deferral attention advances retry cadence without consuming the
  injection budget — a consumer who is merely typing does not burn reminders.
- Parked state is observable: the wake process persists `doorbell_parked` and
  `doorbell_attempts` into its presence record (the same channel as the
  existing `notifier_*` fields; additive `omitempty`, schema unchanged), and
  `doctor --ops` emits a `doorbell_parked` warn hint when an agent is parked
  with unread messages, naming attempts used and oldest-unread age. A parked
  doorbell plus a non-draining consumer is otherwise the silent-backlog failure
  mode of #427.
- Presence writes are best-effort with retry-on-next-tick and change-dedup;
  parked status is cleared on wake startup and on exit.
- No new CLI flags: the budget and cap are named constants with a rationale
  comment. Deliberate YAGNI.
- `parkCurrentCohort` is the seam for #424's `--retry-until injected`
  acknowledgement model: an acknowledgement can park or reset the budget later
  without changing this model.

## Testing

- RED-first: budget exhaustion, park silence, exactly-one top-up per addition,
  lifetime cap, full reset on drain, doctor hint present/absent cells
  (RED evidence: `amq-gates/issue426/red-focused.log`, local artifact).
- Renamed `TestWakeDoorbellRetryCadenceCapsPerDeliveredChannel` to
  `TestWakeDoorbellAttentionRetryCadenceCaps`: synthetic-input cadence is now
  intentionally bounded, while attention cadence remains capped-but-continuing;
  the old name asserted unbounded input retries by design.
- Gates at the exact commit: `make ci` (vet, lint, full `go test ./...`,
  smoke), focused Doorbell/Notify/Ops + presence groups, gofmt, and
  `GOOS=windows` + `GOOS=linux` builds. Independently re-run by a second
  reviewer before commit.

## Wake-test change justification

<!-- BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION -->
TestWakeDoorbellRetryCadenceCapsPerDeliveredChannel: Renamed to TestWakeDoorbellAttentionRetryCadenceCaps because synthetic-input reminder cadence is now intentionally bounded by the per-cohort budget, while attention cadence remains capped-but-continuing; the old name asserted unbounded input retries by design.
<!-- END_WAKE_TEST_CHANGE_JUSTIFICATION -->

## Exact review identity

- base: `bfbbdd41c32b99db7138db02a0b3c96ef150ded6` (v0.52.0)
- tip: `736f6d54aab229533a62fcc6216cc2b4985b5b0c`, tree
  `3c5e96597a89dd8dd4d22dcc028d117941389f8d`
- full-index diff SHA-256:
  `4208242441e887ce93e85d89863a7fe807c5dbebf90d38bafb889fae361486b8`
- Independent of PR #425 (no shared files with the wake-state branch).

## Follow-up (not in this PR)

- Live observation against a real queue-not-dedup consumer (cursor-agent) is
  planned read-only; any wake restart in a live workspace is operator-owned.
- #427 (dead wake, silent backlog) remains open and is complementary.
