### PR TITLE
feat(launchapi): bind provider executable identity into prepare subject

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -22,9 +22,10 @@ _ = negotiated
 ```
 
 A `0.61.1` binary advertises `placement`, `initial_input`, `base_root`,
-`on_live`, and `caller_context`. It can still omit later Wave B3 feature IDs
-while those beads are incomplete. A caller must require every feature it uses.
-Contract semver alone does not claim that an unadvertised feature is available.
+`on_live`, `caller_context`, and `executable_identity`. It can still omit later
+Wave B3 feature IDs while those beads are incomplete. A caller must require
+every feature it uses. Contract semver alone does not claim that an unadvertised
+feature is available.
 
 `PreviewV1.capabilities` reports the selected providers' static adapter grammar
 without executing a caller-supplied provider. `grammar_version` is the

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -30,7 +30,7 @@ import (
 //	finding4_placement_unsupported | 4 placement | AMQ_SQUAD_TMUX_* env rejected as provider env | placement preview; unsupported tuple -> placement_unsupported
 //	finding5_positional_bootstrap_prompt / finding5_claude_allowed_tools / finding5_codex_dash_c | 5 materialized argv | raw positional prompt rejected; exact --allowedTools and -c forms admitted | initial_input + --allowedTools / -c admitted
 //	finding6_caller_context_bound_and_echoed | 6 caller correlation | caller_context is subject-bound and echoed on Apply/evidence/lifecycle
-//	finding7_same_path_inode_replacement_not_subject_changed | 7 physical identity | same-path inode replacement leaves subject/plan/trust digests identical | inode replacement -> subject_changed
+//	finding7_same_path_inode_replacement_subject_changed | 7 physical identity | inode replacement -> subject_changed; plan/trust unchanged | (landed)
 //
 // Real bootstrap text from the squad-v2-29-4 compiler, not the placeholder in
 // #480 comment 5301600497. Finding 5's positional prompt is this string.
@@ -245,7 +245,7 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		}
 	})
 
-	t.Run("finding7_same_path_inode_replacement_not_subject_changed", func(t *testing.T) {
+	t.Run("finding7_same_path_inode_replacement_subject_changed", func(t *testing.T) {
 		fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "collab")
 		intent := fx.legalSquadIntent()
 		intent.Participants = intent.Participants[:2]
@@ -272,11 +272,12 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		}
 		var second launchapi.PrepareResultV1
 		decodeRealLaunchJSON(t, stdout, &second)
-		if first.SubjectDigest != second.SubjectDigest || first.PlanDigest != second.PlanDigest ||
-			first.TrustDigest != second.TrustDigest {
-			t.Fatalf("inode replacement changed digests first=%s/%s/%s second=%s/%s/%s (WB3 wants subject_changed)",
-				first.SubjectDigest, first.PlanDigest, first.TrustDigest,
-				second.SubjectDigest, second.PlanDigest, second.TrustDigest)
+		if first.SubjectDigest == second.SubjectDigest {
+			t.Fatalf("inode replacement kept subject digest %s", first.SubjectDigest)
+		}
+		if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest {
+			t.Fatalf("inode replacement churned plan/trust first=%s/%s second=%s/%s",
+				first.PlanDigest, first.TrustDigest, second.PlanDigest, second.TrustDigest)
 		}
 
 		stdout, stderr, exit = runRealAMQWithExit(t, fx.amqBinary, fx.project, fx.env, "launch", "--apply", firstApplyPath, "--json")
@@ -285,8 +286,8 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		}
 		var applied launchapi.ApplyResultV1
 		decodeRealLaunchJSON(t, stdout, &applied)
-		if applied.ReasonCode == "subject_changed" {
-			t.Fatalf("today inode replacement returned subject_changed; stdout=%s stderr=%s", stdout, stderr)
+		if applied.ReasonCode != "subject_changed" {
+			t.Fatalf("inode replacement Apply reason=%q want subject_changed stdout=%s stderr=%s", applied.ReasonCode, stdout, stderr)
 		}
 	})
 }

--- a/internal/launch/execidentity.go
+++ b/internal/launch/execidentity.go
@@ -1,0 +1,180 @@
+package launch
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	ExecutableTypeFile      = "file"
+	ExecutableTypeSymlink   = "symlink"
+	ExecutableTypeDirectory = "directory"
+	ExecutableTypeOther     = "other"
+)
+
+// ExecutableIdentity is the freeze tuple for amq-xgc. Field names and decimal
+// integer encoding are part of the contract. Schema-v2 subjects embed
+// MarshalExecutableIdentity bytes as executable_identity.identity.
+type ExecutableIdentity struct {
+	CanonicalPath string               `json:"canonical_path"`
+	Type          string               `json:"type"`
+	Dev           uint64               `json:"dev"`
+	Inode         uint64               `json:"inode"`
+	VolumeID      uint64               `json:"volume_id"`
+	FileID        uint64               `json:"file_id"`
+	Size          int64                `json:"size"`
+	MtimeNS       int64                `json:"mtime_ns"`
+	SymlinkChain  []ExecutableIdentity `json:"symlink_chain"`
+}
+
+// ProbeExecutableIdentity records the on-disk identity of path, including
+// every symlink hop. It does not consult PATH; the caller resolves names.
+func ProbeExecutableIdentity(path string) (ExecutableIdentity, error) {
+	if strings.TrimSpace(path) == "" {
+		return ExecutableIdentity{}, fmt.Errorf("executable path is required")
+	}
+	current, err := filepath.Abs(path)
+	if err != nil {
+		return ExecutableIdentity{}, fmt.Errorf("absolute executable path: %w", err)
+	}
+	var chain []ExecutableIdentity
+	seen := make(map[string]struct{}, 8)
+	for {
+		if _, dup := seen[current]; dup {
+			return ExecutableIdentity{}, fmt.Errorf("symlink loop at %s", current)
+		}
+		seen[current] = struct{}{}
+		node, err := probeExecutableNode(current)
+		if err != nil {
+			return ExecutableIdentity{}, err
+		}
+		if node.Type != ExecutableTypeSymlink {
+			node.CanonicalPath = current
+			if resolved, resolveErr := filepath.EvalSymlinks(current); resolveErr == nil {
+				node.CanonicalPath = resolved
+			}
+			if chain == nil {
+				chain = []ExecutableIdentity{}
+			}
+			node.SymlinkChain = chain
+			return node, nil
+		}
+		hop := node
+		hop.CanonicalPath = current
+		hop.SymlinkChain = []ExecutableIdentity{}
+		chain = append(chain, hop)
+		next, err := os.Readlink(current)
+		if err != nil {
+			return ExecutableIdentity{}, fmt.Errorf("read symlink %s: %w", current, err)
+		}
+		if !filepath.IsAbs(next) {
+			next = filepath.Join(filepath.Dir(current), next)
+		}
+		current = filepath.Clean(next)
+	}
+}
+
+func probeExecutableNode(path string) (ExecutableIdentity, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return ExecutableIdentity{}, err
+	}
+	node := ExecutableIdentity{
+		CanonicalPath: path,
+		Type:          executableType(info),
+		Size:          info.Size(),
+		MtimeNS:       info.ModTime().UnixNano(),
+		SymlinkChain:  []ExecutableIdentity{},
+	}
+	node.Dev, node.Inode, node.VolumeID, node.FileID, err = executableFileIDs(path, info)
+	if err != nil {
+		return ExecutableIdentity{}, err
+	}
+	return node, nil
+}
+
+func executableType(info os.FileInfo) string {
+	mode := info.Mode()
+	switch {
+	case mode&os.ModeSymlink != 0:
+		return ExecutableTypeSymlink
+	case info.IsDir():
+		return ExecutableTypeDirectory
+	case mode.IsRegular():
+		return ExecutableTypeFile
+	default:
+		return ExecutableTypeOther
+	}
+}
+
+// MarshalExecutableIdentity emits canonical JSON: struct field order, no HTML
+// escape, empty symlink_chain as [], integers as decimal JSON numbers.
+func MarshalExecutableIdentity(identity ExecutableIdentity) ([]byte, error) {
+	if identity.SymlinkChain == nil {
+		identity.SymlinkChain = []ExecutableIdentity{}
+	}
+	for i := range identity.SymlinkChain {
+		if identity.SymlinkChain[i].SymlinkChain == nil {
+			identity.SymlinkChain[i].SymlinkChain = []ExecutableIdentity{}
+		}
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(identity); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(buf.Bytes()), nil
+}
+
+// ConsultedExecutable is the Prepare-subject binding for one provider
+// executable. Requested is the caller string; Consulted is the PATH lookup or
+// absolute path that was probed. Identity is MarshalExecutableIdentity JSON.
+type ConsultedExecutable struct {
+	Requested string          `json:"requested"`
+	Consulted string          `json:"consulted"`
+	Identity  json.RawMessage `json:"identity,omitempty"`
+}
+
+// ResolveConsultedExecutable looks up requested on PATH when it is not
+// absolute, then probes the consulted path when it exists. Missing paths stay
+// identity-free so schema v2 stays stable for plan-only names.
+func ResolveConsultedExecutable(requested string) (ConsultedExecutable, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return ConsultedExecutable{}, fmt.Errorf("executable path is required")
+	}
+	consulted := requested
+	if filepath.IsAbs(requested) {
+		abs, err := filepath.Abs(requested)
+		if err != nil {
+			return ConsultedExecutable{}, fmt.Errorf("absolute executable path: %w", err)
+		}
+		consulted = abs
+	} else if looked, err := exec.LookPath(requested); err == nil {
+		consulted = looked
+	}
+	result := ConsultedExecutable{Requested: requested, Consulted: consulted}
+	if _, err := os.Lstat(consulted); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return result, nil
+		}
+		return ConsultedExecutable{}, err
+	}
+	identity, err := ProbeExecutableIdentity(consulted)
+	if err != nil {
+		return ConsultedExecutable{}, err
+	}
+	raw, err := MarshalExecutableIdentity(identity)
+	if err != nil {
+		return ConsultedExecutable{}, err
+	}
+	result.Identity = raw
+	return result, nil
+}

--- a/internal/launch/execidentity_test.go
+++ b/internal/launch/execidentity_test.go
@@ -1,0 +1,457 @@
+//go:build unix
+
+package launch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProbeExecutableIdentitySamePathInodeSwap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tool")
+	writeExec(t, path, "#!/bin/sh\necho one\n")
+	first, err := ProbeExecutableIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := path + ".next"
+	writeExec(t, replacement, "#!/bin/sh\necho two\n")
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatal(err)
+	}
+	second, err := ProbeExecutableIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.CanonicalPath != second.CanonicalPath || first.Type != ExecutableTypeFile {
+		t.Fatalf("path/type changed: first=%#v second=%#v", first, second)
+	}
+	if first.Inode == second.Inode && first.FileID == second.FileID {
+		t.Fatalf("inode swap kept identity first=%#v second=%#v", first, second)
+	}
+}
+
+func TestProbeExecutableIdentitySymlinkRetarget(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	link := filepath.Join(dir, "tool")
+	writeExec(t, a, "#!/bin/sh\necho a\n")
+	writeExec(t, b, "#!/bin/sh\necho b\n")
+	if err := os.Symlink(a, link); err != nil {
+		t.Fatal(err)
+	}
+	first, err := ProbeExecutableIdentity(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedA, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.CanonicalPath != resolvedA || len(first.SymlinkChain) != 1 || first.SymlinkChain[0].Type != ExecutableTypeSymlink {
+		t.Fatalf("first symlink probe = %#v", first)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(b, link); err != nil {
+		t.Fatal(err)
+	}
+	second, err := ProbeExecutableIdentity(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedB, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.CanonicalPath != resolvedB || second.Inode == first.Inode {
+		t.Fatalf("retarget did not change identity first=%#v second=%#v", first, second)
+	}
+}
+
+func TestProbeExecutableIdentityPATHRetarget(t *testing.T) {
+	dir := t.TempDir()
+	firstDir := filepath.Join(dir, "first")
+	secondDir := filepath.Join(dir, "second")
+	if err := os.MkdirAll(firstDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(secondDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	name := "amq-xgc-probe-shim"
+	firstPath := filepath.Join(firstDir, name)
+	secondPath := filepath.Join(secondDir, name)
+	writeExec(t, firstPath, "#!/bin/sh\necho first\n")
+	writeExec(t, secondPath, "#!/bin/sh\necho second\n")
+
+	t.Setenv("PATH", secondDir+string(os.PathListSeparator)+firstDir)
+	looked, err := exec.LookPath(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	viaSecond, err := ProbeExecutableIdentity(looked)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", firstDir)
+	looked, err = exec.LookPath(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	viaFirst, err := ProbeExecutableIdentity(looked)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if viaSecond.CanonicalPath == viaFirst.CanonicalPath || viaSecond.Inode == viaFirst.Inode {
+		t.Fatalf("PATH retarget kept identity second=%#v first=%#v", viaSecond, viaFirst)
+	}
+}
+
+func TestProbeExecutableIdentityInPlaceRewriteChangesSize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExec(t, path, "#!/bin/sh\necho small\n")
+	first, err := ProbeExecutableIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeExec(t, path, "#!/bin/sh\necho a-much-longer-payload-for-size\n")
+	second, err := ProbeExecutableIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Size <= first.Size {
+		t.Fatalf("in-place rewrite size first=%d second=%d", first.Size, second.Size)
+	}
+	if first.CanonicalPath != second.CanonicalPath {
+		t.Fatalf("path changed first=%s second=%s", first.CanonicalPath, second.CanonicalPath)
+	}
+}
+
+func TestMarshalExecutableIdentityFixedDecimalFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExec(t, path, "#!/bin/sh\n")
+	identity, err := ProbeExecutableIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := MarshalExecutableIdentity(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{
+		"canonical_path", "type", "dev", "inode", "volume_id", "file_id", "size", "mtime_ns", "symlink_chain",
+	} {
+		if !bytes.Contains(raw, []byte(`"`+field+`"`)) {
+			t.Fatalf("canonical JSON missing %s: %s", field, raw)
+		}
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	if string(document["inode"]) == `""` || strings.Contains(string(document["inode"]), "e") ||
+		strings.Contains(string(document["mtime_ns"]), "e") {
+		t.Fatalf("inode/mtime must be decimal integers: %s", raw)
+	}
+	if !bytes.Equal(document["symlink_chain"], []byte("[]")) {
+		t.Fatalf("empty chain = %s", document["symlink_chain"])
+	}
+}
+
+func TestResolveConsultedExecutableMissingOmitsIdentity(t *testing.T) {
+	result, err := ResolveConsultedExecutable("amq-xgc-missing-binary")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Requested != "amq-xgc-missing-binary" || result.Consulted != "amq-xgc-missing-binary" || result.Identity != nil {
+		t.Fatalf("missing path = %#v", result)
+	}
+}
+
+func TestPrepareV2SubjectBindsExecutableIdentityReplacements(t *testing.T) {
+	t.Run("unchanged", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tool")
+		writeExec(t, path, "#!/bin/sh\necho one\n")
+		fixture := fixtureWithExecutable(t, path)
+		first := prepareFixture(t, fixture, 0)
+		second := prepareFixture(t, fixture, 0)
+		if first.SubjectDigest != second.SubjectDigest || first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest {
+			t.Fatalf("unchanged files churned digests first=%s/%s/%s second=%s/%s/%s",
+				first.SubjectDigest, first.PlanDigest, first.TrustDigest, second.SubjectDigest, second.PlanDigest, second.TrustDigest)
+		}
+		assertCanonicalIdentity(t, first, path)
+	})
+	t.Run("same-path-rename-swap", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tool")
+		writeExec(t, path, "#!/bin/sh\necho one\n")
+		assertV2ReplacementChangesSubjectOnly(t, path, func() {
+			replacement := path + ".next"
+			writeExec(t, replacement, "#!/bin/sh\necho two\n")
+			if err := os.Rename(replacement, path); err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
+	t.Run("symlink-retarget", func(t *testing.T) {
+		dir := t.TempDir()
+		a := filepath.Join(dir, "a")
+		b := filepath.Join(dir, "b")
+		link := filepath.Join(dir, "tool")
+		writeExec(t, a, "#!/bin/sh\necho a\n")
+		writeExec(t, b, "#!/bin/sh\necho b\n")
+		if err := os.Symlink(a, link); err != nil {
+			t.Fatal(err)
+		}
+		assertV2ReplacementChangesSubjectOnly(t, link, func() {
+			if err := os.Remove(link); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(b, link); err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
+	t.Run("path-retarget", func(t *testing.T) {
+		dir := t.TempDir()
+		firstDir := filepath.Join(dir, "first")
+		secondDir := filepath.Join(dir, "second")
+		if err := os.MkdirAll(firstDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(secondDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		name := "amq-xgc-prepare-shim"
+		writeExec(t, filepath.Join(firstDir, name), "#!/bin/sh\necho first\n")
+		writeExec(t, filepath.Join(secondDir, name), "#!/bin/sh\necho second\n")
+		t.Setenv("PATH", firstDir)
+		fixture := fixtureWithExecutable(t, name)
+		first := prepareFixture(t, fixture, 0)
+		t.Setenv("PATH", secondDir)
+		second := prepareFixture(t, fixture, 0)
+		if first.SubjectDigest == second.SubjectDigest {
+			t.Fatal("PATH retarget kept v2 subject digest")
+		}
+		if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest {
+			t.Fatalf("PATH retarget churned plan/trust first=%s/%s second=%s/%s",
+				first.PlanDigest, first.TrustDigest, second.PlanDigest, second.TrustDigest)
+		}
+	})
+	t.Run("in-place-size-rewrite", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tool")
+		writeExec(t, path, "#!/bin/sh\necho small\n")
+		assertV2ReplacementChangesSubjectOnly(t, path, func() {
+			writeExec(t, path, "#!/bin/sh\necho a-much-longer-payload-for-size\n")
+		})
+	})
+	t.Run("mtime-only-same-inode", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "tool")
+		body := "#!/bin/sh\necho one\n"
+		writeExec(t, path, body)
+		fixture := fixtureWithExecutable(t, path)
+		first := prepareFixture(t, fixture, 0)
+		before, err := ProbeExecutableIdentity(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeExec(t, path, body)
+		later := time.Unix(0, before.MtimeNS).Add(time.Second)
+		if err := os.Chtimes(path, later, later); err != nil {
+			t.Fatal(err)
+		}
+		second := prepareFixture(t, fixture, 0)
+		after, err := ProbeExecutableIdentity(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if before.Inode != after.Inode || before.Size != after.Size {
+			t.Fatalf("mtime-only rewrite changed inode/size before=%#v after=%#v", before, after)
+		}
+		if before.MtimeNS == after.MtimeNS {
+			t.Fatal("equal-length rewrite+Chtimes did not change mtime")
+		}
+		if first.SubjectDigest == second.SubjectDigest {
+			t.Fatal("mtime-only rewrite kept v2 subject digest")
+		}
+		if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest {
+			t.Fatalf("mtime-only rewrite churned plan/trust first=%s/%s second=%s/%s",
+				first.PlanDigest, first.TrustDigest, second.PlanDigest, second.TrustDigest)
+		}
+	})
+	t.Run("same-target-hop-retarget", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "target")
+		hop1 := filepath.Join(dir, "hop1")
+		hop2 := filepath.Join(dir, "hop2")
+		link := filepath.Join(dir, "tool")
+		writeExec(t, target, "#!/bin/sh\necho target\n")
+		if err := os.Symlink(target, hop1); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, hop2); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(hop1, link); err != nil {
+			t.Fatal(err)
+		}
+		fixture := fixtureWithExecutable(t, link)
+		first := prepareFixture(t, fixture, 0)
+		before, err := ProbeExecutableIdentity(link)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(link); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(hop2, link); err != nil {
+			t.Fatal(err)
+		}
+		second := prepareFixture(t, fixture, 0)
+		after, err := ProbeExecutableIdentity(link)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if before.CanonicalPath != after.CanonicalPath || len(before.SymlinkChain) != 2 || len(after.SymlinkChain) != 2 {
+			t.Fatalf("same-target hop retarget changed leaf or chain length before=%#v after=%#v", before, after)
+		}
+		if before.SymlinkChain[1].Inode == after.SymlinkChain[1].Inode {
+			t.Fatalf("intermediate hop inode unchanged before=%#v after=%#v", before.SymlinkChain[1], after.SymlinkChain[1])
+		}
+		if first.SubjectDigest == second.SubjectDigest {
+			t.Fatal("same-target hop retarget kept v2 subject digest")
+		}
+		if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest {
+			t.Fatalf("same-target hop retarget churned plan/trust first=%s/%s second=%s/%s",
+				first.PlanDigest, first.TrustDigest, second.PlanDigest, second.TrustDigest)
+		}
+	})
+}
+
+func TestPrepareV1SubjectIgnoresExecutableReplacement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tool")
+	writeExec(t, path, "#!/bin/sh\necho one\n")
+	fixture := fixtureWithExecutable(t, path)
+	first := prepareFixture(t, fixture, SubjectSchemaV1)
+	replacement := path + ".next"
+	writeExec(t, replacement, "#!/bin/sh\necho two\n")
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatal(err)
+	}
+	second := prepareFixture(t, fixture, SubjectSchemaV1)
+	if first.SubjectDigest != second.SubjectDigest || first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest {
+		t.Fatalf("v1 replacement churned digests first=%s/%s/%s second=%s/%s/%s",
+			first.SubjectDigest, first.PlanDigest, first.TrustDigest, second.SubjectDigest, second.PlanDigest, second.TrustDigest)
+	}
+	if first.Participants[0].Executable != nil {
+		t.Fatalf("v1 subject included executable identity: %#v", first.Participants[0].Executable)
+	}
+}
+
+func TestApplyStaleV2SubjectAfterInodeSwapWritesNothing(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	path := filepath.Join(fixture.root, "tool")
+	writeExec(t, path, "#!/bin/sh\necho one\n")
+	fixture.request.Participants[0].Executable = path
+	backend := &prepareTestBackend{}
+	first, err := Prepare(context.Background(), fixture.request, fixture.dependencies(backend))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: fixture.request, SubjectDigest: first.SubjectDigest}
+	for _, action := range first.RequiredActions {
+		request.Decisions = append(request.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: action.AllowedDecisions[0]})
+	}
+	replacement := path + ".next"
+	writeExec(t, replacement, "#!/bin/sh\necho two\n")
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Apply(context.Background(), request, ApplyDependencies{PrepareDependencies: fixture.dependencies(backend)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ReasonCode != "subject_changed" {
+		t.Fatalf("Apply = %#v, want subject_changed", result)
+	}
+	if backend.creates != 0 {
+		t.Fatalf("stale Apply created backend resources: %d", backend.creates)
+	}
+	for _, name := range []string{bindingFilename, journalFilename} {
+		if _, err := os.Stat(filepath.Join(fixture.sessionRoot, bindingDirectory, name)); !os.IsNotExist(err) {
+			t.Fatalf("stale Apply wrote %s: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(fixture.sessionRoot, executionDirectory)); !os.IsNotExist(err) {
+		t.Fatalf("stale Apply wrote tickets: %v", err)
+	}
+}
+
+func writeExec(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fixtureWithExecutable(t *testing.T, executable string) internalPrepareFixture {
+	t.Helper()
+	fixture := newInternalPrepareFixture(t)
+	fixture.request.Participants[0].Executable = executable
+	return fixture
+}
+
+func prepareFixture(t *testing.T, fixture internalPrepareFixture, schema int) PrepareResult {
+	t.Helper()
+	request := fixture.request
+	request.SubjectSchema = schema
+	result, err := Prepare(context.Background(), request, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func assertV2ReplacementChangesSubjectOnly(t *testing.T, executable string, mutate func()) {
+	t.Helper()
+	fixture := fixtureWithExecutable(t, executable)
+	first := prepareFixture(t, fixture, 0)
+	mutate()
+	second := prepareFixture(t, fixture, 0)
+	if first.SubjectDigest == second.SubjectDigest {
+		t.Fatal("replacement kept v2 subject digest")
+	}
+	if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest {
+		t.Fatalf("replacement churned plan/trust first=%s/%s second=%s/%s",
+			first.PlanDigest, first.TrustDigest, second.PlanDigest, second.TrustDigest)
+	}
+}
+
+func assertCanonicalIdentity(t *testing.T, result PrepareResult, path string) {
+	t.Helper()
+	if len(result.Participants) != 1 || result.Participants[0].Executable == nil {
+		t.Fatalf("missing executable identity: %#v", result.Participants)
+	}
+	got := result.Participants[0].Executable
+	probed, err := ProbeExecutableIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := MarshalExecutableIdentity(probed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got.Identity, want) {
+		t.Fatalf("subject identity %s != marshal %s", got.Identity, want)
+	}
+}

--- a/internal/launch/execidentity_unix.go
+++ b/internal/launch/execidentity_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package launch
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func executableFileIDs(_ string, info os.FileInfo) (dev, inode, volumeID, fileID uint64, err error) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, 0, 0, fmt.Errorf("executable stat is not syscall.Stat_t")
+	}
+	return uint64(st.Dev), uint64(st.Ino), 0, 0, nil
+}

--- a/internal/launch/execidentity_windows.go
+++ b/internal/launch/execidentity_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package launch
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func executableFileIDs(path string, _ os.FileInfo) (dev, inode, volumeID, fileID uint64, err error) {
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	handle, err := windows.CreateFile(name, windows.GENERIC_READ, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil, windows.OPEN_EXISTING, windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+	if err != nil {
+		return 0, 0, 0, 0, fmt.Errorf("open executable for identity: %w", err)
+	}
+	defer windows.CloseHandle(handle)
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return 0, 0, 0, 0, fmt.Errorf("executable file id: %w", err)
+	}
+	fileIndex := uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow)
+	return 0, 0, uint64(info.VolumeSerialNumber), fileIndex, nil
+}

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -156,6 +156,7 @@ type PreparedParticipant struct {
 	PlannedOutcome string                  `json:"planned_outcome"`
 	CwdIdentity    string                  `json:"cwd_identity,omitempty"`
 	OnLive         string                  `json:"on_live,omitempty"`
+	Executable     *ConsultedExecutable    `json:"executable_identity,omitempty"`
 }
 
 type PrepareRoster struct {
@@ -442,7 +443,7 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 
 	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{}}
 	for _, participant := range request.Participants {
-		prepared, observation, agentPlan, actions, participantErr := prepareOneParticipant(participant, state, dependencies, mailboxStates[participant.Handle])
+		prepared, observation, agentPlan, actions, participantErr := prepareOneParticipant(participant, state, dependencies, mailboxStates[participant.Handle], subjectSchema)
 		if participantErr != nil {
 			return PrepareResult{}, participantErr
 		}
@@ -873,7 +874,7 @@ func inspectPrepareRoster(root *fsq.DeliveryRoot, authorization *fsq.MailboxConf
 	return roster, states, nil
 }
 
-func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetState, dependencies PrepareDependencies, mailbox string) (PreparedParticipant, PrepareObservation, *AgentPlan, []PrepareRequiredAction, error) {
+func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetState, dependencies PrepareDependencies, mailbox string, subjectSchema int) (PreparedParticipant, PrepareObservation, *AgentPlan, []PrepareRequiredAction, error) {
 	prepared := PreparedParticipant{
 		Handle: participant.Handle, Runnable: participant.Runnable, Provider: participant.Provider,
 		ResumePolicy: participant.ResumePolicy, Execution: participant.Execution, PlannedOutcome: "participant_only",
@@ -910,6 +911,13 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 	}
 	if !participant.Runnable {
 		return prepared, observation, nil, nil, nil
+	}
+	if subjectSchema == SubjectSchemaV2 && strings.TrimSpace(participant.Executable) != "" {
+		consulted, execErr := ResolveConsultedExecutable(participant.Executable)
+		if execErr != nil {
+			return prepared, observation, nil, nil, fmt.Errorf("identify executable for %s: %w", participant.Handle, execErr)
+		}
+		prepared.Executable = &consulted
 	}
 	if reason := prepareInitialInputUnsupported(participant); reason != "" {
 		prepared.PlannedOutcome = "unsupported"

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -21,6 +21,7 @@ var compatibilityFeaturesV1 = []string{
 	FeatureBaseRoot,
 	FeatureOnLive,
 	FeatureCallerContext,
+	FeatureExecutableIdentity,
 }
 
 func Compatibility() CompatibilityV1 {

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -33,8 +33,11 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if !slices.Contains(Compatibility().Features, FeatureCallerContext) {
 		t.Fatal("Compatibility did not advertise the completed caller_context feature")
 	}
+	if !slices.Contains(Compatibility().Features, FeatureExecutableIdentity) {
+		t.Fatal("Compatibility omitted advertised executable_identity")
+	}
 	for _, unfinished := range []string{
-		FeatureWrapper, FeatureExecutableIdentity,
+		FeatureWrapper,
 	} {
 		if slices.Contains(Compatibility().Features, unfinished) {
 			t.Fatalf("Compatibility advertised unfinished feature %q", unfinished)


### PR DESCRIPTION
## Summary
- Bind consulted provider executable identity (PATH/symlink/inode/mtime) into the schema v2 Prepare subject only.
- Apply re-probes under the existing lease; same-path inode replacement is `subject_changed` with zero binding/journal/ticket/backend writes.
- Advertise `executable_identity`. Flip oracle finding7. Schema v1 and plan/trust digests stay unchanged.

## Test plan
- [x] `go test ./internal/launch` identity replacements (inode swap, symlink, PATH, size, mtime-only, same-target hop)
- [x] `go test ./internal/cli -run TestAdoptionSmokeOmriSquadV2294/finding7`
- [x] `make ci` green locally
- [ ] GitHub CI on this PR

Made with [Cursor](https://cursor.com)