### PR TITLE
test(wake): hold retry until replacement publication

### DIFF
--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -1348,12 +1348,22 @@ func TestRunWakeWithLoopAcceptExistingRejectsCanonicalAgentReplacement(t *testin
 			}
 
 			retryEntered := make(chan struct{}, 1)
+			retryRelease := make(chan struct{})
+			releaseRetry := func() {
+				select {
+				case <-retryRelease:
+				default:
+					close(retryRelease)
+				}
+			}
+			t.Cleanup(releaseRetry)
 			originalRetry := waitForWakePreparedRetry
 			waitForWakePreparedRetry = func(time.Time) bool {
 				select {
 				case retryEntered <- struct{}{}:
 				default:
 				}
+				<-retryRelease
 				return true
 			}
 			t.Cleanup(func() { waitForWakePreparedRetry = originalRetry })
@@ -1399,6 +1409,10 @@ func TestRunWakeWithLoopAcceptExistingRejectsCanonicalAgentReplacement(t *testin
 			); err != nil {
 				t.Fatal(err)
 			}
+			// The accept-existing retry must observe the complete replacement,
+			// not a transient state while the test moves the retained directory
+			// and publishes its prepared marker.
+			releaseRetry()
 			select {
 			case err := <-done:
 				if err == nil ||


### PR DESCRIPTION
## Summary

- hold the accept-existing retry seam until the replacement fixture is fully published
- prevent the negative test from observing a transient legacy-state snapshot
- keep product behavior and timeout values unchanged

## Root cause

The test signaled entry into the retry hook and returned immediately. Under scheduler load, the retry could inspect the retained directory while the test was moving it and publishing the replacement state. The product correctly failed closed, but the test asserted the later canonical retained-authority error.

## Verification

- unchanged main: 7 failures in 200 ownerless iterations with `GOMAXPROCS=1`
- patched ownerless: 500/500 with `GOMAXPROCS=1`
- patched ownerless and owner-bound: 200/200
- patched ownerless with race detector: 100/100
- `GOOS=linux GOARCH=amd64 go vet ./internal/cli`
- `make ci`
- full pre-push checks
- peer-approved staged SHA-256: `2881282e84e9aa300a740d6ae8afe3531e30b0f81f1fd3af825dcae96c1b7e38`