### PR TITLE
feat(launchapi): add initial_input and tool-policy grammar

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -26,12 +26,22 @@ the remaining implementation beads are incomplete. A caller must require every
 feature it uses. Contract semver alone does not claim that an unadvertised
 feature is available.
 
-`PreviewV1.capabilities` is present as a deny-by-default skeleton and is empty
-until the `initial_input` feature lands. `ProviderCapabilitiesV1` defines the
-carrier and configuration-override arrays that the owning bead will populate.
-The first Codex configuration-key candidate is
-`model_reasoning_effort`; its accepted values remain TBD and are not advertised
-by this bead.
+`PreviewV1.capabilities` reports the selected providers' static adapter grammar
+without executing a caller-supplied provider. `grammar_version` is the
+adapter-owned version that consumers compare. It changes when the allowed
+argument forms, configuration overrides, or carrier support changes.
+`verified_provider_version` is informational and names the provider release on
+which that grammar was verified; it does not claim the installed version.
+Runtime provider identity is bound separately before Apply executes it.
+
+The initial-input carrier is typed. Claude and Codex currently advertise
+`argument`; AMQ appends its exact text as the final provider argv element.
+`stdin` and `file` remain typed but unadvertised and return
+`initial_input_unsupported`. Content is limited to 262,144 UTF-8 bytes without
+NUL. Content changes the plan and subject digests but not the trust digest.
+Claude admits one `--allowedTools <comma-separated-list>` pair. Codex admits
+ordered `-c model_reasoning_effort=<value>` pairs with values `minimal`, `low`,
+`medium`, `high`, or `xhigh`; duplicate keys and unknown keys or values reject.
 
 ## Intent
 

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -20,16 +20,15 @@ import (
 
 // Adoption-smoke oracle for Omri's seven #480/#557 findings (addendum
 // /private/tmp/amq-480-report/wb3-addendum-draft.md). Each named row asserts
-// TODAY's fail-closed outcome so CI stays green. A later WB3 bead flips
-// exactly one row to the addendum expected outcome; that flip is the
-// visible acceptance.
+// the current outcome so CI stays green. Each WB3 bead flips its rows to the
+// addendum expected outcome; that flip is the visible acceptance.
 //
 //	Row | Finding | Today | WB3 expected
 //	finding1_missing_profile_base_root | 1 named-profile base root | missing .agent-mail/<profile> refuses (not found / stat delivery root) | Prepare planned write create_base_root; Apply creates the authorized base
 //	finding2_mixed_live_fresh_roster_refuses | 2 live-seat dispositions | whole binding refuses rather than keep-live + create-missing | on_live keep -> kept + created missing seats
 //	finding3_wrapper_unknown_field | 3 wrapper | strict decode unknown field "wrapper" | wrapper argv prepended to full provider argv
 //	finding4_squad_tmux_env_rejected | 4 placement | AMQ_SQUAD_TMUX_* env rejected as provider env | placement preview; unsupported tuple -> placement_unsupported
-//	finding5_positional_bootstrap_prompt / finding5_claude_allowed_tools / finding5_codex_dash_c | 5 materialized argv | positional prompt, --allowedTools, and -c rejected by adapter grammar | initial_input + --allowedTools / -c admitted
+//	finding5_positional_bootstrap_prompt / finding5_claude_allowed_tools / finding5_codex_dash_c | 5 materialized argv | raw positional prompt rejected; exact --allowedTools and -c forms admitted | initial_input + --allowedTools / -c admitted
 //	finding6_caller_context_unknown_field | 6 caller correlation | strict decode unknown field "caller_context" | caller_context echoed on Apply/evidence/lifecycle
 //	finding7_same_path_inode_replacement_not_subject_changed | 7 physical identity | same-path inode replacement leaves subject/plan/trust digests identical | inode replacement -> subject_changed
 //
@@ -59,7 +58,7 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		intent := fx.legalSquadIntent()
 		intent.Participants[1].Args = append(intent.Participants[1].Args, "--allowedTools", "Bash,Read,Write,Edit")
 		stdout, stderr, exit := fx.prepare(t, intent, launch.LauncherCommands)
-		assertAdoptionDecodeRejection(t, exit, stdout, stderr, "--allowedTools")
+		assertAdoptionArgumentAdmitted(t, exit, stdout, stderr, "lead", "--allowedTools", "Bash,Read,Write,Edit")
 	})
 
 	t.Run("finding5_codex_dash_c", func(t *testing.T) {
@@ -67,7 +66,7 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		intent := fx.legalSquadIntent()
 		intent.Participants[2].Args = append(intent.Participants[2].Args, "-c", "model_reasoning_effort=high")
 		stdout, stderr, exit := fx.prepare(t, intent, launch.LauncherCommands)
-		assertAdoptionDecodeRejection(t, exit, stdout, stderr, "-c")
+		assertAdoptionArgumentAdmitted(t, exit, stdout, stderr, "senior-dev", "-c", "model_reasoning_effort=high")
 	})
 
 	t.Run("finding4_squad_tmux_env_rejected", func(t *testing.T) {
@@ -630,6 +629,37 @@ func assertAdoptionDecodeRejection(t *testing.T, exit int, stdout, stderr []byte
 	if !strings.Contains(combined, needle) {
 		t.Fatalf("decode rejection did not name %q: stdout=%s stderr=%s", needle, stdout, stderr)
 	}
+}
+
+func assertAdoptionArgumentAdmitted(t *testing.T, exit int, stdout, stderr []byte, handle, flag, value string) {
+	t.Helper()
+	if exit != ExitActionRequired {
+		t.Fatalf("admitted argument exit=%d want %d stdout=%s stderr=%s", exit, ExitActionRequired, stdout, stderr)
+	}
+	var result launchapi.PrepareResultV1
+	decodeRealLaunchJSON(t, stdout, &result)
+	if result.Outcome != "action_required" || result.Reason != "untrusted_config_digest" {
+		t.Fatalf("admitted argument did not reach trust gate: outcome=%q reason=%q", result.Outcome, result.Reason)
+	}
+	for _, participant := range result.Preview.Participants {
+		if participant.Handle != handle {
+			continue
+		}
+		if participant.Command == nil {
+			t.Fatalf("admitted argument participant %q has no command", handle)
+		}
+		matches := 0
+		for i := 0; i+1 < len(participant.Command.Argv); i++ {
+			if participant.Command.Argv[i] == flag && participant.Command.Argv[i+1] == value {
+				matches++
+			}
+		}
+		if matches != 1 {
+			t.Fatalf("admitted argument pair %q %q occurs %d times in %q", flag, value, matches, participant.Command.Argv)
+		}
+		return
+	}
+	t.Fatalf("admitted argument participant %q missing from preview", handle)
 }
 
 func assertAdoptionUnknownField(t *testing.T, exit int, stdout, stderr []byte, field string) {

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 )
 
@@ -42,6 +43,41 @@ type AdapterCapabilities struct {
 	Reason          string      `json:"reason,omitempty"`
 }
 
+type ConfigOverrideCapability struct {
+	Key           string
+	AllowedValues []string
+}
+
+type StaticInputCapabilities struct {
+	GrammarVersion          int
+	VerifiedProviderVersion string
+	AllowedArgumentForms    []string
+	ConfigOverrides         []ConfigOverrideCapability
+	InitialInputKinds       []InitialInputKind
+}
+
+// ProviderStaticInputCapabilities is the single public-compiler projection of
+// the same deny-by-default tables used by validation.
+func ProviderStaticInputCapabilities(provider string) StaticInputCapabilities {
+	switch provider {
+	case ClaudeProvider:
+		return StaticInputCapabilities{
+			GrammarVersion: 1, VerifiedProviderVersion: "2.1.233",
+			AllowedArgumentForms: []string{"--allowedTools"}, InitialInputKinds: []InitialInputKind{InitialInputArgument},
+		}
+	case CodexProvider:
+		values := slices.Clone(codexReasoningEffortValues)
+		return StaticInputCapabilities{
+			GrammarVersion: 1, VerifiedProviderVersion: codexCaptureVersion,
+			AllowedArgumentForms: []string{"-c"},
+			ConfigOverrides:      []ConfigOverrideCapability{{Key: "model_reasoning_effort", AllowedValues: values}},
+			InitialInputKinds:    []InitialInputKind{InitialInputArgument},
+		}
+	default:
+		return StaticInputCapabilities{AllowedArgumentForms: []string{}, ConfigOverrides: []ConfigOverrideCapability{}, InitialInputKinds: []InitialInputKind{}}
+	}
+}
+
 type PlanRequest struct {
 	Handle        string
 	ProjectRoot   string
@@ -58,6 +94,28 @@ type PlanRequest struct {
 	CommittedArgs    []string
 	BypassArgs       []string
 	EnvOverlay       map[string]string
+	InitialInput     *InitialInputRequest
+}
+
+type InitialInputRequest struct {
+	Kind   InitialInputKind
+	Value  string
+	SHA256 string
+}
+
+func appendInitialInput(plan *AgentPlan, input *InitialInputRequest) error {
+	if input == nil {
+		return nil
+	}
+	if input.Kind != InitialInputArgument {
+		return fmt.Errorf("initial input kind %q is unsupported", input.Kind)
+	}
+	if !validDigest(input.SHA256) || strings.ContainsRune(input.Value, 0) {
+		return fmt.Errorf("initial input is invalid")
+	}
+	plan.Argv = append(plan.Argv, input.Value)
+	plan.InitialInput = &PlannedInitialInput{Kind: input.Kind, SHA256: input.SHA256, ArgvIndex: len(plan.Argv) - 1}
+	return nil
 }
 
 type ResumeRequest struct {
@@ -124,6 +182,16 @@ func ValidateStaticProviderInput(executable string, args []string, env map[strin
 	if err := validateStaticProviderArgs(args, argRules, bypassAllowed); err != nil {
 		return "", err
 	}
+	switch provider {
+	case ClaudeProvider:
+		if err := validateSingleStaticArgument(args, "--allowedTools"); err != nil {
+			return "", err
+		}
+	case CodexProvider:
+		if err := validateCodexConfigOverrides(args); err != nil {
+			return "", err
+		}
+	}
 	if provider == CursorProvider {
 		if err := validateCursorBypassArgs(args, true); err != nil {
 			return "", err
@@ -133,6 +201,19 @@ func ValidateStaticProviderInput(executable string, args []string, env map[strin
 		return "", err
 	}
 	return provider, nil
+}
+
+func validateSingleStaticArgument(args []string, name string) error {
+	count := 0
+	for _, arg := range args {
+		if arg == name {
+			count++
+		}
+	}
+	if count > 1 {
+		return fmt.Errorf("static argument %q is duplicated", name)
+	}
+	return nil
 }
 
 // PartitionStaticProviderArgs separates ordinary committed arguments from the
@@ -251,6 +332,11 @@ func validatePlanRequest(request PlanRequest, executable, provider string, envRu
 	resolvedExecutable, err := validateKnownExecutable(executable, request.ProjectRoot, provider)
 	if err != nil {
 		return "", err
+	}
+	if provider == CodexProvider {
+		if err := validateCodexConfigOverrides(request.CommittedArgs); err != nil {
+			return "", err
+		}
 	}
 	if err := validateCommittedArgs(request.CommittedArgs, argRules); err != nil {
 		return "", err

--- a/internal/launch/adapter_claude.go
+++ b/internal/launch/adapter_claude.go
@@ -70,6 +70,9 @@ func (adapter *ClaudeAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) 
 		LaunchNonce: request.LaunchNonce, ConversationID: request.LaunchNonce,
 		DynamicArgv: []DynamicArg{{Index: len(argv) - 1, Kind: DynamicArgLaunchNonce}},
 	}
+	if err := appendInitialInput(&plan, request.InitialInput); err != nil {
+		return AgentPlan{}, err
+	}
 	if err := ValidateAdapterPlan(adapter, plan); err != nil {
 		return AgentPlan{}, err
 	}
@@ -110,6 +113,7 @@ func claudeEnvRules() map[string]valueRule { return commonCommittedEnvRules() }
 
 func claudeArgRules() map[string]argumentRule {
 	return map[string]argumentRule{
+		"--allowedTools":    {value: true, validate: validClaudeAllowedTools},
 		"--effort":          {value: true, validate: oneOf("low", "medium", "high", "xhigh", "max")},
 		"--model":           {value: true, validate: safeArgumentValue},
 		"--no-chrome":       {},
@@ -117,6 +121,22 @@ func claudeArgRules() map[string]argumentRule {
 		"--safe-mode":       {},
 		"--verbose":         {},
 	}
+}
+
+func validClaudeAllowedTools(value string) bool {
+	if value == "" || len(value) > 128 || strings.ContainsRune(value, 0) {
+		return false
+	}
+	parts := strings.Split(value, ",")
+	if len(parts) == 0 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || strings.TrimSpace(part) != part || !safeEnvironmentValue(part) {
+			return false
+		}
+	}
+	return true
 }
 
 func claudeBypassArgs() map[string]struct{} {

--- a/internal/launch/adapter_codex.go
+++ b/internal/launch/adapter_codex.go
@@ -86,6 +86,9 @@ func (adapter *CodexAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) {
 		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
 		AdapterMode: AdapterModeCapture, ResumePolicy: request.ResumePolicy, LaunchNonce: request.LaunchNonce,
 	}
+	if err := appendInitialInput(&plan, request.InitialInput); err != nil {
+		return AgentPlan{}, err
+	}
 	if err := ValidateAdapterPlan(adapter, plan); err != nil {
 		return AgentPlan{}, err
 	}
@@ -158,12 +161,62 @@ func codexEnvRules() map[string]valueRule { return commonCommittedEnvRules() }
 
 func codexArgRules() map[string]argumentRule {
 	return map[string]argumentRule{
+		"-c":                 {value: true, validate: validCodexConfigOverride},
 		"--ask-for-approval": {value: true, validate: oneOf("untrusted", "on-request")},
 		"--model":            {value: true, validate: safeArgumentValue},
 		"--no-alt-screen":    {},
 		"--sandbox":          {value: true, validate: oneOf("read-only", "workspace-write")},
 		"--search":           {},
 	}
+}
+
+var codexReasoningEffortValues = []string{"minimal", "low", "medium", "high", "xhigh"}
+
+var codexConfigOverrideValues = map[string]map[string]struct{}{
+	"model_reasoning_effort": valueSet(codexReasoningEffortValues),
+}
+
+func valueSet(values []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func validCodexConfigOverride(value string) bool {
+	key, configured, ok := strings.Cut(value, "=")
+	if !ok || key == "" || configured == "" {
+		return false
+	}
+	values, ok := codexConfigOverrideValues[key]
+	if !ok {
+		return false
+	}
+	_, ok = values[configured]
+	return ok
+}
+
+func validateCodexConfigOverrides(args []string) error {
+	seen := make(map[string]struct{})
+	for i := 0; i < len(args); i++ {
+		if args[i] != "-c" {
+			continue
+		}
+		if i+1 >= len(args) {
+			return fmt.Errorf("static argument %q requires a value", "-c")
+		}
+		key, _, ok := strings.Cut(args[i+1], "=")
+		if !ok || !validCodexConfigOverride(args[i+1]) {
+			return fmt.Errorf("codex configuration override %q is not allowed", args[i+1])
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return fmt.Errorf("codex configuration key %q is duplicated", key)
+		}
+		seen[key] = struct{}{}
+		i++
+	}
+	return nil
 }
 
 func codexBypassArgs() map[string]struct{} {

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -2,10 +2,13 @@ package launch
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -155,6 +158,66 @@ func TestClaudePlansUseExactMintAndResumeShapes(t *testing.T) {
 	}
 	if result := adapter.CaptureIdentity(CaptureRequest{}); result.State != CaptureUnsupported || result.Degraded || result.CanPersist() {
 		t.Fatalf("mint capture result = %#v", result)
+	}
+}
+
+func TestAdaptersAppendTypedInitialInputAfterOwnedArguments(t *testing.T) {
+	for _, provider := range []string{ClaudeProvider, CodexProvider} {
+		t.Run(provider, func(t *testing.T) {
+			project, executable := testExecutable(t, provider)
+			request := planRequest(project, provider)
+			text := "generated bootstrap"
+			sum := sha256.Sum256([]byte(text))
+			request.InitialInput = &InitialInputRequest{Kind: InitialInputArgument, Value: text, SHA256: "sha256:" + hex.EncodeToString(sum[:])}
+			var plan AgentPlan
+			var err error
+			switch provider {
+			case ClaudeProvider:
+				plan, err = NewClaudeAdapter(executable).PlanFresh(request)
+			case CodexProvider:
+				plan, err = NewCodexAdapter(executable).PlanFresh(request)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.Argv[len(plan.Argv)-1] != text || plan.InitialInput == nil || plan.InitialInput.ArgvIndex != len(plan.Argv)-1 {
+				t.Fatalf("initial input plan = %#v", plan)
+			}
+		})
+	}
+}
+
+func TestAdaptersDoNotRedeliverInitialInputOnResume(t *testing.T) {
+	for _, provider := range []string{ClaudeProvider, CodexProvider} {
+		t.Run(provider, func(t *testing.T) {
+			project, executable := testExecutable(t, provider)
+			request := planRequest(project, provider)
+			text := "generated bootstrap"
+			sum := sha256.Sum256([]byte(text))
+			request.InitialInput = &InitialInputRequest{Kind: InitialInputArgument, Value: text, SHA256: "sha256:" + hex.EncodeToString(sum[:])}
+			conversation := ConversationIdentity{Provider: provider, ID: testConversationID}
+			var plan AgentPlan
+			var err error
+			switch provider {
+			case ClaudeProvider:
+				plan, err = NewClaudeAdapter(executable).PlanResume(ResumeRequest{PlanRequest: request, Conversation: conversation})
+			case CodexProvider:
+				plan, err = NewCodexAdapter(executable).PlanResume(ResumeRequest{PlanRequest: request, Conversation: conversation})
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.InitialInput != nil || slices.Contains(plan.Argv, text) {
+				t.Fatalf("resume redelivered initial input: %#v", plan)
+			}
+			if provider == ClaudeProvider {
+				if !slices.Equal(plan.Argv[len(plan.Argv)-2:], []string{"--resume", testConversationID}) {
+					t.Fatalf("Claude resume tail = %q", plan.Argv)
+				}
+			} else if plan.Argv[len(plan.Argv)-1] != testConversationID {
+				t.Fatalf("Codex resume identity is not final: %q", plan.Argv)
+			}
+		})
 	}
 }
 

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -447,9 +447,14 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		key := participant.Executable
 		command := append([]string{participant.Executable}, participant.Args...)
 		command = append(command, participant.BypassArgs...)
+		var initial *InitialInputRequest
+		if participant.InitialInput != nil {
+			digest := initialInputDigest(participant.InitialInput.Text)
+			initial = &InitialInputRequest{Kind: participant.InitialInput.Kind, Value: participant.InitialInput.Text, SHA256: digest}
+		}
 		config.Agents = append(config.Agents, ProjectAgentConfig{
 			Handle: participant.Handle, Adapter: key, Command: command, Env: cloneEnv(participant.EnvOverlay),
-			Cwd: participant.Cwd, ResumePolicy: participant.ResumePolicy,
+			Cwd: participant.Cwd, ResumePolicy: participant.ResumePolicy, InitialInput: initial,
 		})
 		adapters[key] = adapter
 		executionOptions[participant.Handle] = *clonePrepareExecutionOptions(&participant.Execution)
@@ -475,8 +480,12 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 			if planDigest != snapshot.PlanDigest {
 				return false, fmt.Errorf("static plan changed after Apply authorization")
 			}
+			trustPlanDigest, err := plan.TrustSemanticDigest()
+			if err != nil {
+				return false, err
+			}
 			authorizedTrustDigest, err := PrepareTrustDigest(
-				planDigest, prepared.Target.Session, prepared.Target.SessionRoot, authorizedRootIdentity,
+				trustPlanDigest, prepared.Target.Session, prepared.Target.SessionRoot, authorizedRootIdentity,
 			)
 			if err != nil {
 				return false, err

--- a/internal/launch/config.go
+++ b/internal/launch/config.go
@@ -33,12 +33,13 @@ type ProjectConfig struct {
 }
 
 type ProjectAgentConfig struct {
-	Handle       string            `json:"handle"`
-	Adapter      string            `json:"adapter"`
-	Command      []string          `json:"command"`
-	Env          map[string]string `json:"env,omitempty"`
-	Cwd          string            `json:"cwd,omitempty"`
-	ResumePolicy ResumePolicy      `json:"resume_policy"`
+	Handle       string               `json:"handle"`
+	Adapter      string               `json:"adapter"`
+	Command      []string             `json:"command"`
+	Env          map[string]string    `json:"env,omitempty"`
+	Cwd          string               `json:"cwd,omitempty"`
+	ResumePolicy ResumePolicy         `json:"resume_policy"`
+	InitialInput *InitialInputRequest `json:"initial_input,omitempty"`
 }
 
 type LayoutIntent struct {
@@ -148,6 +149,14 @@ func (cfg ProjectConfig) Validate() error {
 		for _, arg := range agent.Command {
 			if arg == "" || strings.ContainsRune(arg, 0) {
 				return fmt.Errorf("agent %q command contains an invalid argument", agent.Handle)
+			}
+		}
+		if agent.InitialInput != nil {
+			if agent.InitialInput.Kind != InitialInputArgument && agent.InitialInput.Kind != InitialInputFile {
+				return fmt.Errorf("agent %q initial input kind is unsupported", agent.Handle)
+			}
+			if !validDigest(agent.InitialInput.SHA256) || strings.ContainsRune(agent.InitialInput.Value, 0) {
+				return fmt.Errorf("agent %q initial input is invalid", agent.Handle)
 			}
 		}
 		if agent.ResumePolicy != ResumeEnabled && agent.ResumePolicy != ResumeFresh && agent.ResumePolicy != ResumeDisabled {

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -67,13 +67,14 @@ type ExecutionTicket struct {
 	InjectorExecutable         string `json:"injector_executable,omitempty"`
 	InjectorExecutableIdentity string `json:"injector_executable_identity,omitempty"`
 
-	TargetArgv  []string                 `json:"target_argv"`
-	DynamicArgv []DynamicArg             `json:"dynamic_argv,omitempty"`
-	TargetEnv   map[string]string        `json:"target_env,omitempty"`
-	EnvDigest   string                   `json:"env_digest"`
-	State       ExecutionState           `json:"state"`
-	Reason      string                   `json:"reason,omitempty"`
-	Execution   *PrepareExecutionOptions `json:"execution,omitempty"`
+	TargetArgv   []string                 `json:"target_argv"`
+	DynamicArgv  []DynamicArg             `json:"dynamic_argv,omitempty"`
+	InitialInput *PlannedInitialInput     `json:"initial_input,omitempty"`
+	TargetEnv    map[string]string        `json:"target_env,omitempty"`
+	EnvDigest    string                   `json:"env_digest"`
+	State        ExecutionState           `json:"state"`
+	Reason       string                   `json:"reason,omitempty"`
+	Execution    *PrepareExecutionOptions `json:"execution,omitempty"`
 }
 
 type ExecutionTicketRequest struct {
@@ -88,6 +89,7 @@ type ExecutionTicketRequest struct {
 	ProviderExecutable, AMQExecutable string
 	TargetArgv                        []string
 	DynamicArgv                       []DynamicArg
+	InitialInput                      *PlannedInitialInput
 	TargetEnv                         map[string]string
 	State                             ExecutionState
 	Reason                            string
@@ -164,8 +166,9 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 		ProjectRoot: project, ProjectIdentity: projectID, SessionRoot: session, SessionIdentity: sessionID,
 		Cwd: cwd, CwdIdentity: cwdID, ProviderExecutable: provider, ProviderExecutableIdentity: providerID,
 		AMQExecutable: amq, AMQExecutableIdentity: amqID, TargetArgv: append([]string(nil), request.TargetArgv...),
-		DynamicArgv: append([]DynamicArg(nil), request.DynamicArgv...),
-		TargetEnv:   env, EnvDigest: digest, State: request.State, Reason: request.Reason,
+		DynamicArgv:  append([]DynamicArg(nil), request.DynamicArgv...),
+		InitialInput: clonePlannedInitialInput(request.InitialInput),
+		TargetEnv:    env, EnvDigest: digest, State: request.State, Reason: request.Reason,
 		Execution: execution, InjectorExecutable: injector, InjectorExecutableIdentity: injectorID,
 	}
 	if ticket.State == "" {
@@ -224,9 +227,12 @@ func (ticket ExecutionTicket) Validate() error {
 		return fmt.Errorf("target argv is required")
 	}
 	for i, arg := range ticket.TargetArgv {
-		if arg == "" || strings.ContainsRune(arg, 0) {
+		if strings.ContainsRune(arg, 0) || (arg == "" && !ticketInitialInputOwnsArg(ticket, i)) {
 			return fmt.Errorf("target argv[%d] is invalid", i)
 		}
+	}
+	if err := validateTicketInitialInput(ticket); err != nil {
+		return err
 	}
 	if ticket.Mode == AdapterModeCapture && ticket.Provider == CodexProvider && ticket.ProviderVersion == codexCaptureVersion {
 		if err := validateCodexNotifyTargetArgv(ticket); err != nil {
@@ -298,6 +304,45 @@ func (ticket ExecutionTicket) Validate() error {
 	return nil
 }
 
+func clonePlannedInitialInput(input *PlannedInitialInput) *PlannedInitialInput {
+	if input == nil {
+		return nil
+	}
+	cloned := *input
+	return &cloned
+}
+
+func ticketInitialInputOwnsArg(ticket ExecutionTicket, index int) bool {
+	return ticket.InitialInput != nil && ticket.InitialInput.Kind == InitialInputArgument &&
+		ticket.InitialInput.ArgvIndex == index
+}
+
+func validateTicketInitialInput(ticket ExecutionTicket) error {
+	input := ticket.InitialInput
+	if input == nil {
+		return nil
+	}
+	if input.Kind != InitialInputArgument {
+		return fmt.Errorf("execution ticket initial input kind %q is unsupported", input.Kind)
+	}
+	if input.ArgvIndex != len(ticket.TargetArgv)-1 || input.ArgvIndex <= 0 {
+		return fmt.Errorf("execution ticket initial input must be the final provider argument")
+	}
+	if !validDigest(input.SHA256) {
+		return fmt.Errorf("execution ticket initial input digest is invalid")
+	}
+	sum := sha256.Sum256([]byte(ticket.TargetArgv[input.ArgvIndex]))
+	if "sha256:"+hex.EncodeToString(sum[:]) != input.SHA256 {
+		return fmt.Errorf("execution ticket initial input digest does not match argument")
+	}
+	for _, dynamic := range ticket.DynamicArgv {
+		if dynamic.Index == input.ArgvIndex {
+			return fmt.Errorf("execution ticket initial input cannot use a dynamic argv slot")
+		}
+	}
+	return nil
+}
+
 func validateCodexNotifyTargetArgv(ticket ExecutionTicket) error {
 	expected, err := codexNotifyOverride(PlanRequest{
 		AMQExecutable: ticket.AMQExecutable,
@@ -317,10 +362,15 @@ func validateCodexNotifyTargetArgv(ticket ExecutionTicket) error {
 		if arg != "-c" {
 			continue
 		}
-		if i+1 >= len(ticket.TargetArgv) || ticket.TargetArgv[i+1] != expected {
+		if i+1 >= len(ticket.TargetArgv) {
 			return fmt.Errorf("codex notify override does not match the execution ticket")
 		}
-		count++
+		value := ticket.TargetArgv[i+1]
+		if value == expected {
+			count++
+		} else if !validCodexConfigOverride(value) {
+			return fmt.Errorf("codex notify execution ticket contains unsupported configuration override")
+		}
 		i++
 	}
 	if count != 1 {

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -27,14 +27,16 @@ func TestExecutionTicketRoundTripAndCAS(t *testing.T) {
 		InjectorMode: "raw", InjectorVia: fixture.injector, InjectorArgs: []string{"send"},
 		SymphonyEvents: []string{"after_create", "before_run", "after_run", "before_remove"}, SymphonyWorkspaceKey: "team-17",
 	}
+	initialInput := &PlannedInitialInput{Kind: InitialInputArgument, SHA256: initialInputDigest("bootstrap"), ArgvIndex: 3}
 	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
 		Handle: "claude", LaunchNonce: lease.LaunchNonce(), Mode: AdapterModeMint,
 		Provider: ClaudeProvider, ConversationID: lease.LaunchNonce(),
 		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
 		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
-		TargetArgv: []string{fixture.provider, "--session-id", lease.LaunchNonce()},
-		TargetEnv:  map[string]string{"LANG": "C", "NO_COLOR": "1"},
-		Execution:  execution,
+		TargetArgv:   []string{fixture.provider, "--session-id", lease.LaunchNonce(), "bootstrap"},
+		InitialInput: initialInput,
+		TargetEnv:    map[string]string{"LANG": "C", "NO_COLOR": "1"},
+		Execution:    execution,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +48,8 @@ func TestExecutionTicketRoundTripAndCAS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if loaded.State != ExecutionPending || loaded.TargetEnv["LANG"] != "C" || loaded.EnvDigest == "" || !reflect.DeepEqual(loaded.Execution, execution) {
+	if loaded.State != ExecutionPending || loaded.TargetEnv["LANG"] != "C" || loaded.EnvDigest == "" ||
+		!reflect.DeepEqual(loaded.Execution, execution) || !reflect.DeepEqual(loaded.InitialInput, initialInput) {
 		t.Fatalf("loaded ticket = %#v", loaded)
 	}
 	loaded, err = CompareAndSwapExecutionTicket(fixture.root, lease, "claude", ExecutionPending, ExecutionSpawnAttempted, "spawned")
@@ -59,6 +62,28 @@ func TestExecutionTicketRoundTripAndCAS(t *testing.T) {
 	}
 	if _, err := CompareAndSwapExecutionTicket(fixture.root, lease, "claude", ExecutionPending, ExecutionSpawnAttempted, "late"); err == nil || !strings.Contains(err.Error(), "state") {
 		t.Fatalf("stale CAS error = %v", err)
+	}
+}
+
+func TestExecutionTicketAllowsEmptyArgOnlyForDeclaredInitialInput(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	base := ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: "12121212-1212-4212-8212-121212121212", Mode: AdapterModeMint,
+		Provider: ClaudeProvider, ConversationID: "12121212-1212-4212-8212-121212121212",
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: []string{fixture.provider, ""},
+	}
+	if _, err := NewExecutionTicket(base); err == nil || !strings.Contains(err.Error(), "target argv[1]") {
+		t.Fatalf("undeclared empty argv error = %v", err)
+	}
+	base.InitialInput = &PlannedInitialInput{Kind: InitialInputArgument, SHA256: initialInputDigest(""), ArgvIndex: 1}
+	if _, err := NewExecutionTicket(base); err != nil {
+		t.Fatalf("declared empty initial argument rejected: %v", err)
+	}
+	base.InitialInput.ArgvIndex = 0
+	if _, err := NewExecutionTicket(base); err == nil || !strings.Contains(err.Error(), "target argv[1]") {
+		t.Fatalf("misdeclared empty argv error = %v", err)
 	}
 }
 

--- a/internal/launch/plan.go
+++ b/internal/launch/plan.go
@@ -42,6 +42,20 @@ const (
 	DynamicArgConversationID DynamicArgKind = "conversation_id"
 )
 
+type InitialInputKind string
+
+const (
+	InitialInputArgument InitialInputKind = "argument"
+	InitialInputStdin    InitialInputKind = "stdin"
+	InitialInputFile     InitialInputKind = "file"
+)
+
+type PlannedInitialInput struct {
+	Kind      InitialInputKind `json:"kind"`
+	SHA256    string           `json:"sha256"`
+	ArgvIndex int              `json:"argv_index"`
+}
+
 // Plan is the public, backend-independent execution contract. Nonce and
 // ConversationID are per-launch values and are deliberately not trusted.
 type Plan struct {
@@ -62,7 +76,8 @@ type AgentPlan struct {
 	PreSpawnAcquire bool              `json:"pre_spawn_acquire,omitempty"`
 	// Execution is the normalized coop-exec wrapper policy. Keeping it in the
 	// plan makes journal recovery lossless before the wrapper consumes it.
-	Execution *PrepareExecutionOptions `json:"execution,omitempty"`
+	Execution    *PrepareExecutionOptions `json:"execution,omitempty"`
+	InitialInput *PlannedInitialInput     `json:"initial_input,omitempty"`
 }
 
 // DynamicArg marks one runtime-generated argv value. Unmarked argv values are
@@ -155,6 +170,24 @@ func (a AgentPlan) validate() error {
 	if a.PreSpawnAcquire && conversationSlots != 1 {
 		return fmt.Errorf("pre-spawn acquisition requires exactly one dynamic conversation slot")
 	}
+	if a.InitialInput != nil {
+		if a.InitialInput.Kind != InitialInputArgument {
+			return fmt.Errorf("invalid initial input kind %q", a.InitialInput.Kind)
+		}
+		if !validDigest(a.InitialInput.SHA256) {
+			return fmt.Errorf("initial input digest is invalid")
+		}
+		if a.InitialInput.ArgvIndex <= 0 || a.InitialInput.ArgvIndex >= len(a.Argv) {
+			return fmt.Errorf("initial input argv index is invalid")
+		}
+		if _, dynamic := seenDynamic[a.InitialInput.ArgvIndex]; dynamic {
+			return fmt.Errorf("initial input argv index is dynamic")
+		}
+		sum := sha256.Sum256([]byte(a.Argv[a.InitialInput.ArgvIndex]))
+		if "sha256:"+hex.EncodeToString(sum[:]) != a.InitialInput.SHA256 {
+			return fmt.Errorf("initial input digest does not match argument")
+		}
+	}
 	return nil
 }
 
@@ -169,30 +202,47 @@ type canonicalArgument struct {
 }
 
 type staticAgentPlan struct {
-	Handle          string              `json:"handle"`
-	Argv            []canonicalArgument `json:"argv"`
-	EnvOverlay      map[string]string   `json:"env_overlay,omitempty"`
-	Cwd             string              `json:"cwd"`
-	AdapterMode     AdapterMode         `json:"adapter_mode"`
-	ResumePolicy    ResumePolicy        `json:"resume_policy"`
-	PreSpawnAcquire bool                `json:"pre_spawn_acquire,omitempty"`
+	Handle          string                 `json:"handle"`
+	Argv            []canonicalArgument    `json:"argv"`
+	EnvOverlay      map[string]string      `json:"env_overlay,omitempty"`
+	Cwd             string                 `json:"cwd"`
+	AdapterMode     AdapterMode            `json:"adapter_mode"`
+	ResumePolicy    ResumePolicy           `json:"resume_policy"`
+	PreSpawnAcquire bool                   `json:"pre_spawn_acquire,omitempty"`
+	InitialInput    *canonicalInitialInput `json:"initial_input,omitempty"`
+}
+
+type canonicalInitialInput struct {
+	Kind      InitialInputKind `json:"kind"`
+	SHA256    string           `json:"sha256,omitempty"`
+	ArgvIndex int              `json:"argv_index"`
 }
 
 // SemanticDigest hashes the adapter-normalized static execution template.
 // Fresh and resume argv shapes have different digests because only the resume
 // shape carries a conversation slot; each shape therefore requires trust once.
 func (p Plan) SemanticDigest() (string, error) {
-	return p.semanticDigest(false)
+	return p.semanticDigest(false, false)
+}
+
+// TrustSemanticDigest excludes caller-generated initial-input content while
+// retaining the selected carrier kind and argv position.
+func (p Plan) TrustSemanticDigest() (string, error) {
+	return p.semanticDigest(false, true)
 }
 
 // PreparePlanDigest hashes the nonce-free static plan used by Prepare. Unlike
 // a backend execution Plan, it permits zero runnable agents so a participant-
 // only session still has one deterministic plan subject.
 func PreparePlanDigest(p Plan) (string, error) {
-	return p.semanticDigest(true)
+	return p.semanticDigest(true, false)
 }
 
-func (p Plan) semanticDigest(allowEmpty bool) (string, error) {
+func PrepareTrustPlanDigest(p Plan) (string, error) {
+	return p.semanticDigest(true, true)
+}
+
+func (p Plan) semanticDigest(allowEmpty, trustProjection bool) (string, error) {
 	if err := p.validateForDigest(allowEmpty); err != nil {
 		return "", err
 	}
@@ -205,10 +255,18 @@ func (p Plan) semanticDigest(allowEmpty bool) (string, error) {
 		for _, dynamic := range agent.DynamicArgv {
 			argv[dynamic.Index] = canonicalArgument{Dynamic: dynamic.Kind}
 		}
+		var initial *canonicalInitialInput
+		if agent.InitialInput != nil {
+			initial = &canonicalInitialInput{Kind: agent.InitialInput.Kind, SHA256: agent.InitialInput.SHA256, ArgvIndex: agent.InitialInput.ArgvIndex}
+			if trustProjection {
+				argv[agent.InitialInput.ArgvIndex] = canonicalArgument{Value: "${initial_input:" + string(agent.InitialInput.Kind) + "}"}
+				initial.SHA256 = ""
+			}
+		}
 		agents[i] = staticAgentPlan{
 			Handle: agent.Handle, Argv: argv, EnvOverlay: agent.EnvOverlay,
 			Cwd: agent.Cwd, AdapterMode: agent.AdapterMode, ResumePolicy: agent.ResumePolicy,
-			PreSpawnAcquire: agent.PreSpawnAcquire,
+			PreSpawnAcquire: agent.PreSpawnAcquire, InitialInput: initial,
 		}
 	}
 	slices.SortFunc(agents, func(a, b staticAgentPlan) int { return strings.Compare(a.Handle, b.Handle) })

--- a/internal/launch/plan_test.go
+++ b/internal/launch/plan_test.go
@@ -1,6 +1,8 @@
 package launch
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"testing"
 )
@@ -21,6 +23,45 @@ func validPlan() Plan {
 			DynamicArgv: []DynamicArg{{Index: 2, Kind: DynamicArgLaunchNonce}},
 		},
 	}}
+}
+
+func TestInitialInputChangesPlanButNotTrustProjection(t *testing.T) {
+	makePlan := func(text string) Plan {
+		plan := validPlan()
+		sum := sha256.Sum256([]byte(text))
+		plan.Agents[0].Argv = append(plan.Agents[0].Argv, text)
+		plan.Agents[0].InitialInput = &PlannedInitialInput{
+			Kind: InitialInputArgument, SHA256: "sha256:" + hex.EncodeToString(sum[:]), ArgvIndex: len(plan.Agents[0].Argv) - 1,
+		}
+		return plan
+	}
+	first, second := makePlan("bootstrap one"), makePlan("bootstrap two")
+	firstPlan, err := first.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPlan, err := second.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstPlan == secondPlan {
+		t.Fatal("initial input content did not change plan digest")
+	}
+	firstTrust, err := first.TrustSemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondTrust, err := second.TrustSemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstTrust != secondTrust {
+		t.Fatalf("initial input content changed trust digest: %s != %s", firstTrust, secondTrust)
+	}
+	second.Agents[0].InitialInput.Kind = InitialInputFile
+	if _, err := second.TrustSemanticDigest(); err == nil || !strings.Contains(err.Error(), "invalid initial input kind") {
+		t.Fatalf("unsupported carrier kind was accepted: %v", err)
+	}
 }
 
 func TestSemanticDigestCanonicalAndExcludesRuntimeValues(t *testing.T) {

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -37,6 +37,7 @@ func DefaultLaunchStateDir() (string, error) {
 }
 
 const preparePlaceholderUUID = "00000000-0000-4000-8000-000000000000"
+const MaxInitialInputBytes = 256 * 1024
 
 const (
 	PrepareOutcomeReady          = "ready"
@@ -84,6 +85,12 @@ type PrepareParticipant struct {
 	EnvOverlay   map[string]string
 	ResumePolicy ResumePolicy
 	Execution    PrepareExecutionOptions
+	InitialInput *PrepareInitialInput
+}
+
+type PrepareInitialInput struct {
+	Kind InitialInputKind
+	Text string
 }
 
 type PrepareRequest struct {
@@ -369,7 +376,11 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if err != nil {
 		return PrepareResult{}, err
 	}
-	result.TrustDigest, err = PrepareTrustDigest(result.PlanDigest, state.target.Session, state.target.SessionRoot, state.sessionIdentity)
+	trustPlanDigest, err := PrepareTrustPlanDigest(plan)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	result.TrustDigest, err = PrepareTrustDigest(trustPlanDigest, state.target.Session, state.target.SessionRoot, state.sessionIdentity)
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -397,6 +408,8 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	}
 
 	switch {
+	case firstInitialInputUnsupported(result.Observations) != "":
+		result.Outcome, result.Reason = PrepareOutcomeUnsupported, firstInitialInputUnsupported(result.Observations)
 	case len(result.RequiredActions) > 0:
 		result.Outcome, result.Reason = PrepareOutcomeActionRequired, result.RequiredActions[0].ReasonCode
 	case !detect.Available:
@@ -678,6 +691,11 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 	if !participant.Runnable {
 		return prepared, observation, nil, nil, nil
 	}
+	if reason := prepareInitialInputUnsupported(participant); reason != "" {
+		prepared.PlannedOutcome = "unsupported"
+		observation.ReasonCode = reason
+		return prepared, observation, nil, nil, nil
+	}
 	if dependencies.AdapterFor == nil {
 		return prepared, observation, nil, nil, fmt.Errorf("prepare adapter factory is missing")
 	}
@@ -700,6 +718,10 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 		AMQExecutable: dependencies.AMQPath, Cwd: cwd, AllowExternalCwd: true,
 		LaunchNonce: preparePlaceholderUUID, ResumePolicy: participant.ResumePolicy,
 		CommittedArgs: slices.Clone(participant.Args), BypassArgs: slices.Clone(participant.BypassArgs), EnvOverlay: cloneEnv(participant.EnvOverlay),
+	}
+	if participant.InitialInput != nil {
+		digest := initialInputDigest(participant.InitialInput.Text)
+		base.InitialInput = &InitialInputRequest{Kind: participant.InitialInput.Kind, Value: participant.InitialInput.Text, SHA256: digest}
 	}
 	var plan AgentPlan
 	var actions []PrepareRequiredAction
@@ -731,6 +753,33 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 	plan.Execution = clonePrepareExecutionOptions(&participant.Execution)
 	prepared.Command = previewStaticCommand(plan)
 	return prepared, observation, &plan, actions, nil
+}
+
+func initialInputDigest(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func prepareInitialInputUnsupported(participant PrepareParticipant) string {
+	if participant.InitialInput == nil {
+		return ""
+	}
+	if len([]byte(participant.InitialInput.Text)) > MaxInitialInputBytes {
+		return "initial_input_too_large"
+	}
+	if participant.InitialInput.Kind != InitialInputArgument || participant.Provider == CursorProvider {
+		return "initial_input_unsupported"
+	}
+	return ""
+}
+
+func firstInitialInputUnsupported(observations []PrepareObservation) string {
+	for _, observation := range observations {
+		if observation.ReasonCode == "initial_input_too_large" || observation.ReasonCode == "initial_input_unsupported" {
+			return observation.ReasonCode
+		}
+	}
+	return ""
 }
 
 func clonePrepareExecutionOptions(options *PrepareExecutionOptions) *PrepareExecutionOptions {

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -645,7 +645,7 @@ func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []pla
 			ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Cwd: agent.plan.Cwd,
 			ProviderExecutable: agent.plan.Argv[0], AMQExecutable: amqPath,
 			TargetArgv: agent.plan.Argv, DynamicArgv: agent.plan.DynamicArgv, TargetEnv: agent.plan.EnvOverlay,
-			Execution: agent.plan.Execution,
+			InitialInput: agent.plan.InitialInput, Execution: agent.plan.Execution,
 		}
 		if agent.plan.PreSpawnAcquire || (agent.adapter.Name() == CodexProvider && agent.plan.AdapterMode == AdapterModeCapture) {
 			ticketRequest.Backend, ticketRequest.Profile = backend, profile
@@ -743,7 +743,7 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			Handle: cfg.Handle, ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(),
 			AMQExecutable: request.AMQPath, Cwd: cwd,
 			LaunchNonce: nonce, ResumePolicy: policy, CommittedArgs: committedArgs, BypassArgs: bypassArgs,
-			EnvOverlay: cfg.Env, AllowExternalCwd: request.AllowExternalCwd,
+			EnvOverlay: cfg.Env, AllowExternalCwd: request.AllowExternalCwd, InitialInput: cfg.InitialInput,
 		}
 		conversation, loadErr := LoadConversation(request.Root, cfg.Handle)
 		hasConversation := loadErr == nil

--- a/internal/launch/static_input_test.go
+++ b/internal/launch/static_input_test.go
@@ -15,11 +15,20 @@ func TestValidateStaticProviderInput(t *testing.T) {
 	}{
 		{name: "codex bypass", executable: "/opt/bin/codex", args: []string{"--dangerously-bypass-approvals-and-sandbox"}, env: map[string]string{"LANG": "C"}},
 		{name: "claude bypass", executable: "claude", args: []string{"--dangerously-skip-permissions"}},
+		{name: "claude allowed tools", executable: "claude", args: []string{"--allowedTools", "Bash,Read,Write,Edit"}},
+		{name: "codex reasoning minimal", executable: "codex", args: []string{"-c", "model_reasoning_effort=minimal"}},
+		{name: "codex reasoning xhigh", executable: "codex", args: []string{"-c", "model_reasoning_effort=xhigh"}},
 		{name: "unknown provider", executable: "bash", want: "adapter-known"},
 		{name: "provider smuggling", executable: "codex-wrapper", want: "adapter-known"},
 		{name: "unknown argument", executable: "codex", args: []string{"--config", "x=y"}, want: "not allowed"},
 		{name: "bypass value smuggling", executable: "codex", args: []string{"--dangerously-bypass-approvals-and-sandbox", "payload"}, want: "not allowed"},
 		{name: "unknown environment", executable: "claude", env: map[string]string{"CLAUDE_CONFIG_DIR": "/tmp/attacker"}, want: "not allowed"},
+		{name: "duplicate allowed tools", executable: "claude", args: []string{"--allowedTools", "Read", "--allowedTools", "Write"}, want: "duplicated"},
+		{name: "empty allowed tool", executable: "claude", args: []string{"--allowedTools", "Read,,Write"}, want: "invalid value"},
+		{name: "spaced allowed tool", executable: "claude", args: []string{"--allowedTools", "Read, Write"}, want: "invalid value"},
+		{name: "unknown codex key", executable: "codex", args: []string{"-c", "notify=[]"}, want: "invalid value"},
+		{name: "unknown codex value", executable: "codex", args: []string{"-c", "model_reasoning_effort=ultra"}, want: "invalid value"},
+		{name: "duplicate codex key", executable: "codex", args: []string{"-c", "model_reasoning_effort=low", "-c", "model_reasoning_effort=high"}, want: "duplicated"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/launch/trust_digest.go
+++ b/internal/launch/trust_digest.go
@@ -26,7 +26,7 @@ func ExecutionTrustDigest(plan Plan, session string, root *fsq.DeliveryRoot) (st
 	if err := root.VerifyBase(); err != nil {
 		return "", err
 	}
-	planDigest, err := plan.SemanticDigest()
+	planDigest, err := plan.TrustSemanticDigest()
 	if err != nil {
 		return "", err
 	}

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -27,6 +27,7 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 		t.Fatal(err)
 	}
 	runnable := fixture.request.Intent.Participants[0]
+	runnable.InitialInput = &InitialInputV1{Kind: InitialInputArgument, Text: "generated bootstrap"}
 	runnable.Execution = &ExecutionOptionsV1{
 		RequireWake: true, NoGitignore: true,
 		Wake: WakeOptionsV1{Mode: WakeEnabled, Injector: &InjectorOptionsV1{Mode: InjectorRaw, Via: injector, Args: []string{"send"}}},
@@ -87,6 +88,9 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 		}
 		if !reflect.DeepEqual(ticket.Execution, &wantOptions) {
 			t.Fatalf("%s ticket execution options = %#v, want %#v", handle, ticket.Execution, wantOptions)
+		}
+		if len(ticket.TargetArgv) == 0 || ticket.TargetArgv[len(ticket.TargetArgv)-1] != "generated bootstrap" {
+			t.Fatalf("%s ticket did not preserve the final initial argument: %#v", handle, ticket.TargetArgv)
 		}
 	}
 	entries, err := os.ReadDir(filepath.Dir(fixture.request.Target.SessionRoot))

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -16,6 +16,7 @@ var compatibilityFeaturesV1 = []string{
 	"lifecycle_v1",
 	"managed_tmux_v1",
 	"plan_only_commands_v1",
+	FeatureInitialInput,
 }
 
 func Compatibility() CompatibilityV1 {

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -20,11 +20,14 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	}
 	for _, unfinished := range []string{
 		FeatureBaseRoot, FeatureOnLive, FeatureWrapper, FeaturePlacement,
-		FeatureInitialInput, FeatureCallerContext, FeatureExecutableIdentity,
+		FeatureCallerContext, FeatureExecutableIdentity,
 	} {
 		if slices.Contains(Compatibility().Features, unfinished) {
 			t.Fatalf("Compatibility advertised unfinished feature %q", unfinished)
 		}
+	}
+	if !slices.Contains(Compatibility().Features, FeatureInitialInput) {
+		t.Fatal("Compatibility did not advertise the completed initial_input feature")
 	}
 
 	negotiated, err := Negotiate(RequirementV1{

--- a/launchapi/intent.go
+++ b/launchapi/intent.go
@@ -75,7 +75,7 @@ func (participant ParticipantV1) validate() error {
 	}
 	if !participant.Runnable {
 		if participant.Executable != "" || participant.Args != nil || participant.Cwd != nil ||
-			participant.EnvOverlay != nil || participant.ResumePolicy != "" || participant.Execution != nil {
+			participant.InitialInput != nil || participant.EnvOverlay != nil || participant.ResumePolicy != "" || participant.Execution != nil {
 			return fmt.Errorf("non-runnable participant %q must be handle-only", participant.Handle)
 		}
 		return nil
@@ -100,12 +100,29 @@ func (participant ParticipantV1) validate() error {
 	if err := participant.Execution.validate(); err != nil {
 		return fmt.Errorf("runnable participant %q execution: %w", participant.Handle, err)
 	}
+	if participant.InitialInput != nil {
+		if err := participant.InitialInput.validate(); err != nil {
+			return fmt.Errorf("runnable participant %q initial_input: %w", participant.Handle, err)
+		}
+	}
 	if _, err := internallaunch.ValidateStaticProviderInput(
 		participant.Executable,
 		participant.Args,
 		participant.EnvOverlay,
 	); err != nil {
 		return fmt.Errorf("runnable participant %q: %w", participant.Handle, err)
+	}
+	return nil
+}
+
+func (input InitialInputV1) validate() error {
+	switch input.Kind {
+	case InitialInputArgument, InitialInputStdin, InitialInputFile:
+	default:
+		return fmt.Errorf("invalid kind %q", input.Kind)
+	}
+	if !utf8.ValidString(input.Text) || strings.ContainsRune(input.Text, 0) {
+		return fmt.Errorf("text must be valid UTF-8 without NUL")
 	}
 	return nil
 }
@@ -187,6 +204,14 @@ func requireLaunchIntentFields(data []byte) error {
 			for _, optional := range []string{"args", "env_overlay"} {
 				if err := rejectExplicitNull(fields, optional, fmt.Sprintf("participants[%d]", i)); err != nil {
 					return err
+				}
+				if raw := fields["initial_input"]; raw != nil {
+					if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+						return fmt.Errorf("participants[%d].initial_input must not be null", i)
+					}
+					if err := requireObjectFields(raw, fmt.Sprintf("participants[%d].initial_input", i), "kind", "text"); err != nil {
+						return err
+					}
 				}
 			}
 			var execution map[string]json.RawMessage

--- a/launchapi/intent_test.go
+++ b/launchapi/intent_test.go
@@ -175,6 +175,34 @@ func TestLaunchIntentV1UsesAdapterDenyByDefaultGrammar(t *testing.T) {
 	}
 }
 
+func TestLaunchIntentV1InitialInputStrictShape(t *testing.T) {
+	base := `{"intent_version":1,"participants":[{"handle":"codex","runnable":true,"executable":"codex","cwd":{"kind":"relative","path":"."},"resume_policy":"fresh","execution":{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled"}},"initial_input":%s}]}`
+	for _, test := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "null", input: `null`, want: "must not be null"},
+		{name: "unknown kind", input: `{"kind":"pipe","text":"hello"}`, want: "invalid kind"},
+		{name: "missing text", input: `{"kind":"stdin"}`, want: "requires text"},
+		{name: "unknown field", input: `{"kind":"file","text":"hello","path":"/tmp/pwn"}`, want: "unknown field"},
+		{name: "nul", input: `{"kind":"argument","text":"hello\u0000world"}`, want: "without NUL"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := DecodeLaunchIntentV1([]byte(fmt.Sprintf(base, test.input)))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DecodeLaunchIntentV1 error = %v, want %q", err, test.want)
+			}
+		})
+	}
+	for _, kind := range []string{"argument", "stdin", "file"} {
+		raw := fmt.Sprintf(base, fmt.Sprintf(`{"kind":%q,"text":"hello"}`, kind))
+		if _, err := DecodeLaunchIntentV1([]byte(raw)); err != nil {
+			t.Fatalf("kind %s rejected: %v", kind, err)
+		}
+	}
+}
+
 func TestLaunchIntentV1MarshalRoundTrip(t *testing.T) {
 	intent, err := DecodeLaunchIntentV1([]byte(validIntentJSON(t)))
 	if err != nil {

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 
 	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
 )
@@ -106,6 +107,9 @@ func toInternalPrepareParticipant(participant ParticipantV1, provider string, co
 		Executable: participant.Executable, Args: slices.Clone(committedArgs), BypassArgs: slices.Clone(bypassArgs), EnvOverlay: cloneStringMap(participant.EnvOverlay),
 		ResumePolicy: internallaunch.ResumePolicy(participant.ResumePolicy),
 	}
+	if participant.InitialInput != nil {
+		result.InitialInput = &internallaunch.PrepareInitialInput{Kind: internallaunch.InitialInputKind(participant.InitialInput.Kind), Text: participant.InitialInput.Text}
+	}
 	if participant.Cwd != nil {
 		result.Cwd = participant.Cwd.Path
 	}
@@ -186,6 +190,39 @@ func fromInternalPrepareResult(result internallaunch.PrepareResult) PrepareResul
 			Resource: observation.Resource, ReasonCode: observation.ReasonCode,
 		})
 	}
+	seenProviders := make(map[string]struct{})
+	for _, participant := range result.Participants {
+		if !participant.Runnable || participant.Provider == "" {
+			continue
+		}
+		if _, ok := seenProviders[participant.Provider]; ok {
+			continue
+		}
+		seenProviders[participant.Provider] = struct{}{}
+		capability := internallaunch.ProviderStaticInputCapabilities(participant.Provider)
+		if capability.GrammarVersion == 0 || capability.VerifiedProviderVersion == "" {
+			continue
+		}
+		publicCapability := ProviderCapabilitiesV1{
+			Provider: participant.Provider, GrammarVersion: capability.GrammarVersion,
+			VerifiedProviderVersion: capability.VerifiedProviderVersion,
+			AllowedArgumentForms:    slices.Clone(capability.AllowedArgumentForms),
+			ConfigOverrides:         make([]ConfigOverrideCapabilityV1, 0, len(capability.ConfigOverrides)),
+			InitialInputKinds:       make([]InitialInputKindV1, 0, len(capability.InitialInputKinds)),
+		}
+		for _, override := range capability.ConfigOverrides {
+			publicCapability.ConfigOverrides = append(publicCapability.ConfigOverrides, ConfigOverrideCapabilityV1{
+				Key: override.Key, AllowedValues: slices.Clone(override.AllowedValues),
+			})
+		}
+		for _, kind := range capability.InitialInputKinds {
+			publicCapability.InitialInputKinds = append(publicCapability.InitialInputKinds, InitialInputKindV1(kind))
+		}
+		public.Preview.Capabilities = append(public.Preview.Capabilities, publicCapability)
+	}
+	slices.SortFunc(public.Preview.Capabilities, func(left, right ProviderCapabilitiesV1) int {
+		return strings.Compare(left.Provider, right.Provider)
+	})
 	return public
 }
 

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -49,8 +49,13 @@ func TestPrepareIsZeroWriteAndDeterministic(t *testing.T) {
 	if first.SubjectSchema != SubjectSchemaV2 {
 		t.Fatalf("new Prepare subject schema = %d", first.SubjectSchema)
 	}
-	if first.Preview.Capabilities == nil || len(first.Preview.Capabilities) != 0 {
-		t.Fatalf("capability skeleton must be a deny-by-default empty array: %#v", first.Preview.Capabilities)
+	wantCapabilities := []ProviderCapabilitiesV1{{
+		Provider: "claude", GrammarVersion: 1, VerifiedProviderVersion: "2.1.233",
+		AllowedArgumentForms: []string{"--allowedTools"}, ConfigOverrides: []ConfigOverrideCapabilityV1{},
+		InitialInputKinds: []InitialInputKindV1{InitialInputArgument},
+	}}
+	if !reflect.DeepEqual(first.Preview.Capabilities, wantCapabilities) {
+		t.Fatalf("static capabilities = %#v, want %#v", first.Preview.Capabilities, wantCapabilities)
 	}
 	if len(first.RequiredActions) != 1 {
 		t.Fatalf("required actions = %#v", first.RequiredActions)
@@ -78,6 +83,59 @@ func TestPrepareIsZeroWriteAndDeterministic(t *testing.T) {
 	}
 	if !slices.Equal(first.Preview.Roster.Present, []string{"claude"}) || len(first.Preview.Roster.Missing) != 0 {
 		t.Fatalf("roster = %#v", first.Preview.Roster)
+	}
+}
+
+func TestPrepareInitialArgumentIsFinalAndContentDoesNotChurnTrust(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	fixture.request.Intent.Participants[0].InitialInput = &InitialInputV1{Kind: InitialInputArgument, Text: "bootstrap one"}
+	first, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := first.Preview.Participants[0].Command
+	if command == nil || command.Argv[len(command.Argv)-1] != "bootstrap one" {
+		t.Fatalf("initial argument is not the final provider argv element: %#v", command)
+	}
+
+	fixture.request.Intent.Participants[0].InitialInput.Text = "bootstrap two"
+	second, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.PlanDigest == second.PlanDigest || first.SubjectDigest == second.SubjectDigest {
+		t.Fatalf("content change did not change plan and subject: first=%#v second=%#v", first, second)
+	}
+	if first.TrustDigest != second.TrustDigest {
+		t.Fatalf("content change churned trust: %s != %s", first.TrustDigest, second.TrustDigest)
+	}
+}
+
+func TestPrepareUnsupportedInitialCarriersAndOversizeAreTypedAndZeroWrite(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input InitialInputV1
+		want  string
+	}{
+		{name: "stdin", input: InitialInputV1{Kind: InitialInputStdin, Text: "bootstrap"}, want: "initial_input_unsupported"},
+		{name: "file", input: InitialInputV1{Kind: InitialInputFile, Text: "bootstrap"}, want: "initial_input_unsupported"},
+		{name: "oversize", input: InitialInputV1{Kind: InitialInputArgument, Text: strings.Repeat("x", MaxInitialInputBytes+1)}, want: "initial_input_too_large"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newPublicPrepareFixture(t, true)
+			fixture.request.Intent.Participants[0].InitialInput = &test.input
+			before := snapshotTestTree(t, fixture.root)
+			result, err := Prepare(context.Background(), fixture.request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Outcome != PrepareOutcomeUnsupported || result.Reason != test.want {
+				t.Fatalf("unsupported result = %#v", result)
+			}
+			if after := snapshotTestTree(t, fixture.root); after != before {
+				t.Fatalf("Prepare changed the tree: before=%s after=%s", before, after)
+			}
+		})
 	}
 }
 

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -26,7 +26,7 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 		"LaunchIntentV1", "ParticipantV1", "WorkingDirectoryV1", "ExecutionOptionsV1",
 		"WakeOptionsV1", "InjectorOptionsV1", "IntegrationsV1", "SymphonyOptionsV1",
 		"TargetV1", "PrepareRequestV1", "PrepareResultV1", "ApplyRequestV1", "ApplyResultV1",
-		"ConfigOverrideCapabilityV1", "ProviderCapabilitiesV1",
+		"InitialInputV1", "ConfigOverrideCapabilityV1", "ProviderCapabilitiesV1",
 		"DecisionV1", "ParticipantObservationV1", "CompatibilityV1", "RequirementV1", "NegotiatedV1",
 		"InspectRequestV1", "FocusRequestV1", "CloseRequestV1",
 		"InspectResultV1", "FocusResultV1", "CloseResultV1",
@@ -46,6 +46,7 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 	assertSchemaPropertiesMatchType(t, defs, "PreviewV1", reflect.TypeFor[PreviewV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ConfigOverrideCapabilityV1", reflect.TypeFor[ConfigOverrideCapabilityV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ProviderCapabilitiesV1", reflect.TypeFor[ProviderCapabilitiesV1]())
+	assertSchemaPropertiesMatchType(t, defs, "InitialInputV1", reflect.TypeFor[InitialInputV1]())
 	assertSchemaPropertiesMatchType(t, defs, "PrepareResultV1", reflect.TypeFor[PrepareResultV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ApplyRequestV1", reflect.TypeFor[ApplyRequestV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ApplyResultV1", reflect.TypeFor[ApplyResultV1]())

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -73,6 +73,7 @@ type ParticipantV1 struct {
 	Runnable     bool                `json:"runnable"`
 	Executable   string              `json:"executable,omitempty"`
 	Args         []string            `json:"args,omitempty"`
+	InitialInput *InitialInputV1     `json:"initial_input,omitempty"`
 	Cwd          *WorkingDirectoryV1 `json:"cwd,omitempty"`
 	EnvOverlay   map[string]string   `json:"env_overlay,omitempty"`
 	ResumePolicy ResumePolicy        `json:"resume_policy,omitempty"`
@@ -195,17 +196,25 @@ const (
 	InitialInputFile     InitialInputKindV1 = "file"
 )
 
+const MaxInitialInputBytes = 256 * 1024
+
+type InitialInputV1 struct {
+	Kind InitialInputKindV1 `json:"kind"`
+	Text string             `json:"text"`
+}
+
 type ConfigOverrideCapabilityV1 struct {
 	Key           string   `json:"key"`
 	AllowedValues []string `json:"allowed_values"`
 }
 
 type ProviderCapabilitiesV1 struct {
-	Provider             string                       `json:"provider"`
-	ProviderVersion      string                       `json:"provider_version"`
-	AllowedArgumentForms []string                     `json:"allowed_argument_forms"`
-	ConfigOverrides      []ConfigOverrideCapabilityV1 `json:"config_overrides"`
-	InitialInputKinds    []InitialInputKindV1         `json:"initial_input_kinds"`
+	Provider                string                       `json:"provider"`
+	GrammarVersion          int                          `json:"grammar_version"`
+	VerifiedProviderVersion string                       `json:"verified_provider_version"`
+	AllowedArgumentForms    []string                     `json:"allowed_argument_forms"`
+	ConfigOverrides         []ConfigOverrideCapabilityV1 `json:"config_overrides"`
+	InitialInputKinds       []InitialInputKindV1         `json:"initial_input_kinds"`
 }
 
 type ParticipantObservationV1 struct {

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -45,6 +45,7 @@
         "runnable": {"const": true},
         "executable": {"type": "string", "minLength": 1},
         "args": {"type": "array", "items": {"type": "string"}},
+        "initial_input": {"$ref": "#/$defs/InitialInputV1"},
         "cwd": {"$ref": "#/$defs/WorkingDirectoryV1"},
         "env_overlay": {
           "type": "object",
@@ -53,6 +54,15 @@
         },
         "resume_policy": {"enum": ["resume", "fresh", "disabled"]},
         "execution": {"$ref": "#/$defs/ExecutionOptionsV1"}
+      }
+    },
+    "InitialInputV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "text"],
+      "properties": {
+        "kind": {"enum": ["argument", "stdin", "file"]},
+        "text": {"type": "string", "pattern": "^[^\\x00]*$"}
       }
     },
     "Handle": {
@@ -249,10 +259,11 @@
     "ProviderCapabilitiesV1": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["provider", "provider_version", "allowed_argument_forms", "config_overrides", "initial_input_kinds"],
+      "required": ["provider", "grammar_version", "verified_provider_version", "allowed_argument_forms", "config_overrides", "initial_input_kinds"],
       "properties": {
         "provider": {"type": "string", "minLength": 1},
-        "provider_version": {"type": "string", "minLength": 1},
+        "grammar_version": {"type": "integer", "minimum": 1},
+        "verified_provider_version": {"type": "string", "minLength": 1},
         "allowed_argument_forms": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
         "config_overrides": {"type": "array", "items": {"$ref": "#/$defs/ConfigOverrideCapabilityV1"}},
         "initial_input_kinds": {"type": "array", "uniqueItems": true, "items": {"enum": ["argument", "stdin", "file"]}}


### PR DESCRIPTION
## Summary

- add strict `initial_input` DTO/schema validation and materialize the argument carrier only on fresh launch
- admit the verified Claude `--allowedTools` and Codex `-c model_reasoning_effort=<value>` grammar forms with duplicate and value rejection
- advertise only the argument carrier for current providers; stdin and file remain typed `initial_input_unsupported` outcomes and are not advertised
- include initial-input metadata in durable execution tickets while keeping content in plan/subject identity and out of trust identity
- preserve provider resume identity syntax without redelivering bootstrap input

File transport remains follow-up bead `amq-9d5` until a documented provider file seam exists.

## Verification

- repository pre-push checks: PASS (`go vet ./...`, golangci-lint, `go test ./...`, smoke and hook suites)
- `go test ./launchapi ./internal/launch -count=1`: PASS
- finding-5 adoption smoke cases: PASS
- Cursor resume counterexample: PASS

## Peer review

- Claude APPROVE: `2026-08-18T11-55-10.133Z_pid30932_acee8b01`
- Cursor APPROVE: `2026-08-18T11-57-04.487Z_pid39373_2c9e702f`
- reviewed staged SHA-256: `931825868afbbe84eb2c924e3f72e7fa26b9f70fad006d772262cfef9f36ff2f`