### PR TITLE
fix(release): enforce Skild alias ownership

### DIFF
--- a/.github/workflows/publish-skill.yml
+++ b/.github/workflows/publish-skill.yml
@@ -7,6 +7,11 @@ on:
         description: "Tag to publish skills from (e.g. v0.28.9)"
         required: true
         type: string
+      alias-from-skill:
+        description: "One-time source skill for an intentional alias transfer"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -24,6 +29,14 @@ jobs:
         with:
           ref: refs/tags/${{ inputs.tag }}
 
+      - name: Checkout current publisher tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .skild-publisher
+          sparse-checkout: scripts/publish-skild-skills.sh
+          sparse-checkout-cone-mode: false
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
@@ -32,9 +45,12 @@ jobs:
         run: npm install -g skild
 
       - name: Configure skild auth
+        env:
+          SKILD_AUTH_JSON: ${{ secrets.SKILD_AUTH_JSON }}
         run: |
+          umask 077
           mkdir -p ~/.skild
-          echo '${{ secrets.SKILD_AUTH_JSON }}' > ~/.skild/registry-auth.json
+          printf '%s' "$SKILD_AUTH_JSON" > ~/.skild/registry-auth.json
 
       - name: Resolve version from tag
         id: version
@@ -53,53 +69,6 @@ jobs:
       - name: Publish skills
         env:
           TAG_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          FAILED=0
-
-          for dir in skills/*/; do
-            [ -f "$dir/SKILL.md" ] || continue
-            SKILL=$(basename "$dir")
-            VERSION="${TAG_VERSION}"
-
-            echo "Publishing $SKILL version $VERSION"
-
-            ALIAS_ARGS=()
-            if [ ${#SKILL} -ge 3 ] && [ ${#SKILL} -le 64 ]; then
-              ALIAS_ARGS=(--alias "$SKILL")
-            else
-              echo "Skipping alias for $SKILL: length ${#SKILL} outside 3..64"
-            fi
-
-            if OUTPUT=$(npx skild publish \
-              --dir "$dir" \
-              "${ALIAS_ARGS[@]}" \
-              --skill-version "$VERSION" 2>&1); then
-              echo "$OUTPUT"
-              echo "Published $SKILL version $VERSION"
-            elif echo "$OUTPUT" | grep -q "Version already exists"; then
-              echo "$OUTPUT"
-              echo "$SKILL version $VERSION already published -- skipping"
-            elif echo "$OUTPUT" | grep -q "Alias already in use"; then
-              echo "$OUTPUT"
-              echo "Alias '$SKILL' taken -- retrying without alias..."
-              if OUTPUT2=$(npx skild publish \
-                --dir "$dir" \
-                --skill-version "$VERSION" 2>&1); then
-                echo "$OUTPUT2"
-                echo "Published $SKILL version $VERSION (without alias)"
-              elif echo "$OUTPUT2" | grep -q "Version already exists"; then
-                echo "$OUTPUT2"
-                echo "$SKILL version $VERSION already published on retry -- skipping"
-              else
-                echo "Publish failed for $SKILL (even without alias)"
-                echo "$OUTPUT2"
-                FAILED=1
-              fi
-            else
-              echo "Publish failed for $SKILL"
-              echo "$OUTPUT"
-              FAILED=1
-            fi
-          done
-
-          exit $FAILED
+          ALIAS_FROM_SKILL: ${{ inputs['alias-from-skill'] }}
+          SKILD_SKILLS_DIR: ${{ github.workspace }}/skills
+        run: ./.skild-publisher/scripts/publish-skild-skills.sh "$TAG_VERSION" "$ALIAS_FROM_SKILL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,9 +331,12 @@ jobs:
         run: npm install -g skild
 
       - name: Configure skild auth
+        env:
+          SKILD_AUTH_JSON: ${{ secrets.SKILD_AUTH_JSON }}
         run: |
+          umask 077
           mkdir -p ~/.skild
-          echo '${{ secrets.SKILD_AUTH_JSON }}' > ~/.skild/registry-auth.json
+          printf '%s' "$SKILD_AUTH_JSON" > ~/.skild/registry-auth.json
 
       - name: Verify release metadata
         run: ./scripts/check-release-version.sh "${{ needs.prepare.outputs.version }}"
@@ -341,58 +344,4 @@ jobs:
       - name: Publish skills
         env:
           TAG_VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          echo "$TAG_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' || {
-            echo "ERROR: version '$TAG_VERSION' is not semver"
-            exit 1
-          }
-
-          FAILED=0
-
-          for dir in skills/*/; do
-            [ -f "$dir/SKILL.md" ] || continue
-            SKILL=$(basename "$dir")
-            VERSION="${TAG_VERSION}"
-
-            echo "Publishing $SKILL version $VERSION"
-
-            ALIAS_ARGS=()
-            if [ ${#SKILL} -ge 3 ] && [ ${#SKILL} -le 64 ]; then
-              ALIAS_ARGS=(--alias "$SKILL")
-            else
-              echo "Skipping alias for $SKILL: length ${#SKILL} outside 3..64"
-            fi
-
-            if OUTPUT=$(npx skild publish \
-              --dir "$dir" \
-              "${ALIAS_ARGS[@]}" \
-              --skill-version "$VERSION" 2>&1); then
-              echo "$OUTPUT"
-              echo "Published $SKILL version $VERSION"
-            elif echo "$OUTPUT" | grep -q "Version already exists"; then
-              echo "$OUTPUT"
-              echo "$SKILL version $VERSION already published -- skipping"
-            elif echo "$OUTPUT" | grep -q "Alias already in use"; then
-              echo "$OUTPUT"
-              echo "Alias '$SKILL' taken -- retrying without alias..."
-              if OUTPUT2=$(npx skild publish \
-                --dir "$dir" \
-                --skill-version "$VERSION" 2>&1); then
-                echo "$OUTPUT2"
-                echo "Published $SKILL version $VERSION (without alias)"
-              elif echo "$OUTPUT2" | grep -q "Version already exists"; then
-                echo "$OUTPUT2"
-                echo "$SKILL version $VERSION already published on retry -- skipping"
-              else
-                echo "Publish failed for $SKILL (even without alias)"
-                echo "$OUTPUT2"
-                FAILED=1
-              fi
-            else
-              echo "Publish failed for $SKILL"
-              echo "$OUTPUT"
-              FAILED=1
-            fi
-          done
-
-          exit $FAILED
+        run: ./scripts/publish-skild-skills.sh "$TAG_VERSION"

--- a/scripts/publish-skild-skills.sh
+++ b/scripts/publish-skild-skills.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+VERSION="${1:-}"
+ALIAS_FROM_SKILL="${2:-}"
+SKILLS_DIR="${SKILD_SKILLS_DIR:-skills}"
+PUBLISHER="${SKILD_PUBLISHER:-avivsinai}"
+REGISTRY_URL="${SKILD_REGISTRY_URL:-}"
+AUTH_FILE="${SKILD_AUTH_FILE:-${HOME}/.skild/registry-auth.json}"
+CURL_BIN="${CURL_BIN:-curl}"
+NPX_BIN="${NPX_BIN:-npx}"
+
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]] ||
+  die "version '$VERSION' is not semver"
+[[ "$PUBLISHER" =~ ^[a-z0-9][a-z0-9-]{1,31}$ ]] ||
+  die "publisher '$PUBLISHER' is invalid"
+if [[ -n "$ALIAS_FROM_SKILL" && ! "$ALIAS_FROM_SKILL" =~ ^[a-z0-9][a-z0-9-]{1,63}$ ]]; then
+  die "alias source skill '$ALIAS_FROM_SKILL' is invalid"
+fi
+[[ -d "$SKILLS_DIR" ]] || die "skills directory '$SKILLS_DIR' does not exist"
+command -v jq >/dev/null 2>&1 || die "jq is required"
+command -v "$CURL_BIN" >/dev/null 2>&1 || die "$CURL_BIN is required"
+command -v "$NPX_BIN" >/dev/null 2>&1 || die "$NPX_BIN is required"
+
+TOKEN="${SKILD_TOKEN:-}"
+if [[ -z "$TOKEN" || -z "$REGISTRY_URL" ]]; then
+  [[ -r "$AUTH_FILE" ]] || die "Skild auth file '$AUTH_FILE' is not readable"
+  if [[ -z "$TOKEN" ]]; then
+    TOKEN="$(jq -er '.token | select(type == "string" and length > 0)' "$AUTH_FILE")" ||
+      die "Skild auth file does not contain a token"
+  fi
+  if [[ -z "$REGISTRY_URL" ]]; then
+    REGISTRY_URL="$(jq -er '.registryUrl | select(type == "string" and length > 0)' "$AUTH_FILE")" ||
+      die "Skild auth file does not contain a registry URL"
+  fi
+fi
+REGISTRY_URL="${REGISTRY_URL%/}"
+[[ "$REGISTRY_URL" =~ ^https://[^/[:space:]]+(/[^[:space:]]*)?$ ]] ||
+  die "Skild registry URL must use HTTPS"
+
+HTTP_STATUS=""
+HTTP_BODY=""
+request_json() {
+  local method="$1"
+  local url="$2"
+  local body="${3:-}"
+  local response_file
+  local status
+  local -a args
+
+  response_file="$(mktemp "${TMPDIR:-/tmp}/amq-skild-response.XXXXXX")"
+  args=(
+    --silent
+    --show-error
+    --max-time 15
+    --request "$method"
+    --header "accept: application/json"
+    --header "authorization: Bearer $TOKEN"
+    --output "$response_file"
+    --write-out '%{http_code}'
+  )
+  if [[ -n "$body" ]]; then
+    args+=(--header "content-type: application/json" --data "$body")
+  fi
+
+  if ! status="$($CURL_BIN "${args[@]}" "$url")"; then
+    rm -f "$response_file"
+    die "Skild registry request failed"
+  fi
+  [[ "$status" =~ ^[0-9]{3}$ ]] || {
+    rm -f "$response_file"
+    die "Skild registry returned a malformed HTTP status"
+  }
+  HTTP_STATUS="$status"
+  HTTP_BODY="$(<"$response_file")"
+  rm -f "$response_file"
+}
+
+valid_error_response() {
+  local expected="$1"
+  jq -e --arg expected "$expected" '
+    type == "object" and
+    keys == ["error", "ok"] and
+    .ok == false and
+    .error == $expected
+  ' >/dev/null 2>&1 <<<"$HTTP_BODY"
+}
+
+verify_version() {
+  local skill="$1"
+  local canonical="@$PUBLISHER/$skill"
+
+  request_json GET "$REGISTRY_URL/skills/$PUBLISHER/$skill/versions/$VERSION"
+  [[ "$HTTP_STATUS" == "200" ]] ||
+    die "canonical version verification failed for $canonical@$VERSION (HTTP $HTTP_STATUS)"
+  jq -e --arg canonical "$canonical" --arg version "$VERSION" '
+    type == "object" and
+    .ok == true and
+    .name == $canonical and
+    .version == $version and
+    (.integrity | type == "string" and length > 0) and
+    (.tarballUrl | type == "string" and length > 0)
+  ' >/dev/null 2>&1 <<<"$HTTP_BODY" ||
+    die "canonical version verification returned malformed or mismatched data for $canonical@$VERSION"
+}
+
+alias_success_response() {
+  local canonical="$1"
+  local alias="$2"
+  jq -e --arg canonical "$canonical" --arg alias "$alias" '
+    type == "object" and
+    .ok == true and
+    .name == $canonical and
+    .alias == $alias
+  ' >/dev/null 2>&1 <<<"$HTTP_BODY"
+}
+
+alias_clear_success_response() {
+  local canonical="$1"
+  jq -e --arg canonical "$canonical" '
+    type == "object" and
+    .ok == true and
+    .name == $canonical and
+    .alias == null
+  ' >/dev/null 2>&1 <<<"$HTTP_BODY"
+}
+
+post_alias() {
+  local skill="$1"
+  local alias="$2"
+  local payload
+
+  if [[ -n "$alias" ]]; then
+    payload="$(jq -cn --arg alias "$alias" '{alias: $alias}')"
+  else
+    payload='{"alias":null}'
+  fi
+  request_json POST "$REGISTRY_URL/publisher/skills/$PUBLISHER/$skill/alias" "$payload"
+}
+
+verify_alias() {
+  local skill="$1"
+  local canonical="@$PUBLISHER/$skill"
+
+  request_json GET "$REGISTRY_URL/resolve?alias=$skill"
+  [[ "$HTTP_STATUS" == "200" ]] ||
+    die "alias verification failed for $skill (HTTP $HTTP_STATUS)"
+  jq -e --arg alias "$skill" --arg canonical "$canonical" '
+    type == "object" and
+    .ok == true and
+    .alias == $alias and
+    .type == "registry" and
+    .spec == $canonical
+  ' >/dev/null 2>&1 <<<"$HTTP_BODY" ||
+    die "alias '$skill' does not resolve exactly to $canonical"
+}
+
+verify_target_alias_empty() {
+  local skill="$1"
+  local canonical="@$PUBLISHER/$skill"
+
+  request_json GET "$REGISTRY_URL/skills/$PUBLISHER/$skill"
+  [[ "$HTTP_STATUS" == "200" ]] ||
+    die "cannot verify target alias state for $canonical (HTTP $HTTP_STATUS)"
+  jq -e --arg canonical "$canonical" '
+    type == "object" and
+    .ok == true and
+    (.skill | type == "object") and
+    .skill.name == $canonical and
+    .skill.alias == null
+  ' >/dev/null 2>&1 <<<"$HTTP_BODY" ||
+    die "target $canonical already owns a different alias; refusing migration"
+}
+
+rollback_alias() {
+  local old_skill="$1"
+  local alias="$2"
+  local old_canonical="@$PUBLISHER/$old_skill"
+
+  if post_alias "$old_skill" "$alias" &&
+      [[ "$HTTP_STATUS" == "200" ]] &&
+      alias_success_response "$old_canonical" "$alias"; then
+    echo "Restored alias '$alias' to $old_canonical after target assignment failed" >&2
+  else
+    echo "WARNING: failed to restore alias '$alias' to $old_canonical" >&2
+  fi
+}
+
+reconcile_alias() {
+  local skill="$1"
+  local canonical="@$PUBLISHER/$skill"
+  local old_canonical
+  local failed_status
+
+  post_alias "$skill" "$skill"
+  if [[ "$HTTP_STATUS" == "200" ]]; then
+    alias_success_response "$canonical" "$skill" ||
+      die "alias assignment returned malformed or mismatched data for $canonical"
+    verify_alias "$skill"
+    echo "Alias '$skill' resolves to $canonical"
+    return
+  fi
+
+  if [[ "$HTTP_STATUS" != "409" ]] || ! valid_error_response "Alias already in use."; then
+    die "alias assignment failed for $canonical (HTTP $HTTP_STATUS)"
+  fi
+  [[ -n "$ALIAS_FROM_SKILL" ]] ||
+    die "alias '$skill' is already in use; no explicit migration source was supplied"
+  [[ "$ALIAS_FROM_SKILL" != "$skill" ]] ||
+    die "alias migration source and target are both '$skill'"
+
+  old_canonical="@$PUBLISHER/$ALIAS_FROM_SKILL"
+  request_json GET "$REGISTRY_URL/resolve?alias=$skill"
+  [[ "$HTTP_STATUS" == "200" ]] ||
+    die "cannot verify migration source for alias '$skill' (HTTP $HTTP_STATUS)"
+  jq -e --arg alias "$skill" --arg canonical "$old_canonical" '
+    type == "object" and
+    .ok == true and
+    .alias == $alias and
+    .type == "registry" and
+    .spec == $canonical
+  ' >/dev/null 2>&1 <<<"$HTTP_BODY" ||
+    die "alias '$skill' does not resolve exactly to the approved migration source $old_canonical"
+
+  verify_target_alias_empty "$skill"
+
+  post_alias "$ALIAS_FROM_SKILL" ""
+  if [[ "$HTTP_STATUS" != "200" ]] || ! alias_clear_success_response "$old_canonical"; then
+    die "failed to clear alias '$skill' from $old_canonical (HTTP $HTTP_STATUS)"
+  fi
+
+  post_alias "$skill" "$skill"
+  if [[ "$HTTP_STATUS" != "200" ]] || ! alias_success_response "$canonical" "$skill"; then
+    failed_status="$HTTP_STATUS"
+    rollback_alias "$ALIAS_FROM_SKILL" "$skill"
+    die "failed to assign migrated alias '$skill' to $canonical (HTTP $failed_status)"
+  fi
+
+  verify_alias "$skill"
+  echo "Migrated alias '$skill' from $old_canonical to $canonical"
+}
+
+published=0
+for dir in "$SKILLS_DIR"/*/; do
+  [[ -f "$dir/SKILL.md" ]] || continue
+  skill="$(basename "$dir")"
+  [[ "$skill" =~ ^[a-z0-9][a-z0-9-]{2,63}$ ]] ||
+    die "skill '$skill' cannot be used as a Skild alias"
+  canonical="@$PUBLISHER/$skill"
+  output_file="$(mktemp "${TMPDIR:-/tmp}/amq-skild-publish.XXXXXX")"
+
+  echo "Publishing $canonical@$VERSION"
+  if "$NPX_BIN" skild publish --dir "$dir" --skill-version "$VERSION" >"$output_file" 2>&1; then
+    echo "Published $canonical@$VERSION"
+  elif grep -Fqx '{"ok":false,"error":"Version already exists."}' "$output_file"; then
+    echo "$canonical@$VERSION already exists"
+  else
+    echo "Publish failed for $canonical@$VERSION" >&2
+    sed -n '1,80p' "$output_file" >&2
+    rm -f "$output_file"
+    exit 1
+  fi
+  rm -f "$output_file"
+
+  verify_version "$skill"
+  reconcile_alias "$skill"
+  published=$((published + 1))
+done
+
+[[ "$published" -gt 0 ]] || die "no publishable skills found in '$SKILLS_DIR'"
+echo "Published and verified $published Skild skill(s)"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -142,6 +142,7 @@ if command -v python3 >/dev/null 2>&1; then
   bash scripts/test_release_please_state.sh
   bash scripts/test_reconcile_release_please_labels.sh
   bash scripts/test_release_workflow_labels.sh
+  bash scripts/test_publish_skild_skills.sh
   bash scripts/test_git_env_sanitization.sh
 fi
 

--- a/scripts/test_publish_skild_skills.sh
+++ b/scripts/test_publish_skild_skills.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/publish-skild-skills.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+run_case() {
+  local name="$1"
+  local scenario="$2"
+  local publish_mode="$3"
+  local expect="$4"
+  local alias_from="${5:-}"
+  local expected_curl_calls="${6:-}"
+  local case_dir="$TEST_ROOT/$name"
+  local status=0
+
+  mkdir -p "$case_dir/bin" "$case_dir/home/.skild" "$case_dir/skills/amq-spec"
+  printf '%s\n' '---' 'name: amq-spec' 'description: test' '---' >"$case_dir/skills/amq-spec/SKILL.md"
+  printf '%s\n' '{"registryUrl":"https://registry.test","token":"test-secret"}' >"$case_dir/home/.skild/registry-auth.json"
+  cp "$FAKE_NPX" "$case_dir/bin/npx"
+  cp "$FAKE_CURL" "$case_dir/bin/curl"
+  chmod +x "$case_dir/bin/npx" "$case_dir/bin/curl"
+
+  if env \
+    HOME="$case_dir/home" \
+    PATH="$case_dir/bin:$PATH" \
+    SKILD_SKILLS_DIR="$case_dir/skills" \
+    FAKE_SCENARIO="$scenario" \
+    FAKE_PUBLISH_MODE="$publish_mode" \
+    FAKE_STATE_DIR="$case_dir/state" \
+    "$SCRIPT" 0.57.0 "$alias_from" >"$case_dir/stdout" 2>"$case_dir/stderr"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [[ "$expect" == success && "$status" -ne 0 ]]; then
+    sed -n '1,160p' "$case_dir/stderr" >&2
+    fail "$name returned $status, expected success"
+  fi
+  if [[ "$expect" == failure && "$status" -eq 0 ]]; then
+    fail "$name succeeded, expected failure"
+  fi
+  if grep -Fq 'test-secret' "$case_dir/stdout" "$case_dir/stderr"; then
+    fail "$name leaked the auth token"
+  fi
+  if grep -Fq -- '--alias' "$case_dir/state/npx.log"; then
+    fail "$name passed an alias to skild publish"
+  fi
+  [[ "$(wc -l <"$case_dir/state/npx.log" | tr -d ' ')" == "1" ]] ||
+    fail "$name did not call skild publish exactly once"
+  if [[ -n "$expected_curl_calls" ]]; then
+    [[ "$(wc -l <"$case_dir/state/curl.log" | tr -d ' ')" == "$expected_curl_calls" ]] ||
+      fail "$name made an unexpected number of registry calls"
+  fi
+}
+
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/amq-skild-test.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+FAKE_NPX="$TEST_ROOT/fake-npx"
+FAKE_CURL="$TEST_ROOT/fake-curl"
+
+cat >"$FAKE_NPX" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$FAKE_STATE_DIR"
+printf '%q ' "$@" >>"$FAKE_STATE_DIR/npx.log"
+printf '\n' >>"$FAKE_STATE_DIR/npx.log"
+case "$FAKE_PUBLISH_MODE" in
+  fresh) echo "published" ;;
+  exists)
+    echo "Publish failed (409)"
+    echo '{"ok":false,"error":"Version already exists."}'
+    exit 1
+    ;;
+  *) echo "unexpected publish failure" >&2; exit 1 ;;
+esac
+FAKE
+
+cat >"$FAKE_CURL" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$FAKE_STATE_DIR"
+method=GET
+output=""
+data=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --request) method="$2"; shift 2 ;;
+    --output) output="$2"; shift 2 ;;
+    --data) data="$2"; shift 2 ;;
+    --header|--max-time|--write-out) shift 2 ;;
+    --silent|--show-error) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+printf '%s\t%s\t%s\n' "$method" "$url" "$data" >>"$FAKE_STATE_DIR/curl.log"
+count="$(wc -l <"$FAKE_STATE_DIR/curl.log" | tr -d ' ')"
+status=200
+body='{}'
+
+case "$FAKE_SCENARIO:$count" in
+  fresh:1|exists:1|wrong-alias:1|wrong-conflict:1|target-alias:1|malformed:1|migration:1|rollback:1)
+    body='{"ok":true,"name":"@avivsinai/amq-spec","version":"0.57.0","integrity":"sha256","tarballUrl":"/tarball"}'
+    ;;
+  network:1)
+    exit 7
+    ;;
+  not-found:1)
+    status=404
+    body='{"ok":false,"error":"Skill not found."}'
+    ;;
+  fresh:2|exists:2)
+    body='{"ok":true,"name":"@avivsinai/amq-spec","alias":"amq-spec"}'
+    ;;
+  fresh:3|exists:3|migration:7)
+    body='{"ok":true,"alias":"amq-spec","type":"registry","spec":"@avivsinai/amq-spec"}'
+    ;;
+  wrong-alias:2|target-alias:2|migration:2|rollback:2)
+    status=409
+    body='{"ok":false,"error":"Alias already in use."}'
+    ;;
+  wrong-conflict:2)
+    status=409
+    body='{"ok":false,"error":"Different conflict."}'
+    ;;
+  malformed:2)
+    body='{"ok":true,"name":42,"alias":"amq-spec"}'
+    ;;
+  target-alias:3|migration:3|rollback:3)
+    body='{"ok":true,"alias":"amq-spec","type":"registry","spec":"@avivsinai/spec"}'
+    ;;
+  migration:4|rollback:4)
+    body='{"ok":true,"skill":{"name":"@avivsinai/amq-spec","alias":null}}'
+    ;;
+  target-alias:4)
+    body='{"ok":true,"skill":{"name":"@avivsinai/amq-spec","alias":"other-alias"}}'
+    ;;
+  migration:5|rollback:5)
+    body='{"ok":true,"name":"@avivsinai/spec","alias":null}'
+    ;;
+  migration:6)
+    body='{"ok":true,"name":"@avivsinai/amq-spec","alias":"amq-spec"}'
+    ;;
+  rollback:6)
+    status=500
+    body='{"ok":false,"error":"temporary failure"}'
+    ;;
+  rollback:7)
+    body='{"ok":true,"name":"@avivsinai/spec","alias":"amq-spec"}'
+    ;;
+  *)
+    status=500
+    body='{"ok":false,"error":"unexpected request"}'
+    ;;
+esac
+
+printf '%s' "$body" >"$output"
+printf '%s' "$status"
+FAKE
+
+run_case fresh fresh fresh success "" 3
+run_case version_exists exists exists success "" 3
+run_case wrong_alias_409 wrong-alias exists failure "" 2
+run_case wrong_conflict_409 wrong-conflict exists failure spec 2
+run_case target_has_other_alias target-alias exists failure spec 4
+run_case not_found not-found fresh failure "" 1
+run_case malformed malformed fresh failure "" 2
+run_case network network fresh failure "" 1
+run_case migration migration exists success spec 7
+run_case rollback rollback exists failure spec 7
+
+assert_curl_line() {
+  local case_name="$1"
+  local line_number="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(sed -n "${line_number}p" "$TEST_ROOT/$case_name/state/curl.log")"
+  [[ "$actual" == "$expected" ]] ||
+    fail "$case_name registry call $line_number was '$actual', want '$expected'"
+}
+
+assert_curl_line fresh 1 $'GET\thttps://registry.test/skills/avivsinai/amq-spec/versions/0.57.0\t'
+assert_curl_line fresh 2 $'POST\thttps://registry.test/publisher/skills/avivsinai/amq-spec/alias\t{"alias":"amq-spec"}'
+assert_curl_line fresh 3 $'GET\thttps://registry.test/resolve?alias=amq-spec\t'
+
+assert_curl_line migration 3 $'GET\thttps://registry.test/resolve?alias=amq-spec\t'
+assert_curl_line migration 4 $'GET\thttps://registry.test/skills/avivsinai/amq-spec\t'
+assert_curl_line migration 5 $'POST\thttps://registry.test/publisher/skills/avivsinai/spec/alias\t{"alias":null}'
+assert_curl_line migration 6 $'POST\thttps://registry.test/publisher/skills/avivsinai/amq-spec/alias\t{"alias":"amq-spec"}'
+assert_curl_line migration 7 $'GET\thttps://registry.test/resolve?alias=amq-spec\t'
+
+grep -Fq $'POST\thttps://registry.test/publisher/skills/avivsinai/spec/alias\t{"alias":"amq-spec"}' \
+  "$TEST_ROOT/rollback/state/curl.log" || fail "rollback did not attempt to restore the old alias"
+if grep -Fq '/publisher/skills/avivsinai/spec/alias' "$TEST_ROOT/target_has_other_alias/state/curl.log"; then
+  fail "migration cleared the source before proving the target alias was empty"
+fi
+if grep -Fq '/publisher/skills/avivsinai/spec/alias' "$TEST_ROOT/wrong_conflict_409/state/curl.log"; then
+  fail "a non-alias 409 triggered migration"
+fi
+
+RELEASE_WORKFLOW="$REPO_ROOT/.github/workflows/release.yml"
+MANUAL_WORKFLOW="$REPO_ROOT/.github/workflows/publish-skill.yml"
+RELEASE_COMMAND="run: ./scripts/publish-skild-skills.sh \"\$TAG_VERSION\""
+WORKFLOW_SHA_REF="ref: \${{ github.workflow_sha }}"
+MANUAL_COMMAND="run: ./.skild-publisher/scripts/publish-skild-skills.sh \"\$TAG_VERSION\" \"\$ALIAS_FROM_SKILL\""
+
+grep -Fq "$RELEASE_COMMAND" "$RELEASE_WORKFLOW" ||
+  fail "release workflow does not use the hardened publisher"
+grep -Fq 'alias-from-skill:' "$MANUAL_WORKFLOW" ||
+  fail "manual workflow does not expose explicit alias migration"
+grep -Fq "$WORKFLOW_SHA_REF" "$MANUAL_WORKFLOW" ||
+  fail "manual workflow does not check out current publisher tooling"
+grep -Fq "$MANUAL_COMMAND" "$MANUAL_WORKFLOW" ||
+  fail "manual workflow does not use the hardened publisher"
+if grep -Fq 'retrying without alias' "$RELEASE_WORKFLOW" "$MANUAL_WORKFLOW"; then
+  fail "a workflow still masks alias conflicts with an aliasless retry"
+fi
+
+echo "PASS: Skild publish and alias reconciliation"


### PR DESCRIPTION
## Summary

- publish each canonical Skild version independently, then verify the exact version and alias postconditions
- remove the aliasless retry that turned an alias conflict into a false successful release
- fail closed on wrong, missing, malformed, or conflicting alias state
- provide an explicit manual alias-transfer path that proves the approved source and an alias-free target before mutation, with best-effort rollback
- use current hardened publisher tooling when republishing historical tagged skill content
- run the fake-registry failure matrix in the normal smoke suite

## Release

This is a release-pipeline bug fix and should produce **v0.57.1** through Release Please.

## Validation

- `make ci`: PASS
- `bash scripts/test_publish_skild_skills.sh`: PASS
- `bash -n` and ShellCheck for both new scripts: PASS
- workflow YAML parse and `git diff --check`: PASS
- two independent final reviews: PASS after adding target-alias preflight and exact registry-call assertions

Exact reviewed head: `a4d9fefc291738946a8b7982ea5354f09b9cdb54`
Exact tree: `74a80c7287baac95eccb74d3945f3a7afd138f56`

## Post-merge live gate

After merge, dispatch `Publish Skills` for tag `v0.57.0` with `alias-from-skill=spec`, require the workflow to pass, then verify:

- `amq-cli` resolves to `@avivsinai/amq-cli`
- `amq-spec` resolves to `@avivsinai/amq-spec`
