### PR TITLE
feat(cli): add amq launch and session resume reconciliation engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ internal/
 ├── config/        → Config management (meta/config.json)
 ├── receipt/       → Delivery receipt ledger (`drained`, `dlq`)
 ├── integration/   → Shared integration helpers plus Symphony and Kanban adapters
+├── launch/        → Launch plans, adapters, trust, leases, bindings, conversation refs, and reconciliation
 ├── swarm/         → Claude Code Agent Teams interop (team config, tasks, bridge, paths)
 ├── thread/        → Thread collection across mailboxes
 └── presence/      → Agent presence metadata
@@ -216,6 +217,10 @@ amq wake retire --me <agent> --inject-via <absolute-executable> [--inject-arg <a
 amq wake recover-owner --me <agent> [--root <path>] [--strict] [--json]
 amq upgrade
 amq setup [--root <path>] [--agents <a,b,c>] [--default-session <name>] [--launcher-preference <a,b,c>] [--layout columns] [--no-gitignore] [-y] [--json]
+amq launch [--session <name>] [--launcher <auto|commands>] [--fresh] [--allow-fresh-fallback] [--rebind] [--json]
+amq session create <name> [--root <path>] [--json]
+amq session list [--root <path>] [--json]
+amq session resume <name> [--launcher <auto|commands>] [--fresh] [--allow-fresh-fallback] [--rebind] [--json]
 amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--export] [--session-name] [--json]
 amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>] [--grok-alias <name>]
 amq coop init [--root <path>] [--agents <a,b,c>] [--no-gitignore] [--force] [--json]

--- a/COOP.md
+++ b/COOP.md
@@ -56,6 +56,38 @@ use `amq setup -y` after the caller accepts the recomputed preview.
 
 `amq coop init` remains the non-interactive provisioning primitive.
 
+### Launch and Resume
+
+Use the reconciliation engine as the daily entry point:
+
+```bash
+amq launch
+amq launch --session auth
+amq session resume auth
+```
+
+Both command forms use the same engine. It loads `.amq/launch.json`, validates
+adapter-owned argv and environment rules, checks the out-of-worktree trust
+record, acquires the session launch lease and per-agent locks, then reconciles
+the saved backend binding and conversation refs under
+`<session-root>/meta/launch/`. Native resume uses only the exact
+provider-qualified ID saved for that session and handle.
+
+The engine fails closed:
+
+- An unknown `session resume` name exits `3` with zero writes.
+- An untrusted semantic plan, stale conversation ID, unknown backend
+  inspection, foreign binding, or blocked rebind exits `6`.
+- `--fresh` deliberately starts fresh. `--allow-fresh-fallback` permits fresh
+  only when a saved identity is stale.
+- `--launcher <other> --rebind` is interactive. A foreign resource can only be
+  left in place; it is never closed by local inference.
+
+Wave A includes the honest `commands` backend only. It emits executable
+`coop exec` commands without claiming a managed terminal resource, then exits
+`6` because the operator must run those commands. JSON output includes every
+per-agent conversation disposition and the aggregate exit code.
+
 ### Running Co-op Mode
 
 **Terminal 1 - Claude Code:**

--- a/README.md
+++ b/README.md
@@ -118,7 +118,25 @@ the default session, and roster mailboxes. Use `amq setup -y` only after an
 automation caller has accepted that preview. `amq coop init` remains the
 scriptable low-level provisioning command.
 
-### 2. Start Agent Sessions
+### 2. Launch or Resume a Session
+
+```bash
+amq launch
+amq launch --session feature-x
+amq session resume feature-x
+```
+
+`launch` reads the committed roster, selects the declared default session when
+`--session` is absent, and resumes exact provider-qualified conversation IDs.
+It never uses a provider's "last" or "continue" heuristic. The first semantic
+plan, and each semantic plan change, requires an interactive trust
+confirmation stored outside the worktree. Non-interactive or `--json` calls
+exit `6` until that digest is trusted. An unknown `session resume` name exits
+`3` and writes nothing.
+
+Wave A ships the `commands` backend. It prints complete `coop exec` commands
+and exits `6` because executing them is the remaining operator action. Run the
+emitted commands in separate terminals:
 
 ```bash
 # Terminal 1 — Claude Code
@@ -537,7 +555,7 @@ Common command groups:
 | Area | Commands |
 |------|----------|
 | Core messaging | `init`, `send`, `list`, `read`, `drain`, `reply`, `thread`, `trace`, `watch`, `monitor`, `receipts` |
-| Collaboration | `setup`, `coop init`, `coop exec`, `session create`, `session list`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
+| Collaboration | `setup`, `launch`, `coop init`, `coop exec`, `session create`, `session list`, `session resume`, `swarm list`, `swarm join`, `swarm tasks`, `swarm bridge` |
 | Integrations | `integration symphony init`, `integration symphony emit`, `integration kanban bridge` |
 | Operations | `presence set`, `presence list`, `route explain`, `who`, `doctor`, `doctor --ops`, `wake check`, `wake repair`, `wake recover-owner`, `wake retire`, `cleanup`, `dlq *`, `upgrade`, `env`, `shell-setup` |
 

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1,0 +1,271 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+	"golang.org/x/term"
+)
+
+type launchCLIOptions struct {
+	session    string
+	resumeOnly bool
+}
+
+var (
+	launchIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+	launchInput      = func() *bufio.Reader { return bufio.NewReader(os.Stdin) }
+	launchStateDir   = defaultLaunchStateDir
+	launchAMQPath    = func() string { return "amq" }
+	launchAdapters   = defaultLaunchAdapters
+	launchBackends   = func() map[string]launch.Backend {
+		return map[string]launch.Backend{launch.LauncherCommands: launch.Commands{}}
+	}
+	launchHostname = os.Hostname
+)
+
+func runLaunch(args []string) error {
+	return runLaunchEngine(args, launchCLIOptions{})
+}
+
+func runSessionResume(name string, args []string) error {
+	return runLaunchEngine(args, launchCLIOptions{session: name, resumeOnly: true})
+}
+
+func runLaunchEngine(args []string, options launchCLIOptions) error {
+	fs := flag.NewFlagSet("launch", flag.ContinueOnError)
+	common := addCommonFlags(fs)
+	sessionFlag := fs.String("session", options.session, "Named session to launch or resume")
+	launcherFlag := fs.String("launcher", launch.LauncherAuto, "Launcher backend (auto or commands)")
+	freshFlag := fs.Bool("fresh", false, "Start fresh conversations for this launch")
+	allowFreshFlag := fs.Bool("allow-fresh-fallback", false, "Allow fresh conversations when saved identities are stale")
+	rebindFlag := fs.Bool("rebind", false, "Confirm a deliberate launcher binding change")
+	usageName := "amq launch [options]"
+	if options.resumeOnly {
+		usageName = "amq session resume <name> [options]"
+	}
+	usage := usageWithFlags(fs, usageName,
+		"Reconcile one existing AMQ session from the committed launch declaration.",
+		"Unknown sessions are never created. Non-interactive trust, stale identity, and Inspect uncertainty exit 6.")
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	if *freshFlag && *allowFreshFlag {
+		return UsageError("--fresh and --allow-fresh-fallback are mutually exclusive")
+	}
+	if flagWasVisited(fs, "session") && strings.TrimSpace(*sessionFlag) == "" {
+		return UsageError("--session must not be blank")
+	}
+	if options.resumeOnly && flagWasVisited(fs, "session") {
+		return UsageError("session resume takes its session name as a positional argument")
+	}
+	if strings.TrimSpace(*launcherFlag) == "" {
+		return UsageError("--launcher must not be blank")
+	}
+	if *rebindFlag && strings.TrimSpace(*launcherFlag) == launch.LauncherAuto {
+		return UsageError("--rebind requires an explicit --launcher")
+	}
+
+	cfg, present, err := loadProjectLaunchConfig()
+	if err != nil {
+		return err
+	}
+	if !present {
+		return NotFoundError("committed launch config not found; run 'amq setup'")
+	}
+	projectConfigPath, _, err := findProjectLaunchJSONPath()
+	if err != nil {
+		return err
+	}
+	projectRoot := filepath.Dir(filepath.Dir(projectConfigPath))
+	session := strings.TrimSpace(*sessionFlag)
+	if session == "" && !common.rootExplicit() {
+		session = cfg.DefaultSession
+	}
+	if common.rootExplicit() {
+		if options.resumeOnly {
+			return UsageError("session resume does not accept --root; use amq launch --root <session-root>")
+		}
+		if flagWasVisited(fs, "session") {
+			return UsageError("--session and --root are mutually exclusive")
+		}
+		session = resolveSessionName(common.Root)
+		if session == "" {
+			return UsageError("--root must select a named session root")
+		}
+	}
+	if err := validateSessionName(session); err != nil {
+		return UsageError("--session: %v", err)
+	}
+	routeSession := session
+	if common.rootExplicit() {
+		routeSession = ""
+	}
+	root, routed, err := resolveMailboxRoot(common, routeSession)
+	if err != nil {
+		return err
+	}
+	if err := guardMailboxContext("launch", root, routed, false, common.rootExplicit()); err != nil {
+		return err
+	}
+	for _, agent := range cfg.Agents {
+		if err := requireMailbox(root, agent.Handle); err != nil {
+			return err
+		}
+	}
+	identity, err := snapshotMailboxDeliveryRoot(root, routed, false)
+	if err != nil {
+		return err
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+
+	local := launch.LocalConfig{Schema: launch.LocalConfigSchema, LauncherPreference: []string{launch.LauncherCommands}}
+	localPath := filepath.Join(projectRoot, setupLocalConfigPath)
+	if parsed, _, exists, loadErr := loadOptionalLocalConfig(localPath); loadErr != nil {
+		return loadErr
+	} else if exists {
+		local = parsed
+	}
+	stateDir, err := launchStateDir()
+	if err != nil {
+		return err
+	}
+	trust, err := launch.OpenTrustStore(stateDir, projectRoot)
+	if err != nil {
+		return ActionRequiredError("open launch trust store: %v", err)
+	}
+	adapters := launchAdapters(cfg)
+	host, _ := launchHostname()
+	request := launch.ReconcileRequest{
+		ProjectRoot: projectRoot, Session: session, AMQPath: launchAMQPath(), Root: deliveryRoot,
+		Config: cfg, Launcher: strings.TrimSpace(*launcherFlag), Preferences: local.LauncherPreference,
+		Backends: launchBackends(), Adapters: adapters,
+		TrustStore: trust, Fresh: *freshFlag, AllowFreshFallback: *allowFreshFlag,
+		ResumeOnly: options.resumeOnly, Rebind: *rebindFlag, HostIdentity: host,
+	}
+	interactive := !common.JSON && launchIsTerminal()
+	if interactive {
+		reader := launchInput()
+		request.ConfirmTrust = func(plan launch.Plan, digest string) (bool, error) {
+			data, err := json.MarshalIndent(plan, "", "  ")
+			if err != nil {
+				return false, err
+			}
+			if err := writeStdout("Launch plan (%s):\n%s\n", digest, data); err != nil {
+				return false, err
+			}
+			return setupConfirm(reader, "Trust and execute this plan?")
+		}
+		request.ConfirmRebind = func(binding launch.BindingRecord, foreign bool) (launch.RebindDisposition, bool, error) {
+			defaultDisposition := string(launch.RebindClose)
+			if foreign {
+				defaultDisposition = string(launch.RebindLeave)
+			}
+			value, err := setupPromptLine(reader, "Old resource disposition (close or leave)", defaultDisposition)
+			if err != nil {
+				return "", false, err
+			}
+			disposition := launch.RebindDisposition(value)
+			confirmed, err := setupConfirm(reader, fmt.Sprintf("Rebind from %s with disposition %s?", binding.Backend, disposition))
+			return disposition, confirmed, err
+		}
+	}
+	result, err := launch.Reconcile(request)
+	if err != nil {
+		return err
+	}
+	if err := outputLaunchResult(common.JSON, result); err != nil {
+		return err
+	}
+	if result.AggregateCode == ExitSuccess {
+		return nil
+	}
+	reason := result.Reason
+	if reason == "" {
+		reason = "launch did not complete"
+	}
+	switch result.AggregateCode {
+	case ExitActionRequired:
+		return ActionRequiredError("%s", reason)
+	case ExitTimeout:
+		return TimeoutError("%s", reason)
+	default:
+		return WithExitCode(ExitError, errors.New(reason))
+	}
+}
+
+func defaultLaunchAdapters(cfg launch.ProjectConfig) map[string]launch.HarnessAdapter {
+	adapters := make(map[string]launch.HarnessAdapter, len(cfg.Agents))
+	for _, agent := range cfg.Agents {
+		switch agent.Adapter {
+		case launch.ClaudeProvider:
+			adapters[agent.Adapter] = launch.NewClaudeAdapter(agent.Command[0])
+		case launch.CodexProvider:
+			adapters[agent.Adapter] = launch.NewCodexAdapter(agent.Command[0])
+		}
+	}
+	return adapters
+}
+
+func outputLaunchResult(jsonOutput bool, result launch.ReconcileResult) error {
+	if jsonOutput {
+		return writeJSON(os.Stdout, result)
+	}
+	if result.Backend != "" {
+		if err := writeStdout("Session %s: %s via %s\n", result.Session, result.Outcome, result.Backend); err != nil {
+			return err
+		}
+	}
+	for _, agent := range result.Agents {
+		if err := writeStdout("  %s: %s", agent.Handle, agent.ConversationDisposition); err != nil {
+			return err
+		}
+		if agent.Reason != "" {
+			if err := writeStdout(" (%s)", agent.Reason); err != nil {
+				return err
+			}
+		}
+		if err := writeStdout("\n"); err != nil {
+			return err
+		}
+	}
+	for _, command := range result.Commands {
+		if err := writeStdout("  %s\n", command.Line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func defaultLaunchStateDir() (string, error) {
+	if value := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); value != "" {
+		return filepath.Join(value, "amq"), nil
+	}
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		base, err := os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(base, "amq", "state"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".local", "state", "amq"), nil
+}

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -1,0 +1,213 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+type launchFixtureAdapter struct {
+	available bool
+	reason    string
+}
+
+func (launchFixtureAdapter) Name() string               { return launch.ClaudeProvider }
+func (launchFixtureAdapter) Mode() launch.AdapterMode   { return launch.AdapterModeMint }
+func (launchFixtureAdapter) CommittedEnvKeys() []string { return nil }
+func (a launchFixtureAdapter) Capabilities(context.Context) launch.AdapterCapabilities {
+	return launch.AdapterCapabilities{
+		Provider: launch.ClaudeProvider, Mode: launch.AdapterModeMint, Available: a.available,
+		ProviderVersion: "test", Fresh: a.available, Resume: a.available, Reason: a.reason,
+	}
+}
+func (launchFixtureAdapter) PlanFresh(req launch.PlanRequest) (launch.AgentPlan, error) {
+	return launch.AgentPlan{
+		Handle: req.Handle, Argv: []string{"/usr/bin/true", req.LaunchNonce}, Cwd: req.Cwd,
+		AdapterMode: launch.AdapterModeMint, ResumePolicy: req.ResumePolicy,
+		LaunchNonce: req.LaunchNonce, ConversationID: req.LaunchNonce,
+		DynamicArgv: []launch.DynamicArg{{Index: 1, Kind: launch.DynamicArgLaunchNonce}},
+	}, nil
+}
+func (launchFixtureAdapter) PlanResume(req launch.ResumeRequest) (launch.AgentPlan, error) {
+	return launch.AgentPlan{
+		Handle: req.Handle, Argv: []string{"/usr/bin/true", req.Conversation.ID}, Cwd: req.Cwd,
+		AdapterMode: launch.AdapterModeMint, ResumePolicy: launch.ResumeEnabled,
+		LaunchNonce: req.LaunchNonce, ConversationID: req.Conversation.ID,
+		DynamicArgv: []launch.DynamicArg{{Index: 1, Kind: launch.DynamicArgConversationID}},
+	}, nil
+}
+func (launchFixtureAdapter) CaptureIdentity(launch.CaptureRequest) launch.CaptureResult {
+	return launch.CaptureResult{State: launch.CaptureUnsupported, Reason: launch.CaptureReasonAdapterMintsIdentity}
+}
+
+func launchCLIFixture(t *testing.T, sessions ...string) (string, string) {
+	t.Helper()
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	for _, key := range []string{envRoot, envBaseRoot, envRootID, envBaseRootID, envSession, envGlobalRoot} {
+		value, present := os.LookupEnv(key)
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(key, value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		})
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), []byte(`{"root":".agent-mail"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(project, ".amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	projectConfig := launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: sessions[0], Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+		Agents: []launch.ProjectAgentConfig{{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: launch.ResumeEnabled}},
+	}
+	projectData, err := launch.MarshalProjectConfig(projectConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, setupConfigPath), projectData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	localData, err := launch.MarshalLocalConfig(launch.LocalConfig{Schema: launch.LocalConfigSchema, LauncherPreference: []string{launch.LauncherCommands}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, setupLocalConfigPath), localData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := filepath.Join(project, defaultCoopRoot)
+	if err := fsq.EnsureRootDirs(base); err != nil {
+		t.Fatal(err)
+	}
+	for _, session := range sessions {
+		root := filepath.Join(base, session)
+		if err := fsq.EnsureRootDirs(root); err != nil {
+			t.Fatal(err)
+		}
+		if err := fsq.EnsureAgentDirs(root, "claude"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	state := t.TempDir()
+	launchIsTerminal = func() bool { return false }
+	launchStateDir = func() (string, error) { return state, nil }
+	launchAMQPath = func() string { return "amq" }
+	launchAdapters = func(launch.ProjectConfig) map[string]launch.HarnessAdapter {
+		return map[string]launch.HarnessAdapter{"claude": launchFixtureAdapter{available: true}}
+	}
+	launchBackends = func() map[string]launch.Backend {
+		return map[string]launch.Backend{launch.LauncherCommands: launch.Commands{}}
+	}
+	launchHostname = func() (string, error) { return "host:test", nil }
+	t.Cleanup(func() {
+		_ = os.Chdir(oldCWD)
+		launchIsTerminal = func() bool { return false }
+		launchInput = func() *bufio.Reader { return bufio.NewReader(os.Stdin) }
+		launchStateDir = defaultLaunchStateDir
+		launchAMQPath = func() string { return "amq" }
+		launchAdapters = defaultLaunchAdapters
+		launchBackends = func() map[string]launch.Backend {
+			return map[string]launch.Backend{launch.LauncherCommands: launch.Commands{}}
+		}
+		launchHostname = os.Hostname
+	})
+	return project, state
+}
+
+func TestLaunchNonInteractiveUntrustedIsExit6AndNoRuntimeWrites(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	root := filepath.Join(project, defaultCoopRoot, "collab")
+	stdout, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--json"}) })
+	if GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("exit=%d err=%v output=%s", GetExitCode(err), err, stdout)
+	}
+	var result launch.ReconcileResult
+	if json.Unmarshal([]byte(stdout), &result) != nil || result.AggregateCode != ExitActionRequired || result.Reason != "launch plan requires local trust confirmation" {
+		t.Fatalf("result=%s", stdout)
+	}
+	if _, err := os.Stat(launch.ConversationPath(root, "claude")); !os.IsNotExist(err) {
+		t.Fatalf("untrusted launch wrote conversation state: %v", err)
+	}
+}
+
+func TestLaunchAndSessionResumeKeepSessionQualifiedConversation(t *testing.T) {
+	project, _ := launchCLIFixture(t, "one", "two")
+	launchIsTerminal = func() bool { return true }
+	launchInput = func() *bufio.Reader { return bufio.NewReader(strings.NewReader("y\n")) }
+	for _, session := range []string{"one", "two"} {
+		_, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--session", session}) })
+		if GetExitCode(err) != ExitActionRequired {
+			t.Fatalf("fresh %s exit=%d err=%v", session, GetExitCode(err), err)
+		}
+	}
+	loadIdentity := func(session string) string {
+		data, err := os.ReadFile(launch.ConversationPath(filepath.Join(project, defaultCoopRoot, session), "claude"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var record launch.ConversationRecord
+		if err := json.Unmarshal(data, &record); err != nil {
+			t.Fatal(err)
+		}
+		return record.Identity.ID
+	}
+	oneID, twoID := loadIdentity("one"), loadIdentity("two")
+	if oneID == twoID {
+		t.Fatalf("sessions share conversation ID %q", oneID)
+	}
+	for session, wantID := range map[string]string{"one": oneID, "two": twoID} {
+		launchInput = func() *bufio.Reader { return bufio.NewReader(strings.NewReader("y\n")) }
+		stdout, _, err := captureEnvOutput(t, func() error { return runSession([]string{"resume", session}) })
+		if GetExitCode(err) != ExitActionRequired || !strings.Contains(stdout, wantID) {
+			t.Fatalf("resume %s did not emit exact ID %s: exit=%d output=%s err=%v", session, wantID, GetExitCode(err), stdout, err)
+		}
+	}
+}
+
+func TestLaunchMissingBinaryIsStructuredDisposition(t *testing.T) {
+	launchCLIFixture(t, "collab")
+	launchAdapters = func(launch.ProjectConfig) map[string]launch.HarnessAdapter {
+		return map[string]launch.HarnessAdapter{"claude": launchFixtureAdapter{reason: "executable_not_found"}}
+	}
+	stdout, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--json"}) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result launch.ReconcileResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Agents) != 1 || result.Agents[0].ConversationDisposition != launch.DispositionUnsupported || result.Agents[0].Reason != "executable_not_found" {
+		t.Fatalf("result=%#v", result)
+	}
+}
+
+func TestSessionResumeHelpAndInvalidNameAreUsageSafe(t *testing.T) {
+	stdout, _, err := captureEnvOutput(t, func() error { return runSession([]string{"resume", "--help"}) })
+	if err != nil || !strings.Contains(stdout, "amq session resume <name>") {
+		t.Fatalf("help output=%q err=%v", stdout, err)
+	}
+	if err := runSession([]string{"resume", "Bad.Name"}); GetExitCode(err) != ExitUsage {
+		t.Fatalf("invalid name exit=%d err=%v", GetExitCode(err), err)
+	}
+}

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -26,6 +26,7 @@ func init() {
 	commands = []CommandInfo{
 		{Name: "init", Summary: "Initialize the queue root and agent mailboxes", Handler: runInit},
 		{Name: "setup", Summary: "Configure project launch and session defaults", Handler: runSetup},
+		{Name: "launch", Summary: "Launch or resume a configured AMQ session", Handler: runLaunch},
 		{Name: "send", Summary: "Send a message", Handler: runSend},
 		{Name: "list", Summary: "List inbox messages", Handler: runList},
 		{Name: "read", Summary: "Read a message by id", Handler: runRead},
@@ -169,20 +170,23 @@ func init() {
 		},
 		{
 			Name:        "session",
-			Summary:     "Create and list named AMQ sessions",
+			Summary:     "Create, list, and resume named AMQ sessions",
 			Description: "Named session lifecycle",
 			LongDescription: []string{
 				"session create provisions a canonical named session and its roster mailboxes.",
-				"session list reports canonical sessions and safe legacy roots. Attach ships with the launch engine.",
+				"session list reports canonical sessions and safe legacy roots.",
+				"session resume uses the same fail-closed reconciliation engine as amq launch.",
 			},
 			Examples: []string{
 				"amq session create feature-x",
 				"amq session list --json",
+				"amq session resume feature-x --json",
 			},
 			Handler: runSession,
 			Children: []CommandInfo{
 				{Name: "create", Summary: "Create a named session and its roster mailboxes", Handler: runSessionCreate},
 				{Name: "list", Summary: "List sessions under the base root", Handler: runSessionList},
+				{Name: "resume", Summary: "Resume an existing session through launch reconciliation", Handler: runSession},
 			},
 		},
 		{Name: "who", Summary: "Show sessions and agents in current project", Handler: runWho},

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -92,7 +92,7 @@ func TestChildNames(t *testing.T) {
 		{name: "coop", want: []string{"init", "exec"}},
 		{name: "swarm", want: []string{"list", "join", "leave", "tasks", "claim", "complete", "fail", "block", "bridge"}},
 		{name: "receipts", want: []string{"list", "wait"}},
-		{name: "session", want: []string{"create", "list"}},
+		{name: "session", want: []string{"create", "list", "resume"}},
 		{name: "route", want: []string{"explain"}},
 	}
 
@@ -220,7 +220,7 @@ func TestPrintUsageRegistry(t *testing.T) {
 	if !strings.Contains(output, "swarm        Claude Code Agent Teams integration") {
 		t.Fatalf("printUsageRegistry output missing swarm command:\n%s", output)
 	}
-	if !strings.Contains(output, "session") || !strings.Contains(output, "Create and list named AMQ sessions") {
+	if !strings.Contains(output, "session") || !strings.Contains(output, "Create, list, and resume named AMQ sessions") {
 		t.Fatalf("printUsageRegistry output missing session command:\n%s", output)
 	}
 	if !strings.Contains(output, "Exit codes:") {

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -12,6 +12,7 @@ func TestCommandNames(t *testing.T) {
 	want := []string{
 		"init",
 		"setup",
+		"launch",
 		"send",
 		"list",
 		"read",

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -261,11 +261,11 @@ func TestPrintGroupUsageSession(t *testing.T) {
 	if !strings.Contains(output, "list    List sessions under the base root") {
 		t.Fatalf("printGroupUsage(session) missing list:\n%s", output)
 	}
-	if strings.Contains(output, "resume") {
-		t.Fatalf("printGroupUsage(session) must not advertise resume:\n%s", output)
+	if !strings.Contains(output, "resume  Resume an existing session through launch reconciliation") {
+		t.Fatalf("printGroupUsage(session) missing resume:\n%s", output)
 	}
-	if findChild(findCommand("session"), "resume") != nil {
-		t.Fatal("session must not register a resume subcommand")
+	if findChild(findCommand("session"), "resume") == nil {
+		t.Fatal("session must register a resume subcommand")
 	}
 }
 

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -22,9 +22,28 @@ func runSession(args []string) error {
 		return runSessionCreate(args[1:])
 	case "list":
 		return runSessionList(args[1:])
+	case "resume":
+		if len(args) == 1 || (len(args) > 1 && isHelp(args[1])) {
+			return runLaunchEngine([]string{"--help"}, launchCLIOptions{resumeOnly: true})
+		}
+		name, remaining, err := peelSessionResumeName(args[1:])
+		if err != nil {
+			return err
+		}
+		return runSessionResume(name, remaining)
 	default:
 		return formatUnknownSubcommand("session", args[0])
 	}
+}
+
+func peelSessionResumeName(args []string) (string, []string, error) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return "", nil, UsageError("session name required (e.g., amq session resume feature-x)")
+	}
+	if err := validateSessionName(args[0]); err != nil {
+		return "", nil, UsageError("session name: %v", err)
+	}
+	return args[0], args[1:], nil
 }
 
 type sessionExistsError struct {

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -378,13 +379,32 @@ func TestSessionListReportsCanonicalAndLegacy(t *testing.T) {
 	}
 }
 
-func TestSessionResumeIsUnknownSubcommand(t *testing.T) {
-	err := runSession([]string{"resume", "collab"})
-	if err == nil {
-		t.Fatal("session resume should not ship as not-implemented")
+func TestSessionResumeUnknownNameIsNotFoundWithZeroWrites(t *testing.T) {
+	project := isolateSessionProject(t)
+	for _, key := range []string{envRoot, envBaseRoot, envRootID, envBaseRootID, envSession, envGlobalRoot} {
+		_ = os.Unsetenv(key)
 	}
-	if GetExitCode(err) != ExitUsage {
-		t.Fatalf("exit code = %d, want %d: %v", GetExitCode(err), ExitUsage, err)
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
+	writeProjectAmqrc(t, project)
+	writeLaunchRoster(t, project, `{"schema":1,"agents":[{"handle":"claude","command":["claude"]}]}`)
+	base := filepath.Join(project, defaultCoopRoot)
+	if err := os.Mkdir(base, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	before := dirNames(t, base)
+	err = runSession([]string{"resume", "missing"})
+	if GetExitCode(err) != ExitNotFound {
+		t.Fatalf("exit code = %d, want %d: %v", GetExitCode(err), ExitNotFound, err)
+	}
+	if after := dirNames(t, base); !slices.Equal(after, before) {
+		t.Fatalf("unknown resume wrote state: before=%v after=%v", before, after)
 	}
 }
 

--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -17,6 +17,13 @@ type Backend interface {
 	Close(CloseRequest) (CloseResult, error)
 }
 
+// BackendFocuser is the optional managed attach surface. It stays separate
+// from the four-method backend floor: plan_only backends do not own resources,
+// while a managed profile that declares CapFocus must implement this seam.
+type BackendFocuser interface {
+	Focus(FocusRequest) (FocusResult, error)
+}
+
 type Capability string
 
 const (
@@ -40,6 +47,7 @@ const (
 	OutcomeCommandsEmitted Outcome = "commands_emitted"
 	OutcomeActionRequired  Outcome = "action_required"
 	OutcomeUnsupported     Outcome = "unsupported"
+	OutcomeAttached        Outcome = "attached"
 )
 
 type InspectStatus string
@@ -76,10 +84,12 @@ type Degradation struct {
 }
 
 type DetectResult struct {
-	Available    bool          `json:"available"`
-	Profile      Profile       `json:"profile"`
-	Effective    []Capability  `json:"effective"`
-	Degradations []Degradation `json:"degradations,omitempty"`
+	Available        bool          `json:"available"`
+	Profile          Profile       `json:"profile"`
+	HostIdentity     string        `json:"host_identity,omitempty"`
+	InstanceIdentity string        `json:"instance_identity,omitempty"`
+	Effective        []Capability  `json:"effective"`
+	Degradations     []Degradation `json:"degradations,omitempty"`
 }
 
 func (d DetectResult) Validate() error {
@@ -135,12 +145,17 @@ type EmittedCommand struct {
 }
 
 type CreateResult struct {
-	Outcome        Outcome          `json:"outcome"`
-	ActionRequired bool             `json:"action_required"`
-	Profile        string           `json:"profile,omitempty"`
-	Commands       []EmittedCommand `json:"commands,omitempty"`
-	Plan           []byte           `json:"plan,omitempty"`
-	Reason         string           `json:"reason,omitempty"`
+	Outcome        Outcome `json:"outcome"`
+	ActionRequired bool    `json:"action_required"`
+	Profile        string  `json:"profile,omitempty"`
+	// Binding is a managed backend's candidate runtime record. The
+	// reconciliation engine is the only layer allowed to persist it under the
+	// session lease. plan_only backends leave it empty.
+	Binding         BindingRecord                `json:"binding,omitempty"`
+	CaptureEvidence map[string][]CaptureEvidence `json:"-"`
+	Commands        []EmittedCommand             `json:"commands,omitempty"`
+	Plan            []byte                       `json:"plan,omitempty"`
+	Reason          string                       `json:"reason,omitempty"`
 }
 
 type InspectRequest struct {
@@ -160,6 +175,16 @@ type CloseRequest struct {
 }
 
 type CloseResult struct {
+	Outcome Outcome `json:"outcome"`
+	Reason  string  `json:"reason,omitempty"`
+}
+
+type FocusRequest struct {
+	Binding BindingRecord
+	Root    *fsq.DeliveryRoot
+}
+
+type FocusResult struct {
 	Outcome Outcome `json:"outcome"`
 	Reason  string  `json:"reason,omitempty"`
 }

--- a/internal/launch/conversation.go
+++ b/internal/launch/conversation.go
@@ -1,0 +1,112 @@
+package launch
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	ConversationVersion = 1
+	conversationDir     = "meta/launch/conversations"
+)
+
+// ConversationRecord is provider-qualified runtime state for one
+// (session, handle). It carries no execution authority.
+type ConversationRecord struct {
+	Version         int                  `json:"version"`
+	Handle          string               `json:"handle"`
+	State           CaptureState         `json:"state"`
+	Identity        ConversationIdentity `json:"identity,omitempty"`
+	ProviderVersion string               `json:"provider_version,omitempty"`
+	LaunchNonce     string               `json:"launch_nonce"`
+	Reason          CaptureReason        `json:"reason,omitempty"`
+}
+
+func (record ConversationRecord) Validate() error {
+	if record.Version != ConversationVersion {
+		return fmt.Errorf("unsupported conversation record version %d", record.Version)
+	}
+	if err := fsq.ValidateHandle(record.Handle); err != nil {
+		return fmt.Errorf("invalid conversation handle: %w", err)
+	}
+	if !validUUID(record.LaunchNonce) {
+		return fmt.Errorf("conversation launch nonce must be a UUID")
+	}
+	switch record.State {
+	case CapturePending:
+		if record.Identity.Provider != "" || record.Identity.ID != "" {
+			return fmt.Errorf("pending conversation must not contain an identity")
+		}
+	case CaptureReady:
+		if strings.TrimSpace(record.Identity.Provider) == "" || !validUUID(record.Identity.ID) {
+			return fmt.Errorf("ready conversation requires a provider-qualified UUID")
+		}
+	case CaptureStale, CaptureUnsupported:
+		if record.Reason == "" {
+			return fmt.Errorf("terminal conversation state %q requires a reason", record.State)
+		}
+	default:
+		return fmt.Errorf("invalid conversation state %q", record.State)
+	}
+	return nil
+}
+
+func WriteConversation(root *fsq.DeliveryRoot, lease *Lease, record ConversationRecord) error {
+	if err := lease.authorizeWrite(root); err != nil {
+		return err
+	}
+	if !lease.holdsHandle(record.Handle) {
+		return fmt.Errorf("conversation handle %q is not locked by the session lease", record.Handle)
+	}
+	if err := record.Validate(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = root.WriteFileAtomic(conversationDir, record.Handle+".json", data, 0o600)
+	return err
+}
+
+func LoadConversation(root *fsq.DeliveryRoot, handle string) (ConversationRecord, error) {
+	if root == nil {
+		return ConversationRecord{}, fmt.Errorf("missing pinned session root")
+	}
+	if err := fsq.ValidateHandle(handle); err != nil {
+		return ConversationRecord{}, err
+	}
+	file, info, err := root.OpenRegularNoFollow(filepath.Join(conversationDir, handle+".json"))
+	if err != nil {
+		return ConversationRecord{}, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		return ConversationRecord{}, fmt.Errorf("conversation record permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return ConversationRecord{}, err
+	}
+	var record ConversationRecord
+	if err := decodeStrict(data, &record); err != nil {
+		return ConversationRecord{}, fmt.Errorf("decode conversation record: %w", err)
+	}
+	if err := record.Validate(); err != nil {
+		return ConversationRecord{}, err
+	}
+	if record.Handle != handle {
+		return ConversationRecord{}, fmt.Errorf("conversation record handle %q does not match %q", record.Handle, handle)
+	}
+	return record, nil
+}
+
+func ConversationPath(sessionRoot, handle string) string {
+	return filepath.Join(sessionRoot, conversationDir, handle+".json")
+}

--- a/internal/launch/conversation_test.go
+++ b/internal/launch/conversation_test.go
@@ -1,0 +1,55 @@
+package launch
+
+import (
+	"os"
+	"testing"
+)
+
+func TestConversationRoundTripRequiresHandleLock(t *testing.T) {
+	dir, root := harnessRoot(t)
+	lease := mustAcquireLease(t, root)
+	record := ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity:    ConversationIdentity{Provider: ClaudeProvider, ID: testConversationID},
+		LaunchNonce: testLaunchNonce,
+	}
+	if err := WriteConversation(root, lease, record); err == nil {
+		t.Fatal("WriteConversation without handle lock succeeded")
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadConversation(root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Identity != record.Identity || got.LaunchNonce != record.LaunchNonce {
+		t.Fatalf("conversation = %#v, want %#v", got, record)
+	}
+	info, err := os.Stat(ConversationPath(dir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("conversation permissions = %04o", info.Mode().Perm())
+	}
+}
+
+func TestConversationRejectsCrossHandleAndPendingIdentity(t *testing.T) {
+	_, root := harnessRoot(t)
+	lease := mustAcquireLease(t, root)
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	bad := ConversationRecord{
+		Version: ConversationVersion, Handle: "codex", State: CapturePending,
+		Identity:    ConversationIdentity{Provider: CodexProvider, ID: testConversationID},
+		LaunchNonce: testLaunchNonce,
+	}
+	if err := WriteConversation(root, lease, bad); err == nil {
+		t.Fatal("cross-handle pending identity write succeeded")
+	}
+}

--- a/internal/launch/lease.go
+++ b/internal/launch/lease.go
@@ -3,7 +3,6 @@ package launch
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -71,6 +70,10 @@ func (l *Lease) LockedHandles() []string {
 		return nil
 	}
 	return slices.Clone(l.handleIDs)
+}
+
+func (l *Lease) holdsHandle(handle string) bool {
+	return l != nil && slices.Contains(l.handleIDs, handle)
 }
 
 type LeaseHeldError struct {
@@ -372,7 +375,10 @@ func generateNonce() (string, error) {
 	if _, err := rand.Read(buf[:]); err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(buf[:]), nil
+	buf[6] = (buf[6] & 0x0f) | 0x40
+	buf[8] = (buf[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16]), nil
 }
 
 func newSecret() uint64 {

--- a/internal/launch/lease_test.go
+++ b/internal/launch/lease_test.go
@@ -42,6 +42,18 @@ func TestAcquireLeaseExclusiveAndRelease(t *testing.T) {
 	}
 }
 
+func TestAcquireLeaseGeneratedNonceIsAdapterCompatibleUUID(t *testing.T) {
+	_, root := harnessRoot(t)
+	lease, err := AcquireLease(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	if !validUUID(lease.LaunchNonce()) {
+		t.Fatalf("generated launch nonce %q is not a UUID", lease.LaunchNonce())
+	}
+}
+
 func TestConcurrentAcquireExactlyOneWins(t *testing.T) {
 	const contenders = 8
 	dir := t.TempDir()

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -1,0 +1,591 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const LauncherAuto = "auto"
+
+type ConversationDisposition string
+
+const (
+	DispositionResumed         ConversationDisposition = "resumed"
+	DispositionFresh           ConversationDisposition = "fresh"
+	DispositionFreshAfterStale ConversationDisposition = "fresh_after_stale"
+	DispositionDisabled        ConversationDisposition = "disabled"
+	DispositionUnsupported     ConversationDisposition = "unsupported"
+	DispositionDegraded        ConversationDisposition = "degraded"
+)
+
+type RebindDisposition string
+
+const (
+	RebindClose RebindDisposition = "close"
+	RebindLeave RebindDisposition = "leave"
+)
+
+type ConfirmTrustFunc func(Plan, string) (bool, error)
+type ConfirmRebindFunc func(BindingRecord, bool) (RebindDisposition, bool, error)
+
+type ReconcileRequest struct {
+	Context            context.Context
+	ProjectRoot        string
+	Session            string
+	AMQPath            string
+	Root               *fsq.DeliveryRoot
+	Config             ProjectConfig
+	Launcher           string
+	Preferences        []string
+	Backends           map[string]Backend
+	Adapters           map[string]HarnessAdapter
+	TrustStore         *TrustStore
+	ConfirmTrust       ConfirmTrustFunc
+	ConfirmRebind      ConfirmRebindFunc
+	Fresh              bool
+	AllowFreshFallback bool
+	ResumeOnly         bool
+	Rebind             bool
+	HostIdentity       string
+	CrashHook          func(string) error
+}
+
+type AgentReconcileResult struct {
+	Handle                  string                  `json:"handle"`
+	Code                    int                     `json:"code"`
+	ConversationDisposition ConversationDisposition `json:"conversation_disposition"`
+	Reason                  string                  `json:"reason,omitempty"`
+}
+
+type ReconcileResult struct {
+	Session        string                 `json:"session"`
+	Backend        string                 `json:"backend,omitempty"`
+	Outcome        Outcome                `json:"outcome,omitempty"`
+	AggregateCode  int                    `json:"aggregate_code"`
+	Reason         string                 `json:"reason,omitempty"`
+	Agents         []AgentReconcileResult `json:"agents"`
+	Commands       []EmittedCommand       `json:"commands,omitempty"`
+	Plan           *Plan                  `json:"plan,omitempty"`
+	SemanticDigest string                 `json:"semantic_digest,omitempty"`
+}
+
+type plannedAgent struct {
+	plan            AgentPlan
+	record          ConversationRecord
+	write           bool
+	index           int
+	adapter         HarnessAdapter
+	providerVersion string
+}
+
+func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr error) {
+	result = ReconcileResult{Session: request.Session, Agents: []AgentReconcileResult{}}
+	if request.Context == nil {
+		request.Context = context.Background()
+	}
+	if request.Root == nil {
+		return result, fmt.Errorf("missing pinned session root")
+	}
+	if strings.TrimSpace(request.ProjectRoot) == "" || strings.TrimSpace(request.Session) == "" {
+		return result, fmt.Errorf("project root and session are required")
+	}
+	if err := request.Config.Validate(); err != nil {
+		return result, err
+	}
+	nonce, err := generateNonce()
+	if err != nil {
+		return result, err
+	}
+	planned, err := buildReconcilePlan(request, nonce, &result)
+	if err != nil {
+		return result, err
+	}
+	if len(planned) == 0 {
+		result.AggregateCode = aggregateReconcileCode(result.Agents)
+		return result, nil
+	}
+	plan := Plan{Version: PlanVersion, Agents: make([]AgentPlan, 0, len(planned))}
+	for _, agent := range planned {
+		plan.Agents = append(plan.Agents, agent.plan)
+	}
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		return result, err
+	}
+	result.Plan, result.SemanticDigest = &plan, digest
+	trusted, err := ensurePlanTrust(request, plan, digest)
+	if err != nil {
+		markPlannedAgents(&result, planned, 6, "trust_state_unreadable")
+		result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, err.Error()
+		return result, nil
+	}
+	if !trusted {
+		markPlannedAgents(&result, planned, 6, "untrusted_config_digest")
+		result.AggregateCode = 6
+		result.Outcome = OutcomeActionRequired
+		result.Reason = "launch plan requires local trust confirmation"
+		return result, nil
+	}
+
+	lease, err := AcquireLease(request.Root, nonce)
+	if err != nil {
+		markPlannedAgents(&result, planned, 6, "launch_lease_unavailable")
+		result.AggregateCode = 6
+		result.Outcome = OutcomeActionRequired
+		result.Reason = err.Error()
+		return result, nil
+	}
+	defer func() {
+		if err := lease.Release(); err != nil {
+			returnErr = errors.Join(returnErr, err)
+		}
+	}()
+	handles := make([]string, 0, len(planned))
+	for _, agent := range planned {
+		handles = append(handles, agent.plan.Handle)
+	}
+	if err := lease.LockHandles(handles...); err != nil {
+		return result, err
+	}
+	if err := callCrashHook(request.CrashHook, "lease_acquired"); err != nil {
+		return result, err
+	}
+
+	binding, hasBinding, err := loadOptionalBinding(request.Root)
+	if err != nil {
+		markPlannedAgents(&result, planned, 6, "binding_unreadable")
+		result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, err.Error()
+		return result, nil
+	}
+	attachSafe := true
+	for _, agent := range planned {
+		attachSafe = attachSafe && !agent.write
+	}
+	backendName, backend, detect, proceed, err := chooseReconcileBackend(request, binding, hasBinding, attachSafe, &result)
+	if err != nil || !proceed {
+		if err != nil {
+			code := reconcileErrorCode(err)
+			markPlannedAgents(&result, planned, code, "backend_reconciliation_failed")
+			result.AggregateCode, result.Reason = code, err.Error()
+			return result, nil
+		}
+		if result.Outcome == OutcomeAttached {
+			result.AggregateCode = aggregateReconcileCode(result.Agents)
+			return result, nil
+		}
+		markPlannedAgents(&result, planned, 6, result.Reason)
+		result.AggregateCode = 6
+		return result, nil
+	}
+	result.Backend = backendName
+
+	// Commands is the only Wave A backend and Create only emits an idempotent
+	// plan. Before Wave B adds its first managed backend, this boundary needs a
+	// durable recovery journal for a resource created before its binding write.
+	create, err := backend.Create(CreateRequest{Session: request.Session, Plan: plan, AMQPath: request.AMQPath, Root: request.Root})
+	if err != nil {
+		code := reconcileErrorCode(err)
+		markPlannedAgents(&result, planned, code, "backend_create_failed")
+		result.AggregateCode, result.Reason = code, err.Error()
+		return result, nil
+	}
+	result.Outcome, result.Commands = create.Outcome, create.Commands
+	if err := callCrashHook(request.CrashHook, "backend_created"); err != nil {
+		return result, err
+	}
+	for i := range planned {
+		agent := &planned[i]
+		if agent.plan.AdapterMode == AdapterModeCapture && agent.write {
+			capture := agent.adapter.CaptureIdentity(CaptureRequest{
+				LaunchNonce: agent.plan.LaunchNonce, ExpectedProviderVersion: agent.providerVersion,
+				Final: true, Evidence: create.CaptureEvidence[agent.plan.Handle],
+			})
+			agent.record.State, agent.record.Identity, agent.record.Reason = capture.State, capture.Identity, capture.Reason
+			if !capture.CanPersist() {
+				result.Agents[agent.index].Code = 6
+				result.Agents[agent.index].ConversationDisposition = DispositionDegraded
+				if capture.State == CaptureUnsupported && !capture.Degraded {
+					result.Agents[agent.index].Code = 0
+					result.Agents[agent.index].ConversationDisposition = DispositionUnsupported
+				}
+				result.Agents[agent.index].Reason = string(capture.Reason)
+			}
+		}
+		if agent.write {
+			if err := WriteConversation(request.Root, lease, agent.record); err != nil {
+				return result, err
+			}
+		}
+	}
+	if err := callCrashHook(request.CrashHook, "conversations_written"); err != nil {
+		return result, err
+	}
+	if create.Outcome == OutcomeCreated {
+		candidate := create.Binding
+		if candidate.Backend != backendName || candidate.Profile != detect.Profile.Identity() || candidate.LaunchNonce != nonce {
+			return result, fmt.Errorf("backend returned a binding outside the selected launch generation")
+		}
+		if err := WriteBinding(request.Root, lease, candidate); err != nil {
+			return result, err
+		}
+	}
+	if create.ActionRequired || create.Outcome == OutcomeCommandsEmitted || create.Outcome == OutcomeActionRequired {
+		for _, agent := range planned {
+			if result.Agents[agent.index].Code == 0 {
+				result.Agents[agent.index].Code = 6
+				result.Agents[agent.index].Reason = "commands_emitted"
+			}
+		}
+		result.AggregateCode = 6
+		result.Reason = "execute the emitted commands to complete launch"
+		return result, nil
+	}
+	result.AggregateCode = aggregateReconcileCode(result.Agents)
+	return result, nil
+}
+
+func buildReconcilePlan(request ReconcileRequest, nonce string, result *ReconcileResult) ([]plannedAgent, error) {
+	planned := make([]plannedAgent, 0, len(request.Config.Agents))
+	for _, cfg := range request.Config.Agents {
+		item := AgentReconcileResult{Handle: cfg.Handle}
+		adapter := request.Adapters[cfg.Adapter]
+		if adapter == nil {
+			item.ConversationDisposition, item.Reason = DispositionUnsupported, "adapter_not_registered"
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		capabilities := adapter.Capabilities(request.Context)
+		if err := ValidateAdapterCapabilities(adapter, capabilities); err != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 1, DispositionDegraded, "invalid_adapter_capabilities"
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		if !capabilities.Available {
+			item.ConversationDisposition, item.Reason = DispositionUnsupported, capabilities.Reason
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		cwd := cfg.Cwd
+		if strings.TrimSpace(cwd) == "" {
+			cwd = request.ProjectRoot
+		} else if !filepath.IsAbs(cwd) {
+			cwd = filepath.Join(request.ProjectRoot, cwd)
+		}
+		policy := cfg.ResumePolicy
+		base := PlanRequest{
+			Handle: cfg.Handle, ProjectRoot: request.ProjectRoot, Cwd: cwd,
+			LaunchNonce: nonce, ResumePolicy: policy, CommittedArgs: cfg.Command[1:], EnvOverlay: cfg.Env,
+		}
+		conversation, loadErr := LoadConversation(request.Root, cfg.Handle)
+		hasConversation := loadErr == nil
+		if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, "conversation_state_unreadable"
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		forceFresh := request.Fresh || policy == ResumeFresh || policy == ResumeDisabled
+		disposition := DispositionFresh
+		if policy == ResumeDisabled {
+			disposition = DispositionDisabled
+		}
+		var agentPlan AgentPlan
+		var err error
+		if !forceFresh && hasConversation && conversation.State == CaptureReady {
+			agentPlan, err = adapter.PlanResume(ResumeRequest{PlanRequest: base, Conversation: conversation.Identity})
+			if err == nil {
+				disposition = DispositionResumed
+			}
+		} else if !forceFresh && (request.ResumeOnly || hasConversation) {
+			err = fmt.Errorf("conversation identity is %s", conversation.State)
+		}
+		if err != nil && !forceFresh {
+			if !request.AllowFreshFallback {
+				item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, "stale_conversation"
+				result.Agents = append(result.Agents, item)
+				continue
+			}
+			base.ResumePolicy = ResumeFresh
+			agentPlan, err = adapter.PlanFresh(base)
+			disposition = DispositionFreshAfterStale
+		} else if forceFresh || !hasConversation {
+			if request.Fresh {
+				base.ResumePolicy = ResumeFresh
+			}
+			agentPlan, err = adapter.PlanFresh(base)
+		}
+		if err != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		if err := ValidateAdapterPlan(adapter, agentPlan); err != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		item.ConversationDisposition = disposition
+		result.Agents = append(result.Agents, item)
+		record := ConversationRecord{
+			Version: ConversationVersion, Handle: cfg.Handle, State: CapturePending,
+			ProviderVersion: capabilities.ProviderVersion, LaunchNonce: nonce,
+		}
+		if agentPlan.AdapterMode == AdapterModeMint {
+			record.State = CaptureReady
+			record.Identity = ConversationIdentity{Provider: adapter.Name(), ID: agentPlan.ConversationID}
+		}
+		planned = append(planned, plannedAgent{
+			plan: agentPlan, record: record, write: disposition != DispositionResumed,
+			index: len(result.Agents) - 1, adapter: adapter, providerVersion: capabilities.ProviderVersion,
+		})
+	}
+	return planned, nil
+}
+
+func ensurePlanTrust(request ReconcileRequest, plan Plan, digest string) (bool, error) {
+	if request.TrustStore == nil {
+		return false, nil
+	}
+	_, trusted, err := request.TrustStore.LoadForDigest(digest)
+	if err != nil {
+		return false, err
+	}
+	if trusted {
+		return true, nil
+	}
+	if request.ConfirmTrust == nil {
+		return false, nil
+	}
+	confirmed, err := request.ConfirmTrust(plan, digest)
+	if err != nil || !confirmed {
+		return false, err
+	}
+	return true, request.TrustStore.Replace(TrustRecord{SemanticDigest: digest})
+}
+
+func chooseReconcileBackend(request ReconcileRequest, binding BindingRecord, hasBinding, attachSafe bool, result *ReconcileResult) (string, Backend, DetectResult, bool, error) {
+	requested := strings.TrimSpace(request.Launcher)
+	if requested == "" {
+		requested = LauncherAuto
+	}
+	selected := requested
+	if requested == LauncherAuto && hasBinding {
+		selected = binding.Backend
+	}
+	if selected == LauncherAuto {
+		preferred, _, _, ok, err := selectPreferredBackend(request)
+		if err != nil {
+			return "", nil, DetectResult{}, false, err
+		}
+		if !ok {
+			result.Outcome, result.Reason = OutcomeActionRequired, "launcher_not_available"
+			return "", nil, DetectResult{}, false, nil
+		}
+		selected = preferred
+	}
+	backend := request.Backends[selected]
+	if backend == nil {
+		result.Outcome, result.Reason = OutcomeActionRequired, "launcher_not_available"
+		return selected, nil, DetectResult{}, false, nil
+	}
+	detect := backend.Detect()
+	if err := detect.Validate(); err != nil {
+		return selected, nil, detect, false, err
+	}
+	if !detect.Available {
+		result.Outcome, result.Reason = OutcomeActionRequired, "launcher_not_available"
+		return selected, backend, detect, false, nil
+	}
+	if !hasBinding {
+		return selected, backend, detect, true, nil
+	}
+	boundBackend := request.Backends[binding.Backend]
+	if boundBackend == nil {
+		result.Outcome, result.Reason = OutcomeActionRequired, "bound_launcher_not_available"
+		return selected, backend, detect, false, nil
+	}
+	boundDetect := boundBackend.Detect()
+	if err := boundDetect.Validate(); err != nil {
+		return selected, backend, detect, false, err
+	}
+	currentHost := request.HostIdentity
+	if currentHost == "" {
+		currentHost = boundDetect.HostIdentity
+	}
+	foreign := currentHost != "" && binding.HostIdentity != currentHost
+	if boundDetect.InstanceIdentity != "" && binding.InstanceIdentity != boundDetect.InstanceIdentity {
+		foreign = true
+	}
+	if foreign {
+		if !request.Rebind || request.ConfirmRebind == nil {
+			result.Outcome, result.Reason = OutcomeActionRequired, "foreign_binding"
+			return selected, backend, detect, false, nil
+		}
+		disposition, confirmed, err := request.ConfirmRebind(binding, true)
+		if err != nil {
+			return selected, backend, detect, false, err
+		}
+		if !confirmed || disposition != RebindLeave {
+			result.Outcome, result.Reason = OutcomeActionRequired, "foreign_rebind_requires_leave"
+			return selected, backend, detect, false, nil
+		}
+		return selected, backend, detect, true, nil
+	}
+	inspection, err := boundBackend.Inspect(InspectRequest{Binding: binding, Root: request.Root})
+	if err != nil {
+		return selected, backend, detect, false, err
+	}
+	switch inspection.Status {
+	case InspectUnknown:
+		result.Outcome, result.Reason = OutcomeActionRequired, "inspect_unknown"
+		return selected, backend, detect, false, nil
+	case InspectPresent:
+		if binding.Backend == selected && binding.Profile == detect.Profile.Identity() {
+			if !attachSafe {
+				result.Outcome, result.Reason = OutcomeActionRequired, "binding_present_without_resumable_conversation"
+				return selected, backend, detect, false, nil
+			}
+			focuser, ok := backend.(BackendFocuser)
+			if !ok || !detect.Profile.Has(CapFocus) {
+				result.Outcome, result.Reason = OutcomeActionRequired, "bound_launcher_cannot_focus"
+				return selected, backend, detect, false, nil
+			}
+			focused, err := focuser.Focus(FocusRequest{Binding: binding, Root: request.Root})
+			if err != nil {
+				return selected, backend, detect, false, err
+			}
+			if focused.Outcome != OutcomeAttached {
+				result.Outcome, result.Reason = OutcomeActionRequired, "bound_resource_not_focused"
+				return selected, backend, detect, false, nil
+			}
+			result.Backend, result.Outcome, result.AggregateCode = selected, OutcomeAttached, 0
+			return selected, backend, detect, false, nil
+		}
+		if !request.Rebind || request.ConfirmRebind == nil {
+			result.Outcome, result.Reason = OutcomeActionRequired, "present_binding_incompatible"
+			return selected, backend, detect, false, nil
+		}
+		disposition, confirmed, err := request.ConfirmRebind(binding, false)
+		if err != nil {
+			return selected, backend, detect, false, err
+		}
+		if !confirmed || (disposition != RebindClose && disposition != RebindLeave) {
+			result.Outcome, result.Reason = OutcomeActionRequired, "rebind_not_confirmed"
+			return selected, backend, detect, false, nil
+		}
+		if disposition == RebindClose {
+			closed, err := boundBackend.Close(CloseRequest{Binding: binding, Root: request.Root})
+			if err != nil {
+				return selected, backend, detect, false, err
+			}
+			if closed.Outcome == OutcomeUnsupported || closed.Outcome == OutcomeActionRequired {
+				result.Outcome, result.Reason = OutcomeActionRequired, "bound_resource_not_closed"
+				return selected, backend, detect, false, nil
+			}
+		}
+		return selected, backend, detect, true, nil
+	case InspectAbsent:
+		if requested == LauncherAuto {
+			preferredName, preferredBackend, preferredDetect, ok, err := selectPreferredBackend(request)
+			if err != nil {
+				return selected, backend, detect, false, err
+			}
+			if !ok {
+				result.Outcome, result.Reason = OutcomeActionRequired, "launcher_not_available"
+				return selected, backend, detect, false, nil
+			}
+			selected, backend, detect = preferredName, preferredBackend, preferredDetect
+		}
+		if requested != LauncherAuto && binding.Backend != selected && !request.Rebind {
+			result.Outcome, result.Reason = OutcomeActionRequired, "explicit_rebind_required"
+			return selected, backend, detect, false, nil
+		}
+		if binding.Backend != selected && request.Rebind {
+			if request.ConfirmRebind == nil {
+				result.Outcome, result.Reason = OutcomeActionRequired, "rebind_confirmation_required"
+				return selected, backend, detect, false, nil
+			}
+			disposition, confirmed, err := request.ConfirmRebind(binding, false)
+			if err != nil {
+				return selected, backend, detect, false, err
+			}
+			if !confirmed || (disposition != RebindClose && disposition != RebindLeave) {
+				result.Outcome, result.Reason = OutcomeActionRequired, "rebind_not_confirmed"
+				return selected, backend, detect, false, nil
+			}
+		}
+		return selected, backend, detect, true, nil
+	default:
+		return selected, backend, detect, false, fmt.Errorf("backend returned invalid Inspect status %q", inspection.Status)
+	}
+}
+
+func selectPreferredBackend(request ReconcileRequest) (string, Backend, DetectResult, bool, error) {
+	for _, name := range request.Preferences {
+		backend := request.Backends[name]
+		if backend == nil {
+			continue
+		}
+		detect := backend.Detect()
+		if err := detect.Validate(); err != nil {
+			return name, backend, detect, false, err
+		}
+		if detect.Available {
+			return name, backend, detect, true, nil
+		}
+	}
+	return "", nil, DetectResult{}, false, nil
+}
+
+func loadOptionalBinding(root *fsq.DeliveryRoot) (BindingRecord, bool, error) {
+	record, err := LoadBinding(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return BindingRecord{}, false, nil
+	}
+	return record, err == nil, err
+}
+
+func markPlannedAgents(result *ReconcileResult, planned []plannedAgent, code int, reason string) {
+	for _, agent := range planned {
+		result.Agents[agent.index].Code = code
+		result.Agents[agent.index].Reason = reason
+	}
+}
+
+func aggregateReconcileCode(agents []AgentReconcileResult) int {
+	best := 0
+	for _, agent := range agents {
+		code := agent.Code
+		if agent.ConversationDisposition == DispositionDisabled || agent.ConversationDisposition == DispositionUnsupported || agent.ConversationDisposition == DispositionFresh {
+			code = 0
+		}
+		if code == 6 {
+			return 6
+		}
+		if code == 4 {
+			best = 4
+		} else if code != 0 && best == 0 {
+			best = 1
+		}
+	}
+	return best
+}
+
+func callCrashHook(hook func(string) error, stage string) error {
+	if hook == nil {
+		return nil
+	}
+	return hook(stage)
+}
+
+func reconcileErrorCode(err error) int {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return 4
+	}
+	return 1
+}

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -1,0 +1,482 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+type reconcileAdapter struct {
+	name      string
+	mode      AdapterMode
+	available bool
+	reason    string
+}
+
+func (a reconcileAdapter) Name() string               { return a.name }
+func (a reconcileAdapter) Mode() AdapterMode          { return a.mode }
+func (a reconcileAdapter) CommittedEnvKeys() []string { return nil }
+func (a reconcileAdapter) Capabilities(context.Context) AdapterCapabilities {
+	return AdapterCapabilities{
+		Provider: a.name, Mode: a.mode, Available: a.available,
+		ProviderVersion: "test", Fresh: a.available, Resume: a.available,
+		Capture: a.available && a.mode == AdapterModeCapture, Reason: a.reason,
+	}
+}
+func (a reconcileAdapter) PlanFresh(req PlanRequest) (AgentPlan, error) {
+	plan := AgentPlan{
+		Handle: req.Handle, Argv: []string{"/usr/bin/true", req.LaunchNonce}, Cwd: req.Cwd,
+		AdapterMode: a.mode, ResumePolicy: req.ResumePolicy, LaunchNonce: req.LaunchNonce,
+		DynamicArgv: []DynamicArg{{Index: 1, Kind: DynamicArgLaunchNonce}},
+	}
+	if a.mode == AdapterModeMint {
+		plan.ConversationID = req.LaunchNonce
+	}
+	return plan, plan.Validate()
+}
+func (a reconcileAdapter) PlanResume(req ResumeRequest) (AgentPlan, error) {
+	plan := AgentPlan{
+		Handle: req.Handle, Argv: []string{"/usr/bin/true", req.Conversation.ID}, Cwd: req.Cwd,
+		AdapterMode: a.mode, ResumePolicy: ResumeEnabled, LaunchNonce: req.LaunchNonce,
+		ConversationID: req.Conversation.ID,
+		DynamicArgv:    []DynamicArg{{Index: 1, Kind: DynamicArgConversationID}},
+	}
+	return plan, plan.Validate()
+}
+func (a reconcileAdapter) CaptureIdentity(request CaptureRequest) CaptureResult {
+	if a.mode == AdapterModeCapture {
+		return captureCodexIdentity(request)
+	}
+	return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonAdapterMintsIdentity}
+}
+
+type reconcileBackend struct {
+	mu          sync.Mutex
+	name        string
+	inspect     InspectStatus
+	creates     int
+	closes      int
+	focuses     int
+	createGate  chan struct{}
+	createStart chan struct{}
+	capture     bool
+}
+
+func (b *reconcileBackend) Detect() DetectResult {
+	profile := Profile{Backend: b.name, Platform: "test", VersionRange: "*", Version: 1, Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus}}
+	return DetectResult{
+		Available: true, Profile: profile, Effective: profile.Capabilities,
+		HostIdentity: "host:test", InstanceIdentity: "instance:test",
+	}
+}
+func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
+	b.mu.Lock()
+	b.creates++
+	b.mu.Unlock()
+	if b.createStart != nil {
+		select {
+		case b.createStart <- struct{}{}:
+		default:
+		}
+	}
+	if b.createGate != nil {
+		<-b.createGate
+	}
+	result := CreateResult{Outcome: OutcomeCreated, Profile: b.Detect().Profile.Identity(), Binding: BindingRecord{
+		Version: BindingVersion, Backend: b.name, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: b.Detect().Profile.Identity(), LaunchNonce: req.Plan.Agents[0].LaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:test"}}},
+	}}
+	if b.capture {
+		evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Plan.Agents[0].LaunchNonce, false)
+		if err != nil {
+			return CreateResult{}, err
+		}
+		result.CaptureEvidence = map[string][]CaptureEvidence{req.Plan.Agents[0].Handle: {evidence}}
+	}
+	return result, nil
+}
+func (b *reconcileBackend) Inspect(InspectRequest) (InspectResult, error) {
+	return InspectResult{Status: b.inspect, Evidence: "test evidence", ActionRequired: b.inspect == InspectUnknown}, nil
+}
+func (b *reconcileBackend) Close(CloseRequest) (CloseResult, error) {
+	b.mu.Lock()
+	b.closes++
+	b.mu.Unlock()
+	return CloseResult{Outcome: Outcome("closed")}, nil
+}
+func (b *reconcileBackend) Focus(FocusRequest) (FocusResult, error) {
+	b.mu.Lock()
+	b.focuses++
+	b.mu.Unlock()
+	return FocusResult{Outcome: OutcomeAttached}, nil
+}
+
+func reconcileFixture(t *testing.T, backend Backend) ReconcileRequest {
+	t.Helper()
+	project := t.TempDir()
+	_, root := harnessRoot(t)
+	store, err := OpenTrustStore(t.TempDir(), project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backendName := backend.Detect().Profile.Backend
+	return ReconcileRequest{
+		ProjectRoot: project, Session: "collab", Root: root,
+		Config: ProjectConfig{Schema: ProjectConfigSchema, DefaultSession: "collab", Layout: LayoutIntent{Type: LayoutColumns}, Agents: []ProjectAgentConfig{
+			{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeEnabled},
+		}},
+		Launcher: backendName, Preferences: []string{backendName}, Backends: map[string]Backend{backendName: backend},
+		Adapters:   map[string]HarnessAdapter{"claude": reconcileAdapter{name: "claude", mode: AdapterModeMint, available: true}},
+		TrustStore: store, ConfirmTrust: func(Plan, string) (bool, error) { return true, nil }, HostIdentity: "host:test",
+	}
+}
+
+func writeReconcileBinding(t *testing.T, req ReconcileRequest, backend *reconcileBackend, profile string) {
+	t.Helper()
+	lease, err := AcquireLease(req.Root, testLaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := BindingRecord{
+		Version: BindingVersion, Backend: backend.name, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: profile, LaunchNonce: testLaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:test"}}},
+	}
+	if err := WriteBinding(req.Root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeReconcileConversation(t *testing.T, req ReconcileRequest, record ConversationRecord) {
+	t.Helper()
+	lease, err := AcquireLease(req.Root, testLaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles(record.Handle); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(req.Root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcileInspectUnknownMakesZeroBackendMutations(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectUnknown}
+	req := reconcileFixture(t, backend)
+	writeReconcileBinding(t, req, backend, backend.Detect().Profile.Identity())
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Reason != "inspect_unknown" || backend.creates != 0 || backend.closes != 0 {
+		t.Fatalf("result=%#v creates=%d closes=%d", result, backend.creates, backend.closes)
+	}
+}
+
+func TestReconcilePresentCompatibleAttachesWithoutCreate(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	req := reconcileFixture(t, backend)
+	writeReconcileConversation(t, req, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity: ConversationIdentity{Provider: "claude", ID: testConversationID}, LaunchNonce: testLaunchNonce,
+	})
+	writeReconcileBinding(t, req, backend, backend.Detect().Profile.Identity())
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 0 || result.Outcome != OutcomeAttached || backend.creates != 0 || backend.closes != 0 || backend.focuses != 1 {
+		t.Fatalf("result=%#v creates=%d closes=%d focuses=%d", result, backend.creates, backend.closes, backend.focuses)
+	}
+}
+
+func TestReconcilePresentIncompatibleMakesNoBackendMutation(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	req := reconcileFixture(t, backend)
+	writeReconcileBinding(t, req, backend, "test/test/v999")
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Reason != "present_binding_incompatible" || backend.creates != 0 || backend.closes != 0 || backend.focuses != 0 {
+		t.Fatalf("result=%#v creates=%d closes=%d focuses=%d", result, backend.creates, backend.closes, backend.focuses)
+	}
+}
+
+func TestReconcilePresentWithoutConversationMakesNoBackendMutation(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	req := reconcileFixture(t, backend)
+	writeReconcileBinding(t, req, backend, backend.Detect().Profile.Identity())
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Reason != "binding_present_without_resumable_conversation" || backend.creates != 0 || backend.closes != 0 || backend.focuses != 0 {
+		t.Fatalf("result=%#v creates=%d closes=%d focuses=%d", result, backend.creates, backend.closes, backend.focuses)
+	}
+}
+
+func TestReconcileForeignBindingRequiresLeaveRebind(t *testing.T) {
+	old := &reconcileBackend{name: "old", inspect: InspectPresent}
+	newBackend := &reconcileBackend{name: "new", inspect: InspectAbsent}
+	req := reconcileFixture(t, newBackend)
+	req.Backends["old"] = old
+	req.Launcher = "new"
+	writeReconcileBinding(t, req, old, old.Detect().Profile.Identity())
+	record, err := LoadBinding(req.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.HostIdentity = "host:foreign"
+	lease, err := AcquireLease(req.Root, testLaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBinding(req.Root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	_ = lease.Release()
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || newBackend.creates != 0 || old.closes != 0 {
+		t.Fatalf("blocked foreign result=%#v", result)
+	}
+	req.Rebind = true
+	req.ConfirmRebind = func(BindingRecord, bool) (RebindDisposition, bool, error) { return RebindLeave, true, nil }
+	result, err = Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 0 || newBackend.creates != 1 || old.closes != 0 {
+		t.Fatalf("leave rebind result=%#v creates=%d closes=%d", result, newBackend.creates, old.closes)
+	}
+}
+
+func TestReconcileInstanceReuseNeverClosesUnrelatedResource(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	req := reconcileFixture(t, backend)
+	writeReconcileBinding(t, req, backend, backend.Detect().Profile.Identity())
+	record, err := LoadBinding(req.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.InstanceIdentity = "instance:reused"
+	lease, err := AcquireLease(req.Root, testLaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBinding(req.Root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	_ = lease.Release()
+	req.Rebind = true
+	req.ConfirmRebind = func(BindingRecord, bool) (RebindDisposition, bool, error) { return RebindClose, true, nil }
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Reason != "foreign_rebind_requires_leave" || backend.closes != 0 || backend.creates != 0 {
+		t.Fatalf("result=%#v closes=%d creates=%d", result, backend.closes, backend.creates)
+	}
+}
+
+func TestReconcileAbsentBindingAutoSelectsPreferredBackend(t *testing.T) {
+	old := &reconcileBackend{name: "old", inspect: InspectAbsent}
+	preferred := &reconcileBackend{name: "preferred", inspect: InspectAbsent}
+	req := reconcileFixture(t, old)
+	req.Backends["preferred"] = preferred
+	req.Launcher = LauncherAuto
+	req.Preferences = []string{"preferred", "old"}
+	writeReconcileBinding(t, req, old, old.Detect().Profile.Identity())
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 0 || result.Backend != "preferred" || preferred.creates != 1 || old.creates != 0 || old.closes != 0 {
+		t.Fatalf("result=%#v preferred creates=%d old creates=%d closes=%d", result, preferred.creates, old.creates, old.closes)
+	}
+}
+
+func TestReconcileStaleHandleFailsClosedWhilePeerContinues(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	req.ResumeOnly = true
+	req.Config.Agents = append(req.Config.Agents, ProjectAgentConfig{
+		Handle: "peer", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeEnabled,
+	})
+	writeReconcileConversation(t, req, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureStale,
+		LaunchNonce: testLaunchNonce, Reason: CaptureReasonEvidenceMissing,
+	})
+	writeReconcileConversation(t, req, ConversationRecord{
+		Version: ConversationVersion, Handle: "peer", State: CaptureReady,
+		Identity:    ConversationIdentity{Provider: "claude", ID: testConversationID},
+		LaunchNonce: testLaunchNonce,
+	})
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || backend.creates != 1 || result.Plan == nil || len(result.Plan.Agents) != 1 || result.Plan.Agents[0].Handle != "peer" {
+		t.Fatalf("partial stale result=%#v creates=%d", result, backend.creates)
+	}
+	if result.Agents[0].Reason != "stale_conversation" || result.Agents[1].ConversationDisposition != DispositionResumed {
+		t.Fatalf("agent results=%#v", result.Agents)
+	}
+}
+
+func TestReconcileStaleAllowsExplicitFreshFallback(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	req.ResumeOnly = true
+	req.AllowFreshFallback = true
+	writeReconcileConversation(t, req, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureStale,
+		LaunchNonce: testLaunchNonce, Reason: CaptureReasonEvidenceMissing,
+	})
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 0 || result.Agents[0].ConversationDisposition != DispositionFreshAfterStale || backend.creates != 1 {
+		t.Fatalf("fallback result=%#v", result)
+	}
+}
+
+func TestAggregateReconcileCodePrecedence(t *testing.T) {
+	agents := []AgentReconcileResult{
+		{Handle: "failure", Code: 1, ConversationDisposition: DispositionDegraded},
+		{Handle: "timeout", Code: 4, ConversationDisposition: DispositionDegraded},
+		{Handle: "action", Code: 6, ConversationDisposition: DispositionDegraded},
+		{Handle: "expected", Code: 6, ConversationDisposition: DispositionUnsupported},
+	}
+	if got := aggregateReconcileCode(agents); got != 6 {
+		t.Fatalf("aggregate = %d, want 6", got)
+	}
+	if got := aggregateReconcileCode(agents[:2]); got != 4 {
+		t.Fatalf("aggregate without action = %d, want 4", got)
+	}
+	if got := aggregateReconcileCode(agents[3:]); got != 0 {
+		t.Fatalf("expected unsupported aggregate = %d, want 0", got)
+	}
+}
+
+func TestReconcileConcurrentLaunchCreatesOnce(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent, createGate: make(chan struct{}), createStart: make(chan struct{}, 1)}
+	req := reconcileFixture(t, backend)
+	firstDone := make(chan ReconcileResult, 1)
+	go func() {
+		result, _ := Reconcile(req)
+		firstDone <- result
+	}()
+	<-backend.createStart
+	second, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.AggregateCode != 6 || backend.creates != 1 {
+		t.Fatalf("concurrent result=%#v creates=%d", second, backend.creates)
+	}
+	close(backend.createGate)
+	first := <-firstDone
+	if first.AggregateCode != 0 || backend.creates != 1 {
+		t.Fatalf("first result=%#v creates=%d", first, backend.creates)
+	}
+}
+
+func TestReconcileThreeAgentRosterCreatesOneLayoutAndThreeRefs(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	for _, handle := range []string{"peer", "third"} {
+		req.Config.Agents = append(req.Config.Agents, ProjectAgentConfig{
+			Handle: handle, Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeEnabled,
+		})
+	}
+	result, err := Reconcile(req)
+	if err != nil || result.AggregateCode != 0 || backend.creates != 1 || result.Plan == nil || len(result.Plan.Agents) != 3 {
+		t.Fatalf("result=%#v creates=%d err=%v", result, backend.creates, err)
+	}
+	for _, handle := range []string{"claude", "peer", "third"} {
+		if _, err := LoadConversation(req.Root, handle); err != nil {
+			t.Fatalf("conversation %s: %v", handle, err)
+		}
+	}
+}
+
+func TestReconcileUntrustedAndRosterDriftAreStructured(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	req.ConfirmTrust = nil
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || backend.creates != 0 {
+		t.Fatalf("untrusted result=%#v", result)
+	}
+	req.Adapters["claude"] = reconcileAdapter{name: "claude", mode: AdapterModeMint, reason: "executable_not_found"}
+	result, err = Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 0 || result.Agents[0].ConversationDisposition != DispositionUnsupported || backend.creates != 0 {
+		t.Fatalf("roster drift result=%#v", result)
+	}
+}
+
+func TestReconcileCrashAfterCreateReleasesLeaseForRecovery(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	crash := errors.New("injected crash")
+	req.CrashHook = func(stage string) error {
+		if stage == "backend_created" {
+			return crash
+		}
+		return nil
+	}
+	if _, err := Reconcile(req); !errors.Is(err, crash) {
+		t.Fatalf("crash error = %v", err)
+	}
+	inspection, err := InspectLease(req.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.State != LeaseMissing {
+		t.Fatalf("lease after crash = %#v", inspection)
+	}
+	req.CrashHook = nil
+	result, err := Reconcile(req)
+	if err != nil || result.AggregateCode != 0 {
+		t.Fatalf("recovery result=%#v err=%v", result, err)
+	}
+}
+
+func TestReconcileCaptureEvidencePersistsExactIdentity(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent, capture: true}
+	req := reconcileFixture(t, backend)
+	req.Config.Agents[0].Adapter = "codex"
+	req.Config.Agents[0].Command = []string{"codex"}
+	req.Adapters = map[string]HarnessAdapter{"codex": reconcileAdapter{name: "codex", mode: AdapterModeCapture, available: true}}
+	result, err := Reconcile(req)
+	if err != nil || result.AggregateCode != 0 {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	record, err := LoadConversation(req.Root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State != CaptureReady || record.Identity.Provider != CodexProvider || record.Identity.ID != "019c8a2f-2b13-7000-8000-000000000001" {
+		t.Fatalf("record=%#v", record)
+	}
+}


### PR DESCRIPTION
## Summary
Add the Wave A reconciliation engine and CLI entry points for launching or resuming existing AMQ sessions.

## Changes
- add authoritative launch planning, local trust, lease and handle locking, conversation identity persistence, and five-branch backend reconciliation
- add `amq launch` and `amq session resume` with fail-closed exit behavior and Commands plan emission
- add hostile tests for session isolation, concurrency, rebind safety, stale identity, exact capture, crash retry, roster drift, and exit precedence
- document daily launch and resume behavior

Managed backends remain a Wave B concern. Before the first managed `Create`, that backend must add a durable create-to-binding recovery journal and crash matrix. The Commands backend creates no resource and its retry is idempotent plan emission.

## Testing
- [x] `make ci` passes
- [x] `go test -race ./internal/launch ./internal/cli -count=1`
- [x] Windows compile check for `internal/launch` and `internal/cli`
- [x] New tests added

## Related Issues
Refs #480