### PR TITLE
fix(wake): apply submit-only reminder nudge to all injecting wakes, not just owner-bound

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -605,11 +605,13 @@ func deliverNewMessageNotification(
 		}
 	}
 	ownerBound := usesCoopDoorbell(cfg)
-	if ownerBound && cfg.injectMode != wakeInjectModeNone {
+	if cfg.injectMode != wakeInjectModeNone {
 		retainedInputPending := cfg.inputDelivery.pending()
-		notice.input = wakePayload{
-			text:       plan.prompt,
-			provenance: wakePayloadSystemFixed,
+		if ownerBound {
+			notice.input = wakePayload{
+				text:       plan.prompt,
+				provenance: wakePayloadSystemFixed,
+			}
 		}
 		notice.submitOnly = plan.submitOnly
 		deliveryErr := deliverWakeNotification(cfg, notice, deferForInput)
@@ -1100,7 +1102,10 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	}
 
 	// External injection: delegate to user-specified command instead of TIOCSTI.
-	// The command receives the notification text as its last argument.
+	// The command receives the notification text as its last argument. This
+	// transport does not participate in inputDelivery, so exit zero is its only
+	// presentation-confirmation evidence; an unchanged confirmed cohort therefore
+	// invokes the injector with a submit-only CR on its next reminder.
 	if cfg.injectVia != "" {
 		allowed, guardErr := authorizeTerminalWrite(cfg)
 		if guardErr != nil {

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -2661,6 +2661,399 @@ func TestNotifyNewMessagesOwnerlessSuccessfulInputRetryEmitsNoAttention(t *testi
 	}
 }
 
+func TestNotifyNewMessagesGenericFullPresentationConfirmsDoorbell(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "generic-confirmed-presentation")
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	var injected strings.Builder
+	now := time.Unix(1_800_000_000, 0)
+	cfg := &wakeConfig{
+		me:          "codex",
+		root:        root,
+		session:     "session1",
+		injectMode:  wakeInjectModeRaw,
+		doorbellNow: func() time.Time { return now },
+		terminalWrite: func(text string) error {
+			injected.WriteString(text)
+			return nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first generic presentation: %v", err)
+	}
+	if got, want := injected.String(), coopWakeDoorbell+"\n\r\r"; got != want {
+		t.Fatalf("first generic presentation = %q, want %q", got, want)
+	}
+	if !cfg.doorbell.presentationConfirmed {
+		t.Fatal("successful generic full presentation was not confirmed")
+	}
+}
+
+func TestNotifyNewMessagesGenericConfirmedCohortUsesSubmitOnly(t *testing.T) {
+	testCases := []struct {
+		name      string
+		mode      string
+		firstWant string
+		retryWant string
+	}{
+		{
+			name:      "raw",
+			mode:      wakeInjectModeRaw,
+			firstWant: "\a" + coopWakeDoorbell + "\n\r\r",
+			retryWant: "\n\r\r",
+		},
+		{
+			name:      "paste",
+			mode:      wakeInjectModePaste,
+			firstWant: "\a\x1b[200~" + coopWakeDoorbell + "\x1b[201~\r",
+			retryWant: "\r",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			deliverPartialWakeMessageForTest(t, root, "codex", "generic-submit-only-"+tc.name)
+			stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+				return 0, true, nil
+			})
+			stubRawInjectSleep(t)
+
+			var injected strings.Builder
+			now := time.Unix(1_800_000_000, 0)
+			cfg := &wakeConfig{
+				me:          "codex",
+				root:        root,
+				session:     "session1",
+				injectMode:  tc.mode,
+				bell:        true,
+				doorbellNow: func() time.Time { return now },
+				terminalWrite: func(text string) error {
+					injected.WriteString(text)
+					return nil
+				},
+			}
+
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("first generic presentation: %v", err)
+			}
+			if got := injected.String(); got != tc.firstWant {
+				t.Fatalf("first generic presentation = %q, want %q", got, tc.firstWant)
+			}
+			// Keep this test focused on propagating a confirmed cohort's plan into
+			// the generic notification. Confirmation itself has a separate guard.
+			cfg.doorbell.confirmPresentation()
+			injected.Reset()
+			now = cfg.doorbell.nextAttempt
+
+			if err := notifyNewMessages(cfg); err != nil {
+				t.Fatalf("generic submit-only reminder: %v", err)
+			}
+			if got := injected.String(); got != tc.retryWant {
+				t.Fatalf("generic submit-only reminder = %q, want %q", got, tc.retryWant)
+			}
+		})
+	}
+}
+
+func TestNotifyNewMessagesGenericInjectViaConfirmedCohortUsesCROnly(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "alice", "generic-inject-via-submit-only")
+	transport, outputPath := injectViaCaptureConfig(t)
+	now := time.Unix(1_800_000_000, 0)
+	transport.me = "alice"
+	transport.root = root
+	transport.session = "session1"
+	transport.bell = true
+	transport.doorbellNow = func() time.Time { return now }
+
+	if err := notifyNewMessages(transport); err != nil {
+		t.Fatalf("first generic inject-via presentation: %v", err)
+	}
+	if got, err := os.ReadFile(outputPath); err != nil || string(got) != "\a"+coopWakeDoorbell {
+		t.Fatalf("first generic inject-via payload = %q, err=%v; want bell plus %q", got, err, coopWakeDoorbell)
+	}
+	if !transport.doorbell.presentationConfirmed {
+		t.Fatal("inject-via exit zero did not confirm the full presentation")
+	}
+	now = transport.doorbell.nextAttempt
+
+	if err := notifyNewMessages(transport); err != nil {
+		t.Fatalf("generic inject-via submit-only reminder: %v", err)
+	}
+	if got, err := os.ReadFile(outputPath); err != nil || string(got) != "\a\r" {
+		t.Fatalf("generic inject-via reminder = %q, err=%v; want bell plus CR only", got, err)
+	}
+}
+
+func TestNotifyNewMessagesGenericAdditionRearmsFullPresentation(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "generic-addition-first")
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	var injected strings.Builder
+	now := time.Unix(1_800_000_000, 0)
+	cfg := &wakeConfig{
+		me:          "codex",
+		root:        root,
+		session:     "session1",
+		injectMode:  wakeInjectModeRaw,
+		doorbellNow: func() time.Time { return now },
+		terminalWrite: func(text string) error {
+			injected.WriteString(text)
+			return nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first generic presentation: %v", err)
+	}
+	cfg.doorbell.confirmPresentation()
+	deliverPartialWakeMessageForTest(t, root, "codex", "generic-addition-second")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic content addition: %v", err)
+	}
+	if cfg.doorbell.presentationConfirmed {
+		t.Fatal("generic content addition did not rearm the full presentation")
+	}
+	injected.Reset()
+	now = cfg.doorbell.nextAttempt
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic re-presentation: %v", err)
+	}
+	if got, want := injected.String(), coopWakeDoorbell+"\n\r\r"; got != want {
+		t.Fatalf("generic re-presentation = %q, want %q", got, want)
+	}
+	if !cfg.doorbell.presentationConfirmed {
+		t.Fatal("successful generic re-presentation was not confirmed")
+	}
+}
+
+func TestNotifyNewMessagesGenericZeroConfirmedProgressRetriesFullPayload(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "generic-zero-progress")
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	firstWrite := true
+	var accepted strings.Builder
+	now := time.Unix(1_800_000_000, 0)
+	cfg := &wakeConfig{
+		me:             "codex",
+		root:           root,
+		session:        "session1",
+		injectMode:     wakeInjectModeRaw,
+		doorbellNow:    func() time.Time { return now },
+		attentionIsTTY: func() bool { return false },
+		terminalWrite: func(text string) error {
+			if firstWrite {
+				firstWrite = false
+				return &wakeTestAcceptedProgressError{
+					err:      errors.New("refused before acceptance"),
+					accepted: 0,
+				}
+			}
+			accepted.WriteString(text)
+			return nil
+		},
+	}
+
+	captureWakeStderr(t, func() {
+		if err := notifyNewMessages(cfg); err != nil {
+			t.Fatalf("generic zero-progress presentation: %v", err)
+		}
+	})
+	now = cfg.doorbell.nextAttempt
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic full retry: %v", err)
+	}
+	if got, want := accepted.String(), coopWakeDoorbell+"\n\r\r"; got != want {
+		t.Fatalf("generic zero-progress retry = %q, want full payload %q", got, want)
+	}
+}
+
+func TestNotifyNewMessagesGenericNoneDoesNotNudgeTerminal(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "alice", "generic-no-terminal-nudge")
+
+	terminalWrites := 0
+	attentionWrites := 0
+	now := time.Unix(1_800_000_000, 0)
+	cfg := &wakeConfig{
+		me:          "alice",
+		root:        root,
+		session:     "session1",
+		injectMode:  wakeInjectModeNone,
+		doorbellNow: func() time.Time { return now },
+		terminalWrite: func(string) error {
+			terminalWrites++
+			return nil
+		},
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic attention-only notification: %v", err)
+	}
+	if terminalWrites != 0 {
+		t.Fatalf("inject-mode none wrote %d terminal chunks, want 0", terminalWrites)
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("inject-mode none attention writes = %d, want 1", attentionWrites)
+	}
+	now = cfg.doorbell.nextAttempt
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic attention-only reminder: %v", err)
+	}
+	if terminalWrites != 0 {
+		t.Fatalf("inject-mode none reminder wrote %d terminal chunks, want 0", terminalWrites)
+	}
+	if attentionWrites != 2 {
+		t.Fatalf("inject-mode none reminder attention writes = %d, want 2", attentionWrites)
+	}
+	if cfg.doorbell.presentationConfirmed {
+		t.Fatal("inject-mode none marked terminal presentation confirmed")
+	}
+}
+
+func TestNotifyNewMessagesGenericCustomInterruptRePresentsNewUrgentWork(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	writeUrgent := func(id string) {
+		t.Helper()
+		message := format.Message{
+			Header: format.Header{
+				Schema:   1,
+				ID:       id,
+				From:     "peer",
+				To:       []string{"alice"},
+				Thread:   "p2p/alice__peer",
+				Subject:  id,
+				Created:  "2026-08-06T10:00:00Z",
+				Priority: "urgent",
+				Labels:   []string{"interrupt"},
+			},
+		}
+		data, err := message.Marshal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := deliverToInboxForTest(t, root, "alice", id+".md", data); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+	var injected strings.Builder
+	now := time.Unix(1_800_000_000, 0)
+	cfg := &wakeConfig{
+		me:                "alice",
+		root:              root,
+		session:           "session1",
+		injectMode:        wakeInjectModeRaw,
+		interrupt:         true,
+		interruptPriority: "urgent",
+		interruptLabel:    "interrupt",
+		interruptNotice:   "operator interrupt",
+		doorbellNow:       func() time.Time { return now },
+		terminalWrite: func(text string) error {
+			injected.WriteString(text)
+			return nil
+		},
+	}
+
+	writeUrgent("generic-interrupt-first")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first generic custom interrupt: %v", err)
+	}
+	if got, want := injected.String(), cfg.interruptNotice+"\r\r"; got != want {
+		t.Fatalf("first generic custom interrupt = %q, want %q", got, want)
+	}
+	cfg.doorbell.confirmPresentation()
+	injected.Reset()
+	now = cfg.doorbell.nextAttempt
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic custom interrupt reminder: %v", err)
+	}
+	if got, want := injected.String(), "\r\r"; got != want {
+		t.Fatalf("generic custom interrupt reminder = %q, want submit only %q", got, want)
+	}
+
+	writeUrgent("generic-interrupt-second")
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic custom interrupt addition: %v", err)
+	}
+	injected.Reset()
+	now = cfg.doorbell.nextAttempt
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic custom interrupt re-presentation: %v", err)
+	}
+	if got, want := injected.String(), cfg.interruptNotice+"\r\r"; got != want {
+		t.Fatalf("generic custom interrupt re-presentation = %q, want %q", got, want)
+	}
+}
+
+// normalizeWakeInjectMode rejects unknown CLI input; this locks the defensive
+// delivery switch fallback for an internally constructed future mode.
+func TestNotifyNewMessagesGenericUnknownModeUsesSingleChunkFallback(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "alice", "generic-unknown-mode")
+
+	var injected strings.Builder
+	now := time.Unix(1_800_000_000, 0)
+	cfg := &wakeConfig{
+		me:          "alice",
+		root:        root,
+		session:     "session1",
+		injectMode:  "future-mode",
+		bell:        true,
+		doorbellNow: func() time.Time { return now },
+		terminalWrite: func(text string) error {
+			injected.WriteString(text)
+			return nil
+		},
+	}
+
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("first generic unknown-mode presentation: %v", err)
+	}
+	if got, want := injected.String(), "\a"+coopWakeDoorbell+"\r"; got != want {
+		t.Fatalf("first generic unknown-mode bytes = %q, want %q", got, want)
+	}
+	cfg.doorbell.confirmPresentation()
+	injected.Reset()
+	now = cfg.doorbell.nextAttempt
+	if err := notifyNewMessages(cfg); err != nil {
+		t.Fatalf("generic unknown-mode submit-only reminder: %v", err)
+	}
+	if got := injected.String(); got != "\a\r" {
+		t.Fatalf("generic unknown-mode reminder bytes = %q, want bell plus CR only", got)
+	}
+}
+
 func TestRecordWakeAttemptArmsMissingCohort(t *testing.T) {
 	now := time.Unix(1_800_000_000, 0)
 	current := wakeDoorbellTestFiles(t, "pending.md")

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -2092,6 +2092,166 @@ func TestRunWakeLoopRetriesPendingDoorbellWithSubmitOnlyNudge(t *testing.T) {
 	}
 }
 
+func TestRunWakeLoopOwnerlessConfirmedPresentationUsesSubmitOnlyNudge(t *testing.T) {
+	root := secureTempDirForTest(t)
+	deliverPartialWakeMessageForTest(t, root, "codex", "ownerless-submit-only")
+	cleanup, err := acquireWakeLock(root, "codex", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	lock := inspectWakeLock(root, "codex")
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	stubRawInjectSleep(t)
+
+	start := time.Unix(1_800_000_000, 0)
+	var nowNanos atomic.Int64
+	nowNanos.Store(start.UnixNano())
+	var initialRawComplete atomic.Bool
+	var rawWrites atomic.Int64
+	initialAttemptRecorded := make(chan struct{}, 1)
+	writes := make(chan string, 8)
+	attention := make(chan string, 1)
+	ticks := make(chan time.Time)
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	loopDone := make(chan struct{})
+	defer func() {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+		select {
+		case <-loopDone:
+		case <-time.After(2 * time.Second):
+			t.Error("wake loop did not stop during cleanup")
+		}
+	}()
+	stubTIOCSTIInject(t, func(text string) error {
+		writes <- text
+		if text == "\r" && rawWrites.Add(1) == 4 {
+			initialRawComplete.Store(true)
+		} else if text != "\r" {
+			rawWrites.Add(1)
+		}
+		return nil
+	})
+
+	cfg := wakeConfig{
+		root:               root,
+		me:                 "codex",
+		session:            "session1",
+		previewLen:         80,
+		injectMode:         wakeInjectModeRaw,
+		controlStop:        stop,
+		maintenanceTicks:   ticks,
+		terminalGeneration: lock.Lock.Generation,
+		terminalTTY:        lock.Lock.TTY,
+		doorbellNow: func() time.Time {
+			now := time.Unix(0, nowNanos.Load())
+			if initialRawComplete.Load() && now.Equal(start) {
+				select {
+				case initialAttemptRecorded <- struct{}{}:
+				default:
+				}
+			}
+			return now
+		},
+		preconditionCheck: func(*wakeConfig) error { return nil },
+		attentionIsTTY:    func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attention <- string(data)
+			return len(data), nil
+		},
+	}
+	if usesCoopDoorbell(&cfg) {
+		t.Error("ownerless generic wake loop selected the coop doorbell")
+	}
+
+	go func() {
+		defer close(loopDone)
+		done <- runWakeLoop(cfg)
+	}()
+
+	var payload string
+	select {
+	case payload = <-writes:
+		if payload != coopWakeDoorbell {
+			t.Fatalf("initial full raw payload = %q, want %q", payload, coopWakeDoorbell)
+		}
+	case err := <-done:
+		t.Fatalf("wake loop exited before first full presentation: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not write its first raw payload")
+	}
+	for _, want := range []string{"\n", "\r", "\r"} {
+		select {
+		case got := <-writes:
+			if got != want {
+				t.Fatalf("initial raw write = %q, want %q", got, want)
+			}
+		case err := <-done:
+			t.Fatalf("wake loop exited during first full presentation: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("wake loop did not write initial raw chunk %q", want)
+		}
+	}
+	select {
+	case <-initialAttemptRecorded:
+	case err := <-done:
+		t.Fatalf("wake loop exited before recording first presentation: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not record the first full presentation")
+	}
+
+	nowNanos.Store(start.Add(wakeDoorbellRetryBase).UnixNano())
+	select {
+	case ticks <- time.Now():
+	case err := <-done:
+		t.Fatalf("wake loop exited before retry deadline: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept retry-deadline maintenance tick")
+	}
+	for _, want := range []string{"\n", "\r", "\r"} {
+		select {
+		case got := <-writes:
+			if got != want {
+				if got == payload {
+					t.Fatalf("submit-only reminder retyped first payload %q, want %q", got, want)
+				}
+				t.Fatalf("submit-only reminder write = %q, want %q", got, want)
+			}
+		case err := <-done:
+			t.Fatalf("wake loop exited during submit-only reminder: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("wake loop did not write submit-only raw chunk %q", want)
+		}
+	}
+	select {
+	case got := <-writes:
+		t.Fatalf("submit-only reminder retyped payload %q", got)
+	default:
+	}
+	select {
+	case output := <-attention:
+		t.Fatalf("ownerless submit-only reminder emitted attention: %q", output)
+	default:
+	}
+
+	close(stop)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wake loop stop: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not stop")
+	}
+}
+
 func TestNotifyNewMessagesAttentionOnlyRetryCadence(t *testing.T) {
 	root := secureTempDirForTest(t)
 	deliverPartialWakeMessageForTest(t, root, "codex", "attention-cadence")


### PR DESCRIPTION
## Problem

The submit-only reminder nudge shipped in #418/#445 (v0.52.6) stopped wake from re-typing the full doorbell payload on every reminder — but only for **owner-bound (coop) wakes**. A plain or externally-launched `amq wake` (`raw`, `paste`, or `--inject-via`) fell through to the pre-#418 path and **re-typed the entire doorbell payload on every unchanged-cohort reminder**, stacking `: AMQ doorbell run amq drain --include-body then act on it` lines in the agent's terminal. This is the generic half of the flooding the coop fix left uncovered.

The anti-flood invariant — *present the payload once, then nudge the submit* — is intrinsic to what an injecting wake does, not to coop orchestration. This PR moves it to the wake binary boundary.

## Change (15 production lines in `internal/cli/wake.go`)

- `deliverNewMessageNotification` now has **one** injecting path, gated by `injectMode != none` instead of `ownerBound && injectMode != none`.
- **Owner authority is untouched and stays owner-only**: the fixed system-doorbell substitution is re-nested under `if ownerBound`, so owner-bound wakes still cannot inject arbitrary text. All owner normalization and per-write generation/TTY authority checks are unchanged.
- Every injecting wake now consumes `plan.submitOnly` and confirms a successful full presentation through the existing predicate. Generic operator-authored payloads (`--inject-cmd`, custom `--interrupt-notice`) remain intact on first/content-changed full presentations; only unchanged confirmed reminders drop to submit-only.
- `none`, delivery-time demotion, retained-input collision/recovery, content-change re-arm, zero-progress full retry, budgets, and parking all retain their existing paths.

## Behavior change: `--inject-via`

External injection does not participate in the `inputDelivery` state machine, so process **exit zero is its only presentation-confirmation evidence**. An unchanged confirmed cohort therefore now invokes the injector with a **submit-only CR** (bell+CR with `--bell`) on its next reminder, instead of re-invoking it with the full payload. This is documented at the call site. It is a net improvement over guaranteed re-typing, but note the acceptance proof is weaker than the TTY path's — the CR is assumed delivered on exit zero.

## Tests

Eight discriminating notify-level specs for the generic path (`raw`, `paste`, `inject-via`, custom-interrupt, unknown/default fallback, plus zero-progress and `none` as negative controls) and one loop-level test (`TestRunWakeLoopOwnerlessConfirmedPresentationUsesSubmitOnlyNudge`) covering the generic `runWakeLoop` deadline path, which had **no** prior coverage. The owner-bound suite is retained unchanged as a regression oracle. Six of the eight notify specs and the loop test fail on the pre-change gate for the intended reasons; all pass after.

Completes the coop-only fix in #418/#445. `CHANGELOG.md` intentionally left to Release Please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
