### PR TITLE
test(cli): kill round-3 survivors in dlq, session, and wake args

### DIFF
--- a/internal/cli/dlq_guard_test.go
+++ b/internal/cli/dlq_guard_test.go
@@ -491,3 +491,79 @@ func snapshotDLQFileState(t *testing.T, root, agent string) map[string][]byte {
 	}
 	return state
 }
+
+func TestDLQListSkipsDotfilesEvenWhenTheyParse(t *testing.T) {
+	root := initializedSendMailboxRoot(t, "alice")
+	visible := moveInvalidFixtureToDLQForRetryAll(t, root, "alice", "visible-dlq")
+	data, err := os.ReadFile(visible)
+	if err != nil {
+		t.Fatalf("read visible DLQ envelope: %v", err)
+	}
+	hidden := filepath.Join(fsq.AgentDLQNew(root, "alice"), ".hidden.md")
+	if err := os.WriteFile(hidden, data, 0o600); err != nil {
+		t.Fatalf("write hidden DLQ envelope: %v", err)
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runDLQList([]string{"--root", root, "--me", "alice", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("dlq list: %v", err)
+	}
+	var items []dlqListItem
+	if err := unmarshalJSONOutput(stdout, &items); err != nil {
+		t.Fatalf("decode dlq list: %v (output: %s)", err, stdout)
+	}
+	wantID := strings.TrimSuffix(filepath.Base(visible), ".md")
+	if len(items) != 1 || items[0].ID != wantID {
+		t.Fatalf("dlq list items = %#v, want only %s (dotfile skipped)", items, wantID)
+	}
+}
+
+func TestDLQListSortsByFailureTimeWithoutTreatingZeroSortKeyAsNewest(t *testing.T) {
+	t.Run("parsed newest first", func(t *testing.T) {
+		root := initializedSendMailboxRoot(t, "alice")
+		writeDLQEnvelopeWithFailureTime(t, root, "alice", "older-parsed.md", "2020-01-01T00:00:00Z")
+		writeDLQEnvelopeWithFailureTime(t, root, "alice", "newer-parsed.md", "2024-06-01T00:00:00Z")
+		stdout, _, err := captureEnvOutput(t, func() error {
+			return runDLQList([]string{"--root", root, "--me", "alice", "--new", "--json"})
+		})
+		if err != nil {
+			t.Fatalf("dlq list: %v", err)
+		}
+		var items []dlqListItem
+		if err := unmarshalJSONOutput(stdout, &items); err != nil {
+			t.Fatalf("decode: %v (output: %s)", err, stdout)
+		}
+		if len(items) != 2 || items[0].ID != "newer-parsed" || items[1].ID != "older-parsed" {
+			t.Fatalf("parsed order = %v, want newer-parsed then older-parsed", idsOf(items))
+		}
+	})
+
+	t.Run("unparsed string order beats zero SortKey", func(t *testing.T) {
+		root := initializedSendMailboxRoot(t, "alice")
+		writeDLQEnvelopeWithFailureTime(t, root, "alice", "parsed.md", "2020-01-01T00:00:00Z")
+		writeDLQEnvelopeWithFailureTime(t, root, "alice", "unparsed.md", "not-a-rfc3339-time")
+		stdout, _, err := captureEnvOutput(t, func() error {
+			return runDLQList([]string{"--root", root, "--me", "alice", "--new", "--json"})
+		})
+		if err != nil {
+			t.Fatalf("dlq list: %v", err)
+		}
+		var items []dlqListItem
+		if err := unmarshalJSONOutput(stdout, &items); err != nil {
+			t.Fatalf("decode: %v (output: %s)", err, stdout)
+		}
+		if len(items) != 2 || items[0].ID != "unparsed" || items[1].ID != "parsed" {
+			t.Fatalf("mixed order = %v, want unparsed then parsed (string compare, not zero-time After)", idsOf(items))
+		}
+	})
+}
+
+func idsOf(items []dlqListItem) []string {
+	ids := make([]string, len(items))
+	for i, item := range items {
+		ids[i] = item.ID
+	}
+	return ids
+}

--- a/internal/cli/dlq_purge_selection_test.go
+++ b/internal/cli/dlq_purge_selection_test.go
@@ -226,6 +226,38 @@ func TestDLQPurgeDryRunDoesNotCreateDLQLocks(t *testing.T) {
 	}
 }
 
+func TestDLQPurgeSkipsDotfilesEvenWhenTheyParse(t *testing.T) {
+	root := initializedSendMailboxRoot(t, "alice", "bob")
+	visible := writeOldValidDLQEnvelope(t, root, "alice", "visible-purge.md")
+	data, err := os.ReadFile(visible)
+	if err != nil {
+		t.Fatalf("read visible envelope: %v", err)
+	}
+	hidden := filepath.Join(fsq.AgentDLQNew(root, "alice"), ".hidden-purge.md")
+	if err := os.WriteFile(hidden, data, 0o600); err != nil {
+		t.Fatalf("write hidden envelope: %v", err)
+	}
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runDLQPurge([]string{"--root", root, "--me", "alice", "--yes", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	var result struct {
+		Removed int `json:"removed"`
+	}
+	if err := unmarshalJSONOutput(stdout, &result); err != nil {
+		t.Fatalf("decode purge: %v (output: %s)", err, stdout)
+	}
+	if result.Removed != 1 {
+		t.Fatalf("purge removed = %d, want 1 (dotfile skipped)", result.Removed)
+	}
+	if _, err := os.Stat(hidden); err != nil {
+		t.Fatalf("hidden DLQ envelope was purged: %v", err)
+	}
+}
+
 func TestDLQPurgeWithoutAgeFilterRemovesCorruptEnvelope(t *testing.T) {
 	root := initializedSendMailboxRoot(t, "alice", "bob")
 	path, _ := writeFreshCorruptDLQEnvelope(t, root, "alice", "corrupt-unconditional-purge.md")
@@ -356,6 +388,11 @@ func TestDLQPurgeStaleCandidateCannotDeleteConcurrentRetryAudit(t *testing.T) {
 
 func writeOldValidDLQEnvelope(t *testing.T, root, agent, filename string) string {
 	t.Helper()
+	return writeDLQEnvelopeWithFailureTime(t, root, agent, filename, time.Now().Add(-48*time.Hour).UTC().Format(time.RFC3339))
+}
+
+func writeDLQEnvelopeWithFailureTime(t *testing.T, root, agent, filename, failureTime string) string {
+	t.Helper()
 	env := fsq.DLQEnvelope{
 		Schema:        fsq.DLQSchemaVersion,
 		ID:            strings.TrimSuffix(filename, ".md"),
@@ -363,7 +400,7 @@ func writeOldValidDLQEnvelope(t *testing.T, root, agent, filename string) string
 		OriginalFile:  "original.md",
 		FailureReason: "test_failure",
 		FailureDetail: "old deterministic fixture",
-		FailureTime:   time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339),
+		FailureTime:   failureTime,
 		SourceDir:     fsq.BoxNew,
 	}
 	header, err := json.Marshal(env)

--- a/internal/cli/dlq_retry_all_test.go
+++ b/internal/cli/dlq_retry_all_test.go
@@ -487,6 +487,46 @@ func TestRunDLQRetryAllKeepsCommittedEnvelopeUpdateInSkipped(t *testing.T) {
 	}
 }
 
+func TestDLQRetryAllSkipsDotfilesEvenWhenTheyParse(t *testing.T) {
+	root := initializedSendMailboxRoot(t, "alice", "bob")
+	visible := writeOldValidDLQEnvelope(t, root, "alice", "visible-retry.md")
+	data, err := os.ReadFile(visible)
+	if err != nil {
+		t.Fatalf("read visible envelope: %v", err)
+	}
+	hidden := filepath.Join(fsq.AgentDLQNew(root, "alice"), ".hidden-retry.md")
+	if err := os.WriteFile(hidden, data, 0o600); err != nil {
+		t.Fatalf("write hidden envelope: %v", err)
+	}
+
+	stdout, _, retryErr := captureEnvOutput(t, func() error {
+		return runDLQRetry([]string{"--root", root, "--me", "alice", "--all", "--json"})
+	})
+	if retryErr != nil {
+		t.Fatalf("retry-all: %v (output: %s)", retryErr, stdout)
+	}
+	var result struct {
+		Retried []string `json:"retried"`
+		Skipped []string `json:"skipped"`
+		Count   int      `json:"count"`
+	}
+	if decodeErr := unmarshalJSONOutput(stdout, &result); decodeErr != nil {
+		t.Fatalf("decode retry-all: %v (output: %s)", decodeErr, stdout)
+	}
+	if result.Count != 1 || !containsString(result.Retried, "visible-retry") {
+		t.Fatalf("retry-all result = %#v, want visible envelope retried once", result)
+	}
+	if containsString(result.Retried, ".hidden-retry") || containsString(result.Skipped, ".hidden-retry.md") {
+		t.Fatalf("hidden envelope was scanned: %#v", result)
+	}
+	if _, err := os.Stat(visible); !os.IsNotExist(err) {
+		t.Fatalf("visible DLQ envelope was not moved from new: %v", err)
+	}
+	if _, err := os.Stat(hidden); err != nil {
+		t.Fatalf("hidden DLQ envelope was retried away: %v", err)
+	}
+}
+
 func moveInvalidFixtureToDLQForRetryAll(t *testing.T, root, agent, id string) string {
 	t.Helper()
 	deliverInvalidDLQTransitionFixture(t, root, agent, id)

--- a/internal/cli/session_guard_followup_test.go
+++ b/internal/cli/session_guard_followup_test.go
@@ -186,6 +186,50 @@ func TestLoadSessionPinNamesIncompletePinEvidence(t *testing.T) {
 	}
 }
 
+func TestLoadSessionPinRequiresBothIdentityTokensWhenBaseRootIsSet(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv(envBaseRoot, base)
+	setOptionalEnv(t, envSession, "", false)
+	setOptionalEnv(t, envRootID, "v1:root-token-only", true)
+	setOptionalEnv(t, envBaseRootID, "", false)
+
+	_, err := loadSessionPin()
+	if err == nil || GetExitCode(err) != ExitContextMismatch {
+		t.Fatalf("one-sided identity pin should be context mismatch, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "incomplete AMQ identity pin") {
+		t.Fatalf("error = %v, want incomplete identity pin (not a silent success)", err)
+	}
+}
+
+func TestLoadSessionPinRejectsPresentEmptyIdentityToken(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv(envBaseRoot, base)
+	setOptionalEnv(t, envSession, "", false)
+
+	cases := []struct {
+		name       string
+		rootID     string
+		baseRootID string
+	}{
+		{name: "empty root token", rootID: "   ", baseRootID: "v1:base-token"},
+		{name: "empty base token", rootID: "v1:root-token", baseRootID: "   "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setOptionalEnv(t, envRootID, tc.rootID, true)
+			setOptionalEnv(t, envBaseRootID, tc.baseRootID, true)
+			_, err := loadSessionPin()
+			if err == nil || GetExitCode(err) != ExitContextMismatch {
+				t.Fatalf("empty present identity token should be context mismatch, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "incomplete AMQ identity pin") {
+				t.Fatalf("error = %v, want incomplete identity pin", err)
+			}
+		})
+	}
+}
+
 func pointerTo(value string) *string {
 	return &value
 }

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -501,3 +501,49 @@ func dirNames(t *testing.T, path string) []string {
 	sort.Strings(names)
 	return names
 }
+
+func TestPeelSessionResumeNameRejectsFlagAsName(t *testing.T) {
+	_, _, err := peelSessionResumeName([]string{"--json"})
+	if err == nil || GetExitCode(err) != ExitUsage {
+		t.Fatalf("peelSessionResumeName(--json) = %v, want usage", err)
+	}
+	if !strings.Contains(err.Error(), "session name required") {
+		t.Fatalf("error = %v, want session name required (not validateSessionName of --json)", err)
+	}
+}
+
+func TestSessionListSkipsRegularFileAgentsDir(t *testing.T) {
+	base := makeSessionBase(t)
+	sess := filepath.Join(base, "collab")
+	if err := os.Mkdir(sess, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sess, "agents"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runSessionList([]string{"--root", base, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var result sessionListResult
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode: %v (%s)", err, output)
+	}
+	for _, item := range result.Sessions {
+		if item.Name == "collab" {
+			t.Fatalf("regular-file agents dir listed as session: %#v", item)
+		}
+	}
+	found := false
+	for _, skipped := range result.Skipped {
+		if skipped.Name == "collab" && skipped.Reason == "not_a_session" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected collab skipped as not_a_session, got %#v", result.Skipped)
+	}
+}

--- a/internal/cli/wake_lock_test.go
+++ b/internal/cli/wake_lock_test.go
@@ -653,3 +653,17 @@ func TestInspectWakeLockRejectsBootIDWithoutProcessStart(t *testing.T) {
 		t.Fatalf("inspection reason = %q", inspection.Reason)
 	}
 }
+
+func TestWakeArgsMatchRootAgentIgnoresDanglingFlags(t *testing.T) {
+	root := canonicalWakeRoot(secureTempDirForTest(t))
+	const me = "codex"
+	if !wakeArgsMatchRootAgent([]string{"amq", "wake", "--root", root, "--me", me}, root, me) {
+		t.Fatal("complete --root/--me should match")
+	}
+	if wakeArgsMatchRootAgent([]string{"amq", "wake", "--me", me, "--root"}, root, me) {
+		t.Fatal("dangling --root must not match (and must not index past argv)")
+	}
+	if wakeArgsMatchRootAgent([]string{"amq", "wake", "--root", root, "--me"}, root, me) {
+		t.Fatal("dangling --me must not match (and must not index past argv)")
+	}
+}


### PR DESCRIPTION
## Summary
- preserve Cursor's round-3 survivor tests for DLQ, session, and wake argument boundaries
- strengthen retry-all proof so a scan-zero implementation cannot pass
- keep the change test-only

## Original survivor table

| Surface | Survivor exercised | Added proof |
| --- | --- | --- |
| DLQ list | parsed dotfile scanned | only visible envelope is listed |
| DLQ purge | parsed dotfile scanned | visible envelope is removed; hidden envelope remains |
| DLQ retry-all | parsed dotfile scanned | visible envelope retries once; hidden envelope remains |
| DLQ list sort | zero `SortKey` enters time comparison | parsed timestamps sort newest-first; mixed values use string fallback |
| Session resume | flag accepted as name | `--json` is rejected as a missing session name |
| Session list | regular-file `agents` accepted | entry is skipped as `not_a_session` |
| Session pin | one-sided identity tokens accepted | both identity tokens are required |
| Session pin | present-empty identity token accepted | whitespace-only tokens are rejected as incomplete |
| Wake args | dangling `--root` or `--me` indexes past argv | both dangling forms return false without panic |

## Review by execution
Eight production counterexamples failed for the intended reason and were reverted: three DLQ dotfile guards, the mixed `SortKey` logical guard, the session-name flag guard, the session `agents` directory check, the identity-token completeness guard, and the wake argv bound. The retry-all test was tightened to require nil error, one successful visible retry, and removal of the visible source file.

## Remaining mutation scope
- `doctor_wake_lock*`: completed; no eligible invert-logical mutations.
- `wake_lock.go` and `wake_lock_at_unix.go`: contained run stopped after 10.5 minutes when disk headroom reached 17 GiB. The incomplete output is not a verdict. Follow-up: `amq-tu6`.

## Verification
- focused new-test set
- focused `-race` run
- `make ci`

Co-authored with Cursor from the handed-off staged patch.