### PR TITLE
ci(release): verify the published Homebrew formula installs and runs

### DIFF
--- a/.github/workflows/verify-brew-release.yml
+++ b/.github/workflows/verify-brew-release.yml
@@ -1,0 +1,178 @@
+name: Verify Homebrew Release
+
+# Deliberately triggers on workflow_run rather than `release: types:
+# [published]`. GoReleaser publishes the GitHub release in release.yml using
+# the default GITHUB_TOKEN, and GitHub's own recursion-prevention rule does
+# not fire other workflows' `release` events for GITHUB_TOKEN-authored
+# releases (only workflow_dispatch and repository_dispatch are exempt). This
+# repo already works around the same limitation for release-please.yml.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to verify (e.g. v0.61.0); default is the latest published release"
+        required: false
+        type: string
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-brew-release
+  cancel-in-progress: false
+
+jobs:
+  # release.yml runs on every push to main, but its `release` job is only
+  # non-skipped when the commit actually carried a version to publish; most
+  # main merges leave every job "skipped" while the workflow_run conclusion
+  # still reads "success". This job checks the triggering run's own `release`
+  # job conclusion so a routine merge doesn't get verified as if it were a
+  # release (which would just re-check a stale, already-verified version).
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      proceed: ${{ steps.decide.outputs.proceed }}
+      tag: ${{ steps.decide.outputs.tag }}
+    steps:
+      - name: Resolve release and decide whether to verify
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            if [[ "$RUN_CONCLUSION" != "success" ]]; then
+              echo "::notice::Release workflow run (head_sha ${RUN_HEAD_SHA}) did not succeed (conclusion: ${RUN_CONCLUSION}); skipping Homebrew verification."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            release_conclusion="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs" --jq '.jobs[] | select(.name=="release") | .conclusion')"
+            if [[ "$release_conclusion" != "success" ]]; then
+              echo "::notice::Release workflow run (head_sha ${RUN_HEAD_SHA}) completed without publishing a release (release job: ${release_conclusion:-absent}); skipping Homebrew verification."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          if [[ -n "${INPUT_TAG:-}" ]]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName -q .tagName)"
+          fi
+          if [[ -z "$tag" ]]; then
+            echo "::error::Could not resolve a release tag to verify."
+            exit 1
+          fi
+
+          release_json="$(gh release view "$tag" --repo "${GITHUB_REPOSITORY}" --json isDraft,isPrerelease)"
+          is_draft="$(jq -r '.isDraft' <<<"$release_json")"
+          is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
+          if [[ "$is_draft" == "true" || "$is_prerelease" == "true" ]]; then
+            echo "::notice::Release ${tag} is a draft or prerelease; skipping Homebrew verification."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Bind the resolved tag to the run that triggered us: "latest
+          # release" can drift from "the release this run just published" if
+          # another release lands in the gap, so a stale match must fail
+          # loudly rather than silently re-verify an older (already-verified)
+          # release under this run's identity.
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            tag_ref_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}")"
+            tag_object_sha="$(jq -r '.object.sha' <<<"$tag_ref_json")"
+            tag_object_type="$(jq -r '.object.type' <<<"$tag_ref_json")"
+            if [[ "$tag_object_type" == "tag" ]]; then
+              # Annotated tag: dereference the tag object to its target commit.
+              tag_object_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object_sha}" --jq '.object.sha')"
+            fi
+            if [[ "$tag_object_sha" != "$RUN_HEAD_SHA" ]]; then
+              echo "::error::Latest release ${tag} points at ${tag_object_sha}, not the triggering run's head_sha ${RUN_HEAD_SHA}; latest is not this run's release."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+          fi
+
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+  verify-brew-install:
+    needs: gate
+    if: needs.gate.result == 'success' && needs.gate.outputs.proceed == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Tap avivsinai/tap
+        run: brew tap avivsinai/tap
+
+      # Formula push and `brew update` can lag a few minutes behind the
+      # GitHub release, so poll instead of failing on the first mismatch.
+      #
+      # GoReleaser's ldflags use its own `.Version` template variable, which
+      # strips the leading "v" from the git tag (confirmed against the real
+      # v0.62.0 release: its asset filenames and the downloaded binary both
+      # print "0.62.0", not "v0.62.0"). release.yml's own "Check embedded
+      # version" step compares WITH the "v" prefix, but that checks a
+      # separate `make build` artifact whose Makefile ldflags pass the tag
+      # through verbatim — not the GoReleaser-built binary Homebrew actually
+      # installs. So the tag (with "v") stays the identity used for the
+      # head_sha binding above, but the installed binary's version never
+      # carries one.
+      - name: Install amq, tolerating tap propagation lag
+        env:
+          EXPECTED_TAG: ${{ needs.gate.outputs.tag }}
+        run: |
+          set -uo pipefail
+          expected_version="${EXPECTED_TAG#v}"
+          if [[ -z "${EXPECTED_TAG}" || -z "${expected_version}" ]]; then
+            echo "::error::Expected tag ('${EXPECTED_TAG}') did not resolve to a non-empty version."
+            exit 1
+          fi
+          max_attempts=6
+          actual=""
+          for attempt in $(seq 1 "$max_attempts"); do
+            echo "Attempt ${attempt}/${max_attempts}: refreshing tap and installing amq"
+            brew update --quiet
+            brew upgrade avivsinai/tap/amq || brew install avivsinai/tap/amq
+            actual="$(amq --version || true)"
+            echo "Installed version: ${actual:-<none>} (expect '${expected_version}', from release tag '${EXPECTED_TAG}')"
+            if [[ "${actual}" == "${expected_version}" ]]; then
+              echo "amq ${actual} matches expected release ${EXPECTED_TAG}."
+              exit 0
+            fi
+            if [[ "${attempt}" -lt "${max_attempts}" ]]; then
+              echo "Version mismatch (got '${actual}', want '${expected_version}' from tag '${EXPECTED_TAG}'); the tap may still be propagating. Retrying in 60s."
+              sleep 60
+            fi
+          done
+          echo "::error::Homebrew installed amq '${actual}', expected '${expected_version}' (from published release tag '${EXPECTED_TAG}') after ${max_attempts} attempts."
+          exit 1
+
+      - name: End-to-end smoke test on a real queue
+        run: |
+          set -euo pipefail
+          queue_root="${RUNNER_TEMP}/verify-queue"
+          amq init --root "${queue_root}" --agents alpha,beta
+          amq doctor --root "${queue_root}" --json
+          amq send --root "${queue_root}" --me alpha --to beta --body "hello"
+          output="$(amq drain --root "${queue_root}" --me beta --include-body)"
+          echo "${output}"
+          if ! grep -qF "hello" <<<"${output}"; then
+            echo "::error::amq drain did not show the message body sent from alpha to beta."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,15 @@ own worktrees, dependency scheduling, task decomposition, and PR landing.
   or edit the release PR, when release notes need multiple entries. Each entry
   is one conventional header of at most 72 characters, separated by a blank
   line.
+- `verify-brew-release.yml` runs when `release.yml` actually publishes a
+  release, and on demand, to confirm the published release installs from the
+  real `avivsinai/tap/amq` formula. It ignores non-release merges (where
+  `release.yml` completes but its own `release` job stays skipped) and
+  drafts or prereleases. It retries the tap refresh and install for up to 6
+  attempts to absorb tap propagation lag, then requires `amq --version` to
+  match the released tag and runs an init/send/drain round trip against a
+  throwaway queue root to prove the installed binary works end to end. It
+  never writes to the tap.
 
 ## Operational Constraints
 


### PR DESCRIPTION
## Summary

Adds `verify-brew-release.yml`: a post-release check that the published `amq`
Homebrew formula actually installs and runs, so a broken formula push is
caught instead of silently shipping.

## What it does

- Triggers on `workflow_dispatch` (optional `tag` input, default latest
  published release) and on `workflow_run` after `Release` completes.
  `release: types: [published]` was deliberately not used: GoReleaser
  publishes the GitHub release in `release.yml` with the default
  `GITHUB_TOKEN`, and GitHub does not fire other workflows' `release` events
  for `GITHUB_TOKEN`-authored releases (only `workflow_dispatch` and
  `repository_dispatch` are exempt) — the same limitation
  `release-please.yml` already works around with `workflow_run`.
- A `gate` job runs first and decides whether to proceed:
  - For `workflow_run`, it checks the triggering run's own `release` job
    conclusion via the Actions jobs API, not just the overall run
    conclusion. `release.yml` runs on every push to `main`, but its
    `release` job only executes (and only succeeds) when the commit
    actually carried a version to publish; a routine merge leaves every job
    `skipped` while the workflow's overall conclusion still reads
    `success`. Verified live against this repo's most recent `Release` run,
    which shows exactly that: all jobs skipped, run still green.
  - Skips (with `::notice::`) drafts and prereleases.
  - Binds the resolved tag to the triggering run: fetches the tag's git ref
    (dereferencing an annotated tag if needed) and requires it to point at
    `github.event.workflow_run.head_sha`. A mismatch is a hard `::error::`
    and job failure, not a skip — it means "latest release" isn't actually
    this run's release.
  - The `workflow_dispatch` path skips the head_sha binding and uses the
    input tag or `gh release view` latest.
- `verify-brew-install` (macos-latest) taps `avivsinai/tap`, then retries
  `brew update --quiet` + `brew upgrade avivsinai/tap/amq || brew install
  avivsinai/tap/amq` + version compare up to 6 times, 60s apart, to absorb
  tap-formula propagation lag after a release. It only errors after the
  final attempt still mismatches.
- Version comparison strips a leading `v` from the release tag before
  comparing to `amq --version`. Confirmed by downloading and running the
  actual published `v0.62.0` binary: it prints `0.62.0`, not `v0.62.0` —
  GoReleaser's ldflags use its own `.Version` template variable, which
  strips the tag prefix (also visible in the release's own asset filenames,
  e.g. `amq_0.62.0_darwin_arm64.tar.gz`). `release.yml`'s own "Check
  embedded version" step compares WITH the `v` prefix, but that checks a
  separate `make build` artifact where the Makefile passes the tag through
  verbatim — not the GoReleaser-built binary Homebrew actually installs.
- Finally, an end-to-end smoke test on the installed binary against a
  throwaway queue root: `amq init` two agents, `amq doctor --json` must
  exit 0, `amq send` a message, then `amq drain --include-body` must show
  the message body.
- Never writes to the tap; `permissions: contents: read` throughout.

## Reviewer findings addressed

- **False-green trigger**: a bare `workflow_run: completed/success` gate
  would verify a stale "latest release" on every routine main merge. Fixed
  with the `gate` job's release-job-conclusion check plus the head_sha
  binding.
- **v-prefix mismatch**: `amq --version` never carries the tag's `v`
  prefix, so an exact string comparison against the tag could never pass.
  Fixed by stripping `v` before comparing, with both forms shown in
  notices/errors.

## Test plan

- [x] `actionlint .github/workflows/verify-brew-release.yml` clean
      (shellcheck engaged on `run:` blocks)
- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` parses clean
- [x] Downloaded and ran the real `v0.62.0` release binary to confirm the
      version-string format empirically
- [x] Live-checked a real `Release` workflow run's jobs API to confirm the
      false-green scenario and that the gate's check catches it
- [x] `make ci` green locally and via the pre-push hook
- [ ] First live run of this workflow (via `workflow_dispatch` or the next
      real release) — not yet exercised in CI, since it depends on Actions
      execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
