### PR TITLE
feat(launchapi): public launch intent contract with fail-closed codecs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,10 @@ toolchain go1.26.6
 require (
 	github.com/coder/websocket v1.8.15
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,17 @@
 github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
 golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -86,6 +86,63 @@ func ValidateCommittedConfig(adapter HarnessAdapter, request CommittedConfigRequ
 	return validator.ValidateCommittedConfig(request)
 }
 
+// ValidateStaticProviderInput validates caller-owned provider argv and
+// environment without resolving runtime identity or generating a plan. The
+// executable selects one built-in adapter by basename. Operator bypass flags
+// remain explicit static input, but are accepted only from that adapter's
+// fixed allow-list.
+func ValidateStaticProviderInput(executable string, args []string, env map[string]string) (string, error) {
+	if executable == "" || strings.TrimSpace(executable) != executable || strings.ContainsRune(executable, 0) {
+		return "", fmt.Errorf("executable is invalid")
+	}
+	provider := strings.ToLower(filepath.Base(executable))
+	if runtime.GOOS == "windows" {
+		provider = strings.TrimSuffix(provider, ".exe")
+	}
+	var envRules map[string]valueRule
+	var argRules map[string]argumentRule
+	var bypassAllowed map[string]struct{}
+	switch provider {
+	case ClaudeProvider:
+		envRules, argRules, bypassAllowed = claudeEnvRules(), claudeArgRules(), claudeBypassArgs()
+	case CodexProvider:
+		envRules, argRules, bypassAllowed = codexEnvRules(), codexArgRules(), codexBypassArgs()
+	default:
+		return "", fmt.Errorf("executable %q does not select an adapter-known provider", executable)
+	}
+	if err := validateStaticProviderArgs(args, argRules, bypassAllowed); err != nil {
+		return "", err
+	}
+	if err := validateCommittedEnv(env, envRules); err != nil {
+		return "", err
+	}
+	return provider, nil
+}
+
+func validateStaticProviderArgs(args []string, rules map[string]argumentRule, bypassAllowed map[string]struct{}) error {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if _, ok := bypassAllowed[arg]; ok {
+			continue
+		}
+		rule, ok := rules[arg]
+		if !ok {
+			return fmt.Errorf("static argument %q is not allowed by adapter grammar", arg)
+		}
+		if !rule.value {
+			continue
+		}
+		if i+1 >= len(args) {
+			return fmt.Errorf("static argument %q requires a value", arg)
+		}
+		i++
+		if rule.validate != nil && !rule.validate(args[i]) {
+			return fmt.Errorf("static argument %q has invalid value %q", arg, args[i])
+		}
+	}
+	return nil
+}
+
 type commandProbe interface {
 	LookPath(string) (string, error)
 	Output(context.Context, string, ...string) ([]byte, error)

--- a/internal/launch/static_input_test.go
+++ b/internal/launch/static_input_test.go
@@ -1,0 +1,38 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateStaticProviderInput(t *testing.T) {
+	tests := []struct {
+		name       string
+		executable string
+		args       []string
+		env        map[string]string
+		want       string
+	}{
+		{name: "codex bypass", executable: "/opt/bin/codex", args: []string{"--dangerously-bypass-approvals-and-sandbox"}, env: map[string]string{"LANG": "C"}},
+		{name: "claude bypass", executable: "claude", args: []string{"--dangerously-skip-permissions"}},
+		{name: "unknown provider", executable: "bash", want: "adapter-known"},
+		{name: "provider smuggling", executable: "codex-wrapper", want: "adapter-known"},
+		{name: "unknown argument", executable: "codex", args: []string{"--config", "x=y"}, want: "not allowed"},
+		{name: "bypass value smuggling", executable: "codex", args: []string{"--dangerously-bypass-approvals-and-sandbox", "payload"}, want: "not allowed"},
+		{name: "unknown environment", executable: "claude", env: map[string]string{"CLAUDE_CONFIG_DIR": "/tmp/attacker"}, want: "not allowed"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ValidateStaticProviderInput(test.executable, test.args, test.env)
+			if test.want == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateStaticProviderInput error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -1,0 +1,131 @@
+package launchapi
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const ContractSemverV1 = "0.61.0"
+
+var compatibilityFeaturesV1 = []string{
+	"launch_intent_v1",
+	"prepare_apply_v1",
+	"lifecycle_v1",
+	"managed_tmux_v1",
+	"plan_only_commands_v1",
+}
+
+func Compatibility() CompatibilityV1 {
+	return CompatibilityV1{
+		ContractSemver: ContractSemverV1,
+		IntentVersions: []int{IntentVersionV1},
+		ResultVersions: []int{ResultVersionV1},
+		Features:       slices.Clone(compatibilityFeaturesV1),
+	}
+}
+
+func Negotiate(requirement RequirementV1) (NegotiatedV1, error) {
+	if !semverRangeContains(requirement.ContractSemver, ContractSemverV1) {
+		return NegotiatedV1{}, fmt.Errorf("contract semver %q does not include %s", requirement.ContractSemver, ContractSemverV1)
+	}
+	if requirement.IntentVersion != IntentVersionV1 {
+		return NegotiatedV1{}, fmt.Errorf("unsupported intent version %d", requirement.IntentVersion)
+	}
+	if requirement.ResultVersion != ResultVersionV1 {
+		return NegotiatedV1{}, fmt.Errorf("unsupported result version %d", requirement.ResultVersion)
+	}
+	seen := make(map[string]struct{}, len(requirement.Features))
+	for _, feature := range requirement.Features {
+		if _, ok := seen[feature]; ok {
+			return NegotiatedV1{}, fmt.Errorf("duplicate required feature %q", feature)
+		}
+		seen[feature] = struct{}{}
+		if !slices.Contains(compatibilityFeaturesV1, feature) {
+			return NegotiatedV1{}, fmt.Errorf("unsupported required feature %q", feature)
+		}
+	}
+	features := make([]string, 0, len(requirement.Features))
+	for _, feature := range compatibilityFeaturesV1 {
+		if _, ok := seen[feature]; ok {
+			features = append(features, feature)
+		}
+	}
+	return NegotiatedV1{
+		ContractSemver: ContractSemverV1,
+		IntentVersion:  IntentVersionV1,
+		ResultVersion:  ResultVersionV1,
+		Features:       features,
+	}, nil
+}
+
+type semanticVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+var semanticVersionPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+
+func parseSemanticVersion(value string) (semanticVersion, bool) {
+	match := semanticVersionPattern.FindStringSubmatch(value)
+	if match == nil {
+		return semanticVersion{}, false
+	}
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	patch, _ := strconv.Atoi(match[3])
+	return semanticVersion{major: major, minor: minor, patch: patch}, true
+}
+
+func compareSemanticVersions(left, right semanticVersion) int {
+	if left.major != right.major {
+		return left.major - right.major
+	}
+	if left.minor != right.minor {
+		return left.minor - right.minor
+	}
+	return left.patch - right.patch
+}
+
+func semverRangeContains(requirement, candidate string) bool {
+	candidateVersion, ok := parseSemanticVersion(candidate)
+	if !ok || strings.TrimSpace(requirement) != requirement || requirement == "" {
+		return false
+	}
+	terms := strings.Fields(requirement)
+	if len(terms) == 1 {
+		if exact, exactOK := parseSemanticVersion(terms[0]); exactOK {
+			return compareSemanticVersions(candidateVersion, exact) == 0
+		}
+	}
+	for _, term := range terms {
+		operator := ""
+		versionText := term
+		for _, prefix := range []string{">=", "<=", ">", "<", "="} {
+			if strings.HasPrefix(term, prefix) {
+				operator = prefix
+				versionText = strings.TrimPrefix(term, prefix)
+				break
+			}
+		}
+		version, parsed := parseSemanticVersion(versionText)
+		if !parsed || operator == "" {
+			return false
+		}
+		comparison := compareSemanticVersions(candidateVersion, version)
+		matches := map[string]bool{
+			">=": comparison >= 0,
+			"<=": comparison <= 0,
+			">":  comparison > 0,
+			"<":  comparison < 0,
+			"=":  comparison == 0,
+		}[operator]
+		if !matches {
+			return false
+		}
+	}
+	return true
+}

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -1,0 +1,55 @@
+package launchapi
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCompatibilityAndNegotiateV1(t *testing.T) {
+	compatibility := Compatibility()
+	if compatibility.ContractSemver != "0.61.0" ||
+		!reflect.DeepEqual(compatibility.IntentVersions, []int{1}) ||
+		!reflect.DeepEqual(compatibility.ResultVersions, []int{1}) {
+		t.Fatalf("Compatibility() = %#v", compatibility)
+	}
+	compatibility.Features[0] = "mutated"
+	if Compatibility().Features[0] != "launch_intent_v1" {
+		t.Fatal("Compatibility returned shared mutable feature storage")
+	}
+
+	negotiated, err := Negotiate(RequirementV1{
+		ContractSemver: ">=0.61.0 <0.62.0",
+		IntentVersion:  1,
+		ResultVersion:  1,
+		Features:       []string{"managed_tmux_v1", "launch_intent_v1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(negotiated.Features, []string{"launch_intent_v1", "managed_tmux_v1"}) {
+		t.Fatalf("negotiated features = %v", negotiated.Features)
+	}
+}
+
+func TestNegotiateV1FailsClosed(t *testing.T) {
+	tests := []struct {
+		name        string
+		requirement RequirementV1
+		want        string
+	}{
+		{name: "older contract", requirement: RequirementV1{ContractSemver: "<0.61.0", IntentVersion: 1, ResultVersion: 1}, want: "does not include"},
+		{name: "malformed range", requirement: RequirementV1{ContractSemver: "^0.61", IntentVersion: 1, ResultVersion: 1}, want: "does not include"},
+		{name: "intent version", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 2, ResultVersion: 1}, want: "intent version"},
+		{name: "result version", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 2}, want: "result version"},
+		{name: "unknown feature", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 1, Features: []string{"shell_hooks_v1"}}, want: "unsupported required feature"},
+		{name: "duplicate feature", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 1, Features: []string{"launch_intent_v1", "launch_intent_v1"}}, want: "duplicate required feature"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := Negotiate(test.requirement); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Negotiate error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/launchapi/external_test.go
+++ b/launchapi/external_test.go
@@ -1,0 +1,66 @@
+package launchapi_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestExternalConsumerCompileAndNegotiateV1(t *testing.T) {
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve launchapi test source")
+	}
+	repositoryRoot := filepath.Dir(filepath.Dir(sourceFile))
+	consumer := t.TempDir()
+	goMod := fmt.Sprintf(`module example.com/amq-launch-consumer
+
+go 1.25.0
+
+require github.com/avivsinai/agent-message-queue v0.0.0
+
+replace github.com/avivsinai/agent-message-queue => %s
+`, filepath.ToSlash(repositoryRoot))
+	consumerTest := `package consumer
+
+import (
+    "testing"
+
+    "github.com/avivsinai/agent-message-queue/launchapi"
+)
+
+func TestContract(t *testing.T) {
+    intent := launchapi.LaunchIntentV1{
+        IntentVersion: launchapi.IntentVersionV1,
+        Participants: []launchapi.ParticipantV1{{Handle: "operator", Runnable: false}},
+    }
+    if err := intent.Validate(); err != nil {
+        t.Fatal(err)
+    }
+    negotiated, err := launchapi.Negotiate(launchapi.RequirementV1{
+        ContractSemver: ">=0.61.0 <0.62.0",
+        IntentVersion: 1,
+        ResultVersion: 1,
+        Features: []string{"launch_intent_v1"},
+    })
+    if err != nil || negotiated.ContractSemver != "0.61.0" {
+        t.Fatalf("negotiated=%#v err=%v", negotiated, err)
+    }
+}
+`
+	if err := os.WriteFile(filepath.Join(consumer, "go.mod"), []byte(goMod), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(consumer, "contract_test.go"), []byte(consumerTest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command("go", "test", "-mod=mod", "./...")
+	command.Dir = consumer
+	command.Env = append(os.Environ(), "GOWORK=off")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("external consumer compile: %v\n%s", err, output)
+	}
+}

--- a/launchapi/intent.go
+++ b/launchapi/intent.go
@@ -1,0 +1,339 @@
+package launchapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func DecodeLaunchIntentV1(data []byte) (LaunchIntentV1, error) {
+	var intent LaunchIntentV1
+	if err := decodeStrictJSON(data, &intent); err != nil {
+		return LaunchIntentV1{}, fmt.Errorf("decode launch intent v1: %w", err)
+	}
+	return intent, nil
+}
+
+func (intent *LaunchIntentV1) UnmarshalJSON(data []byte) error {
+	type wireLaunchIntentV1 LaunchIntentV1
+	var decoded wireLaunchIntentV1
+	if err := decodeStrictJSON(data, &decoded); err != nil {
+		return err
+	}
+	if err := requireLaunchIntentFields(data); err != nil {
+		return err
+	}
+	value := LaunchIntentV1(decoded)
+	if err := value.Validate(); err != nil {
+		return err
+	}
+	*intent = value
+	return nil
+}
+
+func MarshalLaunchIntentV1(intent LaunchIntentV1) ([]byte, error) {
+	if err := intent.Validate(); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(intent, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func (intent LaunchIntentV1) Validate() error {
+	if intent.IntentVersion != IntentVersionV1 {
+		return fmt.Errorf("unsupported launch intent version %d", intent.IntentVersion)
+	}
+	if len(intent.Participants) == 0 {
+		return fmt.Errorf("launch intent requires at least one participant")
+	}
+	seen := make(map[string]struct{}, len(intent.Participants))
+	for i, participant := range intent.Participants {
+		if err := participant.validate(); err != nil {
+			return fmt.Errorf("participants[%d]: %w", i, err)
+		}
+		if _, ok := seen[participant.Handle]; ok {
+			return fmt.Errorf("duplicate participant handle %q", participant.Handle)
+		}
+		seen[participant.Handle] = struct{}{}
+	}
+	return nil
+}
+
+func (participant ParticipantV1) validate() error {
+	if err := fsq.ValidateHandle(participant.Handle); err != nil {
+		return fmt.Errorf("invalid handle: %w", err)
+	}
+	if !participant.Runnable {
+		if participant.Executable != "" || participant.Args != nil || participant.Cwd != nil ||
+			participant.EnvOverlay != nil || participant.ResumePolicy != "" || participant.Execution != nil {
+			return fmt.Errorf("non-runnable participant %q must be handle-only", participant.Handle)
+		}
+		return nil
+	}
+	if participant.Executable == "" {
+		return fmt.Errorf("runnable participant %q requires executable", participant.Handle)
+	}
+	if participant.Cwd == nil {
+		return fmt.Errorf("runnable participant %q requires cwd", participant.Handle)
+	}
+	if err := participant.Cwd.validate(); err != nil {
+		return fmt.Errorf("runnable participant %q cwd: %w", participant.Handle, err)
+	}
+	switch participant.ResumePolicy {
+	case ResumePolicyResume, ResumePolicyFresh, ResumePolicyDisabled:
+	default:
+		return fmt.Errorf("runnable participant %q has invalid resume policy %q", participant.Handle, participant.ResumePolicy)
+	}
+	if participant.Execution == nil {
+		return fmt.Errorf("runnable participant %q requires execution options", participant.Handle)
+	}
+	if err := participant.Execution.validate(); err != nil {
+		return fmt.Errorf("runnable participant %q execution: %w", participant.Handle, err)
+	}
+	if _, err := internallaunch.ValidateStaticProviderInput(
+		participant.Executable,
+		participant.Args,
+		participant.EnvOverlay,
+	); err != nil {
+		return fmt.Errorf("runnable participant %q: %w", participant.Handle, err)
+	}
+	return nil
+}
+
+func (cwd WorkingDirectoryV1) validate() error {
+	if cwd.Path == "" || !utf8.ValidString(cwd.Path) || strings.ContainsRune(cwd.Path, 0) {
+		return fmt.Errorf("path is invalid")
+	}
+	if filepath.Clean(cwd.Path) != cwd.Path {
+		return fmt.Errorf("path must be clean")
+	}
+	switch cwd.Kind {
+	case WorkingDirectoryRelative:
+		if filepath.IsAbs(cwd.Path) {
+			return fmt.Errorf("relative path must not be absolute")
+		}
+		for _, part := range strings.FieldsFunc(cwd.Path, func(r rune) bool { return r == '/' || r == '\\' }) {
+			if part == ".." {
+				return fmt.Errorf("relative path must not escape its project root")
+			}
+		}
+	case WorkingDirectoryAbsolute:
+		if !filepath.IsAbs(cwd.Path) {
+			return fmt.Errorf("absolute path is required")
+		}
+	default:
+		return fmt.Errorf("invalid kind %q", cwd.Kind)
+	}
+	return nil
+}
+
+func (options ExecutionOptionsV1) validate() error {
+	wake := options.Wake
+	switch wake.Mode {
+	case WakeDisabled:
+		if strings.TrimSpace(wake.AuditReason) == "" {
+			return fmt.Errorf("disabled wake requires an audit reason")
+		}
+		if options.RequireWake {
+			return fmt.Errorf("require_wake conflicts with disabled wake")
+		}
+		if wake.Injector != nil {
+			return fmt.Errorf("disabled wake forbids injector settings")
+		}
+	case WakeEnabled:
+		if wake.AuditReason != "" {
+			return fmt.Errorf("enabled wake forbids a disabled-wake audit reason")
+		}
+	default:
+		return fmt.Errorf("invalid wake mode %q", wake.Mode)
+	}
+	if wake.Injector != nil {
+		if err := wake.Injector.validate(); err != nil {
+			return err
+		}
+	}
+	if options.Integrations.Symphony != nil {
+		if err := options.Integrations.Symphony.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (injector InjectorOptionsV1) validate() error {
+	switch injector.Mode {
+	case InjectorAuto, InjectorRaw, InjectorPaste, InjectorNone:
+	default:
+		return fmt.Errorf("invalid injector mode %q", injector.Mode)
+	}
+	if injector.Mode == InjectorNone && (injector.Via != "" || len(injector.Args) > 0) {
+		return fmt.Errorf("injector mode none forbids via and args")
+	}
+	if injector.Via != "" {
+		if !filepath.IsAbs(injector.Via) || filepath.Clean(injector.Via) != injector.Via || strings.ContainsRune(injector.Via, 0) {
+			return fmt.Errorf("injector via must be a clean absolute path")
+		}
+	} else if len(injector.Args) > 0 {
+		return fmt.Errorf("injector args require via")
+	}
+	for _, arg := range injector.Args {
+		if !utf8.ValidString(arg) || strings.ContainsRune(arg, 0) {
+			return fmt.Errorf("injector args contain an invalid value")
+		}
+	}
+	return nil
+}
+
+func (symphony SymphonyOptionsV1) validate() error {
+	if len(symphony.Events) == 0 {
+		return fmt.Errorf("symphony requires at least one event")
+	}
+	seen := make(map[SymphonyEvent]struct{}, len(symphony.Events))
+	allowed := []SymphonyEvent{
+		SymphonyAfterCreate,
+		SymphonyBeforeRun,
+		SymphonyAfterRun,
+		SymphonyBeforeRemove,
+	}
+	for _, event := range symphony.Events {
+		if !slices.Contains(allowed, event) {
+			return fmt.Errorf("unknown symphony event %q", event)
+		}
+		if _, ok := seen[event]; ok {
+			return fmt.Errorf("duplicate symphony event %q", event)
+		}
+		seen[event] = struct{}{}
+	}
+	if strings.ContainsRune(symphony.WorkspaceKey, 0) || !utf8.ValidString(symphony.WorkspaceKey) {
+		return fmt.Errorf("symphony workspace_key is invalid")
+	}
+	return nil
+}
+
+func requireLaunchIntentFields(data []byte) error {
+	var document struct {
+		IntentVersion json.RawMessage              `json:"intent_version"`
+		Participants  []map[string]json.RawMessage `json:"participants"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		return fmt.Errorf("inspect launch intent fields: %w", err)
+	}
+	if document.IntentVersion == nil {
+		return fmt.Errorf("launch intent requires intent_version")
+	}
+	if document.Participants == nil {
+		return fmt.Errorf("launch intent requires participants")
+	}
+	for i, fields := range document.Participants {
+		if fields["handle"] == nil {
+			return fmt.Errorf("participants[%d] requires handle", i)
+		}
+		if fields["runnable"] == nil {
+			return fmt.Errorf("participants[%d] requires runnable", i)
+		}
+		if bytes.Equal(bytes.TrimSpace(fields["runnable"]), []byte("null")) {
+			return fmt.Errorf("participants[%d] runnable must be a boolean", i)
+		}
+		var runnable bool
+		if err := json.Unmarshal(fields["runnable"], &runnable); err != nil {
+			return fmt.Errorf("participants[%d] runnable: %w", i, err)
+		}
+		if !runnable && len(fields) != 2 {
+			return fmt.Errorf("participants[%d] non-runnable participant must contain exactly handle and runnable", i)
+		}
+		if runnable {
+			for _, required := range []string{"executable", "cwd", "resume_policy", "execution"} {
+				if fields[required] == nil {
+					return fmt.Errorf("participants[%d] requires %s", i, required)
+				}
+			}
+			if err := requireObjectFields(fields["cwd"], fmt.Sprintf("participants[%d].cwd", i), "kind", "path"); err != nil {
+				return err
+			}
+			for _, optional := range []string{"args", "env_overlay"} {
+				if err := rejectExplicitNull(fields, optional, fmt.Sprintf("participants[%d]", i)); err != nil {
+					return err
+				}
+			}
+			var execution map[string]json.RawMessage
+			if err := json.Unmarshal(fields["execution"], &execution); err != nil || execution == nil {
+				return fmt.Errorf("participants[%d].execution must be an object", i)
+			}
+			for _, required := range []string{"require_wake", "no_gitignore", "wake"} {
+				if execution[required] == nil {
+					return fmt.Errorf("participants[%d].execution requires %s", i, required)
+				}
+			}
+			if err := requireObjectFields(execution["wake"], fmt.Sprintf("participants[%d].execution.wake", i), "mode"); err != nil {
+				return err
+			}
+			if err := rejectExplicitNull(execution, "integrations", fmt.Sprintf("participants[%d].execution", i)); err != nil {
+				return err
+			}
+			var wake map[string]json.RawMessage
+			if err := json.Unmarshal(execution["wake"], &wake); err != nil {
+				return fmt.Errorf("participants[%d].execution.wake must be an object", i)
+			}
+			if err := rejectExplicitNull(wake, "injector", fmt.Sprintf("participants[%d].execution.wake", i)); err != nil {
+				return err
+			}
+			if integrationsRaw := execution["integrations"]; integrationsRaw != nil {
+				var integrations map[string]json.RawMessage
+				if err := json.Unmarshal(integrationsRaw, &integrations); err != nil || integrations == nil {
+					return fmt.Errorf("participants[%d].execution.integrations must be an object", i)
+				}
+				if err := rejectExplicitNull(integrations, "symphony", fmt.Sprintf("participants[%d].execution.integrations", i)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func rejectExplicitNull(fields map[string]json.RawMessage, field, context string) error {
+	raw, present := fields[field]
+	if present && bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return fmt.Errorf("%s.%s must not be null", context, field)
+	}
+	return nil
+}
+
+func requireObjectFields(raw json.RawMessage, context string, required ...string) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+		return fmt.Errorf("%s must be an object", context)
+	}
+	for _, field := range required {
+		if fields[field] == nil || bytes.Equal(bytes.TrimSpace(fields[field]), []byte("null")) {
+			return fmt.Errorf("%s requires %s", context, field)
+		}
+	}
+	return nil
+}
+
+func decodeStrictJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}

--- a/launchapi/intent_test.go
+++ b/launchapi/intent_test.go
@@ -1,0 +1,187 @@
+package launchapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func validIntentJSON(t *testing.T) string {
+	t.Helper()
+	return `{
+  "intent_version": 1,
+  "participants": [
+    {"handle":"operator","runnable":false},
+    {
+      "handle":"codex",
+      "runnable":true,
+      "executable":"codex",
+      "args":["--dangerously-bypass-approvals-and-sandbox"],
+      "cwd":{"kind":"absolute","path":` + quotedJSON(t, filepath.Clean(t.TempDir())) + `},
+      "env_overlay":{"LANG":"C"},
+      "resume_policy":"resume",
+      "execution":{
+        "require_wake":true,
+        "no_gitignore":true,
+        "wake":{"mode":"enabled","injector":{"mode":"raw","via":"/opt/amq/inject","args":["send"]}},
+        "integrations":{"symphony":{"events":["after_create","before_run","after_run","before_remove"],"workspace_key":"team-17"}}
+      }
+    }
+  ]
+}`
+}
+
+func quotedJSON(t *testing.T, value string) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func TestLaunchIntentRejectsAMQOwnedFields(t *testing.T) {
+	base := `{"intent_version":1,"participants":[{"handle":"codex","runnable":true,"executable":"codex","cwd":{"kind":"relative","path":"."},"resume_policy":"fresh","execution":{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled"}}}]}`
+	for _, field := range []string{
+		"adapter_mode",
+		"launch_nonce",
+		"conversation_id",
+		"dynamic_argv",
+		"unknown",
+	} {
+		t.Run(field, func(t *testing.T) {
+			hostile := strings.Replace(base, `"runnable":true`, `"runnable":true,"`+field+`":"forged"`, 1)
+			if _, err := DecodeLaunchIntentV1([]byte(hostile)); err == nil || !strings.Contains(err.Error(), "unknown field") {
+				t.Fatalf("DecodeLaunchIntentV1(%s) error = %v, want unknown-field refusal", field, err)
+			}
+		})
+	}
+}
+
+func TestLaunchIntentNonRunnableIsHandleOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "missing runnable", raw: `{"intent_version":1,"participants":[{"handle":"operator"}]}`, want: "requires runnable"},
+		{name: "omitted participants", raw: `{"intent_version":1}`, want: "requires participants"},
+		{name: "extra executable", raw: `{"intent_version":1,"participants":[{"handle":"operator","runnable":false,"executable":"codex"}]}`, want: "exactly handle and runnable"},
+		{name: "extra empty args", raw: `{"intent_version":1,"participants":[{"handle":"operator","runnable":false,"args":[]}]}`, want: "exactly handle and runnable"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := DecodeLaunchIntentV1([]byte(test.raw)); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DecodeLaunchIntentV1 error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLaunchIntentV1AcceptsSiblingWorktreeAndZeroRunnable(t *testing.T) {
+	intent, err := DecodeLaunchIntentV1([]byte(validIntentJSON(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(intent.Participants) != 2 || intent.Participants[0].Runnable || !intent.Participants[1].Runnable {
+		t.Fatalf("participants = %#v", intent.Participants)
+	}
+
+	participantOnly, err := DecodeLaunchIntentV1([]byte(`{"intent_version":1,"participants":[{"handle":"operator","runnable":false}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if participantOnly.Participants[0].Runnable {
+		t.Fatal("participant-only intent became runnable")
+	}
+}
+
+func TestLaunchIntentV1RejectsHostileTypedOptions(t *testing.T) {
+	base := `{"intent_version":1,"participants":[{"handle":"codex","runnable":true,"executable":"codex","cwd":{"kind":"relative","path":"."},"resume_policy":"fresh","execution":%s}]}`
+	tests := []struct {
+		name      string
+		execution string
+		want      string
+	}{
+		{name: "disabled without reason", execution: `{"require_wake":false,"no_gitignore":false,"wake":{"mode":"disabled"}}`, want: "audit reason"},
+		{name: "require disabled", execution: `{"require_wake":true,"no_gitignore":false,"wake":{"mode":"disabled","audit_reason":"operator policy"}}`, want: "conflicts"},
+		{name: "relative injector", execution: `{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled","injector":{"mode":"raw","via":"bin/inject"}}}`, want: "absolute"},
+		{name: "args without via", execution: `{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled","injector":{"mode":"raw","args":["send"]}}}`, want: "require via"},
+		{name: "unknown symphony event", execution: `{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled"},"integrations":{"symphony":{"events":["after_create","shell_hook"]}}}`, want: "unknown symphony event"},
+		{name: "arbitrary hook", execution: `{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled"},"hooks":{"before_run":"touch /tmp/pwned"}}`, want: "unknown field"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := DecodeLaunchIntentV1([]byte(strings.Replace(base, "%s", test.execution, 1)))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DecodeLaunchIntentV1 error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLaunchIntentV1RejectsExplicitNullSmuggling(t *testing.T) {
+	base := `{"intent_version":1,"participants":[{"handle":"codex","runnable":true,"executable":"codex","args":[],"cwd":{"kind":"relative","path":"."},"env_overlay":{},"resume_policy":"fresh","execution":{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled","injector":{"mode":"none"}},"integrations":{"symphony":{"events":["after_create"]}}}}]}`
+	for _, replacement := range []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{name: "args", old: `"args":[]`, new: `"args":null`},
+		{name: "env", old: `"env_overlay":{}`, new: `"env_overlay":null`},
+		{name: "injector", old: `"injector":{"mode":"none"}`, new: `"injector":null`},
+		{name: "integrations", old: `"integrations":{"symphony":{"events":["after_create"]}}`, new: `"integrations":null`},
+		{name: "symphony", old: `"symphony":{"events":["after_create"]}`, new: `"symphony":null`},
+	} {
+		t.Run(replacement.name, func(t *testing.T) {
+			raw := strings.Replace(base, replacement.old, replacement.new, 1)
+			if _, err := DecodeLaunchIntentV1([]byte(raw)); err == nil || !strings.Contains(err.Error(), "must not be null") {
+				t.Fatalf("DecodeLaunchIntentV1 error = %v", err)
+			}
+		})
+	}
+}
+
+func TestLaunchIntentV1UsesAdapterDenyByDefaultGrammar(t *testing.T) {
+	base := `{"intent_version":1,"participants":[{"handle":"codex","runnable":true,"executable":%s,"args":%s,"env_overlay":%s,"cwd":{"kind":"relative","path":"."},"resume_policy":"fresh","execution":{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled"}}}]}`
+	tests := []struct {
+		name       string
+		executable string
+		args       string
+		env        string
+		want       string
+	}{
+		{name: "unknown provider", executable: "bash", args: `[]`, env: `{}`, want: "adapter-known provider"},
+		{name: "unknown flag", executable: "codex", args: `["--config","pwned=true"]`, env: `{}`, want: "not allowed"},
+		{name: "unknown env", executable: "codex", args: `[]`, env: `{"CODEX_HOME":"/tmp/attacker"}`, want: "not allowed"},
+		{name: "forged model value", executable: "codex", args: `["--model","--sandbox"]`, env: `{}`, want: "invalid value"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := fmt.Sprintf(base, quotedJSON(t, test.executable), test.args, test.env)
+			if _, err := DecodeLaunchIntentV1([]byte(raw)); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DecodeLaunchIntentV1 error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLaunchIntentV1MarshalRoundTrip(t *testing.T) {
+	intent, err := DecodeLaunchIntentV1([]byte(validIntentJSON(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := MarshalLaunchIntentV1(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := DecodeLaunchIntentV1(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Participants) != len(intent.Participants) {
+		t.Fatalf("round-trip participant count = %d, want %d", len(decoded.Participants), len(intent.Participants))
+	}
+}

--- a/launchapi/requests.go
+++ b/launchapi/requests.go
@@ -1,0 +1,144 @@
+package launchapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+func ValidateDigest(digest string) error {
+	if !digestPattern.MatchString(digest) {
+		return fmt.Errorf("digest must be canonical sha256:<lowercase-hex>")
+	}
+	return nil
+}
+
+func DecodePrepareRequestV1(data []byte) (PrepareRequestV1, error) {
+	var request PrepareRequestV1
+	if err := decodeStrictJSON(data, &request); err != nil {
+		return PrepareRequestV1{}, fmt.Errorf("decode prepare request v1: %w", err)
+	}
+	if err := request.Validate(); err != nil {
+		return PrepareRequestV1{}, err
+	}
+	return request, nil
+}
+
+func (request PrepareRequestV1) Validate() error {
+	if request.RequestVersion != RequestVersionV1 {
+		return fmt.Errorf("unsupported prepare request version %d", request.RequestVersion)
+	}
+	if err := request.Target.validate(); err != nil {
+		return err
+	}
+	if !slices.Contains([]string{"auto", "cmux", "ghostty", "tmux", "commands"}, request.Launcher) {
+		return fmt.Errorf("unsupported launcher %q", request.Launcher)
+	}
+	return request.Intent.Validate()
+}
+
+func DecodeApplyRequestV1(data []byte) (ApplyRequestV1, error) {
+	var request ApplyRequestV1
+	if err := decodeStrictJSON(data, &request); err != nil {
+		return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: %w", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return ApplyRequestV1{}, fmt.Errorf("inspect apply request fields: %w", err)
+	}
+	if fields["decisions"] == nil || bytes.Equal(bytes.TrimSpace(fields["decisions"]), []byte("null")) {
+		return ApplyRequestV1{}, fmt.Errorf("apply request requires decisions array")
+	}
+	if err := request.Validate(); err != nil {
+		return ApplyRequestV1{}, err
+	}
+	return request, nil
+}
+
+func (request ApplyRequestV1) Validate() error {
+	if request.RequestVersion != RequestVersionV1 {
+		return fmt.Errorf("unsupported apply request version %d", request.RequestVersion)
+	}
+	if err := request.Prepare.Validate(); err != nil {
+		return fmt.Errorf("prepare: %w", err)
+	}
+	if err := ValidateDigest(request.SubjectDigest); err != nil {
+		return fmt.Errorf("subject_digest: %w", err)
+	}
+	seen := make(map[string]struct{}, len(request.Decisions))
+	allowedChoices := []string{
+		"trust_exact_subject",
+		"deny",
+		"fresh_once",
+		"abort",
+		"close_old",
+		"leave_old",
+		"accept_degraded",
+	}
+	for i, decision := range request.Decisions {
+		if strings.TrimSpace(decision.ActionID) == "" || strings.TrimSpace(decision.Choice) == "" {
+			return fmt.Errorf("decisions[%d] requires action_id and choice", i)
+		}
+		if _, ok := seen[decision.ActionID]; ok {
+			return fmt.Errorf("duplicate decision for action %q", decision.ActionID)
+		}
+		if !slices.Contains(allowedChoices, decision.Choice) {
+			return fmt.Errorf("decisions[%d] has invalid choice %q", i, decision.Choice)
+		}
+		seen[decision.ActionID] = struct{}{}
+	}
+	return nil
+}
+
+func DecodeInspectRequestV1(data []byte) (InspectRequestV1, error) {
+	var request InspectRequestV1
+	if err := decodeStrictJSON(data, &request); err != nil {
+		return InspectRequestV1{}, fmt.Errorf("decode inspect request v1: %w", err)
+	}
+	if err := request.validate(); err != nil {
+		return InspectRequestV1{}, err
+	}
+	return request, nil
+}
+
+func DecodeFocusRequestV1(data []byte) (FocusRequestV1, error) {
+	request, err := DecodeInspectRequestV1(data)
+	return FocusRequestV1(request), err
+}
+
+func DecodeCloseRequestV1(data []byte) (CloseRequestV1, error) {
+	request, err := DecodeInspectRequestV1(data)
+	return CloseRequestV1(request), err
+}
+
+func (request InspectRequestV1) validate() error {
+	if request.RequestVersion != RequestVersionV1 {
+		return fmt.Errorf("unsupported lifecycle request version %d", request.RequestVersion)
+	}
+	return request.Target.validate()
+}
+
+func (target TargetV1) validate() error {
+	if !cleanAbsolutePath(target.ProjectRoot) {
+		return fmt.Errorf("target project_root must be a clean absolute path")
+	}
+	if !cleanAbsolutePath(target.SessionRoot) {
+		return fmt.Errorf("target session_root must be a clean absolute path")
+	}
+	if err := fsq.ValidateHandle(target.Session); err != nil {
+		return fmt.Errorf("invalid target session: %w", err)
+	}
+	return nil
+}
+
+func cleanAbsolutePath(path string) bool {
+	return filepath.IsAbs(path) && filepath.Clean(path) == path && !strings.ContainsRune(path, 0)
+}

--- a/launchapi/requests_test.go
+++ b/launchapi/requests_test.go
@@ -1,0 +1,90 @@
+package launchapi
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPublicRequestCodecsRejectUnknownAndMalformedAuthority(t *testing.T) {
+	root := filepath.Clean(t.TempDir())
+	intent, err := DecodeLaunchIntentV1([]byte(validIntentJSON(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepare := PrepareRequestV1{
+		RequestVersion: 1,
+		Target:         TargetV1{ProjectRoot: root, SessionRoot: filepath.Join(root, ".agent-mail", "collab"), Session: "collab"},
+		Launcher:       "auto",
+		Intent:         intent,
+	}
+	raw, err := json.Marshal(prepare)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodePrepareRequestV1(raw); err != nil {
+		t.Fatal(err)
+	}
+	hostile := strings.Replace(string(raw), `"launcher":"auto"`, `"launcher":"auto","binding":{"resource":"foreign"}`, 1)
+	if _, err := DecodePrepareRequestV1([]byte(hostile)); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("hostile Prepare error = %v", err)
+	}
+	missingRunnable := strings.Replace(string(raw), `"runnable":false`, `"runnable_omitted":false`, 1)
+	if _, err := DecodePrepareRequestV1([]byte(missingRunnable)); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("nested hostile Prepare error = %v", err)
+	}
+
+	prepare.Target.ProjectRoot = "relative"
+	raw, _ = json.Marshal(prepare)
+	if _, err := DecodePrepareRequestV1(raw); err == nil || !strings.Contains(err.Error(), "clean absolute") {
+		t.Fatalf("relative project root error = %v", err)
+	}
+}
+
+func TestApplyRequestV1RejectsDigestAndDecisionReplayShapes(t *testing.T) {
+	root := filepath.Clean(t.TempDir())
+	intent, err := DecodeLaunchIntentV1([]byte(validIntentJSON(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequestV1{
+		RequestVersion: 1,
+		Prepare: PrepareRequestV1{
+			RequestVersion: 1,
+			Target:         TargetV1{ProjectRoot: root, SessionRoot: filepath.Join(root, ".agent-mail", "collab"), Session: "collab"},
+			Launcher:       "commands",
+			Intent:         intent,
+		},
+		SubjectDigest: "sha256:" + strings.Repeat("a", 64),
+		Decisions:     []DecisionV1{{ActionID: "trust:1", Choice: "trust_exact_subject"}},
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	request.SubjectDigest = "sha256:ABC"
+	if err := request.Validate(); err == nil || !strings.Contains(err.Error(), "canonical") {
+		t.Fatalf("invalid digest error = %v", err)
+	}
+	request.SubjectDigest = "sha256:" + strings.Repeat("a", 64)
+	request.Decisions[0].Choice = "replay_forever"
+	if err := request.Validate(); err == nil || !strings.Contains(err.Error(), "invalid choice") {
+		t.Fatalf("invalid choice error = %v", err)
+	}
+	request.Decisions[0].Choice = "trust_exact_subject"
+	request.Decisions = append(request.Decisions, request.Decisions[0])
+	if err := request.Validate(); err == nil || !strings.Contains(err.Error(), "duplicate decision") {
+		t.Fatalf("duplicate decision error = %v", err)
+	}
+
+	request.Decisions = nil
+	raw, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = []byte(strings.Replace(string(raw), `,"decisions":null`, ``, 1))
+	if _, err := DecodeApplyRequestV1(raw); err == nil || !strings.Contains(err.Error(), "requires decisions") {
+		t.Fatalf("missing decisions error = %v", err)
+	}
+}

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -1,0 +1,161 @@
+package launchapi
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func TestLaunchAPIV1SchemaContract(t *testing.T) {
+	raw, err := os.ReadFile("../schemas/launch-api-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("parse launch API schema: %v", err)
+	}
+	defs := objectMap(t, schema["$defs"], "$defs")
+	for _, name := range []string{
+		"LaunchIntentV1", "ParticipantV1", "WorkingDirectoryV1", "ExecutionOptionsV1",
+		"WakeOptionsV1", "InjectorOptionsV1", "IntegrationsV1", "SymphonyOptionsV1",
+		"TargetV1", "PrepareRequestV1", "PrepareResultV1", "ApplyRequestV1", "ApplyResultV1",
+		"DecisionV1", "ParticipantObservationV1", "CompatibilityV1", "RequirementV1", "NegotiatedV1",
+		"InspectRequestV1", "FocusRequestV1", "CloseRequestV1",
+		"InspectResultV1", "FocusResultV1", "CloseResultV1",
+	} {
+		if defs[name] == nil {
+			t.Errorf("schema omits named definition %s", name)
+		}
+	}
+	for name, rawDefinition := range defs {
+		definition := objectMap(t, rawDefinition, "$defs."+name)
+		if definition["type"] == "object" && definition["additionalProperties"] != false {
+			t.Errorf("schema object %s is not fail-closed", name)
+		}
+	}
+
+	assertSchemaPropertiesMatchType(t, defs, "LaunchIntentV1", reflect.TypeFor[LaunchIntentV1]())
+	runnableFields := jsonFieldNames(reflect.TypeFor[ParticipantV1]())
+	assertStringSetsEqual(t, schemaPropertyNames(t, defs, "RunnableParticipantV1"), runnableFields, "runnable participant fields")
+	assertStringSetsEqual(
+		t,
+		schemaPropertyNames(t, defs, "NonRunnableParticipantV1"),
+		[]string{"handle", "runnable"},
+		"non-runnable participant fields",
+	)
+
+	prepareProperties := schemaProperties(t, defs, "PrepareResultV1")
+	applyProperties := schemaProperties(t, defs, "ApplyResultV1")
+	for _, field := range []string{"subject_digest", "plan_digest", "trust_digest"} {
+		want := "#/$defs/Digest"
+		if got := objectMap(t, prepareProperties[field], "PrepareResultV1."+field)["$ref"]; got != want {
+			t.Errorf("PrepareResultV1.%s ref = %v, want %s", field, got, want)
+		}
+		if got := objectMap(t, applyProperties[field], "ApplyResultV1."+field)["$ref"]; got != want {
+			t.Errorf("ApplyResultV1.%s ref = %v, want %s", field, got, want)
+		}
+	}
+	if got := objectMap(t, applyProperties["semantic_digest"], "ApplyResultV1.semantic_digest")["$ref"]; got != "#/$defs/Digest" {
+		t.Errorf("ApplyResultV1.semantic_digest ref = %v", got)
+	}
+}
+
+func TestLaunchAPIV1SchemaAcceptsGoldenAndRejectsHostileFields(t *testing.T) {
+	raw, err := os.ReadFile("../schemas/launch-api-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(raw, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("launch-api-v1.schema.json", schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("launch-api-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var golden map[string]any
+	if err := json.Unmarshal([]byte(validIntentJSON(t)), &golden); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(golden); err != nil {
+		t.Fatalf("schema rejected package golden: %v", err)
+	}
+
+	participants := golden["participants"].([]any)
+	runnable := participants[1].(map[string]any)
+	for _, field := range []string{"adapter_mode", "launch_nonce", "conversation_id", "dynamic_argv"} {
+		runnable[field] = "forged"
+		if err := schema.Validate(golden); err == nil {
+			t.Errorf("schema accepted AMQ-owned field %q", field)
+		}
+		delete(runnable, field)
+	}
+	nonRunnable := participants[0].(map[string]any)
+	nonRunnable["args"] = []any{}
+	if err := schema.Validate(golden); err == nil {
+		t.Error("schema accepted non-runnable args smuggling")
+	}
+}
+
+func assertSchemaPropertiesMatchType(t *testing.T, defs map[string]any, definition string, typ reflect.Type) {
+	t.Helper()
+	assertStringSetsEqual(t, schemaPropertyNames(t, defs, definition), jsonFieldNames(typ), definition+" fields")
+}
+
+func schemaPropertyNames(t *testing.T, defs map[string]any, definition string) []string {
+	t.Helper()
+	properties := schemaProperties(t, defs, definition)
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func schemaProperties(t *testing.T, defs map[string]any, definition string) map[string]any {
+	t.Helper()
+	def := objectMap(t, defs[definition], "$defs."+definition)
+	return objectMap(t, def["properties"], "$defs."+definition+".properties")
+}
+
+func jsonFieldNames(typ reflect.Type) []string {
+	names := make([]string, 0, typ.NumField())
+	for i := 0; i < typ.NumField(); i++ {
+		name := strings.Split(typ.Field(i).Tag.Get("json"), ",")[0]
+		if name != "" && name != "-" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func assertStringSetsEqual(t *testing.T, got, want []string, context string) {
+	t.Helper()
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("%s = %v, want %v", context, got, want)
+	}
+}
+
+func objectMap(t *testing.T, value any, context string) map[string]any {
+	t.Helper()
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want object", context, value)
+	}
+	return object
+}

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -1,0 +1,258 @@
+// Package launchapi defines AMQ's versioned public launch-intent contract.
+// Runtime plans, roots, leases, bindings, journals, and backend mutation stay
+// owned by internal/launch and are not represented by caller-writable types.
+package launchapi
+
+import "time"
+
+const (
+	IntentVersionV1  = 1
+	RequestVersionV1 = 1
+	ResultVersionV1  = 1
+)
+
+type ResumePolicy string
+
+const (
+	ResumePolicyResume   ResumePolicy = "resume"
+	ResumePolicyFresh    ResumePolicy = "fresh"
+	ResumePolicyDisabled ResumePolicy = "disabled"
+)
+
+type WorkingDirectoryKind string
+
+const (
+	WorkingDirectoryRelative WorkingDirectoryKind = "relative"
+	WorkingDirectoryAbsolute WorkingDirectoryKind = "absolute"
+)
+
+type WakePolicy string
+
+const (
+	WakeEnabled  WakePolicy = "enabled"
+	WakeDisabled WakePolicy = "disabled"
+)
+
+type InjectorMode string
+
+const (
+	InjectorAuto  InjectorMode = "auto"
+	InjectorRaw   InjectorMode = "raw"
+	InjectorPaste InjectorMode = "paste"
+	InjectorNone  InjectorMode = "none"
+)
+
+type SymphonyEvent string
+
+const (
+	SymphonyAfterCreate  SymphonyEvent = "after_create"
+	SymphonyBeforeRun    SymphonyEvent = "before_run"
+	SymphonyAfterRun     SymphonyEvent = "after_run"
+	SymphonyBeforeRemove SymphonyEvent = "before_remove"
+)
+
+type LaunchIntentV1 struct {
+	IntentVersion int             `json:"intent_version"`
+	Participants  []ParticipantV1 `json:"participants"`
+}
+
+type ParticipantV1 struct {
+	Handle       string              `json:"handle"`
+	Runnable     bool                `json:"runnable"`
+	Executable   string              `json:"executable,omitempty"`
+	Args         []string            `json:"args,omitempty"`
+	Cwd          *WorkingDirectoryV1 `json:"cwd,omitempty"`
+	EnvOverlay   map[string]string   `json:"env_overlay,omitempty"`
+	ResumePolicy ResumePolicy        `json:"resume_policy,omitempty"`
+	Execution    *ExecutionOptionsV1 `json:"execution,omitempty"`
+}
+
+type WorkingDirectoryV1 struct {
+	Kind WorkingDirectoryKind `json:"kind"`
+	Path string               `json:"path"`
+}
+
+type ExecutionOptionsV1 struct {
+	RequireWake  bool           `json:"require_wake"`
+	NoGitignore  bool           `json:"no_gitignore"`
+	Wake         WakeOptionsV1  `json:"wake"`
+	Integrations IntegrationsV1 `json:"integrations,omitempty"`
+}
+
+type WakeOptionsV1 struct {
+	Mode        WakePolicy         `json:"mode"`
+	AuditReason string             `json:"audit_reason,omitempty"`
+	Injector    *InjectorOptionsV1 `json:"injector,omitempty"`
+}
+
+type IntegrationsV1 struct {
+	Symphony *SymphonyOptionsV1 `json:"symphony,omitempty"`
+}
+
+type InjectorOptionsV1 struct {
+	Mode InjectorMode `json:"mode"`
+	Via  string       `json:"via,omitempty"`
+	Args []string     `json:"args,omitempty"`
+}
+
+type SymphonyOptionsV1 struct {
+	Events       []SymphonyEvent `json:"events"`
+	WorkspaceKey string          `json:"workspace_key,omitempty"`
+}
+
+type TargetV1 struct {
+	ProjectRoot string `json:"project_root"`
+	SessionRoot string `json:"session_root"`
+	Session     string `json:"session"`
+}
+
+type PrepareRequestV1 struct {
+	RequestVersion int            `json:"request_version"`
+	Target         TargetV1       `json:"target"`
+	Launcher       string         `json:"launcher"`
+	Intent         LaunchIntentV1 `json:"intent"`
+}
+
+type RequiredActionV1 struct {
+	ActionID         string   `json:"action_id"`
+	Kind             string   `json:"kind"`
+	Handles          []string `json:"handles,omitempty"`
+	Resources        []string `json:"resources,omitempty"`
+	AllowedDecisions []string `json:"allowed_decisions"`
+	ReasonCode       string   `json:"reason_code"`
+}
+
+type CommandV1 struct {
+	Argv       []string          `json:"argv"`
+	Cwd        string            `json:"cwd"`
+	EnvOverlay map[string]string `json:"env_overlay,omitempty"`
+}
+
+type RosterDriftV1 struct {
+	Desired []string `json:"desired"`
+	Present []string `json:"present"`
+	Missing []string `json:"missing"`
+	Extra   []string `json:"extra"`
+}
+
+type ParticipantPreviewV1 struct {
+	Handle         string              `json:"handle"`
+	Runnable       bool                `json:"runnable"`
+	Provider       string              `json:"provider,omitempty"`
+	Command        *CommandV1          `json:"command,omitempty"`
+	ResumePolicy   ResumePolicy        `json:"resume_policy,omitempty"`
+	Execution      *ExecutionOptionsV1 `json:"execution,omitempty"`
+	PlannedOutcome string              `json:"planned_outcome"`
+}
+
+type PreviewV1 struct {
+	Target       TargetV1               `json:"target"`
+	Backend      string                 `json:"backend"`
+	Profile      string                 `json:"profile"`
+	Participants []ParticipantPreviewV1 `json:"participants"`
+	Roster       RosterDriftV1          `json:"roster"`
+}
+
+type ParticipantObservationV1 struct {
+	Handle       string `json:"handle"`
+	Mailbox      string `json:"mailbox"`
+	Runnable     bool   `json:"runnable"`
+	Conversation string `json:"conversation"`
+	Execution    string `json:"execution"`
+	Resource     string `json:"resource"`
+	ReasonCode   string `json:"reason_code,omitempty"`
+}
+
+type PrepareResultV1 struct {
+	ResultVersion   int                        `json:"result_version"`
+	Outcome         string                     `json:"outcome"`
+	Reason          string                     `json:"reason,omitempty"`
+	SubjectDigest   string                     `json:"subject_digest"`
+	PlanDigest      string                     `json:"plan_digest"`
+	TrustDigest     string                     `json:"trust_digest"`
+	RequiredActions []RequiredActionV1         `json:"required_actions"`
+	Preview         PreviewV1                  `json:"preview"`
+	Observations    []ParticipantObservationV1 `json:"observations"`
+}
+
+type DecisionV1 struct {
+	ActionID string `json:"action_id"`
+	Choice   string `json:"choice"`
+}
+
+type ApplyRequestV1 struct {
+	RequestVersion int              `json:"request_version"`
+	Prepare        PrepareRequestV1 `json:"prepare"`
+	SubjectDigest  string           `json:"subject_digest"`
+	Decisions      []DecisionV1     `json:"decisions"`
+}
+
+type EvidenceRefV1 struct {
+	EvidenceVersion int       `json:"evidence_version"`
+	ID              string    `json:"id"`
+	Kind            string    `json:"kind"`
+	SHA256          string    `json:"sha256"`
+	ObservedAt      time.Time `json:"observed_at"`
+}
+
+type ApplyResultV1 struct {
+	ResultVersion int    `json:"result_version"`
+	Outcome       string `json:"outcome"`
+	ReasonCode    string `json:"reason_code,omitempty"`
+	SubjectDigest string `json:"subject_digest"`
+	PlanDigest    string `json:"plan_digest"`
+	TrustDigest   string `json:"trust_digest"`
+	// SemanticDigest is a deprecated compatibility alias of TrustDigest.
+	SemanticDigest string                     `json:"semantic_digest"`
+	Backend        string                     `json:"backend"`
+	Profile        string                     `json:"profile"`
+	Roster         RosterDriftV1              `json:"roster"`
+	Observations   []ParticipantObservationV1 `json:"observations"`
+	Commands       []CommandV1                `json:"commands,omitempty"`
+	FollowUps      []RequiredActionV1         `json:"follow_ups,omitempty"`
+	Evidence       []EvidenceRefV1            `json:"evidence,omitempty"`
+}
+
+type InspectRequestV1 struct {
+	RequestVersion int      `json:"request_version"`
+	Target         TargetV1 `json:"target"`
+}
+
+type FocusRequestV1 = InspectRequestV1
+type CloseRequestV1 = InspectRequestV1
+
+type LifecycleResultV1 struct {
+	ResultVersion int                        `json:"result_version"`
+	Outcome       string                     `json:"outcome"`
+	ReasonCode    string                     `json:"reason_code,omitempty"`
+	Backend       string                     `json:"backend"`
+	Profile       string                     `json:"profile"`
+	State         string                     `json:"state"`
+	Observations  []ParticipantObservationV1 `json:"observations"`
+	Evidence      []EvidenceRefV1            `json:"evidence,omitempty"`
+}
+
+type InspectResultV1 = LifecycleResultV1
+type FocusResultV1 = LifecycleResultV1
+type CloseResultV1 = LifecycleResultV1
+
+type CompatibilityV1 struct {
+	ContractSemver string   `json:"contract_semver"`
+	IntentVersions []int    `json:"intent_versions"`
+	ResultVersions []int    `json:"result_versions"`
+	Features       []string `json:"features"`
+}
+
+type RequirementV1 struct {
+	ContractSemver string   `json:"contract_semver"`
+	IntentVersion  int      `json:"intent_version"`
+	ResultVersion  int      `json:"result_version"`
+	Features       []string `json:"features"`
+}
+
+type NegotiatedV1 struct {
+	ContractSemver string   `json:"contract_semver"`
+	IntentVersion  int      `json:"intent_version"`
+	ResultVersion  int      `json:"result_version"`
+	Features       []string `json:"features"`
+}

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/avivsinai/agent-message-queue/schemas/launch-api-v1.schema.json",
+  "title": "AMQ Launch API v1",
+  "$ref": "#/$defs/LaunchIntentV1",
+  "$defs": {
+    "Digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "LaunchIntentV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["intent_version", "participants"],
+      "properties": {
+        "intent_version": {"const": 1},
+        "participants": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/ParticipantV1"}
+        }
+      }
+    },
+    "ParticipantV1": {
+      "oneOf": [
+        {"$ref": "#/$defs/NonRunnableParticipantV1"},
+        {"$ref": "#/$defs/RunnableParticipantV1"}
+      ]
+    },
+    "NonRunnableParticipantV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["handle", "runnable"],
+      "properties": {
+        "handle": {"$ref": "#/$defs/Handle"},
+        "runnable": {"const": false}
+      }
+    },
+    "RunnableParticipantV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["handle", "runnable", "executable", "cwd", "resume_policy", "execution"],
+      "properties": {
+        "handle": {"$ref": "#/$defs/Handle"},
+        "runnable": {"const": true},
+        "executable": {"type": "string", "minLength": 1},
+        "args": {"type": "array", "items": {"type": "string"}},
+        "cwd": {"$ref": "#/$defs/WorkingDirectoryV1"},
+        "env_overlay": {
+          "type": "object",
+          "additionalProperties": {"type": "string"},
+          "propertyNames": {"pattern": "^[^=]+$"}
+        },
+        "resume_policy": {"enum": ["resume", "fresh", "disabled"]},
+        "execution": {"$ref": "#/$defs/ExecutionOptionsV1"}
+      }
+    },
+    "Handle": {
+      "type": "string",
+      "pattern": "^[a-z0-9_][a-z0-9_-]*$"
+    },
+    "WorkingDirectoryV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "path"],
+      "properties": {
+        "kind": {"enum": ["relative", "absolute"]},
+        "path": {"type": "string", "minLength": 1}
+      }
+    },
+    "ExecutionOptionsV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["require_wake", "no_gitignore", "wake"],
+      "properties": {
+        "require_wake": {"type": "boolean"},
+        "no_gitignore": {"type": "boolean"},
+        "wake": {"$ref": "#/$defs/WakeOptionsV1"},
+        "integrations": {"$ref": "#/$defs/IntegrationsV1"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"wake": {"properties": {"mode": {"const": "disabled"}}}}},
+          "then": {"properties": {"require_wake": {"const": false}}}
+        }
+      ]
+    },
+    "WakeOptionsV1": {
+      "oneOf": [
+        {"$ref": "#/$defs/EnabledWakeOptionsV1"},
+        {"$ref": "#/$defs/DisabledWakeOptionsV1"}
+      ]
+    },
+    "EnabledWakeOptionsV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": {"const": "enabled"},
+        "injector": {"$ref": "#/$defs/InjectorOptionsV1"}
+      }
+    },
+    "DisabledWakeOptionsV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "audit_reason"],
+      "properties": {
+        "mode": {"const": "disabled"},
+        "audit_reason": {"type": "string", "minLength": 1}
+      }
+    },
+    "InjectorOptionsV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": {"enum": ["auto", "raw", "paste", "none"]},
+        "via": {"type": "string", "minLength": 1},
+        "args": {"type": "array", "items": {"type": "string"}}
+      },
+      "allOf": [
+        {
+          "if": {"required": ["args"]},
+          "then": {"required": ["via"]}
+        },
+        {
+          "if": {"properties": {"mode": {"const": "none"}}, "required": ["mode"]},
+          "then": {"not": {"anyOf": [{"required": ["via"]}, {"required": ["args"]}]}}
+        }
+      ]
+    },
+    "IntegrationsV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "symphony": {"$ref": "#/$defs/SymphonyOptionsV1"}
+      }
+    },
+    "SymphonyOptionsV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["events"],
+      "properties": {
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["after_create", "before_run", "after_run", "before_remove"]}
+        },
+        "workspace_key": {"type": "string"}
+      }
+    },
+    "TargetV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["project_root", "session_root", "session"],
+      "properties": {
+        "project_root": {"type": "string", "minLength": 1},
+        "session_root": {"type": "string", "minLength": 1},
+        "session": {"type": "string", "pattern": "^[a-z0-9_][a-z0-9_-]*$"}
+      }
+    },
+    "PrepareRequestV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["request_version", "target", "launcher", "intent"],
+      "properties": {
+        "request_version": {"const": 1},
+        "target": {"$ref": "#/$defs/TargetV1"},
+        "launcher": {"type": "string", "minLength": 1},
+        "intent": {"$ref": "#/$defs/LaunchIntentV1"}
+      }
+    },
+    "RequiredActionV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action_id", "kind", "allowed_decisions", "reason_code"],
+      "properties": {
+        "action_id": {"type": "string", "minLength": 1},
+        "kind": {"enum": ["trust_confirmation", "stale_conversation_decision", "rebind_confirmation", "unsupported_capability_ack"]},
+        "handles": {"type": "array", "items": {"$ref": "#/$defs/Handle"}},
+        "resources": {"type": "array", "items": {"type": "string"}},
+        "allowed_decisions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["trust_exact_subject", "deny", "fresh_once", "abort", "close_old", "leave_old", "accept_degraded"]}
+        },
+        "reason_code": {"type": "string", "minLength": 1}
+      }
+    },
+    "CommandV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["argv", "cwd"],
+      "properties": {
+        "argv": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "cwd": {"type": "string", "minLength": 1},
+        "env_overlay": {"type": "object", "additionalProperties": {"type": "string"}}
+      }
+    },
+    "RosterDriftV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["desired", "present", "missing", "extra"],
+      "properties": {
+        "desired": {"type": "array", "items": {"$ref": "#/$defs/Handle"}},
+        "present": {"type": "array", "items": {"$ref": "#/$defs/Handle"}},
+        "missing": {"type": "array", "items": {"$ref": "#/$defs/Handle"}},
+        "extra": {"type": "array", "items": {"$ref": "#/$defs/Handle"}}
+      }
+    },
+    "ParticipantPreviewV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["handle", "runnable", "planned_outcome"],
+      "properties": {
+        "handle": {"$ref": "#/$defs/Handle"},
+        "runnable": {"type": "boolean"},
+        "provider": {"type": "string"},
+        "command": {"$ref": "#/$defs/CommandV1"},
+        "resume_policy": {"enum": ["resume", "fresh", "disabled"]},
+        "execution": {"$ref": "#/$defs/ExecutionOptionsV1"},
+        "planned_outcome": {"type": "string", "minLength": 1}
+      }
+    },
+    "PreviewV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "backend", "profile", "participants", "roster"],
+      "properties": {
+        "target": {"$ref": "#/$defs/TargetV1"},
+        "backend": {"type": "string"},
+        "profile": {"type": "string"},
+        "participants": {"type": "array", "items": {"$ref": "#/$defs/ParticipantPreviewV1"}},
+        "roster": {"$ref": "#/$defs/RosterDriftV1"}
+      }
+    },
+    "ParticipantObservationV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["handle", "mailbox", "runnable", "conversation", "execution", "resource"],
+      "properties": {
+        "handle": {"$ref": "#/$defs/Handle"},
+        "mailbox": {"type": "string"},
+        "runnable": {"type": "boolean"},
+        "conversation": {"type": "string"},
+        "execution": {"type": "string"},
+        "resource": {"type": "string"},
+        "reason_code": {"type": "string"}
+      }
+    },
+    "PrepareResultV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["result_version", "outcome", "subject_digest", "plan_digest", "trust_digest", "required_actions", "preview", "observations"],
+      "properties": {
+        "result_version": {"const": 1},
+        "outcome": {"type": "string", "minLength": 1},
+        "reason": {"type": "string"},
+        "subject_digest": {"$ref": "#/$defs/Digest"},
+        "plan_digest": {"$ref": "#/$defs/Digest"},
+        "trust_digest": {"$ref": "#/$defs/Digest"},
+        "required_actions": {"type": "array", "items": {"$ref": "#/$defs/RequiredActionV1"}},
+        "preview": {"$ref": "#/$defs/PreviewV1"},
+        "observations": {"type": "array", "items": {"$ref": "#/$defs/ParticipantObservationV1"}}
+      }
+    },
+    "DecisionV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action_id", "choice"],
+      "properties": {
+        "action_id": {"type": "string", "minLength": 1},
+        "choice": {"enum": ["trust_exact_subject", "deny", "fresh_once", "abort", "close_old", "leave_old", "accept_degraded"]}
+      }
+    },
+    "ApplyRequestV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["request_version", "prepare", "subject_digest", "decisions"],
+      "properties": {
+        "request_version": {"const": 1},
+        "prepare": {"$ref": "#/$defs/PrepareRequestV1"},
+        "subject_digest": {"$ref": "#/$defs/Digest"},
+        "decisions": {"type": "array", "items": {"$ref": "#/$defs/DecisionV1"}}
+      }
+    },
+    "EvidenceRefV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_version", "id", "kind", "sha256", "observed_at"],
+      "properties": {
+        "evidence_version": {"const": 1},
+        "id": {"type": "string", "minLength": 1},
+        "kind": {"type": "string", "minLength": 1},
+        "sha256": {"$ref": "#/$defs/Digest"},
+        "observed_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "ApplyResultV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["result_version", "outcome", "subject_digest", "plan_digest", "trust_digest", "semantic_digest", "backend", "profile", "roster", "observations"],
+      "properties": {
+        "result_version": {"const": 1},
+        "outcome": {"type": "string", "minLength": 1},
+        "reason_code": {"type": "string"},
+        "subject_digest": {"$ref": "#/$defs/Digest"},
+        "plan_digest": {"$ref": "#/$defs/Digest"},
+        "trust_digest": {"$ref": "#/$defs/Digest"},
+        "semantic_digest": {"$ref": "#/$defs/Digest"},
+        "backend": {"type": "string"},
+        "profile": {"type": "string"},
+        "roster": {"$ref": "#/$defs/RosterDriftV1"},
+        "observations": {"type": "array", "items": {"$ref": "#/$defs/ParticipantObservationV1"}},
+        "commands": {"type": "array", "items": {"$ref": "#/$defs/CommandV1"}},
+        "follow_ups": {"type": "array", "items": {"$ref": "#/$defs/RequiredActionV1"}},
+        "evidence": {"type": "array", "items": {"$ref": "#/$defs/EvidenceRefV1"}}
+      }
+    },
+    "LifecycleRequestV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["request_version", "target"],
+      "properties": {
+        "request_version": {"const": 1},
+        "target": {"$ref": "#/$defs/TargetV1"}
+      }
+    },
+    "InspectRequestV1": {"$ref": "#/$defs/LifecycleRequestV1"},
+    "FocusRequestV1": {"$ref": "#/$defs/LifecycleRequestV1"},
+    "CloseRequestV1": {"$ref": "#/$defs/LifecycleRequestV1"},
+    "LifecycleResultV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["result_version", "outcome", "backend", "profile", "state", "observations"],
+      "properties": {
+        "result_version": {"const": 1},
+        "outcome": {"type": "string", "minLength": 1},
+        "reason_code": {"type": "string"},
+        "backend": {"type": "string"},
+        "profile": {"type": "string"},
+        "state": {"enum": ["present", "absent", "unknown"]},
+        "observations": {"type": "array", "items": {"$ref": "#/$defs/ParticipantObservationV1"}},
+        "evidence": {"type": "array", "items": {"$ref": "#/$defs/EvidenceRefV1"}}
+      }
+    },
+    "InspectResultV1": {"$ref": "#/$defs/LifecycleResultV1"},
+    "FocusResultV1": {"$ref": "#/$defs/LifecycleResultV1"},
+    "CloseResultV1": {"$ref": "#/$defs/LifecycleResultV1"},
+    "CompatibilityV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_semver", "intent_versions", "result_versions", "features"],
+      "properties": {
+        "contract_semver": {"type": "string", "minLength": 1},
+        "intent_versions": {"type": "array", "items": {"type": "integer", "minimum": 1}},
+        "result_versions": {"type": "array", "items": {"type": "integer", "minimum": 1}},
+        "features": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "RequirementV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_semver", "intent_version", "result_version", "features"],
+      "properties": {
+        "contract_semver": {"type": "string", "minLength": 1},
+        "intent_version": {"type": "integer", "minimum": 1},
+        "result_version": {"type": "integer", "minimum": 1},
+        "features": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "NegotiatedV1": {
+      "$ref": "#/$defs/RequirementV1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the public `launchapi` v1 contract and strict fail-closed JSON codecs
- add separate subject, plan, and trust digests plus compatibility negotiation
- publish a Draft 2020-12 JSON Schema and hostile-boundary tests

## Verification
- `make ci`
- `go test -race ./launchapi ./internal/launch`
- external consumer compile and negotiation test
- real JSON Schema validation with hostile mutations

Reviewed and approved by the peer at staged diff SHA-256 `250037b0e02eb0b5db4c8695a8e83378c2863b995058a068318f4392f882c5e9`.