### PR TITLE
feat(launch): exact-root coop exec emission with typed execution options

### DIFF
--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -67,6 +67,10 @@ func runCoopExec(args []string) error {
 	wakeInjectViaFlag := fs.String("wake-inject-via", "", "Start wake with this absolute --inject-via executable, enabling later amq wake repair")
 	var wakeInjectArgFlags multiStringFlag
 	fs.Var(&wakeInjectArgFlags, "wake-inject-arg", "Fixed argument for wake --inject-via before the payload (repeatable)")
+	managedNoWakeReasonFlag := fs.String("managed-no-wake-reason", "", "")
+	var managedSymphonyEventFlags multiStringFlag
+	fs.Var(&managedSymphonyEventFlags, "managed-symphony-event", "")
+	managedSymphonyWorkspaceFlag := fs.String("managed-symphony-workspace-key", "", "")
 	yesFlag := fs.Bool("y", false, "Skip confirmation prompts (including clearing a blocking wake)")
 
 	usage := usageWithFlags(fs, "amq coop exec [options] <command> [-- <command-flags>]",
@@ -101,10 +105,19 @@ func runCoopExec(args []string) error {
 	} else if handled {
 		return nil
 	}
+	if managedLaunchNonce != "" {
+		if !flagWasVisited(fs, "root") || strings.TrimSpace(*rootFlag) == "" || !filepath.IsAbs(*rootFlag) {
+			return ActionRequiredError("managed launch requires one explicit absolute --root")
+		}
+		if *sessionFlag != "" {
+			return ActionRequiredError("managed launch forbids --session; use the ticket-bound exact --root")
+		}
+	}
 	if *noWakeFlag && *requireWakeFlag {
 		return UsageError("--require-wake cannot be used with --no-wake")
 	}
-	wakeInjectVia := strings.TrimSpace(*wakeInjectViaFlag)
+	declaredWakeInjectVia := strings.TrimSpace(*wakeInjectViaFlag)
+	wakeInjectVia := declaredWakeInjectVia
 	wakeInjectMode, err := normalizeWakeInjectMode(*wakeInjectModeFlag)
 	if err != nil {
 		return UsageError("--wake-inject-mode: %v", err)
@@ -128,6 +141,41 @@ func runCoopExec(args []string) error {
 		}
 		wakeInjectVia = resolvedWakeInjectVia
 	}
+	managedOnlyOptions := flagWasVisited(fs, "managed-no-wake-reason") ||
+		flagWasVisited(fs, "managed-symphony-event") ||
+		flagWasVisited(fs, "managed-symphony-workspace-key")
+	if managedOnlyOptions && managedLaunchNonce == "" {
+		return UsageError("managed execution options require a trusted launch ticket")
+	}
+	var executionOptions *launch.PrepareExecutionOptions
+	if managedLaunchNonce != "" && (managedOnlyOptions ||
+		flagWasVisited(fs, "no-gitignore") || flagWasVisited(fs, "no-wake") ||
+		flagWasVisited(fs, "require-wake") || flagWasVisited(fs, "wake-inject-mode") ||
+		flagWasVisited(fs, "wake-inject-via") || flagWasVisited(fs, "wake-inject-arg")) {
+		wakeMode := "enabled"
+		if *noWakeFlag {
+			wakeMode = "disabled"
+		}
+		managedInjectorMode := ""
+		if flagWasVisited(fs, "wake-inject-mode") {
+			managedInjectorMode = wakeInjectMode
+		}
+		options := launch.PrepareExecutionOptions{
+			RequireWake:          *requireWakeFlag,
+			NoGitignore:          *noGitignoreFlag,
+			WakeMode:             wakeMode,
+			AuditReason:          *managedNoWakeReasonFlag,
+			InjectorMode:         managedInjectorMode,
+			InjectorVia:          declaredWakeInjectVia,
+			InjectorArgs:         append([]string(nil), wakeInjectArgFlags...),
+			SymphonyEvents:       append([]string(nil), managedSymphonyEventFlags...),
+			SymphonyWorkspaceKey: *managedSymphonyWorkspaceFlag,
+		}
+		if err := validateManagedExecutionOptions(options); err != nil {
+			return UsageError("managed execution options: %v", err)
+		}
+		executionOptions = &options
+	}
 
 	remaining := fs.Args()
 	if len(remaining) == 0 {
@@ -147,6 +195,14 @@ func runCoopExec(args []string) error {
 	agentHandle, err = normalizeHandle(agentHandle)
 	if err != nil {
 		return fmt.Errorf("cannot derive agent handle from %q: %w (use --me to override)", cmdName, err)
+	}
+	var managedGuard *managedExecutionGuard
+	if managedLaunchNonce != "" {
+		managedGuard, err = acquireManagedExecutionGuard(*rootFlag, agentHandle, managedLaunchNonce, executionOptions)
+		if err != nil {
+			return ActionRequiredError("refusing managed execution options before root mutation: %v", err)
+		}
+		defer func() { _ = managedGuard.Close() }()
 	}
 
 	rootRequested := flagWasVisited(fs, "root")
@@ -366,15 +422,20 @@ func runCoopExec(args []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve absolute session root: %w", err)
 	}
-
 	// Ensure the agent mailbox exists — but only inside a tree that is
 	// provably a queue. A pre-existing directory is not a provisioning
 	// target just because it exists (dirExists said nothing about what it
 	// is), so classify the layout through a pinned capability first and keep
 	// that same capability for the writes.
 	if !sessionProvisioned {
-		if err := provisionSelfMailboxInExistingRoot(root, agentHandle); err != nil {
-			return err
+		if managedGuard != nil {
+			if err := fsq.ValidateExistingMailboxLayout(managedGuard.root, agentHandle); err != nil {
+				return ActionRequiredError("refusing managed mailbox provisioning: %v", err)
+			}
+		} else {
+			if err := provisionSelfMailboxInExistingRoot(root, agentHandle); err != nil {
+				return err
+			}
 		}
 	}
 	if !*noWakeFlag {
@@ -482,6 +543,16 @@ func runCoopExec(args []string) error {
 			wakeChildCapability, err = configureAuthoritativeWakeChild(wakeCmd)
 			if err == nil && wakeChildCapability == nil {
 				return fmt.Errorf("prepare exact-owner amq wake supervision returned nil capability")
+			}
+			if err == nil && managedGuard != nil {
+				if validateErr := managedGuard.Revalidate(); validateErr != nil {
+					closeErr := wakeChildCapability.Close()
+					wakeChildCapability = nil
+					return ActionRequiredError(
+						"refusing changed managed execution options before wake start: %v",
+						errors.Join(validateErr, closeErr),
+					)
+				}
 			}
 			if err != nil {
 				var closeErr error
@@ -606,6 +677,11 @@ func runCoopExec(args []string) error {
 			}
 		}
 	}
+	if managedGuard != nil {
+		if err := managedGuard.Close(); err != nil {
+			return ActionRequiredError("release managed execution option guard after wake startup: %v", err)
+		}
+	}
 
 	// A named/default or session-shaped explicit root pins an identity
 	// independent of AM_ROOT. A custom sessionless --root clears inherited pins.
@@ -648,7 +724,7 @@ func runCoopExec(args []string) error {
 	env = setEnvVar(unsetEnvVar(env, envWakeOwner), envWakeOwner, encodedOwner)
 	var execErr error
 	if managedLaunchNonce != "" {
-		execErr = reexecManagedLaunchWrapper(root, agentHandle, managedLaunchNonce, binaryPath, argv, env)
+		execErr = reexecManagedLaunchWrapper(root, agentHandle, managedLaunchNonce, binaryPath, argv, env, executionOptions)
 	} else {
 		execErr = coopExecProcess(binaryPath, argv, env)
 	}
@@ -661,7 +737,7 @@ func runCoopExec(args []string) error {
 // reexecManagedLaunchWrapper preserves the coop exec PID while moving the
 // final trust revalidation and conversation acknowledgement directly next to
 // the provider exec boundary.
-func reexecManagedLaunchWrapper(root, handle, nonce, binaryPath string, argv, env []string) error {
+func reexecManagedLaunchWrapper(root, handle, nonce, binaryPath string, argv, env []string, options *launch.PrepareExecutionOptions) error {
 	current, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve current amq executable for managed launch: %w", err)
@@ -672,10 +748,61 @@ func reexecManagedLaunchWrapper(root, handle, nonce, binaryPath string, argv, en
 	}
 	wrapperArgv := []string{
 		amqPath, "__launch-exec", "--root", root, "--handle", handle,
-		"--nonce", nonce, "--target", binaryPath, "--",
+		"--nonce", nonce, "--target", binaryPath,
 	}
+	if options != nil {
+		encoded, err := encodeManagedExecutionOptions(*options)
+		if err != nil {
+			return fmt.Errorf("encode managed execution options: %w", err)
+		}
+		wrapperArgv = append(wrapperArgv, "--"+managedExecutionOptionsFlag, encoded)
+	}
+	wrapperArgv = append(wrapperArgv, "--")
 	wrapperArgv = append(wrapperArgv, argv...)
 	return coopExecProcess(amqPath, wrapperArgv, env)
+}
+
+type managedExecutionGuard struct {
+	root    *fsq.DeliveryRoot
+	handle  string
+	nonce   string
+	options *launch.PrepareExecutionOptions
+	closed  bool
+}
+
+func acquireManagedExecutionGuard(rootPath, handle, nonce string, options *launch.PrepareExecutionOptions) (*managedExecutionGuard, error) {
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("open existing ticket-bound root: %w", err)
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		return nil, err
+	}
+	if err := fsq.ValidateExistingMailboxLayout(root, handle); err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	guard := &managedExecutionGuard{root: root, handle: handle, nonce: nonce, options: options}
+	if err := guard.Revalidate(); err != nil {
+		return nil, errors.Join(err, guard.Close())
+	}
+	return guard, nil
+}
+
+func (guard *managedExecutionGuard) Revalidate() error {
+	if guard == nil || guard.closed || guard.root == nil {
+		return fmt.Errorf("managed execution guard is not active")
+	}
+	return launch.ValidateExecutionOptions(guard.root, guard.handle, guard.nonce, guard.options)
+}
+
+func (guard *managedExecutionGuard) Close() error {
+	if guard == nil || guard.closed {
+		return nil
+	}
+	guard.closed = true
+	return guard.root.Close()
 }
 
 // coopProvisionAfterClassifyHook runs between layout classification and the

--- a/internal/cli/launch_exec_reexec_unix_test.go
+++ b/internal/cli/launch_exec_reexec_unix_test.go
@@ -27,7 +27,8 @@ func TestManagedLaunchReexecPreservesPIDAndTargetArgv(t *testing.T) {
 	}
 	target := []string{"/opt/provider", "--resume", "conversation"}
 	env := []string{"AM_ROOT=/queue", "TOKEN=value"}
-	err := reexecManagedLaunchWrapper("/queue", "codex", "11111111-1111-4111-8111-111111111111", target[0], target, env)
+	options := &launch.PrepareExecutionOptions{WakeMode: "enabled", RequireWake: true}
+	err := reexecManagedLaunchWrapper("/queue", "codex", "11111111-1111-4111-8111-111111111111", target[0], target, env, options)
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("reexec error = %v, want sentinel", err)
 	}
@@ -37,6 +38,14 @@ func TestManagedLaunchReexecPreservesPIDAndTargetArgv(t *testing.T) {
 	dash := slices.Index(gotArgv, "--")
 	if dash < 0 || !slices.Equal(gotArgv[dash+1:], target) {
 		t.Fatalf("wrapper target tail = %#v, want %#v", gotArgv[dash+1:], target)
+	}
+	optionsAt := slices.Index(gotArgv, "--"+managedExecutionOptionsFlag)
+	if optionsAt < 0 || optionsAt+1 >= dash {
+		t.Fatalf("private wrapper omitted execution options: %#v", gotArgv)
+	}
+	decoded, err := decodeManagedExecutionOptions(gotArgv[optionsAt+1])
+	if err != nil || !slices.Equal(decoded.InjectorArgs, options.InjectorArgs) || decoded.RequireWake != options.RequireWake || decoded.WakeMode != options.WakeMode {
+		t.Fatalf("private wrapper options = %#v, %v", decoded, err)
 	}
 	if !slices.Equal(gotEnv, env) {
 		t.Fatalf("wrapper env = %#v, want %#v", gotEnv, env)
@@ -65,6 +74,14 @@ func TestPrivateLaunchWrapperAcknowledgesThenRevertsFailedExec(t *testing.T) {
 	if err := os.WriteFile(provider, []byte("provider"), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	injector := filepath.Join(t.TempDir(), "injector")
+	if err := os.WriteFile(injector, []byte("injector"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	options := &launch.PrepareExecutionOptions{
+		WakeMode: "enabled", InjectorMode: "raw", InjectorVia: injector,
+		InjectorArgs: []string{"--fixed", "ordered"},
+	}
 	amqExecutable, err := os.Executable()
 	if err != nil {
 		t.Fatal(err)
@@ -81,7 +98,7 @@ func TestPrivateLaunchWrapperAcknowledgesThenRevertsFailedExec(t *testing.T) {
 		Handle: "claude", LaunchNonce: nonce, Mode: launch.AdapterModeMint,
 		Provider: launch.ClaudeProvider, ConversationID: nonce,
 		ProjectRoot: project, SessionRoot: session, Cwd: project,
-		ProviderExecutable: provider, AMQExecutable: amqExecutable, TargetArgv: []string{provider},
+		ProviderExecutable: provider, AMQExecutable: amqExecutable, TargetArgv: []string{provider}, Execution: options,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -109,7 +126,11 @@ func TestPrivateLaunchWrapperAcknowledgesThenRevertsFailedExec(t *testing.T) {
 	oldExec := launchExecProcess
 	launchExecProcess = func(string, []string, []string) error { return sentinel }
 	t.Cleanup(func() { launchExecProcess = oldExec })
-	err = runLaunchExec([]string{"--root", session, "--handle", "claude", "--nonce", nonce, "--target", provider, "--", provider})
+	encodedOptions, err := encodeManagedExecutionOptions(*options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = runLaunchExec([]string{"--root", session, "--handle", "claude", "--nonce", nonce, "--target", provider, "--" + managedExecutionOptionsFlag, encodedOptions, "--", provider})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("wrapper error = %v, want provider exec failure", err)
 	}

--- a/internal/cli/launch_exec_unix.go
+++ b/internal/cli/launch_exec_unix.go
@@ -24,8 +24,17 @@ func runLaunchExec(args []string) error {
 	handleFlag := fs.String("handle", "", "")
 	nonceFlag := fs.String("nonce", "", "")
 	targetFlag := fs.String("target", "", "")
+	executionOptionsFlag := fs.String(managedExecutionOptionsFlag, "", "")
 	if err := fs.Parse(amqArgs); err != nil || len(fs.Args()) != 0 || *rootFlag == "" || *handleFlag == "" || *nonceFlag == "" || *targetFlag == "" || len(targetArgv) == 0 {
 		return ActionRequiredError("refusing incomplete private launch wrapper invocation")
+	}
+	var executionOptions *launch.PrepareExecutionOptions
+	if *executionOptionsFlag != "" {
+		decoded, err := decodeManagedExecutionOptions(*executionOptionsFlag)
+		if err != nil {
+			return ActionRequiredError("refusing invalid managed execution options: %v", err)
+		}
+		executionOptions = &decoded
 	}
 	identity, err := fsq.SnapshotDeliveryRoot(*rootFlag)
 	if err != nil {
@@ -46,7 +55,7 @@ func runLaunchExec(args []string) error {
 	}
 	if _, err := launch.PrepareExecution(root, *handleFlag, *nonceFlag, launch.ExecutionEnvelope{
 		Cwd: cwd, AMQExecutable: amqExecutable, ProviderExecutable: *targetFlag,
-		TargetArgv: targetArgv, Environment: os.Environ(),
+		TargetArgv: targetArgv, Environment: os.Environ(), Execution: executionOptions,
 	}); err != nil {
 		return ActionRequiredError("refusing managed launch execution: %v", err)
 	}

--- a/internal/cli/managed_execution_options.go
+++ b/internal/cli/managed_execution_options.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+const managedExecutionOptionsFlag = "execution-options"
+
+var managedSymphonyEvents = []string{"after_create", "before_run", "after_run", "before_remove"}
+
+func validateManagedExecutionOptions(options launch.PrepareExecutionOptions) error {
+	switch options.WakeMode {
+	case "disabled":
+		if strings.TrimSpace(options.AuditReason) == "" {
+			return fmt.Errorf("disabled wake requires an audit reason")
+		}
+		if options.RequireWake {
+			return fmt.Errorf("require_wake conflicts with disabled wake")
+		}
+		if options.InjectorMode != "" || options.InjectorVia != "" || len(options.InjectorArgs) != 0 {
+			return fmt.Errorf("disabled wake forbids injector settings")
+		}
+	case "enabled":
+		if options.AuditReason != "" {
+			return fmt.Errorf("enabled wake forbids a disabled-wake audit reason")
+		}
+	default:
+		return fmt.Errorf("invalid wake mode %q", options.WakeMode)
+	}
+
+	switch options.InjectorMode {
+	case "", "auto", "raw", "paste", "none":
+	default:
+		return fmt.Errorf("invalid injector mode %q", options.InjectorMode)
+	}
+	if options.InjectorMode == "none" && (options.InjectorVia != "" || len(options.InjectorArgs) != 0) {
+		return fmt.Errorf("injector mode none forbids via and args")
+	}
+	if options.InjectorVia != "" {
+		if !filepath.IsAbs(options.InjectorVia) || filepath.Clean(options.InjectorVia) != options.InjectorVia || strings.ContainsRune(options.InjectorVia, 0) {
+			return fmt.Errorf("injector via must be a clean absolute path")
+		}
+	} else if len(options.InjectorArgs) != 0 {
+		return fmt.Errorf("injector args require via")
+	}
+	for _, arg := range options.InjectorArgs {
+		if !utf8.ValidString(arg) || strings.ContainsRune(arg, 0) {
+			return fmt.Errorf("injector args contain an invalid value")
+		}
+	}
+
+	seen := make(map[string]struct{}, len(options.SymphonyEvents))
+	for _, event := range options.SymphonyEvents {
+		if !slices.Contains(managedSymphonyEvents, event) {
+			return fmt.Errorf("unknown symphony event %q", event)
+		}
+		if _, ok := seen[event]; ok {
+			return fmt.Errorf("duplicate symphony event %q", event)
+		}
+		seen[event] = struct{}{}
+	}
+	if options.SymphonyWorkspaceKey != "" && len(options.SymphonyEvents) == 0 {
+		return fmt.Errorf("symphony workspace key requires at least one event")
+	}
+	if !utf8.ValidString(options.SymphonyWorkspaceKey) || strings.ContainsRune(options.SymphonyWorkspaceKey, 0) {
+		return fmt.Errorf("symphony workspace key is invalid")
+	}
+	return nil
+}
+
+func encodeManagedExecutionOptions(options launch.PrepareExecutionOptions) (string, error) {
+	if err := validateManagedExecutionOptions(options); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(options)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodeManagedExecutionOptions(encoded string) (launch.PrepareExecutionOptions, error) {
+	data, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return launch.PrepareExecutionOptions{}, fmt.Errorf("decode execution options: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var options launch.PrepareExecutionOptions
+	if err := decoder.Decode(&options); err != nil {
+		return launch.PrepareExecutionOptions{}, fmt.Errorf("decode execution options: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return launch.PrepareExecutionOptions{}, fmt.Errorf("decode execution options: trailing data")
+	}
+	if err := validateManagedExecutionOptions(options); err != nil {
+		return launch.PrepareExecutionOptions{}, err
+	}
+	return options, nil
+}

--- a/internal/cli/managed_execution_options_test.go
+++ b/internal/cli/managed_execution_options_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestManagedExecutionOptionsCodecRoundTripAndHostileInput(t *testing.T) {
+	want := launch.PrepareExecutionOptions{
+		RequireWake: true, NoGitignore: true, WakeMode: "enabled",
+		InjectorMode: "paste", InjectorVia: "/opt/amq/injector", InjectorArgs: []string{"--fixed", "value"},
+		SymphonyEvents: []string{"after_create", "before_run"}, SymphonyWorkspaceKey: "workspace-7",
+	}
+	encoded, err := encodeManagedExecutionOptions(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := decodeManagedExecutionOptions(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip = %#v, want %#v", got, want)
+	}
+
+	unknown := base64.RawURLEncoding.EncodeToString([]byte(`{"wake_mode":"enabled","arbitrary_hook":"/tmp/run"}`))
+	if _, err := decodeManagedExecutionOptions(unknown); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("arbitrary hook decode error = %v", err)
+	}
+	invalid := want
+	invalid.SymphonyEvents = []string{"unknown"}
+	if _, err := encodeManagedExecutionOptions(invalid); err == nil || !strings.Contains(err.Error(), "unknown symphony event") {
+		t.Fatalf("unknown event error = %v", err)
+	}
+}
+
+func TestManagedExecutionOptionsDisabledWakeRequiresReason(t *testing.T) {
+	if err := validateManagedExecutionOptions(launch.PrepareExecutionOptions{WakeMode: "disabled"}); err == nil {
+		t.Fatal("disabled wake without an audit reason succeeded")
+	}
+	if err := validateManagedExecutionOptions(launch.PrepareExecutionOptions{WakeMode: "disabled", AuditReason: "operator policy", RequireWake: true}); err == nil {
+		t.Fatal("disabled wake with require_wake succeeded")
+	}
+}
+
+func TestCoopExecRejectsManagedOptionsWithoutLaunchTicket(t *testing.T) {
+	t.Setenv(launch.InternalLaunchNonceEnv, "")
+	err := runCoopExec([]string{"--managed-symphony-event", "after_create", "true"})
+	if err == nil || GetExitCode(err) != ExitUsage || !strings.Contains(err.Error(), "require a trusted launch ticket") {
+		t.Fatalf("untrusted managed option error = %v", err)
+	}
+}
+
+func TestManagedCoopExecRequiresExplicitAbsoluteRoot(t *testing.T) {
+	t.Setenv(launch.InternalLaunchNonceEnv, "11111111-1111-4111-8111-111111111111")
+	for _, args := range [][]string{
+		{"--managed-symphony-event", "after_create", "true"},
+		{"--root", "relative/root", "--managed-symphony-event", "after_create", "true"},
+	} {
+		err := runCoopExec(args)
+		if err == nil || GetExitCode(err) != ExitActionRequired || !strings.Contains(err.Error(), "explicit absolute --root") {
+			t.Fatalf("managed exact-root error for %#v = %v", args, err)
+		}
+	}
+}
+
+func TestManagedCoopExecDoesNotProvisionMissingTicketRoot(t *testing.T) {
+	t.Setenv(launch.InternalLaunchNonceEnv, "11111111-1111-4111-8111-111111111111")
+	missing := filepath.Join(t.TempDir(), "missing")
+	err := runCoopExec([]string{
+		"--root", missing, "--no-wake", "--managed-no-wake-reason", "test",
+		"--me", "codex", "true",
+	})
+	if err == nil || GetExitCode(err) != ExitActionRequired || !strings.Contains(err.Error(), "before root mutation") {
+		t.Fatalf("missing managed root error = %v", err)
+	}
+	if _, statErr := os.Stat(missing); !os.IsNotExist(statErr) {
+		t.Fatalf("managed refusal provisioned %s: %v", missing, statErr)
+	}
+}
+
+func TestPrivateLaunchWrapperRejectsInvalidExecutionOptionsBeforeRootAccess(t *testing.T) {
+	invalid := base64.RawURLEncoding.EncodeToString([]byte(`{"wake_mode":"enabled","arbitrary_hook":"/tmp/run"}`))
+	err := runLaunchExec([]string{
+		"--root", "/definitely/missing", "--handle", "codex",
+		"--nonce", "11111111-1111-4111-8111-111111111111", "--target", "/bin/true",
+		"--" + managedExecutionOptionsFlag, invalid, "--", "/bin/true",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid managed execution options") {
+		t.Fatalf("private wrapper error = %v", err)
+	}
+}

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -300,8 +300,9 @@ func TestAdapterKeepsStableExecutableAcrossSymlinkRetarget(t *testing.T) {
 	if firstDigest != secondDigest {
 		t.Fatalf("symlink retarget changed semantic digest: %s != %s", firstDigest, secondDigest)
 	}
+	_, root := openTestRoot(t)
 	emitted, err := (Commands{}).Create(CreateRequest{
-		Session: "collab", AMQPath: "amq", Plan: Plan{Version: PlanVersion, Agents: []AgentPlan{second}},
+		Session: "collab", AMQPath: "amq", Plan: Plan{Version: PlanVersion, Agents: []AgentPlan{second}}, Root: root,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/launch/commands.go
+++ b/internal/launch/commands.go
@@ -46,6 +46,12 @@ func (Commands) Create(req CreateRequest) (CreateResult, error) {
 	if strings.TrimSpace(req.Session) == "" {
 		return CreateResult{}, fmt.Errorf("session is required")
 	}
+	if req.Root == nil {
+		return CreateResult{}, fmt.Errorf("pinned session root is required")
+	}
+	if err := req.Root.VerifyBase(); err != nil {
+		return CreateResult{}, fmt.Errorf("verify pinned session root: %w", err)
+	}
 	if err := req.Plan.Validate(); err != nil {
 		return CreateResult{}, err
 	}
@@ -59,7 +65,7 @@ func (Commands) Create(req CreateRequest) (CreateResult, error) {
 	}
 	commands := make([]EmittedCommand, 0, len(req.Plan.Agents))
 	for _, agent := range req.Plan.Agents {
-		argv := coopExecArgv(amq, req.Session, agent.Handle, agent.Argv)
+		argv := coopExecArgv(amq, req.Root.Base(), agent.Handle, agent.Argv, agent.Execution)
 		env := cloneEnv(agent.EnvOverlay)
 		if env == nil {
 			env = make(map[string]string, 1)
@@ -98,13 +104,48 @@ func (Commands) Close(CloseRequest) (CloseResult, error) {
 // coopExecArgv is amq coop exec [options] <command> [-- <command-flags>].
 // The command positional is required; flags after -- are agent args. A lone
 // executable omits --.
-func coopExecArgv(amq, session, handle string, planArgv []string) []string {
-	argv := []string{amq, "coop", "exec", "--session", session, "--me", handle, planArgv[0]}
+func coopExecArgv(amq, sessionRoot, handle string, planArgv []string, options *PrepareExecutionOptions) []string {
+	argv := []string{amq, "coop", "exec", "--root", sessionRoot, "--me", handle}
+	argv = append(argv, coopExecOptionArgs(options)...)
+	argv = append(argv, planArgv[0])
 	if len(planArgv) > 1 {
 		argv = append(argv, "--")
 		argv = append(argv, planArgv[1:]...)
 	}
 	return argv
+}
+
+func coopExecOptionArgs(options *PrepareExecutionOptions) []string {
+	if options == nil {
+		return nil
+	}
+	args := make([]string, 0, 16)
+	if options.NoGitignore {
+		args = append(args, "--no-gitignore")
+	}
+	if options.WakeMode == "disabled" {
+		args = append(args, "--no-wake", "--managed-no-wake-reason", options.AuditReason)
+	} else {
+		if options.RequireWake {
+			args = append(args, "--require-wake")
+		}
+		if options.InjectorMode != "" {
+			args = append(args, "--wake-inject-mode", options.InjectorMode)
+		}
+		if options.InjectorVia != "" {
+			args = append(args, "--wake-inject-via", options.InjectorVia)
+			for _, arg := range options.InjectorArgs {
+				args = append(args, "--wake-inject-arg", arg)
+			}
+		}
+	}
+	for _, event := range options.SymphonyEvents {
+		args = append(args, "--managed-symphony-event", event)
+	}
+	if options.SymphonyWorkspaceKey != "" {
+		args = append(args, "--managed-symphony-workspace-key", options.SymphonyWorkspaceKey)
+	}
+	return args
 }
 
 func commandLine(cwd string, env map[string]string, argv []string) string {

--- a/internal/launch/commands_test.go
+++ b/internal/launch/commands_test.go
@@ -2,10 +2,15 @@ package launch
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 func TestCommandsPublishedProfile(t *testing.T) {
@@ -58,7 +63,7 @@ func TestCommandsCreateEmitsCoopExecAndRoundTripsPlan(t *testing.T) {
 		if cmd.Handle != agent.Handle || cmd.Cwd != agent.Cwd || cmd.LaunchNonce != agent.LaunchNonce {
 			t.Fatalf("command[%d] metadata = %#v", i, cmd)
 		}
-		assertCoopExecGrammar(t, cmd.Argv, agent.Handle, agent.Argv)
+		assertCoopExecGrammar(t, cmd.Argv, root.Base(), agent.Handle, agent.Argv)
 		if cmd.Env[InternalLaunchNonceEnv] != agent.LaunchNonce {
 			t.Fatalf("command[%d] managed launch nonce = %q, want %q", i, cmd.Env[InternalLaunchNonceEnv], agent.LaunchNonce)
 		}
@@ -127,6 +132,10 @@ func TestCommandsCreateRejectsInvalidInput(t *testing.T) {
 	if err == nil {
 		t.Fatal("invalid plan succeeded")
 	}
+	_, err = Commands{}.Create(CreateRequest{Session: "collab", Plan: validPlan()})
+	if err == nil || !strings.Contains(err.Error(), "pinned session root is required") {
+		t.Fatalf("missing pinned root error = %v", err)
+	}
 }
 
 func TestCommandsCoopExecGrammarShape(t *testing.T) {
@@ -140,15 +149,16 @@ func TestCommandsCoopExecGrammarShape(t *testing.T) {
 			Cwd: "/work/project", AdapterMode: AdapterModeUnsupported, ResumePolicy: ResumeDisabled,
 		},
 	}}
-	result, err := Commands{}.Create(CreateRequest{Session: "collab", Plan: plan})
+	_, root := openTestRoot(t)
+	result, err := Commands{}.Create(CreateRequest{Session: "collab", Plan: plan, Root: root})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(result.Commands) != 2 {
 		t.Fatalf("commands = %d, want 2", len(result.Commands))
 	}
-	assertCoopExecGrammar(t, result.Commands[0].Argv, "claude", plan.Agents[0].Argv)
-	assertCoopExecGrammar(t, result.Commands[1].Argv, "codex", plan.Agents[1].Argv)
+	assertCoopExecGrammar(t, result.Commands[0].Argv, root.Base(), "claude", plan.Agents[0].Argv)
+	assertCoopExecGrammar(t, result.Commands[1].Argv, root.Base(), "codex", plan.Agents[1].Argv)
 	if slices.Contains(result.Commands[1].Argv, "--") {
 		t.Fatalf("lone executable must omit --: %#v", result.Commands[1].Argv)
 	}
@@ -159,8 +169,205 @@ func TestCommandsCoopExecGrammarShape(t *testing.T) {
 
 func TestCommandsCoopExecOldShapeFailsGrammar(t *testing.T) {
 	old := []string{"amq", "coop", "exec", "--session", "collab", "--me", "claude", "--", "/usr/local/bin/claude", "--model", "opus"}
-	if err := coopExecGrammarError(old, "claude", []string{"/usr/local/bin/claude", "--model", "opus"}); err == nil {
+	if err := coopExecGrammarError(old, "/queue/collab", "claude", []string{"/usr/local/bin/claude", "--model", "opus"}); err == nil {
 		t.Fatal("old shape (-- immediately after --me) passed grammar check")
+	}
+}
+
+func TestTypedExecutionOptionsRoundTripAndSingleCoopExec(t *testing.T) {
+	options := &PrepareExecutionOptions{
+		RequireWake: true, NoGitignore: true, WakeMode: "enabled",
+		InjectorMode: "raw", InjectorVia: "/opt/amq/injector", InjectorArgs: []string{"--fixed", "value with space"},
+		SymphonyEvents: []string{"after_create", "before_run", "after_run", "before_remove"}, SymphonyWorkspaceKey: "workspace-7",
+	}
+	_, root := openTestRoot(t)
+	plan := validPlan()
+	plan.Agents = plan.Agents[1:]
+	plan.Agents[0].Execution = options
+	result, err := Commands{}.Create(CreateRequest{Session: "team", Plan: plan, AMQPath: "/opt/amq", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(result.Commands))
+	}
+	argv := result.Commands[0].Argv
+	line := result.Commands[0].Line
+	if strings.Count(line, "coop exec") != 1 {
+		t.Fatalf("coop exec boundary count in %q = %d, want 1", line, strings.Count(line, "coop exec"))
+	}
+	for _, pair := range [][2]string{
+		{"--root", root.Base()},
+		{"--me", "codex"},
+		{"--wake-inject-mode", "raw"},
+		{"--wake-inject-via", "/opt/amq/injector"},
+		{"--managed-symphony-workspace-key", "workspace-7"},
+	} {
+		at := indexOf(argv, pair[0])
+		if at < 0 || at+1 >= len(argv) || argv[at+1] != pair[1] {
+			t.Fatalf("%s transport in %#v, want %q", pair[0], argv, pair[1])
+		}
+	}
+	if countArg(argv, "--wake-inject-arg") != 2 || countArg(argv, "--managed-symphony-event") != 4 {
+		t.Fatalf("repeatable options were not lossless: %#v", argv)
+	}
+	if !slices.Contains(argv, "--require-wake") || !slices.Contains(argv, "--no-gitignore") || slices.Contains(argv, "--session") {
+		t.Fatalf("typed option or exact-root transport mismatch: %#v", argv)
+	}
+}
+
+func TestExplicitDefaultExecutionOptionsEmitNoFlags(t *testing.T) {
+	_, root := openTestRoot(t)
+	plan := validPlan()
+	plan.Agents = plan.Agents[:1]
+	plan.Agents[0].Execution = &PrepareExecutionOptions{WakeMode: "enabled"}
+	if !reflect.DeepEqual(CanonicalExecutionOptions(plan.Agents[0].Execution), CanonicalExecutionOptions(nil)) {
+		t.Fatal("explicit defaults and nil are not canonical equals")
+	}
+	result, err := Commands{}.Create(CreateRequest{Session: "team", Plan: plan, AMQPath: "/opt/amq", Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := result.Commands[0].Argv
+	for _, flag := range []string{"--require-wake", "--no-gitignore", "--no-wake", "--wake-inject-mode", "--managed-symphony-event"} {
+		if slices.Contains(argv, flag) {
+			t.Fatalf("explicit default execution options emitted %s: %#v", flag, argv)
+		}
+	}
+}
+
+func TestExactRootAcrossSiblingWorktrees(t *testing.T) {
+	worktrees := t.TempDir()
+	mainCwd := filepath.Join(worktrees, "main")
+	siblingCwd := filepath.Join(worktrees, "sibling")
+	if err := os.Mkdir(mainCwd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runCommandsTestProcess(t, mainCwd, "git", "init", "-q")
+	if err := os.WriteFile(filepath.Join(mainCwd, "README.md"), []byte("fixture\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runCommandsTestProcess(t, mainCwd, "git", "add", "README.md")
+	runCommandsTestProcess(t, mainCwd, "git", "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "-qm", "fixture")
+	runCommandsTestProcess(t, mainCwd, "git", "worktree", "add", "-q", "-b", "sibling", siblingCwd)
+
+	sessionRoot := filepath.Join(mainCwd, ".agent-mail", "collab")
+	if err := fsq.EnsureRootDirs(sessionRoot); err != nil {
+		t.Fatal(err)
+	}
+	config := []byte(`{"version":1,"agents":["claude","codex"]}`)
+	if err := os.WriteFile(filepath.Join(sessionRoot, "meta", "config.json"), config, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, handle := range []string{"claude", "codex"} {
+		if err := fsq.EnsureAgentDirs(sessionRoot, handle); err != nil {
+			t.Fatal(err)
+		}
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(sessionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(sessionRoot, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+
+	moduleCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	moduleRoot := filepath.Clean(filepath.Join(moduleCwd, "..", ".."))
+	binDir := t.TempDir()
+	amqBinary := filepath.Join(binDir, "amq")
+	build := exec.Command("go", "build", "-o", amqBinary, "./cmd/amq")
+	build.Dir = moduleRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build amq fixture: %v\n%s", err, output)
+	}
+	provider := filepath.Join(binDir, "provider")
+	providerScript := `#!/bin/sh
+set -eu
+case "$AM_ME" in
+  claude) exec "$PROOF_AMQ" --no-update-check send --root "$AM_ROOT" --me claude --to codex --body "exact-root-message" ;;
+  codex) exec "$PROOF_AMQ" --no-update-check drain --root "$AM_ROOT" --me codex --include-body ;;
+  *) exit 64 ;;
+esac
+`
+	if err := os.WriteFile(provider, []byte(providerScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	nonce := "71717171-7171-4171-8171-717171717171"
+	options := &PrepareExecutionOptions{WakeMode: "disabled", AuditReason: "hermetic exact-root proof"}
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{
+		{Handle: "claude", Argv: []string{provider}, EnvOverlay: map[string]string{"PROOF_AMQ": amqBinary}, Cwd: mainCwd, AdapterMode: AdapterModeCapture, ResumePolicy: ResumeFresh, LaunchNonce: nonce, Execution: clonePrepareExecutionOptions(options)},
+		{Handle: "codex", Argv: []string{provider}, EnvOverlay: map[string]string{"PROOF_AMQ": amqBinary}, Cwd: siblingCwd, AdapterMode: AdapterModeCapture, ResumePolicy: ResumeFresh, LaunchNonce: nonce, Execution: clonePrepareExecutionOptions(options)},
+	}}
+	lease, err := AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	for _, agent := range plan.Agents {
+		ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+			Handle: agent.Handle, LaunchNonce: nonce, Mode: agent.AdapterMode, Provider: agent.Handle,
+			ProjectRoot: mainCwd, SessionRoot: sessionRoot, Cwd: agent.Cwd,
+			ProviderExecutable: provider, AMQExecutable: amqBinary,
+			TargetArgv: agent.Argv, TargetEnv: agent.EnvOverlay, Execution: agent.Execution,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := WriteExecutionTicket(root, lease, ticket); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Commands{}.Create(CreateRequest{ProjectRoot: mainCwd, Session: "collab", Plan: plan, AMQPath: amqBinary, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, command := range result.Commands {
+		rootAt := indexOf(command.Argv, "--root")
+		if rootAt < 0 || command.Argv[rootAt+1] != root.Base() {
+			t.Fatalf("command[%d] root = %#v, want %q", i, command.Argv, root.Base())
+		}
+		if slices.Contains(command.Argv, "--session") {
+			t.Fatalf("command[%d] emitted --session: %#v", i, command.Argv)
+		}
+	}
+	for i, command := range result.Commands {
+		cmd := exec.Command(command.Argv[0], command.Argv[1:]...)
+		cmd.Dir = command.Cwd
+		cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + t.TempDir(), "TMPDIR=" + os.TempDir(), "AMQ_NO_UPDATE_CHECK=1"}
+		for key, value := range command.Env {
+			cmd.Env = append(cmd.Env, key+"="+value)
+		}
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("run emitted command[%d]: %v\n%s", i, err, output)
+		}
+		if i == 1 && !strings.Contains(string(output), "exact-root-message") {
+			t.Fatalf("sibling command did not drain the real message:\n%s", output)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(siblingCwd, ".agent-mail")); !os.IsNotExist(err) {
+		t.Fatalf("sibling-local queue exists under %s: %v", siblingCwd, err)
+	}
+}
+
+func runCommandsTestProcess(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v: %v\n%s", name, args, err, output)
 	}
 }
 
@@ -168,14 +375,24 @@ func TestCommandsConformance(t *testing.T) {
 	RunConformance(t, Commands{})
 }
 
-func assertCoopExecGrammar(t *testing.T, argv []string, handle string, planArgv []string) {
+func assertCoopExecGrammar(t *testing.T, argv []string, sessionRoot string, handle string, planArgv []string) {
 	t.Helper()
-	if err := coopExecGrammarError(argv, handle, planArgv); err != nil {
+	if err := coopExecGrammarError(argv, sessionRoot, handle, planArgv); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func coopExecGrammarError(argv []string, handle string, planArgv []string) error {
+func coopExecGrammarError(argv []string, sessionRoot string, handle string, planArgv []string) error {
+	root := indexOf(argv, "--root")
+	if root < 0 || root+1 >= len(argv) {
+		return fmt.Errorf("missing --root in %#v", argv)
+	}
+	if argv[root+1] != sessionRoot {
+		return fmt.Errorf("--root value = %q, want %q", argv[root+1], sessionRoot)
+	}
+	if indexOf(argv, "--session") >= 0 {
+		return fmt.Errorf("exact-root command also emitted --session: %#v", argv)
+	}
 	me := indexOf(argv, "--me")
 	if me < 0 || me+1 >= len(argv) {
 		return fmt.Errorf("missing --me in %#v", argv)
@@ -186,11 +403,13 @@ func coopExecGrammarError(argv []string, handle string, planArgv []string) error
 	if me+2 >= len(argv) {
 		return fmt.Errorf("missing command positional after --me")
 	}
+	command := indexOf(argv[me+2:], planArgv[0])
+	if command < 0 {
+		return fmt.Errorf("missing command positional %q after --me", planArgv[0])
+	}
+	command += me + 2
 	if argv[me+2] == "--" {
 		return fmt.Errorf("old shape: -- immediately after --me (command positional missing): %#v", argv)
-	}
-	if argv[me+2] != planArgv[0] {
-		return fmt.Errorf("command positional = %q, want %q", argv[me+2], planArgv[0])
 	}
 	dash := indexOf(argv, "--")
 	if len(planArgv) == 1 {
@@ -199,7 +418,7 @@ func coopExecGrammarError(argv []string, handle string, planArgv []string) error
 		}
 		return nil
 	}
-	if dash != me+3 {
+	if dash != command+1 {
 		return fmt.Errorf("-- at %d, want immediately after command positional in %#v", dash, argv)
 	}
 	if !slices.Equal(argv[dash+1:], planArgv[1:]) {
@@ -215,4 +434,14 @@ func indexOf(argv []string, want string) int {
 		}
 	}
 	return -1
+}
+
+func countArg(argv []string, want string) int {
+	count := 0
+	for _, arg := range argv {
+		if arg == want {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
@@ -19,6 +20,11 @@ import (
 const ExecutionTicketVersion = 1
 
 const executionDirectory = "meta/launch/executions"
+
+const (
+	executionLeaseRetryInterval = 50 * time.Millisecond
+	executionLeaseWaitTimeout   = 10 * time.Second
+)
 
 type ExecutionState string
 
@@ -51,6 +57,8 @@ type ExecutionTicket struct {
 	ProviderExecutableIdentity string `json:"provider_executable_identity"`
 	AMQExecutable              string `json:"amq_executable"`
 	AMQExecutableIdentity      string `json:"amq_executable_identity"`
+	InjectorExecutable         string `json:"injector_executable,omitempty"`
+	InjectorExecutableIdentity string `json:"injector_executable_identity,omitempty"`
 
 	TargetArgv []string                 `json:"target_argv"`
 	TargetEnv  map[string]string        `json:"target_env,omitempty"`
@@ -76,6 +84,7 @@ type ExecutionTicketRequest struct {
 type ExecutionEnvelope struct {
 	Cwd, AMQExecutable, ProviderExecutable string
 	TargetArgv, Environment                []string
+	Execution                              *PrepareExecutionOptions
 }
 
 func ExecutionTicketPath(sessionRoot, handle string) string {
@@ -117,6 +126,18 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 	if err != nil {
 		return ExecutionTicket{}, fmt.Errorf("amq executable: %w", err)
 	}
+	execution := clonePrepareExecutionOptions(request.Execution)
+	if execution != nil {
+		canonical := CanonicalExecutionOptions(execution)
+		execution = &canonical
+	}
+	var injector, injectorID string
+	if execution != nil && execution.InjectorVia != "" {
+		injector, injectorID, err = canonicalFile(execution.InjectorVia)
+		if err != nil {
+			return ExecutionTicket{}, fmt.Errorf("injector executable: %w", err)
+		}
+	}
 	env := cloneExecutionEnv(request.TargetEnv)
 	digest, err := executionEnvDigest(env)
 	if err != nil {
@@ -129,7 +150,7 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 		Cwd: cwd, CwdIdentity: cwdID, ProviderExecutable: provider, ProviderExecutableIdentity: providerID,
 		AMQExecutable: amq, AMQExecutableIdentity: amqID, TargetArgv: append([]string(nil), request.TargetArgv...),
 		TargetEnv: env, EnvDigest: digest, State: request.State, Reason: request.Reason,
-		Execution: clonePrepareExecutionOptions(request.Execution),
+		Execution: execution, InjectorExecutable: injector, InjectorExecutableIdentity: injectorID,
 	}
 	if ticket.State == "" {
 		ticket.State = ExecutionPending
@@ -163,6 +184,13 @@ func (ticket ExecutionTicket) Validate() error {
 		if strings.TrimSpace(value) == "" {
 			return fmt.Errorf("%s is required", name)
 		}
+	}
+	if ticket.Execution != nil && ticket.Execution.InjectorVia != "" {
+		if ticket.InjectorExecutable == "" || ticket.InjectorExecutableIdentity == "" {
+			return fmt.Errorf("injector executable identity is required")
+		}
+	} else if ticket.InjectorExecutable != "" || ticket.InjectorExecutableIdentity != "" {
+		return fmt.Errorf("injector executable identity exists without injector via")
 	}
 	if len(ticket.TargetArgv) == 0 || strings.TrimSpace(ticket.TargetArgv[0]) == "" {
 		return fmt.Errorf("target argv is required")
@@ -317,7 +345,7 @@ func CompareAndSwapExecutionTicket(root *fsq.DeliveryRoot, lease *Lease, handle 
 // PrepareExecution performs the final envelope check and durable execution
 // acknowledgement under the exact launch nonce and handle lock.
 func PrepareExecution(root *fsq.DeliveryRoot, handle, nonce string, envelope ExecutionEnvelope) (ticket ExecutionTicket, returnErr error) {
-	lease, err := AcquireLease(root, nonce)
+	lease, err := acquireExecutionLease(root, nonce)
 	if err != nil {
 		return ticket, err
 	}
@@ -371,6 +399,29 @@ func PrepareExecution(root *fsq.DeliveryRoot, handle, nonce string, envelope Exe
 		return CompareAndSwapExecutionTicket(root, lease, handle, ExecutionSpawnAttempted, ExecutionAcknowledged, "child_spawn_acknowledged")
 	default:
 		return ticket, fmt.Errorf("execution mode %q cannot acknowledge a provider process", ticket.Mode)
+	}
+}
+
+func acquireExecutionLease(root *fsq.DeliveryRoot, nonce string) (*Lease, error) {
+	deadline := time.Now().Add(executionLeaseWaitTimeout)
+	for {
+		lease, err := AcquireLease(root, nonce)
+		if err == nil {
+			return lease, nil
+		}
+		var held *LeaseHeldError
+		if !errors.As(err, &held) || held.Nonce != nonce {
+			return nil, err
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, fmt.Errorf("wait for own launch lease: %w", err)
+		}
+		delay := executionLeaseRetryInterval
+		if remaining < delay {
+			delay = remaining
+		}
+		time.Sleep(delay)
 	}
 }
 
@@ -445,6 +496,9 @@ func ValidateExecutionEnvelope(root *fsq.DeliveryRoot, ticket ExecutionTicket, e
 	if !reflect.DeepEqual(envelope.TargetArgv, ticket.TargetArgv) {
 		return fmt.Errorf("provider argv changed")
 	}
+	if err := validateExecutionOptions(ticket, envelope.Execution); err != nil {
+		return err
+	}
 	actualEnv := make(map[string]string, len(envelope.Environment))
 	for _, item := range envelope.Environment {
 		if key, value, ok := strings.Cut(item, "="); ok {
@@ -457,6 +511,66 @@ func ValidateExecutionEnvelope(root *fsq.DeliveryRoot, ticket ExecutionTicket, e
 		}
 	}
 	return nil
+}
+
+// ValidateExecutionOptions performs the read-only ticket check required
+// before coop exec can use wake or injector settings. PrepareExecution repeats
+// the same check at the final provider boundary before changing ticket state.
+func ValidateExecutionOptions(root *fsq.DeliveryRoot, handle, nonce string, options *PrepareExecutionOptions) error {
+	if root == nil {
+		return fmt.Errorf("missing pinned session root")
+	}
+	if err := root.VerifyBase(); err != nil {
+		return err
+	}
+	ticket, err := LoadExecutionTicket(root, handle)
+	if err != nil {
+		return err
+	}
+	if ticket.LaunchNonce != nonce {
+		return fmt.Errorf("execution ticket nonce changed")
+	}
+	session, sessionID, err := canonicalDirectory(root.Base())
+	if err != nil || session != ticket.SessionRoot || sessionID != ticket.SessionIdentity {
+		return fmt.Errorf("session root identity changed")
+	}
+	return validateExecutionOptions(ticket, options)
+}
+
+func validateExecutionOptions(ticket ExecutionTicket, options *PrepareExecutionOptions) error {
+	if !reflect.DeepEqual(CanonicalExecutionOptions(options), CanonicalExecutionOptions(ticket.Execution)) {
+		return fmt.Errorf("execution options changed")
+	}
+	if ticket.Execution != nil && ticket.Execution.InjectorVia != "" {
+		injector, injectorID, err := canonicalFile(ticket.Execution.InjectorVia)
+		if err != nil || injector != ticket.InjectorExecutable || injectorID != ticket.InjectorExecutableIdentity {
+			return fmt.Errorf("injector executable identity changed")
+		}
+	}
+	return nil
+}
+
+// CanonicalExecutionOptions returns the normalized policy value used for
+// ticket equality. A missing policy and an explicit all-default policy are
+// equivalent; collection presence is not semantic.
+func CanonicalExecutionOptions(options *PrepareExecutionOptions) PrepareExecutionOptions {
+	var canonical PrepareExecutionOptions
+	if options != nil {
+		canonical = *clonePrepareExecutionOptions(options)
+	}
+	if canonical.WakeMode == "" {
+		canonical.WakeMode = "enabled"
+	}
+	if canonical.InjectorMode == "" {
+		canonical.InjectorMode = "none"
+	}
+	if len(canonical.InjectorArgs) == 0 {
+		canonical.InjectorArgs = nil
+	}
+	if len(canonical.SymphonyEvents) == 0 {
+		canonical.SymphonyEvents = nil
+	}
+	return canonical
 }
 
 func canonicalDirectory(path string) (string, string, error) { return canonicalPath(path, true) }

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -1,11 +1,13 @@
 package launch
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
@@ -22,7 +24,7 @@ func TestExecutionTicketRoundTripAndCAS(t *testing.T) {
 	}
 	execution := &PrepareExecutionOptions{
 		RequireWake: true, NoGitignore: true, WakeMode: "enabled",
-		InjectorMode: "raw", InjectorVia: "/opt/amq/inject", InjectorArgs: []string{"send"},
+		InjectorMode: "raw", InjectorVia: fixture.injector, InjectorArgs: []string{"send"},
 		SymphonyEvents: []string{"after_create", "before_run", "after_run", "before_remove"}, SymphonyWorkspaceKey: "team-17",
 	}
 	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
@@ -148,6 +150,62 @@ func TestPrepareMintPromotesExactPendingAndExecFailureReverts(t *testing.T) {
 	}
 }
 
+func TestPrepareExecutionWaitsForOwnLauncherLease(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "57575757-5757-4757-8757-575757575757"
+	ticket, envelope := seedPendingMintExecution(t, fixture, nonce)
+	blocker, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type result struct {
+		ticket ExecutionTicket
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		prepared, prepareErr := PrepareExecution(fixture.root, "claude", nonce, envelope)
+		done <- result{ticket: prepared, err: prepareErr}
+	}()
+	time.Sleep(200 * time.Millisecond)
+	select {
+	case early := <-done:
+		t.Fatalf("prepare returned before own launcher released its lease: %#v, %v", early.ticket, early.err)
+	default:
+	}
+	if err := blocker.Release(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-done:
+		if got.err != nil || got.ticket.State != ExecutionAcknowledged || got.ticket.LaunchNonce != ticket.LaunchNonce {
+			t.Fatalf("prepare after own lease release = %#v, %v", got.ticket, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("prepare did not acquire the released own-launcher lease")
+	}
+}
+
+func TestPrepareExecutionRefusesDifferentLauncherLeaseImmediately(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "58585858-5858-4858-8858-585858585858"
+	_, envelope := seedPendingMintExecution(t, fixture, nonce)
+	blocker, err := AcquireLease(fixture.root, "59595959-5959-4959-8959-595959595959")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = blocker.Release() }()
+	started := time.Now()
+	_, err = PrepareExecution(fixture.root, "claude", nonce, envelope)
+	var held *LeaseHeldError
+	if !errors.As(err, &held) || held.Nonce == nonce {
+		t.Fatalf("different-launcher lease error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("different-launcher refusal took %s, want immediate", elapsed)
+	}
+}
+
 func TestPrepareExecutionRejectsRetargetedProviderWithoutPromotion(t *testing.T) {
 	fixture := newExecutionFixture(t)
 	nonce := "66666666-6666-4666-8666-666666666666"
@@ -202,6 +260,173 @@ func TestPrepareExecutionRejectsRetargetedProviderWithoutPromotion(t *testing.T)
 	}
 }
 
+func TestPrepareExecutionRejectsRetargetedInjectorWithoutPromotion(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "67676767-6767-4767-8767-676767676767"
+	injectorDir := t.TempDir()
+	first := filepath.Join(injectorDir, "injector-v1")
+	second := filepath.Join(injectorDir, "injector-v2")
+	link := filepath.Join(injectorDir, "injector")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(first, link); err != nil {
+		t.Fatal(err)
+	}
+	execution := &PrepareExecutionOptions{
+		WakeMode: "enabled", InjectorMode: "raw", InjectorVia: link,
+		InjectorArgs: []string{"--fixed", "ordered"},
+	}
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeMint, Provider: ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: []string{fixture.provider}, TargetEnv: map[string]string{"LANG": "C"}, Execution: execution,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{Version: ConversationVersion, Handle: "claude", State: CapturePending, LaunchNonce: nonce}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(second, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateExecutionOptions(fixture.root, "claude", nonce, execution); err == nil || !strings.Contains(err.Error(), "injector executable identity changed") {
+		t.Fatalf("pre-wake retarget error = %v", err)
+	}
+	_, err = PrepareExecution(fixture.root, "claude", nonce, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: fixture.provider,
+		TargetArgv: ticket.TargetArgv, Environment: []string{"LANG=C"}, Execution: execution,
+	})
+	if err == nil || !strings.Contains(err.Error(), "injector executable identity changed") {
+		t.Fatalf("retarget error = %v", err)
+	}
+	record, loadErr := LoadConversation(fixture.root, "claude")
+	if loadErr != nil || record.State != CapturePending {
+		t.Fatalf("conversation mutated = %#v, %v", record, loadErr)
+	}
+}
+
+func TestPrepareExecutionRejectsChangedInjectorArgs(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "68686868-6868-4868-8868-686868686868"
+	execution := &PrepareExecutionOptions{
+		WakeMode: "enabled", InjectorMode: "raw", InjectorVia: fixture.injector,
+		InjectorArgs: []string{"--fixed", "ordered"},
+	}
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeCapture, Provider: CodexProvider,
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: []string{fixture.provider}, TargetEnv: map[string]string{"LANG": "C"}, Execution: execution,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	changed := clonePrepareExecutionOptions(execution)
+	changed.InjectorArgs = []string{"ordered", "--fixed"}
+	if err := ValidateExecutionOptions(fixture.root, "claude", nonce, changed); err == nil || !strings.Contains(err.Error(), "execution options changed") {
+		t.Fatalf("pre-wake reordered args error = %v", err)
+	}
+	_, err = PrepareExecution(fixture.root, "claude", nonce, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: fixture.provider,
+		TargetArgv: ticket.TargetArgv, Environment: []string{"LANG=C"}, Execution: changed,
+	})
+	if err == nil || !strings.Contains(err.Error(), "execution options changed") {
+		t.Fatalf("reordered args error = %v", err)
+	}
+}
+
+func TestValidateExecutionOptionsCanonicalDefaultsAndOmittedNonDefaults(t *testing.T) {
+	tests := []struct {
+		name      string
+		execution *PrepareExecutionOptions
+		wantError bool
+	}{
+		{name: "explicit defaults equal nil", execution: &PrepareExecutionOptions{WakeMode: "enabled"}},
+		{name: "omitted require wake", execution: &PrepareExecutionOptions{WakeMode: "enabled", RequireWake: true}, wantError: true},
+		{name: "omitted no gitignore", execution: &PrepareExecutionOptions{WakeMode: "enabled", NoGitignore: true}, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newExecutionFixture(t)
+			nonce := "69696969-6969-4969-8969-696969696969"
+			lease, err := AcquireLease(fixture.root, nonce)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := lease.LockHandles("claude"); err != nil {
+				t.Fatal(err)
+			}
+			ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+				Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeCapture, Provider: CodexProvider,
+				ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+				ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+				TargetArgv: []string{fixture.provider}, Execution: test.execution,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+				t.Fatal(err)
+			}
+			if err := lease.Release(); err != nil {
+				t.Fatal(err)
+			}
+			err = ValidateExecutionOptions(fixture.root, "claude", nonce, nil)
+			if test.wantError {
+				if err == nil || !strings.Contains(err.Error(), "execution options changed") {
+					t.Fatalf("omitted non-default error = %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("canonical default equality: %v", err)
+			}
+			loaded, err := LoadExecutionTicket(fixture.root, "claude")
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := PrepareExecutionOptions{WakeMode: "enabled", InjectorMode: "none"}
+			if loaded.Execution == nil || !reflect.DeepEqual(*loaded.Execution, want) {
+				t.Fatalf("persisted canonical defaults = %#v, want %#v", loaded.Execution, want)
+			}
+		})
+	}
+}
+
 func TestPrepareCaptureRecordsAttemptWithoutPromotingConversation(t *testing.T) {
 	fixture := newExecutionFixture(t)
 	nonce := "88888888-8888-4888-8888-888888888888"
@@ -244,8 +469,8 @@ func TestPrepareCaptureRecordsAttemptWithoutPromotingConversation(t *testing.T) 
 }
 
 type executionFixture struct {
-	project, session, cwd, provider, amq string
-	root                                 *fsq.DeliveryRoot
+	project, session, cwd, provider, amq, injector string
+	root                                           *fsq.DeliveryRoot
 }
 
 func newExecutionFixture(t *testing.T) executionFixture {
@@ -262,7 +487,8 @@ func newExecutionFixture(t *testing.T) executionFixture {
 	binDir := t.TempDir()
 	provider := filepath.Join(binDir, "provider")
 	amq := filepath.Join(binDir, "amq")
-	for _, path := range []string{provider, amq} {
+	injector := filepath.Join(binDir, "injector")
+	for _, path := range []string{provider, amq, injector} {
 		if err := os.WriteFile(path, []byte("executable"), 0o700); err != nil {
 			t.Fatal(err)
 		}
@@ -276,7 +502,7 @@ func newExecutionFixture(t *testing.T) executionFixture {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = root.Close() })
-	return executionFixture{project: project, session: session, cwd: cwd, provider: provider, amq: amq, root: root}
+	return executionFixture{project: project, session: session, cwd: cwd, provider: provider, amq: amq, injector: injector, root: root}
 }
 
 func mustExecutionTicket(t *testing.T, fixture executionFixture, nonce string) ExecutionTicket {
@@ -292,4 +518,31 @@ func mustExecutionTicket(t *testing.T, fixture executionFixture, nonce string) E
 		t.Fatal(err)
 	}
 	return ticket
+}
+
+func seedPendingMintExecution(t *testing.T, fixture executionFixture, nonce string) (ExecutionTicket, ExecutionEnvelope) {
+	t.Helper()
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket := mustExecutionTicket(t, fixture, nonce)
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CapturePending, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	return ticket, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: fixture.provider,
+		TargetArgv: ticket.TargetArgv, Environment: []string{"LANG=C"},
+	}
 }

--- a/internal/launch/tmux.go
+++ b/internal/launch/tmux.go
@@ -447,7 +447,7 @@ func (b *TmuxBackend) agentCommand(req CreateRequest, agent AgentPlan) string {
 		env = make(map[string]string, 1)
 	}
 	env[InternalLaunchNonceEnv] = agent.LaunchNonce
-	return commandLine(agent.Cwd, env, coopExecArgv(amq, req.Session, agent.Handle, agent.Argv))
+	return commandLine(agent.Cwd, env, coopExecArgv(amq, req.Root.Base(), agent.Handle, agent.Argv, agent.Execution))
 }
 
 func (b *TmuxBackend) args(args ...string) []string {

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -21,10 +21,14 @@ import (
 
 func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, false)
+	injector := filepath.Join(t.TempDir(), "injector")
+	if err := os.WriteFile(injector, []byte("injector"), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	runnable := fixture.request.Intent.Participants[0]
 	runnable.Execution = &ExecutionOptionsV1{
 		RequireWake: true, NoGitignore: true,
-		Wake: WakeOptionsV1{Mode: WakeEnabled, Injector: &InjectorOptionsV1{Mode: InjectorRaw, Via: "/opt/amq/inject", Args: []string{"send"}}},
+		Wake: WakeOptionsV1{Mode: WakeEnabled, Injector: &InjectorOptionsV1{Mode: InjectorRaw, Via: injector, Args: []string{"send"}}},
 		Integrations: IntegrationsV1{Symphony: &SymphonyOptionsV1{
 			Events: []SymphonyEvent{SymphonyAfterCreate, SymphonyBeforeRun, SymphonyAfterRun, SymphonyBeforeRemove}, WorkspaceKey: "team-17",
 		}},
@@ -74,6 +78,7 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 	}
 	defer func() { _ = root.Close() }()
 	wantOptions := toInternalExecutionOptions(*runnable.Execution)
+	wantOptions = internallaunch.CanonicalExecutionOptions(&wantOptions)
 	for _, handle := range []string{"claude", "reviewer"} {
 		ticket, err := internallaunch.LoadExecutionTicket(root, handle)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Emit one pinned absolute `--root` for managed `coop exec` commands and never rediscover the session from cwd or `--session`.
- Carry normalized execution policy through legible wrapper flags, then through a strict private PID-preserving hop.
- Revalidate ticket, root, nonce, options, and injector identity at the wake and provider boundaries.

## Frozen boundary
The frozen semantic digest `ccd0b5a9` is unchanged. Execution options remain outside that digest and retain their existing persistence contract.

## Rulings
- Transport A is one legible flag transport on the emitted `coop exec` command: wake, injector, no-gitignore, and Symphony fields use typed flags.
- Transport B is strict base64url JSON only on the private `__launch-exec` hop. It does not appear in emitted operator commands.
- Ticket and executor options are canonicalized on both sides: nil and explicit defaults compare equal; empty wake mode becomes enabled; empty injector mode becomes none; empty slices become nil. Non-default omissions still refuse.
- The managed precheck guard is read-only. Final `PrepareExecution` owns the lease and handle lock. It waits at most 10 seconds in 50 ms intervals only when the existing lease carries its own launch nonce; a foreign or unverified lease refuses immediately.

## Lease defect and fix
The first gated snapshot took the session lease inside the managed precheck. The tmux backend starts panes before reconciliation releases its launcher lease, so the pane collided with its own nonce and exited action-required with `launch lease already held`.

The fix removes lease acquisition and handle locking from the precheck. `PrepareExecution` now performs the sole authoritative acquisition, with bounded same-nonce retry. Unit tests prove same-nonce release succeeds and a different nonce refuses immediately.

Real-binary tmux verification, with `/opt/homebrew/bin/tmux` present and no skip:

```text
--- PASS: TestTmuxRealBinaryFreshServerRestartResumeLoop (2.13s)
--- PASS: TestTmuxRealBinaryFreshServerRestartResumeLoop (2.05s)
--- PASS: TestTmuxRealBinaryFreshServerRestartResumeLoop (2.02s)
```

The independent gate repeated it three times: 3.16s, 3.22s, and 2.59s.

## Mutant proofs
- Replacing exact-root emission with `--session` fails `TestExactRootAcrossSiblingWorktrees`.
- Skipping option equality fails `TestValidateExecutionOptionsCanonicalDefaultsAndOmittedNonDefaults`.
- Removing canonical wake defaults fails that test and `TestExplicitDefaultExecutionOptionsEmitNoFlags`.
- Removing injector identity validation fails `TestPrepareExecutionRejectsRetargetedInjectorWithoutPromotion`.
- Restoring plain `AcquireLease` without same-nonce wait fails `TestPrepareExecutionWaitsForOwnLauncherLease`.

## Verification
- `make ci`
- `go test ./... -count=1`
- focused `go test -race` across lease wait, exact-root sibling exchange, typed/canonical options, injector mutation, managed CLI, private re-exec, and Apply concurrency
- real-binary tmux restart/resume loop, three consecutive passes
- `go vet ./...`
- `golangci-lint run`

One unrelated keepalive timing test failed once only when the full suite ran concurrently with race and vet. It then passed 10/10 in isolation, and the full suite passed alone. No keepalive files changed.