### PR TITLE
feat(launch): add session launch lease with handle locks and lease-gated binding writes

### DIFF
--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -1,6 +1,7 @@
 package fsq
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -502,6 +503,39 @@ func (r *DeliveryRoot) Remove(name string) error {
 		return err
 	}
 	return r.root.Remove(name)
+}
+
+// OpenLockFile opens or creates a root-relative file for advisory locking.
+// The file is opened O_CREATE on its stable name and is never replaced, so
+// flock serializes on one inode. Callers must close the returned file.
+func (r *DeliveryRoot) OpenLockFile(dir, filename string, perm os.FileMode) (*os.File, error) {
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+	if err := r.root.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	name := filepath.Join(dir, filename)
+	file, err := r.root.OpenFile(name, os.O_CREATE|os.O_RDWR, perm)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := r.root.MkdirAll(dir, 0o700); err != nil {
+			return nil, err
+		}
+		file, err = r.root.OpenFile(name, os.O_CREATE|os.O_RDWR, perm)
+	}
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock file %s is not a regular file", r.displayPath(name))
+	}
+	return file, nil
 }
 
 // SyncDir syncs a root-relative directory through the pinned capability.

--- a/internal/fsq/delivery_root_regular_test.go
+++ b/internal/fsq/delivery_root_regular_test.go
@@ -30,3 +30,29 @@ func TestDeliveryRootOpenRegularNoFollow(t *testing.T) {
 		t.Fatalf("data = %q", data)
 	}
 }
+
+func TestDeliveryRootOpenLockFileStableInode(t *testing.T) {
+	base := t.TempDir()
+	root := openDeliveryRootForTest(t, base)
+	first, err := root.OpenLockFile("meta/launch", "lease.lock", 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = first.Close() }()
+	second, err := root.OpenLockFile("meta/launch", "lease.lock", 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = second.Close() }()
+	a, err := first.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := second.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(a, b) {
+		t.Fatal("OpenLockFile replaced the lock inode")
+	}
+}

--- a/internal/launch/binding.go
+++ b/internal/launch/binding.go
@@ -73,9 +73,11 @@ func (record BindingRecord) Validate() error {
 	return nil
 }
 
-func WriteBinding(root *fsq.DeliveryRoot, record BindingRecord) error {
-	if root == nil {
-		return fmt.Errorf("missing pinned session root")
+// WriteBinding replaces the session binding. A live *Lease is required;
+// there is no lease-free write path.
+func WriteBinding(root *fsq.DeliveryRoot, lease *Lease, record BindingRecord) error {
+	if err := lease.authorizeWrite(root); err != nil {
+		return err
 	}
 	if err := record.Validate(); err != nil {
 		return err

--- a/internal/launch/binding_test.go
+++ b/internal/launch/binding_test.go
@@ -41,7 +41,8 @@ func TestBindingAtomicRoundTripAndMode(t *testing.T) {
 		t.Fatalf("BindingPath = %s, want core-owned %s", got, wantPath)
 	}
 	record := validBinding()
-	if err := WriteBinding(root, record); err != nil {
+	lease := mustAcquireLease(t, root)
+	if err := WriteBinding(root, lease, record); err != nil {
 		t.Fatal(err)
 	}
 	got, err := LoadBinding(root)
@@ -60,15 +61,24 @@ func TestBindingAtomicRoundTripAndMode(t *testing.T) {
 	}
 
 	record.LaunchNonce = "nonce-two"
-	if err := WriteBinding(root, record); err != nil {
+	if err := WriteBinding(root, lease, record); err != nil {
 		t.Fatal(err)
 	}
 	entries, err := os.ReadDir(filepath.Dir(BindingPath(dir)))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 1 || entries[0].Name() != bindingFilename {
-		t.Fatalf("atomic replace left unexpected entries: %v", entries)
+	foundBinding := false
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") && strings.Contains(entry.Name(), "tmp-") {
+			t.Fatalf("atomic replace left tmp file: %v", entries)
+		}
+		if entry.Name() == bindingFilename {
+			foundBinding = true
+		}
+	}
+	if !foundBinding {
+		t.Fatalf("binding.json missing after replace: %v", entries)
 	}
 }
 

--- a/internal/launch/commands_test.go
+++ b/internal/launch/commands_test.go
@@ -95,7 +95,8 @@ func TestCommandsCreateCloseNeverInventSuccess(t *testing.T) {
 func TestCommandsInspectUnknownDoesNotMutate(t *testing.T) {
 	_, root := openTestRoot(t)
 	record := validBinding()
-	if err := WriteBinding(root, record); err != nil {
+	lease := mustAcquireLease(t, root)
+	if err := WriteBinding(root, lease, record); err != nil {
 		t.Fatal(err)
 	}
 	got, err := Commands{}.Inspect(InspectRequest{Root: root, Binding: record})

--- a/internal/launch/lease.go
+++ b/internal/launch/lease.go
@@ -1,0 +1,395 @@
+package launch
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	LeaseVersion      = 1
+	leaseFilename     = "lease.json"
+	leaseLockFilename = "lease.lock"
+	handleLockDir     = "handles"
+)
+
+type LeaseState string
+
+const (
+	LeaseMissing    LeaseState = "missing"
+	LeaseValid      LeaseState = "valid"
+	LeaseStale      LeaseState = "stale"
+	LeaseUnverified LeaseState = "unverified"
+)
+
+// HolderIdentity is the wake-lock idiom: pid plus kernel start token and boot
+// id. A lease is stale only when that holder is proven dead; unverified fails closed.
+type HolderIdentity struct {
+	PID          int    `json:"pid"`
+	ProcessStart string `json:"process_start,omitempty"`
+	BootID       string `json:"boot_id,omitempty"`
+}
+
+type leaseRecord struct {
+	Version     int            `json:"version"`
+	Holder      HolderIdentity `json:"holder"`
+	LaunchNonce string         `json:"launch_nonce"`
+}
+
+// Lease is a live, process-local capability. Unexported fields keep a forged
+// value from authorizing WriteBinding.
+type Lease struct {
+	root      *fsq.DeliveryRoot
+	nonce     string
+	holder    HolderIdentity
+	secret    uint64
+	handleIDs []string
+	handles   []*os.File
+	released  bool
+}
+
+func (l *Lease) LaunchNonce() string {
+	if l == nil {
+		return ""
+	}
+	return l.nonce
+}
+
+func (l *Lease) LockedHandles() []string {
+	if l == nil {
+		return nil
+	}
+	return slices.Clone(l.handleIDs)
+}
+
+type LeaseHeldError struct {
+	Nonce    string
+	Evidence string
+}
+
+func (e *LeaseHeldError) Error() string {
+	return fmt.Sprintf("launch lease already held (nonce %s)", e.Nonce)
+}
+
+type LeaseUnverifiedError struct {
+	Evidence string
+}
+
+func (e *LeaseUnverifiedError) Error() string {
+	return fmt.Sprintf("launch lease holder is unverified: %s", e.Evidence)
+}
+
+type processInfo struct {
+	PID          int
+	Running      bool
+	StartToken   string
+	BootID       string
+	InspectError error
+}
+
+var inspectProcess = inspectProcessPlatform
+
+var liveLeaseSecrets sync.Map
+
+type LeaseInspection struct {
+	State    LeaseState
+	Evidence string
+	Holder   HolderIdentity
+	Nonce    string
+}
+
+func LeasePath(sessionRoot string) string {
+	return filepath.Join(sessionRoot, bindingDirectory, leaseFilename)
+}
+
+func AcquireLease(root *fsq.DeliveryRoot, nonce string) (*Lease, error) {
+	if root == nil {
+		return nil, fmt.Errorf("missing pinned session root")
+	}
+	holder, err := currentHolder()
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(nonce) == "" {
+		nonce, err = generateNonce()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := withLeaseInterlock(root, func() error {
+		inspection, inspectErr := inspectLeaseLocked(root)
+		if inspectErr != nil {
+			return inspectErr
+		}
+		switch inspection.State {
+		case LeaseValid:
+			return &LeaseHeldError{Nonce: inspection.Nonce, Evidence: inspection.Evidence}
+		case LeaseUnverified:
+			return &LeaseUnverifiedError{Evidence: inspection.Evidence}
+		case LeaseStale, LeaseMissing:
+			return writeLeaseRecord(root, leaseRecord{Version: LeaseVersion, Holder: holder, LaunchNonce: nonce})
+		default:
+			return fmt.Errorf("unknown lease state %q", inspection.State)
+		}
+	}); err != nil {
+		return nil, err
+	}
+	lease := &Lease{root: root, nonce: nonce, holder: holder, secret: newSecret()}
+	liveLeaseSecrets.Store(lease.secret, struct{}{})
+	return lease, nil
+}
+
+func InspectLease(root *fsq.DeliveryRoot) (LeaseInspection, error) {
+	if root == nil {
+		return LeaseInspection{}, fmt.Errorf("missing pinned session root")
+	}
+	var inspection LeaseInspection
+	err := withLeaseInterlock(root, func() error {
+		var inspectErr error
+		inspection, inspectErr = inspectLeaseLocked(root)
+		return inspectErr
+	})
+	return inspection, err
+}
+
+func (l *Lease) LockHandles(handles ...string) error {
+	if err := l.authorizeLive(); err != nil {
+		return err
+	}
+	if len(l.handles) != 0 {
+		return fmt.Errorf("handle locks already held")
+	}
+	sorted := slices.Clone(handles)
+	slices.Sort(sorted)
+	sorted = slices.Compact(sorted)
+	for _, handle := range sorted {
+		if err := fsq.ValidateHandle(handle); err != nil {
+			l.unlockHandles()
+			return err
+		}
+		file, err := openAdvisoryLock(l.root, filepath.Join(bindingDirectory, handleLockDir, handle+".lock"))
+		if err != nil {
+			l.unlockHandles()
+			return err
+		}
+		if err := lockExclusive(file); err != nil {
+			_ = file.Close()
+			l.unlockHandles()
+			return err
+		}
+		l.handles = append(l.handles, file)
+		l.handleIDs = append(l.handleIDs, handle)
+	}
+	return nil
+}
+
+func (l *Lease) Release() error {
+	if l == nil {
+		return fmt.Errorf("launch lease is not held")
+	}
+	l.unlockHandles()
+	if l.released {
+		return nil
+	}
+	err := withLeaseInterlock(l.root, func() error {
+		inspection, inspectErr := inspectLeaseLocked(l.root)
+		if inspectErr != nil {
+			return inspectErr
+		}
+		if inspection.State != LeaseValid || inspection.Nonce != l.nonce {
+			return fmt.Errorf("launch lease is no longer held by this process")
+		}
+		return l.root.Remove(filepath.Join(bindingDirectory, leaseFilename))
+	})
+	l.released = true
+	liveLeaseSecrets.Delete(l.secret)
+	l.secret = 0
+	return err
+}
+
+func (l *Lease) authorizeWrite(root *fsq.DeliveryRoot) error {
+	if err := l.authorizeLive(); err != nil {
+		return err
+	}
+	if l.root != root {
+		return fmt.Errorf("launch lease does not match the session root")
+	}
+	return withLeaseInterlock(root, func() error {
+		inspection, err := inspectLeaseLocked(root)
+		if err != nil {
+			return err
+		}
+		if inspection.State != LeaseValid || inspection.Nonce != l.nonce {
+			return fmt.Errorf("launch lease is not live")
+		}
+		return nil
+	})
+}
+
+func (l *Lease) authorizeLive() error {
+	if l == nil || l.released || l.secret == 0 || l.root == nil {
+		return fmt.Errorf("launch lease is not held")
+	}
+	if _, ok := liveLeaseSecrets.Load(l.secret); !ok {
+		return fmt.Errorf("launch lease is not held")
+	}
+	holder, err := currentHolder()
+	if err != nil {
+		return err
+	}
+	if holder.PID != l.holder.PID || holder.ProcessStart != l.holder.ProcessStart {
+		return fmt.Errorf("launch lease holder identity no longer matches this process")
+	}
+	return nil
+}
+
+func (l *Lease) unlockHandles() {
+	for i := len(l.handles) - 1; i >= 0; i-- {
+		_ = unlockExclusive(l.handles[i])
+		_ = l.handles[i].Close()
+	}
+	l.handles = nil
+	l.handleIDs = nil
+}
+
+func inspectLeaseLocked(root *fsq.DeliveryRoot) (LeaseInspection, error) {
+	file, info, err := root.OpenRegularNoFollow(filepath.Join(bindingDirectory, leaseFilename))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return LeaseInspection{State: LeaseMissing}, nil
+		}
+		return LeaseInspection{}, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		return LeaseInspection{}, fmt.Errorf("lease permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return LeaseInspection{}, err
+	}
+	var record leaseRecord
+	if err := decodeStrict(data, &record); err != nil {
+		return LeaseInspection{State: LeaseUnverified, Evidence: "lease file is unreadable"}, nil
+	}
+	if record.Version != LeaseVersion || strings.TrimSpace(record.LaunchNonce) == "" || record.Holder.PID <= 0 {
+		return LeaseInspection{State: LeaseUnverified, Evidence: "lease record is incomplete"}, nil
+	}
+	state, evidence := classifyHolder(record.Holder, inspectProcess(record.Holder.PID))
+	return LeaseInspection{State: state, Evidence: evidence, Holder: record.Holder, Nonce: record.LaunchNonce}, nil
+}
+
+func classifyHolder(recorded HolderIdentity, live processInfo) (LeaseState, string) {
+	if !live.Running {
+		return LeaseStale, "holder pid is not running"
+	}
+	if recorded.ProcessStart != "" {
+		if live.StartToken == "" {
+			return LeaseUnverified, evidenceOr("process start time unavailable", live.InspectError)
+		}
+		if recorded.BootID != "" && live.BootID != "" && recorded.BootID != live.BootID {
+			return LeaseStale, "boot id mismatch"
+		}
+		if recorded.BootID != "" && live.BootID == "" {
+			return LeaseUnverified, evidenceOr("boot id unavailable", live.InspectError)
+		}
+		if recorded.ProcessStart != live.StartToken {
+			if recorded.BootID == "" {
+				return LeaseUnverified, "process start time mismatch"
+			}
+			return LeaseStale, "process start time mismatch"
+		}
+		return LeaseValid, "holder identity confirmed"
+	}
+	return LeaseUnverified, "lease lacks process start metadata"
+}
+
+func currentHolder() (HolderIdentity, error) {
+	proc := inspectProcess(os.Getpid())
+	if !proc.Running {
+		return HolderIdentity{}, fmt.Errorf("current process is not running")
+	}
+	if proc.StartToken == "" {
+		return HolderIdentity{}, fmt.Errorf("process start time unavailable")
+	}
+	return HolderIdentity{PID: proc.PID, ProcessStart: proc.StartToken, BootID: proc.BootID}, nil
+}
+
+func writeLeaseRecord(root *fsq.DeliveryRoot, record leaseRecord) error {
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = root.WriteFileAtomic(bindingDirectory, leaseFilename, data, 0o600)
+	return err
+}
+
+func withLeaseInterlock(root *fsq.DeliveryRoot, fn func() error) error {
+	file, err := openAdvisoryLock(root, filepath.Join(bindingDirectory, leaseLockFilename))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	if err := lockExclusive(file); err != nil {
+		return err
+	}
+	defer func() { _ = unlockExclusive(file) }()
+	return fn()
+}
+
+func openAdvisoryLock(root *fsq.DeliveryRoot, rel string) (*os.File, error) {
+	dir, name := filepath.Split(rel)
+	file, err := root.OpenLockFile(strings.TrimSuffix(dir, string(filepath.Separator)), name, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if info.Mode().Perm() != 0o600 {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	return file, nil
+}
+
+func generateNonce() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+func newSecret() uint64 {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return 1
+	}
+	secret := binary.BigEndian.Uint64(buf[:])
+	if secret == 0 {
+		return 1
+	}
+	return secret
+}
+
+func evidenceOr(base string, err error) string {
+	if err == nil {
+		return base
+	}
+	return fmt.Sprintf("%s: %v", base, err)
+}

--- a/internal/launch/lease_holder_darwin.go
+++ b/internal/launch/lease_holder_darwin.go
@@ -1,0 +1,53 @@
+//go:build darwin
+
+package launch
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const darwinProcessStateZombie int8 = 5
+
+var (
+	readDarwinKinfoProc       = unix.SysctlKinfoProc
+	readDarwinBootSessionUUID = func() (string, error) { return unix.Sysctl("kern.bootsessionuuid") }
+	readDarwinBootTime        = func() (*unix.Timeval, error) { return unix.SysctlTimeval("kern.boottime") }
+)
+
+func inspectProcessPlatform(pid int) processInfo {
+	info := processInfo{PID: pid}
+	if !processAlive(pid) {
+		return info
+	}
+	info.Running = true
+	kp, err := readDarwinKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		info.InspectError = err
+		return info
+	}
+	if kp == nil || kp.Proc.P_stat == darwinProcessStateZombie {
+		info.Running = false
+		return info
+	}
+	sec, nsec := kp.Proc.P_starttime.Unix()
+	info.StartToken = fmt.Sprintf("%d.%09d", sec, nsec)
+	info.BootID = darwinBootID()
+	return info
+}
+
+func darwinBootID() string {
+	if sessionUUID, err := readDarwinBootSessionUUID(); err == nil {
+		sessionUUID = strings.TrimSpace(sessionUUID)
+		if sessionUUID != "" && !strings.ContainsRune(sessionUUID, 0) {
+			return sessionUUID
+		}
+	}
+	if boot, err := readDarwinBootTime(); err == nil && boot != nil {
+		sec, nsec := boot.Unix()
+		return fmt.Sprintf("%d.%09d", sec, nsec)
+	}
+	return ""
+}

--- a/internal/launch/lease_holder_linux.go
+++ b/internal/launch/lease_holder_linux.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package launch
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func inspectProcessPlatform(pid int) processInfo {
+	info := processInfo{PID: pid}
+	if !processAlive(pid) {
+		return info
+	}
+	info.Running = true
+	if bootID, err := os.ReadFile("/proc/sys/kernel/random/boot_id"); err == nil {
+		info.BootID = strings.TrimSpace(string(bootID))
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		info.InspectError = err
+		return info
+	}
+	token, state, err := linuxProcIdentity(string(data))
+	if err != nil {
+		info.InspectError = err
+		return info
+	}
+	if state == "Z" {
+		info.Running = false
+		return info
+	}
+	info.StartToken = token
+	return info
+}
+
+func linuxProcIdentity(stat string) (startToken string, state string, err error) {
+	endComm := strings.LastIndex(stat, ")")
+	if endComm < 0 || endComm+2 >= len(stat) {
+		return "", "", fmt.Errorf("malformed proc stat")
+	}
+	fields := strings.Fields(stat[endComm+2:])
+	const startTimeIndex = 22 - 3
+	if len(fields) <= startTimeIndex {
+		return "", "", fmt.Errorf("proc stat missing starttime")
+	}
+	if len(fields[0]) != 1 {
+		return "", "", fmt.Errorf("proc stat has malformed state")
+	}
+	return fields[startTimeIndex], fields[0], nil
+}

--- a/internal/launch/lease_holder_other.go
+++ b/internal/launch/lease_holder_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !linux
+
+package launch
+
+import "fmt"
+
+func inspectProcessPlatform(pid int) processInfo {
+	info := processInfo{PID: pid, Running: processAlive(pid)}
+	if info.Running {
+		info.InspectError = fmt.Errorf("process start time unavailable on this platform")
+	}
+	return info
+}

--- a/internal/launch/lease_lock_other.go
+++ b/internal/launch/lease_lock_other.go
@@ -1,0 +1,22 @@
+//go:build !darwin && !linux && !freebsd && !windows
+
+package launch
+
+import (
+	"fmt"
+	"os"
+)
+
+func lockExclusive(*os.File) error {
+	return fmt.Errorf("launch lease locking is unsupported on this platform")
+}
+
+func unlockExclusive(*os.File) error { return nil }
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	_, err := os.FindProcess(pid)
+	return err == nil
+}

--- a/internal/launch/lease_lock_unix.go
+++ b/internal/launch/lease_lock_unix.go
@@ -1,0 +1,37 @@
+//go:build darwin || linux || freebsd
+
+package launch
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockExclusive(file *os.File) error {
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		return fmt.Errorf("acquire launch lease lock: %w", err)
+	}
+	return nil
+}
+
+func unlockExclusive(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(unix.Signal(0))
+	if err == nil || errors.Is(err, unix.EPERM) {
+		return true
+	}
+	return false
+}

--- a/internal/launch/lease_lock_windows.go
+++ b/internal/launch/lease_lock_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package launch
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockExclusive(file *os.File) error {
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+		return fmt.Errorf("acquire launch lease lock: %w", err)
+	}
+	return nil
+}
+
+func unlockExclusive(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	_, err := os.FindProcess(pid)
+	return err == nil
+}

--- a/internal/launch/lease_test.go
+++ b/internal/launch/lease_test.go
@@ -1,0 +1,255 @@
+package launch
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func mustAcquireLease(t *testing.T, root *fsq.DeliveryRoot) *Lease {
+	t.Helper()
+	lease, err := AcquireLease(root, "nonce-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lease.Release() })
+	return lease
+}
+
+func TestAcquireLeaseExclusiveAndRelease(t *testing.T) {
+	_, root := openTestRoot(t)
+	first := mustAcquireLease(t, root)
+	_, err := AcquireLease(root, "nonce-other")
+	var held *LeaseHeldError
+	if !errors.As(err, &held) {
+		t.Fatalf("second acquire = %v, want LeaseHeldError", err)
+	}
+	if err := first.Release(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := AcquireLease(root, "nonce-next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConcurrentAcquireExactlyOneWins(t *testing.T) {
+	const contenders = 8
+	dir := t.TempDir()
+	type result struct {
+		lease *Lease
+		err   error
+	}
+	results := make(chan result, contenders)
+	var wg sync.WaitGroup
+	for i := 0; i < contenders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			identity, err := fsq.SnapshotDeliveryRoot(dir)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			root, err := fsq.OpenDeliveryRoot(dir, identity)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			lease, err := AcquireLease(root, "shared-nonce")
+			if err != nil {
+				_ = root.Close()
+				results <- result{err: err}
+				return
+			}
+			t.Cleanup(func() {
+				_ = lease.Release()
+				_ = root.Close()
+			})
+			results <- result{lease: lease}
+		}()
+	}
+	wg.Wait()
+	close(results)
+	var wins, losses int
+	for got := range results {
+		if got.err == nil {
+			wins++
+			continue
+		}
+		var held *LeaseHeldError
+		if !errors.As(got.err, &held) {
+			t.Fatalf("loser error = %v, want LeaseHeldError", got.err)
+		}
+		losses++
+	}
+	if wins != 1 || losses != contenders-1 {
+		t.Fatalf("concurrent acquire wins=%d losses=%d, want 1 and %d", wins, losses, contenders-1)
+	}
+}
+
+func TestStaleLeaseIsReplaceableAfterCrash(t *testing.T) {
+	dir, root := openTestRoot(t)
+	if err := os.MkdirAll(filepath.Dir(LeasePath(dir)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeHostileLease(t, dir, leaseRecord{
+		Version:     LeaseVersion,
+		Holder:      HolderIdentity{PID: 1 << 30, ProcessStart: "1.000000000", BootID: "boot"},
+		LaunchNonce: "dead-nonce",
+	}, 0o600)
+	lease, err := AcquireLease(root, "recovered")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lease.Release() })
+	if lease.LaunchNonce() != "recovered" {
+		t.Fatalf("nonce = %q", lease.LaunchNonce())
+	}
+}
+
+func TestUnverifiedHolderFailsClosed(t *testing.T) {
+	dir, root := openTestRoot(t)
+	if err := os.MkdirAll(filepath.Dir(LeasePath(dir)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeHostileLease(t, dir, leaseRecord{
+		Version:     LeaseVersion,
+		Holder:      HolderIdentity{PID: 1, ProcessStart: "1.000000000", BootID: "boot"},
+		LaunchNonce: "unverified-nonce",
+	}, 0o600)
+	old := inspectProcess
+	inspectProcess = func(pid int) processInfo {
+		if pid == os.Getpid() {
+			return old(pid)
+		}
+		return processInfo{PID: pid, Running: true, InspectError: errors.New("start token unavailable")}
+	}
+	t.Cleanup(func() { inspectProcess = old })
+	_, err := AcquireLease(root, "should-not-win")
+	var unverified *LeaseUnverifiedError
+	if !errors.As(err, &unverified) {
+		t.Fatalf("acquire = %v, want LeaseUnverifiedError", err)
+	}
+	got, err := os.ReadFile(LeasePath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "unverified-nonce") {
+		t.Fatalf("unverified acquire mutated lease: %s", got)
+	}
+}
+
+func TestPidReuseIdentityMismatchIsStale(t *testing.T) {
+	dir, root := openTestRoot(t)
+	if err := os.MkdirAll(filepath.Dir(LeasePath(dir)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	self := inspectProcess(os.Getpid())
+	writeHostileLease(t, dir, leaseRecord{
+		Version: LeaseVersion,
+		Holder: HolderIdentity{
+			PID:          os.Getpid(),
+			ProcessStart: "0.000000001",
+			BootID:       self.BootID,
+		},
+		LaunchNonce: "reused-pid",
+	}, 0o600)
+	lease, err := AcquireLease(root, "replacement")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lease.Release() })
+	if lease.LaunchNonce() != "replacement" {
+		t.Fatalf("pid-reuse did not replace stale lease: %q", lease.LaunchNonce())
+	}
+}
+
+func TestLeaseSymlinkAndPermissiveModeRefused(t *testing.T) {
+	dir, root := openTestRoot(t)
+	path := LeasePath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	self := inspectProcess(os.Getpid())
+	writeHostileLease(t, dir, leaseRecord{
+		Version:     LeaseVersion,
+		Holder:      HolderIdentity{PID: os.Getpid(), ProcessStart: self.StartToken, BootID: self.BootID},
+		LaunchNonce: "permissive",
+	}, 0o644)
+	if _, err := AcquireLease(root, "nope"); err == nil || !strings.Contains(err.Error(), "permissions") {
+		t.Fatalf("0644 acquire = %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "lease.json")
+	if err := os.WriteFile(outside, []byte(`{"version":1,"holder":{"pid":1},"launch_nonce":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AcquireLease(root, "nope"); err == nil {
+		t.Fatal("symlink lease was acquired")
+	}
+}
+
+func TestLockHandlesSortedAndReleasedBeforeLease(t *testing.T) {
+	_, root := openTestRoot(t)
+	lease := mustAcquireLease(t, root)
+	if err := lease.LockHandles("codex", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if got := lease.LockedHandles(); len(got) != 2 || got[0] != "claude" || got[1] != "codex" {
+		t.Fatalf("handle order = %#v, want claude then codex", got)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if len(lease.LockedHandles()) != 0 {
+		t.Fatal("handle locks survived lease release")
+	}
+}
+
+func TestWriteBindingRequiresLiveLease(t *testing.T) {
+	_, root := openTestRoot(t)
+	record := validBinding()
+	if err := WriteBinding(root, nil, record); err == nil {
+		t.Fatal("nil lease wrote a binding")
+	}
+	if err := WriteBinding(root, &Lease{}, record); err == nil {
+		t.Fatal("forged empty lease wrote a binding")
+	}
+	lease := mustAcquireLease(t, root)
+	if err := WriteBinding(root, &Lease{root: root, nonce: lease.LaunchNonce(), holder: lease.holder, secret: 99}, record); err == nil {
+		t.Fatal("forged secret wrote a binding")
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBinding(root, lease, record); err == nil {
+		t.Fatal("released lease wrote a binding")
+	}
+}
+
+func writeHostileLease(t *testing.T, dir string, record leaseRecord, mode os.FileMode) {
+	t.Helper()
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(LeasePath(dir), data, mode); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds the #480 v1.1 §8 session launch lease (`meta/launch/lease.json`) with wake-lock identity (pid, process start, boot id) and valid/stale/unverified inspection. Stale only when the holder is proven dead.
- Handle locks are acquired in sorted order while the lease is held and released before the lease. `WriteBinding` requires a live `*Lease`; there is no lease-free write path.
- `fsq.DeliveryRoot.OpenLockFile` opens the interlock on a stable inode (`O_CREATE` on the real name) so concurrent acquirers serialize. 8-way contention test plus `-race`.

## Test plan
- [ ] `go test ./internal/launch ./internal/fsq -count=1 -race`
- [ ] `TestConcurrentAcquireExactlyOneWins` (8 independent DeliveryRoots, one winner)
- [ ] Dead-pid lease is replaceable; unverified live holder fails closed
- [ ] Nil/empty/forged `WriteBinding` refuses and writes nothing
- [ ] Symlink and 0644 `lease.json` refuse acquire

Refs: #480

Made with [Cursor](https://cursor.com)