### PR TITLE
docs: unify onboarding and extract operational references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # AGENTS.md
 
-This file exists for Codex compatibility. [`CLAUDE.md`](./CLAUDE.md) is the single source of truth for repository instructions.
+This file is the Codex compatibility shim. Follow [`CLAUDE.md`](./CLAUDE.md)
+for repository instructions.
 
 ## Codex Notes
 
-- No repository-specific Codex-only rules are defined here; follow `CLAUDE.md`.
+- No repository-specific Codex-only rules are defined.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,770 +1,254 @@
 # CLAUDE.md
 
-This is the master agent instruction file for this repository. Both Claude Code and Codex should follow these guidelines. `AGENTS.md` exists only as a Codex compatibility shim and should contain only Codex-specific notes.
+This is the repository instruction file for Claude Code and Codex. `AGENTS.md`
+is a Codex compatibility shim and contains no duplicate project guidance.
 
 ## Project Overview
 
-Agent Message Queue (AMQ) is a lightweight, file-based message delivery system for local inter-agent communication. It uses Maildir-style atomic delivery (tmp→new→cur) for crash-safe messaging between coding agents on the same machine. No daemon, database, or server required. Conceptually, it is a local interoperability bus for agent sessions: AMQ manages the conversation, while orchestrators such as Claude Code teams, Codex workflows, Kanban, and Symphony keep owning the task.
-
-AMQ owns agent-to-agent messaging, thread continuity, cross-project/session routing, handoff state, and `doctor --ops`. It does not own task decomposition, worktree management, dependency scheduling, PR landing, or cron/scheduler execution.
+Agent Message Queue (AMQ) is a daemon-free, file-based message bus for local
+coding agents. Maildir-style `tmp -> new -> cur` delivery gives crash-safe
+messages without a database or server. AMQ owns messaging, threads, routing,
+receipts, handoff state, and operational diagnosis. Orchestrators continue to
+own worktrees, dependency scheduling, task decomposition, and PR landing.
 
 ## Release Contract
 
 - Release Please maintains the release PR from conventional squash commits on
-  `main`. Do not create manual release branches, tags, or GitHub releases.
-- A push to `main` updates the AvivSinai marketplace immediately for `amq-cli` and `amq-spec`.
-- Keep one version across `CHANGELOG.md`, the release-please manifest,
-  skill/plugin metadata, and the release commit. Release Please opens PRs only;
-  after a release PR merges, `release.yml` validates that exact commit, creates
-  the matching tag, publishes GitHub/Homebrew artifacts, and uses the committed
-  changelog entry as the GitHub release notes.
-- PR titles must follow `type(scope): description`; the repository uses
-  squash-only merges so the title becomes the conventional commit on `main`.
-  Use `BEGIN_COMMIT_OVERRIDE` in a merged PR body or edit the release PR when a
-  change needs multiple or richer release-note entries. Each override entry
-  must be one conventional header of at most 72 characters, separated from
-  adjacent entries by a blank line.
+  `main`. Do not create release branches, tags, or GitHub releases manually.
+- A push to `main` updates the AvivSinai marketplace for `amq-cli` and
+  `amq-spec`.
+- Keep one version across `CHANGELOG.md`, `.release-please-manifest.json`, and
+  skill/plugin metadata. After the release PR merges, `release.yml` validates
+  that commit, creates the tag, and publishes GitHub and Homebrew artifacts.
+- PR titles use `type(scope): description`. Squash merge makes the title the
+  conventional commit on `main`. Use `BEGIN_COMMIT_OVERRIDE` in the PR body,
+  or edit the release PR, when release notes need multiple entries. Each entry
+  is one conventional header of at most 72 characters, separated by a blank
+  line.
 
 ## Operational Constraints
 
-- Handles must be lowercase, match `[a-z0-9_-]+`, and must not start with `-`.
-- Never edit queue files directly; use the CLI for all mailbox operations.
-- Cleanup is explicit via `amq cleanup`; do not add automatic deletion behavior.
+- Handles are lowercase, match `[a-z0-9_-]+`, and do not start with `-`.
+- Use the CLI for mailbox operations. Never edit queue files directly.
+- Cleanup is explicit through `amq cleanup`; do not add automatic deletion.
+- AMQ remains daemon-free. Supervisors can run `wake` or `monitor`, but AMQ
+  does not own their lifecycle.
 
-## Build & Development Commands
+## Build and Development Commands
 
 ```bash
-make build          # Compile: go build -o amq ./cmd/amq
-make test           # Run tests: go test ./...
-make fmt            # Format code: gofmt -w
-make vet            # Run go vet
-make lint           # Run golangci-lint
-make ci             # Full CI: fmt-check → vet → lint → test
+make build          # go build -o amq ./cmd/amq
+make test           # go test ./...
+make fmt            # gofmt -w
+make vet            # go vet
+make lint           # golangci-lint
+make ci             # fmt-check, vet, lint, test, smoke checks
+make check-skills   # validate canonical and symlinked skill content
 ```
 
-Requires Go 1.25+ and optionally golangci-lint.
+Go 1.25+ is required. `golangci-lint` is optional for local development and
+required by `make lint` and `make ci`.
 
 ## Architecture
 
-```
-cmd/amq/           → Entry point (delegates to cli.Run())
-internal/
-├── cli/           → Command handlers (send, list, read, drain, thread, presence, cleanup, init, setup, launch, session, watch, monitor, reply, dlq, wake, coop, swarm, integration, receipts, doctor)
-├── fsq/           → File system queue (Maildir delivery, atomic ops, scanning)
-├── format/        → Message serialization (JSON frontmatter + Markdown body)
-├── config/        → Config management (meta/config.json)
-├── receipt/       → Delivery receipt ledger (`drained`, `dlq`)
-├── integration/   → Shared integration helpers plus Symphony and Kanban adapters
-├── launch/        → Launch plans, adapters, trust, leases, bindings, conversation refs, and reconciliation
-├── swarm/         → Claude Code Agent Teams interop (team config, tasks, bridge, paths)
-├── thread/        → Thread collection across mailboxes
-└── presence/      → Agent presence metadata
+```text
+cmd/amq/             CLI entry point
+cmd/amq-keepalive/   macOS wake supervisor companion
+internal/cli/        Command handlers and routing policy
+internal/fsq/        Maildir delivery, atomic operations, and scans
+internal/format/     JSON frontmatter plus Markdown message serialization
+internal/config/     Queue and project configuration
+internal/receipt/    Consumer-local drained and DLQ receipts
+internal/integration Shared adapter support for Symphony and Kanban
+internal/launch/     Plans, adapters, trust, leases, bindings, and resume state
+internal/keepalive/  Companion registry, adapters, hooks, and supervision
+internal/sessionguard Shared fail-closed session decision table
+internal/swarm/      Claude Code Agent Teams interoperability
+internal/thread/     Cross-mailbox thread collection
+internal/presence/   Agent presence metadata
 ```
 
-**Mailbox Layout**:
-```
-<root>/agents/<agent>/inbox/{tmp,new,cur}/  → Incoming messages
-<root>/agents/<agent>/outbox/sent/          → Sent copies
-<root>/agents/<agent>/receipts/             → Consumer-local delivery receipts
-<root>/agents/<agent>/dlq/{tmp,new,cur}/    → Dead letter queue
+Mailbox layout:
+
+```text
+<root>/agents/<agent>/inbox/{tmp,new,cur}/
+<root>/agents/<agent>/outbox/sent/
+<root>/agents/<agent>/receipts/
+<root>/agents/<agent>/dlq/{tmp,new,cur}/
 ```
 
 ## Core Concepts
 
-**Atomic Delivery**: Messages written to `tmp/`, fsynced, then atomically renamed to `new/`. Readers only scan `new/` and `cur/`, never seeing incomplete writes.
+**Atomic delivery**: Writers create and sync a file under `tmp`, then rename it
+atomically into `new`. Readers scan only `new` and `cur`.
 
-**Message Format**: JSON frontmatter followed by `---` and Markdown body:
-- `schema` — Format version (currently 1)
-- `id` — Unique message ID (timestamp + pid + random)
-- `from` — Sender handle
-- `to` — Recipient handles (array)
-- `thread` — Thread ID (auto-generated for P2P: `p2p/<a>__<b>`)
-- `subject` — Message subject
-- `created` — RFC3339Nano timestamp
-- `refs` — Related message IDs
-- `priority` — `urgent`, `normal`, or `low`
-- `kind` — Message type (see Message Kinds below)
-- `labels` — Arbitrary tags for filtering
-- `context` — JSON object with additional context (paths, focus, etc.)
-- `reply_to` — Cross-session/cross-project reply routing hint
-- `reply_project` — Sender project for cross-project replies
-- `from_project` — Sender project for cross-project identity
+**Message format**: JSON frontmatter is followed by `---` and a Markdown body.
+The header contains schema, ID, sender, recipients, thread, subject, creation
+time, refs, priority, kind, labels, context, and optional reply-routing fields.
+P2P thread names use `p2p/<lower_handle>__<higher_handle>`.
 
-**Thread Naming**: P2P threads use lexicographic ordering: `p2p/<lower_agent>__<higher_agent>`
+**Receipts**: Consumers write `drained` or `dlq` receipts under their own
+mailbox. Use `receipts list`, `receipts wait`, or `send --wait-for` to inspect
+delivery without treating a wake notification as consumption proof.
 
-**Receipt Ledger**: Delivery outcomes are recorded as consumer-local receipts under `agents/<consumer>/receipts/`. Stages are `drained` and `dlq`. Use `amq receipts list`, `amq receipts wait`, or `amq send --wait-for <stage>` to query or block on them.
+**Sessions**: Named sessions are child queue roots. A participating shell is
+pinned by `AM_ROOT`, `AM_BASE_ROOT`, and `AM_SESSION`; AMQ-managed identity
+tokens authenticate roots. Participating commands fail closed on a mismatch.
+Use `--session` or `--project` for routing, not a foreign raw `--root`. See
+[Session routing and safety](docs/session-routing.md).
 
-**Extension Metadata Namespaces**: Higher-level layers may store their own metadata under reserved extension directories:
-```
-<AM_ROOT>/extensions/<layer>/
-<AM_ROOT>/agents/<handle>/extensions/<layer>/
-```
-Layer names must use lowercase ASCII letters, digits, hyphen, underscore, and dot (for example `io.github.omriariav.amq-squad`). AMQ will not create files inside layer-owned directories, and `amq cleanup` does not remove extension directories unless a future command explicitly targets extension metadata. Layers may publish a passive root manifest at `<AM_ROOT>/extensions/<layer>/manifest.json`; `amq doctor --json` may report it, but AMQ must not execute extension code or invoke hooks from manifests.
+**Wake state**: Wake ownership, injector targets, lifecycle serialization,
+readiness, and repair continuity have separate commit domains. Never infer one
+from another or weaken an uncertain state. See [Wake operations](docs/wake-operations.md),
+[wake state invariants](docs/wake-state-invariants.md), and the
+[doorbell acknowledgement policy](docs/wake-doorbell-acknowledgement.md).
 
-**Environment Variables**: `AM_ROOT` (queue root, e.g., `.agent-mail/collab`), `AM_ME` (agent handle), `AM_BASE_ROOT` (authorized parent for named-session routing, or the exact root for a sessionless pin), `AM_SESSION` (independent session identity set by `coop exec` and every shell-mode `amq env`, empty for sessionless roots), `AMQ_GLOBAL_ROOT` (global root fallback for orchestrator-spawned agents), `AMQ_NO_UPDATE_CHECK` (disable update check), `AMQ_WAKE_NO_SELF_UPGRADE` (disable automatic wake self-upgrade with `1`, `true`, `yes`, or `on`)
-
-**Session Layout**: The default base root directory is `.agent-mail/`. `.amqrc` can configure that root explicitly, but the default `.agent-mail/<session>` layout is also recognized without `.amqrc`. Selector-free `coop exec` uses the declared `default_session` from `.amq/launch.json`, or `collab` when none is declared. Use `--session` to override:
-```
-.agent-mail/              ← default base root (configurable in `.amqrc`)
-.agent-mail/collab/       ← default session (coop exec without --session or --root, unless launch.json declares another)
-.agent-mail/auth/         ← isolated session (via --session auth)
-.agent-mail/api/          ← isolated session (via --session api)
-```
-
-`AM_ROOT` points to the queue root. When `--root` is explicitly provided, it takes precedence over `AM_ROOT`. `send` and `reply` emit a `note:` on stderr when an explicit `--root` overrides `AM_ROOT`.
-
-**Cross-tree send guard**: A direct `--root` is root *selection*, not federation routing. `send` refuses an explicit `--root` that targets a different base tree than the caller's own active session (`AM_ROOT`/`AM_BASE_ROOT`) when no routing dimension (`--project`/`--session`/`--from-session`) is given — such a message carries no sender-origin metadata, so the recipient could not reply and a naive reply would loop into their own tree. Replyable cross-tree messaging must use `--project`/`--session`, which stamp the routing headers. With no session env set (bare-root scripts/CI), the guard does not fire; a direct `--root` cross-tree send in that case can still produce an unreplyable message — the documented cost of keeping bare-root sends working.
-
-**Session-root guard**: `read`, `drain`, `monitor`, `watch`, and all DLQ commands compare their resolved target against the exact context pinned by `AM_BASE_ROOT`/`AM_SESSION` before inspecting or moving mailbox state; `watch` and `monitor` revalidate the same guard during live waits and abort with the same exit-5 refusal if a repin appears mid-wait. `send` and `reply` apply the same check to their local source. For named sessions `AM_BASE_ROOT` is the authorized parent; for sessionless contexts it is the exact root and `AM_SESSION` is empty. A mismatch exits with code 5; use `--session <name>` as the deliberate routing dimension. An implicit participating command also refuses when its active pin conflicts with an initialized cwd-local queue discovered from a project `.amqrc` or repo-local `.agent-mail`; AMQ does not silently choose between them. The narrow exception is a live identity-bound sessionless pin: when both identity tokens authenticate its exact root, that explicit context outranks ambient cwd discovery. Named, legacy, incomplete, stale, or mismatched pins still refuse. Otherwise, repin to the cwd-local queue, use deliberate `--session`/`--project` routing, or pass an explicit `--root` to confirm the active queue. Explicit roots remain subject to the ordinary pin checks. The raw-root escape hatch is `--ignore-session-pin`, which requires a non-empty explicit `--root`; explicitly blank `--root`/`--session` values are usage errors. Target routing never authorizes a mismatched source. `list` warns instead of refusing so it remains a non-destructive inspection path. `doctor --root` likewise selects an exact inspection target without repinning the shell: inspection continues with a mismatch warning. Repair is allowed when the target is the authenticated pinned base root or the caller supplies `--ignore-session-pin`; other mismatches are reported as structured doctor errors, repair is skipped, and the doctor process continues with exit 0. `--base-root` supplies config authority only and never waives the pin. The exact base-backlog inspection command is quiet only when its explicit root is the current pin's own base root, identity-authenticated when tokens are present. With no positive session/tree evidence, scripts and CI remain fail-open. A missing mailbox is a not-found error. Empty `drain` and `list --new` results perform a shallow sibling-session scan and write exact `amq list --session <name> --me <handle> --new` inspection commands to stderr; `doctor --ops` reports the same condition as `sibling_backlog` hints. `doctor --ops --json` adds a structured `backlog` object to `base_backlog` hints with the target root, current session, agent, pending count, and exact command. Known limitation: `send --from-session` remains a double-explicit legacy route from its supplied raw base; callers must ensure that base is intentional until the follow-up resolver work lands.
-
-The same doctor mutation rule applies to `--ops --fix-wake-locks`: a target
-outside the authenticated pinned base is inspected but its wake locks are not
-changed; the structured refusal is reported with process exit 0 unless
-`--ignore-session-pin` is supplied.
-
-**Environment context replacement**: Every shell-mode `amq env` output replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`, and `AM_SESSION` as one context. Sessionless output pins `AM_BASE_ROOT` to the exact root and emits an empty `AM_SESSION`; `--export` additionally prints a pin note. An ambient root that conflicts with an existing pin is rejected unless a non-empty `--root` or `--session` explicitly repins it. `amq env --session` routes from a valid existing pin base before consulting cwd configuration.
-
-**Session Configuration**: The `amq env` command outputs shell commands to set environment variables. It reads configuration from (highest to lowest precedence):
-- **Root**: explicit `--root` > env (`AM_ROOT`) > project-local `.amqrc` > `AMQ_GLOBAL_ROOT` > implicit fallbacks. Inside Git, only repo-local `.agent-mail` is eligible; outside Git, `~/.amqrc` precedes detected `.agent-mail`.
-- **Me**: flags > env (`AM_ME`)
-
-That fail-closed rule applies to participating commands. `coop exec` honors root
-precedence before bootstrap; when no eligible root exists, it initializes
-`.agent-mail` at the worktree top, including explicit `--session <name>`.
-Creating a missing named session or `--root` this way is deprecated and prints
-`warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
-Use `amq session create <name>` or `amq init --root` instead. Zero-config
-`collab` bootstrap in a repo with neither `.amqrc` nor `.amq/launch.json` does
-not warn. `coop init` is the explicit local-bootstrap command and also targets
-the Git top. `coop exec --no-init` keeps the refusal. Bare repositories cannot
-host this implicit bootstrap; use a worktree or `--root`.
-
-Note: `.amqrc` configures the root directory. Agent identity (`me`) is set per-terminal via `--me` or `AM_ME`.
-Auto-detect covers the default `.agent-mail` layout in the current tree. A
-project `.amqrc` is still required for custom root names and peer
-configuration. If a project `.amqrc` exists
-but cannot be read or parsed, AMQ refuses lower-precedence fallback routing;
-an explicit `--root` or `AM_ROOT` can intentionally override it.
-
-The `.amqrc` file is JSON:
-```json
-{"root": ".agent-mail"}
-```
-
-For cross-project federation, `.amqrc` can also include `project` and `peers`:
-```json
-{
-  "root": ".agent-mail",
-  "project": "app",
-  "peers": {
-    "infra-lib": "/Users/me/src/infra-lib/.agent-mail"
-  }
-}
-```
-
-Usage:
-```bash
-amq_context="$(amq env --me claude --wake)" && eval "$amq_context"  # Set up for Claude
-amq_context="$(amq env --me codex --wake)" && eval "$amq_context"   # Set up for Codex
-amq env --shell fish                  # Fish shell syntax
-amq env --json                        # Machine-readable output
-```
-
-## Message Kinds
-
-| Kind | Reply Kind | Default Priority | Description |
-|------|------------|------------------|-------------|
-| `review_request` | `review_response` | normal | Request code review |
-| `review_response` | — | normal | Code review feedback |
-| `question` | `answer` | normal | Question needing answer |
-| `answer` | — | normal | Response to a question |
-| `decision` | — | normal | Decision request/announcement |
-| `brainstorm` | — | low | Open-ended discussion |
-| `status` | — | low | Status update/FYI |
-| `todo` | — | normal | Task assignment |
-
-When `--kind` is set but `--priority` is not, priority defaults to `normal`.
-
-**Progress updates**: Use `status` kind to signal you've started working on a message (e.g., `amq reply --id <msg_id> --kind status --body "Started, eta ~20m"`). This helps when one agent is faster than another—the sender can check progress via `amq thread`.
+**Extension metadata**: Higher layers own data below
+`<AM_ROOT>/extensions/<layer>/` or
+`<AM_ROOT>/agents/<handle>/extensions/<layer>/`. AMQ does not execute extension
+code and cleanup does not remove extension data. See
+[the layer extension ADR](docs/adr-layer-extensions.md).
 
 ## CLI Commands
 
-```bash
-amq init --root <path> --agents a,b,c [--force]
-amq send --me <agent> --to <recipients> [--subject <str>] [--thread <id>] [--refs <ids>] [--body <str|@file|-|stdin>] [--allow-empty] [--allow-self] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--session <target-session>] [--from-session <source-session>] [--project <project>] [--ignore-session-pin] [--wait-for <stage>] [--wait-timeout <duration>]
-amq list --me <agent> [--session <name>] [--new | --cur] [--priority <p>] [--from <h>] [--kind <k>] [--label <l>...] [--limit N] [--offset N] [--json]
-amq read --me <agent> --id <msg_id> [--session <name>] [--ignore-session-pin] [--json]
-amq drain --me <agent> [--session <name>] [--ignore-session-pin] [--limit N] [--include-body] [--json]
-amq thread --id <thread_id> [--agents <a,b,c>] [--limit N] [--include-body] [--json]
-amq trace <message-id> [--root <path>] [--json]
-amq receipts list --me <agent> [--msg-id <id>] [--stage <stage>] [--json]
-amq receipts wait --me <agent> --msg-id <id> [--stage <stage>] [--timeout <duration>] [--poll-interval <duration>] [--json]
-amq presence set --me <agent> --status <busy|idle|...> [--note <str>]
-amq presence list [--json]
-amq route explain --to <handle> [--project <project>] [--session <session>] [--from-root <path>] [--from-cwd <path>] [--me <handle>] --json
-amq cleanup [--tmp-older-than <duration>] [--wake-quarantine-older-than <duration>] [--dry-run] [--yes]
-amq watch --me <agent> [--session <name>] [--ignore-session-pin] [--timeout <duration>] [--poll] [--json]
-amq monitor --me <agent> [--session <name>] [--ignore-session-pin] [--timeout <duration>] [--poll] [--limit N] [--include-body] [--peek] [--json]
-amq reply --me <agent> --id <msg_id> [--ignore-session-pin] [--subject <str>] [--body <str|@file|-|stdin>] [--allow-empty] [--priority <p>] [--kind <k>] [--labels <l>] [--context <json>] [--wait-for <stage>] [--wait-timeout <duration>]
-amq dlq list --me <agent> [--session <name>] [--ignore-session-pin] [--new | --cur] [--json]
-amq dlq read --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--json]
-amq dlq retry --me <agent> --id <dlq_id> [--session <name>] [--ignore-session-pin] [--all] [--force]
-amq dlq purge --me <agent> [--session <name>] [--ignore-session-pin] [--older-than <duration>] [--dry-run] [--yes]
-amq wake --me <agent> [--baseline-existing] [--inject-cmd <cmd>] [--inject-mode <auto|raw|paste|none>] [--inject-via <absolute-executable>] [--inject-arg <arg>...] [--inject-timeout <duration>] [--bell] [--debounce <duration>] [--preview-len <n>] [--defer-while-input] [--input-quiet-for <duration>] [--input-poll-interval <duration>] [--input-max-hold <duration>] [--interrupt] [--interrupt-label <label>] [--interrupt-priority <p>] [--interrupt-cmd <ctrl-c|none>] [--interrupt-notice <str>] [--interrupt-cooldown <duration>] [--no-self-upgrade] [--debug]
-amq wake check --me <agent> [--root <path>] [--strict] [--json] [--json-schema <1|2>]
-amq wake repair --me <agent> [--root <path>] [--json]
-amq wake retire --me <agent> --inject-via <absolute-executable> [--inject-arg <arg>...] [--root <path>] [--json]
-amq wake recover-owner --me <agent> [--root <path>] [--strict] [--json]
-amq upgrade
-amq setup [--root <path>] [--agents <a,b,c>] [--default-session <name>] [--launcher-preference <a,b,c>] [--layout columns] [--no-gitignore] [-y] [--json]
-amq launch [--session <name>] [--root <path>] [--launcher <auto|commands>] [--fresh] [--allow-fresh-fallback] [--rebind] [--json]
-amq session create <name> [--root <path>] [--json]
-amq session list [--root <path>] [--json]
-amq session resume <name> [--launcher <auto|commands>] [--fresh] [--allow-fresh-fallback] [--rebind] [--json]
-amq env [--me <agent>] [--root <path>] [--session <name>] [--shell sh|bash|zsh|fish] [--wake] [--export] [--session-name] [--json]
-amq shell-setup [--shell bash|zsh|fish] [--claude-alias <name>] [--codex-alias <name>] [--grok-alias <name>]
-amq coop init [--root <path>] [--agents <a,b,c>] [--no-gitignore] [--force] [--json]
-amq coop exec [--root <path>] [--session <name>] [--me <handle>] [--no-init] [--no-gitignore] [--no-wake] [--require-wake] [--wake-inject-mode <auto|raw|paste|none>] [--wake-inject-via <absolute-executable>] [--wake-inject-arg <arg>...] [-y] <command> [-- <command-flags>]
-amq swarm list [--json]
-amq swarm join --team <name> --me <agent> [--agent-id <id>] [--type codex|external|claude-code] [--json]
-amq swarm leave --team <name> --agent-id <id> [--json]
-amq swarm tasks --team <name> [--status pending|in_progress|completed|failed|blocked] [--json]
-amq swarm claim --team <name> --task <id> --me <agent> [--agent-id <id>] [--json]
-amq swarm complete --team <name> --task <id> --me <agent> [--agent-id <id>] [--evidence <json|@file>] [--json]
-amq swarm fail --team <name> --task <id> --me <agent> [--agent-id <id>] [--reason <str>] [--json]
-amq swarm block --team <name> --task <id> --me <agent> [--agent-id <id>] [--reason <str>] [--json]
-amq swarm bridge --team <name> --me <agent> [--agent-id <id>] [--poll] [--poll-interval <duration>] [--root <path>] [--strict] [--json]
-amq integration symphony init [--workflow <path>] --me <agent> [--root <path>] [--check] [--force] [--json]
-amq integration symphony emit --event <after_create|before_run|after_run|before_remove> --me <agent> [--root <path>] [--workspace <path>] [--identifier <key>] [--json]
-amq integration kanban bridge --me <agent> [--root <path>] [--url <ws://...>] [--workspace-id <id>] [--reconnect <duration>] [--json]
-amq who [--json]
-amq doctor [--root <path>] [--base-root <path>] [--ignore-session-pin] [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json] [--json-schema <1|2>]
-```
-
-`--root` is accepted only where it is listed above. `launch --root` selects an
-existing named session root; `session resume` takes the name as a positional
-and does not accept `--root`. Participating commands may
-also accept `--json` and `--strict` (error instead of warn on unknown handles or
-unreadable/corrupt config). Global option: `--no-update-check`. Note: `init` has
-its own flags and doesn't accept these. `--json-schema` requires `--json`.
-
-**Exit codes**: `0` success, `1` general error, `2` usage, `3` not found
-(including unknown `session resume`), `4` timeout, `5` context mismatch,
-`6` action required (untrusted launch plan, unknown backend inspect, stale
-conversation, blocked rebind, or Wave A `commands` emission that still needs
-the operator to run `coop exec`). `--json` does not change these codes.
-
-**Body resolution (`send`/`reply`)**: `--body` resolves from `@file`, a literal string, or stdin. A bare `--body -`, `--body @-`, or an omitted `--body` reads stdin (standard CLI convention). A send whose resolved body is empty or whitespace-only **fails closed** with a usage error rather than delivering a blank message — pass `--allow-empty` to send a blank body intentionally. This prevents a dropped or mistyped body (e.g. `--body -` with nothing piped) from silently shipping an empty message.
-
-Swarm-specific flags: `--team`, `--task`, `--agent-id`, `--type`, `--status`, `--poll`, `--poll-interval`, `--reason`, `--evidence`.
-
-Use `amq --version` to check the installed version.
-
-### Message Filtering
-
-The `list` command supports filtering messages:
-
-```bash
-# Filter by priority
-amq list --me claude --new --priority urgent
-
-# Filter by sender
-amq list --me claude --new --from codex
-
-# Filter by message kind
-amq list --me claude --new --kind review_request
-
-# Filter by label (can be repeated for multiple labels)
-amq list --me claude --new --label bug --label critical
-
-# Combine filters
-amq list --me claude --new --from codex --priority urgent --kind question
-```
-
-### Labels and Context
-
-**Labels** are arbitrary tags for categorizing messages:
-
-```bash
-amq send --to codex --labels "bug,urgent,parser" --body "Found critical bug"
-```
-
-**Context** provides structured metadata as JSON:
-
-```bash
-# Inline JSON
-amq send --to codex --kind review_request \
-  --context '{"paths": ["internal/cli/send.go"], "focus": "error handling"}' \
-  --body "Please review error handling"
-
-# From file
-amq send --to codex --context @review-context.json --body "See context file"
-```
-
-Recommended context schema:
-```json
-{
-  "paths": ["internal/cli/send.go", "internal/format/message.go"],
-  "symbols": ["Header", "runSend"],
-  "focus": "error handling in validation",
-  "commands": ["go test ./internal/cli/..."],
-  "hunks": [{"file": "send.go", "lines": "45-60"}]
-}
-```
-
-### Orchestrator Integration Metadata
-
-All integration metadata lives under `context.orchestrator`.
-
-The formal contract lives in [docs/adapter-contract.md](docs/adapter-contract.md). The short version is:
-
-- AMQ transports messages
-- Adapters convert external lifecycle or task events into AMQ messages
-- Symphony is a lightweight hook adapter
-- Kanban is experimental and depends on a preview WebSocket surface
-
-Canonical fields:
-
-```json
-{
-  "orchestrator": {
-    "version": 1,
-    "name": "symphony",
-    "transport": "hook",
-    "event": "before_run",
-    "workspace": {
-      "path": "/abs/path/to/workspace",
-      "key": "workspace-name"
-    },
-    "task": {
-      "id": "workspace-name",
-      "state": "running"
-    }
-  }
-}
-```
-
-Kanban uses the same top-level object with `name: "kanban"` and `transport: "bridge"`, but its task payload may additionally include `prompt`, `column`, `review_reason`, and `agent_id`. Kanban workspace metadata may include `id`/`path`; Symphony uses `path`/`key`.
-
-Standard label conventions for integration messages:
-
-- Always: `orchestrator`, `orchestrator:<name>`
-- When task state is known: `task-state:<state>`
-- Handoff / review-ready events: add `handoff`
-- Failed / interrupted / blocked events: add `blocking`
-
-These labels are intentionally generic so `amq list --label orchestrator --label handoff` works across integrations.
-
-## Dead Letter Queue (DLQ)
-
-Messages that fail to parse during `drain` or `monitor` are automatically moved to the Dead Letter Queue instead of `cur/`. This prevents corrupt messages from blocking processing while preserving them for inspection.
-
-**DLQ Layout**:
-```
-<root>/agents/<agent>/dlq/{tmp,new,cur}/
-```
-
-**DLQ Envelope**: Wraps original message with failure metadata:
-- `failure_reason`: `parse_error`
-- `failure_detail`: Specific error message
-- `retry_count`: Number of retry attempts (max 3 before permanent DLQ)
-- `retry_state`: `ready`, `pending`, `delivered`, or `indeterminate`
-
-**Commands**:
-- `amq dlq list` - List dead-lettered messages
-- `amq dlq read --id <dlq_id>` - Inspect a DLQ message with failure info
-- `amq dlq retry --id <dlq_id>` - Move message back to inbox for reprocessing
-- `amq dlq retry --all` - Retry all DLQ messages
-- `amq dlq purge` - Permanently remove DLQ messages
-
-Successful retries retain a terminal audit in `dlq/cur` until purge.
-`delivered` is terminal and idempotent: retry reports `already_delivered` with
-`audit_finalized`, and `--force` cannot redeliver it. `pending` or
-legacy-`indeterminate` state without a visible inbox destination refuses retry,
-including with `--force`; the flag bypasses only the maximum retry count.
-Bulk JSON output separates `retried`, `already_delivered`, and `skipped`;
-`count` includes only newly retried messages.
-
-`amq read`, `amq drain`, and `amq monitor` now share the same strict header validation. If a message in `inbox/new` is corrupt or has malformed headers, the command moves it to DLQ and emits a `dlq` receipt instead of leaving it in place.
-
-## Doctor / Ops
-
-`amq doctor` verifies installation, root configuration, permissions, config, and skill setup.
-
-`amq doctor --fix-mailboxes` repairs the base mailbox layout without requiring
-`--ops`: it creates only missing required directories for the effective
-configured roster (`config.json` agents plus the reserved human handle
-`user`). Filesystem-discovered mailboxes outside that effective roster are
-reported but are never repair eligible. Repair never edits, moves, overwrites,
-or deletes existing message files; symlinks, non-directories, unreadable
-paths, and concurrent layout changes fail closed. Inspection remains
-available when the target differs from the active session pin (reported
-separately as a warning); repair is also allowed for the authenticated pinned
-base root, while other mismatches produce a structured error check and leave
-the doctor process at exit 0 unless explicitly ignored.
-
-`amq doctor --root <path>` selects the exact inspection or repair target; it
-does not repin the shell or bypass an inherited session pin. Read-only
-inspection still runs on a mismatch and reports a `Session identity pin`
-warning. Mailbox repair refuses a mismatched target outside the authenticated
-pinned base unless the command also uses `--ignore-session-pin`, which
-requires an explicit non-empty `--root`; the refusal is a structured check and
-does not make `doctor` exit nonzero.
-For a base-config-only session, use
-`amq doctor --root <session> --base-root <base> --ignore-session-pin --fix-mailboxes`.
-`--base-root` requires `--root`, is used only as the retained config authority,
-and must be the same tree or the direct parent of the target; it never waives
-the session pin.
-
-`amq doctor --ops` adds runtime checks:
-
-- Queue depth and oldest unread per agent
-- Sibling-session backlogs for the same handles
-- Same-session mailbox divergence across git worktrees (diagnostic-only)
-- DLQ count and oldest age
-- Presence freshness
-- Wake lock health (`--fix-wake-locks` removes stale locks)
-- Integration hints for Kanban and Symphony
-
-Wake lock states are intentionally conservative:
-
-- `stale`: AMQ proved the recorded PID is gone, mismatched, or not the same `amq wake`; `amq doctor --ops --fix-wake-locks` re-inspects and removes only these locks.
-- `unverified`: AMQ could not prove either ownership or staleness, so startup fails closed and doctor leaves the lock in place. Confirm the PID/root/agent manually before removing the `.wake.lock`.
-
-Before stopping or replacing a wake, run `amq wake check --me <agent>
---json`. The probe is read-only and reports `restart_capability` as
-`agent_safe`, `operator_only`, or `unavailable`, with an exact next action.
-Only `agent_safe` authorizes an agent-side action. A non-TTY agent must leave a
-live wake running unless the probe reports `agent_safe`; `operator_only`
-requires the owning terminal or supervisor. The probe diagnoses restart
-capability but does not itself implement agent-safe restart.
-
-Live wake repair is explicit: `amq wake repair --me <agent>` may replace a
-proven-stale lock or supersede an unverified ownerless generic lock and start a
-fresh wake only when the lock was created for `--inject-via`, and
-`agents/<agent>/.wake.target` exists with a digest that matches the lock's
-repair metadata. `.wake.target` is mode `0600` and stores
-schema metadata, root, agent, creation time, `mode:"inject-via"`, an absolute
-executable path, and fixed argv. The private mode-`0600` `.wake.repair-floor`
-must also match the exact generation, target, physical root, boot, and owner
-state. It persists only the device/inode/ctime identities already suppressed by
-that wake, never message IDs. Repair hands that floor to the replacement rather
-than re-snapshotting `inbox/new`, so downtime arrivals and same-name DLQ retries
-remain eligible. Missing, corrupt, or mismatched floor state requires a normal
-wake restart. Raw TTY wake has no repair target; repair must refuse raw locks,
-leftover targets from old locks, and unverified owner-bound or invalid claims.
-An unverified ownerless generic claim is superseded only after its target and
-continuity state pass the same fail-closed validation.
-Repaired wake stdout/stderr goes to
-`agents/<agent>/.wake.repair.log`; repair itself must not keep stdout/stderr
-pipes open after its JSON/text output exits. `doctor --ops` may report
-`target_present`, `repair_available`, and a continuity `repair_reason`, but must
-remain diagnostic-only and never spawn a wake process.
-
-`amq wake retire` requires the expected inject-via executable and ordered fixed
-arguments. It stops only an identity-confirmed live inject-via wake with an
-unchanged, exactly matching saved target, using Linux pidfd signaling or the
-Darwin cooperative control socket; it may also remove an exactly-bound
-proven-stale lock. It preserves the mailbox and saved target. The lifecycle
-boundaries are: repair = replace a proven-stale inject-via wake; `doctor --ops
---fix-wake-locks` = remove a proven-stale lock; retire = stop an
-identity-confirmed live inject-via wake; launchd, systemd, or the owning shell =
-stop a raw wake. Retire neither unloads supervisors nor promises that they will
-not restart a wake.
-
-`who` and `doctor --ops` presence sources have narrow semantics:
-`notifier_live` requires a valid wake lock with process identity confirmed by
-the existing wake-lock inspector; it proves prompt notification only, never
-consumption. `recent_activity` means a fresh `last_seen` without that proof.
-Do not introduce `consumer_live` wording without a separate monitor heartbeat
-or lock. Long-running wake/monitor supervision belongs to launchd, systemd, or
-another layer above daemon-free AMQ.
-
-Git worktree diagnostics stay in `doctor --ops`, never in the send routing
-path. Relative project roots and auto-detected roots are per-worktree; sharing
-requires the same absolute `.amqrc` root or `AMQ_GLOBAL_ROOT`. A local `.git`
-marker or bare-repository signature is also a routing safety signal: when any
-Git checkout or bare repository has no local AMQ configuration or queue,
-implicit `~/.amqrc` fallback is refused instead of
-silently selecting another project's mailbox. This check is local and does not
-scan sibling worktrees. The deep check remains best-effort in `doctor --ops`
-and warns only when the same session exists under another worktree root with
-fresher peer presence. `send --wait-for` timeout text may name the
-already-resolved delivery root/session and recommend `doctor --ops`, but must
-not scan git worktrees itself.
-
-When no higher-precedence root is eligible, the routing refusal does not block
-`coop exec`; it creates a fresh worktree-local queue at that worktree's top.
-`coop init` explicitly targets the same local top. Participating commands still
-refuse, `--no-init` declines creation, and bare repositories still require a
-worktree or explicit `--root`.
-
-Use `amq doctor --ops --json` for machine-readable health output.
-
-## Multi-Agent Coordination
-
-Commands below assume `AM_ME` is set (e.g., `export AM_ME=claude`).
-
-**Preferred: Use `drain`** - One-shot ingestion that reads, moves to cur, and emits `drained` or `dlq` receipts. Silent when empty (hook-friendly).
-
-**During active work**: Use `amq drain --include-body` to ingest messages between steps.
-
-**Waiting for reply**: Use `amq watch --timeout 60s` which blocks until a message arrives, then `amq drain` to process.
-
-| Situation | Command | Behavior |
-|-----------|---------|----------|
-| Ingest messages | `amq drain --include-body` | One-shot: read+move+receipt |
-| Wait for delivery | `amq send --to codex --wait-for drained --wait-timeout 60s ...` | Send then block for `drained`/`dlq` |
-| Inspect delivery | `amq receipts list --me codex --msg-id <msg_id>` | Show receipt history for one message |
-| Waiting for reply | `amq watch --timeout 60s` | Blocks until message |
-| Quick peek only | `amq list --new` | Non-blocking, no side effects |
-| Filter messages | `amq list --new --priority urgent` | Show only urgent messages |
-| Background wake | `amq wake --me <agent> --interrupt-cmd none &` | Injects notification via TIOCSTI with best-effort input deferral, or via explicit external transport (experimental), without Ctrl+C injection |
-| Reply to message | `amq reply --id <msg_id>` | Auto thread/refs handling |
-
-## Co-op Mode (Claude <-> Codex, optional peers)
-
-Co-op mode enables real-time collaboration between multiple agent sessions (e.g., Claude Code and Codex CLI, with Grok CLI as an optional peer). See `COOP.md` for full documentation.
-
-**Initiator rule**: The initiator (agent or human) receives all updates and decisions. Always reply to the initiator and ask the initiator for clarifications. Do not ask a third party.
-
-**Default pairing note**: Claude is often faster and more decisive, while Codex tends to be deeper but slower. That commonly makes Claude a natural coordinator and Codex a strong worker. This is a default, not a rule — roles are set per task by the initiator. Grok CLI can join as an additional optional peer/worker (e.g. a third `amq coop exec grok` in a three-way session) without changing this default two-engine pairing note.
-
-**Progress protocol**: Start with a `kind=status` + ETA, send heartbeats on phase boundaries or every 10-15 minutes, and finish with Summary / Changes / Tests / Notes.
-
-**Modes of collaboration**: Leader+Worker (default), Co-workers, Duplicate (independent solutions), Driver+Navigator, Spec+Implementer, Reviewer+Implementer. See `COOP.md` for details.
-
-### Quick Start
-
-```bash
-# Terminal 1 - Claude Code
-amq coop exec claude -- --dangerously-skip-permissions  # session=collab by default
-
-# Terminal 2 - Codex CLI
-amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox  # Same, with codex flags
-
-# Terminal 3 - Grok CLI (optional peer)
-amq coop exec grok  # Caller flags forwarded unchanged, no baked-in bypass
-```
-
-Without `--session` or `--root`, `coop exec` uses the declared `default_session`
-from `.amq/launch.json`, or `collab` when none is declared. Creating a missing
-session or root from `coop exec` still works in this release but prints
-`warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
-
-Use `--session` for a different isolated session:
-```bash
-amq coop exec --session feature-a claude               # Isolated session
-```
-
-Use `--no-gitignore` to opt out of `.gitignore` changes when `coop exec` auto-initializes a project. Use `--no-wake` to disable auto-wake (e.g., in CI or non-TTY environments). Use `--require-wake` in managed launchers that should refuse to start an agent unless the wake process starts and acquires its lock.
-Use `--wake-inject-via /absolute/path/to/injector` plus repeated
-`--wake-inject-arg` values when a launcher has a terminal-specific injector and
-wants later `amq wake repair` to work without restarting the agent TUI. Repair
-metadata is written only when this invocation starts a new wake; a reused
-existing wake must already have repair metadata to be repairable.
-
-**For scripts/CI** (non-interactive):
-```bash
-amq coop init && amq_context="$(amq env --me claude)" && eval "$amq_context"
-```
-
-### Message Priority Handling
-
-When you see a notification, run `amq drain --include-body`:
-- **urgent** → Interrupt current work and respond immediately. Label
-  `interrupt` enables an interrupt notice; it never enables Ctrl+C by itself.
-- **normal** → Add to TodoWrite, respond when current task done
-- **low** → Batch for end of session
-
-### Fallback: Notify Hook
-
-If `amq wake` fails (TIOCSTI unavailable on hardened Linux), use notify hook:
-```toml
-# ~/.codex/config.toml
-notify = ["python3", "/path/to/repo/scripts/codex-amq-notify.py"]
-```
-
-For a local terminal transport that can receive notifications without a
-controlling TTY, run wake with an explicit external injector:
-```bash
-amq wake --me orchestrator \
-  --inject-via /absolute/path/to/ghostty-bridge \
-  --inject-arg exec \
-  --inject-arg "$TERMINAL_ID"
-```
-
-`--inject-via` is an executable path, not a shell command line. Repeat
-`--inject-arg` for fixed argv entries; AMQ appends the sanitized notification
-payload as the final argument and bounds each invocation with
-`--inject-timeout` (default `5s`). This executes local code for each
-notification, and the payload can include sanitized but message-derived sender
-and subject header content.
-
-### Plan Mode Prompt Hook (Claude)
-
-When Claude is in plan mode, shell tools are unavailable to the model. You can still
-surface AMQ inbox context by using a `UserPromptSubmit` hook:
-
-```json
-{
-  "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "AMQ_PROMPT_HOOK_MODE=plan AMQ_PROMPT_HOOK_ACTION=list python3 $CLAUDE_PROJECT_DIR/scripts/claude-amq-user-prompt-submit.py"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Set `AMQ_PROMPT_HOOK_ACTION=drain` if you want the hook to auto-drain on prompt submit.
-
-### Co-op Commands
-
-```bash
-# Send a review request
-amq send --me claude --to codex --subject "Review needed" \
-  --kind review_request --priority normal \
-  --body "Please review internal/cli/send.go..."
-
-# Reply to a message (auto thread/refs)
-amq reply --me codex --id "msg_123" --kind review_response \
-  --body "LGTM with minor comments..."
-```
-
-## Swarm Mode (Claude Code Agent Teams)
-
-Swarm mode lets external agents (Codex, etc.) participate in Claude Code Agent Teams by reading/writing the team's local config and task list (under `~/.claude/teams/` and `~/.claude/tasks/`).
-See `.claude/skills/amq-cli/SKILL.md` for the agent-facing workflow.
-
-- **Task workflow**: `amq swarm join`, `amq swarm tasks`, `amq swarm claim`, `amq swarm complete`, `amq swarm fail`, `amq swarm block`
-- **Notifications**: `amq swarm bridge` watches the shared task list and delivers AMQ messages labeled `swarm` into the agent's inbox
-
-**Wake compatibility**: bridge notifications are standard AMQ inbox messages,
-so `amq wake` detects them automatically. Bridge lifecycle events are hardcoded
-`priority=normal` plus label `swarm`; do not bind that combination to Ctrl+C.
-Use ordinary non-destructive wake:
-
-```bash
-amq wake --me codex --interrupt-cmd none &
-```
-
-`--interrupt-cmd ctrl-c` is an explicit destructive opt-in: it sends a real
-SIGINT to the foreground process group and can interrupt or crash the agent. If
-process-level interruption is intentional, match a separate operator-controlled
-label/priority that the swarm bridge does not emit.
-
-**Direct messaging (A2A)**: the bridge only emits task lifecycle notifications.
-
-- **Claude Code teammate → external agent**: works directly (Claude Code uses the AMQ skill to `amq send` to the external agent's inbox).
-- **External agent → Claude Code teammate**: requires a relay. Claude Code teammates don't drain AMQ; they use internal team messaging. The team leader must `amq drain --include-body` and forward inbound messages to the intended teammate via Claude Code's internal SendMessage.
-
-Recommended convention for external agents (send to the leader's AMQ handle, include the intended teammate):
-```bash
-amq send --me codex --to claude --thread swarm/my-team --labels swarm \
-  --subject "To: builder - question about task t1" \
-  --body "..."
-```
-
-Leader loop options: periodic `amq drain --include-body`, tighter `amq monitor --include-body` (watch+drain), or `amq wake --me claude --interrupt-cmd none &` for terminal notifications.
+Use `amq <command> --help` for exact flags. This table defines the owning
+workflow for each surface.
+
+| Area | Commands | Contract |
+| --- | --- | --- |
+| Onboarding | `setup`, `launch` | Configure once, then reconcile and print or run the declared launch plan. The [README Quick Start](README.md#quick-start) is canonical. |
+| Sessions | `session create`, `session list`, `session resume` | Create explicitly, inspect available sessions, or resume stored conversations. |
+| Shell context | `env`, `who`, `shell-setup`, `completion` | Set or inspect a complete context and configure shell integration. |
+| Messaging | `send`, `reply`, `list`, `read`, `drain`, `thread`, `trace` | Deliver, ingest, inspect, and follow conversations. Prefer `drain --include-body` for handoffs. |
+| Delivery proof | `receipts list`, `receipts wait` | Inspect consumer-local `drained` and `dlq` outcomes. |
+| Live waits | `watch`, `monitor` | Wait for arrivals; `monitor` also drains and emits receipts. |
+| Routing | `route explain`, `presence set`, `presence list` | Explain a route and publish or inspect advisory presence. |
+| Health | `doctor`, `cleanup`, `upgrade` | Diagnose, perform explicit safe cleanup, or update the binary. |
+| Wake | `wake`, `wake check`, `wake repair`, `wake recover-owner`, `wake retire` | Notify, inspect capability, and make identity-safe lifecycle changes. |
+| DLQ | `dlq list`, `dlq read`, `dlq retry`, `dlq purge` | Inspect and explicitly recover or purge corrupt messages. |
+| Low-level provisioning | `init`, `coop init`, `coop exec` | Create raw queues or enter an agent process. See [COOP.md](COOP.md). |
+| Swarm bridge | `swarm list`, `join`, `leave`, `tasks`, `claim`, `complete`, `fail`, `block`, `bridge` | Interoperate with Claude Code Agent Teams. |
+| Integrations | `integration symphony`, `integration kanban` | Convert external lifecycle events into AMQ messages. See [the adapter contract](docs/adapter-contract.md). |
+
+Exit codes are `0` success, `1` general error, `2` usage, `3` not found, `4`
+timeout, `5` context mismatch, and `6` action required. JSON output does not
+change exit codes. `--json-schema` requires `--json`.
+
+`send` and `reply` resolve `--body` from a literal, `@file`, or stdin. Empty or
+whitespace-only input is a usage error unless `--allow-empty` is explicit.
+
+## Message Kinds
+
+| Kind | Reply kind | Default priority | Purpose |
+| --- | --- | --- | --- |
+| `review_request` | `review_response` | normal | Request review. |
+| `review_response` | - | normal | Return review findings. |
+| `question` | `answer` | normal | Ask for a decision or fact. |
+| `answer` | - | normal | Answer a question. |
+| `decision` | - | normal | Record a decision. |
+| `brainstorm` | - | normal | Explore options. |
+| `status` | - | low | Report progress or state. |
+| `todo` | - | normal | Assign work. |
+
+When work starts, reply with `kind=status` and an ETA. Use `urgent` only for
+work that must interrupt the current activity.
+
+## Dead Letter Queue
+
+`read`, `drain`, and `monitor` move messages with invalid serialization or
+headers to DLQ and emit a `dlq` receipt. The envelope records the parse error,
+retry count, and retry state. A successful retry keeps a terminal audit in
+`dlq/cur` until explicit purge.
+
+`delivered` is terminal and idempotent. `pending` or legacy `indeterminate`
+without a visible inbox destination refuses retry, including with `--force`.
+The flag bypasses only the retry-count limit. Bulk JSON separates new retries,
+already-delivered records, and skipped records.
+
+## Doctor and Wake Operations
+
+`doctor` checks installation, root selection, permissions, configuration, and
+skill setup. `--ops` adds queue depth, sibling backlogs, DLQ age, presence,
+wake health, worktree diagnostics, and integration hints.
+
+Mailbox and wake repair preserve existing messages and fail closed on unsafe
+paths, symlinks, conflicting session pins, or concurrent replacement. Doctor
+can inspect an explicit mismatched root, but mutation requires the
+authenticated pinned base or explicit `--root --ignore-session-pin`.
+
+Before wake mutation, run `amq wake check --me <agent> --json`. Only
+`restart_capability=agent_safe` permits agent-side action. Repair, owner
+recovery, and retirement revalidate exact identity and have distinct scopes.
+See [Wake operations](docs/wake-operations.md) for the full contract.
+
+## Coordination Workflows
+
+During active work, run `amq drain --include-body` between phases. Use
+`send --wait-for drained` when delivery proof matters and `watch` when waiting
+for a response. Reply to the initiator, preserve the existing thread, send
+status at start and phase boundaries, and finish with changes and verification.
+
+The [co-op guide](COOP.md) owns peer roles, phased flow, wake use, supervisor
+recipes, and troubleshooting. The `amq-cli` skill owns agent-facing command
+mechanics. The `amq-spec` skill owns research-discuss-draft-review workflows
+and the human approval gate. Swarm mode is a bridge to Claude Code Agent Teams;
+AMQ messages to a teammate still require the team leader to relay them.
 
 ## Testing
 
-Run individual test: `go test ./internal/fsq -run TestMaildir`
+Run the narrowest test that exercises the owning boundary, then run `make ci`
+before a commit. Useful focused commands include:
 
-Key test files:
-- `internal/fsq/maildir_test.go` - Atomic delivery semantics
-- `internal/fsq/dlq_test.go` - Dead letter queue operations
-- `internal/format/message_test.go` - Message serialization
-- `internal/thread/thread_test.go` - Thread collection
-- `internal/cli/watch_test.go` - Watch command with fsnotify
+```bash
+go test ./internal/fsq -run TestMaildir
+go test ./internal/cli -run '<relevant test>'
+go test ./internal/sessionguard
+make check-skills
+```
+
+Tests must include a negative case that a plausible wrong implementation would
+fail. For concurrency, routing, wake, and filesystem work, exercise the actual
+hostile boundary rather than only a helper or mock.
 
 ## Security
 
-- Directories use 0700 permissions (owner-only access)
-- Files use 0600 permissions (owner read/write only)
-- Unknown handles trigger a warning by default; use `--strict` to error instead
-- With `--strict`, unreadable or corrupt `config.json` also causes an error
-- Handles must be lowercase, match `[a-z0-9_-]+`, and must not start with `-`.
-- Path traversal prevented via strict handle/ID validation
-
-## Contributing
-
-Install git hooks to enforce checks before push:
-
-```bash
-./scripts/install-hooks.sh
-```
-
-The pre-push hook runs `make ci` (vet, lint, test, smoke) before allowing pushes.
+- Queue directories use mode 0700 and files use mode 0600.
+- Handle and message ID validation prevents path traversal.
+- Unknown handles warn by default; `--strict` changes warnings to errors.
+- With `--strict`, unreadable or corrupt configuration is also an error.
+- External injectors execute local code. Their executable and ordered fixed
+  arguments form the saved identity; message-derived payloads are sanitized.
+- Preserve uncertain ownership or filesystem state. Never add a force path
+  that guesses at process, target, generation, or owner identity.
 
 ## Commit Conventions
 
-- Use descriptive commit messages (e.g., `fix: handle corrupt receipt files gracefully`)
-- Run `make ci` before committing
-- Do not edit message files in place; always use the CLI
-- Cleanup is explicit (`amq cleanup`), never automatic
+- Install the repository hooks with `./scripts/install-hooks.sh`.
+- Use conventional, descriptive commits such as
+  `fix(wake): preserve replacement generation`.
+- Run `make ci` before committing and follow every pushed CI run to completion.
+- Do not commit placeholders, weaken a validator, regenerate goldens to hide a
+  defect, or split code from the tests that prove it.
 
 ## Documentation Policy
 
-- Keep `docs/` evergreen. It should contain durable reference material such as architecture notes, protocol contracts, and operational guidance.
-- Do not commit frozen specs, design drafts, or implementation plans into `docs/`.
-- Do not merge spec documents to `main`, and do not keep them in feature branches intended for PRs either.
-- Spec work belongs in the AMQ spec workflow, PR descriptions, issues, or other ephemeral collaboration artifacts rather than committed repository docs.
+- Keep `README.md` as the canonical install and onboarding path.
+- Keep `COOP.md` as the full co-op and supervisor operations guide.
+- Keep `CLAUDE.md` as a concise project index and engineering contract.
+- Keep `docs/` evergreen: architecture, protocol contracts, and operational
+  references only. Plans and frozen specs belong in issues, PRs, or the AMQ
+  spec workflow.
+- Describe current behavior in present tense. Put one-sentence known
+  limitations beside an issue link instead of adding historical narration.
 
 ## Skill Development
 
-This repo includes skills for Claude Code and Codex CLI, distributed via the [skills-marketplace](https://github.com/avivsinai/skills-marketplace).
+Canonical skills live in `skills/amq-cli/` and `skills/amq-spec/`.
+`.claude/skills/` and `.agents/skills/` are symlinks to those directories so
+local runs use repository changes. Project skills take precedence over user
+installations.
 
-### Structure
-
-```
-.claude-plugin/plugin.json     → Plugin manifest for marketplace
-skills/amq-cli/                → Canonical skill contents
-├── SKILL.md
-└── references/
-    ├── coop-mode.md
-    ├── integrations.md
-    ├── message-format.md
-    └── swarm-mode.md
-skills/amq-spec/               → Canonical spec skill contents
-.claude/skills/amq-cli/        → Symlink to ../../skills/amq-cli
-.claude/skills/amq-spec/       → Symlink to ../../skills/amq-spec
-.agents/skills/amq-cli/        → Symlink to ../../skills/amq-cli
-.agents/skills/amq-spec/       → Symlink to ../../skills/amq-spec
-```
-
-### Current Skill Layout
-
-`skills/` holds the canonical contents in this repo. The project-local `.claude/skills/` and `.agents/skills/` entries are symlinks to those same directories so local agent runs pick up in-repo changes immediately.
-
-### Dev vs Installed Skills
-
-When working in this repo, **project-level skills take precedence** over user-level installed skills:
-
-- `.claude/skills/amq-cli/` loads instead of `~/.claude/skills/amq-cli/`
-- `.claude/skills/amq-spec/` loads instead of `~/.claude/skills/amq-spec/`
-- `.agents/skills/amq-cli/` loads the same in-repo contents via symlink
-- `.agents/skills/amq-spec/` loads the same in-repo contents via symlink
-
-This lets you test skill changes locally before publishing.
-
-### Editing Skills
-
-1. Edit files in `skills/<skill-name>/` (or the equivalent `.claude/skills/<skill-name>/` symlink)
-2. If publishing: bump `version:` in the skill's `SKILL.md`
-3. Verify the symlinked views still match: `make check-skills`
-4. Test locally by running Claude Code or Codex in this repo
-5. Commit and push the canonical `skills/` changes
-
-**Important**: Do not create divergent copies. The symlinked paths should always reflect the same `skills/` content.
-
-### Installing Skills
-
-See README.md for installation instructions for Claude Code and Codex CLI.
+Edit only the canonical directory, bump skill metadata when publishing, run
+`make check-skills`, and test the project-local skill. Do not create divergent
+copies. See the [README installation section](README.md#2-install-skill) for
+installed-skill commands.

--- a/COOP.md
+++ b/COOP.md
@@ -12,81 +12,13 @@ AMQ is the communication layer in this setup, not the coordinator. The initiator
 
 For swarm command reference, see [CLAUDE.md](CLAUDE.md).
 
-## Quick Start
+## Co-op Workflow
 
-### Prerequisites (One-Time)
-
-1. **Install amq CLI** ([releases](https://github.com/avivsinai/agent-message-queue/releases)):
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/avivsinai/agent-message-queue/main/scripts/install.sh | bash
-   ```
-
-2. **Install amq-cli skill** for your agents:
-
-   **Via skills** (recommended):
-   ```bash
-   npx skills add avivsinai/agent-message-queue -g -y
-   ```
-
-   **Or via skild:**
-   ```bash
-   npx skild install @avivsinai/amq-cli -t claude -y
-   ```
-
-   See [INSTALL.md](INSTALL.md) for manual installation or troubleshooting.
-
-   If pairing with Grok CLI as an optional peer, Grok discovers skills the
-   same general way Claude Code and Codex CLI do. Native locations include a
-   project-local `.grok/skills` directory, a user-level `~/.grok/skills`
-   directory, installed plugin skills, and explicitly configured skill paths;
-   Grok also reads Claude-compatible skill locations plus the user-level
-   `~/.agents/skills` directory — see the
-   [xAI skill discovery docs](https://docs.x.ai/build/features/skills-plugins-marketplaces)
-   for the authoritative list. See [INSTALL.md](INSTALL.md) for the manual
-   `~/.grok/skills` copy example.
-
-### Project Setup
-
-Run `amq setup` once per project. It probes supported agent CLIs and local
-launchers, lets you select any non-empty roster and the default session, then
-previews every change before it writes. The committed `.amq/launch.json` owns
-the roster, session default, resume policy, and layout intent. The ignored
-`.amq/launch.local.json` contains launcher preferences only. For automation,
-use `amq setup -y` after the caller accepts the recomputed preview.
-
-`amq coop init` remains the non-interactive provisioning primitive.
-
-### Launch and Resume
-
-Use the reconciliation engine as the daily entry point:
-
-```bash
-amq launch
-amq launch --session auth
-amq session resume auth
-```
-
-Both command forms use the same engine. It loads `.amq/launch.json`, validates
-adapter-owned argv and environment rules, checks the out-of-worktree trust
-record, acquires the session launch lease and per-agent locks, then reconciles
-the saved backend binding and conversation refs under
-`<session-root>/meta/launch/`. Native resume uses only the exact
-provider-qualified ID saved for that session and handle.
-
-The engine fails closed:
-
-- An unknown `session resume` name exits `3` with zero writes.
-- An untrusted semantic plan, stale conversation ID, unknown backend
-  inspection, foreign binding, or blocked rebind exits `6`.
-- `--fresh` deliberately starts fresh. `--allow-fresh-fallback` permits fresh
-  only when a saved identity is stale.
-- `--launcher <other> --rebind` is interactive. A foreign resource can only be
-  left in place; it is never closed by local inference.
-
-Wave A includes the honest `commands` backend only. It emits executable
-`coop exec` commands without claiming a managed terminal resource, then exits
-`6` because the operator must run those commands. JSON output includes every
-per-agent conversation disposition and the aggregate exit code.
+Use the [README Quick Start](README.md#quick-start) to install AMQ, configure
+the project with `amq setup`, and run `amq launch`. The `commands` backend
+prints one complete `coop exec` command for each configured agent and exits `6`
+until those commands are started. This document begins at that co-op-specific
+step; it does not define a second setup path.
 
 ### Running Co-op Mode
 
@@ -107,52 +39,45 @@ amq coop exec grok
 
 Grok is a normal handle like any other — `coop exec` forwards caller flags to
 it unchanged (no baked-in permission bypass, unlike the Codex example above).
-The default `coop init`/`coop exec` agent set stays `claude,codex,user`; adding
-Grok is opt-in. To provision mailboxes for all three engines explicitly:
-
-```bash
-amq coop init --agents claude,codex,grok,user
-```
-
-That's it. `coop exec` auto-initializes the project if needed. In a Git
-worktree with no eligible root it creates `.amqrc` and `.agent-mail` at that
-worktree's top, even from a subdirectory or with `--session`; it does not
-consult `~/.amqrc`. Use `--no-init` to keep the refusal instead. It then sets
-`AM_ROOT`/`AM_ME`, `AM_BASE_ROOT`, and the independent `AM_SESSION` identity,
-starts wake notifications, and execs into the agent. Without `--session` or
-`--root`, it uses the declared `default_session` from `.amq/launch.json`, or
-`collab` when none is declared (i.e., `AM_ROOT=.agent-mail/collab`,
-`AM_SESSION=collab` unless launch.json says otherwise). A session-shaped
-explicit root such as `.agent-mail/auth` pins the inferred session; a custom
-sessionless root clears `AM_SESSION`.
-
-Creating a missing named session (`--session`) or missing `--root` still works
-in this release, and so does creating a missing declared default session when
-`.amqrc` or `.amq/launch.json` is present. Each of those paths prints this
-single-line warning exactly once:
-
-```
-warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.
-```
-
-Use `amq session create <name>` or `amq init --root` instead. Existing sessions
-and the zero-config `collab` bootstrap in a repo with neither file do not warn.
+Include Grok in the roster during `amq setup` when it should join the session.
 
 To disable auto-wake (e.g., in CI or non-TTY environments):
 ```bash
 amq coop exec --no-wake claude
 ```
 
+### Low-level provisioning
+
+`amq coop init` is the non-interactive provisioning primitive. Direct
+`coop exec` provisioning also remains available for scripts and legacy flows,
+but it is not the canonical onboarding path. With no eligible root, `coop exec`
+creates `.amqrc` and `.agent-mail` at the worktree top; `--no-init` makes that
+condition an error instead. Without `--session` or `--root`, it uses the
+declared `default_session` from `.amq/launch.json`, or `collab` when none is
+declared.
+
+Creating a missing named session, explicit root, or declared default session
+still works in this release and prints one deprecation warning. Use
+`amq session create <name>` or `amq init --root` instead; the next major release
+makes those missing-target cases exit `3`. The zero-configuration `collab`
+bootstrap in a repo with neither `.amqrc` nor `.amq/launch.json` remains the
+documented exception.
+
 ### Multiple Pairs (Isolated Sessions)
 
-Run multiple agent pairs on different features using `--session`:
+Create each named session explicitly, reconcile it, then run the emitted
+commands in separate terminals:
 
 ```bash
 # Pair A: auth feature
+amq session create auth
+amq launch --session auth
 amq coop exec --session auth claude               # Terminal 1
 amq coop exec --session auth codex                # Terminal 2
 
 # Pair B: api refactor
+amq session create api
+amq launch --session api
 amq coop exec --session api claude                # Terminal 3
 amq coop exec --session api codex                 # Terminal 4
 ```
@@ -168,30 +93,18 @@ and set `AMQ_GLOBAL_ROOT` to one absolute base. Use `amq doctor --ops` when a
 delivery receipt times out; it can name divergent same-session roots when a
 peer has fresher presence in another worktree.
 
-Participating commands in a Git worktree or bare repository with no eligible
-root fail closed instead of implicitly using `~/.amqrc`. `coop init` explicitly
-initializes a worktree-local queue at the worktree top; `coop exec` does the
-same after root precedence finds no eligible root. A bare repository has no
-worktree to host that queue, so use a worktree or explicit `--root` there.
-
-For read-side access, prefer the named route:
+Participating commands fail closed when the active session pin conflicts with
+the selected queue. For read-side access, prefer the named route:
 
 ```bash
 amq list --session auth --new
 amq drain --session auth --include-body
 ```
 
-When a terminal has a complete `AM_BASE_ROOT`/`AM_SESSION` pin, `read`, `drain`,
-`monitor`, `watch`, and all DLQ commands refuse a conflicting target before
-inspecting or moving mailbox state; `send` and `reply` apply the same check to
-their local source. Use `--session <name>` for sibling routing. For deliberate
-raw-root access, `--ignore-session-pin` requires a non-empty explicit `--root`;
-it never blesses an inherited `AM_ROOT`. `list` warns on a mismatch but remains
-available for non-destructive inspection. `doctor --root` also keeps inspection
-available with a mismatch warning, but `--fix-mailboxes` and
-`--ops --fix-wake-locks` require a matching pin unless that explicit root is
-paired with `--ignore-session-pin`. `--base-root` selects config authority and
-never waives the pin. A missing mailbox is an error, not an empty inbox.
+Use `--session <name>` for sibling routing. Deliberate raw-root access requires
+an explicit root plus `--ignore-session-pin`. See
+[Session routing and safety](docs/session-routing.md) for the complete guard,
+doctor repair, fallback, and worktree contracts.
 
 ### For Scripts/CI
 
@@ -201,22 +114,8 @@ amq coop init
 amq_context="$(amq env --me claude)" && eval "$amq_context"
 ```
 
-All shell-mode `amq env` output replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`,
-and `AM_SESSION` as one context. For a base/sessionless root it sets
-`AM_BASE_ROOT` to that exact root and `AM_SESSION` to the empty string.
-
-`amq env` resolves the root with the full precedence chain:
-
-```text
-explicit --root > AM_ROOT > project-local .amqrc > AMQ_GLOBAL_ROOT > implicit fallbacks
-```
-
-Inside a Git worktree or bare repository, the remaining eligible fallback is repo-local detected
-`.agent-mail`; outside Git, `~/.amqrc` precedes detected `.agent-mail`.
-Auto-detect covers the default `.agent-mail` layout in the current tree,
-including `.agent-mail/<session>` session roots without `.amqrc`. Custom root
-names still need `.amqrc`, explicit flags, or env vars.
-That matters when agents are launched by external orchestrators from outside the project root.
+`amq env` replaces the full shell context. For a sessionless root it sets
+`AM_BASE_ROOT` to that exact root and leaves `AM_SESSION` empty.
 
 An initialized cwd-local queue is also a routing safety signal. If the terminal
 is pinned to a different root, implicit participating commands refuse instead
@@ -535,6 +434,9 @@ go build ./cmd/amq-keepalive
 ./amq-keepalive install-launchd
 ./amq-keepalive doctor
 ```
+
+See [docs/amq-keepalive.md](docs/amq-keepalive.md) for the complete command and
+safety reference.
 
 **Options:**
 - `--inject-mode auto|raw|paste|none` - Injection strategy; `none` enforces zero terminal input

--- a/README.md
+++ b/README.md
@@ -93,16 +93,7 @@ amq-keepalive --version
 amq-keepalive version
 ```
 
-Keepalive-managed wakes deliberately discard an ambient `AMQ_WAKE_OWNER` token
-so they remain ownerless and can outlive the short launcher that registered
-them. During startup, keepalive captures at most 16 KiB of child stderr in a
-private regular file and includes it in a pre-readiness exit error. This keeps
-actionable AMQ diagnostics visible without attaching a long-lived wake to the
-caller's terminal or to a pipe whose reader exits first.
-
-See [docs/amq-keepalive.md](docs/amq-keepalive.md) for adapters, launcher
-ordering, supervision, retirement, owner recovery, and the detached stderr
-drain contract.
+See [COOP.md](COOP.md#supervisor-recipes) for the operational guide.
 
 ## Quick Start
 
@@ -115,13 +106,13 @@ amq setup
 Detects supported agent CLIs and launcher preferences, previews the project
 declaration, then creates `.amqrc`, `.amq/launch.json`, local preferences,
 the default session, and roster mailboxes. Use `amq setup -y` only after an
-automation caller has accepted that preview. `amq coop init` remains the
-scriptable low-level provisioning command.
+automation caller has accepted that preview.
 
 ### 2. Launch or Resume a Session
 
 ```bash
 amq launch
+amq session create feature-x   # once, before the first named-session launch
 amq launch --session feature-x
 amq session resume feature-x
 ```
@@ -134,9 +125,9 @@ confirmation stored outside the worktree. Non-interactive or `--json` calls
 exit `6` until that digest is trusted. An unknown `session resume` name exits
 `3` and writes nothing.
 
-Wave A ships the `commands` backend. It prints complete `coop exec` commands
-and exits `6` because executing them is the remaining operator action. Run the
-emitted commands in separate terminals:
+The `commands` backend prints complete `coop exec` commands and exits `6`
+because executing them is the remaining operator action. Run the emitted
+commands in separate terminals:
 
 ```bash
 # Terminal 1 — Claude Code
@@ -146,16 +137,10 @@ amq coop exec claude
 amq coop exec codex
 ```
 
-Each command sets up the environment, starts wake notifications, and launches
-the agent. Wake treats terminal notification as an attempt, not delivery, and
-retries on a capped backoff (starting at 5s for input, 30s for attention-only)
-until the inbox makes durable progress; full diagnostics go to the private
-`agents/<agent>/.wake.log`, never to the agent's terminal. A receipt-aware
-integration using `--inject-via` can opt into `--retry-until injected` so a
-successful external injector suppresses further doorbell retries for an
-unchanged cohort; the default `--retry-until drained` waits for actual inbox
-progress instead. See [docs/wake-doorbell-acknowledgement.md](docs/wake-doorbell-acknowledgement.md)
-for the full retry ladder and acknowledgement contract.
+Each command sets up the session environment, starts wake notifications, and
+launches the agent. See [COOP.md](COOP.md#running-co-op-mode) for co-op
+operations and [the wake acknowledgement contract](docs/wake-doorbell-acknowledgement.md)
+for notification retries.
 
 > **First-message check:** start both agents before sending the test message.
 > A newly started wake deliberately baselines messages that were already
@@ -165,6 +150,10 @@ for the full retry ladder and acknowledgement contract.
 For isolated sessions (multiple pairs working on different features):
 
 ```bash
+amq session create feature-a
+amq launch --session feature-a
+
+# Run the emitted commands in separate terminals.
 amq coop exec --session feature-a claude
 amq coop exec --session feature-a codex
 amq coop exec --session feature-a grok     # Optional third peer
@@ -193,22 +182,9 @@ Run the appropriate append command once, then open a new terminal or source
 that startup file. Use the bare `eval` only when you intentionally want aliases
 in one already-open shell.
 
-`coop exec` auto-initializes `.agent-mail`/`.amqrc` at the worktree top when no
-eligible root exists (see [Global Root Fallback](#global-root-fallback) below);
-pass `--no-gitignore` or `--no-init` to opt out. Add `--require-wake` in
-managed launchers that should fail instead of launching the agent when the
-wake watcher cannot start — a fresh wake baselines messages already waiting
-(see the first-message check above), and `--require-wake` only accepts a wake
-that has proven itself ready, not merely reused.
-
-Launchers with a terminal-specific injector can add
-`--wake-inject-via /absolute/path/to/injector` plus repeated
-`--wake-inject-arg` values; the resulting claim survives an ordinary wake exit,
-so use `amq wake recover-owner` — not `amq wake repair` — if the owner process
-disappears unexpectedly. See
-[docs/wake-lifecycle.md](docs/wake-lifecycle.md) and
-[docs/wake-state-invariants.md](docs/wake-state-invariants.md) for the full
-injector-identity and ownership contract.
+`coop init` and direct `coop exec` provisioning remain available as low-level
+plumbing. See [COOP.md](COOP.md#low-level-provisioning) for those paths and
+advanced wake options; they are not a second project-onboarding flow.
 
 ### 3. Send & Receive
 
@@ -242,74 +218,11 @@ amq receipts list --me codex --msg-id <msg_id>
 amq reply --id <msg_id> --kind review_response --body "LGTM with comments"
 ```
 
-`amq read`, `amq drain`, and `amq monitor` now share the same strict header validation. If a message in `inbox/new` is corrupt or has malformed headers, the command moves it to DLQ and emits a `dlq` receipt instead of leaving it in place.
-
-`coop exec` and every shell-mode `amq env` invocation pin the terminal's exact
-root context with `AM_BASE_ROOT` plus `AM_SESSION`. For named sessions,
-`AM_BASE_ROOT` is the authorized parent; for sessionless contexts, it is the
-exact root and `AM_SESSION` is empty. `read`, `drain`, `monitor`, `watch`,
-`send`, `reply`, and all DLQ commands refuse a raw root that conflicts
-with that pin before reading, moving, or delivering mailbox state. An implicit
-participating command also refuses when the active pin conflicts with an
-initialized cwd-local queue discovered from a project `.amqrc` or repo-local
-`.agent-mail`; AMQ does not silently choose between the two roots. The narrow
-exception is a live identity-bound sessionless pin: when both identity tokens
-authenticate its exact root, that explicit context outranks ambient cwd
-discovery. Named, legacy, incomplete, stale, or mismatched pins still refuse.
-Otherwise, repin to the cwd-local queue, use deliberate `--session`/`--project`
-routing, or pass an explicit `--root` to confirm the active queue. Explicit
-roots remain subject to the ordinary pin checks. For deliberate raw-root access,
-`--ignore-session-pin` is accepted only together with a non-empty explicit
-`--root`; blank `--root` and `--session` values are usage errors. `list`
-remains a non-destructive inspection path: it warns on a pin mismatch but
-still lists the resolved mailbox. The exact base-backlog inspection path is
-quieter: an explicit `--root` equal to the current pin's own base root does
-not warn (and is identity-authenticated when identity tokens are present).
-Implicit, sibling, foreign, stale, and malformed contexts still warn.
-Unpinned scripts and CI retain the existing fail-open behavior.
-
-`amq doctor --root <path>` follows the same inspection-versus-mutation split:
-the explicit root selects the exact target but does not repin the shell or
-waive its session pin. Read-only inspection continues with a mismatch warning.
-`--fix-mailboxes` and `--ops --fix-wake-locks` refuse a mismatched target unless
-`--ignore-session-pin` is also supplied; that override requires an explicit
-non-empty `--root`. For a session whose roster lives only in its base, use
-`amq doctor --root <session> --base-root <base> --ignore-session-pin --fix-mailboxes`.
-`--base-root` is config authority only, must be the target itself or its direct
-parent, and never overrides the session pin.
-
-A missing mailbox is an error, not an empty inbox. When `drain` or `list --new`
-finds an actually empty inbox, it prints a stderr-only note if the same handle
-has pending messages in a sibling session, including an exact non-destructive
-`amq list --session <name> --me <handle> --new` command. `doctor --ops` reports
-the same condition as a `sibling_backlog` warning. When the active root is a
-session, an empty `drain` or `list --new` also notes unread mail for the same
-handle in the base root, while `doctor --ops` reports it as a `base_backlog`
-warning. Both include an exact non-destructive `amq list --root ...` command.
-In JSON output, `base_backlog` hints also include a structured `backlog` object
-with `root`, `current_session`, `agent`, `pending`, and `command`.
-The pin is an operational safety check, not access control: a local process can
-still repin the environment or use the explicit override.
-
-Git worktrees are isolated by default when the project root is relative (for
-example `{"root":".agent-mail"}`): the same session name resolves beneath each
-worktree, so two agents can appear to share `collab` while reading different
-mailboxes. `amq doctor --ops` warns when a linked worktree uses this local
-layout and when a peer has fresher presence in the same session under another
-worktree root. A `send --wait-for` timeout names its delivery root/session and
-points to that diagnostic.
-
-If agents in several worktrees should share one mailbox, give all of them the
-same absolute base root. Use an absolute, machine-local `.amqrc` value such as
-`{"root":"/absolute/path/to/shared/.agent-mail"}`, or remove the project-relative
-`.amqrc` and export `AMQ_GLOBAL_ROOT=/absolute/path/to/shared/.agent-mail`.
-Per-worktree isolation remains the default when sharing is not intended. A Git
-worktree without an eligible root does not implicitly inherit
-`~/.amqrc`; participating commands refuse that ambiguous route so a global
-default cannot silently select a different project's mailbox. `coop init`
-explicitly creates the worktree-local queue at its top; `coop exec` does the
-same when no eligible root exists. Bare repositories still require a worktree
-or explicit `--root`.
+`read`, `drain`, and `monitor` apply the same strict message validation. Invalid
+messages move to DLQ and produce a `dlq` receipt. Participating shells also pin
+their exact session context and refuse mismatched mailbox operations. See
+[Session routing and safety](docs/session-routing.md) for routing, raw-root
+overrides, worktree isolation, doctor repair gates, and backlog discovery.
 
 ### 4. Inspect Health
 
@@ -620,14 +533,16 @@ Building something on AMQ? Open an issue or PR to be listed here.
 ## Documentation
 
 - [INSTALL.md](INSTALL.md) — Alternative installation methods
-- [docs/amq-keepalive.md](docs/amq-keepalive.md) — Keepalive operations, lifecycle, and launcher integration
+- [docs/amq-keepalive.md](docs/amq-keepalive.md) — Keepalive command and safety reference
+- [docs/session-routing.md](docs/session-routing.md) — Session selection, routing guards, and worktree behavior
+- [docs/wake-operations.md](docs/wake-operations.md) — Wake inspection, repair, recovery, and retirement
 - [docs/wake-lifecycle.md](docs/wake-lifecycle.md) — Wake lock/target state contract, self-upgrade, log retention, JSON schema, injector identity
 - [docs/wake-doorbell-acknowledgement.md](docs/wake-doorbell-acknowledgement.md) — Wake retry ladder and `--retry-until` acknowledgement contract
 - [docs/wake-state-invariants.md](docs/wake-state-invariants.md) — Wake artifact ownership, lock states, and quarantine invariants
 - [docs/adapter-contract.md](docs/adapter-contract.md) — Formal v1 adapter contract for integration messages
 - [docs/adr-layer-extensions.md](docs/adr-layer-extensions.md) — ADR for stable layer extension surfaces
 - [docs/trace.md](docs/trace.md) — Read-only trace contract and evidence limits
-- [COOP.md](COOP.md) — Co-op mode protocol & best practices
+- [COOP.md](COOP.md) — Co-op workflow and supervisor operations
 - [CLAUDE.md](CLAUDE.md) — Agent instructions, CLI reference, architecture
 
 ## Development

--- a/docs/session-routing.md
+++ b/docs/session-routing.md
@@ -1,0 +1,85 @@
+# Session routing and safety
+
+AMQ keeps each named session in its own queue root. A participating shell is
+pinned by `AM_ROOT`, `AM_BASE_ROOT`, and `AM_SESSION`; identity-aware shells
+also carry AMQ-managed root identity tokens. For a named session,
+`AM_BASE_ROOT` is the authorized parent. For a sessionless context, it is the
+exact root and `AM_SESSION` is empty. Do not set the identity tokens manually.
+
+## Root selection
+
+Root precedence is explicit `--root`, `AM_ROOT`, project `.amqrc`,
+`AMQ_GLOBAL_ROOT`, then eligible implicit fallbacks. Within a Git checkout,
+only repo-local implicit state is eligible. An unreadable or invalid project
+`.amqrc` blocks lower-precedence fallback; an explicit `--root` or `AM_ROOT`
+can override it intentionally.
+
+A direct `--root` selects a queue. It is not a federation route. `send` refuses
+an explicit root in a different base tree when the caller has an active
+session and supplies no `--project`, `--session`, or `--from-session`. Use
+`--project` or `--session` for replyable routing because these options add the
+sender-origin metadata that `reply` needs. Bare-root scripts without session
+evidence keep direct-root behavior and can create an unreplyable message.
+
+## Session guard
+
+`read`, `drain`, `monitor`, `watch`, and DLQ commands compare their target with
+the active pin before reading or moving mailbox state. `watch` and `monitor`
+repeat this check while they wait. `send` and `reply` apply the same guard to
+their local source. A mismatch exits with code 5. Target routing does not
+authorize a mismatched source.
+
+An implicit participating command also refuses when its pin conflicts with an
+initialized queue in the current project. A live identity-bound sessionless
+pin is the narrow exception: when both identity tokens authenticate its exact
+root, that explicit context outranks ambient project discovery. Named, legacy,
+incomplete, stale, and mismatched pins still refuse.
+
+Use a named `--session` or `--project` route when possible. For intentional
+raw-root access, `--ignore-session-pin` requires a non-empty explicit `--root`.
+Explicitly empty root or session values are usage errors. `--base-root` gives
+`doctor` configuration authority only; it does not bypass the guard.
+
+`list` and `doctor --root` remain read-only inspection paths on a mismatch and
+report a warning. Doctor repairs are allowed for the authenticated pinned base
+root or with an explicit `--root` plus `--ignore-session-pin`. Other mismatch
+repairs are skipped and reported as structured doctor errors while the doctor
+process continues with exit 0.
+
+`doctor --fix-mailboxes` creates only missing required directories for the
+configured roster and reserved `user` handle. It reports discovered mailboxes
+outside that roster but never repairs them. It does not edit, move, overwrite,
+or delete message files; unsafe types, symlinks, unreadable paths, and
+concurrent layout changes fail closed. `--base-root` must name the target or
+its direct parent.
+
+`send --from-session` is deliberately double-explicit and resolves its source
+from the supplied raw base; callers must verify that base. See
+[issue #104](https://github.com/avivsinai/agent-message-queue/issues/104).
+
+## Environment replacement
+
+Every shell-mode `amq env` result replaces `AM_ROOT`, `AM_ME`, `AM_BASE_ROOT`,
+and `AM_SESSION` as one context. Sessionless output pins the exact root and
+emits an empty session. An ambient root that conflicts with an existing pin is
+rejected unless a non-empty `--root` or `--session` explicitly repins it.
+`amq env --session` routes from a valid pinned base before it checks project
+configuration.
+
+## Creation and backlog discovery
+
+Create named sessions explicitly with `amq session create <name>`. `coop exec`
+uses the declared default session, or `collab` when no default is declared.
+Its missing-session bootstrap is deprecated except for zero-configuration
+`collab`; scripts must use `session create` or `init --root`. Bare repositories
+cannot host implicit bootstrap, and `coop exec --no-init` keeps the refusal.
+
+An empty `drain` or `list --new` performs a shallow sibling-session scan and
+prints exact inspection commands. `doctor --ops` reports the same state as
+`sibling_backlog`. When the active session differs from the base queue,
+`doctor --ops` can also report `base_backlog`; JSON output includes the target,
+session, agent, pending count, and exact inspection command.
+
+Git worktree diagnostics remain in `doctor --ops`, not the send path. Relative
+and auto-detected roots belong to one worktree; deliberate sharing requires an
+absolute `.amqrc` root or `AMQ_GLOBAL_ROOT`.

--- a/docs/wake-operations.md
+++ b/docs/wake-operations.md
@@ -1,0 +1,95 @@
+# Wake operations
+
+This reference defines the operator-facing contracts for `wake check`,
+`repair`, `recover-owner`, `retire`, and doctor wake repairs. For durable file
+and crash invariants, see [Wake state invariants](wake-state-invariants.md) and
+the [wake lifecycle document](wake-lifecycle.md).
+
+## Inspect before mutation
+
+Run `amq wake check --me <agent> --json` before stopping, repairing, or
+replacing a wake. The check is read-only. Its `restart_capability` is
+`agent_safe`, `operator_only`, or `unavailable`, and it supplies the next
+action when one is safe. Only `agent_safe` authorizes an automated agent to
+act. `operator_only` requires the owning terminal or supervisor.
+
+A non-TTY agent must preserve a live wake unless the check reports
+`agent_safe`. The check is advice, not mutation authority: every mutating
+command revalidates the current process, target, generation, root, and owner
+state before it changes anything.
+
+## Doctor
+
+`amq doctor --ops` reports queue depth, sibling-session backlog, DLQ age,
+presence freshness, integration hints, and wake health. Wake locks have two
+conservative problem states:
+
+- `stale`: AMQ proves that the recorded process is gone, mismatched, or not the
+  same `amq wake`. `--fix-wake-locks` rechecks and removes only this exact lock.
+- `unverified`: AMQ cannot prove ownership or staleness. Startup fails closed
+  and doctor preserves the lock for operator inspection.
+
+Wake-lock repair follows the session guard. A target outside the authenticated
+pinned base is inspected but not changed unless the command has an explicit
+root and `--ignore-session-pin`. A guard refusal is a structured doctor error;
+doctor otherwise exits 0.
+
+`notifier_live` means the wake-lock inspector confirmed a live wake process.
+It proves prompt notification, not message consumption. `recent_activity`
+means only that `last_seen` is fresh. AMQ does not claim `consumer_live`
+without a separate monitor heartbeat or lock.
+
+## Repair
+
+`amq wake repair --me <agent>` can replace a proven-stale inject-via wake. It
+can also supersede an unverified ownerless generic lock only after the saved
+target and continuity state pass the same fail-closed validation. Raw TTY
+wakes, owner-bound or invalid claims, and leftover targets without an eligible
+lock are not repairable.
+
+Repair requires a private mode-0600 `.wake.target` whose digest matches the
+lock. It also requires `.wake.repair-floor` to match the exact generation,
+target, physical root, boot, and owner state. The floor contains only the file
+identities already suppressed by that wake, not message IDs. Repair passes it
+to the replacement instead of taking a new inbox baseline, so arrivals during
+downtime and same-name DLQ retries remain eligible. Missing, corrupt, or
+mismatched continuity state requires a normal wake restart.
+
+Replacement diagnostics go to `agents/<agent>/.wake.repair.log`. Repair must
+not keep output pipes open after its command response exits. `doctor --ops`
+may report `target_present`, `repair_available`, and `repair_reason`, but it
+never starts a wake.
+
+## Owner recovery
+
+`amq wake recover-owner` releases one cooperative owner claim. A live owner
+must present the AMQ-managed `AMQ_WAKE_OWNER` token. A conclusively dead owner
+does not require the token. There is no force mode: unknown, live, legacy, or
+malformed owner state is preserved.
+
+## Retirement
+
+`amq wake retire` requires the expected absolute inject-via executable and its
+ordered fixed arguments. It stops only an identity-confirmed live inject-via
+wake with an unchanged saved target, using Linux pidfd signaling or the Darwin
+control socket. It can also remove an exactly bound proven-stale lock.
+
+Retirement preserves mailbox contents. Exact lock removal is its commit point:
+a failure before that point is `refused`; a later target or state cleanup
+failure is `retired_with_residue`, an exit-0 success with a warning. The other
+successful result is `retired`. A replacement generation is never selected
+for cleanup.
+
+The lifecycle boundaries are:
+
+- `repair` replaces a proven-stale eligible inject-via wake.
+- `recover-owner` releases one cooperative owner claim.
+- `doctor --ops --fix-wake-locks` removes one proven-stale lock.
+- `retire` stops an identity-confirmed inject-via wake.
+- launchd, systemd, or the owning shell stops a raw wake.
+
+Retirement does not unload a supervisor and cannot promise that the supervisor
+will not start another wake. Long-running wake and monitor supervision belongs
+to launchd, systemd, or another layer above daemon-free AMQ. The
+[co-op guide](../COOP.md#supervisor-recipes) owns supervisor recipes; the
+[keepalive reference](amq-keepalive.md) covers the macOS companion.

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -146,6 +146,10 @@ Before diving in, match the task to the right workflow — this avoids wasted ef
 
 ## Quick Start
 
+The repository [README Quick Start](https://github.com/avivsinai/agent-message-queue#quick-start)
+is the canonical human onboarding path. The commands below keep the agent
+workflow self-contained.
+
 ```bash
 # One-time project setup (preview, then write .amqrc, .amq/launch.json, default session)
 amq setup
@@ -153,6 +157,7 @@ amq setup -y   # automation only, after the caller accepted that preview
 
 # Daily entry: reconcile the declared session (never creates an unknown name)
 amq launch
+amq session create feature-x   # once, before the first named-session launch
 amq launch --session feature-x
 amq session resume feature-x
 ```
@@ -160,8 +165,8 @@ amq session resume feature-x
 The first semantic plan, and each plan change, needs an interactive trust
 confirmation stored outside the worktree. Non-interactive or `--json` calls
 exit `6` until that digest is trusted. An unknown `session resume` name exits
-`3` and writes nothing. Wave A prints complete `coop exec` commands and exits
-`6` because running them is the remaining operator action:
+`3` and writes nothing. The `commands` backend prints complete `coop exec`
+commands and exits `6` because running them is the remaining operator action:
 
 ```bash
 # Then run the emitted commands, one terminal each
@@ -577,7 +582,7 @@ Prose like `operator-held`, `pending operator`, or `manual approval` **inside an
 | `decision` | — | normal |
 | `todo` | — | normal |
 | `status` | — | low |
-| `brainstorm` | — | low |
+| `brainstorm` | — | normal |
 
 ## References
 


### PR DESCRIPTION
Closes #504.

## Changes

- make README Quick Start the single setup-to-launch onboarding path
- keep co-op and supervisor operations in COOP.md
- reduce CLAUDE.md to a current project and command contract
- move detailed session-routing and wake lifecycle operations into evergreen references
- keep AGENTS.md as a Codex-only compatibility shim
- remove internal program jargon and correct the documented brainstorm priority

## Verification

- peer review of the exact staged diff: approved with no findings
- `make ci`
- jargon sweep across README, COOP, CLAUDE, AGENTS, docs, and skills
- local Markdown target check
- `git diff --check`