### PR TITLE
feat(launchapi): record subject_schema and advertise contract 0.61.1

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -4,7 +4,7 @@ AMQ exposes a versioned launch contract for tools that must plan and apply a
 session without parsing human output. The Go package is `launchapi`. The JSON
 contract is [schemas/launch-api-v1.schema.json](../schemas/launch-api-v1.schema.json).
 
-The current compatibility floor is `0.61.0`. A caller must negotiate its
+The current contract is `0.61.1`. A caller must negotiate its
 required contract range, intent version, result version, and features before it
 depends on them:
 
@@ -20,6 +20,18 @@ if err != nil {
 }
 _ = negotiated
 ```
+
+A `0.61.1` binary can advertise only a subset of the Wave B3 feature IDs while
+the remaining implementation beads are incomplete. A caller must require every
+feature it uses. Contract semver alone does not claim that an unadvertised
+feature is available.
+
+`PreviewV1.capabilities` is present as a deny-by-default skeleton and is empty
+until the `initial_input` feature lands. `ProviderCapabilitiesV1` defines the
+carrier and configuration-override arrays that the owning bead will populate.
+The first Codex configuration-key candidate is
+`model_reasoning_effort`; its accepted values remain TBD and are not advertised
+by this bead.
 
 ## Intent
 
@@ -107,10 +119,11 @@ OpenCode also remain outside this adapter set.
 
 ## Prepare and Apply
 
-Prepare is read-only. It returns the exact subject, plan, and trust digests, a
-preview, current observations, and required actions. Apply accepts the original
-Prepare request, the returned subject digest, and one explicit decision for
-each required action. It recomputes the plan and fails closed if state changed.
+Prepare is read-only. It returns the exact subject schema, subject, plan, and
+trust digests, a preview, current observations, and required actions. Apply
+accepts the original Prepare request, the returned subject schema and digest,
+and one explicit decision for each required action. It recomputes the subject
+under that schema and fails closed if state changed.
 
 ```go
 request := launchapi.PrepareRequestV1{
@@ -144,10 +157,16 @@ for _, action := range prepared.RequiredActions {
 result, err := launchapi.Apply(ctx, launchapi.ApplyRequestV1{
 	RequestVersion: launchapi.RequestVersionV1,
 	Prepare:        request,
+	SubjectSchema:  prepared.SubjectSchema,
 	SubjectDigest:  prepared.SubjectDigest,
 	Decisions:      decisions,
 })
 ```
+
+New Prepare calls use subject schema `2`. Apply input serialized by a `0.61.0`
+caller has no `subject_schema`; `0.61.1` interprets that omission as schema `1`
+and reports `reprepare_recommended` in the result hints. A new caller must copy
+the returned schema. It must not omit the field to select legacy behavior.
 
 `reviewedChoiceFor` is intentionally caller-owned. AMQ does not choose trust,
 stale-conversation, rebind, or degraded-capability decisions for the caller.

--- a/internal/cli/launch_api_e2e_test.go
+++ b/internal/cli/launch_api_e2e_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/avivsinai/agent-message-queue/launchapi"
 )
 
+const launchContractV061BaselineCommit = "46fa8e03599f7e7d56b021f91752048838778bce"
+
 func TestCompatibilityFloorAndEndToEndMatrix(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and executes the real amq binary")
@@ -38,7 +40,7 @@ func TestCompatibilityFloorAndEndToEndMatrix(t *testing.T) {
 	}
 
 	t.Run("compatibility floor", func(t *testing.T) {
-		if launchapi.Compatibility().ContractSemver != "0.61.0" {
+		if launchapi.Compatibility().ContractSemver != "0.61.1" {
 			t.Fatalf("contract floor = %q", launchapi.Compatibility().ContractSemver)
 		}
 		if _, err := launchapi.Negotiate(launchapi.RequirementV1{
@@ -199,6 +201,109 @@ func TestCompatibilityFloorAndEndToEndMatrix(t *testing.T) {
 			t.Fatalf("tmux readback = %#v", readback)
 		}
 	})
+}
+
+func TestV061PrepareV0611ApplyCompatibility(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and executes two real amq binaries")
+	}
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	currentBinary := filepath.Join(binDir, "amq-v0611")
+	buildCurrent := exec.Command("go", "build", "-o", currentBinary, "./cmd/amq")
+	buildCurrent.Dir = repoRoot
+	if output, err := buildCurrent.CombinedOutput(); err != nil {
+		t.Fatalf("build v0.61.1 contract binary: %v\n%s", err, output)
+	}
+	legacyBinary := buildHistoricalLaunchBinary(t, repoRoot, binDir, launchContractV061BaselineCommit)
+
+	fixture := newPublicLaunchE2EFixture(t, binDir, launch.LauncherCommands)
+	intent := launchapi.LaunchIntentV1{
+		IntentVersion: launchapi.IntentVersionV1,
+		Participants:  []launchapi.ParticipantV1{{Handle: "operator", Runnable: false}},
+	}
+	intentPath := writeLaunchIntentE2E(t, intent)
+	env := fixture.env()
+	stdout, stderr, exit := runRealAMQWithExit(t, legacyBinary, fixture.project, env,
+		"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "commands")
+	if exit != 0 {
+		t.Fatalf("v0.61.0 Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+	}
+	var legacyPrepared struct {
+		SubjectDigest string `json:"subject_digest"`
+	}
+	if err := json.Unmarshal(stdout, &legacyPrepared); err != nil {
+		t.Fatalf("decode v0.61.0 Prepare: %v\n%s", err, stdout)
+	}
+	if legacyPrepared.SubjectDigest == "" || bytes.Contains(stdout, []byte(`"subject_schema"`)) {
+		t.Fatalf("legacy Prepare shape changed: %s", stdout)
+	}
+	request := fixture.request(intent, launch.LauncherCommands)
+	applyData, err := json.Marshal(struct {
+		RequestVersion int                        `json:"request_version"`
+		Prepare        launchapi.PrepareRequestV1 `json:"prepare"`
+		SubjectDigest  string                     `json:"subject_digest"`
+		Decisions      []launchapi.DecisionV1     `json:"decisions"`
+	}{
+		RequestVersion: launchapi.RequestVersionV1,
+		Prepare:        request,
+		SubjectDigest:  legacyPrepared.SubjectDigest,
+		Decisions:      []launchapi.DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyPath := filepath.Join(t.TempDir(), "legacy-apply.json")
+	if err := os.WriteFile(applyPath, applyData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, exit = runRealAMQWithExit(t, currentBinary, fixture.project, env,
+		"launch", "--apply", applyPath, "--json")
+	if exit != 0 {
+		t.Fatalf("v0.61.1 Apply exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+	}
+	var applied launchapi.ApplyResultV1
+	decodeRealLaunchJSON(t, stdout, &applied)
+	if applied.ReasonCode == "subject_changed" || applied.SubjectSchema != launchapi.SubjectSchemaV1 ||
+		!slices.Equal(applied.Hints, []launchapi.ResultHintV1{launchapi.HintReprepareRecommended}) {
+		t.Fatalf("cross-version Apply = %#v", applied)
+	}
+
+	stdout, stderr, exit = runRealAMQWithExit(t, currentBinary, fixture.project, env,
+		"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", "commands")
+	if exit != 0 {
+		t.Fatalf("v0.61.1 re-Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+	}
+	var upgraded launchapi.PrepareResultV1
+	decodeRealLaunchJSON(t, stdout, &upgraded)
+	if upgraded.SubjectSchema != launchapi.SubjectSchemaV2 || upgraded.SubjectDigest == legacyPrepared.SubjectDigest {
+		t.Fatalf("re-Prepare did not upgrade schema: legacy=%s upgraded=%#v", legacyPrepared.SubjectDigest, upgraded)
+	}
+}
+
+func buildHistoricalLaunchBinary(t *testing.T, repoRoot, binDir, commit string) string {
+	t.Helper()
+	archivePath := filepath.Join(t.TempDir(), "source.tar")
+	archive := exec.Command("git", "archive", "--format=tar", "--output", archivePath, commit)
+	archive.Dir = repoRoot
+	if output, err := archive.CombinedOutput(); err != nil {
+		t.Skipf("v0.61.0 contract commit %s unavailable: %v\n%s", commit, err, output)
+	}
+	sourceDir := t.TempDir()
+	extract := exec.Command("tar", "-xf", archivePath, "-C", sourceDir)
+	if output, err := extract.CombinedOutput(); err != nil {
+		t.Fatalf("extract v0.61.0 contract source: %v\n%s", err, output)
+	}
+	binary := filepath.Join(binDir, "amq-v0610")
+	build := exec.Command("go", "build", "-o", binary, "./cmd/amq")
+	build.Dir = sourceDir
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build v0.61.0 contract binary: %v\n%s", err, output)
+	}
+	return binary
 }
 
 type publicLaunchE2EFixture struct {
@@ -368,7 +473,7 @@ func writeApplyRequestE2E(t *testing.T, request launchapi.PrepareRequestV1, prep
 	}
 	data, err := json.Marshal(launchapi.ApplyRequestV1{
 		RequestVersion: launchapi.RequestVersionV1, Prepare: request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: decisions,
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: decisions,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/launch_public_api.go
+++ b/internal/cli/launch_public_api.go
@@ -93,6 +93,7 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 	result, err := launchapi.Apply(ctx, launchapi.ApplyRequestV1{
 		RequestVersion: launchapi.RequestVersionV1,
 		Prepare:        request,
+		SubjectSchema:  prepared.SubjectSchema,
 		SubjectDigest:  prepared.SubjectDigest,
 		Decisions:      []launchapi.DecisionV1{},
 	})

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -71,7 +71,7 @@ func TestPublicLaunchApplyReadsFullRequest(t *testing.T) {
 	}
 	apply := launchapi.ApplyRequestV1{
 		RequestVersion: launchapi.RequestVersionV1, Prepare: request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: []launchapi.DecisionV1{},
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []launchapi.DecisionV1{},
 	}
 	data, err := json.Marshal(apply)
 	if err != nil {

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -41,6 +41,7 @@ type ApplyResult struct {
 	Outcome         string
 	ReasonCode      string
 	FailureDetail   string
+	SubjectSchema   int
 	SubjectDigest   string
 	PlanDigest      string
 	TrustDigest     string
@@ -559,7 +560,7 @@ func applyActionResult(prepared PrepareResult, reason string) ApplyResult {
 
 func applyResultFromPrepare(prepared PrepareResult) ApplyResult {
 	return ApplyResult{
-		SubjectDigest: prepared.SubjectDigest, PlanDigest: prepared.PlanDigest, TrustDigest: prepared.TrustDigest,
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, PlanDigest: prepared.PlanDigest, TrustDigest: prepared.TrustDigest,
 		Backend: prepared.Backend, Profile: prepared.Profile, Roster: prepared.Roster,
 		Observations: slices.Clone(prepared.Observations), RequiredActions: slices.Clone(prepared.RequiredActions),
 	}

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -42,6 +42,8 @@ const (
 	PrepareOutcomeReady          = "ready"
 	PrepareOutcomeActionRequired = "action_required"
 	PrepareOutcomeUnsupported    = "unsupported"
+	SubjectSchemaV1              = 1
+	SubjectSchemaV2              = 2
 )
 
 type RequiredActionKind string
@@ -85,10 +87,11 @@ type PrepareParticipant struct {
 }
 
 type PrepareRequest struct {
-	Target       PrepareTarget
-	Launcher     string
-	IntentDigest string
-	Participants []PrepareParticipant
+	Target        PrepareTarget
+	Launcher      string
+	IntentDigest  string
+	Participants  []PrepareParticipant
+	SubjectSchema int
 }
 
 type AdapterFactory func(provider, executable string) HarnessAdapter
@@ -150,6 +153,7 @@ type PrepareObservation struct {
 type PrepareResult struct {
 	Outcome         string
 	Reason          string
+	SubjectSchema   int
 	SubjectDigest   string
 	PlanDigest      string
 	TrustDigest     string
@@ -261,6 +265,10 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if len(request.Participants) == 0 {
 		return PrepareResult{}, fmt.Errorf("prepare requires at least one participant")
 	}
+	subjectSchema, err := normalizeSubjectSchema(request.SubjectSchema)
+	if err != nil {
+		return PrepareResult{}, err
+	}
 	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath)
 	if err != nil {
 		return PrepareResult{}, err
@@ -322,7 +330,7 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		return PrepareResult{}, err
 	}
 	result := PrepareResult{
-		Target: state.target, Backend: backendName, Roster: roster,
+		SubjectSchema: subjectSchema, Target: state.target, Backend: backendName, Roster: roster,
 		Participants: make([]PreparedParticipant, 0, len(request.Participants)),
 		Observations: make([]PrepareObservation, 0, len(request.Participants)+len(roster.Extra)),
 	}
@@ -405,7 +413,7 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		return PrepareResult{}, err
 	}
 	result.SubjectDigest, err = digestCanonical(prepareSubject{
-		Version: 1, IntentDigest: request.IntentDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
+		Version: subjectSchema, IntentDigest: request.IntentDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
 		Target: state.target, ProjectIdentity: state.projectIdentity, SessionIdentity: state.sessionIdentity,
 		Backend: result.Backend, Profile: result.Profile, Detection: detect, Binding: bindingObservation, Roster: result.Roster,
 		Actions: result.RequiredActions, Participants: result.Participants, Observations: result.Observations,
@@ -414,6 +422,16 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		return PrepareResult{}, err
 	}
 	return result, nil
+}
+
+func normalizeSubjectSchema(schema int) (int, error) {
+	if schema == 0 {
+		return SubjectSchemaV2, nil
+	}
+	if schema != SubjectSchemaV1 && schema != SubjectSchemaV2 {
+		return 0, fmt.Errorf("unsupported subject schema %d", schema)
+	}
+	return schema, nil
 }
 
 func openPrepareTarget(target PrepareTarget) (*prepareTargetState, error) {

--- a/internal/launch/prepare_test.go
+++ b/internal/launch/prepare_test.go
@@ -11,10 +11,46 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
+
+func TestPrepareRejectsUnknownSubjectSchemaBeforeInspection(t *testing.T) {
+	_, err := Prepare(context.Background(), PrepareRequest{
+		IntentDigest:  "sha256:" + strings.Repeat("a", 64),
+		Participants:  []PrepareParticipant{{Handle: "operator"}},
+		SubjectSchema: 3,
+	}, PrepareDependencies{})
+	if err == nil || !strings.Contains(err.Error(), "unsupported subject schema") {
+		t.Fatalf("Prepare error = %v", err)
+	}
+}
+
+func TestPrepareSubjectSchemasProduceDistinctDigestsForSameState(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	v1Request := fixture.request
+	v1Request.SubjectSchema = SubjectSchemaV1
+	v1, err := Prepare(context.Background(), v1Request, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2Request := fixture.request
+	v2Request.SubjectSchema = SubjectSchemaV2
+	v2, err := Prepare(context.Background(), v2Request, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v1.SubjectSchema != SubjectSchemaV1 || v2.SubjectSchema != SubjectSchemaV2 {
+		t.Fatalf("subject schemas = %d/%d", v1.SubjectSchema, v2.SubjectSchema)
+	}
+	if v1.PlanDigest != v2.PlanDigest || v1.TrustDigest != v2.TrustDigest || v1.SubjectDigest == v2.SubjectDigest {
+		t.Fatalf("same-state digests: plan equal=%t trust equal=%t subject different=%t\nv1=%s\nv2=%s",
+			v1.PlanDigest == v2.PlanDigest, v1.TrustDigest == v2.TrustDigest, v1.SubjectDigest != v2.SubjectDigest,
+			v1.SubjectDigest, v2.SubjectDigest)
+	}
+}
 
 func TestPrepareOwningLayerIsZeroWriteAndBuildsTypedActions(t *testing.T) {
 	fixture := newInternalPrepareFixture(t)

--- a/launchapi/apply.go
+++ b/launchapi/apply.go
@@ -18,6 +18,10 @@ func Apply(ctx context.Context, request ApplyRequestV1) (ApplyResultV1, error) {
 	if err != nil {
 		return ApplyResultV1{}, err
 	}
+	prepared.SubjectSchema = internallaunch.SubjectSchemaV1
+	if request.SubjectSchema != 0 {
+		prepared.SubjectSchema = request.SubjectSchema
+	}
 	decisions := make([]internallaunch.ApplyDecision, 0, len(request.Decisions))
 	for _, decision := range request.Decisions {
 		decisions = append(decisions, internallaunch.ApplyDecision{ActionID: decision.ActionID, Choice: string(decision.Choice)})
@@ -33,7 +37,7 @@ func Apply(ctx context.Context, request ApplyRequestV1) (ApplyResultV1, error) {
 
 func fromInternalApplyResult(result internallaunch.ApplyResult) ApplyResultV1 {
 	public := ApplyResultV1{
-		ResultVersion: ResultVersionV1, Outcome: result.Outcome, ReasonCode: result.ReasonCode, FailureDetail: result.FailureDetail,
+		ResultVersion: ResultVersionV1, SubjectSchema: result.SubjectSchema, Outcome: result.Outcome, ReasonCode: result.ReasonCode, FailureDetail: result.FailureDetail,
 		SubjectDigest: result.SubjectDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
 		SemanticDigest: result.TrustDigest, Backend: result.Backend, Profile: result.Profile,
 		Roster: RosterDriftV1{
@@ -44,6 +48,9 @@ func fromInternalApplyResult(result internallaunch.ApplyResult) ApplyResultV1 {
 		Commands:     make([]CommandV1, 0, len(result.Commands)),
 		FollowUps:    make([]RequiredActionV1, 0, len(result.RequiredActions)),
 		Evidence:     make([]EvidenceRefV1, 0, len(result.Evidence)),
+	}
+	if result.SubjectSchema == SubjectSchemaV1 {
+		public.Hints = []ResultHintV1{HintReprepareRecommended}
 	}
 	for _, evidence := range result.Evidence {
 		public.Evidence = append(public.Evidence, fromInternalEvidenceRef(evidence))

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -46,7 +46,7 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 	decisions := decisionsForPreparedActions(prepared)
 	result, err := Apply(context.Background(), ApplyRequestV1{
 		RequestVersion: RequestVersionV1, Prepare: fixture.request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: decisions,
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: decisions,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -130,7 +130,7 @@ func TestConcurrentApplyPublishesOneInitializedSession(t *testing.T) {
 	}
 	request := ApplyRequestV1{
 		RequestVersion: RequestVersionV1, Prepare: fixture.request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
 	}
 	start := make(chan struct{})
 	results := make(chan ApplyResultV1, 2)
@@ -186,7 +186,7 @@ func TestPrepareIsZeroWriteAndApplyRejectsStaleSubject(t *testing.T) {
 		before := applyTreeFingerprint(t, fixture.root, nil)
 		result, err := Apply(context.Background(), ApplyRequestV1{
 			RequestVersion: RequestVersionV1, Prepare: changed,
-			SubjectDigest: prepared.SubjectDigest, Decisions: decisionsForPreparedActions(prepared),
+			SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: decisionsForPreparedActions(prepared),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -219,7 +219,7 @@ func TestPrepareIsZeroWriteAndApplyRejectsStaleSubject(t *testing.T) {
 		before := applyTreeFingerprint(t, fixture.root, nil)
 		result, err := Apply(context.Background(), ApplyRequestV1{
 			RequestVersion: RequestVersionV1, Prepare: changed,
-			SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+			SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -248,7 +248,7 @@ func TestActionRequiredSurvivesProcessRestart(t *testing.T) {
 	}
 	request := ApplyRequestV1{
 		RequestVersion: RequestVersionV1, Prepare: fixture.request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
 	}
 	raw, err := json.Marshal(request)
 	if err != nil {
@@ -265,8 +265,62 @@ func TestActionRequiredSurvivesProcessRestart(t *testing.T) {
 	if result.Outcome != "provisioned_no_runnable" || result.SemanticDigest != result.TrustDigest {
 		t.Fatalf("fresh-process Apply result = %#v", result)
 	}
+	if result.SubjectSchema != SubjectSchemaV2 || len(result.Hints) != 0 {
+		t.Fatalf("current Apply schema migration fields = %#v", result)
+	}
 	if info, err := os.Stat(filepath.Join(fixture.request.Target.SessionRoot, "agents", "operator")); err != nil || !info.IsDir() {
 		t.Fatalf("participant-only mailbox: info=%v err=%v", info, err)
+	}
+}
+
+func TestApplyOmittedSubjectSchemaUsesV1AndRecommendsReprepare(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	internalRequest, dependencies, err := prepareInputs(fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	internalRequest.SubjectSchema = internallaunch.SubjectSchemaV1
+	legacyInternal, err := internallaunch.Prepare(context.Background(), internalRequest, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := fromInternalPrepareResult(legacyInternal)
+	if legacy.SubjectSchema != SubjectSchemaV1 {
+		t.Fatalf("legacy Prepare schema = %d", legacy.SubjectSchema)
+	}
+	raw, err := json.Marshal(struct {
+		RequestVersion int              `json:"request_version"`
+		Prepare        PrepareRequestV1 `json:"prepare"`
+		SubjectDigest  string           `json:"subject_digest"`
+		Decisions      []DecisionV1     `json:"decisions"`
+	}{RequestVersionV1, fixture.request, legacy.SubjectDigest, []DecisionV1{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := DecodeApplyRequestV1(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.SubjectSchema != 0 {
+		t.Fatalf("omitted subject_schema decoded as %d", request.SubjectSchema)
+	}
+	result, err := Apply(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome == "action_required" && result.ReasonCode == "subject_changed" {
+		t.Fatalf("legacy Apply spuriously changed subject: %#v", result)
+	}
+	if result.SubjectSchema != SubjectSchemaV1 || !reflect.DeepEqual(result.Hints, []ResultHintV1{HintReprepareRecommended}) {
+		t.Fatalf("legacy Apply migration result = %#v", result)
+	}
+	upgraded, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upgraded.SubjectSchema != SubjectSchemaV2 || upgraded.SubjectDigest == legacy.SubjectDigest {
+		t.Fatalf("re-Prepare did not upgrade schema: legacy=%#v upgraded=%#v", legacy, upgraded)
 	}
 }
 
@@ -299,7 +353,7 @@ func TestApplyReportsRosterDriftWithoutDeletingHistory(t *testing.T) {
 	}
 	result, err := Apply(context.Background(), ApplyRequestV1{
 		RequestVersion: RequestVersionV1, Prepare: fixture.request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -330,7 +384,7 @@ func TestApplyMissingConfigPreservesDiscoveredRosterAuthority(t *testing.T) {
 	}
 	result, err := Apply(context.Background(), ApplyRequestV1{
 		RequestVersion: RequestVersionV1, Prepare: fixture.request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -380,7 +434,7 @@ func TestApplyRequiresExactRequestLocalDecisions(t *testing.T) {
 			before := applyTreeFingerprint(t, fixture.root, nil)
 			result, err := Apply(context.Background(), ApplyRequestV1{
 				RequestVersion: RequestVersionV1, Prepare: fixture.request,
-				SubjectDigest: prepared.SubjectDigest, Decisions: test.decisions(prepared),
+				SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: test.decisions(prepared),
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -413,7 +467,7 @@ func TestApplyUnsupportedLauncherRefusesBeforeRosterMutation(t *testing.T) {
 	before := applyTreeFingerprint(t, fixture.root, nil)
 	result, err := Apply(context.Background(), ApplyRequestV1{
 		RequestVersion: RequestVersionV1, Prepare: fixture.request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const ContractSemverV1 = "0.61.0"
+const ContractSemverV1 = "0.61.1"
 
 var compatibilityFeaturesV1 = []string{
 	"launch_intent_v1",

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -2,13 +2,14 @@ package launchapi
 
 import (
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
 
 func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	compatibility := Compatibility()
-	if compatibility.ContractSemver != "0.61.0" ||
+	if compatibility.ContractSemver != "0.61.1" ||
 		!reflect.DeepEqual(compatibility.IntentVersions, []int{1}) ||
 		!reflect.DeepEqual(compatibility.ResultVersions, []int{1}) {
 		t.Fatalf("Compatibility() = %#v", compatibility)
@@ -16,6 +17,14 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	compatibility.Features[0] = "mutated"
 	if Compatibility().Features[0] != "launch_intent_v1" {
 		t.Fatal("Compatibility returned shared mutable feature storage")
+	}
+	for _, unfinished := range []string{
+		FeatureBaseRoot, FeatureOnLive, FeatureWrapper, FeaturePlacement,
+		FeatureInitialInput, FeatureCallerContext, FeatureExecutableIdentity,
+	} {
+		if slices.Contains(Compatibility().Features, unfinished) {
+			t.Fatalf("Compatibility advertised unfinished feature %q", unfinished)
+		}
 	}
 
 	negotiated, err := Negotiate(RequirementV1{
@@ -34,8 +43,8 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if _, err := Negotiate(RequirementV1{ContractSemver: ">=0.61.0", IntentVersion: 1, ResultVersion: 1}); err != nil {
 		t.Fatalf(">=0.61.0 must include the current contract: %v", err)
 	}
-	if _, err := Negotiate(RequirementV1{ContractSemver: "<=0.61.0", IntentVersion: 1, ResultVersion: 1}); err != nil {
-		t.Fatalf("<=0.61.0 must include the current contract: %v", err)
+	if _, err := Negotiate(RequirementV1{ContractSemver: "<=0.61.1", IntentVersion: 1, ResultVersion: 1}); err != nil {
+		t.Fatalf("<=0.61.1 must include the current contract: %v", err)
 	}
 }
 
@@ -47,11 +56,11 @@ func TestNegotiateV1FailsClosed(t *testing.T) {
 	}{
 		{name: "older contract", requirement: RequirementV1{ContractSemver: "<0.61.0", IntentVersion: 1, ResultVersion: 1}, want: "does not include"},
 		{name: "malformed range", requirement: RequirementV1{ContractSemver: "^0.61", IntentVersion: 1, ResultVersion: 1}, want: "does not include"},
-		{name: "intent version", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 2, ResultVersion: 1}, want: "intent version"},
-		{name: "result version", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 2}, want: "result version"},
-		{name: "unknown feature", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 1, Features: []string{"shell_hooks_v1"}}, want: "unsupported required feature"},
-		{name: "duplicate feature", requirement: RequirementV1{ContractSemver: "0.61.0", IntentVersion: 1, ResultVersion: 1, Features: []string{"launch_intent_v1", "launch_intent_v1"}}, want: "duplicate required feature"},
-		{name: "strict greater than current contract", requirement: RequirementV1{ContractSemver: ">0.61.0", IntentVersion: 1, ResultVersion: 1}, want: "does not include"},
+		{name: "intent version", requirement: RequirementV1{ContractSemver: "0.61.1", IntentVersion: 2, ResultVersion: 1}, want: "intent version"},
+		{name: "result version", requirement: RequirementV1{ContractSemver: "0.61.1", IntentVersion: 1, ResultVersion: 2}, want: "result version"},
+		{name: "unknown feature", requirement: RequirementV1{ContractSemver: "0.61.1", IntentVersion: 1, ResultVersion: 1, Features: []string{"shell_hooks_v1"}}, want: "unsupported required feature"},
+		{name: "duplicate feature", requirement: RequirementV1{ContractSemver: "0.61.1", IntentVersion: 1, ResultVersion: 1, Features: []string{"launch_intent_v1", "launch_intent_v1"}}, want: "duplicate required feature"},
+		{name: "strict greater than current contract", requirement: RequirementV1{ContractSemver: ">0.61.1", IntentVersion: 1, ResultVersion: 1}, want: "does not include"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/launchapi/encoding_test.go
+++ b/launchapi/encoding_test.go
@@ -57,9 +57,37 @@ func TestResultV1GoldensRequireDigestAndAliasFields(t *testing.T) {
 	}
 }
 
+func TestV061ResultGoldensRemainDecodeCompatible(t *testing.T) {
+	for _, test := range []struct {
+		file   string
+		result any
+	}{
+		{file: "prepare_result_v0610.golden.json", result: &PrepareResultV1{}},
+		{file: "apply_result_v0610.golden.json", result: &ApplyResultV1{}},
+	} {
+		data, err := os.ReadFile(filepath.Join("testdata", test.file))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(data, test.result); err != nil {
+			t.Fatalf("decode v0.61.0 fixture %s: %v", test.file, err)
+		}
+		switch result := test.result.(type) {
+		case *PrepareResultV1:
+			if result.SubjectSchema != 0 || result.Preview.Capabilities != nil {
+				t.Fatalf("v0.61.0 Prepare defaults changed: %#v", result)
+			}
+		case *ApplyResultV1:
+			if result.SubjectSchema != 0 || result.Hints != nil {
+				t.Fatalf("v0.61.0 Apply defaults changed: %#v", result)
+			}
+		}
+	}
+}
+
 func goldenPrepareResultV1() PrepareResultV1 {
 	return PrepareResultV1{
-		ResultVersion: 1, Outcome: PrepareOutcomeActionRequired, Reason: "untrusted_config_digest",
+		ResultVersion: 1, SubjectSchema: SubjectSchemaV2, Outcome: PrepareOutcomeActionRequired, Reason: "untrusted_config_digest",
 		SubjectDigest: goldenDigest('a'), PlanDigest: goldenDigest('b'), TrustDigest: goldenDigest('c'),
 		RequiredActions: []RequiredActionV1{{
 			ActionID: "trust-example", Kind: RequiredActionTrustConfirmation, Handles: []string{"claude"},
@@ -71,6 +99,7 @@ func goldenPrepareResultV1() PrepareResultV1 {
 			Backend: "commands", Profile: "commands/portable/v1",
 			Participants: []ParticipantPreviewV1{{Handle: "operator", Runnable: false, PlannedOutcome: "observe_only"}},
 			Roster:       RosterDriftV1{Desired: []string{"operator"}, Present: []string{}, Missing: []string{"operator"}, Extra: []string{}},
+			Capabilities: []ProviderCapabilitiesV1{},
 		},
 		Observations: []ParticipantObservationV1{{Handle: "operator", Mailbox: "missing", Runnable: false, Conversation: "none", Execution: "none", Resource: ""}},
 	}
@@ -78,7 +107,7 @@ func goldenPrepareResultV1() PrepareResultV1 {
 
 func goldenApplyResultV1() ApplyResultV1 {
 	return ApplyResultV1{
-		ResultVersion: 1, Outcome: "applied", SubjectDigest: goldenDigest('a'), PlanDigest: goldenDigest('b'),
+		ResultVersion: 1, SubjectSchema: SubjectSchemaV2, Outcome: "applied", SubjectDigest: goldenDigest('a'), PlanDigest: goldenDigest('b'),
 		TrustDigest: goldenDigest('c'), SemanticDigest: goldenDigest('c'), Backend: "commands", Profile: "commands/portable/v1",
 		Roster: RosterDriftV1{Desired: []string{"claude"}, Present: []string{"claude"}, Missing: []string{}, Extra: []string{}},
 		Observations: []ParticipantObservationV1{{

--- a/launchapi/external_test.go
+++ b/launchapi/external_test.go
@@ -60,7 +60,7 @@ func TestContract(t *testing.T) {
         ResultVersion: 1,
         Features: []string{"launch_intent_v1"},
     })
-    if err != nil || negotiated.ContractSemver != "0.61.0" {
+    if err != nil || negotiated.ContractSemver != "0.61.1" {
         t.Fatalf("negotiated=%#v err=%v", negotiated, err)
     }
 }

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -59,7 +59,7 @@ func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, int
 			SessionRoot: request.Target.SessionRoot,
 			Session:     request.Target.Session,
 		},
-		Launcher: request.Launcher, IntentDigest: intentDigest,
+		Launcher: request.Launcher, IntentDigest: intentDigest, SubjectSchema: internallaunch.SubjectSchemaV2,
 		Participants: make([]internallaunch.PrepareParticipant, 0, len(request.Intent.Participants)),
 	}
 	for _, participant := range request.Intent.Participants {
@@ -136,7 +136,7 @@ func toInternalExecutionOptions(options ExecutionOptionsV1) internallaunch.Prepa
 
 func fromInternalPrepareResult(result internallaunch.PrepareResult) PrepareResultV1 {
 	public := PrepareResultV1{
-		ResultVersion: ResultVersionV1, Outcome: result.Outcome, Reason: result.Reason,
+		ResultVersion: ResultVersionV1, SubjectSchema: result.SubjectSchema, Outcome: result.Outcome, Reason: result.Reason,
 		SubjectDigest: result.SubjectDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
 		RequiredActions: make([]RequiredActionV1, 0, len(result.RequiredActions)),
 		Preview: PreviewV1{
@@ -147,6 +147,7 @@ func fromInternalPrepareResult(result internallaunch.PrepareResult) PrepareResul
 				Desired: slices.Clone(result.Roster.Desired), Present: slices.Clone(result.Roster.Present),
 				Missing: slices.Clone(result.Roster.Missing), Extra: slices.Clone(result.Roster.Extra),
 			},
+			Capabilities: make([]ProviderCapabilitiesV1, 0),
 		},
 		Observations: make([]ParticipantObservationV1, 0, len(result.Observations)),
 	}

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -46,6 +46,12 @@ func TestPrepareIsZeroWriteAndDeterministic(t *testing.T) {
 	if first.Outcome != PrepareOutcomeActionRequired || first.Reason != "untrusted_config_digest" {
 		t.Fatalf("outcome/reason = %q/%q", first.Outcome, first.Reason)
 	}
+	if first.SubjectSchema != SubjectSchemaV2 {
+		t.Fatalf("new Prepare subject schema = %d", first.SubjectSchema)
+	}
+	if first.Preview.Capabilities == nil || len(first.Preview.Capabilities) != 0 {
+		t.Fatalf("capability skeleton must be a deny-by-default empty array: %#v", first.Preview.Capabilities)
+	}
 	if len(first.RequiredActions) != 1 {
 		t.Fatalf("required actions = %#v", first.RequiredActions)
 	}

--- a/launchapi/requests.go
+++ b/launchapi/requests.go
@@ -70,6 +70,9 @@ func (request ApplyRequestV1) Validate() error {
 	if err := request.Prepare.Validate(); err != nil {
 		return fmt.Errorf("prepare: %w", err)
 	}
+	if request.SubjectSchema != 0 && request.SubjectSchema != SubjectSchemaV1 && request.SubjectSchema != SubjectSchemaV2 {
+		return fmt.Errorf("unsupported subject schema %d", request.SubjectSchema)
+	}
 	if err := ValidateDigest(request.SubjectDigest); err != nil {
 		return fmt.Errorf("subject_digest: %w", err)
 	}

--- a/launchapi/requests_test.go
+++ b/launchapi/requests_test.go
@@ -62,6 +62,11 @@ func TestApplyRequestV1RejectsDigestAndDecisionReplayShapes(t *testing.T) {
 	if err := request.Validate(); err != nil {
 		t.Fatal(err)
 	}
+	request.SubjectSchema = 3
+	if err := request.Validate(); err == nil || !strings.Contains(err.Error(), "subject schema") {
+		t.Fatalf("invalid subject schema error = %v", err)
+	}
+	request.SubjectSchema = SubjectSchemaV2
 
 	request.SubjectDigest = "sha256:ABC"
 	if err := request.Validate(); err == nil || !strings.Contains(err.Error(), "canonical") {

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -26,6 +26,7 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 		"LaunchIntentV1", "ParticipantV1", "WorkingDirectoryV1", "ExecutionOptionsV1",
 		"WakeOptionsV1", "InjectorOptionsV1", "IntegrationsV1", "SymphonyOptionsV1",
 		"TargetV1", "PrepareRequestV1", "PrepareResultV1", "ApplyRequestV1", "ApplyResultV1",
+		"ConfigOverrideCapabilityV1", "ProviderCapabilitiesV1",
 		"DecisionV1", "ParticipantObservationV1", "CompatibilityV1", "RequirementV1", "NegotiatedV1",
 		"InspectRequestV1", "FocusRequestV1", "CloseRequestV1",
 		"InspectResultV1", "FocusResultV1", "CloseResultV1",
@@ -42,6 +43,12 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 	}
 
 	assertSchemaPropertiesMatchType(t, defs, "LaunchIntentV1", reflect.TypeFor[LaunchIntentV1]())
+	assertSchemaPropertiesMatchType(t, defs, "PreviewV1", reflect.TypeFor[PreviewV1]())
+	assertSchemaPropertiesMatchType(t, defs, "ConfigOverrideCapabilityV1", reflect.TypeFor[ConfigOverrideCapabilityV1]())
+	assertSchemaPropertiesMatchType(t, defs, "ProviderCapabilitiesV1", reflect.TypeFor[ProviderCapabilitiesV1]())
+	assertSchemaPropertiesMatchType(t, defs, "PrepareResultV1", reflect.TypeFor[PrepareResultV1]())
+	assertSchemaPropertiesMatchType(t, defs, "ApplyRequestV1", reflect.TypeFor[ApplyRequestV1]())
+	assertSchemaPropertiesMatchType(t, defs, "ApplyResultV1", reflect.TypeFor[ApplyResultV1]())
 	runnableFields := jsonFieldNames(reflect.TypeFor[ParticipantV1]())
 	assertStringSetsEqual(t, schemaPropertyNames(t, defs, "RunnableParticipantV1"), runnableFields, "runnable participant fields")
 	assertStringSetsEqual(
@@ -111,7 +118,7 @@ func TestApplyResultMatchesPublishedSchema(t *testing.T) {
 	}
 	result, err := Apply(context.Background(), ApplyRequestV1{
 		RequestVersion: RequestVersionV1, Prepare: fixture.request,
-		SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/launchapi/testdata/apply_result_v0610.golden.json
+++ b/launchapi/testdata/apply_result_v0610.golden.json
@@ -1,6 +1,5 @@
 {
   "result_version": 1,
-  "subject_schema": 2,
   "outcome": "applied",
   "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "plan_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",

--- a/launchapi/testdata/prepare_result_v0610.golden.json
+++ b/launchapi/testdata/prepare_result_v0610.golden.json
@@ -1,6 +1,5 @@
 {
   "result_version": 1,
-  "subject_schema": 2,
   "outcome": "action_required",
   "reason": "untrusted_config_digest",
   "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -47,8 +46,7 @@
         "operator"
       ],
       "extra": []
-    },
-    "capabilities": []
+    }
   },
   "observations": [
     {

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -9,7 +9,13 @@ const (
 	IntentVersionV1  = 1
 	RequestVersionV1 = 1
 	ResultVersionV1  = 1
+	SubjectSchemaV1  = 1
+	SubjectSchemaV2  = 2
 )
+
+type ResultHintV1 string
+
+const HintReprepareRecommended ResultHintV1 = "reprepare_recommended"
 
 const (
 	PrepareOutcomeReady          = "ready"
@@ -173,11 +179,33 @@ type ParticipantPreviewV1 struct {
 }
 
 type PreviewV1 struct {
-	Target       TargetV1               `json:"target"`
-	Backend      string                 `json:"backend"`
-	Profile      string                 `json:"profile"`
-	Participants []ParticipantPreviewV1 `json:"participants"`
-	Roster       RosterDriftV1          `json:"roster"`
+	Target       TargetV1                 `json:"target"`
+	Backend      string                   `json:"backend"`
+	Profile      string                   `json:"profile"`
+	Participants []ParticipantPreviewV1   `json:"participants"`
+	Roster       RosterDriftV1            `json:"roster"`
+	Capabilities []ProviderCapabilitiesV1 `json:"capabilities"`
+}
+
+type InitialInputKindV1 string
+
+const (
+	InitialInputArgument InitialInputKindV1 = "argument"
+	InitialInputStdin    InitialInputKindV1 = "stdin"
+	InitialInputFile     InitialInputKindV1 = "file"
+)
+
+type ConfigOverrideCapabilityV1 struct {
+	Key           string   `json:"key"`
+	AllowedValues []string `json:"allowed_values"`
+}
+
+type ProviderCapabilitiesV1 struct {
+	Provider             string                       `json:"provider"`
+	ProviderVersion      string                       `json:"provider_version"`
+	AllowedArgumentForms []string                     `json:"allowed_argument_forms"`
+	ConfigOverrides      []ConfigOverrideCapabilityV1 `json:"config_overrides"`
+	InitialInputKinds    []InitialInputKindV1         `json:"initial_input_kinds"`
 }
 
 type ParticipantObservationV1 struct {
@@ -192,6 +220,7 @@ type ParticipantObservationV1 struct {
 
 type PrepareResultV1 struct {
 	ResultVersion   int                        `json:"result_version"`
+	SubjectSchema   int                        `json:"subject_schema"`
 	Outcome         string                     `json:"outcome"`
 	Reason          string                     `json:"reason,omitempty"`
 	SubjectDigest   string                     `json:"subject_digest"`
@@ -210,6 +239,7 @@ type DecisionV1 struct {
 type ApplyRequestV1 struct {
 	RequestVersion int              `json:"request_version"`
 	Prepare        PrepareRequestV1 `json:"prepare"`
+	SubjectSchema  int              `json:"subject_schema,omitempty"`
 	SubjectDigest  string           `json:"subject_digest"`
 	Decisions      []DecisionV1     `json:"decisions"`
 }
@@ -223,9 +253,11 @@ type EvidenceRefV1 struct {
 }
 
 type ApplyResultV1 struct {
-	ResultVersion int    `json:"result_version"`
-	Outcome       string `json:"outcome"`
-	ReasonCode    string `json:"reason_code,omitempty"`
+	ResultVersion int            `json:"result_version"`
+	SubjectSchema int            `json:"subject_schema"`
+	Outcome       string         `json:"outcome"`
+	ReasonCode    string         `json:"reason_code,omitempty"`
+	Hints         []ResultHintV1 `json:"hints,omitempty"`
 	// FailureDetail is non-contract diagnostic prose for CLI stderr. It is
 	// deliberately excluded from the versioned JSON DTO.
 	FailureDetail string `json:"-"`
@@ -288,3 +320,13 @@ type NegotiatedV1 struct {
 	ResultVersion  int      `json:"result_version"`
 	Features       []string `json:"features"`
 }
+
+const (
+	FeatureBaseRoot           = "base_root"
+	FeatureOnLive             = "on_live"
+	FeatureWrapper            = "wrapper"
+	FeaturePlacement          = "placement"
+	FeatureInitialInput       = "initial_input"
+	FeatureCallerContext      = "caller_context"
+	FeatureExecutableIdentity = "executable_identity"
+)

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -227,13 +227,35 @@
     "PreviewV1": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["target", "backend", "profile", "participants", "roster"],
+      "required": ["target", "backend", "profile", "participants", "roster", "capabilities"],
       "properties": {
         "target": {"$ref": "#/$defs/TargetV1"},
         "backend": {"type": "string"},
         "profile": {"type": "string"},
         "participants": {"type": "array", "items": {"$ref": "#/$defs/ParticipantPreviewV1"}},
-        "roster": {"$ref": "#/$defs/RosterDriftV1"}
+        "roster": {"$ref": "#/$defs/RosterDriftV1"},
+        "capabilities": {"type": "array", "items": {"$ref": "#/$defs/ProviderCapabilitiesV1"}}
+      }
+    },
+    "ConfigOverrideCapabilityV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "allowed_values"],
+      "properties": {
+        "key": {"type": "string", "minLength": 1},
+        "allowed_values": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}}
+      }
+    },
+    "ProviderCapabilitiesV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "provider_version", "allowed_argument_forms", "config_overrides", "initial_input_kinds"],
+      "properties": {
+        "provider": {"type": "string", "minLength": 1},
+        "provider_version": {"type": "string", "minLength": 1},
+        "allowed_argument_forms": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "config_overrides": {"type": "array", "items": {"$ref": "#/$defs/ConfigOverrideCapabilityV1"}},
+        "initial_input_kinds": {"type": "array", "uniqueItems": true, "items": {"enum": ["argument", "stdin", "file"]}}
       }
     },
     "ParticipantObservationV1": {
@@ -253,9 +275,10 @@
     "PrepareResultV1": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["result_version", "outcome", "subject_digest", "plan_digest", "trust_digest", "required_actions", "preview", "observations"],
+      "required": ["result_version", "subject_schema", "outcome", "subject_digest", "plan_digest", "trust_digest", "required_actions", "preview", "observations"],
       "properties": {
         "result_version": {"const": 1},
+        "subject_schema": {"enum": [1, 2]},
         "outcome": {"type": "string", "minLength": 1},
         "reason": {"type": "string"},
         "subject_digest": {"$ref": "#/$defs/Digest"},
@@ -282,6 +305,7 @@
       "properties": {
         "request_version": {"const": 1},
         "prepare": {"$ref": "#/$defs/PrepareRequestV1"},
+        "subject_schema": {"enum": [1, 2]},
         "subject_digest": {"$ref": "#/$defs/Digest"},
         "decisions": {"type": "array", "items": {"$ref": "#/$defs/DecisionV1"}}
       }
@@ -301,11 +325,13 @@
     "ApplyResultV1": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["result_version", "outcome", "subject_digest", "plan_digest", "trust_digest", "semantic_digest", "backend", "profile", "roster", "observations"],
+      "required": ["result_version", "subject_schema", "outcome", "subject_digest", "plan_digest", "trust_digest", "semantic_digest", "backend", "profile", "roster", "observations"],
       "properties": {
         "result_version": {"const": 1},
+        "subject_schema": {"enum": [1, 2]},
         "outcome": {"type": "string", "minLength": 1},
         "reason_code": {"type": "string"},
+        "hints": {"type": "array", "uniqueItems": true, "items": {"enum": ["reprepare_recommended"]}},
         "subject_digest": {"$ref": "#/$defs/Digest"},
         "plan_digest": {"$ref": "#/$defs/Digest"},
         "trust_digest": {"$ref": "#/$defs/Digest"},


### PR DESCRIPTION
## Summary

- record subject schema v1/v2 in Prepare and Apply results
- treat omitted legacy Apply schema as v1 and return `reprepare_recommended`
- advertise contract semver 0.61.1 without advertising unfinished Wave B3 feature IDs
- add the deny-by-default `ProviderCapabilitiesV1` skeleton
- preserve v0.61.0 result goldens byte-for-byte as compatibility fixtures

## Verification

- `make ci`
- `go test -race ./launchapi -run 'Test(ActionRequiredSurvivesProcessRestart|ApplyOmittedSubjectSchemaUsesV1AndRecommendsReprepare|PrepareIsZeroWriteAndDeterministic)' -count=1`\n- `TestV061PrepareV0611ApplyCompatibility` builds and executes two real binaries\n- same-state v1/v2 digest test kills a missing-discriminator mutant\n\nCursor execution approval: `2026-08-18T07-50-15.425Z_pid57729_7c92234e` for staged SHA `e4f1a5e3746d588ab614030048a76d362245b8d7cc832137fd6d0e3332b15603`.