### PR TITLE
fix(wake): skip Codex LF prelude for submit-only reminders

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -1664,12 +1664,11 @@ func injectTerminalSubmitOnly(cfg *wakeConfig, mode string) (bool, error) {
 		return resumeWakeInputDelivery(cfg)
 	}
 
-	phase := wakeInputPrimarySubmitPending
-	if mode == wakeInjectModeRaw && rawSubmitPrelude(cfg.me) != "" {
-		phase = wakeInputRawPreludePending
-	}
+	// A submit-only reminder carries no fresh text and runs well after the
+	// target's paste-burst window. Reusing the Codex LF prelude here would put a
+	// literal blank line into an already-empty composer on every retry.
 	*state = wakeInputDeliveryState{
-		phase: phase,
+		phase: wakeInputPrimarySubmitPending,
 		mode:  mode,
 	}
 	return resumeWakeInputDelivery(cfg)

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -659,6 +659,39 @@ func TestRawSubmitPreludePicksByTarget(t *testing.T) {
 	}
 }
 
+func TestInjectTerminalSubmitOnlyRawSkipsCodexPrelude(t *testing.T) {
+	stubRawInputDrained(t, func(time.Duration, time.Duration) (time.Duration, bool, error) {
+		return 0, true, nil
+	})
+	slept := stubRawInjectSleep(t)
+	var injected []string
+	cfg := &wakeConfig{
+		me:         "codex",
+		injectMode: wakeInjectModeRaw,
+		terminalWrite: func(text string) error {
+			injected = append(injected, text)
+			return nil
+		},
+	}
+
+	confirmed, err := injectTerminalSubmitOnly(cfg, wakeInjectModeRaw)
+	if err != nil {
+		t.Fatalf("inject submit-only reminder: %v", err)
+	}
+	if !confirmed {
+		t.Fatal("submit-only reminder was not confirmed")
+	}
+	if got, want := strings.Join(injected, ""), "\r\r"; got != want {
+		t.Fatalf("submit-only reminder bytes = %q, want %q", got, want)
+	}
+	if got := *slept; len(got) != 2 || got[0] != rawInjectSettleDelay || got[1] != rawInjectSettleDelay {
+		t.Fatalf("submit-only reminder sleeps = %v, want two %s delays", got, rawInjectSettleDelay)
+	}
+	if cfg.inputDelivery.pending() {
+		t.Fatalf("submit-only reminder retained state: %#v", cfg.inputDelivery)
+	}
+}
+
 func TestInjectNotificationRawInjectsLFPreludeForCodex(t *testing.T) {
 	// codex targets get a lone LF between the drained text and the settle: it
 	// routes through codex-tui's Ctrl-J binding, which flushes and clears
@@ -1965,7 +1998,7 @@ func TestNotifyNewMessagesReminderUsesSubmitOnlyAfterConfirmedPresentation(t *te
 			name:                   "raw-confirmed",
 			mode:                   wakeInjectModeRaw,
 			wantConfirmedInitially: true,
-			wantInjected:           coopWakeDoorbell + "\n\r\r\n\r\r",
+			wantInjected:           coopWakeDoorbell + "\n\r\r\r\r",
 		},
 		{
 			name:                   "paste-confirmed",
@@ -2785,7 +2818,7 @@ func TestNotifyNewMessagesGenericConfirmedCohortUsesSubmitOnly(t *testing.T) {
 			name:      "raw",
 			mode:      wakeInjectModeRaw,
 			firstWant: "\a" + coopWakeDoorbell + "\n\r\r",
-			retryWant: "\n\r\r",
+			retryWant: "\r\r",
 		},
 		{
 			name:      "paste",

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -2022,6 +2022,7 @@ func TestRunWakeLoopRetriesPendingDoorbellWithSubmitOnlyNudge(t *testing.T) {
 	}()
 	doorbellPayloads := 0
 	submitKeys := 0
+	preludeLFs := 0
 
 	go func() {
 		defer close(loopDone)
@@ -2049,6 +2050,9 @@ func TestRunWakeLoopRetriesPendingDoorbellWithSubmitOnlyNudge(t *testing.T) {
 					if submitKeys == 4 {
 						reminderSubmit <- struct{}{}
 					}
+				}
+				if text == "\n" {
+					preludeLFs++
 				}
 				return nil
 			},
@@ -2093,6 +2097,9 @@ func TestRunWakeLoopRetriesPendingDoorbellWithSubmitOnlyNudge(t *testing.T) {
 	case output := <-attention:
 		t.Fatalf("retry emitted output-only attention: %q", output)
 	default:
+	}
+	if preludeLFs != 1 {
+		t.Fatalf("raw LF preludes = %d, want exactly the initial full-presentation prelude", preludeLFs)
 	}
 }
 
@@ -2219,7 +2226,7 @@ func TestRunWakeLoopOwnerlessConfirmedPresentationUsesSubmitOnlyNudge(t *testing
 	case <-time.After(2 * time.Second):
 		t.Fatal("wake loop did not accept retry-deadline maintenance tick")
 	}
-	for _, want := range []string{"\n", "\r", "\r"} {
+	for _, want := range []string{"\r", "\r"} {
 		select {
 		case got := <-writes:
 			if got != want {


### PR DESCRIPTION
Closes #457

## What

Submit-only raw reminders now send only the two settled carriage returns. The Codex LF prelude remains unchanged for a newly injected payload, where it is still needed to flush the initial burst.

## Validation

- Exact head `0c091dd16a5da5cab85b345bc4f205476097dde3`, tree `f60684a955e0229d329fb607111c0d04168a3c8a`.
- `git diff --check`
- `go test -race -count=1 ./internal/cli`
- `make ci`
- Hosted push CI `31155510440` and PR CI `31155532141`: success; Gitleaks and GitGuardian: success.
- Focused mutation coverage proves reminders still fire, the initial payload still includes exactly one LF, and paste/inject-via behavior is unchanged.

## Live Ghostty / Codex gate

Candidate binary built from the exact head above. Environment: Darwin, Ghostty 1.3.1, Codex CLI 0.145.0, isolated real Maildir queue, and a real candidate `amq wake --inject-mode raw --retry-until drained` attached to the Ghostty TTY.

- Idle cohort: the initial full presentation logged one LF prelude and two settled submits. All three subsequent reminder cycles logged `mode=raw text_len=0`, primary submit, and rescue submit, with no LF prelude. Screenshots after reminders 1, 2, and 3 showed the same empty composer with zero blank rows.
- Rescue cohort: after the initial presentation returned the TUI to idle, `!printf __AMQ_WAKE_RESCUE_OK__` was inserted without Enter while the reminder count was zero. The first real wake reminder submitted it; Codex displayed `You ran printf __AMQ_WAKE_RESCUE_OK__` and output `__AMQ_WAKE_RESCUE_OK__` exactly once.
- The isolated Codex and wake processes were terminated after the gate; no operator wake was touched.

This is a bug-fix patch for v0.56.1.