### PR TITLE
test(wake): cover legacy Linux reload fallback

### DIFF
--- a/internal/cli/wake_reload_wiring_linux_test.go
+++ b/internal/cli/wake_reload_wiring_linux_test.go
@@ -161,6 +161,145 @@ func TestRunWakeWithLoopSkipsObsoleteLinuxReloadTransportForSignalWake(t *testin
 	}
 }
 
+func TestRunWakeWithLoopClassifiesLegacyLinuxReloadTransportWhenResumeEvidenceUnavailable(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	ownerProcess := exec.Command("/bin/sh", "-c", "exec sleep 30")
+	if err := ownerProcess.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = ownerProcess.Process.Kill()
+		_ = ownerProcess.Wait()
+	})
+	owner := authoritativeOwnerForPIDForCoopWakeTest(t, ownerProcess.Process.Pid)
+	inspectProcess := inspectWakeProcess
+	wakeProcess := inspectProcess(os.Getpid())
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != os.Getpid() {
+			return inspectProcess(pid)
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: wakeProcess.StartToken,
+			BootID:     wakeProcess.BootID,
+			Executable: "/usr/local/bin/amq",
+			Args: []string{
+				"amq", "wake", "--root", root, "--me", "codex",
+				"--inject-mode", wakeInjectModeNone, "--interrupt=false",
+			},
+		}
+	})
+	encoded, err := encodeWakeOwnerEnv(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envWakeOwner, encoded)
+
+	oldCapture := captureCurrentWakeImageEvidence
+	captureCurrentWakeImageEvidence = func() (wakeImageEvidenceV1, error) {
+		return wakeImageEvidenceV1{}, errors.New("test wake image unavailable")
+	}
+	t.Cleanup(func() { captureCurrentWakeImageEvidence = oldCapture })
+
+	bindFailure := errors.New("test reload bind failure")
+	authorityFailure := errors.New("wake reload owner exited during startup")
+	tests := []struct {
+		name            string
+		startErr        error
+		wantErr         error
+		wantErrContains string
+		wantLoop        bool
+		wantDegrade     bool
+	}{
+		{
+			name:        "unavailable degrades",
+			startErr:    &wakeReloadTransportUnavailableError{err: bindFailure},
+			wantLoop:    true,
+			wantDegrade: true,
+		},
+		{
+			name:     "authority failure aborts",
+			startErr: authorityFailure,
+			wantErr:  authorityFailure,
+		},
+		{
+			name:            "nil cleanup aborts",
+			wantErrContains: "wake reload transport returned no cleanup",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			startCalls := 0
+			oldStart := startWakeReloadTransportForWake
+			startWakeReloadTransportForWake = func(
+				_ *wakeAgentDir,
+				gotRoot string,
+				gotAgent string,
+				inspection wakeLockInspection,
+				gotOwner wakeOwner,
+			) (func(), error) {
+				startCalls++
+				if gotRoot != canonicalWakeRoot(root) || gotAgent != "codex" || gotOwner != owner {
+					t.Fatalf("reload start identity = root %q agent %q owner %#v", gotRoot, gotAgent, gotOwner)
+				}
+				if !inspection.IdentityConfirmed {
+					t.Fatal("reload start did not receive confirmed lock identity")
+				}
+				if inspection.Lock.ResumeSchema != 0 || inspection.Lock.ResumeOwner != nil ||
+					inspection.Lock.ResumeSignal != "" || inspection.Lock.ControlSocket != "" ||
+					inspection.Lock.RunningImageEvidence != nil {
+					t.Fatalf("missing-image fallback lock advertised resume metadata: %#v", inspection.Lock)
+				}
+				return nil, test.startErr
+			}
+			t.Cleanup(func() { startWakeReloadTransportForWake = oldStart })
+
+			loopCalled := false
+			var runErr error
+			stderr := captureWakeStderr(t, func() {
+				runErr = runWakeWithLoop([]string{
+					"--root", root,
+					"--me", "codex",
+					"--inject-mode", wakeInjectModeNone,
+					"--interrupt=false",
+				}, func(wakeConfig) error {
+					loopCalled = true
+					return nil
+				})
+			})
+
+			if startCalls != 1 {
+				t.Fatalf("reload transport start calls = %d, want 1", startCalls)
+			}
+			if loopCalled != test.wantLoop {
+				t.Fatalf("wake loop called = %v, want %v", loopCalled, test.wantLoop)
+			}
+			switch {
+			case test.wantErr != nil:
+				if !errors.Is(runErr, test.wantErr) {
+					t.Fatalf("runWakeWithLoop error = %v, want %v", runErr, test.wantErr)
+				}
+			case test.wantErrContains != "":
+				if runErr == nil || !strings.Contains(runErr.Error(), test.wantErrContains) {
+					t.Fatalf("runWakeWithLoop error = %v, want containing %q", runErr, test.wantErrContains)
+				}
+			case runErr != nil:
+				t.Fatal(runErr)
+			}
+			if test.wantDegrade {
+				if !strings.Contains(stderr, "reload transport unavailable: "+bindFailure.Error()) ||
+					!strings.Contains(stderr, "continuing without reload transport") {
+					t.Fatalf("reload transport degradation note = %q", stderr)
+				}
+			} else if strings.Contains(stderr, "continuing without reload transport") {
+				t.Fatalf("hard reload transport failure was narrated as degradable: %q", stderr)
+			}
+		})
+	}
+}
+
 func TestRunWakeWithLoopDoesNotStartLinuxReloadTransportOutsideOrdinaryOwner(t *testing.T) {
 	t.Run("ownerless", func(t *testing.T) {
 		root := secureTempDirForTest(t)


### PR DESCRIPTION
## Summary

- restore integration coverage for the still-reachable legacy Linux reload transport when wake image evidence is unavailable
- assert the fallback starts exactly once with the proven owner-bound lock and no resume metadata
- preserve the three real classifications: unavailable degrades, hard failure aborts, and nil cleanup aborts

## Validation

- pinned Linux/arm64 Go 1.25.12 focused test: PASS
- pinned Linux/arm64 Go 1.25.12 focused race test: PASS
- surrounding Linux reload-wiring tests: PASS
- `gofmt` and `git diff --check`: PASS
- independent review: PASS

Exact reviewed head: `eefad3d78233cdca95668b3df9357d6efe90f4d0`
Exact tree: `c21475845152985f587ba8b221ec79073e2c1e77`

This is test coverage only and should not create a release.

Bead: `agent-message-queue-0jj.7`
