### PR TITLE
feat(launch): no_action aggregate and --require-agent; document symlink trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ exit `6` until that digest is trusted. An unknown `session resume` name exits
 `3` and writes nothing. Managed backends use a fail-closed recovery journal;
 see [Managed launch recovery](docs/launch-recovery.md).
 
+The stable executable path before symlink resolution is the trusted identity;
+retargeting that symlink is machine-owner territory, in the same trust class
+as changing `PATH`.
+
 The `commands` backend prints complete `coop exec` commands and exits `6`
 because executing them is the remaining operator action. Paste those emitted
 lines exactly, one per terminal. Do not reconstruct them from examples: they

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -58,6 +58,7 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 	freshFlag := fs.Bool("fresh", false, "Start fresh conversations for this launch")
 	allowFreshFlag := fs.Bool("allow-fresh-fallback", false, "Allow fresh conversations when saved identities are stale")
 	rebindFlag := fs.Bool("rebind", false, "Confirm a deliberate launcher binding change")
+	requireAgentFlag := fs.Bool("require-agent", false, "Require at least one agent to launch or attach")
 	planFlag := fs.String("plan", "", "Public LaunchIntentV1 file, or - for stdin")
 	prepareFlag := fs.Bool("prepare", false, "Prepare the public launch intent without mutation (requires --plan and --json)")
 	applyFlag := fs.String("apply", "", "Public ApplyRequestV1 file, or - for stdin (requires --json)")
@@ -78,7 +79,8 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 		if options.resumeOnly {
 			return UsageError("session resume does not accept --plan, --prepare, or --apply")
 		}
-		if flagWasVisited(fs, "fresh") || flagWasVisited(fs, "allow-fresh-fallback") || flagWasVisited(fs, "rebind") {
+		if flagWasVisited(fs, "fresh") || flagWasVisited(fs, "allow-fresh-fallback") ||
+			flagWasVisited(fs, "rebind") || flagWasVisited(fs, "require-agent") {
 			return UsageError("--plan, --prepare, and --apply do not accept legacy launch decision flags")
 		}
 		return runPublicLaunch(common, *sessionFlag, *launcherFlag, *planFlag, *prepareFlag, *applyFlag, fs)
@@ -210,6 +212,10 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 	result, err := launch.Reconcile(request)
 	if err != nil {
 		return err
+	}
+	if *requireAgentFlag && result.Outcome == launch.OutcomeNoAction && result.AggregateCode == ExitSuccess {
+		result.AggregateCode = ExitActionRequired
+		result.Reason = launch.ReasonNoAgentLaunched
 	}
 	if err := outputLaunchResult(common.JSON, result); err != nil {
 		return err

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -180,6 +180,7 @@ func TestPublicLaunchModeFlagRefusals(t *testing.T) {
 		{name: "mixed apply and plan", args: []string{"--apply", "apply.json", "--plan", "intent.json", "--json"}, want: "mutually exclusive"},
 		{name: "apply target override", args: []string{"--apply", "apply.json", "--session", "collab", "--json"}, want: "takes its target"},
 		{name: "legacy decision flag", args: []string{"--plan", "intent.json", "--fresh"}, want: "legacy launch decision flags"},
+		{name: "require agent is legacy only", args: []string{"--plan", "intent.json", "--require-agent"}, want: "legacy launch decision flags"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := runLaunch(test.args)

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -165,6 +165,53 @@ func TestLaunchNonInteractiveUntrustedIsExit6AndNoRuntimeWrites(t *testing.T) {
 	}
 }
 
+func TestLaunchNoActionOutcomeAndRequireAgent(t *testing.T) {
+	_, _ = launchCLIFixture(t, "collab")
+	launchAdapters = func(launch.ProjectConfig) map[string]launch.HarnessAdapter {
+		return map[string]launch.HarnessAdapter{"claude": launchFixtureAdapter{
+			available: false, reason: "executable_not_found",
+		}}
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error { return runLaunch([]string{"--json"}) })
+	if err != nil {
+		t.Fatalf("default all-unsupported launch: %v\n%s", err, stdout)
+	}
+	var result launch.ReconcileResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != launch.OutcomeNoAction || result.AggregateCode != ExitSuccess ||
+		len(result.Agents) != 1 || result.Agents[0].ConversationDisposition != launch.DispositionUnsupported {
+		t.Fatalf("default all-unsupported result = %#v", result)
+	}
+
+	for _, test := range []struct {
+		name string
+		run  func() error
+	}{
+		{name: "launch", run: func() error { return runLaunch([]string{"--require-agent", "--json"}) }},
+		{name: "session resume", run: func() error {
+			return runSession([]string{"resume", "collab", "--require-agent", "--json"})
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stdout, _, err := captureEnvOutput(t, test.run)
+			if GetExitCode(err) != ExitActionRequired {
+				t.Fatalf("exit=%d err=%v\n%s", GetExitCode(err), err, stdout)
+			}
+			var result launch.ReconcileResult
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.Outcome != launch.OutcomeNoAction || result.AggregateCode != ExitActionRequired ||
+				result.Reason != launch.ReasonNoAgentLaunched {
+				t.Fatalf("require-agent result = %#v", result)
+			}
+		})
+	}
+}
+
 func TestLaunchWithoutExecutionRemintsAndResumeJSONKeepsSchema(t *testing.T) {
 	project, _ := launchCLIFixture(t, "collab", "empty")
 	launchIsTerminal = func() bool { return true }

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -240,7 +240,7 @@ func applyUnderAuthority(ctx context.Context, request ApplyRequest, dependencies
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	if reconciled.AggregateCode == 0 && reconciled.Outcome != "" {
+	if reconciled.AggregateCode == 0 && reconciled.Outcome != "" && reconciled.Outcome != OutcomeNoAction {
 		result.Outcome = ApplyOutcomeApplied
 		result.ReasonCode = ""
 	} else {

--- a/internal/launch/apply_test.go
+++ b/internal/launch/apply_test.go
@@ -12,6 +12,61 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
+type applyUnavailableAdapter struct{ prepareTestAdapter }
+
+func (adapter applyUnavailableAdapter) Capabilities(context.Context) AdapterCapabilities {
+	return AdapterCapabilities{
+		Provider: adapter.provider, Mode: adapter.Mode(), Available: false,
+		ProviderVersion: "test", Reason: "executable_not_found",
+	}
+}
+
+func TestApplyDoesNotPromoteNoActionToApplied(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	base := filepath.Join(root, "mail")
+	for _, path := range []string{project, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, SessionRoot: filepath.Join(base, "collab"), Session: "collab"},
+		Launcher: "test", IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'f'}, 64)),
+		Participants: []PrepareParticipant{{
+			Handle: "claude", Provider: ClaudeProvider, Executable: "claude", Runnable: true,
+			Cwd: project, ResumePolicy: ResumeDisabled,
+		}},
+	}}
+	backend := &prepareTestBackend{}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"},
+		AdapterFor: func(provider, executable string) HarnessAdapter {
+			return applyUnavailableAdapter{prepareTestAdapter{provider: provider}}
+		},
+		HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	for _, action := range prepared.RequiredActions {
+		request.Decisions = append(request.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: "trust_exact_subject"})
+	}
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "launch_action_required" {
+		t.Fatalf("Apply result = %#v, want action_required without public no_action promotion", result)
+	}
+	if backend.creates != 0 {
+		t.Fatalf("unavailable adapter created backend resources: %d", backend.creates)
+	}
+}
+
 func TestApplyPublishedSessionCannotLoseLeaseTransitionRace(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "project")

--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -57,6 +57,7 @@ const (
 	OutcomeCommandsEmitted Outcome = "commands_emitted"
 	OutcomeActionRequired  Outcome = "action_required"
 	OutcomeUnsupported     Outcome = "unsupported"
+	OutcomeNoAction        Outcome = "no_action"
 	OutcomeAttached        Outcome = "attached"
 	OutcomeClosed          Outcome = "closed"
 )

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -31,6 +31,7 @@ const (
 
 const (
 	ReasonNoSavedConversation    = "no_saved_conversation"
+	ReasonNoAgentLaunched        = "no_agent_launched"
 	ReasonPriorLaunchNotExecuted = "prior_launch_not_executed"
 	ReasonStaleConversation      = "stale_conversation"
 )
@@ -159,7 +160,10 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	}
 	if len(planned) == 0 {
 		result.AggregateCode = aggregateReconcileCode(result.Agents)
-		if result.AggregateCode == 6 {
+		switch result.AggregateCode {
+		case 0:
+			result.Outcome = OutcomeNoAction
+		case 6:
 			result.Outcome = OutcomeActionRequired
 			result.Reason = firstReconcileReason(result.Agents, 6)
 		}

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -65,6 +65,7 @@ func TestReconcileUsesAndRetainsCallerHeldLease(t *testing.T) {
 
 type reconcileAdapter struct {
 	name               string
+	capabilityProvider string
 	mode               AdapterMode
 	available          bool
 	reason             string
@@ -77,8 +78,12 @@ func (a reconcileAdapter) Name() string               { return a.name }
 func (a reconcileAdapter) Mode() AdapterMode          { return a.mode }
 func (a reconcileAdapter) CommittedEnvKeys() []string { return nil }
 func (a reconcileAdapter) Capabilities(context.Context) AdapterCapabilities {
+	provider := a.name
+	if a.capabilityProvider != "" {
+		provider = a.capabilityProvider
+	}
 	return AdapterCapabilities{
-		Provider: a.name, Mode: a.mode, Available: a.available,
+		Provider: provider, Mode: a.mode, Available: a.available,
 		ProviderVersion: "test", Fresh: a.available && !a.freshUnsupported,
 		Resume:  a.available && !a.resumeUnsupported,
 		Capture: a.available && a.mode == AdapterModeCapture && !a.captureUnsupported, Reason: a.reason,
@@ -790,8 +795,20 @@ func TestReconcileUntrustedAndRosterDriftAreStructured(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.AggregateCode != 0 || result.Agents[0].ConversationDisposition != DispositionUnsupported || backend.creates != 0 {
+	if result.AggregateCode != 0 || result.Outcome != OutcomeNoAction ||
+		result.Agents[0].ConversationDisposition != DispositionUnsupported || backend.creates != 0 {
 		t.Fatalf("roster drift result=%#v", result)
+	}
+	req.Adapters["claude"] = reconcileAdapter{
+		name: "claude", capabilityProvider: "wrong-provider", mode: AdapterModeMint, available: true,
+	}
+	result, err = Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 1 || result.Outcome == OutcomeNoAction ||
+		result.Agents[0].ConversationDisposition != DispositionDegraded || backend.creates != 0 {
+		t.Fatalf("degraded result=%#v", result)
 	}
 }
 


### PR DESCRIPTION
Implements #509 items 2 and 3. Item 1 is closed by the cmux and Ghostty backend beads.

Summary:
- Report legacy `ReconcileResult.outcome` as `no_action` only when no agents are planned and the aggregate remains successful. Code-1 degraded and code-6 action-required results are not masked.
- Add legacy-only `--require-agent` to `amq launch` and `amq session resume`; `no_action` then exits 6 with `no_agent_launched` while retaining the `no_action` outcome.
- Reject `--require-agent` in the public plan/prepare/apply mode and prevent internal `no_action` from being promoted to public `applied`.
- Document that the stable executable path before symlink resolution is the trusted identity and symlink retargeting is machine-owner territory.

Verification:
- `GOLANGCI_LINT_CACHE=<fresh-dir> make ci` — exit 0, lint 0 issues.
- `go test ./internal/launch ./internal/cli -count=1`
- Focused race tests for no-action, require-agent, public refusal, and Apply boundary.
- Peer execution verified provider-absent launch, both require-agent entry points, public-mode refusal, and three hostile mutants.