### PR TITLE
test(cli): guard exec seams; PTY-independent same-TTY fixture

### DIFF
--- a/internal/cli/coop_exec_guard_test.go
+++ b/internal/cli/coop_exec_guard_test.go
@@ -12,8 +12,33 @@ import (
 )
 
 func guardTestProcessReplacement() {
-	coopExecProcess = func(path string, _ []string, _ []string) error {
-		return fmt.Errorf("test attempted unguarded process replacement with %q", path)
+	coopExecProcess = guardedTestProcessReplacement("coopExecProcess")
+	launchExecProcess = guardedTestProcessReplacement("launchExecProcess")
+	wakeRestartExec = guardedTestProcessReplacement("wakeRestartExec")
+}
+
+func guardedTestProcessReplacement(seam string) func(string, []string, []string) error {
+	return func(path string, _ []string, _ []string) error {
+		return fmt.Errorf("test attempted unguarded %s process replacement with %q", seam, path)
+	}
+}
+
+func TestProcessReplacementGuardCoversEveryExecSeam(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		exec func(string, []string, []string) error
+	}{
+		{name: "coopExecProcess", exec: coopExecProcess},
+		{name: "launchExecProcess", exec: launchExecProcess},
+		{name: "wakeRestartExec", exec: wakeRestartExec},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "must-not-exec")
+			err := tc.exec(path, []string{path}, os.Environ())
+			if err == nil || !strings.Contains(err.Error(), "test attempted unguarded "+tc.name+" process replacement") || !strings.Contains(err.Error(), path) {
+				t.Fatalf("unguarded %s error = %v, want loud test-process replacement refusal", tc.name, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -6943,6 +6943,8 @@ func TestWakeLockNeedsReplacementKeepsSameTTYSessionCheckForExternalInjector(t *
 		}
 		return 200, nil
 	})
+	// The fake path has no portable terminal-device identity. Leave process
+	// terminal identity unknown so both platforms exercise the path fallback.
 	inspection := wakeLockInspection{
 		IdentityConfirmed: true,
 		Lock: wakeLock{
@@ -6951,13 +6953,15 @@ func TestWakeLockNeedsReplacementKeepsSameTTYSessionCheckForExternalInjector(t *
 			WakeMode:     wakeTargetInjectVia,
 			TargetDigest: "bound-target-digest",
 		},
-		Process: wakeProcessInfo{
-			ControllingTerminalKnown: true,
-			HasControllingTerminal:   true,
-		},
 	}
 	if !wakeLockNeedsReplacement(inspection) {
 		t.Fatal("same-TTY external injector from another session should require replacement")
+	}
+
+	differentTTY := inspection
+	differentTTY.Lock.TTY = filepath.Join(t.TempDir(), "different-tty")
+	if wakeLockNeedsReplacement(differentTTY) {
+		t.Fatal("different-TTY external injector should not require session-based replacement")
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix a PTY-sensitive Darwin test fixture; there was no cross-test polluter
- keep production fail-closed behavior and add a different-TTY negative
- install loud test guards for all three process-replacement seams: `coopExecProcess`, `launchExecProcess`, and `wakeRestartExec`

## Mutation sweep

| Scope | Killed | Lived | Not covered |
| --- | ---: | ---: | ---: |
| `launch*.go` | 118 | 0 | 5 |
| `setup.go` | 159 | 0 | 3 |
| `doctor.go`, `doctor_schema_v2.go` | 150 | 0 | 6 |
| `doctor_ops*.go` | 92 | 0 | 22 |
| `doctor_stale_wake_binary*.go` | 100 | 0 | 13 |

`doctor_wake_lock*` was not swept because it belongs to the concurrent Cursor lane.

## Verification
- exact same-TTY victim passes with and without a PTY
- focused race test covers the victim and every exec guard
- `make ci`
- pre-push hook reran `make ci`

Beads: `amq-4ry`, `amq-5tw`