### PR TITLE
fix(doctor): correlate unread backlog with proven notifier absence

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -48,11 +48,12 @@ type opsOperatorGate struct {
 }
 
 type opsHint struct {
-	Code       string             `json:"code"`
-	Status     string             `json:"status"`
-	Message    string             `json:"message"`
-	Backlog    *opsBacklog        `json:"backlog,omitempty"`
-	WakeBinary *opsWakeBinaryHint `json:"wake_binary,omitempty"`
+	Code                    string                          `json:"code"`
+	Status                  string                          `json:"status"`
+	Message                 string                          `json:"message"`
+	Backlog                 *opsBacklog                     `json:"backlog,omitempty"`
+	WakeBinary              *opsWakeBinaryHint              `json:"wake_binary,omitempty"`
+	UnreadBacklogNoNotifier *opsUnreadBacklogNoNotifierHint `json:"unread_backlog_no_notifier,omitempty"`
 }
 
 type opsBacklog struct {
@@ -67,6 +68,14 @@ type opsWakeBinaryHint struct {
 	Agent  string `json:"agent"`
 	PID    int    `json:"pid"`
 	Remedy string `json:"remedy"`
+}
+
+type opsUnreadBacklogNoNotifierHint struct {
+	Agent                  string  `json:"agent"`
+	UnreadCount            int     `json:"unread_count"`
+	OldestUnreadAgeSeconds float64 `json:"oldest_unread_age_seconds"`
+	Command                string  `json:"command"`
+	Remedy                 string  `json:"remedy"`
 }
 
 type opsWakeLock struct {
@@ -98,6 +107,7 @@ type opsWakeLock struct {
 	OperatorTerminalRequired bool   `json:"operator_terminal_required"`
 	NextAction               string `json:"next_action,omitempty"`
 	CurrentTerminal          bool   `json:"-"`
+	NotifierAbsent           bool   `json:"-"`
 
 	WakeCheckDecision *wakeCheckDecision `json:"-"`
 	Mutation          *opsWakeMutation   `json:"-"`
@@ -245,6 +255,7 @@ func runOpsChecksWithSchema(
 
 	// Operational and integration hints
 	result.Hints = append(result.Hints, wakeHints...)
+	result.Hints = append(result.Hints, checkUnreadBacklogNoNotifierHints(root, result.Agents, result.WakeLocks)...)
 	result.Hints = append(result.Hints, checkSiblingBacklogHints(root, agents)...)
 	result.Hints = append(result.Hints, checkBaseBacklogHints(root, agents)...)
 	result.Hints = append(result.Hints, checkWorktreeDivergenceHints(root, agents)...)
@@ -253,6 +264,62 @@ func runOpsChecksWithSchema(
 	result.Hints = append(result.Hints, checkSymphonyHint()...)
 
 	return result
+}
+
+func checkUnreadBacklogNoNotifierHints(root string, agents []opsAgent, wakeLocks []opsWakeLock) []opsHint {
+	notifierAbsent := make(map[string]bool, len(wakeLocks))
+	for _, lock := range wakeLocks {
+		notifierAbsent[lock.Agent] = wakeLockProvesNotifierAbsent(lock)
+	}
+
+	var hints []opsHint
+	for _, agent := range agents {
+		if agent.UnreadCount == 0 {
+			continue
+		}
+		absent, lockExists := notifierAbsent[agent.Handle]
+		// Missing, proven-stale, and removed locks prove notifier absence.
+		// Unverified and live rows stay with their existing fail-closed signals.
+		if lockExists && !absent {
+			continue
+		}
+
+		messageWord := "messages"
+		if agent.UnreadCount == 1 {
+			messageWord = "message"
+		}
+		command := fmt.Sprintf(
+			"amq wake check --root %s --me %s",
+			shellQuoteArg(root),
+			agent.Handle,
+		)
+		remedy := "drain from the owning session"
+		hints = append(hints, opsHint{
+			Code:   "unread_backlog_no_notifier",
+			Status: "warn",
+			Message: fmt.Sprintf(
+				"%s has %d unread %s, oldest %.0fs; run %s for restart capability; %s",
+				agent.Handle,
+				agent.UnreadCount,
+				messageWord,
+				agent.OldestUnreadAgeSeconds,
+				command,
+				remedy,
+			),
+			UnreadBacklogNoNotifier: &opsUnreadBacklogNoNotifierHint{
+				Agent:                  agent.Handle,
+				UnreadCount:            agent.UnreadCount,
+				OldestUnreadAgeSeconds: agent.OldestUnreadAgeSeconds,
+				Command:                command,
+				Remedy:                 remedy,
+			},
+		})
+	}
+	return hints
+}
+
+func wakeLockProvesNotifierAbsent(lock opsWakeLock) bool {
+	return lock.NotifierAbsent
 }
 
 func loadOpsAgents(root string, fixWakeLocks bool, explicitBaseRoot ...string) ([]string, error) {
@@ -446,6 +513,12 @@ func checkWakeLocksWithHintsSchema(
 			staleBinary,
 			jsonSchema == wakeCheckSchemaV2,
 		)
+		if lock.WakeCheckDecision != nil && lock.WakeCheckDecision.Platform.WakeSupported {
+			status := lock.WakeCheckDecision.Wake.Status
+			lock.NotifierAbsent = status == string(wakeLockMissing) || status == string(wakeLockStale)
+		} else {
+			lock.NotifierAbsent = !inspection.Exists || inspection.Status == wakeLockStale
+		}
 		locks = append(locks, lock)
 	}
 	for _, agent := range agents {
@@ -512,7 +585,9 @@ func checkWakeLocksWithHintsSchema(
 			if fix {
 				guardErr := withWakeLifecycleGuard(root, agent, func() error {
 					recheck := inspectWakeLock(root, agent)
-					if !sameWakeLockGeneration(inspection, recheck) || recheck.Status != wakeLockStale {
+					sameGeneration := sameWakeLockGeneration(inspection, recheck)
+					inspection = recheck
+					if !sameGeneration || recheck.Status != wakeLockStale {
 						lock.Status = string(recheck.Status)
 						lock.Reason = "wake lock changed before fix"
 						return nil

--- a/internal/cli/doctor_unread_backlog_no_notifier_other_test.go
+++ b/internal/cli/doctor_unread_backlog_no_notifier_other_test.go
@@ -1,0 +1,34 @@
+//go:build !darwin && !linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestDoctorOpsV2UnsupportedPlatformDoesNotClaimUnverifiedNotifierAbsent(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "alice")
+	messagePath := filepath.Join(fsq.AgentInboxNew(root, "alice"), "message.md")
+	if err := os.WriteFile(messagePath, []byte("message"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "alice", wakeLock{
+		PID:        4242,
+		Executable: "amq",
+	})
+
+	result := runOpsChecksWithSchema(root, "test", false, wakeCheckSchemaV2)
+	if len(result.WakeLocks) != 1 || result.WakeLocks[0].Status != string(wakeLockUnverified) {
+		t.Fatalf("unsupported-platform lock = %#v", result.WakeLocks)
+	}
+	if result.WakeLocks[0].NotifierAbsent {
+		t.Fatalf("unverified lock classified absent: %#v", result.WakeLocks[0])
+	}
+	if _, found := findOpsHint(result.Hints, "unread_backlog_no_notifier"); found {
+		t.Fatalf("unverified lock emitted no-notifier hint: %#v", result.Hints)
+	}
+}

--- a/internal/cli/doctor_unread_backlog_no_notifier_unix_test.go
+++ b/internal/cli/doctor_unread_backlog_no_notifier_unix_test.go
@@ -1,0 +1,334 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const unreadBacklogNoNotifierRemedy = "drain from the owning session"
+
+func writeUnreadBacklogForTest(t *testing.T, root string, age time.Duration) {
+	t.Helper()
+	messagePath := filepath.Join(fsq.AgentInboxNew(root, "alice"), "message.md")
+	if err := os.WriteFile(messagePath, []byte("message"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if age > 0 {
+		old := time.Now().Add(-age)
+		if err := os.Chtimes(messagePath, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestDoctorOpsUnreadBacklogNoNotifierHintMatrix(t *testing.T) {
+	tests := []struct {
+		name           string
+		unread         bool
+		lockState      string
+		wantHint       bool
+		wantLockStatus string
+	}{
+		{name: "backlog without lock", unread: true, wantHint: true},
+		{name: "backlog with stale lock", unread: true, lockState: "stale", wantHint: true, wantLockStatus: string(wakeLockStale)},
+		{name: "backlog with unverified lock", unread: true, lockState: "unverified", wantLockStatus: string(wakeLockUnverified)},
+		{name: "backlog with live lock", unread: true, lockState: "live"},
+		{name: "no backlog without lock"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := healthyDoctorMailboxRoot(t, "alice")
+			if test.unread {
+				writeUnreadBacklogForTest(t, root, 90*time.Second)
+			}
+			if test.lockState != "" {
+				const pid = 4242
+				const processStart = "verified-start"
+				const bootID = "verified-boot"
+				args := []string{"amq", "wake", "--root", root, "--me", "alice"}
+				lock := wakeLock{
+					PID:          pid,
+					ProcessStart: processStart,
+					BootID:       bootID,
+					Executable:   "amq",
+					Args:         args,
+				}
+				if test.lockState == "unverified" {
+					lock.ProcessStart = ""
+					lock.BootID = ""
+				}
+				writeWakeLockForTest(t, root, "alice", lock)
+				stubInspectWakeProcess(t, func(gotPID int) wakeProcessInfo {
+					if test.lockState == "stale" {
+						return wakeProcessInfo{PID: gotPID, Running: false}
+					}
+					if test.lockState == "unverified" {
+						return wakeProcessInfo{PID: gotPID, Running: true, Executable: "/usr/local/bin/amq"}
+					}
+					return wakeProcessInfo{
+						PID:        gotPID,
+						Running:    true,
+						StartToken: processStart,
+						BootID:     bootID,
+						Executable: "/usr/local/bin/amq",
+						Args:       args,
+					}
+				})
+			}
+
+			result := runOpsChecks(root, "test", false)
+			hint, found := findOpsHint(result.Hints, "unread_backlog_no_notifier")
+			if found != test.wantHint {
+				t.Fatalf("hint present = %v, want %v: %#v", found, test.wantHint, result.Hints)
+			}
+			if test.lockState != "" && (len(result.WakeLocks) != 1 || result.WakeLocks[0].NotifierAbsent != test.wantHint) {
+				t.Fatalf("semantic notifier absence = %#v, want %v", result.WakeLocks, test.wantHint)
+			}
+			if !test.wantHint {
+				if test.wantLockStatus != "" && (len(result.WakeLocks) != 1 || result.WakeLocks[0].Status != test.wantLockStatus) {
+					t.Fatalf("wake lock status = %#v, want %q", result.WakeLocks, test.wantLockStatus)
+				}
+				if test.lockState == "live" && (len(result.Agents) != 1 || result.Agents[0].PresenceSource != presenceSourceNotifierLive) {
+					t.Fatalf("live fixture presence source = %#v", result.Agents)
+				}
+				return
+			}
+
+			if hint.Status != "warn" || hint.UnreadBacklogNoNotifier == nil {
+				t.Fatalf("hint = %#v", hint)
+			}
+			payload := hint.UnreadBacklogNoNotifier
+			if payload.Agent != "alice" || payload.UnreadCount != 1 {
+				t.Fatalf("identity/count = %#v", payload)
+			}
+			if payload.OldestUnreadAgeSeconds < 89 || payload.OldestUnreadAgeSeconds > 92 {
+				t.Fatalf("oldest unread age = %v, want about 90", payload.OldestUnreadAgeSeconds)
+			}
+			wantCommand := "amq wake check --root " + shellQuoteArg(root) + " --me alice"
+			if payload.Command != wantCommand {
+				t.Fatalf("command = %q, want %q", payload.Command, wantCommand)
+			}
+			if payload.Remedy != unreadBacklogNoNotifierRemedy {
+				t.Fatalf("remedy = %q", payload.Remedy)
+			}
+			encoded, err := json.Marshal(hint)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range []string{`"code":"unread_backlog_no_notifier"`, `"agent":"alice"`, `"unread_count":1`, `"oldest_unread_age_seconds":`, `"command":"amq wake check --root `, `"remedy":"drain from the owning session"`} {
+				if !strings.Contains(string(encoded), want) {
+					t.Fatalf("JSON hint missing %q: %s", want, encoded)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorOpsOutputsIncludeUnreadBacklogNoNotifierHint(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "alice")
+	writeUnreadBacklogForTest(t, root, 90*time.Second)
+	clearDoctorSessionPin(t)
+
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--root", root, "--ops"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"alice has 1 unread message",
+		"oldest 90s",
+		"amq wake check --root " + shellQuoteArg(root) + " --me alice",
+		unreadBacklogNoNotifierRemedy,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("human output missing %q:\n%s", want, output)
+		}
+	}
+
+	output, err = captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--root", root, "--ops", "--json", "--json-schema=2"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result doctorResultV2
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Ops == nil {
+		t.Fatal("v2 ops result missing")
+	}
+	hint, found := findOpsHint(result.Ops.Hints, "unread_backlog_no_notifier")
+	if !found || hint.UnreadBacklogNoNotifier == nil ||
+		!strings.Contains(hint.UnreadBacklogNoNotifier.Command, "--root ") {
+		t.Fatalf("v2 JSON hint missing or not root-qualified: %#v", result.Ops.Hints)
+	}
+}
+
+func TestDoctorOpsV2UnreadBacklogNoNotifierAfterStaleLockRemoval(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "alice")
+	writeUnreadBacklogForTest(t, root, 0)
+	lockPath := writeWakeLockForTest(t, root, "alice", wakeLock{
+		PID:        4242,
+		Executable: "/usr/local/bin/amq",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	result := runOpsChecksWithSchema(root, "test", true, wakeCheckSchemaV2)
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale lock was not removed: %v", err)
+	}
+	if len(result.WakeLocks) != 1 || result.WakeLocks[0].Mutation == nil || !result.WakeLocks[0].Mutation.Removed {
+		t.Fatalf("v2 removal result = %#v", result.WakeLocks)
+	}
+	if !result.WakeLocks[0].NotifierAbsent {
+		t.Fatalf("v2 removal lost semantic notifier absence: %#v", result.WakeLocks[0])
+	}
+	if result.WakeLocks[0].WakeCheckDecision == nil || result.WakeLocks[0].WakeCheckDecision.Wake.Status != string(wakeLockMissing) {
+		t.Fatalf("v2 wake decision = %#v", result.WakeLocks[0].WakeCheckDecision)
+	}
+	if _, found := findOpsHint(result.Hints, "unread_backlog_no_notifier"); !found {
+		t.Fatalf("v2 removed stale lock did not emit hint: %#v", result.Hints)
+	}
+}
+
+func TestUnreadBacklogNoNotifierUsesCurrentSemanticWakeState(t *testing.T) {
+	agent := opsAgent{Handle: "alice", UnreadCount: 1, OldestUnreadAgeSeconds: 90}
+	tests := []struct {
+		name     string
+		lock     opsWakeLock
+		wantHint bool
+	}{
+		{
+			name: "v1 removed mutation followed by live replacement",
+			lock: opsWakeLock{
+				Agent:          "alice",
+				Status:         "fixed",
+				Removed:        true,
+				NotifierAbsent: false,
+			},
+		},
+		{
+			name: "v2 removed mutation followed by live replacement",
+			lock: opsWakeLock{
+				Agent:          "alice",
+				Status:         string(wakeLockValid),
+				Mutation:       &opsWakeMutation{Status: "fixed", Removed: true},
+				NotifierAbsent: false,
+				WakeCheckDecision: &wakeCheckDecision{
+					Wake: wakeCheckWakeDecision{Status: string(wakeLockValid), Live: true},
+				},
+			},
+		},
+		{
+			name: "v1 failed removal retains proven stale evidence",
+			lock: opsWakeLock{
+				Agent:          "alice",
+				Status:         "error",
+				Mutation:       &opsWakeMutation{Status: "error"},
+				NotifierAbsent: true,
+			},
+			wantHint: true,
+		},
+		{
+			name: "v2 failed removal retains proven stale evidence",
+			lock: opsWakeLock{
+				Agent:          "alice",
+				Status:         string(wakeLockStale),
+				Mutation:       &opsWakeMutation{Status: "error"},
+				NotifierAbsent: true,
+				WakeCheckDecision: &wakeCheckDecision{
+					Wake: wakeCheckWakeDecision{Status: string(wakeLockStale)},
+				},
+			},
+			wantHint: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hints := checkUnreadBacklogNoNotifierHints(t.TempDir(), []opsAgent{agent}, []opsWakeLock{test.lock})
+			_, found := findOpsHint(hints, "unread_backlog_no_notifier")
+			if found != test.wantHint {
+				t.Fatalf("hint present = %v, want %v: %#v", found, test.wantHint, hints)
+			}
+		})
+	}
+}
+
+func TestDoctorOpsV1ChangedBeforeFixDoesNotClaimNotifierAbsent(t *testing.T) {
+	tests := []struct {
+		name        string
+		replacement wakeProcessInfo
+		wantStatus  string
+	}{
+		{
+			name: "live replacement",
+			replacement: wakeProcessInfo{
+				PID:        4242,
+				Running:    true,
+				StartToken: "verified-start",
+				BootID:     "verified-boot",
+				Executable: "/usr/local/bin/amq",
+				Args:       []string{"amq", "wake"},
+			},
+			wantStatus: string(wakeLockValid),
+		},
+		{
+			name: "unverified replacement",
+			replacement: wakeProcessInfo{
+				PID:          4242,
+				Running:      true,
+				InspectError: errors.New("permission denied"),
+			},
+			wantStatus: string(wakeLockUnverified),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := healthyDoctorMailboxRoot(t, "alice")
+			writeUnreadBacklogForTest(t, root, 0)
+			writeWakeLockForTest(t, root, "alice", wakeLock{
+				PID:          4242,
+				ProcessStart: "verified-start",
+				BootID:       "verified-boot",
+				Executable:   "amq",
+				Args:         []string{"amq", "wake"},
+			})
+			calls := 0
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				calls++
+				if calls < 3 {
+					return wakeProcessInfo{PID: pid, Running: false}
+				}
+				return test.replacement
+			})
+
+			result := runOpsChecks(root, "test", true)
+			if calls < 3 {
+				t.Fatalf("fixture did not reach guarded recheck: %d calls", calls)
+			}
+			if len(result.WakeLocks) != 1 || result.WakeLocks[0].Status != test.wantStatus {
+				t.Fatalf("replacement status = %#v, want %q", result.WakeLocks, test.wantStatus)
+			}
+			if result.WakeLocks[0].NotifierAbsent {
+				t.Fatalf("replacement classified absent: %#v", result.WakeLocks[0])
+			}
+			if _, found := findOpsHint(result.Hints, "unread_backlog_no_notifier"); found {
+				t.Fatalf("replacement emitted no-notifier hint: %#v", result.Hints)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #427. When an agent's inbox held a growing unread backlog and its wake
notifier was gone, `doctor --ops` had every fact (unread count, oldest age,
stale presence, missing lock) but never correlated them: agents without a
`.wake.lock` were skipped by the wake-lock pass entirely, and the human output
reported only "N unread, presence active" — no missing-notifier status, no
severity, no remedy. The incident behind #427 accumulated 30 unread over three
days while remaining technically visible but silent (`amq wake check --me`
reported it perfectly — but only if someone thought to ask per-agent).

`doctor --ops` now emits an `unread_backlog_no_notifier` warn hint when an
agent has unread messages and its notifier is **provably** absent or dead.

## The predicate, and why it names classes

The hint asserts "backlog exists AND the notifier is provably absent or dead."
It fires for a missing lock, a proven-stale lock, and a lock removed by
`--fix-wake-locks` in the same run. It stays silent for **unverified** locks —
where neither ownership nor staleness is provable, claiming notifier absence
would overstate the evidence; the unverified row already fails closed with its
own warning — and for live locks (a live-but-unconsumed doorbell is #428's
`doorbell_parked` hint). Together the two hints close both observability
halves: notifier alive-but-parked, and notifier absent.

Absence is derived from the *current semantic* wake state (the same decision
`amq wake check` reports), not from mutation history: a removed lock followed
by a live replacement does not claim absence, a failed removal retains its
proven-stale evidence, and on platforms where the wake decision is
unsupported the raw inspection is used rather than an unauthoritative claim.
As part of this, the `--fix` path now re-derives its reported state from the
in-guard recheck rather than the pre-guard inspection, fixing a latent
reporting race.

## Hint contents

JSON (`hints[].unread_backlog_no_notifier`): agent, unread count,
oldest-unread age (seconds), a root-qualified runnable `amq wake check`
command, and the owning-session drain remedy. The payload is a new struct —
the existing `backlog` hint JSON is untouched. Human output carries the same
line. Schema v1 and v2 both covered.

## Testing

RED-first. The five-cell matrix includes the discriminating pair — proven-stale
fires, unverified stays silent — plus live-lock silence, no-backlog silence,
and missing-lock firing; mutation-vs-semantics cells (removed-then-replaced,
failed removal); an unsupported-platform cell asserting no absence claim from
an unauthoritative decision; and human/JSON/v2 output assertions. `make ci`
and `GOOS=windows` production build pass at the exact commit. (Windows *test*
cross-compilation remains blocked by the pre-existing `wake_test.go:2307`
issue tracked separately.)

## Exact review identity

- base: `bfbbdd41c32b99db7138db02a0b3c96ef150ded6` (v0.52.0)
- tip: `3734eb05bc0e0f2db497874eeedca3566d419496`, tree
  `404eac639db40479b898a4b1c054d757213cc579`
- reviewed staged full-index SHA-256:
  `efefa56fe1168457c568ad556c659dc0d0276aef888b8ab28f9f1416efb4b349`
- Independent of PRs #425, #428, #429 (no shared files with any of them).
