### PR TITLE
feat(launch): add managed Ghostty backend

### DIFF
--- a/docs/launch-recovery.md
+++ b/docs/launch-recovery.md
@@ -27,7 +27,9 @@ On the next launch, AMQ holds the session lease and follows these rules:
 
 `Create` failures preserve the journal unless the backend returns the typed
 definite-pre-create error that proves no resource was made. Partial creation is
-never adoptable.
+never adoptable. A Ghostty crash between window creation and binding persistence
+leaves that window for manual close; AMQ never treats the gap as proven absence
+and never creates a duplicate.
 
 Managed cmux Create puts the new workspace in the app-wide active window and
 does not retarget it.

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -89,9 +89,12 @@ var (
 			launch.NewCursorAdapter(launch.CursorProvider),
 		}
 	}
-	setupLookPath      = exec.LookPath
-	setupCmuxAvailable = func() bool {
+	setupLookPath         = exec.LookPath
+	setupCmuxAvailable    = func() bool {
 		return launch.NewCmuxBackend("").Detect().Available
+	}
+	setupGhosttyAvailable = func() bool {
+		return launch.NewGhosttyBackend().Detect().Available
 	}
 	setupIsTerminal = func() bool {
 		return term.IsTerminal(int(os.Stdin.Fd()))
@@ -618,8 +621,11 @@ func detectSetupLaunchers() []string {
 }
 
 func setupLauncherAvailable(name string) bool {
-	if name == launch.LauncherCMux {
+	switch name {
+	case launch.LauncherCMux:
 		return setupCmuxAvailable()
+	case launch.LauncherGhostty:
+		return setupGhosttyAvailable()
 	}
 	_, err := setupLookPath(name)
 	return err == nil

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -89,8 +89,8 @@ var (
 			launch.NewCursorAdapter(launch.CursorProvider),
 		}
 	}
-	setupLookPath         = exec.LookPath
-	setupCmuxAvailable    = func() bool {
+	setupLookPath      = exec.LookPath
+	setupCmuxAvailable = func() bool {
 		return launch.NewCmuxBackend("").Detect().Available
 	}
 	setupGhosttyAvailable = func() bool {

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -529,9 +529,10 @@ func TestSetupNoGitignorePreservesExistingBytes(t *testing.T) {
 }
 
 var (
-	execLookPathForSetup      = setupLookPath
-	setupCmuxAvailableDefault = setupCmuxAvailable
-	setupTerminalDefault      = setupIsTerminal
+	execLookPathForSetup         = setupLookPath
+	setupCmuxAvailableDefault    = setupCmuxAvailable
+	setupGhosttyAvailableDefault = setupGhosttyAvailable
+	setupTerminalDefault         = setupIsTerminal
 )
 
 func setupProjectFixture(t *testing.T, adapters ...string) string {
@@ -555,6 +556,7 @@ func setupProjectFixture(t *testing.T, adapters ...string) string {
 	}
 	setupLookPath = func(string) (string, error) { return "", fs.ErrNotExist }
 	setupCmuxAvailable = func() bool { return false }
+	setupGhosttyAvailable = func() bool { return false }
 	setupCommitStepHook = nil
 	t.Cleanup(func() {
 		_ = os.Chdir(oldCWD)
@@ -567,6 +569,7 @@ func setupProjectFixture(t *testing.T, adapters ...string) string {
 		}
 		setupLookPath = execLookPathForSetup
 		setupCmuxAvailable = setupCmuxAvailableDefault
+		setupGhosttyAvailable = setupGhosttyAvailableDefault
 		setupIsTerminal = setupTerminalDefault
 		setupCommitStepHook = nil
 	})
@@ -671,6 +674,26 @@ func TestSetupCmuxAvailableUsesPingNotLookPath(t *testing.T) {
 		t.Fatalf("ping-available bundle cmux was omitted: %s", pingOnly)
 	}
 	_ = project
+}
+
+func TestSetupDetectGhosttyUsesPingNotLookPath(t *testing.T) {
+	_ = setupProjectFixture(t, "claude")
+	setupLookPath = func(name string) (string, error) {
+		if name == launch.LauncherGhostty {
+			return "/usr/bin/ghostty", nil
+		}
+		return "", fs.ErrNotExist
+	}
+	setupGhosttyAvailable = func() bool { return false }
+	got := detectSetupLaunchers()
+	if slices.Contains(got, launch.LauncherGhostty) {
+		t.Fatalf("LookPath without ping listed ghostty: %v", got)
+	}
+	setupGhosttyAvailable = func() bool { return true }
+	got = detectSetupLaunchers()
+	if !slices.Contains(got, launch.LauncherGhostty) {
+		t.Fatalf("ping did not list ghostty: %v", got)
+	}
 }
 
 func setupPreviewLaunchers(t *testing.T, raw string) []string {

--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -3,7 +3,9 @@ package launch
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
+	"strings"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
@@ -243,5 +245,28 @@ func DefaultBackends() map[string]Backend {
 		LauncherCommands: Commands{},
 		LauncherTMux:     NewTmuxBackend("tmux"),
 		LauncherCMux:     NewCmuxBackend(""),
+		LauncherGhostty:  NewGhosttyBackend(),
 	}
+}
+
+// prependInsideSurfacePreference puts the in-surface launcher first. Inside
+// cmux beats inside Ghostty. Selection still requires Detect availability.
+func prependInsideSurfacePreference(prefs []string) []string {
+	if strings.TrimSpace(os.Getenv("CMUX_SURFACE_ID")) != "" {
+		return prependLauncherPreference(prefs, LauncherCMux)
+	}
+	if strings.TrimSpace(os.Getenv("TERM_PROGRAM")) == "ghostty" {
+		return prependLauncherPreference(prefs, LauncherGhostty)
+	}
+	return prefs
+}
+
+func prependLauncherPreference(prefs []string, name string) []string {
+	out := []string{name}
+	for _, existing := range prefs {
+		if existing != name {
+			out = append(out, existing)
+		}
+	}
+	return out
 }

--- a/internal/launch/backend_test.go
+++ b/internal/launch/backend_test.go
@@ -1,6 +1,9 @@
 package launch
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestDetectResultRejectsEffectiveOutsideMaximum(t *testing.T) {
 	result := DetectResult{
@@ -16,5 +19,27 @@ func TestDetectResultRejectsEffectiveOutsideMaximum(t *testing.T) {
 func TestProfileIdentity(t *testing.T) {
 	if got := CommandsProfile().Identity(); got != "commands/any/v1" {
 		t.Fatalf("Identity = %q", got)
+	}
+}
+
+func TestDefaultBackendsMatchesLauncherRegistry(t *testing.T) {
+	want := knownLaunchers()
+	backends := DefaultBackends()
+	if len(backends) != len(want) {
+		t.Fatalf("DefaultBackends size = %d, want %d keys %v", len(backends), len(want), want)
+	}
+	for _, name := range want {
+		backend, ok := backends[name]
+		if !ok || backend == nil {
+			t.Fatalf("DefaultBackends missing %q", name)
+		}
+		if got := backend.Detect().Profile.Backend; got != name {
+			t.Fatalf("DefaultBackends[%q].Profile.Backend = %q", name, got)
+		}
+	}
+	for name := range backends {
+		if !slices.Contains(want, name) {
+			t.Fatalf("DefaultBackends extra %q", name)
+		}
 	}
 }

--- a/internal/launch/cmux.go
+++ b/internal/launch/cmux.go
@@ -1152,16 +1152,3 @@ func redactCmuxArgs(args []string) []string {
 	}
 	return out
 }
-
-func prependInsideCmuxPreference(prefs []string) []string {
-	if strings.TrimSpace(os.Getenv("CMUX_SURFACE_ID")) == "" {
-		return prefs
-	}
-	out := []string{LauncherCMux}
-	for _, name := range prefs {
-		if name != LauncherCMux {
-			out = append(out, name)
-		}
-	}
-	return out
-}

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -794,11 +794,13 @@ func TestCmuxUnreachableSocketIsNotForeignContext(t *testing.T) {
 
 func TestCmuxInsidePreferencePrependsOnlyWhenInside(t *testing.T) {
 	prefs := []string{LauncherTMux, LauncherCommands}
-	if got := prependInsideCmuxPreference(prefs); !strings.EqualFold(strings.Join(got, ","), strings.Join(prefs, ",")) {
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("CMUX_SURFACE_ID", "")
+	if got := prependInsideSurfacePreference(prefs); !strings.EqualFold(strings.Join(got, ","), strings.Join(prefs, ",")) {
 		t.Fatalf("outside prepend = %v", got)
 	}
 	t.Setenv("CMUX_SURFACE_ID", "F901D722-6789-4BBB-9818-C4E97F20BEB3")
-	got := prependInsideCmuxPreference(prefs)
+	got := prependInsideSurfacePreference(prefs)
 	if len(got) != 3 || got[0] != LauncherCMux || got[1] != LauncherTMux {
 		t.Fatalf("inside prepend = %v", got)
 	}

--- a/internal/launch/config.go
+++ b/internal/launch/config.go
@@ -21,6 +21,10 @@ const (
 	LauncherCommands    = "commands"
 )
 
+func knownLaunchers() []string {
+	return []string{LauncherCMux, LauncherGhostty, LauncherTMux, LauncherCommands}
+}
+
 type ProjectConfig struct {
 	Schema         int                  `json:"schema"`
 	DefaultSession string               `json:"default_session"`
@@ -165,7 +169,7 @@ func (cfg LocalConfig) Validate() error {
 	}
 	seen := make(map[string]struct{}, len(cfg.LauncherPreference))
 	for _, launcher := range cfg.LauncherPreference {
-		if !slices.Contains([]string{LauncherCMux, LauncherGhostty, LauncherTMux, LauncherCommands}, launcher) {
+		if !slices.Contains(knownLaunchers(), launcher) {
 			return fmt.Errorf("unsupported launcher preference %q", launcher)
 		}
 		if _, ok := seen[launcher]; ok {

--- a/internal/launch/ghostty.go
+++ b/internal/launch/ghostty.go
@@ -1,0 +1,888 @@
+package launch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	ghosttyProfileVersion      = 1
+	ghosttyProfileVersionRange = ">=1.3.0 <2.0"
+	ghosttyCommandTimeout      = 5 * time.Second
+	ghosttyHealthTimeout       = 15 * time.Second
+	ghosttyHealthPoll          = 100 * time.Millisecond
+	ghosttyBundleID            = "com.mitchellh.ghostty"
+	ghosttyInstancePrefix      = "ghostty-app:"
+	ghosttyWindowPrefix        = "ghostty:v1:window:"
+	ghosttyTabPrefix           = "ghostty:v1:tab:"
+	ghosttyTerminalPrefix      = "ghostty:v1:terminal:"
+)
+
+// GhosttyBackend manages one Ghostty window per AMQ project/session generation
+// on macOS via AppleScript.
+type GhosttyBackend struct {
+	run           func(context.Context, ...string) (string, error)
+	hostname      func() (string, error)
+	getenv        func(string) string
+	sleep         func(context.Context, time.Duration) error
+	healthTimeout time.Duration
+	healthPoll    time.Duration
+	mu            sync.Mutex
+	generations   map[string]string
+}
+
+func NewGhosttyBackend() *GhosttyBackend {
+	b := &GhosttyBackend{
+		hostname: os.Hostname, getenv: os.Getenv,
+		healthTimeout: ghosttyHealthTimeout, healthPoll: ghosttyHealthPoll,
+		generations: make(map[string]string),
+	}
+	b.run = b.runAppleScript
+	return b
+}
+
+func GhosttyProfile() Profile {
+	return Profile{
+		Backend: LauncherGhostty, Platform: "darwin",
+		VersionRange: ghosttyProfileVersionRange, Version: ghosttyProfileVersion,
+		Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus, CapReclaim},
+	}
+}
+
+func (b *GhosttyBackend) Detect() DetectResult {
+	profile := GhosttyProfile()
+	result := DetectResult{Profile: profile}
+	ctx, cancel := context.WithTimeout(context.Background(), ghosttyCommandTimeout)
+	defer cancel()
+	raw, err := b.run(ctx, "version")
+	if err != nil {
+		return result
+	}
+	host, err := b.hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		return result
+	}
+	result.HostIdentity = host
+	result.InstanceIdentity = ghosttyInstancePrefix + ghosttyBundleID
+	if !supportedGhosttyVersion(raw) {
+		reason := fmt.Sprintf("ghostty version %q is outside %s", strings.TrimSpace(raw), ghosttyProfileVersionRange)
+		for _, cap := range profile.Capabilities {
+			result.Degradations = append(result.Degradations, Degradation{Capability: cap, Reason: reason})
+		}
+		return result
+	}
+	result.Available = true
+	result.Effective = append([]Capability(nil), profile.Capabilities...)
+	return result
+}
+
+func (b *GhosttyBackend) Create(req CreateRequest) (CreateResult, error) {
+	if err := b.validateCreate(req); err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: err}
+	}
+	amqPath := req.AMQPath
+	if strings.TrimSpace(amqPath) == "" {
+		amqPath = "amq"
+	}
+	resolvedAMQ, err := exec.LookPath(amqPath)
+	if err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("resolve amq executable: %w", err)}
+	}
+	if resolvedAMQ, err = filepath.EvalSymlinks(resolvedAMQ); err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("resolve amq executable identity: %w", err)}
+	}
+	req.AMQPath = resolvedAMQ
+	detect := b.Detect()
+	if !detect.Available {
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("ghostty %s is unavailable", ghosttyProfileVersionRange)}
+	}
+	nonce := req.Plan.Agents[0].LaunchNonce
+	ctx := context.Background()
+	if existing, err := b.generationWindow(ctx, nonce); err != nil {
+		return CreateResult{}, err
+	} else if existing != "" {
+		return CreateResult{}, fmt.Errorf("ghostty window for launch nonce %s already exists; journal recovery must classify it", nonce)
+	}
+	created, err := b.run(ctx, "new-window", req.ProjectRoot)
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("create ghostty window: %w", err)
+	}
+	windowID, tabID, firstTerminal, err := parseGhosttyCreatedWindow(created)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	terminalIDs := []string{firstTerminal}
+	for _, agent := range req.Plan.Agents[1:] {
+		splitRaw, splitErr := b.run(ctx, "split", terminalIDs[len(terminalIDs)-1], req.ProjectRoot)
+		if splitErr != nil {
+			return CreateResult{}, fmt.Errorf("create ghostty split for %s: %w", agent.Handle, splitErr)
+		}
+		terminalID, splitErr := parseGhosttyTerminalID(splitRaw)
+		if splitErr != nil {
+			return CreateResult{}, fmt.Errorf("ghostty split for %s: %w", agent.Handle, splitErr)
+		}
+		terminalIDs = append(terminalIDs, terminalID)
+	}
+	if err := b.waitHealthy(ctx, terminalIDs); err != nil {
+		return CreateResult{}, err
+	}
+	for i, agent := range req.Plan.Agents {
+		line := b.agentCommand(req, agent)
+		if _, err := b.run(ctx, "input-text", terminalIDs[i], line); err != nil {
+			return CreateResult{}, fmt.Errorf("send ghostty command for %s: %w", agent.Handle, err)
+		}
+		if _, err := b.run(ctx, "send-key-enter", terminalIDs[i]); err != nil {
+			return CreateResult{}, fmt.Errorf("submit ghostty command for %s: %w", agent.Handle, err)
+		}
+	}
+	resources := ghosttyBindingResources(windowID, tabID, nonce, req.Plan, terminalIDs)
+	if issues := ghosttyInventoryIssues(resources, req.Plan); len(issues) != 0 {
+		return CreateResult{}, fmt.Errorf("created ghostty inventory differs from plan: %s", strings.Join(issues, ","))
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherGhostty, HostIdentity: detect.HostIdentity,
+		InstanceIdentity: detect.InstanceIdentity, Profile: detect.Profile.Identity(),
+		LaunchNonce: nonce,
+		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: resources},
+	}
+	if err := binding.Validate(); err != nil {
+		return CreateResult{}, err
+	}
+	b.rememberGeneration(nonce, windowID)
+	return CreateResult{Outcome: OutcomeCreated, Profile: binding.Profile, Binding: binding}, nil
+}
+
+func (b *GhosttyBackend) Inspect(req InspectRequest) (InspectResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ghosttyCommandTimeout)
+	defer cancel()
+	state, err := b.inspect(ctx, req.Binding)
+	if err != nil {
+		return InspectResult{Status: InspectUnknown, Evidence: err.Error(), ActionRequired: true}, nil
+	}
+	return state, nil
+}
+
+func (b *GhosttyBackend) Close(req CloseRequest) (CloseResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ghosttyCommandTimeout)
+	defer cancel()
+	inspection, err := b.inspect(ctx, req.Binding)
+	if err != nil {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: err.Error()}, nil
+	}
+	if inspection.Status == InspectAbsent {
+		return CloseResult{Outcome: OutcomeClosed, Reason: "ghostty window already absent"}, nil
+	}
+	if inspection.Status != InspectPresent {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: inspection.Evidence}, nil
+	}
+	windowID, _, err := parseGhosttyWindowResource(req.Binding)
+	if err != nil {
+		return CloseResult{Outcome: OutcomeActionRequired, Reason: err.Error()}, nil
+	}
+	if _, err := b.run(ctx, "close-window", windowID); err != nil {
+		return CloseResult{}, fmt.Errorf("close ghostty window: %w", err)
+	}
+	b.forgetGeneration(req.Binding.LaunchNonce, windowID)
+	return CloseResult{Outcome: OutcomeClosed, Reason: "ghostty window closed"}, nil
+}
+
+func (b *GhosttyBackend) Focus(req FocusRequest) (FocusResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ghosttyCommandTimeout)
+	defer cancel()
+	inspection, err := b.inspect(ctx, req.Binding)
+	if err != nil || inspection.Status != InspectPresent {
+		if err != nil {
+			return FocusResult{}, err
+		}
+		return FocusResult{Outcome: OutcomeActionRequired, Reason: inspection.Evidence}, nil
+	}
+	terminalID := firstGhosttyTerminalID(req.Binding)
+	if terminalID == "" {
+		return FocusResult{Outcome: OutcomeActionRequired, Reason: "ghostty binding has no terminal identity"}, nil
+	}
+	if _, err := b.run(ctx, "focus-terminal", terminalID); err != nil {
+		return FocusResult{}, err
+	}
+	return FocusResult{Outcome: OutcomeAttached}, nil
+}
+
+func (b *GhosttyBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
+	parent := req.Context
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, ghosttyCommandTimeout)
+	defer cancel()
+	if req.Root == nil {
+		return ReclaimResult{}, fmt.Errorf("missing pinned session root")
+	}
+	rootIdentity, err := canonicalIdentity(req.Root.Base())
+	if err != nil || rootIdentity != req.Journal.RootIdentity {
+		return ReclaimResult{Status: ReclaimForeign, Evidence: "journal session root does not match the pinned root"}, nil
+	}
+	if req.Journal.RootPhysical != "" {
+		physical, physicalErr := fsq.StableTreeIdentityInfo(req.Root.FileInfo())
+		if physicalErr != nil || physical != req.Journal.RootPhysical {
+			return ReclaimResult{Status: ReclaimForeign, Evidence: "journal session root identity changed"}, nil
+		}
+	}
+	want, windowID, err := ghosttyJournalTerminals(req.Journal)
+	if err != nil {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
+	}
+	if len(want) == 0 {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: "journal has no ghostty terminal identities"}, nil
+	}
+	listed, err := b.listWindowIDs(ctx)
+	if err != nil {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
+	}
+	if windowID != "" && !containsString(listed, windowID) {
+		live, liveErr := b.countLiveTerminals(ctx, want)
+		if liveErr != nil {
+			return ReclaimResult{Status: ReclaimUnknown, Evidence: liveErr.Error()}, nil
+		}
+		if live == 0 {
+			return ReclaimResult{Status: ReclaimAbsent, Evidence: "journaled ghostty terminals are absent"}, nil
+		}
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: "ghostty window id is absent while terminals remain"}, nil
+	}
+	if windowID == "" {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: "journal has no ghostty window identity"}, nil
+	}
+	live, err := b.windowTerminals(ctx, windowID)
+	if err != nil {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
+	}
+	if !sameStringSet(live, want) {
+		if len(live) == 0 && !containsString(listed, windowID) {
+			return ReclaimResult{Status: ReclaimAbsent, Evidence: "journaled ghostty window is absent"}, nil
+		}
+		return ReclaimResult{
+			Status: ReclaimIncomplete, Evidence: "ghostty terminal inventory differs from journal",
+			Resources: ghosttyBindingResources(windowID, "", req.Journal.LaunchNonce, req.Journal.Plan, live),
+		}, nil
+	}
+	resources := ghosttyBindingResources(windowID, ghosttyJournalTab(req.Journal), req.Journal.LaunchNonce, req.Journal.Plan, live)
+	issues := ghosttyInventoryIssues(resources, req.Journal.Plan)
+	if len(issues) != 0 {
+		return ReclaimResult{
+			Status: ReclaimIncomplete, Evidence: "ghostty window inventory differs from plan: " + strings.Join(issues, ","),
+			Resources: resources,
+		}, nil
+	}
+	detect := b.Detect()
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherGhostty, HostIdentity: req.Journal.HostIdentity,
+		InstanceIdentity: req.Journal.InstanceIdentity, Profile: req.Journal.Profile,
+		LaunchNonce: req.Journal.LaunchNonce,
+		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: resources},
+	}
+	if !detect.Available || detect.HostIdentity != binding.HostIdentity ||
+		detect.InstanceIdentity != binding.InstanceIdentity || GhosttyProfile().Identity() != binding.Profile {
+		return ReclaimResult{Status: ReclaimForeign, Evidence: "ghostty runtime identity changed", Resources: resources}, nil
+	}
+	return ReclaimResult{Status: ReclaimAdoptable, Evidence: "ghostty window and terminal UUIDs match the complete journal plan", Resources: resources, Binding: binding}, nil
+}
+
+func (b *GhosttyBackend) validateCreate(req CreateRequest) error {
+	if strings.TrimSpace(req.ProjectRoot) == "" || strings.TrimSpace(req.Session) == "" || req.Root == nil {
+		return fmt.Errorf("project root, session, and pinned root are required")
+	}
+	if err := req.Plan.Validate(); err != nil {
+		return err
+	}
+	if _, err := canonicalIdentity(req.ProjectRoot); err != nil {
+		return fmt.Errorf("resolve project root: %w", err)
+	}
+	handles := make([]string, len(req.Plan.Agents))
+	nonce := req.Plan.Agents[0].LaunchNonce
+	if !validUUID(nonce) {
+		return fmt.Errorf("launch nonce must be a UUID")
+	}
+	for i, agent := range req.Plan.Agents {
+		handles[i] = agent.Handle
+		if agent.LaunchNonce != nonce {
+			return fmt.Errorf("agent %q has a different launch nonce", agent.Handle)
+		}
+	}
+	if err := fsq.ValidateExistingMailboxLayout(req.Root, handles...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *GhosttyBackend) inspect(ctx context.Context, binding BindingRecord) (InspectResult, error) {
+	if err := binding.Validate(); err != nil {
+		return InspectResult{}, err
+	}
+	if err := b.validateBindingContext(binding); err != nil {
+		return InspectResult{}, err
+	}
+	windowID, nonce, err := parseGhosttyWindowResource(binding)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	if nonce != binding.LaunchNonce {
+		return InspectResult{Status: InspectUnknown, Evidence: "ghostty window nonce differs from binding", ActionRequired: true}, nil
+	}
+	want := ghosttyBoundTerminals(binding)
+	if len(want) == 0 {
+		return InspectResult{}, fmt.Errorf("ghostty binding has no terminal identities")
+	}
+	listed, err := b.listWindowIDs(ctx)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	if !containsString(listed, windowID) {
+		return InspectResult{Status: InspectAbsent, Evidence: "ghostty window is absent"}, nil
+	}
+	live, err := b.windowTerminals(ctx, windowID)
+	if err != nil {
+		return InspectResult{}, err
+	}
+	if !sameStringSet(live, want) {
+		return InspectResult{Status: InspectUnknown, Evidence: "ghostty window exists but terminal inventory differs from binding", ActionRequired: true}, nil
+	}
+	return InspectResult{Status: InspectPresent, Evidence: "ghostty window and terminal inventory match"}, nil
+}
+
+func (b *GhosttyBackend) validateBindingContext(binding BindingRecord) error {
+	host, err := b.hostname()
+	if err != nil {
+		return fmt.Errorf("resolve ghostty host identity: %w", err)
+	}
+	if binding.Backend != LauncherGhostty || binding.Profile != GhosttyProfile().Identity() ||
+		binding.HostIdentity != host {
+		return fmt.Errorf("ghostty binding belongs to a different backend context")
+	}
+	detect := b.Detect()
+	if detect.InstanceIdentity == "" {
+		return fmt.Errorf("ghostty AppleScript is unreachable")
+	}
+	if binding.InstanceIdentity != detect.InstanceIdentity {
+		return fmt.Errorf("ghostty binding belongs to a different backend context")
+	}
+	return nil
+}
+
+func (b *GhosttyBackend) waitHealthy(parent context.Context, terminalIDs []string) error {
+	timeout := b.healthTimeout
+	if timeout <= 0 {
+		timeout = ghosttyHealthTimeout
+	}
+	poll := b.healthPoll
+	if poll <= 0 {
+		poll = ghosttyHealthPoll
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		ready := true
+		var lastErr error
+		for _, id := range terminalIDs {
+			ctx, cancel := context.WithTimeout(parent, ghosttyCommandTimeout)
+			raw, err := b.run(ctx, "terminal-count", id)
+			cancel()
+			if err != nil {
+				lastErr = err
+				ready = false
+				break
+			}
+			count, err := strconv.Atoi(strings.TrimSpace(raw))
+			if err != nil || count != 1 {
+				ready = false
+				if err != nil {
+					lastErr = err
+				}
+				break
+			}
+		}
+		if ready {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("ghostty surface readiness timed out: %w", lastErr)
+			}
+			return fmt.Errorf("ghostty surface readiness timed out before sending commands")
+		}
+		if err := b.doSleep(parent, poll); err != nil {
+			return err
+		}
+	}
+}
+
+func (b *GhosttyBackend) listWindowIDs(ctx context.Context) ([]string, error) {
+	raw, err := b.run(ctx, "list-windows")
+	if err != nil {
+		return nil, fmt.Errorf("list ghostty windows: %w", err)
+	}
+	return splitGhosttyIDs(raw), nil
+}
+
+func (b *GhosttyBackend) windowTerminals(ctx context.Context, windowID string) ([]string, error) {
+	raw, err := b.run(ctx, "window-terminals", windowID)
+	if err != nil {
+		return nil, fmt.Errorf("list ghostty window terminals: %w", err)
+	}
+	ids := splitGhosttyIDs(raw)
+	for i, id := range ids {
+		normalized, err := normalizeGhosttyUUID(id)
+		if err != nil {
+			return nil, fmt.Errorf("ghostty window terminal: %w", err)
+		}
+		ids[i] = normalized
+	}
+	return ids, nil
+}
+
+func (b *GhosttyBackend) countLiveTerminals(ctx context.Context, ids []string) (int, error) {
+	live := 0
+	for _, id := range ids {
+		raw, err := b.run(ctx, "terminal-count", id)
+		if err != nil {
+			return 0, err
+		}
+		count, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err != nil {
+			return 0, err
+		}
+		if count > 0 {
+			live++
+		}
+	}
+	return live, nil
+}
+
+func (b *GhosttyBackend) agentCommand(req CreateRequest, agent AgentPlan) string {
+	amq := req.AMQPath
+	if strings.TrimSpace(amq) == "" {
+		amq = "amq"
+	}
+	env := cloneEnv(agent.EnvOverlay)
+	if env == nil {
+		env = make(map[string]string, 1)
+	}
+	env[InternalLaunchNonceEnv] = agent.LaunchNonce
+	return commandLine(agent.Cwd, env, coopExecArgv(amq, req.Root.Base(), agent.Handle, agent.Argv, agent.Execution))
+}
+
+func (b *GhosttyBackend) runAppleScript(ctx context.Context, args ...string) (string, error) {
+	if runtime.GOOS != "darwin" {
+		return "", fmt.Errorf("ghostty backend requires macOS")
+	}
+	if len(args) == 0 {
+		return "", fmt.Errorf("ghostty op is required")
+	}
+	script, err := ghosttyScript(args[0])
+	if err != nil {
+		return "", err
+	}
+	cmdArgs := append([]string{"-e", script}, args[1:]...)
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, ghosttyCommandTimeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, "osascript", cmdArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("osascript %s: %w: %s", args[0], err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (b *GhosttyBackend) doSleep(ctx context.Context, delay time.Duration) error {
+	if b.sleep != nil {
+		return b.sleep(ctx, delay)
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func ghosttyScript(op string) (string, error) {
+	switch op {
+	case "version":
+		return `tell application "Ghostty" to get version`, nil
+	case "new-window":
+		return `
+on run argv
+	set cwd to item 1 of argv
+	tell application "Ghostty"
+		set cfg to new surface configuration
+		set initial working directory of cfg to cwd
+		set win to new window with configuration cfg
+		set term to terminal 1 of selected tab of win
+		return (id of win) & "|" & (id of selected tab of win) & "|" & (id of term)
+	end tell
+end run
+`, nil
+	case "split":
+		return `
+on run argv
+	set targetID to item 1 of argv
+	set cwd to item 2 of argv
+	tell application "Ghostty"
+		set cfg to new surface configuration
+		set initial working directory of cfg to cwd
+		set matches to terminals whose id is targetID
+		if (count of matches) is not 1 then error "ghostty terminal not unique"
+		set newTerm to split (item 1 of matches) direction right with configuration cfg
+		return id of newTerm
+	end tell
+end run
+`, nil
+	case "list-windows":
+		return `
+tell application "Ghostty"
+	set ids to {}
+	repeat with w in windows
+		set end of ids to id of w
+	end repeat
+	set AppleScript's text item delimiters to ","
+	return ids as text
+end tell
+`, nil
+	case "window-terminals":
+		return `
+on run argv
+	set winID to item 1 of argv
+	tell application "Ghostty"
+		set wins to windows whose id is winID
+		if (count of wins) is 0 then return ""
+		set ids to {}
+		repeat with t in terminals of (item 1 of wins)
+			set end of ids to id of t
+		end repeat
+		set AppleScript's text item delimiters to ","
+		return ids as text
+	end tell
+end run
+`, nil
+	case "terminal-count":
+		return `
+on run argv
+	tell application "Ghostty"
+		return count of (terminals whose id is (item 1 of argv))
+	end tell
+end run
+`, nil
+	case "input-text":
+		return `
+on run argv
+	set targetID to item 1 of argv
+	set payload to item 2 of argv
+	tell application "Ghostty"
+		set matches to terminals whose id is targetID
+		if (count of matches) is not 1 then error "ghostty terminal not unique"
+		input text payload to (item 1 of matches)
+	end tell
+end run
+`, nil
+	case "send-key-enter":
+		return `
+on run argv
+	tell application "Ghostty"
+		set matches to terminals whose id is (item 1 of argv)
+		if (count of matches) is not 1 then error "ghostty terminal not unique"
+		send key "enter" to (item 1 of matches)
+	end tell
+end run
+`, nil
+	case "focus-terminal":
+		return `
+on run argv
+	tell application "Ghostty"
+		set matches to terminals whose id is (item 1 of argv)
+		if (count of matches) is not 1 then error "ghostty terminal not unique"
+		focus (item 1 of matches)
+	end tell
+end run
+`, nil
+	case "close-window":
+		return `
+on run argv
+	set winID to item 1 of argv
+	tell application "Ghostty"
+		set wins to windows whose id is winID
+		if (count of wins) is 0 then error "ghostty window is absent"
+		close window (item 1 of wins)
+	end tell
+end run
+`, nil
+	default:
+		return "", fmt.Errorf("unknown ghostty op %q", op)
+	}
+}
+
+func parseGhosttyCreatedWindow(raw string) (string, string, string, error) {
+	parts := strings.Split(strings.TrimSpace(raw), "|")
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("ghostty new-window returned invalid identities %q", strings.TrimSpace(raw))
+	}
+	windowID, err := parseGhosttyOpaqueID(parts[0])
+	if err != nil {
+		return "", "", "", fmt.Errorf("ghostty window id: %w", err)
+	}
+	tabID, err := parseGhosttyOpaqueID(parts[1])
+	if err != nil {
+		return "", "", "", fmt.Errorf("ghostty tab id: %w", err)
+	}
+	terminalID, err := parseGhosttyTerminalID(parts[2])
+	if err != nil {
+		return "", "", "", err
+	}
+	return windowID, tabID, terminalID, nil
+}
+
+func parseGhosttyTerminalID(raw string) (string, error) {
+	return normalizeGhosttyUUID(strings.TrimSpace(raw))
+}
+
+func parseGhosttyOpaqueID(raw string) (string, error) {
+	id := strings.TrimSpace(raw)
+	if id == "" || strings.Contains(id, "/") || strings.Contains(id, "..") {
+		return "", fmt.Errorf("invalid ghostty identity %q", raw)
+	}
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return "", fmt.Errorf("invalid ghostty identity %q", raw)
+	}
+	return id, nil
+}
+
+func normalizeGhosttyUUID(raw string) (string, error) {
+	id := strings.ToUpper(strings.TrimSpace(raw))
+	if !validUUID(id) {
+		return "", fmt.Errorf("not a UUID: %q", raw)
+	}
+	return id, nil
+}
+
+func ghosttyBindingResources(windowID, tabID, nonce string, plan Plan, terminalIDs []string) []ResourceIdentity {
+	resources := []ResourceIdentity{{OpaqueID: ghosttyWindowPrefix + windowID + ":" + nonce}}
+	if tabID != "" {
+		resources = append(resources, ResourceIdentity{OpaqueID: ghosttyTabPrefix + tabID})
+	}
+	for i, agent := range plan.Agents {
+		if i < len(terminalIDs) {
+			resources = append(resources, ResourceIdentity{OpaqueID: ghosttyTerminalPrefix + terminalIDs[i], Agent: agent.Handle})
+		}
+	}
+	return resources
+}
+
+func parseGhosttyWindowResource(binding BindingRecord) (string, string, error) {
+	for _, resource := range binding.Resources.Resources {
+		rest, ok := strings.CutPrefix(resource.OpaqueID, ghosttyWindowPrefix)
+		if !ok || resource.Agent != "" {
+			continue
+		}
+		windowID, nonce, found := strings.Cut(rest, ":")
+		if !found {
+			return "", "", fmt.Errorf("binding has no valid ghostty window identity")
+		}
+		id, err := parseGhosttyOpaqueID(windowID)
+		if err != nil || !validUUID(nonce) {
+			return "", "", fmt.Errorf("binding has no valid ghostty window identity")
+		}
+		return id, nonce, nil
+	}
+	return "", "", fmt.Errorf("binding has no valid ghostty window identity")
+}
+
+func ghosttyBoundTerminals(binding BindingRecord) []string {
+	var ids []string
+	for _, resource := range binding.Resources.Resources {
+		if resource.Agent == "" {
+			continue
+		}
+		id, err := parseGhosttyTerminalResource(resource.OpaqueID)
+		if err == nil {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func parseGhosttyTerminalResource(opaqueID string) (string, error) {
+	id, ok := strings.CutPrefix(opaqueID, ghosttyTerminalPrefix)
+	if !ok {
+		return "", fmt.Errorf("invalid ghostty terminal identity %q", opaqueID)
+	}
+	return normalizeGhosttyUUID(id)
+}
+
+func firstGhosttyTerminalID(binding BindingRecord) string {
+	ids := ghosttyBoundTerminals(binding)
+	if len(ids) == 0 {
+		return ""
+	}
+	return ids[0]
+}
+
+func ghosttyJournalTerminals(journal LaunchJournal) ([]string, string, error) {
+	if journal.Binding == nil {
+		return nil, "", nil
+	}
+	windowID, _, err := parseGhosttyWindowResource(*journal.Binding)
+	if err != nil {
+		windowID = ""
+	}
+	return ghosttyBoundTerminals(*journal.Binding), windowID, nil
+}
+
+func ghosttyJournalTab(journal LaunchJournal) string {
+	if journal.Binding == nil {
+		return ""
+	}
+	for _, resource := range journal.Binding.Resources.Resources {
+		id, ok := strings.CutPrefix(resource.OpaqueID, ghosttyTabPrefix)
+		if ok && resource.Agent == "" {
+			if parsed, err := parseGhosttyOpaqueID(id); err == nil {
+				return parsed
+			}
+		}
+	}
+	return ""
+}
+
+func ghosttyInventoryIssues(resources []ResourceIdentity, plan Plan) []string {
+	expected := make(map[string]bool, len(plan.Agents))
+	for _, agent := range plan.Agents {
+		expected[agent.Handle] = true
+	}
+	live := make(map[string]int, len(resources))
+	issues := make([]string, 0)
+	for _, resource := range resources {
+		if resource.Agent != "" {
+			live[resource.Agent]++
+			if !expected[resource.Agent] {
+				issues = append(issues, "unexpected:"+resource.Agent)
+			}
+		}
+	}
+	for _, agent := range plan.Agents {
+		if live[agent.Handle] != 1 {
+			issues = append(issues, "missing:"+agent.Handle)
+		}
+	}
+	return issues
+}
+
+var ghosttyVersionPattern = regexp.MustCompile(`(\d+)\.(\d+)(?:\.(\d+))?`)
+
+func supportedGhosttyVersion(raw string) bool {
+	match := ghosttyVersionPattern.FindStringSubmatch(raw)
+	if match == nil {
+		return false
+	}
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	patch := 0
+	if match[3] != "" {
+		patch, _ = strconv.Atoi(match[3])
+	}
+	if major != 1 || minor < 3 {
+		return false
+	}
+	if minor == 3 && patch < 0 {
+		return false
+	}
+	return true
+}
+
+func splitGhosttyIDs(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	ids := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if id := strings.TrimSpace(part); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func containsString(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func sameStringSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	counts := make(map[string]int, len(left))
+	for _, id := range left {
+		counts[id]++
+	}
+	for _, id := range right {
+		counts[id]--
+		if counts[id] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *GhosttyBackend) rememberGeneration(nonce, windowID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.generations == nil {
+		b.generations = make(map[string]string)
+	}
+	b.generations[nonce] = windowID
+}
+
+func (b *GhosttyBackend) forgetGeneration(nonce, windowID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.generations[nonce] == windowID {
+		delete(b.generations, nonce)
+	}
+}
+
+func (b *GhosttyBackend) generationWindow(ctx context.Context, nonce string) (string, error) {
+	b.mu.Lock()
+	windowID := b.generations[nonce]
+	b.mu.Unlock()
+	if windowID == "" {
+		return "", nil
+	}
+	listed, err := b.listWindowIDs(ctx)
+	if err != nil {
+		return "", err
+	}
+	if containsString(listed, windowID) {
+		return windowID, nil
+	}
+	b.forgetGeneration(nonce, windowID)
+	return "", nil
+}

--- a/internal/launch/ghostty.go
+++ b/internal/launch/ghostty.go
@@ -20,6 +20,7 @@ const (
 	ghosttyProfileVersion      = 1
 	ghosttyProfileVersionRange = ">=1.3.0 <2.0"
 	ghosttyCommandTimeout      = 5 * time.Second
+	ghosttyCreateTimeout       = 30 * time.Second
 	ghosttyHealthTimeout       = 15 * time.Second
 	ghosttyHealthPoll          = 100 * time.Millisecond
 	ghosttyBundleID            = "com.mitchellh.ghostty"
@@ -36,6 +37,7 @@ type GhosttyBackend struct {
 	hostname      func() (string, error)
 	getenv        func(string) string
 	sleep         func(context.Context, time.Duration) error
+	createTimeout time.Duration
 	healthTimeout time.Duration
 	healthPoll    time.Duration
 	mu            sync.Mutex
@@ -108,42 +110,65 @@ func (b *GhosttyBackend) Create(req CreateRequest) (CreateResult, error) {
 		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("ghostty %s is unavailable", ghosttyProfileVersionRange)}
 	}
 	nonce := req.Plan.Agents[0].LaunchNonce
-	ctx := context.Background()
-	if existing, err := b.generationWindow(ctx, nonce); err != nil {
+	inspectCtx, inspectCancel := b.inspectCallContext()
+	if existing, err := b.generationWindow(inspectCtx, nonce); err != nil {
+		inspectCancel()
 		return CreateResult{}, err
 	} else if existing != "" {
+		inspectCancel()
 		return CreateResult{}, fmt.Errorf("ghostty window for launch nonce %s already exists; journal recovery must classify it", nonce)
 	}
-	created, err := b.run(ctx, "new-window", req.ProjectRoot)
+	before, err := b.listWindowIDs(inspectCtx)
+	inspectCancel()
 	if err != nil {
-		return CreateResult{}, fmt.Errorf("create ghostty window: %w", err)
+		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("snapshot ghostty windows before create: %w", err)}
+	}
+	createCtx, createCancel := b.createCallContext()
+	created, err := b.run(createCtx, "new-window", req.ProjectRoot)
+	createCancel()
+	if err != nil {
+		return CreateResult{}, b.reconcileCreateFailure(before, "", false, fmt.Errorf("create ghostty window: %w", err))
 	}
 	windowID, tabID, firstTerminal, err := parseGhosttyCreatedWindow(created)
 	if err != nil {
-		return CreateResult{}, err
+		return CreateResult{}, b.reconcileCreateFailure(before, "", false, err)
 	}
 	terminalIDs := []string{firstTerminal}
 	for _, agent := range req.Plan.Agents[1:] {
-		splitRaw, splitErr := b.run(ctx, "split", terminalIDs[len(terminalIDs)-1], req.ProjectRoot)
+		splitSnapCtx, splitSnapCancel := b.inspectCallContext()
+		splitBefore, snapErr := b.listWindowIDs(splitSnapCtx)
+		splitSnapCancel()
+		if snapErr != nil {
+			return CreateResult{}, b.reconcileCreateFailure(before, windowID, false, fmt.Errorf("snapshot ghostty windows before split: %w", snapErr))
+		}
+		splitCtx, splitCancel := b.createCallContext()
+		splitRaw, splitErr := b.run(splitCtx, "split", terminalIDs[len(terminalIDs)-1], req.ProjectRoot)
+		splitCancel()
 		if splitErr != nil {
-			return CreateResult{}, fmt.Errorf("create ghostty split for %s: %w", agent.Handle, splitErr)
+			return CreateResult{}, b.reconcileCreateFailure(splitBefore, windowID, false, fmt.Errorf("create ghostty split for %s: %w", agent.Handle, splitErr))
 		}
 		terminalID, splitErr := parseGhosttyTerminalID(splitRaw)
 		if splitErr != nil {
-			return CreateResult{}, fmt.Errorf("ghostty split for %s: %w", agent.Handle, splitErr)
+			return CreateResult{}, b.reconcileCreateFailure(splitBefore, windowID, false, fmt.Errorf("ghostty split for %s: %w", agent.Handle, splitErr))
 		}
 		terminalIDs = append(terminalIDs, terminalID)
 	}
-	if err := b.waitHealthy(ctx, terminalIDs); err != nil {
-		return CreateResult{}, err
+	if err := b.waitHealthy(context.Background(), terminalIDs); err != nil {
+		return CreateResult{}, b.reconcileCreateFailure(before, windowID, false, err)
 	}
 	for i, agent := range req.Plan.Agents {
 		line := b.agentCommand(req, agent)
-		if _, err := b.run(ctx, "input-text", terminalIDs[i], line); err != nil {
-			return CreateResult{}, fmt.Errorf("send ghostty command for %s: %w", agent.Handle, err)
+		inputCtx, inputCancel := b.inspectCallContext()
+		_, err := b.run(inputCtx, "input-text", terminalIDs[i], line)
+		inputCancel()
+		if err != nil {
+			return CreateResult{}, b.reconcileCreateFailure(before, windowID, true, fmt.Errorf("send ghostty command for %s: %w", agent.Handle, err))
 		}
-		if _, err := b.run(ctx, "send-key-enter", terminalIDs[i]); err != nil {
-			return CreateResult{}, fmt.Errorf("submit ghostty command for %s: %w", agent.Handle, err)
+		enterCtx, enterCancel := b.inspectCallContext()
+		_, err = b.run(enterCtx, "send-key-enter", terminalIDs[i])
+		enterCancel()
+		if err != nil {
+			return CreateResult{}, b.reconcileCreateFailure(before, windowID, true, fmt.Errorf("submit ghostty command for %s: %w", agent.Handle, err))
 		}
 	}
 	resources := ghosttyBindingResources(windowID, tabID, nonce, req.Plan, terminalIDs)
@@ -161,6 +186,72 @@ func (b *GhosttyBackend) Create(req CreateRequest) (CreateResult, error) {
 	}
 	b.rememberGeneration(nonce, windowID)
 	return CreateResult{Outcome: OutcomeCreated, Profile: binding.Profile, Binding: binding}, nil
+}
+
+func (b *GhosttyBackend) createOpTimeout() time.Duration {
+	if b.createTimeout > 0 {
+		return b.createTimeout
+	}
+	return ghosttyCreateTimeout
+}
+
+func (b *GhosttyBackend) createCallContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), b.createOpTimeout())
+}
+
+func (b *GhosttyBackend) inspectCallContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), ghosttyCommandTimeout)
+}
+
+func (b *GhosttyBackend) reconcileCreateFailure(before []string, knownWindowID string, inputSent bool, cause error) error {
+	if inputSent {
+		return cause
+	}
+	ctx, cancel := b.inspectCallContext()
+	defer cancel()
+	listed, err := b.listWindowIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("%w (orphan window reconciliation failed: %v)", cause, err)
+	}
+	newIDs := ghosttyIDsNotIn(listed, before)
+	if knownWindowID != "" {
+		extras := make([]string, 0, len(newIDs))
+		for _, id := range newIDs {
+			if id != knownWindowID {
+				extras = append(extras, id)
+			}
+		}
+		if containsString(listed, knownWindowID) {
+			if _, closeErr := b.run(ctx, "close-window", knownWindowID); closeErr != nil {
+				return fmt.Errorf("%w (close orphan %s: %v)", cause, knownWindowID, closeErr)
+			}
+		}
+		if len(extras) > 0 {
+			return fmt.Errorf("%w (closed orphan %s; ambiguous extra windows %s, unknown, never guessed)", cause, knownWindowID, strings.Join(extras, ","))
+		}
+		return fmt.Errorf("%w (closed orphan ghostty window %s)", cause, knownWindowID)
+	}
+	switch len(newIDs) {
+	case 0:
+		return fmt.Errorf("%w (no new ghostty window appeared)", cause)
+	case 1:
+		if _, closeErr := b.run(ctx, "close-window", newIDs[0]); closeErr != nil {
+			return fmt.Errorf("%w (close orphan %s: %v)", cause, newIDs[0], closeErr)
+		}
+		return fmt.Errorf("%w (closed orphan ghostty window %s)", cause, newIDs[0])
+	default:
+		return fmt.Errorf("%w (ambiguous new ghostty windows %s; unknown, never guessed)", cause, strings.Join(newIDs, ","))
+	}
+}
+
+func ghosttyIDsNotIn(listed, before []string) []string {
+	out := make([]string, 0)
+	for _, id := range listed {
+		if !containsString(before, id) {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 func (b *GhosttyBackend) Inspect(req InspectRequest) (InspectResult, error) {

--- a/internal/launch/ghostty_live_test.go
+++ b/internal/launch/ghostty_live_test.go
@@ -77,29 +77,40 @@ func TestGhosttyLive(t *testing.T) {
 	if created.Outcome != OutcomeCreated || countGhosttyAgentResources(created.Binding) != 2 {
 		t.Fatalf("Create = %#v", created)
 	}
+	createdWindow, _, err := parseGhosttyWindowResource(created.Binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tabID := ""
+	for _, resource := range created.Binding.Resources.Resources {
+		if id, ok := strings.CutPrefix(resource.OpaqueID, ghosttyTabPrefix); ok && resource.Agent == "" {
+			tabID = id
+			break
+		}
+	}
+	t.Logf("Create %s window=%s tab=%s terminals=%s", created.Outcome, createdWindow, tabID, strings.Join(ghosttyBoundTerminals(created.Binding), ","))
 	req.AMQPath = resolvedAMQ
 	for i, agent := range plan.Agents {
 		want := backend.agentCommand(req, agent)
 		if i >= len(sent) || sent[i] != want {
 			t.Fatalf("sent[%d] = %q, want exact commandLine %q (all=%q)", i, sent, want, sent)
 		}
+		t.Logf("sent %s commandLine %q", agent.Handle, sent[i])
 	}
 	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
 	if err != nil || inspection.Status != InspectPresent {
 		t.Fatalf("Inspect present = %#v, %v", inspection, err)
 	}
+	t.Logf("Inspect present status=%s evidence=%q", inspection.Status, inspection.Evidence)
 	focused, err := backend.Focus(FocusRequest{Binding: created.Binding, Root: root})
 	if err != nil || focused.Outcome != OutcomeAttached {
 		t.Fatalf("Focus = %#v, %v", focused, err)
 	}
+	t.Logf("Focus outcome=%s reason=%q", focused.Outcome, focused.Reason)
 
 	liveWindows, err := backend.listWindowIDs(context.Background())
 	if err != nil || len(liveWindows) == 0 {
 		t.Fatalf("list windows = %v, %v", liveWindows, err)
-	}
-	createdWindow, _, err := parseGhosttyWindowResource(created.Binding)
-	if err != nil {
-		t.Fatal(err)
 	}
 	foreignWindow := ""
 	for _, id := range liveWindows {
@@ -125,15 +136,18 @@ func TestGhosttyLive(t *testing.T) {
 	if refused.Outcome == OutcomeClosed && refused.Reason != "ghostty window already absent" {
 		t.Fatalf("Close mutated an unrelated window: %#v", refused)
 	}
+	t.Logf("Close refuse wrong-window outcome=%s reason=%q", refused.Outcome, refused.Reason)
 
 	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
 	if err != nil || closed.Outcome != OutcomeClosed {
 		t.Fatalf("Close = %#v, %v", closed, err)
 	}
+	t.Logf("Close outcome=%s reason=%q", closed.Outcome, closed.Reason)
 	absent, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
 	if err != nil || absent.Status != InspectAbsent {
 		t.Fatalf("Inspect absent = %#v, %v", absent, err)
 	}
+	t.Logf("Inspect absent status=%s evidence=%q", absent.Status, absent.Evidence)
 	after, err := ghosttyLiveTerminalCount()
 	if err != nil {
 		t.Fatal(err)
@@ -141,6 +155,7 @@ func TestGhosttyLive(t *testing.T) {
 	if after != before {
 		t.Fatalf("live terminal count changed: before=%d after=%d", before, after)
 	}
+	t.Logf("terminal count before=%d after=%d", before, after)
 	if created.Binding.InstanceIdentity != ghosttyInstancePrefix+ghosttyBundleID {
 		t.Fatalf("instance identity = %q", created.Binding.InstanceIdentity)
 	}

--- a/internal/launch/ghostty_live_test.go
+++ b/internal/launch/ghostty_live_test.go
@@ -1,0 +1,130 @@
+package launch
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestGhosttyLive(t *testing.T) {
+	if os.Getenv("AMQ_GHOSTTY_LIVE") != "1" {
+		t.Skip("AMQ_GHOSTTY_LIVE=1 required; run from a shell inside Ghostty")
+	}
+	backend := NewGhosttyBackend()
+	detect := backend.Detect()
+	if !detect.Available {
+		t.Fatal("ghostty AppleScript ping failed; grant Automation permission and run inside Ghostty")
+	}
+	before, err := ghosttyLiveTerminalCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sent []string
+	inner := backend.run
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if len(args) >= 3 && args[0] == "input-text" {
+			sent = append(sent, args[2])
+		}
+		return inner(ctx, args...)
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := writeGhosttySleepAMQ(t)
+	resolvedAMQ, err := filepath.EvalSymlinks(fakeAMQ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70efa5"
+	plan := ghosttyTestPlan(project, nonce)
+	req := CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root}
+	created, err := backend.Create(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	})
+	if created.Outcome != OutcomeCreated || countGhosttyAgentResources(created.Binding) != 2 {
+		t.Fatalf("Create = %#v", created)
+	}
+	req.AMQPath = resolvedAMQ
+	for i, agent := range plan.Agents {
+		want := backend.agentCommand(req, agent)
+		if i >= len(sent) || sent[i] != want {
+			t.Fatalf("sent[%d] = %q, want exact commandLine %q (all=%q)", i, sent, want, sent)
+		}
+	}
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectPresent {
+		t.Fatalf("Inspect present = %#v, %v", inspection, err)
+	}
+	focused, err := backend.Focus(FocusRequest{Binding: created.Binding, Root: root})
+	if err != nil || focused.Outcome != OutcomeAttached {
+		t.Fatalf("Focus = %#v, %v", focused, err)
+	}
+
+	liveWindows, err := backend.listWindowIDs(context.Background())
+	if err != nil || len(liveWindows) == 0 {
+		t.Fatalf("list windows = %v, %v", liveWindows, err)
+	}
+	createdWindow, _, err := parseGhosttyWindowResource(created.Binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreignWindow := ""
+	for _, id := range liveWindows {
+		if id != createdWindow {
+			foreignWindow = id
+			break
+		}
+	}
+	if foreignWindow == "" {
+		t.Fatal("need a pre-existing Ghostty window to prove Close refuses the wrong id")
+	}
+	forged := created.Binding
+	forged.Resources.Resources = append([]ResourceIdentity(nil), created.Binding.Resources.Resources...)
+	for i, resource := range forged.Resources.Resources {
+		if strings.HasPrefix(resource.OpaqueID, ghosttyWindowPrefix) {
+			forged.Resources.Resources[i].OpaqueID = ghosttyWindowPrefix + foreignWindow + ":" + nonce
+		}
+	}
+	refused, err := backend.Close(CloseRequest{Binding: forged, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refused.Outcome == OutcomeClosed && refused.Reason != "ghostty window already absent" {
+		t.Fatalf("Close mutated an unrelated window: %#v", refused)
+	}
+
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("Close = %#v, %v", closed, err)
+	}
+	absent, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || absent.Status != InspectAbsent {
+		t.Fatalf("Inspect absent = %#v, %v", absent, err)
+	}
+	after, err := ghosttyLiveTerminalCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("live terminal count changed: before=%d after=%d", before, after)
+	}
+	if created.Binding.InstanceIdentity != ghosttyInstancePrefix+ghosttyBundleID {
+		t.Fatalf("instance identity = %q", created.Binding.InstanceIdentity)
+	}
+}
+
+func ghosttyLiveTerminalCount() (int, error) {
+	cmd := exec.Command("osascript", "-e", `tell application "Ghostty" to count terminals`)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(out)))
+}

--- a/internal/launch/ghostty_live_test.go
+++ b/internal/launch/ghostty_live_test.go
@@ -19,10 +19,6 @@ func TestGhosttyLive(t *testing.T) {
 	if !detect.Available {
 		t.Fatal("ghostty AppleScript ping failed; grant Automation permission and run inside Ghostty")
 	}
-	before, err := ghosttyLiveTerminalCount()
-	if err != nil {
-		t.Fatal(err)
-	}
 	var sent []string
 	inner := backend.run
 	backend.run = func(ctx context.Context, args ...string) (string, error) {
@@ -31,6 +27,39 @@ func TestGhosttyLive(t *testing.T) {
 		}
 		return inner(ctx, args...)
 	}
+	beforeWindows, err := backend.listWindowIDs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := ghosttyLiveTerminalCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), ghosttyCreateTimeout)
+		defer cancel()
+		listed, listErr := backend.listWindowIDs(ctx)
+		if listErr != nil {
+			t.Errorf("cleanup list windows: %v", listErr)
+			return
+		}
+		for _, id := range listed {
+			if containsString(beforeWindows, id) {
+				continue
+			}
+			if _, closeErr := backend.run(ctx, "close-window", id); closeErr != nil {
+				t.Errorf("cleanup close %s: %v", id, closeErr)
+			}
+		}
+		after, countErr := ghosttyLiveTerminalCount()
+		if countErr != nil {
+			t.Errorf("cleanup terminal count: %v", countErr)
+			return
+		}
+		if after != before {
+			t.Errorf("live terminal count not restored: before=%d after=%d", before, after)
+		}
+	})
 	project := t.TempDir()
 	root := tmuxTestRoot(t, "claude", "codex")
 	fakeAMQ := writeGhosttySleepAMQ(t)
@@ -45,9 +74,6 @@ func TestGhosttyLive(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		_, _ = backend.Close(CloseRequest{Binding: created.Binding, Root: root})
-	})
 	if created.Outcome != OutcomeCreated || countGhosttyAgentResources(created.Binding) != 2 {
 		t.Fatalf("Create = %#v", created)
 	}

--- a/internal/launch/ghostty_test.go
+++ b/internal/launch/ghostty_test.go
@@ -1,0 +1,526 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+type fakeGhostty struct {
+	mu        sync.Mutex
+	log       [][]string
+	version   string
+	windows   []fakeGhosttyWindow
+	seq       int
+	fail      string
+	unhealthy bool
+	reuseNext string
+}
+
+type fakeGhosttyWindow struct {
+	id        string
+	tabID     string
+	terminals []string
+}
+
+func (f *fakeGhostty) run(_ context.Context, args ...string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(args) == 0 {
+		return "", errors.New("missing ghostty op")
+	}
+	f.log = append(f.log, append([]string(nil), args...))
+	op := args[0]
+	if f.fail == op || f.fail == "*" {
+		return "", errors.New("injected failure")
+	}
+	switch op {
+	case "version":
+		return f.version, nil
+	case "new-window":
+		f.seq++
+		windowID := f.reuseNext
+		if windowID == "" {
+			windowID = fmt.Sprintf("tab-group-%d", f.seq)
+		}
+		f.reuseNext = ""
+		tabID := fmt.Sprintf("tab-%d", f.seq)
+		term := f.nextUUID()
+		f.windows = append(f.windows, fakeGhosttyWindow{id: windowID, tabID: tabID, terminals: []string{term}})
+		return windowID + "|" + tabID + "|" + term, nil
+	case "split":
+		parent := args[1]
+		for i := range f.windows {
+			for _, id := range f.windows[i].terminals {
+				if id == strings.ToUpper(parent) || id == parent {
+					term := f.nextUUID()
+					f.windows[i].terminals = append(f.windows[i].terminals, term)
+					return term, nil
+				}
+			}
+		}
+		return "", errors.New("ghostty terminal not unique")
+	case "list-windows":
+		ids := make([]string, 0, len(f.windows))
+		for _, window := range f.windows {
+			ids = append(ids, window.id)
+		}
+		return strings.Join(ids, ","), nil
+	case "window-terminals":
+		for _, window := range f.windows {
+			if window.id == args[1] {
+				return strings.Join(window.terminals, ","), nil
+			}
+		}
+		return "", nil
+	case "terminal-count":
+		if f.unhealthy {
+			return "0", nil
+		}
+		want := strings.ToUpper(args[1])
+		count := 0
+		for _, window := range f.windows {
+			for _, id := range window.terminals {
+				if strings.ToUpper(id) == want {
+					count++
+				}
+			}
+		}
+		return strconv.Itoa(count), nil
+	case "input-text", "send-key-enter", "focus-terminal":
+		return "ok", nil
+	case "close-window":
+		kept := f.windows[:0]
+		for _, window := range f.windows {
+			if window.id != args[1] {
+				kept = append(kept, window)
+			}
+		}
+		f.windows = kept
+		return "ok", nil
+	default:
+		return "", fmt.Errorf("unknown ghostty op %q", op)
+	}
+}
+
+func (f *fakeGhostty) nextUUID() string {
+	f.seq++
+	return fmt.Sprintf("019C5A10-75D8-7EEF-8DB7-%012X", f.seq)
+}
+
+func (f *fakeGhostty) ops() [][]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([][]string, len(f.log))
+	copy(out, f.log)
+	return out
+}
+
+func newFakeGhosttyBackend(t *testing.T) (*GhosttyBackend, *fakeGhostty) {
+	t.Helper()
+	fake := &fakeGhostty{version: "1.3.1"}
+	backend := NewGhosttyBackend()
+	backend.hostname = func() (string, error) { return "host.test", nil }
+	backend.run = fake.run
+	backend.healthTimeout = time.Second
+	backend.healthPoll = 10 * time.Millisecond
+	return backend, fake
+}
+
+func ghosttyTestPlan(project, nonce string) Plan {
+	return Plan{Version: PlanVersion, Agents: []AgentPlan{
+		{Handle: "claude", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7a6"},
+		{Handle: "codex", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e7a7"},
+	}}
+}
+
+func writeGhosttySleepAMQ(t *testing.T) string {
+	t.Helper()
+	fakeAMQ := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nexec /bin/sleep 60\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return fakeAMQ
+}
+
+func TestGhosttyBackendLifecycleAndRecovery(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := writeGhosttySleepAMQ(t)
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70e7a5"
+	plan := ghosttyTestPlan(project, nonce)
+
+	detect := backend.Detect()
+	if !detect.Available || detect.Profile.Identity() != "ghostty/darwin/v1" || detect.InstanceIdentity != ghosttyInstancePrefix+ghosttyBundleID {
+		t.Fatalf("Detect = %#v", detect)
+	}
+	if strings.Contains(detect.InstanceIdentity, "1.3") {
+		t.Fatalf("instance identity leaked version: %q", detect.InstanceIdentity)
+	}
+
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Outcome != OutcomeCreated || countGhosttyAgentResources(created.Binding) != 2 {
+		t.Fatalf("Create = %#v", created)
+	}
+	assertNoGhosttyCommandOp(t, fake)
+
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectPresent {
+		t.Fatalf("Inspect = %#v, %v", inspection, err)
+	}
+
+	journal := LaunchJournal{
+		ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
+		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
+		Backend: LauncherGhostty, Profile: detect.Profile.Identity(),
+		Binding: &created.Binding,
+	}
+	journal.RootIdentity, err = canonicalIdentity(root.Base())
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal.RootPhysical, _ = fsq.StableTreeIdentityInfo(root.FileInfo())
+	reclaimed, err := backend.Reclaim(ReclaimRequest{Context: context.Background(), Journal: journal, Root: root})
+	if err != nil || reclaimed.Status != ReclaimAdoptable || countGhosttyAgentResources(BindingRecord{Resources: ResourceIdentitySet{Resources: reclaimed.Resources}}) != 2 {
+		t.Fatalf("Reclaim = %#v, %v", reclaimed, err)
+	}
+
+	intent := journal
+	intent.Binding = nil
+	unknown, err := backend.Reclaim(ReclaimRequest{Context: context.Background(), Journal: intent, Root: root})
+	if err != nil || unknown.Status != ReclaimUnknown {
+		t.Fatalf("pre-ID Reclaim = %#v, %v", unknown, err)
+	}
+
+	foreignBinding := created.Binding
+	foreignBinding.InstanceIdentity = "ghostty-app:foreign"
+	foreignInspection, err := backend.Inspect(InspectRequest{Binding: foreignBinding, Root: root})
+	if err != nil || foreignInspection.Status != InspectUnknown {
+		t.Fatalf("foreign Inspect = %#v, %v", foreignInspection, err)
+	}
+
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("Close = %#v, %v", closed, err)
+	}
+	absent, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || absent.Status != InspectAbsent {
+		t.Fatalf("Inspect after Close = %#v, %v", absent, err)
+	}
+}
+
+func TestGhosttyBackendConformance(t *testing.T) {
+	backend, _ := newFakeGhosttyBackend(t)
+	RunConformance(t, backend)
+}
+
+func TestGhosttyCreateSendsExactLineAfterHealthGate(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	fakeAMQ := writeGhosttySleepAMQ(t)
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70e8a5")
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := fake.ops()
+	if indexOfGhosttyOp(calls, "input-text") < indexOfGhosttyOp(calls, "terminal-count") {
+		t.Fatalf("sent text before health: %v", calls)
+	}
+	wantAMQ, err := filepath.EvalSymlinks(fakeAMQ)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := backend.agentCommand(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: wantAMQ, Root: root}, plan.Agents[0])
+	found := false
+	for _, argv := range calls {
+		if len(argv) >= 3 && argv[0] == "input-text" && argv[2] == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("exact command line not sent: want %q in %v", want, calls)
+	}
+	_ = created
+}
+
+func TestGhosttyHealthTimeoutDoesNotSend(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	fake.unhealthy = true
+	backend.healthTimeout = 50 * time.Millisecond
+	backend.healthPoll = 10 * time.Millisecond
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70e9a5")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root})
+	if err == nil || !strings.Contains(err.Error(), "readiness timed out") {
+		t.Fatalf("Create error = %v, want readiness timeout", err)
+	}
+	var definite *DefinitePreCreateError
+	if errors.As(err, &definite) {
+		t.Fatal("health timeout must retain the window for journal recovery")
+	}
+	if indexOfGhosttyOp(fake.ops(), "input-text") >= 0 {
+		t.Fatal("sent text after readiness failure")
+	}
+}
+
+func TestGhosttyCloseRefusesWindowIDReuseWithOtherTerminals(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa5")
+	plan.Agents = plan.Agents[:1]
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake.mu.Lock()
+	if len(fake.windows) != 1 {
+		fake.mu.Unlock()
+		t.Fatalf("windows = %#v", fake.windows)
+	}
+	fake.windows[0].terminals = []string{"019C5A10-75D8-7EEF-8DB7-FFFFFFFFFFFF"}
+	fake.mu.Unlock()
+
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectUnknown || !inspection.ActionRequired {
+		t.Fatalf("Inspect = %#v, %v, want unknown", inspection, err)
+	}
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.Outcome != OutcomeActionRequired {
+		t.Fatalf("Close = %#v, want action-required", closed)
+	}
+	if indexOfGhosttyOp(fake.ops(), "close-window") >= 0 {
+		t.Fatalf("close-window invoked for reused window id: %v", fake.ops())
+	}
+}
+
+func TestGhosttyListWindowsErrorIsUnknownNotAbsent(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70efa5")
+	plan.Agents = plan.Agents[:1]
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := len(fake.ops())
+	fake.fail = "list-windows"
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectUnknown || !inspection.ActionRequired {
+		t.Fatalf("Inspect = %#v, %v, want unknown action-required", inspection, err)
+	}
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.Outcome != OutcomeActionRequired {
+		t.Fatalf("Close = %#v, want action-required", closed)
+	}
+	if indexOfGhosttyOp(fake.ops()[before:], "close-window") >= 0 {
+		t.Fatalf("list-windows failure closed a window: %v", fake.ops()[before:])
+	}
+	fake.fail = ""
+	present, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || present.Status != InspectPresent {
+		t.Fatalf("window after list failure = %#v, %v", present, err)
+	}
+}
+
+func TestGhosttyCrashAfterWindowIsUncertain(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	fake.fail = "split"
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eca5"), AMQPath: writeGhosttySleepAMQ(t), Root: root})
+	var definite *DefinitePreCreateError
+	if err == nil || errors.As(err, &definite) {
+		t.Fatalf("Create error = %v, want uncertain post-create failure", err)
+	}
+}
+
+func TestGhosttyCreateMissingAMQRefusesBeforeMutation(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eda5")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: filepath.Join(t.TempDir(), "missing-amq"), Root: root})
+	var definite *DefinitePreCreateError
+	if !errors.As(err, &definite) {
+		t.Fatalf("Create error = %v, want definite pre-create refusal", err)
+	}
+	if indexOfGhosttyOp(fake.ops(), "new-window") >= 0 {
+		t.Fatal("missing amq created a ghostty window")
+	}
+}
+
+func TestGhosttyVersionOutsideEnvelopeIsDegradedNotForeign(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	fake.version = "2.0.0"
+	detect := backend.Detect()
+	if detect.Available {
+		t.Fatal("out-of-range version reported available")
+	}
+	if detect.InstanceIdentity == "" || len(detect.Degradations) == 0 {
+		t.Fatalf("Detect = %#v, want instance identity and degradations", detect)
+	}
+}
+
+func TestGhosttyUnreachableAppleScriptIsNotForeignContext(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70efb5")
+	plan.Agents = plan.Agents[:1]
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake.fail = "version"
+	inspection, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || inspection.Status != InspectUnknown || !inspection.ActionRequired {
+		t.Fatalf("Inspect = %#v, %v, want unknown action-required", inspection, err)
+	}
+	if !strings.Contains(inspection.Evidence, "unreachable") {
+		t.Fatalf("Inspect evidence = %q, want unreachable", inspection.Evidence)
+	}
+	if strings.Contains(inspection.Evidence, "different backend context") {
+		t.Fatalf("unreachable AppleScript reported as foreign: %q", inspection.Evidence)
+	}
+}
+
+func TestSupportedGhosttyVersion(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		want    bool
+	}{{"1.3.0", true}, {"1.3.1", true}, {"Ghostty 1.4.0", true}, {"1.2.9", false}, {"2.0.0", false}} {
+		if got := supportedGhosttyVersion(tc.version); got != tc.want {
+			t.Errorf("supportedGhosttyVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestGhosttyInsidePreferencePrependsOnlyWhenInsideGhosttyNotCmux(t *testing.T) {
+	prefs := []string{LauncherTMux, LauncherCommands}
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("CMUX_SURFACE_ID", "")
+	if got := prependInsideSurfacePreference(prefs); strings.Join(got, ",") != strings.Join(prefs, ",") {
+		t.Fatalf("outside prepend = %v", got)
+	}
+	t.Setenv("TERM_PROGRAM", "ghostty")
+	got := prependInsideSurfacePreference(prefs)
+	if len(got) != 3 || got[0] != LauncherGhostty || got[1] != LauncherTMux {
+		t.Fatalf("inside ghostty prepend = %v", got)
+	}
+	t.Setenv("CMUX_SURFACE_ID", "F901D722-6789-4BBB-9818-C4E97F20BEB3")
+	got = prependInsideSurfacePreference(prefs)
+	if len(got) != 3 || got[0] != LauncherCMux || got[1] != LauncherTMux {
+		t.Fatalf("inside cmux prepend = %v", got)
+	}
+}
+
+func TestReconcileAutoSelectsGhosttyWhenInsideGhostty(t *testing.T) {
+	tmux := &reconcileBackend{name: LauncherTMux, inspect: InspectAbsent}
+	ghostty := &reconcileBackend{name: LauncherGhostty, inspect: InspectAbsent}
+	req := reconcileFixture(t, tmux)
+	req.Launcher = LauncherAuto
+	req.Preferences = []string{LauncherTMux, LauncherGhostty}
+	req.Backends[LauncherGhostty] = ghostty
+	t.Setenv("TERM_PROGRAM", "ghostty")
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Backend != LauncherGhostty || ghostty.creates != 1 || tmux.creates != 0 {
+		t.Fatalf("result=%#v ghostty creates=%d tmux creates=%d", result, ghostty.creates, tmux.creates)
+	}
+}
+
+func TestReconcileInsideCmuxDoesNotPrependGhostty(t *testing.T) {
+	tmux := &reconcileBackend{name: LauncherTMux, inspect: InspectAbsent}
+	ghostty := &reconcileBackend{name: LauncherGhostty, inspect: InspectAbsent}
+	req := reconcileFixture(t, tmux)
+	req.Launcher = LauncherAuto
+	req.Preferences = []string{LauncherTMux, LauncherGhostty}
+	req.Backends[LauncherGhostty] = ghostty
+	t.Setenv("TERM_PROGRAM", "ghostty")
+	t.Setenv("CMUX_SURFACE_ID", "F901D722-6789-4BBB-9818-C4E97F20BEB3")
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Backend != LauncherTMux || tmux.creates != 1 || ghostty.creates != 0 {
+		t.Fatalf("result=%#v tmux creates=%d ghostty creates=%d", result, tmux.creates, ghostty.creates)
+	}
+}
+
+func TestGhosttyArgvRecorderSeesCreateGrammar(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eea5")
+	plan.Agents = plan.Agents[:1]
+	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	joined := fmt.Sprint(fake.ops())
+	for _, needle := range []string{"version", "new-window", "terminal-count", "input-text", "send-key-enter"} {
+		if !strings.Contains(joined, needle) {
+			t.Fatalf("argv log missing %s: %s", needle, joined)
+		}
+	}
+	if strings.Contains(joined, "command") {
+		t.Fatalf("create used configuration.command: %s", joined)
+	}
+}
+
+func countGhosttyAgentResources(binding BindingRecord) int {
+	count := 0
+	for _, resource := range binding.Resources.Resources {
+		if resource.Agent != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func assertNoGhosttyCommandOp(t *testing.T, fake *fakeGhostty) {
+	t.Helper()
+	for _, argv := range fake.ops() {
+		for _, arg := range argv {
+			if arg == "command" || strings.Contains(arg, "configuration.command") {
+				t.Fatalf("ghostty invoked with command: %v", argv)
+			}
+		}
+	}
+}
+
+func indexOfGhosttyOp(calls [][]string, op string) int {
+	for i, argv := range calls {
+		if len(argv) > 0 && argv[0] == op {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/launch/ghostty_test.go
+++ b/internal/launch/ghostty_test.go
@@ -437,6 +437,16 @@ func TestGhosttyCreateTimeoutDoesNotCloseAmbiguousWindows(t *testing.T) {
 	}
 }
 
+func TestGhosttyDefaultCreateTimeoutExceedsInspectTimeout(t *testing.T) {
+	got := NewGhosttyBackend().createOpTimeout()
+	if got <= ghosttyCommandTimeout {
+		t.Fatalf("default create timeout %s is not greater than inspect timeout %s", got, ghosttyCommandTimeout)
+	}
+	if got < 30*time.Second {
+		t.Fatalf("default create timeout %s is below 30s", got)
+	}
+}
+
 func TestGhosttyCreateMissingAMQRefusesBeforeMutation(t *testing.T) {
 	backend, fake := newFakeGhosttyBackend(t)
 	project := t.TempDir()

--- a/internal/launch/ghostty_test.go
+++ b/internal/launch/ghostty_test.go
@@ -117,6 +117,18 @@ func (f *fakeGhostty) nextUUID() string {
 	return fmt.Sprintf("019C5A10-75D8-7EEF-8DB7-%012X", f.seq)
 }
 
+func (f *fakeGhostty) windowCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.windows)
+}
+
+func (f *fakeGhostty) addWindow(id, tabID, term string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.windows = append(f.windows, fakeGhosttyWindow{id: id, tabID: tabID, terminals: []string{term}})
+}
+
 func (f *fakeGhostty) ops() [][]string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -271,12 +283,11 @@ func TestGhosttyHealthTimeoutDoesNotSend(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "readiness timed out") {
 		t.Fatalf("Create error = %v, want readiness timeout", err)
 	}
-	var definite *DefinitePreCreateError
-	if errors.As(err, &definite) {
-		t.Fatal("health timeout must retain the window for journal recovery")
-	}
 	if indexOfGhosttyOp(fake.ops(), "input-text") >= 0 {
 		t.Fatal("sent text after readiness failure")
+	}
+	if fake.windowCount() != 0 {
+		t.Fatalf("health timeout left orphan windows: %d", fake.windowCount())
 	}
 }
 
@@ -356,6 +367,73 @@ func TestGhosttyCrashAfterWindowIsUncertain(t *testing.T) {
 	var definite *DefinitePreCreateError
 	if err == nil || errors.As(err, &definite) {
 		t.Fatalf("Create error = %v, want uncertain post-create failure", err)
+	}
+	if fake.windowCount() != 0 {
+		t.Fatalf("split failure left orphan windows: %d", fake.windowCount())
+	}
+}
+
+func TestGhosttyCreateTimeoutClosesSingleOrphanWindow(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	backend.createTimeout = 20 * time.Millisecond
+	inner := fake.run
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "new-window" {
+			if _, err := inner(ctx, args...); err != nil {
+				return "", err
+			}
+			<-ctx.Done()
+			return "", fmt.Errorf("osascript new-window: %w", ctx.Err())
+		}
+		return inner(ctx, args...)
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa1")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root})
+	if err == nil {
+		t.Fatal("Create succeeded after create-call timeout")
+	}
+	if !strings.Contains(err.Error(), "closed orphan ghostty window") {
+		t.Fatalf("Create error = %v, want closed orphan", err)
+	}
+	if fake.windowCount() != 0 {
+		t.Fatalf("timeout left orphan windows: %d", fake.windowCount())
+	}
+	if indexOfGhosttyOp(fake.ops(), "close-window") < 0 {
+		t.Fatal("timeout did not close the orphan window")
+	}
+}
+
+func TestGhosttyCreateTimeoutDoesNotCloseAmbiguousWindows(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	backend.createTimeout = 20 * time.Millisecond
+	inner := fake.run
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "new-window" {
+			if _, err := inner(ctx, args...); err != nil {
+				return "", err
+			}
+			fake.addWindow("tab-group-extra", "tab-extra", "019C5A10-75D8-7EEF-8DB7-0000000000EE")
+			<-ctx.Done()
+			return "", fmt.Errorf("osascript new-window: %w", ctx.Err())
+		}
+		return inner(ctx, args...)
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa2")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous new ghostty windows") {
+		t.Fatalf("Create error = %v, want ambiguous unknown", err)
+	}
+	if fake.windowCount() != 2 {
+		t.Fatalf("ambiguous timeout closed windows: %d", fake.windowCount())
+	}
+	if indexOfGhosttyOp(fake.ops(), "close-window") >= 0 {
+		t.Fatal("ambiguous timeout guessed a window to close")
 	}
 }
 

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -524,7 +524,7 @@ func selectPrepareBackend(requested string, binding *BindingRecord, dependencies
 		}
 	}
 	if selected == LauncherAuto {
-		for _, name := range prependInsideCmuxPreference(preferences) {
+		for _, name := range prependInsideSurfacePreference(preferences) {
 			backend := dependencies.Backends[name]
 			if backend == nil {
 				continue

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -1051,7 +1051,7 @@ func chooseReconcileBackend(request ReconcileRequest, binding BindingRecord, has
 }
 
 func selectPreferredBackend(request ReconcileRequest) (string, Backend, DetectResult, bool, error) {
-	for _, name := range prependInsideCmuxPreference(request.Preferences) {
+	for _, name := range prependInsideSurfacePreference(request.Preferences) {
 		backend := request.Backends[name]
 		if backend == nil {
 			continue

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -404,7 +404,7 @@ func TestApplyRequiresExactRequestLocalDecisions(t *testing.T) {
 
 func TestApplyUnsupportedLauncherRefusesBeforeRosterMutation(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, true)
-	fixture.request.Launcher = "ghostty"
+	fixture.request.Launcher = unavailableManagedLauncher(t)
 	fixture.request.Intent.Participants = append(fixture.request.Intent.Participants, ParticipantV1{Handle: "reviewer", Runnable: false})
 	prepared, err := Prepare(context.Background(), fixture.request)
 	if err != nil {

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -105,12 +105,13 @@ func TestPrepareParticipantOnlyAbsentSessionDoesNotProvision(t *testing.T) {
 
 func TestPrepareUnavailableLauncherIsTypedAndDoesNotRequestTrust(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, true)
-	fixture.request.Launcher = "ghostty"
+	launcher := unavailableManagedLauncher(t)
+	fixture.request.Launcher = launcher
 	result, err := Prepare(context.Background(), fixture.request)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Outcome != PrepareOutcomeUnsupported || result.Reason != "launcher_not_available" || result.Preview.Backend != "ghostty" {
+	if result.Outcome != PrepareOutcomeUnsupported || result.Reason != "launcher_not_available" || result.Preview.Backend != launcher {
 		t.Fatalf("unavailable launcher result = %#v", result)
 	}
 	if len(result.RequiredActions) != 0 {
@@ -286,6 +287,18 @@ type publicPrepareFixture struct {
 	root       string
 	siblingCwd string
 	request    PrepareRequestV1
+}
+
+func unavailableManagedLauncher(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{internallaunch.LauncherCMux, internallaunch.LauncherGhostty} {
+		backend := internallaunch.DefaultBackends()[name]
+		if backend != nil && !backend.Detect().Available {
+			return name
+		}
+	}
+	t.Skip("cmux and ghostty are both available on this host")
+	return ""
 }
 
 func newPublicPrepareFixture(t *testing.T, existingSession bool) publicPrepareFixture {


### PR DESCRIPTION
## Summary

- AppleScript-only Create (no `+new-window`, no `open -na`, no `configuration.command`). Health-gate then input the exact `commandLine` text and send key enter. Create-call timeout is 30s (inspect stays 5s). Snapshot windows before `new-window`/`split`; one empty orphan is closed; 0 or >1 is unknown and never guessed.
- Instance identity is `ghostty-app:com.mitchellh.ghostty` only. Envelope `>=1.3.0 <2.0`. HostIdentity is hostname. Mixed IDs: window `tab-group-*`, tab `tab-*`, terminal UUID uppercase. Inspect present = window exists AND terminal-UUID set == bound set exactly.
- Inside-cmux beats inside-ghostty. `DefaultBackends` is commands+tmux+cmux+ghostty; setup pings both; `prependInsideSurfacePreference` is cmux > ghostty.
- A Ghostty crash between window creation and binding persistence leaves that window for manual close; AMQ never treats the gap as proven absence and never creates a duplicate.

Stacked on squash-merged cmux `#527` (`main` `b505360`). Rebase `--onto origin/main 9846d28` was clean; stacked content hash unchanged.

```text
BEGIN_COMMIT_OVERRIDE
feat(launch): add managed Ghostty backend

fix(launch): close Ghostty create orphans and pin DefaultBackends

test(launch): pin Ghostty default create timeout above inspect
END_COMMIT_OVERRIDE
```

## Live evidence

- Live PASS on `29179e3`: `TestGhosttyLive` 4.83s. Window `tab-group-7daecb020`, 2 terminals, exact commandLines, Inspect present, Focus attached, wrong-window Close refused, Close closed, Inspect absent, terminal count 12→12.
- `f7e11bb` `-v` logs accepted (window/tab/terminal ids, sent command lines, Inspect/Focus/Close).
- This PR HEAD `cca4585` is that same Ghostty delta rebased onto `b505360`. Content hash `git diff origin/main..HEAD | shasum -a 256` = `8d7b8680fabdbec6d841e7da84db0fee3b77cf5beb890ea70093634d3f6ac1b8` (identical to `git diff 9846d28..b830471` before the rebase).

## Test plan

- [x] Live PASS (`AMQ_GHOSTTY_LIVE=1 go test ./internal/launch -run TestGhosttyLive -v`)
- [x] Mutants stay red:
  - DefaultBackends missing ghostty (`TestDefaultBackendsMatchesLauncherRegistry`)
  - single-orphan close disabled (`TestGhosttyCreateTimeoutClosesSingleOrphanWindow`)
  - ambiguous close added (`TestGhosttyCreateTimeoutDoesNotCloseAmbiguousWindows`)
  - `ghosttyCreateTimeout` 30s→5s (`TestGhosttyDefaultCreateTimeoutExceedsInspectTimeout`)
  - window-id reuse (`TestGhosttyCloseRefusesWindowIDReuseWithOtherTerminals`)
  - input before health (`TestGhosttyHealthTimeoutDoesNotSend`)
  - cmux precedence dropped (`TestGhosttyInsidePreferencePrependsOnlyWhenInsideGhosttyNotCmux` + `TestReconcileInsideCmuxDoesNotPrependGhostty`)
  - version in identity (`TestGhosttyBackendLifecycleAndRecovery`)
  - list-windows error => absent (`TestGhosttyListWindowsErrorIsUnknownNotAbsent`)
- [ ] Claude: verify `origin/feat/ghostty-backend` == `cca4585d6518acc7b56ab1357249c62b8c56604b`
- [ ] Claude: merge pipeline
