### PR TITLE
test(cli): prove coop exec strips the private launch nonce

### DIFF
--- a/internal/cli/managed_execution_options_test.go
+++ b/internal/cli/managed_execution_options_test.go
@@ -2,14 +2,12 @@ package cli
 
 import (
 	"encoding/base64"
-	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
@@ -89,96 +87,6 @@ func TestManagedCoopExecDoesNotProvisionMissingTicketRoot(t *testing.T) {
 	}
 	if _, statErr := os.Stat(missing); !os.IsNotExist(statErr) {
 		t.Fatalf("managed refusal provisioned %s: %v", missing, statErr)
-	}
-}
-
-func TestManagedCoopExecDoesNotForwardPrivateLaunchNonce(t *testing.T) {
-	project := t.TempDir()
-	session := filepath.Join(project, "session")
-	if err := fsq.EnsureRootDirs(session); err != nil {
-		t.Fatal(err)
-	}
-	if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
-		t.Fatal(err)
-	}
-	identity, err := fsq.SnapshotDeliveryRoot(session)
-	if err != nil {
-		t.Fatal(err)
-	}
-	root, err := fsq.OpenDeliveryRoot(session, identity)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = root.Close() }()
-	amqExecutable, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	nonce := "71717171-7171-4171-8171-717171717171"
-	options := &launch.PrepareExecutionOptions{WakeMode: "disabled", AuditReason: "test"}
-	lease, err := launch.AcquireLease(root, nonce)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := lease.LockHandles("claude"); err != nil {
-		t.Fatal(err)
-	}
-	ticket, err := launch.NewExecutionTicket(launch.ExecutionTicketRequest{
-		Handle: "claude", LaunchNonce: nonce, Mode: launch.AdapterModeMint,
-		Provider: launch.ClaudeProvider, ConversationID: nonce,
-		ProjectRoot: project, SessionRoot: session, Cwd: project,
-		ProviderExecutable: "/usr/bin/true", AMQExecutable: amqExecutable,
-		TargetArgv: []string{"/usr/bin/true"}, Execution: options,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := launch.WriteExecutionTicket(root, lease, ticket); err != nil {
-		t.Fatal(err)
-	}
-	if err := launch.WriteConversation(root, lease, launch.ConversationRecord{
-		Version: launch.ConversationVersion, Handle: "claude", State: launch.CapturePending, LaunchNonce: nonce,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := lease.Release(); err != nil {
-		t.Fatal(err)
-	}
-
-	oldCWD, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(project); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
-	t.Setenv(launch.InternalLaunchNonceEnv, nonce)
-	self := os.Getpid()
-	owner := wakeOwner{PID: self, ProcessStart: "12345", BootID: "11111111-1111-1111-1111-111111111111", SessionID: 99}
-	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
-		return wakeProcessInfo{PID: pid, Running: pid == self, StartToken: owner.ProcessStart, BootID: owner.BootID}
-	})
-	stubWakeProcessSID(t, func(int) (int, error) { return owner.SessionID, nil })
-
-	sentinel := errors.New("exec sentinel")
-	oldExec := coopExecProcess
-	var execEnv []string
-	coopExecProcess = func(_ string, _ []string, env []string) error {
-		execEnv = append([]string(nil), env...)
-		return sentinel
-	}
-	t.Cleanup(func() { coopExecProcess = oldExec })
-	err = runCoopExec([]string{
-		"--root", session, "--me", "claude", "--no-wake", "--managed-no-wake-reason", "test", "/usr/bin/true",
-	})
-	if !errors.Is(err, sentinel) {
-		t.Fatalf("coop exec error = %v, want sentinel", err)
-	}
-	for _, entry := range execEnv {
-		if strings.HasPrefix(entry, launch.InternalLaunchNonceEnv+"=") {
-			t.Fatalf("provider environment contains private launch nonce: %q", entry)
-		}
 	}
 }
 

--- a/internal/cli/managed_execution_options_test.go
+++ b/internal/cli/managed_execution_options_test.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"encoding/base64"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
@@ -87,6 +89,96 @@ func TestManagedCoopExecDoesNotProvisionMissingTicketRoot(t *testing.T) {
 	}
 	if _, statErr := os.Stat(missing); !os.IsNotExist(statErr) {
 		t.Fatalf("managed refusal provisioned %s: %v", missing, statErr)
+	}
+}
+
+func TestManagedCoopExecDoesNotForwardPrivateLaunchNonce(t *testing.T) {
+	project := t.TempDir()
+	session := filepath.Join(project, "session")
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	amqExecutable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := "71717171-7171-4171-8171-717171717171"
+	options := &launch.PrepareExecutionOptions{WakeMode: "disabled", AuditReason: "test"}
+	lease, err := launch.AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := launch.NewExecutionTicket(launch.ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: launch.AdapterModeMint,
+		Provider: launch.ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: project, SessionRoot: session, Cwd: project,
+		ProviderExecutable: "/usr/bin/true", AMQExecutable: amqExecutable,
+		TargetArgv: []string{"/usr/bin/true"}, Execution: options,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteExecutionTicket(root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteConversation(root, lease, launch.ConversationRecord{
+		Version: launch.ConversationVersion, Handle: "claude", State: launch.CapturePending, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
+	t.Setenv(launch.InternalLaunchNonceEnv, nonce)
+	self := os.Getpid()
+	owner := wakeOwner{PID: self, ProcessStart: "12345", BootID: "11111111-1111-1111-1111-111111111111", SessionID: 99}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: pid == self, StartToken: owner.ProcessStart, BootID: owner.BootID}
+	})
+	stubWakeProcessSID(t, func(int) (int, error) { return owner.SessionID, nil })
+
+	sentinel := errors.New("exec sentinel")
+	oldExec := coopExecProcess
+	var execEnv []string
+	coopExecProcess = func(_ string, _ []string, env []string) error {
+		execEnv = append([]string(nil), env...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+	err = runCoopExec([]string{
+		"--root", session, "--me", "claude", "--no-wake", "--managed-no-wake-reason", "test", "/usr/bin/true",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want sentinel", err)
+	}
+	for _, entry := range execEnv {
+		if strings.HasPrefix(entry, launch.InternalLaunchNonceEnv+"=") {
+			t.Fatalf("provider environment contains private launch nonce: %q", entry)
+		}
 	}
 }
 

--- a/internal/cli/managed_execution_options_unix_test.go
+++ b/internal/cli/managed_execution_options_unix_test.go
@@ -1,0 +1,104 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+func TestManagedCoopExecDoesNotForwardPrivateLaunchNonce(t *testing.T) {
+	project := t.TempDir()
+	session := filepath.Join(project, "session")
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	amqExecutable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := "71717171-7171-4171-8171-717171717171"
+	options := &launch.PrepareExecutionOptions{WakeMode: "disabled", AuditReason: "test"}
+	lease, err := launch.AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := launch.NewExecutionTicket(launch.ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: launch.AdapterModeMint,
+		Provider: launch.ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: project, SessionRoot: session, Cwd: project,
+		ProviderExecutable: "/usr/bin/true", AMQExecutable: amqExecutable,
+		TargetArgv: []string{"/usr/bin/true"}, Execution: options,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteExecutionTicket(root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteConversation(root, lease, launch.ConversationRecord{
+		Version: launch.ConversationVersion, Handle: "claude", State: launch.CapturePending, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
+	t.Setenv(launch.InternalLaunchNonceEnv, nonce)
+	self := os.Getpid()
+	owner := wakeOwner{PID: self, ProcessStart: "12345", BootID: "11111111-1111-1111-1111-111111111111", SessionID: 99}
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: pid == self, StartToken: owner.ProcessStart, BootID: owner.BootID}
+	})
+	stubWakeProcessSID(t, func(int) (int, error) { return owner.SessionID, nil })
+
+	sentinel := errors.New("exec sentinel")
+	oldExec := coopExecProcess
+	var execEnv []string
+	coopExecProcess = func(_ string, _ []string, env []string) error {
+		execEnv = append([]string(nil), env...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+	err = runCoopExec([]string{
+		"--root", session, "--me", "claude", "--no-wake", "--managed-no-wake-reason", "test", "/usr/bin/true",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want sentinel", err)
+	}
+	for _, entry := range execEnv {
+		if strings.HasPrefix(entry, launch.InternalLaunchNonceEnv+"=") {
+			t.Fatalf("provider environment contains private launch nonce: %q", entry)
+		}
+	}
+}


### PR DESCRIPTION
## Mutation sweep

Gremlins efficacy:

- `internal/launch` high-risk files (`apply.go`, `prepare.go`, `lease.go`, `evidence.go`, `cmux.go`, `ghostty.go`): 653/653 covered mutants killed.
- `internal/launch/commands.go`: 23/23 covered mutants killed.
- `internal/cli`: the package coverprofile was empty (0.0%), so Gremlins reported all 405 candidates as not covered. The CLI surface was tested with handcrafted execution mutants.

## Survivor table

| Location | Mutant | Ruling | Evidence |
| --- | --- | --- | --- |
| `internal/cli/coop_exec_unix.go:464` | Stop stripping `AMQ_INTERNAL_LAUNCH_NONCE` from the provider environment | MEANINGFUL | The full CLI suite initially survived. The new boundary test fails with the exact leaked nonce and passes after the mutant is reverted. |

No noise survivors were padded into the report.

Handcrafted killed controls:

- Bypass the setup approval-digest mismatch check: killed by `TestSetupPreviewDigestBindsApplyWithoutWrites`.
- Accept an empty internal notify nonce: killed by `TestCodexNotifyRequiresManagedNonceEnvironment`.
- Bypass resolved conversation argv in the private launch wrapper: killed by `TestPrivateCursorLaunchWrapperExecsOnlyResolvedConversationSlot`.
- Omit the automatic Apply subject digest: killed by `TestPublicLaunchPlanAppliesWithEmptyDecisionsWhenReady`.
- Omit the exact `--root` from coop execution: killed by `TestExactRootAcrossSiblingWorktrees`.

## Verification

- Focused test passes on canonical code.
- Focused test fails on the nonce-leak mutant.
- `go test ./internal/launch ./internal/cli -count=1`: PASS.
- `make ci`: PASS.
- Pre-push checks: PASS.
- Peer review: Cursor approved by execution.
- Product changes: none.
