### PR TITLE
fix(launch): bind execution trust digest to session and root identity

### DIFF
--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -222,6 +222,46 @@ func TestLaunchWithoutExecutionRemintsAndResumeJSONKeepsSchema(t *testing.T) {
 	}
 }
 
+func TestDefaultSessionChangeInvalidatesEmissionTrust(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab", "empty")
+	launchIsTerminal = func() bool { return true }
+	launchInput = func() *bufio.Reader { return bufio.NewReader(strings.NewReader("y\n")) }
+	if _, _, err := captureEnvOutput(t, func() error { return runLaunch(nil) }); GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("initial trusted launch exit=%d err=%v", GetExitCode(err), err)
+	}
+
+	changed := launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: "empty", Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+		Agents: []launch.ProjectAgentConfig{{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: launch.ResumeEnabled}},
+	}
+	data, err := launch.MarshalProjectConfig(changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, setupConfigPath), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	launchIsTerminal = func() bool { return false }
+	stdout, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--json"}) })
+	if GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("changed default launch exit=%d err=%v output=%s", GetExitCode(err), err, stdout)
+	}
+	var result launch.ReconcileResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Session != "empty" || result.Reason != "launch plan requires local trust confirmation" || result.Plan == nil {
+		t.Fatalf("changed default result=%#v", result)
+	}
+	emptyRoot := filepath.Join(project, defaultCoopRoot, "empty")
+	if _, err := os.Stat(launch.ExecutionTicketPath(emptyRoot, "claude")); !os.IsNotExist(err) {
+		t.Fatalf("stale trust emitted an execution ticket: %v", err)
+	}
+	if _, err := os.Stat(launch.ConversationPath(emptyRoot, "claude")); !os.IsNotExist(err) {
+		t.Fatalf("stale trust wrote conversation state: %v", err)
+	}
+}
+
 func TestLaunchMissingBinaryIsStructuredDisposition(t *testing.T) {
 	launchCLIFixture(t, "collab")
 	launchAdapters = func(launch.ProjectConfig) map[string]launch.HarnessAdapter {

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -157,12 +157,16 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 			plan.Agents = append(plan.Agents, agent.plan)
 		}
 	}
-	digest, err := plan.SemanticDigest()
+	planDigest, err := plan.SemanticDigest()
 	if err != nil {
 		return result, err
 	}
-	result.Plan, result.SemanticDigest = &plan, digest
-	trusted, err := ensurePlanTrust(request, plan, digest)
+	trustDigest, err := ExecutionTrustDigest(plan, request.Session, request.Root)
+	if err != nil {
+		return result, err
+	}
+	result.Plan, result.SemanticDigest = &plan, trustDigest
+	trusted, err := ensurePlanTrust(request, plan, trustDigest)
 	if err != nil {
 		markPlannedAgents(&result, planned, 6, "trust_state_unreadable")
 		result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, err.Error()
@@ -275,7 +279,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 
 	if !recoveredCreate {
 		if detect.Profile.Has(CapCreate) {
-			journal, err = NewLaunchJournal(request, backendName, detect, plan, digest, nonce, result.Agents, plannedConversations(planned), time.Now())
+			journal, err = NewLaunchJournal(request, backendName, detect, plan, planDigest, nonce, result.Agents, plannedConversations(planned), time.Now())
 			if err != nil {
 				return result, err
 			}
@@ -638,6 +642,13 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 		} else if !filepath.IsAbs(cwd) {
 			cwd = filepath.Join(request.ProjectRoot, cwd)
 		}
+		resolvedCwd, resolveErr := resolvedPath(cwd)
+		if resolveErr != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, "working_directory_unavailable"
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		cwd = resolvedCwd
 		policy := cfg.ResumePolicy
 		base := PlanRequest{
 			Handle: cfg.Handle, ProjectRoot: request.ProjectRoot, Cwd: cwd,

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -5,11 +5,36 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
 	"testing"
 )
+
+func TestReconcileEmitsCanonicalResolvedWorkingDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires host policy support")
+	}
+	req := reconcileFixture(t, Commands{})
+	alias := filepath.Join(t.TempDir(), "project-alias")
+	if err := os.Symlink(req.ProjectRoot, alias); err != nil {
+		t.Fatal(err)
+	}
+	req.ProjectRoot = alias
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := filepath.EvalSymlinks(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Commands) != 1 || result.Commands[0].Cwd != resolved || result.Plan == nil || result.Plan.Agents[0].Cwd != resolved {
+		t.Fatalf("canonical cwd result=%#v, want %q", result, resolved)
+	}
+}
 
 type reconcileAdapter struct {
 	name      string

--- a/internal/launch/trust_digest.go
+++ b/internal/launch/trust_digest.go
@@ -1,0 +1,60 @@
+package launch
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const executionTrustDigestVersion = 1
+
+// ExecutionTrustDigest binds the static provider plan to the session root in
+// which the plan will be emitted. The plan digest alone cannot distinguish a
+// selector-free launch after default_session changes.
+func ExecutionTrustDigest(plan Plan, session string, root *fsq.DeliveryRoot) (string, error) {
+	if !canonicalSessionPattern.MatchString(session) || strings.HasPrefix(session, "-") {
+		return "", fmt.Errorf("invalid trust session %q", session)
+	}
+	if root == nil {
+		return "", fmt.Errorf("missing pinned session root")
+	}
+	if err := root.VerifyBase(); err != nil {
+		return "", err
+	}
+	planDigest, err := plan.SemanticDigest()
+	if err != nil {
+		return "", err
+	}
+	rootPath, err := filepath.Abs(root.Base())
+	if err != nil {
+		return "", err
+	}
+	rootPath, err = filepath.EvalSymlinks(rootPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve trust session root: %w", err)
+	}
+	rootIdentity, err := fsq.StableTreeIdentityInfo(root.FileInfo())
+	if err != nil {
+		return "", fmt.Errorf("resolve trust session-root identity: %w", err)
+	}
+	canonical, err := json.Marshal(struct {
+		Version      int    `json:"version"`
+		PlanDigest   string `json:"plan_digest"`
+		Session      string `json:"session"`
+		RootPath     string `json:"root_path"`
+		RootIdentity string `json:"root_identity"`
+	}{
+		Version: executionTrustDigestVersion, PlanDigest: planDigest,
+		Session: session, RootPath: filepath.Clean(rootPath), RootIdentity: rootIdentity,
+	})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/launch/trust_digest_test.go
+++ b/internal/launch/trust_digest_test.go
@@ -1,0 +1,75 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestExecutionTrustDigestBindsSessionAndPhysicalRoot(t *testing.T) {
+	_, firstRoot := openTestRoot(t)
+	_, secondRoot := openTestRoot(t)
+	plan := validPlan()
+	first, err := ExecutionTrustDigest(plan, "collab", firstRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherSession, err := ExecutionTrustDigest(plan, "empty", firstRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherRoot, err := ExecutionTrustDigest(plan, "collab", secondRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == otherSession {
+		t.Fatal("session change retained stale execution trust digest")
+	}
+	if first == otherRoot {
+		t.Fatal("physical session-root change retained stale execution trust digest")
+	}
+}
+
+func TestExecutionTrustDigestRejectsSamePathRootReplacement(t *testing.T) {
+	parent := t.TempDir()
+	path := filepath.Join(parent, "session")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	open := func() *fsq.DeliveryRoot {
+		identity, err := fsq.SnapshotDeliveryRoot(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		root, err := fsq.OpenDeliveryRoot(path, identity)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return root
+	}
+	firstRoot := open()
+	first, err := ExecutionTrustDigest(validPlan(), "collab", firstRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := firstRoot.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path, filepath.Join(parent, "detached")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secondRoot := open()
+	defer func() { _ = secondRoot.Close() }()
+	second, err := ExecutionTrustDigest(validPlan(), "collab", secondRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("same-path session-root replacement retained stale execution trust digest")
+	}
+}


### PR DESCRIPTION
## Summary
- bind local execution trust to the selected session and canonical physical session root
- keep the backend recovery journal bound to the static plan digest
- emit canonical resolved working directories
- reject default-session and same-path root drift before command emission

## Verification
- `make ci`
- `gate-fix456.sh`: FIX-4a PASS, FIX-4b PASS
- Claude exact staged-diff review: APPROVED

Refs: #480 #504