### PR TITLE
feat(cli): add exit code 6 (action_required) and launch aggregate precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,12 +559,19 @@ AMQ exposes stable process exit codes for scripts and agent consumers:
 | `3` | Not found. A requested resource such as a mailbox, message, session, agent, or configuration does not exist. |
 | `4` | Timeout. A watch, monitor, receipt wait, or delivery wait reached its deadline. |
 | `5` | Context mismatch. A syntactically valid route was refused, including a pin conflict or an ineligible implicit root inside Git. |
+| `6` | Action required. The command cannot proceed without an operator action (stale conversation token, unknown backend inspect, untrusted config, blocked rebind). |
 
 The numeric meaning is the machine contract; stderr is human-readable context
 and should not be parsed as a stable discriminator. `--json` does not change
 these process exit codes. A read-only `list` on a mismatched session pin warns
 and continues; commands that consume or mutate mailbox state fail with code
 `5`.
+
+When a command reports per-agent outcomes, whole-command failures that precede
+any per-agent work keep codes `2`, `5`, and `3` and preempt mixed results. Once
+per-agent work begins, the process exit code is the highest-precedence per-agent
+outcome: `6` over `4` over `1` over `0`. Expected dispositions (`disabled`,
+`unsupported`, and policy-consistent `fresh`) contribute `0`.
 
 For the full CLI syntax, examples, and message schema, see [CLAUDE.md](CLAUDE.md).
 For the read-only trace contract and its evidence limits, see [docs/trace.md](docs/trace.md).

--- a/internal/cli/exitcode.go
+++ b/internal/cli/exitcode.go
@@ -24,6 +24,11 @@ const (
 	// ExitContextMismatch indicates a valid command was blocked because its
 	// resolved mailbox root conflicts with the pinned AMQ session context.
 	ExitContextMismatch = 5
+
+	// ExitActionRequired indicates the command cannot proceed without an
+	// operator action (stale conversation token, Inspect unknown, untrusted
+	// config digest, refused committed-command shape, blocked auto-rebind).
+	ExitActionRequired = 6
 )
 
 // SessionContextError identifies an unsafe or incoherent mailbox context.
@@ -102,5 +107,78 @@ func ContextMismatchError(format string, args ...any) error {
 	return &ExitCodeError{
 		Code: ExitContextMismatch,
 		Err:  &SessionContextError{Message: fmt.Sprintf(format, args...)},
+	}
+}
+
+// ActionRequiredError creates an error with ExitActionRequired code.
+func ActionRequiredError(format string, args ...any) error {
+	return &ExitCodeError{
+		Code: ExitActionRequired,
+		Err:  fmt.Errorf(format, args...),
+	}
+}
+
+// AgentDisposition classifies a per-agent launch/resume outcome.
+type AgentDisposition string
+
+const (
+	// AgentDispositionDisabled is an expected skip; it contributes 0.
+	AgentDispositionDisabled AgentDisposition = "disabled"
+	// AgentDispositionUnsupported is an expected capability skip; it contributes 0.
+	AgentDispositionUnsupported AgentDisposition = "unsupported"
+	// AgentDispositionFresh is a policy-consistent fresh start; it contributes 0.
+	AgentDispositionFresh AgentDisposition = "fresh"
+)
+
+// AgentOutcome is one agent's contribution to an aggregate process exit code.
+type AgentOutcome struct {
+	Code        int
+	Disposition AgentDisposition
+}
+
+// AggregateExitCode implements the §11 launch/resume exit contract.
+// A nonzero wholeCommand is a pre-launch failure and is returned as-is.
+// Once per-agent work begins (wholeCommand == 0), the aggregate is the
+// highest-precedence per-agent outcome: 6 > 4 > 1 > 0.
+// Expected dispositions (disabled, unsupported, policy-consistent fresh)
+// contribute 0 even when Code is set to a failure. A nonzero per-agent
+// code outside {6, 4, 1, 0} fails closed as ExitError.
+func AggregateExitCode(wholeCommand int, agents []AgentOutcome) int {
+	if wholeCommand != ExitSuccess {
+		return wholeCommand
+	}
+	best, bestRank := ExitSuccess, 0
+	for _, agent := range agents {
+		code := agent.contribution()
+		if rank := agentExitRank(code); rank > bestRank {
+			best, bestRank = code, rank
+		}
+	}
+	return best
+}
+
+func (o AgentOutcome) contribution() int {
+	switch o.Disposition {
+	case AgentDispositionDisabled, AgentDispositionUnsupported, AgentDispositionFresh:
+		return ExitSuccess
+	}
+	switch o.Code {
+	case ExitSuccess, ExitError, ExitTimeout, ExitActionRequired:
+		return o.Code
+	default:
+		return ExitError
+	}
+}
+
+func agentExitRank(code int) int {
+	switch code {
+	case ExitActionRequired:
+		return 3
+	case ExitTimeout:
+		return 2
+	case ExitError:
+		return 1
+	default:
+		return 0
 	}
 }

--- a/internal/cli/exitcode_test.go
+++ b/internal/cli/exitcode_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -54,5 +55,124 @@ func TestExitCodeErrorMessage(t *testing.T) {
 	empty := &ExitCodeError{Code: ExitError, Err: nil}
 	if empty.Error() != "exit code 1" {
 		t.Errorf("Error() = %q, want %q", empty.Error(), "exit code 1")
+	}
+}
+
+func TestActionRequiredError(t *testing.T) {
+	err := ActionRequiredError("stale token for %s", "claude")
+	if GetExitCode(err) != ExitActionRequired {
+		t.Errorf("GetExitCode() = %d, want %d", GetExitCode(err), ExitActionRequired)
+	}
+	if err.Error() != "stale token for claude" {
+		t.Errorf("Error() = %q, want %q", err.Error(), "stale token for claude")
+	}
+}
+
+func TestAggregateExitCode(t *testing.T) {
+	ranked := []int{ExitSuccess, ExitError, ExitTimeout, ExitActionRequired}
+	rank := map[int]int{
+		ExitActionRequired: 3,
+		ExitTimeout:        2,
+		ExitError:          1,
+		ExitSuccess:        0,
+	}
+
+	for _, a := range ranked {
+		for _, b := range ranked {
+			want := a
+			if rank[b] > rank[a] {
+				want = b
+			}
+			t.Run(fmt.Sprintf("pair %d+%d", a, b), func(t *testing.T) {
+				got := AggregateExitCode(0, []AgentOutcome{{Code: a}, {Code: b}})
+				if got != want {
+					t.Errorf("got %d, want %d", got, want)
+				}
+			})
+		}
+	}
+
+	tests := []struct {
+		name         string
+		wholeCommand int
+		agents       []AgentOutcome
+		want         int
+	}{
+		{
+			name: "6 beats 4: action_required plus timeout",
+			agents: []AgentOutcome{
+				{Code: ExitActionRequired},
+				{Code: ExitTimeout},
+			},
+			want: ExitActionRequired,
+		},
+		{
+			name: "all expected dispositions is 0",
+			agents: []AgentOutcome{
+				{Code: ExitError, Disposition: AgentDispositionDisabled},
+				{Code: ExitTimeout, Disposition: AgentDispositionUnsupported},
+				{Code: ExitActionRequired, Disposition: AgentDispositionFresh},
+			},
+			want: ExitSuccess,
+		},
+		{
+			name: "disabled must not escalate a nonzero code",
+			agents: []AgentOutcome{
+				{Code: ExitError, Disposition: AgentDispositionDisabled},
+			},
+			want: ExitSuccess,
+		},
+		{
+			name: "disabled 6 plus timeout is 4, not 6",
+			agents: []AgentOutcome{
+				{Code: ExitActionRequired, Disposition: AgentDispositionDisabled},
+				{Code: ExitTimeout},
+			},
+			want: ExitTimeout,
+		},
+		{
+			name:         "usage preempts per-agent action_required",
+			wholeCommand: ExitUsage,
+			agents:       []AgentOutcome{{Code: ExitActionRequired}},
+			want:         ExitUsage,
+		},
+		{
+			name:         "context mismatch preempts per-agent timeout",
+			wholeCommand: ExitContextMismatch,
+			agents:       []AgentOutcome{{Code: ExitTimeout}},
+			want:         ExitContextMismatch,
+		},
+		{
+			name:         "not-found preempts per-agent error",
+			wholeCommand: ExitNotFound,
+			agents:       []AgentOutcome{{Code: ExitError}},
+			want:         ExitNotFound,
+		},
+		{
+			name:   "empty agents is success",
+			agents: nil,
+			want:   ExitSuccess,
+		},
+		{
+			name:         "nonzero whole-command is not dropped to success",
+			wholeCommand: ExitError,
+			agents:       nil,
+			want:         ExitError,
+		},
+		{
+			name:         "off-contract per-agent code fails closed as general error",
+			wholeCommand: 0,
+			agents:       []AgentOutcome{{Code: ExitNotFound}},
+			want:         ExitError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AggregateExitCode(tt.wholeCommand, tt.agents)
+			if got != tt.want {
+				t.Errorf("AggregateExitCode() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -204,6 +204,16 @@ var usageEnvironment = []string{
 	"  AMQ_WAKE_NO_SELF_UPGRADE  Disable automatic wake self-upgrade (1/true/yes/on)",
 }
 
+var usageExitCodes = []string{
+	"  0  Success",
+	"  1  General error",
+	"  2  Usage error",
+	"  3  Not found",
+	"  4  Timeout",
+	"  5  Context mismatch",
+	"  6  Action required",
+}
+
 func runUpgradeRegistry(args []string) error {
 	return runUpgrade(args, "dev")
 }
@@ -252,6 +262,11 @@ func topLevelUsageLines() []string {
 		"Environment:",
 	)
 	lines = append(lines, usageEnvironment...)
+	lines = append(lines,
+		"",
+		"Exit codes:",
+	)
+	lines = append(lines, usageExitCodes...)
 	lines = append(lines,
 		"",
 		`Use "amq <command> --help" for more information about a command.`,

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -216,6 +216,12 @@ func TestPrintUsageRegistry(t *testing.T) {
 	if !strings.Contains(output, "swarm        Claude Code Agent Teams integration") {
 		t.Fatalf("printUsageRegistry output missing swarm command:\n%s", output)
 	}
+	if !strings.Contains(output, "Exit codes:") {
+		t.Fatalf("printUsageRegistry output missing Exit codes section:\n%s", output)
+	}
+	if !strings.Contains(output, "6  Action required") {
+		t.Fatalf("printUsageRegistry output missing exit code 6:\n%s", output)
+	}
 }
 
 func TestPrintGroupUsage(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `ExitActionRequired = 6` and `ActionRequiredError` to the CLI machine contract (issue #480 v1.1 §11).
- Add `AggregateExitCode`: nonzero whole-command codes are returned as-is; once per-agent work begins, aggregate is `6 > 4 > 1 > 0`, with `disabled`/`unsupported`/`fresh` contributing 0 and off-contract per-agent codes failing closed as 1.
- Document code 6 in README and `amq --help`. No consumers are wired yet.

## Test plan
- [x] `go test ./internal/cli` (aggregate pair table, 6-beats-4, disabled-must-not-escalate, whole-command passthrough, off-contract agent code)
- [x] Pre-push `make ci` (vet, lint, full test, smoke)
- [ ] GitHub CI green

Refs: #480

Made with [Cursor](https://cursor.com)