### PR TITLE
chore(go): bump toolchain to go1.26.6 for net/url and crypto/tls CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/avivsinai/agent-message-queue
 
 go 1.25.12
 
+toolchain go1.26.6
+
 require (
 	github.com/coder/websocket v1.8.15
 	github.com/fsnotify/fsnotify v1.10.1


### PR DESCRIPTION
## Changes

- keep the module language minimum at Go 1.25.12
- pin the resolved build toolchain to Go 1.26.6 through the `toolchain` directive
- let existing setup-go v7 `go-version-file: go.mod` steps consume the single owning pin

## Reason

Current PR builds fail `govulncheck` on reachable standard-library vulnerabilities GO-2026-6218, GO-2026-6090, GO-2026-5972, and GO-2026-5026 under Go 1.25.12.

## Verification

- peer review of the exact staged diff: approved
- `go version`: go1.26.6
- `govulncheck ./...`: No vulnerabilities found
- `make ci`
- pre-push full checks