### PR TITLE
fix(wake): verify lock machine identity instead of drifting hostname

### DIFF
--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -21,7 +21,8 @@ type wakeLock struct {
 	TTY                  string               `json:"tty"`
 	Root                 string               `json:"root"`                             // Absolute path to disambiguate relative AM_ROOT
 	Agent                string               `json:"agent,omitempty"`                  // Agent handle that owns this lock
-	Hostname             string               `json:"hostname,omitempty"`               // Host that created the lock
+	Hostname             string               `json:"hostname,omitempty"`               // Host that created the lock; diagnostic, drifts with the network on macOS
+	MachineID            string               `json:"machine_id,omitempty"`             // Stable machine identity that created the lock
 	Started              string               `json:"started"`                          // Wall-clock diagnostic timestamp
 	ProcessStart         string               `json:"process_start,omitempty"`          // Kernel process start token, guards PID reuse
 	BootID               string               `json:"boot_id,omitempty"`                // Boot identity paired with ProcessStart when available
@@ -295,18 +296,10 @@ func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
 		inspection.Reason = "agent mismatch"
 		return
 	}
-	if lock.Hostname != "" {
-		hostname, err := os.Hostname()
-		if err != nil || hostname == "" {
-			inspection.Status = wakeLockUnverified
-			inspection.Reason = inspectionReason("hostname unavailable", err)
-			return
-		}
-		if lock.Hostname != hostname {
-			inspection.Status = wakeLockUnverified
-			inspection.Reason = "hostname mismatch"
-			return
-		}
+	if machineState, machineReason := classifyWakeLockMachine(lock); machineState != wakeMachineSame {
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = machineReason
+		return
 	}
 
 	state, reason := classifyWakeIdentity(*inspection, inspection.Process)

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -340,6 +340,7 @@ func TestInspectWakeLockRejectsMalformedWholeJSON(t *testing.T) {
 		{name: "tty wrong type", raw: []byte(`{"pid":4242,"tty":42,"root":"/tmp","started":"now"}`)},
 		{name: "root wrong type", raw: []byte(`{"pid":4242,"tty":"tty","root":42,"started":"now"}`)},
 		{name: "started wrong type", raw: []byte(`{"pid":4242,"tty":"tty","root":"/tmp","started":42}`)},
+		{name: "machine_id wrong type", raw: []byte(`{"pid":4242,"tty":"tty","root":"/tmp","started":"now","machine_id":42}`)},
 		{name: "truncated object", raw: []byte(`{"pid":`)},
 		{name: "null", raw: []byte(`null`)},
 		{name: "array", raw: []byte(`[]`)},
@@ -387,6 +388,7 @@ func TestDecodeWakeLockJSONFieldsWireScanner(t *testing.T) {
 		{name: "raw parse failure", raw: `{"pid":`, wantErr: true},
 		{name: "non-object", raw: `[]`, wantErr: true},
 		{name: "duplicate known", raw: `{"pid":null,"pid":7}`, wantErr: true},
+		{name: "duplicate machine_id", raw: `{"machine_id":null,"machine_id":"x"}`, wantErr: true},
 		{name: "duplicate unknown", raw: `{"future":null,"future":{"pid":null}}`},
 	}
 	for _, test := range tests {

--- a/internal/cli/wake_machine_identity.go
+++ b/internal/cli/wake_machine_identity.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// currentWakeMachineID returns a stable identity for this machine, cached for
+// the life of the process. It is best-effort evidence: an empty string means
+// no stable identity is available and callers must fall back to weaker
+// same-machine signals. Overridable for tests.
+var currentWakeMachineID = sync.OnceValue(func() string {
+	return readWakeMachineIDPlatform()
+})
+
+// currentWakeBootID reports the boot identity of the running system, empty
+// when unavailable. Overridable for tests.
+var currentWakeBootID = func() string {
+	return inspectWakeProcess(os.Getpid()).BootID
+}
+
+// currentWakeHostname reports the kernel hostname. Overridable for tests.
+var currentWakeHostname = os.Hostname
+
+type wakeMachineComparison int
+
+const (
+	// wakeMachineSame: the lock was proven to be written by this machine, so
+	// local process inspection is meaningful.
+	wakeMachineSame wakeMachineComparison = iota
+	// wakeMachineDifferent: the lock records a stable machine identity that
+	// differs from this machine's; local PID state says nothing about the
+	// writer's process.
+	wakeMachineDifferent
+	// wakeMachineUnknown: no decisive same-machine or different-machine
+	// evidence exists.
+	wakeMachineUnknown
+)
+
+// classifyWakeLockMachine decides whether the lock was written by this
+// machine. Evidence order, strongest first:
+//
+//  1. Stable machine identity recorded in the lock versus the current
+//     machine's. Decisive in both directions.
+//  2. Same-boot bridge: a lock whose boot session UUID equals the current
+//     boot session UUID was written during this boot on this machine, because
+//     boot session UUIDs are globally unique. Locks predating the machine_id
+//     field get same-machine proof this way even after the hostname drifts
+//     mid-boot. Only proves sameness; a differing boot UUID may be an older
+//     boot of this same machine.
+//  3. Hostname equality, the legacy signal. It is network-derived on macOS
+//     and drifts, so it can only ever be the last resort.
+func classifyWakeLockMachine(lock wakeLock) (wakeMachineComparison, string) {
+	if recorded := strings.TrimSpace(lock.MachineID); recorded != "" {
+		if current := currentWakeMachineID(); current != "" {
+			if strings.EqualFold(recorded, current) {
+				return wakeMachineSame, ""
+			}
+			return wakeMachineDifferent, "machine id mismatch"
+		}
+	}
+	if isDarwinBootUUID(lock.BootID) {
+		if boot := currentWakeBootID(); isDarwinBootUUID(boot) && strings.EqualFold(lock.BootID, boot) {
+			return wakeMachineSame, ""
+		}
+	}
+	if lock.Hostname == "" {
+		return wakeMachineSame, ""
+	}
+	current, err := currentWakeHostname()
+	if err != nil || current == "" {
+		return wakeMachineUnknown, inspectionReason("hostname unavailable", err)
+	}
+	if lock.Hostname != current {
+		return wakeMachineUnknown, "hostname mismatch"
+	}
+	return wakeMachineSame, ""
+}

--- a/internal/cli/wake_machine_identity.go
+++ b/internal/cli/wake_machine_identity.go
@@ -15,9 +15,11 @@ var currentWakeMachineID = sync.OnceValue(func() string {
 })
 
 // currentWakeBootID reports the boot identity of the running system, empty
-// when unavailable. Overridable for tests.
+// when unavailable. It reads the platform boot identity directly rather than
+// going through process inspection, which doctor and restart tests instrument
+// with scripted call counts. Overridable for tests.
 var currentWakeBootID = func() string {
-	return inspectWakeProcess(os.Getpid()).BootID
+	return readWakeBootIDPlatform()
 }
 
 // currentWakeHostname reports the kernel hostname. Overridable for tests.

--- a/internal/cli/wake_machine_identity_darwin.go
+++ b/internal/cli/wake_machine_identity_darwin.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// darwinGethostuuid wraps gethostuuid(2). Overridable for tests.
+var darwinGethostuuid = func(uuid *[16]byte, timeout *unix.Timespec) syscall.Errno {
+	_, _, errno := unix.Syscall(
+		//nolint:staticcheck // unix.SYS_GETHOSTUUID is deprecated but x/sys has no gethostuuid wrapper
+		unix.SYS_GETHOSTUUID,
+		uintptr(unsafe.Pointer(&uuid[0])),
+		uintptr(unsafe.Pointer(timeout)),
+		0,
+	)
+	return errno
+}
+
+// readWakeMachineIDPlatform returns the hardware platform UUID via
+// gethostuuid(2), the kernel's stable identity for this machine (the same
+// value as IOPlatformUUID). The timeout must be finite: a zero timespec makes
+// the syscall wait indefinitely.
+func readWakeMachineIDPlatform() string {
+	var uuid [16]byte
+	timeout := unix.Timespec{Sec: 3}
+	if errno := darwinGethostuuid(&uuid, &timeout); errno != 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%08X-%04X-%04X-%04X-%012X",
+		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16],
+	)
+}

--- a/internal/cli/wake_machine_identity_darwin.go
+++ b/internal/cli/wake_machine_identity_darwin.go
@@ -22,6 +22,11 @@ var darwinGethostuuid = func(uuid *[16]byte, timeout *unix.Timespec) syscall.Err
 	return errno
 }
 
+func readWakeBootIDPlatform() string {
+	bootID, _ := darwinBootIdentity()
+	return bootID
+}
+
 // readWakeMachineIDPlatform returns the hardware platform UUID via
 // gethostuuid(2), the kernel's stable identity for this machine (the same
 // value as IOPlatformUUID). The timeout must be finite: a zero timespec makes

--- a/internal/cli/wake_machine_identity_darwin_test.go
+++ b/internal/cli/wake_machine_identity_darwin_test.go
@@ -1,0 +1,56 @@
+//go:build darwin
+
+package cli
+
+import (
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func stubDarwinGethostuuid(t *testing.T, fn func(uuid *[16]byte, timeout *unix.Timespec) syscall.Errno) {
+	t.Helper()
+	old := darwinGethostuuid
+	darwinGethostuuid = fn
+	t.Cleanup(func() { darwinGethostuuid = old })
+}
+
+func TestReadWakeMachineIDPlatformFormatsUUIDAndPassesFiniteTimeout(t *testing.T) {
+	var captured unix.Timespec
+	stubDarwinGethostuuid(t, func(uuid *[16]byte, timeout *unix.Timespec) syscall.Errno {
+		captured = *timeout
+		*uuid = [16]byte{
+			0x10, 0x28, 0x4D, 0xF2, 0x40, 0xDE, 0x50, 0xF6,
+			0xBC, 0x1C, 0x4E, 0x79, 0xBA, 0xE6, 0x99, 0xE9,
+		}
+		return 0
+	})
+	if got := readWakeMachineIDPlatform(); got != "10284DF2-40DE-50F6-BC1C-4E79BAE699E9" {
+		t.Fatalf("machine id = %q, want formatted platform UUID", got)
+	}
+	if captured.Sec <= 0 && captured.Nsec <= 0 {
+		t.Fatalf("gethostuuid timeout = %+v, want finite non-zero", captured)
+	}
+}
+
+func TestReadWakeMachineIDPlatformFailsEmptyOnErrno(t *testing.T) {
+	stubDarwinGethostuuid(t, func(uuid *[16]byte, timeout *unix.Timespec) syscall.Errno {
+		return unix.EWOULDBLOCK
+	})
+	if got := readWakeMachineIDPlatform(); got != "" {
+		t.Fatalf("machine id = %q, want empty on errno", got)
+	}
+}
+
+// Live check of the best-effort contract: a UUID-shaped identity or empty,
+// never junk, and stable between reads.
+func TestReadWakeMachineIDPlatformLiveValidOrEmpty(t *testing.T) {
+	first := readWakeMachineIDPlatform()
+	if first != "" && !isDarwinBootUUID(first) {
+		t.Fatalf("machine id = %q, want UUID shape or empty", first)
+	}
+	if second := readWakeMachineIDPlatform(); second != first {
+		t.Fatalf("machine id changed between reads: %q then %q", first, second)
+	}
+}

--- a/internal/cli/wake_machine_identity_linux.go
+++ b/internal/cli/wake_machine_identity_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"strings"
+)
+
+// readWakeMachineIDPlatform returns the machine id, the standard stable
+// machine identity on Linux.
+func readWakeMachineIDPlatform() string {
+	for _, path := range []string{"/etc/machine-id", "/var/lib/dbus/machine-id"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if id := strings.TrimSpace(string(data)); isLinuxMachineID(id) {
+			return id
+		}
+	}
+	return ""
+}
+
+func isLinuxMachineID(value string) bool {
+	if len(value) != 32 {
+		return false
+	}
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/wake_machine_identity_linux.go
+++ b/internal/cli/wake_machine_identity_linux.go
@@ -7,6 +7,14 @@ import (
 	"strings"
 )
 
+func readWakeBootIDPlatform() string {
+	data, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 // readWakeMachineIDPlatform returns the machine id, the standard stable
 // machine identity on Linux.
 func readWakeMachineIDPlatform() string {

--- a/internal/cli/wake_machine_identity_linux_test.go
+++ b/internal/cli/wake_machine_identity_linux_test.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package cli
+
+import "testing"
+
+func TestIsLinuxMachineID(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"0123456789abcdef0123456789abcdef", true},
+		{"", false},
+		{"0123456789abcdef0123456789abcde", false},
+		{"0123456789abcdef0123456789abcdef0", false},
+		{"0123456789ABCDEF0123456789ABCDEF", false},
+		{"0123456789abcdef0123456789abcdeg", false},
+		{"0123456789abcdef0123456789abcde ", false},
+	}
+	for _, tt := range tests {
+		if got := isLinuxMachineID(tt.value); got != tt.want {
+			t.Fatalf("isLinuxMachineID(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestReadWakeMachineIDPlatformValidOrEmpty(t *testing.T) {
+	if id := readWakeMachineIDPlatform(); id != "" && !isLinuxMachineID(id) {
+		t.Fatalf("machine id = %q, want empty or 32 lowercase hex", id)
+	}
+}

--- a/internal/cli/wake_machine_identity_other.go
+++ b/internal/cli/wake_machine_identity_other.go
@@ -5,3 +5,7 @@ package cli
 func readWakeMachineIDPlatform() string {
 	return ""
 }
+
+func readWakeBootIDPlatform() string {
+	return ""
+}

--- a/internal/cli/wake_machine_identity_other.go
+++ b/internal/cli/wake_machine_identity_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package cli
+
+func readWakeMachineIDPlatform() string {
+	return ""
+}

--- a/internal/cli/wake_machine_identity_test.go
+++ b/internal/cli/wake_machine_identity_test.go
@@ -1,0 +1,268 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+const (
+	testMachineUUID  = "11111111-2222-3333-4444-555555555555"
+	otherMachineUUID = "99999999-8888-7777-6666-555555555555"
+	testBootUUID     = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+	otherBootUUID    = "FFFFFFFF-0000-1111-2222-333333333333"
+	legacyBoottimeID = "1781686509.734623000"
+)
+
+func stubCurrentWakeMachineID(t *testing.T, id string) {
+	t.Helper()
+	old := currentWakeMachineID
+	currentWakeMachineID = func() string { return id }
+	t.Cleanup(func() { currentWakeMachineID = old })
+}
+
+func stubCurrentWakeBootID(t *testing.T, id string) {
+	t.Helper()
+	old := currentWakeBootID
+	currentWakeBootID = func() string { return id }
+	t.Cleanup(func() { currentWakeBootID = old })
+}
+
+func stubCurrentWakeHostname(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+	old := currentWakeHostname
+	currentWakeHostname = fn
+	t.Cleanup(func() { currentWakeHostname = old })
+}
+
+func staticHostname(name string) func() (string, error) {
+	return func() (string, error) { return name, nil }
+}
+
+func TestClassifyWakeLockMachine(t *testing.T) {
+	tests := []struct {
+		name       string
+		lock       wakeLock
+		machineID  string
+		bootID     string
+		hostname   func() (string, error)
+		wantState  wakeMachineComparison
+		wantReason string
+	}{
+		{
+			name:      "machine id match outranks hostname drift",
+			lock:      wakeLock{MachineID: testMachineUUID, Hostname: "mac", BootID: legacyBoottimeID},
+			machineID: testMachineUUID,
+			bootID:    testBootUUID,
+			hostname:  staticHostname("avivs-macbook-pro.local"),
+			wantState: wakeMachineSame,
+		},
+		{
+			name:      "machine id comparison is case insensitive",
+			lock:      wakeLock{MachineID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", Hostname: "mac"},
+			machineID: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+			hostname:  staticHostname("avivs-macbook-pro.local"),
+			wantState: wakeMachineSame,
+		},
+		{
+			name:       "machine id mismatch outranks hostname match",
+			lock:       wakeLock{MachineID: otherMachineUUID, Hostname: "host-a"},
+			machineID:  testMachineUUID,
+			hostname:   staticHostname("host-a"),
+			wantState:  wakeMachineDifferent,
+			wantReason: "machine id mismatch",
+		},
+		{
+			name:      "same boot bridge proves same machine without machine id",
+			lock:      wakeLock{Hostname: "mac", BootID: testBootUUID},
+			bootID:    testBootUUID,
+			hostname:  staticHostname("avivs-macbook-pro.local"),
+			wantState: wakeMachineSame,
+		},
+		{
+			name:       "bridge requires uuid boot identity on both sides",
+			lock:       wakeLock{Hostname: "mac", BootID: legacyBoottimeID},
+			bootID:     testBootUUID,
+			hostname:   staticHostname("avivs-macbook-pro.local"),
+			wantState:  wakeMachineUnknown,
+			wantReason: "hostname mismatch",
+		},
+		{
+			name:       "cross boot with hostname drift stays unknown",
+			lock:       wakeLock{Hostname: "mac", BootID: otherBootUUID},
+			bootID:     testBootUUID,
+			hostname:   staticHostname("avivs-macbook-pro.local"),
+			wantState:  wakeMachineUnknown,
+			wantReason: "hostname mismatch",
+		},
+		{
+			name:      "cross boot with matching hostname stays same",
+			lock:      wakeLock{Hostname: "host-a", BootID: otherBootUUID},
+			bootID:    testBootUUID,
+			hostname:  staticHostname("host-a"),
+			wantState: wakeMachineSame,
+		},
+		{
+			name:      "recorded machine id with unavailable current falls back to hostname",
+			lock:      wakeLock{MachineID: testMachineUUID, Hostname: "host-a"},
+			machineID: "",
+			hostname:  staticHostname("host-a"),
+			wantState: wakeMachineSame,
+		},
+		{
+			name:       "recorded machine id with unavailable current still fails on hostname drift",
+			lock:       wakeLock{MachineID: testMachineUUID, Hostname: "mac"},
+			machineID:  "",
+			hostname:   staticHostname("avivs-macbook-pro.local"),
+			wantState:  wakeMachineUnknown,
+			wantReason: "hostname mismatch",
+		},
+		{
+			name:       "empty hostname without error is unknown",
+			lock:       wakeLock{Hostname: "host-a"},
+			hostname:   staticHostname(""),
+			wantState:  wakeMachineUnknown,
+			wantReason: "hostname unavailable",
+		},
+		{
+			name:      "legacy lock without hostname skips the gate",
+			lock:      wakeLock{},
+			machineID: testMachineUUID,
+			hostname:  staticHostname("host-a"),
+			wantState: wakeMachineSame,
+		},
+		{
+			name:       "hostname unavailable is unknown",
+			lock:       wakeLock{Hostname: "host-a"},
+			hostname:   func() (string, error) { return "", errors.New("no hostname") },
+			wantState:  wakeMachineUnknown,
+			wantReason: "hostname unavailable: no hostname",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubCurrentWakeMachineID(t, tt.machineID)
+			stubCurrentWakeBootID(t, tt.bootID)
+			stubCurrentWakeHostname(t, tt.hostname)
+			state, reason := classifyWakeLockMachine(tt.lock)
+			if state != tt.wantState || reason != tt.wantReason {
+				t.Fatalf("state = %v reason = %q, want %v %q", state, reason, tt.wantState, tt.wantReason)
+			}
+		})
+	}
+}
+
+// A dead wake from an old boot of this same machine must classify stale, not
+// unverified, even when the network-derived hostname drifted after the lock
+// was written. This is the resume-after-reboot scenario that used to force an
+// interactive prompt on every coop exec.
+func TestInspectWakeLockHostnameDriftOnSameMachineDeadPIDIsStale(t *testing.T) {
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          66121,
+		TTY:          "ttys001",
+		Hostname:     "definitely-not-this-host",
+		MachineID:    testMachineUUID,
+		ProcessStart: "1783283179.960200000",
+		BootID:       legacyBoottimeID,
+		Executable:   "amq",
+	})
+	stubCurrentWakeMachineID(t, testMachineUUID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockStale {
+		t.Fatalf("inspection status = %q (reason %q), want stale", inspection.Status, inspection.Reason)
+	}
+}
+
+// A lock recording a different stable machine identity must stay unverified
+// even when the hostname happens to match: hostname is the weaker signal.
+func TestInspectWakeLockForeignMachineIDIsUnverified(t *testing.T) {
+	root := secureTempDirForTest(t)
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		t.Fatalf("os.Hostname: %q, %v", hostname, err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          66121,
+		TTY:          "ttys001",
+		Hostname:     hostname,
+		MachineID:    otherMachineUUID,
+		ProcessStart: "start-1",
+		Executable:   "amq",
+	})
+	stubCurrentWakeMachineID(t, testMachineUUID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockUnverified {
+		t.Fatalf("inspection status = %q (reason %q), want unverified", inspection.Status, inspection.Reason)
+	}
+	if inspection.Reason != "machine id mismatch" {
+		t.Fatalf("inspection reason = %q, want machine id mismatch", inspection.Reason)
+	}
+}
+
+// A null machine_id joins the known-field trust matrix: the lock is rejected
+// as malformed and stays unverified rather than proving anything.
+func TestInspectWakeLockNullMachineIDIsRejectedAsMalformed(t *testing.T) {
+	root := secureTempDirForTest(t)
+	path := writeWakeLockForTest(t, root, "codex", wakeLock{PID: 66121, TTY: "ttys001"})
+	raw, err := json.Marshal(map[string]any{
+		"pid":        66121,
+		"tty":        "ttys001",
+		"root":       canonicalWakeRoot(root),
+		"agent":      "codex",
+		"started":    time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+		"hostname":   "definitely-not-this-host",
+		"machine_id": nil,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubCurrentWakeMachineID(t, testMachineUUID)
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockUnverified {
+		t.Fatalf("inspection status = %q (reason %q), want unverified", inspection.Status, inspection.Reason)
+	}
+	if inspection.Reason != `wake lock JSON field "machine_id" must not be null` {
+		t.Fatalf("inspection reason = %q, want null machine_id rejection", inspection.Reason)
+	}
+}
+
+// Locks that predate machine_id keep today's fail-closed behavior: hostname
+// drift without stronger same-machine evidence stays unverified.
+func TestInspectWakeLockLegacyHostnameDriftStaysUnverified(t *testing.T) {
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          66121,
+		TTY:          "ttys001",
+		Hostname:     "definitely-not-this-host",
+		ProcessStart: "1783283179.960200000",
+		BootID:       legacyBoottimeID,
+		Executable:   "amq",
+	})
+	stubCurrentWakeMachineID(t, testMachineUUID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockUnverified {
+		t.Fatalf("inspection status = %q (reason %q), want unverified", inspection.Status, inspection.Reason)
+	}
+	if inspection.Reason != "hostname mismatch" {
+		t.Fatalf("inspection reason = %q, want hostname mismatch", inspection.Reason)
+	}
+}

--- a/internal/cli/wake_machine_identity_unix_test.go
+++ b/internal/cli/wake_machine_identity_unix_test.go
@@ -1,0 +1,51 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestNewWakeLockRecordsMachineIDWhenAvailable(t *testing.T) {
+	root := secureTempDirForTest(t)
+	stubCurrentWakeMachineID(t, testMachineUUID)
+
+	lock, err := newWakeLock(root, "codex", wakeLockAcquireOptions{wakeMode: wakeInjectModeRaw})
+	if err != nil {
+		t.Fatalf("new wake lock: %v", err)
+	}
+	if lock.MachineID != testMachineUUID {
+		t.Fatalf("machine id = %q, want %q", lock.MachineID, testMachineUUID)
+	}
+	data, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte(`"machine_id":"`+testMachineUUID+`"`)) {
+		t.Fatalf("lock JSON lacks machine_id: %s", data)
+	}
+}
+
+// A host without a stable machine identity is a valid runtime state: lock
+// creation must succeed and the omitempty field must stay off the wire.
+func TestNewWakeLockOmitsMachineIDWhenUnavailable(t *testing.T) {
+	root := secureTempDirForTest(t)
+	stubCurrentWakeMachineID(t, "")
+
+	lock, err := newWakeLock(root, "codex", wakeLockAcquireOptions{wakeMode: wakeInjectModeRaw})
+	if err != nil {
+		t.Fatalf("new wake lock without machine id: %v", err)
+	}
+	if lock.MachineID != "" {
+		t.Fatalf("machine id = %q, want empty", lock.MachineID)
+	}
+	data, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte(`"machine_id"`)) {
+		t.Fatalf("lock JSON contains machine_id despite unavailable identity: %s", data)
+	}
+}

--- a/internal/cli/wake_p0_golden_abi_unix_test.go
+++ b/internal/cli/wake_p0_golden_abi_unix_test.go
@@ -718,6 +718,11 @@ func TestWakeP0BinaryWakeLockJSONShape(t *testing.T) {
 		"started": true, "process_start": true, "boot_id": true, "executable": true,
 		"image_path": true, "image_version": true, "wake_mode": true, "generation": true,
 	}
+	// machine_id is best-effort: recorded when a stable machine identity is
+	// available, omitted otherwise. Both are valid lock ABI states.
+	if _, ok := lock["machine_id"]; ok {
+		expectedKeys["machine_id"] = true
+	}
 	if runtime.GOOS == "linux" {
 		expectedKeys["args"] = true
 	} else {
@@ -744,6 +749,11 @@ func TestWakeP0BinaryWakeLockJSONShape(t *testing.T) {
 	for _, key := range []string{"hostname", "process_start", "boot_id", "executable", "image_path", "image_version"} {
 		if strings.TrimSpace(wakeABIString(t, lock, key)) == "" {
 			t.Fatalf("wake lock %s is empty: %#v", key, lock)
+		}
+	}
+	if _, ok := lock["machine_id"]; ok {
+		if strings.TrimSpace(wakeABIString(t, lock, "machine_id")) == "" {
+			t.Fatalf("wake lock machine_id present but empty: %#v", lock)
 		}
 	}
 	if runtime.GOOS == "linux" {

--- a/internal/cli/wake_repair_floor_unix.go
+++ b/internal/cli/wake_repair_floor_unix.go
@@ -21,10 +21,6 @@ const (
 	maxWakeRepairFloorFileBytes = 8 * 1024 * 1024
 )
 
-var currentWakeBootID = func() string {
-	return inspectWakeProcess(os.Getpid()).BootID
-}
-
 // wakeRepairFloor is private continuity state for one ownerless inject-via
 // lineage. Existing contains only the exact local file identities that the
 // running wake deliberately suppresses. It never records or compares message

--- a/internal/cli/wake_repair_unix_test.go
+++ b/internal/cli/wake_repair_unix_test.go
@@ -122,15 +122,6 @@ func stubStartWakeFromTarget(t *testing.T, fn wakeRepairTestStarter) {
 	})
 }
 
-func stubCurrentWakeBootID(t *testing.T, bootID string) {
-	t.Helper()
-	old := currentWakeBootID
-	currentWakeBootID = func() string { return bootID }
-	t.Cleanup(func() {
-		currentWakeBootID = old
-	})
-}
-
 func ensureWakeRepairLockIdentityForTest(t *testing.T, root, me string) wakeLock {
 	t.Helper()
 	path := filepath.Join(fsq.AgentBase(root, me), ".wake.lock")

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -709,6 +709,7 @@ func newWakeLock(root, me string, options wakeLockAcquireOptions) (wakeLock, err
 	if hostname, err := os.Hostname(); err == nil {
 		lock.Hostname = hostname
 	}
+	lock.MachineID = currentWakeMachineID()
 	if proc := inspectWakeProcess(os.Getpid()); proc.Running {
 		lock.ProcessStart = proc.StartToken
 		lock.BootID = proc.BootID


### PR DESCRIPTION
## Problem

`classifyWakeLock` gated on hostname equality before any process inspection. The kernel hostname is network-derived on macOS (when `scutil HostName` is unset, the default), so wake locks record whatever name the network assigned — real locks on one machine recorded `mac`, `Mac`, and `Avivs-MacBook-Pro.local`. After any drift, a lock classified `unverified` forever, forcing an interactive prompt on every `amq coop exec` resume even when the recorded PID was provably dead across a reboot.

## Fix

New locks record a stable machine identity (`machine_id`, best-effort, omitted when unavailable):
- darwin: hardware platform UUID via `gethostuuid(2)` (equal to `IOPlatformUUID`), finite timeout, no cgo, no exec
- linux: `/etc/machine-id`, fallback `/var/lib/dbus/machine-id`

Verification proves same-machine by evidence strength: machine id (decisive both directions) → strict same-boot-session UUID bridge (rescues pre-machine_id locks from in-boot hostname drift) → legacy hostname comparison, unchanged, as last resort. A machine-id mismatch stays `unverified` even when hostnames match.

Effect: a dead wake from an old boot of the same machine now classifies `stale`, and `coop exec` clears it silently. Verified live A/B on the same dead lock: v0.60.3 → `unverified` (prompts), this branch → `stale` (auto-cleared).

## GOLDEN-CHANGE

The P0 lock ABI golden gains the optional `machine_id` key — additive; required non-empty only when present; omission is a valid state (writer tests pin both branches).

## Review

Design + two staged-snapshot reviews by codex via AMQ; approved on the exact committed snapshot (diff SHA-256 `10a60a6a…`). `make ci` green; linux/windows cross-builds pass; hostile test matrix covers machine-id precedence, bridge strictness, JSON trust-matrix joins, and darwin errno/timeout seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N17nDzcBQEbWpboBLTTyRn