### PR TITLE
fix(launch): gate conversation continuity on execution evidence

### DIFF
--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -150,17 +151,14 @@ func TestLaunchNonInteractiveUntrustedIsExit6AndNoRuntimeWrites(t *testing.T) {
 	}
 }
 
-func TestLaunchAndSessionResumeKeepSessionQualifiedConversation(t *testing.T) {
-	project, _ := launchCLIFixture(t, "one", "two")
+func TestLaunchWithoutExecutionRemintsAndResumeJSONKeepsSchema(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab", "empty")
 	launchIsTerminal = func() bool { return true }
 	launchInput = func() *bufio.Reader { return bufio.NewReader(strings.NewReader("y\n")) }
-	for _, session := range []string{"one", "two"} {
-		_, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--session", session}) })
-		if GetExitCode(err) != ExitActionRequired {
-			t.Fatalf("fresh %s exit=%d err=%v", session, GetExitCode(err), err)
-		}
+	if _, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--session", "collab"}) }); GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("first launch exit=%d err=%v", GetExitCode(err), err)
 	}
-	loadIdentity := func(session string) string {
+	loadRecord := func(session string) launch.ConversationRecord {
 		data, err := os.ReadFile(launch.ConversationPath(filepath.Join(project, defaultCoopRoot, session), "claude"))
 		if err != nil {
 			t.Fatal(err)
@@ -169,18 +167,58 @@ func TestLaunchAndSessionResumeKeepSessionQualifiedConversation(t *testing.T) {
 		if err := json.Unmarshal(data, &record); err != nil {
 			t.Fatal(err)
 		}
-		return record.Identity.ID
+		return record
 	}
-	oneID, twoID := loadIdentity("one"), loadIdentity("two")
-	if oneID == twoID {
-		t.Fatalf("sessions share conversation ID %q", oneID)
+	first := loadRecord("collab")
+	if first.State != launch.CapturePending || first.Identity.ID != "" || first.ExecutionEvidence != nil {
+		t.Fatalf("first record=%#v", first)
 	}
-	for session, wantID := range map[string]string{"one": oneID, "two": twoID} {
-		launchInput = func() *bufio.Reader { return bufio.NewReader(strings.NewReader("y\n")) }
-		stdout, _, err := captureEnvOutput(t, func() error { return runSession([]string{"resume", session}) })
-		if GetExitCode(err) != ExitActionRequired || !strings.Contains(stdout, wantID) {
-			t.Fatalf("resume %s did not emit exact ID %s: exit=%d output=%s err=%v", session, wantID, GetExitCode(err), stdout, err)
-		}
+
+	launchJSON, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--session", "collab", "--json"}) })
+	if GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("second launch exit=%d output=%s err=%v", GetExitCode(err), launchJSON, err)
+	}
+	var second launch.ReconcileResult
+	if err := json.Unmarshal([]byte(launchJSON), &second); err != nil {
+		t.Fatal(err)
+	}
+	if second.Plan == nil || second.Plan.Agents[0].ConversationID == first.LaunchNonce ||
+		second.Agents[0].ConversationDisposition != launch.DispositionFresh || second.Agents[0].Reason != launch.ReasonPriorLaunchNotExecuted {
+		t.Fatalf("second result=%#v first=%#v", second, first)
+	}
+	secondRecord := loadRecord("collab")
+	if secondRecord.State != launch.CapturePending || secondRecord.LaunchNonce != second.Plan.Agents[0].ConversationID || secondRecord.ExecutionEvidence != nil {
+		t.Fatalf("second record=%#v result=%#v", secondRecord, second)
+	}
+
+	resumeJSON, _, err := captureEnvOutput(t, func() error { return runSession([]string{"resume", "empty", "--json"}) })
+	if GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("empty resume exit=%d output=%s err=%v", GetExitCode(err), resumeJSON, err)
+	}
+	var resume launch.ReconcileResult
+	if err := json.Unmarshal([]byte(resumeJSON), &resume); err != nil {
+		t.Fatal(err)
+	}
+	if resume.Outcome != launch.OutcomeActionRequired || resume.Reason != launch.ReasonNoSavedConversation ||
+		resume.Agents[0].ConversationDisposition != launch.DispositionActionRequired {
+		t.Fatalf("resume result=%#v", resume)
+	}
+	var launchShape, resumeShape map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(launchJSON), &launchShape); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(resumeJSON), &resumeShape); err != nil {
+		t.Fatal(err)
+	}
+	launchKeys, resumeKeys := map[string]bool{}, map[string]bool{}
+	for key := range launchShape {
+		launchKeys[key] = true
+	}
+	for key := range resumeShape {
+		resumeKeys[key] = true
+	}
+	if !reflect.DeepEqual(launchKeys, resumeKeys) {
+		t.Fatalf("launch JSON keys=%v resume JSON keys=%v", launchKeys, resumeKeys)
 	}
 }
 

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -184,11 +184,16 @@ func cloneEnv(overlay map[string]string) map[string]string {
 
 func validateKnownExecutable(executable, projectRoot, provider string) (string, error) {
 	if !filepath.IsAbs(executable) {
-		resolvedPath, err := exec.LookPath(executable)
+		lookedUp, err := exec.LookPath(executable)
 		if err != nil {
 			return "", fmt.Errorf("resolve %s executable: %w", provider, err)
 		}
-		executable = resolvedPath
+		executable, err = filepath.Abs(lookedUp)
+		if err != nil {
+			return "", fmt.Errorf("make %s executable absolute: %w", provider, err)
+		}
+	} else {
+		executable = filepath.Clean(executable)
 	}
 	resolvedExecutable, err := filepath.EvalSymlinks(executable)
 	if err != nil {
@@ -218,7 +223,11 @@ func validateKnownExecutable(executable, projectRoot, provider string) (string, 
 	if !info.Mode().IsRegular() || (runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0) {
 		return "", fmt.Errorf("%s executable is not an executable regular file", provider)
 	}
-	return resolvedExecutable, nil
+	// Keep the stable pre-resolution path in the plan and semantic digest. The
+	// physical target is used only for the security and executability checks
+	// above; persisting it would freeze version-manager symlink targets and
+	// change trust digests on every tool update.
+	return executable, nil
 }
 
 func validateWorkingDirectory(cwd, projectRoot string) error {

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -234,6 +234,13 @@ func TestAdapterRejectsProjectExecutableAndProviderMismatch(t *testing.T) {
 	if _, err := adapter.PlanFresh(request); err == nil || !strings.Contains(err.Error(), "inside the project") {
 		t.Fatalf("project executable error = %v", err)
 	}
+	externalLink := filepath.Join(t.TempDir(), ClaudeProvider)
+	if err := os.Symlink(inside, externalLink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewClaudeAdapter(externalLink).PlanFresh(request); err == nil || !strings.Contains(err.Error(), "inside the project") {
+		t.Fatalf("external symlink to project executable error = %v", err)
+	}
 
 	otherProject, codexExecutable := testExecutable(t, CodexProvider)
 	request = planRequest(otherProject, ClaudeProvider)
@@ -242,19 +249,65 @@ func TestAdapterRejectsProjectExecutableAndProviderMismatch(t *testing.T) {
 	}
 }
 
-func TestAdapterResolvesConfiguredExecutableFromPath(t *testing.T) {
-	project, executable := testExecutable(t, ClaudeProvider)
-	t.Setenv("PATH", filepath.Dir(executable))
-	plan, err := NewClaudeAdapter(ClaudeProvider).PlanFresh(planRequest(project, ClaudeProvider))
+func TestAdapterKeepsStableExecutableAcrossSymlinkRetarget(t *testing.T) {
+	base := t.TempDir()
+	project := filepath.Join(base, "project")
+	bin := filepath.Join(base, "bin")
+	versions := filepath.Join(base, "versions")
+	for _, dir := range []string{project, bin, versions} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	versionA := filepath.Join(versions, "claude-a")
+	versionB := filepath.Join(versions, "claude-b")
+	for _, path := range []string{versionA, versionB} {
+		if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	executable := filepath.Join(bin, ClaudeProvider)
+	if err := os.Symlink(versionA, executable); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	request := planRequest(project, ClaudeProvider)
+	first, err := NewClaudeAdapter(ClaudeProvider).PlanFresh(request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolved, err := filepath.EvalSymlinks(executable)
+	firstDigest, err := (Plan{Version: PlanVersion, Agents: []AgentPlan{first}}).SemanticDigest()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Argv[0] != resolved {
-		t.Fatalf("resolved executable = %q, want %q", plan.Argv[0], resolved)
+	if err := os.Remove(executable); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(versionB, executable); err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewClaudeAdapter(ClaudeProvider).PlanFresh(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondDigest, err := (Plan{Version: PlanVersion, Agents: []AgentPlan{second}}).SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Argv[0] != executable || second.Argv[0] != executable {
+		t.Fatalf("planned argv0 = %q then %q, want stable %q", first.Argv[0], second.Argv[0], executable)
+	}
+	if firstDigest != secondDigest {
+		t.Fatalf("symlink retarget changed semantic digest: %s != %s", firstDigest, secondDigest)
+	}
+	emitted, err := (Commands{}).Create(CreateRequest{
+		Session: "collab", AMQPath: "amq", Plan: Plan{Version: PlanVersion, Agents: []AgentPlan{second}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(emitted.Commands) != 1 || len(emitted.Commands[0].Argv) < 8 || emitted.Commands[0].Argv[7] != executable {
+		t.Fatalf("emitted command argv = %#v, want stable executable %q", emitted.Commands, executable)
 	}
 }
 

--- a/internal/launch/conversation.go
+++ b/internal/launch/conversation.go
@@ -18,13 +18,26 @@ const (
 // ConversationRecord is provider-qualified runtime state for one
 // (session, handle). It carries no execution authority.
 type ConversationRecord struct {
-	Version         int                  `json:"version"`
-	Handle          string               `json:"handle"`
-	State           CaptureState         `json:"state"`
-	Identity        ConversationIdentity `json:"identity,omitempty"`
-	ProviderVersion string               `json:"provider_version,omitempty"`
-	LaunchNonce     string               `json:"launch_nonce"`
-	Reason          CaptureReason        `json:"reason,omitempty"`
+	Version           int                            `json:"version"`
+	Handle            string                         `json:"handle"`
+	State             CaptureState                   `json:"state"`
+	Identity          ConversationIdentity           `json:"identity,omitempty"`
+	ProviderVersion   string                         `json:"provider_version,omitempty"`
+	LaunchNonce       string                         `json:"launch_nonce"`
+	ExecutionEvidence *ConversationExecutionEvidence `json:"execution_evidence,omitempty"`
+	Reason            CaptureReason                  `json:"reason,omitempty"`
+}
+
+// ConversationExecutionEvidence records the managed backend result that
+// proves a planned agent process started. It does not grant execution
+// authority; it prevents a minted identity from becoming resumable from plan
+// output alone.
+type ConversationExecutionEvidence struct {
+	Backend        string  `json:"backend"`
+	Profile        string  `json:"profile"`
+	Outcome        Outcome `json:"outcome"`
+	LaunchNonce    string  `json:"launch_nonce"`
+	ConversationID string  `json:"conversation_id,omitempty"`
 }
 
 func (record ConversationRecord) Validate() error {
@@ -37,14 +50,34 @@ func (record ConversationRecord) Validate() error {
 	if !validUUID(record.LaunchNonce) {
 		return fmt.Errorf("conversation launch nonce must be a UUID")
 	}
+	if record.ExecutionEvidence != nil {
+		if strings.TrimSpace(record.ExecutionEvidence.Backend) == "" || strings.TrimSpace(record.ExecutionEvidence.Profile) == "" {
+			return fmt.Errorf("conversation execution evidence is incomplete")
+		}
+		if record.ExecutionEvidence.Outcome != OutcomeCreated {
+			return fmt.Errorf("conversation execution evidence outcome must be created")
+		}
+		if record.ExecutionEvidence.LaunchNonce != record.LaunchNonce {
+			return fmt.Errorf("conversation execution evidence launch nonce mismatch")
+		}
+	}
 	switch record.State {
 	case CapturePending:
 		if record.Identity.Provider != "" || record.Identity.ID != "" {
 			return fmt.Errorf("pending conversation must not contain an identity")
 		}
+		if record.ExecutionEvidence != nil {
+			return fmt.Errorf("pending conversation must not contain execution evidence")
+		}
 	case CaptureReady:
 		if strings.TrimSpace(record.Identity.Provider) == "" || !validUUID(record.Identity.ID) {
 			return fmt.Errorf("ready conversation requires a provider-qualified UUID")
+		}
+		if record.ExecutionEvidence == nil {
+			return fmt.Errorf("ready conversation requires execution evidence")
+		}
+		if record.ExecutionEvidence.ConversationID != record.Identity.ID {
+			return fmt.Errorf("conversation execution evidence identity mismatch")
 		}
 	case CaptureStale, CaptureUnsupported:
 		if record.Reason == "" {

--- a/internal/launch/conversation_test.go
+++ b/internal/launch/conversation_test.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -12,6 +13,10 @@ func TestConversationRoundTripRequiresHandleLock(t *testing.T) {
 		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
 		Identity:    ConversationIdentity{Provider: ClaudeProvider, ID: testConversationID},
 		LaunchNonce: testLaunchNonce,
+		ExecutionEvidence: &ConversationExecutionEvidence{
+			Backend: "test", Profile: "test/any/v1", Outcome: OutcomeCreated,
+			LaunchNonce: testLaunchNonce, ConversationID: testConversationID,
+		},
 	}
 	if err := WriteConversation(root, lease, record); err == nil {
 		t.Fatal("WriteConversation without handle lock succeeded")
@@ -35,6 +40,17 @@ func TestConversationRoundTripRequiresHandleLock(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("conversation permissions = %04o", info.Mode().Perm())
+	}
+}
+
+func TestConversationRejectsReadyWithoutExecutionEvidence(t *testing.T) {
+	record := ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity:    ConversationIdentity{Provider: ClaudeProvider, ID: testConversationID},
+		LaunchNonce: testLaunchNonce,
+	}
+	if err := record.Validate(); err == nil || !strings.Contains(err.Error(), "requires execution evidence") {
+		t.Fatalf("ready record without evidence error = %v", err)
 	}
 }
 

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -22,6 +22,13 @@ const (
 	DispositionDisabled        ConversationDisposition = "disabled"
 	DispositionUnsupported     ConversationDisposition = "unsupported"
 	DispositionDegraded        ConversationDisposition = "degraded"
+	DispositionActionRequired  ConversationDisposition = "action_required"
+)
+
+const (
+	ReasonNoSavedConversation    = "no_saved_conversation"
+	ReasonPriorLaunchNotExecuted = "prior_launch_not_executed"
+	ReasonStaleConversation      = "stale_conversation"
 )
 
 type RebindDisposition string
@@ -60,19 +67,19 @@ type AgentReconcileResult struct {
 	Handle                  string                  `json:"handle"`
 	Code                    int                     `json:"code"`
 	ConversationDisposition ConversationDisposition `json:"conversation_disposition"`
-	Reason                  string                  `json:"reason,omitempty"`
+	Reason                  string                  `json:"reason"`
 }
 
 type ReconcileResult struct {
 	Session        string                 `json:"session"`
-	Backend        string                 `json:"backend,omitempty"`
-	Outcome        Outcome                `json:"outcome,omitempty"`
+	Backend        string                 `json:"backend"`
+	Outcome        Outcome                `json:"outcome"`
 	AggregateCode  int                    `json:"aggregate_code"`
-	Reason         string                 `json:"reason,omitempty"`
+	Reason         string                 `json:"reason"`
 	Agents         []AgentReconcileResult `json:"agents"`
-	Commands       []EmittedCommand       `json:"commands,omitempty"`
-	Plan           *Plan                  `json:"plan,omitempty"`
-	SemanticDigest string                 `json:"semantic_digest,omitempty"`
+	Commands       []EmittedCommand       `json:"commands"`
+	Plan           *Plan                  `json:"plan"`
+	SemanticDigest string                 `json:"semantic_digest"`
 }
 
 type plannedAgent struct {
@@ -85,7 +92,7 @@ type plannedAgent struct {
 }
 
 func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr error) {
-	result = ReconcileResult{Session: request.Session, Agents: []AgentReconcileResult{}}
+	result = ReconcileResult{Session: request.Session, Agents: []AgentReconcileResult{}, Commands: []EmittedCommand{}}
 	if request.Context == nil {
 		request.Context = context.Background()
 	}
@@ -108,6 +115,10 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	}
 	if len(planned) == 0 {
 		result.AggregateCode = aggregateReconcileCode(result.Agents)
+		if result.AggregateCode == 6 {
+			result.Outcome = OutcomeActionRequired
+			result.Reason = firstReconcileReason(result.Agents, 6)
+		}
 		return result, nil
 	}
 	plan := Plan{Version: PlanVersion, Agents: make([]AgentPlan, 0, len(planned))}
@@ -199,8 +210,31 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	if err := callCrashHook(request.CrashHook, "backend_created"); err != nil {
 		return result, err
 	}
+	var candidate *BindingRecord
+	var executionEvidence *ConversationExecutionEvidence
+	if create.Outcome == OutcomeCreated {
+		created := create.Binding
+		if created.Backend != backendName || created.Profile != detect.Profile.Identity() || created.LaunchNonce != nonce {
+			return result, fmt.Errorf("backend returned a binding outside the selected launch generation")
+		}
+		if err := created.Validate(); err != nil {
+			return result, fmt.Errorf("backend returned invalid binding: %w", err)
+		}
+		candidate = &created
+		executionEvidence = &ConversationExecutionEvidence{
+			Backend: backendName, Profile: detect.Profile.Identity(), Outcome: OutcomeCreated, LaunchNonce: nonce,
+		}
+	}
 	for i := range planned {
 		agent := &planned[i]
+		if agent.write && executionEvidence != nil {
+			evidence := *executionEvidence
+			agent.record.ExecutionEvidence = &evidence
+		}
+		if agent.plan.AdapterMode == AdapterModeMint && agent.write && executionEvidence != nil {
+			agent.record.State = CaptureReady
+			agent.record.Identity = ConversationIdentity{Provider: agent.adapter.Name(), ID: agent.plan.ConversationID}
+		}
 		if agent.plan.AdapterMode == AdapterModeCapture && agent.write {
 			capture := agent.adapter.CaptureIdentity(CaptureRequest{
 				LaunchNonce: agent.plan.LaunchNonce, ExpectedProviderVersion: agent.providerVersion,
@@ -217,6 +251,9 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 				result.Agents[agent.index].Reason = string(capture.Reason)
 			}
 		}
+		if agent.record.State == CaptureReady && agent.record.ExecutionEvidence != nil {
+			agent.record.ExecutionEvidence.ConversationID = agent.record.Identity.ID
+		}
 		if agent.write {
 			if err := WriteConversation(request.Root, lease, agent.record); err != nil {
 				return result, err
@@ -226,12 +263,8 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	if err := callCrashHook(request.CrashHook, "conversations_written"); err != nil {
 		return result, err
 	}
-	if create.Outcome == OutcomeCreated {
-		candidate := create.Binding
-		if candidate.Backend != backendName || candidate.Profile != detect.Profile.Identity() || candidate.LaunchNonce != nonce {
-			return result, fmt.Errorf("backend returned a binding outside the selected launch generation")
-		}
-		if err := WriteBinding(request.Root, lease, candidate); err != nil {
+	if candidate != nil {
+		if err := WriteBinding(request.Root, lease, *candidate); err != nil {
 			return result, err
 		}
 	}
@@ -239,7 +272,9 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		for _, agent := range planned {
 			if result.Agents[agent.index].Code == 0 {
 				result.Agents[agent.index].Code = 6
-				result.Agents[agent.index].Reason = "commands_emitted"
+				if result.Agents[agent.index].Reason == "" {
+					result.Agents[agent.index].Reason = "commands_emitted"
+				}
 			}
 		}
 		result.AggregateCode = 6
@@ -247,6 +282,9 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		return result, nil
 	}
 	result.AggregateCode = aggregateReconcileCode(result.Agents)
+	if result.AggregateCode != 0 && result.Reason == "" {
+		result.Reason = firstReconcileReason(result.Agents, result.AggregateCode)
+	}
 	return result, nil
 }
 
@@ -296,17 +334,34 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 		}
 		var agentPlan AgentPlan
 		var err error
-		if !forceFresh && hasConversation && conversation.State == CaptureReady {
+		planReason := ""
+		if request.ResumeOnly && !hasConversation {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionActionRequired, ReasonNoSavedConversation
+			result.Agents = append(result.Agents, item)
+			continue
+		} else if request.ResumeOnly {
+			if conversation.State == CaptureReady {
+				agentPlan, err = adapter.PlanResume(ResumeRequest{PlanRequest: base, Conversation: conversation.Identity})
+				if err == nil {
+					disposition = DispositionResumed
+				}
+			} else {
+				err = fmt.Errorf("conversation identity is %s", conversation.State)
+			}
+		} else if !forceFresh && hasConversation && conversation.State == CaptureReady {
 			agentPlan, err = adapter.PlanResume(ResumeRequest{PlanRequest: base, Conversation: conversation.Identity})
 			if err == nil {
 				disposition = DispositionResumed
 			}
-		} else if !forceFresh && (request.ResumeOnly || hasConversation) {
+		} else if !forceFresh && hasConversation && conversation.State == CapturePending && adapter.Mode() == AdapterModeMint {
+			agentPlan, err = adapter.PlanFresh(base)
+			disposition, planReason = DispositionFresh, ReasonPriorLaunchNotExecuted
+		} else if !forceFresh && hasConversation {
 			err = fmt.Errorf("conversation identity is %s", conversation.State)
 		}
 		if err != nil && !forceFresh {
 			if !request.AllowFreshFallback {
-				item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, "stale_conversation"
+				item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, ReasonStaleConversation
 				result.Agents = append(result.Agents, item)
 				continue
 			}
@@ -329,15 +384,11 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			result.Agents = append(result.Agents, item)
 			continue
 		}
-		item.ConversationDisposition = disposition
+		item.ConversationDisposition, item.Reason = disposition, planReason
 		result.Agents = append(result.Agents, item)
 		record := ConversationRecord{
 			Version: ConversationVersion, Handle: cfg.Handle, State: CapturePending,
 			ProviderVersion: capabilities.ProviderVersion, LaunchNonce: nonce,
-		}
-		if agentPlan.AdapterMode == AdapterModeMint {
-			record.State = CaptureReady
-			record.Identity = ConversationIdentity{Provider: adapter.Name(), ID: agentPlan.ConversationID}
 		}
 		planned = append(planned, plannedAgent{
 			plan: agentPlan, record: record, write: disposition != DispositionResumed,
@@ -574,6 +625,15 @@ func aggregateReconcileCode(agents []AgentReconcileResult) int {
 		}
 	}
 	return best
+}
+
+func firstReconcileReason(agents []AgentReconcileResult, code int) string {
+	for _, agent := range agents {
+		if agent.Code == code && agent.Reason != "" {
+			return agent.Reason
+		}
+	}
+	return ""
 }
 
 func callCrashHook(hook func(string) error, stage string) error {

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -2,7 +2,10 @@ package launch
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -61,6 +64,7 @@ type reconcileBackend struct {
 	createGate  chan struct{}
 	createStart chan struct{}
 	capture     bool
+	invalidBind bool
 }
 
 func (b *reconcileBackend) Detect() DetectResult {
@@ -88,6 +92,9 @@ func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
 		Profile: b.Detect().Profile.Identity(), LaunchNonce: req.Plan.Agents[0].LaunchNonce,
 		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:test"}}},
 	}}
+	if b.invalidBind {
+		result.Binding.Resources.Version = 0
+	}
 	if b.capture {
 		evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Plan.Agents[0].LaunchNonce, false)
 		if err != nil {
@@ -169,6 +176,13 @@ func writeReconcileConversation(t *testing.T, req ReconcileRequest, record Conve
 	}
 }
 
+func reconcileExecutionEvidence(backend *reconcileBackend, nonce string) *ConversationExecutionEvidence {
+	return &ConversationExecutionEvidence{
+		Backend: backend.name, Profile: backend.Detect().Profile.Identity(), Outcome: OutcomeCreated,
+		LaunchNonce: nonce, ConversationID: testConversationID,
+	}
+}
+
 func TestReconcileInspectUnknownMakesZeroBackendMutations(t *testing.T) {
 	backend := &reconcileBackend{name: "test", inspect: InspectUnknown}
 	req := reconcileFixture(t, backend)
@@ -188,6 +202,7 @@ func TestReconcilePresentCompatibleAttachesWithoutCreate(t *testing.T) {
 	writeReconcileConversation(t, req, ConversationRecord{
 		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
 		Identity: ConversationIdentity{Provider: "claude", ID: testConversationID}, LaunchNonce: testLaunchNonce,
+		ExecutionEvidence: reconcileExecutionEvidence(backend, testLaunchNonce),
 	})
 	writeReconcileBinding(t, req, backend, backend.Detect().Profile.Identity())
 	result, err := Reconcile(req)
@@ -321,18 +336,46 @@ func TestReconcileStaleHandleFailsClosedWhilePeerContinues(t *testing.T) {
 	})
 	writeReconcileConversation(t, req, ConversationRecord{
 		Version: ConversationVersion, Handle: "peer", State: CaptureReady,
-		Identity:    ConversationIdentity{Provider: "claude", ID: testConversationID},
-		LaunchNonce: testLaunchNonce,
+		Identity:          ConversationIdentity{Provider: "claude", ID: testConversationID},
+		LaunchNonce:       testLaunchNonce,
+		ExecutionEvidence: reconcileExecutionEvidence(backend, testLaunchNonce),
 	})
 	result, err := Reconcile(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.AggregateCode != 6 || backend.creates != 1 || result.Plan == nil || len(result.Plan.Agents) != 1 || result.Plan.Agents[0].Handle != "peer" {
+	if result.AggregateCode != 6 || result.Reason != ReasonStaleConversation || backend.creates != 1 || result.Plan == nil || len(result.Plan.Agents) != 1 || result.Plan.Agents[0].Handle != "peer" {
 		t.Fatalf("partial stale result=%#v creates=%d", result, backend.creates)
 	}
 	if result.Agents[0].Reason != "stale_conversation" || result.Agents[1].ConversationDisposition != DispositionResumed {
 		t.Fatalf("agent results=%#v", result.Agents)
+	}
+}
+
+func TestReconcileResumeDistinguishesNoSavedConversationFromStale(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	req.ResumeOnly = true
+	missing, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing.AggregateCode != 6 || missing.Outcome != OutcomeActionRequired || missing.Reason != ReasonNoSavedConversation ||
+		missing.Agents[0].ConversationDisposition != DispositionActionRequired || missing.Agents[0].Reason != ReasonNoSavedConversation || backend.creates != 0 {
+		t.Fatalf("missing result=%#v creates=%d", missing, backend.creates)
+	}
+
+	writeReconcileConversation(t, req, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureStale,
+		LaunchNonce: testLaunchNonce, Reason: CaptureReasonEvidenceMissing,
+	})
+	stale, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale.AggregateCode != 6 || stale.Outcome != OutcomeActionRequired || stale.Reason != ReasonStaleConversation ||
+		stale.Agents[0].ConversationDisposition != DispositionDegraded || stale.Agents[0].Reason != ReasonStaleConversation || backend.creates != 0 {
+		t.Fatalf("stale result=%#v creates=%d", stale, backend.creates)
 	}
 }
 
@@ -351,6 +394,125 @@ func TestReconcileStaleAllowsExplicitFreshFallback(t *testing.T) {
 	}
 	if result.AggregateCode != 0 || result.Agents[0].ConversationDisposition != DispositionFreshAfterStale || backend.creates != 1 {
 		t.Fatalf("fallback result=%#v", result)
+	}
+}
+
+func TestReconcilePlanOnlyMintWithoutExecutionRemintsPending(t *testing.T) {
+	backend := Commands{}
+	req := reconcileFixture(t, backend)
+	first, err := Reconcile(req)
+	if err != nil || first.AggregateCode != 6 || first.Outcome != OutcomeCommandsEmitted || first.Plan == nil {
+		t.Fatalf("first result=%#v err=%v", first, err)
+	}
+	firstID := first.Plan.Agents[0].ConversationID
+	firstRecord, err := LoadConversation(req.Root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstRecord.State != CapturePending || firstRecord.Identity.ID != "" || firstRecord.ExecutionEvidence != nil || firstRecord.LaunchNonce != firstID {
+		t.Fatalf("first record=%#v, want pending nonce %q without evidence", firstRecord, firstID)
+	}
+	resumeReq := req
+	resumeReq.ResumeOnly = true
+	resume, err := Reconcile(resumeReq)
+	if err != nil || resume.AggregateCode != 6 || resume.Reason != ReasonStaleConversation || resume.Plan != nil {
+		t.Fatalf("resume pending result=%#v err=%v", resume, err)
+	}
+	unchanged, err := LoadConversation(req.Root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged.LaunchNonce != firstID {
+		t.Fatalf("resume reminted pending record: got %q want %q", unchanged.LaunchNonce, firstID)
+	}
+
+	second, err := Reconcile(req)
+	if err != nil || second.AggregateCode != 6 || second.Outcome != OutcomeCommandsEmitted || second.Plan == nil {
+		t.Fatalf("second result=%#v err=%v", second, err)
+	}
+	secondID := second.Plan.Agents[0].ConversationID
+	if secondID == firstID || second.Agents[0].ConversationDisposition != DispositionFresh || second.Agents[0].Reason != ReasonPriorLaunchNotExecuted {
+		t.Fatalf("second result=%#v, first ID=%q second ID=%q", second, firstID, secondID)
+	}
+	secondRecord, err := LoadConversation(req.Root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondRecord.State != CapturePending || secondRecord.LaunchNonce != secondID || secondRecord.ExecutionEvidence != nil {
+		t.Fatalf("second record=%#v, want new pending nonce %q", secondRecord, secondID)
+	}
+}
+
+func TestReconcileMintExecutionEvidencePromotesThenResumesExactIdentity(t *testing.T) {
+	commands := Commands{}
+	req := reconcileFixture(t, commands)
+	first, err := Reconcile(req)
+	if err != nil || first.Plan == nil {
+		t.Fatalf("first result=%#v err=%v", first, err)
+	}
+	firstID := first.Plan.Agents[0].ConversationID
+
+	managed := &reconcileBackend{name: "managed", inspect: InspectAbsent}
+	req.Launcher = managed.name
+	req.Preferences = []string{managed.name}
+	req.Backends = map[string]Backend{managed.name: managed}
+	second, err := Reconcile(req)
+	if err != nil || second.AggregateCode != 0 || second.Plan == nil {
+		t.Fatalf("second result=%#v err=%v", second, err)
+	}
+	readyID := second.Plan.Agents[0].ConversationID
+	if readyID == firstID || second.Agents[0].Reason != ReasonPriorLaunchNotExecuted || second.Agents[0].ConversationDisposition != DispositionFresh {
+		t.Fatalf("second result=%#v, first ID=%q ready ID=%q", second, firstID, readyID)
+	}
+	record, err := LoadConversation(req.Root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State != CaptureReady || record.Identity.ID != readyID || record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != managed.name {
+		t.Fatalf("promoted record=%#v", record)
+	}
+
+	third, err := Reconcile(req)
+	if err != nil || third.AggregateCode != 0 || third.Plan == nil {
+		t.Fatalf("third result=%#v err=%v", third, err)
+	}
+	if third.Agents[0].ConversationDisposition != DispositionResumed || third.Plan.Agents[0].ConversationID != readyID {
+		t.Fatalf("third result=%#v, want resumed ID %q", third, readyID)
+	}
+}
+
+func TestReconcileInvalidCreatedBindingCannotPromoteMint(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent, invalidBind: true}
+	req := reconcileFixture(t, backend)
+	if _, err := Reconcile(req); err == nil || !strings.Contains(err.Error(), "invalid binding") {
+		t.Fatalf("Reconcile error = %v", err)
+	}
+	if _, err := LoadConversation(req.Root, "claude"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid binding published conversation state: %v", err)
+	}
+}
+
+func TestReconcileReadyRecordWithoutExecutionEvidenceFailsClosed(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	req.ResumeOnly = true
+	data, err := json.Marshal(ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity:    ConversationIdentity{Provider: "claude", ID: testConversationID},
+		LaunchNonce: testLaunchNonce,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := req.Root.WriteFileAtomic(conversationDir, "claude.json", append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Outcome != OutcomeActionRequired || result.Agents[0].Reason != "conversation_state_unreadable" || backend.creates != 0 || result.Plan != nil {
+		t.Fatalf("result=%#v creates=%d", result, backend.creates)
 	}
 }
 
@@ -476,7 +638,7 @@ func TestReconcileCaptureEvidencePersistsExactIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record.State != CaptureReady || record.Identity.Provider != CodexProvider || record.Identity.ID != "019c8a2f-2b13-7000-8000-000000000001" {
+	if record.State != CaptureReady || record.Identity.Provider != CodexProvider || record.Identity.ID != "019c8a2f-2b13-7000-8000-000000000001" || record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != backend.name {
 		t.Fatalf("record=%#v", record)
 	}
 }


### PR DESCRIPTION
## Summary

- keep the stable pre-resolution executable path in plans, digests, and emitted commands while validating the resolved target
- persist minted identities as pending until a managed backend provides execution evidence
- report honest resume outcomes for missing, stale, and unexecuted conversation state
- keep launch and resume JSON on one stable top-level schema

## Validation

- `go test ./internal/launch ./internal/cli -count=1`
- `make ci`
- peer hostile-boundary battery and full suite

Refs: #480 #504