### PR TITLE
feat(cli): add amq setup preview-then-commit porcelain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ amq wake repair --me <agent> [--root <path>] [--json]
 amq wake retire --me <agent> --inject-via <absolute-executable> [--inject-arg <arg>...] [--root <path>] [--json]
 amq wake recover-owner --me <agent> [--root <path>] [--strict] [--json]
 amq upgrade
+amq setup [--root <path>] [--agents <a,b,c>] [--default-session <name>] [--launcher-preference <a,b,c>] [--layout columns] [--no-gitignore] [-y] [--json]
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--export] [--session-name] [--json]
 amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>] [--grok-alias <name>]
 amq coop init [--root <path>] [--agents <a,b,c>] [--no-gitignore] [--force] [--json]

--- a/COOP.md
+++ b/COOP.md
@@ -45,6 +45,17 @@ For swarm command reference, see [CLAUDE.md](CLAUDE.md).
    for the authoritative list. See [INSTALL.md](INSTALL.md) for the manual
    `~/.grok/skills` copy example.
 
+### Project Setup
+
+Run `amq setup` once per project. It probes supported agent CLIs and local
+launchers, lets you select any non-empty roster and the default session, then
+previews every change before it writes. The committed `.amq/launch.json` owns
+the roster, session default, resume policy, and layout intent. The ignored
+`.amq/launch.local.json` contains launcher preferences only. For automation,
+use `amq setup -y` after the caller accepts the recomputed preview.
+
+`amq coop init` remains the non-interactive provisioning primitive.
+
 ### Running Co-op Mode
 
 **Terminal 1 - Claude Code:**

--- a/README.md
+++ b/README.md
@@ -109,10 +109,14 @@ drain contract.
 ### 1. Initialize Project
 
 ```bash
-amq coop init
+amq setup
 ```
 
-Creates `.amqrc`, mailboxes for `claude`, `codex`, and the reserved `user` operator handle, and updates `.gitignore`.
+Detects supported agent CLIs and launcher preferences, previews the project
+declaration, then creates `.amqrc`, `.amq/launch.json`, local preferences,
+the default session, and roster mailboxes. Use `amq setup -y` only after an
+automation caller has accepted that preview. `amq coop init` remains the
+scriptable low-level provisioning command.
 
 ### 2. Start Agent Sessions
 
@@ -533,7 +537,7 @@ Common command groups:
 | Area | Commands |
 |------|----------|
 | Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `trace`, `watch`, `monitor`, `receipts` |
-| Collaboration | `coop init`, `coop exec`, `session create`, `session list`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
+| Collaboration | `setup`, `coop init`, `coop exec`, `session create`, `session list`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
 | Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake check`, `wake repair`, `wake recover-owner`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -190,16 +190,8 @@ func runCoopInitInternal(args []string, printNextSteps bool) (returnErr error) {
 
 	// Keep the shared config at the base root, but provision the roster in the
 	// default session that coop exec actually selects.
-	if err := fsq.EnsureRootDirs(queueRoot); err != nil {
-		return fmt.Errorf("failed to create root directories: %w", err)
-	}
-	for _, agent := range agents {
-		if err := fsq.EnsureAgentDirs(queueRoot, agent); err != nil {
-			return fmt.Errorf("failed to create compatibility base mailbox for %s: %w", agent, err)
-		}
-	}
-	if _, err := provisionCoopSession(queueRoot, defaultSessionName, agents, "", ""); err != nil {
-		return fmt.Errorf("failed to create default session root: %w", err)
+	if err := provisionCoopBaseAndSession(queueRoot, defaultSessionName, agents); err != nil {
+		return err
 	}
 
 	configWritten := false
@@ -308,6 +300,24 @@ func runCoopInitInternal(args []string, printNextSteps bool) (returnErr error) {
 // the session through its ambient lexical path.
 func provisionCoopSession(base, session string, agents []string, execAgent, execCommand string) (string, error) {
 	return provisionCoopSessionChild(base, session, agents, execAgent, execCommand, false)
+}
+
+// provisionCoopBaseAndSession is the shared provisioning primitive used by
+// coop init plumbing and setup porcelain. It retains the established base
+// compatibility mailboxes and the pinned named-session creation path.
+func provisionCoopBaseAndSession(base, session string, agents []string) error {
+	if err := fsq.EnsureRootDirs(base); err != nil {
+		return fmt.Errorf("failed to create root directories: %w", err)
+	}
+	for _, agent := range agents {
+		if err := fsq.EnsureAgentDirs(base, agent); err != nil {
+			return fmt.Errorf("failed to create compatibility base mailbox for %s: %w", agent, err)
+		}
+	}
+	if _, err := provisionCoopSession(base, session, agents, "", ""); err != nil {
+		return fmt.Errorf("failed to create default session root: %w", err)
+	}
+	return nil
 }
 
 // provisionNewNamedSession is session create: exclusive child creation so a

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -25,6 +25,7 @@ var commands []CommandInfo
 func init() {
 	commands = []CommandInfo{
 		{Name: "init", Summary: "Initialize the queue root and agent mailboxes", Handler: runInit},
+		{Name: "setup", Summary: "Configure project launch and session defaults", Handler: runSetup},
 		{Name: "send", Summary: "Send a message", Handler: runSend},
 		{Name: "list", Summary: "List inbox messages", Handler: runList},
 		{Name: "read", Summary: "Read a message by id", Handler: runRead},

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -11,6 +11,7 @@ import (
 func TestCommandNames(t *testing.T) {
 	want := []string{
 		"init",
+		"setup",
 		"send",
 		"list",
 		"read",

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 func runSession(args []string) error {
@@ -234,29 +234,17 @@ func loadLaunchRosterHandles() ([]string, bool, error) {
 		}
 		return nil, false, err
 	}
-	var parsed struct {
-		Agents []struct {
-			Handle string `json:"handle"`
-		} `json:"agents"`
-	}
-	if err := json.Unmarshal(data, &parsed); err != nil {
+	parsed, err := launch.ParseProjectConfig(data)
+	if err != nil {
 		return nil, false, fmt.Errorf("parse .amq/launch.json: %w", err)
 	}
 	handles := make([]string, 0, len(parsed.Agents))
-	seen := map[string]bool{}
 	for _, agent := range parsed.Agents {
 		handle := strings.TrimSpace(agent.Handle)
-		if handle == "" {
-			return nil, false, fmt.Errorf("launch.json roster handle is empty")
-		}
 		normalized, err := normalizeHandle(handle)
 		if err != nil {
 			return nil, false, fmt.Errorf("launch.json roster handle %q: %w", handle, err)
 		}
-		if seen[normalized] {
-			continue
-		}
-		seen[normalized] = true
 		handles = append(handles, normalized)
 	}
 	return handles, true, nil

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,0 +1,855 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+	"golang.org/x/term"
+)
+
+const (
+	setupConfigPath      = ".amq/launch.json"
+	setupLocalConfigPath = ".amq/launch.local.json"
+)
+
+type setupChange struct {
+	Path   string `json:"path"`
+	Action string `json:"action"`
+}
+
+type setupPreview struct {
+	ProjectRoot        string                      `json:"project_root"`
+	QueueRoot          string                      `json:"queue_root"`
+	DefaultSession     string                      `json:"default_session"`
+	Agents             []launch.ProjectAgentConfig `json:"agents"`
+	Layout             launch.LayoutIntent         `json:"layout"`
+	LauncherPreference []string                    `json:"launcher_preference"`
+	AvailableLaunchers []string                    `json:"available_launchers"`
+	Changes            []setupChange               `json:"changes"`
+}
+
+type setupResult struct {
+	Status  string       `json:"status"`
+	Preview setupPreview `json:"preview"`
+	Written []string     `json:"written"`
+}
+
+type setupConfigRefusalError struct {
+	Handle  string
+	Adapter string
+	Err     error
+}
+
+func (e *setupConfigRefusalError) Error() string {
+	return fmt.Sprintf("refused committed configuration for agent %q through adapter %q: %v", e.Handle, e.Adapter, e.Err)
+}
+
+func (e *setupConfigRefusalError) Unwrap() error { return e.Err }
+
+type setupState struct {
+	projectRoot     string
+	queueRoot       string
+	projectConfig   launch.ProjectConfig
+	localConfig     launch.LocalConfig
+	projectData     []byte
+	localData       []byte
+	amqrcData       []byte
+	gitignoreData   []byte
+	baseConfigData  []byte
+	unionConfigData []byte
+	needsProvision  bool
+	changes         []setupChange
+	available       []string
+	noGitignore     bool
+}
+
+var (
+	setupHarnessAdapters = func() []launch.HarnessAdapter {
+		return []launch.HarnessAdapter{
+			launch.NewClaudeAdapter(launch.ClaudeProvider),
+			launch.NewCodexAdapter(launch.CodexProvider),
+		}
+	}
+	setupLookPath   = exec.LookPath
+	setupIsTerminal = func() bool {
+		return term.IsTerminal(int(os.Stdin.Fd()))
+	}
+	// setupCommitStepHook is a fault-injection seam. Production leaves it nil.
+	setupCommitStepHook func(string) error
+)
+
+func runSetup(args []string) (returnErr error) {
+	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
+	rootFlag := fs.String("root", defaultCoopRoot, "Queue root written to .amqrc")
+	agentsFlag := fs.String("agents", "", "Comma-separated detected agent adapters")
+	sessionFlag := fs.String("default-session", "", "Default session name")
+	launchersFlag := fs.String("launcher-preference", "", "Comma-separated launcher preference")
+	layoutFlag := fs.String("layout", launch.LayoutColumns, "Advisory layout intent")
+	noGitignoreFlag := fs.Bool("no-gitignore", false, "Do not modify .gitignore")
+	yesFlag := fs.Bool("y", false, "Accept the preview without prompting")
+	jsonFlag := fs.Bool("json", false, "Emit JSON output")
+	usage := usageWithFlags(fs, "amq setup [options]",
+		"Configure this project after previewing every change.",
+		"Detects Claude and Codex through their adapter capability probes.",
+		"Launcher detection is probe-only; setup never calls a launcher backend.")
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if *jsonFlag && !*yesFlag {
+		return UsageError("--json requires -y")
+	}
+	if !*yesFlag && !setupIsTerminal() {
+		return UsageError("non-interactive setup requires -y")
+	}
+	if *layoutFlag != launch.LayoutColumns {
+		return UsageError("unsupported --layout %q", *layoutFlag)
+	}
+
+	originalCWD, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	projectRoot := originalCWD
+	if top, worktree := gitWorktreeTopFromCWD(); worktree {
+		projectRoot = top
+	} else if boundary, insideGit := gitWorktreeRootFromCWD(); insideGit {
+		return noEligibleRootInGitError(boundary)
+	}
+	if !sameTreeIdentity(originalCWD, projectRoot) {
+		if err := os.Chdir(projectRoot); err != nil {
+			return fmt.Errorf("enter Git worktree top %q: %w", projectRoot, err)
+		}
+		resetAmqrcCache()
+		defer func() {
+			if err := os.Chdir(originalCWD); err != nil {
+				returnErr = errors.Join(returnErr, fmt.Errorf("restore working directory %q: %w", originalCWD, err))
+			}
+			resetAmqrcCache()
+		}()
+	}
+
+	var input *bufio.Reader
+	if !*yesFlag {
+		input = bufio.NewReader(os.Stdin)
+	}
+	state, err := buildSetupState(setupOptions{
+		projectRoot: projectRoot,
+		root:        *rootFlag, rootExplicit: flagWasVisited(fs, "root"),
+		agents: *agentsFlag, agentsExplicit: flagWasVisited(fs, "agents"),
+		defaultSession: *sessionFlag, sessionExplicit: flagWasVisited(fs, "default-session"),
+		launchers: *launchersFlag, launchersExplicit: flagWasVisited(fs, "launcher-preference"),
+		layout: *layoutFlag, noGitignore: *noGitignoreFlag, yes: *yesFlag, input: input,
+	})
+	if err != nil {
+		return err
+	}
+	preview := state.preview()
+	if !*jsonFlag {
+		if err := printSetupPreview(preview); err != nil {
+			return err
+		}
+	}
+	if !*yesFlag {
+		confirmed, err := setupConfirm(input, "Create this setup?")
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return writeStdoutLine("Aborted.")
+		}
+	}
+	written, err := commitSetup(state)
+	if err != nil {
+		return err
+	}
+	status := "configured"
+	if len(written) == 0 {
+		status = "unchanged"
+	}
+	result := setupResult{Status: status, Preview: preview, Written: written}
+	if *jsonFlag {
+		return writeJSON(os.Stdout, result)
+	}
+	if status == "unchanged" {
+		return writeStdoutLine("Setup already matches; no writes performed.")
+	}
+	return writeStdout("Setup committed (%d step(s)).\n", len(written))
+}
+
+type setupOptions struct {
+	projectRoot                        string
+	root, agents, defaultSession       string
+	launchers, layout                  string
+	rootExplicit, agentsExplicit       bool
+	sessionExplicit, launchersExplicit bool
+	noGitignore, yes                   bool
+	input                              *bufio.Reader
+}
+
+func buildSetupState(options setupOptions) (setupState, error) {
+	if err := validateSetupConfigDirectory(); err != nil {
+		return setupState{}, err
+	}
+	existingProject, existingProjectData, projectExists, err := loadOptionalProjectConfig(setupConfigPath)
+	if err != nil {
+		return setupState{}, err
+	}
+	existingLocal, existingLocalData, localExists, err := loadOptionalLocalConfig(setupLocalConfigPath)
+	if err != nil {
+		return setupState{}, err
+	}
+
+	root, amqrcData, amqrcExists, err := setupRoot(options.root, options.rootExplicit, options.projectRoot)
+	if err != nil {
+		return setupState{}, err
+	}
+	adapters := setupHarnessAdapters()
+	if projectExists {
+		if err := validateSetupCommittedConfig(existingProject, options.projectRoot, adapters); err != nil {
+			return setupState{}, err
+		}
+	}
+	capabilities, err := detectSetupAgents(adapters)
+	if err != nil {
+		return setupState{}, err
+	}
+	agents, err := chooseSetupAgents(options, capabilities, existingProject, projectExists)
+	if err != nil {
+		return setupState{}, err
+	}
+	defaultSession, err := chooseSetupSession(options, existingProject, projectExists)
+	if err != nil {
+		return setupState{}, err
+	}
+	availableLaunchers := detectSetupLaunchers()
+	launcherPreference, err := chooseSetupLaunchers(options, availableLaunchers, existingLocal, localExists)
+	if err != nil {
+		return setupState{}, err
+	}
+
+	projectConfig := launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: defaultSession, Agents: agents,
+		Layout: launch.LayoutIntent{Type: options.layout},
+	}
+	projectData, err := launch.MarshalProjectConfig(projectConfig)
+	if err != nil {
+		return setupState{}, err
+	}
+	if projectExists {
+		existingCanonical, marshalErr := launch.MarshalProjectConfig(existingProject)
+		if marshalErr != nil {
+			return setupState{}, marshalErr
+		}
+		if bytes.Equal(projectData, existingCanonical) {
+			projectData = existingProjectData
+		}
+	}
+	localConfig := launch.LocalConfig{Schema: launch.LocalConfigSchema, LauncherPreference: launcherPreference}
+	localData, err := launch.MarshalLocalConfig(localConfig)
+	if err != nil {
+		return setupState{}, err
+	}
+	if localExists {
+		existingCanonical, marshalErr := launch.MarshalLocalConfig(existingLocal)
+		if marshalErr != nil {
+			return setupState{}, marshalErr
+		}
+		if bytes.Equal(localData, existingCanonical) {
+			localData = existingLocalData
+		}
+	}
+	if !amqrcExists {
+		value, marshalErr := json.MarshalIndent(amqrc{Root: root}, "", "  ")
+		if marshalErr != nil {
+			return setupState{}, marshalErr
+		}
+		amqrcData = append(value, '\n')
+	}
+
+	handles := projectAgentHandles(agents)
+	baseConfig, currentBaseData, currentAgents, err := setupBaseConfig(root, handles)
+	if err != nil {
+		return setupState{}, err
+	}
+	baseConfigData, err := marshalSetupBaseConfig(baseConfig)
+	if err != nil {
+		return setupState{}, err
+	}
+	unionConfig := baseConfig
+	unionConfig.Agents = sortedUnion(currentAgents, handles)
+	unionConfigData, err := marshalSetupBaseConfig(unionConfig)
+	if err != nil {
+		return setupState{}, err
+	}
+
+	gitignoreData, gitignoreChanged, err := setupGitignoreData(root, options.noGitignore)
+	if err != nil {
+		return setupState{}, err
+	}
+	needsProvision, err := setupNeedsProvisioning(root, defaultSession, handles)
+	if err != nil {
+		return setupState{}, err
+	}
+	state := setupState{
+		projectRoot: options.projectRoot, queueRoot: root, projectConfig: projectConfig,
+		localConfig: localConfig, projectData: projectData, localData: localData,
+		amqrcData: amqrcData, gitignoreData: gitignoreData,
+		baseConfigData: baseConfigData, unionConfigData: unionConfigData,
+		needsProvision: needsProvision, available: availableLaunchers, noGitignore: options.noGitignore,
+	}
+	state.addChange(needsProvision, filepath.Join(root, defaultSession), "ensure queue and roster mailboxes")
+	state.addChange(!bytes.Equal(currentBaseData, unionConfigData), filepath.Join(root, "meta", "config.json"), "update compatible roster")
+	state.addChange(fileDiffers(setupConfigPath, projectData), setupConfigPath, "write project declaration")
+	state.addChange(!bytes.Equal(unionConfigData, baseConfigData), filepath.Join(root, "meta", "config.json"), "finalize roster")
+	state.addChange(fileDiffers(setupLocalConfigPath, localData), setupLocalConfigPath, "write local preferences")
+	state.addChange(gitignoreChanged, ".gitignore", "append AMQ ignore entries")
+	state.addChange(!amqrcExists, ".amqrc", "activate project root discovery")
+	return state, nil
+}
+
+func (state *setupState) addChange(condition bool, path, action string) {
+	if condition {
+		state.changes = append(state.changes, setupChange{Path: path, Action: action})
+	}
+}
+
+func (state setupState) preview() setupPreview {
+	return setupPreview{
+		ProjectRoot: state.projectRoot, QueueRoot: state.queueRoot,
+		DefaultSession:     state.projectConfig.DefaultSession,
+		Agents:             append([]launch.ProjectAgentConfig(nil), state.projectConfig.Agents...),
+		Layout:             state.projectConfig.Layout,
+		LauncherPreference: append([]string(nil), state.localConfig.LauncherPreference...),
+		AvailableLaunchers: append([]string(nil), state.available...),
+		Changes:            append(make([]setupChange, 0, len(state.changes)), state.changes...),
+	}
+}
+
+func printSetupPreview(preview setupPreview) error {
+	if err := writeStdout("Set up AMQ in %s\n\n", preview.ProjectRoot); err != nil {
+		return err
+	}
+	if err := writeStdout("Agents: %s\n", strings.Join(projectAgentHandles(preview.Agents), ", ")); err != nil {
+		return err
+	}
+	if err := writeStdout("Default session: %s\n", preview.DefaultSession); err != nil {
+		return err
+	}
+	if err := writeStdout("Launcher preference: %s\n", strings.Join(preview.LauncherPreference, ", ")); err != nil {
+		return err
+	}
+	if err := writeStdout("Queue root: %s\nLayout: %s\n\nChanges:\n", preview.QueueRoot, preview.Layout.Type); err != nil {
+		return err
+	}
+	if len(preview.Changes) == 0 {
+		return writeStdoutLine("  (none)")
+	}
+	for _, change := range preview.Changes {
+		if err := writeStdout("  - %s: %s\n", change.Path, change.Action); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func detectSetupAgents(adapters []launch.HarnessAdapter) ([]launch.AdapterCapabilities, error) {
+	capabilities := make([]launch.AdapterCapabilities, 0, len(adapters))
+	for _, adapter := range adapters {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		capability := adapter.Capabilities(ctx)
+		cancel()
+		if err := launch.ValidateAdapterCapabilities(adapter, capability); err != nil {
+			return nil, err
+		}
+		if capability.Available && capability.Fresh {
+			capabilities = append(capabilities, capability)
+		}
+	}
+	sort.Slice(capabilities, func(i, j int) bool { return capabilities[i].Provider < capabilities[j].Provider })
+	return capabilities, nil
+}
+
+func validateSetupCommittedConfig(cfg launch.ProjectConfig, projectRoot string, adapters []launch.HarnessAdapter) error {
+	byName := make(map[string]launch.HarnessAdapter, len(adapters))
+	for _, adapter := range adapters {
+		byName[adapter.Name()] = adapter
+	}
+	for _, agent := range cfg.Agents {
+		adapter, ok := byName[agent.Adapter]
+		if !ok {
+			return &setupConfigRefusalError{
+				Handle: agent.Handle, Adapter: agent.Adapter,
+				Err: fmt.Errorf("adapter is not supported by this AMQ build"),
+			}
+		}
+		if err := launch.ValidateCommittedConfig(adapter, launch.CommittedConfigRequest{
+			ProjectRoot: projectRoot,
+			Cwd:         agent.Cwd,
+			Args:        append([]string(nil), agent.Command[1:]...),
+			EnvOverlay:  agent.Env,
+		}); err != nil {
+			return &setupConfigRefusalError{Handle: agent.Handle, Adapter: agent.Adapter, Err: err}
+		}
+	}
+	return nil
+}
+
+func chooseSetupAgents(options setupOptions, detected []launch.AdapterCapabilities, existing launch.ProjectConfig, exists bool) ([]launch.ProjectAgentConfig, error) {
+	available := make(map[string]launch.AdapterCapabilities, len(detected))
+	names := make([]string, 0, len(detected))
+	for _, capability := range detected {
+		available[capability.Provider] = capability
+		names = append(names, capability.Provider)
+	}
+	existingByHandle := make(map[string]launch.ProjectAgentConfig, len(existing.Agents))
+	for _, agent := range existing.Agents {
+		existingByHandle[agent.Handle] = agent
+		if _, ok := available[agent.Handle]; !ok {
+			names = append(names, agent.Handle)
+		}
+	}
+	names = dedupeStrings(names)
+	sort.Strings(names)
+	var selected []string
+	switch {
+	case options.agentsExplicit:
+		var err error
+		selected, err = parseCoopInitAgents(options.agents)
+		if err != nil {
+			return nil, err
+		}
+	case exists && options.yes:
+		return append([]launch.ProjectAgentConfig(nil), existing.Agents...), nil
+	case options.yes:
+		selected = names
+	default:
+		if len(names) == 0 {
+			return nil, fmt.Errorf("no supported agent CLI detected")
+		}
+		defaultSelection := names
+		if exists {
+			defaultSelection = projectAgentHandles(existing.Agents)
+		}
+		line, err := setupPromptLine(options.input, "Agents (comma-separated)", strings.Join(defaultSelection, ","))
+		if err != nil {
+			return nil, err
+		}
+		selected, err = parseCoopInitAgents(line)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("no supported agent CLI detected")
+	}
+	agents := make([]launch.ProjectAgentConfig, 0, len(selected))
+	for _, name := range selected {
+		if agent, ok := existingByHandle[name]; ok {
+			agents = append(agents, agent)
+			continue
+		}
+		if _, ok := available[name]; !ok {
+			return nil, UsageError("agent %q is not available through a supported adapter probe", name)
+		}
+		agents = append(agents, launch.ProjectAgentConfig{
+			Handle: name, Adapter: name, Command: []string{name}, ResumePolicy: launch.ResumeEnabled,
+		})
+	}
+	sort.Slice(agents, func(i, j int) bool { return agents[i].Handle < agents[j].Handle })
+	return agents, nil
+}
+
+func chooseSetupSession(options setupOptions, existing launch.ProjectConfig, exists bool) (string, error) {
+	value := defaultSessionName
+	if exists {
+		value = existing.DefaultSession
+	}
+	if options.sessionExplicit {
+		value = strings.TrimSpace(options.defaultSession)
+	} else if !options.yes {
+		line, err := setupPromptLine(options.input, "Default session", value)
+		if err != nil {
+			return "", err
+		}
+		value = line
+	}
+	if err := validateSessionName(value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+func chooseSetupLaunchers(options setupOptions, detected []string, existing launch.LocalConfig, exists bool) ([]string, error) {
+	preference := append([]string(nil), detected...)
+	if exists {
+		preference = append([]string(nil), existing.LauncherPreference...)
+	}
+	var raw string
+	if options.launchersExplicit {
+		raw = options.launchers
+	} else if !options.yes {
+		line, err := setupPromptLine(options.input, "Launcher preference (comma-separated)", strings.Join(preference, ","))
+		if err != nil {
+			return nil, err
+		}
+		raw = line
+	}
+	if raw != "" {
+		preference = splitSetupList(raw)
+	}
+	if !slices.Contains(preference, launch.LauncherCommands) {
+		preference = append(preference, launch.LauncherCommands)
+	}
+	preference = dedupeStrings(preference)
+	cfg := launch.LocalConfig{Schema: launch.LocalConfigSchema, LauncherPreference: preference}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return preference, nil
+}
+
+func detectSetupLaunchers() []string {
+	result := make([]string, 0, 4)
+	for _, name := range []string{launch.LauncherCMux, launch.LauncherGhostty, launch.LauncherTMux} {
+		if _, err := setupLookPath(name); err == nil {
+			result = append(result, name)
+		}
+	}
+	return append(result, launch.LauncherCommands)
+}
+
+func setupPromptLine(reader *bufio.Reader, label, defaultValue string) (string, error) {
+	if reader == nil {
+		return "", fmt.Errorf("interactive setup reader is unavailable")
+	}
+	if err := writeStdout("%s [%s]: ", label, defaultValue); err != nil {
+		return "", err
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return defaultValue, nil
+	}
+	return line, nil
+}
+
+func setupConfirm(reader *bufio.Reader, prompt string) (bool, error) {
+	if reader == nil {
+		return false, fmt.Errorf("interactive setup reader is unavailable")
+	}
+	if err := writeStdout("%s [Y/n]: ", prompt); err != nil {
+		return false, err
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "" || line == "y" || line == "yes", nil
+}
+
+func splitSetupList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if value := strings.TrimSpace(part); value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func setupRoot(requested string, explicit bool, projectRoot string) (string, []byte, bool, error) {
+	result, err := findAndLoadAmqrc()
+	if err == nil {
+		if !sameTreeIdentity(result.Dir, projectRoot) {
+			return "", nil, false, fmt.Errorf("project setup resolved parent .amqrc at %s", result.Path)
+		}
+		raw, readErr := os.ReadFile(result.Path)
+		if readErr != nil {
+			return "", nil, false, readErr
+		}
+		var fields map[string]json.RawMessage
+		if jsonErr := json.Unmarshal(raw, &fields); jsonErr != nil {
+			return "", nil, false, jsonErr
+		}
+		if _, conflict := fields["default_session"]; conflict {
+			return "", nil, false, &launch.ConfigAuthorityConflictError{Path: ".amqrc", Field: "default_session"}
+		}
+		if explicit && requested != result.Config.Root {
+			return "", nil, false, fmt.Errorf(".amqrc already selects root %q", result.Config.Root)
+		}
+		return result.Config.Root, raw, true, nil
+	}
+	if !errors.Is(err, errAmqrcNotFound) {
+		return "", nil, false, err
+	}
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return "", nil, false, UsageError("--root must not be blank")
+	}
+	return requested, nil, false, nil
+}
+
+func validateSetupConfigDirectory() error {
+	info, err := os.Lstat(".amq")
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf(".amq must be a real directory")
+	}
+	return nil
+}
+
+func loadOptionalProjectConfig(path string) (launch.ProjectConfig, []byte, bool, error) {
+	data, exists, err := readOptionalRegular(path)
+	if err != nil || !exists {
+		return launch.ProjectConfig{}, nil, exists, err
+	}
+	cfg, err := launch.ParseProjectConfig(data)
+	return cfg, data, true, err
+}
+
+func loadOptionalLocalConfig(path string) (launch.LocalConfig, []byte, bool, error) {
+	data, exists, err := readOptionalRegular(path)
+	if err != nil || !exists {
+		return launch.LocalConfig{}, nil, exists, err
+	}
+	cfg, err := launch.ParseLocalConfig(path, data)
+	return cfg, data, true, err
+}
+
+func readOptionalRegular(path string) ([]byte, bool, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, false, fmt.Errorf("%s must be a regular file", path)
+	}
+	data, err := os.ReadFile(path)
+	return data, true, err
+}
+
+func setupBaseConfig(root string, agents []string) (config.Config, []byte, []string, error) {
+	path := filepath.Join(root, "meta", "config.json")
+	data, exists, err := readOptionalRegular(path)
+	if err != nil {
+		return config.Config{}, nil, nil, err
+	}
+	cfg := config.Config{Version: format.CurrentVersion, CreatedUTC: time.Now().UTC().Format(time.RFC3339), Agents: agents}
+	var current []string
+	if exists {
+		loaded, loadErr := config.LoadConfig(path)
+		if loadErr != nil {
+			return config.Config{}, nil, nil, loadErr
+		}
+		for _, agent := range loaded.Agents {
+			if err := fsq.ValidateHandle(agent); err != nil {
+				return config.Config{}, nil, nil, fmt.Errorf("invalid agent in existing config: %w", err)
+			}
+		}
+		cfg.CreatedUTC = loaded.CreatedUTC
+		current = append([]string(nil), loaded.Agents...)
+	}
+	return cfg, data, current, nil
+}
+
+func marshalSetupBaseConfig(cfg config.Config) ([]byte, error) {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func sortedUnion(left, right []string) []string {
+	result := dedupeStrings(append(append([]string(nil), left...), right...))
+	sort.Strings(result)
+	return result
+}
+
+func projectAgentHandles(agents []launch.ProjectAgentConfig) []string {
+	result := make([]string, 0, len(agents))
+	for _, agent := range agents {
+		result = append(result, agent.Handle)
+	}
+	return result
+}
+
+func setupNeedsProvisioning(root, session string, agents []string) (bool, error) {
+	paths := []string{
+		filepath.Join(root, "agents"), filepath.Join(root, "threads"), filepath.Join(root, "meta"),
+		filepath.Join(root, session, "agents"), filepath.Join(root, session, "threads"), filepath.Join(root, session, "meta"),
+	}
+	for _, base := range []string{root, filepath.Join(root, session)} {
+		for _, agent := range agents {
+			for _, leaf := range fsq.RequiredMailboxLeaves() {
+				paths = append(paths, filepath.Join(base, "agents", agent, filepath.FromSlash(string(leaf))))
+			}
+		}
+	}
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func setupGitignoreData(root string, disabled bool) ([]byte, bool, error) {
+	if disabled {
+		return nil, false, nil
+	}
+	data, exists, err := readOptionalRegular(".gitignore")
+	if err != nil {
+		return nil, false, err
+	}
+	patterns := []string{setupLocalConfigPath}
+	if !filepath.IsAbs(root) {
+		patterns = append([]string{strings.TrimSuffix(filepath.ToSlash(root), "/") + "/"}, patterns...)
+	}
+	missing := make([]string, 0, len(patterns))
+	lines := strings.Split(string(data), "\n")
+	for _, pattern := range patterns {
+		found := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == pattern || trimmed == "/"+pattern || trimmed == strings.TrimSuffix(pattern, "/") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, pattern)
+		}
+	}
+	if len(missing) == 0 {
+		return data, false, nil
+	}
+	var suffix strings.Builder
+	if exists && len(data) > 0 {
+		suffix.WriteByte('\n')
+	}
+	suffix.WriteString("# Agent Message Queue local state\n")
+	suffix.WriteString(strings.Join(missing, "\n"))
+	suffix.WriteByte('\n')
+	return append(append([]byte(nil), data...), []byte(suffix.String())...), true, nil
+}
+
+func fileDiffers(path string, desired []byte) bool {
+	current, exists, err := readOptionalRegular(path)
+	return err != nil || !exists || !bytes.Equal(current, desired)
+}
+
+func commitSetup(state setupState) ([]string, error) {
+	written := make([]string, 0, len(state.changes))
+	step := func(name string) error {
+		written = append(written, name)
+		if setupCommitStepHook != nil {
+			return setupCommitStepHook(name)
+		}
+		return nil
+	}
+	if state.needsProvision {
+		if err := provisionCoopBaseAndSession(state.queueRoot, state.projectConfig.DefaultSession, projectAgentHandles(state.projectConfig.Agents)); err != nil {
+			return written, err
+		}
+		if err := step("provision"); err != nil {
+			return written, err
+		}
+	}
+	baseConfigPath := filepath.Join(state.queueRoot, "meta", "config.json")
+	if changed, err := setupWriteAtomicIfChanged(baseConfigPath, state.unionConfigData, 0o600); err != nil {
+		return written, err
+	} else if changed {
+		if err := step("roster_compatible"); err != nil {
+			return written, err
+		}
+	}
+	if changed, err := setupWriteAtomicIfChanged(setupConfigPath, state.projectData, 0o644); err != nil {
+		return written, err
+	} else if changed {
+		if err := step("project_config"); err != nil {
+			return written, err
+		}
+	}
+	if changed, err := setupWriteAtomicIfChanged(baseConfigPath, state.baseConfigData, 0o600); err != nil {
+		return written, err
+	} else if changed {
+		if err := step("roster_final"); err != nil {
+			return written, err
+		}
+	}
+	if changed, err := setupWriteAtomicIfChanged(setupLocalConfigPath, state.localData, 0o600); err != nil {
+		return written, err
+	} else if changed {
+		if err := step("local_config"); err != nil {
+			return written, err
+		}
+	}
+	if !state.noGitignore && len(state.gitignoreData) > 0 {
+		if changed, err := setupWriteAtomicIfChanged(".gitignore", state.gitignoreData, 0o644); err != nil {
+			return written, err
+		} else if changed {
+			if err := step("gitignore"); err != nil {
+				return written, err
+			}
+		}
+	}
+	if changed, err := setupWriteAtomicIfChanged(".amqrc", state.amqrcData, 0o644); err != nil {
+		return written, err
+	} else if changed {
+		if err := step("amqrc"); err != nil {
+			return written, err
+		}
+	}
+	return written, nil
+}
+
+func setupWriteAtomicIfChanged(path string, data []byte, mode os.FileMode) (bool, error) {
+	current, exists, err := readOptionalRegular(path)
+	if err != nil {
+		return false, err
+	}
+	if exists && bytes.Equal(current, data) {
+		return false, nil
+	}
+	_, err = fsq.WriteFileAtomic(filepath.Dir(path), filepath.Base(path), data, mode)
+	return err == nil, err
+}

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,0 +1,551 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+type setupFixtureAdapter struct{ name string }
+
+type setupValidatingFixtureAdapter struct {
+	setupFixtureAdapter
+	validator launch.CommittedConfigValidator
+}
+
+func (a setupValidatingFixtureAdapter) ValidateCommittedConfig(request launch.CommittedConfigRequest) error {
+	return a.validator.ValidateCommittedConfig(request)
+}
+
+func (a setupFixtureAdapter) Name() string               { return a.name }
+func (a setupFixtureAdapter) Mode() launch.AdapterMode   { return launch.AdapterModeMint }
+func (a setupFixtureAdapter) CommittedEnvKeys() []string { return nil }
+func (a setupFixtureAdapter) Capabilities(context.Context) launch.AdapterCapabilities {
+	return launch.AdapterCapabilities{
+		Provider: a.name, Mode: a.Mode(), Available: true, Executable: "/outside/" + a.name,
+		ProviderVersion: "test", Fresh: true, Resume: true,
+	}
+}
+func (a setupFixtureAdapter) PlanFresh(launch.PlanRequest) (launch.AgentPlan, error) {
+	return launch.AgentPlan{}, errors.New("not used")
+}
+func (a setupFixtureAdapter) PlanResume(launch.ResumeRequest) (launch.AgentPlan, error) {
+	return launch.AgentPlan{}, errors.New("not used")
+}
+func (a setupFixtureAdapter) CaptureIdentity(launch.CaptureRequest) launch.CaptureResult {
+	return launch.CaptureResult{State: launch.CaptureUnsupported}
+}
+func (a setupFixtureAdapter) ValidateCommittedConfig(launch.CommittedConfigRequest) error {
+	return nil
+}
+
+func TestSetupWritesAuthoritativeAndPreferenceScopesThenNoOps(t *testing.T) {
+	project := setupProjectFixture(t, "claude", "codex", "grok")
+	const gitignoreBefore = "# user-owned bytes\ncustom/cache\n"
+	if err := os.WriteFile(filepath.Join(project, ".gitignore"), []byte(gitignoreBefore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	setupLookPath = func(name string) (string, error) {
+		if name == launch.LauncherTMux {
+			return "/usr/bin/tmux", nil
+		}
+		return "", fs.ErrNotExist
+	}
+	t.Cleanup(func() { setupLookPath = execLookPathForSetup })
+
+	if _, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude,codex,grok", "--default-session", "work", "--json"})
+	}); err != nil {
+		t.Fatalf("first setup: %v", err)
+	}
+	projectRaw, err := os.ReadFile(filepath.Join(project, setupConfigPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectConfig, err := launch.ParseProjectConfig(projectRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := projectAgentHandles(projectConfig.Agents); !slices.Equal(got, []string{"claude", "codex", "grok"}) {
+		t.Fatalf("roster = %v", got)
+	}
+	if projectConfig.DefaultSession != "work" {
+		t.Fatalf("default session = %q", projectConfig.DefaultSession)
+	}
+	localRaw, err := os.ReadFile(filepath.Join(project, setupLocalConfigPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	local, err := launch.ParseLocalConfig(setupLocalConfigPath, localRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(local.LauncherPreference, []string{launch.LauncherTMux, launch.LauncherCommands}) {
+		t.Fatalf("launcher preference = %v", local.LauncherPreference)
+	}
+	for _, forbidden := range []string{"default_session", "agents", "argv", "env", "cwd", "bypass_args"} {
+		if strings.Contains(string(localRaw), `"`+forbidden+`"`) {
+			t.Fatalf("local config contains authority field %q: %s", forbidden, localRaw)
+		}
+	}
+	gitignoreAfter, err := os.ReadFile(filepath.Join(project, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(gitignoreAfter), gitignoreBefore) ||
+		!strings.Contains(string(gitignoreAfter), ".agent-mail/\n") ||
+		!strings.Contains(string(gitignoreAfter), setupLocalConfigPath+"\n") {
+		t.Fatalf("gitignore did not preserve prefix and append entries:\n%s", gitignoreAfter)
+	}
+	for _, base := range []string{filepath.Join(project, defaultCoopRoot), filepath.Join(project, defaultCoopRoot, "work")} {
+		for _, agent := range []string{"claude", "codex", "grok"} {
+			if err := validateSetupMailbox(base, agent); err != nil {
+				t.Fatalf("mailbox %s/%s: %v", base, agent, err)
+			}
+		}
+	}
+
+	before := setupTreeDigest(t, project)
+	writes := 0
+	setupCommitStepHook = func(string) error { writes++; return nil }
+	t.Cleanup(func() { setupCommitStepHook = nil })
+	output, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--json"}) })
+	if err != nil {
+		t.Fatalf("matching rerun: %v", err)
+	}
+	if writes != 0 || !strings.Contains(output, `"status": "unchanged"`) {
+		t.Fatalf("matching rerun writes=%d output=%s", writes, output)
+	}
+	after := setupTreeDigest(t, project)
+	if before != after {
+		t.Fatalf("matching rerun changed tree digest: %x != %x", before, after)
+	}
+}
+
+func TestSetupInterruptionPrefixesConverge(t *testing.T) {
+	steps := []string{"provision", "roster_compatible", "project_config", "local_config", "gitignore", "amqrc"}
+	for _, stop := range steps {
+		t.Run(stop, func(t *testing.T) {
+			project := setupProjectFixture(t, "claude")
+			injected := errors.New("injected after " + stop)
+			setupCommitStepHook = func(step string) error {
+				if step == stop {
+					return injected
+				}
+				return nil
+			}
+			_, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--agents", "claude"}) })
+			if !errors.Is(err, injected) {
+				t.Fatalf("interrupted setup error = %v", err)
+			}
+			assertSetupPrefixValid(t, project)
+			setupCommitStepHook = nil
+			if _, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--agents", "claude"}) }); err != nil {
+				t.Fatalf("recovery rerun: %v", err)
+			}
+			assertCompleteSetup(t, project, "claude")
+			before := setupTreeDigest(t, project)
+			calls := 0
+			setupCommitStepHook = func(string) error { calls++; return nil }
+			if _, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--agents", "claude"}) }); err != nil {
+				t.Fatalf("stable rerun: %v", err)
+			}
+			if calls != 0 || before != setupTreeDigest(t, project) {
+				t.Fatalf("stable rerun calls=%d changed=%t", calls, before != setupTreeDigest(t, project))
+			}
+			setupCommitStepHook = nil
+		})
+	}
+}
+
+func TestSetupRefusesLocalAuthorityBeforeWrites(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	if err := os.MkdirAll(filepath.Join(project, ".amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	malicious := []byte(`{"schema":1,"launcher_preference":["commands"],"default_session":"attacker"}`)
+	if err := os.WriteFile(filepath.Join(project, setupLocalConfigPath), malicious, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--agents", "claude"}) })
+	var conflict *launch.ConfigAuthorityConflictError
+	if !errors.As(err, &conflict) || GetExitCode(err) != ExitError {
+		t.Fatalf("authority error = %T %v, exit=%d", err, err, GetExitCode(err))
+	}
+	if _, statErr := os.Lstat(filepath.Join(project, ".amqrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("authority refusal wrote .amqrc: %v", statErr)
+	}
+	if _, statErr := os.Lstat(filepath.Join(project, defaultCoopRoot)); !os.IsNotExist(statErr) {
+		t.Fatalf("authority refusal provisioned root: %v", statErr)
+	}
+}
+
+func TestSetupRefusesAdapterHostileCommittedConfigWithoutWrites(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		mutate     func(*launch.ProjectAgentConfig)
+		wantDetail string
+	}{
+		{
+			name: "loader environment",
+			mutate: func(agent *launch.ProjectAgentConfig) {
+				agent.Env = map[string]string{"NODE_OPTIONS": "--require ./evil.js"}
+			},
+			wantDetail: "NODE_OPTIONS",
+		},
+		{
+			name: "repo relative wrapper",
+			mutate: func(agent *launch.ProjectAgentConfig) {
+				agent.Command = append(agent.Command, "bash", "./agent-wrapper")
+			},
+			wantDetail: "bash",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			project := setupProjectFixture(t, "claude")
+			setupHarnessAdapters = func() []launch.HarnessAdapter {
+				return []launch.HarnessAdapter{setupValidatingFixtureAdapter{
+					setupFixtureAdapter: setupFixtureAdapter{name: "claude"},
+					validator:           launch.NewClaudeAdapter("claude"),
+				}}
+			}
+			if _, err := captureEnvStdout(t, func() error {
+				return runSetup([]string{"-y", "--agents", "claude"})
+			}); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(project, setupConfigPath)
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := launch.ParseProjectConfig(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(&cfg.Agents[0])
+			hostile, err := json.Marshal(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, hostile, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			before := setupTreeDigest(t, project)
+			steps := 0
+			setupCommitStepHook = func(string) error { steps++; return nil }
+			_, err = captureEnvStdout(t, func() error { return runSetup([]string{"-y"}) })
+			var refusal *setupConfigRefusalError
+			if !errors.As(err, &refusal) || !strings.Contains(err.Error(), test.wantDetail) {
+				t.Fatalf("hostile config error = %T %v", err, err)
+			}
+			if steps != 0 || before != setupTreeDigest(t, project) {
+				t.Fatalf("hostile refusal steps=%d changed=%t", steps, before != setupTreeDigest(t, project))
+			}
+		})
+	}
+}
+
+func TestSetupPreservesExternallyEditedValidConfigAsZeroWrite(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	setupHarnessAdapters = func() []launch.HarnessAdapter {
+		return []launch.HarnessAdapter{setupValidatingFixtureAdapter{
+			setupFixtureAdapter: setupFixtureAdapter{name: "claude"},
+			validator:           launch.NewClaudeAdapter("claude"),
+		}}
+	}
+	if _, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(project, setupConfigPath)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := launch.ParseProjectConfig(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Agents[0].Command = append(cfg.Agents[0].Command, "--no-chrome")
+	valid, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, valid, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before := setupTreeDigest(t, project)
+	steps := 0
+	setupCommitStepHook = func(string) error { steps++; return nil }
+	output, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--json"}) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if steps != 0 || before != setupTreeDigest(t, project) || !strings.Contains(output, `"status": "unchanged"`) {
+		t.Fatalf("valid external edit steps=%d changed=%t output=%s", steps, before != setupTreeDigest(t, project), output)
+	}
+}
+
+func TestSetupRefusesLegacyDefaultSessionAuthorityInAmqrc(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	legacy := []byte(`{"root":".agent-mail","default_session":"attacker"}`)
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), legacy, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resetAmqrcCache()
+	_, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--agents", "claude"}) })
+	var conflict *launch.ConfigAuthorityConflictError
+	if !errors.As(err, &conflict) || conflict.Path != ".amqrc" || conflict.Field != "default_session" {
+		t.Fatalf("legacy authority error = %T %v", err, err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(project, defaultCoopRoot)); !os.IsNotExist(statErr) {
+		t.Fatalf("authority refusal provisioned root: %v", statErr)
+	}
+}
+
+func TestSetupRosterReplacementFinalizationRecovers(t *testing.T) {
+	for _, stop := range []string{"project_config", "roster_final"} {
+		t.Run(stop, func(t *testing.T) {
+			project := setupProjectFixture(t, "claude", "codex", "grok")
+			if _, err := captureEnvStdout(t, func() error {
+				return runSetup([]string{"-y", "--agents", "claude,codex"})
+			}); err != nil {
+				t.Fatal(err)
+			}
+			injected := errors.New("after " + stop)
+			setupCommitStepHook = func(step string) error {
+				if step == stop {
+					return injected
+				}
+				return nil
+			}
+			_, err := captureEnvStdout(t, func() error {
+				return runSetup([]string{"-y", "--agents", "claude,grok"})
+			})
+			if !errors.Is(err, injected) {
+				t.Fatalf("roster interruption = %v", err)
+			}
+			assertSetupPrefixValid(t, project)
+			if stop == "project_config" {
+				compatible, readErr := os.ReadFile(filepath.Join(project, defaultCoopRoot, "meta", "config.json"))
+				if readErr != nil || !strings.Contains(string(compatible), `"codex"`) || !strings.Contains(string(compatible), `"grok"`) {
+					t.Fatalf("compatible prefix config = %s err=%v", compatible, readErr)
+				}
+			}
+			setupCommitStepHook = nil
+			if _, err := captureEnvStdout(t, func() error {
+				return runSetup([]string{"-y", "--agents", "claude,grok"})
+			}); err != nil {
+				t.Fatalf("roster recovery: %v", err)
+			}
+			raw, err := os.ReadFile(filepath.Join(project, defaultCoopRoot, "meta", "config.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(raw), `"codex"`) || !strings.Contains(string(raw), `"grok"`) {
+				t.Fatalf("final roster config = %s", raw)
+			}
+		})
+	}
+}
+
+func TestSetupInteractiveAbortWritesNothing(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	setupIsTerminal = func() bool { return true }
+	t.Cleanup(func() { setupIsTerminal = setupTerminalDefault })
+	restore := withStdin(t, "\n\n\nno\n")
+	defer restore()
+	output, err := captureEnvStdout(t, func() error { return runSetup(nil) })
+	if err != nil {
+		t.Fatalf("interactive abort: %v", err)
+	}
+	if !strings.Contains(output, "Changes:") || !strings.Contains(output, "Aborted.") {
+		t.Fatalf("output = %q", output)
+	}
+	for _, path := range []string{".amqrc", defaultCoopRoot, setupConfigPath, setupLocalConfigPath} {
+		if _, statErr := os.Lstat(filepath.Join(project, path)); !os.IsNotExist(statErr) {
+			t.Fatalf("abort wrote %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestSetupInteractiveRerunCanChangeRosterAndSession(t *testing.T) {
+	project := setupProjectFixture(t, "claude", "codex")
+	if _, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude,codex"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	setupIsTerminal = func() bool { return true }
+	restore := withStdin(t, "claude\nreview\ncommands\n\n")
+	defer restore()
+	if _, err := captureEnvStdout(t, func() error { return runSetup(nil) }); err != nil {
+		t.Fatalf("interactive update: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(project, setupConfigPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := launch.ParseProjectConfig(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := projectAgentHandles(cfg.Agents); !slices.Equal(got, []string{"claude"}) || cfg.DefaultSession != "review" {
+		t.Fatalf("updated config = %#v", cfg)
+	}
+	if err := validateSetupMailbox(filepath.Join(project, defaultCoopRoot, "review"), "claude"); err != nil {
+		t.Fatalf("updated session mailbox: %v", err)
+	}
+}
+
+func TestSetupNoGitignorePreservesExistingBytes(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	const before = "keep exactly this without newline"
+	if err := os.WriteFile(filepath.Join(project, ".gitignore"), []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude", "--no-gitignore"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(filepath.Join(project, ".gitignore"))
+	if err != nil || string(after) != before {
+		t.Fatalf("gitignore = %q err=%v", after, err)
+	}
+}
+
+var (
+	execLookPathForSetup = setupLookPath
+	setupTerminalDefault = setupIsTerminal
+)
+
+func setupProjectFixture(t *testing.T, adapters ...string) string {
+	t.Helper()
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	resetAmqrcCache()
+	setupHarnessAdapters = func() []launch.HarnessAdapter {
+		result := make([]launch.HarnessAdapter, 0, len(adapters))
+		for _, name := range adapters {
+			result = append(result, setupFixtureAdapter{name: name})
+		}
+		return result
+	}
+	setupLookPath = func(string) (string, error) { return "", fs.ErrNotExist }
+	setupCommitStepHook = nil
+	t.Cleanup(func() {
+		_ = os.Chdir(oldCWD)
+		resetAmqrcCache()
+		setupHarnessAdapters = func() []launch.HarnessAdapter {
+			return []launch.HarnessAdapter{
+				launch.NewClaudeAdapter(launch.ClaudeProvider),
+				launch.NewCodexAdapter(launch.CodexProvider),
+			}
+		}
+		setupLookPath = execLookPathForSetup
+		setupIsTerminal = setupTerminalDefault
+		setupCommitStepHook = nil
+	})
+	return project
+}
+
+func assertSetupPrefixValid(t *testing.T, project string) {
+	t.Helper()
+	if _, err := os.Lstat(filepath.Join(project, ".amqrc")); err == nil {
+		assertCompleteSetup(t, project, "claude")
+	}
+	if data, err := os.ReadFile(filepath.Join(project, setupConfigPath)); err == nil {
+		cfg, parseErr := launch.ParseProjectConfig(data)
+		if parseErr != nil {
+			t.Fatalf("partial launch config: %v", parseErr)
+		}
+		for _, agent := range cfg.Agents {
+			if err := validateSetupMailbox(filepath.Join(project, defaultCoopRoot, cfg.DefaultSession), agent.Handle); err != nil {
+				t.Fatalf("declared partial roster is not provisioned: %v", err)
+			}
+		}
+	}
+}
+
+func assertCompleteSetup(t *testing.T, project string, agents ...string) {
+	t.Helper()
+	for _, path := range []string{".amqrc", setupConfigPath, setupLocalConfigPath, ".gitignore"} {
+		if info, err := os.Stat(filepath.Join(project, path)); err != nil || !info.Mode().IsRegular() {
+			t.Fatalf("missing setup file %s: info=%v err=%v", path, info, err)
+		}
+	}
+	for _, base := range []string{filepath.Join(project, defaultCoopRoot), filepath.Join(project, defaultCoopRoot, defaultSessionName)} {
+		for _, agent := range agents {
+			if err := validateSetupMailbox(base, agent); err != nil {
+				t.Fatalf("mailbox %s/%s: %v", base, agent, err)
+			}
+		}
+	}
+}
+
+func setupTreeDigest(t *testing.T, root string) [32]byte {
+	t.Helper()
+	hash := sha256.New()
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(hash, "%s\x00%s\x00", filepath.ToSlash(relative), info.Mode().String())
+		if info.Mode().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			_, _ = hash.Write(data)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result [32]byte
+	copy(result[:], hash.Sum(nil))
+	return result
+}
+
+func validateSetupMailbox(base, agent string) error {
+	identity, err := fsq.SnapshotDeliveryRoot(base)
+	if err != nil {
+		return err
+	}
+	root, err := fsq.OpenDeliveryRoot(base, identity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	return fsq.ValidateExistingMailboxLayout(root, agent)
+}

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -61,6 +61,31 @@ type ConversationIdentity struct {
 	ID       string `json:"id"`
 }
 
+// CommittedConfigRequest is the static, repository-controlled subset of an
+// adapter plan. Validation does not require the provider executable to be
+// installed, so setup can reject unsafe committed carriers on any machine.
+type CommittedConfigRequest struct {
+	ProjectRoot string
+	Cwd         string
+	Args        []string
+	EnvOverlay  map[string]string
+}
+
+// CommittedConfigValidator is implemented by adapters that can own committed
+// argv, environment, and cwd validation independently from live capability
+// probing and per-launch identity generation.
+type CommittedConfigValidator interface {
+	ValidateCommittedConfig(CommittedConfigRequest) error
+}
+
+func ValidateCommittedConfig(adapter HarnessAdapter, request CommittedConfigRequest) error {
+	validator, ok := adapter.(CommittedConfigValidator)
+	if !ok {
+		return fmt.Errorf("adapter %s does not validate committed configuration", adapter.Name())
+	}
+	return validator.ValidateCommittedConfig(request)
+}
+
 type commandProbe interface {
 	LookPath(string) (string, error)
 	Output(context.Context, string, ...string) ([]byte, error)
@@ -128,6 +153,22 @@ func validatePlanRequest(request PlanRequest, executable, provider string, envRu
 		return "", err
 	}
 	return resolvedExecutable, nil
+}
+
+func validateCommittedConfig(request CommittedConfigRequest, envRules map[string]valueRule, argRules map[string]argumentRule) error {
+	if err := validateCommittedArgs(request.Args, argRules); err != nil {
+		return err
+	}
+	if err := validateCommittedEnv(request.EnvOverlay, envRules); err != nil {
+		return err
+	}
+	cwd := request.Cwd
+	if strings.TrimSpace(cwd) == "" {
+		cwd = request.ProjectRoot
+	} else if !filepath.IsAbs(cwd) {
+		cwd = filepath.Join(request.ProjectRoot, cwd)
+	}
+	return validateWorkingDirectory(cwd, request.ProjectRoot)
 }
 
 func cloneEnv(overlay map[string]string) map[string]string {

--- a/internal/launch/adapter_claude.go
+++ b/internal/launch/adapter_claude.go
@@ -22,6 +22,10 @@ func (adapter *ClaudeAdapter) CommittedEnvKeys() []string {
 	return committedEnvKeys(claudeEnvRules())
 }
 
+func (adapter *ClaudeAdapter) ValidateCommittedConfig(request CommittedConfigRequest) error {
+	return validateCommittedConfig(request, claudeEnvRules(), claudeArgRules())
+}
+
 func (adapter *ClaudeAdapter) Capabilities(ctx context.Context) AdapterCapabilities {
 	result := AdapterCapabilities{Provider: ClaudeProvider, Mode: adapter.Mode()}
 	executable, err := adapter.probe.LookPath(adapter.executable)

--- a/internal/launch/adapter_codex.go
+++ b/internal/launch/adapter_codex.go
@@ -26,6 +26,10 @@ func (adapter *CodexAdapter) CommittedEnvKeys() []string {
 	return committedEnvKeys(codexEnvRules())
 }
 
+func (adapter *CodexAdapter) ValidateCommittedConfig(request CommittedConfigRequest) error {
+	return validateCommittedConfig(request, codexEnvRules(), codexArgRules())
+}
+
 func (adapter *CodexAdapter) Capabilities(ctx context.Context) AdapterCapabilities {
 	result := AdapterCapabilities{Provider: CodexProvider, Mode: adapter.Mode()}
 	executable, err := adapter.probe.LookPath(adapter.executable)

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -297,3 +297,44 @@ func TestValidateAdapterCapabilitiesRejectsModeMisdeclaration(t *testing.T) {
 		}
 	}
 }
+
+func TestCommittedConfigValidationDoesNotRequireInstalledExecutable(t *testing.T) {
+	project := t.TempDir()
+	adapter := NewClaudeAdapter("definitely-not-installed-claude")
+	if err := ValidateCommittedConfig(adapter, CommittedConfigRequest{
+		ProjectRoot: project,
+		Args:        []string{"--no-chrome"},
+		EnvOverlay:  map[string]string{"TERM": "xterm-256color"},
+	}); err != nil {
+		t.Fatalf("safe committed config: %v", err)
+	}
+	for _, test := range []struct {
+		name    string
+		request CommittedConfigRequest
+		want    string
+	}{
+		{
+			name: "loader environment",
+			request: CommittedConfigRequest{ProjectRoot: project,
+				EnvOverlay: map[string]string{"NODE_OPTIONS": "--require ./evil.js"}},
+			want: "NODE_OPTIONS",
+		},
+		{
+			name:    "wrapper argv",
+			request: CommittedConfigRequest{ProjectRoot: project, Args: []string{"bash", "./agent-wrapper"}},
+			want:    "bash",
+		},
+		{
+			name:    "cwd escape",
+			request: CommittedConfigRequest{ProjectRoot: project, Cwd: filepath.Dir(project)},
+			want:    "inside the project",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateCommittedConfig(adapter, test.request)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/launch/config.go
+++ b/internal/launch/config.go
@@ -13,6 +13,7 @@ import (
 const (
 	ProjectConfigSchema = 1
 	LocalConfigSchema   = 1
+	DefaultSessionName  = "collab"
 	LayoutColumns       = "columns"
 	LauncherCMux        = "cmux"
 	LauncherGhostty     = "ghostty"
@@ -63,6 +64,28 @@ func ParseProjectConfig(data []byte) (ProjectConfig, error) {
 	var cfg ProjectConfig
 	if err := decodeStrictJSON(data, &cfg); err != nil {
 		return ProjectConfig{}, fmt.Errorf("decode launch config: %w", err)
+	}
+	var fields struct {
+		DefaultSession json.RawMessage              `json:"default_session"`
+		Agents         []map[string]json.RawMessage `json:"agents"`
+		Layout         json.RawMessage              `json:"layout"`
+	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return ProjectConfig{}, fmt.Errorf("inspect launch config fields: %w", err)
+	}
+	if fields.DefaultSession == nil {
+		cfg.DefaultSession = DefaultSessionName
+	}
+	if fields.Layout == nil {
+		cfg.Layout.Type = LayoutColumns
+	}
+	for i, agentFields := range fields.Agents {
+		if _, ok := agentFields["adapter"]; !ok && len(cfg.Agents[i].Command) > 0 {
+			cfg.Agents[i].Adapter = cfg.Agents[i].Command[0]
+		}
+		if _, ok := agentFields["resume_policy"]; !ok {
+			cfg.Agents[i].ResumePolicy = ResumeEnabled
+		}
 	}
 	if err := cfg.Validate(); err != nil {
 		return ProjectConfig{}, err

--- a/internal/launch/config.go
+++ b/internal/launch/config.go
@@ -1,0 +1,195 @@
+package launch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+const (
+	ProjectConfigSchema = 1
+	LocalConfigSchema   = 1
+	LayoutColumns       = "columns"
+	LauncherCMux        = "cmux"
+	LauncherGhostty     = "ghostty"
+	LauncherTMux        = "tmux"
+	LauncherCommands    = "commands"
+)
+
+type ProjectConfig struct {
+	Schema         int                  `json:"schema"`
+	DefaultSession string               `json:"default_session"`
+	Agents         []ProjectAgentConfig `json:"agents"`
+	Layout         LayoutIntent         `json:"layout"`
+}
+
+type ProjectAgentConfig struct {
+	Handle       string            `json:"handle"`
+	Adapter      string            `json:"adapter"`
+	Command      []string          `json:"command"`
+	Env          map[string]string `json:"env,omitempty"`
+	Cwd          string            `json:"cwd,omitempty"`
+	ResumePolicy ResumePolicy      `json:"resume_policy"`
+}
+
+type LayoutIntent struct {
+	Type string `json:"type"`
+}
+
+// LocalConfig is deliberately preference-only. Execution authority, roster,
+// environment, cwd, bypass arguments, and session selection do not belong in
+// this in-worktree file, even when the file is already tracked.
+type LocalConfig struct {
+	Schema             int      `json:"schema"`
+	LauncherPreference []string `json:"launcher_preference"`
+}
+
+type ConfigAuthorityConflictError struct {
+	Path  string
+	Field string
+}
+
+func (e *ConfigAuthorityConflictError) Error() string {
+	return fmt.Sprintf("configuration authority conflict: %s must not define %q", e.Path, e.Field)
+}
+
+var canonicalSessionPattern = regexp.MustCompile(`^[a-z0-9_][a-z0-9_-]*$`)
+
+func ParseProjectConfig(data []byte) (ProjectConfig, error) {
+	var cfg ProjectConfig
+	if err := decodeStrictJSON(data, &cfg); err != nil {
+		return ProjectConfig{}, fmt.Errorf("decode launch config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return ProjectConfig{}, err
+	}
+	return cfg, nil
+}
+
+func ParseLocalConfig(path string, data []byte) (LocalConfig, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return LocalConfig{}, fmt.Errorf("decode local launch config: %w", err)
+	}
+	for _, field := range []string{
+		"agents", "default_session", "layout", "resume_policy", "command",
+		"argv", "env", "cwd", "bypass_args", "trust", "root",
+	} {
+		if _, ok := fields[field]; ok {
+			return LocalConfig{}, &ConfigAuthorityConflictError{Path: path, Field: field}
+		}
+	}
+	var cfg LocalConfig
+	if err := decodeStrictJSON(data, &cfg); err != nil {
+		return LocalConfig{}, fmt.Errorf("decode local launch config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return LocalConfig{}, err
+	}
+	return cfg, nil
+}
+
+func (cfg ProjectConfig) Validate() error {
+	if cfg.Schema != ProjectConfigSchema {
+		return fmt.Errorf("unsupported launch config schema %d", cfg.Schema)
+	}
+	if !canonicalSessionPattern.MatchString(cfg.DefaultSession) || strings.HasPrefix(cfg.DefaultSession, "-") {
+		return fmt.Errorf("invalid default session %q", cfg.DefaultSession)
+	}
+	if len(cfg.Agents) == 0 {
+		return fmt.Errorf("launch config requires at least one agent")
+	}
+	seen := make(map[string]struct{}, len(cfg.Agents))
+	for i, agent := range cfg.Agents {
+		if !canonicalSessionPattern.MatchString(agent.Handle) || strings.HasPrefix(agent.Handle, "-") {
+			return fmt.Errorf("agent %d has invalid handle %q", i, agent.Handle)
+		}
+		if _, ok := seen[agent.Handle]; ok {
+			return fmt.Errorf("duplicate agent handle %q", agent.Handle)
+		}
+		seen[agent.Handle] = struct{}{}
+		if agent.Adapter == "" {
+			return fmt.Errorf("agent %q has no adapter", agent.Handle)
+		}
+		if len(agent.Command) == 0 || agent.Command[0] != agent.Adapter {
+			return fmt.Errorf("agent %q command must select its adapter-known executable", agent.Handle)
+		}
+		for _, arg := range agent.Command {
+			if arg == "" || strings.ContainsRune(arg, 0) {
+				return fmt.Errorf("agent %q command contains an invalid argument", agent.Handle)
+			}
+		}
+		if agent.ResumePolicy != ResumeEnabled && agent.ResumePolicy != ResumeFresh && agent.ResumePolicy != ResumeDisabled {
+			return fmt.Errorf("agent %q has invalid resume policy %q", agent.Handle, agent.ResumePolicy)
+		}
+	}
+	if cfg.Layout.Type != LayoutColumns {
+		return fmt.Errorf("unsupported layout intent %q", cfg.Layout.Type)
+	}
+	return nil
+}
+
+func (cfg LocalConfig) Validate() error {
+	if cfg.Schema != LocalConfigSchema {
+		return fmt.Errorf("unsupported local launch config schema %d", cfg.Schema)
+	}
+	if len(cfg.LauncherPreference) == 0 {
+		return fmt.Errorf("local launch config requires a launcher preference")
+	}
+	seen := make(map[string]struct{}, len(cfg.LauncherPreference))
+	for _, launcher := range cfg.LauncherPreference {
+		if !slices.Contains([]string{LauncherCMux, LauncherGhostty, LauncherTMux, LauncherCommands}, launcher) {
+			return fmt.Errorf("unsupported launcher preference %q", launcher)
+		}
+		if _, ok := seen[launcher]; ok {
+			return fmt.Errorf("duplicate launcher preference %q", launcher)
+		}
+		seen[launcher] = struct{}{}
+	}
+	if _, ok := seen[LauncherCommands]; !ok {
+		return fmt.Errorf("launcher preference must include %q fallback", LauncherCommands)
+	}
+	return nil
+}
+
+func MarshalProjectConfig(cfg ProjectConfig) ([]byte, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return marshalConfig(cfg)
+}
+
+func MarshalLocalConfig(cfg LocalConfig) ([]byte, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return marshalConfig(cfg)
+}
+
+func marshalConfig(value any) ([]byte, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func decodeStrictJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/launch/config_test.go
+++ b/internal/launch/config_test.go
@@ -1,0 +1,59 @@
+package launch
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestProjectConfigRoundTripAndStrictAuthority(t *testing.T) {
+	cfg := ProjectConfig{
+		Schema: ProjectConfigSchema, DefaultSession: "collab",
+		Agents: []ProjectAgentConfig{
+			{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeEnabled},
+			{Handle: "codex", Adapter: "codex", Command: []string{"codex"}, ResumePolicy: ResumeDisabled},
+		},
+		Layout: LayoutIntent{Type: LayoutColumns},
+	}
+	data, err := MarshalProjectConfig(cfg)
+	if err != nil {
+		t.Fatalf("MarshalProjectConfig: %v", err)
+	}
+	parsed, err := ParseProjectConfig(data)
+	if err != nil {
+		t.Fatalf("ParseProjectConfig: %v", err)
+	}
+	if parsed.DefaultSession != "collab" || len(parsed.Agents) != 2 {
+		t.Fatalf("parsed config = %#v", parsed)
+	}
+	for _, hostile := range []string{
+		`{"schema":1,"default_session":"collab","agents":[{"handle":"claude","adapter":"claude","command":["bash","./agent"],"resume_policy":"resume"}],"layout":{"type":"columns"}}`,
+		`{"schema":1,"default_session":"collab","agents":[{"handle":"claude","adapter":"claude","command":["claude"],"resume_policy":"resume"}],"layout":{"type":"columns"},"root":"elsewhere"}`,
+		`{"schema":1,"default_session":"../escape","agents":[{"handle":"claude","adapter":"claude","command":["claude"],"resume_policy":"resume"}],"layout":{"type":"columns"}}`,
+	} {
+		if _, err := ParseProjectConfig([]byte(hostile)); err == nil {
+			t.Fatalf("hostile config accepted: %s", hostile)
+		}
+	}
+}
+
+func TestLocalConfigRejectsAuthorityFields(t *testing.T) {
+	for _, field := range []string{"agents", "default_session", "argv", "env", "cwd", "bypass_args", "root"} {
+		raw := `{"schema":1,"launcher_preference":["commands"],"` + field + `":"forged"}`
+		_, err := ParseLocalConfig(".amq/launch.local.json", []byte(raw))
+		var conflict *ConfigAuthorityConflictError
+		if !errors.As(err, &conflict) || conflict.Field != field {
+			t.Fatalf("field %s error = %T %v", field, err, err)
+		}
+	}
+	if _, err := ParseLocalConfig("local", []byte(`{"schema":1,"launcher_preference":["commands"],"unknown":true}`)); err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("unknown local field error = %v", err)
+	}
+}
+
+func TestLocalConfigRequiresCommandsFallback(t *testing.T) {
+	_, err := MarshalLocalConfig(LocalConfig{Schema: LocalConfigSchema, LauncherPreference: []string{LauncherTMux}})
+	if err == nil || !strings.Contains(err.Error(), LauncherCommands) {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/launch/config_test.go
+++ b/internal/launch/config_test.go
@@ -37,6 +37,35 @@ func TestProjectConfigRoundTripAndStrictAuthority(t *testing.T) {
 	}
 }
 
+func TestProjectConfigNormalizesLegacyMinimalRoster(t *testing.T) {
+	parsed, err := ParseProjectConfig([]byte(`{"schema":1,"agents":[{"handle":"claude","command":["claude"]}]}`))
+	if err != nil {
+		t.Fatalf("ParseProjectConfig: %v", err)
+	}
+	if parsed.DefaultSession != DefaultSessionName || parsed.Layout.Type != LayoutColumns {
+		t.Fatalf("normalized project defaults = %#v", parsed)
+	}
+	agent := parsed.Agents[0]
+	if agent.Adapter != "claude" || agent.ResumePolicy != ResumeEnabled {
+		t.Fatalf("normalized agent defaults = %#v", agent)
+	}
+}
+
+func TestProjectConfigRejectsExplicitEmptyOptionalDefaults(t *testing.T) {
+	for _, raw := range []string{
+		`{"schema":1,"default_session":"","agents":[{"handle":"claude","command":["claude"]}]}`,
+		`{"schema":1,"default_session":null,"agents":[{"handle":"claude","command":["claude"]}]}`,
+		`{"schema":1,"agents":[{"handle":"claude","adapter":"","command":["claude"]}]}`,
+		`{"schema":1,"agents":[{"handle":"claude","adapter":null,"command":["claude"]}]}`,
+		`{"schema":1,"agents":[{"handle":"claude","command":["claude"],"resume_policy":""}]}`,
+		`{"schema":1,"agents":[{"handle":"claude","command":["claude"]}],"layout":{"type":""}}`,
+	} {
+		if _, err := ParseProjectConfig([]byte(raw)); err == nil {
+			t.Fatalf("explicit empty default accepted: %s", raw)
+		}
+	}
+}
+
 func TestLocalConfigRejectsAuthorityFields(t *testing.T) {
 	for _, field := range []string{"agents", "default_session", "argv", "env", "cwd", "bypass_args", "root"} {
 		raw := `{"schema":1,"launcher_preference":["commands"],"` + field + `":"forged"}`


### PR DESCRIPTION
## Summary

- add strict committed launch and preference-only local schemas
- add adapter-probed amq setup with roster, session, layout, and launcher preference preview
- commit setup through durable ordered writes and shared coop provisioning
- reject adapter-forbidden committed argv, environment, and cwd before any writes
- preserve valid external configuration bytes and make matching reruns zero-write

## Scope

Implements the Wave A setup porcelain from issue #480. This does not add launch reconciliation or backend calls.

Refs: #480

## Validation

- go test ./...
- go test -race ./internal/launch ./internal/cli
- go vet ./...
- golangci-lint run
- Windows test compilation for internal/launch and internal/cli
- repository pre-push checks
