### PR TITLE
fix(wake): recover stalled self-upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,10 @@ same image and restart fields for every discovered wake lock.
 
 Resume-eligible wakes started by `coop exec` also follow the stable AMQ launch
 symlink. When an installer atomically points that locator at a strictly newer
-semantic version, the wake waits for a fully quiescent delivery boundary and
-replaces its image without changing PID, terminal ownership, or unread work.
+self-reported semantic version, the wake waits for a fully quiescent delivery
+boundary and replaces its image without changing PID, terminal ownership, or unread work.
+Failed candidates are attempted at most once until a different candidate is
+observed; observing a new candidate resets that refusal memory.
 Pinned binaries, ownerless/keepalive wakes, repair flows, destructive
 interrupts, and arbitrary inject commands never self-upgrade. Disable the
 eligible default with `amq wake --no-self-upgrade` or

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -837,24 +837,118 @@ func removeWakeRestartRecordSnapshotAt(
 }
 
 func refuseWakeRestartRecord(agentDir *wakeAgentDir, expected wakeRestartRecord, reason string) error {
+	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		return refuseWakeRestartRecordAt(dirfd, agentDir, expected, reason)
+	})
+}
+
+func refuseWakeRestartRecordAt(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeRestartRecord,
+	reason string,
+) error {
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
 		reason = "restart refused"
 	}
-	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+	current, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+	if err != nil || !exists {
+		return err
+	}
+	if expected.Schema != wakeRestartSchemaV1 || expected.Status != wakeRestartPending ||
+		current.Schema != wakeRestartSchemaV1 || current.Status != wakeRestartPending ||
+		!sameWakeRestartAttemptIdentity(expected, current) {
+		return fmt.Errorf("wake restart request changed before refusal")
+	}
+	current.Status = wakeRestartRefused
+	current.Reason = wakeRestartReasonWithRemedy(reason, current.Root, current.Agent)
+	return writeWakeRestartRecordAt(dirfd, agentDir, current)
+}
+
+func sameWakeRestartAttemptIdentity(expected, current wakeRestartRecord) bool {
+	return expected.Schema == current.Schema &&
+		expected.RequestID == current.RequestID &&
+		expected.Source == current.Source &&
+		expected.Root == current.Root &&
+		expected.Agent == current.Agent &&
+		expected.Generation == current.Generation &&
+		sameWakeOwner(&expected.Owner, &current.Owner) &&
+		sameWakeSelfUpgradeCandidateIdentity(expected.Candidate, current.Candidate) &&
+		expected.StagePath == current.StagePath &&
+		sameOptionalWakeImageEvidence(expected.PreviousBoundImage, current.PreviousBoundImage)
+}
+
+func retryWakeSelfUpgradeRefusal(
+	cfg *wakeConfig,
+	agentDir *wakeAgentDir,
+	pending wakeSelfUpgradeRefusalPending,
+) (resolved, persisted bool, returnErr error) {
+	returnErr = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		currentLock := inspectWakeLockAt(
+			dirfd,
+			agentDir,
+			canonicalWakeRoot(cfg.root),
+			cfg.me,
+		)
+		if !currentLock.Exists || currentLock.Status != wakeLockValid ||
+			!currentLock.IdentityConfirmed || currentLock.PID != os.Getpid() ||
+			currentLock.Lock.Generation != cfg.terminalGeneration ||
+			cfg.wakeOwner == nil || currentLock.Lock.ResumeOwner == nil ||
+			!sameWakeOwner(cfg.wakeOwner, currentLock.Lock.ResumeOwner) {
+			resolved = true
+			return nil
+		}
+
 		current, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
-		if err != nil || !exists {
+		if err != nil {
 			return err
 		}
-		if expected.Schema != wakeRestartSchemaV1 || expected.Status != wakeRestartPending ||
-			current.Schema != wakeRestartSchemaV1 || current.Status != wakeRestartPending ||
-			current.RequestID != expected.RequestID || current.Generation != expected.Generation {
-			return fmt.Errorf("wake restart request changed before refusal")
+		if !exists || !sameWakeRestartAttemptIdentity(pending.Record, current) {
+			resolved = true
+			return nil
 		}
-		current.Status = wakeRestartRefused
-		current.Reason = wakeRestartReasonWithRemedy(reason, current.Root, current.Agent)
-		return writeWakeRestartRecordAt(dirfd, agentDir, current)
+		if current.Status == wakeRestartRefused {
+			resolved = true
+			persisted = true
+			return nil
+		}
+		if current.Status != wakeRestartPending {
+			resolved = true
+			return nil
+		}
+
+		persistErr := refuseWakeRestartRecordAt(
+			dirfd,
+			agentDir,
+			pending.Record,
+			pending.Reason,
+		)
+		if persistErr == nil {
+			resolved = true
+			persisted = true
+			return nil
+		}
+
+		// The metadata writer can report a post-rename sync or verification
+		// failure after the refusal is already authoritative. Re-observe under
+		// the same lifecycle guard before deciding whether refusal debt remains.
+		installed, installedExists, readErr := readWakeRestartRecordAt(dirfd, agentDir)
+		if readErr != nil {
+			return errors.Join(persistErr, readErr)
+		}
+		if !installedExists || !sameWakeRestartAttemptIdentity(pending.Record, installed) {
+			resolved = true
+			return nil
+		}
+		if installed.Status == wakeRestartRefused {
+			resolved = true
+			persisted = true
+			return nil
+		}
+		return persistErr
 	})
+	return resolved, persisted, returnErr
 }
 
 func refuseWakeRestartCreatorSnapshot(
@@ -1325,6 +1419,39 @@ func handleWakeRestartAtLoopBoundary(
 	if !ok || agentDir == nil {
 		return
 	}
+	if pending := cfg.selfUpgrade.refusalPending; pending != nil {
+		resolved, persisted, retryErr := retryWakeSelfUpgradeRefusal(cfg, agentDir, *pending)
+		if resolved {
+			cfg.selfUpgrade.refusalPending = nil
+			cfg.selfUpgrade.restartPending = false
+		}
+		if (persisted || !resolved) && pending.Record.Source == wakeRestartSourceSelf &&
+			cfg.inspectTerminalGeneration != nil {
+			action := wakeSelfUpgradeActionRefusalPending
+			reason := pending.Reason
+			if persisted {
+				action = wakeSelfUpgradeActionRefused
+			} else if retryErr != nil {
+				reason = fmt.Sprintf("%s; refusal persistence pending: %v", reason, retryErr)
+			}
+			_ = recordWakeSelfUpgradeDecision(
+				agentDir,
+				cfg.inspectTerminalGeneration(),
+				cfg.selfUpgrade,
+				wakeSelfUpgradeDecision{
+					Action:    action,
+					Reason:    reason,
+					Candidate: wakeSelfUpgradeCandidateFromEvidence(pending.Record.Candidate),
+				},
+			)
+		}
+		if persisted || !resolved {
+			return
+		}
+		// A conclusively replaced or removed record retires the old refusal debt.
+		// Continue this observation so a replacement request does not lose the
+		// only restart signal that announced it.
+	}
 	record, exists, err := pendingWakeRestartForProcess(
 		agentDir,
 		canonicalWakeRoot(cfg.root),
@@ -1374,14 +1501,28 @@ func handleWakeRestartAtLoopBoundary(
 		reason := wakeRestartReasonWithRemedy(err.Error(), cfg.root, cfg.me)
 		if record.Source == wakeRestartSourceSelf {
 			reason += "; candidate=" + wakeSelfUpgradeEvidenceIdentityString(record.Candidate)
+			cfg.selfUpgrade.refusalPending = &wakeSelfUpgradeRefusalPending{
+				Record: record,
+				Reason: reason,
+			}
 		}
 		refuseErr := refuseWakeRestartRecord(
 			agentDir,
 			record,
 			reason,
 		)
-		if record.Source == wakeRestartSourceSelf && refuseErr == nil {
-			cfg.selfUpgrade.restartPending = false
+		if record.Source == wakeRestartSourceSelf {
+			if refuseErr == nil {
+				cfg.selfUpgrade.refusalPending = nil
+				cfg.selfUpgrade.restartPending = false
+				recordSelfUpgradeDecision(wakeSelfUpgradeActionRefused, reason)
+			} else {
+				recordSelfUpgradeDecision(
+					wakeSelfUpgradeActionRefusalPending,
+					fmt.Sprintf("%s; refusal persistence pending: %v", reason, refuseErr),
+				)
+			}
+			return
 		}
 		recordSelfUpgradeDecision(wakeSelfUpgradeActionRefused, reason)
 	}
@@ -1393,6 +1534,10 @@ func maintainWakeSelfUpgradeAtLoopBoundary(
 	watcher wakeAdmissionWatcher,
 	terminalRetry, scanRetry bool,
 ) error {
+	if cfg.selfUpgrade.refusalPending != nil {
+		handleWakeRestartAtLoopBoundary(cfg, watcher, terminalRetry, scanRetry)
+		return nil
+	}
 	if cfg.selfUpgrade.restartPending {
 		pending, exists, pendingErr := pendingWakeRestartForProcess(
 			agentDir,

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -883,18 +883,31 @@ func retryWakeSelfUpgradeRefusal(
 	cfg *wakeConfig,
 	agentDir *wakeAgentDir,
 	pending wakeSelfUpgradeRefusalPending,
-) (resolved, persisted bool, returnErr error) {
+) (resolved, persisted, continueObservation bool, returnErr error) {
 	returnErr = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
-		currentLock := inspectWakeLockAt(
+		currentLock := wakeSelfUpgradeInspectLockAt(
 			dirfd,
 			agentDir,
 			canonicalWakeRoot(cfg.root),
 			cfg.me,
 		)
-		if !currentLock.Exists || currentLock.Status != wakeLockValid ||
-			!currentLock.IdentityConfirmed || currentLock.PID != os.Getpid() ||
+		if (!currentLock.Exists && currentLock.Status == wakeLockMissing) ||
+			currentLock.Status == wakeLockStale {
+			resolved = true
+			return nil
+		}
+		if currentLock.Status != wakeLockValid || !currentLock.IdentityConfirmed {
+			return fmt.Errorf(
+				"wake lock authority is inconclusive while refusal persistence is pending: %s",
+				currentLock.Reason,
+			)
+		}
+		if cfg.wakeOwner == nil {
+			return fmt.Errorf("wake owner authority is unavailable while refusal persistence is pending")
+		}
+		if currentLock.PID != os.Getpid() ||
 			currentLock.Lock.Generation != cfg.terminalGeneration ||
-			cfg.wakeOwner == nil || currentLock.Lock.ResumeOwner == nil ||
+			currentLock.Lock.ResumeOwner == nil ||
 			!sameWakeOwner(cfg.wakeOwner, currentLock.Lock.ResumeOwner) {
 			resolved = true
 			return nil
@@ -906,6 +919,7 @@ func retryWakeSelfUpgradeRefusal(
 		}
 		if !exists || !sameWakeRestartAttemptIdentity(pending.Record, current) {
 			resolved = true
+			continueObservation = true
 			return nil
 		}
 		if current.Status == wakeRestartRefused {
@@ -915,6 +929,7 @@ func retryWakeSelfUpgradeRefusal(
 		}
 		if current.Status != wakeRestartPending {
 			resolved = true
+			continueObservation = true
 			return nil
 		}
 
@@ -939,6 +954,7 @@ func retryWakeSelfUpgradeRefusal(
 		}
 		if !installedExists || !sameWakeRestartAttemptIdentity(pending.Record, installed) {
 			resolved = true
+			continueObservation = true
 			return nil
 		}
 		if installed.Status == wakeRestartRefused {
@@ -948,7 +964,7 @@ func retryWakeSelfUpgradeRefusal(
 		}
 		return persistErr
 	})
-	return resolved, persisted, returnErr
+	return resolved, persisted, continueObservation, returnErr
 }
 
 func refuseWakeRestartCreatorSnapshot(
@@ -1329,7 +1345,8 @@ func pendingWakeRestartForProcess(
 		if err != nil || !exists {
 			return err
 		}
-		if record.Status != wakeRestartPending || record.Root != root || record.Agent != me ||
+		if record.Schema != wakeRestartSchemaV1 || record.SuccessorGeneration != "" ||
+			record.Status != wakeRestartPending || record.Root != root || record.Agent != me ||
 			record.Generation != expectedGeneration || owner == nil || !sameWakeOwner(owner, &record.Owner) ||
 			!sameOptionalWakeImageEvidence(
 				record.PreviousBoundImage,
@@ -1340,6 +1357,45 @@ func pendingWakeRestartForProcess(
 		return nil
 	})
 	return record, exists, err
+}
+
+func pendingWakeSelfUpgradeForProcess(
+	cfg *wakeConfig,
+	agentDir *wakeAgentDir,
+) (wakeRestartRecord, bool, error) {
+	root := canonicalWakeRoot(cfg.root)
+	var record wakeRestartRecord
+	var adopt bool
+	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+		current, exists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		if err != nil || !exists {
+			return err
+		}
+		if current.Schema != wakeRestartSchemaV1 || current.Status != wakeRestartPending ||
+			current.Source != wakeRestartSourceSelf || current.Root != root ||
+			current.Agent != cfg.me || current.Generation != cfg.terminalGeneration ||
+			cfg.wakeOwner == nil || !sameWakeOwner(cfg.wakeOwner, &current.Owner) {
+			return nil
+		}
+		incumbent := wakeSelfUpgradeInspectLockAt(dirfd, agentDir, root, cfg.me)
+		if !incumbent.Exists || incumbent.Status != wakeLockValid ||
+			!incumbent.IdentityConfirmed || incumbent.PID != os.Getpid() ||
+			incumbent.Lock.Generation != cfg.terminalGeneration ||
+			incumbent.Lock.ResumeOwner == nil ||
+			!sameWakeOwner(cfg.wakeOwner, incumbent.Lock.ResumeOwner) {
+			return fmt.Errorf("wake self-upgrade incumbent changed before pending-record reconciliation")
+		}
+		if !sameOptionalWakeImageEvidence(
+			current.PreviousBoundImage,
+			previousDarwinWakeRestartStageForLock(incumbent.Lock),
+		) {
+			return nil
+		}
+		record = current
+		adopt = true
+		return nil
+	})
+	return record, adopt, err
 }
 
 func classifyWakeRestartAtLoopBoundary(
@@ -1420,7 +1476,11 @@ func handleWakeRestartAtLoopBoundary(
 		return
 	}
 	if pending := cfg.selfUpgrade.refusalPending; pending != nil {
-		resolved, persisted, retryErr := retryWakeSelfUpgradeRefusal(cfg, agentDir, *pending)
+		resolved, persisted, continueObservation, retryErr := retryWakeSelfUpgradeRefusal(
+			cfg,
+			agentDir,
+			*pending,
+		)
 		if resolved {
 			cfg.selfUpgrade.refusalPending = nil
 			cfg.selfUpgrade.restartPending = false
@@ -1445,7 +1505,7 @@ func handleWakeRestartAtLoopBoundary(
 				},
 			)
 		}
-		if persisted || !resolved {
+		if persisted || !resolved || !continueObservation {
 			return
 		}
 		// A conclusively replaced or removed record retires the old refusal debt.
@@ -1535,6 +1595,13 @@ func maintainWakeSelfUpgradeAtLoopBoundary(
 	terminalRetry, scanRetry bool,
 ) error {
 	if cfg.selfUpgrade.refusalPending != nil {
+		handleWakeRestartAtLoopBoundary(cfg, watcher, terminalRetry, scanRetry)
+		return nil
+	}
+	if _, exists, pendingErr := pendingWakeSelfUpgradeForProcess(cfg, agentDir); pendingErr != nil {
+		return pendingErr
+	} else if exists {
+		cfg.selfUpgrade.restartPending = true
 		handleWakeRestartAtLoopBoundary(cfg, watcher, terminalRetry, scanRetry)
 		return nil
 	}

--- a/internal/cli/wake_self_upgrade_flow_unix_test.go
+++ b/internal/cli/wake_self_upgrade_flow_unix_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -208,6 +210,601 @@ func TestWakeSelfUpgradePostPublicationQuiescenceRaceDefersPendingRecord(t *test
 		t.Fatal("refused self restart retained its process-local pending marker")
 	}
 	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
+}
+
+func TestWakeSelfUpgradePostWriteReadFailureAdoptsPersistedRecord(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	candidate := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate")
+	state := selfUpgradeStateForCandidate(t, candidate)
+	stubWakeSelfUpgradeVersion(t, "0.57.0")
+
+	bindCalls := 0
+	previousBind := wakeRestartBind
+	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
+		bindCalls++
+		return nil, errors.New("test bind refusal")
+	}
+	previousReadPublished := wakeSelfUpgradeReadPublished
+	wakeSelfUpgradeReadPublished = func(int, *wakeAgentDir) (wakeRestartRecord, bool, error) {
+		return wakeRestartRecord{}, false, errors.New("test post-write read failure")
+	}
+	t.Cleanup(func() {
+		wakeRestartBind = previousBind
+		wakeSelfUpgradeReadPublished = previousReadPublished
+	})
+
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade:          state,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err == nil {
+		t.Fatal("post-write read failure was not reported")
+	}
+	if bindCalls != 0 || cfg.selfUpgrade.restartPending {
+		t.Fatalf("failed publication handled early: binds=%d pending=%v", bindCalls, cfg.selfUpgrade.restartPending)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+
+	wakeSelfUpgradeReadPublished = previousReadPublished
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if bindCalls != 1 || cfg.selfUpgrade.restartPending || cfg.selfUpgrade.refusalPending != nil {
+		t.Fatalf(
+			"adopted publication = binds=%d pending=%v refusal=%#v",
+			bindCalls,
+			cfg.selfUpgrade.restartPending,
+			cfg.selfUpgrade.refusalPending,
+		)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
+}
+
+func TestPublishWakeSelfUpgradePendingAdoptsOnlyExactSelfRecord(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*testing.T, *wakeRestartRecord)
+		wantAction string
+	}{
+		{name: "exact self pending", wantAction: wakeSelfUpgradeActionPending},
+		{
+			name: "foreign pending",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Source = wakeRestartSourceForeign
+			},
+			wantAction: wakeSelfUpgradeActionRestartPending,
+		},
+		{
+			name: "claimed successor",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Schema = wakeRestartSchemaV2
+				record.SuccessorGeneration = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+			wantAction: wakeSelfUpgradeActionRestartPending,
+		},
+		{
+			name: "different owner",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Owner.SessionID++
+			},
+			wantAction: wakeSelfUpgradeActionRestartPending,
+		},
+		{
+			name: "different root",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Root += "-other"
+			},
+			wantAction: wakeSelfUpgradeActionRestartPending,
+		},
+		{
+			name: "different agent",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Agent = "claude"
+			},
+			wantAction: wakeSelfUpgradeActionRestartPending,
+		},
+		{
+			name: "different generation",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Generation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+			wantAction: wakeSelfUpgradeActionRestartPending,
+		},
+		{
+			name: "different candidate",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Candidate.EmbeddedVersion = "0.57.1"
+			},
+			wantAction: wakeSelfUpgradeActionRestartPending,
+		},
+	}
+	if runtime.GOOS == "darwin" {
+		tests = append(tests, struct {
+			name       string
+			mutate     func(*testing.T, *wakeRestartRecord)
+			wantAction string
+		}{
+			name: "different previous bound image",
+			mutate: func(t *testing.T, record *wakeRestartRecord) {
+				t.Helper()
+				previous := record.Candidate
+				stagePath, err := planWakeRestartStagePlatform(
+					previous,
+					"cccccccccccccccccccccccccccccccc",
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				previous.ExecutionPath = stagePath
+				previous.Method = wakeImageMethodPathnameExecObserved
+				record.PreviousBoundImage = &previous
+			},
+			wantAction: wakeSelfUpgradeActionRestartPending,
+		})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeRestartFixture(t)
+			existing := fixture.record
+			existing.Source = wakeRestartSourceSelf
+			if test.mutate != nil {
+				test.mutate(t, &existing)
+			}
+			writeWakeCheckSelfUpgradeRestartRecord(t, fixture, existing)
+
+			proposed := fixture.record
+			proposed.Source = wakeRestartSourceSelf
+			proposed.RequestID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+			decision, err := publishWakeSelfUpgradePending(
+				fixture.agentDir,
+				fixture.lock,
+				proposed,
+				wakeSelfUpgradeDecision{
+					Candidate: wakeSelfUpgradeCandidateFromEvidence(proposed.Candidate),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Action != test.wantAction {
+				t.Fatalf("decision=%#v, want action %q", decision, test.wantAction)
+			}
+		})
+	}
+}
+
+func TestWakeSelfUpgradePreInstallPublicationFailureRetriesCandidate(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	candidate := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate")
+	state := selfUpgradeStateForCandidate(t, candidate)
+	stubWakeSelfUpgradeVersion(t, "0.57.0")
+
+	bindCalls := 0
+	previousBind := wakeRestartBind
+	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
+		bindCalls++
+		return nil, errors.New("test bind refusal")
+	}
+	previousSync := syncWakeOwnerDirFD
+	failNextSync := true
+	syncWakeOwnerDirFD = func(fd int) error {
+		if failNextSync {
+			failNextSync = false
+			return errors.New("test pre-install sync failure")
+		}
+		return previousSync(fd)
+	}
+	t.Cleanup(func() {
+		wakeRestartBind = previousBind
+		syncWakeOwnerDirFD = previousSync
+	})
+
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade:          state,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err == nil {
+		t.Fatal("pre-install publication failure was not reported")
+	}
+	if bindCalls != 0 {
+		t.Fatalf("pre-install failure bound candidate %d time(s)", bindCalls)
+	}
+	if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
+		t.Fatalf("pre-install failure left restart record: %v", err)
+	}
+
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if bindCalls != 1 {
+		t.Fatalf("recovered publication bind calls=%d, want 1", bindCalls)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
+}
+
+func TestWakeSelfUpgradeRefusalWriteFailureNeverReexecutes(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	record.Status = wakeRestartPending
+	writeWakeCheckSelfUpgradeRestartRecord(t, fixture, record)
+
+	bindCalls := 0
+	previousBind := wakeRestartBind
+	previousSync := syncWakeOwnerDirFD
+	failNextSync := false
+	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
+		bindCalls++
+		failNextSync = true
+		return nil, errors.New("test bind refusal")
+	}
+	syncWakeOwnerDirFD = func(fd int) error {
+		if failNextSync {
+			failNextSync = false
+			return errors.New("test refusal sync failure")
+		}
+		return previousSync(fd)
+	}
+	t.Cleanup(func() {
+		wakeRestartBind = previousBind
+		syncWakeOwnerDirFD = previousSync
+	})
+
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade: wakeSelfUpgradeState{
+			Enabled:        true,
+			Eligible:       true,
+			restartPending: true,
+		},
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	handleWakeRestartAtLoopBoundary(&cfg, watcher, false, false)
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending == nil {
+		t.Fatalf("first refusal = binds=%d debt=%#v", bindCalls, cfg.selfUpgrade.refusalPending)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+	assertWakeSelfUpgradeDiagnosticAction(t, fixture, wakeSelfUpgradeActionRefusalPending)
+
+	failNextSync = true
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending == nil {
+		t.Fatalf("failed refusal retry = binds=%d debt=%#v", bindCalls, cfg.selfUpgrade.refusalPending)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending != nil || cfg.selfUpgrade.restartPending {
+		t.Fatalf(
+			"completed refusal retry = binds=%d debt=%#v pending=%v",
+			bindCalls,
+			cfg.selfUpgrade.refusalPending,
+			cfg.selfUpgrade.restartPending,
+		)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
+	assertWakeSelfUpgradeDiagnosticAction(t, fixture, wakeSelfUpgradeActionRefused)
+}
+
+func TestWakeSelfUpgradePostRenameRefusalErrorObservesInstalledRefusal(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	record.Status = wakeRestartPending
+	writeWakeCheckSelfUpgradeRestartRecord(t, fixture, record)
+
+	bindCalls := 0
+	previousBind := wakeRestartBind
+	previousSync := syncWakeOwnerDirFD
+	armed := false
+	syncCalls := 0
+	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
+		bindCalls++
+		armed = true
+		syncCalls = 0
+		return nil, errors.New("test bind refusal")
+	}
+	syncWakeOwnerDirFD = func(fd int) error {
+		if armed {
+			syncCalls++
+			if syncCalls == 2 {
+				armed = false
+				return errors.New("test post-rename sync failure")
+			}
+		}
+		return previousSync(fd)
+	}
+	t.Cleanup(func() {
+		wakeRestartBind = previousBind
+		syncWakeOwnerDirFD = previousSync
+	})
+
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade: wakeSelfUpgradeState{
+			Enabled:        true,
+			Eligible:       true,
+			restartPending: true,
+		},
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending == nil {
+		t.Fatalf("ambiguous refusal = binds=%d debt=%#v", bindCalls, cfg.selfUpgrade.refusalPending)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
+
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending != nil || cfg.selfUpgrade.restartPending {
+		t.Fatalf(
+			"observed refusal = binds=%d debt=%#v pending=%v",
+			bindCalls,
+			cfg.selfUpgrade.refusalPending,
+			cfg.selfUpgrade.restartPending,
+		)
+	}
+	assertWakeSelfUpgradeDiagnosticAction(t, fixture, wakeSelfUpgradeActionRefused)
+}
+
+func TestWakeSelfUpgradeRefusalRetryPostRenameErrorObservesInstalledRefusal(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	record.Status = wakeRestartPending
+	writeWakeCheckSelfUpgradeRestartRecord(t, fixture, record)
+
+	bindCalls := 0
+	previousBind := wakeRestartBind
+	previousSync := syncWakeOwnerDirFD
+	mode := ""
+	syncCalls := 0
+	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
+		bindCalls++
+		mode = "pre-install"
+		return nil, errors.New("test bind refusal")
+	}
+	syncWakeOwnerDirFD = func(fd int) error {
+		switch mode {
+		case "pre-install":
+			mode = ""
+			return errors.New("test pre-install sync failure")
+		case "post-rename":
+			syncCalls++
+			if syncCalls == 2 {
+				mode = ""
+				return errors.New("test post-rename sync failure")
+			}
+		}
+		return previousSync(fd)
+	}
+	t.Cleanup(func() {
+		wakeRestartBind = previousBind
+		syncWakeOwnerDirFD = previousSync
+	})
+
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade: wakeSelfUpgradeState{
+			Enabled:        true,
+			Eligible:       true,
+			restartPending: true,
+		},
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	handleWakeRestartAtLoopBoundary(&cfg, watcher, false, false)
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending == nil {
+		t.Fatalf("initial refusal = binds=%d debt=%#v", bindCalls, cfg.selfUpgrade.refusalPending)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+
+	mode = "post-rename"
+	syncCalls = 0
+	injectedPostRename := false
+	previousSyncWithInjection := syncWakeOwnerDirFD
+	syncWakeOwnerDirFD = func(fd int) error {
+		err := previousSyncWithInjection(fd)
+		if err != nil && strings.Contains(err.Error(), "post-rename") {
+			injectedPostRename = true
+		}
+		return err
+	}
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !injectedPostRename {
+		t.Fatal("refusal retry did not inject the post-rename failure")
+	}
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending != nil || cfg.selfUpgrade.restartPending {
+		t.Fatalf(
+			"post-rename retry = binds=%d debt=%#v pending=%v",
+			bindCalls,
+			cfg.selfUpgrade.refusalPending,
+			cfg.selfUpgrade.restartPending,
+		)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
+	assertWakeSelfUpgradeDiagnosticAction(t, fixture, wakeSelfUpgradeActionRefused)
+}
+
+func TestWakeSelfUpgradeChangedRecordConsumesDebtThenHandlesReplacement(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	debtRecord := fixture.record
+	debtRecord.Source = wakeRestartSourceSelf
+
+	replacement := fixture.record
+	replacement.Source = wakeRestartSourceForeign
+	replacement.RequestID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	writeWakeCheckSelfUpgradeRestartRecord(t, fixture, replacement)
+
+	bindCalls := 0
+	previousBind := wakeRestartBind
+	wakeRestartBind = func(record wakeRestartRecord) (*wakeRestartBoundImage, error) {
+		if record.RequestID == debtRecord.RequestID {
+			t.Fatal("retired refusal debt was executed")
+		}
+		if record.RequestID != replacement.RequestID {
+			t.Fatalf("unexpected replacement request %q", record.RequestID)
+		}
+		bindCalls++
+		return nil, errors.New("test replacement bind refusal")
+	}
+	t.Cleanup(func() { wakeRestartBind = previousBind })
+
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade: wakeSelfUpgradeState{
+			Enabled:        true,
+			Eligible:       true,
+			restartPending: true,
+			refusalPending: &wakeSelfUpgradeRefusalPending{
+				Record: debtRecord,
+				Reason: "retired self-upgrade attempt",
+			},
+		},
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	handleWakeRestartAtLoopBoundary(&cfg, watcher, false, false)
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending != nil {
+		t.Fatalf("replacement handling = binds=%d debt=%#v", bindCalls, cfg.selfUpgrade.refusalPending)
+	}
+	installed := readWakeSelfUpgradeRestartRecord(t, fixture)
+	if installed.RequestID != replacement.RequestID ||
+		installed.Source != wakeRestartSourceForeign || installed.Status != wakeRestartRefused {
+		t.Fatalf("replacement record=%#v", installed)
+	}
 }
 
 func TestWakeSelfUpgradeDiagnosticFailureDoesNotBlockPendingHandler(t *testing.T) {

--- a/internal/cli/wake_self_upgrade_flow_unix_test.go
+++ b/internal/cli/wake_self_upgrade_flow_unix_test.go
@@ -213,76 +213,143 @@ func TestWakeSelfUpgradePostPublicationQuiescenceRaceDefersPendingRecord(t *test
 }
 
 func TestWakeSelfUpgradePostWriteReadFailureAdoptsPersistedRecord(t *testing.T) {
-	fixture := newWakeRestartFixture(t)
-	removeWakeRestartRecordForTest(t, fixture)
-	candidate := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate")
-	state := selfUpgradeStateForCandidate(t, candidate)
-	stubWakeSelfUpgradeVersion(t, "0.57.0")
-
-	bindCalls := 0
-	previousBind := wakeRestartBind
-	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
-		bindCalls++
-		return nil, errors.New("test bind refusal")
-	}
-	previousReadPublished := wakeSelfUpgradeReadPublished
-	wakeSelfUpgradeReadPublished = func(int, *wakeAgentDir) (wakeRestartRecord, bool, error) {
-		return wakeRestartRecord{}, false, errors.New("test post-write read failure")
-	}
-	t.Cleanup(func() {
-		wakeRestartBind = previousBind
-		wakeSelfUpgradeReadPublished = previousReadPublished
-	})
-
-	cfg := wakeConfig{
-		me:                   fixture.agent,
-		root:                 fixture.root,
-		injectMode:           wakeInjectModeNone,
-		wakeOwner:            &fixture.owner,
-		terminalGeneration:   fixture.lock.Lock.Generation,
-		terminalImageVersion: fixture.lock.Lock.ImageVersion,
-		retainedAgent:        fixture.agentDir,
-		retainedInbox:        fixture.inboxDir,
-		selfUpgrade:          state,
-		inspectTerminalGeneration: func() wakeLockInspection {
-			return inspectWakeLock(fixture.root, fixture.agent)
+	tests := []struct {
+		name          string
+		changeLocator func(*testing.T, string)
+		deferOnce     bool
+	}{
+		{
+			name: "locator replaced",
+			changeLocator: func(t *testing.T, locator string) {
+				replacement := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "replacement")
+				replaceWakeSelfUpgradeLocator(t, locator, replacement)
+			},
 		},
-		restartSignals: make(chan os.Signal, 1),
+		{
+			name: "locator missing across quiescence deferral",
+			changeLocator: func(t *testing.T, locator string) {
+				if err := os.Remove(locator); err != nil {
+					t.Fatal(err)
+				}
+			},
+			deferOnce: true,
+		},
 	}
-	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
-	if err := maintainWakeSelfUpgradeAtLoopBoundary(
-		&cfg,
-		fixture.agentDir,
-		watcher,
-		false,
-		false,
-	); err == nil {
-		t.Fatal("post-write read failure was not reported")
-	}
-	if bindCalls != 0 || cfg.selfUpgrade.restartPending {
-		t.Fatalf("failed publication handled early: binds=%d pending=%v", bindCalls, cfg.selfUpgrade.restartPending)
-	}
-	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
 
-	wakeSelfUpgradeReadPublished = previousReadPublished
-	if err := maintainWakeSelfUpgradeAtLoopBoundary(
-		&cfg,
-		fixture.agentDir,
-		watcher,
-		false,
-		false,
-	); err != nil {
-		t.Fatal(err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeRestartFixture(t)
+			removeWakeRestartRecordForTest(t, fixture)
+			candidate := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate")
+			state := selfUpgradeStateForCandidate(t, candidate)
+			stubWakeSelfUpgradeVersion(t, "0.57.0")
+
+			bindCalls := 0
+			var boundRecord wakeRestartRecord
+			previousBind := wakeRestartBind
+			wakeRestartBind = func(record wakeRestartRecord) (*wakeRestartBoundImage, error) {
+				bindCalls++
+				boundRecord = record
+				return nil, errors.New("test bind refusal")
+			}
+			previousReadPublished := wakeSelfUpgradeReadPublished
+			wakeSelfUpgradeReadPublished = func(int, *wakeAgentDir) (wakeRestartRecord, bool, error) {
+				return wakeRestartRecord{}, false, errors.New("test post-write read failure")
+			}
+			t.Cleanup(func() {
+				wakeRestartBind = previousBind
+				wakeSelfUpgradeReadPublished = previousReadPublished
+			})
+
+			cfg := wakeConfig{
+				me:                   fixture.agent,
+				root:                 fixture.root,
+				injectMode:           wakeInjectModeNone,
+				wakeOwner:            &fixture.owner,
+				terminalGeneration:   fixture.lock.Lock.Generation,
+				terminalImageVersion: fixture.lock.Lock.ImageVersion,
+				retainedAgent:        fixture.agentDir,
+				retainedInbox:        fixture.inboxDir,
+				selfUpgrade:          state,
+				inspectTerminalGeneration: func() wakeLockInspection {
+					return inspectWakeLock(fixture.root, fixture.agent)
+				},
+				restartSignals: make(chan os.Signal, 1),
+			}
+			watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+			if err := maintainWakeSelfUpgradeAtLoopBoundary(
+				&cfg,
+				fixture.agentDir,
+				watcher,
+				false,
+				false,
+			); err == nil {
+				t.Fatal("post-write read failure was not reported")
+			}
+			if bindCalls != 0 || cfg.selfUpgrade.restartPending {
+				t.Fatalf(
+					"failed publication handled early: binds=%d pending=%v",
+					bindCalls,
+					cfg.selfUpgrade.restartPending,
+				)
+			}
+			assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+			published := readWakeSelfUpgradeRestartRecord(t, fixture)
+			test.changeLocator(t, cfg.selfUpgrade.Locator)
+			wakeSelfUpgradeReadPublished = previousReadPublished
+
+			if test.deferOnce {
+				cfg.inputDelivery = wakeInputDeliveryState{
+					phase:         wakeInputPrimarySubmitPending,
+					acceptedBytes: 1,
+				}
+				if err := maintainWakeSelfUpgradeAtLoopBoundary(
+					&cfg,
+					fixture.agentDir,
+					watcher,
+					false,
+					false,
+				); err != nil {
+					t.Fatal(err)
+				}
+				if bindCalls != 0 || !cfg.selfUpgrade.restartPending {
+					t.Fatalf(
+						"deferred adoption = binds=%d pending=%v",
+						bindCalls,
+						cfg.selfUpgrade.restartPending,
+					)
+				}
+				assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+				cfg.inputDelivery.reset()
+			}
+
+			if err := maintainWakeSelfUpgradeAtLoopBoundary(
+				&cfg,
+				fixture.agentDir,
+				watcher,
+				false,
+				false,
+			); err != nil {
+				t.Fatal(err)
+			}
+			if bindCalls != 1 || cfg.selfUpgrade.restartPending || cfg.selfUpgrade.refusalPending != nil {
+				t.Fatalf(
+					"adopted publication = binds=%d pending=%v refusal=%#v",
+					bindCalls,
+					cfg.selfUpgrade.restartPending,
+					cfg.selfUpgrade.refusalPending,
+				)
+			}
+			if !sameWakeSelfUpgradeCandidateIdentity(boundRecord.Candidate, published.Candidate) {
+				t.Fatalf(
+					"bound candidate=%#v, want published candidate %#v",
+					boundRecord.Candidate,
+					published.Candidate,
+				)
+			}
+			assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
+		})
 	}
-	if bindCalls != 1 || cfg.selfUpgrade.restartPending || cfg.selfUpgrade.refusalPending != nil {
-		t.Fatalf(
-			"adopted publication = binds=%d pending=%v refusal=%#v",
-			bindCalls,
-			cfg.selfUpgrade.restartPending,
-			cfg.selfUpgrade.refusalPending,
-		)
-	}
-	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
 }
 
 func TestPublishWakeSelfUpgradePendingAdoptsOnlyExactSelfRecord(t *testing.T) {
@@ -399,6 +466,206 @@ func TestPublishWakeSelfUpgradePendingAdoptsOnlyExactSelfRecord(t *testing.T) {
 	}
 }
 
+func TestPendingWakeSelfUpgradeForProcessAdoptsOnlyExactAuthority(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*testing.T, *wakeRestartRecord)
+		inspect    func(wakeRestartFixture) wakeLockInspection
+		noOwner    bool
+		wantAdopt  bool
+		wantErrSub string
+	}{
+		{name: "exact self pending", wantAdopt: true},
+		{
+			name: "foreign pending",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Source = wakeRestartSourceForeign
+			},
+		},
+		{
+			name: "claimed successor",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Schema = wakeRestartSchemaV2
+				record.SuccessorGeneration = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+		},
+		{
+			name: "refused",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Status = wakeRestartRefused
+				record.Reason = "test refusal"
+			},
+		},
+		{
+			name: "different root",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Root += "-other"
+			},
+		},
+		{
+			name: "different agent",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Agent = "claude"
+			},
+		},
+		{
+			name: "different generation",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Generation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			},
+		},
+		{
+			name: "different owner",
+			mutate: func(_ *testing.T, record *wakeRestartRecord) {
+				record.Owner.SessionID++
+			},
+		},
+		{
+			name: "different incumbent pid",
+			inspect: func(fixture wakeRestartFixture) wakeLockInspection {
+				lock := fixture.lock
+				lock.PID++
+				lock.Lock.PID = lock.PID
+				return lock
+			},
+			wantErrSub: "incumbent changed",
+		},
+		{
+			name: "different incumbent generation",
+			inspect: func(fixture wakeRestartFixture) wakeLockInspection {
+				lock := fixture.lock
+				lock.Lock.Generation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+				return lock
+			},
+			wantErrSub: "incumbent changed",
+		},
+		{
+			name: "different incumbent resume owner",
+			inspect: func(fixture wakeRestartFixture) wakeLockInspection {
+				lock := fixture.lock
+				owner := fixture.owner
+				owner.SessionID++
+				lock.Lock.ResumeOwner = &owner
+				return lock
+			},
+			wantErrSub: "incumbent changed",
+		},
+		{
+			name: "missing incumbent resume owner",
+			inspect: func(fixture wakeRestartFixture) wakeLockInspection {
+				lock := fixture.lock
+				lock.Lock.ResumeOwner = nil
+				return lock
+			},
+			wantErrSub: "incumbent changed",
+		},
+		{
+			name:    "owner unavailable",
+			noOwner: true,
+		},
+		{
+			name: "unverified incumbent",
+			inspect: func(fixture wakeRestartFixture) wakeLockInspection {
+				return wakeLockInspection{
+					Exists: true,
+					Status: wakeLockUnverified,
+					Reason: "test transient lock read failure",
+					Root:   fixture.root,
+					Agent:  fixture.agent,
+				}
+			},
+			wantErrSub: "incumbent changed",
+		},
+	}
+	if runtime.GOOS == "darwin" {
+		tests = append(tests, struct {
+			name       string
+			mutate     func(*testing.T, *wakeRestartRecord)
+			inspect    func(wakeRestartFixture) wakeLockInspection
+			noOwner    bool
+			wantAdopt  bool
+			wantErrSub string
+		}{
+			name: "different previous bound image",
+			mutate: func(t *testing.T, record *wakeRestartRecord) {
+				previous := record.Candidate
+				stagePath, err := planWakeRestartStagePlatform(
+					previous,
+					"cccccccccccccccccccccccccccccccc",
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				previous.ExecutionPath = stagePath
+				previous.Method = wakeImageMethodPathnameExecObserved
+				record.PreviousBoundImage = &previous
+			},
+		})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeRestartFixture(t)
+			record := fixture.record
+			record.Source = wakeRestartSourceSelf
+			record.Status = wakeRestartPending
+			if test.mutate != nil {
+				test.mutate(t, &record)
+			}
+			writeWakeCheckSelfUpgradeRestartRecord(t, fixture, record)
+			recordPath := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+			before, err := os.ReadFile(recordPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			previousInspectLockAt := wakeSelfUpgradeInspectLockAt
+			if test.inspect != nil {
+				wakeSelfUpgradeInspectLockAt = func(
+					int,
+					*wakeAgentDir,
+					string,
+					string,
+				) wakeLockInspection {
+					return test.inspect(fixture)
+				}
+			}
+			t.Cleanup(func() { wakeSelfUpgradeInspectLockAt = previousInspectLockAt })
+
+			owner := &fixture.owner
+			if test.noOwner {
+				owner = nil
+			}
+			cfg := wakeConfig{
+				me:                 fixture.agent,
+				root:               fixture.root,
+				wakeOwner:          owner,
+				terminalGeneration: fixture.lock.Lock.Generation,
+			}
+			adoptedRecord, adopted, err := pendingWakeSelfUpgradeForProcess(&cfg, fixture.agentDir)
+			if test.wantErrSub == "" && err != nil {
+				t.Fatal(err)
+			}
+			if test.wantErrSub != "" && (err == nil || !strings.Contains(err.Error(), test.wantErrSub)) {
+				t.Fatalf("error=%v, want substring %q", err, test.wantErrSub)
+			}
+			if adopted != test.wantAdopt {
+				t.Fatalf("adopted=%v, want %v", adopted, test.wantAdopt)
+			}
+			if adopted && !sameWakeRestartAttemptIdentity(record, adoptedRecord) {
+				t.Fatalf("adopted record=%#v, want %#v", adoptedRecord, record)
+			}
+			after, err := os.ReadFile(recordPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != string(before) {
+				t.Fatal("authority reconciliation mutated the restart record")
+			}
+		})
+	}
+}
+
 func TestWakeSelfUpgradePreInstallPublicationFailureRetriesCandidate(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)
@@ -483,6 +750,7 @@ func TestWakeSelfUpgradeRefusalWriteFailureNeverReexecutes(t *testing.T) {
 	bindCalls := 0
 	previousBind := wakeRestartBind
 	previousSync := syncWakeOwnerDirFD
+	previousInspectLockAt := wakeSelfUpgradeInspectLockAt
 	failNextSync := false
 	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
 		bindCalls++
@@ -499,6 +767,7 @@ func TestWakeSelfUpgradeRefusalWriteFailureNeverReexecutes(t *testing.T) {
 	t.Cleanup(func() {
 		wakeRestartBind = previousBind
 		syncWakeOwnerDirFD = previousSync
+		wakeSelfUpgradeInspectLockAt = previousInspectLockAt
 	})
 
 	cfg := wakeConfig{
@@ -524,6 +793,43 @@ func TestWakeSelfUpgradeRefusalWriteFailureNeverReexecutes(t *testing.T) {
 	handleWakeRestartAtLoopBoundary(&cfg, watcher, false, false)
 	if bindCalls != 1 || cfg.selfUpgrade.refusalPending == nil {
 		t.Fatalf("first refusal = binds=%d debt=%#v", bindCalls, cfg.selfUpgrade.refusalPending)
+	}
+	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+	assertWakeSelfUpgradeDiagnosticAction(t, fixture, wakeSelfUpgradeActionRefusalPending)
+
+	transientLockRead := true
+	wakeSelfUpgradeInspectLockAt = func(
+		dirfd int,
+		agentDir *wakeAgentDir,
+		root, me string,
+	) wakeLockInspection {
+		if transientLockRead {
+			transientLockRead = false
+			return wakeLockInspection{
+				Exists:         true,
+				Status:         wakeLockUnverified,
+				Reason:         "test transient lock read failure",
+				observationErr: errors.New("test transient lock read failure"),
+			}
+		}
+		return previousInspectLockAt(dirfd, agentDir, root, me)
+	}
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if bindCalls != 1 || cfg.selfUpgrade.refusalPending == nil || !cfg.selfUpgrade.restartPending {
+		t.Fatalf(
+			"inconclusive lock retry = binds=%d debt=%#v pending=%v",
+			bindCalls,
+			cfg.selfUpgrade.refusalPending,
+			cfg.selfUpgrade.restartPending,
+		)
 	}
 	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
 	assertWakeSelfUpgradeDiagnosticAction(t, fixture, wakeSelfUpgradeActionRefusalPending)
@@ -562,6 +868,106 @@ func TestWakeSelfUpgradeRefusalWriteFailureNeverReexecutes(t *testing.T) {
 	}
 	assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartRefused)
 	assertWakeSelfUpgradeDiagnosticAction(t, fixture, wakeSelfUpgradeActionRefused)
+}
+
+func TestWakeSelfUpgradeAuthorityLossConsumesDebtWithoutReexecution(t *testing.T) {
+	tests := []struct {
+		name       string
+		inspection func(wakeRestartFixture) wakeLockInspection
+	}{
+		{
+			name: "changed resume owner",
+			inspection: func(fixture wakeRestartFixture) wakeLockInspection {
+				lock := fixture.lock
+				changedOwner := fixture.owner
+				changedOwner.SessionID++
+				lock.Lock.ResumeOwner = &changedOwner
+				lock.IdentityConfirmed = true
+				return lock
+			},
+		},
+		{
+			name: "stale lock",
+			inspection: func(fixture wakeRestartFixture) wakeLockInspection {
+				return wakeLockInspection{
+					Exists: true,
+					Status: wakeLockStale,
+					Reason: "pid not running",
+					Root:   fixture.root,
+					Agent:  fixture.agent,
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newWakeRestartFixture(t)
+			record := fixture.record
+			record.Source = wakeRestartSourceSelf
+			record.Status = wakeRestartPending
+			writeWakeCheckSelfUpgradeRestartRecord(t, fixture, record)
+
+			bindCalls := 0
+			previousBind := wakeRestartBind
+			wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
+				bindCalls++
+				return nil, errors.New("old refusal debt was re-executed")
+			}
+			previousInspectLockAt := wakeSelfUpgradeInspectLockAt
+			wakeSelfUpgradeInspectLockAt = func(
+				int,
+				*wakeAgentDir,
+				string,
+				string,
+			) wakeLockInspection {
+				return test.inspection(fixture)
+			}
+			t.Cleanup(func() {
+				wakeRestartBind = previousBind
+				wakeSelfUpgradeInspectLockAt = previousInspectLockAt
+			})
+
+			cfg := wakeConfig{
+				me:                   fixture.agent,
+				root:                 fixture.root,
+				injectMode:           wakeInjectModeNone,
+				wakeOwner:            &fixture.owner,
+				terminalGeneration:   fixture.lock.Lock.Generation,
+				terminalImageVersion: fixture.lock.Lock.ImageVersion,
+				retainedAgent:        fixture.agentDir,
+				retainedInbox:        fixture.inboxDir,
+				selfUpgrade: wakeSelfUpgradeState{
+					Enabled:        true,
+					Eligible:       true,
+					restartPending: true,
+					refusalPending: &wakeSelfUpgradeRefusalPending{
+						Record: record,
+						Reason: "test refusal debt",
+					},
+				},
+				inspectTerminalGeneration: func() wakeLockInspection {
+					return inspectWakeLock(fixture.root, fixture.agent)
+				},
+				restartSignals: make(chan os.Signal, 1),
+			}
+			handleWakeRestartAtLoopBoundary(
+				&cfg,
+				fixedWakeAdmissionWatcher{errors: make(chan error)},
+				false,
+				false,
+			)
+			if bindCalls != 0 || cfg.selfUpgrade.refusalPending != nil || cfg.selfUpgrade.restartPending {
+				t.Fatalf(
+					"authority loss = binds=%d debt=%#v pending=%v",
+					bindCalls,
+					cfg.selfUpgrade.refusalPending,
+					cfg.selfUpgrade.restartPending,
+				)
+			}
+			assertWakeSelfUpgradeRecordStatus(t, fixture, wakeRestartPending)
+		})
+	}
 }
 
 func TestWakeSelfUpgradePostRenameRefusalErrorObservesInstalledRefusal(t *testing.T) {
@@ -804,6 +1210,76 @@ func TestWakeSelfUpgradeChangedRecordConsumesDebtThenHandlesReplacement(t *testi
 	if installed.RequestID != replacement.RequestID ||
 		installed.Source != wakeRestartSourceForeign || installed.Status != wakeRestartRefused {
 		t.Fatalf("replacement record=%#v", installed)
+	}
+}
+
+func TestWakeSelfUpgradeChangedRecordDoesNotExecuteClaimedSuccessor(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	debtRecord := fixture.record
+	debtRecord.Source = wakeRestartSourceSelf
+
+	replacement := debtRecord
+	replacement.RequestID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	replacement.Schema = wakeRestartSchemaV2
+	replacement.SuccessorGeneration = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	writeWakeCheckSelfUpgradeRestartRecord(t, fixture, replacement)
+	recordPath := filepath.Join(fixture.agentDir.path, wakeRestartFileName)
+	before, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bindCalls := 0
+	previousBind := wakeRestartBind
+	wakeRestartBind = func(wakeRestartRecord) (*wakeRestartBoundImage, error) {
+		bindCalls++
+		return nil, errors.New("claimed successor was re-executed")
+	}
+	t.Cleanup(func() { wakeRestartBind = previousBind })
+
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade: wakeSelfUpgradeState{
+			Enabled:        true,
+			Eligible:       true,
+			restartPending: true,
+			refusalPending: &wakeSelfUpgradeRefusalPending{
+				Record: debtRecord,
+				Reason: "retired self-upgrade attempt",
+			},
+		},
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	handleWakeRestartAtLoopBoundary(
+		&cfg,
+		fixedWakeAdmissionWatcher{errors: make(chan error)},
+		false,
+		false,
+	)
+	if bindCalls != 0 || cfg.selfUpgrade.refusalPending != nil || cfg.selfUpgrade.restartPending {
+		t.Fatalf(
+			"claimed successor handling = binds=%d debt=%#v pending=%v",
+			bindCalls,
+			cfg.selfUpgrade.refusalPending,
+			cfg.selfUpgrade.restartPending,
+		)
+	}
+	after, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("claimed successor record was mutated")
 	}
 }
 

--- a/internal/cli/wake_self_upgrade_mixed_version_unix_test.go
+++ b/internal/cli/wake_self_upgrade_mixed_version_unix_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 )
 
-const wakeSelfUpgradeHistoricalTag = "v0.57.3"
+const wakeSelfUpgradeHistoricalTag = "v0.58.0"
 
-func TestWakeSelfUpgradeRestartRecordIsCompatibleWithV0573Reader(t *testing.T) {
+func TestWakeSelfUpgradeRestartRecordIsCompatibleWithV0580Reader(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	record := fixture.record
 	record.Source = wakeRestartSourceSelf
@@ -23,7 +23,7 @@ func TestWakeSelfUpgradeRestartRecordIsCompatibleWithV0573Reader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, sourceRoot := buildWakeSelfUpgradeHistoricalV0573(t)
+	sourceRoot := extractWakeSelfUpgradeHistoricalV0580(t)
 
 	generatedTest := historicalWakeSelfUpgradeSourceCompatibilityTest(string(raw))
 	generatedPath := filepath.Join(sourceRoot, "internal", "cli", "wake_self_upgrade_source_compat_test.go")
@@ -39,19 +39,19 @@ func TestWakeSelfUpgradeRestartRecordIsCompatibleWithV0573Reader(t *testing.T) {
 	)
 }
 
-func buildWakeSelfUpgradeHistoricalV0573(t *testing.T) (binary, sourceRoot string) {
+func extractWakeSelfUpgradeHistoricalV0580(t *testing.T) string {
 	t.Helper()
 	repoRootOutput, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
 	if err != nil {
-		t.Skipf("mixed-version git history unavailable: %v", err)
+		t.Fatalf("mixed-version git history unavailable: %v", err)
 	}
 	repoRoot := strings.TrimSpace(string(repoRootOutput))
 	if output, err := exec.Command("git", "-C", repoRoot, "cat-file", "-e", wakeSelfUpgradeHistoricalTag+"^{commit}").CombinedOutput(); err != nil {
-		t.Skipf("historical tag %s unavailable: %v\n%s", wakeSelfUpgradeHistoricalTag, err, output)
+		t.Fatalf("historical tag %s unavailable: %v\n%s", wakeSelfUpgradeHistoricalTag, err, output)
 	}
 
 	buildRoot := t.TempDir()
-	sourceRoot = filepath.Join(buildRoot, "source")
+	sourceRoot := filepath.Join(buildRoot, "source")
 	if err := os.Mkdir(sourceRoot, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -62,9 +62,7 @@ func buildWakeSelfUpgradeHistoricalV0573(t *testing.T) (binary, sourceRoot strin
 		"git", "archive", "--format=tar", "--output="+archivePath, wakeSelfUpgradeHistoricalTag,
 	)
 	commandOutputForOwnerFence(t, "", "tar", "-xf", archivePath, "-C", sourceRoot)
-	binary = filepath.Join(buildRoot, "amq-v0.57.3")
-	commandOutputForOwnerFence(t, sourceRoot, "go", "build", "-o", binary, "./cmd/amq")
-	return binary, sourceRoot
+	return sourceRoot
 }
 
 func historicalWakeSelfUpgradeSourceCompatibilityTest(record string) string {

--- a/internal/cli/wake_self_upgrade_unix.go
+++ b/internal/cli/wake_self_upgrade_unix.go
@@ -108,6 +108,7 @@ var (
 	wakeSelfUpgradeNow            = time.Now
 	wakeSelfUpgradeLiveDifference = inspectWakeSelfUpgradeLiveDifference
 	wakeSelfUpgradeReadPublished  = readWakeRestartRecordAt
+	wakeSelfUpgradeInspectLockAt  = inspectWakeLockAt
 )
 
 func coopWakeLaunchLocator(argv0 string) string {
@@ -270,6 +271,13 @@ func probeWakeSelfUpgradeLocator(locator string) (wakeSelfUpgradeProbe, error) {
 	resolved, err := wakeSelfUpgradeEvalSymlinks(locator)
 	if err != nil {
 		return wakeSelfUpgradeProbe{}, err
+	}
+	confirmedLocatorInfo, err := wakeSelfUpgradeLstat(locator)
+	if err != nil {
+		return wakeSelfUpgradeProbe{}, err
+	}
+	if !sameWakeFileIdentity(locatorInfo, confirmedLocatorInfo) {
+		return wakeSelfUpgradeProbe{}, fmt.Errorf("launch locator changed while resolving")
 	}
 	resolved = strings.TrimSpace(resolved)
 	if resolved == "" || !filepath.IsAbs(resolved) || filepath.Clean(resolved) != resolved {

--- a/internal/cli/wake_self_upgrade_unix.go
+++ b/internal/cli/wake_self_upgrade_unix.go
@@ -32,6 +32,7 @@ const (
 	wakeSelfUpgradeActionRestartPresent   = "restart_present"
 	wakeSelfUpgradeActionPending          = "pending"
 	wakeSelfUpgradeActionDeferred         = "deferred"
+	wakeSelfUpgradeActionRefusalPending   = "refusal_pending"
 )
 
 // wakeSelfUpgradeState is process-local trigger state. The locator is captured
@@ -44,6 +45,12 @@ type wakeSelfUpgradeState struct {
 	Reason         string
 	lastProbe      wakeSelfUpgradeProbe
 	restartPending bool
+	refusalPending *wakeSelfUpgradeRefusalPending
+}
+
+type wakeSelfUpgradeRefusalPending struct {
+	Record wakeRestartRecord
+	Reason string
 }
 
 type wakeSelfUpgradeProbe struct {
@@ -100,6 +107,7 @@ var (
 	wakeSelfUpgradeRunVersion     = runWakeSelfUpgradeVersion
 	wakeSelfUpgradeNow            = time.Now
 	wakeSelfUpgradeLiveDifference = inspectWakeSelfUpgradeLiveDifference
+	wakeSelfUpgradeReadPublished  = readWakeRestartRecordAt
 )
 
 func coopWakeLaunchLocator(argv0 string) string {
@@ -252,6 +260,13 @@ func constrainWakeSelfUpgradeEligibility(
 }
 
 func probeWakeSelfUpgradeLocator(locator string) (wakeSelfUpgradeProbe, error) {
+	locatorInfo, err := wakeSelfUpgradeLstat(locator)
+	if err != nil {
+		return wakeSelfUpgradeProbe{}, err
+	}
+	if err := validateWakeSelfUpgradeLaunchLocator(locator, locatorInfo); err != nil {
+		return wakeSelfUpgradeProbe{}, err
+	}
 	resolved, err := wakeSelfUpgradeEvalSymlinks(locator)
 	if err != nil {
 		return wakeSelfUpgradeProbe{}, err
@@ -400,8 +415,8 @@ func maintainWakeSelfUpgrade(
 		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
 	}
 	decision.Candidate = wakeSelfUpgradeCandidateFromEvidence(evidence)
-	state.lastProbe = probe
 	if !wakeSelfUpgradeProbeMatchesEvidence(probe, evidence) {
+		state.lastProbe = probe
 		decision.Action = wakeSelfUpgradeActionRefused
 		decision.Reason = wakeRestartReasonWithRemedy(
 			"candidate image changed while capturing evidence",
@@ -412,6 +427,7 @@ func maintainWakeSelfUpgrade(
 	}
 	different, comparisonErr := wakeSelfUpgradeLiveDifference(inspection, probe)
 	if comparisonErr != nil || !different {
+		state.lastProbe = probe
 		decision.Action = wakeSelfUpgradeActionRefused
 		reason := "candidate image identity is not conclusively different from the live wake"
 		if comparisonErr != nil {
@@ -446,6 +462,10 @@ func maintainWakeSelfUpgrade(
 	if err != nil {
 		return decision, err
 	}
+	if decision.Action != wakeSelfUpgradeActionRestartPending &&
+		decision.Action != wakeSelfUpgradeActionRestartPresent {
+		state.lastProbe = probe
+	}
 	return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
 }
 
@@ -466,6 +486,23 @@ func publishWakeSelfUpgradePending(
 		}
 		if exists {
 			switch {
+			case existing.Record.Schema == wakeRestartSchemaV1 &&
+				existing.Record.Status == wakeRestartPending &&
+				existing.Record.Source == wakeRestartSourceSelf &&
+				existing.Record.Root == expected.Root &&
+				existing.Record.Agent == expected.Agent &&
+				existing.Record.Generation == expected.Lock.Generation &&
+				expected.Lock.ResumeOwner != nil &&
+				sameWakeOwner(&existing.Record.Owner, expected.Lock.ResumeOwner) &&
+				sameOptionalWakeImageEvidence(
+					existing.Record.PreviousBoundImage,
+					previousDarwinWakeRestartStageForLock(expected.Lock),
+				) &&
+				sameWakeSelfUpgradeCandidateIdentity(existing.Record.Candidate, record.Candidate):
+				decision.Action = wakeSelfUpgradeActionPending
+				decision.Reason = "existing self-upgrade restart request was adopted"
+				decision.Candidate = wakeSelfUpgradeCandidateFromEvidence(existing.Record.Candidate)
+				return nil
 			case existing.Record.Status == wakeRestartPending:
 				decision.Action = wakeSelfUpgradeActionRestartPending
 				decision.Reason = "an existing wake restart request is preserved"
@@ -493,7 +530,7 @@ func publishWakeSelfUpgradePending(
 		if err := writeWakeRestartRecordAt(dirfd, agentDir, record); err != nil {
 			return err
 		}
-		installed, installedExists, err := readWakeRestartRecordAt(dirfd, agentDir)
+		installed, installedExists, err := wakeSelfUpgradeReadPublished(dirfd, agentDir)
 		if err != nil || !installedExists || !sameWakeRestartRecord(record, installed) {
 			return fmt.Errorf("self-upgrade restart request changed after publication")
 		}

--- a/internal/cli/wake_self_upgrade_unix_test.go
+++ b/internal/cli/wake_self_upgrade_unix_test.go
@@ -199,6 +199,31 @@ func TestProbeWakeSelfUpgradeLocatorRevalidatesUnresolvedOwner(t *testing.T) {
 	}
 }
 
+func TestProbeWakeSelfUpgradeLocatorRejectsReplacementDuringResolution(t *testing.T) {
+	dir := t.TempDir()
+	first := writeWakeSelfUpgradeCandidate(t, dir, "first")
+	second := writeWakeSelfUpgradeCandidate(t, dir, "second")
+	locator := filepath.Join(dir, "amq")
+	if err := os.Symlink(first, locator); err != nil {
+		t.Fatal(err)
+	}
+
+	previousEval := wakeSelfUpgradeEvalSymlinks
+	wakeSelfUpgradeEvalSymlinks = func(path string) (string, error) {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err == nil {
+			replaceWakeSelfUpgradeLocator(t, locator, second)
+		}
+		return resolved, err
+	}
+	t.Cleanup(func() { wakeSelfUpgradeEvalSymlinks = previousEval })
+
+	if _, err := probeWakeSelfUpgradeLocator(locator); err == nil ||
+		!strings.Contains(err.Error(), "changed while resolving") {
+		t.Fatalf("probe error=%v, want locator-change refusal", err)
+	}
+}
+
 func TestMaintainWakeSelfUpgradeUsesLiveProcessImageOverRecordedEvidence(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)

--- a/internal/cli/wake_self_upgrade_unix_test.go
+++ b/internal/cli/wake_self_upgrade_unix_test.go
@@ -171,6 +171,34 @@ func TestCaptureWakeSelfUpgradeStartupStateDoesNotLosePreCaptureFlip(t *testing.
 	}
 }
 
+func TestProbeWakeSelfUpgradeLocatorRevalidatesUnresolvedOwner(t *testing.T) {
+	dir := t.TempDir()
+	target := writeWakeSelfUpgradeCandidate(t, dir, "candidate")
+	locator := filepath.Join(dir, "amq")
+	if err := os.Symlink(target, locator); err != nil {
+		t.Fatal(err)
+	}
+
+	previousCurrentUID := wakeTargetCurrentUID
+	previousOwnerUID := wakeTargetFileOwnerUID
+	previousEval := wakeSelfUpgradeEvalSymlinks
+	wakeTargetCurrentUID = func() (int, bool) { return 1000, true }
+	wakeTargetFileOwnerUID = func(os.FileInfo) (int, bool) { return 2000, true }
+	wakeSelfUpgradeEvalSymlinks = func(string) (string, error) {
+		t.Fatal("unsafe unresolved locator was followed")
+		return "", nil
+	}
+	t.Cleanup(func() {
+		wakeTargetCurrentUID = previousCurrentUID
+		wakeTargetFileOwnerUID = previousOwnerUID
+		wakeSelfUpgradeEvalSymlinks = previousEval
+	})
+
+	if _, err := probeWakeSelfUpgradeLocator(locator); err == nil || !strings.Contains(err.Error(), "owned by uid") {
+		t.Fatalf("probe error=%v, want unresolved-owner refusal", err)
+	}
+}
+
 func TestMaintainWakeSelfUpgradeUsesLiveProcessImageOverRecordedEvidence(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)
@@ -250,6 +278,38 @@ func TestMaintainWakeSelfUpgradeRetriesTransientVersionFailure(t *testing.T) {
 	decision, err = maintainWakeSelfUpgrade(&state, fixture.agentDir, fixture.lock)
 	if err != nil || decision.Action != wakeSelfUpgradeActionPrefilterRefused || attempts != 2 {
 		t.Fatalf("retry decision=%#v attempts=%d err=%v", decision, attempts, err)
+	}
+}
+
+func TestMaintainWakeSelfUpgradeRetriesCandidateAfterForeignRecordClears(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	foreign := fixture.record
+	foreign.Source = wakeRestartSourceForeign
+	writeWakeCheckSelfUpgradeRestartRecord(t, fixture, foreign)
+
+	candidate := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate")
+	state := selfUpgradeStateForCandidate(t, candidate)
+	initialProbe := state.lastProbe
+	stubWakeSelfUpgradeVersion(t, "0.57.0")
+
+	decision, err := maintainWakeSelfUpgrade(&state, fixture.agentDir, fixture.lock)
+	if err != nil || decision.Action != wakeSelfUpgradeActionRestartPending {
+		t.Fatalf("foreign-record decision=%#v err=%v", decision, err)
+	}
+	if state.lastProbe != initialProbe {
+		t.Fatal("foreign restart record advanced the probe baseline")
+	}
+	removeWakeRestartRecordForTest(t, fixture)
+
+	decision, err = maintainWakeSelfUpgrade(&state, fixture.agentDir, fixture.lock)
+	if err != nil || decision.Action != wakeSelfUpgradeActionPending {
+		t.Fatalf("cleared-record decision=%#v err=%v", decision, err)
+	}
+	installed := readWakeSelfUpgradeRestartRecord(t, fixture)
+	installedCandidate := wakeSelfUpgradeCandidateFromEvidence(installed.Candidate)
+	if installed.Source != wakeRestartSourceSelf || decision.Candidate == nil ||
+		*installedCandidate != *decision.Candidate {
+		t.Fatalf("published record=%#v decision=%#v", installed, decision)
 	}
 }
 


### PR DESCRIPTION
## Summary

- recover a durably published self-upgrade request before re-probing a replaced or missing launch locator, including across quiescence deferral
- keep failed refusal persistence fail-static through transient lock-read failures, and retire debt without re-executing after authoritative lock loss or replacement
- close the launch-locator resolution race by revalidating the no-follow locator identity after symlink resolution
- reject claimed-successor records in incumbent execution paths and preserve mismatched restart authority byte-for-byte
- prove v0.58.0 reads the new self record without mutation; document the actual self-reported-version and one-slot refusal-memory contract

## Exact review identity

- Base: `73574dced279387efe149536390cd5bae4237e7b`
- Head: `262d9ef9316f924a14e86161bc2ab082870d1c64`
- Tree: `da7f8a930e8a10a23248aad99a450fa56250af4c`
- Binary diff SHA-256 (`git diff --binary base...head`): `3b2e3a37e7a91e5ee4dd370f8509ed670f6e7fcef878c09b0a1c719ba02451ce`

## Validation

- `make ci` — PASS at exact head
- focused recovery/authority regression suite under `go test -race ./internal/cli` — PASS
- full self-upgrade suite: `go test -race ./internal/cli -run 'WakeSelfUpgrade' -count=1` — PASS
- non-skippable v0.58.0 compatibility gate: `go test -race ./internal/cli -run '^TestWakeSelfUpgradeRestartRecordIsCompatibleWithV0580Reader$' -count=1` — PASS
- Darwin arm64, Go 1.26.5

## Review and release gate

- Claude settled-delta review: APPROVED before the latest Pro findings; exact-tip Pro rerun remains the final external review gate
- independent source review: PASS
- independent test/mutation audit: PASS
- independent simplification/concurrency review: PASS
- hosted checks: running for the exact head
- exact-head Pro delta rerun: pending; merge remains blocked on GO and hosted checks

## Residual contract

Candidates are ordered by their self-reported semantic version. Refusal memory is at most once for the current candidate until a different candidate is observed; multi-candidate A→B→A memory requires a deliberate schema/retention contract and is tracked by `agent-message-queue-0jj.12`.

Bead: `agent-message-queue-0jj.11`

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestWakeSelfUpgradeRestartRecordIsCompatibleWithV0573Reader: renamed to the V0580 reader because the compatibility baseline now exercises the exact v0.58.0 release; the read-and-no-mutation assertion is unchanged.
END_WAKE_TEST_CHANGE_JUSTIFICATION
