### PR TITLE
fix(wake): inject stop preparer for fixture tests

### DIFF
--- a/internal/cli/wake_owner_acquire_unix.go
+++ b/internal/cli/wake_owner_acquire_unix.go
@@ -122,6 +122,20 @@ func acquireAuthoritativeWakeLockWithOptions(
 	me string,
 	options wakeLockAcquireOptions,
 ) (func(), error) {
+	return acquireAuthoritativeWakeLockWithOptionsAndStopPreparer(
+		root,
+		me,
+		options,
+		prepareAuthoritativeWakeStop,
+	)
+}
+
+func acquireAuthoritativeWakeLockWithOptionsAndStopPreparer(
+	root string,
+	me string,
+	options wakeLockAcquireOptions,
+	prepareStop authoritativeWakeStopPreparer,
+) (func(), error) {
 	if err := os.MkdirAll(fsq.AgentBase(root, me), 0o700); err != nil {
 		return nil, fmt.Errorf("failed to create agent directory: %w", err)
 	}
@@ -130,7 +144,13 @@ func acquireAuthoritativeWakeLockWithOptions(
 		return nil, err
 	}
 	defer func() { _ = agentDir.Close() }()
-	return acquireAuthoritativeWakeLockWithOptionsInDir(agentDir, root, me, options)
+	return acquireAuthoritativeWakeLockWithOptionsInDirAndStopPreparer(
+		agentDir,
+		root,
+		me,
+		options,
+		prepareStop,
+	)
 }
 
 func acquireAuthoritativeWakeLockWithOptionsInDir(
@@ -138,6 +158,22 @@ func acquireAuthoritativeWakeLockWithOptionsInDir(
 	root string,
 	me string,
 	options wakeLockAcquireOptions,
+) (func(), error) {
+	return acquireAuthoritativeWakeLockWithOptionsInDirAndStopPreparer(
+		agentDir,
+		root,
+		me,
+		options,
+		prepareAuthoritativeWakeStop,
+	)
+}
+
+func acquireAuthoritativeWakeLockWithOptionsInDirAndStopPreparer(
+	agentDir *wakeAgentDir,
+	root string,
+	me string,
+	options wakeLockAcquireOptions,
+	prepareStop authoritativeWakeStopPreparer,
 ) (func(), error) {
 	if agentDir == nil {
 		return nil, fmt.Errorf("wake agent directory capability is missing")
@@ -200,7 +236,7 @@ func acquireAuthoritativeWakeLockWithOptionsInDir(
 					}
 				}
 				ownersEqual := sameWakeOwner(inspection.Lock.Owner, requested.Owner)
-				wakeCapability, err := prepareAuthoritativeWakeStop(dirfd, agentDir, inspection)
+				wakeCapability, err := prepareStop(dirfd, agentDir, inspection)
 				if err != nil {
 					return fmt.Errorf("inspect authoritative wake through stable capability: %w", err)
 				}

--- a/internal/cli/wake_owner_lifecycle_linux_test.go
+++ b/internal/cli/wake_owner_lifecycle_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -17,6 +18,94 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"golang.org/x/sys/unix"
 )
+
+func TestLinuxConcurrentOwnerRecoveryWithInjectedStopNeverCallsPidfdOpen(t *testing.T) {
+	type fixture struct {
+		root  string
+		owner wakeOwner
+	}
+	fixtures := make([]fixture, 2)
+	for i := range fixtures {
+		root := secureTempDirForTest(t)
+		if err := fsq.EnsureRootDirs(root); err != nil {
+			t.Fatal(err)
+		}
+		if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+			t.Fatal(err)
+		}
+		owner := wakeOwner{
+			PID:          4242 + i,
+			ProcessStart: fmt.Sprintf("1234%d", i),
+			BootID:       "11111111-1111-1111-1111-111111111111",
+			SessionID:    99 + i,
+		}
+		injector := writeExecutableForTest(t, fmt.Sprintf("concurrent-owner-recovery-%d", i))
+		target := mustNewWakeTargetForTest(t, root, "codex", injector, nil)
+		target.Owner = &owner
+		if err := writeWakeTarget(root, "codex", target); err != nil {
+			t.Fatal(err)
+		}
+		lock := bindWakeLockToTarget(wakeLock{
+			PID:          5151 + i,
+			TTY:          "unknown",
+			ProcessStart: fmt.Sprintf("6789%d", i),
+			BootID:       owner.BootID,
+			Generation:   fmt.Sprintf("concurrent-owner-recovery-%d", i),
+			OwnerSchema:  wakeOwnerLockSchema,
+			Owner:        &owner,
+		}, target)
+		lock.WakeMode = wakeOwnerWakeMode
+		lockPath := writeWakeLockForTest(t, root, "codex", lock)
+		if err := os.Chmod(lockPath, wakeOwnerLockFileMode); err != nil {
+			t.Fatal(err)
+		}
+		fixtures[i] = fixture{root: root, owner: owner}
+	}
+
+	oldObserve := observeAuthoritativeWakeOwner
+	observeAuthoritativeWakeOwner = func(wakeOwner) (wakeOwnerObservation, error) {
+		return wakeOwnerObservation{State: wakeOwnerDead}, nil
+	}
+	oldOpen := linuxPidfdOpen
+	var pidfdOpenCalls atomic.Int32
+	linuxPidfdOpen = func(pid, flags int) (int, error) {
+		pidfdOpenCalls.Add(1)
+		return oldOpen(pid, flags)
+	}
+	t.Cleanup(func() {
+		observeAuthoritativeWakeOwner = oldObserve
+		linuxPidfdOpen = oldOpen
+	})
+
+	start := make(chan struct{})
+	errs := make(chan error, len(fixtures))
+	var workers sync.WaitGroup
+	for _, fixture := range fixtures {
+		fixture := fixture
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			result, err := recoverOwnerWakeWithStopPreparer(
+				fixture.root,
+				"codex",
+				absentAuthoritativeWakeStopForTest,
+			)
+			if err != nil || result.Status != "recovered" {
+				errs <- fmt.Errorf("owner %d recovery = %#v: %v", fixture.owner.PID, result, err)
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if calls := pidfdOpenCalls.Load(); calls != 0 {
+		t.Fatalf("concurrent injected owner recovery made %d real pidfd_open calls", calls)
+	}
+}
 
 func TestLinuxStableOwnerStopRefusesBoundInconclusiveBeforePidfd(t *testing.T) {
 	fixture := newAuthoritativeWakePreparedCleanupFixture(t)

--- a/internal/cli/wake_owner_lifecycle_unix_test.go
+++ b/internal/cli/wake_owner_lifecycle_unix_test.go
@@ -16,6 +16,14 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
 
+func absentAuthoritativeWakeStopForTest(
+	_ int,
+	_ *wakeAgentDir,
+	expected wakeLockInspection,
+) (authoritativeWakeStopCapability, error) {
+	return authoritativeWakeStopCapability{Inspection: expected, Absent: true}, nil
+}
+
 func TestValidateAuthoritativeWakeOwnerSeparatesStrictClaimsFromLegacyParsing(t *testing.T) {
 	valid := wakeOwner{
 		PID:          4242,
@@ -904,10 +912,10 @@ func TestAcquireAuthoritativeWakeClaimReclaimsOnlyADeadOwnerWithAbsentWake(t *te
 		}
 	})
 
-	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
+	cleanup, err := acquireAuthoritativeWakeLockWithOptionsAndStopPreparer(root, "codex", wakeLockAcquireOptions{
 		target:   &newTarget,
 		wakeMode: wakeTargetInjectVia,
-	})
+	}, absentAuthoritativeWakeStopForTest)
 	if err != nil {
 		t.Fatalf("dead-owner takeover: %v", err)
 	}
@@ -1281,7 +1289,11 @@ func TestRecoverOwnerRequiresExactTokenAndCallerSessionForLiveOwner(t *testing.T
 				t.Setenv(envWakeOwner, "")
 			}
 
-			result, err := recoverOwnerWake(root, "codex")
+			result, err := recoverOwnerWakeWithStopPreparer(
+				root,
+				"codex",
+				absentAuthoritativeWakeStopForTest,
+			)
 			if test.wantSuccess {
 				if err != nil || result.Status != "recovered" {
 					t.Fatalf("recover result = %#v err=%v", result, err)
@@ -1414,7 +1426,11 @@ func TestRecoverOwnerUsesAuthoritativeLockEvidenceWhenTargetIsMissing(t *testing
 	}
 	t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
 
-	result, err := recoverOwnerWake(root, "codex")
+	result, err := recoverOwnerWakeWithStopPreparer(
+		root,
+		"codex",
+		absentAuthoritativeWakeStopForTest,
+	)
 	if err != nil || result.Status != "recovered" {
 		t.Fatalf("missing-target recovery result = %#v err=%v", result, err)
 	}
@@ -1518,7 +1534,11 @@ func testRecoverOwnerPreservesClaimWhenTargetIsMissingWithPreparedMarker(
 	t.Cleanup(func() { syncWakeOwnerDirFD = originalSync })
 
 	for attempt := 1; attempt <= 2; attempt++ {
-		result, err := recoverOwnerWake(root, "codex")
+		result, err := recoverOwnerWakeWithStopPreparer(
+			root,
+			"codex",
+			absentAuthoritativeWakeStopForTest,
+		)
 		if err == nil || result.Status != "error" ||
 			!strings.Contains(result.Reason, wantReason) {
 			t.Fatalf("attempt %d result = %#v err=%v, want unchanged-state validation error", attempt, result, err)
@@ -1690,7 +1710,11 @@ func TestRecoverOwnerPreservesUntrustedTargetButRejectsDifferentCompleteOwner(t 
 			}
 			t.Cleanup(func() { observeAuthoritativeWakeOwner = oldObserve })
 
-			result, err := recoverOwnerWake(root, "codex")
+			result, err := recoverOwnerWakeWithStopPreparer(
+				root,
+				"codex",
+				absentAuthoritativeWakeStopForTest,
+			)
 			if test.wantRecovered {
 				if err != nil || result.Status != "recovered" {
 					t.Fatalf("untrusted-target recovery = %#v err=%v", result, err)

--- a/internal/cli/wake_owner_recover_unix.go
+++ b/internal/cli/wake_owner_recover_unix.go
@@ -79,6 +79,14 @@ func runWakeRecoverOwner(args []string) error {
 }
 
 func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
+	return recoverOwnerWakeWithStopPreparer(root, me, prepareAuthoritativeWakeStop)
+}
+
+func recoverOwnerWakeWithStopPreparer(
+	root string,
+	me string,
+	prepareStop authoritativeWakeStopPreparer,
+) (wakeOwnerRecoverResult, error) {
 	result := wakeOwnerRecoverResult{
 		Status: "unknown",
 		Agent:  me,
@@ -271,7 +279,7 @@ func recoverOwnerWake(root, me string) (wakeOwnerRecoverResult, error) {
 					"preserve the claim and retry after owner monitoring is healthy",
 				), err)
 			}
-			wakeCapability, err := prepareAuthoritativeWakeStop(dirfd, agentDir, inspection)
+			wakeCapability, err := prepareStop(dirfd, agentDir, inspection)
 			if err != nil {
 				return refuse("exact wake inspection is unavailable: "+err.Error(), "preserve the claim and retry")
 			}

--- a/internal/cli/wake_owner_stop_unix.go
+++ b/internal/cli/wake_owner_stop_unix.go
@@ -14,6 +14,12 @@ type authoritativeWakeStopCapability struct {
 	close      func() error
 }
 
+type authoritativeWakeStopPreparer func(
+	dirfd int,
+	agentDir *wakeAgentDir,
+	expected wakeLockInspection,
+) (authoritativeWakeStopCapability, error)
+
 func (capability *authoritativeWakeStopCapability) Stop(auth wakeOwnerReleaseAuthorization) error {
 	if capability == nil || capability.Absent || capability.stop == nil {
 		return nil


### PR DESCRIPTION
## Summary
- inject authoritative wake stop preparation per call while keeping the platform implementation as the production default
- route fake-PID owner lifecycle fixtures through an absent-stop capability
- add a Linux concurrency regression that records and rejects any real `pidfd_open` call

## Verification
- affected wake-owner tests: 30 repeated runs passed
- `go test ./internal/cli -count=1`
- `go test -race ./internal/cli -count=1`
- Linux amd64 `internal/cli` test binary cross-compiled
- vet and golangci-lint passed
- full local pre-push test is blocked only by unrelated bead `amq-ckm`: macOS canonicalizes `/tmp` to `/private/tmp` in `internal/keepalive/app`
- Ubuntu CI is the platform arbiter

Peer review: lead (cursor unavailable). Exact reviewed staged SHA-256: `5f1f6eac5deb597690a9308f20b5068578b2f12ea9ad5d8cecf042b6f19094aa`.

Bead: amq-erv