### PR TITLE
fix(doctor): report darwin wakes running deleted images (#438)

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -69,6 +69,7 @@ type opsBacklog struct {
 type opsWakeBinaryHint struct {
 	Agent  string `json:"agent"`
 	PID    int    `json:"pid"`
+	Reason string `json:"reason,omitempty"`
 	Remedy string `json:"remedy"`
 }
 
@@ -108,6 +109,7 @@ type opsWakeLock struct {
 	RestartCapability        string `json:"restart_capability,omitempty"`
 	OperatorTerminalRequired bool   `json:"operator_terminal_required"`
 	NextAction               string `json:"next_action,omitempty"`
+	InspectionError          string `json:"inspection_error,omitempty"`
 	CurrentTerminal          bool   `json:"-"`
 	NotifierAbsent           bool   `json:"-"`
 
@@ -547,7 +549,10 @@ func checkWakeLocksWithHintsSchema(
 			continue
 		}
 		staleBinary := false
-		if hint, ok := checkStaleWakeBinaryHint(inspection); ok {
+		wakeBinaryInspectionError := ""
+		if hint, ok, err := checkStaleWakeBinaryHint(inspection); err != nil {
+			wakeBinaryInspectionError = err.Error()
+		} else if ok {
 			hints = append(hints, hint)
 			staleBinary = true
 		}
@@ -561,6 +566,7 @@ func checkWakeLocksWithHintsSchema(
 			TTY:             strings.TrimSpace(inspection.Lock.TTY),
 			Started:         strings.TrimSpace(inspection.Lock.Started),
 			Reason:          inspection.Reason,
+			InspectionError: wakeBinaryInspectionError,
 			CurrentTerminal: doctorWakeLockOnCurrentTerminal(inspection),
 		}
 		ownerBound := classifyWakeClaimForGenericTransition(inspection) == wakeClaimAuthoritative

--- a/internal/cli/doctor_schema_v2.go
+++ b/internal/cli/doctor_schema_v2.go
@@ -27,20 +27,21 @@ type doctorOpsResultV2 struct {
 }
 
 type opsWakeLockV2 struct {
-	Status        string             `json:"status"`
-	Agent         string             `json:"agent"`
-	Root          string             `json:"root"`
-	Lock          string             `json:"lock"`
-	PID           int                `json:"pid,omitempty"`
-	TTY           string             `json:"tty,omitempty"`
-	Started       string             `json:"started,omitempty"`
-	Reason        string             `json:"reason,omitempty"`
-	Removed       bool               `json:"removed,omitempty"`
-	Target        string             `json:"target,omitempty"`
-	TargetPresent bool               `json:"target_present,omitempty"`
-	TargetReason  string             `json:"target_reason,omitempty"`
-	Mutation      *opsWakeMutationV2 `json:"mutation,omitempty"`
-	WakeCheck     *wakeCheckResultV2 `json:"wake_check"`
+	Status          string             `json:"status"`
+	Agent           string             `json:"agent"`
+	Root            string             `json:"root"`
+	Lock            string             `json:"lock"`
+	PID             int                `json:"pid,omitempty"`
+	TTY             string             `json:"tty,omitempty"`
+	Started         string             `json:"started,omitempty"`
+	Reason          string             `json:"reason,omitempty"`
+	Removed         bool               `json:"removed,omitempty"`
+	Target          string             `json:"target,omitempty"`
+	TargetPresent   bool               `json:"target_present,omitempty"`
+	TargetReason    string             `json:"target_reason,omitempty"`
+	InspectionError string             `json:"inspection_error,omitempty"`
+	Mutation        *opsWakeMutationV2 `json:"mutation,omitempty"`
+	WakeCheck       *wakeCheckResultV2 `json:"wake_check"`
 }
 
 type opsWakeMutationV2 struct {
@@ -74,18 +75,19 @@ func renderDoctorResultV2(result doctorResult) doctorResultV2 {
 	}
 	for _, lock := range result.Ops.WakeLocks {
 		v2Lock := opsWakeLockV2{
-			Status:        lock.Status,
-			Agent:         lock.Agent,
-			Root:          lock.Root,
-			Lock:          lock.Lock,
-			PID:           lock.PID,
-			TTY:           lock.TTY,
-			Started:       lock.Started,
-			Reason:        lock.Reason,
-			Removed:       lock.Removed,
-			Target:        lock.Target,
-			TargetPresent: lock.TargetPresent,
-			TargetReason:  lock.TargetReason,
+			Status:          lock.Status,
+			Agent:           lock.Agent,
+			Root:            lock.Root,
+			Lock:            lock.Lock,
+			PID:             lock.PID,
+			TTY:             lock.TTY,
+			Started:         lock.Started,
+			Reason:          lock.Reason,
+			Removed:         lock.Removed,
+			Target:          lock.Target,
+			TargetPresent:   lock.TargetPresent,
+			TargetReason:    lock.TargetReason,
+			InspectionError: lock.InspectionError,
 		}
 		if lock.Mutation != nil {
 			v2Lock.Mutation = &opsWakeMutationV2{

--- a/internal/cli/doctor_stale_wake_binary.go
+++ b/internal/cli/doctor_stale_wake_binary.go
@@ -13,6 +13,7 @@ type wakeBinaryComparisonMethod string
 const (
 	wakeBinaryComparisonExactIdentity      wakeBinaryComparisonMethod = "device_inode"
 	wakeBinaryComparisonDarwinProcessImage wakeBinaryComparisonMethod = "darwin_process_image"
+	wakeBinaryComparisonDarwinDeletedImage wakeBinaryComparisonMethod = "darwin_deleted_process_image"
 	wakeBinaryComparisonStartedMTime       wakeBinaryComparisonMethod = "started_mtime_heuristic"
 )
 
@@ -20,6 +21,7 @@ type wakeBinaryStaleness struct {
 	Stale    bool
 	Method   wakeBinaryComparisonMethod
 	Evidence wakeBinaryEvidence
+	Reason   string
 }
 
 type wakeBinaryEvidence struct {
@@ -71,22 +73,26 @@ func resolveWakeBinary() (resolvedWakeBinary, error) {
 	return resolvedWakeBinary{Info: info}, nil
 }
 
-func checkStaleWakeBinaryHint(inspection wakeLockInspection) (opsHint, bool) {
+func checkStaleWakeBinaryHint(inspection wakeLockInspection) (opsHint, bool, error) {
 	if !inspection.Exists ||
 		inspection.Status != wakeLockValid ||
 		!inspection.IdentityConfirmed ||
 		!inspection.Process.Running {
-		return opsHint{}, false
+		return opsHint{}, false, nil
 	}
 
 	comparison, err := inspectWakeBinaryStaleness(inspection)
-	if err != nil || !comparison.Stale {
-		return opsHint{}, false
+	if err != nil {
+		return opsHint{}, false, err
+	}
+	if !comparison.Stale {
+		return opsHint{}, false, nil
 	}
 	if comparison.Method != wakeBinaryComparisonExactIdentity &&
 		comparison.Method != wakeBinaryComparisonDarwinProcessImage &&
+		comparison.Method != wakeBinaryComparisonDarwinDeletedImage &&
 		comparison.Method != wakeBinaryComparisonStartedMTime {
-		return opsHint{}, false
+		return opsHint{}, false, nil
 	}
 
 	// A PID can exit and be reused while its executable is inspected. Re-read
@@ -95,20 +101,23 @@ func checkStaleWakeBinaryHint(inspection wakeLockInspection) (opsHint, bool) {
 	if !sameWakeBinaryInspection(inspection, confirmed) ||
 		!confirmed.IdentityConfirmed ||
 		!sameWakeBinaryProcessEvidence(inspection.Process, confirmed.Process) {
-		return opsHint{}, false
+		return opsHint{}, false, nil
 	}
 	recheckedComparison, err := inspectWakeBinaryStaleness(confirmed)
-	if err != nil ||
-		!recheckedComparison.Stale ||
+	if err != nil {
+		return opsHint{}, false, err
+	}
+	if !recheckedComparison.Stale ||
 		recheckedComparison.Method != comparison.Method ||
+		comparison.Reason != recheckedComparison.Reason ||
 		!sameWakeBinaryEvidence(comparison.Evidence, recheckedComparison.Evidence) {
-		return opsHint{}, false
+		return opsHint{}, false, nil
 	}
 	final := inspectWakeLock(confirmed.Root, confirmed.Agent)
 	if !sameWakeBinaryInspection(confirmed, final) ||
 		!final.IdentityConfirmed ||
 		!sameWakeBinaryProcessEvidence(confirmed.Process, final.Process) {
-		return opsHint{}, false
+		return opsHint{}, false, nil
 	}
 
 	remedy := "restart this wake through its owning shell, launchd, systemd, or coop supervisor"
@@ -127,6 +136,8 @@ func checkStaleWakeBinaryHint(inspection wakeLockInspection) (opsHint, bool) {
 			inspection.PID,
 			remedy,
 		)
+	} else if comparison.Reason != "" {
+		message = fmt.Sprintf("Wake for agent %q (pid %d): %s.", inspection.Agent, inspection.PID, comparison.Reason)
 	}
 
 	return opsHint{
@@ -136,9 +147,10 @@ func checkStaleWakeBinaryHint(inspection wakeLockInspection) (opsHint, bool) {
 		WakeBinary: &opsWakeBinaryHint{
 			Agent:  inspection.Agent,
 			PID:    inspection.PID,
+			Reason: comparison.Reason,
 			Remedy: remedy,
 		},
-	}, true
+	}, true, nil
 }
 
 func sameWakeBinaryEvidence(first, second wakeBinaryEvidence) bool {

--- a/internal/cli/doctor_stale_wake_binary_darwin.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin.go
@@ -5,14 +5,18 @@ package cli
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
 )
 
 const wakeStartedTimestampUncertainty = time.Second
+
+const deletedWakeImageReason = "wake is running a deleted image; restart it"
 
 func inspectWakeBinaryStalenessPlatform(
 	inspection wakeLockInspection,
@@ -58,6 +62,22 @@ func inspectWakeBinaryStalenessPlatform(
 
 	running, err := inspectDarwinWakeProcessImage(inspection.PID)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) && inspection.IdentityConfirmed && inspection.Process.Running {
+			imagePath := running.Path
+			if imagePath == "" {
+				imagePath = recorded.ExecutionPath
+			}
+			if imagePath == recorded.ExecutionPath {
+				if _, pathErr := os.Lstat(imagePath); errors.Is(pathErr, fs.ErrNotExist) {
+					return wakeBinaryStaleness{
+						Stale:    true,
+						Method:   wakeBinaryComparisonDarwinDeletedImage,
+						Evidence: comparisonEvidence,
+						Reason:   deletedWakeImageReason,
+					}, nil
+				}
+			}
+		}
 		return wakeBinaryStaleness{}, err
 	}
 	if !darwinRecordedImageMatches(recorded, running) {
@@ -108,7 +128,7 @@ func inspectDarwinWakeProcessImage(pid int) (darwinWakeProcessImage, error) {
 
 	pathInfo, err := os.Lstat(path)
 	if err != nil {
-		return darwinWakeProcessImage{}, fmt.Errorf("stat wake process executable path: %w", err)
+		return darwinWakeProcessImage{Path: path}, fmt.Errorf("stat wake process executable path: %w", err)
 	}
 	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.Mode().IsRegular() {
 		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable path is not a regular non-symlink file")

--- a/internal/cli/doctor_stale_wake_binary_darwin_test.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin_test.go
@@ -327,6 +327,150 @@ func TestDarwinWakeBinaryComparisonReportsHomebrewReplacementDifferent(t *testin
 	}
 }
 
+func TestDarwinWakeBinaryComparisonReportsDeletedLiveImageStale(t *testing.T) {
+	started := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	dir := t.TempDir()
+	runningPath := filepath.Join(dir, "Cellar", "amq", "0.52.0", "bin", "amq")
+	currentPath := filepath.Join(dir, "Cellar", "amq", "0.52.3", "bin", "amq")
+	for _, path := range []string{runningPath, currentPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runningInfo, err := os.Stat(runningPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentInfo, err := os.Stat(currentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
+	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return runningPath, nil })
+	if err := os.Remove(runningPath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := inspectWakeBinaryStalenessPlatform(
+		wakeLockInspection{
+			PID:               4242,
+			IdentityConfirmed: true,
+			Process:           wakeProcessInfo{PID: 4242, Running: true},
+			Lock: wakeLock{
+				Started:              started.Format(time.RFC3339),
+				ImagePath:            runningPath,
+				ImageVersion:         evidence.EmbeddedVersion,
+				RunningImageEvidence: &evidence,
+			},
+		},
+		resolvedWakeBinary{Info: currentInfo},
+	)
+	if err != nil {
+		t.Fatalf("compare deleted live image: %v", err)
+	}
+	if !got.Stale || got.Method != wakeBinaryComparisonDarwinDeletedImage {
+		t.Fatalf("deleted live image comparison = %#v, want proven stale", got)
+	}
+	if got.Reason != "wake is running a deleted image; restart it" {
+		t.Fatalf("deleted live image reason = %q", got.Reason)
+	}
+}
+
+func TestDarwinWakeBinaryComparisonReportsDeletedRecordedImageWhenProcPIDPathReturnsENOENT(t *testing.T) {
+	started := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	dir := t.TempDir()
+	runningPath := filepath.Join(dir, "Cellar", "amq", "0.52.0", "bin", "amq")
+	currentPath := filepath.Join(dir, "Cellar", "amq", "0.52.3", "bin", "amq")
+	for _, path := range []string{runningPath, currentPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runningInfo, err := os.Stat(runningPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentInfo, err := os.Stat(currentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
+	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return "", os.ErrNotExist })
+	if err := os.Remove(runningPath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := inspectWakeBinaryStalenessPlatform(
+		wakeLockInspection{
+			PID:               4242,
+			IdentityConfirmed: true,
+			Process:           wakeProcessInfo{PID: 4242, Running: true},
+			Lock: wakeLock{
+				Started:              started.Format(time.RFC3339),
+				ImagePath:            runningPath,
+				ImageVersion:         evidence.EmbeddedVersion,
+				RunningImageEvidence: &evidence,
+			},
+		},
+		resolvedWakeBinary{Info: currentInfo},
+	)
+	if err != nil {
+		t.Fatalf("compare deleted recorded image after proc_pidpath ENOENT: %v", err)
+	}
+	if !got.Stale || got.Method != wakeBinaryComparisonDarwinDeletedImage || got.Reason != deletedWakeImageReason {
+		t.Fatalf("deleted recorded image comparison = %#v, want proven stale", got)
+	}
+}
+
+func TestDarwinWakeBinaryComparisonKeepsNonENOENTImageFailureUnknown(t *testing.T) {
+	path := t.TempDir()
+	currentPath := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(currentPath, []byte("current"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	currentInfo, err := os.Stat(currentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return path, nil })
+	recorded := wakeImageEvidenceV1{
+		Schema:          wakeImageEvidenceSchemaV1,
+		Platform:        "darwin",
+		Method:          wakeImageMethodPathnameExecVerified,
+		ExecutionPath:   path,
+		Device:          1,
+		Inode:           1,
+		Size:            1,
+		CTimeNS:         1,
+		SHA256:          "sha256:" + strings.Repeat("0", 64),
+		EmbeddedVersion: "test-version",
+	}
+
+	got, err := inspectWakeBinaryStalenessPlatform(
+		wakeLockInspection{
+			PID:               4242,
+			IdentityConfirmed: true,
+			Process:           wakeProcessInfo{PID: 4242, Running: true},
+			Lock: wakeLock{
+				Started:              time.Now().UTC().Format(time.RFC3339Nano),
+				ImagePath:            path,
+				ImageVersion:         recorded.EmbeddedVersion,
+				RunningImageEvidence: &recorded,
+			},
+		},
+		resolvedWakeBinary{Info: currentInfo},
+	)
+	if err == nil || got.Stale {
+		t.Fatalf("non-ENOENT image failure = %#v, %v; want unknown error", got, err)
+	}
+}
+
 func TestDarwinWakeBinaryComparisonRejectsRecordedEvidenceDisagreement(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "amq")
 	if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {

--- a/internal/cli/doctor_stale_wake_binary_test.go
+++ b/internal/cli/doctor_stale_wake_binary_test.go
@@ -108,6 +108,63 @@ func TestDoctorOpsReportsStructuredStaleWakeBinaryHintWithoutMutation(t *testing
 	}
 }
 
+func TestDoctorOpsReportsWakeBinaryInspectionErrorInJSONWithoutHumanHint(t *testing.T) {
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	writeWakeLockForTest(t, root, agent, wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        agent,
+		Started:      "2026-07-27T10:00:00Z",
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", agent},
+		Generation:   "inspection-error-generation",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "12345",
+			BootID:     "11111111-1111-1111-1111-111111111111",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", agent},
+		}
+	})
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return wakeBinaryStaleness{}, errors.New("transient image inspection failure")
+	})
+
+	result := runOpsChecks(root, "test", false)
+	if hint, found := findOpsHint(result.Hints, "stale_wake_binary"); found {
+		t.Fatalf("inspection failure emitted human stale hint: %#v", hint)
+	}
+	values := map[string]any{
+		"schema v1": result,
+		"schema v2": renderDoctorResultV2(doctorResult{Ops: result}).Ops,
+	}
+	for name, value := range values {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var wire struct {
+				WakeLocks []struct {
+					InspectionError string `json:"inspection_error"`
+				} `json:"wake_locks"`
+			}
+			if err := json.Unmarshal(encoded, &wire); err != nil {
+				t.Fatal(err)
+			}
+			if len(wire.WakeLocks) != 1 || wire.WakeLocks[0].InspectionError != "transient image inspection failure" {
+				t.Fatalf("machine-readable inspection error missing: %s", encoded)
+			}
+		})
+	}
+}
+
 func TestDoctorOpsReportsLegacyFlagShapedStaleWakeWithoutAuthorizingFix(t *testing.T) {
 	root := secureTempDirForTest(t)
 	const (
@@ -214,6 +271,7 @@ func TestStaleWakeBinaryHintFailsClosedOnUnknownOrUnconfirmedEvidence(t *testing
 		name       string
 		inspection wakeLockInspection
 		probe      func(wakeLockInspection) (wakeBinaryStaleness, error)
+		wantErr    bool
 	}{
 		{
 			name: "identity not confirmed",
@@ -230,6 +288,7 @@ func TestStaleWakeBinaryHintFailsClosedOnUnknownOrUnconfirmedEvidence(t *testing
 		{
 			name:       "probe error",
 			inspection: base,
+			wantErr:    true,
 			probe: func(wakeLockInspection) (wakeBinaryStaleness, error) {
 				return wakeBinaryStaleness{}, errors.New("identity unavailable")
 			},
@@ -244,7 +303,11 @@ func TestStaleWakeBinaryHintFailsClosedOnUnknownOrUnconfirmedEvidence(t *testing
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stubWakeBinaryStaleness(t, tc.probe)
-			if hint, ok := checkStaleWakeBinaryHint(tc.inspection); ok {
+			hint, ok, err := checkStaleWakeBinaryHint(tc.inspection)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if ok {
 				t.Fatalf("unexpected hint: %#v", hint)
 			}
 		})
@@ -292,6 +355,50 @@ func TestStaleWakeBinaryHintDescribesDarwinTimestampEvidenceAsHeuristic(t *testi
 		if !strings.Contains(hint.Message, want) {
 			t.Fatalf("heuristic message missing %q: %q", want, hint.Message)
 		}
+	}
+}
+
+func TestStaleWakeBinaryHintDescribesDeletedImage(t *testing.T) {
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	writeWakeLockForTest(t, root, agent, wakeLock{
+		PID:          4242,
+		Root:         canonicalWakeRoot(root),
+		Agent:        agent,
+		Started:      "2026-07-27T10:00:00Z",
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", agent},
+		Generation:   "deleted-image-generation",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "12345",
+			BootID:     "11111111-1111-1111-1111-111111111111",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"amq", "wake", "--root", root, "--me", agent},
+		}
+	})
+	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
+		return wakeBinaryStaleness{
+			Stale:    true,
+			Method:   wakeBinaryComparisonDarwinDeletedImage,
+			Evidence: stableWakeBinaryEvidenceForTest(),
+			Reason:   "wake is running a deleted image; restart it",
+		}, nil
+	})
+
+	result := runOpsChecks(root, "test", false)
+	hint, found := findOpsHint(result.Hints, "stale_wake_binary")
+	if !found || hint.WakeBinary == nil {
+		t.Fatalf("deleted-image hint missing: %#v", result.Hints)
+	}
+	const want = "wake is running a deleted image; restart it"
+	if hint.WakeBinary.Reason != want || !strings.Contains(hint.Message, want) {
+		t.Fatalf("deleted-image reason = %#v message=%q", hint.WakeBinary, hint.Message)
 	}
 }
 

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -93,7 +93,9 @@ func TestRunUpgradeAlreadyCurrentReportsStaleWakesWithInvalidAmbientAgent(t *tes
 		t.Fatalf("upgrade diagnostic roots = %#v, want both session roots", roots)
 	}
 	inspection := inspectWakeLock(staleRoot, "codex")
-	if hint, ok := checkStaleWakeBinaryHint(inspection); !ok {
+	if hint, ok, err := checkStaleWakeBinaryHint(inspection); err != nil {
+		t.Fatalf("stale fixture inspection error: %v", err)
+	} else if !ok {
 		t.Fatalf("stale fixture produced no hint: %#v", inspection)
 	} else if hint.WakeBinary == nil || hint.WakeBinary.PID != 4242 {
 		t.Fatalf("stale fixture hint = %#v", hint)


### PR DESCRIPTION
Fixes #438.

## Problem

On Darwin, when Homebrew (or any upgrade) deletes the image a live wake is executing, `proc_pidpath` resolution or the follow-up `Lstat` on that path returns ENOENT — and `checkStaleWakeBinaryHint` swallowed the error, producing **no hint at all**. The exact situation the `stale_wake_binary` hint exists for reported silence. Observed live: after upgrading 0.52.0 → 0.52.3, running wakes on the deleted 0.52.0 keg showed lock status `valid` with zero staleness signal. Linux was never affected (`/proc/<pid>/exe` dereferences the kernel-held deleted inode and the device+inode comparison fires correctly).

## Fix

- **Proof, not error**: an identity-confirmed live wake whose live-discovered image path equals the lock's recorded execution path, where that path Lstats to ENOENT, is now `Stale: true` with a distinct method `darwin_deleted_process_image` and reason `wake is running a deleted image; restart it`. A live pid with a vanished recorded image is the strongest staleness evidence Darwin offers.
- Both ENOENT provenances handled: `proc_pidpath` itself failing ENOENT (falls back to the recorded path) and the discovered-path `Lstat` failing ENOENT.
- **Conservative boundary**: if the live-discovered path *differs* from the recorded one, or the failure is anything other than ENOENT, the inspection remains an error — no hint is invented.
- **Silence is never ambiguous anymore**: `checkStaleWakeBinaryHint` returns errors instead of swallowing them; failures that suppress the hint surface as `wake_locks[].inspection_error` in `doctor --ops --json` (schema v1 and v2). Human output stays quiet on non-ENOENT errors (fail-closed).
- TOCTOU recheck now also pins the `Reason` across the confirm pass. Linux comparator untouched.

## Verification

- RED first: both new Darwin cells reproduce the pre-fix behavior (removing the proof branch fails exactly those two cells with the original errors).
- Mutation-tested at both layers: re-swallowing the probe error fails the JSON-visibility test in both schemas plus the fail-closed `probe_error` cell.
- `make ci` PASS; `GOOS=windows` and `GOOS=linux` builds PASS.
- Live read-only proof on the machine that motivated the issue: a build of this head against a real session root reports 2 `stale_wake_binary` hints with the exact deleted-image reason and zero inspection errors, where released 0.52.3 reports nothing. Runtime-selected subjects (real running wakes), no fixtures presented as live proof.
- `errors.Is(err, fs.ErrNotExist)` verified through the real syscall chain, not just test stubs: the `proc_pidpath` errno is `%w`-wrapped at `wake_process_darwin.go` and re-wrapped at `inspectDarwinWakeProcessImage`; `Lstat` wraps `%w` likewise.

Review: exact-hash review passed at staged diff SHA-256 `c8c4f0fe…` (index tree `4e99964e…`), commit `2f8c6865` is byte-identical to the reviewed tree on base `d62eca6d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
