### PR TITLE
fix(release): look up the exact release tag instead of scanning the releases list

### DIFF
--- a/scripts/check-release-please-state.sh
+++ b/scripts/check-release-please-state.sh
@@ -28,23 +28,56 @@ if [[ ! "$main_sha" =~ ^[0-9a-f]{40}([0-9a-f]{24})?$ ]]; then
 fi
 
 tag="v${version}"
-release_pages="$(
-  gh api --paginate --slurp \
-    "repos/${github_repository}/releases?per_page=100"
+set +e
+release_response="$(
+  gh api --include \
+    "repos/${github_repository}/releases/tags/${tag}" 2>&1
 )"
-released=false
-if jq -e --arg tag "$tag" \
-  'any(.[][]; .draft == false and .published_at != null and
-    (.tag_name | type == "string") and .tag_name == $tag)' \
-  >/dev/null <<<"$release_pages"; then
-  released=true
-else
-  jq_status=$?
-  if [[ "$jq_status" != "1" ]]; then
-    echo "::error::GitHub releases response was not valid paginated JSON."
-    exit "$jq_status"
-  fi
+gh_status=$?
+set -e
+
+release_response="${release_response//$'\r'/}"
+status_line="${release_response%%$'\n'*}"
+if [[ ! "$status_line" =~ ^HTTP/[^[:space:]]+[[:space:]]+([0-9]{3})([[:space:]]|$) ]]; then
+  echo "::error::GitHub release lookup did not return an HTTP status."
+  exit 1
 fi
+http_status="${BASH_REMATCH[1]}"
+
+case "$http_status" in
+  200)
+    if [[ "$gh_status" != "0" || "$release_response" != *$'\n\n'* ]]; then
+      echo "::error::GitHub release lookup returned an invalid HTTP 200 response."
+      exit 1
+    fi
+    release_body="${release_response#*$'\n\n'}"
+    if ! released="$(
+      jq -er --arg tag "$tag" '
+        if type != "object" or
+          (.tag_name | type) != "string" or .tag_name != $tag or
+          (.draft | type) != "boolean" or
+          ((.published_at | type) != "string" and .published_at != null)
+        then error("invalid release response fields")
+        else ((.draft == false and .published_at != null) | tostring)
+        end
+      ' <<<"$release_body"
+    )"; then
+      echo "::error::GitHub release lookup returned invalid JSON or response fields."
+      exit 1
+    fi
+    if [[ "$released" != "true" && "$released" != "false" ]]; then
+      echo "::error::GitHub release lookup returned multiple JSON values."
+      exit 1
+    fi
+    ;;
+  404)
+    released=false
+    ;;
+  *)
+    echo "::error::GitHub release lookup failed with HTTP ${http_status}."
+    exit 1
+    ;;
+esac
 
 {
   printf 'version=%s\n' "$version"

--- a/scripts/test_release_please_config.py
+++ b/scripts/test_release_please_config.py
@@ -116,8 +116,11 @@ def test_release_please_workflow_is_pr_only_and_staged() -> None:
 def test_release_state_scripts_are_injection_safe() -> None:
     state = (ROOT / "scripts/check-release-please-state.sh").read_text()
     assert "RELEASE_VERSION_PATTERN=" in state
-    assert 'jq -e --arg tag "$tag"' in state
-    assert ".tag_name == $tag" in state
+    assert "gh api --include" in state
+    assert '"repos/${github_repository}/releases/tags/${tag}"' in state
+    assert 'jq -er --arg tag "$tag"' in state
+    assert ".tag_name != $tag" in state
+    assert "releases?per_page=" not in state
     assert "grep " not in state
     assert "printf 'version=%s\\n'" in state
     assert "printf 'released=%s\\n'" in state

--- a/scripts/test_release_please_state.sh
+++ b/scripts/test_release_please_state.sh
@@ -21,28 +21,37 @@ set -euo pipefail
 
 printf '%s\n' "$*" >>"${GH_CALL_LOG:?}"
 [[ "$1" == "api" ]]
-[[ " $* " == *" --paginate "* ]]
-[[ " $* " == *" --slurp "* ]]
-
-if [[ "${FAKE_RELEASE_MODE:?}" == "api-failure" ]]; then
-  exit 1
-fi
+[[ "$2" == "--include" ]]
+[[ "$3" == "repos/example/amq/releases/tags/${FAKE_RELEASE_TAG:?}" ]]
 
 python3 - "${FAKE_RELEASE_MODE:?}" "${FAKE_RELEASE_TAG:-}" <<'PY'
 import json
 import sys
 
 mode, tag = sys.argv[1:]
-if mode == "invalid-json":
-    print("not json")
-elif mode == "exact":
-    print(json.dumps([[{"draft": False, "published_at": "2026-07-27", "tag_name": tag}]]))
+status = "200 OK"
+body = {"draft": False, "published_at": "2026-07-27", "tag_name": tag}
+if mode == "not-found":
+    status = "404 Not Found"
+    body = {"message": "Not Found"}
+elif mode == "server-error":
+    status = "500 Internal Server Error"
+    body = {"message": "server error"}
+elif mode == "invalid-json":
+    body = "not json"
 elif mode == "draft":
-    print(json.dumps([[{"draft": True, "published_at": None, "tag_name": tag}]]))
-elif mode == "similar":
-    print(json.dumps([[{"draft": False, "published_at": "2026-07-27", "tag_name": tag + "0"}]]))
-else:
-    print(json.dumps([[]]))
+    body = {"draft": True, "published_at": "2026-07-27", "tag_name": tag}
+elif mode == "prerelease":
+    body["prerelease"] = True
+elif mode == "invalid-fields":
+    body["draft"] = "false"
+
+print(f"HTTP/2.0 {status}")
+print("Content-Type: application/json; charset=utf-8\r")
+print("\r")
+print(body if isinstance(body, str) else json.dumps(body))
+if status != "200 OK":
+    sys.exit(1)
 PY
 EOF
 chmod +x "$FAKE_BIN/gh"
@@ -85,13 +94,15 @@ run_state_check() {
 
 write_manifest "1.2.3"
 : >"$TEST_TMPDIR/gh-calls"
-run_state_check similar "v1.2.3"
+run_state_check not-found "v1.2.3"
 grep -Fx "version=1.2.3" "$TEST_TMPDIR/state-output" >/dev/null
 grep -Fx "released=false" "$TEST_TMPDIR/state-output" >/dev/null
 grep -Fx "main_sha=$STATE_SHA" "$TEST_TMPDIR/state-output" >/dev/null
+grep -Fx "api --include repos/example/amq/releases/tags/v1.2.3" \
+  "$TEST_TMPDIR/gh-calls" >/dev/null
 
 write_manifest "1.2.3-rc.1"
-run_state_check exact "v1.2.3-rc.1"
+run_state_check prerelease "v1.2.3-rc.1"
 grep -Fx "released=true" "$TEST_TMPDIR/state-output" >/dev/null
 
 write_manifest "1.2.3"
@@ -107,8 +118,15 @@ fi
 [[ ! -s "$TEST_TMPDIR/state-output" ]]
 
 : >"$TEST_TMPDIR/gh-calls"
-if run_state_check api-failure "v1.2.3"; then
-  echo "releases API failure unexpectedly accepted" >&2
+if run_state_check server-error "v1.2.3"; then
+  echo "release API server error unexpectedly accepted" >&2
+  exit 1
+fi
+[[ ! -s "$TEST_TMPDIR/state-output" ]]
+
+: >"$TEST_TMPDIR/gh-calls"
+if run_state_check invalid-fields "v1.2.3"; then
+  echo "invalid release response fields unexpectedly accepted" >&2
   exit 1
 fi
 [[ ! -s "$TEST_TMPDIR/state-output" ]]


### PR DESCRIPTION
## Summary

- query the exact `releases/tags/v{version}` endpoint
- treat only HTTP 404 as not released and fail closed on other API or response errors
- validate published, draft, malformed, 5xx, 404, and prerelease responses

## Verification

- `bash scripts/test_release_please_state.sh`
- `python3 scripts/test_release_please_config.py`
- fresh-cache `make ci`
- live lookup for `v0.62.0` returned `released=true`