### PR TITLE
fix(launch): gate capture-mode planning on declared capabilities

### DIFF
--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -15,23 +15,37 @@ import (
 )
 
 type launchFixtureAdapter struct {
-	available bool
-	reason    string
+	name               string
+	mode               launch.AdapterMode
+	available          bool
+	captureUnsupported bool
+	reason             string
 }
 
-func (launchFixtureAdapter) Name() string               { return launch.ClaudeProvider }
-func (launchFixtureAdapter) Mode() launch.AdapterMode   { return launch.AdapterModeMint }
+func (a launchFixtureAdapter) Name() string {
+	if a.name != "" {
+		return a.name
+	}
+	return launch.ClaudeProvider
+}
+func (a launchFixtureAdapter) Mode() launch.AdapterMode {
+	if a.mode != "" {
+		return a.mode
+	}
+	return launch.AdapterModeMint
+}
 func (launchFixtureAdapter) CommittedEnvKeys() []string { return nil }
 func (a launchFixtureAdapter) Capabilities(context.Context) launch.AdapterCapabilities {
 	return launch.AdapterCapabilities{
-		Provider: launch.ClaudeProvider, Mode: launch.AdapterModeMint, Available: a.available,
-		ProviderVersion: "test", Fresh: a.available, Resume: a.available, Reason: a.reason,
+		Provider: a.Name(), Mode: a.Mode(), Available: a.available,
+		ProviderVersion: "test", Fresh: a.available, Resume: a.available,
+		Capture: a.available && a.Mode() == launch.AdapterModeCapture && !a.captureUnsupported, Reason: a.reason,
 	}
 }
-func (launchFixtureAdapter) PlanFresh(req launch.PlanRequest) (launch.AgentPlan, error) {
+func (a launchFixtureAdapter) PlanFresh(req launch.PlanRequest) (launch.AgentPlan, error) {
 	return launch.AgentPlan{
 		Handle: req.Handle, Argv: []string{"/usr/bin/true", req.LaunchNonce}, Cwd: req.Cwd,
-		AdapterMode: launch.AdapterModeMint, ResumePolicy: req.ResumePolicy,
+		AdapterMode: a.Mode(), ResumePolicy: req.ResumePolicy,
 		LaunchNonce: req.LaunchNonce, ConversationID: req.LaunchNonce,
 		DynamicArgv: []launch.DynamicArg{{Index: 1, Kind: launch.DynamicArgLaunchNonce}},
 	}, nil
@@ -237,6 +251,42 @@ func TestLaunchMissingBinaryIsStructuredDisposition(t *testing.T) {
 	}
 	if len(result.Agents) != 1 || result.Agents[0].ConversationDisposition != launch.DispositionUnsupported || result.Agents[0].Reason != "executable_not_found" {
 		t.Fatalf("result=%#v", result)
+	}
+}
+
+func TestLaunchCaptureUnsupportedIsActionRequiredBeforeEmission(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	root := filepath.Join(project, defaultCoopRoot, "collab")
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	cfg := launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: "collab", Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+		Agents: []launch.ProjectAgentConfig{{Handle: "codex", Adapter: launch.CodexProvider, Command: []string{launch.CodexProvider}, ResumePolicy: launch.ResumeEnabled}},
+	}
+	data, err := launch.MarshalProjectConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, setupConfigPath), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	launchAdapters = func(launch.ProjectConfig) map[string]launch.HarnessAdapter {
+		return map[string]launch.HarnessAdapter{launch.CodexProvider: launchFixtureAdapter{
+			name: launch.CodexProvider, mode: launch.AdapterModeCapture, available: true,
+			captureUnsupported: true, reason: "capture_version_unsupported",
+		}}
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error { return runLaunch(nil) })
+	if GetExitCode(err) != ExitActionRequired {
+		t.Fatalf("exit=%d err=%v output=%s", GetExitCode(err), err, stdout)
+	}
+	if !strings.Contains(stdout, "codex: action_required (capture_version_unsupported)") || strings.Contains(stdout, "coop exec") {
+		t.Fatalf("capture refusal output=%q", stdout)
+	}
+	if _, err := os.Stat(launch.ConversationPath(root, "codex")); !os.IsNotExist(err) {
+		t.Fatalf("capture refusal wrote conversation state: %v", err)
 	}
 }
 

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -651,12 +651,26 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			continue
 		}
 		forceFresh := request.Fresh || policy == ResumeFresh || policy == ResumeDisabled
+		freshAllowed := capabilities.Fresh && (adapter.Mode() != AdapterModeCapture || capabilities.Capture)
+		freshReason := capabilities.Reason
+		if freshReason == "" {
+			if !capabilities.Fresh {
+				freshReason = "fresh_capability_unsupported"
+			} else {
+				freshReason = "capture_capability_unsupported"
+			}
+		}
+		resumeReason := capabilities.Reason
+		if resumeReason == "" {
+			resumeReason = "resume_capability_unsupported"
+		}
 		disposition := DispositionFresh
 		if policy == ResumeDisabled {
 			disposition = DispositionDisabled
 		}
 		var agentPlan AgentPlan
 		var err error
+		capabilityRefusal := ""
 		planReason := ""
 		if request.ResumeOnly && !hasConversation {
 			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionActionRequired, ReasonNoSavedConversation
@@ -664,40 +678,71 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			continue
 		} else if request.ResumeOnly {
 			if conversation.State == CaptureReady {
-				agentPlan, err = adapter.PlanResume(ResumeRequest{PlanRequest: base, Conversation: conversation.Identity})
-				if err == nil {
-					disposition = DispositionResumed
+				if !capabilities.Resume {
+					err, capabilityRefusal = errors.New(resumeReason), resumeReason
+				} else {
+					agentPlan, err = adapter.PlanResume(ResumeRequest{PlanRequest: base, Conversation: conversation.Identity})
+					if err == nil {
+						disposition = DispositionResumed
+					}
 				}
 			} else {
 				err = fmt.Errorf("conversation identity is %s", conversation.State)
 			}
 		} else if !forceFresh && hasConversation && conversation.State == CaptureReady {
-			agentPlan, err = adapter.PlanResume(ResumeRequest{PlanRequest: base, Conversation: conversation.Identity})
-			if err == nil {
-				disposition = DispositionResumed
+			if !capabilities.Resume {
+				err, capabilityRefusal = errors.New(resumeReason), resumeReason
+			} else {
+				agentPlan, err = adapter.PlanResume(ResumeRequest{PlanRequest: base, Conversation: conversation.Identity})
+				if err == nil {
+					disposition = DispositionResumed
+				}
 			}
 		} else if !forceFresh && hasConversation && conversation.State == CapturePending && adapter.Mode() == AdapterModeMint {
-			agentPlan, err = adapter.PlanFresh(base)
-			disposition, planReason = DispositionFresh, ReasonPriorLaunchNotExecuted
+			if !freshAllowed {
+				err, capabilityRefusal = errors.New(freshReason), freshReason
+			} else {
+				agentPlan, err = adapter.PlanFresh(base)
+				disposition, planReason = DispositionFresh, ReasonPriorLaunchNotExecuted
+			}
 		} else if !forceFresh && hasConversation {
 			err = fmt.Errorf("conversation identity is %s", conversation.State)
 		}
 		if err != nil && !forceFresh {
 			if !request.AllowFreshFallback {
+				if capabilityRefusal != "" {
+					item.Code, item.ConversationDisposition, item.Reason = 6, DispositionActionRequired, capabilityRefusal
+					result.Agents = append(result.Agents, item)
+					continue
+				}
 				item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, ReasonStaleConversation
 				result.Agents = append(result.Agents, item)
 				continue
 			}
 			base.ResumePolicy = ResumeFresh
-			agentPlan, err = adapter.PlanFresh(base)
-			disposition = DispositionFreshAfterStale
+			if !freshAllowed {
+				err, capabilityRefusal = errors.New(freshReason), freshReason
+			} else {
+				capabilityRefusal = ""
+				agentPlan, err = adapter.PlanFresh(base)
+				disposition = DispositionFreshAfterStale
+			}
 		} else if forceFresh || !hasConversation {
 			if request.Fresh {
 				base.ResumePolicy = ResumeFresh
 			}
-			agentPlan, err = adapter.PlanFresh(base)
+			if !freshAllowed {
+				err, capabilityRefusal = errors.New(freshReason), freshReason
+			} else {
+				agentPlan, err = adapter.PlanFresh(base)
+			}
 		}
 		if err != nil {
+			if capabilityRefusal != "" {
+				item.Code, item.ConversationDisposition, item.Reason = 6, DispositionActionRequired, capabilityRefusal
+				result.Agents = append(result.Agents, item)
+				continue
+			}
 			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
 			result.Agents = append(result.Agents, item)
 			continue

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -12,10 +12,13 @@ import (
 )
 
 type reconcileAdapter struct {
-	name      string
-	mode      AdapterMode
-	available bool
-	reason    string
+	name               string
+	mode               AdapterMode
+	available          bool
+	reason             string
+	freshUnsupported   bool
+	resumeUnsupported  bool
+	captureUnsupported bool
 }
 
 func (a reconcileAdapter) Name() string               { return a.name }
@@ -24,10 +27,90 @@ func (a reconcileAdapter) CommittedEnvKeys() []string { return nil }
 func (a reconcileAdapter) Capabilities(context.Context) AdapterCapabilities {
 	return AdapterCapabilities{
 		Provider: a.name, Mode: a.mode, Available: a.available,
-		ProviderVersion: "test", Fresh: a.available, Resume: a.available,
-		Capture: a.available && a.mode == AdapterModeCapture, Reason: a.reason,
+		ProviderVersion: "test", Fresh: a.available && !a.freshUnsupported,
+		Resume:  a.available && !a.resumeUnsupported,
+		Capture: a.available && a.mode == AdapterModeCapture && !a.captureUnsupported, Reason: a.reason,
 	}
 }
+
+func TestReconcileCaptureFreshRequiresFreshAndCaptureCapabilities(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		adapter    reconcileAdapter
+		wantReason string
+	}{
+		{name: "fresh missing", adapter: reconcileAdapter{freshUnsupported: true}, wantReason: "fresh_capability_unsupported"},
+		{name: "capture missing", adapter: reconcileAdapter{captureUnsupported: true, reason: "capture_version_unsupported"}, wantReason: "capture_version_unsupported"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := reconcileFixture(t, Commands{})
+			req.Config.Agents[0].Adapter = CodexProvider
+			req.Config.Agents[0].Command[0] = CodexProvider
+			test.adapter.name, test.adapter.mode, test.adapter.available = CodexProvider, AdapterModeCapture, true
+			req.Adapters = map[string]HarnessAdapter{CodexProvider: test.adapter}
+			result, err := Reconcile(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.AggregateCode != 6 || result.Outcome != OutcomeActionRequired || len(result.Commands) != 0 || len(result.Agents) != 1 ||
+				result.Agents[0].ConversationDisposition != DispositionActionRequired || result.Agents[0].Reason != test.wantReason {
+				t.Fatalf("unsupported capture result=%#v", result)
+			}
+			if _, err := LoadConversation(req.Root, "claude"); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("unsupported capture wrote conversation state: %v", err)
+			}
+			if _, err := LoadExecutionTicket(req.Root, "claude"); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("unsupported capture wrote execution ticket: %v", err)
+			}
+		})
+	}
+}
+
+func TestReconcileCaptureReadyResumeRequiresResumeAlone(t *testing.T) {
+	req := reconcileFixture(t, Commands{})
+	req.Config.Agents[0].Adapter = CodexProvider
+	req.Config.Agents[0].Command[0] = CodexProvider
+	req.Adapters = map[string]HarnessAdapter{CodexProvider: reconcileAdapter{
+		name: CodexProvider, mode: AdapterModeCapture, available: true,
+		captureUnsupported: true, reason: "capture_version_unsupported",
+	}}
+	writeReconcileConversation(t, req, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity: ConversationIdentity{Provider: CodexProvider, ID: testConversationID}, LaunchNonce: testLaunchNonce,
+		ExecutionEvidence: reconcileExecutionEvidence(&reconcileBackend{name: CommandsBackendName}, testLaunchNonce),
+	})
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Outcome != OutcomeCommandsEmitted || len(result.Commands) != 1 ||
+		result.Agents[0].ConversationDisposition != DispositionResumed || result.Plan == nil || result.Plan.Agents[0].ConversationID != testConversationID {
+		t.Fatalf("resume-only capability result=%#v", result)
+	}
+}
+
+func TestReconcileCaptureReadyRefusesWithoutResumeCapability(t *testing.T) {
+	req := reconcileFixture(t, Commands{})
+	req.Config.Agents[0].Adapter = CodexProvider
+	req.Config.Agents[0].Command[0] = CodexProvider
+	req.Adapters = map[string]HarnessAdapter{CodexProvider: reconcileAdapter{
+		name: CodexProvider, mode: AdapterModeCapture, available: true, resumeUnsupported: true,
+	}}
+	writeReconcileConversation(t, req, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity: ConversationIdentity{Provider: CodexProvider, ID: testConversationID}, LaunchNonce: testLaunchNonce,
+		ExecutionEvidence: reconcileExecutionEvidence(&reconcileBackend{name: CommandsBackendName}, testLaunchNonce),
+	})
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Outcome != OutcomeActionRequired || len(result.Commands) != 0 ||
+		result.Agents[0].ConversationDisposition != DispositionActionRequired || result.Agents[0].Reason != "resume_capability_unsupported" {
+		t.Fatalf("unsupported resume result=%#v", result)
+	}
+}
+
 func (a reconcileAdapter) PlanFresh(req PlanRequest) (AgentPlan, error) {
 	plan := AgentPlan{
 		Handle: req.Handle, Argv: []string{"/usr/bin/true", req.LaunchNonce}, Cwd: req.Cwd,


### PR DESCRIPTION
## Summary
- require both Fresh and Capture before fresh planning for capture-mode adapters
- permit evidence-backed resume when Resume is available, independent of Capture
- surface missing capabilities as action_required before command emission or runtime-state writes

## Verification
- make ci
- exact staged peer review: afd8943293e5448bc0a2d73c9fa5c3098c57b473673f78e7d2cbcec0adb8b97d

Refs: #480 #504