### PR TITLE
fix(symphony): select managed fragment bounds once for detect and inject

### DIFF
--- a/internal/format/message_test.go
+++ b/internal/format/message_test.go
@@ -383,6 +383,34 @@ func TestReadHeaderFileRejectsSymlink(t *testing.T) {
 	}
 }
 
+func TestMarshalFillsZeroSchemaAndEmptyCreated(t *testing.T) {
+	msg := Message{
+		Header: Header{
+			ID:   "zero-schema",
+			From: "codex",
+			To:   []string{"claude"},
+		},
+		Body: "defaults\n",
+	}
+	data, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	parsed, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed.Header.Schema != CurrentSchema {
+		t.Fatalf("schema = %d, want %d", parsed.Header.Schema, CurrentSchema)
+	}
+	if parsed.Header.Created == "" {
+		t.Fatal("created was left empty")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, parsed.Header.Created); err != nil {
+		t.Fatalf("created %q is not RFC3339Nano: %v", parsed.Header.Created, err)
+	}
+}
+
 func TestReadMessageFile_SizeLimit(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "huge.md")
@@ -412,6 +440,68 @@ func TestSplitFrontmatter_SizeLimit(t *testing.T) {
 	}
 }
 
+func TestReadMessageFileAllowsExactMaxSize(t *testing.T) {
+	_, data := mustExactMaxSizeMessage(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exact.md")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write exact message: %v", err)
+	}
+	parsed, err := ReadMessageFile(path)
+	if err != nil {
+		t.Fatalf("ReadMessageFile exact MaxMessageSize: %v", err)
+	}
+	if parsed.Header.ID != "exact-max" || !strings.HasPrefix(parsed.Body, "pad\n") {
+		t.Fatalf("parsed exact file = id=%q body[:8]=%q", parsed.Header.ID, parsed.Body)
+	}
+}
+
+func TestParseMessageAllowsExactMaxSize(t *testing.T) {
+	want, data := mustExactMaxSizeMessage(t)
+	if len(data) != MaxMessageSize {
+		t.Fatalf("padded size = %d, want %d", len(data), MaxMessageSize)
+	}
+	parsed, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("ParseMessage exact MaxMessageSize: %v", err)
+	}
+	if parsed.Header.ID != want.Header.ID || parsed.Header.From != want.Header.From {
+		t.Fatalf("header = %+v, want id=%q from=%q", parsed.Header, want.Header.ID, want.Header.From)
+	}
+	if !strings.HasPrefix(parsed.Body, "pad\n") {
+		t.Fatalf("body prefix = %q, want pad\\n", parsed.Body[:min(8, len(parsed.Body))])
+	}
+}
+
+func mustExactMaxSizeMessage(t *testing.T) (Message, []byte) {
+	t.Helper()
+	msg := Message{
+		Header: Header{
+			Schema:  CurrentSchema,
+			ID:      "exact-max",
+			From:    "codex",
+			To:      []string{"claude"},
+			Thread:  "p2p/claude__codex",
+			Subject: "exact",
+			Created: "2026-01-01T00:00:00.000000000Z",
+		},
+		Body: "pad\n",
+	}
+	seed, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if len(seed) > MaxMessageSize {
+		t.Fatalf("seed size %d exceeds MaxMessageSize", len(seed))
+	}
+	data := make([]byte, MaxMessageSize)
+	copy(data, seed)
+	for i := len(seed); i < MaxMessageSize; i++ {
+		data[i] = 'a'
+	}
+	return msg, data
+}
+
 func TestSortByTimestamp(t *testing.T) {
 	headers := []testTimestamped{
 		{id: "c", created: "2025-01-03T00:00:00Z", raw: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)},
@@ -427,6 +517,21 @@ func TestSortByTimestamp(t *testing.T) {
 		if h.id != expected[i] {
 			t.Errorf("position %d: expected %s, got %s", i, expected[i], h.id)
 		}
+	}
+}
+
+func TestSortByTimestampDoesNotCompareMixedZeroRawTimes(t *testing.T) {
+	earlyCreated := "2025-01-01T00:00:00Z"
+	lateCreated := "2025-01-02T00:00:00Z"
+	headers := []testTimestamped{
+		{id: "zero-raw-late-created", created: lateCreated},
+		{id: "raw-early", created: earlyCreated, raw: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+
+	SortByTimestamp(headers)
+
+	if headers[0].id != "raw-early" || headers[1].id != "zero-raw-late-created" {
+		t.Fatalf("order = [%s, %s], want raw-early then created-string fallback", headers[0].id, headers[1].id)
 	}
 }
 

--- a/internal/integration/symphony/init.go
+++ b/internal/integration/symphony/init.go
@@ -61,8 +61,8 @@ func Init(opts InitOptions) (*InitResult, error) {
 		fragments[event] = managedFragment(generateHookLine(event, opts.Me, opts.Root))
 	}
 
-	// Check current state. "HooksFound" means the markers exist. "AlreadyOK"
-	// means the managed fragment exactly matches the requested me/root.
+	// Check current state. "HooksFound" means each hook has an extractable
+	// managed fragment. "AlreadyOK" means that fragment matches me/root.
 	result.HooksFound = hasManagedFragment(hooks.AfterCreate) &&
 		hasManagedFragment(hooks.BeforeRun) &&
 		hasManagedFragment(hooks.AfterRun) &&
@@ -138,9 +138,25 @@ func managedFragment(line string) string {
 	return ManagedBegin + "\n" + line + "\n" + ManagedEnd
 }
 
-// hasManagedFragment returns true if the hook content contains the AMQ managed markers.
+// managedFragmentBounds returns the selected extractable span: the first
+// begin marker and the first end marker after it. A stray end before begin
+// is not part of the span.
+func managedFragmentBounds(hookContent string) (begin, end int, ok bool) {
+	begin = strings.Index(hookContent, ManagedBegin)
+	if begin == -1 {
+		return 0, 0, false
+	}
+	relEnd := strings.Index(hookContent[begin:], ManagedEnd)
+	if relEnd == -1 {
+		return 0, 0, false
+	}
+	end = begin + relEnd + len(ManagedEnd)
+	return begin, end, true
+}
+
 func hasManagedFragment(hookContent string) bool {
-	return strings.Contains(hookContent, ManagedBegin) && strings.Contains(hookContent, ManagedEnd)
+	_, _, ok := managedFragmentBounds(hookContent)
+	return ok
 }
 
 func managedFragmentMatches(hookContent, fragment string) bool {
@@ -152,16 +168,11 @@ func managedFragmentMatches(hookContent, fragment string) bool {
 }
 
 func extractManagedFragment(hookContent string) (string, bool) {
-	beginIdx := strings.Index(hookContent, ManagedBegin)
-	if beginIdx == -1 {
+	begin, end, ok := managedFragmentBounds(hookContent)
+	if !ok {
 		return "", false
 	}
-	endIdx := strings.Index(hookContent[beginIdx:], ManagedEnd)
-	if endIdx == -1 {
-		return "", false
-	}
-	endIdx += beginIdx + len(ManagedEnd)
-	return hookContent[beginIdx:endIdx], true
+	return hookContent[begin:end], true
 }
 
 // injectFragment inserts or replaces the AMQ managed fragment in the hook content.
@@ -171,19 +182,10 @@ func injectFragment(existing, fragment string) string {
 		return fragment + "\n"
 	}
 
-	// If there's already a managed fragment, replace it
-	if hasManagedFragment(existing) {
-		beginIdx := strings.Index(existing, ManagedBegin)
-		endIdx := strings.Index(existing, ManagedEnd) + len(ManagedEnd)
-
-		// Preserve content before and after the managed block
-		before := existing[:beginIdx]
-		after := existing[endIdx:]
-
-		return before + fragment + after
+	if begin, end, ok := managedFragmentBounds(existing); ok {
+		return existing[:begin] + fragment + existing[end:]
 	}
 
-	// No existing fragment: append after existing content
 	content := strings.TrimRight(existing, "\n")
 	return content + "\n" + fragment + "\n"
 }

--- a/internal/integration/symphony/init_test.go
+++ b/internal/integration/symphony/init_test.go
@@ -301,6 +301,43 @@ func TestHasManagedFragmentExtractsFirstBeginToFirstLaterEnd(t *testing.T) {
 	}
 }
 
+func TestInit_CheckModePartialManagedHooksAreNotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestWorkflow(t, dir, `---
+hooks:
+  after_create: |
+    # BEGIN AMQ MANAGED
+    amq integration symphony emit --event after_create --me codex || true
+    # END AMQ MANAGED
+  after_run: |
+    # BEGIN AMQ MANAGED
+    amq integration symphony emit --event after_run --me codex || true
+    # END AMQ MANAGED
+  before_remove: |
+    # BEGIN AMQ MANAGED
+    amq integration symphony emit --event before_remove --me codex || true
+    # END AMQ MANAGED
+---
+
+Prompt.
+`)
+
+	result, err := Init(InitOptions{
+		WorkflowPath: path,
+		Me:           "codex",
+		Check:        true,
+	})
+	if err != nil {
+		t.Fatalf("Init check: %v", err)
+	}
+	if result.HooksFound {
+		t.Fatal("three of four managed hooks is not HooksFound")
+	}
+	if result.AlreadyOK {
+		t.Fatal("partial managed hooks must not be AlreadyOK")
+	}
+}
+
 func TestInit_NoExistingHooks(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTestWorkflow(t, dir, `---

--- a/internal/integration/symphony/init_test.go
+++ b/internal/integration/symphony/init_test.go
@@ -265,6 +265,42 @@ Prompt.
 	}
 }
 
+func TestHasManagedFragmentRequiresBothMarkers(t *testing.T) {
+	if hasManagedFragment(ManagedBegin + "\ncmd\n") {
+		t.Fatal("begin marker without end is not a managed fragment")
+	}
+	if hasManagedFragment("cmd\n" + ManagedEnd) {
+		t.Fatal("end marker without begin is not a managed fragment")
+	}
+}
+
+func TestHasManagedFragmentRejectsReversedMarkers(t *testing.T) {
+	reversed := ManagedEnd + "\ncmd\n" + ManagedBegin
+	if hasManagedFragment(reversed) {
+		t.Fatal("end-before-begin is not a managed fragment")
+	}
+	if _, ok := extractManagedFragment(reversed); ok {
+		t.Fatal("extractManagedFragment must fail when end precedes begin")
+	}
+}
+
+func TestHasManagedFragmentExtractsFirstBeginToFirstLaterEnd(t *testing.T) {
+	nested := ManagedBegin + "\nouter-start\n" + ManagedBegin + "\ninner\n" + ManagedEnd + "\nouter-end\n" + ManagedEnd
+	got, ok := extractManagedFragment(nested)
+	if !ok {
+		t.Fatal("nested markers should extract the first begin-to-end span")
+	}
+	want := ManagedBegin + "\nouter-start\n" + ManagedBegin + "\ninner\n" + ManagedEnd
+	if got != want {
+		t.Fatalf("extracted %q, want first span %q", got, want)
+	}
+	duplicate := managedFragment("first") + "\n" + managedFragment("second")
+	got, ok = extractManagedFragment(duplicate)
+	if !ok || got != managedFragment("first") {
+		t.Fatalf("duplicate fragments extracted %q, want the first fragment", got)
+	}
+}
+
 func TestInit_NoExistingHooks(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTestWorkflow(t, dir, `---
@@ -387,6 +423,21 @@ func TestInjectFragment_PreservesExisting(t *testing.T) {
 	}
 	if !strings.Contains(result, ManagedBegin) {
 		t.Error("expected managed begin marker")
+	}
+}
+
+func TestInjectFragmentReplacesSpanWhenStrayEndPrecedesFragment(t *testing.T) {
+	existing := ManagedEnd + "\nuser-before\n" + managedFragment("old-cmd") + "\nuser-after\n"
+	got := injectFragment(existing, managedFragment("new-cmd"))
+	want := ManagedEnd + "\nuser-before\n" + managedFragment("new-cmd") + "\nuser-after\n"
+	if got != want {
+		t.Fatalf("injectFragment stray-end =\n%q\nwant\n%q", got, want)
+	}
+	if strings.Contains(got, "old-cmd") {
+		t.Fatal("stray ManagedEnd must not keep the old managed block")
+	}
+	if strings.Count(got, "user-before") != 1 {
+		t.Fatalf("user-before copies = %d, want 1", strings.Count(got, "user-before"))
 	}
 }
 

--- a/internal/sessionguard/session_guard_table_test.go
+++ b/internal/sessionguard/session_guard_table_test.go
@@ -104,6 +104,13 @@ func TestSessionGuardDecisionRows(t *testing.T) {
 			row: RowR06ListOwnBase, verdict: Allow,
 		},
 		{
+			name: "R06 does not allow list of own base without explicit root",
+			input: Input{
+				Kind: KindList, Pin: PinIdentity, Relation: TargetOwnPinnedBase,
+			},
+			row: RowR10ListMismatchWarn, verdict: WarnContinue,
+		},
+		{
 			name: "R07 doctor own pinned base allows repair",
 			input: Input{
 				Kind: KindDoctorRepair, Pin: PinIdentity, Relation: TargetOwnPinnedBase,

--- a/internal/swarm/tasks_test.go
+++ b/internal/swarm/tasks_test.go
@@ -84,6 +84,27 @@ func TestListTasks_PerFile(t *testing.T) {
 	}
 }
 
+func TestListTasksIgnoresNonJSONFiles(t *testing.T) {
+	_, dir := setupTasksDir(t, "myteam")
+	writeTaskFile(t, dir, "task-a.json", map[string]any{"id": "a", "title": "Alpha", "status": "pending"})
+	writeTaskFile(t, dir, "sneaky.txt", map[string]any{"id": "sneaky", "title": "Hidden", "status": "pending"})
+
+	tasks, err := ListTasks("myteam")
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "a" {
+		t.Fatalf("tasks = %#v, want only task-a.json", tasks)
+	}
+}
+
+func TestRequireTaskAssigneeFallsBackToHandleWhenAgentIDEmpty(t *testing.T) {
+	err := requireTaskAssignee("t1", map[string]any{"assigned_to": "other"}, "codex", "")
+	if err == nil || !strings.Contains(err.Error(), "codex") {
+		t.Fatalf("error = %v, want assigned-to-other naming the handle", err)
+	}
+}
+
 func TestListTasks_Empty(t *testing.T) {
 	setupTasksDir(t, "empty-team")
 

--- a/internal/swarm/team_test.go
+++ b/internal/swarm/team_test.go
@@ -191,6 +191,29 @@ func TestUnregisterMember(t *testing.T) {
 	}
 }
 
+func TestUnregisterMemberKeepsFollowingMembers(t *testing.T) {
+	home := setupTeamDir(t)
+	writeTeamJSON(t, home, "test-team", TeamConfig{
+		Name: "test-team",
+		Members: []Member{
+			{Name: "claude", AgentID: "cc-1", AgentType: AgentTypeClaudeCode},
+			{Name: "codex", AgentID: "ext_codex_123", AgentType: AgentTypeCodex},
+		},
+	})
+
+	if err := UnregisterMember("test-team", "cc-1"); err != nil {
+		t.Fatalf("UnregisterMember: %v", err)
+	}
+
+	got, err := LoadTeam("test-team")
+	if err != nil {
+		t.Fatalf("LoadTeam after unregister: %v", err)
+	}
+	if len(got.Members) != 1 || got.Members[0].AgentID != "ext_codex_123" {
+		t.Fatalf("members = %#v, want following member retained", got.Members)
+	}
+}
+
 func TestUnregisterMember_NotFound(t *testing.T) {
 	home := setupTeamDir(t)
 	writeTeamJSON(t, home, "test-team", TeamConfig{

--- a/internal/thread/thread_test.go
+++ b/internal/thread/thread_test.go
@@ -1,6 +1,8 @@
 package thread
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -116,5 +118,201 @@ func TestCollectThreadCorruptMessage(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestCollectIgnoresDotfilesAndNonMarkdown(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	visible := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "visible",
+			From:    "codex",
+			To:      []string{"claude"},
+			Thread:  "p2p/claude__codex",
+			Created: time.Date(2025, 12, 24, 15, 2, 33, 0, time.UTC).Format(time.RFC3339Nano),
+		},
+		Body: "visible\n",
+	}
+	hidden := visible
+	hidden.Header.ID = "hidden"
+	data, err := visible.Marshal()
+	if err != nil {
+		t.Fatalf("marshal visible: %v", err)
+	}
+	hiddenData, err := hidden.Marshal()
+	if err != nil {
+		t.Fatalf("marshal hidden: %v", err)
+	}
+	inbox := fsq.AgentInboxNew(root, "codex")
+	if err := os.WriteFile(filepath.Join(inbox, "visible.md"), data, 0o600); err != nil {
+		t.Fatalf("write visible.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inbox, ".hidden.md"), hiddenData, 0o600); err != nil {
+		t.Fatalf("write .hidden.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inbox, "notes.txt"), []byte("not a message"), 0o600); err != nil {
+		t.Fatalf("write notes.txt: %v", err)
+	}
+
+	entries, err := Collect(root, "p2p/claude__codex", []string{"codex"}, false, nil)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ID != "visible" {
+		t.Fatalf("entries = %#v, want only visible.md", entries)
+	}
+}
+
+func TestCollectOnErrorNilStillScansLaterMessages(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	good := format.Message{
+		Header: format.Header{
+			Schema:  1,
+			ID:      "good",
+			From:    "codex",
+			To:      []string{"claude"},
+			Thread:  "p2p/claude__codex",
+			Created: time.Date(2025, 12, 24, 15, 2, 33, 0, time.UTC).Format(time.RFC3339Nano),
+		},
+		Body: "good\n",
+	}
+	data, err := good.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	inbox := fsq.AgentInboxNew(root, "codex")
+	if err := os.WriteFile(filepath.Join(inbox, "a-bad.md"), []byte("not a message"), 0o600); err != nil {
+		t.Fatalf("write a-bad.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inbox, "b-good.md"), data, 0o600); err != nil {
+		t.Fatalf("write b-good.md: %v", err)
+	}
+
+	entries, err := Collect(root, "p2p/claude__codex", []string{"codex"}, false, func(string, error) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ID != "good" {
+		t.Fatalf("entries = %#v, want b-good.md after skipped corrupt file", entries)
+	}
+}
+
+func TestCollectOnErrorPropagatesCallbackError(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	path := filepath.Join(fsq.AgentInboxNew(root, "codex"), "bad.md")
+	if err := os.WriteFile(path, []byte("not a message"), 0o600); err != nil {
+		t.Fatalf("write bad message: %v", err)
+	}
+
+	want := errors.New("stop scan")
+	_, err := Collect(root, "p2p/claude__codex", []string{"codex"}, false, func(string, error) error {
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("Collect error = %v, want callback error", err)
+	}
+}
+
+func TestCollectScansNewCurAndOutboxDedupesAndReportsCallbackPath(t *testing.T) {
+	root := t.TempDir()
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	now := time.Date(2025, 12, 24, 15, 2, 33, 0, time.UTC)
+	write := func(dir, name, id, body string, created time.Time) {
+		t.Helper()
+		msg := format.Message{
+			Header: format.Header{
+				Schema:  1,
+				ID:      id,
+				From:    "codex",
+				To:      []string{"claude"},
+				Thread:  "p2p/claude__codex",
+				Created: created.Format(time.RFC3339Nano),
+			},
+			Body: body,
+		}
+		data, err := msg.Marshal()
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	inboxNew := fsq.AgentInboxNew(root, "codex")
+	inboxCur := fsq.AgentInboxCur(root, "codex")
+	outbox := fsq.AgentOutboxSent(root, "codex")
+	write(inboxNew, "from-new.md", "from-new", "new\n", now)
+	write(inboxCur, "from-cur.md", "from-cur", "cur\n", now.Add(time.Second))
+	write(outbox, "from-sent.md", "from-sent", "sent\n", now.Add(2*time.Second))
+	write(outbox, "dup-of-new.md", "from-new", "dup\n", now.Add(3*time.Second))
+
+	corruptPath := filepath.Join(inboxCur, "zz-corrupt.md")
+	if err := os.WriteFile(corruptPath, []byte("not a message"), 0o600); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+
+	for _, includeBody := range []bool{false, true} {
+		t.Run(fmt.Sprintf("includeBody=%v", includeBody), func(t *testing.T) {
+			var gotPath string
+			var gotErr error
+			entries, err := Collect(root, "p2p/claude__codex", []string{"codex"}, includeBody, func(path string, err error) error {
+				gotPath = path
+				gotErr = err
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("Collect: %v", err)
+			}
+			if gotPath != corruptPath {
+				t.Fatalf("onError path = %q, want %q", gotPath, corruptPath)
+			}
+			if gotErr == nil {
+				t.Fatal("onError err is nil, want parse error")
+			}
+			gotIDs := make([]string, len(entries))
+			for i, e := range entries {
+				gotIDs[i] = e.ID
+				if includeBody && e.Body == "" {
+					t.Fatalf("includeBody entry %s has empty body", e.ID)
+				}
+				if !includeBody && e.Body != "" {
+					t.Fatalf("header-only entry %s has body %q", e.ID, e.Body)
+				}
+			}
+			want := []string{"from-new", "from-cur", "from-sent"}
+			if len(gotIDs) != 3 || gotIDs[0] != want[0] || gotIDs[1] != want[1] || gotIDs[2] != want[2] {
+				t.Fatalf("ids = %v, want %v (duplicate from-new skipped)", gotIDs, want)
+			}
+		})
 	}
 }

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -30,6 +30,13 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if !reflect.DeepEqual(negotiated.Features, []string{"launch_intent_v1", "managed_tmux_v1"}) {
 		t.Fatalf("negotiated features = %v", negotiated.Features)
 	}
+
+	if _, err := Negotiate(RequirementV1{ContractSemver: ">=0.61.0", IntentVersion: 1, ResultVersion: 1}); err != nil {
+		t.Fatalf(">=0.61.0 must include the current contract: %v", err)
+	}
+	if _, err := Negotiate(RequirementV1{ContractSemver: "<=0.61.0", IntentVersion: 1, ResultVersion: 1}); err != nil {
+		t.Fatalf("<=0.61.0 must include the current contract: %v", err)
+	}
 }
 
 func TestNegotiateV1FailsClosed(t *testing.T) {
@@ -44,6 +51,7 @@ func TestNegotiateV1FailsClosed(t *testing.T) {
 		{name: "result version", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 2}, want: "result version"},
 		{name: "unknown feature", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 1, Features: []string{"shell_hooks_v1"}}, want: "unsupported required feature"},
 		{name: "duplicate feature", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 1, Features: []string{"launch_intent_v1", "launch_intent_v1"}}, want: "duplicate required feature"},
+		{name: "strict greater than current contract", requirement: RequirementV1{ContractSemver: ">0.61.0", IntentVersion: 1, ResultVersion: 1}, want: "does not include"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -51,5 +59,28 @@ func TestNegotiateV1FailsClosed(t *testing.T) {
 				t.Fatalf("Negotiate error = %v, want %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestCompareSemanticVersionsOrdersPatch(t *testing.T) {
+	left, ok := parseSemanticVersion("1.0.1")
+	if !ok {
+		t.Fatal("parse 1.0.1")
+	}
+	right, ok := parseSemanticVersion("1.0.2")
+	if !ok {
+		t.Fatal("parse 1.0.2")
+	}
+	if cmp := compareSemanticVersions(left, right); cmp >= 0 {
+		t.Fatalf("compare(1.0.1, 1.0.2) = %d, want negative", cmp)
+	}
+	if cmp := compareSemanticVersions(right, left); cmp <= 0 {
+		t.Fatalf("compare(1.0.2, 1.0.1) = %d, want positive", cmp)
+	}
+}
+
+func TestSemverRangeContainsRejectsRequirementWhitespace(t *testing.T) {
+	if semverRangeContains(" >=0.61.0", "0.61.0") {
+		t.Fatal("leading whitespace in the requirement must not match")
 	}
 }

--- a/launchapi/intent_test.go
+++ b/launchapi/intent_test.go
@@ -80,6 +80,13 @@ func TestLaunchIntentNonRunnableIsHandleOnly(t *testing.T) {
 	}
 }
 
+func TestNonRunnableValidateRejectsSmuggledGoFields(t *testing.T) {
+	participant := ParticipantV1{Handle: "operator", Runnable: false, Executable: "codex"}
+	if err := participant.validate(); err == nil || !strings.Contains(err.Error(), "handle-only") {
+		t.Fatalf("validate error = %v, want handle-only refusal", err)
+	}
+}
+
 func TestLaunchIntentV1AcceptsSiblingWorktreeAndZeroRunnable(t *testing.T) {
 	intent, err := DecodeLaunchIntentV1([]byte(validIntentJSON(t)))
 	if err != nil {


### PR DESCRIPTION
## Summary
- Detect, extract, and inject now share one selected span: first `# BEGIN AMQ MANAGED` through the first `# END AMQ MANAGED` after it. A stray end before a valid fragment no longer duplicates user content or keeps the old block.
- Round-2 mutation tests kill fail-closed survivors in format, thread, sessionguard, swarm, symphony check-mode, and launchapi. Exact-`MaxMessageSize` proofs require a successful parse of a valid padded message. `Collect` covers inbox `new`/`cur` and outbox `sent`, duplicate IDs, and both parse-callback paths.

```text
BEGIN_COMMIT_OVERRIDE
fix(symphony): select managed fragment bounds once for detect and inject

test: kill mutation-sweep round-2 survivors in format, swarm, launchapi
END_COMMIT_OVERRIDE
```

Commits:
1. `bd0ff87` `fix(symphony): select managed fragment bounds once for detect and inject`
2. `44e3c16` `test: kill mutation-sweep round-2 survivors in format, swarm, launchapi`

Codex approve (execution): `2026-08-17T19-14-04.242Z_pid63049_ef6271d9`

Gremlins (invert-logical ON) after killing tests / last sweep:

| package | killed | lived | not covered | efficacy |
| --- | --- | --- | --- | --- |
| format | 35 | 8 | 10 | 81.4% |
| config | 5 | 0 | 0 | 100% |
| presence | 6 | 0 | 4 | 100% |
| thread | 8 | 1 | 13 | 88.9% |
| sessionguard | 29 | 0 | 0 | 100% |
| swarm | 112 | 13 | 36 | 89.6% |
| integration/common | 12 | 0 | 0 | 100% |
| integration/kanban | 45 | 19 | 7 | 70.3% |
| integration/symphony | 74 | 11 | 47 | 87.1% |
| launchapi | 153 | 13 | 7 | 92.2% |

MEANINGFUL killed (real-boundary tests):

| site | mutant | killing test |
| --- | --- | --- |
| session_guard_table.go:172 | ExplicitRoot `&&` validPin -> `\|\|` | R06 without explicit root falls through to R10 |
| message.go Schema/Created defaults | `==0` / `==""` invert | `TestMarshalFillsZeroSchemaAndEmptyCreated` |
| message.go size `>` Max | `>` -> `>=` | exact MaxMessageSize valid padded parse |
| message.go mixed zero raw | `&&` -> `\|\|` | `TestSortByTimestampDoesNotCompareMixedZeroRawTimes` |
| thread.go skip / onError | `\|\|` -> `&&`; continue->break | dotfiles/non-md skip; callback path+error; new/cur/sent + dup ID |
| tasks.go / team.go | skip non-json; empty agentID; continue->break | list non-json; assignee handle fallback; unregister keeps following members |
| init.go markers | Contains both -> extractable span | both-markers, reversed, nested, stray-end inject |
| compatibility.go / intent.go | patch subtract; `>=`/`<=`; extra-field `\|\|` | patch order; Negotiate bounds; non-runnable Go fields |

NOISE leftovers (not killed): prealloc arithmetic; crypto/rand.Read without a seam; LimitReader +1 belt; equal-ID sort; kanban optional fields / websocket reconnect OR; swarm dep-state else-if; launchapi cwd utf8 OR chain and nil vs empty maps.

## Test plan
- [x] `go test ./internal/format ./internal/integration/symphony ./internal/thread ./internal/sessionguard ./internal/swarm ./launchapi`
- [x] `make ci` on this worktree
- [ ] GitHub CI green
