### PR TITLE
test(wake): stabilize repair downtime delivery

### DIFF
--- a/internal/cli/wake_repair_continuity_unix_test.go
+++ b/internal/cli/wake_repair_continuity_unix_test.go
@@ -122,7 +122,7 @@ func TestWakeRepairNotifiesMessageDeliveredDuringDowntime(t *testing.T) {
 	if result.Status != "repaired" {
 		t.Fatalf("repair result = %#v", result)
 	}
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(wakeDoorbellRetryBase + 2*time.Second)
 	for time.Now().Before(deadline) {
 		data, readErr := os.ReadFile(injectedPath)
 		if readErr == nil && strings.Contains(string(data), coopWakeDoorbell) {
@@ -138,7 +138,12 @@ func TestWakeRepairNotifiesMessageDeliveredDuringDowntime(t *testing.T) {
 		time.Sleep(25 * time.Millisecond)
 	}
 	data, _ := os.ReadFile(injectedPath)
-	t.Fatalf("repaired wake suppressed the downtime message; injected output: %q", data)
+	repairLog, _ := os.ReadFile(filepath.Join(fsq.AgentBase(root, "codex"), ".wake.repair.log"))
+	t.Fatalf(
+		"repaired wake suppressed the downtime message; injected output: %q\nrepair log:\n%s",
+		data,
+		repairLog,
+	)
 }
 
 func stopWakeContinuityHelper(pid int, helper, root, me string) bool {


### PR DESCRIPTION
## What changed

- wait through one real wake retry interval in the downtime-delivery continuity test
- include `.wake.repair.log` when the assertion times out
- keep the user-visible doorbell assertion unchanged

## Why

`wake repair` returns after admission/release, before the replacement child is guaranteed to complete its first inbox scan. The test allowed only 2 seconds even though the retry base is 5 seconds, so shared-host scheduling could produce an empty injected-output failure.

## Validation

- `go test ./internal/cli -run ^'^TestWakeRepairNotifiesMessageDeliveredDuringDowntime$' -count=1 -timeout=30s -v`\n- same focused test with `-count=3 -timeout=60s`\n- `git diff --check`\n\nFixes #408