### PR TITLE
build(release): embed bare semver from make build to match goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,8 @@ jobs:
         run: VERSION=${{ needs.prepare.outputs.tag }} make build
       - name: Check embedded version
         run: |
-          ./amq version | grep -Fx "${{ needs.prepare.outputs.tag }}"
-          ./amq-keepalive --version | grep -Fx "${{ needs.prepare.outputs.tag }}"
+          ./amq version | grep -Fx "${{ needs.prepare.outputs.version }}"
+          ./amq-keepalive --version | grep -Fx "${{ needs.prepare.outputs.version }}"
 
   release:
     needs: [prepare, verify]

--- a/.github/workflows/verify-brew-release.yml
+++ b/.github/workflows/verify-brew-release.yml
@@ -123,16 +123,9 @@ jobs:
       # Formula push and `brew update` can lag a few minutes behind the
       # GitHub release, so poll instead of failing on the first mismatch.
       #
-      # GoReleaser's ldflags use its own `.Version` template variable, which
-      # strips the leading "v" from the git tag (confirmed against the real
-      # v0.62.0 release: its asset filenames and the downloaded binary both
-      # print "0.62.0", not "v0.62.0"). release.yml's own "Check embedded
-      # version" step compares WITH the "v" prefix, but that checks a
-      # separate `make build` artifact whose Makefile ldflags pass the tag
-      # through verbatim — not the GoReleaser-built binary Homebrew actually
-      # installs. So the tag (with "v") stays the identity used for the
-      # head_sha binding above, but the installed binary's version never
-      # carries one.
+      # GoReleaser {{.Version}} and `make build` both embed bare semver
+      # (the Makefile strips one leading v from VERSION). Compare the
+      # Homebrew-installed binary to the tag with that prefix stripped.
       - name: Install amq, tolerating tap propagation lag
         env:
           EXPECTED_TAG: ${{ needs.gate.outputs.tag }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ own worktrees, dependency scheduling, task decomposition, and PR landing.
 - Keep one version across `CHANGELOG.md`, `.release-please-manifest.json`, and
   skill/plugin metadata. After the release PR merges, `release.yml` validates
   that commit, creates the tag, and publishes GitHub and Homebrew artifacts.
+- `make build` and GoReleaser embed the same bare semver (for example `0.63.0`,
+  not `v0.63.0`); the Makefile strips one leading `v` from `VERSION`.
 - PR titles use `type(scope): description`. Squash merge makes the title the
   conventional commit on `main`. Use `BEGIN_COMMIT_OVERRIDE` in the PR body,
   or edit the release PR, when release notes need multiple entries. Each entry

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# GoReleaser {{.Version}} is bare semver; strip one leading v from VERSION.
+EMBED_VERSION := $(patsubst v%,%,$(VERSION))
 GOLANGCI_LINT_CACHE ?= $(CURDIR)/.golangci-cache
 
 build:
-	go build -ldflags "-X main.version=$(VERSION)" -o amq ./cmd/amq
-	go build -ldflags "-X main.version=$(VERSION)" -o amq-keepalive ./cmd/amq-keepalive
+	go build -ldflags "-X main.version=$(EMBED_VERSION)" -o amq ./cmd/amq
+	go build -ldflags "-X main.version=$(EMBED_VERSION)" -o amq-keepalive ./cmd/amq-keepalive
 
 test:
 	go test ./...

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -527,4 +527,5 @@ echo "integration: kanban needs a live websocket workspace, skipping invocation 
 
 bash scripts/test_install_checksum.sh
 AMQ_TEST_BIN="$BIN" bash scripts/test_stop_hook.sh
+bash scripts/test_version_embed.sh
 echo "smoke test ok"

--- a/scripts/test_version_embed.sh
+++ b/scripts/test_version_embed.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+fail() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+assert_make_embeds() {
+  local input="$1"
+  local want="$2"
+  local dry
+  dry="$(make -n build VERSION="$input")"
+  printf '%s\n' "$dry" | grep -F -- "-X main.version=${want}" >/dev/null ||
+    fail "make build VERSION=${input} ldflags missing -X main.version=${want}: ${dry}"
+}
+
+assert_make_embeds v9.9.9 9.9.9
+assert_make_embeds 9.9.9 9.9.9
+assert_make_embeds vv9.9.9 v9.9.9
+assert_make_embeds dev dev
+
+if make -n build VERSION=v9.9.9 | grep -F -- "-X main.version=v9.9.9" >/dev/null; then
+  fail "make build VERSION=v9.9.9 still embeds a leading v"
+fi
+
+make build VERSION=v9.9.9
+got="$(./amq --version)"
+[[ "$got" == "9.9.9" ]] || fail "amq --version = ${got}, want 9.9.9"
+got="$(./amq version)"
+[[ "$got" == "9.9.9" ]] || fail "amq version = ${got}, want 9.9.9"
+got="$(./amq-keepalive --version)"
+[[ "$got" == "9.9.9" ]] || fail "amq-keepalive --version = ${got}, want 9.9.9"
+echo "version embed ok"

--- a/scripts/test_version_embed.sh
+++ b/scripts/test_version_embed.sh
@@ -35,3 +35,4 @@ got="$(./amq version)"
 got="$(./amq-keepalive --version)"
 [[ "$got" == "9.9.9" ]] || fail "amq-keepalive --version = ${got}, want 9.9.9"
 echo "version embed ok"
+make build


### PR DESCRIPTION
## Summary

- Shipped GoReleaser binaries print bare semver (`0.62.0`); `make build VERSION=v0.62.0` used to embed `v0.62.0`. The Makefile now strips one leading `v` so both paths stamp `main.version` the same way.
- `release.yml` still builds with `VERSION=<tag>` (v-prefixed) and checks `./amq version` and `./amq-keepalive --version` against `prepare.outputs.version` (bare).
- Smoke runs `scripts/test_version_embed.sh`: `make build VERSION=v9.9.9` must print `9.9.9`, then a plain `make build` restores the default `VERSION`.

```text
BEGIN_COMMIT_OVERRIDE
fix(build): embed the same bare semver as GoReleaser

test(build): restore default VERSION after embed smoke
END_COMMIT_OVERRIDE
```

## Test plan

- [x] `bash scripts/test_version_embed.sh` — embed `9.9.9`, then restore default `make build`
- [x] Mutant: keep the leading `v` in ldflags → `make -n build VERSION=v9.9.9` still contains `-X main.version=v9.9.9` and the script fails
- [ ] Claude: verify `origin/chore/version-parity` == `6eaff17a8ddc0f19b5209b046677235a1f8b73de` and run the pipeline

Made with [Cursor](https://cursor.com)