### PR TITLE
fix(init): provision reserved user mailbox so fresh queue passes doctor

### DIFF
--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -310,7 +310,7 @@ func provisionCoopBaseAndSession(base, session string, agents []string) error {
 	if err := fsq.EnsureRootDirs(base); err != nil {
 		return fmt.Errorf("failed to create root directories: %w", err)
 	}
-	for _, agent := range agents {
+	for _, agent := range withReservedHumanHandle(agents) {
 		if err := fsq.EnsureAgentDirs(base, agent); err != nil {
 			return fmt.Errorf("failed to create compatibility base mailbox for %s: %w", agent, err)
 		}
@@ -394,7 +394,7 @@ func provisionCoopSessionChild(base, session string, agents []string, execAgent,
 		if err := sessionRoot.EnsureRootDirs(); err != nil {
 			return err
 		}
-		for _, agent := range agents {
+		for _, agent := range withReservedHumanHandle(agents) {
 			if err := sessionRoot.EnsureAgentDirs(agent); err != nil {
 				return fmt.Errorf("failed to create mailbox for %s: %w", agent, err)
 			}

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -909,10 +909,13 @@ func TestCoopInitRerunUsesConfiguredAgents(t *testing.T) {
 			t.Fatalf("%s inbox was not restored: %v", agent, err)
 		}
 	}
-	for _, agent := range []string{"claude", "codex", "user"} {
+	for _, agent := range []string{"claude", "codex"} {
 		if _, err := os.Stat(filepath.Join(root, defaultSessionName, "agents", agent)); !os.IsNotExist(err) {
 			t.Fatalf("rerun created default agent %q, stat err=%v", agent, err)
 		}
+	}
+	if _, err := os.Stat(filepath.Join(root, defaultSessionName, "agents", reservedHumanHandle, "inbox", "new")); err != nil {
+		t.Fatalf("rerun did not provision the reserved human inbox: %v", err)
 	}
 	configAfter, err := os.ReadFile(cfgPath)
 	if err != nil {

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -1431,7 +1431,7 @@ func runCoopExecAutoInitNoGitignoreFixture(t *testing.T) string {
 	return projectDir
 }
 
-func TestInitExplicitAgentsDoesNotInjectUser(t *testing.T) {
+func TestInitExplicitAgentsKeepsConfigLiteralAndProvisionsUser(t *testing.T) {
 	root := t.TempDir()
 	_, err := captureEnvStdout(t, func() error {
 		return runInit([]string{"--root", root, "--agents", "claude,codex"})
@@ -1448,8 +1448,8 @@ func TestInitExplicitAgentsDoesNotInjectUser(t *testing.T) {
 	if !reflect.DeepEqual(cfg.Agents, want) {
 		t.Fatalf("config agents = %#v, want %#v", cfg.Agents, want)
 	}
-	if _, err := os.Stat(filepath.Join(root, "agents", "user")); !os.IsNotExist(err) {
-		t.Fatalf("user mailbox should not be created by explicit init, stat err=%v", err)
+	if _, err := os.Stat(filepath.Join(root, "agents", "user", "inbox", "new")); err != nil {
+		t.Fatalf("implicit user inbox should be created without changing config agents: %v", err)
 	}
 }
 

--- a/internal/cli/doctor_mailboxes_test.go
+++ b/internal/cli/doctor_mailboxes_test.go
@@ -834,6 +834,22 @@ type doctorMailboxResultJSON struct {
 	Ops           *doctorOpsResult         `json:"ops"`
 }
 
+func TestFreshInitProvisionsReservedHumanMailboxForDoctor(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "queue")
+	if err := runInit([]string{"--root", root, "--agents", "alpha,beta"}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	result := runDoctorMailboxJSON(t, root)
+	if got := doctorCheckStatus(result.Checks, "Mailboxes"); got != "ok" {
+		t.Fatalf("Mailboxes status = %q, want ok; mailboxes=%#v", got, result.Mailboxes)
+	}
+	user := findDoctorMailboxTestEntry(t, result.Mailboxes, reservedHumanHandle)
+	if user.Status != "ok" || len(user.Issues) != 0 || user.Remedy != "" {
+		t.Fatalf("reserved human mailbox = %#v, want healthy without repair", user)
+	}
+}
+
 func runDoctorMailboxJSON(t *testing.T, root string) doctorMailboxResultJSON {
 	t.Helper()
 	return runDoctorMailboxJSONArgs(t, root, "--json")

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -40,7 +40,7 @@ func runInit(args []string) error {
 		return err
 	}
 
-	for _, agent := range agents {
+	for _, agent := range withReservedHumanHandle(agents) {
 		if err := fsq.EnsureAgentDirs(root, agent); err != nil {
 			return err
 		}

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -121,7 +121,7 @@ func TestSessionCreateProvisionsRosterMailboxes(t *testing.T) {
 	if result.Name != "feature-x" {
 		t.Fatalf("name = %q, want feature-x", result.Name)
 	}
-	for _, agent := range []string{"claude", "codex"} {
+	for _, agent := range []string{"claude", "codex", reservedHumanHandle} {
 		if _, err := os.Stat(filepath.Join(result.Path, "agents", agent, "inbox", "new")); err != nil {
 			t.Fatalf("mailbox %s: %v", agent, err)
 		}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -23,6 +23,17 @@ QUEUE_ROOT="$ROOT_DIR/agent-mail"
 
 "$BIN" init --root "$QUEUE_ROOT" --agents codex,claude
 
+doctor_out="$("$BIN" doctor --root "$QUEUE_ROOT")"
+printf '%s\n' "$doctor_out" | grep -q "✓ Mailboxes:"
+if printf '%s\n' "$doctor_out" | grep -q "repair: amq doctor --fix-mailboxes"; then
+  echo "fresh init doctor advertised mailbox repair"
+  exit 1
+fi
+if printf '%s\n' "$doctor_out" | grep -Eq 'Summary:.*[1-9][0-9]* errors'; then
+  echo "fresh init doctor reported errors"
+  exit 1
+fi
+
 send_json="$("$BIN" send --root "$QUEUE_ROOT" --me codex --to claude --body "hello" --json)"
 msg_id="$(printf '%s\n' "$send_json" | awk -F'"' '/"id":/ {print $4; exit}')"
 thread_id="$(printf '%s\n' "$send_json" | awk -F'"' '/"thread":/ {print $4; exit}')"


### PR DESCRIPTION
## Reproduction

On a fresh v0.63.0 queue:

```text
amq init --root R --agents alpha,beta
amq doctor --root R
```

Doctor reported the implicit `user` handle as a configured mailbox with every required leaf missing, then advertised `amq doctor --fix-mailboxes`.

## History and contract

- `4fc3bff` reserved the human `user` handle, provisioned it in co-op defaults, and kept explicit init configuration literal.
- `fab4c76` later made the implicit `user` an effective configured, repair-eligible mailbox, including for empty rosters.

This change reconciles that newer mailbox invariant at the provisioning layer. `config.json` and session command output remain literal; init, co-op base/session, and named-session creation now provision the implicit human mailbox. Doctor and configured-agent validation are unchanged.

Existing queues created before this fix can still report one doctor mailbox error when `user` is absent. The existing exact `amq doctor --fix-mailboxes` repair command remains the supported migration.

## Red proof

`TestFreshInitProvisionsReservedHumanMailboxForDoctor` failed on current main with `Mailboxes=error`; `user` was missing all required mailbox leaves.

## Verification

- Focused fresh-init, explicit-roster, and named-session tests: PASS.
- Real-binary `scripts/smoke-test.sh` init-to-doctor row: PASS.
- `GOOS=windows GOARCH=amd64 go vet ./internal/cli/`: PASS.
- `make ci`: PASS.
- Pre-push checks: PASS.
- Peer review: Claude approved the exact staged snapshot and reran the focused tests.

Closes amq-4o9.
