### PR TITLE
fix(wake): harden restart control plane

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -347,6 +347,14 @@ func runDoctor(args []string) error {
 					wakeCheckTextValue(wl.RestartCapability),
 					wakeCheckTextValue(wl.NextAction),
 				)
+				if wl.RestartStageStatus != "" {
+					line += fmt.Sprintf(
+						" restart_stage=%s restart_stage_path=%s restart_stage_reason=%s",
+						wl.RestartStageStatus,
+						wakeCheckTextValue(wl.RestartStagePath),
+						wakeCheckTextValue(wl.RestartStageReason),
+					)
+				}
 				if err := writeStdoutLine(line); err != nil {
 					return err
 				}
@@ -367,7 +375,7 @@ func runDoctor(args []string) error {
 			if wl.Reason != "" {
 				line += " reason=" + wl.Reason
 			}
-			if wl.Fix != "" && wl.Status == string(wakeLockStale) {
+			if wl.Fix != "" && (wl.Status == string(wakeLockStale) || wl.RestartStageStatus != "") {
 				line += " fix=" + wl.Fix
 			}
 			if wl.TargetPresent {
@@ -392,6 +400,14 @@ func runDoctor(args []string) error {
 					wakeCheckTextValue(wl.ImageStatus),
 					wl.RestartCapability,
 					wakeCheckTextValue(wl.NextAction),
+				)
+			}
+			if wl.RestartStageStatus != "" {
+				line += fmt.Sprintf(
+					" restart_stage=%s restart_stage_path=%s restart_stage_reason=%s",
+					wl.RestartStageStatus,
+					wakeCheckTextValue(wl.RestartStagePath),
+					wakeCheckTextValue(wl.RestartStageReason),
 				)
 			}
 			if err := writeStdoutLine(line); err != nil {

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -114,6 +114,9 @@ type opsWakeLock struct {
 	CurrentVersion           string `json:"current_version,omitempty"`
 	ImageStatus              string `json:"image_status,omitempty"`
 	RestartCapability        string `json:"restart_capability,omitempty"`
+	RestartStagePath         string `json:"restart_stage_path,omitempty"`
+	RestartStageStatus       string `json:"restart_stage_status,omitempty"`
+	RestartStageReason       string `json:"restart_stage_reason,omitempty"`
 	OperatorTerminalRequired bool   `json:"operator_terminal_required"`
 	NextAction               string `json:"next_action,omitempty"`
 	InspectionError          string `json:"inspection_error,omitempty"`
@@ -540,7 +543,14 @@ func checkWakeLocksWithHintsSchema(
 ) ([]opsWakeLock, []opsHint) {
 	var locks []opsWakeLock
 	var hints []opsHint
-	appendLock := func(agent string, lock opsWakeLock, inspection wakeLockInspection, staleBinary bool) {
+	appendLock := func(
+		agent string,
+		lock opsWakeLock,
+		inspection wakeLockInspection,
+		staleBinary bool,
+		stage wakeRestartStageDiagnostic,
+	) {
+		fixCommand := lock.Fix
 		decorateOpsWakeLockWithWakeCheck(
 			root,
 			agent,
@@ -549,6 +559,12 @@ func checkWakeLocksWithHintsSchema(
 			staleBinary,
 			jsonSchema == wakeCheckSchemaV2,
 		)
+		lock.RestartStagePath = stage.Path
+		lock.RestartStageStatus = stage.Status
+		lock.RestartStageReason = stage.Reason
+		if stage.Status != "" && fixCommand != "" {
+			lock.Fix = fixCommand
+		}
 		if lock.WakeCheckDecision != nil && lock.WakeCheckDecision.Platform.WakeSupported {
 			status := lock.WakeCheckDecision.Wake.Status
 			lock.NotifierAbsent = status == string(wakeLockMissing) || status == string(wakeLockStale)
@@ -563,7 +579,39 @@ func checkWakeLocksWithHintsSchema(
 		}
 		mutationAuthorized := fsq.ValidateHandle(agent) == nil
 		inspection := inspectWakeLock(root, agent)
+		stage := diagnoseWakeRestartStage(root, agent, inspection)
 		if !inspection.Exists {
+			if stage.Status == "" {
+				continue
+			}
+			lock := opsWakeLock{
+				Status: string(wakeLockMissing),
+				Agent:  agent,
+				Root:   inspection.Root,
+				Lock:   inspection.LockPath,
+				Reason: inspection.Reason,
+				Fix:    doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks"),
+			}
+			if fix {
+				fixErr := fixWakeRestartResidueWithoutLock(root, agent)
+				inspection = inspectWakeLock(root, agent)
+				stage = diagnoseWakeRestartStage(root, agent, inspection)
+				if fixErr != nil {
+					lock.Status = "error"
+					lock.Reason = fixErr.Error()
+				} else {
+					lock.Fix = ""
+					lock.Status = "fixed"
+					lock.Reason = ""
+					lock.Removed = true
+				}
+				lock.Mutation = &opsWakeMutation{
+					Status:  lock.Status,
+					Reason:  lock.Reason,
+					Removed: lock.Removed,
+				}
+			}
+			appendLock(agent, lock, inspection, false, stage)
 			continue
 		}
 		staleBinary := false
@@ -596,7 +644,7 @@ func checkWakeLocksWithHintsSchema(
 			lock.Reason = "live raw wake orphan; stop the owning terminal or launchd supervisor"
 		}
 		if !mutationAuthorized {
-			appendLock(agent, lock, inspection, staleBinary)
+			appendLock(agent, lock, inspection, staleBinary, stage)
 			continue
 		}
 		assessment := assessWakeRepair(
@@ -617,7 +665,7 @@ func checkWakeLocksWithHintsSchema(
 		}
 		if inspection.Status == wakeLockStale {
 			if ownerBound {
-				appendLock(agent, lock, inspection, staleBinary)
+				appendLock(agent, lock, inspection, staleBinary, stage)
 				continue
 			}
 			lock.Fix = doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
@@ -645,7 +693,10 @@ func checkWakeLocksWithHintsSchema(
 				}
 			}
 		}
-		appendLock(agent, lock, inspection, staleBinary)
+		if fix {
+			stage = diagnoseWakeRestartStage(root, agent, inspection)
+		}
+		appendLock(agent, lock, inspection, staleBinary, stage)
 	}
 	return locks, hints
 }

--- a/internal/cli/doctor_ops_unix_test.go
+++ b/internal/cli/doctor_ops_unix_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -117,6 +118,55 @@ func TestRunOpsChecksAlwaysReportsExactWakeQuarantineNamesWithoutLocks(t *testin
 	v2 := renderDoctorResultV2(doctorResult{Ops: result})
 	if v2.Ops == nil || v2.Ops.WakeQuarantine.Count != 2 {
 		t.Fatalf("schema v2 wake quarantine = %#v", v2.Ops)
+	}
+}
+
+func TestRunOpsChecksFailedNoLockRestartFixRetainsRemedy(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"alice"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	agentDir := fsq.AgentBase(root, "alice")
+	restartPath := filepath.Join(agentDir, wakeRestartFileName)
+	raw := []byte(`{"schema":`)
+	if err := os.WriteFile(restartPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(restartPath, wakeLifecycleGuardPath(root, "alice")); err != nil {
+		t.Fatal(err)
+	}
+
+	result := runOpsChecksWithSchema(root, "test", true, wakeCheckSchemaV2)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("doctor wake diagnostics = %#v, want one failed restart fix", result.WakeLocks)
+	}
+	got := result.WakeLocks[0]
+	wantFix := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
+	if got.Status != string(wakeLockMissing) || got.Mutation == nil || got.Mutation.Status != "error" ||
+		!strings.Contains(got.Mutation.Reason, "lifecycle guard") || got.Fix != wantFix {
+		t.Fatalf("failed no-lock restart fix = %#v, want retained remedy %q", got, wantFix)
+	}
+	after, err := os.ReadFile(restartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(raw) {
+		t.Fatalf("failed doctor fix mutated restart record: got %q, want %q", after, raw)
+	}
+	quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+	if err != nil || len(quarantined) != 0 {
+		t.Fatalf("failed doctor fix quarantined restart record: %v, err=%v", quarantined, err)
 	}
 }
 

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -499,7 +499,7 @@ func classifyWakeCheckReload(root, agent string, inspection wakeLockInspection) 
 		}
 		return unavailable(wakeReloadReasonAdvertisementInvalid)
 	}
-	if inspection.Lock.ResumeSignal == wakeResumeSignalUSR1 {
+	if err := validateWakeRestartTransportPlatform(inspection.Lock, root, agent); err == nil {
 		readiness, err := observeWakeRestartReadiness(root, agent, inspection)
 		if err != nil {
 			return unavailable(wakeReloadReasonNotPrepared)

--- a/internal/cli/wake_control_darwin.go
+++ b/internal/cli/wake_control_darwin.go
@@ -30,13 +30,17 @@ const darwinXUCredVersion uint32 = 0
 
 type wakeControlOwnerRequest struct {
 	Generation string     `json:"generation"`
+	RequestID  string     `json:"request_id,omitempty"`
 	Owner      *wakeOwner `json:"owner,omitempty"`
 	Rollback   bool       `json:"rollback,omitempty"`
 	Operation  string     `json:"operation,omitempty"`
 }
 
+const wakeControlRestartOperation = "restart"
+
 func wakeControlSocketPath(root, me, generation string) string {
-	sum := sha256.Sum256([]byte(canonicalWakeRoot(root) + "\x00" + me + "\x00" + generation))
+	root = canonicalWakeRoot(root)
+	sum := sha256.Sum256([]byte(root + "\x00" + me + "\x00" + generation))
 	return filepath.Join(fsq.AgentBase(root, me), ".w."+hex.EncodeToString(sum[:8]))
 }
 
@@ -197,7 +201,9 @@ func dialDarwinUnixAt(agentDir *wakeAgentDir, name string, timeout time.Duration
 func darwinControlSocketName(agentDir *wakeAgentDir, path string) (string, error) {
 	cleanPath := filepath.Clean(path)
 	name := filepath.Base(cleanPath)
-	if filepath.Dir(cleanPath) != filepath.Clean(agentDir.path) || !strings.HasPrefix(name, ".w.") || name == ".w." {
+	if !filepath.IsAbs(cleanPath) ||
+		canonicalWakeRoot(filepath.Dir(cleanPath)) != canonicalWakeRoot(agentDir.path) ||
+		!strings.HasPrefix(name, ".w.") || name == ".w." {
 		return "", fmt.Errorf("wake control socket %s is outside authorized agent directory %s", path, agentDir.path)
 	}
 	return name, nil
@@ -495,6 +501,145 @@ func handleDarwinOwnerControl(
 	_, _ = conn.Write([]byte("ACK\n"))
 }
 
+func authorizeDarwinWakeRestartControlAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	expected wakeLock,
+	request wakeControlOwnerRequest,
+	peerPID int,
+	peerUID uint32,
+) (retErr error) {
+	canonicalRoot := canonicalWakeRoot(root)
+	if request.Operation != wakeControlRestartOperation {
+		return fmt.Errorf("wake restart control operation is unsupported")
+	}
+	if request.Rollback {
+		return fmt.Errorf("wake restart control refuses rollback authorization")
+	}
+	if peerUID != uint32(os.Geteuid()) {
+		return fmt.Errorf("wake restart control peer uid is not authorized")
+	}
+	if !validWakeReloadTransportGeneration(request.RequestID) {
+		return fmt.Errorf("wake restart control request id is malformed")
+	}
+	if request.Owner == nil {
+		return fmt.Errorf("wake restart control owner token is missing")
+	}
+	if err := validateAuthoritativeWakeOwner(*request.Owner); err != nil {
+		return fmt.Errorf("wake restart control owner token is invalid: %w", err)
+	}
+
+	current := inspectWakeLockAt(dirfd, agentDir, root, me)
+	if !current.Exists || current.Status != wakeLockValid || !current.IdentityConfirmed ||
+		expected.Root != canonicalRoot || expected.Agent != me ||
+		current.Lock.Root != canonicalRoot || current.Lock.Agent != me ||
+		current.Lock.PID != expected.PID ||
+		current.Lock.ProcessStart != expected.ProcessStart ||
+		current.Lock.BootID != expected.BootID ||
+		current.Lock.Generation != expected.Generation ||
+		request.Generation != expected.Generation ||
+		current.Lock.ControlSocket != expected.ControlSocket {
+		return fmt.Errorf("authoritative wake generation changed")
+	}
+	if expected.ControlSocket != wakeControlSocketPath(root, me, expected.Generation) ||
+		current.Lock.ControlSocket != wakeControlSocketPath(root, me, current.Lock.Generation) {
+		return fmt.Errorf("wake restart control socket does not match the exact root, agent, and generation")
+	}
+	if expected.ResumeSchema != wakeResumeSchemaV2 || current.Lock.ResumeSchema != wakeResumeSchemaV2 ||
+		expected.ResumeOwner == nil || current.Lock.ResumeOwner == nil {
+		return fmt.Errorf("wake restart control target is not resumable")
+	}
+	if err := validateAuthoritativeWakeOwner(*current.Lock.ResumeOwner); err != nil {
+		return fmt.Errorf("wake restart control advertised owner is invalid: %w", err)
+	}
+	if err := validateWakeRestartTransportPlatform(current.Lock, root, me); err != nil {
+		return err
+	}
+	if !sameWakeOwner(request.Owner, current.Lock.ResumeOwner) ||
+		!sameWakeOwner(expected.ResumeOwner, current.Lock.ResumeOwner) {
+		return fmt.Errorf("wake restart control owner token does not match the claim")
+	}
+
+	observation, err := observeAuthoritativeWakeOwner(*current.Lock.ResumeOwner)
+	defer func() {
+		if closeErr := observation.Close(); closeErr != nil {
+			retErr = errors.Join(retErr, closeErr)
+		}
+	}()
+	if err != nil {
+		return err
+	}
+	if observation.State != wakeOwnerSame {
+		return fmt.Errorf("wake restart control owner is %s: %s", observation.State, observation.Reason)
+	}
+	peerSession, err := getWakeProcessSID(peerPID)
+	if err != nil {
+		return fmt.Errorf("wake restart control peer session unavailable: %w", err)
+	}
+	if peerSession != current.Lock.ResumeOwner.SessionID {
+		return fmt.Errorf(
+			"wake restart control peer session %d does not match owner session %d",
+			peerSession,
+			current.Lock.ResumeOwner.SessionID,
+		)
+	}
+
+	record, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+	if err != nil {
+		return err
+	}
+	if !exists || record.Status != wakeRestartPending ||
+		record.RequestID != request.RequestID ||
+		record.Generation != expected.Generation ||
+		record.Root != canonicalRoot || record.Agent != me ||
+		!sameWakeOwner(&record.Owner, current.Lock.ResumeOwner) {
+		return fmt.Errorf("wake restart control request does not match the exact pending record")
+	}
+	return nil
+}
+
+func handleDarwinWakeRestartControl(
+	conn *net.UnixConn,
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	lock wakeLock,
+	request wakeControlOwnerRequest,
+	peerPID int,
+	peerUID uint32,
+	restartSignals chan<- os.Signal,
+) {
+	if restartSignals == nil {
+		return
+	}
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		if err := authorizeDarwinWakeRestartControlAt(
+			dirfd,
+			agentDir,
+			root,
+			me,
+			lock,
+			request,
+			peerPID,
+			peerUID,
+		); err != nil {
+			return err
+		}
+		select {
+		case restartSignals <- syscall.SIGUSR1:
+			return nil
+		default:
+			return fmt.Errorf("wake restart control signal queue is full")
+		}
+	})
+	if err != nil {
+		return
+	}
+	_, _ = conn.Write([]byte("ACK\n"))
+}
+
 func startWakeControlListener(
 	root, me string,
 	lock wakeLock,
@@ -517,12 +662,21 @@ func startWakeControlListener(
 	return cleanup, stop, markStopped, err
 }
 
-func startWakeControlListenerInDir(
+func startWakeControlListenerInDirWithRestart(
 	agentDir *wakeAgentDir,
 	root, me string,
 	lock wakeLock,
+	restartSignals chan<- os.Signal,
 ) (func(), <-chan struct{}, func(), error) {
-	return startWakeControlListenerInDirOwned(agentDir, root, me, lock, false, nil)
+	return startWakeControlListenerInDirOwnedWithRestart(
+		agentDir,
+		root,
+		me,
+		lock,
+		false,
+		nil,
+		restartSignals,
+	)
 }
 
 type darwinWakeControlTestHooks struct {
@@ -535,6 +689,25 @@ func startWakeControlListenerInDirOwned(
 	lock wakeLock,
 	closeAgentDir bool,
 	testHooks *darwinWakeControlTestHooks,
+) (func(), <-chan struct{}, func(), error) {
+	return startWakeControlListenerInDirOwnedWithRestart(
+		agentDir,
+		root,
+		me,
+		lock,
+		closeAgentDir,
+		testHooks,
+		nil,
+	)
+}
+
+func startWakeControlListenerInDirOwnedWithRestart(
+	agentDir *wakeAgentDir,
+	root, me string,
+	lock wakeLock,
+	closeAgentDir bool,
+	testHooks *darwinWakeControlTestHooks,
+	restartSignals chan<- os.Signal,
 ) (func(), <-chan struct{}, func(), error) {
 	path := lock.ControlSocket
 	if path == "" {
@@ -593,34 +766,49 @@ func startWakeControlListenerInDirOwned(
 				if err != nil || len(line) > 4096 {
 					return
 				}
-				if lock.WakeMode == wakeOwnerWakeMode {
+				if lock.WakeMode == wakeOwnerWakeMode ||
+					(lock.ResumeSchema == wakeResumeSchemaV2 && lock.ControlSocket != "") {
 					var request wakeControlOwnerRequest
 					if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &request); err != nil {
-						return
-					}
-					// Named operations are reserved for forward compatibility.
-					// Current owner control is only the empty-operation release
-					// request; fail closed on retired or unknown operations.
-					if request.Operation != "" {
 						return
 					}
 					peerPID, err := darwinPeerPID(conn)
 					if err != nil {
 						return
 					}
-					handleDarwinOwnerControl(
-						conn,
-						agentDir,
-						root,
-						me,
-						lock,
-						request,
-						peerPID,
-						uid,
-						stopRequest,
-						loopStopped,
-						testHooks,
-					)
+					switch request.Operation {
+					case "":
+						if lock.WakeMode != wakeOwnerWakeMode {
+							return
+						}
+						handleDarwinOwnerControl(
+							conn,
+							agentDir,
+							root,
+							me,
+							lock,
+							request,
+							peerPID,
+							uid,
+							stopRequest,
+							loopStopped,
+							testHooks,
+						)
+					case wakeControlRestartOperation:
+						handleDarwinWakeRestartControl(
+							conn,
+							agentDir,
+							root,
+							me,
+							lock,
+							request,
+							peerPID,
+							uid,
+							restartSignals,
+						)
+					default:
+						return
+					}
 					return
 				}
 				if strings.TrimSpace(line) != lock.Generation {

--- a/internal/cli/wake_control_darwin_test.go
+++ b/internal/cli/wake_control_darwin_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -127,6 +128,127 @@ func testDarwinOwnerControlLock(
 		return peerSession, nil
 	})
 	return root, agent, owner, lock, &ownerState, &peerSession
+}
+
+func testDarwinWakeRestartControlLock(
+	t *testing.T,
+) (string, string, wakeOwner, wakeLock, *int) {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatal(err)
+	}
+	owner := wakeOwner{
+		PID:          4242,
+		ProcessStart: "12345",
+		BootID:       "11111111-1111-1111-1111-111111111111",
+		SessionID:    99,
+	}
+	lock := wakeLock{
+		PID:          os.Getpid(),
+		TTY:          "unknown",
+		Root:         canonicalWakeRoot(root),
+		Agent:        agent,
+		Started:      "2026-08-07T00:00:00Z",
+		ProcessStart: "67890",
+		BootID:       owner.BootID,
+		Executable:   "/usr/local/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", agent},
+		WakeMode:     wakeInjectModeNone,
+		Generation:   "0123456789abcdef0123456789abcdef",
+		ResumeSchema: wakeResumeSchemaV2,
+		ResumeOwner:  &owner,
+	}
+	configureWakeRestartAdvertisementPlatform(&lock, root, agent)
+	writeWakeLockForTest(t, root, agent, lock)
+
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != lock.PID {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: lock.ProcessStart,
+			BootID:     lock.BootID,
+			Executable: lock.Executable,
+			Args:       lock.Args,
+		}
+	})
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("observed restart owner = %#v, want %#v", got, owner)
+		}
+		return wakeOwnerObservation{State: wakeOwnerSame, Reason: "test owner evidence"}, nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+	peerSession := owner.SessionID
+	stubWakeProcessSID(t, func(pid int) (int, error) {
+		if pid != os.Getpid() {
+			t.Fatalf("restart peer session pid = %d, want %d", pid, os.Getpid())
+		}
+		return peerSession, nil
+	})
+	return root, agent, owner, lock, &peerSession
+}
+
+func writeDarwinWakeRestartRecordForTest(
+	t *testing.T,
+	root string,
+	agent string,
+	owner wakeOwner,
+	lock wakeLock,
+) wakeRestartRecord {
+	t.Helper()
+	record := wakeRestartRecord{
+		Schema:     wakeRestartSchemaV1,
+		RequestID:  "fedcba9876543210fedcba9876543210",
+		Status:     wakeRestartPending,
+		Root:       canonicalWakeRoot(root),
+		Agent:      agent,
+		Generation: lock.Generation,
+		Owner:      owner,
+		Candidate:  validWakeImageEvidenceForTest(),
+	}
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return record
+}
+
+func readDarwinWakeRestartRecordForTest(
+	t *testing.T,
+	root string,
+	agent string,
+) (wakeRestartRecord, bool) {
+	t.Helper()
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	var record wakeRestartRecord
+	var exists bool
+	if err := agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		record, exists, readErr = readWakeRestartRecordAt(dirfd, agentDir)
+		return readErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return record, exists
 }
 
 func TestDarwinStableOwnerStopTreatsDifferentLivePIDOccupantAsAbsent(t *testing.T) {
@@ -258,6 +380,303 @@ func TestDarwinOwnerControlRejectsNamedOperationsAndContinues(t *testing.T) {
 	}
 	if inspectWakeLock(root, agent).Exists {
 		t.Fatal("valid release after named-operation refusals left the lock")
+	}
+}
+
+func TestDarwinWakeRestartControlEnqueuesSignalWithoutStopping(t *testing.T) {
+	root, agent, owner, lock, _ := testDarwinWakeRestartControlLock(t)
+	record := writeDarwinWakeRestartRecordForTest(t, root, agent, owner, lock)
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	restartSignals := make(chan os.Signal, 1)
+	cleanup, stopped, _, err := startWakeControlListenerInDirWithRestart(
+		agentDir,
+		root,
+		agent,
+		lock,
+		restartSignals,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	expected := inspectWakeLock(root, agent)
+	if err := notifyWakeRestartPlatform(agentDir, expected, record); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case signal := <-restartSignals:
+		if signal != syscall.SIGUSR1 {
+			t.Fatalf("restart signal = %v, want SIGUSR1", signal)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("restart control did not enqueue SIGUSR1")
+	}
+	select {
+	case signal := <-restartSignals:
+		t.Fatalf("restart control enqueued duplicate signal %v", signal)
+	default:
+	}
+	select {
+	case <-stopped:
+		t.Fatal("restart control requested owner shutdown")
+	default:
+	}
+	if current := inspectWakeLock(root, agent); !current.Exists ||
+		current.Lock.Generation != lock.Generation {
+		t.Fatalf("restart control changed owner claim: %#v", current)
+	}
+	observed, exists := readDarwinWakeRestartRecordForTest(t, root, agent)
+	if !exists || !sameWakeRestartRecord(record, observed) {
+		t.Fatalf("restart control changed pending record: exists=%v record=%#v", exists, observed)
+	}
+}
+
+func TestDarwinWakeRestartControlRefusesMismatchedAuthorization(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(
+			t *testing.T,
+			root string,
+			agent string,
+			owner wakeOwner,
+			lock wakeLock,
+			record wakeRestartRecord,
+			request *wakeControlOwnerRequest,
+			peerSession *int,
+		)
+	}{
+		{
+			name: "request id",
+			mutate: func(_ *testing.T, _, _ string, _ wakeOwner, _ wakeLock, _ wakeRestartRecord, request *wakeControlOwnerRequest, _ *int) {
+				request.RequestID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+		},
+		{
+			name: "generation",
+			mutate: func(_ *testing.T, _, _ string, _ wakeOwner, _ wakeLock, _ wakeRestartRecord, request *wakeControlOwnerRequest, _ *int) {
+				request.Generation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+		},
+		{
+			name: "owner",
+			mutate: func(_ *testing.T, _, _ string, owner wakeOwner, _ wakeLock, _ wakeRestartRecord, request *wakeControlOwnerRequest, _ *int) {
+				owner.PID++
+				request.Owner = &owner
+			},
+		},
+		{
+			name: "session",
+			mutate: func(_ *testing.T, _, _ string, owner wakeOwner, _ wakeLock, _ wakeRestartRecord, _ *wakeControlOwnerRequest, peerSession *int) {
+				*peerSession = owner.SessionID + 1
+			},
+		},
+		{
+			name: "missing record",
+			mutate: func(t *testing.T, root, agent string, _ wakeOwner, _ wakeLock, _ wakeRestartRecord, _ *wakeControlOwnerRequest, _ *int) {
+				agentDir, err := openWakeAgentDir(root, agent)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = agentDir.Close() }()
+				if err := withWakeLifecycleGuardInDir(agentDir, func(_ int) error {
+					return os.Remove(filepath.Join(agentDir.path, wakeRestartFileName))
+				}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root, agent, owner, lock, peerSession := testDarwinWakeRestartControlLock(t)
+			record := writeDarwinWakeRestartRecordForTest(t, root, agent, owner, lock)
+			restartSignals := make(chan os.Signal, 1)
+			agentDir, err := openWakeAgentDir(root, agent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = agentDir.Close() }()
+			cleanup, stopped, _, err := startWakeControlListenerInDirWithRestart(
+				agentDir,
+				root,
+				agent,
+				lock,
+				restartSignals,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+
+			request := wakeControlOwnerRequest{
+				Generation: record.Generation,
+				RequestID:  record.RequestID,
+				Owner:      &owner,
+				Operation:  wakeControlRestartOperation,
+			}
+			test.mutate(t, root, agent, owner, lock, record, &request, peerSession)
+			if response := sendDarwinOwnerControlRequest(t, root, agent, lock, request); response != "" {
+				t.Fatalf("restart refusal response = %q, want closed connection", response)
+			}
+			select {
+			case signal := <-restartSignals:
+				t.Fatalf("refused restart enqueued signal %v", signal)
+			default:
+			}
+			select {
+			case <-stopped:
+				t.Fatal("refused restart requested owner shutdown")
+			default:
+			}
+			if current := inspectWakeLock(root, agent); !current.Exists ||
+				current.Lock.Generation != lock.Generation {
+				t.Fatalf("refused restart changed owner claim: %#v", current)
+			}
+		})
+	}
+}
+
+func TestDarwinWakeRestartControlRefusesWrongUID(t *testing.T) {
+	root, agent, owner, lock, _ := testDarwinWakeRestartControlLock(t)
+	record := writeDarwinWakeRestartRecordForTest(t, root, agent, owner, lock)
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return authorizeDarwinWakeRestartControlAt(
+			dirfd,
+			agentDir,
+			root,
+			agent,
+			lock,
+			wakeControlOwnerRequest{
+				Generation: record.Generation,
+				RequestID:  record.RequestID,
+				Owner:      &owner,
+				Operation:  wakeControlRestartOperation,
+			},
+			os.Getpid(),
+			uint32(os.Geteuid()+1),
+		)
+	})
+	if err == nil || !strings.Contains(err.Error(), "uid") {
+		t.Fatalf("wrong-uid restart error = %v, want uid refusal", err)
+	}
+}
+
+func TestDarwinWakeRestartControlRefusesDeadOwner(t *testing.T) {
+	root, agent, owner, lock, _ := testDarwinWakeRestartControlLock(t)
+	record := writeDarwinWakeRestartRecordForTest(t, root, agent, owner, lock)
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(got wakeOwner) (wakeOwnerObservation, error) {
+		if got != owner {
+			t.Fatalf("observed restart owner = %#v, want %#v", got, owner)
+		}
+		return deadWakeOwnerObservation("test owner exited"), nil
+	}
+	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return authorizeDarwinWakeRestartControlAt(
+			dirfd,
+			agentDir,
+			root,
+			agent,
+			lock,
+			wakeControlOwnerRequest{
+				Generation: record.Generation,
+				RequestID:  record.RequestID,
+				Owner:      &owner,
+				Operation:  wakeControlRestartOperation,
+			},
+			os.Getpid(),
+			uint32(os.Geteuid()),
+		)
+	})
+	if err == nil || !strings.Contains(err.Error(), "dead") {
+		t.Fatalf("dead-owner restart error = %v, want dead refusal", err)
+	}
+}
+
+func TestDarwinWakeRestartControlRefusesWithoutRestartChannel(t *testing.T) {
+	root, agent, owner, lock, _ := testDarwinWakeRestartControlLock(t)
+	record := writeDarwinWakeRestartRecordForTest(t, root, agent, owner, lock)
+	cleanup, stopped, _, err := startWakeControlListener(root, agent, lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	response := sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+		Generation: record.Generation,
+		RequestID:  record.RequestID,
+		Owner:      &owner,
+		Operation:  wakeControlRestartOperation,
+	})
+	if response != "" {
+		t.Fatalf("restart without channel response = %q, want refusal", response)
+	}
+	select {
+	case <-stopped:
+		t.Fatal("restart without channel requested owner shutdown")
+	default:
+	}
+	if current := inspectWakeLock(root, agent); !current.Exists ||
+		current.Lock.Generation != lock.Generation {
+		t.Fatalf("restart without channel changed owner claim: %#v", current)
+	}
+}
+
+func TestDarwinWakeRestartControlRefusesEmptyStopOperation(t *testing.T) {
+	root, agent, owner, lock, _ := testDarwinWakeRestartControlLock(t)
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	restartSignals := make(chan os.Signal, 1)
+	cleanup, stopped, _, err := startWakeControlListenerInDirWithRestart(
+		agentDir,
+		root,
+		agent,
+		lock,
+		restartSignals,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	response := sendDarwinOwnerControlRequest(t, root, agent, lock, wakeControlOwnerRequest{
+		Generation: lock.Generation,
+		Owner:      &owner,
+	})
+	if response != "" {
+		t.Fatalf("ordinary empty-operation response = %q, want refusal", response)
+	}
+	select {
+	case <-stopped:
+		t.Fatal("ordinary empty operation requested wake shutdown")
+	default:
+	}
+	select {
+	case signal := <-restartSignals:
+		t.Fatalf("ordinary empty operation enqueued signal %v", signal)
+	default:
+	}
+	if current := inspectWakeLock(root, agent); !current.Exists ||
+		current.Lock.Generation != lock.Generation {
+		t.Fatalf("ordinary empty operation changed wake lock: %#v", current)
 	}
 }
 

--- a/internal/cli/wake_control_linux.go
+++ b/internal/cli/wake_control_linux.go
@@ -2,6 +2,8 @@
 
 package cli
 
+import "os"
+
 func darwinControlSocketBasenameForCleanup(*wakeAgentDir, string) (string, error) {
 	return "", nil
 }
@@ -13,4 +15,14 @@ func startWakeControlListenerInDir(
 	wakeLock,
 ) (func(), <-chan struct{}, func(), error) {
 	return func() {}, nil, func() {}, nil
+}
+
+func startWakeControlListenerInDirWithRestart(
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	lock wakeLock,
+	_ chan<- os.Signal,
+) (func(), <-chan struct{}, func(), error) {
+	return startWakeControlListenerInDir(agentDir, root, me, lock)
 }

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -651,6 +651,9 @@ func removeWakeLockIfUnchangedGuarded(inspection wakeLockInspection) error {
 	); err != nil {
 		return err
 	}
+	if err := reclaimWakeRestartStateForGuardedLockRemoval(inspection); err != nil {
+		return fmt.Errorf("reconcile wake restart ownership before lock removal: %w", err)
+	}
 	return removeWakeLockIfUnchangedGuardedWithIO(
 		inspection,
 		func() ([]byte, os.FileInfo, error) { return readWakeLockFileWithInfo(inspection.LockPath) },

--- a/internal/cli/wake_lock_at_unix.go
+++ b/internal/cli/wake_lock_at_unix.go
@@ -256,6 +256,12 @@ func removeWakeLockIfUnchangedGuardedAtOutcome(
 		}
 		detachedValidationErr = err
 	}
+	if err := reclaimWakeRestartStateForLockRemovalAt(dirfd, agentDir, inspection); err != nil {
+		return wakeLockRemovalOutcome{Err: fmt.Errorf(
+			"reconcile wake restart ownership before lock removal: %w",
+			err,
+		)}
+	}
 	path := filepath.Join(agentDir.path, ".wake.lock")
 	committed, err := removeWakeLockIfUnchangedGuardedWithIOStatus(
 		inspection,

--- a/internal/cli/wake_owner_acquire_unix.go
+++ b/internal/cli/wake_owner_acquire_unix.go
@@ -230,14 +230,14 @@ func acquireAuthoritativeWakeLockWithOptionsInDir(
 				case wakeOwnerActionReuse:
 					return wakeLockAlreadyRunningError(me, classified)
 				case wakeOwnerActionRelease:
-					if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, inspection, &persisted); err != nil {
+					if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, classified, &persisted); err != nil {
 						return err
 					}
 					retry = true
 					return nil
 				case wakeOwnerActionStopAndRelease:
 					if wakeCapability.Absent {
-						if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, inspection, &persisted); err != nil {
+						if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, classified, &persisted); err != nil {
 							return err
 						}
 						retry = true

--- a/internal/cli/wake_owner_recover_unix.go
+++ b/internal/cli/wake_owner_recover_unix.go
@@ -292,7 +292,7 @@ func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
 			})
 			switch action {
 			case wakeOwnerActionRelease:
-				if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, inspection, target); err != nil {
+				if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, classified, target); err != nil {
 					return err
 				}
 				result.Status = "recovered"
@@ -300,7 +300,7 @@ func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
 				return nil
 			case wakeOwnerActionStopAndRelease:
 				if wakeCapability.Absent {
-					if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, inspection, target); err != nil {
+					if err := removeAuthoritativeWakeClaimAt(dirfd, agentDir, classified, target); err != nil {
 						return err
 					}
 					result.Status = "recovered"

--- a/internal/cli/wake_owner_storage_unix.go
+++ b/internal/cli/wake_owner_storage_unix.go
@@ -534,6 +534,9 @@ func removeAuthoritativeWakeClaimAt(
 		))
 		releaseStateExists = false
 	}
+	if err := reclaimWakeRestartStateForLockRemovalAt(dirfd, agentDir, current); err != nil {
+		return fmt.Errorf("reconcile wake restart ownership before authoritative lock release: %w", err)
+	}
 
 	// Pathname unlink is safe under the lifecycle guard held by every
 	// cooperating writer; an unguarded same-UID writer is out of contract. A

--- a/internal/cli/wake_quarantine_unix.go
+++ b/internal/cli/wake_quarantine_unix.go
@@ -40,9 +40,10 @@ type wakeQuarantineCleanupCandidate struct {
 }
 
 var beforeWakeQuarantineCleanupRevalidation = func(wakeQuarantineCleanupCandidate) {}
+var beforeWakeRestartQuarantineRevalidation = func(wakeRestartRecordSnapshot) {}
 
 func parseWakeQuarantineName(name string) (time.Time, bool) {
-	for _, source := range []string{".wake.lock", wakeTargetFileName} {
+	for _, source := range []string{".wake.lock", wakeTargetFileName, wakeRestartFileName} {
 		prefix := source + ".quarantined."
 		if !strings.HasPrefix(name, prefix) {
 			continue
@@ -337,7 +338,7 @@ func isJSONWhitespace(value byte) bool {
 }
 
 func wakeQuarantineName(source string, now time.Time) (string, error) {
-	if source != ".wake.lock" && source != wakeTargetFileName {
+	if source != ".wake.lock" && source != wakeTargetFileName && source != wakeRestartFileName {
 		return "", fmt.Errorf("unsupported wake quarantine source %q", source)
 	}
 	return source + ".quarantined." + now.UTC().Format(wakeQuarantineTimestampLayout), nil
@@ -472,6 +473,30 @@ func quarantineWakeTargetAt(
 		wakeTargetFileName,
 		"wake target",
 		current,
+	)
+}
+
+func quarantineWakeRestartRecordAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeRestartRecordSnapshot,
+) (string, error) {
+	beforeWakeRestartQuarantineRevalidation(expected)
+	current, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+	if err != nil && (!exists || current.Object.FileInfo == nil) {
+		return "", err
+	}
+	if !exists || !sameWakeRestartObjectSnapshot(expected, current) {
+		return "", newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake restart request changed before quarantine"),
+		)
+	}
+	return moveWakeQuarantineAt(
+		dirfd,
+		agentDir,
+		wakeRestartFileName,
+		"wake restart request",
+		current.Object,
 	)
 }
 

--- a/internal/cli/wake_quarantine_unix_test.go
+++ b/internal/cli/wake_quarantine_unix_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,6 +48,80 @@ func assertExactWakeQuarantineForTest(
 	}
 	if !bytes.Equal(gotRaw, wantRaw) || !os.SameFile(gotInfo, wantInfo) {
 		t.Fatal("quarantine artifact did not preserve exact inode/raw")
+	}
+}
+
+func TestWakeRestartQuarantineRefusesReplacedSnapshot(t *testing.T) {
+	root := secureTempDirForTest(t)
+	ensureCoopWakeMailboxForTest(t, root, "codex")
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	path := filepath.Join(agentDir.path, wakeRestartFileName)
+	original := []byte(`{"schema":`)
+	replacement := []byte(`{"schema":99`)
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var expected wakeRestartRecordSnapshot
+	if err := agentDir.withFD(func(dirfd int) error {
+		var exists bool
+		var readErr error
+		expected, exists, readErr = readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+		if !exists || readErr == nil || expected.Object.FileInfo == nil {
+			return fmt.Errorf("initial restart snapshot exists=%v err=%v", exists, readErr)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHook := beforeWakeRestartQuarantineRevalidation
+	beforeWakeRestartQuarantineRevalidation = func(wakeRestartRecordSnapshot) {
+		temp := path + ".replacement"
+		if err := os.WriteFile(temp, replacement, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(temp, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { beforeWakeRestartQuarantineRevalidation = oldHook })
+
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		_, quarantineErr := quarantineWakeRestartRecordAt(dirfd, agentDir, expected)
+		return quarantineErr
+	})
+	if err == nil || !strings.Contains(err.Error(), "changed before quarantine") {
+		t.Fatalf("replacement quarantine error = %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(got, replacement) {
+		t.Fatalf("replacement restart raw=%q err=%v", got, err)
+	}
+	entries, err := os.ReadDir(agentDir.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), wakeRestartFileName+".quarantined.") {
+			t.Fatalf("replaced restart record was quarantined as %s", entry.Name())
+		}
+	}
+}
+
+func TestParseWakeRestartQuarantineName(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 34, 56, 789, time.UTC)
+	name, err := wakeQuarantineName(wakeRestartFileName, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := parseWakeQuarantineName(name)
+	if !ok || !got.Equal(now) {
+		t.Fatalf("parse restart quarantine %q = %s ok=%v", name, got, ok)
 	}
 }
 

--- a/internal/cli/wake_restart_bound_darwin.go
+++ b/internal/cli/wake_restart_bound_darwin.go
@@ -12,6 +12,14 @@ import (
 )
 
 func bindWakeRestartCandidatePlatform(candidate wakeImageEvidenceV1) (*wakeRestartBoundImage, error) {
+	return bindWakeRestartCandidateAtPlatform(candidate, "")
+}
+
+func bindWakeRestartCandidateForRecordPlatform(record wakeRestartRecord) (*wakeRestartBoundImage, error) {
+	return bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+}
+
+func bindWakeRestartCandidateAtPlatform(candidate wakeImageEvidenceV1, plannedStagePath string) (*wakeRestartBoundImage, error) {
 	sourceLstat, err := os.Lstat(candidate.ExecutionPath)
 	if err != nil {
 		return nil, fmt.Errorf("stat wake restart candidate: %w", err)
@@ -49,12 +57,23 @@ func bindWakeRestartCandidatePlatform(candidate wakeImageEvidenceV1) (*wakeResta
 		return nil, fmt.Errorf("wake restart candidate changed before Darwin staging")
 	}
 
-	stageDir, err := os.MkdirTemp(
-		filepath.Dir(candidate.ExecutionPath),
-		"."+filepath.Base(candidate.ExecutionPath)+".amq-restart-",
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create adjacent wake restart stage: %w", err)
+	var stageDir string
+	if plannedStagePath == "" {
+		stageDir, err = os.MkdirTemp(
+			filepath.Dir(candidate.ExecutionPath),
+			"."+filepath.Base(candidate.ExecutionPath)+".amq-restart-",
+		)
+		if err != nil {
+			return nil, fmt.Errorf("create adjacent wake restart stage: %w", err)
+		}
+	} else {
+		stageDir = filepath.Dir(plannedStagePath)
+		if filepath.Base(plannedStagePath) != filepath.Base(candidate.ExecutionPath) {
+			return nil, fmt.Errorf("planned Darwin wake restart stage path is invalid")
+		}
+		if err := os.Mkdir(stageDir, 0o700); err != nil {
+			return nil, fmt.Errorf("create planned adjacent wake restart stage: %w", err)
+		}
 	}
 	stagePath := filepath.Join(stageDir, filepath.Base(candidate.ExecutionPath))
 	stageCreated := false
@@ -129,7 +148,7 @@ func bindWakeRestartCandidatePlatform(candidate wakeImageEvidenceV1) (*wakeResta
 		stage,
 		stagePath,
 		candidate.EmbeddedVersion,
-		wakeImageMethodPathnameExecVerified,
+		wakeImageMethodPathnameExecObserved,
 	)
 	if err != nil {
 		return nil, err
@@ -171,7 +190,7 @@ func revalidateBoundWakeRestartImagePlatform(image *wakeRestartBoundImage) error
 		image.file,
 		image.executionPath,
 		image.evidence.EmbeddedVersion,
-		wakeImageMethodPathnameExecVerified,
+		wakeImageMethodPathnameExecObserved,
 	)
 	if err != nil {
 		return err
@@ -199,7 +218,7 @@ func verifyWakeResumeBoundImagePlatform(bound wakeImageEvidenceV1) (wakeImageEvi
 	if err != nil {
 		return wakeImageEvidenceV1{}, err
 	}
-	actual.Method = wakeImageMethodPathnameExecVerified
+	actual.Method = wakeImageMethodPathnameExecObserved
 	if !sameDarwinStagedWakeImageEvidence(actual, bound) {
 		return wakeImageEvidenceV1{}, fmt.Errorf("running wake image does not match bound restart image")
 	}
@@ -218,7 +237,7 @@ func cleanupWakeResumeBoundImagePlatform(bound wakeImageEvidenceV1) error {
 }
 
 func validPreviousWakeRestartBoundImagePlatform(bound wakeImageEvidenceV1) bool {
-	if bound.Platform != "darwin" || bound.Method != wakeImageMethodPathnameExecVerified {
+	if bound.Platform != "darwin" || !wakeImageMethodIsDarwinExecObserved(bound.Method) {
 		return false
 	}
 	stagePath := bound.ExecutionPath
@@ -263,7 +282,7 @@ func cleanupDarwinWakeRestartStage(bound wakeImageEvidenceV1, allowNamespaceCTim
 		file,
 		stagePath,
 		bound.EmbeddedVersion,
-		wakeImageMethodPathnameExecVerified,
+		wakeImageMethodPathnameExecObserved,
 	)
 	if err != nil {
 		return err

--- a/internal/cli/wake_restart_bound_linux.go
+++ b/internal/cli/wake_restart_bound_linux.go
@@ -58,6 +58,10 @@ func bindWakeRestartCandidatePlatform(candidate wakeImageEvidenceV1) (*wakeResta
 	return bound, nil
 }
 
+func bindWakeRestartCandidateForRecordPlatform(record wakeRestartRecord) (*wakeRestartBoundImage, error) {
+	return bindWakeRestartCandidatePlatform(record.Candidate)
+}
+
 func boundWakeRestartPreflightCommandPlatform(image *wakeRestartBoundImage) (string, []*os.File, error) {
 	if image == nil || image.file == nil {
 		return "", nil, fmt.Errorf("bound wake restart image is missing")

--- a/internal/cli/wake_restart_bound_unix.go
+++ b/internal/cli/wake_restart_bound_unix.go
@@ -39,6 +39,13 @@ func bindWakeRestartCandidate(candidate wakeImageEvidenceV1) (*wakeRestartBoundI
 	return bindWakeRestartCandidatePlatform(candidate)
 }
 
+func bindWakeRestartCandidateForRecord(record wakeRestartRecord) (*wakeRestartBoundImage, error) {
+	if err := validateWakeRestartRecord(record); err != nil {
+		return nil, err
+	}
+	return bindWakeRestartCandidateForRecordPlatform(record)
+}
+
 func preflightBoundWakeRestartCandidate(
 	image *wakeRestartBoundImage,
 	argv []string,
@@ -119,11 +126,12 @@ func sameWakeImageEvidenceExceptMethodPath(first, second wakeImageEvidenceV1) bo
 // retained device/inode plus size and digest remain the binding authority.
 func sameDarwinStagedWakeImageEvidence(first, second wakeImageEvidenceV1) bool {
 	if first.Platform != "darwin" || second.Platform != "darwin" ||
-		first.Method != wakeImageMethodPathnameExecVerified ||
-		second.Method != wakeImageMethodPathnameExecVerified ||
+		!wakeImageMethodIsDarwinExecObserved(first.Method) ||
+		!wakeImageMethodIsDarwinExecObserved(second.Method) ||
 		first.ExecutionPath != second.ExecutionPath {
 		return first == second
 	}
+	first.Method = second.Method
 	first.CTimeNS = second.CTimeNS
 	return first == second
 }
@@ -138,7 +146,7 @@ func sameRequestedAndBoundWakeImageEvidence(first, second wakeImageEvidenceV1) b
 	}
 	switch first.Platform {
 	case "darwin":
-		if second.Method != wakeImageMethodPathnameExecVerified {
+		if !wakeImageMethodIsDarwinExecObserved(second.Method) {
 			return false
 		}
 		first.CTimeNS = second.CTimeNS

--- a/internal/cli/wake_restart_notify_darwin.go
+++ b/internal/cli/wake_restart_notify_darwin.go
@@ -1,0 +1,128 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+const darwinWakeRestartControlTimeout = 2 * time.Second
+
+func configureWakeRestartAdvertisementPlatform(lock *wakeLock, root, me string) {
+	if lock == nil {
+		return
+	}
+	lock.ResumeSignal = ""
+	lock.ControlSocket = wakeControlSocketPath(root, me, lock.Generation)
+}
+
+func validateWakeRestartTransportPlatform(lock wakeLock, root, me string) error {
+	if lock.ResumeSignal != "" {
+		return fmt.Errorf("darwin wake restart refuses direct signal delivery")
+	}
+	if !validWakeReloadTransportGeneration(lock.Generation) {
+		return fmt.Errorf("darwin wake restart generation is malformed")
+	}
+	expected := wakeControlSocketPath(root, me, lock.Generation)
+	if lock.ControlSocket == "" || lock.ControlSocket != expected {
+		return fmt.Errorf("darwin wake restart requires the exact generation control socket")
+	}
+	return nil
+}
+
+func notifyWakeRestartPlatform(
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+	record wakeRestartRecord,
+) error {
+	if agentDir == nil {
+		return fmt.Errorf("wake restart agent directory capability is missing")
+	}
+	if record.Status != wakeRestartPending ||
+		record.Root != expected.Root || record.Agent != expected.Agent ||
+		record.Generation != expected.Lock.Generation {
+		return fmt.Errorf("wake restart request does not match the expected generation")
+	}
+	if expected.Lock.ResumeOwner == nil ||
+		!sameWakeOwner(expected.Lock.ResumeOwner, &record.Owner) {
+		return fmt.Errorf("wake restart owner does not match the advertised owner")
+	}
+	if err := validateWakeRestartTransportPlatform(
+		expected.Lock,
+		expected.Root,
+		expected.Agent,
+	); err != nil {
+		return err
+	}
+
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current := inspectWakeLockAt(
+			dirfd,
+			agentDir,
+			expected.Root,
+			expected.Agent,
+		)
+		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
+			return fmt.Errorf("wake changed before restart control request")
+		}
+		if err := validateWakeRestartTransportPlatform(
+			current.Lock,
+			expected.Root,
+			expected.Agent,
+		); err != nil {
+			return err
+		}
+		observed, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists || record.Status != wakeRestartPending ||
+			observed.Status != wakeRestartPending ||
+			observed.RequestID != record.RequestID ||
+			observed.Generation != record.Generation ||
+			!sameWakeRestartRecord(observed, record) {
+			return fmt.Errorf("wake restart request changed before control notification")
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	name, err := darwinControlSocketName(agentDir, expected.Lock.ControlSocket)
+	if err != nil {
+		return fmt.Errorf("wake restart control endpoint unavailable: %w", err)
+	}
+	conn, err := dialDarwinUnixAt(agentDir, name, darwinWakeRestartControlTimeout)
+	if err != nil {
+		return fmt.Errorf("wake restart control endpoint unavailable: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(darwinWakeRestartControlTimeout))
+
+	request := wakeControlOwnerRequest{
+		Generation: record.Generation,
+		RequestID:  record.RequestID,
+		Owner:      &record.Owner,
+		Operation:  wakeControlRestartOperation,
+	}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("encode wake restart control request: %w", err)
+	}
+	if _, err := conn.Write(append(payload, '\n')); err != nil {
+		return fmt.Errorf("send wake restart control request: %w", err)
+	}
+	line, err := bufio.NewReader(
+		io.LimitReader(conn, wakeControlInjectViaACKMaxBytes+1),
+	).ReadString('\n')
+	if err != nil || len(line) > wakeControlInjectViaACKMaxBytes || strings.TrimSpace(line) != "ACK" {
+		return fmt.Errorf("wake restart control request refused")
+	}
+	return nil
+}

--- a/internal/cli/wake_restart_notify_darwin_test.go
+++ b/internal/cli/wake_restart_notify_darwin_test.go
@@ -1,0 +1,77 @@
+//go:build darwin
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigureDarwinWakeRestartAdvertisementUsesExactControlSocket(t *testing.T) {
+	root := secureTempDirForTest(t)
+	lock := wakeLock{
+		Generation:   "0123456789abcdef0123456789abcdef",
+		ResumeSignal: wakeResumeSignalUSR1,
+	}
+	configureWakeRestartAdvertisementPlatform(&lock, root, "codex")
+	if lock.ResumeSignal != "" {
+		t.Fatalf("Darwin resume signal = %q, want empty", lock.ResumeSignal)
+	}
+	want := wakeControlSocketPath(root, "codex", lock.Generation)
+	if lock.ControlSocket != want {
+		t.Fatalf("Darwin control socket = %q, want %q", lock.ControlSocket, want)
+	}
+	if err := validateWakeRestartTransportPlatform(lock, root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateDarwinWakeRestartTransportRefusesLegacySignalAndWrongSocket(t *testing.T) {
+	root := secureTempDirForTest(t)
+	valid := wakeLock{Generation: "0123456789abcdef0123456789abcdef"}
+	configureWakeRestartAdvertisementPlatform(&valid, root, "codex")
+	tests := []struct {
+		name   string
+		mutate func(*wakeLock)
+		want   string
+	}{
+		{
+			name: "legacy direct signal",
+			mutate: func(lock *wakeLock) {
+				lock.ResumeSignal = wakeResumeSignalUSR1
+			},
+			want: "direct signal",
+		},
+		{
+			name: "missing socket",
+			mutate: func(lock *wakeLock) {
+				lock.ControlSocket = ""
+			},
+			want: "exact generation control socket",
+		},
+		{
+			name: "wrong socket",
+			mutate: func(lock *wakeLock) {
+				lock.ControlSocket = wakeControlSocketPath(root, "claude", lock.Generation)
+			},
+			want: "exact generation control socket",
+		},
+		{
+			name: "malformed generation",
+			mutate: func(lock *wakeLock) {
+				lock.Generation = "not-a-generation"
+			},
+			want: "malformed",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lock := valid
+			test.mutate(&lock)
+			err := validateWakeRestartTransportPlatform(lock, root, "codex")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("transport validation error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/cli/wake_restart_notify_linux.go
+++ b/internal/cli/wake_restart_notify_linux.go
@@ -18,10 +18,10 @@ func configureWakeRestartAdvertisementPlatform(lock *wakeLock, _, _ string) {
 
 func validateWakeRestartTransportPlatform(lock wakeLock, _, _ string) error {
 	if lock.ResumeSignal != wakeResumeSignalUSR1 {
-		return fmt.Errorf("Linux wake restart requires direct SIGUSR1 delivery")
+		return fmt.Errorf("linux wake restart requires direct SIGUSR1 delivery")
 	}
 	if lock.ControlSocket != "" {
-		return fmt.Errorf("Linux wake restart refuses a control socket")
+		return fmt.Errorf("linux wake restart refuses a control socket")
 	}
 	return nil
 }

--- a/internal/cli/wake_restart_notify_linux.go
+++ b/internal/cli/wake_restart_notify_linux.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func configureWakeRestartAdvertisementPlatform(lock *wakeLock, _, _ string) {
+	if lock == nil {
+		return
+	}
+	lock.ResumeSignal = wakeResumeSignalUSR1
+	lock.ControlSocket = ""
+}
+
+func validateWakeRestartTransportPlatform(lock wakeLock, _, _ string) error {
+	if lock.ResumeSignal != wakeResumeSignalUSR1 {
+		return fmt.Errorf("Linux wake restart requires direct SIGUSR1 delivery")
+	}
+	if lock.ControlSocket != "" {
+		return fmt.Errorf("Linux wake restart refuses a control socket")
+	}
+	return nil
+}
+
+func notifyWakeRestartPlatform(
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+	record wakeRestartRecord,
+) error {
+	if agentDir == nil {
+		return fmt.Errorf("wake restart agent directory capability is missing")
+	}
+
+	pidfd := -1
+	defer func() {
+		if pidfd >= 0 {
+			_ = linuxPidfdClose(pidfd)
+		}
+	}()
+
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		metadata := readWakeLockMetadataAt(
+			dirfd,
+			agentDir,
+			expected.Root,
+			expected.Agent,
+		)
+		if !sameWakeLockGeneration(expected, metadata) {
+			return fmt.Errorf("wake changed before restart pidfd acquisition")
+		}
+
+		fd, err := linuxPidfdOpen(metadata.PID, 0)
+		if err != nil {
+			return fmt.Errorf("pidfd_open wake restart process %d: %w", metadata.PID, err)
+		}
+		pidfd = fd
+
+		current := inspectWakeLockAt(
+			dirfd,
+			agentDir,
+			expected.Root,
+			expected.Agent,
+		)
+		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
+			return fmt.Errorf("wake changed before restart signal")
+		}
+		if err := validateWakeRestartTransportPlatform(
+			current.Lock,
+			expected.Root,
+			expected.Agent,
+		); err != nil {
+			return err
+		}
+
+		observed, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists || record.Status != wakeRestartPending ||
+			observed.Status != wakeRestartPending ||
+			observed.RequestID != record.RequestID ||
+			observed.Generation != record.Generation ||
+			!sameWakeRestartRecord(observed, record) {
+			return fmt.Errorf("wake restart request changed before signal")
+		}
+
+		if err := linuxPidfdSendSignal(pidfd, unix.SIGUSR1, nil, 0); err != nil {
+			return fmt.Errorf("pidfd_send_signal SIGUSR1: %w", err)
+		}
+		return nil
+	})
+}

--- a/internal/cli/wake_restart_notify_linux_test.go
+++ b/internal/cli/wake_restart_notify_linux_test.go
@@ -1,0 +1,290 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func stubWakeRestartPidfdForTest(
+	t *testing.T,
+	open func(int, int) (int, error),
+	send func(int, unix.Signal, *unix.Siginfo, int) error,
+	close func(int) error,
+) {
+	t.Helper()
+	oldOpen := linuxPidfdOpen
+	oldSend := linuxPidfdSendSignal
+	oldClose := linuxPidfdClose
+	linuxPidfdOpen = open
+	linuxPidfdSendSignal = send
+	linuxPidfdClose = close
+	t.Cleanup(func() {
+		linuxPidfdOpen = oldOpen
+		linuxPidfdSendSignal = oldSend
+		linuxPidfdClose = oldClose
+	})
+}
+
+func TestLinuxWakeRestartAdvertisementUsesOnlySIGUSR1(t *testing.T) {
+	lock := wakeLock{ControlSocket: "/tmp/stale-control.sock"}
+	configureWakeRestartAdvertisementPlatform(&lock, "/ignored", "codex")
+	if lock.ResumeSignal != wakeResumeSignalUSR1 || lock.ControlSocket != "" {
+		t.Fatalf("restart transport = signal %q socket %q", lock.ResumeSignal, lock.ControlSocket)
+	}
+	if err := validateWakeRestartTransportPlatform(lock, "/ignored", "codex"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		lock wakeLock
+	}{
+		{name: "missing_signal", lock: wakeLock{}},
+		{name: "control_socket", lock: wakeLock{ResumeSignal: wakeResumeSignalUSR1, ControlSocket: "/tmp/control.sock"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateWakeRestartTransportPlatform(test.lock, "/ignored", "codex"); err == nil {
+				t.Fatal("unsafe Linux restart transport was accepted")
+			}
+		})
+	}
+}
+
+func TestNotifyWakeRestartLinuxUsesPidfdAfterExactLockRead(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	events := make([]string, 0, 4)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		events = append(events, "inspect")
+		if pid == fixture.process.PID {
+			return fixture.process
+		}
+		return wakeProcessInfo{PID: pid}
+	})
+	stubWakeRestartPidfdForTest(
+		t,
+		func(pid, flags int) (int, error) {
+			events = append(events, "open")
+			if pid != fixture.lock.PID || flags != 0 {
+				t.Fatalf("pidfd_open = (%d, %d), want (%d, 0)", pid, flags, fixture.lock.PID)
+			}
+			return 41, nil
+		},
+		func(fd int, signal unix.Signal, info *unix.Siginfo, flags int) error {
+			events = append(events, "send")
+			if fd != 41 || signal != unix.SIGUSR1 || info != nil || flags != 0 {
+				t.Fatalf("pidfd_send_signal = (%d, %v, %v, %d)", fd, signal, info, flags)
+			}
+			return nil
+		},
+		func(fd int) error {
+			events = append(events, "close")
+			if fd != 41 {
+				t.Fatalf("close fd = %d, want 41", fd)
+			}
+			return nil
+		},
+	)
+
+	if err := notifyWakeRestartPlatform(fixture.agentDir, fixture.lock, fixture.record); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"open", "inspect", "send", "close"}; !reflect.DeepEqual(events, want) {
+		t.Fatalf("call order = %v, want %v", events, want)
+	}
+}
+
+func TestNotifyWakeRestartLinuxRefusesLockChangeBeforePidfdOpen(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	changed := fixture.lock.Lock
+	changed.TTY = "replacement-tty"
+	writeWakeLockForTest(t, fixture.root, fixture.agent, changed)
+	stubWakeRestartPidfdForTest(
+		t,
+		func(int, int) (int, error) {
+			t.Fatal("pidfd_open called for a changed wake lock")
+			return -1, nil
+		},
+		func(int, unix.Signal, *unix.Siginfo, int) error {
+			t.Fatal("pidfd_send_signal called for a changed wake lock")
+			return nil
+		},
+		func(int) error {
+			t.Fatal("close called without an acquired pidfd")
+			return nil
+		},
+	)
+
+	err := notifyWakeRestartPlatform(fixture.agentDir, fixture.lock, fixture.record)
+	if err == nil || !strings.Contains(err.Error(), "changed before restart pidfd acquisition") {
+		t.Fatalf("error = %v, want exact-lock refusal", err)
+	}
+}
+
+func TestNotifyWakeRestartLinuxRefusesPidfdOpenErrors(t *testing.T) {
+	for _, openErr := range []error{syscall.ENOSYS, syscall.EPERM, syscall.ESRCH} {
+		t.Run(openErr.Error(), func(t *testing.T) {
+			fixture := newWakeRestartFixture(t)
+			closed := false
+			stubWakeRestartPidfdForTest(
+				t,
+				func(int, int) (int, error) { return -1, openErr },
+				func(int, unix.Signal, *unix.Siginfo, int) error {
+					t.Fatal("pidfd_send_signal called after pidfd_open failure")
+					return nil
+				},
+				func(int) error {
+					closed = true
+					return nil
+				},
+			)
+
+			err := notifyWakeRestartPlatform(fixture.agentDir, fixture.lock, fixture.record)
+			if !errors.Is(err, openErr) || !strings.Contains(err.Error(), "pidfd_open") {
+				t.Fatalf("error = %v, want wrapped %v", err, openErr)
+			}
+			if closed {
+				t.Fatal("close called without an acquired pidfd")
+			}
+		})
+	}
+}
+
+func TestNotifyWakeRestartLinuxClosesPidfdOnSignalError(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	closed := false
+	stubWakeRestartPidfdForTest(
+		t,
+		func(int, int) (int, error) { return 42, nil },
+		func(int, unix.Signal, *unix.Siginfo, int) error { return syscall.ESRCH },
+		func(fd int) error {
+			closed = true
+			if fd != 42 {
+				t.Fatalf("close fd = %d, want 42", fd)
+			}
+			return nil
+		},
+	)
+
+	err := notifyWakeRestartPlatform(fixture.agentDir, fixture.lock, fixture.record)
+	if !errors.Is(err, syscall.ESRCH) || !strings.Contains(err.Error(), "pidfd_send_signal") {
+		t.Fatalf("error = %v, want wrapped ESRCH", err)
+	}
+	if !closed {
+		t.Fatal("pidfd was not closed after signal failure")
+	}
+}
+
+func TestNotifyWakeRestartLinuxRefusesIdentityChangeAfterPidfdOpen(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	pidfdOpened := false
+	signaled := false
+	closed := false
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != fixture.process.PID {
+			return wakeProcessInfo{PID: pid}
+		}
+		process := fixture.process
+		if pidfdOpened {
+			process.StartToken += "-reused"
+		}
+		return process
+	})
+	stubWakeRestartPidfdForTest(
+		t,
+		func(int, int) (int, error) {
+			pidfdOpened = true
+			return 43, nil
+		},
+		func(int, unix.Signal, *unix.Siginfo, int) error {
+			signaled = true
+			return nil
+		},
+		func(int) error {
+			closed = true
+			return nil
+		},
+	)
+
+	err := notifyWakeRestartPlatform(fixture.agentDir, fixture.lock, fixture.record)
+	if err == nil || !strings.Contains(err.Error(), "wake changed before restart signal") {
+		t.Fatalf("error = %v, want identity-change refusal", err)
+	}
+	if signaled {
+		t.Fatal("identity-changed process was signaled")
+	}
+	if !closed {
+		t.Fatal("pidfd was not closed after identity change")
+	}
+}
+
+func TestNotifyWakeRestartLinuxRefusesChangedPendingRecord(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*wakeRestartRecord)
+	}{
+		{
+			name: "request_id",
+			mutate: func(record *wakeRestartRecord) {
+				record.RequestID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+		},
+		{
+			name: "generation",
+			mutate: func(record *wakeRestartRecord) {
+				record.Generation = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+			},
+		},
+		{
+			name: "not_pending",
+			mutate: func(record *wakeRestartRecord) {
+				record.Status = wakeRestartRefused
+				record.Reason = "changed"
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeRestartFixture(t)
+			signaled := false
+			closed := false
+			stubWakeRestartPidfdForTest(
+				t,
+				func(int, int) (int, error) {
+					changed := fixture.record
+					test.mutate(&changed)
+					if err := fixture.agentDir.withFD(func(dirfd int) error {
+						return writeWakeRestartRecordAt(dirfd, fixture.agentDir, changed)
+					}); err != nil {
+						t.Fatal(err)
+					}
+					return 44, nil
+				},
+				func(int, unix.Signal, *unix.Siginfo, int) error {
+					signaled = true
+					return nil
+				},
+				func(int) error {
+					closed = true
+					return nil
+				},
+			)
+
+			err := notifyWakeRestartPlatform(fixture.agentDir, fixture.lock, fixture.record)
+			if err == nil || !strings.Contains(err.Error(), "request changed before signal") {
+				t.Fatalf("error = %v, want request-change refusal", err)
+			}
+			if signaled {
+				t.Fatal("changed restart request was signaled")
+			}
+			if !closed {
+				t.Fatal("pidfd was not closed after request change")
+			}
+		})
+	}
+}

--- a/internal/cli/wake_restart_stage_darwin.go
+++ b/internal/cli/wake_restart_stage_darwin.go
@@ -34,9 +34,9 @@ func validateWakeRestartStageStatePlatform(record wakeRestartRecord) error {
 			return fmt.Errorf("previous wake restart bound stage is not an owned Darwin stage")
 		}
 	}
-	// Records written before persisted stage ownership was introduced have no
-	// stage fields. They remain readable so an in-flight v0.57.2 restart can
-	// finish after the binary is upgraded.
+	// Records written before persisted stage ownership was introduced, and the
+	// schema-2 successor claims derived from them, have no stage fields. They
+	// remain readable so an in-flight v0.57.2 restart can finish after upgrade.
 	if record.StagePath == "" && record.BoundImage == nil {
 		return nil
 	}
@@ -131,6 +131,10 @@ func validateWakeRestartPersistedBoundPlatform(
 	bootstrap wakeImageEvidenceV1,
 ) error {
 	if record.BoundImage == nil {
+		if record.Schema == wakeRestartSchemaV1 && record.StagePath == "" &&
+			bootstrap.Method == wakeImageMethodPathnameExecVerified {
+			return nil
+		}
 		return fmt.Errorf("darwin wake restart record has no persisted bound stage")
 	}
 	if !sameDarwinStagedWakeImageEvidence(*record.BoundImage, bootstrap) {

--- a/internal/cli/wake_restart_stage_darwin.go
+++ b/internal/cli/wake_restart_stage_darwin.go
@@ -1,0 +1,212 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func planWakeRestartStagePlatform(candidate wakeImageEvidenceV1, requestID string) (string, error) {
+	if !validWakeReloadTransportGeneration(requestID) {
+		return "", fmt.Errorf("wake restart stage request id is invalid")
+	}
+	if err := validateWakeImageEvidenceForPlatform(candidate, "darwin"); err != nil {
+		return "", err
+	}
+	base := filepath.Base(candidate.ExecutionPath)
+	dir := filepath.Join(filepath.Dir(candidate.ExecutionPath), "."+base+".amq-restart-"+requestID)
+	return filepath.Join(dir, base), nil
+}
+
+func validateWakeRestartStageStatePlatform(record wakeRestartRecord) error {
+	if record.PreviousBoundImage != nil {
+		if err := validateWakeImageEvidenceForPlatform(*record.PreviousBoundImage, "darwin"); err != nil {
+			return fmt.Errorf("previous wake restart bound stage is invalid: %w", err)
+		}
+		if !validPreviousWakeRestartBoundImagePlatform(*record.PreviousBoundImage) {
+			return fmt.Errorf("previous wake restart bound stage is not an owned Darwin stage")
+		}
+	}
+	// Records written before persisted stage ownership was introduced have no
+	// stage fields. They remain readable so an in-flight v0.57.2 restart can
+	// finish after the binary is upgraded.
+	if record.StagePath == "" && record.BoundImage == nil {
+		return nil
+	}
+	planned, err := planWakeRestartStagePlatform(record.Candidate, record.RequestID)
+	if err != nil {
+		return err
+	}
+	if record.StagePath != planned {
+		return fmt.Errorf("wake restart stage path does not match the exact request")
+	}
+	if record.BoundImage == nil {
+		return nil
+	}
+	if err := validateWakeImageEvidenceForPlatform(*record.BoundImage, "darwin"); err != nil {
+		return fmt.Errorf("wake restart bound stage is invalid: %w", err)
+	}
+	if record.BoundImage.ExecutionPath != record.StagePath ||
+		!sameRequestedAndBoundWakeImageEvidence(record.Candidate, *record.BoundImage) {
+		return fmt.Errorf("wake restart bound stage does not match the planned request")
+	}
+	if record.PreviousBoundImage != nil &&
+		record.PreviousBoundImage.ExecutionPath == record.BoundImage.ExecutionPath {
+		return fmt.Errorf("wake restart previous and current stages use the same path")
+	}
+	return nil
+}
+
+func reclaimWakeRestartStagePlatform(record wakeRestartRecord) error {
+	if err := validateWakeRestartStageStatePlatform(record); err != nil {
+		return err
+	}
+	if record.PreviousBoundImage != nil {
+		if err := cleanupPersistedDarwinWakeRestartStage(*record.PreviousBoundImage); err != nil {
+			return fmt.Errorf("reclaim previous Darwin wake restart stage: %w", err)
+		}
+	}
+	if record.StagePath == "" {
+		return nil
+	}
+	if record.BoundImage != nil {
+		return cleanupPersistedDarwinWakeRestartStage(*record.BoundImage)
+	}
+
+	info, err := os.Lstat(record.StagePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return removeEmptyDarwinWakeRestartStageDir(record.StagePath)
+	}
+	if err != nil {
+		return fmt.Errorf("stat planned Darwin wake restart stage: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refuse reclaim of replaced Darwin wake restart stage")
+	}
+	fd, err := unix.Open(record.StagePath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open planned Darwin wake restart stage: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), record.StagePath)
+	if file == nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("bind planned Darwin wake restart stage")
+	}
+	defer func() { _ = file.Close() }()
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(info, opened) {
+		return fmt.Errorf("planned Darwin wake restart stage changed before reclaim")
+	}
+	bound, err := captureWakeImageEvidenceFromOpenFile(
+		file,
+		record.StagePath,
+		record.Candidate.EmbeddedVersion,
+		wakeImageMethodPathnameExecObserved,
+	)
+	if err != nil {
+		return err
+	}
+	if !sameRequestedAndBoundWakeImageEvidence(record.Candidate, bound) {
+		return fmt.Errorf("refuse reclaim of Darwin stage that does not match the persisted request")
+	}
+	return cleanupDarwinWakeRestartStage(bound, true)
+}
+
+func cleanupPersistedDarwinWakeRestartStage(bound wakeImageEvidenceV1) error {
+	if err := cleanupDarwinWakeRestartStage(bound, true); err != nil {
+		return err
+	}
+	return removeEmptyDarwinWakeRestartStageDir(bound.ExecutionPath)
+}
+
+func validateWakeRestartPersistedBoundPlatform(
+	record wakeRestartRecord,
+	bootstrap wakeImageEvidenceV1,
+) error {
+	if record.BoundImage == nil {
+		return fmt.Errorf("darwin wake restart record has no persisted bound stage")
+	}
+	if !sameDarwinStagedWakeImageEvidence(*record.BoundImage, bootstrap) {
+		return fmt.Errorf("darwin wake restart persisted stage does not match the exec bootstrap")
+	}
+	return nil
+}
+
+func removeEmptyDarwinWakeRestartStageDir(stagePath string) error {
+	dirPath := filepath.Dir(stagePath)
+	parentPath := filepath.Dir(dirPath)
+	name := filepath.Base(dirPath)
+	parentFD, err := unix.Open(parentPath, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open Darwin wake restart stage parent: %w", err)
+	}
+	defer func() { _ = unix.Close(parentFD) }()
+	var before unix.Stat_t
+	if err := unix.Fstatat(parentFD, name, &before, unix.AT_SYMLINK_NOFOLLOW); errors.Is(err, syscall.ENOENT) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("stat Darwin wake restart stage directory: %w", err)
+	}
+	if before.Mode&unix.S_IFMT != unix.S_IFDIR || before.Mode&0o777 != 0o700 || before.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("refuse reclaim of replaced Darwin wake restart stage directory")
+	}
+	dirFD, err := unix.Openat(parentFD, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open Darwin wake restart stage directory: %w", err)
+	}
+	dir := os.NewFile(uintptr(dirFD), dirPath)
+	if dir == nil {
+		_ = unix.Close(dirFD)
+		return fmt.Errorf("bind Darwin wake restart stage directory")
+	}
+	entries, readErr := dir.ReadDir(1)
+	_ = dir.Close()
+	if !errors.Is(readErr, io.EOF) || len(entries) != 0 {
+		return fmt.Errorf("refuse reclaim of non-empty Darwin wake restart stage directory")
+	}
+	var after unix.Stat_t
+	if err := unix.Fstatat(parentFD, name, &after, unix.AT_SYMLINK_NOFOLLOW); err != nil ||
+		before.Dev != after.Dev || before.Ino != after.Ino || before.Ctim != after.Ctim {
+		return fmt.Errorf("darwin wake restart stage directory changed before reclaim")
+	}
+	if err := unix.Unlinkat(parentFD, name, unix.AT_REMOVEDIR); err != nil && !errors.Is(err, syscall.ENOENT) {
+		return fmt.Errorf("remove empty Darwin wake restart stage directory: %w", err)
+	}
+	return nil
+}
+
+func wakeRestartStageExistsPlatform(record wakeRestartRecord) (bool, error) {
+	if err := validateWakeRestartStageStatePlatform(record); err != nil {
+		return false, err
+	}
+	if record.StagePath == "" {
+		return false, nil
+	}
+	if _, err := os.Lstat(record.StagePath); err == nil {
+		return true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	if _, err := os.Lstat(filepath.Dir(record.StagePath)); err == nil {
+		return true, nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
+func reclaimWakeRestartRunningImagePlatform(lock wakeLock) error {
+	if lock.RunningImageEvidence == nil ||
+		!validPreviousWakeRestartBoundImagePlatform(*lock.RunningImageEvidence) {
+		return nil
+	}
+	return cleanupPersistedDarwinWakeRestartStage(*lock.RunningImageEvidence)
+}

--- a/internal/cli/wake_restart_stage_darwin_test.go
+++ b/internal/cli/wake_restart_stage_darwin_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -704,5 +705,118 @@ func TestDarwinPostAcquireErrorRetainsLockBeforeReadinessCommit(t *testing.T) {
 	}
 	if lockCleaned {
 		t.Fatal("post-acquire failure removed the lock before readiness commit")
+	}
+}
+
+func TestDarwinAcquireWakeLockAfterLegacyRestartCompletesMixedVersionHandoff(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	bound := boundWakeImageEvidenceForTest(fixture.candidate)
+	if bound.Method != wakeImageMethodPathnameExecVerified ||
+		fixture.record.Schema != wakeRestartSchemaV1 ||
+		fixture.record.StagePath != "" || fixture.record.BoundImage != nil {
+		t.Fatalf("legacy v0.57.2 restart shape changed: record=%#v bound=%#v", fixture.record, bound)
+	}
+
+	cleanup, err := acquireWakeLockAfterResumeInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		wakeLockAcquireOptions{
+			wakeMode:            wakeInjectModeNone,
+			requestedOwner:      &fixture.owner,
+			resumeEligible:      true,
+			resumeImageEvidence: &bound,
+		},
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  fixture.record.RequestID,
+			Generation: fixture.record.Generation,
+			BoundImage: &bound,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if !current.IdentityConfirmed || current.PID != fixture.lock.PID ||
+		current.Lock.ProcessStart != fixture.lock.Lock.ProcessStart ||
+		current.Lock.Generation == fixture.lock.Lock.Generation {
+		t.Fatalf("legacy resumed lock = %#v", current)
+	}
+	var claimed wakeRestartRecord
+	var exists bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		claimed, exists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !exists || claimed.Schema != wakeRestartSchemaV2 ||
+		claimed.SuccessorGeneration != current.Lock.Generation ||
+		claimed.StagePath != "" || claimed.BoundImage != nil {
+		t.Fatalf("legacy successor claim = %#v, exists=%v", claimed, exists)
+	}
+	if err := writeWakePreparedFileInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		current,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := consumeWakeRestartAfterPrepared(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		current,
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  fixture.record.RequestID,
+			Generation: fixture.record.Generation,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		_, exists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("legacy mixed-version handoff was not consumed")
+	}
+}
+
+func TestDarwinAcquireWakeLockAfterResumeRefusesUnpersistedCurrentStage(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	bound := boundWakeImageEvidenceForTest(fixture.candidate)
+	bound.Method = wakeImageMethodPathnameExecObserved
+
+	cleanup, err := acquireWakeLockAfterResumeInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		wakeLockAcquireOptions{
+			wakeMode:            wakeInjectModeNone,
+			requestedOwner:      &fixture.owner,
+			resumeEligible:      true,
+			resumeImageEvidence: &bound,
+		},
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  fixture.record.RequestID,
+			Generation: fixture.record.Generation,
+			BoundImage: &bound,
+		},
+	)
+	if cleanup != nil || err == nil || !strings.Contains(err.Error(), "no persisted bound stage") {
+		t.Fatalf("unpersisted current stage cleanup=%v err=%v", cleanup != nil, err)
+	}
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	if !sameWakeLockInspection(fixture.lock, current) {
+		t.Fatalf("unpersisted current stage changed incumbent: before=%#v after=%#v", fixture.lock, current)
 	}
 }

--- a/internal/cli/wake_restart_stage_darwin_test.go
+++ b/internal/cli/wake_restart_stage_darwin_test.go
@@ -1,0 +1,708 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func newDarwinWakeRestartStageRecordForTest(t *testing.T) wakeRestartRecord {
+	t.Helper()
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(testBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(path, raw, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := captureWakeImageEvidence(path, "stage-reclaim-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := wakeRestartRecord{
+		RequestID: "0123456789abcdef0123456789abcdef",
+		Candidate: candidate,
+	}
+	record.StagePath, err = planWakeRestartStagePlatform(candidate, record.RequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record
+}
+
+type consecutiveDarwinWakeRestartFixture struct {
+	root             string
+	agent            string
+	agentDir         *wakeAgentDir
+	record           wakeRestartRecord
+	previousEvidence wakeImageEvidenceV1
+	currentEvidence  wakeImageEvidenceV1
+	lockPath         string
+	stale            wakeLockInspection
+}
+
+func newConsecutiveDarwinWakeRestartFixture(t *testing.T) consecutiveDarwinWakeRestartFixture {
+	t.Helper()
+	previousRecord := newDarwinWakeRestartStageRecordForTest(t)
+	previousBound, err := bindWakeRestartCandidateAtPlatform(
+		previousRecord.Candidate,
+		previousRecord.StagePath,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousEvidence := previousBound.evidence
+	if err := previousBound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	previousBound.file = nil
+
+	currentRecord := newDarwinWakeRestartStageRecordForTest(t)
+	currentBound, err := bindWakeRestartCandidateAtPlatform(
+		currentRecord.Candidate,
+		currentRecord.StagePath,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentEvidence := currentBound.evidence
+	if err := currentBound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	currentBound.file = nil
+
+	root := canonicalWakeRoot(t.TempDir())
+	const agent = "codex"
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatal(err)
+	}
+	record := currentRecord
+	record.Schema = wakeRestartSchemaV2
+	record.Status = wakeRestartPending
+	record.Root = root
+	record.Agent = agent
+	record.Generation = "abcdef0123456789abcdef0123456789"
+	record.SuccessorGeneration = "fedcba9876543210fedcba9876543210"
+	record.Owner = validWakeResumeOwnerForTest()
+	record.BoundImage = &currentEvidence
+	record.PreviousBoundImage = &previousEvidence
+	agentDir, err := openWakeAgentDir(root, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agentDir.Close() })
+	if err := agentDir.withFD(func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := writeWakeLockForTest(t, root, agent, wakeLock{
+		PID:                  4242,
+		Executable:           "/opt/homebrew/bin/amq",
+		Generation:           record.SuccessorGeneration,
+		RunningImageEvidence: &currentEvidence,
+	})
+	currentProcess := inspectWakeProcess(os.Getpid())
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid == os.Getpid() {
+			return currentProcess
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	stale := inspectWakeLock(root, agent)
+	if stale.Status != wakeLockStale {
+		t.Fatalf("wake status = %s, want stale", stale.Status)
+	}
+	return consecutiveDarwinWakeRestartFixture{
+		root:             root,
+		agent:            agent,
+		agentDir:         agentDir,
+		record:           record,
+		previousEvidence: previousEvidence,
+		currentEvidence:  currentEvidence,
+		lockPath:         lockPath,
+		stale:            stale,
+	}
+}
+
+func TestDarwinReclaimsCrashStageFromPersistedIntentBeforeBoundEvidence(t *testing.T) {
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Model a hard crash after the hardlink exists but before BoundImage is
+	// persisted: release the test descriptor without running normal cleanup.
+	if err := bound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bound.file = nil
+
+	if err := reclaimWakeRestartStagePlatform(record); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(record.StagePath); !os.IsNotExist(err) {
+		t.Fatalf("crash stage survived exact intent-based reclaim: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Dir(record.StagePath)); !os.IsNotExist(err) {
+		t.Fatalf("crash stage directory survived exact reclaim: %v", err)
+	}
+}
+
+func TestDarwinCrashStageReclaimPreservesReplacement(t *testing.T) {
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bound.file = nil
+	if err := os.Remove(record.StagePath); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := os.ReadFile("/usr/bin/false")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(record.StagePath, replacement, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reclaimWakeRestartStagePlatform(record); err == nil {
+		t.Fatal("reclaim accepted a replacement stage")
+	}
+	if _, err := os.Lstat(record.StagePath); err != nil {
+		t.Fatalf("replacement stage was removed: %v", err)
+	}
+}
+
+func TestDoctorDiagnosesCrashOrphanedDarwinRestartStage(t *testing.T) {
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = bound.close() }()
+
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	evidence := bound.evidence
+	inspection := wakeLockInspection{
+		Exists: true,
+		Status: wakeLockStale,
+		Root:   root,
+		Agent:  "codex",
+		Lock: wakeLock{
+			Root:                 root,
+			Agent:                "codex",
+			RunningImageEvidence: &evidence,
+		},
+	}
+	diagnostic := diagnoseWakeRestartStage(root, "codex", inspection)
+	if diagnostic.Status != "orphan" || diagnostic.Path != record.StagePath {
+		t.Fatalf("Darwin restart-stage diagnostic = %#v, want exact orphan", diagnostic)
+	}
+}
+
+func TestDoctorFixRetriesExactPersistedDarwinRestartStageReclaim(t *testing.T) {
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bound.file = nil
+	record.Schema = wakeRestartSchemaV1
+	record.Status = wakeRestartPending
+	record.Root = canonicalWakeRoot(t.TempDir())
+	record.Agent = "codex"
+	record.Generation = "abcdef0123456789abcdef0123456789"
+	record.Owner = validWakeResumeOwnerForTest()
+	evidence := bound.evidence
+	record.BoundImage = &evidence
+	if err := fsq.EnsureRootDirs(record.Root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(record.Root, record.Agent); err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(record.Root, record.Agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	if err := agentDir.withFD(func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := writeWakeLockForTest(t, record.Root, record.Agent, wakeLock{
+		PID:                  4242,
+		Executable:           "/opt/homebrew/bin/amq",
+		Generation:           record.Generation,
+		RunningImageEvidence: &evidence,
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	oldReclaim := reclaimWakeRestartStageForStaleLock
+	reclaimErr := errors.New("injected persisted stage reclaim failure")
+	reclaimAttempts := 0
+	reclaimWakeRestartStageForStaleLock = func(record wakeRestartRecord) error {
+		reclaimAttempts++
+		if reclaimAttempts == 1 {
+			return reclaimErr
+		}
+		return oldReclaim(record)
+	}
+	t.Cleanup(func() { reclaimWakeRestartStageForStaleLock = oldReclaim })
+
+	stale := inspectWakeLock(record.Root, record.Agent)
+	if stale.Status != wakeLockStale {
+		t.Fatalf("wake status = %s, want stale", stale.Status)
+	}
+	first := opsWakeLock{}
+	if err := fixStaleWakeLockForDoctor(record.Root, record.Agent, &stale, &first); !errors.Is(err, reclaimErr) {
+		t.Fatalf("first doctor fix error = %v, want %v", err, reclaimErr)
+	}
+	if first.Removed {
+		t.Fatalf("first doctor fix removed stale lock: %#v", first)
+	}
+	if _, err := os.Lstat(lockPath); err != nil {
+		t.Fatalf("first doctor fix removed stale lock: %v", err)
+	}
+	if _, err := os.Lstat(record.StagePath); err != nil {
+		t.Fatalf("first doctor fix removed retryable stage: %v", err)
+	}
+	if err := agentDir.withFD(func(dirfd int) error {
+		current, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists || !sameWakeRestartRecord(current, record) {
+			return errors.New("first doctor fix did not preserve the exact restart record")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	restartPath := filepath.Join(agentDir.path, wakeRestartFileName)
+	quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+	if err != nil || len(quarantined) != 0 {
+		t.Fatalf("first doctor fix quarantine = %v, err=%v", quarantined, err)
+	}
+
+	stale = inspectWakeLock(record.Root, record.Agent)
+	second := opsWakeLock{}
+	if err := fixStaleWakeLockForDoctor(record.Root, record.Agent, &stale, &second); err != nil {
+		t.Fatal(err)
+	}
+	if !second.Removed || second.Status != "fixed" {
+		t.Fatalf("second doctor fix = %#v, want fixed removal", second)
+	}
+	if reclaimAttempts != 2 {
+		t.Fatalf("restart stage reclaim attempts = %d, want 2", reclaimAttempts)
+	}
+	if _, err := os.Lstat(record.StagePath); !os.IsNotExist(err) {
+		t.Fatalf("second doctor fix left exact crash stage: %v", err)
+	}
+	if _, err := os.Lstat(restartPath); !os.IsNotExist(err) {
+		t.Fatalf("second doctor fix left live restart record: %v", err)
+	}
+	if _, err := os.Lstat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("second doctor fix left stale wake lock: %v", err)
+	}
+	quarantined, err = filepath.Glob(restartPath + ".quarantined.*")
+	if err != nil || len(quarantined) != 1 {
+		t.Fatalf("second doctor fix quarantine = %v, err=%v", quarantined, err)
+	}
+}
+
+func TestDoctorDiagnosesAndReclaimsConsecutiveDarwinRestartStages(t *testing.T) {
+	fixture := newConsecutiveDarwinWakeRestartFixture(t)
+
+	live := fixture.stale
+	live.Status = wakeLockValid
+	live.IdentityConfirmed = true
+	live.Process.Running = true
+	diagnostic := diagnoseWakeRestartStage(fixture.root, fixture.agent, live)
+	if diagnostic.Status != "cleanup-pending" ||
+		diagnostic.Path != fixture.previousEvidence.ExecutionPath {
+		t.Fatalf("live previous-stage diagnostic = %#v, want exact cleanup-pending stage", diagnostic)
+	}
+	diagnostic = diagnoseWakeRestartStage(fixture.root, fixture.agent, fixture.stale)
+	if diagnostic.Status != "orphan" ||
+		diagnostic.Path != fixture.previousEvidence.ExecutionPath {
+		t.Fatalf("stale previous-stage diagnostic = %#v, want exact orphan", diagnostic)
+	}
+
+	result := opsWakeLock{}
+	if err := fixStaleWakeLockForDoctor(
+		fixture.root,
+		fixture.agent,
+		&fixture.stale,
+		&result,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !result.Removed || result.Status != "fixed" {
+		t.Fatalf("doctor fix = %#v, want fixed removal", result)
+	}
+	for label, stagePath := range map[string]string{
+		"previous": fixture.previousEvidence.ExecutionPath,
+		"current":  fixture.currentEvidence.ExecutionPath,
+	} {
+		if _, err := os.Lstat(stagePath); !os.IsNotExist(err) {
+			t.Fatalf("%s crash stage survived doctor reclaim: %v", label, err)
+		}
+		if _, err := os.Lstat(filepath.Dir(stagePath)); !os.IsNotExist(err) {
+			t.Fatalf("%s crash stage directory survived doctor reclaim: %v", label, err)
+		}
+	}
+	if _, err := os.Lstat(fixture.lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale successor lock survived doctor fix: %v", err)
+	}
+	restartPath := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+	if _, err := os.Lstat(restartPath); !os.IsNotExist(err) {
+		t.Fatalf("live restart record survived doctor fix: %v", err)
+	}
+	quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+	if err != nil || len(quarantined) != 1 {
+		t.Fatalf("doctor fix quarantine = %v, err=%v", quarantined, err)
+	}
+}
+
+func TestNextWakeStartupReclaimsRetainedConsecutiveDarwinRestartStages(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		prepareCoop bool
+	}{
+		{name: "ordinary wake acquire"},
+		{name: "coop startup preflight", prepareCoop: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newConsecutiveDarwinWakeRestartFixture(t)
+			oldGeneration := fixture.record.SuccessorGeneration
+			if test.prepareCoop {
+				if err := prepareCoopWakeLock(fixture.root, fixture.agent, true, "unused"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cleanup, err := acquireWakeLockWithOptionsInDir(
+				fixture.agentDir,
+				fixture.root,
+				fixture.agent,
+				wakeLockAcquireOptions{wakeMode: wakeInjectModeNone},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+
+			current := inspectWakeLock(fixture.root, fixture.agent)
+			if !current.Exists || current.Lock.Generation == "" ||
+				current.Lock.Generation == oldGeneration {
+				t.Fatalf("next wake generation = %#v, want a fresh lock", current)
+			}
+			for label, stagePath := range map[string]string{
+				"previous": fixture.previousEvidence.ExecutionPath,
+				"current":  fixture.currentEvidence.ExecutionPath,
+			} {
+				if _, err := os.Lstat(stagePath); !os.IsNotExist(err) {
+					t.Fatalf("%s restart stage survived next startup: %v", label, err)
+				}
+				if _, err := os.Lstat(filepath.Dir(stagePath)); !os.IsNotExist(err) {
+					t.Fatalf("%s restart stage directory survived next startup: %v", label, err)
+				}
+			}
+			restartPath := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+			if _, err := os.Lstat(restartPath); !os.IsNotExist(err) {
+				t.Fatalf("live restart record survived next startup: %v", err)
+			}
+			quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+			if err != nil || len(quarantined) != 1 {
+				t.Fatalf("next startup restart quarantine = %v, err=%v", quarantined, err)
+			}
+		})
+	}
+}
+
+func TestForeignDarwinRestartRecordDoesNotDeadEndLockRemoval(t *testing.T) {
+	for _, action := range []string{"next-start", "doctor"} {
+		t.Run(action, func(t *testing.T) {
+			fixture := newConsecutiveDarwinWakeRestartFixture(t)
+			foreign := fixture.record
+			foreign.Generation = "11111111111111111111111111111111"
+			foreign.SuccessorGeneration = "22222222222222222222222222222222"
+			if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+				return writeWakeRestartRecordAt(dirfd, fixture.agentDir, foreign)
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			switch action {
+			case "next-start":
+				cleanup, err := acquireWakeLockWithOptionsInDir(
+					fixture.agentDir,
+					fixture.root,
+					fixture.agent,
+					wakeLockAcquireOptions{wakeMode: wakeInjectModeNone},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer cleanup()
+			case "doctor":
+				result := opsWakeLock{}
+				if err := fixStaleWakeLockForDoctor(
+					fixture.root,
+					fixture.agent,
+					&fixture.stale,
+					&result,
+				); err != nil {
+					t.Fatal(err)
+				}
+				if !result.Removed {
+					t.Fatalf("doctor did not remove stale foreign-record lock: %#v", result)
+				}
+			}
+
+			for label, stagePath := range map[string]string{
+				"previous": fixture.previousEvidence.ExecutionPath,
+				"current":  fixture.currentEvidence.ExecutionPath,
+			} {
+				if _, err := os.Lstat(stagePath); !os.IsNotExist(err) {
+					t.Fatalf("%s foreign restart stage survived %s: %v", label, action, err)
+				}
+			}
+			restartPath := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+			if _, err := os.Lstat(restartPath); !os.IsNotExist(err) {
+				t.Fatalf("foreign canonical restart record survived %s: %v", action, err)
+			}
+			quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+			if err != nil || len(quarantined) != 1 {
+				t.Fatalf("foreign restart quarantine after %s = %v, err=%v", action, quarantined, err)
+			}
+		})
+	}
+}
+
+func TestDarwinPreviousCleanupFailurePreservesRecordAndSuccessorLock(t *testing.T) {
+	fixture := newConsecutiveDarwinWakeRestartFixture(t)
+	cleanupErr := errors.New("injected previous-stage cleanup failure")
+	retainLock := false
+	bootstrap := wakeResumeBootstrap{
+		Schema:             wakeRestartSchemaV1,
+		RequestID:          fixture.record.RequestID,
+		Generation:         fixture.record.Generation,
+		BoundImage:         &fixture.currentEvidence,
+		PreviousBoundImage: &fixture.previousEvidence,
+	}
+	err := commitWakeRestartReadiness(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		fixture.stale,
+		bootstrap,
+		&retainLock,
+		func(got wakeResumeBootstrap) error {
+			if !sameOptionalWakeImageEvidence(got.PreviousBoundImage, bootstrap.PreviousBoundImage) {
+				t.Fatal("readiness cleanup lost exact previous-stage ownership")
+			}
+			return cleanupErr
+		},
+	)
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("readiness commit error = %v, want %v", err, cleanupErr)
+	}
+	if !retainLock {
+		t.Fatal("previous-stage cleanup failure did not retain the successor lock")
+	}
+	var current wakeRestartRecord
+	var exists bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		current, exists, readErr = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return readErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !exists || !sameWakeRestartRecord(current, fixture.record) {
+		t.Fatalf("cleanup failure changed restart ownership: exists=%v record=%#v", exists, current)
+	}
+
+	lockCleaned := false
+	if err := cleanupWakeResumeStageBeforeLock(
+		func() error { return cleanupWakeResumeBoundImage(bootstrap) },
+		func() { lockCleaned = true },
+		&retainLock,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if lockCleaned {
+		t.Fatal("successful current-stage cleanup removed lock after previous-stage refusal")
+	}
+	if _, err := os.Lstat(fixture.currentEvidence.ExecutionPath); !os.IsNotExist(err) {
+		t.Fatalf("current restart stage survived final cleanup: %v", err)
+	}
+	if _, err := os.Lstat(fixture.previousEvidence.ExecutionPath); err != nil {
+		t.Fatalf("failed previous restart stage was not preserved: %v", err)
+	}
+	if _, err := os.Lstat(fixture.lockPath); err != nil {
+		t.Fatalf("successor lock was not retained for doctor recovery: %v", err)
+	}
+}
+
+func TestDarwinRestartRetryReclaimsAndQuarantinesRefusedOwnedStage(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	refused := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(refused.Candidate, refused.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundEvidence := bound.evidence
+	if err := bound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bound.file = nil
+	refused.Schema = wakeRestartSchemaV1
+	refused.Status = wakeRestartRefused
+	refused.Reason = "prior cleanup refusal"
+	refused.Root = fixture.root
+	refused.Agent = fixture.agent
+	refused.Generation = fixture.lock.Lock.Generation
+	refused.Owner = fixture.owner
+	refused.BoundImage = &boundEvidence
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, refused)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	retryErr := errors.New("injected retry notification failure")
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		return nil
+	}
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		return retryErr
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+	})
+
+	if _, err := requestWakeRestart(fixture.root, fixture.agent); !errors.Is(err, retryErr) {
+		t.Fatalf("restart retry error = %v, want %v", err, retryErr)
+	}
+	if _, err := os.Lstat(refused.StagePath); !os.IsNotExist(err) {
+		t.Fatalf("refused restart stage survived retry reclaim: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Dir(refused.StagePath)); !os.IsNotExist(err) {
+		t.Fatalf("refused restart stage directory survived retry reclaim: %v", err)
+	}
+	restartPath := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+	quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+	if err != nil || len(quarantined) != 1 {
+		t.Fatalf("refused retry quarantine = %v, err=%v", quarantined, err)
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		if readErr != nil {
+			return readErr
+		}
+		if !exists || current.Status != wakeRestartRefused || current.RequestID == refused.RequestID {
+			return fmt.Errorf("retry did not install an independent refused request: exists=%v record=%#v", exists, current)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDarwinFinalStageCleanupPrecedesLockReleaseAndRetainsOnFailure(t *testing.T) {
+	cleanupErr := errors.New("injected current-stage cleanup failure")
+	retainLock := false
+	var events []string
+	err := cleanupWakeResumeStageBeforeLock(
+		func() error {
+			events = append(events, "stage")
+			return cleanupErr
+		},
+		func() { events = append(events, "lock") },
+		&retainLock,
+	)
+	if !errors.Is(err, cleanupErr) || !retainLock {
+		t.Fatalf("failed final cleanup: err=%v retain=%v", err, retainLock)
+	}
+	if len(events) != 1 || events[0] != "stage" {
+		t.Fatalf("cleanup order after refusal = %v, want stage only", events)
+	}
+
+	retainLock = false
+	events = nil
+	if err := cleanupWakeResumeStageBeforeLock(
+		func() error {
+			events = append(events, "stage")
+			return nil
+		},
+		func() { events = append(events, "lock") },
+		&retainLock,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 || events[0] != "stage" || events[1] != "lock" {
+		t.Fatalf("successful cleanup order = %v, want stage then lock", events)
+	}
+}
+
+func TestDarwinPostAcquireErrorRetainsLockBeforeReadinessCommit(t *testing.T) {
+	bootstrap := &wakeResumeBootstrap{Schema: wakeRestartSchemaV1}
+	retainLock := newWakeRestartCleanupRetention(bootstrap)
+	if !*retainLock {
+		t.Fatal("resumed generation did not retain its lock before readiness commit")
+	}
+	stageCleaned := false
+	lockCleaned := false
+	if err := cleanupWakeResumeStageBeforeLock(
+		func() error {
+			stageCleaned = true
+			return nil
+		},
+		func() { lockCleaned = true },
+		retainLock,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !stageCleaned {
+		t.Fatal("post-acquire failure did not clean the current resume stage")
+	}
+	if lockCleaned {
+		t.Fatal("post-acquire failure removed the lock before readiness commit")
+	}
+}

--- a/internal/cli/wake_restart_stage_diagnostic_darwin_test.go
+++ b/internal/cli/wake_restart_stage_diagnostic_darwin_test.go
@@ -1,0 +1,365 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestDoctorReportsInvalidWakeRestartRecordWithoutLockReadOnly(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		raw        func(t *testing.T, root string) []byte
+		wantReason string
+	}{
+		{
+			name: "malformed",
+			raw: func(_ *testing.T, _ string) []byte {
+				return []byte(`{"schema":`)
+			},
+			wantReason: "parse wake restart request",
+		},
+		{
+			name: "future schema",
+			raw: func(t *testing.T, root string) []byte {
+				return futureWakeRestartRecordRawForDoctorTest(t, root)
+			},
+			wantReason: "schema 3 unsupported",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			if err := config.WriteConfig(
+				filepath.Join(root, "meta", "config.json"),
+				config.Config{Version: 1, Agents: []string{"codex"}},
+				true,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			path := filepath.Join(root, "agents", "codex", wakeRestartFileName)
+			raw := test.raw(t, root)
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.Lstat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result := runOpsChecksWithSchema(root, "test", false, wakeCheckSchemaV2)
+			if len(result.WakeLocks) != 1 {
+				t.Fatalf("doctor wake diagnostics = %#v, want one restart residue", result.WakeLocks)
+			}
+			got := result.WakeLocks[0]
+			wantFix := doctorRootCommandForOS(root, "", "darwin", "--ops", "--fix-wake-locks")
+			if got.Status != string(wakeLockMissing) || got.RestartStageStatus != "record-invalid" ||
+				!strings.Contains(got.RestartStageReason, test.wantReason) || got.Fix != wantFix {
+				t.Fatalf("doctor restart residue = %#v", got)
+			}
+			setDoctorIdentityPin(t, root)
+			output, err := captureEnvStdout(t, func() error {
+				return runDoctor([]string{"--root", root, "--ops"})
+			})
+			if err != nil {
+				t.Fatalf("doctor --ops: %v", err)
+			}
+			if !strings.Contains(output, "restart_stage=record-invalid") ||
+				!strings.Contains(output, test.wantReason) ||
+				!strings.Contains(output, "fix="+wantFix) {
+				t.Fatalf("doctor --ops omitted invalid restart residue: %q", output)
+			}
+			if _, err := os.Lstat(filepath.Join(root, "agents", "codex", ".wake.lock")); !os.IsNotExist(err) {
+				t.Fatalf("doctor diagnosis created a wake lock: %v", err)
+			}
+			afterRaw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			after, err := os.Lstat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(afterRaw, raw) || !os.SameFile(before, after) {
+				t.Fatal("doctor diagnosis mutated the invalid restart record")
+			}
+		})
+	}
+}
+
+func TestDoctorDoesNotReportMissingAgentWithoutRestartResidue(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"codex"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	agentDir := fsq.AgentBase(root, "codex")
+	if _, err := os.Lstat(agentDir); !os.IsNotExist(err) {
+		t.Fatalf("configured agent directory unexpectedly exists before doctor: %v", err)
+	}
+	result := runOpsChecksWithSchema(root, "test", false, wakeCheckSchemaV2)
+	if len(result.WakeLocks) != 0 {
+		t.Fatalf("missing agent without restart residue was reported: %#v", result.WakeLocks)
+	}
+	if _, err := os.Lstat(agentDir); !os.IsNotExist(err) {
+		t.Fatalf("read-only doctor created configured agent directory: %v", err)
+	}
+}
+
+func TestDoctorFixQuarantinesInvalidWakeRestartRecordWithoutLock(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		raw  func(t *testing.T, root string) []byte
+	}{
+		{name: "malformed", raw: func(_ *testing.T, _ string) []byte { return []byte(`{"schema":`) }},
+		{name: "future schema", raw: futureWakeRestartRecordRawForDoctorTest},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := secureTempDirForTest(t)
+			if err := fsq.EnsureRootDirs(root); err != nil {
+				t.Fatal(err)
+			}
+			if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+				t.Fatal(err)
+			}
+			if err := config.WriteConfig(
+				filepath.Join(root, "meta", "config.json"),
+				config.Config{Version: 1, Agents: []string{"codex"}},
+				true,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			agentDir := fsq.AgentBase(root, "codex")
+			path := filepath.Join(agentDir, wakeRestartFileName)
+			raw := test.raw(t, root)
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.Lstat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result := runOpsChecksWithSchema(root, "test", true, wakeCheckSchemaV1)
+			if len(result.WakeLocks) != 1 || result.WakeLocks[0].Status != "fixed" ||
+				!result.WakeLocks[0].Removed {
+				t.Fatalf("doctor fix result = %#v", result.WakeLocks)
+			}
+			if _, err := os.Lstat(path); !os.IsNotExist(err) {
+				t.Fatalf("canonical restart record survived fix: %v", err)
+			}
+			if _, err := os.Lstat(filepath.Join(agentDir, ".wake.lock")); !os.IsNotExist(err) {
+				t.Fatalf("doctor restart residue fix created a wake lock: %v", err)
+			}
+			assertExactWakeQuarantineForTest(
+				t,
+				agentDir,
+				wakeRestartFileName+".quarantined.",
+				raw,
+				before,
+			)
+		})
+	}
+}
+
+func TestDoctorFixReclaimsValidDarwinRestartStageWithoutLock(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"codex"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := bound.evidence
+	if err := bound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bound.file = nil
+	record.Schema = wakeRestartSchemaV1
+	record.Status = wakeRestartPending
+	record.Root = canonicalWakeRoot(root)
+	record.Agent = "codex"
+	record.Generation = "abcdef0123456789abcdef0123456789"
+	record.Owner = validWakeResumeOwnerForTest()
+	record.BoundImage = &evidence
+
+	agentDir, err := openWakeDirectory(fsq.AgentBase(root, "codex"), "wake agent directory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	if err := agentDir.withFD(func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	restartPath := filepath.Join(agentDir.path, wakeRestartFileName)
+	raw, err := os.ReadFile(restartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Lstat(restartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := runOpsChecksWithSchema(root, "test", true, wakeCheckSchemaV1)
+	if len(result.WakeLocks) != 1 || result.WakeLocks[0].Status != "fixed" ||
+		!result.WakeLocks[0].Removed {
+		t.Fatalf("doctor valid-stage fix result = %#v", result.WakeLocks)
+	}
+	if _, err := os.Lstat(record.StagePath); !os.IsNotExist(err) {
+		t.Fatalf("owned Darwin restart stage survived doctor fix: %v", err)
+	}
+	assertExactWakeQuarantineForTest(
+		t,
+		agentDir.path,
+		wakeRestartFileName+".quarantined.",
+		raw,
+		before,
+	)
+}
+
+func TestDoctorFixPreservesRestartResidueWhenLockAppears(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := fsq.AgentBase(root, "codex")
+	restartPath := filepath.Join(agentDir, wakeRestartFileName)
+	raw := []byte(`{"schema":`)
+	if err := os.WriteFile(restartPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Lstat(restartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{PID: os.Getpid()})
+
+	err = fixWakeRestartResidueWithoutLock(root, "codex")
+	if err == nil || !strings.Contains(err.Error(), "wake lock appeared") {
+		t.Fatalf("fix with appeared wake lock error = %v", err)
+	}
+	afterRaw, err := os.ReadFile(restartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Lstat(restartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(afterRaw, raw) || !os.SameFile(before, after) {
+		t.Fatal("doctor fix mutated restart residue after a lock appeared")
+	}
+	quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+	if err != nil || len(quarantined) != 0 {
+		t.Fatalf("doctor fix quarantined restart residue after a lock appeared: %v, err=%v", quarantined, err)
+	}
+}
+
+func futureWakeRestartRecordRawForDoctorTest(t *testing.T, root string) []byte {
+	t.Helper()
+	candidate, err := captureCurrentWakeImageEvidence()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := wakeRestartRecord{
+		Schema:     wakeRestartSchemaV2 + 1,
+		RequestID:  "0123456789abcdef0123456789abcdef",
+		Status:     wakeRestartPending,
+		Root:       canonicalWakeRoot(root),
+		Agent:      "codex",
+		Generation: "abcdef0123456789abcdef0123456789",
+		Owner:      validWakeResumeOwnerForTest(),
+		Candidate:  candidate,
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(raw, '\n')
+}
+
+func TestDoctorReportsRefusedSurvivingDarwinStageAsCleanupFailed(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = bound.close() }()
+
+	record.Schema = wakeRestartSchemaV1
+	record.Status = wakeRestartRefused
+	record.Reason = "restart execution refused"
+	record.Root = fixture.root
+	record.Agent = fixture.agent
+	record.Generation = fixture.lock.Lock.Generation
+	record.Owner = fixture.owner
+	evidence := bound.evidence
+	record.BoundImage = &evidence
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	diagnostic := diagnoseWakeRestartStage(fixture.root, fixture.agent, fixture.lock)
+	if diagnostic.Status != "cleanup-failed" || diagnostic.Path != record.StagePath ||
+		diagnostic.Status == "pending" || diagnostic.Status == "handoff" {
+		t.Fatalf("refused restart stage diagnostic = %#v", diagnostic)
+	}
+	locks, _ := checkWakeLocksWithHintsSchema(
+		fixture.root,
+		[]string{fixture.agent},
+		false,
+		wakeCheckSchemaV2,
+	)
+	if len(locks) != 1 || locks[0].RestartStageStatus != "cleanup-failed" ||
+		locks[0].RestartStagePath != record.StagePath {
+		t.Fatalf("doctor refused restart stage = %#v", locks)
+	}
+	if _, err := os.Lstat(record.StagePath); err != nil {
+		t.Fatalf("doctor diagnosis mutated refused restart stage: %v", err)
+	}
+}

--- a/internal/cli/wake_restart_stage_diagnostic_other.go
+++ b/internal/cli/wake_restart_stage_diagnostic_other.go
@@ -1,0 +1,25 @@
+//go:build !darwin && !linux
+
+package cli
+
+type wakeRestartStageDiagnostic struct {
+	Path   string
+	Status string
+	Reason string
+}
+
+func diagnoseWakeRestartStage(
+	string,
+	string,
+	wakeLockInspection,
+) wakeRestartStageDiagnostic {
+	return wakeRestartStageDiagnostic{}
+}
+
+func fixWakeRestartResidueWithoutLock(string, string) error {
+	return nil
+}
+
+func reclaimWakeRestartStateForGuardedLockRemoval(wakeLockInspection) error {
+	return nil
+}

--- a/internal/cli/wake_restart_stage_diagnostic_unix.go
+++ b/internal/cli/wake_restart_stage_diagnostic_unix.go
@@ -1,0 +1,187 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type wakeRestartStageDiagnostic struct {
+	Path   string
+	Status string
+	Reason string
+}
+
+func diagnoseWakeRestartStage(
+	root string,
+	agent string,
+	inspection wakeLockInspection,
+) wakeRestartStageDiagnostic {
+	if err := fsq.ValidateHandle(agent); err != nil {
+		return wakeRestartStageDiagnostic{Status: "inspection-error", Reason: err.Error()}
+	}
+	agentDirPath := fsq.AgentBase(root, agent)
+	if _, err := os.Lstat(agentDirPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return wakeRestartStageDiagnostic{}
+		}
+		return wakeRestartStageDiagnostic{Status: "inspection-error", Reason: err.Error()}
+	}
+	agentDir, err := openWakeDirectory(agentDirPath, "wake agent directory")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return wakeRestartStageDiagnostic{}
+		}
+		return wakeRestartStageDiagnostic{Status: "inspection-error", Reason: err.Error()}
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	var snapshot wakeRestartRecordSnapshot
+	var exists bool
+	err = agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		snapshot, exists, readErr = readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+		return readErr
+	})
+	if err != nil {
+		return wakeRestartStageDiagnostic{
+			Status: "record-invalid",
+			Reason: fmt.Sprintf("wake restart record is not safely readable: %v", err),
+		}
+	}
+	if exists && snapshot.Record.PreviousBoundImage != nil {
+		previous := *snapshot.Record.PreviousBoundImage
+		if _, stageErr := os.Lstat(previous.ExecutionPath); stageErr != nil && !os.IsNotExist(stageErr) {
+			return wakeRestartStageDiagnostic{
+				Path:   previous.ExecutionPath,
+				Status: "inspection-error",
+				Reason: stageErr.Error(),
+			}
+		} else if stageErr == nil {
+			live := inspection.Exists && inspection.Status == wakeLockValid &&
+				inspection.IdentityConfirmed && inspection.Process.Running
+			previousIsLivePredecessor := snapshot.Record.Status == wakeRestartPending && live &&
+				snapshot.Record.Schema == wakeRestartSchemaV1 &&
+				snapshot.Record.Generation == inspection.Lock.Generation &&
+				inspection.Lock.RunningImageEvidence != nil &&
+				sameDarwinStagedWakeImageEvidence(previous, *inspection.Lock.RunningImageEvidence)
+			if !previousIsLivePredecessor {
+				status := "orphan"
+				reason := "previous Darwin restart stage is retained by a non-live handoff"
+				if snapshot.Record.Status == wakeRestartRefused {
+					status = "cleanup-failed"
+					reason = "refused wake restart retained its previous Darwin stage for cleanup"
+				} else if snapshot.Record.Status == wakeRestartPending && live &&
+					snapshot.Record.Schema == wakeRestartSchemaV2 &&
+					snapshot.Record.SuccessorGeneration == inspection.Lock.Generation {
+					status = "cleanup-pending"
+					reason = "previous Darwin restart stage is retained until successor readiness cleanup"
+				}
+				return wakeRestartStageDiagnostic{
+					Path:   previous.ExecutionPath,
+					Status: status,
+					Reason: reason,
+				}
+			}
+		}
+	}
+	if exists && snapshot.Record.StagePath != "" {
+		present, stageErr := wakeRestartStageExistsPlatform(snapshot.Record)
+		if stageErr != nil {
+			return wakeRestartStageDiagnostic{
+				Path:   snapshot.Record.StagePath,
+				Status: "inspection-error",
+				Reason: stageErr.Error(),
+			}
+		}
+		if present {
+			status := "orphan"
+			reason := "persisted Darwin restart stage is not bound to a live handoff"
+			if snapshot.Record.Status == wakeRestartRefused {
+				status = "cleanup-failed"
+				reason = "refused wake restart retained its Darwin stage for cleanup"
+			} else if snapshot.Record.Status == wakeRestartPending &&
+				inspection.Exists && inspection.Status == wakeLockValid &&
+				inspection.IdentityConfirmed && inspection.Process.Running {
+				switch {
+				case snapshot.Record.Schema == wakeRestartSchemaV1 &&
+					snapshot.Record.Generation == inspection.Lock.Generation:
+					status = "pending"
+					reason = "restart stage is owned by the live predecessor generation"
+				case snapshot.Record.Schema == wakeRestartSchemaV2 &&
+					snapshot.Record.SuccessorGeneration == inspection.Lock.Generation:
+					status = "handoff"
+					reason = "restart stage is owned by the live successor handoff"
+				}
+			}
+			return wakeRestartStageDiagnostic{
+				Path:   snapshot.Record.StagePath,
+				Status: status,
+				Reason: reason,
+			}
+		}
+	}
+
+	running := inspection.Lock.RunningImageEvidence
+	if running == nil || !validPreviousWakeRestartBoundImagePlatform(*running) {
+		return wakeRestartStageDiagnostic{}
+	}
+	if _, err := os.Lstat(running.ExecutionPath); os.IsNotExist(err) {
+		return wakeRestartStageDiagnostic{}
+	} else if err != nil {
+		return wakeRestartStageDiagnostic{
+			Path:   running.ExecutionPath,
+			Status: "inspection-error",
+			Reason: err.Error(),
+		}
+	}
+	if inspection.Status == wakeLockValid && inspection.IdentityConfirmed && inspection.Process.Running {
+		return wakeRestartStageDiagnostic{
+			Path:   running.ExecutionPath,
+			Status: "active",
+			Reason: "restart stage is the live wake image",
+		}
+	}
+	return wakeRestartStageDiagnostic{
+		Path:   running.ExecutionPath,
+		Status: "orphan",
+		Reason: "restart stage is retained by a non-live wake generation",
+	}
+}
+
+func fixWakeRestartResidueWithoutLock(root, agent string) error {
+	if err := fsq.ValidateHandle(agent); err != nil {
+		return err
+	}
+	agentDir, err := openWakeDirectory(fsq.AgentBase(root, agent), "wake agent directory")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = agentDir.Close() }()
+
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		if current := inspectWakeLockAt(dirfd, agentDir, root, agent); current.Exists {
+			return fmt.Errorf("wake lock appeared before restart residue fix; preserving restart state")
+		}
+
+		snapshot, exists, readErr := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+		if readErr != nil {
+			if !exists || snapshot.Object.FileInfo == nil {
+				return fmt.Errorf("inspect wake restart record before fix: %w", readErr)
+			}
+		} else if !exists {
+			return nil
+		} else if err := reclaimWakeRestartStagePlatform(snapshot.Record); err != nil {
+			return fmt.Errorf("reclaim wake restart stage before quarantine: %w", err)
+		}
+
+		if _, err := quarantineWakeRestartRecordAt(dirfd, agentDir, snapshot); err != nil {
+			return fmt.Errorf("quarantine wake restart record: %w", err)
+		}
+		return nil
+	})
+}

--- a/internal/cli/wake_restart_stage_linux.go
+++ b/internal/cli/wake_restart_stage_linux.go
@@ -10,7 +10,7 @@ func planWakeRestartStagePlatform(wakeImageEvidenceV1, string) (string, error) {
 
 func validateWakeRestartStageStatePlatform(record wakeRestartRecord) error {
 	if record.StagePath != "" || record.BoundImage != nil {
-		return fmt.Errorf("Linux wake restart record contains Darwin stage state")
+		return fmt.Errorf("linux wake restart record contains Darwin stage state")
 	}
 	return nil
 }
@@ -21,7 +21,7 @@ func reclaimWakeRestartStagePlatform(record wakeRestartRecord) error {
 
 func validateWakeRestartPersistedBoundPlatform(record wakeRestartRecord, _ wakeImageEvidenceV1) error {
 	if record.BoundImage != nil {
-		return fmt.Errorf("Linux wake restart record contains a persisted Darwin bound stage")
+		return fmt.Errorf("linux wake restart record contains a persisted Darwin bound stage")
 	}
 	return nil
 }

--- a/internal/cli/wake_restart_stage_linux.go
+++ b/internal/cli/wake_restart_stage_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package cli
+
+import "fmt"
+
+func planWakeRestartStagePlatform(wakeImageEvidenceV1, string) (string, error) {
+	return "", nil
+}
+
+func validateWakeRestartStageStatePlatform(record wakeRestartRecord) error {
+	if record.StagePath != "" || record.BoundImage != nil {
+		return fmt.Errorf("Linux wake restart record contains Darwin stage state")
+	}
+	return nil
+}
+
+func reclaimWakeRestartStagePlatform(record wakeRestartRecord) error {
+	return validateWakeRestartStageStatePlatform(record)
+}
+
+func validateWakeRestartPersistedBoundPlatform(record wakeRestartRecord, _ wakeImageEvidenceV1) error {
+	if record.BoundImage != nil {
+		return fmt.Errorf("Linux wake restart record contains a persisted Darwin bound stage")
+	}
+	return nil
+}
+
+func wakeRestartStageExistsPlatform(wakeRestartRecord) (bool, error) {
+	return false, nil
+}
+
+func reclaimWakeRestartRunningImagePlatform(wakeLock) error { return nil }

--- a/internal/cli/wake_restart_stage_reclaim_unix.go
+++ b/internal/cli/wake_restart_stage_reclaim_unix.go
@@ -13,7 +13,7 @@ func reclaimWakeRestartStateForGuardedLockRemoval(inspection wakeLockInspection)
 	}
 	defer func() { _ = agentDir.Close() }()
 	return agentDir.withFD(func(dirfd int) error {
-		current := inspectWakeLockAt(
+		current := readWakeLockMetadataAt(
 			dirfd,
 			agentDir,
 			inspection.Root,
@@ -22,7 +22,7 @@ func reclaimWakeRestartStateForGuardedLockRemoval(inspection wakeLockInspection)
 		if !sameWakeLockGeneration(inspection, current) {
 			return fmt.Errorf("wake lock changed before restart-state reconciliation")
 		}
-		return reclaimWakeRestartStateForLockRemovalAt(dirfd, agentDir, current)
+		return reclaimWakeRestartStateForLockRemovalAt(dirfd, agentDir, inspection)
 	})
 }
 

--- a/internal/cli/wake_restart_stage_reclaim_unix.go
+++ b/internal/cli/wake_restart_stage_reclaim_unix.go
@@ -1,0 +1,64 @@
+//go:build darwin || linux
+
+package cli
+
+import "fmt"
+
+var reclaimWakeRestartStageForStaleLock = reclaimWakeRestartStagePlatform
+
+func reclaimWakeRestartStateForGuardedLockRemoval(inspection wakeLockInspection) error {
+	agentDir, err := openWakeAgentDir(inspection.Root, inspection.Agent)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = agentDir.Close() }()
+	return agentDir.withFD(func(dirfd int) error {
+		current := inspectWakeLockAt(
+			dirfd,
+			agentDir,
+			inspection.Root,
+			inspection.Agent,
+		)
+		if !sameWakeLockGeneration(inspection, current) {
+			return fmt.Errorf("wake lock changed before restart-state reconciliation")
+		}
+		return reclaimWakeRestartStateForLockRemovalAt(dirfd, agentDir, current)
+	})
+}
+
+func reclaimWakeRestartStateForLockRemovalAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	lock wakeLockInspection,
+) error {
+	snapshot, exists, readErr := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+	var quarantine *wakeRestartRecordSnapshot
+	if readErr != nil {
+		if !exists || snapshot.Object.FileInfo == nil {
+			return fmt.Errorf("inspect wake restart state before lock removal: %w", readErr)
+		}
+		quarantine = &snapshot
+	} else if exists {
+		record := snapshot.Record
+		boundToLock := record.Generation == lock.Lock.Generation ||
+			record.SuccessorGeneration == lock.Lock.Generation
+		if boundToLock && record.Schema == wakeRestartSchemaV2 && lock.Status != wakeLockStale {
+			return fmt.Errorf(
+				"live wake restart successor handoff is preserved before lock removal",
+			)
+		}
+		if err := reclaimWakeRestartStageForStaleLock(record); err != nil {
+			return fmt.Errorf("reclaim persisted wake restart stage: %w", err)
+		}
+		quarantine = &snapshot
+	}
+	if err := reclaimWakeRestartRunningImagePlatform(lock.Lock); err != nil {
+		return fmt.Errorf("reclaim wake running stage before lock removal: %w", err)
+	}
+	if quarantine != nil {
+		if _, err := quarantineWakeRestartRecordAt(dirfd, agentDir, *quarantine); err != nil {
+			return fmt.Errorf("quarantine wake restart state before lock removal: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -32,22 +32,26 @@ const (
 	wakeResumePreflightTimeout = 5 * time.Second
 	wakeRestartFileName        = ".wake.restart"
 	wakeRestartSchemaV1        = 1
+	wakeRestartSchemaV2        = 2
 	wakeRestartPending         = "pending"
 	wakeRestartRefused         = "refused"
 	wakeRestartWaitTimeout     = 15 * time.Second
 )
 
 type wakeRestartRecord struct {
-	Schema             int                  `json:"schema"`
-	RequestID          string               `json:"request_id"`
-	Status             string               `json:"status"`
-	Root               string               `json:"root"`
-	Agent              string               `json:"agent"`
-	Generation         string               `json:"generation"`
-	Owner              wakeOwner            `json:"owner"`
-	Candidate          wakeImageEvidenceV1  `json:"candidate"`
-	PreviousBoundImage *wakeImageEvidenceV1 `json:"previous_bound_image,omitempty"`
-	Reason             string               `json:"reason,omitempty"`
+	Schema              int                  `json:"schema"`
+	RequestID           string               `json:"request_id"`
+	Status              string               `json:"status"`
+	Root                string               `json:"root"`
+	Agent               string               `json:"agent"`
+	Generation          string               `json:"generation"`
+	SuccessorGeneration string               `json:"successor_generation,omitempty"`
+	Owner               wakeOwner            `json:"owner"`
+	Candidate           wakeImageEvidenceV1  `json:"candidate"`
+	StagePath           string               `json:"stage_path,omitempty"`
+	BoundImage          *wakeImageEvidenceV1 `json:"bound_image,omitempty"`
+	PreviousBoundImage  *wakeImageEvidenceV1 `json:"previous_bound_image,omitempty"`
+	Reason              string               `json:"reason,omitempty"`
 }
 
 type wakeResumeBootstrap struct {
@@ -77,10 +81,10 @@ type wakeRestartReadiness struct {
 var (
 	wakeRestartNow            = time.Now
 	wakeRestartSleep          = time.Sleep
-	wakeRestartSignal         = func(process *os.Process) error { return process.Signal(syscall.SIGUSR1) }
+	wakeRestartNotify         = notifyWakeRestartPlatform
 	wakeRestartExec           = syscall.Exec
 	wakeRestartPreflight      = preflightWakeRestartCandidate
-	wakeRestartBind           = bindWakeRestartCandidate
+	wakeRestartBind           = bindWakeRestartCandidateForRecord
 	wakeRestartBoundPreflight = preflightBoundWakeRestartCandidate
 )
 
@@ -162,6 +166,11 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 		result.Reason = err.Error()
 		return result, err
 	}
+	stagePath, err := planWakeRestartStagePlatform(candidate, requestID)
+	if err != nil {
+		result.Reason = err.Error()
+		return result, err
+	}
 
 	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
@@ -171,6 +180,9 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 	defer func() { _ = agentDir.Close() }()
 
 	var expected wakeLockInspection
+	var creatorSnapshot wakeRestartRecordSnapshot
+	adopted := false
+	needsNotify := true
 	record := wakeRestartRecord{
 		Schema:    wakeRestartSchemaV1,
 		RequestID: requestID,
@@ -179,38 +191,92 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 		Agent:     me,
 		Owner:     *owner,
 		Candidate: candidate,
+		StagePath: stagePath,
 	}
 	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		expected = inspectWakeLockAt(dirfd, agentDir, root, me)
 		if err := validateWakeRestartIncumbent(expected, root, me, *owner); err != nil {
 			return err
 		}
-		if existing, exists, err := readWakeRestartRecordAt(dirfd, agentDir); err != nil {
-			return err
-		} else if exists && existing.Status == wakeRestartPending {
-			if existing.Generation == expected.Lock.Generation {
-				return fmt.Errorf("wake restart is already pending for generation %s", existing.Generation)
+		existing, exists, readErr := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+		if readErr != nil {
+			if !exists || existing.Object.FileInfo == nil {
+				return readErr
 			}
-			if err := removeWakeRestartRecordAt(dirfd, "stale wake restart request"); err != nil {
+			quarantined, quarantineErr := quarantineWakeRestartRecordAt(dirfd, agentDir, existing)
+			if quarantineErr != nil {
+				return errors.Join(readErr, quarantineErr)
+			}
+			return fmt.Errorf(
+				"invalid wake restart request was preserved as %s; retry restart: %w",
+				quarantined,
+				readErr,
+			)
+		}
+		if exists && existing.Record.Status == wakeRestartPending {
+			disposition := classifyPendingWakeRestart(
+				existing.Record,
+				expected,
+				root,
+				me,
+				*owner,
+			)
+			if disposition == wakeRestartPendingPreserve {
+				return fmt.Errorf(
+					"pending wake restart for predecessor generation %s is preserved because it does not match live generation %s",
+					existing.Record.Generation,
+					expected.Lock.Generation,
+				)
+			}
+			if disposition == wakeRestartPendingClaimUnstable {
+				return fmt.Errorf(
+					"pending wake restart claim from generation %s to %s is preserved before successor publication",
+					existing.Record.Generation,
+					existing.Record.SuccessorGeneration,
+				)
+			}
+			record = existing.Record
+			requestID = record.RequestID
+			candidate = record.Candidate
+			adopted = true
+			needsNotify = disposition == wakeRestartPendingAdoptNotify
+		}
+		if exists && existing.Record.Status == wakeRestartRefused {
+			if err := reclaimWakeRestartStagePlatform(existing.Record); err != nil {
+				return fmt.Errorf("reclaim refused wake restart stage before retry: %w", err)
+			}
+			if _, err := quarantineWakeRestartRecordAt(dirfd, agentDir, existing); err != nil {
+				return fmt.Errorf("quarantine refused wake restart request before retry: %w", err)
+			}
+		}
+		if needsNotify {
+			if err := validateWakeRestartArgv(expected.Lock.Args, root, me); err != nil {
 				return err
 			}
 		}
-		if err := validateWakeRestartArgv(expected.Lock.Args, root, me); err != nil {
-			return err
-		}
-		record.Generation = expected.Lock.Generation
-		record.PreviousBoundImage = previousDarwinWakeRestartStageForLock(expected.Lock)
-		bootstrap := wakeResumeBootstrap{
-			Schema:             wakeRestartSchemaV1,
-			RequestID:          record.RequestID,
-			Generation:         record.Generation,
-			PreviousBoundImage: record.PreviousBoundImage,
-		}
-		if err := wakeRestartPreflight(candidate, expected.Lock.Args, bootstrap); err != nil {
-			return fmt.Errorf("wake restart candidate preflight failed: %w", err)
-		}
-		if err := writeWakeRestartRecordAt(dirfd, agentDir, record); err != nil {
-			return err
+		if !adopted {
+			record.Generation = expected.Lock.Generation
+			record.PreviousBoundImage = previousDarwinWakeRestartStageForLock(expected.Lock)
+			bootstrap := wakeResumeBootstrap{
+				Schema:             wakeRestartSchemaV1,
+				RequestID:          record.RequestID,
+				Generation:         record.Generation,
+				PreviousBoundImage: record.PreviousBoundImage,
+			}
+			if err := wakeRestartPreflight(candidate, expected.Lock.Args, bootstrap); err != nil {
+				return fmt.Errorf("wake restart candidate preflight failed: %w", err)
+			}
+			if err := writeWakeRestartRecordAt(dirfd, agentDir, record); err != nil {
+				return err
+			}
+			createdSnapshot, created, readErr := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+			if readErr != nil {
+				return readErr
+			}
+			if !created || !sameWakeRestartRecord(createdSnapshot.Record, record) {
+				return fmt.Errorf("wake restart request changed after creation")
+			}
+			creatorSnapshot = createdSnapshot
 		}
 		current := inspectWakeLockAt(dirfd, agentDir, root, me)
 		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
@@ -223,36 +289,23 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 		return result, err
 	}
 	result.PID = expected.PID
-	result.PreviousGeneration = expected.Lock.Generation
+	result.PreviousGeneration = record.Generation
 
-	process, err := os.FindProcess(expected.PID)
-	if err != nil {
-		_ = refuseWakeRestartRecord(agentDir, record, err.Error())
-		result.Reason = err.Error()
-		return result, err
-	}
-	// Close the publication-to-signal gap with one final exact identity read.
-	// A changed PID start, boot, or generation is a refusal, never a signal to
-	// the newly occupying process.
-	currentBeforeSignal := inspectWakeLock(root, me)
-	if !sameWakeLockInspection(expected, currentBeforeSignal) ||
-		!currentBeforeSignal.IdentityConfirmed {
-		err := fmt.Errorf("wake changed before restart signal")
-		_ = refuseWakeRestartRecord(agentDir, record, err.Error())
-		result.Reason = err.Error()
-		return result, err
-	}
-	if err := wakeRestartSignal(process); err != nil {
-		_ = refuseWakeRestartRecord(agentDir, record, err.Error())
-		result.Reason = err.Error()
-		return result, err
+	if needsNotify {
+		if err := wakeRestartNotify(agentDir, expected, record); err != nil {
+			if !adopted {
+				_ = refuseWakeRestartCreatorSnapshot(agentDir, creatorSnapshot, err.Error())
+			}
+			result.Reason = err.Error()
+			return result, err
+		}
 	}
 
 	deadline := wakeRestartNow().Add(wakeRestartWaitTimeout)
 	for wakeRestartNow().Before(deadline) {
 		current := inspectWakeLock(root, me)
 		if current.Exists && current.Status == wakeLockValid && current.IdentityConfirmed &&
-			current.PID == expected.PID && current.Lock.Generation != expected.Lock.Generation {
+			current.PID == expected.PID && current.Lock.Generation != record.Generation {
 			if current.Lock.RunningImageEvidence == nil ||
 				!sameRequestedAndBoundWakeImageEvidence(candidate, *current.Lock.RunningImageEvidence) ||
 				current.Lock.ImagePath != current.Lock.RunningImageEvidence.ExecutionPath ||
@@ -295,7 +348,7 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 			return result, err
 		}
 		if (!exists || observed.RequestID != requestID) &&
-			(!current.Exists || current.Lock.Generation == expected.Lock.Generation) {
+			(!current.Exists || current.Lock.Generation == record.Generation) {
 			err := fmt.Errorf("wake restart request disappeared before generation change")
 			result.Reason = err.Error()
 			return result, err
@@ -359,12 +412,52 @@ func sameOptionalWakeImageEvidence(first, second *wakeImageEvidenceV1) bool {
 }
 
 func sameWakeRestartRecord(first, second wakeRestartRecord) bool {
+	if !sameOptionalWakeImageEvidence(first.BoundImage, second.BoundImage) {
+		return false
+	}
 	if !sameOptionalWakeImageEvidence(first.PreviousBoundImage, second.PreviousBoundImage) {
 		return false
 	}
+	first.BoundImage = nil
+	second.BoundImage = nil
 	first.PreviousBoundImage = nil
 	second.PreviousBoundImage = nil
 	return first == second
+}
+
+type wakeRestartPendingDisposition uint8
+
+const (
+	wakeRestartPendingPreserve wakeRestartPendingDisposition = iota
+	wakeRestartPendingAdoptNotify
+	wakeRestartPendingJoinWait
+	wakeRestartPendingClaimUnstable
+)
+
+func classifyPendingWakeRestart(
+	record wakeRestartRecord,
+	incumbent wakeLockInspection,
+	root, me string,
+	owner wakeOwner,
+) wakeRestartPendingDisposition {
+	if record.Status != wakeRestartPending || record.Root != root || record.Agent != me ||
+		!sameWakeOwner(&record.Owner, &owner) {
+		return wakeRestartPendingPreserve
+	}
+	switch record.Schema {
+	case wakeRestartSchemaV1:
+		if record.Generation == incumbent.Lock.Generation {
+			return wakeRestartPendingAdoptNotify
+		}
+	case wakeRestartSchemaV2:
+		if record.SuccessorGeneration == incumbent.Lock.Generation {
+			return wakeRestartPendingJoinWait
+		}
+		if record.Generation == incumbent.Lock.Generation {
+			return wakeRestartPendingClaimUnstable
+		}
+	}
+	return wakeRestartPendingPreserve
 }
 
 func validateWakeRestartIncumbent(
@@ -382,8 +475,8 @@ func validateWakeRestartIncumbent(
 	if err := validateWakeResumeAdvertisement(inspection.Lock, root, me); err != nil {
 		return fmt.Errorf("wake does not advertise restart support: %w", err)
 	}
-	if inspection.Lock.ResumeSignal != wakeResumeSignalUSR1 {
-		return fmt.Errorf("wake does not advertise direct SIGUSR1 restart support")
+	if err := validateWakeRestartTransportPlatform(inspection.Lock, root, me); err != nil {
+		return fmt.Errorf("wake does not advertise a safe restart transport: %w", err)
 	}
 	if inspection.Lock.ResumeOwner == nil || !sameWakeOwner(inspection.Lock.ResumeOwner, &owner) {
 		return fmt.Errorf("wake restart caller is not the exact coop owner")
@@ -464,7 +557,7 @@ func sameWakeImageEvidence(first, second wakeImageEvidenceV1) bool {
 }
 
 func validateWakeRestartRecord(record wakeRestartRecord) error {
-	if record.Schema != wakeRestartSchemaV1 {
+	if record.Schema != wakeRestartSchemaV1 && record.Schema != wakeRestartSchemaV2 {
 		return fmt.Errorf("wake restart schema %d unsupported", record.Schema)
 	}
 	if !validWakeReloadTransportGeneration(record.RequestID) ||
@@ -480,6 +573,17 @@ func validateWakeRestartRecord(record wakeRestartRecord) error {
 	if record.Status == wakeRestartRefused && strings.TrimSpace(record.Reason) == "" {
 		return fmt.Errorf("refused wake restart has no reason")
 	}
+	switch record.Schema {
+	case wakeRestartSchemaV1:
+		if record.SuccessorGeneration != "" {
+			return fmt.Errorf("schema-1 wake restart contains a successor generation")
+		}
+	case wakeRestartSchemaV2:
+		if !validWakeReloadTransportGeneration(record.SuccessorGeneration) ||
+			record.SuccessorGeneration == record.Generation {
+			return fmt.Errorf("claimed wake restart successor generation is invalid")
+		}
+	}
 	if record.Root == "" || !filepath.IsAbs(record.Root) || canonicalWakeRoot(record.Root) != record.Root {
 		return fmt.Errorf("wake restart root is invalid")
 	}
@@ -492,6 +596,9 @@ func validateWakeRestartRecord(record wakeRestartRecord) error {
 	if err := validateWakeImageEvidence(record.Candidate); err != nil {
 		return fmt.Errorf("wake restart candidate is invalid: %w", err)
 	}
+	if err := validateWakeRestartStageStatePlatform(record); err != nil {
+		return fmt.Errorf("wake restart stage state is invalid: %w", err)
+	}
 	if record.PreviousBoundImage != nil {
 		if err := validateWakeImageEvidence(*record.PreviousBoundImage); err != nil {
 			return fmt.Errorf("previous bound wake image is invalid: %w", err)
@@ -503,32 +610,40 @@ func validateWakeRestartRecord(record wakeRestartRecord) error {
 	return nil
 }
 
-func wakeRestartPath(agentDir *wakeAgentDir) string {
-	return filepath.Join(agentDir.path, wakeRestartFileName)
-}
-
 func readWakeRestartRecordAt(
 	dirfd int,
 	agentDir *wakeAgentDir,
 ) (wakeRestartRecord, bool, error) {
-	raw, _, exists, err := readWakeRepairMetadataAt(
+	snapshot, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+	return snapshot.Record, exists, err
+}
+
+type wakeRestartRecordSnapshot struct {
+	Record wakeRestartRecord
+	Object wakeQuarantineSnapshot
+}
+
+func readWakeRestartRecordSnapshotAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+) (wakeRestartRecordSnapshot, bool, error) {
+	object, exists, err := readWakeQuarantineSnapshotAt(
 		dirfd,
+		agentDir,
 		wakeRestartFileName,
 		"wake restart request",
-		wakeRestartPath(agentDir),
-		maxWakeMetadataFileBytes,
 	)
+	snapshot := wakeRestartRecordSnapshot{Object: object}
 	if err != nil || !exists {
-		return wakeRestartRecord{}, exists, err
+		return snapshot, exists, err
 	}
-	var record wakeRestartRecord
-	if err := json.Unmarshal(raw, &record); err != nil {
-		return wakeRestartRecord{}, true, fmt.Errorf("parse wake restart request: %w", err)
+	if err := json.Unmarshal(object.Raw, &snapshot.Record); err != nil {
+		return snapshot, true, fmt.Errorf("parse wake restart request: %w", err)
 	}
-	if err := validateWakeRestartRecord(record); err != nil {
-		return wakeRestartRecord{}, true, err
+	if err := validateWakeRestartRecord(snapshot.Record); err != nil {
+		return snapshot, true, err
 	}
-	return record, true, nil
+	return snapshot, true, nil
 }
 
 func observeWakeRestartReadinessInDir(
@@ -620,8 +735,68 @@ func writeWakeRestartRecordAt(dirfd int, agentDir *wakeAgentDir, record wakeRest
 	)
 }
 
-func removeWakeRestartRecordAt(dirfd int, description string) error {
-	if err := unix.Unlinkat(dirfd, wakeRestartFileName, 0); err != nil && err != unix.ENOENT {
+func sameWakeRestartObjectSnapshot(first, second wakeRestartRecordSnapshot) bool {
+	return first.Object.FileInfo != nil && second.Object.FileInfo != nil &&
+		sameWakeFileIdentity(first.Object.FileInfo, second.Object.FileInfo) &&
+		bytes.Equal(first.Object.Raw, second.Object.Raw) &&
+		first.Record.RequestID == second.Record.RequestID
+}
+
+func claimWakeRestartSuccessorAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeRestartRecordSnapshot,
+	successorGeneration string,
+) (wakeRestartRecord, error) {
+	if expected.Record.Schema != wakeRestartSchemaV1 ||
+		expected.Record.Status != wakeRestartPending ||
+		!validWakeReloadTransportGeneration(successorGeneration) ||
+		successorGeneration == expected.Record.Generation {
+		return wakeRestartRecord{}, fmt.Errorf("wake restart successor claim is invalid")
+	}
+	current, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+	if err != nil {
+		return wakeRestartRecord{}, err
+	}
+	if !exists || !sameWakeRestartObjectSnapshot(expected, current) ||
+		!sameWakeRestartRecord(expected.Record, current.Record) {
+		return wakeRestartRecord{}, newWakeSnapshotReadChangedError(
+			fmt.Errorf("wake restart request changed before successor claim"),
+		)
+	}
+	claimed := current.Record
+	claimed.Schema = wakeRestartSchemaV2
+	claimed.SuccessorGeneration = successorGeneration
+	if err := writeWakeRestartRecordAt(dirfd, agentDir, claimed); err != nil {
+		return wakeRestartRecord{}, err
+	}
+	installed, installedExists, err := readWakeRestartRecordAt(dirfd, agentDir)
+	if err != nil {
+		return wakeRestartRecord{}, err
+	}
+	if !installedExists || !sameWakeRestartRecord(claimed, installed) {
+		return wakeRestartRecord{}, fmt.Errorf("wake restart successor claim was not installed")
+	}
+	return claimed, nil
+}
+
+func removeWakeRestartRecordSnapshotAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeRestartRecordSnapshot,
+	description string,
+) error {
+	current, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+	if err != nil {
+		return err
+	}
+	if !exists || !sameWakeRestartObjectSnapshot(expected, current) ||
+		!sameWakeRestartRecord(expected.Record, current.Record) {
+		return newWakeSnapshotReadChangedError(
+			fmt.Errorf("%s changed before removal", description),
+		)
+	}
+	if err := unix.Unlinkat(dirfd, wakeRestartFileName, 0); err != nil {
 		return fmt.Errorf("remove %s: %w", description, err)
 	}
 	if err := syncWakeOwnerDirFD(dirfd); err != nil {
@@ -640,12 +815,45 @@ func refuseWakeRestartRecord(agentDir *wakeAgentDir, expected wakeRestartRecord,
 		if err != nil || !exists {
 			return err
 		}
-		if current.RequestID != expected.RequestID || current.Generation != expected.Generation {
+		if expected.Schema != wakeRestartSchemaV1 || expected.Status != wakeRestartPending ||
+			current.Schema != wakeRestartSchemaV1 || current.Status != wakeRestartPending ||
+			current.RequestID != expected.RequestID || current.Generation != expected.Generation {
 			return fmt.Errorf("wake restart request changed before refusal")
 		}
 		current.Status = wakeRestartRefused
 		current.Reason = wakeRestartReasonWithRemedy(reason, current.Root, current.Agent)
 		return writeWakeRestartRecordAt(dirfd, agentDir, current)
+	})
+}
+
+func refuseWakeRestartCreatorSnapshot(
+	agentDir *wakeAgentDir,
+	expected wakeRestartRecordSnapshot,
+	reason string,
+) error {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "restart refused"
+	}
+	if expected.Record.Schema != wakeRestartSchemaV1 ||
+		expected.Record.Status != wakeRestartPending {
+		return fmt.Errorf("created wake restart snapshot is not pending schema 1")
+	}
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+		if err != nil || !exists {
+			return err
+		}
+		if current.Record.Schema != wakeRestartSchemaV1 ||
+			current.Record.Status != wakeRestartPending ||
+			!sameWakeRestartObjectSnapshot(expected, current) ||
+			!sameWakeRestartRecord(expected.Record, current.Record) {
+			return fmt.Errorf("created wake restart request changed before refusal")
+		}
+		refused := current.Record
+		refused.Status = wakeRestartRefused
+		refused.Reason = wakeRestartReasonWithRemedy(reason, refused.Root, refused.Agent)
+		return writeWakeRestartRecordAt(dirfd, agentDir, refused)
 	})
 }
 
@@ -724,10 +932,11 @@ func acquireWakeLockAfterResumeInDir(
 		if err := validateWakeResumeAdvertisement(current.Lock, root, me); err != nil {
 			return err
 		}
-		record, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		recordSnapshot, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
 		if err != nil {
 			return err
 		}
+		record := recordSnapshot.Record
 		if !exists || record.Status != wakeRestartPending || record.RequestID != bootstrap.RequestID ||
 			record.Generation != bootstrap.Generation || current.Lock.ResumeOwner == nil ||
 			!sameWakeOwner(current.Lock.ResumeOwner, &record.Owner) {
@@ -748,6 +957,9 @@ func acquireWakeLockAfterResumeInDir(
 			!sameRequestedAndBoundWakeImageEvidence(record.Candidate, *bootstrap.BoundImage) {
 			return fmt.Errorf("wake resume bound image does not match the requested candidate")
 		}
+		if err := validateWakeRestartPersistedBoundPlatform(record, *bootstrap.BoundImage); err != nil {
+			return err
+		}
 		lock, err := newWakeLock(root, me, options)
 		if err != nil {
 			return err
@@ -756,6 +968,15 @@ func acquireWakeLockAfterResumeInDir(
 			compareWakeBootID(current.Lock.BootID, lockProcessInfo(lock)) != bootIDMatch {
 			return fmt.Errorf("wake resume did not preserve process identity")
 		}
+		claimed, err := claimWakeRestartSuccessorAt(
+			dirfd,
+			agentDir,
+			recordSnapshot,
+			lock.Generation,
+		)
+		if err != nil {
+			return err
+		}
 		if err := replaceWakeLockForResumeAt(dirfd, agentDir, current, lock); err != nil {
 			return err
 		}
@@ -763,6 +984,10 @@ func acquireWakeLockAfterResumeInDir(
 		if !created.Exists || created.Status != wakeLockValid || !created.IdentityConfirmed ||
 			created.Lock.Generation != lock.Generation {
 			return fmt.Errorf("wake resume generation was not installed")
+		}
+		installed, installedExists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil || !installedExists || !sameWakeRestartRecord(claimed, installed) {
+			return fmt.Errorf("wake resume successor claim changed during generation commit")
 		}
 		return nil
 	})
@@ -803,15 +1028,23 @@ func consumeWakeRestartAfterPrepared(
 		if !prepared {
 			return fmt.Errorf("wake resume prepared proof is not current")
 		}
-		record, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		recordSnapshot, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
 		if err != nil {
 			return err
 		}
+		record := recordSnapshot.Record
 		if !exists || record.Status != wakeRestartPending ||
-			record.RequestID != bootstrap.RequestID || record.Generation != bootstrap.Generation {
+			record.Schema != wakeRestartSchemaV2 ||
+			record.RequestID != bootstrap.RequestID || record.Generation != bootstrap.Generation ||
+			record.SuccessorGeneration != observed.Lock.Generation {
 			return fmt.Errorf("wake resume request changed before readiness commit")
 		}
-		return removeWakeRestartRecordAt(dirfd, "ready wake restart request")
+		return removeWakeRestartRecordSnapshotAt(
+			dirfd,
+			agentDir,
+			recordSnapshot,
+			"ready wake restart request",
+		)
 	})
 }
 
@@ -861,6 +1094,46 @@ func replaceWakeLockForResumeAt(
 	return nil
 }
 
+func persistWakeRestartBoundImage(
+	record wakeRestartRecord,
+	bound wakeImageEvidenceV1,
+) (wakeRestartRecord, error) {
+	if record.StagePath == "" {
+		return record, nil
+	}
+	agentDir, err := openWakeAgentDir(record.Root, record.Agent)
+	if err != nil {
+		return wakeRestartRecord{}, err
+	}
+	defer func() { _ = agentDir.Close() }()
+	var persisted wakeRestartRecord
+	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !exists || !sameWakeRestartRecord(current.Record, record) {
+			return newWakeSnapshotReadChangedError(
+				fmt.Errorf("wake restart request changed before bound-stage publication"),
+			)
+		}
+		persisted = current.Record
+		persisted.BoundImage = &bound
+		if err := writeWakeRestartRecordAt(dirfd, agentDir, persisted); err != nil {
+			return err
+		}
+		installed, installedExists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil {
+			return err
+		}
+		if !installedExists || !sameWakeRestartRecord(persisted, installed) {
+			return fmt.Errorf("wake restart bound stage was not persisted")
+		}
+		return nil
+	})
+	return persisted, err
+}
+
 func executeWakeRestart(record wakeRestartRecord, argv []string, restartSignals chan os.Signal) (returnErr error) {
 	bootstrapValue := wakeResumeBootstrap{
 		Schema:             wakeRestartSchemaV1,
@@ -868,12 +1141,16 @@ func executeWakeRestart(record wakeRestartRecord, argv []string, restartSignals 
 		Generation:         record.Generation,
 		PreviousBoundImage: record.PreviousBoundImage,
 	}
-	bound, err := wakeRestartBind(record.Candidate)
+	bound, err := wakeRestartBind(record)
 	if err != nil {
 		return fmt.Errorf("bind wake restart candidate: %w", err)
 	}
 	defer func() { returnErr = errors.Join(returnErr, bound.close()) }()
 	boundEvidence := bound.evidence
+	record, err = persistWakeRestartBoundImage(record, boundEvidence)
+	if err != nil {
+		return fmt.Errorf("persist wake restart bound stage: %w", err)
+	}
 	bootstrapValue.BoundImage = &boundEvidence
 	if err := wakeRestartBoundPreflight(bound, argv, bootstrapValue); err != nil {
 		return err

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -79,6 +79,8 @@ type wakeRestartReadiness struct {
 }
 
 var (
+	errWakeRestartSchemaTooNew = errors.New("wake restart schema is newer than supported")
+
 	wakeRestartNow            = time.Now
 	wakeRestartSleep          = time.Sleep
 	wakeRestartNotify         = notifyWakeRestartPlatform
@@ -202,6 +204,13 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 		if readErr != nil {
 			if !exists || existing.Object.FileInfo == nil {
 				return readErr
+			}
+			if errors.Is(readErr, errWakeRestartSchemaTooNew) {
+				return fmt.Errorf(
+					"future-schema wake restart request is preserved at %s; retry with a newer AMQ: %w",
+					wakeRestartFileName,
+					readErr,
+				)
 			}
 			quarantined, quarantineErr := quarantineWakeRestartRecordAt(dirfd, agentDir, existing)
 			if quarantineErr != nil {
@@ -557,6 +566,9 @@ func sameWakeImageEvidence(first, second wakeImageEvidenceV1) bool {
 }
 
 func validateWakeRestartRecord(record wakeRestartRecord) error {
+	if record.Schema > wakeRestartSchemaV2 {
+		return fmt.Errorf("%w: wake restart schema %d unsupported", errWakeRestartSchemaTooNew, record.Schema)
+	}
 	if record.Schema != wakeRestartSchemaV1 && record.Schema != wakeRestartSchemaV2 {
 		return fmt.Errorf("wake restart schema %d unsupported", record.Schema)
 	}
@@ -636,6 +648,19 @@ func readWakeRestartRecordSnapshotAt(
 	snapshot := wakeRestartRecordSnapshot{Object: object}
 	if err != nil || !exists {
 		return snapshot, exists, err
+	}
+	var envelope struct {
+		Schema int `json:"schema"`
+	}
+	if err := json.Unmarshal(object.Raw, &envelope); err != nil {
+		return snapshot, true, fmt.Errorf("parse wake restart request: %w", err)
+	}
+	if envelope.Schema > wakeRestartSchemaV2 {
+		return snapshot, true, fmt.Errorf(
+			"%w: wake restart schema %d unsupported",
+			errWakeRestartSchemaTooNew,
+			envelope.Schema,
+		)
 	}
 	if err := json.Unmarshal(object.Raw, &snapshot.Record); err != nil {
 		return snapshot, true, fmt.Errorf("parse wake restart request: %w", err)

--- a/internal/cli/wake_restart_unix_test.go
+++ b/internal/cli/wake_restart_unix_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1310,77 +1311,136 @@ func TestWakeRestartPreservesPendingForeignGeneration(t *testing.T) {
 }
 
 func TestWakeRestartQuarantinesExactInvalidRecordAndStops(t *testing.T) {
-	for _, test := range []struct {
-		name   string
-		future bool
-		second int
-	}{
-		{name: "malformed", second: 0},
-		{name: "future schema", future: true, second: 1},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			fixture := newWakeRestartFixture(t)
-			raw := []byte(`{"schema":`)
-			if test.future {
-				future := fixture.record
-				future.Schema = wakeRestartSchemaV2 + 1
-				encoded, err := json.Marshal(future)
-				if err != nil {
-					t.Fatal(err)
-				}
-				raw = append(encoded, '\n')
-			}
-			removeWakeRestartRecordForTest(t, fixture)
-			path := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
-			if err := os.WriteFile(path, raw, 0o600); err != nil {
-				t.Fatal(err)
-			}
-			before, err := os.Lstat(path)
-			if err != nil {
-				t.Fatal(err)
-			}
+	fixture := newWakeRestartFixture(t)
+	raw := []byte(`{"schema":`)
+	removeWakeRestartRecordForTest(t, fixture)
+	path := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-			oldNow := wakeQuarantineNow
-			oldPreflight := wakeRestartPreflight
-			oldNotify := wakeRestartNotify
-			wakeQuarantineNow = func() time.Time {
-				return time.Date(2026, 8, 7, 12, 0, test.second, 0, time.UTC)
-			}
-			preflightCalled := false
-			notifyCalled := false
-			wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
-				preflightCalled = true
-				return nil
-			}
-			wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
-				notifyCalled = true
-				return nil
-			}
-			t.Cleanup(func() {
-				wakeQuarantineNow = oldNow
-				wakeRestartPreflight = oldPreflight
-				wakeRestartNotify = oldNotify
-			})
+	oldNow := wakeQuarantineNow
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	wakeQuarantineNow = func() time.Time {
+		return time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	}
+	preflightCalled := false
+	notifyCalled := false
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalled = true
+		return nil
+	}
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		notifyCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		wakeQuarantineNow = oldNow
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+	})
 
-			result, restartErr := requestWakeRestart(fixture.root, fixture.agent)
-			if restartErr == nil || !strings.Contains(restartErr.Error(), "was preserved as .wake.restart.quarantined.") ||
-				!strings.Contains(result.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) {
-				t.Fatalf("invalid restart result=%#v err=%v", result, restartErr)
-			}
-			if preflightCalled || notifyCalled {
-				t.Fatalf("invalid restart reached preflight=%v notify=%v", preflightCalled, notifyCalled)
-			}
-			if _, statErr := os.Lstat(path); !os.IsNotExist(statErr) {
-				t.Fatalf("invalid restart source remains: %v", statErr)
-			}
-			assertExactWakeQuarantineForTest(
-				t,
-				fixture.agentDir.path,
-				wakeRestartFileName+".quarantined.",
-				raw,
-				before,
-			)
-		})
+	result, restartErr := requestWakeRestart(fixture.root, fixture.agent)
+	if restartErr == nil || !strings.Contains(restartErr.Error(), "was preserved as .wake.restart.quarantined.") ||
+		!strings.Contains(result.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) {
+		t.Fatalf("invalid restart result=%#v err=%v", result, restartErr)
+	}
+	if preflightCalled || notifyCalled {
+		t.Fatalf("invalid restart reached preflight=%v notify=%v", preflightCalled, notifyCalled)
+	}
+	if _, statErr := os.Lstat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid restart source remains: %v", statErr)
+	}
+	assertExactWakeQuarantineForTest(
+		t,
+		fixture.agentDir.path,
+		wakeRestartFileName+".quarantined.",
+		raw,
+		before,
+	)
+}
+
+func TestWakeRestartPreservesExactFutureSchemaRecordAndStops(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	future := fixture.record
+	future.Schema = wakeRestartSchemaV2 + 1
+	encoded, err := json.Marshal(future)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		t.Fatal(err)
+	}
+	document["request_id"] = map[string]any{"value": future.RequestID}
+	document["future_extension"] = map[string]any{"mode": "new"}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = append(raw, '\n')
+	removeWakeRestartRecordForTest(t, fixture)
+	path := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	preflightCalled := false
+	notifyCalled := false
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalled = true
+		return nil
+	}
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		notifyCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+	})
+
+	result, restartErr := requestWakeRestart(fixture.root, fixture.agent)
+	if restartErr == nil || !errors.Is(restartErr, errWakeRestartSchemaTooNew) ||
+		!strings.Contains(restartErr.Error(), "future-schema wake restart request is preserved") ||
+		!strings.Contains(restartErr.Error(), "newer AMQ") ||
+		!strings.Contains(result.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) {
+		t.Fatalf("future restart result=%#v err=%v", result, restartErr)
+	}
+	if preflightCalled || notifyCalled {
+		t.Fatalf("future restart reached preflight=%v notify=%v", preflightCalled, notifyCalled)
+	}
+	after, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("future restart record identity changed")
+	}
+	afterRaw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, afterRaw) {
+		t.Fatal("future restart record content changed")
+	}
+	quarantined, err := filepath.Glob(path + ".quarantined.*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(quarantined) != 0 {
+		t.Fatalf("future restart record was quarantined: %v", quarantined)
 	}
 }
 

--- a/internal/cli/wake_restart_unix_test.go
+++ b/internal/cli/wake_restart_unix_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -10,6 +11,8 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -82,9 +85,9 @@ func newWakeRestartFixture(t *testing.T) wakeRestartFixture {
 		Generation:           "0123456789abcdef0123456789abcdef",
 		ResumeSchema:         wakeResumeSchemaV2,
 		ResumeOwner:          &owner,
-		ResumeSignal:         wakeResumeSignalUSR1,
 		RunningImageEvidence: &candidate,
 	}
+	configureWakeRestartAdvertisementPlatform(&lock, root, agent)
 	writeWakeLockForTest(t, root, agent, lock)
 	inspection := inspectWakeLock(root, agent)
 	if !inspection.IdentityConfirmed || inspection.Status != wakeLockValid {
@@ -148,6 +151,30 @@ func boundWakeImageEvidenceForTest(candidate wakeImageEvidenceV1) wakeImageEvide
 	return bound
 }
 
+func prepareWakeRestartRecordForBoundResumeTest(
+	t *testing.T,
+	fixture *wakeRestartFixture,
+	bound *wakeImageEvidenceV1,
+) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	stagePath, err := planWakeRestartStagePlatform(fixture.candidate, fixture.record.RequestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound.ExecutionPath = stagePath
+	fixture.record.StagePath = stagePath
+	boundCopy := *bound
+	fixture.record.BoundImage = &boundCopy
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, fixture.record)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRequestedAndBoundWakeImageEvidenceHasOnlyDarwinHardlinkCTimeException(t *testing.T) {
 	candidate, err := captureCurrentWakeImageEvidence()
 	if err != nil {
@@ -186,6 +213,7 @@ func TestRequestedAndBoundWakeImageEvidenceHasOnlyDarwinHardlinkCTimeException(t
 func TestAcquireWakeLockAfterResumeKeepsRequestUntilNewPreparedProof(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	bound := boundWakeImageEvidenceForTest(fixture.candidate)
+	prepareWakeRestartRecordForBoundResumeTest(t, &fixture, &bound)
 	if err := writeWakePreparedFileInDir(
 		fixture.agentDir,
 		fixture.root,
@@ -238,15 +266,21 @@ func TestAcquireWakeLockAfterResumeKeepsRequestUntilNewPreparedProof(t *testing.
 	if prepared {
 		t.Fatal("old generation prepared marker remained current after resume")
 	}
+	var restart wakeRestartRecord
 	var restartExists bool
 	if err := fixture.agentDir.withFD(func(dirfd int) error {
-		_, restartExists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		restart, restartExists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
 		return err
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if !restartExists {
 		t.Fatal("restart request was consumed before successor readiness")
+	}
+	if restart.Schema != wakeRestartSchemaV2 ||
+		restart.Generation != fixture.record.Generation ||
+		restart.SuccessorGeneration != current.Lock.Generation {
+		t.Fatalf("restart successor claim = %#v", restart)
 	}
 	if err := writeWakePreparedFileInDir(
 		fixture.agentDir,
@@ -278,6 +312,551 @@ func TestAcquireWakeLockAfterResumeKeepsRequestUntilNewPreparedProof(t *testing.
 	if restartExists {
 		t.Fatal("ready successor did not consume restart request")
 	}
+}
+
+func TestWakeRestartJoinsClaimedSuccessorWithoutRenotifying(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	bound := boundWakeImageEvidenceForTest(fixture.candidate)
+	prepareWakeRestartRecordForBoundResumeTest(t, &fixture, &bound)
+	cleanup, err := acquireWakeLockAfterResumeInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		wakeLockAcquireOptions{
+			wakeMode:            wakeInjectModeNone,
+			requestedOwner:      &fixture.owner,
+			resumeEligible:      true,
+			resumeImageEvidence: &bound,
+		},
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  fixture.record.RequestID,
+			Generation: fixture.record.Generation,
+			BoundImage: &bound,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	current := inspectWakeLock(fixture.root, fixture.agent)
+
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	oldSleep := wakeRestartSleep
+	preflightCalled := false
+	notifyCalled := false
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalled = true
+		return nil
+	}
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		notifyCalled = true
+		return nil
+	}
+	sleepCalls := 0
+	wakeRestartSleep = func(time.Duration) {
+		sleepCalls++
+		if sleepCalls != 1 {
+			return
+		}
+		if err := writeWakePreparedFileInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			current,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if err := consumeWakeRestartAfterPrepared(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			current,
+			wakeResumeBootstrap{
+				Schema:     wakeRestartSchemaV1,
+				RequestID:  fixture.record.RequestID,
+				Generation: fixture.record.Generation,
+			},
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+		wakeRestartSleep = oldSleep
+	})
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err != nil {
+		t.Fatalf("join claimed successor: result=%#v err=%v", result, err)
+	}
+	if result.Status != "restarted" || result.PreviousGeneration != fixture.record.Generation ||
+		result.Generation != current.Lock.Generation {
+		t.Fatalf("join claimed successor result=%#v", result)
+	}
+	if preflightCalled || notifyCalled || sleepCalls == 0 {
+		t.Fatalf("join claimed successor preflight=%v notify=%v sleeps=%d", preflightCalled, notifyCalled, sleepCalls)
+	}
+}
+
+func TestConcurrentWakeRestartCallersJoinSuccessorThroughReadinessCommit(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	bound := boundWakeImageEvidenceForTest(fixture.candidate)
+	prepareWakeRestartRecordForBoundResumeTest(t, &fixture, &bound)
+
+	type restartOutcome struct {
+		result wakeRestartResult
+		err    error
+	}
+	type successorState struct {
+		inspection wakeLockInspection
+		record     wakeRestartRecord
+		cleanup    func()
+	}
+
+	successorClaimed := make(chan successorState, 1)
+	allowReadiness := make(chan struct{})
+	readinessCommitted := make(chan struct{})
+	caller2Waiting := make(chan struct{})
+	var caller2WaitingOnce sync.Once
+	var readinessCommittedOnce sync.Once
+	var notifyCalls atomic.Int32
+	var preflightCalls atomic.Int32
+
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	oldSleep := wakeRestartSleep
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalls.Add(1)
+		return errors.New("concurrent restart unexpectedly replaced the canonical request")
+	}
+	wakeRestartNotify = func(
+		_ *wakeAgentDir,
+		expected wakeLockInspection,
+		record wakeRestartRecord,
+	) (returnErr error) {
+		if notifyCalls.Add(1) != 1 {
+			return errors.New("concurrent restart unexpectedly renotified the successor")
+		}
+		if !sameWakeLockInspection(expected, fixture.lock) ||
+			!sameWakeRestartRecord(record, fixture.record) {
+			return fmt.Errorf("first restart did not adopt the canonical request")
+		}
+		cleanup, err := acquireWakeLockAfterResumeInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			wakeLockAcquireOptions{
+				wakeMode:            wakeInjectModeNone,
+				requestedOwner:      &fixture.owner,
+				resumeEligible:      true,
+				resumeImageEvidence: &bound,
+			},
+			wakeResumeBootstrap{
+				Schema:     wakeRestartSchemaV1,
+				RequestID:  fixture.record.RequestID,
+				Generation: fixture.record.Generation,
+				BoundImage: &bound,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		keepSuccessor := false
+		defer func() {
+			if !keepSuccessor {
+				cleanup()
+			}
+		}()
+
+		current := inspectWakeLock(fixture.root, fixture.agent)
+		var claimed wakeRestartRecord
+		var exists bool
+		if err := fixture.agentDir.withFD(func(dirfd int) error {
+			var readErr error
+			claimed, exists, readErr = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+			return readErr
+		}); err != nil {
+			return err
+		}
+		if !exists {
+			return errors.New("successor claim disappeared after lock rotation")
+		}
+		keepSuccessor = true
+		successorClaimed <- successorState{
+			inspection: current,
+			record:     claimed,
+			cleanup:    cleanup,
+		}
+
+		<-allowReadiness
+		defer readinessCommittedOnce.Do(func() { close(readinessCommitted) })
+		if err := writeWakePreparedFileInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			current,
+		); err != nil {
+			return err
+		}
+		return consumeWakeRestartAfterPrepared(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			current,
+			wakeResumeBootstrap{
+				Schema:     wakeRestartSchemaV1,
+				RequestID:  fixture.record.RequestID,
+				Generation: fixture.record.Generation,
+			},
+		)
+	}
+	wakeRestartSleep = func(time.Duration) {
+		caller2WaitingOnce.Do(func() { close(caller2Waiting) })
+		<-readinessCommitted
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+		wakeRestartSleep = oldSleep
+	})
+
+	caller1Done := make(chan restartOutcome, 1)
+	go func() {
+		result, err := requestWakeRestart(fixture.root, fixture.agent)
+		caller1Done <- restartOutcome{result: result, err: err}
+	}()
+
+	var successor successorState
+	select {
+	case successor = <-successorClaimed:
+		defer successor.cleanup()
+	case outcome := <-caller1Done:
+		t.Fatalf("caller 1 exited before successor claim: result=%#v err=%v", outcome.result, outcome.err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("caller 1 did not claim and rotate to the successor within 5s")
+	}
+	if successor.inspection.Lock.Generation == fixture.record.Generation ||
+		successor.record.Schema != wakeRestartSchemaV2 ||
+		successor.record.RequestID != fixture.record.RequestID ||
+		successor.record.Generation != fixture.record.Generation ||
+		successor.record.SuccessorGeneration != successor.inspection.Lock.Generation {
+		t.Fatalf(
+			"successor state after claim/rotation: lock=%#v record=%#v",
+			successor.inspection,
+			successor.record,
+		)
+	}
+
+	caller2Done := make(chan restartOutcome, 1)
+	go func() {
+		result, err := requestWakeRestart(fixture.root, fixture.agent)
+		caller2Done <- restartOutcome{result: result, err: err}
+	}()
+	select {
+	case <-caller2Waiting:
+	case outcome := <-caller2Done:
+		t.Fatalf("caller 2 exited instead of joining successor: result=%#v err=%v", outcome.result, outcome.err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("caller 2 did not join the claimed successor within 5s")
+	}
+
+	current := inspectWakeLock(fixture.root, fixture.agent)
+	var canonical wakeRestartRecord
+	var canonicalExists bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		canonical, canonicalExists, readErr = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return readErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !sameWakeLockInspection(successor.inspection, current) || !canonicalExists ||
+		!sameWakeRestartRecord(successor.record, canonical) {
+		t.Fatalf(
+			"caller 2 changed canonical successor state: lock=%#v exists=%v record=%#v",
+			current,
+			canonicalExists,
+			canonical,
+		)
+	}
+
+	close(allowReadiness)
+	await := func(label string, done <-chan restartOutcome) restartOutcome {
+		t.Helper()
+		select {
+		case outcome := <-done:
+			return outcome
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s did not finish within 5s", label)
+			return restartOutcome{}
+		}
+	}
+	caller1 := await("caller 1", caller1Done)
+	caller2 := await("caller 2", caller2Done)
+	for label, outcome := range map[string]restartOutcome{
+		"caller 1": caller1,
+		"caller 2": caller2,
+	} {
+		if outcome.err != nil || outcome.result.Status != "restarted" ||
+			outcome.result.PreviousGeneration != fixture.record.Generation ||
+			outcome.result.Generation != successor.inspection.Lock.Generation {
+			t.Fatalf("%s outcome: result=%#v err=%v", label, outcome.result, outcome.err)
+		}
+	}
+	if notifyCalls.Load() != 1 || preflightCalls.Load() != 0 {
+		t.Fatalf(
+			"concurrent callers notify=%d preflight=%d, want 1 and 0",
+			notifyCalls.Load(),
+			preflightCalls.Load(),
+		)
+	}
+	current = inspectWakeLock(fixture.root, fixture.agent)
+	if !sameWakeLockInspection(successor.inspection, current) {
+		t.Fatalf("readiness commit changed successor lock: %#v", current)
+	}
+	prepared, err := validateWakePreparedFileAgainstInspection(
+		fixture.root,
+		fixture.agent,
+		current,
+	)
+	if err != nil || !prepared {
+		t.Fatalf("successor readiness after concurrent callers: prepared=%v err=%v", prepared, err)
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		_, canonicalExists, err = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if canonicalExists {
+		t.Fatal("canonical restart request survived successor readiness commit")
+	}
+}
+
+func TestWakeRestartAckFailurePreservesClaimedSuccessor(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+
+	ackErr := errors.New("injected restart acknowledgement failure")
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		return nil
+	}
+	var successor wakeLockInspection
+	var successorCleanup func()
+	wakeRestartNotify = func(
+		_ *wakeAgentDir,
+		_ wakeLockInspection,
+		record wakeRestartRecord,
+	) error {
+		bound := boundWakeImageEvidenceForTest(record.Candidate)
+		if runtime.GOOS == "darwin" {
+			bound.ExecutionPath = record.StagePath
+			var err error
+			record, err = persistWakeRestartBoundImage(record, bound)
+			if err != nil {
+				return err
+			}
+		}
+		cleanup, err := acquireWakeLockAfterResumeInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			wakeLockAcquireOptions{
+				wakeMode:            wakeInjectModeNone,
+				requestedOwner:      &fixture.owner,
+				resumeEligible:      true,
+				resumeImageEvidence: &bound,
+			},
+			wakeResumeBootstrap{
+				Schema:             wakeRestartSchemaV1,
+				RequestID:          record.RequestID,
+				Generation:         record.Generation,
+				BoundImage:         &bound,
+				PreviousBoundImage: record.PreviousBoundImage,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		successorCleanup = cleanup
+		successor = inspectWakeLock(fixture.root, fixture.agent)
+		return ackErr
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+		if successorCleanup != nil {
+			successorCleanup()
+		}
+	})
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if !errors.Is(err, ackErr) || !strings.Contains(result.Reason, ackErr.Error()) {
+		t.Fatalf("restart result = %#v err=%v, want acknowledgement failure", result, err)
+	}
+	var claimed wakeRestartRecord
+	var exists bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		claimed, exists, readErr = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return readErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !exists || claimed.Schema != wakeRestartSchemaV2 ||
+		claimed.Status != wakeRestartPending ||
+		claimed.SuccessorGeneration != successor.Lock.Generation {
+		t.Fatalf("claimed successor was changed by late refusal: exists=%v record=%#v", exists, claimed)
+	}
+	if err := writeWakePreparedFileInDir(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		successor,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := consumeWakeRestartAfterPrepared(
+		fixture.agentDir,
+		fixture.root,
+		fixture.agent,
+		successor,
+		wakeResumeBootstrap{
+			Schema:     wakeRestartSchemaV1,
+			RequestID:  claimed.RequestID,
+			Generation: claimed.Generation,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenericCleanupReconcilesPendingRestartOwnership(t *testing.T) {
+	t.Run("schema 1 stop wins before successor claim", func(t *testing.T) {
+		fixture := newWakeRestartFixture(t)
+		if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+			return cleanupGenericWakeGenerationAt(
+				dirfd,
+				fixture.agentDir,
+				fixture.root,
+				fixture.agent,
+				fixture.lock,
+				wakeLockAcquireOptions{wakeMode: wakeInjectModeNone},
+			)
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if current := inspectWakeLock(fixture.root, fixture.agent); current.Exists {
+			t.Fatalf("schema-1 cleanup left wake lock: %#v", current)
+		}
+		restartPath := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+		if _, err := os.Lstat(restartPath); !os.IsNotExist(err) {
+			t.Fatalf("schema-1 cleanup left canonical restart record: %v", err)
+		}
+		quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+		if err != nil || len(quarantined) != 1 {
+			t.Fatalf("schema-1 cleanup quarantine = %v, err=%v", quarantined, err)
+		}
+	})
+
+	t.Run("future restart record is quarantined before lock removal", func(t *testing.T) {
+		fixture := newWakeRestartFixture(t)
+		restartPath := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+		if err := os.WriteFile(
+			restartPath,
+			[]byte("{\"schema\":99,\"request_id\":\"future\"}\n"),
+			0o600,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+			return cleanupGenericWakeGenerationAt(
+				dirfd,
+				fixture.agentDir,
+				fixture.root,
+				fixture.agent,
+				fixture.lock,
+				wakeLockAcquireOptions{wakeMode: wakeInjectModeNone},
+			)
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if current := inspectWakeLock(fixture.root, fixture.agent); current.Exists {
+			t.Fatalf("future-record cleanup left wake lock: %#v", current)
+		}
+		if _, err := os.Lstat(restartPath); !os.IsNotExist(err) {
+			t.Fatalf("future restart record survived canonical cleanup: %v", err)
+		}
+		quarantined, err := filepath.Glob(restartPath + ".quarantined.*")
+		if err != nil || len(quarantined) != 1 {
+			t.Fatalf("future restart quarantine = %v, err=%v", quarantined, err)
+		}
+	})
+
+	t.Run("schema 2 live handoff is preserved", func(t *testing.T) {
+		fixture := newWakeRestartFixture(t)
+		bound := boundWakeImageEvidenceForTest(fixture.candidate)
+		prepareWakeRestartRecordForBoundResumeTest(t, &fixture, &bound)
+		cleanup, err := acquireWakeLockAfterResumeInDir(
+			fixture.agentDir,
+			fixture.root,
+			fixture.agent,
+			wakeLockAcquireOptions{
+				wakeMode:            wakeInjectModeNone,
+				requestedOwner:      &fixture.owner,
+				resumeEligible:      true,
+				resumeImageEvidence: &bound,
+			},
+			wakeResumeBootstrap{
+				Schema:     wakeRestartSchemaV1,
+				RequestID:  fixture.record.RequestID,
+				Generation: fixture.record.Generation,
+				BoundImage: &bound,
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		current := inspectWakeLock(fixture.root, fixture.agent)
+		err = withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+			return cleanupGenericWakeGenerationAt(
+				dirfd,
+				fixture.agentDir,
+				fixture.root,
+				fixture.agent,
+				current,
+				wakeLockAcquireOptions{
+					wakeMode:       wakeInjectModeNone,
+					requestedOwner: &fixture.owner,
+				},
+			)
+		})
+		if err == nil || !strings.Contains(err.Error(), "live wake restart successor handoff") {
+			t.Fatalf("schema-2 cleanup error = %v, want handoff preservation", err)
+		}
+		if observed := inspectWakeLock(fixture.root, fixture.agent); !sameWakeLockGeneration(current, observed) {
+			t.Fatalf("schema-2 cleanup changed successor lock: %#v", observed)
+		}
+		if err := fixture.agentDir.withFD(func(dirfd int) error {
+			record, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
+			if readErr != nil {
+				return readErr
+			}
+			if !exists || record.Schema != wakeRestartSchemaV2 ||
+				record.SuccessorGeneration != current.Lock.Generation {
+				return fmt.Errorf("live successor record changed: exists=%v record=%#v", exists, record)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestWakeRestartLoopRefusesInputDebtWithoutExec(t *testing.T) {
@@ -443,23 +1022,23 @@ func TestWakeRestartIncompatibleCandidatePreflightLeavesIncumbentLive(t *testing
 	}
 
 	oldCapture := captureCurrentWakeImageEvidence
-	oldSignal := wakeRestartSignal
+	oldNotify := wakeRestartNotify
 	captureCurrentWakeImageEvidence = func() (wakeImageEvidenceV1, error) { return candidate, nil }
-	signalCalled := false
-	wakeRestartSignal = func(*os.Process) error {
-		signalCalled = true
+	notifyCalled := false
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		notifyCalled = true
 		return nil
 	}
 	t.Cleanup(func() {
 		captureCurrentWakeImageEvidence = oldCapture
-		wakeRestartSignal = oldSignal
+		wakeRestartNotify = oldNotify
 	})
 
 	result, restartErr := requestWakeRestart(fixture.root, fixture.agent)
 	if restartErr == nil || !strings.Contains(restartErr.Error(), "candidate preflight failed") {
 		t.Fatalf("incompatible restart result=%#v err=%v", result, restartErr)
 	}
-	if signalCalled {
+	if notifyCalled {
 		t.Fatal("incompatible candidate reached the incumbent signal boundary")
 	}
 	current := inspectWakeLock(fixture.root, fixture.agent)
@@ -477,7 +1056,7 @@ func TestWakeRestartIncompatibleCandidatePreflightLeavesIncumbentLive(t *testing
 	}
 }
 
-func TestWakeRestartRejectsControlOnlyIncumbentBeforePublication(t *testing.T) {
+func TestWakeRestartRequiresCurrentPlatformTransportBeforePublication(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)
 	legacy := fixture.lock.Lock
@@ -489,31 +1068,35 @@ func TestWakeRestartRejectsControlOnlyIncumbentBeforePublication(t *testing.T) {
 	writeWakeLockForTest(t, fixture.root, fixture.agent, legacy)
 
 	preflightCalled := false
-	signalCalled := false
+	notifyCalled := false
 	oldPreflight := wakeRestartPreflight
-	oldSignal := wakeRestartSignal
+	oldNotify := wakeRestartNotify
 	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
 		preflightCalled = true
 		return nil
 	}
-	wakeRestartSignal = func(*os.Process) error {
-		signalCalled = true
-		return nil
+	notifyErr := errors.New("stop after safe platform notification")
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		notifyCalled = true
+		return notifyErr
 	}
 	t.Cleanup(func() {
 		wakeRestartPreflight = oldPreflight
-		wakeRestartSignal = oldSignal
+		wakeRestartNotify = oldNotify
 	})
 
 	result, err := requestWakeRestart(fixture.root, fixture.agent)
-	if err == nil || !strings.Contains(err.Error(), "direct SIGUSR1 restart support") {
-		t.Fatalf("control-only restart result=%#v err=%v", result, err)
-	}
-	if preflightCalled || signalCalled {
-		t.Fatalf("control-only incumbent reached preflight=%v signal=%v", preflightCalled, signalCalled)
-	}
-	if _, statErr := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(statErr) {
-		t.Fatalf("control-only incumbent published restart record: %v", statErr)
+	if runtime.GOOS == "darwin" {
+		if !errors.Is(err, notifyErr) || !preflightCalled || !notifyCalled {
+			t.Fatalf("Darwin control restart result=%#v err=%v preflight=%v notify=%v", result, err, preflightCalled, notifyCalled)
+		}
+	} else {
+		if err == nil || !strings.Contains(err.Error(), "safe restart transport") || preflightCalled || notifyCalled {
+			t.Fatalf("Linux control restart result=%#v err=%v preflight=%v notify=%v", result, err, preflightCalled, notifyCalled)
+		}
+		if _, statErr := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(statErr) {
+			t.Fatalf("unsupported transport published restart record: %v", statErr)
+		}
 	}
 	current := inspectWakeLock(fixture.root, fixture.agent)
 	if !current.IdentityConfirmed || current.Lock.Generation != legacy.Generation || current.Lock.ResumeSignal != "" {
@@ -544,18 +1127,18 @@ func TestWakeRestartRejectsRegisteredOwnerlessInjectViaBeforeSignal(t *testing.T
 	preflightCalled := false
 	signalCalled := false
 	oldPreflight := wakeRestartPreflight
-	oldSignal := wakeRestartSignal
+	oldNotify := wakeRestartNotify
 	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
 		preflightCalled = true
 		return nil
 	}
-	wakeRestartSignal = func(*os.Process) error {
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
 		signalCalled = true
 		return nil
 	}
 	t.Cleanup(func() {
 		wakeRestartPreflight = oldPreflight
-		wakeRestartSignal = oldSignal
+		wakeRestartNotify = oldNotify
 	})
 	before := snapshotWakeCheckTree(t, fixture.root)
 
@@ -572,7 +1155,7 @@ func TestWakeRestartRejectsRegisteredOwnerlessInjectViaBeforeSignal(t *testing.T
 	assertWakeCheckTreeUnchanged(t, fixture.root, before)
 }
 
-func TestWakeRestartRejectsPendingCurrentGenerationBeforePreflight(t *testing.T) {
+func TestWakeRestartAdoptsPendingCurrentGenerationAndRenotifies(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	pending := fixture.record
 	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
@@ -582,28 +1165,32 @@ func TestWakeRestartRejectsPendingCurrentGenerationBeforePreflight(t *testing.T)
 	}
 
 	preflightCalled := false
-	signalCalled := false
+	notifyCalled := false
 	oldPreflight := wakeRestartPreflight
-	oldSignal := wakeRestartSignal
+	oldNotify := wakeRestartNotify
 	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
 		preflightCalled = true
 		return nil
 	}
-	wakeRestartSignal = func(*os.Process) error {
-		signalCalled = true
-		return nil
+	notifyErr := errors.New("stop after adopted restart notification")
+	wakeRestartNotify = func(_ *wakeAgentDir, current wakeLockInspection, record wakeRestartRecord) error {
+		notifyCalled = true
+		if !sameWakeLockInspection(current, fixture.lock) || !sameWakeRestartRecord(record, pending) {
+			t.Fatalf("adopted notification current=%#v record=%#v", current, record)
+		}
+		return notifyErr
 	}
 	t.Cleanup(func() {
 		wakeRestartPreflight = oldPreflight
-		wakeRestartSignal = oldSignal
+		wakeRestartNotify = oldNotify
 	})
 
 	result, err := requestWakeRestart(fixture.root, fixture.agent)
-	if err == nil || !strings.Contains(err.Error(), "already pending for generation "+pending.Generation) {
-		t.Fatalf("second restart result=%#v err=%v", result, err)
+	if !errors.Is(err, notifyErr) {
+		t.Fatalf("adopted restart result=%#v err=%v", result, err)
 	}
-	if preflightCalled || signalCalled {
-		t.Fatalf("second restart reached preflight=%v signal=%v", preflightCalled, signalCalled)
+	if preflightCalled || !notifyCalled {
+		t.Fatalf("adopted restart preflight=%v notify=%v", preflightCalled, notifyCalled)
 	}
 	if err := fixture.agentDir.withFD(func(dirfd int) error {
 		current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
@@ -623,7 +1210,57 @@ func TestWakeRestartRejectsPendingCurrentGenerationBeforePreflight(t *testing.T)
 	}
 }
 
-func TestWakeRestartReplacesPendingOtherGenerationBeforeSignal(t *testing.T) {
+func TestWakeRestartPreservesClaimBeforeSuccessorPublication(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	claimed := fixture.record
+	claimed.Schema = wakeRestartSchemaV2
+	claimed.SuccessorGeneration = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if err := withWakeLifecycleGuardInDir(fixture.agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, claimed)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	preflightCalled := false
+	notifyCalled := false
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalled = true
+		return nil
+	}
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		notifyCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+	})
+
+	result, err := requestWakeRestart(fixture.root, fixture.agent)
+	if err == nil || !strings.Contains(err.Error(), "is preserved before successor publication") ||
+		!strings.Contains(result.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) {
+		t.Fatalf("unstable claim result=%#v err=%v", result, err)
+	}
+	if preflightCalled || notifyCalled {
+		t.Fatalf("unstable claim reached preflight=%v notify=%v", preflightCalled, notifyCalled)
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		if readErr != nil {
+			return readErr
+		}
+		if !exists || !sameWakeRestartRecord(current, claimed) {
+			return fmt.Errorf("unstable claim changed: %#v exists=%v", current, exists)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWakeRestartPreservesPendingForeignGeneration(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	pending := fixture.record
 	pending.Generation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -634,57 +1271,116 @@ func TestWakeRestartReplacesPendingOtherGenerationBeforeSignal(t *testing.T) {
 	}
 
 	preflightCalled := false
+	notifyCalled := false
 	oldPreflight := wakeRestartPreflight
-	oldSignal := wakeRestartSignal
+	oldNotify := wakeRestartNotify
 	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
 		preflightCalled = true
 		return nil
 	}
-	signalErr := errors.New("stop after stale request replacement")
-	wakeRestartSignal = func(*os.Process) error {
-		if err := fixture.agentDir.withFD(func(dirfd int) error {
-			current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
-			if readErr != nil {
-				return readErr
-			}
-			if !exists || current.Status != wakeRestartPending {
-				return fmt.Errorf("replacement restart record = %#v, exists=%v", current, exists)
-			}
-			if current.Generation != fixture.lock.Lock.Generation || current.RequestID == pending.RequestID {
-				return fmt.Errorf("replacement restart record did not supersede stale generation: %#v", current)
-			}
-			return nil
-		}); err != nil {
-			t.Error(err)
-		}
-		return signalErr
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		notifyCalled = true
+		return nil
 	}
 	t.Cleanup(func() {
 		wakeRestartPreflight = oldPreflight
-		wakeRestartSignal = oldSignal
+		wakeRestartNotify = oldNotify
 	})
 
 	result, err := requestWakeRestart(fixture.root, fixture.agent)
-	if !errors.Is(err, signalErr) {
-		t.Fatalf("restart result=%#v err=%v, want signal error", result, err)
+	if err == nil || !strings.Contains(err.Error(), "is preserved because it does not match live generation") ||
+		!strings.Contains(result.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) {
+		t.Fatalf("foreign pending restart result=%#v err=%v", result, err)
 	}
-	if !preflightCalled {
-		t.Fatal("replacement restart did not preflight candidate")
+	if preflightCalled || notifyCalled {
+		t.Fatalf("foreign pending reached preflight=%v notify=%v", preflightCalled, notifyCalled)
 	}
 	if err := fixture.agentDir.withFD(func(dirfd int) error {
 		current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
 		if readErr != nil {
 			return readErr
 		}
-		if !exists || current.Generation != fixture.lock.Lock.Generation ||
-			current.RequestID == pending.RequestID || current.Status != wakeRestartRefused ||
-			!strings.Contains(current.Reason, signalErr.Error()) ||
-			strings.Count(current.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) != 1 {
-			return fmt.Errorf("post-signal replacement restart record = %#v, exists=%v", current, exists)
+		if !exists || !sameWakeRestartRecord(current, pending) {
+			return fmt.Errorf("foreign pending restart record = %#v, exists=%v", current, exists)
 		}
 		return nil
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestWakeRestartQuarantinesExactInvalidRecordAndStops(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		future bool
+		second int
+	}{
+		{name: "malformed", second: 0},
+		{name: "future schema", future: true, second: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeRestartFixture(t)
+			raw := []byte(`{"schema":`)
+			if test.future {
+				future := fixture.record
+				future.Schema = wakeRestartSchemaV2 + 1
+				encoded, err := json.Marshal(future)
+				if err != nil {
+					t.Fatal(err)
+				}
+				raw = append(encoded, '\n')
+			}
+			removeWakeRestartRecordForTest(t, fixture)
+			path := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.Lstat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			oldNow := wakeQuarantineNow
+			oldPreflight := wakeRestartPreflight
+			oldNotify := wakeRestartNotify
+			wakeQuarantineNow = func() time.Time {
+				return time.Date(2026, 8, 7, 12, 0, test.second, 0, time.UTC)
+			}
+			preflightCalled := false
+			notifyCalled := false
+			wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+				preflightCalled = true
+				return nil
+			}
+			wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+				notifyCalled = true
+				return nil
+			}
+			t.Cleanup(func() {
+				wakeQuarantineNow = oldNow
+				wakeRestartPreflight = oldPreflight
+				wakeRestartNotify = oldNotify
+			})
+
+			result, restartErr := requestWakeRestart(fixture.root, fixture.agent)
+			if restartErr == nil || !strings.Contains(restartErr.Error(), "was preserved as .wake.restart.quarantined.") ||
+				!strings.Contains(result.Reason, wakeRestartCheckCommand(fixture.root, fixture.agent)) {
+				t.Fatalf("invalid restart result=%#v err=%v", result, restartErr)
+			}
+			if preflightCalled || notifyCalled {
+				t.Fatalf("invalid restart reached preflight=%v notify=%v", preflightCalled, notifyCalled)
+			}
+			if _, statErr := os.Lstat(path); !os.IsNotExist(statErr) {
+				t.Fatalf("invalid restart source remains: %v", statErr)
+			}
+			assertExactWakeQuarantineForTest(
+				t,
+				fixture.agentDir.path,
+				wakeRestartFileName+".quarantined.",
+				raw,
+				before,
+			)
+		})
 	}
 }
 
@@ -694,10 +1390,10 @@ func TestWakeRestartClientWaitsForPreparedRequestConsumption(t *testing.T) {
 	const nextGeneration = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 	oldPreflight := wakeRestartPreflight
-	oldSignal := wakeRestartSignal
+	oldNotify := wakeRestartNotify
 	oldSleep := wakeRestartSleep
 	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error { return nil }
-	wakeRestartSignal = func(*os.Process) error {
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
 		restarted := fixture.lock.Lock
 		restarted.Generation = nextGeneration
 		bound := boundWakeImageEvidenceForTest(fixture.candidate)
@@ -723,7 +1419,7 @@ func TestWakeRestartClientWaitsForPreparedRequestConsumption(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		wakeRestartPreflight = oldPreflight
-		wakeRestartSignal = oldSignal
+		wakeRestartNotify = oldNotify
 		wakeRestartSleep = oldSleep
 	})
 
@@ -745,7 +1441,7 @@ func TestWakeRestartStraySignalWithoutRecordIsNoOp(t *testing.T) {
 	execCalled := false
 	oldBind := wakeRestartBind
 	oldExec := wakeRestartExec
-	wakeRestartBind = func(wakeImageEvidenceV1) (*wakeRestartBoundImage, error) {
+	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
 		bindCalled = true
 		return nil, errors.New("unexpected bind")
 	}

--- a/internal/cli/wake_resume_protocol.go
+++ b/internal/cli/wake_resume_protocol.go
@@ -15,17 +15,20 @@ const (
 	wakeResumeSchemaV2        = 2
 	wakeImageEvidenceSchemaV1 = 1
 
-	wakeImageMethodFDExec               = "fd_exec"
-	wakeImageMethodPathnameObserved     = "pathname_observed"
-	wakeImageMethodPathnameExecVerified = "pathname_execve_verified"
-	wakeResumeSignalUSR1                = "SIGUSR1"
+	wakeImageMethodFDExec                     = "fd_exec"
+	wakeImageMethodPathnameObserved           = "pathname_observed"
+	wakeImageMethodPathnameExecObserved       = "pathname_exec_observed"
+	wakeImageMethodPathnameExecVerifiedLegacy = "pathname_execve_verified"
+	wakeImageMethodPathnameExecVerified       = wakeImageMethodPathnameExecVerifiedLegacy
+	wakeResumeSignalUSR1                      = "SIGUSR1"
 )
 
 // wakeImageEvidenceV1 records image metadata and its authority method.
 // pathname_observed is diagnostic on every platform. A resumed Darwin wake
-// publishes the exact private hardlink path it executed after successor-side
-// verification; a resumed Linux wake publishes evidence from its bound FD and
-// verifies the running image through /proc/self/exe before rotating generation.
+// publishes the private hardlink path observed by the successor after exec;
+// Darwin cannot atomically bind exec to an already-open descriptor. A resumed
+// Linux wake publishes evidence from its bound FD and verifies the running
+// image through /proc/self/exe before rotating generation.
 type wakeImageEvidenceV1 struct {
 	Schema          int    `json:"schema"`
 	Platform        string `json:"platform"`
@@ -142,7 +145,7 @@ func validateWakeImageEvidenceForPlatform(evidence wakeImageEvidenceV1, platform
 	}
 	if platform == "darwin" {
 		if evidence.Method != wakeImageMethodPathnameObserved &&
-			evidence.Method != wakeImageMethodPathnameExecVerified {
+			!wakeImageMethodIsDarwinExecObserved(evidence.Method) {
 			return fmt.Errorf("wake image method %q does not match a Darwin pathname evidence method", evidence.Method)
 		}
 	} else if platform == "linux" {
@@ -178,6 +181,11 @@ func validateWakeImageEvidenceForPlatform(evidence wakeImageEvidenceV1, platform
 		return fmt.Errorf("wake image embedded version is missing or non-canonical")
 	}
 	return nil
+}
+
+func wakeImageMethodIsDarwinExecObserved(method string) bool {
+	return method == wakeImageMethodPathnameExecObserved ||
+		method == wakeImageMethodPathnameExecVerifiedLegacy
 }
 
 func validWakeImageSHA256(value string) bool {

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -58,6 +58,8 @@ func terminateAndRemoveOrphanedWakeLockInDir(
 		fd, err := linuxPidfdOpen(locked.PID, 0)
 		if err != nil {
 			if errors.Is(err, syscall.ESRCH) {
+				locked.Process = wakeProcessInfo{PID: locked.PID}
+				classifyWakeLock(locked.Root, locked.Agent, &locked)
 				var removeErr error
 				outcome := removeWakeLockIfUnchangedGuardedAtDurableOutcome(
 					dirfd,
@@ -207,6 +209,8 @@ func terminateAndRemoveOrphanedWakeLockWithRawConsent(
 		fd, err := linuxPidfdOpen(locked.PID, 0)
 		if err != nil {
 			if errors.Is(err, syscall.ESRCH) {
+				locked.Process = wakeProcessInfo{PID: locked.PID}
+				classifyWakeLock(locked.Root, locked.Agent, &locked)
 				provenGone = true
 				return removeWakeLockIfUnchangedGuarded(locked)
 			}

--- a/internal/cli/wake_terminate_linux_test.go
+++ b/internal/cli/wake_terminate_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -149,8 +150,52 @@ func TestTerminateTreatsPidfdESRCHAsProvenGone(t *testing.T) {
 	const wakePID = 4242
 	root := secureTempDirForTest(t)
 	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
-		PID: wakePID, TTY: "missing", ProcessStart: "start-1", BootID: "boot-1", Executable: "/usr/bin/amq",
+		PID:          wakePID,
+		TTY:          "missing",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/usr/bin/amq",
+		Generation:   "abcdef0123456789abcdef0123456789",
 	})
+	metadata := readWakeLockMetadata(root, "codex")
+	if !metadata.Exists || metadata.Lock.Generation == "" {
+		t.Fatalf("wake lock metadata = %#v", metadata)
+	}
+	setCLIVersionForTest(t, "0.57.3-test")
+	candidate, err := captureCurrentWakeImageEvidence()
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentDir, err := openWakeAgentDir(root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = agentDir.Close() }()
+	restart := wakeRestartRecord{
+		Schema:              wakeRestartSchemaV2,
+		RequestID:           "0123456789abcdef0123456789abcdef",
+		Status:              wakeRestartPending,
+		Root:                canonicalWakeRoot(root),
+		Agent:               "codex",
+		Generation:          metadata.Lock.Generation,
+		SuccessorGeneration: "fedcba9876543210fedcba9876543210",
+		Owner:               validWakeResumeOwnerForTest(),
+		Candidate:           candidate,
+	}
+	if err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, agentDir, restart)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	restartPath := filepath.Join(agentDir.path, wakeRestartFileName)
+	restartRaw, err := os.ReadFile(restartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restartInfo, err := os.Lstat(restartPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	inspectCalls := 0
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		inspectCalls++
@@ -179,6 +224,16 @@ func TestTerminateTreatsPidfdESRCHAsProvenGone(t *testing.T) {
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Fatalf("proven-gone lock was not removed: %v", err)
 	}
+	if _, err := os.Lstat(restartPath); !os.IsNotExist(err) {
+		t.Fatalf("proven-gone restart record was not reclaimed: %v", err)
+	}
+	assertExactWakeQuarantineForTest(
+		t,
+		agentDir.path,
+		wakeRestartFileName+".quarantined.",
+		restartRaw,
+		restartInfo,
+	)
 }
 
 func TestTerminateOpensPidfdBeforeIdentityInspectionAndReleasesGuardBeforeWait(t *testing.T) {

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -724,7 +724,7 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 			owner := *options.requestedOwner
 			candidate.ResumeSchema = wakeResumeSchemaV2
 			candidate.ResumeOwner = &owner
-			candidate.ResumeSignal = wakeResumeSignalUSR1
+			configureWakeRestartAdvertisementPlatform(&candidate, root, me)
 			candidate.RunningImageEvidence = evidence
 			candidate.Args = append([]string(nil), os.Args...)
 			candidate.ImagePath = evidence.ExecutionPath
@@ -1744,6 +1744,57 @@ func buildRepairWakeArgs(root, me string, target wakeTarget, generation, readyPa
 	return args
 }
 
+func cleanupWakeResumeStageBeforeLock(
+	cleanupStage func() error,
+	cleanupLock func(),
+	retainLock *bool,
+) error {
+	if retainLock == nil {
+		return fmt.Errorf("wake restart cleanup retention state is missing")
+	}
+	if cleanupStage != nil {
+		if err := cleanupStage(); err != nil {
+			*retainLock = true
+			return fmt.Errorf("cleanup resumed wake stage before lock release: %w", err)
+		}
+	}
+	if cleanupLock != nil && !*retainLock {
+		cleanupLock()
+	}
+	return nil
+}
+
+func newWakeRestartCleanupRetention(bootstrap *wakeResumeBootstrap) *bool {
+	retain := bootstrap != nil
+	return &retain
+}
+
+func commitWakeRestartReadiness(
+	agentDir *wakeAgentDir,
+	root, me string,
+	current wakeLockInspection,
+	bootstrap wakeResumeBootstrap,
+	retainLock *bool,
+	cleanupPrevious func(wakeResumeBootstrap) error,
+) error {
+	if retainLock == nil {
+		return fmt.Errorf("wake restart cleanup retention state is missing")
+	}
+	if cleanupPrevious == nil {
+		return fmt.Errorf("wake restart previous-stage cleanup is missing")
+	}
+	if err := cleanupPrevious(bootstrap); err != nil {
+		*retainLock = true
+		return fmt.Errorf("cleanup previous wake restart stage before readiness commit: %w", err)
+	}
+	if err := consumeWakeRestartAfterPrepared(agentDir, root, me, current, bootstrap); err != nil {
+		*retainLock = true
+		return err
+	}
+	*retainLock = false
+	return nil
+}
+
 func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	resumeBootstrap, err := wakeResumeBootstrapFromEnv()
 	if err != nil {
@@ -1975,7 +2026,13 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 	if resumeContext == nil {
 		resumeContext = resumePreflight
 	}
+	var cleanup func()
 	var resumeImageEvidence *wakeImageEvidenceV1
+	var cleanupResumeStage func() error
+	resumeStageCleanupTransferred := false
+	// A resumed generation keeps its lock until the previous stage is reclaimed
+	// and the exact restart record is consumed at the readiness boundary.
+	retainLockOnRestartCleanupError := newWakeRestartCleanupRetention(resumeBootstrap)
 	if resumeContext != nil {
 		if repairGeneration != "" || repairHandoffPresent {
 			return fmt.Errorf("wake resume cannot inherit repair state")
@@ -1996,8 +2053,13 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		if resumeBootstrap != nil {
 			cleanupBootstrap := *resumeBootstrap
 			cleanupBootstrap.BoundImage = resumeImageEvidence
+			cleanupResumeStage = func() error {
+				return cleanupWakeResumeBoundImage(cleanupBootstrap)
+			}
 			defer func() {
-				returnErr = errors.Join(returnErr, cleanupWakeResumeBoundImage(cleanupBootstrap))
+				if !resumeStageCleanupTransferred {
+					returnErr = errors.Join(returnErr, cleanupResumeStage())
+				}
 			}()
 		}
 	}
@@ -2192,6 +2254,17 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		}
 		defer func() { _ = activeAgentDir.Close() }()
 	}
+	defer func() {
+		returnErr = errors.Join(
+			returnErr,
+			cleanupWakeResumeStageBeforeLock(
+				cleanupResumeStage,
+				cleanup,
+				retainLockOnRestartCleanupError,
+			),
+		)
+	}()
+	resumeStageCleanupTransferred = true
 
 	// Acquire lock to prevent duplicate wake processes
 	acceptExistingWake := readyFile != "" && *acceptExistingWakeFlag
@@ -2210,7 +2283,6 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		lockWakeMode,
 	)
 	reloadTransportEligible := resumeEligible && target == nil
-	var cleanup func()
 	var repairFloorAuthority wakeRepairFloorAuthority
 	for {
 		if requestedOwner != nil {
@@ -2320,7 +2392,6 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		}
 		return err
 	}
-	defer cleanup()
 	controlStop := privateStop
 	if requestedOwner != nil {
 		controlStop = mergeWakeStopChannels(controlStop, ownerObservation.Done())
@@ -2337,8 +2408,8 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 		var stop <-chan struct{}
 		var markStopped func()
 		var controlErr error
-		controlCleanup, stop, markStopped, controlErr = startWakeControlListenerInDir(
-			activeAgentDir, root, me, currentWake.Lock,
+		controlCleanup, stop, markStopped, controlErr = startWakeControlListenerInDirWithRestart(
+			activeAgentDir, root, me, currentWake.Lock, restartSignals,
 		)
 		if controlErr != nil {
 			return controlErr
@@ -2527,15 +2598,14 @@ func runWakeWithLoop(args []string, loop wakeLoopFunc) (returnErr error) {
 				return err
 			}
 			if resumeBootstrap != nil {
-				if err := cleanupPreviousWakeResumeBoundImage(*resumeBootstrap); err != nil {
-					_ = writeStderr("amq wake: preserve prior restart stage after cleanup refusal: %v\n", err)
-				}
-				if err := consumeWakeRestartAfterPrepared(
+				if err := commitWakeRestartReadiness(
 					activeAgentDir,
 					root,
 					me,
 					currentWake,
 					*resumeBootstrap,
+					retainLockOnRestartCleanupError,
+					cleanupPreviousWakeResumeBoundImage,
 				); err != nil {
 					return err
 				}


### PR DESCRIPTION
## What changed

- Make `.wake.restart` an atomic predecessor-to-successor handoff so concurrent restart callers join or preserve a claimed successor instead of deleting a live handoff.
- Recover same-generation pending requests by adopting and re-notifying them after requester death.
- Use identity-stable notification: Linux `pidfd` and a generation-scoped authenticated macOS control socket, with no bare-PID fallback.
- Quarantine the exact observed malformed record, but preserve a live future-schema record byte-for-byte so an older requester cannot disrupt a newer AMQ handoff.
- Persist and reconcile current and previous macOS stage ownership before wake-lock removal, retaining actionable residue when cleanup cannot complete safely.
- Preserve the exact legacy v0.57.2 Darwin handoff shape so an in-flight mixed-version restart can complete after upgrade.

User-visible result: `amq wake restart` is safe across concurrent callers, lost acknowledgements, requester death, PID reuse, mixed-version upgrades, and crash residue. `amq doctor --ops` now reports actionable restart residue; `--fix-wake-locks` performs guarded exact-object cleanup and retains the remedy when a fix fails.

## Exact review identity

- Head: `041f690e7c27c6ed9beea81662309ec4f3e84d9a`
- Tree: `529ebf9dfc3aefd279daec60540c105aa00d89b0`
- PR diff SHA-256: `14421755dfebaad20787d9f95fccf6aa85f2643a47200bf5e24d0b6e256ed033`

## Validation

- `make ci`: PASS at the pinned head (format, skill links, vet, lint, full Go suite, smoke and release-contract tests).
- Focused Darwin restart/staging/future-schema race tests: PASS.
- Linux container `go test ./internal/cli -count=1`: PASS (122.341s).
- Isolated macOS real-PTY restart E2E: PASS as part of the exact-head full suite.
- Three independent native reviews plus Claude exact-delta review: PASS.

Hosted CI and the required exact-head ChatGPT Pro GO remain merge gates.

## Wake test change justification

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestWakeRestartRejectsControlOnlyIncumbentBeforePublication: renamed to TestWakeRestartRequiresCurrentPlatformTransportBeforePublication because restart notification is now platform-specific while preserving the pre-publication refusal contract
TestWakeRestartRejectsPendingCurrentGenerationBeforePreflight: replaced by TestWakeRestartAdoptsPendingCurrentGenerationAndRenotifies because requester-death recovery intentionally adopts the exact pending request instead of permanently refusing it
TestWakeRestartReplacesPendingOtherGenerationBeforeSignal: replaced by claimed and foreign-generation preservation tests because deleting a live handoff was the F1 race; the safe contract now preserves it and refuses without notification
END_WAKE_TEST_CHANGE_JUSTIFICATION

## Accepted LOW residuals

- macOS final exec remains pathname-based because Darwin has no `fexecve`; the evidence label is now `pathname_exec_observed`, while the legacy label remains readable.
- The retained file descriptor is identity-stable but does not byte-seal the executable.
- Darwin stage cleanup retains identity checks, but a same-UID deliberate pathname replacement can still race the final stat-to-unlink window and leave safe, actionable residue.
- A hard crash in the narrow legacy Darwin interval after successor claim but before lock rotation can orphan the single legacy stage; this is bounded one-transition cleanup residue without identity, handoff, or record corruption.

Non-blocking follow-up: the recoverable creator/adopter one-slot notification race is tracked in `agent-message-queue-0jj.10`.

Release target: patch `v0.57.3`.

Bead: `agent-message-queue-0jj.9` (unblocks `agent-message-queue-0jj.4`).
