### PR TITLE
feat(cli): add stateless setup preview with digest-gated apply

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -22,24 +22,13 @@ step; it does not define a second setup path.
 
 ### Running Co-op Mode
 
-**Terminal 1 - Claude Code:**
-```bash
-amq coop exec claude -- --dangerously-skip-permissions
-```
+Paste each complete command emitted by `amq launch` into its own terminal. The
+emitted lines are the canonical execution surface: they include the exact
+session, launch nonce, execution ticket, and provider command declared in
+`.amq/launch.json`. Do not shorten or rebuild them from an example.
 
-**Terminal 2 - Codex CLI:**
-```bash
-amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
-```
-
-**Terminal 3 - Grok CLI (optional third peer):**
-```bash
-amq coop exec grok
-```
-
-Grok is a normal handle like any other — `coop exec` forwards caller flags to
-it unchanged (no baked-in permission bypass, unlike the Codex example above).
-Include Grok in the roster during `amq setup` when it should join the session.
+Include Grok in the setup roster when it should join the session. AMQ starts
+only adapters that pass their capability probe.
 
 To disable auto-wake (e.g., in CI or non-TTY environments):
 ```bash
@@ -55,6 +44,16 @@ creates `.amqrc` and `.agent-mail` at the worktree top; `--no-init` makes that
 condition an error instead. Without `--session` or `--root`, it uses the
 declared `default_session` from `.amq/launch.json`, or `collab` when none is
 declared.
+
+For a deliberate direct launch, provider flags follow `--`. Dangerous bypass
+flags are operator-controlled here and are rejected from committed
+`.amq/launch.json` arguments:
+
+```bash
+amq coop exec claude -- --dangerously-skip-permissions
+amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
+amq coop exec grok
+```
 
 Creating a missing named session, explicit root, or declared default session
 still works in this release and prints one deprecation warning. Use
@@ -72,15 +71,13 @@ commands in separate terminals:
 # Pair A: auth feature
 amq session create auth
 amq launch --session auth
-amq coop exec --session auth claude               # Terminal 1
-amq coop exec --session auth codex                # Terminal 2
 
 # Pair B: api refactor
 amq session create api
 amq launch --session api
-amq coop exec --session api claude                # Terminal 3
-amq coop exec --session api codex                 # Terminal 4
 ```
+
+Paste the commands emitted by each `launch` into separate terminals.
 
 Each pair has isolated inboxes and threads. Messages stay within their root.
 Equivalent explicit root form: `--root .agent-mail/<session>`.

--- a/README.md
+++ b/README.md
@@ -105,8 +105,52 @@ amq setup
 
 Detects supported agent CLIs and launcher preferences, previews the project
 declaration, then creates `.amqrc`, `.amq/launch.json`, local preferences,
-the default session, and roster mailboxes. Use `amq setup -y` only after an
-automation caller has accepted that preview.
+the default session, and roster mailboxes.
+
+Automation uses a stateless preview and applies only that approved digest. The
+first non-interactive setup must name the roster, default session, and launcher
+preference explicitly:
+
+```bash
+setup_args=(--agents claude,codex --default-session collab --launcher-preference commands)
+setup_preview="$(amq setup --preview --json "${setup_args[@]}")"
+setup_digest="$(printf '%s\n' "$setup_preview" | jq -r '.preview.digest')"
+amq setup --apply "$setup_digest" "${setup_args[@]}"
+```
+
+`--preview` performs zero writes. `--apply` recomputes the preview and exits `6`
+without writing if its `sha256:<hex>` digest differs. `-y` remains available
+for callers that already own an approval gate, but it cannot be combined with
+`--preview` or `--apply`.
+
+Provider arguments belong in the committed `.amq/launch.json`, so `launch`
+can validate and include them in its semantic trust digest. For example:
+
+```json
+{
+  "schema": 1,
+  "default_session": "collab",
+  "agents": [
+    {
+      "handle": "claude",
+      "adapter": "claude",
+      "command": ["claude", "--permission-mode", "acceptEdits"],
+      "resume_policy": "enabled"
+    },
+    {
+      "handle": "codex",
+      "adapter": "codex",
+      "command": ["codex", "--sandbox", "workspace-write", "--ask-for-approval", "on-request"],
+      "resume_policy": "enabled"
+    }
+  ],
+  "layout": {"type": "columns"}
+}
+```
+
+Dangerous permission-bypass flags are not valid committed arguments. Keep them
+in an operator-controlled direct `coop exec` invocation when that low-level
+path is intentionally required.
 
 ### 2. Launch or Resume a Session
 
@@ -127,16 +171,10 @@ exit `6` until that digest is trusted. An unknown `session resume` name exits
 see [Managed launch recovery](docs/launch-recovery.md).
 
 The `commands` backend prints complete `coop exec` commands and exits `6`
-because executing them is the remaining operator action. Run the emitted
-commands in separate terminals:
-
-```bash
-# Terminal 1 — Claude Code
-amq coop exec claude
-
-# Terminal 2 — Codex CLI
-amq coop exec codex
-```
+because executing them is the remaining operator action. Paste those emitted
+lines exactly, one per terminal. Do not reconstruct them from examples: they
+bind the selected session, launch nonce, provider arguments, and execution
+ticket.
 
 Each command sets up the session environment, starts wake notifications, and
 launches the agent. See [COOP.md](COOP.md#running-co-op-mode) for co-op
@@ -153,18 +191,9 @@ For isolated sessions (multiple pairs working on different features):
 ```bash
 amq session create feature-a
 amq launch --session feature-a
-
-# Run the emitted commands in separate terminals.
-amq coop exec --session feature-a claude
-amq coop exec --session feature-a codex
-amq coop exec --session feature-a grok     # Optional third peer
 ```
 
-Pass agent flags after `--`:
-```bash
-amq coop exec claude -- --dangerously-skip-permissions
-amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
-```
+Again, paste the complete commands emitted by `launch` into separate terminals.
 
 Optional aliases are a convenience, not part of the canonical quickstart.
 A bare `eval "$(amq shell-setup)"` affects only the current shell. To make
@@ -183,9 +212,10 @@ Run the appropriate append command once, then open a new terminal or source
 that startup file. Use the bare `eval` only when you intentionally want aliases
 in one already-open shell.
 
-`coop init` and direct `coop exec` provisioning remain available as low-level
-plumbing. See [COOP.md](COOP.md#low-level-provisioning) for those paths and
-advanced wake options; they are not a second project-onboarding flow.
+`coop init` and direct `coop exec` provisioning remain available as legacy
+low-level plumbing. See [COOP.md](COOP.md#low-level-provisioning) for those
+paths, operator-only bypass examples, and advanced wake options; they are not a
+second project-onboarding flow.
 
 ### 3. Send & Receive
 

--- a/internal/cli/launch_conformance_test.go
+++ b/internal/cli/launch_conformance_test.go
@@ -97,7 +97,10 @@ func TestWaveACloseEvidenceSetupLaunchResume(t *testing.T) {
 	project := setupProjectFixture(t, "claude")
 	clearPinnedSessionEnv(t)
 	setupOut, err := captureEnvStdout(t, func() error {
-		return runSetup([]string{"-y", "--agents", "claude", "--no-gitignore", "--json"})
+		return runSetup([]string{
+			"-y", "--agents", "claude", "--default-session", "collab",
+			"--launcher-preference", "commands", "--no-gitignore", "--json",
+		})
 	})
 	if err != nil {
 		t.Fatalf("setup -y: %v\n%s", err, setupOut)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -34,6 +35,7 @@ type setupChange struct {
 }
 
 type setupPreview struct {
+	Digest             string                      `json:"digest"`
 	ProjectRoot        string                      `json:"project_root"`
 	QueueRoot          string                      `json:"queue_root"`
 	DefaultSession     string                      `json:"default_session"`
@@ -102,6 +104,8 @@ func runSetup(args []string) (returnErr error) {
 	launchersFlag := fs.String("launcher-preference", "", "Comma-separated launcher preference")
 	layoutFlag := fs.String("layout", launch.LayoutColumns, "Advisory layout intent")
 	noGitignoreFlag := fs.Bool("no-gitignore", false, "Do not modify .gitignore")
+	previewFlag := fs.Bool("preview", false, "Preview changes without writing")
+	applyFlag := fs.String("apply", "", "Apply only when the recomputed preview matches this digest")
 	yesFlag := fs.Bool("y", false, "Accept the preview without prompting")
 	jsonFlag := fs.Bool("json", false, "Emit JSON output")
 	usage := usageWithFlags(fs, "amq setup [options]",
@@ -113,10 +117,24 @@ func runSetup(args []string) (returnErr error) {
 	} else if handled {
 		return nil
 	}
-	if *jsonFlag && !*yesFlag {
-		return UsageError("--json requires -y")
+	applyExplicit := flagWasVisited(fs, "apply")
+	if *previewFlag && *yesFlag {
+		return UsageError("--preview and -y are mutually exclusive")
 	}
-	if !*yesFlag && !setupIsTerminal() {
+	if *previewFlag && applyExplicit {
+		return UsageError("--preview and --apply are mutually exclusive")
+	}
+	if applyExplicit && *yesFlag {
+		return UsageError("--apply and -y are mutually exclusive")
+	}
+	if applyExplicit && !validSetupDigest(*applyFlag) {
+		return UsageError("--apply requires a sha256:<hex> digest")
+	}
+	nonInteractive := *previewFlag || applyExplicit || *yesFlag
+	if *jsonFlag && !nonInteractive {
+		return UsageError("--json requires --preview, --apply, or -y")
+	}
+	if !nonInteractive && !setupIsTerminal() {
 		return UsageError("non-interactive setup requires -y")
 	}
 	if *layoutFlag != launch.LayoutColumns {
@@ -147,7 +165,7 @@ func runSetup(args []string) (returnErr error) {
 	}
 
 	var input *bufio.Reader
-	if !*yesFlag {
+	if !nonInteractive {
 		input = bufio.NewReader(os.Stdin)
 	}
 	state, err := buildSetupState(setupOptions{
@@ -156,18 +174,30 @@ func runSetup(args []string) (returnErr error) {
 		agents: *agentsFlag, agentsExplicit: flagWasVisited(fs, "agents"),
 		defaultSession: *sessionFlag, sessionExplicit: flagWasVisited(fs, "default-session"),
 		launchers: *launchersFlag, launchersExplicit: flagWasVisited(fs, "launcher-preference"),
-		layout: *layoutFlag, noGitignore: *noGitignoreFlag, yes: *yesFlag, input: input,
+		layout: *layoutFlag, noGitignore: *noGitignoreFlag, nonInteractive: nonInteractive, input: input,
 	})
 	if err != nil {
 		return err
 	}
-	preview := state.preview()
+	preview, err := state.preview()
+	if err != nil {
+		return err
+	}
 	if !*jsonFlag {
 		if err := printSetupPreview(preview); err != nil {
 			return err
 		}
 	}
-	if !*yesFlag {
+	if *previewFlag {
+		if *jsonFlag {
+			return writeJSON(os.Stdout, setupResult{Status: "preview", Preview: preview, Written: []string{}})
+		}
+		return nil
+	}
+	if applyExplicit && *applyFlag != preview.Digest {
+		return ActionRequiredError("setup approval digest mismatch: approved %s, recomputed %s", *applyFlag, preview.Digest)
+	}
+	if !nonInteractive {
 		confirmed, err := setupConfirm(input, "Create this setup?")
 		if err != nil {
 			return err
@@ -200,7 +230,7 @@ type setupOptions struct {
 	launchers, layout                  string
 	rootExplicit, agentsExplicit       bool
 	sessionExplicit, launchersExplicit bool
-	noGitignore, yes                   bool
+	noGitignore, nonInteractive        bool
 	input                              *bufio.Reader
 }
 
@@ -215,6 +245,10 @@ func buildSetupState(options setupOptions) (setupState, error) {
 	existingLocal, existingLocalData, localExists, err := loadOptionalLocalConfig(setupLocalConfigPath)
 	if err != nil {
 		return setupState{}, err
+	}
+	if !projectExists && options.nonInteractive &&
+		(!options.agentsExplicit || !options.sessionExplicit || !options.launchersExplicit) {
+		return setupState{}, UsageError("first non-interactive setup requires explicit --agents, --default-session, and --launcher-preference")
 	}
 
 	root, amqrcData, amqrcExists, err := setupRoot(options.root, options.rootExplicit, options.projectRoot)
@@ -331,8 +365,8 @@ func (state *setupState) addChange(condition bool, path, action string) {
 	}
 }
 
-func (state setupState) preview() setupPreview {
-	return setupPreview{
+func (state setupState) preview() (setupPreview, error) {
+	preview := setupPreview{
 		ProjectRoot: state.projectRoot, QueueRoot: state.queueRoot,
 		DefaultSession:     state.projectConfig.DefaultSession,
 		Agents:             append([]launch.ProjectAgentConfig(nil), state.projectConfig.Agents...),
@@ -341,6 +375,46 @@ func (state setupState) preview() setupPreview {
 		AvailableLaunchers: append([]string(nil), state.available...),
 		Changes:            append(make([]setupChange, 0, len(state.changes)), state.changes...),
 	}
+	digest, err := setupPreviewDigest(preview)
+	if err != nil {
+		return setupPreview{}, err
+	}
+	preview.Digest = digest
+	return preview, nil
+}
+
+func setupPreviewDigest(preview setupPreview) (string, error) {
+	canonical, err := json.Marshal(struct {
+		Version            int                         `json:"version"`
+		ProjectRoot        string                      `json:"project_root"`
+		QueueRoot          string                      `json:"queue_root"`
+		DefaultSession     string                      `json:"default_session"`
+		Agents             []launch.ProjectAgentConfig `json:"agents"`
+		Layout             launch.LayoutIntent         `json:"layout"`
+		LauncherPreference []string                    `json:"launcher_preference"`
+		Changes            []setupChange               `json:"changes"`
+	}{
+		Version: 1, ProjectRoot: preview.ProjectRoot, QueueRoot: preview.QueueRoot,
+		DefaultSession: preview.DefaultSession, Agents: preview.Agents, Layout: preview.Layout,
+		LauncherPreference: preview.LauncherPreference, Changes: preview.Changes,
+	})
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return fmt.Sprintf("sha256:%x", sum), nil
+}
+
+func validSetupDigest(value string) bool {
+	if !strings.HasPrefix(value, "sha256:") || len(value) != len("sha256:")+sha256.Size*2 {
+		return false
+	}
+	for _, char := range strings.TrimPrefix(value, "sha256:") {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func printSetupPreview(preview setupPreview) error {
@@ -360,14 +434,17 @@ func printSetupPreview(preview setupPreview) error {
 		return err
 	}
 	if len(preview.Changes) == 0 {
-		return writeStdoutLine("  (none)")
-	}
-	for _, change := range preview.Changes {
-		if err := writeStdout("  - %s: %s\n", change.Path, change.Action); err != nil {
+		if err := writeStdoutLine("  (none)"); err != nil {
 			return err
 		}
+	} else {
+		for _, change := range preview.Changes {
+			if err := writeStdout("  - %s: %s\n", change.Path, change.Action); err != nil {
+				return err
+			}
+		}
 	}
-	return nil
+	return writeStdout("\nApproval digest: %s\n", preview.Digest)
 }
 
 func detectSetupAgents(adapters []launch.HarnessAdapter) ([]launch.AdapterCapabilities, error) {
@@ -436,9 +513,9 @@ func chooseSetupAgents(options setupOptions, detected []launch.AdapterCapabiliti
 		if err != nil {
 			return nil, err
 		}
-	case exists && options.yes:
+	case exists && options.nonInteractive:
 		return append([]launch.ProjectAgentConfig(nil), existing.Agents...), nil
-	case options.yes:
+	case options.nonInteractive:
 		selected = names
 	default:
 		if len(names) == 0 {
@@ -484,7 +561,7 @@ func chooseSetupSession(options setupOptions, existing launch.ProjectConfig, exi
 	}
 	if options.sessionExplicit {
 		value = strings.TrimSpace(options.defaultSession)
-	} else if !options.yes {
+	} else if !options.nonInteractive {
 		line, err := setupPromptLine(options.input, "Default session", value)
 		if err != nil {
 			return "", err
@@ -505,7 +582,7 @@ func chooseSetupLaunchers(options setupOptions, detected []string, existing laun
 	var raw string
 	if options.launchersExplicit {
 		raw = options.launchers
-	} else if !options.yes {
+	} else if !options.nonInteractive {
 		line, err := setupPromptLine(options.input, "Launcher preference (comma-separated)", strings.Join(preference, ","))
 		if err != nil {
 			return nil, err

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -65,7 +65,7 @@ func TestSetupWritesAuthoritativeAndPreferenceScopesThenNoOps(t *testing.T) {
 	t.Cleanup(func() { setupLookPath = execLookPathForSetup })
 
 	if _, err := captureEnvStdout(t, func() error {
-		return runSetup([]string{"-y", "--agents", "claude,codex,grok", "--default-session", "work", "--json"})
+		return runSetup([]string{"-y", "--agents", "claude,codex,grok", "--default-session", "work", "--launcher-preference", "tmux", "--json"})
 	}); err != nil {
 		t.Fatalf("first setup: %v", err)
 	}
@@ -133,6 +133,100 @@ func TestSetupWritesAuthoritativeAndPreferenceScopesThenNoOps(t *testing.T) {
 	}
 }
 
+func TestSetupPreviewDigestBindsApplyWithoutWrites(t *testing.T) {
+	project := setupProjectFixture(t, "claude", "codex")
+	args := []string{
+		"--agents", "claude,codex", "--default-session", "collab",
+		"--launcher-preference", "commands",
+	}
+	before := setupTreeDigest(t, project)
+	steps := 0
+	setupCommitStepHook = func(string) error { steps++; return nil }
+
+	previewOutput, err := captureEnvStdout(t, func() error {
+		return runSetup(append([]string{"--preview", "--json"}, args...))
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var previewResult setupResult
+	if err := json.Unmarshal([]byte(previewOutput), &previewResult); err != nil {
+		t.Fatal(err)
+	}
+	if previewResult.Status != "preview" || !validSetupDigest(previewResult.Preview.Digest) || len(previewResult.Written) != 0 {
+		t.Fatalf("preview result=%#v", previewResult)
+	}
+	if steps != 0 || before != setupTreeDigest(t, project) {
+		t.Fatalf("preview steps=%d changed=%t", steps, before != setupTreeDigest(t, project))
+	}
+
+	textOutput, err := captureEnvStdout(t, func() error {
+		return runSetup(append([]string{"--preview"}, args...))
+	})
+	if err != nil || !strings.Contains(textOutput, "Approval digest: "+previewResult.Preview.Digest) {
+		t.Fatalf("text preview output=%q err=%v", textOutput, err)
+	}
+	if steps != 0 || before != setupTreeDigest(t, project) {
+		t.Fatalf("text preview steps=%d changed=%t", steps, before != setupTreeDigest(t, project))
+	}
+
+	mismatchArgs := append([]string{"--apply", previewResult.Preview.Digest}, args...)
+	for i, value := range mismatchArgs {
+		if value == "collab" {
+			mismatchArgs[i] = "other"
+			break
+		}
+	}
+	_, err = captureEnvStdout(t, func() error { return runSetup(mismatchArgs) })
+	if GetExitCode(err) != ExitActionRequired || steps != 0 || before != setupTreeDigest(t, project) {
+		t.Fatalf("mismatch exit=%d err=%v steps=%d changed=%t", GetExitCode(err), err, steps, before != setupTreeDigest(t, project))
+	}
+
+	applyOutput, err := captureEnvStdout(t, func() error {
+		return runSetup(append([]string{"--apply", previewResult.Preview.Digest}, args...))
+	})
+	if err != nil {
+		t.Fatalf("apply: %v\n%s", err, applyOutput)
+	}
+	if !strings.Contains(applyOutput, "Setup committed") || steps == 0 {
+		t.Fatalf("apply output=%q steps=%d", applyOutput, steps)
+	}
+	assertCompleteSetup(t, project, "claude", "codex")
+}
+
+func TestSetupPreviewAndApplyAcceptanceModesAreExclusive(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	digest := "sha256:" + strings.Repeat("0", 64)
+	for _, args := range [][]string{
+		{"--preview", "-y"},
+		{"--apply", digest, "-y"},
+		{"--preview", "--apply", digest},
+		{"--apply", "not-a-digest"},
+	} {
+		if err := runSetup(args); GetExitCode(err) != ExitUsage {
+			t.Fatalf("args=%v exit=%d err=%v", args, GetExitCode(err), err)
+		}
+	}
+	if entries, err := os.ReadDir(project); err != nil || len(entries) != 0 {
+		t.Fatalf("usage refusals wrote project entries=%v err=%v", entries, err)
+	}
+}
+
+func TestSetupFirstNonInteractiveRunRequiresExplicitSemanticInputs(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	before := setupTreeDigest(t, project)
+	_, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"--preview", "--json", "--agents", "claude"})
+	})
+	if GetExitCode(err) != ExitUsage || !strings.Contains(err.Error(), "--default-session") ||
+		!strings.Contains(err.Error(), "--launcher-preference") {
+		t.Fatalf("explicit-input refusal exit=%d err=%v", GetExitCode(err), err)
+	}
+	if before != setupTreeDigest(t, project) {
+		t.Fatal("explicit-input refusal changed project")
+	}
+}
+
 func TestSetupInterruptionPrefixesConverge(t *testing.T) {
 	steps := []string{"provision", "roster_compatible", "project_config", "local_config", "gitignore", "amqrc"}
 	for _, stop := range steps {
@@ -145,13 +239,17 @@ func TestSetupInterruptionPrefixesConverge(t *testing.T) {
 				}
 				return nil
 			}
-			_, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--agents", "claude"}) })
+			_, err := captureEnvStdout(t, func() error {
+				return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands"})
+			})
 			if !errors.Is(err, injected) {
 				t.Fatalf("interrupted setup error = %v", err)
 			}
 			assertSetupPrefixValid(t, project)
 			setupCommitStepHook = nil
-			if _, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--agents", "claude"}) }); err != nil {
+			if _, err := captureEnvStdout(t, func() error {
+				return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands"})
+			}); err != nil {
 				t.Fatalf("recovery rerun: %v", err)
 			}
 			assertCompleteSetup(t, project, "claude")
@@ -221,7 +319,7 @@ func TestSetupRefusesAdapterHostileCommittedConfigWithoutWrites(t *testing.T) {
 				}}
 			}
 			if _, err := captureEnvStdout(t, func() error {
-				return runSetup([]string{"-y", "--agents", "claude"})
+				return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands"})
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -266,7 +364,7 @@ func TestSetupPreservesExternallyEditedValidConfigAsZeroWrite(t *testing.T) {
 		}}
 	}
 	if _, err := captureEnvStdout(t, func() error {
-		return runSetup([]string{"-y", "--agents", "claude"})
+		return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands"})
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -306,7 +404,9 @@ func TestSetupRefusesLegacyDefaultSessionAuthorityInAmqrc(t *testing.T) {
 		t.Fatal(err)
 	}
 	resetAmqrcCache()
-	_, err := captureEnvStdout(t, func() error { return runSetup([]string{"-y", "--agents", "claude"}) })
+	_, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands"})
+	})
 	var conflict *launch.ConfigAuthorityConflictError
 	if !errors.As(err, &conflict) || conflict.Path != ".amqrc" || conflict.Field != "default_session" {
 		t.Fatalf("legacy authority error = %T %v", err, err)
@@ -321,7 +421,7 @@ func TestSetupRosterReplacementFinalizationRecovers(t *testing.T) {
 		t.Run(stop, func(t *testing.T) {
 			project := setupProjectFixture(t, "claude", "codex", "grok")
 			if _, err := captureEnvStdout(t, func() error {
-				return runSetup([]string{"-y", "--agents", "claude,codex"})
+				return runSetup([]string{"-y", "--agents", "claude,codex", "--default-session", "collab", "--launcher-preference", "commands"})
 			}); err != nil {
 				t.Fatal(err)
 			}
@@ -385,7 +485,7 @@ func TestSetupInteractiveAbortWritesNothing(t *testing.T) {
 func TestSetupInteractiveRerunCanChangeRosterAndSession(t *testing.T) {
 	project := setupProjectFixture(t, "claude", "codex")
 	if _, err := captureEnvStdout(t, func() error {
-		return runSetup([]string{"-y", "--agents", "claude,codex"})
+		return runSetup([]string{"-y", "--agents", "claude,codex", "--default-session", "collab", "--launcher-preference", "commands"})
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +518,7 @@ func TestSetupNoGitignorePreservesExistingBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := captureEnvStdout(t, func() error {
-		return runSetup([]string{"-y", "--agents", "claude", "--no-gitignore"})
+		return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands", "--no-gitignore"})
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -151,9 +151,14 @@ is the canonical human onboarding path. The commands below keep the agent
 workflow self-contained.
 
 ```bash
-# One-time project setup (preview, then write .amqrc, .amq/launch.json, default session)
+# Interactive one-time project setup
 amq setup
-amq setup -y   # automation only, after the caller accepted that preview
+
+# Non-interactive setup: re-pass the same explicit inputs on preview and apply
+setup_args=(--agents claude,codex --default-session collab --launcher-preference commands)
+setup_preview="$(amq setup --preview --json "${setup_args[@]}")"
+setup_digest="$(printf '%s\n' "$setup_preview" | jq -r '.preview.digest')"
+amq setup --apply "$setup_digest" "${setup_args[@]}"
 
 # Daily entry: reconcile the declared session (never creates an unknown name)
 amq launch
@@ -162,22 +167,35 @@ amq launch --session feature-x
 amq session resume feature-x
 ```
 
-The first semantic plan, and each plan change, needs an interactive trust
+`setup --preview` performs zero writes. On a fresh non-interactive setup,
+`--agents`, `--default-session`, and `--launcher-preference` are required.
+`--apply` recomputes the preview and exits `6` without writes unless the
+approved `sha256:<hex>` digest matches. It is mutually exclusive with `-y`;
+`--preview` is also mutually exclusive with `-y`.
+
+Put provider flags in the committed `.amq/launch.json` `command` arrays. The
+launcher validates them and includes them in the semantic trust digest. The
+first semantic plan, and each plan change, needs an interactive trust
 confirmation stored outside the worktree. Non-interactive or `--json` calls
 exit `6` until that digest is trusted. An unknown `session resume` name exits
 `3` and writes nothing. The `commands` backend prints complete `coop exec`
-commands and exits `6` because running them is the remaining operator action:
-
-```bash
-# Then run the emitted commands, one terminal each
-amq coop exec claude -- --dangerously-skip-permissions
-amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
-amq coop exec grok  # optional peer — caller flags forwarded unchanged
-```
+commands and exits `6` because running them is the remaining operator action.
+Paste the emitted lines exactly, one per terminal; do not reconstruct them from
+generic `coop exec` examples.
 
 Without `--session` or `--root`, `coop exec` uses the declared `default_session` from `.amq/launch.json`, or `collab` when none is declared. Creating a missing session or root from `coop exec` is deprecated and prints `warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
 
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
+
+Direct `coop exec` is legacy low-level plumbing. When an operator deliberately
+uses it, provider flags follow `--`; dangerous bypass flags belong only on this
+operator-controlled path and are rejected from committed launch arguments:
+
+```bash
+amq coop exec claude -- --dangerously-skip-permissions
+amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
+amq coop exec grok
+```
 
 ### Standalone wake interrupt safety
 


### PR DESCRIPTION
## Summary
- add zero-write setup preview with a stable sha256 approval digest
- add stateless digest-gated apply and fail closed on option or state drift
- require explicit roster, session, and launcher inputs for the first non-interactive setup
- make launch output the canonical copy-paste path and move provider flags into launch.json

This completes the last blocking onboarding item tracked by #504.

## Verification
- make ci
- real-binary fresh-repository preview and digest-gated apply
- exact staged peer review: 84052cb0cf3cea785fcc2a3d95d68622a78cb029f7f57a91d5a2ebab4c2a504f

Refs: #480 #504