### PR TITLE
test(keepalive): prove StartWake against the real amq wake binary

### DIFF
--- a/internal/keepalive/amq/runner_real_amq_unix_test.go
+++ b/internal/keepalive/amq/runner_real_amq_unix_test.go
@@ -1,0 +1,389 @@
+//go:build darwin || linux
+
+package amq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+// These tests deliberately invoke a freshly built cmd/amq binary. The rest of
+// this package proves StartWake's own readiness/cancellation/stderr-capture
+// logic against fixture shell scripts; these tests instead prove that the
+// real amq wake command accepts exactly the argv StartWake constructs and
+// becomes ready, mirroring the real-binary E2E pattern in
+// internal/cli/wake_p0_golden_abi_unix_test.go and wake_restart_e2e_unix_test.go.
+
+var buildRealAMQBinaryOnce = sync.OnceValues(func() (string, error) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("resolve real amq test source path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", "..", ".."))
+	dir, err := os.MkdirTemp("", "amq-keepalive-real-wake-bin-")
+	if err != nil {
+		return "", fmt.Errorf("create real amq binary build dir: %w", err)
+	}
+	binary := filepath.Join(dir, "amq")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", binary, "./cmd/amq")
+	cmd.Dir = repoRoot
+	cmd.Env = realAMQCleanEnv()
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return "", fmt.Errorf("build real amq binary timed out: %w\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		return "", fmt.Errorf("build real amq binary: %w\n%s", err, output)
+	}
+	return binary, nil
+})
+
+func realAMQBinaryForTest(t *testing.T) string {
+	t.Helper()
+	binary, err := buildRealAMQBinaryOnce()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	return binary
+}
+
+// realAMQCleanEnv strips ambient AMQ session/root identity so a real amq
+// child process resolves only the --root this test passed explicitly,
+// mirroring internal/cli/wake_p0_golden_abi_unix_test.go's wakeABICleanEnv.
+func realAMQCleanEnv() []string {
+	env := os.Environ()
+	for _, name := range []string{
+		"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION",
+		"AMQ_GLOBAL_ROOT", "AMQ_WAKE_OWNER", "AMQ_WAKE_PRIVATE_STOP_FD",
+	} {
+		env = environmentWithout(env, name)
+	}
+	return append(env, "AMQ_NO_UPDATE_CHECK=1", "AMQ_WAKE_NO_SELF_UPGRADE=1")
+}
+
+func clearAMQSessionIdentityEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION",
+		"AMQ_GLOBAL_ROOT", "AMQ_WAKE_OWNER", "AMQ_WAKE_PRIVATE_STOP_FD",
+	} {
+		t.Setenv(name, "")
+	}
+	t.Setenv("AMQ_NO_UPDATE_CHECK", "1")
+	t.Setenv("AMQ_WAKE_NO_SELF_UPGRADE", "1")
+}
+
+// secureAMQTestRoot returns a fresh directory rooted under $HOME rather than
+// the system temp directory. amq's --inject-via validation walks every
+// ancestor directory and refuses a group/world-writable one; /tmp itself is
+// typically mode 1777 and would fail that walk. This mirrors
+// internal/cli/main_test.go's cliSecureTempRoot / secureTempDirForTest.
+func secureAMQTestRoot(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("resolve home directory: %v", err)
+	}
+	home, err = filepath.EvalSymlinks(home)
+	if err != nil {
+		t.Fatalf("resolve home directory symlinks: %v", err)
+	}
+	dir, err := os.MkdirTemp(home, ".amq-keepalive-real-wake-test-")
+	if err != nil {
+		t.Fatalf("create secure test root: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("remove secure test root: %v", err)
+		}
+	})
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("secure test root: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolve secure test root symlinks: %v", err)
+	}
+	return resolved
+}
+
+func writeRealAMQInjector(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "inject.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write inject-via executable: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve inject-via executable: %v", err)
+	}
+	return resolved
+}
+
+// indexOfSubsequence returns the index at which needle first occurs as a
+// contiguous run inside haystack, or -1.
+func indexOfSubsequence(haystack, needle []string) int {
+	if len(needle) == 0 || len(haystack) < len(needle) {
+		return -1
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j, want := range needle {
+			if haystack[i+j] != want {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+func realWakeReadinessDirEmpty(t *testing.T, cacheDir string) {
+	t.Helper()
+	readinessDir := filepath.Join(cacheDir, "amq-keepalive", "readiness")
+	entries, err := os.ReadDir(readinessDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		t.Fatalf("read readiness dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "wake-") {
+			t.Fatalf("ready marker %q leaked in %s", entry.Name(), readinessDir)
+		}
+	}
+}
+
+// TestStartWakeRealAMQBinaryBecomesReadyAndMatchesTarget starts a real amq
+// wake process (not a fixture) through StartWake against a freshly
+// initialized queue, and proves the running process itself — inspected via
+// its own argv and via `amq wake check` — was launched with exactly the
+// target/args StartWake constructed.
+func TestStartWakeRealAMQBinaryBecomesReadyAndMatchesTarget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real amq wake E2E")
+	}
+	binary := realAMQBinaryForTest(t)
+	root := secureAMQTestRoot(t)
+	const handle = "codex"
+
+	initCmd := exec.Command(binary, "init", "--root", root, "--agents", handle)
+	initCmd.Env = realAMQCleanEnv()
+	if output, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("amq init: %v\n%s", err, output)
+	}
+
+	injector := writeRealAMQInjector(t, root)
+	cacheDir := filepath.Join(root, "cache")
+	clearAMQSessionIdentityEnv(t)
+	t.Setenv("AMQ_KEEPALIVE_CACHE_DIR", cacheDir)
+
+	const adapter = "real-amq-e2e"
+	const target = "real-amq-e2e:surface:startwake-test"
+	req := StartWakeRequest{
+		Root:      root,
+		Me:        handle,
+		InjectVia: injector,
+		Adapter:   adapter,
+		Target:    target,
+		Timeout:   20 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := NewCLI(binary).StartWake(ctx, req); err != nil {
+		t.Fatalf("StartWake() against real amq binary: %v", err)
+	}
+
+	lockPath := filepath.Join(fsq.AgentBase(root, handle), ".wake.lock")
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read real wake lock: %v", err)
+	}
+	var lock struct {
+		PID      int      `json:"pid"`
+		WakeMode string   `json:"wake_mode"`
+		Args     []string `json:"args"`
+	}
+	if err := json.Unmarshal(lockData, &lock); err != nil {
+		t.Fatalf("parse real wake lock: %v", err)
+	}
+	if lock.PID <= 0 {
+		t.Fatalf("wake lock pid = %d, want > 0", lock.PID)
+	}
+	if lock.WakeMode != "inject-via" {
+		t.Fatalf("wake lock mode = %q, want inject-via", lock.WakeMode)
+	}
+
+	// Safety net only: the assertions below retire the real wake explicitly.
+	// This just guarantees no detached daemon survives if an earlier
+	// assertion aborts the test before that point.
+	t.Cleanup(func() {
+		if killErr := exec.Command("kill", "-0", strconv.Itoa(lock.PID)).Run(); killErr == nil {
+			_ = exec.Command("kill", "-TERM", strconv.Itoa(lock.PID)).Run()
+		}
+	})
+
+	// wakeProcessInfo.Args (and therefore lock.Args) is only populated on
+	// Linux — internal/cli/wake_process_darwin.go never reads argv for the
+	// process it inspects. Where it is available, prove the real process's
+	// own argv is exactly what StartWake constructed.
+	if runtime.GOOS == "linux" {
+		wantArgs := []string{
+			"wake",
+			"-root", root,
+			"-me", handle,
+			"-inject-via", injector,
+			"-inject-arg", "inject",
+			"-inject-arg", adapter,
+			"-inject-arg", target,
+			"--retry-until", "injected",
+			"--accept-existing-wake",
+			"-ready-file",
+		}
+		idx := indexOfSubsequence(lock.Args, wantArgs)
+		if idx < 0 {
+			t.Fatalf("real wake process argv = %#v, want contiguous %#v", lock.Args, wantArgs)
+		}
+		readyValueIdx := idx + len(wantArgs)
+		if readyValueIdx >= len(lock.Args) || !filepath.IsAbs(lock.Args[readyValueIdx]) {
+			t.Fatalf("real wake process -ready-file value missing or not absolute: argv = %#v", lock.Args)
+		}
+	}
+
+	check, err := NewCLI(binary).checkWake(context.Background(), req)
+	if err != nil {
+		t.Fatalf("checkWake() against real amq binary: %v", err)
+	}
+	if !check.LiveWake {
+		t.Fatal("checkWake() live_wake = false, want true after StartWake")
+	}
+	if check.ImageStatus != wakeImageCurrent {
+		t.Fatalf("checkWake() image_status = %q, want %q", check.ImageStatus, wakeImageCurrent)
+	}
+
+	realWakeReadinessDirEmpty(t, cacheDir)
+
+	// Cross-platform proof that the real amq wake stored exactly the
+	// target/args StartWake passed: amq wake retire recomputes an identity
+	// from (root, me, inject-via, inject-arg...) and refuses unless it
+	// matches the persisted target byte-for-byte. A mismatched target must
+	// be refused, with the specific stable reason amq's own target-identity
+	// comparison (sameWakeInjectorIdentity in internal/cli/wake_target.go)
+	// reports — not just any non-retired outcome, which a wrong generic
+	// refusal (owner-bound, unverified identity, artifact error) would also
+	// satisfy — and it must leave the live wake untouched.
+	const wantMismatchReason = "saved wake target uses a different injector identity or retry acknowledgement policy"
+	mismatched, mismatchErr := NewCLI(binary).RetireWake(context.Background(), RetireWakeRequest{
+		Root: root, Me: handle, InjectVia: injector, Adapter: adapter, Target: target + "-wrong",
+	})
+	if mismatched.Retired() {
+		t.Fatalf("RetireWake() with a mismatched target retired the real wake: %+v", mismatched)
+	}
+	if !errors.Is(mismatchErr, ErrWakeRetireNotConfirmed) {
+		t.Fatalf("RetireWake() with a mismatched target error = %v, want ErrWakeRetireNotConfirmed", mismatchErr)
+	}
+	if mismatched.Status != "refused" || mismatched.Reason != wantMismatchReason {
+		t.Fatalf("RetireWake() with a mismatched target = %+v, want status=refused reason=%q",
+			mismatched, wantMismatchReason)
+	}
+	if stillLive, checkErr := NewCLI(binary).checkWake(context.Background(), req); checkErr != nil || !stillLive.LiveWake {
+		t.Fatalf("wake did not survive a refused mismatched retire: live=%+v err=%v", stillLive, checkErr)
+	}
+
+	// ...while the exact identity StartWake used must retire it, and the
+	// retirement must be real: the running process actually exits, the lock
+	// file is gone, and a fresh amq wake check no longer sees it live. The
+	// returned JSON claiming "retired" is not sufficient proof on its own.
+	result, retireErr := NewCLI(binary).RetireWake(context.Background(), RetireWakeRequest{
+		Root: root, Me: handle, InjectVia: injector, Adapter: adapter, Target: target,
+	})
+	if retireErr != nil || !result.Retired() {
+		t.Fatalf("RetireWake() with the exact StartWake identity = %+v, err = %v, want retired", result, retireErr)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		running, runErr := fakeWakeProcessRunning(lock.PID)
+		if runErr != nil {
+			t.Fatalf("inspect retired wake pid %d: %v", lock.PID, runErr)
+		}
+		if !running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("real wake process pid %d still alive after RetireWake() reported retired", lock.PID)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
+		t.Fatalf("wake lock file %q still exists after retirement: %v", lockPath, statErr)
+	}
+	afterCheck, afterErr := NewCLI(binary).checkWake(context.Background(), req)
+	if afterErr != nil {
+		t.Fatalf("checkWake() after retirement: %v", afterErr)
+	}
+	if afterCheck.LiveWake {
+		t.Fatalf("checkWake() live_wake = true after retirement, want false")
+	}
+}
+
+// TestStartWakeRealAMQBinaryFailsForInvalidHandle proves StartWake surfaces a
+// real, documented amq failure — rather than hanging or silently starting a
+// wake — when asked to start against an invalid agent handle, and that no
+// readiness marker is left behind.
+func TestStartWakeRealAMQBinaryFailsForInvalidHandle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real amq wake E2E")
+	}
+	binary := realAMQBinaryForTest(t)
+	root := secureAMQTestRoot(t)
+
+	injector := writeRealAMQInjector(t, root)
+	cacheDir := filepath.Join(root, "cache")
+	clearAMQSessionIdentityEnv(t)
+	t.Setenv("AMQ_KEEPALIVE_CACHE_DIR", cacheDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	err := NewCLI(binary).StartWake(ctx, StartWakeRequest{
+		Root:      root,
+		Me:        "Invalid-Handle", // fsq.ValidateHandle requires [a-z0-9_-]+
+		InjectVia: injector,
+		Adapter:   "real-amq-e2e",
+		Target:    "real-amq-e2e:surface:invalid-handle",
+		Timeout:   10 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("StartWake() error = nil, want failure for an invalid agent handle")
+	}
+	if !strings.Contains(err.Error(), "must match") {
+		t.Fatalf("StartWake() error = %v, want the real amq handle-validation message", err)
+	}
+
+	realWakeReadinessDirEmpty(t, cacheDir)
+
+	// No wake lock should exist for an identity that was never accepted.
+	if _, statErr := os.Stat(filepath.Join(root, "agents", "Invalid-Handle", ".wake.lock")); !os.IsNotExist(statErr) {
+		t.Fatalf("wake lock exists after a refused invalid handle: %v", statErr)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/keepalive/amq/runner_real_amq_unix_test.go` (`//go:build darwin || linux`), proving `StartWake` against a freshly built, real `cmd/amq` binary instead of only the fixture shell scripts already covering `StartWake`'s own readiness/cancellation/stderr-drain logic in `runner_test.go` (kept unchanged — they exercise distinct behavior).
- Two tests share a `sync.OnceValues` build-once helper, modeled on `internal/cli/wake_p0_golden_abi_unix_test.go`'s `buildWakeABIBinary`.

## What the two tests prove

**`TestStartWakeRealAMQBinaryBecomesReadyAndMatchesTarget`**: builds the real `amq` binary, runs `amq init --root <secure-home-tmp> --agents codex`, then calls `StartWake` against it with a real `--inject-via` executable (placed under `$HOME`, not `/tmp`, since amq's inject-via validation walks every ancestor directory and refuses a group/world-writable one). Asserts:
- The ready file appeared (`StartWake` returned `nil`) and the readiness marker directory is empty afterward (no leaked marker).
- `.wake.lock` has `pid > 0` and `wake_mode == "inject-via"`.
- `amq wake check` reports `live_wake=true`, `image_status="current"`.
- On Linux only, the real process's own `/proc/<pid>/cmdline` argv contains the exact contiguous arg sequence `StartWake` constructed (Darwin's `inspectWakeProcessPlatform` never populates process `Args` — verified against `internal/cli/wake_process_darwin.go` vs `wake_process_linux.go` — so this check is `runtime.GOOS == "linux"`-gated rather than faked).
- **Retire mismatch discriminator (cross-platform target/args proof)**: `amq wake retire` with a deliberately wrong `Target` is refused with the *specific* stable reason amq's `sameWakeInjectorIdentity` comparison (`internal/cli/wake_target.go`) reports — `"saved wake target uses a different injector identity or retry acknowledgement policy"` — not just any non-retired outcome (a generic owner-bound/unverified-identity/artifact-error refusal would otherwise also satisfy a looser check). The wake is confirmed still live afterward.
- **Post-retire liveness proof**: after retiring with the *exact* identity `StartWake` used, the test does not trust the returned "retired" JSON status alone — it polls the real OS process until it actually exits, asserts the `.wake.lock` file is removed, and asserts a fresh `amq wake check` reports `live_wake=false`.

**`TestStartWakeRealAMQBinaryFailsForInvalidHandle`** (negative): calls `StartWake` with `Me="Invalid-Handle"` (fails `fsq.ValidateHandle`'s `[a-z0-9_-]+` grammar). Asserts `StartWake` returns a real, documented amq validation error (contains `"must match"`) and that no readiness marker or `.wake.lock` file was ever created.

## Reviewer findings addressed

An earlier round of peer review (Codex) flagged two gaps in this PR's own test, both fixed in the committed version:
1. The mismatched-target retire assertion originally accepted any non-retired result wrapping `ErrWakeRetireNotConfirmed` — now asserts the specific `Status`/`Reason` discriminator above.
2. The exact-identity retire assertion originally trusted the returned "retired" JSON alone — now polls for real process exit, absent lock file, and a fresh `live_wake=false` check.

Both fixes were proven non-tautological by temporarily retargeting each assertion to a wrong expected value, confirming the test genuinely failed against the real binary's actual output, verifying no process leaked, then restoring.

## Test plan

- [x] `go test ./internal/keepalive/... -count=1` — all packages pass
- [x] `go test ./internal/keepalive/amq/... -race -count=2` — pass
- [x] `gofmt -l` — clean
- [x] `golangci-lint run ./internal/keepalive/...` — 0 issues
- [x] `make ci` — green (fresh `GOLANGCI_LINT_CACHE`)
- [x] Pre-push `make ci` — green
- [x] Proved both new assertions can fail (mutated expected values, confirmed FAIL, confirmed no leaked `amq wake` process via the safety-net cleanup, restored)
- [x] No leaked `amq wake` processes after any run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
