### PR TITLE
feat(launchapi): public lifecycle API and immutable capture evidence

### DIFF
--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -597,6 +597,27 @@ func (r *DeliveryRoot) WriteFileAtomic(dir, filename string, data []byte, perm o
 	return committedPath, nil
 }
 
+// WriteFileExclusive publishes one immutable root-relative file. It never
+// replaces an existing final name; callers that use content-addressed names
+// must treat os.ErrExist as a collision or an explicit idempotence decision.
+func (r *DeliveryRoot) WriteFileExclusive(dir, filename string, data []byte, perm os.FileMode) (string, error) {
+	if err := r.VerifyBase(); err != nil {
+		return "", err
+	}
+	if err := r.root.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	finalPath := filepath.Join(dir, filename)
+	if err := r.writeAndSync(finalPath, data, perm); err != nil {
+		return "", err
+	}
+	committedPath := r.displayPath(finalPath)
+	if err := r.syncDir(dir); err != nil {
+		return committedPath, &CommittedDurabilityError{FinalPath: committedPath, Err: err}
+	}
+	return committedPath, nil
+}
+
 // ReadFile reads a root-relative file through the pinned capability.
 func (r *DeliveryRoot) ReadFile(name string) ([]byte, error) {
 	if err := r.VerifyBase(); err != nil {

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -49,6 +49,7 @@ type ApplyResult struct {
 	Observations    []PrepareObservation
 	Commands        []EmittedCommand
 	RequiredActions []PrepareRequiredAction
+	Evidence        []EvidenceRef
 }
 
 var afterApplySessionPublishedForTest func()
@@ -234,6 +235,10 @@ func applyUnderAuthority(ctx context.Context, request ApplyRequest, dependencies
 	result.RequiredActions = nil
 	result.Commands = slices.Clone(reconciled.Commands)
 	result.Backend, result.TrustDigest = reconciled.Backend, reconciled.SemanticDigest
+	result.Evidence, err = CollectEvidenceRefs(root, handles)
+	if err != nil {
+		return ApplyResult{}, err
+	}
 	if reconciled.AggregateCode == 0 && reconciled.Outcome != "" {
 		result.Outcome = ApplyOutcomeApplied
 		result.ReasonCode = ""

--- a/internal/launch/capture.go
+++ b/internal/launch/capture.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
 type CaptureState string
@@ -52,6 +53,8 @@ type CaptureEvidence struct {
 	conversationID  string
 	activeElsewhere bool
 	verified        bool
+	observedAt      time.Time
+	payload         []byte
 }
 
 type CaptureResult struct {
@@ -101,7 +104,7 @@ func ParseCodexThreadStartedEvidence(raw []byte, launchNonce string, activeElsew
 		source: CodexThreadStartedV2, provider: CodexProvider,
 		providerVersion: event.Params.Thread.CLIVersion, launchNonce: launchNonce,
 		conversationID: event.Params.Thread.ID, activeElsewhere: activeElsewhere,
-		verified: true,
+		verified: true, observedAt: time.Now().UTC(), payload: bytes.Clone(raw),
 	}, nil
 }
 

--- a/internal/launch/conversation.go
+++ b/internal/launch/conversation.go
@@ -25,6 +25,7 @@ type ConversationRecord struct {
 	ProviderVersion   string                         `json:"provider_version,omitempty"`
 	LaunchNonce       string                         `json:"launch_nonce"`
 	ExecutionEvidence *ConversationExecutionEvidence `json:"execution_evidence,omitempty"`
+	EvidenceRefs      []string                       `json:"evidence_refs,omitempty"`
 	Reason            CaptureReason                  `json:"reason,omitempty"`
 }
 
@@ -61,6 +62,16 @@ func (record ConversationRecord) Validate() error {
 			return fmt.Errorf("conversation execution evidence launch nonce mismatch")
 		}
 	}
+	seenEvidence := make(map[string]struct{}, len(record.EvidenceRefs))
+	for i, id := range record.EvidenceRefs {
+		if !validDigest(id) {
+			return fmt.Errorf("conversation evidence_refs[%d] is not a canonical digest", i)
+		}
+		if _, exists := seenEvidence[id]; exists {
+			return fmt.Errorf("duplicate conversation evidence ref %q", id)
+		}
+		seenEvidence[id] = struct{}{}
+	}
 	switch record.State {
 	case CapturePending:
 		if record.Identity.Provider != "" || record.Identity.ID != "" {
@@ -68,6 +79,9 @@ func (record ConversationRecord) Validate() error {
 		}
 		if record.ExecutionEvidence != nil {
 			return fmt.Errorf("pending conversation must not contain execution evidence")
+		}
+		if len(record.EvidenceRefs) != 0 {
+			return fmt.Errorf("pending conversation must not contain evidence refs")
 		}
 	case CaptureReady:
 		if strings.TrimSpace(record.Identity.Provider) == "" || !validUUID(record.Identity.ID) {
@@ -97,6 +111,9 @@ func WriteConversation(root *fsq.DeliveryRoot, lease *Lease, record Conversation
 		return fmt.Errorf("conversation handle %q is not locked by the session lease", record.Handle)
 	}
 	if err := record.Validate(); err != nil {
+		return err
+	}
+	if err := validateConversationEvidence(root, record); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(record, "", "  ")
@@ -134,10 +151,36 @@ func LoadConversation(root *fsq.DeliveryRoot, handle string) (ConversationRecord
 	if err := record.Validate(); err != nil {
 		return ConversationRecord{}, err
 	}
+	if err := validateConversationEvidence(root, record); err != nil {
+		return ConversationRecord{}, err
+	}
 	if record.Handle != handle {
 		return ConversationRecord{}, fmt.Errorf("conversation record handle %q does not match %q", record.Handle, handle)
 	}
 	return record, nil
+}
+
+func validateConversationEvidence(root *fsq.DeliveryRoot, record ConversationRecord) error {
+	if len(record.EvidenceRefs) == 0 {
+		return nil // Legacy ready records remain readable until their next capture.
+	}
+	providerCapture := false
+	for _, id := range record.EvidenceRefs {
+		evidence, _, err := ReadEvidence(root, id)
+		if err != nil {
+			return err
+		}
+		if evidence.Handle != record.Handle {
+			return fmt.Errorf("conversation evidence handle mismatch")
+		}
+		if evidence.Kind == EvidenceProviderCapture {
+			providerCapture = true
+		}
+	}
+	if record.Identity.Provider == CodexProvider && !providerCapture {
+		return fmt.Errorf("capture conversation requires provider_capture evidence")
+	}
+	return nil
 }
 
 func ConversationPath(sessionRoot, handle string) string {

--- a/internal/launch/evidence.go
+++ b/internal/launch/evidence.go
@@ -1,0 +1,265 @@
+package launch
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	EvidenceVersion   = 1
+	evidenceDirectory = "meta/launch/evidence"
+)
+
+type EvidenceKind string
+
+const (
+	EvidenceProviderCapture EvidenceKind = "provider_capture"
+	EvidenceRetainedCapture EvidenceKind = "retained_capture"
+	EvidenceFixture         EvidenceKind = "fixture"
+	EvidenceManual          EvidenceKind = "manual"
+)
+
+type EvidenceRecord struct {
+	EvidenceVersion int             `json:"evidence_version"`
+	Kind            EvidenceKind    `json:"kind"`
+	Handle          string          `json:"handle"`
+	ObservedAt      time.Time       `json:"observed_at"`
+	PayloadSHA256   string          `json:"payload_sha256"`
+	Payload         json.RawMessage `json:"payload"`
+}
+
+type EvidenceRef struct {
+	EvidenceVersion int          `json:"evidence_version"`
+	ID              string       `json:"id"`
+	Kind            EvidenceKind `json:"kind"`
+	SHA256          string       `json:"sha256"`
+	ObservedAt      time.Time    `json:"observed_at"`
+}
+
+type EvidenceWriteRequest struct {
+	Kind       EvidenceKind
+	Handle     string
+	ObservedAt time.Time
+	Payload    []byte
+}
+
+type EvidenceCorruptError struct {
+	ID     string
+	Reason string
+}
+
+func (e *EvidenceCorruptError) Error() string {
+	return fmt.Sprintf("evidence_corrupt: %s: %s", e.ID, e.Reason)
+}
+
+type EvidenceExistsError struct{ ID string }
+
+func (e *EvidenceExistsError) Error() string {
+	return fmt.Sprintf("immutable evidence already exists: %s", e.ID)
+}
+
+func WriteEvidence(root *fsq.DeliveryRoot, lease *Lease, request EvidenceWriteRequest) (EvidenceRef, error) {
+	if err := lease.authorizeWrite(root); err != nil {
+		return EvidenceRef{}, err
+	}
+	if !lease.holdsHandle(request.Handle) {
+		return EvidenceRef{}, fmt.Errorf("evidence handle %q is not locked by the session lease", request.Handle)
+	}
+	record, ref, data, err := prepareEvidence(request)
+	if err != nil {
+		return EvidenceRef{}, err
+	}
+	_, err = root.WriteFileExclusive(evidenceDirectory, evidenceFilename(ref.ID), data, 0o600)
+	if errors.Is(err, os.ErrExist) {
+		return EvidenceRef{}, &EvidenceExistsError{ID: ref.ID}
+	}
+	if err != nil {
+		return EvidenceRef{}, err
+	}
+	return evidenceRef(ref.ID, record), nil
+}
+
+func prepareEvidence(request EvidenceWriteRequest) (EvidenceRecord, EvidenceRef, []byte, error) {
+	payload, err := canonicalEvidencePayload(request.Payload)
+	if err != nil {
+		return EvidenceRecord{}, EvidenceRef{}, nil, err
+	}
+	payloadDigest := digestBytes(payload)
+	record := EvidenceRecord{
+		EvidenceVersion: EvidenceVersion, Kind: request.Kind, Handle: request.Handle,
+		ObservedAt: request.ObservedAt.UTC(), PayloadSHA256: payloadDigest, Payload: payload,
+	}
+	if err := record.Validate(); err != nil {
+		return EvidenceRecord{}, EvidenceRef{}, nil, err
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return EvidenceRecord{}, EvidenceRef{}, nil, err
+	}
+	id := digestBytes(data)
+	return record, evidenceRef(id, record), data, nil
+}
+
+func ReadEvidence(root *fsq.DeliveryRoot, id string) (EvidenceRecord, EvidenceRef, error) {
+	record, ref, _, err := readEvidence(root, id)
+	return record, ref, err
+}
+
+func readEvidence(root *fsq.DeliveryRoot, id string) (EvidenceRecord, EvidenceRef, []byte, error) {
+	if !validDigest(id) {
+		return EvidenceRecord{}, EvidenceRef{}, nil, &EvidenceCorruptError{ID: id, Reason: "invalid evidence id"}
+	}
+	file, info, err := root.OpenRegularNoFollow(filepath.Join(evidenceDirectory, evidenceFilename(id)))
+	if err != nil {
+		return EvidenceRecord{}, EvidenceRef{}, nil, &EvidenceCorruptError{ID: id, Reason: err.Error()}
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		return EvidenceRecord{}, EvidenceRef{}, nil, &EvidenceCorruptError{ID: id, Reason: fmt.Sprintf("permissions are %04o, want 0600", info.Mode().Perm())}
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return EvidenceRecord{}, EvidenceRef{}, nil, err
+	}
+	if digestBytes(data) != id {
+		return EvidenceRecord{}, EvidenceRef{}, nil, &EvidenceCorruptError{ID: id, Reason: "record digest mismatch"}
+	}
+	var record EvidenceRecord
+	if err := decodeStrict(data, &record); err != nil {
+		return EvidenceRecord{}, EvidenceRef{}, nil, &EvidenceCorruptError{ID: id, Reason: err.Error()}
+	}
+	if err := record.Validate(); err != nil {
+		return EvidenceRecord{}, EvidenceRef{}, nil, &EvidenceCorruptError{ID: id, Reason: err.Error()}
+	}
+	return record, evidenceRef(id, record), data, nil
+}
+
+func (record EvidenceRecord) Validate() error {
+	if record.EvidenceVersion != EvidenceVersion {
+		return fmt.Errorf("unsupported evidence version %d", record.EvidenceVersion)
+	}
+	if !slices.Contains([]EvidenceKind{EvidenceProviderCapture, EvidenceRetainedCapture, EvidenceFixture, EvidenceManual}, record.Kind) {
+		return fmt.Errorf("invalid evidence kind %q", record.Kind)
+	}
+	if err := fsq.ValidateHandle(record.Handle); err != nil {
+		return fmt.Errorf("invalid evidence handle: %w", err)
+	}
+	if record.ObservedAt.IsZero() || record.ObservedAt.Location() != time.UTC {
+		return fmt.Errorf("observed_at must be a non-zero UTC timestamp")
+	}
+	payload, err := canonicalEvidencePayload(record.Payload)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(payload, record.Payload) {
+		return fmt.Errorf("payload is not canonical JSON")
+	}
+	if record.PayloadSHA256 != digestBytes(payload) {
+		return fmt.Errorf("payload digest mismatch")
+	}
+	return nil
+}
+
+func canonicalEvidencePayload(raw []byte) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("decode evidence payload: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("decode evidence payload: trailing JSON value")
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode canonical evidence payload: %w", err)
+	}
+	return data, nil
+}
+
+func evidenceRef(id string, record EvidenceRecord) EvidenceRef {
+	return EvidenceRef{EvidenceVersion: EvidenceVersion, ID: id, Kind: record.Kind, SHA256: id, ObservedAt: record.ObservedAt}
+}
+
+func evidenceFilename(id string) string { return strings.TrimPrefix(id, "sha256:") + ".json" }
+
+func digestBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func EvidencePath(sessionRoot, id string) string {
+	return filepath.Join(sessionRoot, evidenceDirectory, evidenceFilename(id))
+}
+
+func persistProviderCaptureEvidence(root *fsq.DeliveryRoot, lease *Lease, handle string, evidence []CaptureEvidence) ([]string, error) {
+	refs := make([]string, 0, len(evidence))
+	for _, item := range evidence {
+		if !item.verified || item.source != CodexThreadStartedV2 || len(item.payload) == 0 {
+			return nil, fmt.Errorf("provider capture evidence is not persistable")
+		}
+		request := EvidenceWriteRequest{
+			Kind: EvidenceProviderCapture, Handle: handle, ObservedAt: item.observedAt, Payload: item.payload,
+		}
+		ref, err := WriteEvidence(root, lease, request)
+		var exists *EvidenceExistsError
+		if errors.As(err, &exists) {
+			_, expectedRef, expectedData, prepareErr := prepareEvidence(request)
+			if prepareErr != nil {
+				return nil, prepareErr
+			}
+			record, existingRef, existingData, readErr := readEvidence(root, exists.ID)
+			if readErr != nil {
+				return nil, readErr
+			}
+			if existingRef.ID != expectedRef.ID || !bytes.Equal(existingData, expectedData) || record.Handle != handle || record.Kind != EvidenceProviderCapture {
+				return nil, &EvidenceCorruptError{ID: exists.ID, Reason: "existing record does not match provider capture"}
+			}
+			ref, err = existingRef, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		refs = append(refs, ref.ID)
+	}
+	return refs, nil
+}
+
+func CollectEvidenceRefs(root *fsq.DeliveryRoot, handles []string) ([]EvidenceRef, error) {
+	seen := make(map[string]struct{})
+	refs := make([]EvidenceRef, 0)
+	for _, handle := range handles {
+		record, err := LoadConversation(root, handle)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range record.EvidenceRefs {
+			if _, exists := seen[id]; exists {
+				continue
+			}
+			_, ref, err := ReadEvidence(root, id)
+			if err != nil {
+				return nil, err
+			}
+			seen[id] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+	slices.SortFunc(refs, func(a, b EvidenceRef) int { return strings.Compare(a.ID, b.ID) })
+	return refs, nil
+}

--- a/internal/launch/evidence_test.go
+++ b/internal/launch/evidence_test.go
@@ -1,0 +1,188 @@
+package launch
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestImmutableCaptureEvidenceReadback(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "70707070-7070-4070-8070-707070707070"
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	observed := time.Date(2026, 8, 17, 1, 2, 3, 0, time.UTC)
+	request := EvidenceWriteRequest{
+		Kind: EvidenceProviderCapture, Handle: "claude", ObservedAt: observed,
+		Payload: []byte(`{ "params": {"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001"}}, "method":"thread/started" }`),
+	}
+	providerRef, err := WriteEvidence(fixture.root, lease, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEvidence(fixture.root, lease, request); err == nil {
+		t.Fatal("same content-addressed evidence overwrote its existing record")
+	} else {
+		var exists *EvidenceExistsError
+		if !errors.As(err, &exists) || exists.ID != providerRef.ID {
+			t.Fatalf("duplicate evidence error = %v", err)
+		}
+	}
+	manualRef, err := WriteEvidence(fixture.root, lease, EvidenceWriteRequest{
+		Kind: EvidenceManual, Handle: "claude", ObservedAt: observed.Add(time.Second), Payload: []byte(`{"claimed":"provider"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manualConversation := ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity: ConversationIdentity{Provider: CodexProvider, ID: "019c8a2f-2b13-7000-8000-000000000001"}, LaunchNonce: nonce,
+		ExecutionEvidence: &ConversationExecutionEvidence{
+			Backend: LauncherTMux, Profile: TmuxProfile().Identity(), Outcome: OutcomeCreated,
+			LaunchNonce: nonce, ConversationID: "019c8a2f-2b13-7000-8000-000000000001",
+		},
+		EvidenceRefs: []string{manualRef.ID},
+	}
+	if err := WriteConversation(fixture.root, lease, manualConversation); err == nil || !strings.Contains(err.Error(), "requires provider_capture") {
+		t.Fatalf("manual evidence inflated continuity: %v", err)
+	}
+	manualPath := EvidencePath(fixture.session, manualRef.ID)
+	manualData, err := os.ReadFile(manualPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		old  []byte
+		new  []byte
+	}{
+		{name: "kind inflation", old: []byte(`"kind":"manual"`), new: []byte(`"kind":"provider_capture"`)},
+		{name: "handle substitution", old: []byte(`"handle":"claude"`), new: []byte(`"handle":"peerxx"`)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mutated := bytes.Replace(manualData, test.old, test.new, 1)
+			if bytes.Equal(mutated, manualData) {
+				t.Fatal("tamper target was not found")
+			}
+			if err := os.WriteFile(manualPath, mutated, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := os.WriteFile(manualPath, manualData, 0o600); err != nil {
+					t.Errorf("restore evidence: %v", err)
+				}
+			})
+			_, _, readErr := ReadEvidence(fixture.root, manualRef.ID)
+			var corrupt *EvidenceCorruptError
+			if !errors.As(readErr, &corrupt) {
+				t.Fatalf("non-payload tamper read error = %v", readErr)
+			}
+			if err := WriteConversation(fixture.root, lease, manualConversation); !errors.As(err, &corrupt) {
+				t.Fatalf("non-payload tamper gated continuity: %v", err)
+			}
+		})
+	}
+	manualConversation.EvidenceRefs = []string{providerRef.ID, manualRef.ID}
+	if err := WriteConversation(fixture.root, lease, manualConversation); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := fsq.SnapshotDeliveryRoot(fixture.session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := fsq.OpenDeliveryRoot(fixture.session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = restarted.Close() }()
+	record, gotRef, err := ReadEvidence(restarted, providerRef.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotRef, providerRef) || record.Kind != EvidenceProviderCapture || record.PayloadSHA256 == "" {
+		t.Fatalf("restart evidence = %#v %#v", record, gotRef)
+	}
+	conversation, err := LoadConversation(restarted, "claude")
+	if err != nil || !reflect.DeepEqual(conversation.EvidenceRefs, []string{providerRef.ID, manualRef.ID}) {
+		t.Fatalf("restart conversation evidence = %#v, %v", conversation.EvidenceRefs, err)
+	}
+
+	path := EvidencePath(fixture.session, providerRef.ID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[len(data)-1] ^= 1
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = ReadEvidence(restarted, providerRef.ID)
+	var corrupt *EvidenceCorruptError
+	if !errors.As(err, &corrupt) {
+		t.Fatalf("tampered evidence error = %v", err)
+	}
+	if _, err := LoadConversation(restarted, "claude"); !errors.As(err, &corrupt) {
+		t.Fatalf("tampered continuity readback error = %v", err)
+	}
+}
+
+func TestEvidenceExclusivePublicationRace(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	lease, err := AcquireLease(fixture.root, "71717171-7171-4171-8171-717171717171")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	request := EvidenceWriteRequest{
+		Kind: EvidenceFixture, Handle: "claude", ObservedAt: time.Date(2026, 8, 17, 2, 3, 4, 0, time.UTC),
+		Payload: []byte(`{"fixture":true}`),
+	}
+	const writers = 12
+	results := make(chan error, writers)
+	var group sync.WaitGroup
+	for range writers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, err := WriteEvidence(fixture.root, lease, request)
+			results <- err
+		}()
+	}
+	group.Wait()
+	close(results)
+	wins, collisions := 0, 0
+	for err := range results {
+		if err == nil {
+			wins++
+			continue
+		}
+		var exists *EvidenceExistsError
+		if errors.As(err, &exists) {
+			collisions++
+			continue
+		}
+		t.Fatalf("exclusive evidence race error = %v", err)
+	}
+	if wins != 1 || collisions != writers-1 {
+		t.Fatalf("exclusive evidence race wins=%d collisions=%d", wins, collisions)
+	}
+}

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -450,7 +450,7 @@ func RevertExecution(root *fsq.DeliveryRoot, handle, nonce string) (returnErr er
 			return loadErr
 		}
 		if record.State == CaptureReady && record.LaunchNonce == nonce && record.ExecutionEvidence != nil && record.ExecutionEvidence.LaunchNonce == nonce {
-			record.State, record.Identity, record.ExecutionEvidence = CapturePending, ConversationIdentity{}, nil
+			record.State, record.Identity, record.ExecutionEvidence, record.EvidenceRefs = CapturePending, ConversationIdentity{}, nil, nil
 			record.Reason = CaptureReason("spawn_failed")
 			if err := WriteConversation(root, lease, record); err != nil {
 				return err

--- a/internal/launch/lifecycle.go
+++ b/internal/launch/lifecycle.go
@@ -1,0 +1,274 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"os"
+	"reflect"
+	"slices"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const LifecycleOutcomeInspected = "inspected"
+
+type LifecycleRequest struct{ Target PrepareTarget }
+
+type LifecycleDependencies struct{ Backends map[string]Backend }
+
+type LifecycleResult struct {
+	Outcome      string
+	ReasonCode   string
+	Backend      string
+	Profile      string
+	State        string
+	Observations []PrepareObservation
+	Evidence     []EvidenceRef
+}
+
+var beforeLifecycleBackendMutationForTest func()
+
+func InspectLifecycle(ctx context.Context, request LifecycleRequest, dependencies LifecycleDependencies) (LifecycleResult, error) {
+	state, err := openLifecycleTarget(ctx, request.Target)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	defer state.close()
+	if state.sessionRoot == nil {
+		return LifecycleResult{Outcome: LifecycleOutcomeInspected, State: string(InspectAbsent)}, nil
+	}
+	binding, err := LoadBinding(state.sessionRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return LifecycleResult{Outcome: LifecycleOutcomeInspected, State: string(InspectAbsent), ReasonCode: "binding_missing"}, nil
+	}
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	backend, detect, refusal, err := validateLifecycleBinding(binding, dependencies, CapInspect)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	if refusal != "" {
+		return lifecycleRefusal(binding, detect, refusal), nil
+	}
+	inspection, err := backend.Inspect(InspectRequest{Binding: binding, Root: state.sessionRoot})
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	result, err := lifecycleResultFromBinding(state.sessionRoot, binding)
+	if err != nil {
+		var corrupt *EvidenceCorruptError
+		if errors.As(err, &corrupt) {
+			return lifecycleRefusal(binding, detect, "evidence_corrupt"), nil
+		}
+		return LifecycleResult{}, err
+	}
+	result.Outcome, result.State = LifecycleOutcomeInspected, string(inspection.Status)
+	if inspection.Status == InspectUnknown || inspection.ActionRequired {
+		result.Outcome, result.ReasonCode = string(OutcomeActionRequired), "inspect_unknown"
+	}
+	return result, nil
+}
+
+func FocusLifecycle(ctx context.Context, request LifecycleRequest, dependencies LifecycleDependencies) (LifecycleResult, error) {
+	return mutateLifecycle(ctx, request, dependencies, CapFocus, func(backend Backend, binding BindingRecord, root *fsq.DeliveryRoot) (Outcome, string, error) {
+		focuser, ok := backend.(BackendFocuser)
+		if !ok {
+			return OutcomeUnsupported, "focus_not_supported", nil
+		}
+		result, err := focuser.Focus(FocusRequest{Binding: binding, Root: root})
+		return result.Outcome, result.Reason, err
+	})
+}
+
+func CloseLifecycle(ctx context.Context, request LifecycleRequest, dependencies LifecycleDependencies) (LifecycleResult, error) {
+	return mutateLifecycle(ctx, request, dependencies, CapClose, func(backend Backend, binding BindingRecord, root *fsq.DeliveryRoot) (Outcome, string, error) {
+		result, err := backend.Close(CloseRequest{Binding: binding, Root: root})
+		return result.Outcome, result.Reason, err
+	})
+}
+
+func mutateLifecycle(ctx context.Context, request LifecycleRequest, dependencies LifecycleDependencies, capability Capability, operation func(Backend, BindingRecord, *fsq.DeliveryRoot) (Outcome, string, error)) (result LifecycleResult, returnErr error) {
+	state, err := openLifecycleTarget(ctx, request.Target)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	defer state.close()
+	if state.sessionRoot == nil {
+		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectAbsent), ReasonCode: "binding_missing"}, nil
+	}
+	lease, err := AcquireLease(state.sessionRoot, "")
+	if err != nil {
+		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "launch_lease_unavailable"}, nil
+	}
+	defer func() { returnErr = errors.Join(returnErr, lease.Release()) }()
+	binding, err := LoadBinding(state.sessionRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectAbsent), ReasonCode: "binding_missing"}, nil
+	}
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	backend, detect, refusal, err := validateLifecycleBinding(binding, dependencies, capability)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	if refusal != "" {
+		return lifecycleRefusal(binding, detect, refusal), nil
+	}
+	inspection, err := backend.Inspect(InspectRequest{Binding: binding, Root: state.sessionRoot})
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	if inspection.Status != InspectPresent && (capability != CapClose || inspection.Status != InspectAbsent) {
+		refusal := "inspect_unknown"
+		if inspection.Status == InspectAbsent {
+			refusal = "resource_absent"
+		}
+		return lifecycleRefusal(binding, detect, refusal), nil
+	}
+	if beforeLifecycleBackendMutationForTest != nil {
+		beforeLifecycleBackendMutationForTest()
+	}
+	if err := state.verify(); err != nil {
+		return lifecycleRefusal(binding, detect, "root_changed"), nil
+	}
+	current, err := LoadBinding(state.sessionRoot)
+	if err != nil || !reflect.DeepEqual(current, binding) {
+		return lifecycleRefusal(binding, detect, "binding_changed"), nil
+	}
+	currentBackend, currentDetect, refusal, err := validateLifecycleBinding(current, dependencies, capability)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	if refusal != "" || currentBackend != backend || !reflect.DeepEqual(currentDetect, detect) {
+		if refusal == "" {
+			refusal = "backend_changed"
+		}
+		return lifecycleRefusal(current, currentDetect, refusal), nil
+	}
+	result, err = lifecycleResultFromBinding(state.sessionRoot, current)
+	if err != nil {
+		var corrupt *EvidenceCorruptError
+		if errors.As(err, &corrupt) {
+			return lifecycleRefusal(current, currentDetect, "evidence_corrupt"), nil
+		}
+		return LifecycleResult{}, err
+	}
+	outcome, _, err := operation(backend, current, state.sessionRoot)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	if outcome == OutcomeActionRequired || outcome == OutcomeUnsupported {
+		return lifecycleRefusal(current, currentDetect, "backend_refused"), nil
+	}
+	postMutation, err := backend.Inspect(InspectRequest{Binding: current, Root: state.sessionRoot})
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	result.Outcome = string(outcome)
+	result.State = string(postMutation.Status)
+	expectedState := InspectPresent
+	if capability == CapClose {
+		expectedState = InspectAbsent
+	}
+	if postMutation.Status != expectedState || postMutation.ActionRequired {
+		result.Outcome, result.ReasonCode = string(OutcomeActionRequired), "post_mutation_state_unexpected"
+	}
+	return result, nil
+}
+
+func openLifecycleTarget(ctx context.Context, target PrepareTarget) (*prepareTargetState, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return openPrepareTarget(target)
+}
+
+func validateLifecycleBinding(binding BindingRecord, dependencies LifecycleDependencies, capability Capability) (Backend, DetectResult, string, error) {
+	backend := dependencies.Backends[binding.Backend]
+	if backend == nil {
+		return nil, DetectResult{}, "backend_unknown", nil
+	}
+	detect := backend.Detect()
+	if err := detect.Validate(); err != nil {
+		return nil, detect, "backend_profile_invalid", nil
+	}
+	if binding.Backend != detect.Profile.Backend {
+		return backend, detect, "backend_mismatch", nil
+	}
+	if binding.Profile != detect.Profile.Identity() {
+		return backend, detect, "profile_mismatch", nil
+	}
+	if binding.HostIdentity != detect.HostIdentity || binding.InstanceIdentity != detect.InstanceIdentity {
+		return backend, detect, "foreign_binding", nil
+	}
+	if !detect.Available || !slices.Contains(detect.Effective, capability) {
+		return backend, detect, "capability_unavailable", nil
+	}
+	return backend, detect, "", nil
+}
+
+func lifecycleRefusal(binding BindingRecord, detect DetectResult, reason string) LifecycleResult {
+	profile := binding.Profile
+	if detect.Profile.Backend != "" {
+		profile = detect.Profile.Identity()
+	}
+	return LifecycleResult{Outcome: string(OutcomeActionRequired), ReasonCode: reason, Backend: binding.Backend, Profile: profile, State: string(InspectUnknown)}
+}
+
+func lifecycleResultFromBinding(root *fsq.DeliveryRoot, binding BindingRecord) (LifecycleResult, error) {
+	resources := make(map[string]string)
+	for _, resource := range binding.Resources.Resources {
+		if resource.Agent != "" {
+			resources[resource.Agent] = resource.OpaqueID
+		}
+	}
+	handles := make([]string, 0, len(resources))
+	for handle := range resources {
+		handles = append(handles, handle)
+	}
+	slices.Sort(handles)
+	participants := make([]PrepareParticipant, 0, len(handles))
+	for _, handle := range handles {
+		participants = append(participants, PrepareParticipant{Handle: handle})
+	}
+	_, mailboxes, err := inspectPrepareRoster(root, nil, participants)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	observations := make([]PrepareObservation, 0, len(handles))
+	for _, handle := range handles {
+		observation := PrepareObservation{
+			Handle: handle, Mailbox: mailboxes[handle], Conversation: "none", Execution: "none", Resource: resources[handle],
+			ConversationIdentityDigest: "absent", ExecutionIdentityDigest: "absent",
+		}
+		if conversation, err := LoadConversation(root, handle); err == nil {
+			observation.Conversation = string(conversation.State)
+			observation.ConversationIdentityDigest, err = digestCanonical(conversation)
+			if err != nil {
+				return LifecycleResult{}, err
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return LifecycleResult{}, err
+		}
+		if ticket, err := LoadExecutionTicket(root, handle); err == nil {
+			observation.Execution = string(ticket.State)
+			observation.ExecutionIdentityDigest, err = digestCanonical(ticket)
+			if err != nil {
+				return LifecycleResult{}, err
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return LifecycleResult{}, err
+		}
+		observations = append(observations, observation)
+	}
+	evidence, err := CollectEvidenceRefs(root, handles)
+	if err != nil {
+		return LifecycleResult{}, err
+	}
+	return LifecycleResult{Backend: binding.Backend, Profile: binding.Profile, Observations: observations, Evidence: evidence}, nil
+}

--- a/internal/launch/lifecycle_test.go
+++ b/internal/launch/lifecycle_test.go
@@ -1,0 +1,215 @@
+package launch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestPublicLifecycleManagedObservations(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	project := t.TempDir()
+	sessionPath := filepath.Join(project, ".agent-mail", "collab")
+	if err := fsq.EnsureRootDirs(sessionPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionPath, "meta", "config.json"), []byte(`{"version":1,"agents":["claude"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(sessionPath, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(sessionPath, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+
+	tmux := NewTmuxBackend("tmux")
+	tmux.socketName = fmt.Sprintf("amq-lifecycle-%d-%d", os.Getpid(), time.Now().UnixNano())
+	tmux.focus = func(context.Context, string) error { return nil }
+	t.Cleanup(func() { stopTmuxTestServer(t, tmux) })
+	backend := &lifecycleCountingBackend{TmuxBackend: tmux}
+	fakeAMQ := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nexec /bin/sleep 60\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	nonce := "72727272-7272-4272-8272-727272727272"
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{{
+		Handle: "claude", Argv: []string{"/bin/sleep", "60"}, Cwd: project,
+		AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce,
+		ConversationID: "73737373-7373-4373-8373-737373737373",
+	}}}
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeLifecycleBinding(t, root, created.Binding)
+	target := PrepareTarget{ProjectRoot: project, SessionRoot: sessionPath, Session: "collab"}
+	deps := LifecycleDependencies{Backends: map[string]Backend{LauncherTMux: backend}}
+
+	before := prepareTreeSnapshot(t, sessionPath)
+	inspected, err := InspectLifecycle(context.Background(), LifecycleRequest{Target: target}, deps)
+	if err != nil || inspected.Outcome != LifecycleOutcomeInspected || inspected.State != string(InspectPresent) || len(inspected.Observations) != 1 || inspected.Observations[0].Resource == "" {
+		t.Fatalf("Inspect = %#v, %v", inspected, err)
+	}
+	if after := prepareTreeSnapshot(t, sessionPath); after != before {
+		t.Fatal("Inspect changed the session tree")
+	}
+
+	backend.unknown = true
+	mutations := backend.mutations
+	before = prepareTreeSnapshot(t, sessionPath)
+	unknown, err := FocusLifecycle(context.Background(), LifecycleRequest{Target: target}, deps)
+	if err != nil || unknown.ReasonCode != "inspect_unknown" || backend.mutations != mutations {
+		t.Fatalf("unknown Focus = %#v, %v mutations=%d", unknown, err, backend.mutations)
+	}
+	if after := prepareTreeSnapshot(t, sessionPath); after != before {
+		t.Fatal("unknown Focus changed the session tree")
+	}
+	backend.unknown = false
+
+	foreign := created.Binding
+	foreign.HostIdentity = "foreign-host"
+	writeLifecycleBinding(t, root, foreign)
+	before = prepareTreeSnapshot(t, sessionPath)
+	refused, err := CloseLifecycle(context.Background(), LifecycleRequest{Target: target}, deps)
+	if err != nil || refused.ReasonCode != "foreign_binding" || backend.mutations != mutations {
+		t.Fatalf("foreign Close = %#v, %v mutations=%d", refused, err, backend.mutations)
+	}
+	if after := prepareTreeSnapshot(t, sessionPath); after != before {
+		t.Fatal("foreign Close changed the session tree")
+	}
+	writeLifecycleBinding(t, root, created.Binding)
+
+	profileMismatch := created.Binding
+	profileMismatch.Profile = "tmux/test/v999"
+	writeLifecycleBinding(t, root, profileMismatch)
+	before = prepareTreeSnapshot(t, sessionPath)
+	refused, err = FocusLifecycle(context.Background(), LifecycleRequest{Target: target}, deps)
+	if err != nil || refused.ReasonCode != "profile_mismatch" || backend.mutations != mutations {
+		t.Fatalf("profile Focus = %#v, %v mutations=%d", refused, err, backend.mutations)
+	}
+	if after := prepareTreeSnapshot(t, sessionPath); after != before {
+		t.Fatal("profile-mismatch Focus changed the session tree")
+	}
+	writeLifecycleBinding(t, root, created.Binding)
+
+	changed := created.Binding
+	changed.LaunchNonce = "74747474-7474-4474-8474-747474747474"
+	t.Cleanup(func() { beforeLifecycleBackendMutationForTest = nil })
+	beforeLifecycleBackendMutationForTest = func() { writeLifecycleBindingRaw(t, sessionPath, changed) }
+	refused, err = FocusLifecycle(context.Background(), LifecycleRequest{Target: target}, deps)
+	beforeLifecycleBackendMutationForTest = nil
+	if err != nil || refused.ReasonCode != "binding_changed" || backend.mutations != mutations {
+		t.Fatalf("changed binding Focus = %#v, %v mutations=%d", refused, err, backend.mutations)
+	}
+	writeLifecycleBinding(t, root, created.Binding)
+
+	focused, err := FocusLifecycle(context.Background(), LifecycleRequest{Target: target}, deps)
+	if err != nil || focused.Outcome != string(OutcomeAttached) || backend.mutations != mutations+1 {
+		t.Fatalf("Focus = %#v, %v mutations=%d", focused, err, backend.mutations)
+	}
+	backend.closeLeavesResource = true
+	unexpected, err := CloseLifecycle(context.Background(), LifecycleRequest{Target: target}, deps)
+	if err != nil || unexpected.Outcome != string(OutcomeActionRequired) || unexpected.ReasonCode != "post_mutation_state_unexpected" || unexpected.State != string(InspectPresent) || backend.mutations != mutations+2 {
+		t.Fatalf("Close with resource retained = %#v, %v mutations=%d", unexpected, err, backend.mutations)
+	}
+	backend.closeLeavesResource = false
+	closed, err := CloseLifecycle(context.Background(), LifecycleRequest{Target: target}, deps)
+	if err != nil || closed.Outcome != string(OutcomeClosed) || closed.State != string(InspectAbsent) || backend.mutations != mutations+3 {
+		t.Fatalf("Close = %#v, %v mutations=%d", closed, err, backend.mutations)
+	}
+	if _, err := LoadBinding(root); err != nil {
+		t.Fatalf("Close removed durable binding: %v", err)
+	}
+}
+
+func TestInspectMissingBindingCreatesNothing(t *testing.T) {
+	project := t.TempDir()
+	sessionPath := filepath.Join(project, ".agent-mail", "collab")
+	if err := fsq.EnsureRootDirs(sessionPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionPath, "meta", "config.json"), []byte(`{"version":1,"agents":["operator"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := prepareTreeSnapshot(t, sessionPath)
+	result, err := InspectLifecycle(context.Background(), LifecycleRequest{Target: PrepareTarget{
+		ProjectRoot: project, SessionRoot: sessionPath, Session: "collab",
+	}}, LifecycleDependencies{})
+	if err != nil || result.Outcome != LifecycleOutcomeInspected || result.State != string(InspectAbsent) || result.ReasonCode != "binding_missing" {
+		t.Fatalf("missing binding Inspect = %#v, %v", result, err)
+	}
+	if after := prepareTreeSnapshot(t, sessionPath); after != before {
+		t.Fatal("missing-binding Inspect changed the session tree")
+	}
+	if _, err := os.Stat(filepath.Join(sessionPath, "meta", "launch")); !os.IsNotExist(err) {
+		t.Fatalf("Inspect created meta/launch: %v", err)
+	}
+}
+
+type lifecycleCountingBackend struct {
+	*TmuxBackend
+	unknown             bool
+	closeLeavesResource bool
+	mutations           int
+}
+
+func (backend *lifecycleCountingBackend) Inspect(request InspectRequest) (InspectResult, error) {
+	if backend.unknown {
+		return InspectResult{Status: InspectUnknown, Evidence: "injected unknown", ActionRequired: true}, nil
+	}
+	return backend.TmuxBackend.Inspect(request)
+}
+
+func (backend *lifecycleCountingBackend) Focus(request FocusRequest) (FocusResult, error) {
+	backend.mutations++
+	return backend.TmuxBackend.Focus(request)
+}
+
+func (backend *lifecycleCountingBackend) Close(request CloseRequest) (CloseResult, error) {
+	backend.mutations++
+	if backend.closeLeavesResource {
+		return CloseResult{Outcome: OutcomeClosed}, nil
+	}
+	return backend.TmuxBackend.Close(request)
+}
+
+func writeLifecycleBinding(t *testing.T, root *fsq.DeliveryRoot, binding BindingRecord) {
+	t.Helper()
+	lease, err := AcquireLease(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBinding(root, lease, binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeLifecycleBindingRaw(t *testing.T, sessionRoot string, binding BindingRecord) {
+	t.Helper()
+	data, err := json.MarshalIndent(binding, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(BindingPath(sessionRoot), append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -355,8 +355,11 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		if journalActive && journal.Phase == JournalCreated {
 			candidate = journal.Binding
 		} else {
-			candidate, err = finalizeCreatedState(create, backendName, detect, nonce, planned, &result)
+			candidate, err = finalizeCreatedState(request.Root, lease, create, backendName, detect, nonce, planned, &result)
 			if err != nil {
+				return result, err
+			}
+			if err := callCrashHook(request.CrashHook, "evidence_written"); err != nil {
 				return result, err
 			}
 		}
@@ -566,7 +569,7 @@ func revalidateAdoption(request ReconcileRequest, backend Backend, journal Launc
 	return nil
 }
 
-func finalizeCreatedState(create CreateResult, backendName string, detect DetectResult, nonce string, planned []plannedAgent, result *ReconcileResult) (*BindingRecord, error) {
+func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateResult, backendName string, detect DetectResult, nonce string, planned []plannedAgent, result *ReconcileResult) (*BindingRecord, error) {
 	created := create.Binding
 	if created.Backend != backendName || created.Profile != detect.Profile.Identity() || created.LaunchNonce != nonce ||
 		created.HostIdentity != detect.HostIdentity || created.InstanceIdentity != detect.InstanceIdentity {
@@ -589,11 +592,19 @@ func finalizeCreatedState(create CreateResult, backendName string, detect Detect
 			agent.record.Identity = ConversationIdentity{Provider: agent.adapter.Name(), ID: agent.plan.ConversationID}
 		}
 		if agent.plan.AdapterMode == AdapterModeCapture && agent.write {
+			captureEvidence := create.CaptureEvidence[agent.plan.Handle]
 			capture := agent.adapter.CaptureIdentity(CaptureRequest{
 				LaunchNonce: agent.plan.LaunchNonce, ExpectedProviderVersion: agent.providerVersion,
-				Final: true, Evidence: create.CaptureEvidence[agent.plan.Handle],
+				Final: true, Evidence: captureEvidence,
 			})
 			agent.record.State, agent.record.Identity, agent.record.Reason = capture.State, capture.Identity, capture.Reason
+			if capture.CanPersist() {
+				refs, evidenceErr := persistProviderCaptureEvidence(root, lease, agent.plan.Handle, captureEvidence)
+				if evidenceErr != nil {
+					return nil, evidenceErr
+				}
+				agent.record.EvidenceRefs = refs
+			}
 			if !capture.CanPersist() {
 				result.Agents[agent.index].Code = 6
 				result.Agents[agent.index].ConversationDisposition = DispositionDegraded

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -199,6 +200,7 @@ type reconcileBackend struct {
 	createGate  chan struct{}
 	createStart chan struct{}
 	capture     bool
+	captured    *CaptureEvidence
 	invalidBind bool
 	reclaims    int
 	resourceUp  bool
@@ -247,11 +249,14 @@ func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
 		result.Binding.Resources.Version = 0
 	}
 	if b.capture {
-		evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Plan.Agents[0].LaunchNonce, false)
-		if err != nil {
-			return CreateResult{}, err
+		if b.captured == nil {
+			evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Plan.Agents[0].LaunchNonce, false)
+			if err != nil {
+				return CreateResult{}, err
+			}
+			b.captured = &evidence
 		}
-		result.CaptureEvidence = map[string][]CaptureEvidence{req.Plan.Agents[0].Handle: {evidence}}
+		result.CaptureEvidence = map[string][]CaptureEvidence{req.Plan.Agents[0].Handle: {*b.captured}}
 	}
 	return result, nil
 }
@@ -297,11 +302,14 @@ func (b *reconcileBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
 		result.Resources = slices.Clone(result.Binding.Resources.Resources)
 	}
 	if b.capture {
-		evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Journal.LaunchNonce, false)
-		if err != nil {
-			return ReclaimResult{}, err
+		if b.captured == nil {
+			evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Journal.LaunchNonce, false)
+			if err != nil {
+				return ReclaimResult{}, err
+			}
+			b.captured = &evidence
 		}
-		result.CaptureEvidence = map[string][]CaptureEvidence{req.Journal.Plan.Agents[0].Handle: {evidence}}
+		result.CaptureEvidence = map[string][]CaptureEvidence{req.Journal.Plan.Agents[0].Handle: {*b.captured}}
 	}
 	return result, nil
 }
@@ -990,7 +998,72 @@ func TestReconcileCaptureEvidencePersistsExactIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record.State != CaptureReady || record.Identity.Provider != CodexProvider || record.Identity.ID != "019c8a2f-2b13-7000-8000-000000000001" || record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != backend.name {
+	if record.State != CaptureReady || record.Identity.Provider != CodexProvider || record.Identity.ID != "019c8a2f-2b13-7000-8000-000000000001" || record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != backend.name || len(record.EvidenceRefs) != 1 {
 		t.Fatalf("record=%#v", record)
+	}
+	evidence, ref, err := ReadEvidence(req.Root, record.EvidenceRefs[0])
+	if err != nil || evidence.Kind != EvidenceProviderCapture || ref.ID != record.EvidenceRefs[0] {
+		t.Fatalf("capture evidence = %#v %#v, %v", evidence, ref, err)
+	}
+}
+
+func TestReconcileCaptureEvidencePublicationCrashRecovery(t *testing.T) {
+	for _, corrupt := range []bool{false, true} {
+		name := map[bool]string{false: "verified reuse", true: "corrupt collision"}[corrupt]
+		t.Run(name, func(t *testing.T) {
+			backend := &reconcileBackend{name: "test", inspect: InspectAbsent, capture: true}
+			req := reconcileFixture(t, backend)
+			req.Config.Agents[0].Adapter = CodexProvider
+			req.Config.Agents[0].Command = []string{CodexProvider}
+			req.Adapters = map[string]HarnessAdapter{CodexProvider: reconcileAdapter{name: CodexProvider, mode: AdapterModeCapture, available: true}}
+			crash := errors.New("injected crash after evidence publication")
+			req.CrashHook = func(stage string) error {
+				if stage == "evidence_written" {
+					return crash
+				}
+				return nil
+			}
+			if _, err := Reconcile(req); !errors.Is(err, crash) {
+				t.Fatalf("crash error = %v", err)
+			}
+			journalBefore, err := LoadJournal(req.Root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if backend.captured == nil {
+				t.Fatal("backend did not retain capture evidence")
+			}
+			_, expectedRef, _, err := prepareEvidence(EvidenceWriteRequest{
+				Kind: EvidenceProviderCapture, Handle: "claude", ObservedAt: backend.captured.observedAt, Payload: backend.captured.payload,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if corrupt {
+				if err := os.WriteFile(req.Root.DisplayPath(filepath.Join(evidenceDirectory, evidenceFilename(expectedRef.ID))), []byte(`{"different":true}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			req.CrashHook = nil
+			result, recoveryErr := Reconcile(req)
+			if corrupt {
+				var evidenceErr *EvidenceCorruptError
+				if !errors.As(recoveryErr, &evidenceErr) {
+					t.Fatalf("corrupt collision error = %v", recoveryErr)
+				}
+				journalAfter, err := LoadJournal(req.Root)
+				if err != nil || !reflect.DeepEqual(journalAfter, journalBefore) {
+					t.Fatalf("journal changed after corrupt collision: before=%#v after=%#v err=%v", journalBefore, journalAfter, err)
+				}
+				return
+			}
+			if recoveryErr != nil || result.AggregateCode != 0 || backend.creates != 1 {
+				t.Fatalf("recovery result=%#v creates=%d err=%v", result, backend.creates, recoveryErr)
+			}
+			record, err := LoadConversation(req.Root, "claude")
+			if err != nil || !reflect.DeepEqual(record.EvidenceRefs, []string{expectedRef.ID}) {
+				t.Fatalf("recovered conversation=%#v err=%v", record, err)
+			}
+		})
 	}
 }

--- a/launchapi/apply.go
+++ b/launchapi/apply.go
@@ -43,6 +43,10 @@ func fromInternalApplyResult(result internallaunch.ApplyResult) ApplyResultV1 {
 		Observations: make([]ParticipantObservationV1, 0, len(result.Observations)),
 		Commands:     make([]CommandV1, 0, len(result.Commands)),
 		FollowUps:    make([]RequiredActionV1, 0, len(result.RequiredActions)),
+		Evidence:     make([]EvidenceRefV1, 0, len(result.Evidence)),
+	}
+	for _, evidence := range result.Evidence {
+		public.Evidence = append(public.Evidence, fromInternalEvidenceRef(evidence))
 	}
 	for _, observation := range result.Observations {
 		public.Observations = append(public.Observations, ParticipantObservationV1{

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
@@ -96,6 +97,17 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 		if strings.HasPrefix(entry.Name(), ".amq-session-") {
 			t.Fatalf("Apply leaked staging child %q", entry.Name())
 		}
+	}
+}
+
+func TestApplyResultMapsEvidenceRefs(t *testing.T) {
+	observed := time.Date(2026, 8, 17, 3, 4, 5, 0, time.UTC)
+	result := fromInternalApplyResult(internallaunch.ApplyResult{Evidence: []internallaunch.EvidenceRef{{
+		EvidenceVersion: 1, ID: "sha256:" + strings.Repeat("a", 64), Kind: internallaunch.EvidenceProviderCapture,
+		SHA256: "sha256:" + strings.Repeat("a", 64), ObservedAt: observed,
+	}}})
+	if len(result.Evidence) != 1 || result.Evidence[0].Kind != "provider_capture" || result.Evidence[0].ObservedAt != observed || result.Evidence[0].ID != result.Evidence[0].SHA256 {
+		t.Fatalf("public evidence mapping = %#v", result.Evidence)
 	}
 }
 

--- a/launchapi/external_test.go
+++ b/launchapi/external_test.go
@@ -38,6 +38,10 @@ func TestContract(t *testing.T) {
 	_ = prepare
 	var apply func(context.Context, launchapi.ApplyRequestV1) (launchapi.ApplyResultV1, error) = launchapi.Apply
 	_ = apply
+	var inspect func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) = launchapi.Inspect
+	var focus func(context.Context, launchapi.FocusRequestV1) (launchapi.FocusResultV1, error) = launchapi.Focus
+	var closeLaunch func(context.Context, launchapi.CloseRequestV1) (launchapi.CloseResultV1, error) = launchapi.Close
+	_, _, _ = inspect, focus, closeLaunch
 	var action launchapi.RequiredActionKindV1 = launchapi.RequiredActionTrustConfirmation
 	var choice launchapi.DecisionChoiceV1 = launchapi.DecisionTrustExactSubject
 	if action == "" || choice == "" {

--- a/launchapi/lifecycle.go
+++ b/launchapi/lifecycle.go
@@ -1,0 +1,84 @@
+package launchapi
+
+import (
+	"context"
+
+	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func Inspect(ctx context.Context, request InspectRequestV1) (InspectResultV1, error) {
+	if err := request.validate(); err != nil {
+		return InspectResultV1{}, err
+	}
+	result, err := internallaunch.InspectLifecycle(ctx, lifecycleRequest(request), lifecycleDependencies())
+	if err != nil {
+		return InspectResultV1{}, err
+	}
+	return lifecycleResult(result), nil
+}
+
+func Focus(ctx context.Context, request FocusRequestV1) (FocusResultV1, error) {
+	if err := request.validate(); err != nil {
+		return FocusResultV1{}, err
+	}
+	result, err := internallaunch.FocusLifecycle(ctx, lifecycleRequest(request), lifecycleDependencies())
+	if err != nil {
+		return FocusResultV1{}, err
+	}
+	return lifecycleResult(result), nil
+}
+
+func Close(ctx context.Context, request CloseRequestV1) (CloseResultV1, error) {
+	if err := request.validate(); err != nil {
+		return CloseResultV1{}, err
+	}
+	result, err := internallaunch.CloseLifecycle(ctx, lifecycleRequest(request), lifecycleDependencies())
+	if err != nil {
+		return CloseResultV1{}, err
+	}
+	return lifecycleResult(result), nil
+}
+
+func lifecycleRequest(request InspectRequestV1) internallaunch.LifecycleRequest {
+	return internallaunch.LifecycleRequest{Target: internallaunch.PrepareTarget{
+		ProjectRoot: request.Target.ProjectRoot, SessionRoot: request.Target.SessionRoot, Session: request.Target.Session,
+	}}
+}
+
+func lifecycleDependencies() internallaunch.LifecycleDependencies {
+	return internallaunch.LifecycleDependencies{Backends: lifecycleBackends()}
+}
+
+var lifecycleBackends = func() map[string]internallaunch.Backend {
+	return map[string]internallaunch.Backend{
+		internallaunch.LauncherCommands: internallaunch.Commands{},
+		internallaunch.LauncherTMux:     internallaunch.NewTmuxBackend("tmux"),
+	}
+}
+
+func lifecycleResult(result internallaunch.LifecycleResult) LifecycleResultV1 {
+	public := LifecycleResultV1{
+		ResultVersion: ResultVersionV1, Outcome: result.Outcome, ReasonCode: result.ReasonCode,
+		Backend: result.Backend, Profile: result.Profile, State: result.State,
+		Observations: make([]ParticipantObservationV1, 0, len(result.Observations)),
+		Evidence:     make([]EvidenceRefV1, 0, len(result.Evidence)),
+	}
+	for _, observation := range result.Observations {
+		public.Observations = append(public.Observations, ParticipantObservationV1{
+			Handle: observation.Handle, Mailbox: observation.Mailbox, Runnable: observation.Runnable,
+			Conversation: observation.Conversation, Execution: observation.Execution,
+			Resource: observation.Resource, ReasonCode: observation.ReasonCode,
+		})
+	}
+	for _, evidence := range result.Evidence {
+		public.Evidence = append(public.Evidence, fromInternalEvidenceRef(evidence))
+	}
+	return public
+}
+
+func fromInternalEvidenceRef(evidence internallaunch.EvidenceRef) EvidenceRefV1 {
+	return EvidenceRefV1{
+		EvidenceVersion: evidence.EvidenceVersion, ID: evidence.ID, Kind: string(evidence.Kind),
+		SHA256: evidence.SHA256, ObservedAt: evidence.ObservedAt,
+	}
+}

--- a/launchapi/lifecycle_test.go
+++ b/launchapi/lifecycle_test.go
@@ -1,0 +1,160 @@
+package launchapi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
+	project := t.TempDir()
+	session := filepath.Join(project, ".agent-mail", "collab")
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(session, "meta", "config.json"), []byte(`{"version":1,"agents":["claude"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	backend := &publicLifecycleBackend{}
+	detect := backend.Detect()
+	binding := internallaunch.BindingRecord{
+		Version: internallaunch.BindingVersion, Backend: detect.Profile.Backend,
+		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
+		Profile: detect.Profile.Identity(), LaunchNonce: "75757575-7575-4575-8575-757575757575",
+		Resources: internallaunch.ResourceIdentitySet{Version: internallaunch.ResourceSetVersion, Resources: []internallaunch.ResourceIdentity{
+			{OpaqueID: "session:one"}, {OpaqueID: "window:one", Agent: "claude"},
+		}},
+	}
+	lease, err := internallaunch.AcquireLease(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := internallaunch.WriteBinding(root, lease, binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	previous := lifecycleBackends
+	lifecycleBackends = func() map[string]internallaunch.Backend { return map[string]internallaunch.Backend{"test": backend} }
+	t.Cleanup(func() { lifecycleBackends = previous })
+	request := InspectRequestV1{RequestVersion: RequestVersionV1, Target: TargetV1{ProjectRoot: project, SessionRoot: session, Session: "collab"}}
+
+	before := snapshotTestTree(t, session)
+	inspected, err := Inspect(context.Background(), request)
+	if err != nil || inspected.ResultVersion != ResultVersionV1 || inspected.State != "present" || len(inspected.Observations) != 1 || inspected.Observations[0].Resource != "window:one" {
+		t.Fatalf("Inspect = %#v, %v", inspected, err)
+	}
+	if after := snapshotTestTree(t, session); after != before {
+		t.Fatal("public Inspect mutated the session tree")
+	}
+	focused, err := Focus(context.Background(), FocusRequestV1(request))
+	if err != nil || focused.Outcome != "attached" || backend.focuses != 1 {
+		t.Fatalf("Focus = %#v, %v focuses=%d", focused, err, backend.focuses)
+	}
+	closed, err := Close(context.Background(), CloseRequestV1(request))
+	if err != nil || closed.Outcome != "closed" || backend.closes != 1 {
+		t.Fatalf("Close = %#v, %v closes=%d", closed, err, backend.closes)
+	}
+	if _, err := internallaunch.LoadBinding(root); err != nil {
+		t.Fatalf("public Close removed AMQ binding: %v", err)
+	}
+
+	lease, err = internallaunch.AcquireLease(root, "76767676-7676-4676-8676-767676767676")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := internallaunch.WriteEvidence(root, lease, internallaunch.EvidenceWriteRequest{
+		Kind: internallaunch.EvidenceProviderCapture, Handle: "claude", ObservedAt: time.Now().UTC(),
+		Payload: []byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001"}}}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conversationID := "019c8a2f-2b13-7000-8000-000000000001"
+	if err := internallaunch.WriteConversation(root, lease, internallaunch.ConversationRecord{
+		Version: internallaunch.ConversationVersion, Handle: "claude", State: internallaunch.CaptureReady,
+		Identity:    internallaunch.ConversationIdentity{Provider: internallaunch.CodexProvider, ID: conversationID},
+		LaunchNonce: "76767676-7676-4676-8676-767676767676", EvidenceRefs: []string{evidence.ID},
+		ExecutionEvidence: &internallaunch.ConversationExecutionEvidence{
+			Backend: "test", Profile: detect.Profile.Identity(), Outcome: internallaunch.OutcomeCreated,
+			LaunchNonce: "76767676-7676-4676-8676-767676767676", ConversationID: conversationID,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	evidencePath := internallaunch.EvidencePath(session, evidence.ID)
+	data, err := os.ReadFile(evidencePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[0] ^= 1
+	if err := os.WriteFile(evidencePath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corrupt, err := Inspect(context.Background(), request)
+	if err != nil || corrupt.Outcome != "action_required" || corrupt.ReasonCode != "evidence_corrupt" || backend.focuses != 1 || backend.closes != 1 {
+		t.Fatalf("corrupt evidence Inspect = %#v, %v", corrupt, err)
+	}
+}
+
+type publicLifecycleBackend struct {
+	focuses int
+	closes  int
+	closed  bool
+}
+
+func (*publicLifecycleBackend) Detect() internallaunch.DetectResult {
+	profile := internallaunch.Profile{Backend: "test", Platform: "test", VersionRange: ">=1 <2", Version: 1, Capabilities: []internallaunch.Capability{
+		internallaunch.CapInspect, internallaunch.CapFocus, internallaunch.CapClose,
+	}}
+	return internallaunch.DetectResult{
+		Available: true, Profile: profile, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Effective: append([]internallaunch.Capability(nil), profile.Capabilities...),
+	}
+}
+
+func (*publicLifecycleBackend) Create(internallaunch.CreateRequest) (internallaunch.CreateResult, error) {
+	return internallaunch.CreateResult{Outcome: internallaunch.OutcomeUnsupported}, nil
+}
+
+func (backend *publicLifecycleBackend) Inspect(internallaunch.InspectRequest) (internallaunch.InspectResult, error) {
+	if backend.closed {
+		return internallaunch.InspectResult{Status: internallaunch.InspectAbsent, Evidence: "closed"}, nil
+	}
+	return internallaunch.InspectResult{Status: internallaunch.InspectPresent, Evidence: "owned"}, nil
+}
+
+func (backend *publicLifecycleBackend) Focus(internallaunch.FocusRequest) (internallaunch.FocusResult, error) {
+	backend.focuses++
+	return internallaunch.FocusResult{Outcome: internallaunch.OutcomeAttached}, nil
+}
+
+func (backend *publicLifecycleBackend) Close(internallaunch.CloseRequest) (internallaunch.CloseResult, error) {
+	backend.closes++
+	backend.closed = true
+	return internallaunch.CloseResult{Outcome: internallaunch.OutcomeClosed}, nil
+}


### PR DESCRIPTION
# Summary

- Add thin public Inspect, Focus, and Close launchapi facades over the owned binding and backend.
- Keep Inspect lease-free and zero-write.
- Hold the launch lease for Focus and Close, then revalidate the pinned root, binding, backend, profile, and capability before mutation.
- Store immutable content-addressed capture evidence with O_EXCL publication and verified same-record recovery reuse.
- Gate conversation continuity only with provider_capture evidence.
- Report observed post-mutation state instead of inferring it from the requested operation.

# Frozen design

Frozen design snapshot ccd0b5a9 is unchanged.

# Gate fixes

- Recovery now reuses an existing evidence record only after digest validation and byte equality with the candidate. Tamper or collision returns typed evidence_corrupt and never overwrites.
- Non-payload kind and handle tamper tests now prove the record-level digest check is required.
- Focus and Close now inspect after mutation. Unexpected or unknown observed state returns action_required with post_mutation_state_unexpected and preserves the durable mutation.

# Mutant evidence

All six targeted mutants turn the owning tests red:

1. Replace exclusive evidence publication with O_TRUNC.
2. Skip the binding re-check before lifecycle mutation.
3. Count manual evidence as provider capture.
4. Make Inspect acquire a lease.
5. Skip the evidence record digest check.
6. Disable the post-mutation observed-state check.

# Validation

- make ci
- go test ./... -count=1
- Focused race tests for evidence, lifecycle, crash recovery, and public mapping
- TestTmuxRealBinaryFreshServerRestartResumeLoop with the real tmux binary
- Clean-cache golangci-lint: 0 issues
- Peer gate PASS at staged diff SHA-256 39665df9895c433e1fbb5b6d3154346eb5696b4da3393487ab8e7b453c4c1319
