### PR TITLE
fix(dlq): verify purge content under the envelope lock

### DIFF
--- a/internal/cli/dlq.go
+++ b/internal/cli/dlq.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"crypto/sha256"
 	"errors"
 	"flag"
 	"fmt"
@@ -21,6 +22,10 @@ var removeDLQPurgeCandidate = func(root *fsq.DeliveryRoot, path string) error {
 	return root.Remove(path)
 }
 
+var statDLQPurgeCandidate = func(root *fsq.DeliveryRoot, path string) (os.FileInfo, error) {
+	return root.Stat(path)
+}
+
 var retryDLQMessage = fsq.RetryFromDLQ
 
 var inspectDLQMessage = fsq.InspectDLQEnvelope
@@ -32,6 +37,7 @@ var readDLQRetryDir = func(root *fsq.DeliveryRoot, dir string) ([]os.DirEntry, e
 type dlqPurgeCandidate struct {
 	path     string
 	identity os.FileInfo
+	digest   [sha256.Size]byte
 }
 
 func runDLQ(args []string) error {
@@ -733,14 +739,22 @@ func runDLQPurge(args []string) error {
 }
 
 func selectDLQPurgeCandidate(root *fsq.DeliveryRoot, path string, cutoff time.Time) (candidate dlqPurgeCandidate, selected bool, err error) {
-	identity, err := root.Stat(path)
+	identity, err := statDLQPurgeCandidate(root, path)
 	if err != nil {
 		if cutoff.IsZero() {
 			return candidate, false, fmt.Errorf("inspect DLQ message %s for purge: %w", root.DisplayPath(path), err)
 		}
 		return candidate, false, fmt.Errorf("inspect DLQ message %s for --older-than: %w", root.DisplayPath(path), err)
 	}
-	candidate = dlqPurgeCandidate{path: path, identity: identity}
+	raw, err := root.ReadRegularNoFollow(path)
+	if err != nil {
+		return candidate, false, fmt.Errorf("read DLQ message %s for purge: %w", root.DisplayPath(path), err)
+	}
+	candidate = dlqPurgeCandidate{
+		path:     path,
+		identity: identity,
+		digest:   sha256.Sum256(raw),
+	}
 	if cutoff.IsZero() {
 		return candidate, true, nil
 	}
@@ -758,11 +772,18 @@ func selectDLQPurgeCandidate(root *fsq.DeliveryRoot, path string, cutoff time.Ti
 func removeSelectedDLQPurgeCandidate(root *fsq.DeliveryRoot, me string, candidate dlqPurgeCandidate) (removed bool, err error) {
 	filename := filepath.Base(candidate.path)
 	err = root.WithDLQEnvelopeLock(me, filename, func(batch *fsq.DeliveryRoot) error {
-		current, statErr := batch.Stat(candidate.path)
+		current, statErr := statDLQPurgeCandidate(batch, candidate.path)
 		if statErr != nil {
 			return statErr
 		}
 		if !os.SameFile(candidate.identity, current) {
+			return nil
+		}
+		raw, readErr := batch.ReadRegularNoFollow(candidate.path)
+		if readErr != nil {
+			return readErr
+		}
+		if sha256.Sum256(raw) != candidate.digest {
 			return nil
 		}
 		if removeErr := removeDLQPurgeCandidate(batch, candidate.path); removeErr != nil {

--- a/internal/cli/dlq_purge_selection_test.go
+++ b/internal/cli/dlq_purge_selection_test.go
@@ -337,6 +337,14 @@ func TestDLQPurgeStaleCandidateCannotDeleteConcurrentRetryAudit(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("concurrent retry winner: %v", err)
 	}
+	oldStat := statDLQPurgeCandidate
+	statDLQPurgeCandidate = func(deliveryRoot *fsq.DeliveryRoot, path string) (os.FileInfo, error) {
+		if path == curPath {
+			return candidate.identity, nil
+		}
+		return oldStat(deliveryRoot, path)
+	}
+	t.Cleanup(func() { statDLQPurgeCandidate = oldStat })
 	removed, err := removeSelectedDLQPurgeCandidate(purgeRoot, "alice", candidate)
 	if err != nil || removed {
 		t.Fatalf("stale purge removal = removed:%t err:%v, want no deletion", removed, err)


### PR DESCRIPTION
## Mechanism

DLQ purge selection now snapshots the SHA-256 digest of the exact no-follow file bytes. Under the existing per-envelope lock, removal retains the inode identity fast rejection, rereads the exact bytes, and declines to unlink when the digest changed. Corrupt-message purge uses the same exact-byte guard.

## Defect

A concurrent retry rewrites the DLQ audit file through ready, pending, and delivered states. On ext4, inode reuse can make a stale purge candidate pass `os.SameFile` after those rewrites and delete the fresh audit record.

## Red proof

The unchanged-main counterexample failed with `removed:true`, where stale purge removal must preserve the rewritten audit. A digest-comparison mutant failed with the same result.

## Deterministic seam

The test uses a stat seam to make the post-retry file identity equal the stale candidate after a real retry rewrite. It does not depend on probabilistic inode allocator reuse.

## Verification

- Focused DLQ purge tests passed.
- `go test -race ./internal/cli -run DLQ.*Purge -count=1` passed.
- `go test -race ./internal/fsq -run DLQ.*(Retry|Lock|Inspect|Cur) -count=1` passed.
- Honest full Darwin `internal/cli` run passed with 3,222 test/subtest starts, 1,792 top-level tests, and the final sentinel.
- `make ci` passed.
- The pre-push gate passed without bypass.

Peer review: Cursor approved by execution. AMQ message `2026-08-17T18-20-07.822Z_pid47873_587b07a3`.