### PR TITLE
fix(wake): reclaim a darwin restart stage whose parent directory is gone

### DIFF
--- a/internal/cli/wake_restart_bound_darwin.go
+++ b/internal/cli/wake_restart_bound_darwin.go
@@ -3,10 +3,12 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -256,8 +258,8 @@ func cleanupDarwinWakeRestartStage(bound wakeImageEvidenceV1, allowNamespaceCTim
 	stageDir := filepath.Dir(stagePath)
 	lstat, err := os.Lstat(stagePath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+		if errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ENOTDIR) {
+			return removeEmptyDarwinWakeRestartStageDir(stagePath)
 		}
 		return fmt.Errorf("stat Darwin wake restart stage: %w", err)
 	}

--- a/internal/cli/wake_restart_stage_darwin.go
+++ b/internal/cli/wake_restart_stage_darwin.go
@@ -149,6 +149,9 @@ func removeEmptyDarwinWakeRestartStageDir(stagePath string) error {
 	name := filepath.Base(dirPath)
 	parentFD, err := unix.Open(parentPath, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
+		if errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ENOTDIR) {
+			return nil
+		}
 		return fmt.Errorf("open Darwin wake restart stage parent: %w", err)
 	}
 	defer func() { _ = unix.Close(parentFD) }()
@@ -163,6 +166,9 @@ func removeEmptyDarwinWakeRestartStageDir(stagePath string) error {
 	}
 	dirFD, err := unix.Openat(parentFD, name, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
+		if errors.Is(err, syscall.ENOENT) {
+			return nil
+		}
 		return fmt.Errorf("open Darwin wake restart stage directory: %w", err)
 	}
 	dir := os.NewFile(uintptr(dirFD), dirPath)
@@ -176,8 +182,9 @@ func removeEmptyDarwinWakeRestartStageDir(stagePath string) error {
 		return fmt.Errorf("refuse reclaim of non-empty Darwin wake restart stage directory")
 	}
 	var after unix.Stat_t
-	if err := unix.Fstatat(parentFD, name, &after, unix.AT_SYMLINK_NOFOLLOW); err != nil ||
-		before.Dev != after.Dev || before.Ino != after.Ino || before.Ctim != after.Ctim {
+	if err := unix.Fstatat(parentFD, name, &after, unix.AT_SYMLINK_NOFOLLOW); errors.Is(err, syscall.ENOENT) {
+		return nil
+	} else if err != nil || before.Dev != after.Dev || before.Ino != after.Ino || before.Ctim != after.Ctim {
 		return fmt.Errorf("darwin wake restart stage directory changed before reclaim")
 	}
 	if err := unix.Unlinkat(parentFD, name, unix.AT_REMOVEDIR); err != nil && !errors.Is(err, syscall.ENOENT) {

--- a/internal/cli/wake_restart_stage_darwin_test.go
+++ b/internal/cli/wake_restart_stage_darwin_test.go
@@ -193,6 +193,106 @@ func TestDarwinCrashStageReclaimPreservesReplacement(t *testing.T) {
 	}
 }
 
+func TestPrepareCoopWakeLockReclaimsStaleDarwinStageAfterParentDisappears(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		replaceParent bool
+	}{
+		{name: "missing parent"},
+		{name: "non-directory parent", replaceParent: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			record := newDarwinWakeRestartStageRecordForTest(t)
+			bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			evidence := bound.evidence
+			if err := bound.file.Close(); err != nil {
+				t.Fatal(err)
+			}
+			bound.file = nil
+
+			root := secureTempDirForTest(t)
+			const agent = "codex"
+			lockPath := writeWakeLockForTest(t, root, agent, wakeLock{
+				PID:                  66121,
+				Executable:           "/opt/homebrew/bin/amq",
+				Generation:           "removed-cellar-stage",
+				RunningImageEvidence: &evidence,
+			})
+			stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+				return wakeProcessInfo{PID: pid, Running: false}
+			})
+
+			stageParent := filepath.Dir(filepath.Dir(record.StagePath))
+			if err := os.RemoveAll(stageParent); err != nil {
+				t.Fatal(err)
+			}
+			if test.replaceParent {
+				if err := os.WriteFile(stageParent, []byte("former Cellar directory"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := prepareCoopWakeLock(root, agent, true, "unused"); err != nil {
+				t.Fatalf("coop startup preflight: %v", err)
+			}
+			if _, err := os.Lstat(lockPath); !os.IsNotExist(err) {
+				t.Fatalf("stale wake lock survived coop startup preflight: %v", err)
+			}
+
+			agentDir, err := openWakeAgentDir(root, agent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = agentDir.Close() }()
+			cleanup, err := acquireWakeLockWithOptionsInDir(
+				agentDir,
+				root,
+				agent,
+				wakeLockAcquireOptions{wakeMode: wakeInjectModeNone},
+			)
+			if err != nil {
+				t.Fatalf("coop wake acquisition after stale removal: %v", err)
+			}
+			cleanup()
+		})
+	}
+}
+
+func TestDarwinPersistedStageCleanupRefusesReplacedStageDirectory(t *testing.T) {
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := bound.evidence
+	if err := bound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bound.file = nil
+
+	stageDir := filepath.Dir(record.StagePath)
+	if err := os.Remove(record.StagePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(stageDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stageDir, []byte("hostile replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err = cleanupPersistedDarwinWakeRestartStage(evidence)
+	if err == nil || !strings.Contains(err.Error(), "refuse reclaim of replaced Darwin wake restart stage directory") {
+		t.Fatalf("cleanup replaced stage directory = %v, want explicit refusal", err)
+	}
+	if info, statErr := os.Lstat(stageDir); statErr != nil || !info.Mode().IsRegular() {
+		t.Fatalf("replacement stage directory changed: info=%v err=%v", info, statErr)
+	}
+}
+
 func TestDoctorDiagnosesCrashOrphanedDarwinRestartStage(t *testing.T) {
 	record := newDarwinWakeRestartStageRecordForTest(t)
 	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)


### PR DESCRIPTION
## What changed

- Treat a missing or non-directory Darwin restart-stage parent as already reclaimed.
- Route missing-stage cleanup through the same directory identity check.
- Keep fail-closed refusal when the immediate stage directory exists but was replaced.

## Why

Homebrew upgrades remove the old Cellar directory beside the running AMQ binary. A stale wake lock retained restart-stage evidence under that removed directory, and cleanup returned `open Darwin wake restart stage parent: no such file or directory` before it could remove the stale lock. This blocked every later `amq coop exec`.

## Impact

A stale wake lock can now be removed after its old Homebrew Cellar directory disappears. Hostile or ambiguous replacements under an existing parent remain preserved and refused.

## Validation

- Unchanged-code red proof through the real coop stale-lock removal path for both `ENOENT` and `ENOTDIR`.
- Negative replacement test requires the explicit fail-closed refusal and verifies the replacement survives.
- Focused Darwin restart and coop suite passed.
- New boundary tests passed 20 consecutive runs.
- Full pre-push `make ci` passed.