### PR TITLE
fix(upgrade): guard Homebrew-owned paths by prefix ownership

### DIFF
--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -15,9 +16,21 @@ import (
 )
 
 var (
-	executablePathForUpgrade = update.ExecutablePath
-	fetchLatestTagForUpgrade = update.FetchLatestTag
+	executablePathForUpgrade        = update.ExecutablePath
+	fetchLatestTagForUpgrade        = update.FetchLatestTag
+	detectHomebrewPrefixForUpgrade  = detectHomebrewPrefix
+	lookPathForHomebrewUpgrade      = exec.LookPath
+	runBrewPrefixForHomebrewUpgrade = runBrewPrefix
+	homebrewBrewExistsForUpgrade    = homebrewBrewExists
 )
+
+const homebrewDetectionTimeout = 2 * time.Second
+
+var wellKnownHomebrewPrefixes = []string{
+	"/opt/homebrew",
+	"/usr/local",
+	"/home/linuxbrew/.linuxbrew",
+}
 
 func runUpgrade(args []string, currentVersion string) error {
 	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
@@ -134,11 +147,80 @@ func selectUpgradeDestination(path, resolved string, writable func(string) error
 	}
 	destPath = filepath.Clean(destPath)
 
-	if strings.Contains(filepath.ToSlash(destPath), "/Cellar/") {
-		return "", fmt.Errorf("amq is installed via Homebrew; run brew upgrade amq instead")
+	if prefix := detectHomebrewPrefixForUpgrade(); prefix != "" &&
+		(homebrewOwnsUpgradePath(prefix, path) || homebrewOwnsUpgradePath(prefix, destPath)) {
+		if isSeveredHomebrewBinary(prefix, path) {
+			return "", fmt.Errorf("amq is installed via Homebrew; run brew reinstall amq")
+		}
+		return "", fmt.Errorf("amq is installed via Homebrew; run brew update && brew upgrade amq")
 	}
 	if err := writable(destPath); err != nil {
 		return "", fmt.Errorf("cannot write the amq install location %s: %w", destPath, err)
 	}
 	return destPath, nil
+}
+
+func detectHomebrewPrefix() string {
+	if prefix := cleanHomebrewPrefix(os.Getenv("HOMEBREW_PREFIX")); prefix != "" {
+		return prefix
+	}
+
+	if brewPath, err := lookPathForHomebrewUpgrade("brew"); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), homebrewDetectionTimeout)
+		output, runErr := runBrewPrefixForHomebrewUpgrade(ctx, brewPath)
+		cancel()
+		if runErr == nil {
+			if prefix := cleanHomebrewPrefix(strings.TrimSpace(string(output))); prefix != "" {
+				return prefix
+			}
+		}
+	}
+
+	for _, prefix := range wellKnownHomebrewPrefixes {
+		if homebrewBrewExistsForUpgrade(filepath.Join(prefix, "bin", "brew")) {
+			return filepath.Clean(prefix)
+		}
+	}
+	return ""
+}
+
+func runBrewPrefix(ctx context.Context, brewPath string) ([]byte, error) {
+	return exec.CommandContext(ctx, brewPath, "--prefix").Output()
+}
+
+func homebrewBrewExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func cleanHomebrewPrefix(prefix string) string {
+	if prefix == "" || !filepath.IsAbs(prefix) {
+		return ""
+	}
+	return filepath.Clean(prefix)
+}
+
+func homebrewOwnsUpgradePath(prefix, path string) bool {
+	if path == "" {
+		return false
+	}
+	path = filepath.Clean(path)
+	return pathWithinDirectory(path, filepath.Join(prefix, "bin")) ||
+		pathWithinDirectory(path, filepath.Join(prefix, "Cellar"))
+}
+
+func pathWithinDirectory(path, directory string) bool {
+	rel, err := filepath.Rel(filepath.Clean(directory), path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func isSeveredHomebrewBinary(prefix, path string) bool {
+	if path == "" || !pathWithinDirectory(filepath.Clean(path), filepath.Join(prefix, "bin")) {
+		return false
+	}
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular()
 }

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -7,10 +7,12 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
@@ -161,6 +163,9 @@ func TestRunUpgradeRefusesHomebrewSymlinkBeforeDownload(t *testing.T) {
 		return link, resolved, nil
 	}
 	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return filepath.Join(base, "homebrew") }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
 	oldFetchLatestTag := fetchLatestTagForUpgrade
 	fetchCalls := 0
 	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
@@ -170,7 +175,7 @@ func TestRunUpgradeRefusesHomebrewSymlinkBeforeDownload(t *testing.T) {
 	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetchLatestTag })
 
 	err = runUpgrade(nil, "v0.0.0")
-	const want = "amq is installed via Homebrew; run brew upgrade amq instead"
+	const want = "amq is installed via Homebrew; run brew update && brew upgrade amq"
 	if err == nil || err.Error() != want {
 		t.Fatalf("runUpgrade error = %v, want %q", err, want)
 	}
@@ -285,5 +290,189 @@ func TestSelectUpgradeDestinationRefusesUnwritableResolvedPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cannot write the amq install location") {
 		t.Fatalf("selectUpgradeDestination error = %q, want clean writability refusal", err)
+	}
+}
+
+func TestSelectUpgradeDestinationRefusesHomebrewOwnedPaths(t *testing.T) {
+	prefix := filepath.Join(t.TempDir(), "homebrew")
+	binPath := filepath.Join(prefix, "bin", "amq")
+	cellarPath := filepath.Join(prefix, "Cellar", "amq", "0.52.2", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
+		t.Fatalf("mkdir Homebrew bin: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cellarPath), 0o755); err != nil {
+		t.Fatalf("mkdir Homebrew Cellar: %v", err)
+	}
+	if err := os.WriteFile(cellarPath, []byte("homebrew"), 0o755); err != nil {
+		t.Fatalf("write Homebrew Cellar binary: %v", err)
+	}
+
+	oldDetect := detectHomebrewPrefixForUpgrade
+	detectHomebrewPrefixForUpgrade = func() string { return prefix }
+	t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+
+	t.Run("severed regular prefix binary recommends reinstall", func(t *testing.T) {
+		if err := os.WriteFile(binPath, []byte("self-upgraded"), 0o755); err != nil {
+			t.Fatalf("write severed prefix binary: %v", err)
+		}
+
+		_, err := selectUpgradeDestination(binPath, binPath, func(string) error { return nil })
+		if err == nil || !strings.Contains(err.Error(), "brew reinstall amq") {
+			t.Fatalf("selectUpgradeDestination error = %v, want reinstall remedy", err)
+		}
+	})
+
+	t.Run("dangling Cellar symlink refuses before resolution", func(t *testing.T) {
+		if err := os.Remove(binPath); err != nil {
+			t.Fatalf("remove regular prefix binary: %v", err)
+		}
+		danglingTarget := filepath.Join(prefix, "Cellar", "amq", "missing", "bin", "amq")
+		if err := os.Symlink(danglingTarget, binPath); err != nil {
+			t.Fatalf("create dangling Cellar symlink: %v", err)
+		}
+
+		_, err := selectUpgradeDestination(binPath, binPath, func(string) error { return nil })
+		if err == nil || !strings.Contains(err.Error(), "brew update && brew upgrade amq") {
+			t.Fatalf("selectUpgradeDestination error = %v, want update and upgrade remedy", err)
+		}
+	})
+
+	t.Run("healthy Cellar symlink refuses", func(t *testing.T) {
+		if err := os.Remove(binPath); err != nil {
+			t.Fatalf("remove dangling symlink: %v", err)
+		}
+		if err := os.Symlink(cellarPath, binPath); err != nil {
+			t.Fatalf("create healthy Cellar symlink: %v", err)
+		}
+
+		_, err := selectUpgradeDestination(binPath, cellarPath, func(string) error { return nil })
+		if err == nil || !strings.Contains(err.Error(), "brew update && brew upgrade amq") {
+			t.Fatalf("selectUpgradeDestination error = %v, want update and upgrade remedy", err)
+		}
+	})
+}
+
+func TestSelectUpgradeDestinationRequiresDetectedHomebrewOwnership(t *testing.T) {
+	prefix := filepath.Join(t.TempDir(), "homebrew")
+	brewBinPath := filepath.Join(prefix, "bin", "amq")
+	brewCellarPath := filepath.Join(prefix, "Cellar", "amq", "0.52.2", "bin", "amq")
+	manualPath := filepath.Join(t.TempDir(), "bin", "amq")
+
+	t.Run("brew paths proceed without Homebrew detection", func(t *testing.T) {
+		oldDetect := detectHomebrewPrefixForUpgrade
+		detectHomebrewPrefixForUpgrade = func() string { return "" }
+		t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+
+		for _, path := range []string{brewBinPath, brewCellarPath} {
+			got, err := selectUpgradeDestination(path, path, func(string) error { return nil })
+			if err != nil {
+				t.Fatalf("selectUpgradeDestination(%q): %v", path, err)
+			}
+			if got != path {
+				t.Fatalf("destination = %q, want %q", got, path)
+			}
+		}
+	})
+
+	t.Run("manual path proceeds with Homebrew present", func(t *testing.T) {
+		oldDetect := detectHomebrewPrefixForUpgrade
+		detectHomebrewPrefixForUpgrade = func() string { return prefix }
+		t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+
+		got, err := selectUpgradeDestination(manualPath, manualPath, func(string) error { return nil })
+		if err != nil {
+			t.Fatalf("selectUpgradeDestination: %v", err)
+		}
+		if got != manualPath {
+			t.Fatalf("destination = %q, want %q", got, manualPath)
+		}
+	})
+
+	t.Run("prefix-like sibling path proceeds with Homebrew present", func(t *testing.T) {
+		oldDetect := detectHomebrewPrefixForUpgrade
+		detectHomebrewPrefixForUpgrade = func() string { return prefix }
+		t.Cleanup(func() { detectHomebrewPrefixForUpgrade = oldDetect })
+
+		siblingPath := prefix + "-other/bin/amq"
+		got, err := selectUpgradeDestination(siblingPath, siblingPath, func(string) error { return nil })
+		if err != nil {
+			t.Fatalf("selectUpgradeDestination: %v", err)
+		}
+		if got != siblingPath {
+			t.Fatalf("destination = %q, want %q", got, siblingPath)
+		}
+	})
+}
+
+func TestDetectHomebrewPrefixForUpgradeRespectsEnvironment(t *testing.T) {
+	prefix := filepath.Join(t.TempDir(), "custom-homebrew")
+	t.Setenv("HOMEBREW_PREFIX", prefix)
+
+	oldLookPath := lookPathForHomebrewUpgrade
+	lookPathForHomebrewUpgrade = func(string) (string, error) {
+		t.Fatal("brew PATH lookup must not run when HOMEBREW_PREFIX is set")
+		return "", errors.New("unreachable")
+	}
+	t.Cleanup(func() { lookPathForHomebrewUpgrade = oldLookPath })
+
+	if got := detectHomebrewPrefix(); got != prefix {
+		t.Fatalf("detectHomebrewPrefix() = %q, want %q", got, prefix)
+	}
+}
+
+func TestDetectHomebrewPrefixForUpgradeUsesBoundedBrewLookup(t *testing.T) {
+	t.Setenv("HOMEBREW_PREFIX", "")
+	prefix := filepath.Join(t.TempDir(), "path-homebrew")
+
+	oldLookPath := lookPathForHomebrewUpgrade
+	lookPathForHomebrewUpgrade = func(name string) (string, error) {
+		if name != "brew" {
+			t.Fatalf("LookPath name = %q, want brew", name)
+		}
+		return "/custom/bin/brew", nil
+	}
+	t.Cleanup(func() { lookPathForHomebrewUpgrade = oldLookPath })
+
+	oldRun := runBrewPrefixForHomebrewUpgrade
+	runBrewPrefixForHomebrewUpgrade = func(ctx context.Context, path string) ([]byte, error) {
+		if path != "/custom/bin/brew" {
+			t.Fatalf("brew path = %q, want /custom/bin/brew", path)
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > homebrewDetectionTimeout {
+			t.Fatalf("brew --prefix context is not bounded by %s", homebrewDetectionTimeout)
+		}
+		return []byte(prefix + "\n"), nil
+	}
+	t.Cleanup(func() { runBrewPrefixForHomebrewUpgrade = oldRun })
+
+	oldExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(string) bool {
+		t.Fatal("well-known prefix lookup must not run after brew --prefix succeeds")
+		return false
+	}
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldExists })
+
+	if got := detectHomebrewPrefix(); got != prefix {
+		t.Fatalf("detectHomebrewPrefix() = %q, want %q", got, prefix)
+	}
+}
+
+func TestDetectHomebrewPrefixForUpgradeFallsBackToExistingWellKnownBrew(t *testing.T) {
+	t.Setenv("HOMEBREW_PREFIX", "")
+
+	oldLookPath := lookPathForHomebrewUpgrade
+	lookPathForHomebrewUpgrade = func(string) (string, error) { return "", exec.ErrNotFound }
+	t.Cleanup(func() { lookPathForHomebrewUpgrade = oldLookPath })
+
+	want := "/home/linuxbrew/.linuxbrew"
+	oldExists := homebrewBrewExistsForUpgrade
+	homebrewBrewExistsForUpgrade = func(path string) bool {
+		return path == filepath.Join(want, "bin", "brew")
+	}
+	t.Cleanup(func() { homebrewBrewExistsForUpgrade = oldExists })
+
+	if got := detectHomebrewPrefix(); got != want {
+		t.Fatalf("detectHomebrewPrefix() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #434 (reported by Ohad Edelstein with a live reproduction — thank you). The
`amq upgrade` Homebrew guard checked only whether the **resolved** executable
path contained `/Cellar/`. That misses the severed states brew installs decay
into: when `<brew-prefix>/bin/amq` has become a **regular file**, or a
**dangling symlink** into a removed keg, resolution either returns the prefix
path or fails back to it, the substring check passes, and self-upgrade silently
takes over a path Homebrew still believes it owns. Observed live: `brew`
reporting 0.34.1 while the PATH binary was 0.51.1 — permanently divorced
bookkeeping. The dangling-symlink case is also the likely severing mechanism
itself: the old guard let the first self-upgrade replace a broken Cellar link
with a regular file.

## Behavior

The guard now refuses on **prefix ownership**, not a path substring:

- Homebrew is detected via `HOMEBREW_PREFIX`, then a timeout-bounded
  `brew --prefix`, then well-known prefixes only when `<prefix>/bin/brew`
  actually exists. No Homebrew detected → no refusal (a brewless
  `/usr/local/bin` stays writable; ownership is evidence-based, never guessed
  from path shape).
- **Both** the pre-resolution path and the resolved destination are checked for
  containment in `<prefix>/bin` or `<prefix>/Cellar` (via `filepath.Rel`, not
  string prefix — `/opt/homebrew-other/bin` proceeds). Checking the raw path is
  what catches the dangling-symlink case before resolution can launder it.
- Remedies are state-aware: a severed regular file inside `<prefix>/bin` gets
  `brew reinstall amq` (brew and the binary already disagree); symlink states
  get `brew update && brew upgrade amq` — the `brew update` prefix also fixes
  the report's other half, where a stale **local tap clone** offered an old
  version (the canonical tap was verified current for every release since
  0.49.13; that finding was environment-side, not pipeline-side).
- The guard remains pure: it selects or refuses a destination, mutates nothing.

## Testing

RED-first. Matrix: severed regular file → reinstall remedy; dangling Cellar
symlink → refuses **before resolution** with the update+upgrade remedy; healthy
Cellar symlink → refuses; the same brew-shaped paths **without** Homebrew
detected → proceed; a manual `~/bin` path with Homebrew present → proceeds; the
prefix-like sibling path (`<prefix>-other/bin`) → proceeds (the cell a naive
`strings.HasPrefix` implementation fails); detection honors `HOMEBREW_PREFIX`,
bounds the `brew --prefix` lookup, and requires `bin/brew` for the well-known
fallback. Detection is seam-stubbed — tests never shell out. Full `go test
./...`, gofmt, vet, and `GOOS=windows`/`GOOS=linux` builds pass at the exact
commit; independently re-run at the frozen staged hash before commit.

## Exact review identity

- base: `a9e92bd9619185cea159fedd5ec89fb827192818` (v0.52.2)
- tip: `722793e20ffc371d321f88ba2764d76607d38a86`
- reviewed staged diff SHA-256:
  `72c7671376d525659fcdd54cbccad1739d7a9a489949b5ceb3968f88c88533a6`
- Independent of PR #425 (no shared files).
