### PR TITLE
test(wake): gate coalescing delivery on baseline readiness

### DIFF
--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -2340,6 +2340,7 @@ func TestRunWakeLoopCoalescesAdditionThenRearmsAfterDrain(t *testing.T) {
 	decayedRetryAt := startedAt.Add(15 * time.Minute)
 	doorbells := make(chan struct{}, 3)
 	pending := make(chan struct{}, 1)
+	baselineReady := make(chan struct{})
 	stop := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
@@ -2359,6 +2360,10 @@ func TestRunWakeLoopCoalescesAdditionThenRearmsAfterDrain(t *testing.T) {
 				additionAttemptFloor: lastAttempt.Add(wakeDoorbellRetryBase),
 			},
 			preconditionCheck: func(*wakeConfig) error { return nil },
+			onBaselineReady: func(map[string]wakeFileIdentity) error {
+				close(baselineReady)
+				return nil
+			},
 			terminalWrite: func(text string) error {
 				if strings.Contains(text, coopWakeDoorbell) {
 					doorbells <- struct{}{}
@@ -2386,6 +2391,13 @@ func TestRunWakeLoopCoalescesAdditionThenRearmsAfterDrain(t *testing.T) {
 		}
 	}()
 
+	select {
+	case <-baselineReady:
+	case err := <-done:
+		t.Fatalf("wake loop exited before baseline readiness: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not publish baseline readiness")
+	}
 	deliverWakeWatcherMessageForTest(t, root, "codex", "b", "claude")
 	select {
 	case <-pending:


### PR DESCRIPTION
## Summary

Fixes #433. `TestRunWakeLoopCoalescesAdditionThenRearmsAfterDrain` raced its
first message delivery against the wake loop's baseline scan: when delivery
won, the initial scan legitimately absorbed the addition (by design — a
pre-baseline arrival belongs to the baseline), `onPendingNotify` never fired
for it, and the test timed out at "did not observe first addition". Under a
digest-pinned Linux arm64 container the race fired 8–9 times out of 10 —
near-deterministic — and ~1/10 on Darwin, which is what identified it as a
harness race rather than platform behavior. Diagnosed during PR #425's
main-absorption gate, where an identical-harness probe at the merge-base
cleared that PR of a composition defect and attributed the failure here.

## Fix (test-only, +12 lines)

Delivery of the raced message now waits for the loop's **existing**
`onBaselineReady` hook (a production seam already exercised by another test —
no new product surface) via a fail-fast `select`: proceed on readiness, fail
immediately with the loop's own error if it exits early, and bound the wait
with a timeout. No sleeps; no product changes; the coalescing and rearm
assertions the test exists to prove are untouched.

## Evidence

- RED at base (pinned `golang:1.25` arm64 image, non-root, read-only source):
  8/10 fail at the first-addition timeout.
- GREEN with the fix: 10/10 on the same pinned image; 10/10 on Darwin —
  the exact acceptance gate defined in #433.
- Neighbor groups (`RunWakeLoop`/`NotifyNewMessages`/`WakeDoorbell`), full
  `go test ./...`, gofmt, vet all pass at the exact commit; independently
  re-run at the frozen staged hash before commit.

## Exact review identity

- base: `9dcd0bd11432e6e72e6a295d8551b5b61d77ecf2` (v0.52.3)
- tip: `9c5d06a1196d840a36f6f93563a575658d2b9957`
- reviewed staged diff SHA-256:
  `33e32ee99e8365a6442c915f1f52a4ac57ade07352c28f9a2c320f149a71167a`
- Same-file-but-disjoint with PR #425's `wake_unix_test.go` changes (target
  function byte-identical on both lines; verified before routing this fix to
  main).

Diagnosis credit: codex, during the PR #425 absorption gate.
