### PR TITLE
fix(ci): isolate git env in fixture tests and pre-push hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt fmt-check vet lint ci smoke contract-check check-skills
+.PHONY: build test fmt fmt-check vet lint ci smoke contract-check check-skills hook-env-check
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -36,7 +36,10 @@ smoke:
 	AMQ_WAKE_OWNER=smoke-inherited-wake-owner \
 	./scripts/smoke-test.sh
 
-ci: check-skills fmt-check vet lint test smoke contract-check
+ci: check-skills fmt-check vet lint test smoke contract-check hook-env-check
+
+hook-env-check:
+	@sh scripts/test_pre_push_hook_env.sh
 
 contract-check:
 	@bash scripts/check-keepalive-amq-contract_test.sh

--- a/cmd/amq-keepalive/main_test.go
+++ b/cmd/amq-keepalive/main_test.go
@@ -106,14 +106,41 @@ func TestBuiltBinaryRunsStderrDrainBeforeArgumentHandling(t *testing.T) {
 
 func TestBuiltBinaryReportsStderrDrainFailure(t *testing.T) {
 	binary := buildKeepaliveForTest(t)
+	// Construct the capture failure explicitly: fd 3 delivers real bytes and
+	// fd 4 is read-only, so the drain's capture write must fail. Relying on
+	// fd 3/4 being closed is not hermetic — an ancestor (git's pre-push hook
+	// chain, make) can leak a live descriptor without close-on-exec, and the
+	// drain then blocks reading it until the package times out.
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reader.Close() }()
+	defer func() { _ = writer.Close() }()
+	readOnlyCapture, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = readOnlyCapture.Close() }()
+
 	cmd := exec.Command(binary, "__wake-stderr-drain")
 	cmd.Env = append(os.Environ(), stderrDrainModeForTest)
-	output, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("built drain unexpectedly succeeded; output=%q", output)
+	cmd.ExtraFiles = []*os.File{reader, readOnlyCapture}
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(string(output), "amq-keepalive stderr drain failed: capture wake stderr") {
-		t.Fatalf("output = %q, want concrete drain failure", output)
+	if _, err := writer.WriteString("diagnostic that cannot be captured\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = writer.Close()
+	if err := cmd.Wait(); err == nil {
+		t.Fatalf("built drain unexpectedly succeeded; output=%q", output.String())
+	}
+	if !strings.Contains(output.String(), "amq-keepalive stderr drain failed: capture wake stderr") {
+		t.Fatalf("output = %q, want concrete drain failure", output.String())
 	}
 }
 

--- a/internal/cli/worktree_divergence_test.go
+++ b/internal/cli/worktree_divergence_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -172,12 +173,117 @@ func createGitWorktreeFixture(t *testing.T) (primary, linked string) {
 	return primary, linked
 }
 
+// gitRepoSelectionEnv lists the variables through which an enclosing git
+// process — a pre-push hook running `make ci`, most commonly — redirects git
+// away from the `-C` target. A leaked GIT_DIR pointed every fixture command
+// at the enclosing repository itself, committing fixture content onto real
+// branches and re-initializing the real repo as bare. Mirrors the unset list
+// in scripts/smoke-test.sh. The contract here is direct repo-selection
+// isolation only; scrubbing git's full local environment (config injection,
+// grafts, shallow files) is the generated pre-push hook's job.
+var gitRepoSelectionEnv = []string{
+	"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY",
+	"GIT_COMMON_DIR", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE",
+}
+
+func gitEnvForTest() []string {
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		// GIT_CONFIG_NOSYSTEM is filtered too: git honors the first
+		// occurrence, so an inherited empty value would defeat the "=1"
+		// appended below.
+		if slices.Contains(gitRepoSelectionEnv, name) || name == "GIT_CONFIG_NOSYSTEM" {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env, "GIT_CONFIG_NOSYSTEM=1")
+}
+
 func runGitForTest(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
-	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	cmd.Env = gitEnvForTest()
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func gitOutputForTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = gitEnvForTest()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// TestRunGitForTestIsolatesEnclosingRepo executes the incident that motivated
+// gitEnvForTest: a pre-push hook leaked GIT_DIR into `make ci`, and every
+// fixture git command then mutated the enclosing repository — a fixture
+// commit landed on a real branch and `init --bare` flipped core.bare on the
+// real repo. Before the scrub, this test fails with the victim corrupted.
+func TestRunGitForTestIsolatesEnclosingRepo(t *testing.T) {
+	victim := t.TempDir()
+	runGitForTest(t, victim, "init")
+	runGitForTest(t, victim, "-c", "user.name=Victim", "-c", "user.email=victim@example.invalid",
+		"commit", "--allow-empty", "-m", "base")
+	victimHead := gitOutputForTest(t, victim, "rev-parse", "HEAD")
+
+	t.Setenv("GIT_DIR", filepath.Join(victim, ".git"))
+	t.Setenv("GIT_WORK_TREE", victim)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(victim, ".git", "index"))
+	t.Setenv("GIT_OBJECT_DIRECTORY", filepath.Join(victim, ".git", "objects"))
+	t.Setenv("GIT_COMMON_DIR", filepath.Join(victim, ".git"))
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "")
+
+	nosystem := 0
+	for _, entry := range gitEnvForTest() {
+		if strings.HasPrefix(entry, "GIT_CONFIG_NOSYSTEM=") {
+			nosystem++
+			if entry != "GIT_CONFIG_NOSYSTEM=1" {
+				t.Fatalf("gitEnvForTest emitted %q, want GIT_CONFIG_NOSYSTEM=1", entry)
+			}
+		}
+	}
+	if nosystem != 1 {
+		t.Fatalf("gitEnvForTest emitted GIT_CONFIG_NOSYSTEM %d times, want exactly once", nosystem)
+	}
+
+	// The incident sequence: fixture init, commit, worktree add, and a bare
+	// init, all under the hostile environment above.
+	fixture := filepath.Join(t.TempDir(), "primary")
+	if err := os.Mkdir(fixture, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture, "README.md"), []byte("fixture\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, fixture, "init")
+	runGitForTest(t, fixture, "add", "README.md")
+	runGitForTest(t, fixture, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid",
+		"commit", "-m", "fixture")
+	runGitForTest(t, fixture, "worktree", "add", "-b", "linked", filepath.Join(t.TempDir(), "linked"))
+	bare := filepath.Join(t.TempDir(), "bare")
+	if err := os.Mkdir(bare, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, bare, "init", "--bare")
+
+	if head := gitOutputForTest(t, victim, "rev-parse", "HEAD"); head != victimHead {
+		t.Fatalf("victim HEAD moved from %s to %s", victimHead, head)
+	}
+	if count := gitOutputForTest(t, victim, "rev-list", "--count", "HEAD"); count != "1" {
+		t.Fatalf("victim commit count = %s, want 1", count)
+	}
+	if bareFlag := gitOutputForTest(t, victim, "config", "core.bare"); bareFlag != "false" {
+		t.Fatalf("victim core.bare = %s, want false", bareFlag)
+	}
+	if subject := gitOutputForTest(t, victim, "log", "-1", "--format=%s"); subject != "base" {
+		t.Fatalf("victim HEAD subject = %q, want %q", subject, "base")
 	}
 }
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -7,6 +7,14 @@ cat > "$HOOK_DIR/pre-push" << 'EOF'
 #!/bin/sh
 # Pre-push hook: runs lint and tests before allowing push
 
+# git exports repo-selection variables into hooks; make ci runs tests that
+# create git fixtures, and an inherited GIT_DIR would point their git
+# commands at this repository itself. Config-injection variables are
+# scrubbed too so hook-launched git sees only on-disk configuration.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE \
+  GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS GIT_CONFIG_NOSYSTEM 2>/dev/null || true
+
 echo "Running pre-push checks..."
 
 # Run the CI checks (fmt-check, vet, lint, test)

--- a/scripts/test_pre_push_hook_env.sh
+++ b/scripts/test_pre_push_hook_env.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Integration test for the generated pre-push hook's git-env scrub.
+# Installs the hook into a temp repo, invokes it under hostile git
+# environment variables, and proves the hook's `make ci` sees none of them.
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/amq-hook-env.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT INT TERM
+
+REPO="$WORK/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+
+# Fake `make` earlier in PATH: records which scrubbed variables leaked
+# through, so the assertion proves the postcondition instead of trusting
+# the unset line.
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+cat > "$BIN/make" << 'EOF'
+#!/bin/sh
+leaked=""
+for name in GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+    GIT_COMMON_DIR GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE \
+    GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS GIT_CONFIG_NOSYSTEM; do
+  if eval "[ \"\${$name+set}\" = set ]"; then
+    leaked="$leaked $name"
+  fi
+done
+printf '%s\n' "$leaked" > "$MAKE_ENV_REPORT"
+[ -z "$leaked" ]
+EOF
+chmod +x "$BIN/make"
+
+(cd "$REPO" && sh "$ROOT/scripts/install-hooks.sh" > /dev/null)
+HOOK="$REPO/.git/hooks/pre-push"
+[ -x "$HOOK" ] || { echo "FAIL: hook not installed"; exit 1; }
+
+REPORT="$WORK/report"
+if ! env \
+    GIT_DIR="$REPO/.git" \
+    GIT_WORK_TREE="$REPO" \
+    GIT_INDEX_FILE="$REPO/.git/index" \
+    GIT_OBJECT_DIRECTORY="$REPO/.git/objects" \
+    GIT_COMMON_DIR="$REPO/.git" \
+    GIT_ALTERNATE_OBJECT_DIRECTORIES="$WORK/alt" \
+    GIT_NAMESPACE=hostile \
+    GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_PARAMETERS="'core.bare=true'" \
+    GIT_CONFIG_NOSYSTEM= \
+    MAKE_ENV_REPORT="$REPORT" \
+    PATH="$BIN:$PATH" \
+    sh "$HOOK" origin file:///dev/null < /dev/null > "$WORK/hook.out" 2>&1; then
+  echo "FAIL: hook exited nonzero under hostile git env"
+  cat "$WORK/hook.out"
+  cat "$REPORT" 2>/dev/null || true
+  exit 1
+fi
+
+[ -f "$REPORT" ] || { echo "FAIL: hook never ran make ci"; exit 1; }
+leaked="$(cat "$REPORT")"
+if [ -n "$(printf '%s' "$leaked" | tr -d ' ')" ]; then
+  echo "FAIL: hook leaked git env into make ci:$leaked"
+  exit 1
+fi
+
+echo "pre-push hook git env scrub ok"


### PR DESCRIPTION
## Summary

Two hermeticity defects made local pushes corrupt or hang the repository:

1. **Repo corruption**: git exports repo-selection variables (`GIT_DIR` and friends) into hooks; `make ci` under the pre-push hook ran internal/cli tests whose `runGitForTest` inherited them, so fixture git commands targeted the enclosing repository — a `fixture` commit landed on a real branch and `init --bare` flipped the real repo to `core.bare=true`. `runGitForTest` now scrubs the seven direct repo-selection variables (mirroring `scripts/smoke-test.sh`) and normalizes `GIT_CONFIG_NOSYSTEM` to exactly one `=1` entry. The generated pre-push hook unsets the same list plus config-injection variables before `make ci`.
2. **Package timeout hang**: `TestBuiltBinaryReportsStderrDrainFailure` assumed fds 3/4 are closed in the drain child; git's hook chain leaks a live descriptor without close-on-exec, and the drain read it until the 10-minute package timeout. The test now passes fd 3 as a pipe with real bytes and fd 4 as read-only `/dev/null`, forcing the exact capture-write failure it asserts.

## Verification

- `TestRunGitForTestIsolatesEnclosingRepo` executes the corruption counterexample against a temp victim repo — fails on the pre-fix helper (reverted-and-rerun), passes post-fix.
- `scripts/test_pre_push_hook_env.sh` (`make hook-env-check`, wired into `ci`) installs the real generated hook and proves the scrub postcondition via a fake `make` under hostile git env, including `GIT_CONFIG_COUNT`/`GIT_CONFIG_PARAMETERS`.
- Drain test verified passing clean AND with `3< <(sleep 65)` leaking a live fd.
- Full `make ci` green locally; the previously-failing pre-push hook path now passes end-to-end (this push went through it).
- Peer-reviewed via AMQ (thread review/fix-git-env): three blocking findings applied, then approved; scope addition reviewed and approved separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFFsHRPVbytCCvRKV9Rvd