### PR TITLE
feat(launchapi): add typed placement with negotiation and preview

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -21,10 +21,10 @@ if err != nil {
 _ = negotiated
 ```
 
-A `0.61.1` binary can advertise only a subset of the Wave B3 feature IDs while
-the remaining implementation beads are incomplete. A caller must require every
-feature it uses. Contract semver alone does not claim that an unadvertised
-feature is available.
+A `0.61.1` binary advertises `placement` and `initial_input` and can still omit
+later Wave B3 feature IDs while those beads are incomplete. A caller must
+require every feature it uses. Contract semver alone does not claim that an
+unadvertised feature is available.
 
 `PreviewV1.capabilities` reports the selected providers' static adapter grammar
 without executing a caller-supplied provider. `grammar_version` is the
@@ -135,6 +135,12 @@ accepts the original Prepare request, the returned subject schema and digest,
 and one explicit decision for each required action. It recomputes the subject
 under that schema and fails closed if state changed.
 
+Omitted `placement` keeps the selected backend's v0.61 layout and still appears
+on `PreviewV1.placement.effective`. An explicit tuple the backend cannot
+realize returns `outcome: unsupported` and `reason: placement_unsupported`
+with zero planned backend mutation. Subject schema 2 binds that preview into
+`subject_digest`; schema 1 rejects an explicit placement field.
+
 ```go
 request := launchapi.PrepareRequestV1{
 	RequestVersion: launchapi.RequestVersionV1,
@@ -143,8 +149,11 @@ request := launchapi.PrepareRequestV1{
 		SessionRoot: "/workspace/project/.agent-mail/collab",
 		Session:     "collab",
 	},
-	Launcher: "commands",
-	Intent:   intent,
+	Launcher: "tmux",
+	Placement: &launchapi.PlacementV1{
+		Target: launchapi.PlacementCurrentWindow, Layout: launchapi.PlacementColumns, LauncherPane: "%17",
+	},
+	Intent: intent,
 }
 
 prepared, err := launchapi.Prepare(ctx, request)

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -59,6 +59,7 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 	planFlag := fs.String("plan", "", "Public LaunchIntentV1 file, or - for stdin")
 	prepareFlag := fs.Bool("prepare", false, "Prepare the public launch intent without mutation (requires --plan and --json)")
 	applyFlag := fs.String("apply", "", "Public ApplyRequestV1 file, or - for stdin (requires --json)")
+	placementFlag := fs.String("placement", "", "Public PlacementV1 JSON object (with --plan)")
 	usageName := "amq launch [options]"
 	if options.resumeOnly {
 		usageName = "amq session resume <name> [options]"
@@ -71,7 +72,7 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 	} else if handled {
 		return nil
 	}
-	publicMode := flagWasVisited(fs, "plan") || flagWasVisited(fs, "prepare") || flagWasVisited(fs, "apply")
+	publicMode := flagWasVisited(fs, "plan") || flagWasVisited(fs, "prepare") || flagWasVisited(fs, "apply") || flagWasVisited(fs, "placement")
 	if publicMode {
 		if options.resumeOnly {
 			return UsageError("session resume does not accept --plan, --prepare, or --apply")
@@ -80,7 +81,7 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 			flagWasVisited(fs, "rebind") || flagWasVisited(fs, "require-agent") {
 			return UsageError("--plan, --prepare, and --apply do not accept legacy launch decision flags")
 		}
-		return runPublicLaunch(common, *sessionFlag, *launcherFlag, *planFlag, *prepareFlag, *applyFlag, fs)
+		return runPublicLaunch(common, *sessionFlag, *launcherFlag, *planFlag, *prepareFlag, *applyFlag, *placementFlag, fs)
 	}
 	if *freshFlag && *allowFreshFlag {
 		return UsageError("--fresh and --allow-fresh-fallback are mutually exclusive")

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -27,7 +27,7 @@ import (
 //	finding1_missing_profile_base_root | 1 named-profile base root | missing .agent-mail/<profile> refuses (not found / stat delivery root) | Prepare planned write create_base_root; Apply creates the authorized base
 //	finding2_mixed_live_fresh_roster_refuses | 2 live-seat dispositions | whole binding refuses rather than keep-live + create-missing | on_live keep -> kept + created missing seats
 //	finding3_wrapper_unknown_field | 3 wrapper | strict decode unknown field "wrapper" | wrapper argv prepended to full provider argv
-//	finding4_squad_tmux_env_rejected | 4 placement | AMQ_SQUAD_TMUX_* env rejected as provider env | placement preview; unsupported tuple -> placement_unsupported
+//	finding4_placement_unsupported | 4 placement | AMQ_SQUAD_TMUX_* env rejected as provider env | placement preview; unsupported tuple -> placement_unsupported
 //	finding5_positional_bootstrap_prompt / finding5_claude_allowed_tools / finding5_codex_dash_c | 5 materialized argv | raw positional prompt rejected; exact --allowedTools and -c forms admitted | initial_input + --allowedTools / -c admitted
 //	finding6_caller_context_unknown_field | 6 caller correlation | strict decode unknown field "caller_context" | caller_context echoed on Apply/evidence/lifecycle
 //	finding7_same_path_inode_replacement_not_subject_changed | 7 physical identity | same-path inode replacement leaves subject/plan/trust digests identical | inode replacement -> subject_changed
@@ -69,15 +69,31 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		assertAdoptionArgumentAdmitted(t, exit, stdout, stderr, "senior-dev", "-c", "model_reasoning_effort=high")
 	})
 
-	t.Run("finding4_squad_tmux_env_rejected", func(t *testing.T) {
+	t.Run("finding4_placement_unsupported", func(t *testing.T) {
 		fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "collab")
-		intent := fx.legalSquadIntent()
-		intent.Participants[1].EnvOverlay = map[string]string{
-			"AMQ_SQUAD_TMUX_TARGET":        "current-window",
-			"AMQ_SQUAD_TMUX_LAUNCHER_PANE": "%323",
+		intentPath := filepath.Join(t.TempDir(), "intent.json")
+		if err := os.WriteFile(intentPath, fx.intentJSON(t, fx.legalSquadIntent()), 0o600); err != nil {
+			t.Fatal(err)
 		}
-		stdout, stderr, exit := fx.prepare(t, intent, launch.LauncherCommands)
-		assertAdoptionDecodeRejection(t, exit, stdout, stderr, "AMQ_SQUAD_TMUX_")
+		stdout, stderr, exit := runRealAMQWithExit(t, fx.amqBinary, fx.project, fx.env,
+			"launch", "--plan", intentPath, "--prepare", "--json", "--launcher", launch.LauncherCommands,
+			"--session", fx.session, "--placement", `{"target":"current_window","layout":"columns","launcher_pane":"%323"}`)
+		if exit != ExitActionRequired {
+			t.Fatalf("Prepare unsupported placement exit=%d stdout=%s stderr=%s", exit, stdout, stderr)
+		}
+		var prepared launchapi.PrepareResultV1
+		decodeRealLaunchJSON(t, stdout, &prepared)
+		if prepared.Outcome != launchapi.PrepareOutcomeUnsupported || prepared.Reason != launch.PlacementUnsupportedReason {
+			t.Fatalf("Prepare placement = %#v stderr=%s", prepared, stderr)
+		}
+		if prepared.Preview.Placement == nil || prepared.Preview.Placement.Supported ||
+			prepared.Preview.Placement.ReasonCode != launch.PlacementUnsupportedReason ||
+			prepared.Preview.Placement.Requested == nil || prepared.Preview.Placement.Requested.LauncherPane != "%323" {
+			t.Fatalf("placement preview = %#v", prepared.Preview.Placement)
+		}
+		if _, err := os.Stat(launch.BindingPath(fx.sessionRoot)); !os.IsNotExist(err) {
+			t.Fatalf("unsupported placement mutated binding: %v", err)
+		}
 	})
 
 	t.Run("finding3_wrapper_unknown_field", func(t *testing.T) {

--- a/internal/cli/launch_public_api.go
+++ b/internal/cli/launch_public_api.go
@@ -36,6 +36,9 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 	if flagWasVisited(fs, "placement") && !planExplicit {
 		return UsageError("--placement requires --plan")
 	}
+	if flagWasVisited(fs, "placement") && strings.TrimSpace(placementJSON) == "" {
+		return UsageError("--placement must be a PlacementV1 JSON object")
+	}
 	if planExplicit && strings.TrimSpace(planSource) == "" {
 		return UsageError("--plan must name a file or -")
 	}
@@ -81,7 +84,7 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 		Launcher:       strings.TrimSpace(launcher),
 		Intent:         intent,
 	}
-	if strings.TrimSpace(placementJSON) != "" {
+	if flagWasVisited(fs, "placement") {
 		placement, err := decodePublicPlacement(placementJSON)
 		if err != nil {
 			return err
@@ -183,6 +186,13 @@ func decodePublicPlacement(raw string) (*launchapi.PlacementV1, error) {
 	decoder.DisallowUnknownFields()
 	var placement launchapi.PlacementV1
 	if err := decoder.Decode(&placement); err != nil {
+		return nil, UsageError("placement: %v", err)
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, UsageError("placement: multiple JSON values")
+		}
 		return nil, UsageError("placement: %v", err)
 	}
 	if err := placement.Validate(); err != nil {

--- a/internal/cli/launch_public_api.go
+++ b/internal/cli/launch_public_api.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -12,7 +13,7 @@ import (
 	"github.com/avivsinai/agent-message-queue/launchapi"
 )
 
-func runPublicLaunch(common *commonFlags, session, launcher, planSource string, prepareOnly bool, applySource string, fs *flag.FlagSet) error {
+func runPublicLaunch(common *commonFlags, session, launcher, planSource string, prepareOnly bool, applySource, placementJSON string, fs *flag.FlagSet) error {
 	planExplicit, applyExplicit := flagWasVisited(fs, "plan"), flagWasVisited(fs, "apply")
 	if prepareOnly && !planExplicit {
 		return UsageError("--prepare requires --plan")
@@ -28,6 +29,12 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 	}
 	if applyExplicit && (flagWasVisited(fs, "session") || flagWasVisited(fs, "launcher") || common.rootExplicit()) {
 		return UsageError("--apply takes its target and launcher from ApplyRequestV1")
+	}
+	if applyExplicit && flagWasVisited(fs, "placement") {
+		return UsageError("--apply takes placement from ApplyRequestV1")
+	}
+	if flagWasVisited(fs, "placement") && !planExplicit {
+		return UsageError("--placement requires --plan")
 	}
 	if planExplicit && strings.TrimSpace(planSource) == "" {
 		return UsageError("--plan must name a file or -")
@@ -73,6 +80,13 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 		Target:         target,
 		Launcher:       strings.TrimSpace(launcher),
 		Intent:         intent,
+	}
+	if strings.TrimSpace(placementJSON) != "" {
+		placement, err := decodePublicPlacement(placementJSON)
+		if err != nil {
+			return err
+		}
+		request.Placement = placement
 	}
 	prepared, err := launchapi.Prepare(ctx, request)
 	if err != nil {
@@ -162,6 +176,19 @@ func resolvePublicLaunchTarget(common *commonFlags, session string) (launchapi.T
 		return launchapi.TargetV1{}, err
 	}
 	return launchapi.TargetV1{ProjectRoot: filepath.Clean(projectRoot), SessionRoot: filepath.Clean(root), Session: session}, nil
+}
+
+func decodePublicPlacement(raw string) (*launchapi.PlacementV1, error) {
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var placement launchapi.PlacementV1
+	if err := decoder.Decode(&placement); err != nil {
+		return nil, UsageError("placement: %v", err)
+	}
+	if err := placement.Validate(); err != nil {
+		return nil, UsageError("placement: %v", err)
+	}
+	return &placement, nil
 }
 
 func readLaunchAPIDocument(source string) ([]byte, error) {

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -181,6 +181,8 @@ func TestPublicLaunchModeFlagRefusals(t *testing.T) {
 		{name: "apply target override", args: []string{"--apply", "apply.json", "--session", "collab", "--json"}, want: "takes its target"},
 		{name: "legacy decision flag", args: []string{"--plan", "intent.json", "--fresh"}, want: "legacy launch decision flags"},
 		{name: "require agent is legacy only", args: []string{"--plan", "intent.json", "--require-agent"}, want: "legacy launch decision flags"},
+		{name: "placement without plan", args: []string{"--placement", `{"target":"session","layout":"columns"}`, "--json"}, want: "--placement requires --plan"},
+		{name: "apply with placement flag", args: []string{"--apply", "apply.json", "--json", "--placement", `{"target":"session","layout":"columns"}`}, want: "takes placement"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := runLaunch(test.args)

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -183,6 +183,8 @@ func TestPublicLaunchModeFlagRefusals(t *testing.T) {
 		{name: "require agent is legacy only", args: []string{"--plan", "intent.json", "--require-agent"}, want: "legacy launch decision flags"},
 		{name: "placement without plan", args: []string{"--placement", `{"target":"session","layout":"columns"}`, "--json"}, want: "--placement requires --plan"},
 		{name: "apply with placement flag", args: []string{"--apply", "apply.json", "--json", "--placement", `{"target":"session","layout":"columns"}`}, want: "takes placement"},
+		{name: "empty placement", args: []string{"--plan", "intent.json", "--prepare", "--json", "--placement", ""}, want: "--placement must be a PlacementV1 JSON object"},
+		{name: "whitespace placement", args: []string{"--plan", "intent.json", "--prepare", "--json", "--placement", " \t"}, want: "--placement must be a PlacementV1 JSON object"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := runLaunch(test.args)
@@ -190,6 +192,29 @@ func TestPublicLaunchModeFlagRefusals(t *testing.T) {
 				t.Fatalf("error = %v, want usage containing %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestPublicLaunchPlacementRejectsTrailingJSON(t *testing.T) {
+	launchCLIFixture(t, "collab")
+	intent := launchapi.LaunchIntentV1{
+		IntentVersion: launchapi.IntentVersionV1,
+		Participants:  []launchapi.ParticipantV1{{Handle: "operator", Runnable: false}},
+	}
+	data, err := launchapi.MarshalLaunchIntentV1(intent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "intent.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = runLaunch([]string{
+		"--plan", path, "--prepare", "--json", "--launcher", "commands",
+		"--placement", `{"target":"session","layout":"columns"} {"target":"new_window","layout":"rows"}`,
+	})
+	if GetExitCode(err) != ExitUsage || !strings.Contains(err.Error(), "multiple JSON values") {
+		t.Fatalf("trailing placement JSON error = %v", err)
 	}
 }
 

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -470,6 +470,7 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		HostIdentity: dependencies.HostIdentity, AllowExternalCwd: true,
 		ExecutionOptions:   executionOptions,
 		AllowFreshFallback: decisions[ActionStaleConversation] == "fresh_once",
+		Placement:          prepared.Placement,
 	}
 	if choice := decisions[ActionTrustConfirmation]; choice == "trust_exact_subject" {
 		request.ConfirmTrust = func(plan Plan, actualTrustDigest string) (bool, error) {

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -99,6 +99,7 @@ type PrepareRequest struct {
 	IntentDigest  string
 	Participants  []PrepareParticipant
 	SubjectSchema int
+	Placement     *Placement
 }
 
 type AdapterFactory func(provider, executable string) HarnessAdapter
@@ -171,6 +172,7 @@ type PrepareResult struct {
 	Roster          PrepareRoster
 	RequiredActions []PrepareRequiredAction
 	Observations    []PrepareObservation
+	Placement       PlacementPreview
 }
 
 type prepareTargetState struct {
@@ -253,6 +255,7 @@ type prepareSubject struct {
 	Actions         []PrepareRequiredAction   `json:"actions"`
 	Participants    []PreparedParticipant     `json:"participants"`
 	Observations    []PrepareObservation      `json:"observations"`
+	Placement       *PlacementPreview         `json:"placement,omitempty"`
 }
 
 // Prepare compiles public caller intent and inspects current launch state. It
@@ -275,6 +278,14 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	subjectSchema, err := normalizeSubjectSchema(request.SubjectSchema)
 	if err != nil {
 		return PrepareResult{}, err
+	}
+	if request.Placement != nil {
+		if subjectSchema == SubjectSchemaV1 {
+			return PrepareResult{}, fmt.Errorf("placement requires subject schema %d", SubjectSchemaV2)
+		}
+		if err := request.Placement.Validate(); err != nil {
+			return PrepareResult{}, err
+		}
 	}
 	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath)
 	if err != nil {
@@ -344,6 +355,12 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if detect.Profile.Backend != "" {
 		result.Profile = detect.Profile.Identity()
 	}
+	placement, err := ResolvePlacement(backendName, request.Placement)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	result.Placement = placement
+	placementUnsupported := request.Placement != nil && !placement.Supported
 
 	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{}}
 	for _, participant := range request.Participants {
@@ -351,11 +368,16 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		if participantErr != nil {
 			return PrepareResult{}, participantErr
 		}
+		if placementUnsupported && prepared.Runnable {
+			prepared.PlannedOutcome = "unsupported"
+		}
 		result.Participants = append(result.Participants, prepared)
 		result.Observations = append(result.Observations, observation)
-		result.RequiredActions = append(result.RequiredActions, actions...)
-		if agentPlan != nil {
-			plan.Agents = append(plan.Agents, *agentPlan)
+		if !placementUnsupported {
+			result.RequiredActions = append(result.RequiredActions, actions...)
+			if agentPlan != nil {
+				plan.Agents = append(plan.Agents, *agentPlan)
+			}
 		}
 	}
 	applyBindingResources(result.Observations, binding)
@@ -363,14 +385,16 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		return PrepareResult{}, err
 	}
 
-	result.RequiredActions = append(result.RequiredActions, prepareRebindActions(binding, bindingObservation, boundDetect, backendName, result.Profile, dependencies.HostIdentity)...)
-	for i := range result.RequiredActions {
-		result.RequiredActions[i].ActionID, err = prepareActionID(result.RequiredActions[i])
-		if err != nil {
-			return PrepareResult{}, err
+	if !placementUnsupported {
+		result.RequiredActions = append(result.RequiredActions, prepareRebindActions(binding, bindingObservation, boundDetect, backendName, result.Profile, dependencies.HostIdentity)...)
+		for i := range result.RequiredActions {
+			result.RequiredActions[i].ActionID, err = prepareActionID(result.RequiredActions[i])
+			if err != nil {
+				return PrepareResult{}, err
+			}
 		}
+		slices.SortFunc(result.RequiredActions, comparePrepareActions)
 	}
-	slices.SortFunc(result.RequiredActions, comparePrepareActions)
 
 	result.PlanDigest, err = PreparePlanDigest(plan)
 	if err != nil {
@@ -384,7 +408,7 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if err != nil {
 		return PrepareResult{}, err
 	}
-	if detect.Available && len(plan.Agents) > 0 {
+	if !placementUnsupported && detect.Available && len(plan.Agents) > 0 {
 		trusted, trustErr := loadPrepareTrust(dependencies.TrustStore, result.TrustDigest)
 		if trustErr != nil {
 			return PrepareResult{}, trustErr
@@ -408,6 +432,8 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	}
 
 	switch {
+	case placementUnsupported:
+		result.Outcome, result.Reason = PrepareOutcomeUnsupported, PlacementUnsupportedReason
 	case firstInitialInputUnsupported(result.Observations) != "":
 		result.Outcome, result.Reason = PrepareOutcomeUnsupported, firstInitialInputUnsupported(result.Observations)
 	case len(result.RequiredActions) > 0:
@@ -425,12 +451,17 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if err := ctx.Err(); err != nil {
 		return PrepareResult{}, err
 	}
-	result.SubjectDigest, err = digestCanonical(prepareSubject{
+	subject := prepareSubject{
 		Version: subjectSchema, IntentDigest: request.IntentDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
 		Target: state.target, ProjectIdentity: state.projectIdentity, SessionIdentity: state.sessionIdentity,
 		Backend: result.Backend, Profile: result.Profile, Detection: detect, Binding: bindingObservation, Roster: result.Roster,
 		Actions: result.RequiredActions, Participants: result.Participants, Observations: result.Observations,
-	})
+	}
+	if subjectSchema == SubjectSchemaV2 {
+		placement := result.Placement
+		subject.Placement = &placement
+	}
+	result.SubjectDigest, err = digestCanonical(subject)
 	if err != nil {
 		return PrepareResult{}, err
 	}

--- a/internal/launch/prepare_test.go
+++ b/internal/launch/prepare_test.go
@@ -28,6 +28,98 @@ func TestPrepareRejectsUnknownSubjectSchemaBeforeInspection(t *testing.T) {
 	}
 }
 
+func TestPrepareRejectsPlacementOnSubjectSchemaV1BeforeInspection(t *testing.T) {
+	_, err := Prepare(context.Background(), PrepareRequest{
+		IntentDigest:  "sha256:" + strings.Repeat("a", 64),
+		Participants:  []PrepareParticipant{{Handle: "operator"}},
+		SubjectSchema: SubjectSchemaV1,
+		Placement:     &Placement{Target: PlacementTargetSession, Layout: PlacementLayoutColumns},
+	}, PrepareDependencies{})
+	if err == nil || !strings.Contains(err.Error(), "placement requires subject schema") {
+		t.Fatalf("Prepare error = %v", err)
+	}
+}
+
+func TestPrepareRejectsInvalidPlacementBeforeInspection(t *testing.T) {
+	_, err := Prepare(context.Background(), PrepareRequest{
+		IntentDigest: "sha256:" + strings.Repeat("a", 64),
+		Participants: []PrepareParticipant{{Handle: "operator"}},
+		Placement:    &Placement{Target: PlacementTargetSession, Layout: PlacementLayoutColumns, LauncherPane: "%1"},
+	}, PrepareDependencies{})
+	if err == nil || !strings.Contains(err.Error(), "launcher_pane") {
+		t.Fatalf("Prepare error = %v", err)
+	}
+}
+
+func TestPrepareUnsupportedPlacementSkipsTrustAndCreate(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	fixture.request.Placement = &Placement{Target: PlacementTargetSession, Layout: PlacementLayoutColumns}
+	backend := &prepareTestBackend{}
+	before := prepareTreeSnapshot(t, fixture.root)
+	result, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after := prepareTreeSnapshot(t, fixture.root); after != before {
+		t.Fatalf("unsupported placement Prepare changed filesystem: before %s after %s", before, after)
+	}
+	if backend.creates != 0 {
+		t.Fatalf("Prepare created: %d", backend.creates)
+	}
+	if result.Outcome != PrepareOutcomeUnsupported || result.Reason != PlacementUnsupportedReason || len(result.RequiredActions) != 0 {
+		t.Fatalf("unsupported placement = %#v", result)
+	}
+	if result.Placement.Supported || result.Placement.ReasonCode != PlacementUnsupportedReason {
+		t.Fatalf("placement preview = %#v", result.Placement)
+	}
+}
+
+func TestPrepareV2SubjectDigestIncludesPlacement(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	omitted, err := Prepare(context.Background(), fixture.request, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v1Request := fixture.request
+	v1Request.SubjectSchema = SubjectSchemaV1
+	v1, err := Prepare(context.Background(), v1Request, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if omitted.SubjectSchema != SubjectSchemaV2 || omitted.SubjectDigest == v1.SubjectDigest {
+		t.Fatalf("v2 omitted digest did not diverge from v1: v1=%s v2=%s", v1.SubjectDigest, omitted.SubjectDigest)
+	}
+	staggered := fixture.request
+	staggered.Launcher = LauncherTMux
+	staggered.Placement = &Placement{Target: PlacementTargetSession, Layout: PlacementLayoutColumns, StaggerMS: 250}
+	tmux := &prepareTestBackend{}
+	withStagger, err := Prepare(context.Background(), staggered, PrepareDependencies{
+		Backends: map[string]Backend{LauncherTMux: tmux}, Preferences: []string{LauncherTMux},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseline := fixture.request
+	baseline.Launcher = LauncherTMux
+	baseline.Placement = &Placement{Target: PlacementTargetSession, Layout: PlacementLayoutColumns}
+	withoutStagger, err := Prepare(context.Background(), baseline, PrepareDependencies{
+		Backends: map[string]Backend{LauncherTMux: tmux}, Preferences: []string{LauncherTMux},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withStagger.SubjectDigest == withoutStagger.SubjectDigest {
+		t.Fatal("stagger_ms did not enter the v2 subject digest")
+	}
+	if withStagger.Outcome == PrepareOutcomeUnsupported || withoutStagger.Outcome == PrepareOutcomeUnsupported {
+		t.Fatalf("tmux session placement unsupported: stagger=%#v baseline=%#v", withStagger, withoutStagger)
+	}
+}
+
 func TestPrepareSubjectSchemasProduceDistinctDigestsForSameState(t *testing.T) {
 	fixture := newInternalPrepareFixture(t)
 	v1Request := fixture.request

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -104,6 +104,33 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 	}
 }
 
+func TestApplyUnsupportedPlacementDoesNotPublishSession(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	fixture.request.Placement = &PlacementV1{
+		Target: PlacementCurrentWindow, Layout: PlacementColumns, LauncherPane: "%323",
+	}
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Outcome != PrepareOutcomeUnsupported {
+		t.Fatalf("prepare = %#v", prepared)
+	}
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ReasonCode != internallaunch.PlacementUnsupportedReason {
+		t.Fatalf("Apply unsupported placement = %#v", result)
+	}
+	if _, err := os.Stat(fixture.request.Target.SessionRoot); !os.IsNotExist(err) {
+		t.Fatalf("unsupported placement published a session: %v", err)
+	}
+}
+
 func TestApplyResultMapsEvidenceRefsAndNonContractFailureDetail(t *testing.T) {
 	observed := time.Date(2026, 8, 17, 3, 4, 5, 0, time.UTC)
 	result := fromInternalApplyResult(internallaunch.ApplyResult{FailureDetail: "create tmux session: pane exited", Evidence: []internallaunch.EvidenceRef{{

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -17,6 +17,7 @@ var compatibilityFeaturesV1 = []string{
 	"managed_tmux_v1",
 	"plan_only_commands_v1",
 	FeatureInitialInput,
+	FeaturePlacement,
 }
 
 func Compatibility() CompatibilityV1 {

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -18,16 +18,19 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if Compatibility().Features[0] != "launch_intent_v1" {
 		t.Fatal("Compatibility returned shared mutable feature storage")
 	}
+	if !slices.Contains(Compatibility().Features, FeaturePlacement) {
+		t.Fatal("Compatibility omitted advertised placement")
+	}
+	if !slices.Contains(Compatibility().Features, FeatureInitialInput) {
+		t.Fatal("Compatibility did not advertise the completed initial_input feature")
+	}
 	for _, unfinished := range []string{
-		FeatureBaseRoot, FeatureOnLive, FeatureWrapper, FeaturePlacement,
+		FeatureBaseRoot, FeatureOnLive, FeatureWrapper,
 		FeatureCallerContext, FeatureExecutableIdentity,
 	} {
 		if slices.Contains(Compatibility().Features, unfinished) {
 			t.Fatalf("Compatibility advertised unfinished feature %q", unfinished)
 		}
-	}
-	if !slices.Contains(Compatibility().Features, FeatureInitialInput) {
-		t.Fatal("Compatibility did not advertise the completed initial_input feature")
 	}
 
 	negotiated, err := Negotiate(RequirementV1{
@@ -41,6 +44,15 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	}
 	if !reflect.DeepEqual(negotiated.Features, []string{"launch_intent_v1", "managed_tmux_v1"}) {
 		t.Fatalf("negotiated features = %v", negotiated.Features)
+	}
+	placed, err := Negotiate(RequirementV1{
+		ContractSemver: "0.61.1", IntentVersion: 1, ResultVersion: 1, Features: []string{FeaturePlacement},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(placed.Features, []string{FeaturePlacement}) {
+		t.Fatalf("negotiated placement = %v", placed.Features)
 	}
 
 	if _, err := Negotiate(RequirementV1{ContractSemver: ">=0.61.0", IntentVersion: 1, ResultVersion: 1}); err != nil {

--- a/launchapi/placement.go
+++ b/launchapi/placement.go
@@ -1,0 +1,40 @@
+package launchapi
+
+import internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
+
+func (placement PlacementV1) Validate() error {
+	return toInternalPlacementValue(placement).Validate()
+}
+
+func toInternalPlacement(placement *PlacementV1) *internallaunch.Placement {
+	if placement == nil {
+		return nil
+	}
+	copied := toInternalPlacementValue(*placement)
+	return &copied
+}
+
+func toInternalPlacementValue(placement PlacementV1) internallaunch.Placement {
+	return internallaunch.Placement{
+		Target: string(placement.Target), Layout: string(placement.Layout),
+		StaggerMS: placement.StaggerMS, LauncherPane: placement.LauncherPane,
+	}
+}
+
+func fromInternalPlacement(placement internallaunch.Placement) PlacementV1 {
+	return PlacementV1{
+		Target: PlacementTargetV1(placement.Target), Layout: PlacementLayoutV1(placement.Layout),
+		StaggerMS: placement.StaggerMS, LauncherPane: placement.LauncherPane,
+	}
+}
+
+func fromInternalPlacementPreview(preview internallaunch.PlacementPreview) PlacementPreviewV1 {
+	result := PlacementPreviewV1{
+		Effective: fromInternalPlacement(preview.Effective), Supported: preview.Supported, ReasonCode: preview.ReasonCode,
+	}
+	if preview.Requested != nil {
+		requested := fromInternalPlacement(*preview.Requested)
+		result.Requested = &requested
+	}
+	return result
+}

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -61,6 +61,7 @@ func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, int
 			Session:     request.Target.Session,
 		},
 		Launcher: request.Launcher, IntentDigest: intentDigest, SubjectSchema: internallaunch.SubjectSchemaV2,
+		Placement:    toInternalPlacement(request.Placement),
 		Participants: make([]internallaunch.PrepareParticipant, 0, len(request.Intent.Participants)),
 	}
 	for _, participant := range request.Intent.Participants {
@@ -155,6 +156,8 @@ func fromInternalPrepareResult(result internallaunch.PrepareResult) PrepareResul
 		},
 		Observations: make([]ParticipantObservationV1, 0, len(result.Observations)),
 	}
+	placement := fromInternalPlacementPreview(result.Placement)
+	public.Preview.Placement = &placement
 	for _, action := range result.RequiredActions {
 		allowed := make([]DecisionChoiceV1, len(action.AllowedDecisions))
 		for i, choice := range action.AllowedDecisions {

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -167,6 +167,68 @@ func TestPrepareParticipantOnlyAbsentSessionDoesNotProvision(t *testing.T) {
 	}
 }
 
+func TestPrepareOmittedPlacementExposesLegacyPreview(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Preview.Placement == nil || result.Preview.Placement.Requested != nil || !result.Preview.Placement.Supported {
+		t.Fatalf("omitted placement preview = %#v", result.Preview.Placement)
+	}
+	if result.Preview.Placement.Effective != (PlacementV1{Target: PlacementSession, Layout: PlacementColumns}) {
+		t.Fatalf("commands legacy placement = %#v", result.Preview.Placement.Effective)
+	}
+}
+
+func TestPrepareUnsupportedPlacementIsTypedAndZeroWrite(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	before := snapshotTestTree(t, fixture.root)
+	fixture.request.Placement = &PlacementV1{
+		Target: PlacementCurrentWindow, Layout: PlacementColumns, LauncherPane: "%323",
+	}
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after := snapshotTestTree(t, fixture.root); after != before {
+		t.Fatalf("unsupported placement Prepare changed filesystem: before %s, after %s", before, after)
+	}
+	if result.Outcome != PrepareOutcomeUnsupported || result.Reason != internallaunch.PlacementUnsupportedReason {
+		t.Fatalf("unsupported placement result = %#v", result)
+	}
+	if len(result.RequiredActions) != 0 {
+		t.Fatalf("unsupported placement required actions = %#v", result.RequiredActions)
+	}
+	if result.Preview.Placement == nil || result.Preview.Placement.Supported ||
+		result.Preview.Placement.ReasonCode != internallaunch.PlacementUnsupportedReason ||
+		result.Preview.Placement.Requested == nil || result.Preview.Placement.Requested.LauncherPane != "%323" {
+		t.Fatalf("unsupported placement preview = %#v", result.Preview.Placement)
+	}
+	if result.Preview.Participants[0].PlannedOutcome != "unsupported" {
+		t.Fatalf("planned outcome = %q", result.Preview.Participants[0].PlannedOutcome)
+	}
+}
+
+func TestPrepareExplicitPlacementChangesSubjectDigest(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	omitted, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.request.Placement = &PlacementV1{Target: PlacementSession, Layout: PlacementColumns}
+	explicit, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if explicit.Outcome != PrepareOutcomeUnsupported {
+		t.Fatalf("commands explicit placement outcome = %s", explicit.Outcome)
+	}
+	if omitted.SubjectDigest == explicit.SubjectDigest {
+		t.Fatal("explicit placement left the v2 subject digest unchanged")
+	}
+}
+
 func TestPrepareUnavailableLauncherIsTypedAndDoesNotRequestTrust(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, true)
 	launcher := unavailableManagedLauncher(t)

--- a/launchapi/requests.go
+++ b/launchapi/requests.go
@@ -42,6 +42,11 @@ func (request PrepareRequestV1) Validate() error {
 	if !slices.Contains([]string{"auto", "cmux", "ghostty", "tmux", "commands"}, request.Launcher) {
 		return fmt.Errorf("unsupported launcher %q", request.Launcher)
 	}
+	if request.Placement != nil {
+		if err := request.Placement.Validate(); err != nil {
+			return err
+		}
+	}
 	return request.Intent.Validate()
 }
 

--- a/launchapi/requests_test.go
+++ b/launchapi/requests_test.go
@@ -40,6 +40,17 @@ func TestPublicRequestCodecsRejectUnknownAndMalformedAuthority(t *testing.T) {
 	if _, err := DecodePrepareRequestV1(raw); err == nil || !strings.Contains(err.Error(), "clean absolute") {
 		t.Fatalf("relative project root error = %v", err)
 	}
+
+	prepare.Target.ProjectRoot = root
+	prepare.Placement = &PlacementV1{Target: PlacementSession, Layout: PlacementColumns, LauncherPane: "%1"}
+	raw, _ = json.Marshal(prepare)
+	if _, err := DecodePrepareRequestV1(raw); err == nil || !strings.Contains(err.Error(), "launcher_pane") {
+		t.Fatalf("session launcher_pane error = %v", err)
+	}
+	hostilePlacement := strings.Replace(string(raw), `"launcher_pane":"%1"`, `"launcher_pane":"%1","window":"@1"`, 1)
+	if _, err := DecodePrepareRequestV1([]byte(hostilePlacement)); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("hostile placement error = %v", err)
+	}
 }
 
 func TestApplyRequestV1RejectsDigestAndDecisionReplayShapes(t *testing.T) {

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -25,7 +25,7 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 	for _, name := range []string{
 		"LaunchIntentV1", "ParticipantV1", "WorkingDirectoryV1", "ExecutionOptionsV1",
 		"WakeOptionsV1", "InjectorOptionsV1", "IntegrationsV1", "SymphonyOptionsV1",
-		"TargetV1", "PrepareRequestV1", "PrepareResultV1", "ApplyRequestV1", "ApplyResultV1",
+		"TargetV1", "PlacementV1", "PlacementPreviewV1", "PrepareRequestV1", "PrepareResultV1", "ApplyRequestV1", "ApplyResultV1",
 		"InitialInputV1", "ConfigOverrideCapabilityV1", "ProviderCapabilitiesV1",
 		"DecisionV1", "ParticipantObservationV1", "CompatibilityV1", "RequirementV1", "NegotiatedV1",
 		"InspectRequestV1", "FocusRequestV1", "CloseRequestV1",
@@ -43,6 +43,9 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 	}
 
 	assertSchemaPropertiesMatchType(t, defs, "LaunchIntentV1", reflect.TypeFor[LaunchIntentV1]())
+	assertSchemaPropertiesMatchType(t, defs, "PrepareRequestV1", reflect.TypeFor[PrepareRequestV1]())
+	assertSchemaPropertiesMatchType(t, defs, "PlacementV1", reflect.TypeFor[PlacementV1]())
+	assertSchemaPropertiesMatchType(t, defs, "PlacementPreviewV1", reflect.TypeFor[PlacementPreviewV1]())
 	assertSchemaPropertiesMatchType(t, defs, "PreviewV1", reflect.TypeFor[PreviewV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ConfigOverrideCapabilityV1", reflect.TypeFor[ConfigOverrideCapabilityV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ProviderCapabilitiesV1", reflect.TypeFor[ProviderCapabilitiesV1]())

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -119,10 +119,38 @@ type TargetV1 struct {
 	Session     string `json:"session"`
 }
 
+type PlacementTargetV1 string
+type PlacementLayoutV1 string
+
+const (
+	PlacementCurrentWindow PlacementTargetV1 = "current_window"
+	PlacementNewWindow     PlacementTargetV1 = "new_window"
+	PlacementSession       PlacementTargetV1 = "session"
+
+	PlacementColumns PlacementLayoutV1 = "columns"
+	PlacementRows    PlacementLayoutV1 = "rows"
+	PlacementTiled   PlacementLayoutV1 = "tiled"
+)
+
+type PlacementV1 struct {
+	Target       PlacementTargetV1 `json:"target"`
+	Layout       PlacementLayoutV1 `json:"layout"`
+	StaggerMS    int               `json:"stagger_ms,omitempty"`
+	LauncherPane string            `json:"launcher_pane,omitempty"`
+}
+
+type PlacementPreviewV1 struct {
+	Requested  *PlacementV1 `json:"requested,omitempty"`
+	Effective  PlacementV1  `json:"effective"`
+	Supported  bool         `json:"supported"`
+	ReasonCode string       `json:"reason_code,omitempty"`
+}
+
 type PrepareRequestV1 struct {
 	RequestVersion int            `json:"request_version"`
 	Target         TargetV1       `json:"target"`
 	Launcher       string         `json:"launcher"`
+	Placement      *PlacementV1   `json:"placement,omitempty"`
 	Intent         LaunchIntentV1 `json:"intent"`
 }
 
@@ -186,6 +214,7 @@ type PreviewV1 struct {
 	Participants []ParticipantPreviewV1   `json:"participants"`
 	Roster       RosterDriftV1            `json:"roster"`
 	Capabilities []ProviderCapabilitiesV1 `json:"capabilities"`
+	Placement    *PlacementPreviewV1      `json:"placement,omitempty"`
 }
 
 type InitialInputKindV1 string

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -170,6 +170,28 @@
         "session": {"type": "string", "pattern": "^[a-z0-9_][a-z0-9_-]*$"}
       }
     },
+    "PlacementV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "layout"],
+      "properties": {
+        "target": {"enum": ["current_window", "new_window", "session"]},
+        "layout": {"enum": ["columns", "rows", "tiled"]},
+        "stagger_ms": {"type": "integer", "minimum": 0, "maximum": 60000},
+        "launcher_pane": {"type": "string", "minLength": 1, "maxLength": 256}
+      }
+    },
+    "PlacementPreviewV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["effective", "supported"],
+      "properties": {
+        "requested": {"$ref": "#/$defs/PlacementV1"},
+        "effective": {"$ref": "#/$defs/PlacementV1"},
+        "supported": {"type": "boolean"},
+        "reason_code": {"type": "string", "minLength": 1}
+      }
+    },
     "PrepareRequestV1": {
       "type": "object",
       "additionalProperties": false,
@@ -178,6 +200,7 @@
         "request_version": {"const": 1},
         "target": {"$ref": "#/$defs/TargetV1"},
         "launcher": {"type": "string", "minLength": 1},
+        "placement": {"$ref": "#/$defs/PlacementV1"},
         "intent": {"$ref": "#/$defs/LaunchIntentV1"}
       }
     },
@@ -244,7 +267,8 @@
         "profile": {"type": "string"},
         "participants": {"type": "array", "items": {"$ref": "#/$defs/ParticipantPreviewV1"}},
         "roster": {"$ref": "#/$defs/RosterDriftV1"},
-        "capabilities": {"type": "array", "items": {"$ref": "#/$defs/ProviderCapabilitiesV1"}}
+        "capabilities": {"type": "array", "items": {"$ref": "#/$defs/ProviderCapabilitiesV1"}},
+        "placement": {"$ref": "#/$defs/PlacementPreviewV1"}
       }
     },
     "ConfigOverrideCapabilityV1": {


### PR DESCRIPTION
## Summary

- Public `PlacementV1` / `PlacementPreviewV1` on Prepare/Preview. `FeaturePlacement` is advertised with `initial_input`. Unsupported tuples return `placement_unsupported` with an empty plan and zero planned backend mutation.
- Schema v2 digest includes placement; schema v1 rejects explicit placement. v0.61 Apply stays subject-stable. Apply copies the requested Placement onto `ReconcileRequest`/`CreateRequest`.
- `amq launch --plan` accepts `--placement` JSON. Trailing extra JSON values and a visited empty/whitespace `--placement` are usage errors (Codex OBJECT `1db264e3`).

## Test plan

- [ ] `go test ./launchapi ./internal/launch ./internal/cli -count=1`
- [ ] `TestPublicLaunchPlacementRejectsTrailingJSON` and empty `--placement` refusals
- [ ] unsupported tuple (`current_window` + `%323` + `commands`) → `placement_unsupported`, no binding
- [ ] omitted `--placement` keeps v0.61 backend defaults

BEGIN_COMMIT_OVERRIDE
feat(launchapi): add typed placement with negotiation and preview

fix(cli): reject trailing JSON on launch --placement
END_COMMIT_OVERRIDE

Made with [Cursor](https://cursor.com)