### PR TITLE
feat(wake): retain bounded self-upgrade refusal memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,9 @@ Resume-eligible wakes started by `coop exec` also follow the stable AMQ launch
 symlink. When an installer atomically points that locator at a strictly newer
 self-reported semantic version, the wake waits for a fully quiescent delivery
 boundary and replaces its image without changing PID, terminal ownership, or unread work.
-Failed candidates are attempted at most once until a different candidate is
-observed; observing a new candidate resets that refusal memory.
+Failed candidates are attempted at most once per candidate within a wake
+generation, bounded to the 8 most recent distinct candidates. A new wake
+generation resets that refusal memory.
 Pinned binaries, ownerless/keepalive wakes, repair flows, destructive
 interrupts, and arbitrary inject commands never self-upgrade. Disable the
 eligible default with `amq wake --no-self-upgrade` or

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"syscall"
 	"time"
@@ -41,20 +42,21 @@ const (
 )
 
 type wakeRestartRecord struct {
-	Schema              int                  `json:"schema"`
-	Source              string               `json:"source,omitempty"`
-	RequestID           string               `json:"request_id"`
-	Status              string               `json:"status"`
-	Root                string               `json:"root"`
-	Agent               string               `json:"agent"`
-	Generation          string               `json:"generation"`
-	SuccessorGeneration string               `json:"successor_generation,omitempty"`
-	Owner               wakeOwner            `json:"owner"`
-	Candidate           wakeImageEvidenceV1  `json:"candidate"`
-	StagePath           string               `json:"stage_path,omitempty"`
-	BoundImage          *wakeImageEvidenceV1 `json:"bound_image,omitempty"`
-	PreviousBoundImage  *wakeImageEvidenceV1 `json:"previous_bound_image,omitempty"`
-	Reason              string               `json:"reason,omitempty"`
+	Schema              int                               `json:"schema"`
+	Source              string                            `json:"source,omitempty"`
+	RequestID           string                            `json:"request_id"`
+	Status              string                            `json:"status"`
+	Root                string                            `json:"root"`
+	Agent               string                            `json:"agent"`
+	Generation          string                            `json:"generation"`
+	SuccessorGeneration string                            `json:"successor_generation,omitempty"`
+	Owner               wakeOwner                         `json:"owner"`
+	Candidate           wakeImageEvidenceV1               `json:"candidate"`
+	StagePath           string                            `json:"stage_path,omitempty"`
+	BoundImage          *wakeImageEvidenceV1              `json:"bound_image,omitempty"`
+	PreviousBoundImage  *wakeImageEvidenceV1              `json:"previous_bound_image,omitempty"`
+	RefusedCandidates   []wakeSelfUpgradeRefusedCandidate `json:"refused_candidates,omitempty"`
+	Reason              string                            `json:"reason,omitempty"`
 }
 
 type wakeResumeBootstrap struct {
@@ -419,17 +421,22 @@ func sameOptionalWakeImageEvidence(first, second *wakeImageEvidenceV1) bool {
 }
 
 func sameWakeRestartRecord(first, second wakeRestartRecord) bool {
+	if !sameWakeSelfUpgradeRefusedCandidates(first.RefusedCandidates, second.RefusedCandidates) {
+		return false
+	}
 	if !sameOptionalWakeImageEvidence(first.BoundImage, second.BoundImage) {
 		return false
 	}
 	if !sameOptionalWakeImageEvidence(first.PreviousBoundImage, second.PreviousBoundImage) {
 		return false
 	}
+	first.RefusedCandidates = nil
+	second.RefusedCandidates = nil
 	first.BoundImage = nil
 	second.BoundImage = nil
 	first.PreviousBoundImage = nil
 	second.PreviousBoundImage = nil
-	return first == second
+	return reflect.DeepEqual(first, second)
 }
 
 type wakeRestartPendingDisposition uint8
@@ -608,6 +615,9 @@ func validateWakeRestartRecord(record wakeRestartRecord) error {
 	}
 	if err := validateWakeImageEvidence(record.Candidate); err != nil {
 		return fmt.Errorf("wake restart candidate is invalid: %w", err)
+	}
+	if err := validateWakeSelfUpgradeRefusedCandidates(record); err != nil {
+		return err
 	}
 	if err := validateWakeRestartStageStatePlatform(record); err != nil {
 		return fmt.Errorf("wake restart stage state is invalid: %w", err)
@@ -856,6 +866,12 @@ func refuseWakeRestartRecordAt(
 		!sameWakeRestartAttemptIdentity(expected, current) {
 		return fmt.Errorf("wake restart request changed before refusal")
 	}
+	if current.Source == wakeRestartSourceSelf {
+		current.RefusedCandidates = rememberWakeSelfUpgradeRefusal(
+			current.RefusedCandidates,
+			current.Candidate,
+		)
+	}
 	current.Status = wakeRestartRefused
 	current.Reason = wakeRestartReasonWithRemedy(reason, current.Root, current.Agent)
 	return writeWakeRestartRecordAt(dirfd, agentDir, current)
@@ -871,7 +887,26 @@ func sameWakeRestartAttemptIdentity(expected, current wakeRestartRecord) bool {
 		sameWakeOwner(&expected.Owner, &current.Owner) &&
 		sameWakeSelfUpgradeCandidateIdentity(expected.Candidate, current.Candidate) &&
 		expected.StagePath == current.StagePath &&
+		sameWakeSelfUpgradeAttemptRefusalMemory(expected, current) &&
 		sameOptionalWakeImageEvidence(expected.PreviousBoundImage, current.PreviousBoundImage)
+}
+
+func sameWakeSelfUpgradeAttemptRefusalMemory(expected, current wakeRestartRecord) bool {
+	if sameWakeSelfUpgradeRefusedCandidates(
+		expected.RefusedCandidates,
+		current.RefusedCandidates,
+	) {
+		return true
+	}
+	if expected.Source != wakeRestartSourceSelf ||
+		expected.Status != wakeRestartPending ||
+		current.Status != wakeRestartRefused {
+		return false
+	}
+	return sameWakeSelfUpgradeRefusedCandidates(
+		rememberWakeSelfUpgradeRefusal(expected.RefusedCandidates, expected.Candidate),
+		current.RefusedCandidates,
+	)
 }
 
 func retryWakeSelfUpgradeRefusal(

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -185,7 +185,6 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 	defer func() { _ = agentDir.Close() }()
 
 	var expected wakeLockInspection
-	var creatorSnapshot wakeRestartRecordSnapshot
 	adopted := false
 	needsNotify := true
 	record := wakeRestartRecord{
@@ -288,7 +287,6 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 			if !created || !sameWakeRestartRecord(createdSnapshot.Record, record) {
 				return fmt.Errorf("wake restart request changed after creation")
 			}
-			creatorSnapshot = createdSnapshot
 		}
 		current := inspectWakeLockAt(dirfd, agentDir, root, me)
 		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
@@ -305,9 +303,6 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 
 	if needsNotify {
 		if err := wakeRestartNotify(agentDir, expected, record); err != nil {
-			if !adopted {
-				_ = refuseWakeRestartCreatorSnapshot(agentDir, creatorSnapshot, err.Error())
-			}
 			result.Reason = err.Error()
 			return result, err
 		}
@@ -965,37 +960,6 @@ func retryWakeSelfUpgradeRefusal(
 		return persistErr
 	})
 	return resolved, persisted, continueObservation, returnErr
-}
-
-func refuseWakeRestartCreatorSnapshot(
-	agentDir *wakeAgentDir,
-	expected wakeRestartRecordSnapshot,
-	reason string,
-) error {
-	reason = strings.TrimSpace(reason)
-	if reason == "" {
-		reason = "restart refused"
-	}
-	if expected.Record.Schema != wakeRestartSchemaV1 ||
-		expected.Record.Status != wakeRestartPending {
-		return fmt.Errorf("created wake restart snapshot is not pending schema 1")
-	}
-	return withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
-		current, exists, err := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
-		if err != nil || !exists {
-			return err
-		}
-		if current.Record.Schema != wakeRestartSchemaV1 ||
-			current.Record.Status != wakeRestartPending ||
-			!sameWakeRestartObjectSnapshot(expected, current) ||
-			!sameWakeRestartRecord(expected.Record, current.Record) {
-			return fmt.Errorf("created wake restart request changed before refusal")
-		}
-		refused := current.Record
-		refused.Status = wakeRestartRefused
-		refused.Reason = wakeRestartReasonWithRemedy(reason, refused.Root, refused.Agent)
-		return writeWakeRestartRecordAt(dirfd, agentDir, refused)
-	})
 }
 
 func encodeWakeResumeBootstrap(value wakeResumeBootstrap) (string, error) {

--- a/internal/cli/wake_restart_unix_test.go
+++ b/internal/cli/wake_restart_unix_test.go
@@ -402,6 +402,127 @@ func TestWakeRestartJoinsClaimedSuccessorWithoutRenotifying(t *testing.T) {
 	}
 }
 
+func TestWakeRestartCreatorNotifyFailurePreservesAdoptedPendingRecord(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+
+	type restartOutcome struct {
+		result wakeRestartResult
+		err    error
+	}
+
+	creatorNotifyStarted := make(chan struct{})
+	adopterNotified := make(chan struct{})
+	var releaseCreator sync.Once
+	var published wakeRestartRecord
+	var notifyCalls atomic.Int32
+	var preflightCalls atomic.Int32
+	var nowCalls atomic.Int32
+	creatorNotifyErr := errors.New("injected creator notification failure")
+
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	oldNow := wakeRestartNow
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		preflightCalls.Add(1)
+		return nil
+	}
+	wakeRestartNotify = func(
+		_ *wakeAgentDir,
+		_ wakeLockInspection,
+		record wakeRestartRecord,
+	) error {
+		switch notifyCalls.Add(1) {
+		case 1:
+			published = record
+			close(creatorNotifyStarted)
+			<-adopterNotified
+			return creatorNotifyErr
+		case 2:
+			defer releaseCreator.Do(func() { close(adopterNotified) })
+			if record.Schema != wakeRestartSchemaV1 ||
+				record.Status != wakeRestartPending ||
+				!sameWakeRestartRecord(record, published) {
+				return fmt.Errorf("adopter notification record = %#v, want published schema-1 pending record %#v", record, published)
+			}
+			return nil
+		default:
+			return errors.New("restart request notified more than twice")
+		}
+	}
+	baseNow := time.Unix(1_700_000_000, 0)
+	wakeRestartNow = func() time.Time {
+		if nowCalls.Add(1) == 1 {
+			return baseNow
+		}
+		return baseNow.Add(wakeRestartWaitTimeout + time.Second)
+	}
+	t.Cleanup(func() {
+		releaseCreator.Do(func() { close(adopterNotified) })
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+		wakeRestartNow = oldNow
+	})
+
+	creatorDone := make(chan restartOutcome, 1)
+	go func() {
+		result, err := requestWakeRestart(fixture.root, fixture.agent)
+		creatorDone <- restartOutcome{result: result, err: err}
+	}()
+	select {
+	case <-creatorNotifyStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("creator did not publish and reach notification within 5s")
+	}
+
+	adopterDone := make(chan restartOutcome, 1)
+	go func() {
+		result, err := requestWakeRestart(fixture.root, fixture.agent)
+		adopterDone <- restartOutcome{result: result, err: err}
+	}()
+
+	wait := func(label string, done <-chan restartOutcome) restartOutcome {
+		t.Helper()
+		select {
+		case outcome := <-done:
+			return outcome
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s did not finish within 5s", label)
+			return restartOutcome{}
+		}
+	}
+	creator := wait("creator", creatorDone)
+	adopter := wait("adopter", adopterDone)
+	if !errors.Is(creator.err, creatorNotifyErr) {
+		t.Fatalf("creator outcome: result=%#v err=%v, want notification failure", creator.result, creator.err)
+	}
+	if adopter.err == nil || !strings.Contains(adopter.err.Error(), "did not complete") {
+		t.Fatalf("adopter outcome: result=%#v err=%v, want bounded wait timeout", adopter.result, adopter.err)
+	}
+	if preflightCalls.Load() != 1 || notifyCalls.Load() != 2 {
+		t.Fatalf(
+			"concurrent creator/adopter preflights=%d notifications=%d, want 1 and 2",
+			preflightCalls.Load(),
+			notifyCalls.Load(),
+		)
+	}
+
+	var current wakeRestartRecord
+	var exists bool
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		var readErr error
+		current, exists, readErr = readWakeRestartRecordAt(dirfd, fixture.agentDir)
+		return readErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !exists || current.Schema != wakeRestartSchemaV1 ||
+		current.Status != wakeRestartPending ||
+		!sameWakeRestartRecord(current, published) {
+		t.Fatalf("restart record after creator failure = %#v, exists=%v; want unchanged published pending record %#v", current, exists, published)
+	}
+}
+
 func TestConcurrentWakeRestartCallersJoinSuccessorThroughReadinessCommit(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	bound := boundWakeImageEvidenceForTest(fixture.candidate)

--- a/internal/cli/wake_restart_unix_test.go
+++ b/internal/cli/wake_restart_unix_test.go
@@ -1319,7 +1319,7 @@ func TestWakeRestartAdoptsPendingCurrentGenerationAndRenotifies(t *testing.T) {
 		if readErr != nil {
 			return readErr
 		}
-		if !exists || current != pending {
+		if !exists || !sameWakeRestartRecord(current, pending) {
 			return errors.New("pending restart record changed")
 		}
 		return nil

--- a/internal/cli/wake_self_upgrade_flow_unix_test.go
+++ b/internal/cli/wake_self_upgrade_flow_unix_test.go
@@ -36,6 +36,8 @@ func TestWakeSelfUpgradeRefusalMemoryBlocksABARetryWithinGeneration(t *testing.T
 	previousBoundPreflight := wakeRestartBoundPreflight
 	previousNotify := wakeRestartNotify
 	previousExec := wakeRestartExec
+	previousSync := syncWakeOwnerDirFD
+	supersedingFailurePhase := ""
 	wakeRestartBind = func(record wakeRestartRecord) (*wakeRestartBoundImage, error) {
 		switch {
 		case sameWakeSelfUpgradeCandidateIdentity(record.Candidate, evidenceA):
@@ -59,11 +61,39 @@ func TestWakeSelfUpgradeRefusalMemoryBlocksABARetryWithinGeneration(t *testing.T
 		execs++
 		return errors.New("unexpected exec")
 	}
+	syncWakeOwnerDirFD = func(fd int) error {
+		if supersedingFailurePhase != "" {
+			entries, err := os.ReadDir(fixture.agentDir.path)
+			if err != nil {
+				return err
+			}
+			tempPresent := false
+			for _, entry := range entries {
+				if strings.HasPrefix(entry.Name(), ".wake.restart.tmp.") {
+					tempPresent = true
+					break
+				}
+			}
+			if supersedingFailurePhase == "pre-install" && tempPresent {
+				supersedingFailurePhase = ""
+				return errors.New("test superseding pre-install failure")
+			}
+			if supersedingFailurePhase == "post-rename" && !tempPresent {
+				raw, readErr := os.ReadFile(filepath.Join(fixture.agentDir.path, wakeRestartFileName))
+				if readErr == nil && strings.Contains(string(raw), evidenceB.SHA256) {
+					supersedingFailurePhase = ""
+					return errors.New("test superseding post-rename failure")
+				}
+			}
+		}
+		return previousSync(fd)
+	}
 	t.Cleanup(func() {
 		wakeRestartBind = previousBind
 		wakeRestartBoundPreflight = previousBoundPreflight
 		wakeRestartNotify = previousNotify
 		wakeRestartExec = previousExec
+		syncWakeOwnerDirFD = previousSync
 	})
 
 	cfg := wakeConfig{
@@ -110,12 +140,80 @@ func TestWakeSelfUpgradeRefusalMemoryBlocksABARetryWithinGeneration(t *testing.T
 	if binds["a"] != 1 || binds["b"] != 0 || preflights != 0 || notifies != 0 || execs != 0 {
 		t.Fatalf("A attempt counters: bind=%v preflight=%d notify=%d exec=%d", binds, preflights, notifies, execs)
 	}
+	refusedA := readWakeSelfUpgradeRestartRecord(t, fixture)
+	beforeSupersession := quarantineCount()
 	replaceWakeSelfUpgradeLocator(t, cfg.selfUpgrade.Locator, candidateB)
+	supersedingFailurePhase = "pre-install"
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err == nil || !strings.Contains(err.Error(), "test superseding pre-install failure") {
+		t.Fatalf("superseding publication failure = %v", err)
+	}
+	if supersedingFailurePhase != "" {
+		t.Fatal("superseding publication failure was not injected")
+	}
+	if binds["a"] != 1 || binds["b"] != 0 || quarantineCount() != beforeSupersession {
+		t.Fatalf("failed B publication changed execution or quarantine: bind=%v quarantine=%d", binds, quarantineCount())
+	}
+	if got := readWakeSelfUpgradeRestartRecord(t, fixture); !sameWakeRestartRecord(got, refusedA) {
+		t.Fatalf("failed B publication lost A refusal: got=%#v want=%#v", got, refusedA)
+	}
+
+	supersedingFailurePhase = "post-rename"
+	if err := maintainWakeSelfUpgradeAtLoopBoundary(
+		&cfg,
+		fixture.agentDir,
+		watcher,
+		false,
+		false,
+	); err == nil || !strings.Contains(err.Error(), "test superseding post-rename failure") {
+		t.Fatalf("superseding post-rename failure = %v", err)
+	}
+	if supersedingFailurePhase != "" {
+		t.Fatal("superseding post-rename failure was not injected")
+	}
+	freshAgentDir, err := openWakeAgentDir(fixture.root, fixture.agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = freshAgentDir.Close() }()
+	var persistedB wakeRestartRecord
+	if err := freshAgentDir.withFD(func(dirfd int) error {
+		var exists bool
+		var readErr error
+		persistedB, exists, readErr = readWakeRestartRecordAt(dirfd, freshAgentDir)
+		if readErr != nil {
+			return readErr
+		}
+		if !exists {
+			return os.ErrNotExist
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if persistedB.Status != wakeRestartPending ||
+		!sameWakeSelfUpgradeCandidateIdentity(persistedB.Candidate, evidenceB) ||
+		len(persistedB.RefusedCandidates) != 1 ||
+		!wakeSelfUpgradeRefusedCandidatesContain(persistedB.RefusedCandidates, evidenceA) {
+		t.Fatalf("fresh read after B post-rename failure = %#v", persistedB)
+	}
+	if quarantineCount() != beforeSupersession {
+		t.Fatalf("post-rename B publication grew quarantine: before=%d after=%d", beforeSupersession, quarantineCount())
+	}
+
 	tick()
 	if binds["a"] != 1 || binds["b"] != 1 || preflights != 0 || notifies != 0 || execs != 0 {
 		t.Fatalf("B attempt counters: bind=%v preflight=%d notify=%d exec=%d", binds, preflights, notifies, execs)
 	}
 	beforeRememberedA := quarantineCount()
+	if beforeRememberedA != beforeSupersession {
+		t.Fatalf("same-scope A to B supersession grew quarantine: before=%d after=%d", beforeSupersession, beforeRememberedA)
+	}
 	refusedB := readWakeSelfUpgradeRestartRecord(t, fixture)
 	if refusedB.Status != wakeRestartRefused ||
 		!sameWakeSelfUpgradeCandidateIdentity(refusedB.Candidate, evidenceB) ||

--- a/internal/cli/wake_self_upgrade_flow_unix_test.go
+++ b/internal/cli/wake_self_upgrade_flow_unix_test.go
@@ -11,6 +11,137 @@ import (
 	"testing"
 )
 
+func TestWakeSelfUpgradeRefusalMemoryBlocksABARetryWithinGeneration(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	dir := t.TempDir()
+	candidateA := writeWakeSelfUpgradeCandidate(t, dir, "candidate-a")
+	candidateB := writeWakeSelfUpgradeCandidate(t, dir, "candidate-b")
+	state := selfUpgradeStateForCandidate(t, candidateA)
+	stubWakeSelfUpgradeVersion(t, "9.9.9")
+	evidenceA, err := captureWakeImageEvidence(candidateA, "9.9.9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidenceB, err := captureWakeImageEvidence(candidateB, "9.9.9")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binds := map[string]int{}
+	preflights := 0
+	notifies := 0
+	execs := 0
+	previousBind := wakeRestartBind
+	previousBoundPreflight := wakeRestartBoundPreflight
+	previousNotify := wakeRestartNotify
+	previousExec := wakeRestartExec
+	wakeRestartBind = func(record wakeRestartRecord) (*wakeRestartBoundImage, error) {
+		switch {
+		case sameWakeSelfUpgradeCandidateIdentity(record.Candidate, evidenceA):
+			binds["a"]++
+		case sameWakeSelfUpgradeCandidateIdentity(record.Candidate, evidenceB):
+			binds["b"]++
+		default:
+			t.Fatalf("bound unexpected candidate: %#v", record.Candidate)
+		}
+		return nil, errors.New("test candidate refusal")
+	}
+	wakeRestartBoundPreflight = func(*wakeRestartBoundImage, []string, wakeResumeBootstrap) error {
+		preflights++
+		return errors.New("unexpected preflight")
+	}
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		notifies++
+		return errors.New("unexpected notify")
+	}
+	wakeRestartExec = func(string, []string, []string) error {
+		execs++
+		return errors.New("unexpected exec")
+	}
+	t.Cleanup(func() {
+		wakeRestartBind = previousBind
+		wakeRestartBoundPreflight = previousBoundPreflight
+		wakeRestartNotify = previousNotify
+		wakeRestartExec = previousExec
+	})
+
+	cfg := wakeConfig{
+		me:                   fixture.agent,
+		root:                 fixture.root,
+		injectMode:           wakeInjectModeNone,
+		wakeOwner:            &fixture.owner,
+		terminalGeneration:   fixture.lock.Lock.Generation,
+		terminalImageVersion: fixture.lock.Lock.ImageVersion,
+		retainedAgent:        fixture.agentDir,
+		retainedInbox:        fixture.inboxDir,
+		selfUpgrade:          state,
+		inspectTerminalGeneration: func() wakeLockInspection {
+			return inspectWakeLock(fixture.root, fixture.agent)
+		},
+		restartSignals: make(chan os.Signal, 1),
+	}
+	watcher := fixedWakeAdmissionWatcher{errors: make(chan error)}
+	tick := func() {
+		t.Helper()
+		if err := maintainWakeSelfUpgradeAtLoopBoundary(
+			&cfg,
+			fixture.agentDir,
+			watcher,
+			false,
+			false,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	quarantineCount := func() int {
+		t.Helper()
+		paths, err := filepath.Glob(filepath.Join(
+			fixture.agentDir.path,
+			wakeRestartFileName+".quarantined.*",
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(paths)
+	}
+
+	tick()
+	if binds["a"] != 1 || binds["b"] != 0 || preflights != 0 || notifies != 0 || execs != 0 {
+		t.Fatalf("A attempt counters: bind=%v preflight=%d notify=%d exec=%d", binds, preflights, notifies, execs)
+	}
+	replaceWakeSelfUpgradeLocator(t, cfg.selfUpgrade.Locator, candidateB)
+	tick()
+	if binds["a"] != 1 || binds["b"] != 1 || preflights != 0 || notifies != 0 || execs != 0 {
+		t.Fatalf("B attempt counters: bind=%v preflight=%d notify=%d exec=%d", binds, preflights, notifies, execs)
+	}
+	beforeRememberedA := quarantineCount()
+	refusedB := readWakeSelfUpgradeRestartRecord(t, fixture)
+	if refusedB.Status != wakeRestartRefused ||
+		!sameWakeSelfUpgradeCandidateIdentity(refusedB.Candidate, evidenceB) ||
+		len(refusedB.RefusedCandidates) != 2 ||
+		!wakeSelfUpgradeRefusedCandidatesContain(refusedB.RefusedCandidates, evidenceA) ||
+		!wakeSelfUpgradeRefusedCandidatesContain(refusedB.RefusedCandidates, evidenceB) {
+		t.Fatalf("B refusal memory = %#v", refusedB)
+	}
+
+	replaceWakeSelfUpgradeLocator(t, cfg.selfUpgrade.Locator, candidateA)
+	tick()
+	if binds["a"] != 1 || binds["b"] != 1 || preflights != 0 || notifies != 0 || execs != 0 {
+		t.Fatalf("remembered A was executed: bind=%v preflight=%d notify=%d exec=%d", binds, preflights, notifies, execs)
+	}
+	if got := quarantineCount(); got != beforeRememberedA {
+		t.Fatalf("remembered A grew quarantine: before=%d after=%d", beforeRememberedA, got)
+	}
+	if got := readWakeSelfUpgradeRestartRecord(t, fixture); !sameWakeRestartRecord(got, refusedB) {
+		t.Fatalf("remembered A churned active refusal: got=%#v want=%#v", got, refusedB)
+	}
+	tick()
+	if binds["a"] != 1 || binds["b"] != 1 || quarantineCount() != beforeRememberedA {
+		t.Fatalf("unchanged remembered A churned state: bind=%v quarantine=%d", binds, quarantineCount())
+	}
+}
+
 func TestWakeSelfUpgradeQuiescenceDefersThenRetries(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)

--- a/internal/cli/wake_self_upgrade_mixed_version_unix_test.go
+++ b/internal/cli/wake_self_upgrade_mixed_version_unix_test.go
@@ -18,6 +18,11 @@ func TestWakeSelfUpgradeRestartRecordIsCompatibleWithV0580Reader(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	record := fixture.record
 	record.Source = wakeRestartSourceSelf
+	prior := record.Candidate
+	prior.Inode++
+	record.RefusedCandidates = []wakeSelfUpgradeRefusedCandidate{
+		wakeSelfUpgradeRefusedCandidateFromEvidence(prior),
+	}
 	raw, err := json.Marshal(record)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/wake_self_upgrade_unix.go
+++ b/internal/cli/wake_self_upgrade_unix.go
@@ -20,6 +20,7 @@ const (
 	wakeSelfUpgradeFileName       = ".wake.selfupgrade"
 	wakeSelfUpgradeSchemaV1       = 1
 	wakeSelfUpgradeVersionTimeout = 5 * time.Second
+	wakeSelfUpgradeRefusalLimit   = 8
 
 	wakeSelfUpgradeActionDisabled         = "disabled"
 	wakeSelfUpgradeActionIneligible       = "ineligible"
@@ -63,6 +64,18 @@ type wakeSelfUpgradeCandidate struct {
 	Version  string           `json:"version"`
 }
 
+// wakeSelfUpgradeRefusedCandidate is the path-free identity used by the
+// generation-scoped refusal memory in .wake.restart. Execution paths, methods,
+// and ctimes are deliberately excluded because Darwin binding changes them.
+type wakeSelfUpgradeRefusedCandidate struct {
+	Platform        string `json:"platform"`
+	Device          uint64 `json:"device"`
+	Inode           uint64 `json:"inode"`
+	Size            int64  `json:"size"`
+	SHA256          string `json:"sha256"`
+	EmbeddedVersion string `json:"embedded_version"`
+}
+
 func wakeSelfUpgradeCandidateFromEvidence(evidence wakeImageEvidenceV1) *wakeSelfUpgradeCandidate {
 	return &wakeSelfUpgradeCandidate{
 		Identity: wakeFileIdentity{
@@ -73,6 +86,116 @@ func wakeSelfUpgradeCandidateFromEvidence(evidence wakeImageEvidenceV1) *wakeSel
 		},
 		Version: evidence.EmbeddedVersion,
 	}
+}
+
+func wakeSelfUpgradeRefusedCandidateFromEvidence(evidence wakeImageEvidenceV1) wakeSelfUpgradeRefusedCandidate {
+	return wakeSelfUpgradeRefusedCandidate{
+		Platform:        evidence.Platform,
+		Device:          evidence.Device,
+		Inode:           evidence.Inode,
+		Size:            evidence.Size,
+		SHA256:          evidence.SHA256,
+		EmbeddedVersion: evidence.EmbeddedVersion,
+	}
+}
+
+func sameWakeSelfUpgradeRefusedCandidates(
+	first, second []wakeSelfUpgradeRefusedCandidate,
+) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for index := range first {
+		if first[index] != second[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func wakeSelfUpgradeRefusedCandidatesContain(
+	candidates []wakeSelfUpgradeRefusedCandidate,
+	evidence wakeImageEvidenceV1,
+) bool {
+	want := wakeSelfUpgradeRefusedCandidateFromEvidence(evidence)
+	for _, candidate := range candidates {
+		if candidate == want {
+			return true
+		}
+	}
+	return false
+}
+
+// rememberWakeSelfUpgradeRefusal appends the current identity as the most
+// recent distinct refusal and retains at most the eight most recent entries.
+func rememberWakeSelfUpgradeRefusal(
+	candidates []wakeSelfUpgradeRefusedCandidate,
+	evidence wakeImageEvidenceV1,
+) []wakeSelfUpgradeRefusedCandidate {
+	current := wakeSelfUpgradeRefusedCandidateFromEvidence(evidence)
+	remembered := make([]wakeSelfUpgradeRefusedCandidate, 0, len(candidates)+1)
+	for _, candidate := range candidates {
+		if candidate != current {
+			remembered = append(remembered, candidate)
+		}
+	}
+	remembered = append(remembered, current)
+	if len(remembered) > wakeSelfUpgradeRefusalLimit {
+		remembered = append(
+			[]wakeSelfUpgradeRefusedCandidate(nil),
+			remembered[len(remembered)-wakeSelfUpgradeRefusalLimit:]...,
+		)
+	}
+	return remembered
+}
+
+func wakeSelfUpgradeRefusalMemory(record wakeRestartRecord) []wakeSelfUpgradeRefusedCandidate {
+	remembered := append([]wakeSelfUpgradeRefusedCandidate(nil), record.RefusedCandidates...)
+	if record.Status == wakeRestartRefused && len(remembered) == 0 {
+		remembered = rememberWakeSelfUpgradeRefusal(remembered, record.Candidate)
+	}
+	return remembered
+}
+
+func validateWakeSelfUpgradeRefusedCandidates(record wakeRestartRecord) error {
+	if len(record.RefusedCandidates) == 0 {
+		return nil
+	}
+	if record.Source != wakeRestartSourceSelf {
+		return fmt.Errorf("wake restart refused candidates require a self-upgrade source")
+	}
+	if len(record.RefusedCandidates) > wakeSelfUpgradeRefusalLimit {
+		return fmt.Errorf(
+			"wake restart refused candidates exceed the limit of %d",
+			wakeSelfUpgradeRefusalLimit,
+		)
+	}
+	seen := make(map[wakeSelfUpgradeRefusedCandidate]struct{}, len(record.RefusedCandidates))
+	for _, candidate := range record.RefusedCandidates {
+		if candidate.Platform != record.Candidate.Platform || candidate.Device == 0 ||
+			candidate.Inode == 0 || candidate.Size <= 0 ||
+			!validWakeImageSHA256(candidate.SHA256) ||
+			strings.TrimSpace(candidate.EmbeddedVersion) == "" ||
+			candidate.EmbeddedVersion != strings.TrimSpace(candidate.EmbeddedVersion) ||
+			strings.ContainsRune(candidate.EmbeddedVersion, 0) {
+			return fmt.Errorf("wake restart refused candidate identity is invalid")
+		}
+		if _, exists := seen[candidate]; exists {
+			return fmt.Errorf("wake restart refused candidates contain a duplicate identity")
+		}
+		seen[candidate] = struct{}{}
+	}
+	containsCurrent := wakeSelfUpgradeRefusedCandidatesContain(
+		record.RefusedCandidates,
+		record.Candidate,
+	)
+	if record.Status == wakeRestartPending && containsCurrent {
+		return fmt.Errorf("pending wake restart candidate is already in refusal memory")
+	}
+	if record.Status == wakeRestartRefused && !containsCurrent {
+		return fmt.Errorf("refused wake restart candidate is missing from refusal memory")
+	}
+	return nil
 }
 
 type wakeSelfUpgradeDecision struct {
@@ -516,13 +639,16 @@ func publishWakeSelfUpgradePending(
 				decision.Reason = "an existing wake restart request is preserved"
 				return nil
 			case existing.Record.Status == wakeRestartRefused &&
-				existing.Record.Source == wakeRestartSourceSelf &&
-				sameWakeSelfUpgradeCandidateIdentity(existing.Record.Candidate, record.Candidate):
-				decision.Action = wakeSelfUpgradeActionRefusedMemory
-				decision.Reason = "candidate was already refused for this wake generation"
-				return nil
-			case existing.Record.Status == wakeRestartRefused &&
 				existing.Record.Source == wakeRestartSourceSelf:
+				if sameWakeSelfUpgradeRefusalScope(existing.Record, expected) {
+					remembered := wakeSelfUpgradeRefusalMemory(existing.Record)
+					if wakeSelfUpgradeRefusedCandidatesContain(remembered, record.Candidate) {
+						decision.Action = wakeSelfUpgradeActionRefusedMemory
+						decision.Reason = "candidate was already refused for this wake generation"
+						return nil
+					}
+					record.RefusedCandidates = remembered
+				}
 				if err := reclaimWakeRestartStagePlatform(existing.Record); err != nil {
 					return fmt.Errorf("reclaim superseded self-upgrade attempt: %w", err)
 				}
@@ -547,6 +673,25 @@ func publishWakeSelfUpgradePending(
 		return nil
 	})
 	return decision, err
+}
+
+func sameWakeSelfUpgradeRefusalScope(
+	record wakeRestartRecord,
+	expected wakeLockInspection,
+) bool {
+	return record.Schema == wakeRestartSchemaV1 &&
+		record.SuccessorGeneration == "" &&
+		record.Status == wakeRestartRefused &&
+		record.Source == wakeRestartSourceSelf &&
+		record.Root == expected.Root &&
+		record.Agent == expected.Agent &&
+		record.Generation == expected.Lock.Generation &&
+		expected.Lock.ResumeOwner != nil &&
+		sameWakeOwner(&record.Owner, expected.Lock.ResumeOwner) &&
+		sameOptionalWakeImageEvidence(
+			record.PreviousBoundImage,
+			previousDarwinWakeRestartStageForLock(expected.Lock),
+		)
 }
 
 // Darwin staging necessarily changes the candidate inode ctime and execution

--- a/internal/cli/wake_self_upgrade_unix.go
+++ b/internal/cli/wake_self_upgrade_unix.go
@@ -640,7 +640,8 @@ func publishWakeSelfUpgradePending(
 				return nil
 			case existing.Record.Status == wakeRestartRefused &&
 				existing.Record.Source == wakeRestartSourceSelf:
-				if sameWakeSelfUpgradeRefusalScope(existing.Record, expected) {
+				sameScope := sameWakeSelfUpgradeRefusalScope(existing.Record, expected)
+				if sameScope {
 					remembered := wakeSelfUpgradeRefusalMemory(existing.Record)
 					if wakeSelfUpgradeRefusedCandidatesContain(remembered, record.Candidate) {
 						decision.Action = wakeSelfUpgradeActionRefusedMemory
@@ -652,8 +653,10 @@ func publishWakeSelfUpgradePending(
 				if err := reclaimWakeRestartStagePlatform(existing.Record); err != nil {
 					return fmt.Errorf("reclaim superseded self-upgrade attempt: %w", err)
 				}
-				if _, err := quarantineWakeRestartRecordAt(dirfd, agentDir, existing); err != nil {
-					return fmt.Errorf("quarantine superseded self-upgrade attempt: %w", err)
+				if !sameScope {
+					if _, err := quarantineWakeRestartRecordAt(dirfd, agentDir, existing); err != nil {
+						return fmt.Errorf("quarantine superseded self-upgrade attempt: %w", err)
+					}
 				}
 			default:
 				decision.Action = wakeSelfUpgradeActionRestartPresent

--- a/internal/cli/wake_self_upgrade_unix_test.go
+++ b/internal/cli/wake_self_upgrade_unix_test.go
@@ -507,8 +507,8 @@ func TestPublishWakeSelfUpgradePendingCarriesLegacyRefusalMemory(t *testing.T) {
 		wakeSelfUpgradeRefusedCandidatesContain(installedB.RefusedCandidates, evidenceB) {
 		t.Fatalf("carried legacy refusal memory = %#v", installedB)
 	}
-	if got := quarantineCount(); got != 1 {
-		t.Fatalf("legacy A to B quarantine count=%d, want 1", got)
+	if got := quarantineCount(); got != 0 {
+		t.Fatalf("same-scope legacy A to B quarantine count=%d, want 0", got)
 	}
 	if err := refuseWakeRestartRecord(fixture.agentDir, installedB, "B failed"); err != nil {
 		t.Fatal(err)

--- a/internal/cli/wake_self_upgrade_unix_test.go
+++ b/internal/cli/wake_self_upgrade_unix_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -422,6 +423,314 @@ func TestMaintainWakeSelfUpgradeRefusedMemorySurvivesTicks(t *testing.T) {
 		return nil
 	}); err != nil {
 		t.Fatalf("refused memory did not survive ticks: %v", err)
+	}
+}
+
+func TestPublishWakeSelfUpgradePendingCarriesLegacyRefusalMemory(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	dir := t.TempDir()
+	pathA := writeWakeSelfUpgradeCandidate(t, dir, "candidate-a")
+	pathB := writeWakeSelfUpgradeCandidate(t, dir, "candidate-b")
+	evidenceA, err := captureWakeImageEvidence(pathA, "9.9.9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidenceB, err := captureWakeImageEvidence(pathB, "9.9.9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := wakeRestartRecord{
+		Schema:     wakeRestartSchemaV1,
+		Source:     wakeRestartSourceSelf,
+		RequestID:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Status:     wakeRestartRefused,
+		Root:       fixture.root,
+		Agent:      fixture.agent,
+		Generation: fixture.lock.Lock.Generation,
+		Owner:      fixture.owner,
+		Candidate:  evidenceA,
+		Reason:     "legacy refusal",
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, legacy)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	quarantineCount := func() int {
+		t.Helper()
+		paths, err := filepath.Glob(filepath.Join(
+			fixture.agentDir.path,
+			wakeRestartFileName+".quarantined.*",
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(paths)
+	}
+
+	sameA := legacy
+	sameA.RequestID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	sameA.Status = wakeRestartPending
+	sameA.Reason = ""
+	decision, err := publishWakeSelfUpgradePending(
+		fixture.agentDir,
+		fixture.lock,
+		sameA,
+		wakeSelfUpgradeDecision{},
+	)
+	if err != nil || decision.Action != wakeSelfUpgradeActionRefusedMemory {
+		t.Fatalf("legacy same-A decision=%#v err=%v", decision, err)
+	}
+	if got := quarantineCount(); got != 0 {
+		t.Fatalf("legacy same-A quarantine count=%d, want 0", got)
+	}
+	if got := readWakeSelfUpgradeRestartRecord(t, fixture); !sameWakeRestartRecord(got, legacy) {
+		t.Fatalf("legacy same-A changed active record: got=%#v want=%#v", got, legacy)
+	}
+
+	pendingB := sameA
+	pendingB.RequestID = "cccccccccccccccccccccccccccccccc"
+	pendingB.Candidate = evidenceB
+	decision, err = publishWakeSelfUpgradePending(
+		fixture.agentDir,
+		fixture.lock,
+		pendingB,
+		wakeSelfUpgradeDecision{},
+	)
+	if err != nil || decision.Action != wakeSelfUpgradeActionPending {
+		t.Fatalf("legacy A to B decision=%#v err=%v", decision, err)
+	}
+	installedB := readWakeSelfUpgradeRestartRecord(t, fixture)
+	if installedB.Status != wakeRestartPending || len(installedB.RefusedCandidates) != 1 ||
+		!wakeSelfUpgradeRefusedCandidatesContain(installedB.RefusedCandidates, evidenceA) ||
+		wakeSelfUpgradeRefusedCandidatesContain(installedB.RefusedCandidates, evidenceB) {
+		t.Fatalf("carried legacy refusal memory = %#v", installedB)
+	}
+	if got := quarantineCount(); got != 1 {
+		t.Fatalf("legacy A to B quarantine count=%d, want 1", got)
+	}
+	if err := refuseWakeRestartRecord(fixture.agentDir, installedB, "B failed"); err != nil {
+		t.Fatal(err)
+	}
+	refusedB := readWakeSelfUpgradeRestartRecord(t, fixture)
+	if len(refusedB.RefusedCandidates) != 2 ||
+		!wakeSelfUpgradeRefusedCandidatesContain(refusedB.RefusedCandidates, evidenceA) ||
+		!wakeSelfUpgradeRefusedCandidatesContain(refusedB.RefusedCandidates, evidenceB) {
+		t.Fatalf("B refusal memory = %#v", refusedB)
+	}
+}
+
+func TestPublishWakeSelfUpgradePendingResetsRefusalsForNewGeneration(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+	path := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate-a")
+	evidence, err := captureWakeImageEvidence(path, "9.9.9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := wakeRestartRecord{
+		Schema:     wakeRestartSchemaV1,
+		Source:     wakeRestartSourceSelf,
+		RequestID:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Status:     wakeRestartRefused,
+		Root:       fixture.root,
+		Agent:      fixture.agent,
+		Generation: fixture.lock.Lock.Generation,
+		Owner:      fixture.owner,
+		Candidate:  evidence,
+		RefusedCandidates: []wakeSelfUpgradeRefusedCandidate{
+			wakeSelfUpgradeRefusedCandidateFromEvidence(evidence),
+		},
+		Reason: "old generation refusal",
+	}
+	if err := fixture.agentDir.withFD(func(dirfd int) error {
+		return writeWakeRestartRecordAt(dirfd, fixture.agentDir, old)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	nextLock := fixture.lock.Lock
+	nextLock.Generation = "dddddddddddddddddddddddddddddddd"
+	writeWakeLockForTest(t, fixture.root, fixture.agent, nextLock)
+	nextInspection := inspectWakeLock(fixture.root, fixture.agent)
+	if !nextInspection.IdentityConfirmed || nextInspection.Lock.Generation != nextLock.Generation {
+		t.Fatalf("next-generation lock = %#v", nextInspection)
+	}
+	next := wakeRestartRecord{
+		Schema:     wakeRestartSchemaV1,
+		Source:     wakeRestartSourceSelf,
+		RequestID:  "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		Status:     wakeRestartPending,
+		Root:       fixture.root,
+		Agent:      fixture.agent,
+		Generation: nextLock.Generation,
+		Owner:      fixture.owner,
+		Candidate:  evidence,
+	}
+	decision, err := publishWakeSelfUpgradePending(
+		fixture.agentDir,
+		nextInspection,
+		next,
+		wakeSelfUpgradeDecision{},
+	)
+	if err != nil || decision.Action != wakeSelfUpgradeActionPending {
+		t.Fatalf("new-generation decision=%#v err=%v", decision, err)
+	}
+	installed := readWakeSelfUpgradeRestartRecord(t, fixture)
+	if installed.Generation != nextLock.Generation || len(installed.RefusedCandidates) != 0 {
+		t.Fatalf("new generation inherited refusal memory: %#v", installed)
+	}
+}
+
+func TestSameWakeSelfUpgradeRefusalScope(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	record.Status = wakeRestartRefused
+	record.Reason = "candidate refused"
+	record.PreviousBoundImage = previousDarwinWakeRestartStageForLock(fixture.lock.Lock)
+
+	if !sameWakeSelfUpgradeRefusalScope(record, fixture.lock) {
+		t.Fatal("matching refusal scope was rejected")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*wakeRestartRecord)
+	}{
+		{name: "root", mutate: func(record *wakeRestartRecord) { record.Root += "-other" }},
+		{name: "agent", mutate: func(record *wakeRestartRecord) { record.Agent = "claude" }},
+		{name: "generation", mutate: func(record *wakeRestartRecord) { record.Generation = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }},
+		{name: "owner", mutate: func(record *wakeRestartRecord) { record.Owner.SessionID++ }},
+		{name: "previous bound image", mutate: func(record *wakeRestartRecord) {
+			if record.PreviousBoundImage == nil {
+				changed := fixture.candidate
+				record.PreviousBoundImage = &changed
+				return
+			}
+			changed := *record.PreviousBoundImage
+			changed.Inode++
+			record.PreviousBoundImage = &changed
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mismatched := record
+			test.mutate(&mismatched)
+			if sameWakeSelfUpgradeRefusalScope(mismatched, fixture.lock) {
+				t.Fatal("mismatched refusal scope was accepted")
+			}
+		})
+	}
+}
+
+func TestRememberWakeSelfUpgradeRefusalRetainsEightMostRecentDistinct(t *testing.T) {
+	template := newWakeRestartFixture(t).candidate
+	var remembered []wakeSelfUpgradeRefusedCandidate
+	var evidence []wakeImageEvidenceV1
+	for index := 0; index < wakeSelfUpgradeRefusalLimit+2; index++ {
+		candidate := template
+		candidate.Inode = uint64(index + 1)
+		evidence = append(evidence, candidate)
+		remembered = rememberWakeSelfUpgradeRefusal(remembered, candidate)
+	}
+	if len(remembered) != wakeSelfUpgradeRefusalLimit {
+		t.Fatalf("remembered=%d, want %d", len(remembered), wakeSelfUpgradeRefusalLimit)
+	}
+	for _, evicted := range evidence[:2] {
+		if wakeSelfUpgradeRefusedCandidatesContain(remembered, evicted) {
+			t.Fatalf("old refusal was not evicted: %#v", evicted)
+		}
+	}
+	for _, retained := range evidence[2:] {
+		if !wakeSelfUpgradeRefusedCandidatesContain(remembered, retained) {
+			t.Fatalf("recent refusal was not retained: %#v", retained)
+		}
+	}
+	remembered = rememberWakeSelfUpgradeRefusal(remembered, evidence[2])
+	if len(remembered) != wakeSelfUpgradeRefusalLimit ||
+		remembered[len(remembered)-1] != wakeSelfUpgradeRefusedCandidateFromEvidence(evidence[2]) {
+		t.Fatalf("repeat refusal did not move to most recent: %#v", remembered)
+	}
+}
+
+func TestValidateWakeRestartRecordRefusedCandidates(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	record := fixture.record
+	record.Source = wakeRestartSourceSelf
+	current := wakeSelfUpgradeRefusedCandidateFromEvidence(record.Candidate)
+	prior := current
+	prior.Inode++
+
+	valid := record
+	valid.RefusedCandidates = []wakeSelfUpgradeRefusedCandidate{prior}
+	if err := validateWakeRestartRecord(valid); err != nil {
+		t.Fatalf("valid pending history: %v", err)
+	}
+	encoded, err := json.Marshal(valid.RefusedCandidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"execution_path", "method", "ctime"} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("path-free refusal identity contains %q: %s", forbidden, encoded)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*wakeRestartRecord)
+	}{
+		{
+			name: "foreign source",
+			mutate: func(record *wakeRestartRecord) {
+				record.Source = wakeRestartSourceForeign
+			},
+		},
+		{
+			name: "duplicate",
+			mutate: func(record *wakeRestartRecord) {
+				record.RefusedCandidates = append(record.RefusedCandidates, prior)
+			},
+		},
+		{
+			name: "over limit",
+			mutate: func(record *wakeRestartRecord) {
+				record.RefusedCandidates = nil
+				for index := 0; index <= wakeSelfUpgradeRefusalLimit; index++ {
+					candidate := prior
+					candidate.Inode = uint64(index + 1)
+					record.RefusedCandidates = append(record.RefusedCandidates, candidate)
+				}
+			},
+		},
+		{
+			name: "pending current candidate",
+			mutate: func(record *wakeRestartRecord) {
+				record.RefusedCandidates = []wakeSelfUpgradeRefusedCandidate{current}
+			},
+		},
+		{
+			name: "refused current missing",
+			mutate: func(record *wakeRestartRecord) {
+				record.Status = wakeRestartRefused
+				record.Reason = "test refusal"
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := valid
+			candidate.RefusedCandidates = append(
+				[]wakeSelfUpgradeRefusedCandidate(nil),
+				valid.RefusedCandidates...,
+			)
+			test.mutate(&candidate)
+			if err := validateWakeRestartRecord(candidate); err == nil {
+				t.Fatalf("validateWakeRestartRecord(%s) error=nil", test.name)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve a published schema-1 restart request when its creator's notify loses a creator/adopter race
- retain the 8 most recent distinct refused self-upgrade candidates within one wake generation
- prevent A→B→A installer oscillation from re-executing remembered candidate A
- keep refusal authority in the canonical restart record with no quarantine churn on remembered candidates
- document generation-scoped bounded refusal memory

## Validation
- combined creator/adopter + A→B→A race pack under `-race`, 20 repetitions
- `make ci`
- v0.58 mixed-reader compatibility regression
- Claude pre-commit review: PASS on both lanes and convergence rule
- independent Codex source review + full `go test -race ./internal/cli -count=1`: PASS

Beads: agent-message-queue-0jj.10, agent-message-queue-0jj.12

BEGIN_COMMIT_OVERRIDE
feat(wake): retain bounded refused self-upgrade history

fix(wake): preserve pending restart after notify race
END_COMMIT_OVERRIDE