### PR TITLE
fix(wake): nudge submit instead of re-typing reminder payloads

### DIFF
--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -251,7 +251,7 @@ func runOpsChecksWithSchema(
 				Code:   "doorbell_parked",
 				Status: "warn",
 				Message: fmt.Sprintf(
-					"Agent %s doorbell is parked after %d attempts with unread messages (oldest unread %.0fs)",
+					"Agent %s doorbell is parked after %d attempts with unread messages (oldest unread %.0fs); input may be stranded at the agent prompt, and a manual Enter in its pane can recover it",
 					agent.Handle,
 					agent.DoorbellAttempts,
 					agent.OldestUnreadAgeSeconds,

--- a/internal/cli/doctor_ops_test.go
+++ b/internal/cli/doctor_ops_test.go
@@ -149,8 +149,18 @@ func TestRunOpsChecks_DoorbellParkedHintRequiresUnreadBacklog(t *testing.T) {
 	if hint.Status != "warn" ||
 		!strings.Contains(hint.Message, "codex") ||
 		!strings.Contains(hint.Message, "4 attempts") ||
-		!strings.Contains(hint.Message, "90s") {
+		!strings.Contains(hint.Message, "90s") ||
+		!strings.Contains(hint.Message, "input may be stranded") ||
+		!strings.Contains(hint.Message, "manual Enter") {
 		t.Fatalf("parked hint = %#v", hint)
+	}
+	parkedJSON, err := json.Marshal(parkedResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(parkedJSON), "input may be stranded") ||
+		!strings.Contains(string(parkedJSON), "manual Enter") {
+		t.Fatalf("parked JSON omitted recovery guidance: %s", parkedJSON)
 	}
 	if len(parkedResult.Agents) != 1 ||
 		!parkedResult.Agents[0].DoorbellParked ||

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -281,8 +281,9 @@ type wakePayload struct {
 }
 
 type wakeNotification struct {
-	input  wakePayload
-	output wakePayload
+	input      wakePayload
+	output     wakePayload
+	submitOnly bool
 }
 
 func peerWakeNotification(output string) wakeNotification {
@@ -605,10 +606,12 @@ func deliverNewMessageNotification(
 	}
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound && cfg.injectMode != wakeInjectModeNone {
+		retainedInputPending := cfg.inputDelivery.pending()
 		notice.input = wakePayload{
 			text:       plan.prompt,
 			provenance: wakePayloadSystemFixed,
 		}
+		notice.submitOnly = plan.submitOnly
 		deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
 		if isWakeInputDemotionBlocked(deliveryErr) {
 			return enterWakeInputRecovery(cfg, currentPending, deliveryErr)
@@ -626,6 +629,11 @@ func deliverNewMessageNotification(
 			return deliveryErr
 		}
 		if shouldRecordWakeAttempt(deliveryErr) {
+			if !plan.submitOnly &&
+				(!plan.contentChange || !retainedInputPending) &&
+				wakeInputAttemptConfirmed(cfg, deliveryErr) {
+				cfg.doorbell.confirmPresentation()
+			}
 			recordWakeAttempt(
 				cfg,
 				cfg.wakeDoorbellNow(),
@@ -649,6 +657,14 @@ func deliverNewMessageNotification(
 		)
 	}
 	return deliveryErr
+}
+
+func wakeInputAttemptConfirmed(cfg *wakeConfig, deliveryErr error) bool {
+	return deliveryErr == nil &&
+		cfg.injectMode != wakeInjectModeNone &&
+		!cfg.inputDelivery.pending() &&
+		!cfg.lastAttemptAttention &&
+		!cfg.lastAttemptTransientAttention
 }
 
 func recordWakeAttempt(
@@ -1049,7 +1065,10 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	cfg.lastAttemptTransientAttention = false
 	ownerBound := usesCoopDoorbell(cfg)
 	if ownerBound {
-		if validCoopWakeDoorbell(notice.input.text) {
+		if notice.submitOnly && notice.input.provenance == wakePayloadSystemFixed {
+			// A submit-only reminder is system-created from cohort state. It has
+			// no payload text to validate or replace.
+		} else if validCoopWakeDoorbell(notice.input.text) {
 			// The fixed doorbell is system-created before delivery.
 		} else {
 			notice.input = wakePayload{
@@ -1063,7 +1082,13 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	}
 
 	inputText := notice.input.text
+	if notice.submitOnly {
+		inputText = ""
+	}
 	plainText := inputText
+	if notice.submitOnly {
+		plainText = "\r"
+	}
 	if cfg.bell && !ownerBound {
 		plainText = "\a" + plainText
 	}
@@ -1114,7 +1139,11 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		if cfg.bell && !ownerBound {
 			injectedText = "\a" + injectedText
 		}
-		inputAccepted, injectErr = injectRawNotification(cfg, injectedText)
+		if notice.submitOnly {
+			inputAccepted, injectErr = injectTerminalSubmitOnly(cfg, wakeInjectModeRaw)
+		} else {
+			inputAccepted, injectErr = injectRawNotification(cfg, injectedText)
+		}
 		inputAccepted = inputAccepted || cfg.inputDelivery.confirmedInput()
 
 	case wakeInjectModePaste:
@@ -1128,24 +1157,32 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 		if cfg.bell && !ownerBound {
 			pasteText = "\a" + pasteText
 		}
-		inputAccepted, injectErr = injectTerminalNotification(
-			cfg,
-			wakeInjectModePaste,
-			pasteText,
-		)
+		if notice.submitOnly {
+			inputAccepted, injectErr = injectTerminalSubmitOnly(cfg, wakeInjectModePaste)
+		} else {
+			inputAccepted, injectErr = injectTerminalNotification(
+				cfg,
+				wakeInjectModePaste,
+				pasteText,
+			)
+		}
 		inputAccepted = inputAccepted || cfg.inputDelivery.confirmedInput()
 
 	default:
 		// Unknown mode, fall back to raw
 		if ownerBound {
-			wrote, err := writeTerminalChunk(cfg, inputText)
-			inputAccepted = wrote
-			if err != nil {
-				injectErr = err
-			} else if wrote {
-				submitted, err := writeTerminalChunk(cfg, "\r")
-				inputAccepted = inputAccepted || submitted
-				injectErr = err
+			if notice.submitOnly {
+				inputAccepted, injectErr = writeTerminalChunk(cfg, "\r")
+			} else {
+				wrote, err := writeTerminalChunk(cfg, inputText)
+				inputAccepted = wrote
+				if err != nil {
+					injectErr = err
+				} else if wrote {
+					submitted, err := writeTerminalChunk(cfg, "\r")
+					inputAccepted = inputAccepted || submitted
+					injectErr = err
+				}
 			}
 		} else {
 			injectedText := inputText + "\r"
@@ -1561,6 +1598,33 @@ func injectTerminalNotification(
 			mode:    mode,
 			payload: payload,
 		}
+	}
+	return resumeWakeInputDelivery(cfg)
+}
+
+func injectTerminalSubmitOnly(cfg *wakeConfig, mode string) (bool, error) {
+	state := &cfg.inputDelivery
+	if state.acceptanceUncertain {
+		return false, &wakeInputDemotionBlockedError{
+			err: errors.New("submit-only terminal input followed a write with uncertain acceptance"),
+		}
+	}
+	if state.pending() {
+		if state.mode != mode || state.payload != "" {
+			return false, &wakeInputDemotionBlockedError{
+				err: errors.New("submit-only terminal input collided with retained payload delivery"),
+			}
+		}
+		return resumeWakeInputDelivery(cfg)
+	}
+
+	phase := wakeInputPrimarySubmitPending
+	if mode == wakeInjectModeRaw && rawSubmitPrelude(cfg.me) != "" {
+		phase = wakeInputRawPreludePending
+	}
+	*state = wakeInputDeliveryState{
+		phase: phase,
+		mode:  mode,
 	}
 	return resumeWakeInputDelivery(cfg)
 }

--- a/internal/cli/wake_doorbell.go
+++ b/internal/cli/wake_doorbell.go
@@ -31,6 +31,7 @@ const (
 type wakeDoorbellState struct {
 	phase                        wakeDoorbellPhase
 	cohort                       map[string]*wakeFileIdentity
+	presentationConfirmed        bool
 	attempts                     uint
 	reminderAttempts             uint
 	attemptBudget                uint
@@ -43,9 +44,11 @@ type wakeDoorbellState struct {
 }
 
 type wakeDoorbellPlan struct {
-	attempt  bool
-	prompt   string
-	progress bool
+	attempt       bool
+	prompt        string
+	submitOnly    bool
+	contentChange bool
+	progress      bool
 }
 
 func (state *wakeDoorbellState) plan(
@@ -58,9 +61,11 @@ func (state *wakeDoorbellState) plan(
 	}
 
 	progress := state.phase != wakeDoorbellIdle && wakeCohortProgressed(state.cohort, current)
+	contentChange := false
 	if progress {
 		state.reset()
 	} else if state.phase != wakeDoorbellIdle && wakeCohortExpanded(state.cohort, current) {
+		contentChange = true
 		// Additions extend the pending obligation without resetting its retry
 		// ladder, but pull its deadline forward to the delivery floor because
 		// the new information has not been announced yet. One outstanding
@@ -68,6 +73,7 @@ func (state *wakeDoorbellState) plan(
 		// unread messages do not need N doorbells.
 		if state.phase == wakeDoorbellParked {
 			state.cohort = snapshotWakeFileIdentities(current)
+			state.presentationConfirmed = false
 			if state.attemptBudget < wakeDoorbellLifetimeAttemptCap {
 				state.attemptBudget++
 				state.phase = wakeDoorbellRetrying
@@ -89,18 +95,25 @@ func (state *wakeDoorbellState) plan(
 	}
 
 	return wakeDoorbellPlan{
-		attempt:  true,
-		prompt:   coopWakeDoorbell,
-		progress: progress,
+		attempt:       true,
+		prompt:        coopWakeDoorbell,
+		submitOnly:    state.presentationConfirmed,
+		contentChange: contentChange,
+		progress:      progress,
 	}
 }
 
 func (state *wakeDoorbellState) arm(current map[string]os.FileInfo) {
 	state.phase = wakeDoorbellRetrying
 	state.cohort = snapshotWakeFileIdentities(current)
+	state.presentationConfirmed = false
 	if state.attemptBudget == 0 {
 		state.attemptBudget = wakeDoorbellInitialAttemptBudget
 	}
+}
+
+func (state *wakeDoorbellState) confirmPresentation() {
+	state.presentationConfirmed = true
 }
 
 func (state *wakeDoorbellState) recordAttempt(now time.Time) {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -1953,6 +1953,182 @@ func TestNotifyNewMessagesCoalescesAdditionsUntilRetryOrProgress(t *testing.T) {
 	}
 }
 
+func TestNotifyNewMessagesReminderUsesSubmitOnlyAfterConfirmedPresentation(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		mode                   string
+		queueFirstSubmit       bool
+		wantConfirmedInitially bool
+		wantInjected           string
+	}{
+		{
+			name:                   "raw-confirmed",
+			mode:                   wakeInjectModeRaw,
+			wantConfirmedInitially: true,
+			wantInjected:           coopWakeDoorbell + "\n\r\r\n\r\r",
+		},
+		{
+			name:                   "paste-confirmed",
+			mode:                   wakeInjectModePaste,
+			wantConfirmedInitially: true,
+			wantInjected:           coopWakeDoorbell + "\r\r",
+		},
+		{
+			name:             "raw-first-submit-queued",
+			mode:             wakeInjectModeRaw,
+			queueFirstSubmit: true,
+			wantInjected:     coopWakeDoorbell + "\n\r\r",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			msg := format.Message{
+				Header: format.Header{
+					Schema:  1,
+					ID:      "unchanged-reminder-" + tc.name,
+					From:    "peer",
+					To:      []string{"codex"},
+					Thread:  "p2p/codex__peer",
+					Subject: "unchanged reminder",
+					Created: "2026-08-05T19:00:00Z",
+				},
+			}
+			data, err := msg.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := deliverToInboxForTest(t, root, "codex", "unchanged.md", data); err != nil {
+				t.Fatal(err)
+			}
+
+			drainCall := 0
+			stubRawInputDrained(t, func(timeout time.Duration, _ time.Duration) (time.Duration, bool, error) {
+				drainCall++
+				if tc.queueFirstSubmit && drainCall == 2 {
+					return timeout, false, nil
+				}
+				return 0, true, nil
+			})
+			stubRawInjectSleep(t)
+			var injected strings.Builder
+			now := time.Unix(1_800_000_000, 0)
+			cfg := &wakeConfig{
+				me:          "codex",
+				root:        root,
+				session:     "session1",
+				wakeOwner:   &wakeOwner{},
+				injectMode:  tc.mode,
+				doorbellNow: func() time.Time { return now },
+				terminalWrite: func(text string) error {
+					injected.WriteString(text)
+					return nil
+				},
+			}
+
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("initial presentation: %v", err)
+			}
+			if got := cfg.doorbell.presentationConfirmed; got != tc.wantConfirmedInitially {
+				t.Fatalf("initial presentation confirmed = %t, want %t", got, tc.wantConfirmedInitially)
+			}
+			now = cfg.doorbell.nextAttempt
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("next attempt: %v", err)
+			}
+			if cfg.inputRecoveryRequired {
+				t.Fatal("ordinary queued-suffix resume entered input recovery")
+			}
+			if !cfg.doorbell.presentationConfirmed {
+				t.Fatal("completed full presentation was not marked confirmed")
+			}
+
+			got := injected.String()
+			if count := strings.Count(got, coopWakeDoorbell); count != 1 {
+				t.Fatalf("payload occurrences = %d, want exactly one across presentation and reminder: %q", count, got)
+			}
+			if got != tc.wantInjected {
+				t.Fatalf("presentation sequence = %q, want %q", got, tc.wantInjected)
+			}
+		})
+	}
+}
+
+func TestNotifyNewMessagesRetriesFullPayloadAfterZeroConfirmedProgress(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	msg := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "zero-progress",
+			From:    "peer",
+			To:      []string{"codex"},
+			Thread:  "p2p/codex__peer",
+			Subject: "zero progress",
+			Created: "2026-08-05T19:00:00Z",
+		},
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deliverToInboxForTest(t, root, "codex", "zero-progress.md", data); err != nil {
+		t.Fatal(err)
+	}
+
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+	firstWrite := true
+	var accepted strings.Builder
+	now := time.Unix(1_800_000_000, 0)
+	cfg := &wakeConfig{
+		me:             "codex",
+		root:           root,
+		session:        "session1",
+		wakeOwner:      &wakeOwner{},
+		injectMode:     wakeInjectModeRaw,
+		doorbellNow:    func() time.Time { return now },
+		attentionIsTTY: func() bool { return false },
+		terminalWrite: func(text string) error {
+			if firstWrite {
+				firstWrite = false
+				return &wakeTestAcceptedProgressError{
+					err:      errors.New("refused before acceptance"),
+					accepted: 0,
+				}
+			}
+			accepted.WriteString(text)
+			return nil
+		},
+	}
+
+	captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("zero-progress presentation: %v", err)
+		}
+	})
+	now = cfg.doorbell.nextAttempt
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("full retry: %v", err)
+	}
+	if got, want := accepted.String(), coopWakeDoorbell+"\n\r\r"; got != want {
+		t.Fatalf("accepted retry = %q, want full presentation %q", got, want)
+	}
+}
+
 func TestNotifyNewMessagesCoalescesUrgentAdditionWithoutOutputAttention(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1970,7 +1970,7 @@ func awaitWakeAttentionFrom(
 	}
 }
 
-func TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood(t *testing.T) {
+func TestRunWakeLoopRetriesPendingDoorbellWithSubmitOnlyNudge(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	message := format.Message{
@@ -1998,13 +1998,29 @@ func TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood(t *testing.T) {
 	})
 	stubRawInjectSleep(t)
 	firstDoorbell := make(chan struct{}, 1)
-	extraDoorbell := make(chan struct{}, 1)
+	retypedDoorbell := make(chan struct{}, 1)
+	reminderSubmit := make(chan struct{}, 1)
 	attention := make(chan string, 1)
 	stop := make(chan struct{})
 	done := make(chan error, 1)
-	doorbells := 0
+	loopDone := make(chan struct{})
+	defer func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-loopDone:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop during cleanup")
+		}
+	}()
+	doorbellPayloads := 0
+	submitKeys := 0
 
 	go func() {
+		defer close(loopDone)
 		done <- runWakeLoop(wakeConfig{
 			root:        root,
 			me:          "codex",
@@ -2016,12 +2032,18 @@ func TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood(t *testing.T) {
 				return nil
 			},
 			terminalWrite: func(text string) error {
-				if strings.Contains(text, coopWakeDoorbell) {
-					doorbells++
-					if doorbells == 1 {
+				if text == coopWakeDoorbell {
+					doorbellPayloads++
+					if doorbellPayloads == 1 {
 						firstDoorbell <- struct{}{}
 					} else {
-						extraDoorbell <- struct{}{}
+						retypedDoorbell <- struct{}{}
+					}
+				}
+				if text == "\r" {
+					submitKeys++
+					if submitKeys == 4 {
+						reminderSubmit <- struct{}{}
 					}
 				}
 				return nil
@@ -2043,11 +2065,11 @@ func TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood(t *testing.T) {
 	}
 
 	select {
-	case <-extraDoorbell:
+	case <-reminderSubmit:
 	case err := <-done:
 		t.Fatalf("wake loop exited before retry: %v", err)
 	case <-time.After(wakeDoorbellRetryBase + 2*time.Second):
-		t.Fatal("pending doorbell was not retried on its own deadline")
+		t.Fatal("pending doorbell did not receive a submit-only nudge on its own deadline")
 	}
 	close(stop)
 	select {
@@ -2057,6 +2079,11 @@ func TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("wake loop did not stop")
+	}
+	select {
+	case <-retypedDoorbell:
+		t.Fatal("submit-only reminder retyped the fixed doorbell payload")
+	default:
 	}
 	select {
 	case output := <-attention:


### PR DESCRIPTION
Fixes #418.

## Problem

Under raw wake injection, a prompt's text can land while its submit is lost — the agent sits silently unreachable with text stranded at its input line (observed up to 22 prompts deep, ~12 times in one 8-hour session; each a 15–20 minute stall recovered only by a human pressing Enter). The wake process can observe the kernel tty queue but never the TUI's input buffer, so "stranded at the prompt" and "consumed and running" are indistinguishable from outside — and the reminder loop made the failure worse by re-typing the full payload on every retry, which is exactly the observed stacking.

## Fix

Reminders stop re-typing and start nudging:

- Once a cohort's full presentation (payload + submit) reaches **confirmed tty acceptance** (`presentationConfirmed`, set only when the delivery state machine is fully idle — a queued submit is not a completed presentation), every later reminder for that cohort injects a **submit-only CR nudge** through the existing prelude/settle/rescue submit machinery. If text is stranded, the nudge submits it — the manual recovery, automated. If it was consumed, a CR at an idle prompt is a no-op. Payload stacking becomes impossible: at most one copy of the text, ever.
- A presentation that never made confirmed progress re-presents in full (nothing landed, so it isn't a re-type). A parked cohort's top-up attempt also re-presents in full.
- Budget, deferral, and parking semantics are unchanged (nudges consume attempts exactly like presentations). The `doorbell_parked` doctor hint now says input may be stranded at the agent prompt and that a manual Enter recovers it, in both human and JSON output.

## Verification

- Notify-level discriminating table (raw confirmed / paste confirmed / raw first-submit-queued): byte-exact injected streams, payload-exactly-once across presentation + reminder, queued-CR exact-suffix resume with no recovery entry, zero-progress full retry.
- Mutation-tested at both layers by the reviewer: removing the idle-state term from the confirmation predicate fails the queued case ("confirmed = true, want false"); defeating submit-only planning fails raw+paste with payload-count-2 — the literal doubled-doorbell flood.
- Wake-loop integration test re-aimed at the new contract (see justification below): retains its original no-output-flood assertion, adds a deadline assertion on the complete reminder submit suffix (4th CR = presentation CR+rescue then nudge CR+rescue) and a discriminating rejection of any retyped payload (fails on pre-fix code).
- `make ci`, focused `-race`, full Linux `internal/cli` suite, `GOOS=linux` and `GOOS=windows` builds — green on the exact frozen trees (exact-hash review protocol, staged trees `bd8a0347` + `8ef6efa1`).

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestRunWakeLoopRetriesPendingDoorbellWithoutOutputFlood: Renamed to TestRunWakeLoopRetriesPendingDoorbellWithSubmitOnlyNudge because the old name asserted the pre-fix contract (a second literal payload re-type on retry) that this change intentionally removes; the successor retains the original no-output-flood negative assertion and adds a discriminating rejection of retyped payloads plus a deadline assertion on the submit-only nudge.
END_WAKE_TEST_CHANGE_JUSTIFICATION

🤖 Generated with [Claude Code](https://claude.com/claude-code)
