### PR TITLE
feat(launchapi): zero-write Prepare with typed required actions

### DIFF
--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -24,7 +23,7 @@ type launchCLIOptions struct {
 var (
 	launchIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 	launchInput      = func() *bufio.Reader { return bufio.NewReader(os.Stdin) }
-	launchStateDir   = defaultLaunchStateDir
+	launchStateDir   = launch.DefaultLaunchStateDir
 	launchAMQPath    = func() string {
 		if path, err := os.Executable(); err == nil {
 			return path
@@ -261,19 +260,5 @@ func outputLaunchResult(jsonOutput bool, result launch.ReconcileResult) error {
 }
 
 func defaultLaunchStateDir() (string, error) {
-	if value := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); value != "" {
-		return filepath.Join(value, "amq"), nil
-	}
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		base, err := os.UserConfigDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(base, "amq", "state"), nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".local", "state", "amq"), nil
+	return launch.DefaultLaunchStateDir()
 }

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -41,14 +41,19 @@ type AdapterCapabilities struct {
 }
 
 type PlanRequest struct {
-	Handle        string
-	ProjectRoot   string
-	Cwd           string
-	LaunchNonce   string
-	ResumePolicy  ResumePolicy
-	CommittedArgs []string
-	BypassArgs    []string
-	EnvOverlay    map[string]string
+	Handle      string
+	ProjectRoot string
+	Cwd         string
+	// AllowExternalCwd is reserved for the public intent compiler. Public
+	// intents can name an absolute sibling worktree after that path is
+	// canonicalized and physically identified. Committed project config keeps
+	// the historical project-contained rule.
+	AllowExternalCwd bool
+	LaunchNonce      string
+	ResumePolicy     ResumePolicy
+	CommittedArgs    []string
+	BypassArgs       []string
+	EnvOverlay       map[string]string
 }
 
 type ResumeRequest struct {
@@ -117,6 +122,42 @@ func ValidateStaticProviderInput(executable string, args []string, env map[strin
 		return "", err
 	}
 	return provider, nil
+}
+
+// PartitionStaticProviderArgs separates ordinary committed arguments from the
+// adapter's explicit operator-bypass arguments. Callers must first validate the
+// complete input with ValidateStaticProviderInput.
+func PartitionStaticProviderArgs(provider string, args []string) (committed, bypass []string, err error) {
+	var argRules map[string]argumentRule
+	var bypassAllowed map[string]struct{}
+	switch provider {
+	case ClaudeProvider:
+		argRules, bypassAllowed = claudeArgRules(), claudeBypassArgs()
+	case CodexProvider:
+		argRules, bypassAllowed = codexArgRules(), codexBypassArgs()
+	default:
+		return nil, nil, fmt.Errorf("unknown provider %q", provider)
+	}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if _, ok := bypassAllowed[arg]; ok {
+			bypass = append(bypass, arg)
+			continue
+		}
+		rule, ok := argRules[arg]
+		if !ok {
+			return nil, nil, fmt.Errorf("static argument %q is not allowed by adapter grammar", arg)
+		}
+		committed = append(committed, arg)
+		if rule.value {
+			if i+1 >= len(args) {
+				return nil, nil, fmt.Errorf("static argument %q requires a value", arg)
+			}
+			i++
+			committed = append(committed, args[i])
+		}
+	}
+	return committed, bypass, nil
 }
 
 func validateStaticProviderArgs(args []string, rules map[string]argumentRule, bypassAllowed map[string]struct{}) error {
@@ -206,10 +247,31 @@ func validatePlanRequest(request PlanRequest, executable, provider string, envRu
 	if err := validateCommittedEnv(request.EnvOverlay, envRules); err != nil {
 		return "", err
 	}
-	if err := validateWorkingDirectory(request.Cwd, request.ProjectRoot); err != nil {
+	if err := validatePlanWorkingDirectory(request); err != nil {
 		return "", err
 	}
 	return resolvedExecutable, nil
+}
+
+func validatePlanWorkingDirectory(request PlanRequest) error {
+	if !request.AllowExternalCwd {
+		return validateWorkingDirectory(request.Cwd, request.ProjectRoot)
+	}
+	if !filepath.IsAbs(request.Cwd) {
+		return fmt.Errorf("external working directory must be absolute")
+	}
+	resolved, err := resolvedPath(request.Cwd)
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return fmt.Errorf("stat working directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("working directory is not a directory")
+	}
+	return nil
 }
 
 func validateCommittedConfig(request CommittedConfigRequest, envRules map[string]valueRule, argRules map[string]argumentRule) error {

--- a/internal/launch/plan.go
+++ b/internal/launch/plan.go
@@ -163,7 +163,18 @@ type staticAgentPlan struct {
 // Fresh and resume argv shapes have different digests because only the resume
 // shape carries a conversation slot; each shape therefore requires trust once.
 func (p Plan) SemanticDigest() (string, error) {
-	if err := p.Validate(); err != nil {
+	return p.semanticDigest(false)
+}
+
+// PreparePlanDigest hashes the nonce-free static plan used by Prepare. Unlike
+// a backend execution Plan, it permits zero runnable agents so a participant-
+// only session still has one deterministic plan subject.
+func PreparePlanDigest(p Plan) (string, error) {
+	return p.semanticDigest(true)
+}
+
+func (p Plan) semanticDigest(allowEmpty bool) (string, error) {
+	if err := p.validateForDigest(allowEmpty); err != nil {
 		return "", err
 	}
 	agents := make([]staticAgentPlan, len(p.Agents))
@@ -190,6 +201,16 @@ func (p Plan) SemanticDigest() (string, error) {
 	}
 	sum := sha256.Sum256(canonical)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func (p Plan) validateForDigest(allowEmpty bool) error {
+	if !allowEmpty || len(p.Agents) != 0 {
+		return p.Validate()
+	}
+	if p.Version != PlanVersion {
+		return fmt.Errorf("unsupported launch plan version %d", p.Version)
+	}
+	return nil
 }
 
 func DecodePlan(data []byte) (Plan, error) {

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -1,0 +1,876 @@
+package launch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// DefaultLaunchStateDir returns the existing platform-specific trust-state
+// root without creating it.
+func DefaultLaunchStateDir() (string, error) {
+	if value := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); value != "" {
+		return filepath.Join(value, "amq"), nil
+	}
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		base, err := os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(base, "amq", "state"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".local", "state", "amq"), nil
+}
+
+const preparePlaceholderUUID = "00000000-0000-4000-8000-000000000000"
+
+const (
+	PrepareOutcomeReady          = "ready"
+	PrepareOutcomeActionRequired = "action_required"
+	PrepareOutcomeUnsupported    = "unsupported"
+)
+
+type RequiredActionKind string
+
+const (
+	ActionTrustConfirmation     RequiredActionKind = "trust_confirmation"
+	ActionStaleConversation     RequiredActionKind = "stale_conversation_decision"
+	ActionRebindConfirmation    RequiredActionKind = "rebind_confirmation"
+	ActionUnsupportedCapability RequiredActionKind = "unsupported_capability_ack"
+)
+
+type PrepareTarget struct {
+	ProjectRoot string `json:"project_root"`
+	SessionRoot string `json:"session_root"`
+	Session     string `json:"session"`
+}
+
+type PrepareExecutionOptions struct {
+	RequireWake          bool     `json:"require_wake"`
+	NoGitignore          bool     `json:"no_gitignore"`
+	WakeMode             string   `json:"wake_mode"`
+	AuditReason          string   `json:"audit_reason,omitempty"`
+	InjectorMode         string   `json:"injector_mode,omitempty"`
+	InjectorVia          string   `json:"injector_via,omitempty"`
+	InjectorArgs         []string `json:"injector_args,omitempty"`
+	SymphonyEvents       []string `json:"symphony_events,omitempty"`
+	SymphonyWorkspaceKey string   `json:"symphony_workspace_key,omitempty"`
+}
+
+type PrepareParticipant struct {
+	Handle       string
+	Runnable     bool
+	Provider     string
+	Executable   string
+	Args         []string
+	BypassArgs   []string
+	Cwd          string
+	EnvOverlay   map[string]string
+	ResumePolicy ResumePolicy
+	Execution    PrepareExecutionOptions
+}
+
+type PrepareRequest struct {
+	Target       PrepareTarget
+	Launcher     string
+	IntentDigest string
+	Participants []PrepareParticipant
+}
+
+type AdapterFactory func(provider, executable string) HarnessAdapter
+
+type PrepareDependencies struct {
+	Backends     map[string]Backend
+	Preferences  []string
+	AdapterFor   AdapterFactory
+	TrustStore   *TrustStore
+	HostIdentity string
+}
+
+type PrepareRequiredAction struct {
+	ActionID         string             `json:"action_id"`
+	Kind             RequiredActionKind `json:"kind"`
+	Handles          []string           `json:"handles,omitempty"`
+	Resources        []string           `json:"resources,omitempty"`
+	AllowedDecisions []string           `json:"allowed_decisions"`
+	ReasonCode       string             `json:"reason_code"`
+}
+
+type PrepareCommand struct {
+	Argv       []string          `json:"argv"`
+	Cwd        string            `json:"cwd"`
+	EnvOverlay map[string]string `json:"env_overlay,omitempty"`
+}
+
+type PreparedParticipant struct {
+	Handle         string                  `json:"handle"`
+	Runnable       bool                    `json:"runnable"`
+	Provider       string                  `json:"provider,omitempty"`
+	Command        *PrepareCommand         `json:"command,omitempty"`
+	ResumePolicy   ResumePolicy            `json:"resume_policy,omitempty"`
+	Execution      PrepareExecutionOptions `json:"execution,omitempty"`
+	PlannedOutcome string                  `json:"planned_outcome"`
+	CwdIdentity    string                  `json:"cwd_identity,omitempty"`
+}
+
+type PrepareRoster struct {
+	Desired []string `json:"desired"`
+	Present []string `json:"present"`
+	Missing []string `json:"missing"`
+	Extra   []string `json:"extra"`
+}
+
+type PrepareObservation struct {
+	Handle                     string `json:"handle"`
+	Mailbox                    string `json:"mailbox"`
+	Runnable                   bool   `json:"runnable"`
+	Conversation               string `json:"conversation"`
+	ConversationIdentityDigest string `json:"conversation_identity_digest"`
+	Execution                  string `json:"execution"`
+	ExecutionIdentityDigest    string `json:"execution_identity_digest"`
+	Resource                   string `json:"resource"`
+	ReasonCode                 string `json:"reason_code,omitempty"`
+}
+
+type PrepareResult struct {
+	Outcome         string
+	Reason          string
+	SubjectDigest   string
+	PlanDigest      string
+	TrustDigest     string
+	Target          PrepareTarget
+	Backend         string
+	Profile         string
+	Participants    []PreparedParticipant
+	Roster          PrepareRoster
+	RequiredActions []PrepareRequiredAction
+	Observations    []PrepareObservation
+}
+
+type prepareTargetState struct {
+	target          PrepareTarget
+	projectIdentity string
+	sessionIdentity string
+	projectRoot     *fsq.DeliveryRoot
+	baseRoot        *fsq.DeliveryRoot
+	sessionRoot     *fsq.DeliveryRoot
+	mailboxConfig   *fsq.MailboxConfigAuthorization
+}
+
+func (state *prepareTargetState) close() {
+	if state == nil {
+		return
+	}
+	if state.mailboxConfig != nil {
+		_ = state.mailboxConfig.Close()
+	}
+	if state.sessionRoot != nil {
+		_ = state.sessionRoot.Close()
+	}
+	if state.baseRoot != nil {
+		_ = state.baseRoot.Close()
+	}
+	if state.projectRoot != nil {
+		_ = state.projectRoot.Close()
+	}
+}
+
+func (state *prepareTargetState) verify() error {
+	if state.mailboxConfig != nil {
+		if err := state.mailboxConfig.Verify(); err != nil {
+			return fmt.Errorf("mailbox config changed during Prepare: %w", err)
+		}
+	}
+	if err := state.projectRoot.VerifyBase(); err != nil {
+		return fmt.Errorf("project root changed during Prepare: %w", err)
+	}
+	if err := state.baseRoot.VerifyBase(); err != nil {
+		return fmt.Errorf("session base root changed during Prepare: %w", err)
+	}
+	if state.sessionRoot != nil {
+		if err := state.sessionRoot.VerifyBase(); err != nil {
+			return fmt.Errorf("session root changed during Prepare: %w", err)
+		}
+		return nil
+	}
+	child, err := state.baseRoot.OpenDirectChild(state.target.Session)
+	if err == nil {
+		_ = child.Close()
+		return fmt.Errorf("session root appeared during Prepare")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+type prepareBindingObservation struct {
+	Present    bool           `json:"present"`
+	Binding    *BindingRecord `json:"binding,omitempty"`
+	Inspection string         `json:"inspection"`
+	Evidence   string         `json:"evidence,omitempty"`
+}
+
+type prepareSubject struct {
+	Version         int                       `json:"version"`
+	IntentDigest    string                    `json:"intent_digest"`
+	PlanDigest      string                    `json:"plan_digest"`
+	TrustDigest     string                    `json:"trust_digest"`
+	Target          PrepareTarget             `json:"target"`
+	ProjectIdentity string                    `json:"project_identity"`
+	SessionIdentity string                    `json:"session_identity"`
+	Backend         string                    `json:"backend"`
+	Profile         string                    `json:"profile"`
+	Detection       DetectResult              `json:"detection"`
+	Binding         prepareBindingObservation `json:"binding"`
+	Roster          PrepareRoster             `json:"roster"`
+	Actions         []PrepareRequiredAction   `json:"actions"`
+	Participants    []PreparedParticipant     `json:"participants"`
+	Observations    []PrepareObservation      `json:"observations"`
+}
+
+// Prepare compiles public caller intent and inspects current launch state. It
+// deliberately has no write-capable dependency: no lease, Create, Close,
+// Focus, trust replacement, journal writer, or mailbox repair callback is
+// reachable from this function.
+func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDependencies) (PrepareResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return PrepareResult{}, err
+	}
+	if !validDigest(request.IntentDigest) {
+		return PrepareResult{}, fmt.Errorf("invalid intent digest")
+	}
+	if len(request.Participants) == 0 {
+		return PrepareResult{}, fmt.Errorf("prepare requires at least one participant")
+	}
+	state, err := openPrepareTarget(request.Target)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	defer state.close()
+
+	binding, bindingObservation, err := inspectPrepareBinding(state.sessionRoot)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	backendName, _, detect, err := selectPrepareBackend(request.Launcher, binding, dependencies, state.projectRoot)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	var boundDetect DetectResult
+	if binding != nil {
+		boundBackend := dependencies.Backends[binding.Backend]
+		if boundBackend == nil {
+			bindingObservation.Inspection = "backend_unavailable"
+		} else {
+			if binding.Backend == backendName {
+				boundDetect = detect
+			} else {
+				boundDetect = boundBackend.Detect()
+			}
+			if err := boundDetect.Validate(); err != nil {
+				return PrepareResult{}, err
+			}
+			switch {
+			case prepareBindingForeign(*binding, boundDetect, dependencies.HostIdentity):
+				bindingObservation.Inspection = "foreign"
+			case !boundDetect.Available:
+				bindingObservation.Inspection = "backend_unavailable"
+			default:
+				bindingObservation, err = inspectBoundBackend(boundBackend, *binding, state.sessionRoot, bindingObservation)
+			}
+		}
+		if err != nil {
+			return PrepareResult{}, err
+		}
+	}
+
+	if state.sessionRoot != nil {
+		authorization, inventory, authorizationErr := fsq.OpenMailboxConfigAuthorization(state.sessionRoot)
+		switch {
+		case authorizationErr == nil:
+			state.mailboxConfig = authorization
+		case inventory.ActiveConfigStatus != string(fsq.MailboxPathMissing):
+			return PrepareResult{}, fmt.Errorf("pin mailbox config: %w", authorizationErr)
+		}
+	}
+	roster, mailboxStates, err := inspectPrepareRoster(state.sessionRoot, state.mailboxConfig, request.Participants)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	result := PrepareResult{
+		Target: state.target, Backend: backendName, Roster: roster,
+		Participants: make([]PreparedParticipant, 0, len(request.Participants)),
+		Observations: make([]PrepareObservation, 0, len(request.Participants)+len(roster.Extra)),
+	}
+	if detect.Profile.Backend != "" {
+		result.Profile = detect.Profile.Identity()
+	}
+
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{}}
+	for _, participant := range request.Participants {
+		prepared, observation, agentPlan, actions, participantErr := prepareOneParticipant(participant, state, dependencies, mailboxStates[participant.Handle])
+		if participantErr != nil {
+			return PrepareResult{}, participantErr
+		}
+		result.Participants = append(result.Participants, prepared)
+		result.Observations = append(result.Observations, observation)
+		result.RequiredActions = append(result.RequiredActions, actions...)
+		if agentPlan != nil {
+			plan.Agents = append(plan.Agents, *agentPlan)
+		}
+	}
+	applyBindingResources(result.Observations, binding)
+	if err := appendExtraObservations(&result, roster.Extra, mailboxStates, binding, state.sessionRoot); err != nil {
+		return PrepareResult{}, err
+	}
+
+	result.RequiredActions = append(result.RequiredActions, prepareRebindActions(binding, bindingObservation, boundDetect, backendName, result.Profile, dependencies.HostIdentity)...)
+	for i := range result.RequiredActions {
+		result.RequiredActions[i].ActionID, err = prepareActionID(result.RequiredActions[i])
+		if err != nil {
+			return PrepareResult{}, err
+		}
+	}
+	slices.SortFunc(result.RequiredActions, comparePrepareActions)
+
+	result.PlanDigest, err = PreparePlanDigest(plan)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	result.TrustDigest, err = PrepareTrustDigest(result.PlanDigest, state.target.Session, state.target.SessionRoot, state.sessionIdentity)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	if detect.Available && len(plan.Agents) > 0 {
+		trusted, trustErr := loadPrepareTrust(dependencies.TrustStore, result.TrustDigest)
+		if trustErr != nil {
+			return PrepareResult{}, trustErr
+		}
+		if !trusted {
+			handles := make([]string, 0, len(plan.Agents))
+			for _, agent := range plan.Agents {
+				handles = append(handles, agent.Handle)
+			}
+			action := PrepareRequiredAction{
+				Kind: ActionTrustConfirmation, Handles: handles, Resources: []string{result.TrustDigest},
+				AllowedDecisions: []string{"trust_exact_subject", "deny"}, ReasonCode: "untrusted_config_digest",
+			}
+			action.ActionID, err = prepareActionID(action)
+			if err != nil {
+				return PrepareResult{}, err
+			}
+			result.RequiredActions = append(result.RequiredActions, action)
+			slices.SortFunc(result.RequiredActions, comparePrepareActions)
+		}
+	}
+
+	switch {
+	case len(result.RequiredActions) > 0:
+		result.Outcome, result.Reason = PrepareOutcomeActionRequired, result.RequiredActions[0].ReasonCode
+	case !detect.Available:
+		result.Outcome, result.Reason = PrepareOutcomeUnsupported, "launcher_not_available"
+	case bindingObservation.Present && (bindingObservation.Inspection == string(InspectUnknown) || bindingObservation.Inspection == "backend_unavailable"):
+		result.Outcome, result.Reason = PrepareOutcomeActionRequired, "binding_inspection_unavailable"
+	default:
+		result.Outcome = PrepareOutcomeReady
+	}
+	if err := state.verify(); err != nil {
+		return PrepareResult{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return PrepareResult{}, err
+	}
+	result.SubjectDigest, err = digestCanonical(prepareSubject{
+		Version: 1, IntentDigest: request.IntentDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
+		Target: state.target, ProjectIdentity: state.projectIdentity, SessionIdentity: state.sessionIdentity,
+		Backend: result.Backend, Profile: result.Profile, Detection: detect, Binding: bindingObservation, Roster: result.Roster,
+		Actions: result.RequiredActions, Participants: result.Participants, Observations: result.Observations,
+	})
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	return result, nil
+}
+
+func openPrepareTarget(target PrepareTarget) (*prepareTargetState, error) {
+	if strings.TrimSpace(target.ProjectRoot) == "" || strings.TrimSpace(target.SessionRoot) == "" || strings.TrimSpace(target.Session) == "" {
+		return nil, fmt.Errorf("prepare target is incomplete")
+	}
+	project, err := resolvedPath(target.ProjectRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve project root: %w", err)
+	}
+	projectSnapshot, err := fsq.SnapshotDeliveryRoot(project)
+	if err != nil {
+		return nil, err
+	}
+	projectRoot, err := fsq.OpenDeliveryRoot(project, projectSnapshot)
+	if err != nil {
+		return nil, err
+	}
+	projectIdentity, err := fsq.StableTreeIdentityInfo(projectRoot.FileInfo())
+	if err != nil {
+		_ = projectRoot.Close()
+		return nil, err
+	}
+
+	sessionPath := filepath.Clean(target.SessionRoot)
+	if filepath.Base(sessionPath) != target.Session || filepath.Dir(sessionPath) == sessionPath {
+		_ = projectRoot.Close()
+		return nil, fmt.Errorf("session root must be the direct child named %q", target.Session)
+	}
+	base, err := resolvedPath(filepath.Dir(sessionPath))
+	if err != nil {
+		_ = projectRoot.Close()
+		return nil, fmt.Errorf("resolve session base root: %w", err)
+	}
+	canonicalSession := filepath.Join(base, target.Session)
+	baseSnapshot, err := fsq.SnapshotDeliveryRoot(base)
+	if err != nil {
+		_ = projectRoot.Close()
+		return nil, err
+	}
+	baseRoot, err := fsq.OpenDeliveryRoot(base, baseSnapshot)
+	if err != nil {
+		_ = projectRoot.Close()
+		return nil, err
+	}
+	state := &prepareTargetState{
+		target:          PrepareTarget{ProjectRoot: project, SessionRoot: canonicalSession, Session: target.Session},
+		projectIdentity: projectIdentity, projectRoot: projectRoot, baseRoot: baseRoot,
+	}
+	sessionRoot, err := baseRoot.OpenDirectChild(target.Session)
+	if err == nil {
+		state.sessionRoot = sessionRoot
+		state.sessionIdentity, err = fsq.StableTreeIdentityInfo(sessionRoot.FileInfo())
+		if err != nil {
+			state.close()
+			return nil, err
+		}
+		return state, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		state.close()
+		return nil, err
+	}
+	baseIdentity, identityErr := fsq.StableTreeIdentityInfo(baseRoot.FileInfo())
+	if identityErr != nil {
+		state.close()
+		return nil, identityErr
+	}
+	state.sessionIdentity = "intended-child:" + baseIdentity + ":" + target.Session
+	return state, nil
+}
+
+func inspectPrepareBinding(root *fsq.DeliveryRoot) (*BindingRecord, prepareBindingObservation, error) {
+	observation := prepareBindingObservation{Inspection: "absent"}
+	if root == nil {
+		return nil, observation, nil
+	}
+	binding, err := LoadBinding(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, observation, nil
+	}
+	if err != nil {
+		return nil, observation, err
+	}
+	observation.Present, observation.Binding = true, &binding
+	observation.Inspection = "not_inspected"
+	return &binding, observation, nil
+}
+
+func inspectBoundBackend(backend Backend, binding BindingRecord, root *fsq.DeliveryRoot, observation prepareBindingObservation) (prepareBindingObservation, error) {
+	inspection, err := backend.Inspect(InspectRequest{Binding: binding, Root: root})
+	if err != nil {
+		return observation, err
+	}
+	observation.Inspection, observation.Evidence = string(inspection.Status), inspection.Evidence
+	return observation, nil
+}
+
+func selectPrepareBackend(requested string, binding *BindingRecord, dependencies PrepareDependencies, projectRoot *fsq.DeliveryRoot) (string, Backend, DetectResult, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		requested = LauncherAuto
+	}
+	selected := requested
+	if selected == LauncherAuto && binding != nil {
+		selected = binding.Backend
+	}
+	preferences := slices.Clone(dependencies.Preferences)
+	if selected == LauncherAuto && len(preferences) == 0 {
+		var err error
+		preferences, err = loadPreparePreferences(projectRoot)
+		if err != nil {
+			return "", nil, DetectResult{}, err
+		}
+	}
+	if selected == LauncherAuto {
+		for _, name := range preferences {
+			backend := dependencies.Backends[name]
+			if backend == nil {
+				continue
+			}
+			detect := backend.Detect()
+			if err := detect.Validate(); err != nil {
+				return name, backend, detect, err
+			}
+			if detect.Available {
+				return name, backend, detect, nil
+			}
+		}
+		return LauncherAuto, nil, DetectResult{}, nil
+	}
+	backend := dependencies.Backends[selected]
+	if backend == nil {
+		return selected, nil, DetectResult{}, nil
+	}
+	detect := backend.Detect()
+	if err := detect.Validate(); err != nil {
+		return selected, backend, detect, err
+	}
+	return selected, backend, detect, nil
+}
+
+func loadPreparePreferences(projectRoot *fsq.DeliveryRoot) ([]string, error) {
+	const localConfigPath = ".amq/launch.local.json"
+	data, err := projectRoot.ReadRegularNoFollow(localConfigPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return []string{LauncherCommands}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	config, err := ParseLocalConfig(localConfigPath, data)
+	if err != nil {
+		return nil, err
+	}
+	return slices.Clone(config.LauncherPreference), nil
+}
+
+func inspectPrepareRoster(root *fsq.DeliveryRoot, authorization *fsq.MailboxConfigAuthorization, participants []PrepareParticipant) (PrepareRoster, map[string]string, error) {
+	roster := PrepareRoster{Desired: []string{}, Present: []string{}, Missing: []string{}, Extra: []string{}}
+	states := make(map[string]string, len(participants))
+	for _, participant := range participants {
+		roster.Desired = append(roster.Desired, participant.Handle)
+		states[participant.Handle] = "missing"
+	}
+	slices.Sort(roster.Desired)
+	if root == nil {
+		roster.Missing = slices.Clone(roster.Desired)
+		return roster, states, nil
+	}
+	var inventory fsq.MailboxInventory
+	var err error
+	if authorization != nil {
+		inventory, err = fsq.InspectMailboxLayoutWithAuthorization(root, authorization)
+	} else {
+		inventory, err = fsq.InspectMailboxLayout(root)
+	}
+	if err != nil {
+		return PrepareRoster{}, nil, err
+	}
+	desired := make(map[string]struct{}, len(roster.Desired))
+	for _, handle := range roster.Desired {
+		desired[handle] = struct{}{}
+	}
+	for _, mailbox := range inventory.Mailboxes {
+		state := "invalid"
+		if mailbox.Status == "ok" {
+			state = "present"
+		}
+		states[mailbox.Handle] = state
+		if _, ok := desired[mailbox.Handle]; ok {
+			if state == "present" {
+				roster.Present = append(roster.Present, mailbox.Handle)
+			} else {
+				roster.Missing = append(roster.Missing, mailbox.Handle)
+			}
+		} else {
+			roster.Extra = append(roster.Extra, mailbox.Handle)
+		}
+	}
+	for _, handle := range roster.Desired {
+		if states[handle] == "missing" {
+			roster.Missing = append(roster.Missing, handle)
+		}
+	}
+	slices.Sort(roster.Present)
+	slices.Sort(roster.Missing)
+	slices.Sort(roster.Extra)
+	return roster, states, nil
+}
+
+func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetState, dependencies PrepareDependencies, mailbox string) (PreparedParticipant, PrepareObservation, *AgentPlan, []PrepareRequiredAction, error) {
+	prepared := PreparedParticipant{
+		Handle: participant.Handle, Runnable: participant.Runnable, Provider: participant.Provider,
+		ResumePolicy: participant.ResumePolicy, Execution: participant.Execution, PlannedOutcome: "participant_only",
+	}
+	observation := PrepareObservation{
+		Handle: participant.Handle, Mailbox: mailbox, Runnable: participant.Runnable,
+		Conversation: "none", ConversationIdentityDigest: "absent",
+		Execution: "none", ExecutionIdentityDigest: "absent", Resource: "none",
+	}
+	if state.sessionRoot != nil {
+		if ticket, err := LoadExecutionTicket(state.sessionRoot, participant.Handle); err == nil {
+			observation.Execution = string(ticket.State)
+			observation.ExecutionIdentityDigest, err = digestCanonical(ticket)
+			if err != nil {
+				return prepared, observation, nil, nil, err
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return prepared, observation, nil, nil, err
+		}
+	}
+	conversation, hasConversation, err := loadPrepareConversation(state.sessionRoot, participant.Handle)
+	if err != nil {
+		return prepared, observation, nil, nil, err
+	}
+	if hasConversation {
+		observation.Conversation = string(conversation.State)
+		observation.ConversationIdentityDigest, err = digestCanonical(conversation)
+		if err != nil {
+			return prepared, observation, nil, nil, err
+		}
+	}
+	if !participant.Runnable {
+		return prepared, observation, nil, nil, nil
+	}
+	if dependencies.AdapterFor == nil {
+		return prepared, observation, nil, nil, fmt.Errorf("prepare adapter factory is missing")
+	}
+
+	cwd, err := resolvePrepareCwd(state.target.ProjectRoot, participant.Cwd)
+	if err != nil {
+		return prepared, observation, nil, nil, err
+	}
+	prepared.CwdIdentity, err = fsq.StableTreeIdentity(cwd)
+	if err != nil {
+		return prepared, observation, nil, nil, fmt.Errorf("identify cwd for %s: %w", participant.Handle, err)
+	}
+	adapter := dependencies.AdapterFor(participant.Provider, participant.Executable)
+	if adapter == nil {
+		return prepared, observation, nil, nil, fmt.Errorf("provider %q has no adapter", participant.Provider)
+	}
+
+	base := PlanRequest{
+		Handle: participant.Handle, ProjectRoot: state.target.ProjectRoot, Cwd: cwd, AllowExternalCwd: true,
+		LaunchNonce: preparePlaceholderUUID, ResumePolicy: participant.ResumePolicy,
+		CommittedArgs: slices.Clone(participant.Args), BypassArgs: slices.Clone(participant.BypassArgs), EnvOverlay: cloneEnv(participant.EnvOverlay),
+	}
+	var plan AgentPlan
+	var actions []PrepareRequiredAction
+	useResume := participant.ResumePolicy == ResumeEnabled && hasConversation && conversation.State == CaptureReady
+	if useResume {
+		plan, err = adapter.PlanResume(ResumeRequest{PlanRequest: base, Conversation: conversation.Identity})
+		prepared.PlannedOutcome = "resume"
+	} else {
+		if participant.ResumePolicy == ResumeEnabled && hasConversation {
+			actions = append(actions, PrepareRequiredAction{
+				Kind: ActionStaleConversation, Handles: []string{participant.Handle},
+				AllowedDecisions: []string{"fresh_once", "abort"}, ReasonCode: ReasonStaleConversation,
+			})
+			if conversation.State == CapturePending {
+				prepared.PlannedOutcome = "capture_pending"
+				return prepared, observation, nil, actions, nil
+			}
+		}
+		base.ResumePolicy = participant.ResumePolicy
+		plan, err = adapter.PlanFresh(base)
+		prepared.PlannedOutcome = "fresh"
+		if participant.ResumePolicy == ResumeDisabled {
+			prepared.PlannedOutcome = "fresh_without_continuation"
+		}
+	}
+	if err != nil {
+		return prepared, observation, nil, actions, err
+	}
+	prepared.Command = previewStaticCommand(plan)
+	return prepared, observation, &plan, actions, nil
+}
+
+func resolvePrepareCwd(projectRoot, cwd string) (string, error) {
+	if !filepath.IsAbs(cwd) {
+		cwd = filepath.Join(projectRoot, cwd)
+	}
+	resolved, err := resolvedPath(cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("stat working directory: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("working directory is not a directory")
+	}
+	return resolved, nil
+}
+
+func loadPrepareConversation(root *fsq.DeliveryRoot, handle string) (ConversationRecord, bool, error) {
+	if root == nil {
+		return ConversationRecord{}, false, nil
+	}
+	record, err := LoadConversation(root, handle)
+	if errors.Is(err, os.ErrNotExist) {
+		return ConversationRecord{}, false, nil
+	}
+	return record, err == nil, err
+}
+
+func previewStaticCommand(plan AgentPlan) *PrepareCommand {
+	argv := slices.Clone(plan.Argv)
+	for _, dynamic := range plan.DynamicArgv {
+		switch dynamic.Kind {
+		case DynamicArgLaunchNonce:
+			argv[dynamic.Index] = "${launch_nonce}"
+		case DynamicArgConversationID:
+			argv[dynamic.Index] = "${conversation_id}"
+		}
+	}
+	return &PrepareCommand{Argv: argv, Cwd: plan.Cwd, EnvOverlay: cloneEnv(plan.EnvOverlay)}
+}
+
+func prepareRebindActions(binding *BindingRecord, observation prepareBindingObservation, boundDetect DetectResult, selectedBackend, selectedProfile, hostIdentity string) []PrepareRequiredAction {
+	if binding == nil {
+		return nil
+	}
+	foreign := prepareBindingForeign(*binding, boundDetect, hostIdentity)
+	incompatible := binding.Backend != selectedBackend || binding.Profile != selectedProfile
+	if !foreign && !incompatible {
+		return nil
+	}
+	allowed := []string{"close_old", "leave_old", "abort"}
+	reason := "rebind_confirmation_required"
+	if foreign {
+		allowed, reason = []string{"leave_old", "abort"}, "foreign_binding"
+	}
+	resources := make([]string, 0, len(binding.Resources.Resources))
+	for _, resource := range binding.Resources.Resources {
+		resources = append(resources, resource.OpaqueID)
+	}
+	slices.Sort(resources)
+	return []PrepareRequiredAction{{
+		Kind: ActionRebindConfirmation, Resources: resources, AllowedDecisions: allowed, ReasonCode: reason,
+	}}
+}
+
+func prepareBindingForeign(binding BindingRecord, detect DetectResult, hostIdentity string) bool {
+	if hostIdentity == "" || detect.InstanceIdentity == "" {
+		return true
+	}
+	if binding.HostIdentity != hostIdentity {
+		return true
+	}
+	return binding.InstanceIdentity != detect.InstanceIdentity
+}
+
+func applyBindingResources(observations []PrepareObservation, binding *BindingRecord) {
+	if binding == nil {
+		return
+	}
+	resources := make(map[string]string, len(binding.Resources.Resources))
+	for _, resource := range binding.Resources.Resources {
+		if resource.Agent != "" {
+			resources[resource.Agent] = resource.OpaqueID
+		}
+	}
+	for i := range observations {
+		if resource := resources[observations[i].Handle]; resource != "" {
+			observations[i].Resource = resource
+		}
+	}
+}
+
+func appendExtraObservations(result *PrepareResult, extras []string, mailboxStates map[string]string, binding *BindingRecord, root *fsq.DeliveryRoot) error {
+	for _, handle := range extras {
+		observation := PrepareObservation{
+			Handle: handle, Mailbox: mailboxStates[handle], Conversation: "none", ConversationIdentityDigest: "absent",
+			Execution: "none", ExecutionIdentityDigest: "absent", Resource: "none", ReasonCode: "extra_mailbox_preserved",
+		}
+		if conversation, present, err := loadPrepareConversation(root, handle); err != nil {
+			return err
+		} else if present {
+			observation.Conversation = string(conversation.State)
+			observation.ConversationIdentityDigest, err = digestCanonical(conversation)
+			if err != nil {
+				return err
+			}
+		}
+		if root != nil {
+			if ticket, err := LoadExecutionTicket(root, handle); err == nil {
+				observation.Execution = string(ticket.State)
+				observation.ExecutionIdentityDigest, err = digestCanonical(ticket)
+				if err != nil {
+					return err
+				}
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+		}
+		if binding != nil {
+			for _, resource := range binding.Resources.Resources {
+				if resource.Agent == handle {
+					observation.Resource = resource.OpaqueID
+					break
+				}
+			}
+		}
+		result.Observations = append(result.Observations, observation)
+	}
+	return nil
+}
+
+func loadPrepareTrust(store *TrustStore, digest string) (bool, error) {
+	if store == nil {
+		return false, nil
+	}
+	_, trusted, err := store.LoadForDigest(digest)
+	return trusted, err
+}
+
+func prepareActionID(action PrepareRequiredAction) (string, error) {
+	action.ActionID = ""
+	return digestCanonical(struct {
+		Version          int                `json:"version"`
+		Kind             RequiredActionKind `json:"kind"`
+		Handles          []string           `json:"handles"`
+		Resources        []string           `json:"resources"`
+		AllowedDecisions []string           `json:"allowed_decisions"`
+		ReasonCode       string             `json:"reason_code"`
+	}{1, action.Kind, action.Handles, action.Resources, action.AllowedDecisions, action.ReasonCode})
+}
+
+func comparePrepareActions(left, right PrepareRequiredAction) int {
+	if value := strings.Compare(string(left.Kind), string(right.Kind)); value != 0 {
+		return value
+	}
+	return strings.Compare(left.ActionID, right.ActionID)
+}
+
+func digestCanonical(value any) (string, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/launch/prepare_test.go
+++ b/internal/launch/prepare_test.go
@@ -1,0 +1,434 @@
+package launch
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestPrepareOwningLayerIsZeroWriteAndBuildsTypedActions(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	writePrepareConversation(t, fixture.sessionRoot, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureStale,
+		LaunchNonce: "11111111-1111-4111-8111-111111111111", Reason: CaptureReasonEvidenceMissing,
+	})
+	writePrepareBinding(t, fixture.sessionRoot, prepareBinding("host:test", "instance:test", "11111111-1111-4111-8111-111111111111"))
+	backend := &prepareTestBackend{}
+	before := prepareTreeSnapshot(t, fixture.root)
+
+	first, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := prepareTreeSnapshot(t, fixture.root)
+	if before != after {
+		t.Fatalf("Prepare changed filesystem: before %s, after %s", before, after)
+	}
+	if backend.detects != 2 || backend.creates != 0 || backend.closes != 0 || backend.focuses != 0 || backend.inspects != 2 {
+		t.Fatalf("backend calls = detect:%d inspect:%d create:%d close:%d focus:%d", backend.detects, backend.inspects, backend.creates, backend.closes, backend.focuses)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repeated Prepare changed result:\n%#v\n%#v", first, second)
+	}
+	if first.Outcome != PrepareOutcomeActionRequired || len(first.RequiredActions) != 2 {
+		t.Fatalf("Prepare result = %#v", first)
+	}
+	kinds := []RequiredActionKind{first.RequiredActions[0].Kind, first.RequiredActions[1].Kind}
+	if !slices.Equal(kinds, []RequiredActionKind{ActionStaleConversation, ActionTrustConfirmation}) {
+		t.Fatalf("action kinds = %v", kinds)
+	}
+	for _, action := range first.RequiredActions {
+		if !validDigest(action.ActionID) {
+			t.Fatalf("action ID = %q", action.ActionID)
+		}
+	}
+	if got := first.Participants[0].Command.Argv[len(first.Participants[0].Command.Argv)-1]; got != "${launch_nonce}" {
+		t.Fatalf("static command placeholder = %q", got)
+	}
+}
+
+func TestPrepareSubjectDigestIncludesBindingObservation(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	backend := &prepareTestBackend{}
+	writePrepareBinding(t, fixture.sessionRoot, prepareBinding("host:test", "instance:test", "11111111-1111-4111-8111-111111111111"))
+	first, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePrepareBinding(t, fixture.sessionRoot, prepareBinding("host:test", "instance:test", "22222222-2222-4222-8222-222222222222"))
+	second, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest || first.SubjectDigest == second.SubjectDigest {
+		t.Fatalf("binding-only digest change = plan:%t trust:%t subject:%t",
+			first.PlanDigest != second.PlanDigest,
+			first.TrustDigest != second.TrustDigest,
+			first.SubjectDigest != second.SubjectDigest)
+	}
+}
+
+func TestPrepareSubjectDigestIncludesPrivateConversationIdentity(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	backend := &prepareTestBackend{}
+	firstID := "11111111-1111-4111-8111-111111111111"
+	secondID := "22222222-2222-4222-8222-222222222222"
+	writePrepareConversation(t, fixture.sessionRoot, readyPrepareConversation(firstID))
+	first, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePrepareConversation(t, fixture.sessionRoot, readyPrepareConversation(secondID))
+	second, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Observations[0].Conversation != second.Observations[0].Conversation ||
+		first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest || first.SubjectDigest == second.SubjectDigest {
+		t.Fatalf("conversation-identity-only change = public-state:%t plan:%t trust:%t subject:%t",
+			first.Observations[0].Conversation != second.Observations[0].Conversation,
+			first.PlanDigest != second.PlanDigest,
+			first.TrustDigest != second.TrustDigest,
+			first.SubjectDigest != second.SubjectDigest)
+	}
+}
+
+func TestPrepareForeignBindingRestrictsRebindDecision(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	backend := &prepareTestBackend{}
+	writePrepareBinding(t, fixture.sessionRoot, prepareBinding("host:foreign", "instance:test", "11111111-1111-4111-8111-111111111111"))
+	result, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rebind *PrepareRequiredAction
+	for i := range result.RequiredActions {
+		if result.RequiredActions[i].Kind == ActionRebindConfirmation {
+			rebind = &result.RequiredActions[i]
+		}
+	}
+	if rebind == nil || rebind.ReasonCode != "foreign_binding" || !slices.Equal(rebind.AllowedDecisions, []string{"leave_old", "abort"}) {
+		t.Fatalf("foreign rebind action = %#v", rebind)
+	}
+	if backend.closes != 0 || backend.focuses != 0 || backend.creates != 0 {
+		t.Fatalf("Prepare mutated foreign backend: %#v", backend)
+	}
+}
+
+func TestPrepareCapturePendingRequiresDecisionWithoutFreshPlan(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	writePrepareConversation(t, fixture.sessionRoot, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CapturePending,
+		LaunchNonce: "11111111-1111-4111-8111-111111111111",
+	})
+	result, err := Prepare(context.Background(), fixture.request, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.RequiredActions) != 1 || result.RequiredActions[0].Kind != ActionStaleConversation {
+		t.Fatalf("pending actions = %#v", result.RequiredActions)
+	}
+	if result.Participants[0].PlannedOutcome != "capture_pending" || result.Participants[0].Command != nil {
+		t.Fatalf("pending participant = %#v", result.Participants[0])
+	}
+}
+
+func TestPreparePinsMailboxConfigThroughFinalVerification(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	configPath := filepath.Join(fixture.sessionRoot, "meta", "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"version":1,"agents":["claude"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dependencies := fixture.dependencies(&prepareTestBackend{})
+	dependencies.AdapterFor = func(provider, executable string) HarnessAdapter {
+		return hookPrepareAdapter{
+			prepareTestAdapter: prepareTestAdapter{provider: provider},
+			beforePlan: func() {
+				if err := os.WriteFile(configPath, []byte(`{"version":1,"agents":["claude","operator"]}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		}
+	}
+	if _, err := Prepare(context.Background(), fixture.request, dependencies); err == nil {
+		t.Fatal("Prepare accepted a mailbox config changed after roster inspection")
+	}
+}
+
+func TestPrepareTreatsMissingRuntimeIdentityAsForeign(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	writePrepareBinding(t, fixture.sessionRoot, prepareBinding("host:test", "instance:test", "11111111-1111-4111-8111-111111111111"))
+	backend := &missingIdentityPrepareBackend{}
+	dependencies := PrepareDependencies{
+		Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	}
+	result, err := Prepare(context.Background(), fixture.request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != PrepareOutcomeActionRequired {
+		t.Fatalf("missing-identity outcome = %q", result.Outcome)
+	}
+	var rebind *PrepareRequiredAction
+	for i := range result.RequiredActions {
+		if result.RequiredActions[i].Kind == ActionRebindConfirmation {
+			rebind = &result.RequiredActions[i]
+		}
+	}
+	if rebind == nil || rebind.ReasonCode != "foreign_binding" || !slices.Equal(rebind.AllowedDecisions, []string{"leave_old", "abort"}) {
+		t.Fatalf("missing-identity rebind = %#v", rebind)
+	}
+	if backend.inspects != 0 {
+		t.Fatalf("Prepare inspected a binding with unknown runtime identity: %d", backend.inspects)
+	}
+}
+
+func TestTmuxDetectDoesNotMutateBackend(t *testing.T) {
+	backend := NewTmuxBackend("sh")
+	backend.run = func(context.Context, ...string) (string, error) { return "tmux 3.4", nil }
+	backend.hostname = func() (string, error) { return "host:test", nil }
+	before := backend.binary
+	if result := backend.Detect(); !result.Available {
+		t.Fatalf("tmux detection = %#v", result)
+	}
+	if backend.binary != before {
+		t.Fatalf("Detect mutated binary from %q to %q", before, backend.binary)
+	}
+}
+
+type internalPrepareFixture struct {
+	root        string
+	projectRoot string
+	sessionRoot string
+	cwd         string
+	request     PrepareRequest
+}
+
+func newInternalPrepareFixture(t *testing.T) internalPrepareFixture {
+	t.Helper()
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	cwd := filepath.Join(root, "sibling")
+	base := filepath.Join(root, "mail")
+	session := filepath.Join(base, "collab")
+	for _, path := range []string{project, cwd, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	return internalPrepareFixture{
+		root: root, projectRoot: project, sessionRoot: session, cwd: cwd,
+		request: PrepareRequest{
+			Target:   PrepareTarget{ProjectRoot: project, SessionRoot: session, Session: "collab"},
+			Launcher: "test", IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'a'}, 64)),
+			Participants: []PrepareParticipant{{
+				Handle: "claude", Runnable: true, Provider: ClaudeProvider, Executable: "claude",
+				Cwd: cwd, ResumePolicy: ResumeEnabled,
+				Execution: PrepareExecutionOptions{WakeMode: "enabled"},
+			}},
+		},
+	}
+}
+
+func (fixture internalPrepareFixture) dependencies(backend *prepareTestBackend) PrepareDependencies {
+	return PrepareDependencies{
+		Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"},
+		AdapterFor: func(provider, executable string) HarnessAdapter {
+			return prepareTestAdapter{provider: provider}
+		},
+		HostIdentity: "host:test",
+	}
+}
+
+type prepareTestAdapter struct{ provider string }
+
+type hookPrepareAdapter struct {
+	prepareTestAdapter
+	beforePlan func()
+}
+
+func (adapter hookPrepareAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) {
+	adapter.beforePlan()
+	return adapter.prepareTestAdapter.PlanFresh(request)
+}
+
+func (adapter prepareTestAdapter) Name() string       { return adapter.provider }
+func (prepareTestAdapter) Mode() AdapterMode          { return AdapterModeMint }
+func (prepareTestAdapter) CommittedEnvKeys() []string { return nil }
+func (adapter prepareTestAdapter) Capabilities(context.Context) AdapterCapabilities {
+	return AdapterCapabilities{Provider: adapter.provider, Mode: adapter.Mode(), Available: true, ProviderVersion: "test", Fresh: true, Resume: true}
+}
+func (adapter prepareTestAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) {
+	plan := AgentPlan{
+		Handle: request.Handle, Argv: []string{"claude", "--session-id", request.LaunchNonce}, Cwd: request.Cwd,
+		AdapterMode: adapter.Mode(), ResumePolicy: request.ResumePolicy, LaunchNonce: request.LaunchNonce,
+		ConversationID: request.LaunchNonce, DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgLaunchNonce}},
+	}
+	return plan, plan.Validate()
+}
+func (adapter prepareTestAdapter) PlanResume(request ResumeRequest) (AgentPlan, error) {
+	plan := AgentPlan{
+		Handle: request.Handle, Argv: []string{"claude", "--resume", request.Conversation.ID}, Cwd: request.Cwd,
+		AdapterMode: adapter.Mode(), ResumePolicy: request.ResumePolicy, LaunchNonce: request.LaunchNonce,
+		ConversationID: request.Conversation.ID, DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgConversationID}},
+	}
+	return plan, plan.Validate()
+}
+func (prepareTestAdapter) CaptureIdentity(CaptureRequest) CaptureResult {
+	return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonAdapterMintsIdentity}
+}
+
+type prepareTestBackend struct {
+	detects  int
+	inspects int
+	creates  int
+	closes   int
+	focuses  int
+}
+
+type missingIdentityPrepareBackend struct{ prepareTestBackend }
+
+func (*missingIdentityPrepareBackend) Detect() DetectResult {
+	profile := Profile{Backend: "test", Platform: "test", VersionRange: "*", Version: 1, Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus}}
+	return DetectResult{Available: true, Profile: profile, HostIdentity: "host:test", Effective: slices.Clone(profile.Capabilities)}
+}
+
+func (backend *prepareTestBackend) Detect() DetectResult {
+	backend.detects++
+	profile := Profile{Backend: "test", Platform: "test", VersionRange: "*", Version: 1, Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus}}
+	return DetectResult{Available: true, Profile: profile, HostIdentity: "host:test", InstanceIdentity: "instance:test", Effective: slices.Clone(profile.Capabilities)}
+}
+func (backend *prepareTestBackend) Create(CreateRequest) (CreateResult, error) {
+	backend.creates++
+	return CreateResult{}, fmt.Errorf("Prepare called Create")
+}
+func (backend *prepareTestBackend) Inspect(InspectRequest) (InspectResult, error) {
+	backend.inspects++
+	return InspectResult{Status: InspectPresent, Evidence: "test-present"}, nil
+}
+func (backend *prepareTestBackend) Close(CloseRequest) (CloseResult, error) {
+	backend.closes++
+	return CloseResult{}, fmt.Errorf("Prepare called Close")
+}
+func (backend *prepareTestBackend) Focus(FocusRequest) (FocusResult, error) {
+	backend.focuses++
+	return FocusResult{}, fmt.Errorf("Prepare called Focus")
+}
+
+func prepareBinding(host, instance, nonce string) BindingRecord {
+	return BindingRecord{
+		Version: BindingVersion, Backend: "test", HostIdentity: host, InstanceIdentity: instance,
+		Profile: "test/test/v1", LaunchNonce: nonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:claude", Agent: "claude"}}},
+	}
+}
+
+func readyPrepareConversation(identity string) ConversationRecord {
+	launchNonce := "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	return ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity: ConversationIdentity{Provider: ClaudeProvider, ID: identity}, ProviderVersion: "test",
+		LaunchNonce: launchNonce,
+		ExecutionEvidence: &ConversationExecutionEvidence{
+			Backend: "test", Profile: "test/test/v1", Outcome: OutcomeCreated,
+			LaunchNonce: launchNonce, ConversationID: identity,
+		},
+	}
+}
+
+func writePrepareBinding(t *testing.T, rootPath string, binding BindingRecord) {
+	t.Helper()
+	withPrepareLease(t, rootPath, []string{"claude"}, func(root *fsq.DeliveryRoot, lease *Lease) error {
+		return WriteBinding(root, lease, binding)
+	})
+}
+
+func writePrepareConversation(t *testing.T, rootPath string, record ConversationRecord) {
+	t.Helper()
+	withPrepareLease(t, rootPath, []string{record.Handle}, func(root *fsq.DeliveryRoot, lease *Lease) error {
+		return WriteConversation(root, lease, record)
+	})
+}
+
+func withPrepareLease(t *testing.T, rootPath string, handles []string, operation func(*fsq.DeliveryRoot, *Lease) error) {
+	t.Helper()
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	lease, err := AcquireLease(root, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := lease.Release(); err != nil {
+			t.Error(err)
+		}
+	}()
+	if err := lease.LockHandles(handles...); err != nil {
+		t.Fatal(err)
+	}
+	if err := operation(root, lease); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func prepareTreeSnapshot(t *testing.T, root string) string {
+	t.Helper()
+	var snapshot bytes.Buffer
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(&snapshot, "%s\x00%s\x00%04o\x00", filepath.ToSlash(relative), entry.Type(), info.Mode().Perm())
+		if entry.Type().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			snapshot.Write(data)
+		}
+		snapshot.WriteByte(0)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(snapshot.Bytes())
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/launch/tmux.go
+++ b/internal/launch/tmux.go
@@ -61,7 +61,7 @@ func TmuxProfile() Profile {
 func (b *TmuxBackend) Detect() DetectResult {
 	profile := TmuxProfile()
 	result := DetectResult{Profile: profile}
-	path, err := exec.LookPath(b.binary)
+	_, err := exec.LookPath(b.binary)
 	if err != nil {
 		return result
 	}
@@ -75,7 +75,6 @@ func (b *TmuxBackend) Detect() DetectResult {
 	if err != nil || strings.TrimSpace(host) == "" {
 		return result
 	}
-	b.binary = path
 	result.Available = true
 	result.HostIdentity = host
 	result.InstanceIdentity = "tmux-socket:" + b.socketPath()

--- a/internal/launch/trust_digest.go
+++ b/internal/launch/trust_digest.go
@@ -42,6 +42,30 @@ func ExecutionTrustDigest(plan Plan, session string, root *fsq.DeliveryRoot) (st
 	if err != nil {
 		return "", fmt.Errorf("resolve trust session-root identity: %w", err)
 	}
+	return executionTrustDigest(planDigest, session, rootPath, rootIdentity)
+}
+
+// PrepareTrustDigest binds a nonce-free plan digest to the canonical target
+// and its physical identity. For an absent session, rootIdentity is a stable
+// intended-child identity derived from the pinned parent and child name.
+func PrepareTrustDigest(planDigest, session, rootPath, rootIdentity string) (string, error) {
+	if !validDigest(planDigest) {
+		return "", fmt.Errorf("invalid prepare plan digest")
+	}
+	if !canonicalSessionPattern.MatchString(session) || strings.HasPrefix(session, "-") {
+		return "", fmt.Errorf("invalid trust session %q", session)
+	}
+	if strings.TrimSpace(rootPath) == "" || strings.TrimSpace(rootIdentity) == "" {
+		return "", fmt.Errorf("prepare trust target identity is incomplete")
+	}
+	canonicalRoot, err := resolvedPath(rootPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve prepare trust session root: %w", err)
+	}
+	return executionTrustDigest(planDigest, session, canonicalRoot, rootIdentity)
+}
+
+func executionTrustDigest(planDigest, session, rootPath, rootIdentity string) (string, error) {
 	canonical, err := json.Marshal(struct {
 		Version      int    `json:"version"`
 		PlanDigest   string `json:"plan_digest"`

--- a/internal/launch/trust_digest_test.go
+++ b/internal/launch/trust_digest_test.go
@@ -32,6 +32,30 @@ func TestExecutionTrustDigestBindsSessionAndPhysicalRoot(t *testing.T) {
 	}
 }
 
+func TestPrepareTrustDigestMatchesExistingTrustSubjectForPresentRoot(t *testing.T) {
+	_, root := openTestRoot(t)
+	plan := validPlan()
+	planDigest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootIdentity, err := fsq.StableTreeIdentityInfo(root.FileInfo())
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := PrepareTrustDigest(planDigest, "collab", root.Base(), rootIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing, err := ExecutionTrustDigest(plan, "collab", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared != existing {
+		t.Fatalf("Prepare trust digest %q differs from existing execution trust digest %q", prepared, existing)
+	}
+}
+
 func TestExecutionTrustDigestRejectsSamePathRootReplacement(t *testing.T) {
 	parent := t.TempDir()
 	path := filepath.Join(parent, "session")

--- a/launchapi/external_test.go
+++ b/launchapi/external_test.go
@@ -27,12 +27,20 @@ replace github.com/avivsinai/agent-message-queue => %s
 	consumerTest := `package consumer
 
 import (
-    "testing"
+	"context"
+	"testing"
 
     "github.com/avivsinai/agent-message-queue/launchapi"
 )
 
 func TestContract(t *testing.T) {
+	var prepare func(context.Context, launchapi.PrepareRequestV1) (launchapi.PrepareResultV1, error) = launchapi.Prepare
+	_ = prepare
+	var action launchapi.RequiredActionKindV1 = launchapi.RequiredActionTrustConfirmation
+	var choice launchapi.DecisionChoiceV1 = launchapi.DecisionTrustExactSubject
+	if action == "" || choice == "" {
+		t.Fatal("typed Prepare action contract is empty")
+	}
     intent := launchapi.LaunchIntentV1{
         IntentVersion: launchapi.IntentVersionV1,
         Participants: []launchapi.ParticipantV1{{Handle: "operator", Runnable: false}},

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -1,0 +1,216 @@
+package launchapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+
+	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+// Prepare validates and compiles caller intent, then inspects the exact target
+// without creating or changing filesystem, trust, lease, or backend state.
+func Prepare(ctx context.Context, request PrepareRequestV1) (PrepareResultV1, error) {
+	if err := request.Validate(); err != nil {
+		return PrepareResultV1{}, err
+	}
+	intentDigest, err := launchIntentDigest(request.Intent)
+	if err != nil {
+		return PrepareResultV1{}, err
+	}
+	stateDir, err := internallaunch.DefaultLaunchStateDir()
+	if err != nil {
+		return PrepareResultV1{}, err
+	}
+	trustStore, err := internallaunch.OpenTrustStore(stateDir, request.Target.ProjectRoot)
+	if err != nil {
+		return PrepareResultV1{}, fmt.Errorf("open launch trust store: %w", err)
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		return PrepareResultV1{}, fmt.Errorf("resolve host identity: %w", err)
+	}
+	if host == "" {
+		return PrepareResultV1{}, fmt.Errorf("resolve host identity: empty hostname")
+	}
+	internalRequest := internallaunch.PrepareRequest{
+		Target: internallaunch.PrepareTarget{
+			ProjectRoot: request.Target.ProjectRoot,
+			SessionRoot: request.Target.SessionRoot,
+			Session:     request.Target.Session,
+		},
+		Launcher: request.Launcher, IntentDigest: intentDigest,
+		Participants: make([]internallaunch.PrepareParticipant, 0, len(request.Intent.Participants)),
+	}
+	for _, participant := range request.Intent.Participants {
+		provider := ""
+		var committedArgs, bypassArgs []string
+		if participant.Runnable {
+			provider, err = internallaunch.ValidateStaticProviderInput(participant.Executable, participant.Args, participant.EnvOverlay)
+			if err != nil {
+				return PrepareResultV1{}, err
+			}
+			committedArgs, bypassArgs, err = internallaunch.PartitionStaticProviderArgs(provider, participant.Args)
+			if err != nil {
+				return PrepareResultV1{}, err
+			}
+		}
+		internalRequest.Participants = append(internalRequest.Participants, toInternalPrepareParticipant(participant, provider, committedArgs, bypassArgs))
+	}
+	internalResult, err := internallaunch.Prepare(ctx, internalRequest, internallaunch.PrepareDependencies{
+		Backends: map[string]internallaunch.Backend{
+			internallaunch.LauncherCommands: internallaunch.Commands{},
+			internallaunch.LauncherTMux:     internallaunch.NewTmuxBackend("tmux"),
+		},
+		AdapterFor:   defaultPrepareAdapter,
+		TrustStore:   trustStore,
+		HostIdentity: host,
+	})
+	if err != nil {
+		return PrepareResultV1{}, err
+	}
+	return fromInternalPrepareResult(internalResult), nil
+}
+
+func defaultPrepareAdapter(provider, executable string) internallaunch.HarnessAdapter {
+	switch provider {
+	case internallaunch.ClaudeProvider:
+		return internallaunch.NewClaudeAdapter(executable)
+	case internallaunch.CodexProvider:
+		return internallaunch.NewCodexAdapter(executable)
+	default:
+		return nil
+	}
+}
+
+func toInternalPrepareParticipant(participant ParticipantV1, provider string, committedArgs, bypassArgs []string) internallaunch.PrepareParticipant {
+	result := internallaunch.PrepareParticipant{
+		Handle: participant.Handle, Runnable: participant.Runnable, Provider: provider,
+		Executable: participant.Executable, Args: slices.Clone(committedArgs), BypassArgs: slices.Clone(bypassArgs), EnvOverlay: cloneStringMap(participant.EnvOverlay),
+		ResumePolicy: internallaunch.ResumePolicy(participant.ResumePolicy),
+	}
+	if participant.Cwd != nil {
+		result.Cwd = participant.Cwd.Path
+	}
+	if participant.Execution != nil {
+		result.Execution = toInternalExecutionOptions(*participant.Execution)
+	}
+	return result
+}
+
+func toInternalExecutionOptions(options ExecutionOptionsV1) internallaunch.PrepareExecutionOptions {
+	result := internallaunch.PrepareExecutionOptions{
+		RequireWake: options.RequireWake, NoGitignore: options.NoGitignore,
+		WakeMode: string(options.Wake.Mode), AuditReason: options.Wake.AuditReason,
+	}
+	if options.Wake.Injector != nil {
+		result.InjectorMode = string(options.Wake.Injector.Mode)
+		result.InjectorVia = options.Wake.Injector.Via
+		result.InjectorArgs = slices.Clone(options.Wake.Injector.Args)
+	}
+	if options.Integrations.Symphony != nil {
+		result.SymphonyWorkspaceKey = options.Integrations.Symphony.WorkspaceKey
+		for _, event := range options.Integrations.Symphony.Events {
+			result.SymphonyEvents = append(result.SymphonyEvents, string(event))
+		}
+	}
+	return result
+}
+
+func fromInternalPrepareResult(result internallaunch.PrepareResult) PrepareResultV1 {
+	public := PrepareResultV1{
+		ResultVersion: ResultVersionV1, Outcome: result.Outcome, Reason: result.Reason,
+		SubjectDigest: result.SubjectDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
+		RequiredActions: make([]RequiredActionV1, 0, len(result.RequiredActions)),
+		Preview: PreviewV1{
+			Target:  TargetV1{ProjectRoot: result.Target.ProjectRoot, SessionRoot: result.Target.SessionRoot, Session: result.Target.Session},
+			Backend: result.Backend, Profile: result.Profile,
+			Participants: make([]ParticipantPreviewV1, 0, len(result.Participants)),
+			Roster: RosterDriftV1{
+				Desired: slices.Clone(result.Roster.Desired), Present: slices.Clone(result.Roster.Present),
+				Missing: slices.Clone(result.Roster.Missing), Extra: slices.Clone(result.Roster.Extra),
+			},
+		},
+		Observations: make([]ParticipantObservationV1, 0, len(result.Observations)),
+	}
+	for _, action := range result.RequiredActions {
+		allowed := make([]DecisionChoiceV1, len(action.AllowedDecisions))
+		for i, choice := range action.AllowedDecisions {
+			allowed[i] = DecisionChoiceV1(choice)
+		}
+		public.RequiredActions = append(public.RequiredActions, RequiredActionV1{
+			ActionID: action.ActionID, Kind: RequiredActionKindV1(action.Kind),
+			Handles: slices.Clone(action.Handles), Resources: slices.Clone(action.Resources),
+			AllowedDecisions: allowed, ReasonCode: action.ReasonCode,
+		})
+	}
+	for _, participant := range result.Participants {
+		preview := ParticipantPreviewV1{
+			Handle: participant.Handle, Runnable: participant.Runnable, Provider: participant.Provider,
+			ResumePolicy: ResumePolicy(participant.ResumePolicy), PlannedOutcome: participant.PlannedOutcome,
+		}
+		if participant.Command != nil {
+			preview.Command = &CommandV1{
+				Argv: slices.Clone(participant.Command.Argv), Cwd: participant.Command.Cwd,
+				EnvOverlay: cloneStringMap(participant.Command.EnvOverlay),
+			}
+		}
+		if participant.Runnable {
+			execution := fromInternalExecutionOptions(participant.Execution)
+			preview.Execution = &execution
+		}
+		public.Preview.Participants = append(public.Preview.Participants, preview)
+	}
+	for _, observation := range result.Observations {
+		public.Observations = append(public.Observations, ParticipantObservationV1{
+			Handle: observation.Handle, Mailbox: observation.Mailbox, Runnable: observation.Runnable,
+			Conversation: observation.Conversation, Execution: observation.Execution,
+			Resource: observation.Resource, ReasonCode: observation.ReasonCode,
+		})
+	}
+	return public
+}
+
+func fromInternalExecutionOptions(options internallaunch.PrepareExecutionOptions) ExecutionOptionsV1 {
+	result := ExecutionOptionsV1{
+		RequireWake: options.RequireWake, NoGitignore: options.NoGitignore,
+		Wake: WakeOptionsV1{Mode: WakePolicy(options.WakeMode), AuditReason: options.AuditReason},
+	}
+	if options.InjectorMode != "" {
+		result.Wake.Injector = &InjectorOptionsV1{
+			Mode: InjectorMode(options.InjectorMode), Via: options.InjectorVia, Args: slices.Clone(options.InjectorArgs),
+		}
+	}
+	if len(options.SymphonyEvents) > 0 || options.SymphonyWorkspaceKey != "" {
+		symphony := &SymphonyOptionsV1{WorkspaceKey: options.SymphonyWorkspaceKey}
+		for _, event := range options.SymphonyEvents {
+			symphony.Events = append(symphony.Events, SymphonyEvent(event))
+		}
+		result.Integrations.Symphony = symphony
+	}
+	return result
+}
+
+func launchIntentDigest(intent LaunchIntentV1) (string, error) {
+	data, err := json.Marshal(intent)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	if source == nil {
+		return nil
+	}
+	result := make(map[string]string, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -1,0 +1,416 @@
+package launchapi
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestPrepareIsZeroWriteAndDeterministic(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	before := snapshotTestTree(t, fixture.root)
+
+	first, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := snapshotTestTree(t, fixture.root)
+	if before != after {
+		t.Fatalf("Prepare changed filesystem snapshot: before %s, after %s", before, after)
+	}
+	if _, err := os.Stat(filepath.Join(fixture.root, "provider-probed")); !os.IsNotExist(err) {
+		t.Fatalf("Prepare executed the caller provider during its zero-write phase: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repeated Prepare changed result:\nfirst=%#v\nsecond=%#v", first, second)
+	}
+	if first.Outcome != PrepareOutcomeActionRequired || first.Reason != "untrusted_config_digest" {
+		t.Fatalf("outcome/reason = %q/%q", first.Outcome, first.Reason)
+	}
+	if len(first.RequiredActions) != 1 {
+		t.Fatalf("required actions = %#v", first.RequiredActions)
+	}
+	action := first.RequiredActions[0]
+	if action.Kind != RequiredActionTrustConfirmation ||
+		!slices.Equal(action.AllowedDecisions, []DecisionChoiceV1{DecisionTrustExactSubject, DecisionDeny}) ||
+		action.ActionID == "" {
+		t.Fatalf("trust action = %#v", action)
+	}
+	for _, digest := range []string{first.PlanDigest, first.TrustDigest, first.SubjectDigest, action.ActionID} {
+		if err := ValidateDigest(digest); err != nil {
+			t.Fatalf("digest %q: %v", digest, err)
+		}
+	}
+	if first.PlanDigest == first.TrustDigest || first.TrustDigest == first.SubjectDigest || first.PlanDigest == first.SubjectDigest {
+		t.Fatalf("distinct digest contract collapsed: %#v", first)
+	}
+	command := first.Preview.Participants[0].Command
+	if command == nil || !slices.Contains(command.Argv, "${launch_nonce}") || slices.Contains(command.Argv, prepareTestPlaceholderUUID) {
+		t.Fatalf("public command leaked runtime identity or omitted placeholder: %#v", command)
+	}
+	if command.Cwd != fixture.siblingCwd {
+		t.Fatalf("compiled sibling cwd = %q, want %q", command.Cwd, fixture.siblingCwd)
+	}
+	if !slices.Equal(first.Preview.Roster.Present, []string{"claude"}) || len(first.Preview.Roster.Missing) != 0 {
+		t.Fatalf("roster = %#v", first.Preview.Roster)
+	}
+}
+
+func TestPrepareParticipantOnlyAbsentSessionDoesNotProvision(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	before := snapshotTestTree(t, fixture.root)
+
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(fixture.request.Target.SessionRoot); !os.IsNotExist(err) {
+		t.Fatalf("Prepare provisioned absent session or returned unexpected stat error: %v", err)
+	}
+	if after := snapshotTestTree(t, fixture.root); after != before {
+		t.Fatalf("participant-only Prepare changed filesystem: before %s, after %s", before, after)
+	}
+	if result.Outcome != PrepareOutcomeReady || len(result.RequiredActions) != 0 {
+		t.Fatalf("participant-only result = %#v", result)
+	}
+	if !slices.Equal(result.Preview.Roster.Missing, []string{"operator"}) || result.Preview.Participants[0].Command != nil {
+		t.Fatalf("participant-only preview = %#v", result.Preview)
+	}
+	for _, digest := range []string{result.PlanDigest, result.TrustDigest, result.SubjectDigest} {
+		if err := ValidateDigest(digest); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestPrepareUnavailableLauncherIsTypedAndDoesNotRequestTrust(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	fixture.request.Launcher = "cmux"
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != PrepareOutcomeUnsupported || result.Reason != "launcher_not_available" || result.Preview.Backend != "cmux" {
+		t.Fatalf("unavailable launcher result = %#v", result)
+	}
+	if len(result.RequiredActions) != 0 {
+		t.Fatalf("unavailable launcher requested decisions for an inapplicable plan: %#v", result.RequiredActions)
+	}
+}
+
+func TestPrepareCompilesAdapterBypassArguments(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	fixture.request.Intent.Participants[0].Args = []string{"--model", "test-model", "--dangerously-skip-permissions"}
+
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := result.Preview.Participants[0].Command
+	if command == nil || !slices.Contains(command.Argv, "--dangerously-skip-permissions") {
+		t.Fatalf("compiled bypass command = %#v", command)
+	}
+}
+
+func TestPrepareReportsConfiguredOnlyExtraMailbox(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	config := []byte(`{"version":1,"agents":["claude","operator"]}`)
+	if err := os.WriteFile(filepath.Join(fixture.request.Target.SessionRoot, "meta", "config.json"), config, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(result.Preview.Roster.Extra, []string{"operator"}) {
+		t.Fatalf("configured-only extras = %v", result.Preview.Roster.Extra)
+	}
+	if len(result.Observations) != 2 || result.Observations[1].Handle != "operator" || result.Observations[1].Mailbox == "present" {
+		t.Fatalf("configured-only observation = %#v", result.Observations)
+	}
+}
+
+func TestPrepareSubjectDigestTracksFrozenInputs(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	baseline, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	optionsChanged := fixture.request
+	optionsChanged.Intent.Participants = slices.Clone(fixture.request.Intent.Participants)
+	participant := optionsChanged.Intent.Participants[0]
+	execution := *participant.Execution
+	execution.NoGitignore = !execution.NoGitignore
+	participant.Execution = &execution
+	optionsChanged.Intent.Participants[0] = participant
+	withOptions, err := Prepare(context.Background(), optionsChanged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withOptions.PlanDigest != baseline.PlanDigest || withOptions.TrustDigest != baseline.TrustDigest || withOptions.SubjectDigest == baseline.SubjectDigest {
+		t.Fatalf("option-only digest change = plan %t trust %t subject %t",
+			withOptions.PlanDigest != baseline.PlanDigest,
+			withOptions.TrustDigest != baseline.TrustDigest,
+			withOptions.SubjectDigest != baseline.SubjectDigest)
+	}
+
+	otherBase := filepath.Join(fixture.root, "other-mail")
+	otherSession := filepath.Join(otherBase, "collab")
+	if err := os.MkdirAll(otherBase, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureRootDirs(otherSession); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(otherSession, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	rootChanged := fixture.request
+	rootChanged.Target.SessionRoot = otherSession
+	withRoot, err := Prepare(context.Background(), rootChanged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withRoot.PlanDigest != baseline.PlanDigest || withRoot.TrustDigest == baseline.TrustDigest || withRoot.SubjectDigest == baseline.SubjectDigest {
+		t.Fatalf("root-only digest change = plan %t trust %t subject %t",
+			withRoot.PlanDigest != baseline.PlanDigest,
+			withRoot.TrustDigest != baseline.TrustDigest,
+			withRoot.SubjectDigest != baseline.SubjectDigest)
+	}
+}
+
+func TestPrepareSubjectDigestTracksCwdIdentityAndRosterObservation(t *testing.T) {
+	t.Run("cwd physical identity", func(t *testing.T) {
+		fixture := newPublicPrepareFixture(t, true)
+		first, err := Prepare(context.Background(), fixture.request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cwd := fixture.request.Intent.Participants[0].Cwd.Path
+		if err := os.Rename(cwd, cwd+"-detached"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(cwd, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		second, err := Prepare(context.Background(), fixture.request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest || first.SubjectDigest == second.SubjectDigest {
+			t.Fatalf("cwd identity change = plan:%t trust:%t subject:%t",
+				first.PlanDigest != second.PlanDigest,
+				first.TrustDigest != second.TrustDigest,
+				first.SubjectDigest != second.SubjectDigest)
+		}
+	})
+
+	t.Run("roster observation", func(t *testing.T) {
+		fixture := newPublicPrepareFixture(t, true)
+		first, err := Prepare(context.Background(), fixture.request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := fsq.EnsureAgentDirs(fixture.request.Target.SessionRoot, "operator"); err != nil {
+			t.Fatal(err)
+		}
+		second, err := Prepare(context.Background(), fixture.request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest || first.SubjectDigest == second.SubjectDigest {
+			t.Fatalf("roster-only change = plan:%t trust:%t subject:%t",
+				first.PlanDigest != second.PlanDigest,
+				first.TrustDigest != second.TrustDigest,
+				first.SubjectDigest != second.SubjectDigest)
+		}
+		if !slices.Equal(second.Preview.Roster.Extra, []string{"operator"}) {
+			t.Fatalf("extra roster = %v", second.Preview.Roster.Extra)
+		}
+	})
+}
+
+func TestPrepareTrustObservationChangesOnlySubjectAndActions(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	first, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := internallaunch.OpenTrustStore(filepath.Join(fixture.root, "state", "amq"), fixture.request.Target.ProjectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Replace(internallaunch.TrustRecord{SemanticDigest: first.TrustDigest}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest || first.SubjectDigest == second.SubjectDigest {
+		t.Fatalf("trust-only change = plan:%t trust:%t subject:%t",
+			first.PlanDigest != second.PlanDigest,
+			first.TrustDigest != second.TrustDigest,
+			first.SubjectDigest != second.SubjectDigest)
+	}
+	if len(first.RequiredActions) != 1 || len(second.RequiredActions) != 0 || second.Outcome != PrepareOutcomeReady {
+		t.Fatalf("trust actions before=%#v after=%#v outcome=%s", first.RequiredActions, second.RequiredActions, second.Outcome)
+	}
+}
+
+const prepareTestPlaceholderUUID = "00000000-0000-4000-8000-000000000000"
+
+type publicPrepareFixture struct {
+	root       string
+	siblingCwd string
+	request    PrepareRequestV1
+}
+
+func newPublicPrepareFixture(t *testing.T, existingSession bool) publicPrepareFixture {
+	t.Helper()
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	sibling := filepath.Join(root, "sibling-worktree")
+	base := filepath.Join(root, "mail")
+	session := filepath.Join(base, "collab")
+	for _, path := range []string{project, sibling, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if existingSession {
+		if err := fsq.EnsureRootDirs(session); err != nil {
+			t.Fatal(err)
+		}
+		if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	executable := buildPrepareTestProvider(t, root)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
+	t.Setenv("AMQ_PREPARE_PROBE_MARKER", filepath.Join(root, "provider-probed"))
+	canonicalSibling, err := filepath.EvalSymlinks(sibling)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return publicPrepareFixture{
+		root: root, siblingCwd: canonicalSibling,
+		request: PrepareRequestV1{
+			RequestVersion: RequestVersionV1,
+			Target:         TargetV1{ProjectRoot: project, SessionRoot: session, Session: "collab"},
+			Launcher:       "commands",
+			Intent: LaunchIntentV1{IntentVersion: IntentVersionV1, Participants: []ParticipantV1{{
+				Handle: "claude", Runnable: true, Executable: executable,
+				Args:       []string{"--model", "test-model"},
+				Cwd:        &WorkingDirectoryV1{Kind: WorkingDirectoryAbsolute, Path: sibling},
+				EnvOverlay: map[string]string{"LANG": "C"}, ResumePolicy: ResumePolicyResume,
+				Execution: &ExecutionOptionsV1{Wake: WakeOptionsV1{Mode: WakeEnabled}},
+			}}},
+		},
+	}
+}
+
+func buildPrepareTestProvider(t *testing.T, root string) string {
+	t.Helper()
+	dir := filepath.Join(root, "provider")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(dir, "main.go")
+	program := `package main
+import ("fmt"; "os")
+func main() {
+	if marker := os.Getenv("AMQ_PREPARE_PROBE_MARKER"); marker != "" { _ = os.WriteFile(marker, []byte("probed"), 0600) }
+	if len(os.Args) == 2 && os.Args[1] == "--version" { fmt.Println("1.0.0"); return }
+	if len(os.Args) == 2 && os.Args[1] == "--help" { fmt.Println("--session-id <uuid> --resume [value]"); return }
+	os.Exit(2)
+}`
+	if err := os.WriteFile(source, []byte(program), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	name := "claude"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	executable := filepath.Join(dir, name)
+	command := exec.Command("go", "build", "-o", executable, source)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build provider helper: %v\n%s", err, output)
+	}
+	return executable
+}
+
+func snapshotTestTree(t *testing.T, root string) string {
+	t.Helper()
+	var snapshot bytes.Buffer
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(&snapshot, "%s\x00%s\x00%04o\x00", filepath.ToSlash(relative), entry.Type(), info.Mode().Perm())
+		if entry.Type().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			snapshot.Write(data)
+		}
+		snapshot.WriteByte(0)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(snapshot.Bytes())
+	return hex.EncodeToString(sum[:])
+}
+
+func TestPrepareResultDoesNotContainInternalPlanFields(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		"adapter_mode", "launch_nonce", "conversation_id", "dynamic_argv",
+		"conversation_identity_digest", "execution_identity_digest", "cwd_identity",
+	} {
+		if strings.Contains(string(raw), `"`+forbidden+`"`) {
+			t.Errorf("Prepare result exposed %s: %s", forbidden, raw)
+		}
+	}
+}

--- a/launchapi/requests.go
+++ b/launchapi/requests.go
@@ -74,17 +74,17 @@ func (request ApplyRequestV1) Validate() error {
 		return fmt.Errorf("subject_digest: %w", err)
 	}
 	seen := make(map[string]struct{}, len(request.Decisions))
-	allowedChoices := []string{
-		"trust_exact_subject",
-		"deny",
-		"fresh_once",
-		"abort",
-		"close_old",
-		"leave_old",
-		"accept_degraded",
+	allowedChoices := []DecisionChoiceV1{
+		DecisionTrustExactSubject,
+		DecisionDeny,
+		DecisionFreshOnce,
+		DecisionAbort,
+		DecisionCloseOld,
+		DecisionLeaveOld,
+		DecisionAcceptDegraded,
 	}
 	for i, decision := range request.Decisions {
-		if strings.TrimSpace(decision.ActionID) == "" || strings.TrimSpace(decision.Choice) == "" {
+		if strings.TrimSpace(decision.ActionID) == "" || strings.TrimSpace(string(decision.Choice)) == "" {
 			return fmt.Errorf("decisions[%d] requires action_id and choice", i)
 		}
 		if _, ok := seen[decision.ActionID]; ok {

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -1,6 +1,7 @@
 package launchapi
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"reflect"
@@ -63,6 +64,41 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 	}
 	if got := objectMap(t, applyProperties["semantic_digest"], "ApplyResultV1.semantic_digest")["$ref"]; got != "#/$defs/Digest" {
 		t.Errorf("ApplyResultV1.semantic_digest ref = %v", got)
+	}
+}
+
+func TestPrepareResultMatchesPublishedSchema(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawSchema, err := os.ReadFile("../schemas/launch-api-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(rawSchema, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("launch-api-v1.schema.json", schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("launch-api-v1.schema.json#/$defs/PrepareResultV1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawResult, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(rawResult, &document); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(document); err != nil {
+		t.Fatalf("schema rejected live Prepare result: %v\n%s", err, rawResult)
 	}
 }
 

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -11,6 +11,12 @@ const (
 	ResultVersionV1  = 1
 )
 
+const (
+	PrepareOutcomeReady          = "ready"
+	PrepareOutcomeActionRequired = "action_required"
+	PrepareOutcomeUnsupported    = "unsupported"
+)
+
 type ResumePolicy string
 
 const (
@@ -113,13 +119,34 @@ type PrepareRequestV1 struct {
 	Intent         LaunchIntentV1 `json:"intent"`
 }
 
+type RequiredActionKindV1 string
+
+const (
+	RequiredActionTrustConfirmation     RequiredActionKindV1 = "trust_confirmation"
+	RequiredActionStaleConversation     RequiredActionKindV1 = "stale_conversation_decision"
+	RequiredActionRebindConfirmation    RequiredActionKindV1 = "rebind_confirmation"
+	RequiredActionUnsupportedCapability RequiredActionKindV1 = "unsupported_capability_ack"
+)
+
+type DecisionChoiceV1 string
+
+const (
+	DecisionTrustExactSubject DecisionChoiceV1 = "trust_exact_subject"
+	DecisionDeny              DecisionChoiceV1 = "deny"
+	DecisionFreshOnce         DecisionChoiceV1 = "fresh_once"
+	DecisionAbort             DecisionChoiceV1 = "abort"
+	DecisionCloseOld          DecisionChoiceV1 = "close_old"
+	DecisionLeaveOld          DecisionChoiceV1 = "leave_old"
+	DecisionAcceptDegraded    DecisionChoiceV1 = "accept_degraded"
+)
+
 type RequiredActionV1 struct {
-	ActionID         string   `json:"action_id"`
-	Kind             string   `json:"kind"`
-	Handles          []string `json:"handles,omitempty"`
-	Resources        []string `json:"resources,omitempty"`
-	AllowedDecisions []string `json:"allowed_decisions"`
-	ReasonCode       string   `json:"reason_code"`
+	ActionID         string               `json:"action_id"`
+	Kind             RequiredActionKindV1 `json:"kind"`
+	Handles          []string             `json:"handles,omitempty"`
+	Resources        []string             `json:"resources,omitempty"`
+	AllowedDecisions []DecisionChoiceV1   `json:"allowed_decisions"`
+	ReasonCode       string               `json:"reason_code"`
 }
 
 type CommandV1 struct {
@@ -176,8 +203,8 @@ type PrepareResultV1 struct {
 }
 
 type DecisionV1 struct {
-	ActionID string `json:"action_id"`
-	Choice   string `json:"choice"`
+	ActionID string           `json:"action_id"`
+	Choice   DecisionChoiceV1 `json:"choice"`
 }
 
 type ApplyRequestV1 struct {


### PR DESCRIPTION
## Summary
- add the public versioned `launchapi.Prepare` seam and typed required actions
- compile static provider plans without executing caller-selected binaries or mutating launch state
- bind decisions to separate plan, trust, and exact observed-subject digests
- pin target, mailbox configuration, roster, binding, and per-handle observations through final verification

## Verification
- unchanged merged main fails the new Prepare contract tests
- `go test ./launchapi ./internal/launch -run "TestPrepare|TestTmuxDetectDoesNotMutateBackend" -count=10`
- `go test -race ./launchapi ./internal/launch`
- `make ci`
- independent exact-staged peer review approved SHA-256 `e4cfdec57c32a98e6ee18eef97e2c9b76a1cfee86b4c5b2ea93a13793560502a`