### PR TITLE
fix(coop): refuse provisioning into non-queue roots and resolve the binary first

### DIFF
--- a/internal/cli/coop_exec_guard_test.go
+++ b/internal/cli/coop_exec_guard_test.go
@@ -168,6 +168,39 @@ func TestCoopExecInvalidSessionPrecedesMissingBinary(t *testing.T) {
 	}
 }
 
+// Selector-free exec with a missing binary must not auto-init anything: no
+// .amqrc, no queue tree. This is the new-contract twin of the old fixture
+// that asserted auto-init ran before binary resolution.
+func TestCoopExecSelectorFreeMissingBinaryPerformsZeroWrites(t *testing.T) {
+	clearCoopSessionPinForTest(t)
+	setOptionalEnv(t, envRoot, "", false)
+	setOptionalEnv(t, envGlobalRoot, "", false)
+	t.Setenv("HOME", t.TempDir())
+	projectDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldDir)
+		resetAmqrcCache()
+	})
+	resetAmqrcCache()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	err = runCoopExec([]string{"--no-gitignore", "--no-wake", "-y", "definitely-missing-agent-binary-xyz"})
+	if err == nil || !strings.Contains(err.Error(), "command not found") {
+		t.Fatalf("error = %v, want command-not-found", err)
+	}
+	for _, artifact := range []string{".amqrc", defaultCoopRoot} {
+		if _, statErr := os.Lstat(filepath.Join(projectDir, artifact)); !os.IsNotExist(statErr) {
+			t.Fatalf("%s created despite missing binary: %v", artifact, statErr)
+		}
+	}
+}
+
 // The alias-swap boundary: replacing the lexical root between classification
 // and provisioning must fail closed with zero writes to the impostor.
 func TestCoopExecAliasSwapBetweenClassifyAndProvisionFailsClosed(t *testing.T) {

--- a/internal/cli/coop_exec_guard_test.go
+++ b/internal/cli/coop_exec_guard_test.go
@@ -1,0 +1,210 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func stubCoopExecSentinel(t *testing.T) error {
+	t.Helper()
+	sentinel := errors.New("exec sentinel")
+	old := coopExecProcess
+	coopExecProcess = func(string, []string, []string) error { return sentinel }
+	t.Cleanup(func() { coopExecProcess = old })
+	return sentinel
+}
+
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// The notaqueue repro from #480: a pre-existing directory that is not a queue
+// must never gain a mailbox, no matter that it exists.
+func TestCoopExecForeignRootRefusedWithZeroWrites(t *testing.T) {
+	dir := secureTempDirForTest(t)
+	if err := os.WriteFile(filepath.Join(dir, "somefile.txt"), []byte("not a queue"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_ = stubCoopExecSentinel(t)
+
+	err := runCoopExec([]string{"--root", dir, "--me", "codex", "--no-wake", "sh"})
+	if err == nil || !strings.Contains(err.Error(), "not an initialized AMQ queue root") {
+		t.Fatalf("error = %v, want foreign-root refusal", err)
+	}
+	if code := GetExitCode(err); code != ExitNotFound {
+		t.Fatalf("exit code = %d, want %d (not-found contract)", code, ExitNotFound)
+	}
+	if got := dirEntryNames(t, dir); len(got) != 1 || got[0] != "somefile.txt" {
+		t.Fatalf("foreign dir mutated: %v", got)
+	}
+}
+
+// An empty pre-made directory provisions the same full tree a missing root
+// gets — a valid queue, never the partial agents-only shape the bug minted.
+func TestCoopExecEmptyPremadeRootProvisionsFullTree(t *testing.T) {
+	dir := secureTempDirForTest(t)
+	sentinel := stubCoopExecSentinel(t)
+
+	err := runCoopExec([]string{"--root", dir, "--me", "codex", "--no-wake", "sh"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want exec sentinel", err)
+	}
+	for _, marker := range []string{"agents", "threads", "meta"} {
+		info, statErr := os.Lstat(filepath.Join(dir, marker))
+		if statErr != nil || !info.IsDir() {
+			t.Fatalf("marker %s missing or not a dir: %v", marker, statErr)
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "agents", "codex", "inbox", "new")); statErr != nil {
+		t.Fatalf("mailbox missing: %v", statErr)
+	}
+}
+
+// A partial tree (the shape this very bug used to mint) converges to a valid
+// queue instead of persisting half-initialized.
+func TestCoopExecPartialRootConvergesToValidTree(t *testing.T) {
+	dir := secureTempDirForTest(t)
+	if err := os.Mkdir(filepath.Join(dir, "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := stubCoopExecSentinel(t)
+
+	err := runCoopExec([]string{"--root", dir, "--me", "codex", "--no-wake", "sh"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want exec sentinel", err)
+	}
+	for _, marker := range []string{"threads", "meta"} {
+		info, statErr := os.Lstat(filepath.Join(dir, marker))
+		if statErr != nil || !info.IsDir() {
+			t.Fatalf("marker %s not completed: %v", marker, statErr)
+		}
+	}
+}
+
+// agents/ existing as a symlink is a hostile shape: refuse, and never write
+// through the link.
+func TestCoopExecAgentsSymlinkFailsClosed(t *testing.T) {
+	dir := secureTempDirForTest(t)
+	target := secureTempDirForTest(t)
+	if err := os.Symlink(target, filepath.Join(dir, "agents")); err != nil {
+		t.Fatal(err)
+	}
+	_ = stubCoopExecSentinel(t)
+
+	err := runCoopExec([]string{"--root", dir, "--me", "codex", "--no-wake", "sh"})
+	if err == nil || !strings.Contains(err.Error(), "refusing to provision") {
+		t.Fatalf("error = %v, want hostile-shape refusal", err)
+	}
+	if got := dirEntryNames(t, target); len(got) != 0 {
+		t.Fatalf("symlink target gained entries: %v", got)
+	}
+}
+
+// A hostile threads/ or meta/ symlink beside a real agents/ must never cause
+// a write outside the tree; same-root partial completion before the failure
+// is reported honestly via the returned error.
+func TestCoopExecHostileSiblingSymlinkNeverWritesOutside(t *testing.T) {
+	for _, marker := range []string{"threads", "meta"} {
+		t.Run(marker, func(t *testing.T) {
+			dir := secureTempDirForTest(t)
+			outside := secureTempDirForTest(t)
+			if err := os.Mkdir(filepath.Join(dir, "agents"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(outside, filepath.Join(dir, marker)); err != nil {
+				t.Fatal(err)
+			}
+			_ = stubCoopExecSentinel(t)
+
+			err := runCoopExec([]string{"--root", dir, "--me", "codex", "--no-wake", "sh"})
+			if err == nil {
+				t.Fatalf("hostile %s symlink accepted", marker)
+			}
+			if got := dirEntryNames(t, outside); len(got) != 0 {
+				t.Fatalf("outside tree gained entries through %s: %v", marker, got)
+			}
+		})
+	}
+}
+
+// A typo'd command must fail before any provisioning: no root, no tree.
+func TestCoopExecMissingBinaryPerformsZeroWrites(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	root := filepath.Join(parent, "wouldberoot")
+
+	err := runCoopExec([]string{"--root", root, "--me", "codex", "--no-wake", "definitely-missing-agent-binary-xyz"})
+	if err == nil || !strings.Contains(err.Error(), "command not found") {
+		t.Fatalf("error = %v, want command-not-found", err)
+	}
+	if _, statErr := os.Lstat(root); !os.IsNotExist(statErr) {
+		t.Fatalf("root created despite missing binary: %v", statErr)
+	}
+}
+
+// Usage validation keeps precedence over binary resolution: an invalid
+// session name with a missing binary reports the validation error, never
+// command-not-found.
+func TestCoopExecInvalidSessionPrecedesMissingBinary(t *testing.T) {
+	err := runCoopExec([]string{"--session", "../bad", "--no-wake", "definitely-missing-agent-binary-xyz"})
+	if err == nil || strings.Contains(err.Error(), "command not found") {
+		t.Fatalf("error = %v, want session validation error before binary resolution", err)
+	}
+	if code := GetExitCode(err); code != ExitUsage {
+		t.Fatalf("exit code = %d, want %d (usage contract)", code, ExitUsage)
+	}
+}
+
+// The alias-swap boundary: replacing the lexical root between classification
+// and provisioning must fail closed with zero writes to the impostor.
+func TestCoopExecAliasSwapBetweenClassifyAndProvisionFailsClosed(t *testing.T) {
+	parent := secureTempDirForTest(t)
+	root := filepath.Join(parent, "queue")
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	moved := filepath.Join(parent, "moved-away")
+	impostor := filepath.Join(parent, "impostor")
+	if err := os.Mkdir(impostor, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHook := coopProvisionAfterClassifyHook
+	coopProvisionAfterClassifyHook = func() {
+		if err := os.Rename(root, moved); err != nil {
+			t.Fatalf("move root: %v", err)
+		}
+		if err := os.Rename(impostor, root); err != nil {
+			t.Fatalf("install impostor: %v", err)
+		}
+	}
+	t.Cleanup(func() { coopProvisionAfterClassifyHook = oldHook })
+	_ = stubCoopExecSentinel(t)
+
+	err := runCoopExec([]string{"--root", root, "--me", "codex", "--no-wake", "sh"})
+	if err == nil {
+		t.Fatal("alias swap accepted")
+	}
+	if got := dirEntryNames(t, root); len(got) != 0 {
+		t.Fatalf("impostor gained entries: %v", got)
+	}
+	if got := dirEntryNames(t, filepath.Join(moved, "agents")); len(got) != 0 {
+		t.Fatalf("moved tree mutated after swap detection: %v", got)
+	}
+}

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -1379,7 +1379,7 @@ func TestCoopExecAutoInitNoGitignoreLeavesInheritedCoopTreeUnchanged(t *testing.
 	}
 	fixtureAgent := fsq.AgentBase(
 		filepath.Join(projectDir, defaultCoopRoot, defaultSessionName),
-		"definitely-missing-amq-test-binary",
+		"fixtureagent",
 	)
 	if info, err := os.Stat(fixtureAgent); err != nil || !info.IsDir() {
 		t.Fatalf("isolated fixture mailbox missing: info=%v err=%v", info, err)
@@ -1410,12 +1410,13 @@ func runCoopExecAutoInitNoGitignoreFixture(t *testing.T) string {
 		t.Fatalf("write .gitignore: %v", err)
 	}
 
-	err = runCoopExec([]string{"--no-gitignore", "--no-wake", "-y", "definitely-missing-amq-test-binary"})
-	if err == nil {
-		t.Fatal("expected command lookup error")
-	}
-	if !containsStr(err.Error(), "command not found") {
-		t.Fatalf("unexpected error: %v", err)
+	// Auto-init requires a resolvable binary: the provisioning guard resolves
+	// the command before any filesystem effect, so the fixture runs a real
+	// binary with the exec stubbed to a sentinel.
+	sentinel := stubCoopExecSentinel(t)
+	err = runCoopExec([]string{"--no-gitignore", "--no-wake", "-y", "--me", "fixtureagent", "sh"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want exec sentinel", err)
 	}
 	if _, err := os.Stat(filepath.Join(projectDir, ".amqrc")); err != nil {
 		t.Fatalf(".amqrc should be created by coop exec auto-init: %v", err)

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -215,6 +215,15 @@ func runCoopExec(args []string) error {
 		}
 	}
 
+	// Resolve the command binary after every pure flag/name validation but
+	// before the first provisioning mutation: a typo'd command must fail
+	// without minting roots, sessions, or mailboxes, while usage errors keep
+	// their established precedence over command-not-found.
+	binaryPath, err := exec.LookPath(cmdName)
+	if err != nil {
+		return fmt.Errorf("command not found: %s", cmdName)
+	}
+
 	// Explicit named sessions use the same direct-child creation boundary as
 	// coop init/default exec. In particular, never let MkdirAll traverse a
 	// pre-existing session symlink.
@@ -325,17 +334,15 @@ func runCoopExec(args []string) error {
 		return fmt.Errorf("resolve absolute session root: %w", err)
 	}
 
-	// Ensure agent mailbox exists.
+	// Ensure the agent mailbox exists — but only inside a tree that is
+	// provably a queue. A pre-existing directory is not a provisioning
+	// target just because it exists (dirExists said nothing about what it
+	// is), so classify the layout through a pinned capability first and keep
+	// that same capability for the writes.
 	if !sessionProvisioned {
-		if err := fsq.EnsureAgentDirs(root, agentHandle); err != nil {
-			return fmt.Errorf("failed to ensure mailbox for %s: %w", agentHandle, err)
+		if err := provisionSelfMailboxInExistingRoot(root, agentHandle); err != nil {
+			return err
 		}
-	}
-
-	// Resolve command binary.
-	binaryPath, err := exec.LookPath(cmdName)
-	if err != nil {
-		return fmt.Errorf("command not found: %s", cmdName)
 	}
 	if !*noWakeFlag {
 		if err := prepareCoopWakeLock(
@@ -604,6 +611,53 @@ func runCoopExec(args []string) error {
 		execErr = fmt.Errorf("exec returned without replacing process")
 	}
 	return cleanupAfterError(execErr)
+}
+
+// coopProvisionAfterClassifyHook runs between layout classification and the
+// provisioning writes. Test-only seam for the alias-swap boundary proof.
+var coopProvisionAfterClassifyHook func()
+
+// provisionSelfMailboxInExistingRoot provisions one agent mailbox inside a
+// pre-existing root, refusing trees that are not queues. The pinned
+// capability opened for classification is retained through the writes, so the
+// lexical root cannot be aliased between validation and provisioning.
+func provisionSelfMailboxInExistingRoot(root, agentHandle string) error {
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		return fmt.Errorf("inspect root %q: %w", root, err)
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		return fmt.Errorf("open root %q: %w", root, err)
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+
+	state, err := deliveryRoot.ClassifyLayout()
+	if err != nil {
+		return fmt.Errorf("refusing to provision in %q: %w", root, err)
+	}
+	if coopProvisionAfterClassifyHook != nil {
+		coopProvisionAfterClassifyHook()
+	}
+	switch state {
+	case fsq.LayoutForeign:
+		return NotFoundError(
+			"root %q exists but is not an initialized AMQ queue root (no agents/ directory); "+
+				"point --root at an existing queue, or create one with: amq init --root %s --agents %s",
+			root, shellQuoteArg(root), shellQuoteArg(agentHandle),
+		)
+	case fsq.LayoutEmpty, fsq.LayoutInitialized:
+		// Empty pre-made directories provision the same full tree a missing
+		// root gets today; initialized roots idempotently gain any missing
+		// top-level directories so a partial tree converges to a valid one.
+		if err := deliveryRoot.EnsureRootDirs(); err != nil {
+			return fmt.Errorf("failed to ensure root layout at %q: %w", root, err)
+		}
+	}
+	if err := deliveryRoot.EnsureAgentDirs(agentHandle); err != nil {
+		return fmt.Errorf("failed to ensure mailbox for %s: %w", agentHandle, err)
+	}
+	return nil
 }
 
 func exactCoopWakeHelperClaim(

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -272,6 +272,47 @@ func (r *DeliveryRoot) EnsureAgentDirs(agent string) error {
 	return nil
 }
 
+// LayoutState classifies a pinned root's top-level queue layout.
+type LayoutState int
+
+const (
+	// LayoutInitialized: agents/ exists as a real directory — the minimum
+	// evidence that this tree is (or is becoming) an AMQ queue.
+	LayoutInitialized LayoutState = iota
+	// LayoutEmpty: the root directory has no entries at all.
+	LayoutEmpty
+	// LayoutForeign: the root has entries but no agents/ directory — it is
+	// some other directory, not a queue.
+	LayoutForeign
+)
+
+// ClassifyLayout inspects the pinned root without writes and reports whether
+// it is an initialized queue, an empty directory, or a foreign tree. An
+// agents/ entry that is not a real directory (symlink, file) is a hostile
+// shape and fails closed with an error.
+func (r *DeliveryRoot) ClassifyLayout() (LayoutState, error) {
+	entries, err := r.ReadDir(".")
+	if err != nil {
+		return LayoutForeign, err
+	}
+	if len(entries) == 0 {
+		return LayoutEmpty, nil
+	}
+	for _, entry := range entries {
+		if entry.Name() != "agents" {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+			return LayoutForeign, fmt.Errorf(
+				"agents entry at %s is not a real directory; refusing to treat this tree as a queue root",
+				r.displayPath("agents"),
+			)
+		}
+		return LayoutInitialized, nil
+	}
+	return LayoutForeign, nil
+}
+
 // VerifyBase reports a lexical alias change after authorization. The open root
 // remains the security boundary even if an alias changes immediately after
 // this check; this verification makes a detected swap fail closed instead of


### PR DESCRIPTION
## Problem

Verified in the #480 thread (round-four repro at `449b49e`): `coop exec` treated any pre-existing directory as a provisioning target. `dirExists(root)` said nothing about what the directory was, and raw lexical `fsq.EnsureAgentDirs` minted `agents/<handle>` into arbitrary trees — leaving structurally incomplete roots (no `meta/`, no `threads/`) that satisfy `dirExists` forever. Separately, the agent binary was resolved after every provisioning site, so a typo'd command still left writes behind.

## Fix

Direct-root provisioning now runs through one pinned `DeliveryRoot` capability held from classification through the writes (`ClassifyLayout` in fsq):

- foreign directory (entries, no `agents/`) → exit 3, zero writes
- empty pre-made directory → the same full valid tree a missing root gets today
- partial tree (the shape this bug minted) → converges to a valid queue
- hostile shapes (`agents/`/`threads/`/`meta/` as symlinks) → fail closed, never write outside the tree
- alias swap between classification and provisioning → fails closed via `VerifyBase` (execution-tested)

`exec.LookPath` moves after all pure validation and before the first provisioning mutation — usage errors keep precedence, and a missing binary now performs zero writes.

Interim fix ahead of the #480 Wave A contract: no selector behavior changes, no creation-path retirement.

## Review

Design + two staged reviews by codex via AMQ (approved snapshot `75f43996…`), including its counterexample that became `TestCoopExecInvalidSessionPrecedesMissingBinary`. Codex ran independent focused, race, vet, and owning-package checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N17nDzcBQEbWpboBLTTyRn