### PR TITLE
fix(coop): bootstrap AMQ queue at Git worktree top when unconfigured

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,13 @@ changed; the structured refusal is reported with process exit 0 unless
 - **Root**: explicit `--root` > env (`AM_ROOT`) > project-local `.amqrc` > `AMQ_GLOBAL_ROOT` > implicit fallbacks. Inside Git, only repo-local `.agent-mail` is eligible; outside Git, `~/.amqrc` precedes detected `.agent-mail`.
 - **Me**: flags > env (`AM_ME`)
 
+That fail-closed rule applies to participating commands. `coop exec` honors root
+precedence before bootstrap; when no eligible root exists, it initializes
+`.agent-mail` at the worktree top, including explicit `--session <name>`.
+`coop init` is the explicit local-bootstrap command and also targets the Git
+top. `coop exec --no-init` keeps the refusal. Bare repositories cannot host
+this implicit bootstrap; use a worktree or `--root`.
+
 Note: `.amqrc` configures the root directory. Agent identity (`me`) is set per-terminal via `--me` or `AM_ME`.
 Auto-detect covers the default `.agent-mail` layout in the current tree. A
 project `.amqrc` is still required for custom root names and peer
@@ -466,6 +473,12 @@ and warns only when the same session exists under another worktree root with
 fresher peer presence. `send --wait-for` timeout text may name the
 already-resolved delivery root/session and recommend `doctor --ops`, but must
 not scan git worktrees itself.
+
+When no higher-precedence root is eligible, the routing refusal does not block
+`coop exec`; it creates a fresh worktree-local queue at that worktree's top.
+`coop init` explicitly targets the same local top. Participating commands still
+refuse, `--no-init` declines creation, and bare repositories still require a
+worktree or explicit `--root`.
 
 Use `amq doctor --ops --json` for machine-readable health output.
 

--- a/COOP.md
+++ b/COOP.md
@@ -71,7 +71,10 @@ Grok is opt-in. To provision mailboxes for all three engines explicitly:
 amq coop init --agents claude,codex,grok,user
 ```
 
-That's it. `coop exec` auto-initializes the project if needed, sets
+That's it. `coop exec` auto-initializes the project if needed. In a Git
+worktree with no eligible root it creates `.amqrc` and `.agent-mail` at that
+worktree's top, even from a subdirectory or with `--session`; it does not
+consult `~/.amqrc`. Use `--no-init` to keep the refusal instead. It then sets
 `AM_ROOT`/`AM_ME`, `AM_BASE_ROOT`, and the independent `AM_SESSION` identity,
 starts wake notifications, and execs into the agent. Without `--session` or
 `--root`, it defaults to `--session collab` (i.e.,
@@ -109,9 +112,11 @@ and set `AMQ_GLOBAL_ROOT` to one absolute base. Use `amq doctor --ops` when a
 delivery receipt times out; it can name divergent same-session roots when a
 peer has fresher presence in another worktree.
 
-An unconfigured Git worktree or bare repository fails closed instead of implicitly using
-`~/.amqrc`. Add a local `.amqrc`, retain an existing pin, pass explicit
-`--root`, or set `AMQ_GLOBAL_ROOT` when sharing is intentional.
+Participating commands in a Git worktree or bare repository with no eligible
+root fail closed instead of implicitly using `~/.amqrc`. `coop init` explicitly
+initializes a worktree-local queue at the worktree top; `coop exec` does the
+same after root precedence finds no eligible root. A bare repository has no
+worktree to host that queue, so use a worktree or explicit `--root` there.
 
 For read-side access, prefer the named route:
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ Run the appropriate append command once, then open a new terminal or source
 that startup file. Use the bare `eval` only when you intentionally want aliases
 in one already-open shell.
 
-Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
+In a Git worktree with no eligible root, `coop exec` initializes `.agent-mail` and
+`.amqrc` at the worktree top, even when invoked from a subdirectory or with
+`--session`. It never uses `~/.amqrc` for that bootstrap. Add `--no-gitignore`
+to leave `.gitignore` unchanged, or `--no-init` to refuse instead of creating
+the local queue.
 Managed launchers can add `--require-wake` to fail instead of launching the agent when the wake watcher cannot start.
 When `coop exec` starts a fresh wake, it baselines messages that were already
 waiting. Those messages remain unread, create no receipt, and do not trigger
@@ -289,9 +293,12 @@ same absolute base root. Use an absolute, machine-local `.amqrc` value such as
 `{"root":"/absolute/path/to/shared/.agent-mail"}`, or remove the project-relative
 `.amqrc` and export `AMQ_GLOBAL_ROOT=/absolute/path/to/shared/.agent-mail`.
 Per-worktree isolation remains the default when sharing is not intended. A Git
-worktree without local AMQ configuration does not implicitly inherit
-`~/.amqrc`; AMQ refuses that ambiguous route so a global default cannot
-silently select a different project's mailbox.
+worktree without an eligible root does not implicitly inherit
+`~/.amqrc`; participating commands refuse that ambiguous route so a global
+default cannot silently select a different project's mailbox. `coop init`
+explicitly creates the worktree-local queue at its top; `coop exec` does the
+same when no eligible root exists. Bare repositories still require a worktree
+or explicit `--root`.
 
 ### 4. Inspect Health
 
@@ -464,6 +471,12 @@ repo-local detected `.agent-mail`; implicit `~/.amqrc` is refused. Outside
 Git, `~/.amqrc` remains a convenience fallback and precedes detected
 `.agent-mail`. Set
 `AMQ_GLOBAL_ROOT` explicitly when shared routing is intentional.
+
+`coop exec` honors that precedence before bootstrap. In a Git worktree with no
+eligible root, it bootstraps `<git-top>/.agent-mail`; `--session X` creates that
+named session afterward, while `--no-init` preserves the refusal. `coop init`
+is the explicit local-bootstrap command and also targets the Git top. Bare
+repositories do not auto-bootstrap.
 
 If a project `.amqrc` exists but cannot be read or parsed, AMQ stops instead
 of silently delivering through a lower-precedence fallback. Use an explicit

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -41,7 +42,7 @@ func runCoopInit(args []string) error {
 	return runCoopInitInternal(args, true)
 }
 
-func runCoopInitInternal(args []string, printNextSteps bool) error {
+func runCoopInitInternal(args []string, printNextSteps bool) (returnErr error) {
 	fs := flag.NewFlagSet("coop init", flag.ContinueOnError)
 	rootFlag := fs.String("root", defaultCoopRoot, "Root directory for the queue")
 	agentsFlag := fs.String("agents", defaultCoopAgents, "Comma-separated agent handles")
@@ -68,6 +69,33 @@ func runCoopInitInternal(args []string, printNextSteps bool) error {
 		return err
 	} else if handled {
 		return nil
+	}
+
+	rootExplicit := flagWasVisited(fs, "root")
+	if !rootExplicit {
+		if _, existingErr := findAndLoadAmqrc(); errors.Is(existingErr, errAmqrcNotFound) {
+			gitBoundary, insideGit := gitWorktreeRootFromCWD()
+			if top, worktree := gitWorktreeTopFromCWD(); worktree {
+				cwd, cwdErr := os.Getwd()
+				if cwdErr != nil {
+					return cwdErr
+				}
+				if !sameTreeIdentity(cwd, top) {
+					if err := os.Chdir(top); err != nil {
+						return fmt.Errorf("enter Git worktree top %q: %w", top, err)
+					}
+					resetAmqrcCache()
+					defer func() {
+						if err := os.Chdir(cwd); err != nil {
+							returnErr = errors.Join(returnErr, fmt.Errorf("restore working directory %q: %w", cwd, err))
+						}
+						resetAmqrcCache()
+					}()
+				}
+			} else if insideGit {
+				return noEligibleRootInGitError(gitBoundary)
+			}
+		}
 	}
 
 	explicitAgents := false

--- a/internal/cli/coop_exec_git_bootstrap_unix_test.go
+++ b/internal/cli/coop_exec_git_bootstrap_unix_test.go
@@ -1,0 +1,330 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/presence"
+)
+
+func TestCoopExecBootstrapsFreshGitWorktreeWithoutConsultingHomeAmqrc(t *testing.T) {
+	repo, homeBase := enterFreshGitBootstrapProject(t, false)
+	before := snapshotTreeDigest(t, homeBase)
+	homeRead := false
+	originalReadFile := globalAmqrcReadFile
+	globalAmqrcReadFile = func(path string) ([]byte, error) {
+		homeRead = true
+		return originalReadFile(path)
+	}
+	t.Cleanup(func() { globalAmqrcReadFile = originalReadFile })
+
+	execEnv := captureCoopExecEnvironment(t, []string{"--no-wake", "--me", "alice", "sh"})
+	wantBase := filepath.Join(repo, defaultCoopRoot)
+	wantRoot := filepath.Join(wantBase, defaultSessionName)
+	if got := envValue(execEnv, envRoot); !sameTreeIdentity(got, wantRoot) {
+		t.Fatalf("coop exec AM_ROOT = %q, want repo-local bootstrap %q", got, wantRoot)
+	}
+	if got := envValue(execEnv, envBaseRoot); !sameTreeIdentity(got, wantBase) {
+		t.Fatalf("coop exec AM_BASE_ROOT = %q, want %q", got, wantBase)
+	}
+	if got := envValue(execEnv, envSession); got != defaultSessionName {
+		t.Fatalf("coop exec AM_SESSION = %q, want %q", got, defaultSessionName)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".amqrc")); err != nil {
+		t.Fatalf("repo-local .amqrc missing after bootstrap: %v", err)
+	}
+	if after := snapshotTreeDigest(t, homeBase); after != before {
+		t.Fatalf("bootstrap consulted or mutated HOME .amqrc target: before=%s after=%s", before, after)
+	}
+	if homeRead {
+		t.Fatal("bootstrap consulted HOME .amqrc")
+	}
+}
+
+func TestCoopExecNamedSessionBootstrapsFreshGitWorktree(t *testing.T) {
+	repo, _ := enterFreshGitBootstrapProject(t, false)
+
+	execEnv := captureCoopExecEnvironment(t, []string{"--session", "session1", "--no-wake", "--me", "alice", "sh"})
+	wantBase := filepath.Join(repo, defaultCoopRoot)
+	if got := envValue(execEnv, envRoot); !sameTreeIdentity(got, filepath.Join(wantBase, "session1")) {
+		t.Fatalf("coop exec AM_ROOT = %q, want named bootstrap under %q", got, wantBase)
+	}
+	if got := envValue(execEnv, envBaseRoot); !sameTreeIdentity(got, wantBase) {
+		t.Fatalf("coop exec AM_BASE_ROOT = %q, want %q", got, wantBase)
+	}
+}
+
+func TestCoopExecBootstrapFromSubdirectoryUsesGitTop(t *testing.T) {
+	repo, _ := enterFreshGitBootstrapProject(t, true)
+
+	execEnv := captureCoopExecEnvironment(t, []string{"--no-wake", "--me", "alice", "sh"})
+	wantBase := filepath.Join(repo, defaultCoopRoot)
+	if got := envValue(execEnv, envBaseRoot); !sameTreeIdentity(got, wantBase) {
+		t.Fatalf("coop exec AM_BASE_ROOT = %q, want Git top %q", got, wantBase)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "nested", defaultCoopRoot)); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap scattered queue below Git top: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "nested", ".amqrc")); !os.IsNotExist(err) {
+		t.Fatalf("bootstrap scattered .amqrc below Git top: %v", err)
+	}
+}
+
+func TestCoopInitBootstrapFromSubdirectoryUsesGitTop(t *testing.T) {
+	repo, _ := enterFreshGitBootstrapProject(t, true)
+
+	if err := runCoopInitInternal([]string{"--no-gitignore", "--json"}, false); err != nil {
+		t.Fatalf("coop init from subdirectory: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".amqrc")); err != nil {
+		t.Fatalf("Git-top .amqrc missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, defaultCoopRoot)); err != nil {
+		t.Fatalf("Git-top queue missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "nested", defaultCoopRoot)); !os.IsNotExist(err) {
+		t.Fatalf("coop init scattered queue below Git top: %v", err)
+	}
+}
+
+func TestCoopExecBootstrapsLinkedWorktreeLocallyAndDoctorDetectsDivergence(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for linked-worktree bootstrap")
+	}
+	parent := t.TempDir()
+	primary := filepath.Join(parent, "primary")
+	linked := filepath.Join(parent, "linked")
+	if err := os.MkdirAll(primary, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(primary, "README.md"), []byte("fixture\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, primary, "init")
+	runGitForTest(t, primary, "add", "README.md")
+	runGitForTest(t, primary, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "-m", "fixture")
+	runGitForTest(t, primary, "worktree", "add", "-b", "linked-bootstrap", linked)
+	enterBootstrapEnvironment(t, linked)
+
+	execEnv := captureCoopExecEnvironment(t, []string{"--no-wake", "--me", "alice", "sh"})
+	linkedRoot := filepath.Join(linked, defaultCoopRoot, defaultSessionName)
+	if got := envValue(execEnv, envRoot); !sameTreeIdentity(got, linkedRoot) {
+		t.Fatalf("linked-worktree AM_ROOT = %q, want %q", got, linkedRoot)
+	}
+	if _, err := os.Stat(filepath.Join(primary, defaultCoopRoot)); !os.IsNotExist(err) {
+		t.Fatalf("linked bootstrap mutated primary worktree: %v", err)
+	}
+
+	primaryRoot := filepath.Join(primary, defaultCoopRoot, defaultSessionName)
+	for _, root := range []string{primaryRoot, linkedRoot} {
+		ensureOpsRoot(t, root, "alice", "bob")
+	}
+	now := time.Now()
+	if err := presence.Write(linkedRoot, presence.New("bob", "active", "linked", now.Add(-time.Minute))); err != nil {
+		t.Fatal(err)
+	}
+	if err := presence.Write(primaryRoot, presence.New("bob", "active", "primary", now)); err != nil {
+		t.Fatal(err)
+	}
+	result := runOpsChecks(linkedRoot, string(rootSourceProjectRC), false)
+	if _, found := findOpsHint(result.Hints, "worktree_divergence"); !found {
+		t.Fatalf("doctor --ops did not report cross-worktree divergence: %#v", result.Hints)
+	}
+}
+
+func TestFreshGitParticipatingCommandsKeepRefusingWithBootstrapRemedy(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "send", run: func() error { return runSend([]string{"--me", "alice", "--to", "bob", "--body", "no route"}) }},
+		{name: "list", run: func() error { return runList([]string{"--me", "alice", "--new"}) }},
+		{name: "drain", run: func() error { return runDrain([]string{"--me", "alice"}) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			enterFreshGitBootstrapProject(t, false)
+			err := test.run()
+			if err == nil || GetExitCode(err) != ExitContextMismatch {
+				t.Fatalf("%s error = %v, want context-mismatch refusal", test.name, err)
+			}
+			if !strings.Contains(err.Error(), "amq coop init") {
+				t.Fatalf("%s refusal missing runnable bootstrap remedy: %v", test.name, err)
+			}
+		})
+	}
+}
+
+func TestCoopExecNoInitKeepsFreshGitRefusal(t *testing.T) {
+	for _, args := range [][]string{
+		{"--no-init", "--no-wake", "--me", "alice", "sh"},
+		{"--session", "session1", "--no-init", "--no-wake", "--me", "alice", "sh"},
+	} {
+		repo, _ := enterFreshGitBootstrapProject(t, false)
+		err := runCoopExec(args)
+		if err == nil || GetExitCode(err) != ExitContextMismatch {
+			t.Fatalf("coop exec %v error = %v, want context-mismatch refusal", args, err)
+		}
+		if !strings.Contains(err.Error(), "amq coop init") {
+			t.Fatalf("coop exec %v refusal missing runnable remedy: %v", args, err)
+		}
+		if _, statErr := os.Stat(filepath.Join(repo, defaultCoopRoot)); !os.IsNotExist(statErr) {
+			t.Fatalf("coop exec %v mutated fresh repo: %v", args, statErr)
+		}
+	}
+}
+
+func TestCoopExecRefusesBareRepositoryBootstrap(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for bare-repository bootstrap")
+	}
+	bare := filepath.Join(t.TempDir(), "repo.git")
+	if err := os.MkdirAll(bare, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, bare, "init", "--bare")
+	enterBootstrapEnvironment(t, bare)
+
+	for _, args := range [][]string{
+		{"--no-wake", "--me", "alice", "sh"},
+		{"--session", "session1", "--no-wake", "--me", "alice", "sh"},
+	} {
+		err := runCoopExec(args)
+		if err == nil || GetExitCode(err) != ExitContextMismatch {
+			t.Fatalf("bare-repository coop exec %v error = %v, want context-mismatch refusal", args, err)
+		}
+		for _, want := range []string{"cd into a worktree", "--root"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("bare-repository refusal missing %q: %v", want, err)
+			}
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(bare, defaultCoopRoot)); !os.IsNotExist(statErr) {
+		t.Fatalf("bare-repository bootstrap created a queue: %v", statErr)
+	}
+	if err := runCoopInitInternal([]string{"--no-gitignore"}, false); err == nil || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("bare-repository coop init error = %v, want context-mismatch refusal", err)
+	}
+}
+
+func TestCoopExecBootstrapRequiresProvenGitWorktree(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string)
+	}{
+		{
+			name: "empty git directory",
+			setup: func(t *testing.T, project string) {
+				if err := os.Mkdir(filepath.Join(project, ".git"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "arbitrary git file",
+			setup: func(t *testing.T, project string) {
+				if err := os.WriteFile(filepath.Join(project, ".git"), []byte("not a gitdir\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "symlinked git marker",
+			setup: func(t *testing.T, project string) {
+				target := filepath.Join(t.TempDir(), "target")
+				if err := os.MkdirAll(target, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				runGitForTest(t, target, "init")
+				if err := os.Symlink(filepath.Join(target, ".git"), filepath.Join(project, ".git")); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			project := t.TempDir()
+			test.setup(t, project)
+			enterBootstrapEnvironment(t, project)
+			assertBootstrapRefusedWithoutWrites(t, project)
+		})
+	}
+
+	t.Run("git marker inspection failure", func(t *testing.T) {
+		project, _ := enterFreshGitBootstrapProject(t, false)
+		marker := filepath.Join(project, ".git")
+		original := gitMarkerLstat
+		gitMarkerLstat = func(path string) (os.FileInfo, error) {
+			if sameCleanPath(path, marker) {
+				return nil, os.ErrPermission
+			}
+			return os.Lstat(path)
+		}
+		t.Cleanup(func() { gitMarkerLstat = original })
+		assertBootstrapRefusedWithoutWrites(t, project)
+	})
+}
+
+func assertBootstrapRefusedWithoutWrites(t *testing.T, project string) {
+	t.Helper()
+	err := runCoopExec([]string{"--no-wake", "--me", "alice", "sh"})
+	if err == nil || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("coop exec error = %v, want context-mismatch refusal", err)
+	}
+	for _, name := range []string{".amqrc", defaultCoopRoot, ".gitignore"} {
+		if _, statErr := os.Lstat(filepath.Join(project, name)); !os.IsNotExist(statErr) {
+			t.Fatalf("refused bootstrap created %s: %v", name, statErr)
+		}
+	}
+}
+
+func enterFreshGitBootstrapProject(t *testing.T, nested bool) (string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for repository bootstrap")
+	}
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, repo, "init")
+	cwd := repo
+	if nested {
+		cwd = filepath.Join(repo, "nested")
+		if err := os.MkdirAll(cwd, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	homeBase := enterBootstrapEnvironment(t, cwd)
+	return repo, homeBase
+}
+
+func enterBootstrapEnvironment(t *testing.T, cwd string) string {
+	t.Helper()
+	clearCoopSessionPinForTest(t)
+	for _, key := range []string{envRoot, envMe, envGlobalRoot} {
+		setOptionalEnv(t, key, "", false)
+	}
+	fakeHome := t.TempDir()
+	homeBase := filepath.Join(fakeHome, "other-project", defaultCoopRoot)
+	if err := fsq.EnsureRootDirs(homeBase); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fakeHome, ".amqrc"), []byte(`{"root":"`+homeBase+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", fakeHome)
+	t.Chdir(cwd)
+	resetAmqrcCache()
+	t.Cleanup(resetAmqrcCache)
+	return homeBase
+}

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -147,6 +147,9 @@ func runCoopExec(args []string) error {
 	}
 
 	// Resolve explicit --session (pure sugar for --root <base>/<session>).
+	// A fresh Git worktree has no base yet; remember that bootstrap is needed
+	// and provision the requested session after full coop init completes.
+	bootstrapBase := ""
 	if *sessionFlag != "" {
 		if flagWasVisited(fs, "root") {
 			return UsageError("--session and --root are mutually exclusive")
@@ -159,12 +162,26 @@ func runCoopExec(args []string) error {
 			return err
 		}
 		if !ambient {
-			base, err = resolveBaseRoot()
-			if err != nil {
-				return err
+			if *noInitFlag {
+				base, err = resolveBaseRoot()
+				if err != nil {
+					return err
+				}
+			} else {
+				var found bool
+				base, found, err = resolveDiscoveredBaseRootForBootstrap()
+				if err != nil {
+					return err
+				}
+				if !found {
+					bootstrapBase = base
+					base = ""
+				}
 			}
 		}
-		*rootFlag = filepath.Join(base, *sessionFlag)
+		if base != "" {
+			*rootFlag = filepath.Join(base, *sessionFlag)
+		}
 	}
 
 	// Resolve root: --root flag (or --session-derived) > ambient context >
@@ -179,12 +196,21 @@ func runCoopExec(args []string) error {
 		if ambient {
 			root = ambientBase
 		} else {
-			discoveredBase, found, discoveryErr := resolveDiscoveredBaseRoot()
+			var discoveredBase string
+			var found bool
+			var discoveryErr error
+			if *noInitFlag {
+				discoveredBase, found, discoveryErr = resolveDiscoveredBaseRoot()
+			} else {
+				discoveredBase, found, discoveryErr = resolveDiscoveredBaseRootForBootstrap()
+			}
 			if discoveryErr != nil {
-				return fmt.Errorf("invalid AMQ root configuration: %w", discoveryErr)
+				return discoveryErr
 			}
 			if found {
 				root = discoveredBase
+			} else if discoveredBase != "" {
+				bootstrapBase = discoveredBase
 			}
 		}
 	}
@@ -192,7 +218,7 @@ func runCoopExec(args []string) error {
 	// Explicit named sessions use the same direct-child creation boundary as
 	// coop init/default exec. In particular, never let MkdirAll traverse a
 	// pre-existing session symlink.
-	if *sessionFlag != "" {
+	if *sessionFlag != "" && root != "" {
 		if *noInitFlag && !dirExists(root) {
 			return fmt.Errorf("root %q does not exist; run 'amq coop init' first or remove --no-init", root)
 		}
@@ -229,9 +255,14 @@ func runCoopExec(args []string) error {
 			}
 		} else {
 			// No explicit, ambient, project, repo-local, or global root: run
-			// full coop init in the cwd (writes .amqrc).
+			// full coop init. In a Git worktree, coop init relocates this to
+			// the worktree top so nested invocations do not scatter queues.
 			if !*yesFlag {
-				ok, err := confirmPromptYes("No project, repo-local, or global AMQ root found. Initialize co-op mode in current directory?")
+				location := "current directory"
+				if bootstrapBase != "" {
+					location = fmt.Sprintf("Git worktree at %s", filepath.Dir(bootstrapBase))
+				}
+				ok, err := confirmPromptYes(fmt.Sprintf("No project, repo-local, or global AMQ root found. Initialize co-op mode in %s?", location))
 				if err != nil {
 					return err
 				}
@@ -258,6 +289,19 @@ func runCoopExec(args []string) error {
 				root = filepath.Join(existing.Dir, root)
 			}
 		}
+	}
+
+	if *sessionFlag != "" && !sessionProvisioned {
+		base := root
+		if bootstrapBase != "" && !sameTreeIdentity(base, bootstrapBase) {
+			return fmt.Errorf("bootstrap resolved base %q, but coop init produced %q", bootstrapBase, base)
+		}
+		requestedRoot := filepath.Join(base, *sessionFlag)
+		root, err = provisionCoopSession(base, *sessionFlag, []string{agentHandle}, agentHandle, cmdName)
+		if err != nil {
+			return fmt.Errorf("failed to create session root %q: %w", requestedRoot, err)
+		}
+		sessionProvisioned = true
 	}
 
 	// Default to --session collab when neither --session nor --root was specified.

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -539,11 +539,50 @@ func resolveDiscoveredBaseRoot() (string, bool, error) {
 	return "", false, nil
 }
 
+// resolveDiscoveredBaseRootForBootstrap preserves ordinary root precedence but
+// turns an unconfigured Git worktree into a bootstrap target. Participating
+// commands must continue using resolveDiscoveredBaseRoot so they never create a
+// queue merely because cwd is inside a repository.
+func resolveDiscoveredBaseRootForBootstrap() (string, bool, error) {
+	base, found, err := resolveDiscoveredBaseRoot()
+	if err == nil || GetExitCode(err) != ExitContextMismatch {
+		return base, found, err
+	}
+
+	if top, ok := gitWorktreeTopFromCWD(); ok {
+		return filepath.Join(top, defaultCoopRoot), false, nil
+	}
+	return "", false, err
+}
+
 func noEligibleRootInGitError(top string) error {
 	return ContextMismatchError(
-		"cannot determine an eligible AMQ root while cwd is inside Git worktree or bare repository %s: no project .amqrc, repo-local .agent-mail, or explicit root was found; implicit ~/.amqrc is ineligible here; --session selects a session but does not authorize a base root; configure this repository, set AMQ_GLOBAL_ROOT or AM_ROOT, or pass --root explicitly",
+		"cannot determine an eligible AMQ root while cwd is inside Git worktree or bare repository %s: no project .amqrc, repo-local .agent-mail, or explicit root was found; implicit ~/.amqrc is ineligible here; --session selects a session but does not authorize a base root; run 'amq coop init' (or 'amq coop exec <agent>') in this repository to create its queue; for a bare repository, cd into a worktree or pass --root explicitly; alternatively configure this repository, set AMQ_GLOBAL_ROOT or AM_ROOT, or pass --root explicitly",
 		top,
 	)
+}
+
+func gitWorktreeTopFromCWD() (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(cwd); resolveErr == nil {
+		cwd = resolved
+	}
+	top, err := gitTopLevel(cwd)
+	if err != nil {
+		return "", false
+	}
+	markerInfo, err := gitMarkerLstat(filepath.Join(top, ".git"))
+	if err != nil || (!markerInfo.IsDir() && !markerInfo.Mode().IsRegular()) {
+		return "", false
+	}
+	boundary, insideGit := gitWorktreeRootFromCWD()
+	if !insideGit || !sameTreeIdentity(top, boundary) {
+		return "", false
+	}
+	return top, true
 }
 
 func gitWorktreeRootFromCWD() (string, bool) {

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -79,9 +79,12 @@ Set `AMQ_GLOBAL_ROOT` or `~/.amqrc` so `amq env` and `amq doctor` still resolve
 the correct queue. `AMQ_GLOBAL_ROOT` is explicit authority and therefore
 precedes repo-local auto-detection. The implicit home config is ineligible
 inside a Git worktree or bare repository.
-An unconfigured Git worktree or bare repository refuses implicit `~/.amqrc` fallback
-because it can silently select another project's mailbox; use a local
-`.amqrc`, an existing pin, explicit `--root`, or `AMQ_GLOBAL_ROOT`.
+A Git worktree or bare repository with no eligible root refuses implicit
+`~/.amqrc` fallback because it can silently select another project's mailbox.
+Participating commands keep that refusal. `coop exec` honors root precedence,
+then bootstraps a worktree-local queue at the Git top when no eligible root
+exists; `coop exec --no-init` refuses. `coop init` explicitly targets that local
+Git top. Bare repositories require a worktree or an explicit `--root`.
 
 **Session pitfall**: `coop exec` defaults to `--session collab` (i.e., `.agent-mail/collab`). Outside `coop exec`, the base root is `.agent-mail` (no session suffix). These are different mailbox trees — don't mix them up.
 
@@ -91,7 +94,11 @@ because it can silently select another project's mailbox; use a local
 |---------|---------|---------------------|
 | Outside `coop exec` | `amq env --me claude` | resolved base root from project `.amqrc`, `AMQ_GLOBAL_ROOT`, or an eligible implicit fallback |
 | Git worktree or bare repository, no project `.amqrc` | `amq env --me claude` | `AMQ_GLOBAL_ROOT` when set, otherwise repo-local detected `.agent-mail` |
-| Unconfigured Git worktree or bare repository | `amq env --session auth --me claude` | refuses implicit `~/.amqrc`; requires a local or explicit root |
+| Git worktree or bare repository, no eligible root | `amq env --session auth --me claude` | refuses implicit `~/.amqrc`; requires a local or explicit root |
+| Git worktree, no eligible root | `amq coop exec claude` | bootstraps `<git-top>/.agent-mail/collab`; never consults `~/.amqrc` |
+| Git worktree, no eligible root | `amq coop exec --session auth claude` | bootstraps `<git-top>/.agent-mail/auth` |
+| Git worktree, no eligible root | `amq coop exec --no-init claude` | refuses and names `amq coop init` as the remedy |
+| Bare repository, no eligible root | `amq coop exec claude` | refuses; use a worktree or explicit `--root` |
 | Outside `coop exec`, isolated session | `amq env --session auth --me claude` | `<resolved-base-root>/auth` |
 | Inside `coop exec` (no flags) | automatic | `.agent-mail/collab` (default session) |
 | Inside `coop exec --session X` | automatic | `.agent-mail/X` |


### PR DESCRIPTION
## Summary

`amq coop exec` documents auto-initialization of a fresh project, but inside
any Git checkout the documented path was unreachable: the root resolver
returned a hard refusal for an unconfigured repository before the bootstrap
branch could run, so the quick-start command failed on every fresh clone
(reported live by the operator; `--session` died even earlier). The refusal
exists to stop implicit `~/.amqrc` fallback from routing one project's messages
into another project's mailbox — that protection is correct and is preserved;
the defect was refusing to *create the right queue*, not just refusing to fall
back to the wrong one.

Bootstrap commands (`coop exec`, `coop init`) now treat "inside Git with no
eligible root" as *not found* and auto-initialize the repo-local queue at the
Git worktree top. Participating commands (`send`, `list`, `drain`, …) keep the
hard refusal — now naming the runnable remedy.

## Behavior

- `amq coop exec <agent>` in a fresh clone bootstraps `<gitTop>/.agent-mail`
  (with `.amqrc` and gitignore handling exactly as documented); invocations
  from a subdirectory initialize at the Git top, never scattering queues below
  it. `--session <name>` bootstraps the base the same way, then provisions the
  session; a consistency check fails closed if the bootstrap-resolved base and
  the init product ever disagree.
- Bootstrap requires a *proven* worktree: the `.git` marker must be a directory
  or regular file, symlinks are resolved, and the top is cross-checked against
  the routing boundary. Spoofed markers (empty `.git` dir, arbitrary file,
  symlinked marker, unstatable marker) refuse.
- Bootstrap never consults or mutates `~/.amqrc` — proven by a test that
  compares the HOME file before/after. The cross-project routing guard keeps
  its teeth.
- Bare repositories still refuse (no working tree to host a queue); the message
  says to cd into a worktree or pass `--root`.
- `--no-init` keeps meaning what it says: refusal, unchanged.
- The participating-command refusal now names the remedy: run `amq coop init`
  (or `amq coop exec <agent>`) in this repository.
- `coop init` from a subdirectory relocates to the Git top with a deferred
  working-directory restore that reports (rather than swallows) a restore
  failure.

## Testing

Nine RED-first acceptance cells in
`internal/cli/coop_exec_git_bootstrap_unix_test.go`: fresh-clone bootstrap with
the HOME-`.amqrc` negative assertion, named-session bootstrap, subdirectory →
Git top (exec and init), linked-worktree bootstrap with `doctor --ops`
divergence detection, participating-command refusal with the new remedy text,
`--no-init` refusal, bare-repo refusal, and the four-case spoofed-marker
matrix. Full `make ci` and `GOOS=windows` production build pass at the exact
commit; independently re-reviewed and re-run at the frozen staged hash before
commit.

## Exact review identity

- base: `bfbbdd41c32b99db7138db02a0b3c96ef150ded6` (v0.52.0)
- tip: `02b4d2a0c9dcf285378950cfdf9a7ef668611fe7`, tree
  `bda8f4ec15c806d703b0843be9371f01e28e417b`
- reviewed staged patch SHA-256:
  `850bf731e01aa0f8c70f85edff9fcffab87d47368b0195cea0c1d125d34f27cd`
- Independent of PR #425 and PR #428 (no shared files).
