### PR TITLE
feat(cli): add session create and session list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Common command groups:
 | Area | Commands |
 |------|----------|
 | Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `trace`, `watch`, `monitor`, `receipts` |
-| Collaboration | `coop init`, `coop exec`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
+| Collaboration | `coop init`, `coop exec`, `session create`, `session list`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
 | Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake check`, `wake repair`, `wake recover-owner`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -307,6 +307,20 @@ func runCoopInitInternal(args []string, printNextSteps bool) (returnErr error) {
 // mailbox through the pinned child capability. No provisioning write reopens
 // the session through its ambient lexical path.
 func provisionCoopSession(base, session string, agents []string, execAgent, execCommand string) (string, error) {
+	return provisionCoopSessionChild(base, session, agents, execAgent, execCommand, false)
+}
+
+// provisionNewNamedSession is session create: exclusive child creation so a
+// racing creator cannot silently open an existing session.
+func provisionNewNamedSession(base, session string, agents []string) (string, error) {
+	return provisionCoopSessionChild(base, session, agents, "", "", true)
+}
+
+// sessionCreateBeforeExclusive runs after the base is pinned and before the
+// exclusive mkdir so tests can inject a racing creator.
+var sessionCreateBeforeExclusive func(base, name string)
+
+func provisionCoopSessionChild(base, session string, agents []string, execAgent, execCommand string, exclusive bool) (string, error) {
 	if err := validateSessionName(session); err != nil {
 		return "", err
 	}
@@ -327,8 +341,22 @@ func provisionCoopSession(base, session string, agents []string, execAgent, exec
 	}
 	defer func() { _ = baseRoot.Close() }()
 
-	sessionRoot, err := baseRoot.OpenOrCreateDirectChild(session, 0o700)
+	if exclusive && sessionCreateBeforeExclusive != nil {
+		sessionCreateBeforeExclusive(base, session)
+	}
+	var sessionRoot *fsq.DeliveryRoot
+	if exclusive {
+		sessionRoot, err = baseRoot.CreateDirectChildExclusive(session, 0o700)
+	} else {
+		sessionRoot, err = baseRoot.OpenOrCreateDirectChild(session, 0o700)
+	}
 	if err != nil {
+		if exclusive {
+			var exists *fsq.DirectChildExistsError
+			if errors.As(err, &exists) {
+				return "", err
+			}
+		}
 		sessionPath := filepath.Join(base, session)
 		if info, lstatErr := os.Lstat(sessionPath); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
 			message := fmt.Sprintf(

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -68,6 +68,16 @@ func TestRunHelp_Routed(t *testing.T) {
 		t.Fatalf("Run(help presence set) returned error: %v", err)
 	}
 
+	err = Run([]string{"help", "session"}, "test")
+	if err != nil {
+		t.Fatalf("Run(help session) returned error: %v", err)
+	}
+
+	err = Run([]string{"help", "session", "create"}, "test")
+	if err != nil {
+		t.Fatalf("Run(help session create) returned error: %v", err)
+	}
+
 	// amq help upgrade should succeed
 	err = Run([]string{"help", "upgrade"}, "test")
 	if err != nil {
@@ -223,7 +233,7 @@ func TestCommandHelp_ExitZero(t *testing.T) {
 
 func TestSubcommandGroupHelp_ExitZero(t *testing.T) {
 	// Subcommand groups with no args should show help and exit 0
-	groups := []string{"dlq", "coop", "swarm", "presence"}
+	groups := []string{"dlq", "coop", "swarm", "presence", "session"}
 	for _, group := range groups {
 		t.Run(group, func(t *testing.T) {
 			err := Run([]string{group}, "test")

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -166,6 +166,24 @@ func init() {
 				{Name: "wait", Summary: "Wait for a receipt to appear", Handler: runReceiptsWait},
 			},
 		},
+		{
+			Name:        "session",
+			Summary:     "Create and list named AMQ sessions",
+			Description: "Named session lifecycle",
+			LongDescription: []string{
+				"session create provisions a canonical named session and its roster mailboxes.",
+				"session list reports canonical sessions and safe legacy roots. Attach ships with the launch engine.",
+			},
+			Examples: []string{
+				"amq session create feature-x",
+				"amq session list --json",
+			},
+			Handler: runSession,
+			Children: []CommandInfo{
+				{Name: "create", Summary: "Create a named session and its roster mailboxes", Handler: runSessionCreate},
+				{Name: "list", Summary: "List sessions under the base root", Handler: runSessionList},
+			},
+		},
 		{Name: "who", Summary: "Show sessions and agents in current project", Handler: runWho},
 		{
 			Name:        "route",

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -30,6 +30,7 @@ func TestCommandNames(t *testing.T) {
 		"swarm",
 		"integration",
 		"receipts",
+		"session",
 		"who",
 		"route",
 		"doctor",
@@ -89,6 +90,7 @@ func TestChildNames(t *testing.T) {
 		{name: "coop", want: []string{"init", "exec"}},
 		{name: "swarm", want: []string{"list", "join", "leave", "tasks", "claim", "complete", "fail", "block", "bridge"}},
 		{name: "receipts", want: []string{"list", "wait"}},
+		{name: "session", want: []string{"create", "list"}},
 		{name: "route", want: []string{"explain"}},
 	}
 
@@ -216,6 +218,9 @@ func TestPrintUsageRegistry(t *testing.T) {
 	if !strings.Contains(output, "swarm        Claude Code Agent Teams integration") {
 		t.Fatalf("printUsageRegistry output missing swarm command:\n%s", output)
 	}
+	if !strings.Contains(output, "session") || !strings.Contains(output, "Create and list named AMQ sessions") {
+		t.Fatalf("printUsageRegistry output missing session command:\n%s", output)
+	}
 	if !strings.Contains(output, "Exit codes:") {
 		t.Fatalf("printUsageRegistry output missing Exit codes section:\n%s", output)
 	}
@@ -237,6 +242,28 @@ func TestPrintGroupUsage(t *testing.T) {
 	}
 	if !strings.Contains(output, `Use "amq coop <subcommand> --help" for details.`) {
 		t.Fatalf("printGroupUsage(coop) missing footer:\n%s", output)
+	}
+}
+
+func TestPrintGroupUsageSession(t *testing.T) {
+	output := captureRegistryStdout(t, func() error {
+		return printGroupUsage(findCommand("session"))
+	})
+
+	if !strings.Contains(output, "amq session - Named session lifecycle") {
+		t.Fatalf("printGroupUsage(session) missing header:\n%s", output)
+	}
+	if !strings.Contains(output, "create  Create a named session and its roster mailboxes") {
+		t.Fatalf("printGroupUsage(session) missing create:\n%s", output)
+	}
+	if !strings.Contains(output, "list    List sessions under the base root") {
+		t.Fatalf("printGroupUsage(session) missing list:\n%s", output)
+	}
+	if strings.Contains(output, "resume") {
+		t.Fatalf("printGroupUsage(session) must not advertise resume:\n%s", output)
+	}
+	if findChild(findCommand("session"), "resume") != nil {
+		t.Fatal("session must not register a resume subcommand")
 	}
 }
 

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -1,0 +1,373 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func runSession(args []string) error {
+	if len(args) == 0 || isHelp(args[0]) {
+		return printGroupUsage(findCommand("session"))
+	}
+	switch args[0] {
+	case "create":
+		return runSessionCreate(args[1:])
+	case "list":
+		return runSessionList(args[1:])
+	default:
+		return formatUnknownSubcommand("session", args[0])
+	}
+}
+
+type sessionExistsError struct {
+	Name string
+	Path string
+}
+
+func (e *sessionExistsError) Error() string {
+	return fmt.Sprintf("session %q already exists at %s", e.Name, e.Path)
+}
+
+type sessionCreateResult struct {
+	Name   string   `json:"name"`
+	Path   string   `json:"path"`
+	Agents []string `json:"agents"`
+}
+
+func runSessionCreate(args []string) error {
+	fs := flag.NewFlagSet("session create", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	usage := usageWithFlags(fs, "amq session create <name> [options]",
+		"Create a named session and its roster mailboxes under the base root.",
+		"Canonical names only ([a-z0-9_-]+). Existing sessions fail loudly; create is never silent.")
+	name, flagArgs, peelErr := peelSessionCreateName(fs, args)
+	if peelErr != nil {
+		flagArgs = args
+	}
+	if handled, err := parseFlags(fs, flagArgs, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if peelErr != nil {
+		return peelErr
+	}
+	if err := validateSessionName(name); err != nil {
+		return err
+	}
+
+	base, err := sessionCreateBaseRoot(common.Root)
+	if err != nil {
+		return err
+	}
+
+	agents, err := loadSessionCreateAgents(base)
+	if err != nil {
+		return err
+	}
+	created, err := provisionNewNamedSession(base, name, agents)
+	if err != nil {
+		var exists *fsq.DirectChildExistsError
+		if errors.As(err, &exists) {
+			return &sessionExistsError{Name: name, Path: filepath.Join(base, name)}
+		}
+		return err
+	}
+	if agents == nil {
+		agents = []string{}
+	}
+	result := sessionCreateResult{Name: name, Path: created, Agents: agents}
+	if common.JSON {
+		return writeJSON(os.Stdout, result)
+	}
+	return writeStdout("Created session %q at %s\n", name, created)
+}
+
+type sessionListEntry struct {
+	Name   string   `json:"name"`
+	Path   string   `json:"path"`
+	Kind   string   `json:"kind"`
+	Agents []string `json:"agents"`
+	Hint   string   `json:"hint"`
+}
+
+type sessionSkipEntry struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+type sessionListResult struct {
+	Sessions []sessionListEntry `json:"sessions"`
+	Skipped  []sessionSkipEntry `json:"skipped,omitempty"`
+}
+
+func runSessionList(args []string) error {
+	fs := flag.NewFlagSet("session list", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	usage := usageWithFlags(fs, "amq session list [options]",
+		"List named sessions under the base root.",
+		"Canonical sessions are listed normally. Safe legacy roots are marked legacy_name with an exact --root hint.")
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+
+	base, err := sessionBaseRoot(common.Root)
+	if err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return err
+	}
+
+	result := sessionListResult{Sessions: []sessionListEntry{}}
+	for _, entry := range entries {
+		item, skipped, skip := classifySessionChild(base, entry.Name())
+		if skip {
+			result.Skipped = append(result.Skipped, skipped)
+			continue
+		}
+		result.Sessions = append(result.Sessions, item)
+	}
+	sort.Slice(result.Sessions, func(i, j int) bool {
+		return result.Sessions[i].Name < result.Sessions[j].Name
+	})
+	sort.Slice(result.Skipped, func(i, j int) bool {
+		return result.Skipped[i].Name < result.Skipped[j].Name
+	})
+
+	if common.JSON {
+		return writeJSON(os.Stdout, result)
+	}
+	if len(result.Sessions) == 0 {
+		return writeStdoutLine("No sessions found.")
+	}
+	width := 0
+	for _, item := range result.Sessions {
+		if len(item.Name) > width {
+			width = len(item.Name)
+		}
+	}
+	for _, item := range result.Sessions {
+		agents := strings.Join(item.Agents, ", ")
+		if item.Kind == sessionKindLegacy {
+			if err := writeStdout("  %-*s  (legacy_name)  use: %s\n", width, item.Name, item.Hint); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := writeStdout("  %-*s  %s\n", width, item.Name, agents); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sessionBaseRoot(root string) (string, error) {
+	base := absPath(baseRootOf(resolveRoot(root)))
+	if !dirExists(base) {
+		return "", NotFoundError("base root not found at %s", base)
+	}
+	return base, nil
+}
+
+func sessionCreateBaseRoot(root string) (string, error) {
+	base := absPath(baseRootOf(resolveRoot(root)))
+	if dirExists(base) {
+		return base, nil
+	}
+	_, err := findAndLoadAmqrc()
+	if errors.Is(err, errAmqrcNotFound) {
+		return "", NotFoundError("base root not found at %s; run 'amq setup' or 'amq coop init'", base)
+	}
+	if err != nil {
+		return "", err
+	}
+	if err := fsq.EnsureRootDirs(base); err != nil {
+		return "", fmt.Errorf("failed to create base root %q: %w", base, err)
+	}
+	return base, nil
+}
+
+func loadSessionCreateAgents(base string) ([]string, error) {
+	if handles, ok, err := loadLaunchRosterHandles(); err != nil {
+		return nil, err
+	} else if ok {
+		return handles, nil
+	}
+	cfg, err := config.LoadConfig(filepath.Join(base, "meta", "config.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return cfg.Agents, nil
+}
+
+func loadLaunchRosterHandles() ([]string, bool, error) {
+	// WA5-superseded peek: the authoritative launch.json parser lands with setup.
+	result, err := findAndLoadAmqrc()
+	if errors.Is(err, errAmqrcNotFound) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	path := filepath.Join(result.Dir, ".amq", "launch.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	var parsed struct {
+		Agents []struct {
+			Handle string `json:"handle"`
+		} `json:"agents"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, false, fmt.Errorf("parse .amq/launch.json: %w", err)
+	}
+	handles := make([]string, 0, len(parsed.Agents))
+	seen := map[string]bool{}
+	for _, agent := range parsed.Agents {
+		handle := strings.TrimSpace(agent.Handle)
+		if handle == "" {
+			return nil, false, fmt.Errorf("launch.json roster handle is empty")
+		}
+		normalized, err := normalizeHandle(handle)
+		if err != nil {
+			return nil, false, fmt.Errorf("launch.json roster handle %q: %w", handle, err)
+		}
+		if seen[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		handles = append(handles, normalized)
+	}
+	return handles, true, nil
+}
+
+func peelSessionCreateName(fs *flag.FlagSet, args []string) (string, []string, error) {
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+		if arg == "--" {
+			if i+1 >= len(args) {
+				return "", nil, UsageError("session name required (e.g., amq session create feature-x)")
+			}
+			name := args[i+1]
+			rest := append(append([]string{}, args[:i]...), args[i+2:]...)
+			return name, rest, nil
+		}
+		if strings.HasPrefix(arg, "-") && arg != "-" {
+			span := sessionCreateFlagSpan(fs, arg)
+			if i+span > len(args) {
+				break
+			}
+			i += span
+			continue
+		}
+		rest := append(append([]string{}, args[:i]...), args[i+1:]...)
+		return arg, rest, nil
+	}
+	return "", nil, UsageError("session name required (e.g., amq session create feature-x)")
+}
+
+func sessionCreateFlagSpan(fs *flag.FlagSet, arg string) int {
+	name := strings.TrimLeft(arg, "-")
+	if strings.Contains(name, "=") {
+		return 1
+	}
+	fl := fs.Lookup(name)
+	if fl == nil {
+		return 1
+	}
+	type boolFlag interface {
+		IsBoolFlag() bool
+	}
+	if bf, ok := fl.Value.(boolFlag); ok && bf.IsBoolFlag() {
+		return 1
+	}
+	return 2
+}
+
+func classifySessionChild(base, name string) (sessionListEntry, sessionSkipEntry, bool) {
+	path := filepath.Join(base, name)
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	skip := func(reason string) (sessionListEntry, sessionSkipEntry, bool) {
+		return sessionListEntry{}, sessionSkipEntry{Name: name, Path: abs, Reason: reason}, true
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return skip("unreadable")
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return skip("symlink")
+	}
+	if !info.IsDir() {
+		return skip("not_a_directory")
+	}
+	agentsDir := filepath.Join(path, "agents")
+	agentsInfo, err := os.Lstat(agentsDir)
+	if err != nil || !agentsInfo.IsDir() || agentsInfo.Mode()&os.ModeSymlink != 0 {
+		return skip("not_a_session")
+	}
+
+	agents := listSessionAgents(path)
+	switch {
+	case isCanonicalSessionName(name):
+		return sessionListEntry{
+			Name:   name,
+			Path:   abs,
+			Kind:   sessionKindCanonical,
+			Agents: agents,
+		}, sessionSkipEntry{}, false
+	case isSafeLegacySessionName(name):
+		return sessionListEntry{
+			Name:   name,
+			Path:   abs,
+			Kind:   sessionKindLegacy,
+			Agents: agents,
+			Hint:   fmt.Sprintf("amq list --root %s", abs),
+		}, sessionSkipEntry{}, false
+	default:
+		return skip("non_canonical_name")
+	}
+}
+
+func listSessionAgents(sessionRoot string) []string {
+	entries, err := os.ReadDir(filepath.Join(sessionRoot, "agents"))
+	if err != nil {
+		return []string{}
+	}
+	var agents []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		agents = append(agents, entry.Name())
+	}
+	sort.Strings(agents)
+	if agents == nil {
+		return []string{}
+	}
+	return agents
+}

--- a/internal/cli/session_name.go
+++ b/internal/cli/session_name.go
@@ -1,0 +1,40 @@
+package cli
+
+import "strings"
+
+const (
+	sessionKindCanonical = "canonical"
+	sessionKindLegacy    = "legacy_name"
+)
+
+// isCanonicalSessionName reports whether name is a porcelain session spelling.
+// Resume will reuse this; it is the same grammar as validateSessionName.
+func isCanonicalSessionName(name string) bool {
+	return validateSessionName(name) == nil
+}
+
+// isSafeLegacySessionName reports whether name is a safe single-component
+// legacy spelling (uppercase and/or dotted) that session list may report.
+// Separators, `.`, and `..` are never legacy. Resume will reuse this helper
+// without granting those spellings creation authority.
+func isSafeLegacySessionName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return false
+	}
+	if isCanonicalSessionName(name) {
+		return false
+	}
+	hasUpper, hasDot := false, false
+	for _, r := range name {
+		switch {
+		case r == '.':
+			hasDot = true
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		}
+	}
+	return hasUpper || hasDot
+}

--- a/internal/cli/session_name_test.go
+++ b/internal/cli/session_name_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import "testing"
+
+func TestIsCanonicalSessionName(t *testing.T) {
+	valid := []string{"collab", "feature-x", "auth", "my_session", "abc123"}
+	for _, name := range valid {
+		if !isCanonicalSessionName(name) {
+			t.Errorf("isCanonicalSessionName(%q) = false, want true", name)
+		}
+	}
+	invalid := []string{"", "Collab", "foo.bar", "my/session", ".", "..", "has space"}
+	for _, name := range invalid {
+		if isCanonicalSessionName(name) {
+			t.Errorf("isCanonicalSessionName(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestIsSafeLegacySessionName(t *testing.T) {
+	legacy := []string{"Collab", "foo.bar", "My_Session", "Auth.v2"}
+	for _, name := range legacy {
+		if !isSafeLegacySessionName(name) {
+			t.Errorf("isSafeLegacySessionName(%q) = false, want true", name)
+		}
+	}
+	notLegacy := []string{
+		"collab", "feature-x", "", ".", "..", "my/session", `my\session`, "foo+bar", "has space",
+	}
+	for _, name := range notLegacy {
+		if isSafeLegacySessionName(name) {
+			t.Errorf("isSafeLegacySessionName(%q) = true, want false", name)
+		}
+	}
+}

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -1,0 +1,440 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestSessionCreateExistingFailsLoudly(t *testing.T) {
+	base := makeSessionBase(t)
+	writeKnownAgentsConfig(t, base, []string{"claude", "codex"})
+
+	if _, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", base, "auth"})
+	}); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	_, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", base, "auth"})
+	})
+	if err == nil {
+		t.Fatal("creating an existing session succeeded")
+	}
+	if GetExitCode(err) != ExitError {
+		t.Fatalf("exit code = %d, want %d: %v", GetExitCode(err), ExitError, err)
+	}
+	var exists *sessionExistsError
+	if !errors.As(err, &exists) {
+		t.Fatalf("error type = %T (%v), want *sessionExistsError", err, err)
+	}
+	if exists.Name != "auth" {
+		t.Fatalf("exists.Name = %q, want auth", exists.Name)
+	}
+}
+
+func TestSessionCreateInvalidNameWritesNothing(t *testing.T) {
+	base := makeSessionBase(t)
+	before := dirNames(t, base)
+
+	_, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", base, "Feature-X"})
+	})
+	if err == nil {
+		t.Fatal("invalid session name succeeded")
+	}
+	if GetExitCode(err) != ExitUsage {
+		t.Fatalf("exit code = %d, want %d: %v", GetExitCode(err), ExitUsage, err)
+	}
+	after := dirNames(t, base)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("directory listing changed: before %#v after %#v", before, after)
+	}
+}
+
+func TestSessionCreateProvisionsRosterMailboxes(t *testing.T) {
+	base := makeSessionBase(t)
+	writeKnownAgentsConfig(t, base, []string{"claude", "codex"})
+
+	output, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", base, "--json", "feature-x"})
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var result sessionCreateResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode create json: %v (%s)", err, output)
+	}
+	if result.Name != "feature-x" {
+		t.Fatalf("name = %q, want feature-x", result.Name)
+	}
+	for _, agent := range []string{"claude", "codex"} {
+		if _, err := os.Stat(filepath.Join(result.Path, "agents", agent, "inbox", "new")); err != nil {
+			t.Fatalf("mailbox %s: %v", agent, err)
+		}
+	}
+}
+
+func TestSessionCreatePrefersLaunchRoster(t *testing.T) {
+	base := makeSessionBase(t)
+	writeKnownAgentsConfig(t, base, []string{"alice"})
+	project := isolateSessionProject(t)
+	writeProjectAmqrc(t, project)
+	writeLaunchRoster(t, project, `{"schema":1,"agents":[{"handle":"claude","command":["claude"]}]}`)
+	t.Chdir(project)
+
+	output, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", base, "--json", "squad"})
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var result sessionCreateResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode: %v (%s)", err, output)
+	}
+	if !reflect.DeepEqual(result.Agents, []string{"claude"}) {
+		t.Fatalf("agents = %#v, want [claude] from launch.json", result.Agents)
+	}
+	if _, err := os.Stat(filepath.Join(result.Path, "agents", "claude", "inbox", "new")); err != nil {
+		t.Fatalf("claude mailbox: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(result.Path, "agents", "alice")); !os.IsNotExist(err) {
+		t.Fatalf("alice mailbox should not be created from base config: %v", err)
+	}
+}
+
+func TestSessionCreateTrailingJSONFlag(t *testing.T) {
+	base := makeSessionBase(t)
+	output, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"feat-x", "--json", "--root", base})
+	})
+	if err != nil {
+		t.Fatalf("create with trailing --json: %v", err)
+	}
+	var result sessionCreateResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("expected json output: %v (%s)", err, output)
+	}
+	if result.Name != "feat-x" {
+		t.Fatalf("name = %q, want feat-x", result.Name)
+	}
+}
+
+func TestSessionCreateMaterializesBaseWhenAmqrcPresent(t *testing.T) {
+	project := isolateSessionProject(t)
+	writeProjectAmqrc(t, project)
+	t.Chdir(project)
+
+	if _, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"auth"})
+	}); err != nil {
+		t.Fatalf("create in configured repo: %v", err)
+	}
+	base := filepath.Join(project, defaultCoopRoot)
+	if _, err := os.Stat(filepath.Join(base, "meta")); err != nil {
+		t.Fatalf("base tree was not materialized: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "auth", "agents")); err != nil {
+		t.Fatalf("session was not created: %v", err)
+	}
+}
+
+func TestSessionCreateUnconfiguredRepoIsNotFound(t *testing.T) {
+	project := isolateSessionProject(t)
+	t.Chdir(project)
+	missing := filepath.Join(project, defaultCoopRoot)
+
+	_, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", missing, "auth"})
+	})
+	if err == nil {
+		t.Fatal("unconfigured create succeeded")
+	}
+	if GetExitCode(err) != ExitNotFound {
+		t.Fatalf("exit code = %d, want %d: %v", GetExitCode(err), ExitNotFound, err)
+	}
+	if !strings.Contains(err.Error(), "amq setup") || !strings.Contains(err.Error(), "amq coop init") {
+		t.Fatalf("error = %v, want setup/coop init remedy", err)
+	}
+	if _, statErr := os.Lstat(missing); !os.IsNotExist(statErr) {
+		t.Fatalf("unconfigured create wrote %s: %v", missing, statErr)
+	}
+}
+
+func TestSessionCreateLaunchRosterFromAmqrcDirNotCwd(t *testing.T) {
+	base := makeSessionBase(t)
+	writeKnownAgentsConfig(t, base, []string{"alice"})
+	project := isolateSessionProject(t)
+	writeProjectAmqrc(t, project)
+	writeLaunchRoster(t, project, `{"schema":1,"agents":[{"handle":"claude","command":["claude"]}]}`)
+	nested := filepath.Join(project, "nested")
+	if err := os.Mkdir(nested, 0o700); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	t.Chdir(nested)
+
+	output, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", base, "--json", "squad"})
+	})
+	if err != nil {
+		t.Fatalf("create from subdirectory: %v", err)
+	}
+	var result sessionCreateResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode: %v (%s)", err, output)
+	}
+	if !reflect.DeepEqual(result.Agents, []string{"claude"}) {
+		t.Fatalf("agents = %#v, want [claude] from project launch.json", result.Agents)
+	}
+}
+
+func TestSessionCreateRaceIsLoud(t *testing.T) {
+	base := makeSessionBase(t)
+	old := sessionCreateBeforeExclusive
+	sessionCreateBeforeExclusive = func(root, name string) {
+		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+			t.Fatalf("pre-create: %v", err)
+		}
+	}
+	t.Cleanup(func() { sessionCreateBeforeExclusive = old })
+
+	_, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", base, "auth"})
+	})
+	if err == nil {
+		t.Fatal("racing create succeeded silently")
+	}
+	if GetExitCode(err) != ExitError {
+		t.Fatalf("exit code = %d, want %d: %v", GetExitCode(err), ExitError, err)
+	}
+	var exists *sessionExistsError
+	if !errors.As(err, &exists) {
+		t.Fatalf("error = %T (%v), want *sessionExistsError", err, err)
+	}
+}
+
+func TestSessionCreateEmptyLaunchHandleFailsClosed(t *testing.T) {
+	base := makeSessionBase(t)
+	project := isolateSessionProject(t)
+	writeProjectAmqrc(t, project)
+	writeLaunchRoster(t, project, `{"schema":1,"agents":[{"handle":""},{"handle":"claude"}]}`)
+	t.Chdir(project)
+
+	_, err := captureEnvStdout(t, func() error {
+		return runSessionCreate([]string{"--root", base, "squad"})
+	})
+	if err == nil {
+		t.Fatal("empty launch.json handle succeeded")
+	}
+	if GetExitCode(err) != ExitError {
+		t.Fatalf("exit code = %d, want %d: %v", GetExitCode(err), ExitError, err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(base, "squad")); !os.IsNotExist(statErr) {
+		t.Fatalf("empty-handle create wrote a session: %v", statErr)
+	}
+}
+
+func TestSessionListJSONEmptyBase(t *testing.T) {
+	base := t.TempDir()
+	output, err := captureEnvStdout(t, func() error {
+		return runSessionList([]string{"--root", base, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("list empty base: %v", err)
+	}
+	var result sessionListResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("empty list is not valid json: %v (%q)", err, output)
+	}
+	if result.Sessions == nil {
+		t.Fatal("sessions is null, want empty array")
+	}
+	if len(result.Sessions) != 0 {
+		t.Fatalf("sessions = %#v, want empty", result.Sessions)
+	}
+}
+
+func TestSessionListSymlinkIsNeverLegacy(t *testing.T) {
+	base := makeSessionBase(t)
+	realSession := filepath.Join(t.TempDir(), "Collab")
+	if err := fsq.EnsureRootDirs(realSession); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(realSession, "claude"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	link := filepath.Join(base, "Collab")
+	if err := os.Symlink(realSession, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runSessionList([]string{"--root", base, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var result sessionListResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode: %v (%s)", err, output)
+	}
+	for _, item := range result.Sessions {
+		if item.Name == "Collab" {
+			t.Fatalf("symlinked session listed as %s: %#v", item.Kind, item)
+		}
+	}
+	found := false
+	for _, skipped := range result.Skipped {
+		if skipped.Name == "Collab" && skipped.Reason == "symlink" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected Collab skipped as symlink, got %#v", result.Skipped)
+	}
+
+	text, err := captureEnvStdout(t, func() error {
+		return runSessionList([]string{"--root", base})
+	})
+	if err != nil {
+		t.Fatalf("text list: %v", err)
+	}
+	if strings.Contains(text, "Collab") {
+		t.Fatalf("text list leaked symlink: %s", text)
+	}
+}
+
+func TestSessionListReportsCanonicalAndLegacy(t *testing.T) {
+	base := makeSessionBase(t)
+	if _, err := provisionCoopSession(base, "collab", []string{"claude"}, "", ""); err != nil {
+		t.Fatalf("provision collab: %v", err)
+	}
+	legacy := filepath.Join(base, "foo.bar")
+	if err := fsq.EnsureRootDirs(legacy); err != nil {
+		t.Fatalf("EnsureRootDirs legacy: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(legacy, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs legacy: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "notes.txt"), []byte("nope"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runSessionList([]string{"--root", base, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var result sessionListResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode: %v (%s)", err, output)
+	}
+
+	byName := map[string]sessionListEntry{}
+	for _, item := range result.Sessions {
+		byName[item.Name] = item
+	}
+	collab, ok := byName["collab"]
+	if !ok || collab.Kind != sessionKindCanonical {
+		t.Fatalf("collab = %#v, want canonical", collab)
+	}
+	legacyItem, ok := byName["foo.bar"]
+	if !ok || legacyItem.Kind != sessionKindLegacy {
+		t.Fatalf("foo.bar = %#v, want legacy_name", legacyItem)
+	}
+	if legacyItem.Hint != "amq list --root "+legacyItem.Path {
+		t.Fatalf("legacy hint = %q", legacyItem.Hint)
+	}
+
+	foundFile := false
+	for _, skipped := range result.Skipped {
+		if skipped.Name == "notes.txt" && skipped.Reason == "not_a_directory" {
+			foundFile = true
+		}
+	}
+	if !foundFile {
+		t.Fatalf("notes.txt should be skipped in json: %#v", result.Skipped)
+	}
+
+	text, err := captureEnvStdout(t, func() error {
+		return runSessionList([]string{"--root", base})
+	})
+	if err != nil {
+		t.Fatalf("text list: %v", err)
+	}
+	if strings.Contains(text, "notes.txt") {
+		t.Fatalf("text list leaked hostile file: %s", text)
+	}
+}
+
+func TestSessionResumeIsUnknownSubcommand(t *testing.T) {
+	err := runSession([]string{"resume", "collab"})
+	if err == nil {
+		t.Fatal("session resume should not ship as not-implemented")
+	}
+	if GetExitCode(err) != ExitUsage {
+		t.Fatalf("exit code = %d, want %d: %v", GetExitCode(err), ExitUsage, err)
+	}
+}
+
+func makeSessionBase(t *testing.T) string {
+	t.Helper()
+	base := filepath.Join(t.TempDir(), defaultCoopRoot)
+	if err := os.Mkdir(base, 0o700); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+	return base
+}
+
+func isolateSessionProject(t *testing.T) string {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(envRoot, "")
+	t.Setenv(envBaseRoot, "")
+	t.Setenv(envSession, "")
+	t.Setenv(envGlobalRoot, "")
+	return t.TempDir()
+}
+
+func writeProjectAmqrc(t *testing.T, project string) {
+	t.Helper()
+	data := []byte(`{"root":".agent-mail"}`)
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), data, 0o600); err != nil {
+		t.Fatalf("write .amqrc: %v", err)
+	}
+}
+
+func writeLaunchRoster(t *testing.T, project, body string) {
+	t.Helper()
+	if err := os.Mkdir(filepath.Join(project, ".amq"), 0o700); err != nil {
+		t.Fatalf("mkdir .amq: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amq", "launch.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write launch.json: %v", err)
+	}
+}
+
+func dirNames(t *testing.T, path string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -34,6 +34,20 @@ type pinnedBatchLease struct {
 	active atomic.Bool
 }
 
+// DirectChildExistsError is returned when CreateDirectChildExclusive finds the
+// name already present.
+type DirectChildExistsError struct {
+	Name string
+}
+
+func (e *DirectChildExistsError) Error() string {
+	return fmt.Sprintf("direct child %q already exists", e.Name)
+}
+
+// beforeCreateDirectChildExclusiveForTest runs after VerifyBase and before
+// Mkdir so tests can inject a racing creator.
+var beforeCreateDirectChildExclusiveForTest func(r *DeliveryRoot, name string)
+
 // SnapshotDeliveryRoot captures the physical directory identity at the
 // authorization boundary. The snapshot is intentionally opaque so callers
 // cannot forge or reinterpret it.
@@ -138,6 +152,42 @@ func (r *DeliveryRoot) OpenOrCreateDirectChild(name string, perm os.FileMode) (*
 		return nil, fmt.Errorf("%q is not a direct directory under delivery root", name)
 	}
 
+	return r.pinDirectChild(name, before)
+}
+
+// CreateDirectChildExclusive creates one direct, non-symlink child directory
+// and fails if the name already exists. Session create uses this so a racing
+// creator cannot silently open an existing session.
+func (r *DeliveryRoot) CreateDirectChildExclusive(name string, perm os.FileMode) (*DeliveryRoot, error) {
+	if r == nil || r.root == nil {
+		return nil, fmt.Errorf("delivery root is closed")
+	}
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+		return nil, fmt.Errorf("invalid direct child name %q", name)
+	}
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+	if beforeCreateDirectChildExclusiveForTest != nil {
+		beforeCreateDirectChildExclusiveForTest(r, name)
+	}
+	if err := r.root.Mkdir(name, perm); err != nil {
+		if os.IsExist(err) {
+			return nil, &DirectChildExistsError{Name: name}
+		}
+		return nil, err
+	}
+	before, err := r.root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if !before.IsDir() || before.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%q is not a direct directory under delivery root", name)
+	}
+	return r.pinDirectChild(name, before)
+}
+
+func (r *DeliveryRoot) pinDirectChild(name string, before os.FileInfo) (*DeliveryRoot, error) {
 	childRoot, err := r.root.OpenRoot(name)
 	if err != nil {
 		return nil, err

--- a/internal/fsq/delivery_root_child_test.go
+++ b/internal/fsq/delivery_root_child_test.go
@@ -1,6 +1,7 @@
 package fsq
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,5 +120,42 @@ func TestDeliveryRootPinnedBatchChildExpiresAfterCallback(t *testing.T) {
 
 	if _, err := retainedChild.ReadDir("."); err == nil || !strings.Contains(err.Error(), "pinned delivery batch expired") {
 		t.Fatalf("retained child ReadDir error = %v, want expired batch refusal", err)
+	}
+}
+
+func TestCreateDirectChildExclusiveFailsIfNameExists(t *testing.T) {
+	base := t.TempDir()
+	if err := os.Mkdir(filepath.Join(base, "auth"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := openDeliveryRootForTest(t, base)
+	_, err := root.CreateDirectChildExclusive("auth", 0o700)
+	if err == nil {
+		t.Fatal("expected exists error")
+	}
+	var exists *DirectChildExistsError
+	if !errors.As(err, &exists) || exists.Name != "auth" {
+		t.Fatalf("error = %v, want DirectChildExistsError", err)
+	}
+}
+
+func TestCreateDirectChildExclusiveRaceIsLoud(t *testing.T) {
+	base := t.TempDir()
+	root := openDeliveryRootForTest(t, base)
+	old := beforeCreateDirectChildExclusiveForTest
+	beforeCreateDirectChildExclusiveForTest = func(r *DeliveryRoot, name string) {
+		if err := os.Mkdir(filepath.Join(r.Base(), name), 0o700); err != nil {
+			t.Fatalf("pre-create: %v", err)
+		}
+	}
+	t.Cleanup(func() { beforeCreateDirectChildExclusiveForTest = old })
+
+	_, err := root.CreateDirectChildExclusive("auth", 0o700)
+	if err == nil {
+		t.Fatal("racing creator was opened silently")
+	}
+	var exists *DirectChildExistsError
+	if !errors.As(err, &exists) {
+		t.Fatalf("error = %v, want DirectChildExistsError", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `amq session create` and `amq session list` (v1.1 section 1, A3 partial). `session resume` is not registered; it ships later with the reconciliation engine.
- Create is exclusive and loud: existing names exit 1, invalid names exit 2 with zero writes, unconfigured repos exit 3. List reports canonical sessions and safe `legacy_name` roots with an exact `--root` hint.
- Introduces `fsq.DeliveryRoot.CreateDirectChildExclusive` so create cannot silently open a racing existing session. `coop exec` stays idempotent.

## Test plan
- [ ] `go test ./internal/cli ./internal/fsq -count=1`
- [ ] `amq session create feat-x --json` then duplicate create exits 1
- [ ] Invalid name exits 2 and writes nothing
- [ ] `amq session list --json` reports canonical + legacy; symlink is skipped
- [ ] `amq session resume` is unknown (exit 2)

Refs: #480

Made with [Cursor](https://cursor.com)