### PR TITLE
test(launch): add wave A close conformance, evidence chain, and docs sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Requires Go 1.25+ and optionally golangci-lint.
 ```
 cmd/amq/           → Entry point (delegates to cli.Run())
 internal/
-├── cli/           → Command handlers (send, list, read, drain, thread, presence, cleanup, init, watch, monitor, reply, dlq, wake, coop, swarm, integration, receipts, doctor)
+├── cli/           → Command handlers (send, list, read, drain, thread, presence, cleanup, init, setup, launch, session, watch, monitor, reply, dlq, wake, coop, swarm, integration, receipts, doctor)
 ├── fsq/           → File system queue (Maildir delivery, atomic ops, scanning)
 ├── format/        → Message serialization (JSON frontmatter + Markdown body)
 ├── config/        → Config management (meta/config.json)
@@ -217,7 +217,7 @@ amq wake retire --me <agent> --inject-via <absolute-executable> [--inject-arg <a
 amq wake recover-owner --me <agent> [--root <path>] [--strict] [--json]
 amq upgrade
 amq setup [--root <path>] [--agents <a,b,c>] [--default-session <name>] [--launcher-preference <a,b,c>] [--layout columns] [--no-gitignore] [-y] [--json]
-amq launch [--session <name>] [--launcher <auto|commands>] [--fresh] [--allow-fresh-fallback] [--rebind] [--json]
+amq launch [--session <name>] [--root <path>] [--launcher <auto|commands>] [--fresh] [--allow-fresh-fallback] [--rebind] [--json]
 amq session create <name> [--root <path>] [--json]
 amq session list [--root <path>] [--json]
 amq session resume <name> [--launcher <auto|commands>] [--fresh] [--allow-fresh-fallback] [--rebind] [--json]
@@ -241,10 +241,18 @@ amq who [--json]
 amq doctor [--root <path>] [--base-root <path>] [--ignore-session-pin] [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json] [--json-schema <1|2>]
 ```
 
-`--root` is accepted only where it is listed above. Participating commands may
+`--root` is accepted only where it is listed above. `launch --root` selects an
+existing named session root; `session resume` takes the name as a positional
+and does not accept `--root`. Participating commands may
 also accept `--json` and `--strict` (error instead of warn on unknown handles or
 unreadable/corrupt config). Global option: `--no-update-check`. Note: `init` has
 its own flags and doesn't accept these. `--json-schema` requires `--json`.
+
+**Exit codes**: `0` success, `1` general error, `2` usage, `3` not found
+(including unknown `session resume`), `4` timeout, `5` context mismatch,
+`6` action required (untrusted launch plan, unknown backend inspect, stale
+conversation, blocked rebind, or Wave A `commands` emission that still needs
+the operator to run `coop exec`). `--json` does not change these codes.
 
 **Body resolution (`send`/`reply`)**: `--body` resolves from `@file`, a literal string, or stdin. A bare `--body -`, `--body @-`, or an omitted `--body` reads stdin (standard CLI convention). A send whose resolved body is empty or whitespace-only **fails closed** with a usage error rather than delivering a blank message — pass `--allow-empty` to send a blank body intentionally. This prevents a dropped or mistyped body (e.g. `--body -` with nothing piped) from silently shipping an empty message.
 

--- a/internal/cli/launch_conformance_test.go
+++ b/internal/cli/launch_conformance_test.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+type countingLaunchBackend struct {
+	launch.Backend
+	creates *int
+	closes  *int
+}
+
+func (b countingLaunchBackend) Create(req launch.CreateRequest) (launch.CreateResult, error) {
+	*b.creates++
+	return b.Backend.Create(req)
+}
+
+func (b countingLaunchBackend) Close(req launch.CloseRequest) (launch.CloseResult, error) {
+	*b.closes++
+	return b.Backend.Close(req)
+}
+
+func TestLaunchPathDeclaredPlanOnlyEmitsCoopExec(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	launchIsTerminal = func() bool { return true }
+	launchInput = func() *bufio.Reader { return bufio.NewReader(strings.NewReader("y\n")) }
+
+	stdout, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{}) })
+	if GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("exit=%d err=%v output=%s", GetExitCode(err), err, stdout)
+	}
+	if !strings.Contains(stdout, "coop exec") {
+		t.Fatalf("plan_only launch did not emit coop exec: %s", stdout)
+	}
+	assertNoLaunchBinding(t, filepath.Join(project, defaultCoopRoot, "collab"))
+}
+
+func TestLaunchPathInspectUnknownMakesZeroMutations(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	sessionRoot := filepath.Join(project, defaultCoopRoot, "collab")
+	creates, closes := 0, 0
+	launchBackends = func() map[string]launch.Backend {
+		return map[string]launch.Backend{
+			launch.LauncherCommands: countingLaunchBackend{Backend: launch.Commands{}, creates: &creates, closes: &closes},
+		}
+	}
+	writeCommandsBinding(t, sessionRoot)
+	before := readBindingFile(t, sessionRoot)
+	launchIsTerminal = func() bool { return true }
+	launchInput = func() *bufio.Reader { return bufio.NewReader(strings.NewReader("y\n")) }
+
+	_, _, trustErr := captureEnvOutput(t, func() error { return runLaunch([]string{}) })
+	if GetExitCode(trustErr) != ExitActionRequired || !strings.Contains(trustErr.Error(), "inspect_unknown") {
+		t.Fatalf("interactive inspect_unknown: exit=%d err=%v", GetExitCode(trustErr), trustErr)
+	}
+	stdout, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--json"}) })
+	if GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("exit=%d err=%v output=%s", GetExitCode(err), err, stdout)
+	}
+	var result launch.ReconcileResult
+	if json.Unmarshal([]byte(stdout), &result) != nil || result.Reason != "inspect_unknown" {
+		t.Fatalf("result=%s", stdout)
+	}
+	if creates != 0 || closes != 0 {
+		t.Fatalf("Inspect unknown mutated backend: creates=%d closes=%d", creates, closes)
+	}
+	if after := readBindingFile(t, sessionRoot); after != before {
+		t.Fatal("Inspect unknown mutated the seeded binding")
+	}
+}
+
+func TestLaunchPathTypoRefusalUnknownSession(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	before := snapshotTree(t, project)
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runSession([]string{"resume", "no-such-session"})
+	})
+	if GetExitCode(err) != ExitNotFound {
+		t.Fatalf("exit=%d err=%v output=%s", GetExitCode(err), err, stdout)
+	}
+	after := snapshotTree(t, project)
+	if strings.Join(after, "\n") != strings.Join(before, "\n") {
+		t.Fatalf("unknown resume mutated the tree\nbefore:\n%s\nafter:\n%s", strings.Join(before, "\n"), strings.Join(after, "\n"))
+	}
+}
+
+func TestWaveACloseEvidenceSetupLaunchResume(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	clearPinnedSessionEnv(t)
+	setupOut, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude", "--no-gitignore", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("setup -y: %v\n%s", err, setupOut)
+	}
+
+	overlayLaunchEngine(t)
+
+	untrustedOut, _, untrustedErr := captureEnvOutput(t, func() error { return runLaunch([]string{"--json"}) })
+	if GetExitCode(untrustedErr) != ExitActionRequired {
+		t.Fatalf("untrusted launch exit=%d err=%v output=%s", GetExitCode(untrustedErr), untrustedErr, untrustedOut)
+	}
+	if !strings.Contains(untrustedOut, "launch plan requires local trust confirmation") {
+		t.Fatalf("untrusted output missing trust reason: %s", untrustedOut)
+	}
+
+	unknownOut, _, unknownErr := captureEnvOutput(t, func() error {
+		return runSession([]string{"resume", "missing"})
+	})
+	if GetExitCode(unknownErr) != ExitNotFound {
+		t.Fatalf("unknown resume exit=%d err=%v output=%s", GetExitCode(unknownErr), unknownErr, unknownOut)
+	}
+
+	launchIsTerminal = func() bool { return true }
+	launchInput = func() *bufio.Reader { return bufio.NewReader(strings.NewReader("y\n")) }
+	trustedOut, _, trustedErr := captureEnvOutput(t, func() error { return runLaunch([]string{}) })
+	if GetExitCode(trustedErr) != ExitActionRequired {
+		t.Fatalf("trusted launch exit=%d err=%v output=%s", GetExitCode(trustedErr), trustedErr, trustedOut)
+	}
+	if !strings.Contains(trustedOut, "coop exec") {
+		t.Fatalf("trusted launch did not emit coop exec: %s", trustedOut)
+	}
+
+	t.Logf("evidence setup: %s", strings.TrimSpace(setupOut))
+	t.Logf("evidence untrusted launch: %s", strings.TrimSpace(untrustedOut))
+	t.Logf("evidence unknown resume: %v", unknownErr)
+	t.Logf("evidence commands emission: %s", strings.TrimSpace(trustedOut))
+	_ = project
+}
+
+func overlayLaunchEngine(t *testing.T) {
+	t.Helper()
+	state := t.TempDir()
+	launchIsTerminal = func() bool { return false }
+	launchStateDir = func() (string, error) { return state, nil }
+	launchAMQPath = func() string { return "amq" }
+	launchAdapters = func(launch.ProjectConfig) map[string]launch.HarnessAdapter {
+		return map[string]launch.HarnessAdapter{"claude": launchFixtureAdapter{available: true}}
+	}
+	launchBackends = func() map[string]launch.Backend {
+		return map[string]launch.Backend{launch.LauncherCommands: launch.Commands{}}
+	}
+	launchHostname = func() (string, error) { return "host:test", nil }
+	t.Cleanup(func() {
+		launchIsTerminal = func() bool { return false }
+		launchInput = func() *bufio.Reader { return bufio.NewReader(os.Stdin) }
+		launchStateDir = defaultLaunchStateDir
+		launchAMQPath = func() string { return "amq" }
+		launchAdapters = defaultLaunchAdapters
+		launchBackends = func() map[string]launch.Backend {
+			return map[string]launch.Backend{launch.LauncherCommands: launch.Commands{}}
+		}
+		launchHostname = os.Hostname
+	})
+}
+
+func clearPinnedSessionEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{envRoot, envBaseRoot, envRootID, envBaseRootID, envSession, envGlobalRoot} {
+		value, present := os.LookupEnv(key)
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(key, value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		})
+	}
+}
+
+func writeCommandsBinding(t *testing.T, sessionRoot string) {
+	t.Helper()
+	identity, err := fsq.SnapshotDeliveryRoot(sessionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(sessionRoot, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	lease, err := launch.AcquireLease(root, "nonce-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := launch.BindingRecord{
+		Version: launch.BindingVersion, Backend: launch.CommandsBackendName,
+		HostIdentity: "host:test", InstanceIdentity: "commands:test",
+		Profile: launch.CommandsProfile().Identity(), LaunchNonce: "nonce-test",
+		Resources: launch.ResourceIdentitySet{Version: launch.ResourceSetVersion, Resources: []launch.ResourceIdentity{{OpaqueID: "resource:test"}}},
+	}
+	if err := launch.WriteBinding(root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertNoLaunchBinding(t *testing.T, sessionRoot string) {
+	t.Helper()
+	identity, err := fsq.SnapshotDeliveryRoot(sessionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(sessionRoot, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	if _, err := launch.LoadBinding(root); err == nil {
+		t.Fatal("plan_only launch wrote a binding")
+	}
+}
+
+func readBindingFile(t *testing.T, sessionRoot string) string {
+	t.Helper()
+	data, err := os.ReadFile(launch.BindingPath(sessionRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func snapshotTree(t *testing.T, root string) []string {
+	t.Helper()
+	var names []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		names = append(names, rel+"\t"+info.Mode().String())
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return names
+}

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -147,13 +147,27 @@ Before diving in, match the task to the right workflow — this avoids wasted ef
 ## Quick Start
 
 ```bash
-# One-time project setup
-amq coop init
+# One-time project setup (preview, then write .amqrc, .amq/launch.json, default session)
+amq setup
+amq setup -y   # automation only, after the caller accepted that preview
 
-# Per-session (one command per terminal — defaults to --session collab)
-amq coop exec claude -- --dangerously-skip-permissions  # Terminal 1
-amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Terminal 2
-amq coop exec grok  # Terminal 3 (optional peer) — caller flags forwarded unchanged, no baked-in bypass
+# Daily entry: reconcile the declared session (never creates an unknown name)
+amq launch
+amq launch --session feature-x
+amq session resume feature-x
+```
+
+The first semantic plan, and each plan change, needs an interactive trust
+confirmation stored outside the worktree. Non-interactive or `--json` calls
+exit `6` until that digest is trusted. An unknown `session resume` name exits
+`3` and writes nothing. Wave A prints complete `coop exec` commands and exits
+`6` because running them is the remaining operator action:
+
+```bash
+# Then run the emitted commands, one terminal each
+amq coop exec claude -- --dangerously-skip-permissions
+amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
+amq coop exec grok  # optional peer — caller flags forwarded unchanged
 ```
 
 Without `--session` or `--root`, `coop exec` uses the declared `default_session` from `.amq/launch.json`, or `collab` when none is declared. Creating a missing session or root from `coop exec` is deprecated and prints `warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
@@ -246,6 +260,7 @@ Treat AMQ's process exit code as the stable machine contract:
 | `3` | Not found. A requested resource such as a mailbox, message, session, agent, or configuration does not exist. |
 | `4` | Timeout. A watch, monitor, receipt wait, or delivery wait reached its deadline. |
 | `5` | Context mismatch. A syntactically valid route was refused, including a pin conflict or an ineligible implicit root inside Git. |
+| `6` | Action required. The command cannot proceed without an operator action (untrusted launch plan, unknown backend inspect, stale conversation token, blocked rebind, or emitted `coop exec` commands still to run). |
 
 Do not parse stderr prose as a stable discriminator. `--json` preserves the
 same process exit codes. A read-only `list` on a mismatched session pin warns
@@ -452,7 +467,7 @@ Note: The `agent@name` inline syntax (e.g., `codex@infra`) is for cross-project 
 2. If the name matches a session, use `--session <name>` on the send command
 3. If it matches both a session and an agent handle, prefer the session interpretation when the user's phrasing implies a group/context ("on X", "in X", "the X team"), and the agent interpretation when it implies a person ("ask X", "tell X")
 4. If the target session differs from your current session (`$AM_ROOT` basename), use `--session <name>`
-5. Never guess — if the name doesn't appear in `amq who --json` output, tell the user (it may need `coop exec --session <name>` to initialize)
+5. Never guess — if the name doesn't appear in `amq who --json` output, tell the user (it may need `amq session create <name>`)
 6. For cross-project routing (different repo), use `--project` instead — see Cross-Project Routing section
 
 ## Messaging


### PR DESCRIPTION
## Summary
- Close Wave A of #480: CLI-path conformance for `amq launch` / `session resume` (plan_only emission, Inspect-unknown zero mutations, typo-refusal) plus the setup → untrusted `--json` → unknown resume → trusted commands-emission evidence chain.
- Docs sweep: skill Quick Start and exit code 6; CLAUDE.md `launch --root` and exit-code note. README and COOP.md were already consistent. Skill version left for Release Please.
- Documented Wave A limits (not engine changes): organic `commands` launch never writes a binding; a fresh-to-resume plan change requires a second trust confirmation.

## Test plan
- [x] `go test ./internal/cli ./internal/launch ./internal/fsq`
- [x] `make check-skills`
- [x] Pre-push `make ci` (vet, lint, test, smoke)


Made with [Cursor](https://cursor.com)