### PR TITLE
feat(launchapi): bind and persist caller context in subject and evidence

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -21,10 +21,10 @@ if err != nil {
 _ = negotiated
 ```
 
-A `0.61.1` binary advertises `placement`, `initial_input`, `base_root`, and
-`on_live` and can still omit later Wave B3 feature IDs while those beads are
-incomplete. A caller must require every feature it uses. Contract semver alone
-does not claim that an unadvertised feature is available.
+A `0.61.1` binary advertises `placement`, `initial_input`, `base_root`,
+`on_live`, and `caller_context`. It can still omit later Wave B3 feature IDs
+while those beads are incomplete. A caller must require every feature it uses.
+Contract semver alone does not claim that an unadvertised feature is available.
 
 `PreviewV1.capabilities` reports the selected providers' static adapter grammar
 without executing a caller-supplied provider. `grammar_version` is the
@@ -157,6 +157,14 @@ process and lets Apply create missing seats in the same tmux omitted-placement
 session. Hostile live resources refuse even with `keep`. Schema 1 rejects
 `on_live: keep`; omit and `refuse` stay digest-stable.
 
+`caller_context` is an opaque correlation map. It is limited to 32 entries;
+keys are 1 through 64 UTF-8 bytes, values are at most 1,024 UTF-8 bytes, and
+all keys plus values are at most 16 KiB. NUL, invalid UTF-8, and duplicate JSON
+keys reject. Canonical key ordering enters subject schema 2 and immutable
+evidence, but never the plan or trust digest. Apply echoes the request map.
+Inspect, Focus, and Close load it from the proven-owned binding; lifecycle
+requests cannot replace it.
+
 ```go
 request := launchapi.PrepareRequestV1{
 	RequestVersion: launchapi.RequestVersionV1,
@@ -169,6 +177,9 @@ request := launchapi.PrepareRequestV1{
 	Launcher: "tmux",
 	Placement: &launchapi.PlacementV1{
 		Target: launchapi.PlacementCurrentWindow, Layout: launchapi.PlacementColumns, LauncherPane: "%17",
+	},
+	CallerContext: map[string]string{
+		"run_id": "run-42", "task_generation": "3",
 	},
 	Intent: intent,
 }

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -29,7 +29,7 @@ import (
 //	finding3_wrapper_unknown_field | 3 wrapper | strict decode unknown field "wrapper" | wrapper argv prepended to full provider argv
 //	finding4_placement_unsupported | 4 placement | AMQ_SQUAD_TMUX_* env rejected as provider env | placement preview; unsupported tuple -> placement_unsupported
 //	finding5_positional_bootstrap_prompt / finding5_claude_allowed_tools / finding5_codex_dash_c | 5 materialized argv | raw positional prompt rejected; exact --allowedTools and -c forms admitted | initial_input + --allowedTools / -c admitted
-//	finding6_caller_context_unknown_field | 6 caller correlation | strict decode unknown field "caller_context" | caller_context echoed on Apply/evidence/lifecycle
+//	finding6_caller_context_bound_and_echoed | 6 caller correlation | caller_context is subject-bound and echoed on Apply/evidence/lifecycle
 //	finding7_same_path_inode_replacement_not_subject_changed | 7 physical identity | same-path inode replacement leaves subject/plan/trust digests identical | inode replacement -> subject_changed
 //
 // Real bootstrap text from the squad-v2-29-4 compiler, not the placeholder in
@@ -107,12 +107,20 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		assertAdoptionUnknownField(t, exit, stdout, stderr, "wrapper")
 	})
 
-	t.Run("finding6_caller_context_unknown_field", func(t *testing.T) {
+	t.Run("finding6_caller_context_bound_and_echoed", func(t *testing.T) {
 		fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "collab")
 		raw := fx.applyEnvelopeJSON(t, fx.legalSquadIntent(), launch.LauncherCommands, "sha256:"+strings.Repeat("a", 64))
 		raw = injectPrepareJSONField(t, raw, "caller_context", map[string]any{"run_id": "v2-29-6"})
+		raw = []byte(strings.Replace(string(raw), `"subject_digest":`, `"subject_schema":2,"subject_digest":`, 1))
 		stdout, stderr, exit := fx.applyJSONBytes(t, raw)
-		assertAdoptionUnknownField(t, exit, stdout, stderr, "caller_context")
+		if exit != ExitActionRequired {
+			t.Fatalf("caller context Apply exit=%d stderr=%s stdout=%s", exit, stderr, stdout)
+		}
+		var result launchapi.ApplyResultV1
+		decodeRealLaunchJSON(t, stdout, &result)
+		if result.ReasonCode != "subject_changed" || len(result.CallerContext) != 1 || result.CallerContext["run_id"] != "v2-29-6" {
+			t.Fatalf("caller context Apply = %#v", result)
+		}
 	})
 
 	t.Run("finding1_missing_profile_base_root", func(t *testing.T) {

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -52,6 +52,7 @@ type ApplyResult struct {
 	Commands        []EmittedCommand
 	RequiredActions []PrepareRequiredAction
 	Evidence        []EvidenceRef
+	CallerContext   map[string]string
 }
 
 var afterApplySessionPublishedForTest func()
@@ -539,6 +540,7 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		AllowFreshFallback: decisions[ActionStaleConversation] == "fresh_once",
 		Placement:          prepared.Placement,
 		OnLive:             onLivePolicies(runnable),
+		CallerContext:      cloneCallerContext(prepared.CallerContext),
 	}
 	if choice := decisions[ActionTrustConfirmation]; choice == "trust_exact_subject" {
 		request.ConfirmTrust = func(plan Plan, actualTrustDigest string) (bool, error) {
@@ -651,6 +653,7 @@ func applyResultFromPrepare(prepared PrepareResult) ApplyResult {
 		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, PlanDigest: prepared.PlanDigest, TrustDigest: prepared.TrustDigest,
 		Backend: prepared.Backend, Profile: prepared.Profile, Roster: prepared.Roster,
 		Observations: slices.Clone(prepared.Observations), RequiredActions: slices.Clone(prepared.RequiredActions),
+		CallerContext: cloneCallerContext(prepared.CallerContext),
 	}
 }
 

--- a/internal/launch/binding.go
+++ b/internal/launch/binding.go
@@ -28,6 +28,7 @@ type BindingRecord struct {
 	LaunchNonce      string              `json:"launch_nonce"`
 	Resources        ResourceIdentitySet `json:"resources"`
 	Placement        PlacementPreview    `json:"placement,omitempty"`
+	CallerContext    map[string]string   `json:"caller_context,omitempty"`
 }
 
 type ResourceIdentitySet struct {
@@ -76,6 +77,9 @@ func (record BindingRecord) Validate() error {
 		if _, ok := seen[owned]; ok {
 			return fmt.Errorf("launcher pane %q must not be an owned resource", pane)
 		}
+	}
+	if err := ValidateCallerContext(record.CallerContext); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/launch/caller_context.go
+++ b/internal/launch/caller_context.go
@@ -1,0 +1,60 @@
+package launch
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	MaxCallerContextEntries    = 32
+	MaxCallerContextKeyBytes   = 64
+	MaxCallerContextValueBytes = 1024
+	MaxCallerContextTotalBytes = 16 * 1024
+)
+
+type CallerContextValidationError struct{ Reason string }
+
+func (err *CallerContextValidationError) Error() string { return "caller_context: " + err.Reason }
+
+func callerContextErrorf(format string, args ...any) error {
+	return &CallerContextValidationError{Reason: fmt.Sprintf(format, args...)}
+}
+
+// ValidateCallerContext validates opaque caller-owned correlation metadata.
+func ValidateCallerContext(context map[string]string) error {
+	if len(context) > MaxCallerContextEntries {
+		return callerContextErrorf("has %d entries, maximum is %d", len(context), MaxCallerContextEntries)
+	}
+	total := 0
+	for key, value := range context {
+		if !utf8.ValidString(key) || !utf8.ValidString(value) {
+			return callerContextErrorf("contains invalid UTF-8")
+		}
+		if strings.ContainsRune(key, 0) || strings.ContainsRune(value, 0) {
+			return callerContextErrorf("must not contain NUL")
+		}
+		if len(key) == 0 || len(key) > MaxCallerContextKeyBytes {
+			return callerContextErrorf("key length must be 1 through %d UTF-8 bytes", MaxCallerContextKeyBytes)
+		}
+		if len(value) > MaxCallerContextValueBytes {
+			return callerContextErrorf("value length must not exceed %d UTF-8 bytes", MaxCallerContextValueBytes)
+		}
+		total += len(key) + len(value)
+	}
+	if total > MaxCallerContextTotalBytes {
+		return callerContextErrorf("contains %d UTF-8 bytes, maximum is %d", total, MaxCallerContextTotalBytes)
+	}
+	return nil
+}
+
+func cloneCallerContext(context map[string]string) map[string]string {
+	if len(context) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(context))
+	for key, value := range context {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/launch/caller_context_test.go
+++ b/internal/launch/caller_context_test.go
@@ -1,0 +1,53 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCallerContextBounds(t *testing.T) {
+	valid := map[string]string{"": ""}
+	if err := ValidateCallerContext(valid); err == nil || !strings.Contains(err.Error(), "key length") {
+		t.Fatalf("empty key error = %v", err)
+	}
+	for _, test := range []struct {
+		name    string
+		context map[string]string
+		want    string
+	}{
+		{name: "entries", context: callerContextEntries(33), want: "entries"},
+		{name: "key", context: map[string]string{strings.Repeat("k", 65): "v"}, want: "key length"},
+		{name: "value", context: map[string]string{"key": strings.Repeat("v", 1025)}, want: "value length"},
+		{name: "total", context: callerContextTotalOverflow(), want: "UTF-8 bytes"},
+		{name: "key NUL", context: map[string]string{"bad\x00key": "v"}, want: "NUL"},
+		{name: "value NUL", context: map[string]string{"key": "bad\x00value"}, want: "NUL"},
+		{name: "invalid key UTF-8", context: map[string]string{string([]byte{0xff}): "v"}, want: "invalid UTF-8"},
+		{name: "invalid value UTF-8", context: map[string]string{"key": string([]byte{0xff})}, want: "invalid UTF-8"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateCallerContext(test.context); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateCallerContext error = %v, want %q", err, test.want)
+			}
+		})
+	}
+	if err := ValidateCallerContext(callerContextEntries(32)); err != nil {
+		t.Fatalf("maximum valid context: %v", err)
+	}
+}
+
+func callerContextEntries(count int) map[string]string {
+	context := make(map[string]string, count)
+	for i := 0; i < count; i++ {
+		context[string(rune('a'+i))] = "v"
+	}
+	return context
+}
+
+func callerContextTotalOverflow() map[string]string {
+	context := make(map[string]string, 16)
+	for i := 0; i < 15; i++ {
+		context[string(rune('a'+i))] = strings.Repeat("v", 1024)
+	}
+	context["p"] = strings.Repeat("v", 1009)
+	return context
+}

--- a/internal/launch/evidence.go
+++ b/internal/launch/evidence.go
@@ -32,27 +32,30 @@ const (
 )
 
 type EvidenceRecord struct {
-	EvidenceVersion int             `json:"evidence_version"`
-	Kind            EvidenceKind    `json:"kind"`
-	Handle          string          `json:"handle"`
-	ObservedAt      time.Time       `json:"observed_at"`
-	PayloadSHA256   string          `json:"payload_sha256"`
-	Payload         json.RawMessage `json:"payload"`
+	EvidenceVersion int               `json:"evidence_version"`
+	Kind            EvidenceKind      `json:"kind"`
+	Handle          string            `json:"handle"`
+	ObservedAt      time.Time         `json:"observed_at"`
+	PayloadSHA256   string            `json:"payload_sha256"`
+	Payload         json.RawMessage   `json:"payload"`
+	CallerContext   map[string]string `json:"caller_context,omitempty"`
 }
 
 type EvidenceRef struct {
-	EvidenceVersion int          `json:"evidence_version"`
-	ID              string       `json:"id"`
-	Kind            EvidenceKind `json:"kind"`
-	SHA256          string       `json:"sha256"`
-	ObservedAt      time.Time    `json:"observed_at"`
+	EvidenceVersion int               `json:"evidence_version"`
+	ID              string            `json:"id"`
+	Kind            EvidenceKind      `json:"kind"`
+	SHA256          string            `json:"sha256"`
+	ObservedAt      time.Time         `json:"observed_at"`
+	CallerContext   map[string]string `json:"caller_context,omitempty"`
 }
 
 type EvidenceWriteRequest struct {
-	Kind       EvidenceKind
-	Handle     string
-	ObservedAt time.Time
-	Payload    []byte
+	Kind          EvidenceKind
+	Handle        string
+	ObservedAt    time.Time
+	Payload       []byte
+	CallerContext map[string]string
 }
 
 type EvidenceCorruptError struct {
@@ -100,6 +103,7 @@ func prepareEvidence(request EvidenceWriteRequest) (EvidenceRecord, EvidenceRef,
 	record := EvidenceRecord{
 		EvidenceVersion: EvidenceVersion, Kind: request.Kind, Handle: request.Handle,
 		ObservedAt: request.ObservedAt.UTC(), PayloadSHA256: payloadDigest, Payload: payload,
+		CallerContext: cloneCallerContext(request.CallerContext),
 	}
 	if err := record.Validate(); err != nil {
 		return EvidenceRecord{}, EvidenceRef{}, nil, err
@@ -169,6 +173,9 @@ func (record EvidenceRecord) Validate() error {
 	if record.PayloadSHA256 != digestBytes(payload) {
 		return fmt.Errorf("payload digest mismatch")
 	}
+	if err := ValidateCallerContext(record.CallerContext); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -190,7 +197,7 @@ func canonicalEvidencePayload(raw []byte) ([]byte, error) {
 }
 
 func evidenceRef(id string, record EvidenceRecord) EvidenceRef {
-	return EvidenceRef{EvidenceVersion: EvidenceVersion, ID: id, Kind: record.Kind, SHA256: id, ObservedAt: record.ObservedAt}
+	return EvidenceRef{EvidenceVersion: EvidenceVersion, ID: id, Kind: record.Kind, SHA256: id, ObservedAt: record.ObservedAt, CallerContext: cloneCallerContext(record.CallerContext)}
 }
 
 func evidenceFilename(id string) string { return strings.TrimPrefix(id, "sha256:") + ".json" }
@@ -205,6 +212,10 @@ func EvidencePath(sessionRoot, id string) string {
 }
 
 func persistProviderCaptureEvidence(root *fsq.DeliveryRoot, lease *Lease, handle string, evidence []CaptureEvidence) ([]string, error) {
+	return persistProviderCaptureEvidenceWithContext(root, lease, handle, nil, evidence)
+}
+
+func persistProviderCaptureEvidenceWithContext(root *fsq.DeliveryRoot, lease *Lease, handle string, callerContext map[string]string, evidence []CaptureEvidence) ([]string, error) {
 	refs := make([]string, 0, len(evidence))
 	for _, item := range evidence {
 		if !item.verified || len(item.payload) == 0 {
@@ -228,6 +239,7 @@ func persistProviderCaptureEvidence(root *fsq.DeliveryRoot, lease *Lease, handle
 		}
 		request := EvidenceWriteRequest{
 			Kind: EvidenceProviderCapture, Handle: handle, ObservedAt: item.observedAt, Payload: item.payload,
+			CallerContext: cloneCallerContext(callerContext),
 		}
 		ref, err := WriteEvidence(root, lease, request)
 		var exists *EvidenceExistsError

--- a/internal/launch/evidence_test.go
+++ b/internal/launch/evidence_test.go
@@ -30,7 +30,7 @@ func TestImmutableCaptureEvidenceReadback(t *testing.T) {
 	}
 	request := EvidenceWriteRequest{
 		Kind: EvidenceProviderCapture, Handle: "claude", ObservedAt: observed,
-		Payload: capture.payload,
+		Payload: capture.payload, CallerContext: map[string]string{"run_id": "run-42"},
 	}
 	providerRef, err := WriteEvidence(fixture.root, lease, request)
 	if err != nil {
@@ -43,6 +43,19 @@ func TestImmutableCaptureEvidenceReadback(t *testing.T) {
 		if !errors.As(err, &exists) || exists.ID != providerRef.ID {
 			t.Fatalf("duplicate evidence error = %v", err)
 		}
+	}
+	record, readRef, err := ReadEvidence(fixture.root, providerRef.ID)
+	if err != nil || !reflect.DeepEqual(record.CallerContext, request.CallerContext) || !reflect.DeepEqual(readRef.CallerContext, request.CallerContext) {
+		t.Fatalf("evidence caller context readback = record %#v ref %#v err %v", record.CallerContext, readRef.CallerContext, err)
+	}
+	changedContext := request
+	changedContext.CallerContext = map[string]string{"run_id": "run-43"}
+	changedRef, err := WriteEvidence(fixture.root, lease, changedContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changedRef.ID == providerRef.ID {
+		t.Fatal("caller context did not enter immutable evidence digest")
 	}
 	manualRef, err := WriteEvidence(fixture.root, lease, EvidenceWriteRequest{
 		Kind: EvidenceManual, Handle: "claude", ObservedAt: observed.Add(time.Second), Payload: []byte(`{"claimed":"provider"}`),

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -67,14 +67,15 @@ type ExecutionTicket struct {
 	InjectorExecutable         string `json:"injector_executable,omitempty"`
 	InjectorExecutableIdentity string `json:"injector_executable_identity,omitempty"`
 
-	TargetArgv   []string                 `json:"target_argv"`
-	DynamicArgv  []DynamicArg             `json:"dynamic_argv,omitempty"`
-	InitialInput *PlannedInitialInput     `json:"initial_input,omitempty"`
-	TargetEnv    map[string]string        `json:"target_env,omitempty"`
-	EnvDigest    string                   `json:"env_digest"`
-	State        ExecutionState           `json:"state"`
-	Reason       string                   `json:"reason,omitempty"`
-	Execution    *PrepareExecutionOptions `json:"execution,omitempty"`
+	TargetArgv    []string                 `json:"target_argv"`
+	DynamicArgv   []DynamicArg             `json:"dynamic_argv,omitempty"`
+	InitialInput  *PlannedInitialInput     `json:"initial_input,omitempty"`
+	TargetEnv     map[string]string        `json:"target_env,omitempty"`
+	EnvDigest     string                   `json:"env_digest"`
+	State         ExecutionState           `json:"state"`
+	Reason        string                   `json:"reason,omitempty"`
+	Execution     *PrepareExecutionOptions `json:"execution,omitempty"`
+	CallerContext map[string]string        `json:"caller_context,omitempty"`
 }
 
 type ExecutionTicketRequest struct {
@@ -94,6 +95,7 @@ type ExecutionTicketRequest struct {
 	State                             ExecutionState
 	Reason                            string
 	Execution                         *PrepareExecutionOptions
+	CallerContext                     map[string]string
 }
 
 type ExecutionEnvelope struct {
@@ -170,6 +172,7 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 		InitialInput: clonePlannedInitialInput(request.InitialInput),
 		TargetEnv:    env, EnvDigest: digest, State: request.State, Reason: request.Reason,
 		Execution: execution, InjectorExecutable: injector, InjectorExecutableIdentity: injectorID,
+		CallerContext: cloneCallerContext(request.CallerContext),
 	}
 	if ticket.State == "" {
 		ticket.State = ExecutionPending
@@ -232,6 +235,9 @@ func (ticket ExecutionTicket) Validate() error {
 		}
 	}
 	if err := validateTicketInitialInput(ticket); err != nil {
+		return err
+	}
+	if err := ValidateCallerContext(ticket.CallerContext); err != nil {
 		return err
 	}
 	if ticket.Mode == AdapterModeCapture && ticket.Provider == CodexProvider && ticket.ProviderVersion == codexCaptureVersion {
@@ -655,7 +661,7 @@ func preparePreSpawnCapture(root *fsq.DeliveryRoot, lease *Lease, ticket Executi
 			if !capture.CanPersist() || capture.Identity.Provider != ticket.Provider {
 				return ticket, fmt.Errorf("cursor create-chat did not yield persistable launch evidence")
 			}
-			refs, persistErr := persistProviderCaptureEvidence(root, lease, ticket.Handle, []CaptureEvidence{evidence})
+			refs, persistErr := persistProviderCaptureEvidenceWithContext(root, lease, ticket.Handle, ticket.CallerContext, []CaptureEvidence{evidence})
 			if persistErr != nil {
 				return ticket, persistErr
 			}
@@ -746,7 +752,8 @@ func validateCursorExecutionEvidence(root *fsq.DeliveryRoot, ticket ExecutionTic
 	}
 	if record.Kind != EvidenceProviderCapture || record.Handle != ticket.Handle || payload.Handle != ticket.Handle ||
 		payload.Provider != ticket.Provider || payload.LaunchNonce != ticket.LaunchNonce ||
-		payload.ProviderVersion != ticket.ProviderVersion || payload.ConversationID != ticket.ConversationID {
+		payload.ProviderVersion != ticket.ProviderVersion || payload.ConversationID != ticket.ConversationID ||
+		!reflect.DeepEqual(record.CallerContext, ticket.CallerContext) {
 		return fmt.Errorf("cursor execution evidence binding mismatch")
 	}
 	return nil
@@ -825,11 +832,15 @@ func recordCodexNotify(root *fsq.DeliveryRoot, handle, nonce, amqExecutable stri
 		return result, err
 	}
 	if found {
+		_, ref, readErr := ReadEvidence(root, refID)
+		if readErr != nil || !reflect.DeepEqual(ref.CallerContext, ticket.CallerContext) {
+			return result, fmt.Errorf("codex notify evidence caller context mismatch")
+		}
 		if stored.conversationID != evidence.conversationID {
 			return result, &CodexNotifyConflictError{Existing: stored.conversationID, Observed: evidence.conversationID}
 		}
 	} else {
-		refs, persistErr := persistProviderCaptureEvidence(root, lease, handle, []CaptureEvidence{evidence})
+		refs, persistErr := persistProviderCaptureEvidenceWithContext(root, lease, handle, ticket.CallerContext, []CaptureEvidence{evidence})
 		if persistErr != nil {
 			return result, persistErr
 		}

--- a/internal/launch/journal.go
+++ b/internal/launch/journal.go
@@ -53,6 +53,7 @@ type LaunchJournal struct {
 	Conversations    []ConversationRecord   `json:"conversations"`
 	Binding          *BindingRecord         `json:"binding,omitempty"`
 	Placement        PlacementPreview       `json:"placement,omitempty"`
+	CallerContext    map[string]string      `json:"caller_context,omitempty"`
 }
 
 func (record LaunchJournal) Validate() error {
@@ -82,6 +83,9 @@ func (record LaunchJournal) Validate() error {
 	}
 	if err := validateOptionalPlacement(record.Placement); err != nil {
 		return fmt.Errorf("launch journal placement: %w", err)
+	}
+	if err := ValidateCallerContext(record.CallerContext); err != nil {
+		return err
 	}
 	if !validUUID(record.LaunchNonce) {
 		return fmt.Errorf("launch journal nonce must be a UUID")
@@ -185,7 +189,8 @@ func NewLaunchJournal(request ReconcileRequest, backend string, detect DetectRes
 		InstanceIdentity: detect.InstanceIdentity, RosterDigest: rosterDigest,
 		PlanDigest: planDigest, LaunchNonce: nonce, CreatedAt: now.UTC(), Plan: plan,
 		Agents: slices.Clone(agents), Conversations: slices.Clone(conversations),
-		Placement: preview,
+		Placement:     preview,
+		CallerContext: cloneCallerContext(request.CallerContext),
 	}
 	record.ProjectPhysical, _ = fsq.StableTreeIdentity(projectIdentity)
 	record.RootPhysical, _ = fsq.StableTreeIdentityInfo(request.Root.FileInfo())
@@ -219,6 +224,9 @@ func (record LaunchJournal) ValidateRequest(request ReconcileRequest) error {
 	}
 	if record.RosterDigest != rosterDigest {
 		return fmt.Errorf("launch journal roster changed since resource creation")
+	}
+	if !reflect.DeepEqual(record.CallerContext, request.CallerContext) {
+		return fmt.Errorf("launch journal caller context changed")
 	}
 	if err := journalPlacementMatches(record, request); err != nil {
 		return err
@@ -338,7 +346,7 @@ func journalPlacementMatches(record LaunchJournal, request ReconcileRequest) err
 func journalMatchesBinding(journal LaunchJournal, binding BindingRecord) bool {
 	return binding.Backend == journal.Backend && binding.Profile == journal.Profile &&
 		binding.HostIdentity == journal.HostIdentity && binding.InstanceIdentity == journal.InstanceIdentity &&
-		binding.LaunchNonce == journal.LaunchNonce
+		binding.LaunchNonce == journal.LaunchNonce && reflect.DeepEqual(binding.CallerContext, journal.CallerContext)
 }
 
 func canonicalIdentity(path string) (string, error) {

--- a/internal/launch/lifecycle.go
+++ b/internal/launch/lifecycle.go
@@ -17,13 +17,14 @@ type LifecycleRequest struct{ Target PrepareTarget }
 type LifecycleDependencies struct{ Backends map[string]Backend }
 
 type LifecycleResult struct {
-	Outcome      string
-	ReasonCode   string
-	Backend      string
-	Profile      string
-	State        string
-	Observations []PrepareObservation
-	Evidence     []EvidenceRef
+	Outcome       string
+	ReasonCode    string
+	Backend       string
+	Profile       string
+	State         string
+	Observations  []PrepareObservation
+	Evidence      []EvidenceRef
+	CallerContext map[string]string
 }
 
 var beforeLifecycleBackendMutationForTest func()
@@ -42,6 +43,10 @@ func InspectLifecycle(ctx context.Context, request LifecycleRequest, dependencie
 		return LifecycleResult{Outcome: LifecycleOutcomeInspected, State: string(InspectAbsent), ReasonCode: "binding_missing"}, nil
 	}
 	if err != nil {
+		var contextError *CallerContextValidationError
+		if errors.As(err, &contextError) {
+			return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "caller_context_corrupt"}, nil
+		}
 		return LifecycleResult{}, err
 	}
 	backend, detect, refusal, err := validateLifecycleBinding(binding, dependencies, CapInspect)
@@ -107,6 +112,10 @@ func mutateLifecycle(ctx context.Context, request LifecycleRequest, dependencies
 		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectAbsent), ReasonCode: "binding_missing"}, nil
 	}
 	if err != nil {
+		var contextError *CallerContextValidationError
+		if errors.As(err, &contextError) {
+			return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "caller_context_corrupt"}, nil
+		}
 		return LifecycleResult{}, err
 	}
 	backend, detect, refusal, err := validateLifecycleBinding(binding, dependencies, capability)
@@ -270,5 +279,5 @@ func lifecycleResultFromBinding(root *fsq.DeliveryRoot, binding BindingRecord) (
 	if err != nil {
 		return LifecycleResult{}, err
 	}
-	return LifecycleResult{Backend: binding.Backend, Profile: binding.Profile, Observations: observations, Evidence: evidence}, nil
+	return LifecycleResult{Backend: binding.Backend, Profile: binding.Profile, Observations: observations, Evidence: evidence, CallerContext: cloneCallerContext(binding.CallerContext)}, nil
 }

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -117,6 +117,7 @@ type PrepareRequest struct {
 	Participants  []PrepareParticipant
 	SubjectSchema int
 	Placement     *Placement
+	CallerContext map[string]string
 }
 
 type AdapterFactory func(provider, executable string) HarnessAdapter
@@ -195,6 +196,7 @@ type PrepareResult struct {
 	RequiredActions     []PrepareRequiredAction
 	Observations        []PrepareObservation
 	Placement           PlacementPreview
+	CallerContext       map[string]string
 }
 
 type prepareTargetState struct {
@@ -293,6 +295,7 @@ type prepareSubject struct {
 	Participants    []PreparedParticipant     `json:"participants"`
 	Observations    []PrepareObservation      `json:"observations"`
 	Placement       *PlacementPreview         `json:"placement,omitempty"`
+	CallerContext   map[string]string         `json:"caller_context,omitempty"`
 }
 
 // Prepare compiles public caller intent and inspects current launch state. It
@@ -334,6 +337,12 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		default:
 			return PrepareResult{}, fmt.Errorf("invalid on_live %q", participant.OnLive)
 		}
+	}
+	if len(request.CallerContext) > 0 && subjectSchema == SubjectSchemaV1 {
+		return PrepareResult{}, fmt.Errorf("caller_context requires subject schema %d", SubjectSchemaV2)
+	}
+	if err := ValidateCallerContext(request.CallerContext); err != nil {
+		return PrepareResult{}, err
 	}
 	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath)
 	if err != nil {
@@ -400,8 +409,9 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	}
 	result := PrepareResult{
 		SubjectSchema: subjectSchema, Target: state.target, Backend: backendName, Roster: roster,
-		Participants: make([]PreparedParticipant, 0, len(request.Participants)),
-		Observations: make([]PrepareObservation, 0, len(request.Participants)+len(roster.Extra)),
+		Participants:  make([]PreparedParticipant, 0, len(request.Participants)),
+		Observations:  make([]PrepareObservation, 0, len(request.Participants)+len(roster.Extra)),
+		CallerContext: cloneCallerContext(request.CallerContext),
 	}
 	baseAuthorityDigest := ""
 	if state.baseAuthority != nil {
@@ -527,19 +537,23 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		Actions: result.RequiredActions, Participants: result.Participants, Observations: result.Observations,
 	}
 	if subjectSchema == SubjectSchemaV2 {
-		plannedWrites := slices.Clone(result.PlannedWrites)
-		if plannedWrites == nil {
-			plannedWrites = []PlannedWrite{}
-		}
-		subject.PlannedWrites = &plannedWrites
-		placement := result.Placement
-		subject.Placement = &placement
+		setPrepareSubjectV2Fields(&subject, result.PlannedWrites, result.Placement, request.CallerContext)
 	}
 	result.SubjectDigest, err = digestCanonical(subject)
 	if err != nil {
 		return PrepareResult{}, err
 	}
 	return result, nil
+}
+
+func setPrepareSubjectV2Fields(subject *prepareSubject, plannedWrites []PlannedWrite, placement PlacementPreview, callerContext map[string]string) {
+	writes := slices.Clone(plannedWrites)
+	if writes == nil {
+		writes = []PlannedWrite{}
+	}
+	subject.PlannedWrites = &writes
+	subject.Placement = &placement
+	subject.CallerContext = cloneCallerContext(callerContext)
 }
 
 func prepareBaseRootRefusal(request PrepareRequest, subjectSchema int, reason string) (PrepareResult, error) {

--- a/internal/launch/prepare_test.go
+++ b/internal/launch/prepare_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -160,6 +161,41 @@ func TestPrepareV2SubjectDigestIncludesPlacement(t *testing.T) {
 	}
 	if withStagger.Outcome == PrepareOutcomeUnsupported || withoutStagger.Outcome == PrepareOutcomeUnsupported {
 		t.Fatalf("tmux session placement unsupported: stagger=%#v baseline=%#v", withStagger, withoutStagger)
+	}
+}
+
+func TestCallerContextOmittedMatchesV061Digests(t *testing.T) {
+	subject := prepareSubject{
+		Version:      SubjectSchemaV2,
+		IntentDigest: "sha256:" + strings.Repeat("a", 64),
+		PlanDigest:   "sha256:" + strings.Repeat("b", 64),
+		TrustDigest:  "sha256:" + strings.Repeat("c", 64),
+		Target: PrepareTarget{
+			ProjectRoot: "/fixed/project", SessionRoot: "/fixed/mail/collab", Session: "collab",
+		},
+		ProjectIdentity: "project:fixed",
+		SessionIdentity: "session:fixed",
+		Backend:         LauncherCommands,
+		Profile:         "commands",
+	}
+	setPrepareSubjectV2Fields(&subject, nil, PlacementPreview{}, nil)
+	if subject.CallerContext != nil {
+		t.Fatalf("omitted caller_context normalized to %#v, want nil", subject.CallerContext)
+	}
+	encoded, err := json.Marshal(subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(`"caller_context"`)) {
+		t.Fatalf("omitted caller_context entered v0.61-compatible subject bytes: %s", encoded)
+	}
+	digest, err := digestCanonical(subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "sha256:a77730e6d4903a7cfc9e44fc4463307f3251de052e0de453fb23e100ca580e27"
+	if digest != want {
+		t.Fatalf("omitted caller_context subject digest = %s, want %s", digest, want)
 	}
 }
 

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -80,7 +80,8 @@ type ReconcileRequest struct {
 	// Placement is the caller-requested tuple. Nil preserves v0.61 Create.
 	Placement *Placement
 	// OnLive is the per-handle live-seat policy. Missing keys are refuse.
-	OnLive map[string]string
+	OnLive        map[string]string
+	CallerContext map[string]string
 }
 
 type AgentReconcileResult struct {
@@ -415,7 +416,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		if journalActive && journal.Phase == JournalCreated {
 			candidate = journal.Binding
 		} else {
-			candidate, err = finalizeCreatedState(request.Root, lease, create, backendName, detect, nonce, planned, &result, joinBinding)
+			candidate, err = finalizeCreatedState(request.Root, lease, create, backendName, detect, nonce, request.CallerContext, planned, &result, joinBinding)
 			if err != nil {
 				return result, err
 			}
@@ -583,6 +584,7 @@ func recoverJournal(request ReconcileRequest, journal LaunchJournal, binding Bin
 	case ReclaimAbsent:
 		return journal.Backend, backend, detect, CreateResult{}, false, nil
 	case ReclaimAdoptable:
+		reclaim.Binding.CallerContext = cloneCallerContext(journal.CallerContext)
 		if err := reclaim.Binding.Validate(); err != nil || !journalMatchesBinding(journal, reclaim.Binding) {
 			result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_identity_mismatch"
 			return journal.Backend, backend, detect, CreateResult{}, false, nil
@@ -623,14 +625,16 @@ func revalidateAdoption(request ReconcileRequest, backend Backend, journal Launc
 	if err != nil {
 		return err
 	}
+	reclaim.Binding.CallerContext = cloneCallerContext(journal.CallerContext)
 	if reclaim.Status != ReclaimAdoptable || !reflect.DeepEqual(reclaim.Binding, candidate) {
 		return fmt.Errorf("journaled resource changed before binding commit")
 	}
 	return nil
 }
 
-func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateResult, backendName string, detect DetectResult, nonce string, planned []plannedAgent, result *ReconcileResult, joinBinding *BindingRecord) (*BindingRecord, error) {
+func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateResult, backendName string, detect DetectResult, nonce string, callerContext map[string]string, planned []plannedAgent, result *ReconcileResult, joinBinding *BindingRecord) (*BindingRecord, error) {
 	created := create.Binding
+	created.CallerContext = cloneCallerContext(callerContext)
 	bindingNonce := nonce
 	if joinBinding != nil {
 		bindingNonce = joinBinding.LaunchNonce
@@ -663,7 +667,7 @@ func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateRes
 			})
 			agent.record.State, agent.record.Identity, agent.record.Reason = capture.State, capture.Identity, capture.Reason
 			if capture.CanPersist() {
-				refs, evidenceErr := persistProviderCaptureEvidence(root, lease, agent.plan.Handle, captureEvidence)
+				refs, evidenceErr := persistProviderCaptureEvidenceWithContext(root, lease, agent.plan.Handle, callerContext, captureEvidence)
 				if evidenceErr != nil {
 					return nil, evidenceErr
 				}
@@ -705,6 +709,7 @@ func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []pla
 			ProviderExecutable: agent.plan.Argv[0], AMQExecutable: amqPath,
 			TargetArgv: agent.plan.Argv, DynamicArgv: agent.plan.DynamicArgv, TargetEnv: agent.plan.EnvOverlay,
 			InitialInput: agent.plan.InitialInput, Execution: agent.plan.Execution,
+			CallerContext: cloneCallerContext(request.CallerContext),
 		}
 		if agent.plan.PreSpawnAcquire || (agent.adapter.Name() == CodexProvider && agent.plan.AdapterMode == AdapterModeCapture) {
 			ticketRequest.Backend, ticketRequest.Profile = backend, profile

--- a/launchapi/apply.go
+++ b/launchapi/apply.go
@@ -44,10 +44,11 @@ func fromInternalApplyResult(result internallaunch.ApplyResult) ApplyResultV1 {
 			Desired: slices.Clone(result.Roster.Desired), Present: slices.Clone(result.Roster.Present),
 			Missing: slices.Clone(result.Roster.Missing), Extra: slices.Clone(result.Roster.Extra),
 		},
-		Observations: make([]ParticipantObservationV1, 0, len(result.Observations)),
-		Commands:     make([]CommandV1, 0, len(result.Commands)),
-		FollowUps:    make([]RequiredActionV1, 0, len(result.RequiredActions)),
-		Evidence:     make([]EvidenceRefV1, 0, len(result.Evidence)),
+		Observations:  make([]ParticipantObservationV1, 0, len(result.Observations)),
+		Commands:      make([]CommandV1, 0, len(result.Commands)),
+		FollowUps:     make([]RequiredActionV1, 0, len(result.RequiredActions)),
+		Evidence:      make([]EvidenceRefV1, 0, len(result.Evidence)),
+		CallerContext: cloneStringMap(result.CallerContext),
 	}
 	if result.SubjectSchema == SubjectSchemaV1 {
 		public.Hints = []ResultHintV1{HintReprepareRecommended}

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -214,6 +214,11 @@ func TestSameSessionLabelAcrossProfileRootsIsIsolated(t *testing.T) {
 
 func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, false)
+	fixture.request.CallerContext = map[string]string{
+		"discovery_fingerprint": "sha256:abc", "namespace": "squad-v2", "policy_generation": "7",
+		"task_generation": "3", "run_id": "run-42", "evidence_chain": "chain-9",
+	}
+	wantCallerContext := cloneStringMap(fixture.request.CallerContext)
 	injector := filepath.Join(t.TempDir(), "injector")
 	if err := os.WriteFile(injector, []byte("injector"), 0o700); err != nil {
 		t.Fatal(err)
@@ -250,6 +255,13 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 	if result.SubjectDigest != prepared.SubjectDigest {
 		t.Fatalf("Apply authorization subject = %q, want accepted %q", result.SubjectDigest, prepared.SubjectDigest)
 	}
+	if !reflect.DeepEqual(result.CallerContext, wantCallerContext) {
+		t.Fatalf("Apply caller context = %#v, want %#v", result.CallerContext, wantCallerContext)
+	}
+	fixture.request.CallerContext["run_id"] = "mutated-after-apply"
+	if result.CallerContext["run_id"] != "run-42" {
+		t.Fatalf("Apply result aliases request caller context: %#v", result.CallerContext)
+	}
 	if !slices.Equal(result.Roster.Desired, []string{"claude", "operator", "reviewer"}) ||
 		!slices.Equal(result.Roster.Present, result.Roster.Desired) || len(result.Roster.Missing) != 0 || len(result.Roster.Extra) != 0 {
 		t.Fatalf("published Apply roster = %#v", result.Roster)
@@ -280,6 +292,9 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 		}
 		if !reflect.DeepEqual(ticket.Execution, &wantOptions) {
 			t.Fatalf("%s ticket execution options = %#v, want %#v", handle, ticket.Execution, wantOptions)
+		}
+		if !reflect.DeepEqual(ticket.CallerContext, wantCallerContext) {
+			t.Fatalf("%s ticket caller context = %#v, want %#v", handle, ticket.CallerContext, wantCallerContext)
 		}
 		if len(ticket.TargetArgv) == 0 || ticket.TargetArgv[len(ticket.TargetArgv)-1] != "generated bootstrap" {
 			t.Fatalf("%s ticket did not preserve the final initial argument: %#v", handle, ticket.TargetArgv)
@@ -320,6 +335,34 @@ func TestApplyUnsupportedPlacementDoesNotPublishSession(t *testing.T) {
 	}
 	if _, err := os.Stat(fixture.request.Target.SessionRoot); !os.IsNotExist(err) {
 		t.Fatalf("unsupported placement published a session: %v", err)
+	}
+}
+
+func TestApplyRejectsChangedCallerContextWithoutMutation(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	fixture.request.CallerContext = map[string]string{"run_id": "run-42", "task_generation": "3"}
+	prepared, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := applyTreeFingerprint(t, fixture.root, nil)
+	fixture.request.CallerContext["task_generation"] = "4"
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1, Prepare: fixture.request,
+		SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: []DecisionV1{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "action_required" || result.ReasonCode != "subject_changed" || result.CallerContext["task_generation"] != "4" {
+		t.Fatalf("changed caller context Apply = %#v", result)
+	}
+	allowed := map[string]bool{
+		"mail/collab/meta/launch":            true,
+		"mail/collab/meta/launch/lease.lock": true,
+	}
+	if after := applyTreeFingerprint(t, fixture.root, allowed); after != before {
+		t.Fatalf("changed caller context mutated state: before %s after %s", before, after)
 	}
 }
 

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -20,6 +20,7 @@ var compatibilityFeaturesV1 = []string{
 	FeaturePlacement,
 	FeatureBaseRoot,
 	FeatureOnLive,
+	FeatureCallerContext,
 }
 
 func Compatibility() CompatibilityV1 {

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -30,9 +30,11 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if !slices.Contains(Compatibility().Features, FeatureOnLive) {
 		t.Fatal("Compatibility omitted advertised on_live")
 	}
+	if !slices.Contains(Compatibility().Features, FeatureCallerContext) {
+		t.Fatal("Compatibility did not advertise the completed caller_context feature")
+	}
 	for _, unfinished := range []string{
-		FeatureWrapper,
-		FeatureCallerContext, FeatureExecutableIdentity,
+		FeatureWrapper, FeatureExecutableIdentity,
 	} {
 		if slices.Contains(Compatibility().Features, unfinished) {
 			t.Fatalf("Compatibility advertised unfinished feature %q", unfinished)

--- a/launchapi/lifecycle.go
+++ b/launchapi/lifecycle.go
@@ -56,8 +56,9 @@ func lifecycleResult(result internallaunch.LifecycleResult) LifecycleResultV1 {
 	public := LifecycleResultV1{
 		ResultVersion: ResultVersionV1, Outcome: result.Outcome, ReasonCode: result.ReasonCode,
 		Backend: result.Backend, Profile: result.Profile, State: result.State,
-		Observations: make([]ParticipantObservationV1, 0, len(result.Observations)),
-		Evidence:     make([]EvidenceRefV1, 0, len(result.Evidence)),
+		Observations:  make([]ParticipantObservationV1, 0, len(result.Observations)),
+		Evidence:      make([]EvidenceRefV1, 0, len(result.Evidence)),
+		CallerContext: cloneStringMap(result.CallerContext),
 	}
 	for _, observation := range result.Observations {
 		public.Observations = append(public.Observations, ParticipantObservationV1{
@@ -76,5 +77,6 @@ func fromInternalEvidenceRef(evidence internallaunch.EvidenceRef) EvidenceRefV1 
 	return EvidenceRefV1{
 		EvidenceVersion: evidence.EvidenceVersion, ID: evidence.ID, Kind: string(evidence.Kind),
 		SHA256: evidence.SHA256, ObservedAt: evidence.ObservedAt,
+		CallerContext: cloneStringMap(evidence.CallerContext),
 	}
 }

--- a/launchapi/lifecycle_test.go
+++ b/launchapi/lifecycle_test.go
@@ -1,9 +1,11 @@
 package launchapi
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -41,6 +43,7 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 		Resources: internallaunch.ResourceIdentitySet{Version: internallaunch.ResourceSetVersion, Resources: []internallaunch.ResourceIdentity{
 			{OpaqueID: "session:one"}, {OpaqueID: "window:one", Agent: "claude"},
 		}},
+		CallerContext: map[string]string{"run_id": "run-42", "task_generation": "3"},
 	}
 	lease, err := internallaunch.AcquireLease(root, "")
 	if err != nil {
@@ -62,6 +65,9 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	if err != nil || inspected.ResultVersion != ResultVersionV1 || inspected.State != "present" || len(inspected.Observations) != 1 || inspected.Observations[0].Resource != "window:one" {
 		t.Fatalf("Inspect = %#v, %v", inspected, err)
 	}
+	if !reflect.DeepEqual(inspected.CallerContext, binding.CallerContext) {
+		t.Fatalf("Inspect caller context = %#v, want %#v", inspected.CallerContext, binding.CallerContext)
+	}
 	if after := snapshotTestTree(t, session); after != before {
 		t.Fatal("public Inspect mutated the session tree")
 	}
@@ -76,6 +82,22 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	if _, err := internallaunch.LoadBinding(root); err != nil {
 		t.Fatalf("public Close removed AMQ binding: %v", err)
 	}
+	bindingPath := internallaunch.BindingPath(session)
+	bindingData, err := os.ReadFile(bindingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corruptBinding := bytes.Replace(bindingData, []byte("run-42"), bytes.Repeat([]byte("x"), internallaunch.MaxCallerContextValueBytes+1), 1)
+	if err := os.WriteFile(bindingPath, corruptBinding, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corruptContext, err := Inspect(context.Background(), request)
+	if err != nil || corruptContext.Outcome != "action_required" || corruptContext.ReasonCode != "caller_context_corrupt" {
+		t.Fatalf("corrupt binding caller context Inspect = %#v, %v", corruptContext, err)
+	}
+	if err := os.WriteFile(bindingPath, bindingData, 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	lease, err = internallaunch.AcquireLease(root, "76767676-7676-4676-8676-767676767676")
 	if err != nil {
@@ -86,7 +108,8 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	}
 	evidence, err := internallaunch.WriteEvidence(root, lease, internallaunch.EvidenceWriteRequest{
 		Kind: internallaunch.EvidenceProviderCapture, Handle: "claude", ObservedAt: time.Now().UTC(),
-		Payload: []byte(`{"source":"codex_notify_v1","provider":"codex","provider_version":"0.147.0","launch_nonce":"76767676-7676-4676-8676-767676767676","handle":"claude","conversation_id":"019c8a2f-2b13-7000-8000-000000000001","cwd":"/tmp","notification":"{\"type\":\"agent-turn-complete\",\"thread-id\":\"019c8a2f-2b13-7000-8000-000000000001\",\"turn-id\":\"turn-1\",\"cwd\":\"/tmp\",\"input-messages\":[]}"}`),
+		CallerContext: binding.CallerContext,
+		Payload:       []byte(`{"source":"codex_notify_v1","provider":"codex","provider_version":"0.147.0","launch_nonce":"76767676-7676-4676-8676-767676767676","handle":"claude","conversation_id":"019c8a2f-2b13-7000-8000-000000000001","cwd":"/tmp","notification":"{\"type\":\"agent-turn-complete\",\"thread-id\":\"019c8a2f-2b13-7000-8000-000000000001\",\"turn-id\":\"turn-1\",\"cwd\":\"/tmp\",\"input-messages\":[]}"}`),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -105,6 +128,11 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	}
 	if err := lease.Release(); err != nil {
 		t.Fatal(err)
+	}
+	withEvidence, err := Inspect(context.Background(), request)
+	if err != nil || len(withEvidence.Evidence) != 1 || !reflect.DeepEqual(withEvidence.Evidence[0].CallerContext, binding.CallerContext) ||
+		!reflect.DeepEqual(withEvidence.CallerContext, binding.CallerContext) {
+		t.Fatalf("Inspect evidence caller context = %#v, %v", withEvidence, err)
 	}
 	evidencePath := internallaunch.EvidencePath(session, evidence.ID)
 	data, err := os.ReadFile(evidencePath)

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -62,7 +62,7 @@ func prepareInputs(request PrepareRequestV1) (internallaunch.PrepareRequest, int
 			Session:     request.Target.Session,
 		},
 		Launcher: request.Launcher, IntentDigest: intentDigest, SubjectSchema: internallaunch.SubjectSchemaV2,
-		Placement:    toInternalPlacement(request.Placement),
+		Placement: toInternalPlacement(request.Placement), CallerContext: cloneStringMap(request.CallerContext),
 		Participants: make([]internallaunch.PrepareParticipant, 0, len(request.Intent.Participants)),
 	}
 	for _, participant := range request.Intent.Participants {

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -111,6 +111,55 @@ func TestPrepareInitialArgumentIsFinalAndContentDoesNotChurnTrust(t *testing.T) 
 	}
 }
 
+func TestCallerContextCanonicalOrderChangesSubjectButNotPlanOrTrust(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	fixture.request.CallerContext = map[string]string{
+		"run_id": "run-42", "discovery_fingerprint": "sha256:abc", "policy_generation": "7",
+	}
+	first, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.request.CallerContext = map[string]string{
+		"policy_generation": "7", "discovery_fingerprint": "sha256:abc", "run_id": "run-42",
+	}
+	reordered, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.SubjectDigest != reordered.SubjectDigest || first.PlanDigest != reordered.PlanDigest || first.TrustDigest != reordered.TrustDigest {
+		t.Fatalf("map insertion order changed digests: first=%#v reordered=%#v", first, reordered)
+	}
+	fixture.request.CallerContext["policy_generation"] = "8"
+	changed, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.SubjectDigest == changed.SubjectDigest {
+		t.Fatal("caller context value change did not change subject digest")
+	}
+	if first.PlanDigest != changed.PlanDigest || first.TrustDigest != changed.TrustDigest {
+		t.Fatalf("caller context changed plan or trust: first=%#v changed=%#v", first, changed)
+	}
+
+	fixture.request.CallerContext = map[string]string{"é": "value"}
+	composed, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.request.CallerContext = map[string]string{"e\u0301": "value"}
+	decomposed, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if composed.SubjectDigest == decomposed.SubjectDigest {
+		t.Fatal("caller context normalized distinct UTF-8 key bytes")
+	}
+	if composed.PlanDigest != decomposed.PlanDigest || composed.TrustDigest != decomposed.TrustDigest {
+		t.Fatalf("UTF-8 key bytes changed plan or trust: composed=%#v decomposed=%#v", composed, decomposed)
+	}
+}
+
 func TestPrepareUnsupportedInitialCarriersAndOversizeAreTypedAndZeroWrite(t *testing.T) {
 	for _, test := range []struct {
 		name  string

--- a/launchapi/requests.go
+++ b/launchapi/requests.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
@@ -22,6 +25,9 @@ func ValidateDigest(digest string) error {
 }
 
 func DecodePrepareRequestV1(data []byte) (PrepareRequestV1, error) {
+	if err := validateCallerContextJSON(data); err != nil {
+		return PrepareRequestV1{}, fmt.Errorf("decode prepare request v1: %w", err)
+	}
 	var request PrepareRequestV1
 	if err := decodeStrictJSON(data, &request); err != nil {
 		return PrepareRequestV1{}, fmt.Errorf("decode prepare request v1: %w", err)
@@ -47,10 +53,25 @@ func (request PrepareRequestV1) Validate() error {
 			return err
 		}
 	}
+	if err := internallaunch.ValidateCallerContext(request.CallerContext); err != nil {
+		return err
+	}
 	return request.Intent.Validate()
 }
 
 func DecodeApplyRequestV1(data []byte) (ApplyRequestV1, error) {
+	if !utf8.Valid(data) {
+		return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: invalid UTF-8")
+	}
+	prepare, present, err := rawObjectField(data, "prepare")
+	if err != nil {
+		return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: %w", err)
+	}
+	if present {
+		if err := validateCallerContextJSON(prepare); err != nil {
+			return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: prepare: %w", err)
+		}
+	}
 	var request ApplyRequestV1
 	if err := decodeStrictJSON(data, &request); err != nil {
 		return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: %w", err)
@@ -66,6 +87,93 @@ func DecodeApplyRequestV1(data []byte) (ApplyRequestV1, error) {
 		return ApplyRequestV1{}, err
 	}
 	return request, nil
+}
+
+func validateCallerContextJSON(data []byte) error {
+	if !utf8.Valid(data) {
+		return fmt.Errorf("invalid UTF-8")
+	}
+	raw, present, err := rawObjectField(data, "caller_context")
+	if err != nil || !present {
+		return err
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return fmt.Errorf("caller_context must be an object")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	token, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("caller_context: %w", err)
+	}
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '{' {
+		return fmt.Errorf("caller_context must be an object")
+	}
+	seen := make(map[string]struct{})
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("caller_context: %w", err)
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return fmt.Errorf("caller_context key must be a string")
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return fmt.Errorf("caller_context contains duplicate key %q", key)
+		}
+		seen[key] = struct{}{}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return fmt.Errorf("caller_context[%q]: %w", key, err)
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("caller_context: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("caller_context has trailing JSON")
+	}
+	return nil
+}
+
+func rawObjectField(data []byte, field string) (json.RawMessage, bool, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, false, err
+	}
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '{' {
+		return nil, false, fmt.Errorf("request must be an object")
+	}
+	var found json.RawMessage
+	present := false
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return nil, false, err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, false, fmt.Errorf("request field name must be a string")
+		}
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, false, err
+		}
+		if key == field {
+			if present {
+				return nil, false, fmt.Errorf("duplicate field %q", field)
+			}
+			found, present = raw, true
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, false, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, false, fmt.Errorf("request has trailing JSON")
+	}
+	return found, present, nil
 }
 
 func (request ApplyRequestV1) Validate() error {

--- a/launchapi/requests_test.go
+++ b/launchapi/requests_test.go
@@ -104,3 +104,36 @@ func TestApplyRequestV1RejectsDigestAndDecisionReplayShapes(t *testing.T) {
 		t.Fatalf("missing decisions error = %v", err)
 	}
 }
+
+func TestCallerContextJSONRejectsDuplicateNullInvalidAndUnknownAdjacentFields(t *testing.T) {
+	root := filepath.Clean(t.TempDir())
+	intent, err := DecodeLaunchIntentV1([]byte(validIntentJSON(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := PrepareRequestV1{
+		RequestVersion: 1,
+		Target:         TargetV1{ProjectRoot: root, SessionRoot: filepath.Join(root, ".agent-mail", "collab"), Session: "collab"},
+		Launcher:       "commands", CallerContext: map[string]string{"run_id": "run-42"}, Intent: intent,
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{name: "duplicate", raw: []byte(strings.Replace(string(raw), `"run_id":"run-42"`, `"run_id":"run-42","run_id":"other"`, 1)), want: "duplicate key"},
+		{name: "null", raw: []byte(strings.Replace(string(raw), `{"run_id":"run-42"}`, `null`, 1)), want: "must be an object"},
+		{name: "unknown adjacent", raw: []byte(strings.Replace(string(raw), `"caller_context":`, `"caller_context_policy":"opaque","caller_context":`, 1)), want: "unknown field"},
+		{name: "invalid UTF-8", raw: append(append([]byte(nil), raw[:len(raw)-1]...), 0xff, '}'), want: "invalid UTF-8"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := DecodePrepareRequestV1(test.raw); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DecodePrepareRequestV1 error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -156,11 +156,12 @@ type PlacementPreviewV1 struct {
 }
 
 type PrepareRequestV1 struct {
-	RequestVersion int            `json:"request_version"`
-	Target         TargetV1       `json:"target"`
-	Launcher       string         `json:"launcher"`
-	Placement      *PlacementV1   `json:"placement,omitempty"`
-	Intent         LaunchIntentV1 `json:"intent"`
+	RequestVersion int               `json:"request_version"`
+	Target         TargetV1          `json:"target"`
+	Launcher       string            `json:"launcher"`
+	Placement      *PlacementV1      `json:"placement,omitempty"`
+	CallerContext  map[string]string `json:"caller_context,omitempty"`
+	Intent         LaunchIntentV1    `json:"intent"`
 }
 
 type RequiredActionKindV1 string
@@ -310,11 +311,12 @@ type ApplyRequestV1 struct {
 }
 
 type EvidenceRefV1 struct {
-	EvidenceVersion int       `json:"evidence_version"`
-	ID              string    `json:"id"`
-	Kind            string    `json:"kind"`
-	SHA256          string    `json:"sha256"`
-	ObservedAt      time.Time `json:"observed_at"`
+	EvidenceVersion int               `json:"evidence_version"`
+	ID              string            `json:"id"`
+	Kind            string            `json:"kind"`
+	SHA256          string            `json:"sha256"`
+	ObservedAt      time.Time         `json:"observed_at"`
+	CallerContext   map[string]string `json:"caller_context,omitempty"`
 }
 
 type ApplyResultV1 struct {
@@ -340,6 +342,7 @@ type ApplyResultV1 struct {
 	Commands       []CommandV1                `json:"commands,omitempty"`
 	FollowUps      []RequiredActionV1         `json:"follow_ups,omitempty"`
 	Evidence       []EvidenceRefV1            `json:"evidence,omitempty"`
+	CallerContext  map[string]string          `json:"caller_context,omitempty"`
 }
 
 type InspectRequestV1 struct {
@@ -359,6 +362,7 @@ type LifecycleResultV1 struct {
 	State         string                     `json:"state"`
 	Observations  []ParticipantObservationV1 `json:"observations"`
 	Evidence      []EvidenceRefV1            `json:"evidence,omitempty"`
+	CallerContext map[string]string          `json:"caller_context,omitempty"`
 }
 
 type InspectResultV1 = LifecycleResultV1

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -194,6 +194,13 @@
         "reason_code": {"type": "string", "minLength": 1}
       }
     },
+    "CallerContextV1": {
+      "type": "object",
+      "maxProperties": 32,
+      "propertyNames": {"minLength": 1, "maxLength": 64},
+      "patternProperties": {"^.+$": {"type": "string", "maxLength": 1024}},
+      "additionalProperties": false
+    },
     "PrepareRequestV1": {
       "type": "object",
       "additionalProperties": false,
@@ -203,6 +210,7 @@
         "target": {"$ref": "#/$defs/TargetV1"},
         "launcher": {"type": "string", "minLength": 1},
         "placement": {"$ref": "#/$defs/PlacementV1"},
+        "caller_context": {"$ref": "#/$defs/CallerContextV1"},
         "intent": {"$ref": "#/$defs/LaunchIntentV1"}
       }
     },
@@ -371,7 +379,8 @@
         "id": {"type": "string", "minLength": 1},
         "kind": {"type": "string", "minLength": 1},
         "sha256": {"$ref": "#/$defs/Digest"},
-        "observed_at": {"type": "string", "format": "date-time"}
+        "observed_at": {"type": "string", "format": "date-time"},
+        "caller_context": {"$ref": "#/$defs/CallerContextV1"}
       }
     },
     "ApplyResultV1": {
@@ -394,7 +403,8 @@
         "observations": {"type": "array", "items": {"$ref": "#/$defs/ParticipantObservationV1"}},
         "commands": {"type": "array", "items": {"$ref": "#/$defs/CommandV1"}},
         "follow_ups": {"type": "array", "items": {"$ref": "#/$defs/RequiredActionV1"}},
-        "evidence": {"type": "array", "items": {"$ref": "#/$defs/EvidenceRefV1"}}
+        "evidence": {"type": "array", "items": {"$ref": "#/$defs/EvidenceRefV1"}},
+        "caller_context": {"$ref": "#/$defs/CallerContextV1"}
       }
     },
     "LifecycleRequestV1": {
@@ -421,7 +431,8 @@
         "profile": {"type": "string"},
         "state": {"enum": ["present", "absent", "unknown"]},
         "observations": {"type": "array", "items": {"$ref": "#/$defs/ParticipantObservationV1"}},
-        "evidence": {"type": "array", "items": {"$ref": "#/$defs/EvidenceRefV1"}}
+        "evidence": {"type": "array", "items": {"$ref": "#/$defs/EvidenceRefV1"}},
+        "caller_context": {"$ref": "#/$defs/CallerContextV1"}
       }
     },
     "InspectResultV1": {"$ref": "#/$defs/LifecycleResultV1"},


### PR DESCRIPTION
## Summary
- validate and canonicalize bounded caller-owned context
- bind context into schema-v2 subjects, journals, tickets, and immutable evidence
- echo context through Apply and lifecycle results with corruption refusal

## Verification
- `make ci`
- limit-raising mutant makes literal bound tests fail
- omitted-field mutant makes the v0.61 digest guard fail