### PR TITLE
feat(launch): add versioned launch plan, binding, and trust contracts

### DIFF
--- a/internal/cli/tree_identity_unix.go
+++ b/internal/cli/tree_identity_unix.go
@@ -3,22 +3,21 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 const treeIdentityPlatform = runtime.GOOS
 
-func platformTreeIdentityToken(_ string, info os.FileInfo) (string, error) {
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return "", fmt.Errorf("filesystem identity unavailable on %s", runtime.GOOS)
+func platformTreeIdentityToken(path string, info os.FileInfo) (string, error) {
+	if path == "" {
+		return fsq.StableTreeIdentityInfo(info)
 	}
-	return fmt.Sprintf("v1:%s:%x:%x", treeIdentityPlatform, uint64(stat.Dev), uint64(stat.Ino)), nil
+	return fsq.StableTreeIdentity(path)
 }
 
 func validPlatformTreeIdentityToken(token string) bool {

--- a/internal/fsq/tree_identity.go
+++ b/internal/fsq/tree_identity.go
@@ -1,0 +1,37 @@
+package fsq
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StableTreeIdentity returns the opaque physical identity used to bind
+// authority to one project directory. Callers must not parse the token.
+func StableTreeIdentity(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("empty tree path")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("tree path is not a directory: %s", abs)
+	}
+	return platformStableTreeIdentity(abs, info)
+}
+
+// StableTreeIdentityInfo returns the same token from an already authorized
+// filesystem snapshot.
+func StableTreeIdentityInfo(info os.FileInfo) (string, error) {
+	if info == nil || !info.IsDir() {
+		return "", fmt.Errorf("tree identity requires a directory snapshot")
+	}
+	return platformStableTreeIdentity("", info)
+}

--- a/internal/fsq/tree_identity_unix.go
+++ b/internal/fsq/tree_identity_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package fsq
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+)
+
+func platformStableTreeIdentity(_ string, info os.FileInfo) (string, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("filesystem identity unavailable on %s", runtime.GOOS)
+	}
+	return fmt.Sprintf("v1:%s:%x:%x", runtime.GOOS, uint64(stat.Dev), uint64(stat.Ino)), nil
+}

--- a/internal/fsq/tree_identity_windows.go
+++ b/internal/fsq/tree_identity_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package fsq
+
+import (
+	"fmt"
+	"os"
+)
+
+func platformStableTreeIdentity(_ string, _ os.FileInfo) (string, error) {
+	return "", fmt.Errorf("Windows identity pinning is out of scope")
+}

--- a/internal/launch/binding.go
+++ b/internal/launch/binding.go
@@ -1,0 +1,121 @@
+package launch
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	BindingVersion     = 1
+	ResourceSetVersion = 1
+	bindingDirectory   = "meta/launch"
+	bindingFilename    = "binding.json"
+)
+
+// BindingRecord is disposable runtime state. It never identifies an AMQ
+// session and never grants authority to execute a plan.
+type BindingRecord struct {
+	Version          int                 `json:"version"`
+	Backend          string              `json:"backend"`
+	HostIdentity     string              `json:"host_identity"`
+	InstanceIdentity string              `json:"instance_identity"`
+	Profile          string              `json:"profile"`
+	LaunchNonce      string              `json:"launch_nonce"`
+	Resources        ResourceIdentitySet `json:"resources"`
+}
+
+type ResourceIdentitySet struct {
+	Version   int                `json:"version"`
+	Resources []ResourceIdentity `json:"resources"`
+}
+
+type ResourceIdentity struct {
+	OpaqueID string `json:"opaque_id"`
+	Agent    string `json:"agent,omitempty"`
+}
+
+func (record BindingRecord) Validate() error {
+	if record.Version != BindingVersion {
+		return fmt.Errorf("unsupported binding version %d", record.Version)
+	}
+	for name, value := range map[string]string{
+		"backend": record.Backend, "host identity": record.HostIdentity,
+		"instance identity": record.InstanceIdentity, "profile": record.Profile,
+		"launch nonce": record.LaunchNonce,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", name)
+		}
+	}
+	if record.Resources.Version != ResourceSetVersion {
+		return fmt.Errorf("unsupported resource identity set version %d", record.Resources.Version)
+	}
+	seen := make(map[string]struct{}, len(record.Resources.Resources))
+	for i, resource := range record.Resources.Resources {
+		if strings.TrimSpace(resource.OpaqueID) == "" {
+			return fmt.Errorf("resources[%d]: opaque identity is required", i)
+		}
+		if resource.Agent != "" {
+			if err := fsq.ValidateHandle(resource.Agent); err != nil {
+				return fmt.Errorf("resources[%d]: invalid agent association: %w", i, err)
+			}
+		}
+		if _, ok := seen[resource.OpaqueID]; ok {
+			return fmt.Errorf("duplicate resource identity %q", resource.OpaqueID)
+		}
+		seen[resource.OpaqueID] = struct{}{}
+	}
+	return nil
+}
+
+func WriteBinding(root *fsq.DeliveryRoot, record BindingRecord) error {
+	if root == nil {
+		return fmt.Errorf("missing pinned session root")
+	}
+	if err := record.Validate(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = root.WriteFileAtomic(bindingDirectory, bindingFilename, data, 0o600)
+	return err
+}
+
+func LoadBinding(root *fsq.DeliveryRoot) (BindingRecord, error) {
+	if root == nil {
+		return BindingRecord{}, fmt.Errorf("missing pinned session root")
+	}
+	file, info, err := root.OpenRegularNoFollow(filepath.Join(bindingDirectory, bindingFilename))
+	if err != nil {
+		return BindingRecord{}, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		return BindingRecord{}, fmt.Errorf("binding permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return BindingRecord{}, err
+	}
+	var record BindingRecord
+	if err := decodeStrict(data, &record); err != nil {
+		return BindingRecord{}, fmt.Errorf("decode launch binding: %w", err)
+	}
+	if err := record.Validate(); err != nil {
+		return BindingRecord{}, err
+	}
+	return record, nil
+}
+
+// BindingPath is for diagnostics and tests only. I/O must use a pinned root.
+func BindingPath(sessionRoot string) string {
+	return filepath.Join(sessionRoot, bindingDirectory, bindingFilename)
+}

--- a/internal/launch/binding_test.go
+++ b/internal/launch/binding_test.go
@@ -1,0 +1,126 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func openTestRoot(t *testing.T) (string, *fsq.DeliveryRoot) {
+	t.Helper()
+	dir := t.TempDir()
+	identity, err := fsq.SnapshotDeliveryRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(dir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return dir, root
+}
+
+func validBinding() BindingRecord {
+	return BindingRecord{
+		Version: BindingVersion, Backend: "tmux", HostIdentity: "host:one",
+		InstanceIdentity: "tmux-server:one", Profile: "tmux/darwin/v1", LaunchNonce: "nonce-one",
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{
+			{OpaqueID: "session:amq-project-collab"}, {OpaqueID: "pane:%1", Agent: "claude"},
+		}},
+	}
+}
+
+func TestBindingAtomicRoundTripAndMode(t *testing.T) {
+	dir, root := openTestRoot(t)
+	wantPath := filepath.Join(dir, "meta", "launch", "binding.json")
+	if got := BindingPath(dir); got != wantPath {
+		t.Fatalf("BindingPath = %s, want core-owned %s", got, wantPath)
+	}
+	record := validBinding()
+	if err := WriteBinding(root, record); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadBinding(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Backend != record.Backend || got.Resources.Resources[1].Agent != "claude" {
+		t.Fatalf("binding round trip = %#v", got)
+	}
+	info, err := os.Stat(BindingPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("binding mode = %04o, want 0600", info.Mode().Perm())
+	}
+
+	record.LaunchNonce = "nonce-two"
+	if err := WriteBinding(root, record); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(BindingPath(dir)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != bindingFilename {
+		t.Fatalf("atomic replace left unexpected entries: %v", entries)
+	}
+}
+
+func TestLoadBindingFailsClosed(t *testing.T) {
+	tests := []struct{ name, data, want string }{
+		{"malformed", `{`, "decode launch binding"},
+		{"downgrade", `{"version":0}`, "unsupported binding version 0"},
+		{"unknown field", `{"version":1,"backend":"x","host_identity":"h","instance_identity":"i","profile":"p","launch_nonce":"n","resources":{"version":1,"resources":[]},"extra":true}`, "unknown field"},
+		{"resource downgrade", `{"version":1,"backend":"x","host_identity":"h","instance_identity":"i","profile":"p","launch_nonce":"n","resources":{"version":0,"resources":[]}}`, "unsupported resource identity set version 0"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, root := openTestRoot(t)
+			path := BindingPath(dir)
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(test.data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadBinding(root)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("LoadBinding error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLoadBindingRejectsPermissiveOrSymlinkState(t *testing.T) {
+	dir, root := openTestRoot(t)
+	path := BindingPath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := `{"version":1,"backend":"x","host_identity":"h","instance_identity":"i","profile":"p","launch_nonce":"n","resources":{"version":1,"resources":[]}}`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadBinding(root); err == nil || !strings.Contains(err.Error(), "permissions") {
+		t.Fatalf("permissive LoadBinding error = %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "binding.json")
+	if err := os.WriteFile(outside, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadBinding(root); err == nil {
+		t.Fatal("LoadBinding followed a symlink")
+	}
+}

--- a/internal/launch/plan.go
+++ b/internal/launch/plan.go
@@ -1,0 +1,214 @@
+// Package launch defines the versioned contracts shared by launch
+// orchestration, harness adapters, and terminal backends.
+package launch
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const PlanVersion = 1
+
+type AdapterMode string
+
+const (
+	AdapterModeMint        AdapterMode = "mint"
+	AdapterModeCapture     AdapterMode = "capture"
+	AdapterModeUnsupported AdapterMode = "unsupported"
+)
+
+type ResumePolicy string
+
+const (
+	ResumeEnabled  ResumePolicy = "resume"
+	ResumeFresh    ResumePolicy = "fresh"
+	ResumeDisabled ResumePolicy = "disabled"
+)
+
+type DynamicArgKind string
+
+const (
+	DynamicArgLaunchNonce    DynamicArgKind = "launch_nonce"
+	DynamicArgConversationID DynamicArgKind = "conversation_id"
+)
+
+// Plan is the public, backend-independent execution contract. Nonce and
+// ConversationID are per-launch values and are deliberately not trusted.
+type Plan struct {
+	Version int         `json:"version"`
+	Agents  []AgentPlan `json:"agents"`
+}
+
+type AgentPlan struct {
+	Handle         string            `json:"handle"`
+	Argv           []string          `json:"argv"`
+	EnvOverlay     map[string]string `json:"env_overlay,omitempty"`
+	Cwd            string            `json:"cwd"`
+	AdapterMode    AdapterMode       `json:"adapter_mode"`
+	ResumePolicy   ResumePolicy      `json:"resume_policy"`
+	LaunchNonce    string            `json:"launch_nonce,omitempty"`
+	ConversationID string            `json:"conversation_id,omitempty"`
+	DynamicArgv    []DynamicArg      `json:"dynamic_argv,omitempty"`
+}
+
+// DynamicArg marks one runtime-generated argv value. Unmarked argv values are
+// always trust-bearing. Version 1 has no dynamic environment slots; adding
+// them requires a plan schema version change when an adapter needs one.
+type DynamicArg struct {
+	Index int            `json:"index"`
+	Kind  DynamicArgKind `json:"kind"`
+}
+
+func (p Plan) Validate() error {
+	if p.Version != PlanVersion {
+		return fmt.Errorf("unsupported launch plan version %d", p.Version)
+	}
+	if len(p.Agents) == 0 {
+		return fmt.Errorf("launch plan has no agents")
+	}
+	seen := make(map[string]struct{}, len(p.Agents))
+	for i, agent := range p.Agents {
+		if err := agent.validate(); err != nil {
+			return fmt.Errorf("agents[%d]: %w", i, err)
+		}
+		if _, ok := seen[agent.Handle]; ok {
+			return fmt.Errorf("duplicate agent handle %q", agent.Handle)
+		}
+		seen[agent.Handle] = struct{}{}
+	}
+	return nil
+}
+
+func (a AgentPlan) validate() error {
+	if err := fsq.ValidateHandle(a.Handle); err != nil {
+		return fmt.Errorf("invalid handle: %w", err)
+	}
+	if len(a.Argv) == 0 || strings.TrimSpace(a.Argv[0]) == "" {
+		return fmt.Errorf("argv must name an executable")
+	}
+	if strings.TrimSpace(a.Cwd) == "" {
+		return fmt.Errorf("cwd is required")
+	}
+	switch a.AdapterMode {
+	case AdapterModeMint, AdapterModeCapture, AdapterModeUnsupported:
+	default:
+		return fmt.Errorf("invalid adapter mode %q", a.AdapterMode)
+	}
+	switch a.ResumePolicy {
+	case ResumeEnabled, ResumeFresh, ResumeDisabled:
+	default:
+		return fmt.Errorf("invalid resume policy %q", a.ResumePolicy)
+	}
+	for key := range a.EnvOverlay {
+		if key == "" || strings.ContainsRune(key, '=') {
+			return fmt.Errorf("invalid environment key %q", key)
+		}
+	}
+	seenDynamic := make(map[int]struct{}, len(a.DynamicArgv))
+	for i, dynamic := range a.DynamicArgv {
+		if dynamic.Index < 0 || dynamic.Index >= len(a.Argv) {
+			return fmt.Errorf("dynamic_argv[%d]: index %d is outside argv", i, dynamic.Index)
+		}
+		if dynamic.Index == 0 {
+			return fmt.Errorf("dynamic_argv[%d]: argv[0] executable must be static", i)
+		}
+		if _, ok := seenDynamic[dynamic.Index]; ok {
+			return fmt.Errorf("dynamic_argv[%d]: duplicate index %d", i, dynamic.Index)
+		}
+		seenDynamic[dynamic.Index] = struct{}{}
+		var expected string
+		switch dynamic.Kind {
+		case DynamicArgLaunchNonce:
+			expected = a.LaunchNonce
+		case DynamicArgConversationID:
+			expected = a.ConversationID
+		default:
+			return fmt.Errorf("dynamic_argv[%d]: invalid kind %q", i, dynamic.Kind)
+		}
+		if expected == "" || a.Argv[dynamic.Index] != expected {
+			return fmt.Errorf("dynamic_argv[%d]: argv value does not match %s", i, dynamic.Kind)
+		}
+	}
+	return nil
+}
+
+type canonicalArgument struct {
+	Value   string         `json:"value,omitempty"`
+	Dynamic DynamicArgKind `json:"dynamic,omitempty"`
+}
+
+type staticAgentPlan struct {
+	Handle       string              `json:"handle"`
+	Argv         []canonicalArgument `json:"argv"`
+	EnvOverlay   map[string]string   `json:"env_overlay,omitempty"`
+	Cwd          string              `json:"cwd"`
+	AdapterMode  AdapterMode         `json:"adapter_mode"`
+	ResumePolicy ResumePolicy        `json:"resume_policy"`
+}
+
+// SemanticDigest hashes the adapter-normalized static execution template.
+// Fresh and resume argv shapes have different digests because only the resume
+// shape carries a conversation slot; each shape therefore requires trust once.
+func (p Plan) SemanticDigest() (string, error) {
+	if err := p.Validate(); err != nil {
+		return "", err
+	}
+	agents := make([]staticAgentPlan, len(p.Agents))
+	for i, agent := range p.Agents {
+		argv := make([]canonicalArgument, len(agent.Argv))
+		for j, value := range agent.Argv {
+			argv[j].Value = value
+		}
+		for _, dynamic := range agent.DynamicArgv {
+			argv[dynamic.Index] = canonicalArgument{Dynamic: dynamic.Kind}
+		}
+		agents[i] = staticAgentPlan{
+			Handle: agent.Handle, Argv: argv, EnvOverlay: agent.EnvOverlay,
+			Cwd: agent.Cwd, AdapterMode: agent.AdapterMode, ResumePolicy: agent.ResumePolicy,
+		}
+	}
+	slices.SortFunc(agents, func(a, b staticAgentPlan) int { return strings.Compare(a.Handle, b.Handle) })
+	canonical, err := json.Marshal(struct {
+		Version int               `json:"version"`
+		Agents  []staticAgentPlan `json:"agents"`
+	}{Version: p.Version, Agents: agents})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func DecodePlan(data []byte) (Plan, error) {
+	var plan Plan
+	if err := decodeStrict(data, &plan); err != nil {
+		return Plan{}, fmt.Errorf("decode launch plan: %w", err)
+	}
+	if err := plan.Validate(); err != nil {
+		return Plan{}, err
+	}
+	return plan, nil
+}
+
+func decodeStrict(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/launch/plan_test.go
+++ b/internal/launch/plan_test.go
@@ -1,0 +1,108 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+)
+
+func validPlan() Plan {
+	return Plan{Version: PlanVersion, Agents: []AgentPlan{
+		{
+			Handle: "claude", Argv: []string{"/usr/local/bin/claude", "--model", "opus", "--session-id", "claude:one"},
+			EnvOverlay: map[string]string{"LANG": "C", "TERM": "xterm"}, Cwd: "/work/project",
+			AdapterMode: AdapterModeMint, ResumePolicy: ResumeEnabled,
+			LaunchNonce: "launch-one", ConversationID: "claude:one",
+			DynamicArgv: []DynamicArg{{Index: 4, Kind: DynamicArgConversationID}},
+		},
+		{
+			Handle: "codex", Argv: []string{"/usr/local/bin/codex", "--launch-nonce", "launch-one"}, Cwd: "/work/project",
+			AdapterMode: AdapterModeCapture, ResumePolicy: ResumeFresh,
+			LaunchNonce: "launch-one", ConversationID: "codex:one",
+			DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgLaunchNonce}},
+		},
+	}}
+}
+
+func TestSemanticDigestCanonicalAndExcludesRuntimeValues(t *testing.T) {
+	first := validPlan()
+	second := validPlan()
+	second.Agents[0], second.Agents[1] = second.Agents[1], second.Agents[0]
+	second.Agents[0].LaunchNonce = "launch-two"
+	second.Agents[0].Argv[2] = "launch-two"
+	second.Agents[0].ConversationID = "codex:two"
+	second.Agents[1].LaunchNonce = "launch-two"
+	second.Agents[1].ConversationID = "claude:two"
+	second.Agents[1].Argv[4] = "claude:two"
+	second.Agents[1].EnvOverlay = map[string]string{"TERM": "xterm", "LANG": "C"}
+
+	want, err := first.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := second.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("cosmetic/runtime changes changed digest: %s != %s", got, want)
+	}
+
+	second.Agents[1].Argv = append(second.Agents[1].Argv, "--dangerously-skip-permissions")
+	changed, err := second.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed == want {
+		t.Fatal("semantic argv change did not invalidate digest")
+	}
+}
+
+func TestDynamicArgValidationPreventsDigestExclusionsFromLying(t *testing.T) {
+	plan := validPlan()
+	tests := []struct {
+		name   string
+		mutate func(*AgentPlan)
+		want   string
+	}{
+		{"out of range", func(agent *AgentPlan) { agent.DynamicArgv[0].Index = 99 }, "outside argv"},
+		{"executable", func(agent *AgentPlan) { agent.DynamicArgv[0].Index = 0 }, "argv[0] executable must be static"},
+		{"duplicate index", func(agent *AgentPlan) { agent.DynamicArgv = append(agent.DynamicArgv, agent.DynamicArgv[0]) }, "duplicate index"},
+		{"unknown kind", func(agent *AgentPlan) { agent.DynamicArgv[0].Kind = "other" }, "invalid kind"},
+		{"mismatched value", func(agent *AgentPlan) { agent.Argv[4] = "another-id" }, "does not match"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			copyPlan := plan
+			copyPlan.Agents = append([]AgentPlan(nil), plan.Agents...)
+			copyPlan.Agents[0].Argv = append([]string(nil), plan.Agents[0].Argv...)
+			copyPlan.Agents[0].DynamicArgv = append([]DynamicArg(nil), plan.Agents[0].DynamicArgv...)
+			test.mutate(&copyPlan.Agents[0])
+			if _, err := copyPlan.SemanticDigest(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("SemanticDigest error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodePlanStrictAndVersioned(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want string
+	}{
+		{"malformed", `{`, "decode launch plan"},
+		{"unknown field", `{"version":1,"agents":[],"extra":true}`, "unknown field"},
+		{"downgrade", `{"version":0,"agents":[]}`, "unsupported launch plan version 0"},
+		{"future", `{"version":2,"agents":[]}`, "unsupported launch plan version 2"},
+		{"duplicate handle", `{"version":1,"agents":[{"handle":"a","argv":["a"],"cwd":"/x","adapter_mode":"mint","resume_policy":"resume"},{"handle":"a","argv":["a"],"cwd":"/x","adapter_mode":"capture","resume_policy":"fresh"}]}`, "duplicate agent handle"},
+		{"invalid handle", `{"version":1,"agents":[{"handle":"../a","argv":["a"],"cwd":"/x","adapter_mode":"mint","resume_policy":"resume"}]}`, "invalid handle"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := DecodePlan([]byte(test.json))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DecodePlan error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/launch/trust.go
+++ b/internal/launch/trust.go
@@ -1,0 +1,223 @@
+// Package launch trust state uses physical project identity and fails closed
+// where that identity is unavailable. Windows callers must surface exit 6
+// (action_required); they must never substitute a path-based identity.
+package launch
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const TrustVersion = 1
+
+type TrustStore struct {
+	dir             string
+	projectIdentity string
+}
+
+// TrustRecord contains all local execution authority for one project. Replace
+// overwrites the prior digest, so a semantic change invalidates every prior
+// bypass argument and arbitrary-command grant.
+type TrustRecord struct {
+	Version           int                     `json:"version"`
+	ProjectIdentity   string                  `json:"project_identity"`
+	SemanticDigest    string                  `json:"semantic_digest"`
+	BypassArgs        map[string][]string     `json:"bypass_args,omitempty"`
+	ArbitraryCommands []ArbitraryCommandGrant `json:"arbitrary_commands,omitempty"`
+}
+
+type ArbitraryCommandGrant struct {
+	Name       string            `json:"name"`
+	Argv       []string          `json:"argv"`
+	EnvOverlay map[string]string `json:"env_overlay,omitempty"`
+	Cwd        string            `json:"cwd"`
+}
+
+func OpenTrustStore(userStateDir, projectRoot string) (*TrustStore, error) {
+	if strings.TrimSpace(userStateDir) == "" {
+		return nil, fmt.Errorf("user state directory is required")
+	}
+	projectAbs, err := resolvedPath(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	identity, err := fsq.StableTreeIdentity(projectAbs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve project identity: %w", err)
+	}
+	stateAbs, err := resolvedPath(userStateDir)
+	if err != nil {
+		return nil, err
+	}
+	if pathWithin(stateAbs, projectAbs) {
+		return nil, fmt.Errorf("trust state directory must be outside the project worktree")
+	}
+	sum := sha256.Sum256([]byte(identity))
+	return &TrustStore{
+		dir:             filepath.Join(stateAbs, "launch", "projects", hex.EncodeToString(sum[:])),
+		projectIdentity: identity,
+	}, nil
+}
+
+// resolvedPath resolves symlinks in the existing prefix while preserving a
+// missing tail. This prevents an apparently external state path from being an
+// alias back into the project.
+func resolvedPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	prefix := abs
+	var tail []string
+	for {
+		resolved, resolveErr := filepath.EvalSymlinks(prefix)
+		if resolveErr == nil {
+			for i := len(tail) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, tail[i])
+			}
+			return resolved, nil
+		}
+		if !errors.Is(resolveErr, os.ErrNotExist) {
+			return "", resolveErr
+		}
+		parent := filepath.Dir(prefix)
+		if parent == prefix {
+			return "", resolveErr
+		}
+		tail = append(tail, filepath.Base(prefix))
+		prefix = parent
+	}
+}
+
+func pathWithin(path, parent string) bool {
+	rel, err := filepath.Rel(parent, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func (store *TrustStore) Path() string {
+	if store == nil {
+		return ""
+	}
+	return filepath.Join(store.dir, "trust.json")
+}
+
+// Replace atomically installs the only active authority record for a project.
+func (store *TrustStore) Replace(record TrustRecord) error {
+	if store == nil {
+		return fmt.Errorf("missing trust store")
+	}
+	record.Version = TrustVersion
+	record.ProjectIdentity = store.projectIdentity
+	if err := validateTrustRecord(record); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = fsq.WriteFileAtomic(store.dir, "trust.json", data, 0o600)
+	return err
+}
+
+// LoadForDigest returns no record when the plan changed. Malformed, unreadable,
+// cross-project, or overly permissive state is an error and must fail closed.
+func (store *TrustStore) LoadForDigest(digest string) (TrustRecord, bool, error) {
+	if store == nil {
+		return TrustRecord{}, false, fmt.Errorf("missing trust store")
+	}
+	if !validDigest(digest) {
+		return TrustRecord{}, false, fmt.Errorf("invalid requested semantic digest")
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(store.dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return TrustRecord{}, false, nil
+		}
+		return TrustRecord{}, false, err
+	}
+	root, err := fsq.OpenDeliveryRoot(store.dir, identity)
+	if err != nil {
+		return TrustRecord{}, false, err
+	}
+	defer func() { _ = root.Close() }()
+	file, info, err := root.OpenRegularNoFollow("trust.json")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return TrustRecord{}, false, nil
+		}
+		return TrustRecord{}, false, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		return TrustRecord{}, false, fmt.Errorf("trust record permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return TrustRecord{}, false, err
+	}
+	var record TrustRecord
+	if err := decodeStrict(data, &record); err != nil {
+		return TrustRecord{}, false, fmt.Errorf("decode trust record: %w", err)
+	}
+	if err := validateTrustRecord(record); err != nil {
+		return TrustRecord{}, false, err
+	}
+	if record.ProjectIdentity != store.projectIdentity {
+		return TrustRecord{}, false, fmt.Errorf("trust record belongs to a different project identity")
+	}
+	if record.SemanticDigest != digest {
+		return TrustRecord{}, false, nil
+	}
+	return record, true, nil
+}
+
+func validateTrustRecord(record TrustRecord) error {
+	if record.Version != TrustVersion {
+		return fmt.Errorf("unsupported trust record version %d", record.Version)
+	}
+	if strings.TrimSpace(record.ProjectIdentity) == "" {
+		return fmt.Errorf("project identity is required")
+	}
+	if !validDigest(record.SemanticDigest) {
+		return fmt.Errorf("invalid semantic digest")
+	}
+	for handle, args := range record.BypassArgs {
+		if fsq.ValidateHandle(handle) != nil || len(args) == 0 {
+			return fmt.Errorf("invalid bypass arguments for %q", handle)
+		}
+	}
+	seen := make(map[string]struct{}, len(record.ArbitraryCommands))
+	for i, grant := range record.ArbitraryCommands {
+		if strings.TrimSpace(grant.Name) == "" || len(grant.Argv) == 0 || strings.TrimSpace(grant.Argv[0]) == "" || strings.TrimSpace(grant.Cwd) == "" {
+			return fmt.Errorf("arbitrary_commands[%d] is incomplete", i)
+		}
+		if _, ok := seen[grant.Name]; ok {
+			return fmt.Errorf("duplicate arbitrary command grant %q", grant.Name)
+		}
+		seen[grant.Name] = struct{}{}
+		for key := range grant.EnvOverlay {
+			if key == "" || strings.ContainsRune(key, '=') {
+				return fmt.Errorf("arbitrary_commands[%d] has invalid environment key %q", i, key)
+			}
+		}
+	}
+	return nil
+}
+
+func validDigest(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(strings.TrimPrefix(value, "sha256:"))
+	return err == nil
+}

--- a/internal/launch/trust_test.go
+++ b/internal/launch/trust_test.go
@@ -1,0 +1,180 @@
+package launch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func trustFixture(t *testing.T) (*TrustStore, string) {
+	t.Helper()
+	base := t.TempDir()
+	project := filepath.Join(base, "project")
+	state := filepath.Join(base, "state")
+	if err := os.Mkdir(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenTrustStore(state, project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, project
+}
+
+func testDigest(ch byte) string { return "sha256:" + strings.Repeat(string(ch), 64) }
+
+func TestTrustRecordRoundTripAndSemanticInvalidation(t *testing.T) {
+	store, _ := trustFixture(t)
+	record := TrustRecord{
+		SemanticDigest:    testDigest('a'),
+		BypassArgs:        map[string][]string{"claude": {"--dangerously-skip-permissions"}},
+		ArbitraryCommands: []ArbitraryCommandGrant{{Name: "operator-tool", Argv: []string{"/opt/tool", "run"}, Cwd: "/tmp"}},
+	}
+	if err := store.Replace(record); err != nil {
+		t.Fatal(err)
+	}
+	got, trusted, err := store.LoadForDigest(record.SemanticDigest)
+	if err != nil || !trusted {
+		t.Fatalf("LoadForDigest = trusted %t, err %v", trusted, err)
+	}
+	if got.ProjectIdentity == "" || len(got.BypassArgs["claude"]) != 1 || len(got.ArbitraryCommands) != 1 {
+		t.Fatalf("stored authority = %#v", got)
+	}
+	if info, err := os.Stat(store.Path()); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("trust record mode: info=%v err=%v", info, err)
+	}
+
+	stale, trusted, err := store.LoadForDigest(testDigest('b'))
+	if err != nil || trusted {
+		t.Fatalf("changed digest = trusted %t, err %v", trusted, err)
+	}
+	if len(stale.BypassArgs) != 0 || len(stale.ArbitraryCommands) != 0 {
+		t.Fatalf("invalidated authority leaked: %#v", stale)
+	}
+}
+
+func TestTrustStoreUsesPhysicalProjectIdentityAndDoesNotLeak(t *testing.T) {
+	base := t.TempDir()
+	state := filepath.Join(base, "state")
+	projectA := filepath.Join(base, "a")
+	projectB := filepath.Join(base, "b")
+	if err := os.Mkdir(projectA, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(projectB, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	aliasA := filepath.Join(base, "alias-a")
+	if err := os.Symlink(projectA, aliasA); err != nil {
+		t.Fatal(err)
+	}
+	storeA, err := OpenTrustStore(state, projectA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeAlias, err := OpenTrustStore(state, aliasA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeB, err := OpenTrustStore(state, projectB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storeA.Path() != storeAlias.Path() {
+		t.Fatalf("physical alias got another trust key: %s != %s", storeA.Path(), storeAlias.Path())
+	}
+	if storeA.Path() == storeB.Path() {
+		t.Fatal("different projects shared a trust key")
+	}
+	if err := storeA.Replace(TrustRecord{SemanticDigest: testDigest('c')}); err != nil {
+		t.Fatal(err)
+	}
+	if _, trusted, err := storeB.LoadForDigest(testDigest('c')); err != nil || trusted {
+		t.Fatalf("project B inherited project A trust: trusted=%t err=%v", trusted, err)
+	}
+}
+
+func TestTrustLoadFailsClosed(t *testing.T) {
+	store, _ := trustFixture(t)
+	if err := os.MkdirAll(filepath.Dir(store.Path()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct{ name, data, want string }{
+		{"malformed", `{`, "decode trust record"},
+		{"downgrade", `{"version":0}`, "unsupported trust record version 0"},
+		{"unknown field", `{"version":1,"project_identity":"x","semantic_digest":"` + testDigest('d') + `","extra":true}`, "unknown field"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.WriteFile(store.Path(), []byte(test.data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, trusted, err := store.LoadForDigest(testDigest('d'))
+			if trusted || err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("LoadForDigest = trusted %t, err %v, want %q", trusted, err, test.want)
+			}
+		})
+	}
+
+	valid := TrustRecord{Version: TrustVersion, ProjectIdentity: "another-project", SemanticDigest: testDigest('e')}
+	data, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.Path(), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, trusted, err := store.LoadForDigest(valid.SemanticDigest); trusted || err == nil || !strings.Contains(err.Error(), "different project") {
+		t.Fatalf("cross-project record = trusted %t, err %v", trusted, err)
+	}
+
+	if err := os.Chmod(store.Path(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, trusted, err := store.LoadForDigest(valid.SemanticDigest); trusted || err == nil || !strings.Contains(err.Error(), "permissions") {
+		t.Fatalf("permissive record = trusted %t, err %v", trusted, err)
+	}
+}
+
+func TestTrustStoreRejectsInWorktreeState(t *testing.T) {
+	project := t.TempDir()
+	_, err := OpenTrustStore(filepath.Join(project, ".amq", "state"), project)
+	if err == nil || !strings.Contains(err.Error(), "outside") {
+		t.Fatalf("OpenTrustStore error = %v, want outside-worktree refusal", err)
+	}
+	alias := filepath.Join(t.TempDir(), "state-alias")
+	if err := os.Symlink(project, alias); err != nil {
+		t.Fatal(err)
+	}
+	_, err = OpenTrustStore(filepath.Join(alias, ".amq", "state"), project)
+	if err == nil || !strings.Contains(err.Error(), "outside") {
+		t.Fatalf("aliased OpenTrustStore error = %v, want outside-worktree refusal", err)
+	}
+}
+
+func TestTrustLoadRejectsSymlinkRecord(t *testing.T) {
+	store, _ := trustFixture(t)
+	if err := os.MkdirAll(filepath.Dir(store.Path()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "trust.json")
+	data := `{"version":1,"project_identity":"x","semantic_digest":"` + testDigest('f') + `"}`
+	if err := os.WriteFile(outside, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, store.Path()); err != nil {
+		t.Fatal(err)
+	}
+	if _, trusted, err := store.LoadForDigest(testDigest('f')); trusted || err == nil {
+		t.Fatalf("symlink record = trusted %t, err %v", trusted, err)
+	}
+}
+
+func TestTrustLoadRejectsInvalidRequestedDigest(t *testing.T) {
+	store, _ := trustFixture(t)
+	if _, trusted, err := store.LoadForDigest("not-a-digest"); trusted || err == nil {
+		t.Fatalf("invalid requested digest = trusted %t, err %v", trusted, err)
+	}
+}


### PR DESCRIPTION
## Summary

- add the versioned public launch-plan contract with typed dynamic argv slots and A4 semantic digest canonicalization
- add the core-owned `meta/launch/binding.json` record with pinned, atomic, no-follow persistence
- add the out-of-worktree project trust store for digest trust, confirmed bypass arguments, and arbitrary-command grants
- extract the existing Unix physical tree identity token into `internal/fsq` for shared trust binding

Implements issue #480 v1.1 sections 2, 4, and 7: Wave A state model and schemas. This is additive infrastructure only; there are no CLI consumers yet. No golden files changed.

Refs: #480

## Verification

- `go test ./...`
- `go vet ./...`
- `golangci-lint run`
- Windows test compilation for `internal/launch` and `internal/cli`
- repository pre-push smoke and contract suite