### PR TITLE
docs: managed launchers, adapters, live proofs, and release checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,11 @@ go test ./internal/sessionguard
 make check-skills
 ```
 
+Opt-in live proofs (`AMQ_CMUX_LIVE`, `AMQ_GHOSTTY_LIVE`, `AMQ_CLAUDE_LIVE`,
+`AMQ_CODEX_LIVE`, `AMQ_CURSOR_LIVE`) skip unless the env is `1`. They are not
+part of `make ci`. Operator commands are in
+[the public launch API guide](docs/launch-api.md).
+
 Tests must include a negative case that a plausible wrong implementation would
 fail. For concurrency, routing, wake, and filesystem work, exercise the actual
 hostile boundary rather than only a helper or mock.

--- a/COOP.md
+++ b/COOP.md
@@ -15,17 +15,21 @@ For swarm command reference, see [CLAUDE.md](CLAUDE.md).
 ## Co-op Workflow
 
 Use the [README Quick Start](README.md#quick-start) to install AMQ, configure
-the project with `amq setup`, and run `amq launch`. The `commands` backend
-prints one complete `coop exec` command for each configured agent and exits `6`
-until those commands are started. This document begins at that co-op-specific
-step; it does not define a second setup path.
+the project with `amq setup`, and run `amq launch`. `--launcher auto` (the
+default) may select `tmux`, `cmux`, or `ghostty` and run the declared plan
+in-app. The `commands` backend prints one complete `coop exec` command for
+each configured agent and exits `6` until those commands are started. This
+document begins at that co-op-specific step; it does not define a second
+setup path.
 
 ### Running Co-op Mode
 
-Paste each complete command emitted by `amq launch` into its own terminal. The
-emitted lines are the canonical execution surface: they include the exact
-session, launch nonce, execution ticket, and provider command declared in
-`.amq/launch.json`. Do not shorten or rebuild them from an example.
+When launch uses the `commands` backend, paste each complete emitted command
+into its own terminal. The emitted lines are the canonical execution surface:
+they include the exact session, launch nonce, execution ticket, and provider
+command declared in `.amq/launch.json`. Do not shorten or rebuild them from
+an example. Managed `tmux`, `cmux`, and `ghostty` backends do not print those
+lines; they create the panes or windows themselves.
 
 Include Grok in the setup roster when it should join the session. AMQ starts
 only adapters that pass their capability probe.
@@ -64,8 +68,8 @@ documented exception.
 
 ### Multiple Pairs (Isolated Sessions)
 
-Create each named session explicitly, reconcile it, then run the emitted
-commands in separate terminals:
+Create each named session explicitly, then launch it. When launch uses the
+`commands` backend, run the emitted commands in separate terminals:
 
 ```bash
 # Pair A: auth feature
@@ -77,7 +81,8 @@ amq session create api
 amq launch --session api
 ```
 
-Paste the commands emitted by each `launch` into separate terminals.
+When launch uses the `commands` backend, paste the emitted commands into
+separate terminals.
 
 Each pair has isolated inboxes and threads. Messages stay within their root.
 Equivalent explicit root form: `--root .agent-mail/<session>`.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ For Homebrew installations:
 brew upgrade amq
 ```
 
+GitHub Actions `verify-brew-release` confirms a published tag installs from
+`avivsinai/tap/amq` and that `amq --version` matches that tag. It does not
+replace `brew upgrade` on an operator machine.
+
 For installations made with the install script or another manual binary install:
 ```bash
 amq upgrade
@@ -170,15 +174,27 @@ exit `6` until that digest is trusted. An unknown `session resume` name exits
 `3` and writes nothing. Managed backends use a fail-closed recovery journal;
 see [Managed launch recovery](docs/launch-recovery.md).
 
+Registered launchers are `commands`, `tmux`, `cmux` (envelope `>=0.64.3 <1.0`,
+protocol 2), and `ghostty` (AppleScript, envelope `>=1.3.0 <2.0`).
+`--launcher auto` is the default: it walks the local launcher preference and
+selects the first backend whose Detect reports Available. An explicit
+`--launcher <name>` wins. When `CMUX_SURFACE_ID` is set, auto prepends `cmux`
+ahead of `ghostty`; otherwise `TERM_PROGRAM=ghostty` prepends `ghostty`. Setup
+lists cmux and Ghostty in `available_launchers` only after their Detect ping
+succeeds, not from `LookPath` alone. Operator live proofs are in
+[the public launch API guide](docs/launch-api.md).
+
 The stable executable path before symlink resolution is the trusted identity;
 retargeting that symlink is machine-owner territory, in the same trust class
 as changing `PATH`.
 
 The `commands` backend prints complete `coop exec` commands and exits `6`
-because executing them is the remaining operator action. Paste those emitted
-lines exactly, one per terminal. Do not reconstruct them from examples: they
-bind the selected session, launch nonce, provider arguments, and execution
-ticket.
+because executing them is the remaining operator action. When launch uses that
+backend, paste those emitted lines exactly, one per terminal. Do not
+reconstruct them from examples: they bind the selected session, launch nonce,
+provider arguments, and execution ticket. Managed `tmux`, `cmux`, and
+`ghostty` backends run the declared plan in-app instead of printing those
+lines.
 
 Automation can use the versioned public launch contract instead of the
 interactive flow:
@@ -214,7 +230,8 @@ amq session create feature-a
 amq launch --session feature-a
 ```
 
-Again, paste the complete commands emitted by `launch` into separate terminals.
+When launch uses the `commands` backend, paste the complete emitted commands
+into separate terminals.
 
 Optional aliases are a convenience, not part of the canonical quickstart.
 A bare `eval "$(amq shell-setup)"` affects only the current shell. To make

--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -42,6 +42,14 @@ clipboard.
 The cmux CLI is resolved from `AMQ_KEEPALIVE_CMUX`,
 `CMUX_BUNDLED_CLI_PATH`, `PATH`, or the standard application bundle locations.
 
+Operator live discover probes skip unless the env is `1`. Run them from a
+shell inside the matching surface:
+
+```sh
+AMQ_CMUX_LIVE=1 go test ./internal/keepalive/adapter -run TestCmuxLiveDiscoverProbe -count=1 -v
+AMQ_GHOSTTY_LIVE=1 go test ./internal/keepalive/adapter -run TestGhosttyLiveDiscoverProbe -count=1 -v
+```
+
 ## Attach and reattach
 
 Register without starting a wake when another owner, such as `amq coop exec`,

--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -61,16 +61,33 @@ configured Codex notify command after publication; a missing command is a
 no-op, and a forwarding failure cannot undo or fail the evidence path. An
 unused Codex launch remains pending and cannot be resumed. Cursor CLI acquires
 its provider-owned chat ID before process start through `create-chat` at exact
-version `2026.08.11-e8db854`.
+version `2026.08.11-e8db854`. Cursor's provider identity is `cursor-agent`.
 
-The tier-1 provider smokes are opt-in. The Codex smoke first proves that an
-unused launch stays pending and returns AMQ's typed stale-conversation action.
-It then sends one fixed prompt through the managed pane, waits for notify-backed
-identity publication, and performs one exact headless resume:
+The registered launcher backends are `commands`, `tmux`, `cmux`, and
+`ghostty`. `--launcher auto` walks the local preference; an explicit
+`--launcher <name>` wins. When `CMUX_SURFACE_ID` is set, auto prepends `cmux`
+ahead of `ghostty`; otherwise `TERM_PROGRAM=ghostty` prepends `ghostty`.
+Selection still requires Detect Available. Cmux Create uses `--focus false`
+and restores prior selection; see [Managed launch recovery](launch-recovery.md).
+
+The tier-1 provider smokes are opt-in and skip unless the env is `1`. The Codex
+smoke first proves that an unused launch stays pending and returns AMQ's typed
+stale-conversation action. It then sends one fixed prompt through the managed
+pane, waits for notify-backed identity publication, and performs one exact
+headless resume:
 
 ```bash
 AMQ_CLAUDE_LIVE=1 go test ./internal/launch -run TestClaudeLiveManagedMintResumeAndCrashReuse -count=1 -v
 AMQ_CODEX_LIVE=1 go test ./internal/launch -run TestCodexLiveManagedAcquireResumeAndCrashReuse -count=1 -v
+AMQ_CURSOR_LIVE=1 go test ./internal/launch -run TestCursorLiveResumeManagedExecutionAndCrashReuse -count=1 -v
+```
+
+Managed launcher live proofs skip unless the env is `1`. Run them from a shell
+inside the matching surface:
+
+```bash
+AMQ_CMUX_LIVE=1 go test ./internal/launch -run TestCmuxLive -count=1 -v
+AMQ_GHOSTTY_LIVE=1 go test ./internal/launch -run TestGhosttyLive -count=1 -v
 ```
 
 The smoke harness disables Claude tools with the CLI-equivalent single argument

--- a/docs/launch-recovery.md
+++ b/docs/launch-recovery.md
@@ -31,8 +31,10 @@ never adoptable. A Ghostty crash between window creation and binding persistence
 leaves that window for manual close; AMQ never treats the gap as proven absence
 and never creates a duplicate.
 
-Managed cmux Create puts the new workspace in the app-wide active window and
-does not retarget it.
+Cmux Create uses `--focus false` and restores the previously selected workspace
+after Create, including on failure cleanup. Close restores the workspace that
+was selected at Close time, skipping the workspace being closed. Focus then
+Close can leave a neighbor workspace selected.
 
 If an operator chooses to abandon recovery evidence, first inspect the exact
 target without mutation:

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -178,10 +178,15 @@ launcher validates them and includes them in the semantic trust digest. The
 first semantic plan, and each plan change, needs an interactive trust
 confirmation stored outside the worktree. Non-interactive or `--json` calls
 exit `6` until that digest is trusted. An unknown `session resume` name exits
-`3` and writes nothing. The `commands` backend prints complete `coop exec`
-commands and exits `6` because running them is the remaining operator action.
-Paste the emitted lines exactly, one per terminal; do not reconstruct them from
-generic `coop exec` examples.
+`3` and writes nothing. Registered launchers are `commands`, `tmux`, `cmux`,
+and `ghostty`. `--launcher auto` walks the local preference; an explicit
+`--launcher <name>` wins. Inside cmux (`CMUX_SURFACE_ID`) is preferred over
+inside Ghostty (`TERM_PROGRAM=ghostty`). Setup lists cmux and Ghostty as
+available only when Detect ping succeeds, not from LookPath alone. The
+`commands` backend prints complete `coop exec` commands and exits `6` because
+running them is the remaining operator action. Paste the emitted lines exactly,
+one per terminal; do not reconstruct them from generic `coop exec` examples.
+Managed `tmux`, `cmux`, and `ghostty` backends run the plan in-app instead.
 
 Without `--session` or `--root`, `coop exec` uses the declared `default_session` from `.amq/launch.json`, or `collab` when none is declared. Creating a missing session or root from `coop exec` is deprecated and prints `warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
 


### PR DESCRIPTION
## Summary
- Documents registered launchers (`commands`, `tmux`, `cmux` `>=0.64.3 <1.0` protocol 2, `ghostty` AppleScript `>=1.3.0 <2.0`), `--launcher auto` preference walking, and explicit `--launcher <name>` override. Inside cmux (`CMUX_SURFACE_ID`) prepends ahead of Ghostty (`TERM_PROGRAM=ghostty`); Detect Available still gates selection.
- Setup lists cmux and Ghostty in `available_launchers` only after Detect ping succeeds, not from `LookPath` alone. The `commands` backend still prints `coop exec` and exits `6`; managed backends run the plan in-app.
- Cursor capture is pre-spawn `create-chat` at `2026.08.11-e8db854` with provider identity `cursor-agent`. Codex notify pin `0.147.0` forwards the operator hook. Claude minted `--session-id` persists after the first turn.
- Opt-in live proofs: `AMQ_CLAUDE_LIVE`, `AMQ_CODEX_LIVE`, `AMQ_CURSOR_LIVE`, `AMQ_CMUX_LIVE`, `AMQ_GHOSTTY_LIVE` (skip unless env is `1`; not part of `make ci`). Keepalive discover probes use the same cmux/Ghostty gates.
- Cmux Create uses `--focus false` and restores the previously selected workspace; Focus then Close can leave a neighbor selected. README notes `verify-brew-release` confirms tap install and `amq --version` vs tag; it does not replace local `brew upgrade`.
- Docs-only. No product changes. `make check-skills` pass. Skill version left at 0.62.0. Peer-reviewed by Codex (no factual counterexample; live test names verified).

## Test plan
- [ ] Launchers and envelope bounds in README, `docs/launch-api.md`, and `skills/amq-cli/SKILL.md` match `DefaultBackends()` / profiles.
- [ ] Auto-order: `CMUX_SURFACE_ID` prepends `cmux` over `ghostty`; otherwise `TERM_PROGRAM=ghostty` prepends `ghostty`; explicit `--launcher` wins.
- [ ] Setup `available_launchers` for cmux/Ghostty requires Detect ping, not `LookPath` alone.
- [ ] Live tests skip unless documented env vars are `1`.
- [ ] Cmux Create uses `--focus false` and restores prior selection per `docs/launch-recovery.md`.
- [ ] `verify-brew-release` README sentence matches the workflow (tap install + version; not an operator upgrade substitute).

Made with [Cursor](https://cursor.com)