### PR TITLE
feat(launch): add cursor-agent capture adapter

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -50,6 +50,10 @@ does not replace committed project configuration.
 
 `resume_policy` accepts exactly `resume`, `fresh`, or `disabled`.
 
+The v1 adapter set supports Claude Code, Codex CLI, and Cursor CLI capture at
+exact version `2026.08.11-e8db854`. Grok and Pi are excluded because they have
+no provider CLI; Gemini CLI and OpenCode also remain outside this adapter set.
+
 ## Prepare and Apply
 
 Prepare is read-only. It returns the exact subject, plan, and trust digests, a

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -245,6 +245,8 @@ func defaultLaunchAdapters(cfg launch.ProjectConfig) map[string]launch.HarnessAd
 			adapters[agent.Adapter] = launch.NewClaudeAdapter(agent.Command[0])
 		case launch.CodexProvider:
 			adapters[agent.Adapter] = launch.NewCodexAdapter(agent.Command[0])
+		case launch.CursorProvider:
+			adapters[agent.Adapter] = launch.NewCursorAdapter(agent.Command[0])
 		}
 	}
 	return adapters

--- a/internal/cli/launch_exec_reexec_unix_test.go
+++ b/internal/cli/launch_exec_reexec_unix_test.go
@@ -139,3 +139,90 @@ func TestPrivateLaunchWrapperAcknowledgesThenRevertsFailedExec(t *testing.T) {
 		t.Fatalf("reverted record = %#v, %v", record, err)
 	}
 }
+
+func TestPrivateCursorLaunchWrapperExecsOnlyResolvedConversationSlot(t *testing.T) {
+	project := t.TempDir()
+	session := filepath.Join(project, "session")
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	conversationID := "018f1f2a-bc34-71bd-9056-23838e27f859"
+	provider := filepath.Join(t.TempDir(), "cursor-agent")
+	script := "#!/bin/sh\n[ \"$1\" = create-chat ] || exit 91\nprintf '%s\\n' " + conversationID + "\n"
+	if err := os.WriteFile(provider, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	amqExecutable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := "79797979-7979-4797-8797-797979797979"
+	placeholder := "__AMQ_CONVERSATION_ID__"
+	targetArgv := []string{provider, "--resume", placeholder}
+	lease, err := launch.AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("cursor"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := launch.NewExecutionTicket(launch.ExecutionTicketRequest{
+		Handle: "cursor", LaunchNonce: nonce, Mode: launch.AdapterModeCapture, Provider: launch.CursorProvider,
+		ProviderVersion: "2026.08.11-e8db854", PreSpawnAcquire: true,
+		Backend: launch.CommandsBackendName, Profile: launch.CommandsProfile().Identity(),
+		ProjectRoot: project, SessionRoot: session, Cwd: project,
+		ProviderExecutable: provider, AMQExecutable: amqExecutable, TargetArgv: targetArgv,
+		DynamicArgv: []launch.DynamicArg{{Index: 2, Kind: launch.DynamicArgConversationID}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteExecutionTicket(root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteConversation(root, lease, launch.ConversationRecord{
+		Version: launch.ConversationVersion, Handle: "cursor", State: launch.CapturePending,
+		ProviderVersion: "2026.08.11-e8db854", LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+	sentinel := errors.New("provider exec failed")
+	oldExec := launchExecProcess
+	var gotArgv []string
+	launchExecProcess = func(_ string, argv, _ []string) error {
+		gotArgv = slices.Clone(argv)
+		return sentinel
+	}
+	t.Cleanup(func() { launchExecProcess = oldExec })
+	err = runLaunchExec([]string{"--root", session, "--handle", "cursor", "--nonce", nonce, "--target", provider, "--", provider, "--resume", placeholder})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("wrapper error = %v, want provider exec failure", err)
+	}
+	if !slices.Equal(gotArgv, []string{provider, "--resume", conversationID}) {
+		t.Fatalf("provider argv = %#v", gotArgv)
+	}
+	loaded, err := launch.LoadExecutionTicket(root, "cursor")
+	if err != nil || loaded.State != launch.ExecutionIdentityAcquired || loaded.ConversationID != conversationID {
+		t.Fatalf("reverted Cursor ticket = %#v, %v", loaded, err)
+	}
+}

--- a/internal/cli/launch_exec_unix.go
+++ b/internal/cli/launch_exec_unix.go
@@ -53,13 +53,19 @@ func runLaunchExec(args []string) error {
 	if err != nil {
 		return ActionRequiredError("resolve launch wrapper executable: %v", err)
 	}
-	if _, err := launch.PrepareExecution(root, *handleFlag, *nonceFlag, launch.ExecutionEnvelope{
+	prepared, err := launch.PrepareExecution(root, *handleFlag, *nonceFlag, launch.ExecutionEnvelope{
 		Cwd: cwd, AMQExecutable: amqExecutable, ProviderExecutable: *targetFlag,
 		TargetArgv: targetArgv, Environment: os.Environ(), Execution: executionOptions,
-	}); err != nil {
+	})
+	if err != nil {
 		return ActionRequiredError("refusing managed launch execution: %v", err)
 	}
-	execErr := launchExecProcess(*targetFlag, targetArgv, os.Environ())
+	resolvedArgv, err := launch.ResolveExecutionArgv(prepared)
+	if err != nil {
+		revertErr := launch.RevertExecution(root, *handleFlag, *nonceFlag)
+		return errors.Join(ActionRequiredError("refusing unresolved managed launch execution: %v", err), revertErr)
+	}
+	execErr := launchExecProcess(*targetFlag, resolvedArgv, os.Environ())
 	if execErr == nil {
 		execErr = fmt.Errorf("provider exec returned without replacing process")
 	}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -86,6 +86,7 @@ var (
 		return []launch.HarnessAdapter{
 			launch.NewClaudeAdapter(launch.ClaudeProvider),
 			launch.NewCodexAdapter(launch.CodexProvider),
+			launch.NewCursorAdapter(launch.CursorProvider),
 		}
 	}
 	setupLookPath   = exec.LookPath

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -14,6 +14,7 @@ import (
 const (
 	ClaudeProvider = "claude"
 	CodexProvider  = "codex"
+	CursorProvider = "cursor-agent"
 )
 
 // HarnessAdapter owns conversation identity and produces backend-ready plans.
@@ -37,6 +38,7 @@ type AdapterCapabilities struct {
 	Fresh           bool        `json:"fresh"`
 	Resume          bool        `json:"resume"`
 	Capture         bool        `json:"capture"`
+	PreSpawnAcquire bool        `json:"pre_spawn_acquire"`
 	Reason          string      `json:"reason,omitempty"`
 }
 
@@ -112,11 +114,18 @@ func ValidateStaticProviderInput(executable string, args []string, env map[strin
 		envRules, argRules, bypassAllowed = claudeEnvRules(), claudeArgRules(), claudeBypassArgs()
 	case CodexProvider:
 		envRules, argRules, bypassAllowed = codexEnvRules(), codexArgRules(), codexBypassArgs()
+	case CursorProvider:
+		envRules, argRules, bypassAllowed = cursorEnvRules(), cursorArgRules(), cursorBypassArgs()
 	default:
 		return "", fmt.Errorf("executable %q does not select an adapter-known provider", executable)
 	}
 	if err := validateStaticProviderArgs(args, argRules, bypassAllowed); err != nil {
 		return "", err
+	}
+	if provider == CursorProvider {
+		if err := validateCursorBypassArgs(args, true); err != nil {
+			return "", err
+		}
 	}
 	if err := validateCommittedEnv(env, envRules); err != nil {
 		return "", err
@@ -135,6 +144,8 @@ func PartitionStaticProviderArgs(provider string, args []string) (committed, byp
 		argRules, bypassAllowed = claudeArgRules(), claudeBypassArgs()
 	case CodexProvider:
 		argRules, bypassAllowed = codexArgRules(), codexBypassArgs()
+	case CursorProvider:
+		argRules, bypassAllowed = cursorArgRules(), cursorBypassArgs()
 	default:
 		return nil, nil, fmt.Errorf("unknown provider %q", provider)
 	}
@@ -221,6 +232,9 @@ func ValidateAdapterCapabilities(adapter HarnessAdapter, capabilities AdapterCap
 	}
 	if capabilities.Capture && adapter.Mode() != AdapterModeCapture {
 		return fmt.Errorf("adapter %s capture capability conflicts with %q mode", adapter.Name(), adapter.Mode())
+	}
+	if capabilities.PreSpawnAcquire && (!capabilities.Capture || adapter.Mode() != AdapterModeCapture) {
+		return fmt.Errorf("adapter %s pre-spawn acquisition requires capture mode", adapter.Name())
 	}
 	return nil
 }

--- a/internal/launch/adapter_cursor.go
+++ b/internal/launch/adapter_cursor.go
@@ -1,0 +1,156 @@
+package launch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const cursorCaptureVersion = "2026.08.11-e8db854"
+
+const CursorCreateChatV1 CaptureEvidenceSource = "cursor_create_chat_v1"
+
+type CursorAdapter struct {
+	executable string
+	probe      commandProbe
+}
+
+func NewCursorAdapter(executable string) *CursorAdapter {
+	return &CursorAdapter{executable: executable, probe: systemCommandProbe{}}
+}
+
+func (adapter *CursorAdapter) Name() string      { return CursorProvider }
+func (adapter *CursorAdapter) Mode() AdapterMode { return AdapterModeCapture }
+
+func (adapter *CursorAdapter) CommittedEnvKeys() []string {
+	return committedEnvKeys(cursorEnvRules())
+}
+
+func (adapter *CursorAdapter) ValidateCommittedConfig(request CommittedConfigRequest) error {
+	if err := validateCursorBypassArgs(request.Args, true); err != nil {
+		return err
+	}
+	return validateCommittedConfig(request, cursorEnvRules(), cursorArgRules())
+}
+
+func (adapter *CursorAdapter) Capabilities(ctx context.Context) AdapterCapabilities {
+	result := AdapterCapabilities{Provider: CursorProvider, Mode: adapter.Mode()}
+	executable, err := adapter.probe.LookPath(adapter.executable)
+	if err != nil {
+		result.Reason = "executable_not_found"
+		return result
+	}
+	version, err := adapter.probe.Output(ctx, executable, "--version")
+	if err != nil {
+		result.Reason = "version_probe_failed"
+		return result
+	}
+	help, helpErr := adapter.probe.Output(ctx, executable, "--help")
+	createHelp, createErr := adapter.probe.Output(ctx, executable, "create-chat", "--help")
+	if helpErr != nil || createErr != nil ||
+		!strings.Contains(string(help), "--resume [chatId]") ||
+		!strings.Contains(string(help), "--output-format <format>") ||
+		!strings.Contains(string(help), "create-chat") ||
+		!strings.Contains(string(createHelp), "return its ID") {
+		result.Reason = "identity_contract_unsupported"
+		return result
+	}
+	result.Available = true
+	result.Executable = executable
+	result.ProviderVersion = strings.TrimSpace(string(version))
+	if result.ProviderVersion == "" {
+		result.Available = false
+		result.Reason = "version_probe_failed"
+		return result
+	}
+	result.Resume = true
+	if result.ProviderVersion != cursorCaptureVersion {
+		result.Reason = "capture_version_unsupported"
+		return result
+	}
+	result.Fresh = true
+	result.Capture = true
+	result.PreSpawnAcquire = true
+	return result
+}
+
+func (adapter *CursorAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) {
+	if err := validateCursorBypassArgs(request.BypassArgs, false); err != nil {
+		return AgentPlan{}, err
+	}
+	executable, err := validatePlanRequest(request, adapter.executable, CursorProvider, cursorEnvRules(), cursorArgRules(), cursorBypassArgs())
+	if err != nil {
+		return AgentPlan{}, err
+	}
+	argv := append([]string{executable}, request.CommittedArgs...)
+	argv = append(argv, request.BypassArgs...)
+	argv = append(argv, "--resume", preSpawnConversationPlaceholder)
+	plan := AgentPlan{
+		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
+		AdapterMode: AdapterModeCapture, ResumePolicy: request.ResumePolicy, LaunchNonce: request.LaunchNonce,
+		DynamicArgv: []DynamicArg{{Index: len(argv) - 1, Kind: DynamicArgConversationID}}, PreSpawnAcquire: true,
+	}
+	if err := ValidateAdapterPlan(adapter, plan); err != nil {
+		return AgentPlan{}, err
+	}
+	return plan, nil
+}
+
+func (adapter *CursorAdapter) PlanResume(request ResumeRequest) (AgentPlan, error) {
+	if request.ResumePolicy != ResumeEnabled {
+		return AgentPlan{}, fmt.Errorf("resume plan requires resume policy %q", ResumeEnabled)
+	}
+	if err := validateConversation(request.Conversation, CursorProvider); err != nil {
+		return AgentPlan{}, err
+	}
+	if err := validateCursorBypassArgs(request.BypassArgs, false); err != nil {
+		return AgentPlan{}, err
+	}
+	executable, err := validatePlanRequest(request.PlanRequest, adapter.executable, CursorProvider, cursorEnvRules(), cursorArgRules(), cursorBypassArgs())
+	if err != nil {
+		return AgentPlan{}, err
+	}
+	argv := append([]string{executable}, request.CommittedArgs...)
+	argv = append(argv, request.BypassArgs...)
+	argv = append(argv, "--resume", request.Conversation.ID)
+	plan := AgentPlan{
+		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
+		AdapterMode: AdapterModeCapture, ResumePolicy: request.ResumePolicy, LaunchNonce: request.LaunchNonce,
+		ConversationID: request.Conversation.ID,
+		DynamicArgv:    []DynamicArg{{Index: len(argv) - 1, Kind: DynamicArgConversationID}},
+	}
+	if err := ValidateAdapterPlan(adapter, plan); err != nil {
+		return AgentPlan{}, err
+	}
+	return plan, nil
+}
+
+func (adapter *CursorAdapter) CaptureIdentity(request CaptureRequest) CaptureResult {
+	return captureCursorIdentity(request)
+}
+
+func cursorEnvRules() map[string]valueRule { return commonCommittedEnvRules() }
+
+func cursorArgRules() map[string]argumentRule {
+	return map[string]argumentRule{"--model": {value: true, validate: safeArgumentValue}}
+}
+
+func cursorBypassArgs() map[string]struct{} {
+	return map[string]struct{}{"--force": {}, "--yolo": {}}
+}
+
+func validateCursorBypassArgs(args []string, mixed bool) error {
+	count := 0
+	for _, arg := range args {
+		if _, ok := cursorBypassArgs()[arg]; ok {
+			count++
+		}
+	}
+	if !mixed {
+		count = len(args)
+	}
+	if count > 1 {
+		return fmt.Errorf("cursor bypass accepts at most one of --force or --yolo")
+	}
+	return nil
+}

--- a/internal/launch/adapter_cursor_live_test.go
+++ b/internal/launch/adapter_cursor_live_test.go
@@ -1,0 +1,353 @@
+package launch
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const cursorLivePrompt = "Reply with exactly AMQ_OK. Do not use tools."
+
+func TestCursorLiveResumeManagedExecutionAndCrashReuse(t *testing.T) {
+	if os.Getenv("AMQ_CURSOR_LIVE") != "1" {
+		t.Skip("set AMQ_CURSOR_LIVE=1 to create one real Cursor chat and run the resume proof")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+
+	adapter := NewCursorAdapter("cursor-agent")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	capabilities := adapter.Capabilities(ctx)
+	if !capabilities.Available || !capabilities.Capture || !capabilities.PreSpawnAcquire || capabilities.ProviderVersion != cursorCaptureVersion {
+		t.Fatalf("Cursor live capture capability is unavailable: %#v", capabilities)
+	}
+	t.Logf("Cursor executable: %q", capabilities.Executable)
+
+	fixture := newCursorLiveExecutionFixture(t, capabilities.Executable)
+	t.Logf("create-chat argv: %q %q", fixture.ticket.ProviderExecutable, []string{"create-chat"})
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-cursor-live-%d-%d", os.Getpid(), time.Now().UnixNano())
+	t.Cleanup(func() { stopTmuxTestServer(t, backend) })
+
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{{
+		Handle: "cursor", Argv: fixture.ticket.TargetArgv, Cwd: fixture.project,
+		AdapterMode: AdapterModeCapture, ResumePolicy: ResumeFresh, LaunchNonce: fixture.nonce,
+		Execution: fixture.ticket.Execution,
+	}}}
+	created, err := backend.Create(CreateRequest{
+		ProjectRoot: fixture.project, Session: "collab", Plan: plan,
+		AMQPath: fixture.amq, Root: fixture.root,
+	})
+	if err != nil {
+		t.Fatalf("managed tmux/coop-exec create: %v", err)
+	}
+	if created.Outcome != OutcomeCreated {
+		t.Fatalf("managed tmux/coop-exec outcome = %q", created.Outcome)
+	}
+
+	acknowledged := waitForCursorLiveTicket(t, fixture.root, fixture.nonce)
+	conversationID := acknowledged.ConversationID
+	t.Logf("created Cursor chat ID: %s", conversationID)
+	if len(acknowledged.EvidenceRefs) != 1 {
+		t.Fatalf("acknowledged ticket evidence refs = %#v", acknowledged.EvidenceRefs)
+	}
+	record, err := LoadConversation(fixture.root, "cursor")
+	if err != nil || record.State != CaptureReady || record.Identity != (ConversationIdentity{Provider: CursorProvider, ID: conversationID}) ||
+		len(record.EvidenceRefs) != 1 || record.EvidenceRefs[0] != acknowledged.EvidenceRefs[0] {
+		t.Fatalf("managed conversation = %#v, %v", record, err)
+	}
+	evidence, _, err := ReadEvidence(fixture.root, acknowledged.EvidenceRefs[0])
+	if err != nil {
+		t.Fatalf("read immutable provider evidence: %v", err)
+	}
+	payload, err := decodeCursorCreateChatPayload(evidence.Payload)
+	if err != nil || payload.ConversationID != conversationID || payload.Handle != "cursor" || payload.LaunchNonce != fixture.nonce {
+		t.Fatalf("provider evidence payload = %#v, %v", payload, err)
+	}
+
+	processArgv := cursorLivePaneArgv(t, backend, capabilities.Executable, conversationID)
+	t.Logf("managed provider process argv: %s", processArgv)
+	if !strings.Contains(processArgv, "--resume") || !strings.Contains(processArgv, conversationID) {
+		t.Fatalf("managed provider process argv does not carry exact resume identity: %s", processArgv)
+	}
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: fixture.root})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("close managed Cursor tmux process: %v", err)
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		cursorLiveResume(t, capabilities.Executable, fixture.project, conversationID, attempt)
+	}
+
+	crashFixture := newExecutionFixture(t)
+	crashNonce := "85858585-8585-4585-8585-858585858585"
+	_, envelope := seedPendingCursorExecution(t, crashFixture, crashNonce)
+	acquirer := &countingCursorAcquirer{id: conversationID}
+	crash := errors.New("live receipt crash after evidence persistence")
+	_, err = prepareExecution(crashFixture.root, "cursor", crashNonce, envelope, acquirer, func(stage string) error {
+		if stage == "evidence_persisted" {
+			return crash
+		}
+		return nil
+	})
+	if !errors.Is(err, crash) {
+		t.Fatalf("crash injection error = %v", err)
+	}
+	retried, err := prepareExecution(crashFixture.root, "cursor", crashNonce, envelope, acquirer, nil)
+	if err != nil || retried.State != ExecutionAcknowledged || retried.ConversationID != conversationID || acquirer.calls != 1 {
+		t.Fatalf("crash restart = %#v, %v; create-chat calls = %d", retried, err, acquirer.calls)
+	}
+	t.Logf("crash restart reused Cursor chat ID %s with one acquisition", conversationID)
+}
+
+type cursorLiveFixture struct {
+	project, amq, nonce string
+	root                *fsq.DeliveryRoot
+	ticket              ExecutionTicket
+}
+
+func newCursorLiveExecutionFixture(t *testing.T, provider string) cursorLiveFixture {
+	t.Helper()
+	project := t.TempDir()
+	git := exec.Command("git", "init", "--quiet")
+	git.Dir = project
+	if output, err := git.CombinedOutput(); err != nil {
+		t.Fatalf("initialize empty Cursor live project: %v\n%s", err, output)
+	}
+	session := filepath.Join(project, ".agent-mail", "collab")
+	if err := fsq.EnsureAgentDirs(session, "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+
+	moduleCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	moduleRoot := filepath.Clean(filepath.Join(moduleCwd, "..", ".."))
+	amq := filepath.Join(t.TempDir(), "amq")
+	build := exec.Command("go", "build", "-o", amq, "./cmd/amq")
+	build.Dir = moduleRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build live amq executable: %v\n%s", err, output)
+	}
+	provider, err = filepath.EvalSymlinks(provider)
+	if err != nil {
+		t.Fatalf("resolve Cursor executable: %v", err)
+	}
+	nonce := "84848484-8484-4484-8484-848484848484"
+	options := &PrepareExecutionOptions{WakeMode: "disabled", AuditReason: "Cursor live managed resume proof"}
+	targetArgv := []string{provider, "--resume", preSpawnConversationPlaceholder}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "cursor", LaunchNonce: nonce, Mode: AdapterModeCapture, Provider: CursorProvider,
+		ProviderVersion: cursorCaptureVersion, PreSpawnAcquire: true,
+		Backend: LauncherTMux, Profile: TmuxProfile().Identity(),
+		ProjectRoot: project, SessionRoot: session, Cwd: project,
+		ProviderExecutable: provider, AMQExecutable: amq, TargetArgv: targetArgv,
+		DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgConversationID}}, Execution: options,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("cursor"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: "cursor", State: CapturePending,
+		ProviderVersion: cursorCaptureVersion, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	return cursorLiveFixture{project: project, amq: amq, nonce: nonce, root: root, ticket: ticket}
+}
+
+func waitForCursorLiveTicket(t *testing.T, root *fsq.DeliveryRoot, nonce string) ExecutionTicket {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	var last ExecutionTicket
+	var lastErr error
+	for time.Now().Before(deadline) {
+		last, lastErr = LoadExecutionTicket(root, "cursor")
+		if lastErr == nil && last.LaunchNonce == nonce && last.State == ExecutionAcknowledged {
+			return last
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("wait for managed Cursor acknowledgement: ticket=%#v error=%v", last, lastErr)
+	return ExecutionTicket{}
+}
+
+func cursorLivePaneArgv(t *testing.T, backend *TmuxBackend, provider, conversationID string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	output, err := backend.run(ctx, backend.args("list-panes", "-a", "-F", "#{pane_pid}")...)
+	if err != nil {
+		t.Fatalf("list managed Cursor pane: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(output))
+	if err != nil || pid <= 0 {
+		t.Fatalf("managed Cursor pane pid = %q", strings.TrimSpace(output))
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		command := exec.Command("ps", "-ww", "-axo", "pid=,ppid=,command=")
+		argv, psErr := command.Output()
+		if psErr == nil {
+			if found := findCursorLiveDescendantArgv(argv, pid, filepath.Base(provider), conversationID); found != "" {
+				return found
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("managed Cursor process %d never exposed resume identity %s", pid, conversationID)
+	return ""
+}
+
+func findCursorLiveDescendantArgv(output []byte, panePID int, providerBase, conversationID string) string {
+	type process struct {
+		parent int
+		argv   string
+	}
+	processes := make(map[int]process)
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 3 {
+			continue
+		}
+		pid, pidErr := strconv.Atoi(fields[0])
+		parent, parentErr := strconv.Atoi(fields[1])
+		if pidErr == nil && parentErr == nil {
+			processes[pid] = process{parent: parent, argv: strings.Join(fields[2:], " ")}
+		}
+	}
+	for pid, candidate := range processes {
+		if !strings.Contains(candidate.argv, providerBase) || !strings.Contains(candidate.argv, "--resume") || !strings.Contains(candidate.argv, conversationID) {
+			continue
+		}
+		for current := pid; current > 0; current = processes[current].parent {
+			if current == panePID {
+				return candidate.argv
+			}
+			if _, ok := processes[current]; !ok {
+				break
+			}
+		}
+	}
+	return ""
+}
+
+func cursorLiveResume(t *testing.T, executable, cwd, conversationID string, attempt int) {
+	t.Helper()
+	argv := []string{"--resume", conversationID, "--print", "--trust", "--output-format", "stream-json", "--mode", "ask", "--model", "auto", cursorLivePrompt}
+	t.Logf("resume %d argv: %q %q", attempt, executable, argv)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	command := exec.CommandContext(ctx, executable, argv...)
+	command.Dir = cwd
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	stdout, err := command.Output()
+	if err != nil {
+		t.Fatalf("Cursor resume %d failed: %v\nstderr: %s\nstdout: %s", attempt, err, stderr.String(), stdout)
+	}
+	if err := validateCursorLiveStream(stdout, conversationID); err != nil {
+		t.Fatalf("Cursor resume %d stream: %v\nstdout: %s", attempt, err, stdout)
+	}
+	t.Logf("resume %d PASS: exit 0, one terminal success, all session_id values equal %s", attempt, conversationID)
+}
+
+func validateCursorLiveStream(stdout []byte, conversationID string) error {
+	type event struct {
+		Type      string `json:"type"`
+		Subtype   string `json:"subtype"`
+		SessionID string `json:"session_id"`
+		IsError   bool   `json:"is_error"`
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(stdout))
+	events, terminal := 0, 0
+	for scanner.Scan() {
+		if len(bytes.TrimSpace(scanner.Bytes())) == 0 {
+			continue
+		}
+		var got event
+		if err := json.Unmarshal(scanner.Bytes(), &got); err != nil {
+			return fmt.Errorf("decode NDJSON event %d: %w", events+1, err)
+		}
+		events++
+		if got.SessionID != conversationID {
+			return fmt.Errorf("event %d session_id = %q, want %q", events, got.SessionID, conversationID)
+		}
+		if got.Type == "tool_call" {
+			return fmt.Errorf("event %d used a tool despite the fixed no-tool prompt", events)
+		}
+		if got.Type == "result" {
+			if got.Subtype != "success" || got.IsError {
+				return fmt.Errorf("terminal event %d is not successful", events)
+			}
+			terminal++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if events == 0 || terminal != 1 {
+		return fmt.Errorf("events=%d terminal_success=%d, want nonzero and exactly one", events, terminal)
+	}
+	return nil
+}
+
+func TestValidateCursorLiveStream(t *testing.T) {
+	id := "018f1f2a-bc34-71bd-9056-23838e27f859"
+	terminal := "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"session_id\":\"" + id + "\"}\n"
+	valid := []byte("{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"" + id + "\"}\n" + terminal)
+	if err := validateCursorLiveStream(valid, id); err != nil {
+		t.Fatalf("valid stream: %v", err)
+	}
+	for name, hostile := range map[string][]byte{
+		"wrong identity": bytes.ReplaceAll(valid, []byte(id), []byte("028f1f2a-bc34-71bd-9056-23838e27f859")),
+		"no terminal":    []byte("{\"type\":\"system\",\"session_id\":\"" + id + "\"}\n"),
+		"two terminals":  []byte(string(valid) + terminal),
+		"tool call":      []byte("{\"type\":\"tool_call\",\"session_id\":\"" + id + "\"}\n" + string(valid)),
+		"invalid json":   []byte("not-json\n"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateCursorLiveStream(hostile, id); err == nil {
+				t.Fatal("hostile stream was accepted")
+			}
+		})
+	}
+}

--- a/internal/launch/adapter_cursor_test.go
+++ b/internal/launch/adapter_cursor_test.go
@@ -1,0 +1,93 @@
+package launch
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func cursorProbe(version string) fakeCommandProbe {
+	return fakeCommandProbe{path: "/bin/cursor-agent", outputs: map[string]string{
+		"--version":          version + "\n",
+		"--help":             "commands: create-chat --resume [chatId] --output-format <format>",
+		"create-chat --help": "Create a new chat and return its ID",
+	}}
+}
+
+func TestCursorCapabilitiesRequireExactCaptureVersion(t *testing.T) {
+	adapter := NewCursorAdapter("cursor-agent")
+	adapter.probe = cursorProbe(cursorCaptureVersion)
+	got := adapter.Capabilities(context.Background())
+	if !got.Available || !got.Fresh || !got.Resume || !got.Capture || !got.PreSpawnAcquire || got.ProviderVersion != cursorCaptureVersion {
+		t.Fatalf("pinned Cursor capabilities = %#v", got)
+	}
+	if err := ValidateAdapterCapabilities(adapter, got); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter.probe = cursorProbe("2026.08.12-unknown")
+	got = adapter.Capabilities(context.Background())
+	if !got.Available || got.Fresh || !got.Resume || got.Capture || got.PreSpawnAcquire || got.Reason != "capture_version_unsupported" {
+		t.Fatalf("untested Cursor capabilities = %#v", got)
+	}
+}
+
+func TestCursorPlansAcquireBeforeFreshResume(t *testing.T) {
+	project, executable := testExecutable(t, CursorProvider)
+	adapter := NewCursorAdapter(executable)
+	request := planRequest(project, CursorProvider)
+	request.CommittedArgs = []string{"--model", "auto"}
+	request.BypassArgs = []string{"--force"}
+
+	fresh, err := adapter.PlanFresh(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFresh := []string{"--model", "auto", "--force", "--resume", preSpawnConversationPlaceholder}
+	if !reflect.DeepEqual(fresh.Argv[1:], wantFresh) || !fresh.PreSpawnAcquire || fresh.ConversationID != "" ||
+		len(fresh.DynamicArgv) != 1 || fresh.DynamicArgv[0].Kind != DynamicArgConversationID {
+		t.Fatalf("fresh Cursor plan = %#v", fresh)
+	}
+
+	resume, err := adapter.PlanResume(ResumeRequest{
+		PlanRequest: request, Conversation: ConversationIdentity{Provider: CursorProvider, ID: testConversationID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resume.PreSpawnAcquire || !reflect.DeepEqual(resume.Argv[len(resume.Argv)-2:], []string{"--resume", testConversationID}) {
+		t.Fatalf("resume Cursor plan = %#v", resume)
+	}
+}
+
+func TestCursorGrammarRejectsUnownedFlagsAndMultipleBypass(t *testing.T) {
+	project, executable := testExecutable(t, CursorProvider)
+	adapter := NewCursorAdapter(executable)
+	base := planRequest(project, CursorProvider)
+	tests := []struct {
+		name      string
+		committed []string
+		bypass    []string
+	}{
+		{name: "positional", committed: []string{"prompt"}},
+		{name: "resume", committed: []string{"--resume", testConversationID}},
+		{name: "output", committed: []string{"--output-format", "json"}},
+		{name: "trust", committed: []string{"--trust"}},
+		{name: "two bypass", bypass: []string{"--force", "--yolo"}},
+		{name: "unknown bypass", bypass: []string{"--approve-mcps"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := base
+			request.CommittedArgs = test.committed
+			request.BypassArgs = test.bypass
+			if _, err := adapter.PlanFresh(request); err == nil {
+				t.Fatal("PlanFresh error = nil")
+			}
+		})
+	}
+	if err := adapter.ValidateCommittedConfig(CommittedConfigRequest{Args: []string{"--model", ""}}); err == nil || !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("unsafe model error = %v", err)
+	}
+}

--- a/internal/launch/capture.go
+++ b/internal/launch/capture.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"strings"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
 type CaptureState string
@@ -50,6 +52,7 @@ type CaptureEvidence struct {
 	provider        string
 	providerVersion string
 	launchNonce     string
+	handle          string
 	conversationID  string
 	activeElsewhere bool
 	verified        bool
@@ -62,6 +65,16 @@ type CaptureResult struct {
 	Identity ConversationIdentity
 	Degraded bool
 	Reason   CaptureReason
+}
+
+type cursorCreateChatPayload struct {
+	Source          CaptureEvidenceSource `json:"source"`
+	Provider        string                `json:"provider"`
+	ProviderVersion string                `json:"provider_version"`
+	LaunchNonce     string                `json:"launch_nonce"`
+	Handle          string                `json:"handle"`
+	ConversationID  string                `json:"conversation_id"`
+	Stdout          string                `json:"stdout"`
 }
 
 func (result CaptureResult) CanPersist() bool {
@@ -106,6 +119,58 @@ func ParseCodexThreadStartedEvidence(raw []byte, launchNonce string, activeElsew
 		conversationID: event.Params.Thread.ID, activeElsewhere: activeElsewhere,
 		verified: true, observedAt: time.Now().UTC(), payload: bytes.Clone(raw),
 	}, nil
+}
+
+// ParseCursorCreateChatEvidence validates the exact stdout returned by the
+// pinned cursor-agent create-chat command. The executing channel supplies the
+// nonce, handle, and version bindings; provider output is never authority for
+// those values.
+func ParseCursorCreateChatEvidence(raw []byte, launchNonce, handle, providerVersion string) (CaptureEvidence, error) {
+	if !validUUID(launchNonce) {
+		return CaptureEvidence{}, fmt.Errorf("launch nonce must be a UUID")
+	}
+	if err := fsq.ValidateHandle(handle); err != nil {
+		return CaptureEvidence{}, fmt.Errorf("invalid capture handle: %w", err)
+	}
+	if providerVersion != cursorCaptureVersion {
+		return CaptureEvidence{}, fmt.Errorf("cursor capture version %q is unsupported", providerVersion)
+	}
+	stdout := string(raw)
+	stdout = strings.TrimSuffix(stdout, "\n")
+	if stdout == "" || strings.ContainsAny(stdout, "\r\n") || stdout != strings.ToLower(stdout) || !validUUID(stdout) {
+		return CaptureEvidence{}, fmt.Errorf("cursor create-chat output must be one canonical UUID")
+	}
+	payload, err := json.Marshal(cursorCreateChatPayload{
+		Source: CursorCreateChatV1, Provider: CursorProvider, ProviderVersion: providerVersion,
+		LaunchNonce: launchNonce, Handle: handle, ConversationID: stdout, Stdout: string(raw),
+	})
+	if err != nil {
+		return CaptureEvidence{}, err
+	}
+	return CaptureEvidence{
+		source: CursorCreateChatV1, provider: CursorProvider, providerVersion: providerVersion,
+		launchNonce: launchNonce, handle: handle, conversationID: stdout,
+		verified: true, observedAt: time.Now().UTC(), payload: payload,
+	}, nil
+}
+
+func decodeCursorCreateChatPayload(raw []byte) (cursorCreateChatPayload, error) {
+	var payload cursorCreateChatPayload
+	if err := decodeStrict(raw, &payload); err != nil {
+		return payload, fmt.Errorf("decode cursor create-chat evidence: %w", err)
+	}
+	if payload.Source != CursorCreateChatV1 || payload.Provider != CursorProvider ||
+		payload.ProviderVersion != cursorCaptureVersion || !validUUID(payload.LaunchNonce) {
+		return payload, fmt.Errorf("cursor create-chat evidence metadata is invalid")
+	}
+	if err := fsq.ValidateHandle(payload.Handle); err != nil {
+		return payload, fmt.Errorf("cursor create-chat evidence handle: %w", err)
+	}
+	parsed, err := ParseCursorCreateChatEvidence([]byte(payload.Stdout), payload.LaunchNonce, payload.Handle, payload.ProviderVersion)
+	if err != nil || parsed.conversationID != payload.ConversationID {
+		return payload, fmt.Errorf("cursor create-chat evidence identity is invalid")
+	}
+	return payload, nil
 }
 
 func captureCodexIdentity(request CaptureRequest) CaptureResult {
@@ -154,6 +219,46 @@ func captureCodexIdentity(request CaptureRequest) CaptureResult {
 			State:    CaptureReady,
 			Identity: ConversationIdentity{Provider: CodexProvider, ID: id},
 		}
+	}
+	return degradedCapture(CaptureStale, CaptureReasonEvidenceMissing)
+}
+
+func captureCursorIdentity(request CaptureRequest) CaptureResult {
+	if !validUUID(request.LaunchNonce) {
+		return degradedCapture(CaptureStale, CaptureReasonLaunchNonceMismatch)
+	}
+	if request.ExpectedProviderVersion != cursorCaptureVersion {
+		return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonProviderVersion}
+	}
+	if len(request.Evidence) == 0 {
+		if !request.Final {
+			return CaptureResult{State: CapturePending}
+		}
+		return degradedCapture(CaptureStale, CaptureReasonEvidenceMissing)
+	}
+	identities := make(map[string]struct{}, len(request.Evidence))
+	for _, evidence := range request.Evidence {
+		switch {
+		case !evidence.verified:
+			return degradedCapture(CaptureStale, CaptureReasonEvidenceUnverified)
+		case evidence.source != CursorCreateChatV1:
+			return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonEvidenceSource}
+		case evidence.provider != CursorProvider:
+			return degradedCapture(CaptureStale, CaptureReasonProviderMismatch)
+		case evidence.providerVersion != request.ExpectedProviderVersion:
+			return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonProviderVersion}
+		case evidence.launchNonce != request.LaunchNonce:
+			return degradedCapture(CaptureStale, CaptureReasonLaunchNonceMismatch)
+		case !validUUID(evidence.conversationID):
+			return degradedCapture(CaptureStale, CaptureReasonInvalidIdentity)
+		}
+		identities[evidence.conversationID] = struct{}{}
+	}
+	if len(identities) != 1 {
+		return degradedCapture(CaptureStale, CaptureReasonEvidenceAmbiguous)
+	}
+	for id := range identities {
+		return CaptureResult{State: CaptureReady, Identity: ConversationIdentity{Provider: CursorProvider, ID: id}}
 	}
 	return degradedCapture(CaptureStale, CaptureReasonEvidenceMissing)
 }

--- a/internal/launch/capture_test.go
+++ b/internal/launch/capture_test.go
@@ -94,3 +94,53 @@ func TestParseCodexThreadStartedEvidenceRejectsForgedEvents(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCursorCreateChatEvidenceRequiresOneCanonicalUUID(t *testing.T) {
+	valid, err := ParseCursorCreateChatEvidence([]byte(testConversationID+"\n"), testLaunchNonce, "cursor", cursorCaptureVersion)
+	if err != nil || valid.source != CursorCreateChatV1 || valid.handle != "cursor" || valid.conversationID != testConversationID {
+		t.Fatalf("valid Cursor evidence = %#v, %v", valid, err)
+	}
+	tests := []struct {
+		name    string
+		raw     string
+		version string
+	}{
+		{name: "empty", raw: "", version: cursorCaptureVersion},
+		{name: "two lines", raw: testConversationID + "\n" + testLaunchNonce, version: cursorCaptureVersion},
+		{name: "carriage return", raw: testConversationID + "\r\n", version: cursorCaptureVersion},
+		{name: "surrounding space", raw: " " + testConversationID, version: cursorCaptureVersion},
+		{name: "uppercase", raw: strings.ToUpper(testConversationID), version: cursorCaptureVersion},
+		{name: "wrong version", raw: testConversationID, version: "2026.08.12-unknown"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := ParseCursorCreateChatEvidence([]byte(test.raw), testLaunchNonce, "cursor", test.version); err == nil {
+				t.Fatal("ParseCursorCreateChatEvidence error = nil")
+			}
+		})
+	}
+}
+
+func TestCursorCaptureRejectsForgedBinding(t *testing.T) {
+	evidence, err := ParseCursorCreateChatEvidence([]byte(testConversationID), testLaunchNonce, "cursor", cursorCaptureVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := CaptureRequest{LaunchNonce: testLaunchNonce, ExpectedProviderVersion: cursorCaptureVersion, Final: true, Evidence: []CaptureEvidence{evidence}}
+	ready := captureCursorIdentity(request)
+	if !ready.CanPersist() || ready.Identity != (ConversationIdentity{Provider: CursorProvider, ID: testConversationID}) {
+		t.Fatalf("ready Cursor capture = %#v", ready)
+	}
+	request.Evidence[0].launchNonce = testConversationID
+	forged := captureCursorIdentity(request)
+	if forged.State != CaptureStale || forged.Reason != CaptureReasonLaunchNonceMismatch || forged.CanPersist() {
+		t.Fatalf("forged Cursor capture = %#v", forged)
+	}
+}
+
+func TestDecodeCursorCreateChatPayloadRejectsUnknownFields(t *testing.T) {
+	raw := `{"source":"cursor_create_chat_v1","provider":"cursor-agent","provider_version":"2026.08.11-e8db854","launch_nonce":"` + testLaunchNonce + `","handle":"cursor","conversation_id":"` + testConversationID + `","stdout":"` + testConversationID + `","extra":true}`
+	if _, err := decodeCursorCreateChatPayload([]byte(raw)); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("unknown field error = %v", err)
+	}
+}

--- a/internal/launch/conversation.go
+++ b/internal/launch/conversation.go
@@ -165,6 +165,7 @@ func validateConversationEvidence(root *fsq.DeliveryRoot, record ConversationRec
 		return nil // Legacy ready records remain readable until their next capture.
 	}
 	providerCapture := false
+	cursorCapture := false
 	for _, id := range record.EvidenceRefs {
 		evidence, _, err := ReadEvidence(root, id)
 		if err != nil {
@@ -175,10 +176,25 @@ func validateConversationEvidence(root *fsq.DeliveryRoot, record ConversationRec
 		}
 		if evidence.Kind == EvidenceProviderCapture {
 			providerCapture = true
+			if record.Identity.Provider == CursorProvider {
+				payload, decodeErr := decodeCursorCreateChatPayload(evidence.Payload)
+				if decodeErr != nil {
+					return decodeErr
+				}
+				if payload.Handle != record.Handle || payload.LaunchNonce != record.LaunchNonce ||
+					payload.Provider != record.Identity.Provider || payload.ProviderVersion != record.ProviderVersion ||
+					payload.ConversationID != record.Identity.ID {
+					return fmt.Errorf("cursor conversation evidence binding mismatch")
+				}
+				cursorCapture = true
+			}
 		}
 	}
 	if record.Identity.Provider == CodexProvider && !providerCapture {
 		return fmt.Errorf("capture conversation requires provider_capture evidence")
+	}
+	if record.Identity.Provider == CursorProvider && !cursorCapture {
+		return fmt.Errorf("cursor capture conversation requires bound provider_capture evidence")
 	}
 	return nil
 }

--- a/internal/launch/evidence.go
+++ b/internal/launch/evidence.go
@@ -207,8 +207,19 @@ func EvidencePath(sessionRoot, id string) string {
 func persistProviderCaptureEvidence(root *fsq.DeliveryRoot, lease *Lease, handle string, evidence []CaptureEvidence) ([]string, error) {
 	refs := make([]string, 0, len(evidence))
 	for _, item := range evidence {
-		if !item.verified || item.source != CodexThreadStartedV2 || len(item.payload) == 0 {
+		if !item.verified || len(item.payload) == 0 {
 			return nil, fmt.Errorf("provider capture evidence is not persistable")
+		}
+		switch item.source {
+		case CodexThreadStartedV2:
+		case CursorCreateChatV1:
+			payload, err := decodeCursorCreateChatPayload(item.payload)
+			if err != nil || payload.Handle != handle || item.handle != handle || payload.LaunchNonce != item.launchNonce ||
+				payload.ConversationID != item.conversationID || payload.ProviderVersion != item.providerVersion {
+				return nil, fmt.Errorf("cursor provider capture evidence is not persistable")
+			}
+		default:
+			return nil, fmt.Errorf("provider capture evidence source is not persistable")
 		}
 		request := EvidenceWriteRequest{
 			Kind: EvidenceProviderCapture, Handle: handle, ObservedAt: item.observedAt, Payload: item.payload,
@@ -235,6 +246,57 @@ func persistProviderCaptureEvidence(root *fsq.DeliveryRoot, lease *Lease, handle
 		refs = append(refs, ref.ID)
 	}
 	return refs, nil
+}
+
+func findCursorCaptureEvidence(root *fsq.DeliveryRoot, handle, nonce, providerVersion string) (CaptureEvidence, string, bool, error) {
+	entries, err := root.ReadDir(evidenceDirectory)
+	if errors.Is(err, os.ErrNotExist) {
+		return CaptureEvidence{}, "", false, nil
+	}
+	if err != nil {
+		return CaptureEvidence{}, "", false, err
+	}
+	var found CaptureEvidence
+	foundID := ""
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id := "sha256:" + strings.TrimSuffix(entry.Name(), ".json")
+		record, _, err := ReadEvidence(root, id)
+		if err != nil {
+			return CaptureEvidence{}, "", false, err
+		}
+		if record.Kind != EvidenceProviderCapture || record.Handle != handle {
+			continue
+		}
+		var envelope struct {
+			Source CaptureEvidenceSource `json:"source"`
+		}
+		if err := json.Unmarshal(record.Payload, &envelope); err != nil {
+			return CaptureEvidence{}, "", false, fmt.Errorf("decode provider capture source: %w", err)
+		}
+		if envelope.Source != CursorCreateChatV1 {
+			continue
+		}
+		payload, err := decodeCursorCreateChatPayload(record.Payload)
+		if err != nil {
+			return CaptureEvidence{}, "", false, err
+		}
+		if payload.Handle != handle || payload.LaunchNonce != nonce || payload.ProviderVersion != providerVersion {
+			continue
+		}
+		if foundID != "" && foundID != id {
+			return CaptureEvidence{}, "", false, fmt.Errorf("cursor acquisition evidence is ambiguous for handle %q", handle)
+		}
+		found = CaptureEvidence{
+			source: CursorCreateChatV1, provider: CursorProvider, providerVersion: payload.ProviderVersion,
+			launchNonce: payload.LaunchNonce, handle: payload.Handle, conversationID: payload.ConversationID,
+			verified: true, observedAt: record.ObservedAt, payload: bytes.Clone(record.Payload),
+		}
+		foundID = id
+	}
+	return found, foundID, foundID != "", nil
 }
 
 func CollectEvidenceRefs(root *fsq.DeliveryRoot, handles []string) ([]EvidenceRef, error) {

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -29,9 +30,10 @@ const (
 type ExecutionState string
 
 const (
-	ExecutionPending        ExecutionState = "pending"
-	ExecutionSpawnAttempted ExecutionState = "spawn_attempted"
-	ExecutionAcknowledged   ExecutionState = "acknowledged"
+	ExecutionPending          ExecutionState = "pending"
+	ExecutionIdentityAcquired ExecutionState = "identity_acquired"
+	ExecutionSpawnAttempted   ExecutionState = "spawn_attempted"
+	ExecutionAcknowledged     ExecutionState = "acknowledged"
 )
 
 // ExecutionTicket is the durable, nonce-bound handoff between planning and
@@ -40,11 +42,16 @@ const (
 type ExecutionTicket struct {
 	Version int `json:"version"`
 
-	Handle         string      `json:"handle"`
-	LaunchNonce    string      `json:"launch_nonce"`
-	Mode           AdapterMode `json:"mode"`
-	Provider       string      `json:"provider"`
-	ConversationID string      `json:"conversation_id,omitempty"`
+	Handle          string      `json:"handle"`
+	LaunchNonce     string      `json:"launch_nonce"`
+	Mode            AdapterMode `json:"mode"`
+	Provider        string      `json:"provider"`
+	ProviderVersion string      `json:"provider_version,omitempty"`
+	ConversationID  string      `json:"conversation_id,omitempty"`
+	PreSpawnAcquire bool        `json:"pre_spawn_acquire,omitempty"`
+	EvidenceRefs    []string    `json:"evidence_refs,omitempty"`
+	Backend         string      `json:"backend,omitempty"`
+	Profile         string      `json:"profile,omitempty"`
 
 	ProjectRoot     string `json:"project_root"`
 	ProjectIdentity string `json:"project_identity"`
@@ -60,21 +67,27 @@ type ExecutionTicket struct {
 	InjectorExecutable         string `json:"injector_executable,omitempty"`
 	InjectorExecutableIdentity string `json:"injector_executable_identity,omitempty"`
 
-	TargetArgv []string                 `json:"target_argv"`
-	TargetEnv  map[string]string        `json:"target_env,omitempty"`
-	EnvDigest  string                   `json:"env_digest"`
-	State      ExecutionState           `json:"state"`
-	Reason     string                   `json:"reason,omitempty"`
-	Execution  *PrepareExecutionOptions `json:"execution,omitempty"`
+	TargetArgv  []string                 `json:"target_argv"`
+	DynamicArgv []DynamicArg             `json:"dynamic_argv,omitempty"`
+	TargetEnv   map[string]string        `json:"target_env,omitempty"`
+	EnvDigest   string                   `json:"env_digest"`
+	State       ExecutionState           `json:"state"`
+	Reason      string                   `json:"reason,omitempty"`
+	Execution   *PrepareExecutionOptions `json:"execution,omitempty"`
 }
 
 type ExecutionTicketRequest struct {
 	Handle, LaunchNonce               string
 	Mode                              AdapterMode
-	Provider, ConversationID          string
+	Provider, ProviderVersion         string
+	ConversationID                    string
+	PreSpawnAcquire                   bool
+	EvidenceRefs                      []string
+	Backend, Profile                  string
 	ProjectRoot, SessionRoot, Cwd     string
 	ProviderExecutable, AMQExecutable string
 	TargetArgv                        []string
+	DynamicArgv                       []DynamicArg
 	TargetEnv                         map[string]string
 	State                             ExecutionState
 	Reason                            string
@@ -145,11 +158,14 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 	}
 	ticket := ExecutionTicket{
 		Version: ExecutionTicketVersion, Handle: request.Handle, LaunchNonce: request.LaunchNonce, Mode: request.Mode,
-		Provider: request.Provider, ConversationID: request.ConversationID,
+		Provider: request.Provider, ProviderVersion: request.ProviderVersion, ConversationID: request.ConversationID,
+		PreSpawnAcquire: request.PreSpawnAcquire, EvidenceRefs: append([]string(nil), request.EvidenceRefs...),
+		Backend: request.Backend, Profile: request.Profile,
 		ProjectRoot: project, ProjectIdentity: projectID, SessionRoot: session, SessionIdentity: sessionID,
 		Cwd: cwd, CwdIdentity: cwdID, ProviderExecutable: provider, ProviderExecutableIdentity: providerID,
 		AMQExecutable: amq, AMQExecutableIdentity: amqID, TargetArgv: append([]string(nil), request.TargetArgv...),
-		TargetEnv: env, EnvDigest: digest, State: request.State, Reason: request.Reason,
+		DynamicArgv: append([]DynamicArg(nil), request.DynamicArgv...),
+		TargetEnv:   env, EnvDigest: digest, State: request.State, Reason: request.Reason,
 		Execution: execution, InjectorExecutable: injector, InjectorExecutableIdentity: injectorID,
 	}
 	if ticket.State == "" {
@@ -180,6 +196,14 @@ func (ticket ExecutionTicket) Validate() error {
 	if ticket.ConversationID != "" && !validUUID(ticket.ConversationID) {
 		return fmt.Errorf("conversation identity must be a UUID")
 	}
+	if ticket.PreSpawnAcquire {
+		if ticket.Mode != AdapterModeCapture || ticket.Provider != CursorProvider || ticket.ProviderVersion == "" ||
+			strings.TrimSpace(ticket.Backend) == "" || strings.TrimSpace(ticket.Profile) == "" {
+			return fmt.Errorf("pre-spawn identity acquisition requires a versioned cursor capture ticket")
+		}
+	} else if ticket.Backend != "" || ticket.Profile != "" {
+		return fmt.Errorf("execution backend identity exists without pre-spawn acquisition")
+	}
 	for name, value := range map[string]string{"project root": ticket.ProjectRoot, "project identity": ticket.ProjectIdentity, "session root": ticket.SessionRoot, "session identity": ticket.SessionIdentity, "cwd": ticket.Cwd, "cwd identity": ticket.CwdIdentity, "provider executable": ticket.ProviderExecutable, "provider executable identity": ticket.ProviderExecutableIdentity, "amq executable": ticket.AMQExecutable, "amq executable identity": ticket.AMQExecutableIdentity, "environment digest": ticket.EnvDigest} {
 		if strings.TrimSpace(value) == "" {
 			return fmt.Errorf("%s is required", name)
@@ -200,6 +224,47 @@ func (ticket ExecutionTicket) Validate() error {
 			return fmt.Errorf("target argv[%d] is invalid", i)
 		}
 	}
+	seenDynamic := make(map[int]struct{}, len(ticket.DynamicArgv))
+	conversationSlots := 0
+	for i, dynamic := range ticket.DynamicArgv {
+		if dynamic.Index <= 0 || dynamic.Index >= len(ticket.TargetArgv) {
+			return fmt.Errorf("dynamic argv[%d] index is invalid", i)
+		}
+		if _, exists := seenDynamic[dynamic.Index]; exists {
+			return fmt.Errorf("dynamic argv[%d] index is duplicated", i)
+		}
+		seenDynamic[dynamic.Index] = struct{}{}
+		switch dynamic.Kind {
+		case DynamicArgLaunchNonce:
+			if ticket.TargetArgv[dynamic.Index] != ticket.LaunchNonce {
+				return fmt.Errorf("dynamic launch nonce slot does not match ticket")
+			}
+		case DynamicArgConversationID:
+			conversationSlots++
+			expected := ticket.ConversationID
+			if ticket.PreSpawnAcquire {
+				expected = preSpawnConversationPlaceholder
+			}
+			if expected == "" || ticket.TargetArgv[dynamic.Index] != expected {
+				return fmt.Errorf("dynamic conversation slot does not match ticket")
+			}
+		default:
+			return fmt.Errorf("dynamic argv[%d] kind is invalid", i)
+		}
+	}
+	if ticket.PreSpawnAcquire && conversationSlots != 1 {
+		return fmt.Errorf("pre-spawn execution requires exactly one dynamic conversation slot")
+	}
+	seenEvidence := make(map[string]struct{}, len(ticket.EvidenceRefs))
+	for _, id := range ticket.EvidenceRefs {
+		if !validDigest(id) {
+			return fmt.Errorf("execution evidence ref is invalid")
+		}
+		if _, exists := seenEvidence[id]; exists {
+			return fmt.Errorf("execution evidence ref is duplicated")
+		}
+		seenEvidence[id] = struct{}{}
+	}
 	if digest, err := executionEnvDigest(ticket.TargetEnv); err != nil || digest != ticket.EnvDigest {
 		if err != nil {
 			return err
@@ -208,9 +273,15 @@ func (ticket ExecutionTicket) Validate() error {
 	}
 	switch ticket.State {
 	case ExecutionPending:
-	case ExecutionSpawnAttempted, ExecutionAcknowledged:
+		if ticket.PreSpawnAcquire && (ticket.ConversationID != "" || len(ticket.EvidenceRefs) != 0) {
+			return fmt.Errorf("pending pre-spawn ticket must not contain acquired identity")
+		}
+	case ExecutionIdentityAcquired, ExecutionSpawnAttempted, ExecutionAcknowledged:
 		if strings.TrimSpace(ticket.Reason) == "" {
 			return fmt.Errorf("reason is required for execution state %q", ticket.State)
+		}
+		if ticket.PreSpawnAcquire && (!validUUID(ticket.ConversationID) || len(ticket.EvidenceRefs) != 1) {
+			return fmt.Errorf("pre-spawn execution state %q requires one acquired identity evidence ref", ticket.State)
 		}
 	default:
 		return fmt.Errorf("invalid execution state %q", ticket.State)
@@ -322,13 +393,17 @@ func CompareAndSwapExecutionTicket(root *fsq.DeliveryRoot, lease *Lease, handle 
 	if ticket.State != expected {
 		return ticket, fmt.Errorf("execution ticket state is %q, want %q", ticket.State, expected)
 	}
-	if next != ExecutionSpawnAttempted && next != ExecutionAcknowledged && next != ExecutionPending {
+	if next != ExecutionIdentityAcquired && next != ExecutionSpawnAttempted && next != ExecutionAcknowledged && next != ExecutionPending {
 		return ticket, fmt.Errorf("invalid execution state %q", next)
 	}
 	validTransition := expected == ExecutionPending && next == ExecutionSpawnAttempted
+	validTransition = validTransition || expected == ExecutionPending && next == ExecutionIdentityAcquired
+	validTransition = validTransition || expected == ExecutionIdentityAcquired && next == ExecutionSpawnAttempted
 	validTransition = validTransition || expected == ExecutionSpawnAttempted && next == ExecutionAcknowledged
 	validTransition = validTransition || expected == ExecutionAcknowledged && next == ExecutionPending
 	validTransition = validTransition || expected == ExecutionSpawnAttempted && next == ExecutionPending
+	validTransition = validTransition || expected == ExecutionSpawnAttempted && next == ExecutionIdentityAcquired
+	validTransition = validTransition || expected == ExecutionAcknowledged && next == ExecutionIdentityAcquired
 	if !validTransition {
 		return ticket, fmt.Errorf("invalid execution state transition %q -> %q", expected, next)
 	}
@@ -342,9 +417,73 @@ func CompareAndSwapExecutionTicket(root *fsq.DeliveryRoot, lease *Lease, handle 
 	return ticket, nil
 }
 
+// CompareAndSwapExecutionIdentity publishes the provider-owned identity and
+// its immutable evidence in the same pending-to-acquired ticket write.
+func CompareAndSwapExecutionIdentity(root *fsq.DeliveryRoot, lease *Lease, handle, conversationID, evidenceRef string) (ExecutionTicket, error) {
+	if err := lease.authorizeWrite(root); err != nil {
+		return ExecutionTicket{}, err
+	}
+	if !lease.holdsHandle(handle) {
+		return ExecutionTicket{}, fmt.Errorf("launch lease does not hold handle %q", handle)
+	}
+	ticket, err := LoadExecutionTicket(root, handle)
+	if err != nil {
+		return ExecutionTicket{}, err
+	}
+	if ticket.LaunchNonce != lease.LaunchNonce() {
+		return ticket, fmt.Errorf("execution ticket nonce does not match launch lease")
+	}
+	if ticket.State != ExecutionPending {
+		return ticket, fmt.Errorf("execution ticket state is %q, want %q", ticket.State, ExecutionPending)
+	}
+	ticket.ConversationID = conversationID
+	ticket.EvidenceRefs = []string{evidenceRef}
+	ticket.State, ticket.Reason = ExecutionIdentityAcquired, "identity_acquired"
+	if err := ticket.Validate(); err != nil {
+		return ticket, err
+	}
+	if err := validateCursorExecutionEvidence(root, ticket); err != nil {
+		return ticket, err
+	}
+	if err := WriteExecutionTicket(root, lease, ticket); err != nil {
+		return ticket, err
+	}
+	return ticket, nil
+}
+
+type preSpawnIdentityAcquirer interface {
+	Acquire(ExecutionTicket) (CaptureEvidence, error)
+}
+
+type systemPreSpawnIdentityAcquirer struct{}
+
+func (systemPreSpawnIdentityAcquirer) Acquire(ticket ExecutionTicket) (CaptureEvidence, error) {
+	if ticket.Provider != CursorProvider || ticket.ProviderVersion != cursorCaptureVersion {
+		return CaptureEvidence{}, fmt.Errorf("pre-spawn identity acquisition is unsupported for provider %q", ticket.Provider)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, ticket.ProviderExecutable, "create-chat")
+	command.Dir = ticket.Cwd
+	stdout, err := command.Output()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return CaptureEvidence{}, fmt.Errorf("cursor create-chat timed out")
+		}
+		return CaptureEvidence{}, fmt.Errorf("cursor create-chat failed: %w", err)
+	}
+	return ParseCursorCreateChatEvidence(stdout, ticket.LaunchNonce, ticket.Handle, ticket.ProviderVersion)
+}
+
+type prepareExecutionHook func(string) error
+
 // PrepareExecution performs the final envelope check and durable execution
 // acknowledgement under the exact launch nonce and handle lock.
 func PrepareExecution(root *fsq.DeliveryRoot, handle, nonce string, envelope ExecutionEnvelope) (ticket ExecutionTicket, returnErr error) {
+	return prepareExecution(root, handle, nonce, envelope, systemPreSpawnIdentityAcquirer{}, nil)
+}
+
+func prepareExecution(root *fsq.DeliveryRoot, handle, nonce string, envelope ExecutionEnvelope, acquirer preSpawnIdentityAcquirer, hook prepareExecutionHook) (ticket ExecutionTicket, returnErr error) {
 	lease, err := acquireExecutionLease(root, nonce)
 	if err != nil {
 		return ticket, err
@@ -365,6 +504,9 @@ func PrepareExecution(root *fsq.DeliveryRoot, handle, nonce string, envelope Exe
 	}
 	switch ticket.Mode {
 	case AdapterModeCapture:
+		if ticket.PreSpawnAcquire {
+			return preparePreSpawnCapture(root, lease, ticket, acquirer, hook)
+		}
 		return CompareAndSwapExecutionTicket(root, lease, handle, ExecutionPending, ExecutionSpawnAttempted, "spawn_attempted")
 	case AdapterModeMint:
 		if ticket.State == ExecutionPending {
@@ -400,6 +542,158 @@ func PrepareExecution(root *fsq.DeliveryRoot, handle, nonce string, envelope Exe
 	default:
 		return ticket, fmt.Errorf("execution mode %q cannot acknowledge a provider process", ticket.Mode)
 	}
+}
+
+func preparePreSpawnCapture(root *fsq.DeliveryRoot, lease *Lease, ticket ExecutionTicket, acquirer preSpawnIdentityAcquirer, hook prepareExecutionHook) (ExecutionTicket, error) {
+	if ticket.State == ExecutionPending {
+		evidence, refID, found, err := findCursorCaptureEvidence(root, ticket.Handle, ticket.LaunchNonce, ticket.ProviderVersion)
+		if err != nil {
+			return ticket, err
+		}
+		if !found {
+			if acquirer == nil {
+				return ticket, fmt.Errorf("cursor pre-spawn identity acquirer is unavailable")
+			}
+			evidence, err = acquirer.Acquire(ticket)
+			if err != nil {
+				return ticket, err
+			}
+			capture := captureCursorIdentity(CaptureRequest{
+				LaunchNonce: ticket.LaunchNonce, ExpectedProviderVersion: ticket.ProviderVersion,
+				Final: true, Evidence: []CaptureEvidence{evidence},
+			})
+			if !capture.CanPersist() || capture.Identity.Provider != ticket.Provider {
+				return ticket, fmt.Errorf("cursor create-chat did not yield persistable launch evidence")
+			}
+			refs, persistErr := persistProviderCaptureEvidence(root, lease, ticket.Handle, []CaptureEvidence{evidence})
+			if persistErr != nil {
+				return ticket, persistErr
+			}
+			refID = refs[0]
+		}
+		if err := callPrepareExecutionHook(hook, "evidence_persisted"); err != nil {
+			return ticket, err
+		}
+		ticket, err = CompareAndSwapExecutionIdentity(root, lease, ticket.Handle, evidence.conversationID, refID)
+		if err != nil {
+			return ticket, err
+		}
+		if err := callPrepareExecutionHook(hook, "identity_acquired"); err != nil {
+			return ticket, err
+		}
+	}
+	if ticket.State == ExecutionIdentityAcquired || ticket.State == ExecutionSpawnAttempted || ticket.State == ExecutionAcknowledged {
+		if err := validateCursorExecutionEvidence(root, ticket); err != nil {
+			return ticket, err
+		}
+	}
+	if ticket.State == ExecutionIdentityAcquired {
+		var err error
+		ticket, err = CompareAndSwapExecutionTicket(root, lease, ticket.Handle, ExecutionIdentityAcquired, ExecutionSpawnAttempted, "spawn_attempted")
+		if err != nil {
+			return ticket, err
+		}
+		if err := callPrepareExecutionHook(hook, "spawn_attempted"); err != nil {
+			return ticket, err
+		}
+	}
+	if ticket.State == ExecutionSpawnAttempted {
+		if err := promotePreSpawnConversation(root, lease, ticket); err != nil {
+			return ticket, err
+		}
+		var err error
+		ticket, err = CompareAndSwapExecutionTicket(root, lease, ticket.Handle, ExecutionSpawnAttempted, ExecutionAcknowledged, "child_spawn_acknowledged")
+		if err != nil {
+			return ticket, err
+		}
+	}
+	if ticket.State != ExecutionAcknowledged {
+		return ticket, fmt.Errorf("execution ticket state is %q, want acknowledged", ticket.State)
+	}
+	return ticket, nil
+}
+
+func promotePreSpawnConversation(root *fsq.DeliveryRoot, lease *Lease, ticket ExecutionTicket) error {
+	record, err := LoadConversation(root, ticket.Handle)
+	if err != nil {
+		return err
+	}
+	if record.State == CaptureReady {
+		if record.Identity.Provider != ticket.Provider || record.Identity.ID != ticket.ConversationID ||
+			record.LaunchNonce != ticket.LaunchNonce || !reflect.DeepEqual(record.EvidenceRefs, ticket.EvidenceRefs) ||
+			record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != ticket.Backend ||
+			record.ExecutionEvidence.Profile != ticket.Profile || record.ExecutionEvidence.LaunchNonce != ticket.LaunchNonce ||
+			record.ExecutionEvidence.ConversationID != ticket.ConversationID {
+			return fmt.Errorf("ready conversation does not match acquired cursor identity")
+		}
+		return nil
+	}
+	if record.State != CapturePending || record.LaunchNonce != ticket.LaunchNonce {
+		return fmt.Errorf("pending conversation does not match acquired cursor generation")
+	}
+	record.State = CaptureReady
+	record.Identity = ConversationIdentity{Provider: ticket.Provider, ID: ticket.ConversationID}
+	record.EvidenceRefs = append([]string(nil), ticket.EvidenceRefs...)
+	record.ExecutionEvidence = &ConversationExecutionEvidence{
+		Backend: ticket.Backend, Profile: ticket.Profile, Outcome: OutcomeCreated,
+		LaunchNonce: ticket.LaunchNonce, ConversationID: ticket.ConversationID,
+	}
+	record.Reason = ""
+	return WriteConversation(root, lease, record)
+}
+
+func validateCursorExecutionEvidence(root *fsq.DeliveryRoot, ticket ExecutionTicket) error {
+	if len(ticket.EvidenceRefs) != 1 {
+		return fmt.Errorf("cursor execution ticket requires one evidence ref")
+	}
+	record, _, err := ReadEvidence(root, ticket.EvidenceRefs[0])
+	if err != nil {
+		return err
+	}
+	payload, err := decodeCursorCreateChatPayload(record.Payload)
+	if err != nil {
+		return err
+	}
+	if record.Kind != EvidenceProviderCapture || record.Handle != ticket.Handle || payload.Handle != ticket.Handle ||
+		payload.Provider != ticket.Provider ||
+		payload.LaunchNonce != ticket.LaunchNonce || payload.ProviderVersion != ticket.ProviderVersion ||
+		payload.ConversationID != ticket.ConversationID {
+		return fmt.Errorf("cursor execution evidence binding mismatch")
+	}
+	return nil
+}
+
+func callPrepareExecutionHook(hook prepareExecutionHook, stage string) error {
+	if hook == nil {
+		return nil
+	}
+	return hook(stage)
+}
+
+// ResolveExecutionArgv replaces only declared dynamic slots after the ticket
+// has durably acquired their values. Static argv remains byte-identical.
+func ResolveExecutionArgv(ticket ExecutionTicket) ([]string, error) {
+	if err := ticket.Validate(); err != nil {
+		return nil, err
+	}
+	if ticket.PreSpawnAcquire && ticket.State != ExecutionAcknowledged {
+		return nil, fmt.Errorf("pre-spawn execution identity is not acknowledged")
+	}
+	argv := append([]string(nil), ticket.TargetArgv...)
+	for _, dynamic := range ticket.DynamicArgv {
+		switch dynamic.Kind {
+		case DynamicArgLaunchNonce:
+			argv[dynamic.Index] = ticket.LaunchNonce
+		case DynamicArgConversationID:
+			if !validUUID(ticket.ConversationID) {
+				return nil, fmt.Errorf("conversation identity is not acquired")
+			}
+			argv[dynamic.Index] = ticket.ConversationID
+		default:
+			return nil, fmt.Errorf("unsupported dynamic argv kind %q", dynamic.Kind)
+		}
+	}
+	return argv, nil
 }
 
 func acquireExecutionLease(root *fsq.DeliveryRoot, nonce string) (*Lease, error) {
@@ -460,6 +754,13 @@ func RevertExecution(root *fsq.DeliveryRoot, handle, nonce string) (returnErr er
 		return err
 	}
 	if ticket.Mode == AdapterModeCapture {
+		if ticket.PreSpawnAcquire {
+			if ticket.State == ExecutionIdentityAcquired {
+				return nil
+			}
+			_, err = CompareAndSwapExecutionTicket(root, lease, handle, ticket.State, ExecutionIdentityAcquired, "spawn_failed")
+			return err
+		}
 		_, err = CompareAndSwapExecutionTicket(root, lease, handle, ExecutionSpawnAttempted, ExecutionPending, "spawn_failed")
 		return err
 	}

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -468,6 +468,176 @@ func TestPrepareCaptureRecordsAttemptWithoutPromotingConversation(t *testing.T) 
 	}
 }
 
+type countingCursorAcquirer struct {
+	calls int
+	id    string
+}
+
+func (acquirer *countingCursorAcquirer) Acquire(ticket ExecutionTicket) (CaptureEvidence, error) {
+	acquirer.calls++
+	return ParseCursorCreateChatEvidence([]byte(acquirer.id+"\n"), ticket.LaunchNonce, ticket.Handle, ticket.ProviderVersion)
+}
+
+func TestPrepareCursorPreSpawnReusesAcquisitionAcrossCrashes(t *testing.T) {
+	for _, crashStage := range []string{"evidence_persisted", "identity_acquired", "spawn_attempted"} {
+		t.Run(crashStage, func(t *testing.T) {
+			fixture := newExecutionFixture(t)
+			nonce := "91919191-9191-4919-8919-919191919191"
+			ticket, envelope := seedPendingCursorExecution(t, fixture, nonce)
+			acquirer := &countingCursorAcquirer{id: testConversationID}
+			crash := errors.New("simulated crash")
+			_, err := prepareExecution(fixture.root, "cursor", nonce, envelope, acquirer, func(stage string) error {
+				if stage == crashStage {
+					return crash
+				}
+				return nil
+			})
+			if !errors.Is(err, crash) {
+				t.Fatalf("first prepare error = %v", err)
+			}
+			prepared, err := prepareExecution(fixture.root, "cursor", nonce, envelope, acquirer, nil)
+			if err != nil || prepared.State != ExecutionAcknowledged || acquirer.calls != 1 {
+				t.Fatalf("retry prepare = %#v, %v; acquisition calls = %d", prepared, err, acquirer.calls)
+			}
+			argv, err := ResolveExecutionArgv(prepared)
+			if err != nil || argv[ticket.DynamicArgv[0].Index] != testConversationID || argv[ticket.DynamicArgv[0].Index] == preSpawnConversationPlaceholder {
+				t.Fatalf("resolved argv = %#v, %v", argv, err)
+			}
+			record, err := LoadConversation(fixture.root, "cursor")
+			if err != nil || record.State != CaptureReady || record.Identity.Provider != CursorProvider ||
+				record.Identity.ID != testConversationID || len(record.EvidenceRefs) != 1 {
+				t.Fatalf("ready Cursor conversation = %#v, %v", record, err)
+			}
+		})
+	}
+}
+
+func TestRevertCursorExecutionRetainsAcquiredIdentity(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "92929292-9292-4929-8929-929292929292"
+	_, envelope := seedPendingCursorExecution(t, fixture, nonce)
+	acquirer := &countingCursorAcquirer{id: testConversationID}
+	prepared, err := prepareExecution(fixture.root, "cursor", nonce, envelope, acquirer, nil)
+	if err != nil || prepared.State != ExecutionAcknowledged {
+		t.Fatalf("prepare = %#v, %v", prepared, err)
+	}
+	if err := RevertExecution(fixture.root, "cursor", nonce); err != nil {
+		t.Fatal(err)
+	}
+	reverted, err := LoadExecutionTicket(fixture.root, "cursor")
+	if err != nil || reverted.State != ExecutionIdentityAcquired || reverted.ConversationID != testConversationID || len(reverted.EvidenceRefs) != 1 {
+		t.Fatalf("reverted Cursor ticket = %#v, %v", reverted, err)
+	}
+	if _, err := prepareExecution(fixture.root, "cursor", nonce, envelope, acquirer, nil); err != nil || acquirer.calls != 1 {
+		t.Fatalf("retry after revert = %v; acquisition calls = %d", err, acquirer.calls)
+	}
+}
+
+func TestPrepareCursorFailsClosedOnTamperedAcquisitionEvidence(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "93939393-9393-4939-8939-939393939393"
+	_, envelope := seedPendingCursorExecution(t, fixture, nonce)
+	acquirer := &countingCursorAcquirer{id: testConversationID}
+	crash := errors.New("stop after identity publication")
+	_, err := prepareExecution(fixture.root, "cursor", nonce, envelope, acquirer, func(stage string) error {
+		if stage == "identity_acquired" {
+			return crash
+		}
+		return nil
+	})
+	if !errors.Is(err, crash) {
+		t.Fatalf("prepare error = %v", err)
+	}
+	ticket, err := LoadExecutionTicket(fixture.root, "cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := EvidencePath(fixture.session, ticket.EvidenceRefs[0])
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[len(data)/2] ^= 1
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareExecution(fixture.root, "cursor", nonce, envelope, acquirer, nil); err == nil || !strings.Contains(err.Error(), "evidence_corrupt") {
+		t.Fatalf("tampered evidence error = %v", err)
+	}
+	if acquirer.calls != 1 {
+		t.Fatalf("tampered retry acquisition calls = %d, want 1", acquirer.calls)
+	}
+}
+
+func TestPrepareCursorRejectsValidEvidenceBoundToAnotherNonce(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "95959595-9595-4959-8959-959595959595"
+	_, envelope := seedPendingCursorExecution(t, fixture, nonce)
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("cursor"); err != nil {
+		t.Fatal(err)
+	}
+	foreignNonce := "96969696-9696-4969-8969-969696969696"
+	foreign, err := ParseCursorCreateChatEvidence([]byte(testConversationID), foreignNonce, "cursor", cursorCaptureVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs, err := persistProviderCaptureEvidence(fixture.root, lease, "cursor", []CaptureEvidence{foreign})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := LoadExecutionTicket(fixture.root, "cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ticket.State, ticket.Reason = ExecutionIdentityAcquired, "identity_acquired"
+	ticket.ConversationID, ticket.EvidenceRefs = testConversationID, refs
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	acquirer := &countingCursorAcquirer{id: testConversationID}
+	if _, err := prepareExecution(fixture.root, "cursor", nonce, envelope, acquirer, nil); err == nil || !strings.Contains(err.Error(), "cursor execution evidence binding mismatch") {
+		t.Fatalf("foreign evidence error = %v", err)
+	}
+	loaded, err := LoadExecutionTicket(fixture.root, "cursor")
+	if err != nil || loaded.State != ExecutionIdentityAcquired || acquirer.calls != 0 {
+		t.Fatalf("ticket after foreign evidence refusal = %#v, %v; acquisition calls = %d", loaded, err, acquirer.calls)
+	}
+}
+
+func TestCursorOrphanEvidenceRejectsSameIdentityWithDifferentBytes(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "94949494-9494-4949-8949-949494949494"
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	if err := lease.LockHandles("cursor"); err != nil {
+		t.Fatal(err)
+	}
+	first, err := ParseCursorCreateChatEvidence([]byte(testConversationID), nonce, "cursor", cursorCaptureVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ParseCursorCreateChatEvidence([]byte(testConversationID+"\n"), nonce, "cursor", cursorCaptureVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := persistProviderCaptureEvidence(fixture.root, lease, "cursor", []CaptureEvidence{first, second}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := findCursorCaptureEvidence(fixture.root, "cursor", nonce, cursorCaptureVersion); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("ambiguous orphan evidence error = %v", err)
+	}
+}
+
 type executionFixture struct {
 	project, session, cwd, provider, amq, injector string
 	root                                           *fsq.DeliveryRoot
@@ -535,6 +705,45 @@ func seedPendingMintExecution(t *testing.T, fixture executionFixture, nonce stri
 	}
 	if err := WriteConversation(fixture.root, lease, ConversationRecord{
 		Version: ConversationVersion, Handle: "claude", State: CapturePending, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	return ticket, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: fixture.provider,
+		TargetArgv: ticket.TargetArgv, Environment: []string{"LANG=C"},
+	}
+}
+
+func seedPendingCursorExecution(t *testing.T, fixture executionFixture, nonce string) (ExecutionTicket, ExecutionEnvelope) {
+	t.Helper()
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("cursor"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "cursor", LaunchNonce: nonce, Mode: AdapterModeCapture, Provider: CursorProvider,
+		ProviderVersion: cursorCaptureVersion, PreSpawnAcquire: true,
+		Backend: CommandsBackendName, Profile: CommandsProfile().Identity(),
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv:  []string{fixture.provider, "--resume", preSpawnConversationPlaceholder},
+		DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgConversationID}}, TargetEnv: map[string]string{"LANG": "C"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: "cursor", State: CapturePending,
+		ProviderVersion: cursorCaptureVersion, LaunchNonce: nonce,
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/launch/plan.go
+++ b/internal/launch/plan.go
@@ -17,6 +17,8 @@ import (
 
 const PlanVersion = 1
 
+const preSpawnConversationPlaceholder = "__AMQ_CONVERSATION_ID__"
+
 type AdapterMode string
 
 const (
@@ -48,15 +50,16 @@ type Plan struct {
 }
 
 type AgentPlan struct {
-	Handle         string            `json:"handle"`
-	Argv           []string          `json:"argv"`
-	EnvOverlay     map[string]string `json:"env_overlay,omitempty"`
-	Cwd            string            `json:"cwd"`
-	AdapterMode    AdapterMode       `json:"adapter_mode"`
-	ResumePolicy   ResumePolicy      `json:"resume_policy"`
-	LaunchNonce    string            `json:"launch_nonce,omitempty"`
-	ConversationID string            `json:"conversation_id,omitempty"`
-	DynamicArgv    []DynamicArg      `json:"dynamic_argv,omitempty"`
+	Handle          string            `json:"handle"`
+	Argv            []string          `json:"argv"`
+	EnvOverlay      map[string]string `json:"env_overlay,omitempty"`
+	Cwd             string            `json:"cwd"`
+	AdapterMode     AdapterMode       `json:"adapter_mode"`
+	ResumePolicy    ResumePolicy      `json:"resume_policy"`
+	LaunchNonce     string            `json:"launch_nonce,omitempty"`
+	ConversationID  string            `json:"conversation_id,omitempty"`
+	DynamicArgv     []DynamicArg      `json:"dynamic_argv,omitempty"`
+	PreSpawnAcquire bool              `json:"pre_spawn_acquire,omitempty"`
 	// Execution is the normalized coop-exec wrapper policy. Keeping it in the
 	// plan makes journal recovery lossless before the wrapper consumes it.
 	Execution *PrepareExecutionOptions `json:"execution,omitempty"`
@@ -115,7 +118,11 @@ func (a AgentPlan) validate() error {
 			return fmt.Errorf("invalid environment key %q", key)
 		}
 	}
+	if a.PreSpawnAcquire && (a.AdapterMode != AdapterModeCapture || a.ConversationID != "") {
+		return fmt.Errorf("pre-spawn acquisition requires capture mode without a planned identity")
+	}
 	seenDynamic := make(map[int]struct{}, len(a.DynamicArgv))
+	conversationSlots := 0
 	for i, dynamic := range a.DynamicArgv {
 		if dynamic.Index < 0 || dynamic.Index >= len(a.Argv) {
 			return fmt.Errorf("dynamic_argv[%d]: index %d is outside argv", i, dynamic.Index)
@@ -132,13 +139,21 @@ func (a AgentPlan) validate() error {
 		case DynamicArgLaunchNonce:
 			expected = a.LaunchNonce
 		case DynamicArgConversationID:
+			conversationSlots++
 			expected = a.ConversationID
 		default:
 			return fmt.Errorf("dynamic_argv[%d]: invalid kind %q", i, dynamic.Kind)
 		}
+		if dynamic.Kind == DynamicArgConversationID && a.PreSpawnAcquire && a.AdapterMode == AdapterModeCapture &&
+			a.ConversationID == "" && a.Argv[dynamic.Index] == preSpawnConversationPlaceholder {
+			continue
+		}
 		if expected == "" || a.Argv[dynamic.Index] != expected {
 			return fmt.Errorf("dynamic_argv[%d]: argv value does not match %s", i, dynamic.Kind)
 		}
+	}
+	if a.PreSpawnAcquire && conversationSlots != 1 {
+		return fmt.Errorf("pre-spawn acquisition requires exactly one dynamic conversation slot")
 	}
 	return nil
 }
@@ -154,12 +169,13 @@ type canonicalArgument struct {
 }
 
 type staticAgentPlan struct {
-	Handle       string              `json:"handle"`
-	Argv         []canonicalArgument `json:"argv"`
-	EnvOverlay   map[string]string   `json:"env_overlay,omitempty"`
-	Cwd          string              `json:"cwd"`
-	AdapterMode  AdapterMode         `json:"adapter_mode"`
-	ResumePolicy ResumePolicy        `json:"resume_policy"`
+	Handle          string              `json:"handle"`
+	Argv            []canonicalArgument `json:"argv"`
+	EnvOverlay      map[string]string   `json:"env_overlay,omitempty"`
+	Cwd             string              `json:"cwd"`
+	AdapterMode     AdapterMode         `json:"adapter_mode"`
+	ResumePolicy    ResumePolicy        `json:"resume_policy"`
+	PreSpawnAcquire bool                `json:"pre_spawn_acquire,omitempty"`
 }
 
 // SemanticDigest hashes the adapter-normalized static execution template.
@@ -192,6 +208,7 @@ func (p Plan) semanticDigest(allowEmpty bool) (string, error) {
 		agents[i] = staticAgentPlan{
 			Handle: agent.Handle, Argv: argv, EnvOverlay: agent.EnvOverlay,
 			Cwd: agent.Cwd, AdapterMode: agent.AdapterMode, ResumePolicy: agent.ResumePolicy,
+			PreSpawnAcquire: agent.PreSpawnAcquire,
 		}
 	}
 	slices.SortFunc(agents, func(a, b staticAgentPlan) int { return strings.Compare(a.Handle, b.Handle) })

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -327,7 +327,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		if err != nil {
 			return result, err
 		}
-		if err := writeExecutionTickets(request, lease, planned, amqExecutable); err != nil {
+		if err := writeExecutionTickets(request, lease, planned, amqExecutable, backendName, detect.Profile.Identity()); err != nil {
 			return result, err
 		}
 		create, err = backend.Create(CreateRequest{
@@ -587,7 +587,7 @@ func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateRes
 	}
 	for i := range planned {
 		agent := &planned[i]
-		if agent.write {
+		if agent.write && !agent.plan.PreSpawnAcquire {
 			evidence := executionEvidence
 			agent.record.ExecutionEvidence = &evidence
 		}
@@ -595,7 +595,7 @@ func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateRes
 			agent.record.State = CaptureReady
 			agent.record.Identity = ConversationIdentity{Provider: agent.adapter.Name(), ID: agent.plan.ConversationID}
 		}
-		if agent.plan.AdapterMode == AdapterModeCapture && agent.write {
+		if agent.plan.AdapterMode == AdapterModeCapture && agent.write && !agent.plan.PreSpawnAcquire {
 			captureEvidence := create.CaptureEvidence[agent.plan.Handle]
 			capture := agent.adapter.CaptureIdentity(CaptureRequest{
 				LaunchNonce: agent.plan.LaunchNonce, ExpectedProviderVersion: agent.providerVersion,
@@ -634,17 +634,22 @@ func plannedConversations(planned []plannedAgent) []ConversationRecord {
 	return records
 }
 
-func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []plannedAgent, amqPath string) error {
+func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []plannedAgent, amqPath, backend, profile string) error {
 	written := make([]plannedAgent, 0, len(planned))
 	for _, agent := range planned {
-		ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		ticketRequest := ExecutionTicketRequest{
 			Handle: agent.plan.Handle, LaunchNonce: agent.plan.LaunchNonce,
-			Mode: agent.plan.AdapterMode, Provider: agent.adapter.Name(), ConversationID: agent.plan.ConversationID,
+			Mode: agent.plan.AdapterMode, Provider: agent.adapter.Name(), ProviderVersion: agent.providerVersion,
+			ConversationID: agent.plan.ConversationID, PreSpawnAcquire: agent.plan.PreSpawnAcquire,
 			ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Cwd: agent.plan.Cwd,
 			ProviderExecutable: agent.plan.Argv[0], AMQExecutable: amqPath,
-			TargetArgv: agent.plan.Argv, TargetEnv: agent.plan.EnvOverlay,
+			TargetArgv: agent.plan.Argv, DynamicArgv: agent.plan.DynamicArgv, TargetEnv: agent.plan.EnvOverlay,
 			Execution: agent.plan.Execution,
-		})
+		}
+		if agent.plan.PreSpawnAcquire {
+			ticketRequest.Backend, ticketRequest.Profile = backend, profile
+		}
+		ticket, err := NewExecutionTicket(ticketRequest)
 		if err != nil {
 			return errors.Join(fmt.Errorf("build execution ticket for %s: %w", agent.plan.Handle, err), removeExecutionTickets(request.Root, lease, written))
 		}

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -72,6 +72,7 @@ type reconcileAdapter struct {
 	freshUnsupported   bool
 	resumeUnsupported  bool
 	captureUnsupported bool
+	preSpawnAcquire    bool
 }
 
 func (a reconcileAdapter) Name() string               { return a.name }
@@ -82,11 +83,16 @@ func (a reconcileAdapter) Capabilities(context.Context) AdapterCapabilities {
 	if a.capabilityProvider != "" {
 		provider = a.capabilityProvider
 	}
+	providerVersion := "test"
+	if a.preSpawnAcquire {
+		providerVersion = cursorCaptureVersion
+	}
 	return AdapterCapabilities{
 		Provider: provider, Mode: a.mode, Available: a.available,
-		ProviderVersion: "test", Fresh: a.available && !a.freshUnsupported,
-		Resume:  a.available && !a.resumeUnsupported,
-		Capture: a.available && a.mode == AdapterModeCapture && !a.captureUnsupported, Reason: a.reason,
+		ProviderVersion: providerVersion, Fresh: a.available && !a.freshUnsupported,
+		Resume:          a.available && !a.resumeUnsupported,
+		Capture:         a.available && a.mode == AdapterModeCapture && !a.captureUnsupported,
+		PreSpawnAcquire: a.available && a.preSpawnAcquire, Reason: a.reason,
 	}
 }
 
@@ -120,6 +126,29 @@ func TestReconcileCaptureFreshRequiresFreshAndCaptureCapabilities(t *testing.T) 
 				t.Fatalf("unsupported capture wrote execution ticket: %v", err)
 			}
 		})
+	}
+}
+
+func TestReconcileCursorPreSpawnLeavesPendingConversationForWrapper(t *testing.T) {
+	backend := &reconcileBackend{name: "cursor-test"}
+	req := reconcileFixture(t, backend)
+	req.Config.Agents[0].Adapter = CursorProvider
+	req.Config.Agents[0].Command = []string{CursorProvider}
+	req.Adapters = map[string]HarnessAdapter{CursorProvider: reconcileAdapter{
+		name: CursorProvider, mode: AdapterModeCapture, available: true, preSpawnAcquire: true,
+	}}
+	result, err := Reconcile(req)
+	if err != nil || result.AggregateCode != 0 || result.Outcome != OutcomeCreated {
+		t.Fatalf("Cursor reconcile = %#v, %v", result, err)
+	}
+	record, err := LoadConversation(req.Root, "claude")
+	if err != nil || record.State != CapturePending || record.ExecutionEvidence != nil || record.ProviderVersion != cursorCaptureVersion {
+		t.Fatalf("pending Cursor conversation = %#v, %v", record, err)
+	}
+	ticket, err := LoadExecutionTicket(req.Root, "claude")
+	if err != nil || !ticket.PreSpawnAcquire || ticket.State != ExecutionPending || ticket.Backend != backend.name ||
+		ticket.Profile != backend.Detect().Profile.Identity() || len(ticket.DynamicArgv) != 1 {
+		t.Fatalf("pending Cursor ticket = %#v, %v", ticket, err)
 	}
 }
 
@@ -169,6 +198,14 @@ func TestReconcileCaptureReadyRefusesWithoutResumeCapability(t *testing.T) {
 }
 
 func (a reconcileAdapter) PlanFresh(req PlanRequest) (AgentPlan, error) {
+	if a.preSpawnAcquire {
+		plan := AgentPlan{
+			Handle: req.Handle, Argv: []string{"/usr/bin/true", "--resume", preSpawnConversationPlaceholder}, Cwd: req.Cwd,
+			AdapterMode: a.mode, ResumePolicy: req.ResumePolicy, LaunchNonce: req.LaunchNonce, PreSpawnAcquire: true,
+			DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgConversationID}},
+		}
+		return plan, plan.Validate()
+	}
 	plan := AgentPlan{
 		Handle: req.Handle, Argv: []string{"/usr/bin/true", req.LaunchNonce}, Cwd: req.Cwd,
 		AdapterMode: a.mode, ResumePolicy: req.ResumePolicy, LaunchNonce: req.LaunchNonce,

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -91,6 +91,8 @@ func defaultPrepareAdapter(provider, executable string) internallaunch.HarnessAd
 		return internallaunch.NewClaudeAdapter(executable)
 	case internallaunch.CodexProvider:
 		return internallaunch.NewCodexAdapter(executable)
+	case internallaunch.CursorProvider:
+		return internallaunch.NewCursorAdapter(executable)
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Add a pinned `cursor-agent` adapter for `2026.08.11-e8db854`.
- Classify `create-chat` as capture, never mint: the provider creates the identity and AMQ records it under the live launch authority.
- Acquire the identity at the lease-bound `__launch-exec` / `PrepareExecution` boundary before provider exec.
- Persist the raw receipt as immutable `provider_capture` evidence and carry the exact ID through the ticket, conversation record, dynamic `--resume` slot, and managed process argv.
- Keep Grok and Pi excluded because no installed CLI on this machine can pass the required real smoke test; no refusal-only stubs are shipped.

## Rulings implemented

1. Cursor is capture mode, never mint. `create-chat` is the pre-spawn provider-identity acquisition step.
2. The ticket state machine is `pending -> identity_acquired -> spawn_attempted -> acknowledged`. A retry after acquisition reuses the persisted ID and does not create another chat.
3. Raw `create-chat` stdout is strict-parsed as one canonical UUID with an optional final newline, bound to provider version, launch nonce, and handle, then stored in the immutable evidence store as `cursor_create_chat_v1`.
4. Committed argv accepts only `--model <safe-value>`. `--resume` is dynamic-only. Bypass accepts at most one of `--force` or `--yolo`. Provider-control flags, positional prompts, unsafe environment, and `--trust` are rejected. `--trust` appears only in the opt-in headless smoke harness for its harness-owned temporary project.
5. Capabilities are read-only and require the exact pin and help markers. Untested versions report `capture_version_unsupported`.
6. The real smoke is opt-in with `AMQ_CURSOR_LIVE=1` because it writes a provider-side chat and consumes service usage.
7. Grok, Pi, Gemini, and OpenCode remain excluded as documented; no unsupported stubs are added.

## Mutation review

Each hostile mutation made a named test fail:

- Disable crash reuse -> `TestPrepareCursorPreSpawnReusesAcquisitionAcrossCrashes`.
- Remove the exact version pin -> `TestCursorCapabilitiesRequireExactCaptureVersion`.
- Accept both bypass aliases -> `TestCursorGrammarRejectsUnownedFlagsAndMultipleBypass`.
- Accept trailing capture bytes -> `TestParseCursorCreateChatEvidenceRequiresOneCanonicalUUID`.
- Exec the unresolved placeholder argv -> `TestPrivateCursorLaunchWrapperExecsOnlyResolvedConversationSlot`.
- Disable ticket-to-evidence binding checks -> the valid foreign-binding case in `TestPrepareCursorRejectsValidEvidenceBoundToAnotherNonce`.

The stream validator also has hostile cases for a wrong identity, no terminal result, two terminal results, tool use, and invalid JSON.

## Live provider record

Three provider-side test chats were created in total. This is the complete record.

### Chat 1: capture-parser smoke

Command:

```text
/Users/avivsinai/.local/bin/cursor-agent create-chat
```

Result:

```text
--- PASS: TestCursorLiveCreateChatCapture (4.78s)
PASS
```

The first harness revision did not log the returned ID. The ID is therefore unavailable; it was not reconstructed through `ls`, newest-state inference, or a second write.

### Chat 2: honest workspace-trust failure

ID: `44d0d751-e0d0-484c-a099-071701ff6b3c`

The managed tmux / `amq coop exec` / `__launch-exec` row reached the real provider with:

```text
/Users/avivsinai/.local/share/cursor-agent/versions/2026.08.11-e8db854/cursor-agent --use-system-ca /Users/avivsinai/.local/share/cursor-agent/versions/2026.08.11-e8db854/index.js --resume 44d0d751-e0d0-484c-a099-071701ff6b3c
```

The first headless resume stopped with exit 1 before any model result:

```text
Workspace Trust Required
To proceed, you can either:
  - Run 'agent' interactively to decide
  - Pass --trust, --yolo, or -f if you trust this directory
--- FAIL: TestCursorLiveResumeManagedExecutionAndCrashReuse (10.79s)
```

The test stopped without retry or weakened assertions. Review then ruled that the harness owns the empty temporary Git project and can pass `--trust` on headless smoke resumes only.

### Chat 3: full six-step proof

ID: `d55c4efd-b335-4d56-a5fc-595f27fdbe47`

Create argv:

```text
/Users/avivsinai/.local/share/cursor-agent/versions/2026.08.11-e8db854/cursor-agent create-chat
```

Managed process argv:

```text
/Users/avivsinai/.local/share/cursor-agent/versions/2026.08.11-e8db854/cursor-agent --use-system-ca /Users/avivsinai/.local/share/cursor-agent/versions/2026.08.11-e8db854/index.js --resume d55c4efd-b335-4d56-a5fc-595f27fdbe47
```

The managed row also verified an acknowledged ticket, one immutable evidence ref with the exact nonce/handle/ID binding, and a ready `ConversationRecord` carrying the same ID.

```text
resume 1 PASS: exit 0, one terminal success, all session_id values equal d55c4efd-b335-4d56-a5fc-595f27fdbe47
resume 2 PASS: exit 0, one terminal success, all session_id values equal d55c4efd-b335-4d56-a5fc-595f27fdbe47
crash restart reused Cursor chat ID d55c4efd-b335-4d56-a5fc-595f27fdbe47 with one acquisition
--- PASS: TestCursorLiveResumeManagedExecutionAndCrashReuse (45.74s)
PASS
ok github.com/avivsinai/agent-message-queue/internal/launch 46.063s
```

Each headless resume was a fresh process using:

```text
cursor-agent --resume d55c4efd-b335-4d56-a5fc-595f27fdbe47 --print --trust --output-format stream-json --mode ask --model auto "Reply with exactly AMQ_OK. Do not use tools."
```

The assertions required exit 0, no tool event, exactly one successful terminal result, and the same `session_id` on every event.

## Verification

- Peer review passed the frozen implementation and the expanded live harness.
- `AMQ_CURSOR_LIVE=1 go test ./internal/launch -run 'TestCursorLive' -v` passed as shown above.
- Post-commit fresh-cache `make ci` passed: `go vet`, `golangci-lint` with 0 issues, all Go packages, smoke suites, and hook/install regressions.
- The pre-push gate passed the same full checks. One first pre-push attempt hit an unrelated load-sensitive 3-second keepalive watchdog test; the exact test then passed five consecutive isolated runs and the full retry passed.

Bead: `amq-bz8.3`
