### PR TITLE
fix(fsq): reconcile windows claim residue when the source name is already gone

### DIFF
--- a/internal/fsq/claim_rename_windows.go
+++ b/internal/fsq/claim_rename_windows.go
@@ -69,7 +69,10 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 			return fmt.Errorf("claim %s: %w", root.displayPath(newPath), windowsClaimError(err))
 		}
 		if err := removeClaimSource(source); err != nil && !claimTransitionAlreadyDone(err) {
-			return &claimCommittedResidueError{Err: windowsClaimError(err)}
+			gone, recheckErr := claimSourceNameGone(root, newPath)
+			if !gone {
+				return &claimCommittedResidueError{Err: errors.Join(windowsClaimError(err), recheckErr)}
+			}
 		}
 		return nil
 	}
@@ -98,7 +101,10 @@ func claimRename(root *DeliveryRoot, newPath, curPath string) error {
 		// process crashed between those operations. Reconcile that residue and
 		// report this caller as a loser rather than redelivering the message.
 		if err := removeClaimSource(source); err != nil && !claimTransitionAlreadyDone(err) {
-			return fmt.Errorf("remove duplicate claim source %s: %w", root.displayPath(newPath), windowsClaimError(err))
+			gone, recheckErr := claimSourceNameGone(root, newPath)
+			if !gone {
+				return fmt.Errorf("remove duplicate claim source %s: %w", root.displayPath(newPath), errors.Join(windowsClaimError(err), recheckErr))
+			}
 		}
 		return os.ErrNotExist
 	}
@@ -160,7 +166,12 @@ func linkClaimHandle(source, destinationDirectory windows.Handle, destinationNam
 	)
 }
 
-func removeClaimSource(source windows.Handle) error {
+// removeClaimSource is a var so tests can interleave a concurrent unlink with
+// a hostile NT status deterministically. setClaimSourceDisposition stays
+// reachable so those tests unlink through the real production primitive.
+var removeClaimSource = setClaimSourceDisposition
+
+func setClaimSourceDisposition(source windows.Handle) error {
 	info := fileDispositionInformationEx{
 		Flags: fileDispositionDelete | fileDispositionPosixSemantics,
 	}
@@ -172,6 +183,26 @@ func removeClaimSource(source windows.Handle) error {
 		uint32(unsafe.Sizeof(info)),
 		windows.FileDispositionInformationEx,
 	)
+}
+
+// claimSourceNameGone reports whether the claim source name has already been
+// removed from the directory. It adjudicates removal failures whose NT status
+// is not in claimTransitionAlreadyDone: concurrent claimants race their
+// POSIX-semantics disposition sets on the same file, and the loser of that
+// inner race can see a status such as ERROR_ACCESS_DENIED even though the
+// name is gone and its removal goal is met. Only proven absence is benign; a
+// still-present name (including out-of-contract recreation) or an inspection
+// failure keeps the loud error, with the inspection error returned so callers
+// can join both causes.
+func claimSourceNameGone(root *DeliveryRoot, newPath string) (bool, error) {
+	_, err := root.root.Lstat(newPath)
+	if err == nil {
+		return false, nil
+	}
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	return false, fmt.Errorf("recheck claim source after failed removal: %w", err)
 }
 
 func windowsClaimLinkUnsupported(err error) bool {

--- a/internal/fsq/claim_residue_race_windows_test.go
+++ b/internal/fsq/claim_residue_race_windows_test.go
@@ -1,0 +1,164 @@
+//go:build windows
+
+package fsq
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func stubRemoveClaimSource(t *testing.T, fn func(source windows.Handle) error) {
+	t.Helper()
+	old := removeClaimSource
+	removeClaimSource = fn
+	t.Cleanup(func() { removeClaimSource = old })
+}
+
+// unlinkClaimSourceOutOfBand removes the source name through an independent
+// POSIX-disposition handle — the actual production primitive — simulating a
+// concurrent claimant winning the inner disposition race. os.Remove cannot
+// stand in here: it uses classic DeleteFile delete-on-close, which leaves the
+// name visible while the claimant's handle is still open. Closing the
+// independent handle removes the namespace link while other existing handles
+// remain usable.
+func unlinkClaimSourceOutOfBand(t *testing.T, path string) {
+	t.Helper()
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("open source directory: %v", err)
+	}
+	defer func() { _ = dir.Close() }()
+	handle, err := openClaimSource(windows.Handle(dir.Fd()), filepath.Base(path))
+	if err != nil {
+		t.Fatalf("open independent claim handle: %v", err)
+	}
+	if err := setClaimSourceDisposition(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		t.Fatalf("posix unlink via independent handle: %v", err)
+	}
+	if err := windows.CloseHandle(handle); err != nil {
+		t.Fatalf("close independent handle: %v", err)
+	}
+	if _, statErr := os.Lstat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("source name state after out-of-band unlink = %v, want absent", statErr)
+	}
+}
+
+// A residue-reconciling loser whose removal fails with a status outside
+// claimTransitionAlreadyDone must still honor the loser contract when the
+// source name is provably gone. This is the race behind the flaky
+// TestMoveNewToCurConcurrentClaimsSingleWinner Access-is-denied failure.
+func TestClaimResidueLoserBenignWhenSourceAlreadyUnlinked(t *testing.T) {
+	base := setupClaimAgent(t, "alice")
+	newPath := filepath.Join(AgentInboxNew(base, "alice"), "residue.md")
+	curPath := filepath.Join(AgentInboxCur(base, "alice"), "residue.md")
+	if err := os.WriteFile(newPath, []byte("body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Winner residue state: cur linked, new still present, same file.
+	if err := os.Link(newPath, curPath); err != nil {
+		t.Fatal(err)
+	}
+
+	stubRemoveClaimSource(t, func(source windows.Handle) error {
+		unlinkClaimSourceOutOfBand(t, newPath)
+		return windows.STATUS_ACCESS_DENIED
+	})
+
+	root := openDeliveryRootForTest(t, base)
+	err := MoveNewToCur(root, "alice", "residue.md")
+	if !os.IsNotExist(err) {
+		t.Fatalf("error = %T %v, want os.IsNotExist loser contract", err, err)
+	}
+	if got, readErr := os.ReadFile(curPath); readErr != nil || string(got) != "body" {
+		t.Fatalf("retained cur copy = %q, %v; want intact payload", got, readErr)
+	}
+	if _, statErr := os.Lstat(newPath); !os.IsNotExist(statErr) {
+		t.Fatalf("source name state = %v, want absent", statErr)
+	}
+}
+
+// The same adjudication on the winner path: a committed claim whose source
+// removal reports a hostile status must not surface residue durability noise
+// when the name is already gone.
+func TestClaimWinnerBenignWhenSourceAlreadyUnlinked(t *testing.T) {
+	base := setupClaimAgent(t, "alice")
+	newPath := filepath.Join(AgentInboxNew(base, "alice"), "winner.md")
+	if err := os.WriteFile(newPath, []byte("body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stubRemoveClaimSource(t, func(source windows.Handle) error {
+		unlinkClaimSourceOutOfBand(t, newPath)
+		return windows.STATUS_ACCESS_DENIED
+	})
+
+	root := openDeliveryRootForTest(t, base)
+	if err := MoveNewToCur(root, "alice", "winner.md"); err != nil {
+		t.Fatalf("winner claim = %v, want nil", err)
+	}
+	curPath := filepath.Join(AgentInboxCur(base, "alice"), "winner.md")
+	if got, readErr := os.ReadFile(curPath); readErr != nil || string(got) != "body" {
+		t.Fatalf("claimed cur copy = %q, %v; want intact payload", got, readErr)
+	}
+	if _, statErr := os.Lstat(newPath); !os.IsNotExist(statErr) {
+		t.Fatalf("source name state = %v, want absent", statErr)
+	}
+}
+
+// A removal failure with the source name still present must stay loud at both
+// sites; proven absence is the only benign evidence. This is the case that
+// proves real DELETE-access failures are not masked.
+func TestClaimWinnerRemovalFailureWithSourcePresentStaysLoud(t *testing.T) {
+	base := setupClaimAgent(t, "alice")
+	newPath := filepath.Join(AgentInboxNew(base, "alice"), "loud.md")
+	if err := os.WriteFile(newPath, []byte("body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stubRemoveClaimSource(t, func(source windows.Handle) error {
+		return windows.STATUS_ACCESS_DENIED
+	})
+
+	root := openDeliveryRootForTest(t, base)
+	err := MoveNewToCur(root, "alice", "loud.md")
+	if err == nil || os.IsNotExist(err) {
+		t.Fatalf("error = %T %v, want loud residue failure", err, err)
+	}
+	var committed *CommittedDurabilityError
+	if !errors.As(err, &committed) {
+		t.Fatalf("error = %T %v, want CommittedDurabilityError", err, err)
+	}
+	if _, statErr := os.Lstat(newPath); statErr != nil {
+		t.Fatalf("source name state = %v, want still present", statErr)
+	}
+}
+
+func TestClaimResidueLoserRemovalFailureWithSourcePresentStaysLoud(t *testing.T) {
+	base := setupClaimAgent(t, "alice")
+	newPath := filepath.Join(AgentInboxNew(base, "alice"), "loud_residue.md")
+	curPath := filepath.Join(AgentInboxCur(base, "alice"), "loud_residue.md")
+	if err := os.WriteFile(newPath, []byte("body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(newPath, curPath); err != nil {
+		t.Fatal(err)
+	}
+
+	stubRemoveClaimSource(t, func(source windows.Handle) error {
+		return windows.STATUS_ACCESS_DENIED
+	})
+
+	root := openDeliveryRootForTest(t, base)
+	err := MoveNewToCur(root, "alice", "loud_residue.md")
+	if err == nil || os.IsNotExist(err) {
+		t.Fatalf("error = %T %v, want loud remove-duplicate failure", err, err)
+	}
+	if _, statErr := os.Lstat(newPath); statErr != nil {
+		t.Fatalf("source name state = %v, want still present", statErr)
+	}
+}


### PR DESCRIPTION
## Problem

`windows-claim-test` flakes intermittently (last seen blocking release PR #489): `TestMoveNewToCurConcurrentClaimsSingleWinner` fails with `remove duplicate claim source ... Access is denied`. Concurrent claimants race their POSIX-semantics disposition sets on the same source file; the loser of that inner race can observe a hostile NT status even though the name is already gone and its removal goal is met.

## Fix

Verify-then-benign at both `removeClaimSource` sites in `claimRename`: on a removal error outside `claimTransitionAlreadyDone`, re-inspect the source name through the pinned root. Proven absence keeps the existing contracts (winner → `nil`, residue loser → `os.ErrNotExist`); a present name — including out-of-contract recreation — or an uninspectable state stays loud, with the removal and recheck causes joined. `STATUS_ACCESS_DENIED` is never blanket-benign, so real DELETE-access failures still fail. Unix untouched.

## Tests

Deterministic Windows regression tests recreate the exact race via the production POSIX disposition primitive on an independent handle (`os.Remove` cannot stand in — it is classic `DeleteFile` delete-on-close in Go 1.25): winner-benign, residue-loser-benign, and loud negatives at both sites proving present-name failures are not masked. The concurrent stress test remains as integration evidence.

## Review

Design + two staged-snapshot reviews by codex via AMQ; approved on the exact committed snapshot (`ebcdd19d…`), including independent windows vet/compile evidence. Merge held until the real `windows-claim-test` job is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N17nDzcBQEbWpboBLTTyRn