### PR TITLE
feat(launchapi): Apply with atomic roster provisioning and no-replace session publication

### DIFF
--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -15,6 +15,7 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/format"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 const (
@@ -351,56 +352,62 @@ func provisionCoopSessionChild(base, session string, agents []string, execAgent,
 	}
 	defer func() { _ = baseRoot.Close() }()
 
-	if exclusive && sessionCreateBeforeExclusive != nil {
-		sessionCreateBeforeExclusive(base, session)
-	}
-	var sessionRoot *fsq.DeliveryRoot
-	if exclusive {
-		sessionRoot, err = baseRoot.CreateDirectChildExclusive(session, 0o700)
-	} else {
-		sessionRoot, err = baseRoot.OpenOrCreateDirectChild(session, 0o700)
-	}
-	if err != nil {
+	var result string
+	provision := func() error {
+		if exclusive && sessionCreateBeforeExclusive != nil {
+			sessionCreateBeforeExclusive(base, session)
+		}
+		var sessionRoot *fsq.DeliveryRoot
 		if exclusive {
-			var exists *fsq.DirectChildExistsError
-			if errors.As(err, &exists) {
-				return "", err
-			}
+			sessionRoot, err = baseRoot.CreateDirectChildExclusive(session, 0o700)
+		} else {
+			sessionRoot, err = baseRoot.OpenOrCreateDirectChild(session, 0o700)
 		}
-		sessionPath := filepath.Join(base, session)
-		if info, lstatErr := os.Lstat(sessionPath); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
-			message := fmt.Sprintf(
-				"session root %s is a symlink; refusing to provision through it; remove it to use the named session",
-				sessionPath,
-			)
-			if target, resolveErr := filepath.EvalSymlinks(sessionPath); resolveErr == nil &&
-				execAgent != "" && execCommand != "" {
-				message += fmt.Sprintf(
-					"; for intentional relocation, use: amq coop exec --root %s --me %s %s",
-					shellQuoteArg(target),
-					shellQuoteArg(execAgent),
-					shellQuoteArg(execCommand),
+		if err != nil {
+			if exclusive {
+				var exists *fsq.DirectChildExistsError
+				if errors.As(err, &exists) {
+					return err
+				}
+			}
+			sessionPath := filepath.Join(base, session)
+			if info, lstatErr := os.Lstat(sessionPath); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+				message := fmt.Sprintf(
+					"session root %s is a symlink; refusing to provision through it; remove it to use the named session",
+					sessionPath,
 				)
+				if target, resolveErr := filepath.EvalSymlinks(sessionPath); resolveErr == nil &&
+					execAgent != "" && execCommand != "" {
+					message += fmt.Sprintf(
+						"; for intentional relocation, use: amq coop exec --root %s --me %s %s",
+						shellQuoteArg(target), shellQuoteArg(execAgent), shellQuoteArg(execCommand),
+					)
+				}
+				return ContextMismatchError("%s", message)
 			}
-			return "", ContextMismatchError("%s", message)
+			return ContextMismatchError(
+				"refusing session %q: path %s is not a stable direct directory under base: %v",
+				session, sessionPath, err,
+			)
 		}
-		return "", ContextMismatchError(
-			"refusing session %q: path %s is not a stable direct directory under base: %v",
-			session,
-			sessionPath,
-			err,
-		)
-	}
-	defer func() { _ = sessionRoot.Close() }()
-	if err := sessionRoot.EnsureRootDirs(); err != nil {
-		return "", err
-	}
-	for _, agent := range agents {
-		if err := sessionRoot.EnsureAgentDirs(agent); err != nil {
-			return "", fmt.Errorf("failed to create mailbox for %s: %w", agent, err)
+		defer func() { _ = sessionRoot.Close() }()
+		if err := sessionRoot.EnsureRootDirs(); err != nil {
+			return err
 		}
+		for _, agent := range agents {
+			if err := sessionRoot.EnsureAgentDirs(agent); err != nil {
+				return fmt.Errorf("failed to create mailbox for %s: %w", agent, err)
+			}
+		}
+		result = sessionRoot.Base()
+		return nil
 	}
-	return sessionRoot.Base(), nil
+	if exclusive {
+		err = launch.WithSessionCreationLock(baseRoot, session, provision)
+	} else {
+		err = provision()
+	}
+	return result, err
 }
 
 func parseCoopInitAgents(raw string) ([]string, error) {

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -10,9 +10,52 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
+
+func TestSessionCreateUsesSharedCreationLock(t *testing.T) {
+	base := makeSessionBase(t)
+	identity, err := fsq.SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	holder := make(chan error, 1)
+	go func() {
+		holder <- launch.WithSessionCreationLock(root, "auth", func() error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+	created := make(chan error, 1)
+	go func() {
+		_, createErr := provisionNewNamedSession(base, "auth", []string{"claude"})
+		created <- createErr
+	}()
+	select {
+	case err := <-created:
+		t.Fatalf("session create bypassed shared creation lock: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	if err := <-holder; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-created; err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestSessionCreateExistingFailsLoudly(t *testing.T) {
 	base := makeSessionBase(t)

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -1,6 +1,8 @@
 package fsq
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -48,6 +50,11 @@ func (e *DirectChildExistsError) Error() string {
 // beforeCreateDirectChildExclusiveForTest runs after VerifyBase and before
 // Mkdir so tests can inject a racing creator.
 var beforeCreateDirectChildExclusiveForTest func(r *DeliveryRoot, name string)
+
+// beforePublishInitializedDirectChildForTest runs after staging is complete and
+// the final name is confirmed absent, immediately before publication.
+var beforePublishInitializedDirectChildForTest func(r *DeliveryRoot, name string)
+var afterPublishInitializedDirectChildForTest func(r *DeliveryRoot, name string)
 
 // SnapshotDeliveryRoot captures the physical directory identity at the
 // authorization boundary. The snapshot is intentionally opaque so callers
@@ -196,6 +203,118 @@ func (r *DeliveryRoot) CreateDirectChildExclusive(name string, perm os.FileMode)
 		return nil, fmt.Errorf("%q is not a direct directory under delivery root", name)
 	}
 	return r.pinDirectChild(name, before)
+}
+
+// PublishInitializedDirectChildExclusive builds a direct child under a hidden
+// sibling name and publishes it only after initialize succeeds. Publication
+// uses the platform's no-replace primitive, so even an uncooperative racing
+// creator can never be overwritten.
+func (r *DeliveryRoot) PublishInitializedDirectChildExclusive(name string, perm os.FileMode, initialize func(*DeliveryRoot) error) (*DeliveryRoot, error) {
+	if r == nil || r.root == nil {
+		return nil, fmt.Errorf("delivery root is closed")
+	}
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+		return nil, fmt.Errorf("invalid direct child name %q", name)
+	}
+	if initialize == nil {
+		return nil, fmt.Errorf("direct child initializer is missing")
+	}
+	if err := r.VerifyBase(); err != nil {
+		return nil, err
+	}
+	if _, err := r.root.Lstat(name); err == nil {
+		return nil, &DirectChildExistsError{Name: name}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	var random [12]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return nil, fmt.Errorf("generate direct child staging name: %w", err)
+	}
+	stagingName := ".amq-session-" + hex.EncodeToString(random[:])
+	if err := r.root.Mkdir(stagingName, perm); err != nil {
+		return nil, err
+	}
+	published := false
+	defer func() {
+		if !published {
+			_ = r.root.RemoveAll(stagingName)
+		}
+	}()
+	stagingInfo, err := r.root.Lstat(stagingName)
+	if err != nil {
+		return nil, err
+	}
+	staging, err := r.pinDirectChild(stagingName, stagingInfo)
+	if err != nil {
+		return nil, err
+	}
+	keepStagingOpen := false
+	defer func() {
+		if !keepStagingOpen {
+			_ = staging.Close()
+		}
+	}()
+	if err := initialize(staging); err != nil {
+		return nil, err
+	}
+	if err := staging.VerifyBase(); err != nil {
+		return nil, err
+	}
+	if err := syncInitializedTree(staging, "."); err != nil {
+		return nil, err
+	}
+	if _, err := r.root.Lstat(name); err == nil {
+		return nil, &DirectChildExistsError{Name: name}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if beforePublishInitializedDirectChildForTest != nil {
+		beforePublishInitializedDirectChildForTest(r, name)
+	}
+	if err := r.renameDirectChildNoReplace(stagingName, name); err != nil {
+		if _, statErr := r.root.Lstat(name); statErr == nil {
+			return nil, &DirectChildExistsError{Name: name}
+		}
+		return nil, err
+	}
+	published = true
+	staging.base = filepath.Join(r.base, name)
+	keepStagingOpen = true
+	if afterPublishInitializedDirectChildForTest != nil {
+		afterPublishInitializedDirectChildForTest(r, name)
+	}
+	after, err := r.root.Lstat(name)
+	if err != nil {
+		return staging, &CommittedDurabilityError{FinalPath: staging.Base(), Err: fmt.Errorf("inspect published direct child: %w", err)}
+	}
+	if !after.IsDir() || after.Mode()&os.ModeSymlink != 0 || !os.SameFile(stagingInfo, after) {
+		return staging, &CommittedDurabilityError{FinalPath: staging.Base(), Err: fmt.Errorf("published direct child %q changed identity", name)}
+	}
+	if err := r.SyncDir("."); err != nil {
+		return staging, &CommittedDurabilityError{FinalPath: staging.Base(), Err: err}
+	}
+	return staging, nil
+}
+
+func syncInitializedTree(root *DeliveryRoot, name string) error {
+	entries, err := root.ReadDir(name)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("initialized child contains symlink %q", filepath.Join(name, entry.Name()))
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		if err := syncInitializedTree(root, filepath.Join(name, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return root.SyncDir(name)
 }
 
 func (r *DeliveryRoot) pinDirectChild(name string, before os.FileInfo) (*DeliveryRoot, error) {

--- a/internal/fsq/delivery_root_child_test.go
+++ b/internal/fsq/delivery_root_child_test.go
@@ -159,3 +159,150 @@ func TestCreateDirectChildExclusiveRaceIsLoud(t *testing.T) {
 		t.Fatalf("error = %v, want DirectChildExistsError", err)
 	}
 }
+
+func TestPublishInitializedDirectChildExclusiveIsAllOrNothing(t *testing.T) {
+	base := t.TempDir()
+	root := openDeliveryRootForTest(t, base)
+	failure := errors.New("initializer failed")
+	if _, err := root.PublishInitializedDirectChildExclusive("collab", 0o700, func(child *DeliveryRoot) error {
+		if err := child.EnsureRootDirs(); err != nil {
+			return err
+		}
+		if err := child.EnsureAgentDirs("operator"); err != nil {
+			return err
+		}
+		return failure
+	}); !errors.Is(err, failure) {
+		t.Fatalf("failed publication error = %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(base, "collab")); !os.IsNotExist(err) {
+		t.Fatalf("failed publication exposed authoritative child: %v", err)
+	}
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("failed publication left staging entries: %v", entries)
+	}
+
+	child, err := root.PublishInitializedDirectChildExclusive("collab", 0o700, func(child *DeliveryRoot) error {
+		if err := child.EnsureRootDirs(); err != nil {
+			return err
+		}
+		return child.EnsureAgentDirs("operator")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = child.Close() }()
+	if err := child.VerifyBase(); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range requiredMailboxLeaves {
+		if info, err := child.Stat(filepath.Join("agents", "operator", string(path))); err != nil || !info.IsDir() {
+			t.Fatalf("published mailbox path %s: info=%v err=%v", path, info, err)
+		}
+	}
+}
+
+func TestPublishInitializedDirectChildExclusiveNeverReplacesRacingEmptyChild(t *testing.T) {
+	base := t.TempDir()
+	root := openDeliveryRootForTest(t, base)
+	old := beforePublishInitializedDirectChildForTest
+	beforePublishInitializedDirectChildForTest = func(r *DeliveryRoot, name string) {
+		if err := os.Mkdir(filepath.Join(r.Base(), name), 0o711); err != nil {
+			t.Fatalf("create racing child: %v", err)
+		}
+	}
+	t.Cleanup(func() { beforePublishInitializedDirectChildForTest = old })
+
+	_, err := root.PublishInitializedDirectChildExclusive("collab", 0o700, func(child *DeliveryRoot) error {
+		if err := child.EnsureRootDirs(); err != nil {
+			return err
+		}
+		return child.EnsureAgentDirs("operator")
+	})
+	var exists *DirectChildExistsError
+	if !errors.As(err, &exists) {
+		t.Fatalf("publication error = %v, want DirectChildExistsError", err)
+	}
+	info, statErr := os.Stat(filepath.Join(base, "collab"))
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if info.Mode().Perm() != 0o711 {
+		t.Fatalf("racing child mode = %04o, want untouched 0711", info.Mode().Perm())
+	}
+	entries, readErr := os.ReadDir(filepath.Join(base, "collab"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("racing child was merged or replaced: %v", entries)
+	}
+}
+
+func TestPublishInitializedDirectChildExclusiveReportsCommittedDurabilityFailure(t *testing.T) {
+	base := t.TempDir()
+	root := openDeliveryRootForTest(t, base)
+	failure := errors.New("parent sync failed")
+	child, err := root.PublishInitializedDirectChildExclusive("collab", 0o700, func(child *DeliveryRoot) error {
+		if err := child.EnsureRootDirs(); err != nil {
+			return err
+		}
+		if err := child.EnsureAgentDirs("operator"); err != nil {
+			return err
+		}
+		// The staged child captured the prior nil hook. Only the final parent
+		// directory sync observes this injected failure.
+		root.syncDirForTest = func(string) error { return failure }
+		return nil
+	})
+	if child == nil {
+		t.Fatal("committed publication did not return its pinned child")
+	}
+	defer func() { _ = child.Close() }()
+	var committed *CommittedDurabilityError
+	if !errors.As(err, &committed) || !errors.Is(err, failure) {
+		t.Fatalf("publication error = %v, want committed durability failure", err)
+	}
+	if child.Base() != filepath.Join(base, "collab") {
+		t.Fatalf("committed child base = %q", child.Base())
+	}
+	if err := child.VerifyBase(); err != nil {
+		t.Fatal(err)
+	}
+	for _, leaf := range requiredMailboxLeaves {
+		if info, err := child.Stat(filepath.Join("agents", "operator", string(leaf))); err != nil || !info.IsDir() {
+			t.Fatalf("committed mailbox %s: info=%v err=%v", leaf, info, err)
+		}
+	}
+}
+
+func TestPublishInitializedDirectChildExclusiveReportsPostRenameIdentityLossAsCommitted(t *testing.T) {
+	base := t.TempDir()
+	root := openDeliveryRootForTest(t, base)
+	old := afterPublishInitializedDirectChildForTest
+	afterPublishInitializedDirectChildForTest = func(r *DeliveryRoot, name string) {
+		if err := os.Rename(filepath.Join(r.Base(), name), filepath.Join(r.Base(), "moved-away")); err != nil {
+			t.Fatalf("move published child: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterPublishInitializedDirectChildForTest = old })
+
+	child, err := root.PublishInitializedDirectChildExclusive("collab", 0o700, func(child *DeliveryRoot) error {
+		return child.EnsureRootDirs()
+	})
+	if child == nil {
+		t.Fatal("post-rename identity loss did not return the committed capability")
+	}
+	defer func() { _ = child.Close() }()
+	var committed *CommittedDurabilityError
+	if !errors.As(err, &committed) {
+		t.Fatalf("post-rename identity error = %v, want committed error", err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "moved-away", "agents")); err != nil {
+		t.Fatalf("published tree was not retained at racing location: %v", err)
+	}
+}

--- a/internal/fsq/direct_child_rename_darwin.go
+++ b/internal/fsq/direct_child_rename_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package fsq
+
+import "golang.org/x/sys/unix"
+
+func (r *DeliveryRoot) renameDirectChildNoReplace(oldName, newName string) error {
+	dir, err := r.root.Open(".")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return unix.RenameatxNp(int(dir.Fd()), oldName, int(dir.Fd()), newName, unix.RENAME_EXCL)
+}

--- a/internal/fsq/direct_child_rename_linux.go
+++ b/internal/fsq/direct_child_rename_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package fsq
+
+import "golang.org/x/sys/unix"
+
+func (r *DeliveryRoot) renameDirectChildNoReplace(oldName, newName string) error {
+	dir, err := r.root.Open(".")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return unix.Renameat2(int(dir.Fd()), oldName, int(dir.Fd()), newName, unix.RENAME_NOREPLACE)
+}

--- a/internal/fsq/direct_child_rename_unsupported.go
+++ b/internal/fsq/direct_child_rename_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux && !windows
+
+package fsq
+
+import (
+	"errors"
+	"fmt"
+)
+
+func (r *DeliveryRoot) renameDirectChildNoReplace(_, _ string) error {
+	return fmt.Errorf("exclusive direct-child publication: %w", errors.ErrUnsupported)
+}

--- a/internal/fsq/direct_child_rename_windows.go
+++ b/internal/fsq/direct_child_rename_windows.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package fsq
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type fileRenameInformationEx struct {
+	Flags          uint32
+	RootDirectory  windows.Handle
+	FileNameLength uint32
+	FileName       [1]uint16
+}
+
+const fileRenameInformationExClass = 65
+
+// renameDirectChildNoReplace uses FileRenameInformationEx without
+// FILE_RENAME_REPLACE_IF_EXISTS. os.Root.Rename cannot be used here because
+// Go's Windows implementation explicitly requests replacement semantics.
+func (r *DeliveryRoot) renameDirectChildNoReplace(oldName, newName string) error {
+	dir, err := r.root.Open(".")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	dirHandle := windows.Handle(dir.Fd())
+
+	objectName, err := windows.NewNTUnicodeString(oldName)
+	if err != nil {
+		return err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length: uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})), RootDirectory: dirHandle,
+		ObjectName: objectName, Attributes: windows.OBJ_CASE_INSENSITIVE,
+	}
+	var source windows.Handle
+	var openStatus windows.IO_STATUS_BLOCK
+	err = windows.NtCreateFile(
+		&source, windows.SYNCHRONIZE|windows.DELETE, attributes, &openStatus, nil, 0,
+		windows.FILE_SHARE_DELETE|windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		windows.FILE_OPEN,
+		windows.FILE_OPEN_REPARSE_POINT|windows.FILE_OPEN_FOR_BACKUP_INTENT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0, 0,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = windows.CloseHandle(source) }()
+
+	name, err := windows.UTF16FromString(newName)
+	if err != nil {
+		return err
+	}
+	name = name[:len(name)-1]
+	headerSize := unsafe.Offsetof(fileRenameInformationEx{}.FileName)
+	buffer := make([]byte, int(headerSize)+len(name)*2)
+	info := (*fileRenameInformationEx)(unsafe.Pointer(&buffer[0]))
+	info.Flags = windows.FILE_RENAME_POSIX_SEMANTICS
+	info.RootDirectory = dirHandle
+	info.FileNameLength = uint32(len(name) * 2)
+	copy(unsafe.Slice(&info.FileName[0], len(name)), name)
+
+	var renameStatus windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(
+		source, &renameStatus, &buffer[0], uint32(len(buffer)), fileRenameInformationExClass,
+	)
+}

--- a/internal/fsq/layout.go
+++ b/internal/fsq/layout.go
@@ -1109,6 +1109,40 @@ func RepairMailboxLayoutForAgentsWithAuthorization(root *DeliveryRoot, authoriza
 	return repairMailboxLayoutHandlesAuthorized(root, authorization, handles, false, mailboxRepairHooks{})
 }
 
+// RepairMailboxLayoutForAgentsWithAuthorizationAndWriteGuard is the
+// lease-bound variant used by launch Apply. writeGuard is revalidated before
+// each directory mutation and durability sync; a revoked authority therefore
+// stops the repair at the next owning write boundary.
+func RepairMailboxLayoutForAgentsWithAuthorizationAndWriteGuard(root *DeliveryRoot, authorization *MailboxConfigAuthorization, agents []string, writeGuard func() error) MailboxRepairResult {
+	if authorization == nil || authorization.pin == nil {
+		return MailboxRepairResult{
+			Status:  "failed",
+			Failure: &MailboxRepairFailure{Code: "preflight_failed", Stage: "authorization", Message: "mailbox config authorization is missing"},
+		}
+	}
+	if writeGuard == nil {
+		return MailboxRepairResult{
+			Status:  "failed",
+			Failure: &MailboxRepairFailure{Code: "preflight_failed", Stage: "authorization", Message: "mailbox write guard is missing"},
+		}
+	}
+	return repairMailboxLayoutHandlesAuthorizedWithConfig(
+		root,
+		authorization,
+		agents,
+		false,
+		authorization.pin.cfg,
+		mailboxRepairHooks{fail: func(stage, _ string) error {
+			switch stage {
+			case "mkdir", "chmod", "child_sync", "parent_sync":
+				return writeGuard()
+			default:
+				return nil
+			}
+		}},
+	)
+}
+
 // RepairMailboxLayoutForConfiguredAgentsWithAuthorization repairs an effective
 // configured roster, including caller-owned implicit handles, while retaining
 // the exact on-disk config authorization for mutation checks.

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -1,0 +1,559 @@
+package launch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	ApplyOutcomeApplied               = "applied"
+	ApplyOutcomeActionRequired        = "action_required"
+	ApplyOutcomeProvisionedNoRunnable = "provisioned_no_runnable"
+)
+
+type ApplyDecision struct {
+	ActionID string
+	Choice   string
+}
+
+type ApplyRequest struct {
+	Prepare       PrepareRequest
+	SubjectDigest string
+	Decisions     []ApplyDecision
+}
+
+type ApplyDependencies struct {
+	PrepareDependencies
+	AMQPath string
+}
+
+type ApplyResult struct {
+	Outcome         string
+	ReasonCode      string
+	SubjectDigest   string
+	PlanDigest      string
+	TrustDigest     string
+	Backend         string
+	Profile         string
+	Roster          PrepareRoster
+	Observations    []PrepareObservation
+	Commands        []EmittedCommand
+	RequiredActions []PrepareRequiredAction
+}
+
+var afterApplySessionPublishedForTest func()
+var beforeApplySessionPublishForTest func()
+var beforeApplyRosterMutationForTest func()
+var publishApplySession = func(base *fsq.DeliveryRoot, session string, initialize func(*fsq.DeliveryRoot) error) (*fsq.DeliveryRoot, error) {
+	return base.PublishInitializedDirectChildExclusive(session, 0o700, initialize)
+}
+var writeApplyConfigFile = func(root *fsq.DeliveryRoot, data []byte) error {
+	_, err := root.WriteFileAtomic("meta", "config.json", data, 0o600)
+	return err
+}
+
+// Apply retains the same authority from its re-Prepare through roster and
+// launch mutation. Stable authority-lock inodes are substrate; all decision,
+// trust, roster, journal, ticket, binding, and backend state remains untouched
+// until the exact subject and decisions are accepted.
+func Apply(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies) (result ApplyResult, returnErr error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return ApplyResult{}, err
+	}
+	if !validDigest(request.SubjectDigest) {
+		return ApplyResult{}, fmt.Errorf("invalid Apply subject digest")
+	}
+	state, err := openPrepareTarget(request.Prepare.Target)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	defer state.close()
+
+	if state.sessionRoot == nil {
+		err = WithSessionCreationLock(state.baseRoot, state.target.Session, func() error {
+			result, err = applyUnderAuthority(ctx, request, dependencies, state, nil)
+			return err
+		})
+		return result, err
+	}
+
+	nonce := ""
+	if journal, present, loadErr := loadOptionalJournal(state.sessionRoot); loadErr != nil {
+		return ApplyResult{}, loadErr
+	} else if present {
+		nonce = journal.LaunchNonce
+	}
+	lease, err := acquireExistingApplyLease(state, nonce)
+	if err != nil {
+		current, prepareErr := Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+		if prepareErr != nil {
+			return ApplyResult{}, prepareErr
+		}
+		return applyActionResult(current, "launch_lease_unavailable"), nil
+	}
+	defer func() { returnErr = errors.Join(returnErr, lease.Release()) }()
+	return applyUnderAuthority(ctx, request, dependencies, state, lease)
+}
+
+func applyUnderAuthority(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies, state *prepareTargetState, lease *Lease) (result ApplyResult, returnErr error) {
+	prepared, err := Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	if prepared.SubjectDigest != request.SubjectDigest {
+		return applyActionResult(prepared, "subject_changed"), nil
+	}
+	if prepared.Outcome == PrepareOutcomeUnsupported {
+		return applyActionResult(prepared, prepared.Reason), nil
+	}
+	decisions, reason := validateApplyDecisions(prepared.RequiredActions, request.Decisions)
+	if reason != "" {
+		return applyActionResult(prepared, reason), nil
+	}
+
+	handles := make([]string, 0, len(request.Prepare.Participants))
+	for _, participant := range request.Prepare.Participants {
+		handles = append(handles, participant.Handle)
+	}
+	slices.Sort(handles)
+
+	root := state.sessionRoot
+	if root == nil {
+		var stagedLease *Lease
+		root, err = publishApplySession(state.baseRoot, state.target.Session, func(staging *fsq.DeliveryRoot) error {
+			if err := initializeApplySession(staging, handles); err != nil {
+				return err
+			}
+			stagedLease, err = AcquireLease(staging, "")
+			if err == nil && beforeApplySessionPublishForTest != nil {
+				beforeApplySessionPublishForTest()
+			}
+			return err
+		})
+		if err != nil {
+			var committed *fsq.CommittedDurabilityError
+			if errors.As(err, &committed) && root != nil && stagedLease != nil {
+				result := applyActionResult(prepared, "session_publication_durability_uncertain")
+				result.SubjectDigest = request.SubjectDigest
+				if verifyErr := root.VerifyBase(); verifyErr != nil {
+					stagedLease.abandonCapability()
+					_ = root.Close()
+					return result, nil
+				}
+				defer func() { _ = root.Close() }()
+				lease = stagedLease
+				defer func() { returnErr = errors.Join(returnErr, lease.Release()) }()
+				return result, nil
+			}
+			if stagedLease != nil {
+				if root != nil {
+					_ = stagedLease.Release()
+					_ = root.Close()
+				} else {
+					stagedLease.abandonCapability()
+				}
+			}
+			var exists *fsq.DirectChildExistsError
+			if errors.As(err, &exists) {
+				current, prepareErr := Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+				if prepareErr != nil {
+					return ApplyResult{}, prepareErr
+				}
+				return applyActionResult(current, "subject_changed"), nil
+			}
+			return ApplyResult{}, err
+		}
+		defer func() { _ = root.Close() }()
+		if afterApplySessionPublishedForTest != nil {
+			afterApplySessionPublishedForTest()
+		}
+		lease = stagedLease
+		defer func() { returnErr = errors.Join(returnErr, lease.Release()) }()
+	} else {
+		if err := provisionExistingApplyRoster(root, lease, handles); err != nil {
+			var committed *applyCommittedMutationError
+			if errors.As(err, &committed) {
+				current, prepareErr := Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+				if prepareErr != nil {
+					return ApplyResult{}, errors.Join(err, prepareErr)
+				}
+				result := applyActionResult(current, committed.Reason)
+				result.SubjectDigest = request.SubjectDigest
+				return result, nil
+			}
+			return ApplyResult{}, err
+		}
+	}
+
+	runnable := make([]PrepareParticipant, 0, len(request.Prepare.Participants))
+	for _, participant := range request.Prepare.Participants {
+		if participant.Runnable {
+			runnable = append(runnable, participant)
+		}
+	}
+	if len(runnable) == 0 {
+		prepared, err = Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+		if err != nil {
+			return ApplyResult{}, err
+		}
+		result := applyResultFromPrepare(prepared)
+		result.SubjectDigest = request.SubjectDigest
+		result.Outcome = ApplyOutcomeProvisionedNoRunnable
+		result.ReasonCode = ""
+		result.RequiredActions = nil
+		return result, nil
+	}
+
+	reconcileRequest, err := buildApplyReconcileRequest(ctx, request.Prepare, runnable, dependencies, root, lease, decisions, prepared, state.sessionIdentity)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	reconciled, err := Reconcile(reconcileRequest)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	finalPrepared, err := Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	result = applyResultFromPrepare(finalPrepared)
+	result.SubjectDigest = request.SubjectDigest
+	result.RequiredActions = nil
+	result.Commands = slices.Clone(reconciled.Commands)
+	result.Backend, result.TrustDigest = reconciled.Backend, reconciled.SemanticDigest
+	if reconciled.AggregateCode == 0 && reconciled.Outcome != "" {
+		result.Outcome = ApplyOutcomeApplied
+		result.ReasonCode = ""
+	} else {
+		result.Outcome = ApplyOutcomeActionRequired
+		result.ReasonCode = applyReconcileReasonCode(reconciled)
+	}
+	return result, nil
+}
+
+func applyReconcileReasonCode(result ReconcileResult) string {
+	for _, agent := range result.Agents {
+		if agent.Code != 0 && agent.Reason != "" {
+			return agent.Reason
+		}
+	}
+	if len(result.Commands) > 0 {
+		return "commands_emitted"
+	}
+	if result.Reason != "" {
+		return result.Reason
+	}
+	return "launch_action_required"
+}
+
+func validateApplyDecisions(actions []PrepareRequiredAction, supplied []ApplyDecision) (map[RequiredActionKind]string, string) {
+	if len(actions) != len(supplied) {
+		return nil, "decisions_incomplete"
+	}
+	actionsByID := make(map[string]PrepareRequiredAction, len(actions))
+	for _, action := range actions {
+		actionsByID[action.ActionID] = action
+	}
+	result := make(map[RequiredActionKind]string, len(actions))
+	seen := make(map[string]struct{}, len(supplied))
+	for _, decision := range supplied {
+		action, ok := actionsByID[decision.ActionID]
+		if !ok {
+			return nil, "decision_unknown_action"
+		}
+		if _, duplicate := seen[decision.ActionID]; duplicate {
+			return nil, "decision_duplicate"
+		}
+		seen[decision.ActionID] = struct{}{}
+		if !slices.Contains(action.AllowedDecisions, decision.Choice) {
+			return nil, "decision_disallowed"
+		}
+		if decision.Choice == "deny" || decision.Choice == "abort" {
+			return nil, "decision_declined"
+		}
+		result[action.Kind] = decision.Choice
+	}
+	return result, ""
+}
+
+func initializeApplySession(root *fsq.DeliveryRoot, handles []string) error {
+	if err := root.EnsureRootDirs(); err != nil {
+		return err
+	}
+	config := struct {
+		Version    int      `json:"version"`
+		CreatedUTC string   `json:"created_utc"`
+		Agents     []string `json:"agents"`
+	}{Version: 1, CreatedUTC: time.Now().UTC().Format(time.RFC3339), Agents: slices.Clone(handles)}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if _, err := root.WriteFileAtomic("meta", "config.json", data, 0o600); err != nil {
+		return err
+	}
+	for _, handle := range handles {
+		if err := root.EnsureAgentDirs(handle); err != nil {
+			return fmt.Errorf("provision mailbox %s: %w", handle, err)
+		}
+	}
+	return nil
+}
+
+func provisionExistingApplyRoster(root *fsq.DeliveryRoot, lease *Lease, handles []string) error {
+	if err := lease.authorizeWrite(root); err != nil {
+		return fmt.Errorf("authorize Apply roster write: %w", err)
+	}
+	authorization, inventory, err := fsq.OpenMailboxConfigAuthorization(root)
+	if err != nil {
+		if inventory.ActiveConfigStatus != string(fsq.MailboxPathMissing) {
+			return err
+		}
+		roster, discoverErr := discoveredApplyRoster(root, handles)
+		if discoverErr != nil {
+			return discoverErr
+		}
+		if err := writeApplySessionConfig(root, lease, time.Now().UTC().Format(time.RFC3339), roster); err != nil {
+			return err
+		}
+		authorization, _, err = fsq.OpenMailboxConfigAuthorization(root)
+		if err != nil {
+			return err
+		}
+	}
+	defer func() { _ = authorization.Close() }()
+	effective := append(authorization.ConfiguredAgents(), handles...)
+	slices.Sort(effective)
+	effective = slices.Compact(effective)
+	if beforeApplyRosterMutationForTest != nil {
+		beforeApplyRosterMutationForTest()
+	}
+	// Repair only the requested roster. Configured/discovered extras and all of
+	// their history are observations, never mutation targets for Apply.
+	repaired := fsq.RepairMailboxLayoutForAgentsWithAuthorizationAndWriteGuard(root, authorization, handles, func() error {
+		return lease.authorizeWrite(root)
+	})
+	if repaired.Status == "failed" {
+		return fmt.Errorf("provision Apply roster: %s", repaired.Failure.Message)
+	}
+	if !slices.Equal(effective, authorization.ConfiguredAgents()) {
+		var current struct {
+			CreatedUTC string `json:"created_utc"`
+		}
+		data, readErr := root.ReadFile(filepath.Join("meta", "config.json"))
+		if readErr != nil {
+			return readErr
+		}
+		if err := json.Unmarshal(data, &current); err != nil {
+			return err
+		}
+		if err := authorization.Verify(); err != nil {
+			return err
+		}
+		if err := writeApplySessionConfig(root, lease, current.CreatedUTC, effective); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func discoveredApplyRoster(root *fsq.DeliveryRoot, requested []string) ([]string, error) {
+	roster := slices.Clone(requested)
+	entries, err := root.ReadDir("agents")
+	if errors.Is(err, os.ErrNotExist) {
+		err = nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+			return nil, fmt.Errorf("unsafe existing mailbox entry %q", entry.Name())
+		}
+		if err := fsq.ValidateHandle(entry.Name()); err != nil {
+			return nil, fmt.Errorf("invalid existing mailbox entry %q: %w", entry.Name(), err)
+		}
+		roster = append(roster, entry.Name())
+	}
+	slices.Sort(roster)
+	return slices.Compact(roster), nil
+}
+
+func writeApplySessionConfig(root *fsq.DeliveryRoot, lease *Lease, createdUTC string, handles []string) error {
+	if createdUTC == "" {
+		createdUTC = time.Now().UTC().Format(time.RFC3339)
+	}
+	config := struct {
+		Version    int      `json:"version"`
+		CreatedUTC string   `json:"created_utc"`
+		Agents     []string `json:"agents"`
+	}{Version: 1, CreatedUTC: createdUTC, Agents: slices.Clone(handles)}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := lease.authorizeWrite(root); err != nil {
+		return err
+	}
+	err = writeApplyConfigFile(root, append(data, '\n'))
+	if err != nil {
+		var committed *fsq.CommittedDurabilityError
+		if errors.As(err, &committed) {
+			return &applyCommittedMutationError{Reason: "roster_config_durability_uncertain", Err: err}
+		}
+	}
+	return err
+}
+
+type applyCommittedMutationError struct {
+	Reason string
+	Err    error
+}
+
+func (err *applyCommittedMutationError) Error() string { return err.Err.Error() }
+func (err *applyCommittedMutationError) Unwrap() error { return err.Err }
+
+func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, runnable []PrepareParticipant, dependencies ApplyDependencies, root *fsq.DeliveryRoot, lease *Lease, decisions map[RequiredActionKind]string, snapshot PrepareResult, authorizedRootIdentity string) (ReconcileRequest, error) {
+	config := ProjectConfig{Schema: ProjectConfigSchema, DefaultSession: prepared.Target.Session, Layout: LayoutIntent{Type: LayoutColumns}}
+	adapters := make(map[string]HarnessAdapter, len(runnable))
+	executionOptions := make(map[string]PrepareExecutionOptions, len(runnable))
+	for _, participant := range runnable {
+		adapter := dependencies.AdapterFor(participant.Provider, participant.Executable)
+		if adapter == nil {
+			return ReconcileRequest{}, fmt.Errorf("provider %q has no adapter", participant.Provider)
+		}
+		key := participant.Executable
+		command := append([]string{participant.Executable}, participant.Args...)
+		command = append(command, participant.BypassArgs...)
+		config.Agents = append(config.Agents, ProjectAgentConfig{
+			Handle: participant.Handle, Adapter: key, Command: command, Env: cloneEnv(participant.EnvOverlay),
+			Cwd: participant.Cwd, ResumePolicy: participant.ResumePolicy,
+		})
+		adapters[key] = adapter
+		executionOptions[participant.Handle] = *clonePrepareExecutionOptions(&participant.Execution)
+	}
+	if err := config.Validate(); err != nil {
+		return ReconcileRequest{}, err
+	}
+	request := ReconcileRequest{
+		Context: ctx, ProjectRoot: prepared.Target.ProjectRoot, Session: prepared.Target.Session,
+		AMQPath: dependencies.AMQPath, Root: root, Config: config, Launcher: prepared.Launcher,
+		Preferences: slices.Clone(dependencies.Preferences), Backends: dependencies.Backends,
+		Adapters: adapters, TrustStore: dependencies.TrustStore, HeldLease: lease,
+		HostIdentity: dependencies.HostIdentity, AllowExternalCwd: true,
+		ExecutionOptions:   executionOptions,
+		AllowFreshFallback: decisions[ActionStaleConversation] == "fresh_once",
+	}
+	if choice := decisions[ActionTrustConfirmation]; choice == "trust_exact_subject" {
+		request.ConfirmTrust = func(plan Plan, actualTrustDigest string) (bool, error) {
+			planDigest, err := plan.SemanticDigest()
+			if err != nil {
+				return false, err
+			}
+			if planDigest != snapshot.PlanDigest {
+				return false, fmt.Errorf("static plan changed after Apply authorization")
+			}
+			authorizedTrustDigest, err := PrepareTrustDigest(
+				planDigest, prepared.Target.Session, prepared.Target.SessionRoot, authorizedRootIdentity,
+			)
+			if err != nil {
+				return false, err
+			}
+			if authorizedTrustDigest != snapshot.TrustDigest {
+				return false, fmt.Errorf("authorized trust subject changed after Apply authorization")
+			}
+			expectedActual, err := ExecutionTrustDigest(plan, prepared.Target.Session, root)
+			if err != nil {
+				return false, err
+			}
+			if actualTrustDigest != expectedActual {
+				return false, fmt.Errorf("execution trust subject changed after session publication")
+			}
+			return true, nil
+		}
+	}
+	if choice := decisions[ActionRebindConfirmation]; choice != "" {
+		request.Rebind = true
+		request.ConfirmRebind = func(_ BindingRecord, _ bool) (RebindDisposition, bool, error) {
+			switch choice {
+			case "close_old":
+				return RebindClose, true, nil
+			case "leave_old":
+				return RebindLeave, true, nil
+			default:
+				return "", false, fmt.Errorf("invalid rebind decision %q", choice)
+			}
+		}
+	}
+	return request, nil
+}
+
+// WithSessionCreationLock serializes in-repository creators for one direct
+// session child. Filesystem-exclusive creation remains the correctness boundary
+// against callers that do not cooperate with this advisory lock.
+func WithSessionCreationLock(base *fsq.DeliveryRoot, session string, operation func() error) (returnErr error) {
+	if operation == nil {
+		return fmt.Errorf("session creation operation is missing")
+	}
+	file, err := openAdvisoryLock(base, applyCreationLockPath(session))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	if err := lockExclusive(file); err != nil {
+		return err
+	}
+	defer func() { returnErr = errors.Join(returnErr, unlockExclusive(file)) }()
+	return operation()
+}
+
+func acquireExistingApplyLease(state *prepareTargetState, nonce string) (*Lease, error) {
+	lockPath := applyCreationLockPath(state.target.Session)
+	if _, err := state.baseRoot.Stat(lockPath); errors.Is(err, os.ErrNotExist) {
+		return AcquireLease(state.sessionRoot, nonce)
+	} else if err != nil {
+		return nil, err
+	}
+	var lease *Lease
+	err := WithSessionCreationLock(state.baseRoot, state.target.Session, func() error {
+		var acquireErr error
+		lease, acquireErr = AcquireLease(state.sessionRoot, nonce)
+		return acquireErr
+	})
+	return lease, err
+}
+
+func applyCreationLockPath(session string) string {
+	sum := sha256.Sum256([]byte(session))
+	name := "create-" + hex.EncodeToString(sum[:12]) + ".lock"
+	return filepath.Join("meta", "launch", name)
+}
+
+func applyActionResult(prepared PrepareResult, reason string) ApplyResult {
+	result := applyResultFromPrepare(prepared)
+	result.Outcome = ApplyOutcomeActionRequired
+	result.ReasonCode = reason
+	return result
+}
+
+func applyResultFromPrepare(prepared PrepareResult) ApplyResult {
+	return ApplyResult{
+		SubjectDigest: prepared.SubjectDigest, PlanDigest: prepared.PlanDigest, TrustDigest: prepared.TrustDigest,
+		Backend: prepared.Backend, Profile: prepared.Profile, Roster: prepared.Roster,
+		Observations: slices.Clone(prepared.Observations), RequiredActions: slices.Clone(prepared.RequiredActions),
+	}
+}

--- a/internal/launch/apply_test.go
+++ b/internal/launch/apply_test.go
@@ -1,0 +1,305 @@
+package launch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestApplyPublishedSessionCannotLoseLeaseTransitionRace(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	base := filepath.Join(root, "mail")
+	for _, path := range []string{project, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, SessionRoot: filepath.Join(base, "collab"), Session: "collab"},
+		Launcher: LauncherCommands, IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'a'}, 64)),
+		Participants: []PrepareParticipant{{Handle: "operator", Runnable: false}},
+	}}
+	backend := &prepareTestBackend{}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends:     map[string]Backend{LauncherCommands: backend},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	request.Decisions = []ApplyDecision{}
+
+	published := make(chan struct{})
+	releasePublisher := make(chan struct{})
+	afterApplySessionPublishedForTest = func() {
+		close(published)
+		<-releasePublisher
+	}
+	t.Cleanup(func() { afterApplySessionPublishedForTest = nil })
+
+	type applyResponse struct {
+		result ApplyResult
+		err    error
+	}
+	first := make(chan applyResponse, 1)
+	go func() {
+		result, applyErr := Apply(context.Background(), request, dependencies)
+		first <- applyResponse{result: result, err: applyErr}
+	}()
+	<-published
+
+	second := make(chan applyResponse, 1)
+	go func() {
+		result, applyErr := Apply(context.Background(), request, dependencies)
+		second <- applyResponse{result: result, err: applyErr}
+	}()
+	select {
+	case response := <-second:
+		t.Fatalf("existing-path Apply crossed publication before publisher acquired its lease: %#v", response)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releasePublisher)
+
+	firstResult := <-first
+	secondResult := <-second
+	if firstResult.err != nil || firstResult.result.Outcome != ApplyOutcomeProvisionedNoRunnable {
+		t.Fatalf("publisher result=%#v err=%v", firstResult.result, firstResult.err)
+	}
+	if secondResult.err != nil || secondResult.result.ReasonCode != "subject_changed" {
+		t.Fatalf("racing result=%#v err=%v", secondResult.result, secondResult.err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "collab", "meta", "launch", leaseFilename)); !os.IsNotExist(err) {
+		t.Fatalf("Apply transition retained lease record: %v", err)
+	}
+}
+
+func TestApplyNeverReplacesUncooperativeRacingSession(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	base := filepath.Join(root, "mail")
+	for _, path := range []string{project, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, SessionRoot: filepath.Join(base, "collab"), Session: "collab"},
+		Launcher: LauncherCommands, IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'b'}, 64)),
+		Participants: []PrepareParticipant{{Handle: "operator", Runnable: false}},
+	}}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends:     map[string]Backend{LauncherCommands: &prepareTestBackend{}},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	beforeApplySessionPublishForTest = func() {
+		if err := os.Mkdir(request.Prepare.Target.SessionRoot, 0o711); err != nil {
+			t.Fatalf("create racing session: %v", err)
+		}
+	}
+	t.Cleanup(func() { beforeApplySessionPublishForTest = nil })
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "subject_changed" {
+		t.Fatalf("racing Apply result = %#v", result)
+	}
+	info, err := os.Stat(request.Prepare.Target.SessionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o711 {
+		t.Fatalf("racing session mode = %04o, want untouched 0711", info.Mode().Perm())
+	}
+	entries, err := os.ReadDir(request.Prepare.Target.SessionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("racing session was merged or replaced: %v", entries)
+	}
+}
+
+func TestApplyRosterMutationStopsWhenLeaseAuthorityIsRevoked(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	base := filepath.Join(root, "mail")
+	session := filepath.Join(base, "collab")
+	for _, path := range []string{project, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "operator"); err != nil {
+		t.Fatal(err)
+	}
+	config := []byte("{\"version\":1,\"agents\":[\"operator\"]}\n")
+	if err := os.WriteFile(filepath.Join(session, "meta", "config.json"), config, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, SessionRoot: session, Session: "collab"},
+		Launcher: LauncherCommands, IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'c'}, 64)),
+		Participants: []PrepareParticipant{
+			{Handle: "operator", Runnable: false},
+			{Handle: "reviewer", Runnable: false},
+		},
+	}}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends:     map[string]Backend{LauncherCommands: &prepareTestBackend{}},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	beforeApplyRosterMutationForTest = func() {
+		if err := os.Remove(filepath.Join(session, bindingDirectory, leaseFilename)); err != nil {
+			t.Fatalf("revoke Apply lease: %v", err)
+		}
+	}
+	t.Cleanup(func() { beforeApplyRosterMutationForTest = nil })
+
+	if _, err := Apply(context.Background(), request, dependencies); err == nil {
+		t.Fatal("Apply succeeded after lease authority was revoked")
+	}
+	if _, err := os.Stat(filepath.Join(session, "agents", "reviewer")); !os.IsNotExist(err) {
+		t.Fatalf("Apply mutated roster after lease revocation: %v", err)
+	}
+	gotConfig, err := os.ReadFile(filepath.Join(session, "meta", "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotConfig, config) {
+		t.Fatalf("Apply changed config after lease revocation: %q", gotConfig)
+	}
+}
+
+func TestApplyReturnsTypedOutcomeForCommittedPublicationDurabilityFailure(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	base := filepath.Join(root, "mail")
+	for _, path := range []string{project, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, SessionRoot: filepath.Join(base, "collab"), Session: "collab"},
+		Launcher: LauncherCommands, IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'d'}, 64)),
+		Participants: []PrepareParticipant{{Handle: "operator", Runnable: false}},
+	}}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends:     map[string]Backend{LauncherCommands: &prepareTestBackend{}},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	originalPublish := publishApplySession
+	publishApplySession = func(base *fsq.DeliveryRoot, session string, initialize func(*fsq.DeliveryRoot) error) (*fsq.DeliveryRoot, error) {
+		published, publishErr := originalPublish(base, session, initialize)
+		if publishErr != nil {
+			return published, publishErr
+		}
+		return published, &fsq.CommittedDurabilityError{FinalPath: published.Base(), Err: errors.New("parent sync failed")}
+	}
+	t.Cleanup(func() { publishApplySession = originalPublish })
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "session_publication_durability_uncertain" || result.SubjectDigest != request.SubjectDigest {
+		t.Fatalf("committed durability Apply result = %#v", result)
+	}
+	if _, err := os.Stat(filepath.Join(request.Prepare.Target.SessionRoot, "agents", "operator")); err != nil {
+		t.Fatalf("committed session was not published fully: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(request.Prepare.Target.SessionRoot, bindingDirectory, leaseFilename)); !os.IsNotExist(err) {
+		t.Fatalf("committed durability outcome retained lease: %v", err)
+	}
+}
+
+func TestApplyReturnsTypedOutcomeForCommittedRosterConfigDurabilityFailure(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	base := filepath.Join(root, "mail")
+	session := filepath.Join(base, "collab")
+	for _, path := range []string{project, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "operator"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(session, "meta", "config.json"), []byte("{\"version\":1,\"agents\":[\"operator\"]}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, SessionRoot: session, Session: "collab"},
+		Launcher: LauncherCommands, IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'e'}, 64)),
+		Participants: []PrepareParticipant{
+			{Handle: "operator", Runnable: false},
+			{Handle: "reviewer", Runnable: false},
+		},
+	}}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends:     map[string]Backend{LauncherCommands: &prepareTestBackend{}},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	originalWrite := writeApplyConfigFile
+	writeApplyConfigFile = func(root *fsq.DeliveryRoot, data []byte) error {
+		if err := originalWrite(root, data); err != nil {
+			return err
+		}
+		return &fsq.CommittedDurabilityError{FinalPath: filepath.Join(root.Base(), "meta", "config.json"), Err: errors.New("config parent sync failed")}
+	}
+	t.Cleanup(func() { writeApplyConfigFile = originalWrite })
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "roster_config_durability_uncertain" || result.SubjectDigest != request.SubjectDigest {
+		t.Fatalf("committed roster config Apply result = %#v", result)
+	}
+	if _, err := os.Stat(filepath.Join(session, "agents", "reviewer")); err != nil {
+		t.Fatalf("committed roster was not applied: %v", err)
+	}
+}

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -52,11 +52,12 @@ type ExecutionTicket struct {
 	AMQExecutable              string `json:"amq_executable"`
 	AMQExecutableIdentity      string `json:"amq_executable_identity"`
 
-	TargetArgv []string          `json:"target_argv"`
-	TargetEnv  map[string]string `json:"target_env,omitempty"`
-	EnvDigest  string            `json:"env_digest"`
-	State      ExecutionState    `json:"state"`
-	Reason     string            `json:"reason,omitempty"`
+	TargetArgv []string                 `json:"target_argv"`
+	TargetEnv  map[string]string        `json:"target_env,omitempty"`
+	EnvDigest  string                   `json:"env_digest"`
+	State      ExecutionState           `json:"state"`
+	Reason     string                   `json:"reason,omitempty"`
+	Execution  *PrepareExecutionOptions `json:"execution,omitempty"`
 }
 
 type ExecutionTicketRequest struct {
@@ -69,6 +70,7 @@ type ExecutionTicketRequest struct {
 	TargetEnv                         map[string]string
 	State                             ExecutionState
 	Reason                            string
+	Execution                         *PrepareExecutionOptions
 }
 
 type ExecutionEnvelope struct {
@@ -127,6 +129,7 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 		Cwd: cwd, CwdIdentity: cwdID, ProviderExecutable: provider, ProviderExecutableIdentity: providerID,
 		AMQExecutable: amq, AMQExecutableIdentity: amqID, TargetArgv: append([]string(nil), request.TargetArgv...),
 		TargetEnv: env, EnvDigest: digest, State: request.State, Reason: request.Reason,
+		Execution: clonePrepareExecutionOptions(request.Execution),
 	}
 	if ticket.State == "" {
 		ticket.State = ExecutionPending

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -19,6 +20,11 @@ func TestExecutionTicketRoundTripAndCAS(t *testing.T) {
 	if err := lease.LockHandles("claude"); err != nil {
 		t.Fatal(err)
 	}
+	execution := &PrepareExecutionOptions{
+		RequireWake: true, NoGitignore: true, WakeMode: "enabled",
+		InjectorMode: "raw", InjectorVia: "/opt/amq/inject", InjectorArgs: []string{"send"},
+		SymphonyEvents: []string{"after_create", "before_run", "after_run", "before_remove"}, SymphonyWorkspaceKey: "team-17",
+	}
 	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
 		Handle: "claude", LaunchNonce: lease.LaunchNonce(), Mode: AdapterModeMint,
 		Provider: ClaudeProvider, ConversationID: lease.LaunchNonce(),
@@ -26,6 +32,7 @@ func TestExecutionTicketRoundTripAndCAS(t *testing.T) {
 		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
 		TargetArgv: []string{fixture.provider, "--session-id", lease.LaunchNonce()},
 		TargetEnv:  map[string]string{"LANG": "C", "NO_COLOR": "1"},
+		Execution:  execution,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -37,7 +44,7 @@ func TestExecutionTicketRoundTripAndCAS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if loaded.State != ExecutionPending || loaded.TargetEnv["LANG"] != "C" || loaded.EnvDigest == "" {
+	if loaded.State != ExecutionPending || loaded.TargetEnv["LANG"] != "C" || loaded.EnvDigest == "" || !reflect.DeepEqual(loaded.Execution, execution) {
 		t.Fatalf("loaded ticket = %#v", loaded)
 	}
 	loaded, err = CompareAndSwapExecutionTicket(fixture.root, lease, "claude", ExecutionPending, ExecutionSpawnAttempted, "spawned")

--- a/internal/launch/journal.go
+++ b/internal/launch/journal.go
@@ -211,6 +211,25 @@ func (record LaunchJournal) ValidateRequest(request ReconcileRequest) error {
 	if record.RosterDigest != rosterDigest {
 		return fmt.Errorf("launch journal roster changed since resource creation")
 	}
+	seenExecution := make(map[string]struct{}, len(record.Plan.Agents))
+	for _, agent := range record.Plan.Agents {
+		seenExecution[agent.Handle] = struct{}{}
+		options, ok := request.ExecutionOptions[agent.Handle]
+		if !ok {
+			if agent.Execution != nil {
+				return fmt.Errorf("launch journal execution options changed for %q", agent.Handle)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(agent.Execution, clonePrepareExecutionOptions(&options)) {
+			return fmt.Errorf("launch journal execution options changed for %q", agent.Handle)
+		}
+	}
+	for handle := range request.ExecutionOptions {
+		if _, ok := seenExecution[handle]; !ok {
+			return fmt.Errorf("launch journal has no execution options carrier for %q", handle)
+		}
+	}
 	return nil
 }
 

--- a/internal/launch/journal_test.go
+++ b/internal/launch/journal_test.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"errors"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,11 @@ func TestLaunchJournalRequiresLeaseAndClearsOnlyExactRecord(t *testing.T) {
 	request := reconcileFixture(t, backend)
 	nonce := "019c8a2f-2b13-7000-8000-000000000010"
 	plan, agents, conversations := journalFixturePlan(nonce)
+	plan.Agents[0].Execution = &PrepareExecutionOptions{
+		RequireWake: true, NoGitignore: true, WakeMode: "enabled",
+		InjectorMode: "raw", InjectorVia: "/opt/amq/inject", InjectorArgs: []string{"send"},
+		SymphonyEvents: []string{"after_create", "before_run", "after_run", "before_remove"}, SymphonyWorkspaceKey: "team-17",
+	}
 	digest, err := plan.SemanticDigest()
 	if err != nil {
 		t.Fatal(err)
@@ -34,6 +40,19 @@ func TestLaunchJournalRequiresLeaseAndClearsOnlyExactRecord(t *testing.T) {
 	loaded, err := LoadJournal(request.Root)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(loaded.Plan.Agents[0].Execution, plan.Agents[0].Execution) {
+		t.Fatalf("journal execution options = %#v, want %#v", loaded.Plan.Agents[0].Execution, plan.Agents[0].Execution)
+	}
+	request.ExecutionOptions = map[string]PrepareExecutionOptions{"claude": *plan.Agents[0].Execution}
+	if err := loaded.ValidateRequest(request); err != nil {
+		t.Fatalf("journal rejected matching execution options: %v", err)
+	}
+	changedOptions := request.ExecutionOptions["claude"]
+	changedOptions.NoGitignore = !changedOptions.NoGitignore
+	request.ExecutionOptions["claude"] = changedOptions
+	if err := loaded.ValidateRequest(request); err == nil || !strings.Contains(err.Error(), "execution options changed") {
+		t.Fatalf("journal accepted changed execution options: %v", err)
 	}
 	changed := record
 	changed.CreatedAt = changed.CreatedAt.Add(time.Second)

--- a/internal/launch/lease.go
+++ b/internal/launch/lease.go
@@ -221,6 +221,19 @@ func (l *Lease) Release() error {
 	return err
 }
 
+// abandonCapability drops only the process-local capability when its pinned
+// root is no longer reachable through the authorized namespace. The caller
+// owns any remaining filesystem diagnosis or cleanup.
+func (l *Lease) abandonCapability() {
+	if l == nil || l.released {
+		return
+	}
+	l.unlockHandles()
+	l.released = true
+	liveLeaseSecrets.Delete(l.secret)
+	l.secret = 0
+}
+
 func (l *Lease) authorizeWrite(root *fsq.DeliveryRoot) error {
 	if err := l.authorizeLive(); err != nil {
 		return err

--- a/internal/launch/plan.go
+++ b/internal/launch/plan.go
@@ -57,6 +57,9 @@ type AgentPlan struct {
 	LaunchNonce    string            `json:"launch_nonce,omitempty"`
 	ConversationID string            `json:"conversation_id,omitempty"`
 	DynamicArgv    []DynamicArg      `json:"dynamic_argv,omitempty"`
+	// Execution is the normalized coop-exec wrapper policy. Keeping it in the
+	// plan makes journal recovery lossless before the wrapper consumes it.
+	Execution *PrepareExecutionOptions `json:"execution,omitempty"`
 }
 
 // DynamicArg marks one runtime-generated argv value. Unmarked argv values are

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -703,8 +703,19 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 	if err != nil {
 		return prepared, observation, nil, actions, err
 	}
+	plan.Execution = clonePrepareExecutionOptions(&participant.Execution)
 	prepared.Command = previewStaticCommand(plan)
 	return prepared, observation, &plan, actions, nil
+}
+
+func clonePrepareExecutionOptions(options *PrepareExecutionOptions) *PrepareExecutionOptions {
+	if options == nil {
+		return nil
+	}
+	cloned := *options
+	cloned.InjectorArgs = slices.Clone(options.InjectorArgs)
+	cloned.SymphonyEvents = slices.Clone(options.SymphonyEvents)
+	return &cloned
 }
 
 func resolvePrepareCwd(projectRoot, cwd string) (string, error) {

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -65,6 +65,16 @@ type ReconcileRequest struct {
 	Rebind             bool
 	HostIdentity       string
 	CrashHook          func(string) error
+	// HeldLease lets Apply retain session authority across its lease-held
+	// re-Prepare, roster provisioning, and the existing reconciliation crash
+	// contract. Reconcile validates but never releases a caller-owned lease.
+	HeldLease *Lease
+	// AllowExternalCwd is set only by the public intent seam, whose cwd identity
+	// was already bound by lease-held Prepare.
+	AllowExternalCwd bool
+	// ExecutionOptions carries normalized wrapper policy into the plan, journal,
+	// and ticket. The exact-root/options boundary owns later consumption.
+	ExecutionOptions map[string]PrepareExecutionOptions
 }
 
 type AgentReconcileResult struct {
@@ -135,7 +145,11 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 			return result, nil
 		}
 	} else {
-		nonce, err = generateNonce()
+		if request.HeldLease != nil {
+			nonce = request.HeldLease.LaunchNonce()
+		} else {
+			nonce, err = generateNonce()
+		}
 		if err == nil {
 			planned, err = buildReconcilePlan(request, nonce, &result)
 		}
@@ -181,19 +195,32 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		return result, nil
 	}
 
-	lease, err := AcquireLease(request.Root, nonce)
-	if err != nil {
-		markPlannedAgents(&result, planned, 6, "launch_lease_unavailable")
-		result.AggregateCode = 6
-		result.Outcome = OutcomeActionRequired
-		result.Reason = err.Error()
-		return result, nil
-	}
-	defer func() {
-		if err := lease.Release(); err != nil {
-			returnErr = errors.Join(returnErr, err)
+	lease := request.HeldLease
+	if lease == nil {
+		lease, err = AcquireLease(request.Root, nonce)
+		if err != nil {
+			markPlannedAgents(&result, planned, 6, "launch_lease_unavailable")
+			result.AggregateCode = 6
+			result.Outcome = OutcomeActionRequired
+			result.Reason = err.Error()
+			return result, nil
 		}
-	}()
+		defer func() {
+			if err := lease.Release(); err != nil {
+				returnErr = errors.Join(returnErr, err)
+			}
+		}()
+	} else {
+		if lease.LaunchNonce() != nonce {
+			return result, fmt.Errorf("held launch lease nonce does not match reconciliation generation")
+		}
+		if err := lease.authorizeWrite(request.Root); err != nil {
+			return result, fmt.Errorf("validate held launch lease: %w", err)
+		}
+		if len(lease.LockedHandles()) != 0 {
+			return result, fmt.Errorf("held launch lease already has handle locks")
+		}
+	}
 	handles := make([]string, 0, len(planned))
 	for _, agent := range planned {
 		handles = append(handles, agent.plan.Handle)
@@ -601,6 +628,7 @@ func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []pla
 			ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Cwd: agent.plan.Cwd,
 			ProviderExecutable: agent.plan.Argv[0], AMQExecutable: amqPath,
 			TargetArgv: agent.plan.Argv, TargetEnv: agent.plan.EnvOverlay,
+			Execution: agent.plan.Execution,
 		})
 		if err != nil {
 			return errors.Join(fmt.Errorf("build execution ticket for %s: %w", agent.plan.Handle, err), removeExecutionTickets(request.Root, lease, written))
@@ -684,9 +712,16 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 		}
 		cwd = resolvedCwd
 		policy := cfg.ResumePolicy
+		committedArgs, bypassArgs, partitionErr := PartitionStaticProviderArgs(capabilities.Provider, cfg.Command[1:])
+		if partitionErr != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionActionRequired, "provider_arguments_changed"
+			result.Agents = append(result.Agents, item)
+			continue
+		}
 		base := PlanRequest{
 			Handle: cfg.Handle, ProjectRoot: request.ProjectRoot, Cwd: cwd,
-			LaunchNonce: nonce, ResumePolicy: policy, CommittedArgs: cfg.Command[1:], EnvOverlay: cfg.Env,
+			LaunchNonce: nonce, ResumePolicy: policy, CommittedArgs: committedArgs, BypassArgs: bypassArgs,
+			EnvOverlay: cfg.Env, AllowExternalCwd: request.AllowExternalCwd,
 		}
 		conversation, loadErr := LoadConversation(request.Root, cfg.Handle)
 		hasConversation := loadErr == nil
@@ -796,6 +831,9 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
 			result.Agents = append(result.Agents, item)
 			continue
+		}
+		if execution, ok := request.ExecutionOptions[cfg.Handle]; ok {
+			agentPlan.Execution = clonePrepareExecutionOptions(&execution)
 		}
 		item.ConversationDisposition, item.Reason = disposition, planReason
 		result.Agents = append(result.Agents, item)

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -36,6 +36,32 @@ func TestReconcileEmitsCanonicalResolvedWorkingDirectory(t *testing.T) {
 	}
 }
 
+func TestReconcileUsesAndRetainsCallerHeldLease(t *testing.T) {
+	req := reconcileFixture(t, Commands{})
+	lease, err := AcquireLease(req.Root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.HeldLease = lease
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Plan == nil || len(result.Commands) != 1 {
+		t.Fatalf("held-lease reconciliation = %#v", result)
+	}
+	inspection, err := InspectLease(req.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.State != LeaseValid || inspection.Nonce != lease.LaunchNonce() {
+		t.Fatalf("caller-held lease after Reconcile = %#v", inspection)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 type reconcileAdapter struct {
 	name               string
 	mode               AdapterMode

--- a/launchapi/apply.go
+++ b/launchapi/apply.go
@@ -1,0 +1,70 @@
+package launchapi
+
+import (
+	"context"
+	"slices"
+
+	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+// Apply revalidates a prior Prepare subject under launch authority, consumes
+// request-local decisions, provisions the participant roster, and runs the
+// existing managed reconciliation crash contract.
+func Apply(ctx context.Context, request ApplyRequestV1) (ApplyResultV1, error) {
+	if err := request.Validate(); err != nil {
+		return ApplyResultV1{}, err
+	}
+	prepared, dependencies, err := prepareInputs(request.Prepare)
+	if err != nil {
+		return ApplyResultV1{}, err
+	}
+	decisions := make([]internallaunch.ApplyDecision, 0, len(request.Decisions))
+	for _, decision := range request.Decisions {
+		decisions = append(decisions, internallaunch.ApplyDecision{ActionID: decision.ActionID, Choice: string(decision.Choice)})
+	}
+	result, err := internallaunch.Apply(ctx, internallaunch.ApplyRequest{
+		Prepare: prepared, SubjectDigest: request.SubjectDigest, Decisions: decisions,
+	}, internallaunch.ApplyDependencies{PrepareDependencies: dependencies})
+	if err != nil {
+		return ApplyResultV1{}, err
+	}
+	return fromInternalApplyResult(result), nil
+}
+
+func fromInternalApplyResult(result internallaunch.ApplyResult) ApplyResultV1 {
+	public := ApplyResultV1{
+		ResultVersion: ResultVersionV1, Outcome: result.Outcome, ReasonCode: result.ReasonCode,
+		SubjectDigest: result.SubjectDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
+		SemanticDigest: result.TrustDigest, Backend: result.Backend, Profile: result.Profile,
+		Roster: RosterDriftV1{
+			Desired: slices.Clone(result.Roster.Desired), Present: slices.Clone(result.Roster.Present),
+			Missing: slices.Clone(result.Roster.Missing), Extra: slices.Clone(result.Roster.Extra),
+		},
+		Observations: make([]ParticipantObservationV1, 0, len(result.Observations)),
+		Commands:     make([]CommandV1, 0, len(result.Commands)),
+		FollowUps:    make([]RequiredActionV1, 0, len(result.RequiredActions)),
+	}
+	for _, observation := range result.Observations {
+		public.Observations = append(public.Observations, ParticipantObservationV1{
+			Handle: observation.Handle, Mailbox: observation.Mailbox, Runnable: observation.Runnable,
+			Conversation: observation.Conversation, Execution: observation.Execution,
+			Resource: observation.Resource, ReasonCode: observation.ReasonCode,
+		})
+	}
+	for _, command := range result.Commands {
+		public.Commands = append(public.Commands, CommandV1{
+			Argv: slices.Clone(command.Argv), Cwd: command.Cwd, EnvOverlay: cloneStringMap(command.Env),
+		})
+	}
+	for _, action := range result.RequiredActions {
+		choices := make([]DecisionChoiceV1, len(action.AllowedDecisions))
+		for i, choice := range action.AllowedDecisions {
+			choices[i] = DecisionChoiceV1(choice)
+		}
+		public.FollowUps = append(public.FollowUps, RequiredActionV1{
+			ActionID: action.ActionID, Kind: RequiredActionKindV1(action.Kind), Handles: slices.Clone(action.Handles),
+			Resources: slices.Clone(action.Resources), AllowedDecisions: choices, ReasonCode: action.ReasonCode,
+		})
+	}
+	return public
+}

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -1,0 +1,455 @@
+package launchapi
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	runnable := fixture.request.Intent.Participants[0]
+	runnable.Execution = &ExecutionOptionsV1{
+		RequireWake: true, NoGitignore: true,
+		Wake: WakeOptionsV1{Mode: WakeEnabled, Injector: &InjectorOptionsV1{Mode: InjectorRaw, Via: "/opt/amq/inject", Args: []string{"send"}}},
+		Integrations: IntegrationsV1{Symphony: &SymphonyOptionsV1{
+			Events: []SymphonyEvent{SymphonyAfterCreate, SymphonyBeforeRun, SymphonyAfterRun, SymphonyBeforeRemove}, WorkspaceKey: "team-17",
+		}},
+	}
+	reviewer := runnable
+	reviewer.Handle = "reviewer"
+	fixture.request.Intent.Participants = []ParticipantV1{
+		{Handle: "operator", Runnable: false}, runnable, reviewer,
+	}
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decisions := decisionsForPreparedActions(prepared)
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: decisions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "action_required" || result.ReasonCode != "commands_emitted" || len(result.Commands) != 2 {
+		t.Fatalf("commands Apply result = %#v", result)
+	}
+	if result.SubjectDigest != prepared.SubjectDigest {
+		t.Fatalf("Apply authorization subject = %q, want accepted %q", result.SubjectDigest, prepared.SubjectDigest)
+	}
+	if !slices.Equal(result.Roster.Desired, []string{"claude", "operator", "reviewer"}) ||
+		!slices.Equal(result.Roster.Present, result.Roster.Desired) || len(result.Roster.Missing) != 0 || len(result.Roster.Extra) != 0 {
+		t.Fatalf("published Apply roster = %#v", result.Roster)
+	}
+	for _, handle := range []string{"operator", "claude", "reviewer"} {
+		for _, leaf := range fsq.RequiredMailboxLeaves() {
+			info, err := os.Stat(filepath.Join(fixture.request.Target.SessionRoot, "agents", handle, filepath.FromSlash(string(leaf))))
+			if err != nil || !info.IsDir() {
+				t.Fatalf("published mailbox %s/%s: info=%v err=%v", handle, leaf, info, err)
+			}
+		}
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(fixture.request.Target.SessionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(fixture.request.Target.SessionRoot, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	wantOptions := toInternalExecutionOptions(*runnable.Execution)
+	for _, handle := range []string{"claude", "reviewer"} {
+		ticket, err := internallaunch.LoadExecutionTicket(root, handle)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(ticket.Execution, &wantOptions) {
+			t.Fatalf("%s ticket execution options = %#v, want %#v", handle, ticket.Execution, wantOptions)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Dir(fixture.request.Target.SessionRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".amq-session-") {
+			t.Fatalf("Apply leaked staging child %q", entry.Name())
+		}
+	}
+}
+
+func TestConcurrentApplyPublishesOneInitializedSession(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	}
+	start := make(chan struct{})
+	results := make(chan ApplyResultV1, 2)
+	errors := make(chan error, 2)
+	var wait sync.WaitGroup
+	for range 2 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			result, applyErr := Apply(context.Background(), request)
+			results <- result
+			errors <- applyErr
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(errors)
+	for applyErr := range errors {
+		if applyErr != nil {
+			t.Fatal(applyErr)
+		}
+	}
+	counts := map[string]int{}
+	for result := range results {
+		counts[result.Outcome+":"+result.ReasonCode]++
+	}
+	if counts["provisioned_no_runnable:"] != 1 || counts["action_required:subject_changed"] != 1 {
+		t.Fatalf("concurrent Apply outcomes = %#v", counts)
+	}
+	for _, leaf := range fsq.RequiredMailboxLeaves() {
+		if info, err := os.Stat(filepath.Join(fixture.request.Target.SessionRoot, "agents", "operator", filepath.FromSlash(string(leaf)))); err != nil || !info.IsDir() {
+			t.Fatalf("single-winner mailbox %s: info=%v err=%v", leaf, info, err)
+		}
+	}
+}
+
+func TestPrepareIsZeroWriteAndApplyRejectsStaleSubject(t *testing.T) {
+	t.Run("existing session", func(t *testing.T) {
+		fixture := newPublicPrepareFixture(t, true)
+		prepared, err := Prepare(context.Background(), fixture.request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		changed := fixture.request
+		changed.Intent.Participants = slices.Clone(changed.Intent.Participants)
+		participant := changed.Intent.Participants[0]
+		execution := *participant.Execution
+		execution.NoGitignore = !execution.NoGitignore
+		participant.Execution = &execution
+		changed.Intent.Participants[0] = participant
+		before := applyTreeFingerprint(t, fixture.root, nil)
+		result, err := Apply(context.Background(), ApplyRequestV1{
+			RequestVersion: RequestVersionV1, Prepare: changed,
+			SubjectDigest: prepared.SubjectDigest, Decisions: decisionsForPreparedActions(prepared),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Outcome != "action_required" || result.ReasonCode != "subject_changed" {
+			t.Fatalf("stale Apply result = %#v", result)
+		}
+		allowed := map[string]bool{
+			"mail/collab/meta/launch":            true,
+			"mail/collab/meta/launch/lease.lock": true,
+		}
+		after := applyTreeFingerprint(t, fixture.root, allowed)
+		if before != after {
+			t.Fatalf("stale Apply changed durable state: before=%s after=%s", before, after)
+		}
+		if _, err := os.Stat(filepath.Join(fixture.request.Target.SessionRoot, "meta", "launch", "lease.json")); !os.IsNotExist(err) {
+			t.Fatalf("stale Apply retained lease record: %v", err)
+		}
+	})
+
+	t.Run("absent session", func(t *testing.T) {
+		fixture := newPublicPrepareFixture(t, false)
+		fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+		prepared, err := Prepare(context.Background(), fixture.request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		changed := fixture.request
+		changed.Intent.Participants = []ParticipantV1{{Handle: "reviewer", Runnable: false}}
+		before := applyTreeFingerprint(t, fixture.root, nil)
+		result, err := Apply(context.Background(), ApplyRequestV1{
+			RequestVersion: RequestVersionV1, Prepare: changed,
+			SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.ReasonCode != "subject_changed" {
+			t.Fatalf("absent stale Apply result = %#v", result)
+		}
+		digest := sha256.Sum256([]byte("collab"))
+		lock := "mail/meta/launch/create-" + hex.EncodeToString(digest[:12]) + ".lock"
+		allowed := map[string]bool{"mail/meta": true, "mail/meta/launch": true, lock: true}
+		if after := applyTreeFingerprint(t, fixture.root, allowed); before != after {
+			t.Fatalf("absent stale Apply changed durable state: before=%s after=%s", before, after)
+		}
+		if _, err := os.Stat(fixture.request.Target.SessionRoot); !os.IsNotExist(err) {
+			t.Fatalf("stale Apply published absent session: %v", err)
+		}
+	})
+}
+
+func TestActionRequiredSurvivesProcessRestart(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := DecodeApplyRequestV1(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Apply(context.Background(), decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "provisioned_no_runnable" || result.SemanticDigest != result.TrustDigest {
+		t.Fatalf("fresh-process Apply result = %#v", result)
+	}
+	if info, err := os.Stat(filepath.Join(fixture.request.Target.SessionRoot, "agents", "operator")); err != nil || !info.IsDir() {
+		t.Fatalf("participant-only mailbox: info=%v err=%v", info, err)
+	}
+}
+
+func TestApplyReportsRosterDriftWithoutDeletingHistory(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	if err := fsq.EnsureAgentDirs(fixture.request.Target.SessionRoot, "operator"); err != nil {
+		t.Fatal(err)
+	}
+	config := []byte(`{"version":1,"agents":["claude","operator"]}`)
+	if err := os.WriteFile(filepath.Join(fixture.request.Target.SessionRoot, "meta", "config.json"), config, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	historyPath := filepath.Join(fixture.request.Target.SessionRoot, "agents", "operator", "inbox", "cur", "history.json")
+	history := []byte("preserved-history")
+	if err := os.WriteFile(historyPath, history, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(fixture.request.Target.SessionRoot, "agents", "operator", "receipts")); err != nil {
+		t.Fatal(err)
+	}
+	operatorRoot := filepath.Join(fixture.request.Target.SessionRoot, "agents", "operator")
+	operatorBefore := applyTreeFingerprint(t, operatorRoot, nil)
+	fixture.request.Intent.Participants = []ParticipantV1{
+		{Handle: "claude", Runnable: false},
+		{Handle: "reviewer", Runnable: false},
+	}
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "provisioned_no_runnable" ||
+		!slices.Equal(result.Roster.Desired, []string{"claude", "reviewer"}) ||
+		!slices.Equal(result.Roster.Present, []string{"claude", "reviewer"}) ||
+		len(result.Roster.Missing) != 0 || !slices.Equal(result.Roster.Extra, []string{"operator"}) {
+		t.Fatalf("Apply roster drift = %#v", result.Roster)
+	}
+	if got, err := os.ReadFile(historyPath); err != nil || !bytes.Equal(got, history) {
+		t.Fatalf("removed participant history changed: got=%q err=%v", got, err)
+	}
+	if operatorAfter := applyTreeFingerprint(t, operatorRoot, nil); operatorAfter != operatorBefore {
+		t.Fatalf("Apply repaired or changed removed participant: before=%s after=%s", operatorBefore, operatorAfter)
+	}
+}
+
+func TestApplyMissingConfigPreservesDiscoveredRosterAuthority(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	if err := fsq.EnsureAgentDirs(fixture.request.Target.SessionRoot, "operator"); err != nil {
+		t.Fatal(err)
+	}
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "reviewer", Runnable: false}}
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "provisioned_no_runnable" || !slices.Equal(result.Roster.Extra, []string{"claude", "operator"}) {
+		t.Fatalf("missing-config Apply result = %#v", result)
+	}
+	data, err := os.ReadFile(filepath.Join(fixture.request.Target.SessionRoot, "meta", "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		Agents []string `json:"agents"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(config.Agents, []string{"claude", "operator", "reviewer"}) {
+		t.Fatalf("recovered roster authority = %v", config.Agents)
+	}
+}
+
+func TestApplyRequiresExactRequestLocalDecisions(t *testing.T) {
+	tests := []struct {
+		name      string
+		decisions func(PrepareResultV1) []DecisionV1
+		reason    string
+	}{
+		{name: "missing", decisions: func(PrepareResultV1) []DecisionV1 { return []DecisionV1{} }, reason: "decisions_incomplete"},
+		{name: "unknown action", decisions: func(prepared PrepareResultV1) []DecisionV1 {
+			return []DecisionV1{{ActionID: "sha256:" + strings.Repeat("0", 64), Choice: DecisionTrustExactSubject}}
+		}, reason: "decision_unknown_action"},
+		{name: "disallowed", decisions: func(prepared PrepareResultV1) []DecisionV1 {
+			return []DecisionV1{{ActionID: prepared.RequiredActions[0].ActionID, Choice: DecisionFreshOnce}}
+		}, reason: "decision_disallowed"},
+		{name: "declined", decisions: func(prepared PrepareResultV1) []DecisionV1 {
+			return []DecisionV1{{ActionID: prepared.RequiredActions[0].ActionID, Choice: DecisionDeny}}
+		}, reason: "decision_declined"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newPublicPrepareFixture(t, true)
+			prepared, err := Prepare(context.Background(), fixture.request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before := applyTreeFingerprint(t, fixture.root, nil)
+			result, err := Apply(context.Background(), ApplyRequestV1{
+				RequestVersion: RequestVersionV1, Prepare: fixture.request,
+				SubjectDigest: prepared.SubjectDigest, Decisions: test.decisions(prepared),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Outcome != "action_required" || result.ReasonCode != test.reason {
+				t.Fatalf("decision refusal = %#v", result)
+			}
+			allowed := map[string]bool{
+				"mail/collab/meta/launch":            true,
+				"mail/collab/meta/launch/lease.lock": true,
+			}
+			if after := applyTreeFingerprint(t, fixture.root, allowed); before != after {
+				t.Fatalf("decision refusal changed durable state: before=%s after=%s", before, after)
+			}
+			if _, err := os.Stat(filepath.Join(fixture.root, "provider-probed")); !os.IsNotExist(err) {
+				t.Fatalf("decision refusal executed provider: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyUnsupportedLauncherRefusesBeforeRosterMutation(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	fixture.request.Launcher = "cmux"
+	fixture.request.Intent.Participants = append(fixture.request.Intent.Participants, ParticipantV1{Handle: "reviewer", Runnable: false})
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := applyTreeFingerprint(t, fixture.root, nil)
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "action_required" || result.ReasonCode != "launcher_not_available" {
+		t.Fatalf("unsupported Apply = %#v", result)
+	}
+	allowed := map[string]bool{
+		"mail/collab/meta/launch":            true,
+		"mail/collab/meta/launch/lease.lock": true,
+	}
+	if after := applyTreeFingerprint(t, fixture.root, allowed); before != after {
+		t.Fatalf("unsupported Apply changed durable state: before=%s after=%s", before, after)
+	}
+	if _, err := os.Stat(filepath.Join(fixture.request.Target.SessionRoot, "agents", "reviewer")); !os.IsNotExist(err) {
+		t.Fatalf("unsupported Apply provisioned reviewer: %v", err)
+	}
+}
+
+func decisionsForPreparedActions(prepared PrepareResultV1) []DecisionV1 {
+	result := make([]DecisionV1, 0, len(prepared.RequiredActions))
+	for _, action := range prepared.RequiredActions {
+		result = append(result, DecisionV1{ActionID: action.ActionID, Choice: action.AllowedDecisions[0]})
+	}
+	return result
+}
+
+func applyTreeFingerprint(t *testing.T, root string, allowed map[string]bool) string {
+	t.Helper()
+	var snapshot bytes.Buffer
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		if allowed[relative] {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		snapshot.WriteString(relative)
+		snapshot.WriteByte(0)
+		snapshot.WriteString(info.Mode().String())
+		snapshot.WriteByte(0)
+		if entry.Type().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			snapshot.Write(data)
+		}
+		snapshot.WriteByte(0)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(snapshot.Bytes())
+	return hex.EncodeToString(sum[:])
+}

--- a/launchapi/external_test.go
+++ b/launchapi/external_test.go
@@ -36,6 +36,8 @@ import (
 func TestContract(t *testing.T) {
 	var prepare func(context.Context, launchapi.PrepareRequestV1) (launchapi.PrepareResultV1, error) = launchapi.Prepare
 	_ = prepare
+	var apply func(context.Context, launchapi.ApplyRequestV1) (launchapi.ApplyResultV1, error) = launchapi.Apply
+	_ = apply
 	var action launchapi.RequiredActionKindV1 = launchapi.RequiredActionTrustConfirmation
 	var choice launchapi.DecisionChoiceV1 = launchapi.DecisionTrustExactSubject
 	if action == "" || choice == "" {

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -18,24 +18,36 @@ func Prepare(ctx context.Context, request PrepareRequestV1) (PrepareResultV1, er
 	if err := request.Validate(); err != nil {
 		return PrepareResultV1{}, err
 	}
-	intentDigest, err := launchIntentDigest(request.Intent)
+	internalRequest, dependencies, err := prepareInputs(request)
 	if err != nil {
 		return PrepareResultV1{}, err
+	}
+	internalResult, err := internallaunch.Prepare(ctx, internalRequest, dependencies)
+	if err != nil {
+		return PrepareResultV1{}, err
+	}
+	return fromInternalPrepareResult(internalResult), nil
+}
+
+func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, internallaunch.PrepareDependencies, error) {
+	intentDigest, err := launchIntentDigest(request.Intent)
+	if err != nil {
+		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, err
 	}
 	stateDir, err := internallaunch.DefaultLaunchStateDir()
 	if err != nil {
-		return PrepareResultV1{}, err
+		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, err
 	}
 	trustStore, err := internallaunch.OpenTrustStore(stateDir, request.Target.ProjectRoot)
 	if err != nil {
-		return PrepareResultV1{}, fmt.Errorf("open launch trust store: %w", err)
+		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, fmt.Errorf("open launch trust store: %w", err)
 	}
 	host, err := os.Hostname()
 	if err != nil {
-		return PrepareResultV1{}, fmt.Errorf("resolve host identity: %w", err)
+		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, fmt.Errorf("resolve host identity: %w", err)
 	}
 	if host == "" {
-		return PrepareResultV1{}, fmt.Errorf("resolve host identity: empty hostname")
+		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, fmt.Errorf("resolve host identity: empty hostname")
 	}
 	internalRequest := internallaunch.PrepareRequest{
 		Target: internallaunch.PrepareTarget{
@@ -52,16 +64,16 @@ func Prepare(ctx context.Context, request PrepareRequestV1) (PrepareResultV1, er
 		if participant.Runnable {
 			provider, err = internallaunch.ValidateStaticProviderInput(participant.Executable, participant.Args, participant.EnvOverlay)
 			if err != nil {
-				return PrepareResultV1{}, err
+				return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, err
 			}
 			committedArgs, bypassArgs, err = internallaunch.PartitionStaticProviderArgs(provider, participant.Args)
 			if err != nil {
-				return PrepareResultV1{}, err
+				return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, err
 			}
 		}
 		internalRequest.Participants = append(internalRequest.Participants, toInternalPrepareParticipant(participant, provider, committedArgs, bypassArgs))
 	}
-	internalResult, err := internallaunch.Prepare(ctx, internalRequest, internallaunch.PrepareDependencies{
+	dependencies := internallaunch.PrepareDependencies{
 		Backends: map[string]internallaunch.Backend{
 			internallaunch.LauncherCommands: internallaunch.Commands{},
 			internallaunch.LauncherTMux:     internallaunch.NewTmuxBackend("tmux"),
@@ -69,11 +81,8 @@ func Prepare(ctx context.Context, request PrepareRequestV1) (PrepareResultV1, er
 		AdapterFor:   defaultPrepareAdapter,
 		TrustStore:   trustStore,
 		HostIdentity: host,
-	})
-	if err != nil {
-		return PrepareResultV1{}, err
 	}
-	return fromInternalPrepareResult(internalResult), nil
+	return internalRequest, dependencies, nil
 }
 
 func defaultPrepareAdapter(provider, executable string) internallaunch.HarnessAdapter {

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -102,6 +102,49 @@ func TestPrepareResultMatchesPublishedSchema(t *testing.T) {
 	}
 }
 
+func TestApplyResultMatchesPublishedSchema(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawSchema, err := os.ReadFile("../schemas/launch-api-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(rawSchema, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("launch-api-v1.schema.json", schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("launch-api-v1.schema.json#/$defs/ApplyResultV1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawResult, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(rawResult, &document); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(document); err != nil {
+		t.Fatalf("schema rejected live Apply result: %v\n%s", err, rawResult)
+	}
+}
+
 func TestLaunchAPIV1SchemaAcceptsGoldenAndRejectsHostileFields(t *testing.T) {
 	raw, err := os.ReadFile("../schemas/launch-api-v1.schema.json")
 	if err != nil {

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -226,6 +226,8 @@ type ApplyResultV1 struct {
 	ResultVersion int    `json:"result_version"`
 	Outcome       string `json:"outcome"`
 	ReasonCode    string `json:"reason_code,omitempty"`
+	// SubjectDigest is the pre-mutation subject that this Apply request was
+	// authorized against, not a post-mutation Prepare snapshot.
 	SubjectDigest string `json:"subject_digest"`
 	PlanDigest    string `json:"plan_digest"`
 	TrustDigest   string `json:"trust_digest"`


### PR DESCRIPTION
## Summary

- add public `launchapi.Apply` with lease-bound subject revalidation and typed action-required results
- provision participant rosters atomically with add-only history preservation
- publish absent sessions through platform no-replace primitives and preserve committed durability uncertainty
- persist normalized execution options through plan, journal, and execution tickets for Bead 4 consumption

## Frozen-contract rulings

The WB2 freeze remains SHA-256 `ccd0b5a9…45e76aa`; this change does not alter it. Exact gate rulings:

> per-path lock allow-list with directories still descended (no dir-level exclusion)

> subject_digest = accepted pre-mutation subject

> no-replace publication

The lossless-options finding landed in the persisted journal+ticket round-trip case: consumption can defer to Bead 4. Public V1 fields are normalized, cloned into reconciliation, persisted in the journal and execution ticket, read back for both tickets, and recovery rejects option drift. The converter completeness proof is the source field audit because the round-trip test derives its expected value through the same converter.

## Review by execution

Peer gate ran against exact staged-diff SHA-256 `1d33870f44ce178fadbe3581690a0230cb95ba1fb6ebc1820b94711c18bb7aab`:

- `go test ./... -count=1` green across 23 packages
- `-race` x8 on concurrent Apply, filesystem publication, P0-2, and P0-4
- removing the subject check made `TestPrepareIsZeroWriteAndApplyRejectsStaleSubject` fail
- repairing the effective roster instead of the requested roster made `TestApplyReportsRosterDriftWithoutDeletingHistory` fail
- replacing exclusive publication with raw unguarded rename made `TestPublishInitializedDirectChildExclusiveNeverReplacesRacingEmptyChild` fail

A plain `os.Root.Rename` mutant passed the sequential publication test because Go `os.Rename` performs a non-atomic `Lstat` guard for directory targets. The implementation correctly uses `RENAME_EXCL`/`RENAME_NOREPLACE`, but that sequential test cannot observe the atomicity window and is not claimed as proof of atomic no-replace behavior.

## Verification

- `make ci`
- pre-push checks
- gate: gofmt, vet, golangci-lint, full tests, focused race repetitions, and the three mutants above