### PR TITLE
feat(launch): add managed-create recovery journal and execution acknowledgement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,11 @@ from another or weaken an uncertain state. See [Wake operations](docs/wake-opera
 [wake state invariants](docs/wake-state-invariants.md), and the
 [doorbell acknowledgement policy](docs/wake-doorbell-acknowledgement.md).
 
+**Managed launch recovery**: A mode-0600 journal closes the create-before-binding
+crash window. A matching binding is authoritative; otherwise the backend must
+prove absent or adoptable state. Uncertain or partial state is action-required
+and preserved. See [Managed launch recovery](docs/launch-recovery.md).
+
 **Extension metadata**: Higher layers own data below
 `<AM_ROOT>/extensions/<layer>/` or
 `<AM_ROOT>/agents/<handle>/extensions/<layer>/`. AMQ does not execute extension
@@ -123,7 +128,7 @@ workflow for each surface.
 | Delivery proof | `receipts list`, `receipts wait` | Inspect consumer-local `drained` and `dlq` outcomes. |
 | Live waits | `watch`, `monitor` | Wait for arrivals; `monitor` also drains and emits receipts. |
 | Routing | `route explain`, `presence set`, `presence list` | Explain a route and publish or inspect advisory presence. |
-| Health | `doctor`, `cleanup`, `upgrade` | Diagnose, perform explicit safe cleanup, or update the binary. |
+| Health | `doctor`, `cleanup`, `upgrade` | Diagnose, perform explicit safe cleanup (including exact stuck launch journals), or update the binary. |
 | Wake | `wake`, `wake check`, `wake repair`, `wake recover-owner`, `wake retire` | Notify, inspect capability, and make identity-safe lifecycle changes. |
 | DLQ | `dlq list`, `dlq read`, `dlq retry`, `dlq purge` | Inspect and explicitly recover or purge corrupt messages. |
 | Low-level provisioning | `init`, `coop init`, `coop exec` | Create raw queues or enter an agent process. See [COOP.md](COOP.md). |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ It never uses a provider's "last" or "continue" heuristic. The first semantic
 plan, and each semantic plan change, requires an interactive trust
 confirmation stored outside the worktree. Non-interactive or `--json` calls
 exit `6` until that digest is trusted. An unknown `session resume` name exits
-`3` and writes nothing.
+`3` and writes nothing. Managed backends use a fail-closed recovery journal;
+see [Managed launch recovery](docs/launch-recovery.md).
 
 The `commands` backend prints complete `coop exec` commands and exits `6`
 because executing them is the remaining operator action. Run the emitted
@@ -477,7 +478,7 @@ Canonical schema-selecting diagnostic forms:
 ```text
 amq wake check --me <agent> [--root <path>] [--strict] [--json] [--json-schema <1|2>]
 amq doctor [--root <path>] [--base-root <path>] [--ignore-session-pin] [--ops] [--fix-wake-locks] [--fix-mailboxes] [--json] [--json-schema <1|2>]
-amq cleanup [--tmp-older-than <duration>] [--wake-quarantine-older-than <duration>] [--dry-run] [--yes]
+amq cleanup [--tmp-older-than <duration>] [--wake-quarantine-older-than <duration>] [--launch-journal --root <session-root>] [--dry-run] [--yes]
 ```
 
 `--json-schema` requires `--json`.

--- a/docs/launch-recovery.md
+++ b/docs/launch-recovery.md
@@ -1,0 +1,62 @@
+# Managed launch recovery
+
+Managed launcher backends can create a terminal resource before AMQ commits its
+authoritative binding. AMQ records `meta/launch/journal.json` before `Create` so
+a crash cannot turn that gap into permission to spawn a duplicate layout.
+
+The journal is a private, mode-0600 recovery transaction. It binds the canonical
+project and session-root paths, session name, backend profile, host and backend
+instance identities, roster digest, semantic plan digest, launch nonce, and
+creation time. It can also retain the validated candidate binding and final
+conversation records needed to finish an interrupted commit. It contains no
+message data and is never a launcher binding.
+
+On the next launch, AMQ holds the session lease and follows these rules:
+
+- A valid binding from the same launch generation is authoritative. AMQ
+  completes any interrupted conversation writes and removes the journal.
+- Without a matching binding, the journaled backend must implement `Reclaim`
+  and prove the exact resource state within a bounded timeout.
+- Proven absence permits recreation with the journaled, trusted plan.
+- An adoptable resource must match the backend identity, profile, nonce, and
+  full candidate binding. AMQ revalidates it immediately before committing the
+  binding.
+- Incomplete, foreign, unknown, changed, or unsupported recovery returns
+  `action_required` and preserves the journal. Incomplete output includes the
+  exact resource inventory known to the backend.
+
+`Create` failures preserve the journal unless the backend returns the typed
+definite-pre-create error that proves no resource was made. Partial creation is
+never adoptable.
+
+If an operator chooses to abandon recovery evidence, first inspect the exact
+target without mutation:
+
+```bash
+amq cleanup --launch-journal --root <session-root> --dry-run --json
+```
+
+Removal requires confirmation or `--yes`. It removes only the unchanged
+journal under the session lease. It never closes or adopts backend resources.
+
+## Commands backend execution acknowledgement
+
+An emitted command does not make a minted conversation resumable by itself.
+Before AMQ prints the command, it writes a mode-0600 execution ticket for the
+handle. The ticket binds the launch nonce, physical project, session-root and
+working-directory identities, backend and adapter mode, AMQ and provider
+executable identities, and the complete provider arguments and environment
+overlay.
+
+`coop exec` uses a private PID-preserving wrapper for emitted commands. The
+wrapper checks the complete ticket immediately before provider execution. A
+mismatch returns `action_required` and does not promote conversation state.
+For a mint adapter, the wrapper promotes only the exact pending generation to
+ready. For a capture adapter, it records `spawn_attempted`; only verified
+provider start evidence can make the conversation ready.
+
+If provider execution returns an error, AMQ changes the exact minted ready
+generation back to pending with reason `spawn_failed`. A process kill in the
+small interval after ready promotion and before the kernel replaces the AMQ
+image can leave a ready record. The normal stale-conversation policy absorbs
+this case; AMQ does not infer a second successful spawn.

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 func runCleanup(args []string) error {
@@ -18,19 +19,33 @@ func runCleanup(args []string) error {
 		"",
 		"Remove preserved wake quarantine artifacts older than this duration",
 	)
+	launchJournalFlag := fs.Bool(
+		"launch-journal",
+		false,
+		"Remove one exact stuck managed-launch recovery journal",
+	)
 	dryRunFlag := fs.Bool("dry-run", false, "Show what would be removed without deleting")
 	yesFlag := fs.Bool("yes", false, "Skip confirmation prompt")
 	usage := usageWithFlags(
 		fs,
-		"amq cleanup [--tmp-older-than <duration>] [--wake-quarantine-older-than <duration>] [--dry-run] [--yes] [options]",
+		"amq cleanup [--tmp-older-than <duration>] [--wake-quarantine-older-than <duration>] [--launch-journal --root <session-root>] [--dry-run] [--yes] [options]",
 	)
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
 		return nil
 	}
-	if *olderFlag == "" && *wakeQuarantineOlderFlag == "" {
-		return UsageError("one of --tmp-older-than or --wake-quarantine-older-than is required")
+	if *olderFlag == "" && *wakeQuarantineOlderFlag == "" && !*launchJournalFlag {
+		return UsageError("one of --tmp-older-than, --wake-quarantine-older-than, or --launch-journal is required")
+	}
+	if *launchJournalFlag {
+		if *olderFlag != "" || *wakeQuarantineOlderFlag != "" {
+			return UsageError("--launch-journal cannot be combined with other cleanup selectors")
+		}
+		if !common.rootExplicit() {
+			return UsageError("--launch-journal requires an explicit --root <session-root>")
+		}
+		return cleanupLaunchJournal(common.Root, common.JSON, *dryRunFlag, *yesFlag)
 	}
 	var tmpDuration time.Duration
 	if *olderFlag != "" {
@@ -154,6 +169,90 @@ func runCleanup(args []string) error {
 	}
 	if err := writeStdout("Removed %d %s.\n", removed, label); err != nil {
 		return err
+	}
+	return nil
+}
+
+type launchJournalCleanupReport struct {
+	Path             string                    `json:"path"`
+	Phase            launch.JournalPhase       `json:"phase"`
+	Backend          string                    `json:"backend"`
+	Profile          string                    `json:"profile"`
+	LaunchNonce      string                    `json:"launch_nonce"`
+	CreatedAt        time.Time                 `json:"created_at"`
+	KnownResources   []launch.ResourceIdentity `json:"known_resources"`
+	ResourceEvidence string                    `json:"resource_evidence"`
+}
+
+func cleanupLaunchJournal(root string, jsonOutput, dryRun, yes bool) error {
+	identity, err := fsq.SnapshotDeliveryRoot(root)
+	if err != nil {
+		return err
+	}
+	deliveryRoot, err := fsq.OpenDeliveryRoot(root, identity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = deliveryRoot.Close() }()
+	record, err := launch.LoadJournal(deliveryRoot)
+	if err != nil {
+		return err
+	}
+	report := launchJournalCleanupReport{
+		Path: launch.JournalPath(deliveryRoot.Base()), Phase: record.Phase,
+		Backend: record.Backend, Profile: record.Profile, LaunchNonce: record.LaunchNonce,
+		CreatedAt: record.CreatedAt, KnownResources: []launch.ResourceIdentity{},
+		ResourceEvidence: "journal is non-authoritative; backend resources may still exist",
+	}
+	if record.Binding != nil {
+		report.KnownResources = append(report.KnownResources, record.Binding.Resources.Resources...)
+	}
+	if dryRun {
+		if jsonOutput {
+			return writeJSON(os.Stdout, map[string]any{"removed": false, "launch_journal": report})
+		}
+		return writeLaunchJournalCleanupReport("Would remove", report)
+	}
+	if !yes {
+		if err := writeLaunchJournalCleanupReport("Will remove", report); err != nil {
+			return err
+		}
+		confirmed, err := confirmPrompt("Remove this recovery journal and leave any backend resources untouched?")
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return writeStdoutLine("Aborted.")
+		}
+	}
+	lease, err := launch.AcquireLease(deliveryRoot, record.LaunchNonce)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lease.Release() }()
+	if err := launch.ClearJournal(deliveryRoot, lease, record); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(os.Stdout, map[string]any{"removed": true, "launch_journal": report})
+	}
+	return writeLaunchJournalCleanupReport("Removed", report)
+}
+
+func writeLaunchJournalCleanupReport(action string, report launchJournalCleanupReport) error {
+	if err := writeStdout("%s launch journal %s\n", action, report.Path); err != nil {
+		return err
+	}
+	if err := writeStdout("Backend: %s; profile: %s; nonce: %s; phase: %s\n", report.Backend, report.Profile, report.LaunchNonce, report.Phase); err != nil {
+		return err
+	}
+	if len(report.KnownResources) == 0 {
+		return writeStdoutLine("Known resources: none recorded; live resources may still exist.")
+	}
+	for _, resource := range report.KnownResources {
+		if err := writeStdout("Known resource: %s (agent: %s)\n", resource.OpaqueID, resource.Agent); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/cli/cleanup_launch_journal_test.go
+++ b/internal/cli/cleanup_launch_journal_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestCleanupLaunchJournalReportsExactTargetAndRequiresExplicitRoot(t *testing.T) {
+	rootPath := t.TempDir()
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	nonce := "019c8a2f-2b13-7000-8000-000000000020"
+	plan := launch.Plan{Version: launch.PlanVersion, Agents: []launch.AgentPlan{{
+		Handle: "claude", Argv: []string{"/usr/bin/true", nonce}, Cwd: t.TempDir(),
+		AdapterMode: launch.AdapterModeMint, ResumePolicy: launch.ResumeEnabled,
+		LaunchNonce: nonce, ConversationID: nonce,
+		DynamicArgv: []launch.DynamicArg{{Index: 1, Kind: launch.DynamicArgLaunchNonce}},
+	}}}
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	config := launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: "collab", Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+		Agents: []launch.ProjectAgentConfig{{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: launch.ResumeEnabled}},
+	}
+	profile := launch.Profile{Backend: "test", Platform: "test", VersionRange: "*", Version: 1, Capabilities: []launch.Capability{launch.CapCreate}}
+	record, err := launch.NewLaunchJournal(
+		launch.ReconcileRequest{ProjectRoot: project, Session: "collab", Root: root, Config: config},
+		"test", launch.DetectResult{Available: true, Profile: profile, HostIdentity: "host:test", InstanceIdentity: "instance:test"},
+		plan, digest, nonce,
+		[]launch.AgentReconcileResult{{Handle: "claude", ConversationDisposition: launch.DispositionFresh}},
+		[]launch.ConversationRecord{{Version: launch.ConversationVersion, Handle: "claude", State: launch.CapturePending, ProviderVersion: "test", LaunchNonce: nonce}},
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := launch.AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteJournal(root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runCleanup([]string{"--launch-journal", "--dry-run"}); err == nil {
+		t.Fatalf("cleanup without explicit root error = %v", err)
+	}
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runCleanup([]string{"--launch-journal", "--root", rootPath, "--dry-run", "--json"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dry struct {
+		Removed bool `json:"removed"`
+		Journal struct {
+			Path        string `json:"path"`
+			Backend     string `json:"backend"`
+			LaunchNonce string `json:"launch_nonce"`
+		} `json:"launch_journal"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &dry); err != nil {
+		t.Fatal(err)
+	}
+	if dry.Removed || dry.Journal.Path != launch.JournalPath(rootPath) || dry.Journal.Backend != "test" || dry.Journal.LaunchNonce != nonce {
+		t.Fatalf("dry-run report=%#v", dry)
+	}
+	if _, err := launch.LoadJournal(root); err != nil {
+		t.Fatalf("dry-run removed journal: %v", err)
+	}
+
+	stdout, _, err = captureEnvOutput(t, func() error {
+		return runCleanup([]string{"--launch-journal", "--root", rootPath, "--yes", "--json"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(stdout), &dry); err != nil || !dry.Removed {
+		t.Fatalf("cleanup report=%s err=%v", stdout, err)
+	}
+	if _, err := launch.LoadJournal(root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("journal after cleanup: %v", err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -19,6 +19,11 @@ func Run(args []string, version string) error {
 		version = "dev"
 	}
 	cliVersion = version
+	// Private PID-preserving wrapper for commands emitted by amq launch. It is
+	// intentionally dispatched before help, registry, and update handling.
+	if len(args) > 0 && args[0] == "__launch-exec" {
+		return runLaunchExec(args[1:])
+	}
 
 	args, noUpdate := stripNoUpdateCheckArgs(args)
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 	"golang.org/x/sys/unix"
 )
 
@@ -50,6 +51,7 @@ func openCoopWakeAttention(output *os.File) (*os.File, error) {
 }
 
 func runCoopExec(args []string) error {
+	managedLaunchNonce := strings.TrimSpace(os.Getenv(launch.InternalLaunchNonceEnv))
 	// Split at "--" before flag parsing so agent flags aren't consumed.
 	amqArgs, agentArgs := splitDashDash(args)
 
@@ -397,7 +399,10 @@ func runCoopExec(args []string) error {
 	var earlyOwner *wakeOwner
 	baseEnv := unsetEnvVar(
 		unsetEnvVar(
-			unsetEnvVar(os.Environ(), envWakeOwner),
+			unsetEnvVar(
+				unsetEnvVar(os.Environ(), launch.InternalLaunchNonceEnv),
+				envWakeOwner,
+			),
 			envWakePrivateStopFD,
 		),
 		envWakeAttentionFD,
@@ -641,11 +646,36 @@ func runCoopExec(args []string) error {
 		return cleanupAfterError(fmt.Errorf("encode final wake owner: %w", ownerErr))
 	}
 	env = setEnvVar(unsetEnvVar(env, envWakeOwner), envWakeOwner, encodedOwner)
-	execErr := coopExecProcess(binaryPath, argv, env)
+	var execErr error
+	if managedLaunchNonce != "" {
+		execErr = reexecManagedLaunchWrapper(root, agentHandle, managedLaunchNonce, binaryPath, argv, env)
+	} else {
+		execErr = coopExecProcess(binaryPath, argv, env)
+	}
 	if execErr == nil {
 		execErr = fmt.Errorf("exec returned without replacing process")
 	}
 	return cleanupAfterError(execErr)
+}
+
+// reexecManagedLaunchWrapper preserves the coop exec PID while moving the
+// final trust revalidation and conversation acknowledgement directly next to
+// the provider exec boundary.
+func reexecManagedLaunchWrapper(root, handle, nonce, binaryPath string, argv, env []string) error {
+	current, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve current amq executable for managed launch: %w", err)
+	}
+	amqPath, err := coopWakeExecutionPath(current)
+	if err != nil {
+		return err
+	}
+	wrapperArgv := []string{
+		amqPath, "__launch-exec", "--root", root, "--handle", handle,
+		"--nonce", nonce, "--target", binaryPath, "--",
+	}
+	wrapperArgv = append(wrapperArgv, argv...)
+	return coopExecProcess(amqPath, wrapperArgv, env)
 }
 
 // coopProvisionAfterClassifyHook runs between layout classification and the

--- a/internal/cli/launch_exec_other.go
+++ b/internal/cli/launch_exec_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package cli
+
+func runLaunchExec([]string) error {
+	return ActionRequiredError("managed launch execution acknowledgement is unsupported on this platform")
+}

--- a/internal/cli/launch_exec_reexec_unix_test.go
+++ b/internal/cli/launch_exec_reexec_unix_test.go
@@ -1,0 +1,120 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestManagedLaunchReexecPreservesPIDAndTargetArgv(t *testing.T) {
+	sentinel := errors.New("exec sentinel")
+	old := coopExecProcess
+	t.Cleanup(func() { coopExecProcess = old })
+	var gotPath string
+	var gotArgv, gotEnv []string
+	coopExecProcess = func(path string, argv, env []string) error {
+		gotPath = path
+		gotArgv = slices.Clone(argv)
+		gotEnv = slices.Clone(env)
+		return sentinel
+	}
+	target := []string{"/opt/provider", "--resume", "conversation"}
+	env := []string{"AM_ROOT=/queue", "TOKEN=value"}
+	err := reexecManagedLaunchWrapper("/queue", "codex", "11111111-1111-4111-8111-111111111111", target[0], target, env)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("reexec error = %v, want sentinel", err)
+	}
+	if gotPath == "" || len(gotArgv) < 12 || gotArgv[1] != "__launch-exec" {
+		t.Fatalf("wrapper exec = path %q argv %#v", gotPath, gotArgv)
+	}
+	dash := slices.Index(gotArgv, "--")
+	if dash < 0 || !slices.Equal(gotArgv[dash+1:], target) {
+		t.Fatalf("wrapper target tail = %#v, want %#v", gotArgv[dash+1:], target)
+	}
+	if !slices.Equal(gotEnv, env) {
+		t.Fatalf("wrapper env = %#v, want %#v", gotEnv, env)
+	}
+}
+
+func TestPrivateLaunchWrapperAcknowledgesThenRevertsFailedExec(t *testing.T) {
+	project := t.TempDir()
+	session := filepath.Join(project, "session")
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	provider := filepath.Join(t.TempDir(), "provider")
+	if err := os.WriteFile(provider, []byte("provider"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	amqExecutable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := "77777777-7777-4777-8777-777777777777"
+	lease, err := launch.AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := launch.NewExecutionTicket(launch.ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: launch.AdapterModeMint,
+		Provider: launch.ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: project, SessionRoot: session, Cwd: project,
+		ProviderExecutable: provider, AMQExecutable: amqExecutable, TargetArgv: []string{provider},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteExecutionTicket(root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteConversation(root, lease, launch.ConversationRecord{
+		Version: launch.ConversationVersion, Handle: "claude", State: launch.CapturePending, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+	sentinel := errors.New("provider exec failed")
+	oldExec := launchExecProcess
+	launchExecProcess = func(string, []string, []string) error { return sentinel }
+	t.Cleanup(func() { launchExecProcess = oldExec })
+	err = runLaunchExec([]string{"--root", session, "--handle", "claude", "--nonce", nonce, "--target", provider, "--", provider})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("wrapper error = %v, want provider exec failure", err)
+	}
+	record, err := launch.LoadConversation(root, "claude")
+	if err != nil || record.State != launch.CapturePending || record.Reason != "spawn_failed" {
+		t.Fatalf("reverted record = %#v, %v", record, err)
+	}
+}

--- a/internal/cli/launch_exec_unix.go
+++ b/internal/cli/launch_exec_unix.go
@@ -1,0 +1,59 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+var launchExecProcess = syscall.Exec
+
+func runLaunchExec(args []string) error {
+	amqArgs, targetArgv := splitDashDash(args)
+	fs := flag.NewFlagSet("__launch-exec", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	rootFlag := fs.String("root", "", "")
+	handleFlag := fs.String("handle", "", "")
+	nonceFlag := fs.String("nonce", "", "")
+	targetFlag := fs.String("target", "", "")
+	if err := fs.Parse(amqArgs); err != nil || len(fs.Args()) != 0 || *rootFlag == "" || *handleFlag == "" || *nonceFlag == "" || *targetFlag == "" || len(targetArgv) == 0 {
+		return ActionRequiredError("refusing incomplete private launch wrapper invocation")
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(*rootFlag)
+	if err != nil {
+		return ActionRequiredError("validate launch session root: %v", err)
+	}
+	root, err := fsq.OpenDeliveryRoot(*rootFlag, identity)
+	if err != nil {
+		return ActionRequiredError("open launch session root: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ActionRequiredError("resolve launch working directory: %v", err)
+	}
+	amqExecutable, err := os.Executable()
+	if err != nil {
+		return ActionRequiredError("resolve launch wrapper executable: %v", err)
+	}
+	if _, err := launch.PrepareExecution(root, *handleFlag, *nonceFlag, launch.ExecutionEnvelope{
+		Cwd: cwd, AMQExecutable: amqExecutable, ProviderExecutable: *targetFlag,
+		TargetArgv: targetArgv, Environment: os.Environ(),
+	}); err != nil {
+		return ActionRequiredError("refusing managed launch execution: %v", err)
+	}
+	execErr := launchExecProcess(*targetFlag, targetArgv, os.Environ())
+	if execErr == nil {
+		execErr = fmt.Errorf("provider exec returned without replacing process")
+	}
+	revertErr := launch.RevertExecution(root, *handleFlag, *nonceFlag)
+	return errors.Join(execErr, revertErr)
+}

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -49,7 +49,7 @@ func init() {
 				{Name: "list", Summary: "List presence data", Handler: runPresenceList},
 			},
 		},
-		{Name: "cleanup", Summary: "Remove selected stale tmp or wake quarantine artifacts", Handler: runCleanup},
+		{Name: "cleanup", Summary: "Remove selected tmp, wake quarantine, or launch recovery artifacts", Handler: runCleanup},
 		{Name: "watch", Summary: "Wait for new messages (uses fsnotify)", Handler: runWatch},
 		{Name: "drain", Summary: "Drain new messages (read, move to cur, emit receipts)", Handler: runDrain},
 		{Name: "monitor", Summary: "Combined watch+drain for co-op mode", Handler: runMonitor},

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -125,6 +125,16 @@ func (r *DeliveryRoot) Base() string {
 	return r.base
 }
 
+// FileInfo returns the physical directory snapshot captured when this root
+// capability was opened. Callers may derive an opaque identity token from it;
+// filesystem operations must still use the pinned capability.
+func (r *DeliveryRoot) FileInfo() os.FileInfo {
+	if r == nil {
+		return nil
+	}
+	return r.identity
+}
+
 // OpenOrCreateDirectChild pins one direct, non-symlink child directory beneath
 // the authorized root. The before/open/after identity checks prevent a child
 // swapped during validation from redirecting later writes through a symlink.

--- a/internal/fsq/tree_identity.go
+++ b/internal/fsq/tree_identity.go
@@ -35,3 +35,23 @@ func StableTreeIdentityInfo(info os.FileInfo) (string, error) {
 	}
 	return platformStableTreeIdentity("", info)
 }
+
+// StableFileIdentity returns an opaque physical identity for one regular file.
+// It is used to pin executable targets across a delayed launch boundary.
+func StableFileIdentity(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("empty file path")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("file identity requires a regular file: %s", abs)
+	}
+	return platformStableTreeIdentity(abs, info)
+}

--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
@@ -24,6 +25,13 @@ type BackendFocuser interface {
 	Focus(FocusRequest) (FocusResult, error)
 }
 
+// BackendReclaimer is the optional recovery surface for a managed resource
+// that may have been created before its authoritative binding was committed.
+// It must inspect only the exact journal generation and must not mutate it.
+type BackendReclaimer interface {
+	Reclaim(ReclaimRequest) (ReclaimResult, error)
+}
+
 type Capability string
 
 const (
@@ -38,6 +46,8 @@ const (
 	CapClose Capability = "close"
 	// CapFocus means the backend can attach to a present layout.
 	CapFocus Capability = "focus"
+	// CapReclaim means the backend can prove the state of a journaled create.
+	CapReclaim Capability = "reclaim"
 )
 
 type Outcome string
@@ -188,3 +198,36 @@ type FocusResult struct {
 	Outcome Outcome `json:"outcome"`
 	Reason  string  `json:"reason,omitempty"`
 }
+
+type ReclaimStatus string
+
+const (
+	ReclaimAbsent     ReclaimStatus = "absent"
+	ReclaimAdoptable  ReclaimStatus = "adoptable"
+	ReclaimIncomplete ReclaimStatus = "incomplete"
+	ReclaimUnknown    ReclaimStatus = "unknown"
+	ReclaimForeign    ReclaimStatus = "foreign"
+)
+
+type ReclaimRequest struct {
+	Context context.Context
+	Journal LaunchJournal
+	Root    *fsq.DeliveryRoot
+}
+
+type ReclaimResult struct {
+	Status          ReclaimStatus                `json:"status"`
+	Evidence        string                       `json:"evidence"`
+	Resources       []ResourceIdentity           `json:"resources"`
+	Binding         BindingRecord                `json:"binding,omitempty"`
+	CaptureEvidence map[string][]CaptureEvidence `json:"-"`
+}
+
+// DefinitePreCreateError means Create proved that it made no backend resource.
+// All other Create errors are uncertain and retain the journal for recovery.
+type DefinitePreCreateError struct{ Err error }
+
+func (e *DefinitePreCreateError) Error() string {
+	return fmt.Sprintf("create refused before resource creation: %v", e.Err)
+}
+func (e *DefinitePreCreateError) Unwrap() error { return e.Err }

--- a/internal/launch/commands.go
+++ b/internal/launch/commands.go
@@ -8,7 +8,10 @@ import (
 )
 
 const (
-	CommandsBackendName       = "commands"
+	CommandsBackendName = "commands"
+	// InternalLaunchNonceEnv marks a command emitted by the trusted launch
+	// reconciler. coop exec consumes it and never forwards it to the provider.
+	InternalLaunchNonceEnv    = "AMQ_INTERNAL_LAUNCH_NONCE"
 	PlanOnlyInspectEvidence   = "plan_only backend has no query surface"
 	PlanOnlyCloseReason       = "plan_only backend owns no terminal resource"
 	commandsProfileVersion    = 1
@@ -58,6 +61,10 @@ func (Commands) Create(req CreateRequest) (CreateResult, error) {
 	for _, agent := range req.Plan.Agents {
 		argv := coopExecArgv(amq, req.Session, agent.Handle, agent.Argv)
 		env := cloneEnv(agent.EnvOverlay)
+		if env == nil {
+			env = make(map[string]string, 1)
+		}
+		env[InternalLaunchNonceEnv] = agent.LaunchNonce
 		commands = append(commands, EmittedCommand{
 			Handle:      agent.Handle,
 			Argv:        argv,

--- a/internal/launch/commands_test.go
+++ b/internal/launch/commands_test.go
@@ -59,6 +59,9 @@ func TestCommandsCreateEmitsCoopExecAndRoundTripsPlan(t *testing.T) {
 			t.Fatalf("command[%d] metadata = %#v", i, cmd)
 		}
 		assertCoopExecGrammar(t, cmd.Argv, agent.Handle, agent.Argv)
+		if cmd.Env[InternalLaunchNonceEnv] != agent.LaunchNonce {
+			t.Fatalf("command[%d] managed launch nonce = %q, want %q", i, cmd.Env[InternalLaunchNonceEnv], agent.LaunchNonce)
+		}
 		if !strings.Contains(cmd.Line, "coop exec") || !strings.Contains(cmd.Line, agent.Handle) {
 			t.Fatalf("command[%d] line missing coop exec: %s", i, cmd.Line)
 		}

--- a/internal/launch/conformance.go
+++ b/internal/launch/conformance.go
@@ -35,7 +35,7 @@ func RunConformance(t *testing.T, b Backend) {
 				switch cap {
 				case CapPlanOnly:
 					assertPlanOnlyCreate(t, b, root)
-				case CapCreate, CapInspect, CapClose, CapFocus:
+				case CapCreate, CapInspect, CapClose, CapFocus, CapReclaim:
 					t.Fatal("managed capability declared but this skeleton has no managed assertion yet")
 				default:
 					t.Fatalf("unknown declared capability %q", cap)

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -1,0 +1,525 @@
+package launch
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const ExecutionTicketVersion = 1
+
+const executionDirectory = "meta/launch/executions"
+
+type ExecutionState string
+
+const (
+	ExecutionPending        ExecutionState = "pending"
+	ExecutionSpawnAttempted ExecutionState = "spawn_attempted"
+	ExecutionAcknowledged   ExecutionState = "acknowledged"
+)
+
+// ExecutionTicket is the durable, nonce-bound handoff between planning and
+// the process which actually starts a command. It is evidence, not execution
+// authority: writes require the live launch lease and the matching handle lock.
+type ExecutionTicket struct {
+	Version int `json:"version"`
+
+	Handle         string      `json:"handle"`
+	LaunchNonce    string      `json:"launch_nonce"`
+	Mode           AdapterMode `json:"mode"`
+	Provider       string      `json:"provider"`
+	ConversationID string      `json:"conversation_id,omitempty"`
+
+	ProjectRoot     string `json:"project_root"`
+	ProjectIdentity string `json:"project_identity"`
+	SessionRoot     string `json:"session_root"`
+	SessionIdentity string `json:"session_identity"`
+	Cwd             string `json:"cwd"`
+	CwdIdentity     string `json:"cwd_identity"`
+
+	ProviderExecutable         string `json:"provider_executable"`
+	ProviderExecutableIdentity string `json:"provider_executable_identity"`
+	AMQExecutable              string `json:"amq_executable"`
+	AMQExecutableIdentity      string `json:"amq_executable_identity"`
+
+	TargetArgv []string          `json:"target_argv"`
+	TargetEnv  map[string]string `json:"target_env,omitempty"`
+	EnvDigest  string            `json:"env_digest"`
+	State      ExecutionState    `json:"state"`
+	Reason     string            `json:"reason,omitempty"`
+}
+
+type ExecutionTicketRequest struct {
+	Handle, LaunchNonce               string
+	Mode                              AdapterMode
+	Provider, ConversationID          string
+	ProjectRoot, SessionRoot, Cwd     string
+	ProviderExecutable, AMQExecutable string
+	TargetArgv                        []string
+	TargetEnv                         map[string]string
+	State                             ExecutionState
+	Reason                            string
+}
+
+type ExecutionEnvelope struct {
+	Cwd, AMQExecutable, ProviderExecutable string
+	TargetArgv, Environment                []string
+}
+
+func ExecutionTicketPath(sessionRoot, handle string) string {
+	return filepath.Join(sessionRoot, executionDirectory, handle+".json")
+}
+
+// NewExecutionTicket canonicalizes every filesystem input and snapshots its
+// physical identity before the ticket can be persisted.
+func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error) {
+	if err := fsq.ValidateHandle(request.Handle); err != nil {
+		return ExecutionTicket{}, err
+	}
+	if !validUUID(request.LaunchNonce) {
+		return ExecutionTicket{}, fmt.Errorf("launch nonce must be a UUID")
+	}
+	if request.Mode != AdapterModeMint && request.Mode != AdapterModeCapture && request.Mode != AdapterModeUnsupported {
+		return ExecutionTicket{}, fmt.Errorf("invalid execution mode %q", request.Mode)
+	}
+	project, projectID, err := canonicalDirectory(request.ProjectRoot)
+	if err != nil {
+		return ExecutionTicket{}, fmt.Errorf("project root: %w", err)
+	}
+	session, sessionID, err := canonicalDirectory(request.SessionRoot)
+	if err != nil {
+		return ExecutionTicket{}, fmt.Errorf("session root: %w", err)
+	}
+	cwd, cwdID, err := canonicalDirectory(request.Cwd)
+	if err != nil {
+		return ExecutionTicket{}, fmt.Errorf("cwd: %w", err)
+	}
+	provider, providerID, err := canonicalFile(request.ProviderExecutable)
+	if err != nil {
+		return ExecutionTicket{}, fmt.Errorf("provider executable: %w", err)
+	}
+	if pathWithin(provider, project) {
+		return ExecutionTicket{}, fmt.Errorf("provider executable resolves inside the project")
+	}
+	amq, amqID, err := canonicalFile(request.AMQExecutable)
+	if err != nil {
+		return ExecutionTicket{}, fmt.Errorf("amq executable: %w", err)
+	}
+	env := cloneExecutionEnv(request.TargetEnv)
+	digest, err := executionEnvDigest(env)
+	if err != nil {
+		return ExecutionTicket{}, err
+	}
+	ticket := ExecutionTicket{
+		Version: ExecutionTicketVersion, Handle: request.Handle, LaunchNonce: request.LaunchNonce, Mode: request.Mode,
+		Provider: request.Provider, ConversationID: request.ConversationID,
+		ProjectRoot: project, ProjectIdentity: projectID, SessionRoot: session, SessionIdentity: sessionID,
+		Cwd: cwd, CwdIdentity: cwdID, ProviderExecutable: provider, ProviderExecutableIdentity: providerID,
+		AMQExecutable: amq, AMQExecutableIdentity: amqID, TargetArgv: append([]string(nil), request.TargetArgv...),
+		TargetEnv: env, EnvDigest: digest, State: request.State, Reason: request.Reason,
+	}
+	if ticket.State == "" {
+		ticket.State = ExecutionPending
+	}
+	if err := ticket.Validate(); err != nil {
+		return ExecutionTicket{}, err
+	}
+	return ticket, nil
+}
+
+func (ticket ExecutionTicket) Validate() error {
+	if ticket.Version != ExecutionTicketVersion {
+		return fmt.Errorf("unsupported execution ticket version %d", ticket.Version)
+	}
+	if err := fsq.ValidateHandle(ticket.Handle); err != nil {
+		return err
+	}
+	if !validUUID(ticket.LaunchNonce) {
+		return fmt.Errorf("launch nonce must be a UUID")
+	}
+	if ticket.Mode != AdapterModeMint && ticket.Mode != AdapterModeCapture && ticket.Mode != AdapterModeUnsupported {
+		return fmt.Errorf("invalid execution mode %q", ticket.Mode)
+	}
+	if strings.TrimSpace(ticket.Provider) == "" {
+		return fmt.Errorf("provider is required")
+	}
+	if ticket.ConversationID != "" && !validUUID(ticket.ConversationID) {
+		return fmt.Errorf("conversation identity must be a UUID")
+	}
+	for name, value := range map[string]string{"project root": ticket.ProjectRoot, "project identity": ticket.ProjectIdentity, "session root": ticket.SessionRoot, "session identity": ticket.SessionIdentity, "cwd": ticket.Cwd, "cwd identity": ticket.CwdIdentity, "provider executable": ticket.ProviderExecutable, "provider executable identity": ticket.ProviderExecutableIdentity, "amq executable": ticket.AMQExecutable, "amq executable identity": ticket.AMQExecutableIdentity, "environment digest": ticket.EnvDigest} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", name)
+		}
+	}
+	if len(ticket.TargetArgv) == 0 || strings.TrimSpace(ticket.TargetArgv[0]) == "" {
+		return fmt.Errorf("target argv is required")
+	}
+	for i, arg := range ticket.TargetArgv {
+		if arg == "" || strings.ContainsRune(arg, 0) {
+			return fmt.Errorf("target argv[%d] is invalid", i)
+		}
+	}
+	if digest, err := executionEnvDigest(ticket.TargetEnv); err != nil || digest != ticket.EnvDigest {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("environment digest does not match target environment")
+	}
+	switch ticket.State {
+	case ExecutionPending:
+	case ExecutionSpawnAttempted, ExecutionAcknowledged:
+		if strings.TrimSpace(ticket.Reason) == "" {
+			return fmt.Errorf("reason is required for execution state %q", ticket.State)
+		}
+	default:
+		return fmt.Errorf("invalid execution state %q", ticket.State)
+	}
+	return nil
+}
+
+func WriteExecutionTicket(root *fsq.DeliveryRoot, lease *Lease, ticket ExecutionTicket) error {
+	if root == nil {
+		return fmt.Errorf("missing pinned session root")
+	}
+	if err := lease.authorizeWrite(root); err != nil {
+		return err
+	}
+	if ticket.LaunchNonce != lease.LaunchNonce() {
+		return fmt.Errorf("execution ticket nonce does not match launch lease")
+	}
+	if !lease.holdsHandle(ticket.Handle) {
+		return fmt.Errorf("launch lease does not hold handle %q", ticket.Handle)
+	}
+	if ticket.SessionRoot != canonicalOrRaw(root.Base()) {
+		return fmt.Errorf("execution ticket session root does not match pinned root")
+	}
+	if err := ticket.Validate(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(ticket, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = root.WriteFileAtomic(executionDirectory, ticket.Handle+".json", data, 0o600)
+	return err
+}
+
+func LoadExecutionTicket(root *fsq.DeliveryRoot, handle string) (ExecutionTicket, error) {
+	if root == nil {
+		return ExecutionTicket{}, fmt.Errorf("missing pinned session root")
+	}
+	if err := fsq.ValidateHandle(handle); err != nil {
+		return ExecutionTicket{}, err
+	}
+	file, info, err := root.OpenRegularNoFollow(filepath.Join(executionDirectory, handle+".json"))
+	if err != nil {
+		return ExecutionTicket{}, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		return ExecutionTicket{}, fmt.Errorf("execution ticket permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return ExecutionTicket{}, err
+	}
+	var ticket ExecutionTicket
+	if err := decodeExecutionJSON(data, &ticket); err != nil {
+		return ExecutionTicket{}, fmt.Errorf("decode execution ticket: %w", err)
+	}
+	if ticket.Handle != handle {
+		return ExecutionTicket{}, fmt.Errorf("execution ticket handle mismatch")
+	}
+	if err := ticket.Validate(); err != nil {
+		return ExecutionTicket{}, err
+	}
+	if ticket.SessionRoot != canonicalOrRaw(root.Base()) {
+		return ExecutionTicket{}, fmt.Errorf("execution ticket session root does not match pinned root")
+	}
+	return ticket, nil
+}
+
+// CompareAndSwapExecutionTicket changes one ticket state while the caller's
+// live lease and handle lock exclude competing launch/reconcile operations.
+func CompareAndSwapExecutionTicket(root *fsq.DeliveryRoot, lease *Lease, handle string, expected ExecutionState, next ExecutionState, reason string) (ExecutionTicket, error) {
+	if err := lease.authorizeWrite(root); err != nil {
+		return ExecutionTicket{}, err
+	}
+	if !lease.holdsHandle(handle) {
+		return ExecutionTicket{}, fmt.Errorf("launch lease does not hold handle %q", handle)
+	}
+	ticket, err := LoadExecutionTicket(root, handle)
+	if err != nil {
+		return ExecutionTicket{}, err
+	}
+	if ticket.LaunchNonce != lease.LaunchNonce() {
+		return ExecutionTicket{}, fmt.Errorf("execution ticket nonce does not match launch lease")
+	}
+	if ticket.State != expected {
+		return ticket, fmt.Errorf("execution ticket state is %q, want %q", ticket.State, expected)
+	}
+	if next != ExecutionSpawnAttempted && next != ExecutionAcknowledged && next != ExecutionPending {
+		return ticket, fmt.Errorf("invalid execution state %q", next)
+	}
+	validTransition := expected == ExecutionPending && next == ExecutionSpawnAttempted
+	validTransition = validTransition || expected == ExecutionSpawnAttempted && next == ExecutionAcknowledged
+	validTransition = validTransition || expected == ExecutionAcknowledged && next == ExecutionPending
+	validTransition = validTransition || expected == ExecutionSpawnAttempted && next == ExecutionPending
+	if !validTransition {
+		return ticket, fmt.Errorf("invalid execution state transition %q -> %q", expected, next)
+	}
+	ticket.State, ticket.Reason = next, reason
+	if err := ticket.Validate(); err != nil {
+		return ticket, err
+	}
+	if err := WriteExecutionTicket(root, lease, ticket); err != nil {
+		return ticket, err
+	}
+	return ticket, nil
+}
+
+// PrepareExecution performs the final envelope check and durable execution
+// acknowledgement under the exact launch nonce and handle lock.
+func PrepareExecution(root *fsq.DeliveryRoot, handle, nonce string, envelope ExecutionEnvelope) (ticket ExecutionTicket, returnErr error) {
+	lease, err := AcquireLease(root, nonce)
+	if err != nil {
+		return ticket, err
+	}
+	defer func() { returnErr = errors.Join(returnErr, lease.Release()) }()
+	if err := lease.LockHandles(handle); err != nil {
+		return ticket, err
+	}
+	ticket, err = LoadExecutionTicket(root, handle)
+	if err != nil {
+		return ticket, err
+	}
+	if ticket.LaunchNonce != nonce {
+		return ticket, fmt.Errorf("execution ticket nonce mismatch")
+	}
+	if err := ValidateExecutionEnvelope(root, ticket, envelope); err != nil {
+		return ticket, err
+	}
+	switch ticket.Mode {
+	case AdapterModeCapture:
+		return CompareAndSwapExecutionTicket(root, lease, handle, ExecutionPending, ExecutionSpawnAttempted, "spawn_attempted")
+	case AdapterModeMint:
+		if ticket.State == ExecutionPending {
+			ticket, err = CompareAndSwapExecutionTicket(root, lease, handle, ExecutionPending, ExecutionSpawnAttempted, "spawn_attempted")
+			if err != nil {
+				return ticket, err
+			}
+		} else if ticket.State != ExecutionSpawnAttempted {
+			return ticket, fmt.Errorf("execution ticket state is %q, want pending", ticket.State)
+		}
+		record, err := LoadConversation(root, handle)
+		if err != nil {
+			return ticket, err
+		}
+		if record.State == CapturePending {
+			if record.LaunchNonce != nonce || !validUUID(ticket.ConversationID) {
+				return ticket, fmt.Errorf("pending conversation does not match execution generation")
+			}
+			record.State = CaptureReady
+			record.Identity = ConversationIdentity{Provider: ticket.Provider, ID: ticket.ConversationID}
+			record.ExecutionEvidence = &ConversationExecutionEvidence{
+				Backend: CommandsBackendName, Profile: CommandsProfile().Identity(), Outcome: OutcomeCreated,
+				LaunchNonce: nonce, ConversationID: ticket.ConversationID,
+			}
+			record.Reason = ""
+			if err := WriteConversation(root, lease, record); err != nil {
+				return ticket, err
+			}
+		} else if record.State != CaptureReady || record.Identity.Provider != ticket.Provider || record.Identity.ID != ticket.ConversationID {
+			return ticket, fmt.Errorf("ready conversation does not match execution target")
+		}
+		return CompareAndSwapExecutionTicket(root, lease, handle, ExecutionSpawnAttempted, ExecutionAcknowledged, "child_spawn_acknowledged")
+	default:
+		return ticket, fmt.Errorf("execution mode %q cannot acknowledge a provider process", ticket.Mode)
+	}
+}
+
+// RevertExecution records a provider exec failure. It demotes only a ready
+// mint generation created by this exact ticket; an older resumed identity is
+// retained.
+func RevertExecution(root *fsq.DeliveryRoot, handle, nonce string) (returnErr error) {
+	lease, err := AcquireLease(root, nonce)
+	if err != nil {
+		return err
+	}
+	defer func() { returnErr = errors.Join(returnErr, lease.Release()) }()
+	if err := lease.LockHandles(handle); err != nil {
+		return err
+	}
+	ticket, err := LoadExecutionTicket(root, handle)
+	if err != nil || ticket.LaunchNonce != nonce {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("execution ticket nonce mismatch")
+	}
+	if ticket.Mode == AdapterModeMint {
+		record, loadErr := LoadConversation(root, handle)
+		if loadErr != nil {
+			return loadErr
+		}
+		if record.State == CaptureReady && record.LaunchNonce == nonce && record.ExecutionEvidence != nil && record.ExecutionEvidence.LaunchNonce == nonce {
+			record.State, record.Identity, record.ExecutionEvidence = CapturePending, ConversationIdentity{}, nil
+			record.Reason = CaptureReason("spawn_failed")
+			if err := WriteConversation(root, lease, record); err != nil {
+				return err
+			}
+		}
+		_, err = CompareAndSwapExecutionTicket(root, lease, handle, ExecutionAcknowledged, ExecutionPending, "spawn_failed")
+		return err
+	}
+	if ticket.Mode == AdapterModeCapture {
+		_, err = CompareAndSwapExecutionTicket(root, lease, handle, ExecutionSpawnAttempted, ExecutionPending, "spawn_failed")
+		return err
+	}
+	return fmt.Errorf("execution mode %q cannot be reverted", ticket.Mode)
+}
+
+func ValidateExecutionEnvelope(root *fsq.DeliveryRoot, ticket ExecutionTicket, envelope ExecutionEnvelope) error {
+	if root == nil {
+		return fmt.Errorf("missing pinned session root")
+	}
+	if err := root.VerifyBase(); err != nil {
+		return err
+	}
+	session, sessionID, err := canonicalDirectory(root.Base())
+	if err != nil || session != ticket.SessionRoot || sessionID != ticket.SessionIdentity {
+		return fmt.Errorf("session root identity changed")
+	}
+	project, projectID, err := canonicalDirectory(ticket.ProjectRoot)
+	if err != nil || project != ticket.ProjectRoot || projectID != ticket.ProjectIdentity {
+		return fmt.Errorf("project identity changed")
+	}
+	cwd, cwdID, err := canonicalDirectory(envelope.Cwd)
+	if err != nil || cwd != ticket.Cwd || cwdID != ticket.CwdIdentity {
+		return fmt.Errorf("working directory identity changed")
+	}
+	provider, providerID, err := canonicalFile(envelope.ProviderExecutable)
+	if err != nil || provider != ticket.ProviderExecutable || providerID != ticket.ProviderExecutableIdentity || pathWithin(provider, project) {
+		return fmt.Errorf("provider executable identity changed")
+	}
+	amq, amqID, err := canonicalFile(envelope.AMQExecutable)
+	if err != nil || amq != ticket.AMQExecutable || amqID != ticket.AMQExecutableIdentity {
+		return fmt.Errorf("amq executable identity changed")
+	}
+	if !reflect.DeepEqual(envelope.TargetArgv, ticket.TargetArgv) {
+		return fmt.Errorf("provider argv changed")
+	}
+	actualEnv := make(map[string]string, len(envelope.Environment))
+	for _, item := range envelope.Environment {
+		if key, value, ok := strings.Cut(item, "="); ok {
+			actualEnv[key] = value
+		}
+	}
+	for key, value := range ticket.TargetEnv {
+		if actualEnv[key] != value {
+			return fmt.Errorf("provider environment %q changed", key)
+		}
+	}
+	return nil
+}
+
+func canonicalDirectory(path string) (string, string, error) { return canonicalPath(path, true) }
+func canonicalFile(path string) (string, string, error)      { return canonicalPath(path, false) }
+func canonicalPath(path string, directory bool) (string, string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", "", fmt.Errorf("path is required")
+	}
+	if !directory && !filepath.IsAbs(path) {
+		resolved, err := exec.LookPath(path)
+		if err != nil {
+			return "", "", err
+		}
+		path = resolved
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", "", err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", "", err
+	}
+	if directory != info.IsDir() {
+		return "", "", fmt.Errorf("path has wrong type")
+	}
+	identity, err := executionPhysicalIdentity(resolved, info)
+	if err != nil {
+		return "", "", err
+	}
+	return filepath.Clean(resolved), identity, nil
+}
+
+func executionPhysicalIdentity(path string, info os.FileInfo) (string, error) {
+	if info == nil || info.Sys() == nil {
+		return "", fmt.Errorf("physical identity unavailable for %s", path)
+	}
+	if info.IsDir() {
+		return fsq.StableTreeIdentityInfo(info)
+	}
+	return fsq.StableFileIdentity(path)
+}
+
+func executionEnvDigest(env map[string]string) (string, error) {
+	data, err := json.Marshal(cloneExecutionEnv(env))
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+func cloneExecutionEnv(env map[string]string) map[string]string {
+	if env == nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(env))
+	for k, v := range env {
+		out[k] = v
+	}
+	return out
+}
+func decodeExecutionJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+func canonicalOrRaw(path string) string {
+	value, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		value = path
+	}
+	abs, err := filepath.Abs(value)
+	if err == nil {
+		value = abs
+	}
+	return filepath.Clean(value)
+}

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -1,0 +1,288 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestExecutionTicketRoundTripAndCAS(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	lease, err := AcquireLease(fixture.root, "11111111-1111-4111-8111-111111111111")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: lease.LaunchNonce(), Mode: AdapterModeMint,
+		Provider: ClaudeProvider, ConversationID: lease.LaunchNonce(),
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: []string{fixture.provider, "--session-id", lease.LaunchNonce()},
+		TargetEnv:  map[string]string{"LANG": "C", "NO_COLOR": "1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadExecutionTicket(fixture.root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.State != ExecutionPending || loaded.TargetEnv["LANG"] != "C" || loaded.EnvDigest == "" {
+		t.Fatalf("loaded ticket = %#v", loaded)
+	}
+	loaded, err = CompareAndSwapExecutionTicket(fixture.root, lease, "claude", ExecutionPending, ExecutionSpawnAttempted, "spawned")
+	if err != nil || loaded.State != ExecutionSpawnAttempted {
+		t.Fatalf("pending -> spawn_attempted = %#v, %v", loaded, err)
+	}
+	loaded, err = CompareAndSwapExecutionTicket(fixture.root, lease, "claude", ExecutionSpawnAttempted, ExecutionAcknowledged, "acknowledged")
+	if err != nil || loaded.State != ExecutionAcknowledged {
+		t.Fatalf("spawn_attempted -> acknowledged = %#v, %v", loaded, err)
+	}
+	if _, err := CompareAndSwapExecutionTicket(fixture.root, lease, "claude", ExecutionPending, ExecutionSpawnAttempted, "late"); err == nil || !strings.Contains(err.Error(), "state") {
+		t.Fatalf("stale CAS error = %v", err)
+	}
+}
+
+func TestExecutionTicketWritesRequireNonceAndHandleLock(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	lease, err := AcquireLease(fixture.root, "22222222-2222-4222-8222-222222222222")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	ticket := mustExecutionTicket(t, fixture, "33333333-3333-4333-8333-333333333333")
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err == nil || !strings.Contains(err.Error(), "nonce") {
+		t.Fatalf("wrong nonce write error = %v", err)
+	}
+	ticket = mustExecutionTicket(t, fixture, lease.LaunchNonce())
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err == nil || !strings.Contains(err.Error(), "hold handle") {
+		t.Fatalf("unlocked handle write error = %v", err)
+	}
+}
+
+func TestExecutionTicketLoadRejectsUnknownFieldsAndPermissiveMode(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	lease, err := AcquireLease(fixture.root, "44444444-4444-4444-8444-444444444444")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket := mustExecutionTicket(t, fixture, lease.LaunchNonce())
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	path := ExecutionTicketPath(fixture.session, "claude")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data[:len(data)-2], []byte(",\"extra\":true}\n")...)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadExecutionTicket(fixture.root, "claude"); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown field load error = %v", err)
+	}
+}
+
+func TestPrepareMintPromotesExactPendingAndExecFailureReverts(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "55555555-5555-4555-8555-555555555555"
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket := mustExecutionTicket(t, fixture, nonce)
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CapturePending, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	envelope := ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: fixture.provider,
+		TargetArgv: ticket.TargetArgv, Environment: []string{"LANG=C"},
+	}
+	prepared, err := PrepareExecution(fixture.root, "claude", nonce, envelope)
+	if err != nil || prepared.State != ExecutionAcknowledged {
+		t.Fatalf("prepare = %#v, %v", prepared, err)
+	}
+	record, err := LoadConversation(fixture.root, "claude")
+	if err != nil || record.State != CaptureReady || record.Identity.ID != nonce {
+		t.Fatalf("ready conversation = %#v, %v", record, err)
+	}
+	if err := RevertExecution(fixture.root, "claude", nonce); err != nil {
+		t.Fatal(err)
+	}
+	record, err = LoadConversation(fixture.root, "claude")
+	if err != nil || record.State != CapturePending || record.Reason != "spawn_failed" {
+		t.Fatalf("reverted conversation = %#v, %v", record, err)
+	}
+}
+
+func TestPrepareExecutionRejectsRetargetedProviderWithoutPromotion(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "66666666-6666-4666-8666-666666666666"
+	link := filepath.Join(t.TempDir(), "provider-link")
+	if err := os.Symlink(fixture.provider, link); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeMint, Provider: ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: link, AMQExecutable: fixture.amq, TargetArgv: []string{link}, TargetEnv: map[string]string{"LANG": "C"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{Version: ConversationVersion, Handle: "claude", State: CapturePending, LaunchNonce: nonce}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	replacement := filepath.Join(t.TempDir(), "replacement")
+	if err := os.WriteFile(replacement, []byte("replacement"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(replacement, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err = PrepareExecution(fixture.root, "claude", nonce, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: link,
+		TargetArgv: ticket.TargetArgv, Environment: []string{"LANG=C"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "provider executable identity changed") {
+		t.Fatalf("retarget error = %v", err)
+	}
+	record, loadErr := LoadConversation(fixture.root, "claude")
+	if loadErr != nil || record.State != CapturePending {
+		t.Fatalf("conversation mutated = %#v, %v", record, loadErr)
+	}
+}
+
+func TestPrepareCaptureRecordsAttemptWithoutPromotingConversation(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "88888888-8888-4888-8888-888888888888"
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeCapture, Provider: CodexProvider,
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: []string{fixture.provider}, TargetEnv: map[string]string{"LANG": "C"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{Version: ConversationVersion, Handle: "claude", State: CapturePending, LaunchNonce: nonce}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := PrepareExecution(fixture.root, "claude", nonce, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: fixture.provider,
+		TargetArgv: ticket.TargetArgv, Environment: []string{"LANG=C"},
+	})
+	if err != nil || prepared.State != ExecutionSpawnAttempted {
+		t.Fatalf("capture prepare = %#v, %v", prepared, err)
+	}
+	record, err := LoadConversation(fixture.root, "claude")
+	if err != nil || record.State != CapturePending || record.ExecutionEvidence != nil {
+		t.Fatalf("capture conversation = %#v, %v", record, err)
+	}
+}
+
+type executionFixture struct {
+	project, session, cwd, provider, amq string
+	root                                 *fsq.DeliveryRoot
+}
+
+func newExecutionFixture(t *testing.T) executionFixture {
+	t.Helper()
+	project := t.TempDir()
+	session := filepath.Join(project, "session")
+	cwd := filepath.Join(project, "work")
+	if err := os.MkdirAll(filepath.Join(session, "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(cwd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	provider := filepath.Join(binDir, "provider")
+	amq := filepath.Join(binDir, "amq")
+	for _, path := range []string{provider, amq} {
+		if err := os.WriteFile(path, []byte("executable"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return executionFixture{project: project, session: session, cwd: cwd, provider: provider, amq: amq, root: root}
+}
+
+func mustExecutionTicket(t *testing.T, fixture executionFixture, nonce string) ExecutionTicket {
+	t.Helper()
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeMint,
+		Provider: ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: []string{fixture.provider}, TargetEnv: map[string]string{"LANG": "C"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ticket
+}

--- a/internal/launch/journal.go
+++ b/internal/launch/journal.go
@@ -1,0 +1,312 @@
+package launch
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	JournalVersion  = 1
+	journalFilename = "journal.json"
+)
+
+type JournalPhase string
+
+const (
+	JournalIntent  JournalPhase = "intent"
+	JournalCreated JournalPhase = "created"
+)
+
+// LaunchJournal is a recovery transaction, not a launcher binding. A resource
+// recorded here is never owned or adoptable until a backend proves its live
+// identity or a matching authoritative binding already exists.
+type LaunchJournal struct {
+	Version          int                    `json:"version"`
+	Phase            JournalPhase           `json:"phase"`
+	ProjectIdentity  string                 `json:"project_identity"`
+	RootIdentity     string                 `json:"root_identity"`
+	ProjectPhysical  string                 `json:"project_physical_identity,omitempty"`
+	RootPhysical     string                 `json:"root_physical_identity,omitempty"`
+	Session          string                 `json:"session"`
+	Backend          string                 `json:"backend"`
+	Profile          string                 `json:"profile"`
+	HostIdentity     string                 `json:"host_identity"`
+	InstanceIdentity string                 `json:"instance_identity"`
+	RosterDigest     string                 `json:"roster_digest"`
+	PlanDigest       string                 `json:"plan_digest"`
+	LaunchNonce      string                 `json:"launch_nonce"`
+	CreatedAt        time.Time              `json:"created_at"`
+	Plan             Plan                   `json:"plan"`
+	Agents           []AgentReconcileResult `json:"agents"`
+	Conversations    []ConversationRecord   `json:"conversations"`
+	Binding          *BindingRecord         `json:"binding,omitempty"`
+}
+
+func (record LaunchJournal) Validate() error {
+	if record.Version != JournalVersion {
+		return fmt.Errorf("unsupported launch journal version %d", record.Version)
+	}
+	if record.Phase != JournalIntent && record.Phase != JournalCreated {
+		return fmt.Errorf("invalid launch journal phase %q", record.Phase)
+	}
+	for name, value := range map[string]string{
+		"project identity": record.ProjectIdentity, "root identity": record.RootIdentity,
+		"session": record.Session, "backend": record.Backend, "profile": record.Profile,
+		"host identity": record.HostIdentity, "instance identity": record.InstanceIdentity,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", name)
+		}
+	}
+	if !filepath.IsAbs(record.ProjectIdentity) || filepath.Clean(record.ProjectIdentity) != record.ProjectIdentity {
+		return fmt.Errorf("project identity must be a canonical absolute path")
+	}
+	if !filepath.IsAbs(record.RootIdentity) || filepath.Clean(record.RootIdentity) != record.RootIdentity {
+		return fmt.Errorf("root identity must be a canonical absolute path")
+	}
+	if !canonicalSessionPattern.MatchString(record.Session) || strings.HasPrefix(record.Session, "-") {
+		return fmt.Errorf("invalid launch journal session %q", record.Session)
+	}
+	if !validUUID(record.LaunchNonce) {
+		return fmt.Errorf("launch journal nonce must be a UUID")
+	}
+	if record.CreatedAt.IsZero() || record.CreatedAt.Location() != time.UTC {
+		return fmt.Errorf("launch journal creation time must be UTC")
+	}
+	decodedRoster, err := hex.DecodeString(record.RosterDigest)
+	if err != nil || len(decodedRoster) != sha256.Size {
+		return fmt.Errorf("launch journal roster digest must be SHA-256")
+	}
+	decodedPlan, err := hex.DecodeString(strings.TrimPrefix(record.PlanDigest, "sha256:"))
+	if !strings.HasPrefix(record.PlanDigest, "sha256:") || err != nil || len(decodedPlan) != sha256.Size {
+		return fmt.Errorf("launch journal plan digest must be SHA-256")
+	}
+	if err := record.Plan.Validate(); err != nil {
+		return fmt.Errorf("launch journal plan: %w", err)
+	}
+	digest, err := record.Plan.SemanticDigest()
+	if err != nil {
+		return err
+	}
+	if digest != record.PlanDigest {
+		return fmt.Errorf("launch journal plan digest mismatch")
+	}
+	if len(record.Agents) == 0 || len(record.Conversations) != len(record.Plan.Agents) {
+		return fmt.Errorf("launch journal roster lengths do not match")
+	}
+	agentHandles := make(map[string]struct{}, len(record.Agents))
+	for i, agent := range record.Agents {
+		if err := fsq.ValidateHandle(agent.Handle); err != nil {
+			return fmt.Errorf("launch journal result %d: %w", i, err)
+		}
+		if _, ok := agentHandles[agent.Handle]; ok {
+			return fmt.Errorf("duplicate launch journal result handle %q", agent.Handle)
+		}
+		agentHandles[agent.Handle] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(record.Plan.Agents))
+	for i, plan := range record.Plan.Agents {
+		if plan.LaunchNonce != record.LaunchNonce || record.Conversations[i].Handle != plan.Handle {
+			return fmt.Errorf("launch journal agent %d does not match its plan", i)
+		}
+		if _, ok := agentHandles[plan.Handle]; !ok {
+			return fmt.Errorf("launch journal plan handle %q has no result", plan.Handle)
+		}
+		if err := record.Conversations[i].Validate(); err != nil {
+			return fmt.Errorf("launch journal conversation %q: %w", plan.Handle, err)
+		}
+		conversation := record.Conversations[i]
+		if conversation.State == CapturePending && conversation.LaunchNonce != record.LaunchNonce {
+			return fmt.Errorf("launch journal pending conversation %q has a different nonce", plan.Handle)
+		}
+		if conversation.State == CaptureReady && plan.ConversationID != "" && plan.ConversationID != conversation.Identity.ID {
+			return fmt.Errorf("launch journal resume identity for %q does not match its conversation", plan.Handle)
+		}
+		if _, ok := seen[plan.Handle]; ok {
+			return fmt.Errorf("duplicate launch journal handle %q", plan.Handle)
+		}
+		seen[plan.Handle] = struct{}{}
+	}
+	if record.Phase == JournalIntent {
+		if record.Binding != nil {
+			return fmt.Errorf("intent journal must not contain a binding")
+		}
+		return nil
+	}
+	if record.Binding == nil {
+		return fmt.Errorf("created journal requires a candidate binding")
+	}
+	if err := record.Binding.Validate(); err != nil {
+		return fmt.Errorf("created journal binding: %w", err)
+	}
+	if !journalMatchesBinding(record, *record.Binding) {
+		return fmt.Errorf("created journal binding does not match its launch generation")
+	}
+	return nil
+}
+
+func NewLaunchJournal(request ReconcileRequest, backend string, detect DetectResult, plan Plan, planDigest, nonce string, agents []AgentReconcileResult, conversations []ConversationRecord, now time.Time) (LaunchJournal, error) {
+	projectIdentity, err := canonicalIdentity(request.ProjectRoot)
+	if err != nil {
+		return LaunchJournal{}, fmt.Errorf("resolve project identity: %w", err)
+	}
+	rootIdentity, err := canonicalIdentity(request.Root.Base())
+	if err != nil {
+		return LaunchJournal{}, fmt.Errorf("resolve session root identity: %w", err)
+	}
+	rosterDigest, err := projectConfigDigest(request.Config)
+	if err != nil {
+		return LaunchJournal{}, err
+	}
+	record := LaunchJournal{
+		Version: JournalVersion, Phase: JournalIntent, ProjectIdentity: projectIdentity,
+		RootIdentity: rootIdentity, Session: request.Session, Backend: backend,
+		Profile: detect.Profile.Identity(), HostIdentity: detect.HostIdentity,
+		InstanceIdentity: detect.InstanceIdentity, RosterDigest: rosterDigest,
+		PlanDigest: planDigest, LaunchNonce: nonce, CreatedAt: now.UTC(), Plan: plan,
+		Agents: slices.Clone(agents), Conversations: slices.Clone(conversations),
+	}
+	record.ProjectPhysical, _ = fsq.StableTreeIdentity(projectIdentity)
+	record.RootPhysical, _ = fsq.StableTreeIdentityInfo(request.Root.FileInfo())
+	if err := record.Validate(); err != nil {
+		return LaunchJournal{}, err
+	}
+	return record, nil
+}
+
+func (record LaunchJournal) ValidateRequest(request ReconcileRequest) error {
+	projectIdentity, err := canonicalIdentity(request.ProjectRoot)
+	if err != nil {
+		return err
+	}
+	rootIdentity, err := canonicalIdentity(request.Root.Base())
+	if err != nil {
+		return err
+	}
+	rosterDigest, err := projectConfigDigest(request.Config)
+	if err != nil {
+		return err
+	}
+	if record.ProjectIdentity != projectIdentity || record.RootIdentity != rootIdentity || record.Session != request.Session {
+		return fmt.Errorf("launch journal belongs to a different project or session root")
+	}
+	projectPhysical, _ := fsq.StableTreeIdentity(projectIdentity)
+	rootPhysical, _ := fsq.StableTreeIdentityInfo(request.Root.FileInfo())
+	if (record.ProjectPhysical != "" && record.ProjectPhysical != projectPhysical) ||
+		(record.RootPhysical != "" && record.RootPhysical != rootPhysical) {
+		return fmt.Errorf("launch journal physical project or session root changed")
+	}
+	if record.RosterDigest != rosterDigest {
+		return fmt.Errorf("launch journal roster changed since resource creation")
+	}
+	return nil
+}
+
+func WriteJournal(root *fsq.DeliveryRoot, lease *Lease, record LaunchJournal) error {
+	if err := lease.authorizeWrite(root); err != nil {
+		return err
+	}
+	if err := record.Validate(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = root.WriteFileAtomic(bindingDirectory, journalFilename, append(data, '\n'), 0o600)
+	return err
+}
+
+func LoadJournal(root *fsq.DeliveryRoot) (LaunchJournal, error) {
+	if root == nil {
+		return LaunchJournal{}, fmt.Errorf("missing pinned session root")
+	}
+	file, info, err := root.OpenRegularNoFollow(filepath.Join(bindingDirectory, journalFilename))
+	if err != nil {
+		return LaunchJournal{}, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		return LaunchJournal{}, fmt.Errorf("launch journal permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return LaunchJournal{}, err
+	}
+	var record LaunchJournal
+	if err := decodeStrict(data, &record); err != nil {
+		return LaunchJournal{}, fmt.Errorf("decode launch journal: %w", err)
+	}
+	if err := record.Validate(); err != nil {
+		return LaunchJournal{}, err
+	}
+	return record, nil
+}
+
+func ClearJournal(root *fsq.DeliveryRoot, lease *Lease, expected LaunchJournal) error {
+	if err := lease.authorizeWrite(root); err != nil {
+		return err
+	}
+	current, err := LoadJournal(root)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(current, expected) {
+		return fmt.Errorf("launch journal changed before clear")
+	}
+	return root.Remove(filepath.Join(bindingDirectory, journalFilename))
+}
+
+func JournalPath(sessionRoot string) string {
+	return filepath.Join(sessionRoot, bindingDirectory, journalFilename)
+}
+
+func journalMatchesBinding(journal LaunchJournal, binding BindingRecord) bool {
+	return binding.Backend == journal.Backend && binding.Profile == journal.Profile &&
+		binding.HostIdentity == journal.HostIdentity && binding.InstanceIdentity == journal.InstanceIdentity &&
+		binding.LaunchNonce == journal.LaunchNonce
+}
+
+func canonicalIdentity(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func projectConfigDigest(config ProjectConfig) (string, error) {
+	if err := config.Validate(); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func loadOptionalJournal(root *fsq.DeliveryRoot) (LaunchJournal, bool, error) {
+	record, err := LoadJournal(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return LaunchJournal{}, false, nil
+	}
+	return record, err == nil, err
+}

--- a/internal/launch/journal_test.go
+++ b/internal/launch/journal_test.go
@@ -1,0 +1,122 @@
+package launch
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLaunchJournalRequiresLeaseAndClearsOnlyExactRecord(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	request := reconcileFixture(t, backend)
+	nonce := "019c8a2f-2b13-7000-8000-000000000010"
+	plan, agents, conversations := journalFixturePlan(nonce)
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := NewLaunchJournal(request, backend.name, backend.Detect(), plan, digest, nonce, agents, conversations, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteJournal(request.Root, nil, record); err == nil {
+		t.Fatal("WriteJournal without lease succeeded")
+	}
+	lease, err := AcquireLease(request.Root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteJournal(request.Root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadJournal(request.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := record
+	changed.CreatedAt = changed.CreatedAt.Add(time.Second)
+	if err := ClearJournal(request.Root, lease, changed); err == nil {
+		t.Fatal("ClearJournal removed a different record")
+	}
+	if err := ClearJournal(request.Root, lease, loaded); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadJournal(request.Root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("journal after clear: %v", err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLaunchJournalRejectsPlanRosterAndBindingDrift(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	request := reconcileFixture(t, backend)
+	nonce := "019c8a2f-2b13-7000-8000-000000000011"
+	plan, agents, conversations := journalFixturePlan(nonce)
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := NewLaunchJournal(request, backend.name, backend.Detect(), plan, digest, nonce, agents, conversations, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	drifted := record
+	drifted.PlanDigest = "sha256:" + strings.Repeat("0", 64)
+	if err := drifted.Validate(); err == nil {
+		t.Fatal("journal accepted a different plan digest")
+	}
+	drifted = record
+	drifted.Conversations = nil
+	if err := drifted.Validate(); err == nil {
+		t.Fatal("journal accepted a different roster")
+	}
+	drifted = record
+	drifted.Phase = JournalCreated
+	drifted.Binding = &BindingRecord{
+		Version: BindingVersion, Backend: backend.name, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: backend.Detect().Profile.Identity(), LaunchNonce: testLaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:test"}}},
+	}
+	if err := drifted.Validate(); err == nil {
+		t.Fatal("journal accepted a binding from a different launch generation")
+	}
+	originalProject := request.ProjectRoot + "-original"
+	if err := os.Rename(request.ProjectRoot, originalProject); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(originalProject) })
+	if err := os.Mkdir(request.ProjectRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := record.ValidateRequest(request); err == nil || !strings.Contains(err.Error(), "physical") {
+		t.Fatalf("journal accepted replacement project directory: %v", err)
+	}
+	if err := os.Remove(request.ProjectRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(originalProject, request.ProjectRoot); err != nil {
+		t.Fatal(err)
+	}
+	request.Config.Agents[0].Env = map[string]string{"LANG": "C"}
+	if err := record.ValidateRequest(request); err == nil {
+		t.Fatal("journal accepted roster drift")
+	}
+}
+
+func journalFixturePlan(nonce string) (Plan, []AgentReconcileResult, []ConversationRecord) {
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{{
+		Handle: "claude", Argv: []string{"/usr/bin/true", nonce}, Cwd: "/tmp",
+		AdapterMode: AdapterModeMint, ResumePolicy: ResumeEnabled, LaunchNonce: nonce,
+		ConversationID: nonce, DynamicArgv: []DynamicArg{{Index: 1, Kind: DynamicArgLaunchNonce}},
+	}}}
+	agents := []AgentReconcileResult{{Handle: "claude", ConversationDisposition: DispositionFresh}}
+	conversations := []ConversationRecord{{
+		Version: ConversationVersion, Handle: "claude", State: CapturePending,
+		ProviderVersion: "test", LaunchNonce: nonce,
+	}}
+	return plan, agents, conversations
+}

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
@@ -80,6 +83,13 @@ type ReconcileResult struct {
 	Commands       []EmittedCommand       `json:"commands"`
 	Plan           *Plan                  `json:"plan"`
 	SemanticDigest string                 `json:"semantic_digest"`
+	Recovery       *RecoveryReport        `json:"recovery"`
+}
+
+type RecoveryReport struct {
+	Status    ReclaimStatus      `json:"status"`
+	Evidence  string             `json:"evidence"`
+	Resources []ResourceIdentity `json:"resources"`
 }
 
 type plannedAgent struct {
@@ -105,11 +115,30 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	if err := request.Config.Validate(); err != nil {
 		return result, err
 	}
-	nonce, err := generateNonce()
+	journal, hasJournal, err := loadOptionalJournal(request.Root)
 	if err != nil {
-		return result, err
+		result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_unreadable"
+		return result, nil
 	}
-	planned, err := buildReconcilePlan(request, nonce, &result)
+	var nonce string
+	var planned []plannedAgent
+	if hasJournal {
+		if err := journal.ValidateRequest(request); err != nil {
+			result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_context_mismatch"
+			return result, nil
+		}
+		nonce = journal.LaunchNonce
+		planned, err = plannedFromJournal(request, journal, &result)
+		if err != nil {
+			result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_plan_unavailable"
+			return result, nil
+		}
+	} else {
+		nonce, err = generateNonce()
+		if err == nil {
+			planned, err = buildReconcilePlan(request, nonce, &result)
+		}
+	}
 	if err != nil {
 		return result, err
 	}
@@ -121,9 +150,12 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		}
 		return result, nil
 	}
-	plan := Plan{Version: PlanVersion, Agents: make([]AgentPlan, 0, len(planned))}
-	for _, agent := range planned {
-		plan.Agents = append(plan.Agents, agent.plan)
+	plan := journal.Plan
+	if !hasJournal {
+		plan = Plan{Version: PlanVersion, Agents: make([]AgentPlan, 0, len(planned))}
+		for _, agent := range planned {
+			plan.Agents = append(plan.Agents, agent.plan)
+		}
 	}
 	digest, err := plan.SemanticDigest()
 	if err != nil {
@@ -174,64 +206,345 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, err.Error()
 		return result, nil
 	}
-	attachSafe := true
-	for _, agent := range planned {
-		attachSafe = attachSafe && !agent.write
-	}
-	backendName, backend, detect, proceed, err := chooseReconcileBackend(request, binding, hasBinding, attachSafe, &result)
-	if err != nil || !proceed {
-		if err != nil {
-			code := reconcileErrorCode(err)
-			markPlannedAgents(&result, planned, code, "backend_reconciliation_failed")
-			result.AggregateCode, result.Reason = code, err.Error()
+	var backendName string
+	var backend Backend
+	var detect DetectResult
+	var create CreateResult
+	recoveredCreate := false
+	journalActive := hasJournal
+	if hasJournal {
+		current, present, loadErr := loadOptionalJournal(request.Root)
+		if loadErr != nil || !present || !reflect.DeepEqual(current, journal) {
+			result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_changed"
 			return result, nil
 		}
-		if result.Outcome == OutcomeAttached {
+		journal = current
+		backendName, backend, detect, create, recoveredCreate, err = recoverJournal(request, journal, binding, hasBinding, &result)
+		if err != nil {
+			return result, err
+		}
+		if result.Outcome == OutcomeActionRequired {
+			markPlannedAgents(&result, planned, 6, result.Reason)
+			result.AggregateCode = 6
+			return result, nil
+		}
+		if hasBinding && journalMatchesBinding(journal, binding) {
+			if journal.Phase != JournalCreated {
+				result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_incomplete"
+				return result, nil
+			}
+			if err := commitRecoveredJournal(request, lease, journal); err != nil {
+				return result, err
+			}
+			result.Backend, result.Outcome = journal.Backend, OutcomeCreated
 			result.AggregateCode = aggregateReconcileCode(result.Agents)
 			return result, nil
 		}
-		markPlannedAgents(&result, planned, 6, result.Reason)
-		result.AggregateCode = 6
-		return result, nil
+		if !recoveredCreate {
+			// Reclaim proved the old generation absent. Recreate the exact trusted
+			// plan under the existing resume policy and journal generation.
+			if err := ClearJournal(request.Root, lease, journal); err != nil {
+				return result, err
+			}
+			journalActive = false
+		}
+	} else {
+		attachSafe := true
+		for _, agent := range planned {
+			attachSafe = attachSafe && !agent.write
+		}
+		var proceed bool
+		backendName, backend, detect, proceed, err = chooseReconcileBackend(request, binding, hasBinding, attachSafe, &result)
+		if err != nil || !proceed {
+			if err != nil {
+				code := reconcileErrorCode(err)
+				markPlannedAgents(&result, planned, code, "backend_reconciliation_failed")
+				result.AggregateCode, result.Reason = code, err.Error()
+				return result, nil
+			}
+			if result.Outcome == OutcomeAttached {
+				result.AggregateCode = aggregateReconcileCode(result.Agents)
+				return result, nil
+			}
+			markPlannedAgents(&result, planned, 6, result.Reason)
+			result.AggregateCode = 6
+			return result, nil
+		}
 	}
 	result.Backend = backendName
 
-	// Commands is the only Wave A backend and Create only emits an idempotent
-	// plan. Before Wave B adds its first managed backend, this boundary needs a
-	// durable recovery journal for a resource created before its binding write.
-	create, err := backend.Create(CreateRequest{Session: request.Session, Plan: plan, AMQPath: request.AMQPath, Root: request.Root})
-	if err != nil {
-		code := reconcileErrorCode(err)
-		markPlannedAgents(&result, planned, code, "backend_create_failed")
-		result.AggregateCode, result.Reason = code, err.Error()
-		return result, nil
+	if !recoveredCreate {
+		if detect.Profile.Has(CapCreate) {
+			journal, err = NewLaunchJournal(request, backendName, detect, plan, digest, nonce, result.Agents, plannedConversations(planned), time.Now())
+			if err != nil {
+				return result, err
+			}
+			if err := WriteJournal(request.Root, lease, journal); err != nil {
+				return result, err
+			}
+			journalActive = true
+			if err := callCrashHook(request.CrashHook, "journal_written"); err != nil {
+				return result, err
+			}
+		}
+		create, err = backend.Create(CreateRequest{Session: request.Session, Plan: plan, AMQPath: request.AMQPath, Root: request.Root})
+		if err != nil {
+			var definite *DefinitePreCreateError
+			if journalActive && errors.As(err, &definite) {
+				if clearErr := ClearJournal(request.Root, lease, journal); clearErr != nil {
+					return result, errors.Join(err, clearErr)
+				}
+			}
+			code := reconcileErrorCode(err)
+			markPlannedAgents(&result, planned, code, "backend_create_failed")
+			result.AggregateCode, result.Reason = code, err.Error()
+			return result, nil
+		}
+		if err := callCrashHook(request.CrashHook, "backend_created"); err != nil {
+			return result, err
+		}
 	}
 	result.Outcome, result.Commands = create.Outcome, create.Commands
-	if err := callCrashHook(request.CrashHook, "backend_created"); err != nil {
-		return result, err
+	if create.Outcome == OutcomeCommandsEmitted {
+		if err := writeExecutionTickets(request, lease, planned); err != nil {
+			return result, err
+		}
 	}
 	var candidate *BindingRecord
-	var executionEvidence *ConversationExecutionEvidence
 	if create.Outcome == OutcomeCreated {
-		created := create.Binding
-		if created.Backend != backendName || created.Profile != detect.Profile.Identity() || created.LaunchNonce != nonce {
-			return result, fmt.Errorf("backend returned a binding outside the selected launch generation")
+		if journalActive && journal.Phase == JournalCreated {
+			candidate = journal.Binding
+		} else {
+			candidate, err = finalizeCreatedState(create, backendName, detect, nonce, planned, &result)
+			if err != nil {
+				return result, err
+			}
 		}
-		if err := created.Validate(); err != nil {
-			return result, fmt.Errorf("backend returned invalid binding: %w", err)
+	}
+	if journalActive {
+		if candidate == nil {
+			result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "managed_create_not_completed"
+			return result, nil
 		}
-		candidate = &created
-		executionEvidence = &ConversationExecutionEvidence{
-			Backend: backendName, Profile: detect.Profile.Identity(), Outcome: OutcomeCreated, LaunchNonce: nonce,
+		journal.Phase, journal.Binding = JournalCreated, candidate
+		journal.Agents, journal.Conversations = slices.Clone(result.Agents), plannedConversations(planned)
+		if err := WriteJournal(request.Root, lease, journal); err != nil {
+			return result, err
+		}
+		if err := callCrashHook(request.CrashHook, "journal_created"); err != nil {
+			return result, err
 		}
 	}
 	for i := range planned {
+		if planned[i].write {
+			if err := WriteConversation(request.Root, lease, planned[i].record); err != nil {
+				return result, err
+			}
+		}
+	}
+	if err := callCrashHook(request.CrashHook, "conversations_written"); err != nil {
+		return result, err
+	}
+	if candidate != nil {
+		if recoveredCreate {
+			if err := revalidateAdoption(request, backend, journal, *candidate); err != nil {
+				result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_recovery_changed"
+				return result, nil
+			}
+		}
+		if err := WriteBinding(request.Root, lease, *candidate); err != nil {
+			return result, err
+		}
+		if err := callCrashHook(request.CrashHook, "binding_written"); err != nil {
+			return result, err
+		}
+	}
+	if journalActive {
+		if err := ClearJournal(request.Root, lease, journal); err != nil {
+			return result, err
+		}
+		if err := callCrashHook(request.CrashHook, "journal_cleared"); err != nil {
+			return result, err
+		}
+	}
+	if create.ActionRequired || create.Outcome == OutcomeCommandsEmitted || create.Outcome == OutcomeActionRequired {
+		for _, agent := range planned {
+			if result.Agents[agent.index].Code == 0 {
+				result.Agents[agent.index].Code = 6
+				if result.Agents[agent.index].Reason == "" {
+					result.Agents[agent.index].Reason = "commands_emitted"
+				}
+			}
+		}
+		result.AggregateCode = 6
+		result.Reason = "execute the emitted commands to complete launch"
+		return result, nil
+	}
+	result.AggregateCode = aggregateReconcileCode(result.Agents)
+	if result.AggregateCode != 0 && result.Reason == "" {
+		result.Reason = firstReconcileReason(result.Agents, result.AggregateCode)
+	}
+	return result, nil
+}
+
+const reclaimTimeout = 5 * time.Second
+
+func plannedFromJournal(request ReconcileRequest, journal LaunchJournal, result *ReconcileResult) ([]plannedAgent, error) {
+	result.Agents = slices.Clone(journal.Agents)
+	planned := make([]plannedAgent, len(journal.Plan.Agents))
+	for i, plan := range journal.Plan.Agents {
+		var cfg ProjectAgentConfig
+		foundConfig := false
+		for _, candidate := range request.Config.Agents {
+			if candidate.Handle == plan.Handle {
+				cfg, foundConfig = candidate, true
+				break
+			}
+		}
+		if !foundConfig {
+			return nil, fmt.Errorf("launch journal handle %q does not match current roster", plan.Handle)
+		}
+		adapter := request.Adapters[cfg.Adapter]
+		if adapter == nil || adapter.Mode() != plan.AdapterMode {
+			return nil, fmt.Errorf("launch journal adapter for %q is unavailable or changed", plan.Handle)
+		}
+		capabilities := adapter.Capabilities(request.Context)
+		if err := ValidateAdapterCapabilities(adapter, capabilities); err != nil {
+			return nil, err
+		}
+		if !capabilities.Available {
+			return nil, fmt.Errorf("launch journal adapter for %q is unavailable", plan.Handle)
+		}
+		resultIndex := -1
+		for j, agentResult := range journal.Agents {
+			if agentResult.Handle == plan.Handle {
+				resultIndex = j
+				break
+			}
+		}
+		if resultIndex < 0 {
+			return nil, fmt.Errorf("launch journal handle %q has no result", plan.Handle)
+		}
+		write := journal.Agents[resultIndex].ConversationDisposition != DispositionResumed
+		planned[i] = plannedAgent{
+			plan: plan, record: journal.Conversations[i], write: write, index: resultIndex,
+			adapter: adapter, providerVersion: journal.Conversations[i].ProviderVersion,
+		}
+	}
+	return planned, nil
+}
+
+func recoverJournal(request ReconcileRequest, journal LaunchJournal, binding BindingRecord, hasBinding bool, result *ReconcileResult) (string, Backend, DetectResult, CreateResult, bool, error) {
+	requested := strings.TrimSpace(request.Launcher)
+	if requested != "" && requested != LauncherAuto && requested != journal.Backend {
+		result.Outcome, result.Reason = OutcomeActionRequired, "launch_journal_backend_conflict"
+		return journal.Backend, nil, DetectResult{}, CreateResult{}, false, nil
+	}
+	backend := request.Backends[journal.Backend]
+	if backend == nil {
+		result.Outcome, result.Reason = OutcomeActionRequired, "journaled_launcher_not_available"
+		return journal.Backend, nil, DetectResult{}, CreateResult{}, false, nil
+	}
+	detect := backend.Detect()
+	if err := detect.Validate(); err != nil {
+		return journal.Backend, backend, detect, CreateResult{}, false, err
+	}
+	if !detect.Available || detect.Profile.Identity() != journal.Profile || detect.HostIdentity != journal.HostIdentity || detect.InstanceIdentity != journal.InstanceIdentity {
+		result.Outcome, result.Reason = OutcomeActionRequired, "launch_journal_context_mismatch"
+		return journal.Backend, backend, detect, CreateResult{}, false, nil
+	}
+	if request.HostIdentity != "" && request.HostIdentity != journal.HostIdentity {
+		result.Outcome, result.Reason = OutcomeActionRequired, "launch_journal_context_mismatch"
+		return journal.Backend, backend, detect, CreateResult{}, false, nil
+	}
+	if hasBinding {
+		if !journalMatchesBinding(journal, binding) {
+			result.Outcome, result.Reason = OutcomeActionRequired, "launch_journal_binding_conflict"
+		}
+		return journal.Backend, backend, detect, CreateResult{}, false, nil
+	}
+	reclaimer, ok := backend.(BackendReclaimer)
+	if !ok || !detect.Profile.Has(CapReclaim) {
+		result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_not_supported"
+		return journal.Backend, backend, detect, CreateResult{}, false, nil
+	}
+	reclaim, err := callReclaim(request.Context, reclaimer, journal, request.Root)
+	if err != nil {
+		return journal.Backend, backend, detect, CreateResult{}, false, err
+	}
+	result.Recovery = &RecoveryReport{Status: reclaim.Status, Evidence: reclaim.Evidence, Resources: slices.Clone(reclaim.Resources)}
+	if strings.TrimSpace(reclaim.Evidence) == "" {
+		return journal.Backend, backend, detect, CreateResult{}, false, fmt.Errorf("backend reclaim returned no evidence")
+	}
+	switch reclaim.Status {
+	case ReclaimAbsent:
+		return journal.Backend, backend, detect, CreateResult{}, false, nil
+	case ReclaimAdoptable:
+		if err := reclaim.Binding.Validate(); err != nil || !journalMatchesBinding(journal, reclaim.Binding) {
+			result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_identity_mismatch"
+			return journal.Backend, backend, detect, CreateResult{}, false, nil
+		}
+		if journal.Phase == JournalCreated && (journal.Binding == nil || !reflect.DeepEqual(*journal.Binding, reclaim.Binding)) {
+			result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_identity_mismatch"
+			return journal.Backend, backend, detect, CreateResult{}, false, nil
+		}
+		create := CreateResult{
+			Outcome: OutcomeCreated, Profile: journal.Profile, Binding: reclaim.Binding,
+			CaptureEvidence: reclaim.CaptureEvidence,
+		}
+		return journal.Backend, backend, detect, create, true, nil
+	case ReclaimIncomplete:
+		result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_incomplete"
+	case ReclaimForeign:
+		result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_foreign"
+	case ReclaimUnknown:
+		result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_unknown"
+	default:
+		return journal.Backend, backend, detect, CreateResult{}, false, fmt.Errorf("backend reclaim returned invalid status %q", reclaim.Status)
+	}
+	return journal.Backend, backend, detect, CreateResult{}, false, nil
+}
+
+func callReclaim(parent context.Context, backend BackendReclaimer, journal LaunchJournal, root *fsq.DeliveryRoot) (ReclaimResult, error) {
+	ctx, cancel := context.WithTimeout(parent, reclaimTimeout)
+	defer cancel()
+	return backend.Reclaim(ReclaimRequest{Context: ctx, Journal: journal, Root: root})
+}
+
+func revalidateAdoption(request ReconcileRequest, backend Backend, journal LaunchJournal, candidate BindingRecord) error {
+	reclaimer, ok := backend.(BackendReclaimer)
+	if !ok {
+		return fmt.Errorf("backend no longer supports reclaim")
+	}
+	reclaim, err := callReclaim(request.Context, reclaimer, journal, request.Root)
+	if err != nil {
+		return err
+	}
+	if reclaim.Status != ReclaimAdoptable || !reflect.DeepEqual(reclaim.Binding, candidate) {
+		return fmt.Errorf("journaled resource changed before binding commit")
+	}
+	return nil
+}
+
+func finalizeCreatedState(create CreateResult, backendName string, detect DetectResult, nonce string, planned []plannedAgent, result *ReconcileResult) (*BindingRecord, error) {
+	created := create.Binding
+	if created.Backend != backendName || created.Profile != detect.Profile.Identity() || created.LaunchNonce != nonce ||
+		created.HostIdentity != detect.HostIdentity || created.InstanceIdentity != detect.InstanceIdentity {
+		return nil, fmt.Errorf("backend returned a binding outside the selected launch generation")
+	}
+	if err := created.Validate(); err != nil {
+		return nil, fmt.Errorf("backend returned invalid binding: %w", err)
+	}
+	executionEvidence := ConversationExecutionEvidence{
+		Backend: backendName, Profile: detect.Profile.Identity(), Outcome: OutcomeCreated, LaunchNonce: nonce,
+	}
+	for i := range planned {
 		agent := &planned[i]
-		if agent.write && executionEvidence != nil {
-			evidence := *executionEvidence
+		if agent.write {
+			evidence := executionEvidence
 			agent.record.ExecutionEvidence = &evidence
 		}
-		if agent.plan.AdapterMode == AdapterModeMint && agent.write && executionEvidence != nil {
+		if agent.plan.AdapterMode == AdapterModeMint && agent.write {
 			agent.record.State = CaptureReady
 			agent.record.Identity = ConversationIdentity{Provider: agent.adapter.Name(), ID: agent.plan.ConversationID}
 		}
@@ -254,38 +567,48 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		if agent.record.State == CaptureReady && agent.record.ExecutionEvidence != nil {
 			agent.record.ExecutionEvidence.ConversationID = agent.record.Identity.ID
 		}
-		if agent.write {
-			if err := WriteConversation(request.Root, lease, agent.record); err != nil {
-				return result, err
-			}
+	}
+	return &created, nil
+}
+
+func plannedConversations(planned []plannedAgent) []ConversationRecord {
+	records := make([]ConversationRecord, len(planned))
+	for i := range planned {
+		records[i] = planned[i].record
+	}
+	return records
+}
+
+func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []plannedAgent) error {
+	amqPath := request.AMQPath
+	if strings.TrimSpace(amqPath) == "" {
+		amqPath = "amq"
+	}
+	for _, agent := range planned {
+		ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+			Handle: agent.plan.Handle, LaunchNonce: agent.plan.LaunchNonce,
+			Mode: agent.plan.AdapterMode, Provider: agent.adapter.Name(), ConversationID: agent.plan.ConversationID,
+			ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Cwd: agent.plan.Cwd,
+			ProviderExecutable: agent.plan.Argv[0], AMQExecutable: amqPath,
+			TargetArgv: agent.plan.Argv, TargetEnv: agent.plan.EnvOverlay,
+		})
+		if err != nil {
+			return fmt.Errorf("build execution ticket for %s: %w", agent.plan.Handle, err)
+		}
+		if err := WriteExecutionTicket(request.Root, lease, ticket); err != nil {
+			return fmt.Errorf("write execution ticket for %s: %w", agent.plan.Handle, err)
 		}
 	}
-	if err := callCrashHook(request.CrashHook, "conversations_written"); err != nil {
-		return result, err
-	}
-	if candidate != nil {
-		if err := WriteBinding(request.Root, lease, *candidate); err != nil {
-			return result, err
+	return nil
+}
+
+func commitRecoveredJournal(request ReconcileRequest, lease *Lease, journal LaunchJournal) error {
+	for _, record := range journal.Conversations {
+		if err := WriteConversation(request.Root, lease, record); err != nil {
+			return err
 		}
 	}
-	if create.ActionRequired || create.Outcome == OutcomeCommandsEmitted || create.Outcome == OutcomeActionRequired {
-		for _, agent := range planned {
-			if result.Agents[agent.index].Code == 0 {
-				result.Agents[agent.index].Code = 6
-				if result.Agents[agent.index].Reason == "" {
-					result.Agents[agent.index].Reason = "commands_emitted"
-				}
-			}
-		}
-		result.AggregateCode = 6
-		result.Reason = "execute the emitted commands to complete launch"
-		return result, nil
-	}
-	result.AggregateCode = aggregateReconcileCode(result.Agents)
-	if result.AggregateCode != 0 && result.Reason == "" {
-		result.Reason = firstReconcileReason(result.Agents, result.AggregateCode)
-	}
-	return result, nil
+	return ClearJournal(request.Root, lease, journal)
 }
 
 func buildReconcilePlan(request ReconcileRequest, nonce string, result *ReconcileResult) ([]plannedAgent, error) {
@@ -389,6 +712,9 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 		record := ConversationRecord{
 			Version: ConversationVersion, Handle: cfg.Handle, State: CapturePending,
 			ProviderVersion: capabilities.ProviderVersion, LaunchNonce: nonce,
+		}
+		if disposition == DispositionResumed {
+			record = conversation
 		}
 		planned = append(planned, plannedAgent{
 			plan: agentPlan, record: record, write: disposition != DispositionResumed,

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -580,9 +580,9 @@ func plannedConversations(planned []plannedAgent) []ConversationRecord {
 }
 
 func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []plannedAgent) error {
-	amqPath := request.AMQPath
-	if strings.TrimSpace(amqPath) == "" {
-		amqPath = "amq"
+	amqPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve current amq executable: %w", err)
 	}
 	for _, agent := range planned {
 		ticket, err := NewExecutionTicket(ExecutionTicketRequest{

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -65,10 +66,17 @@ type reconcileBackend struct {
 	createStart chan struct{}
 	capture     bool
 	invalidBind bool
+	reclaims    int
+	resourceUp  bool
+	reclaimAs   ReclaimStatus
+	reclaimList []ResourceIdentity
+	reclaimFlip bool
+	createErr   error
+	definiteErr bool
 }
 
 func (b *reconcileBackend) Detect() DetectResult {
-	profile := Profile{Backend: b.name, Platform: "test", VersionRange: "*", Version: 1, Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus}}
+	profile := Profile{Backend: b.name, Platform: "test", VersionRange: "*", Version: 1, Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus, CapReclaim}}
 	return DetectResult{
 		Available: true, Profile: profile, Effective: profile.Capabilities,
 		HostIdentity: "host:test", InstanceIdentity: "instance:test",
@@ -77,6 +85,15 @@ func (b *reconcileBackend) Detect() DetectResult {
 func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
 	b.mu.Lock()
 	b.creates++
+	createErr, definiteErr := b.createErr, b.definiteErr
+	if createErr != nil {
+		b.mu.Unlock()
+		if definiteErr {
+			return CreateResult{}, &DefinitePreCreateError{Err: createErr}
+		}
+		return CreateResult{}, createErr
+	}
+	b.resourceUp = true
 	b.mu.Unlock()
 	if b.createStart != nil {
 		select {
@@ -118,6 +135,41 @@ func (b *reconcileBackend) Focus(FocusRequest) (FocusResult, error) {
 	b.focuses++
 	b.mu.Unlock()
 	return FocusResult{Outcome: OutcomeAttached}, nil
+}
+func (b *reconcileBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.reclaims++
+	if b.reclaimAs != "" && b.reclaimAs != ReclaimAdoptable {
+		return ReclaimResult{
+			Status: b.reclaimAs, Evidence: "test classified recovery",
+			Resources: slices.Clone(b.reclaimList),
+		}, nil
+	}
+	if !b.resourceUp {
+		return ReclaimResult{Status: ReclaimAbsent, Evidence: "test resource absent"}, nil
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: b.name, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: b.Detect().Profile.Identity(), LaunchNonce: req.Journal.LaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:test"}}},
+	}
+	result := ReclaimResult{
+		Status: ReclaimAdoptable, Evidence: "test name and nonce match", Binding: binding,
+		Resources: slices.Clone(binding.Resources.Resources),
+	}
+	if b.reclaimFlip && b.reclaims > 1 {
+		result.Binding.Resources.Resources[0].OpaqueID = "resource:replacement"
+		result.Resources = slices.Clone(result.Binding.Resources.Resources)
+	}
+	if b.capture {
+		evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Journal.LaunchNonce, false)
+		if err != nil {
+			return ReclaimResult{}, err
+		}
+		result.CaptureEvidence = map[string][]CaptureEvidence{req.Journal.Plan.Agents[0].Handle: {evidence}}
+	}
+	return result, nil
 }
 
 func reconcileFixture(t *testing.T, backend Backend) ReconcileRequest {
@@ -412,6 +464,10 @@ func TestReconcilePlanOnlyMintWithoutExecutionRemintsPending(t *testing.T) {
 	if firstRecord.State != CapturePending || firstRecord.Identity.ID != "" || firstRecord.ExecutionEvidence != nil || firstRecord.LaunchNonce != firstID {
 		t.Fatalf("first record=%#v, want pending nonce %q without evidence", firstRecord, firstID)
 	}
+	ticket, err := LoadExecutionTicket(req.Root, "claude")
+	if err != nil || ticket.State != ExecutionPending || ticket.LaunchNonce != firstID || !slices.Equal(ticket.TargetArgv, first.Plan.Agents[0].Argv) {
+		t.Fatalf("first execution ticket=%#v err=%v", ticket, err)
+	}
 	resumeReq := req
 	resumeReq.ResumeOnly = true
 	resume, err := Reconcile(resumeReq)
@@ -597,8 +653,142 @@ func TestReconcileUntrustedAndRosterDriftAreStructured(t *testing.T) {
 	}
 }
 
-func TestReconcileCrashAfterCreateReleasesLeaseForRecovery(t *testing.T) {
+func TestReconcileManagedCreateCrashMatrixConvergesWithoutDuplicateSpawn(t *testing.T) {
+	for _, stage := range []string{
+		"journal_written", "backend_created", "journal_created",
+		"conversations_written", "binding_written", "journal_cleared",
+	} {
+		t.Run(stage, func(t *testing.T) {
+			backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+			req := reconcileFixture(t, backend)
+			crash := errors.New("injected crash")
+			fired := false
+			req.CrashHook = func(got string) error {
+				if got == stage && !fired {
+					fired = true
+					return crash
+				}
+				return nil
+			}
+			if _, err := Reconcile(req); !errors.Is(err, crash) {
+				t.Fatalf("crash error = %v", err)
+			}
+			inspection, err := InspectLease(req.Root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if inspection.State != LeaseMissing {
+				t.Fatalf("lease after crash = %#v", inspection)
+			}
+
+			req.CrashHook = nil
+			result, err := Reconcile(req)
+			if err != nil || result.AggregateCode != 0 {
+				t.Fatalf("recovery result=%#v err=%v", result, err)
+			}
+			if backend.creates != 1 {
+				t.Fatalf("backend creates=%d, want exactly one", backend.creates)
+			}
+			if _, err := LoadJournal(req.Root); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("journal after recovery: %v", err)
+			}
+			if _, err := LoadBinding(req.Root); err != nil {
+				t.Fatalf("binding after recovery: %v", err)
+			}
+			record, err := LoadConversation(req.Root, "claude")
+			if err != nil || record.State != CaptureReady || record.ExecutionEvidence == nil {
+				t.Fatalf("conversation after recovery=%#v err=%v", record, err)
+			}
+		})
+	}
+}
+
+func TestReconcileCrashRecoveryPreservesExistingConversationIdentity(t *testing.T) {
 	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	writeReconcileConversation(t, req, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity: ConversationIdentity{Provider: "claude", ID: testConversationID}, LaunchNonce: testLaunchNonce,
+		ExecutionEvidence: reconcileExecutionEvidence(backend, testLaunchNonce),
+	})
+	crash := errors.New("injected crash")
+	req.CrashHook = func(stage string) error {
+		if stage == "backend_created" {
+			return crash
+		}
+		return nil
+	}
+	first, err := Reconcile(req)
+	if !errors.Is(err, crash) || first.Plan == nil || first.Plan.Agents[0].ConversationID != testConversationID {
+		t.Fatalf("first result=%#v err=%v", first, err)
+	}
+	journal, err := LoadJournal(req.Root)
+	if err != nil || journal.Conversations[0].Identity.ID != testConversationID || journal.Conversations[0].LaunchNonce != testLaunchNonce {
+		t.Fatalf("journal=%#v err=%v", journal, err)
+	}
+	req.CrashHook = nil
+	result, err := Reconcile(req)
+	if err != nil || result.AggregateCode != 0 || backend.creates != 1 {
+		t.Fatalf("recovery result=%#v creates=%d err=%v", result, backend.creates, err)
+	}
+	record, err := LoadConversation(req.Root, "claude")
+	if err != nil || record.Identity.ID != testConversationID || record.LaunchNonce != testLaunchNonce {
+		t.Fatalf("conversation=%#v err=%v", record, err)
+	}
+}
+
+func TestReconcileJournalRequiresClassifiedReclaimAndPreservesInventory(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		wrap       bool
+		status     ReclaimStatus
+		wantReason string
+	}{
+		{name: "no_reclaim", wrap: true, wantReason: "launch_recovery_not_supported"},
+		{name: "incomplete", status: ReclaimIncomplete, wantReason: "launch_recovery_incomplete"},
+		{name: "unknown", status: ReclaimUnknown, wantReason: "launch_recovery_unknown"},
+		{name: "foreign", status: ReclaimForeign, wantReason: "launch_recovery_foreign"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := &reconcileBackend{
+				name: "test", inspect: InspectAbsent, reclaimAs: test.status,
+				reclaimList: []ResourceIdentity{{OpaqueID: "resource:partial", Agent: "claude"}},
+			}
+			var selected Backend = backend
+			if test.wrap {
+				selected = noReclaimBackend{Backend: backend}
+			}
+			req := reconcileFixture(t, selected)
+			crash := errors.New("injected crash")
+			req.CrashHook = func(stage string) error {
+				if stage == "backend_created" {
+					return crash
+				}
+				return nil
+			}
+			if _, err := Reconcile(req); !errors.Is(err, crash) {
+				t.Fatalf("crash error = %v", err)
+			}
+			req.CrashHook = nil
+			result, err := Reconcile(req)
+			if err != nil || result.AggregateCode != 6 || result.Reason != test.wantReason || backend.creates != 1 {
+				t.Fatalf("result=%#v creates=%d err=%v", result, backend.creates, err)
+			}
+			if test.status != "" && (result.Recovery == nil || !slices.Equal(result.Recovery.Resources, backend.reclaimList)) {
+				t.Fatalf("recovery report=%#v, want exact inventory %#v", result.Recovery, backend.reclaimList)
+			}
+			if _, err := LoadJournal(req.Root); err != nil {
+				t.Fatalf("journal was not preserved: %v", err)
+			}
+			if _, err := LoadBinding(req.Root); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("recovery published binding: %v", err)
+			}
+		})
+	}
+}
+
+func TestReconcileRevalidatesAdoptionImmediatelyBeforeBinding(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent, reclaimFlip: true}
 	req := reconcileFixture(t, backend)
 	crash := errors.New("injected crash")
 	req.CrashHook = func(stage string) error {
@@ -610,19 +800,40 @@ func TestReconcileCrashAfterCreateReleasesLeaseForRecovery(t *testing.T) {
 	if _, err := Reconcile(req); !errors.Is(err, crash) {
 		t.Fatalf("crash error = %v", err)
 	}
-	inspection, err := InspectLease(req.Root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if inspection.State != LeaseMissing {
-		t.Fatalf("lease after crash = %#v", inspection)
-	}
 	req.CrashHook = nil
 	result, err := Reconcile(req)
-	if err != nil || result.AggregateCode != 0 {
-		t.Fatalf("recovery result=%#v err=%v", result, err)
+	if err != nil || result.AggregateCode != 6 || result.Reason != "launch_recovery_changed" || backend.reclaims != 2 {
+		t.Fatalf("result=%#v reclaims=%d err=%v", result, backend.reclaims, err)
+	}
+	if _, err := LoadBinding(req.Root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("changed adoption published binding: %v", err)
+	}
+	if _, err := LoadJournal(req.Root); err != nil {
+		t.Fatalf("changed adoption lost journal: %v", err)
 	}
 }
+
+func TestReconcileCreateFailureClassificationControlsJournalClear(t *testing.T) {
+	for _, definite := range []bool{true, false} {
+		t.Run(map[bool]string{true: "definite", false: "uncertain"}[definite], func(t *testing.T) {
+			backend := &reconcileBackend{name: "test", inspect: InspectAbsent, createErr: errors.New("create failed"), definiteErr: definite}
+			req := reconcileFixture(t, backend)
+			result, err := Reconcile(req)
+			if err != nil || result.AggregateCode != 1 {
+				t.Fatalf("result=%#v err=%v", result, err)
+			}
+			_, journalErr := LoadJournal(req.Root)
+			if definite && !errors.Is(journalErr, os.ErrNotExist) {
+				t.Fatalf("definite pre-create failure retained journal: %v", journalErr)
+			}
+			if !definite && journalErr != nil {
+				t.Fatalf("uncertain create failure lost journal: %v", journalErr)
+			}
+		})
+	}
+}
+
+type noReclaimBackend struct{ Backend }
 
 func TestReconcileCaptureEvidencePersistsExactIdentity(t *testing.T) {
 	backend := &reconcileBackend{name: "test", inspect: InspectAbsent, capture: true}


### PR DESCRIPTION
## Summary
- add a lease-bound managed-create recovery journal with classified reclaim and crash-boundary recovery
- add nonce-bound Commands execution tickets and a PID-preserving final execution wrapper
- keep capture pending until verified provider evidence and revert exact mint generations when exec fails
- add explicit journal cleanup, hostile tests, and recovery documentation

## Verification
- `make ci`
- pre-push checks
- Claude exact staged-diff review: APPROVED

Refs: #480