### PR TITLE
test(keepalive): live cmux/Ghostty probes and UUID surface identity

### DIFF
--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -33,9 +33,11 @@ The supported terminal target forms are:
 
 cmux short references such as `surface:2` are rejected because they can drift.
 cmux UUIDs are canonicalized before registration, and the adapter fails closed
-when a surface or its physical TTY identity is missing or ambiguous. Ghostty
-uses its native AppleScript interface and does not use titles, focus stealing,
-System Events, or the clipboard.
+when a surface UUID is missing, not `type==terminal`, or physically ambiguous.
+cmux 0.64.3 `system.tree` omits tty for most surfaces; identity is the surface
+UUID; tty corroborates when present. Ghostty uses its native AppleScript
+interface and does not use titles, focus stealing, System Events, or the
+clipboard.
 
 The cmux CLI is resolved from `AMQ_KEEPALIVE_CMUX`,
 `CMUX_BUNDLED_CLI_PATH`, `PATH`, or the standard application bundle locations.

--- a/internal/keepalive/adapter/adapter.go
+++ b/internal/keepalive/adapter/adapter.go
@@ -73,14 +73,14 @@ func NewRegistry(adapters ...Adapter) Registry {
 }
 
 func DefaultRegistry() Registry {
-	return NewRegistry(File{}, Ghostty{}, Cmux{})
+	return NewRegistry(File{}, Ghostty{}, Cmux{recorded: newCmuxOwnershipRecord()})
 }
 
 // DefaultRegistryWithLogf returns the production adapter set with non-fatal
 // adapter diagnostics wired to logf. Callers that do not own a diagnostic
 // stream can continue using DefaultRegistry.
 func DefaultRegistryWithLogf(logf func(format string, args ...any)) Registry {
-	return NewRegistry(File{}, Ghostty{}, Cmux{Logf: logf})
+	return NewRegistry(File{}, Ghostty{}, Cmux{Logf: logf, recorded: newCmuxOwnershipRecord()})
 }
 
 func (r Registry) Get(name string) (Adapter, error) {

--- a/internal/keepalive/adapter/cmux.go
+++ b/internal/keepalive/adapter/cmux.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -48,6 +49,10 @@ type Cmux struct {
 	// Logf receives non-fatal diagnostics (evictions, degraded fail-closed
 	// ttys). Nil is a no-op.
 	Logf func(format string, args ...any)
+	// recorded remembers the last successful OwnershipKey per surface UUID so
+	// a blank-tty surface:<uuid> key may promote to tty:<pty> once, while a
+	// later tty:<other> for the same UUID stays fail-closed.
+	recorded *cmuxOwnershipRecord
 }
 
 type cmuxSystemTree struct {
@@ -68,8 +73,9 @@ type cmuxPane struct {
 }
 
 type cmuxSurface struct {
-	ID  string `json:"id"`
-	TTY string `json:"tty"`
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	TTY  string `json:"tty"`
 	// ProcessAlive is forward-compat: a future cmux may report per-surface
 	// process liveness directly. Absent (nil) means unknown -> no effect.
 	// Explicit false marks the surface a corpse (a non-claimant, evictable).
@@ -77,9 +83,20 @@ type cmuxSurface struct {
 }
 
 type cmuxSurfaceIdentity struct {
+	Type         string
 	TTY          string
 	WorkspaceID  string
 	ProcessAlive *bool
+}
+
+// cmuxOwnershipRecord is the process-local last-key map for one Cmux adapter.
+type cmuxOwnershipRecord struct {
+	mu   sync.Mutex
+	keys map[string]string
+}
+
+func newCmuxOwnershipRecord() *cmuxOwnershipRecord {
+	return &cmuxOwnershipRecord{keys: map[string]string{}}
 }
 
 // Keep the token non-zero-sized so distinct snapshots cannot legally share an
@@ -124,6 +141,7 @@ type cmuxTargetInventory struct {
 	// notFound marks a canonical tty proven to have zero live owners; its
 	// surfaces resolve to ErrTargetNotFound.
 	notFound map[string]bool
+	recorded *cmuxOwnershipRecord
 }
 
 func (Cmux) Name() string {
@@ -183,7 +201,7 @@ func (c Cmux) buildInventory(ctx context.Context, path string) (cmuxTargetInvent
 	}
 	res := c.resolveOwners(surfaces, true)
 	if len(res.evictions) == 0 {
-		return newCmuxInventory(surfaces, res), nil
+		return c.snapshotInventory(surfaces, res), nil
 	}
 
 	failedTTYs, evicted := c.evict(ctx, path, res.evictions)
@@ -194,7 +212,7 @@ func (c Cmux) buildInventory(ctx context.Context, path string) (cmuxTargetInvent
 		for tty := range failedTTYs {
 			res.forceDegraded(tty)
 		}
-		return newCmuxInventory(surfaces, res), nil
+		return c.snapshotInventory(surfaces, res), nil
 	}
 
 	// At least one alias was retracted; rebuild once so the snapshot reflects
@@ -214,7 +232,7 @@ func (c Cmux) buildInventory(ctx context.Context, path string) (cmuxTargetInvent
 		res2.forceDegraded(tty)
 		c.logf("WARN cmux eviction incomplete, degraded to fail-closed: tty=%s", tty)
 	}
-	return newCmuxInventory(rebuilt, res2), nil
+	return c.snapshotInventory(rebuilt, res2), nil
 }
 
 // fetchSurfaces runs one system.tree RPC and parses it into a surface identity
@@ -251,7 +269,12 @@ func (c Cmux) fetchSurfaces(ctx context.Context, path string) (map[string]cmuxSu
 						return nil, fmt.Errorf("parse cmux system.tree surface id: %w", err)
 					}
 					id = strings.ToUpper(id)
+					typ := strings.TrimSpace(surface.Type)
+					if typ == "" {
+						typ = "terminal"
+					}
 					identity := cmuxSurfaceIdentity{
+						Type:         typ,
 						TTY:          strings.TrimSpace(surface.TTY),
 						WorkspaceID:  strings.TrimSpace(workspace.ID),
 						ProcessAlive: surface.ProcessAlive,
@@ -375,9 +398,15 @@ func (i cmuxTargetInventory) OwnershipKey(target string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if !isCmuxTerminalType(surface.Type) {
+		return "", fmt.Errorf("%w: cmux target %q has type %q, want terminal", ErrTargetDegraded, target, surface.Type)
+	}
 	tty, err := canonicalCmuxTTY(surface.TTY)
 	if err != nil {
-		return "", fmt.Errorf("%w: cmux target %q physical identity is ambiguous: %v", ErrTargetDegraded, target, err)
+		if strings.TrimSpace(surface.TTY) != "" {
+			return "", fmt.Errorf("%w: cmux target %q physical identity is ambiguous: %v", ErrTargetDegraded, target, err)
+		}
+		return i.commitOwnershipKey(id, "surface:"+id)
 	}
 	if tty == cmuxEvictedTTY {
 		return "", fmt.Errorf("%w: cmux target %q was retired as a stale tty alias", ErrTargetNotFound, target)
@@ -391,7 +420,35 @@ func (i cmuxTargetInventory) OwnershipKey(target string) (string, error) {
 	if owner, ok := i.owner[tty]; !ok || owner != id {
 		return "", i.ambiguityError(target, tty)
 	}
-	return "tty:" + tty, nil
+	return i.commitOwnershipKey(id, "tty:"+tty)
+}
+
+func (i cmuxTargetInventory) commitOwnershipKey(id, key string) (string, error) {
+	if err := i.recorded.accept(id, key); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+func (r *cmuxOwnershipRecord) accept(id, key string) error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.keys == nil {
+		r.keys = map[string]string{}
+	}
+	prev, ok := r.keys[id]
+	if !ok || prev == key {
+		r.keys[id] = key
+		return nil
+	}
+	if strings.HasPrefix(prev, "surface:") && strings.HasPrefix(key, "tty:") {
+		r.keys[id] = key
+		return nil
+	}
+	return fmt.Errorf("%w: cmux surface %s ownership key conflict: recorded %q now %q", ErrTargetDegraded, id, prev, key)
 }
 
 func (i cmuxTargetInventory) ambiguityError(target, tty string) error {
@@ -468,7 +525,7 @@ func isCmuxPTY(tty string) bool {
 }
 
 func sameCmuxSurfaceIdentity(left, right cmuxSurfaceIdentity) bool {
-	if left.WorkspaceID != right.WorkspaceID || !sameOptionalBool(left.ProcessAlive, right.ProcessAlive) {
+	if left.WorkspaceID != right.WorkspaceID || left.Type != right.Type || !sameOptionalBool(left.ProcessAlive, right.ProcessAlive) {
 		return false
 	}
 	leftTTY, leftErr := canonicalCmuxTTY(left.TTY)
@@ -556,6 +613,16 @@ func newCmuxInventory(surfaces map[string]cmuxSurfaceIdentity, res cmuxResolutio
 		degraded:       res.degraded,
 		notFound:       res.notFound,
 	}
+}
+
+func (c Cmux) snapshotInventory(surfaces map[string]cmuxSurfaceIdentity, res cmuxResolution) cmuxTargetInventory {
+	inventory := newCmuxInventory(surfaces, res)
+	inventory.recorded = c.recorded
+	return inventory
+}
+
+func isCmuxTerminalType(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "terminal")
 }
 
 // evict retracts each corpse alias via surface.report_tty, writing the sentinel

--- a/internal/keepalive/adapter/cmux_live_test.go
+++ b/internal/keepalive/adapter/cmux_live_test.go
@@ -1,0 +1,240 @@
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCmuxLiveDiscoverProbe(t *testing.T) {
+	if os.Getenv("AMQ_CMUX_LIVE") != "1" {
+		t.Skip("AMQ_CMUX_LIVE=1 required; run from a shell inside a cmux surface")
+	}
+	skipCmuxNonDarwin(t)
+
+	path, err := (Cmux{}).executable()
+	if err != nil {
+		t.Skipf("cmux CLI unavailable: %v", err)
+	}
+	beforeRaw, err := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-workspaces")
+	if err != nil {
+		t.Skipf("cmux list-workspaces denied or failed: %s", strings.TrimSpace(beforeRaw+": "+err.Error()))
+	}
+	before, err := parseCmuxLiveWorkspaces(beforeRaw)
+	if err != nil {
+		t.Fatalf("parse list-workspaces: %v raw=%s", err, beforeRaw)
+	}
+	beforeIDs := cmuxLiveIDs(before)
+	beforeSelected := cmuxLiveSelected(before)
+	beforeCount := len(before)
+	var workspaceID string
+	t.Cleanup(func() {
+		listedRaw, listErr := cmuxLiveRun(path, 30*time.Second, "--id-format", "uuids", "--json", "list-workspaces")
+		if listErr != nil {
+			t.Errorf("cleanup list-workspaces: %s", strings.TrimSpace(listedRaw+": "+listErr.Error()))
+			return
+		}
+		listed, parseErr := parseCmuxLiveWorkspaces(listedRaw)
+		if parseErr != nil {
+			t.Errorf("cleanup parse list-workspaces: %v", parseErr)
+			return
+		}
+		for _, id := range cmuxLiveIDs(listed) {
+			if containsString(beforeIDs, id) {
+				continue
+			}
+			if _, closeErr := cmuxLiveRun(path, 30*time.Second, "close-workspace", "--workspace", id); closeErr != nil {
+				t.Errorf("cleanup close %s: %v", id, closeErr)
+			}
+		}
+		afterRaw, afterErr := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-workspaces")
+		if afterErr != nil {
+			t.Errorf("cleanup recount: %s", strings.TrimSpace(afterRaw+": "+afterErr.Error()))
+			return
+		}
+		after, afterParse := parseCmuxLiveWorkspaces(afterRaw)
+		if afterParse != nil {
+			t.Errorf("cleanup parse recount: %v", afterParse)
+			return
+		}
+		if len(after) != beforeCount {
+			t.Errorf("live workspace count not restored: before=%d after=%d", beforeCount, len(after))
+		}
+		if beforeSelected == "" || !containsString(cmuxLiveIDs(after), beforeSelected) {
+			return
+		}
+		if cmuxLiveSelected(after) == beforeSelected {
+			return
+		}
+		if _, selErr := cmuxLiveRun(path, 5*time.Second, "select-workspace", "--workspace", beforeSelected); selErr != nil {
+			t.Errorf("cleanup restore selected %s: %v", beforeSelected, selErr)
+		}
+	})
+
+	name := "amq-aop1-" + strings.ReplaceAll(t.Name(), "/", "-")
+	cwd := t.TempDir()
+	ack, err := cmuxLiveRun(path, 30*time.Second, "--id-format", "uuids", "--json", "new-workspace", "--name", name, "--cwd", cwd, "--focus", "false")
+	if err != nil {
+		t.Fatalf("new-workspace: %s", strings.TrimSpace(ack+": "+err.Error()))
+	}
+	if !strings.HasPrefix(strings.TrimSpace(ack), "OK workspace:") {
+		t.Fatalf("new-workspace ack = %q, want OK workspace:", ack)
+	}
+	listedRaw, err := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-workspaces")
+	if err != nil {
+		t.Fatalf("list-workspaces after create: %s", strings.TrimSpace(listedRaw+": "+err.Error()))
+	}
+	listed, err := parseCmuxLiveWorkspaces(listedRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := make([]cmuxLiveWorkspace, 0, 1)
+	for _, workspace := range listed {
+		if workspace.Title == name {
+			matches = append(matches, workspace)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("throwaway title %q matched %d workspaces, want 1", name, len(matches))
+	}
+	workspaceID = matches[0].ID
+	surfaceID, err := cmuxLiveTerminalSurface(path, workspaceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := Cmux{
+		Path: path,
+		Getenv: func(key string) string {
+			if key == "CMUX_SURFACE_ID" {
+				return surfaceID
+			}
+			return os.Getenv(key)
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	target, err := adapter.Discover(ctx)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	gotID, err := parseCmuxSurfaceTarget(target)
+	if err != nil {
+		t.Fatalf("Discover target %q: %v", target, err)
+	}
+	wantID, err := normalizeCmuxSurfaceID(surfaceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotID != strings.ToUpper(wantID) {
+		t.Fatalf("Discover = %q, want throwaway surface %q (refusing to touch another surface)", target, surfaceID)
+	}
+	t.Logf("PASS Discover throwaway %s", target)
+	if err := adapter.Probe(ctx, target); err != nil {
+		t.Fatalf("Probe() error = %v", err)
+	}
+	t.Logf("PASS Probe throwaway %s", target)
+
+	if _, err := cmuxLiveRun(path, 30*time.Second, "close-workspace", "--workspace", workspaceID); err != nil {
+		t.Fatalf("close throwaway: %v", err)
+	}
+	workspaceID = ""
+	if err := adapter.Probe(ctx, target); !errors.Is(err, ErrTargetNotFound) {
+		t.Fatalf("Probe after close error = %v, want ErrTargetNotFound", err)
+	}
+	t.Logf("PASS Probe after close is not-found")
+}
+
+type cmuxLiveWorkspace struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Selected bool   `json:"selected"`
+}
+
+func parseCmuxLiveWorkspaces(raw string) ([]cmuxLiveWorkspace, error) {
+	var parsed struct {
+		Workspaces []cmuxLiveWorkspace `json:"workspaces"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, err
+	}
+	if parsed.Workspaces == nil {
+		return []cmuxLiveWorkspace{}, nil
+	}
+	return parsed.Workspaces, nil
+}
+
+func cmuxLiveIDs(records []cmuxLiveWorkspace) []string {
+	ids := make([]string, 0, len(records))
+	for _, workspace := range records {
+		ids = append(ids, strings.ToLower(workspace.ID))
+	}
+	return ids
+}
+
+func cmuxLiveSelected(records []cmuxLiveWorkspace) string {
+	for _, workspace := range records {
+		if workspace.Selected {
+			return strings.ToLower(workspace.ID)
+		}
+	}
+	return ""
+}
+
+func cmuxLiveTerminalSurface(path, workspaceID string) (string, error) {
+	raw, err := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-panes", "--workspace", workspaceID)
+	if err != nil {
+		return "", err
+	}
+	var panes struct {
+		Panes []struct {
+			ID string `json:"id"`
+		} `json:"panes"`
+	}
+	if err := json.Unmarshal([]byte(raw), &panes); err != nil {
+		return "", err
+	}
+	for _, pane := range panes.Panes {
+		surfRaw, surfErr := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-pane-surfaces", "--workspace", workspaceID, "--pane", pane.ID)
+		if surfErr != nil {
+			return "", surfErr
+		}
+		var surfaces struct {
+			Surfaces []struct {
+				ID   string `json:"id"`
+				Type string `json:"type"`
+			} `json:"surfaces"`
+		}
+		if err := json.Unmarshal([]byte(surfRaw), &surfaces); err != nil {
+			return "", err
+		}
+		for _, surface := range surfaces.Surfaces {
+			if surface.Type == "terminal" && strings.TrimSpace(surface.ID) != "" {
+				return surface.ID, nil
+			}
+		}
+	}
+	return "", errors.New("throwaway cmux workspace has no terminal surface")
+}
+
+func cmuxLiveRun(path string, timeout time.Duration, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func containsString(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/keepalive/adapter/cmux_live_test.go
+++ b/internal/keepalive/adapter/cmux_live_test.go
@@ -165,7 +165,6 @@ func TestCmuxLiveDiscoverProbe(t *testing.T) {
 	if _, err := cmuxLiveRun(path, 30*time.Second, "close-workspace", "--workspace", workspaceID); err != nil {
 		t.Fatalf("close throwaway: %v", err)
 	}
-	workspaceID = ""
 	if err := adapter.Probe(ctx, target); !errors.Is(err, ErrTargetNotFound) {
 		t.Fatalf("Probe after close error = %v, want ErrTargetNotFound", err)
 	}
@@ -259,7 +258,6 @@ func cmuxLiveWaitForTerminalSurface(t *testing.T, path, surfaceID string) (json.
 				lastEntry = "<absent from system.tree>"
 				t.Logf("system.tree surface %s absent", surfaceID)
 			} else {
-				lastEntry = string(entry)
 				t.Logf("system.tree surface entry=%s tty=%q", entry, tty)
 				return entry, tty, nil
 			}

--- a/internal/keepalive/adapter/cmux_live_test.go
+++ b/internal/keepalive/adapter/cmux_live_test.go
@@ -147,13 +147,20 @@ func TestCmuxLiveDiscoverProbe(t *testing.T) {
 		t.Fatalf("Discover = %q, want throwaway surface %q (refusing to touch another surface)", target, surfaceID)
 	}
 	t.Logf("PASS Discover throwaway %s", target)
-	if err := cmuxLiveWaitForSurfaceTTY(t, path, surfaceID); err != nil {
+	entry, tty, err := cmuxLiveWaitForTerminalSurface(t, path, surfaceID)
+	if err != nil {
 		t.Fatal(err)
 	}
+	t.Logf("throwaway system.tree entry=%s tty=%q", entry, tty)
 	if err := adapter.Probe(ctx, target); err != nil {
-		t.Fatalf("Probe() error = %v", err)
+		t.Fatalf("Probe() error = %v (null tty must still pass)", err)
 	}
 	t.Logf("PASS Probe throwaway %s", target)
+
+	missing := "cmux:surface:00000000-0000-4000-8000-000000000000"
+	if err := adapter.Probe(ctx, missing); !errors.Is(err, ErrTargetNotFound) {
+		t.Fatalf("Probe missing UUID error = %v, want ErrTargetNotFound", err)
+	}
 
 	if _, err := cmuxLiveRun(path, 30*time.Second, "close-workspace", "--workspace", workspaceID); err != nil {
 		t.Fatalf("close throwaway: %v", err)
@@ -237,7 +244,7 @@ func cmuxLiveTerminalSurface(path, workspaceID string) (string, error) {
 	return "", errors.New("throwaway cmux workspace has no terminal surface")
 }
 
-func cmuxLiveWaitForSurfaceTTY(t *testing.T, path, surfaceID string) error {
+func cmuxLiveWaitForTerminalSurface(t *testing.T, path, surfaceID string) (json.RawMessage, string, error) {
 	t.Helper()
 	deadline := time.Now().Add(cmuxLiveInspectTimeout)
 	var lastEntry string
@@ -253,14 +260,12 @@ func cmuxLiveWaitForSurfaceTTY(t *testing.T, path, surfaceID string) error {
 				t.Logf("system.tree surface %s absent", surfaceID)
 			} else {
 				lastEntry = string(entry)
-				t.Logf("system.tree surface entry=%s", entry)
-				if cmuxLiveTTYReady(tty) {
-					return nil
-				}
+				t.Logf("system.tree surface entry=%s tty=%q", entry, tty)
+				return entry, tty, nil
 			}
 		}
 		if !time.Now().Before(deadline) {
-			return fmt.Errorf("throwaway surface %s never reported a tty in system.tree within %s: last entry=%s", surfaceID, cmuxLiveInspectTimeout, lastEntry)
+			return nil, "", fmt.Errorf("throwaway surface %s never appeared in system.tree within %s: last entry=%s", surfaceID, cmuxLiveInspectTimeout, lastEntry)
 		}
 		time.Sleep(250 * time.Millisecond)
 	}

--- a/internal/keepalive/adapter/cmux_live_test.go
+++ b/internal/keepalive/adapter/cmux_live_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -146,6 +147,9 @@ func TestCmuxLiveDiscoverProbe(t *testing.T) {
 		t.Fatalf("Discover = %q, want throwaway surface %q (refusing to touch another surface)", target, surfaceID)
 	}
 	t.Logf("PASS Discover throwaway %s", target)
+	if err := cmuxLiveWaitForSurfaceTTY(t, path, surfaceID); err != nil {
+		t.Fatal(err)
+	}
 	if err := adapter.Probe(ctx, target); err != nil {
 		t.Fatalf("Probe() error = %v", err)
 	}
@@ -231,6 +235,100 @@ func cmuxLiveTerminalSurface(path, workspaceID string) (string, error) {
 		}
 	}
 	return "", errors.New("throwaway cmux workspace has no terminal surface")
+}
+
+func cmuxLiveWaitForSurfaceTTY(t *testing.T, path, surfaceID string) error {
+	t.Helper()
+	deadline := time.Now().Add(cmuxLiveInspectTimeout)
+	var lastEntry string
+	for {
+		raw, err := cmuxLiveRun(path, cmuxLiveInspectTimeout, "rpc", "system.tree", cmuxSystemTreeParams)
+		if err != nil {
+			lastEntry = strings.TrimSpace(raw + ": " + err.Error())
+			t.Logf("system.tree poll error=%s", lastEntry)
+		} else {
+			entry, tty, found := cmuxLiveFindSurfaceEntry([]byte(raw), surfaceID)
+			if !found {
+				lastEntry = "<absent from system.tree>"
+				t.Logf("system.tree surface %s absent", surfaceID)
+			} else {
+				lastEntry = string(entry)
+				t.Logf("system.tree surface entry=%s", entry)
+				if cmuxLiveTTYReady(tty) {
+					return nil
+				}
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("throwaway surface %s never reported a tty in system.tree within %s: last entry=%s", surfaceID, cmuxLiveInspectTimeout, lastEntry)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func cmuxLiveFindSurfaceEntry(tree []byte, surfaceID string) (json.RawMessage, string, bool) {
+	want, err := normalizeCmuxSurfaceID(surfaceID)
+	if err != nil {
+		return nil, "", false
+	}
+	want = strings.ToUpper(want)
+	var parsed struct {
+		Windows []struct {
+			Workspaces []struct {
+				Panes []struct {
+					Surfaces []json.RawMessage `json:"surfaces"`
+				} `json:"panes"`
+			} `json:"workspaces"`
+		} `json:"windows"`
+	}
+	if err := json.Unmarshal(tree, &parsed); err != nil {
+		return nil, "", false
+	}
+	for _, window := range parsed.Windows {
+		for _, workspace := range window.Workspaces {
+			for _, pane := range workspace.Panes {
+				for _, entry := range pane.Surfaces {
+					var surface struct {
+						ID  string `json:"id"`
+						TTY string `json:"tty"`
+					}
+					if json.Unmarshal(entry, &surface) != nil {
+						continue
+					}
+					id, idErr := normalizeCmuxSurfaceID(surface.ID)
+					if idErr != nil || strings.ToUpper(id) != want {
+						continue
+					}
+					return entry, surface.TTY, true
+				}
+			}
+		}
+	}
+	return nil, "", false
+}
+
+func cmuxLiveTTYReady(tty string) bool {
+	canon, err := canonicalCmuxTTY(tty)
+	if err != nil {
+		return false
+	}
+	return isCmuxPTY(canon)
+}
+
+func TestCmuxLiveFindSurfaceEntryAndTTYReady(t *testing.T) {
+	blank := cmuxTreeWithSurfaceRecords(map[string]string{"id": testCmuxSurfaceID, "tty": ""})
+	entry, tty, ok := cmuxLiveFindSurfaceEntry(blank, testCmuxSurfaceID)
+	if !ok || len(entry) == 0 {
+		t.Fatalf("blank tree missing surface: ok=%v entry=%s", ok, entry)
+	}
+	if cmuxLiveTTYReady(tty) {
+		t.Fatal("blank tty must not be ready")
+	}
+	ready := cmuxTreeWithSurfaces(testCmuxSurfaceID)
+	_, tty, ok = cmuxLiveFindSurfaceEntry(ready, testCmuxSurfaceID)
+	if !ok || !cmuxLiveTTYReady(tty) {
+		t.Fatalf("populated tty ready=%v tty=%q", ok, tty)
+	}
 }
 
 func cmuxLiveRun(path string, timeout time.Duration, args ...string) (string, error) {

--- a/internal/keepalive/adapter/cmux_live_test.go
+++ b/internal/keepalive/adapter/cmux_live_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const cmuxLiveInspectTimeout = 15 * time.Second
+
 func TestCmuxLiveDiscoverProbe(t *testing.T) {
 	if os.Getenv("AMQ_CMUX_LIVE") != "1" {
 		t.Skip("AMQ_CMUX_LIVE=1 required; run from a shell inside a cmux surface")
@@ -21,9 +23,18 @@ func TestCmuxLiveDiscoverProbe(t *testing.T) {
 	if err != nil {
 		t.Skipf("cmux CLI unavailable: %v", err)
 	}
-	beforeRaw, err := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-workspaces")
+	precheckArgs := []string{"--id-format", "uuids", "--json", "list-workspaces"}
+	t.Logf("cmux precheck binary=%s args=%s", path, strings.Join(precheckArgs, " "))
+	start := time.Now()
+	beforeRaw, err := cmuxLiveRun(path, cmuxLiveInspectTimeout, precheckArgs...)
+	elapsed := time.Since(start)
+	t.Logf("cmux precheck duration=%s output=%q err=%v", elapsed, beforeRaw, err)
 	if err != nil {
-		t.Skipf("cmux list-workspaces denied or failed: %s", strings.TrimSpace(beforeRaw+": "+err.Error()))
+		detail := strings.TrimSpace(beforeRaw + ": " + err.Error())
+		if cmuxLiveSocketDenied(beforeRaw, err) {
+			t.Skipf("cmux socket denied: %s", detail)
+		}
+		t.Fatalf("cmux list-workspaces precheck failed: binary=%s args=%s duration=%s output=%q err=%v", path, strings.Join(precheckArgs, " "), elapsed, beforeRaw, err)
 	}
 	before, err := parseCmuxLiveWorkspaces(beforeRaw)
 	if err != nil {
@@ -52,7 +63,7 @@ func TestCmuxLiveDiscoverProbe(t *testing.T) {
 				t.Errorf("cleanup close %s: %v", id, closeErr)
 			}
 		}
-		afterRaw, afterErr := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-workspaces")
+		afterRaw, afterErr := cmuxLiveRun(path, cmuxLiveInspectTimeout, "--id-format", "uuids", "--json", "list-workspaces")
 		if afterErr != nil {
 			t.Errorf("cleanup recount: %s", strings.TrimSpace(afterRaw+": "+afterErr.Error()))
 			return
@@ -71,7 +82,7 @@ func TestCmuxLiveDiscoverProbe(t *testing.T) {
 		if cmuxLiveSelected(after) == beforeSelected {
 			return
 		}
-		if _, selErr := cmuxLiveRun(path, 5*time.Second, "select-workspace", "--workspace", beforeSelected); selErr != nil {
+		if _, selErr := cmuxLiveRun(path, cmuxLiveInspectTimeout, "select-workspace", "--workspace", beforeSelected); selErr != nil {
 			t.Errorf("cleanup restore selected %s: %v", beforeSelected, selErr)
 		}
 	})
@@ -85,7 +96,7 @@ func TestCmuxLiveDiscoverProbe(t *testing.T) {
 	if !strings.HasPrefix(strings.TrimSpace(ack), "OK workspace:") {
 		t.Fatalf("new-workspace ack = %q, want OK workspace:", ack)
 	}
-	listedRaw, err := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-workspaces")
+	listedRaw, err := cmuxLiveRun(path, cmuxLiveInspectTimeout, "--id-format", "uuids", "--json", "list-workspaces")
 	if err != nil {
 		t.Fatalf("list-workspaces after create: %s", strings.TrimSpace(listedRaw+": "+err.Error()))
 	}
@@ -187,7 +198,7 @@ func cmuxLiveSelected(records []cmuxLiveWorkspace) string {
 }
 
 func cmuxLiveTerminalSurface(path, workspaceID string) (string, error) {
-	raw, err := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-panes", "--workspace", workspaceID)
+	raw, err := cmuxLiveRun(path, cmuxLiveInspectTimeout, "--id-format", "uuids", "--json", "list-panes", "--workspace", workspaceID)
 	if err != nil {
 		return "", err
 	}
@@ -200,7 +211,7 @@ func cmuxLiveTerminalSurface(path, workspaceID string) (string, error) {
 		return "", err
 	}
 	for _, pane := range panes.Panes {
-		surfRaw, surfErr := cmuxLiveRun(path, 5*time.Second, "--id-format", "uuids", "--json", "list-pane-surfaces", "--workspace", workspaceID, "--pane", pane.ID)
+		surfRaw, surfErr := cmuxLiveRun(path, cmuxLiveInspectTimeout, "--id-format", "uuids", "--json", "list-pane-surfaces", "--workspace", workspaceID, "--pane", pane.ID)
 		if surfErr != nil {
 			return "", surfErr
 		}
@@ -228,6 +239,32 @@ func cmuxLiveRun(path string, timeout time.Duration, args ...string) (string, er
 	cmd := exec.CommandContext(ctx, path, args...)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+func cmuxLiveSocketDenied(output string, err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(strings.TrimSpace(output + "\n" + err.Error()))
+	for _, needle := range []string{"operation not permitted", "permission denied", "access denied"} {
+		if strings.Contains(text, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCmuxLiveSocketDeniedClassification(t *testing.T) {
+	denied := errors.New("cmux: Operation not permitted")
+	if !cmuxLiveSocketDenied("connect: operation not permitted", denied) {
+		t.Fatal("access-denied text must skip")
+	}
+	if cmuxLiveSocketDenied("", errors.New("signal: killed")) {
+		t.Fatal("precheck timeout/kill must not skip when LIVE=1")
+	}
+	if cmuxLiveSocketDenied("", context.DeadlineExceeded) {
+		t.Fatal("deadline exceeded must not skip when LIVE=1")
+	}
 }
 
 func containsString(ids []string, want string) bool {

--- a/internal/keepalive/adapter/cmux_test.go
+++ b/internal/keepalive/adapter/cmux_test.go
@@ -256,7 +256,7 @@ func TestCmuxInventoryCanonicalizesBareTTYDeviceName(t *testing.T) {
 	}
 }
 
-func TestCmuxInventoryRejectsBlankTTYInsteadOfAssumingUUIDOwnership(t *testing.T) {
+func TestCmuxInventoryUsesSurfaceUUIDWhenTTYBlank(t *testing.T) {
 	skipCmuxNonDarwin(t)
 	runner := &fakeCommandRunner{output: cmuxTreeWithSurfaceRecords(
 		map[string]string{"id": testCmuxSurfaceID, "tty": "  "},
@@ -265,12 +265,81 @@ func TestCmuxInventoryRejectsBlankTTYInsteadOfAssumingUUIDOwnership(t *testing.T
 	if err != nil {
 		t.Fatalf("Inventory() error = %v", err)
 	}
+	key, err := inventory.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
+	if err != nil || key != "surface:"+testCmuxSurfaceID {
+		t.Fatalf("OwnershipKey() = %q, %v, want surface UUID key", key, err)
+	}
+}
+
+func TestCmuxInventoryRejectsNonTerminalType(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{output: cmuxTreeWithSurfaceRecords(
+		map[string]string{"id": testCmuxSurfaceID, "type": "browser", "tty": "ttys011"},
+	)}
+	inventory, err := (Cmux{Runner: runner, Path: "/fake/cmux"}).Inventory(context.Background(), OwnershipContext{})
+	if err != nil {
+		t.Fatalf("Inventory() error = %v", err)
+	}
 	err = inventory.Probe("cmux:surface:" + testCmuxSurfaceID)
-	if err == nil || errors.Is(err, ErrTargetNotFound) {
-		t.Fatalf("Probe() error = %v, want ambiguous missing-tty failure", err)
+	if err == nil || errors.Is(err, ErrTargetNotFound) || !errors.Is(err, ErrTargetDegraded) {
+		t.Fatalf("Probe() error = %v, want degraded non-terminal type", err)
 	}
 	if key, ok := CmuxDegradedOwnershipKey(inventory, err); ok || key != "" {
-		t.Fatalf("CmuxDegradedOwnershipKey(blank tty) = %q, %v; want unavailable", key, ok)
+		t.Fatalf("CmuxDegradedOwnershipKey(non-terminal) = %q, %v; want unavailable", key, ok)
+	}
+}
+
+func TestCmuxOwnershipKeyPromotesBlankTTYToCanonicalTTYOnce(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	recorded := newCmuxOwnershipRecord()
+	blank := &fakeCommandRunner{output: cmuxTreeWithSurfaceRecords(
+		map[string]string{"id": testCmuxSurfaceID, "tty": ""},
+	)}
+	blankInv, err := (Cmux{Runner: blank, Path: "/fake/cmux", recorded: recorded}).Inventory(context.Background(), OwnershipContext{})
+	if err != nil {
+		t.Fatalf("blank Inventory() error = %v", err)
+	}
+	key, err := blankInv.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
+	if err != nil || key != "surface:"+testCmuxSurfaceID {
+		t.Fatalf("blank OwnershipKey() = %q, %v, want surface UUID", key, err)
+	}
+	present := &fakeCommandRunner{output: cmuxTreeWithSurfaceRecords(
+		map[string]string{"id": testCmuxSurfaceID, "tty": "ttys011"},
+	)}
+	presentInv, err := (Cmux{Runner: present, Path: "/fake/cmux", recorded: recorded}).Inventory(context.Background(), OwnershipContext{})
+	if err != nil {
+		t.Fatalf("present Inventory() error = %v", err)
+	}
+	key, err = presentInv.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
+	if err != nil || key != "tty:/dev/ttys011" {
+		t.Fatalf("promoted OwnershipKey() = %q, %v, want tty", key, err)
+	}
+}
+
+func TestCmuxOwnershipKeyRejectsTTYChangeAfterRecordedTTY(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	recorded := newCmuxOwnershipRecord()
+	first := &fakeCommandRunner{output: cmuxTreeWithSurfaceRecords(
+		map[string]string{"id": testCmuxSurfaceID, "tty": "ttys011"},
+	)}
+	firstInv, err := (Cmux{Runner: first, Path: "/fake/cmux", recorded: recorded}).Inventory(context.Background(), OwnershipContext{})
+	if err != nil {
+		t.Fatalf("first Inventory() error = %v", err)
+	}
+	key, err := firstInv.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
+	if err != nil || key != "tty:/dev/ttys011" {
+		t.Fatalf("first OwnershipKey() = %q, %v", key, err)
+	}
+	second := &fakeCommandRunner{output: cmuxTreeWithSurfaceRecords(
+		map[string]string{"id": testCmuxSurfaceID, "tty": "ttys012"},
+	)}
+	secondInv, err := (Cmux{Runner: second, Path: "/fake/cmux", recorded: recorded}).Inventory(context.Background(), OwnershipContext{})
+	if err != nil {
+		t.Fatalf("second Inventory() error = %v", err)
+	}
+	_, err = secondInv.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
+	if err == nil || !errors.Is(err, ErrTargetDegraded) || !strings.Contains(err.Error(), "ownership key conflict") {
+		t.Fatalf("second OwnershipKey() error = %v, want recorded tty conflict", err)
 	}
 }
 
@@ -971,6 +1040,9 @@ func cmuxTreeWithWorkspace(workspaceID string, surfaces ...map[string]string) []
 				continue
 			}
 			record[key] = value
+		}
+		if _, ok := record["type"]; !ok {
+			record["type"] = "terminal"
 		}
 		records = append(records, record)
 	}

--- a/internal/keepalive/adapter/ghostty_live_test.go
+++ b/internal/keepalive/adapter/ghostty_live_test.go
@@ -1,0 +1,190 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGhosttyLiveDiscoverProbe(t *testing.T) {
+	if os.Getenv("AMQ_GHOSTTY_LIVE") != "1" {
+		t.Skip("AMQ_GHOSTTY_LIVE=1 required; run from a shell inside Ghostty")
+	}
+	skipNonDarwin(t)
+
+	if _, err := ghosttyLiveRun(5*time.Second, ghosttyLiveVersionScript); err != nil {
+		t.Skipf("Ghostty AppleScript unavailable: %v", err)
+	}
+	beforeWindows, err := ghosttyLiveWindowIDs()
+	if err != nil {
+		t.Skipf("Ghostty list-windows failed: %v", err)
+	}
+	beforeCount, err := ghosttyLiveTerminalCount()
+	if err != nil {
+		t.Fatalf("count terminals: %v", err)
+	}
+	var windowID string
+	t.Cleanup(func() {
+		listed, listErr := ghosttyLiveWindowIDs()
+		if listErr != nil {
+			t.Errorf("cleanup list windows: %v", listErr)
+			return
+		}
+		for _, id := range listed {
+			if ghosttyContainsID(beforeWindows, id) {
+				continue
+			}
+			if _, closeErr := ghosttyLiveRun(30*time.Second, ghosttyLiveCloseWindowScript, id); closeErr != nil {
+				t.Errorf("cleanup close %s: %v", id, closeErr)
+			}
+		}
+		after, countErr := ghosttyLiveTerminalCount()
+		if countErr != nil {
+			t.Errorf("cleanup terminal count: %v", countErr)
+			return
+		}
+		if after != beforeCount {
+			t.Errorf("live terminal count not restored: before=%d after=%d", beforeCount, after)
+		}
+	})
+
+	created, err := ghosttyLiveRun(30*time.Second, ghosttyLiveNewWindowScript, t.TempDir())
+	if err != nil {
+		t.Fatalf("new-window: %v", err)
+	}
+	parts := strings.Split(strings.TrimSpace(created), "|")
+	if len(parts) != 3 {
+		t.Fatalf("new-window identities %q, want window|tab|terminal", created)
+	}
+	windowID = strings.TrimSpace(parts[0])
+	rawTerminalID := strings.TrimSpace(parts[2])
+	if windowID == "" || rawTerminalID == "" {
+		t.Fatalf("new-window identities %q", created)
+	}
+	terminalID := strings.ToUpper(rawTerminalID)
+	if _, err := ghosttyLiveRun(5*time.Second, ghosttyLiveFocusScript, rawTerminalID); err != nil {
+		t.Fatalf("focus throwaway: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	adapter := Ghostty{}
+	target, err := adapter.Discover(ctx)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	gotID, err := parseGhosttyTerminalTarget(target)
+	if err != nil {
+		t.Fatalf("Discover target %q: %v", target, err)
+	}
+	if gotID != terminalID {
+		t.Fatalf("Discover = %q, want throwaway %q (refusing to touch another terminal)", target, terminalID)
+	}
+	t.Logf("PASS Discover throwaway %s", target)
+	if err := adapter.Probe(ctx, target); err != nil {
+		t.Fatalf("Probe() error = %v", err)
+	}
+	t.Logf("PASS Probe throwaway %s", target)
+
+	if _, err := ghosttyLiveRun(30*time.Second, ghosttyLiveCloseWindowScript, windowID); err != nil {
+		t.Fatalf("close throwaway: %v", err)
+	}
+	windowID = ""
+	if err := adapter.Probe(ctx, target); !errors.Is(err, ErrTargetNotFound) {
+		t.Fatalf("Probe after close error = %v, want ErrTargetNotFound", err)
+	}
+	t.Logf("PASS Probe after close is not-found")
+}
+
+func ghosttyContainsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func ghosttyLiveTerminalCount() (int, error) {
+	out, err := ghosttyLiveRun(5*time.Second, `tell application "Ghostty" to count terminals`)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(out))
+}
+
+func ghosttyLiveWindowIDs() ([]string, error) {
+	out, err := ghosttyLiveRun(5*time.Second, ghosttyLiveListWindowsScript)
+	if err != nil {
+		return nil, err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, ","), nil
+}
+
+func ghosttyLiveRun(timeout time.Duration, script string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmdArgs := append([]string{"-e", script}, args...)
+	cmd := exec.CommandContext(ctx, "osascript", cmdArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), errors.New(strings.TrimSpace(string(out) + ": " + err.Error()))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+const ghosttyLiveVersionScript = `tell application "Ghostty" to get version`
+
+const ghosttyLiveNewWindowScript = `
+on run argv
+	set cwd to item 1 of argv
+	tell application "Ghostty"
+		set cfg to new surface configuration
+		set initial working directory of cfg to cwd
+		set win to new window with configuration cfg
+		set term to terminal 1 of selected tab of win
+		return (id of win) & "|" & (id of selected tab of win) & "|" & (id of term)
+	end tell
+end run
+`
+
+const ghosttyLiveListWindowsScript = `
+tell application "Ghostty"
+	set ids to {}
+	repeat with w in windows
+		set end of ids to id of w
+	end repeat
+	set AppleScript's text item delimiters to ","
+	return ids as text
+end tell
+`
+
+const ghosttyLiveFocusScript = `
+on run argv
+	tell application "Ghostty"
+		set matches to terminals whose id is (item 1 of argv)
+		if (count of matches) is not 1 then error "ghostty terminal not unique"
+		focus (item 1 of matches)
+	end tell
+end run
+`
+
+const ghosttyLiveCloseWindowScript = `
+on run argv
+	set winID to item 1 of argv
+	tell application "Ghostty"
+		set wins to windows whose id is winID
+		if (count of wins) is 0 then error "ghostty window is absent"
+		close window (item 1 of wins)
+	end tell
+end run
+`

--- a/internal/keepalive/adapter/ghostty_live_test.go
+++ b/internal/keepalive/adapter/ghostty_live_test.go
@@ -94,7 +94,6 @@ func TestGhosttyLiveDiscoverProbe(t *testing.T) {
 	if _, err := ghosttyLiveRun(30*time.Second, ghosttyLiveCloseWindowScript, windowID); err != nil {
 		t.Fatalf("close throwaway: %v", err)
 	}
-	windowID = ""
 	if err := adapter.Probe(ctx, target); !errors.Is(err, ErrTargetNotFound) {
 		t.Fatalf("Probe after close error = %v, want ErrTargetNotFound", err)
 	}


### PR DESCRIPTION
## Summary

- Opt-in live Discover/Probe tests for cmux (`AMQ_CMUX_LIVE=1`) and Ghostty (`AMQ_GHOSTTY_LIVE=1`): throwaway target, cleanup registered first, Probe only that id, close, assert not-found and count restored. LIVE=1 precheck timeout/kill is a FAIL, not a skip.
- cmux 0.64.3 `system.tree` omits tty for most surfaces (4/5 long-lived terminals were `tty: null` on the operator machine; only one pane had `ttys012`). Identity is surface UUID + `type==terminal`. Tty corroborates when canonical.
- `OwnershipKey` is `tty:<pty>` when the tree gives a canonical tty this UUID uniquely owns; otherwise `surface:<uuid>`. Blank-to-tty promotion is allowed once and recorded; a later `tty:<other>` for that UUID is degraded. Contested-tty eviction stays tty-only. Ghostty's tty path is unchanged.

```text
BEGIN_COMMIT_OVERRIDE
test(keepalive): live cmux and Ghostty adapter probes

fix(keepalive): identify cmux surfaces by UUID when tty is absent
END_COMMIT_OVERRIDE
```

## Live evidence

- cmux `0d92d3f` inside a real surface: `--- PASS: TestCmuxLiveDiscoverProbe (0.77s)`; precheck 43ms; Discover `9DED367F...`; `system.tree` logged `tty` null / `type` terminal; Probe PASS on that null-tty surface; Probe after close is not-found; operator window before/after identical; no leftovers. HEAD `c5f6bf5` is lint-only (ineffassign) on the live tests; Probe code unchanged.
- Ghostty live PASS on `a4d5cd6` (`TestGhosttyLiveDiscoverProbe`); Ghostty adapter path untouched after that SHA.

## Test plan

- [x] `go test ./... -count=1`
- [x] `go test -race ./internal/keepalive/adapter -count=1`
- [x] gofmt clean on the branch Go files
- [x] fresh-cache `golangci-lint run ./internal/keepalive/...` (0 issues after ineffassign fold)
- [x] Live cmux Probe PASS on a null-tty `type==terminal` surface; FAIL/not-found when missing or gone
- [x] Hostile negatives stay red:
  - `type!=terminal` degrades, not not-found (`TestCmuxInventoryRejectsNonTerminalType`)
  - missing UUID is not-found (`TestCmuxProbeClassifiesSurfaceAbsentFromGlobalTree` + live missing UUID)
  - invalid present tty degrades with no ownership key (`TestCmuxInventoryRejectsNonPTYPathWithoutOwnershipKey`)
  - recorded `tty:<pty>` then `tty:<other>` degrades (`TestCmuxOwnershipKeyRejectsTTYChangeAfterRecordedTTY`)
  - blank tty promotes to canonical tty once (`TestCmuxOwnershipKeyPromotesBlankTTYToCanonicalTTYOnce`)
  - contested tty stays fail-closed (`TestCmuxInventoryRejectsMultipleLiveAliasesForPhysicalTTY`)
  - LIVE=1 timeout/kill is not a skip (`TestCmuxLiveSocketDeniedClassification`)
- [ ] Claude: verify `origin/feat/keepalive-live-probes` == `c5f6bf536937804f88b1969a5cb55d37064a1408` and run the pipeline

Made with [Cursor](https://cursor.com)