### PR TITLE
feat(wake): add agent-safe self restart

### DIFF
--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 )
 
-const cliHelperEnv = "AMQ_TEST_CLI_HELPER"
+const (
+	cliHelperEnv                 = "AMQ_TEST_CLI_HELPER"
+	wakeRestartPTYOwnerHelperEnv = "AMQ_TEST_WAKE_RESTART_PTY_OWNER"
+)
 
 var cliSecureTempRoot string
 
@@ -30,7 +33,8 @@ func TestMain(m *testing.M) {
 		}
 		os.Exit(0)
 	}
-	if os.Getenv(injectViaHelperEnv) == "1" {
+	if os.Getenv(injectViaHelperEnv) == "1" || os.Getenv(wakeRestartPTYOwnerHelperEnv) == "1" ||
+		os.Getenv("AMQ_TEST_WAKE_RESTART_BOUND_EXEC") != "" {
 		os.Exit(m.Run())
 	}
 

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -71,6 +71,7 @@ func init() {
 			Children: []CommandInfo{
 				{Name: "check", Summary: "Inspect wake start and restart capability without mutation", Handler: runWake},
 				{Name: "repair", Summary: "Restart a proven-stale wake from a saved inject-via target", Handler: runWake},
+				{Name: "restart", Summary: "Ask a live owner-bound wake to replace itself", Handler: runWake},
 				{Name: "recover-owner", Summary: "Recover an exact owner-bound wake claim", Handler: runWake},
 				{Name: "retire", Summary: "Retire an exact managed wake and its matching retained state", Handler: runWake},
 			},

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -85,7 +85,7 @@ func TestChildNames(t *testing.T) {
 	}{
 		{name: "presence", want: []string{"set", "list"}},
 		{name: "dlq", want: []string{"list", "read", "retry", "purge"}},
-		{name: "wake", want: []string{"check", "repair", "recover-owner", "retire"}},
+		{name: "wake", want: []string{"check", "repair", "restart", "recover-owner", "retire"}},
 		{name: "coop", want: []string{"init", "exec"}},
 		{name: "swarm", want: []string{"list", "join", "leave", "tasks", "claim", "complete", "fail", "block", "bridge"}},
 		{name: "receipts", want: []string{"list", "wait"}},

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -46,6 +46,7 @@ type wakeConfig struct {
 	interruptCooldown             time.Duration
 	lastInterrupt                 time.Time
 	controlStop                   <-chan struct{}
+	restartSignals                chan os.Signal
 	beforeTerminalWrite           func() error
 	terminalWrite                 func(string) error
 	inspectTerminalGeneration     func() wakeLockInspection

--- a/internal/cli/wake_check_schema.go
+++ b/internal/cli/wake_check_schema.go
@@ -23,12 +23,14 @@ const (
 
 	wakeCheckUnknown      = "unknown"
 	wakeReloadAdvertised  = "advertised"
+	wakeReloadReady       = "ready"
 	wakeReloadUnavailable = "unavailable"
 )
 
 const (
 	wakeActionStartWake          = "start_wake"
 	wakeActionRepairWake         = "repair_wake"
+	wakeActionRestartWake        = "restart_wake"
 	wakeActionRecoverOwner       = "recover_owner"
 	wakeActionPreserveLiveWake   = "preserve_live_wake"
 	wakeActionInspectUnverified  = "inspect_unverified"
@@ -68,6 +70,10 @@ const (
 	wakeReloadReasonObservationChanged   = "reload_observation_changed"
 	wakeReloadReasonPlatformUnsupported  = "reload_platform_unsupported"
 	wakeReloadReasonCommandUnavailable   = "reload_command_unavailable"
+	wakeReloadReasonReady                = "reload_ready"
+	wakeReloadReasonOwnerMismatch        = "reload_owner_mismatch"
+	wakeReloadReasonNotPrepared          = "reload_not_prepared"
+	wakeReloadReasonRestartPending       = "reload_restart_pending"
 )
 
 type wakeCheckDecision struct {
@@ -327,7 +333,8 @@ func finalizeWakeCheckDecision(decision *wakeCheckDecision) {
 
 func wakeCheckActionRequiresExecutable(action wakeCheckActionDecision) bool {
 	switch action.Kind {
-	case wakeActionStartWake, wakeActionRepairWake, wakeActionRecoverOwner:
+	case wakeActionStartWake, wakeActionRepairWake, wakeActionRestartWake, wakeActionRecoverOwner,
+		wakeActionWaitForStableState:
 		return true
 	case wakeActionRetryCheck:
 		return action.ReasonCode == wakeReasonObservationChanged

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -503,8 +502,9 @@ func TestWakeCheckV2ClassifierActions(t *testing.T) {
 				d.Wake.Status = string(wakeLockCreating)
 				return wakeLockInspection{Exists: true, Status: wakeLockCreating}, nil
 			},
-			kind: wakeActionWaitForStableState, actor: wakeActionActorNone,
+			kind: wakeActionWaitForStableState, actor: wakeActionActorAgent,
 			reason: wakeReasonWakeStateCreating, restart: wakeRestartUnavailable,
+			args: []string{"wake", "check", "--root", "/queue with spaces", "--me", "codex", "--json", "--json-schema=2"},
 		},
 		{
 			name: "unverified wake",
@@ -637,23 +637,20 @@ func TestWakeCheckV2ReloadObservationChangeUsesExistingSnapshotRetry(t *testing.
 }
 
 func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.T) {
-	validLock := validWakeResumeLockForTest()
-	validStatus := wakeReloadAdvertised
-	validReason := wakeReloadReasonCommandUnavailable
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	if err := writeWakePreparedFileInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.lock,
+	); err != nil {
+		t.Fatal(err)
+	}
+	validStatus := wakeReloadReady
+	validReason := wakeReloadReasonReady
 	invalidAdvertisementReason := wakeReloadReasonAdvertisementInvalid
-	if runtime.GOOS != "darwin" {
-		validStatus = wakeReloadUnavailable
-		validReason = wakeReloadReasonPlatformUnsupported
-		invalidAdvertisementReason = wakeReloadReasonPlatformUnsupported
-	}
-	validInspection := wakeLockInspection{
-		Exists:            true,
-		Status:            wakeLockValid,
-		PID:               validLock.PID,
-		Lock:              validLock,
-		Process:           wakeProcessInfo{PID: validLock.PID, Running: true},
-		IdentityConfirmed: true,
-	}
+	validInspection := fixture.lock
 	tests := []struct {
 		name       string
 		mutate     func(*wakeLockInspection)
@@ -715,7 +712,7 @@ func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.
 			if test.mutate != nil {
 				test.mutate(&inspection)
 			}
-			got := classifyWakeCheckReload("/queue", "codex", inspection)
+			got := classifyWakeCheckReload(fixture.root, fixture.agent, inspection)
 			if got.Status != test.wantStatus || got.ReasonCode != test.wantReason {
 				t.Fatalf("reload decision = %#v, want status=%q reason=%q", got, test.wantStatus, test.wantReason)
 			}
@@ -723,13 +720,13 @@ func TestWakeCheckV2ReloadClassificationIsStructuralAndNonExecutable(t *testing.
 	}
 
 	stubWakeCheckRuntime(t, false, "0.50.1")
-	decision := buildWakeCheckDecision("/queue", "codex", validInspection, &opsWakeLock{}, false)
+	decision := buildWakeCheckDecision(fixture.root, fixture.agent, validInspection, &opsWakeLock{}, false)
 	if decision.Reload.Status != validStatus ||
 		decision.Reload.ReasonCode != validReason ||
-		decision.RestartCapability != wakeRestartOperatorOnly ||
-		decision.Action.Kind != wakeActionPreserveLiveWake ||
-		decision.Action.Command != nil {
-		t.Fatalf("advertised reload changed executable action semantics: %#v", decision)
+		decision.RestartCapability != wakeRestartAgentSafe ||
+		decision.Action.Kind != wakeActionRestartWake ||
+		decision.Action.Command == nil {
+		t.Fatalf("ready reload is not executable: %#v", decision)
 	}
 	rendered := renderWakeCheckV2(decision)
 	if rendered.Reload.Status != validStatus ||
@@ -819,22 +816,31 @@ func TestDoctorOpsV2UsesTrustedRosterAgentInsteadOfOuterRecord(t *testing.T) {
 		}
 	})
 	stubWakeCheckRuntime(t, false, "0.50.1")
+	ownerEnv, err := encodeWakeOwnerEnv(*lock.ResumeOwner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envWakeOwner, ownerEnv)
 
 	inspection := inspectWakeLock(root, "codex")
 	if inspection.Status != wakeLockValid {
 		t.Fatalf("initial inspection = %#v", inspection)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	if err := writeWakePreparedFileInDir(agentDir, root, "codex", inspection); err != nil {
+		t.Fatal(err)
 	}
 	opsLock := opsWakeLock{Agent: "claude"}
 	decorateOpsWakeLockWithWakeCheck(root, "codex", &opsLock, inspection, false, true)
 	if opsLock.Agent != "codex" || opsLock.WakeCheckDecision == nil {
 		t.Fatalf("doctor trusted-agent snapshot = %#v", opsLock)
 	}
-	wantStatus := wakeReloadAdvertised
-	wantReason := wakeReloadReasonCommandUnavailable
-	if runtime.GOOS == "linux" {
-		wantStatus = wakeReloadUnavailable
-		wantReason = wakeReloadReasonPlatformUnsupported
-	}
+	wantStatus := wakeReloadReady
+	wantReason := wakeReloadReasonReady
 	if reload := opsLock.WakeCheckDecision.Reload; reload.Status != wantStatus || reload.ReasonCode != wantReason {
 		t.Fatalf("doctor trusted-agent reload = %#v, want status=%q reason=%q", reload, wantStatus, wantReason)
 	}

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -499,6 +499,27 @@ func classifyWakeCheckReload(root, agent string, inspection wakeLockInspection) 
 		}
 		return unavailable(wakeReloadReasonAdvertisementInvalid)
 	}
+	if inspection.Lock.ResumeSignal == wakeResumeSignalUSR1 {
+		readiness, err := observeWakeRestartReadiness(root, agent, inspection)
+		if err != nil {
+			return unavailable(wakeReloadReasonNotPrepared)
+		}
+		if readiness.RecordExists && readiness.Record.Status == wakeRestartPending {
+			return unavailable(wakeReloadReasonRestartPending)
+		}
+		owner, err := wakeOwnerFromEnv()
+		if err != nil || owner == nil || inspection.Lock.ResumeOwner == nil ||
+			!sameWakeOwner(owner, inspection.Lock.ResumeOwner) {
+			return unavailable(wakeReloadReasonOwnerMismatch)
+		}
+		if !readiness.Prepared {
+			return unavailable(wakeReloadReasonNotPrepared)
+		}
+		return wakeCheckReloadDecision{
+			Status:     wakeReloadReady,
+			ReasonCode: wakeReloadReasonReady,
+		}
+	}
 	return wakeCheckReloadDecision{
 		Status:     wakeReloadAdvertised,
 		ReasonCode: wakeReloadReasonCommandUnavailable,
@@ -668,6 +689,10 @@ func classifyWakeCheckRestart(
 	startArgv := wakeCheckActionCommand(
 		"wake", "--root", decision.Root, "--me", decision.Agent,
 	)
+	retryCheckArgv := wakeCheckActionCommand(
+		"wake", "check", "--root", decision.Root, "--me", decision.Agent,
+		"--json", "--json-schema=2",
+	)
 	if !inspection.Exists {
 		switch {
 		case decision.Start.Available && decision.Start.Mode != wakeInjectModeNone:
@@ -700,6 +725,23 @@ func classifyWakeCheckRestart(
 		}
 		return
 	}
+	if decision.Wake.Live &&
+		(decision.Reload.ReasonCode == wakeReloadReasonNotPrepared ||
+			decision.Reload.ReasonCode == wakeReloadReasonRestartPending) {
+		message := "leave wake state unchanged and retry after restart preparation reaches a stable state"
+		if decision.Reload.ReasonCode == wakeReloadReasonRestartPending {
+			message = "leave wake state unchanged and retry after the pending wake restart reaches a stable state"
+		}
+		decision.RestartCapability = wakeRestartUnavailable
+		decision.Action = wakeCheckActionDecision{
+			Kind:       wakeActionWaitForStableState,
+			Actor:      wakeActionActorAgent,
+			ReasonCode: decision.Reload.ReasonCode,
+			Command:    retryCheckArgv,
+			Message:    message,
+		}
+		return
+	}
 	if decision.Repair.InjectViaAvailable && opsLock != nil {
 		decision.RestartCapability = wakeRestartAgentSafe
 		decision.Action = wakeCheckActionDecision{
@@ -714,6 +756,19 @@ func classifyWakeCheckRestart(
 		return
 	}
 	if decision.Wake.Live {
+		if decision.Reload.Status == wakeReloadReady {
+			decision.RestartCapability = wakeRestartAgentSafe
+			decision.Action = wakeCheckActionDecision{
+				Kind:       wakeActionRestartWake,
+				Actor:      wakeActionActorAgent,
+				ReasonCode: wakeReloadReasonReady,
+				Command: wakeCheckActionCommand(
+					"wake", "restart", "--root", decision.Root, "--me", decision.Agent,
+				),
+				Message: "ask the live wake to restart itself with amq wake restart",
+			}
+			return
+		}
 		decision.RestartCapability = wakeRestartOperatorOnly
 		terminalRequired :=
 			wakeCheckStringValue(decision.Wake.Mode, "") != wakeTargetInjectVia &&
@@ -780,8 +835,9 @@ func classifyWakeCheckRestart(
 		decision.RestartCapability = wakeRestartUnavailable
 		decision.Action = wakeCheckActionDecision{
 			Kind:       wakeActionWaitForStableState,
-			Actor:      wakeActionActorNone,
+			Actor:      wakeActionActorAgent,
 			ReasonCode: wakeReasonWakeStateCreating,
+			Command:    retryCheckArgv,
 			Message:    "leave wake state unchanged and retry after lock creation finishes",
 		}
 	default:

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -41,6 +41,7 @@ type wakeLock struct {
 	Owner                *wakeOwner           `json:"owner,omitempty"`                  // Exact owner identity for an authoritative owner-bound lock
 	ResumeSchema         int                  `json:"resume_schema,omitempty"`          // Agent-safe self-exec protocol; independent of OwnerSchema
 	ResumeOwner          *wakeOwner           `json:"resume_owner,omitempty"`           // Exact coop owner used only for reload authentication/lifetime
+	ResumeSignal         string               `json:"resume_signal,omitempty"`          // Same-process restart request signal advertised by resumable wakes
 	RunningImageEvidence *wakeImageEvidenceV1 `json:"running_image_evidence,omitempty"` // Serialized running-image authority
 }
 

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -456,6 +456,11 @@ func recordWakeGenerationFileFailureAt(
 
 var afterWakeGenerationFileSnapshotDataRead = func(string) {}
 
+func sameWakeGenerationFileSnapshot(first, second os.FileInfo) bool {
+	return sameWakeFileIdentity(first, second) &&
+		first.Mode() == second.Mode() && first.Size() == second.Size()
+}
+
 func readWakeGenerationFileSnapshotAt(
 	dirfd int,
 	agentDir *wakeAgentDir,
@@ -515,7 +520,11 @@ func readWakeGenerationFileSnapshotAt(
 			fmt.Errorf("%s changed while restating: %w", label, statErr),
 		)
 	}
-	if !sameWakeFileIdentity(info, pathInfo) {
+	// Some Linux filesystems can report the same ctime for a same-timestamp
+	// chmod. Freeze the portable acceptance shape explicitly so a mid-read mode
+	// or size change is still classified as a changed snapshot, not as stable
+	// malformed state.
+	if !sameWakeGenerationFileSnapshot(info, pathInfo) {
 		return wakeGenerationFileSnapshot{}, true, newWakeSnapshotReadChangedError(
 			fmt.Errorf("%s changed while opening", label),
 		)

--- a/internal/cli/wake_p0_golden_abi_unix_test.go
+++ b/internal/cli/wake_p0_golden_abi_unix_test.go
@@ -197,6 +197,9 @@ func wakeABIWakeReasonCodes() map[string]bool {
 		"observation_changed":                 true,
 		"executable_identity_unavailable":     true,
 		"platform_unsupported":                true,
+		"reload_ready":                        true,
+		"reload_not_prepared":                 true,
+		"reload_restart_pending":              true,
 	}
 }
 
@@ -219,6 +222,10 @@ func wakeABIReloadReasonCodes() map[string]bool {
 		"reload_observation_changed":   true,
 		"reload_platform_unsupported":  true,
 		"reload_command_unavailable":   true,
+		"reload_ready":                 true,
+		"reload_owner_mismatch":        true,
+		"reload_not_prepared":          true,
+		"reload_restart_pending":       true,
 	}
 }
 
@@ -534,12 +541,12 @@ func TestWakeP0BinaryJSONFieldsAndEnums(t *testing.T) {
 		"missing": true, "valid": true, "stale": true, "creating": true, "unverified": true,
 	})
 	wakeABIAssertEnum(t, "image.status", image["status"], map[string]bool{"current": true, "different": true, "unknown": true})
-	wakeABIAssertEnum(t, "reload.status", reload["status"], map[string]bool{"advertised": true, "unavailable": true})
+	wakeABIAssertEnum(t, "reload.status", reload["status"], map[string]bool{"advertised": true, "ready": true, "unavailable": true})
 	wakeABIAssertEnum(t, "restart_capability", result["restart_capability"], map[string]bool{
 		"agent_safe": true, "operator_only": true, "unavailable": true,
 	})
 	wakeABIAssertEnum(t, "action.kind", action["kind"], map[string]bool{
-		"start_wake": true, "repair_wake": true, "recover_owner": true,
+		"start_wake": true, "repair_wake": true, "restart_wake": true, "recover_owner": true,
 		"preserve_live_wake": true, "inspect_unverified": true, "retry_check": true,
 		"configure_injector": true, "manual_stale_cleanup": true,
 		"wait_for_stable_state": true, "unsupported": true,

--- a/internal/cli/wake_reload_wiring_linux_test.go
+++ b/internal/cli/wake_reload_wiring_linux_test.go
@@ -28,7 +28,7 @@ func linuxWakeReloadSocketPathsForTest(t *testing.T, root, agent string) []strin
 	return paths
 }
 
-func TestRunWakeWithLoopStartsUnadvertisedLinuxReloadTransportForOrdinaryOwner(t *testing.T) {
+func TestRunWakeWithLoopAdvertisesSignalWithoutLinuxReloadTransport(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	ownerProcess := exec.Command("/bin/sh", "-c", "exec sleep 30")
@@ -64,7 +64,6 @@ func TestRunWakeWithLoopStartsUnadvertisedLinuxReloadTransportForOrdinaryOwner(t
 	}
 	t.Setenv(envWakeOwner, encoded)
 
-	var endpointPath string
 	err = runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "codex",
@@ -72,37 +71,26 @@ func TestRunWakeWithLoopStartsUnadvertisedLinuxReloadTransportForOrdinaryOwner(t
 		"--interrupt=false",
 	}, func(wakeConfig) error {
 		paths := linuxWakeReloadSocketPathsForTest(t, root, "codex")
-		if len(paths) != 1 {
-			t.Fatalf("Linux reload endpoint paths = %#v, want exactly one", paths)
-		}
-		endpointPath = paths[0]
-		info, err := os.Lstat(endpointPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if info.Mode()&os.ModeSocket == 0 || info.Mode().Perm() != 0o600 {
-			t.Fatalf("Linux reload endpoint mode = %v", info.Mode())
+		if len(paths) != 0 {
+			t.Fatalf("signal-capable Linux wake opened reload endpoints: %#v", paths)
 		}
 
 		inspection := inspectWakeLock(root, "codex")
-		if inspection.Lock.ResumeSchema != 0 || inspection.Lock.ResumeOwner != nil ||
-			inspection.Lock.ControlSocket != "" || inspection.Lock.RunningImageEvidence != nil {
-			t.Fatalf("Linux reload endpoint advertised resume metadata: %#v", inspection.Lock)
+		if inspection.Lock.ResumeSchema != wakeResumeSchemaV2 ||
+			!sameWakeOwner(inspection.Lock.ResumeOwner, &owner) ||
+			inspection.Lock.ResumeSignal != wakeResumeSignalUSR1 ||
+			inspection.Lock.ControlSocket != "" ||
+			inspection.Lock.RunningImageEvidence == nil {
+			t.Fatalf("Linux signal resume advertisement = %#v", inspection.Lock)
 		}
 		return nil
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if endpointPath == "" {
-		t.Fatal("Linux reload endpoint was not observed")
-	}
-	if _, err := os.Lstat(endpointPath); !os.IsNotExist(err) {
-		t.Fatalf("Linux reload endpoint survived wake cleanup: %v", err)
-	}
 }
 
-func TestRunWakeWithLoopClassifiesOptionalLinuxReloadTransportStartFailures(t *testing.T) {
+func TestRunWakeWithLoopSkipsObsoleteLinuxReloadTransportForSignalWake(t *testing.T) {
 	root := secureTempDirForTest(t)
 	ensureCoopWakeMailboxForTest(t, root, "codex")
 	ownerProcess := exec.Command("/bin/sh", "-c", "exec sleep 30")
@@ -139,108 +127,37 @@ func TestRunWakeWithLoopClassifiesOptionalLinuxReloadTransportStartFailures(t *t
 	t.Setenv(envWakeOwner, encoded)
 
 	startCalled := false
-	startFailure := errors.New("test reload bind failure")
 	oldStart := startWakeReloadTransportForWake
 	startWakeReloadTransportForWake = func(
 		_ *wakeAgentDir,
-		gotRoot string,
-		gotAgent string,
-		inspection wakeLockInspection,
-		gotOwner wakeOwner,
+		_ string,
+		_ string,
+		_ wakeLockInspection,
+		_ wakeOwner,
 	) (func(), error) {
 		startCalled = true
-		if gotRoot != canonicalWakeRoot(root) || gotAgent != "codex" || gotOwner != owner {
-			t.Fatalf("reload start identity = root %q agent %q owner %#v", gotRoot, gotAgent, gotOwner)
-		}
-		if !inspection.IdentityConfirmed {
-			t.Fatal("reload start did not receive confirmed lock identity")
-		}
-		return nil, &wakeReloadTransportUnavailableError{err: startFailure}
+		return nil, errors.New("obsolete reload transport must not start")
 	}
 	t.Cleanup(func() { startWakeReloadTransportForWake = oldStart })
 
 	loopCalled := false
-	var runErr error
-	stderr := captureWakeStderr(t, func() {
-		runErr = runWakeWithLoop([]string{
-			"--root", root,
-			"--me", "codex",
-			"--inject-mode", wakeInjectModeNone,
-			"--interrupt=false",
-		}, func(wakeConfig) error {
-			loopCalled = true
-			if paths := linuxWakeReloadSocketPathsForTest(t, root, "codex"); len(paths) != 0 {
-				t.Fatalf("failed Linux reload endpoint paths = %#v", paths)
-			}
-			return nil
-		})
-	})
-	if runErr != nil {
-		t.Fatal(runErr)
-	}
-	if !startCalled || !loopCalled {
-		t.Fatalf("reload start called = %v, loop called = %v", startCalled, loopCalled)
-	}
-	if !strings.Contains(stderr, "reload transport unavailable: "+startFailure.Error()) ||
-		!strings.Contains(stderr, "continuing without reload transport") {
-		t.Fatalf("reload transport degradation note = %q", stderr)
-	}
-
-	authorityFailure := errors.New("wake reload owner exited during startup")
-	startCalled = false
-	loopCalled = false
-	startWakeReloadTransportForWake = func(
-		_ *wakeAgentDir,
-		_ string,
-		_ string,
-		_ wakeLockInspection,
-		_ wakeOwner,
-	) (func(), error) {
-		startCalled = true
-		return nil, authorityFailure
-	}
-	stderr = captureWakeStderr(t, func() {
-		runErr = runWakeWithLoop([]string{
-			"--root", root,
-			"--me", "codex",
-			"--inject-mode", wakeInjectModeNone,
-			"--interrupt=false",
-		}, func(wakeConfig) error {
-			loopCalled = true
-			return nil
-		})
-	})
-	if !errors.Is(runErr, authorityFailure) || !startCalled || loopCalled {
-		t.Fatalf("authority failure result = %v, start called = %v, loop called = %v", runErr, startCalled, loopCalled)
-	}
-	if strings.Contains(stderr, "continuing without reload transport") {
-		t.Fatalf("authority failure was narrated as degradable: %q", stderr)
-	}
-
-	startCalled = false
-	loopCalled = false
-	startWakeReloadTransportForWake = func(
-		_ *wakeAgentDir,
-		_ string,
-		_ string,
-		_ wakeLockInspection,
-		_ wakeOwner,
-	) (func(), error) {
-		startCalled = true
-		return nil, nil
-	}
-	runErr = runWakeWithLoop([]string{
+	runErr := runWakeWithLoop([]string{
 		"--root", root,
 		"--me", "codex",
 		"--inject-mode", wakeInjectModeNone,
 		"--interrupt=false",
 	}, func(wakeConfig) error {
 		loopCalled = true
+		if paths := linuxWakeReloadSocketPathsForTest(t, root, "codex"); len(paths) > 0 {
+			t.Fatalf("signal wake reload endpoint paths = %#v", paths)
+		}
 		return nil
 	})
-	if runErr == nil || !strings.Contains(runErr.Error(), "returned no cleanup") ||
-		!startCalled || loopCalled {
-		t.Fatalf("nil cleanup result = %v, start called = %v, loop called = %v", runErr, startCalled, loopCalled)
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	if startCalled || !loopCalled {
+		t.Fatalf("reload start called = %v, loop called = %v", startCalled, loopCalled)
 	}
 }
 

--- a/internal/cli/wake_restart_bound_darwin.go
+++ b/internal/cli/wake_restart_bound_darwin.go
@@ -1,0 +1,287 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func bindWakeRestartCandidatePlatform(candidate wakeImageEvidenceV1) (*wakeRestartBoundImage, error) {
+	sourceLstat, err := os.Lstat(candidate.ExecutionPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat wake restart candidate: %w", err)
+	}
+	if sourceLstat.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("wake restart candidate must not be a symlink")
+	}
+	sourceFD, err := unix.Open(candidate.ExecutionPath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open wake restart candidate: %w", err)
+	}
+	source := os.NewFile(uintptr(sourceFD), candidate.ExecutionPath)
+	if source == nil {
+		_ = unix.Close(sourceFD)
+		return nil, fmt.Errorf("bind wake restart candidate file descriptor")
+	}
+	defer func() { _ = source.Close() }()
+	sourceOpened, err := source.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat opened wake restart candidate: %w", err)
+	}
+	if !os.SameFile(sourceLstat, sourceOpened) {
+		return nil, fmt.Errorf("wake restart candidate changed while binding")
+	}
+	requestedSource, err := captureWakeImageEvidenceFromOpenFile(
+		source,
+		candidate.ExecutionPath,
+		candidate.EmbeddedVersion,
+		wakeImageMethodPathnameObserved,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if requestedSource != candidate {
+		return nil, fmt.Errorf("wake restart candidate changed before Darwin staging")
+	}
+
+	stageDir, err := os.MkdirTemp(
+		filepath.Dir(candidate.ExecutionPath),
+		"."+filepath.Base(candidate.ExecutionPath)+".amq-restart-",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create adjacent wake restart stage: %w", err)
+	}
+	stagePath := filepath.Join(stageDir, filepath.Base(candidate.ExecutionPath))
+	stageCreated := false
+	stageIdentityKnown := false
+	var stageIdentity os.FileInfo
+	defer func() {
+		if !stageCreated {
+			_ = os.Remove(stageDir)
+			return
+		}
+		if stageIdentityKnown {
+			if current, statErr := os.Lstat(stagePath); statErr == nil && os.SameFile(stageIdentity, current) {
+				_ = os.Remove(stagePath)
+				_ = os.Remove(stageDir)
+			}
+		}
+	}()
+	if err := os.Link(candidate.ExecutionPath, stagePath); err != nil {
+		return nil, fmt.Errorf("hardlink wake restart candidate into adjacent stage: %w", err)
+	}
+	stageCreated = true
+	stageLstat, err := os.Lstat(stagePath)
+	if err != nil {
+		return nil, fmt.Errorf("stat staged wake restart image: %w", err)
+	}
+	stageIdentity = stageLstat
+	stageIdentityKnown = true
+	if stageLstat.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("staged wake restart image must not be a symlink")
+	}
+	stageFD, err := unix.Open(stagePath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open staged wake restart image: %w", err)
+	}
+	stage := os.NewFile(uintptr(stageFD), stagePath)
+	if stage == nil {
+		_ = unix.Close(stageFD)
+		return nil, fmt.Errorf("bind staged wake restart image file descriptor")
+	}
+	bound := &wakeRestartBoundImage{
+		file:          stage,
+		executionPath: stagePath,
+		stageDir:      stageDir,
+	}
+	failed := true
+	defer func() {
+		if failed {
+			_ = stage.Close()
+		}
+	}()
+	stageOpened, err := stage.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat opened staged wake restart image: %w", err)
+	}
+	postLinkSource, err := source.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("re-stat linked wake restart source: %w", err)
+	}
+	if !os.SameFile(sourceOpened, postLinkSource) || !os.SameFile(postLinkSource, stageLstat) ||
+		!os.SameFile(stageLstat, stageOpened) {
+		return nil, fmt.Errorf("darwin wake restart source and stage identities do not match")
+	}
+	postLinkSourceEvidence, err := captureWakeImageEvidenceFromOpenFile(
+		source,
+		candidate.ExecutionPath,
+		candidate.EmbeddedVersion,
+		wakeImageMethodPathnameObserved,
+	)
+	if err != nil {
+		return nil, err
+	}
+	bound.evidence, err = captureWakeImageEvidenceFromOpenFile(
+		stage,
+		stagePath,
+		candidate.EmbeddedVersion,
+		wakeImageMethodPathnameExecVerified,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !sameWakeImageEvidenceExceptMethodPath(postLinkSourceEvidence, bound.evidence) {
+		return nil, fmt.Errorf("darwin wake restart source and staged image changed while hashing")
+	}
+	if !sameRequestedAndBoundWakeImageEvidence(candidate, bound.evidence) {
+		return nil, fmt.Errorf("darwin staged wake restart image differs from requested candidate")
+	}
+	stageCreated = false
+	failed = false
+	return bound, nil
+}
+
+func boundWakeRestartPreflightCommandPlatform(image *wakeRestartBoundImage) (string, []*os.File, error) {
+	if image == nil || image.file == nil || image.executionPath == "" {
+		return "", nil, fmt.Errorf("bound Darwin wake restart image is missing")
+	}
+	return image.executionPath, nil, nil
+}
+
+func revalidateBoundWakeRestartImagePlatform(image *wakeRestartBoundImage) error {
+	if image == nil || image.file == nil {
+		return fmt.Errorf("bound Darwin wake restart image is missing")
+	}
+	pathInfo, err := os.Lstat(image.executionPath)
+	if err != nil {
+		return fmt.Errorf("stat bound Darwin wake restart image: %w", err)
+	}
+	opened, err := image.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat opened bound Darwin wake restart image: %w", err)
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !os.SameFile(pathInfo, opened) {
+		return fmt.Errorf("bound Darwin wake restart path changed during preflight")
+	}
+	evidence, err := captureWakeImageEvidenceFromOpenFile(
+		image.file,
+		image.executionPath,
+		image.evidence.EmbeddedVersion,
+		wakeImageMethodPathnameExecVerified,
+	)
+	if err != nil {
+		return err
+	}
+	if !sameDarwinStagedWakeImageEvidence(evidence, image.evidence) {
+		return fmt.Errorf("bound Darwin wake restart image changed during preflight")
+	}
+	return nil
+}
+
+func verifyWakeResumeBoundImagePlatform(bound wakeImageEvidenceV1) (wakeImageEvidenceV1, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("resolve running wake image: %w", err)
+	}
+	path, err = filepath.EvalSymlinks(path)
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("resolve running wake image path: %w", err)
+	}
+	path = filepath.Clean(path)
+	if path != bound.ExecutionPath {
+		return wakeImageEvidenceV1{}, fmt.Errorf("running wake path does not match bound restart path")
+	}
+	actual, err := captureWakeImageEvidence(path, bound.EmbeddedVersion)
+	if err != nil {
+		return wakeImageEvidenceV1{}, err
+	}
+	actual.Method = wakeImageMethodPathnameExecVerified
+	if !sameDarwinStagedWakeImageEvidence(actual, bound) {
+		return wakeImageEvidenceV1{}, fmt.Errorf("running wake image does not match bound restart image")
+	}
+	return actual, nil
+}
+
+func cleanupBoundWakeRestartImagePlatform(image wakeRestartBoundImage) error {
+	if image.stageDir == "" || image.evidence.ExecutionPath == "" {
+		return nil
+	}
+	return cleanupDarwinWakeRestartStage(image.evidence, true)
+}
+
+func cleanupWakeResumeBoundImagePlatform(bound wakeImageEvidenceV1) error {
+	return cleanupDarwinWakeRestartStage(bound, true)
+}
+
+func validPreviousWakeRestartBoundImagePlatform(bound wakeImageEvidenceV1) bool {
+	if bound.Platform != "darwin" || bound.Method != wakeImageMethodPathnameExecVerified {
+		return false
+	}
+	stagePath := bound.ExecutionPath
+	stageBase := filepath.Base(stagePath)
+	stageDirBase := filepath.Base(filepath.Dir(stagePath))
+	prefix := "." + stageBase + ".amq-restart-"
+	return stageBase != "." && stageBase != string(filepath.Separator) &&
+		strings.HasPrefix(stageDirBase, prefix) && len(stageDirBase) > len(prefix)
+}
+
+func cleanupDarwinWakeRestartStage(bound wakeImageEvidenceV1, allowNamespaceCTimeChange bool) error {
+	if !validPreviousWakeRestartBoundImagePlatform(bound) {
+		return fmt.Errorf("refuse cleanup of non-staged Darwin wake image")
+	}
+	stagePath := bound.ExecutionPath
+	stageDir := filepath.Dir(stagePath)
+	lstat, err := os.Lstat(stagePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat Darwin wake restart stage: %w", err)
+	}
+	if lstat.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refuse cleanup of replaced Darwin wake restart stage")
+	}
+	fd, err := unix.Open(stagePath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open Darwin wake restart stage for cleanup: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), stagePath)
+	if file == nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("bind Darwin wake restart stage for cleanup")
+	}
+	defer func() { _ = file.Close() }()
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(lstat, opened) {
+		return fmt.Errorf("darwin wake restart stage changed before cleanup")
+	}
+	evidence, err := captureWakeImageEvidenceFromOpenFile(
+		file,
+		stagePath,
+		bound.EmbeddedVersion,
+		wakeImageMethodPathnameExecVerified,
+	)
+	if err != nil {
+		return err
+	}
+	if evidence != bound &&
+		(!allowNamespaceCTimeChange || !sameDarwinStagedWakeImageEvidence(evidence, bound)) {
+		return fmt.Errorf("refuse cleanup of changed Darwin wake restart stage")
+	}
+	confirmed, err := os.Lstat(stagePath)
+	if err != nil || !os.SameFile(lstat, confirmed) {
+		return fmt.Errorf("darwin wake restart stage changed at cleanup boundary")
+	}
+	if err := os.Remove(stagePath); err != nil {
+		return fmt.Errorf("remove Darwin wake restart stage: %w", err)
+	}
+	if err := os.Remove(stageDir); err != nil {
+		return fmt.Errorf("remove Darwin wake restart stage directory: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/wake_restart_bound_darwin.go
+++ b/internal/cli/wake_restart_bound_darwin.go
@@ -97,7 +97,6 @@ func bindWakeRestartCandidatePlatform(candidate wakeImageEvidenceV1) (*wakeResta
 	bound := &wakeRestartBoundImage{
 		file:          stage,
 		executionPath: stagePath,
-		stageDir:      stageDir,
 	}
 	failed := true
 	defer func() {
@@ -208,7 +207,7 @@ func verifyWakeResumeBoundImagePlatform(bound wakeImageEvidenceV1) (wakeImageEvi
 }
 
 func cleanupBoundWakeRestartImagePlatform(image wakeRestartBoundImage) error {
-	if image.stageDir == "" || image.evidence.ExecutionPath == "" {
+	if image.evidence.ExecutionPath == "" {
 		return nil
 	}
 	return cleanupDarwinWakeRestartStage(image.evidence, true)

--- a/internal/cli/wake_restart_bound_linux.go
+++ b/internal/cli/wake_restart_bound_linux.go
@@ -1,0 +1,112 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func bindWakeRestartCandidatePlatform(candidate wakeImageEvidenceV1) (*wakeRestartBoundImage, error) {
+	lstat, err := os.Lstat(candidate.ExecutionPath)
+	if err != nil {
+		return nil, fmt.Errorf("stat wake restart candidate: %w", err)
+	}
+	if lstat.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("wake restart candidate must not be a symlink")
+	}
+	fd, err := unix.Open(candidate.ExecutionPath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open wake restart candidate: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), candidate.ExecutionPath)
+	if file == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("bind wake restart candidate file descriptor")
+	}
+	bound := &wakeRestartBoundImage{file: file}
+	failed := true
+	defer func() {
+		if failed {
+			_ = bound.close()
+		}
+	}()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat opened wake restart candidate: %w", err)
+	}
+	if !os.SameFile(lstat, opened) {
+		return nil, fmt.Errorf("wake restart candidate changed while binding")
+	}
+	bound.executionPath = filepath.Clean(fmt.Sprintf("/proc/self/fd/%d", fd))
+	bound.evidence, err = captureWakeImageEvidenceFromOpenFile(
+		file,
+		bound.executionPath,
+		candidate.EmbeddedVersion,
+		wakeImageMethodFDExec,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !sameWakeImageEvidenceExceptMethodPath(bound.evidence, candidate) {
+		return nil, fmt.Errorf("wake restart candidate changed while binding")
+	}
+	failed = false
+	return bound, nil
+}
+
+func boundWakeRestartPreflightCommandPlatform(image *wakeRestartBoundImage) (string, []*os.File, error) {
+	if image == nil || image.file == nil {
+		return "", nil, fmt.Errorf("bound wake restart image is missing")
+	}
+	return "/proc/self/fd/3", []*os.File{image.file}, nil
+}
+
+func revalidateBoundWakeRestartImagePlatform(image *wakeRestartBoundImage) error {
+	if image == nil || image.file == nil {
+		return fmt.Errorf("bound wake restart image is missing")
+	}
+	evidence, err := captureWakeImageEvidenceFromOpenFile(
+		image.file,
+		image.executionPath,
+		image.evidence.EmbeddedVersion,
+		wakeImageMethodFDExec,
+	)
+	if err != nil {
+		return err
+	}
+	if evidence != image.evidence {
+		return fmt.Errorf("bound wake restart image changed during preflight")
+	}
+	return nil
+}
+
+func verifyWakeResumeBoundImagePlatform(bound wakeImageEvidenceV1) (wakeImageEvidenceV1, error) {
+	file, err := os.Open("/proc/self/exe")
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("open running wake image: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	actual, err := captureWakeImageEvidenceFromOpenFile(
+		file,
+		bound.ExecutionPath,
+		bound.EmbeddedVersion,
+		wakeImageMethodFDExec,
+	)
+	if err != nil {
+		return wakeImageEvidenceV1{}, err
+	}
+	if actual != bound {
+		return wakeImageEvidenceV1{}, fmt.Errorf("running wake image does not match bound restart image")
+	}
+	return actual, nil
+}
+
+func cleanupBoundWakeRestartImagePlatform(wakeRestartBoundImage) error { return nil }
+
+func cleanupWakeResumeBoundImagePlatform(wakeImageEvidenceV1) error { return nil }
+
+func validPreviousWakeRestartBoundImagePlatform(wakeImageEvidenceV1) bool { return false }

--- a/internal/cli/wake_restart_bound_unix.go
+++ b/internal/cli/wake_restart_bound_unix.go
@@ -1,0 +1,154 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type wakeRestartBoundImage struct {
+	file          *os.File
+	executionPath string
+	evidence      wakeImageEvidenceV1
+	stageDir      string
+}
+
+func (image *wakeRestartBoundImage) close() error {
+	if image == nil {
+		return nil
+	}
+	var closeErr error
+	if image.file != nil {
+		closeErr = image.file.Close()
+		image.file = nil
+	}
+	cleanupErr := cleanupBoundWakeRestartImagePlatform(*image)
+	if closeErr != nil {
+		return fmt.Errorf("close bound wake restart image: %w", closeErr)
+	}
+	return cleanupErr
+}
+
+func bindWakeRestartCandidate(candidate wakeImageEvidenceV1) (*wakeRestartBoundImage, error) {
+	if err := validateWakeImageEvidence(candidate); err != nil {
+		return nil, err
+	}
+	return bindWakeRestartCandidatePlatform(candidate)
+}
+
+func preflightBoundWakeRestartCandidate(
+	image *wakeRestartBoundImage,
+	argv []string,
+	bootstrap wakeResumeBootstrap,
+) error {
+	if image == nil || image.file == nil {
+		return fmt.Errorf("bound wake restart image is missing")
+	}
+	if len(argv) == 0 {
+		return fmt.Errorf("wake restart argv is empty")
+	}
+	bound := image.evidence
+	bootstrap.BoundImage = &bound
+	encodedBootstrap, err := encodeWakeResumeBootstrap(bootstrap)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), wakeResumePreflightTimeout)
+	defer cancel()
+	preflightArgs := append(append([]string(nil), argv[1:]...), "--"+wakeResumePreflightFlag)
+	path, extraFiles, err := boundWakeRestartPreflightCommandPlatform(image)
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, path, preflightArgs...)
+	cmd.ExtraFiles = extraFiles
+	cmd.Env = setEnvVar(
+		unsetEnvVar(unsetEnvVar(os.Environ(), envWakeResumeBootstrap), envWakeResumePreflight),
+		envWakeResumePreflight,
+		encodedBootstrap,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("wake resume preflight timed out: %w", ctx.Err())
+		}
+		return err
+	}
+	if strings.TrimSpace(string(out)) != wakeResumePreflightOK {
+		return fmt.Errorf("wake restart candidate did not confirm exact wake argv and bootstrap")
+	}
+	return revalidateBoundWakeRestartImagePlatform(image)
+}
+
+func verifyWakeResumeBoundImage(bootstrap wakeResumeBootstrap) (wakeImageEvidenceV1, error) {
+	if bootstrap.BoundImage == nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake resume bound image evidence is missing")
+	}
+	if err := validateWakeImageEvidence(*bootstrap.BoundImage); err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake resume bound image evidence is invalid: %w", err)
+	}
+	return verifyWakeResumeBoundImagePlatform(*bootstrap.BoundImage)
+}
+
+func cleanupWakeResumeBoundImage(bootstrap wakeResumeBootstrap) error {
+	if bootstrap.BoundImage == nil {
+		return nil
+	}
+	return cleanupWakeResumeBoundImagePlatform(*bootstrap.BoundImage)
+}
+
+func cleanupPreviousWakeResumeBoundImage(bootstrap wakeResumeBootstrap) error {
+	if bootstrap.PreviousBoundImage == nil {
+		return nil
+	}
+	return cleanupWakeResumeBoundImagePlatform(*bootstrap.PreviousBoundImage)
+}
+
+func sameWakeImageEvidenceExceptMethodPath(first, second wakeImageEvidenceV1) bool {
+	first.Method = second.Method
+	first.ExecutionPath = second.ExecutionPath
+	return first == second
+}
+
+// Link and unlink operations on any name for a Darwin hardlink mutate the
+// shared inode ctime. Once both values identify the same private staged path,
+// ctime cannot distinguish a public-name swap from an image mutation; the
+// retained device/inode plus size and digest remain the binding authority.
+func sameDarwinStagedWakeImageEvidence(first, second wakeImageEvidenceV1) bool {
+	if first.Platform != "darwin" || second.Platform != "darwin" ||
+		first.Method != wakeImageMethodPathnameExecVerified ||
+		second.Method != wakeImageMethodPathnameExecVerified ||
+		first.ExecutionPath != second.ExecutionPath {
+		return first == second
+	}
+	first.CTimeNS = second.CTimeNS
+	return first == second
+}
+
+// A Darwin hardlink necessarily changes the shared inode's ctime. This is the
+// only extra delta allowed between the requester's pre-link observation and
+// the post-link bound image; every stable identity, content, and version field
+// remains exact. Linux does not receive this exception.
+func sameRequestedAndBoundWakeImageEvidence(first, second wakeImageEvidenceV1) bool {
+	if first.Platform != second.Platform || first.Method != wakeImageMethodPathnameObserved {
+		return false
+	}
+	switch first.Platform {
+	case "darwin":
+		if second.Method != wakeImageMethodPathnameExecVerified {
+			return false
+		}
+		first.CTimeNS = second.CTimeNS
+	case "linux":
+		if second.Method != wakeImageMethodFDExec {
+			return false
+		}
+	default:
+		return false
+	}
+	return sameWakeImageEvidenceExceptMethodPath(first, second)
+}

--- a/internal/cli/wake_restart_bound_unix.go
+++ b/internal/cli/wake_restart_bound_unix.go
@@ -14,7 +14,6 @@ type wakeRestartBoundImage struct {
 	file          *os.File
 	executionPath string
 	evidence      wakeImageEvidenceV1
-	stageDir      string
 }
 
 func (image *wakeRestartBoundImage) close() error {

--- a/internal/cli/wake_restart_darwin_test.go
+++ b/internal/cli/wake_restart_darwin_test.go
@@ -202,6 +202,7 @@ func TestDarwinWakeRestartRealPTYPreservesPIDAndUnreadWork(t *testing.T) {
 	}
 
 	agentPath := filepath.Join(root, "agents", "codex")
+	stagePattern := filepath.Join(newDir, ".amq.amq-restart-*")
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		remaining := make([]string, 0, 3)
@@ -212,16 +213,20 @@ func TestDarwinWakeRestartRealPTYPreservesPIDAndUnreadWork(t *testing.T) {
 				t.Fatal(statErr)
 			}
 		}
-		if len(remaining) == 0 {
+		stages, globErr := filepath.Glob(stagePattern)
+		if globErr != nil {
+			t.Fatal(globErr)
+		}
+		if len(remaining) == 0 && len(stages) == 0 {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("wake lifecycle files survived owner exit: %v", remaining)
+			t.Fatalf(
+				"wake cleanup survived owner exit: lifecycle=%v stages=%v",
+				remaining,
+				stages,
+			)
 		}
 		time.Sleep(25 * time.Millisecond)
-	}
-	stages, err := filepath.Glob(filepath.Join(newDir, ".amq.amq-restart-*"))
-	if err != nil || len(stages) != 0 {
-		t.Fatalf("Darwin restart stages survived owner exit: %v, err=%v", stages, err)
 	}
 }

--- a/internal/cli/wake_restart_darwin_test.go
+++ b/internal/cli/wake_restart_darwin_test.go
@@ -1,0 +1,227 @@
+//go:build darwin
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDarwinWakeRestartBoundPayload(t *testing.T) {
+	if os.Getenv("AMQ_TEST_WAKE_RESTART_BOUND_EXEC") != "payload" {
+		t.Skip("bound-image payload helper")
+	}
+	_, _ = os.Stdout.WriteString("BOUND_IMAGE_A\n")
+}
+
+func TestDarwinStagedWakeImageCTimeExceptionDoesNotWeakenIdentityOrContent(t *testing.T) {
+	base, err := captureCurrentWakeImageEvidence()
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.Method = wakeImageMethodPathnameExecVerified
+	base.ExecutionPath = filepath.Join(t.TempDir(), ".amq.amq-restart-test", "amq")
+	ctimeOnly := base
+	ctimeOnly.CTimeNS++
+	if !sameDarwinStagedWakeImageEvidence(base, ctimeOnly) {
+		t.Fatal("staged Darwin ctime-only namespace mutation was rejected")
+	}
+	mutations := []struct {
+		name   string
+		mutate func(*wakeImageEvidenceV1)
+	}{
+		{name: "device", mutate: func(value *wakeImageEvidenceV1) { value.Device++ }},
+		{name: "inode", mutate: func(value *wakeImageEvidenceV1) { value.Inode++ }},
+		{name: "size", mutate: func(value *wakeImageEvidenceV1) { value.Size++ }},
+		{name: "content", mutate: func(value *wakeImageEvidenceV1) { value.SHA256 = "sha256:" + strings.Repeat("0", 64) }},
+	}
+	for _, test := range mutations {
+		t.Run(test.name, func(t *testing.T) {
+			changed := ctimeOnly
+			test.mutate(&changed)
+			if sameDarwinStagedWakeImageEvidence(base, changed) {
+				t.Fatalf("staged Darwin %s mutation was accepted", test.name)
+			}
+		})
+	}
+}
+
+func TestDarwinWakeRestartBindingSurvivesPublicPathSwapAndCleansStage(t *testing.T) {
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binaryA, err := os.ReadFile(testBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	publicPath := filepath.Join(dir, "amq")
+	if err := os.WriteFile(publicPath, binaryA, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := captureWakeImageEvidence(publicPath, "bound-swap-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Link creation is the one intentional ctime mutation in this protocol.
+	// Cross a timestamp boundary so the regression proves that the narrow
+	// Darwin exception is exercised rather than accidentally unused.
+	time.Sleep(1100 * time.Millisecond)
+	bound, err := bindWakeRestartCandidate(candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bound.evidence.CTimeNS == candidate.CTimeNS {
+		_ = bound.close()
+		t.Fatal("Darwin hardlink did not change the shared inode ctime")
+	}
+	if !sameRequestedAndBoundWakeImageEvidence(candidate, bound.evidence) {
+		_ = bound.close()
+		t.Fatal("Darwin hardlink ctime exception did not preserve exact stable evidence")
+	}
+	stagePath := bound.executionPath
+	stageDir := bound.stageDir
+
+	binaryB, err := os.ReadFile("/usr/bin/false")
+	if err != nil {
+		_ = bound.close()
+		t.Fatal(err)
+	}
+	replacement := filepath.Join(dir, "amq.replacement")
+	if err := os.WriteFile(replacement, binaryB, 0o700); err != nil {
+		_ = bound.close()
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, publicPath); err != nil {
+		_ = bound.close()
+		t.Fatal(err)
+	}
+	if err := exec.Command(publicPath).Run(); err == nil {
+		_ = bound.close()
+		t.Fatal("normal public path still executed image A after atomic replacement")
+	}
+	command := exec.Command(stagePath, "-test.run=^TestDarwinWakeRestartBoundPayload$")
+	command.Env = setEnvVar(os.Environ(), "AMQ_TEST_WAKE_RESTART_BOUND_EXEC", "payload")
+	output, err := command.CombinedOutput()
+	if err != nil || !strings.Contains(string(output), "BOUND_IMAGE_A") {
+		_ = bound.close()
+		t.Fatalf("execute staged bound image after swap: err=%v output=%q", err, output)
+	}
+	if err := bound.close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(stagePath); !os.IsNotExist(err) {
+		t.Fatalf("staged image survived exact cleanup: %v", err)
+	}
+	if _, err := os.Lstat(stageDir); !os.IsNotExist(err) {
+		t.Fatalf("staged directory survived exact cleanup: %v", err)
+	}
+}
+
+func TestDarwinWakeRestartRealPTYPreservesPIDAndUnreadWork(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real PTY restart E2E")
+	}
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve restart test source path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
+	temp := t.TempDir()
+	oldDir := filepath.Join(temp, "old")
+	newDir := filepath.Join(temp, "new")
+	if err := os.MkdirAll(oldDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(newDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldBinary := filepath.Join(oldDir, "amq")
+	newBinary := filepath.Join(newDir, "amq")
+	const oldVersion = "0.56.0-e2e-old"
+	const newVersion = "0.56.0-e2e-new"
+	buildVersionedWakeRestartBinary(t, repoRoot, oldBinary, oldVersion)
+	buildVersionedWakeRestartBinary(t, repoRoot, newBinary, newVersion)
+
+	root := filepath.Join(temp, "root")
+	initCmd := exec.Command(oldBinary, "init", "--root", root, "--agents", "codex")
+	initCmd.Env = wakeABICleanEnv()
+	if output, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("init restart E2E: %v\n%s", err, output)
+	}
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ptyLog := filepath.Join(temp, "pty.log")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(
+		ctx,
+		"/usr/bin/script", "-q", ptyLog,
+		oldBinary,
+		"coop", "exec",
+		"--root", root,
+		"--me", "codex",
+		"--require-wake",
+		"--wake-inject-mode", "raw",
+		testBinary,
+		"-test.run=^TestWakeRestartRealPTYOwnerHelper$",
+	)
+	cmd.Env = wakeABICleanEnv(
+		wakeRestartPTYOwnerHelperEnv+"=1",
+		"AMQ_E2E_ROOT="+root,
+		"AMQ_E2E_OLD="+oldBinary,
+		"AMQ_E2E_NEW="+newBinary,
+		"AMQ_E2E_OLD_VERSION="+oldVersion,
+		"AMQ_E2E_NEW_VERSION="+newVersion,
+	)
+	ptyInput, keepPTYInputOpen, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ptyInput.Close() }()
+	defer func() { _ = keepPTYInputOpen.Close() }()
+	cmd.Stdin = ptyInput
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("restart PTY E2E timed out: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("restart PTY E2E: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "AMQ_RESTART_HELPER_OK") {
+		t.Fatalf("restart PTY helper proof missing:\n%s", output)
+	}
+
+	agentPath := filepath.Join(root, "agents", "codex")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		remaining := make([]string, 0, 3)
+		for _, name := range []string{".wake.lock", ".wake.prepared", ".wake.restart"} {
+			if _, statErr := os.Lstat(filepath.Join(agentPath, name)); statErr == nil {
+				remaining = append(remaining, name)
+			} else if !os.IsNotExist(statErr) {
+				t.Fatal(statErr)
+			}
+		}
+		if len(remaining) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("wake lifecycle files survived owner exit: %v", remaining)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	stages, err := filepath.Glob(filepath.Join(newDir, ".amq.amq-restart-*"))
+	if err != nil || len(stages) != 0 {
+		t.Fatalf("Darwin restart stages survived owner exit: %v, err=%v", stages, err)
+	}
+}

--- a/internal/cli/wake_restart_darwin_test.go
+++ b/internal/cli/wake_restart_darwin_test.go
@@ -87,7 +87,7 @@ func TestDarwinWakeRestartBindingSurvivesPublicPathSwapAndCleansStage(t *testing
 		t.Fatal("Darwin hardlink ctime exception did not preserve exact stable evidence")
 	}
 	stagePath := bound.executionPath
-	stageDir := bound.stageDir
+	stageDir := filepath.Dir(stagePath)
 
 	binaryB, err := os.ReadFile("/usr/bin/false")
 	if err != nil {

--- a/internal/cli/wake_restart_e2e_unix_test.go
+++ b/internal/cli/wake_restart_e2e_unix_test.go
@@ -1,0 +1,231 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildVersionedWakeRestartBinary(
+	t *testing.T,
+	repoRoot, destination, version string,
+) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(
+		ctx,
+		"go", "build",
+		"-ldflags", "-X main.version="+version,
+		"-o", destination,
+		"./cmd/amq",
+	)
+	cmd.Dir = repoRoot
+	cmd.Env = wakeABICleanEnv()
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("build %s timed out: %v\n%s", version, ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("build %s: %v\n%s", version, err, output)
+	}
+}
+
+func runWakeRestartPTYCommand(t *testing.T, binary string, args ...string) string {
+	t.Helper()
+	null, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = null.Close() }()
+	cmd := exec.Command(binary, args...)
+	cmd.Env = os.Environ()
+	cmd.Stdin = null
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run %s %v from non-TTY owner child: %v\n%s", binary, args, err, output)
+	}
+	return string(output)
+}
+
+func readWakeRestartPTYDoorbell(t *testing.T, label string) {
+	t.Helper()
+	type result struct {
+		text string
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		var observed strings.Builder
+		buffer := make([]byte, 512)
+		for observed.Len() < 16*1024 {
+			n, err := os.Stdin.Read(buffer)
+			if n > 0 {
+				_, _ = observed.Write(buffer[:n])
+				if strings.Contains(observed.String(), coopWakeDoorbell) &&
+					strings.Count(observed.String(), "\n") >= 3 {
+					resultCh <- result{text: observed.String()}
+					return
+				}
+			}
+			if err != nil {
+				resultCh <- result{text: observed.String(), err: err}
+				return
+			}
+		}
+		resultCh <- result{text: observed.String(), err: fmt.Errorf("doorbell input exceeded bound")}
+	}()
+	select {
+	case got := <-resultCh:
+		if got.err != nil {
+			t.Fatalf("read %s doorbell: %v; input=%q", label, got.err, got.text)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out reading %s doorbell from owning PTY", label)
+	}
+}
+
+func TestWakeRestartRealPTYOwnerHelper(t *testing.T) {
+	if os.Getenv(wakeRestartPTYOwnerHelperEnv) == "" {
+		t.Skip("external PTY owner helper")
+	}
+	if !wakeInputIsTTY() {
+		t.Fatal("restart owner helper stdin is not the retained PTY")
+	}
+	root := os.Getenv("AMQ_E2E_ROOT")
+	oldBinary := os.Getenv("AMQ_E2E_OLD")
+	newBinary := os.Getenv("AMQ_E2E_NEW")
+	oldVersion := os.Getenv("AMQ_E2E_OLD_VERSION")
+	newVersion := os.Getenv("AMQ_E2E_NEW_VERSION")
+	if root == "" || oldBinary == "" || newBinary == "" || oldVersion == "" || newVersion == "" {
+		t.Fatal("restart owner helper environment is incomplete")
+	}
+	oldBinary, err := filepath.EvalSymlinks(oldBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newBinary, err = filepath.EvalSymlinks(newBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := inspectWakeLock(root, "codex")
+	if !before.Exists || before.Status != wakeLockValid || !before.IdentityConfirmed ||
+		before.Lock.ImagePath != oldBinary || before.Lock.ImageVersion != oldVersion ||
+		before.Lock.WakeMode != wakeInjectModeRaw {
+		t.Fatalf("initial wake = %#v", before)
+	}
+	prepared, err := validateWakePreparedFileAgainstInspection(root, "codex", before)
+	if err != nil || !prepared {
+		t.Fatalf("initial prepared proof = %v, err=%v", prepared, err)
+	}
+
+	runWakeRestartPTYCommand(
+		t,
+		newBinary,
+		"send", "--root", root, "--me", "user", "--to", "codex",
+		"--subject", "pre-restart", "--body", "before",
+	)
+	readWakeRestartPTYDoorbell(t, "pre-restart")
+	// The fixed payload arrives before the final submit/rescue bytes. Let the
+	// synchronous raw-delivery state settle before asking for a quiescent exec.
+	time.Sleep(500 * time.Millisecond)
+
+	restartOutput := runWakeRestartPTYCommand(
+		t,
+		newBinary,
+		"wake", "restart", "--root", root, "--me", "codex", "--json",
+	)
+	if !strings.Contains(restartOutput, `"status": "restarted"`) {
+		t.Fatalf("restart result = %s", restartOutput)
+	}
+	after := inspectWakeLock(root, "codex")
+	requestedImage, err := captureWakeImageEvidence(newBinary, newVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.Exists || after.Status != wakeLockValid || !after.IdentityConfirmed ||
+		after.PID != before.PID || after.Lock.Generation == before.Lock.Generation ||
+		after.Lock.ImageVersion != newVersion ||
+		after.Lock.RunningImageEvidence == nil ||
+		after.Lock.ImagePath != after.Lock.RunningImageEvidence.ExecutionPath ||
+		!sameRequestedAndBoundWakeImageEvidence(requestedImage, *after.Lock.RunningImageEvidence) {
+		t.Fatalf("restarted wake before=%#v after=%#v", before, after)
+	}
+	prepared, err = validateWakePreparedFileAgainstInspection(root, "codex", after)
+	if err != nil || !prepared {
+		t.Fatalf("restarted prepared proof = %v, err=%v", prepared, err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "agents", "codex", wakeRestartFileName)); !os.IsNotExist(err) {
+		t.Fatalf("ready restart record survived: %v", err)
+	}
+	readWakeRestartPTYDoorbell(t, "pre-restart redelivery")
+
+	firstRestartImagePath := after.Lock.ImagePath
+	secondRestartOutput := runWakeRestartPTYCommand(
+		t,
+		newBinary,
+		"wake", "restart", "--root", root, "--me", "codex", "--json",
+	)
+	if !strings.Contains(secondRestartOutput, `"status": "restarted"`) {
+		t.Fatalf("second restart result = %s", secondRestartOutput)
+	}
+	second := inspectWakeLock(root, "codex")
+	if !second.Exists || second.Status != wakeLockValid || !second.IdentityConfirmed ||
+		second.PID != after.PID || second.Lock.Generation == after.Lock.Generation ||
+		second.Lock.ImageVersion != newVersion || second.Lock.RunningImageEvidence == nil ||
+		second.Lock.ImagePath != second.Lock.RunningImageEvidence.ExecutionPath ||
+		!sameRequestedAndBoundWakeImageEvidence(requestedImage, *second.Lock.RunningImageEvidence) {
+		t.Fatalf("second restarted wake first=%#v second=%#v", after, second)
+	}
+	prepared, err = validateWakePreparedFileAgainstInspection(root, "codex", second)
+	if err != nil || !prepared {
+		t.Fatalf("second restarted prepared proof = %v, err=%v", prepared, err)
+	}
+	if runtime.GOOS == "darwin" {
+		if _, err := os.Lstat(firstRestartImagePath); !os.IsNotExist(err) {
+			t.Fatalf("first Darwin restart stage survived the second prepared restart: %v", err)
+		}
+		stagePattern := filepath.Join(
+			filepath.Dir(newBinary),
+			"."+filepath.Base(newBinary)+".amq-restart-*",
+		)
+		stages, globErr := filepath.Glob(stagePattern)
+		if globErr != nil || len(stages) != 1 || filepath.Dir(second.Lock.ImagePath) != stages[0] {
+			t.Fatalf("Darwin restart stages after second restart = %v, err=%v", stages, globErr)
+		}
+	}
+	after = second
+
+	runWakeRestartPTYCommand(
+		t,
+		newBinary,
+		"send", "--root", root, "--me", "user", "--to", "codex",
+		"--subject", "post-restart", "--body", "after",
+	)
+	readWakeRestartPTYDoorbell(t, "post-restart")
+	drained := runWakeRestartPTYCommand(
+		t,
+		newBinary,
+		"drain", "--root", root, "--me", "codex", "--include-body",
+	)
+	if !strings.Contains(drained, "Subject: pre-restart") ||
+		!strings.Contains(drained, "Subject: post-restart") {
+		t.Fatalf("restart drain did not retain both cohorts:\n%s", drained)
+	}
+	fmt.Printf(
+		"AMQ_RESTART_HELPER_OK pid=%d old_generation=%s new_generation=%s image=%s prepared=true restarts=2\n",
+		after.PID,
+		before.Lock.Generation,
+		after.Lock.Generation,
+		after.Lock.ImagePath,
+	)
+}

--- a/internal/cli/wake_restart_linux_test.go
+++ b/internal/cli/wake_restart_linux_test.go
@@ -1,0 +1,208 @@
+//go:build linux
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const wakeRestartBoundExecHelperEnv = "AMQ_TEST_WAKE_RESTART_BOUND_EXEC"
+
+func TestLinuxWakeRestartBoundPayload(t *testing.T) {
+	if os.Getenv(wakeRestartBoundExecHelperEnv) != "payload" {
+		t.Skip("bound-image payload helper")
+	}
+	_, _ = os.Stdout.WriteString("BOUND_IMAGE_A\n")
+}
+
+func TestLinuxWakeRestartBoundExecHelper(t *testing.T) {
+	if os.Getenv(wakeRestartBoundExecHelperEnv) != "exec" {
+		t.Skip("bound-image exec helper")
+	}
+	env := setEnvVar(os.Environ(), wakeRestartBoundExecHelperEnv, "payload")
+	err := syscall.Exec(
+		"/proc/self/fd/3",
+		[]string{"bound-amq", "-test.run=^TestLinuxWakeRestartBoundPayload$"},
+		env,
+	)
+	t.Fatalf("exec bound image: %v", err)
+}
+
+func TestLinuxWakeRestartBindingSurvivesPublicPathSwap(t *testing.T) {
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binaryA, err := os.ReadFile(testBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	publicPath := filepath.Join(dir, "amq")
+	if err := os.WriteFile(publicPath, binaryA, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := captureWakeImageEvidence(publicPath, "bound-swap-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, err := bindWakeRestartCandidate(candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := bound.close(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	preflight := exec.Command("/proc/self/fd/3", "-test.run=^TestLinuxWakeRestartBoundPayload$")
+	preflight.ExtraFiles = []*os.File{bound.file}
+	preflight.Env = setEnvVar(os.Environ(), wakeRestartBoundExecHelperEnv, "payload")
+	if output, err := preflight.CombinedOutput(); err != nil || !strings.Contains(string(output), "BOUND_IMAGE_A") {
+		t.Fatalf("execute bound preflight image: err=%v output=%q", err, output)
+	}
+
+	binaryB, err := os.ReadFile("/usr/bin/false")
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := filepath.Join(dir, "amq.replacement")
+	if err := os.WriteFile(replacement, binaryB, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, publicPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command(publicPath).Run(); err == nil {
+		t.Fatal("normal public path still executed image A after atomic replacement")
+	}
+
+	helper := exec.Command(testBinary, "-test.run=^TestLinuxWakeRestartBoundExecHelper$")
+	helper.ExtraFiles = []*os.File{bound.file}
+	helper.Env = setEnvVar(os.Environ(), wakeRestartBoundExecHelperEnv, "exec")
+	output, err := helper.CombinedOutput()
+	if err != nil || !strings.Contains(string(output), "BOUND_IMAGE_A") {
+		t.Fatalf("execute parent-FD-bound image after swap: err=%v output=%q", err, output)
+	}
+}
+
+func TestLinuxWakeRestartRealPTYPreservesPIDAndUnreadWork(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real Linux PTY restart E2E")
+	}
+	legacyTIOCSTI, err := os.ReadFile("/proc/sys/dev/tty/legacy_tiocsti")
+	if err != nil {
+		t.Skipf("raw PTY restart E2E requires readable legacy_tiocsti opt-in: %v", err)
+	}
+	if strings.TrimSpace(string(legacyTIOCSTI)) != "1" {
+		t.Skip("raw PTY restart E2E requires /proc/sys/dev/tty/legacy_tiocsti=1")
+	}
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve restart test source path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
+	temp := t.TempDir()
+	oldDir := filepath.Join(temp, "old")
+	newDir := filepath.Join(temp, "new")
+	if err := os.MkdirAll(oldDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(newDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldBinary := filepath.Join(oldDir, "amq")
+	newBinary := filepath.Join(newDir, "amq")
+	const oldVersion = "0.56.0-e2e-old"
+	const newVersion = "0.56.0-e2e-new"
+	buildVersionedWakeRestartBinary(t, repoRoot, oldBinary, oldVersion)
+	buildVersionedWakeRestartBinary(t, repoRoot, newBinary, newVersion)
+
+	root := filepath.Join(temp, "root")
+	initCmd := exec.Command(oldBinary, "init", "--root", root, "--agents", "codex")
+	initCmd.Env = wakeABICleanEnv()
+	if output, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("init Linux restart E2E: %v\n%s", err, output)
+	}
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerCommand := []string{
+		oldBinary,
+		"coop", "exec",
+		"--root", root,
+		"--me", "codex",
+		"--require-wake",
+		"--wake-inject-mode", "raw",
+		testBinary,
+		"-test.run=^TestWakeRestartRealPTYOwnerHelper$",
+	}
+	quoted := make([]string, 0, len(ownerCommand))
+	for _, arg := range ownerCommand {
+		quoted = append(quoted, wakeABIShellQuoteArg(arg))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(
+		ctx,
+		"/usr/bin/script",
+		"-q", "-e", "-c", strings.Join(quoted, " "),
+		"/dev/null",
+	)
+	cmd.Env = wakeABICleanEnv(
+		wakeRestartPTYOwnerHelperEnv+"=1",
+		"AMQ_E2E_ROOT="+root,
+		"AMQ_E2E_OLD="+oldBinary,
+		"AMQ_E2E_NEW="+newBinary,
+		"AMQ_E2E_OLD_VERSION="+oldVersion,
+		"AMQ_E2E_NEW_VERSION="+newVersion,
+	)
+	ptyInput, keepPTYInputOpen, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ptyInput.Close() }()
+	defer func() { _ = keepPTYInputOpen.Close() }()
+	cmd.Stdin = ptyInput
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("Linux restart PTY E2E timed out: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("Linux restart PTY E2E: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "AMQ_RESTART_HELPER_OK") {
+		t.Fatalf("Linux restart PTY helper proof missing:\n%s", output)
+	}
+
+	agentPath := filepath.Join(root, "agents", "codex")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		remaining := make([]string, 0, 3)
+		for _, name := range []string{".wake.lock", ".wake.prepared", ".wake.restart"} {
+			if _, statErr := os.Lstat(filepath.Join(agentPath, name)); statErr == nil {
+				remaining = append(remaining, name)
+			} else if !os.IsNotExist(statErr) {
+				t.Fatal(statErr)
+			}
+		}
+		if len(remaining) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Linux wake lifecycle files survived owner exit: %v", remaining)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -1,0 +1,1036 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	envWakeResumeBootstrap     = "AMQ_WAKE_RESUME_BOOTSTRAP"
+	envWakeResumePreflight     = "AMQ_WAKE_RESUME_PREFLIGHT"
+	wakeResumePreflightFlag    = "wake-resume-preflight"
+	wakeResumePreflightOK      = "wake-resume-preflight-ok"
+	wakeResumePreflightTimeout = 5 * time.Second
+	wakeRestartFileName        = ".wake.restart"
+	wakeRestartSchemaV1        = 1
+	wakeRestartPending         = "pending"
+	wakeRestartRefused         = "refused"
+	wakeRestartWaitTimeout     = 15 * time.Second
+)
+
+type wakeRestartRecord struct {
+	Schema             int                  `json:"schema"`
+	RequestID          string               `json:"request_id"`
+	Status             string               `json:"status"`
+	Root               string               `json:"root"`
+	Agent              string               `json:"agent"`
+	Generation         string               `json:"generation"`
+	Owner              wakeOwner            `json:"owner"`
+	Candidate          wakeImageEvidenceV1  `json:"candidate"`
+	PreviousBoundImage *wakeImageEvidenceV1 `json:"previous_bound_image,omitempty"`
+	Reason             string               `json:"reason,omitempty"`
+}
+
+type wakeResumeBootstrap struct {
+	Schema             int                  `json:"schema"`
+	RequestID          string               `json:"request_id"`
+	Generation         string               `json:"generation"`
+	BoundImage         *wakeImageEvidenceV1 `json:"bound_image,omitempty"`
+	PreviousBoundImage *wakeImageEvidenceV1 `json:"previous_bound_image,omitempty"`
+}
+
+type wakeRestartResult struct {
+	Status             string `json:"status"`
+	Agent              string `json:"agent"`
+	Root               string `json:"root"`
+	PID                int    `json:"pid,omitempty"`
+	PreviousGeneration string `json:"previous_generation,omitempty"`
+	Generation         string `json:"generation,omitempty"`
+	Reason             string `json:"reason,omitempty"`
+}
+
+type wakeRestartReadiness struct {
+	Prepared     bool
+	Record       wakeRestartRecord
+	RecordExists bool
+}
+
+var (
+	wakeRestartNow            = time.Now
+	wakeRestartSleep          = time.Sleep
+	wakeRestartSignal         = func(process *os.Process) error { return process.Signal(syscall.SIGUSR1) }
+	wakeRestartExec           = syscall.Exec
+	wakeRestartPreflight      = preflightWakeRestartCandidate
+	wakeRestartBind           = bindWakeRestartCandidate
+	wakeRestartBoundPreflight = preflightBoundWakeRestartCandidate
+)
+
+func runWakeRestart(args []string) error {
+	fs := flag.NewFlagSet("wake restart", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	usage := usageWithFlags(
+		fs,
+		"amq wake restart --me <agent> [options]",
+		"Ask a live owner-bound wake to replace itself without a caller TTY.",
+		"",
+		"The existing wake keeps its terminal and PID, validates a fresh AMQ image,",
+		"then execs that image only from a quiescent delivery boundary.",
+	)
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if err := requireMe(common.Me); err != nil {
+		return err
+	}
+	me, err := normalizeHandle(common.Me)
+	if err != nil {
+		return UsageError("--me: %v", err)
+	}
+	root := canonicalWakeRoot(resolveRoot(common.Root))
+	if err := validateKnownHandles(root, common.Strict, me); err != nil {
+		return err
+	}
+
+	result, restartErr := requestWakeRestart(root, me)
+	if common.JSON {
+		if err := writeJSON(os.Stdout, result); err != nil {
+			return err
+		}
+		return restartErr
+	}
+	line := fmt.Sprintf("wake restart: %s agent=%s root=%s", result.Status, result.Agent, result.Root)
+	if result.PID > 0 {
+		line += fmt.Sprintf(" pid=%d", result.PID)
+	}
+	if result.Generation != "" {
+		line += " generation=" + result.Generation
+	}
+	if result.Reason != "" {
+		line += " reason=" + result.Reason
+	}
+	if err := writeStdoutLine(line); err != nil {
+		return err
+	}
+	return restartErr
+}
+
+func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr error) {
+	result = wakeRestartResult{Status: "refused", Agent: me, Root: root}
+	defer func() {
+		if returnErr != nil {
+			result.Reason = wakeRestartReasonWithRemedy(result.Reason, root, me)
+		}
+	}()
+	owner, err := wakeOwnerFromEnv()
+	if err != nil {
+		result.Reason = err.Error()
+		return result, err
+	}
+	if owner == nil {
+		err := fmt.Errorf("wake restart requires the exact coop owner environment")
+		result.Reason = err.Error()
+		return result, err
+	}
+	candidate, err := captureCurrentWakeImageEvidence()
+	if err != nil {
+		result.Reason = err.Error()
+		return result, err
+	}
+	requestID, err := newWakeRestartRequestID()
+	if err != nil {
+		result.Reason = err.Error()
+		return result, err
+	}
+
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		result.Reason = err.Error()
+		return result, err
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	var expected wakeLockInspection
+	record := wakeRestartRecord{
+		Schema:    wakeRestartSchemaV1,
+		RequestID: requestID,
+		Status:    wakeRestartPending,
+		Root:      root,
+		Agent:     me,
+		Owner:     *owner,
+		Candidate: candidate,
+	}
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		expected = inspectWakeLockAt(dirfd, agentDir, root, me)
+		if err := validateWakeRestartIncumbent(expected, root, me, *owner); err != nil {
+			return err
+		}
+		if existing, exists, err := readWakeRestartRecordAt(dirfd, agentDir); err != nil {
+			return err
+		} else if exists && existing.Status == wakeRestartPending {
+			if existing.Generation == expected.Lock.Generation {
+				return fmt.Errorf("wake restart is already pending for generation %s", existing.Generation)
+			}
+			if err := removeWakeRestartRecordAt(dirfd, "stale wake restart request"); err != nil {
+				return err
+			}
+		}
+		if err := validateWakeRestartArgv(expected.Lock.Args, root, me); err != nil {
+			return err
+		}
+		record.Generation = expected.Lock.Generation
+		record.PreviousBoundImage = previousDarwinWakeRestartStageForLock(expected.Lock)
+		bootstrap := wakeResumeBootstrap{
+			Schema:             wakeRestartSchemaV1,
+			RequestID:          record.RequestID,
+			Generation:         record.Generation,
+			PreviousBoundImage: record.PreviousBoundImage,
+		}
+		if err := wakeRestartPreflight(candidate, expected.Lock.Args, bootstrap); err != nil {
+			return fmt.Errorf("wake restart candidate preflight failed: %w", err)
+		}
+		if err := writeWakeRestartRecordAt(dirfd, agentDir, record); err != nil {
+			return err
+		}
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
+			return fmt.Errorf("wake changed while publishing restart request")
+		}
+		return nil
+	})
+	if err != nil {
+		result.Reason = err.Error()
+		return result, err
+	}
+	result.PID = expected.PID
+	result.PreviousGeneration = expected.Lock.Generation
+
+	process, err := os.FindProcess(expected.PID)
+	if err != nil {
+		_ = refuseWakeRestartRecord(agentDir, record, err.Error())
+		result.Reason = err.Error()
+		return result, err
+	}
+	// Close the publication-to-signal gap with one final exact identity read.
+	// A changed PID start, boot, or generation is a refusal, never a signal to
+	// the newly occupying process.
+	currentBeforeSignal := inspectWakeLock(root, me)
+	if !sameWakeLockInspection(expected, currentBeforeSignal) ||
+		!currentBeforeSignal.IdentityConfirmed {
+		err := fmt.Errorf("wake changed before restart signal")
+		_ = refuseWakeRestartRecord(agentDir, record, err.Error())
+		result.Reason = err.Error()
+		return result, err
+	}
+	if err := wakeRestartSignal(process); err != nil {
+		_ = refuseWakeRestartRecord(agentDir, record, err.Error())
+		result.Reason = err.Error()
+		return result, err
+	}
+
+	deadline := wakeRestartNow().Add(wakeRestartWaitTimeout)
+	for wakeRestartNow().Before(deadline) {
+		current := inspectWakeLock(root, me)
+		if current.Exists && current.Status == wakeLockValid && current.IdentityConfirmed &&
+			current.PID == expected.PID && current.Lock.Generation != expected.Lock.Generation {
+			if current.Lock.RunningImageEvidence == nil ||
+				!sameRequestedAndBoundWakeImageEvidence(candidate, *current.Lock.RunningImageEvidence) ||
+				current.Lock.ImagePath != current.Lock.RunningImageEvidence.ExecutionPath ||
+				current.Lock.ImageVersion != candidate.EmbeddedVersion {
+				err := fmt.Errorf("restarted wake generation does not match the requested candidate")
+				result.Reason = err.Error()
+				return result, err
+			}
+			readiness, readinessErr := observeWakeRestartReadinessInDir(
+				agentDir,
+				root,
+				me,
+				current,
+			)
+			if readinessErr != nil {
+				result.Reason = readinessErr.Error()
+				return result, readinessErr
+			}
+			if readiness.Prepared && !readiness.RecordExists {
+				result.Status = "restarted"
+				result.Generation = current.Lock.Generation
+				result.Reason = ""
+				return result, nil
+			}
+		}
+		var observed wakeRestartRecord
+		var exists bool
+		readErr := agentDir.withFD(func(dirfd int) error {
+			var err error
+			observed, exists, err = readWakeRestartRecordAt(dirfd, agentDir)
+			return err
+		})
+		if readErr != nil {
+			result.Reason = readErr.Error()
+			return result, readErr
+		}
+		if exists && observed.RequestID == requestID && observed.Status == wakeRestartRefused {
+			err := fmt.Errorf("wake restart refused: %s", observed.Reason)
+			result.Reason = observed.Reason
+			return result, err
+		}
+		if (!exists || observed.RequestID != requestID) &&
+			(!current.Exists || current.Lock.Generation == expected.Lock.Generation) {
+			err := fmt.Errorf("wake restart request disappeared before generation change")
+			result.Reason = err.Error()
+			return result, err
+		}
+		wakeRestartSleep(25 * time.Millisecond)
+	}
+	err = fmt.Errorf("wake restart did not complete within %s", wakeRestartWaitTimeout)
+	result.Reason = err.Error()
+	return result, err
+}
+
+func newWakeRestartRequestID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate wake restart request id: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+func wakeRestartCheckCommand(root, me string) string {
+	return fmt.Sprintf(
+		"amq wake check --root %s --me %s --json --json-schema=2",
+		shellQuoteArg(root),
+		shellQuoteArg(me),
+	)
+}
+
+func wakeRestartReasonWithRemedy(reason, root, me string) string {
+	reason = strings.TrimSpace(reason)
+	remedy := wakeRestartCheckCommand(root, me)
+	if strings.Contains(reason, remedy) {
+		return reason
+	}
+	if reason == "" {
+		return "inspect restart state with " + remedy
+	}
+	return reason + "; inspect restart state with " + remedy
+}
+
+func previousDarwinWakeRestartStage(evidence *wakeImageEvidenceV1) *wakeImageEvidenceV1 {
+	if evidence == nil || !validPreviousWakeRestartBoundImagePlatform(*evidence) {
+		return nil
+	}
+	value := *evidence
+	return &value
+}
+
+func previousDarwinWakeRestartStageForLock(lock wakeLock) *wakeImageEvidenceV1 {
+	if lock.RunningImageEvidence == nil ||
+		lock.ImagePath != lock.RunningImageEvidence.ExecutionPath {
+		return nil
+	}
+	return previousDarwinWakeRestartStage(lock.RunningImageEvidence)
+}
+
+func sameOptionalWakeImageEvidence(first, second *wakeImageEvidenceV1) bool {
+	if first == nil || second == nil {
+		return first == nil && second == nil
+	}
+	return *first == *second
+}
+
+func sameWakeRestartRecord(first, second wakeRestartRecord) bool {
+	if !sameOptionalWakeImageEvidence(first.PreviousBoundImage, second.PreviousBoundImage) {
+		return false
+	}
+	first.PreviousBoundImage = nil
+	second.PreviousBoundImage = nil
+	return first == second
+}
+
+func validateWakeRestartIncumbent(
+	inspection wakeLockInspection,
+	root, me string,
+	owner wakeOwner,
+) error {
+	if !inspection.Exists || inspection.Status != wakeLockValid || !inspection.IdentityConfirmed ||
+		!inspection.Process.Running {
+		return fmt.Errorf("wake is not a live identity-confirmed process")
+	}
+	if inspection.Root != root || inspection.Agent != me {
+		return fmt.Errorf("wake restart scope does not match")
+	}
+	if err := validateWakeResumeAdvertisement(inspection.Lock, root, me); err != nil {
+		return fmt.Errorf("wake does not advertise restart support: %w", err)
+	}
+	if inspection.Lock.ResumeSignal != wakeResumeSignalUSR1 {
+		return fmt.Errorf("wake does not advertise direct SIGUSR1 restart support")
+	}
+	if inspection.Lock.ResumeOwner == nil || !sameWakeOwner(inspection.Lock.ResumeOwner, &owner) {
+		return fmt.Errorf("wake restart caller is not the exact coop owner")
+	}
+	if err := wakeOwnerHealthCheck(owner); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateWakeRestartArgv(argv []string, root, me string) error {
+	if len(argv) < 2 || !processArgsLookLikeWake(argv) || !wakeArgsMatchRootAgent(argv, root, me) {
+		return fmt.Errorf("wake restart cannot recover the exact original wake argv")
+	}
+	for _, arg := range argv {
+		switch {
+		case arg == "--repair-lineage" || strings.HasPrefix(arg, "--repair-lineage="),
+			arg == "--inject-via" || strings.HasPrefix(arg, "--inject-via="),
+			arg == "--inject-cmd" || strings.HasPrefix(arg, "--inject-cmd="),
+			arg == "--"+wakeResumePreflightFlag || strings.HasPrefix(arg, "--"+wakeResumePreflightFlag+"="),
+			arg == "--interrupt-cmd=ctrl-c":
+			return fmt.Errorf("wake restart refuses non-ordinary wake argv")
+		}
+	}
+	return nil
+}
+
+func preflightWakeRestartCandidate(
+	candidate wakeImageEvidenceV1,
+	argv []string,
+	bootstrap wakeResumeBootstrap,
+) error {
+	before, err := captureWakeImageEvidence(candidate.ExecutionPath, candidate.EmbeddedVersion)
+	if err != nil {
+		return err
+	}
+	if !sameWakeImageEvidence(before, candidate) {
+		return fmt.Errorf("wake restart candidate changed before preflight")
+	}
+	if len(argv) == 0 {
+		return fmt.Errorf("wake restart argv is empty")
+	}
+	encodedBootstrap, err := encodeWakeResumeBootstrap(bootstrap)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), wakeResumePreflightTimeout)
+	defer cancel()
+	preflightArgs := append(append([]string(nil), argv[1:]...), "--"+wakeResumePreflightFlag)
+	cmd := exec.CommandContext(ctx, candidate.ExecutionPath, preflightArgs...)
+	cmd.Env = setEnvVar(
+		unsetEnvVar(unsetEnvVar(os.Environ(), envWakeResumeBootstrap), envWakeResumePreflight),
+		envWakeResumePreflight,
+		encodedBootstrap,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("wake resume preflight timed out: %w", ctx.Err())
+		}
+		return err
+	}
+	if strings.TrimSpace(string(out)) != wakeResumePreflightOK {
+		return fmt.Errorf("wake restart candidate did not confirm exact wake argv and bootstrap")
+	}
+	after, err := captureWakeImageEvidence(candidate.ExecutionPath, candidate.EmbeddedVersion)
+	if err != nil {
+		return err
+	}
+	if !sameWakeImageEvidence(after, candidate) {
+		return fmt.Errorf("wake restart candidate changed during preflight")
+	}
+	return nil
+}
+
+func sameWakeImageEvidence(first, second wakeImageEvidenceV1) bool {
+	return first == second
+}
+
+func validateWakeRestartRecord(record wakeRestartRecord) error {
+	if record.Schema != wakeRestartSchemaV1 {
+		return fmt.Errorf("wake restart schema %d unsupported", record.Schema)
+	}
+	if !validWakeReloadTransportGeneration(record.RequestID) ||
+		!validWakeReloadTransportGeneration(record.Generation) {
+		return fmt.Errorf("wake restart request or generation is malformed")
+	}
+	if record.Status != wakeRestartPending && record.Status != wakeRestartRefused {
+		return fmt.Errorf("wake restart status is invalid")
+	}
+	if record.Status == wakeRestartPending && record.Reason != "" {
+		return fmt.Errorf("pending wake restart contains a refusal reason")
+	}
+	if record.Status == wakeRestartRefused && strings.TrimSpace(record.Reason) == "" {
+		return fmt.Errorf("refused wake restart has no reason")
+	}
+	if record.Root == "" || !filepath.IsAbs(record.Root) || canonicalWakeRoot(record.Root) != record.Root {
+		return fmt.Errorf("wake restart root is invalid")
+	}
+	if err := fsq.ValidateHandle(record.Agent); err != nil {
+		return fmt.Errorf("wake restart agent is invalid: %w", err)
+	}
+	if err := validateAuthoritativeWakeOwner(record.Owner); err != nil {
+		return fmt.Errorf("wake restart owner is invalid: %w", err)
+	}
+	if err := validateWakeImageEvidence(record.Candidate); err != nil {
+		return fmt.Errorf("wake restart candidate is invalid: %w", err)
+	}
+	if record.PreviousBoundImage != nil {
+		if err := validateWakeImageEvidence(*record.PreviousBoundImage); err != nil {
+			return fmt.Errorf("previous bound wake image is invalid: %w", err)
+		}
+		if previousDarwinWakeRestartStage(record.PreviousBoundImage) == nil {
+			return fmt.Errorf("previous bound wake image is not a Darwin restart stage")
+		}
+	}
+	return nil
+}
+
+func wakeRestartPath(agentDir *wakeAgentDir) string {
+	return filepath.Join(agentDir.path, wakeRestartFileName)
+}
+
+func readWakeRestartRecordAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+) (wakeRestartRecord, bool, error) {
+	raw, _, exists, err := readWakeRepairMetadataAt(
+		dirfd,
+		wakeRestartFileName,
+		"wake restart request",
+		wakeRestartPath(agentDir),
+		maxWakeMetadataFileBytes,
+	)
+	if err != nil || !exists {
+		return wakeRestartRecord{}, exists, err
+	}
+	var record wakeRestartRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		return wakeRestartRecord{}, true, fmt.Errorf("parse wake restart request: %w", err)
+	}
+	if err := validateWakeRestartRecord(record); err != nil {
+		return wakeRestartRecord{}, true, err
+	}
+	return record, true, nil
+}
+
+func observeWakeRestartReadinessInDir(
+	agentDir *wakeAgentDir,
+	root, me string,
+	expected wakeLockInspection,
+) (wakeRestartReadiness, error) {
+	var readiness wakeRestartReadiness
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		var err error
+		readiness, err = readWakeRestartReadinessAt(dirfd, agentDir, root, me, expected)
+		return err
+	})
+	return readiness, err
+}
+
+func readWakeRestartReadinessAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root, me string,
+	expected wakeLockInspection,
+) (wakeRestartReadiness, error) {
+	current := inspectWakeLockAt(dirfd, agentDir, root, me)
+	if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
+		return wakeRestartReadiness{}, fmt.Errorf("wake changed while observing restart readiness")
+	}
+	var readiness wakeRestartReadiness
+	var err error
+	readiness.Record, readiness.RecordExists, err = readWakeRestartRecordAt(dirfd, agentDir)
+	if err != nil {
+		return wakeRestartReadiness{}, err
+	}
+	readiness.Prepared, err = validateWakePreparedFileAgainstInspectionAt(
+		dirfd,
+		agentDir,
+		root,
+		me,
+		current,
+	)
+	if err != nil {
+		return wakeRestartReadiness{}, err
+	}
+	confirmedRecord, confirmedExists, err := readWakeRestartRecordAt(dirfd, agentDir)
+	if err != nil {
+		return wakeRestartReadiness{}, err
+	}
+	confirmed := inspectWakeLockAt(dirfd, agentDir, root, me)
+	if !sameWakeLockInspection(expected, confirmed) || !confirmed.IdentityConfirmed ||
+		readiness.RecordExists != confirmedExists ||
+		!sameWakeRestartRecord(readiness.Record, confirmedRecord) {
+		return wakeRestartReadiness{}, fmt.Errorf("wake restart readiness changed while observing it")
+	}
+	return readiness, nil
+}
+
+func observeWakeRestartReadiness(
+	root, me string,
+	expected wakeLockInspection,
+) (wakeRestartReadiness, error) {
+	agentDir, err := openWakeAgentDir(root, me)
+	if err != nil {
+		return wakeRestartReadiness{}, err
+	}
+	defer func() { _ = agentDir.Close() }()
+	var readiness wakeRestartReadiness
+	err = agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		readiness, readErr = readWakeRestartReadinessAt(dirfd, agentDir, root, me, expected)
+		return readErr
+	})
+	return readiness, err
+}
+
+func writeWakeRestartRecordAt(dirfd int, agentDir *wakeAgentDir, record wakeRestartRecord) error {
+	if err := validateWakeRestartRecord(record); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	return writeWakeRepairMetadataAt(
+		dirfd,
+		agentDir,
+		wakeRestartFileName,
+		"wake restart request",
+		append(raw, '\n'),
+		maxWakeMetadataFileBytes,
+	)
+}
+
+func removeWakeRestartRecordAt(dirfd int, description string) error {
+	if err := unix.Unlinkat(dirfd, wakeRestartFileName, 0); err != nil && err != unix.ENOENT {
+		return fmt.Errorf("remove %s: %w", description, err)
+	}
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync %s removal: %w", description, err)
+	}
+	return nil
+}
+
+func refuseWakeRestartRecord(agentDir *wakeAgentDir, expected wakeRestartRecord, reason string) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "restart refused"
+	}
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil || !exists {
+			return err
+		}
+		if current.RequestID != expected.RequestID || current.Generation != expected.Generation {
+			return fmt.Errorf("wake restart request changed before refusal")
+		}
+		current.Status = wakeRestartRefused
+		current.Reason = wakeRestartReasonWithRemedy(reason, current.Root, current.Agent)
+		return writeWakeRestartRecordAt(dirfd, agentDir, current)
+	})
+}
+
+func encodeWakeResumeBootstrap(value wakeResumeBootstrap) (string, error) {
+	if value.Schema != wakeRestartSchemaV1 || !validWakeReloadTransportGeneration(value.RequestID) ||
+		!validWakeReloadTransportGeneration(value.Generation) {
+		return "", fmt.Errorf("wake resume bootstrap is invalid")
+	}
+	if value.BoundImage != nil {
+		if err := validateWakeImageEvidence(*value.BoundImage); err != nil {
+			return "", fmt.Errorf("wake resume bound image is invalid: %w", err)
+		}
+	}
+	if value.PreviousBoundImage != nil {
+		if err := validateWakeImageEvidence(*value.PreviousBoundImage); err != nil {
+			return "", fmt.Errorf("wake resume previous bound image is invalid: %w", err)
+		}
+		if previousDarwinWakeRestartStage(value.PreviousBoundImage) == nil {
+			return "", fmt.Errorf("wake resume previous bound image is not a Darwin restart stage")
+		}
+	}
+	if value.BoundImage != nil && value.PreviousBoundImage != nil &&
+		value.BoundImage.ExecutionPath == value.PreviousBoundImage.ExecutionPath {
+		return "", fmt.Errorf("wake resume previous and replacement images use the same execution path")
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func wakeResumeBootstrapFromEnv() (*wakeResumeBootstrap, error) {
+	return wakeResumeBootstrapFromEnvName(envWakeResumeBootstrap)
+}
+
+func wakeResumePreflightFromEnv() (*wakeResumeBootstrap, error) {
+	return wakeResumeBootstrapFromEnvName(envWakeResumePreflight)
+}
+
+func wakeResumeBootstrapFromEnvName(name string) (*wakeResumeBootstrap, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return nil, nil
+	}
+	if err := os.Unsetenv(name); err != nil {
+		return nil, err
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode wake resume bootstrap: %w", err)
+	}
+	var value wakeResumeBootstrap
+	if err := json.Unmarshal(decoded, &value); err != nil {
+		return nil, fmt.Errorf("parse wake resume bootstrap: %w", err)
+	}
+	if _, err := encodeWakeResumeBootstrap(value); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func acquireWakeLockAfterResumeInDir(
+	agentDir *wakeAgentDir,
+	root, me string,
+	options wakeLockAcquireOptions,
+	bootstrap wakeResumeBootstrap,
+) (func(), error) {
+	var created wakeLockInspection
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !current.Exists || current.Status != wakeLockValid || !current.IdentityConfirmed ||
+			current.PID != os.Getpid() || current.Lock.Generation != bootstrap.Generation {
+			return fmt.Errorf("wake resume incumbent identity changed")
+		}
+		if err := validateWakeResumeAdvertisement(current.Lock, root, me); err != nil {
+			return err
+		}
+		record, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists || record.Status != wakeRestartPending || record.RequestID != bootstrap.RequestID ||
+			record.Generation != bootstrap.Generation || current.Lock.ResumeOwner == nil ||
+			!sameWakeOwner(current.Lock.ResumeOwner, &record.Owner) {
+			return fmt.Errorf("wake resume request does not match the incumbent")
+		}
+		if options.requestedOwner == nil || !sameWakeOwner(options.requestedOwner, &record.Owner) {
+			return fmt.Errorf("wake resume owner environment changed")
+		}
+		if !sameOptionalWakeImageEvidence(record.PreviousBoundImage, bootstrap.PreviousBoundImage) ||
+			!sameOptionalWakeImageEvidence(
+				record.PreviousBoundImage,
+				previousDarwinWakeRestartStageForLock(current.Lock),
+			) {
+			return fmt.Errorf("wake resume previous bound image does not match the incumbent")
+		}
+		if bootstrap.BoundImage == nil || options.resumeImageEvidence == nil ||
+			!sameDarwinStagedWakeImageEvidence(*options.resumeImageEvidence, *bootstrap.BoundImage) ||
+			!sameRequestedAndBoundWakeImageEvidence(record.Candidate, *bootstrap.BoundImage) {
+			return fmt.Errorf("wake resume bound image does not match the requested candidate")
+		}
+		lock, err := newWakeLock(root, me, options)
+		if err != nil {
+			return err
+		}
+		if lock.PID != current.PID || lock.ProcessStart != current.Lock.ProcessStart ||
+			compareWakeBootID(current.Lock.BootID, lockProcessInfo(lock)) != bootIDMatch {
+			return fmt.Errorf("wake resume did not preserve process identity")
+		}
+		if err := replaceWakeLockForResumeAt(dirfd, agentDir, current, lock); err != nil {
+			return err
+		}
+		created = inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !created.Exists || created.Status != wakeLockValid || !created.IdentityConfirmed ||
+			created.Lock.Generation != lock.Generation {
+			return fmt.Errorf("wake resume generation was not installed")
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return func() {
+		if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+			return cleanupGenericWakeGenerationAt(dirfd, agentDir, root, me, created, options)
+		}); err != nil {
+			_ = writeStderr("amq wake: cleanup failed: %v\n", err)
+		}
+	}, nil
+}
+
+func consumeWakeRestartAfterPrepared(
+	agentDir *wakeAgentDir,
+	root, me string,
+	current wakeLockInspection,
+	bootstrap wakeResumeBootstrap,
+) error {
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		observed := inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !sameWakeLockInspection(current, observed) || !observed.IdentityConfirmed ||
+			observed.PID != os.Getpid() || observed.Lock.Generation == bootstrap.Generation {
+			return fmt.Errorf("wake resume generation changed before readiness commit")
+		}
+		prepared, err := validateWakePreparedFileAgainstInspectionAt(
+			dirfd,
+			agentDir,
+			root,
+			me,
+			observed,
+		)
+		if err != nil {
+			return err
+		}
+		if !prepared {
+			return fmt.Errorf("wake resume prepared proof is not current")
+		}
+		record, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists || record.Status != wakeRestartPending ||
+			record.RequestID != bootstrap.RequestID || record.Generation != bootstrap.Generation {
+			return fmt.Errorf("wake resume request changed before readiness commit")
+		}
+		return removeWakeRestartRecordAt(dirfd, "ready wake restart request")
+	})
+}
+
+func lockProcessInfo(lock wakeLock) wakeProcessInfo {
+	return wakeProcessInfo{BootID: lock.BootID}
+}
+
+func replaceWakeLockForResumeAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+	replacement wakeLock,
+) error {
+	if replacement.Generation == "" || replacement.Generation == expected.Lock.Generation {
+		return fmt.Errorf("wake resume replacement generation is invalid")
+	}
+	raw, err := json.Marshal(replacement)
+	if err != nil {
+		return err
+	}
+	temp, err := writeWakeOwnerTempAt(dirfd, "wake-resume-lock", raw, 0o600)
+	if err != nil {
+		return err
+	}
+	tempPresent := true
+	defer func() {
+		if tempPresent {
+			_ = unix.Unlinkat(dirfd, temp, 0)
+		}
+	}()
+	current := inspectWakeLockAt(dirfd, agentDir, expected.Root, expected.Agent)
+	if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
+		return fmt.Errorf("wake resume incumbent changed before generation commit")
+	}
+	if err := unix.Renameat(dirfd, temp, dirfd, ".wake.lock"); err != nil {
+		return fmt.Errorf("commit wake resume generation: %w", err)
+	}
+	tempPresent = false
+	if err := syncWakeOwnerDirFD(dirfd); err != nil {
+		return fmt.Errorf("sync wake resume generation: %w", err)
+	}
+	installed := readWakeLockMetadataAt(dirfd, agentDir, expected.Root, expected.Agent)
+	if !installed.Exists || installed.Lock.Generation != replacement.Generation ||
+		!bytes.Equal(installed.raw, raw) {
+		return fmt.Errorf("verify wake resume generation")
+	}
+	return nil
+}
+
+func executeWakeRestart(record wakeRestartRecord, argv []string, restartSignals chan os.Signal) (returnErr error) {
+	bootstrapValue := wakeResumeBootstrap{
+		Schema:             wakeRestartSchemaV1,
+		RequestID:          record.RequestID,
+		Generation:         record.Generation,
+		PreviousBoundImage: record.PreviousBoundImage,
+	}
+	bound, err := wakeRestartBind(record.Candidate)
+	if err != nil {
+		return fmt.Errorf("bind wake restart candidate: %w", err)
+	}
+	defer func() { returnErr = errors.Join(returnErr, bound.close()) }()
+	boundEvidence := bound.evidence
+	bootstrapValue.BoundImage = &boundEvidence
+	if err := wakeRestartBoundPreflight(bound, argv, bootstrapValue); err != nil {
+		return err
+	}
+	bootstrap, err := encodeWakeResumeBootstrap(bootstrapValue)
+	if err != nil {
+		return err
+	}
+	env := setEnvVar(unsetEnvVar(os.Environ(), envWakeResumeBootstrap), envWakeResumeBootstrap, bootstrap)
+	// An ignored disposition survives exec, unlike a caught disposition. The
+	// bootstrap installs Notify before it rotates and advertises the successor
+	// generation. If exec fails, restore delivery to the incumbent loop.
+	signal.Ignore(syscall.SIGUSR1)
+	err = wakeRestartExec(bound.executionPath, append([]string(nil), argv...), env)
+	if restartSignals != nil {
+		signal.Notify(restartSignals, syscall.SIGUSR1)
+	}
+	if err != nil {
+		return fmt.Errorf("exec wake restart candidate: %w", err)
+	}
+	return fmt.Errorf("exec wake restart candidate returned without replacing the process")
+}
+
+func pendingWakeRestartForProcess(
+	agentDir *wakeAgentDir,
+	root, me string,
+	expectedGeneration string,
+	owner *wakeOwner,
+) (wakeRestartRecord, bool, error) {
+	root = canonicalWakeRoot(root)
+	var record wakeRestartRecord
+	var exists bool
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(dirfd, agentDir, root, me)
+		if !current.Exists || current.Status != wakeLockValid || !current.IdentityConfirmed ||
+			current.PID != os.Getpid() || current.Lock.Generation != expectedGeneration {
+			return fmt.Errorf("wake restart incumbent changed")
+		}
+		var err error
+		record, exists, err = readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil || !exists {
+			return err
+		}
+		if record.Status != wakeRestartPending || record.Root != root || record.Agent != me ||
+			record.Generation != expectedGeneration || owner == nil || !sameWakeOwner(owner, &record.Owner) ||
+			!sameOptionalWakeImageEvidence(
+				record.PreviousBoundImage,
+				previousDarwinWakeRestartStageForLock(current.Lock),
+			) {
+			return fmt.Errorf("wake restart request does not match this generation")
+		}
+		return nil
+	})
+	return record, exists, err
+}
+
+func classifyWakeRestartAtLoopBoundary(
+	cfg *wakeConfig,
+	watcher wakeAdmissionWatcher,
+	terminalRetry, scanRetry bool,
+) wakeResumeQuiescenceDecision {
+	state := wakeResumeQuiescence{
+		Lifecycle:             wakeResumeLifecycleAdmitted,
+		Delivery:              cfg.inputDelivery,
+		RecoveryRequired:      cfg.inputRecoveryRequired,
+		RepairLineage:         cfg.baselineInherited,
+		BaselineInherited:     cfg.baselineInherited,
+		ArbitraryInjectCmd:    strings.TrimSpace(cfg.injectCmd) != "",
+		DestructiveInterrupt:  cfg.interruptKey != "",
+		TerminalSuffixRetry:   terminalRetry,
+		ScanRetry:             scanRetry,
+		WatcherArmed:          watcher != nil,
+		ControlListenerReady:  true,
+		OwnerObservation:      wakeResumeAuthorityExact,
+		GenerationObservation: wakeResumeAuthorityExact,
+		LockTargetObservation: wakeResumeAuthorityExact,
+		CanonicalDirs:         true,
+		FinalScan:             wakeResumeScanComplete,
+		PendingDoorbell:       cfg.doorbell.pendingInput(),
+	}
+	if watcher == nil || pendingWakeWatcherError(watcher) != nil {
+		state.WatcherError = true
+	}
+	if cfg.wakeOwner == nil || wakeOwnerHealthCheck(*cfg.wakeOwner) != nil {
+		state.OwnerObservation = wakeResumeAuthorityLost
+	}
+	if cfg.inspectTerminalGeneration == nil {
+		state.GenerationObservation = wakeResumeAuthorityInconclusive
+	} else {
+		current := cfg.inspectTerminalGeneration()
+		if !current.Exists || current.Status != wakeLockValid || !current.IdentityConfirmed ||
+			current.PID != os.Getpid() || current.Lock.Generation != cfg.terminalGeneration {
+			state.GenerationObservation = wakeResumeAuthorityLost
+		}
+	}
+	if cfg.beforeTerminalWrite != nil {
+		if err := cfg.beforeTerminalWrite(); err != nil {
+			state.TerminalIdentityObservation = wakeResumeAuthorityLost
+		} else {
+			state.TerminalIdentityObservation = wakeResumeAuthorityExact
+		}
+	} else if cfg.injectMode == wakeInjectModeNone {
+		state.TerminalIdentityObservation = wakeResumeAuthorityExact
+	} else {
+		state.TerminalIdentityObservation = wakeResumeAuthorityInconclusive
+	}
+	if retained, ok := cfg.retainedAgent.(*wakeAgentDir); ok {
+		if err := validateCanonicalWakeAgentDir(retained); err != nil {
+			state.CanonicalDirs = false
+		}
+	}
+	if retained, ok := cfg.retainedInbox.(*wakeInboxDir); ok {
+		if err := retained.ValidateCanonical(); err != nil {
+			state.CanonicalDirs = false
+		}
+	}
+	if messages, err := snapshotWakeExistingMessagesForConfig(cfg); err != nil {
+		state.FinalScan = wakeResumeScanTransientFailure
+	} else {
+		state.FinalScanMessages = len(messages)
+	}
+	return classifyWakeResumeQuiescence(state)
+}
+
+func handleWakeRestartAtLoopBoundary(
+	cfg *wakeConfig,
+	watcher wakeAdmissionWatcher,
+	terminalRetry, scanRetry bool,
+) {
+	agentDir, ok := cfg.retainedAgent.(*wakeAgentDir)
+	if !ok || agentDir == nil {
+		return
+	}
+	record, exists, err := pendingWakeRestartForProcess(
+		agentDir,
+		canonicalWakeRoot(cfg.root),
+		cfg.me,
+		cfg.terminalGeneration,
+		cfg.wakeOwner,
+	)
+	if err != nil || !exists {
+		return
+	}
+	decision := classifyWakeRestartAtLoopBoundary(cfg, watcher, terminalRetry, scanRetry)
+	if decision.Disposition != wakeResumeProceed {
+		_ = refuseWakeRestartRecord(
+			agentDir,
+			record,
+			wakeRestartReasonWithRemedy(decision.Reason, cfg.root, cfg.me),
+		)
+		return
+	}
+	if err := executeWakeRestart(record, os.Args, cfg.restartSignals); err != nil {
+		_ = refuseWakeRestartRecord(
+			agentDir,
+			record,
+			wakeRestartReasonWithRemedy(err.Error(), cfg.root, cfg.me),
+		)
+	}
+}

--- a/internal/cli/wake_restart_unix_test.go
+++ b/internal/cli/wake_restart_unix_test.go
@@ -1,0 +1,981 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+type wakeRestartFixture struct {
+	root      string
+	agent     string
+	owner     wakeOwner
+	process   wakeProcessInfo
+	candidate wakeImageEvidenceV1
+	lock      wakeLockInspection
+	record    wakeRestartRecord
+	agentDir  *wakeAgentDir
+	inboxDir  *wakeInboxDir
+}
+
+func newWakeRestartFixture(t *testing.T) wakeRestartFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	ensureCoopWakeMailboxForTest(t, root, agent)
+	setCLIVersionForTest(t, "0.56.0-test")
+	candidate, err := captureCurrentWakeImageEvidence()
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner := currentAuthoritativeOwnerForCoopWakeTest(t)
+	ownerEnv, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envWakeOwner, ownerEnv)
+	realProcess := inspectWakeProcess(os.Getpid())
+	args := []string{
+		candidate.ExecutionPath,
+		"wake",
+		"--root", root,
+		"--me", agent,
+		"--inject-mode", wakeInjectModeNone,
+		"--interrupt=false",
+	}
+	process := wakeProcessInfo{
+		PID:          os.Getpid(),
+		Running:      true,
+		StartToken:   realProcess.StartToken,
+		BootID:       realProcess.BootID,
+		Executable:   "amq",
+		Args:         args,
+		InspectError: realProcess.InspectError,
+	}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == os.Getpid() {
+			return process
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	lock := wakeLock{
+		PID:                  os.Getpid(),
+		TTY:                  "test-tty",
+		Root:                 root,
+		Agent:                agent,
+		Started:              time.Now().UTC().Format(time.RFC3339),
+		ProcessStart:         process.StartToken,
+		BootID:               process.BootID,
+		Executable:           "amq",
+		Args:                 args,
+		ImagePath:            candidate.ExecutionPath,
+		ImageVersion:         candidate.EmbeddedVersion,
+		WakeMode:             wakeInjectModeNone,
+		Generation:           "0123456789abcdef0123456789abcdef",
+		ResumeSchema:         wakeResumeSchemaV2,
+		ResumeOwner:          &owner,
+		ResumeSignal:         wakeResumeSignalUSR1,
+		RunningImageEvidence: &candidate,
+	}
+	writeWakeLockForTest(t, root, agent, lock)
+	inspection := inspectWakeLock(root, agent)
+	if !inspection.IdentityConfirmed || inspection.Status != wakeLockValid {
+		t.Fatalf("fixture lock = %#v", inspection)
+	}
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	inboxDir, err := openWakeRepairInboxDir(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inboxDir.Close() })
+	record := wakeRestartRecord{
+		Schema:     wakeRestartSchemaV1,
+		RequestID:  "fedcba9876543210fedcba9876543210",
+		Status:     wakeRestartPending,
+		Root:       root,
+		Agent:      agent,
+		Generation: lock.Generation,
+		Owner:      owner,
+		Candidate:  candidate,
+	}
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return wakeRestartFixture{
+		root:      root,
+		agent:     agent,
+		owner:     owner,
+		process:   process,
+		candidate: candidate,
+		lock:      inspection,
+		record:    record,
+		agentDir:  agentDir,
+		inboxDir:  inboxDir,
+	}
+}
+
+func removeWakeRestartRecordForTest(t *testing.T, fixture wakeRestartFixture) {
+	t.Helper()
+	err := os.Remove(filepath.Join(fixture.agentDir.path, wakeRestartFileName))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+}
+
+func boundWakeImageEvidenceForTest(candidate wakeImageEvidenceV1) wakeImageEvidenceV1 {
+	bound := candidate
+	if runtime.GOOS == "linux" {
+		bound.Method = wakeImageMethodFDExec
+		bound.ExecutionPath = "/proc/self/fd/99"
+	} else {
+		bound.Method = wakeImageMethodPathnameExecVerified
+		bound.ExecutionPath = filepath.Join(filepath.Dir(candidate.ExecutionPath), ".amq.amq-restart-test", "amq")
+	}
+	return bound
+}
+
+func TestRequestedAndBoundWakeImageEvidenceHasOnlyDarwinHardlinkCTimeException(t *testing.T) {
+	candidate, err := captureCurrentWakeImageEvidence()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound := boundWakeImageEvidenceForTest(candidate)
+	if !sameRequestedAndBoundWakeImageEvidence(candidate, bound) {
+		t.Fatal("method/path-only bound image delta was rejected")
+	}
+	ctimeChanged := bound
+	ctimeChanged.CTimeNS++
+	if got := sameRequestedAndBoundWakeImageEvidence(candidate, ctimeChanged); got != (runtime.GOOS == "darwin") {
+		t.Fatalf("ctime exception accepted=%v on %s", got, runtime.GOOS)
+	}
+	mutations := []struct {
+		name   string
+		mutate func(*wakeImageEvidenceV1)
+	}{
+		{name: "device", mutate: func(value *wakeImageEvidenceV1) { value.Device++ }},
+		{name: "inode", mutate: func(value *wakeImageEvidenceV1) { value.Inode++ }},
+		{name: "size", mutate: func(value *wakeImageEvidenceV1) { value.Size++ }},
+		{name: "digest", mutate: func(value *wakeImageEvidenceV1) { value.SHA256 = strings.Repeat("0", len(value.SHA256)) }},
+		{name: "version", mutate: func(value *wakeImageEvidenceV1) { value.EmbeddedVersion += ".other" }},
+	}
+	for _, test := range mutations {
+		t.Run(test.name, func(t *testing.T) {
+			changed := bound
+			test.mutate(&changed)
+			if sameRequestedAndBoundWakeImageEvidence(candidate, changed) {
+				t.Fatalf("%s delta was accepted", test.name)
+			}
+		})
+	}
+}
+
+func TestAcquireWakeLockAfterResumeKeepsRequestUntilNewPreparedProof(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	bound := boundWakeImageEvidenceForTest(fixture.candidate)
+	if err := writeWakePreparedFileInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.lock,
+	); err != nil {
+		t.Fatal(err)
+	}
+	cleanup, err := acquireWakeLockAfterResumeInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		wakeLockAcquireOptions{
+			wakeMode:            wakeInjectModeNone,
+			requestedOwner:      &fixture.owner,
+			resumeEligible:      true,
+			resumeImageEvidence: &bound,
+		},
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  fixture.record.RequestID,
+			Generation: fixture.record.Generation,
+			BoundImage: &bound,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if !current.IdentityConfirmed || current.PID != fixture.lock.PID ||
+		current.Lock.ProcessStart != fixture.lock.Lock.ProcessStart ||
+		current.Lock.Generation == fixture.lock.Lock.Generation {
+		t.Fatalf("resumed lock = %#v", current)
+	}
+	if current.Lock.RunningImageEvidence == nil || *current.Lock.RunningImageEvidence != bound ||
+		current.Lock.ImagePath != bound.ExecutionPath ||
+		current.Lock.ImageVersion != bound.EmbeddedVersion {
+		t.Fatalf("resumed lock did not publish bound image evidence: %#v", current.Lock)
+	}
+	prepared, err := validateWakePreparedFileAgainstInspection(
+		fixture.root,
+		fixture.agent,
+		current,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared {
+		t.Fatal("old generation prepared marker remained current after resume")
+	}
+	var restartExists bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		_, restartExists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !restartExists {
+		t.Fatal("restart request was consumed before successor readiness")
+	}
+	if err := writeWakePreparedFileInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		current,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := consumeWakeRestartAfterPrepared(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		current,
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  fixture.record.RequestID,
+			Generation: fixture.record.Generation,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		_, restartExists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if restartExists {
+		t.Fatal("ready successor did not consume restart request")
+	}
+}
+
+func TestWakeRestartLoopRefusesInputDebtWithoutExec(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	execCalled := false
+	oldPreflight := wakeRestartPreflight
+	oldExec := wakeRestartExec
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error { return nil }
+	wakeRestartExec = func(string, []string, []string) error {
+		execCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartExec = oldExec
+	})
+
+	cfg := wakeConfig{
+		me:                 fixture.agent,
+		root:               fixture.root,
+		injectMode:         wakeInjectModeNone,
+		wakeOwner:          &fixture.owner,
+		terminalGeneration: fixture.lock.Lock.Generation,
+		retainedAgent:      fixture.agentDir,
+		retainedInbox:      fixture.inboxDir,
+		inputDelivery: wakeInputDeliveryState{
+			phase:         wakeInputPrimarySubmitPending,
+			acceptedBytes: 1,
+		},
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	handleWakeRestartAtLoopBoundary(&cfg, watcher, false, false)
+	if execCalled {
+		t.Fatal("restart exec ran with partial input debt")
+	}
+	record, exists, err := func() (wakeRestartRecord, bool, error) {
+		var record wakeRestartRecord
+		var exists bool
+		err := fixture.agentDir.withFD(func(dirfd int) error {
+			var err error
+			record, exists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+			return err
+		})
+		return record, exists, err
+	}()
+	if err != nil || !exists {
+		t.Fatalf("refusal record = %#v exists=%v err=%v", record, exists, err)
+	}
+	if record.Status != wakeRestartRefused ||
+		!strings.HasPrefix(record.Reason, wakeResumeReasonInputProgress+";") ||
+		!strings.Contains(record.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) {
+		t.Fatalf("refusal record = %#v", record)
+	}
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if current.Lock.Generation != fixture.lock.Lock.Generation || !current.IdentityConfirmed {
+		t.Fatalf("incumbent changed after refusal: %#v", current)
+	}
+}
+
+func TestWakeRestartExecFailureLeavesIncumbentLive(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	sentinel := errors.New("test exec failure")
+	oldBoundPreflight := wakeRestartBoundPreflight
+	oldExec := wakeRestartExec
+	wakeRestartBoundPreflight = func(got *wakeRestartBoundImage, argv []string, bootstrap wakeResumeBootstrap) error {
+		if got == nil || !sameRequestedAndBoundWakeImageEvidence(fixture.candidate, got.evidence) ||
+			!reflect.DeepEqual(argv, os.Args) {
+			t.Fatalf("restart preflight got bound=%#v argv=%#v", got, argv)
+		}
+		if bootstrap.RequestID != fixture.record.RequestID || bootstrap.Generation != fixture.record.Generation {
+			t.Fatalf("restart preflight bootstrap=%#v", bootstrap)
+		}
+		return nil
+	}
+	wakeRestartExec = func(path string, argv, _ []string) error {
+		if path == fixture.candidate.ExecutionPath || !filepath.IsAbs(path) || !reflect.DeepEqual(argv, os.Args) {
+			t.Fatalf("restart exec got path=%q argv=%#v", path, argv)
+		}
+		return sentinel
+	}
+	t.Cleanup(func() {
+		wakeRestartBoundPreflight = oldBoundPreflight
+		wakeRestartExec = oldExec
+	})
+
+	cfg := wakeConfig{
+		me:                 fixture.agent,
+		root:               fixture.root,
+		injectMode:         wakeInjectModeNone,
+		wakeOwner:          &fixture.owner,
+		terminalGeneration: fixture.lock.Lock.Generation,
+		retainedAgent:      fixture.agentDir,
+		retainedInbox:      fixture.inboxDir,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	handleWakeRestartAtLoopBoundary(&cfg, watcher, false, false)
+
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if current.Lock.Generation != fixture.lock.Lock.Generation || !current.IdentityConfirmed {
+		t.Fatalf("incumbent changed after exec failure: %#v", current)
+	}
+	var record wakeRestartRecord
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var exists bool
+		var err error
+		record, exists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		if !exists && err == nil {
+			return errors.New("restart refusal disappeared")
+		}
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if record.Status != wakeRestartRefused || !strings.Contains(record.Reason, sentinel.Error()) {
+		t.Fatalf("exec refusal = %#v", record)
+	}
+	if strings.Count(record.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) != 1 {
+		t.Fatalf("exec refusal remedy = %q", record.Reason)
+	}
+}
+
+func TestWakeRestartRefusalIncludesOneRunnableCheckRemedy(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	t.Setenv(envWakeOwner, "")
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err == nil || !strings.Contains(result.Reason, "requires the exact coop owner environment") {
+		t.Fatalf("ownerless restart result=%#v err=%v", result, err)
+	}
+	remedy := wakeRestartCheckCommand(fixture.root, fixture.agent)
+	if strings.Count(result.Reason, remedy) != 1 {
+		t.Fatalf("restart refusal remedy = %q, want exactly one %q", result.Reason, remedy)
+	}
+}
+
+func TestWakeRestartIncompatibleCandidatePreflightLeavesIncumbentLive(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	legacyPath := filepath.Join(t.TempDir(), "amq")
+	const legacyVersion = "0.55.0-legacy-version-only"
+	legacy := "#!/bin/sh\n" +
+		"if [ \"$1\" = --no-update-check ] && [ \"$2\" = --version ]; then\n" +
+		"  printf '%s\\n' '" + legacyVersion + "'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"printf '%s\\n' 'unknown wake flag or bootstrap' >&2\n" +
+		"exit 2\n"
+	if err := os.WriteFile(legacyPath, []byte(legacy), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := captureWakeImageEvidence(legacyPath, legacyVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldCapture := captureCurrentWakeImageEvidence
+	oldSignal := wakeRestartSignal
+	captureCurrentWakeImageEvidence = func() (wakeImageEvidenceV1, error) { return candidate, nil }
+	signalCalled := false
+	wakeRestartSignal = func(*os.Process) error {
+		signalCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		captureCurrentWakeImageEvidence = oldCapture
+		wakeRestartSignal = oldSignal
+	})
+
+	result, restartErr := requestWakeRestart(fixture.root, fixture.agent)
+	if restartErr == nil || !strings.Contains(restartErr.Error(), "candidate preflight failed") {
+		t.Fatalf("incompatible restart result=%#v err=%v", result, restartErr)
+	}
+	if signalCalled {
+		t.Fatal("incompatible candidate reached the incumbent signal boundary")
+	}
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if !current.IdentityConfirmed || current.Lock.Generation != fixture.lock.Lock.Generation {
+		t.Fatalf("incumbent changed after incompatible preflight: %#v", current)
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		_, exists, err := readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		if err == nil && exists {
+			return errors.New("incompatible candidate published a restart record")
+		}
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWakeRestartRejectsControlOnlyIncumbentBeforePublication(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	legacy := fixture.lock.Lock
+	legacy.ResumeSignal = ""
+	legacy.ControlSocket = wakeControlSocketPath(fixture.root, fixture.agent, legacy.Generation)
+	if legacy.ControlSocket == "" {
+		legacy.ControlSocket = filepath.Join(fixture.agentDir.path, ".wake-control-legacy.sock")
+	}
+	writeWakeLockForTest(t, fixture.root, fixture.agent, legacy)
+
+	preflightCalled := false
+	signalCalled := false
+	oldPreflight := wakeRestartPreflight
+	oldSignal := wakeRestartSignal
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalled = true
+		return nil
+	}
+	wakeRestartSignal = func(*os.Process) error {
+		signalCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartSignal = oldSignal
+	})
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err == nil || !strings.Contains(err.Error(), "direct SIGUSR1 restart support") {
+		t.Fatalf("control-only restart result=%#v err=%v", result, err)
+	}
+	if preflightCalled || signalCalled {
+		t.Fatalf("control-only incumbent reached preflight=%v signal=%v", preflightCalled, signalCalled)
+	}
+	if _, statErr := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("control-only incumbent published restart record: %v", statErr)
+	}
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if !current.IdentityConfirmed || current.Lock.Generation != legacy.Generation || current.Lock.ResumeSignal != "" {
+		t.Fatalf("control-only incumbent changed: %#v", current)
+	}
+}
+
+func TestWakeRestartRejectsRegisteredOwnerlessInjectViaBeforeSignal(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	injector := filepath.Join(secureTempDirForTest(t), "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := mustNewWakeTargetForTest(t, fixture.root, fixture.agent, injector, nil)
+	if err := writeWakeTarget(fixture.root, fixture.agent, target); err != nil {
+		t.Fatal(err)
+	}
+	ownerless := fixture.lock.Lock
+	ownerless.WakeMode = wakeTargetInjectVia
+	ownerless.TargetDigest = mustWakeTargetDigest(target)
+	ownerless.ControlSocket = wakeControlSocketPath(fixture.root, fixture.agent, ownerless.Generation)
+	ownerless.ResumeSchema = 0
+	ownerless.ResumeOwner = nil
+	ownerless.ResumeSignal = ""
+	writeWakeLockForTest(t, fixture.root, fixture.agent, ownerless)
+
+	preflightCalled := false
+	signalCalled := false
+	oldPreflight := wakeRestartPreflight
+	oldSignal := wakeRestartSignal
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalled = true
+		return nil
+	}
+	wakeRestartSignal = func(*os.Process) error {
+		signalCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartSignal = oldSignal
+	})
+	before := snapshotWakeCheckTree(t, fixture.root)
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err == nil || !strings.Contains(err.Error(), "does not advertise restart support") {
+		t.Fatalf("ownerless inject-via restart result=%#v err=%v", result, err)
+	}
+	if preflightCalled || signalCalled {
+		t.Fatalf("ownerless inject-via reached preflight=%v signal=%v", preflightCalled, signalCalled)
+	}
+	if _, statErr := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("ownerless inject-via published restart record: %v", statErr)
+	}
+	assertWakeCheckTreeUnchanged(t, fixture.root, before)
+}
+
+func TestWakeRestartRejectsPendingCurrentGenerationBeforePreflight(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	pending := fixture.record
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, pending)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	preflightCalled := false
+	signalCalled := false
+	oldPreflight := wakeRestartPreflight
+	oldSignal := wakeRestartSignal
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalled = true
+		return nil
+	}
+	wakeRestartSignal = func(*os.Process) error {
+		signalCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartSignal = oldSignal
+	})
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err == nil || !strings.Contains(err.Error(), "already pending for generation "+pending.Generation) {
+		t.Fatalf("second restart result=%#v err=%v", result, err)
+	}
+	if preflightCalled || signalCalled {
+		t.Fatalf("second restart reached preflight=%v signal=%v", preflightCalled, signalCalled)
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		if readErr != nil {
+			return readErr
+		}
+		if !exists || current != pending {
+			return errors.New("pending restart record changed")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if !current.IdentityConfirmed || current.Lock.Generation != fixture.lock.Lock.Generation {
+		t.Fatalf("incumbent changed after second request: %#v", current)
+	}
+}
+
+func TestWakeRestartReplacesPendingOtherGenerationBeforeSignal(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	pending := fixture.record
+	pending.Generation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, pending)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	preflightCalled := false
+	oldPreflight := wakeRestartPreflight
+	oldSignal := wakeRestartSignal
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalled = true
+		return nil
+	}
+	signalErr := errors.New("stop after stale request replacement")
+	wakeRestartSignal = func(*os.Process) error {
+		if err := fixture.agentDir.withFD(func(dirfd int) error {
+			current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
+			if readErr != nil {
+				return readErr
+			}
+			if !exists || current.Status != wakeRestartPending {
+				return fmt.Errorf("replacement restart record = %#v, exists=%v", current, exists)
+			}
+			if current.Generation != fixture.lock.Lock.Generation || current.RequestID == pending.RequestID {
+				return fmt.Errorf("replacement restart record did not supersede stale generation: %#v", current)
+			}
+			return nil
+		}); err != nil {
+			t.Error(err)
+		}
+		return signalErr
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartSignal = oldSignal
+	})
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if !errors.Is(err, signalErr) {
+		t.Fatalf("restart result=%#v err=%v, want signal error", result, err)
+	}
+	if !preflightCalled {
+		t.Fatal("replacement restart did not preflight candidate")
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		if readErr != nil {
+			return readErr
+		}
+		if !exists || current.Generation != fixture.lock.Lock.Generation ||
+			current.RequestID == pending.RequestID || current.Status != wakeRestartRefused ||
+			!strings.Contains(current.Reason, signalErr.Error()) ||
+			strings.Count(current.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) != 1 {
+			return fmt.Errorf("post-signal replacement restart record = %#v, exists=%v", current, exists)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWakeRestartClientWaitsForPreparedRequestConsumption(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	const nextGeneration = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	oldPreflight := wakeRestartPreflight
+	oldSignal := wakeRestartSignal
+	oldSleep := wakeRestartSleep
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error { return nil }
+	wakeRestartSignal = func(*os.Process) error {
+		restarted := fixture.lock.Lock
+		restarted.Generation = nextGeneration
+		bound := boundWakeImageEvidenceForTest(fixture.candidate)
+		restarted.RunningImageEvidence = &bound
+		restarted.ImagePath = bound.ExecutionPath
+		restarted.ImageVersion = bound.EmbeddedVersion
+		writeWakeLockForTest(t, fixture.root, fixture.agent, restarted)
+		current := inspectWakeLock(fixture.root, fixture.agent)
+		if err := writeWakePreparedFileInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			current,
+		); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}
+	sleepCalls := 0
+	wakeRestartSleep = func(time.Duration) {
+		sleepCalls++
+		removeWakeRestartRecordForTest(t, fixture)
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartSignal = oldSignal
+		wakeRestartSleep = oldSleep
+	})
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err != nil {
+		t.Fatalf("restart client: result=%#v err=%v", result, err)
+	}
+	if result.Status != "restarted" || result.Generation != nextGeneration || sleepCalls == 0 {
+		t.Fatalf("restart client returned before request consumption: result=%#v sleep_calls=%d", result, sleepCalls)
+	}
+}
+
+func TestWakeRestartStraySignalWithoutRecordIsNoOp(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	before := snapshotWakeCheckTree(t, fixture.root)
+
+	bindCalled := false
+	execCalled := false
+	oldBind := wakeRestartBind
+	oldExec := wakeRestartExec
+	wakeRestartBind = func(wakeImageEvidenceV1) (*wakeRestartBoundImage, error) {
+		bindCalled = true
+		return nil, errors.New("unexpected bind")
+	}
+	wakeRestartExec = func(string, []string, []string) error {
+		execCalled = true
+		return errors.New("unexpected exec")
+	}
+	t.Cleanup(func() {
+		wakeRestartBind = oldBind
+		wakeRestartExec = oldExec
+	})
+	cfg := wakeConfig{
+		me:                 fixture.agent,
+		root:               fixture.root,
+		injectMode:         wakeInjectModeNone,
+		wakeOwner:          &fixture.owner,
+		terminalGeneration: fixture.lock.Lock.Generation,
+		retainedAgent:      fixture.agentDir,
+		retainedInbox:      fixture.inboxDir,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+	}
+	handleWakeRestartAtLoopBoundary(
+		&cfg,
+		fixedWakeAdmissionWatcher{errors: make(chan error)},
+		false,
+		false,
+	)
+	if bindCalled || execCalled {
+		t.Fatalf("stray signal reached bind=%v exec=%v", bindCalled, execCalled)
+	}
+	assertWakeCheckTreeUnchanged(t, fixture.root, before)
+}
+
+func TestValidateWakeRestartArgvRejectsRepairAndArbitraryInjection(t *testing.T) {
+	root := secureTempDirForTest(t)
+	base := []string{"amq", "wake", "--root", root, "--me", "codex"}
+	if err := validateWakeRestartArgv(base, root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	for _, flag := range []string{"--repair-lineage=old", "--inject-via=/bin/echo", "--inject-cmd=true", "--interrupt-cmd=ctrl-c"} {
+		argv := append(append([]string(nil), base...), flag)
+		if err := validateWakeRestartArgv(argv, root, "codex"); err == nil {
+			t.Fatalf("argv %v was accepted", argv)
+		}
+	}
+}
+
+func TestWakeCheckMakesAdvertisedSelfRestartActionable(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	if err := writeWakePreparedFileInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.lock,
+	); err != nil {
+		t.Fatal(err)
+	}
+	decision := buildWakeCheckDecision(
+		fixture.root,
+		fixture.agent,
+		fixture.lock,
+		nil,
+		false,
+	)
+	if decision.Reload.Status != wakeReloadReady ||
+		decision.Reload.ReasonCode != wakeReloadReasonReady ||
+		decision.RestartCapability != wakeRestartAgentSafe ||
+		decision.Action.Kind != wakeActionRestartWake ||
+		decision.Action.Command == nil {
+		t.Fatalf("wake restart decision = %#v", decision)
+	}
+	wantArgs := []string{
+		"wake", "restart", "--root", fixture.root, "--me", fixture.agent,
+	}
+	if !reflect.DeepEqual(decision.Action.Command.Args, wantArgs) {
+		t.Fatalf("restart action args = %#v, want %#v", decision.Action.Command.Args, wantArgs)
+	}
+}
+
+func TestWakeCheckRestartRequiresMatchingOwnerAndPreparedProof(t *testing.T) {
+	t.Run("missing prepared proof", func(t *testing.T) {
+		fixture := newWakeRestartFixture(t)
+		removeWakeRestartRecordForTest(t, fixture)
+		decision := buildWakeCheckDecision(
+			fixture.root,
+			fixture.agent,
+			fixture.lock,
+			nil,
+			false,
+		)
+		if decision.Reload.Status != wakeReloadUnavailable ||
+			decision.Reload.ReasonCode != wakeReloadReasonNotPrepared ||
+			decision.RestartCapability != wakeRestartUnavailable ||
+			decision.Action.Kind != wakeActionWaitForStableState ||
+			decision.Action.Actor != wakeActionActorAgent ||
+			decision.Action.ReasonCode != wakeReloadReasonNotPrepared ||
+			decision.Action.Command == nil ||
+			decision.Action.TerminalRequired ||
+			decision.Action.Message != "leave wake state unchanged and retry after restart preparation reaches a stable state" {
+			t.Fatalf("unprepared restart decision = %#v", decision)
+		}
+		wantArgs := []string{
+			"wake", "check", "--root", fixture.root, "--me", fixture.agent,
+			"--json", "--json-schema=2",
+		}
+		if !reflect.DeepEqual(decision.Action.Command.Args, wantArgs) {
+			t.Fatalf("unprepared retry args = %#v, want %#v", decision.Action.Command.Args, wantArgs)
+		}
+	})
+
+	t.Run("pending restart", func(t *testing.T) {
+		fixture := newWakeRestartFixture(t)
+		if err := writeWakePreparedFileInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			fixture.lock,
+		); err != nil {
+			t.Fatal(err)
+		}
+		decision := buildWakeCheckDecision(
+			fixture.root,
+			fixture.agent,
+			fixture.lock,
+			nil,
+			false,
+		)
+		if decision.Reload.Status != wakeReloadUnavailable ||
+			decision.Reload.ReasonCode != wakeReloadReasonRestartPending ||
+			decision.RestartCapability != wakeRestartUnavailable ||
+			decision.Action.Kind != wakeActionWaitForStableState ||
+			decision.Action.Actor != wakeActionActorAgent ||
+			decision.Action.ReasonCode != wakeReloadReasonRestartPending ||
+			decision.Action.Command == nil ||
+			decision.Action.TerminalRequired ||
+			decision.Action.Message != "leave wake state unchanged and retry after the pending wake restart reaches a stable state" {
+			t.Fatalf("pending restart decision = %#v", decision)
+		}
+		wantArgs := []string{
+			"wake", "check", "--root", fixture.root, "--me", fixture.agent,
+			"--json", "--json-schema=2",
+		}
+		if !reflect.DeepEqual(decision.Action.Command.Args, wantArgs) {
+			t.Fatalf("pending retry args = %#v, want %#v", decision.Action.Command.Args, wantArgs)
+		}
+		before := snapshotWakeCheckTree(t, fixture.root)
+		if _, err := captureEnvStdout(t, func() error {
+			return runWake(decision.Action.Command.Args[1:])
+		}); err != nil {
+			t.Fatalf("execute pending-restart check action: %v", err)
+		}
+		assertWakeCheckTreeUnchanged(t, fixture.root, before)
+
+		ops := runOpsChecksWithSchema(fixture.root, "test", false, wakeCheckSchemaV2)
+		var doctorDecision *wakeCheckDecision
+		for index := range ops.WakeLocks {
+			if ops.WakeLocks[index].Agent == fixture.agent {
+				doctorDecision = ops.WakeLocks[index].WakeCheckDecision
+				break
+			}
+		}
+		if doctorDecision == nil ||
+			doctorDecision.Reload.Status != wakeReloadUnavailable ||
+			doctorDecision.Reload.ReasonCode != wakeReloadReasonRestartPending ||
+			doctorDecision.Action.Kind != wakeActionWaitForStableState ||
+			doctorDecision.Action.Command == nil {
+			t.Fatalf("doctor pending restart decision = %#v", doctorDecision)
+		}
+		assertWakeCheckTreeUnchanged(t, fixture.root, before)
+	})
+
+	t.Run("missing caller owner", func(t *testing.T) {
+		fixture := newWakeRestartFixture(t)
+		removeWakeRestartRecordForTest(t, fixture)
+		if err := writeWakePreparedFileInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			fixture.lock,
+		); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(envWakeOwner, "")
+		decision := buildWakeCheckDecision(
+			fixture.root,
+			fixture.agent,
+			fixture.lock,
+			nil,
+			false,
+		)
+		if decision.Reload.Status != wakeReloadUnavailable ||
+			decision.Reload.ReasonCode != wakeReloadReasonOwnerMismatch ||
+			decision.RestartCapability != wakeRestartOperatorOnly ||
+			decision.Action.Kind != wakeActionPreserveLiveWake {
+			t.Fatalf("owner-mismatched restart decision = %#v", decision)
+		}
+	})
+}
+
+func TestWakeRestartQuiescenceValidatesRetainedInboxCapability(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	moved := fixture.inboxDir.path + ".moved"
+	if err := os.Rename(fixture.inboxDir.path, moved); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(fixture.inboxDir.path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := wakeConfig{
+		me:                 fixture.agent,
+		root:               fixture.root,
+		injectMode:         wakeInjectModeNone,
+		wakeOwner:          &fixture.owner,
+		terminalGeneration: fixture.lock.Lock.Generation,
+		retainedAgent:      fixture.agentDir,
+		retainedInbox:      fixture.inboxDir,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+	}
+	decision := classifyWakeRestartAtLoopBoundary(
+		&cfg,
+		fixedWakeAdmissionWatcher{errors: make(chan error)},
+		false,
+		false,
+	)
+	if decision.Disposition == wakeResumeProceed || decision.Reason != wakeResumeReasonDirectoriesUnverified {
+		t.Fatalf("replaced retained inbox decision = %#v", decision)
+	}
+}

--- a/internal/cli/wake_resume_image_unix.go
+++ b/internal/cli/wake_resume_image_unix.go
@@ -67,6 +67,48 @@ func captureWakeImageEvidence(path, embeddedVersion string) (wakeImageEvidenceV1
 	if err := validateWakeTargetPathOwnership("wake image", path, before); err != nil {
 		return wakeImageEvidenceV1{}, err
 	}
+	evidence, err := captureWakeImageEvidenceFromOpenFile(
+		file,
+		path,
+		embeddedVersion,
+		wakeImageMethodPathnameObserved,
+	)
+	if err != nil {
+		return wakeImageEvidenceV1{}, err
+	}
+	confirmed, err := file.Stat()
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("re-stat wake image: %w", err)
+	}
+	if !sameWakeFileIdentity(before, confirmed) || before.Size() != confirmed.Size() {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image changed while hashing")
+	}
+	return evidence, nil
+}
+
+func captureWakeImageEvidenceFromOpenFile(
+	file *os.File,
+	executionPath, embeddedVersion, method string,
+) (wakeImageEvidenceV1, error) {
+	if file == nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image file is missing")
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("seek wake image: %w", err)
+	}
+	before, err := file.Stat()
+	if err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("stat opened wake image: %w", err)
+	}
+	if !before.Mode().IsRegular() {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image must be a regular file")
+	}
+	if before.Mode().Perm()&0o111 == 0 {
+		return wakeImageEvidenceV1{}, fmt.Errorf("wake image is not executable")
+	}
+	if err := validateWakeTargetPathOwnership("wake image", executionPath, before); err != nil {
+		return wakeImageEvidenceV1{}, err
+	}
 	identity, ok := captureWakeFileIdentity(before)
 	if !ok {
 		return wakeImageEvidenceV1{}, fmt.Errorf("capture wake image identity")
@@ -83,12 +125,15 @@ func captureWakeImageEvidence(path, embeddedVersion string) (wakeImageEvidenceV1
 	if !sameWakeFileIdentity(before, after) || before.Size() != after.Size() {
 		return wakeImageEvidenceV1{}, fmt.Errorf("wake image changed while hashing")
 	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return wakeImageEvidenceV1{}, fmt.Errorf("rewind wake image: %w", err)
+	}
 
 	evidence := wakeImageEvidenceV1{
 		Schema:          wakeImageEvidenceSchemaV1,
 		Platform:        runtime.GOOS,
-		Method:          wakeImageMethodPathnameObserved,
-		ExecutionPath:   path,
+		Method:          method,
+		ExecutionPath:   executionPath,
 		Device:          identity.Device,
 		Inode:           identity.Inode,
 		Size:            after.Size(),

--- a/internal/cli/wake_resume_protocol.go
+++ b/internal/cli/wake_resume_protocol.go
@@ -18,12 +18,14 @@ const (
 	wakeImageMethodFDExec               = "fd_exec"
 	wakeImageMethodPathnameObserved     = "pathname_observed"
 	wakeImageMethodPathnameExecVerified = "pathname_execve_verified"
+	wakeResumeSignalUSR1                = "SIGUSR1"
 )
 
 // wakeImageEvidenceV1 records image metadata and its authority method.
-// pathname_observed is diagnostic on every platform. Darwin reserves
-// pathname_execve_verified for a path authenticated immediately before execve;
-// Linux resume authority requires fd_exec evidence from the executing image.
+// pathname_observed is diagnostic on every platform. A resumed Darwin wake
+// publishes the exact private hardlink path it executed after successor-side
+// verification; a resumed Linux wake publishes evidence from its bound FD and
+// verifies the running image through /proc/self/exe before rotating generation.
 type wakeImageEvidenceV1 struct {
 	Schema          int    `json:"schema"`
 	Platform        string `json:"platform"`
@@ -72,9 +74,6 @@ func validateWakeResumeAdvertisementWithContext(
 	if lock.Agent != expectedAgent {
 		return fmt.Errorf("wake resume agent does not match the trusted agent")
 	}
-	if expectedControlSocket == "" {
-		return fmt.Errorf("%w on %s", errWakeResumeControlEndpointUnsupported, platform)
-	}
 	if lock.ResumeSchema != wakeResumeSchemaV2 {
 		if lock.ResumeSchema == 0 {
 			return fmt.Errorf("wake resume schema is missing")
@@ -93,11 +92,14 @@ func validateWakeResumeAdvertisementWithContext(
 	if err := validateAuthoritativeWakeProcessIdentity(lock); err != nil {
 		return fmt.Errorf("wake resume process identity is invalid: %w", err)
 	}
-	if strings.TrimSpace(lock.ControlSocket) == "" {
+	if lock.ResumeSignal != "" && lock.ResumeSignal != wakeResumeSignalUSR1 {
+		return fmt.Errorf("wake resume signal is unsupported")
+	}
+	if lock.ResumeSignal == "" && strings.TrimSpace(lock.ControlSocket) == "" {
 		return fmt.Errorf("wake resume control endpoint is missing")
 	}
-	if lock.ControlSocket != expectedControlSocket {
-		return fmt.Errorf("wake resume control endpoint does not match the exact root, agent, and generation")
+	if lock.ResumeSignal == "" && lock.ControlSocket != "" && expectedControlSocket != "" && lock.ControlSocket != expectedControlSocket {
+		return fmt.Errorf("wake control endpoint does not match the exact root, agent, and generation")
 	}
 	if lock.SourceGeneration != "" || lock.SourceFloorDigest != "" {
 		return fmt.Errorf("wake repair lineage is not resumable")
@@ -108,16 +110,8 @@ func validateWakeResumeAdvertisementWithContext(
 	if err := validateWakeImageEvidenceForPlatform(*lock.RunningImageEvidence, platform); err != nil {
 		return err
 	}
-	switch platform {
-	case "darwin":
-		if lock.RunningImageEvidence.Method != wakeImageMethodPathnameExecVerified {
-			return fmt.Errorf("wake running image evidence is not bound immediately before execve")
-		}
-	case "linux":
-		if lock.RunningImageEvidence.Method != wakeImageMethodFDExec {
-			return fmt.Errorf("wake running image evidence is not kernel-bound to the executing image")
-		}
-	}
+	// Resumed wakes publish execution-bound evidence. Ordinary Darwin wakes may
+	// still publish pathname_observed evidence for diagnostics only.
 	if lock.ImagePath != lock.RunningImageEvidence.ExecutionPath {
 		return fmt.Errorf("wake image path does not match running image evidence")
 	}
@@ -211,7 +205,7 @@ func wakeResumeStartupEligible(
 		return false
 	}
 	switch wakeMode {
-	case wakeInjectModeRaw, wakeInjectModePaste, wakeInjectModeNone, wakeTargetInjectVia:
+	case wakeInjectModeRaw, wakeInjectModePaste, wakeInjectModeNone:
 		return true
 	default:
 		return false

--- a/internal/cli/wake_resume_protocol_unix_test.go
+++ b/internal/cli/wake_resume_protocol_unix_test.go
@@ -45,6 +45,9 @@ func TestCaptureWakeImageEvidenceBindsStableRegularExecutable(t *testing.T) {
 }
 
 func TestLinuxFabricatedPathEvidenceCannotAuthorizeResume(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux pathname evidence invariant")
+	}
 	dir := secureTempDirForTest(t)
 	path := filepath.Join(dir, "fabricated-amq")
 	if err := os.WriteFile(path, []byte("not the running image\n"), 0o700); err != nil {
@@ -68,18 +71,31 @@ func TestLinuxFabricatedPathEvidenceCannotAuthorizeResume(t *testing.T) {
 	lock.RunningImageEvidence = &evidence
 	lock.ImagePath = evidence.ExecutionPath
 	lock.ImageVersion = evidence.EmbeddedVersion
-	controlSocket := filepath.Join(fsq.AgentBase(lock.Root, lock.Agent), ".w.test-linux-resume")
-	lock.ControlSocket = controlSocket
+	lock.ResumeSignal = wakeResumeSignalUSR1
+	lock.ControlSocket = ""
 
 	err = validateWakeResumeAdvertisementWithContext(
 		lock,
 		lock.Root,
 		lock.Agent,
 		"linux",
-		controlSocket,
+		"",
 	)
-	if err == nil || !strings.Contains(err.Error(), "kernel-bound") {
-		t.Fatalf("Linux fabricated path advertisement error = %v, want kernel-bound refusal", err)
+	if err != nil {
+		t.Fatalf("Linux persisted pathname diagnostics should remain a valid advertisement: %v", err)
+	}
+	bootstrap := wakeResumeBootstrap{
+		Schema:     wakeRestartSchemaV1,
+		RequestID:  "0123456789abcdef0123456789abcdef",
+		Generation: lock.Generation,
+	}
+	if err := preflightWakeRestartCandidate(evidence, []string{
+		evidence.ExecutionPath,
+		"wake",
+		"--root", lock.Root,
+		"--me", lock.Agent,
+	}, bootstrap); err == nil {
+		t.Fatal("persisted pathname evidence alone authorized executing a mismatched candidate")
 	}
 }
 
@@ -177,7 +193,7 @@ func validWakeResumeLockForTest() wakeLock {
 		BootID:               owner.BootID,
 		WakeMode:             wakeInjectModeRaw,
 		Generation:           generation,
-		ControlSocket:        wakeControlSocketPath(root, agent, generation),
+		ResumeSignal:         wakeResumeSignalUSR1,
 		ImagePath:            evidence.ExecutionPath,
 		ImageVersion:         evidence.EmbeddedVersion,
 		ResumeSchema:         wakeResumeSchemaV2,
@@ -229,14 +245,6 @@ func TestValidateWakeResumeAdvertisementBindsTrustedRootAndAgent(t *testing.T) {
 }
 
 func TestValidateWakeResumeAdvertisementAcceptsOnlyCompleteExactV2(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		lock := validWakeResumeLockForTest()
-		err := validateWakeResumeAdvertisement(lock, lock.Root, lock.Agent)
-		if err == nil || !strings.Contains(err.Error(), "unsupported") {
-			t.Fatalf("non-Darwin resume advertisement error = %v, want unsupported", err)
-		}
-		return
-	}
 	lock := validWakeResumeLockForTest()
 	if err := validateWakeResumeAdvertisement(lock, lock.Root, lock.Agent); err != nil {
 		t.Fatalf("valid resume advertisement rejected: %v", err)
@@ -254,23 +262,8 @@ func TestValidateWakeResumeAdvertisementAcceptsOnlyCompleteExactV2(t *testing.T)
 		{name: "missing generation", mutate: func(l *wakeLock) { l.Generation = "" }, want: "generation"},
 		{name: "missing wake process start", mutate: func(l *wakeLock) { l.ProcessStart = "" }, want: "process start"},
 		{name: "missing wake boot id", mutate: func(l *wakeLock) { l.BootID = "" }, want: "boot id"},
-		{name: "missing control endpoint", mutate: func(l *wakeLock) { l.ControlSocket = "" }, want: "control"},
-		{name: "relative control endpoint", mutate: func(l *wakeLock) { l.ControlSocket = ".w.relative" }, want: "control"},
-		{name: "outside-agent control endpoint", mutate: func(l *wakeLock) {
-			l.ControlSocket = filepath.Join(l.Root, ".w.outside")
-		}, want: "control"},
-		{name: "wrong-prefix control endpoint", mutate: func(l *wakeLock) {
-			l.ControlSocket = filepath.Join(fsq.AgentBase(l.Root, l.Agent), ".wake.sock")
-		}, want: "control"},
-		{name: "wrong-generation control endpoint", mutate: func(l *wakeLock) {
-			l.ControlSocket = wakeControlSocketPath(l.Root, l.Agent, "other-generation")
-		}, want: "control"},
-		{name: "wrong-agent control endpoint", mutate: func(l *wakeLock) {
-			l.ControlSocket = wakeControlSocketPath(l.Root, "other", l.Generation)
-		}, want: "control"},
-		{name: "wrong-root control endpoint", mutate: func(l *wakeLock) {
-			l.ControlSocket = wakeControlSocketPath(filepath.Join(l.Root, "other"), l.Agent, l.Generation)
-		}, want: "control"},
+		{name: "missing request endpoint", mutate: func(l *wakeLock) { l.ResumeSignal = "" }, want: "control"},
+		{name: "unsupported signal", mutate: func(l *wakeLock) { l.ResumeSignal = "SIGUSR2" }, want: "signal"},
 		{name: "repair lineage", mutate: func(l *wakeLock) { l.SourceGeneration = "dead-generation" }, want: "repair"},
 		{name: "missing evidence", mutate: func(l *wakeLock) { l.RunningImageEvidence = nil }, want: "image evidence"},
 		{name: "wrong evidence schema", mutate: func(l *wakeLock) { l.RunningImageEvidence.Schema++ }, want: "image evidence schema"},
@@ -314,6 +307,37 @@ func TestValidateWakeResumeAdvertisementAcceptsOnlyCompleteExactV2(t *testing.T)
 	}
 }
 
+func TestValidateWakeResumeAdvertisementRetainsLegacyControlEndpointValidation(t *testing.T) {
+	lock := validWakeResumeLockForTest()
+	lock.ResumeSignal = ""
+	lock.ControlSocket = "/queue/agents/codex/.w.resume-generation"
+	lock.RunningImageEvidence.Platform = "darwin"
+	lock.RunningImageEvidence.Method = wakeImageMethodPathnameExecVerified
+	lock.RunningImageEvidence.ExecutionPath = "/opt/homebrew/bin/amq"
+	lock.ImagePath = lock.RunningImageEvidence.ExecutionPath
+	expected := lock.ControlSocket
+	if err := validateWakeResumeAdvertisementWithContext(lock, lock.Root, lock.Agent, "darwin", expected); err != nil {
+		t.Fatalf("legacy control advertisement rejected: %v", err)
+	}
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "missing", want: "control endpoint is missing"},
+		{name: "mismatched", path: expected + ".other", want: "control endpoint does not match"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := lock
+			candidate.ControlSocket = test.path
+			err := validateWakeResumeAdvertisementWithContext(candidate, lock.Root, lock.Agent, "darwin", expected)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("legacy control error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestWakeResumeMetadataRoundTripsWithoutChangingGenericClaim(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
@@ -341,19 +365,15 @@ func TestWakeResumeMetadataRoundTripsWithoutChangingGenericClaim(t *testing.T) {
 	if got := classifyWakeClaimForGenericTransition(inspection); got != wakeClaimGeneric {
 		t.Fatalf("claim = %v, want generic", got)
 	}
-	if err := validateWakeResumeAdvertisement(inspection.Lock, root, "codex"); runtime.GOOS == "darwin" {
-		if err != nil {
-			t.Fatalf("round-tripped advertisement invalid: %v", err)
-		}
-	} else if err == nil || !strings.Contains(err.Error(), "unsupported") {
-		t.Fatalf("non-Darwin round-tripped advertisement error = %v, want unsupported", err)
+	if err := validateWakeResumeAdvertisement(inspection.Lock, root, "codex"); err != nil {
+		t.Fatalf("round-tripped advertisement invalid: %v", err)
 	}
 
 	data, err := json.Marshal(inspection.Lock)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, field := range []string{"resume_schema", "resume_owner", "running_image_evidence"} {
+	for _, field := range []string{"resume_schema", "resume_owner", "resume_signal", "running_image_evidence"} {
 		if !strings.Contains(string(data), `"`+field+`"`) {
 			t.Fatalf("lock JSON missing %q: %s", field, data)
 		}
@@ -402,23 +422,32 @@ func TestNewWakeLockAdvertisesResumeOnlyWhenTheProtocolIsComplete(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if runtime.GOOS == "linux" {
-		// Wave 1 deliberately does not advertise the protocol before Wave 2
-		// supplies Linux's authenticated control endpoint.
-		if lock.ResumeSchema != 0 || lock.ResumeOwner != nil || lock.RunningImageEvidence != nil {
-			t.Fatalf("Linux advertised resume before its control transport exists: %#v", lock)
-		}
-		return
-	}
 	if lock.ResumeSchema != wakeResumeSchemaV2 || !sameWakeOwner(lock.ResumeOwner, &owner) ||
+		lock.ResumeSignal != wakeResumeSignalUSR1 || lock.ControlSocket != "" ||
 		lock.RunningImageEvidence == nil || *lock.RunningImageEvidence != evidence {
 		t.Fatalf("resume advertisement = %#v", lock)
 	}
-	if lock.ControlSocket == "" {
-		t.Fatal("Darwin resume advertisement has no control endpoint")
-	}
 	if err := validateWakeResumeAdvertisement(lock, "/queue", "codex"); err != nil {
 		t.Fatalf("new lock advertisement invalid: %v", err)
+	}
+
+	targetRoot := secureTempDirForTest(t)
+	injector := filepath.Join(targetRoot, "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := mustNewWakeTargetForTest(t, targetRoot, "codex", injector, nil)
+	targetLock, err := newWakeLock(targetRoot, "codex", wakeLockAcquireOptions{
+		target:         &target,
+		wakeMode:       wakeTargetInjectVia,
+		requestedOwner: &owner,
+		resumeEligible: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targetLock.ResumeSchema != 0 || targetLock.ResumeOwner != nil || targetLock.ResumeSignal != "" {
+		t.Fatalf("inject-via target advertised resume despite target guard: %#v", targetLock)
 	}
 
 	notEligible, err := newWakeLock("/queue", "codex", wakeLockAcquireOptions{
@@ -431,7 +460,8 @@ func TestNewWakeLockAdvertisesResumeOnlyWhenTheProtocolIsComplete(t *testing.T) 
 	if notEligible.ResumeSchema != 0 || notEligible.ResumeOwner != nil {
 		t.Fatalf("ineligible wake advertised resume: %#v", notEligible)
 	}
-	if notEligible.RunningImageEvidence == nil || *notEligible.RunningImageEvidence != evidence {
+	if runtime.GOOS == "darwin" &&
+		(notEligible.RunningImageEvidence == nil || *notEligible.RunningImageEvidence != evidence) {
 		t.Fatalf("ordinary Darwin wake omitted additive image evidence: %#v", notEligible)
 	}
 
@@ -465,7 +495,7 @@ func TestWakeResumeStartupEligibilityIsNarrowAndOwnerBound(t *testing.T) {
 		{name: "raw coop", owner: &owner, mode: wakeInjectModeRaw, want: true},
 		{name: "paste coop", owner: &owner, mode: wakeInjectModePaste, want: true},
 		{name: "none coop", owner: &owner, mode: wakeInjectModeNone, want: true},
-		{name: "ordinary inject via", owner: &owner, mode: wakeTargetInjectVia, want: true},
+		{name: "ordinary inject via", owner: &owner, mode: wakeTargetInjectVia},
 		{name: "ownerless", mode: wakeInjectModeRaw},
 		{name: "repair lineage", owner: &owner, mode: wakeTargetInjectVia, repair: true},
 		{name: "arbitrary inject command", owner: &owner, mode: wakeInjectModeRaw, injectCmd: "helper"},

--- a/internal/cli/wake_state_dual_read_unix_test.go
+++ b/internal/cli/wake_state_dual_read_unix_test.go
@@ -774,6 +774,44 @@ func TestWakeTargetAndPreparedReopenFailuresAreTypedSnapshotChanges(t *testing.T
 	})
 }
 
+type wakeGenerationFileInfoOverride struct {
+	os.FileInfo
+	mode os.FileMode
+	size int64
+}
+
+func (info wakeGenerationFileInfoOverride) Mode() os.FileMode { return info.mode }
+func (info wakeGenerationFileInfoOverride) Size() int64       { return info.size }
+
+func TestWakeGenerationFileSnapshotFreezesModeAndSizeWhenCTimeAliases(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "marker")
+	if err := os.WriteFile(path, []byte("marker"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sameIdentity := wakeGenerationFileInfoOverride{
+		FileInfo: base,
+		mode:     base.Mode(),
+		size:     base.Size(),
+	}
+	if !sameWakeGenerationFileSnapshot(base, sameIdentity) {
+		t.Fatal("identical generation file snapshot was rejected")
+	}
+	modeChanged := sameIdentity
+	modeChanged.mode = 0o640
+	if sameWakeGenerationFileSnapshot(base, modeChanged) {
+		t.Fatal("same-ctime mode change was accepted")
+	}
+	sizeChanged := sameIdentity
+	sizeChanged.size++
+	if sameWakeGenerationFileSnapshot(base, sizeChanged) {
+		t.Fatal("same-ctime size change was accepted")
+	}
+}
+
 func readWakeStateSelectionForTest(t *testing.T, fixture wakeStateUnixFixture) (wakeStateReadSelection, error) {
 	t.Helper()
 	var selection wakeStateReadSelection

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -108,7 +108,8 @@ type wakeLockAcquireOptions struct {
 	repairFloorAuthority    *wakeRepairFloorAuthority
 	// resumeEligible is startup policy, not authority. newWakeLock still requires
 	// the complete owner/process/control/image advertisement below.
-	resumeEligible bool
+	resumeEligible      bool
+	resumeImageEvidence *wakeImageEvidenceV1
 }
 
 func debugWakeNoLockShadowReplacementAt(
@@ -662,7 +663,15 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 		}
 	}
 	lock.ImageVersion = strings.TrimSpace(cliVersion)
-	if runtime.GOOS == "darwin" {
+	if options.resumeImageEvidence != nil {
+		evidence := *options.resumeImageEvidence
+		if err := validateWakeImageEvidence(evidence); err != nil {
+			return wakeLock{}, fmt.Errorf("wake resume image evidence is invalid: %w", err)
+		}
+		lock.RunningImageEvidence = &evidence
+		lock.ImagePath = evidence.ExecutionPath
+		lock.ImageVersion = evidence.EmbeddedVersion
+	} else if runtime.GOOS == "darwin" {
 		// Darwin has no retained executable FD. Capture the observed pathname
 		// identity for diagnostics, but do not treat it as agent-safe resume
 		// authority after exec.
@@ -700,13 +709,10 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 		lock.Executable = proc.Executable
 		lock.Args = proc.Args
 	}
-	if options.resumeEligible && options.requestedOwner != nil && options.repairLineage == nil {
+	if options.resumeEligible && options.target == nil && options.requestedOwner != nil && options.repairLineage == nil {
 		// Resume metadata is additive capability. Missing or inconsistent evidence
 		// keeps the ordinary notifier usable without advertising agent-safe reload.
 		candidate := lock
-		if candidate.ControlSocket == "" {
-			candidate.ControlSocket = wakeControlSocketPath(root, me, candidate.Generation)
-		}
 		evidence := lock.RunningImageEvidence
 		if evidence == nil {
 			captured, evidenceErr := captureCurrentWakeImageEvidence()
@@ -718,7 +724,9 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 			owner := *options.requestedOwner
 			candidate.ResumeSchema = wakeResumeSchemaV2
 			candidate.ResumeOwner = &owner
+			candidate.ResumeSignal = wakeResumeSignalUSR1
 			candidate.RunningImageEvidence = evidence
+			candidate.Args = append([]string(nil), os.Args...)
 			candidate.ImagePath = evidence.ExecutionPath
 			candidate.ImageVersion = evidence.EmbeddedVersion
 			if validateWakeResumeAdvertisement(candidate, root, me) == nil {
@@ -995,6 +1003,8 @@ func runWake(args []string) error {
 			return runWakeCheck(args[1:])
 		case "repair":
 			return runWakeRepair(args[1:])
+		case "restart":
+			return runWakeRestart(args[1:])
 		case "retire":
 			return runWakeRetire(args[1:])
 		case "recover-owner":
@@ -1735,6 +1745,23 @@ func buildRepairWakeArgs(root, me string, target wakeTarget, generation, readyPa
 }
 
 func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
+	resumeBootstrap, err := wakeResumeBootstrapFromEnv()
+	if err != nil {
+		return err
+	}
+	resumePreflight, err := wakeResumePreflightFromEnv()
+	if err != nil {
+		return err
+	}
+	if resumeBootstrap != nil && resumePreflight != nil {
+		return fmt.Errorf("wake resume bootstrap and preflight cannot be combined")
+	}
+	// Install restart delivery before a resumable generation can be published.
+	// SIGUSR1's default disposition is termination, so advertising first would
+	// create a small but real kill window.
+	restartSignals := make(chan os.Signal, 1)
+	signal.Notify(restartSignals, syscall.SIGUSR1)
+	defer signal.Stop(restartSignals)
 	privateStop, cleanupPrivateStop, err := authoritativeWakePrivateStopFromEnv()
 	if err != nil {
 		return err
@@ -1789,9 +1816,10 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	refuseUnverifiedWakeFlag := fs.Bool("refuse-unverified-wake", false, "Internal: refuse unverified wake locks instead of superseding them")
 	repairLineageFlag := fs.String("repair-lineage", "", "Internal: inherit the suppression floor from an exact dead wake generation")
 	baselineExistingFlag := fs.Bool("baseline-existing", false, "Ignore messages already waiting when this wake starts")
+	resumePreflightFlag := fs.Bool(wakeResumePreflightFlag, false, "Internal: validate an exact wake resume without starting")
 
 	usage := usageWithHiddenFlags(fs, "amq wake --me <agent> [options]",
-		[]string{"ready-file", "accept-existing-wake", "refuse-unverified-wake", "repair-lineage"},
+		[]string{"ready-file", "accept-existing-wake", "refuse-unverified-wake", "repair-lineage", wakeResumePreflightFlag},
 		"Background waker: injects terminal notification when messages arrive.",
 		"Run as background job before starting CLI: amq wake --me claude --interrupt-cmd none &",
 		"",
@@ -1844,6 +1872,9 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		return err
 	} else if handled {
 		return nil
+	}
+	if *resumePreflightFlag != (resumePreflight != nil) {
+		return fmt.Errorf("wake resume preflight flag and environment must be paired")
 	}
 	if *previewLenFlag < 0 {
 		return UsageError("--preview-len must be >= 0")
@@ -1940,10 +1971,53 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	if repairGeneration == "" && repairHandoffPresent {
 		return fmt.Errorf("wake repair handoff requires --repair-lineage")
 	}
+	resumeContext := resumeBootstrap
+	if resumeContext == nil {
+		resumeContext = resumePreflight
+	}
+	var resumeImageEvidence *wakeImageEvidenceV1
+	if resumeContext != nil {
+		if repairGeneration != "" || repairHandoffPresent {
+			return fmt.Errorf("wake resume cannot inherit repair state")
+		}
+		// Readiness files and startup baselines are one-shot launch inputs. A
+		// self-resume republishes readiness for its new generation and treats all
+		// durable inbox/new entries as pending.
+		readyFile = ""
+		*acceptExistingWakeFlag = false
+		*baselineExistingFlag = false
+		if resumeBootstrap != nil || resumeContext.BoundImage != nil {
+			verified, verifyErr := verifyWakeResumeBoundImage(*resumeContext)
+			if verifyErr != nil {
+				return verifyErr
+			}
+			resumeImageEvidence = &verified
+		}
+		if resumeBootstrap != nil {
+			cleanupBootstrap := *resumeBootstrap
+			cleanupBootstrap.BoundImage = resumeImageEvidence
+			defer func() {
+				returnErr = errors.Join(returnErr, cleanupWakeResumeBoundImage(cleanupBootstrap))
+			}()
+		}
+	}
 
 	requestedOwner, err := wakeOwnerFromEnv()
 	if err != nil {
 		return err
+	}
+	if resumePreflight != nil {
+		if requestedOwner == nil {
+			return fmt.Errorf("wake resume preflight requires the exact coop owner environment")
+		}
+		if len(args) == 0 || args[len(args)-1] != "--"+wakeResumePreflightFlag {
+			return fmt.Errorf("wake resume preflight must be the final internal argument")
+		}
+		preservedArgv := append([]string{os.Args[0], "wake"}, args[:len(args)-1]...)
+		if err := validateWakeRestartArgv(preservedArgv, canonicalWakeRoot(root), me); err != nil {
+			return err
+		}
+		return writeStdoutLine(wakeResumePreflightOK)
 	}
 	if repairGeneration != "" && requestedOwner != nil {
 		return fmt.Errorf("owner-bearing wake state requires 'amq wake recover-owner --me %s'", me)
@@ -2128,7 +2202,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		lockWakeMode = effectiveInjectMode(&wakeConfig{me: me, injectMode: lockWakeMode})
 	}
 	acceptExistingDeadline := time.Now().Add(wakeReadyTimeout)
-	resumeEligible := wakeResumeStartupEligible(
+	resumeEligible := target == nil && wakeResumeStartupEligible(
 		requestedOwner,
 		repairLineage != nil,
 		*injectCmdFlag,
@@ -2155,13 +2229,27 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			requestedOwner:          requestedOwner,
 			repairLineage:           repairLineage,
 			resumeEligible:          resumeEligible,
+			resumeImageEvidence:     resumeImageEvidence,
 		}
 		if repairLineage != nil {
 			options.repairFloorAuthority = &repairFloorAuthority
 		}
-		cleanup, err = acquireWakeLockWithOptionsInDir(activeAgentDir, root, me, options)
+		if resumeBootstrap != nil {
+			cleanup, err = acquireWakeLockAfterResumeInDir(
+				activeAgentDir,
+				root,
+				me,
+				options,
+				*resumeBootstrap,
+			)
+		} else {
+			cleanup, err = acquireWakeLockWithOptionsInDir(activeAgentDir, root, me, options)
+		}
 		if err == nil {
 			break
+		}
+		if resumeBootstrap != nil {
+			return err
 		}
 		var creating *wakeLockCreatingError
 		if acceptExistingWake && errors.As(err, &creating) {
@@ -2323,6 +2411,7 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		interruptNotice:     strings.TrimSpace(*interruptNoticeFlag),
 		interruptCooldown:   *interruptCooldownFlag,
 		controlStop:         controlStop,
+		restartSignals:      restartSignals,
 		inspectTerminalGeneration: func() wakeLockInspection {
 			return inspectWakeTerminalGeneration(root, me)
 		},
@@ -2437,6 +2526,20 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 			if err := writeWakePreparedFileInDir(activeAgentDir, root, me, currentWake); err != nil {
 				return err
 			}
+			if resumeBootstrap != nil {
+				if err := cleanupPreviousWakeResumeBoundImage(*resumeBootstrap); err != nil {
+					_ = writeStderr("amq wake: preserve prior restart stage after cleanup refusal: %v\n", err)
+				}
+				if err := consumeWakeRestartAfterPrepared(
+					activeAgentDir,
+					root,
+					me,
+					currentWake,
+					*resumeBootstrap,
+				); err != nil {
+					return err
+				}
+			}
 			return writeWakeReadyFileAgainstOwnerInDir(
 				activeAgentDir,
 				root,
@@ -2508,7 +2611,8 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	// Reload transport is additive capability. If this process cannot confirm
 	// the freshly published lock identity, keep the ordinary notifier running
 	// without opening the unadvertised endpoint.
-	if reloadTransportEligible && currentWake.IdentityConfirmed {
+	if reloadTransportEligible && currentWake.IdentityConfirmed &&
+		currentWake.Lock.ResumeSignal != wakeResumeSignalUSR1 {
 		if requestedOwner == nil {
 			return fmt.Errorf("wake reload transport requires an exact owner")
 		}
@@ -2936,6 +3040,13 @@ func runWakeLoop(cfg wakeConfig) error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
+	restartCh := cfg.restartSignals
+	if restartCh == nil {
+		restartCh = make(chan os.Signal, 1)
+		signal.Notify(restartCh, syscall.SIGUSR1)
+		defer signal.Stop(restartCh)
+		cfg.restartSignals = restartCh
+	}
 	select {
 	case <-cfg.controlStop:
 		return nil
@@ -3563,6 +3674,13 @@ func runWakeLoop(cfg wakeConfig) error {
 		case <-sigCh:
 			// Clean exit on SIGHUP/SIGTERM
 			return nil
+		case <-restartCh:
+			handleWakeRestartAtLoopBoundary(
+				&cfg,
+				watcher,
+				terminalAuthorityRetryC != nil,
+				inboxScanRetryC != nil,
+			)
 
 		case event, ok := <-watcherEvents:
 			if !ok {


### PR DESCRIPTION
## Summary

- add `amq wake restart` for ordinary coop owner-bound wakes without requiring a caller TTY
- keep the existing notifier PID and terminal while replacing its image only at a quiescent delivery boundary
- bind Linux exec to an open executable FD and Darwin exec to an exact adjacent private hardlink, including safe cleanup across consecutive restarts
- make `wake check` and `doctor --ops` report restart readiness and pending handshakes without mutation
- keep inject-via, repair-lineage, arbitrary injection, and ownerless wakes outside the self-restart authority boundary
- classify same-ctime generation-marker mode/size races as changed snapshots so Linux callers retry fail-closed

Fixes #356.

## Release

This is a user-visible feature and should produce **v0.57.0** through Release Please.

## Exact review identity

- head: `16b2ea39336434a017fec00d7b41a20f0e6835b7`
- tree: `b1fd1d3f85a2350bb5b005cf885c15ddc1619aeb`

## Validation

- local `make ci`: PASS
- local `go test -race -count=1 ./internal/cli`: PASS
- Darwin real-PTY E2E: PASS; two consecutive prepared restarts preserve PID and unread work, remove the previous private stage, and leave zero stage residue after owner exit
- Linux exact-tip gate: PASS in official `golang:1.25` image `sha256:fe5d57d3b718e7a4986bae156c2d73f44973bfd313073aed08a4de6692bb6161` on linux/arm64, Go 1.25.12, kernel 6.8.0-117-generic
  - full `go test ./internal/cli -count=1`: PASS
  - focused restart and deterministic generation-marker tests: PASS
  - isolated privileged real-PTY restart: PASS; PID and unread work preserved
  - `/proc/sys/dev/tty/legacy_tiocsti`: original `0`, enabled `1` for the gate, trap-restored `0`, independently read back as `0`
- `GOOS=windows GOARCH=amd64 go build ./...`: PASS
- hosted push and pull-request CI, Gitleaks, and GitGuardian: PASS
- fresh exact-tip review after rebasing onto v0.56.1: PASS; #454 Darwin mapped-image identity and #458 submit-only no-LF behavior remain covered

## Wake test replacements

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestRunWakeWithLoopStartsUnadvertisedLinuxReloadTransportForOrdinaryOwner: replaced because signal-capable wakes now advertise SIGUSR1 self-restart and must not start the obsolete reload socket; the replacement verifies both the signal advertisement and absence of an endpoint.
TestRunWakeWithLoopClassifiesOptionalLinuxReloadTransportStartFailures: replaced because signal-capable wakes intentionally bypass the obsolete reload transport, making its startup-failure classification unreachable; the replacement verifies the transport is never started and the wake loop proceeds.
END_WAKE_TEST_CHANGE_JUSTIFICATION
