### PR TITLE
feat(launchapi): add on_live keep|refuse with per-member dispositions

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -21,10 +21,10 @@ if err != nil {
 _ = negotiated
 ```
 
-A `0.61.1` binary advertises `placement`, `initial_input`, and `base_root` and
-can still omit later Wave B3 feature IDs while those beads are incomplete. A caller must
-require every feature it uses. Contract semver alone does not claim that an
-unadvertised feature is available.
+A `0.61.1` binary advertises `placement`, `initial_input`, `base_root`, and
+`on_live` and can still omit later Wave B3 feature IDs while those beads are
+incomplete. A caller must require every feature it uses. Contract semver alone
+does not claim that an unadvertised feature is available.
 
 `PreviewV1.capabilities` reports the selected providers' static adapter grammar
 without executing a caller-supplied provider. `grammar_version` is the
@@ -150,6 +150,12 @@ authorized base appears as a deterministic `create_base_root` entry in
 the base and session exclusively with mode `0700`. Siblings, nested roots,
 symlinks, alternate spellings, or changed authority return a typed refusal with
 no launch mutation.
+
+`on_live` is `keep` or `refuse`. Omission and explicit `refuse` keep the v0.61
+whole-binding refusal. Explicit `keep` on a proven-owned live seat keeps that
+process and lets Apply create missing seats in the same tmux omitted-placement
+session. Hostile live resources refuse even with `keep`. Schema 1 rejects
+`on_live: keep`; omit and `refuse` stay digest-stable.
 
 ```go
 request := launchapi.PrepareRequestV1{

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
@@ -26,7 +25,7 @@ import (
 //
 //	Row | Finding | Today | WB3 expected
 //	finding1_missing_profile_base_root | 1 named-profile base root | missing .agent-mail/<profile> refuses (not found / stat delivery root) | Prepare planned write create_base_root; Apply creates the authorized base
-//	finding2_mixed_live_fresh_roster_refuses | 2 live-seat dispositions | whole binding refuses rather than keep-live + create-missing | on_live keep -> kept + created missing seats
+//	finding2_mixed_live_fresh_keep_creates | 2 live-seat dispositions | on_live keep -> kept + created missing seats | omitted on_live still refuses
 //	finding3_wrapper_unknown_field | 3 wrapper | strict decode unknown field "wrapper" | wrapper argv prepended to full provider argv
 //	finding4_placement_unsupported | 4 placement | AMQ_SQUAD_TMUX_* env rejected as provider env | placement preview; unsupported tuple -> placement_unsupported
 //	finding5_positional_bootstrap_prompt / finding5_claude_allowed_tools / finding5_codex_dash_c | 5 materialized argv | raw positional prompt rejected; exact --allowedTools and -c forms admitted | initial_input + --allowedTools / -c admitted
@@ -161,12 +160,12 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		}
 	})
 
-	t.Run("finding2_mixed_live_fresh_roster_refuses", func(t *testing.T) {
+	t.Run("finding2_mixed_live_fresh_keep_creates", func(t *testing.T) {
 		if _, err := exec.LookPath("tmux"); err != nil {
 			t.Skip("tmux is not installed")
 		}
 		fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "collab")
-		socketDir, err := os.MkdirTemp("/tmp", "amq-ro9-tmux-")
+		socketDir, err := os.MkdirTemp("/tmp", "amq-09i-tmux-")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -195,39 +194,46 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		mixed := fx.legalSquadIntent()
 		mixed.Participants[1].ResumePolicy = launchapi.ResumePolicyResume
 		mixed.Participants[1].Execution = disabledWakeExecution()
-		mixed.Participants[2].ResumePolicy = launchapi.ResumePolicyFresh
-		mixed.Participants[2].Execution = disabledWakeExecution()
-		mixed.Participants = mixed.Participants[:3] // user + live lead + fresh senior-dev
+		mixed.Participants[1].OnLive = launchapi.OnLiveKeep
+		// Create fullstack (Claude mint). Hermetic Codex never emits notify, so
+		// Apply cannot commit senior-dev in-process.
+		mixed.Participants[3].ResumePolicy = launchapi.ResumePolicyFresh
+		mixed.Participants[3].Execution = disabledWakeExecution()
+		mixed.Participants = []launchapi.ParticipantV1{
+			mixed.Participants[0], mixed.Participants[1], mixed.Participants[3],
+		}
 		stdout, stderr, exit = fx.prepare(t, mixed, launch.LauncherTMux)
-		if exit == 0 {
-			t.Fatalf("mixed roster Prepare succeeded: stdout=%s", stdout)
+		if exit != 0 && exit != ExitActionRequired {
+			t.Fatalf("mixed keep Prepare exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
 		}
-		combined := string(stdout) + string(stderr)
-		if !strings.Contains(combined, "binding_present_without_resumable_conversation") &&
-			!strings.Contains(combined, "present_binding") {
-			var mixedPrepared launchapi.PrepareResultV1
-			decodeRealLaunchJSON(t, stdout, &mixedPrepared)
-			applyPath = writeApplyRequestE2E(t, fx.request(mixed, launch.LauncherTMux), mixedPrepared)
-			stdout, stderr, exit = runRealAMQWithExit(t, fx.amqBinary, fx.project, fx.env, "launch", "--apply", applyPath, "--json")
-			if exit == 0 {
-				t.Fatalf("mixed roster Apply succeeded: stdout=%s", stdout)
-			}
-			combined = string(stdout) + string(stderr)
-			if !strings.Contains(combined, "binding_present_without_resumable_conversation") &&
-				!strings.Contains(combined, "present_binding") {
-				t.Fatalf("mixed roster refusal = exit %d stdout=%s stderr=%s", exit, stdout, stderr)
-			}
+		var mixedPrepared launchapi.PrepareResultV1
+		decodeRealLaunchJSON(t, stdout, &mixedPrepared)
+		applyPath = writeApplyRequestE2E(t, fx.request(mixed, launch.LauncherTMux), mixedPrepared)
+		stdout, stderr, exit = runRealAMQWithExit(t, fx.amqBinary, fx.project, fx.env, "launch", "--apply", applyPath, "--json")
+		if exit != 0 {
+			t.Fatalf("mixed keep Apply exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
 		}
+		var applied launchapi.ApplyResultV1
+		decodeRealLaunchJSON(t, stdout, &applied)
 		after := fx.liveSeatSnapshot(t, socketDir)
-		if after.Binding != before.Binding || after.LeadConversation != before.LeadConversation ||
-			after.SeniorConversation != before.SeniorConversation || after.Journal != before.Journal ||
-			after.Panes != before.Panes || after.SessionIDs != before.SessionIDs ||
-			!slices.Equal(after.LaunchTree, before.LaunchTree) {
-			t.Fatalf("mixed roster refusal mutated live seat snapshot\nbefore=%+v\nafter=%+v\nlaunch-tree diff:\n%s",
-				before, after, strings.Join(diffStrings(before.LaunchTree, after.LaunchTree), "\n"))
+		if after.LeadConversation != before.LeadConversation {
+			t.Fatalf("keep mutated lead conversation\nbefore=%s\nafter=%s", before.LeadConversation, after.LeadConversation)
 		}
-		if after.Panes != 1 || after.SessionIDs != 1 || after.SeniorConversation {
-			t.Fatalf("mixed roster refusal duplicated or created a live seat: %+v", after)
+		_, createdErr := os.Stat(launch.ConversationPath(fx.sessionRoot, "fullstack"))
+		if createdErr != nil || after.Panes != 2 || after.SessionIDs != 1 {
+			t.Fatalf("keep+create snapshot = %+v created=%v", after, createdErr)
+		}
+		kept, created := 0, 0
+		for _, observation := range applied.Observations {
+			switch observation.Disposition {
+			case launch.SeatKept:
+				kept++
+			case launch.SeatCreated:
+				created++
+			}
+		}
+		if kept != 1 || created != 1 {
+			t.Fatalf("dispositions kept=%d created=%d observations=%#v", kept, created, applied.Observations)
 		}
 	})
 
@@ -591,27 +597,6 @@ func snapshotLaunchTree(t *testing.T, sessionRoot string) []string {
 func snapshotTreeDigestBytes(data []byte) string {
 	sum := sha256.Sum256(data)
 	return fmt.Sprintf("%x", sum)
-}
-
-func diffStrings(before, after []string) []string {
-	seen := make(map[string]int, len(before)+len(after))
-	for _, row := range before {
-		seen[row]--
-	}
-	for _, row := range after {
-		seen[row]++
-	}
-	var diff []string
-	for row, n := range seen {
-		switch {
-		case n < 0:
-			diff = append(diff, "- "+row)
-		case n > 0:
-			diff = append(diff, "+ "+row)
-		}
-	}
-	slices.Sort(diff)
-	return diff
 }
 
 func countHermeticTmuxPanes(t *testing.T, socketDir string) int {

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -103,6 +103,14 @@ func Apply(ctx context.Context, request ApplyRequest, dependencies ApplyDependen
 		return ApplyResult{}, loadErr
 	} else if present {
 		nonce = journal.LaunchNonce
+	} else if !applyRequestsRebind(request) {
+		binding, hasBinding, bindErr := loadOptionalBinding(state.sessionRoot)
+		if bindErr != nil {
+			return ApplyResult{}, bindErr
+		}
+		if hasBinding {
+			nonce = binding.LaunchNonce
+		}
 	}
 	lease, err := acquireExistingApplyLease(state, nonce)
 	if err != nil {
@@ -266,6 +274,7 @@ func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, depe
 		result.ReasonCode = applyReconcileReasonCode(reconciled)
 		result.FailureDetail = reconciled.Reason
 	}
+	stampApplySeatDispositions(&result, reconciled.Seats)
 	return result, nil
 }
 
@@ -529,6 +538,7 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		ExecutionOptions:   executionOptions,
 		AllowFreshFallback: decisions[ActionStaleConversation] == "fresh_once",
 		Placement:          prepared.Placement,
+		OnLive:             onLivePolicies(runnable),
 	}
 	if choice := decisions[ActionTrustConfirmation]; choice == "trust_exact_subject" {
 		request.ConfirmTrust = func(plan Plan, actualTrustDigest string) (bool, error) {
@@ -545,6 +555,7 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 			}
 			authorizedTrustDigest, err := PrepareTrustDigestWithAuthority(
 				trustPlanDigest, prepared.Target.Session, prepared.Target.SessionRoot, authorizedRootIdentity, snapshot.BaseAuthorityDigest,
+				onLiveKeepHandles(prepared.Participants),
 			)
 			if err != nil {
 				return false, err
@@ -613,6 +624,15 @@ func acquireExistingApplyLease(state *prepareTargetState, nonce string) (*Lease,
 	return lease, err
 }
 
+func applyRequestsRebind(request ApplyRequest) bool {
+	for _, decision := range request.Decisions {
+		if decision.Choice == "close_old" || decision.Choice == "leave_old" {
+			return true
+		}
+	}
+	return false
+}
+
 func applyCreationLockPath(session string) string {
 	sum := sha256.Sum256([]byte(session))
 	name := "create-" + hex.EncodeToString(sum[:12]) + ".lock"
@@ -631,5 +651,39 @@ func applyResultFromPrepare(prepared PrepareResult) ApplyResult {
 		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, PlanDigest: prepared.PlanDigest, TrustDigest: prepared.TrustDigest,
 		Backend: prepared.Backend, Profile: prepared.Profile, Roster: prepared.Roster,
 		Observations: slices.Clone(prepared.Observations), RequiredActions: slices.Clone(prepared.RequiredActions),
+	}
+}
+
+func onLivePolicies(participants []PrepareParticipant) map[string]string {
+	policies := make(map[string]string, len(participants))
+	for _, participant := range participants {
+		if participant.OnLive != "" {
+			policies[participant.Handle] = participant.OnLive
+		}
+	}
+	return policies
+}
+
+func stampApplySeatDispositions(result *ApplyResult, seats []SeatDisposition) {
+	if len(seats) == 0 {
+		return
+	}
+	byHandle := make(map[string]SeatDisposition, len(seats))
+	for _, seat := range seats {
+		byHandle[seat.Handle] = seat
+	}
+	for i := range result.Observations {
+		seat, ok := byHandle[result.Observations[i].Handle]
+		if !ok || !result.Observations[i].Runnable {
+			continue
+		}
+		result.Observations[i].Disposition = seat.Decision
+		if seat.Decision == SeatRefused {
+			result.Observations[i].ReasonCode = seat.ReasonCode
+			continue
+		}
+		if seat.Decision == SeatCreated {
+			result.Observations[i].StartMode = seat.StartMode
+		}
 	}
 }

--- a/internal/launch/apply_test.go
+++ b/internal/launch/apply_test.go
@@ -523,3 +523,87 @@ func TestApplyReturnsTypedOutcomeForCommittedRosterConfigDurabilityFailure(t *te
 		t.Fatalf("committed roster was not applied: %v", err)
 	}
 }
+
+func TestOnLiveOmittedMatchesV061Apply(t *testing.T) {
+	// Apply-path guard: omit matches explicit refuse (v0.61 whole-binding
+	// refusal). Digest stability is TestPrepareV2SubjectDigestIncludesOnLiveKeepOnly.
+	omitted := applyMixedLiveMissing(t, "")
+	refused := applyMixedLiveMissing(t, OnLiveRefuse)
+	if omitted.Outcome != ApplyOutcomeActionRequired || omitted.ReasonCode != "binding_present_without_resumable_conversation" {
+		t.Fatalf("omitted on_live Apply = %#v, want v0.61 whole-binding refusal", omitted)
+	}
+	if omitted.Outcome != refused.Outcome || omitted.ReasonCode != refused.ReasonCode {
+		t.Fatalf("omitted Apply diverged from explicit refuse: omit=%#v refuse=%#v", omitted, refused)
+	}
+	for _, result := range []ApplyResult{omitted, refused} {
+		for _, observation := range result.Observations {
+			if observation.Disposition == SeatKept || observation.Disposition == SeatCreated {
+				t.Fatalf("omitted/refuse stamped keep-or-create: %#v", result.Observations)
+			}
+		}
+	}
+	kept := applyMixedLiveMissing(t, OnLiveKeep)
+	if kept.ReasonCode == omitted.ReasonCode {
+		t.Fatalf("on_live keep used the v0.61 refusal path: %#v", kept)
+	}
+}
+
+func applyMixedLiveMissing(t *testing.T, onLive string) ApplyResult {
+	t.Helper()
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	base := filepath.Join(root, "mail")
+	session := filepath.Join(base, "collab")
+	for _, path := range []string{project, base} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	writePrepareBinding(t, session, prepareBinding("host:test", "instance:test", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+	store, err := OpenTrustStore(t.TempDir(), project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, SessionRoot: session, Session: "collab"},
+		Launcher: "test", IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'a'}, 64)),
+		Participants: []PrepareParticipant{
+			{
+				Handle: "claude", Provider: ClaudeProvider, Executable: "claude", Runnable: true,
+				Cwd: project, ResumePolicy: ResumeEnabled, OnLive: onLive,
+			},
+			{
+				Handle: "codex", Provider: CodexProvider, Executable: "codex", Runnable: true,
+				Cwd: project, ResumePolicy: ResumeFresh, OnLive: onLive,
+			},
+		},
+	}}
+	backend := &prepareTestBackend{}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"},
+		AdapterFor: func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		TrustStore: store, HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	for _, action := range prepared.RequiredActions {
+		request.Decisions = append(request.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: "trust_exact_subject"})
+	}
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if backend.creates != 0 {
+		t.Fatalf("on_live %q created backend resources: %d result=%#v", onLive, backend.creates, result)
+	}
+	return result
+}

--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -150,6 +150,9 @@ type CreateRequest struct {
 	Root        *fsq.DeliveryRoot
 	// Placement is the caller-requested tuple. Nil preserves v0.61 Create.
 	Placement *Placement
+	// JoinBinding, when set, adds Plan agents into this owned session instead
+	// of creating a new generation. Nil preserves create-from-absent.
+	JoinBinding *BindingRecord
 }
 
 type EmittedCommand struct {

--- a/internal/launch/cmux.go
+++ b/internal/launch/cmux.go
@@ -130,6 +130,9 @@ func cmuxUnsupported(result *DetectResult, reason string) {
 }
 
 func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
+	if req.JoinBinding != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: placementError(PlacementUnsupportedReason)}
+	}
 	preview, err := resolveCreatePlacement(LauncherCMux, req)
 	if err != nil {
 		return CreateResult{}, &DefinitePreCreateError{Err: err}

--- a/internal/launch/commands.go
+++ b/internal/launch/commands.go
@@ -46,6 +46,9 @@ func (Commands) Create(req CreateRequest) (CreateResult, error) {
 	if req.Placement != nil {
 		return CreateResult{}, &DefinitePreCreateError{Err: placementError(PlacementUnsupportedReason)}
 	}
+	if req.JoinBinding != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: placementError(PlacementUnsupportedReason)}
+	}
 	if strings.TrimSpace(req.Session) == "" {
 		return CreateResult{}, fmt.Errorf("session is required")
 	}

--- a/internal/launch/ghostty.go
+++ b/internal/launch/ghostty.go
@@ -90,6 +90,9 @@ func (b *GhosttyBackend) Detect() DetectResult {
 }
 
 func (b *GhosttyBackend) Create(req CreateRequest) (CreateResult, error) {
+	if req.JoinBinding != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: placementError(PlacementUnsupportedReason)}
+	}
 	preview, err := resolveCreatePlacement(LauncherGhostty, req)
 	if err != nil {
 		return CreateResult{}, &DefinitePreCreateError{Err: err}

--- a/internal/launch/liveseat.go
+++ b/internal/launch/liveseat.go
@@ -1,0 +1,212 @@
+package launch
+
+const (
+	SeatKept    = "kept"
+	SeatCreated = "created"
+	SeatRefused = "refused"
+)
+
+const (
+	ReasonLiveParticipantRefused = "live_participant_refused"
+	ReasonCohortRefused          = "cohort_refused"
+)
+
+const (
+	StartModeResumed = "resumed"
+	StartModeFresh   = "fresh"
+)
+
+const (
+	OnLiveRefuse = "refuse"
+	OnLiveKeep   = "keep"
+)
+
+// SeatFacts is the observation for one desired handle. Keep eligibility is
+// the conjunction of managed, owned, attached, and live; hostile facts
+// (foreign, stale, profile mismatch, unknown inspect) fail closed.
+type SeatFacts struct {
+	Handle       string
+	Managed      bool
+	Owned        bool
+	Attached     bool
+	Live         bool
+	Inspect      InspectStatus
+	Foreign      bool
+	Stale        bool
+	ProfileMatch bool
+	Missing      bool
+	OnLive       string
+}
+
+// SeatDisposition is the Apply preflight row for one handle.
+type SeatDisposition struct {
+	Handle     string
+	Decision   string
+	ReasonCode string
+	StartMode  string
+}
+
+func EligibleToKeep(facts SeatFacts) bool {
+	return facts.Managed && facts.Owned && facts.Attached && facts.Live &&
+		facts.Inspect == InspectPresent && facts.ProfileMatch && !facts.Foreign && !facts.Stale && !facts.Missing
+}
+
+// ClassifyLiveSeats applies the cohort rule as a pure function: any refused
+// live seat turns remaining missing seats into cohort_refused; if every live
+// seat is kept, missing seats are created.
+func ClassifyLiveSeats(roster []SeatFacts) []SeatDisposition {
+	rows := make([]SeatDisposition, 0, len(roster))
+	refused := false
+	for _, facts := range roster {
+		row := classifyOneLiveSeat(facts)
+		if row.Decision == SeatRefused {
+			refused = true
+		}
+		rows = append(rows, row)
+	}
+	if !refused {
+		return rows
+	}
+	for i := range rows {
+		if rows[i].Decision == SeatCreated {
+			rows[i] = SeatDisposition{
+				Handle: rows[i].Handle, Decision: SeatRefused,
+				ReasonCode: ReasonCohortRefused,
+			}
+		}
+	}
+	return rows
+}
+
+func classifyOneLiveSeat(facts SeatFacts) SeatDisposition {
+	if EligibleToKeep(facts) {
+		if facts.OnLive == OnLiveKeep {
+			return SeatDisposition{Handle: facts.Handle, Decision: SeatKept, StartMode: StartModeResumed}
+		}
+		return SeatDisposition{Handle: facts.Handle, Decision: SeatRefused, ReasonCode: ReasonLiveParticipantRefused}
+	}
+	if facts.Missing && facts.Inspect == InspectAbsent && !facts.Foreign && !facts.Stale {
+		return SeatDisposition{Handle: facts.Handle, Decision: SeatCreated, StartMode: StartModeFresh}
+	}
+	return SeatDisposition{Handle: facts.Handle, Decision: SeatRefused, ReasonCode: ReasonLiveParticipantRefused}
+}
+
+func tmuxOmittedPlacementJoinSupported(backend string, placement *Placement) bool {
+	return backend == LauncherTMux && placement == nil
+}
+
+func onLiveKeepHandles(participants []PrepareParticipant) []string {
+	handles := make([]string, 0)
+	for _, participant := range participants {
+		if participant.OnLive == OnLiveKeep {
+			handles = append(handles, participant.Handle)
+		}
+	}
+	return handles
+}
+
+func ticketAgentsForCreate(planned []plannedAgent, joinBinding *BindingRecord) []plannedAgent {
+	if joinBinding == nil {
+		return planned
+	}
+	filtered := make([]plannedAgent, 0, len(planned))
+	for _, agent := range planned {
+		if agent.write {
+			filtered = append(filtered, agent)
+		}
+	}
+	return filtered
+}
+
+func reconcileLiveSeats(request ReconcileRequest, binding BindingRecord) ([]SeatDisposition, bool, string) {
+	anyKeep := false
+	for _, policy := range request.OnLive {
+		if policy == OnLiveKeep {
+			anyKeep = true
+			break
+		}
+	}
+	if !anyKeep {
+		return nil, false, ""
+	}
+	backend := request.Backends[binding.Backend]
+	if backend == nil {
+		return nil, false, ReasonLiveParticipantRefused
+	}
+	inspection, err := backend.Inspect(InspectRequest{Binding: binding, Root: request.Root})
+	if err != nil {
+		return nil, false, ReasonLiveParticipantRefused
+	}
+	foreign := request.HostIdentity != "" && binding.HostIdentity != request.HostIdentity
+	detect := backend.Detect()
+	if detect.InstanceIdentity != "" && binding.InstanceIdentity != detect.InstanceIdentity {
+		foreign = true
+	}
+	participants := make([]PrepareParticipant, 0, len(request.Config.Agents))
+	for _, cfg := range request.Config.Agents {
+		participants = append(participants, PrepareParticipant{
+			Handle: cfg.Handle, Runnable: true, OnLive: request.OnLive[cfg.Handle],
+		})
+	}
+	seats := ClassifyLiveSeats(seatFactsFromBinding(participants, &binding, inspection.Status, detect.Profile.Identity(), foreign))
+	kept, created := 0, 0
+	reason := ""
+	for _, seat := range seats {
+		switch seat.Decision {
+		case SeatRefused:
+			if reason == "" {
+				reason = seat.ReasonCode
+			}
+		case SeatKept:
+			kept++
+		case SeatCreated:
+			created++
+		}
+	}
+	if reason != "" {
+		return seats, false, reason
+	}
+	if kept > 0 && created > 0 {
+		if !tmuxOmittedPlacementJoinSupported(binding.Backend, request.Placement) {
+			return seats, false, PlacementUnsupportedReason
+		}
+		return seats, true, ""
+	}
+	return seats, false, ""
+}
+
+func seatFactsFromBinding(participants []PrepareParticipant, binding *BindingRecord, inspection InspectStatus, profile string, foreign bool) []SeatFacts {
+	owned := map[string]bool{}
+	if binding != nil {
+		for _, resource := range binding.Resources.Resources {
+			if resource.Agent != "" {
+				owned[resource.Agent] = true
+			}
+		}
+	}
+	profileMatch := binding != nil && binding.Profile == profile
+	facts := make([]SeatFacts, 0, len(participants))
+	for _, participant := range participants {
+		if !participant.Runnable {
+			continue
+		}
+		hasResource := owned[participant.Handle]
+		row := SeatFacts{
+			Handle: participant.Handle, Managed: true, OnLive: participant.OnLive,
+			ProfileMatch: profileMatch, Foreign: foreign,
+		}
+		if !hasResource {
+			row.Missing = true
+			row.Inspect = InspectAbsent
+			facts = append(facts, row)
+			continue
+		}
+		row.Owned = true
+		row.Inspect = inspection
+		row.Stale = inspection == InspectUnknown
+		row.Attached = inspection == InspectPresent
+		row.Live = inspection == InspectPresent
+		facts = append(facts, row)
+	}
+	return facts
+}

--- a/internal/launch/liveseat_test.go
+++ b/internal/launch/liveseat_test.go
@@ -1,0 +1,108 @@
+package launch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEligibleToKeepRequiresManagedOwnedAttachedLive(t *testing.T) {
+	ok := keepable("claude")
+	if !EligibleToKeep(ok) {
+		t.Fatal("complete facts must be eligible")
+	}
+	for _, mutate := range []func(*SeatFacts){
+		func(f *SeatFacts) { f.Managed = false },
+		func(f *SeatFacts) { f.Owned = false },
+		func(f *SeatFacts) { f.Attached = false },
+		func(f *SeatFacts) { f.Live = false },
+		func(f *SeatFacts) { f.Inspect = InspectUnknown },
+		func(f *SeatFacts) { f.Foreign = true },
+		func(f *SeatFacts) { f.Stale = true },
+		func(f *SeatFacts) { f.ProfileMatch = false },
+		func(f *SeatFacts) { f.Missing = true },
+	} {
+		facts := ok
+		mutate(&facts)
+		if EligibleToKeep(facts) {
+			t.Fatalf("still eligible after hostile mutate: %#v", facts)
+		}
+	}
+}
+
+func TestClassifyLiveSeatsKeepsLiveAndCreatesMissing(t *testing.T) {
+	rows := ClassifyLiveSeats([]SeatFacts{
+		keepable("claude"),
+		missing("codex"),
+	})
+	want := []SeatDisposition{
+		{Handle: "claude", Decision: SeatKept, StartMode: StartModeResumed},
+		{Handle: "codex", Decision: SeatCreated, StartMode: StartModeFresh},
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("rows = %#v", rows)
+	}
+}
+
+func TestClassifyLiveSeatsForeignRefusesAndCohortBlocksMissing(t *testing.T) {
+	foreign := keepable("claude")
+	foreign.Foreign = true
+	rows := ClassifyLiveSeats([]SeatFacts{foreign, missing("codex")})
+	want := []SeatDisposition{
+		{Handle: "claude", Decision: SeatRefused, ReasonCode: ReasonLiveParticipantRefused},
+		{Handle: "codex", Decision: SeatRefused, ReasonCode: ReasonCohortRefused},
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("foreign cohort = %#v", rows)
+	}
+}
+
+func TestClassifyLiveSeatsStaleAndProfileMismatchRefuse(t *testing.T) {
+	stale := keepable("claude")
+	stale.Stale = true
+	mismatch := keepable("codex")
+	mismatch.ProfileMatch = false
+	rows := ClassifyLiveSeats([]SeatFacts{stale, mismatch, missing("reviewer")})
+	if rows[0].Decision != SeatRefused || rows[0].ReasonCode != ReasonLiveParticipantRefused {
+		t.Fatalf("stale = %#v", rows[0])
+	}
+	if rows[1].Decision != SeatRefused || rows[1].ReasonCode != ReasonLiveParticipantRefused {
+		t.Fatalf("profile mismatch = %#v", rows[1])
+	}
+	if rows[2].Decision != SeatRefused || rows[2].ReasonCode != ReasonCohortRefused {
+		t.Fatalf("cohort missing = %#v", rows[2])
+	}
+}
+
+func TestClassifyLiveSeatsUnknownInspectRefuses(t *testing.T) {
+	unknown := keepable("claude")
+	unknown.Inspect = InspectUnknown
+	unknown.Live = false
+	rows := ClassifyLiveSeats([]SeatFacts{unknown, missing("codex")})
+	if rows[0].ReasonCode != ReasonLiveParticipantRefused || rows[1].ReasonCode != ReasonCohortRefused {
+		t.Fatalf("unknown inspect = %#v", rows)
+	}
+}
+
+func TestClassifyLiveSeatsDefaultRefuseBlocksMissing(t *testing.T) {
+	live := keepable("claude")
+	live.OnLive = ""
+	rows := ClassifyLiveSeats([]SeatFacts{live, missing("codex")})
+	want := []SeatDisposition{
+		{Handle: "claude", Decision: SeatRefused, ReasonCode: ReasonLiveParticipantRefused},
+		{Handle: "codex", Decision: SeatRefused, ReasonCode: ReasonCohortRefused},
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("default refuse = %#v", rows)
+	}
+}
+
+func keepable(handle string) SeatFacts {
+	return SeatFacts{
+		Handle: handle, Managed: true, Owned: true, Attached: true, Live: true,
+		Inspect: InspectPresent, ProfileMatch: true, OnLive: OnLiveKeep,
+	}
+}
+
+func missing(handle string) SeatFacts {
+	return SeatFacts{Handle: handle, Missing: true, Inspect: InspectAbsent, ProfileMatch: true, Managed: true}
+}

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -102,6 +102,7 @@ type PrepareParticipant struct {
 	ResumePolicy ResumePolicy
 	Execution    PrepareExecutionOptions
 	InitialInput *PrepareInitialInput
+	OnLive       string
 }
 
 type PrepareInitialInput struct {
@@ -153,6 +154,7 @@ type PreparedParticipant struct {
 	Execution      PrepareExecutionOptions `json:"execution,omitempty"`
 	PlannedOutcome string                  `json:"planned_outcome"`
 	CwdIdentity    string                  `json:"cwd_identity,omitempty"`
+	OnLive         string                  `json:"on_live,omitempty"`
 }
 
 type PrepareRoster struct {
@@ -172,6 +174,8 @@ type PrepareObservation struct {
 	ExecutionIdentityDigest    string `json:"execution_identity_digest"`
 	Resource                   string `json:"resource"`
 	ReasonCode                 string `json:"reason_code,omitempty"`
+	Disposition                string `json:"disposition,omitempty"`
+	StartMode                  string `json:"start_mode,omitempty"`
 }
 
 type PrepareResult struct {
@@ -320,6 +324,17 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 			return PrepareResult{}, err
 		}
 	}
+	for _, participant := range request.Participants {
+		switch participant.OnLive {
+		case "", OnLiveRefuse:
+		case OnLiveKeep:
+			if subjectSchema == SubjectSchemaV1 {
+				return PrepareResult{}, fmt.Errorf("on_live keep requires subject schema %d", SubjectSchemaV2)
+			}
+		default:
+			return PrepareResult{}, fmt.Errorf("invalid on_live %q", participant.OnLive)
+		}
+	}
 	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath)
 	if err != nil {
 		return PrepareResult{}, err
@@ -457,7 +472,7 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if err != nil {
 		return PrepareResult{}, err
 	}
-	result.TrustDigest, err = PrepareTrustDigestWithAuthority(trustPlanDigest, state.target.Session, state.target.SessionRoot, state.sessionIdentity, baseAuthorityDigest)
+	result.TrustDigest, err = PrepareTrustDigestWithAuthority(trustPlanDigest, state.target.Session, state.target.SessionRoot, state.sessionIdentity, baseAuthorityDigest, onLiveKeepHandles(request.Participants))
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -848,6 +863,9 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 	prepared := PreparedParticipant{
 		Handle: participant.Handle, Runnable: participant.Runnable, Provider: participant.Provider,
 		ResumePolicy: participant.ResumePolicy, Execution: participant.Execution, PlannedOutcome: "participant_only",
+	}
+	if participant.OnLive == OnLiveKeep {
+		prepared.OnLive = OnLiveKeep
 	}
 	observation := PrepareObservation{
 		Handle: participant.Handle, Mailbox: mailbox, Runnable: participant.Runnable,

--- a/internal/launch/prepare_test.go
+++ b/internal/launch/prepare_test.go
@@ -74,6 +74,49 @@ func TestPrepareUnsupportedPlacementSkipsTrustAndCreate(t *testing.T) {
 	}
 }
 
+func TestPrepareRejectsOnLiveKeepOnSubjectSchemaV1BeforeInspection(t *testing.T) {
+	_, err := Prepare(context.Background(), PrepareRequest{
+		IntentDigest:  "sha256:" + strings.Repeat("a", 64),
+		Participants:  []PrepareParticipant{{Handle: "operator", OnLive: OnLiveKeep}},
+		SubjectSchema: SubjectSchemaV1,
+	}, PrepareDependencies{})
+	if err == nil || !strings.Contains(err.Error(), "on_live keep requires subject schema") {
+		t.Fatalf("Prepare error = %v", err)
+	}
+}
+
+func TestPrepareV2SubjectDigestIncludesOnLiveKeepOnly(t *testing.T) {
+	// Digest-stability guard: omit and explicit refuse share subject/trust
+	// digests; keep is the only on_live value that enters them.
+	fixture := newInternalPrepareFixture(t)
+	omitted, err := Prepare(context.Background(), fixture.request, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	refused := fixture.request
+	refused.Participants[0].OnLive = OnLiveRefuse
+	withRefuse, err := Prepare(context.Background(), refused, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if omitted.SubjectDigest != withRefuse.SubjectDigest || omitted.TrustDigest != withRefuse.TrustDigest {
+		t.Fatalf("explicit refuse changed digests omit=%s/%s refuse=%s/%s",
+			omitted.SubjectDigest, omitted.TrustDigest, withRefuse.SubjectDigest, withRefuse.TrustDigest)
+	}
+	kept := fixture.request
+	kept.Participants[0].OnLive = OnLiveKeep
+	withKeep, err := Prepare(context.Background(), kept, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withKeep.SubjectDigest == omitted.SubjectDigest {
+		t.Fatal("on_live keep did not enter the v2 subject digest")
+	}
+	if withKeep.TrustDigest == omitted.TrustDigest {
+		t.Fatal("on_live keep did not enter the trust digest")
+	}
+}
+
 func TestPrepareV2SubjectDigestIncludesPlacement(t *testing.T) {
 	fixture := newInternalPrepareFixture(t)
 	omitted, err := Prepare(context.Background(), fixture.request, fixture.dependencies(&prepareTestBackend{}))

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -79,6 +79,8 @@ type ReconcileRequest struct {
 	ExecutionOptions map[string]PrepareExecutionOptions
 	// Placement is the caller-requested tuple. Nil preserves v0.61 Create.
 	Placement *Placement
+	// OnLive is the per-handle live-seat policy. Missing keys are refuse.
+	OnLive map[string]string
 }
 
 type AgentReconcileResult struct {
@@ -99,6 +101,7 @@ type ReconcileResult struct {
 	Plan           *Plan                  `json:"plan"`
 	SemanticDigest string                 `json:"semantic_digest"`
 	Recovery       *RecoveryReport        `json:"recovery"`
+	Seats          []SeatDisposition      `json:"-"`
 }
 
 type RecoveryReport struct {
@@ -254,6 +257,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	var backend Backend
 	var detect DetectResult
 	var create CreateResult
+	var joinBinding *BindingRecord
 	recoveredCreate := false
 	journalActive := hasJournal
 	if hasJournal {
@@ -293,32 +297,70 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 			journalActive = false
 		}
 	} else {
+		if hasBinding {
+			seats, join, reason := reconcileLiveSeats(request, binding)
+			result.Seats = seats
+			if reason != "" {
+				markPlannedAgents(&result, planned, 6, reason)
+				result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, reason
+				return result, nil
+			}
+			if join {
+				copied := binding
+				joinBinding = &copied
+				kept := make(map[string]bool, len(seats))
+				for _, seat := range seats {
+					if seat.Decision == SeatKept {
+						kept[seat.Handle] = true
+					}
+				}
+				for i := range planned {
+					if kept[planned[i].plan.Handle] {
+						planned[i].write = false
+					}
+				}
+			}
+		}
 		attachSafe := true
 		for _, agent := range planned {
 			attachSafe = attachSafe && !agent.write
 		}
-		var proceed bool
-		backendName, backend, detect, proceed, err = chooseReconcileBackend(request, binding, hasBinding, attachSafe, &result)
-		if err != nil || !proceed {
-			if err != nil {
-				code := reconcileErrorCode(err)
-				markPlannedAgents(&result, planned, code, "backend_reconciliation_failed")
-				result.AggregateCode, result.Reason = code, err.Error()
+		if joinBinding != nil {
+			backendName = binding.Backend
+			backend = request.Backends[backendName]
+			if backend == nil {
+				markPlannedAgents(&result, planned, 6, "bound_launcher_not_available")
+				result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "bound_launcher_not_available"
 				return result, nil
 			}
-			if result.Outcome == OutcomeAttached {
-				result.AggregateCode = aggregateReconcileCode(result.Agents)
+			detect = backend.Detect()
+			if err := detect.Validate(); err != nil {
+				return result, err
+			}
+		} else {
+			var proceed bool
+			backendName, backend, detect, proceed, err = chooseReconcileBackend(request, binding, hasBinding, attachSafe, &result)
+			if err != nil || !proceed {
+				if err != nil {
+					code := reconcileErrorCode(err)
+					markPlannedAgents(&result, planned, code, "backend_reconciliation_failed")
+					result.AggregateCode, result.Reason = code, err.Error()
+					return result, nil
+				}
+				if result.Outcome == OutcomeAttached {
+					result.AggregateCode = aggregateReconcileCode(result.Agents)
+					return result, nil
+				}
+				markPlannedAgents(&result, planned, 6, result.Reason)
+				result.AggregateCode = 6
 				return result, nil
 			}
-			markPlannedAgents(&result, planned, 6, result.Reason)
-			result.AggregateCode = 6
-			return result, nil
 		}
 	}
 	result.Backend = backendName
 
 	if !recoveredCreate {
-		if detect.Profile.Has(CapCreate) {
+		if detect.Profile.Has(CapCreate) && joinBinding == nil {
 			journal, err = NewLaunchJournal(request, backendName, detect, plan, planDigest, nonce, result.Agents, plannedConversations(planned), time.Now())
 			if err != nil {
 				return result, err
@@ -331,12 +373,22 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 				return result, err
 			}
 		}
-		if err := writeExecutionTickets(request, lease, planned, amqExecutable, backendName, detect.Profile.Identity()); err != nil {
+		if err := writeExecutionTickets(request, lease, ticketAgentsForCreate(planned, joinBinding), amqExecutable, backendName, detect.Profile.Identity()); err != nil {
 			return result, err
 		}
+		createPlan := plan
+		if joinBinding != nil {
+			createPlan = Plan{Version: PlanVersion, Agents: make([]AgentPlan, 0)}
+			for _, agent := range planned {
+				if agent.write {
+					createPlan.Agents = append(createPlan.Agents, agent.plan)
+				}
+			}
+		}
 		create, err = backend.Create(CreateRequest{
-			ProjectRoot: request.ProjectRoot, Session: request.Session, Plan: plan,
+			ProjectRoot: request.ProjectRoot, Session: request.Session, Plan: createPlan,
 			AMQPath: amqExecutable, Root: request.Root, Placement: request.Placement,
+			JoinBinding: joinBinding,
 		})
 		if err != nil {
 			var definite *DefinitePreCreateError
@@ -363,7 +415,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		if journalActive && journal.Phase == JournalCreated {
 			candidate = journal.Binding
 		} else {
-			candidate, err = finalizeCreatedState(request.Root, lease, create, backendName, detect, nonce, planned, &result)
+			candidate, err = finalizeCreatedState(request.Root, lease, create, backendName, detect, nonce, planned, &result, joinBinding)
 			if err != nil {
 				return result, err
 			}
@@ -577,9 +629,13 @@ func revalidateAdoption(request ReconcileRequest, backend Backend, journal Launc
 	return nil
 }
 
-func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateResult, backendName string, detect DetectResult, nonce string, planned []plannedAgent, result *ReconcileResult) (*BindingRecord, error) {
+func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateResult, backendName string, detect DetectResult, nonce string, planned []plannedAgent, result *ReconcileResult, joinBinding *BindingRecord) (*BindingRecord, error) {
 	created := create.Binding
-	if created.Backend != backendName || created.Profile != detect.Profile.Identity() || created.LaunchNonce != nonce ||
+	bindingNonce := nonce
+	if joinBinding != nil {
+		bindingNonce = joinBinding.LaunchNonce
+	}
+	if created.Backend != backendName || created.Profile != detect.Profile.Identity() || created.LaunchNonce != bindingNonce ||
 		created.HostIdentity != detect.HostIdentity || created.InstanceIdentity != detect.InstanceIdentity {
 		return nil, fmt.Errorf("backend returned a binding outside the selected launch generation")
 	}

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestReconcileEmitsCanonicalResolvedWorkingDirectory(t *testing.T) {
@@ -276,6 +278,9 @@ type reconcileBackend struct {
 	reclaimFlip bool
 	createErr   error
 	definiteErr bool
+	joined      bool
+	planNonce   string
+	planHandles []string
 }
 
 func (b *reconcileBackend) Detect() DetectResult {
@@ -297,6 +302,14 @@ func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
 		return CreateResult{}, createErr
 	}
 	b.resourceUp = true
+	b.joined = req.JoinBinding != nil
+	b.planHandles = make([]string, 0, len(req.Plan.Agents))
+	for _, agent := range req.Plan.Agents {
+		b.planHandles = append(b.planHandles, agent.Handle)
+	}
+	if len(req.Plan.Agents) > 0 {
+		b.planNonce = req.Plan.Agents[0].LaunchNonce
+	}
 	b.mu.Unlock()
 	if b.createStart != nil {
 		select {
@@ -307,9 +320,13 @@ func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
 	if b.createGate != nil {
 		<-b.createGate
 	}
+	bindingNonce := req.Plan.Agents[0].LaunchNonce
+	if req.JoinBinding != nil {
+		bindingNonce = req.JoinBinding.LaunchNonce
+	}
 	result := CreateResult{Outcome: OutcomeCreated, Profile: b.Detect().Profile.Identity(), Binding: BindingRecord{
 		Version: BindingVersion, Backend: b.name, HostIdentity: "host:test", InstanceIdentity: "instance:test",
-		Profile: b.Detect().Profile.Identity(), LaunchNonce: req.Plan.Agents[0].LaunchNonce,
+		Profile: b.Detect().Profile.Identity(), LaunchNonce: bindingNonce,
 		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:test"}}},
 	}}
 	if b.invalidBind {
@@ -498,6 +515,213 @@ func TestReconcilePresentWithoutConversationMakesNoBackendMutation(t *testing.T)
 	}
 	if result.AggregateCode != 6 || result.Reason != "binding_present_without_resumable_conversation" || backend.creates != 0 || backend.closes != 0 || backend.focuses != 0 {
 		t.Fatalf("result=%#v creates=%d closes=%d focuses=%d", result, backend.creates, backend.closes, backend.focuses)
+	}
+}
+
+func TestReconcileOnLiveKeepJoinWritesTicketsUnderLeaseNonce(t *testing.T) {
+	backend := &reconcileBackend{name: LauncherTMux, inspect: InspectPresent}
+	req := reconcileFixture(t, backend)
+	req.Config.Agents = append(req.Config.Agents, ProjectAgentConfig{
+		Handle: "codex", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeFresh,
+	})
+	req.OnLive = map[string]string{"claude": OnLiveKeep, "codex": OnLiveKeep}
+	lease, err := AcquireLease(req.Root, testLaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherTMux, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: backend.Detect().Profile.Identity(), LaunchNonce: testLaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{
+			{OpaqueID: "resource:claude", Agent: "claude"},
+		}},
+	}
+	if err := WriteBinding(req.Root, lease, binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	held, err := AcquireLease(req.Root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.HeldLease = held
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 0 || result.Outcome != OutcomeCreated {
+		t.Fatalf("join result=%#v", result)
+	}
+	if backend.creates != 1 || !backend.joined {
+		t.Fatalf("join create=%d joined=%v", backend.creates, backend.joined)
+	}
+	if backend.planNonce != held.LaunchNonce() {
+		t.Fatalf("join plan nonce=%s lease=%s", backend.planNonce, held.LaunchNonce())
+	}
+	ticket, err := LoadExecutionTicket(req.Root, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ticket.LaunchNonce != held.LaunchNonce() {
+		t.Fatalf("created ticket nonce=%s lease=%s", ticket.LaunchNonce, held.LaunchNonce())
+	}
+	if _, err := LoadExecutionTicket(req.Root, "claude"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("kept seat wrote an execution ticket: %v", err)
+	}
+	published, err := LoadBinding(req.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if published.LaunchNonce != testLaunchNonce {
+		t.Fatalf("join rebound generation to %s", published.LaunchNonce)
+	}
+	if err := held.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcileOnLiveKeepDoesNotRedeliverKeptSeat(t *testing.T) {
+	backend := &reconcileBackend{name: LauncherTMux, inspect: InspectPresent}
+	req := reconcileFixture(t, backend)
+	req.Config.Agents = append(req.Config.Agents, ProjectAgentConfig{
+		Handle: "codex", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeFresh,
+	})
+	req.OnLive = map[string]string{"claude": OnLiveKeep, "codex": OnLiveKeep}
+	lease, err := AcquireLease(req.Root, testLaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ref, err := WriteEvidence(req.Root, lease, EvidenceWriteRequest{
+		Kind: EvidenceManual, Handle: "claude", ObservedAt: time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC),
+		Payload: []byte(`{"kept":true}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(req.Root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CaptureReady,
+		Identity: ConversationIdentity{Provider: "claude", ID: testConversationID}, LaunchNonce: testLaunchNonce,
+		ExecutionEvidence: reconcileExecutionEvidence(backend, testLaunchNonce),
+		EvidenceRefs:      []string{ref.ID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherTMux, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: backend.Detect().Profile.Identity(), LaunchNonce: testLaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{
+			{OpaqueID: "resource:claude", Agent: "claude"},
+		}},
+	}
+	if err := WriteBinding(req.Root, lease, binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	conversationBefore, err := os.ReadFile(ConversationPath(req.Root.Base(), "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidenceBefore, err := os.ReadFile(EvidencePath(req.Root.Base(), ref.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	held, err := AcquireLease(req.Root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.HeldLease = held
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 0 || backend.creates != 1 || !slices.Equal(backend.planHandles, []string{"codex"}) {
+		t.Fatalf("kept seat redelivered: result=%#v creates=%d handles=%v", result, backend.creates, backend.planHandles)
+	}
+	conversationAfter, err := os.ReadFile(ConversationPath(req.Root.Base(), "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidenceAfter, err := os.ReadFile(EvidencePath(req.Root.Base(), ref.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(conversationBefore, conversationAfter) {
+		t.Fatalf("kept conversation mutated\nbefore=%s\nafter=%s", conversationBefore, conversationAfter)
+	}
+	if !bytes.Equal(evidenceBefore, evidenceAfter) {
+		t.Fatalf("kept evidence mutated")
+	}
+	if err := held.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcileOnLiveProfileMismatchRefusesCohortWithoutMutation(t *testing.T) {
+	backend := &reconcileBackend{name: LauncherTMux, inspect: InspectPresent}
+	req := reconcileFixture(t, backend)
+	req.Config.Agents = append(req.Config.Agents, ProjectAgentConfig{
+		Handle: "codex", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeFresh,
+	})
+	req.OnLive = map[string]string{"claude": OnLiveKeep, "codex": OnLiveKeep}
+	lease, err := AcquireLease(req.Root, testLaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherTMux, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: "tmux/test/v2", LaunchNonce: testLaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{
+			{OpaqueID: "resource:claude", Agent: "claude"},
+		}},
+	}
+	if err := WriteBinding(req.Root, lease, binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	bindingBefore, err := os.ReadFile(BindingPath(req.Root.Base()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Reason != ReasonLiveParticipantRefused {
+		t.Fatalf("profile mismatch result=%#v", result)
+	}
+	if backend.creates != 0 || backend.closes != 0 || backend.focuses != 0 {
+		t.Fatalf("cohort refusal mutated backend creates=%d closes=%d focuses=%d", backend.creates, backend.closes, backend.focuses)
+	}
+	bindingAfter, err := os.ReadFile(BindingPath(req.Root.Base()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(bindingBefore, bindingAfter) {
+		t.Fatalf("cohort refusal mutated binding")
+	}
+	if _, err := LoadJournal(req.Root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cohort refusal wrote a journal: %v", err)
+	}
+	if _, err := LoadExecutionTicket(req.Root, "claude"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cohort refusal wrote a claude ticket: %v", err)
+	}
+	if _, err := LoadExecutionTicket(req.Root, "codex"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cohort refusal wrote a codex ticket: %v", err)
+	}
+	if _, err := os.Stat(ConversationPath(req.Root.Base(), "claude")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cohort refusal wrote a claude conversation")
+	}
+	if _, err := os.Stat(ConversationPath(req.Root.Base(), "codex")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cohort refusal wrote a codex conversation")
 	}
 }
 

--- a/internal/launch/tmux.go
+++ b/internal/launch/tmux.go
@@ -132,6 +132,12 @@ func (b *TmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 	if !detect.Available {
 		return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("tmux %s is unavailable", tmuxProfileVersionRange)}
 	}
+	if req.JoinBinding != nil {
+		if req.Placement != nil {
+			return CreateResult{}, &DefinitePreCreateError{Err: placementError(PlacementUnsupportedReason)}
+		}
+		return b.joinExistingSession(req, detect)
+	}
 	if req.Placement != nil {
 		switch req.Placement.Target {
 		case PlacementTargetSession:
@@ -408,6 +414,59 @@ func (b *TmuxBackend) validateCreate(req CreateRequest) error {
 		return err
 	}
 	return nil
+}
+
+func (b *TmuxBackend) joinExistingSession(req CreateRequest, detect DetectResult) (CreateResult, error) {
+	sessionID, name, err := parseTmuxSessionResource(*req.JoinBinding)
+	if err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: err}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+	defer cancel()
+	present, err := b.hasSession(ctx, name)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	if !present {
+		return CreateResult{}, fmt.Errorf("tmux session %q is absent; keep cannot join", name)
+	}
+	nonce := req.JoinBinding.LaunchNonce
+	for _, agent := range req.Plan.Agents {
+		createdWindow, createErr := b.run(ctx, b.args("new-window", "-d", "-P", "-F", "#{window_id}\t#{pane_id}",
+			"-t", "="+name, "-n", agent.Handle, b.agentCommand(req, agent))...)
+		if createErr != nil {
+			return CreateResult{}, fmt.Errorf("join tmux window for %s: %w", agent.Handle, createErr)
+		}
+		windowFields := strings.Split(strings.TrimSpace(createdWindow), "\t")
+		if len(windowFields) != 2 || windowFields[0] == "" || !tmuxPaneID(windowFields[1]) {
+			return CreateResult{}, fmt.Errorf("tmux returned no window identity for %s", agent.Handle)
+		}
+		if err := b.markWindow(ctx, windowFields[0], agent.Handle); err != nil {
+			return CreateResult{}, err
+		}
+		if err := b.markPane(ctx, windowFields[1], agent.Handle, nonce); err != nil {
+			return CreateResult{}, err
+		}
+	}
+	resources, err := b.liveResources(ctx, name)
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("revalidate joined tmux session: %w", err)
+	}
+	live := map[string]int{}
+	for _, resource := range resources {
+		if resource.Agent != "" {
+			live[resource.Agent]++
+		}
+	}
+	for _, agent := range req.Plan.Agents {
+		if live[agent.Handle] != 1 {
+			return CreateResult{}, fmt.Errorf("joined tmux inventory missing %s", agent.Handle)
+		}
+	}
+	if resources[0].OpaqueID != tmuxSessionResource(sessionID, name) {
+		return CreateResult{}, fmt.Errorf("joined tmux session identity changed before binding")
+	}
+	return b.createdBinding(detect, nonce, resources, req.JoinBinding.Placement)
 }
 
 func (b *TmuxBackend) inspect(ctx context.Context, binding BindingRecord) (InspectResult, error) {

--- a/internal/launch/trust_digest.go
+++ b/internal/launch/trust_digest.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -46,17 +47,18 @@ func ExecutionTrustDigestWithAuthority(plan Plan, session string, root *fsq.Deli
 	if err != nil {
 		return "", fmt.Errorf("resolve trust session-root identity: %w", err)
 	}
-	return executionTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest)
+	return executionTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest, nil)
 }
 
 // PrepareTrustDigest binds a nonce-free plan digest to the canonical target
 // and its physical identity. For an absent session, rootIdentity is a stable
 // intended-child identity derived from the pinned parent and child name.
-func PrepareTrustDigest(planDigest, session, rootPath, rootIdentity string) (string, error) {
-	return PrepareTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, "")
+// onLiveKeep is sorted handles with explicit keep; empty preserves the v0.61 digest.
+func PrepareTrustDigest(planDigest, session, rootPath, rootIdentity string, onLiveKeep []string) (string, error) {
+	return PrepareTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, "", onLiveKeep)
 }
 
-func PrepareTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest string) (string, error) {
+func PrepareTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest string, onLiveKeep []string) (string, error) {
 	if !validDigest(planDigest) {
 		return "", fmt.Errorf("invalid prepare plan digest")
 	}
@@ -70,11 +72,11 @@ func PrepareTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity
 	if err != nil {
 		return "", fmt.Errorf("resolve prepare trust session root: %w", err)
 	}
-	return executionTrustDigestWithAuthority(planDigest, session, canonicalRoot, rootIdentity, authorityDigest)
+	return executionTrustDigestWithAuthority(planDigest, session, canonicalRoot, rootIdentity, authorityDigest, onLiveKeep)
 }
 
-func executionTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest string) (string, error) {
-	legacy, err := executionTrustDigest(planDigest, session, rootPath, rootIdentity)
+func executionTrustDigestWithAuthority(planDigest, session, rootPath, rootIdentity, authorityDigest string, onLiveKeep []string) (string, error) {
+	legacy, err := executionTrustDigest(planDigest, session, rootPath, rootIdentity, onLiveKeep)
 	if err != nil || authorityDigest == "" {
 		return legacy, err
 	}
@@ -88,16 +90,20 @@ func executionTrustDigestWithAuthority(planDigest, session, rootPath, rootIdenti
 	}{Version: 2, LegacyDigest: legacy, AuthorityDigest: authorityDigest})
 }
 
-func executionTrustDigest(planDigest, session, rootPath, rootIdentity string) (string, error) {
+func executionTrustDigest(planDigest, session, rootPath, rootIdentity string, onLiveKeep []string) (string, error) {
+	keep := slices.Clone(onLiveKeep)
+	slices.Sort(keep)
 	canonical, err := json.Marshal(struct {
-		Version      int    `json:"version"`
-		PlanDigest   string `json:"plan_digest"`
-		Session      string `json:"session"`
-		RootPath     string `json:"root_path"`
-		RootIdentity string `json:"root_identity"`
+		Version      int      `json:"version"`
+		PlanDigest   string   `json:"plan_digest"`
+		Session      string   `json:"session"`
+		RootPath     string   `json:"root_path"`
+		RootIdentity string   `json:"root_identity"`
+		OnLiveKeep   []string `json:"on_live_keep,omitempty"`
 	}{
 		Version: executionTrustDigestVersion, PlanDigest: planDigest,
 		Session: session, RootPath: filepath.Clean(rootPath), RootIdentity: rootIdentity,
+		OnLiveKeep: keep,
 	})
 	if err != nil {
 		return "", err

--- a/internal/launch/trust_digest_test.go
+++ b/internal/launch/trust_digest_test.go
@@ -43,7 +43,7 @@ func TestPrepareTrustDigestMatchesExistingTrustSubjectForPresentRoot(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	prepared, err := PrepareTrustDigest(planDigest, "collab", root.Base(), rootIdentity)
+	prepared, err := PrepareTrustDigest(planDigest, "collab", root.Base(), rootIdentity, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/launchapi/apply.go
+++ b/launchapi/apply.go
@@ -60,6 +60,7 @@ func fromInternalApplyResult(result internallaunch.ApplyResult) ApplyResultV1 {
 			Handle: observation.Handle, Mailbox: observation.Mailbox, Runnable: observation.Runnable,
 			Conversation: observation.Conversation, Execution: observation.Execution,
 			Resource: observation.Resource, ReasonCode: observation.ReasonCode,
+			Disposition: observation.Disposition, StartMode: observation.StartMode,
 		})
 	}
 	for _, command := range result.Commands {

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -19,6 +19,7 @@ var compatibilityFeaturesV1 = []string{
 	FeatureInitialInput,
 	FeaturePlacement,
 	FeatureBaseRoot,
+	FeatureOnLive,
 }
 
 func Compatibility() CompatibilityV1 {

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -27,8 +27,11 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if !slices.Contains(Compatibility().Features, FeatureBaseRoot) {
 		t.Fatal("Compatibility did not advertise the completed base_root feature")
 	}
+	if !slices.Contains(Compatibility().Features, FeatureOnLive) {
+		t.Fatal("Compatibility omitted advertised on_live")
+	}
 	for _, unfinished := range []string{
-		FeatureOnLive, FeatureWrapper,
+		FeatureWrapper,
 		FeatureCallerContext, FeatureExecutableIdentity,
 	} {
 		if slices.Contains(Compatibility().Features, unfinished) {

--- a/launchapi/intent.go
+++ b/launchapi/intent.go
@@ -75,7 +75,8 @@ func (participant ParticipantV1) validate() error {
 	}
 	if !participant.Runnable {
 		if participant.Executable != "" || participant.Args != nil || participant.Cwd != nil ||
-			participant.InitialInput != nil || participant.EnvOverlay != nil || participant.ResumePolicy != "" || participant.Execution != nil {
+			participant.InitialInput != nil || participant.EnvOverlay != nil || participant.ResumePolicy != "" ||
+			participant.Execution != nil || participant.OnLive != "" {
 			return fmt.Errorf("non-runnable participant %q must be handle-only", participant.Handle)
 		}
 		return nil
@@ -93,6 +94,11 @@ func (participant ParticipantV1) validate() error {
 	case ResumePolicyResume, ResumePolicyFresh, ResumePolicyDisabled:
 	default:
 		return fmt.Errorf("runnable participant %q has invalid resume policy %q", participant.Handle, participant.ResumePolicy)
+	}
+	switch participant.OnLive {
+	case "", OnLiveRefuse, OnLiveKeep:
+	default:
+		return fmt.Errorf("runnable participant %q has invalid on_live %q", participant.Handle, participant.OnLive)
 	}
 	if participant.Execution == nil {
 		return fmt.Errorf("runnable participant %q requires execution options", participant.Handle)
@@ -201,7 +207,7 @@ func requireLaunchIntentFields(data []byte) error {
 			if err := requireObjectFields(fields["cwd"], fmt.Sprintf("participants[%d].cwd", i), "kind", "path"); err != nil {
 				return err
 			}
-			for _, optional := range []string{"args", "env_overlay"} {
+			for _, optional := range []string{"args", "env_overlay", "on_live"} {
 				if err := rejectExplicitNull(fields, optional, fmt.Sprintf("participants[%d]", i)); err != nil {
 					return err
 				}

--- a/launchapi/intent_test.go
+++ b/launchapi/intent_test.go
@@ -80,6 +80,23 @@ func TestLaunchIntentNonRunnableIsHandleOnly(t *testing.T) {
 	}
 }
 
+func TestLaunchIntentOnLivePolicy(t *testing.T) {
+	base := `{"intent_version":1,"participants":[{"handle":"codex","runnable":true,"executable":"codex","cwd":{"kind":"relative","path":"."},"resume_policy":"fresh","execution":{"require_wake":false,"no_gitignore":false,"wake":{"mode":"enabled"}}%s}]}`
+	if _, err := DecodeLaunchIntentV1([]byte(fmt.Sprintf(base, `,"on_live":"keep"`))); err != nil {
+		t.Fatalf("keep rejected: %v", err)
+	}
+	if _, err := DecodeLaunchIntentV1([]byte(fmt.Sprintf(base, `,"on_live":"refuse"`))); err != nil {
+		t.Fatalf("refuse rejected: %v", err)
+	}
+	if _, err := DecodeLaunchIntentV1([]byte(fmt.Sprintf(base, `,"on_live":"resume"`))); err == nil || !strings.Contains(err.Error(), "on_live") {
+		t.Fatalf("invalid on_live error = %v", err)
+	}
+	hostile := `{"intent_version":1,"participants":[{"handle":"operator","runnable":false,"on_live":"keep"}]}`
+	if _, err := DecodeLaunchIntentV1([]byte(hostile)); err == nil || !strings.Contains(err.Error(), "exactly handle and runnable") {
+		t.Fatalf("non-runnable on_live error = %v", err)
+	}
+}
+
 func TestNonRunnableValidateRejectsSmuggledGoFields(t *testing.T) {
 	participant := ParticipantV1{Handle: "operator", Runnable: false, Executable: "codex"}
 	if err := participant.validate(); err == nil || !strings.Contains(err.Error(), "handle-only") {

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -108,6 +108,7 @@ func toInternalPrepareParticipant(participant ParticipantV1, provider string, co
 		Handle: participant.Handle, Runnable: participant.Runnable, Provider: provider,
 		Executable: participant.Executable, Args: slices.Clone(committedArgs), BypassArgs: slices.Clone(bypassArgs), EnvOverlay: cloneStringMap(participant.EnvOverlay),
 		ResumePolicy: internallaunch.ResumePolicy(participant.ResumePolicy),
+		OnLive:       string(participant.OnLive),
 	}
 	if participant.InitialInput != nil {
 		result.InitialInput = &internallaunch.PrepareInitialInput{Kind: internallaunch.InitialInputKind(participant.InitialInput.Kind), Text: participant.InitialInput.Text}

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -31,6 +31,13 @@ const (
 	ResumePolicyDisabled ResumePolicy = "disabled"
 )
 
+type OnLivePolicyV1 string
+
+const (
+	OnLiveRefuse OnLivePolicyV1 = "refuse"
+	OnLiveKeep   OnLivePolicyV1 = "keep"
+)
+
 type WorkingDirectoryKind string
 
 const (
@@ -78,6 +85,7 @@ type ParticipantV1 struct {
 	EnvOverlay   map[string]string   `json:"env_overlay,omitempty"`
 	ResumePolicy ResumePolicy        `json:"resume_policy,omitempty"`
 	Execution    *ExecutionOptionsV1 `json:"execution,omitempty"`
+	OnLive       OnLivePolicyV1      `json:"on_live,omitempty"`
 }
 
 type WorkingDirectoryV1 struct {
@@ -255,6 +263,8 @@ type ParticipantObservationV1 struct {
 	Execution    string `json:"execution"`
 	Resource     string `json:"resource"`
 	ReasonCode   string `json:"reason_code,omitempty"`
+	Disposition  string `json:"disposition,omitempty"`
+	StartMode    string `json:"start_mode,omitempty"`
 }
 
 type PlannedWriteKindV1 string

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -53,6 +53,7 @@
           "propertyNames": {"pattern": "^[^=]+$"}
         },
         "resume_policy": {"enum": ["resume", "fresh", "disabled"]},
+        "on_live": {"enum": ["keep", "refuse"]},
         "execution": {"$ref": "#/$defs/ExecutionOptionsV1"}
       }
     },
@@ -305,7 +306,9 @@
         "conversation": {"type": "string"},
         "execution": {"type": "string"},
         "resource": {"type": "string"},
-        "reason_code": {"type": "string"}
+        "reason_code": {"type": "string"},
+        "disposition": {"enum": ["kept", "created", "refused"]},
+        "start_mode": {"enum": ["resumed", "fresh"]}
       }
     },
     "PlannedWriteV1": {


### PR DESCRIPTION
## Summary
- Add `on_live` keep|refuse on launch participants. Omission matches explicit refuse (v0.61 whole-binding refusal). Explicit keep on a proven-owned live tmux seat keeps that process and creates missing seats in the same omitted-placement session.
- Advertise `on_live` alongside `base_root`. Schema 1 rejects keep; omit/refuse stay digest-stable. Apply reuses the existing binding nonce for join (one nonce per binding) so tickets match the live generation.
- Hostile live seats refuse even with keep. ProfileMatch uses `detect.Profile.Identity()`. Cohort refusal and kept-seat paths have zero-mutation / no-redelivery proofs.

## Test plan
- [x] `make ci` on `feat/amq-09i-on-live`
- [x] `go test ./internal/launch` including keep join, profile-mismatch cohort refusal, and kept-seat no-redelivery
- [x] Adoption oracle `finding1_missing_profile_base_root` and `finding2_mixed_live_fresh_keep_creates`
- [ ] GitHub CI green


Made with [Cursor](https://cursor.com)