### PR TITLE
test: kill mutation-sweep survivors in fsq, receipt, and keepalive cmux

### DIFF
--- a/internal/fsq/delivery_root_regular_test.go
+++ b/internal/fsq/delivery_root_regular_test.go
@@ -56,3 +56,35 @@ func TestDeliveryRootOpenLockFileStableInode(t *testing.T) {
 		t.Fatal("OpenLockFile replaced the lock inode")
 	}
 }
+
+func TestClassifyLayoutRejectsAgentsSymlink(t *testing.T) {
+	base := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(base, "agents")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	root := openDeliveryRootForTest(t, base)
+	state, err := root.ClassifyLayout()
+	if err == nil || state == LayoutInitialized {
+		t.Fatalf("ClassifyLayout = %v, %v; want foreign and error", state, err)
+	}
+}
+
+func TestWriteFileExclusiveDoesNotReplace(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	root := openDeliveryRootForTest(t, base)
+	dir := filepath.Join("agents", "alice", "receipts")
+	if _, err := root.WriteFileExclusive(dir, "once.json", []byte("first\n"), 0o600); err != nil {
+		t.Fatalf("first WriteFileExclusive: %v", err)
+	}
+	if _, err := root.WriteFileExclusive(dir, "once.json", []byte("second\n"), 0o600); err == nil {
+		t.Fatal("second WriteFileExclusive replaced an existing name")
+	}
+	data, err := os.ReadFile(filepath.Join(base, dir, "once.json"))
+	if err != nil || string(data) != "first\n" {
+		t.Fatalf("exclusive file contents = %q, %v", data, err)
+	}
+}

--- a/internal/fsq/filename_test.go
+++ b/internal/fsq/filename_test.go
@@ -16,6 +16,7 @@ func invalidMessageFilenames(t *testing.T) []string {
 		filepath.Join(os.TempDir(), "message.md"),
 		"message\x00.md",
 		"message.txt",
+		".attack.md",
 	}
 }
 
@@ -82,6 +83,24 @@ func TestMessageFilenameEntryPointsAcceptValidFilenames(t *testing.T) {
 	restoredPath := filepath.Join(AgentInboxNew(root, "alice"), "valid_dlq_source.md")
 	if _, err := os.Stat(restoredPath); err != nil {
 		t.Fatalf("expected retry to restore original filename unchanged: %v", err)
+	}
+}
+
+func TestFindMessagePrefersNewWhenBothBoxesExist(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	filename := "both.md"
+	if err := os.WriteFile(filepath.Join(AgentInboxNew(root, "alice"), filename), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(AgentInboxCur(root, "alice"), filename), []byte("cur"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path, box, err := FindMessage(root, "alice", filename)
+	if err != nil || box != BoxNew || path != filepath.Join(AgentInboxNew(root, "alice"), filename) {
+		t.Fatalf("FindMessage = %q %q %v, want inbox/new", path, box, err)
 	}
 }
 

--- a/internal/fsq/scan_test.go
+++ b/internal/fsq/scan_test.go
@@ -30,6 +30,7 @@ func TestFindTmpFilesOlderThan(t *testing.T) {
 	oldPath := filepath.Join(tmpDir, "old.tmp")
 	dlqOldPath := filepath.Join(dlqTmpDir, "dlq-old.tmp")
 	dotOldPath := filepath.Join(outboxDir, ".outbox.tmp-123")
+	dotNoisePath := filepath.Join(outboxDir, ".DS_Store")
 	newPath := filepath.Join(tmpDir, "new.tmp")
 	if err := os.WriteFile(oldPath, []byte("old"), 0o644); err != nil {
 		t.Fatalf("write old: %v", err)
@@ -39,6 +40,9 @@ func TestFindTmpFilesOlderThan(t *testing.T) {
 	}
 	if err := os.WriteFile(dotOldPath, []byte("old dot"), 0o644); err != nil {
 		t.Fatalf("write dot tmp: %v", err)
+	}
+	if err := os.WriteFile(dotNoisePath, []byte("finder"), 0o644); err != nil {
+		t.Fatalf("write dot noise: %v", err)
 	}
 	if err := os.WriteFile(newPath, []byte("new"), 0o644); err != nil {
 		t.Fatalf("write new: %v", err)
@@ -53,6 +57,9 @@ func TestFindTmpFilesOlderThan(t *testing.T) {
 	}
 	if err := os.Chtimes(dotOldPath, oldTime, oldTime); err != nil {
 		t.Fatalf("chtimes dot old: %v", err)
+	}
+	if err := os.Chtimes(dotNoisePath, oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes dot noise: %v", err)
 	}
 
 	cutoff := time.Now().Add(-36 * time.Hour)

--- a/internal/keepalive/adapter/cmux_test.go
+++ b/internal/keepalive/adapter/cmux_test.go
@@ -289,6 +289,21 @@ func TestCmuxInventoryRejectsNonTerminalType(t *testing.T) {
 	}
 }
 
+func TestCmuxInventoryAcceptsMixedCaseTerminalType(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{output: cmuxTreeWithSurfaceRecords(
+		map[string]string{"id": testCmuxSurfaceID, "type": "Terminal", "tty": "ttys011"},
+	)}
+	inventory, err := (Cmux{Runner: runner, Path: "/fake/cmux"}).Inventory(context.Background(), OwnershipContext{})
+	if err != nil {
+		t.Fatalf("Inventory() error = %v", err)
+	}
+	key, err := inventory.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
+	if err != nil || key != "tty:/dev/ttys011" {
+		t.Fatalf("OwnershipKey() = %q, %v, want tty for mixed-case Terminal type", key, err)
+	}
+}
+
 func TestCmuxOwnershipKeyPromotesBlankTTYToCanonicalTTYOnce(t *testing.T) {
 	skipCmuxNonDarwin(t)
 	recorded := newCmuxOwnershipRecord()
@@ -340,6 +355,46 @@ func TestCmuxOwnershipKeyRejectsTTYChangeAfterRecordedTTY(t *testing.T) {
 	_, err = secondInv.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
 	if err == nil || !errors.Is(err, ErrTargetDegraded) || !strings.Contains(err.Error(), "ownership key conflict") {
 		t.Fatalf("second OwnershipKey() error = %v, want recorded tty conflict", err)
+	}
+}
+
+func TestCmuxOwnershipKeyAcceptsRepeatedIdenticalTTY(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	recorded := newCmuxOwnershipRecord()
+	runner := &fakeCommandRunner{output: cmuxTreeWithSurfaceRecords(
+		map[string]string{"id": testCmuxSurfaceID, "tty": "ttys011"},
+	)}
+	firstInv, err := (Cmux{Runner: runner, Path: "/fake/cmux", recorded: recorded}).Inventory(context.Background(), OwnershipContext{})
+	if err != nil {
+		t.Fatalf("first Inventory() error = %v", err)
+	}
+	first, err := firstInv.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
+	if err != nil || first != "tty:/dev/ttys011" {
+		t.Fatalf("first OwnershipKey() = %q, %v", first, err)
+	}
+	secondInv, err := (Cmux{Runner: runner, Path: "/fake/cmux", recorded: recorded}).Inventory(context.Background(), OwnershipContext{})
+	if err != nil {
+		t.Fatalf("second Inventory() error = %v", err)
+	}
+	second, err := secondInv.OwnershipKey("cmux:surface:" + testCmuxSurfaceID)
+	if err != nil || second != first {
+		t.Fatalf("repeated identical OwnershipKey() = %q, %v; want %q", second, err, first)
+	}
+}
+
+func TestCmuxInventoryRejectsDuplicateSurfaceIDWhenProcessAliveOmitted(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte(`{
+		"windows":[{
+			"workspaces":[{"id":"WS-1","panes":[{"surfaces":[
+				{"id":"F901D722-6789-4BBB-9818-C4E97F20BEB3","tty":"ttys011"},
+				{"id":"F901D722-6789-4BBB-9818-C4E97F20BEB3","tty":"ttys011","process_alive":true}
+			]}]}]
+		}]
+	}`)}
+	_, err := (Cmux{Runner: runner, Path: "/fake/cmux"}).Inventory(context.Background(), OwnershipContext{})
+	if err == nil || !strings.Contains(err.Error(), "conflicting tty identities") {
+		t.Fatalf("Inventory() error = %v, want nil vs set process_alive conflict", err)
 	}
 }
 
@@ -633,6 +688,33 @@ func TestCmuxInjectEvictsProcessDeadAliasThenSendsText(t *testing.T) {
 	}
 	if evictParams["surface_id"] != corpse || evictParams["tty_name"] != cmuxEvictedTTYName {
 		t.Fatalf("report_tty params = %#v, want corpse retracted to sentinel", evictParams)
+	}
+}
+
+func TestCmuxEvictDoesNotReportTTYWhenWorkspaceIDEmpty(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	corpse := "B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2"
+	runner := &fakeCommandRunner{output: cmuxTreeWithWorkspace("",
+		map[string]string{"id": testCmuxSurfaceID, "tty": "ttys011"},
+		map[string]string{"id": corpse, "tty": "ttys011", "process_alive": "false"},
+	)}
+	liveness := &fakeTTYLiveness{count: 1}
+	err := (Cmux{
+		Runner:            runner,
+		Path:              "/fake/cmux",
+		LiveTTYOwnerCount: liveness.ownerCount,
+		Sleep:             func(context.Context, time.Duration) error { return nil },
+	}).Inject(context.Background(), "cmux:surface:"+testCmuxSurfaceID, "payload")
+	if err == nil {
+		t.Fatal("Inject() succeeded; empty workspace id must fail closed without report_tty")
+	}
+	for _, call := range runner.calls {
+		if len(call.args) >= 2 && call.args[1] == "surface.report_tty" {
+			t.Fatalf("report_tty with empty workspace id: %#v", call)
+		}
+	}
+	if len(runner.calls) != 1 || runner.calls[0].args[1] != "system.tree" {
+		t.Fatalf("calls = %#v, want inventory only", runner.calls)
 	}
 }
 

--- a/internal/receipt/receipt_delivery_root_unix_test.go
+++ b/internal/receipt/receipt_delivery_root_unix_test.go
@@ -51,3 +51,71 @@ func TestWaitForDeliveryRootRejectsReplacedRootAlias(t *testing.T) {
 		t.Fatalf("WaitForDeliveryRoot error = %v, want root-change refusal", err)
 	}
 }
+
+func TestReadDeliveryRootRejectsSymlink(t *testing.T) {
+	rootPath := t.TempDir()
+	if err := fsq.EnsureAgentDirs(rootPath, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	r := New("msg_symlink_root", "p2p/claude__codex", "claude", "codex", StageDrained, "")
+	if err := EmitDeliveryRoot(root, r); err != nil {
+		t.Fatalf("EmitDeliveryRoot: %v", err)
+	}
+	rel := filepath.Join("agents", "codex", "receipts")
+	if err := os.Symlink(r.filename(), filepath.Join(rootPath, rel, "linked.json")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	_, err = ReadDeliveryRoot(root, filepath.Join(rel, "linked.json"))
+	if err == nil {
+		t.Fatal("expected symlink receipt to be rejected")
+	}
+}
+
+func TestWaitForDeliveryRootTimeoutZeroWaitsUntilReceipt(t *testing.T) {
+	rootPath := t.TempDir()
+	if err := fsq.EnsureAgentDirs(rootPath, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		t.Fatalf("SnapshotDeliveryRoot: %v", err)
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		t.Fatalf("OpenDeliveryRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := WaitForDeliveryRoot(root, "msg_zero_root", "codex", StageDrained, 0, 20*time.Millisecond)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("timeout 0 returned immediately: %v", err)
+	case <-time.After(80 * time.Millisecond):
+	}
+	r := New("msg_zero_root", "p2p/claude__codex", "claude", "codex", StageDrained, "")
+	if err := EmitDeliveryRoot(root, r); err != nil {
+		t.Fatalf("EmitDeliveryRoot: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WaitForDeliveryRoot(timeout 0): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForDeliveryRoot(timeout 0) did not observe the receipt")
+	}
+}

--- a/internal/receipt/receipt_test.go
+++ b/internal/receipt/receipt_test.go
@@ -195,3 +195,102 @@ func TestWaitForCrossRoot(t *testing.T) {
 		t.Fatalf("WaitFor(sourceRoot) error = %v, want deadline exceeded", err)
 	}
 }
+
+func TestEmitReceiptMode0600(t *testing.T) {
+	root := setupTestRoot(t)
+	r := New("msg_mode", "p2p/claude__codex", "claude", "codex", StageDrained, "")
+	if err := Emit(root, r); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(root, "agents", "codex", "receipts", r.filename()))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("receipt mode = %04o, want 0600", got)
+	}
+}
+
+func TestWaitForTimeoutZeroWaitsUntilReceipt(t *testing.T) {
+	root := setupTestRoot(t)
+	done := make(chan error, 1)
+	go func() {
+		_, err := WaitFor(root, "msg_zero", "codex", StageDrained, 0, 20*time.Millisecond)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("timeout 0 returned immediately: %v", err)
+	case <-time.After(80 * time.Millisecond):
+	}
+	r := New("msg_zero", "p2p/claude__codex", "claude", "codex", StageDrained, "")
+	if err := Emit(root, r); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WaitFor(timeout 0): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitFor(timeout 0) did not observe the receipt")
+	}
+}
+
+func TestListFilterConsumerAndMsgIDDelimiter(t *testing.T) {
+	root := setupTestRoot(t)
+	for _, r := range []Receipt{
+		New("msg_01", "p2p/claude__codex", "claude", "codex", StageDrained, ""),
+		New("msg_010", "p2p/claude__codex", "claude", "codex", StageDrained, ""),
+	} {
+		if err := Emit(root, r); err != nil {
+			t.Fatalf("Emit %s: %v", r.MsgID, err)
+		}
+	}
+
+	got, err := List(root, "codex", ListFilter{MsgID: "msg_01"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].MsgID != "msg_01" {
+		t.Fatalf("MsgID msg_01 filter = %+v, want only msg_01", got)
+	}
+
+	got, err = List(root, "codex", ListFilter{Consumer: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Consumer claude in codex mailbox = %+v, want empty", got)
+	}
+	got, err = List(root, "codex", ListFilter{Consumer: "codex"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Consumer codex filter = %d, want 2", len(got))
+	}
+}
+
+func TestListOrdersByEmittedAt(t *testing.T) {
+	root := setupTestRoot(t)
+	first := New("msg_early", "p2p/claude__codex", "claude", "codex", StageDrained, "")
+	if err := Emit(root, first); err != nil {
+		t.Fatalf("Emit first: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	second := New("msg_late", "p2p/claude__codex", "claude", "codex", StageDrained, "")
+	if err := Emit(root, second); err != nil {
+		t.Fatalf("Emit second: %v", err)
+	}
+	got, err := List(root, "codex", ListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].MsgID != "msg_early" || got[1].MsgID != "msg_late" {
+		t.Fatalf("List order = %+v, want msg_early then msg_late", got)
+	}
+	if got[0].EmittedAt >= got[1].EmittedAt {
+		t.Fatalf("EmittedAt not ascending: %q then %q", got[0].EmittedAt, got[1].EmittedAt)
+	}
+}


### PR DESCRIPTION
## Summary
- Gremlins on `0317640`: `internal/receipt` Killed 17 / Lived 5 / Not covered 3 (efficacy 77%); `internal/fsq` Killed 344 / Lived 67 / Not covered 122 (efficacy 84%); `internal/keepalive/adapter` Killed 16 / Lived 0 / Not covered 10 / Timed out 142 (default mutators; invert-logical off).
- Docs-adjacent tests only. No product changes. Peer review: Codex approved by execution (nonce-leak sibling #537 path; this PR's tests reviewed in the same sweep).

Survivor table (MEANINGFUL killed; tests are real-boundary):

| site | mutant | verdict | killing test |
| --- | --- | --- | --- |
| `receipt.go:94/119` | `timeout > 0` boundary | MEANINGFUL | `TestWaitForTimeoutZeroWaitsUntilReceipt` + delivery-root twin |
| `receipt.go:203` | invert/change `EmittedAt` sort | MEANINGFUL | `TestListOrdersByEmittedAt` |
| `receipt.go:123/147` | `ReadFile` instead of `ReadRegularNoFollow` | MEANINGFUL | `TestReadDeliveryRootRejectsSymlink` (`darwin \|\| linux`) |
| `receipt.go:186` | MsgID prefix without `__` | MEANINGFUL | `TestListFilterConsumerAndMsgIDDelimiter` |
| `receipt.go:192` | drop Consumer filter | MEANINGFUL | same |
| `receipt.go:67` | `0o600` → `0o644` | MEANINGFUL | `TestEmitReceiptMode0600` |
| `cmux.go:443` | drop `\|\| prev == key` | MEANINGFUL | `TestCmuxOwnershipKeyAcceptsRepeatedIdenticalTTY` |
| `cmux.go:541` | `sameOptionalBool` nil vs set | MEANINGFUL | `TestCmuxInventoryRejectsDuplicateSurfaceIDWhenProcessAliveOmitted` |
| `cmux.go:625` | `==` instead of `EqualFold` | MEANINGFUL | `TestCmuxInventoryAcceptsMixedCaseTerminalType` |
| `cmux.go:637` | skip empty `workspaceID` evict guard | MEANINGFUL | `TestCmuxEvictDoesNotReportTTYWhenWorkspaceIDEmpty` |
| `filename.go:14` | allow `.attack.md` | MEANINGFUL | `invalidMessageFilenames` |
| `find.go` | cur-before-new | MEANINGFUL | `TestFindMessagePrefersNewWhenBothBoxesExist` |
| `scan.go:85` | treat `.DS_Store` as tmp | MEANINGFUL | `TestFindTmpFilesOlderThan` noise file |
| `delivery_root.go:485` | ClassifyLayout agents symlink | MEANINGFUL | `TestClassifyLayoutRejectsAgentsSymlink` (`Skipf` if symlink unsupported) |
| `delivery_root.go:611` | `WriteFileExclusive` replaces | MEANINGFUL | `TestWriteFileExclusiveDoesNotReplace` |

Remaining ~60 fsq LIVED are NOISE or hook-unreachable (layout comparisons, atomic close-defer, `isSyncUnsupported` behind `syncDirForTest`).

## Test plan
- [x] `go test ./internal/receipt ./internal/fsq ./internal/keepalive/... -race -count=1`
- [x] `golangci-lint run ./internal/receipt/... ./internal/fsq/... ./internal/keepalive/...` (0 issues)
- [x] `GOOS=windows GOARCH=amd64 go vet ./internal/receipt/ ./internal/fsq/ ./internal/keepalive/...` and `go test -c` of those packages
- [ ] CI green on ubuntu/macos/windows

Made with [Cursor](https://cursor.com)