### PR TITLE
feat(launch): capture Codex identity through an adapter-owned notify hook

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -50,9 +50,43 @@ does not replace committed project configuration.
 
 `resume_policy` accepts exactly `resume`, `fresh`, or `disabled`.
 
-The v1 adapter set supports Claude Code, Codex CLI, and Cursor CLI capture at
-exact version `2026.08.11-e8db854`. Grok and Pi are excluded because they have
-no provider CLI; Gemini CLI and OpenCode also remain outside this adapter set.
+The v1 adapter set supports Claude Code, Codex CLI, and Cursor CLI. Claude Code
+mints its session ID from the launch nonce. Codex CLI `0.147.0` reports its
+provider-owned thread ID after a completed turn through its legacy `notify`
+hook. AMQ adds one static hook override that is bound to the session root,
+handle, launch nonce, and AMQ executable. The private hook validates the exact
+ticket and payload, persists immutable evidence, and only then publishes the
+conversation identity. It forwards the identical payload to the operator's
+configured Codex notify command after publication; a missing command is a
+no-op, and a forwarding failure cannot undo or fail the evidence path. An
+unused Codex launch remains pending and cannot be resumed. Cursor CLI acquires
+its provider-owned chat ID before process start through `create-chat` at exact
+version `2026.08.11-e8db854`.
+
+The tier-1 provider smokes are opt-in. The Codex smoke first proves that an
+unused launch stays pending and returns AMQ's typed stale-conversation action.
+It then sends one fixed prompt through the managed pane, waits for notify-backed
+identity publication, and performs one exact headless resume:
+
+```bash
+AMQ_CLAUDE_LIVE=1 go test ./internal/launch -run TestClaudeLiveManagedMintResumeAndCrashReuse -count=1 -v
+AMQ_CODEX_LIVE=1 go test ./internal/launch -run TestCodexLiveManagedAcquireResumeAndCrashReuse -count=1 -v
+```
+
+The smoke harness disables Claude tools with the CLI-equivalent single argument
+`--tools=` and uses
+`--permission-mode plan`; it runs Codex with `--sandbox read-only`. These are
+harness controls, not additions to the adapter's committed option contract.
+The smokes record the exact managed process arguments and provider IDs, require
+headless resume to return the requested ID, and stop at the first failure.
+Claude persists a minted `--session-id` only after its first turn. The live
+smoke proves that an unused mint returns AMQ's typed stale-conversation action,
+then bootstraps the same ID with a no-tools turn before it proves exact resume.
+It uses an already-trusted checkout as the Claude cwd and keeps its AMQ session
+root in a temporary directory; it never changes Claude trust state.
+
+Grok and Pi are excluded because they have no provider CLI; Gemini CLI and
+OpenCode also remain outside this adapter set.
 
 ## Prepare and Apply
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.6
 require (
 	github.com/coder/websocket v1.8.15
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,6 +24,9 @@ func Run(args []string, version string) error {
 	if len(args) > 0 && args[0] == "__launch-exec" {
 		return runLaunchExec(args[1:])
 	}
+	if len(args) > 0 && args[0] == "__codex-notify" {
+		return runCodexNotify(args[1:])
+	}
 
 	args, noUpdate := stripNoUpdateCheckArgs(args)
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {

--- a/internal/cli/codex_notify.go
+++ b/internal/cli/codex_notify.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+	"github.com/pelletier/go-toml/v2"
+)
+
+const codexNotifyForwardTimeout = 10 * time.Second
+
+var (
+	codexNotifyExecutable = os.Executable
+	codexNotifyForward    = forwardOperatorCodexNotify
+)
+
+func runCodexNotify(args []string) error {
+	if len(args) != 7 || args[0] != "--root" || args[2] != "--handle" || args[4] != "--nonce" ||
+		strings.TrimSpace(args[1]) == "" || strings.TrimSpace(args[3]) == "" || strings.TrimSpace(args[5]) == "" {
+		return fmt.Errorf("codex notify requires --root, --handle, --nonce, and one payload")
+	}
+	rootPath, handle, nonce := args[1], args[3], args[5]
+	payload := []byte(args[6])
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		return fmt.Errorf("snapshot codex notify root: %w", err)
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		return fmt.Errorf("open codex notify root: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+	if err := fsq.ValidateExistingMailboxLayout(root, handle); err != nil {
+		return fmt.Errorf("validate codex notify root: %w", err)
+	}
+	amqExecutable, err := codexNotifyExecutable()
+	if err != nil {
+		return fmt.Errorf("resolve codex notify executable: %w", err)
+	}
+	if _, err := launch.RecordCodexNotify(root, handle, nonce, amqExecutable, payload); err != nil {
+		return err
+	}
+	if err := codexNotifyForward(amqExecutable, payload); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "amq: codex operator notify failed: %v\n", err)
+	}
+	return nil
+}
+
+type codexOperatorConfig struct {
+	Notify []string `toml:"notify"`
+}
+
+func forwardOperatorCodexNotify(amqExecutable string, payload []byte) error {
+	argv, err := loadOperatorCodexNotify()
+	if err != nil {
+		return err
+	}
+	if len(argv) == 0 || strings.TrimSpace(argv[0]) == "" {
+		return nil
+	}
+	target, err := exec.LookPath(argv[0])
+	if err != nil {
+		return fmt.Errorf("resolve operator notify executable: %w", err)
+	}
+	targetIdentity, err := fsq.StableFileIdentity(target)
+	if err != nil {
+		return fmt.Errorf("identify operator notify executable: %w", err)
+	}
+	amqIdentity, err := fsq.StableFileIdentity(amqExecutable)
+	if err != nil {
+		return fmt.Errorf("identify AMQ executable: %w", err)
+	}
+	if targetIdentity == amqIdentity {
+		return nil
+	}
+	forwardArgs := append(append([]string(nil), argv[1:]...), string(payload))
+	ctx, cancel := context.WithTimeout(context.Background(), codexNotifyForwardTimeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, target, forwardArgs...)
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	if err := command.Run(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("operator notify timed out: %w", ctx.Err())
+		}
+		return fmt.Errorf("operator notify failed: %w", err)
+	}
+	return nil
+}
+
+func loadOperatorCodexNotify() ([]string, error) {
+	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	if codexHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve Codex home: %w", err)
+		}
+		codexHome = filepath.Join(home, ".codex")
+	}
+	raw, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read Codex config: %w", err)
+	}
+	var config codexOperatorConfig
+	if err := toml.Unmarshal(raw, &config); err != nil {
+		return nil, fmt.Errorf("decode Codex config: %w", err)
+	}
+	return append([]string(nil), config.Notify...), nil
+}

--- a/internal/cli/codex_notify.go
+++ b/internal/cli/codex_notify.go
@@ -23,12 +23,16 @@ var (
 )
 
 func runCodexNotify(args []string) error {
-	if len(args) != 7 || args[0] != "--root" || args[2] != "--handle" || args[4] != "--nonce" ||
-		strings.TrimSpace(args[1]) == "" || strings.TrimSpace(args[3]) == "" || strings.TrimSpace(args[5]) == "" {
-		return fmt.Errorf("codex notify requires --root, --handle, --nonce, and one payload")
+	if len(args) != 5 || args[0] != "--root" || args[2] != "--handle" ||
+		strings.TrimSpace(args[1]) == "" || strings.TrimSpace(args[3]) == "" {
+		return fmt.Errorf("codex notify requires --root, --handle, and one payload")
 	}
-	rootPath, handle, nonce := args[1], args[3], args[5]
-	payload := []byte(args[6])
+	rootPath, handle := args[1], args[3]
+	nonce := strings.TrimSpace(os.Getenv(launch.InternalLaunchNonceEnv))
+	if nonce == "" {
+		return fmt.Errorf("codex notify requires %s", launch.InternalLaunchNonceEnv)
+	}
+	payload := []byte(args[4])
 	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
 	if err != nil {
 		return fmt.Errorf("snapshot codex notify root: %w", err)

--- a/internal/cli/codex_notify_test.go
+++ b/internal/cli/codex_notify_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -35,8 +36,17 @@ func TestCodexNotifyRecordsBeforeForwardAndIgnoresForwardFailure(t *testing.T) {
 		}
 		return wantForwardErr
 	}
-	if err := Run([]string{"__codex-notify", "--root", session, "--handle", "codex", "--nonce", nonce, string(payload)}, "test"); err != nil {
+	t.Setenv(launch.InternalLaunchNonceEnv, nonce)
+	if err := Run([]string{"__codex-notify", "--root", session, "--handle", "codex", string(payload)}, "test"); err != nil {
 		t.Fatalf("run notify with failed operator hook: %v", err)
+	}
+}
+
+func TestCodexNotifyRequiresManagedNonceEnvironment(t *testing.T) {
+	t.Setenv(launch.InternalLaunchNonceEnv, "")
+	err := runCodexNotify([]string{"--root", t.TempDir(), "--handle", "codex", `{}`})
+	if err == nil || !strings.Contains(err.Error(), launch.InternalLaunchNonceEnv) {
+		t.Fatalf("missing managed nonce error = %v", err)
 	}
 }
 
@@ -121,7 +131,7 @@ func seedCodexNotifyCLI(t *testing.T) (string, *fsq.DeliveryRoot, string, string
 		t.Fatal(err)
 	}
 	nonce := "78787878-7878-4787-8787-787878787878"
-	notifyArgv := []string{amq, "__codex-notify", "--root", session, "--handle", "codex", "--nonce", nonce}
+	notifyArgv := []string{amq, "__codex-notify", "--root", session, "--handle", "codex"}
 	encoded, err := json.Marshal(notifyArgv)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/codex_notify_test.go
+++ b/internal/cli/codex_notify_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+const codexNotifyTestID = "019c8a2f-2b13-7000-8000-000000000001"
+
+func TestCodexNotifyRecordsBeforeForwardAndIgnoresForwardFailure(t *testing.T) {
+	session, root, nonce, amq := seedCodexNotifyCLI(t)
+	payload := []byte(`{"type":"agent-turn-complete","thread-id":"` + codexNotifyTestID + `","turn-id":"turn-1","cwd":"` + filepath.Join(session, "work") + `","input-messages":["reply with ok"],"last-assistant-message":"ok"}`)
+	original := codexNotifyForward
+	t.Cleanup(func() { codexNotifyForward = original })
+	wantForwardErr := errors.New("operator hook failed")
+	codexNotifyForward = func(gotAMQ string, gotPayload []byte) error {
+		gotIdentity, gotErr := fsq.StableFileIdentity(gotAMQ)
+		wantIdentity, wantErr := fsq.StableFileIdentity(amq)
+		if gotErr != nil || wantErr != nil || gotIdentity != wantIdentity || !reflect.DeepEqual(gotPayload, payload) {
+			t.Fatalf("forward = %q %q", gotAMQ, gotPayload)
+		}
+		record, err := launch.LoadConversation(root, "codex")
+		if err != nil || record.State != launch.CaptureReady || record.Identity.ID != codexNotifyTestID || len(record.EvidenceRefs) != 1 {
+			t.Fatalf("conversation before forward = %#v, %v", record, err)
+		}
+		if _, _, err := launch.ReadEvidence(root, record.EvidenceRefs[0]); err != nil {
+			t.Fatalf("evidence before forward: %v", err)
+		}
+		return wantForwardErr
+	}
+	if err := Run([]string{"__codex-notify", "--root", session, "--handle", "codex", "--nonce", nonce, string(payload)}, "test"); err != nil {
+		t.Fatalf("run notify with failed operator hook: %v", err)
+	}
+}
+
+func TestForwardOperatorCodexNotifyUsesIdenticalPayload(t *testing.T) {
+	home := t.TempDir()
+	output := filepath.Join(t.TempDir(), "payload")
+	script := filepath.Join(t.TempDir(), "notify")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s' \"$2\" > \"$1\"\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	config := "notify = [" + tomlQuote(script) + ", " + tomlQuote(output) + "]\n"
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", home)
+	amq, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"type":"agent-turn-complete","thread-id":"` + codexNotifyTestID + `"}`)
+	if err := forwardOperatorCodexNotify(amq, payload); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(output)
+	if err != nil || !reflect.DeepEqual(got, payload) {
+		t.Fatalf("forwarded payload = %q, %v", got, err)
+	}
+}
+
+func TestForwardOperatorCodexNotifyAbsentAndSelfAreNoOps(t *testing.T) {
+	amq, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	if err := forwardOperatorCodexNotify(amq, []byte(`{}`)); err != nil {
+		t.Fatalf("absent config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte("notify = ["+tomlQuote(amq)+"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := forwardOperatorCodexNotify(amq, []byte(`{}`)); err != nil {
+		t.Fatalf("self config: %v", err)
+	}
+}
+
+func seedCodexNotifyCLI(t *testing.T) (string, *fsq.DeliveryRoot, string, string) {
+	t.Helper()
+	project := t.TempDir()
+	session := filepath.Join(t.TempDir(), "collab")
+	cwd := filepath.Join(session, "work")
+	if err := os.MkdirAll(cwd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	amq, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	amq, err = filepath.EvalSymlinks(amq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err = filepath.EvalSymlinks(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := filepath.Join(t.TempDir(), "codex")
+	if err := os.WriteFile(provider, []byte("provider"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	nonce := "78787878-7878-4787-8787-787878787878"
+	notifyArgv := []string{amq, "__codex-notify", "--root", session, "--handle", "codex", "--nonce", nonce}
+	encoded, err := json.Marshal(notifyArgv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := launch.NewExecutionTicket(launch.ExecutionTicketRequest{
+		Handle: "codex", LaunchNonce: nonce, Mode: launch.AdapterModeCapture, Provider: launch.CodexProvider,
+		ProviderVersion: "0.147.0", Backend: launch.CommandsBackendName, Profile: launch.CommandsProfile().Identity(),
+		ProjectRoot: project, SessionRoot: session, Cwd: cwd, ProviderExecutable: provider, AMQExecutable: amq,
+		TargetArgv: []string{provider, "-c", "notify=" + string(encoded)}, State: launch.ExecutionSpawnAttempted, Reason: "spawn_attempted",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := launch.AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteExecutionTicket(root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteConversation(root, lease, launch.ConversationRecord{
+		Version: launch.ConversationVersion, Handle: "codex", State: launch.CapturePending,
+		ProviderVersion: "0.147.0", LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	return session, root, nonce, amq
+}
+
+func tomlQuote(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/internal/cli/launch_api_e2e_test.go
+++ b/internal/cli/launch_api_e2e_test.go
@@ -567,7 +567,7 @@ esac
 	var applied launchapi.ApplyResultV1
 	decodeRealLaunchJSON(t, stdout, &applied)
 	if len(applied.Commands) != 2 {
-		t.Fatalf("exact-root commands = %#v", applied.Commands)
+		t.Fatalf("exact-root Apply = %#v", applied)
 	}
 	commands := make(map[string]launchapi.CommandV1, len(applied.Commands))
 	for _, command := range applied.Commands {

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -43,9 +43,11 @@ type AdapterCapabilities struct {
 }
 
 type PlanRequest struct {
-	Handle      string
-	ProjectRoot string
-	Cwd         string
+	Handle        string
+	ProjectRoot   string
+	SessionRoot   string
+	AMQExecutable string
+	Cwd           string
 	// AllowExternalCwd is reserved for the public intent compiler. Public
 	// intents can name an absolute sibling worktree after that path is
 	// canonicalized and physically identified. Committed project config keeps

--- a/internal/launch/adapter_codex.go
+++ b/internal/launch/adapter_codex.go
@@ -2,11 +2,13 @@ package launch
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
-const CodexThreadStartedV2 CaptureEvidenceSource = "codex_app_server_thread_started_v2"
+const CodexNotifyV1 CaptureEvidenceSource = "codex_notify_v1"
 
 const codexCaptureVersion = "0.147.0"
 
@@ -44,11 +46,9 @@ func (adapter *CodexAdapter) Capabilities(ctx context.Context) AdapterCapabiliti
 	}
 	help, helpErr := adapter.probe.Output(ctx, executable, "--help")
 	resumeHelp, resumeErr := adapter.probe.Output(ctx, executable, "resume", "--help")
-	appServerHelp, appServerErr := adapter.probe.Output(ctx, executable, "app-server", "--help")
-	if helpErr != nil || resumeErr != nil || appServerErr != nil ||
+	if helpErr != nil || resumeErr != nil ||
 		!strings.Contains(string(help), "resume") ||
-		!strings.Contains(string(resumeHelp), "[SESSION_ID]") ||
-		!strings.Contains(string(appServerHelp), "generate-json-schema") {
+		!strings.Contains(string(resumeHelp), "[SESSION_ID]") {
 		result.Reason = "identity_contract_unsupported"
 		return result
 	}
@@ -75,8 +75,13 @@ func (adapter *CodexAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) {
 	if err != nil {
 		return AgentPlan{}, err
 	}
+	notify, err := codexNotifyOverride(request)
+	if err != nil {
+		return AgentPlan{}, err
+	}
 	argv := append([]string{executable}, request.CommittedArgs...)
 	argv = append(argv, request.BypassArgs...)
+	argv = append(argv, "-c", notify)
 	plan := AgentPlan{
 		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
 		AdapterMode: AdapterModeCapture, ResumePolicy: request.ResumePolicy, LaunchNonce: request.LaunchNonce,
@@ -98,8 +103,13 @@ func (adapter *CodexAdapter) PlanResume(request ResumeRequest) (AgentPlan, error
 	if err != nil {
 		return AgentPlan{}, err
 	}
+	notify, err := codexNotifyOverride(request.PlanRequest)
+	if err != nil {
+		return AgentPlan{}, err
+	}
 	argv := append([]string{executable, "resume"}, request.CommittedArgs...)
 	argv = append(argv, request.BypassArgs...)
+	argv = append(argv, "-c", notify)
 	argv = append(argv, request.Conversation.ID)
 	plan := AgentPlan{
 		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
@@ -111,6 +121,33 @@ func (adapter *CodexAdapter) PlanResume(request ResumeRequest) (AgentPlan, error
 		return AgentPlan{}, err
 	}
 	return plan, nil
+}
+
+func codexNotifyOverride(request PlanRequest) (string, error) {
+	if strings.TrimSpace(request.AMQExecutable) == "" || strings.TrimSpace(request.SessionRoot) == "" {
+		return "", fmt.Errorf("codex notify capture requires an AMQ executable and session root")
+	}
+	amqExecutable, err := filepath.EvalSymlinks(request.AMQExecutable)
+	if err != nil {
+		return "", fmt.Errorf("resolve codex notify AMQ executable: %w", err)
+	}
+	amqExecutable, err = filepath.Abs(amqExecutable)
+	if err != nil {
+		return "", fmt.Errorf("make codex notify AMQ executable absolute: %w", err)
+	}
+	sessionRoot, err := resolvedPath(request.SessionRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve codex notify session root: %w", err)
+	}
+	command := []string{
+		amqExecutable, "__codex-notify", "--root", sessionRoot,
+		"--handle", request.Handle, "--nonce", request.LaunchNonce,
+	}
+	encoded, err := json.Marshal(command)
+	if err != nil {
+		return "", fmt.Errorf("encode codex notify override: %w", err)
+	}
+	return "notify=" + string(encoded), nil
 }
 
 func (adapter *CodexAdapter) CaptureIdentity(request CaptureRequest) CaptureResult {

--- a/internal/launch/adapter_codex.go
+++ b/internal/launch/adapter_codex.go
@@ -141,7 +141,7 @@ func codexNotifyOverride(request PlanRequest) (string, error) {
 	}
 	command := []string{
 		amqExecutable, "__codex-notify", "--root", sessionRoot,
-		"--handle", request.Handle, "--nonce", request.LaunchNonce,
+		"--handle", request.Handle,
 	}
 	encoded, err := json.Marshal(command)
 	if err != nil {

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -53,6 +53,7 @@ func testExecutable(t *testing.T, name string) (string, string) {
 func planRequest(project, handle string) PlanRequest {
 	return PlanRequest{
 		Handle: handle, ProjectRoot: project, Cwd: project,
+		SessionRoot: project, AMQExecutable: "/usr/bin/true",
 		LaunchNonce: testLaunchNonce, ResumePolicy: ResumeEnabled,
 		EnvOverlay: map[string]string{"LANG": "en_US.UTF-8", "TERM": "xterm-256color"},
 	}
@@ -77,13 +78,12 @@ func TestAdapterCapabilitiesProbeExactIdentityContracts(t *testing.T) {
 
 	codex := NewCodexAdapter("codex")
 	codex.probe = fakeCommandProbe{path: "/bin/codex", outputs: map[string]string{
-		"--version":         "codex-cli 0.147.0\n",
-		"--help":            "commands: resume",
-		"resume --help":     "Usage: codex resume [OPTIONS] [SESSION_ID]",
-		"app-server --help": "generate-json-schema",
+		"--version":     "codex-cli 0.147.0\n",
+		"--help":        "commands: resume",
+		"resume --help": "Usage: codex resume [OPTIONS] [SESSION_ID]",
 	}}
 	gotCodex := codex.Capabilities(context.Background())
-	if !gotCodex.Available || !gotCodex.Fresh || !gotCodex.Resume || !gotCodex.Capture || gotCodex.Mode != AdapterModeCapture {
+	if !gotCodex.Available || !gotCodex.Fresh || !gotCodex.Resume || !gotCodex.Capture || gotCodex.PreSpawnAcquire || gotCodex.Mode != AdapterModeCapture {
 		t.Fatalf("Codex capabilities = %#v", gotCodex)
 	}
 	if gotCodex.ProviderVersion != "0.147.0" {
@@ -95,7 +95,7 @@ func TestAdapterCapabilitiesProbeExactIdentityContracts(t *testing.T) {
 
 	codex.probe = fakeCommandProbe{path: "/bin/codex", outputs: map[string]string{
 		"--version": "codex-cli 0.147.0\n", "--help": "commands: resume",
-		"resume --help": "--last only", "app-server --help": "generate-json-schema",
+		"resume --help": "--last only",
 	}}
 	unsupported := codex.Capabilities(context.Background())
 	if unsupported.Available || unsupported.Reason != "identity_contract_unsupported" {
@@ -103,10 +103,10 @@ func TestAdapterCapabilitiesProbeExactIdentityContracts(t *testing.T) {
 	}
 	codex.probe = fakeCommandProbe{path: "/bin/codex", outputs: map[string]string{
 		"--version": "codex-cli 0.148.0\n", "--help": "commands: resume",
-		"resume --help": "Usage: codex resume [OPTIONS] [SESSION_ID]", "app-server --help": "generate-json-schema",
+		"resume --help": "Usage: codex resume [OPTIONS] [SESSION_ID]",
 	}}
 	untestedVersion := codex.Capabilities(context.Background())
-	if !untestedVersion.Available || !untestedVersion.Fresh || !untestedVersion.Resume || untestedVersion.Capture || untestedVersion.Reason != "capture_version_unsupported" {
+	if !untestedVersion.Available || !untestedVersion.Fresh || !untestedVersion.Resume || untestedVersion.Capture || untestedVersion.PreSpawnAcquire || untestedVersion.Reason != "capture_version_unsupported" {
 		t.Fatalf("untested Codex version capabilities = %#v", untestedVersion)
 	}
 	if err := ValidateAdapterCapabilities(codex, untestedVersion); err != nil {
@@ -169,7 +169,12 @@ func TestCodexPlansUseExactCaptureAndResumeShapes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if fresh.AdapterMode != AdapterModeCapture || fresh.ConversationID != "" || len(fresh.DynamicArgv) != 0 {
+	notify, err := codexNotifyOverride(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.AdapterMode != AdapterModeCapture || fresh.ConversationID != "" || fresh.PreSpawnAcquire ||
+		len(fresh.DynamicArgv) != 0 || !reflect.DeepEqual(fresh.Argv[len(fresh.Argv)-2:], []string{"-c", notify}) {
 		t.Fatalf("fresh plan = %#v", fresh)
 	}
 	resume, err := adapter.PlanResume(ResumeRequest{
@@ -221,6 +226,14 @@ func TestAdapterEnvAndArgGrammarFailsClosed(t *testing.T) {
 			}
 		})
 	}
+	t.Run("codex committed notify override", func(t *testing.T) {
+		codexProject, codexExecutable := testExecutable(t, CodexProvider)
+		request := planRequest(codexProject, CodexProvider)
+		request.CommittedArgs = []string{"-c", "notify=[]"}
+		if _, err := NewCodexAdapter(codexExecutable).PlanFresh(request); err == nil || !strings.Contains(err.Error(), "not allowed") {
+			t.Fatalf("PlanFresh error = %v, want committed notify refusal", err)
+		}
+	})
 }
 
 func TestAdapterRejectsProjectExecutableAndProviderMismatch(t *testing.T) {

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -177,6 +177,23 @@ func TestCodexPlansUseExactCaptureAndResumeShapes(t *testing.T) {
 		len(fresh.DynamicArgv) != 0 || !reflect.DeepEqual(fresh.Argv[len(fresh.Argv)-2:], []string{"-c", notify}) {
 		t.Fatalf("fresh plan = %#v", fresh)
 	}
+	otherRequest := request
+	otherRequest.LaunchNonce = "56565656-5656-4565-8565-565656565656"
+	otherFresh, err := adapter.PlanFresh(otherRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freshDigest, err := (Plan{Version: PlanVersion, Agents: []AgentPlan{fresh}}).SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherDigest, err := (Plan{Version: PlanVersion, Agents: []AgentPlan{otherFresh}}).SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if freshDigest != otherDigest || fresh.Argv[len(fresh.Argv)-1] != otherFresh.Argv[len(otherFresh.Argv)-1] {
+		t.Fatalf("codex notify changed the static trust subject across launch nonces: %s != %s", freshDigest, otherDigest)
+	}
 	resume, err := adapter.PlanResume(ResumeRequest{
 		PlanRequest:  request,
 		Conversation: ConversationIdentity{Provider: CodexProvider, ID: testConversationID},

--- a/internal/launch/adapter_tier1_live_test.go
+++ b/internal/launch/adapter_tier1_live_test.go
@@ -1,0 +1,743 @@
+package launch
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	claudeLiveVersion      = "2.1.233"
+	tier1LivePrompt        = "Reply with exactly AMQ_OK. Do not use tools."
+	claudeBootstrapPrompt  = "Reply with exactly AMQ_BOOTSTRAP_OK. Do not use tools."
+	tier1LivePrepareDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+
+func TestClaudeLiveManagedMintResumeAndCrashReuse(t *testing.T) {
+	if os.Getenv("AMQ_CLAUDE_LIVE") != "1" {
+		t.Skip("set AMQ_CLAUDE_LIVE=1 to create and resume one real Claude session")
+	}
+	requireTier1LiveTmux(t)
+	adapter := NewClaudeAdapter("claude")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	capabilities := adapter.Capabilities(ctx)
+	if !capabilities.Available || !capabilities.Fresh || !capabilities.Resume || capabilities.ProviderVersion != claudeLiveVersion {
+		t.Fatalf("Claude %s live capability is unavailable: %#v", claudeLiveVersion, capabilities)
+	}
+	trustedProject := claudeTrustedLiveProject(t)
+	fixture := newTier1LiveFixture(t, tier1LiveFixtureRequest{
+		handle: "claude", provider: ClaudeProvider, providerVersion: capabilities.ProviderVersion,
+		executable: capabilities.Executable, nonce: "86868686-8686-4686-8686-868686868686", mode: AdapterModeMint,
+		projectRoot: trustedProject, target: claudeTier1LiveTarget,
+	})
+	backend, created := startTier1LiveManagedProcess(t, fixture)
+	ticket := waitForTier1LiveTicket(t, backend, fixture.root, fixture.handle, fixture.nonce)
+	if ticket.ConversationID != fixture.nonce {
+		t.Fatalf("Claude ticket identity = %q, want launch nonce %q", ticket.ConversationID, fixture.nonce)
+	}
+	argv := tier1LiveDescendantArgv(t, backend, filepath.Base(capabilities.Executable), "--session-id", fixture.nonce)
+	t.Logf("Claude unused-mint managed argv: %s", argv)
+	closeTier1LiveProcess(t, backend, created, fixture.root)
+
+	if err := RevertExecution(fixture.root, fixture.handle, fixture.nonce); err != nil {
+		t.Fatal(err)
+	}
+	assertClaudeUnusedMintStaleAction(t, fixture, capabilities.Executable)
+
+	bootstrap := newTier1LiveFixture(t, tier1LiveFixtureRequest{
+		handle: "claude", provider: ClaudeProvider, providerVersion: capabilities.ProviderVersion,
+		executable: capabilities.Executable, nonce: fixture.nonce, mode: AdapterModeMint,
+		projectRoot: trustedProject, target: claudeTier1BootstrapTarget,
+	})
+	bootstrapBackend, bootstrapCreated := startTier1LiveManagedProcess(t, bootstrap)
+	bootstrapTicket := waitForTier1LiveTicket(t, bootstrapBackend, bootstrap.root, bootstrap.handle, bootstrap.nonce)
+	bootstrapArgv := tier1LiveDescendantArgv(t, bootstrapBackend, filepath.Base(capabilities.Executable), "--session-id", bootstrap.nonce, claudeBootstrapPrompt)
+	t.Logf("Claude bootstrapped managed argv: %s", bootstrapArgv)
+	waitForClaudeLiveSessionRecord(t, bootstrap.project, bootstrap.nonce)
+	closeTier1LiveProcess(t, bootstrapBackend, bootstrapCreated, bootstrap.root)
+
+	if err := RevertExecution(bootstrap.root, bootstrap.handle, bootstrap.nonce); err != nil {
+		t.Fatal(err)
+	}
+	retried, err := PrepareExecution(bootstrap.root, bootstrap.handle, bootstrap.nonce, bootstrap.envelope)
+	if err != nil || retried.State != ExecutionAcknowledged || retried.ConversationID != fixture.nonce {
+		t.Fatalf("Claude crash retry = %#v, %v", retried, err)
+	}
+	if bootstrapTicket.ConversationID != fixture.nonce {
+		t.Fatalf("Claude bootstrap ticket identity = %q, want %q", bootstrapTicket.ConversationID, fixture.nonce)
+	}
+	claudeLiveResume(t, capabilities.Executable, bootstrap.project, fixture.nonce)
+}
+
+func TestCodexLiveManagedAcquireResumeAndCrashReuse(t *testing.T) {
+	if os.Getenv("AMQ_CODEX_LIVE") != "1" {
+		t.Skip("set AMQ_CODEX_LIVE=1 to create and resume one real Codex thread")
+	}
+	requireTier1LiveTmux(t)
+	adapter := NewCodexAdapter("codex")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	capabilities := adapter.Capabilities(ctx)
+	if !capabilities.Available || !capabilities.Fresh || !capabilities.Resume || !capabilities.Capture || capabilities.PreSpawnAcquire || capabilities.ProviderVersion != codexCaptureVersion {
+		t.Fatalf("Codex %s live capture capability is unavailable: %#v", codexCaptureVersion, capabilities)
+	}
+	trustedProject := codexTrustedLiveProject(t)
+	pending := newTier1LiveFixture(t, tier1LiveFixtureRequest{
+		handle: "codex", provider: CodexProvider, providerVersion: capabilities.ProviderVersion,
+		executable: capabilities.Executable, nonce: "87878787-8787-4787-8787-878787878786", mode: AdapterModeCapture,
+		projectRoot: trustedProject, target: codexTier1LiveTarget,
+	})
+	pendingBackend, pendingCreated := startTier1LiveManagedProcess(t, pending)
+	_ = waitForCodexLiveTicket(t, pendingBackend, pending.root, pending.handle, pending.nonce)
+	pendingArgv := tier1LiveDescendantArgv(t, pendingBackend, filepath.Base(capabilities.Executable), "notify=")
+	t.Logf("Codex pending managed argv: %s", pendingArgv)
+	closeTier1LiveProcess(t, pendingBackend, pendingCreated, pending.root)
+	if err := RevertExecution(pending.root, pending.handle, pending.nonce); err != nil {
+		t.Fatal(err)
+	}
+	assertCodexPendingStaleAction(t, pending, capabilities.Executable)
+
+	fixture := newTier1LiveFixture(t, tier1LiveFixtureRequest{
+		handle: "codex", provider: CodexProvider, providerVersion: capabilities.ProviderVersion,
+		executable: capabilities.Executable, nonce: "87878787-8787-4787-8787-878787878787", mode: AdapterModeCapture,
+		projectRoot: trustedProject, target: codexTier1LiveTarget,
+	})
+	backend, created := startTier1LiveManagedProcess(t, fixture)
+	_ = waitForCodexLiveTicket(t, backend, fixture.root, fixture.handle, fixture.nonce)
+	_ = tier1LiveDescendantArgv(t, backend, filepath.Base(capabilities.Executable), "notify=")
+	waitForCodexLivePrompt(t, backend)
+	ctx, sendCancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer sendCancel()
+	if _, err := backend.run(ctx, backend.args("send-keys", "-l", tier1LivePrompt)...); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.run(ctx, backend.args("send-keys", "Enter")...); err != nil {
+		t.Fatal(err)
+	}
+	record := waitForCodexLiveConversation(t, backend, fixture.root, fixture.handle)
+	evidenceRecord, _, err := ReadEvidence(fixture.root, record.EvidenceRefs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := decodeCodexNotifyPayload(evidenceRecord.Payload)
+	if err != nil || payload.ConversationID != record.Identity.ID || payload.LaunchNonce != fixture.nonce || payload.Handle != fixture.handle {
+		t.Fatalf("Codex provider evidence = %#v, %v", payload, err)
+	}
+	argv := tier1LiveDescendantArgv(t, backend, filepath.Base(capabilities.Executable), "notify=")
+	t.Logf("Codex managed argv: %s", argv)
+	closeTier1LiveProcess(t, backend, created, fixture.root)
+	codexLiveResume(t, capabilities.Executable, fixture.project, record.Identity.ID)
+}
+
+type tier1LiveFixtureRequest struct {
+	handle, provider, providerVersion, executable, nonce, projectRoot string
+	mode                                                              AdapterMode
+	preSpawn                                                          bool
+	target                                                            func(string, string, string, string, string) ([]string, []DynamicArg, error)
+}
+
+type tier1LiveFixture struct {
+	handle, project, amq, nonce string
+	root                        *fsq.DeliveryRoot
+	ticket                      ExecutionTicket
+	envelope                    ExecutionEnvelope
+}
+
+func TestTier1LiveHarnessTicketsValidateWithVersionManagerSymlinks(t *testing.T) {
+	_, claude := testExecutable(t, ClaudeProvider)
+	claudeFixture := newTier1LiveFixture(t, tier1LiveFixtureRequest{
+		handle: "claude", provider: ClaudeProvider, providerVersion: claudeLiveVersion,
+		executable: claude, nonce: "89898989-8989-4989-8989-898989898989", mode: AdapterModeMint,
+		target: claudeTier1LiveTarget,
+	})
+	if err := claudeFixture.ticket.Validate(); err != nil {
+		t.Fatalf("Claude live harness ticket: %v", err)
+	}
+	claudePrepared, err := PrepareExecution(claudeFixture.root, claudeFixture.handle, claudeFixture.nonce, claudeFixture.envelope)
+	if err != nil || claudePrepared.State != ExecutionAcknowledged {
+		t.Fatalf("Claude live harness prepare = %#v, %v", claudePrepared, err)
+	}
+	if err := RevertExecution(claudeFixture.root, claudeFixture.handle, claudeFixture.nonce); err != nil {
+		t.Fatal(err)
+	}
+	assertClaudeUnusedMintStaleAction(t, claudeFixture, claude)
+	bootstrapArgv, bootstrapDynamic, err := claudeTier1BootstrapTarget(claude, claudeFixture.nonce, claudeFixture.project, claudeFixture.amq, "")
+	if err != nil || bootstrapArgv[len(bootstrapArgv)-1] != claudeBootstrapPrompt ||
+		len(bootstrapDynamic) != 1 || bootstrapArgv[bootstrapDynamic[0].Index] != claudeFixture.nonce {
+		t.Fatalf("Claude bootstrap target = %q %#v, %v", bootstrapArgv, bootstrapDynamic, err)
+	}
+
+	_, codex := testExecutable(t, CodexProvider)
+	codexFixture := newTier1LiveFixture(t, tier1LiveFixtureRequest{
+		handle: "codex", provider: CodexProvider, providerVersion: codexCaptureVersion,
+		executable: codex, nonce: "90909090-9090-4090-8090-909090909090", mode: AdapterModeCapture,
+		target: codexTier1LiveTarget,
+	})
+	if err := codexFixture.ticket.Validate(); err != nil {
+		t.Fatalf("Codex live harness ticket: %v", err)
+	}
+	codexPrepared, err := PrepareExecution(codexFixture.root, codexFixture.handle, codexFixture.nonce, codexFixture.envelope)
+	if err != nil || codexPrepared.State != ExecutionSpawnAttempted {
+		t.Fatalf("Codex live harness prepare = %#v, %v", codexPrepared, err)
+	}
+}
+
+func claudeTier1LiveTarget(executable, nonce, project, _, _ string) ([]string, []DynamicArg, error) {
+	plan, err := NewClaudeAdapter(executable).PlanFresh(PlanRequest{
+		Handle: "claude", ProjectRoot: project, Cwd: project, LaunchNonce: nonce, ResumePolicy: ResumeFresh,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	argv := append([]string{plan.Argv[0], "--tools=", "--permission-mode", "plan"}, plan.Argv[1:]...)
+	return argv, []DynamicArg{{Index: len(argv) - 1, Kind: DynamicArgLaunchNonce}}, nil
+}
+
+func claudeTier1BootstrapTarget(executable, nonce, project, amq, session string) ([]string, []DynamicArg, error) {
+	argv, dynamic, err := claudeTier1LiveTarget(executable, nonce, project, amq, session)
+	if err != nil {
+		return nil, nil, err
+	}
+	return append(argv, claudeBootstrapPrompt), dynamic, nil
+}
+
+func codexTier1LiveTarget(executable, nonce, project, amq, session string) ([]string, []DynamicArg, error) {
+	plan, err := NewCodexAdapter(executable).PlanFresh(PlanRequest{
+		Handle: "codex", ProjectRoot: project, Cwd: project, SessionRoot: session, AMQExecutable: amq,
+		LaunchNonce: nonce, ResumePolicy: ResumeFresh,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	argv := append([]string(nil), plan.Argv...)
+	argv = append(argv, "--sandbox", "read-only")
+	return argv, nil, nil
+}
+
+func newTier1LiveFixture(t *testing.T, request tier1LiveFixtureRequest) tier1LiveFixture {
+	t.Helper()
+	project := request.projectRoot
+	if project == "" {
+		project = t.TempDir()
+		git := exec.Command("git", "init", "--quiet")
+		git.Dir = project
+		if output, err := git.CombinedOutput(); err != nil {
+			t.Fatalf("initialize live project: %v\n%s", err, output)
+		}
+	}
+	session := filepath.Join(t.TempDir(), "collab")
+	if err := fsq.EnsureAgentDirs(session, request.handle); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	moduleCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	moduleRoot := filepath.Clean(filepath.Join(moduleCwd, "..", ".."))
+	amq := filepath.Join(t.TempDir(), "amq")
+	build := exec.Command("go", "build", "-o", amq, "./cmd/amq")
+	build.Dir = moduleRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build live amq executable: %v\n%s", err, output)
+	}
+	targetAMQ, err := filepath.EvalSymlinks(amq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetSession, err := filepath.EvalSymlinks(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetArgv, dynamicArgv, err := request.target(request.executable, request.nonce, project, targetAMQ, targetSession)
+	if err != nil {
+		t.Fatalf("build %s adapter plan: %v", request.provider, err)
+	}
+	executable, err := filepath.EvalSymlinks(request.executable)
+	if err != nil {
+		t.Fatalf("resolve %s executable: %v", request.provider, err)
+	}
+	options := &PrepareExecutionOptions{WakeMode: "disabled", AuditReason: request.provider + " tier-1 live proof"}
+	conversationID := ""
+	if request.mode == AdapterModeMint {
+		conversationID = request.nonce
+	}
+	backend, profile := "", ""
+	if request.preSpawn || (request.provider == CodexProvider && request.mode == AdapterModeCapture) {
+		backend, profile = LauncherTMux, TmuxProfile().Identity()
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: request.handle, LaunchNonce: request.nonce, Mode: request.mode, Provider: request.provider,
+		ProviderVersion: request.providerVersion, ConversationID: conversationID,
+		PreSpawnAcquire: request.preSpawn, Backend: backend, Profile: profile,
+		ProjectRoot: project, SessionRoot: session, Cwd: project, ProviderExecutable: executable, AMQExecutable: amq,
+		TargetArgv: targetArgv, DynamicArgv: dynamicArgv, Execution: options,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := AcquireLease(root, request.nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles(request.handle); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: request.handle, State: CapturePending,
+		ProviderVersion: request.providerVersion, LaunchNonce: request.nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	envelope := ExecutionEnvelope{
+		Cwd: project, AMQExecutable: amq, ProviderExecutable: executable,
+		TargetArgv: targetArgv, Execution: options,
+	}
+	return tier1LiveFixture{handle: request.handle, project: project, amq: amq, nonce: request.nonce, root: root, ticket: ticket, envelope: envelope}
+}
+
+func startTier1LiveManagedProcess(t *testing.T, fixture tier1LiveFixture) (*TmuxBackend, CreateResult) {
+	t.Helper()
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-%s-live-%d-%d", fixture.handle, os.Getpid(), time.Now().UnixNano())
+	t.Cleanup(func() { stopTmuxTestServer(t, backend) })
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	if _, err := backend.run(ctx, backend.args(
+		"start-server", ";", "set-option", "-g", "exit-empty", "off", ";", "set-window-option", "-g", "remain-on-exit", "on",
+	)...); err != nil {
+		t.Fatalf("configure live diagnostic tmux server: %v", err)
+	}
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{{
+		Handle: fixture.handle, Argv: fixture.ticket.TargetArgv, DynamicArgv: fixture.ticket.DynamicArgv,
+		Cwd: fixture.project, AdapterMode: fixture.ticket.Mode, ResumePolicy: ResumeFresh,
+		LaunchNonce: fixture.nonce, ConversationID: fixture.ticket.ConversationID,
+		PreSpawnAcquire: fixture.ticket.PreSpawnAcquire, Execution: fixture.ticket.Execution,
+	}}}
+	created, err := backend.Create(CreateRequest{ProjectRoot: fixture.project, Session: "collab", Plan: plan, AMQPath: fixture.amq, Root: fixture.root})
+	if err != nil || created.Outcome != OutcomeCreated {
+		t.Fatalf("managed tmux/coop-exec create = %#v, %v", created, err)
+	}
+	return backend, created
+}
+
+func waitForTier1LiveTicket(t *testing.T, backend *TmuxBackend, root *fsq.DeliveryRoot, handle, nonce string) ExecutionTicket {
+	return waitForTier1LiveTicketState(t, backend, root, handle, nonce, ExecutionAcknowledged)
+}
+
+func waitForCodexLiveTicket(t *testing.T, backend *TmuxBackend, root *fsq.DeliveryRoot, handle, nonce string) ExecutionTicket {
+	return waitForTier1LiveTicketState(t, backend, root, handle, nonce, ExecutionSpawnAttempted)
+}
+
+func waitForTier1LiveTicketState(t *testing.T, backend *TmuxBackend, root *fsq.DeliveryRoot, handle, nonce string, state ExecutionState) ExecutionTicket {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	var last ExecutionTicket
+	var lastErr error
+	for time.Now().Before(deadline) {
+		last, lastErr = LoadExecutionTicket(root, handle)
+		if lastErr == nil && last.LaunchNonce == nonce && last.State == state {
+			return last
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	diagnostic := ""
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	if output, err := backend.run(ctx, backend.args("capture-pane", "-p", "-S", "-200")...); err == nil {
+		diagnostic = strings.TrimSpace(output)
+	} else {
+		diagnostic = "capture pane: " + err.Error()
+	}
+	t.Fatalf("wait for managed %s state %s: ticket=%#v error=%v\npane:\n%s", handle, state, last, lastErr, diagnostic)
+	return ExecutionTicket{}
+}
+
+func waitForCodexLiveConversation(t *testing.T, backend *TmuxBackend, root *fsq.DeliveryRoot, handle string) ConversationRecord {
+	t.Helper()
+	deadline := time.Now().Add(45 * time.Second)
+	var last ConversationRecord
+	var lastErr error
+	for time.Now().Before(deadline) {
+		last, lastErr = LoadConversation(root, handle)
+		if lastErr == nil && last.State == CaptureReady && last.Identity.Provider == CodexProvider &&
+			validUUIDv7(last.Identity.ID) && len(last.EvidenceRefs) == 1 {
+			return last
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	diagnostic := ""
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	if output, err := backend.run(ctx, backend.args("capture-pane", "-p", "-S", "-200")...); err == nil {
+		diagnostic = strings.TrimSpace(output)
+	} else {
+		diagnostic = "capture pane: " + err.Error()
+	}
+	t.Fatalf("wait for Codex notify promotion: record=%#v error=%v\npane:\n%s", last, lastErr, diagnostic)
+	return ConversationRecord{}
+}
+
+func waitForCodexLivePrompt(t *testing.T, backend *TmuxBackend) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	last := ""
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+		output, err := backend.run(ctx, backend.args("capture-pane", "-p", "-S", "-80")...)
+		cancel()
+		if err == nil {
+			last = output
+			if strings.Contains(output, "OpenAI Codex") && strings.Contains(output, "›") &&
+				strings.LastIndex(output, "model:") > strings.LastIndex(output, "model:     loading") {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("Codex live prompt did not become ready:\n%s", strings.TrimSpace(last))
+}
+
+func tier1LiveDescendantArgv(t *testing.T, backend *TmuxBackend, required ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	output, err := backend.run(ctx, backend.args("list-panes", "-a", "-F", "#{pane_pid}")...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	panePID, err := strconv.Atoi(strings.TrimSpace(output))
+	if err != nil || panePID <= 0 {
+		t.Fatalf("managed pane pid = %q", strings.TrimSpace(output))
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		processes, psErr := exec.Command("ps", "-ww", "-axo", "pid=,ppid=,command=").Output()
+		if psErr == nil {
+			if found := findTier1LiveDescendantArgv(processes, panePID, required...); found != "" {
+				return found
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("managed descendant never exposed required argv %q", required)
+	return ""
+}
+
+func findTier1LiveDescendantArgv(output []byte, panePID int, required ...string) string {
+	type process struct {
+		parent int
+		argv   string
+	}
+	processes := make(map[int]process)
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 3 {
+			continue
+		}
+		pid, pidErr := strconv.Atoi(fields[0])
+		parent, parentErr := strconv.Atoi(fields[1])
+		if pidErr == nil && parentErr == nil {
+			processes[pid] = process{parent: parent, argv: strings.Join(fields[2:], " ")}
+		}
+	}
+	for pid, candidate := range processes {
+		matches := true
+		for _, requiredPart := range required {
+			matches = matches && strings.Contains(candidate.argv, requiredPart)
+		}
+		if !matches {
+			continue
+		}
+		for current := pid; current > 0; current = processes[current].parent {
+			if current == panePID {
+				return candidate.argv
+			}
+			if _, ok := processes[current]; !ok {
+				break
+			}
+		}
+	}
+	return ""
+}
+
+func closeTier1LiveProcess(t *testing.T, backend *TmuxBackend, created CreateResult, root *fsq.DeliveryRoot) {
+	t.Helper()
+	closed, err := backend.Close(CloseRequest{Binding: created.Binding, Root: root})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("close managed process = %#v, %v", closed, err)
+	}
+}
+
+func assertClaudeUnusedMintStaleAction(t *testing.T, fixture tier1LiveFixture, executable string) {
+	t.Helper()
+	ticket, err := LoadExecutionTicket(fixture.root, fixture.handle)
+	if err != nil || ticket.State != ExecutionPending || ticket.ConversationID != fixture.nonce {
+		t.Fatalf("unused Claude mint ticket = %#v, %v", ticket, err)
+	}
+	backend := Commands{}
+	detect := backend.Detect()
+	result, err := Prepare(context.Background(), PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: fixture.project, SessionRoot: fixture.root.Base(), Session: "collab"},
+		Launcher: CommandsBackendName, IntentDigest: tier1LivePrepareDigest,
+		Participants: []PrepareParticipant{{
+			Handle: fixture.handle, Runnable: true, Provider: ClaudeProvider, Executable: executable,
+			Cwd: fixture.project, ResumePolicy: ResumeEnabled, Execution: PrepareExecutionOptions{WakeMode: "disabled"},
+		}},
+	}, PrepareDependencies{
+		Backends: map[string]Backend{CommandsBackendName: backend}, Preferences: []string{CommandsBackendName},
+		AdapterFor:   func(_ string, executable string) HarnessAdapter { return NewClaudeAdapter(executable) },
+		HostIdentity: detect.HostIdentity,
+	})
+	if err != nil {
+		t.Fatalf("prepare unused Claude mint: %v", err)
+	}
+	for _, action := range result.RequiredActions {
+		if action.Kind == ActionStaleConversation && len(action.Handles) == 1 && action.Handles[0] == fixture.handle &&
+			reflect.DeepEqual(action.AllowedDecisions, []string{"fresh_once", "abort"}) {
+			t.Logf("Claude unused mint typed action: kind=%s handle=%s conversation_id=%s", action.Kind, fixture.handle, ticket.ConversationID)
+			return
+		}
+	}
+	t.Fatalf("unused Claude mint required actions = %#v", result.RequiredActions)
+}
+
+func assertCodexPendingStaleAction(t *testing.T, fixture tier1LiveFixture, executable string) {
+	t.Helper()
+	record, err := LoadConversation(fixture.root, fixture.handle)
+	if err != nil || record.State != CapturePending || record.Identity.ID != "" || len(record.EvidenceRefs) != 0 {
+		t.Fatalf("pending Codex conversation = %#v, %v", record, err)
+	}
+	backend := Commands{}
+	detect := backend.Detect()
+	result, err := Prepare(context.Background(), PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: fixture.project, SessionRoot: fixture.root.Base(), Session: "collab"},
+		Launcher: CommandsBackendName, IntentDigest: tier1LivePrepareDigest,
+		Participants: []PrepareParticipant{{
+			Handle: fixture.handle, Runnable: true, Provider: CodexProvider, Executable: executable,
+			Cwd: fixture.project, ResumePolicy: ResumeEnabled, Execution: PrepareExecutionOptions{WakeMode: "disabled"},
+		}},
+	}, PrepareDependencies{
+		Backends: map[string]Backend{CommandsBackendName: backend}, Preferences: []string{CommandsBackendName},
+		AdapterFor:   func(_ string, executable string) HarnessAdapter { return NewCodexAdapter(executable) },
+		HostIdentity: detect.HostIdentity,
+	})
+	if err != nil {
+		t.Fatalf("prepare pending Codex conversation: %v", err)
+	}
+	for _, action := range result.RequiredActions {
+		if action.Kind == ActionStaleConversation && len(action.Handles) == 1 && action.Handles[0] == fixture.handle &&
+			reflect.DeepEqual(action.AllowedDecisions, []string{"fresh_once", "abort"}) {
+			t.Logf("Codex pending typed action: kind=%s handle=%s", action.Kind, fixture.handle)
+			return
+		}
+	}
+	t.Fatalf("pending Codex required actions = %#v", result.RequiredActions)
+}
+
+func waitForClaudeLiveSessionRecord(t *testing.T, project, sessionID string) {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectKey := strings.ReplaceAll(filepath.Clean(project), string(filepath.Separator), "-")
+	record := filepath.Join(home, ".claude", "projects", projectKey, sessionID+".jsonl")
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		info, statErr := os.Stat(record)
+		if statErr == nil && info.Mode().IsRegular() && info.Size() > 0 {
+			t.Logf("Claude provider session record: %s", record)
+			return
+		}
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("inspect Claude provider session record: %v", statErr)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("Claude provider session record did not appear for %s", sessionID)
+}
+
+func claudeTrustedLiveProject(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command("git", "rev-parse", "--git-common-dir")
+	command.Dir = cwd
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("resolve trusted Claude project: %v", err)
+	}
+	common := strings.TrimSpace(string(output))
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(cwd, common)
+	}
+	common, err = filepath.Abs(common)
+	if err != nil || filepath.Base(common) != ".git" {
+		t.Fatalf("git common directory = %q, %v", common, err)
+	}
+	project := filepath.Dir(common)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	if err != nil {
+		t.Fatalf("read Claude trust state: %v", err)
+	}
+	var config struct {
+		Projects map[string]json.RawMessage `json:"projects"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("decode Claude trust state: %v", err)
+	}
+	if _, trusted := config.Projects[project]; !trusted {
+		t.Fatalf("Claude live project %q is not already trusted", project)
+	}
+	t.Logf("Claude trusted live project: %s", project)
+	return project
+}
+
+func codexTrustedLiveProject(t *testing.T) string {
+	t.Helper()
+	command := exec.Command("git", "rev-parse", "--path-format=absolute", "--git-common-dir")
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("resolve Codex trusted checkout: %v", err)
+	}
+	project := filepath.Dir(strings.TrimSpace(string(output)))
+	if info, err := os.Stat(filepath.Join(project, ".git")); err != nil || !info.IsDir() {
+		t.Fatalf("Codex trusted checkout is invalid: %s", project)
+	}
+	return project
+}
+
+func claudeLiveResume(t *testing.T, executable, cwd, sessionID string) {
+	t.Helper()
+	argv := []string{"-p", "--resume", sessionID, "--output-format", "json", "--tools=", "--permission-mode", "plan", tier1LivePrompt}
+	t.Logf("Claude headless resume argv: %q %q", executable, argv)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	command := exec.CommandContext(ctx, executable, argv...)
+	command.Dir = cwd
+	var stdout, stderr bytes.Buffer
+	command.Stdout, command.Stderr = &stdout, &stderr
+	err := command.Run()
+	if err != nil {
+		t.Fatalf("Claude headless resume: %v\n%s", err, stderr.String())
+	}
+	var response struct {
+		SessionID string `json:"session_id"`
+		IsError   bool   `json:"is_error"`
+		Result    string `json:"result"`
+	}
+	decoder := json.NewDecoder(&stdout)
+	if err := decoder.Decode(&response); err != nil {
+		t.Fatalf("decode Claude headless result: %v\n%s", err, stdout.String())
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("Claude headless result has trailing JSON: %v", err)
+	}
+	if response.IsError || response.SessionID != sessionID || strings.TrimSpace(response.Result) != "AMQ_OK" {
+		t.Fatalf("Claude headless result = %#v", response)
+	}
+}
+
+func codexLiveResume(t *testing.T, executable, cwd, threadID string) {
+	t.Helper()
+	argv := []string{"exec", "--json", "--sandbox", "read-only", "resume", threadID, tier1LivePrompt}
+	t.Logf("Codex headless resume argv: %q %q", executable, argv)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	command := exec.CommandContext(ctx, executable, argv...)
+	command.Dir = cwd
+	var stdout, stderr bytes.Buffer
+	command.Stdout, command.Stderr = &stdout, &stderr
+	err := command.Run()
+	if err != nil {
+		t.Fatalf("Codex headless resume: %v\n%s", err, stderr.String())
+	}
+	var started, completed bool
+	var answer string
+	scanner := bufio.NewScanner(&stdout)
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	for scanner.Scan() {
+		var event struct {
+			Type     string `json:"type"`
+			ThreadID string `json:"thread_id"`
+			Item     struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"item"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			t.Fatalf("decode Codex JSONL event: %v\n%s", err, scanner.Bytes())
+		}
+		switch event.Type {
+		case "thread.started":
+			if started || event.ThreadID != threadID {
+				t.Fatalf("Codex thread.started = %#v, want exact %s", event, threadID)
+			}
+			started = true
+		case "turn.completed":
+			completed = true
+		case "turn.failed", "error":
+			t.Fatalf("Codex resume failure event: %s", scanner.Bytes())
+		case "item.started", "item.completed":
+			switch event.Item.Type {
+			case "agent_message":
+				if event.Type == "item.completed" {
+					answer = event.Item.Text
+				}
+			case "reasoning":
+			default:
+				t.Fatalf("Codex resume emitted a non-message tool item: %s", scanner.Bytes())
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !started || !completed || strings.TrimSpace(answer) != "AMQ_OK" {
+		t.Fatalf("Codex headless proof incomplete: started=%t completed=%t answer=%q", started, completed, answer)
+	}
+}
+
+func requireTier1LiveTmux(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+}

--- a/internal/launch/capture.go
+++ b/internal/launch/capture.go
@@ -1,10 +1,8 @@
 package launch
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -77,48 +75,101 @@ type cursorCreateChatPayload struct {
 	Stdout          string                `json:"stdout"`
 }
 
+const CodexNotifyPayloadLimit = 1 << 20
+
+type codexNotifyEvent struct {
+	Type                 string   `json:"type"`
+	ThreadID             string   `json:"thread-id"`
+	TurnID               string   `json:"turn-id"`
+	Cwd                  string   `json:"cwd"`
+	Client               *string  `json:"client,omitempty"`
+	InputMessages        []string `json:"input-messages"`
+	LastAssistantMessage *string  `json:"last-assistant-message,omitempty"`
+}
+
+type codexNotifyPayload struct {
+	Source          CaptureEvidenceSource `json:"source"`
+	Provider        string                `json:"provider"`
+	ProviderVersion string                `json:"provider_version"`
+	LaunchNonce     string                `json:"launch_nonce"`
+	Handle          string                `json:"handle"`
+	ConversationID  string                `json:"conversation_id"`
+	Cwd             string                `json:"cwd"`
+	Notification    string                `json:"notification"`
+}
+
 func (result CaptureResult) CanPersist() bool {
 	return result.State == CaptureReady && !result.Degraded && result.Identity.Provider != "" && result.Identity.ID != ""
 }
 
-// ParseCodexThreadStartedEvidence verifies the provider event shape and binds
-// the observation to the launch generation of the channel that received it.
-// It does not scan the Codex session store or accept newest-file evidence.
-func ParseCodexThreadStartedEvidence(raw []byte, launchNonce string, activeElsewhere bool) (CaptureEvidence, error) {
+// ParseCodexNotifyEvidence verifies the pinned Codex legacy notify wire shape
+// and binds it to the exact managed launch generation. It does not scan the
+// Codex session store or accept newest-file evidence.
+func ParseCodexNotifyEvidence(raw []byte, launchNonce, handle, expectedVersion, expectedCwd string) (CaptureEvidence, error) {
+	if len(raw) == 0 || len(raw) > CodexNotifyPayloadLimit {
+		return CaptureEvidence{}, fmt.Errorf("codex notify payload size is invalid")
+	}
 	if !validUUID(launchNonce) {
 		return CaptureEvidence{}, fmt.Errorf("launch nonce must be a UUID")
 	}
-	var event struct {
-		Method string `json:"method"`
-		Params struct {
-			Thread struct {
-				ID         string `json:"id"`
-				CLIVersion string `json:"cliVersion"`
-			} `json:"thread"`
-		} `json:"params"`
+	if err := fsq.ValidateHandle(handle); err != nil {
+		return CaptureEvidence{}, fmt.Errorf("invalid capture handle: %w", err)
 	}
-	decoder := json.NewDecoder(bytes.NewReader(raw))
-	if err := decoder.Decode(&event); err != nil {
-		return CaptureEvidence{}, fmt.Errorf("decode Codex capture evidence: %w", err)
+	if expectedVersion != codexCaptureVersion {
+		return CaptureEvidence{}, fmt.Errorf("codex capture version %q is unsupported", expectedVersion)
 	}
-	if err := decoder.Decode(&struct{}{}); err != io.EOF {
-		return CaptureEvidence{}, fmt.Errorf("decode Codex capture evidence: trailing JSON value")
+	var event codexNotifyEvent
+	if err := decodeStrict(raw, &event); err != nil {
+		return CaptureEvidence{}, fmt.Errorf("decode Codex notify evidence: %w", err)
 	}
-	if event.Method != "thread/started" {
-		return CaptureEvidence{}, fmt.Errorf("codex capture evidence method is %q, want thread/started", event.Method)
+	if event.Type != "agent-turn-complete" {
+		return CaptureEvidence{}, fmt.Errorf("codex notify type is %q, want agent-turn-complete", event.Type)
 	}
-	if !validUUIDv7(event.Params.Thread.ID) {
-		return CaptureEvidence{}, fmt.Errorf("codex thread/started identity must be a UUIDv7")
+	if !validUUIDv7(event.ThreadID) {
+		return CaptureEvidence{}, fmt.Errorf("codex notify thread identity must be a UUIDv7")
 	}
-	if strings.TrimSpace(event.Params.Thread.CLIVersion) == "" {
-		return CaptureEvidence{}, fmt.Errorf("codex thread/started evidence has no CLI version")
+	if strings.TrimSpace(event.TurnID) == "" {
+		return CaptureEvidence{}, fmt.Errorf("codex notify turn identity is empty")
+	}
+	if event.Cwd != expectedCwd {
+		return CaptureEvidence{}, fmt.Errorf("codex notify cwd does not match execution ticket")
+	}
+	if event.InputMessages == nil {
+		return CaptureEvidence{}, fmt.Errorf("codex notify input-messages is missing")
+	}
+	payload, err := json.Marshal(codexNotifyPayload{
+		Source: CodexNotifyV1, Provider: CodexProvider, ProviderVersion: expectedVersion,
+		LaunchNonce: launchNonce, Handle: handle, ConversationID: event.ThreadID,
+		Cwd: expectedCwd, Notification: string(raw),
+	})
+	if err != nil {
+		return CaptureEvidence{}, err
 	}
 	return CaptureEvidence{
-		source: CodexThreadStartedV2, provider: CodexProvider,
-		providerVersion: event.Params.Thread.CLIVersion, launchNonce: launchNonce,
-		conversationID: event.Params.Thread.ID, activeElsewhere: activeElsewhere,
-		verified: true, observedAt: time.Now().UTC(), payload: bytes.Clone(raw),
+		source: CodexNotifyV1, provider: CodexProvider,
+		providerVersion: expectedVersion, launchNonce: launchNonce, handle: handle,
+		conversationID: event.ThreadID,
+		verified:       true, observedAt: time.Now().UTC(), payload: payload,
 	}, nil
+}
+
+func decodeCodexNotifyPayload(raw []byte) (codexNotifyPayload, error) {
+	var payload codexNotifyPayload
+	if err := decodeStrict(raw, &payload); err != nil {
+		return payload, fmt.Errorf("decode codex notify evidence: %w", err)
+	}
+	if payload.Source != CodexNotifyV1 || payload.Provider != CodexProvider ||
+		payload.ProviderVersion != codexCaptureVersion || !validUUID(payload.LaunchNonce) {
+		return payload, fmt.Errorf("codex notify evidence metadata is invalid")
+	}
+	if err := fsq.ValidateHandle(payload.Handle); err != nil {
+		return payload, fmt.Errorf("codex notify evidence handle: %w", err)
+	}
+	parsed, err := ParseCodexNotifyEvidence([]byte(payload.Notification), payload.LaunchNonce, payload.Handle, payload.ProviderVersion, payload.Cwd)
+	if err != nil || parsed.conversationID != payload.ConversationID {
+		return payload, fmt.Errorf("codex notify evidence identity is invalid")
+	}
+	return payload, nil
 }
 
 // ParseCursorCreateChatEvidence validates the exact stdout returned by the
@@ -191,7 +242,7 @@ func captureCodexIdentity(request CaptureRequest) CaptureResult {
 		if !evidence.verified {
 			return degradedCapture(CaptureStale, CaptureReasonEvidenceUnverified)
 		}
-		if evidence.source != CodexThreadStartedV2 {
+		if evidence.source != CodexNotifyV1 {
 			return CaptureResult{State: CaptureUnsupported, Reason: CaptureReasonEvidenceSource}
 		}
 		if evidence.provider != CodexProvider {

--- a/internal/launch/capture_test.go
+++ b/internal/launch/capture_test.go
@@ -1,12 +1,19 @@
 package launch
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
+const testCodexCwd = "/tmp/codex-project"
+
+func codexNotifyTestPayload(conversationID, cwd string) []byte {
+	return []byte(fmt.Sprintf(`{"type":"agent-turn-complete","thread-id":%q,"turn-id":"turn-1","cwd":%q,"input-messages":["reply with ok"],"last-assistant-message":"ok"}`, conversationID, cwd))
+}
+
 func validCodexCapture() CaptureRequest {
-	evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"`+testConversationID+`","cliVersion":"0.147.0","ignored_provider_field":true}}}`), testLaunchNonce, false)
+	evidence, err := ParseCodexNotifyEvidence(codexNotifyTestPayload(testConversationID, testCodexCwd), testLaunchNonce, "codex", codexCaptureVersion, testCodexCwd)
 	if err != nil {
 		panic(err)
 	}
@@ -73,23 +80,33 @@ func TestCodexCaptureRejectsAmbiguousOrForgedEvidence(t *testing.T) {
 	}
 }
 
-func TestParseCodexThreadStartedEvidenceRejectsForgedEvents(t *testing.T) {
+func TestParseCodexNotifyEvidenceRejectsForgedEvents(t *testing.T) {
+	valid := codexNotifyTestPayload(testConversationID, testCodexCwd)
+	if _, err := ParseCodexNotifyEvidence(valid, testLaunchNonce, "codex", "0.148.0", testCodexCwd); err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("unsupported expected version error = %v", err)
+	}
+	if _, err := ParseCodexNotifyEvidence(valid, testLaunchNonce, "codex", codexCaptureVersion, "/wrong"); err == nil || !strings.Contains(err.Error(), "cwd") {
+		t.Fatalf("wrong cwd error = %v", err)
+	}
+
 	tests := []struct {
 		name string
 		raw  string
 		want string
 	}{
 		{"malformed", `{`, "decode"},
-		{"wrong method", `{"method":"thread/resumed","params":{"thread":{"id":"` + testConversationID + `","cliVersion":"codex-cli 0.147.0"}}}`, "thread/started"},
-		{"missing version", `{"method":"thread/started","params":{"thread":{"id":"` + testConversationID + `"}}}`, "no CLI version"},
-		{"invalid id", `{"method":"thread/started","params":{"thread":{"id":"newest","cliVersion":"codex-cli 0.147.0"}}}`, "must be a UUID"},
-		{"non-v7 id", `{"method":"thread/started","params":{"thread":{"id":"550e8400-e29b-41d4-a716-446655440000","cliVersion":"0.147.0"}}}`, "UUIDv7"},
-		{"trailing event", `{"method":"thread/started","params":{"thread":{"id":"` + testConversationID + `","cliVersion":"codex-cli 0.147.0"}}} {}`, "trailing"},
+		{"wrong type", `{"type":"turn-started","thread-id":"` + testConversationID + `","turn-id":"turn-1","cwd":"` + testCodexCwd + `","input-messages":[]}`, "agent-turn-complete"},
+		{"missing turn", `{"type":"agent-turn-complete","thread-id":"` + testConversationID + `","cwd":"` + testCodexCwd + `","input-messages":[]}`, "turn identity"},
+		{"invalid id", `{"type":"agent-turn-complete","thread-id":"newest","turn-id":"turn-1","cwd":"` + testCodexCwd + `","input-messages":[]}`, "UUIDv7"},
+		{"non-v7 id", `{"type":"agent-turn-complete","thread-id":"550e8400-e29b-41d4-a716-446655440000","turn-id":"turn-1","cwd":"` + testCodexCwd + `","input-messages":[]}`, "UUIDv7"},
+		{"missing messages", `{"type":"agent-turn-complete","thread-id":"` + testConversationID + `","turn-id":"turn-1","cwd":"` + testCodexCwd + `"}`, "input-messages"},
+		{"unknown field", `{"type":"agent-turn-complete","thread-id":"` + testConversationID + `","turn-id":"turn-1","cwd":"` + testCodexCwd + `","input-messages":[],"extra":true}`, "unknown field"},
+		{"trailing event", string(valid) + ` {}`, "multiple JSON values"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := ParseCodexThreadStartedEvidence([]byte(test.raw), testLaunchNonce, false); err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("ParseCodexThreadStartedEvidence error = %v, want %q", err, test.want)
+			if _, err := ParseCodexNotifyEvidence([]byte(test.raw), testLaunchNonce, "codex", codexCaptureVersion, testCodexCwd); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ParseCodexNotifyEvidence error = %v, want %q", err, test.want)
 			}
 		})
 	}

--- a/internal/launch/conversation.go
+++ b/internal/launch/conversation.go
@@ -166,6 +166,7 @@ func validateConversationEvidence(root *fsq.DeliveryRoot, record ConversationRec
 	}
 	providerCapture := false
 	cursorCapture := false
+	codexCapture := false
 	for _, id := range record.EvidenceRefs {
 		evidence, _, err := ReadEvidence(root, id)
 		if err != nil {
@@ -176,7 +177,8 @@ func validateConversationEvidence(root *fsq.DeliveryRoot, record ConversationRec
 		}
 		if evidence.Kind == EvidenceProviderCapture {
 			providerCapture = true
-			if record.Identity.Provider == CursorProvider {
+			switch record.Identity.Provider {
+			case CursorProvider:
 				payload, decodeErr := decodeCursorCreateChatPayload(evidence.Payload)
 				if decodeErr != nil {
 					return decodeErr
@@ -187,10 +189,21 @@ func validateConversationEvidence(root *fsq.DeliveryRoot, record ConversationRec
 					return fmt.Errorf("cursor conversation evidence binding mismatch")
 				}
 				cursorCapture = true
+			case CodexProvider:
+				payload, decodeErr := decodeCodexNotifyPayload(evidence.Payload)
+				if decodeErr != nil {
+					return decodeErr
+				}
+				if payload.Handle != record.Handle || payload.LaunchNonce != record.LaunchNonce ||
+					payload.Provider != record.Identity.Provider || payload.ProviderVersion != record.ProviderVersion ||
+					payload.ConversationID != record.Identity.ID {
+					return fmt.Errorf("codex conversation evidence binding mismatch")
+				}
+				codexCapture = true
 			}
 		}
 	}
-	if record.Identity.Provider == CodexProvider && !providerCapture {
+	if record.Identity.Provider == CodexProvider && (!providerCapture || !codexCapture) {
 		return fmt.Errorf("capture conversation requires provider_capture evidence")
 	}
 	if record.Identity.Provider == CursorProvider && !cursorCapture {

--- a/internal/launch/evidence.go
+++ b/internal/launch/evidence.go
@@ -211,7 +211,12 @@ func persistProviderCaptureEvidence(root *fsq.DeliveryRoot, lease *Lease, handle
 			return nil, fmt.Errorf("provider capture evidence is not persistable")
 		}
 		switch item.source {
-		case CodexThreadStartedV2:
+		case CodexNotifyV1:
+			payload, err := decodeCodexNotifyPayload(item.payload)
+			if err != nil || payload.Handle != handle || item.handle != handle || payload.LaunchNonce != item.launchNonce ||
+				payload.ConversationID != item.conversationID || payload.ProviderVersion != item.providerVersion {
+				return nil, fmt.Errorf("codex provider capture evidence is not persistable")
+			}
 		case CursorCreateChatV1:
 			payload, err := decodeCursorCreateChatPayload(item.payload)
 			if err != nil || payload.Handle != handle || item.handle != handle || payload.LaunchNonce != item.launchNonce ||
@@ -248,7 +253,7 @@ func persistProviderCaptureEvidence(root *fsq.DeliveryRoot, lease *Lease, handle
 	return refs, nil
 }
 
-func findCursorCaptureEvidence(root *fsq.DeliveryRoot, handle, nonce, providerVersion string) (CaptureEvidence, string, bool, error) {
+func findProviderCaptureEvidence(root *fsq.DeliveryRoot, provider, handle, nonce, providerVersion string) (CaptureEvidence, string, bool, error) {
 	entries, err := root.ReadDir(evidenceDirectory)
 	if errors.Is(err, os.ErrNotExist) {
 		return CaptureEvidence{}, "", false, nil
@@ -276,27 +281,54 @@ func findCursorCaptureEvidence(root *fsq.DeliveryRoot, handle, nonce, providerVe
 		if err := json.Unmarshal(record.Payload, &envelope); err != nil {
 			return CaptureEvidence{}, "", false, fmt.Errorf("decode provider capture source: %w", err)
 		}
-		if envelope.Source != CursorCreateChatV1 {
-			continue
-		}
-		payload, err := decodeCursorCreateChatPayload(record.Payload)
-		if err != nil {
-			return CaptureEvidence{}, "", false, err
-		}
-		if payload.Handle != handle || payload.LaunchNonce != nonce || payload.ProviderVersion != providerVersion {
-			continue
+		var candidate CaptureEvidence
+		switch provider {
+		case CursorProvider:
+			if envelope.Source != CursorCreateChatV1 {
+				continue
+			}
+			payload, err := decodeCursorCreateChatPayload(record.Payload)
+			if err != nil {
+				return CaptureEvidence{}, "", false, err
+			}
+			if payload.Handle != handle || payload.LaunchNonce != nonce || payload.ProviderVersion != providerVersion {
+				continue
+			}
+			candidate = CaptureEvidence{
+				source: CursorCreateChatV1, provider: CursorProvider, providerVersion: payload.ProviderVersion,
+				launchNonce: payload.LaunchNonce, handle: payload.Handle, conversationID: payload.ConversationID,
+				verified: true, observedAt: record.ObservedAt, payload: bytes.Clone(record.Payload),
+			}
+		case CodexProvider:
+			if envelope.Source != CodexNotifyV1 {
+				continue
+			}
+			payload, err := decodeCodexNotifyPayload(record.Payload)
+			if err != nil {
+				return CaptureEvidence{}, "", false, err
+			}
+			if payload.Handle != handle || payload.LaunchNonce != nonce || payload.ProviderVersion != providerVersion {
+				continue
+			}
+			candidate = CaptureEvidence{
+				source: CodexNotifyV1, provider: CodexProvider, providerVersion: payload.ProviderVersion,
+				launchNonce: payload.LaunchNonce, handle: payload.Handle, conversationID: payload.ConversationID,
+				verified: true, observedAt: record.ObservedAt, payload: bytes.Clone(record.Payload),
+			}
+		default:
+			return CaptureEvidence{}, "", false, fmt.Errorf("pre-spawn capture provider %q is unsupported", provider)
 		}
 		if foundID != "" && foundID != id {
-			return CaptureEvidence{}, "", false, fmt.Errorf("cursor acquisition evidence is ambiguous for handle %q", handle)
+			return CaptureEvidence{}, "", false, fmt.Errorf("%s acquisition evidence is ambiguous for handle %q", provider, handle)
 		}
-		found = CaptureEvidence{
-			source: CursorCreateChatV1, provider: CursorProvider, providerVersion: payload.ProviderVersion,
-			launchNonce: payload.LaunchNonce, handle: payload.Handle, conversationID: payload.ConversationID,
-			verified: true, observedAt: record.ObservedAt, payload: bytes.Clone(record.Payload),
-		}
+		found = candidate
 		foundID = id
 	}
 	return found, foundID, foundID != "", nil
+}
+
+func findCursorCaptureEvidence(root *fsq.DeliveryRoot, handle, nonce, providerVersion string) (CaptureEvidence, string, bool, error) {
+	return findProviderCaptureEvidence(root, CursorProvider, handle, nonce, providerVersion)
 }
 
 func CollectEvidenceRefs(root *fsq.DeliveryRoot, handles []string) ([]EvidenceRef, error) {

--- a/internal/launch/evidence_test.go
+++ b/internal/launch/evidence_test.go
@@ -24,9 +24,13 @@ func TestImmutableCaptureEvidenceReadback(t *testing.T) {
 		t.Fatal(err)
 	}
 	observed := time.Date(2026, 8, 17, 1, 2, 3, 0, time.UTC)
+	capture, err := ParseCodexNotifyEvidence(codexNotifyTestPayload("019c8a2f-2b13-7000-8000-000000000001", fixture.cwd), nonce, "claude", codexCaptureVersion, fixture.cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	request := EvidenceWriteRequest{
 		Kind: EvidenceProviderCapture, Handle: "claude", ObservedAt: observed,
-		Payload: []byte(`{ "params": {"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001"}}, "method":"thread/started" }`),
+		Payload: capture.payload,
 	}
 	providerRef, err := WriteEvidence(fixture.root, lease, request)
 	if err != nil {
@@ -48,7 +52,7 @@ func TestImmutableCaptureEvidenceReadback(t *testing.T) {
 	}
 	manualConversation := ConversationRecord{
 		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
-		Identity: ConversationIdentity{Provider: CodexProvider, ID: "019c8a2f-2b13-7000-8000-000000000001"}, LaunchNonce: nonce,
+		Identity: ConversationIdentity{Provider: CodexProvider, ID: "019c8a2f-2b13-7000-8000-000000000001"}, ProviderVersion: codexCaptureVersion, LaunchNonce: nonce,
 		ExecutionEvidence: &ConversationExecutionEvidence{
 			Backend: LauncherTMux, Profile: TmuxProfile().Identity(), Outcome: OutcomeCreated,
 			LaunchNonce: nonce, ConversationID: "019c8a2f-2b13-7000-8000-000000000001",
@@ -184,5 +188,49 @@ func TestEvidenceExclusivePublicationRace(t *testing.T) {
 	}
 	if wins != 1 || collisions != writers-1 {
 		t.Fatalf("exclusive evidence race wins=%d collisions=%d", wins, collisions)
+	}
+}
+
+func TestCodexProviderEvidenceRejectsOuterPayloadBindingDivergenceBeforeWrite(t *testing.T) {
+	mutations := []struct {
+		name   string
+		mutate func(*CaptureEvidence)
+	}{
+		{name: "nonce", mutate: func(evidence *CaptureEvidence) { evidence.launchNonce = testConversationID }},
+		{name: "handle", mutate: func(evidence *CaptureEvidence) { evidence.handle = "other" }},
+		{name: "version", mutate: func(evidence *CaptureEvidence) { evidence.providerVersion = "0.148.0" }},
+		{name: "conversation id", mutate: func(evidence *CaptureEvidence) { evidence.conversationID = "019c8a2f-2b13-7000-8000-000000000099" }},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			fixture := newExecutionFixture(t)
+			nonce := "79797979-7979-4979-8979-797979797979"
+			lease, err := AcquireLease(fixture.root, nonce)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = lease.Release() }()
+			if err := lease.LockHandles("codex"); err != nil {
+				t.Fatal(err)
+			}
+			evidence, err := ParseCodexNotifyEvidence(
+				codexNotifyTestPayload(testConversationID, fixture.cwd),
+				nonce, "codex", codexCaptureVersion, fixture.cwd,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mutation.mutate(&evidence)
+			if _, err := persistProviderCaptureEvidence(fixture.root, lease, "codex", []CaptureEvidence{evidence}); err == nil || !strings.Contains(err.Error(), "not persistable") {
+				t.Fatalf("binding divergence error = %v", err)
+			}
+			entries, err := fixture.root.ReadDir(evidenceDirectory)
+			if err == nil && len(entries) != 0 {
+				t.Fatalf("binding divergence wrote %d evidence record(s)", len(entries))
+			}
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("inspect evidence directory: %v", err)
+			}
+		})
 	}
 }

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -197,12 +197,16 @@ func (ticket ExecutionTicket) Validate() error {
 		return fmt.Errorf("conversation identity must be a UUID")
 	}
 	if ticket.PreSpawnAcquire {
-		if ticket.Mode != AdapterModeCapture || ticket.Provider != CursorProvider || ticket.ProviderVersion == "" ||
+		if ticket.Mode != AdapterModeCapture || ticket.Provider != CursorProvider || ticket.ProviderVersion != cursorCaptureVersion ||
 			strings.TrimSpace(ticket.Backend) == "" || strings.TrimSpace(ticket.Profile) == "" {
 			return fmt.Errorf("pre-spawn identity acquisition requires a versioned cursor capture ticket")
 		}
-	} else if ticket.Backend != "" || ticket.Profile != "" {
-		return fmt.Errorf("execution backend identity exists without pre-spawn acquisition")
+	} else if (ticket.Backend == "") != (ticket.Profile == "") {
+		return fmt.Errorf("execution backend identity is incomplete")
+	} else if ticket.Mode == AdapterModeCapture && ticket.Provider == CodexProvider && ticket.ProviderVersion == codexCaptureVersion && ticket.Backend == "" {
+		return fmt.Errorf("codex notify capture requires execution backend identity")
+	} else if ticket.Backend != "" && (ticket.Mode != AdapterModeCapture || ticket.Provider != CodexProvider || ticket.ProviderVersion != codexCaptureVersion) {
+		return fmt.Errorf("execution backend identity is unsupported without pre-spawn acquisition")
 	}
 	for name, value := range map[string]string{"project root": ticket.ProjectRoot, "project identity": ticket.ProjectIdentity, "session root": ticket.SessionRoot, "session identity": ticket.SessionIdentity, "cwd": ticket.Cwd, "cwd identity": ticket.CwdIdentity, "provider executable": ticket.ProviderExecutable, "provider executable identity": ticket.ProviderExecutableIdentity, "amq executable": ticket.AMQExecutable, "amq executable identity": ticket.AMQExecutableIdentity, "environment digest": ticket.EnvDigest} {
 		if strings.TrimSpace(value) == "" {
@@ -222,6 +226,11 @@ func (ticket ExecutionTicket) Validate() error {
 	for i, arg := range ticket.TargetArgv {
 		if arg == "" || strings.ContainsRune(arg, 0) {
 			return fmt.Errorf("target argv[%d] is invalid", i)
+		}
+	}
+	if ticket.Mode == AdapterModeCapture && ticket.Provider == CodexProvider && ticket.ProviderVersion == codexCaptureVersion {
+		if err := validateCodexNotifyTargetArgv(ticket); err != nil {
+			return err
 		}
 	}
 	seenDynamic := make(map[int]struct{}, len(ticket.DynamicArgv))
@@ -285,6 +294,37 @@ func (ticket ExecutionTicket) Validate() error {
 		}
 	default:
 		return fmt.Errorf("invalid execution state %q", ticket.State)
+	}
+	return nil
+}
+
+func validateCodexNotifyTargetArgv(ticket ExecutionTicket) error {
+	expected, err := codexNotifyOverride(PlanRequest{
+		AMQExecutable: ticket.AMQExecutable,
+		SessionRoot:   ticket.SessionRoot,
+		Handle:        ticket.Handle,
+		LaunchNonce:   ticket.LaunchNonce,
+	})
+	if err != nil {
+		return err
+	}
+	count := 0
+	for i := 1; i < len(ticket.TargetArgv); i++ {
+		arg := ticket.TargetArgv[i]
+		if arg == "--config" || strings.HasPrefix(arg, "--config=") || strings.HasPrefix(arg, "notify=") {
+			return fmt.Errorf("codex notify override uses an unpinned configuration carrier")
+		}
+		if arg != "-c" {
+			continue
+		}
+		if i+1 >= len(ticket.TargetArgv) || ticket.TargetArgv[i+1] != expected {
+			return fmt.Errorf("codex notify override does not match the execution ticket")
+		}
+		count++
+		i++
+	}
+	if count != 1 {
+		return fmt.Errorf("codex execution ticket requires exactly one notify override")
 	}
 	return nil
 }
@@ -624,12 +664,12 @@ func promotePreSpawnConversation(root *fsq.DeliveryRoot, lease *Lease, ticket Ex
 			record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != ticket.Backend ||
 			record.ExecutionEvidence.Profile != ticket.Profile || record.ExecutionEvidence.LaunchNonce != ticket.LaunchNonce ||
 			record.ExecutionEvidence.ConversationID != ticket.ConversationID {
-			return fmt.Errorf("ready conversation does not match acquired cursor identity")
+			return fmt.Errorf("ready conversation does not match acquired provider identity")
 		}
 		return nil
 	}
 	if record.State != CapturePending || record.LaunchNonce != ticket.LaunchNonce {
-		return fmt.Errorf("pending conversation does not match acquired cursor generation")
+		return fmt.Errorf("pending conversation does not match acquired provider generation")
 	}
 	record.State = CaptureReady
 	record.Identity = ConversationIdentity{Provider: ticket.Provider, ID: ticket.ConversationID}
@@ -655,12 +695,114 @@ func validateCursorExecutionEvidence(root *fsq.DeliveryRoot, ticket ExecutionTic
 		return err
 	}
 	if record.Kind != EvidenceProviderCapture || record.Handle != ticket.Handle || payload.Handle != ticket.Handle ||
-		payload.Provider != ticket.Provider ||
-		payload.LaunchNonce != ticket.LaunchNonce || payload.ProviderVersion != ticket.ProviderVersion ||
-		payload.ConversationID != ticket.ConversationID {
+		payload.Provider != ticket.Provider || payload.LaunchNonce != ticket.LaunchNonce ||
+		payload.ProviderVersion != ticket.ProviderVersion || payload.ConversationID != ticket.ConversationID {
 		return fmt.Errorf("cursor execution evidence binding mismatch")
 	}
 	return nil
+}
+
+type CodexNotifyConflictError struct {
+	Existing string
+	Observed string
+}
+
+func (err *CodexNotifyConflictError) Error() string {
+	return fmt.Sprintf("codex_notify_identity_conflict: existing %s, observed %s", err.Existing, err.Observed)
+}
+
+type CodexNotifyResult struct {
+	ConversationID string
+	EvidenceRef    string
+	AlreadyReady   bool
+}
+
+// RecordCodexNotify binds one provider-owned turn-complete notification to
+// the exact managed launch, persists immutable evidence, and only then makes
+// the provider identity resumable.
+func RecordCodexNotify(root *fsq.DeliveryRoot, handle, nonce, amqExecutable string, raw []byte) (CodexNotifyResult, error) {
+	return recordCodexNotify(root, handle, nonce, amqExecutable, raw, nil)
+}
+
+func recordCodexNotify(root *fsq.DeliveryRoot, handle, nonce, amqExecutable string, raw []byte, hook prepareExecutionHook) (result CodexNotifyResult, returnErr error) {
+	lease, err := AcquireLease(root, nonce)
+	if err != nil {
+		return result, err
+	}
+	defer func() { returnErr = errors.Join(returnErr, lease.Release()) }()
+	if err := lease.LockHandles(handle); err != nil {
+		return result, err
+	}
+	ticket, err := LoadExecutionTicket(root, handle)
+	if err != nil {
+		return result, err
+	}
+	if ticket.LaunchNonce != nonce || ticket.Handle != handle || ticket.Mode != AdapterModeCapture ||
+		ticket.Provider != CodexProvider || ticket.ProviderVersion != codexCaptureVersion || ticket.PreSpawnAcquire {
+		return result, fmt.Errorf("codex notify execution ticket binding mismatch")
+	}
+	if ticket.State != ExecutionSpawnAttempted && ticket.State != ExecutionAcknowledged {
+		return result, fmt.Errorf("codex notify execution ticket state is %q", ticket.State)
+	}
+	_, amqIdentity, err := canonicalFile(amqExecutable)
+	if err != nil || amqIdentity != ticket.AMQExecutableIdentity {
+		return result, fmt.Errorf("codex notify AMQ executable identity mismatch")
+	}
+	evidence, err := ParseCodexNotifyEvidence(raw, nonce, handle, ticket.ProviderVersion, ticket.Cwd)
+	if err != nil {
+		return result, err
+	}
+	record, err := LoadConversation(root, handle)
+	if err != nil {
+		return result, err
+	}
+	if record.State == CaptureReady {
+		if record.LaunchNonce != nonce || record.ProviderVersion != ticket.ProviderVersion ||
+			record.Identity.Provider != CodexProvider || record.Identity.ID != evidence.conversationID {
+			return result, &CodexNotifyConflictError{Existing: record.Identity.ID, Observed: evidence.conversationID}
+		}
+		if len(record.EvidenceRefs) != 1 {
+			return result, fmt.Errorf("ready codex conversation does not have one evidence ref")
+		}
+		return CodexNotifyResult{ConversationID: record.Identity.ID, EvidenceRef: record.EvidenceRefs[0], AlreadyReady: true}, nil
+	}
+	if record.State != CapturePending || record.LaunchNonce != nonce || record.ProviderVersion != ticket.ProviderVersion {
+		return result, fmt.Errorf("pending codex conversation does not match notify generation")
+	}
+
+	stored, refID, found, err := findProviderCaptureEvidence(root, CodexProvider, handle, nonce, ticket.ProviderVersion)
+	if err != nil {
+		return result, err
+	}
+	if found {
+		if stored.conversationID != evidence.conversationID {
+			return result, &CodexNotifyConflictError{Existing: stored.conversationID, Observed: evidence.conversationID}
+		}
+	} else {
+		refs, persistErr := persistProviderCaptureEvidence(root, lease, handle, []CaptureEvidence{evidence})
+		if persistErr != nil {
+			return result, persistErr
+		}
+		refID = refs[0]
+	}
+	if err := callPrepareExecutionHook(hook, "evidence_persisted"); err != nil {
+		return result, err
+	}
+	record.State = CaptureReady
+	record.Identity = ConversationIdentity{Provider: CodexProvider, ID: evidence.conversationID}
+	record.EvidenceRefs = []string{refID}
+	record.ExecutionEvidence = &ConversationExecutionEvidence{
+		Backend: ticket.Backend, Profile: ticket.Profile, Outcome: OutcomeCreated,
+		LaunchNonce: nonce, ConversationID: evidence.conversationID,
+	}
+	record.Reason = ""
+	if err := WriteConversation(root, lease, record); err != nil {
+		return result, err
+	}
+	if err := callPrepareExecutionHook(hook, "conversation_promoted"); err != nil {
+		return result, err
+	}
+	return CodexNotifyResult{ConversationID: evidence.conversationID, EvidenceRef: refID}, nil
 }
 
 func callPrepareExecutionHook(hook prepareExecutionHook, stage string) error {

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -638,6 +638,170 @@ func TestCursorOrphanEvidenceRejectsSameIdentityWithDifferentBytes(t *testing.T)
 	}
 }
 
+func TestCodexOrphanEvidenceRejectsSameIdentityWithDifferentBytes(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "99999999-9999-4999-8999-999999999999"
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = lease.Release() }()
+	if err := lease.LockHandles("codex"); err != nil {
+		t.Fatal(err)
+	}
+	first, err := ParseCodexNotifyEvidence(
+		codexNotifyTestPayload(testConversationID, fixture.cwd),
+		nonce, "codex", codexCaptureVersion, fixture.cwd,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRaw := []byte(strings.Replace(string(codexNotifyTestPayload(testConversationID, fixture.cwd)), `"last-assistant-message":"ok"`, `"last-assistant-message":"different"`, 1))
+	second, err := ParseCodexNotifyEvidence(
+		secondRaw, nonce, "codex", codexCaptureVersion, fixture.cwd,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := persistProviderCaptureEvidence(fixture.root, lease, "codex", []CaptureEvidence{first, second}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := findProviderCaptureEvidence(fixture.root, CodexProvider, "codex", nonce, codexCaptureVersion); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("ambiguous Codex orphan evidence error = %v", err)
+	}
+}
+
+func TestRecordCodexNotifyPersistsBeforePromotionAndUsesTicketBackend(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "96969696-9696-4969-8969-969696969696"
+	ticket := seedPendingCodexNotifyExecution(t, fixture, nonce)
+	raw := codexNotifyTestPayload(testConversationID, ticket.Cwd)
+	result, err := RecordCodexNotify(fixture.root, "codex", nonce, fixture.amq, raw)
+	if err != nil || result.ConversationID != testConversationID || result.EvidenceRef == "" || result.AlreadyReady {
+		t.Fatalf("RecordCodexNotify = %#v, %v", result, err)
+	}
+	record, err := LoadConversation(fixture.root, "codex")
+	if err != nil || record.State != CaptureReady || record.Identity != (ConversationIdentity{Provider: CodexProvider, ID: testConversationID}) ||
+		record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != CommandsBackendName ||
+		record.ExecutionEvidence.Profile != CommandsProfile().Identity() || !reflect.DeepEqual(record.EvidenceRefs, []string{result.EvidenceRef}) {
+		t.Fatalf("ready conversation = %#v, %v", record, err)
+	}
+	if _, _, err := ReadEvidence(fixture.root, result.EvidenceRef); err != nil {
+		t.Fatal(err)
+	}
+	second, err := RecordCodexNotify(fixture.root, "codex", nonce, fixture.amq, raw)
+	if err != nil || !second.AlreadyReady || second.EvidenceRef != result.EvidenceRef {
+		t.Fatalf("idempotent notify = %#v, %v", second, err)
+	}
+}
+
+func TestRecordCodexNotifyRefusesPendingExecutionTicket(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "93939393-9393-4939-8939-939393939393"
+	ticket := seedPendingCodexNotifyExecution(t, fixture, nonce)
+	if err := RevertExecution(fixture.root, "codex", nonce); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RecordCodexNotify(fixture.root, "codex", nonce, fixture.amq, codexNotifyTestPayload(testConversationID, ticket.Cwd)); err == nil || !strings.Contains(err.Error(), `state is "pending"`) {
+		t.Fatalf("pending notify error = %v", err)
+	}
+	record, err := LoadConversation(fixture.root, "codex")
+	if err != nil || record.State != CapturePending || record.Identity.ID != "" || len(record.EvidenceRefs) != 0 {
+		t.Fatalf("pending conversation after refused notify = %#v, %v", record, err)
+	}
+}
+
+func TestRecordCodexNotifyCrashRecoveryAndIdentityConflict(t *testing.T) {
+	for _, crashStage := range []string{"evidence_persisted", "conversation_promoted"} {
+		t.Run(crashStage, func(t *testing.T) {
+			fixture := newExecutionFixture(t)
+			nonce := "95959595-9595-4959-8959-959595959595"
+			ticket := seedPendingCodexNotifyExecution(t, fixture, nonce)
+			crash := errors.New("simulated crash")
+			_, err := recordCodexNotify(fixture.root, "codex", nonce, fixture.amq, codexNotifyTestPayload(testConversationID, ticket.Cwd), func(stage string) error {
+				if stage == crashStage {
+					return crash
+				}
+				return nil
+			})
+			if !errors.Is(err, crash) {
+				t.Fatalf("crash error = %v", err)
+			}
+			result, err := RecordCodexNotify(fixture.root, "codex", nonce, fixture.amq, codexNotifyTestPayload(testConversationID, ticket.Cwd))
+			if err != nil || result.ConversationID != testConversationID || (crashStage == "conversation_promoted" && !result.AlreadyReady) {
+				t.Fatalf("retry = %#v, %v", result, err)
+			}
+			_, err = RecordCodexNotify(fixture.root, "codex", nonce, fixture.amq, codexNotifyTestPayload("019c8a2f-2b13-7000-8000-000000000099", ticket.Cwd))
+			var conflict *CodexNotifyConflictError
+			if !errors.As(err, &conflict) || conflict.Existing != testConversationID {
+				t.Fatalf("identity conflict = %#v, %v", conflict, err)
+			}
+		})
+	}
+}
+
+func TestCodexNotifyTicketRejectsAlteredStaticHook(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "94949494-9494-4949-8949-949494949494"
+	notify, err := codexNotifyOverride(PlanRequest{AMQExecutable: fixture.amq, SessionRoot: fixture.session, Handle: "codex", LaunchNonce: nonce})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, argv := range [][]string{
+		{fixture.provider},
+		{fixture.provider, "-c", notify, "-c", notify},
+		{fixture.provider, "-c", strings.Replace(notify, nonce, testLaunchNonce, 1)},
+		{fixture.provider, "-c", notify, "--config", "notify=[]"},
+	} {
+		_, err := NewExecutionTicket(ExecutionTicketRequest{
+			Handle: "codex", LaunchNonce: nonce, Mode: AdapterModeCapture, Provider: CodexProvider, ProviderVersion: codexCaptureVersion,
+			Backend: CommandsBackendName, Profile: CommandsProfile().Identity(), ProjectRoot: fixture.project, SessionRoot: fixture.session,
+			Cwd: fixture.cwd, ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq, TargetArgv: argv,
+		})
+		if err == nil || !strings.Contains(err.Error(), "notify") {
+			t.Fatalf("altered static hook error = %v for %q", err, argv)
+		}
+	}
+}
+
+func seedPendingCodexNotifyExecution(t *testing.T, fixture executionFixture, nonce string) ExecutionTicket {
+	t.Helper()
+	notify, err := codexNotifyOverride(PlanRequest{
+		AMQExecutable: fixture.amq, SessionRoot: fixture.session, Handle: "codex", LaunchNonce: nonce,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "codex", LaunchNonce: nonce, Mode: AdapterModeCapture, Provider: CodexProvider, ProviderVersion: codexCaptureVersion,
+		Backend: CommandsBackendName, Profile: CommandsProfile().Identity(), ProjectRoot: fixture.project, SessionRoot: fixture.session,
+		Cwd: fixture.cwd, ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: []string{fixture.provider, "-c", notify}, State: ExecutionSpawnAttempted, Reason: "spawn_attempted",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: "codex", State: CapturePending, ProviderVersion: codexCaptureVersion, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	return ticket
+}
+
 type executionFixture struct {
 	project, session, cwd, provider, amq, injector string
 	root                                           *fsq.DeliveryRoot

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -750,7 +750,7 @@ func TestCodexNotifyTicketRejectsAlteredStaticHook(t *testing.T) {
 	for _, argv := range [][]string{
 		{fixture.provider},
 		{fixture.provider, "-c", notify, "-c", notify},
-		{fixture.provider, "-c", strings.Replace(notify, nonce, testLaunchNonce, 1)},
+		{fixture.provider, "-c", strings.Replace(notify, `"codex"`, `"claude"`, 1)},
 		{fixture.provider, "-c", notify, "--config", "notify=[]"},
 	} {
 		_, err := NewExecutionTicket(ExecutionTicketRequest{

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -97,6 +97,7 @@ type PrepareDependencies struct {
 	Backends     map[string]Backend
 	Preferences  []string
 	AdapterFor   AdapterFactory
+	AMQPath      string
 	TrustStore   *TrustStore
 	HostIdentity string
 }
@@ -260,6 +261,11 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if len(request.Participants) == 0 {
 		return PrepareResult{}, fmt.Errorf("prepare requires at least one participant")
 	}
+	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	dependencies.AMQPath = amqPath
 	state, err := openPrepareTarget(request.Target)
 	if err != nil {
 		return PrepareResult{}, err
@@ -672,7 +678,8 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 	}
 
 	base := PlanRequest{
-		Handle: participant.Handle, ProjectRoot: state.target.ProjectRoot, Cwd: cwd, AllowExternalCwd: true,
+		Handle: participant.Handle, ProjectRoot: state.target.ProjectRoot, SessionRoot: state.target.SessionRoot,
+		AMQExecutable: dependencies.AMQPath, Cwd: cwd, AllowExternalCwd: true,
 		LaunchNonce: preparePlaceholderUUID, ResumePolicy: participant.ResumePolicy,
 		CommittedArgs: slices.Clone(participant.Args), BypassArgs: slices.Clone(participant.BypassArgs), EnvOverlay: cloneEnv(participant.EnvOverlay),
 	}

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -127,6 +127,11 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	if err := request.Config.Validate(); err != nil {
 		return result, err
 	}
+	amqExecutable, err := resolveLaunchAMQExecutable(request.AMQPath)
+	if err != nil {
+		return result, err
+	}
+	request.AMQPath = amqExecutable
 	journal, hasJournal, err := loadOptionalJournal(request.Root)
 	if err != nil {
 		result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_unreadable"
@@ -322,10 +327,6 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 			if err := callCrashHook(request.CrashHook, "journal_written"); err != nil {
 				return result, err
 			}
-		}
-		amqExecutable, err := resolveLaunchAMQExecutable(request.AMQPath)
-		if err != nil {
-			return result, err
 		}
 		if err := writeExecutionTickets(request, lease, planned, amqExecutable, backendName, detect.Profile.Identity()); err != nil {
 			return result, err
@@ -646,7 +647,7 @@ func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []pla
 			TargetArgv: agent.plan.Argv, DynamicArgv: agent.plan.DynamicArgv, TargetEnv: agent.plan.EnvOverlay,
 			Execution: agent.plan.Execution,
 		}
-		if agent.plan.PreSpawnAcquire {
+		if agent.plan.PreSpawnAcquire || (agent.adapter.Name() == CodexProvider && agent.plan.AdapterMode == AdapterModeCapture) {
 			ticketRequest.Backend, ticketRequest.Profile = backend, profile
 		}
 		ticket, err := NewExecutionTicket(ticketRequest)
@@ -739,7 +740,8 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			continue
 		}
 		base := PlanRequest{
-			Handle: cfg.Handle, ProjectRoot: request.ProjectRoot, Cwd: cwd,
+			Handle: cfg.Handle, ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(),
+			AMQExecutable: request.AMQPath, Cwd: cwd,
 			LaunchNonce: nonce, ResumePolicy: policy, CommittedArgs: committedArgs, BypassArgs: bypassArgs,
 			EnvOverlay: cfg.Env, AllowExternalCwd: request.AllowExternalCwd,
 		}

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -84,7 +84,9 @@ func (a reconcileAdapter) Capabilities(context.Context) AdapterCapabilities {
 		provider = a.capabilityProvider
 	}
 	providerVersion := "test"
-	if a.preSpawnAcquire {
+	if a.name == CodexProvider {
+		providerVersion = codexCaptureVersion
+	} else if a.preSpawnAcquire {
 		providerVersion = cursorCaptureVersion
 	}
 	return AdapterCapabilities{
@@ -162,7 +164,7 @@ func TestReconcileCaptureReadyResumeRequiresResumeAlone(t *testing.T) {
 	}}
 	writeReconcileConversation(t, req, ConversationRecord{
 		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
-		Identity: ConversationIdentity{Provider: CodexProvider, ID: testConversationID}, LaunchNonce: testLaunchNonce,
+		Identity: ConversationIdentity{Provider: CodexProvider, ID: testConversationID}, ProviderVersion: codexCaptureVersion, LaunchNonce: testLaunchNonce,
 		ExecutionEvidence: reconcileExecutionEvidence(&reconcileBackend{name: CommandsBackendName}, testLaunchNonce),
 	})
 	result, err := Reconcile(req)
@@ -184,7 +186,7 @@ func TestReconcileCaptureReadyRefusesWithoutResumeCapability(t *testing.T) {
 	}}
 	writeReconcileConversation(t, req, ConversationRecord{
 		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
-		Identity: ConversationIdentity{Provider: CodexProvider, ID: testConversationID}, LaunchNonce: testLaunchNonce,
+		Identity: ConversationIdentity{Provider: CodexProvider, ID: testConversationID}, ProviderVersion: codexCaptureVersion, LaunchNonce: testLaunchNonce,
 		ExecutionEvidence: reconcileExecutionEvidence(&reconcileBackend{name: CommandsBackendName}, testLaunchNonce),
 	})
 	result, err := Reconcile(req)
@@ -198,6 +200,17 @@ func TestReconcileCaptureReadyRefusesWithoutResumeCapability(t *testing.T) {
 }
 
 func (a reconcileAdapter) PlanFresh(req PlanRequest) (AgentPlan, error) {
+	if a.name == CodexProvider && a.mode == AdapterModeCapture {
+		notify, err := codexNotifyOverride(req)
+		if err != nil {
+			return AgentPlan{}, err
+		}
+		plan := AgentPlan{
+			Handle: req.Handle, Argv: []string{"/usr/bin/true", "-c", notify}, Cwd: req.Cwd,
+			AdapterMode: a.mode, ResumePolicy: req.ResumePolicy, LaunchNonce: req.LaunchNonce,
+		}
+		return plan, plan.Validate()
+	}
 	if a.preSpawnAcquire {
 		plan := AgentPlan{
 			Handle: req.Handle, Argv: []string{"/usr/bin/true", "--resume", preSpawnConversationPlaceholder}, Cwd: req.Cwd,
@@ -217,6 +230,18 @@ func (a reconcileAdapter) PlanFresh(req PlanRequest) (AgentPlan, error) {
 	return plan, plan.Validate()
 }
 func (a reconcileAdapter) PlanResume(req ResumeRequest) (AgentPlan, error) {
+	if a.name == CodexProvider && a.mode == AdapterModeCapture {
+		notify, err := codexNotifyOverride(req.PlanRequest)
+		if err != nil {
+			return AgentPlan{}, err
+		}
+		plan := AgentPlan{
+			Handle: req.Handle, Argv: []string{"/usr/bin/true", "resume", "-c", notify, req.Conversation.ID}, Cwd: req.Cwd,
+			AdapterMode: a.mode, ResumePolicy: ResumeEnabled, LaunchNonce: req.LaunchNonce, ConversationID: req.Conversation.ID,
+			DynamicArgv: []DynamicArg{{Index: 4, Kind: DynamicArgConversationID}},
+		}
+		return plan, plan.Validate()
+	}
 	plan := AgentPlan{
 		Handle: req.Handle, Argv: []string{"/usr/bin/true", req.Conversation.ID}, Cwd: req.Cwd,
 		AdapterMode: a.mode, ResumePolicy: ResumeEnabled, LaunchNonce: req.LaunchNonce,
@@ -292,7 +317,7 @@ func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
 	}
 	if b.capture {
 		if b.captured == nil {
-			evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Plan.Agents[0].LaunchNonce, false)
+			evidence, err := ParseCodexNotifyEvidence(codexNotifyTestPayload("019c8a2f-2b13-7000-8000-000000000001", req.Plan.Agents[0].Cwd), req.Plan.Agents[0].LaunchNonce, req.Plan.Agents[0].Handle, codexCaptureVersion, req.Plan.Agents[0].Cwd)
 			if err != nil {
 				return CreateResult{}, err
 			}
@@ -345,7 +370,7 @@ func (b *reconcileBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
 	}
 	if b.capture {
 		if b.captured == nil {
-			evidence, err := ParseCodexThreadStartedEvidence([]byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001","cliVersion":"test"}}}`), req.Journal.LaunchNonce, false)
+			evidence, err := ParseCodexNotifyEvidence(codexNotifyTestPayload("019c8a2f-2b13-7000-8000-000000000001", req.Journal.Plan.Agents[0].Cwd), req.Journal.LaunchNonce, req.Journal.Plan.Agents[0].Handle, codexCaptureVersion, req.Journal.Plan.Agents[0].Cwd)
 			if err != nil {
 				return ReclaimResult{}, err
 			}

--- a/launchapi/apply.go
+++ b/launchapi/apply.go
@@ -24,7 +24,7 @@ func Apply(ctx context.Context, request ApplyRequestV1) (ApplyResultV1, error) {
 	}
 	result, err := internallaunch.Apply(ctx, internallaunch.ApplyRequest{
 		Prepare: prepared, SubjectDigest: request.SubjectDigest, Decisions: decisions,
-	}, internallaunch.ApplyDependencies{PrepareDependencies: dependencies})
+	}, internallaunch.ApplyDependencies{PrepareDependencies: dependencies, AMQPath: dependencies.AMQPath})
 	if err != nil {
 		return ApplyResultV1{}, err
 	}

--- a/launchapi/lifecycle_test.go
+++ b/launchapi/lifecycle_test.go
@@ -86,7 +86,7 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	}
 	evidence, err := internallaunch.WriteEvidence(root, lease, internallaunch.EvidenceWriteRequest{
 		Kind: internallaunch.EvidenceProviderCapture, Handle: "claude", ObservedAt: time.Now().UTC(),
-		Payload: []byte(`{"method":"thread/started","params":{"thread":{"id":"019c8a2f-2b13-7000-8000-000000000001"}}}`),
+		Payload: []byte(`{"source":"codex_notify_v1","provider":"codex","provider_version":"0.147.0","launch_nonce":"76767676-7676-4676-8676-767676767676","handle":"claude","conversation_id":"019c8a2f-2b13-7000-8000-000000000001","cwd":"/tmp","notification":"{\"type\":\"agent-turn-complete\",\"thread-id\":\"019c8a2f-2b13-7000-8000-000000000001\",\"turn-id\":\"turn-1\",\"cwd\":\"/tmp\",\"input-messages\":[]}"}`),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -94,8 +94,8 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	conversationID := "019c8a2f-2b13-7000-8000-000000000001"
 	if err := internallaunch.WriteConversation(root, lease, internallaunch.ConversationRecord{
 		Version: internallaunch.ConversationVersion, Handle: "claude", State: internallaunch.CaptureReady,
-		Identity:    internallaunch.ConversationIdentity{Provider: internallaunch.CodexProvider, ID: conversationID},
-		LaunchNonce: "76767676-7676-4676-8676-767676767676", EvidenceRefs: []string{evidence.ID},
+		Identity:        internallaunch.ConversationIdentity{Provider: internallaunch.CodexProvider, ID: conversationID},
+		ProviderVersion: "0.147.0", LaunchNonce: "76767676-7676-4676-8676-767676767676", EvidenceRefs: []string{evidence.ID},
 		ExecutionEvidence: &internallaunch.ConversationExecutionEvidence{
 			Backend: "test", Profile: detect.Profile.Identity(), Outcome: internallaunch.OutcomeCreated,
 			LaunchNonce: "76767676-7676-4676-8676-767676767676", ConversationID: conversationID,

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -49,6 +49,10 @@ func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, int
 	if host == "" {
 		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, fmt.Errorf("resolve host identity: empty hostname")
 	}
+	amqPath, err := os.Executable()
+	if err != nil {
+		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, fmt.Errorf("resolve AMQ executable: %w", err)
+	}
 	internalRequest := internallaunch.PrepareRequest{
 		Target: internallaunch.PrepareTarget{
 			ProjectRoot: request.Target.ProjectRoot,
@@ -76,6 +80,7 @@ func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, int
 	dependencies := internallaunch.PrepareDependencies{
 		Backends:     internallaunch.DefaultBackends(),
 		AdapterFor:   defaultPrepareAdapter,
+		AMQPath:      amqPath,
 		TrustStore:   trustStore,
 		HostIdentity: host,
 	}


### PR DESCRIPTION
## Summary

- capture Codex 0.147.0 provider-owned thread IDs through a launch-bound private notify hook
- persist immutable evidence before conversation promotion and forward the identical payload to the operator notify command
- retain Cursor pre-spawn acquisition and add hostile-boundary, crash-recovery, and real tier-1 live smokes

## Verification

- `go test ./... -count=1`
- fresh-cache `make ci`
- `AMQ_CODEX_LIVE=1 go test ./internal/launch -run ^TestCodexLiveManagedAcquireResumeAndCrashReuse$ -count=1 -v`
  - pending launch returned typed stale-conversation action
  - notify-backed thread `01a00fc0-59ad-7d51-83f3-86b91ca49919` resumed by exact ID
- peer hostile-mutant gate and test-only follow-up ACK