### PR TITLE
feat(wake): derive Darwin mapped image identity

### DIFF
--- a/internal/cli/doctor_stale_wake_binary.go
+++ b/internal/cli/doctor_stale_wake_binary.go
@@ -39,6 +39,7 @@ type wakeBinaryFileEvidence struct {
 }
 
 type resolvedWakeBinary struct {
+	Path string
 	Info os.FileInfo
 }
 
@@ -70,7 +71,7 @@ func resolveWakeBinary() (resolvedWakeBinary, error) {
 	if !info.Mode().IsRegular() {
 		return resolvedWakeBinary{}, fmt.Errorf("current amq executable is not a regular file")
 	}
-	return resolvedWakeBinary{Info: info}, nil
+	return resolvedWakeBinary{Path: path, Info: info}, nil
 }
 
 func checkStaleWakeBinaryHint(inspection wakeLockInspection) (opsHint, bool, error) {

--- a/internal/cli/doctor_stale_wake_binary_darwin.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin.go
@@ -3,11 +3,8 @@
 package cli
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -80,10 +77,13 @@ func inspectWakeBinaryStalenessPlatform(
 		}
 		return wakeBinaryStaleness{}, err
 	}
-	if !darwinRecordedImageMatches(recorded, running) {
-		return wakeBinaryStaleness{}, fmt.Errorf("live wake image disagrees with recorded image evidence")
+	if recorded.ExecutionPath != running.Path {
+		return wakeBinaryStaleness{}, fmt.Errorf("live wake image path disagrees with recorded image evidence")
 	}
 	comparisonEvidence.Running = wakeBinaryFileEvidenceFromIdentity(running.Identity)
+	if err := confirmResolvedDarwinWakeBinary(current, currentIdentity); err != nil {
+		return wakeBinaryStaleness{}, err
+	}
 
 	if running.Identity.Device != currentIdentity.Device || running.Identity.Inode != currentIdentity.Inode {
 		return wakeBinaryStaleness{
@@ -92,7 +92,7 @@ func inspectWakeBinaryStalenessPlatform(
 			Evidence: comparisonEvidence,
 		}, nil
 	}
-	if running.Identity != currentIdentity || running.Info.Size() != current.Info.Size() {
+	if running.Identity != currentIdentity || running.Size != current.Info.Size() {
 		return wakeBinaryStaleness{}, fmt.Errorf("current wake image changed during comparison")
 	}
 	if staleByStarted {
@@ -110,81 +110,26 @@ func inspectWakeBinaryStalenessPlatform(
 	}, nil
 }
 
-type darwinWakeProcessImage struct {
-	Path     string
-	Info     os.FileInfo
-	Identity wakeFileIdentity
-	SHA256   string
-}
+type darwinWakeProcessImage = darwinMappedWakeImage
 
-func inspectDarwinWakeProcessImage(pid int) (darwinWakeProcessImage, error) {
-	path, err := readDarwinProcessExecutablePath(pid)
+var inspectDarwinWakeProcessImage = inspectDarwinWakeMappedImage
+
+func confirmResolvedDarwinWakeBinary(current resolvedWakeBinary, expected wakeFileIdentity) error {
+	if !filepath.IsAbs(current.Path) || filepath.Clean(current.Path) != current.Path {
+		return fmt.Errorf("current amq executable path is not canonical and absolute")
+	}
+	confirmed, err := os.Stat(current.Path)
 	if err != nil {
-		return darwinWakeProcessImage{}, fmt.Errorf("resolve wake process executable: %w", err)
+		return fmt.Errorf("re-stat current amq executable: %w", err)
 	}
-	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
-		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable path is not canonical and absolute")
+	if !confirmed.Mode().IsRegular() {
+		return fmt.Errorf("current amq executable is no longer a regular file")
 	}
-
-	pathInfo, err := os.Lstat(path)
-	if err != nil {
-		return darwinWakeProcessImage{Path: path}, fmt.Errorf("stat wake process executable path: %w", err)
+	identity, ok := captureWakeFileIdentity(confirmed)
+	if !ok || identity != expected || confirmed.Size() != current.Info.Size() {
+		return fmt.Errorf("current amq executable changed during comparison")
 	}
-	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.Mode().IsRegular() {
-		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable path is not a regular non-symlink file")
-	}
-	file, err := openWakeMetadataFile(path)
-	if err != nil {
-		return darwinWakeProcessImage{}, fmt.Errorf("open wake process executable: %w", err)
-	}
-	defer func() { _ = file.Close() }()
-
-	openedInfo, err := file.Stat()
-	if err != nil {
-		return darwinWakeProcessImage{}, fmt.Errorf("stat opened wake process executable: %w", err)
-	}
-	if !sameWakeFileIdentity(pathInfo, openedInfo) || pathInfo.Size() != openedInfo.Size() {
-		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable changed while opening")
-	}
-	identity, ok := captureWakeFileIdentity(openedInfo)
-	if !ok || identity.Device == 0 || identity.Inode == 0 {
-		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable identity unavailable")
-	}
-	hasher := sha256.New()
-	if _, err := io.Copy(hasher, file); err != nil {
-		return darwinWakeProcessImage{}, fmt.Errorf("digest wake process executable: %w", err)
-	}
-	hashedInfo, err := file.Stat()
-	if err != nil || !sameWakeFileIdentity(openedInfo, hashedInfo) || openedInfo.Size() != hashedInfo.Size() {
-		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable changed while hashing")
-	}
-
-	confirmedPath, err := readDarwinProcessExecutablePath(pid)
-	if err != nil || confirmedPath != path {
-		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable path changed during inspection")
-	}
-	confirmedInfo, err := os.Lstat(path)
-	if err != nil || !sameWakeFileIdentity(hashedInfo, confirmedInfo) || hashedInfo.Size() != confirmedInfo.Size() {
-		return darwinWakeProcessImage{}, fmt.Errorf("wake process executable changed during inspection")
-	}
-	return darwinWakeProcessImage{
-		Path:     path,
-		Info:     hashedInfo,
-		Identity: identity,
-		SHA256:   "sha256:" + hex.EncodeToString(hasher.Sum(nil)),
-	}, nil
-}
-
-func darwinRecordedImageMatches(
-	recorded wakeImageEvidenceV1,
-	running darwinWakeProcessImage,
-) bool {
-	return recorded.ExecutionPath == running.Path &&
-		recorded.Device == running.Identity.Device &&
-		recorded.Inode == running.Identity.Inode &&
-		recorded.Size == running.Info.Size() &&
-		recorded.CTimeNS == running.Identity.CTimeSec*1_000_000_000+running.Identity.CTimeNsec &&
-		recorded.SHA256 == running.SHA256
+	return nil
 }
 
 func wakeBinaryFileEvidenceFromIdentity(identity wakeFileIdentity) wakeBinaryFileEvidence {

--- a/internal/cli/doctor_stale_wake_binary_darwin_test.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin_test.go
@@ -134,13 +134,13 @@ func TestDarwinSameVersionPathReplacementCannotReportCurrent(t *testing.T) {
 	}
 	comparison, err := inspectWakeBinaryStalenessPlatform(
 		inspection,
-		resolvedWakeBinary{Info: currentInfo},
+		resolvedWakeBinary{Path: captured.Evidence.ExecutionPath, Info: currentInfo},
 	)
 	if err != nil {
 		t.Fatalf("compare post-exec replacement: %v", err)
 	}
-	if comparison.Stale || comparison.Method != wakeBinaryComparisonDarwinProcessImage {
-		t.Fatalf("pathname evidence did not reproduce false agreement: %#v", comparison)
+	if !comparison.Stale || comparison.Method != wakeBinaryComparisonDarwinProcessImage {
+		t.Fatalf("mapped image did not distinguish post-exec replacement: %#v", comparison)
 	}
 	stubWakeBinaryStaleness(t, func(wakeLockInspection) (wakeBinaryStaleness, error) {
 		return comparison, nil
@@ -148,8 +148,8 @@ func TestDarwinSameVersionPathReplacementCannotReportCurrent(t *testing.T) {
 	if got := inspectWakeCheckImageStatus(inspection, wakeCheckResult{
 		RunningVersion: captured.Evidence.EmbeddedVersion,
 		CurrentVersion: captured.Evidence.EmbeddedVersion,
-	}); got != wakeImageUnknown {
-		t.Fatalf("post-exec pathname replacement image status = %q, want %q", got, wakeImageUnknown)
+	}); got != wakeImageDifferent {
+		t.Fatalf("post-exec pathname replacement image status = %q, want %q", got, wakeImageDifferent)
 	}
 
 	if err := os.WriteFile(releasePath, []byte("release\n"), 0o600); err != nil {
@@ -264,7 +264,7 @@ func TestDarwinWakeBinaryComparisonReportsCurrentFromCorroboratedLiveImage(t *te
 				RunningImageEvidence: &evidence,
 			},
 		},
-		resolvedWakeBinary{Info: info},
+		resolvedWakeBinary{Path: path, Info: info},
 	)
 	if err != nil {
 		t.Fatalf("compare corroborated current image: %v", err)
@@ -305,7 +305,7 @@ func TestDarwinWakeBinaryComparisonReportsHomebrewReplacementDifferent(t *testin
 		t.Fatal(err)
 	}
 	evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
-	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return runningPath, nil })
+	stubDarwinProcessImage(t, darwinMappedImageForTest(t, runningPath, runningInfo), nil)
 
 	got, err := inspectWakeBinaryStalenessPlatform(
 		wakeLockInspection{
@@ -317,7 +317,7 @@ func TestDarwinWakeBinaryComparisonReportsHomebrewReplacementDifferent(t *testin
 				RunningImageEvidence: &evidence,
 			},
 		},
-		resolvedWakeBinary{Info: currentInfo},
+		resolvedWakeBinary{Path: currentPath, Info: currentInfo},
 	)
 	if err != nil {
 		t.Fatalf("compare Homebrew replacement: %v", err)
@@ -349,7 +349,7 @@ func TestDarwinWakeBinaryComparisonReportsDeletedLiveImageStale(t *testing.T) {
 		t.Fatal(err)
 	}
 	evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
-	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return runningPath, nil })
+	stubDarwinProcessImage(t, darwinWakeProcessImage{Path: runningPath}, os.ErrNotExist)
 	if err := os.Remove(runningPath); err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestDarwinWakeBinaryComparisonReportsDeletedLiveImageStale(t *testing.T) {
 				RunningImageEvidence: &evidence,
 			},
 		},
-		resolvedWakeBinary{Info: currentInfo},
+		resolvedWakeBinary{Path: currentPath, Info: currentInfo},
 	)
 	if err != nil {
 		t.Fatalf("compare deleted live image: %v", err)
@@ -401,7 +401,7 @@ func TestDarwinWakeBinaryComparisonReportsDeletedRecordedImageWhenProcPIDPathRet
 		t.Fatal(err)
 	}
 	evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
-	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return "", os.ErrNotExist })
+	stubDarwinProcessImage(t, darwinWakeProcessImage{}, os.ErrNotExist)
 	if err := os.Remove(runningPath); err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +418,7 @@ func TestDarwinWakeBinaryComparisonReportsDeletedRecordedImageWhenProcPIDPathRet
 				RunningImageEvidence: &evidence,
 			},
 		},
-		resolvedWakeBinary{Info: currentInfo},
+		resolvedWakeBinary{Path: currentPath, Info: currentInfo},
 	)
 	if err != nil {
 		t.Fatalf("compare deleted recorded image after proc_pidpath ENOENT: %v", err)
@@ -438,7 +438,7 @@ func TestDarwinWakeBinaryComparisonKeepsNonENOENTImageFailureUnknown(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return path, nil })
+	stubDarwinProcessImage(t, darwinWakeProcessImage{Path: path}, fmt.Errorf("region query denied"))
 	recorded := wakeImageEvidenceV1{
 		Schema:          wakeImageEvidenceSchemaV1,
 		Platform:        "darwin",
@@ -464,14 +464,14 @@ func TestDarwinWakeBinaryComparisonKeepsNonENOENTImageFailureUnknown(t *testing.
 				RunningImageEvidence: &recorded,
 			},
 		},
-		resolvedWakeBinary{Info: currentInfo},
+		resolvedWakeBinary{Path: currentPath, Info: currentInfo},
 	)
 	if err == nil || got.Stale {
 		t.Fatalf("non-ENOENT image failure = %#v, %v; want unknown error", got, err)
 	}
 }
 
-func TestDarwinWakeBinaryComparisonRejectsRecordedEvidenceDisagreement(t *testing.T) {
+func TestDarwinWakeBinaryComparisonUsesMappedVnodeOverRecordedPathIdentity(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "amq")
 	if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {
 		t.Fatal(err)
@@ -482,7 +482,7 @@ func TestDarwinWakeBinaryComparisonRejectsRecordedEvidenceDisagreement(t *testin
 	}
 	evidence := darwinWakeImageEvidenceForTest(t, path, info)
 	evidence.Inode++
-	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return path, nil })
+	stubDarwinProcessImage(t, darwinMappedImageForTest(t, path, info), nil)
 
 	got, err := inspectWakeBinaryStalenessPlatform(
 		wakeLockInspection{
@@ -494,14 +494,14 @@ func TestDarwinWakeBinaryComparisonRejectsRecordedEvidenceDisagreement(t *testin
 				RunningImageEvidence: &evidence,
 			},
 		},
-		resolvedWakeBinary{Info: info},
+		resolvedWakeBinary{Path: path, Info: info},
 	)
-	if err == nil {
-		t.Fatalf("disagreeing recorded evidence returned %#v, want unknown error", got)
+	if err != nil || got.Stale || got.Method != wakeBinaryComparisonDarwinProcessImage {
+		t.Fatalf("mapped vnode comparison = %#v, %v; want current despite stale pathname identity", got, err)
 	}
 }
 
-func TestDarwinWakeBinaryComparisonRejectsRecordedDigestDisagreement(t *testing.T) {
+func TestDarwinWakeBinaryComparisonDoesNotTreatRecordedDigestAsMappedAuthority(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "amq")
 	if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {
 		t.Fatal(err)
@@ -512,7 +512,7 @@ func TestDarwinWakeBinaryComparisonRejectsRecordedDigestDisagreement(t *testing.
 	}
 	evidence := darwinWakeImageEvidenceForTest(t, path, info)
 	evidence.SHA256 = "sha256:" + strings.Repeat("f", 64)
-	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return path, nil })
+	stubDarwinProcessImage(t, darwinMappedImageForTest(t, path, info), nil)
 
 	got, err := inspectWakeBinaryStalenessPlatform(
 		wakeLockInspection{
@@ -524,10 +524,46 @@ func TestDarwinWakeBinaryComparisonRejectsRecordedDigestDisagreement(t *testing.
 				RunningImageEvidence: &evidence,
 			},
 		},
-		resolvedWakeBinary{Info: info},
+		resolvedWakeBinary{Path: path, Info: info},
 	)
-	if err == nil {
-		t.Fatalf("disagreeing recorded digest returned %#v, want unknown error", got)
+	if err != nil || got.Stale || got.Method != wakeBinaryComparisonDarwinProcessImage {
+		t.Fatalf("mapped vnode comparison = %#v, %v; want current despite pathname digest", got, err)
+	}
+}
+
+func TestDarwinWakeBinaryComparisonCurrentRelinkBecomesUnknown(t *testing.T) {
+	dir := t.TempDir()
+	currentPath := filepath.Join(dir, "amq")
+	replacementPath := filepath.Join(dir, "replacement")
+	for _, path := range []string{currentPath, replacementPath} {
+		if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	currentInfo, err := os.Stat(currentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := darwinWakeImageEvidenceForTest(t, currentPath, currentInfo)
+	stubDarwinProcessImage(t, darwinMappedImageForTest(t, currentPath, currentInfo), nil)
+	if err := os.Rename(replacementPath, currentPath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := inspectWakeBinaryStalenessPlatform(
+		wakeLockInspection{
+			PID: 42,
+			Lock: wakeLock{
+				Started:              time.Now().UTC().Format(time.RFC3339Nano),
+				ImagePath:            currentPath,
+				ImageVersion:         evidence.EmbeddedVersion,
+				RunningImageEvidence: &evidence,
+			},
+		},
+		resolvedWakeBinary{Path: currentPath, Info: currentInfo},
+	)
+	if err == nil || got.Stale || !strings.Contains(err.Error(), "changed during comparison") {
+		t.Fatalf("current relink comparison = %#v, %v; want unknown change error", got, err)
 	}
 }
 
@@ -563,6 +599,24 @@ func stubDarwinProcessExecutablePath(t *testing.T, fn func(int) (string, error))
 	t.Cleanup(func() { readDarwinProcessExecutablePath = old })
 }
 
+func darwinMappedImageForTest(t *testing.T, path string, info os.FileInfo) darwinWakeProcessImage {
+	t.Helper()
+	identity, ok := captureWakeFileIdentity(info)
+	if !ok {
+		t.Fatal("capture mapped image identity")
+	}
+	return darwinWakeProcessImage{Path: path, Identity: identity, Size: info.Size()}
+}
+
+func stubDarwinProcessImage(t *testing.T, image darwinWakeProcessImage, err error) {
+	t.Helper()
+	old := inspectDarwinWakeProcessImage
+	inspectDarwinWakeProcessImage = func(int) (darwinWakeProcessImage, error) {
+		return image, err
+	}
+	t.Cleanup(func() { inspectDarwinWakeProcessImage = old })
+}
+
 func TestDarwinWakeBinaryComparisonUsesStrictStartedMTimeHeuristic(t *testing.T) {
 	started := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
 	path := filepath.Join(t.TempDir(), "amq")
@@ -591,7 +645,7 @@ func TestDarwinWakeBinaryComparisonUsesStrictStartedMTimeHeuristic(t *testing.T)
 			}
 			got, err := inspectWakeBinaryStalenessPlatform(
 				wakeLockInspection{Lock: wakeLock{Started: started.Format(time.RFC3339)}},
-				resolvedWakeBinary{Info: info},
+				resolvedWakeBinary{Path: path, Info: info},
 			)
 			if err != nil {
 				t.Fatalf("compare timestamps: %v", err)
@@ -620,7 +674,7 @@ func TestDarwinWakeBinaryComparisonReturnsUnknownForInvalidStarted(t *testing.T)
 	}
 	got, err := inspectWakeBinaryStalenessPlatform(
 		wakeLockInspection{Lock: wakeLock{Started: "not-a-timestamp"}},
-		resolvedWakeBinary{Info: info},
+		resolvedWakeBinary{Path: path, Info: info},
 	)
 	if err == nil {
 		t.Fatal("invalid Started returned nil error")

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -818,7 +818,8 @@ func inspectWakeCheckImageStatus(
 	if comparison.Stale {
 		return wakeImageDifferent
 	}
-	if comparison.Method == wakeBinaryComparisonExactIdentity {
+	if comparison.Method == wakeBinaryComparisonExactIdentity ||
+		comparison.Method == wakeBinaryComparisonDarwinProcessImage {
 		return wakeImageCurrent
 	}
 	return wakeImageUnknown

--- a/internal/cli/wake_check_unix_test.go
+++ b/internal/cli/wake_check_unix_test.go
@@ -229,7 +229,7 @@ func TestWakeCheckImageStatusRequiresCompleteExactEvidence(t *testing.T) {
 			want: wakeImageUnknown,
 		},
 		{
-			name: "complete lock with post-exec Darwin pathname agreement stays unknown",
+			name: "complete lock with Darwin mapped-vnode agreement is current",
 			lock: wakeLock{
 				ImagePath:    "/opt/homebrew/bin/amq",
 				ImageVersion: "0.49.14",
@@ -239,10 +239,10 @@ func TestWakeCheckImageStatusRequiresCompleteExactEvidence(t *testing.T) {
 				CurrentVersion: "0.49.14",
 			},
 			comparison: wakeBinaryStaleness{
-				Method:   wakeBinaryComparisonMethod("darwin_process_image"),
+				Method:   wakeBinaryComparisonDarwinProcessImage,
 				Evidence: stableWakeBinaryEvidenceForTest(),
 			},
-			want: wakeImageUnknown,
+			want: wakeImageCurrent,
 		},
 		{
 			name: "legacy lock stays unknown despite exact comparison",

--- a/internal/cli/wake_process_region_darwin.go
+++ b/internal/cli/wake_process_region_darwin.go
@@ -1,0 +1,237 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	darwinProcPIDRegionPathInfo = 8
+	darwinVMProtExecute         = 0x04
+	darwinVnodeTypeRegular      = 1
+	darwinModeTypeMask          = 0o170000
+	darwinModeRegular           = 0o100000
+	darwinMaxProcessRegions     = 1 << 16
+
+	// struct proc_regionwithpathinfo is composed entirely of fixed-width
+	// public proc_info fields and has this layout on both Darwin arm64 and
+	// amd64. Keep the assertion adjacent to the Go transcription below.
+	darwinProcRegionWithPathInfoSize = 1272
+)
+
+type darwinProcRegionInfo struct {
+	Protection            uint32
+	MaxProtection         uint32
+	Inheritance           uint32
+	Flags                 uint32
+	Offset                uint64
+	Behavior              uint32
+	UserWiredCount        uint32
+	UserTag               uint32
+	PagesResident         uint32
+	PagesSharedNowPrivate uint32
+	PagesSwappedOut       uint32
+	PagesDirtied          uint32
+	RefCount              uint32
+	ShadowDepth           uint32
+	ShareMode             uint32
+	PrivatePagesResident  uint32
+	SharedPagesResident   uint32
+	ObjectID              uint32
+	Depth                 uint32
+	Address               uint64
+	Size                  uint64
+}
+
+type darwinVInfoStat struct {
+	Device       uint32
+	Mode         uint16
+	LinkCount    uint16
+	Inode        uint64
+	UID          uint32
+	GID          uint32
+	AccessTime   int64
+	AccessTimeNS int64
+	ModifyTime   int64
+	ModifyTimeNS int64
+	ChangeTime   int64
+	ChangeTimeNS int64
+	BirthTime    int64
+	BirthTimeNS  int64
+	Size         int64
+	Blocks       int64
+	BlockSize    int32
+	Flags        uint32
+	Generation   uint32
+	RDevice      uint32
+	Reserved     [2]int64
+}
+
+type darwinVnodeInfo struct {
+	Stat darwinVInfoStat
+	Type int32
+	Pad  int32
+	FSID [2]int32
+}
+
+type darwinVnodeInfoPath struct {
+	Info darwinVnodeInfo
+	Path [unix.PathMax]byte
+}
+
+type darwinProcRegionWithPathInfo struct {
+	Region darwinProcRegionInfo
+	Vnode  darwinVnodeInfoPath
+}
+
+const darwinProcRegionWithPathInfoGoSize = int(unsafe.Sizeof(darwinProcRegionWithPathInfo{}))
+
+var (
+	_ [darwinProcRegionWithPathInfoSize - darwinProcRegionWithPathInfoGoSize]byte
+	_ [darwinProcRegionWithPathInfoGoSize - darwinProcRegionWithPathInfoSize]byte
+)
+
+type darwinMappedWakeImage struct {
+	Path     string
+	Identity wakeFileIdentity
+	Size     int64
+}
+
+var readDarwinProcessRegionPathInfo = readDarwinProcessRegionPathInfoDefault
+
+func inspectDarwinWakeMappedImage(pid int) (darwinMappedWakeImage, error) {
+	firstPath, err := readDarwinProcessExecutablePath(pid)
+	if err != nil {
+		return darwinMappedWakeImage{}, fmt.Errorf("resolve wake process executable: %w", err)
+	}
+	if !filepath.IsAbs(firstPath) || filepath.Clean(firstPath) != firstPath {
+		return darwinMappedWakeImage{}, fmt.Errorf("wake process executable path is not canonical and absolute")
+	}
+	first, err := scanDarwinWakeMappedImage(pid, firstPath)
+	if err != nil {
+		return darwinMappedWakeImage{Path: firstPath}, err
+	}
+
+	secondPath, err := readDarwinProcessExecutablePath(pid)
+	if err != nil {
+		return darwinMappedWakeImage{Path: firstPath}, fmt.Errorf("recheck wake process executable: %w", err)
+	}
+	if secondPath != firstPath {
+		return darwinMappedWakeImage{}, fmt.Errorf("wake process executable path changed during mapped-image inspection")
+	}
+	second, err := scanDarwinWakeMappedImage(pid, secondPath)
+	if err != nil {
+		return darwinMappedWakeImage{Path: secondPath}, err
+	}
+	if first != second {
+		return darwinMappedWakeImage{}, fmt.Errorf("wake mapped executable identity changed during inspection")
+	}
+	return first, nil
+}
+
+func scanDarwinWakeMappedImage(pid int, executablePath string) (darwinMappedWakeImage, error) {
+	if pid <= 0 {
+		return darwinMappedWakeImage{}, fmt.Errorf("invalid process id %d", pid)
+	}
+	candidates := make(map[darwinMappedWakeImage]struct{})
+	address := uint64(0)
+	for scanned := 0; scanned < darwinMaxProcessRegions; scanned++ {
+		region, found, err := readDarwinProcessRegionPathInfo(pid, address)
+		if err != nil {
+			return darwinMappedWakeImage{}, fmt.Errorf("inspect wake process region at %#x: %w", address, err)
+		}
+		if !found {
+			if len(candidates) != 1 {
+				return darwinMappedWakeImage{}, fmt.Errorf("wake mapped executable identity is ambiguous: found %d candidates", len(candidates))
+			}
+			for candidate := range candidates {
+				return candidate, nil
+			}
+		}
+
+		if region.Region.Address < address || region.Region.Size == 0 {
+			return darwinMappedWakeImage{}, fmt.Errorf("wake process region did not advance")
+		}
+		next := region.Region.Address + region.Region.Size
+		if next <= region.Region.Address {
+			return darwinMappedWakeImage{}, fmt.Errorf("wake process region address overflow")
+		}
+
+		if region.Region.Protection&darwinVMProtExecute != 0 {
+			pathEnd := bytes.IndexByte(region.Vnode.Path[:], 0)
+			if pathEnd < 0 {
+				return darwinMappedWakeImage{}, fmt.Errorf("wake process region returned an unterminated path")
+			}
+			mappedPath := string(region.Vnode.Path[:pathEnd])
+			stat := region.Vnode.Info.Stat
+			if mappedPath == executablePath &&
+				region.Vnode.Info.Type == darwinVnodeTypeRegular &&
+				stat.Mode&darwinModeTypeMask == darwinModeRegular {
+				candidate := darwinMappedWakeImage{
+					Path: executablePath,
+					Identity: wakeFileIdentity{
+						Device:    uint64(stat.Device),
+						Inode:     stat.Inode,
+						CTimeSec:  stat.ChangeTime,
+						CTimeNsec: stat.ChangeTimeNS,
+					},
+					Size: stat.Size,
+				}
+				if candidate.Identity.Device == 0 || candidate.Identity.Inode == 0 || candidate.Size <= 0 {
+					return darwinMappedWakeImage{}, fmt.Errorf("wake mapped executable vnode identity is incomplete")
+				}
+				candidates[candidate] = struct{}{}
+			}
+		}
+		address = next
+	}
+	return darwinMappedWakeImage{}, fmt.Errorf("wake process region scan exceeded %d regions", darwinMaxProcessRegions)
+}
+
+func readDarwinProcessRegionPathInfoDefault(
+	pid int,
+	address uint64,
+) (darwinProcRegionWithPathInfo, bool, error) {
+	if pid <= 0 {
+		return darwinProcRegionWithPathInfo{}, false, fmt.Errorf("invalid process id %d", pid)
+	}
+	var region darwinProcRegionWithPathInfo
+	read, _, errno := unix.Syscall6(
+		darwinSysProcInfo,
+		darwinProcInfoCallPIDInfo,
+		uintptr(pid),
+		darwinProcPIDRegionPathInfo,
+		uintptr(address),
+		uintptr(unsafe.Pointer(&region)),
+		uintptr(darwinProcRegionWithPathInfoGoSize),
+	)
+	runtime.KeepAlive(&region)
+	if errno != 0 {
+		// proc_pidinfo reports EINVAL when the requested address is beyond the
+		// process's final region. The caller still requires exactly one selected
+		// executable vnode, so an early EINVAL cannot produce authority.
+		if errno == unix.EINVAL {
+			return darwinProcRegionWithPathInfo{}, false, nil
+		}
+		return darwinProcRegionWithPathInfo{}, false, fmt.Errorf("proc_pidinfo pid %d: %w", pid, errno)
+	}
+	if read == 0 {
+		return darwinProcRegionWithPathInfo{}, false, nil
+	}
+	if read != uintptr(darwinProcRegionWithPathInfoGoSize) {
+		return darwinProcRegionWithPathInfo{}, false, fmt.Errorf(
+			"proc_pidinfo pid %d returned %d bytes, want %d",
+			pid,
+			read,
+			darwinProcRegionWithPathInfoGoSize,
+		)
+	}
+	return region, true, nil
+}

--- a/internal/cli/wake_process_region_darwin_test.go
+++ b/internal/cli/wake_process_region_darwin_test.go
@@ -1,0 +1,193 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+func TestDarwinProcessRegionABILayout(t *testing.T) {
+	if got := unsafe.Sizeof(darwinProcRegionWithPathInfo{}); got != darwinProcRegionWithPathInfoSize {
+		t.Fatalf("proc_regionwithpathinfo size = %d, want %d", got, darwinProcRegionWithPathInfoSize)
+	}
+}
+
+func TestDarwinMappedImageMatchesCurrentProcessVnode(t *testing.T) {
+	got, err := inspectDarwinWakeMappedImage(os.Getpid())
+	if err != nil {
+		t.Fatalf("inspect mapped current image: %v", err)
+	}
+	path, err := readDarwinProcessExecutablePath(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, ok := captureWakeFileIdentity(info)
+	if !ok {
+		t.Fatal("capture current process identity")
+	}
+	if got.Path != path || got.Identity != want || got.Size != info.Size() {
+		t.Fatalf("mapped image = %#v, want path=%q identity=%#v size=%d", got, path, want, info.Size())
+	}
+}
+
+func TestDarwinMappedImageDeduplicatesExecutableRegionsForOneVnode(t *testing.T) {
+	path := "/tmp/amq-mapped-test"
+	identity := wakeFileIdentity{Device: 17, Inode: 41, CTimeSec: 7, CTimeNsec: 9}
+	regions := []darwinProcRegionWithPathInfo{
+		testDarwinMappedRegion(0x1000, 0x1000, path, identity, 8192),
+		testDarwinMappedRegion(0x2000, 0x1000, path, identity, 8192),
+	}
+	var calls int
+	stubDarwinProcessRegionReader(t, func(_ int, address uint64) (darwinProcRegionWithPathInfo, bool, error) {
+		wantAddresses := []uint64{0, 0x2000, 0x3000}
+		if calls >= len(wantAddresses) || address != wantAddresses[calls] {
+			t.Fatalf("query %d address = %#x, want %#x", calls, address, wantAddresses[calls])
+		}
+		if calls == len(regions) {
+			calls++
+			return darwinProcRegionWithPathInfo{}, false, nil
+		}
+		region := regions[calls]
+		calls++
+		return region, true, nil
+	})
+
+	got, err := scanDarwinWakeMappedImage(42, path)
+	if err != nil {
+		t.Fatalf("scan mapped image: %v", err)
+	}
+	if got != (darwinMappedWakeImage{Path: path, Identity: identity, Size: 8192}) {
+		t.Fatalf("mapped image = %#v", got)
+	}
+}
+
+func TestDarwinMappedImageRejectsTwoExecutableVnodesAtExactPath(t *testing.T) {
+	path := "/tmp/amq-mapped-test"
+	regions := []darwinProcRegionWithPathInfo{
+		testDarwinMappedRegion(0x1000, 0x1000, path, wakeFileIdentity{Device: 17, Inode: 41}, 8192),
+		testDarwinMappedRegion(0x2000, 0x1000, path, wakeFileIdentity{Device: 17, Inode: 42}, 8192),
+	}
+	var calls int
+	stubDarwinProcessRegionReader(t, func(int, uint64) (darwinProcRegionWithPathInfo, bool, error) {
+		if calls == len(regions) {
+			return darwinProcRegionWithPathInfo{}, false, nil
+		}
+		region := regions[calls]
+		calls++
+		return region, true, nil
+	})
+
+	if _, err := scanDarwinWakeMappedImage(42, path); err == nil || !strings.Contains(err.Error(), "found 2 candidates") {
+		t.Fatalf("scan error = %v, want ambiguous mapped vnodes", err)
+	}
+}
+
+func TestDarwinMappedImageRejectsNonAdvancingAndMalformedRegions(t *testing.T) {
+	path := "/tmp/amq-mapped-test"
+	tests := []struct {
+		name   string
+		region darwinProcRegionWithPathInfo
+		want   string
+	}{
+		{
+			name:   "zero size",
+			region: testDarwinMappedRegion(0x1000, 0, path, wakeFileIdentity{Device: 17, Inode: 41}, 8192),
+			want:   "did not advance",
+		},
+		{
+			name: "unterminated path",
+			region: func() darwinProcRegionWithPathInfo {
+				region := testDarwinMappedRegion(0x1000, 0x1000, path, wakeFileIdentity{Device: 17, Inode: 41}, 8192)
+				for index := range region.Vnode.Path {
+					region.Vnode.Path[index] = 'x'
+				}
+				return region
+			}(),
+			want: "unterminated path",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stubDarwinProcessRegionReader(t, func(int, uint64) (darwinProcRegionWithPathInfo, bool, error) {
+				return tc.region, true, nil
+			})
+			if _, err := scanDarwinWakeMappedImage(42, path); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("scan error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestDarwinMappedImageKeepsQueryFailureUnknown(t *testing.T) {
+	stubDarwinProcessRegionReader(t, func(int, uint64) (darwinProcRegionWithPathInfo, bool, error) {
+		return darwinProcRegionWithPathInfo{}, false, errors.New("query denied")
+	})
+	if _, err := scanDarwinWakeMappedImage(42, "/tmp/amq-mapped-test"); err == nil || !strings.Contains(err.Error(), "query denied") {
+		t.Fatalf("scan error = %v, want query failure", err)
+	}
+}
+
+func TestDarwinMappedImageRejectsChangingSecondScan(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "amq")
+	stubDarwinProcessExecutablePath(t, func(int) (string, error) { return path, nil })
+	first := testDarwinMappedRegion(0x1000, 0x1000, path, wakeFileIdentity{Device: 17, Inode: 41}, 8192)
+	second := testDarwinMappedRegion(0x1000, 0x1000, path, wakeFileIdentity{Device: 17, Inode: 42}, 8192)
+	var calls int
+	stubDarwinProcessRegionReader(t, func(int, uint64) (darwinProcRegionWithPathInfo, bool, error) {
+		defer func() { calls++ }()
+		switch calls {
+		case 0:
+			return first, true, nil
+		case 1:
+			return darwinProcRegionWithPathInfo{}, false, nil
+		case 2:
+			return second, true, nil
+		default:
+			return darwinProcRegionWithPathInfo{}, false, nil
+		}
+	})
+	if _, err := inspectDarwinWakeMappedImage(42); err == nil || !strings.Contains(err.Error(), "changed during inspection") {
+		t.Fatalf("mapped-image error = %v, want changing evidence refusal", err)
+	}
+}
+
+func testDarwinMappedRegion(
+	address uint64,
+	size uint64,
+	path string,
+	identity wakeFileIdentity,
+	fileSize int64,
+) darwinProcRegionWithPathInfo {
+	var region darwinProcRegionWithPathInfo
+	region.Region.Address = address
+	region.Region.Size = size
+	region.Region.Protection = darwinVMProtExecute
+	region.Vnode.Info.Type = darwinVnodeTypeRegular
+	region.Vnode.Info.Stat.Mode = darwinModeRegular | 0o755
+	region.Vnode.Info.Stat.Device = uint32(identity.Device)
+	region.Vnode.Info.Stat.Inode = identity.Inode
+	region.Vnode.Info.Stat.ChangeTime = identity.CTimeSec
+	region.Vnode.Info.Stat.ChangeTimeNS = identity.CTimeNsec
+	region.Vnode.Info.Stat.Size = fileSize
+	copy(region.Vnode.Path[:], path)
+	return region
+}
+
+func stubDarwinProcessRegionReader(
+	t *testing.T,
+	reader func(int, uint64) (darwinProcRegionWithPathInfo, bool, error),
+) {
+	t.Helper()
+	old := readDarwinProcessRegionPathInfo
+	readDarwinProcessRegionPathInfo = reader
+	t.Cleanup(func() { readDarwinProcessRegionPathInfo = old })
+}


### PR DESCRIPTION
Closes #398

## What changed

- inspect the live Darwin process mapping with public PROC_PIDREGIONPATHINFO evidence
- compare the mapped executable vnode to the current amq binary instead of re-reading only the replaced pathname
- report current only from stable mapped-vnode agreement; preserve unknown for incomplete or changing evidence
- cover real post-exec path replacement on native arm64 and Rosetta amd64

## Validation

- make ci
- go test -race -count=1 ./internal/cli
- native arm64 mapped-image and real relink tests
- Rosetta amd64 mapped-image and real relink tests
- Darwin arm64 and amd64 CGO-disabled cross-builds

Reviewed commit: add8847bc05cf5a84c8ab36175998e4048dda666
Reviewed tree: efdaeb38ffbdcc426f7b8be370080ccc6a6b7d2f

This is user-visible wake correctness work and should release as v0.56.0, not a patch version.

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestDarwinWakeBinaryComparisonRejectsRecordedEvidenceDisagreement: Replaced by TestDarwinWakeBinaryComparisonUsesMappedVnodeOverRecordedPathIdentity because the live mapped vnode is authoritative over stale launch-time pathname identity.
TestDarwinWakeBinaryComparisonRejectsRecordedDigestDisagreement: Replaced by TestDarwinWakeBinaryComparisonDoesNotTreatRecordedDigestAsMappedAuthority because a path digest does not identify the vnode mapped in the live process.
END_WAKE_TEST_CHANGE_JUSTIFICATION
