### PR TITLE
docs(launch): describe WB3 contract fields and amq-squad compiler delta

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -138,6 +138,8 @@ amq doctor --ops
 
 Integration messages are self-delivered and carry `context.orchestrator` plus labels such as `orchestrator:*`, `task-state:*`, `handoff`, and `blocking`, so they fit naturally into the same `amq drain` / `amq reply` workflow used for co-op.
 
+Orchestrators that compile public launch requests send `target.base_root` as the one profile child of the `.amqrc` root, `on_live: keep` only for a proven-live seat, mapped placement enums (`current-window` → `current_window`, `vertical` → `columns`, `horizontal` → `rows`), and bootstrap text through `initial_input`. The decoder accepts only those underscore enums. See [the public launch API](docs/launch-api.md).
+
 ### Fallback: Notify Hook (if wake unavailable)
 
 `amq wake` uses TIOCSTI which may be unavailable on:

--- a/README.md
+++ b/README.md
@@ -213,6 +213,17 @@ degraded-capability decision. Launch configuration uses the resume vocabulary
 `resume`, `fresh`, or `disabled`. See the [public launch API guide](docs/launch-api.md)
 and the [v1 JSON schema](schemas/launch-api-v1.schema.json).
 
+The public launch contract is `0.61.1`. A caller negotiates every feature it
+uses: `placement`, `initial_input` (argument only; `stdin` and `file` stay typed
+but return `initial_input_unsupported` until real seams exist), `base_root`,
+`on_live`, `caller_context`, `executable_identity`, and `wrapper`. New Prepare
+calls use `subject_schema` 2. `PreviewV1.capabilities` reports adapter grammar
+without executing a caller-supplied provider. `wrapper` is a typed participant
+field and is advertised. amq-squad maps
+`current-window` to `current_window`, `vertical` to `columns`, and `horizontal`
+to `rows`; the decoder accepts only those underscore enums. Details live in
+[docs/launch-api.md](docs/launch-api.md).
+
 Each command sets up the session environment, starts wake notifications, and
 launches the agent. See [COOP.md](COOP.md#running-co-op-mode) for co-op
 operations and [the wake acknowledgement contract](docs/wake-doorbell-acknowledgement.md)

--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -32,13 +32,19 @@ adapter-owned version that consumers compare. It changes when the allowed
 argument forms, configuration overrides, or carrier support changes.
 `verified_provider_version` is informational and names the provider release on
 which that grammar was verified; it does not claim the installed version.
-Runtime provider identity is bound separately before Apply executes it.
+Runtime provider identity is bound into subject schema 2 before Apply executes
+it. Prepare records each runnable provider's consulted path (PATH lookup or
+absolute) plus the on-disk identity tuple, including symlink hops. Schema 1
+omits that binding. A same-path inode, mtime, symlink-hop, or PATH retarget
+changes `subject_digest`; Apply then returns `subject_changed` with no launch
+mutation. Plan and trust digests stay stable across those replacements.
 
 The initial-input carrier is typed. Claude and Codex currently advertise
 `argument`; AMQ appends its exact text as the final provider argv element.
 `stdin` and `file` remain typed but unadvertised and return
-`initial_input_unsupported`. Content is limited to 262,144 UTF-8 bytes without
-NUL. Content changes the plan and subject digests but not the trust digest.
+`initial_input_unsupported` until real stdin/file seams exist. Content is
+limited to 262,144 UTF-8 bytes without NUL. Content changes the plan and
+subject digests but not the trust digest.
 Claude admits one `--allowedTools <comma-separated-list>` pair. Codex admits
 ordered `-c model_reasoning_effort=<value>` pairs with values `minimal`, `low`,
 `medium`, `high`, or `xhigh`; duplicate keys and unknown keys or values reject.
@@ -50,7 +56,8 @@ args + resolved provider executable + provider args`, without a shell. The
 declared wrapper path and arguments enter the plan, trust, subject, ticket, and
 command preview. An argument initial input stays the final inner-provider
 argument. Unsupported `stdin` and `file` carriers remain typed refusals when a
-wrapper is present.
+wrapper is present. The `wrapper` feature is advertised, and a strict decode
+accepts the field.
 
 ## Intent
 
@@ -174,6 +181,17 @@ keys reject. Canonical key ordering enters subject schema 2 and immutable
 evidence, but never the plan or trust digest. Apply echoes the request map.
 Inspect, Focus, and Close load it from the proven-owned binding; lifecycle
 requests cannot replace it.
+
+amq-squad compiles only its public request: it sends `target.base_root` as the
+one profile child of the `.amqrc` root; sends `on_live: keep` only for a seat
+it already knows to be proven live; maps placement spellings `current-window` to
+`current_window`, `vertical` to `columns`, and `horizontal` to `rows`; and sends
+the generated bootstrap prompt through `initial_input`. Those are compiler
+mappings, not contract aliases. The public decoder accepts only the underscore
+target enum and the `columns|rows|tiled` layout enum. One refused seat
+cohort-blocks creation of every missing seat. When a wrapper is present, stdin
+initial input is delivered to the wrapper, which owns forwarding it to the
+provider.
 
 ```go
 request := launchapi.PrepareRequestV1{

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -308,14 +308,14 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 	})
 }
 
-func TestAdoptionSmokeLiveHomebrewBinary(t *testing.T) {
+func TestAdoptionSmokeLiveLocalBinary(t *testing.T) {
 	if os.Getenv("AMQ_LAUNCH_LIVE") != "1" {
-		t.Skip("AMQ_LAUNCH_LIVE=1 required; uses a released amq on PATH")
+		t.Skip("AMQ_LAUNCH_LIVE=1 required; uses a locally built amq with tmux on PATH")
 	}
-	amqBinary, err := exec.LookPath("amq")
-	if err != nil {
-		t.Fatalf("AMQ_LAUNCH_LIVE=1 but amq is not on PATH: %v", err)
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Fatalf("AMQ_LAUNCH_LIVE=1 requires tmux on PATH: %v", err)
 	}
+	amqBinary := buildAdoptionSmokeAMQ(t)
 	fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "collab")
 	intent := fx.legalSquadIntent()
 	intent.Participants[1].Args = append(intent.Participants[1].Args, omriSquadBootstrapPrompt)


### PR DESCRIPTION
## Summary
- Rebase the 23a docs onto `main` (`a6b8b8f`, wrapper #568) and document the seven advertised WB3 features in present tense: `placement`, `initial_input`, `base_root`, `on_live`, `caller_context`, `executable_identity`, and `wrapper`.
- Record that `wrapper` is advertised and a strict decode accepts the field; keep the amq-squad compiler mappings (`current-window` → `current_window`, `vertical` → `columns`, `horizontal` → `rows`).
- Point the live adoption oracle at a locally built `amq` with `tmux` on PATH.

## Test plan
- [x] Pre-push hook green (`make ci` path: vet, lint, `go test ./...`, smoke)
- [ ] Confirm advertised feature list in `docs/launch-api.md` / `README.md` matches `launchapi.Compatibility().Features` on this tree (includes `wrapper`)
- [ ] Optional: `AMQ_LAUNCH_LIVE=1 go test ./internal/cli -run TestAdoptionSmokeLiveLocalBinary` with `tmux` on PATH


Made with [Cursor](https://cursor.com)