### PR TITLE
feat(launch): add managed tmux backend with journal-backed recovery

### DIFF
--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -25,10 +25,18 @@ var (
 	launchIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 	launchInput      = func() *bufio.Reader { return bufio.NewReader(os.Stdin) }
 	launchStateDir   = defaultLaunchStateDir
-	launchAMQPath    = func() string { return "amq" }
-	launchAdapters   = defaultLaunchAdapters
-	launchBackends   = func() map[string]launch.Backend {
-		return map[string]launch.Backend{launch.LauncherCommands: launch.Commands{}}
+	launchAMQPath    = func() string {
+		if path, err := os.Executable(); err == nil {
+			return path
+		}
+		return "amq"
+	}
+	launchAdapters = defaultLaunchAdapters
+	launchBackends = func() map[string]launch.Backend {
+		return map[string]launch.Backend{
+			launch.LauncherCommands: launch.Commands{},
+			launch.LauncherTMux:     launch.NewTmuxBackend("tmux"),
+		}
 	}
 	launchHostname = os.Hostname
 )

--- a/internal/cli/launch_conformance_test.go
+++ b/internal/cli/launch_conformance_test.go
@@ -145,7 +145,7 @@ func overlayLaunchEngine(t *testing.T) {
 	state := t.TempDir()
 	launchIsTerminal = func() bool { return false }
 	launchStateDir = func() (string, error) { return state, nil }
-	launchAMQPath = func() string { return "amq" }
+	launchAMQPath = func() string { path, _ := os.Executable(); return path }
 	launchAdapters = func(launch.ProjectConfig) map[string]launch.HarnessAdapter {
 		return map[string]launch.HarnessAdapter{"claude": launchFixtureAdapter{available: true}}
 	}
@@ -157,7 +157,7 @@ func overlayLaunchEngine(t *testing.T) {
 		launchIsTerminal = func() bool { return false }
 		launchInput = func() *bufio.Reader { return bufio.NewReader(os.Stdin) }
 		launchStateDir = defaultLaunchStateDir
-		launchAMQPath = func() string { return "amq" }
+		launchAMQPath = func() string { path, _ := os.Executable(); return path }
 		launchAdapters = defaultLaunchAdapters
 		launchBackends = func() map[string]launch.Backend {
 			return map[string]launch.Backend{launch.LauncherCommands: launch.Commands{}}

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -126,7 +126,7 @@ func launchCLIFixture(t *testing.T, sessions ...string) (string, string) {
 	state := t.TempDir()
 	launchIsTerminal = func() bool { return false }
 	launchStateDir = func() (string, error) { return state, nil }
-	launchAMQPath = func() string { return "amq" }
+	launchAMQPath = func() string { path, _ := os.Executable(); return path }
 	launchAdapters = func(launch.ProjectConfig) map[string]launch.HarnessAdapter {
 		return map[string]launch.HarnessAdapter{"claude": launchFixtureAdapter{available: true}}
 	}
@@ -139,7 +139,7 @@ func launchCLIFixture(t *testing.T, sessions ...string) (string, string) {
 		launchIsTerminal = func() bool { return false }
 		launchInput = func() *bufio.Reader { return bufio.NewReader(os.Stdin) }
 		launchStateDir = defaultLaunchStateDir
-		launchAMQPath = func() string { return "amq" }
+		launchAMQPath = func() string { path, _ := os.Executable(); return path }
 		launchAdapters = defaultLaunchAdapters
 		launchBackends = func() map[string]launch.Backend {
 			return map[string]launch.Backend{launch.LauncherCommands: launch.Commands{}}

--- a/internal/cli/launch_tmux_e2e_test.go
+++ b/internal/cli/launch_tmux_e2e_test.go
@@ -1,0 +1,224 @@
+//go:build !windows
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestTmuxRealBinaryFreshServerRestartResumeLoop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the real amq binary")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	repo, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	amqBinary := filepath.Join(binDir, "amq")
+	build := exec.Command("go", "build", "-o", amqBinary, "./cmd/amq")
+	build.Dir = repo
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build real amq: %v\n%s", err, output)
+	}
+
+	project := t.TempDir()
+	canonicalProject, err := filepath.EvalSymlinks(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerLog := filepath.Join(t.TempDir(), "provider.log")
+	provider := filepath.Join(binDir, "claude")
+	providerScript := fmt.Sprintf(`#!/bin/sh
+case "$1" in
+  --version) echo "1.0.0 (Claude Code)"; exit 0 ;;
+  --help) echo "--session-id <uuid> --resume [value]"; exit 0 ;;
+esac
+printf '%%s\n' "$*" >> %s
+exec /bin/sleep 60
+`, shellQuoteArg(providerLog))
+	if err := os.WriteFile(provider, []byte(providerScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), []byte(`{"root":".agent-mail"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(project, ".amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	projectConfig := launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: "collab", Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+		Agents: []launch.ProjectAgentConfig{{
+			Handle: "claude", Adapter: launch.ClaudeProvider, Command: []string{launch.ClaudeProvider}, ResumePolicy: launch.ResumeEnabled,
+		}},
+	}
+	projectData, err := launch.MarshalProjectConfig(projectConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, setupConfigPath), projectData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	localData, err := launch.MarshalLocalConfig(launch.LocalConfig{
+		Schema: launch.LocalConfigSchema, LauncherPreference: []string{launch.LauncherTMux, launch.LauncherCommands},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, setupLocalConfigPath), localData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	baseRoot := filepath.Join(project, defaultCoopRoot)
+	sessionRoot := filepath.Join(baseRoot, "collab")
+	for _, rootPath := range []string{baseRoot, sessionRoot} {
+		if err := fsq.EnsureRootDirs(rootPath); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(rootPath, "meta", "config.json"), []byte(`{"version":1,"agents":["claude"]}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fsq.EnsureAgentDirs(sessionRoot, "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := fsq.SnapshotDeliveryRoot(sessionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(sessionRoot, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	xdgState := t.TempDir()
+	store, err := launch.OpenTrustStore(filepath.Join(xdgState, "amq"), project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := launch.NewClaudeAdapter(launch.ClaudeProvider)
+	freshPlan, err := adapter.PlanFresh(launch.PlanRequest{
+		Handle: "claude", ProjectRoot: canonicalProject, Cwd: canonicalProject,
+		LaunchNonce: "019c5a10-75d8-7eef-8db7-5ee77f70e8a1", ResumePolicy: launch.ResumeEnabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustPlan(t, store, launch.Plan{Version: launch.PlanVersion, Agents: []launch.AgentPlan{freshPlan}}, root)
+
+	socketDir, err := os.MkdirTemp("/tmp", "amq-tmux-e2e-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	env := append(os.Environ(),
+		"HOME="+t.TempDir(), "XDG_STATE_HOME="+xdgState, "TMUX_TMPDIR="+socketDir,
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	t.Cleanup(func() { killHermeticTmuxServer(socketDir) })
+	firstOutput := runRealAMQ(t, amqBinary, project, env, "launch", "--launcher", "tmux", "--json")
+	var first launch.ReconcileResult
+	if err := json.Unmarshal(firstOutput, &first); err != nil || first.AggregateCode != 0 || first.Outcome != launch.OutcomeCreated {
+		t.Fatalf("fresh launch = %s, decode=%v", firstOutput, err)
+	}
+	waitForProviderLog(t, providerLog, "--session-id ")
+	firstTicket, err := launch.LoadExecutionTicket(root, "claude")
+	if err != nil || firstTicket.State != launch.ExecutionAcknowledged {
+		t.Fatalf("fresh execution ticket = %#v, %v", firstTicket, err)
+	}
+	recordData, err := os.ReadFile(launch.ConversationPath(sessionRoot, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record launch.ConversationRecord
+	if err := json.Unmarshal(recordData, &record); err != nil || record.State != launch.CaptureReady || record.Identity.ID == "" {
+		t.Fatalf("fresh conversation = %s, decode=%v", recordData, err)
+	}
+
+	killHermeticTmuxServer(socketDir)
+	resumePlan, err := adapter.PlanResume(launch.ResumeRequest{
+		PlanRequest: launch.PlanRequest{
+			Handle: "claude", ProjectRoot: canonicalProject, Cwd: canonicalProject,
+			LaunchNonce: "019c5a10-75d8-7eef-8db7-5ee77f70e8a2", ResumePolicy: launch.ResumeEnabled,
+		},
+		Conversation: record.Identity,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustPlan(t, store, launch.Plan{Version: launch.PlanVersion, Agents: []launch.AgentPlan{resumePlan}}, root)
+	secondOutput := runRealAMQ(t, amqBinary, project, env, "session", "resume", "collab", "--launcher", "tmux", "--json")
+	var second launch.ReconcileResult
+	if err := json.Unmarshal(secondOutput, &second); err != nil || second.AggregateCode != 0 || second.Outcome != launch.OutcomeCreated ||
+		len(second.Agents) != 1 || second.Agents[0].ConversationDisposition != launch.DispositionResumed {
+		t.Fatalf("resume launch = %s, decode=%v", secondOutput, err)
+	}
+	waitForProviderLog(t, providerLog, "--resume "+record.Identity.ID)
+	secondTicket, err := launch.LoadExecutionTicket(root, "claude")
+	if err != nil || secondTicket.State != launch.ExecutionAcknowledged {
+		t.Fatalf("resume execution ticket = %#v, %v", secondTicket, err)
+	}
+	logData, err := os.ReadFile(providerLog)
+	if err != nil || !strings.Contains(string(logData), "--session-id "+record.Identity.ID) || !strings.Contains(string(logData), "--resume "+record.Identity.ID) {
+		t.Fatalf("provider log = %q, err=%v", logData, err)
+	}
+}
+
+func trustPlan(t *testing.T, store *launch.TrustStore, plan launch.Plan, root *fsq.DeliveryRoot) {
+	t.Helper()
+	digest, err := launch.ExecutionTrustDigest(plan, "collab", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Replace(launch.TrustRecord{SemanticDigest: digest}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runRealAMQ(t *testing.T, binary, project string, env []string, args ...string) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir, cmd.Env = project, env
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("real amq %v: %v\n%s", args, err, output)
+	}
+	return output
+}
+
+func waitForProviderLog(t *testing.T, path, needle string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil && strings.Contains(string(data), needle) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	data, _ := os.ReadFile(path)
+	t.Fatalf("provider did not record %q: %q", needle, data)
+}
+
+func killHermeticTmuxServer(socketDir string) {
+	cmd := exec.Command("tmux", "kill-server")
+	cmd.Env = append(os.Environ(), "TMUX_TMPDIR="+socketDir)
+	_ = cmd.Run()
+}

--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -58,6 +58,7 @@ const (
 	OutcomeActionRequired  Outcome = "action_required"
 	OutcomeUnsupported     Outcome = "unsupported"
 	OutcomeAttached        Outcome = "attached"
+	OutcomeClosed          Outcome = "closed"
 )
 
 type InspectStatus string
@@ -139,10 +140,11 @@ func (d DetectResult) Validate() error {
 }
 
 type CreateRequest struct {
-	Session string
-	Plan    Plan
-	AMQPath string
-	Root    *fsq.DeliveryRoot
+	ProjectRoot string
+	Session     string
+	Plan        Plan
+	AMQPath     string
+	Root        *fsq.DeliveryRoot
 }
 
 type EmittedCommand struct {

--- a/internal/launch/conformance.go
+++ b/internal/launch/conformance.go
@@ -1,7 +1,9 @@
 package launch
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -35,8 +37,41 @@ func RunConformance(t *testing.T, b Backend) {
 				switch cap {
 				case CapPlanOnly:
 					assertPlanOnlyCreate(t, b, root)
-				case CapCreate, CapInspect, CapClose, CapFocus, CapReclaim:
-					t.Fatal("managed capability declared but this skeleton has no managed assertion yet")
+				case CapCreate:
+					withManagedConformanceResource(t, b, root, func(CreateRequest, CreateResult) {})
+				case CapInspect:
+					withManagedConformanceResource(t, b, root, func(_ CreateRequest, created CreateResult) {
+						got, err := b.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+						if err != nil || got.Status != InspectPresent || got.Evidence == "" {
+							t.Fatalf("managed Inspect = %#v, %v", got, err)
+						}
+					})
+				case CapClose:
+					req := managedConformanceRequest(t, root)
+					created := mustManagedCreate(t, b, req)
+					got, err := b.Close(CloseRequest{Binding: created.Binding, Root: root})
+					if err != nil || got.Outcome == OutcomeUnsupported || got.Outcome == OutcomeActionRequired {
+						t.Fatalf("managed Close = %#v, %v", got, err)
+					}
+					inspection, err := b.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+					if err != nil || inspection.Status != InspectAbsent {
+						t.Fatalf("Inspect after Close = %#v, %v", inspection, err)
+					}
+				case CapFocus:
+					focuser, ok := b.(BackendFocuser)
+					if !ok {
+						t.Fatal("focus capability declared without BackendFocuser")
+					}
+					withManagedConformanceResource(t, b, root, func(_ CreateRequest, created CreateResult) {
+						got, err := focuser.Focus(FocusRequest{Binding: created.Binding, Root: root})
+						if err != nil || got.Outcome != OutcomeAttached {
+							t.Fatalf("managed Focus = %#v, %v", got, err)
+						}
+					})
+				case CapReclaim:
+					if _, ok := b.(BackendReclaimer); !ok {
+						t.Fatal("reclaim capability declared without BackendReclaimer")
+					}
 				default:
 					t.Fatalf("unknown declared capability %q", cap)
 				}
@@ -121,7 +156,10 @@ func RunConformance(t *testing.T, b Backend) {
 		}
 		result, err := b.Create(CreateRequest{Session: "no-such-session", Plan: harnessPlan(), Root: typoRoot})
 		if err != nil {
-			t.Fatal(err)
+			var definite *DefinitePreCreateError
+			if !errors.As(err, &definite) {
+				t.Fatal(err)
+			}
 		}
 		if result.Outcome == OutcomeCreated {
 			t.Fatal("typo session invented managed create success")
@@ -140,18 +178,57 @@ func RunConformance(t *testing.T, b Backend) {
 		if !profile.Has(CapInspect) || !profile.Has(CapCreate) {
 			t.Skip("managed inspect/create not in profile; reused by tmux/cmux/ghostty")
 		}
+		req := managedConformanceRequest(t, root)
+		first := mustManagedCreate(t, b, req)
+		closed, err := b.Close(CloseRequest{Binding: first.Binding, Root: root})
+		if err != nil || closed.Outcome == OutcomeUnsupported || closed.Outcome == OutcomeActionRequired {
+			t.Fatalf("close stale resource = %#v, %v", closed, err)
+		}
+		inspection, err := b.Inspect(InspectRequest{Binding: first.Binding, Root: root})
+		if err != nil || inspection.Status != InspectAbsent {
+			t.Fatalf("stale binding Inspect = %#v, %v", inspection, err)
+		}
+		second := mustManagedCreate(t, b, req)
+		if second.Binding.LaunchNonce != first.Binding.LaunchNonce {
+			t.Fatal("recreate changed the requested generation")
+		}
+		closed, err = b.Close(CloseRequest{Binding: second.Binding, Root: root})
+		if err != nil || closed.Outcome == OutcomeUnsupported || closed.Outcome == OutcomeActionRequired {
+			t.Fatalf("close recreated resource = %#v, %v", closed, err)
+		}
 	})
 
 	t.Run("duplicate_spawn_prevention", func(t *testing.T) {
 		if !profile.Has(CapCreate) {
 			t.Skip("managed create not in profile; reused by tmux/cmux/ghostty")
 		}
+		withManagedConformanceResource(t, b, root, func(req CreateRequest, first CreateResult) {
+			second, err := b.Create(req)
+			if err == nil && second.Outcome == OutcomeCreated {
+				t.Fatal("duplicate Create invented a second managed success")
+			}
+			inspection, inspectErr := b.Inspect(InspectRequest{Binding: first.Binding, Root: root})
+			if inspectErr != nil || inspection.Status != InspectPresent {
+				t.Fatalf("duplicate Create changed first resource: %#v, %v", inspection, inspectErr)
+			}
+		})
 	})
 
 	t.Run("foreign_context_binding_rejection", func(t *testing.T) {
 		if !profile.Has(CapInspect) {
 			t.Skip("inspect not in profile; reused by tmux/cmux/ghostty")
 		}
+		withManagedConformanceResource(t, b, root, func(_ CreateRequest, created CreateResult) {
+			foreign := created.Binding
+			foreign.LaunchNonce = "019c5a10-75d8-7eef-8db7-5ee77f70e799"
+			inspection, err := b.Inspect(InspectRequest{Binding: foreign, Root: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if inspection.Status == InspectPresent {
+				t.Fatal("Inspect accepted a foreign launch generation")
+			}
+		})
 	})
 
 	t.Run("capability_degradation", func(t *testing.T) {
@@ -240,6 +317,13 @@ func names(entries []os.DirEntry) []string {
 func harnessRoot(t *testing.T) (string, *fsq.DeliveryRoot) {
 	t.Helper()
 	dir := t.TempDir()
+	if err := fsq.EnsureRootDirs(dir); err != nil {
+		t.Fatal(err)
+	}
+	config := []byte(`{"version":1,"agents":["claude","codex"]}`)
+	if err := os.WriteFile(filepath.Join(dir, "meta", "config.json"), config, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	identity, err := fsq.SnapshotDeliveryRoot(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -249,22 +333,73 @@ func harnessRoot(t *testing.T) (string, *fsq.DeliveryRoot) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = root.Close() })
+	if repaired := fsq.RepairMailboxLayoutForAgents(root, []string{"claude", "codex"}); repaired.Status != "repaired" {
+		t.Fatalf("repair conformance root: %#v", repaired)
+	}
 	return dir, root
 }
 
+func managedConformanceRequest(t *testing.T, root *fsq.DeliveryRoot) CreateRequest {
+	t.Helper()
+	project := t.TempDir()
+	amq := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(amq, []byte("#!/bin/sh\nexec /bin/sleep 60\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	plan := harnessPlan()
+	for i := range plan.Agents {
+		plan.Agents[i].Cwd = project
+		plan.Agents[i].Argv = []string{"/bin/sleep", "60"}
+		plan.Agents[i].DynamicArgv = nil
+	}
+	return CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: amq, Root: root}
+}
+
+func mustManagedCreate(t *testing.T, b Backend, req CreateRequest) CreateResult {
+	t.Helper()
+	created, err := b.Create(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Outcome != OutcomeCreated || created.ActionRequired {
+		t.Fatalf("managed Create = %#v", created)
+	}
+	if err := created.Binding.Validate(); err != nil {
+		t.Fatalf("managed binding: %v", err)
+	}
+	if created.Binding.Profile != b.Detect().Profile.Identity() {
+		t.Fatalf("binding profile = %q, want %q", created.Binding.Profile, b.Detect().Profile.Identity())
+	}
+	return created
+}
+
+func withManagedConformanceResource(t *testing.T, b Backend, root *fsq.DeliveryRoot, fn func(CreateRequest, CreateResult)) {
+	t.Helper()
+	req := managedConformanceRequest(t, root)
+	created := mustManagedCreate(t, b, req)
+	t.Cleanup(func() {
+		closed, err := b.Close(CloseRequest{Binding: created.Binding, Root: root})
+		if err != nil || closed.Outcome == OutcomeUnsupported || closed.Outcome == OutcomeActionRequired {
+			t.Errorf("cleanup managed resource: %#v, %v", closed, err)
+		}
+	})
+	fn(req, created)
+}
+
 func harnessPlan() Plan {
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70e7a5"
 	return Plan{Version: PlanVersion, Agents: []AgentPlan{
 		{
-			Handle: "claude", Argv: []string{"/usr/local/bin/claude", "--session-id", "claude:one"},
+			Handle: "claude", Argv: []string{"/usr/local/bin/claude", "--session-id", nonce},
 			EnvOverlay: map[string]string{"LANG": "C"}, Cwd: "/work/project",
 			AdapterMode: AdapterModeMint, ResumePolicy: ResumeEnabled,
-			LaunchNonce: "launch-one", ConversationID: "claude:one",
+			LaunchNonce: nonce, ConversationID: nonce,
 			DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgConversationID}},
 		},
 		{
-			Handle: "codex", Argv: []string{"/usr/local/bin/codex", "--launch-nonce", "launch-one"}, Cwd: "/work/project",
+			Handle: "codex", Argv: []string{"/usr/local/bin/codex", "--launch-nonce", nonce}, Cwd: "/work/project",
 			AdapterMode: AdapterModeCapture, ResumePolicy: ResumeFresh,
-			LaunchNonce: "launch-one",
+			LaunchNonce: nonce,
 			DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgLaunchNonce}},
 		},
 	}}

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -250,6 +250,28 @@ func LoadExecutionTicket(root *fsq.DeliveryRoot, handle string) (ExecutionTicket
 	return ticket, nil
 }
 
+// RemoveExecutionTicket removes only the exact pending generation while the
+// caller still holds both the launch lease and the handle lock.
+func RemoveExecutionTicket(root *fsq.DeliveryRoot, lease *Lease, handle, nonce string) error {
+	if err := lease.authorizeWrite(root); err != nil {
+		return err
+	}
+	if !lease.holdsHandle(handle) {
+		return fmt.Errorf("launch lease does not hold handle %q", handle)
+	}
+	ticket, err := LoadExecutionTicket(root, handle)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if ticket.LaunchNonce != nonce || nonce != lease.LaunchNonce() {
+		return fmt.Errorf("execution ticket generation changed before removal")
+	}
+	return root.Remove(filepath.Join(executionDirectory, handle+".json"))
+}
+
 // CompareAndSwapExecutionTicket changes one ticket state while the caller's
 // live lease and handle lock exclude competing launch/reconcile operations.
 func CompareAndSwapExecutionTicket(root *fsq.DeliveryRoot, lease *Lease, handle string, expected ExecutionState, next ExecutionState, reason string) (ExecutionTicket, error) {

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -291,10 +292,23 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 				return result, err
 			}
 		}
-		create, err = backend.Create(CreateRequest{Session: request.Session, Plan: plan, AMQPath: request.AMQPath, Root: request.Root})
+		amqExecutable, err := resolveLaunchAMQExecutable(request.AMQPath)
+		if err != nil {
+			return result, err
+		}
+		if err := writeExecutionTickets(request, lease, planned, amqExecutable); err != nil {
+			return result, err
+		}
+		create, err = backend.Create(CreateRequest{
+			ProjectRoot: request.ProjectRoot, Session: request.Session, Plan: plan,
+			AMQPath: amqExecutable, Root: request.Root,
+		})
 		if err != nil {
 			var definite *DefinitePreCreateError
 			if journalActive && errors.As(err, &definite) {
+				if clearErr := removeExecutionTickets(request.Root, lease, planned); clearErr != nil {
+					return result, errors.Join(err, clearErr)
+				}
 				if clearErr := ClearJournal(request.Root, lease, journal); clearErr != nil {
 					return result, errors.Join(err, clearErr)
 				}
@@ -309,11 +323,6 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		}
 	}
 	result.Outcome, result.Commands = create.Outcome, create.Commands
-	if create.Outcome == OutcomeCommandsEmitted {
-		if err := writeExecutionTickets(request, lease, planned); err != nil {
-			return result, err
-		}
-	}
 	var candidate *BindingRecord
 	if create.Outcome == OutcomeCreated {
 		if journalActive && journal.Phase == JournalCreated {
@@ -583,11 +592,8 @@ func plannedConversations(planned []plannedAgent) []ConversationRecord {
 	return records
 }
 
-func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []plannedAgent) error {
-	amqPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("resolve current amq executable: %w", err)
-	}
+func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []plannedAgent, amqPath string) error {
+	written := make([]plannedAgent, 0, len(planned))
 	for _, agent := range planned {
 		ticket, err := NewExecutionTicket(ExecutionTicketRequest{
 			Handle: agent.plan.Handle, LaunchNonce: agent.plan.LaunchNonce,
@@ -597,13 +603,41 @@ func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []pla
 			TargetArgv: agent.plan.Argv, TargetEnv: agent.plan.EnvOverlay,
 		})
 		if err != nil {
-			return fmt.Errorf("build execution ticket for %s: %w", agent.plan.Handle, err)
+			return errors.Join(fmt.Errorf("build execution ticket for %s: %w", agent.plan.Handle, err), removeExecutionTickets(request.Root, lease, written))
 		}
 		if err := WriteExecutionTicket(request.Root, lease, ticket); err != nil {
-			return fmt.Errorf("write execution ticket for %s: %w", agent.plan.Handle, err)
+			return errors.Join(fmt.Errorf("write execution ticket for %s: %w", agent.plan.Handle, err), removeExecutionTickets(request.Root, lease, append(written, agent)))
 		}
+		written = append(written, agent)
 	}
 	return nil
+}
+
+func resolveLaunchAMQExecutable(value string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		path, err := os.Executable()
+		if err != nil {
+			return "", fmt.Errorf("resolve current amq executable: %w", err)
+		}
+		value = path
+	}
+	path, err := exec.LookPath(value)
+	if err != nil {
+		return "", fmt.Errorf("resolve amq executable: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve amq executable identity: %w", err)
+	}
+	return resolved, nil
+}
+
+func removeExecutionTickets(root *fsq.DeliveryRoot, lease *Lease, planned []plannedAgent) error {
+	var result error
+	for _, agent := range planned {
+		result = errors.Join(result, RemoveExecutionTicket(root, lease, agent.plan.Handle, agent.plan.LaunchNonce))
+	}
+	return result
 }
 
 func commitRecoveredJournal(request ReconcileRequest, lease *Lease, journal LaunchJournal) error {

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -937,6 +937,13 @@ func TestReconcileCreateFailureClassificationControlsJournalClear(t *testing.T) 
 			if !definite && journalErr != nil {
 				t.Fatalf("uncertain create failure lost journal: %v", journalErr)
 			}
+			_, ticketErr := LoadExecutionTicket(req.Root, "claude")
+			if definite && !errors.Is(ticketErr, os.ErrNotExist) {
+				t.Fatalf("definite pre-create failure retained execution ticket: %v", ticketErr)
+			}
+			if !definite && ticketErr != nil {
+				t.Fatalf("uncertain create failure lost execution ticket: %v", ticketErr)
+			}
 		})
 	}
 }

--- a/internal/launch/tmux.go
+++ b/internal/launch/tmux.go
@@ -1,0 +1,592 @@
+package launch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	tmuxProfileVersion      = 1
+	tmuxProfileVersionRange = ">=3.2 <4.0"
+	tmuxNonceEnvironment    = "AMQ_LAUNCH_NONCE"
+	tmuxCommandTimeout      = 5 * time.Second
+)
+
+// TmuxBackend manages one deterministic tmux session per AMQ project/session.
+// The socket namespace is stable across tmux server restarts; resource IDs are
+// still live tmux IDs and are never reconstructed from display names.
+type TmuxBackend struct {
+	binary     string
+	socketName string
+	run        func(context.Context, ...string) (string, error)
+	focus      func(context.Context, string) error
+	hostname   func() (string, error)
+	getenv     func(string) string
+	uid        func() string
+}
+
+func NewTmuxBackend(binary string) *TmuxBackend {
+	if strings.TrimSpace(binary) == "" {
+		binary = "tmux"
+	}
+	b := &TmuxBackend{
+		binary: binary, hostname: os.Hostname, getenv: os.Getenv, uid: currentUserID,
+	}
+	b.run = b.runCommand
+	b.focus = b.focusResource
+	return b
+}
+
+func TmuxProfile() Profile {
+	return Profile{
+		Backend: LauncherTMux, Platform: runtime.GOOS,
+		VersionRange: tmuxProfileVersionRange, Version: tmuxProfileVersion,
+		Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus, CapReclaim},
+	}
+}
+
+func (b *TmuxBackend) Detect() DetectResult {
+	profile := TmuxProfile()
+	result := DetectResult{Profile: profile}
+	path, err := exec.LookPath(b.binary)
+	if err != nil {
+		return result
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	out, err := b.run(ctx, "-V")
+	if err != nil || !supportedTmuxVersion(out) {
+		return result
+	}
+	host, err := b.hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		return result
+	}
+	b.binary = path
+	result.Available = true
+	result.HostIdentity = host
+	result.InstanceIdentity = "tmux-socket:" + b.socketPath()
+	result.Effective = append([]Capability(nil), profile.Capabilities...)
+	return result
+}
+
+func (b *TmuxBackend) Create(req CreateRequest) (CreateResult, error) {
+	if err := b.validateCreate(req); err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: err}
+	}
+	amqPath := req.AMQPath
+	if strings.TrimSpace(amqPath) == "" {
+		amqPath = "amq"
+	}
+	resolvedAMQ, err := exec.LookPath(amqPath)
+	if err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("resolve amq executable: %w", err)}
+	}
+	if resolvedAMQ, err = filepath.EvalSymlinks(resolvedAMQ); err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("resolve amq executable identity: %w", err)}
+	}
+	req.AMQPath = resolvedAMQ
+	detect := b.Detect()
+	if !detect.Available {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("tmux %s is unavailable", tmuxProfileVersionRange)}
+	}
+	name, err := tmuxSessionName(req.ProjectRoot, req.Session)
+	if err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: err}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	present, err := b.hasSession(ctx, name)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	if present {
+		return CreateResult{}, fmt.Errorf("tmux session %q already exists; journal recovery must classify it", name)
+	}
+
+	first := req.Plan.Agents[0]
+	firstLine := b.agentCommand(req, first)
+	out, err := b.run(ctx, b.args("new-session", "-d", "-P", "-F", "#{session_id}\t#{window_id}",
+		"-s", name, "-n", first.Handle, "-e", tmuxNonceEnvironment+"="+first.LaunchNonce, firstLine)...)
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("create tmux session: %w", err)
+	}
+	fields := strings.Split(strings.TrimSpace(out), "\t")
+	if len(fields) != 2 || fields[0] == "" || fields[1] == "" {
+		return CreateResult{}, fmt.Errorf("tmux create returned invalid resource identities %q", strings.TrimSpace(out))
+	}
+	sessionID := fields[0]
+	if err := b.markWindow(ctx, fields[1], first.Handle); err != nil {
+		return CreateResult{}, err
+	}
+	for _, agent := range req.Plan.Agents[1:] {
+		windowID, createErr := b.run(ctx, b.args("new-window", "-d", "-P", "-F", "#{window_id}",
+			"-t", "="+name, "-n", agent.Handle, b.agentCommand(req, agent))...)
+		if createErr != nil {
+			return CreateResult{}, fmt.Errorf("create tmux window for %s: %w", agent.Handle, createErr)
+		}
+		windowID = strings.TrimSpace(windowID)
+		if windowID == "" {
+			return CreateResult{}, fmt.Errorf("tmux returned no window identity for %s", agent.Handle)
+		}
+		if err := b.markWindow(ctx, windowID, agent.Handle); err != nil {
+			return CreateResult{}, err
+		}
+	}
+	resources, err := b.liveResources(ctx, name)
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("revalidate created tmux session: %w", err)
+	}
+	if issues := tmuxInventoryIssues(resources, req.Plan); len(issues) != 0 {
+		return CreateResult{}, fmt.Errorf("created tmux inventory differs from plan: %s", strings.Join(issues, ","))
+	}
+	if resources[0].OpaqueID != tmuxSessionResource(sessionID, name) {
+		return CreateResult{}, fmt.Errorf("created tmux session identity changed before binding")
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherTMux, HostIdentity: detect.HostIdentity,
+		InstanceIdentity: detect.InstanceIdentity, Profile: detect.Profile.Identity(),
+		LaunchNonce: first.LaunchNonce,
+		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: resources},
+	}
+	if err := binding.Validate(); err != nil {
+		return CreateResult{}, err
+	}
+	return CreateResult{Outcome: OutcomeCreated, Profile: binding.Profile, Binding: binding}, nil
+}
+
+func (b *TmuxBackend) Inspect(req InspectRequest) (InspectResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	state, err := b.inspect(ctx, req.Binding)
+	if err != nil {
+		return InspectResult{Status: InspectUnknown, Evidence: err.Error(), ActionRequired: true}, nil
+	}
+	return state, nil
+}
+
+func (b *TmuxBackend) Close(req CloseRequest) (CloseResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	inspection, err := b.inspect(ctx, req.Binding)
+	if err != nil {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: err.Error()}, nil
+	}
+	if inspection.Status == InspectAbsent {
+		return CloseResult{Outcome: OutcomeClosed, Reason: "tmux session already absent"}, nil
+	}
+	if inspection.Status != InspectPresent {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: inspection.Evidence}, nil
+	}
+	sessionID, _, err := parseTmuxSessionResource(req.Binding)
+	if err != nil {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: err.Error()}, nil
+	}
+	if _, err := b.run(ctx, b.args("kill-session", "-t", sessionID)...); err != nil {
+		return CloseResult{}, fmt.Errorf("close tmux session: %w", err)
+	}
+	return CloseResult{Outcome: OutcomeClosed, Reason: "tmux session closed"}, nil
+}
+
+func (b *TmuxBackend) Focus(req FocusRequest) (FocusResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	inspection, err := b.inspect(ctx, req.Binding)
+	if err != nil || inspection.Status != InspectPresent {
+		if err != nil {
+			return FocusResult{}, err
+		}
+		return FocusResult{Outcome: OutcomeActionRequired, Reason: inspection.Evidence}, nil
+	}
+	sessionID, _, err := parseTmuxSessionResource(req.Binding)
+	if err != nil {
+		return FocusResult{}, err
+	}
+	if err := b.focus(ctx, sessionID); err != nil {
+		return FocusResult{}, err
+	}
+	return FocusResult{Outcome: OutcomeAttached}, nil
+}
+
+func (b *TmuxBackend) focusResource(ctx context.Context, sessionID string) error {
+	if strings.TrimSpace(b.getenv("TMUX")) != "" {
+		_, err := b.run(ctx, b.args("switch-client", "-t", sessionID)...)
+		return err
+	}
+	cmd := exec.Command(b.binary, b.args("attach-session", "-t", sessionID)...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
+func (b *TmuxBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
+	parent := req.Context
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, tmuxCommandTimeout)
+	defer cancel()
+	if req.Root == nil {
+		return ReclaimResult{}, fmt.Errorf("missing pinned session root")
+	}
+	rootIdentity, err := canonicalIdentity(req.Root.Base())
+	if err != nil || rootIdentity != req.Journal.RootIdentity {
+		return ReclaimResult{Status: ReclaimForeign, Evidence: "journal session root does not match the pinned root"}, nil
+	}
+	if req.Journal.RootPhysical != "" {
+		physical, physicalErr := fsq.StableTreeIdentityInfo(req.Root.FileInfo())
+		if physicalErr != nil || physical != req.Journal.RootPhysical {
+			return ReclaimResult{Status: ReclaimForeign, Evidence: "journal session root identity changed"}, nil
+		}
+	}
+	name, err := tmuxSessionName(req.Journal.ProjectIdentity, req.Journal.Session)
+	if err != nil {
+		return ReclaimResult{}, err
+	}
+	present, err := b.hasSession(ctx, name)
+	if err != nil {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
+	}
+	if !present {
+		return ReclaimResult{Status: ReclaimAbsent, Evidence: "deterministic tmux session is absent"}, nil
+	}
+	nonce, err := b.sessionNonce(ctx, name)
+	if err != nil {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
+	}
+	if nonce != req.Journal.LaunchNonce {
+		return ReclaimResult{Status: ReclaimForeign, Evidence: "tmux session nonce does not match the journal"}, nil
+	}
+	resources, err := b.liveResources(ctx, name)
+	if err != nil {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
+	}
+	issues := tmuxInventoryIssues(resources, req.Journal.Plan)
+	if len(issues) != 0 {
+		return ReclaimResult{
+			Status: ReclaimIncomplete, Evidence: "tmux session inventory differs from plan: " + strings.Join(issues, ","),
+			Resources: resources,
+		}, nil
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherTMux, HostIdentity: req.Journal.HostIdentity,
+		InstanceIdentity: req.Journal.InstanceIdentity, Profile: req.Journal.Profile,
+		LaunchNonce: req.Journal.LaunchNonce,
+		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: resources},
+	}
+	host, hostErr := b.hostname()
+	instance := "tmux-socket:" + b.socketPath()
+	if hostErr != nil || host != binding.HostIdentity || instance != binding.InstanceIdentity || TmuxProfile().Identity() != binding.Profile {
+		return ReclaimResult{Status: ReclaimForeign, Evidence: "tmux runtime identity changed", Resources: resources}, nil
+	}
+	return ReclaimResult{Status: ReclaimAdoptable, Evidence: "tmux session and nonce match the complete journal plan", Resources: resources, Binding: binding}, nil
+}
+
+func (b *TmuxBackend) validateCreate(req CreateRequest) error {
+	if strings.TrimSpace(req.ProjectRoot) == "" || strings.TrimSpace(req.Session) == "" || req.Root == nil {
+		return fmt.Errorf("project root, session, and pinned root are required")
+	}
+	if err := req.Plan.Validate(); err != nil {
+		return err
+	}
+	if _, err := canonicalIdentity(req.ProjectRoot); err != nil {
+		return fmt.Errorf("resolve project root: %w", err)
+	}
+	handles := make([]string, len(req.Plan.Agents))
+	nonce := req.Plan.Agents[0].LaunchNonce
+	if !validUUID(nonce) {
+		return fmt.Errorf("launch nonce must be a UUID")
+	}
+	for i, agent := range req.Plan.Agents {
+		handles[i] = agent.Handle
+		if agent.LaunchNonce != nonce {
+			return fmt.Errorf("agent %q has a different launch nonce", agent.Handle)
+		}
+	}
+	if err := fsq.ValidateExistingMailboxLayout(req.Root, handles...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *TmuxBackend) inspect(ctx context.Context, binding BindingRecord) (InspectResult, error) {
+	if err := binding.Validate(); err != nil {
+		return InspectResult{}, err
+	}
+	if err := b.validateBindingContext(binding); err != nil {
+		return InspectResult{}, err
+	}
+	sessionID, name, err := parseTmuxSessionResource(binding)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	present, err := b.hasSession(ctx, name)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	if !present {
+		return InspectResult{Status: InspectAbsent, Evidence: "tmux session is absent"}, nil
+	}
+	nonce, err := b.sessionNonce(ctx, name)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	if nonce != binding.LaunchNonce {
+		return InspectResult{Status: InspectUnknown, Evidence: "tmux session nonce differs from binding", ActionRequired: true}, nil
+	}
+	resources, err := b.liveResources(ctx, name)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	if len(resources) != len(binding.Resources.Resources) {
+		return InspectResult{Status: InspectUnknown, Evidence: "tmux resource inventory differs from binding", ActionRequired: true}, nil
+	}
+	live := make(map[string]string, len(resources))
+	for _, resource := range resources {
+		live[resource.OpaqueID] = resource.Agent
+	}
+	for _, expected := range binding.Resources.Resources {
+		if live[expected.OpaqueID] != expected.Agent {
+			return InspectResult{Status: InspectUnknown, Evidence: "tmux resource identity differs from binding", ActionRequired: true}, nil
+		}
+	}
+	if resources[0].OpaqueID != tmuxSessionResource(sessionID, name) {
+		return InspectResult{Status: InspectUnknown, Evidence: "tmux session identity differs from binding", ActionRequired: true}, nil
+	}
+	return InspectResult{Status: InspectPresent, Evidence: "tmux session nonce and resource inventory match"}, nil
+}
+
+func (b *TmuxBackend) validateBindingContext(binding BindingRecord) error {
+	host, err := b.hostname()
+	if err != nil {
+		return fmt.Errorf("resolve tmux host identity: %w", err)
+	}
+	if binding.Backend != LauncherTMux || binding.Profile != TmuxProfile().Identity() ||
+		binding.HostIdentity != host || binding.InstanceIdentity != "tmux-socket:"+b.socketPath() {
+		return fmt.Errorf("tmux binding belongs to a different backend context")
+	}
+	return nil
+}
+
+func (b *TmuxBackend) liveResources(ctx context.Context, name string) ([]ResourceIdentity, error) {
+	out, err := b.run(ctx, b.args("list-windows", "-t", "="+name, "-F", "#{session_id}\t#{session_name}\t#{window_id}\t#{@amq_agent}")...)
+	if err != nil {
+		return nil, fmt.Errorf("inspect tmux windows: %w", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
+		return nil, fmt.Errorf("tmux session has no windows")
+	}
+	resources := make([]ResourceIdentity, 0, len(lines)+1)
+	var sessionID string
+	for i, line := range lines {
+		fields := strings.Split(line, "\t")
+		if len(fields) != 4 || fields[0] == "" || fields[1] != name || fields[2] == "" || fields[3] == "" {
+			return nil, fmt.Errorf("invalid tmux resource inventory line %q", line)
+		}
+		if i == 0 {
+			sessionID = fields[0]
+			resources = append(resources, ResourceIdentity{OpaqueID: tmuxSessionResource(sessionID, name)})
+		} else if fields[0] != sessionID {
+			return nil, fmt.Errorf("tmux inventory crossed session identities")
+		}
+		resources = append(resources, ResourceIdentity{OpaqueID: tmuxWindowResource(fields[2]), Agent: fields[3]})
+	}
+	return resources, nil
+}
+
+func (b *TmuxBackend) hasSession(ctx context.Context, name string) (bool, error) {
+	_, err := b.run(ctx, b.args("has-session", "-t", "="+name)...)
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
+}
+
+func (b *TmuxBackend) sessionNonce(ctx context.Context, name string) (string, error) {
+	out, err := b.run(ctx, b.args("show-environment", "-t", "="+name, tmuxNonceEnvironment)...)
+	if err != nil {
+		return "", fmt.Errorf("read tmux launch nonce: %w", err)
+	}
+	key, value, ok := strings.Cut(strings.TrimSpace(out), "=")
+	if !ok || key != tmuxNonceEnvironment || value == "" {
+		return "", fmt.Errorf("tmux launch nonce marker is missing")
+	}
+	return value, nil
+}
+
+func (b *TmuxBackend) markWindow(ctx context.Context, windowID, handle string) error {
+	if _, err := b.run(ctx, b.args("set-option", "-w", "-t", windowID, "@amq_agent", handle)...); err != nil {
+		return fmt.Errorf("mark tmux window for %s: %w", handle, err)
+	}
+	return nil
+}
+
+func (b *TmuxBackend) agentCommand(req CreateRequest, agent AgentPlan) string {
+	amq := req.AMQPath
+	if strings.TrimSpace(amq) == "" {
+		amq = "amq"
+	}
+	env := cloneEnv(agent.EnvOverlay)
+	if env == nil {
+		env = make(map[string]string, 1)
+	}
+	env[InternalLaunchNonceEnv] = agent.LaunchNonce
+	return commandLine(agent.Cwd, env, coopExecArgv(amq, req.Session, agent.Handle, agent.Argv))
+}
+
+func (b *TmuxBackend) args(args ...string) []string {
+	if b.socketName == "" || b.socketName == "default" {
+		return args
+	}
+	return append([]string{"-L", b.socketName}, args...)
+}
+
+func (b *TmuxBackend) runCommand(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, b.binary, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("tmux %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func (b *TmuxBackend) socketPath() string {
+	if active := strings.TrimSpace(b.getenv("TMUX")); b.socketName == "" && active != "" {
+		if path, _, ok := strings.Cut(active, ","); ok && filepath.IsAbs(path) {
+			return filepath.Clean(path)
+		}
+	}
+	base := strings.TrimSpace(b.getenv("TMUX_TMPDIR"))
+	if base == "" {
+		base = "/tmp"
+	}
+	if resolved, err := filepath.EvalSymlinks(base); err == nil {
+		base = resolved
+	}
+	name := b.socketName
+	if name == "" {
+		name = "default"
+	}
+	return filepath.Join(base, "tmux-"+b.uid(), name)
+}
+
+func currentUserID() string {
+	current, err := user.Current()
+	if err != nil || strings.TrimSpace(current.Uid) == "" {
+		return "unknown"
+	}
+	return current.Uid
+}
+
+func supportedTmuxVersion(raw string) bool {
+	fields := strings.Fields(strings.TrimSpace(raw))
+	if len(fields) < 2 || fields[0] != "tmux" {
+		return false
+	}
+	version := strings.TrimRightFunc(fields[1], func(r rune) bool { return r < '0' || r > '9' })
+	parts := strings.SplitN(version, ".", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	major, errMajor := strconv.Atoi(parts[0])
+	minor, errMinor := strconv.Atoi(parts[1])
+	return errMajor == nil && errMinor == nil && major == 3 && minor >= 2
+}
+
+func tmuxSessionName(projectRoot, session string) (string, error) {
+	canonical, err := canonicalIdentity(projectRoot)
+	if err != nil {
+		return "", err
+	}
+	slug := tmuxSlug(filepath.Base(canonical))
+	sessionSlug := tmuxSlug(session)
+	projectSum := sha256.Sum256([]byte(canonical))
+	sessionSum := sha256.Sum256([]byte(session))
+	return fmt.Sprintf("amq-%s-%s-%s-%s",
+		truncateTMuxPart(slug, 30), hex.EncodeToString(projectSum[:5]),
+		truncateTMuxPart(sessionSlug, 24), hex.EncodeToString(sessionSum[:4])), nil
+}
+
+func tmuxSlug(value string) string {
+	var out strings.Builder
+	for _, r := range strings.ToLower(value) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			out.WriteRune(r)
+		} else if out.Len() != 0 && !strings.HasSuffix(out.String(), "-") {
+			out.WriteByte('-')
+		}
+	}
+	return strings.Trim(out.String(), "-")
+}
+
+func truncateTMuxPart(value string, max int) string {
+	if value == "" {
+		return "session"
+	}
+	if len(value) > max {
+		return strings.TrimRight(value[:max], "-")
+	}
+	return value
+}
+
+func tmuxSessionResource(id, name string) string { return "tmux:v1:session:" + id + ":" + name }
+func tmuxWindowResource(id string) string        { return "tmux:v1:window:" + id }
+
+func parseTmuxSessionResource(binding BindingRecord) (string, string, error) {
+	for _, resource := range binding.Resources.Resources {
+		if strings.HasPrefix(resource.OpaqueID, "tmux:v1:session:") && resource.Agent == "" {
+			parts := strings.SplitN(strings.TrimPrefix(resource.OpaqueID, "tmux:v1:session:"), ":", 2)
+			if len(parts) == 2 && strings.HasPrefix(parts[0], "$") && parts[1] != "" {
+				return parts[0], parts[1], nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("binding has no valid tmux session identity")
+}
+
+func tmuxInventoryIssues(resources []ResourceIdentity, plan Plan) []string {
+	expected := make(map[string]bool, len(plan.Agents))
+	for _, agent := range plan.Agents {
+		expected[agent.Handle] = true
+	}
+	live := make(map[string]int, len(resources))
+	issues := make([]string, 0)
+	for _, resource := range resources {
+		if resource.Agent != "" {
+			live[resource.Agent]++
+			if !expected[resource.Agent] {
+				issues = append(issues, "unexpected:"+resource.Agent)
+			}
+		}
+	}
+	for _, agent := range plan.Agents {
+		switch live[agent.Handle] {
+		case 0:
+			issues = append(issues, "missing:"+agent.Handle)
+		case 1:
+		default:
+			issues = append(issues, "duplicate:"+agent.Handle)
+		}
+	}
+	if len(resources) != len(plan.Agents)+1 {
+		issues = append(issues, fmt.Sprintf("resource_count:%d", len(resources)))
+	}
+	return issues
+}

--- a/internal/launch/tmux_test.go
+++ b/internal/launch/tmux_test.go
@@ -1,0 +1,311 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestTmuxBackendLifecycleAndRecovery(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nexec /bin/sleep 60\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70e7a5"
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{
+		{Handle: "claude", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7a6"},
+		{Handle: "codex", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7a7"},
+	}}
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-test-%d-%d", os.Getpid(), time.Now().UnixNano())
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+		defer cancel()
+		_, _ = backend.run(ctx, backend.args("kill-server")...)
+	})
+
+	detect := backend.Detect()
+	if !detect.Available {
+		t.Fatalf("Detect = %#v", detect)
+	}
+	if detect.Profile.VersionRange != tmuxProfileVersionRange || !detect.Profile.Has(CapReclaim) {
+		t.Fatalf("profile = %#v", detect.Profile)
+	}
+	created, err := backend.Create(CreateRequest{
+		ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Outcome != OutcomeCreated || len(created.Binding.Resources.Resources) != 3 {
+		t.Fatalf("Create = %#v", created)
+	}
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectPresent {
+		t.Fatalf("Inspect = %#v, %v", inspection, err)
+	}
+
+	journal := LaunchJournal{
+		ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
+		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
+		Backend: LauncherTMux, Profile: detect.Profile.Identity(),
+	}
+	journal.RootIdentity, err = canonicalIdentity(root.Base())
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal.RootPhysical, _ = fsq.StableTreeIdentityInfo(root.FileInfo())
+	reclaimed, err := backend.Reclaim(ReclaimRequest{Context: context.Background(), Journal: journal, Root: root})
+	if err != nil || reclaimed.Status != ReclaimAdoptable || len(reclaimed.Resources) != 3 {
+		t.Fatalf("Reclaim = %#v, %v", reclaimed, err)
+	}
+
+	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root}); err == nil {
+		t.Fatal("duplicate Create succeeded")
+	}
+	afterDuplicate, _ := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if afterDuplicate.Status != InspectPresent {
+		t.Fatalf("duplicate Create changed live resource: %#v", afterDuplicate)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	name, err := tmuxSessionName(project, "collab")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.run(ctx, backend.args("set-environment", "-t", "="+name, tmuxNonceEnvironment, "foreign")...); err != nil {
+		t.Fatal(err)
+	}
+	foreign, _ := backend.Reclaim(ReclaimRequest{Context: ctx, Journal: journal, Root: root})
+	if foreign.Status != ReclaimForeign {
+		t.Fatalf("foreign Reclaim = %#v", foreign)
+	}
+	if _, err := backend.run(ctx, backend.args("set-environment", "-t", "="+name, tmuxNonceEnvironment, nonce)...); err != nil {
+		t.Fatal(err)
+	}
+	foreignBinding := created.Binding
+	foreignBinding.InstanceIdentity = "tmux-socket:/foreign"
+	foreignInspection, err := backend.Inspect(InspectRequest{Binding: foreignBinding, Root: root})
+	if err != nil || foreignInspection.Status != InspectUnknown {
+		t.Fatalf("foreign Inspect = %#v, %v", foreignInspection, err)
+	}
+
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("Close = %#v, %v", closed, err)
+	}
+	absent, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || absent.Status != InspectAbsent {
+		t.Fatalf("Inspect after Close = %#v, %v", absent, err)
+	}
+}
+
+func TestTmuxBackendConformance(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-conformance-%d-%d", os.Getpid(), time.Now().UnixNano())
+	backend.focus = func(context.Context, string) error { return nil }
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+		defer cancel()
+		_, _ = backend.run(ctx, backend.args("kill-server")...)
+	})
+	RunConformance(t, backend)
+}
+
+func TestTmuxReconcileCrashRestartThenRelaunchResumes(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-restart-%d-%d", os.Getpid(), time.Now().UnixNano())
+	backend.focus = func(context.Context, string) error { return nil }
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+		defer cancel()
+		_, _ = backend.run(ctx, backend.args("kill-server")...)
+	})
+	req := reconcileFixture(t, backend)
+	fakeAMQ := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nexec /bin/sleep 60\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	req.AMQPath = fakeAMQ
+	req.HostIdentity = backend.Detect().HostIdentity
+	crash := fmt.Errorf("injected process crash")
+	req.CrashHook = func(stage string) error {
+		if stage == "backend_created" {
+			return crash
+		}
+		return nil
+	}
+	first, err := Reconcile(req)
+	if !errors.Is(err, crash) || first.Plan == nil {
+		t.Fatalf("crashed Reconcile = %#v, %v", first, err)
+	}
+	if _, err := LoadJournal(req.Root); err != nil {
+		t.Fatalf("journal after crash: %v", err)
+	}
+	req.CrashHook = nil
+	recovered, err := Reconcile(req)
+	if err != nil || recovered.AggregateCode != 0 || recovered.Recovery == nil || recovered.Recovery.Status != ReclaimAdoptable {
+		t.Fatalf("recovered Reconcile = %#v, %v", recovered, err)
+	}
+	binding, err := LoadBinding(req.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadJournal(req.Root); !os.IsNotExist(err) {
+		t.Fatalf("journal after recovery: %v", err)
+	}
+	relaunched, err := Reconcile(req)
+	if err != nil || relaunched.AggregateCode != 0 || relaunched.Outcome != OutcomeAttached || relaunched.Agents[0].ConversationDisposition != DispositionResumed {
+		t.Fatalf("resume Reconcile = %#v, %v", relaunched, err)
+	}
+	inspection, err := backend.Inspect(InspectRequest{Binding: binding, Root: req.Root})
+	if err != nil || inspection.Status != InspectPresent {
+		t.Fatalf("resource after resume = %#v, %v", inspection, err)
+	}
+}
+
+func TestTmuxBackendReclaimReportsExactPartialInventory(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nexec /bin/sleep 60\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70e7b5"
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{
+		{Handle: "claude", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7b6"},
+		{Handle: "codex", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7b7"},
+	}}
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-partial-%d-%d", os.Getpid(), time.Now().UnixNano())
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+		defer cancel()
+		_, _ = backend.run(ctx, backend.args("kill-server")...)
+	})
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var removed string
+	for _, resource := range created.Binding.Resources.Resources {
+		if resource.Agent == "codex" {
+			removed = strings.TrimPrefix(resource.OpaqueID, "tmux:v1:window:")
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	if _, err := backend.run(ctx, backend.args("kill-window", "-t", removed)...); err != nil {
+		t.Fatal(err)
+	}
+	detect := backend.Detect()
+	rootIdentity, err := canonicalIdentity(root.Base())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootPhysical, _ := fsq.StableTreeIdentityInfo(root.FileInfo())
+	journal := LaunchJournal{ProjectIdentity: project, RootIdentity: rootIdentity, RootPhysical: rootPhysical, Session: "collab", Plan: plan, LaunchNonce: nonce, HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity, Backend: LauncherTMux, Profile: detect.Profile.Identity()}
+	reclaimed, err := backend.Reclaim(ReclaimRequest{Context: ctx, Journal: journal, Root: root})
+	if err != nil || reclaimed.Status != ReclaimIncomplete || !strings.Contains(reclaimed.Evidence, "codex") || len(reclaimed.Resources) != 2 {
+		t.Fatalf("partial Reclaim = %#v, %v", reclaimed, err)
+	}
+}
+
+func TestSupportedTmuxVersion(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		want    bool
+	}{{"tmux 3.2", true}, {"tmux 3.7b", true}, {"tmux 3.1c", false}, {"tmux 4.0", false}, {"screen 3.7", false}} {
+		if got := supportedTmuxVersion(tc.version); got != tc.want {
+			t.Errorf("supportedTmuxVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestTmuxCreateMissingAMQRefusesBeforeServerMutation(t *testing.T) {
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70e7c5"
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{{
+		Handle: "claude", Argv: []string{"/bin/sleep", "60"}, Cwd: project,
+		AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh,
+		LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7c6",
+	}}}
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-missing-%d-%d", os.Getpid(), time.Now().UnixNano())
+	_, err := backend.Create(CreateRequest{
+		ProjectRoot: project, Session: "collab", Plan: plan,
+		AMQPath: filepath.Join(t.TempDir(), "missing-amq"), Root: root,
+	})
+	var definite *DefinitePreCreateError
+	if !errors.As(err, &definite) {
+		t.Fatalf("Create error = %v, want definite pre-create refusal", err)
+	}
+	if _, statErr := os.Lstat(backend.socketPath()); !os.IsNotExist(statErr) {
+		t.Fatalf("missing amq created a tmux socket: %v", statErr)
+	}
+}
+
+func TestTmuxSessionNameBindsFullSessionName(t *testing.T) {
+	project := t.TempDir()
+	first, err := tmuxSessionName(project, "session-with-a-very-long-shared-prefix-alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := tmuxSessionName(project, "session-with-a-very-long-shared-prefix-bravo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("long session names collided: %q", first)
+	}
+}
+
+func tmuxTestRoot(t *testing.T, handles ...string) *fsq.DeliveryRoot {
+	t.Helper()
+	path := t.TempDir()
+	if err := fsq.EnsureRootDirs(path); err != nil {
+		t.Fatal(err)
+	}
+	config := `{"version":1,"agents":["` + strings.Join(handles, `","`) + `"]}`
+	if err := os.WriteFile(filepath.Join(path, "meta", "config.json"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(path, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	repaired := fsq.RepairMailboxLayoutForAgents(root, handles)
+	if repaired.Status != "repaired" {
+		t.Fatalf("repair mailbox root: %#v", repaired)
+	}
+	return root
+}


### PR DESCRIPTION
## Summary

- add a versioned managed tmux backend with Detect/Create/Inspect/Focus/Close/Reclaim
- bind recovery to the exact project, session root, socket, host, nonce, and tmux resource inventory
- write execution tickets before managed creation and remove them on definite pre-create refusal
- promote managed conformance checks for stale recovery, duplicate-spawn prevention, and foreign bindings
- add crash/restart recovery plus a hermetic real-binary fresh -> tmux server restart -> resume test

## Validation

- `make ci`
- `go test -race ./internal/launch -run 'TestTmux|TestReconcileCreateFailureClassification' -count=1`\n- `GOOS=windows GOARCH=amd64 go test -c ./internal/launch`\n- independent live tmux 3.7b peer review at staged SHA `3ee35569ce068b552957f3d5c7b97c4630cd93793e4a475cf24b5d9aa5da540f`\n\nRefs: #480