### PR TITLE
feat(launch): add harness adapter contract and tier-1 identity adapters

### DIFF
--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -1,0 +1,257 @@
+package launch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+const (
+	ClaudeProvider = "claude"
+	CodexProvider  = "codex"
+)
+
+// HarnessAdapter owns conversation identity and produces backend-ready plans.
+// It must not create, inspect, focus, or close terminal resources.
+type HarnessAdapter interface {
+	Name() string
+	Mode() AdapterMode
+	CommittedEnvKeys() []string
+	Capabilities(context.Context) AdapterCapabilities
+	PlanFresh(PlanRequest) (AgentPlan, error)
+	PlanResume(ResumeRequest) (AgentPlan, error)
+	CaptureIdentity(CaptureRequest) CaptureResult
+}
+
+type AdapterCapabilities struct {
+	Provider        string      `json:"provider"`
+	Mode            AdapterMode `json:"mode"`
+	Available       bool        `json:"available"`
+	Executable      string      `json:"executable,omitempty"`
+	ProviderVersion string      `json:"provider_version,omitempty"`
+	Fresh           bool        `json:"fresh"`
+	Resume          bool        `json:"resume"`
+	Capture         bool        `json:"capture"`
+	Reason          string      `json:"reason,omitempty"`
+}
+
+type PlanRequest struct {
+	Handle        string
+	ProjectRoot   string
+	Cwd           string
+	LaunchNonce   string
+	ResumePolicy  ResumePolicy
+	CommittedArgs []string
+	BypassArgs    []string
+	EnvOverlay    map[string]string
+}
+
+type ResumeRequest struct {
+	PlanRequest
+	Conversation ConversationIdentity
+}
+
+type ConversationIdentity struct {
+	Provider string `json:"provider"`
+	ID       string `json:"id"`
+}
+
+type commandProbe interface {
+	LookPath(string) (string, error)
+	Output(context.Context, string, ...string) ([]byte, error)
+}
+
+type systemCommandProbe struct{}
+
+func (systemCommandProbe) LookPath(name string) (string, error) {
+	return exec.LookPath(name)
+}
+
+func (systemCommandProbe) Output(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func ValidateAdapterPlan(adapter HarnessAdapter, plan AgentPlan) error {
+	if adapter == nil {
+		return fmt.Errorf("missing harness adapter")
+	}
+	if plan.AdapterMode != adapter.Mode() {
+		return fmt.Errorf("adapter %s declares %q but built %q plan", adapter.Name(), adapter.Mode(), plan.AdapterMode)
+	}
+	return plan.Validate()
+}
+
+func ValidateAdapterCapabilities(adapter HarnessAdapter, capabilities AdapterCapabilities) error {
+	if adapter == nil {
+		return fmt.Errorf("missing harness adapter")
+	}
+	if capabilities.Provider != adapter.Name() {
+		return fmt.Errorf("adapter %s reported provider %q", adapter.Name(), capabilities.Provider)
+	}
+	if capabilities.Mode != adapter.Mode() {
+		return fmt.Errorf("adapter %s declares %q but reported %q mode", adapter.Name(), adapter.Mode(), capabilities.Mode)
+	}
+	if capabilities.Capture && adapter.Mode() != AdapterModeCapture {
+		return fmt.Errorf("adapter %s capture capability conflicts with %q mode", adapter.Name(), adapter.Mode())
+	}
+	return nil
+}
+
+func validatePlanRequest(request PlanRequest, executable, provider string, envRules map[string]valueRule, argRules map[string]argumentRule, bypassAllowed map[string]struct{}) (string, error) {
+	if !validUUID(request.LaunchNonce) {
+		return "", fmt.Errorf("launch nonce must be a UUID")
+	}
+	if request.ResumePolicy != ResumeEnabled && request.ResumePolicy != ResumeFresh && request.ResumePolicy != ResumeDisabled {
+		return "", fmt.Errorf("invalid resume policy %q", request.ResumePolicy)
+	}
+	resolvedExecutable, err := validateKnownExecutable(executable, request.ProjectRoot, provider)
+	if err != nil {
+		return "", err
+	}
+	if err := validateCommittedArgs(request.CommittedArgs, argRules); err != nil {
+		return "", err
+	}
+	for _, arg := range request.BypassArgs {
+		if _, ok := bypassAllowed[arg]; !ok {
+			return "", fmt.Errorf("unrecognized operator bypass argument %q", arg)
+		}
+	}
+	if err := validateCommittedEnv(request.EnvOverlay, envRules); err != nil {
+		return "", err
+	}
+	if err := validateWorkingDirectory(request.Cwd, request.ProjectRoot); err != nil {
+		return "", err
+	}
+	return resolvedExecutable, nil
+}
+
+func cloneEnv(overlay map[string]string) map[string]string {
+	if overlay == nil {
+		return nil
+	}
+	clone := make(map[string]string, len(overlay))
+	for key, value := range overlay {
+		clone[key] = value
+	}
+	return clone
+}
+
+func validateKnownExecutable(executable, projectRoot, provider string) (string, error) {
+	if !filepath.IsAbs(executable) {
+		resolvedPath, err := exec.LookPath(executable)
+		if err != nil {
+			return "", fmt.Errorf("resolve %s executable: %w", provider, err)
+		}
+		executable = resolvedPath
+	}
+	resolvedExecutable, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s executable: %w", provider, err)
+	}
+	base := strings.ToLower(filepath.Base(executable))
+	if runtime.GOOS == "windows" {
+		base = strings.TrimSuffix(base, ".exe")
+	}
+	if base != provider {
+		return "", fmt.Errorf("adapter %s cannot execute %q", provider, resolvedExecutable)
+	}
+	if strings.TrimSpace(projectRoot) == "" {
+		return "", fmt.Errorf("project root is required for executable validation")
+	}
+	resolvedProject, err := resolvedPath(projectRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve project root: %w", err)
+	}
+	if pathWithin(resolvedExecutable, resolvedProject) {
+		return "", fmt.Errorf("%s executable resolves inside the project", provider)
+	}
+	info, err := os.Stat(resolvedExecutable)
+	if err != nil {
+		return "", fmt.Errorf("stat %s executable: %w", provider, err)
+	}
+	if !info.Mode().IsRegular() || (runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0) {
+		return "", fmt.Errorf("%s executable is not an executable regular file", provider)
+	}
+	return resolvedExecutable, nil
+}
+
+func validateWorkingDirectory(cwd, projectRoot string) error {
+	resolvedProject, err := resolvedPath(projectRoot)
+	if err != nil {
+		return fmt.Errorf("resolve project root: %w", err)
+	}
+	resolvedCwd, err := resolvedPath(cwd)
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	if !pathWithin(resolvedCwd, resolvedProject) {
+		return fmt.Errorf("working directory must be inside the project")
+	}
+	info, err := os.Stat(resolvedCwd)
+	if err != nil {
+		return fmt.Errorf("stat working directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("working directory is not a directory")
+	}
+	return nil
+}
+
+type argumentRule struct {
+	value    bool
+	validate valueRule
+}
+
+func validateCommittedArgs(args []string, rules map[string]argumentRule) error {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		rule, ok := rules[arg]
+		if !ok {
+			return fmt.Errorf("committed argument %q is not allowed by adapter grammar", arg)
+		}
+		if !rule.value {
+			continue
+		}
+		if i+1 >= len(args) {
+			return fmt.Errorf("committed argument %q requires a value", arg)
+		}
+		i++
+		if rule.validate != nil && !rule.validate(args[i]) {
+			return fmt.Errorf("committed argument %q has invalid value %q", arg, args[i])
+		}
+	}
+	return nil
+}
+
+var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func safeArgumentValue(value string) bool {
+	return !strings.HasPrefix(value, "-") && safeEnvironmentValue(value)
+}
+
+func validUUID(value string) bool {
+	return uuidPattern.MatchString(value)
+}
+
+func validUUIDv7(value string) bool {
+	if !validUUID(value) || value[14] != '7' {
+		return false
+	}
+	variant := value[19]
+	return variant == '8' || variant == '9' || variant == 'a' || variant == 'A' || variant == 'b' || variant == 'B'
+}
+
+func validateConversation(identity ConversationIdentity, provider string) error {
+	if identity.Provider != provider {
+		return fmt.Errorf("conversation provider %q does not match adapter %q", identity.Provider, provider)
+	}
+	if !validUUID(identity.ID) {
+		return fmt.Errorf("conversation ID must be a UUID")
+	}
+	return nil
+}

--- a/internal/launch/adapter_claude.go
+++ b/internal/launch/adapter_claude.go
@@ -1,0 +1,139 @@
+package launch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type ClaudeAdapter struct {
+	executable string
+	probe      commandProbe
+}
+
+func NewClaudeAdapter(executable string) *ClaudeAdapter {
+	return &ClaudeAdapter{executable: executable, probe: systemCommandProbe{}}
+}
+
+func (adapter *ClaudeAdapter) Name() string      { return ClaudeProvider }
+func (adapter *ClaudeAdapter) Mode() AdapterMode { return AdapterModeMint }
+
+func (adapter *ClaudeAdapter) CommittedEnvKeys() []string {
+	return committedEnvKeys(claudeEnvRules())
+}
+
+func (adapter *ClaudeAdapter) Capabilities(ctx context.Context) AdapterCapabilities {
+	result := AdapterCapabilities{Provider: ClaudeProvider, Mode: adapter.Mode()}
+	executable, err := adapter.probe.LookPath(adapter.executable)
+	if err != nil {
+		result.Reason = "executable_not_found"
+		return result
+	}
+	version, err := adapter.probe.Output(ctx, executable, "--version")
+	if err != nil {
+		result.Reason = "version_probe_failed"
+		return result
+	}
+	help, err := adapter.probe.Output(ctx, executable, "--help")
+	if err != nil || !strings.Contains(string(help), "--session-id <uuid>") || !strings.Contains(string(help), "--resume [value]") {
+		result.Reason = "identity_flags_unsupported"
+		return result
+	}
+	result.Available = true
+	result.Executable = executable
+	result.ProviderVersion = claudeVersion(string(version))
+	if result.ProviderVersion == "" {
+		result.Available = false
+		result.Reason = "version_probe_failed"
+		return result
+	}
+	result.Fresh = true
+	result.Resume = true
+	return result
+}
+
+func (adapter *ClaudeAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) {
+	executable, err := validatePlanRequest(request, adapter.executable, ClaudeProvider, claudeEnvRules(), claudeArgRules(), claudeBypassArgs())
+	if err != nil {
+		return AgentPlan{}, err
+	}
+	argv := append([]string{executable}, request.CommittedArgs...)
+	argv = append(argv, request.BypassArgs...)
+	argv = append(argv, "--session-id", request.LaunchNonce)
+	plan := AgentPlan{
+		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
+		AdapterMode: AdapterModeMint, ResumePolicy: request.ResumePolicy,
+		LaunchNonce: request.LaunchNonce, ConversationID: request.LaunchNonce,
+		DynamicArgv: []DynamicArg{{Index: len(argv) - 1, Kind: DynamicArgLaunchNonce}},
+	}
+	if err := ValidateAdapterPlan(adapter, plan); err != nil {
+		return AgentPlan{}, err
+	}
+	return plan, nil
+}
+
+func (adapter *ClaudeAdapter) PlanResume(request ResumeRequest) (AgentPlan, error) {
+	if request.ResumePolicy != ResumeEnabled {
+		return AgentPlan{}, fmt.Errorf("resume plan requires resume policy %q", ResumeEnabled)
+	}
+	if err := validateConversation(request.Conversation, ClaudeProvider); err != nil {
+		return AgentPlan{}, err
+	}
+	executable, err := validatePlanRequest(request.PlanRequest, adapter.executable, ClaudeProvider, claudeEnvRules(), claudeArgRules(), claudeBypassArgs())
+	if err != nil {
+		return AgentPlan{}, err
+	}
+	argv := append([]string{executable}, request.CommittedArgs...)
+	argv = append(argv, request.BypassArgs...)
+	argv = append(argv, "--resume", request.Conversation.ID)
+	plan := AgentPlan{
+		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
+		AdapterMode: AdapterModeMint, ResumePolicy: request.ResumePolicy,
+		LaunchNonce: request.LaunchNonce, ConversationID: request.Conversation.ID,
+		DynamicArgv: []DynamicArg{{Index: len(argv) - 1, Kind: DynamicArgConversationID}},
+	}
+	if err := ValidateAdapterPlan(adapter, plan); err != nil {
+		return AgentPlan{}, err
+	}
+	return plan, nil
+}
+
+func (adapter *ClaudeAdapter) CaptureIdentity(CaptureRequest) CaptureResult {
+	return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonAdapterMintsIdentity}
+}
+
+func claudeEnvRules() map[string]valueRule { return commonCommittedEnvRules() }
+
+func claudeArgRules() map[string]argumentRule {
+	return map[string]argumentRule{
+		"--effort":          {value: true, validate: oneOf("low", "medium", "high", "xhigh", "max")},
+		"--model":           {value: true, validate: safeArgumentValue},
+		"--no-chrome":       {},
+		"--permission-mode": {value: true, validate: oneOf("acceptEdits", "auto", "manual", "dontAsk", "plan")},
+		"--safe-mode":       {},
+		"--verbose":         {},
+	}
+}
+
+func claudeBypassArgs() map[string]struct{} {
+	return map[string]struct{}{"--dangerously-skip-permissions": {}}
+}
+
+func claudeVersion(output string) string {
+	fields := strings.Fields(output)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+func oneOf(values ...string) valueRule {
+	return func(value string) bool {
+		for _, candidate := range values {
+			if value == candidate {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/internal/launch/adapter_codex.go
+++ b/internal/launch/adapter_codex.go
@@ -1,0 +1,134 @@
+package launch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const CodexThreadStartedV2 CaptureEvidenceSource = "codex_app_server_thread_started_v2"
+
+const codexCaptureVersion = "0.147.0"
+
+type CodexAdapter struct {
+	executable string
+	probe      commandProbe
+}
+
+func NewCodexAdapter(executable string) *CodexAdapter {
+	return &CodexAdapter{executable: executable, probe: systemCommandProbe{}}
+}
+
+func (adapter *CodexAdapter) Name() string      { return CodexProvider }
+func (adapter *CodexAdapter) Mode() AdapterMode { return AdapterModeCapture }
+
+func (adapter *CodexAdapter) CommittedEnvKeys() []string {
+	return committedEnvKeys(codexEnvRules())
+}
+
+func (adapter *CodexAdapter) Capabilities(ctx context.Context) AdapterCapabilities {
+	result := AdapterCapabilities{Provider: CodexProvider, Mode: adapter.Mode()}
+	executable, err := adapter.probe.LookPath(adapter.executable)
+	if err != nil {
+		result.Reason = "executable_not_found"
+		return result
+	}
+	version, err := adapter.probe.Output(ctx, executable, "--version")
+	if err != nil {
+		result.Reason = "version_probe_failed"
+		return result
+	}
+	help, helpErr := adapter.probe.Output(ctx, executable, "--help")
+	resumeHelp, resumeErr := adapter.probe.Output(ctx, executable, "resume", "--help")
+	appServerHelp, appServerErr := adapter.probe.Output(ctx, executable, "app-server", "--help")
+	if helpErr != nil || resumeErr != nil || appServerErr != nil ||
+		!strings.Contains(string(help), "resume") ||
+		!strings.Contains(string(resumeHelp), "[SESSION_ID]") ||
+		!strings.Contains(string(appServerHelp), "generate-json-schema") {
+		result.Reason = "identity_contract_unsupported"
+		return result
+	}
+	result.Available = true
+	result.Executable = executable
+	result.ProviderVersion = codexVersion(string(version))
+	if result.ProviderVersion == "" {
+		result.Available = false
+		result.Reason = "version_probe_failed"
+		return result
+	}
+	result.Fresh = true
+	result.Resume = true
+	if result.ProviderVersion != codexCaptureVersion {
+		result.Reason = "capture_version_unsupported"
+		return result
+	}
+	result.Capture = true
+	return result
+}
+
+func (adapter *CodexAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) {
+	executable, err := validatePlanRequest(request, adapter.executable, CodexProvider, codexEnvRules(), codexArgRules(), codexBypassArgs())
+	if err != nil {
+		return AgentPlan{}, err
+	}
+	argv := append([]string{executable}, request.CommittedArgs...)
+	argv = append(argv, request.BypassArgs...)
+	plan := AgentPlan{
+		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
+		AdapterMode: AdapterModeCapture, ResumePolicy: request.ResumePolicy, LaunchNonce: request.LaunchNonce,
+	}
+	if err := ValidateAdapterPlan(adapter, plan); err != nil {
+		return AgentPlan{}, err
+	}
+	return plan, nil
+}
+
+func (adapter *CodexAdapter) PlanResume(request ResumeRequest) (AgentPlan, error) {
+	if request.ResumePolicy != ResumeEnabled {
+		return AgentPlan{}, fmt.Errorf("resume plan requires resume policy %q", ResumeEnabled)
+	}
+	if err := validateConversation(request.Conversation, CodexProvider); err != nil {
+		return AgentPlan{}, err
+	}
+	executable, err := validatePlanRequest(request.PlanRequest, adapter.executable, CodexProvider, codexEnvRules(), codexArgRules(), codexBypassArgs())
+	if err != nil {
+		return AgentPlan{}, err
+	}
+	argv := append([]string{executable, "resume"}, request.CommittedArgs...)
+	argv = append(argv, request.BypassArgs...)
+	argv = append(argv, request.Conversation.ID)
+	plan := AgentPlan{
+		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
+		AdapterMode: AdapterModeCapture, ResumePolicy: request.ResumePolicy,
+		LaunchNonce: request.LaunchNonce, ConversationID: request.Conversation.ID,
+		DynamicArgv: []DynamicArg{{Index: len(argv) - 1, Kind: DynamicArgConversationID}},
+	}
+	if err := ValidateAdapterPlan(adapter, plan); err != nil {
+		return AgentPlan{}, err
+	}
+	return plan, nil
+}
+
+func (adapter *CodexAdapter) CaptureIdentity(request CaptureRequest) CaptureResult {
+	return captureCodexIdentity(request)
+}
+
+func codexEnvRules() map[string]valueRule { return commonCommittedEnvRules() }
+
+func codexArgRules() map[string]argumentRule {
+	return map[string]argumentRule{
+		"--ask-for-approval": {value: true, validate: oneOf("untrusted", "on-request")},
+		"--model":            {value: true, validate: safeArgumentValue},
+		"--no-alt-screen":    {},
+		"--sandbox":          {value: true, validate: oneOf("read-only", "workspace-write")},
+		"--search":           {},
+	}
+}
+
+func codexBypassArgs() map[string]struct{} {
+	return map[string]struct{}{"--dangerously-bypass-approvals-and-sandbox": {}}
+}
+
+func codexVersion(output string) string {
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(output), "codex-cli "))
+}

--- a/internal/launch/adapter_env.go
+++ b/internal/launch/adapter_env.go
@@ -1,0 +1,45 @@
+package launch
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+)
+
+type valueRule func(string) bool
+
+var safeEnvironmentValue = regexp.MustCompile(`^[A-Za-z0-9_.@+:-]{1,128}$`).MatchString
+
+func commonCommittedEnvRules() map[string]valueRule {
+	return map[string]valueRule{
+		"COLORTERM": safeEnvironmentValue,
+		"LANG":      safeEnvironmentValue,
+		"LC_ALL":    safeEnvironmentValue,
+		"NO_COLOR": func(value string) bool {
+			return value == "1" || value == "true"
+		},
+		"TERM": safeEnvironmentValue,
+	}
+}
+
+func validateCommittedEnv(overlay map[string]string, rules map[string]valueRule) error {
+	for key, value := range overlay {
+		rule, ok := rules[key]
+		if !ok {
+			return fmt.Errorf("committed environment key %q is not allowed by adapter", key)
+		}
+		if !rule(value) {
+			return fmt.Errorf("committed environment key %q has invalid literal value", key)
+		}
+	}
+	return nil
+}
+
+func committedEnvKeys(rules map[string]valueRule) []string {
+	keys := make([]string, 0, len(rules))
+	for key := range rules {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -1,0 +1,299 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const (
+	testLaunchNonce    = "018f1f29-7b58-7cc3-98f1-9a74b7d01733"
+	testConversationID = "018f1f2a-bc34-71bd-9056-23838e27f859"
+)
+
+type fakeCommandProbe struct {
+	path    string
+	lookErr error
+	outputs map[string]string
+	errors  map[string]error
+}
+
+func (probe fakeCommandProbe) LookPath(string) (string, error) { return probe.path, probe.lookErr }
+func (probe fakeCommandProbe) Output(_ context.Context, _ string, args ...string) ([]byte, error) {
+	key := strings.Join(args, " ")
+	return []byte(probe.outputs[key]), probe.errors[key]
+}
+
+func testExecutable(t *testing.T, name string) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	project := filepath.Join(base, "project")
+	bin := filepath.Join(base, "bin")
+	if err := os.Mkdir(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(bin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := "/usr/bin/true"
+	if _, err := os.Stat(target); err != nil {
+		target = "/bin/true"
+	}
+	executable := filepath.Join(bin, name)
+	if err := os.Symlink(target, executable); err != nil {
+		t.Fatal(err)
+	}
+	return project, executable
+}
+
+func planRequest(project, handle string) PlanRequest {
+	return PlanRequest{
+		Handle: handle, ProjectRoot: project, Cwd: project,
+		LaunchNonce: testLaunchNonce, ResumePolicy: ResumeEnabled,
+		EnvOverlay: map[string]string{"LANG": "en_US.UTF-8", "TERM": "xterm-256color"},
+	}
+}
+
+func TestAdapterCapabilitiesProbeExactIdentityContracts(t *testing.T) {
+	claude := NewClaudeAdapter("claude")
+	claude.probe = fakeCommandProbe{path: "/bin/claude", outputs: map[string]string{
+		"--version": "2.1.229 (Claude Code)\n",
+		"--help":    "--session-id <uuid> --resume [value]",
+	}}
+	gotClaude := claude.Capabilities(context.Background())
+	if !gotClaude.Available || !gotClaude.Fresh || !gotClaude.Resume || gotClaude.Capture || gotClaude.Mode != AdapterModeMint {
+		t.Fatalf("Claude capabilities = %#v", gotClaude)
+	}
+	if gotClaude.ProviderVersion != "2.1.229" {
+		t.Fatalf("Claude provider version = %q", gotClaude.ProviderVersion)
+	}
+	if err := ValidateAdapterCapabilities(claude, gotClaude); err != nil {
+		t.Fatal(err)
+	}
+
+	codex := NewCodexAdapter("codex")
+	codex.probe = fakeCommandProbe{path: "/bin/codex", outputs: map[string]string{
+		"--version":         "codex-cli 0.147.0\n",
+		"--help":            "commands: resume",
+		"resume --help":     "Usage: codex resume [OPTIONS] [SESSION_ID]",
+		"app-server --help": "generate-json-schema",
+	}}
+	gotCodex := codex.Capabilities(context.Background())
+	if !gotCodex.Available || !gotCodex.Fresh || !gotCodex.Resume || !gotCodex.Capture || gotCodex.Mode != AdapterModeCapture {
+		t.Fatalf("Codex capabilities = %#v", gotCodex)
+	}
+	if gotCodex.ProviderVersion != "0.147.0" {
+		t.Fatalf("Codex provider version = %q", gotCodex.ProviderVersion)
+	}
+	if err := ValidateAdapterCapabilities(codex, gotCodex); err != nil {
+		t.Fatal(err)
+	}
+
+	codex.probe = fakeCommandProbe{path: "/bin/codex", outputs: map[string]string{
+		"--version": "codex-cli 0.147.0\n", "--help": "commands: resume",
+		"resume --help": "--last only", "app-server --help": "generate-json-schema",
+	}}
+	unsupported := codex.Capabilities(context.Background())
+	if unsupported.Available || unsupported.Reason != "identity_contract_unsupported" {
+		t.Fatalf("unsupported Codex capabilities = %#v", unsupported)
+	}
+	codex.probe = fakeCommandProbe{path: "/bin/codex", outputs: map[string]string{
+		"--version": "codex-cli 0.148.0\n", "--help": "commands: resume",
+		"resume --help": "Usage: codex resume [OPTIONS] [SESSION_ID]", "app-server --help": "generate-json-schema",
+	}}
+	untestedVersion := codex.Capabilities(context.Background())
+	if !untestedVersion.Available || !untestedVersion.Fresh || !untestedVersion.Resume || untestedVersion.Capture || untestedVersion.Reason != "capture_version_unsupported" {
+		t.Fatalf("untested Codex version capabilities = %#v", untestedVersion)
+	}
+	if err := ValidateAdapterCapabilities(codex, untestedVersion); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaudePlansUseExactMintAndResumeShapes(t *testing.T) {
+	project, executable := testExecutable(t, ClaudeProvider)
+	adapter := NewClaudeAdapter(executable)
+	request := planRequest(project, ClaudeProvider)
+	request.CommittedArgs = []string{"--model", "opus", "--permission-mode", "plan"}
+	request.BypassArgs = []string{"--dangerously-skip-permissions"}
+
+	fresh, err := adapter.PlanFresh(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFreshTail := []string{"--session-id", testLaunchNonce}
+	if !reflect.DeepEqual(fresh.Argv[len(fresh.Argv)-2:], wantFreshTail) {
+		t.Fatalf("fresh argv = %q", fresh.Argv)
+	}
+	if fresh.AdapterMode != AdapterModeMint || fresh.ConversationID != testLaunchNonce ||
+		len(fresh.DynamicArgv) != 1 || fresh.DynamicArgv[0].Kind != DynamicArgLaunchNonce {
+		t.Fatalf("fresh plan = %#v", fresh)
+	}
+
+	resume, err := adapter.PlanResume(ResumeRequest{
+		PlanRequest:  request,
+		Conversation: ConversationIdentity{Provider: ClaudeProvider, ID: testConversationID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantResumeTail := []string{"--resume", testConversationID}
+	if !reflect.DeepEqual(resume.Argv[len(resume.Argv)-2:], wantResumeTail) {
+		t.Fatalf("resume argv = %q", resume.Argv)
+	}
+	if resume.DynamicArgv[0].Kind != DynamicArgConversationID {
+		t.Fatalf("resume dynamic argv = %#v", resume.DynamicArgv)
+	}
+
+	resume.Argv[resume.DynamicArgv[0].Index] = testLaunchNonce
+	if err := ValidateAdapterPlan(adapter, resume); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("slot laundering error = %v", err)
+	}
+	if result := adapter.CaptureIdentity(CaptureRequest{}); result.State != CaptureUnsupported || result.Degraded || result.CanPersist() {
+		t.Fatalf("mint capture result = %#v", result)
+	}
+}
+
+func TestCodexPlansUseExactCaptureAndResumeShapes(t *testing.T) {
+	project, executable := testExecutable(t, CodexProvider)
+	adapter := NewCodexAdapter(executable)
+	request := planRequest(project, CodexProvider)
+	request.CommittedArgs = []string{"--model", "gpt-5.6-sol", "--sandbox", "workspace-write"}
+	request.BypassArgs = []string{"--dangerously-bypass-approvals-and-sandbox"}
+
+	fresh, err := adapter.PlanFresh(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.AdapterMode != AdapterModeCapture || fresh.ConversationID != "" || len(fresh.DynamicArgv) != 0 {
+		t.Fatalf("fresh plan = %#v", fresh)
+	}
+	resume, err := adapter.PlanResume(ResumeRequest{
+		PlanRequest:  request,
+		Conversation: ConversationIdentity{Provider: CodexProvider, ID: testConversationID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resume.Argv) < 3 || resume.Argv[1] != "resume" || resume.Argv[len(resume.Argv)-1] != testConversationID {
+		t.Fatalf("resume argv = %q", resume.Argv)
+	}
+	for _, arg := range resume.Argv {
+		if arg == "--last" {
+			t.Fatalf("resume argv used forbidden heuristic: %q", resume.Argv)
+		}
+	}
+}
+
+func TestAdapterEnvAndArgGrammarFailsClosed(t *testing.T) {
+	project, executable := testExecutable(t, ClaudeProvider)
+	adapter := NewClaudeAdapter(executable)
+	base := planRequest(project, ClaudeProvider)
+	tests := []struct {
+		name   string
+		mutate func(*PlanRequest)
+		want   string
+	}{
+		{"node options", func(request *PlanRequest) { request.EnvOverlay["NODE_OPTIONS"] = "--require=./repo.js" }, "NODE_OPTIONS"},
+		{"path", func(request *PlanRequest) { request.EnvOverlay["PATH"] = filepath.Join(project, "bin") }, "PATH"},
+		{"config redirect", func(request *PlanRequest) { request.EnvOverlay["CLAUDE_CONFIG_DIR"] = project }, "CLAUDE_CONFIG_DIR"},
+		{"literal interpolation", func(request *PlanRequest) { request.EnvOverlay["LANG"] = "${REPO_LANG}" }, "invalid literal"},
+		{"shell wrapper", func(request *PlanRequest) { request.CommittedArgs = []string{"bash", "./wrapper.sh"} }, "not allowed"},
+		{"identity override", func(request *PlanRequest) { request.CommittedArgs = []string{"--session-id", testConversationID} }, "not allowed"},
+		{"committed bypass", func(request *PlanRequest) { request.CommittedArgs = []string{"--permission-mode", "bypassPermissions"} }, "invalid value"},
+		{"bypass as flag value", func(request *PlanRequest) {
+			request.CommittedArgs = []string{"--model", "--dangerously-skip-permissions"}
+		}, "invalid value"},
+		{"unknown bypass", func(request *PlanRequest) { request.BypassArgs = []string{"--allow-everything"} }, "unrecognized operator bypass"},
+		{"cwd escape", func(request *PlanRequest) { request.Cwd = t.TempDir() }, "inside the project"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := base
+			request.EnvOverlay = cloneEnv(base.EnvOverlay)
+			test.mutate(&request)
+			if _, err := adapter.PlanFresh(request); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("PlanFresh error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestAdapterRejectsProjectExecutableAndProviderMismatch(t *testing.T) {
+	project := t.TempDir()
+	inside := filepath.Join(project, ClaudeProvider)
+	if err := os.WriteFile(inside, []byte("not executable"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	adapter := NewClaudeAdapter(inside)
+	request := planRequest(project, ClaudeProvider)
+	if _, err := adapter.PlanFresh(request); err == nil || !strings.Contains(err.Error(), "inside the project") {
+		t.Fatalf("project executable error = %v", err)
+	}
+
+	otherProject, codexExecutable := testExecutable(t, CodexProvider)
+	request = planRequest(otherProject, ClaudeProvider)
+	if _, err := NewClaudeAdapter(codexExecutable).PlanFresh(request); err == nil || !strings.Contains(err.Error(), "cannot execute") {
+		t.Fatalf("provider executable error = %v", err)
+	}
+}
+
+func TestAdapterResolvesConfiguredExecutableFromPath(t *testing.T) {
+	project, executable := testExecutable(t, ClaudeProvider)
+	t.Setenv("PATH", filepath.Dir(executable))
+	plan, err := NewClaudeAdapter(ClaudeProvider).PlanFresh(planRequest(project, ClaudeProvider))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Argv[0] != resolved {
+		t.Fatalf("resolved executable = %q, want %q", plan.Argv[0], resolved)
+	}
+}
+
+type misdeclaredAdapter struct{}
+
+func (misdeclaredAdapter) Name() string               { return "bad" }
+func (misdeclaredAdapter) Mode() AdapterMode          { return AdapterModeMint }
+func (misdeclaredAdapter) CommittedEnvKeys() []string { return nil }
+func (misdeclaredAdapter) Capabilities(context.Context) AdapterCapabilities {
+	return AdapterCapabilities{}
+}
+func (misdeclaredAdapter) PlanFresh(PlanRequest) (AgentPlan, error) {
+	return AgentPlan{}, errors.New("unused")
+}
+func (misdeclaredAdapter) PlanResume(ResumeRequest) (AgentPlan, error) {
+	return AgentPlan{}, errors.New("unused")
+}
+func (misdeclaredAdapter) CaptureIdentity(CaptureRequest) CaptureResult { return CaptureResult{} }
+
+func TestValidateAdapterPlanRejectsModeMisdeclaration(t *testing.T) {
+	plan := AgentPlan{
+		Handle: "bad", Argv: []string{"/bin/bad"}, Cwd: "/tmp",
+		AdapterMode: AdapterModeCapture, ResumePolicy: ResumeEnabled,
+	}
+	if err := ValidateAdapterPlan(misdeclaredAdapter{}, plan); err == nil || !strings.Contains(err.Error(), "declares") {
+		t.Fatalf("mode declaration error = %v", err)
+	}
+}
+
+func TestValidateAdapterCapabilitiesRejectsModeMisdeclaration(t *testing.T) {
+	adapter := misdeclaredAdapter{}
+	tests := []AdapterCapabilities{
+		{Provider: "other", Mode: AdapterModeMint},
+		{Provider: "bad", Mode: AdapterModeCapture},
+		{Provider: "bad", Mode: AdapterModeMint, Available: true, Capture: true},
+	}
+	for _, capabilities := range tests {
+		if err := ValidateAdapterCapabilities(adapter, capabilities); err == nil {
+			t.Fatalf("ValidateAdapterCapabilities(%#v) error = nil", capabilities)
+		}
+	}
+}

--- a/internal/launch/capture.go
+++ b/internal/launch/capture.go
@@ -1,0 +1,160 @@
+package launch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type CaptureState string
+
+const (
+	CapturePending     CaptureState = "pending"
+	CaptureReady       CaptureState = "ready"
+	CaptureStale       CaptureState = "stale"
+	CaptureUnsupported CaptureState = "unsupported"
+)
+
+type CaptureEvidenceSource string
+
+type CaptureReason string
+
+const (
+	CaptureReasonAdapterMintsIdentity CaptureReason = "adapter_mints_identity"
+	CaptureReasonEvidenceMissing      CaptureReason = "evidence_missing"
+	CaptureReasonEvidenceAmbiguous    CaptureReason = "evidence_ambiguous"
+	CaptureReasonProviderMismatch     CaptureReason = "provider_mismatch"
+	CaptureReasonProviderVersion      CaptureReason = "provider_version_mismatch"
+	CaptureReasonLaunchNonceMismatch  CaptureReason = "launch_nonce_mismatch"
+	CaptureReasonEvidenceSource       CaptureReason = "evidence_source_unsupported"
+	CaptureReasonEvidenceUnverified   CaptureReason = "evidence_unverified"
+	CaptureReasonInvalidIdentity      CaptureReason = "invalid_conversation_identity"
+	CaptureReasonConversationActive   CaptureReason = "conversation_active_elsewhere"
+)
+
+type CaptureRequest struct {
+	LaunchNonce             string
+	ExpectedProviderVersion string
+	Final                   bool
+	Evidence                []CaptureEvidence
+}
+
+// CaptureEvidence is an observer-correlated envelope around provider-owned
+// evidence. Source names the provider protocol event; LaunchNonce binds the
+// observation to the launch generation held by the caller's session lease.
+type CaptureEvidence struct {
+	source          CaptureEvidenceSource
+	provider        string
+	providerVersion string
+	launchNonce     string
+	conversationID  string
+	activeElsewhere bool
+	verified        bool
+}
+
+type CaptureResult struct {
+	State    CaptureState
+	Identity ConversationIdentity
+	Degraded bool
+	Reason   CaptureReason
+}
+
+func (result CaptureResult) CanPersist() bool {
+	return result.State == CaptureReady && !result.Degraded && result.Identity.Provider != "" && result.Identity.ID != ""
+}
+
+// ParseCodexThreadStartedEvidence verifies the provider event shape and binds
+// the observation to the launch generation of the channel that received it.
+// It does not scan the Codex session store or accept newest-file evidence.
+func ParseCodexThreadStartedEvidence(raw []byte, launchNonce string, activeElsewhere bool) (CaptureEvidence, error) {
+	if !validUUID(launchNonce) {
+		return CaptureEvidence{}, fmt.Errorf("launch nonce must be a UUID")
+	}
+	var event struct {
+		Method string `json:"method"`
+		Params struct {
+			Thread struct {
+				ID         string `json:"id"`
+				CLIVersion string `json:"cliVersion"`
+			} `json:"thread"`
+		} `json:"params"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if err := decoder.Decode(&event); err != nil {
+		return CaptureEvidence{}, fmt.Errorf("decode Codex capture evidence: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return CaptureEvidence{}, fmt.Errorf("decode Codex capture evidence: trailing JSON value")
+	}
+	if event.Method != "thread/started" {
+		return CaptureEvidence{}, fmt.Errorf("codex capture evidence method is %q, want thread/started", event.Method)
+	}
+	if !validUUIDv7(event.Params.Thread.ID) {
+		return CaptureEvidence{}, fmt.Errorf("codex thread/started identity must be a UUIDv7")
+	}
+	if strings.TrimSpace(event.Params.Thread.CLIVersion) == "" {
+		return CaptureEvidence{}, fmt.Errorf("codex thread/started evidence has no CLI version")
+	}
+	return CaptureEvidence{
+		source: CodexThreadStartedV2, provider: CodexProvider,
+		providerVersion: event.Params.Thread.CLIVersion, launchNonce: launchNonce,
+		conversationID: event.Params.Thread.ID, activeElsewhere: activeElsewhere,
+		verified: true,
+	}, nil
+}
+
+func captureCodexIdentity(request CaptureRequest) CaptureResult {
+	if !validUUID(request.LaunchNonce) {
+		return degradedCapture(CaptureStale, CaptureReasonLaunchNonceMismatch)
+	}
+	if strings.TrimSpace(request.ExpectedProviderVersion) == "" {
+		return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonProviderVersion}
+	}
+	if len(request.Evidence) == 0 {
+		if !request.Final {
+			return CaptureResult{State: CapturePending}
+		}
+		return degradedCapture(CaptureStale, CaptureReasonEvidenceMissing)
+	}
+	identities := make(map[string]struct{}, len(request.Evidence))
+	for _, evidence := range request.Evidence {
+		if !evidence.verified {
+			return degradedCapture(CaptureStale, CaptureReasonEvidenceUnverified)
+		}
+		if evidence.source != CodexThreadStartedV2 {
+			return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonEvidenceSource}
+		}
+		if evidence.provider != CodexProvider {
+			return degradedCapture(CaptureStale, CaptureReasonProviderMismatch)
+		}
+		if evidence.providerVersion != request.ExpectedProviderVersion {
+			return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonProviderVersion}
+		}
+		if evidence.launchNonce != request.LaunchNonce {
+			return degradedCapture(CaptureStale, CaptureReasonLaunchNonceMismatch)
+		}
+		if evidence.activeElsewhere {
+			return degradedCapture(CaptureStale, CaptureReasonConversationActive)
+		}
+		if !validUUIDv7(evidence.conversationID) {
+			return degradedCapture(CaptureStale, CaptureReasonInvalidIdentity)
+		}
+		identities[evidence.conversationID] = struct{}{}
+	}
+	if len(identities) != 1 {
+		return degradedCapture(CaptureStale, CaptureReasonEvidenceAmbiguous)
+	}
+	for id := range identities {
+		return CaptureResult{
+			State:    CaptureReady,
+			Identity: ConversationIdentity{Provider: CodexProvider, ID: id},
+		}
+	}
+	return degradedCapture(CaptureStale, CaptureReasonEvidenceMissing)
+}
+
+func degradedCapture(state CaptureState, reason CaptureReason) CaptureResult {
+	return CaptureResult{State: state, Degraded: true, Reason: reason}
+}

--- a/internal/launch/capture_test.go
+++ b/internal/launch/capture_test.go
@@ -1,0 +1,96 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+)
+
+func validCodexCapture() CaptureRequest {
+	evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"`+testConversationID+`","cliVersion":"0.147.0","ignored_provider_field":true}}}`), testLaunchNonce, false)
+	if err != nil {
+		panic(err)
+	}
+	return CaptureRequest{
+		LaunchNonce: testLaunchNonce, ExpectedProviderVersion: "0.147.0", Final: true,
+		Evidence: []CaptureEvidence{evidence},
+	}
+}
+
+func TestCodexCaptureStateMachine(t *testing.T) {
+	adapter := NewCodexAdapter("codex")
+	pending := adapter.CaptureIdentity(CaptureRequest{
+		LaunchNonce: testLaunchNonce, ExpectedProviderVersion: "0.147.0",
+	})
+	if pending.State != CapturePending || pending.Degraded || pending.CanPersist() {
+		t.Fatalf("pending = %#v", pending)
+	}
+	ready := adapter.CaptureIdentity(validCodexCapture())
+	if ready.State != CaptureReady || ready.Degraded || !ready.CanPersist() || ready.Identity.Provider != CodexProvider || ready.Identity.ID != testConversationID {
+		t.Fatalf("ready = %#v", ready)
+	}
+	missing := validCodexCapture()
+	missing.Evidence = nil
+	stale := adapter.CaptureIdentity(missing)
+	if stale.State != CaptureStale || !stale.Degraded || stale.CanPersist() || stale.Identity.ID != "" || stale.Reason != CaptureReasonEvidenceMissing {
+		t.Fatalf("stale = %#v", stale)
+	}
+	unsupported := validCodexCapture()
+	unsupported.Evidence[0].providerVersion = "0.146.0"
+	result := adapter.CaptureIdentity(unsupported)
+	if result.State != CaptureUnsupported || result.Degraded || result.CanPersist() || result.Reason != CaptureReasonProviderVersion {
+		t.Fatalf("unsupported = %#v", result)
+	}
+}
+
+func TestCodexCaptureRejectsAmbiguousOrForgedEvidence(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*CaptureRequest)
+		state  CaptureState
+		reason CaptureReason
+	}{
+		{"ambiguous", func(request *CaptureRequest) {
+			other := request.Evidence[0]
+			other.conversationID = "018f1f2b-e465-75b8-87d7-21dddb678c13"
+			request.Evidence = append(request.Evidence, other)
+		}, CaptureStale, CaptureReasonEvidenceAmbiguous},
+		{"forged nonce", func(request *CaptureRequest) { request.Evidence[0].launchNonce = testConversationID }, CaptureStale, CaptureReasonLaunchNonceMismatch},
+		{"wrong provider", func(request *CaptureRequest) { request.Evidence[0].provider = ClaudeProvider }, CaptureStale, CaptureReasonProviderMismatch},
+		{"newest file", func(request *CaptureRequest) { request.Evidence[0].source = "codex_newest_session_file" }, CaptureUnsupported, CaptureReasonEvidenceSource},
+		{"invalid id", func(request *CaptureRequest) { request.Evidence[0].conversationID = "newest" }, CaptureStale, CaptureReasonInvalidIdentity},
+		{"active elsewhere", func(request *CaptureRequest) { request.Evidence[0].activeElsewhere = true }, CaptureStale, CaptureReasonConversationActive},
+		{"unverified struct", func(request *CaptureRequest) { request.Evidence[0].verified = false }, CaptureStale, CaptureReasonEvidenceUnverified},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := validCodexCapture()
+			test.mutate(&request)
+			result := NewCodexAdapter("codex").CaptureIdentity(request)
+			if result.State != test.state || result.Reason != test.reason || result.CanPersist() || result.Identity.ID != "" {
+				t.Fatalf("CaptureIdentity = %#v, want state %q reason %q and no identity", result, test.state, test.reason)
+			}
+		})
+	}
+}
+
+func TestParseCodexThreadStartedEvidenceRejectsForgedEvents(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"malformed", `{`, "decode"},
+		{"wrong method", `{"method":"thread/resumed","params":{"thread":{"id":"` + testConversationID + `","cliVersion":"codex-cli 0.147.0"}}}`, "thread/started"},
+		{"missing version", `{"method":"thread/started","params":{"thread":{"id":"` + testConversationID + `"}}}`, "no CLI version"},
+		{"invalid id", `{"method":"thread/started","params":{"thread":{"id":"newest","cliVersion":"codex-cli 0.147.0"}}}`, "must be a UUID"},
+		{"non-v7 id", `{"method":"thread/started","params":{"thread":{"id":"550e8400-e29b-41d4-a716-446655440000","cliVersion":"0.147.0"}}}`, "UUIDv7"},
+		{"trailing event", `{"method":"thread/started","params":{"thread":{"id":"` + testConversationID + `","cliVersion":"codex-cli 0.147.0"}}} {}`, "trailing"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := ParseCodexThreadStartedEvidence([]byte(test.raw), testLaunchNonce, false); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ParseCodexThreadStartedEvidence error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/launch/plan.go
+++ b/internal/launch/plan.go
@@ -140,6 +140,11 @@ func (a AgentPlan) validate() error {
 	return nil
 }
 
+// Validate checks one backend-ready agent plan independently of its parent.
+func (a AgentPlan) Validate() error {
+	return a.validate()
+}
+
 type canonicalArgument struct {
 	Value   string         `json:"value,omitempty"`
 	Dynamic DynamicArgKind `json:"dynamic,omitempty"`


### PR DESCRIPTION
## Summary

- Add the harness adapter contract for runtime capabilities, fresh and resume planning, and identity capture.
- Add Claude mint and Codex provider-evidence capture adapters with deny-default argv and environment validation.
- Add hostile tests for slot laundering, unsafe environment and config redirects, mode misdeclaration, and forged or ambiguous capture evidence.

## Scope

Implements the Wave A adapter boundary from issue #480. This is additive launch-package work only. It does not add CLI wiring, backend execution, or reconciliation.

Refs: #480

## Validation

- go test ./...
- go test -race ./internal/launch
- go vet ./internal/launch
- golangci-lint run ./internal/launch/...
- Windows test compilation for internal/launch and internal/cli
- repository pre-push checks
