### PR TITLE
test(cli): stop coop exec from replacing Darwin test process

### DIFF
--- a/internal/cli/coop_exec_git_bootstrap_unix_test.go
+++ b/internal/cli/coop_exec_git_bootstrap_unix_test.go
@@ -264,7 +264,7 @@ func TestCoopExecBootstrapRequiresProvenGitWorktree(t *testing.T) {
 		marker := filepath.Join(project, ".git")
 		original := gitMarkerLstat
 		gitMarkerLstat = func(path string) (os.FileInfo, error) {
-			if sameCleanPath(path, marker) {
+			if sameTreeIdentity(path, marker) {
 				return nil, os.ErrPermission
 			}
 			return os.Lstat(path)

--- a/internal/cli/coop_exec_guard_test.go
+++ b/internal/cli/coop_exec_guard_test.go
@@ -4,11 +4,18 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func guardTestProcessReplacement() {
+	coopExecProcess = func(path string, _ []string, _ []string) error {
+		return fmt.Errorf("test attempted unguarded process replacement with %q", path)
+	}
+}
 
 func stubCoopExecSentinel(t *testing.T) error {
 	t.Helper()

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -36,6 +36,7 @@ func TestMain(m *testing.M) {
 		os.Getenv("AMQ_TEST_WAKE_RESTART_BOUND_EXEC") != "" {
 		os.Exit(m.Run())
 	}
+	guardTestProcessReplacement()
 
 	for _, k := range []string{"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION", "AMQ_GLOBAL_ROOT", envWakeOwner, "AMQ_WAKE_PRIVATE_STOP_FD"} {
 		_ = os.Unsetenv(k)

--- a/internal/cli/process_guard_other_test.go
+++ b/internal/cli/process_guard_other_test.go
@@ -1,0 +1,5 @@
+//go:build !darwin && !linux
+
+package cli
+
+func guardTestProcessReplacement() {}

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -806,7 +806,8 @@ func TestDoctorOpsV2UsesTrustedRosterAgentInsteadOfOuterRecord(t *testing.T) {
 	}
 	lock := validWakeResumeLockForTest()
 	lock.Root = canonicalWakeRoot(root)
-	lock.ControlSocket = wakeControlSocketPath(lock.Root, lock.Agent, lock.Generation)
+	lock.Generation = "0123456789abcdef0123456789abcdef"
+	configureWakeRestartAdvertisementPlatform(&lock, lock.Root, lock.Agent)
 	writeWakeLockExactForTest(t, root, "codex", lock)
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		return wakeProcessInfo{

--- a/internal/cli/wake_restart_stage_darwin_test.go
+++ b/internal/cli/wake_restart_stage_darwin_test.go
@@ -637,8 +637,8 @@ func TestDarwinRestartRetryReclaimsAndQuarantinesRefusedOwnedStage(t *testing.T)
 		if readErr != nil {
 			return readErr
 		}
-		if !exists || current.Status != wakeRestartRefused || current.RequestID == refused.RequestID {
-			return fmt.Errorf("retry did not install an independent refused request: exists=%v record=%#v", exists, current)
+		if !exists || current.Status != wakeRestartPending || current.RequestID == refused.RequestID {
+			return fmt.Errorf("retry did not preserve an independent pending request: exists=%v record=%#v", exists, current)
 		}
 		return nil
 	}); err != nil {

--- a/internal/cli/wake_resume_protocol_unix_test.go
+++ b/internal/cli/wake_resume_protocol_unix_test.go
@@ -422,8 +422,14 @@ func TestNewWakeLockAdvertisesResumeOnlyWhenTheProtocolIsComplete(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
+	wantSignal := wakeResumeSignalUSR1
+	wantControlSocket := ""
+	if runtime.GOOS == "darwin" {
+		wantSignal = ""
+		wantControlSocket = wakeControlSocketPath("/queue", "codex", lock.Generation)
+	}
 	if lock.ResumeSchema != wakeResumeSchemaV2 || !sameWakeOwner(lock.ResumeOwner, &owner) ||
-		lock.ResumeSignal != wakeResumeSignalUSR1 || lock.ControlSocket != "" ||
+		lock.ResumeSignal != wantSignal || lock.ControlSocket != wantControlSocket ||
 		lock.RunningImageEvidence == nil || *lock.RunningImageEvidence != evidence {
 		t.Fatalf("resume advertisement = %#v", lock)
 	}


### PR DESCRIPTION
## Root cause

`TestCoopExecBootstrapRequiresProvenGitWorktree/git_marker_inspection_failure` compared the injected `.git` path lexically. On macOS, Git returned `/private/var/...` while the fixture retained `/var/...`, so the injection did not fire. The successful path reached the production `syscall.Exec` seam, replaced `cli.test` with `/bin/sh`, and made `go test` report a false green after skipping every later test.

## Fix

- Match the injected `.git` marker by filesystem identity.
- Install an ordinary-suite guard in `TestMain` so an un-stubbed co-op exec returns an explicit error instead of replacing the test process. Explicit helper subprocess modes remain outside the guard.
- Keep the guard portable with a no-op implementation on platforms without the Unix exec seam.

The lexical-compare mutant now fails loudly with `test attempted unguarded process replacement` instead of truncating the package.

## Reclassified assertions

The newly complete Darwin run exposed three test assumptions. All were test-side and were corrected without product changes:

- Resume advertisement expected Linux `SIGUSR1`; Darwin correctly uses an exact-generation control socket.
- The doctor fixture combined Linux `SIGUSR1` with a Darwin socket and used a noncanonical Darwin generation; it now uses the platform helper with a valid generation.
- Darwin restart retry expected a notify-failed fresh request to become refused; the established creator/adopter contract preserves that independent request as pending for retry.

## Verification

- Cursor execution review approved staged tree SHA-256 `80163c6f6038d3fcb6bed21b5f7a130b8bd106864239fa68aa3abd16710b56f9`.
- Full Darwin `internal/cli` suite: PASS in 164.6s.
- 3,221 test/subtest run events; 1,791 top-level tests.
- Final `TestRunGitForTestIsolatesEnclosingRepo`: PASS.
- `make ci`: PASS.
- `GOOS=windows GOARCH=amd64 go vet ./internal/cli/`: PASS.
- Linux execution is delegated to repository CI.