### PR TITLE
feat(launchapi): add typed wrapper pre-exec with trust-bound argv

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -22,10 +22,9 @@ _ = negotiated
 ```
 
 A `0.61.1` binary advertises `placement`, `initial_input`, `base_root`,
-`on_live`, `caller_context`, and `executable_identity`. It can still omit later
-Wave B3 feature IDs while those beads are incomplete. A caller must require
-every feature it uses. Contract semver alone does not claim that an unadvertised
-feature is available.
+`on_live`, `caller_context`, `executable_identity`, and `wrapper`. A caller must
+require every feature it uses. Contract semver alone does not claim that an
+unadvertised feature is available.
 
 `PreviewV1.capabilities` reports the selected providers' static adapter grammar
 without executing a caller-supplied provider. `grammar_version` is the
@@ -44,6 +43,15 @@ Claude admits one `--allowedTools <comma-separated-list>` pair. Codex admits
 ordered `-c model_reasoning_effort=<value>` pairs with values `minimal`, `low`,
 `medium`, `high`, or `xhigh`; duplicate keys and unknown keys or values reject.
 
+An optional participant `wrapper` contains a clean absolute `executable` path
+and static `args`. The path must resolve to one regular file; resolvable
+symlinks are accepted. AMQ executes the exact argv `wrapper executable + wrapper
+args + resolved provider executable + provider args`, without a shell. The
+declared wrapper path and arguments enter the plan, trust, subject, ticket, and
+command preview. An argument initial input stays the final inner-provider
+argument. Unsupported `stdin` and `file` carriers remain typed refusals when a
+wrapper is present.
+
 ## Intent
 
 The intent owns the desired participants. Discovery owns the project root,
@@ -58,6 +66,7 @@ does not replace committed project configuration.
       "handle": "claude",
       "runnable": true,
       "executable": "claude",
+      "wrapper": {"executable": "/opt/company/bin/seat-wrapper", "args": ["--profile", "lead"]},
       "cwd": {"kind": "relative", "path": "."},
       "resume_policy": "resume",
       "execution": {

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -26,7 +27,7 @@ import (
 //	Row | Finding | Today | WB3 expected
 //	finding1_missing_profile_base_root | 1 named-profile base root | missing .agent-mail/<profile> refuses (not found / stat delivery root) | Prepare planned write create_base_root; Apply creates the authorized base
 //	finding2_mixed_live_fresh_keep_creates | 2 live-seat dispositions | on_live keep -> kept + created missing seats | omitted on_live still refuses
-//	finding3_wrapper_unknown_field | 3 wrapper | strict decode unknown field "wrapper" | wrapper argv prepended to full provider argv
+//	finding3_wrapper_argv | 3 wrapper | strict decode unknown field "wrapper" | wrapper argv prepended to full provider argv
 //	finding4_placement_unsupported | 4 placement | AMQ_SQUAD_TMUX_* env rejected as provider env | placement preview; unsupported tuple -> placement_unsupported
 //	finding5_positional_bootstrap_prompt / finding5_claude_allowed_tools / finding5_codex_dash_c | 5 materialized argv | raw positional prompt rejected; exact --allowedTools and -c forms admitted | initial_input + --allowedTools / -c admitted
 //	finding6_caller_context_bound_and_echoed | 6 caller correlation | caller_context is subject-bound and echoed on Apply/evidence/lifecycle
@@ -96,15 +97,30 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 		}
 	})
 
-	t.Run("finding3_wrapper_unknown_field", func(t *testing.T) {
+	t.Run("finding3_wrapper_argv", func(t *testing.T) {
 		fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "collab")
-		raw := fx.intentJSON(t, fx.legalSquadIntent())
-		raw = injectParticipantJSONField(t, raw, 1, "wrapper", map[string]any{
-			"executable": "/opt/company/bin/seat-wrapper",
-			"args":       []string{"--profile", "lead"},
-		})
-		stdout, stderr, exit := fx.prepareJSON(t, raw, launch.LauncherCommands)
-		assertAdoptionUnknownField(t, exit, stdout, stderr, "wrapper")
+		wrapper := filepath.Join(t.TempDir(), "seat-wrapper")
+		if err := os.WriteFile(wrapper, []byte("#!/bin/sh\nexec \"$@\"\n"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		intent := fx.legalSquadIntent()
+		intent.Participants[1].Wrapper = &launchapi.WrapperV1{Executable: wrapper, Args: []string{"--profile", "lead"}}
+		stdout, stderr, exit := fx.prepare(t, intent, launch.LauncherCommands)
+		if exit != ExitActionRequired {
+			t.Fatalf("wrapper Prepare exit=%d stdout=%s stderr=%s", exit, stdout, stderr)
+		}
+		var result launchapi.PrepareResultV1
+		decodeRealLaunchJSON(t, stdout, &result)
+		for _, participant := range result.Preview.Participants {
+			if participant.Handle == "lead" && participant.Command != nil {
+				want := []string{wrapper, "--profile", "lead", fx.claudePath}
+				if len(participant.Command.Argv) < len(want) || !slices.Equal(participant.Command.Argv[:len(want)], want) {
+					t.Fatalf("wrapper argv = %#v, want prefix %#v", participant.Command.Argv, want)
+				}
+				return
+			}
+		}
+		t.Fatal("lead wrapper preview missing")
 	})
 
 	t.Run("finding6_caller_context_bound_and_echoed", func(t *testing.T) {
@@ -619,28 +635,6 @@ func countHermeticTmuxPanes(t *testing.T, socketDir string) int {
 	return len(strings.Fields(string(output)))
 }
 
-func injectParticipantJSONField(t *testing.T, intentJSON []byte, index int, key string, value any) []byte {
-	t.Helper()
-	var doc map[string]any
-	if err := json.Unmarshal(intentJSON, &doc); err != nil {
-		t.Fatal(err)
-	}
-	participants, ok := doc["participants"].([]any)
-	if !ok || index >= len(participants) {
-		t.Fatalf("participants[%d] missing", index)
-	}
-	participant, ok := participants[index].(map[string]any)
-	if !ok {
-		t.Fatalf("participants[%d] is not an object", index)
-	}
-	participant[key] = value
-	data, err := json.MarshalIndent(doc, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return append(data, '\n')
-}
-
 func injectPrepareJSONField(t *testing.T, applyJSON []byte, key string, value any) []byte {
 	t.Helper()
 	var doc map[string]any
@@ -702,15 +696,4 @@ func assertAdoptionArgumentAdmitted(t *testing.T, exit int, stdout, stderr []byt
 		return
 	}
 	t.Fatalf("admitted argument participant %q missing from preview", handle)
-}
-
-func assertAdoptionUnknownField(t *testing.T, exit int, stdout, stderr []byte, field string) {
-	t.Helper()
-	if exit != ExitUsage {
-		t.Fatalf("unknown-field rejection exit=%d want %d stdout=%s stderr=%s", exit, ExitUsage, stdout, stderr)
-	}
-	combined := string(stdout) + string(stderr)
-	if !strings.Contains(combined, "unknown field") || !strings.Contains(combined, field) {
-		t.Fatalf("unknown-field rejection missing %q: stdout=%s stderr=%s", field, stdout, stderr)
-	}
 }

--- a/internal/cli/launch_api_e2e_test.go
+++ b/internal/cli/launch_api_e2e_test.go
@@ -600,6 +600,8 @@ func testSiblingWorktreeExactRoot(t *testing.T, amqBinary, binDir string) {
 	providerDir := t.TempDir()
 	claudeProvider := filepath.Join(providerDir, "claude")
 	codexProvider := filepath.Join(providerDir, "codex")
+	wrapperPath := filepath.Join(providerDir, "seat-wrapper")
+	wrapperRecord := filepath.Join(providerDir, "wrapper-argv")
 	proofScript := func(capabilities string) string {
 		return `#!/bin/sh
 set -eu
@@ -630,6 +632,17 @@ esac
 `)), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	wrapperScript := `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > ` + shellQuoteArg(wrapperRecord) + `
+[ "${1:-}" = "--profile" ]
+[ "${2:-}" = "lead" ]
+shift 2
+exec "$@"
+`
+	if err := os.WriteFile(wrapperPath, []byte(wrapperScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
 
 	disabledWake := func() *launchapi.ExecutionOptionsV1 {
 		return &launchapi.ExecutionOptionsV1{Wake: launchapi.WakeOptionsV1{
@@ -639,6 +652,8 @@ esac
 	intent := launchapi.LaunchIntentV1{IntentVersion: launchapi.IntentVersionV1, Participants: []launchapi.ParticipantV1{
 		{
 			Handle: "claude", Runnable: true, Executable: claudeProvider,
+			Args:         []string{"--allowedTools", "Read"},
+			Wrapper:      &launchapi.WrapperV1{Executable: wrapperPath, Args: []string{"--profile", "lead"}},
 			Cwd:          &launchapi.WorkingDirectoryV1{Kind: launchapi.WorkingDirectoryAbsolute, Path: canonicalRepo},
 			ResumePolicy: launchapi.ResumePolicyFresh, Execution: disabledWake(),
 		},
@@ -701,6 +716,19 @@ esac
 		if handle == "codex" && !strings.Contains(string(output), "exact-root-message") {
 			t.Fatalf("sibling command did not drain the real message:\n%s", output)
 		}
+	}
+	recorded, err := os.ReadFile(wrapperRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claudeNonce := commands["claude"].EnvOverlay[launch.InternalLaunchNonceEnv]
+	if claudeNonce == "" {
+		t.Fatal("emitted Claude command omitted managed launch nonce")
+	}
+	wantWrapperArgv := []string{"--profile", "lead", claudeProvider, "--allowedTools", "Read", "--session-id", claudeNonce}
+	gotWrapperArgv := strings.Split(strings.TrimSuffix(string(recorded), "\n"), "\n")
+	if !slices.Equal(gotWrapperArgv, wantWrapperArgv) {
+		t.Fatalf("real wrapper argv = %#v, want %#v", gotWrapperArgv, wantWrapperArgv)
 	}
 	if _, err := os.Stat(filepath.Join(canonicalSibling, defaultCoopRoot)); !os.IsNotExist(err) {
 		t.Fatalf("sibling-local queue exists under %s: %v", canonicalSibling, err)

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -95,6 +95,7 @@ type PlanRequest struct {
 	BypassArgs       []string
 	EnvOverlay       map[string]string
 	InitialInput     *InitialInputRequest
+	Wrapper          *Wrapper
 }
 
 type InitialInputRequest struct {

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -521,7 +521,7 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		}
 		config.Agents = append(config.Agents, ProjectAgentConfig{
 			Handle: participant.Handle, Adapter: key, Command: command, Env: cloneEnv(participant.EnvOverlay),
-			Cwd: participant.Cwd, ResumePolicy: participant.ResumePolicy, InitialInput: initial,
+			Cwd: participant.Cwd, ResumePolicy: participant.ResumePolicy, InitialInput: initial, Wrapper: cloneWrapper(participant.Wrapper),
 		})
 		adapters[key] = adapter
 		executionOptions[participant.Handle] = *clonePrepareExecutionOptions(&participant.Execution)

--- a/internal/launch/commands_test.go
+++ b/internal/launch/commands_test.go
@@ -167,6 +167,28 @@ func TestCommandsCoopExecGrammarShape(t *testing.T) {
 	}
 }
 
+func TestCommandsWrapperUsesOneCoopExecBoundary(t *testing.T) {
+	wrapper := &Wrapper{Executable: "/opt/company/bin/seat-wrapper", Args: []string{"--profile", "lead"}}
+	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{{
+		Handle: "claude", Wrapper: wrapper,
+		Argv: []string{wrapper.Executable, "--profile", "lead", "/usr/local/bin/claude", "--model", "opus"},
+		Cwd:  "/work/project", AdapterMode: AdapterModeUnsupported, ResumePolicy: ResumeDisabled,
+	}}}
+	_, root := openTestRoot(t)
+	result, err := Commands{}.Create(CreateRequest{Session: "collab", Plan: plan, Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(result.Commands))
+	}
+	command := result.Commands[0]
+	assertCoopExecGrammar(t, command.Argv, root.Base(), "claude", plan.Agents[0].Argv)
+	if count := slices.Index(command.Argv, wrapper.Executable); count < 0 || strings.Count(command.Line, "coop exec") != 1 {
+		t.Fatalf("wrapper command crossed an invalid coop boundary: %#v line=%q", command.Argv, command.Line)
+	}
+}
+
 func TestCommandsCoopExecOldShapeFailsGrammar(t *testing.T) {
 	old := []string{"amq", "coop", "exec", "--session", "collab", "--me", "claude", "--", "/usr/local/bin/claude", "--model", "opus"}
 	if err := coopExecGrammarError(old, "/queue/collab", "claude", []string{"/usr/local/bin/claude", "--model", "opus"}); err == nil {

--- a/internal/launch/config.go
+++ b/internal/launch/config.go
@@ -40,6 +40,7 @@ type ProjectAgentConfig struct {
 	Cwd          string               `json:"cwd,omitempty"`
 	ResumePolicy ResumePolicy         `json:"resume_policy"`
 	InitialInput *InitialInputRequest `json:"initial_input,omitempty"`
+	Wrapper      *Wrapper             `json:"wrapper,omitempty"`
 }
 
 type LayoutIntent struct {
@@ -157,6 +158,11 @@ func (cfg ProjectConfig) Validate() error {
 			}
 			if !validDigest(agent.InitialInput.SHA256) || strings.ContainsRune(agent.InitialInput.Value, 0) {
 				return fmt.Errorf("agent %q initial input is invalid", agent.Handle)
+			}
+		}
+		if agent.Wrapper != nil {
+			if err := agent.Wrapper.Validate(); err != nil {
+				return fmt.Errorf("agent %q wrapper: %w", agent.Handle, err)
 			}
 		}
 		if agent.ResumePolicy != ResumeEnabled && agent.ResumePolicy != ResumeFresh && agent.ResumePolicy != ResumeDisabled {

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -60,12 +61,13 @@ type ExecutionTicket struct {
 	Cwd             string `json:"cwd"`
 	CwdIdentity     string `json:"cwd_identity"`
 
-	ProviderExecutable         string `json:"provider_executable"`
-	ProviderExecutableIdentity string `json:"provider_executable_identity"`
-	AMQExecutable              string `json:"amq_executable"`
-	AMQExecutableIdentity      string `json:"amq_executable_identity"`
-	InjectorExecutable         string `json:"injector_executable,omitempty"`
-	InjectorExecutableIdentity string `json:"injector_executable_identity,omitempty"`
+	ProviderExecutable         string   `json:"provider_executable"`
+	ProviderExecutableIdentity string   `json:"provider_executable_identity"`
+	AMQExecutable              string   `json:"amq_executable"`
+	AMQExecutableIdentity      string   `json:"amq_executable_identity"`
+	InjectorExecutable         string   `json:"injector_executable,omitempty"`
+	InjectorExecutableIdentity string   `json:"injector_executable_identity,omitempty"`
+	Wrapper                    *Wrapper `json:"wrapper,omitempty"`
 
 	TargetArgv    []string                 `json:"target_argv"`
 	DynamicArgv   []DynamicArg             `json:"dynamic_argv,omitempty"`
@@ -96,6 +98,7 @@ type ExecutionTicketRequest struct {
 	Reason                            string
 	Execution                         *PrepareExecutionOptions
 	CallerContext                     map[string]string
+	Wrapper                           *Wrapper
 }
 
 type ExecutionEnvelope struct {
@@ -172,7 +175,7 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 		InitialInput: clonePlannedInitialInput(request.InitialInput),
 		TargetEnv:    env, EnvDigest: digest, State: request.State, Reason: request.Reason,
 		Execution: execution, InjectorExecutable: injector, InjectorExecutableIdentity: injectorID,
-		CallerContext: cloneCallerContext(request.CallerContext),
+		CallerContext: cloneCallerContext(request.CallerContext), Wrapper: cloneWrapper(request.Wrapper),
 	}
 	if ticket.State == "" {
 		ticket.State = ExecutionPending
@@ -228,6 +231,16 @@ func (ticket ExecutionTicket) Validate() error {
 	}
 	if len(ticket.TargetArgv) == 0 || strings.TrimSpace(ticket.TargetArgv[0]) == "" {
 		return fmt.Errorf("target argv is required")
+	}
+	if ticket.Wrapper != nil {
+		if err := ticket.Wrapper.Validate(); err != nil {
+			return fmt.Errorf("wrapper: %w", err)
+		}
+		prefix := append([]string{ticket.Wrapper.Executable}, ticket.Wrapper.Args...)
+		providerIndex := len(prefix)
+		if len(ticket.TargetArgv) <= providerIndex || !slices.Equal(ticket.TargetArgv[:providerIndex], prefix) {
+			return fmt.Errorf("wrapper does not match target argv")
+		}
 	}
 	for i, arg := range ticket.TargetArgv {
 		if strings.ContainsRune(arg, 0) || (arg == "" && !ticketInitialInputOwnsArg(ticket, i)) {
@@ -989,9 +1002,30 @@ func ValidateExecutionEnvelope(root *fsq.DeliveryRoot, ticket ExecutionTicket, e
 	if err != nil || cwd != ticket.Cwd || cwdID != ticket.CwdIdentity {
 		return fmt.Errorf("working directory identity changed")
 	}
-	provider, providerID, err := canonicalFile(envelope.ProviderExecutable)
+	provider, providerID, err := canonicalFile(ticket.ProviderExecutable)
 	if err != nil || provider != ticket.ProviderExecutable || providerID != ticket.ProviderExecutableIdentity || pathWithin(provider, project) {
 		return fmt.Errorf("provider executable identity changed")
+	}
+	if ticket.Wrapper != nil {
+		providerIndex := len(ticket.Wrapper.Args) + 1
+		if providerIndex >= len(ticket.TargetArgv) {
+			return fmt.Errorf("provider target is missing")
+		}
+		targetProvider, targetProviderID, targetProviderErr := canonicalFile(ticket.TargetArgv[providerIndex])
+		if targetProviderErr != nil || targetProvider != ticket.ProviderExecutable || targetProviderID != ticket.ProviderExecutableIdentity {
+			return fmt.Errorf("provider target identity changed")
+		}
+		if err := validateWrapperFile(ticket.Wrapper); err != nil {
+			return fmt.Errorf("wrapper executable changed: %w", err)
+		}
+		if envelope.ProviderExecutable != ticket.Wrapper.Executable {
+			return fmt.Errorf("execution target changed")
+		}
+	} else {
+		target, targetID, targetErr := canonicalFile(envelope.ProviderExecutable)
+		if targetErr != nil || target != ticket.ProviderExecutable || targetID != ticket.ProviderExecutableIdentity {
+			return fmt.Errorf("provider executable identity changed")
+		}
 	}
 	amq, amqID, err := canonicalFile(envelope.AMQExecutable)
 	if err != nil || amq != ticket.AMQExecutable || amqID != ticket.AMQExecutableIdentity {

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -172,6 +173,66 @@ func TestPrepareMintPromotesExactPendingAndExecFailureReverts(t *testing.T) {
 	record, err = LoadConversation(fixture.root, "claude")
 	if err != nil || record.State != CapturePending || record.Reason != "spawn_failed" {
 		t.Fatalf("reverted conversation = %#v, %v", record, err)
+	}
+}
+
+func TestPrepareExecutionAcceptsDeclaredWrapperTarget(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "56565656-5656-4565-8565-565656565656"
+	wrapper := testWrapper(t)
+	targetArgv := []string{wrapper.Executable, "--profile", "lead", fixture.provider, "--session-id", nonce}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeMint, Provider: ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: targetArgv, TargetEnv: map[string]string{"LANG": "C"}, Wrapper: wrapper,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CapturePending, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := PrepareExecution(fixture.root, "claude", nonce, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: wrapper.Executable,
+		TargetArgv: targetArgv, Environment: []string{"LANG=C"},
+	})
+	if err != nil || prepared.State != ExecutionAcknowledged {
+		t.Fatalf("PrepareExecution = %#v, %v", prepared, err)
+	}
+	resolved, err := ResolveExecutionArgv(prepared)
+	if err != nil || !slices.Equal(resolved, targetArgv) {
+		t.Fatalf("ResolveExecutionArgv = %#v, %v", resolved, err)
+	}
+	changed := ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: fixture.provider,
+		TargetArgv: targetArgv, Environment: []string{"LANG=C"},
+	}
+	if err := ValidateExecutionEnvelope(fixture.root, prepared, changed); err == nil || !strings.Contains(err.Error(), "execution target changed") {
+		t.Fatalf("provider bypassed wrapper: %v", err)
+	}
+	tampered := prepared
+	tampered.TargetArgv = slices.Clone(prepared.TargetArgv)
+	tampered.TargetArgv[3] = wrapper.Executable
+	changed.ProviderExecutable = wrapper.Executable
+	changed.TargetArgv = tampered.TargetArgv
+	if err := ValidateExecutionEnvelope(fixture.root, tampered, changed); err == nil || !strings.Contains(err.Error(), "provider target identity changed") {
+		t.Fatalf("wrapper redirected inner provider: %v", err)
 	}
 }
 

--- a/internal/launch/plan.go
+++ b/internal/launch/plan.go
@@ -78,6 +78,7 @@ type AgentPlan struct {
 	// plan makes journal recovery lossless before the wrapper consumes it.
 	Execution    *PrepareExecutionOptions `json:"execution,omitempty"`
 	InitialInput *PlannedInitialInput     `json:"initial_input,omitempty"`
+	Wrapper      *Wrapper                 `json:"wrapper,omitempty"`
 }
 
 // DynamicArg marks one runtime-generated argv value. Unmarked argv values are
@@ -170,6 +171,15 @@ func (a AgentPlan) validate() error {
 	if a.PreSpawnAcquire && conversationSlots != 1 {
 		return fmt.Errorf("pre-spawn acquisition requires exactly one dynamic conversation slot")
 	}
+	if a.Wrapper != nil {
+		if err := a.Wrapper.Validate(); err != nil {
+			return fmt.Errorf("wrapper: %w", err)
+		}
+		prefix := append([]string{a.Wrapper.Executable}, a.Wrapper.Args...)
+		if len(a.Argv) <= len(prefix) || !slices.Equal(a.Argv[:len(prefix)], prefix) {
+			return fmt.Errorf("wrapper does not match argv prefix")
+		}
+	}
 	if a.InitialInput != nil {
 		if a.InitialInput.Kind != InitialInputArgument {
 			return fmt.Errorf("invalid initial input kind %q", a.InitialInput.Kind)
@@ -210,6 +220,7 @@ type staticAgentPlan struct {
 	ResumePolicy    ResumePolicy           `json:"resume_policy"`
 	PreSpawnAcquire bool                   `json:"pre_spawn_acquire,omitempty"`
 	InitialInput    *canonicalInitialInput `json:"initial_input,omitempty"`
+	Wrapper         *Wrapper               `json:"wrapper,omitempty"`
 }
 
 type canonicalInitialInput struct {
@@ -266,7 +277,7 @@ func (p Plan) semanticDigest(allowEmpty, trustProjection bool) (string, error) {
 		agents[i] = staticAgentPlan{
 			Handle: agent.Handle, Argv: argv, EnvOverlay: agent.EnvOverlay,
 			Cwd: agent.Cwd, AdapterMode: agent.AdapterMode, ResumePolicy: agent.ResumePolicy,
-			PreSpawnAcquire: agent.PreSpawnAcquire, InitialInput: initial,
+			PreSpawnAcquire: agent.PreSpawnAcquire, InitialInput: initial, Wrapper: cloneWrapper(agent.Wrapper),
 		}
 	}
 	slices.SortFunc(agents, func(a, b staticAgentPlan) int { return strings.Compare(a.Handle, b.Handle) })

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -103,6 +103,7 @@ type PrepareParticipant struct {
 	Execution    PrepareExecutionOptions
 	InitialInput *PrepareInitialInput
 	OnLive       string
+	Wrapper      *Wrapper
 }
 
 type PrepareInitialInput struct {
@@ -157,6 +158,7 @@ type PreparedParticipant struct {
 	CwdIdentity    string                  `json:"cwd_identity,omitempty"`
 	OnLive         string                  `json:"on_live,omitempty"`
 	Executable     *ConsultedExecutable    `json:"executable_identity,omitempty"`
+	Wrapper        *ConsultedExecutable    `json:"wrapper_executable_identity,omitempty"`
 }
 
 type PrepareRoster struct {
@@ -924,6 +926,24 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 		observation.ReasonCode = reason
 		return prepared, observation, nil, nil, nil
 	}
+	if err := validateWrapperFile(participant.Wrapper); err != nil {
+		return prepared, observation, nil, nil, fmt.Errorf("wrapper for %s: %w", participant.Handle, err)
+	}
+	if subjectSchema == SubjectSchemaV2 && participant.Wrapper != nil {
+		identity, err := ProbeExecutableIdentity(participant.Wrapper.Executable)
+		if err != nil {
+			return prepared, observation, nil, nil, fmt.Errorf("identify wrapper for %s: %w", participant.Handle, err)
+		}
+		raw, err := MarshalExecutableIdentity(identity)
+		if err != nil {
+			return prepared, observation, nil, nil, err
+		}
+		prepared.Wrapper = &ConsultedExecutable{
+			Requested: participant.Wrapper.Executable,
+			Consulted: participant.Wrapper.Executable,
+			Identity:  raw,
+		}
+	}
 	if dependencies.AdapterFor == nil {
 		return prepared, observation, nil, nil, fmt.Errorf("prepare adapter factory is missing")
 	}
@@ -977,6 +997,10 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 	}
 	if err != nil {
 		return prepared, observation, nil, actions, err
+	}
+	plan, err = applyWrapper(plan, participant.Wrapper)
+	if err != nil {
+		return prepared, observation, nil, actions, fmt.Errorf("wrapper for %s: %w", participant.Handle, err)
 	}
 	plan.Execution = clonePrepareExecutionOptions(&participant.Execution)
 	prepared.Command = previewStaticCommand(plan)

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -701,15 +701,19 @@ func plannedConversations(planned []plannedAgent) []ConversationRecord {
 func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []plannedAgent, amqPath, backend, profile string) error {
 	written := make([]plannedAgent, 0, len(planned))
 	for _, agent := range planned {
+		provider, err := providerExecutable(agent.plan)
+		if err != nil {
+			return errors.Join(fmt.Errorf("resolve provider executable for %s: %w", agent.plan.Handle, err), removeExecutionTickets(request.Root, lease, written))
+		}
 		ticketRequest := ExecutionTicketRequest{
 			Handle: agent.plan.Handle, LaunchNonce: agent.plan.LaunchNonce,
 			Mode: agent.plan.AdapterMode, Provider: agent.adapter.Name(), ProviderVersion: agent.providerVersion,
 			ConversationID: agent.plan.ConversationID, PreSpawnAcquire: agent.plan.PreSpawnAcquire,
 			ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Cwd: agent.plan.Cwd,
-			ProviderExecutable: agent.plan.Argv[0], AMQExecutable: amqPath,
+			ProviderExecutable: provider, AMQExecutable: amqPath,
 			TargetArgv: agent.plan.Argv, DynamicArgv: agent.plan.DynamicArgv, TargetEnv: agent.plan.EnvOverlay,
 			InitialInput: agent.plan.InitialInput, Execution: agent.plan.Execution,
-			CallerContext: cloneCallerContext(request.CallerContext),
+			CallerContext: cloneCallerContext(request.CallerContext), Wrapper: cloneWrapper(agent.plan.Wrapper),
 		}
 		if agent.plan.PreSpawnAcquire || (agent.adapter.Name() == CodexProvider && agent.plan.AdapterMode == AdapterModeCapture) {
 			ticketRequest.Backend, ticketRequest.Profile = backend, profile
@@ -807,7 +811,7 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			Handle: cfg.Handle, ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(),
 			AMQExecutable: request.AMQPath, Cwd: cwd,
 			LaunchNonce: nonce, ResumePolicy: policy, CommittedArgs: committedArgs, BypassArgs: bypassArgs,
-			EnvOverlay: cfg.Env, AllowExternalCwd: request.AllowExternalCwd, InitialInput: cfg.InitialInput,
+			EnvOverlay: cfg.Env, AllowExternalCwd: request.AllowExternalCwd, InitialInput: cfg.InitialInput, Wrapper: cloneWrapper(cfg.Wrapper),
 		}
 		conversation, loadErr := LoadConversation(request.Root, cfg.Handle)
 		hasConversation := loadErr == nil
@@ -914,6 +918,12 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			continue
 		}
 		if err := ValidateAdapterPlan(adapter, agentPlan); err != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		agentPlan, err = applyWrapper(agentPlan, cfg.Wrapper)
+		if err != nil {
 			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
 			result.Agents = append(result.Agents, item)
 			continue

--- a/internal/launch/wrapper.go
+++ b/internal/launch/wrapper.go
@@ -1,0 +1,91 @@
+package launch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"unicode/utf8"
+)
+
+type Wrapper struct {
+	Executable string   `json:"executable"`
+	Args       []string `json:"args,omitempty"`
+}
+
+func (wrapper Wrapper) Validate() error {
+	if !utf8.ValidString(wrapper.Executable) || strings.ContainsRune(wrapper.Executable, 0) {
+		return fmt.Errorf("executable must be valid UTF-8 without NUL")
+	}
+	if !filepath.IsAbs(wrapper.Executable) || filepath.Clean(wrapper.Executable) != wrapper.Executable {
+		return fmt.Errorf("executable must be a clean absolute path")
+	}
+	for i, arg := range wrapper.Args {
+		if arg == "" {
+			return fmt.Errorf("args[%d] must not be empty", i)
+		}
+		if !utf8.ValidString(arg) || strings.ContainsRune(arg, 0) {
+			return fmt.Errorf("args[%d] must be valid UTF-8 without NUL", i)
+		}
+	}
+	return nil
+}
+
+func validateWrapperFile(wrapper *Wrapper) error {
+	if wrapper == nil {
+		return nil
+	}
+	if err := wrapper.Validate(); err != nil {
+		return err
+	}
+	info, err := os.Stat(wrapper.Executable)
+	if err != nil {
+		return fmt.Errorf("stat executable: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("executable must resolve to one regular file")
+	}
+	return nil
+}
+
+func cloneWrapper(wrapper *Wrapper) *Wrapper {
+	if wrapper == nil {
+		return nil
+	}
+	return &Wrapper{Executable: wrapper.Executable, Args: slices.Clone(wrapper.Args)}
+}
+
+func applyWrapper(plan AgentPlan, wrapper *Wrapper) (AgentPlan, error) {
+	if wrapper == nil {
+		return plan, nil
+	}
+	if err := validateWrapperFile(wrapper); err != nil {
+		return AgentPlan{}, err
+	}
+	offset := len(wrapper.Args) + 1
+	argv := make([]string, 0, offset+len(plan.Argv))
+	argv = append(argv, wrapper.Executable)
+	argv = append(argv, wrapper.Args...)
+	argv = append(argv, plan.Argv...)
+	plan.Argv = argv
+	for i := range plan.DynamicArgv {
+		plan.DynamicArgv[i].Index += offset
+	}
+	if plan.InitialInput != nil {
+		plan.InitialInput.ArgvIndex += offset
+	}
+	plan.Wrapper = cloneWrapper(wrapper)
+	return plan, plan.Validate()
+}
+
+func providerExecutable(plan AgentPlan) (string, error) {
+	index := 0
+	if plan.Wrapper != nil {
+		index = len(plan.Wrapper.Args) + 1
+	}
+	if index >= len(plan.Argv) || strings.TrimSpace(plan.Argv[index]) == "" {
+		return "", fmt.Errorf("provider executable is missing from wrapped argv")
+	}
+	return plan.Argv[index], nil
+}

--- a/internal/launch/wrapper_test.go
+++ b/internal/launch/wrapper_test.go
@@ -1,0 +1,190 @@
+package launch
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestApplyWrapperComposesArgvAndShiftsOwnedSlots(t *testing.T) {
+	wrapper := testWrapper(t)
+	input := "bootstrap"
+	sum := sha256.Sum256([]byte(input))
+	plan := AgentPlan{
+		Handle: "claude", Argv: []string{"/usr/local/bin/claude", "--session-id", "00000000-0000-4000-8000-000000000000", input},
+		Cwd: "/work", AdapterMode: AdapterModeMint, ResumePolicy: ResumeEnabled,
+		LaunchNonce:  "00000000-0000-4000-8000-000000000000",
+		DynamicArgv:  []DynamicArg{{Index: 2, Kind: DynamicArgLaunchNonce}},
+		InitialInput: &PlannedInitialInput{Kind: InitialInputArgument, SHA256: "sha256:" + hex.EncodeToString(sum[:]), ArgvIndex: 3},
+	}
+
+	wrapped, err := applyWrapper(plan, wrapper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{wrapper.Executable, "--profile", "lead", "/usr/local/bin/claude", "--session-id", plan.LaunchNonce, input}
+	if !slices.Equal(wrapped.Argv, want) {
+		t.Fatalf("wrapped argv = %#v, want %#v", wrapped.Argv, want)
+	}
+	if wrapped.DynamicArgv[0].Index != 5 || wrapped.InitialInput.ArgvIndex != 6 {
+		t.Fatalf("shifted slots = dynamic:%#v initial:%#v", wrapped.DynamicArgv, wrapped.InitialInput)
+	}
+	provider, err := providerExecutable(wrapped)
+	if err != nil || provider != "/usr/local/bin/claude" {
+		t.Fatalf("provider executable = %q, %v", provider, err)
+	}
+}
+
+func TestWrapperValidationAcceptsRegularFileAndResolvableSymlink(t *testing.T) {
+	wrapper := testWrapper(t)
+	if err := validateWrapperFile(wrapper); err != nil {
+		t.Fatalf("regular wrapper: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "wrapper-link")
+	if err := os.Symlink(wrapper.Executable, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateWrapperFile(&Wrapper{Executable: link}); err != nil {
+		t.Fatalf("symlink wrapper: %v", err)
+	}
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "missing", path: filepath.Join(t.TempDir(), "missing"), want: "stat executable"},
+		{name: "directory", path: t.TempDir(), want: "regular file"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateWrapperFile(&Wrapper{Executable: test.path}); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateWrapperFile error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestWrapperValidateRejectsUnsafeSyntax(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		wrapper Wrapper
+		want    string
+	}{
+		{name: "relative path", wrapper: Wrapper{Executable: "bin/seat-wrapper"}, want: "absolute path"},
+		{name: "PATH lookup", wrapper: Wrapper{Executable: "seat-wrapper"}, want: "absolute path"},
+		{name: "shell fragment", wrapper: Wrapper{Executable: "sh -c"}, want: "absolute path"},
+		{name: "unclean path", wrapper: Wrapper{Executable: "/opt/bin/../seat-wrapper"}, want: "clean absolute"},
+		{name: "executable NUL", wrapper: Wrapper{Executable: "/opt/seat\x00wrapper"}, want: "without NUL"},
+		{name: "empty arg", wrapper: Wrapper{Executable: "/opt/seat-wrapper", Args: []string{""}}, want: "must not be empty"},
+		{name: "arg NUL", wrapper: Wrapper{Executable: "/opt/seat-wrapper", Args: []string{"bad\x00arg"}}, want: "without NUL"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.wrapper.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Wrapper.Validate error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestWrapperChangesPlanAndTrustDigests(t *testing.T) {
+	wrapper := testWrapper(t)
+	base := validPlan()
+	wrapped := validPlan()
+	var err error
+	wrapped.Agents[0], err = applyWrapper(wrapped.Agents[0], wrapper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	basePlan, _ := base.SemanticDigest()
+	baseTrust, _ := base.TrustSemanticDigest()
+	wrappedPlan, err := wrapped.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrappedTrust, err := wrapped.TrustSemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if basePlan == wrappedPlan || baseTrust == wrappedTrust {
+		t.Fatalf("wrapper did not change both digests: plan=%t trust=%t", basePlan != wrappedPlan, baseTrust != wrappedTrust)
+	}
+	changed := wrapped
+	changed.Agents = slices.Clone(wrapped.Agents)
+	changed.Agents[0].Wrapper = cloneWrapper(wrapped.Agents[0].Wrapper)
+	changed.Agents[0].Argv = slices.Clone(wrapped.Agents[0].Argv)
+	changed.Agents[0].Wrapper.Args[1] = "reviewer"
+	changed.Agents[0].Argv[2] = "reviewer"
+	changedTrust, err := changed.TrustSemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changedTrust == wrappedTrust {
+		t.Fatal("wrapper args did not change trust digest")
+	}
+}
+
+func TestPrepareWrapperExecutableIdentityBindsV2SubjectOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "seat-wrapper")
+	writeExec(t, path, "#!/bin/sh\necho one\n")
+	fixture := newInternalPrepareFixture(t)
+	fixture.request.Participants[0].Wrapper = &Wrapper{Executable: path, Args: []string{"--profile", "lead"}}
+
+	first := prepareFixture(t, fixture, SubjectSchemaV2)
+	if len(first.Participants) != 1 || first.Participants[0].Wrapper == nil {
+		t.Fatalf("v2 subject omitted wrapper identity: %#v", first.Participants)
+	}
+	probed, err := ProbeExecutableIdentity(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := MarshalExecutableIdentity(probed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := first.Participants[0].Wrapper
+	if got.Requested != path || got.Consulted != path || !bytes.Equal(got.Identity, want) {
+		t.Fatalf("wrapper identity = %#v, want path %q identity %s", got, path, want)
+	}
+
+	replacement := path + ".next"
+	writeExec(t, replacement, "#!/bin/sh\necho two\n")
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatal(err)
+	}
+	second := prepareFixture(t, fixture, SubjectSchemaV2)
+	if first.SubjectDigest == second.SubjectDigest {
+		t.Fatal("same-path wrapper replacement kept v2 subject digest")
+	}
+	if first.PlanDigest != second.PlanDigest || first.TrustDigest != second.TrustDigest {
+		t.Fatalf("wrapper replacement churned plan/trust first=%s/%s second=%s/%s",
+			first.PlanDigest, first.TrustDigest, second.PlanDigest, second.TrustDigest)
+	}
+
+	v1First := prepareFixture(t, fixture, SubjectSchemaV1)
+	writeExec(t, replacement, "#!/bin/sh\necho tri\n")
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatal(err)
+	}
+	v1Second := prepareFixture(t, fixture, SubjectSchemaV1)
+	if v1First.SubjectDigest != v1Second.SubjectDigest || v1First.PlanDigest != v1Second.PlanDigest || v1First.TrustDigest != v1Second.TrustDigest {
+		t.Fatalf("v1 wrapper replacement changed digests first=%s/%s/%s second=%s/%s/%s",
+			v1First.SubjectDigest, v1First.PlanDigest, v1First.TrustDigest,
+			v1Second.SubjectDigest, v1Second.PlanDigest, v1Second.TrustDigest)
+	}
+	if v1First.Participants[0].Wrapper != nil {
+		t.Fatalf("v1 subject included wrapper identity: %#v", v1First.Participants[0].Wrapper)
+	}
+}
+
+func testWrapper(t *testing.T) *Wrapper {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "seat-wrapper")
+	if err := os.WriteFile(path, []byte("wrapper"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return &Wrapper{Executable: path, Args: []string{"--profile", "lead"}}
+}

--- a/internal/launch/wrapper_test.go
+++ b/internal/launch/wrapper_test.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -129,11 +130,11 @@ func TestWrapperChangesPlanAndTrustDigests(t *testing.T) {
 
 func TestPrepareWrapperExecutableIdentityBindsV2SubjectOnly(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "seat-wrapper")
-	writeExec(t, path, "#!/bin/sh\necho one\n")
+	writeWrapperFixture(t, path, "#!/bin/sh\necho one\n")
 	fixture := newInternalPrepareFixture(t)
 	fixture.request.Participants[0].Wrapper = &Wrapper{Executable: path, Args: []string{"--profile", "lead"}}
 
-	first := prepareFixture(t, fixture, SubjectSchemaV2)
+	first := prepareWrapperFixture(t, fixture, SubjectSchemaV2)
 	if len(first.Participants) != 1 || first.Participants[0].Wrapper == nil {
 		t.Fatalf("v2 subject omitted wrapper identity: %#v", first.Participants)
 	}
@@ -151,11 +152,11 @@ func TestPrepareWrapperExecutableIdentityBindsV2SubjectOnly(t *testing.T) {
 	}
 
 	replacement := path + ".next"
-	writeExec(t, replacement, "#!/bin/sh\necho two\n")
+	writeWrapperFixture(t, replacement, "#!/bin/sh\necho two\n")
 	if err := os.Rename(replacement, path); err != nil {
 		t.Fatal(err)
 	}
-	second := prepareFixture(t, fixture, SubjectSchemaV2)
+	second := prepareWrapperFixture(t, fixture, SubjectSchemaV2)
 	if first.SubjectDigest == second.SubjectDigest {
 		t.Fatal("same-path wrapper replacement kept v2 subject digest")
 	}
@@ -164,12 +165,12 @@ func TestPrepareWrapperExecutableIdentityBindsV2SubjectOnly(t *testing.T) {
 			first.PlanDigest, first.TrustDigest, second.PlanDigest, second.TrustDigest)
 	}
 
-	v1First := prepareFixture(t, fixture, SubjectSchemaV1)
-	writeExec(t, replacement, "#!/bin/sh\necho tri\n")
+	v1First := prepareWrapperFixture(t, fixture, SubjectSchemaV1)
+	writeWrapperFixture(t, replacement, "#!/bin/sh\necho tri\n")
 	if err := os.Rename(replacement, path); err != nil {
 		t.Fatal(err)
 	}
-	v1Second := prepareFixture(t, fixture, SubjectSchemaV1)
+	v1Second := prepareWrapperFixture(t, fixture, SubjectSchemaV1)
 	if v1First.SubjectDigest != v1Second.SubjectDigest || v1First.PlanDigest != v1Second.PlanDigest || v1First.TrustDigest != v1Second.TrustDigest {
 		t.Fatalf("v1 wrapper replacement changed digests first=%s/%s/%s second=%s/%s/%s",
 			v1First.SubjectDigest, v1First.PlanDigest, v1First.TrustDigest,
@@ -187,4 +188,22 @@ func testWrapper(t *testing.T) *Wrapper {
 		t.Fatal(err)
 	}
 	return &Wrapper{Executable: path, Args: []string{"--profile", "lead"}}
+}
+
+func writeWrapperFixture(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func prepareWrapperFixture(t *testing.T, fixture internalPrepareFixture, schema int) PrepareResult {
+	t.Helper()
+	request := fixture.request
+	request.SubjectSchema = schema
+	result, err := Prepare(context.Background(), request, fixture.dependencies(&prepareTestBackend{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
 }

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -219,11 +219,16 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 		"task_generation": "3", "run_id": "run-42", "evidence_chain": "chain-9",
 	}
 	wantCallerContext := cloneStringMap(fixture.request.CallerContext)
+	wrapperPath := filepath.Join(t.TempDir(), "seat-wrapper")
+	if err := os.WriteFile(wrapperPath, []byte("wrapper"), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	injector := filepath.Join(t.TempDir(), "injector")
 	if err := os.WriteFile(injector, []byte("injector"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	runnable := fixture.request.Intent.Participants[0]
+	runnable.Wrapper = &WrapperV1{Executable: wrapperPath, Args: []string{"--profile", "lead"}}
 	runnable.InitialInput = &InitialInputV1{Kind: InitialInputArgument, Text: "generated bootstrap"}
 	runnable.Execution = &ExecutionOptionsV1{
 		RequireWake: true, NoGitignore: true,
@@ -298,6 +303,14 @@ func TestApplyProvisionsMultiSeatRosterAtomically(t *testing.T) {
 		}
 		if len(ticket.TargetArgv) == 0 || ticket.TargetArgv[len(ticket.TargetArgv)-1] != "generated bootstrap" {
 			t.Fatalf("%s ticket did not preserve the final initial argument: %#v", handle, ticket.TargetArgv)
+		}
+		canonicalProvider, err := filepath.EvalSymlinks(runnable.Executable)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ticket.ProviderExecutable != canonicalProvider || ticket.Wrapper == nil || ticket.Wrapper.Executable != wrapperPath ||
+			!slices.Equal(ticket.TargetArgv[:3], []string{wrapperPath, "--profile", "lead"}) || ticket.TargetArgv[3] != runnable.Executable {
+			t.Fatalf("%s ticket wrapper/provider boundary = %#v", handle, ticket)
 		}
 	}
 	entries, err := os.ReadDir(filepath.Dir(fixture.request.Target.SessionRoot))
@@ -470,6 +483,37 @@ func TestPrepareIsZeroWriteAndApplyRejectsStaleSubject(t *testing.T) {
 		}
 		if _, err := os.Stat(filepath.Join(fixture.request.Target.SessionRoot, "meta", "launch", "lease.json")); !os.IsNotExist(err) {
 			t.Fatalf("stale Apply retained lease record: %v", err)
+		}
+	})
+
+	t.Run("changed wrapper", func(t *testing.T) {
+		fixture := newPublicPrepareFixture(t, true)
+		fixture.request.Intent.Participants[0].Wrapper = &WrapperV1{
+			Executable: writePublicTestWrapper(t), Args: []string{"--profile", "lead"},
+		}
+		prepared, err := Prepare(context.Background(), fixture.request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		changed := fixture.request
+		changed.Intent.Participants = slices.Clone(changed.Intent.Participants)
+		participant := changed.Intent.Participants[0]
+		participant.Wrapper = &WrapperV1{Executable: participant.Wrapper.Executable, Args: []string{"--profile", "reviewer"}}
+		changed.Intent.Participants[0] = participant
+		before := applyTreeFingerprint(t, fixture.root, nil)
+		result, err := Apply(context.Background(), ApplyRequestV1{
+			RequestVersion: RequestVersionV1, Prepare: changed,
+			SubjectSchema: prepared.SubjectSchema, SubjectDigest: prepared.SubjectDigest, Decisions: decisionsForPreparedActions(prepared),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Outcome != "action_required" || result.ReasonCode != "subject_changed" {
+			t.Fatalf("changed wrapper Apply = %#v", result)
+		}
+		allowed := map[string]bool{"mail/collab/meta/launch": true, "mail/collab/meta/launch/lease.lock": true}
+		if after := applyTreeFingerprint(t, fixture.root, allowed); before != after {
+			t.Fatalf("changed wrapper Apply mutated state: before=%s after=%s", before, after)
 		}
 	})
 

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -22,6 +22,7 @@ var compatibilityFeaturesV1 = []string{
 	FeatureOnLive,
 	FeatureCallerContext,
 	FeatureExecutableIdentity,
+	FeatureWrapper,
 }
 
 func Compatibility() CompatibilityV1 {

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -36,12 +36,8 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if !slices.Contains(Compatibility().Features, FeatureExecutableIdentity) {
 		t.Fatal("Compatibility omitted advertised executable_identity")
 	}
-	for _, unfinished := range []string{
-		FeatureWrapper,
-	} {
-		if slices.Contains(Compatibility().Features, unfinished) {
-			t.Fatalf("Compatibility advertised unfinished feature %q", unfinished)
-		}
+	if !slices.Contains(Compatibility().Features, FeatureWrapper) {
+		t.Fatal("Compatibility did not advertise the completed wrapper feature")
 	}
 
 	negotiated, err := Negotiate(RequirementV1{

--- a/launchapi/intent.go
+++ b/launchapi/intent.go
@@ -75,7 +75,7 @@ func (participant ParticipantV1) validate() error {
 	}
 	if !participant.Runnable {
 		if participant.Executable != "" || participant.Args != nil || participant.Cwd != nil ||
-			participant.InitialInput != nil || participant.EnvOverlay != nil || participant.ResumePolicy != "" ||
+			participant.Wrapper != nil || participant.InitialInput != nil || participant.EnvOverlay != nil || participant.ResumePolicy != "" ||
 			participant.Execution != nil || participant.OnLive != "" {
 			return fmt.Errorf("non-runnable participant %q must be handle-only", participant.Handle)
 		}
@@ -83,6 +83,11 @@ func (participant ParticipantV1) validate() error {
 	}
 	if participant.Executable == "" {
 		return fmt.Errorf("runnable participant %q requires executable", participant.Handle)
+	}
+	if participant.Wrapper != nil {
+		if err := participant.Wrapper.validate(); err != nil {
+			return fmt.Errorf("runnable participant %q wrapper: %w", participant.Handle, err)
+		}
 	}
 	if participant.Cwd == nil {
 		return fmt.Errorf("runnable participant %q requires cwd", participant.Handle)
@@ -117,6 +122,24 @@ func (participant ParticipantV1) validate() error {
 		participant.EnvOverlay,
 	); err != nil {
 		return fmt.Errorf("runnable participant %q: %w", participant.Handle, err)
+	}
+	return nil
+}
+
+func (wrapper WrapperV1) validate() error {
+	if !utf8.ValidString(wrapper.Executable) || strings.ContainsRune(wrapper.Executable, 0) {
+		return fmt.Errorf("executable must be valid UTF-8 without NUL")
+	}
+	if !filepath.IsAbs(wrapper.Executable) || filepath.Clean(wrapper.Executable) != wrapper.Executable {
+		return fmt.Errorf("executable must be a clean absolute path")
+	}
+	for i, arg := range wrapper.Args {
+		if arg == "" {
+			return fmt.Errorf("args[%d] must not be empty", i)
+		}
+		if !utf8.ValidString(arg) || strings.ContainsRune(arg, 0) {
+			return fmt.Errorf("args[%d] must be valid UTF-8 without NUL", i)
+		}
 	}
 	return nil
 }

--- a/launchapi/intent_test.go
+++ b/launchapi/intent_test.go
@@ -70,6 +70,7 @@ func TestLaunchIntentNonRunnableIsHandleOnly(t *testing.T) {
 		{name: "omitted participants", raw: `{"intent_version":1}`, want: "requires participants"},
 		{name: "extra executable", raw: `{"intent_version":1,"participants":[{"handle":"operator","runnable":false,"executable":"codex"}]}`, want: "exactly handle and runnable"},
 		{name: "extra empty args", raw: `{"intent_version":1,"participants":[{"handle":"operator","runnable":false,"args":[]}]}`, want: "exactly handle and runnable"},
+		{name: "extra wrapper", raw: `{"intent_version":1,"participants":[{"handle":"operator","runnable":false,"wrapper":{"executable":"/bin/wrapper"}}]}`, want: "exactly handle and runnable"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -225,6 +226,10 @@ func TestLaunchIntentV1MarshalRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	intent.Participants[1].Wrapper = &WrapperV1{
+		Executable: filepath.Join(t.TempDir(), "seat-wrapper"),
+		Args:       []string{"--profile", "lead"},
+	}
 	raw, err := MarshalLaunchIntentV1(intent)
 	if err != nil {
 		t.Fatal(err)
@@ -235,5 +240,38 @@ func TestLaunchIntentV1MarshalRoundTrip(t *testing.T) {
 	}
 	if len(decoded.Participants) != len(intent.Participants) {
 		t.Fatalf("round-trip participant count = %d, want %d", len(decoded.Participants), len(intent.Participants))
+	}
+	wrapper := decoded.Participants[1].Wrapper
+	if wrapper == nil || wrapper.Executable != intent.Participants[1].Wrapper.Executable ||
+		len(wrapper.Args) != 2 || wrapper.Args[0] != "--profile" || wrapper.Args[1] != "lead" {
+		t.Fatalf("round-trip wrapper = %#v", wrapper)
+	}
+}
+
+func TestWrapperV1SyntaxValidation(t *testing.T) {
+	valid := WrapperV1{Executable: filepath.Join(t.TempDir(), "seat-wrapper"), Args: []string{"--profile", "lead"}}
+	if err := valid.validate(); err != nil {
+		t.Fatalf("valid wrapper: %v", err)
+	}
+	for _, test := range []struct {
+		name    string
+		wrapper WrapperV1
+		want    string
+	}{
+		{name: "empty executable", wrapper: WrapperV1{}, want: "absolute path"},
+		{name: "PATH lookup", wrapper: WrapperV1{Executable: "seat-wrapper"}, want: "absolute path"},
+		{name: "shell fragment", wrapper: WrapperV1{Executable: "sh -c"}, want: "absolute path"},
+		{name: "unclean path", wrapper: WrapperV1{Executable: filepath.Join(t.TempDir(), "bin") + "/../seat-wrapper"}, want: "clean absolute"},
+		{name: "executable NUL", wrapper: WrapperV1{Executable: "/bin/wrap\x00per"}, want: "without NUL"},
+		{name: "invalid UTF-8 executable", wrapper: WrapperV1{Executable: "/bin/" + string([]byte{0xff})}, want: "valid UTF-8"},
+		{name: "empty arg", wrapper: WrapperV1{Executable: "/bin/wrapper", Args: []string{""}}, want: "must not be empty"},
+		{name: "arg NUL", wrapper: WrapperV1{Executable: "/bin/wrapper", Args: []string{"bad\x00arg"}}, want: "without NUL"},
+		{name: "invalid UTF-8 arg", wrapper: WrapperV1{Executable: "/bin/wrapper", Args: []string{string([]byte{0xff})}}, want: "valid UTF-8"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.wrapper.validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("WrapperV1.validate error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }

--- a/launchapi/prepare.go
+++ b/launchapi/prepare.go
@@ -113,6 +113,9 @@ func toInternalPrepareParticipant(participant ParticipantV1, provider string, co
 	if participant.InitialInput != nil {
 		result.InitialInput = &internallaunch.PrepareInitialInput{Kind: internallaunch.InitialInputKind(participant.InitialInput.Kind), Text: participant.InitialInput.Text}
 	}
+	if participant.Wrapper != nil {
+		result.Wrapper = &internallaunch.Wrapper{Executable: participant.Wrapper.Executable, Args: slices.Clone(participant.Wrapper.Args)}
+	}
 	if participant.Cwd != nil {
 		result.Cwd = participant.Cwd.Path
 	}

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -160,6 +160,61 @@ func TestCallerContextCanonicalOrderChangesSubjectButNotPlanOrTrust(t *testing.T
 	}
 }
 
+func TestPrepareWrapperComposesVerbatimArgvAndChangesAllDigests(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	baseline, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper := writePublicTestWrapper(t)
+	runnable := &fixture.request.Intent.Participants[0]
+	runnable.Wrapper = &WrapperV1{Executable: wrapper, Args: []string{"--profile", "lead"}}
+	runnable.InitialInput = &InitialInputV1{Kind: InitialInputArgument, Text: "bootstrap"}
+	wrapped, err := Prepare(context.Background(), fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv := wrapped.Preview.Participants[0].Command.Argv
+	if len(argv) < 5 || !slices.Equal(argv[:4], []string{wrapper, "--profile", "lead", runnable.Executable}) || argv[len(argv)-1] != "bootstrap" {
+		t.Fatalf("wrapped preview argv = %#v", argv)
+	}
+	if wrapped.PlanDigest == baseline.PlanDigest || wrapped.TrustDigest == baseline.TrustDigest || wrapped.SubjectDigest == baseline.SubjectDigest {
+		t.Fatalf("wrapper digest changes = plan:%t trust:%t subject:%t", wrapped.PlanDigest != baseline.PlanDigest, wrapped.TrustDigest != baseline.TrustDigest, wrapped.SubjectDigest != baseline.SubjectDigest)
+	}
+}
+
+func TestPrepareWrapperFileValidationAndStdinRefusalAreZeroWrite(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		wrapper    func(*testing.T) string
+		input      *InitialInputV1
+		wantErr    string
+		wantReason string
+	}{
+		{name: "missing", wrapper: func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing") }, wantErr: "stat executable"},
+		{name: "directory", wrapper: func(t *testing.T) string { return t.TempDir() }, wantErr: "regular file"},
+		{name: "stdin", wrapper: writePublicTestWrapper, input: &InitialInputV1{Kind: InitialInputStdin, Text: "bootstrap"}, wantReason: "initial_input_unsupported"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newPublicPrepareFixture(t, true)
+			fixture.request.Intent.Participants[0].Wrapper = &WrapperV1{Executable: test.wrapper(t)}
+			fixture.request.Intent.Participants[0].InitialInput = test.input
+			before := snapshotTestTree(t, fixture.root)
+			result, err := Prepare(context.Background(), fixture.request)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("Prepare error = %v, want %q", err, test.wantErr)
+				}
+			} else if err != nil || result.Outcome != PrepareOutcomeUnsupported || result.Reason != test.wantReason {
+				t.Fatalf("Prepare = %#v, %v; want reason %q", result, err, test.wantReason)
+			}
+			if after := snapshotTestTree(t, fixture.root); after != before {
+				t.Fatalf("Prepare changed tree: before=%s after=%s", before, after)
+			}
+		})
+	}
+}
+
 func TestPrepareUnsupportedInitialCarriersAndOversizeAreTypedAndZeroWrite(t *testing.T) {
 	for _, test := range []struct {
 		name  string
@@ -670,6 +725,15 @@ func main() {
 		t.Fatalf("build provider helper: %v\n%s", err, output)
 	}
 	return executable
+}
+
+func writePublicTestWrapper(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "seat-wrapper")
+	if err := os.WriteFile(path, []byte("wrapper"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func snapshotTestTree(t *testing.T, root string) string {

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -26,7 +26,7 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 		"LaunchIntentV1", "ParticipantV1", "WorkingDirectoryV1", "ExecutionOptionsV1",
 		"WakeOptionsV1", "InjectorOptionsV1", "IntegrationsV1", "SymphonyOptionsV1",
 		"TargetV1", "PlacementV1", "PlacementPreviewV1", "PrepareRequestV1", "PrepareResultV1", "ApplyRequestV1", "ApplyResultV1",
-		"InitialInputV1", "ConfigOverrideCapabilityV1", "ProviderCapabilitiesV1",
+		"InitialInputV1", "WrapperV1", "ConfigOverrideCapabilityV1", "ProviderCapabilitiesV1",
 		"DecisionV1", "ParticipantObservationV1", "CompatibilityV1", "RequirementV1", "NegotiatedV1",
 		"InspectRequestV1", "FocusRequestV1", "CloseRequestV1",
 		"InspectResultV1", "FocusResultV1", "CloseResultV1",
@@ -50,6 +50,7 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 	assertSchemaPropertiesMatchType(t, defs, "ConfigOverrideCapabilityV1", reflect.TypeFor[ConfigOverrideCapabilityV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ProviderCapabilitiesV1", reflect.TypeFor[ProviderCapabilitiesV1]())
 	assertSchemaPropertiesMatchType(t, defs, "InitialInputV1", reflect.TypeFor[InitialInputV1]())
+	assertSchemaPropertiesMatchType(t, defs, "WrapperV1", reflect.TypeFor[WrapperV1]())
 	assertSchemaPropertiesMatchType(t, defs, "PrepareResultV1", reflect.TypeFor[PrepareResultV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ApplyRequestV1", reflect.TypeFor[ApplyRequestV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ApplyResultV1", reflect.TypeFor[ApplyResultV1]())

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -80,12 +80,18 @@ type ParticipantV1 struct {
 	Runnable     bool                `json:"runnable"`
 	Executable   string              `json:"executable,omitempty"`
 	Args         []string            `json:"args,omitempty"`
+	Wrapper      *WrapperV1          `json:"wrapper,omitempty"`
 	InitialInput *InitialInputV1     `json:"initial_input,omitempty"`
 	Cwd          *WorkingDirectoryV1 `json:"cwd,omitempty"`
 	EnvOverlay   map[string]string   `json:"env_overlay,omitempty"`
 	ResumePolicy ResumePolicy        `json:"resume_policy,omitempty"`
 	Execution    *ExecutionOptionsV1 `json:"execution,omitempty"`
 	OnLive       OnLivePolicyV1      `json:"on_live,omitempty"`
+}
+
+type WrapperV1 struct {
+	Executable string   `json:"executable"`
+	Args       []string `json:"args,omitempty"`
 }
 
 type WorkingDirectoryV1 struct {

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -45,6 +45,7 @@
         "runnable": {"const": true},
         "executable": {"type": "string", "minLength": 1},
         "args": {"type": "array", "items": {"type": "string"}},
+        "wrapper": {"$ref": "#/$defs/WrapperV1"},
         "initial_input": {"$ref": "#/$defs/InitialInputV1"},
         "cwd": {"$ref": "#/$defs/WorkingDirectoryV1"},
         "env_overlay": {
@@ -55,6 +56,15 @@
         "resume_policy": {"enum": ["resume", "fresh", "disabled"]},
         "on_live": {"enum": ["keep", "refuse"]},
         "execution": {"$ref": "#/$defs/ExecutionOptionsV1"}
+      }
+    },
+    "WrapperV1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["executable"],
+      "properties": {
+        "executable": {"type": "string", "minLength": 1, "pattern": "^[^\\x00]*$"},
+        "args": {"type": "array", "items": {"type": "string", "minLength": 1, "pattern": "^[^\\x00]*$"}}
       }
     },
     "InitialInputV1": {


### PR DESCRIPTION
## Summary

- add typed launch wrapper configuration to the public API and schema
- compose wrapper, provider, static, and dynamic arguments at the single execution boundary
- bind wrapper executable identity into schema-v2 prepared subjects while preserving schema-v1 compatibility
- carry wrapper state through prepare, apply, reconcile, journals, tickets, and trust validation
- flip the wrapper adoption oracle and cover hostile validation plus the real OS execution chain

## Verification

- `make ci`
- focused `internal/launch`, `launchapi`, and `internal/cli` wrapper and compatibility tests
- peer-approved staged diff SHA-256: `78b84170bb42eb0dc91af203f486c88d0d069a826cd75e1e98ec8d0938fe3ef2`