### PR TITLE
feat(launch): add managed cmux backend

### DIFF
--- a/docs/launch-recovery.md
+++ b/docs/launch-recovery.md
@@ -29,6 +29,9 @@ On the next launch, AMQ holds the session lease and follows these rules:
 definite-pre-create error that proves no resource was made. Partial creation is
 never adoptable.
 
+Managed cmux Create puts the new workspace in the app-wide active window and
+does not retarget it.
+
 If an operator chooses to abandon recovery evidence, first inspect the exact
 target without mutation:
 

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -34,10 +34,7 @@ var (
 	}
 	launchAdapters = defaultLaunchAdapters
 	launchBackends = func() map[string]launch.Backend {
-		return map[string]launch.Backend{
-			launch.LauncherCommands: launch.Commands{},
-			launch.LauncherTMux:     launch.NewTmuxBackend("tmux"),
-		}
+		return launch.DefaultBackends()
 	}
 	launchHostname = os.Hostname
 )

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -89,7 +89,10 @@ var (
 			launch.NewCursorAdapter(launch.CursorProvider),
 		}
 	}
-	setupLookPath   = exec.LookPath
+	setupLookPath      = exec.LookPath
+	setupCmuxAvailable = func() bool {
+		return launch.NewCmuxBackend("").Detect().Available
+	}
 	setupIsTerminal = func() bool {
 		return term.IsTerminal(int(os.Stdin.Fd()))
 	}
@@ -607,11 +610,19 @@ func chooseSetupLaunchers(options setupOptions, detected []string, existing laun
 func detectSetupLaunchers() []string {
 	result := make([]string, 0, 4)
 	for _, name := range []string{launch.LauncherCMux, launch.LauncherGhostty, launch.LauncherTMux} {
-		if _, err := setupLookPath(name); err == nil {
+		if setupLauncherAvailable(name) {
 			result = append(result, name)
 		}
 	}
 	return append(result, launch.LauncherCommands)
+}
+
+func setupLauncherAvailable(name string) bool {
+	if name == launch.LauncherCMux {
+		return setupCmuxAvailable()
+	}
+	_, err := setupLookPath(name)
+	return err == nil
 }
 
 func setupPromptLine(reader *bufio.Reader, label, defaultValue string) (string, error) {

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -529,8 +529,9 @@ func TestSetupNoGitignorePreservesExistingBytes(t *testing.T) {
 }
 
 var (
-	execLookPathForSetup = setupLookPath
-	setupTerminalDefault = setupIsTerminal
+	execLookPathForSetup      = setupLookPath
+	setupCmuxAvailableDefault = setupCmuxAvailable
+	setupTerminalDefault      = setupIsTerminal
 )
 
 func setupProjectFixture(t *testing.T, adapters ...string) string {
@@ -553,6 +554,7 @@ func setupProjectFixture(t *testing.T, adapters ...string) string {
 		return result
 	}
 	setupLookPath = func(string) (string, error) { return "", fs.ErrNotExist }
+	setupCmuxAvailable = func() bool { return false }
 	setupCommitStepHook = nil
 	t.Cleanup(func() {
 		_ = os.Chdir(oldCWD)
@@ -564,6 +566,7 @@ func setupProjectFixture(t *testing.T, adapters ...string) string {
 			}
 		}
 		setupLookPath = execLookPathForSetup
+		setupCmuxAvailable = setupCmuxAvailableDefault
 		setupIsTerminal = setupTerminalDefault
 		setupCommitStepHook = nil
 	})
@@ -635,6 +638,48 @@ func setupTreeDigest(t *testing.T, root string) [32]byte {
 	var result [32]byte
 	copy(result[:], hash.Sum(nil))
 	return result
+}
+
+func TestSetupCmuxAvailableUsesPingNotLookPath(t *testing.T) {
+	project := setupProjectFixture(t, "claude")
+	setupLookPath = func(name string) (string, error) {
+		if name == launch.LauncherCMux {
+			return "/usr/bin/cmux", nil
+		}
+		return "", fs.ErrNotExist
+	}
+	setupCmuxAvailable = func() bool { return false }
+	lookPathOnly, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"--preview", "--json", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(setupPreviewLaunchers(t, lookPathOnly), launch.LauncherCMux) {
+		t.Fatalf("LookPath-only cmux was treated as available: %s", lookPathOnly)
+	}
+
+	setupLookPath = func(string) (string, error) { return "", fs.ErrNotExist }
+	setupCmuxAvailable = func() bool { return true }
+	pingOnly, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"--preview", "--json", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(setupPreviewLaunchers(t, pingOnly), launch.LauncherCMux) {
+		t.Fatalf("ping-available bundle cmux was omitted: %s", pingOnly)
+	}
+	_ = project
+}
+
+func setupPreviewLaunchers(t *testing.T, raw string) []string {
+	t.Helper()
+	var result setupResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("decode setup preview: %v\n%s", err, raw)
+	}
+	return result.Preview.AvailableLaunchers
 }
 
 func validateSetupMailbox(base, agent string) error {

--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -234,3 +234,14 @@ func (e *DefinitePreCreateError) Error() string {
 	return fmt.Sprintf("create refused before resource creation: %v", e.Err)
 }
 func (e *DefinitePreCreateError) Unwrap() error { return e.Err }
+
+// DefaultBackends is the production launcher map. Every CLI and public API
+// entry must use this set so a new managed backend cannot be omitted from one
+// facade.
+func DefaultBackends() map[string]Backend {
+	return map[string]Backend{
+		LauncherCommands: Commands{},
+		LauncherTMux:     NewTmuxBackend("tmux"),
+		LauncherCMux:     NewCmuxBackend(""),
+	}
+}

--- a/internal/launch/cmux.go
+++ b/internal/launch/cmux.go
@@ -155,25 +155,42 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 		return CreateResult{}, &DefinitePreCreateError{Err: err}
 	}
 	inspectCtx, inspectCancel := b.inspectCallContext()
-	existing, err := b.workspaceByName(inspectCtx, name)
+	before, err := b.listWorkspaceRecords(inspectCtx)
 	inspectCancel()
 	if err != nil {
 		return CreateResult{}, err
 	}
-	if existing != "" {
+	previousSelected := cmuxSelectedWorkspaceID(before)
+	if countNamedCmuxWorkspaces(before, name) > 0 {
 		return CreateResult{}, fmt.Errorf("cmux workspace %q already exists; journal recovery must classify it", name)
 	}
 
 	createCtx, createCancel := b.createCallContext()
-	createRaw, err := b.runJSON(createCtx, "new-workspace", "--name", name, "--cwd", req.ProjectRoot, "--focus", "true")
+	createRaw, err := b.runJSON(createCtx, "new-workspace", "--name", name, "--cwd", req.ProjectRoot, "--focus", "false")
 	createCancel()
 	if err != nil {
 		return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("create cmux workspace: %w", err))
 	}
-	workspaceID, windowID, err := parseCmuxCreatedWorkspace(createRaw)
+	if err := parseCmuxOKWorkspaceAck(createRaw); err != nil {
+		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
+	}
+	resolveCtx, resolveCancel := b.inspectCallContext()
+	createdWS, err := b.uniqueWorkspaceByName(resolveCtx, name)
+	resolveCancel()
 	if err != nil {
 		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
 	}
+	workspaceID := createdWS.ID
+	windowID := createdWS.WindowID
+	var didSelect bool
+	defer func() {
+		if !didSelect || previousSelected == "" || previousSelected == workspaceID {
+			return
+		}
+		ctx, cancel := b.inspectCallContext()
+		defer cancel()
+		_, _ = b.run(ctx, "select-workspace", "--workspace", previousSelected)
+	}()
 	surfaceCtx, surfaceCancel := b.inspectCallContext()
 	firstSurfaces, err := b.workspaceSurfaces(surfaceCtx, workspaceID)
 	surfaceCancel()
@@ -186,18 +203,20 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 	surfaceIDs := []string{firstSurfaces[0]}
 	for _, agent := range req.Plan.Agents[1:] {
 		splitCtx, splitCancel := b.createCallContext()
-		splitRaw, splitErr := b.runJSON(splitCtx, "new-split", "right", "--workspace", workspaceID, "--surface", surfaceIDs[len(surfaceIDs)-1], "--focus", "true")
+		splitRaw, splitErr := b.runJSON(splitCtx, "new-split", "right", "--workspace", workspaceID, "--surface", surfaceIDs[len(surfaceIDs)-1], "--focus", "false")
 		splitCancel()
 		if splitErr != nil {
 			return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("create cmux split for %s: %w", agent.Handle, splitErr))
 		}
-		surfaceID, splitErr := parseCmuxID(splitRaw)
+		surfaceID, splitErr := parseCmuxSplitSurface(splitRaw)
 		if splitErr != nil {
 			return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("cmux split for %s: %w", agent.Handle, splitErr))
 		}
 		surfaceIDs = append(surfaceIDs, surfaceID)
 	}
-	if err := b.waitHealthy(context.Background(), workspaceID, surfaceIDs); err != nil {
+	selected, err := b.waitHealthy(context.Background(), workspaceID, len(surfaceIDs))
+	didSelect = selected
+	if err != nil {
 		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
 	}
 	for i, agent := range req.Plan.Agents {
@@ -246,21 +265,19 @@ func (b *CmuxBackend) inspectCallContext() (context.Context, context.CancelFunc)
 	return context.WithTimeout(context.Background(), cmuxCommandTimeout)
 }
 
+func (b *CmuxBackend) orphanCallContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), cmuxCreateTimeout)
+}
+
 func (b *CmuxBackend) reconcileCreateFailure(name string, inputSent bool, cause error) error {
 	if inputSent {
 		return cause
 	}
-	ctx, cancel := b.inspectCallContext()
+	ctx, cancel := b.orphanCallContext()
 	defer cancel()
-	records, err := b.listWorkspaceRecords(ctx)
+	matches, err := b.namedWorkspaces(ctx, name)
 	if err != nil {
 		return fmt.Errorf("%w (orphan workspace reconciliation failed: %v)", cause, err)
-	}
-	var matches []cmuxListedWorkspace
-	for _, workspace := range records {
-		if workspace.Title == name {
-			matches = append(matches, workspace)
-		}
 	}
 	switch len(matches) {
 	case 0:
@@ -491,7 +508,7 @@ func (b *CmuxBackend) validateBindingContext(binding BindingRecord) error {
 	return nil
 }
 
-func (b *CmuxBackend) waitHealthy(parent context.Context, workspaceID string, surfaceIDs []string) error {
+func (b *CmuxBackend) waitHealthy(parent context.Context, workspaceID string, want int) (bool, error) {
 	timeout := b.healthTimeout
 	if timeout <= 0 {
 		timeout = cmuxHealthTimeout
@@ -501,25 +518,37 @@ func (b *CmuxBackend) waitHealthy(parent context.Context, workspaceID string, su
 		poll = cmuxHealthPoll
 	}
 	deadline := time.Now().Add(timeout)
+	didSelect := false
 	for {
 		ctx, cancel := context.WithTimeout(parent, cmuxCommandTimeout)
 		raw, err := b.runJSON(ctx, "surface-health", "--workspace", workspaceID)
-		cancel()
 		if err == nil {
-			if ready, readyErr := cmuxSurfacesHealthy(raw, surfaceIDs); readyErr != nil {
-				return readyErr
-			} else if ready {
-				return nil
+			ready, needSelect, readyErr := cmuxSurfacesHealthy(raw, want)
+			if readyErr != nil {
+				cancel()
+				return didSelect, readyErr
+			}
+			if ready {
+				cancel()
+				return didSelect, nil
+			}
+			if needSelect && !didSelect {
+				if _, selErr := b.run(ctx, "select-workspace", "--workspace", workspaceID); selErr != nil {
+					cancel()
+					return false, selErr
+				}
+				didSelect = true
 			}
 		}
+		cancel()
 		if time.Now().After(deadline) {
 			if err != nil {
-				return fmt.Errorf("cmux surface readiness timed out: %w", err)
+				return didSelect, fmt.Errorf("cmux surface readiness timed out: %w", err)
 			}
-			return fmt.Errorf("cmux surface readiness timed out before sending commands")
+			return didSelect, fmt.Errorf("cmux surface readiness timed out before sending commands")
 		}
 		if err := b.doSleep(parent, poll); err != nil {
-			return err
+			return didSelect, err
 		}
 	}
 }
@@ -529,39 +558,56 @@ func (b *CmuxBackend) workspaceSurfaces(ctx context.Context, workspaceID string)
 	if err != nil {
 		return nil, fmt.Errorf("list cmux panes: %w", err)
 	}
-	panes, err := parseCmuxIDList(raw, "panes")
+	surfaces, err := parseCmuxPaneSurfaceIDs(raw)
 	if err != nil {
 		return nil, err
 	}
-	if len(panes) == 0 {
-		return nil, fmt.Errorf("cmux workspace has no panes")
-	}
-	var surfaces []string
-	for _, pane := range panes {
-		paneRaw, paneErr := b.runJSON(ctx, "list-pane-surfaces", "--workspace", workspaceID, "--pane", pane)
-		if paneErr != nil {
-			return nil, fmt.Errorf("list cmux pane surfaces: %w", paneErr)
-		}
-		ids, paneErr := parseCmuxIDList(paneRaw, "surfaces")
-		if paneErr != nil {
-			return nil, paneErr
-		}
-		surfaces = append(surfaces, ids...)
+	if len(surfaces) == 0 {
+		return nil, fmt.Errorf("cmux workspace has no surfaces")
 	}
 	return surfaces, nil
 }
 
+func (b *CmuxBackend) uniqueWorkspaceByName(ctx context.Context, name string) (cmuxListedWorkspace, error) {
+	matches, err := b.namedWorkspaces(ctx, name)
+	if err != nil {
+		return cmuxListedWorkspace{}, err
+	}
+	switch len(matches) {
+	case 0:
+		return cmuxListedWorkspace{}, fmt.Errorf("no cmux workspace named %q appeared", name)
+	case 1:
+		return matches[0], nil
+	default:
+		ids := make([]string, 0, len(matches))
+		for _, workspace := range matches {
+			ids = append(ids, strings.ToLower(workspace.ID))
+		}
+		return cmuxListedWorkspace{}, fmt.Errorf("ambiguous cmux workspaces named %q: %s; unknown, never guessed", name, strings.Join(ids, ","))
+	}
+}
+
+func (b *CmuxBackend) namedWorkspaces(ctx context.Context, name string) ([]cmuxListedWorkspace, error) {
+	records, err := b.listWorkspaceRecords(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return namedCmuxWorkspaces(records, name), nil
+}
+
 func (b *CmuxBackend) workspaceByName(ctx context.Context, name string) (string, error) {
-	workspaces, err := b.listWorkspaceRecords(ctx)
+	matches, err := b.namedWorkspaces(ctx, name)
 	if err != nil {
 		return "", err
 	}
-	for _, workspace := range workspaces {
-		if workspace.Title == name {
-			return strings.ToLower(workspace.ID), nil
-		}
+	switch len(matches) {
+	case 0:
+		return "", nil
+	case 1:
+		return strings.ToLower(matches[0].ID), nil
+	default:
+		return "", fmt.Errorf("ambiguous cmux workspaces named %q", name)
 	}
-	return "", nil
 }
 
 func (b *CmuxBackend) listWorkspaces(ctx context.Context) ([]string, error) {
@@ -660,18 +706,14 @@ type cmuxCapabilities struct {
 }
 
 type cmuxListedWorkspace struct {
-	ID    string `json:"id"`
-	Title string `json:"title"`
-}
-
-type cmuxCreatedWorkspace struct {
 	ID       string `json:"id"`
+	Title    string `json:"title"`
 	WindowID string `json:"window_id"`
+	Selected bool   `json:"selected"`
 }
 
 type cmuxHealthSurface struct {
-	ID       string `json:"id"`
-	InWindow *bool  `json:"in_window"`
+	InWindow *bool `json:"in_window"`
 }
 
 func parseCmuxCapabilities(raw string) (cmuxCapabilities, error) {
@@ -702,6 +744,7 @@ func parseCmuxCapabilities(raw string) (cmuxCapabilities, error) {
 
 func parseCmuxWorkspaceList(raw string) ([]cmuxListedWorkspace, error) {
 	var parsed struct {
+		WindowID   string                `json:"window_id"`
 		Workspaces []cmuxListedWorkspace `json:"workspaces"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
@@ -710,94 +753,139 @@ func parseCmuxWorkspaceList(raw string) ([]cmuxListedWorkspace, error) {
 	if parsed.Workspaces == nil {
 		return nil, fmt.Errorf("cmux workspaces list is missing")
 	}
+	envelopeWindow := strings.TrimSpace(parsed.WindowID)
+	if envelopeWindow != "" {
+		id, err := normalizeCmuxUUID(envelopeWindow)
+		if err != nil {
+			return nil, fmt.Errorf("cmux workspaces window_id: %w", err)
+		}
+		envelopeWindow = id
+	}
 	for i, workspace := range parsed.Workspaces {
 		id, err := normalizeCmuxUUID(workspace.ID)
 		if err != nil {
 			return nil, fmt.Errorf("cmux workspaces[%d]: %w", i, err)
 		}
 		parsed.Workspaces[i].ID = id
+		windowID := strings.TrimSpace(workspace.WindowID)
+		if windowID == "" {
+			parsed.Workspaces[i].WindowID = envelopeWindow
+			continue
+		}
+		windowID, err = normalizeCmuxUUID(windowID)
+		if err != nil {
+			return nil, fmt.Errorf("cmux workspaces[%d] window_id: %w", i, err)
+		}
+		parsed.Workspaces[i].WindowID = windowID
 	}
 	return parsed.Workspaces, nil
 }
 
-func parseCmuxCreatedWorkspace(raw string) (string, string, error) {
-	var parsed cmuxCreatedWorkspace
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return "", "", fmt.Errorf("parse cmux new-workspace: %w", err)
+func parseCmuxOKWorkspaceAck(raw string) error {
+	if strings.Contains(strings.TrimSuffix(raw, "\n"), "\n") {
+		return fmt.Errorf("parse cmux new-workspace: extra line")
 	}
-	id, err := normalizeCmuxUUID(parsed.ID)
-	if err != nil {
-		return "", "", fmt.Errorf("cmux new-workspace: %w", err)
+	line := strings.TrimSpace(raw)
+	if !strings.HasPrefix(line, "OK workspace:") {
+		return fmt.Errorf("parse cmux new-workspace: want OK workspace: ack, got %q", line)
 	}
-	windowID := strings.TrimSpace(parsed.WindowID)
-	if windowID != "" {
-		windowID, err = normalizeCmuxUUID(windowID)
-		if err != nil {
-			return "", "", fmt.Errorf("cmux new-workspace window_id: %w", err)
-		}
+	if strings.TrimSpace(strings.TrimPrefix(line, "OK workspace:")) == "" {
+		return fmt.Errorf("parse cmux new-workspace: missing workspace ref")
 	}
-	return id, windowID, nil
+	return nil
 }
 
-func parseCmuxID(raw string) (string, error) {
+func parseCmuxSplitSurface(raw string) (string, error) {
 	var parsed struct {
-		ID string `json:"id"`
+		SurfaceID string `json:"surface_id"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return "", fmt.Errorf("parse cmux id: %w", err)
+		return "", fmt.Errorf("parse cmux new-split: %w", err)
 	}
-	return normalizeCmuxUUID(parsed.ID)
+	id, err := normalizeCmuxUUID(parsed.SurfaceID)
+	if err != nil {
+		return "", fmt.Errorf("cmux new-split surface_id: %w", err)
+	}
+	return id, nil
 }
 
-func parseCmuxIDList(raw, field string) ([]string, error) {
-	var parsed map[string][]struct {
-		ID string `json:"id"`
+func parseCmuxPaneSurfaceIDs(raw string) ([]string, error) {
+	var parsed struct {
+		Panes []struct {
+			SurfaceIDs []string `json:"surface_ids"`
+		} `json:"panes"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return nil, fmt.Errorf("parse cmux %s: %w", field, err)
+		return nil, fmt.Errorf("parse cmux panes: %w", err)
 	}
-	items, ok := parsed[field]
-	if !ok || items == nil {
-		return nil, fmt.Errorf("cmux %s list is missing", field)
+	if parsed.Panes == nil {
+		return nil, fmt.Errorf("cmux panes list is missing")
 	}
-	ids := make([]string, 0, len(items))
-	for i, item := range items {
-		id, err := normalizeCmuxUUID(item.ID)
-		if err != nil {
-			return nil, fmt.Errorf("cmux %s[%d]: %w", field, i, err)
+	var ids []string
+	for i, pane := range parsed.Panes {
+		if pane.SurfaceIDs == nil {
+			return nil, fmt.Errorf("cmux panes[%d]: surface_ids is missing", i)
 		}
-		ids = append(ids, id)
+		for j, surfaceID := range pane.SurfaceIDs {
+			id, err := normalizeCmuxUUID(surfaceID)
+			if err != nil {
+				return nil, fmt.Errorf("cmux panes[%d].surface_ids[%d]: %w", i, j, err)
+			}
+			ids = append(ids, id)
+		}
 	}
 	return ids, nil
 }
 
-func cmuxSurfacesHealthy(raw string, want []string) (bool, error) {
+func cmuxSurfacesHealthy(raw string, want int) (bool, bool, error) {
 	var parsed struct {
 		Surfaces []cmuxHealthSurface `json:"surfaces"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return false, fmt.Errorf("parse cmux surface-health: %w", err)
+		return false, false, fmt.Errorf("parse cmux surface-health: %w", err)
 	}
 	if parsed.Surfaces == nil {
-		return false, fmt.Errorf("cmux surface-health list is missing")
+		return false, false, fmt.Errorf("cmux surface-health list is missing")
 	}
-	health := map[string]bool{}
+	if len(parsed.Surfaces) != want {
+		return false, false, nil
+	}
+	needSelect := false
 	for i, surface := range parsed.Surfaces {
-		id, err := normalizeCmuxUUID(surface.ID)
-		if err != nil {
-			return false, fmt.Errorf("cmux surface-health[%d]: %w", i, err)
-		}
 		if surface.InWindow == nil {
-			return false, fmt.Errorf("cmux surface-health[%d]: in_window is required", i)
+			return false, false, fmt.Errorf("cmux surface-health[%d]: in_window is required", i)
 		}
-		health[id] = *surface.InWindow
-	}
-	for _, id := range want {
-		if !health[id] {
-			return false, nil
+		if !*surface.InWindow {
+			needSelect = true
 		}
 	}
-	return true, nil
+	if needSelect {
+		return false, true, nil
+	}
+	return true, false, nil
+}
+
+func namedCmuxWorkspaces(records []cmuxListedWorkspace, name string) []cmuxListedWorkspace {
+	var matches []cmuxListedWorkspace
+	for _, workspace := range records {
+		if workspace.Title == name {
+			matches = append(matches, workspace)
+		}
+	}
+	return matches
+}
+
+func countNamedCmuxWorkspaces(records []cmuxListedWorkspace, name string) int {
+	return len(namedCmuxWorkspaces(records, name))
+}
+
+func cmuxSelectedWorkspaceID(records []cmuxListedWorkspace) string {
+	for _, workspace := range records {
+		if workspace.Selected {
+			return strings.ToLower(workspace.ID)
+		}
+	}
+	return ""
 }
 
 func normalizeCmuxUUID(id string) (string, error) {

--- a/internal/launch/cmux.go
+++ b/internal/launch/cmux.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,6 +19,7 @@ const (
 	cmuxProfileVersion      = 1
 	cmuxProfileVersionRange = ">=0.64.3 <1.0"
 	cmuxCommandTimeout      = 5 * time.Second
+	cmuxCreateTimeout       = 30 * time.Second
 	cmuxHealthTimeout       = 15 * time.Second
 	cmuxHealthPoll          = 100 * time.Millisecond
 	cmuxBundleCLI           = "/Applications/cmux.app/Contents/Resources/bin/cmux"
@@ -25,6 +27,7 @@ const (
 	cmuxWindowPrefix        = "cmux:v1:window:"
 	cmuxSurfacePrefix       = "cmux:v1:surface:"
 	cmuxInstancePrefix      = "cmux-socket:"
+	cmuxProtocolVersion     = 2
 )
 
 // CmuxBackend manages one cmux workspace per AMQ project/session generation.
@@ -37,6 +40,7 @@ type CmuxBackend struct {
 	userHomeDir   func() (string, error)
 	isExecutable  func(string) bool
 	sleep         func(context.Context, time.Duration) error
+	createTimeout time.Duration
 	healthTimeout time.Duration
 	healthPoll    time.Duration
 }
@@ -72,32 +76,57 @@ func (b *CmuxBackend) Detect() DetectResult {
 	}
 	raw, err := b.run(ctx, "--json", "capabilities")
 	if err != nil {
+		cmuxUnsupported(&result, "cmux capabilities: "+err.Error())
 		return result
 	}
 	caps, err := parseCmuxCapabilities(raw)
 	if err != nil {
+		cmuxUnsupported(&result, err.Error())
 		return result
 	}
 	host, err := b.hostname()
 	if err != nil || strings.TrimSpace(host) == "" {
+		cmuxUnsupported(&result, "cmux host identity is unavailable")
 		return result
 	}
 	socket, err := canonicalCmuxSocket(caps.SocketPath)
 	if err != nil {
+		cmuxUnsupported(&result, "cmux socket_path: "+err.Error())
 		return result
 	}
 	result.HostIdentity = host
 	result.InstanceIdentity = cmuxInstancePrefix + socket
-	if !supportedCmuxVersion(caps.Version) {
-		reason := fmt.Sprintf("cmux version %q is outside %s", caps.Version, cmuxProfileVersionRange)
-		for _, cap := range profile.Capabilities {
-			result.Degradations = append(result.Degradations, Degradation{Capability: cap, Reason: reason})
-		}
+	if !caps.ProtocolIsInt {
+		cmuxUnsupported(&result, "cmux capabilities.version must be protocol integer 2")
+		return result
+	}
+	if caps.ProtocolVersion != cmuxProtocolVersion {
+		cmuxUnsupported(&result, fmt.Sprintf("cmux protocol version %d is unsupported (want %d)", caps.ProtocolVersion, cmuxProtocolVersion))
+		return result
+	}
+	verRaw, err := b.run(ctx, "version")
+	if err != nil {
+		cmuxUnsupported(&result, "cmux version: "+err.Error())
+		return result
+	}
+	appVersion, err := parseCmuxCLIVersion(verRaw)
+	if err != nil {
+		cmuxUnsupported(&result, err.Error())
+		return result
+	}
+	if !supportedCmuxVersion(appVersion) {
+		cmuxUnsupported(&result, fmt.Sprintf("cmux version %q is outside %s", appVersion, cmuxProfileVersionRange))
 		return result
 	}
 	result.Available = true
 	result.Effective = append([]Capability(nil), profile.Capabilities...)
 	return result
+}
+
+func cmuxUnsupported(result *DetectResult, reason string) {
+	for _, cap := range result.Profile.Capabilities {
+		result.Degradations = append(result.Degradations, Degradation{Capability: cap, Reason: reason})
+	}
 }
 
 func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
@@ -125,8 +154,9 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 	if err != nil {
 		return CreateResult{}, &DefinitePreCreateError{Err: err}
 	}
-	ctx := context.Background()
-	existing, err := b.workspaceByName(ctx, name)
+	inspectCtx, inspectCancel := b.inspectCallContext()
+	existing, err := b.workspaceByName(inspectCtx, name)
+	inspectCancel()
 	if err != nil {
 		return CreateResult{}, err
 	}
@@ -134,43 +164,55 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 		return CreateResult{}, fmt.Errorf("cmux workspace %q already exists; journal recovery must classify it", name)
 	}
 
-	createRaw, err := b.runJSON(ctx, "new-workspace", "--name", name, "--cwd", req.ProjectRoot, "--focus", "true")
+	createCtx, createCancel := b.createCallContext()
+	createRaw, err := b.runJSON(createCtx, "new-workspace", "--name", name, "--cwd", req.ProjectRoot, "--focus", "true")
+	createCancel()
 	if err != nil {
-		return CreateResult{}, fmt.Errorf("create cmux workspace: %w", err)
+		return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("create cmux workspace: %w", err))
 	}
 	workspaceID, windowID, err := parseCmuxCreatedWorkspace(createRaw)
 	if err != nil {
-		return CreateResult{}, err
+		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
 	}
-	firstSurfaces, err := b.workspaceSurfaces(ctx, workspaceID)
+	surfaceCtx, surfaceCancel := b.inspectCallContext()
+	firstSurfaces, err := b.workspaceSurfaces(surfaceCtx, workspaceID)
+	surfaceCancel()
 	if err != nil {
-		return CreateResult{}, err
+		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
 	}
 	if len(firstSurfaces) != 1 {
-		return CreateResult{}, fmt.Errorf("cmux workspace created %d surfaces, want 1", len(firstSurfaces))
+		return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("cmux workspace created %d surfaces, want 1", len(firstSurfaces)))
 	}
 	surfaceIDs := []string{firstSurfaces[0]}
 	for _, agent := range req.Plan.Agents[1:] {
-		splitRaw, splitErr := b.runJSON(ctx, "new-split", "right", "--workspace", workspaceID, "--surface", surfaceIDs[len(surfaceIDs)-1], "--focus", "true")
+		splitCtx, splitCancel := b.createCallContext()
+		splitRaw, splitErr := b.runJSON(splitCtx, "new-split", "right", "--workspace", workspaceID, "--surface", surfaceIDs[len(surfaceIDs)-1], "--focus", "true")
+		splitCancel()
 		if splitErr != nil {
-			return CreateResult{}, fmt.Errorf("create cmux split for %s: %w", agent.Handle, splitErr)
+			return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("create cmux split for %s: %w", agent.Handle, splitErr))
 		}
 		surfaceID, splitErr := parseCmuxID(splitRaw)
 		if splitErr != nil {
-			return CreateResult{}, fmt.Errorf("cmux split for %s: %w", agent.Handle, splitErr)
+			return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("cmux split for %s: %w", agent.Handle, splitErr))
 		}
 		surfaceIDs = append(surfaceIDs, surfaceID)
 	}
-	if err := b.waitHealthy(ctx, workspaceID, surfaceIDs); err != nil {
-		return CreateResult{}, err
+	if err := b.waitHealthy(context.Background(), workspaceID, surfaceIDs); err != nil {
+		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
 	}
 	for i, agent := range req.Plan.Agents {
 		line := b.agentCommand(req, agent)
-		if _, err := b.run(ctx, "send", "--surface", surfaceIDs[i], "--", line); err != nil {
-			return CreateResult{}, fmt.Errorf("send cmux command for %s: %w", agent.Handle, err)
+		sendCtx, sendCancel := b.inspectCallContext()
+		_, err := b.run(sendCtx, "send", "--surface", surfaceIDs[i], "--", line)
+		sendCancel()
+		if err != nil {
+			return CreateResult{}, b.reconcileCreateFailure(name, true, fmt.Errorf("send cmux command for %s: %w", agent.Handle, err))
 		}
-		if _, err := b.run(ctx, "send-key", "--surface", surfaceIDs[i], "enter"); err != nil {
-			return CreateResult{}, fmt.Errorf("submit cmux command for %s: %w", agent.Handle, err)
+		enterCtx, enterCancel := b.inspectCallContext()
+		_, err = b.run(enterCtx, "send-key", "--surface", surfaceIDs[i], "enter")
+		enterCancel()
+		if err != nil {
+			return CreateResult{}, b.reconcileCreateFailure(name, true, fmt.Errorf("submit cmux command for %s: %w", agent.Handle, err))
 		}
 	}
 	resources := cmuxBindingResources(workspaceID, windowID, nonce, req.Plan, surfaceIDs)
@@ -187,6 +229,55 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 		return CreateResult{}, err
 	}
 	return CreateResult{Outcome: OutcomeCreated, Profile: binding.Profile, Binding: binding}, nil
+}
+
+func (b *CmuxBackend) createOpTimeout() time.Duration {
+	if b.createTimeout > 0 {
+		return b.createTimeout
+	}
+	return cmuxCreateTimeout
+}
+
+func (b *CmuxBackend) createCallContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), b.createOpTimeout())
+}
+
+func (b *CmuxBackend) inspectCallContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), cmuxCommandTimeout)
+}
+
+func (b *CmuxBackend) reconcileCreateFailure(name string, inputSent bool, cause error) error {
+	if inputSent {
+		return cause
+	}
+	ctx, cancel := b.inspectCallContext()
+	defer cancel()
+	records, err := b.listWorkspaceRecords(ctx)
+	if err != nil {
+		return fmt.Errorf("%w (orphan workspace reconciliation failed: %v)", cause, err)
+	}
+	var matches []cmuxListedWorkspace
+	for _, workspace := range records {
+		if workspace.Title == name {
+			matches = append(matches, workspace)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return fmt.Errorf("%w (no cmux workspace named %q appeared)", cause, name)
+	case 1:
+		id := strings.ToLower(matches[0].ID)
+		if _, closeErr := b.run(ctx, "close-workspace", "--workspace", id); closeErr != nil {
+			return fmt.Errorf("%w (close orphan %s: %v)", cause, id, closeErr)
+		}
+		return fmt.Errorf("%w (closed orphan cmux workspace %s)", cause, id)
+	default:
+		ids := make([]string, 0, len(matches))
+		for _, workspace := range matches {
+			ids = append(ids, strings.ToLower(workspace.ID))
+		}
+		return fmt.Errorf("%w (ambiguous cmux workspaces named %q: %s; unknown, never guessed)", cause, name, strings.Join(ids, ","))
+	}
 }
 
 func (b *CmuxBackend) Inspect(req InspectRequest) (InspectResult, error) {
@@ -563,8 +654,9 @@ func (b *CmuxBackend) doSleep(ctx context.Context, delay time.Duration) error {
 }
 
 type cmuxCapabilities struct {
-	SocketPath string `json:"socket_path"`
-	Version    string `json:"version"`
+	SocketPath      string
+	ProtocolVersion int
+	ProtocolIsInt   bool
 }
 
 type cmuxListedWorkspace struct {
@@ -583,13 +675,28 @@ type cmuxHealthSurface struct {
 }
 
 func parseCmuxCapabilities(raw string) (cmuxCapabilities, error) {
-	var caps cmuxCapabilities
-	if err := json.Unmarshal([]byte(raw), &caps); err != nil {
+	var parsed struct {
+		SocketPath string          `json:"socket_path"`
+		Version    json.RawMessage `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
 		return cmuxCapabilities{}, fmt.Errorf("parse cmux capabilities: %w", err)
 	}
-	if strings.TrimSpace(caps.SocketPath) == "" || strings.TrimSpace(caps.Version) == "" {
-		return cmuxCapabilities{}, fmt.Errorf("cmux capabilities missing socket_path or version")
+	if strings.TrimSpace(parsed.SocketPath) == "" {
+		return cmuxCapabilities{}, fmt.Errorf("cmux capabilities missing socket_path")
 	}
+	caps := cmuxCapabilities{SocketPath: parsed.SocketPath}
+	version := bytes.TrimSpace(parsed.Version)
+	if len(version) == 0 || string(version) == "null" {
+		return cmuxCapabilities{}, fmt.Errorf("cmux capabilities missing version")
+	}
+	if version[0] == '"' {
+		return caps, nil
+	}
+	if err := json.Unmarshal(version, &caps.ProtocolVersion); err != nil {
+		return cmuxCapabilities{}, fmt.Errorf("parse cmux capabilities version: %w", err)
+	}
+	caps.ProtocolIsInt = true
 	return caps, nil
 }
 
@@ -712,26 +819,57 @@ func canonicalCmuxSocket(path string) (string, error) {
 	return cleaned, nil
 }
 
-func supportedCmuxVersion(raw string) bool {
-	version := strings.TrimSpace(raw)
-	if fields := strings.Fields(version); len(fields) > 0 {
-		version = strings.TrimPrefix(fields[0], "cmux")
-		if version == "" && len(fields) > 1 {
-			version = fields[1]
-		}
-		version = strings.TrimSpace(strings.TrimPrefix(version, "-"))
+func parseCmuxCLIVersion(raw string) (string, error) {
+	if strings.Contains(strings.TrimSuffix(raw, "\n"), "\n") {
+		return "", fmt.Errorf("parse cmux version: extra line")
 	}
-	parts := strings.SplitN(version, ".", 3)
-	if len(parts) < 2 {
+	line := strings.TrimSpace(raw)
+	fields := strings.Fields(line)
+	if len(fields) < 2 || fields[0] != "cmux" {
+		return "", fmt.Errorf("parse cmux version: %q", line)
+	}
+	version := fields[1]
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("parse cmux version: %q", line)
+	}
+	for _, part := range parts {
+		if part == "" {
+			return "", fmt.Errorf("parse cmux version: %q", line)
+		}
+		if _, err := strconv.Atoi(part); err != nil {
+			return "", fmt.Errorf("parse cmux version: %q", line)
+		}
+	}
+	rest := fields[2:]
+	switch len(rest) {
+	case 0:
+		return version, nil
+	case 1:
+		if !strings.HasPrefix(rest[0], "(") || !strings.HasSuffix(rest[0], ")") {
+			return "", fmt.Errorf("parse cmux version: %q", line)
+		}
+		return version, nil
+	case 2:
+		if !strings.HasPrefix(rest[0], "(") || !strings.HasSuffix(rest[0], ")") ||
+			!strings.HasPrefix(rest[1], "[") || !strings.HasSuffix(rest[1], "]") {
+			return "", fmt.Errorf("parse cmux version: %q", line)
+		}
+		return version, nil
+	default:
+		return "", fmt.Errorf("parse cmux version: %q", line)
+	}
+}
+
+func supportedCmuxVersion(raw string) bool {
+	parts := strings.Split(strings.TrimSpace(raw), ".")
+	if len(parts) != 3 {
 		return false
 	}
 	major, errMajor := strconv.Atoi(parts[0])
-	minor, errMinor := strconv.Atoi(strings.TrimRightFunc(parts[1], func(r rune) bool { return r < '0' || r > '9' }))
-	patch := 0
-	if len(parts) > 2 {
-		patch, _ = strconv.Atoi(strings.TrimRightFunc(parts[2], func(r rune) bool { return r < '0' || r > '9' }))
-	}
-	if errMajor != nil || errMinor != nil || major != 0 {
+	minor, errMinor := strconv.Atoi(parts[1])
+	patch, errPatch := strconv.Atoi(parts[2])
+	if errMajor != nil || errMinor != nil || errPatch != nil || major != 0 {
 		return false
 	}
 	if minor > 64 {

--- a/internal/launch/cmux.go
+++ b/internal/launch/cmux.go
@@ -1,0 +1,870 @@
+package launch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	cmuxProfileVersion      = 1
+	cmuxProfileVersionRange = ">=0.64.3 <1.0"
+	cmuxCommandTimeout      = 5 * time.Second
+	cmuxHealthTimeout       = 15 * time.Second
+	cmuxHealthPoll          = 100 * time.Millisecond
+	cmuxBundleCLI           = "/Applications/cmux.app/Contents/Resources/bin/cmux"
+	cmuxWorkspacePrefix     = "cmux:v1:workspace:"
+	cmuxWindowPrefix        = "cmux:v1:window:"
+	cmuxSurfacePrefix       = "cmux:v1:surface:"
+	cmuxInstancePrefix      = "cmux-socket:"
+)
+
+// CmuxBackend manages one cmux workspace per AMQ project/session generation.
+type CmuxBackend struct {
+	binary        string
+	run           func(context.Context, ...string) (string, error)
+	hostname      func() (string, error)
+	getenv        func(string) string
+	lookPath      func(string) (string, error)
+	userHomeDir   func() (string, error)
+	isExecutable  func(string) bool
+	sleep         func(context.Context, time.Duration) error
+	healthTimeout time.Duration
+	healthPoll    time.Duration
+}
+
+func NewCmuxBackend(binary string) *CmuxBackend {
+	b := &CmuxBackend{
+		binary: strings.TrimSpace(binary), hostname: os.Hostname, getenv: os.Getenv,
+		lookPath: exec.LookPath, userHomeDir: os.UserHomeDir, isExecutable: cmuxExecutable,
+		healthTimeout: cmuxHealthTimeout, healthPoll: cmuxHealthPoll,
+	}
+	b.run = b.runCommand
+	return b
+}
+
+func CmuxProfile() Profile {
+	return Profile{
+		Backend: LauncherCMux, Platform: "darwin",
+		VersionRange: cmuxProfileVersionRange, Version: cmuxProfileVersion,
+		Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus, CapReclaim},
+	}
+}
+
+func (b *CmuxBackend) Detect() DetectResult {
+	profile := CmuxProfile()
+	result := DetectResult{Profile: profile}
+	if _, err := b.resolveExecutable(); err != nil {
+		return result
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), cmuxCommandTimeout)
+	defer cancel()
+	if _, err := b.run(ctx, "ping"); err != nil {
+		return result
+	}
+	raw, err := b.run(ctx, "--json", "capabilities")
+	if err != nil {
+		return result
+	}
+	caps, err := parseCmuxCapabilities(raw)
+	if err != nil {
+		return result
+	}
+	host, err := b.hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		return result
+	}
+	socket, err := canonicalCmuxSocket(caps.SocketPath)
+	if err != nil {
+		return result
+	}
+	result.HostIdentity = host
+	result.InstanceIdentity = cmuxInstancePrefix + socket
+	if !supportedCmuxVersion(caps.Version) {
+		reason := fmt.Sprintf("cmux version %q is outside %s", caps.Version, cmuxProfileVersionRange)
+		for _, cap := range profile.Capabilities {
+			result.Degradations = append(result.Degradations, Degradation{Capability: cap, Reason: reason})
+		}
+		return result
+	}
+	result.Available = true
+	result.Effective = append([]Capability(nil), profile.Capabilities...)
+	return result
+}
+
+func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
+	if err := b.validateCreate(req); err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: err}
+	}
+	amqPath := req.AMQPath
+	if strings.TrimSpace(amqPath) == "" {
+		amqPath = "amq"
+	}
+	resolvedAMQ, err := exec.LookPath(amqPath)
+	if err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("resolve amq executable: %w", err)}
+	}
+	if resolvedAMQ, err = filepath.EvalSymlinks(resolvedAMQ); err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("resolve amq executable identity: %w", err)}
+	}
+	req.AMQPath = resolvedAMQ
+	detect := b.Detect()
+	if !detect.Available {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("cmux %s is unavailable", cmuxProfileVersionRange)}
+	}
+	nonce := req.Plan.Agents[0].LaunchNonce
+	name, err := cmuxWorkspaceName(req.ProjectRoot, req.Session, nonce)
+	if err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: err}
+	}
+	ctx := context.Background()
+	existing, err := b.workspaceByName(ctx, name)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	if existing != "" {
+		return CreateResult{}, fmt.Errorf("cmux workspace %q already exists; journal recovery must classify it", name)
+	}
+
+	createRaw, err := b.runJSON(ctx, "new-workspace", "--name", name, "--cwd", req.ProjectRoot, "--focus", "true")
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("create cmux workspace: %w", err)
+	}
+	workspaceID, windowID, err := parseCmuxCreatedWorkspace(createRaw)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	firstSurfaces, err := b.workspaceSurfaces(ctx, workspaceID)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	if len(firstSurfaces) != 1 {
+		return CreateResult{}, fmt.Errorf("cmux workspace created %d surfaces, want 1", len(firstSurfaces))
+	}
+	surfaceIDs := []string{firstSurfaces[0]}
+	for _, agent := range req.Plan.Agents[1:] {
+		splitRaw, splitErr := b.runJSON(ctx, "new-split", "right", "--workspace", workspaceID, "--surface", surfaceIDs[len(surfaceIDs)-1], "--focus", "true")
+		if splitErr != nil {
+			return CreateResult{}, fmt.Errorf("create cmux split for %s: %w", agent.Handle, splitErr)
+		}
+		surfaceID, splitErr := parseCmuxID(splitRaw)
+		if splitErr != nil {
+			return CreateResult{}, fmt.Errorf("cmux split for %s: %w", agent.Handle, splitErr)
+		}
+		surfaceIDs = append(surfaceIDs, surfaceID)
+	}
+	if err := b.waitHealthy(ctx, workspaceID, surfaceIDs); err != nil {
+		return CreateResult{}, err
+	}
+	for i, agent := range req.Plan.Agents {
+		line := b.agentCommand(req, agent)
+		if _, err := b.run(ctx, "send", "--surface", surfaceIDs[i], "--", line); err != nil {
+			return CreateResult{}, fmt.Errorf("send cmux command for %s: %w", agent.Handle, err)
+		}
+		if _, err := b.run(ctx, "send-key", "--surface", surfaceIDs[i], "enter"); err != nil {
+			return CreateResult{}, fmt.Errorf("submit cmux command for %s: %w", agent.Handle, err)
+		}
+	}
+	resources := cmuxBindingResources(workspaceID, windowID, nonce, req.Plan, surfaceIDs)
+	if issues := cmuxInventoryIssues(resources, req.Plan); len(issues) != 0 {
+		return CreateResult{}, fmt.Errorf("created cmux inventory differs from plan: %s", strings.Join(issues, ","))
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherCMux, HostIdentity: detect.HostIdentity,
+		InstanceIdentity: detect.InstanceIdentity, Profile: detect.Profile.Identity(),
+		LaunchNonce: nonce,
+		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: resources},
+	}
+	if err := binding.Validate(); err != nil {
+		return CreateResult{}, err
+	}
+	return CreateResult{Outcome: OutcomeCreated, Profile: binding.Profile, Binding: binding}, nil
+}
+
+func (b *CmuxBackend) Inspect(req InspectRequest) (InspectResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), cmuxCommandTimeout)
+	defer cancel()
+	state, err := b.inspect(ctx, req.Binding)
+	if err != nil {
+		return InspectResult{Status: InspectUnknown, Evidence: err.Error(), ActionRequired: true}, nil
+	}
+	return state, nil
+}
+
+func (b *CmuxBackend) Close(req CloseRequest) (CloseResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), cmuxCommandTimeout)
+	defer cancel()
+	inspection, err := b.inspect(ctx, req.Binding)
+	if err != nil {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: err.Error()}, nil
+	}
+	if inspection.Status == InspectAbsent {
+		return CloseResult{Outcome: OutcomeClosed, Reason: "cmux workspace already absent"}, nil
+	}
+	if inspection.Status != InspectPresent {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: inspection.Evidence}, nil
+	}
+	workspaceID, _, err := parseCmuxWorkspaceResource(req.Binding)
+	if err != nil {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: err.Error()}, nil
+	}
+	if _, err := b.run(ctx, "close-workspace", "--workspace", workspaceID); err != nil {
+		return CloseResult{}, fmt.Errorf("close cmux workspace: %w", err)
+	}
+	return CloseResult{Outcome: OutcomeClosed, Reason: "cmux workspace closed"}, nil
+}
+
+func (b *CmuxBackend) Focus(req FocusRequest) (FocusResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), cmuxCommandTimeout)
+	defer cancel()
+	inspection, err := b.inspect(ctx, req.Binding)
+	if err != nil || inspection.Status != InspectPresent {
+		if err != nil {
+			return FocusResult{}, err
+		}
+		return FocusResult{Outcome: OutcomeActionRequired, Reason: inspection.Evidence}, nil
+	}
+	workspaceID, _, err := parseCmuxWorkspaceResource(req.Binding)
+	if err != nil {
+		return FocusResult{}, err
+	}
+	if _, err := b.run(ctx, "select-workspace", "--workspace", workspaceID); err != nil {
+		return FocusResult{}, err
+	}
+	if windowID := cmuxWindowID(req.Binding); windowID != "" {
+		if _, err := b.run(ctx, "focus-window", "--window", windowID); err != nil {
+			return FocusResult{}, err
+		}
+	}
+	return FocusResult{Outcome: OutcomeAttached}, nil
+}
+
+func (b *CmuxBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
+	parent := req.Context
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, cmuxCommandTimeout)
+	defer cancel()
+	if req.Root == nil {
+		return ReclaimResult{}, fmt.Errorf("missing pinned session root")
+	}
+	rootIdentity, err := canonicalIdentity(req.Root.Base())
+	if err != nil || rootIdentity != req.Journal.RootIdentity {
+		return ReclaimResult{Status: ReclaimForeign, Evidence: "journal session root does not match the pinned root"}, nil
+	}
+	if req.Journal.RootPhysical != "" {
+		physical, physicalErr := fsq.StableTreeIdentityInfo(req.Root.FileInfo())
+		if physicalErr != nil || physical != req.Journal.RootPhysical {
+			return ReclaimResult{Status: ReclaimForeign, Evidence: "journal session root identity changed"}, nil
+		}
+	}
+	name, err := cmuxWorkspaceName(req.Journal.ProjectIdentity, req.Journal.Session, req.Journal.LaunchNonce)
+	if err != nil {
+		return ReclaimResult{}, err
+	}
+	workspaceID, err := b.workspaceByName(ctx, name)
+	if err != nil {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
+	}
+	if workspaceID == "" {
+		return ReclaimResult{Status: ReclaimAbsent, Evidence: "deterministic cmux workspace is absent"}, nil
+	}
+	surfaceIDs, err := b.workspaceSurfaces(ctx, workspaceID)
+	if err != nil {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
+	}
+	resources := cmuxBindingResources(workspaceID, "", req.Journal.LaunchNonce, req.Journal.Plan, surfaceIDs)
+	issues := cmuxInventoryIssues(resources, req.Journal.Plan)
+	if len(issues) != 0 {
+		return ReclaimResult{
+			Status: ReclaimIncomplete, Evidence: "cmux workspace inventory differs from plan: " + strings.Join(issues, ","),
+			Resources: resources,
+		}, nil
+	}
+	detect := b.Detect()
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherCMux, HostIdentity: req.Journal.HostIdentity,
+		InstanceIdentity: req.Journal.InstanceIdentity, Profile: req.Journal.Profile,
+		LaunchNonce: req.Journal.LaunchNonce,
+		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: resources},
+	}
+	if !detect.Available || detect.HostIdentity != binding.HostIdentity ||
+		detect.InstanceIdentity != binding.InstanceIdentity || CmuxProfile().Identity() != binding.Profile {
+		return ReclaimResult{Status: ReclaimForeign, Evidence: "cmux runtime identity changed", Resources: resources}, nil
+	}
+	return ReclaimResult{Status: ReclaimAdoptable, Evidence: "cmux workspace and nonce match the complete journal plan", Resources: resources, Binding: binding}, nil
+}
+
+func (b *CmuxBackend) validateCreate(req CreateRequest) error {
+	if strings.TrimSpace(req.ProjectRoot) == "" || strings.TrimSpace(req.Session) == "" || req.Root == nil {
+		return fmt.Errorf("project root, session, and pinned root are required")
+	}
+	if err := req.Plan.Validate(); err != nil {
+		return err
+	}
+	if _, err := canonicalIdentity(req.ProjectRoot); err != nil {
+		return fmt.Errorf("resolve project root: %w", err)
+	}
+	handles := make([]string, len(req.Plan.Agents))
+	nonce := req.Plan.Agents[0].LaunchNonce
+	if !validUUID(nonce) {
+		return fmt.Errorf("launch nonce must be a UUID")
+	}
+	for i, agent := range req.Plan.Agents {
+		handles[i] = agent.Handle
+		if agent.LaunchNonce != nonce {
+			return fmt.Errorf("agent %q has a different launch nonce", agent.Handle)
+		}
+	}
+	if err := fsq.ValidateExistingMailboxLayout(req.Root, handles...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *CmuxBackend) inspect(ctx context.Context, binding BindingRecord) (InspectResult, error) {
+	if err := binding.Validate(); err != nil {
+		return InspectResult{}, err
+	}
+	if err := b.validateBindingContext(binding); err != nil {
+		return InspectResult{}, err
+	}
+	workspaceID, nonce, err := parseCmuxWorkspaceResource(binding)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	if nonce != binding.LaunchNonce {
+		return InspectResult{Status: InspectUnknown, Evidence: "cmux workspace nonce differs from binding", ActionRequired: true}, nil
+	}
+	listed, err := b.listWorkspaces(ctx)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	if !cmuxContainsID(listed, workspaceID) {
+		return InspectResult{Status: InspectAbsent, Evidence: "cmux workspace is absent"}, nil
+	}
+	live, err := b.workspaceSurfaces(ctx, workspaceID)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	want := map[string]string{}
+	for _, resource := range binding.Resources.Resources {
+		if resource.Agent != "" {
+			id, parseErr := parseCmuxSurfaceResource(resource.OpaqueID)
+			if parseErr != nil {
+				return InspectResult{}, parseErr
+			}
+			want[id] = resource.Agent
+		}
+	}
+	if len(live) != len(want) {
+		return InspectResult{Status: InspectUnknown, Evidence: "cmux resource inventory differs from binding", ActionRequired: true}, nil
+	}
+	liveSet := map[string]bool{}
+	for _, id := range live {
+		liveSet[id] = true
+	}
+	for id := range want {
+		if !liveSet[id] {
+			return InspectResult{Status: InspectUnknown, Evidence: "cmux resource identity differs from binding", ActionRequired: true}, nil
+		}
+	}
+	return InspectResult{Status: InspectPresent, Evidence: "cmux workspace and surface inventory match"}, nil
+}
+
+func (b *CmuxBackend) validateBindingContext(binding BindingRecord) error {
+	host, err := b.hostname()
+	if err != nil {
+		return fmt.Errorf("resolve cmux host identity: %w", err)
+	}
+	if binding.Backend != LauncherCMux || binding.Profile != CmuxProfile().Identity() ||
+		binding.HostIdentity != host {
+		return fmt.Errorf("cmux binding belongs to a different backend context")
+	}
+	detect := b.Detect()
+	if detect.InstanceIdentity == "" {
+		return fmt.Errorf("cmux socket is unreachable")
+	}
+	if binding.InstanceIdentity != detect.InstanceIdentity {
+		return fmt.Errorf("cmux binding belongs to a different backend context")
+	}
+	return nil
+}
+
+func (b *CmuxBackend) waitHealthy(parent context.Context, workspaceID string, surfaceIDs []string) error {
+	timeout := b.healthTimeout
+	if timeout <= 0 {
+		timeout = cmuxHealthTimeout
+	}
+	poll := b.healthPoll
+	if poll <= 0 {
+		poll = cmuxHealthPoll
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		ctx, cancel := context.WithTimeout(parent, cmuxCommandTimeout)
+		raw, err := b.runJSON(ctx, "surface-health", "--workspace", workspaceID)
+		cancel()
+		if err == nil {
+			if ready, readyErr := cmuxSurfacesHealthy(raw, surfaceIDs); readyErr != nil {
+				return readyErr
+			} else if ready {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("cmux surface readiness timed out: %w", err)
+			}
+			return fmt.Errorf("cmux surface readiness timed out before sending commands")
+		}
+		if err := b.doSleep(parent, poll); err != nil {
+			return err
+		}
+	}
+}
+
+func (b *CmuxBackend) workspaceSurfaces(ctx context.Context, workspaceID string) ([]string, error) {
+	raw, err := b.runJSON(ctx, "list-panes", "--workspace", workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list cmux panes: %w", err)
+	}
+	panes, err := parseCmuxIDList(raw, "panes")
+	if err != nil {
+		return nil, err
+	}
+	if len(panes) == 0 {
+		return nil, fmt.Errorf("cmux workspace has no panes")
+	}
+	var surfaces []string
+	for _, pane := range panes {
+		paneRaw, paneErr := b.runJSON(ctx, "list-pane-surfaces", "--workspace", workspaceID, "--pane", pane)
+		if paneErr != nil {
+			return nil, fmt.Errorf("list cmux pane surfaces: %w", paneErr)
+		}
+		ids, paneErr := parseCmuxIDList(paneRaw, "surfaces")
+		if paneErr != nil {
+			return nil, paneErr
+		}
+		surfaces = append(surfaces, ids...)
+	}
+	return surfaces, nil
+}
+
+func (b *CmuxBackend) workspaceByName(ctx context.Context, name string) (string, error) {
+	workspaces, err := b.listWorkspaceRecords(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, workspace := range workspaces {
+		if workspace.Title == name {
+			return strings.ToLower(workspace.ID), nil
+		}
+	}
+	return "", nil
+}
+
+func (b *CmuxBackend) listWorkspaces(ctx context.Context) ([]string, error) {
+	records, err := b.listWorkspaceRecords(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(records))
+	for _, workspace := range records {
+		ids = append(ids, strings.ToLower(workspace.ID))
+	}
+	return ids, nil
+}
+
+func (b *CmuxBackend) listWorkspaceRecords(ctx context.Context) ([]cmuxListedWorkspace, error) {
+	raw, err := b.runJSON(ctx, "list-workspaces")
+	if err != nil {
+		return nil, fmt.Errorf("list cmux workspaces: %w", err)
+	}
+	return parseCmuxWorkspaceList(raw)
+}
+
+func (b *CmuxBackend) agentCommand(req CreateRequest, agent AgentPlan) string {
+	amq := req.AMQPath
+	if strings.TrimSpace(amq) == "" {
+		amq = "amq"
+	}
+	env := cloneEnv(agent.EnvOverlay)
+	if env == nil {
+		env = make(map[string]string, 1)
+	}
+	env[InternalLaunchNonceEnv] = agent.LaunchNonce
+	return commandLine(agent.Cwd, env, coopExecArgv(amq, req.Root.Base(), agent.Handle, agent.Argv, agent.Execution))
+}
+
+func (b *CmuxBackend) runJSON(ctx context.Context, args ...string) (string, error) {
+	full := append([]string{"--id-format", "uuids", "--json"}, args...)
+	return b.run(ctx, full...)
+}
+
+func (b *CmuxBackend) runCommand(ctx context.Context, args ...string) (string, error) {
+	path, err := b.resolveExecutable()
+	if err != nil {
+		return "", err
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cmuxCommandTimeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, path, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("cmux %s: %w: %s", strings.Join(redactCmuxArgs(args), " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func (b *CmuxBackend) resolveExecutable() (string, error) {
+	if strings.TrimSpace(b.binary) != "" {
+		return filepath.Clean(b.binary), nil
+	}
+	if path, err := b.lookPath("cmux"); err == nil {
+		return filepath.Clean(path), nil
+	}
+	candidates := []string{cmuxBundleCLI}
+	if home, err := b.userHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		candidates = append(candidates, filepath.Join(home, "Applications", "cmux.app", "Contents", "Resources", "bin", "cmux"))
+	}
+	for _, candidate := range candidates {
+		if b.isExecutable(candidate) {
+			return filepath.Clean(candidate), nil
+		}
+	}
+	return "", fmt.Errorf("cmux CLI not found")
+}
+
+func (b *CmuxBackend) doSleep(ctx context.Context, delay time.Duration) error {
+	if b.sleep != nil {
+		return b.sleep(ctx, delay)
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type cmuxCapabilities struct {
+	SocketPath string `json:"socket_path"`
+	Version    string `json:"version"`
+}
+
+type cmuxListedWorkspace struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+type cmuxCreatedWorkspace struct {
+	ID       string `json:"id"`
+	WindowID string `json:"window_id"`
+}
+
+type cmuxHealthSurface struct {
+	ID       string `json:"id"`
+	InWindow *bool  `json:"in_window"`
+}
+
+func parseCmuxCapabilities(raw string) (cmuxCapabilities, error) {
+	var caps cmuxCapabilities
+	if err := json.Unmarshal([]byte(raw), &caps); err != nil {
+		return cmuxCapabilities{}, fmt.Errorf("parse cmux capabilities: %w", err)
+	}
+	if strings.TrimSpace(caps.SocketPath) == "" || strings.TrimSpace(caps.Version) == "" {
+		return cmuxCapabilities{}, fmt.Errorf("cmux capabilities missing socket_path or version")
+	}
+	return caps, nil
+}
+
+func parseCmuxWorkspaceList(raw string) ([]cmuxListedWorkspace, error) {
+	var parsed struct {
+		Workspaces []cmuxListedWorkspace `json:"workspaces"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("parse cmux workspaces: %w", err)
+	}
+	if parsed.Workspaces == nil {
+		return nil, fmt.Errorf("cmux workspaces list is missing")
+	}
+	for i, workspace := range parsed.Workspaces {
+		id, err := normalizeCmuxUUID(workspace.ID)
+		if err != nil {
+			return nil, fmt.Errorf("cmux workspaces[%d]: %w", i, err)
+		}
+		parsed.Workspaces[i].ID = id
+	}
+	return parsed.Workspaces, nil
+}
+
+func parseCmuxCreatedWorkspace(raw string) (string, string, error) {
+	var parsed cmuxCreatedWorkspace
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return "", "", fmt.Errorf("parse cmux new-workspace: %w", err)
+	}
+	id, err := normalizeCmuxUUID(parsed.ID)
+	if err != nil {
+		return "", "", fmt.Errorf("cmux new-workspace: %w", err)
+	}
+	windowID := strings.TrimSpace(parsed.WindowID)
+	if windowID != "" {
+		windowID, err = normalizeCmuxUUID(windowID)
+		if err != nil {
+			return "", "", fmt.Errorf("cmux new-workspace window_id: %w", err)
+		}
+	}
+	return id, windowID, nil
+}
+
+func parseCmuxID(raw string) (string, error) {
+	var parsed struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return "", fmt.Errorf("parse cmux id: %w", err)
+	}
+	return normalizeCmuxUUID(parsed.ID)
+}
+
+func parseCmuxIDList(raw, field string) ([]string, error) {
+	var parsed map[string][]struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("parse cmux %s: %w", field, err)
+	}
+	items, ok := parsed[field]
+	if !ok || items == nil {
+		return nil, fmt.Errorf("cmux %s list is missing", field)
+	}
+	ids := make([]string, 0, len(items))
+	for i, item := range items {
+		id, err := normalizeCmuxUUID(item.ID)
+		if err != nil {
+			return nil, fmt.Errorf("cmux %s[%d]: %w", field, i, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func cmuxSurfacesHealthy(raw string, want []string) (bool, error) {
+	var parsed struct {
+		Surfaces []cmuxHealthSurface `json:"surfaces"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return false, fmt.Errorf("parse cmux surface-health: %w", err)
+	}
+	if parsed.Surfaces == nil {
+		return false, fmt.Errorf("cmux surface-health list is missing")
+	}
+	health := map[string]bool{}
+	for i, surface := range parsed.Surfaces {
+		id, err := normalizeCmuxUUID(surface.ID)
+		if err != nil {
+			return false, fmt.Errorf("cmux surface-health[%d]: %w", i, err)
+		}
+		if surface.InWindow == nil {
+			return false, fmt.Errorf("cmux surface-health[%d]: in_window is required", i)
+		}
+		health[id] = *surface.InWindow
+	}
+	for _, id := range want {
+		if !health[id] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func normalizeCmuxUUID(id string) (string, error) {
+	id = strings.ToLower(strings.TrimSpace(id))
+	if !validUUID(id) {
+		return "", fmt.Errorf("id %q is not a UUID", id)
+	}
+	return id, nil
+}
+
+func canonicalCmuxSocket(path string) (string, error) {
+	cleaned := filepath.Clean(strings.TrimSpace(path))
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("cmux socket path must be absolute")
+	}
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return resolved, nil
+	}
+	return cleaned, nil
+}
+
+func supportedCmuxVersion(raw string) bool {
+	version := strings.TrimSpace(raw)
+	if fields := strings.Fields(version); len(fields) > 0 {
+		version = strings.TrimPrefix(fields[0], "cmux")
+		if version == "" && len(fields) > 1 {
+			version = fields[1]
+		}
+		version = strings.TrimSpace(strings.TrimPrefix(version, "-"))
+	}
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	major, errMajor := strconv.Atoi(parts[0])
+	minor, errMinor := strconv.Atoi(strings.TrimRightFunc(parts[1], func(r rune) bool { return r < '0' || r > '9' }))
+	patch := 0
+	if len(parts) > 2 {
+		patch, _ = strconv.Atoi(strings.TrimRightFunc(parts[2], func(r rune) bool { return r < '0' || r > '9' }))
+	}
+	if errMajor != nil || errMinor != nil || major != 0 {
+		return false
+	}
+	if minor > 64 {
+		return true
+	}
+	return minor == 64 && patch >= 3
+}
+
+func cmuxWorkspaceName(projectRoot, session, nonce string) (string, error) {
+	canonical, err := canonicalIdentity(projectRoot)
+	if err != nil {
+		return "", err
+	}
+	if !validUUID(nonce) {
+		return "", fmt.Errorf("launch nonce must be a UUID")
+	}
+	return fmt.Sprintf("amq-%s-%s-%s",
+		truncateTMuxPart(tmuxSlug(filepath.Base(canonical)), 20),
+		truncateTMuxPart(tmuxSlug(session), 16), nonce), nil
+}
+
+func cmuxBindingResources(workspaceID, windowID, nonce string, plan Plan, surfaceIDs []string) []ResourceIdentity {
+	resources := []ResourceIdentity{{OpaqueID: cmuxWorkspacePrefix + workspaceID + ":" + nonce}}
+	if windowID != "" {
+		resources = append(resources, ResourceIdentity{OpaqueID: cmuxWindowPrefix + windowID})
+	}
+	for i, agent := range plan.Agents {
+		if i < len(surfaceIDs) {
+			resources = append(resources, ResourceIdentity{OpaqueID: cmuxSurfacePrefix + surfaceIDs[i], Agent: agent.Handle})
+		}
+	}
+	return resources
+}
+
+func parseCmuxWorkspaceResource(binding BindingRecord) (string, string, error) {
+	for _, resource := range binding.Resources.Resources {
+		rest, ok := strings.CutPrefix(resource.OpaqueID, cmuxWorkspacePrefix)
+		if !ok || resource.Agent != "" {
+			continue
+		}
+		uuid, nonce, found := strings.Cut(rest, ":")
+		if !found {
+			return "", "", fmt.Errorf("binding has no valid cmux workspace identity")
+		}
+		id, err := normalizeCmuxUUID(uuid)
+		if err != nil || !validUUID(nonce) {
+			return "", "", fmt.Errorf("binding has no valid cmux workspace identity")
+		}
+		return id, nonce, nil
+	}
+	return "", "", fmt.Errorf("binding has no valid cmux workspace identity")
+}
+
+func parseCmuxSurfaceResource(opaqueID string) (string, error) {
+	id, ok := strings.CutPrefix(opaqueID, cmuxSurfacePrefix)
+	if !ok {
+		return "", fmt.Errorf("invalid cmux surface identity %q", opaqueID)
+	}
+	return normalizeCmuxUUID(id)
+}
+
+func cmuxWindowID(binding BindingRecord) string {
+	for _, resource := range binding.Resources.Resources {
+		id, ok := strings.CutPrefix(resource.OpaqueID, cmuxWindowPrefix)
+		if ok && resource.Agent == "" {
+			if normalized, err := normalizeCmuxUUID(id); err == nil {
+				return normalized
+			}
+		}
+	}
+	return ""
+}
+
+func cmuxContainsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func cmuxInventoryIssues(resources []ResourceIdentity, plan Plan) []string {
+	expected := make(map[string]bool, len(plan.Agents))
+	for _, agent := range plan.Agents {
+		expected[agent.Handle] = true
+	}
+	live := make(map[string]int, len(resources))
+	issues := make([]string, 0)
+	for _, resource := range resources {
+		if resource.Agent != "" {
+			live[resource.Agent]++
+			if !expected[resource.Agent] {
+				issues = append(issues, "unexpected:"+resource.Agent)
+			}
+		}
+	}
+	for _, agent := range plan.Agents {
+		switch live[agent.Handle] {
+		case 0:
+			issues = append(issues, "missing:"+agent.Handle)
+		case 1:
+		default:
+			issues = append(issues, "duplicate:"+agent.Handle)
+		}
+	}
+	return issues
+}
+
+func cmuxExecutable(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0
+}
+
+func redactCmuxArgs(args []string) []string {
+	out := append([]string(nil), args...)
+	for i, arg := range out {
+		if arg == "--password" && i+1 < len(out) {
+			out[i+1] = "<redacted>"
+		}
+	}
+	return out
+}
+
+func prependInsideCmuxPreference(prefs []string) []string {
+	if strings.TrimSpace(os.Getenv("CMUX_SURFACE_ID")) == "" {
+		return prefs
+	}
+	out := []string{LauncherCMux}
+	for _, name := range prefs {
+		if name != LauncherCMux {
+			out = append(out, name)
+		}
+	}
+	return out
+}

--- a/internal/launch/cmux.go
+++ b/internal/launch/cmux.go
@@ -161,6 +161,10 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 		return CreateResult{}, err
 	}
 	previousSelected := cmuxSelectedWorkspaceID(before)
+	var workspaceID string
+	defer func() {
+		b.restoreSelectedWorkspace(previousSelected, workspaceID)
+	}()
 	if countNamedCmuxWorkspaces(before, name) > 0 {
 		return CreateResult{}, fmt.Errorf("cmux workspace %q already exists; journal recovery must classify it", name)
 	}
@@ -180,17 +184,8 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 	if err != nil {
 		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
 	}
-	workspaceID := createdWS.ID
+	workspaceID = createdWS.ID
 	windowID := createdWS.WindowID
-	var didSelect bool
-	defer func() {
-		if !didSelect || previousSelected == "" || previousSelected == workspaceID {
-			return
-		}
-		ctx, cancel := b.inspectCallContext()
-		defer cancel()
-		_, _ = b.run(ctx, "select-workspace", "--workspace", previousSelected)
-	}()
 	surfaceCtx, surfaceCancel := b.inspectCallContext()
 	firstSurfaces, err := b.workspaceSurfaces(surfaceCtx, workspaceID)
 	surfaceCancel()
@@ -214,21 +209,19 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 		}
 		surfaceIDs = append(surfaceIDs, surfaceID)
 	}
-	selected, err := b.waitHealthy(context.Background(), workspaceID, len(surfaceIDs))
-	didSelect = selected
-	if err != nil {
+	if _, err := b.waitHealthy(context.Background(), workspaceID, len(surfaceIDs)); err != nil {
 		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
 	}
 	for i, agent := range req.Plan.Agents {
 		line := b.agentCommand(req, agent)
 		sendCtx, sendCancel := b.inspectCallContext()
-		_, err := b.run(sendCtx, "send", "--surface", surfaceIDs[i], "--", line)
+		_, err := b.run(sendCtx, "send", "--workspace", workspaceID, "--surface", surfaceIDs[i], "--", line)
 		sendCancel()
 		if err != nil {
 			return CreateResult{}, b.reconcileCreateFailure(name, true, fmt.Errorf("send cmux command for %s: %w", agent.Handle, err))
 		}
 		enterCtx, enterCancel := b.inspectCallContext()
-		_, err = b.run(enterCtx, "send-key", "--surface", surfaceIDs[i], "enter")
+		_, err = b.run(enterCtx, "send-key", "--workspace", workspaceID, "--surface", surfaceIDs[i], "enter")
 		enterCancel()
 		if err != nil {
 			return CreateResult{}, b.reconcileCreateFailure(name, true, fmt.Errorf("submit cmux command for %s: %w", agent.Handle, err))
@@ -267,6 +260,25 @@ func (b *CmuxBackend) inspectCallContext() (context.Context, context.CancelFunc)
 
 func (b *CmuxBackend) orphanCallContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), cmuxCreateTimeout)
+}
+
+func (b *CmuxBackend) restoreSelectedWorkspace(previousSelected, skipID string) {
+	if previousSelected == "" || previousSelected == skipID {
+		return
+	}
+	ctx, cancel := b.inspectCallContext()
+	defer cancel()
+	records, err := b.listWorkspaceRecords(ctx)
+	if err != nil {
+		return
+	}
+	if !cmuxContainsID(cmuxWorkspaceIDs(records), previousSelected) {
+		return
+	}
+	if cmuxSelectedWorkspaceID(records) == previousSelected {
+		return
+	}
+	_, _ = b.run(ctx, "select-workspace", "--workspace", previousSelected)
 }
 
 func (b *CmuxBackend) reconcileCreateFailure(name string, inputSent bool, cause error) error {
@@ -324,9 +336,15 @@ func (b *CmuxBackend) Close(req CloseRequest) (CloseResult, error) {
 	if err != nil {
 		return CloseResult{Outcome: OutcomeActionRequired, Reason: err.Error()}, nil
 	}
+	records, err := b.listWorkspaceRecords(ctx)
+	if err != nil {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: err.Error()}, nil
+	}
+	previousSelected := cmuxSelectedWorkspaceID(records)
 	if _, err := b.run(ctx, "close-workspace", "--workspace", workspaceID); err != nil {
 		return CloseResult{}, fmt.Errorf("close cmux workspace: %w", err)
 	}
+	b.restoreSelectedWorkspace(previousSelected, workspaceID)
 	return CloseResult{Outcome: OutcomeClosed, Reason: "cmux workspace closed"}, nil
 }
 
@@ -558,14 +576,29 @@ func (b *CmuxBackend) workspaceSurfaces(ctx context.Context, workspaceID string)
 	if err != nil {
 		return nil, fmt.Errorf("list cmux panes: %w", err)
 	}
-	surfaces, err := parseCmuxPaneSurfaceIDs(raw)
+	panes, err := parseCmuxPaneIDs(raw)
 	if err != nil {
 		return nil, err
 	}
-	if len(surfaces) == 0 {
-		return nil, fmt.Errorf("cmux workspace has no surfaces")
+	if len(panes) == 0 {
+		return nil, fmt.Errorf("cmux workspace has no panes")
 	}
-	return surfaces, nil
+	var terminals []string
+	for _, pane := range panes {
+		paneRaw, paneErr := b.runJSON(ctx, "list-pane-surfaces", "--workspace", workspaceID, "--pane", pane)
+		if paneErr != nil {
+			return nil, fmt.Errorf("list cmux pane surfaces: %w", paneErr)
+		}
+		ids, paneErr := parseCmuxTerminalSurfaceIDs(paneRaw)
+		if paneErr != nil {
+			return nil, paneErr
+		}
+		terminals = append(terminals, ids...)
+	}
+	if len(terminals) == 0 {
+		return nil, fmt.Errorf("cmux workspace has no terminal surfaces")
+	}
+	return terminals, nil
 }
 
 func (b *CmuxBackend) uniqueWorkspaceByName(ctx context.Context, name string) (cmuxListedWorkspace, error) {
@@ -713,7 +746,8 @@ type cmuxListedWorkspace struct {
 }
 
 type cmuxHealthSurface struct {
-	InWindow *bool `json:"in_window"`
+	Type     string `json:"type"`
+	InWindow *bool  `json:"in_window"`
 }
 
 func parseCmuxCapabilities(raw string) (cmuxCapabilities, error) {
@@ -809,10 +843,10 @@ func parseCmuxSplitSurface(raw string) (string, error) {
 	return id, nil
 }
 
-func parseCmuxPaneSurfaceIDs(raw string) ([]string, error) {
+func parseCmuxPaneIDs(raw string) ([]string, error) {
 	var parsed struct {
 		Panes []struct {
-			SurfaceIDs []string `json:"surface_ids"`
+			ID string `json:"id"`
 		} `json:"panes"`
 	}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
@@ -821,18 +855,40 @@ func parseCmuxPaneSurfaceIDs(raw string) ([]string, error) {
 	if parsed.Panes == nil {
 		return nil, fmt.Errorf("cmux panes list is missing")
 	}
-	var ids []string
+	ids := make([]string, 0, len(parsed.Panes))
 	for i, pane := range parsed.Panes {
-		if pane.SurfaceIDs == nil {
-			return nil, fmt.Errorf("cmux panes[%d]: surface_ids is missing", i)
+		id, err := normalizeCmuxUUID(pane.ID)
+		if err != nil {
+			return nil, fmt.Errorf("cmux panes[%d]: %w", i, err)
 		}
-		for j, surfaceID := range pane.SurfaceIDs {
-			id, err := normalizeCmuxUUID(surfaceID)
-			if err != nil {
-				return nil, fmt.Errorf("cmux panes[%d].surface_ids[%d]: %w", i, j, err)
-			}
-			ids = append(ids, id)
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func parseCmuxTerminalSurfaceIDs(raw string) ([]string, error) {
+	var parsed struct {
+		Surfaces []struct {
+			ID   string `json:"id"`
+			Type string `json:"type"`
+		} `json:"surfaces"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("parse cmux pane surfaces: %w", err)
+	}
+	if parsed.Surfaces == nil {
+		return nil, fmt.Errorf("cmux pane surfaces list is missing")
+	}
+	var ids []string
+	for i, surface := range parsed.Surfaces {
+		if surface.Type != "terminal" {
+			continue
 		}
+		id, err := normalizeCmuxUUID(surface.ID)
+		if err != nil {
+			return nil, fmt.Errorf("cmux pane surfaces[%d]: %w", i, err)
+		}
+		ids = append(ids, id)
 	}
 	return ids, nil
 }
@@ -847,11 +903,18 @@ func cmuxSurfacesHealthy(raw string, want int) (bool, bool, error) {
 	if parsed.Surfaces == nil {
 		return false, false, fmt.Errorf("cmux surface-health list is missing")
 	}
-	if len(parsed.Surfaces) != want {
+	var terminals []cmuxHealthSurface
+	for _, surface := range parsed.Surfaces {
+		if surface.Type != "" && surface.Type != "terminal" {
+			continue
+		}
+		terminals = append(terminals, surface)
+	}
+	if len(terminals) != want {
 		return false, false, nil
 	}
 	needSelect := false
-	for i, surface := range parsed.Surfaces {
+	for i, surface := range terminals {
 		if surface.InWindow == nil {
 			return false, false, fmt.Errorf("cmux surface-health[%d]: in_window is required", i)
 		}
@@ -886,6 +949,14 @@ func cmuxSelectedWorkspaceID(records []cmuxListedWorkspace) string {
 		}
 	}
 	return ""
+}
+
+func cmuxWorkspaceIDs(records []cmuxListedWorkspace) []string {
+	ids := make([]string, 0, len(records))
+	for _, workspace := range records {
+		ids = append(ids, strings.ToLower(workspace.ID))
+	}
+	return ids
 }
 
 func normalizeCmuxUUID(id string) (string, error) {

--- a/internal/launch/cmux_live_test.go
+++ b/internal/launch/cmux_live_test.go
@@ -31,6 +31,38 @@ func TestCmuxLive(t *testing.T) {
 		}
 		return inner(ctx, args...)
 	}
+	snapCtx, snapCancel := context.WithTimeout(context.Background(), cmuxCreateTimeout)
+	before, err := backend.listWorkspaces(snapCtx)
+	snapCancel()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeCount := len(before)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), cmuxCreateTimeout)
+		defer cancel()
+		listed, listErr := backend.listWorkspaces(ctx)
+		if listErr != nil {
+			t.Errorf("cleanup list workspaces: %v", listErr)
+			return
+		}
+		for _, id := range listed {
+			if cmuxContainsID(before, id) {
+				continue
+			}
+			if _, closeErr := backend.run(ctx, "close-workspace", "--workspace", id); closeErr != nil {
+				t.Errorf("cleanup close %s: %v", id, closeErr)
+			}
+		}
+		after, countErr := backend.listWorkspaces(ctx)
+		if countErr != nil {
+			t.Errorf("cleanup workspace count: %v", countErr)
+			return
+		}
+		if len(after) != beforeCount {
+			t.Errorf("live workspace/tab count not restored: before=%d after=%d", beforeCount, len(after))
+		}
+	})
 	project := t.TempDir()
 	root := tmuxTestRoot(t, "claude", "codex")
 	fakeAMQ := writeSleepAMQ(t)
@@ -45,9 +77,6 @@ func TestCmuxLive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		_, _ = backend.Close(CloseRequest{Binding: created.Binding, Root: root})
-	})
 	if created.Outcome != OutcomeCreated || countCmuxAgentResources(created.Binding) != 2 {
 		t.Fatalf("Create = %#v", created)
 	}
@@ -73,6 +102,13 @@ func TestCmuxLive(t *testing.T) {
 	absent, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
 	if err != nil || absent.Status != InspectAbsent {
 		t.Fatalf("Inspect absent = %#v, %v", absent, err)
+	}
+	after, err := backend.listWorkspaces(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != beforeCount {
+		t.Fatalf("live workspace/tab count changed: before=%d after=%d", beforeCount, len(after))
 	}
 	if !strings.HasPrefix(created.Binding.InstanceIdentity, "cmux-socket:") {
 		t.Fatalf("instance identity = %q", created.Binding.InstanceIdentity)

--- a/internal/launch/cmux_live_test.go
+++ b/internal/launch/cmux_live_test.go
@@ -32,11 +32,13 @@ func TestCmuxLive(t *testing.T) {
 		return inner(ctx, args...)
 	}
 	snapCtx, snapCancel := context.WithTimeout(context.Background(), cmuxCreateTimeout)
-	before, err := backend.listWorkspaces(snapCtx)
+	beforeRecords, err := backend.listWorkspaceRecords(snapCtx)
 	snapCancel()
 	if err != nil {
 		t.Fatal(err)
 	}
+	before := cmuxWorkspaceIDs(beforeRecords)
+	beforeSelected := cmuxSelectedWorkspaceID(beforeRecords)
 	beforeCount := len(before)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), cmuxCreateTimeout)
@@ -54,13 +56,30 @@ func TestCmuxLive(t *testing.T) {
 				t.Errorf("cleanup close %s: %v", id, closeErr)
 			}
 		}
-		after, countErr := backend.listWorkspaces(ctx)
+		afterRecords, countErr := backend.listWorkspaceRecords(ctx)
 		if countErr != nil {
 			t.Errorf("cleanup workspace count: %v", countErr)
 			return
 		}
-		if len(after) != beforeCount {
-			t.Errorf("live workspace/tab count not restored: before=%d after=%d", beforeCount, len(after))
+		if len(afterRecords) != beforeCount {
+			t.Errorf("live workspace/tab count not restored: before=%d after=%d", beforeCount, len(afterRecords))
+		}
+		if beforeSelected == "" || !cmuxContainsID(cmuxWorkspaceIDs(afterRecords), beforeSelected) {
+			return
+		}
+		if cmuxSelectedWorkspaceID(afterRecords) != beforeSelected {
+			if _, selErr := backend.run(ctx, "select-workspace", "--workspace", beforeSelected); selErr != nil {
+				t.Errorf("cleanup restore selected %s: %v", beforeSelected, selErr)
+				return
+			}
+		}
+		restored, restoreErr := backend.listWorkspaceRecords(ctx)
+		if restoreErr != nil {
+			t.Errorf("cleanup list selected workspace: %v", restoreErr)
+			return
+		}
+		if got := cmuxSelectedWorkspaceID(restored); got != beforeSelected {
+			t.Errorf("live selected workspace = %q, want %q", got, beforeSelected)
 		}
 	})
 	project := t.TempDir()
@@ -79,6 +98,13 @@ func TestCmuxLive(t *testing.T) {
 	}
 	if created.Outcome != OutcomeCreated || countCmuxAgentResources(created.Binding) != 2 {
 		t.Fatalf("Create = %#v", created)
+	}
+	afterCreate, err := backend.listWorkspaceRecords(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cmuxSelectedWorkspaceID(afterCreate); got != beforeSelected {
+		t.Fatalf("Create changed selected workspace: before=%q after=%q", beforeSelected, got)
 	}
 	req.AMQPath = resolvedAMQ
 	for i, agent := range plan.Agents {

--- a/internal/launch/cmux_live_test.go
+++ b/internal/launch/cmux_live_test.go
@@ -15,7 +15,7 @@ func TestCmuxLive(t *testing.T) {
 	backend := NewCmuxBackend("")
 	detect := backend.Detect()
 	if !detect.Available {
-		t.Fatal("cmux ping failed; run this test from a shell inside a cmux surface")
+		t.Fatalf("cmux Detect unavailable: host=%q instance=%q degradations=%v", detect.HostIdentity, detect.InstanceIdentity, detect.Degradations)
 	}
 	var sent []string
 	inner := backend.run

--- a/internal/launch/cmux_live_test.go
+++ b/internal/launch/cmux_live_test.go
@@ -103,40 +103,68 @@ func TestCmuxLive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := cmuxSelectedWorkspaceID(afterCreate); got != beforeSelected {
-		t.Fatalf("Create changed selected workspace: before=%q after=%q", beforeSelected, got)
+	afterCreateSelected := cmuxSelectedWorkspaceID(afterCreate)
+	if afterCreateSelected != beforeSelected {
+		t.Fatalf("Create changed selected workspace: before=%q after=%q", beforeSelected, afterCreateSelected)
 	}
+	workspaceID, _, err := parseCmuxWorkspaceResource(created.Binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Create %s workspace=%s window=%s surfaces=%s", created.Outcome, workspaceID, cmuxWindowID(created.Binding), strings.Join(cmuxLiveBoundSurfaces(created.Binding), ","))
+	t.Logf("selected-id before=%s after-create=%s", beforeSelected, afterCreateSelected)
 	req.AMQPath = resolvedAMQ
 	for i, agent := range plan.Agents {
 		want := backend.agentCommand(req, agent)
 		if i >= len(sent) || sent[i] != want {
 			t.Fatalf("sent[%d] = %q, want exact commandLine %q (all=%q)", i, sent, want, sent)
 		}
+		t.Logf("sent %s commandLine %q", agent.Handle, sent[i])
 	}
 	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
 	if err != nil || inspection.Status != InspectPresent {
 		t.Fatalf("Inspect present = %#v, %v", inspection, err)
 	}
+	t.Logf("Inspect present status=%s evidence=%q", inspection.Status, inspection.Evidence)
 	focused, err := backend.Focus(FocusRequest{Binding: created.Binding, Root: root})
 	if err != nil || focused.Outcome != OutcomeAttached {
 		t.Fatalf("Focus = %#v, %v", focused, err)
 	}
+	t.Logf("Focus outcome=%s reason=%q", focused.Outcome, focused.Reason)
 	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
 	if err != nil || closed.Outcome != OutcomeClosed {
 		t.Fatalf("Close = %#v, %v", closed, err)
 	}
+	t.Logf("Close outcome=%s reason=%q", closed.Outcome, closed.Reason)
 	absent, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
 	if err != nil || absent.Status != InspectAbsent {
 		t.Fatalf("Inspect absent = %#v, %v", absent, err)
 	}
-	after, err := backend.listWorkspaces(context.Background())
+	t.Logf("Inspect absent status=%s evidence=%q", absent.Status, absent.Evidence)
+	afterRecords, err := backend.listWorkspaceRecords(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(after) != beforeCount {
-		t.Fatalf("live workspace/tab count changed: before=%d after=%d", beforeCount, len(after))
+	if len(afterRecords) != beforeCount {
+		t.Fatalf("live workspace/tab count changed: before=%d after=%d", beforeCount, len(afterRecords))
 	}
+	t.Logf("selected-id after-close=%s", cmuxSelectedWorkspaceID(afterRecords))
+	t.Logf("workspace count before=%d after=%d", beforeCount, len(afterRecords))
 	if !strings.HasPrefix(created.Binding.InstanceIdentity, "cmux-socket:") {
 		t.Fatalf("instance identity = %q", created.Binding.InstanceIdentity)
 	}
+}
+
+func cmuxLiveBoundSurfaces(binding BindingRecord) []string {
+	var ids []string
+	for _, resource := range binding.Resources.Resources {
+		if resource.Agent == "" {
+			continue
+		}
+		id, err := parseCmuxSurfaceResource(resource.OpaqueID)
+		if err == nil {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }

--- a/internal/launch/cmux_live_test.go
+++ b/internal/launch/cmux_live_test.go
@@ -1,0 +1,80 @@
+package launch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCmuxLive(t *testing.T) {
+	if os.Getenv("AMQ_CMUX_LIVE") != "1" {
+		t.Skip("AMQ_CMUX_LIVE=1 required; run from a shell inside a cmux surface")
+	}
+	backend := NewCmuxBackend("")
+	detect := backend.Detect()
+	if !detect.Available {
+		t.Fatal("cmux ping failed; run this test from a shell inside a cmux surface")
+	}
+	var sent []string
+	inner := backend.run
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		for i, arg := range args {
+			if arg == "send" {
+				for j := i + 1; j < len(args); j++ {
+					if args[j] == "--" && j+1 < len(args) {
+						sent = append(sent, args[j+1])
+					}
+				}
+			}
+		}
+		return inner(ctx, args...)
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := writeSleepAMQ(t)
+	resolvedAMQ, err := filepath.EvalSymlinks(fakeAMQ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70efa5"
+	plan := cmuxTestPlan(project, nonce)
+	req := CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root}
+	created, err := backend.Create(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	})
+	if created.Outcome != OutcomeCreated || countCmuxAgentResources(created.Binding) != 2 {
+		t.Fatalf("Create = %#v", created)
+	}
+	req.AMQPath = resolvedAMQ
+	for i, agent := range plan.Agents {
+		want := backend.agentCommand(req, agent)
+		if i >= len(sent) || sent[i] != want {
+			t.Fatalf("sent[%d] = %q, want exact commandLine %q (all=%q)", i, sent, want, sent)
+		}
+	}
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectPresent {
+		t.Fatalf("Inspect present = %#v, %v", inspection, err)
+	}
+	focused, err := backend.Focus(FocusRequest{Binding: created.Binding, Root: root})
+	if err != nil || focused.Outcome != OutcomeAttached {
+		t.Fatalf("Focus = %#v, %v", focused, err)
+	}
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("Close = %#v, %v", closed, err)
+	}
+	absent, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || absent.Status != InspectAbsent {
+		t.Fatalf("Inspect absent = %#v, %v", absent, err)
+	}
+	if !strings.HasPrefix(created.Binding.InstanceIdentity, "cmux-socket:") {
+		t.Fatalf("instance identity = %q", created.Binding.InstanceIdentity)
+	}
+}

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -502,6 +502,82 @@ func TestCmuxCreateNonJSONClosesOrphanOnFreshContext(t *testing.T) {
 	}
 }
 
+func TestCmuxCreateAmbiguousTitleAfterAckDoesNotBindOrClose(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	inner := backend.run
+	pending := false
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if pending && cmuxArgvHas(args, "list-workspaces") {
+			duplicateCmuxFakeNamedWorkspace(t)
+			pending = false
+		}
+		out, err := inner(ctx, args...)
+		if cmuxArgvHas(args, "new-workspace") && err == nil {
+			pending = true
+		}
+		return out, err
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eac1")
+	plan.Agents = plan.Agents[:1]
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil || created.Outcome == OutcomeCreated {
+		t.Fatalf("Create = %#v, %v, want ambiguous refusal", created, err)
+	}
+	if !strings.Contains(err.Error(), "ambiguous cmux workspaces") {
+		t.Fatalf("Create error = %v, want ambiguous title match", err)
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") >= 0 {
+		t.Fatal("ambiguous title match guessed a workspace to close")
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "send") >= 0 {
+		t.Fatal("ambiguous title match sent commands")
+	}
+	if cmuxFakeWorkspaceCount(t) != 2 {
+		t.Fatalf("ambiguous title match closed workspaces: %d", cmuxFakeWorkspaceCount(t))
+	}
+}
+
+func TestCmuxCreateZeroTitleMatchAfterAckNamesIt(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	inner := backend.run
+	pending := false
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if pending && cmuxArgvHas(args, "list-workspaces") {
+			hideCmuxFakeWorkspaceTitles(t)
+			pending = false
+		}
+		out, err := inner(ctx, args...)
+		if cmuxArgvHas(args, "new-workspace") && err == nil {
+			pending = true
+		}
+		return out, err
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70eac2"
+	plan := cmuxTestPlan(project, nonce)
+	plan.Agents = plan.Agents[:1]
+	name, err := cmuxWorkspaceName(project, "collab", nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil || created.Outcome == OutcomeCreated {
+		t.Fatalf("Create = %#v, %v, want zero-match refusal", created, err)
+	}
+	if !strings.Contains(err.Error(), name) || !strings.Contains(err.Error(), "no cmux workspace named") {
+		t.Fatalf("Create error = %v, want named zero-match for %q", err, name)
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") >= 0 {
+		t.Fatal("zero title match guessed a workspace to close")
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "send") >= 0 {
+		t.Fatal("zero title match sent commands")
+	}
+}
+
 func TestCmuxDefaultCreateTimeoutExceedsCommandTimeout(t *testing.T) {
 	got := NewCmuxBackend("").createOpTimeout()
 	if got <= cmuxCommandTimeout {
@@ -941,6 +1017,36 @@ func duplicateCmuxFakeNamedWorkspace(t *testing.T) {
 		"panes":     first["panes"],
 	}
 	state["workspaces"] = append(workspaces, clone)
+	out, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hideCmuxFakeWorkspaceTitles(t *testing.T) {
+	t.Helper()
+	path := os.Getenv("AMQ_CMUX_FAKE_STATE")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	workspaces, _ := state["workspaces"].([]any)
+	if len(workspaces) == 0 {
+		t.Fatal("no cmux workspace to hide")
+	}
+	for i, item := range workspaces {
+		workspace, _ := item.(map[string]any)
+		workspace["title"] = "foreign-title"
+		workspaces[i] = workspace
+	}
+	state["workspaces"] = workspaces
 	out, err := json.Marshal(state)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -194,7 +194,13 @@ if command == "focus-window":
 if command == "close-workspace":
     want = (flags.get("workspace") or "").lower()
     closed = next((ws for ws in state["workspaces"] if ws["id"].lower() == want), None)
-    state["workspaces"] = [ws for ws in state["workspaces"] if ws["id"].lower() != want]
+    remaining = [ws for ws in state["workspaces"] if ws["id"].lower() != want]
+    selected_id = next((ws["id"] for ws in remaining if ws.get("selected")), None)
+    if len(remaining) > 1 and selected_id:
+        steal = next(ws for ws in remaining if ws["id"] != selected_id)
+        for ws in remaining:
+            ws["selected"] = ws["id"] == steal["id"]
+    state["workspaces"] = remaining
     save(state)
     print("OK workspace:" + (closed or {}).get("ref", "1"))
     sys.exit(0)
@@ -977,6 +983,37 @@ func seedCmuxSelectedWorkspace(t *testing.T) string {
 	return id
 }
 
+func seedCmuxNeighborWorkspace(t *testing.T) {
+	t.Helper()
+	path := os.Getenv("AMQ_CMUX_FAKE_STATE")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	workspaces, _ := state["workspaces"].([]any)
+	workspaces = append(workspaces, map[string]any{
+		"id": "019c5a10-75d8-7eef-8db7-5ee77f70aaa4", "title": "neighbor-tab",
+		"window_id": "019c5a10-75d8-7eef-8db7-5ee77f70aaa0",
+		"cwd":       "", "selected": false, "ref": "neighbor",
+		"panes": []any{map[string]any{
+			"id":       "019c5a10-75d8-7eef-8db7-5ee77f70aaa5",
+			"surfaces": []any{map[string]any{"id": "019c5a10-75d8-7eef-8db7-5ee77f70aaa6"}},
+		}},
+	})
+	state["workspaces"] = workspaces
+	out, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func cmuxFakeSelectedWorkspace(t *testing.T) string {
 	t.Helper()
 	data, err := os.ReadFile(os.Getenv("AMQ_CMUX_FAKE_STATE"))
@@ -1217,8 +1254,9 @@ func TestCmuxSendFailureRestoresSelection(t *testing.T) {
 }
 
 func TestCmuxCloseRestoresPriorSelection(t *testing.T) {
-	backend, _ := newFakeCmuxBackend(t)
+	backend, logPath := newFakeCmuxBackend(t)
 	previous := seedCmuxSelectedWorkspace(t)
+	seedCmuxNeighborWorkspace(t)
 	project := t.TempDir()
 	root := tmuxTestRoot(t, "claude")
 	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eab4")
@@ -1227,12 +1265,35 @@ func TestCmuxCloseRestoresPriorSelection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if got := cmuxFakeSelectedWorkspace(t); got != previous {
+		t.Fatalf("selected after Create = %q, want %q", got, previous)
+	}
 	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
 	if err != nil || closed.Outcome != OutcomeClosed {
 		t.Fatalf("Close = %#v, %v", closed, err)
 	}
 	if got := cmuxFakeSelectedWorkspace(t); got != previous {
 		t.Fatalf("selected workspace = %q, want restored %q after Close", got, previous)
+	}
+	var afterClose []string
+	sawClose := false
+	for _, argv := range readCmuxArgvLog(t, logPath) {
+		if len(argv) > 0 && argv[0] == "close-workspace" {
+			sawClose = true
+			afterClose = nil
+			continue
+		}
+		if !sawClose || len(argv) == 0 || argv[0] != "select-workspace" {
+			continue
+		}
+		for i, arg := range argv {
+			if arg == "--workspace" && i+1 < len(argv) {
+				afterClose = append(afterClose, strings.ToLower(argv[i+1]))
+			}
+		}
+	}
+	if len(afterClose) == 0 || afterClose[len(afterClose)-1] != previous {
+		t.Fatalf("Close select-workspace = %v, want restore to %s", afterClose, previous)
 	}
 }
 

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -87,66 +87,107 @@ if command == "capabilities":
           "methods": ["workspace.list"]})
     sys.exit(0)
 if command == "list-workspaces":
-    emit({"workspaces": [{"id": ws["id"], "window_id": ws.get("window_id", ""), "current_directory": ws.get("cwd", ""),
-                          "title": ws["title"]} for ws in state["workspaces"]]})
+    window_id = state.get("window_id", os.environ.get("AMQ_CMUX_FAKE_WINDOW", "019c5a10-75d8-7eef-8db7-5ee77f70aaa0"))
+    workspaces = []
+    for i, ws in enumerate(state["workspaces"]):
+        item = {
+            "id": ws["id"], "title": ws["title"], "current_directory": ws.get("cwd", ""),
+            "index": i + 1, "selected": bool(ws.get("selected")), "pinned": False,
+            "custom_color": None, "description": "", "listening_ports": [],
+            "remote": {},
+        }
+        if missing == "id":
+            del item["id"]
+        workspaces.append(item)
+    emit({"window_id": window_id, "workspaces": workspaces})
     sys.exit(0)
 if command == "new-workspace":
     ws_id = str(uuid.uuid4())
-    window_id = str(uuid.uuid4())
+    window_id = state.get("window_id") or str(uuid.uuid4())
     pane_id = str(uuid.uuid4())
     surface_id = str(uuid.uuid4())
+    ref = str(len(state["workspaces"]) + 1)
+    state["window_id"] = window_id
     state["workspaces"].append({
         "id": ws_id, "title": flags.get("name", ""), "window_id": window_id,
-        "cwd": flags.get("cwd", ""),
+        "cwd": flags.get("cwd", ""), "selected": False, "ref": ref,
         "panes": [{"id": pane_id, "surfaces": [{"id": surface_id}]}],
     })
     save(state)
-    created = {"id": ws_id, "window_id": window_id}
-    if missing == "id":
-        del created["id"]
-    emit(created)
+    print("OK workspace:" + ref)
     sys.exit(0)
 if command == "list-panes":
-    ws = next((item for item in state["workspaces"] if item["id"] == flags.get("workspace")), None)
-    emit({"panes": [{"id": pane["id"]} for pane in (ws["panes"] if ws else [])]})
+    ws = next((item for item in state["workspaces"] if item["id"].lower() == (flags.get("workspace") or "").lower()), None)
+    panes = []
+    for i, pane in enumerate(ws["panes"] if ws else []):
+        surface_ids = [surface["id"] for surface in pane.get("surfaces", [])]
+        panes.append({
+            "id": pane["id"], "index": i, "focused": False,
+            "selected_surface_id": surface_ids[0] if surface_ids else "",
+            "surface_ids": surface_ids, "surface_count": len(surface_ids),
+            "rows": 24, "columns": 80, "cell_width_px": 8, "cell_height_px": 16,
+            "pixel_frame": {},
+        })
+    emit({"container_frame": {}, "window_id": (ws or {}).get("window_id", ""),
+          "workspace_id": (ws or {}).get("id", ""), "panes": panes})
     sys.exit(0)
 if command == "list-pane-surfaces":
-    ws = next((item for item in state["workspaces"] if item["id"] == flags.get("workspace")), None)
+    ws = next((item for item in state["workspaces"] if item["id"].lower() == (flags.get("workspace") or "").lower()), None)
     pane = None
     if ws:
         pane = next((item for item in ws["panes"] if item["id"] == flags.get("pane")), None)
-    emit({"surfaces": [{"id": surface["id"]} for surface in (pane["surfaces"] if pane else [])]})
+    emit({"window_id": (ws or {}).get("window_id", ""), "workspace_id": (ws or {}).get("id", ""),
+          "pane_id": flags.get("pane", ""),
+          "surfaces": [{"id": surface["id"], "type": "terminal", "title": "", "index": i, "selected": i == 0}
+                       for i, surface in enumerate(pane["surfaces"] if pane else [])]})
     sys.exit(0)
 if command == "new-split":
-    ws = next((item for item in state["workspaces"] if item["id"] == flags.get("workspace")), None)
+    ws = next((item for item in state["workspaces"] if item["id"].lower() == (flags.get("workspace") or "").lower()), None)
     if ws is None:
         print("workspace not found", file=sys.stderr)
         sys.exit(1)
     surface_id = str(uuid.uuid4())
-    ws["panes"].append({"id": str(uuid.uuid4()), "surfaces": [{"id": surface_id}]})
+    pane_id = str(uuid.uuid4())
+    ws["panes"].append({"id": pane_id, "surfaces": [{"id": surface_id}]})
     save(state)
-    emit({"id": surface_id})
+    emit({"workspace_id": ws["id"], "surface_id": surface_id, "window_id": ws.get("window_id", ""),
+          "pane_id": pane_id, "type": "terminal"})
     sys.exit(0)
 if command == "surface-health":
-    ws = next((item for item in state["workspaces"] if item["id"] == flags.get("workspace")), None)
+    ws = next((item for item in state["workspaces"] if item["id"].lower() == (flags.get("workspace") or "").lower()), None)
+    require_select = os.environ.get("AMQ_CMUX_FAKE_REQUIRE_SELECT") == "1"
     surfaces = []
+    idx = 0
     if ws:
         for pane in ws["panes"]:
-            for surface in pane["surfaces"]:
-                item = {"id": surface["id"], "in_window": healthy}
+            for _surface in pane["surfaces"]:
+                in_window = healthy
+                if require_select:
+                    in_window = healthy and bool(ws.get("selected"))
+                item = {"index": idx, "ref": "surface:%d" % (idx + 1), "type": "terminal", "in_window": in_window}
                 if missing == "in_window":
                     del item["in_window"]
                 surfaces.append(item)
-    emit({"surfaces": surfaces})
+                idx += 1
+    emit({"window_ref": "window:1", "workspace_ref": "workspace:%s" % (ws or {}).get("ref", "1"),
+          "surfaces": surfaces})
     sys.exit(0)
-if command in ("send", "send-key", "select-workspace", "focus-window"):
+if command == "select-workspace":
+    want = (flags.get("workspace") or "").lower()
+    for ws in state["workspaces"]:
+        ws["selected"] = ws["id"].lower() == want
+    save(state)
+    print("OK workspace:" + next((ws.get("ref", "1") for ws in state["workspaces"] if ws["id"].lower() == want), "1"))
+    sys.exit(0)
+if command in ("send", "send-key", "focus-window"):
     emit({"ok": True})
     sys.exit(0)
 if command == "close-workspace":
-    before = len(state["workspaces"])
-    state["workspaces"] = [ws for ws in state["workspaces"] if ws["id"] != flags.get("workspace")]
+    want = (flags.get("workspace") or "").lower()
+    closed = next((ws for ws in state["workspaces"] if ws["id"].lower() == want), None)
+    state["workspaces"] = [ws for ws in state["workspaces"] if ws["id"].lower() != want]
     save(state)
-    emit({"ok": True, "closed": before - len(state["workspaces"])})
+    print("OK workspace:" + (closed or {}).get("ref", "1"))
     sys.exit(0)
 print("unknown command " + command, file=sys.stderr)
 sys.exit(2)
@@ -329,7 +370,7 @@ func TestCmuxMissingIDFailsClosed(t *testing.T) {
 	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eba5")
 	plan.Agents = plan.Agents[:1]
 	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
-	if err == nil || !strings.Contains(err.Error(), "not a UUID") && !strings.Contains(err.Error(), "new-workspace") {
+	if err == nil || !strings.Contains(err.Error(), "not a UUID") {
 		t.Fatalf("Create error = %v, want fail-closed uuid parse", err)
 	}
 }
@@ -359,8 +400,13 @@ func TestCmuxCreateTimeoutClosesSingleOrphanWorkspace(t *testing.T) {
 	backend, logPath := newFakeCmuxBackend(t)
 	backend.createTimeout = 20 * time.Millisecond
 	inner := backend.run
+	afterCreate := false
 	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if afterCreate {
+			assertCmuxOrphanCtxFresh(t, ctx, args)
+		}
 		if cmuxArgvHas(args, "new-workspace") {
+			afterCreate = true
 			if _, err := inner(context.Background(), args...); err != nil {
 				return "", err
 			}
@@ -416,6 +462,43 @@ func TestCmuxCreateTimeoutDoesNotCloseAmbiguousWorkspaces(t *testing.T) {
 	}
 	if cmuxFakeWorkspaceCount(t) != 2 {
 		t.Fatalf("ambiguous timeout closed workspaces: %d", cmuxFakeWorkspaceCount(t))
+	}
+}
+
+func TestCmuxCreateNonJSONClosesOrphanOnFreshContext(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	backend.createTimeout = 20 * time.Millisecond
+	inner := backend.run
+	afterCreate := false
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if afterCreate {
+			assertCmuxOrphanCtxFresh(t, ctx, args)
+		}
+		if cmuxArgvHas(args, "new-workspace") {
+			afterCreate = true
+			if _, err := inner(context.Background(), args...); err != nil {
+				return "", err
+			}
+			return "Opened workspace", nil
+		}
+		return inner(ctx, args...)
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa3")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil || !strings.Contains(err.Error(), "parse cmux new-workspace") {
+		t.Fatalf("Create error = %v, want parse failure", err)
+	}
+	if !strings.Contains(err.Error(), "closed orphan cmux workspace") {
+		t.Fatalf("Create error = %v, want closed orphan after parse failure", err)
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") < 0 {
+		t.Fatal("parse failure did not close the orphan workspace")
+	}
+	if cmuxFakeWorkspaceCount(t) != 0 {
+		t.Fatalf("parse failure left orphan workspaces: %d", cmuxFakeWorkspaceCount(t))
 	}
 }
 
@@ -725,6 +808,96 @@ func cmuxArgvHas(args []string, command string) bool {
 	return false
 }
 
+func assertCmuxOrphanCtxFresh(t *testing.T, ctx context.Context, args []string) {
+	t.Helper()
+	if !cmuxArgvHas(args, "list-workspaces") && !cmuxArgvHas(args, "close-workspace") {
+		return
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("%v used cancelled context: %v", args, err)
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatalf("%v missing deadline", args)
+	}
+	if remain := time.Until(deadline); remain < 20*time.Second {
+		t.Fatalf("%v leftover deadline %s, want a fresh create-timeout-scale bound", args, remain)
+	}
+}
+
+func assertCmuxFocusFalse(t *testing.T, calls [][]string) {
+	t.Helper()
+	seen := false
+	for _, argv := range calls {
+		if !cmuxArgvHas(argv, "new-workspace") && !cmuxArgvHas(argv, "new-split") {
+			continue
+		}
+		seen = true
+		focus := ""
+		for i, arg := range argv {
+			if arg == "--focus" && i+1 < len(argv) {
+				focus = argv[i+1]
+			}
+		}
+		if focus != "false" {
+			t.Fatalf("Create used --focus %q: %v", focus, argv)
+		}
+	}
+	if !seen {
+		t.Fatal("Create did not invoke new-workspace")
+	}
+}
+
+func seedCmuxSelectedWorkspace(t *testing.T) string {
+	t.Helper()
+	id := "019c5a10-75d8-7eef-8db7-5ee77f70aaa1"
+	state := map[string]any{
+		"socket_path": os.Getenv("AMQ_CMUX_FAKE_SOCKET"),
+		"window_id":   "019c5a10-75d8-7eef-8db7-5ee77f70aaa0",
+		"workspaces": []any{
+			map[string]any{
+				"id": id, "title": "operator-tab", "window_id": "019c5a10-75d8-7eef-8db7-5ee77f70aaa0",
+				"cwd": "", "selected": true, "ref": "1",
+				"panes": []any{map[string]any{
+					"id":       "019c5a10-75d8-7eef-8db7-5ee77f70aaa2",
+					"surfaces": []any{map[string]any{"id": "019c5a10-75d8-7eef-8db7-5ee77f70aaa3"}},
+				}},
+			},
+		},
+	}
+	out, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(os.Getenv("AMQ_CMUX_FAKE_STATE"), out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func cmuxFakeSelectedWorkspace(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(os.Getenv("AMQ_CMUX_FAKE_STATE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state struct {
+		Workspaces []struct {
+			ID       string `json:"id"`
+			Selected bool   `json:"selected"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	for _, workspace := range state.Workspaces {
+		if workspace.Selected {
+			return strings.ToLower(workspace.ID)
+		}
+	}
+	return ""
+}
+
 func cmuxFakeWorkspaceCount(t *testing.T) int {
 	t.Helper()
 	data, err := os.ReadFile(os.Getenv("AMQ_CMUX_FAKE_STATE"))
@@ -763,6 +936,8 @@ func duplicateCmuxFakeNamedWorkspace(t *testing.T) {
 		"id":        "019c5a10-75d8-7eef-8db7-5ee77f70ffff",
 		"title":     first["title"],
 		"window_id": "019c5a10-75d8-7eef-8db7-5ee77f70fffe",
+		"selected":  first["selected"],
+		"ref":       "dup",
 		"panes":     first["panes"],
 	}
 	state["workspaces"] = append(workspaces, clone)
@@ -794,10 +969,73 @@ func TestCmuxArgvRecorderSeesCreateGrammar(t *testing.T) {
 	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root}); err != nil {
 		t.Fatal(err)
 	}
-	joined := fmt.Sprint(readCmuxArgvLog(t, logPath))
-	for _, needle := range []string{"ping", "capabilities", "version", "new-workspace", "list-pane-surfaces", "surface-health", "send", "send-key"} {
+	calls := readCmuxArgvLog(t, logPath)
+	joined := fmt.Sprint(calls)
+	for _, needle := range []string{"ping", "capabilities", "version", "new-workspace", "list-workspaces", "list-panes", "surface-health", "send", "send-key"} {
 		if !strings.Contains(joined, needle) {
 			t.Fatalf("argv log missing %s: %s", needle, joined)
+		}
+	}
+	if strings.Contains(joined, "list-pane-surfaces") {
+		t.Fatalf("Create used list-pane-surfaces: %s", joined)
+	}
+	assertCmuxFocusFalse(t, calls)
+}
+
+func TestCmuxHealthyCreateDoesNotSelect(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	previous := seedCmuxSelectedWorkspace(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eab1")
+	plan.Agents = plan.Agents[:1]
+	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "select-workspace") >= 0 {
+		t.Fatal("healthy Create stole operator selection")
+	}
+	if got := cmuxFakeSelectedWorkspace(t); got != previous {
+		t.Fatalf("selected workspace = %q, want previous %q", got, previous)
+	}
+}
+
+func TestCmuxSelectsThenRestoresWhenInWindowFalse(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_REQUIRE_SELECT", "1")
+	previous := seedCmuxSelectedWorkspace(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eab2")
+	plan.Agents = plan.Agents[:1]
+	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	var selected []string
+	for _, argv := range readCmuxArgvLog(t, logPath) {
+		if len(argv) > 0 && argv[0] == "select-workspace" {
+			for i, arg := range argv {
+				if arg == "--workspace" && i+1 < len(argv) {
+					selected = append(selected, strings.ToLower(argv[i+1]))
+				}
+			}
+		}
+	}
+	if len(selected) < 2 || selected[len(selected)-1] != previous {
+		t.Fatalf("select-workspace sequence = %v, want restore to %s", selected, previous)
+	}
+	if got := cmuxFakeSelectedWorkspace(t); got != previous {
+		t.Fatalf("selected workspace = %q, want restored %q", got, previous)
+	}
+}
+
+func TestParseCmuxOKWorkspaceAck(t *testing.T) {
+	if err := parseCmuxOKWorkspaceAck("OK workspace:5\n"); err != nil {
+		t.Fatal(err)
+	}
+	for _, raw := range []string{"{\"id\":\"019c5a10-75d8-7eef-8db7-5ee77f70e7a5\"}", "Opened workspace", "OK workspace:", "OK workspace:5\nextra"} {
+		if err := parseCmuxOKWorkspaceAck(raw); err == nil {
+			t.Errorf("parseCmuxOKWorkspaceAck(%q) succeeded, want error", raw)
 		}
 	}
 }

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -108,10 +108,13 @@ if command == "new-workspace":
     surface_id = str(uuid.uuid4())
     ref = str(len(state["workspaces"]) + 1)
     state["window_id"] = window_id
+    surfaces = [{"id": surface_id, "type": "terminal"}]
+    if os.environ.get("AMQ_CMUX_FAKE_BROWSER") == "1":
+        surfaces = [{"id": str(uuid.uuid4()), "type": "browser"}] + surfaces
     state["workspaces"].append({
         "id": ws_id, "title": flags.get("name", ""), "window_id": window_id,
         "cwd": flags.get("cwd", ""), "selected": False, "ref": ref,
-        "panes": [{"id": pane_id, "surfaces": [{"id": surface_id}]}],
+        "panes": [{"id": pane_id, "surfaces": surfaces}],
     })
     save(state)
     print("OK workspace:" + ref)
@@ -138,7 +141,7 @@ if command == "list-pane-surfaces":
         pane = next((item for item in ws["panes"] if item["id"] == flags.get("pane")), None)
     emit({"window_id": (ws or {}).get("window_id", ""), "workspace_id": (ws or {}).get("id", ""),
           "pane_id": flags.get("pane", ""),
-          "surfaces": [{"id": surface["id"], "type": "terminal", "title": "", "index": i, "selected": i == 0}
+          "surfaces": [{"id": surface["id"], "type": surface.get("type", "terminal"), "title": "", "index": i, "selected": i == 0}
                        for i, surface in enumerate(pane["surfaces"] if pane else [])]})
     sys.exit(0)
 if command == "new-split":
@@ -148,7 +151,7 @@ if command == "new-split":
         sys.exit(1)
     surface_id = str(uuid.uuid4())
     pane_id = str(uuid.uuid4())
-    ws["panes"].append({"id": pane_id, "surfaces": [{"id": surface_id}]})
+    ws["panes"].append({"id": pane_id, "surfaces": [{"id": surface_id, "type": "terminal"}]})
     save(state)
     emit({"workspace_id": ws["id"], "surface_id": surface_id, "window_id": ws.get("window_id", ""),
           "pane_id": pane_id, "type": "terminal"})
@@ -164,7 +167,7 @@ if command == "surface-health":
                 in_window = healthy
                 if require_select:
                     in_window = healthy and bool(ws.get("selected"))
-                item = {"index": idx, "ref": "surface:%d" % (idx + 1), "type": "terminal", "in_window": in_window}
+                item = {"index": idx, "ref": "surface:%d" % (idx + 1), "type": _surface.get("type", "terminal"), "in_window": in_window}
                 if missing == "in_window":
                     del item["in_window"]
                 surfaces.append(item)
@@ -179,7 +182,13 @@ if command == "select-workspace":
     save(state)
     print("OK workspace:" + next((ws.get("ref", "1") for ws in state["workspaces"] if ws["id"].lower() == want), "1"))
     sys.exit(0)
-if command in ("send", "send-key", "focus-window"):
+if command in ("send", "send-key"):
+    if flags.get("surface") and not flags.get("workspace"):
+        print("Error: invalid_params: Surface is not a terminal", file=sys.stderr)
+        sys.exit(1)
+    print("OK surface:11 workspace:7")
+    sys.exit(0)
+if command == "focus-window":
     emit({"ok": True})
     sys.exit(0)
 if command == "close-workspace":
@@ -924,6 +933,23 @@ func assertCmuxFocusFalse(t *testing.T, calls [][]string) {
 	}
 }
 
+func assertCmuxSendHasWorkspace(t *testing.T, calls [][]string) {
+	t.Helper()
+	seen := false
+	for _, argv := range calls {
+		if len(argv) == 0 || (argv[0] != "send" && argv[0] != "send-key") {
+			continue
+		}
+		seen = true
+		if !cmuxArgvHas(argv, "--workspace") || !cmuxArgvHas(argv, "--surface") {
+			t.Fatalf("%s missing --workspace/--surface: %v", argv[0], argv)
+		}
+	}
+	if !seen {
+		t.Fatal("Create did not send")
+	}
+}
+
 func seedCmuxSelectedWorkspace(t *testing.T) string {
 	t.Helper()
 	id := "019c5a10-75d8-7eef-8db7-5ee77f70aaa1"
@@ -969,6 +995,45 @@ func cmuxFakeSelectedWorkspace(t *testing.T) string {
 	for _, workspace := range state.Workspaces {
 		if workspace.Selected {
 			return strings.ToLower(workspace.ID)
+		}
+	}
+	return ""
+}
+
+func cmuxFakeTerminalSurfaceID(t *testing.T) string {
+	return cmuxFakeSurfaceIDByType(t, "terminal")
+}
+
+func cmuxFakeBrowserSurfaceID(t *testing.T) string {
+	return cmuxFakeSurfaceIDByType(t, "browser")
+}
+
+func cmuxFakeSurfaceIDByType(t *testing.T, wantType string) string {
+	t.Helper()
+	data, err := os.ReadFile(os.Getenv("AMQ_CMUX_FAKE_STATE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state struct {
+		Workspaces []struct {
+			Panes []struct {
+				Surfaces []struct {
+					ID   string `json:"id"`
+					Type string `json:"type"`
+				} `json:"surfaces"`
+			} `json:"panes"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	for _, workspace := range state.Workspaces {
+		for _, pane := range workspace.Panes {
+			for _, surface := range pane.Surfaces {
+				if surface.Type == wantType {
+					return strings.ToLower(surface.ID)
+				}
+			}
 		}
 	}
 	return ""
@@ -1077,15 +1142,13 @@ func TestCmuxArgvRecorderSeesCreateGrammar(t *testing.T) {
 	}
 	calls := readCmuxArgvLog(t, logPath)
 	joined := fmt.Sprint(calls)
-	for _, needle := range []string{"ping", "capabilities", "version", "new-workspace", "list-workspaces", "list-panes", "surface-health", "send", "send-key"} {
+	for _, needle := range []string{"ping", "capabilities", "version", "new-workspace", "list-workspaces", "list-panes", "list-pane-surfaces", "surface-health", "send", "send-key"} {
 		if !strings.Contains(joined, needle) {
 			t.Fatalf("argv log missing %s: %s", needle, joined)
 		}
 	}
-	if strings.Contains(joined, "list-pane-surfaces") {
-		t.Fatalf("Create used list-pane-surfaces: %s", joined)
-	}
 	assertCmuxFocusFalse(t, calls)
+	assertCmuxSendHasWorkspace(t, calls)
 }
 
 func TestCmuxHealthyCreateDoesNotSelect(t *testing.T) {
@@ -1132,6 +1195,93 @@ func TestCmuxSelectsThenRestoresWhenInWindowFalse(t *testing.T) {
 	}
 	if got := cmuxFakeSelectedWorkspace(t); got != previous {
 		t.Fatalf("selected workspace = %q, want restored %q", got, previous)
+	}
+}
+
+func TestCmuxSendFailureRestoresSelection(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_REQUIRE_SELECT", "1")
+	t.Setenv("AMQ_CMUX_FAKE_FAIL", "send")
+	previous := seedCmuxSelectedWorkspace(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eab3")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil || !strings.Contains(err.Error(), "send cmux command") {
+		t.Fatalf("Create error = %v, want send failure", err)
+	}
+	if got := cmuxFakeSelectedWorkspace(t); got != previous {
+		t.Fatalf("selected workspace = %q, want restored %q after send failure", got, previous)
+	}
+}
+
+func TestCmuxCloseRestoresPriorSelection(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	previous := seedCmuxSelectedWorkspace(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eab4")
+	plan.Agents = plan.Agents[:1]
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("Close = %#v, %v", closed, err)
+	}
+	if got := cmuxFakeSelectedWorkspace(t); got != previous {
+		t.Fatalf("selected workspace = %q, want restored %q after Close", got, previous)
+	}
+}
+
+func TestCmuxSendWithoutWorkspaceRejected(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	for _, args := range [][]string{
+		{"send", "--surface", "07eee802-4dde-4788-9281-95dd9a4ce502", "--", "hi"},
+		{"send-key", "--surface", "07eee802-4dde-4788-9281-95dd9a4ce502", "enter"},
+	} {
+		_, err := backend.run(context.Background(), args...)
+		if err == nil || !strings.Contains(err.Error(), "Surface is not a terminal") {
+			t.Fatalf("%s without --workspace error = %v, want invalid_params", args[0], err)
+		}
+	}
+}
+
+func TestCmuxCreateSendsOnlyTerminalSurface(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_BROWSER", "1")
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eab5")
+	plan.Agents = plan.Agents[:1]
+	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	terminal := cmuxFakeTerminalSurfaceID(t)
+	browser := cmuxFakeBrowserSurfaceID(t)
+	if terminal == "" || browser == "" {
+		t.Fatal("fake did not record browser and terminal surfaces")
+	}
+	for _, argv := range readCmuxArgvLog(t, logPath) {
+		if len(argv) == 0 || argv[0] != "send" {
+			continue
+		}
+		joined := strings.Join(argv, " ")
+		if strings.Contains(joined, browser) {
+			t.Fatalf("send targeted browser surface: %v", argv)
+		}
+		if !strings.Contains(joined, terminal) {
+			t.Fatalf("send missed terminal surface %s: %v", terminal, argv)
+		}
+	}
+}
+
+func TestParseCmuxTerminalSurfaceIDs(t *testing.T) {
+	ids, err := parseCmuxTerminalSurfaceIDs(`{"surfaces":[{"id":"019c5a10-75d8-7eef-8db7-5ee77f70aaa1","type":"browser"},{"id":"019c5a10-75d8-7eef-8db7-5ee77f70aaa2","type":"terminal"}]}`)
+	if err != nil || len(ids) != 1 || ids[0] != "019c5a10-75d8-7eef-8db7-5ee77f70aaa2" {
+		t.Fatalf("parseCmuxTerminalSurfaceIDs = %v, %v", ids, err)
 	}
 }
 

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -74,12 +74,21 @@ missing = os.environ.get("AMQ_CMUX_FAKE_MISSING", "")
 if command == "ping":
     emit({"pong": True})
     sys.exit(0)
+if command == "version":
+    print(os.environ.get("AMQ_CMUX_FAKE_APP_VERSION", "cmux 0.64.3 (83) [aea6cfcde]"))
+    sys.exit(0)
 if command == "capabilities":
-    emit({"access_mode": "cmuxOnly", "methods": ["workspace.list"], "protocol": "cmux-socket",
-          "socket_path": state["socket_path"], "version": state["version"]})
+    protocol = os.environ.get("AMQ_CMUX_FAKE_PROTOCOL", "2")
+    if protocol == "string":
+        cap_version = "0.64.3"
+    else:
+        cap_version = int(protocol)
+    emit({"socket_path": state["socket_path"], "version": cap_version, "protocol": "cmux-socket",
+          "methods": ["workspace.list"]})
     sys.exit(0)
 if command == "list-workspaces":
-    emit({"workspaces": [{"id": ws["id"], "title": ws["title"], "ref": "workspace:1", "index": 1, "selected": True} for ws in state["workspaces"]]})
+    emit({"workspaces": [{"id": ws["id"], "window_id": ws.get("window_id", ""), "current_directory": ws.get("cwd", ""),
+                          "title": ws["title"]} for ws in state["workspaces"]]})
     sys.exit(0)
 if command == "new-workspace":
     ws_id = str(uuid.uuid4())
@@ -88,10 +97,11 @@ if command == "new-workspace":
     surface_id = str(uuid.uuid4())
     state["workspaces"].append({
         "id": ws_id, "title": flags.get("name", ""), "window_id": window_id,
+        "cwd": flags.get("cwd", ""),
         "panes": [{"id": pane_id, "surfaces": [{"id": surface_id}]}],
     })
     save(state)
-    created = {"id": ws_id, "window_id": window_id, "ref": "workspace:1"}
+    created = {"id": ws_id, "window_id": window_id}
     if missing == "id":
         del created["id"]
     emit(created)
@@ -268,12 +278,11 @@ func TestCmuxHealthTimeoutDoesNotSend(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "readiness timed out") {
 		t.Fatalf("Create error = %v, want readiness timeout", err)
 	}
-	var definite *DefinitePreCreateError
-	if errors.As(err, &definite) {
-		t.Fatal("health timeout must retain the workspace for journal recovery")
-	}
 	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "send") >= 0 {
 		t.Fatal("sent text after readiness failure")
+	}
+	if cmuxFakeWorkspaceCount(t) != 0 {
+		t.Fatalf("health timeout left orphan workspaces: %d", cmuxFakeWorkspaceCount(t))
 	}
 }
 
@@ -326,7 +335,7 @@ func TestCmuxMissingIDFailsClosed(t *testing.T) {
 }
 
 func TestCmuxCrashAfterWorkspaceIsUncertain(t *testing.T) {
-	backend, _ := newFakeCmuxBackend(t)
+	backend, logPath := newFakeCmuxBackend(t)
 	t.Setenv("AMQ_CMUX_FAKE_FAIL", "new-split")
 	project := t.TempDir()
 	root := tmuxTestRoot(t, "claude", "codex")
@@ -334,6 +343,89 @@ func TestCmuxCrashAfterWorkspaceIsUncertain(t *testing.T) {
 	var definite *DefinitePreCreateError
 	if err == nil || errors.As(err, &definite) {
 		t.Fatalf("Create error = %v, want uncertain post-create failure", err)
+	}
+	if !strings.Contains(err.Error(), "closed orphan cmux workspace") {
+		t.Fatalf("Create error = %v, want closed orphan", err)
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") < 0 {
+		t.Fatal("split failure did not close the orphan workspace")
+	}
+	if cmuxFakeWorkspaceCount(t) != 0 {
+		t.Fatalf("split failure left orphan workspaces: %d", cmuxFakeWorkspaceCount(t))
+	}
+}
+
+func TestCmuxCreateTimeoutClosesSingleOrphanWorkspace(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	backend.createTimeout = 20 * time.Millisecond
+	inner := backend.run
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if cmuxArgvHas(args, "new-workspace") {
+			if _, err := inner(context.Background(), args...); err != nil {
+				return "", err
+			}
+			<-ctx.Done()
+			return "", fmt.Errorf("cmux new-workspace: %w", ctx.Err())
+		}
+		return inner(ctx, args...)
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa1")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil {
+		t.Fatal("Create succeeded after create-call timeout")
+	}
+	if !strings.Contains(err.Error(), "closed orphan cmux workspace") {
+		t.Fatalf("Create error = %v, want closed orphan", err)
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") < 0 {
+		t.Fatal("timeout did not close the orphan workspace")
+	}
+	if cmuxFakeWorkspaceCount(t) != 0 {
+		t.Fatalf("timeout left orphan workspaces: %d", cmuxFakeWorkspaceCount(t))
+	}
+}
+
+func TestCmuxCreateTimeoutDoesNotCloseAmbiguousWorkspaces(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	backend.createTimeout = 20 * time.Millisecond
+	inner := backend.run
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if cmuxArgvHas(args, "new-workspace") {
+			if _, err := inner(context.Background(), args...); err != nil {
+				return "", err
+			}
+			duplicateCmuxFakeNamedWorkspace(t)
+			<-ctx.Done()
+			return "", fmt.Errorf("cmux new-workspace: %w", ctx.Err())
+		}
+		return inner(ctx, args...)
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa2")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous cmux workspaces") {
+		t.Fatalf("Create error = %v, want ambiguous unknown", err)
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") >= 0 {
+		t.Fatal("ambiguous timeout guessed a workspace to close")
+	}
+	if cmuxFakeWorkspaceCount(t) != 2 {
+		t.Fatalf("ambiguous timeout closed workspaces: %d", cmuxFakeWorkspaceCount(t))
+	}
+}
+
+func TestCmuxDefaultCreateTimeoutExceedsCommandTimeout(t *testing.T) {
+	got := NewCmuxBackend("").createOpTimeout()
+	if got <= cmuxCommandTimeout {
+		t.Fatalf("default create timeout %s is not greater than command timeout %s", got, cmuxCommandTimeout)
+	}
+	if got < 30*time.Second {
+		t.Fatalf("default create timeout %s is below 30s", got)
 	}
 }
 
@@ -355,7 +447,7 @@ func TestCmuxCreateMissingAMQRefusesBeforeMutation(t *testing.T) {
 
 func TestCmuxVersionOutsideEnvelopeIsDegradedNotForeign(t *testing.T) {
 	backend, _ := newFakeCmuxBackend(t)
-	t.Setenv("AMQ_CMUX_FAKE_VERSION", "1.0.0")
+	t.Setenv("AMQ_CMUX_FAKE_APP_VERSION", "cmux 1.0.0 (1) [deadbeef]")
 	detect := backend.Detect()
 	if detect.Available {
 		t.Fatal("out-of-range version reported available")
@@ -363,15 +455,64 @@ func TestCmuxVersionOutsideEnvelopeIsDegradedNotForeign(t *testing.T) {
 	if detect.InstanceIdentity == "" || len(detect.Degradations) == 0 {
 		t.Fatalf("Detect = %#v, want instance identity and degradations", detect)
 	}
+	if !strings.Contains(detect.Degradations[0].Reason, "cmux version") {
+		t.Fatalf("degradation = %q, want CLI version refusal", detect.Degradations[0].Reason)
+	}
+}
+
+func TestCmuxCapabilitiesStringVersionIsUnsupported(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_PROTOCOL", "string")
+	detect := backend.Detect()
+	if detect.Available {
+		t.Fatal("string capabilities.version reported available")
+	}
+	if detect.InstanceIdentity == "" {
+		t.Fatal("string version lost instance identity")
+	}
+	if len(detect.Degradations) == 0 || !strings.Contains(detect.Degradations[0].Reason, "protocol integer") {
+		t.Fatalf("degradations = %#v, want typed protocol refusal", detect.Degradations)
+	}
+}
+
+func TestCmuxProtocolVersionUnsupported(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_PROTOCOL", "3")
+	detect := backend.Detect()
+	if detect.Available {
+		t.Fatal("protocol 3 reported available")
+	}
+	if len(detect.Degradations) == 0 || !strings.Contains(detect.Degradations[0].Reason, "protocol version 3") {
+		t.Fatalf("degradations = %#v, want protocol 3 refusal", detect.Degradations)
+	}
 }
 
 func TestSupportedCmuxVersion(t *testing.T) {
 	for _, tc := range []struct {
 		version string
 		want    bool
-	}{{"0.64.3", true}, {"cmux 0.64.3 (83)", true}, {"0.65.0", true}, {"0.64.2", false}, {"1.0.0", false}} {
+	}{{"0.64.3", true}, {"0.65.0", true}, {"0.64.2", false}, {"1.0.0", false}, {"cmux 0.64.3", false}} {
 		if got := supportedCmuxVersion(tc.version); got != tc.want {
 			t.Errorf("supportedCmuxVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestParseCmuxCLIVersion(t *testing.T) {
+	ok, err := parseCmuxCLIVersion("cmux 0.64.3 (83) [aea6cfcde]\n")
+	if err != nil || ok != "0.64.3" {
+		t.Fatalf("parseCmuxCLIVersion live shape = %q, %v", ok, err)
+	}
+	for _, raw := range []string{
+		"0.64.3",
+		"cmux 0.64.3 extra",
+		"cmux 0.64.3 (83) [aea6cfcde]\nsecond line",
+		"cmux 0.64",
+		"cmux v0.64.3",
+		"Cmux 0.64.3",
+	} {
+		if _, err := parseCmuxCLIVersion(raw); err == nil {
+			t.Errorf("parseCmuxCLIVersion(%q) succeeded, want error", raw)
 		}
 	}
 }
@@ -503,6 +644,8 @@ func newFakeCmuxBackend(t *testing.T) (*CmuxBackend, string) {
 	t.Setenv("AMQ_CMUX_FAKE_STATE", statePath)
 	t.Setenv("AMQ_CMUX_FAKE_SOCKET", socket)
 	t.Setenv("AMQ_CMUX_FAKE_VERSION", "0.64.3")
+	t.Setenv("AMQ_CMUX_FAKE_APP_VERSION", "cmux 0.64.3 (83) [aea6cfcde]")
+	t.Setenv("AMQ_CMUX_FAKE_PROTOCOL", "2")
 	t.Setenv("AMQ_CMUX_FAKE_FAIL", "")
 	t.Setenv("AMQ_CMUX_FAKE_UNHEALTHY", "")
 	t.Setenv("AMQ_CMUX_FAKE_MISSING", "")
@@ -573,6 +716,65 @@ func indexOfCmuxCommand(calls [][]string, command string) int {
 	return -1
 }
 
+func cmuxArgvHas(args []string, command string) bool {
+	for _, arg := range args {
+		if arg == command {
+			return true
+		}
+	}
+	return false
+}
+
+func cmuxFakeWorkspaceCount(t *testing.T) int {
+	t.Helper()
+	data, err := os.ReadFile(os.Getenv("AMQ_CMUX_FAKE_STATE"))
+	if errors.Is(err, os.ErrNotExist) {
+		return 0
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state struct {
+		Workspaces []json.RawMessage `json:"workspaces"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	return len(state.Workspaces)
+}
+
+func duplicateCmuxFakeNamedWorkspace(t *testing.T) {
+	t.Helper()
+	path := os.Getenv("AMQ_CMUX_FAKE_STATE")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	workspaces, _ := state["workspaces"].([]any)
+	if len(workspaces) == 0 {
+		t.Fatal("no cmux workspace to duplicate")
+	}
+	first, _ := workspaces[0].(map[string]any)
+	clone := map[string]any{
+		"id":        "019c5a10-75d8-7eef-8db7-5ee77f70ffff",
+		"title":     first["title"],
+		"window_id": "019c5a10-75d8-7eef-8db7-5ee77f70fffe",
+		"panes":     first["panes"],
+	}
+	state["workspaces"] = append(workspaces, clone)
+	out, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func countCmuxAgentResources(binding BindingRecord) int {
 	count := 0
 	for _, resource := range binding.Resources.Resources {
@@ -593,7 +795,7 @@ func TestCmuxArgvRecorderSeesCreateGrammar(t *testing.T) {
 		t.Fatal(err)
 	}
 	joined := fmt.Sprint(readCmuxArgvLog(t, logPath))
-	for _, needle := range []string{"ping", "capabilities", "new-workspace", "list-pane-surfaces", "surface-health", "send", "send-key"} {
+	for _, needle := range []string{"ping", "capabilities", "version", "new-workspace", "list-pane-surfaces", "surface-health", "send", "send-key"} {
 		if !strings.Contains(joined, needle) {
 			t.Fatalf("argv log missing %s: %s", needle, joined)
 		}

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -1,0 +1,601 @@
+package launch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const fakeCmuxScript = `#!/usr/bin/env python3
+import json, os, sys, uuid
+
+log_path = os.environ["AMQ_CMUX_FAKE_LOG"]
+state_path = os.environ["AMQ_CMUX_FAKE_STATE"]
+with open(log_path, "a", encoding="utf-8") as log:
+    log.write(json.dumps(sys.argv[1:]) + "\n")
+
+args = sys.argv[1:]
+flags = {}
+positional = []
+i = 0
+while i < len(args):
+    arg = args[i]
+    if arg == "--":
+        positional.extend(args[i + 1 :])
+        break
+    if arg == "--json":
+        i += 1
+        continue
+    if arg == "--id-format" and i + 1 < len(args):
+        i += 2
+        continue
+    if arg.startswith("--") and i + 1 < len(args) and not args[i + 1].startswith("--"):
+        flags[arg[2:].replace("-", "_")] = args[i + 1]
+        i += 2
+        continue
+    positional.append(arg)
+    i += 1
+
+command = positional[0] if positional else ""
+fail = os.environ.get("AMQ_CMUX_FAKE_FAIL", "")
+if fail == command or fail == "*":
+    print("injected failure", file=sys.stderr)
+    sys.exit(1)
+
+def load():
+    if not os.path.exists(state_path):
+        return {
+            "socket_path": os.environ.get("AMQ_CMUX_FAKE_SOCKET", "/tmp/cmux-fake.sock"),
+            "version": os.environ.get("AMQ_CMUX_FAKE_VERSION", "0.64.3"),
+            "workspaces": [],
+        }
+    with open(state_path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+def save(state):
+    with open(state_path, "w", encoding="utf-8") as fh:
+        json.dump(state, fh)
+
+def emit(obj):
+    print(json.dumps(obj))
+
+state = load()
+healthy = os.environ.get("AMQ_CMUX_FAKE_UNHEALTHY") != "1"
+missing = os.environ.get("AMQ_CMUX_FAKE_MISSING", "")
+
+if command == "ping":
+    emit({"pong": True})
+    sys.exit(0)
+if command == "capabilities":
+    emit({"access_mode": "cmuxOnly", "methods": ["workspace.list"], "protocol": "cmux-socket",
+          "socket_path": state["socket_path"], "version": state["version"]})
+    sys.exit(0)
+if command == "list-workspaces":
+    emit({"workspaces": [{"id": ws["id"], "title": ws["title"], "ref": "workspace:1", "index": 1, "selected": True} for ws in state["workspaces"]]})
+    sys.exit(0)
+if command == "new-workspace":
+    ws_id = str(uuid.uuid4())
+    window_id = str(uuid.uuid4())
+    pane_id = str(uuid.uuid4())
+    surface_id = str(uuid.uuid4())
+    state["workspaces"].append({
+        "id": ws_id, "title": flags.get("name", ""), "window_id": window_id,
+        "panes": [{"id": pane_id, "surfaces": [{"id": surface_id}]}],
+    })
+    save(state)
+    created = {"id": ws_id, "window_id": window_id, "ref": "workspace:1"}
+    if missing == "id":
+        del created["id"]
+    emit(created)
+    sys.exit(0)
+if command == "list-panes":
+    ws = next((item for item in state["workspaces"] if item["id"] == flags.get("workspace")), None)
+    emit({"panes": [{"id": pane["id"]} for pane in (ws["panes"] if ws else [])]})
+    sys.exit(0)
+if command == "list-pane-surfaces":
+    ws = next((item for item in state["workspaces"] if item["id"] == flags.get("workspace")), None)
+    pane = None
+    if ws:
+        pane = next((item for item in ws["panes"] if item["id"] == flags.get("pane")), None)
+    emit({"surfaces": [{"id": surface["id"]} for surface in (pane["surfaces"] if pane else [])]})
+    sys.exit(0)
+if command == "new-split":
+    ws = next((item for item in state["workspaces"] if item["id"] == flags.get("workspace")), None)
+    if ws is None:
+        print("workspace not found", file=sys.stderr)
+        sys.exit(1)
+    surface_id = str(uuid.uuid4())
+    ws["panes"].append({"id": str(uuid.uuid4()), "surfaces": [{"id": surface_id}]})
+    save(state)
+    emit({"id": surface_id})
+    sys.exit(0)
+if command == "surface-health":
+    ws = next((item for item in state["workspaces"] if item["id"] == flags.get("workspace")), None)
+    surfaces = []
+    if ws:
+        for pane in ws["panes"]:
+            for surface in pane["surfaces"]:
+                item = {"id": surface["id"], "in_window": healthy}
+                if missing == "in_window":
+                    del item["in_window"]
+                surfaces.append(item)
+    emit({"surfaces": surfaces})
+    sys.exit(0)
+if command in ("send", "send-key", "select-workspace", "focus-window"):
+    emit({"ok": True})
+    sys.exit(0)
+if command == "close-workspace":
+    before = len(state["workspaces"])
+    state["workspaces"] = [ws for ws in state["workspaces"] if ws["id"] != flags.get("workspace")]
+    save(state)
+    emit({"ok": True, "closed": before - len(state["workspaces"])})
+    sys.exit(0)
+print("unknown command " + command, file=sys.stderr)
+sys.exit(2)
+`
+
+func TestCmuxBackendLifecycleAndRecovery(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := writeSleepAMQ(t)
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70e7a5"
+	plan := cmuxTestPlan(project, nonce)
+
+	detect := backend.Detect()
+	if !detect.Available || detect.Profile.Identity() != "cmux/darwin/v1" || !strings.HasPrefix(detect.InstanceIdentity, "cmux-socket:") {
+		t.Fatalf("Detect = %#v", detect)
+	}
+	if strings.Contains(detect.InstanceIdentity, "@") || strings.Contains(detect.InstanceIdentity, detect.Profile.VersionRange) {
+		t.Fatalf("instance identity leaked version: %q", detect.InstanceIdentity)
+	}
+
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Outcome != OutcomeCreated {
+		t.Fatalf("Create = %#v", created)
+	}
+	assertNoCmuxCommandFlag(t, logPath)
+	if agents := countCmuxAgentResources(created.Binding); agents != 2 {
+		t.Fatalf("binding agents = %d, want 2: %#v", agents, created.Binding.Resources)
+	}
+
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectPresent {
+		t.Fatalf("Inspect = %#v, %v", inspection, err)
+	}
+
+	journal := LaunchJournal{
+		ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
+		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
+		Backend: LauncherCMux, Profile: detect.Profile.Identity(),
+	}
+	journal.RootIdentity, err = canonicalIdentity(root.Base())
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal.RootPhysical, _ = fsq.StableTreeIdentityInfo(root.FileInfo())
+	reclaimed, err := backend.Reclaim(ReclaimRequest{Context: context.Background(), Journal: journal, Root: root})
+	if err != nil || reclaimed.Status != ReclaimAdoptable || countCmuxAgentResources(BindingRecord{Resources: ResourceIdentitySet{Resources: reclaimed.Resources}}) != 2 {
+		t.Fatalf("Reclaim = %#v, %v", reclaimed, err)
+	}
+
+	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root}); err == nil {
+		t.Fatal("duplicate Create succeeded")
+	}
+	afterDuplicate, _ := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if afterDuplicate.Status != InspectPresent {
+		t.Fatalf("duplicate Create changed live resource: %#v", afterDuplicate)
+	}
+
+	foreignBinding := created.Binding
+	foreignBinding.InstanceIdentity = "cmux-socket:/foreign"
+	foreignInspection, err := backend.Inspect(InspectRequest{Binding: foreignBinding, Root: root})
+	if err != nil || foreignInspection.Status != InspectUnknown {
+		t.Fatalf("foreign Inspect = %#v, %v", foreignInspection, err)
+	}
+
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("Close = %#v, %v", closed, err)
+	}
+	absent, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || absent.Status != InspectAbsent {
+		t.Fatalf("Inspect after Close = %#v, %v", absent, err)
+	}
+}
+
+func TestCmuxBackendConformance(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	RunConformance(t, backend)
+}
+
+func TestCmuxCreateSendsExactLineAfterHealthGate(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := writeSleepAMQ(t)
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70e8a5")
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := readCmuxArgvLog(t, logPath)
+	if indexOfCmuxCommand(calls, "send") < indexOfCmuxCommand(calls, "surface-health") {
+		t.Fatalf("sent text before surface-health: %v", calls)
+	}
+	wantAMQ, err := filepath.EvalSymlinks(fakeAMQ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := backend.agentCommand(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: wantAMQ, Root: root}, plan.Agents[0])
+	found := false
+	for _, argv := range calls {
+		if len(argv) >= 1 && argv[0] == "send" {
+			for i, arg := range argv {
+				if arg == "--" && i+1 < len(argv) && argv[i+1] == want {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("exact command line not sent: want %q in %v", want, calls)
+	}
+	_ = created
+}
+
+func TestCmuxHealthTimeoutDoesNotSend(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_UNHEALTHY", "1")
+	backend.healthTimeout = 50 * time.Millisecond
+	backend.healthPoll = 10 * time.Millisecond
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70e9a5")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil || !strings.Contains(err.Error(), "readiness timed out") {
+		t.Fatalf("Create error = %v, want readiness timeout", err)
+	}
+	var definite *DefinitePreCreateError
+	if errors.As(err, &definite) {
+		t.Fatal("health timeout must retain the workspace for journal recovery")
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "send") >= 0 {
+		t.Fatal("sent text after readiness failure")
+	}
+}
+
+func TestCmuxCloseRefusesDifferentUUIDSameName(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa5")
+	plan.Agents = plan.Agents[:1]
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	forged := created.Binding
+	forged.Resources.Resources = append([]ResourceIdentity(nil), created.Binding.Resources.Resources...)
+	for i, resource := range forged.Resources.Resources {
+		if strings.HasPrefix(resource.OpaqueID, cmuxWorkspacePrefix) {
+			forged.Resources.Resources[i].OpaqueID = cmuxWorkspacePrefix + "019c5a10-75d8-7eef-8db7-5ee77f70eaaa:" + plan.Agents[0].LaunchNonce
+		}
+	}
+	closed, err := backend.Close(CloseRequest{Binding: forged, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.Outcome == OutcomeClosed && closed.Reason != "cmux workspace already absent" {
+		t.Fatalf("Close mutated an unrelated workspace: %#v", closed)
+	}
+	for _, argv := range readCmuxArgvLog(t, logPath) {
+		if len(argv) > 0 && argv[0] == "close-workspace" {
+			t.Fatalf("close-workspace invoked for a missing uuid: %v", argv)
+		}
+	}
+	present, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || present.Status != InspectPresent {
+		t.Fatalf("live workspace was closed: %#v, %v", present, err)
+	}
+}
+
+func TestCmuxMissingIDFailsClosed(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_MISSING", "id")
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eba5")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil || !strings.Contains(err.Error(), "not a UUID") && !strings.Contains(err.Error(), "new-workspace") {
+		t.Fatalf("Create error = %v, want fail-closed uuid parse", err)
+	}
+}
+
+func TestCmuxCrashAfterWorkspaceIsUncertain(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_FAIL", "new-split")
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eca5"), AMQPath: writeSleepAMQ(t), Root: root})
+	var definite *DefinitePreCreateError
+	if err == nil || errors.As(err, &definite) {
+		t.Fatalf("Create error = %v, want uncertain post-create failure", err)
+	}
+}
+
+func TestCmuxCreateMissingAMQRefusesBeforeMutation(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eda5")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: filepath.Join(t.TempDir(), "missing-amq"), Root: root})
+	var definite *DefinitePreCreateError
+	if !errors.As(err, &definite) {
+		t.Fatalf("Create error = %v, want definite pre-create refusal", err)
+	}
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "new-workspace") >= 0 {
+		t.Fatal("missing amq created a cmux workspace")
+	}
+}
+
+func TestCmuxVersionOutsideEnvelopeIsDegradedNotForeign(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_VERSION", "1.0.0")
+	detect := backend.Detect()
+	if detect.Available {
+		t.Fatal("out-of-range version reported available")
+	}
+	if detect.InstanceIdentity == "" || len(detect.Degradations) == 0 {
+		t.Fatalf("Detect = %#v, want instance identity and degradations", detect)
+	}
+}
+
+func TestSupportedCmuxVersion(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		want    bool
+	}{{"0.64.3", true}, {"cmux 0.64.3 (83)", true}, {"0.65.0", true}, {"0.64.2", false}, {"1.0.0", false}} {
+		if got := supportedCmuxVersion(tc.version); got != tc.want {
+			t.Errorf("supportedCmuxVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestCmuxListWorkspacesErrorIsUnknownNotAbsent(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := writeSleepAMQ(t)
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70efa5"
+	plan := cmuxTestPlan(project, nonce)
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := AcquireLease(root, created.Binding.LaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBinding(root, lease, created.Binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenTrustStore(t.TempDir(), project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	detect := backend.Detect()
+	req := ReconcileRequest{
+		ProjectRoot: project, Session: "collab", AMQPath: fakeAMQ, Root: root,
+		Config: ProjectConfig{Schema: ProjectConfigSchema, DefaultSession: "collab", Layout: LayoutIntent{Type: LayoutColumns}, Agents: []ProjectAgentConfig{
+			{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeEnabled},
+		}},
+		Launcher: LauncherCMux, Preferences: []string{LauncherCMux},
+		Backends:   map[string]Backend{LauncherCMux: backend},
+		Adapters:   map[string]HarnessAdapter{"claude": reconcileAdapter{name: "claude", mode: AdapterModeMint, available: true}},
+		TrustStore: store, ConfirmTrust: func(Plan, string) (bool, error) { return true, nil },
+		HostIdentity: detect.HostIdentity,
+	}
+	if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMQ_CMUX_FAKE_FAIL", "list-workspaces")
+
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectUnknown || !inspection.ActionRequired {
+		t.Fatalf("Inspect = %#v, %v, want unknown action-required", inspection, err)
+	}
+	if !strings.Contains(inspection.Evidence, "list cmux workspaces") {
+		t.Fatalf("Inspect evidence = %q, want list-workspaces failure", inspection.Evidence)
+	}
+
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Reason != "inspect_unknown" {
+		t.Fatalf("Reconcile = %#v, want inspect_unknown", result)
+	}
+
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.Outcome != OutcomeActionRequired {
+		t.Fatalf("Close = %#v, want action-required", closed)
+	}
+
+	calls := readCmuxArgvLog(t, logPath)
+	if indexOfCmuxCommand(calls, "new-workspace") >= 0 || indexOfCmuxCommand(calls, "close-workspace") >= 0 {
+		t.Fatalf("list-workspaces failure mutated backend: %v", calls)
+	}
+
+	t.Setenv("AMQ_CMUX_FAKE_FAIL", "")
+	present, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || present.Status != InspectPresent {
+		t.Fatalf("workspace after list failure = %#v, %v", present, err)
+	}
+}
+
+func TestCmuxUnreachableSocketIsNotForeignContext(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70efb5")
+	plan.Agents = plan.Agents[:1]
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMQ_CMUX_FAKE_FAIL", "ping")
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectUnknown || !inspection.ActionRequired {
+		t.Fatalf("Inspect = %#v, %v, want unknown action-required", inspection, err)
+	}
+	if !strings.Contains(inspection.Evidence, "unreachable") {
+		t.Fatalf("Inspect evidence = %q, want unreachable socket", inspection.Evidence)
+	}
+	if strings.Contains(inspection.Evidence, "different backend context") {
+		t.Fatalf("unreachable socket reported as foreign: %q", inspection.Evidence)
+	}
+}
+
+func TestCmuxInsidePreferencePrependsOnlyWhenInside(t *testing.T) {
+	prefs := []string{LauncherTMux, LauncherCommands}
+	if got := prependInsideCmuxPreference(prefs); !strings.EqualFold(strings.Join(got, ","), strings.Join(prefs, ",")) {
+		t.Fatalf("outside prepend = %v", got)
+	}
+	t.Setenv("CMUX_SURFACE_ID", "F901D722-6789-4BBB-9818-C4E97F20BEB3")
+	got := prependInsideCmuxPreference(prefs)
+	if len(got) != 3 || got[0] != LauncherCMux || got[1] != LauncherTMux {
+		t.Fatalf("inside prepend = %v", got)
+	}
+}
+
+func newFakeCmuxBackend(t *testing.T) (*CmuxBackend, string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "cmux")
+	if err := os.WriteFile(script, []byte(fakeCmuxScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(dir, "argv.log")
+	statePath := filepath.Join(dir, "state.json")
+	socket := filepath.Join(dir, "cmux.sock")
+	t.Setenv("AMQ_CMUX_FAKE_LOG", logPath)
+	t.Setenv("AMQ_CMUX_FAKE_STATE", statePath)
+	t.Setenv("AMQ_CMUX_FAKE_SOCKET", socket)
+	t.Setenv("AMQ_CMUX_FAKE_VERSION", "0.64.3")
+	t.Setenv("AMQ_CMUX_FAKE_FAIL", "")
+	t.Setenv("AMQ_CMUX_FAKE_UNHEALTHY", "")
+	t.Setenv("AMQ_CMUX_FAKE_MISSING", "")
+	backend := NewCmuxBackend(script)
+	backend.healthTimeout = time.Second
+	backend.healthPoll = 10 * time.Millisecond
+	return backend, logPath
+}
+
+func writeSleepAMQ(t *testing.T) string {
+	t.Helper()
+	fakeAMQ := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nexec /bin/sleep 60\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return fakeAMQ
+}
+
+func cmuxTestPlan(project, nonce string) Plan {
+	return Plan{Version: PlanVersion, Agents: []AgentPlan{
+		{Handle: "claude", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7a6"},
+		{Handle: "codex", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7a7"},
+	}}
+}
+
+func assertNoCmuxCommandFlag(t *testing.T, logPath string) {
+	t.Helper()
+	for _, argv := range readCmuxArgvLog(t, logPath) {
+		for _, arg := range argv {
+			if arg == "--command" {
+				t.Fatalf("cmux invoked with --command: %v", argv)
+			}
+		}
+	}
+}
+
+func readCmuxArgvLog(t *testing.T, logPath string) [][]string {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var calls [][]string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var argv []string
+		if err := json.Unmarshal([]byte(line), &argv); err != nil {
+			t.Fatal(err)
+		}
+		calls = append(calls, argv)
+	}
+	return calls
+}
+
+func indexOfCmuxCommand(calls [][]string, command string) int {
+	for i, argv := range calls {
+		for _, arg := range argv {
+			if arg == command {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func countCmuxAgentResources(binding BindingRecord) int {
+	count := 0
+	for _, resource := range binding.Resources.Resources {
+		if resource.Agent != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func TestCmuxArgvRecorderSeesCreateGrammar(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eea5")
+	plan.Agents = plan.Agents[:1]
+	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	joined := fmt.Sprint(readCmuxArgvLog(t, logPath))
+	for _, needle := range []string{"ping", "capabilities", "new-workspace", "list-pane-surfaces", "surface-health", "send", "send-key"} {
+		if !strings.Contains(joined, needle) {
+			t.Fatalf("argv log missing %s: %s", needle, joined)
+		}
+	}
+}

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -524,7 +524,7 @@ func selectPrepareBackend(requested string, binding *BindingRecord, dependencies
 		}
 	}
 	if selected == LauncherAuto {
-		for _, name := range preferences {
+		for _, name := range prependInsideCmuxPreference(preferences) {
 			backend := dependencies.Backends[name]
 			if backend == nil {
 				continue

--- a/internal/launch/prepare_test.go
+++ b/internal/launch/prepare_test.go
@@ -212,6 +212,49 @@ func TestTmuxDetectDoesNotMutateBackend(t *testing.T) {
 	}
 }
 
+func TestPrepareAutoFollowsPreferenceOutsideCmux(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	fixture.request.Launcher = LauncherAuto
+	tmux := &prepareTestBackend{}
+	cmux := &prepareTestBackend{}
+	result, err := Prepare(context.Background(), fixture.request, PrepareDependencies{
+		Backends:    map[string]Backend{LauncherCMux: cmux, LauncherTMux: tmux},
+		Preferences: []string{LauncherTMux, LauncherCommands},
+		AdapterFor: func(provider, executable string) HarnessAdapter {
+			return prepareTestAdapter{provider: provider}
+		},
+		HostIdentity: "host:test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Backend != LauncherTMux {
+		t.Fatalf("outside backend = %q", result.Backend)
+	}
+}
+
+func TestPrepareAutoInsideCmuxPrependsCmux(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	fixture.request.Launcher = LauncherAuto
+	tmux := &prepareTestBackend{}
+	cmux := &prepareTestBackend{}
+	t.Setenv("CMUX_SURFACE_ID", "F901D722-6789-4BBB-9818-C4E97F20BEB3")
+	result, err := Prepare(context.Background(), fixture.request, PrepareDependencies{
+		Backends:    map[string]Backend{LauncherCMux: cmux, LauncherTMux: tmux},
+		Preferences: []string{LauncherTMux, LauncherCommands},
+		AdapterFor: func(provider, executable string) HarnessAdapter {
+			return prepareTestAdapter{provider: provider}
+		},
+		HostIdentity: "host:test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Backend != LauncherCMux {
+		t.Fatalf("inside-cmux backend = %q", result.Backend)
+	}
+}
+
 type internalPrepareFixture struct {
 	root        string
 	projectRoot string

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -1051,7 +1051,7 @@ func chooseReconcileBackend(request ReconcileRequest, binding BindingRecord, has
 }
 
 func selectPreferredBackend(request ReconcileRequest) (string, Backend, DetectResult, bool, error) {
-	for _, name := range request.Preferences {
+	for _, name := range prependInsideCmuxPreference(request.Preferences) {
 		backend := request.Backends[name]
 		if backend == nil {
 			continue

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -542,6 +542,56 @@ func TestReconcileInstanceReuseNeverClosesUnrelatedResource(t *testing.T) {
 	}
 }
 
+func TestReconcileAutoSelectsPreferenceWhenNotInsideCmux(t *testing.T) {
+	tmux := &reconcileBackend{name: LauncherTMux, inspect: InspectAbsent}
+	cmux := &reconcileBackend{name: LauncherCMux, inspect: InspectAbsent}
+	req := reconcileFixture(t, tmux)
+	req.Backends[LauncherCMux] = cmux
+	req.Launcher = LauncherAuto
+	req.Preferences = []string{LauncherTMux, LauncherCommands}
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Backend != LauncherTMux || tmux.creates != 1 || cmux.creates != 0 {
+		t.Fatalf("ping-live without inside-cmux selected %#v tmux=%d cmux=%d", result, tmux.creates, cmux.creates)
+	}
+}
+
+func TestReconcileAutoInsideCmuxPrependsCmux(t *testing.T) {
+	tmux := &reconcileBackend{name: LauncherTMux, inspect: InspectAbsent}
+	cmux := &reconcileBackend{name: LauncherCMux, inspect: InspectAbsent}
+	req := reconcileFixture(t, tmux)
+	req.Backends[LauncherCMux] = cmux
+	req.Launcher = LauncherAuto
+	req.Preferences = []string{LauncherTMux, LauncherCommands}
+	t.Setenv("CMUX_SURFACE_ID", "F901D722-6789-4BBB-9818-C4E97F20BEB3")
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Backend != LauncherCMux || cmux.creates != 1 || tmux.creates != 0 {
+		t.Fatalf("inside-cmux selected %#v tmux=%d cmux=%d", result, tmux.creates, cmux.creates)
+	}
+}
+
+func TestReconcileExplicitLauncherWinsInsideCmux(t *testing.T) {
+	tmux := &reconcileBackend{name: LauncherTMux, inspect: InspectAbsent}
+	cmux := &reconcileBackend{name: LauncherCMux, inspect: InspectAbsent}
+	req := reconcileFixture(t, tmux)
+	req.Backends[LauncherCMux] = cmux
+	req.Launcher = LauncherTMux
+	req.Preferences = []string{LauncherCMux, LauncherTMux}
+	t.Setenv("CMUX_SURFACE_ID", "F901D722-6789-4BBB-9818-C4E97F20BEB3")
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Backend != LauncherTMux || tmux.creates != 1 || cmux.creates != 0 {
+		t.Fatalf("explicit launcher = %#v tmux=%d cmux=%d", result, tmux.creates, cmux.creates)
+	}
+}
+
 func TestReconcileAbsentBindingAutoSelectsPreferredBackend(t *testing.T) {
 	old := &reconcileBackend{name: "old", inspect: InspectAbsent}
 	preferred := &reconcileBackend{name: "preferred", inspect: InspectAbsent}

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -404,7 +404,7 @@ func TestApplyRequiresExactRequestLocalDecisions(t *testing.T) {
 
 func TestApplyUnsupportedLauncherRefusesBeforeRosterMutation(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, true)
-	fixture.request.Launcher = "cmux"
+	fixture.request.Launcher = "ghostty"
 	fixture.request.Intent.Participants = append(fixture.request.Intent.Participants, ParticipantV1{Handle: "reviewer", Runnable: false})
 	prepared, err := Prepare(context.Background(), fixture.request)
 	if err != nil {

--- a/launchapi/lifecycle.go
+++ b/launchapi/lifecycle.go
@@ -49,12 +49,7 @@ func lifecycleDependencies() internallaunch.LifecycleDependencies {
 	return internallaunch.LifecycleDependencies{Backends: lifecycleBackends()}
 }
 
-var lifecycleBackends = func() map[string]internallaunch.Backend {
-	return map[string]internallaunch.Backend{
-		internallaunch.LauncherCommands: internallaunch.Commands{},
-		internallaunch.LauncherTMux:     internallaunch.NewTmuxBackend("tmux"),
-	}
-}
+var lifecycleBackends = internallaunch.DefaultBackends
 
 func lifecycleResult(result internallaunch.LifecycleResult) LifecycleResultV1 {
 	public := LifecycleResultV1{

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -74,10 +74,7 @@ func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, int
 		internalRequest.Participants = append(internalRequest.Participants, toInternalPrepareParticipant(participant, provider, committedArgs, bypassArgs))
 	}
 	dependencies := internallaunch.PrepareDependencies{
-		Backends: map[string]internallaunch.Backend{
-			internallaunch.LauncherCommands: internallaunch.Commands{},
-			internallaunch.LauncherTMux:     internallaunch.NewTmuxBackend("tmux"),
-		},
+		Backends:     internallaunch.DefaultBackends(),
 		AdapterFor:   defaultPrepareAdapter,
 		TrustStore:   trustStore,
 		HostIdentity: host,

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -105,12 +105,12 @@ func TestPrepareParticipantOnlyAbsentSessionDoesNotProvision(t *testing.T) {
 
 func TestPrepareUnavailableLauncherIsTypedAndDoesNotRequestTrust(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, true)
-	fixture.request.Launcher = "cmux"
+	fixture.request.Launcher = "ghostty"
 	result, err := Prepare(context.Background(), fixture.request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Outcome != PrepareOutcomeUnsupported || result.Reason != "launcher_not_available" || result.Preview.Backend != "cmux" {
+	if result.Outcome != PrepareOutcomeUnsupported || result.Reason != "launcher_not_available" || result.Preview.Backend != "ghostty" {
 		t.Fatalf("unavailable launcher result = %#v", result)
 	}
 	if len(result.RequiredActions) != 0 {


### PR DESCRIPTION
## Summary

- Add a managed `cmux` launch backend: `amq launch --backend cmux` creates a workspace, injects the AMQ start snippet, and returns a binding with `cmux-socket:` instance identity.
- Pin protocol 2 (`capabilities.version` as a JSON number), parse `new-workspace --json` `OK workspace:<ref>` acks, resolve the workspace UUID by an exact unique title match, and fail closed on 0 or >1 matches.
- Send/send-key require both `--workspace` and `--surface` (`type==terminal` only). `--focus false` on create. Restore operator selection after Create (always) and after Close when a neighbor steal is observed.
- Create timeout after ack orphan-closes the new workspace. Close restore is covered by a fake that steals selection to a remaining neighbor.

```text
BEGIN_COMMIT_OVERRIDE
feat(launch): add managed cmux backend

fix(launch): pin cmux protocol 2 and orphan-close on create timeout

fix(launch): parse cmux OK workspace ack and keep operator focus

fix(launch): send cmux input with workspace and restore selection
END_COMMIT_OVERRIDE
```

## Live 0.64.3 findings

- `capabilities.version` is a JSON number, protocol **2**.
- Instance id is `cmux-socket:` plus the canonical socket path.
- `new-workspace --json` stdout is plain text `OK workspace:<ref>`; resolve UUID by exactly one title match after the ack.
- `--focus false` on create. `send` and `send-key` need both `--workspace` and `--surface`. Surfaces must be `type==terminal`.
- Fake CLI rejects `--surface` without `--workspace` with stderr `Error: invalid_params: Surface is not a terminal`.
- Create: `defer restoreSelectedWorkspace(previousSelected, workspaceID)` on every exit path.
- Close: capture selected workspace before close; re-select if that id is still present and is not the closed workspace.

**Follow-up (not this PR):** after Create, `Focus` then `Close` captures the created workspace as selected, so Close restore skips the operator tab and cmux may leave a neighbor selected. Cleanup in `TestCmuxLive` restores the pre-Create selected id.

## Test plan

- [x] `go test ./internal/launch -count=1` green on this worktree
- [x] `go test -race ./internal/launch ./internal/keepalive ./internal/sessionguard -count=2`
- [x] `golangci-lint run ./internal/launch/... ./internal/keepalive/...` (0 issues)
- [x] Mutants (must fail): drop protocol==2; treat version as string `"2"`; skip unique-title resolve; skip `--workspace` on send; skip `--surface` on send; skip `--focus false`; skip Create restore; skip Close restore (neighbor steal)
- [x] Live: `AMQ_CMUX_LIVE=1 go test ./internal/launch -run TestCmuxLive -count=1 -v` on `516b955` — selected workspace unchanged after Create; two extra tabs; operator focus preserved
- [ ] Claude: verify `origin/feat/cmux-backend` == `9846d287befaa73f3e65aa32938d5250558731f7`
- [ ] Claude: merge pipeline (tests + race + lint + live if available)

Content hash `git diff 3289365..HEAD | shasum -a 256` =
`4bb8b534c89dad028e94960babb2c4bc0fc7c78ead8d6547336e9d724dffce77`

Made with [Cursor](https://cursor.com)