### PR TITLE
feat(wake): classify a stale wake whose binary directory is gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ For Homebrew installations:
 brew upgrade amq
 ```
 
+Retire live wakes started by the previous Cellar binary first. If a leftover
+lock's image directory is gone, `wake check` reports `binary_dir_gone`; remove
+it with `amq doctor --ops --fix-wake-locks`.
+
 GitHub Actions `verify-brew-release` confirms a published tag installs from
 `avivsinai/tap/amq` and that `amq --version` matches that tag. It does not
 replace `brew upgrade` on an operator machine.

--- a/docs/wake-operations.md
+++ b/docs/wake-operations.md
@@ -26,6 +26,10 @@ conservative problem states:
 
 - `stale`: AMQ proves that the recorded process is gone, mismatched, or not the
   same `amq wake`. `--fix-wake-locks` rechecks and removes only this exact lock.
+  When the lock's image or restart stage lives under a directory that no longer
+  exists, `wake check --json` and `doctor --ops` report `reason_code=binary_dir_gone`
+  and name `amq doctor --ops --fix-wake-locks` as the next action instead of a
+  raw ENOENT.
 - `unverified`: AMQ cannot prove ownership or staleness. Startup fails closed
   and doctor preserves the lock for operator inspection.
 

--- a/internal/cli/doctor_ops.go
+++ b/internal/cli/doctor_ops.go
@@ -562,7 +562,8 @@ func checkWakeLocksWithHintsSchema(
 		lock.RestartStagePath = stage.Path
 		lock.RestartStageStatus = stage.Status
 		lock.RestartStageReason = stage.Reason
-		if stage.Status != "" && fixCommand != "" {
+		applyWakeBinaryDirGoneOpsReason(&lock, inspection, stage)
+		if fixCommand != "" && (stage.Status != "" || lock.Reason == wakeReasonBinaryDirGone) {
 			lock.Fix = fixCommand
 		}
 		if lock.WakeCheckDecision != nil && lock.WakeCheckDecision.Platform.WakeSupported {

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -34,7 +34,14 @@ var wellKnownHomebrewPrefixes = []string{
 
 func runUpgrade(args []string, currentVersion string) error {
 	fs := flag.NewFlagSet("upgrade", flag.ContinueOnError)
-	usage := usageWithFlags(fs, "amq upgrade", "Downloads and installs the latest amq release from GitHub")
+	usage := usageWithFlags(
+		fs,
+		"amq upgrade",
+		"Downloads and installs the latest amq release from GitHub",
+		"",
+		"Retire live wakes started by the previous binary before its install directory is removed.",
+		"If wake check reports binary_dir_gone, run amq doctor --ops --fix-wake-locks.",
+	)
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {

--- a/internal/cli/upgrade_stale_wake.go
+++ b/internal/cli/upgrade_stale_wake.go
@@ -13,7 +13,12 @@ type upgradeStaleWake struct {
 	Hint opsHint
 }
 
+const upgradeLiveWakePreviousBinaryNote = "Live wakes started by the previous binary stay bound to that image; retire them first, or run amq doctor --ops --fix-wake-locks after the old install directory is gone."
+
 func reportStaleWakesAfterUpgrade() error {
+	if err := writeStdoutLine(upgradeLiveWakePreviousBinaryNote); err != nil {
+		return err
+	}
 	root, err := resolveUpgradeDiagnosticRoot()
 	if err != nil || strings.TrimSpace(root) == "" {
 		return nil

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -109,6 +109,7 @@ func TestRunUpgradeAlreadyCurrentReportsStaleWakesWithInvalidAmbientAgent(t *tes
 	}
 	for _, want := range []string{
 		"amq is already up to date (v0.49.9)",
+		upgradeLiveWakePreviousBinaryNote,
 		"Stale running wakes:",
 		staleRoot,
 		`agent "codex"`,

--- a/internal/cli/wake_binary_dir_gone.go
+++ b/internal/cli/wake_binary_dir_gone.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const (
+	wakeRestartStageBinaryDirGone = "binary-dir-gone"
+	wakeBinaryDirGoneMessage      = "wake started by a binary that no longer exists"
+)
+
+func wakeInspectionBinaryDirGone(inspection wakeLockInspection) bool {
+	paths := []string{inspection.Lock.ImagePath}
+	if inspection.Lock.RunningImageEvidence != nil {
+		paths = append(paths, inspection.Lock.RunningImageEvidence.ExecutionPath)
+	}
+	return wakeAnyRecordedPathParentGone(paths)
+}
+
+func wakeRestartRecordBinaryDirGone(record wakeRestartRecord) bool {
+	paths := []string{record.StagePath}
+	if record.BoundImage != nil {
+		paths = append(paths, record.BoundImage.ExecutionPath)
+	}
+	if record.PreviousBoundImage != nil {
+		paths = append(paths, record.PreviousBoundImage.ExecutionPath)
+	}
+	return wakeAnyRecordedPathParentGone(paths)
+}
+
+func wakeAnyRecordedPathParentGone(paths []string) bool {
+	for _, path := range paths {
+		if wakeRecordedPathParentGone(path) {
+			return true
+		}
+	}
+	return false
+}
+
+// wakeRecordedPathParentGone reports that path lives under a directory that no
+// longer exists (or is no longer a directory). A missing file whose parent is
+// still present is not this state.
+func wakeRecordedPathParentGone(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" || !filepath.IsAbs(path) {
+		return false
+	}
+	path = filepath.Clean(path)
+	parent := filepath.Dir(path)
+	if parent == "." || parent == string(filepath.Separator) {
+		return false
+	}
+	info, err := os.Lstat(parent)
+	if err != nil {
+		return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func applyWakeBinaryDirGoneOpsReason(lock *opsWakeLock, inspection wakeLockInspection, stage wakeRestartStageDiagnostic) {
+	if lock == nil {
+		return
+	}
+	if wakeInspectionBinaryDirGone(inspection) ||
+		stage.Status == wakeRestartStageBinaryDirGone ||
+		(lock.WakeCheckDecision != nil &&
+			lock.WakeCheckDecision.Action.ReasonCode == wakeReasonBinaryDirGone) {
+		lock.Reason = wakeReasonBinaryDirGone
+	}
+}

--- a/internal/cli/wake_binary_dir_gone.go
+++ b/internal/cli/wake_binary_dir_gone.go
@@ -21,17 +21,6 @@ func wakeInspectionBinaryDirGone(inspection wakeLockInspection) bool {
 	return wakeAnyRecordedPathParentGone(paths)
 }
 
-func wakeRestartRecordBinaryDirGone(record wakeRestartRecord) bool {
-	paths := []string{record.StagePath}
-	if record.BoundImage != nil {
-		paths = append(paths, record.BoundImage.ExecutionPath)
-	}
-	if record.PreviousBoundImage != nil {
-		paths = append(paths, record.PreviousBoundImage.ExecutionPath)
-	}
-	return wakeAnyRecordedPathParentGone(paths)
-}
-
 func wakeAnyRecordedPathParentGone(paths []string) bool {
 	for _, path := range paths {
 		if wakeRecordedPathParentGone(path) {

--- a/internal/cli/wake_binary_dir_gone_darwin_test.go
+++ b/internal/cli/wake_binary_dir_gone_darwin_test.go
@@ -1,0 +1,85 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestDoctorFixReclaimsStaleLockAfterDarwinStageParentDisappears(t *testing.T) {
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := bound.evidence
+	if err := bound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bound.file = nil
+
+	root := secureTempDirForTest(t)
+	const agent = "codex"
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, agent); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{agent}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	lockPath := writeWakeLockForTest(t, root, agent, wakeLock{
+		PID:                  66121,
+		Executable:           "/opt/homebrew/bin/amq",
+		ImagePath:            evidence.ExecutionPath,
+		ImageVersion:         evidence.EmbeddedVersion,
+		Generation:           "removed-cellar-stage",
+		WakeMode:             wakeInjectModeRaw,
+		RunningImageEvidence: &evidence,
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid, Running: false}
+	})
+	stubWakeCheckRuntime(t, true, "0.64.1")
+
+	stageParent := filepath.Dir(filepath.Dir(record.StagePath))
+	if err := os.RemoveAll(stageParent); err != nil {
+		t.Fatal(err)
+	}
+
+	result := runOpsChecksWithSchema(root, "test", false, wakeCheckSchemaV2)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("doctor wake locks = %#v", result.WakeLocks)
+	}
+	got := result.WakeLocks[0]
+	wantFix := doctorRootCommandForOS(root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
+	if got.Status != string(wakeLockStale) ||
+		got.Reason != wakeReasonBinaryDirGone ||
+		got.RestartStageStatus != wakeRestartStageBinaryDirGone ||
+		!strings.Contains(got.RestartStageReason, wakeBinaryDirGoneMessage) ||
+		got.Fix != wantFix {
+		t.Fatalf("doctor --ops vanished Darwin stage = %#v", got)
+	}
+	assertNoRawENOENT(t, got.Reason, got.InspectionError, got.RestartStageReason, got.NextAction)
+
+	fixed := runOpsChecks(root, "test", true)
+	if len(fixed.WakeLocks) != 1 || fixed.WakeLocks[0].Status != "fixed" || !fixed.WakeLocks[0].Removed {
+		t.Fatalf("doctor --fix-wake-locks vanished Darwin stage = %#v", fixed.WakeLocks)
+	}
+	if _, err := os.Lstat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale lock survived Darwin stage-parent fix: %v", err)
+	}
+}

--- a/internal/cli/wake_binary_dir_gone_unix.go
+++ b/internal/cli/wake_binary_dir_gone_unix.go
@@ -1,0 +1,14 @@
+//go:build darwin || linux
+
+package cli
+
+func wakeRestartRecordBinaryDirGone(record wakeRestartRecord) bool {
+	paths := []string{record.StagePath}
+	if record.BoundImage != nil {
+		paths = append(paths, record.BoundImage.ExecutionPath)
+	}
+	if record.PreviousBoundImage != nil {
+		paths = append(paths, record.PreviousBoundImage.ExecutionPath)
+	}
+	return wakeAnyRecordedPathParentGone(paths)
+}

--- a/internal/cli/wake_binary_dir_gone_unix_test.go
+++ b/internal/cli/wake_binary_dir_gone_unix_test.go
@@ -1,0 +1,278 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/config"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestWakeCheckAndDoctorClassifyVanishedBinaryDir(t *testing.T) {
+	fixture := newVanishedBinaryStaleLockFixture(t)
+
+	decision := inspectWakeCheckDecision(fixture.root, "codex")
+	v1 := renderWakeCheckV1(decision)
+	v2 := renderWakeCheckV2(decision)
+	wantFix := doctorRootCommandForOS(fixture.root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
+	if v1.WakeStatus != string(wakeLockStale) ||
+		v1.RestartCapability != wakeRestartAgentSafe ||
+		v2.Action.ReasonCode != wakeReasonBinaryDirGone ||
+		v1.NextAction != v2.Action.Message ||
+		!strings.Contains(v1.NextAction, wakeBinaryDirGoneMessage) ||
+		!strings.Contains(v1.NextAction, wantFix) {
+		t.Fatalf("wake check vanished-binary = v1%#v v2%#v", v1, v2)
+	}
+	assertNoRawENOENT(t, v1.NextAction, v2.Action.Message, v2.Action.ReasonCode)
+
+	result := runOpsChecksWithSchema(fixture.root, "test", false, wakeCheckSchemaV2)
+	if len(result.WakeLocks) != 1 {
+		t.Fatalf("doctor wake locks = %#v", result.WakeLocks)
+	}
+	got := result.WakeLocks[0]
+	if got.Status != string(wakeLockStale) ||
+		got.Reason != wakeReasonBinaryDirGone ||
+		got.WakeCheckDecision == nil ||
+		got.WakeCheckDecision.Action.ReasonCode != wakeReasonBinaryDirGone ||
+		!strings.Contains(got.WakeCheckDecision.Action.Message, wantFix) {
+		t.Fatalf("doctor --ops vanished-binary = %#v decision=%#v", got, got.WakeCheckDecision)
+	}
+	assertNoRawENOENT(t, got.Reason, got.InspectionError, got.RestartStageReason, got.NextAction)
+
+	v1ops := runOpsChecks(fixture.root, "test", false)
+	if len(v1ops.WakeLocks) != 1 ||
+		v1ops.WakeLocks[0].Reason != wakeReasonBinaryDirGone ||
+		v1ops.WakeLocks[0].Fix != wantFix ||
+		!strings.Contains(v1ops.WakeLocks[0].NextAction, wantFix) {
+		t.Fatalf("doctor --ops v1 vanished-binary = %#v", v1ops.WakeLocks)
+	}
+
+	setDoctorIdentityPin(t, fixture.root)
+	output, err := captureEnvStdout(t, func() error {
+		return runDoctor([]string{"--root", fixture.root, "--ops", "--json", "--json-schema=2"})
+	})
+	if err != nil {
+		t.Fatalf("doctor --ops --json: %v", err)
+	}
+	assertNoRawENOENT(t, output)
+	var encoded doctorResultV2
+	if err := json.Unmarshal([]byte(output), &encoded); err != nil {
+		t.Fatalf("decode doctor json: %v\n%s", err, output)
+	}
+	if encoded.Ops == nil || len(encoded.Ops.WakeLocks) != 1 {
+		t.Fatalf("doctor json wake locks = %#v", encoded.Ops)
+	}
+	jsonLock := encoded.Ops.WakeLocks[0]
+	if jsonLock.Reason != wakeReasonBinaryDirGone ||
+		jsonLock.WakeCheck == nil ||
+		jsonLock.WakeCheck.Action.ReasonCode != wakeReasonBinaryDirGone ||
+		!strings.Contains(jsonLock.WakeCheck.Action.Message, wantFix) {
+		t.Fatalf("doctor json vanished-binary = %#v", jsonLock)
+	}
+
+	fixed := runOpsChecks(fixture.root, "test", true)
+	if len(fixed.WakeLocks) != 1 || fixed.WakeLocks[0].Status != "fixed" || !fixed.WakeLocks[0].Removed {
+		t.Fatalf("doctor --fix-wake-locks = %#v", fixed.WakeLocks)
+	}
+	if _, err := os.Lstat(fixture.lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale lock survived fix: %v", err)
+	}
+}
+
+func TestWakeCheckDoesNotClassifyMissingFileWhenParentRemains(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"codex"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(t.TempDir(), "Cellar", "amq", "0.63.3", "bin")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	imagePath := filepath.Join(parent, "amq")
+	if err := os.WriteFile(imagePath, []byte("amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+		ImagePath:  imagePath,
+		WakeMode:   wakeInjectModeRaw,
+		Generation: "missing-file-generation",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid}
+	})
+	stubWakeCheckRuntime(t, true, "0.64.1")
+	if err := os.Remove(imagePath); err != nil {
+		t.Fatal(err)
+	}
+
+	decision := inspectWakeCheckDecision(root, "codex")
+	v2 := renderWakeCheckV2(decision)
+	if v2.Action.ReasonCode == wakeReasonBinaryDirGone {
+		t.Fatalf("missing file with live parent classified as binary_dir_gone: %#v", v2)
+	}
+	if v2.Wake.Status != string(wakeLockStale) {
+		t.Fatalf("wake status = %s, want stale", v2.Wake.Status)
+	}
+}
+
+func TestUpgradePrintsPreviousBinaryWakeNote(t *testing.T) {
+	baseRoot := secureTempDirForTest(t)
+	if err := fsq.EnsureAgentDirs(baseRoot, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(t.TempDir(), "amq")
+	if err := os.WriteFile(binary, []byte("current"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldExecutablePath := executablePathForUpgrade
+	executablePathForUpgrade = func() (string, string, error) {
+		return binary, binary, nil
+	}
+	t.Cleanup(func() { executablePathForUpgrade = oldExecutablePath })
+	oldFetchLatestTag := fetchLatestTagForUpgrade
+	fetchLatestTagForUpgrade = func(context.Context, *http.Client) (string, error) {
+		return "v0.64.1", nil
+	}
+	t.Cleanup(func() { fetchLatestTagForUpgrade = oldFetchLatestTag })
+	t.Setenv(envRoot, baseRoot)
+
+	stdout, _, err := captureEnvOutput(t, func() error {
+		return runUpgrade(nil, "v0.64.1")
+	})
+	if err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	if !strings.Contains(stdout, upgradeLiveWakePreviousBinaryNote) {
+		t.Fatalf("upgrade omitted previous-binary wake note:\n%s", stdout)
+	}
+}
+
+func TestWakeRecordedPathParentGone(t *testing.T) {
+	parent := t.TempDir()
+	path := filepath.Join(parent, "amq")
+	if err := os.WriteFile(path, []byte("amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if wakeRecordedPathParentGone(path) {
+		t.Fatal("present parent reported gone")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if wakeRecordedPathParentGone(path) {
+		t.Fatal("missing file with present parent reported gone")
+	}
+	vanished := filepath.Join(t.TempDir(), "gone", "bin", "amq")
+	if err := os.MkdirAll(filepath.Dir(vanished), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Dir(filepath.Dir(vanished))); err != nil {
+		t.Fatal(err)
+	}
+	if !wakeRecordedPathParentGone(vanished) {
+		t.Fatal("vanished parent not detected")
+	}
+	replaced := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(replaced, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !wakeRecordedPathParentGone(filepath.Join(replaced, "amq")) {
+		t.Fatal("non-directory parent not detected")
+	}
+	if wakeRecordedPathParentGone("amq") || wakeRecordedPathParentGone("") {
+		t.Fatal("relative or empty path treated as vanished parent")
+	}
+}
+
+type vanishedBinaryStaleLockFixture struct {
+	root     string
+	lockPath string
+}
+
+func newVanishedBinaryStaleLockFixture(t *testing.T) vanishedBinaryStaleLockFixture {
+	t.Helper()
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(root, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.WriteConfig(
+		filepath.Join(root, "meta", "config.json"),
+		config.Config{Version: 1, Agents: []string{"codex"}},
+		true,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	versionDir := filepath.Join(t.TempDir(), "Cellar", "amq", "0.63.3")
+	binDir := filepath.Join(versionDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	imagePath := filepath.Join(binDir, "amq")
+	if err := os.WriteFile(imagePath, []byte("amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	imagePath, err := filepath.EvalSymlinks(imagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	versionDir, err = filepath.EvalSymlinks(versionDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:        4242,
+		Executable: "/opt/homebrew/bin/amq",
+		ImagePath:  imagePath,
+		WakeMode:   wakeInjectModeRaw,
+		Generation: "vanished-binary-generation",
+	})
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return wakeProcessInfo{PID: pid}
+	})
+	stubWakeCheckRuntime(t, true, "0.64.1")
+	if err := os.RemoveAll(versionDir); err != nil {
+		t.Fatal(err)
+	}
+	inspection := inspectWakeLock(root, "codex")
+	if inspection.Status != wakeLockStale {
+		t.Fatalf("fixture status = %s, want stale", inspection.Status)
+	}
+	if !wakeInspectionBinaryDirGone(inspection) {
+		t.Fatalf("fixture image parent still present: %#v", inspection.Lock)
+	}
+	return vanishedBinaryStaleLockFixture{root: root, lockPath: lockPath}
+}
+
+func assertNoRawENOENT(t *testing.T, parts ...string) {
+	t.Helper()
+	for _, part := range parts {
+		lower := strings.ToLower(part)
+		if strings.Contains(lower, "no such file") ||
+			strings.Contains(lower, "enoent") ||
+			strings.Contains(part, "open Darwin wake restart stage parent") {
+			t.Fatalf("raw ENOENT leaked: %q", part)
+		}
+	}
+}

--- a/internal/cli/wake_check_schema.go
+++ b/internal/cli/wake_check_schema.go
@@ -53,6 +53,7 @@ const (
 	wakeReasonLiveWakePreserve           = "live_wake_preserve"
 	wakeReasonOwnerRecoveryRequired      = "owner_bound_stale_recovery_required"
 	wakeReasonStaleManualCleanupRequired = "stale_lock_manual_cleanup_required"
+	wakeReasonBinaryDirGone              = "binary_dir_gone"
 	wakeReasonWakeStateCreating          = "wake_state_creating"
 	wakeReasonWakeStateUnverified        = "wake_state_unverified"
 	wakeReasonObservationChanged         = "observation_changed"

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -497,6 +497,22 @@ func TestWakeCheckV2ClassifierActions(t *testing.T) {
 			terminal: true,
 		},
 		{
+			name: "stale vanished binary dir",
+			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
+				d.Wake.Status = string(wakeLockStale)
+				d.Wake.Mode = wakeCheckOptionalString(wakeInjectModeRaw)
+				image := filepath.Join(t.TempDir(), "Cellar", "amq", "0.61.0", "bin", "amq")
+				return wakeLockInspection{
+					Exists: true,
+					Status: wakeLockStale,
+					Lock:   wakeLock{ImagePath: image},
+				}, nil
+			},
+			kind: wakeActionManualStaleCleanup, actor: wakeActionActorAgent,
+			reason: wakeReasonBinaryDirGone, restart: wakeRestartAgentSafe,
+			args: []string{"doctor", "--root", "/queue with spaces", "--ops", "--fix-wake-locks"},
+		},
+		{
 			name: "creating wake",
 			configure: func(d *wakeCheckDecision) (wakeLockInspection, *opsWakeLock) {
 				d.Wake.Status = string(wakeLockCreating)

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -806,6 +806,20 @@ func classifyWakeCheckRestart(
 			}
 			return
 		}
+		if wakeInspectionBinaryDirGone(inspection) {
+			fix := doctorRootCommandForOS(decision.Root, "", runtime.GOOS, "--ops", "--fix-wake-locks")
+			decision.RestartCapability = wakeRestartAgentSafe
+			decision.Action = wakeCheckActionDecision{
+				Kind:       wakeActionManualStaleCleanup,
+				Actor:      wakeActionActorAgent,
+				ReasonCode: wakeReasonBinaryDirGone,
+				Command: wakeCheckActionCommand(
+					"doctor", "--root", decision.Root, "--ops", "--fix-wake-locks",
+				),
+				Message: wakeBinaryDirGoneMessage + "; run " + fix,
+			}
+			return
+		}
 		if wakeCheckStringValue(decision.Wake.Mode, "") == wakeTargetInjectVia {
 			decision.RestartCapability = wakeRestartUnavailable
 			decision.Action = wakeCheckActionDecision{

--- a/internal/cli/wake_p0_golden_abi_unix_test.go
+++ b/internal/cli/wake_p0_golden_abi_unix_test.go
@@ -192,6 +192,7 @@ func wakeABIWakeReasonCodes() map[string]bool {
 		"live_wake_preserve":                  true,
 		"owner_bound_stale_recovery_required": true,
 		"stale_lock_manual_cleanup_required":  true,
+		"binary_dir_gone":                     true,
 		"wake_state_creating":                 true,
 		"wake_state_unverified":               true,
 		"observation_changed":                 true,

--- a/internal/cli/wake_restart_stage_diagnostic_unix.go
+++ b/internal/cli/wake_restart_stage_diagnostic_unix.go
@@ -55,6 +55,13 @@ func diagnoseWakeRestartStage(
 	}
 	if exists && snapshot.Record.PreviousBoundImage != nil {
 		previous := *snapshot.Record.PreviousBoundImage
+		if wakeRecordedPathParentGone(previous.ExecutionPath) {
+			return wakeRestartStageDiagnostic{
+				Path:   previous.ExecutionPath,
+				Status: wakeRestartStageBinaryDirGone,
+				Reason: wakeBinaryDirGoneMessage,
+			}
+		}
 		if _, stageErr := os.Lstat(previous.ExecutionPath); stageErr != nil && !os.IsNotExist(stageErr) {
 			return wakeRestartStageDiagnostic{
 				Path:   previous.ExecutionPath,
@@ -90,8 +97,18 @@ func diagnoseWakeRestartStage(
 		}
 	}
 	if exists && snapshot.Record.StagePath != "" {
+		if wakeRestartRecordBinaryDirGone(snapshot.Record) {
+			return wakeRestartStageDiagnostic{
+				Path:   snapshot.Record.StagePath,
+				Status: wakeRestartStageBinaryDirGone,
+				Reason: wakeBinaryDirGoneMessage,
+			}
+		}
 		present, stageErr := wakeRestartStageExistsPlatform(snapshot.Record)
 		if stageErr != nil {
+			if errors.Is(stageErr, os.ErrNotExist) {
+				return wakeRestartStageDiagnostic{}
+			}
 			return wakeRestartStageDiagnostic{
 				Path:   snapshot.Record.StagePath,
 				Status: "inspection-error",
@@ -129,6 +146,13 @@ func diagnoseWakeRestartStage(
 	running := inspection.Lock.RunningImageEvidence
 	if running == nil || !validPreviousWakeRestartBoundImagePlatform(*running) {
 		return wakeRestartStageDiagnostic{}
+	}
+	if wakeRecordedPathParentGone(running.ExecutionPath) {
+		return wakeRestartStageDiagnostic{
+			Path:   running.ExecutionPath,
+			Status: wakeRestartStageBinaryDirGone,
+			Reason: wakeBinaryDirGoneMessage,
+		}
 	}
 	if _, err := os.Lstat(running.ExecutionPath); os.IsNotExist(err) {
 		return wakeRestartStageDiagnostic{}

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -338,7 +338,10 @@ read-only and reports the running/current image path and version plus an exact
 running and hand off to its owning terminal or supervisor. For `unavailable`,
 preserve the state and diagnose it. Never kill a live raw wake from a non-TTY
 process, and never accept an attention-only fallback as a replacement for
-full-strength input delivery.
+full-strength input delivery. When the recorded image or restart stage lives
+under a directory that no longer exists, the check reports
+`reason_code=binary_dir_gone` and names `amq doctor --ops --fix-wake-locks`
+instead of a raw ENOENT.
 
 Current resume-eligible `coop exec` wakes automatically observe their stable
 AMQ launch symlink and adopt a strictly newer semantic version at a fully


### PR DESCRIPTION
## Summary
When a stale wake lock's image or restart stage lives under a directory that no longer exists (Homebrew Cellar removed on upgrade), `amq wake check --json` and `amq doctor --ops` report typed `reason_code=binary_dir_gone` and name `amq doctor --ops --fix-wake-locks` instead of a raw ENOENT.

## Changes
- Typed `binary_dir_gone` on wake check / doctor for a vanished recorded image parent
- `doctor --ops --fix-wake-locks` still reclaims the stale lock (amq-0ja / #572 path)
- `amq upgrade` and docs warn to retire live wakes started by the previous binary first

## Testing
- [x] Focused `internal/cli` tests including vanished-parent classification, missing-file-with-parent-present negative, Darwin stage-parent fix, and upgrade note
- [x] Pre-push `go test ./...` and smoke checks passed

## Review
Peer gate satisfied by lead execution check (Claude reviewed predicate + classifier and ran `TestWakeCheckAndDoctorClassifyVanishedBinaryDir` plus the doctor-fix test). Codex is deep in ju3 and did not review this PR by execution.

## Related Issues
Fixes amq-z0a