### PR TITLE
fix(wake): confirm SIGKILL with a 3s window, not 100ms SIGTERM grace

### DIFF
--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -181,7 +181,7 @@ func terminateWakeProcess(inspection wakeLockInspection) error {
 	if err := signalWakeProcess(inspection.PID, syscall.SIGKILL); err != nil {
 		return fmt.Errorf("signal wake process SIGKILL: %w", err)
 	}
-	deadline := time.Now().Add(wakeTerminateGrace)
+	deadline := time.Now().Add(wakeTerminateKillConfirm)
 	for {
 		switch state := inspectWakeIdentity(inspection); state {
 		case wakeIdentityGoneOrDifferent:
@@ -219,7 +219,7 @@ func terminateWakeProcessInDir(
 	if err := signalWakeProcess(inspection.PID, syscall.SIGKILL); err != nil {
 		return fmt.Errorf("signal wake process SIGKILL: %w", err)
 	}
-	deadline := time.Now().Add(wakeTerminateGrace)
+	deadline := time.Now().Add(wakeTerminateKillConfirm)
 	for {
 		switch state := inspectWakeIdentity(inspection); state {
 		case wakeIdentityGoneOrDifferent:

--- a/internal/cli/wake_terminate_linux.go
+++ b/internal/cli/wake_terminate_linux.go
@@ -306,7 +306,7 @@ func terminateWakePidfd(pidfd int) error {
 		}
 		return fmt.Errorf("pidfd_send_signal SIGKILL: %w", err)
 	}
-	exited, err = linuxPidfdPoll(pidfd, wakeTerminateGrace)
+	exited, err = linuxPidfdPoll(pidfd, wakeTerminateKillConfirm)
 	if err != nil {
 		return fmt.Errorf("poll pidfd after SIGKILL: %w", err)
 	}

--- a/internal/cli/wake_terminate_linux_test.go
+++ b/internal/cli/wake_terminate_linux_test.go
@@ -391,3 +391,85 @@ func matchingLinuxWakeProcess(pid int, root string) wakeProcessInfo {
 		Args: []string{"/usr/bin/amq", "wake", "--root", root, "--me", "codex"},
 	}
 }
+
+func TestTerminateWakePidfdKillsChildThatIgnoresSIGTERM(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "trap '' TERM; exec sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	pidfd, err := linuxPidfdOpen(cmd.Process.Pid, 0)
+	if err != nil {
+		t.Fatalf("pidfd_open child: %v", err)
+	}
+	defer func() { _ = linuxPidfdClose(pidfd) }()
+	if err := terminateWakePidfd(pidfd); err != nil {
+		t.Fatalf("terminate TERM-immune child: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+	if err := linuxPidfdSendSignal(pidfd, unix.SIGTERM, nil, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("signal retained pidfd after exit = %v, want ESRCH", err)
+	}
+}
+
+func TestTerminateWakePidfdReportsRetiredWhenSIGKILLExitIsDelayed(t *testing.T) {
+	oldGrace := wakeTerminateGrace
+	oldConfirm := wakeTerminateKillConfirm
+	wakeTerminateGrace = 50 * time.Millisecond
+	wakeTerminateKillConfirm = 2 * time.Second
+	t.Cleanup(func() {
+		wakeTerminateGrace = oldGrace
+		wakeTerminateKillConfirm = oldConfirm
+	})
+	var timeouts []time.Duration
+	stubLinuxPidfd(t,
+		func(int, int) (int, error) { return 7, nil },
+		func(int, unix.Signal, *unix.Siginfo, int) error { return nil },
+		func(_ int, timeout time.Duration) (bool, error) {
+			timeouts = append(timeouts, timeout)
+			if timeout <= wakeTerminateGrace {
+				return false, nil
+			}
+			time.Sleep(500 * time.Millisecond)
+			return true, nil
+		},
+	)
+	start := time.Now()
+	if err := terminateWakePidfd(7); err != nil {
+		t.Fatalf("delayed SIGKILL exit should retire: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 500*time.Millisecond {
+		t.Fatalf("retired in %s, want to wait for the delayed SIGKILL exit", elapsed)
+	}
+	if len(timeouts) != 2 || timeouts[0] != wakeTerminateGrace || timeouts[1] != wakeTerminateKillConfirm {
+		t.Fatalf("pidfd poll timeouts = %v, want [%s %s]", timeouts, wakeTerminateGrace, wakeTerminateKillConfirm)
+	}
+}
+
+func TestTerminateWakePidfdRefusesImmortalWithinKillConfirm(t *testing.T) {
+	oldGrace := wakeTerminateGrace
+	oldConfirm := wakeTerminateKillConfirm
+	wakeTerminateGrace = 20 * time.Millisecond
+	wakeTerminateKillConfirm = 200 * time.Millisecond
+	t.Cleanup(func() {
+		wakeTerminateGrace = oldGrace
+		wakeTerminateKillConfirm = oldConfirm
+	})
+	stubLinuxPidfd(t,
+		func(int, int) (int, error) { return 7, nil },
+		func(int, unix.Signal, *unix.Siginfo, int) error { return nil },
+		func(int, time.Duration) (bool, error) { return false, nil },
+	)
+	start := time.Now()
+	err := terminateWakePidfd(7)
+	elapsed := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "still alive after SIGKILL") {
+		t.Fatalf("immortal process error = %v, want SIGKILL confirmation refusal", err)
+	}
+	if elapsed < 200*time.Millisecond || elapsed > time.Second {
+		t.Fatalf("immortal refusal took %s, want within the kill-confirm bound", elapsed)
+	}
+}

--- a/internal/cli/wake_terminate_linux_test.go
+++ b/internal/cli/wake_terminate_linux_test.go
@@ -416,33 +416,17 @@ func TestTerminateWakePidfdKillsChildThatIgnoresSIGTERM(t *testing.T) {
 }
 
 func TestTerminateWakePidfdReportsRetiredWhenSIGKILLExitIsDelayed(t *testing.T) {
-	oldGrace := wakeTerminateGrace
-	oldConfirm := wakeTerminateKillConfirm
-	wakeTerminateGrace = 50 * time.Millisecond
-	wakeTerminateKillConfirm = 2 * time.Second
-	t.Cleanup(func() {
-		wakeTerminateGrace = oldGrace
-		wakeTerminateKillConfirm = oldConfirm
-	})
 	var timeouts []time.Duration
 	stubLinuxPidfd(t,
 		func(int, int) (int, error) { return 7, nil },
 		func(int, unix.Signal, *unix.Siginfo, int) error { return nil },
 		func(_ int, timeout time.Duration) (bool, error) {
 			timeouts = append(timeouts, timeout)
-			if timeout <= wakeTerminateGrace {
-				return false, nil
-			}
-			time.Sleep(500 * time.Millisecond)
-			return true, nil
+			return timeout == wakeTerminateKillConfirm, nil
 		},
 	)
-	start := time.Now()
 	if err := terminateWakePidfd(7); err != nil {
 		t.Fatalf("delayed SIGKILL exit should retire: %v", err)
-	}
-	if elapsed := time.Since(start); elapsed < 500*time.Millisecond {
-		t.Fatalf("retired in %s, want to wait for the delayed SIGKILL exit", elapsed)
 	}
 	if len(timeouts) != 2 || timeouts[0] != wakeTerminateGrace || timeouts[1] != wakeTerminateKillConfirm {
 		t.Fatalf("pidfd poll timeouts = %v, want [%s %s]", timeouts, wakeTerminateGrace, wakeTerminateKillConfirm)
@@ -450,26 +434,27 @@ func TestTerminateWakePidfdReportsRetiredWhenSIGKILLExitIsDelayed(t *testing.T) 
 }
 
 func TestTerminateWakePidfdRefusesImmortalWithinKillConfirm(t *testing.T) {
-	oldGrace := wakeTerminateGrace
-	oldConfirm := wakeTerminateKillConfirm
-	wakeTerminateGrace = 20 * time.Millisecond
-	wakeTerminateKillConfirm = 200 * time.Millisecond
-	t.Cleanup(func() {
-		wakeTerminateGrace = oldGrace
-		wakeTerminateKillConfirm = oldConfirm
-	})
+	var timeouts []time.Duration
+	killPollReportedAlive := false
 	stubLinuxPidfd(t,
 		func(int, int) (int, error) { return 7, nil },
 		func(int, unix.Signal, *unix.Siginfo, int) error { return nil },
-		func(int, time.Duration) (bool, error) { return false, nil },
+		func(_ int, timeout time.Duration) (bool, error) {
+			timeouts = append(timeouts, timeout)
+			if timeout == wakeTerminateKillConfirm {
+				killPollReportedAlive = true
+			}
+			return false, nil
+		},
 	)
-	start := time.Now()
 	err := terminateWakePidfd(7)
-	elapsed := time.Since(start)
 	if err == nil || !strings.Contains(err.Error(), "still alive after SIGKILL") {
 		t.Fatalf("immortal process error = %v, want SIGKILL confirmation refusal", err)
 	}
-	if elapsed < 200*time.Millisecond || elapsed > time.Second {
-		t.Fatalf("immortal refusal took %s, want within the kill-confirm bound", elapsed)
+	if !killPollReportedAlive {
+		t.Fatal("refused before the SIGKILL poll reported not-exited")
+	}
+	if len(timeouts) != 2 || timeouts[0] != wakeTerminateGrace || timeouts[1] != wakeTerminateKillConfirm {
+		t.Fatalf("pidfd poll timeouts = %v, want [%s %s]", timeouts, wakeTerminateGrace, wakeTerminateKillConfirm)
 	}
 }

--- a/internal/cli/wake_unix.go
+++ b/internal/cli/wake_unix.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	wakeTerminateGrace              = 100 * time.Millisecond
+	wakeTerminateKillConfirm        = 3 * time.Second
 	wakeBaselineTimeout             = 5 * time.Second
 	wakeBaselineSettle              = 50 * time.Millisecond
 	wakeTerminalAuthorityRetryDelay = 250 * time.Millisecond

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -627,11 +627,14 @@ func stubSignalWakeProcess(t *testing.T, fn func(pid int, sig os.Signal) error) 
 	t.Helper()
 	oldSignal := signalWakeProcess
 	oldGrace := wakeTerminateGrace
+	oldKillConfirm := wakeTerminateKillConfirm
 	signalWakeProcess = fn
 	wakeTerminateGrace = 0
+	wakeTerminateKillConfirm = 0
 	t.Cleanup(func() {
 		signalWakeProcess = oldSignal
 		wakeTerminateGrace = oldGrace
+		wakeTerminateKillConfirm = oldKillConfirm
 	})
 }
 
@@ -7984,6 +7987,111 @@ func TestShouldReplaceOrphanedWakeLockKeepsLockWhenKillDoesNotTerminate(t *testi
 	}
 	if _, statErr := os.Stat(lockPath); statErr != nil {
 		t.Fatalf("lock should remain after failed kill, stat=%v", statErr)
+	}
+}
+
+func TestTerminateWakeProcessReportsRetiredWhenSIGKILLExitIsDelayed(t *testing.T) {
+	requireBarePIDWakeTermination(t)
+	const wakePID = 5151
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "/dev/amq-missing-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	oldGrace := wakeTerminateGrace
+	oldConfirm := wakeTerminateKillConfirm
+	wakeTerminateGrace = 50 * time.Millisecond
+	wakeTerminateKillConfirm = 2 * time.Second
+	t.Cleanup(func() {
+		wakeTerminateGrace = oldGrace
+		wakeTerminateKillConfirm = oldConfirm
+	})
+	var killedAt time.Time
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		live := wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "start-1",
+			BootID:     "boot-1",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "codex", "--root", root},
+		}
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		if killedAt.IsZero() || time.Since(killedAt) < 500*time.Millisecond {
+			return live
+		}
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	oldSignal := signalWakeProcess
+	signalWakeProcess = func(pid int, sig os.Signal) error {
+		if pid != wakePID {
+			t.Fatalf("signal pid = %d, want %d", pid, wakePID)
+		}
+		if sig == syscall.SIGKILL {
+			killedAt = time.Now()
+		}
+		return nil
+	}
+	t.Cleanup(func() { signalWakeProcess = oldSignal })
+
+	start := time.Now()
+	if err := terminateWakeProcess(inspectWakeLock(root, "codex")); err != nil {
+		t.Fatalf("delayed SIGKILL exit should retire: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 500*time.Millisecond {
+		t.Fatalf("retired in %s, want to wait for the ~500ms post-SIGKILL exit", elapsed)
+	}
+}
+
+func TestTerminateWakeProcessRefusesImmortalWithinKillConfirm(t *testing.T) {
+	requireBarePIDWakeTermination(t)
+	const wakePID = 5252
+	root := secureTempDirForTest(t)
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "/dev/amq-missing-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+	})
+	oldGrace := wakeTerminateGrace
+	oldConfirm := wakeTerminateKillConfirm
+	wakeTerminateGrace = 20 * time.Millisecond
+	wakeTerminateKillConfirm = 200 * time.Millisecond
+	t.Cleanup(func() {
+		wakeTerminateGrace = oldGrace
+		wakeTerminateKillConfirm = oldConfirm
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		return wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "start-1",
+			BootID:     "boot-1",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"/opt/homebrew/bin/amq", "wake", "--me", "codex", "--root", root},
+		}
+	})
+	oldSignal := signalWakeProcess
+	signalWakeProcess = func(int, os.Signal) error { return nil }
+	t.Cleanup(func() { signalWakeProcess = oldSignal })
+
+	start := time.Now()
+	err := terminateWakeProcess(inspectWakeLock(root, "codex"))
+	elapsed := time.Since(start)
+	if err == nil || !strings.Contains(err.Error(), "still alive after SIGKILL") {
+		t.Fatalf("immortal process error = %v, want SIGKILL confirmation refusal", err)
+	}
+	if elapsed < 200*time.Millisecond || elapsed > time.Second {
+		t.Fatalf("immortal refusal took %s, want within the kill-confirm bound", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- CI run [32046017764](https://github.com/avivsinai/agent-message-queue/actions/runs/32046017764) failed because SIGKILL confirmation reused the 100ms SIGTERM grace (`wakeTerminateGrace`). A child that was still running ~500ms after SIGKILL was reported as still running instead of retired.
- Keep SIGTERM wait at 100ms. Confirm SIGKILL over a separate 3s window (`wakeTerminateKillConfirm`) on Darwin (`terminateWakeProcess` / `terminateWakeProcessInDir`) and Linux pidfd (`terminateWakePidfd`).
- Tests: delayed-exit reports retired; immortal still refuses within the confirm bound. `stubSignalWakeProcess` zeros both grace and confirm so existing tests stay fast.

Peer review: Codex approved by execution (mutants: 100ms-confirm made the delayed-exit test fail; deadline-success mutant made the immortal test fail; `-race` PASS).

## Test plan
- [x] Darwin delayed-exit + immortal refuse tests
- [x] Linux pidfd poll timeout sequence + SIGTERM-ignore kill + immortal refuse
- [x] `go test -race ./internal/cli ./internal/keepalive/amq`
- [x] `GOOS=linux go test -c ./internal/cli`
- [x] `make ci`