### PR TITLE
test(keepalive): bound StartWake timeout by a timer seam, not wall clock

### DIFF
--- a/internal/keepalive/amq/runner.go
+++ b/internal/keepalive/amq/runner.go
@@ -714,12 +714,36 @@ func (c CLI) run(ctx context.Context, args ...string) ([]byte, string, error) {
 	return stdout.Bytes(), stderr.String(), err
 }
 
+type wakeReadyTimer struct {
+	channel <-chan time.Time
+	stop    func()
+}
+
+type wakeReadyTimerFactory func(time.Duration) wakeReadyTimer
+type wakeGraceObserver func(<-chan wakeProcessResult, string, time.Duration) (bool, bool, error)
+
+func newRealWakeReadyTimer(timeout time.Duration) wakeReadyTimer {
+	timer := time.NewTimer(timeout)
+	return wakeReadyTimer{channel: timer.C, stop: func() { timer.Stop() }}
+}
+
 func waitForWakeReady(ctx context.Context, done <-chan wakeProcessResult, readyFile string, timeout time.Duration) (bool, error) {
+	return waitForWakeReadyWith(ctx, done, readyFile, timeout, newRealWakeReadyTimer, observeWakeDuringGrace)
+}
+
+func waitForWakeReadyWith(
+	ctx context.Context,
+	done <-chan wakeProcessResult,
+	readyFile string,
+	timeout time.Duration,
+	newTimer wakeReadyTimerFactory,
+	observe wakeGraceObserver,
+) (bool, error) {
 	if timeout <= 0 {
 		timeout = defaultWakeReadyTimeout
 	}
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
+	timer := newTimer(timeout)
+	defer timer.stop()
 	ticker := time.NewTicker(20 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -731,12 +755,12 @@ func waitForWakeReady(ctx context.Context, done <-chan wakeProcessResult, readyF
 		case result := <-done:
 			return finishWakeProcess(result, readyFile)
 		case <-ctx.Done():
-			if processDone, observed, err := observeWakeDuringGrace(done, readyFile, wakeProcessExitGrace); observed {
+			if processDone, observed, err := observe(done, readyFile, wakeProcessExitGrace); observed {
 				return processDone, err
 			}
 			return false, ctx.Err()
-		case <-timer.C:
-			if processDone, observed, err := observeWakeDuringGrace(done, readyFile, wakeProcessExitGrace); observed {
+		case <-timer.channel:
+			if processDone, observed, err := observe(done, readyFile, wakeProcessExitGrace); observed {
 				return processDone, err
 			}
 			return false, fmt.Errorf("timed out after %s waiting for amq wake readiness", timeout)

--- a/internal/keepalive/amq/runner_test.go
+++ b/internal/keepalive/amq/runner_test.go
@@ -595,7 +595,6 @@ while [ ! -f "$AMQ_KEEPALIVE_RELEASE" ]; do sleep 0.01; done
 `)
 	registerDetachedWakeCleanup(t, pidFile, release)
 
-	start := time.Now()
 	err := NewCLI(fakeAMQ).StartWake(context.Background(), StartWakeRequest{
 		Root:      "/tmp/amq-root",
 		Me:        "codex",
@@ -610,8 +609,38 @@ while [ ! -f "$AMQ_KEEPALIVE_RELEASE" ]; do sleep 0.01; done
 	if !strings.Contains(err.Error(), "timed out") || !errors.Is(err, ErrWakeReadinessUncertain) {
 		t.Fatalf("error = %v, want uncertain timeout", err)
 	}
-	if elapsed := time.Since(start); elapsed > 2*time.Second {
-		t.Fatalf("StartWake took %s, want timeout branch to return promptly", elapsed)
+}
+
+func TestWaitForWakeReadyUsesRequestedTimeoutDeterministically(t *testing.T) {
+	timeoutSignal := make(chan time.Time, 1)
+	timeoutSignal <- time.Time{}
+	var requestedTimeout time.Duration
+	var observedGrace time.Duration
+	processDone, err := waitForWakeReadyWith(
+		context.Background(),
+		make(chan wakeProcessResult),
+		filepath.Join(t.TempDir(), "missing"),
+		50*time.Millisecond,
+		func(timeout time.Duration) wakeReadyTimer {
+			requestedTimeout = timeout
+			return wakeReadyTimer{channel: timeoutSignal, stop: func() {}}
+		},
+		func(_ <-chan wakeProcessResult, _ string, grace time.Duration) (bool, bool, error) {
+			observedGrace = grace
+			return false, false, nil
+		},
+	)
+	if processDone {
+		t.Fatal("waitForWakeReadyWith() processDone = true, want uncertain timeout")
+	}
+	if err == nil || !strings.Contains(err.Error(), "timed out after 50ms") {
+		t.Fatalf("waitForWakeReadyWith() error = %v, want exact timeout", err)
+	}
+	if requestedTimeout != 50*time.Millisecond {
+		t.Fatalf("timer duration = %s, want 50ms", requestedTimeout)
+	}
+	if observedGrace != wakeProcessExitGrace {
+		t.Fatalf("observation grace = %s, want %s", observedGrace, wakeProcessExitGrace)
 	}
 }
 


### PR DESCRIPTION
## Diagnosis

`TestStartWakeTimesOutWhenReadyFileNeverAppears` used a 50ms readiness timeout but also asserted the complete real-child path returned within two wall-clock seconds. That measurement included shell startup, stderr-drain helper setup, filesystem work, scheduler delay, and the deliberate 300ms readiness/exit race grace. It flaked under parallel Darwin load without evidence of a product liveness defect.

## Change

- Keep the real child integration test and its uncertain-timeout error assertion.
- Remove the host-scheduling wall-clock upper bound.
- Add a package-local timer-factory and grace-observer seam around `waitForWakeReady`.
- Deterministically assert that the requested 50ms reaches the timer factory, the timeout error names 50ms, and the 300ms grace path is consulted.
- Production still uses `time.NewTimer` and `observeWakeDuringGrace`.

## Hostile proof

A `newTimer(5 * timeout)` mutant fails immediately with `timer duration = 250ms, want 50ms`. A no-wait/success mutant fails the retained real-child integration test.

## Verification

- Real-child and deterministic tests passed together for 20 repetitions.
- `go test -race ./internal/keepalive/amq -count=1` passed.
- `go test ./... -count=1` passed.
- The complete pre-push gate passed without bypass.

Peer review: Cursor approved exact staged SHA `c8143606336d4491bc8bdd559415eb3ab49be363c43e5eae71c22280770d69b0` by execution in AMQ message `2026-08-17T19-47-58.552Z_pid27569_836c08b9`.