### PR TITLE
test(wake): make foreground-authority retry test deterministic

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -72,6 +72,7 @@ type wakeConfig struct {
 	maintenanceOutputs            []*os.File
 	preconditionCheck             func(*wakeConfig) error
 	onPendingNotify               func()
+	onNotificationAttemptComplete func()
 	recordNotifierStatus          func(status, mode, reason string) error
 	pendingNotifierStatus         *wakeNotifierStatus
 	recordDoorbellStatus          func(parked bool, attempts uint) error

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -3703,6 +3703,11 @@ func runWakeLoop(cfg wakeConfig) error {
 	}
 	var unreadableGenerationNotice wakeUnreadableGenerationNoticeState
 	attemptNotification := func() error {
+		defer func() {
+			if cfg.onNotificationAttemptComplete != nil {
+				cfg.onNotificationAttemptComplete()
+			}
+		}()
 		if terminalAuthorityRetryC != nil || inboxScanRetryC != nil {
 			return nil
 		}

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -3001,9 +3001,10 @@ func TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell(t 
 	nowNanos.Store(start.UnixNano())
 	var promptWrites atomic.Int64
 	initialSubmitted := make(chan struct{}, 1)
-	initialAttemptClockSampled := make(chan struct{}, 1)
+	initialAttemptCompleted := make(chan struct{}, 1)
 	refused := make(chan struct{}, 1)
 	extra := make(chan struct{}, 1)
+	ticks := make(chan time.Time)
 	stop := make(chan struct{})
 	stopped := false
 	stopLoop := func() {
@@ -3025,15 +3026,17 @@ func TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell(t 
 			injectMode:  wakeInjectModePaste,
 			controlStop: stop,
 			doorbellNow: func() time.Time {
-				now := time.Unix(0, nowNanos.Load())
-				if promptWrites.Load() == 1 && now.Equal(start) {
+				return time.Unix(0, nowNanos.Load())
+			},
+			onNotificationAttemptComplete: func() {
+				if promptWrites.Load() == 1 {
 					select {
-					case initialAttemptClockSampled <- struct{}{}:
+					case initialAttemptCompleted <- struct{}{}:
 					default:
 					}
 				}
-				return now
 			},
+			maintenanceTicks: ticks,
 			preconditionCheck: func(*wakeConfig) error {
 				return nil
 			},
@@ -3072,14 +3075,14 @@ func TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell(t 
 		t.Fatal("wake loop did not submit initial doorbell")
 	}
 	// terminalWrite reports the submit before deliverNewMessageNotification
-	// records the attempt. Wait until that record has sampled the old clock;
-	// the loop completes the state update before it can handle another event.
+	// commits the attempt. Wait for the committed retry state before advancing
+	// the fake clock or introducing the next cohort member.
 	select {
-	case <-initialAttemptClockSampled:
+	case <-initialAttemptCompleted:
 	case err := <-done:
 		t.Fatalf("wake loop exited before recording initial attempt: %v", err)
 	case <-time.After(2 * time.Second):
-		t.Fatal("wake loop did not sample the initial attempt clock")
+		t.Fatal("wake loop did not complete the initial attempt")
 	}
 	nowNanos.Store(start.Add(wakeDoorbellRetryBase).UnixNano())
 	message.Header.ID = "trigger-expired-foreground-retry"
@@ -3095,6 +3098,17 @@ func TestRunWakeLoopForegroundAuthorityRetryDoesNotCompeteWithExpiredDoorbell(t 
 		data,
 	); err != nil {
 		t.Fatal(err)
+	}
+	// Use a maintenance tick as a loop-boundary barrier. The send cannot
+	// complete until the initial notification has recorded its retry state,
+	// and maintenance scans the expanded cohort with the explicitly advanced
+	// clock. Do not depend on watcher delivery timing to trigger the retry.
+	select {
+	case ticks <- start.Add(wakeDoorbellRetryBase):
+	case err := <-done:
+		t.Fatalf("wake loop exited before expired foreground retry: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("wake loop did not accept expired foreground retry tick")
 	}
 
 	select {


### PR DESCRIPTION
## Summary

- add a test synchronization hook after each complete wake notification attempt
- advance the fake clock only after the initial retry state and deadline are committed
- trigger the expanded-cohort scan with an injected maintenance tick instead of watcher timing

## Verification

- unchanged main reproduced the exact failure 2/100
- patched focused test: 200/200 normal and 100/100 with `-race`
- related wake-loop timing tests: 20/20
- `make ci`
- pre-push checks