### PR TITLE
feat(launch): public CLI plan workflow, golden parity, and end-to-end matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ can validate and include them in its semantic trust digest. For example:
       "handle": "claude",
       "adapter": "claude",
       "command": ["claude", "--permission-mode", "acceptEdits"],
-      "resume_policy": "enabled"
+      "resume_policy": "resume"
     },
     {
       "handle": "codex",
       "adapter": "codex",
       "command": ["codex", "--sandbox", "workspace-write", "--ask-for-approval", "on-request"],
-      "resume_policy": "enabled"
+      "resume_policy": "resume"
     }
   ],
   "layout": {"type": "columns"}
@@ -175,6 +175,23 @@ because executing them is the remaining operator action. Paste those emitted
 lines exactly, one per terminal. Do not reconstruct them from examples: they
 bind the selected session, launch nonce, provider arguments, and execution
 ticket.
+
+Automation can use the versioned public launch contract instead of the
+interactive flow:
+
+```bash
+amq launch --plan intent.json --prepare --json --launcher commands > prepared.json
+# Review required_actions and construct an ApplyRequestV1 with exact decisions.
+amq launch --apply apply.json --json
+```
+
+`--prepare` is read-only. `--apply` accepts the complete serialized request, so
+it can run in a fresh process. A plain `--plan intent.json --json` applies only
+when Prepare reports no required actions. Otherwise it prints the Prepare
+result and exits `6`; it never invents a trust, stale-conversation, rebind, or
+degraded-capability decision. Launch configuration uses the resume vocabulary
+`resume`, `fresh`, or `disabled`. See the [public launch API guide](docs/launch-api.md)
+and the [v1 JSON schema](schemas/launch-api-v1.schema.json).
 
 Each command sets up the session environment, starts wake notifications, and
 launches the agent. See [COOP.md](COOP.md#running-co-op-mode) for co-op
@@ -511,6 +528,13 @@ amq doctor [--root <path>] [--base-root <path>] [--ignore-session-pin] [--ops] [
 amq cleanup [--tmp-older-than <duration>] [--wake-quarantine-older-than <duration>] [--launch-journal --root <session-root>] [--dry-run] [--yes]
 ```
 
+Public launch forms:
+
+```text
+amq launch --plan <file|-> [--prepare] --json [--session <name>] [--launcher <name>]
+amq launch --apply <file|-> --json
+```
+
 `--json-schema` requires `--json`.
 
 ### Exit codes
@@ -573,6 +597,7 @@ Building something on AMQ? Open an issue or PR to be listed here.
 - [docs/adapter-contract.md](docs/adapter-contract.md) — Formal v1 adapter contract for integration messages
 - [docs/adr-layer-extensions.md](docs/adr-layer-extensions.md) — ADR for stable layer extension surfaces
 - [docs/trace.md](docs/trace.md) — Read-only trace contract and evidence limits
+- [docs/launch-api.md](docs/launch-api.md) — Public launch intent, Prepare/Apply flow, compatibility floor, and schema
 - [COOP.md](COOP.md) — Co-op workflow and supervisor operations
 - [CLAUDE.md](CLAUDE.md) — Agent instructions, CLI reference, architecture
 

--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -1,0 +1,111 @@
+# Public Launch API
+
+AMQ exposes a versioned launch contract for tools that must plan and apply a
+session without parsing human output. The Go package is `launchapi`. The JSON
+contract is [schemas/launch-api-v1.schema.json](../schemas/launch-api-v1.schema.json).
+
+The current compatibility floor is `0.61.0`. A caller must negotiate its
+required contract range, intent version, result version, and features before it
+depends on them:
+
+```go
+negotiated, err := launchapi.Negotiate(launchapi.RequirementV1{
+	ContractSemver: ">=0.61.0 <0.62.0",
+	IntentVersion:  launchapi.IntentVersionV1,
+	ResultVersion:  launchapi.ResultVersionV1,
+	Features:       []string{"prepare_apply_v1"},
+})
+if err != nil {
+	return err
+}
+_ = negotiated
+```
+
+## Intent
+
+The intent owns the desired participants. Discovery owns the project root,
+default session, session root, and local launcher preference. A public intent
+does not replace committed project configuration.
+
+```json
+{
+  "intent_version": 1,
+  "participants": [
+    {
+      "handle": "claude",
+      "runnable": true,
+      "executable": "claude",
+      "cwd": {"kind": "relative", "path": "."},
+      "resume_policy": "resume",
+      "execution": {
+        "require_wake": true,
+        "no_gitignore": false,
+        "wake": {"mode": "enabled"}
+      }
+    },
+    {"handle": "operator", "runnable": false}
+  ]
+}
+```
+
+`resume_policy` accepts exactly `resume`, `fresh`, or `disabled`.
+
+## Prepare and Apply
+
+Prepare is read-only. It returns the exact subject, plan, and trust digests, a
+preview, current observations, and required actions. Apply accepts the original
+Prepare request, the returned subject digest, and one explicit decision for
+each required action. It recomputes the plan and fails closed if state changed.
+
+```go
+request := launchapi.PrepareRequestV1{
+	RequestVersion: launchapi.RequestVersionV1,
+	Target: launchapi.TargetV1{
+		ProjectRoot: "/workspace/project",
+		SessionRoot: "/workspace/project/.agent-mail/collab",
+		Session:     "collab",
+	},
+	Launcher: "commands",
+	Intent:   intent,
+}
+
+prepared, err := launchapi.Prepare(ctx, request)
+if err != nil {
+	return err
+}
+
+decisions := make([]launchapi.DecisionV1, 0, len(prepared.RequiredActions))
+for _, action := range prepared.RequiredActions {
+	choice, ok := reviewedChoiceFor(action)
+	if !ok {
+		return fmt.Errorf("no reviewed decision for %s", action.ActionID)
+	}
+	decisions = append(decisions, launchapi.DecisionV1{
+		ActionID: action.ActionID,
+		Choice:   choice,
+	})
+}
+
+result, err := launchapi.Apply(ctx, launchapi.ApplyRequestV1{
+	RequestVersion: launchapi.RequestVersionV1,
+	Prepare:        request,
+	SubjectDigest:  prepared.SubjectDigest,
+	Decisions:      decisions,
+})
+```
+
+`reviewedChoiceFor` is intentionally caller-owned. AMQ does not choose trust,
+stale-conversation, rebind, or degraded-capability decisions for the caller.
+
+The equivalent CLI split is:
+
+```bash
+amq launch --plan intent.json --prepare --json --launcher commands
+amq launch --apply apply-request.json --json
+```
+
+Both commands accept `-` for standard input. The Apply document contains the
+complete target and launcher, so `--session`, `--root`, and `--launcher` are not
+valid with `--apply`. Exit code `6` means the JSON result requires an operator
+action. JSON on stdout remains the machine contract; stderr is for people and
+must not be parsed.

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -20,6 +20,8 @@ type launchCLIOptions struct {
 	resumeOnly bool
 }
 
+const maxLaunchAPIDocumentBytes = 4 << 20
+
 var (
 	launchIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 	launchInput      = func() *bufio.Reader { return bufio.NewReader(os.Stdin) }
@@ -56,6 +58,9 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 	freshFlag := fs.Bool("fresh", false, "Start fresh conversations for this launch")
 	allowFreshFlag := fs.Bool("allow-fresh-fallback", false, "Allow fresh conversations when saved identities are stale")
 	rebindFlag := fs.Bool("rebind", false, "Confirm a deliberate launcher binding change")
+	planFlag := fs.String("plan", "", "Public LaunchIntentV1 file, or - for stdin")
+	prepareFlag := fs.Bool("prepare", false, "Prepare the public launch intent without mutation (requires --plan and --json)")
+	applyFlag := fs.String("apply", "", "Public ApplyRequestV1 file, or - for stdin (requires --json)")
 	usageName := "amq launch [options]"
 	if options.resumeOnly {
 		usageName = "amq session resume <name> [options]"
@@ -67,6 +72,16 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 		return err
 	} else if handled {
 		return nil
+	}
+	publicMode := flagWasVisited(fs, "plan") || flagWasVisited(fs, "prepare") || flagWasVisited(fs, "apply")
+	if publicMode {
+		if options.resumeOnly {
+			return UsageError("session resume does not accept --plan, --prepare, or --apply")
+		}
+		if flagWasVisited(fs, "fresh") || flagWasVisited(fs, "allow-fresh-fallback") || flagWasVisited(fs, "rebind") {
+			return UsageError("--plan, --prepare, and --apply do not accept legacy launch decision flags")
+		}
+		return runPublicLaunch(common, *sessionFlag, *launcherFlag, *planFlag, *prepareFlag, *applyFlag, fs)
 	}
 	if *freshFlag && *allowFreshFlag {
 		return UsageError("--fresh and --allow-fresh-fallback are mutually exclusive")

--- a/internal/cli/launch_api_e2e_test.go
+++ b/internal/cli/launch_api_e2e_test.go
@@ -142,6 +142,9 @@ func TestCompatibilityFloorAndEndToEndMatrix(t *testing.T) {
 		}
 		fixture := newPublicLaunchE2EFixture(t, binDir, launch.LauncherTMux)
 		intent := fixture.intent(launchapi.ResumePolicyFresh, false)
+		intent.Participants[0].Execution = &launchapi.ExecutionOptionsV1{Wake: launchapi.WakeOptionsV1{
+			Mode: launchapi.WakeDisabled, AuditReason: "hermetic tmux matrix row",
+		}}
 		intentPath := writeLaunchIntentE2E(t, intent)
 		socketDir, err := os.MkdirTemp("/tmp", "amq-public-tmux-e2e-")
 		if err != nil {
@@ -149,8 +152,7 @@ func TestCompatibilityFloorAndEndToEndMatrix(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
 		env := append(fixture.env(), "TMUX_TMPDIR="+socketDir)
-		serverRunning := false
-		t.Cleanup(func() { stopHermeticTmuxServer(t, socketDir, fixture.sessionRoot, "claude", serverRunning) })
+		t.Cleanup(func() { stopHermeticTmuxServer(t, socketDir, fixture.sessionRoot, "claude", false) })
 
 		stdout, stderr, exit := runRealAMQWithExit(t, amqBinary, fixture.project, env,
 			"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "tmux")
@@ -165,11 +167,24 @@ func TestCompatibilityFloorAndEndToEndMatrix(t *testing.T) {
 		if exit != 0 {
 			t.Fatalf("tmux Apply exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
 		}
-		serverRunning = true
 		var applied launchapi.ApplyResultV1
 		decodeRealLaunchJSON(t, stdout, &applied)
 		if applied.Outcome != "applied" || len(applied.Commands) != 0 {
 			t.Fatalf("tmux Apply = %#v", applied)
+		}
+		rootIdentity, err := fsq.SnapshotDeliveryRoot(fixture.sessionRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		root, err := fsq.OpenDeliveryRoot(fixture.sessionRoot, rootIdentity)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = root.Close() }()
+		ticket, err := launch.LoadExecutionTicket(root, "claude")
+		if err != nil || ticket.Execution == nil || ticket.Execution.WakeMode != string(launchapi.WakeDisabled) ||
+			ticket.Execution.AuditReason != "hermetic tmux matrix row" {
+			t.Fatalf("tmux execution options = %#v, err=%v", ticket.Execution, err)
 		}
 		waitForProviderLog(t, fixture.providerLog, "--session-id ")
 

--- a/internal/cli/launch_api_e2e_test.go
+++ b/internal/cli/launch_api_e2e_test.go
@@ -1,0 +1,597 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+	"github.com/avivsinai/agent-message-queue/launchapi"
+)
+
+func TestCompatibilityFloorAndEndToEndMatrix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes the real amq binary")
+	}
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	amqBinary := filepath.Join(binDir, "amq")
+	build := exec.Command("go", "build", "-o", amqBinary, "./cmd/amq")
+	build.Dir = repoRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build real amq: %v\n%s", err, output)
+	}
+
+	t.Run("compatibility floor", func(t *testing.T) {
+		if launchapi.Compatibility().ContractSemver != "0.61.0" {
+			t.Fatalf("contract floor = %q", launchapi.Compatibility().ContractSemver)
+		}
+		if _, err := launchapi.Negotiate(launchapi.RequirementV1{
+			ContractSemver: ">=0.61.0 <0.62.0", IntentVersion: 1, ResultVersion: 1,
+			Features: []string{"prepare_apply_v1", "plan_only_commands_v1"},
+		}); err != nil {
+			t.Fatalf("negotiate supported floor: %v", err)
+		}
+		if _, err := launchapi.Negotiate(launchapi.RequirementV1{
+			ContractSemver: "<0.61.0", IntentVersion: 1, ResultVersion: 1,
+		}); err == nil {
+			t.Fatal("negotiation accepted a range below the compatibility floor")
+		}
+	})
+
+	t.Run("commands serialized prepare apply and durable resume", func(t *testing.T) {
+		fixture := newPublicLaunchE2EFixture(t, binDir, launch.LauncherCommands)
+		intent := fixture.intent(launchapi.ResumePolicyResume, true)
+		intentPath := writeLaunchIntentE2E(t, intent)
+		env := fixture.env()
+
+		stdout, stderr, exit := runRealAMQWithExit(t, amqBinary, fixture.project, env,
+			"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "commands")
+		if exit != ExitActionRequired {
+			t.Fatalf("Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		var prepared launchapi.PrepareResultV1
+		decodeRealLaunchJSON(t, stdout, &prepared)
+		if prepared.Outcome != launchapi.PrepareOutcomeActionRequired ||
+			!containsActionKind(prepared.RequiredActions, launchapi.RequiredActionTrustConfirmation) {
+			t.Fatalf("initial Prepare = %#v", prepared)
+		}
+		if !slices.Equal(prepared.Preview.Roster.Desired, []string{"claude", "operator"}) ||
+			len(prepared.Preview.Participants) != 2 || prepared.Preview.Participants[1].Handle != "operator" ||
+			prepared.Preview.Participants[1].Runnable {
+			t.Fatalf("multi-seat preview = %#v", prepared.Preview)
+		}
+
+		request := fixture.request(intent, launch.LauncherCommands)
+		applyPath := writeApplyRequestE2E(t, request, prepared)
+		stdout, stderr, exit = runRealAMQWithExit(t, amqBinary, fixture.project, env,
+			"launch", "--apply", applyPath, "--json")
+		if exit != ExitActionRequired {
+			t.Fatalf("Apply exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		var applied launchapi.ApplyResultV1
+		decodeRealLaunchJSON(t, stdout, &applied)
+		if applied.Outcome != "action_required" || len(applied.Commands) != 1 ||
+			!slices.Equal(applied.Roster.Desired, []string{"claude", "operator"}) {
+			t.Fatalf("commands Apply = %#v", applied)
+		}
+		assertManagedCommandOptions(t, applied.Commands[0].Argv, fixture.injector)
+
+		stdout, stderr, exit = runRealAMQWithExit(t, amqBinary, fixture.project, env,
+			"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "commands")
+		if exit != ExitActionRequired {
+			t.Fatalf("resume Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		var resumePrepared launchapi.PrepareResultV1
+		decodeRealLaunchJSON(t, stdout, &resumePrepared)
+		if containsActionKind(resumePrepared.RequiredActions, launchapi.RequiredActionTrustConfirmation) ||
+			!containsActionKind(resumePrepared.RequiredActions, launchapi.RequiredActionStaleConversation) ||
+			!slices.Equal(resumePrepared.Preview.Roster.Present, []string{"claude", "operator"}) ||
+			len(resumePrepared.Observations) != 2 {
+			t.Fatalf("durable resume actions = %#v", resumePrepared.RequiredActions)
+		}
+		resumeApplyPath := writeApplyRequestE2E(t, request, resumePrepared)
+		stdout, stderr, exit = runRealAMQWithExit(t, amqBinary, fixture.project, env,
+			"launch", "--apply", resumeApplyPath, "--json")
+		if exit != ExitActionRequired {
+			t.Fatalf("fresh-process resume Apply exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		var resumed launchapi.ApplyResultV1
+		decodeRealLaunchJSON(t, stdout, &resumed)
+		if len(resumed.Commands) != 1 || resumed.Outcome != "action_required" {
+			t.Fatalf("resume Apply = %#v", resumed)
+		}
+
+		if err := fsq.EnsureAgentDirs(fixture.sessionRoot, "reviewer"); err != nil {
+			t.Fatal(err)
+		}
+		stdout, stderr, exit = runRealAMQWithExit(t, amqBinary, fixture.project, env,
+			"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "commands")
+		if exit != ExitActionRequired {
+			t.Fatalf("roster-drift Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		var drifted launchapi.PrepareResultV1
+		decodeRealLaunchJSON(t, stdout, &drifted)
+		if !slices.Contains(drifted.Preview.Roster.Extra, "reviewer") {
+			t.Fatalf("roster drift = %#v", drifted.Preview.Roster)
+		}
+	})
+
+	t.Run("sibling git worktree exact root real message", func(t *testing.T) {
+		testSiblingWorktreeExactRoot(t, amqBinary, binDir)
+	})
+
+	t.Run("tmux serialized prepare apply and readback", func(t *testing.T) {
+		if _, err := exec.LookPath("tmux"); err != nil {
+			t.Skip("tmux is not installed")
+		}
+		fixture := newPublicLaunchE2EFixture(t, binDir, launch.LauncherTMux)
+		intent := fixture.intent(launchapi.ResumePolicyFresh, false)
+		intentPath := writeLaunchIntentE2E(t, intent)
+		socketDir, err := os.MkdirTemp("/tmp", "amq-public-tmux-e2e-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+		env := append(fixture.env(), "TMUX_TMPDIR="+socketDir)
+		serverRunning := false
+		t.Cleanup(func() { stopHermeticTmuxServer(t, socketDir, fixture.sessionRoot, "claude", serverRunning) })
+
+		stdout, stderr, exit := runRealAMQWithExit(t, amqBinary, fixture.project, env,
+			"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "tmux")
+		if exit != ExitActionRequired {
+			t.Fatalf("tmux Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		var prepared launchapi.PrepareResultV1
+		decodeRealLaunchJSON(t, stdout, &prepared)
+		applyPath := writeApplyRequestE2E(t, fixture.request(intent, launch.LauncherTMux), prepared)
+		stdout, stderr, exit = runRealAMQWithExit(t, amqBinary, fixture.project, env,
+			"launch", "--apply", applyPath, "--json")
+		if exit != 0 {
+			t.Fatalf("tmux Apply exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		serverRunning = true
+		var applied launchapi.ApplyResultV1
+		decodeRealLaunchJSON(t, stdout, &applied)
+		if applied.Outcome != "applied" || len(applied.Commands) != 0 {
+			t.Fatalf("tmux Apply = %#v", applied)
+		}
+		waitForProviderLog(t, fixture.providerLog, "--session-id ")
+
+		stdout, stderr, exit = runRealAMQWithExit(t, amqBinary, fixture.project, env,
+			"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "tmux")
+		if exit != 0 {
+			t.Fatalf("tmux readback Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		var readback launchapi.PrepareResultV1
+		decodeRealLaunchJSON(t, stdout, &readback)
+		if readback.Outcome != launchapi.PrepareOutcomeReady || len(readback.Observations) != 2 {
+			t.Fatalf("tmux readback = %#v", readback)
+		}
+	})
+}
+
+type publicLaunchE2EFixture struct {
+	project     string
+	sessionRoot string
+	home        string
+	state       string
+	binDir      string
+	provider    string
+	providerLog string
+	injector    string
+}
+
+func newPublicLaunchE2EFixture(t *testing.T, binDir, launcher string) publicLaunchE2EFixture {
+	t.Helper()
+	project := t.TempDir()
+	canonicalProject, err := filepath.EvalSymlinks(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerLog := filepath.Join(t.TempDir(), "provider.log")
+	provider := filepath.Join(t.TempDir(), "claude")
+	providerScript := fmt.Sprintf(`#!/bin/sh
+case "$1" in
+  --version) echo "1.0.0 (Claude Code)"; exit 0 ;;
+  --help) echo "--session-id <uuid> --resume [value]"; exit 0 ;;
+esac
+printf '%%s\n' "$*" >> %s
+exec /bin/sleep 60
+`, shellQuoteArg(providerLog))
+	if err := os.WriteFile(provider, []byte(providerScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	injector := filepath.Join(t.TempDir(), "injector")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writePublicLaunchProjectConfig(t, canonicalProject, launcher)
+	sessionRoot := filepath.Join(canonicalProject, defaultCoopRoot, "collab")
+	for _, root := range []string{filepath.Dir(sessionRoot), sessionRoot} {
+		if err := fsq.EnsureRootDirs(root); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "meta", "config.json"), []byte(`{"version":1,"agents":["claude"]}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fsq.EnsureAgentDirs(sessionRoot, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	return publicLaunchE2EFixture{
+		project: canonicalProject, sessionRoot: sessionRoot, home: t.TempDir(), state: t.TempDir(),
+		binDir: binDir, provider: provider, providerLog: providerLog, injector: injector,
+	}
+}
+
+func (f publicLaunchE2EFixture) intent(policy launchapi.ResumePolicy, symphony bool) launchapi.LaunchIntentV1 {
+	execution := &launchapi.ExecutionOptionsV1{
+		RequireWake: true, NoGitignore: true,
+		Wake: launchapi.WakeOptionsV1{
+			Mode:     launchapi.WakeEnabled,
+			Injector: &launchapi.InjectorOptionsV1{Mode: launchapi.InjectorRaw, Via: f.injector, Args: []string{"exec", "terminal-a"}},
+		},
+	}
+	if symphony {
+		execution.Integrations.Symphony = &launchapi.SymphonyOptionsV1{
+			Events: []launchapi.SymphonyEvent{
+				launchapi.SymphonyAfterCreate, launchapi.SymphonyBeforeRun,
+				launchapi.SymphonyAfterRun, launchapi.SymphonyBeforeRemove,
+			},
+			WorkspaceKey: "workspace-7",
+		}
+	}
+	return launchapi.LaunchIntentV1{
+		IntentVersion: launchapi.IntentVersionV1,
+		Participants: []launchapi.ParticipantV1{
+			{
+				Handle: "claude", Runnable: true, Executable: f.provider,
+				Cwd:          &launchapi.WorkingDirectoryV1{Kind: launchapi.WorkingDirectoryAbsolute, Path: f.project},
+				ResumePolicy: policy, Execution: execution,
+			},
+			{Handle: "operator", Runnable: false},
+		},
+	}
+}
+
+func (f publicLaunchE2EFixture) request(intent launchapi.LaunchIntentV1, launcher string) launchapi.PrepareRequestV1 {
+	return launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target:         launchapi.TargetV1{ProjectRoot: f.project, SessionRoot: f.sessionRoot, Session: "collab"},
+		Launcher:       launcher, Intent: intent,
+	}
+}
+
+func (f publicLaunchE2EFixture) env() []string {
+	return append(cleanLaunchE2EEnv(),
+		"HOME="+f.home, "XDG_STATE_HOME="+f.state,
+		"PATH="+f.binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+}
+
+func writePublicLaunchProjectConfig(t *testing.T, project, launcher string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), []byte(`{"root":".agent-mail"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(project, ".amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	projectData, err := launch.MarshalProjectConfig(launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: "collab", Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+		Agents: []launch.ProjectAgentConfig{{Handle: "claude", Adapter: launch.ClaudeProvider, Command: []string{launch.ClaudeProvider}, ResumePolicy: launch.ResumeEnabled}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, setupConfigPath), projectData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	preference := []string{launcher}
+	if launcher != launch.LauncherCommands {
+		preference = append(preference, launch.LauncherCommands)
+	}
+	localData, err := launch.MarshalLocalConfig(launch.LocalConfig{
+		Schema: launch.LocalConfigSchema, LauncherPreference: preference,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, setupLocalConfigPath), localData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeLaunchIntentE2E(t *testing.T, intent launchapi.LaunchIntentV1) string {
+	t.Helper()
+	data, err := launchapi.MarshalLaunchIntentV1(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "intent.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeApplyRequestE2E(t *testing.T, request launchapi.PrepareRequestV1, prepared launchapi.PrepareResultV1) string {
+	t.Helper()
+	decisions := make([]launchapi.DecisionV1, 0, len(prepared.RequiredActions))
+	for _, action := range prepared.RequiredActions {
+		choice := action.AllowedDecisions[0]
+		switch action.Kind {
+		case launchapi.RequiredActionTrustConfirmation:
+			choice = launchapi.DecisionTrustExactSubject
+		case launchapi.RequiredActionStaleConversation:
+			choice = launchapi.DecisionFreshOnce
+		case launchapi.RequiredActionRebindConfirmation:
+			choice = launchapi.DecisionCloseOld
+		case launchapi.RequiredActionUnsupportedCapability:
+			choice = launchapi.DecisionAcceptDegraded
+		}
+		if !slices.Contains(action.AllowedDecisions, choice) {
+			t.Fatalf("action %s does not allow %s: %#v", action.ActionID, choice, action.AllowedDecisions)
+		}
+		decisions = append(decisions, launchapi.DecisionV1{ActionID: action.ActionID, Choice: choice})
+	}
+	data, err := json.Marshal(launchapi.ApplyRequestV1{
+		RequestVersion: launchapi.RequestVersionV1, Prepare: request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: decisions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "apply.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func runRealAMQWithExit(t *testing.T, binary, project string, env []string, args ...string) ([]byte, []byte, int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir, cmd.Env = project, env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		t.Fatalf("real amq %v timed out: %v\n%s", args, ctx.Err(), stderr.Bytes())
+	}
+	if err == nil {
+		return stdout.Bytes(), stderr.Bytes(), 0
+	}
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) {
+		t.Fatalf("real amq %v failed to execute: %v\n%s", args, err, stderr.Bytes())
+	}
+	return stdout.Bytes(), stderr.Bytes(), exitError.ExitCode()
+}
+
+func cleanLaunchE2EEnv() []string {
+	blocked := []string{
+		"AM_ROOT", "AM_BASE_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT_ID", "AM_SESSION", "AMQ_GLOBAL_ROOT", "AM_ME",
+		"HOME", "XDG_STATE_HOME", "PATH", "TMUX_TMPDIR",
+	}
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if !slices.Contains(blocked, key) {
+			env = append(env, entry)
+		}
+	}
+	return env
+}
+
+func decodeRealLaunchJSON(t *testing.T, data []byte, result any) {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(result); err != nil {
+		t.Fatalf("decode real launch output: %v\n%s", err, data)
+	}
+}
+
+func containsActionKind(actions []launchapi.RequiredActionV1, kind launchapi.RequiredActionKindV1) bool {
+	return slices.ContainsFunc(actions, func(action launchapi.RequiredActionV1) bool { return action.Kind == kind })
+}
+
+func assertManagedCommandOptions(t *testing.T, argv []string, injector string) {
+	t.Helper()
+	joined := strings.Join(argv, "\x00")
+	for _, want := range []string{
+		"--require-wake", "--no-gitignore", "--wake-inject-mode\x00raw",
+		"--wake-inject-via\x00" + injector, "--wake-inject-arg\x00exec", "--wake-inject-arg\x00terminal-a",
+		"--managed-symphony-workspace-key\x00workspace-7",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("managed command omitted %q: %#v", want, argv)
+		}
+	}
+	if strings.Count(joined, "--managed-symphony-event") != 4 {
+		t.Fatalf("managed command events = %#v", argv)
+	}
+}
+
+func testSiblingWorktreeExactRoot(t *testing.T, amqBinary, binDir string) {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.Mkdir(repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(dir string, args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	runGit(repo, "init", "-b", "main")
+	runGit(repo, "config", "user.email", "test@example.invalid")
+	runGit(repo, "config", "user.name", "AMQ Test")
+	writePublicLaunchProjectConfig(t, repo, launch.LauncherCommands)
+	runGit(repo, "add", ".amq", ".amqrc")
+	runGit(repo, "commit", "-m", "fixture")
+	sibling := filepath.Join(filepath.Dir(repo), "sibling")
+	runGit(repo, "worktree", "add", "-b", "sibling", sibling)
+
+	canonicalRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalSibling, err := filepath.EvalSymlinks(sibling)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionRoot := filepath.Join(canonicalRepo, defaultCoopRoot, "collab")
+	for _, root := range []string{filepath.Dir(sessionRoot), sessionRoot} {
+		if err := fsq.EnsureRootDirs(root); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "meta", "config.json"), []byte(`{"version":1,"agents":["claude","codex"]}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, handle := range []string{"claude", "codex"} {
+		if err := fsq.EnsureAgentDirs(sessionRoot, handle); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	providerDir := t.TempDir()
+	claudeProvider := filepath.Join(providerDir, "claude")
+	codexProvider := filepath.Join(providerDir, "codex")
+	proofScript := func(capabilities string) string {
+		return `#!/bin/sh
+set -eu
+if [ -n "${AM_ME:-}" ]; then
+  case "$AM_ME" in
+    claude) exec amq --no-update-check send --root "$AM_ROOT" --me claude --to codex --body "exact-root-message" ;;
+    codex) exec amq --no-update-check drain --root "$AM_ROOT" --me codex --include-body ;;
+    *) exit 64 ;;
+  esac
+fi
+` + capabilities
+	}
+	if err := os.WriteFile(claudeProvider, []byte(proofScript(`case "${1:-}" in
+  --version) echo "1.0.0 (Claude Code)" ;;
+  --help) echo "--session-id <uuid> --resume [value]" ;;
+  *) exit 64 ;;
+esac
+`)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(codexProvider, []byte(proofScript(`case "${1:-}" in
+  --version) echo "codex-cli 0.147.0" ;;
+  --help) echo "commands: resume" ;;
+  resume) [ "${2:-}" = "--help" ] && echo "Usage: codex resume [OPTIONS] [SESSION_ID]" ;;
+  app-server) [ "${2:-}" = "--help" ] && echo "generate-json-schema" ;;
+  *) exit 64 ;;
+esac
+`)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	disabledWake := func() *launchapi.ExecutionOptionsV1 {
+		return &launchapi.ExecutionOptionsV1{Wake: launchapi.WakeOptionsV1{
+			Mode: launchapi.WakeDisabled, AuditReason: "hermetic exact-root proof",
+		}}
+	}
+	intent := launchapi.LaunchIntentV1{IntentVersion: launchapi.IntentVersionV1, Participants: []launchapi.ParticipantV1{
+		{
+			Handle: "claude", Runnable: true, Executable: claudeProvider,
+			Cwd:          &launchapi.WorkingDirectoryV1{Kind: launchapi.WorkingDirectoryAbsolute, Path: canonicalRepo},
+			ResumePolicy: launchapi.ResumePolicyFresh, Execution: disabledWake(),
+		},
+		{
+			Handle: "codex", Runnable: true, Executable: codexProvider,
+			Cwd:          &launchapi.WorkingDirectoryV1{Kind: launchapi.WorkingDirectoryAbsolute, Path: canonicalSibling},
+			ResumePolicy: launchapi.ResumePolicyFresh, Execution: disabledWake(),
+		},
+	}}
+	intentPath := writeLaunchIntentE2E(t, intent)
+	env := append(cleanLaunchE2EEnv(), "HOME="+t.TempDir(), "XDG_STATE_HOME="+t.TempDir(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	stdout, stderr, exit := runRealAMQWithExit(t, amqBinary, canonicalRepo, env,
+		"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "commands")
+	if exit != ExitActionRequired {
+		t.Fatalf("exact-root Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+	}
+	var prepared launchapi.PrepareResultV1
+	decodeRealLaunchJSON(t, stdout, &prepared)
+	request := launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target:         launchapi.TargetV1{ProjectRoot: canonicalRepo, SessionRoot: sessionRoot, Session: "collab"},
+		Launcher:       launch.LauncherCommands, Intent: intent,
+	}
+	applyPath := writeApplyRequestE2E(t, request, prepared)
+	stdout, stderr, exit = runRealAMQWithExit(t, amqBinary, canonicalRepo, env,
+		"launch", "--apply", applyPath, "--json")
+	if exit != ExitActionRequired {
+		t.Fatalf("exact-root Apply exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+	}
+	var applied launchapi.ApplyResultV1
+	decodeRealLaunchJSON(t, stdout, &applied)
+	if len(applied.Commands) != 2 {
+		t.Fatalf("exact-root commands = %#v", applied.Commands)
+	}
+	commands := make(map[string]launchapi.CommandV1, len(applied.Commands))
+	for _, command := range applied.Commands {
+		handle := commandArgValue(command.Argv, "--me")
+		if commandArgValue(command.Argv, "--root") != sessionRoot || slices.Contains(command.Argv, "--session") {
+			t.Fatalf("%s command does not use one exact root: %#v", handle, command.Argv)
+		}
+		commands[handle] = command
+	}
+	for _, handle := range []string{"claude", "codex"} {
+		command, ok := commands[handle]
+		if !ok {
+			t.Fatalf("missing emitted command for %s: %#v", handle, applied.Commands)
+		}
+		cmd := exec.Command(command.Argv[0], command.Argv[1:]...)
+		cmd.Dir = command.Cwd
+		cmd.Env = append(cleanLaunchE2EEnv(), "HOME="+t.TempDir(), "XDG_STATE_HOME="+t.TempDir(),
+			"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"), "AMQ_NO_UPDATE_CHECK=1")
+		for key, value := range command.EnvOverlay {
+			cmd.Env = append(cmd.Env, key+"="+value)
+		}
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("run %s emitted command: %v\n%s", handle, err, output)
+		}
+		if handle == "codex" && !strings.Contains(string(output), "exact-root-message") {
+			t.Fatalf("sibling command did not drain the real message:\n%s", output)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(canonicalSibling, defaultCoopRoot)); !os.IsNotExist(err) {
+		t.Fatalf("sibling-local queue exists under %s: %v", canonicalSibling, err)
+	}
+}
+
+func commandArgValue(argv []string, name string) string {
+	for index := 0; index+1 < len(argv); index++ {
+		if argv[index] == name {
+			return argv[index+1]
+		}
+	}
+	return ""
+}

--- a/internal/cli/launch_public_api.go
+++ b/internal/cli/launch_public_api.go
@@ -201,6 +201,11 @@ func publicApplyExit(result launchapi.ApplyResultV1) error {
 	if result.Outcome != "action_required" {
 		return nil
 	}
+	if result.FailureDetail != "" {
+		if err := writeStderr("amq launch: %s\n", result.FailureDetail); err != nil {
+			return err
+		}
+	}
 	reason := result.ReasonCode
 	if reason == "" {
 		reason = "launch apply requires action"

--- a/internal/cli/launch_public_api.go
+++ b/internal/cli/launch_public_api.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
+)
+
+func runPublicLaunch(common *commonFlags, session, launcher, planSource string, prepareOnly bool, applySource string, fs *flag.FlagSet) error {
+	planExplicit, applyExplicit := flagWasVisited(fs, "plan"), flagWasVisited(fs, "apply")
+	if prepareOnly && !planExplicit {
+		return UsageError("--prepare requires --plan")
+	}
+	if prepareOnly && !common.JSON {
+		return UsageError("--prepare requires --json")
+	}
+	if applyExplicit && !common.JSON {
+		return UsageError("--apply requires --json")
+	}
+	if applyExplicit && (planExplicit || prepareOnly) {
+		return UsageError("--apply is mutually exclusive with --plan and --prepare")
+	}
+	if applyExplicit && (flagWasVisited(fs, "session") || flagWasVisited(fs, "launcher") || common.rootExplicit()) {
+		return UsageError("--apply takes its target and launcher from ApplyRequestV1")
+	}
+	if planExplicit && strings.TrimSpace(planSource) == "" {
+		return UsageError("--plan must name a file or -")
+	}
+	if applyExplicit && strings.TrimSpace(applySource) == "" {
+		return UsageError("--apply must name a file or -")
+	}
+
+	ctx := context.Background()
+	if applyExplicit {
+		data, err := readLaunchAPIDocument(applySource)
+		if err != nil {
+			return err
+		}
+		request, err := launchapi.DecodeApplyRequestV1(data)
+		if err != nil {
+			return UsageError("%v", err)
+		}
+		result, err := launchapi.Apply(ctx, request)
+		if err != nil {
+			return err
+		}
+		if err := outputPublicLaunchResult(result); err != nil {
+			return err
+		}
+		return publicApplyExit(result)
+	}
+
+	target, err := resolvePublicLaunchTarget(common, session)
+	if err != nil {
+		return err
+	}
+	data, err := readLaunchAPIDocument(planSource)
+	if err != nil {
+		return err
+	}
+	intent, err := launchapi.DecodeLaunchIntentV1(data)
+	if err != nil {
+		return UsageError("%v", err)
+	}
+	request := launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target:         target,
+		Launcher:       strings.TrimSpace(launcher),
+		Intent:         intent,
+	}
+	prepared, err := launchapi.Prepare(ctx, request)
+	if err != nil {
+		return err
+	}
+	if prepareOnly || prepared.Outcome != launchapi.PrepareOutcomeReady || len(prepared.RequiredActions) != 0 {
+		if err := outputPublicLaunchResult(prepared); err != nil {
+			return err
+		}
+		if prepared.Outcome == launchapi.PrepareOutcomeActionRequired || len(prepared.RequiredActions) != 0 {
+			return ActionRequiredError("%s", publicPrepareReason(prepared))
+		}
+		if prepared.Outcome == launchapi.PrepareOutcomeUnsupported {
+			return ActionRequiredError("%s", publicPrepareReason(prepared))
+		}
+		return nil
+	}
+	result, err := launchapi.Apply(ctx, launchapi.ApplyRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Prepare:        request,
+		SubjectDigest:  prepared.SubjectDigest,
+		Decisions:      []launchapi.DecisionV1{},
+	})
+	if err != nil {
+		return err
+	}
+	if err := outputPublicLaunchResult(result); err != nil {
+		return err
+	}
+	return publicApplyExit(result)
+}
+
+func outputPublicLaunchResult(result any) error {
+	return launchapi.EncodeResultV1(os.Stdout, result)
+}
+
+func resolvePublicLaunchTarget(common *commonFlags, session string) (launchapi.TargetV1, error) {
+	cfg, present, err := loadProjectLaunchConfig()
+	if err != nil {
+		return launchapi.TargetV1{}, err
+	}
+	if !present {
+		return launchapi.TargetV1{}, NotFoundError("committed launch config not found; run 'amq setup'")
+	}
+	configPath, _, err := findProjectLaunchJSONPath()
+	if err != nil {
+		return launchapi.TargetV1{}, err
+	}
+	projectRoot := filepath.Dir(filepath.Dir(configPath))
+	if resolved, resolveErr := filepath.EvalSymlinks(projectRoot); resolveErr == nil {
+		projectRoot = resolved
+	}
+	projectRoot, err = filepath.Abs(projectRoot)
+	if err != nil {
+		return launchapi.TargetV1{}, err
+	}
+	session = strings.TrimSpace(session)
+	if session == "" && !common.rootExplicit() {
+		session = cfg.DefaultSession
+	}
+	if common.rootExplicit() {
+		if flagWasVisited(common.flagSet, "session") {
+			return launchapi.TargetV1{}, UsageError("--session and --root are mutually exclusive")
+		}
+		session = resolveSessionName(common.Root)
+		if session == "" {
+			return launchapi.TargetV1{}, UsageError("--root must select a named session root")
+		}
+	}
+	if err := validateSessionName(session); err != nil {
+		return launchapi.TargetV1{}, UsageError("--session: %v", err)
+	}
+	routeSession := session
+	if common.rootExplicit() {
+		routeSession = ""
+	}
+	root, routed, err := resolveMailboxRoot(common, routeSession)
+	if err != nil {
+		return launchapi.TargetV1{}, err
+	}
+	if err := guardMailboxContext("launch", root, routed, false, common.rootExplicit()); err != nil {
+		return launchapi.TargetV1{}, err
+	}
+	root, err = filepath.Abs(root)
+	if err != nil {
+		return launchapi.TargetV1{}, err
+	}
+	return launchapi.TargetV1{ProjectRoot: filepath.Clean(projectRoot), SessionRoot: filepath.Clean(root), Session: session}, nil
+}
+
+func readLaunchAPIDocument(source string) ([]byte, error) {
+	var reader io.Reader
+	var file *os.File
+	if source == "-" {
+		reader = os.Stdin
+	} else {
+		var err error
+		file, err = os.Open(source)
+		if err != nil {
+			return nil, fmt.Errorf("open launch document: %w", err)
+		}
+		defer func() { _ = file.Close() }()
+		reader = file
+	}
+	data, err := io.ReadAll(io.LimitReader(reader, maxLaunchAPIDocumentBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read launch document: %w", err)
+	}
+	if len(data) > maxLaunchAPIDocumentBytes {
+		return nil, UsageError("launch document exceeds %d bytes", maxLaunchAPIDocumentBytes)
+	}
+	return data, nil
+}
+
+func publicPrepareReason(result launchapi.PrepareResultV1) string {
+	if result.Reason != "" {
+		return result.Reason
+	}
+	if len(result.RequiredActions) != 0 {
+		return result.RequiredActions[0].ReasonCode
+	}
+	return "launch prepare requires action"
+}
+
+func publicApplyExit(result launchapi.ApplyResultV1) error {
+	if result.Outcome != "action_required" {
+		return nil
+	}
+	reason := result.ReasonCode
+	if reason == "" {
+		reason = "launch apply requires action"
+	}
+	return ActionRequiredError("%s", reason)
+}

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -215,6 +215,26 @@ func TestCLIResultEncoderUsesPackageGoldens(t *testing.T) {
 	}
 }
 
+func TestPublicApplyFailureDetailIsStderrOnly(t *testing.T) {
+	result := launchapi.ApplyResultV1{
+		ResultVersion: launchapi.ResultVersionV1,
+		Outcome:       "action_required",
+		ReasonCode:    "backend_create_failed",
+		FailureDetail: "create tmux session: pane exited before inspection",
+	}
+	encoded, err := launchapi.MarshalResultV1(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "pane exited") || strings.Contains(string(encoded), "failure_detail") {
+		t.Fatalf("failure detail leaked into public JSON: %s", encoded)
+	}
+	_, stderr, err := captureEnvOutput(t, func() error { return publicApplyExit(result) })
+	if GetExitCode(err) != ExitActionRequired || !strings.Contains(stderr, result.FailureDetail) {
+		t.Fatalf("exit=%d err=%v stderr=%q", GetExitCode(err), err, stderr)
+	}
+}
+
 func dereferenceGoldenResult(result any) any {
 	switch value := result.(type) {
 	case *launchapi.PrepareResultV1:

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -1,0 +1,324 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/launchapi"
+)
+
+func TestPublicLaunchUnsupportedIsExit6AndZeroWrite(t *testing.T) {
+	for _, args := range [][]string{
+		{"--launcher", "cmux", "--json"},
+		{"--launcher", "cmux", "--prepare", "--json"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			project, _ := launchCLIFixture(t, "collab")
+			intent := launchapi.LaunchIntentV1{
+				IntentVersion: launchapi.IntentVersionV1,
+				Participants:  []launchapi.ParticipantV1{{Handle: "claude", Runnable: false}},
+			}
+			data, err := launchapi.MarshalLaunchIntentV1(intent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(t.TempDir(), "intent.json")
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			before := strings.Join(snapshotTree(t, project), "\n")
+			commandArgs := append([]string{"--plan", path}, args...)
+			stdout, _, cliErr := captureEnvOutput(t, func() error { return runLaunch(commandArgs) })
+			if GetExitCode(cliErr) != ExitActionRequired {
+				t.Fatalf("unsupported exit=%d err=%v\n%s", GetExitCode(cliErr), cliErr, stdout)
+			}
+			var result launchapi.PrepareResultV1
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.Outcome != launchapi.PrepareOutcomeUnsupported || result.Reason != "launcher_not_available" {
+				t.Fatalf("unsupported result = %#v", result)
+			}
+			if after := strings.Join(snapshotTree(t, project), "\n"); after != before {
+				t.Fatalf("unsupported Prepare changed the project tree\nbefore:\n%s\nafter:\n%s", before, after)
+			}
+		})
+	}
+}
+
+func TestPublicLaunchApplyReadsFullRequest(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	request := launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target: launchapi.TargetV1{
+			ProjectRoot: project,
+			SessionRoot: filepath.Join(project, defaultCoopRoot, "collab"),
+			Session:     "collab",
+		},
+		Launcher: "commands",
+		Intent: launchapi.LaunchIntentV1{IntentVersion: launchapi.IntentVersionV1, Participants: []launchapi.ParticipantV1{{
+			Handle: "operator", Runnable: false,
+		}}},
+	}
+	prepared, err := launchapi.Prepare(context.Background(), request)
+	if err != nil || prepared.Outcome != launchapi.PrepareOutcomeReady || len(prepared.RequiredActions) != 0 {
+		t.Fatalf("Prepare = %#v, %v", prepared, err)
+	}
+	apply := launchapi.ApplyRequestV1{
+		RequestVersion: launchapi.RequestVersionV1, Prepare: request,
+		SubjectDigest: prepared.SubjectDigest, Decisions: []launchapi.DecisionV1{},
+	}
+	data, err := json.Marshal(apply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "apply.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, cliErr := captureEnvOutput(t, func() error { return runLaunch([]string{"--apply", path, "--json"}) })
+	if cliErr != nil {
+		t.Fatalf("CLI Apply: %v\n%s", cliErr, stdout)
+	}
+	var result launchapi.ApplyResultV1
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "provisioned_no_runnable" || result.SemanticDigest != result.TrustDigest || len(result.Roster.Desired) != 1 || result.Roster.Desired[0] != "operator" {
+		t.Fatalf("CLI Apply result = %#v", result)
+	}
+}
+
+func TestPublicLaunchPlanNeverAutoAuthorizesRequiredActions(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	provider := filepath.Join(t.TempDir(), "claude")
+	if err := os.WriteFile(provider, []byte("#!/bin/sh\ncase \"$1\" in --version) echo '1.0.0 (Claude Code)' ;; --help) echo '--session-id --resume' ;; esac\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	intent := launchapi.LaunchIntentV1{
+		IntentVersion: launchapi.IntentVersionV1,
+		Participants: []launchapi.ParticipantV1{{
+			Handle: "claude", Runnable: true, Executable: provider,
+			Cwd:          &launchapi.WorkingDirectoryV1{Kind: launchapi.WorkingDirectoryAbsolute, Path: project},
+			ResumePolicy: launchapi.ResumePolicyFresh,
+			Execution: &launchapi.ExecutionOptionsV1{
+				Wake: launchapi.WakeOptionsV1{Mode: launchapi.WakeDisabled, AuditReason: "test fixture"},
+			},
+		}},
+	}
+	data, err := launchapi.MarshalLaunchIntentV1(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "intent.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sessionRoot := filepath.Join(project, defaultCoopRoot, "collab")
+	before := strings.Join(snapshotTree(t, project), "\n")
+	stdout, _, cliErr := captureEnvOutput(t, func() error { return runLaunch([]string{"--plan", path, "--json"}) })
+	if GetExitCode(cliErr) != ExitActionRequired {
+		t.Fatalf("plain --plan exit=%d err=%v\n%s", GetExitCode(cliErr), cliErr, stdout)
+	}
+	var result launchapi.PrepareResultV1
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != launchapi.PrepareOutcomeActionRequired || len(result.RequiredActions) == 0 || result.RequiredActions[0].Kind != launchapi.RequiredActionTrustConfirmation {
+		t.Fatalf("plain --plan result = %#v", result)
+	}
+	if after := strings.Join(snapshotTree(t, project), "\n"); after != before {
+		t.Fatalf("action-required --plan changed the project tree\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	if _, err := os.Stat(filepath.Join(sessionRoot, "meta", "launch", "binding.json")); !os.IsNotExist(err) {
+		t.Fatalf("action-required --plan wrote a binding: %v", err)
+	}
+}
+
+func TestPublicLaunchPlanAppliesWithEmptyDecisionsWhenReady(t *testing.T) {
+	_, _ = launchCLIFixture(t, "collab")
+	intent := launchapi.LaunchIntentV1{
+		IntentVersion: launchapi.IntentVersionV1,
+		Participants:  []launchapi.ParticipantV1{{Handle: "operator", Runnable: false}},
+	}
+	data, err := launchapi.MarshalLaunchIntentV1(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "intent.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, cliErr := captureEnvOutput(t, func() error { return runLaunch([]string{"--plan", path, "--json"}) })
+	if cliErr != nil {
+		t.Fatalf("plain --plan: %v\n%s", cliErr, stdout)
+	}
+	var result launchapi.ApplyResultV1
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "provisioned_no_runnable" || result.SemanticDigest != result.TrustDigest || len(result.Roster.Desired) != 1 || result.Roster.Desired[0] != "operator" {
+		t.Fatalf("plain --plan result = %#v", result)
+	}
+}
+
+func TestPublicLaunchModeFlagRefusals(t *testing.T) {
+	launchCLIFixture(t, "collab")
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "prepare without plan", args: []string{"--prepare", "--json"}, want: "--prepare requires --plan"},
+		{name: "prepare without json", args: []string{"--plan", "intent.json", "--prepare"}, want: "--prepare requires --json"},
+		{name: "apply without json", args: []string{"--apply", "apply.json"}, want: "--apply requires --json"},
+		{name: "mixed apply and plan", args: []string{"--apply", "apply.json", "--plan", "intent.json", "--json"}, want: "mutually exclusive"},
+		{name: "apply target override", args: []string{"--apply", "apply.json", "--session", "collab", "--json"}, want: "takes its target"},
+		{name: "legacy decision flag", args: []string{"--plan", "intent.json", "--fresh"}, want: "legacy launch decision flags"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := runLaunch(test.args)
+			if GetExitCode(err) != ExitUsage || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want usage containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestCLIResultEncoderUsesPackageGoldens(t *testing.T) {
+	for _, test := range []struct {
+		file   string
+		result any
+	}{
+		{file: "prepare_result_v1.golden.json", result: &launchapi.PrepareResultV1{}},
+		{file: "apply_result_v1.golden.json", result: &launchapi.ApplyResultV1{}},
+	} {
+		golden, err := os.ReadFile(filepath.Join("..", "..", "launchapi", "testdata", test.file))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(golden, test.result); err != nil {
+			t.Fatal(err)
+		}
+		stdout, _, err := captureEnvOutput(t, func() error { return outputPublicLaunchResult(dereferenceGoldenResult(test.result)) })
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stdout != string(golden) {
+			t.Fatalf("CLI output differs from shared %s\ngot:\n%s\nwant:\n%s", test.file, stdout, golden)
+		}
+	}
+}
+
+func dereferenceGoldenResult(result any) any {
+	switch value := result.(type) {
+	case *launchapi.PrepareResultV1:
+		return *value
+	case *launchapi.ApplyResultV1:
+		return *value
+	default:
+		return result
+	}
+}
+
+func TestCLIAndPackageResultGoldenParity(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, _ := launchCLIFixture(t, "collab")
+	intent := launchapi.LaunchIntentV1{
+		IntentVersion: launchapi.IntentVersionV1,
+		Participants:  []launchapi.ParticipantV1{{Handle: "claude", Runnable: false}},
+	}
+	intentData, err := launchapi.MarshalLaunchIntentV1(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	intentPath := filepath.Join(t.TempDir(), "intent.json")
+	if err := os.WriteFile(intentPath, intentData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := strings.Join(snapshotTree(t, project), "\n")
+	stdout, _, cliErr := captureEnvOutput(t, func() error {
+		return runLaunch([]string{"--plan", intentPath, "--prepare", "--json"})
+	})
+	if cliErr != nil {
+		t.Fatalf("CLI Prepare: %v\n%s", cliErr, stdout)
+	}
+	if after := strings.Join(snapshotTree(t, project), "\n"); after != before {
+		t.Fatalf("CLI Prepare changed the project tree\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	request := launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target: launchapi.TargetV1{
+			ProjectRoot: project,
+			SessionRoot: filepath.Join(project, defaultCoopRoot, "collab"),
+			Session:     "collab",
+		},
+		Launcher: "auto",
+		Intent:   intent,
+	}
+	packageResult, err := launchapi.Prepare(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageJSON, err := launchapi.MarshalResultV1(packageResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout != string(packageJSON) {
+		t.Fatalf("CLI/package JSON differ\nCLI:\n%s\npackage:\n%s", stdout, packageJSON)
+	}
+	t.Run("digests present", func(t *testing.T) {
+		if packageResult.PlanDigest == "" || packageResult.TrustDigest == "" || packageResult.SubjectDigest == "" {
+			t.Fatalf("result omitted required digests: %#v", packageResult)
+		}
+	})
+	t.Run("root-only change", func(t *testing.T) {
+		otherSession := filepath.Join(project, "other-mail", "collab")
+		if err := fsq.EnsureRootDirs(otherSession); err != nil {
+			t.Fatal(err)
+		}
+		if err := fsq.EnsureAgentDirs(otherSession, "claude"); err != nil {
+			t.Fatal(err)
+		}
+		changedRequest := request
+		changedRequest.Target.SessionRoot = otherSession
+		changed, err := launchapi.Prepare(context.Background(), changedRequest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed.PlanDigest != packageResult.PlanDigest || changed.TrustDigest == packageResult.TrustDigest || changed.SubjectDigest == packageResult.SubjectDigest {
+			t.Fatalf("root-only digest change: plan=%t trust=%t subject=%t", changed.PlanDigest != packageResult.PlanDigest, changed.TrustDigest != packageResult.TrustDigest, changed.SubjectDigest != packageResult.SubjectDigest)
+		}
+	})
+	t.Run("binding-only change", func(t *testing.T) {
+		writeCommandsBinding(t, request.Target.SessionRoot)
+		changed, err := launchapi.Prepare(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if changed.PlanDigest != packageResult.PlanDigest || changed.TrustDigest != packageResult.TrustDigest || changed.SubjectDigest == packageResult.SubjectDigest {
+			t.Fatalf("binding-only digest change: plan=%t trust=%t subject=%t", changed.PlanDigest != packageResult.PlanDigest, changed.TrustDigest != packageResult.TrustDigest, changed.SubjectDigest != packageResult.SubjectDigest)
+		}
+	})
+	t.Run("semantic digest alias", func(t *testing.T) {
+		data, err := os.ReadFile(filepath.Join(repoRoot, "launchapi", "testdata", "apply_result_v1.golden.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var result launchapi.ApplyResultV1
+		if err := json.Unmarshal(data, &result); err != nil {
+			t.Fatal(err)
+		}
+		if result.SemanticDigest == "" || result.SemanticDigest != result.TrustDigest {
+			t.Fatalf("semantic_digest=%q trust_digest=%q", result.SemanticDigest, result.TrustDigest)
+		}
+	})
+}

--- a/internal/cli/managed_execution_options.go
+++ b/internal/cli/managed_execution_options.go
@@ -6,76 +6,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path/filepath"
-	"slices"
-	"strings"
-	"unicode/utf8"
 
 	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 const managedExecutionOptionsFlag = "execution-options"
 
-var managedSymphonyEvents = []string{"after_create", "before_run", "after_run", "before_remove"}
-
 func validateManagedExecutionOptions(options launch.PrepareExecutionOptions) error {
-	switch options.WakeMode {
-	case "disabled":
-		if strings.TrimSpace(options.AuditReason) == "" {
-			return fmt.Errorf("disabled wake requires an audit reason")
-		}
-		if options.RequireWake {
-			return fmt.Errorf("require_wake conflicts with disabled wake")
-		}
-		if options.InjectorMode != "" || options.InjectorVia != "" || len(options.InjectorArgs) != 0 {
-			return fmt.Errorf("disabled wake forbids injector settings")
-		}
-	case "enabled":
-		if options.AuditReason != "" {
-			return fmt.Errorf("enabled wake forbids a disabled-wake audit reason")
-		}
-	default:
-		return fmt.Errorf("invalid wake mode %q", options.WakeMode)
-	}
-
-	switch options.InjectorMode {
-	case "", "auto", "raw", "paste", "none":
-	default:
-		return fmt.Errorf("invalid injector mode %q", options.InjectorMode)
-	}
-	if options.InjectorMode == "none" && (options.InjectorVia != "" || len(options.InjectorArgs) != 0) {
-		return fmt.Errorf("injector mode none forbids via and args")
-	}
-	if options.InjectorVia != "" {
-		if !filepath.IsAbs(options.InjectorVia) || filepath.Clean(options.InjectorVia) != options.InjectorVia || strings.ContainsRune(options.InjectorVia, 0) {
-			return fmt.Errorf("injector via must be a clean absolute path")
-		}
-	} else if len(options.InjectorArgs) != 0 {
-		return fmt.Errorf("injector args require via")
-	}
-	for _, arg := range options.InjectorArgs {
-		if !utf8.ValidString(arg) || strings.ContainsRune(arg, 0) {
-			return fmt.Errorf("injector args contain an invalid value")
-		}
-	}
-
-	seen := make(map[string]struct{}, len(options.SymphonyEvents))
-	for _, event := range options.SymphonyEvents {
-		if !slices.Contains(managedSymphonyEvents, event) {
-			return fmt.Errorf("unknown symphony event %q", event)
-		}
-		if _, ok := seen[event]; ok {
-			return fmt.Errorf("duplicate symphony event %q", event)
-		}
-		seen[event] = struct{}{}
-	}
-	if options.SymphonyWorkspaceKey != "" && len(options.SymphonyEvents) == 0 {
-		return fmt.Errorf("symphony workspace key requires at least one event")
-	}
-	if !utf8.ValidString(options.SymphonyWorkspaceKey) || strings.ContainsRune(options.SymphonyWorkspaceKey, 0) {
-		return fmt.Errorf("symphony workspace key is invalid")
-	}
-	return nil
+	return launch.ValidatePrepareExecutionOptionsGrammar(options, launch.PrepareExecutionOptionsPresence{
+		Injector: options.InjectorMode != "" || options.InjectorVia != "" || len(options.InjectorArgs) != 0,
+		Symphony: len(options.SymphonyEvents) != 0 || options.SymphonyWorkspaceKey != "",
+	})
 }
 
 func encodeManagedExecutionOptions(options launch.PrepareExecutionOptions) (string, error) {

--- a/internal/cli/managed_execution_options_test.go
+++ b/internal/cli/managed_execution_options_test.go
@@ -38,6 +38,11 @@ func TestManagedExecutionOptionsCodecRoundTripAndHostileInput(t *testing.T) {
 	if _, err := encodeManagedExecutionOptions(invalid); err == nil || !strings.Contains(err.Error(), "unknown symphony event") {
 		t.Fatalf("unknown event error = %v", err)
 	}
+	argsWithoutVia := want
+	argsWithoutVia.InjectorVia = ""
+	if _, err := encodeManagedExecutionOptions(argsWithoutVia); err == nil || !strings.Contains(err.Error(), "injector args require via") {
+		t.Fatalf("injector args without via error = %v", err)
+	}
 }
 
 func TestManagedExecutionOptionsDisabledWakeRequiresReason(t *testing.T) {

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -40,6 +40,7 @@ type ApplyDependencies struct {
 type ApplyResult struct {
 	Outcome         string
 	ReasonCode      string
+	FailureDetail   string
 	SubjectDigest   string
 	PlanDigest      string
 	TrustDigest     string
@@ -245,6 +246,7 @@ func applyUnderAuthority(ctx context.Context, request ApplyRequest, dependencies
 	} else {
 		result.Outcome = ApplyOutcomeActionRequired
 		result.ReasonCode = applyReconcileReasonCode(reconciled)
+		result.FailureDetail = reconciled.Reason
 	}
 	return result, nil
 }

--- a/internal/launch/execution_options_grammar.go
+++ b/internal/launch/execution_options_grammar.go
@@ -1,0 +1,83 @@
+package launch
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode/utf8"
+)
+
+type PrepareExecutionOptionsPresence struct {
+	Injector bool
+	Symphony bool
+}
+
+var allowedSymphonyEvents = []string{"after_create", "before_run", "after_run", "before_remove"}
+
+// ValidatePrepareExecutionOptionsGrammar is the single input-grammar validator
+// for public launch intents and the managed execution-options codec.
+func ValidatePrepareExecutionOptionsGrammar(options PrepareExecutionOptions, presence PrepareExecutionOptionsPresence) error {
+	injectorConfigured := presence.Injector || options.InjectorMode != "" || options.InjectorVia != "" || len(options.InjectorArgs) != 0
+	symphonyConfigured := presence.Symphony || len(options.SymphonyEvents) != 0 || options.SymphonyWorkspaceKey != ""
+
+	switch options.WakeMode {
+	case "disabled":
+		if strings.TrimSpace(options.AuditReason) == "" {
+			return fmt.Errorf("disabled wake requires an audit reason")
+		}
+		if options.RequireWake {
+			return fmt.Errorf("require_wake conflicts with disabled wake")
+		}
+		if injectorConfigured {
+			return fmt.Errorf("disabled wake forbids injector settings")
+		}
+	case "enabled":
+		if options.AuditReason != "" {
+			return fmt.Errorf("enabled wake forbids a disabled-wake audit reason")
+		}
+	default:
+		return fmt.Errorf("invalid wake mode %q", options.WakeMode)
+	}
+
+	if injectorConfigured {
+		if !slices.Contains([]string{"auto", "raw", "paste", "none"}, options.InjectorMode) {
+			return fmt.Errorf("invalid injector mode %q", options.InjectorMode)
+		}
+		if options.InjectorMode == "none" && (options.InjectorVia != "" || len(options.InjectorArgs) != 0) {
+			return fmt.Errorf("injector mode none forbids via and args")
+		}
+		if options.InjectorVia != "" {
+			if !filepath.IsAbs(options.InjectorVia) || filepath.Clean(options.InjectorVia) != options.InjectorVia || strings.ContainsRune(options.InjectorVia, 0) {
+				return fmt.Errorf("injector via must be a clean absolute path")
+			}
+		} else if len(options.InjectorArgs) != 0 {
+			return fmt.Errorf("injector args require via")
+		}
+		for _, arg := range options.InjectorArgs {
+			if !utf8.ValidString(arg) || strings.ContainsRune(arg, 0) {
+				return fmt.Errorf("injector args contain an invalid value")
+			}
+		}
+	}
+
+	if symphonyConfigured {
+		if len(options.SymphonyEvents) == 0 {
+			return fmt.Errorf("symphony requires at least one event")
+		}
+		seen := make(map[string]struct{}, len(options.SymphonyEvents))
+		for _, event := range options.SymphonyEvents {
+			if !slices.Contains(allowedSymphonyEvents, event) {
+				return fmt.Errorf("unknown symphony event %q", event)
+			}
+			if _, ok := seen[event]; ok {
+				return fmt.Errorf("duplicate symphony event %q", event)
+			}
+			seen[event] = struct{}{}
+		}
+		if !utf8.ValidString(options.SymphonyWorkspaceKey) || strings.ContainsRune(options.SymphonyWorkspaceKey, 0) {
+			return fmt.Errorf("symphony workspace key is invalid")
+		}
+	}
+	return nil
+}

--- a/launchapi/apply.go
+++ b/launchapi/apply.go
@@ -33,7 +33,7 @@ func Apply(ctx context.Context, request ApplyRequestV1) (ApplyResultV1, error) {
 
 func fromInternalApplyResult(result internallaunch.ApplyResult) ApplyResultV1 {
 	public := ApplyResultV1{
-		ResultVersion: ResultVersionV1, Outcome: result.Outcome, ReasonCode: result.ReasonCode,
+		ResultVersion: ResultVersionV1, Outcome: result.Outcome, ReasonCode: result.ReasonCode, FailureDetail: result.FailureDetail,
 		SubjectDigest: result.SubjectDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
 		SemanticDigest: result.TrustDigest, Backend: result.Backend, Profile: result.Profile,
 		Roster: RosterDriftV1{

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -100,14 +100,24 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 	}
 }
 
-func TestApplyResultMapsEvidenceRefs(t *testing.T) {
+func TestApplyResultMapsEvidenceRefsAndNonContractFailureDetail(t *testing.T) {
 	observed := time.Date(2026, 8, 17, 3, 4, 5, 0, time.UTC)
-	result := fromInternalApplyResult(internallaunch.ApplyResult{Evidence: []internallaunch.EvidenceRef{{
+	result := fromInternalApplyResult(internallaunch.ApplyResult{FailureDetail: "create tmux session: pane exited", Evidence: []internallaunch.EvidenceRef{{
 		EvidenceVersion: 1, ID: "sha256:" + strings.Repeat("a", 64), Kind: internallaunch.EvidenceProviderCapture,
 		SHA256: "sha256:" + strings.Repeat("a", 64), ObservedAt: observed,
 	}}})
 	if len(result.Evidence) != 1 || result.Evidence[0].Kind != "provider_capture" || result.Evidence[0].ObservedAt != observed || result.Evidence[0].ID != result.Evidence[0].SHA256 {
 		t.Fatalf("public evidence mapping = %#v", result.Evidence)
+	}
+	if result.FailureDetail != "create tmux session: pane exited" {
+		t.Fatalf("failure detail = %q", result.FailureDetail)
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("pane exited")) || bytes.Contains(encoded, []byte("failure_detail")) {
+		t.Fatalf("non-contract failure detail leaked into DTO JSON: %s", encoded)
 	}
 }
 

--- a/launchapi/encoding.go
+++ b/launchapi/encoding.go
@@ -1,0 +1,31 @@
+package launchapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// MarshalResultV1 is the canonical JSON encoder for all V1 result DTOs.
+func MarshalResultV1(result any) ([]byte, error) {
+	switch result.(type) {
+	case PrepareResultV1, ApplyResultV1, LifecycleResultV1:
+	default:
+		return nil, fmt.Errorf("unsupported launch result type %T", result)
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+// EncodeResultV1 writes the exact bytes returned by MarshalResultV1.
+func EncodeResultV1(writer io.Writer, result any) error {
+	data, err := MarshalResultV1(result)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+	return err
+}

--- a/launchapi/encoding_test.go
+++ b/launchapi/encoding_test.go
@@ -1,0 +1,91 @@
+package launchapi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResultV1GoldenEncoding(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		file   string
+		result any
+	}{
+		{name: "prepare", file: "prepare_result_v1.golden.json", result: goldenPrepareResultV1()},
+		{name: "apply", file: "apply_result_v1.golden.json", result: goldenApplyResultV1()},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			golden, err := os.ReadFile(filepath.Join("testdata", test.file))
+			if err != nil {
+				t.Fatal(err)
+			}
+			encoded, err := MarshalResultV1(test.result)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(encoded) != string(golden) {
+				t.Fatalf("result encoding differs from %s\ngot:\n%s\nwant:\n%s", test.file, encoded, golden)
+			}
+		})
+	}
+	if _, err := MarshalResultV1(struct{}{}); err == nil {
+		t.Fatal("canonical result encoder accepted a non-contract type")
+	}
+}
+
+func TestResultV1GoldensRequireDigestAndAliasFields(t *testing.T) {
+	for _, file := range []string{"prepare_result_v1.golden.json", "apply_result_v1.golden.json"} {
+		data, err := os.ReadFile(filepath.Join("testdata", file))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var document map[string]json.RawMessage
+		if err := json.Unmarshal(data, &document); err != nil {
+			t.Fatal(err)
+		}
+		for _, field := range []string{"subject_digest", "plan_digest", "trust_digest"} {
+			if len(document[field]) == 0 {
+				t.Fatalf("%s omits %s", file, field)
+			}
+		}
+		if strings.HasPrefix(file, "apply") && string(document["semantic_digest"]) != string(document["trust_digest"]) {
+			t.Fatalf("%s semantic_digest is not byte-equal to trust_digest", file)
+		}
+	}
+}
+
+func goldenPrepareResultV1() PrepareResultV1 {
+	return PrepareResultV1{
+		ResultVersion: 1, Outcome: PrepareOutcomeActionRequired, Reason: "untrusted_config_digest",
+		SubjectDigest: goldenDigest('a'), PlanDigest: goldenDigest('b'), TrustDigest: goldenDigest('c'),
+		RequiredActions: []RequiredActionV1{{
+			ActionID: "trust-example", Kind: RequiredActionTrustConfirmation, Handles: []string{"claude"},
+			Resources: []string{goldenDigest('c')}, AllowedDecisions: []DecisionChoiceV1{DecisionTrustExactSubject, DecisionDeny},
+			ReasonCode: "untrusted_config_digest",
+		}},
+		Preview: PreviewV1{
+			Target:  TargetV1{ProjectRoot: "/workspace/example", SessionRoot: "/workspace/example/.agent-mail/collab", Session: "collab"},
+			Backend: "commands", Profile: "commands/portable/v1",
+			Participants: []ParticipantPreviewV1{{Handle: "operator", Runnable: false, PlannedOutcome: "observe_only"}},
+			Roster:       RosterDriftV1{Desired: []string{"operator"}, Present: []string{}, Missing: []string{"operator"}, Extra: []string{}},
+		},
+		Observations: []ParticipantObservationV1{{Handle: "operator", Mailbox: "missing", Runnable: false, Conversation: "none", Execution: "none", Resource: ""}},
+	}
+}
+
+func goldenApplyResultV1() ApplyResultV1 {
+	return ApplyResultV1{
+		ResultVersion: 1, Outcome: "applied", SubjectDigest: goldenDigest('a'), PlanDigest: goldenDigest('b'),
+		TrustDigest: goldenDigest('c'), SemanticDigest: goldenDigest('c'), Backend: "commands", Profile: "commands/portable/v1",
+		Roster: RosterDriftV1{Desired: []string{"claude"}, Present: []string{"claude"}, Missing: []string{}, Extra: []string{}},
+		Observations: []ParticipantObservationV1{{
+			Handle: "claude", Mailbox: "present", Runnable: true, Conversation: "ready", Execution: "acknowledged", Resource: "commands:claude",
+		}},
+		Commands: []CommandV1{{Argv: []string{"amq", "coop", "exec", "claude"}, Cwd: "/workspace/example"}},
+	}
+}
+
+func goldenDigest(character byte) string { return "sha256:" + strings.Repeat(string(character), 64) }

--- a/launchapi/intent.go
+++ b/launchapi/intent.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -139,86 +138,10 @@ func (cwd WorkingDirectoryV1) validate() error {
 }
 
 func (options ExecutionOptionsV1) validate() error {
-	wake := options.Wake
-	switch wake.Mode {
-	case WakeDisabled:
-		if strings.TrimSpace(wake.AuditReason) == "" {
-			return fmt.Errorf("disabled wake requires an audit reason")
-		}
-		if options.RequireWake {
-			return fmt.Errorf("require_wake conflicts with disabled wake")
-		}
-		if wake.Injector != nil {
-			return fmt.Errorf("disabled wake forbids injector settings")
-		}
-	case WakeEnabled:
-		if wake.AuditReason != "" {
-			return fmt.Errorf("enabled wake forbids a disabled-wake audit reason")
-		}
-	default:
-		return fmt.Errorf("invalid wake mode %q", wake.Mode)
-	}
-	if wake.Injector != nil {
-		if err := wake.Injector.validate(); err != nil {
-			return err
-		}
-	}
-	if options.Integrations.Symphony != nil {
-		if err := options.Integrations.Symphony.validate(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (injector InjectorOptionsV1) validate() error {
-	switch injector.Mode {
-	case InjectorAuto, InjectorRaw, InjectorPaste, InjectorNone:
-	default:
-		return fmt.Errorf("invalid injector mode %q", injector.Mode)
-	}
-	if injector.Mode == InjectorNone && (injector.Via != "" || len(injector.Args) > 0) {
-		return fmt.Errorf("injector mode none forbids via and args")
-	}
-	if injector.Via != "" {
-		if !filepath.IsAbs(injector.Via) || filepath.Clean(injector.Via) != injector.Via || strings.ContainsRune(injector.Via, 0) {
-			return fmt.Errorf("injector via must be a clean absolute path")
-		}
-	} else if len(injector.Args) > 0 {
-		return fmt.Errorf("injector args require via")
-	}
-	for _, arg := range injector.Args {
-		if !utf8.ValidString(arg) || strings.ContainsRune(arg, 0) {
-			return fmt.Errorf("injector args contain an invalid value")
-		}
-	}
-	return nil
-}
-
-func (symphony SymphonyOptionsV1) validate() error {
-	if len(symphony.Events) == 0 {
-		return fmt.Errorf("symphony requires at least one event")
-	}
-	seen := make(map[SymphonyEvent]struct{}, len(symphony.Events))
-	allowed := []SymphonyEvent{
-		SymphonyAfterCreate,
-		SymphonyBeforeRun,
-		SymphonyAfterRun,
-		SymphonyBeforeRemove,
-	}
-	for _, event := range symphony.Events {
-		if !slices.Contains(allowed, event) {
-			return fmt.Errorf("unknown symphony event %q", event)
-		}
-		if _, ok := seen[event]; ok {
-			return fmt.Errorf("duplicate symphony event %q", event)
-		}
-		seen[event] = struct{}{}
-	}
-	if strings.ContainsRune(symphony.WorkspaceKey, 0) || !utf8.ValidString(symphony.WorkspaceKey) {
-		return fmt.Errorf("symphony workspace_key is invalid")
-	}
-	return nil
+	return internallaunch.ValidatePrepareExecutionOptionsGrammar(toInternalExecutionOptions(options), internallaunch.PrepareExecutionOptionsPresence{
+		Injector: options.Wake.Injector != nil,
+		Symphony: options.Integrations.Symphony != nil,
+	})
 }
 
 func requireLaunchIntentFields(data []byte) error {

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -185,6 +185,34 @@ func TestLaunchAPIV1SchemaAcceptsGoldenAndRejectsHostileFields(t *testing.T) {
 	if err := schema.Validate(golden); err == nil {
 		t.Error("schema accepted non-runnable args smuggling")
 	}
+
+	for _, resultGolden := range []struct {
+		file       string
+		definition string
+	}{
+		{file: "prepare_result_v1.golden.json", definition: "PrepareResultV1"},
+		{file: "apply_result_v1.golden.json", definition: "ApplyResultV1"},
+	} {
+		data, err := os.ReadFile("testdata/" + resultGolden.file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var document map[string]any
+		if err := json.Unmarshal(data, &document); err != nil {
+			t.Fatal(err)
+		}
+		resultSchema, err := compiler.Compile("launch-api-v1.schema.json#/$defs/" + resultGolden.definition)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := resultSchema.Validate(document); err != nil {
+			t.Fatalf("schema rejected %s: %v", resultGolden.file, err)
+		}
+		document["caller_owned_backend_state"] = true
+		if err := resultSchema.Validate(document); err == nil {
+			t.Errorf("schema accepted hostile field in %s", resultGolden.file)
+		}
+	}
 }
 
 func assertSchemaPropertiesMatchType(t *testing.T, defs map[string]any, definition string, typ reflect.Type) {

--- a/launchapi/testdata/apply_result_v1.golden.json
+++ b/launchapi/testdata/apply_result_v1.golden.json
@@ -1,0 +1,41 @@
+{
+  "result_version": 1,
+  "outcome": "applied",
+  "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "plan_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "trust_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "semantic_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "backend": "commands",
+  "profile": "commands/portable/v1",
+  "roster": {
+    "desired": [
+      "claude"
+    ],
+    "present": [
+      "claude"
+    ],
+    "missing": [],
+    "extra": []
+  },
+  "observations": [
+    {
+      "handle": "claude",
+      "mailbox": "present",
+      "runnable": true,
+      "conversation": "ready",
+      "execution": "acknowledged",
+      "resource": "commands:claude"
+    }
+  ],
+  "commands": [
+    {
+      "argv": [
+        "amq",
+        "coop",
+        "exec",
+        "claude"
+      ],
+      "cwd": "/workspace/example"
+    }
+  ]
+}

--- a/launchapi/testdata/prepare_result_v1.golden.json
+++ b/launchapi/testdata/prepare_result_v1.golden.json
@@ -1,0 +1,61 @@
+{
+  "result_version": 1,
+  "outcome": "action_required",
+  "reason": "untrusted_config_digest",
+  "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "plan_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "trust_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "required_actions": [
+    {
+      "action_id": "trust-example",
+      "kind": "trust_confirmation",
+      "handles": [
+        "claude"
+      ],
+      "resources": [
+        "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      ],
+      "allowed_decisions": [
+        "trust_exact_subject",
+        "deny"
+      ],
+      "reason_code": "untrusted_config_digest"
+    }
+  ],
+  "preview": {
+    "target": {
+      "project_root": "/workspace/example",
+      "session_root": "/workspace/example/.agent-mail/collab",
+      "session": "collab"
+    },
+    "backend": "commands",
+    "profile": "commands/portable/v1",
+    "participants": [
+      {
+        "handle": "operator",
+        "runnable": false,
+        "planned_outcome": "observe_only"
+      }
+    ],
+    "roster": {
+      "desired": [
+        "operator"
+      ],
+      "present": [],
+      "missing": [
+        "operator"
+      ],
+      "extra": []
+    }
+  },
+  "observations": [
+    {
+      "handle": "operator",
+      "mailbox": "missing",
+      "runnable": false,
+      "conversation": "none",
+      "execution": "none",
+      "resource": ""
+    }
+  ]
+}

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -226,6 +226,9 @@ type ApplyResultV1 struct {
 	ResultVersion int    `json:"result_version"`
 	Outcome       string `json:"outcome"`
 	ReasonCode    string `json:"reason_code,omitempty"`
+	// FailureDetail is non-contract diagnostic prose for CLI stderr. It is
+	// deliberately excluded from the versioned JSON DTO.
+	FailureDetail string `json:"-"`
 	// SubjectDigest is the pre-mutation subject that this Apply request was
 	// authorized against, not a post-mutation Prepare snapshot.
 	SubjectDigest string `json:"subject_digest"`


### PR DESCRIPTION
## Frozen scope

Implements frozen WB2 design ccd0b5a9 unchanged.

## Wave rulings

- Wave 1: one internal launch validator owns the typed execution-option grammar used by both the public package and CLI.
- Wave 2: one public result encoder and shared V1 golden fixtures serve package, CLI, and schema parity. Unsupported launchers return a Prepare result and exit 6.
- P1-7: named parity exercises required digests, root-only changes, binding-only changes, and the semantic_digest compatibility alias.
- P1-9: real-binary rows cover the compatibility floor, multi-seat commands with a non-runnable operator, serialized Prepare decisions and fresh-process Apply, durable stale resume, roster drift, wrapper/wake/Symphony options, sibling-worktree exact-root message exchange, fresh-process readback, and real tmux execution.

## Review findings fixed

- Unsupported public launch initially returned exit 0. It now prints the typed Prepare result and exits 6 without writes.
- The README used invalid resume_policy value enabled and made a false legacy-vocabulary claim. Examples now use resume, and documentation consistently specifies resume, fresh, or disabled.
- The first sibling-worktree row proved only distinct discovery roots. It now proves the frozen property: both emitted commands use one absolute main-session root, emit no --session, exchange a real message through that queue, and create no sibling-local queue.

## GOLDEN-CHANGE

Adds launchapi/testdata/prepare_result_v1.golden.json and launchapi/testdata/apply_result_v1.golden.json. Semantic review confirmed stable public field names and ordering, required digest presence, semantic_digest byte equality with trust_digest, and identical package, CLI, and JSON-schema interpretation.

## Mutants killed in peer review

- Plain --plan auto-applies despite required actions: killed by TestPublicLaunchPlanNeverAutoAuthorizesRequiredActions and TestPublicLaunchUnsupportedIsExit6AndZeroWrite.
- --apply accepts --session, --launcher, or --root overrides: killed by TestPublicLaunchModeFlagRefusals.
- Compact or divergent result encoding: killed by TestCLIResultEncoderUsesPackageGoldens and TestResultV1GoldenEncoding.
- Commands emit --session instead of the exact root: killed by the sibling exact-root row in TestCompatibilityFloorAndEndToEndMatrix.
- Dropped typed-option grammar rules: both the package and CLI caller suites fail.
- Unsupported returns exit 0: the real-binary probe requires exit 6.
- Invalid README resume vocabulary: the documented example parses through the built binary.

## Verification

- go test ./... -count=1
- focused public API, golden, matrix, and tmux E2E race runs
- verbose PASS for all four TestCompatibilityFloorAndEndToEndMatrix rows
- verbose PASS for TestTmuxRealBinaryFreshServerRestartResumeLoop
- make ci with a fresh golangci-lint cache, 0 issues
