### PR TITLE
feat(launch): add backend contract, commands plan_only backend, and conformance skeleton

### DIFF
--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -1,0 +1,165 @@
+package launch
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// Backend is the launcher contract from #480 v1.1 §6.
+// Attach-or-recreate is an orchestration decision from Inspect evidence,
+// never a backend method.
+type Backend interface {
+	Detect() DetectResult
+	Create(CreateRequest) (CreateResult, error)
+	Inspect(InspectRequest) (InspectResult, error)
+	Close(CloseRequest) (CloseResult, error)
+}
+
+type Capability string
+
+const (
+	// CapPlanOnly is the commands-backend floor: emit an executable plan,
+	// never claim a managed terminal resource.
+	CapPlanOnly Capability = "plan_only"
+	// CapCreate is managed layout creation (writes a binding).
+	CapCreate Capability = "create"
+	// CapInspect means the backend can distinguish present from absent.
+	CapInspect Capability = "inspect"
+	// CapClose means the backend can dispose of a resource it owns.
+	CapClose Capability = "close"
+	// CapFocus means the backend can attach to a present layout.
+	CapFocus Capability = "focus"
+)
+
+type Outcome string
+
+const (
+	OutcomeCreated         Outcome = "created"
+	OutcomeCommandsEmitted Outcome = "commands_emitted"
+	OutcomeActionRequired  Outcome = "action_required"
+	OutcomeUnsupported     Outcome = "unsupported"
+)
+
+type InspectStatus string
+
+const (
+	InspectPresent InspectStatus = "present"
+	InspectAbsent  InspectStatus = "absent"
+	InspectUnknown InspectStatus = "unknown"
+)
+
+// Profile is the versioned static maximum envelope for one
+// (backend, platform, version-range). Conformance graduates this identity;
+// Detect reports the runtime subset separately so the envelope cannot shrink
+// to dodge a failing test.
+type Profile struct {
+	Backend      string       `json:"backend"`
+	Platform     string       `json:"platform"`
+	VersionRange string       `json:"version_range"`
+	Version      int          `json:"version"`
+	Capabilities []Capability `json:"capabilities"`
+}
+
+func (p Profile) Identity() string {
+	return fmt.Sprintf("%s/%s/v%d", p.Backend, p.Platform, p.Version)
+}
+
+func (p Profile) Has(c Capability) bool {
+	return slices.Contains(p.Capabilities, c)
+}
+
+type Degradation struct {
+	Capability Capability `json:"capability"`
+	Reason     string     `json:"reason"`
+}
+
+type DetectResult struct {
+	Available    bool          `json:"available"`
+	Profile      Profile       `json:"profile"`
+	Effective    []Capability  `json:"effective"`
+	Degradations []Degradation `json:"degradations,omitempty"`
+}
+
+func (d DetectResult) Validate() error {
+	if d.Profile.Backend == "" || d.Profile.Platform == "" || d.Profile.Version < 1 {
+		return fmt.Errorf("capability profile is incomplete")
+	}
+	if d.Profile.Identity() == "" {
+		return fmt.Errorf("capability profile identity is empty")
+	}
+	seen := make(map[Capability]struct{}, len(d.Profile.Capabilities))
+	for _, c := range d.Profile.Capabilities {
+		if c == "" {
+			return fmt.Errorf("empty capability in static profile")
+		}
+		if _, ok := seen[c]; ok {
+			return fmt.Errorf("duplicate capability %q", c)
+		}
+		seen[c] = struct{}{}
+	}
+	for _, c := range d.Effective {
+		if !d.Profile.Has(c) {
+			return fmt.Errorf("effective capability %q is outside the static profile", c)
+		}
+	}
+	for _, deg := range d.Degradations {
+		if !d.Profile.Has(deg.Capability) {
+			return fmt.Errorf("degradation %q is outside the static profile", deg.Capability)
+		}
+		if slices.Contains(d.Effective, deg.Capability) {
+			return fmt.Errorf("degradation %q is still in the effective set", deg.Capability)
+		}
+		if deg.Reason == "" {
+			return fmt.Errorf("degradation %q has no reason", deg.Capability)
+		}
+	}
+	return nil
+}
+
+type CreateRequest struct {
+	Session string
+	Plan    Plan
+	AMQPath string
+	Root    *fsq.DeliveryRoot
+}
+
+type EmittedCommand struct {
+	Handle      string            `json:"handle"`
+	Argv        []string          `json:"argv"`
+	Cwd         string            `json:"cwd"`
+	Env         map[string]string `json:"env,omitempty"`
+	LaunchNonce string            `json:"launch_nonce,omitempty"`
+	Line        string            `json:"line"`
+}
+
+type CreateResult struct {
+	Outcome        Outcome          `json:"outcome"`
+	ActionRequired bool             `json:"action_required"`
+	Profile        string           `json:"profile,omitempty"`
+	Commands       []EmittedCommand `json:"commands,omitempty"`
+	Plan           []byte           `json:"plan,omitempty"`
+	Reason         string           `json:"reason,omitempty"`
+}
+
+type InspectRequest struct {
+	Binding BindingRecord
+	Root    *fsq.DeliveryRoot
+}
+
+type InspectResult struct {
+	Status         InspectStatus `json:"status"`
+	Evidence       string        `json:"evidence"`
+	ActionRequired bool          `json:"action_required"`
+}
+
+type CloseRequest struct {
+	Binding BindingRecord
+	Root    *fsq.DeliveryRoot
+}
+
+type CloseResult struct {
+	Outcome Outcome `json:"outcome"`
+	Reason  string  `json:"reason,omitempty"`
+}

--- a/internal/launch/backend_test.go
+++ b/internal/launch/backend_test.go
@@ -1,0 +1,20 @@
+package launch
+
+import "testing"
+
+func TestDetectResultRejectsEffectiveOutsideMaximum(t *testing.T) {
+	result := DetectResult{
+		Available: true,
+		Profile:   CommandsProfile(),
+		Effective: []Capability{CapClose},
+	}
+	if err := result.Validate(); err == nil || err.Error() != `effective capability "close" is outside the static profile` {
+		t.Fatalf("Validate = %v", err)
+	}
+}
+
+func TestProfileIdentity(t *testing.T) {
+	if got := CommandsProfile().Identity(); got != "commands/any/v1" {
+		t.Fatalf("Identity = %q", got)
+	}
+}

--- a/internal/launch/commands.go
+++ b/internal/launch/commands.go
@@ -1,0 +1,142 @@
+package launch
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+const (
+	CommandsBackendName       = "commands"
+	PlanOnlyInspectEvidence   = "plan_only backend has no query surface"
+	PlanOnlyCloseReason       = "plan_only backend owns no terminal resource"
+	commandsProfileVersion    = 1
+	commandsProfilePlatform   = "any"
+	commandsProfileVersionRng = "*"
+)
+
+// Commands is the plan_only backend. It emits exact coop-exec invocations
+// from a prebuilt plan and never owns a terminal resource.
+type Commands struct{}
+
+func CommandsProfile() Profile {
+	return Profile{
+		Backend:      CommandsBackendName,
+		Platform:     commandsProfilePlatform,
+		VersionRange: commandsProfileVersionRng,
+		Version:      commandsProfileVersion,
+		Capabilities: []Capability{CapPlanOnly},
+	}
+}
+
+func (Commands) Detect() DetectResult {
+	profile := CommandsProfile()
+	return DetectResult{
+		Available: true,
+		Profile:   profile,
+		Effective: slices.Clone(profile.Capabilities),
+	}
+}
+
+func (Commands) Create(req CreateRequest) (CreateResult, error) {
+	if strings.TrimSpace(req.Session) == "" {
+		return CreateResult{}, fmt.Errorf("session is required")
+	}
+	if err := req.Plan.Validate(); err != nil {
+		return CreateResult{}, err
+	}
+	amq := req.AMQPath
+	if strings.TrimSpace(amq) == "" {
+		amq = "amq"
+	}
+	planJSON, err := json.Marshal(req.Plan)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	commands := make([]EmittedCommand, 0, len(req.Plan.Agents))
+	for _, agent := range req.Plan.Agents {
+		argv := coopExecArgv(amq, req.Session, agent.Handle, agent.Argv)
+		env := cloneEnv(agent.EnvOverlay)
+		commands = append(commands, EmittedCommand{
+			Handle:      agent.Handle,
+			Argv:        argv,
+			Cwd:         agent.Cwd,
+			Env:         env,
+			LaunchNonce: agent.LaunchNonce,
+			Line:        commandLine(agent.Cwd, env, argv),
+		})
+	}
+	return CreateResult{
+		Outcome:        OutcomeCommandsEmitted,
+		ActionRequired: true,
+		Profile:        CommandsProfile().Identity(),
+		Commands:       commands,
+		Plan:           planJSON,
+	}, nil
+}
+
+func (Commands) Inspect(InspectRequest) (InspectResult, error) {
+	return InspectResult{
+		Status:         InspectUnknown,
+		Evidence:       PlanOnlyInspectEvidence,
+		ActionRequired: true,
+	}, nil
+}
+
+func (Commands) Close(CloseRequest) (CloseResult, error) {
+	return CloseResult{Outcome: OutcomeUnsupported, Reason: PlanOnlyCloseReason}, nil
+}
+
+// coopExecArgv is amq coop exec [options] <command> [-- <command-flags>].
+// The command positional is required; flags after -- are agent args. A lone
+// executable omits --.
+func coopExecArgv(amq, session, handle string, planArgv []string) []string {
+	argv := []string{amq, "coop", "exec", "--session", session, "--me", handle, planArgv[0]}
+	if len(planArgv) > 1 {
+		argv = append(argv, "--")
+		argv = append(argv, planArgv[1:]...)
+	}
+	return argv
+}
+
+func commandLine(cwd string, env map[string]string, argv []string) string {
+	parts := make([]string, 0, 4+len(env)+len(argv))
+	if cwd != "" {
+		parts = append(parts, "cd", shellQuote(cwd), "&&")
+	}
+	if len(env) != 0 {
+		parts = append(parts, "env")
+		keys := make([]string, 0, len(env))
+		for k := range env {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+		for _, k := range keys {
+			parts = append(parts, k+"="+shellQuote(env[k]))
+		}
+	}
+	for _, arg := range argv {
+		parts = append(parts, shellQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return false
+		case strings.ContainsRune("@%_+=:,./-", r):
+			return false
+		default:
+			return true
+		}
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/internal/launch/commands_test.go
+++ b/internal/launch/commands_test.go
@@ -1,0 +1,214 @@
+package launch
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCommandsPublishedProfile(t *testing.T) {
+	got := Commands{}.Detect()
+	want := CommandsProfile()
+	if err := got.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if got.Profile.Identity() != "commands/any/v1" {
+		t.Fatalf("profile identity = %q", got.Profile.Identity())
+	}
+	if !reflect.DeepEqual(got.Profile, want) {
+		t.Fatalf("Detect profile = %#v, want %#v", got.Profile, want)
+	}
+	if !reflect.DeepEqual(got.Effective, want.Capabilities) {
+		t.Fatalf("effective = %#v, want static maximum %#v", got.Effective, want.Capabilities)
+	}
+	if len(got.Degradations) != 0 {
+		t.Fatalf("commands profile must not shrink at runtime: %#v", got.Degradations)
+	}
+}
+
+func TestCommandsCreateEmitsCoopExecAndRoundTripsPlan(t *testing.T) {
+	_, root := openTestRoot(t)
+	plan := validPlan()
+	result, err := Commands{}.Create(CreateRequest{
+		Session: "feature-x", Plan: plan, AMQPath: "/opt/amq", Root: root,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != OutcomeCommandsEmitted || !result.ActionRequired {
+		t.Fatalf("Create = %#v, want commands_emitted + action_required", result)
+	}
+	if result.Outcome == OutcomeCreated || result.Outcome == OutcomeUnsupported {
+		t.Fatalf("Create invented %s", result.Outcome)
+	}
+	decoded, err := DecodePlan(result.Plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(decoded, plan) {
+		t.Fatalf("DecodePlan round-trip mismatch\ngot %#v\nwant %#v", decoded, plan)
+	}
+	if len(result.Commands) != len(plan.Agents) {
+		t.Fatalf("commands = %d, want %d", len(result.Commands), len(plan.Agents))
+	}
+	for i, agent := range plan.Agents {
+		cmd := result.Commands[i]
+		if cmd.Handle != agent.Handle || cmd.Cwd != agent.Cwd || cmd.LaunchNonce != agent.LaunchNonce {
+			t.Fatalf("command[%d] metadata = %#v", i, cmd)
+		}
+		assertCoopExecGrammar(t, cmd.Argv, agent.Handle, agent.Argv)
+		if !strings.Contains(cmd.Line, "coop exec") || !strings.Contains(cmd.Line, agent.Handle) {
+			t.Fatalf("command[%d] line missing coop exec: %s", i, cmd.Line)
+		}
+		if !strings.Contains(cmd.Line, agent.Argv[0]) {
+			t.Fatalf("command[%d] line missing command positional: %s", i, cmd.Line)
+		}
+	}
+	if _, err := LoadBinding(root); err == nil {
+		t.Fatal("plan_only Create wrote a binding")
+	}
+}
+
+func TestCommandsCreateCloseNeverInventSuccess(t *testing.T) {
+	_, root := openTestRoot(t)
+	created, err := Commands{}.Create(CreateRequest{Session: "collab", Plan: validPlan(), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Outcome == OutcomeCreated {
+		t.Fatal("Create invented managed success")
+	}
+	closed, err := Commands{}.Close(CloseRequest{Root: root, Binding: validBinding()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.Outcome != OutcomeUnsupported || closed.Reason != PlanOnlyCloseReason {
+		t.Fatalf("Close = %#v, want unsupported %q", closed, PlanOnlyCloseReason)
+	}
+	if _, err := LoadBinding(root); err == nil {
+		t.Fatal("Close wrote or required a binding")
+	}
+}
+
+func TestCommandsInspectUnknownDoesNotMutate(t *testing.T) {
+	_, root := openTestRoot(t)
+	record := validBinding()
+	if err := WriteBinding(root, record); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Commands{}.Inspect(InspectRequest{Root: root, Binding: record})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != InspectUnknown || got.Evidence != PlanOnlyInspectEvidence || !got.ActionRequired {
+		t.Fatalf("Inspect = %#v", got)
+	}
+	loaded, err := LoadBinding(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.LaunchNonce != record.LaunchNonce {
+		t.Fatalf("Inspect mutated binding: %#v", loaded)
+	}
+}
+
+func TestCommandsCreateRejectsInvalidInput(t *testing.T) {
+	_, err := Commands{}.Create(CreateRequest{Plan: validPlan()})
+	if err == nil || !strings.Contains(err.Error(), "session is required") {
+		t.Fatalf("empty session error = %v", err)
+	}
+	_, err = Commands{}.Create(CreateRequest{Session: "collab"})
+	if err == nil {
+		t.Fatal("invalid plan succeeded")
+	}
+}
+
+func TestCommandsCoopExecGrammarShape(t *testing.T) {
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{
+		{
+			Handle: "claude", Argv: []string{"/usr/local/bin/claude", "--model", "opus"},
+			Cwd: "/work/project", AdapterMode: AdapterModeUnsupported, ResumePolicy: ResumeDisabled,
+		},
+		{
+			Handle: "codex", Argv: []string{"/usr/local/bin/codex"},
+			Cwd: "/work/project", AdapterMode: AdapterModeUnsupported, ResumePolicy: ResumeDisabled,
+		},
+	}}
+	result, err := Commands{}.Create(CreateRequest{Session: "collab", Plan: plan})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Commands) != 2 {
+		t.Fatalf("commands = %d, want 2", len(result.Commands))
+	}
+	assertCoopExecGrammar(t, result.Commands[0].Argv, "claude", plan.Agents[0].Argv)
+	assertCoopExecGrammar(t, result.Commands[1].Argv, "codex", plan.Agents[1].Argv)
+	if slices.Contains(result.Commands[1].Argv, "--") {
+		t.Fatalf("lone executable must omit --: %#v", result.Commands[1].Argv)
+	}
+	if !strings.Contains(result.Commands[0].Line, "/usr/local/bin/claude --") {
+		t.Fatalf("Line missing command positional before --: %s", result.Commands[0].Line)
+	}
+}
+
+func TestCommandsCoopExecOldShapeFailsGrammar(t *testing.T) {
+	old := []string{"amq", "coop", "exec", "--session", "collab", "--me", "claude", "--", "/usr/local/bin/claude", "--model", "opus"}
+	if err := coopExecGrammarError(old, "claude", []string{"/usr/local/bin/claude", "--model", "opus"}); err == nil {
+		t.Fatal("old shape (-- immediately after --me) passed grammar check")
+	}
+}
+
+func TestCommandsConformance(t *testing.T) {
+	RunConformance(t, Commands{})
+}
+
+func assertCoopExecGrammar(t *testing.T, argv []string, handle string, planArgv []string) {
+	t.Helper()
+	if err := coopExecGrammarError(argv, handle, planArgv); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func coopExecGrammarError(argv []string, handle string, planArgv []string) error {
+	me := indexOf(argv, "--me")
+	if me < 0 || me+1 >= len(argv) {
+		return fmt.Errorf("missing --me in %#v", argv)
+	}
+	if argv[me+1] != handle {
+		return fmt.Errorf("--me value = %q, want %q", argv[me+1], handle)
+	}
+	if me+2 >= len(argv) {
+		return fmt.Errorf("missing command positional after --me")
+	}
+	if argv[me+2] == "--" {
+		return fmt.Errorf("old shape: -- immediately after --me (command positional missing): %#v", argv)
+	}
+	if argv[me+2] != planArgv[0] {
+		return fmt.Errorf("command positional = %q, want %q", argv[me+2], planArgv[0])
+	}
+	dash := indexOf(argv, "--")
+	if len(planArgv) == 1 {
+		if dash >= 0 {
+			return fmt.Errorf("lone command must omit --: %#v", argv)
+		}
+		return nil
+	}
+	if dash != me+3 {
+		return fmt.Errorf("-- at %d, want immediately after command positional in %#v", dash, argv)
+	}
+	if !slices.Equal(argv[dash+1:], planArgv[1:]) {
+		return fmt.Errorf("argv tail = %#v, want %#v", argv[dash+1:], planArgv[1:])
+	}
+	return nil
+}
+
+func indexOf(argv []string, want string) int {
+	for i, v := range argv {
+		if v == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/launch/conformance.go
+++ b/internal/launch/conformance.go
@@ -1,0 +1,305 @@
+package launch
+
+import (
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// RunConformance exercises declared capabilities identically for any backend
+// and requires stable unsupported / unknown for the rest. The Inspect-unknown
+// injection and typo-refusal cases always run so tmux/cmux/ghostty can reuse
+// them unchanged.
+func RunConformance(t *testing.T, b Backend) {
+	t.Helper()
+	detect := b.Detect()
+	if !detect.Available {
+		t.Fatal("Detect reported unavailable")
+	}
+	if err := detect.Validate(); err != nil {
+		t.Fatalf("Detect profile: %v", err)
+	}
+	profile := detect.Profile
+	_, root := harnessRoot(t)
+
+	t.Run("declared_capabilities", func(t *testing.T) {
+		for _, cap := range profile.Capabilities {
+			effective := slices.Contains(detect.Effective, cap)
+			t.Run(string(cap), func(t *testing.T) {
+				if !effective {
+					assertDegradedOrUnsupported(t, b, cap, detect, root)
+					return
+				}
+				switch cap {
+				case CapPlanOnly:
+					assertPlanOnlyCreate(t, b, root)
+				case CapCreate, CapInspect, CapClose, CapFocus:
+					t.Fatal("managed capability declared but this skeleton has no managed assertion yet")
+				default:
+					t.Fatalf("unknown declared capability %q", cap)
+				}
+			})
+		}
+	})
+
+	t.Run("undeclared_create_is_not_managed_success", func(t *testing.T) {
+		if profile.Has(CapCreate) {
+			t.Skip("managed create is declared")
+		}
+		result, err := b.Create(CreateRequest{Session: "collab", Plan: harnessPlan(), Root: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Outcome == OutcomeCreated {
+			t.Fatalf("undeclared create invented managed success: %#v", result)
+		}
+		assertNoBinding(t, root)
+	})
+
+	t.Run("undeclared_inspect_is_unknown", func(t *testing.T) {
+		if profile.Has(CapInspect) {
+			t.Skip("inspect is declared")
+		}
+		got, err := b.Inspect(InspectRequest{Root: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != InspectUnknown || got.Evidence == "" {
+			t.Fatalf("undeclared Inspect = %#v, want unknown with evidence", got)
+		}
+		assertNoBinding(t, root)
+	})
+
+	t.Run("undeclared_close_is_unsupported", func(t *testing.T) {
+		if profile.Has(CapClose) {
+			t.Skip("close is declared")
+		}
+		got, err := b.Close(CloseRequest{Root: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Outcome != OutcomeUnsupported {
+			t.Fatalf("undeclared Close = %#v, want unsupported", got)
+		}
+		assertNoBinding(t, root)
+	})
+
+	t.Run("inspect_unknown_zero_mutations", func(t *testing.T) {
+		creates, closes := 0, 0
+		injected := unknownInspect{Backend: countingBackend{Backend: b, creates: &creates, closes: &closes}}
+		got, err := injected.Inspect(InspectRequest{Root: root, Binding: harnessBinding()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != InspectUnknown {
+			t.Fatalf("injected Inspect = %#v, want unknown", got)
+		}
+		if creates != 0 || closes != 0 {
+			t.Fatalf("Inspect unknown mutated backend state: creates=%d closes=%d", creates, closes)
+		}
+		assertNoBinding(t, root)
+	})
+
+	t.Run("typo_refusal", func(t *testing.T) {
+		// A missing session name must not be created by the backend. plan_only
+		// emits commands; managed backends reuse this to refuse layout create.
+		dir := t.TempDir()
+		identity, err := fsq.SnapshotDeliveryRoot(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		typoRoot, err := fsq.OpenDeliveryRoot(dir, identity)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = typoRoot.Close() })
+		before, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := b.Create(CreateRequest{Session: "no-such-session", Plan: harnessPlan(), Root: typoRoot})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Outcome == OutcomeCreated {
+			t.Fatal("typo session invented managed create success")
+		}
+		assertNoBinding(t, typoRoot)
+		after, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := names(after), names(before); !slices.Equal(got, want) {
+			t.Fatalf("backend wrote files for a missing session: before=%v after=%v", want, got)
+		}
+	})
+
+	t.Run("stale_binding_recovery", func(t *testing.T) {
+		if !profile.Has(CapInspect) || !profile.Has(CapCreate) {
+			t.Skip("managed inspect/create not in profile; reused by tmux/cmux/ghostty")
+		}
+	})
+
+	t.Run("duplicate_spawn_prevention", func(t *testing.T) {
+		if !profile.Has(CapCreate) {
+			t.Skip("managed create not in profile; reused by tmux/cmux/ghostty")
+		}
+	})
+
+	t.Run("foreign_context_binding_rejection", func(t *testing.T) {
+		if !profile.Has(CapInspect) {
+			t.Skip("inspect not in profile; reused by tmux/cmux/ghostty")
+		}
+	})
+
+	t.Run("capability_degradation", func(t *testing.T) {
+		if len(detect.Degradations) == 0 {
+			t.Skip("no runtime degradation on this profile")
+		}
+		for _, deg := range detect.Degradations {
+			if deg.Reason == "" {
+				t.Fatalf("degradation %q has no reason", deg.Capability)
+			}
+			if slices.Contains(detect.Effective, deg.Capability) {
+				t.Fatalf("degraded capability %q remains effective", deg.Capability)
+			}
+		}
+	})
+}
+
+func assertPlanOnlyCreate(t *testing.T, b Backend, root *fsq.DeliveryRoot) {
+	t.Helper()
+	plan := harnessPlan()
+	result, err := b.Create(CreateRequest{Session: "collab", Plan: plan, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != OutcomeCommandsEmitted || !result.ActionRequired {
+		t.Fatalf("plan_only Create = %#v, want commands_emitted + action_required", result)
+	}
+	if _, err := DecodePlan(result.Plan); err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Commands) != len(plan.Agents) {
+		t.Fatalf("emitted %d commands, want %d", len(result.Commands), len(plan.Agents))
+	}
+	assertNoBinding(t, root)
+}
+
+func assertDegradedOrUnsupported(t *testing.T, b Backend, cap Capability, detect DetectResult, root *fsq.DeliveryRoot) {
+	t.Helper()
+	found := false
+	for _, deg := range detect.Degradations {
+		if deg.Capability == cap && deg.Reason != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("capability %q is not effective and has no degradation reason", cap)
+	}
+	switch cap {
+	case CapClose:
+		got, err := b.Close(CloseRequest{Root: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Outcome != OutcomeUnsupported {
+			t.Fatalf("degraded Close = %#v, want unsupported", got)
+		}
+	case CapInspect:
+		got, err := b.Inspect(InspectRequest{Root: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status == InspectPresent {
+			t.Fatalf("degraded Inspect invented present: %#v", got)
+		}
+	}
+}
+
+func assertNoBinding(t *testing.T, root *fsq.DeliveryRoot) {
+	t.Helper()
+	if root == nil {
+		return
+	}
+	if _, err := LoadBinding(root); err == nil {
+		t.Fatal("backend wrote a binding")
+	}
+}
+
+func names(entries []os.DirEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Name()
+	}
+	return out
+}
+
+func harnessRoot(t *testing.T) (string, *fsq.DeliveryRoot) {
+	t.Helper()
+	dir := t.TempDir()
+	identity, err := fsq.SnapshotDeliveryRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(dir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return dir, root
+}
+
+func harnessPlan() Plan {
+	return Plan{Version: PlanVersion, Agents: []AgentPlan{
+		{
+			Handle: "claude", Argv: []string{"/usr/local/bin/claude", "--session-id", "claude:one"},
+			EnvOverlay: map[string]string{"LANG": "C"}, Cwd: "/work/project",
+			AdapterMode: AdapterModeMint, ResumePolicy: ResumeEnabled,
+			LaunchNonce: "launch-one", ConversationID: "claude:one",
+			DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgConversationID}},
+		},
+		{
+			Handle: "codex", Argv: []string{"/usr/local/bin/codex", "--launch-nonce", "launch-one"}, Cwd: "/work/project",
+			AdapterMode: AdapterModeCapture, ResumePolicy: ResumeFresh,
+			LaunchNonce: "launch-one",
+			DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgLaunchNonce}},
+		},
+	}}
+}
+
+func harnessBinding() BindingRecord {
+	return BindingRecord{
+		Version: BindingVersion, Backend: "tmux", HostIdentity: "host:one",
+		InstanceIdentity: "tmux-server:one", Profile: "tmux/darwin/v1", LaunchNonce: "nonce-one",
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion},
+	}
+}
+
+type countingBackend struct {
+	Backend
+	creates *int
+	closes  *int
+}
+
+func (b countingBackend) Create(req CreateRequest) (CreateResult, error) {
+	*b.creates++
+	return b.Backend.Create(req)
+}
+
+func (b countingBackend) Close(req CloseRequest) (CloseResult, error) {
+	*b.closes++
+	return b.Backend.Close(req)
+}
+
+type unknownInspect struct{ Backend }
+
+func (unknownInspect) Inspect(InspectRequest) (InspectResult, error) {
+	return InspectResult{
+		Status:         InspectUnknown,
+		Evidence:       "injected unknown",
+		ActionRequired: true,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- Adds the #480 v1.1 §6 launcher backend contract (`Detect` / `Create` / `Inspect` / `Close`) in `internal/launch`. Attach-or-recreate is not a backend method.
- Ships the `commands` `plan_only` backend: emits `amq coop exec --session --me <argv[0]> -- <argv[1:]…>` (`--` omitted for a lone executable), `Inspect` unknown with exact evidence, `Close` unsupported, never writes a binding.
- Adds `RunConformance` with declared-capability tests, Inspect-unknown zero-mutation injection, and typo-refusal; managed cases are skipped placeholders for tmux/cmux/ghostty.

## Test plan
- [ ] `go test ./internal/launch -count=1`
- [ ] Create does not write `binding.json` and does not return `created`
- [ ] Emitted argv: command positional between `--me` and `--`; old `--`-after-`--me` shape is rejected
- [ ] `Inspect` evidence is exactly `plan_only backend has no query surface`
- [ ] `Close` is `unsupported`

Refs: #480

Made with [Cursor](https://cursor.com)