### PR TITLE
fix(fsq): make concurrent drain claims exclusive on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,29 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
+
+  # Native Windows leg for the exclusive drain-claim contract (issue #485).
+  # Cross-compilation cannot exercise the bug: os.Root.Rename on Windows is
+  # handle-based and lets every concurrent claimer succeed. Scope stays
+  # focused on the claim path; the broader suite has known unrelated Windows
+  # failures tracked separately.
+  windows-claim-test:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      # Focused regex, not the full fsq suite: pristine v0.60.2 already fails
+      # unrelated Windows tests (e.g. TestRetryFromDLQEnvelopeUpdateFailure...),
+      # tracked separately from this claim-exclusivity gate. read/monitor/DLQ
+      # capture all claim through the same MoveNewToCur primitive proven here.
+      - name: Claim primitive and maildir contracts
+        run: go test ./internal/fsq -run '^TestMoveNewToCur|^TestClaimRename|^TestClaimCollision|^TestClaimPinnedRoot|^TestMaildir' -count=1
+      - name: Concurrent drain single-winner gate
+        run: go test ./internal/cli -run '^TestDrainInboxItemsConcurrentClaimsSingleWinner$' -count=50
+      - name: Drain claim path
+        run: go test ./internal/cli -run '^TestDrainInboxItems' -count=1

--- a/internal/fsq/claim_collision_windows_test.go
+++ b/internal/fsq/claim_collision_windows_test.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+package fsq
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestClaimCollisionPreservesBothCopies proves the loud-collision contract:
+// when inbox/new and inbox/cur both hold the claimed filename, the claim is
+// refused with *ClaimCollisionError and neither copy is modified. Unix
+// deliberately keeps rename-replace semantics (the state is unreachable
+// through AMQ's own flows), so this contract is Windows-only.
+func TestClaimCollisionPreservesBothCopies(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	newPath := filepath.Join(AgentInboxNew(base, "alice"), "collide.md")
+	curPath := filepath.Join(AgentInboxCur(base, "alice"), "collide.md")
+	if err := os.WriteFile(newPath, []byte("new copy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(curPath, []byte("retained cur copy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := openDeliveryRootForTest(t, base)
+	err := MoveNewToCur(root, "alice", "collide.md")
+	var collision *ClaimCollisionError
+	if !errors.As(err, &collision) {
+		t.Fatalf("error = %T %v, want *ClaimCollisionError", err, err)
+	}
+
+	got, readErr := os.ReadFile(curPath)
+	if readErr != nil || string(got) != "retained cur copy" {
+		t.Fatalf("cur copy = %q, %v; collision must not overwrite the retained copy", got, readErr)
+	}
+	got, readErr = os.ReadFile(newPath)
+	if readErr != nil || string(got) != "new copy" {
+		t.Fatalf("new copy = %q, %v; collision must not consume the source", got, readErr)
+	}
+}
+
+// TestClaimPinnedRootIgnoresBaseAliasSwap is the capability acceptance
+// property from the issue #485 design review: after DeliveryRoot pins its
+// base, replacing the lexical base path must not redirect the claim. The
+// primitive must mutate the originally pinned tree and leave the impostor
+// tree byte-identical — exclusivity gained by discarding root authority
+// would be an incomplete fix.
+func TestClaimPinnedRootIgnoresBaseAliasSwap(t *testing.T) {
+	parent := t.TempDir()
+	base := filepath.Join(parent, "root")
+	if err := os.Mkdir(base, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	newRel := filepath.Join("agents", "alice", "inbox", "new", "pinned.md")
+	curRel := filepath.Join("agents", "alice", "inbox", "cur", "pinned.md")
+	if err := os.WriteFile(filepath.Join(base, newRel), []byte("pinned payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := openDeliveryRootForTest(t, base)
+
+	// Swap the lexical base for an impostor tree carrying a decoy message.
+	moved := filepath.Join(parent, "root.moved")
+	if err := os.Rename(base, moved); err != nil {
+		t.Fatalf("alias-swap rename: %v", err)
+	}
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs impostor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(base, newRel), []byte("decoy payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call the primitive directly: VerifyBase in MoveNewToCur intentionally
+	// fails closed on a moved base, but the primitive itself must also be
+	// pinned so no caller ordering can be redirected.
+	if err := claimRename(root, newRel, curRel); err != nil {
+		t.Fatalf("claimRename through pinned root: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(moved, curRel))
+	if err != nil || string(got) != "pinned payload" {
+		t.Fatalf("pinned tree cur = %q, %v; claim must land in the originally pinned tree", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(moved, newRel)); !os.IsNotExist(err) {
+		t.Fatalf("pinned tree new still present: %v", err)
+	}
+	got, err = os.ReadFile(filepath.Join(base, newRel))
+	if err != nil || string(got) != "decoy payload" {
+		t.Fatalf("impostor new = %q, %v; impostor tree must stay untouched", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(base, curRel)); !os.IsNotExist(err) {
+		t.Fatalf("impostor cur was created: %v", err)
+	}
+}

--- a/internal/fsq/claim_collision_windows_test.go
+++ b/internal/fsq/claim_collision_windows_test.go
@@ -68,11 +68,24 @@ func TestClaimPinnedRootIgnoresBaseAliasSwap(t *testing.T) {
 
 	root := openDeliveryRootForTest(t, base)
 
-	// Swap the lexical base for an impostor tree carrying a decoy message.
+	// Attempt the alias swap while the root is pinned. Windows normally
+	// refuses to rename a directory with open handles inside it — that
+	// refusal IS the pinned-root property, enforced by the OS itself, and is
+	// the expected branch. If a future Windows/Go semantic lets the rename
+	// through, fall through and require the claim to still land in the
+	// originally pinned tree while the impostor stays untouched.
 	moved := filepath.Join(parent, "root.moved")
 	if err := os.Rename(base, moved); err != nil {
-		t.Fatalf("alias-swap rename: %v", err)
+		if err := claimRename(root, newRel, curRel); err != nil {
+			t.Fatalf("claimRename through pinned root: %v", err)
+		}
+		got, readErr := os.ReadFile(filepath.Join(base, curRel))
+		if readErr != nil || string(got) != "pinned payload" {
+			t.Fatalf("pinned tree cur = %q, %v after refused swap", got, readErr)
+		}
+		return
 	}
+
 	if err := EnsureAgentDirs(base, "alice"); err != nil {
 		t.Fatalf("EnsureAgentDirs impostor: %v", err)
 	}

--- a/internal/fsq/claim_rename.go
+++ b/internal/fsq/claim_rename.go
@@ -1,0 +1,37 @@
+package fsq
+
+import "fmt"
+
+// ClaimCollisionError reports a claim rename that found the destination name
+// already present. Normal AMQ flows never hold the same filename in both
+// inbox/new and inbox/cur — a committed claim removes new, and DLQ retry
+// refuses redelivery while a retained cur exists — so a collision means
+// external reintroduction or an invariant violation. It is a loud, terminal
+// condition: the claim is neither won nor lost, and callers must not treat it
+// as either.
+type ClaimCollisionError struct {
+	NewPath string
+	CurPath string
+}
+
+func (e *ClaimCollisionError) Error() string {
+	return fmt.Sprintf(
+		"claim collision: %s and %s both exist; refusing to replace the retained copy",
+		e.NewPath, e.CurPath,
+	)
+}
+
+// claimCommittedResidueError reports a claim whose destination name was
+// created but whose source name could not be removed. The claim is committed
+// — exactly this caller owns the message and must emit it — with source
+// residue that a later claimer reconciles. MoveNewToCur translates it into
+// the caller-facing CommittedDurabilityError contract.
+type claimCommittedResidueError struct {
+	Err error
+}
+
+func (e *claimCommittedResidueError) Error() string {
+	return fmt.Sprintf("claim committed with unresolved source residue: %v", e.Err)
+}
+
+func (e *claimCommittedResidueError) Unwrap() error { return e.Err }

--- a/internal/fsq/claim_rename_other.go
+++ b/internal/fsq/claim_rename_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package fsq
+
+// claimRename is the exclusive-claim primitive behind MoveNewToCur. On POSIX,
+// rename(2) resolves the source by path atomically: exactly one of several
+// concurrent claimers moves new/<name> to cur/<name> and every loser observes
+// ENOENT. A pre-existing cur/<name> is replaced — that state is unreachable
+// through AMQ's own flows (see ClaimCollisionError), and rename's atomicity is
+// the exclusivity guarantee, so no pre-check is added here.
+//
+// The Windows implementation must provide the same winner/loser contract
+// without path-atomic rename: see claim_rename_windows.go and issue #485.
+func claimRename(root *DeliveryRoot, newPath, curPath string) error {
+	return root.root.Rename(newPath, curPath)
+}

--- a/internal/fsq/claim_rename_test.go
+++ b/internal/fsq/claim_rename_test.go
@@ -1,0 +1,112 @@
+package fsq
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func setupClaimAgent(t *testing.T, agent string) string {
+	t.Helper()
+	base := t.TempDir()
+	if err := EnsureAgentDirs(base, agent); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	return base
+}
+
+func writeClaimMessage(t *testing.T, base, agent, filename string) {
+	t.Helper()
+	path := filepath.Join(AgentInboxNew(base, agent), filename)
+	if err := os.WriteFile(path, []byte("claim test payload"), 0o600); err != nil {
+		t.Fatalf("write inbox message: %v", err)
+	}
+}
+
+func TestMoveNewToCurWinnerClaimsExactlyOnce(t *testing.T) {
+	base := setupClaimAgent(t, "alice")
+	writeClaimMessage(t, base, "alice", "claim_once.md")
+
+	root := openDeliveryRootForTest(t, base)
+	if err := MoveNewToCur(root, "alice", "claim_once.md"); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	err := MoveNewToCur(root, "alice", "claim_once.md")
+	if err == nil {
+		t.Fatal("second claim succeeded; claim must be exclusive")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("second claim error = %T %v, want os.IsNotExist", err, err)
+	}
+	if _, statErr := os.Stat(filepath.Join(AgentInboxCur(base, "alice"), "claim_once.md")); statErr != nil {
+		t.Fatalf("claimed message missing from cur: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(AgentInboxNew(base, "alice"), "claim_once.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("claimed message still present in new: %v", statErr)
+	}
+}
+
+// TestMoveNewToCurConcurrentClaimsSingleWinner releases many claimers at once
+// and requires exactly one winner. This is the fsq-level twin of the CLI-level
+// drain regression test that fails on windows/amd64 in issue #485.
+func TestMoveNewToCurConcurrentClaimsSingleWinner(t *testing.T) {
+	const claimers = 8
+	base := setupClaimAgent(t, "alice")
+	writeClaimMessage(t, base, "alice", "claim_race.md")
+
+	roots := make([]*DeliveryRoot, claimers)
+	for i := range roots {
+		roots[i] = openDeliveryRootForTest(t, base)
+	}
+
+	start := make(chan struct{})
+	results := make(chan error, claimers)
+	var wg sync.WaitGroup
+	for i := 0; i < claimers; i++ {
+		wg.Add(1)
+		go func(root *DeliveryRoot) {
+			defer wg.Done()
+			<-start
+			results <- MoveNewToCur(root, "alice", "claim_race.md")
+		}(roots[i])
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	winners := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			winners++
+		case os.IsNotExist(err):
+		default:
+			var committed *CommittedDurabilityError
+			if errors.As(err, &committed) {
+				winners++
+				continue
+			}
+			t.Fatalf("claim error = %T %v, want nil or os.IsNotExist", err, err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("winners = %d, want exactly 1", winners)
+	}
+	if _, err := os.Stat(filepath.Join(AgentInboxCur(base, "alice"), "claim_race.md")); err != nil {
+		t.Fatalf("claimed message missing from cur: %v", err)
+	}
+}
+
+func TestMoveNewToCurLoserForMissingMessage(t *testing.T) {
+	base := setupClaimAgent(t, "alice")
+	root := openDeliveryRootForTest(t, base)
+	err := MoveNewToCur(root, "alice", "never_delivered.md")
+	if err == nil {
+		t.Fatal("claim of missing message succeeded")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("error = %T %v, want os.IsNotExist", err, err)
+	}
+}

--- a/internal/fsq/claim_rename_windows.go
+++ b/internal/fsq/claim_rename_windows.go
@@ -1,0 +1,180 @@
+//go:build windows
+
+package fsq
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// fileLinkInformation is the variable-length FILE_LINK_INFORMATION shape
+// consumed by NtSetInformationFile. ReplaceIfExists is a Windows BOOLEAN
+// (uint32), not a Go bool.
+type fileLinkInformation struct {
+	ReplaceIfExists uint32
+	RootDirectory   windows.Handle
+	FileNameLength  uint32
+	FileName        [1]uint16
+}
+
+type fileDispositionInformationEx struct {
+	Flags uint32
+}
+
+const (
+	fileDispositionDelete         = 0x00000001
+	fileDispositionPosixSemantics = 0x00000002
+)
+
+// claimRename claims newPath by exclusively inserting curPath as a hard link,
+// then removing the source name with POSIX disposition semantics. All handles
+// are relative to the already-pinned os.Root, so an ambient rename of
+// DeliveryRoot.Base cannot redirect the claim. Link insertion, unlike a rename
+// performed through two already-open source handles, has one unambiguous
+// winner because ReplaceIfExists is false.
+func claimRename(root *DeliveryRoot, newPath, curPath string) error {
+	newDir, err := root.root.Open(filepath.Dir(newPath))
+	if err != nil {
+		return fmt.Errorf("open claim source directory: %w", err)
+	}
+	defer func() { _ = newDir.Close() }()
+
+	curDir, err := root.root.Open(filepath.Dir(curPath))
+	if err != nil {
+		return fmt.Errorf("open claim destination directory: %w", err)
+	}
+	defer func() { _ = curDir.Close() }()
+
+	source, err := openClaimSource(windows.Handle(newDir.Fd()), filepath.Base(newPath))
+	if err != nil {
+		mapped := windowsClaimError(err)
+		if os.IsNotExist(mapped) {
+			return os.ErrNotExist
+		}
+		return fmt.Errorf("open claim source %s: %w", root.displayPath(newPath), mapped)
+	}
+	defer func() { _ = windows.CloseHandle(source) }()
+
+	err = linkClaimHandle(source, windows.Handle(curDir.Fd()), filepath.Base(curPath))
+	if !errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) {
+		if err != nil {
+			if windowsClaimLinkUnsupported(err) {
+				return fmt.Errorf("claim filesystem does not support exclusive hard-link claims: %w", errors.ErrUnsupported)
+			}
+			return fmt.Errorf("claim %s: %w", root.displayPath(newPath), windowsClaimError(err))
+		}
+		if err := removeClaimSource(source); err != nil && !os.IsNotExist(windowsClaimError(err)) {
+			return &claimCommittedResidueError{Err: windowsClaimError(err)}
+		}
+		return nil
+	}
+
+	newInfo, statErr := root.root.Lstat(newPath)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return os.ErrNotExist
+		}
+		return fmt.Errorf("inspect claim source after collision: %w", statErr)
+	}
+	curInfo, statErr := root.root.Lstat(curPath)
+	if statErr != nil {
+		return fmt.Errorf("inspect claim destination after collision: %w", statErr)
+	}
+	if os.SameFile(newInfo, curInfo) {
+		// A winner inserted curPath but has not yet removed newPath, or a prior
+		// process crashed between those operations. Reconcile that residue and
+		// report this caller as a loser rather than redelivering the message.
+		if err := removeClaimSource(source); err != nil && !os.IsNotExist(windowsClaimError(err)) {
+			return fmt.Errorf("remove duplicate claim source %s: %w", root.displayPath(newPath), windowsClaimError(err))
+		}
+		return os.ErrNotExist
+	}
+	return &ClaimCollisionError{
+		NewPath: root.displayPath(newPath),
+		CurPath: root.displayPath(curPath),
+	}
+}
+
+func openClaimSource(directory windows.Handle, name string) (windows.Handle, error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return 0, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory: directory,
+		ObjectName:    objectName,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE,
+	}
+	var source windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(
+		&source,
+		windows.SYNCHRONIZE|windows.DELETE,
+		attributes,
+		&status,
+		nil,
+		0,
+		windows.FILE_SHARE_DELETE|windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		windows.FILE_OPEN,
+		windows.FILE_OPEN_REPARSE_POINT|windows.FILE_OPEN_FOR_BACKUP_INTENT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0,
+		0,
+	)
+	return source, err
+}
+
+func linkClaimHandle(source, destinationDirectory windows.Handle, destinationName string) error {
+	utf16Name, err := windows.UTF16FromString(destinationName)
+	if err != nil {
+		return err
+	}
+	nameLength := len(utf16Name) - 1 // exclude the terminating NUL
+	headerLength := int(unsafe.Offsetof(fileLinkInformation{}.FileName))
+	buffer := make([]byte, headerLength+nameLength*2)
+	info := (*fileLinkInformation)(unsafe.Pointer(&buffer[0]))
+	info.RootDirectory = destinationDirectory
+	info.FileNameLength = uint32(nameLength * 2)
+	copy(unsafe.Slice(&info.FileName[0], nameLength), utf16Name[:nameLength])
+
+	var status windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(
+		source,
+		&status,
+		&buffer[0],
+		uint32(len(buffer)),
+		windows.FileLinkInformation,
+	)
+}
+
+func removeClaimSource(source windows.Handle) error {
+	info := fileDispositionInformationEx{
+		Flags: fileDispositionDelete | fileDispositionPosixSemantics,
+	}
+	var status windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(
+		source,
+		&status,
+		(*byte)(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+		windows.FileDispositionInformationEx,
+	)
+}
+
+func windowsClaimLinkUnsupported(err error) bool {
+	return errors.Is(err, windows.STATUS_INVALID_DEVICE_REQUEST) ||
+		errors.Is(err, windows.STATUS_NOT_SUPPORTED) ||
+		errors.Is(err, windows.STATUS_NOT_SAME_DEVICE)
+}
+
+func windowsClaimError(err error) error {
+	if status, ok := err.(windows.NTStatus); ok {
+		return status.Errno()
+	}
+	return err
+}

--- a/internal/fsq/claim_rename_windows.go
+++ b/internal/fsq/claim_rename_windows.go
@@ -52,6 +52,9 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 
 	source, err := openClaimSource(windows.Handle(newDir.Fd()), filepath.Base(newPath))
 	if err != nil {
+		if errors.Is(err, windows.STATUS_DELETE_PENDING) {
+			return os.ErrNotExist
+		}
 		mapped := windowsClaimError(err)
 		if os.IsNotExist(mapped) {
 			return os.ErrNotExist
@@ -78,6 +81,14 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 	if statErr != nil {
 		if os.IsNotExist(statErr) {
 			return os.ErrNotExist
+		}
+		if os.IsPermission(statErr) {
+			probe, probeErr := openClaimSource(windows.Handle(newDir.Fd()), filepath.Base(newPath))
+			if probeErr == nil {
+				_ = windows.CloseHandle(probe)
+			} else if errors.Is(probeErr, windows.STATUS_DELETE_PENDING) {
+				return os.ErrNotExist
+			}
 		}
 		return fmt.Errorf("inspect claim source after collision: %w", statErr)
 	}

--- a/internal/fsq/claim_rename_windows.go
+++ b/internal/fsq/claim_rename_windows.go
@@ -86,7 +86,7 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 			probe, probeErr := openClaimSource(windows.Handle(newDir.Fd()), filepath.Base(newPath))
 			if probeErr == nil {
 				_ = windows.CloseHandle(probe)
-			} else if errors.Is(probeErr, windows.STATUS_DELETE_PENDING) {
+			} else if errors.Is(probeErr, windows.STATUS_DELETE_PENDING) || os.IsNotExist(windowsClaimError(probeErr)) {
 				return os.ErrNotExist
 			}
 		}

--- a/internal/fsq/claim_rename_windows.go
+++ b/internal/fsq/claim_rename_windows.go
@@ -52,13 +52,10 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 
 	source, err := openClaimSource(windows.Handle(newDir.Fd()), filepath.Base(newPath))
 	if err != nil {
-		if errors.Is(err, windows.STATUS_DELETE_PENDING) {
+		if claimTransitionAlreadyDone(err) {
 			return os.ErrNotExist
 		}
 		mapped := windowsClaimError(err)
-		if os.IsNotExist(mapped) {
-			return os.ErrNotExist
-		}
 		return fmt.Errorf("open claim source %s: %w", root.displayPath(newPath), mapped)
 	}
 	defer func() { _ = windows.CloseHandle(source) }()
@@ -71,7 +68,7 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 			}
 			return fmt.Errorf("claim %s: %w", root.displayPath(newPath), windowsClaimError(err))
 		}
-		if err := removeClaimSource(source); err != nil && !os.IsNotExist(windowsClaimError(err)) {
+		if err := removeClaimSource(source); err != nil && !claimTransitionAlreadyDone(err) {
 			return &claimCommittedResidueError{Err: windowsClaimError(err)}
 		}
 		return nil
@@ -86,7 +83,7 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 			probe, probeErr := openClaimSource(windows.Handle(newDir.Fd()), filepath.Base(newPath))
 			if probeErr == nil {
 				_ = windows.CloseHandle(probe)
-			} else if errors.Is(probeErr, windows.STATUS_DELETE_PENDING) || os.IsNotExist(windowsClaimError(probeErr)) {
+			} else if claimTransitionAlreadyDone(probeErr) {
 				return os.ErrNotExist
 			}
 		}
@@ -100,7 +97,7 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 		// A winner inserted curPath but has not yet removed newPath, or a prior
 		// process crashed between those operations. Reconcile that residue and
 		// report this caller as a loser rather than redelivering the message.
-		if err := removeClaimSource(source); err != nil && !os.IsNotExist(windowsClaimError(err)) {
+		if err := removeClaimSource(source); err != nil && !claimTransitionAlreadyDone(err) {
 			return fmt.Errorf("remove duplicate claim source %s: %w", root.displayPath(newPath), windowsClaimError(err))
 		}
 		return os.ErrNotExist
@@ -181,6 +178,14 @@ func windowsClaimLinkUnsupported(err error) bool {
 	return errors.Is(err, windows.STATUS_INVALID_DEVICE_REQUEST) ||
 		errors.Is(err, windows.STATUS_NOT_SUPPORTED) ||
 		errors.Is(err, windows.STATUS_NOT_SAME_DEVICE)
+}
+
+// claimTransitionAlreadyDone reports NT outcomes that prove another
+// cooperating claimant has removed, or is currently removing, the source
+// name. They are benign completion at cleanup sites and the ordinary loser
+// contract at acquisition sites.
+func claimTransitionAlreadyDone(err error) bool {
+	return errors.Is(err, windows.STATUS_DELETE_PENDING) || os.IsNotExist(windowsClaimError(err))
 }
 
 func windowsClaimError(err error) error {

--- a/internal/fsq/claim_rename_windows_test.go
+++ b/internal/fsq/claim_rename_windows_test.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package fsq
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestWindowsClaimRenameConcurrentSingleWinner(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureRootDirs(base); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	root := openDeliveryRootForTest(t, base)
+	const filename = "windows-exclusive-claim.md"
+	payload := []byte("one physical message\n")
+	if _, err := DeliverToInbox(root, "alice", filename, payload); err != nil {
+		t.Fatalf("DeliverToInbox: %v", err)
+	}
+
+	newPath := filepath.Join("agents", "alice", "inbox", "new", filename)
+	curPath := filepath.Join("agents", "alice", "inbox", "cur", filename)
+	const workers = 8
+	start := make(chan struct{})
+	results := make(chan error, workers)
+	var group sync.WaitGroup
+	group.Add(workers)
+	for range workers {
+		go func() {
+			defer group.Done()
+			<-start
+			results <- claimRename(root, newPath, curPath)
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(results)
+
+	winners := 0
+	losers := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			winners++
+		case os.IsNotExist(err):
+			losers++
+		default:
+			t.Fatalf("claimRename returned unexpected error: %T %v", err, err)
+		}
+	}
+	if winners != 1 || losers != workers-1 {
+		t.Fatalf("claim outcomes: winners=%d losers=%d, want 1/%d", winners, losers, workers-1)
+	}
+	if _, err := os.Stat(filepath.Join(base, newPath)); !os.IsNotExist(err) {
+		t.Fatalf("source still visible after winning claim: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(base, curPath))
+	if err != nil {
+		t.Fatalf("read claimed payload: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("claimed payload = %q, want %q", got, payload)
+	}
+}

--- a/internal/fsq/find.go
+++ b/internal/fsq/find.go
@@ -44,7 +44,21 @@ func MoveNewToCur(root *DeliveryRoot, agent, filename string) error {
 	if err := root.root.MkdirAll(curDir, 0o700); err != nil {
 		return err
 	}
-	if err := root.root.Rename(newPath, curPath); err != nil {
+	// claimRename is the exclusive-claim point: exactly one concurrent caller
+	// wins; losers observe os.IsNotExist. Windows cannot use os.Root.Rename
+	// here — it renames by handle and lets every contender succeed (#485).
+	if err := claimRename(root, newPath, curPath); err != nil {
+		var residue *claimCommittedResidueError
+		if errors.As(err, &residue) {
+			// The destination name exists and this caller owns the claim; the
+			// leftover source name is reconciled by a later claimer. Same
+			// contract as a post-rename sync failure: committed, not failed.
+			return &CommittedDurabilityError{
+				FinalPath: root.displayPath(curPath),
+				Recipient: agent,
+				Err:       residue.Err,
+			}
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Fixes #485. On Windows, `os.Root.Rename` opens the source by handle and renames with replacement enabled, so concurrent drains of one mailbox both claim and both emit the same message (reporter measured 19/20 failures of the single-winner regression test on windows/amd64, and double delivery at CLI level).

The claim behind `MoveNewToCur` — shared by drain, monitor, read, and DLQ capture — is now a platform primitive:

- **POSIX**: unchanged path-atomic rename; the loser observes ENOENT.
- **Windows**: pinned-handle NT hard-link insertion into `cur` with `ReplaceIfExists=false` (directory-entry creation has exactly one winner), then POSIX-semantics disposition unlinks the `new` name via the same handle. All handles resolve relative to the pinned `os.Root`, preserving the capability model — a lexical base swap cannot redirect the claim (property-tested). Collision resolution through the pinned namespace: source gone → ordinary loser; `SameFile` residue → reconcile crashed winner, report loser; a different retained `cur` copy → loud `ClaimCollisionError`, never replaced. A winner whose source unlink fails returns the committed-residue contract so the caller still emits (mirror of the post-rename sync semantics). Non-hardlink filesystems get a typed `errors.ErrUnsupported` refusal — never a fallback to the non-exclusive rename.

## Verification

- New `windows-claim-test` CI job on this PR is the decisive native gate: fsq claim/collision/alias-swap/maildir tests, the concurrent single-winner drain gate at `-count=50`, and the drain claim path.
- Portable fsq tests (winner-once, 8-way concurrent single-winner, missing-source loser) pass with `-race` on darwin; `GOOS=windows go vet` and Windows test-binary cross-builds pass.
- Full `make ci` passed via the pre-push hook.
- Known cap, stated: the broader Windows suite has pre-existing unrelated failures (e.g. `TestRetryFromDLQEnvelopeUpdateFailure...`), tracked separately from this gate.
- Joint implementation, cross-reviewed both directions via AMQ (thread fix/issue-485): design review rejected the initial full-path `MoveFileEx` approach for breaking pinned-root authority, then rejected rename-by-handle for an unprovable same-file semantic, landing on link-first; separate findings fixed on both lanes (os.IsNotExist wrapping, committed-residue emission, focused CI scope, collision/alias-swap coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NFFsHRPVbytCCvRKV9Rvd