### PR TITLE
feat(launchapi): add base_root authority with planned base creation

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -21,8 +21,8 @@ if err != nil {
 _ = negotiated
 ```
 
-A `0.61.1` binary advertises `placement` and `initial_input` and can still omit
-later Wave B3 feature IDs while those beads are incomplete. A caller must
+A `0.61.1` binary advertises `placement`, `initial_input`, and `base_root` and
+can still omit later Wave B3 feature IDs while those beads are incomplete. A caller must
 require every feature it uses. Contract semver alone does not claim that an
 unadvertised feature is available.
 
@@ -141,12 +141,23 @@ realize returns `outcome: unsupported` and `reason: placement_unsupported`
 with zero planned backend mutation. Subject schema 2 binds that preview into
 `subject_digest`; schema 1 rejects an explicit placement field.
 
+Omitted `TargetV1.base_root` preserves the v0.61 exact-root behavior. When it
+is present, only the exact `project_root/.amqrc` authorizes it: the value must
+be the configured root or one direct child, and `session_root` must be the
+direct child named by `session`. Prepare does not create directories. A missing
+authorized base appears as a deterministic `create_base_root` entry in
+`planned_writes`; Apply revalidates the config and parent identity, then creates
+the base and session exclusively with mode `0700`. Siblings, nested roots,
+symlinks, alternate spellings, or changed authority return a typed refusal with
+no launch mutation.
+
 ```go
 request := launchapi.PrepareRequestV1{
 	RequestVersion: launchapi.RequestVersionV1,
 	Target: launchapi.TargetV1{
 		ProjectRoot: "/workspace/project",
-		SessionRoot: "/workspace/project/.agent-mail/collab",
+		BaseRoot:    "/workspace/project/.agent-mail/profile-a",
+		SessionRoot: "/workspace/project/.agent-mail/profile-a/collab",
 		Session:     "collab",
 	},
 	Launcher: "tmux",

--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -364,6 +364,9 @@ func provisionCoopSessionChild(base, session string, agents []string, execAgent,
 			sessionRoot, err = baseRoot.OpenOrCreateDirectChild(session, 0o700)
 		}
 		if err != nil {
+			if sessionRoot != nil {
+				_ = sessionRoot.Close()
+			}
 			if exclusive {
 				var exists *fsq.DirectChildExistsError
 				if errors.As(err, &exists) {

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -116,16 +117,47 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 	})
 
 	t.Run("finding1_missing_profile_base_root", func(t *testing.T) {
-		fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail/squad-v2-29-4", "v2-29-6")
-		intent := fx.legalSquadIntent()
-		stdout, stderr, exit := fx.prepare(t, intent, launch.LauncherCommands)
-		if exit == 0 {
-			t.Fatalf("missing profile base root succeeded: stdout=%s stderr=%s", stdout, stderr)
+		fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "v2-29-6")
+		intent := launchapi.LaunchIntentV1{
+			IntentVersion: launchapi.IntentVersionV1,
+			Participants:  []launchapi.ParticipantV1{{Handle: "user", Runnable: false}},
 		}
-		combined := string(stdout) + string(stderr)
-		if !strings.Contains(combined, "squad-v2-29-4") && !strings.Contains(combined, "no such file") &&
-			!strings.Contains(combined, "stat delivery root") && !strings.Contains(combined, "not found") {
-			t.Fatalf("missing profile refusal = exit %d stdout=%s stderr=%s", exit, stdout, stderr)
+		baseRoot := filepath.Join(fx.project, ".agent-mail", "squad-v2-29-4")
+		sessionRoot := filepath.Join(baseRoot, fx.session)
+		request := launchapi.PrepareRequestV1{
+			RequestVersion: launchapi.RequestVersionV1,
+			Target: launchapi.TargetV1{
+				ProjectRoot: fx.project, BaseRoot: baseRoot, SessionRoot: sessionRoot, Session: fx.session,
+			},
+			Launcher: launch.LauncherCommands, Intent: intent,
+		}
+		prepared, err := launchapi.Prepare(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(prepared.PlannedWrites) != 1 || prepared.PlannedWrites[0].Kind != launchapi.PlannedWriteCreateBaseRoot || prepared.PlannedWrites[0].Path != baseRoot {
+			t.Fatalf("base-root planned writes = %#v", prepared.PlannedWrites)
+		}
+		if _, err := os.Lstat(baseRoot); !os.IsNotExist(err) {
+			t.Fatalf("Prepare created base root: %v", err)
+		}
+
+		applyPath := writeApplyRequestE2E(t, request, prepared)
+		stdout, stderr, exit := runRealAMQWithExit(t, fx.amqBinary, fx.project, fx.env,
+			"launch", "--apply", applyPath, "--json")
+		if exit != 0 {
+			t.Fatalf("base-root Apply exit=%d stdout=%s stderr=%s", exit, stdout, stderr)
+		}
+		var applied launchapi.ApplyResultV1
+		decodeRealLaunchJSON(t, stdout, &applied)
+		if applied.Outcome != "provisioned_no_runnable" {
+			t.Fatalf("base-root Apply = %#v", applied)
+		}
+		for _, path := range []string{baseRoot, sessionRoot} {
+			info, err := os.Stat(path)
+			if err != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+				t.Fatalf("created %s: info=%v err=%v", path, info, err)
+			}
 		}
 	})
 

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -202,7 +202,17 @@ func (r *DeliveryRoot) CreateDirectChildExclusive(name string, perm os.FileMode)
 	if !before.IsDir() || before.Mode()&os.ModeSymlink != 0 {
 		return nil, fmt.Errorf("%q is not a direct directory under delivery root", name)
 	}
-	return r.pinDirectChild(name, before)
+	child, err := r.pinDirectChild(name, before)
+	if err != nil {
+		return nil, err
+	}
+	if err := child.SyncDir("."); err != nil {
+		return child, &CommittedDurabilityError{FinalPath: child.Base(), Err: err}
+	}
+	if err := r.SyncDir("."); err != nil {
+		return child, &CommittedDurabilityError{FinalPath: child.Base(), Err: err}
+	}
+	return child, nil
 }
 
 // PublishInitializedDirectChildExclusive builds a direct child under a hidden

--- a/internal/fsq/delivery_root_child_test.go
+++ b/internal/fsq/delivery_root_child_test.go
@@ -160,6 +160,34 @@ func TestCreateDirectChildExclusiveRaceIsLoud(t *testing.T) {
 	}
 }
 
+func TestCreateDirectChildExclusiveReportsCommittedDurabilityFailure(t *testing.T) {
+	base := t.TempDir()
+	identity, err := SnapshotDeliveryRoot(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := OpenDeliveryRoot(base, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	failure := errors.New("sync parent failed")
+	root.syncDirForTest = func(string) error { return failure }
+	child, err := root.CreateDirectChildExclusive("profile-a", 0o700)
+	if child == nil {
+		t.Fatal("committed child capability is missing")
+	}
+	defer func() { _ = child.Close() }()
+	var committed *CommittedDurabilityError
+	if !errors.As(err, &committed) || !errors.Is(err, failure) {
+		t.Fatalf("CreateDirectChildExclusive error = %v", err)
+	}
+	info, statErr := os.Stat(filepath.Join(root.Base(), "profile-a"))
+	if statErr != nil || !info.IsDir() {
+		t.Fatalf("committed child is not visible: info=%v err=%v", info, statErr)
+	}
+}
+
 func TestPublishInitializedDirectChildExclusiveIsAllOrNothing(t *testing.T) {
 	base := t.TempDir()
 	root := openDeliveryRootForTest(t, base)

--- a/internal/fsq/tree_identity.go
+++ b/internal/fsq/tree_identity.go
@@ -27,6 +27,15 @@ func StableTreeIdentity(path string) (string, error) {
 	return platformStableTreeIdentity(abs, info)
 }
 
+// StableFileIdentityInfo returns the opaque identity for an already opened
+// regular-file snapshot.
+func StableFileIdentityInfo(info os.FileInfo) (string, error) {
+	if info == nil || !info.Mode().IsRegular() {
+		return "", fmt.Errorf("file identity requires a regular file snapshot")
+	}
+	return platformStableTreeIdentity("", info)
+}
+
 // StableTreeIdentityInfo returns the same token from an already authorized
 // filesystem snapshot.
 func StableTreeIdentityInfo(info os.FileInfo) (string, error) {

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -57,6 +57,8 @@ type ApplyResult struct {
 var afterApplySessionPublishedForTest func()
 var beforeApplySessionPublishForTest func()
 var beforeApplyRosterMutationForTest func()
+var beforeApplyBaseRootCreateForTest func()
+var afterApplyBaseRootCreatedForTest func() error
 var publishApplySession = func(base *fsq.DeliveryRoot, session string, initialize func(*fsq.DeliveryRoot) error) (*fsq.DeliveryRoot, error) {
 	return base.PublishInitializedDirectChildExclusive(session, 0o700, initialize)
 }
@@ -85,6 +87,9 @@ func Apply(ctx context.Context, request ApplyRequest, dependencies ApplyDependen
 	}
 	defer state.close()
 
+	if state.baseRoot == nil {
+		return applyMissingBaseRoot(ctx, request, dependencies, state)
+	}
 	if state.sessionRoot == nil {
 		err = WithSessionCreationLock(state.baseRoot, state.target.Session, func() error {
 			result, err = applyUnderAuthority(ctx, request, dependencies, state, nil)
@@ -112,21 +117,33 @@ func Apply(ctx context.Context, request ApplyRequest, dependencies ApplyDependen
 }
 
 func applyUnderAuthority(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies, state *prepareTargetState, lease *Lease) (result ApplyResult, returnErr error) {
+	prepared, decisions, refusal, allowed, err := authorizeApply(ctx, request, dependencies)
+	if err != nil || !allowed {
+		return refusal, err
+	}
+	return applyPreparedUnderAuthority(ctx, request, dependencies, state, lease, prepared, decisions)
+}
+
+func authorizeApply(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies) (PrepareResult, map[RequiredActionKind]string, ApplyResult, bool, error) {
 	prepared, err := Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
 	if err != nil {
-		return ApplyResult{}, err
+		return PrepareResult{}, nil, ApplyResult{}, false, err
 	}
 	if prepared.SubjectDigest != request.SubjectDigest {
-		return applyActionResult(prepared, "subject_changed"), nil
+		return prepared, nil, applyActionResult(prepared, "subject_changed"), false, nil
 	}
 	if prepared.Outcome == PrepareOutcomeUnsupported {
-		return applyActionResult(prepared, prepared.Reason), nil
+		return prepared, nil, applyActionResult(prepared, prepared.Reason), false, nil
 	}
 	decisions, reason := validateApplyDecisions(prepared.RequiredActions, request.Decisions)
 	if reason != "" {
-		return applyActionResult(prepared, reason), nil
+		return prepared, nil, applyActionResult(prepared, reason), false, nil
 	}
+	return prepared, decisions, ApplyResult{}, true, nil
+}
 
+func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies, state *prepareTargetState, lease *Lease, prepared PrepareResult, decisions map[RequiredActionKind]string) (result ApplyResult, returnErr error) {
+	var err error
 	handles := make([]string, 0, len(request.Prepare.Participants))
 	for _, participant := range request.Prepare.Participants {
 		handles = append(handles, participant.Handle)
@@ -250,6 +267,46 @@ func applyUnderAuthority(ctx context.Context, request ApplyRequest, dependencies
 		result.FailureDetail = reconciled.Reason
 	}
 	return result, nil
+}
+
+func applyMissingBaseRoot(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies, state *prepareTargetState) (result ApplyResult, returnErr error) {
+	if state.baseAuthority == nil || !state.baseAuthority.baseMissing || state.baseAuthority.parentRoot == nil {
+		return ApplyResult{}, fmt.Errorf("missing base-root creation authority")
+	}
+	prepared, decisions, refusal, allowed, err := authorizeApply(ctx, request, dependencies)
+	if err != nil || !allowed {
+		return refusal, err
+	}
+	if beforeApplyBaseRootCreateForTest != nil {
+		beforeApplyBaseRootCreateForTest()
+	}
+	if err := state.verify(); err != nil {
+		return applyActionResult(prepared, "subject_changed"), nil
+	}
+	baseRoot, err := state.baseAuthority.parentRoot.CreateDirectChildExclusive(state.baseAuthority.baseName, 0o700)
+	if err != nil {
+		var committed *fsq.CommittedDurabilityError
+		if errors.As(err, &committed) && baseRoot != nil {
+			state.baseRoot = baseRoot
+			return applyActionResult(prepared, "base_root_creation_durability_uncertain"), nil
+		}
+		var exists *fsq.DirectChildExistsError
+		if errors.As(err, &exists) {
+			return applyActionResult(prepared, "subject_changed"), nil
+		}
+		return ApplyResult{}, err
+	}
+	state.baseRoot = baseRoot
+	if afterApplyBaseRootCreatedForTest != nil {
+		if err := afterApplyBaseRootCreatedForTest(); err != nil {
+			return ApplyResult{}, err
+		}
+	}
+	err = WithSessionCreationLock(baseRoot, state.target.Session, func() error {
+		result, err = applyPreparedUnderAuthority(ctx, request, dependencies, state, nil, prepared, decisions)
+		return err
+	})
+	return result, err
 }
 
 func applyReconcileReasonCode(result ReconcileResult) string {
@@ -467,7 +524,8 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		AMQPath: dependencies.AMQPath, Root: root, Config: config, Launcher: prepared.Launcher,
 		Preferences: slices.Clone(dependencies.Preferences), Backends: dependencies.Backends,
 		Adapters: adapters, TrustStore: dependencies.TrustStore, HeldLease: lease,
-		HostIdentity: dependencies.HostIdentity, AllowExternalCwd: true,
+		TrustAuthorityDigest: snapshot.BaseAuthorityDigest,
+		HostIdentity:         dependencies.HostIdentity, AllowExternalCwd: true,
 		ExecutionOptions:   executionOptions,
 		AllowFreshFallback: decisions[ActionStaleConversation] == "fresh_once",
 		Placement:          prepared.Placement,
@@ -485,8 +543,8 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 			if err != nil {
 				return false, err
 			}
-			authorizedTrustDigest, err := PrepareTrustDigest(
-				trustPlanDigest, prepared.Target.Session, prepared.Target.SessionRoot, authorizedRootIdentity,
+			authorizedTrustDigest, err := PrepareTrustDigestWithAuthority(
+				trustPlanDigest, prepared.Target.Session, prepared.Target.SessionRoot, authorizedRootIdentity, snapshot.BaseAuthorityDigest,
 			)
 			if err != nil {
 				return false, err
@@ -494,7 +552,7 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 			if authorizedTrustDigest != snapshot.TrustDigest {
 				return false, fmt.Errorf("authorized trust subject changed after Apply authorization")
 			}
-			expectedActual, err := ExecutionTrustDigest(plan, prepared.Target.Session, root)
+			expectedActual, err := ExecutionTrustDigestWithAuthority(plan, prepared.Target.Session, root, snapshot.BaseAuthorityDigest)
 			if err != nil {
 				return false, err
 			}

--- a/internal/launch/apply_test.go
+++ b/internal/launch/apply_test.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -11,6 +12,170 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 )
+
+func TestApplyRejectsBaseRootAuthorityDriftBeforeCreation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(t *testing.T, project, configuredRoot string, configBytes []byte)
+	}{
+		{
+			name: "project config identity replacement",
+			mutate: func(t *testing.T, project, _ string, configBytes []byte) {
+				replacement := filepath.Join(project, ".amqrc.next")
+				if err := os.WriteFile(replacement, configBytes, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Rename(replacement, filepath.Join(project, ".amqrc")); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "base parent identity replacement",
+			mutate: func(t *testing.T, _ string, configuredRoot string, _ []byte) {
+				old := configuredRoot + ".old"
+				if err := os.Rename(configuredRoot, old); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(configuredRoot, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			project := filepath.Join(root, "project")
+			configuredRoot := filepath.Join(root, "configured")
+			for _, path := range []string{project, configuredRoot} {
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			configBytes, err := json.Marshal(map[string]string{"root": configuredRoot})
+			if err != nil {
+				t.Fatal(err)
+			}
+			configBytes = append(configBytes, '\n')
+			if err := os.WriteFile(filepath.Join(project, ".amqrc"), configBytes, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			profileRoot := filepath.Join(configuredRoot, "profile-a")
+			sessionRoot := filepath.Join(profileRoot, "collab")
+			request := ApplyRequest{Prepare: PrepareRequest{
+				Target:   PrepareTarget{ProjectRoot: project, BaseRoot: profileRoot, SessionRoot: sessionRoot, Session: "collab"},
+				Launcher: LauncherCommands, IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'d'}, 64)),
+				Participants: []PrepareParticipant{{Handle: "operator", Runnable: false}},
+			}}
+			dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+				Backends: map[string]Backend{LauncherCommands: &prepareTestBackend{}},
+				AdapterFor: func(provider, executable string) HarnessAdapter {
+					return prepareTestAdapter{provider: provider}
+				},
+				HostIdentity: "host:test",
+			}}
+			prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request.SubjectDigest = prepared.SubjectDigest
+			request.Decisions = []ApplyDecision{}
+			beforeApplyBaseRootCreateForTest = func() { test.mutate(t, project, configuredRoot, configBytes) }
+			t.Cleanup(func() { beforeApplyBaseRootCreateForTest = nil })
+
+			result, err := Apply(context.Background(), request, dependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "subject_changed" {
+				t.Fatalf("Apply drift result = %#v", result)
+			}
+			if _, err := os.Lstat(profileRoot); !os.IsNotExist(err) {
+				t.Fatalf("authority drift created profile root: %v", err)
+			}
+			if _, err := os.Lstat(sessionRoot); !os.IsNotExist(err) {
+				t.Fatalf("authority drift created session root: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyRestartsAfterBaseCreationBeforeSessionPublication(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := filepath.Join(root, "project")
+	configuredRoot := filepath.Join(root, "configured")
+	for _, path := range []string{project, configuredRoot} {
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	configBytes, err := json.Marshal(map[string]string{"root": configuredRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), append(configBytes, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profileRoot := filepath.Join(configuredRoot, "profile-a")
+	sessionRoot := filepath.Join(profileRoot, "collab")
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, BaseRoot: profileRoot, SessionRoot: sessionRoot, Session: "collab"},
+		Launcher: LauncherCommands, IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'e'}, 64)),
+		Participants: []PrepareParticipant{{Handle: "operator", Runnable: false}},
+	}}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends: map[string]Backend{LauncherCommands: &prepareTestBackend{}},
+		AdapterFor: func(provider, executable string) HarnessAdapter {
+			return prepareTestAdapter{provider: provider}
+		},
+		HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	request.Decisions = []ApplyDecision{}
+	crash := errors.New("crash after base creation")
+	afterApplyBaseRootCreatedForTest = func() error { return crash }
+	_, err = Apply(context.Background(), request, dependencies)
+	if !errors.Is(err, crash) {
+		t.Fatalf("Apply crash error = %v", err)
+	}
+	afterApplyBaseRootCreatedForTest = nil
+	t.Cleanup(func() { afterApplyBaseRootCreatedForTest = nil })
+	if info, err := os.Stat(profileRoot); err != nil || !info.IsDir() {
+		t.Fatalf("base root not committed before crash: info=%v err=%v", info, err)
+	}
+	if _, err := os.Stat(sessionRoot); !os.IsNotExist(err) {
+		t.Fatalf("session published before injected crash: %v", err)
+	}
+
+	reprepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reprepared.PlannedWrites) != 0 {
+		t.Fatalf("restart still planned existing base root: %#v", reprepared.PlannedWrites)
+	}
+	request.SubjectDigest = reprepared.SubjectDigest
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeProvisionedNoRunnable {
+		t.Fatalf("restart Apply result = %#v", result)
+	}
+	if info, err := os.Stat(sessionRoot); err != nil || !info.IsDir() {
+		t.Fatalf("restart did not publish session: info=%v err=%v", info, err)
+	}
+}
 
 type applyUnavailableAdapter struct{ prepareTestAdapter }
 

--- a/internal/launch/base_root.go
+++ b/internal/launch/base_root.go
@@ -1,0 +1,286 @@
+package launch
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	baseRootUnauthorized    = "base_root_unauthorized"
+	baseRootRelationInvalid = "base_root_relation_invalid"
+)
+
+type projectAMQRC struct {
+	Root    string            `json:"root"`
+	Project string            `json:"project,omitempty"`
+	Peers   map[string]string `json:"peers,omitempty"`
+}
+
+type explicitBaseAuthority struct {
+	configBytes     []byte
+	configIdentity  string
+	configSHA256    string
+	configuredRoot  string
+	parentIdentity  string
+	authorityDigest string
+	baseName        string
+	baseMissing     bool
+	parentRoot      *fsq.DeliveryRoot
+}
+
+func openExplicitBaseAuthority(projectRoot *fsq.DeliveryRoot, target PrepareTarget) (*explicitBaseAuthority, *fsq.DeliveryRoot, error) {
+	config, configBytes, configIdentity, configSHA256, err := readExactProjectAMQRC(projectRoot)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", baseRootUnauthorized, err)
+	}
+	configuredRoot, err := configuredBasePath(projectRoot.Base(), config.Root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", baseRootUnauthorized, err)
+	}
+	if target.BaseRoot != configuredRoot && filepath.Dir(target.BaseRoot) != configuredRoot {
+		return nil, nil, fmt.Errorf("%s: base_root must be the configured root or one direct child", baseRootUnauthorized)
+	}
+	if filepath.Dir(target.SessionRoot) != target.BaseRoot || filepath.Base(target.SessionRoot) != target.Session {
+		return nil, nil, fmt.Errorf("%s: session_root must be the direct child named %q", baseRootRelationInvalid, target.Session)
+	}
+
+	configured, configuredExists, err := openCanonicalDirectoryIfPresent(configuredRoot)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: configured root: %w", baseRootRelationInvalid, err)
+	}
+	var parentRoot, baseRoot *fsq.DeliveryRoot
+	baseName := filepath.Base(target.BaseRoot)
+	baseMissing := false
+	switch {
+	case configuredExists && target.BaseRoot == configuredRoot:
+		baseRoot = configured
+		parentRoot, err = openCanonicalDirectory(filepath.Dir(configuredRoot))
+	case configuredExists:
+		parentRoot = configured
+		baseRoot, err = parentRoot.OpenDirectChild(baseName)
+		if errors.Is(err, os.ErrNotExist) {
+			err = nil
+			baseMissing = true
+		} else if err == nil {
+			exact, exactErr := hasExactDirectChildName(parentRoot, baseName)
+			if exactErr != nil {
+				err = exactErr
+			} else if !exact {
+				err = fmt.Errorf("base_root uses an alternate direct-child spelling")
+			}
+		}
+	case target.BaseRoot != configuredRoot:
+		return nil, nil, fmt.Errorf("%s: configured root must exist before creating a profile child", baseRootUnauthorized)
+	default:
+		parentRoot, err = openCanonicalDirectory(filepath.Dir(configuredRoot))
+		baseMissing = true
+	}
+	if err != nil {
+		if baseRoot != nil {
+			_ = baseRoot.Close()
+		}
+		if configured != nil && configured != parentRoot && configured != baseRoot {
+			_ = configured.Close()
+		}
+		if parentRoot != nil && parentRoot != configured {
+			_ = parentRoot.Close()
+		}
+		return nil, nil, fmt.Errorf("%s: open base authority: %w", baseRootRelationInvalid, err)
+	}
+	if baseRoot != nil && baseRoot.Base() != target.BaseRoot {
+		_ = baseRoot.Close()
+		if parentRoot != nil && parentRoot != baseRoot {
+			_ = parentRoot.Close()
+		}
+		return nil, nil, fmt.Errorf("%s: base_root changed after canonicalization", baseRootRelationInvalid)
+	}
+	parentIdentity, err := fsq.StableTreeIdentityInfo(parentRoot.FileInfo())
+	if err != nil {
+		if baseRoot != nil {
+			_ = baseRoot.Close()
+		}
+		_ = parentRoot.Close()
+		return nil, nil, err
+	}
+	authorityDigest, err := digestCanonical(struct {
+		ConfigIdentity string `json:"config_identity"`
+		ConfigSHA256   string `json:"config_sha256"`
+		ConfiguredRoot string `json:"configured_root"`
+		BaseRoot       string `json:"base_root"`
+		ParentIdentity string `json:"parent_identity"`
+	}{configIdentity, configSHA256, configuredRoot, target.BaseRoot, parentIdentity})
+	if err != nil {
+		if baseRoot != nil {
+			_ = baseRoot.Close()
+		}
+		_ = parentRoot.Close()
+		return nil, nil, err
+	}
+	return &explicitBaseAuthority{
+		configBytes: configBytes, configIdentity: configIdentity, configSHA256: configSHA256,
+		configuredRoot: configuredRoot, parentIdentity: parentIdentity, authorityDigest: authorityDigest,
+		baseName: baseName, baseMissing: baseMissing, parentRoot: parentRoot,
+	}, baseRoot, nil
+}
+
+func readExactProjectAMQRC(projectRoot *fsq.DeliveryRoot) (projectAMQRC, []byte, string, string, error) {
+	file, info, err := projectRoot.OpenRegularNoFollow(".amqrc")
+	if err != nil {
+		return projectAMQRC{}, nil, "", "", err
+	}
+	defer func() { _ = file.Close() }()
+	if err := validateExactAMQRCFileInfo(info); err != nil {
+		return projectAMQRC{}, nil, "", "", err
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return projectAMQRC{}, nil, "", "", err
+	}
+	identity, err := fsq.StableFileIdentityInfo(info)
+	if err != nil {
+		return projectAMQRC{}, nil, "", "", err
+	}
+	var config projectAMQRC
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&config); err != nil {
+		return projectAMQRC{}, nil, "", "", fmt.Errorf("strict decode .amqrc: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return projectAMQRC{}, nil, "", "", fmt.Errorf("strict decode .amqrc: trailing content")
+	}
+	if strings.TrimSpace(config.Root) == "" {
+		return projectAMQRC{}, nil, "", "", fmt.Errorf(".amqrc root is required")
+	}
+	sum := sha256.Sum256(data)
+	return config, data, identity, "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func configuredBasePath(projectRoot, configured string) (string, error) {
+	if strings.ContainsRune(configured, 0) || filepath.Clean(configured) != configured || configured == "." {
+		return "", fmt.Errorf(".amqrc root must be a clean path")
+	}
+	if !filepath.IsAbs(configured) {
+		for _, element := range strings.Split(filepath.ToSlash(configured), "/") {
+			if element == "" || element == ".." || element == "." {
+				return "", fmt.Errorf(".amqrc root contains an unsafe path element")
+			}
+		}
+		configured = filepath.Join(projectRoot, configured)
+	}
+	if !filepath.IsAbs(configured) || filepath.Clean(configured) != configured {
+		return "", fmt.Errorf("resolved .amqrc root must be a clean absolute path")
+	}
+	return configured, nil
+}
+
+func openCanonicalDirectory(path string) (*fsq.DeliveryRoot, error) {
+	root, exists, err := openCanonicalDirectoryIfPresent(path)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, os.ErrNotExist
+	}
+	return root, nil
+}
+
+func openCanonicalDirectoryIfPresent(path string) (*fsq.DeliveryRoot, bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, false, fmt.Errorf("not a direct directory")
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, false, err
+	}
+	if resolved != path {
+		return nil, false, fmt.Errorf("path traverses a symlink or uses an alternate spelling")
+	}
+	snapshot, err := fsq.SnapshotDeliveryRoot(path)
+	if err != nil {
+		return nil, false, err
+	}
+	root, err := fsq.OpenDeliveryRoot(path, snapshot)
+	return root, err == nil, err
+}
+
+func hasExactDirectChildName(root *fsq.DeliveryRoot, name string) (bool, error) {
+	entries, err := root.ReadDir(".")
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if entry.Name() == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (authority *explicitBaseAuthority) close() {
+	if authority != nil && authority.parentRoot != nil {
+		_ = authority.parentRoot.Close()
+	}
+}
+
+func (authority *explicitBaseAuthority) verify(projectRoot *fsq.DeliveryRoot, baseRoot *fsq.DeliveryRoot) error {
+	_, data, identity, digest, err := readExactProjectAMQRC(projectRoot)
+	if err != nil {
+		return err
+	}
+	if identity != authority.configIdentity || digest != authority.configSHA256 || !bytes.Equal(data, authority.configBytes) {
+		return fmt.Errorf("project .amqrc changed")
+	}
+	if err := authority.parentRoot.VerifyBase(); err != nil {
+		return fmt.Errorf("base parent changed: %w", err)
+	}
+	parentIdentity, err := fsq.StableTreeIdentityInfo(authority.parentRoot.FileInfo())
+	if err != nil || parentIdentity != authority.parentIdentity {
+		return fmt.Errorf("base parent identity changed")
+	}
+	if authority.baseMissing {
+		child, childErr := authority.parentRoot.OpenDirectChild(authority.baseName)
+		if childErr == nil {
+			_ = child.Close()
+			return fmt.Errorf("base root appeared")
+		}
+		if !errors.Is(childErr, os.ErrNotExist) {
+			return childErr
+		}
+	} else if baseRoot == nil {
+		return fmt.Errorf("base root capability is missing")
+	} else if err := baseRoot.VerifyBase(); err != nil {
+		return fmt.Errorf("base root changed: %w", err)
+	}
+	return nil
+}
+
+func baseRootRefusalReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	for _, reason := range []string{baseRootUnauthorized, baseRootRelationInvalid} {
+		if message == reason || strings.HasPrefix(message, reason+":") {
+			return reason
+		}
+	}
+	return ""
+}

--- a/internal/launch/base_root_security_unix.go
+++ b/internal/launch/base_root_security_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package launch
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func validateExactAMQRCFileInfo(info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf(".amqrc ownership metadata is unavailable")
+	}
+	if uint32(stat.Uid) != uint32(os.Geteuid()) {
+		return fmt.Errorf(".amqrc is owned by uid %d, want euid %d", stat.Uid, os.Geteuid())
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf(".amqrc is group/world-writable")
+	}
+	return nil
+}

--- a/internal/launch/base_root_security_windows.go
+++ b/internal/launch/base_root_security_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package launch
+
+import "os"
+
+func validateExactAMQRCFileInfo(os.FileInfo) error { return nil }

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -58,8 +58,24 @@ const (
 
 type PrepareTarget struct {
 	ProjectRoot string `json:"project_root"`
+	BaseRoot    string `json:"base_root,omitempty"`
 	SessionRoot string `json:"session_root"`
 	Session     string `json:"session"`
+}
+
+type PlannedWriteKind string
+
+const (
+	PlannedWriteCreateBaseRoot PlannedWriteKind = "create_base_root"
+	PlannedWriteInitialInput   PlannedWriteKind = "write_initial_input"
+)
+
+type PlannedWrite struct {
+	WriteID string           `json:"write_id"`
+	Kind    PlannedWriteKind `json:"kind"`
+	Path    string           `json:"path"`
+	Handle  string           `json:"handle,omitempty"`
+	SHA256  string           `json:"sha256,omitempty"`
 }
 
 type PrepareExecutionOptions struct {
@@ -159,20 +175,22 @@ type PrepareObservation struct {
 }
 
 type PrepareResult struct {
-	Outcome         string
-	Reason          string
-	SubjectSchema   int
-	SubjectDigest   string
-	PlanDigest      string
-	TrustDigest     string
-	Target          PrepareTarget
-	Backend         string
-	Profile         string
-	Participants    []PreparedParticipant
-	Roster          PrepareRoster
-	RequiredActions []PrepareRequiredAction
-	Observations    []PrepareObservation
-	Placement       PlacementPreview
+	Outcome             string
+	Reason              string
+	SubjectSchema       int
+	SubjectDigest       string
+	PlanDigest          string
+	TrustDigest         string
+	BaseAuthorityDigest string
+	PlannedWrites       []PlannedWrite
+	Target              PrepareTarget
+	Backend             string
+	Profile             string
+	Participants        []PreparedParticipant
+	Roster              PrepareRoster
+	RequiredActions     []PrepareRequiredAction
+	Observations        []PrepareObservation
+	Placement           PlacementPreview
 }
 
 type prepareTargetState struct {
@@ -183,6 +201,7 @@ type prepareTargetState struct {
 	baseRoot        *fsq.DeliveryRoot
 	sessionRoot     *fsq.DeliveryRoot
 	mailboxConfig   *fsq.MailboxConfigAuthorization
+	baseAuthority   *explicitBaseAuthority
 }
 
 func (state *prepareTargetState) close() {
@@ -198,6 +217,9 @@ func (state *prepareTargetState) close() {
 	if state.baseRoot != nil {
 		_ = state.baseRoot.Close()
 	}
+	if state.baseAuthority != nil {
+		state.baseAuthority.close()
+	}
 	if state.projectRoot != nil {
 		_ = state.projectRoot.Close()
 	}
@@ -212,13 +234,22 @@ func (state *prepareTargetState) verify() error {
 	if err := state.projectRoot.VerifyBase(); err != nil {
 		return fmt.Errorf("project root changed during Prepare: %w", err)
 	}
-	if err := state.baseRoot.VerifyBase(); err != nil {
-		return fmt.Errorf("session base root changed during Prepare: %w", err)
+	if state.baseAuthority != nil {
+		if err := state.baseAuthority.verify(state.projectRoot, state.baseRoot); err != nil {
+			return fmt.Errorf("base-root authority changed during Prepare: %w", err)
+		}
+	} else {
+		if err := state.baseRoot.VerifyBase(); err != nil {
+			return fmt.Errorf("session base root changed during Prepare: %w", err)
+		}
 	}
 	if state.sessionRoot != nil {
 		if err := state.sessionRoot.VerifyBase(); err != nil {
 			return fmt.Errorf("session root changed during Prepare: %w", err)
 		}
+		return nil
+	}
+	if state.baseRoot == nil {
 		return nil
 	}
 	child, err := state.baseRoot.OpenDirectChild(state.target.Session)
@@ -247,6 +278,8 @@ type prepareSubject struct {
 	Target          PrepareTarget             `json:"target"`
 	ProjectIdentity string                    `json:"project_identity"`
 	SessionIdentity string                    `json:"session_identity"`
+	BaseAuthority   string                    `json:"base_authority,omitempty"`
+	PlannedWrites   *[]PlannedWrite           `json:"planned_writes,omitempty"`
 	Backend         string                    `json:"backend"`
 	Profile         string                    `json:"profile"`
 	Detection       DetectResult              `json:"detection"`
@@ -294,6 +327,9 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	dependencies.AMQPath = amqPath
 	state, err := openPrepareTarget(request.Target)
 	if err != nil {
+		if reason := baseRootRefusalReason(err); reason != "" {
+			return prepareBaseRootRefusal(request, subjectSchema, reason)
+		}
 		return PrepareResult{}, err
 	}
 	defer state.close()
@@ -352,6 +388,23 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		Participants: make([]PreparedParticipant, 0, len(request.Participants)),
 		Observations: make([]PrepareObservation, 0, len(request.Participants)+len(roster.Extra)),
 	}
+	baseAuthorityDigest := ""
+	if state.baseAuthority != nil {
+		baseAuthorityDigest = state.baseAuthority.authorityDigest
+		result.BaseAuthorityDigest = baseAuthorityDigest
+		if state.baseAuthority.baseMissing {
+			write := PlannedWrite{Kind: PlannedWriteCreateBaseRoot, Path: state.target.BaseRoot}
+			write.WriteID, err = digestCanonical(struct {
+				Kind      PlannedWriteKind `json:"kind"`
+				Target    PrepareTarget    `json:"target"`
+				Authority string           `json:"authority"`
+			}{write.Kind, state.target, baseAuthorityDigest})
+			if err != nil {
+				return PrepareResult{}, err
+			}
+			result.PlannedWrites = []PlannedWrite{write}
+		}
+	}
 	if detect.Profile.Backend != "" {
 		result.Profile = detect.Profile.Identity()
 	}
@@ -404,7 +457,7 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if err != nil {
 		return PrepareResult{}, err
 	}
-	result.TrustDigest, err = PrepareTrustDigest(trustPlanDigest, state.target.Session, state.target.SessionRoot, state.sessionIdentity)
+	result.TrustDigest, err = PrepareTrustDigestWithAuthority(trustPlanDigest, state.target.Session, state.target.SessionRoot, state.sessionIdentity, baseAuthorityDigest)
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -454,10 +507,16 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	subject := prepareSubject{
 		Version: subjectSchema, IntentDigest: request.IntentDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
 		Target: state.target, ProjectIdentity: state.projectIdentity, SessionIdentity: state.sessionIdentity,
-		Backend: result.Backend, Profile: result.Profile, Detection: detect, Binding: bindingObservation, Roster: result.Roster,
+		BaseAuthority: baseAuthorityDigest,
+		Backend:       result.Backend, Profile: result.Profile, Detection: detect, Binding: bindingObservation, Roster: result.Roster,
 		Actions: result.RequiredActions, Participants: result.Participants, Observations: result.Observations,
 	}
 	if subjectSchema == SubjectSchemaV2 {
+		plannedWrites := slices.Clone(result.PlannedWrites)
+		if plannedWrites == nil {
+			plannedWrites = []PlannedWrite{}
+		}
+		subject.PlannedWrites = &plannedWrites
 		placement := result.Placement
 		subject.Placement = &placement
 	}
@@ -466,6 +525,54 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		return PrepareResult{}, err
 	}
 	return result, nil
+}
+
+func prepareBaseRootRefusal(request PrepareRequest, subjectSchema int, reason string) (PrepareResult, error) {
+	result := PrepareResult{
+		Outcome: PrepareOutcomeUnsupported, Reason: reason, SubjectSchema: subjectSchema,
+		Target: request.Target, Backend: request.Launcher,
+		Participants:  make([]PreparedParticipant, 0, len(request.Participants)),
+		Observations:  make([]PrepareObservation, 0, len(request.Participants)),
+		PlannedWrites: []PlannedWrite{}, RequiredActions: []PrepareRequiredAction{},
+	}
+	for _, participant := range request.Participants {
+		result.Roster.Desired = append(result.Roster.Desired, participant.Handle)
+		result.Roster.Missing = append(result.Roster.Missing, participant.Handle)
+		result.Participants = append(result.Participants, PreparedParticipant{
+			Handle: participant.Handle, Runnable: participant.Runnable, Provider: participant.Provider,
+			ResumePolicy: participant.ResumePolicy, PlannedOutcome: "unsupported",
+		})
+		result.Observations = append(result.Observations, PrepareObservation{
+			Handle: participant.Handle, Mailbox: "unknown", Runnable: participant.Runnable,
+			Conversation: "none", Execution: "none", Resource: "none", ReasonCode: reason,
+		})
+	}
+	slices.Sort(result.Roster.Desired)
+	slices.Sort(result.Roster.Missing)
+	var err error
+	result.PlanDigest, err = digestCanonical(struct {
+		Version int           `json:"version"`
+		Reason  string        `json:"reason"`
+		Target  PrepareTarget `json:"target"`
+		Intent  string        `json:"intent_digest"`
+	}{1, reason, request.Target, request.IntentDigest})
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	result.TrustDigest, err = digestCanonical(struct {
+		Version int           `json:"version"`
+		Reason  string        `json:"reason"`
+		Target  PrepareTarget `json:"target"`
+	}{1, reason, request.Target})
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	result.SubjectDigest, err = digestCanonical(struct {
+		Version int    `json:"version"`
+		Plan    string `json:"plan_digest"`
+		Trust   string `json:"trust_digest"`
+	}{subjectSchema, result.PlanDigest, result.TrustDigest})
+	return result, err
 }
 
 func normalizeSubjectSchema(schema int) (int, error) {
@@ -498,6 +605,56 @@ func openPrepareTarget(target PrepareTarget) (*prepareTargetState, error) {
 	if err != nil {
 		_ = projectRoot.Close()
 		return nil, err
+	}
+
+	if target.BaseRoot != "" {
+		if project != target.ProjectRoot {
+			_ = projectRoot.Close()
+			return nil, fmt.Errorf("%s: project_root must be canonical", baseRootRelationInvalid)
+		}
+		authority, baseRoot, authorityErr := openExplicitBaseAuthority(projectRoot, target)
+		if authorityErr != nil {
+			_ = projectRoot.Close()
+			return nil, authorityErr
+		}
+		state := &prepareTargetState{
+			target:          PrepareTarget{ProjectRoot: project, BaseRoot: target.BaseRoot, SessionRoot: target.SessionRoot, Session: target.Session},
+			projectIdentity: projectIdentity, projectRoot: projectRoot, baseRoot: baseRoot, baseAuthority: authority,
+		}
+		if baseRoot == nil {
+			state.sessionIdentity = "intended-base-child:" + authority.parentIdentity + ":" + authority.baseName + ":" + target.Session
+			return state, nil
+		}
+		sessionRoot, openErr := baseRoot.OpenDirectChild(target.Session)
+		if openErr == nil {
+			exact, exactErr := hasExactDirectChildName(baseRoot, target.Session)
+			if exactErr != nil || !exact {
+				_ = sessionRoot.Close()
+				state.close()
+				if exactErr != nil {
+					return nil, exactErr
+				}
+				return nil, fmt.Errorf("%s: session uses an alternate direct-child spelling", baseRootRelationInvalid)
+			}
+			state.sessionRoot = sessionRoot
+			state.sessionIdentity, openErr = fsq.StableTreeIdentityInfo(sessionRoot.FileInfo())
+			if openErr != nil {
+				state.close()
+				return nil, openErr
+			}
+			return state, nil
+		}
+		if !errors.Is(openErr, os.ErrNotExist) {
+			state.close()
+			return nil, openErr
+		}
+		baseIdentity, identityErr := fsq.StableTreeIdentityInfo(baseRoot.FileInfo())
+		if identityErr != nil {
+			state.close()
+			return nil, identityErr
+		}
+		state.sessionIdentity = "intended-child:" + baseIdentity + ":" + target.Session
+		return state, nil
 	}
 
 	sessionPath := filepath.Clean(target.SessionRoot)

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -47,25 +47,26 @@ type ConfirmTrustFunc func(Plan, string) (bool, error)
 type ConfirmRebindFunc func(BindingRecord, bool) (RebindDisposition, bool, error)
 
 type ReconcileRequest struct {
-	Context            context.Context
-	ProjectRoot        string
-	Session            string
-	AMQPath            string
-	Root               *fsq.DeliveryRoot
-	Config             ProjectConfig
-	Launcher           string
-	Preferences        []string
-	Backends           map[string]Backend
-	Adapters           map[string]HarnessAdapter
-	TrustStore         *TrustStore
-	ConfirmTrust       ConfirmTrustFunc
-	ConfirmRebind      ConfirmRebindFunc
-	Fresh              bool
-	AllowFreshFallback bool
-	ResumeOnly         bool
-	Rebind             bool
-	HostIdentity       string
-	CrashHook          func(string) error
+	Context              context.Context
+	ProjectRoot          string
+	Session              string
+	AMQPath              string
+	Root                 *fsq.DeliveryRoot
+	Config               ProjectConfig
+	Launcher             string
+	Preferences          []string
+	Backends             map[string]Backend
+	Adapters             map[string]HarnessAdapter
+	TrustStore           *TrustStore
+	TrustAuthorityDigest string
+	ConfirmTrust         ConfirmTrustFunc
+	ConfirmRebind        ConfirmRebindFunc
+	Fresh                bool
+	AllowFreshFallback   bool
+	ResumeOnly           bool
+	Rebind               bool
+	HostIdentity         string
+	CrashHook            func(string) error
 	// HeldLease lets Apply retain session authority across its lease-held
 	// re-Prepare, roster provisioning, and the existing reconciliation crash
 	// contract. Reconcile validates but never releases a caller-owned lease.
@@ -187,7 +188,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	if err != nil {
 		return result, err
 	}
-	trustDigest, err := ExecutionTrustDigest(plan, request.Session, request.Root)
+	trustDigest, err := ExecutionTrustDigestWithAuthority(plan, request.Session, request.Root, request.TrustAuthorityDigest)
 	if err != nil {
 		return result, err
 	}

--- a/internal/launch/trust.go
+++ b/internal/launch/trust.go
@@ -43,6 +43,10 @@ type ArbitraryCommandGrant struct {
 }
 
 func OpenTrustStore(userStateDir, projectRoot string) (*TrustStore, error) {
+	return OpenTrustStoreForBase(userStateDir, projectRoot, "")
+}
+
+func OpenTrustStoreForBase(userStateDir, projectRoot, baseRoot string) (*TrustStore, error) {
 	if strings.TrimSpace(userStateDir) == "" {
 		return nil, fmt.Errorf("user state directory is required")
 	}
@@ -61,9 +65,18 @@ func OpenTrustStore(userStateDir, projectRoot string) (*TrustStore, error) {
 	if pathWithin(stateAbs, projectAbs) {
 		return nil, fmt.Errorf("trust state directory must be outside the project worktree")
 	}
-	sum := sha256.Sum256([]byte(identity))
+	projectSum := sha256.Sum256([]byte(identity))
+	dir := filepath.Join(stateAbs, "launch", "projects", hex.EncodeToString(projectSum[:]))
+	if baseRoot != "" {
+		baseAbs, err := resolvedPath(baseRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve explicit base root trust scope: %w", err)
+		}
+		baseSum := sha256.Sum256([]byte(baseAbs))
+		dir = filepath.Join(dir, "bases", hex.EncodeToString(baseSum[:]))
+	}
 	return &TrustStore{
-		dir:             filepath.Join(stateAbs, "launch", "projects", hex.EncodeToString(sum[:])),
+		dir:             dir,
 		projectIdentity: identity,
 	}, nil
 }

--- a/internal/launch/trust_digest.go
+++ b/internal/launch/trust_digest.go
@@ -17,6 +17,10 @@ const executionTrustDigestVersion = 1
 // which the plan will be emitted. The plan digest alone cannot distinguish a
 // selector-free launch after default_session changes.
 func ExecutionTrustDigest(plan Plan, session string, root *fsq.DeliveryRoot) (string, error) {
+	return ExecutionTrustDigestWithAuthority(plan, session, root, "")
+}
+
+func ExecutionTrustDigestWithAuthority(plan Plan, session string, root *fsq.DeliveryRoot, authorityDigest string) (string, error) {
 	if !canonicalSessionPattern.MatchString(session) || strings.HasPrefix(session, "-") {
 		return "", fmt.Errorf("invalid trust session %q", session)
 	}
@@ -42,13 +46,17 @@ func ExecutionTrustDigest(plan Plan, session string, root *fsq.DeliveryRoot) (st
 	if err != nil {
 		return "", fmt.Errorf("resolve trust session-root identity: %w", err)
 	}
-	return executionTrustDigest(planDigest, session, rootPath, rootIdentity)
+	return executionTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest)
 }
 
 // PrepareTrustDigest binds a nonce-free plan digest to the canonical target
 // and its physical identity. For an absent session, rootIdentity is a stable
 // intended-child identity derived from the pinned parent and child name.
 func PrepareTrustDigest(planDigest, session, rootPath, rootIdentity string) (string, error) {
+	return PrepareTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, "")
+}
+
+func PrepareTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest string) (string, error) {
 	if !validDigest(planDigest) {
 		return "", fmt.Errorf("invalid prepare plan digest")
 	}
@@ -62,7 +70,22 @@ func PrepareTrustDigest(planDigest, session, rootPath, rootIdentity string) (str
 	if err != nil {
 		return "", fmt.Errorf("resolve prepare trust session root: %w", err)
 	}
-	return executionTrustDigest(planDigest, session, canonicalRoot, rootIdentity)
+	return executionTrustDigestWithAuthority(planDigest, session, canonicalRoot, rootIdentity, authorityDigest)
+}
+
+func executionTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest string) (string, error) {
+	legacy, err := executionTrustDigest(planDigest, session, rootPath, rootIdentity)
+	if err != nil || authorityDigest == "" {
+		return legacy, err
+	}
+	if !validDigest(authorityDigest) {
+		return "", fmt.Errorf("invalid base-root authority digest")
+	}
+	return digestCanonical(struct {
+		Version         int    `json:"version"`
+		LegacyDigest    string `json:"legacy_digest"`
+		AuthorityDigest string `json:"authority_digest"`
+	}{Version: 2, LegacyDigest: legacy, AuthorityDigest: authorityDigest})
 }
 
 func executionTrustDigest(planDigest, session, rootPath, rootIdentity string) (string, error) {

--- a/internal/launch/trust_test.go
+++ b/internal/launch/trust_test.go
@@ -96,6 +96,42 @@ func TestTrustStoreUsesPhysicalProjectIdentityAndDoesNotLeak(t *testing.T) {
 	}
 }
 
+func TestTrustStoreScopesExplicitBaseRoots(t *testing.T) {
+	state := t.TempDir()
+	project := t.TempDir()
+	baseA := filepath.Join(project, ".agent-mail", "profile-a")
+	baseB := filepath.Join(project, ".agent-mail", "profile-b")
+	legacy, err := OpenTrustStore(state, project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	omitted, err := OpenTrustStoreForBase(state, project, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.Path() != omitted.Path() {
+		t.Fatalf("omitted base_root changed legacy trust path: %s != %s", legacy.Path(), omitted.Path())
+	}
+	storeA, err := OpenTrustStoreForBase(state, project, baseA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeB, err := OpenTrustStoreForBase(state, project, baseB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if storeA.Path() == storeB.Path() || storeA.Path() == legacy.Path() || storeB.Path() == legacy.Path() {
+		t.Fatalf("explicit base trust stores alias: legacy=%s a=%s b=%s", legacy.Path(), storeA.Path(), storeB.Path())
+	}
+	digest := "sha256:" + strings.Repeat("a", 64)
+	if err := storeA.Replace(TrustRecord{SemanticDigest: digest}); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := storeB.LoadForDigest(digest); err != nil || found {
+		t.Fatalf("profile-b loaded profile-a trust: found=%v err=%v", found, err)
+	}
+}
+
 func TestTrustLoadFailsClosed(t *testing.T) {
 	store, _ := trustFixture(t)
 	if err := os.MkdirAll(filepath.Dir(store.Path()), 0o700); err != nil {

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -20,6 +20,198 @@ import (
 	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
+func TestPrepareApplyCreatesAuthorizedProfileBaseRoot(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	projectRoot, err := filepath.EvalSymlinks(fixture.request.Target.ProjectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.request.Target.ProjectRoot = projectRoot
+	configuredPath := filepath.Join(fixture.root, "configured-mail")
+	if err := os.Mkdir(configuredPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configuredRoot, err := filepath.EvalSymlinks(configuredPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profileRoot := filepath.Join(configuredRoot, "profile-a")
+	sessionRoot := filepath.Join(profileRoot, "collab")
+	amqrc, err := json.Marshal(map[string]string{"root": configuredRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture.request.Target.ProjectRoot, ".amqrc"), append(amqrc, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture.request.Target.BaseRoot = profileRoot
+	fixture.request.Target.SessionRoot = sessionRoot
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	before := snapshotTestTree(t, fixture.root)
+
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after := snapshotTestTree(t, fixture.root); after != before {
+		t.Fatalf("Prepare changed filesystem: before=%s after=%s", before, after)
+	}
+	if prepared.Outcome != PrepareOutcomeReady || len(prepared.RequiredActions) != 0 {
+		t.Fatalf("Prepare result = %#v", prepared)
+	}
+	if len(prepared.PlannedWrites) != 1 || prepared.PlannedWrites[0].Kind != PlannedWriteCreateBaseRoot || prepared.PlannedWrites[0].Path != profileRoot {
+		t.Fatalf("planned writes = %#v", prepared.PlannedWrites)
+	}
+
+	applied, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1,
+		Prepare:        fixture.request,
+		SubjectSchema:  prepared.SubjectSchema,
+		SubjectDigest:  prepared.SubjectDigest,
+		Decisions:      []DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied.Outcome != "provisioned_no_runnable" {
+		t.Fatalf("Apply result = %#v", applied)
+	}
+	for _, path := range []string{profileRoot, sessionRoot, filepath.Join(sessionRoot, "agents", "operator")} {
+		info, err := os.Stat(path)
+		if err != nil || !info.IsDir() {
+			t.Fatalf("created path %s: info=%v err=%v", path, info, err)
+		}
+		if path != filepath.Join(sessionRoot, "agents", "operator") && info.Mode().Perm() != 0o700 {
+			t.Fatalf("created path %s mode = %o, want 0700", path, info.Mode().Perm())
+		}
+	}
+}
+
+func TestPrepareApplyCreatesMissingConfiguredBaseRoot(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	project, err := filepath.EvalSymlinks(fixture.request.Target.ProjectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(fixture.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configuredRoot := filepath.Join(canonicalRoot, "configured-mail")
+	config, err := json.Marshal(map[string]string{"root": configuredRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), append(config, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	request := fixture.request
+	request.Target = TargetV1{
+		ProjectRoot: project, BaseRoot: configuredRoot,
+		SessionRoot: filepath.Join(configuredRoot, "collab"), Session: "collab",
+	}
+	request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	prepared, err := Prepare(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prepared.PlannedWrites) != 1 || prepared.PlannedWrites[0].Path != configuredRoot {
+		t.Fatalf("planned writes = %#v", prepared.PlannedWrites)
+	}
+	if _, err := os.Lstat(configuredRoot); !os.IsNotExist(err) {
+		t.Fatalf("Prepare created configured root: %v", err)
+	}
+	applied, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: request,
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied.Outcome != "provisioned_no_runnable" {
+		t.Fatalf("Apply = %#v", applied)
+	}
+	for _, path := range []string{configuredRoot, request.Target.SessionRoot} {
+		info, err := os.Stat(path)
+		if err != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+			t.Fatalf("created %s: info=%v err=%v", path, info, err)
+		}
+	}
+}
+
+func TestSameSessionLabelAcrossProfileRootsIsIsolated(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	root, err := filepath.EvalSymlinks(fixture.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, err := filepath.EvalSymlinks(fixture.request.Target.ProjectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configuredRoot := filepath.Join(root, "configured-mail")
+	if err := os.Mkdir(configuredRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configBytes, err := json.Marshal(map[string]string{"root": configuredRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), append(configBytes, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := []TargetV1{
+		{ProjectRoot: project, BaseRoot: filepath.Join(configuredRoot, "profile-a"), SessionRoot: filepath.Join(configuredRoot, "profile-a", "collab"), Session: "collab"},
+		{ProjectRoot: project, BaseRoot: filepath.Join(configuredRoot, "profile-b"), SessionRoot: filepath.Join(configuredRoot, "profile-b", "collab"), Session: "collab"},
+	}
+	ticketBytes := make([][]byte, len(targets))
+	evidenceIDs := make(map[string]struct{})
+	for i, target := range targets {
+		request := fixture.request
+		request.Target = target
+		prepared, err := Prepare(context.Background(), request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		applied, err := Apply(context.Background(), ApplyRequestV1{
+			RequestVersion: RequestVersionV1, Prepare: request,
+			SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest,
+			Decisions: decisionsForPreparedActions(prepared),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if applied.Outcome != "action_required" || applied.ReasonCode != "commands_emitted" {
+			t.Fatalf("profile %d Apply = %#v", i, applied)
+		}
+		ticketPath := filepath.Join(target.SessionRoot, "meta", "launch", "executions", "claude.json")
+		ticketBytes[i], err = os.ReadFile(ticketPath)
+		if err != nil {
+			t.Fatalf("profile %d ticket: %v", i, err)
+		}
+		if !bytes.Contains(ticketBytes[i], []byte(target.SessionRoot)) {
+			t.Fatalf("profile %d ticket does not bind its session root", i)
+		}
+		for _, evidence := range applied.Evidence {
+			if _, duplicate := evidenceIDs[evidence.ID]; duplicate {
+				t.Fatalf("evidence %q shared across profile roots", evidence.ID)
+			}
+			evidenceIDs[evidence.ID] = struct{}{}
+		}
+	}
+	if bytes.Equal(ticketBytes[0], ticketBytes[1]) {
+		t.Fatal("same-label profile tickets are byte-identical")
+	}
+	profileBBefore := snapshotTestTree(t, targets[1].SessionRoot)
+	if _, err := Inspect(context.Background(), InspectRequestV1{RequestVersion: RequestVersionV1, Target: targets[0]}); err != nil {
+		t.Fatal(err)
+	}
+	if after := snapshotTestTree(t, targets[1].SessionRoot); after != profileBBefore {
+		t.Fatalf("profile-a lifecycle read changed profile-b: before=%s after=%s", profileBBefore, after)
+	}
+}
+
 func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, false)
 	injector := filepath.Join(t.TempDir(), "injector")

--- a/launchapi/base_root_security_unix_test.go
+++ b/launchapi/base_root_security_unix_test.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package launchapi
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPrepareRejectsWritableProjectAMQRCWithoutWrites(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	root, err := filepath.EvalSymlinks(fixture.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, err := filepath.EvalSymlinks(fixture.request.Target.ProjectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configured := filepath.Join(root, "configured")
+	if err := os.Mkdir(configured, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(map[string]string{"root": configured})
+	if err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(project, ".amqrc")
+	if err := os.WriteFile(configPath, append(data, '\n'), 0o622); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(configPath, 0o622); err != nil {
+		t.Fatal(err)
+	}
+	profile := filepath.Join(configured, "profile-a")
+	fixture.request.Target = TargetV1{
+		ProjectRoot: project, BaseRoot: profile,
+		SessionRoot: filepath.Join(profile, "collab"), Session: "collab",
+	}
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	before := snapshotTestTree(t, fixture.root)
+	result, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != PrepareOutcomeUnsupported || result.Reason != "base_root_unauthorized" {
+		t.Fatalf("writable .amqrc refusal = %#v", result)
+	}
+	if len(result.PlannedWrites) != 0 || snapshotTestTree(t, fixture.root) != before {
+		t.Fatalf("writable .amqrc refusal mutated or planned writes: %#v", result)
+	}
+}

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -18,6 +18,7 @@ var compatibilityFeaturesV1 = []string{
 	"plan_only_commands_v1",
 	FeatureInitialInput,
 	FeaturePlacement,
+	FeatureBaseRoot,
 }
 
 func Compatibility() CompatibilityV1 {

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -24,8 +24,11 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if !slices.Contains(Compatibility().Features, FeatureInitialInput) {
 		t.Fatal("Compatibility did not advertise the completed initial_input feature")
 	}
+	if !slices.Contains(Compatibility().Features, FeatureBaseRoot) {
+		t.Fatal("Compatibility did not advertise the completed base_root feature")
+	}
 	for _, unfinished := range []string{
-		FeatureBaseRoot, FeatureOnLive, FeatureWrapper,
+		FeatureOnLive, FeatureWrapper,
 		FeatureCallerContext, FeatureExecutableIdentity,
 	} {
 		if slices.Contains(Compatibility().Features, unfinished) {

--- a/launchapi/encoding_test.go
+++ b/launchapi/encoding_test.go
@@ -89,6 +89,7 @@ func goldenPrepareResultV1() PrepareResultV1 {
 	return PrepareResultV1{
 		ResultVersion: 1, SubjectSchema: SubjectSchemaV2, Outcome: PrepareOutcomeActionRequired, Reason: "untrusted_config_digest",
 		SubjectDigest: goldenDigest('a'), PlanDigest: goldenDigest('b'), TrustDigest: goldenDigest('c'),
+		PlannedWrites: []PlannedWriteV1{},
 		RequiredActions: []RequiredActionV1{{
 			ActionID: "trust-example", Kind: RequiredActionTrustConfirmation, Handles: []string{"claude"},
 			Resources: []string{goldenDigest('c')}, AllowedDecisions: []DecisionChoiceV1{DecisionTrustExactSubject, DecisionDeny},

--- a/launchapi/lifecycle.go
+++ b/launchapi/lifecycle.go
@@ -41,7 +41,8 @@ func Close(ctx context.Context, request CloseRequestV1) (CloseResultV1, error) {
 
 func lifecycleRequest(request InspectRequestV1) internallaunch.LifecycleRequest {
 	return internallaunch.LifecycleRequest{Target: internallaunch.PrepareTarget{
-		ProjectRoot: request.Target.ProjectRoot, SessionRoot: request.Target.SessionRoot, Session: request.Target.Session,
+		ProjectRoot: request.Target.ProjectRoot, BaseRoot: request.Target.BaseRoot,
+		SessionRoot: request.Target.SessionRoot, Session: request.Target.Session,
 	}}
 }
 

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -39,7 +39,7 @@ func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, int
 	if err != nil {
 		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, err
 	}
-	trustStore, err := internallaunch.OpenTrustStore(stateDir, request.Target.ProjectRoot)
+	trustStore, err := internallaunch.OpenTrustStoreForBase(stateDir, request.Target.ProjectRoot, request.Target.BaseRoot)
 	if err != nil {
 		return internallaunch.PrepareRequest{}, internallaunch.PrepareDependencies{}, fmt.Errorf("open launch trust store: %w", err)
 	}
@@ -57,6 +57,7 @@ func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, int
 	internalRequest := internallaunch.PrepareRequest{
 		Target: internallaunch.PrepareTarget{
 			ProjectRoot: request.Target.ProjectRoot,
+			BaseRoot:    request.Target.BaseRoot,
 			SessionRoot: request.Target.SessionRoot,
 			Session:     request.Target.Session,
 		},
@@ -143,9 +144,10 @@ func fromInternalPrepareResult(result internallaunch.PrepareResult) PrepareResul
 	public := PrepareResultV1{
 		ResultVersion: ResultVersionV1, SubjectSchema: result.SubjectSchema, Outcome: result.Outcome, Reason: result.Reason,
 		SubjectDigest: result.SubjectDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
+		PlannedWrites:   make([]PlannedWriteV1, 0, len(result.PlannedWrites)),
 		RequiredActions: make([]RequiredActionV1, 0, len(result.RequiredActions)),
 		Preview: PreviewV1{
-			Target:  TargetV1{ProjectRoot: result.Target.ProjectRoot, SessionRoot: result.Target.SessionRoot, Session: result.Target.Session},
+			Target:  TargetV1{ProjectRoot: result.Target.ProjectRoot, BaseRoot: result.Target.BaseRoot, SessionRoot: result.Target.SessionRoot, Session: result.Target.Session},
 			Backend: result.Backend, Profile: result.Profile,
 			Participants: make([]ParticipantPreviewV1, 0, len(result.Participants)),
 			Roster: RosterDriftV1{
@@ -158,6 +160,12 @@ func fromInternalPrepareResult(result internallaunch.PrepareResult) PrepareResul
 	}
 	placement := fromInternalPlacementPreview(result.Placement)
 	public.Preview.Placement = &placement
+	for _, write := range result.PlannedWrites {
+		public.PlannedWrites = append(public.PlannedWrites, PlannedWriteV1{
+			WriteID: write.WriteID, Kind: PlannedWriteKindV1(write.Kind), Path: write.Path,
+			Handle: write.Handle, SHA256: write.SHA256,
+		})
+	}
 	for _, action := range result.RequiredActions {
 		allowed := make([]DecisionChoiceV1, len(action.AllowedDecisions))
 		for i, choice := range action.AllowedDecisions {

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -229,6 +229,128 @@ func TestPrepareExplicitPlacementChangesSubjectDigest(t *testing.T) {
 	}
 }
 
+func TestPrepareRejectsUnauthorizedBaseRootRelationsWithoutWrites(t *testing.T) {
+	tests := []struct {
+		name  string
+		want  string
+		build func(t *testing.T, root string) (configuredRoot, baseRoot, sessionRoot string)
+	}{
+		{
+			name: "sibling base", want: "base_root_unauthorized",
+			build: func(t *testing.T, root string) (string, string, string) {
+				configured := filepath.Join(root, "configured")
+				sibling := filepath.Join(root, "sibling")
+				for _, path := range []string{configured, sibling} {
+					if err := os.Mkdir(path, 0o700); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return configured, sibling, filepath.Join(sibling, "collab")
+			},
+		},
+		{
+			name: "missing configured root plus profile", want: "base_root_unauthorized",
+			build: func(_ *testing.T, root string) (string, string, string) {
+				configured := filepath.Join(root, "missing-configured")
+				profile := filepath.Join(configured, "profile-a")
+				return configured, profile, filepath.Join(profile, "collab")
+			},
+		},
+		{
+			name: "nested session", want: "base_root_relation_invalid",
+			build: func(t *testing.T, root string) (string, string, string) {
+				configured := filepath.Join(root, "configured")
+				profile := filepath.Join(configured, "profile-a")
+				if err := os.MkdirAll(profile, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				return configured, profile, filepath.Join(profile, "nested", "collab")
+			},
+		},
+		{
+			name: "symlink profile escape", want: "base_root_relation_invalid",
+			build: func(t *testing.T, root string) (string, string, string) {
+				configured := filepath.Join(root, "configured")
+				escape := filepath.Join(root, "escape")
+				if err := os.Mkdir(configured, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(escape, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				profile := filepath.Join(configured, "profile-a")
+				if err := os.Symlink(escape, profile); err != nil {
+					t.Fatal(err)
+				}
+				return configured, profile, filepath.Join(profile, "collab")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newPublicPrepareFixture(t, false)
+			root, err := filepath.EvalSymlinks(fixture.root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			project, err := filepath.EvalSymlinks(fixture.request.Target.ProjectRoot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			configured, base, session := test.build(t, root)
+			data, err := json.Marshal(map[string]string{"root": configured})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(project, ".amqrc"), append(data, '\n'), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			fixture.request.Target = TargetV1{ProjectRoot: project, BaseRoot: base, SessionRoot: session, Session: "collab"}
+			fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+			before := snapshotTestTree(t, fixture.root)
+
+			result, err := Prepare(context.Background(), fixture.request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Outcome != PrepareOutcomeUnsupported || result.Reason != test.want {
+				t.Fatalf("refusal = %#v", result)
+			}
+			if len(result.PlannedWrites) != 0 || len(result.RequiredActions) != 0 {
+				t.Fatalf("refusal advertised mutations or decisions: %#v", result)
+			}
+			if after := snapshotTestTree(t, fixture.root); after != before {
+				t.Fatalf("Prepare refusal changed filesystem: before=%s after=%s", before, after)
+			}
+		})
+	}
+}
+
+func TestBaseRootOmittedMatchesV061ExactRoot(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	unrelated := filepath.Join(fixture.root, "unrelated-mail")
+	if err := os.Mkdir(unrelated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	config, err := json.Marshal(map[string]string{"root": unrelated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture.request.Target.ProjectRoot, ".amqrc"), append(config, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	omitted, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if omitted.Outcome == PrepareOutcomeUnsupported || omitted.Reason == "base_root_unauthorized" || omitted.Reason == "base_root_relation_invalid" {
+		t.Fatalf("omitted base_root consulted new authority: %#v", omitted)
+	}
+	if len(omitted.PlannedWrites) != 0 || omitted.Preview.Target.BaseRoot != "" {
+		t.Fatalf("omitted base_root changed legacy result: %#v", omitted)
+	}
+}
+
 func TestPrepareUnavailableLauncherIsTypedAndDoesNotRequestTrust(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, true)
 	launcher := unavailableManagedLauncher(t)

--- a/launchapi/requests.go
+++ b/launchapi/requests.go
@@ -138,6 +138,9 @@ func (target TargetV1) validate() error {
 	if !cleanAbsolutePath(target.ProjectRoot) {
 		return fmt.Errorf("target project_root must be a clean absolute path")
 	}
+	if target.BaseRoot != "" && !cleanAbsolutePath(target.BaseRoot) {
+		return fmt.Errorf("target base_root must be a clean absolute path")
+	}
 	if !cleanAbsolutePath(target.SessionRoot) {
 		return fmt.Errorf("target session_root must be a clean absolute path")
 	}

--- a/launchapi/testdata/prepare_result_v1.golden.json
+++ b/launchapi/testdata/prepare_result_v1.golden.json
@@ -6,6 +6,7 @@
   "subject_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "plan_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "trust_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "planned_writes": [],
   "required_actions": [
     {
       "action_id": "trust-example",

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -115,6 +115,7 @@ type SymphonyOptionsV1 struct {
 
 type TargetV1 struct {
 	ProjectRoot string `json:"project_root"`
+	BaseRoot    string `json:"base_root,omitempty"`
 	SessionRoot string `json:"session_root"`
 	Session     string `json:"session"`
 }
@@ -256,6 +257,21 @@ type ParticipantObservationV1 struct {
 	ReasonCode   string `json:"reason_code,omitempty"`
 }
 
+type PlannedWriteKindV1 string
+
+const (
+	PlannedWriteCreateBaseRoot PlannedWriteKindV1 = "create_base_root"
+	PlannedWriteInitialInput   PlannedWriteKindV1 = "write_initial_input"
+)
+
+type PlannedWriteV1 struct {
+	WriteID string             `json:"write_id"`
+	Kind    PlannedWriteKindV1 `json:"kind"`
+	Path    string             `json:"path"`
+	Handle  string             `json:"handle,omitempty"`
+	SHA256  string             `json:"sha256,omitempty"`
+}
+
 type PrepareResultV1 struct {
 	ResultVersion   int                        `json:"result_version"`
 	SubjectSchema   int                        `json:"subject_schema"`
@@ -264,6 +280,7 @@ type PrepareResultV1 struct {
 	SubjectDigest   string                     `json:"subject_digest"`
 	PlanDigest      string                     `json:"plan_digest"`
 	TrustDigest     string                     `json:"trust_digest"`
+	PlannedWrites   []PlannedWriteV1           `json:"planned_writes"`
 	RequiredActions []RequiredActionV1         `json:"required_actions"`
 	Preview         PreviewV1                  `json:"preview"`
 	Observations    []ParticipantObservationV1 `json:"observations"`

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -166,6 +166,7 @@
       "required": ["project_root", "session_root", "session"],
       "properties": {
         "project_root": {"type": "string", "minLength": 1},
+        "base_root": {"type": "string", "minLength": 1},
         "session_root": {"type": "string", "minLength": 1},
         "session": {"type": "string", "pattern": "^[a-z0-9_][a-z0-9_-]*$"}
       }
@@ -307,10 +308,22 @@
         "reason_code": {"type": "string"}
       }
     },
+    "PlannedWriteV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["write_id", "kind", "path"],
+      "properties": {
+        "write_id": {"$ref": "#/$defs/Digest"},
+        "kind": {"enum": ["create_base_root", "write_initial_input"]},
+        "path": {"type": "string", "minLength": 1},
+        "handle": {"$ref": "#/$defs/Handle"},
+        "sha256": {"$ref": "#/$defs/Digest"}
+      }
+    },
     "PrepareResultV1": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["result_version", "subject_schema", "outcome", "subject_digest", "plan_digest", "trust_digest", "required_actions", "preview", "observations"],
+      "required": ["result_version", "subject_schema", "outcome", "subject_digest", "plan_digest", "trust_digest", "planned_writes", "required_actions", "preview", "observations"],
       "properties": {
         "result_version": {"const": 1},
         "subject_schema": {"enum": [1, 2]},
@@ -319,6 +332,7 @@
         "subject_digest": {"$ref": "#/$defs/Digest"},
         "plan_digest": {"$ref": "#/$defs/Digest"},
         "trust_digest": {"$ref": "#/$defs/Digest"},
+        "planned_writes": {"type": "array", "items": {"$ref": "#/$defs/PlannedWriteV1"}},
         "required_actions": {"type": "array", "items": {"$ref": "#/$defs/RequiredActionV1"}},
         "preview": {"$ref": "#/$defs/PreviewV1"},
         "observations": {"type": "array", "items": {"$ref": "#/$defs/ParticipantObservationV1"}}


### PR DESCRIPTION
## Summary
- Lands Codex 7ke exact staged SHA-256 `fd83ab9671b832164637592d211bad0fed3a07d20e374de448a8748c528d4b3d` on `origin/main` `55287d4`.
- Adds `TargetV1.base_root`, Prepare `planned_writes`, exclusive 0700 base creation, `.amqrc` authority, and oracle row 1 (`finding1_missing_profile_base_root`).
- Dual-approved by Claude and Cursor on that exact diff. Co-authored by Codex.

## Test plan
- [x] `git apply --index` of the extracted patch; staged SHA-256 matches `fd83ab96...`
- [x] `go test ./launchapi ./internal/launch ./internal/fsq -count=1`
- [x] `go test ./internal/cli -count=1 -run TestAdoptionSmokeOmriSquadV2294/finding1_missing_profile_base_root`


Made with [Cursor](https://cursor.com)