### PR TITLE
test(launch): let the live adoption oracle target a released binary

### DIFF
--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -44,7 +44,7 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and executes the real amq binary")
 	}
-	amqBinary := buildAdoptionSmokeAMQ(t)
+	amqBinary := resolveRealAMQBinary(t)
 
 	t.Run("finding5_positional_bootstrap_prompt", func(t *testing.T) {
 		fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "collab")
@@ -310,12 +310,12 @@ func TestAdoptionSmokeOmriSquadV2294(t *testing.T) {
 
 func TestAdoptionSmokeLiveLocalBinary(t *testing.T) {
 	if os.Getenv("AMQ_LAUNCH_LIVE") != "1" {
-		t.Skip("AMQ_LAUNCH_LIVE=1 required; uses a locally built amq with tmux on PATH")
+		t.Skip("AMQ_LAUNCH_LIVE=1 required; uses AMQ_LAUNCH_LIVE_BINARY or a locally built amq, with tmux on PATH")
 	}
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Fatalf("AMQ_LAUNCH_LIVE=1 requires tmux on PATH: %v", err)
 	}
-	amqBinary := buildAdoptionSmokeAMQ(t)
+	amqBinary := resolveRealAMQBinary(t)
 	fx := newAdoptionSmokeFixture(t, amqBinary, ".agent-mail", "collab")
 	intent := fx.legalSquadIntent()
 	intent.Participants[1].Args = append(intent.Participants[1].Args, omriSquadBootstrapPrompt)
@@ -333,6 +333,58 @@ type adoptionSmokeFixture struct {
 	claudeLog   string
 	fullstack   string
 	env         []string
+}
+
+func resolveRealAMQBinary(t *testing.T) string {
+	t.Helper()
+	if path := strings.TrimSpace(os.Getenv("AMQ_LAUNCH_LIVE_BINARY")); path != "" {
+		if !filepath.IsAbs(path) {
+			t.Fatalf("AMQ_LAUNCH_LIVE_BINARY must be an absolute path, got %q", path)
+		}
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			t.Fatalf("AMQ_LAUNCH_LIVE_BINARY %q: %v", path, err)
+		}
+		info, err := os.Stat(resolved)
+		if err != nil || info.IsDir() {
+			t.Fatalf("AMQ_LAUNCH_LIVE_BINARY %q is not a file", path)
+		}
+		return resolved
+	}
+	return buildAdoptionSmokeAMQ(t)
+}
+
+func TestResolveRealAMQBinaryHonorsLiveBinaryEnv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "released-amq")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMQ_LAUNCH_LIVE_BINARY", path)
+	got := resolveRealAMQBinary(t)
+	want, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("resolveRealAMQBinary = %q, want released path %q", got, want)
+	}
+}
+
+func TestResolveRealAMQBinaryRejectsRelativePath(t *testing.T) {
+	if os.Getenv("AMQ_TEST_LIVE_BINARY_RELATIVE") == "1" {
+		t.Setenv("AMQ_LAUNCH_LIVE_BINARY", "amq")
+		resolveRealAMQBinary(t)
+		t.Fatal("relative AMQ_LAUNCH_LIVE_BINARY was accepted")
+	}
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestResolveRealAMQBinaryRejectsRelativePath$")
+	cmd.Env = append(os.Environ(), "AMQ_TEST_LIVE_BINARY_RELATIVE=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("relative path did not fail:\n%s", out)
+	}
+	if !strings.Contains(string(out), "absolute path") {
+		t.Fatalf("relative path error = %v\n%s", err, out)
+	}
 }
 
 func buildAdoptionSmokeAMQ(t *testing.T) string {

--- a/internal/cli/launch_api_e2e_test.go
+++ b/internal/cli/launch_api_e2e_test.go
@@ -27,16 +27,12 @@ func TestCompatibilityFloorAndEndToEndMatrix(t *testing.T) {
 	if testing.Short() {
 		t.Skip("builds and executes the real amq binary")
 	}
-	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
-	if err != nil {
-		t.Fatal(err)
-	}
 	binDir := t.TempDir()
-	amqBinary := filepath.Join(binDir, "amq")
-	build := exec.Command("go", "build", "-o", amqBinary, "./cmd/amq")
-	build.Dir = repoRoot
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build real amq: %v\n%s", err, output)
+	amqBinary := resolveRealAMQBinary(t)
+	if filepath.Dir(amqBinary) != binDir {
+		if err := os.Symlink(amqBinary, filepath.Join(binDir, "amq")); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	t.Run("compatibility floor", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `AMQ_LAUNCH_LIVE_BINARY=/abs/path` selects a released `amq` for the live adoption oracle and the compatibility matrix; unset still tree-builds.
- Relative paths fail closed. Default CI behavior is unchanged.

## Test plan
- [x] `go test ./internal/cli -run 'TestResolveRealAMQBinaryHonorsLiveBinaryEnv|TestResolveRealAMQBinaryRejectsRelativePath'`
- [x] Pre-push hook green
- [x] Live re-verify: `AMQ_LAUNCH_LIVE=1 AMQ_LAUNCH_LIVE_BINARY=/opt/homebrew/bin/amq go test ./internal/cli -run 'TestAdoptionSmokeOmriSquadV2294|TestAdoptionSmokeLiveLocalBinary|TestCompatibilityFloorAndEndToEndMatrix'` against Homebrew 0.64.0 (all PASS)


Made with [Cursor](https://cursor.com)