### PR TITLE
feat(coop): honor declared default_session and deprecate exec creation paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,10 @@ Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and do
 
 **Environment Variables**: `AM_ROOT` (queue root, e.g., `.agent-mail/collab`), `AM_ME` (agent handle), `AM_BASE_ROOT` (authorized parent for named-session routing, or the exact root for a sessionless pin), `AM_SESSION` (independent session identity set by `coop exec` and every shell-mode `amq env`, empty for sessionless roots), `AMQ_GLOBAL_ROOT` (global root fallback for orchestrator-spawned agents), `AMQ_NO_UPDATE_CHECK` (disable update check), `AMQ_WAKE_NO_SELF_UPGRADE` (disable automatic wake self-upgrade with `1`, `true`, `yes`, or `on`)
 
-**Session Layout**: The default base root directory is `.agent-mail/`. `.amqrc` can configure that root explicitly, but the default `.agent-mail/<session>` layout is also recognized without `.amqrc`. `coop exec` defaults to `--session collab`, so agents get session isolation without explicit flags. Use `--session` to override:
+**Session Layout**: The default base root directory is `.agent-mail/`. `.amqrc` can configure that root explicitly, but the default `.agent-mail/<session>` layout is also recognized without `.amqrc`. Selector-free `coop exec` uses the declared `default_session` from `.amq/launch.json`, or `collab` when none is declared. Use `--session` to override:
 ```
 .agent-mail/              ← default base root (configurable in `.amqrc`)
-.agent-mail/collab/       ← default session (coop exec without --session or --root)
+.agent-mail/collab/       ← default session (coop exec without --session or --root, unless launch.json declares another)
 .agent-mail/auth/         ← isolated session (via --session auth)
 .agent-mail/api/          ← isolated session (via --session api)
 ```
@@ -130,9 +130,13 @@ changed; the structured refusal is reported with process exit 0 unless
 That fail-closed rule applies to participating commands. `coop exec` honors root
 precedence before bootstrap; when no eligible root exists, it initializes
 `.agent-mail` at the worktree top, including explicit `--session <name>`.
-`coop init` is the explicit local-bootstrap command and also targets the Git
-top. `coop exec --no-init` keeps the refusal. Bare repositories cannot host
-this implicit bootstrap; use a worktree or `--root`.
+Creating a missing named session or `--root` this way is deprecated and prints
+`warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
+Use `amq session create <name>` or `amq init --root` instead. Zero-config
+`collab` bootstrap in a repo with neither `.amqrc` nor `.amq/launch.json` does
+not warn. `coop init` is the explicit local-bootstrap command and also targets
+the Git top. `coop exec --no-init` keeps the refusal. Bare repositories cannot
+host this implicit bootstrap; use a worktree or `--root`.
 
 Note: `.amqrc` configures the root directory. Agent identity (`me`) is set per-terminal via `--me` or `AM_ME`.
 Auto-detect covers the default `.agent-mail` layout in the current tree. A
@@ -530,7 +534,10 @@ amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Same, with 
 amq coop exec grok  # Caller flags forwarded unchanged, no baked-in bypass
 ```
 
-Without `--session` or `--root`, `coop exec` defaults to `--session collab`.
+Without `--session` or `--root`, `coop exec` uses the declared `default_session`
+from `.amq/launch.json`, or `collab` when none is declared. Creating a missing
+session or root from `coop exec` still works in this release but prints
+`warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
 
 Use `--session` for a different isolated session:
 ```bash

--- a/COOP.md
+++ b/COOP.md
@@ -88,10 +88,23 @@ worktree's top, even from a subdirectory or with `--session`; it does not
 consult `~/.amqrc`. Use `--no-init` to keep the refusal instead. It then sets
 `AM_ROOT`/`AM_ME`, `AM_BASE_ROOT`, and the independent `AM_SESSION` identity,
 starts wake notifications, and execs into the agent. Without `--session` or
-`--root`, it defaults to `--session collab` (i.e.,
-`AM_ROOT=.agent-mail/collab`, `AM_SESSION=collab`). A session-shaped explicit
-root such as `.agent-mail/auth` pins the inferred session; a custom sessionless
-root clears `AM_SESSION`.
+`--root`, it uses the declared `default_session` from `.amq/launch.json`, or
+`collab` when none is declared (i.e., `AM_ROOT=.agent-mail/collab`,
+`AM_SESSION=collab` unless launch.json says otherwise). A session-shaped
+explicit root such as `.agent-mail/auth` pins the inferred session; a custom
+sessionless root clears `AM_SESSION`.
+
+Creating a missing named session (`--session`) or missing `--root` still works
+in this release, and so does creating a missing declared default session when
+`.amqrc` or `.amq/launch.json` is present. Each of those paths prints this
+single-line warning exactly once:
+
+```
+warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.
+```
+
+Use `amq session create <name>` or `amq init --root` instead. Existing sessions
+and the zero-config `collab` bootstrap in a repo with neither file do not warn.
 
 To disable auto-wake (e.g., in CI or non-TTY environments):
 ```bash

--- a/internal/cli/coop_exec_declaration.go
+++ b/internal/cli/coop_exec_declaration.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+// coopExecCreationDeprecated is the stable, greppable stderr line for the
+// #480 v1.1 §9 deprecation wave. Behavior is unchanged this release; the next
+// major release makes the same paths exit 3 with zero writes.
+const coopExecCreationDeprecated = "warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3."
+
+func warnCoopExecCreationDeprecated(warned *bool) {
+	if warned == nil || *warned {
+		return
+	}
+	*warned = true
+	_ = writeStderr("%s\n", coopExecCreationDeprecated)
+}
+
+func hasBootstrapSuppressingDeclaration() (bool, error) {
+	_, err := findAndLoadAmqrc()
+	if err == nil {
+		return true, nil
+	}
+	if !errors.Is(err, errAmqrcNotFound) {
+		// Present but unreadable or corrupt: still a declaration. Routing
+		// owns the parse failure so an AM_ROOT override can proceed.
+		return true, nil
+	}
+	_, present, err := findProjectLaunchJSONPath()
+	return present, err
+}
+
+func declaredCoopExecSession() (string, error) {
+	cfg, present, err := loadProjectLaunchConfig()
+	if err != nil {
+		return "", err
+	}
+	if !present {
+		return defaultSessionName, nil
+	}
+	return cfg.DefaultSession, nil
+}
+
+func loadProjectLaunchConfig() (launch.ProjectConfig, bool, error) {
+	path, present, err := findProjectLaunchJSONPath()
+	if err != nil || !present {
+		return launch.ProjectConfig{}, present, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return launch.ProjectConfig{}, false, fmt.Errorf("cannot read %s: %w", path, err)
+	}
+	cfg, err := launch.ParseProjectConfig(data)
+	if err != nil {
+		return launch.ProjectConfig{}, false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return cfg, true, nil
+}
+
+func findProjectLaunchJSONPath() (string, bool, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false, err
+	}
+	ceiling := ""
+	if top, insideGit := gitWorktreeRootFromCWD(); insideGit {
+		ceiling = top
+		if resolved, resolveErr := filepath.EvalSymlinks(cwd); resolveErr == nil {
+			cwd = resolved
+		}
+	}
+
+	dir := cwd
+	for ceiling != "" || !isHomeConfigDir(dir) {
+		path := filepath.Join(dir, setupConfigPath)
+		info, statErr := os.Stat(path)
+		if statErr == nil && info.Mode().IsRegular() {
+			return path, true, nil
+		}
+		if statErr != nil && !os.IsNotExist(statErr) {
+			return "", false, fmt.Errorf("cannot inspect %s: %w", path, statErr)
+		}
+		if ceiling != "" && sameCleanPath(dir, ceiling) {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", false, nil
+}

--- a/internal/cli/coop_exec_deprecation_unix_test.go
+++ b/internal/cli/coop_exec_deprecation_unix_test.go
@@ -1,0 +1,207 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestCoopExecHonorsDeclaredDefaultSessionSelectorFree(t *testing.T) {
+	base := initCoopProjectForTest(t, "alice")
+	clearCoopSessionPinForTest(t)
+	writeProjectLaunchJSON(t, "dev")
+
+	env, stderr, err := captureCoopExecStderr(t, []string{"--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	wantRoot := filepath.Join(base, "dev")
+	if got := envValue(env, envRoot); !sameTreeIdentity(got, wantRoot) {
+		t.Fatalf("AM_ROOT = %q, want declared session %q", got, wantRoot)
+	}
+	if got := envValue(env, envSession); got != "dev" {
+		t.Fatalf("AM_SESSION = %q, want dev", got)
+	}
+	requireDeprecationWarningCount(t, stderr, 1)
+	if _, statErr := os.Stat(filepath.Join(wantRoot, "agents", "alice", "inbox", "new")); statErr != nil {
+		t.Fatalf("declared session was not created: %v", statErr)
+	}
+}
+
+func TestCoopExecExistingDeclaredDefaultSessionDoesNotWarn(t *testing.T) {
+	base := initCoopProjectForTest(t, "alice")
+	clearCoopSessionPinForTest(t)
+	writeProjectLaunchJSON(t, "dev")
+	if _, err := provisionCoopSession(base, "dev", []string{"alice"}, "", ""); err != nil {
+		t.Fatalf("provision declared session: %v", err)
+	}
+
+	env, stderr, err := captureCoopExecStderr(t, []string{"--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	if got := envValue(env, envSession); got != "dev" {
+		t.Fatalf("AM_SESSION = %q, want dev", got)
+	}
+	requireDeprecationWarningCount(t, stderr, 0)
+}
+
+func TestCoopExecExistingCollabSelectorFreeDoesNotWarn(t *testing.T) {
+	initCoopProjectForTest(t, "alice")
+	clearCoopSessionPinForTest(t)
+
+	_, stderr, err := captureCoopExecStderr(t, []string{"--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	requireDeprecationWarningCount(t, stderr, 0)
+}
+
+func TestCoopExecMissingDeclaredCollabWarnsOnce(t *testing.T) {
+	base := initCoopProjectForTest(t, "alice")
+	clearCoopSessionPinForTest(t)
+	if err := os.RemoveAll(filepath.Join(base, defaultSessionName)); err != nil {
+		t.Fatalf("remove collab: %v", err)
+	}
+
+	_, stderr, err := captureCoopExecStderr(t, []string{"--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	requireDeprecationWarningCount(t, stderr, 1)
+}
+
+func TestCoopExecMissingExplicitSessionWarnsOnce(t *testing.T) {
+	initCoopProjectForTest(t, "alice")
+	clearCoopSessionPinForTest(t)
+
+	env, stderr, err := captureCoopExecStderr(t, []string{"--session", "feature", "--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	if got := envValue(env, envSession); got != "feature" {
+		t.Fatalf("AM_SESSION = %q, want feature", got)
+	}
+	requireDeprecationWarningCount(t, stderr, 1)
+}
+
+func TestCoopExecExistingExplicitSessionDoesNotWarn(t *testing.T) {
+	base := initCoopProjectForTest(t, "alice")
+	clearCoopSessionPinForTest(t)
+	if _, err := provisionCoopSession(base, "feature", []string{"alice"}, "", ""); err != nil {
+		t.Fatalf("provision feature: %v", err)
+	}
+
+	_, stderr, err := captureCoopExecStderr(t, []string{"--session", "feature", "--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	requireDeprecationWarningCount(t, stderr, 0)
+}
+
+func TestCoopExecMissingExplicitRootWarnsOnce(t *testing.T) {
+	clearCoopSessionPinForTest(t)
+	root := filepath.Join(t.TempDir(), "custom-root")
+
+	env, stderr, err := captureCoopExecStderr(t, []string{"--root", root, "--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	if got := envValue(env, envRoot); !sameTreeIdentity(got, root) {
+		t.Fatalf("AM_ROOT = %q, want %q", got, root)
+	}
+	requireDeprecationWarningCount(t, stderr, 1)
+}
+
+func TestCoopExecExistingExplicitRootDoesNotWarn(t *testing.T) {
+	clearCoopSessionPinForTest(t)
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := captureCoopExecStderr(t, []string{"--root", root, "--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	requireDeprecationWarningCount(t, stderr, 0)
+}
+
+func TestCoopExecZeroConfigCollabBootstrapDoesNotWarn(t *testing.T) {
+	enterFreshGitBootstrapProject(t, false)
+	clearCoopSessionPinForTest(t)
+
+	env, stderr, err := captureCoopExecStderr(t, []string{"--no-wake", "--me", "alice", "sh"})
+	if err != nil {
+		t.Fatalf("coop exec: %v", err)
+	}
+	if got := envValue(env, envSession); got != defaultSessionName {
+		t.Fatalf("AM_SESSION = %q, want %q", got, defaultSessionName)
+	}
+	requireDeprecationWarningCount(t, stderr, 0)
+}
+
+func writeProjectLaunchJSON(t *testing.T, defaultSession string) {
+	t.Helper()
+	if err := os.MkdirAll(".amq", 0o700); err != nil {
+		t.Fatalf("mkdir .amq: %v", err)
+	}
+	body, err := launch.MarshalProjectConfig(launch.ProjectConfig{
+		Schema:         launch.ProjectConfigSchema,
+		DefaultSession: defaultSession,
+		Agents: []launch.ProjectAgentConfig{{
+			Handle:       "claude",
+			Adapter:      "claude",
+			Command:      []string{"claude"},
+			ResumePolicy: launch.ResumeEnabled,
+		}},
+		Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+	})
+	if err != nil {
+		t.Fatalf("marshal launch.json: %v", err)
+	}
+	if err := os.WriteFile(setupConfigPath, body, 0o600); err != nil {
+		t.Fatalf("write launch.json: %v", err)
+	}
+}
+
+func captureCoopExecStderr(t *testing.T, args []string) ([]string, string, error) {
+	t.Helper()
+	sentinel := errors.New("exec sentinel")
+	var execEnv []string
+	oldExec := coopExecProcess
+	coopExecProcess = func(_ string, _ []string, env []string) error {
+		execEnv = append([]string(nil), env...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runCoopExec(args)
+	})
+	if !errors.Is(err, sentinel) {
+		return execEnv, stderr, err
+	}
+	return execEnv, stderr, nil
+}
+
+func requireDeprecationWarningCount(t *testing.T, stderr string, want int) {
+	t.Helper()
+	got := strings.Count(stderr, coopExecCreationDeprecated)
+	if got != want {
+		t.Fatalf("deprecation warning count = %d, want %d\nstderr:\n%s", got, want, stderr)
+	}
+	if want == 0 {
+		return
+	}
+	if strings.Contains(coopExecCreationDeprecated, "\n") {
+		t.Fatal("deprecation warning constant must be a single line")
+	}
+}

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -74,11 +74,12 @@ func runCoopExec(args []string) error {
 		"starts amq wake in background, then",
 		"replaces itself with the given command via exec.",
 		"",
-		"If neither --session nor --root is given, defaults to --session collab.",
+		"If neither --session nor --root is given, defaults to the declared",
+		"default_session from .amq/launch.json, or collab when none is declared.",
 		"The agent handle is derived from the command basename unless --me is set.",
 		"",
 		"Examples:",
-		"  amq coop exec claude                              # Exec into Claude Code (session=collab)",
+		"  amq coop exec claude                              # Exec into Claude Code (declared session or collab)",
 		"  amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Codex with flags",
 		"  amq coop exec grok                                # Grok CLI, caller flags forwarded as-is",
 		"  amq coop exec --session feature-x claude          # Isolated session",
@@ -145,6 +146,12 @@ func runCoopExec(args []string) error {
 	if err != nil {
 		return fmt.Errorf("cannot derive agent handle from %q: %w (use --me to override)", cmdName, err)
 	}
+
+	rootRequested := flagWasVisited(fs, "root")
+	sessionRequested := *sessionFlag != ""
+	selectorFree := !rootRequested && !sessionRequested
+	defaultSession := defaultSessionName
+	var warnedCreation bool
 
 	// Resolve explicit --session (pure sugar for --root <base>/<session>).
 	// A fresh Git worktree has no base yet; remember that bootstrap is needed
@@ -224,6 +231,17 @@ func runCoopExec(args []string) error {
 		return fmt.Errorf("command not found: %s", cmdName)
 	}
 
+	if selectorFree {
+		defaultSession, err = declaredCoopExecSession()
+		if err != nil {
+			return err
+		}
+	}
+	creationDeprecated, err := hasBootstrapSuppressingDeclaration()
+	if err != nil {
+		return err
+	}
+
 	// Explicit named sessions use the same direct-child creation boundary as
 	// coop init/default exec. In particular, never let MkdirAll traverse a
 	// pre-existing session symlink.
@@ -238,6 +256,9 @@ func runCoopExec(args []string) error {
 			}
 		}
 		requestedRoot := root
+		if !dirExists(requestedRoot) {
+			warnCoopExecCreationDeprecated(&warnedCreation)
+		}
 		root, err = provisionCoopSession(base, *sessionFlag, []string{agentHandle}, agentHandle, cmdName)
 		if err != nil {
 			return fmt.Errorf("failed to create session root %q: %w", requestedRoot, err)
@@ -256,6 +277,9 @@ func runCoopExec(args []string) error {
 
 		if root != "" {
 			// We have a root (from --root, --session, or .amqrc) — create root + agent dirs.
+			if rootRequested {
+				warnCoopExecCreationDeprecated(&warnedCreation)
+			}
 			if err := fsq.EnsureRootDirs(root); err != nil {
 				return fmt.Errorf("failed to create root %q: %w", root, err)
 			}
@@ -306,6 +330,9 @@ func runCoopExec(args []string) error {
 			return fmt.Errorf("bootstrap resolved base %q, but coop init produced %q", bootstrapBase, base)
 		}
 		requestedRoot := filepath.Join(base, *sessionFlag)
+		if !dirExists(requestedRoot) {
+			warnCoopExecCreationDeprecated(&warnedCreation)
+		}
 		root, err = provisionCoopSession(base, *sessionFlag, []string{agentHandle}, agentHandle, cmdName)
 		if err != nil {
 			return fmt.Errorf("failed to create session root %q: %w", requestedRoot, err)
@@ -313,13 +340,17 @@ func runCoopExec(args []string) error {
 		sessionProvisioned = true
 	}
 
-	// Default to --session collab when neither --session nor --root was specified.
-	// This runs after auto-init so .amqrc exists and resolveBaseRoot() works.
-	if *sessionFlag == "" && *rootFlag == "" {
+	// Default to the declared session (or collab) when neither --session nor
+	// --root was specified. This runs after auto-init so .amqrc exists.
+	if selectorFree {
 		base := root // root is the literal .amqrc root (e.g., .agent-mail)
-		root, err = provisionCoopSession(base, defaultSessionName, []string{agentHandle}, agentHandle, cmdName)
+		requestedRoot := filepath.Join(base, defaultSession)
+		if creationDeprecated && !dirExists(requestedRoot) {
+			warnCoopExecCreationDeprecated(&warnedCreation)
+		}
+		root, err = provisionCoopSession(base, defaultSession, []string{agentHandle}, agentHandle, cmdName)
 		if err != nil {
-			return fmt.Errorf("failed to create session root %q: %w", filepath.Join(base, defaultSessionName), err)
+			return fmt.Errorf("failed to create session root %q: %w", requestedRoot, err)
 		}
 		sessionProvisioned = true
 	}
@@ -573,7 +604,11 @@ func runCoopExec(args []string) error {
 
 	// A named/default or session-shaped explicit root pins an identity
 	// independent of AM_ROOT. A custom sessionless --root clears inherited pins.
-	sessionIdentity := coopSessionIdentity(root, *sessionFlag, *rootFlag)
+	requestedSession := *sessionFlag
+	if selectorFree {
+		requestedSession = defaultSession
+	}
+	sessionIdentity := coopSessionIdentity(root, requestedSession, *rootFlag)
 	env := buildCoopExecEnvironment(baseEnv, root, agentHandle, sessionIdentity)
 
 	// Build argv: command name + agent args.

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
-	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 func runSession(args []string) error {
@@ -218,25 +217,9 @@ func loadSessionCreateAgents(base string) ([]string, error) {
 }
 
 func loadLaunchRosterHandles() ([]string, bool, error) {
-	// WA5-superseded peek: the authoritative launch.json parser lands with setup.
-	result, err := findAndLoadAmqrc()
-	if errors.Is(err, errAmqrcNotFound) {
-		return nil, false, nil
-	}
-	if err != nil {
-		return nil, false, err
-	}
-	path := filepath.Join(result.Dir, ".amq", "launch.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, false, nil
-		}
-		return nil, false, err
-	}
-	parsed, err := launch.ParseProjectConfig(data)
-	if err != nil {
-		return nil, false, fmt.Errorf("parse .amq/launch.json: %w", err)
+	parsed, ok, err := loadProjectLaunchConfig()
+	if err != nil || !ok {
+		return nil, ok, err
 	}
 	handles := make([]string, 0, len(parsed.Agents))
 	for _, agent := range parsed.Agents {

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -86,7 +86,7 @@ then bootstraps a worktree-local queue at the Git top when no eligible root
 exists; `coop exec --no-init` refuses. `coop init` explicitly targets that local
 Git top. Bare repositories require a worktree or an explicit `--root`.
 
-**Session pitfall**: `coop exec` defaults to `--session collab` (i.e., `.agent-mail/collab`). Outside `coop exec`, the base root is `.agent-mail` (no session suffix). These are different mailbox trees — don't mix them up.
+**Session pitfall**: Selector-free `coop exec` uses the declared `default_session` from `.amq/launch.json`, or `collab` (i.e., `.agent-mail/collab`). Outside `coop exec`, the base root is `.agent-mail` (no session suffix). These are different mailbox trees — don't mix them up.
 
 ### Root Resolution Truth-Table
 
@@ -156,7 +156,7 @@ amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Terminal 2
 amq coop exec grok  # Terminal 3 (optional peer) — caller flags forwarded unchanged, no baked-in bypass
 ```
 
-Without `--session` or `--root`, `coop exec` defaults to `--session collab`.
+Without `--session` or `--root`, `coop exec` uses the declared `default_session` from `.amq/launch.json`, or `collab` when none is declared. Creating a missing session or root from `coop exec` is deprecated and prints `warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
 
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
 


### PR DESCRIPTION
## Summary
- Selector-free `coop exec` honors `.amq/launch.json` `default_session` via `launch.ParseProjectConfig` (optional field defaults to `collab`; explicit empty is invalid). Session roster loading uses the same loader.
- Missing `--session`/`--root` and missing declared sessions still create in this wave, with one stable stderr warning. Existing sessions/roots and zero-config `collab` bootstrap do not warn. Corrupt `.amqrc` still counts as a declaration without preempting `AM_ROOT` routing.
- Docs updated in CLAUDE.md, COOP.md, and the amq-cli skill.

## Test plan
- [ ] `go test ./internal/cli -run TestCoopExec`
- [ ] Declared `default_session=dev` selector-free creates `dev`, not `collab`, and warns once
- [ ] Existing declared session / existing collab / zero-config collab bootstrap emit zero warnings
- [ ] Explicit missing `--session` and `--root` warn once and still create

Refs: #480

Made with [Cursor](https://cursor.com)