### PR TITLE
feat(wake): stage darwin restart images under the machine-local state dir

### DIFF
--- a/internal/cli/wake_restart_bound_darwin.go
+++ b/internal/cli/wake_restart_bound_darwin.go
@@ -3,15 +3,21 @@
 package cli
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	"golang.org/x/sys/unix"
 )
+
+var linkDarwinWakeRestartStage = os.Link
+var copyDarwinWakeRestartStageFn = copyDarwinWakeRestartStage
 
 func bindWakeRestartCandidatePlatform(candidate wakeImageEvidenceV1) (*wakeRestartBoundImage, error) {
 	return bindWakeRestartCandidateAtPlatform(candidate, "")
@@ -73,8 +79,11 @@ func bindWakeRestartCandidateAtPlatform(candidate wakeImageEvidenceV1, plannedSt
 		if filepath.Base(plannedStagePath) != filepath.Base(candidate.ExecutionPath) {
 			return nil, fmt.Errorf("planned Darwin wake restart stage path is invalid")
 		}
+		if err := prepareStableDarwinWakeRestartStageParent(plannedStagePath); err != nil {
+			return nil, err
+		}
 		if err := os.Mkdir(stageDir, 0o700); err != nil {
-			return nil, fmt.Errorf("create planned adjacent wake restart stage: %w", err)
+			return nil, fmt.Errorf("create planned Darwin wake restart stage: %w", err)
 		}
 	}
 	stagePath := filepath.Join(stageDir, filepath.Base(candidate.ExecutionPath))
@@ -93,8 +102,14 @@ func bindWakeRestartCandidateAtPlatform(candidate wakeImageEvidenceV1, plannedSt
 			}
 		}
 	}()
-	if err := os.Link(candidate.ExecutionPath, stagePath); err != nil {
-		return nil, fmt.Errorf("hardlink wake restart candidate into adjacent stage: %w", err)
+	linked := true
+	if err := linkDarwinWakeRestartStage(candidate.ExecutionPath, stagePath); errors.Is(err, syscall.EXDEV) {
+		linked = false
+		if err := copyDarwinWakeRestartStageFn(source, stagePath); err != nil {
+			return nil, fmt.Errorf("copy cross-device wake restart candidate into stage: %w", err)
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("hardlink wake restart candidate into stage: %w", err)
 	}
 	stageCreated = true
 	stageLstat, err := os.Lstat(stagePath)
@@ -103,6 +118,9 @@ func bindWakeRestartCandidateAtPlatform(candidate wakeImageEvidenceV1, plannedSt
 	}
 	stageIdentity = stageLstat
 	stageIdentityKnown = true
+	if err := syncDarwinWakeRestartStageDirectory(stageDir); err != nil {
+		return nil, fmt.Errorf("sync Darwin wake restart stage directory: %w", err)
+	}
 	if stageLstat.Mode()&os.ModeSymlink != 0 {
 		return nil, fmt.Errorf("staged wake restart image must not be a symlink")
 	}
@@ -133,8 +151,8 @@ func bindWakeRestartCandidateAtPlatform(candidate wakeImageEvidenceV1, plannedSt
 	if err != nil {
 		return nil, fmt.Errorf("re-stat linked wake restart source: %w", err)
 	}
-	if !os.SameFile(sourceOpened, postLinkSource) || !os.SameFile(postLinkSource, stageLstat) ||
-		!os.SameFile(stageLstat, stageOpened) {
+	if !os.SameFile(sourceOpened, postLinkSource) || !os.SameFile(stageLstat, stageOpened) ||
+		(linked && !os.SameFile(postLinkSource, stageLstat)) {
 		return nil, fmt.Errorf("darwin wake restart source and stage identities do not match")
 	}
 	postLinkSourceEvidence, err := captureWakeImageEvidenceFromOpenFile(
@@ -155,8 +173,11 @@ func bindWakeRestartCandidateAtPlatform(candidate wakeImageEvidenceV1, plannedSt
 	if err != nil {
 		return nil, err
 	}
-	if !sameWakeImageEvidenceExceptMethodPath(postLinkSourceEvidence, bound.evidence) {
+	if linked && !sameWakeImageEvidenceExceptMethodPath(postLinkSourceEvidence, bound.evidence) {
 		return nil, fmt.Errorf("darwin wake restart source and staged image changed while hashing")
+	}
+	if !linked && !sameWakeImageContent(postLinkSourceEvidence, bound.evidence) {
+		return nil, fmt.Errorf("copied Darwin wake restart stage content differs from source")
 	}
 	if !sameRequestedAndBoundWakeImageEvidence(candidate, bound.evidence) {
 		return nil, fmt.Errorf("darwin staged wake restart image differs from requested candidate")
@@ -164,6 +185,119 @@ func bindWakeRestartCandidateAtPlatform(candidate wakeImageEvidenceV1, plannedSt
 	stageCreated = false
 	failed = false
 	return bound, nil
+}
+
+func syncDarwinWakeRestartStageDirectory(stageDir string) error {
+	fd, err := unix.Open(stageDir, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	return unix.Fsync(fd)
+}
+
+func copyDarwinWakeRestartStage(source *os.File, stagePath string) error {
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind wake restart candidate for copy: %w", err)
+	}
+	fd, err := unix.Open(stagePath, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o700)
+	if err != nil {
+		return err
+	}
+	destination := os.NewFile(uintptr(fd), stagePath)
+	if destination == nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("bind copied Darwin wake restart stage")
+	}
+	published := false
+	defer func() {
+		_ = destination.Close()
+		if !published {
+			_ = os.Remove(stagePath)
+		}
+	}()
+	if _, err := io.Copy(destination, source); err != nil {
+		return err
+	}
+	if err := destination.Sync(); err != nil {
+		return err
+	}
+	if err := destination.Close(); err != nil {
+		return err
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind wake restart candidate after copy: %w", err)
+	}
+	published = true
+	return nil
+}
+
+func prepareStableDarwinWakeRestartStageParent(stagePath string) error {
+	parts, stable, err := stableDarwinWakeRestartStageParts(stagePath)
+	if err != nil || !stable {
+		return err
+	}
+	root, err := darwinWakeRestartStageRoot()
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(filepath.Dir(stagePath))
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return fmt.Errorf("create stable Darwin wake restart stage hierarchy: %w", err)
+	}
+	for _, managed := range []string{
+		root,
+		filepath.Join(root, parts[0]),
+		parent,
+	} {
+		info, err := os.Lstat(managed)
+		if err != nil {
+			return fmt.Errorf("inspect stable Darwin wake restart stage hierarchy: %w", err)
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o700 ||
+			stat.Uid != uint32(os.Geteuid()) {
+			return fmt.Errorf("refuse unsafe stable Darwin wake restart stage hierarchy")
+		}
+	}
+	return nil
+}
+
+func stableDarwinWakeRestartStageParts(stagePath string) ([]string, bool, error) {
+	root, err := darwinWakeRestartStageRoot()
+	if err != nil {
+		return nil, false, err
+	}
+	rel, err := filepath.Rel(root, stagePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, false, nil
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) != 4 || len(parts[0]) != sha256HexLength {
+		return nil, true, fmt.Errorf("planned stable Darwin wake restart stage path is invalid")
+	}
+	if _, err := hex.DecodeString(parts[0]); err != nil {
+		return nil, true, fmt.Errorf("planned stable Darwin wake restart root identity is invalid")
+	}
+	if err := fsq.ValidateHandle(parts[1]); err != nil || !validWakeReloadTransportGeneration(parts[2]) ||
+		parts[3] == "" || filepath.Base(parts[3]) != parts[3] {
+		return nil, true, fmt.Errorf("planned stable Darwin wake restart stage path is invalid")
+	}
+	return parts, true, nil
+}
+
+func wakeRestartStageUsesStableStatePlatform(stagePath string) (bool, error) {
+	_, stable, err := stableDarwinWakeRestartStageParts(stagePath)
+	return stable, err
+}
+
+func sameWakeImageContent(first, second wakeImageEvidenceV1) bool {
+	first.Method = second.Method
+	first.ExecutionPath = second.ExecutionPath
+	first.Device = second.Device
+	first.Inode = second.Inode
+	first.CTimeNS = second.CTimeNS
+	return first == second
 }
 
 func boundWakeRestartPreflightCommandPlatform(image *wakeRestartBoundImage) (string, []*os.File, error) {
@@ -246,8 +380,13 @@ func validPreviousWakeRestartBoundImagePlatform(bound wakeImageEvidenceV1) bool 
 	stageBase := filepath.Base(stagePath)
 	stageDirBase := filepath.Base(filepath.Dir(stagePath))
 	prefix := "." + stageBase + ".amq-restart-"
-	return stageBase != "." && stageBase != string(filepath.Separator) &&
+	legacy := stageBase != "." && stageBase != string(filepath.Separator) &&
 		strings.HasPrefix(stageDirBase, prefix) && len(stageDirBase) > len(prefix)
+	if legacy {
+		return true
+	}
+	_, stable, err := stableDarwinWakeRestartStageParts(stagePath)
+	return err == nil && stable
 }
 
 func cleanupDarwinWakeRestartStage(bound wakeImageEvidenceV1, allowNamespaceCTimeChange bool) error {
@@ -259,7 +398,10 @@ func cleanupDarwinWakeRestartStage(bound wakeImageEvidenceV1, allowNamespaceCTim
 	lstat, err := os.Lstat(stagePath)
 	if err != nil {
 		if errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ENOTDIR) {
-			return removeEmptyDarwinWakeRestartStageDir(stagePath)
+			if err := removeEmptyDarwinWakeRestartStageDir(stagePath); err != nil {
+				return err
+			}
+			return pruneEmptyStableDarwinWakeRestartStageHierarchy(stagePath)
 		}
 		return fmt.Errorf("stat Darwin wake restart stage: %w", err)
 	}
@@ -303,5 +445,5 @@ func cleanupDarwinWakeRestartStage(bound wakeImageEvidenceV1, allowNamespaceCTim
 	if err := os.Remove(stageDir); err != nil {
 		return fmt.Errorf("remove Darwin wake restart stage directory: %w", err)
 	}
-	return nil
+	return pruneEmptyStableDarwinWakeRestartStageHierarchy(stagePath)
 }

--- a/internal/cli/wake_restart_bound_unix.go
+++ b/internal/cli/wake_restart_bound_unix.go
@@ -181,10 +181,9 @@ func sameDarwinStagedWakeImageEvidence(first, second wakeImageEvidenceV1) bool {
 	return first == second
 }
 
-// A Darwin hardlink necessarily changes the shared inode's ctime. This is the
-// only extra delta allowed between the requester's pre-link observation and
-// the post-link bound image; every stable identity, content, and version field
-// remains exact. Linux does not receive this exception.
+// A Darwin hardlink changes the shared inode's ctime. Cross-device staging
+// instead copies and fsyncs the image, so the bound evidence has the stage's
+// own device, inode, and ctime. Both paths require exact content and version.
 func sameRequestedAndBoundWakeImageEvidence(first, second wakeImageEvidenceV1) bool {
 	if first.Platform != second.Platform || first.Method != wakeImageMethodPathnameObserved {
 		return false
@@ -194,6 +193,8 @@ func sameRequestedAndBoundWakeImageEvidence(first, second wakeImageEvidenceV1) b
 		if !wakeImageMethodIsDarwinExecObserved(second.Method) {
 			return false
 		}
+		first.Device = second.Device
+		first.Inode = second.Inode
 		first.CTimeNS = second.CTimeNS
 	case "linux":
 		if second.Method != wakeImageMethodFDExec {

--- a/internal/cli/wake_restart_darwin_test.go
+++ b/internal/cli/wake_restart_darwin_test.go
@@ -135,6 +135,7 @@ func TestDarwinWakeRestartRealPTYPreservesPIDAndUnreadWork(t *testing.T) {
 	}
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
 	temp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", filepath.Join(temp, "state"))
 	oldDir := filepath.Join(temp, "old")
 	newDir := filepath.Join(temp, "new")
 	if err := os.MkdirAll(oldDir, 0o700); err != nil {

--- a/internal/cli/wake_restart_e2e_unix_test.go
+++ b/internal/cli/wake_restart_e2e_unix_test.go
@@ -194,13 +194,14 @@ func TestWakeRestartRealPTYOwnerHelper(t *testing.T) {
 		if _, err := os.Lstat(firstRestartImagePath); !os.IsNotExist(err) {
 			t.Fatalf("first Darwin restart stage survived the second prepared restart: %v", err)
 		}
-		stagePattern := filepath.Join(
-			filepath.Dir(newBinary),
-			"."+filepath.Base(newBinary)+".amq-restart-*",
-		)
-		stages, globErr := filepath.Glob(stagePattern)
-		if globErr != nil || len(stages) != 1 || filepath.Dir(second.Lock.ImagePath) != stages[0] {
-			t.Fatalf("Darwin restart stages after second restart = %v, err=%v", stages, globErr)
+		if stable, err := wakeRestartStageUsesStableStatePlatform(second.Lock.ImagePath); err != nil || !stable {
+			t.Fatalf("second Darwin restart stage is not under stable state: path=%s err=%v", second.Lock.ImagePath, err)
+		}
+		agentStages := filepath.Dir(filepath.Dir(second.Lock.ImagePath))
+		stages, readErr := os.ReadDir(agentStages)
+		if readErr != nil || len(stages) != 1 || !stages[0].IsDir() ||
+			filepath.Join(agentStages, stages[0].Name()) != filepath.Dir(second.Lock.ImagePath) {
+			t.Fatalf("Darwin restart stages after second restart = %v, err=%v", stages, readErr)
 		}
 	}
 	after = second

--- a/internal/cli/wake_restart_stage_darwin.go
+++ b/internal/cli/wake_restart_stage_darwin.go
@@ -3,15 +3,22 @@
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 	"golang.org/x/sys/unix"
 )
+
+const sha256HexLength = sha256.Size * 2
 
 func planWakeRestartStagePlatform(candidate wakeImageEvidenceV1, requestID string) (string, error) {
 	if !validWakeReloadTransportGeneration(requestID) {
@@ -23,6 +30,81 @@ func planWakeRestartStagePlatform(candidate wakeImageEvidenceV1, requestID strin
 	base := filepath.Base(candidate.ExecutionPath)
 	dir := filepath.Join(filepath.Dir(candidate.ExecutionPath), "."+base+".amq-restart-"+requestID)
 	return filepath.Join(dir, base), nil
+}
+
+func planWakeRestartStageForRecordPlatform(record wakeRestartRecord) (string, error) {
+	if !validWakeReloadTransportGeneration(record.RequestID) {
+		return "", fmt.Errorf("wake restart stage request id is invalid")
+	}
+	if err := fsq.ValidateHandle(record.Agent); err != nil {
+		return "", fmt.Errorf("wake restart stage agent is invalid: %w", err)
+	}
+	if err := validateWakeImageEvidenceForPlatform(record.Candidate, "darwin"); err != nil {
+		return "", err
+	}
+	rootIdentity, err := resolveTreeIdentityToken(record.Root)
+	if err != nil {
+		return "", fmt.Errorf("resolve wake restart stage root identity: %w", err)
+	}
+	stateRoot, err := darwinWakeRestartStageRoot()
+	if err != nil {
+		return "", err
+	}
+	if wakeRestartPathWithinDirectory(stateRoot, record.Root) {
+		return "", fmt.Errorf("wake restart stage state directory must be outside AM_ROOT")
+	}
+	sum := sha256.Sum256([]byte(rootIdentity))
+	return filepath.Join(
+		stateRoot,
+		hex.EncodeToString(sum[:]),
+		record.Agent,
+		record.RequestID,
+		filepath.Base(record.Candidate.ExecutionPath),
+	), nil
+}
+
+func darwinWakeRestartStageRoot() (string, error) {
+	stateDir, err := launch.DefaultLaunchStateDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve Darwin wake restart state directory: %w", err)
+	}
+	stateDir, err = resolveDarwinWakeRestartStatePath(stateDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve physical Darwin wake restart state directory: %w", err)
+	}
+	return filepath.Join(stateDir, "wake-stages"), nil
+}
+
+func resolveDarwinWakeRestartStatePath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	prefix := filepath.Clean(abs)
+	var tail []string
+	for {
+		resolved, err := filepath.EvalSymlinks(prefix)
+		if err == nil {
+			for i := len(tail) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, tail[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(prefix)
+		if parent == prefix {
+			return "", err
+		}
+		tail = append(tail, filepath.Base(prefix))
+		prefix = parent
+	}
+}
+
+func wakeRestartPathWithinDirectory(path, parent string) bool {
+	rel, err := filepath.Rel(parent, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func validateWakeRestartStageStatePlatform(record wakeRestartRecord) error {
@@ -40,11 +122,12 @@ func validateWakeRestartStageStatePlatform(record wakeRestartRecord) error {
 	if record.StagePath == "" && record.BoundImage == nil {
 		return nil
 	}
-	planned, err := planWakeRestartStagePlatform(record.Candidate, record.RequestID)
+	planned, err := planWakeRestartStageForRecordPlatform(record)
 	if err != nil {
 		return err
 	}
-	if record.StagePath != planned {
+	legacyPlanned, legacyErr := planWakeRestartStagePlatform(record.Candidate, record.RequestID)
+	if record.StagePath != planned && (legacyErr != nil || record.StagePath != legacyPlanned) {
 		return fmt.Errorf("wake restart stage path does not match the exact request")
 	}
 	if record.BoundImage == nil {
@@ -120,10 +203,35 @@ func reclaimWakeRestartStagePlatform(record wakeRestartRecord) error {
 }
 
 func cleanupPersistedDarwinWakeRestartStage(bound wakeImageEvidenceV1) error {
-	if err := cleanupDarwinWakeRestartStage(bound, true); err != nil {
+	return cleanupDarwinWakeRestartStage(bound, true)
+}
+
+func pruneEmptyStableDarwinWakeRestartStageHierarchy(stagePath string) error {
+	_, stable, err := stableDarwinWakeRestartStageParts(stagePath)
+	if err != nil || !stable {
 		return err
 	}
-	return removeEmptyDarwinWakeRestartStageDir(bound.ExecutionPath)
+	stageDir := filepath.Dir(stagePath)
+	for _, dir := range []string{filepath.Dir(stageDir), filepath.Dir(filepath.Dir(stageDir))} {
+		info, err := os.Lstat(dir)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("inspect stable Darwin wake restart stage hierarchy for pruning: %w", err)
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o700 ||
+			stat.Uid != uint32(os.Geteuid()) {
+			return fmt.Errorf("refuse pruning replaced stable Darwin wake restart stage hierarchy")
+		}
+		if err := os.Remove(dir); errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
+			return nil
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("prune empty stable Darwin wake restart stage hierarchy: %w", err)
+		}
+	}
+	return nil
 }
 
 func validateWakeRestartPersistedBoundPlatform(

--- a/internal/cli/wake_restart_stage_darwin_test.go
+++ b/internal/cli/wake_restart_stage_darwin_test.go
@@ -3,11 +3,14 @@
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -15,6 +18,14 @@ import (
 
 func newDarwinWakeRestartStageRecordForTest(t *testing.T) wakeRestartRecord {
 	t.Helper()
+	return newDarwinWakeRestartStageRecordForRootTest(t, canonicalWakeRoot(t.TempDir()), "codex")
+}
+
+func newDarwinWakeRestartStageRecordForRootTest(t *testing.T, root, agent string) wakeRestartRecord {
+	t.Helper()
+	if os.Getenv("AMQ_TEST_DARWIN_WAKE_STAGE_STATE") == "" {
+		setDarwinWakeRestartStateHomeForTest(t, t.TempDir())
+	}
 	testBinary, err := os.Executable()
 	if err != nil {
 		t.Fatal(err)
@@ -33,9 +44,28 @@ func newDarwinWakeRestartStageRecordForTest(t *testing.T) wakeRestartRecord {
 	}
 	record := wakeRestartRecord{
 		RequestID: "0123456789abcdef0123456789abcdef",
+		Root:      root,
+		Agent:     agent,
 		Candidate: candidate,
 	}
-	record.StagePath, err = planWakeRestartStagePlatform(candidate, record.RequestID)
+	record.StagePath, err = planWakeRestartStageForRecordPlatform(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record
+}
+
+func setDarwinWakeRestartStateHomeForTest(t *testing.T, stateHome string) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("AMQ_TEST_DARWIN_WAKE_STAGE_STATE", stateHome)
+}
+
+func newLegacyDarwinWakeRestartStageRecordForTest(t *testing.T) wakeRestartRecord {
+	t.Helper()
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	var err error
+	record.StagePath, err = planWakeRestartStagePlatform(record.Candidate, record.RequestID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +85,9 @@ type consecutiveDarwinWakeRestartFixture struct {
 
 func newConsecutiveDarwinWakeRestartFixture(t *testing.T) consecutiveDarwinWakeRestartFixture {
 	t.Helper()
-	previousRecord := newDarwinWakeRestartStageRecordForTest(t)
+	root := canonicalWakeRoot(t.TempDir())
+	const agent = "codex"
+	previousRecord := newDarwinWakeRestartStageRecordForRootTest(t, root, agent)
 	previousBound, err := bindWakeRestartCandidateAtPlatform(
 		previousRecord.Candidate,
 		previousRecord.StagePath,
@@ -69,7 +101,12 @@ func newConsecutiveDarwinWakeRestartFixture(t *testing.T) consecutiveDarwinWakeR
 	}
 	previousBound.file = nil
 
-	currentRecord := newDarwinWakeRestartStageRecordForTest(t)
+	currentRecord := newDarwinWakeRestartStageRecordForRootTest(t, root, agent)
+	currentRecord.RequestID = "fedcba9876543210fedcba9876543210"
+	currentRecord.StagePath, err = planWakeRestartStageForRecordPlatform(currentRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
 	currentBound, err := bindWakeRestartCandidateAtPlatform(
 		currentRecord.Candidate,
 		currentRecord.StagePath,
@@ -83,8 +120,6 @@ func newConsecutiveDarwinWakeRestartFixture(t *testing.T) consecutiveDarwinWakeR
 	}
 	currentBound.file = nil
 
-	root := canonicalWakeRoot(t.TempDir())
-	const agent = "codex"
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatal(err)
 	}
@@ -94,8 +129,6 @@ func newConsecutiveDarwinWakeRestartFixture(t *testing.T) consecutiveDarwinWakeR
 	record := currentRecord
 	record.Schema = wakeRestartSchemaV2
 	record.Status = wakeRestartPending
-	record.Root = root
-	record.Agent = agent
 	record.Generation = "abcdef0123456789abcdef0123456789"
 	record.SuccessorGeneration = "fedcba9876543210fedcba9876543210"
 	record.Owner = validWakeResumeOwnerForTest()
@@ -193,6 +226,200 @@ func TestDarwinCrashStageReclaimPreservesReplacement(t *testing.T) {
 	}
 }
 
+func TestDarwinRestartStageUsesMachineLocalStateAndSurvivesCandidateRemoval(t *testing.T) {
+	stateHome := t.TempDir()
+	setDarwinWakeRestartStateHomeForTest(t, stateHome)
+	record := newDarwinWakeRestartStageRecordForTest(t)
+
+	wakeStages, err := darwinWakeRestartStageRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootIdentity, err := resolveTreeIdentityToken(record.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootDigest := sha256.Sum256([]byte(rootIdentity))
+	wantStagePath := filepath.Join(
+		wakeStages,
+		hex.EncodeToString(rootDigest[:]),
+		record.Agent,
+		record.RequestID,
+		filepath.Base(record.Candidate.ExecutionPath),
+	)
+	if record.StagePath != wantStagePath {
+		t.Fatalf("stage path = %q, want %q", record.StagePath, wantStagePath)
+	}
+	if strings.Contains(record.StagePath, record.Candidate.ExecutionPath) {
+		t.Fatalf("stage path remains derived from candidate path: %s", record.StagePath)
+	}
+
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = bound.close() }()
+	if bound.evidence.Device != record.Candidate.Device || bound.evidence.Inode != record.Candidate.Inode {
+		t.Fatalf("same-filesystem stage was not a hardlink: candidate=%#v stage=%#v", record.Candidate, bound.evidence)
+	}
+	if err := os.RemoveAll(filepath.Dir(record.Candidate.ExecutionPath)); err != nil {
+		t.Fatal(err)
+	}
+	if err := revalidateBoundWakeRestartImagePlatform(bound); err != nil {
+		t.Fatalf("revalidate stage after candidate directory removal: %v", err)
+	}
+	for path := filepath.Dir(record.StagePath); path != wakeStages; path = filepath.Dir(path) {
+		info, err := os.Lstat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !info.IsDir() || info.Mode().Perm() != 0o700 {
+			t.Fatalf("managed stage directory %s mode = %v, want directory 0700", path, info.Mode())
+		}
+	}
+}
+
+func TestDarwinRestartStageRefusesStateInsideAMRoot(t *testing.T) {
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	setDarwinWakeRestartStateHomeForTest(t, filepath.Join(record.Root, "state"))
+
+	if _, err := planWakeRestartStageForRecordPlatform(record); err == nil ||
+		!strings.Contains(err.Error(), "outside AM_ROOT") {
+		t.Fatalf("plan with state inside AM_ROOT = %v, want refusal", err)
+	}
+}
+
+func TestDarwinRestartStageRefusesStateSymlinkedInsideAMRoot(t *testing.T) {
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	inside := filepath.Join(record.Root, "local-state")
+	if err := os.Mkdir(inside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(t.TempDir(), "state-alias")
+	if err := os.Symlink(inside, alias); err != nil {
+		t.Fatal(err)
+	}
+	setDarwinWakeRestartStateHomeForTest(t, alias)
+
+	if _, err := planWakeRestartStageForRecordPlatform(record); err == nil ||
+		!strings.Contains(err.Error(), "outside AM_ROOT") {
+		t.Fatalf("plan with state symlinked inside AM_ROOT = %v, want refusal", err)
+	}
+}
+
+func TestDarwinRestartStageCopiesAndSyncsOnCrossDeviceLink(t *testing.T) {
+	stateHome := t.TempDir()
+	setDarwinWakeRestartStateHomeForTest(t, stateHome)
+	record := newDarwinWakeRestartStageRecordForTest(t)
+
+	oldLink := linkDarwinWakeRestartStage
+	linkDarwinWakeRestartStage = func(string, string) error { return syscall.EXDEV }
+	t.Cleanup(func() { linkDarwinWakeRestartStage = oldLink })
+
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatalf("bind with forced cross-device link: %v", err)
+	}
+	defer func() { _ = bound.close() }()
+	if bound.evidence.Device == record.Candidate.Device && bound.evidence.Inode == record.Candidate.Inode {
+		t.Fatal("copy fallback retained the source file identity")
+	}
+	if bound.evidence.SHA256 != record.Candidate.SHA256 ||
+		bound.evidence.Size != record.Candidate.Size ||
+		bound.evidence.EmbeddedVersion != record.Candidate.EmbeddedVersion {
+		t.Fatalf("copy fallback evidence = %#v, want source content evidence %#v", bound.evidence, record.Candidate)
+	}
+	if err := revalidateBoundWakeRestartImagePlatform(bound); err != nil {
+		t.Fatalf("revalidate copied stage: %v", err)
+	}
+}
+
+func TestDarwinRestartStageRejectsWrongBytesAfterCrossDeviceCopy(t *testing.T) {
+	stateHome := t.TempDir()
+	setDarwinWakeRestartStateHomeForTest(t, stateHome)
+	record := newDarwinWakeRestartStageRecordForTest(t)
+
+	oldLink := linkDarwinWakeRestartStage
+	linkDarwinWakeRestartStage = func(string, string) error { return syscall.EXDEV }
+	t.Cleanup(func() { linkDarwinWakeRestartStage = oldLink })
+	oldCopy := copyDarwinWakeRestartStageFn
+	copyDarwinWakeRestartStageFn = func(_ *os.File, stagePath string) error {
+		return os.WriteFile(stagePath, []byte("wrong staged bytes"), 0o700)
+	}
+	t.Cleanup(func() { copyDarwinWakeRestartStageFn = oldCopy })
+
+	if _, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath); err == nil ||
+		!strings.Contains(err.Error(), "copied Darwin wake restart stage content differs") {
+		t.Fatalf("wrong-byte cross-device copy error = %v", err)
+	}
+}
+
+func TestDarwinRestartStageSeparatesTwoRoots(t *testing.T) {
+	stateHome := t.TempDir()
+	setDarwinWakeRestartStateHomeForTest(t, stateHome)
+	rootOne := canonicalWakeRoot(t.TempDir())
+	rootTwo := canonicalWakeRoot(t.TempDir())
+	recordOne := newDarwinWakeRestartStageRecordForRootTest(t, rootOne, "codex")
+	recordTwo := newDarwinWakeRestartStageRecordForRootTest(t, rootTwo, "codex")
+
+	if recordOne.StagePath == recordTwo.StagePath {
+		t.Fatalf("two roots collided at stage path %q", recordOne.StagePath)
+	}
+	hashDirOne := filepath.Dir(filepath.Dir(filepath.Dir(recordOne.StagePath)))
+	hashDirTwo := filepath.Dir(filepath.Dir(filepath.Dir(recordTwo.StagePath)))
+	if hashDirOne == hashDirTwo {
+		t.Fatalf("two roots shared stage hierarchy %q", hashDirOne)
+	}
+	boundOne, err := bindWakeRestartCandidateAtPlatform(recordOne.Candidate, recordOne.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = boundOne.close() }()
+	boundTwo, err := bindWakeRestartCandidateAtPlatform(recordTwo.Candidate, recordTwo.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = boundTwo.close() }()
+	if _, err := os.Lstat(recordOne.StagePath); err != nil {
+		t.Fatalf("first root stage missing after second bind: %v", err)
+	}
+	if _, err := os.Lstat(recordTwo.StagePath); err != nil {
+		t.Fatalf("second root stage missing: %v", err)
+	}
+}
+
+func TestDarwinRestartStageCleanupPrunesEmptyStableHierarchy(t *testing.T) {
+	stateHome := t.TempDir()
+	setDarwinWakeRestartStateHomeForTest(t, stateHome)
+	record := newDarwinWakeRestartStageRecordForTest(t)
+	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := bound.evidence
+	if err := bound.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	bound.file = nil
+
+	if err := cleanupPersistedDarwinWakeRestartStage(evidence); err != nil {
+		t.Fatal(err)
+	}
+	stageDir := filepath.Dir(record.StagePath)
+	for _, path := range []string{stageDir, filepath.Dir(stageDir), filepath.Dir(filepath.Dir(stageDir))} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("empty stable stage hierarchy survived at %s: %v", path, err)
+		}
+	}
+	wakeStages, err := darwinWakeRestartStageRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Lstat(wakeStages); err != nil || !info.IsDir() {
+		t.Fatalf("shared wake-stages root was pruned: info=%v err=%v", info, err)
+	}
+}
+
 func TestPrepareCoopWakeLockReclaimsStaleDarwinStageAfterParentDisappears(t *testing.T) {
 	for _, test := range []struct {
 		name          string
@@ -202,7 +429,7 @@ func TestPrepareCoopWakeLockReclaimsStaleDarwinStageAfterParentDisappears(t *tes
 		{name: "non-directory parent", replaceParent: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			record := newDarwinWakeRestartStageRecordForTest(t)
+			record := newLegacyDarwinWakeRestartStageRecordForTest(t)
 			bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
 			if err != nil {
 				t.Fatal(err)
@@ -327,7 +554,8 @@ func TestDoctorDiagnosesCrashOrphanedDarwinRestartStage(t *testing.T) {
 }
 
 func TestDoctorFixRetriesExactPersistedDarwinRestartStageReclaim(t *testing.T) {
-	record := newDarwinWakeRestartStageRecordForTest(t)
+	root := canonicalWakeRoot(t.TempDir())
+	record := newDarwinWakeRestartStageRecordForRootTest(t, root, "codex")
 	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
 	if err != nil {
 		t.Fatal(err)
@@ -338,8 +566,6 @@ func TestDoctorFixRetriesExactPersistedDarwinRestartStageReclaim(t *testing.T) {
 	bound.file = nil
 	record.Schema = wakeRestartSchemaV1
 	record.Status = wakeRestartPending
-	record.Root = canonicalWakeRoot(t.TempDir())
-	record.Agent = "codex"
 	record.Generation = "abcdef0123456789abcdef0123456789"
 	record.Owner = validWakeResumeOwnerForTest()
 	evidence := bound.evidence
@@ -680,7 +906,7 @@ func TestDarwinPreviousCleanupFailurePreservesRecordAndSuccessorLock(t *testing.
 
 func TestDarwinRestartRetryReclaimsAndQuarantinesRefusedOwnedStage(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
-	refused := newDarwinWakeRestartStageRecordForTest(t)
+	refused := newDarwinWakeRestartStageRecordForRootTest(t, fixture.root, fixture.agent)
 	bound, err := bindWakeRestartCandidateAtPlatform(refused.Candidate, refused.StagePath)
 	if err != nil {
 		t.Fatal(err)
@@ -693,8 +919,6 @@ func TestDarwinRestartRetryReclaimsAndQuarantinesRefusedOwnedStage(t *testing.T)
 	refused.Schema = wakeRestartSchemaV1
 	refused.Status = wakeRestartRefused
 	refused.Reason = "prior cleanup refusal"
-	refused.Root = fixture.root
-	refused.Agent = fixture.agent
 	refused.Generation = fixture.lock.Lock.Generation
 	refused.Owner = fixture.owner
 	refused.BoundImage = &boundEvidence

--- a/internal/cli/wake_restart_stage_diagnostic_darwin_test.go
+++ b/internal/cli/wake_restart_stage_diagnostic_darwin_test.go
@@ -200,7 +200,7 @@ func TestDoctorFixReclaimsValidDarwinRestartStageWithoutLock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	record := newDarwinWakeRestartStageRecordForTest(t)
+	record := newDarwinWakeRestartStageRecordForRootTest(t, canonicalWakeRoot(root), "codex")
 	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
 	if err != nil {
 		t.Fatal(err)
@@ -212,8 +212,6 @@ func TestDoctorFixReclaimsValidDarwinRestartStageWithoutLock(t *testing.T) {
 	bound.file = nil
 	record.Schema = wakeRestartSchemaV1
 	record.Status = wakeRestartPending
-	record.Root = canonicalWakeRoot(root)
-	record.Agent = "codex"
 	record.Generation = "abcdef0123456789abcdef0123456789"
 	record.Owner = validWakeResumeOwnerForTest()
 	record.BoundImage = &evidence
@@ -322,7 +320,7 @@ func futureWakeRestartRecordRawForDoctorTest(t *testing.T, root string) []byte {
 func TestDoctorReportsRefusedSurvivingDarwinStageAsCleanupFailed(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)
-	record := newDarwinWakeRestartStageRecordForTest(t)
+	record := newDarwinWakeRestartStageRecordForRootTest(t, fixture.root, fixture.agent)
 	bound, err := bindWakeRestartCandidateAtPlatform(record.Candidate, record.StagePath)
 	if err != nil {
 		t.Fatal(err)
@@ -332,8 +330,6 @@ func TestDoctorReportsRefusedSurvivingDarwinStageAsCleanupFailed(t *testing.T) {
 	record.Schema = wakeRestartSchemaV1
 	record.Status = wakeRestartRefused
 	record.Reason = "restart execution refused"
-	record.Root = fixture.root
-	record.Agent = fixture.agent
 	record.Generation = fixture.lock.Lock.Generation
 	record.Owner = fixture.owner
 	evidence := bound.evidence

--- a/internal/cli/wake_restart_stage_linux.go
+++ b/internal/cli/wake_restart_stage_linux.go
@@ -8,6 +8,10 @@ func planWakeRestartStagePlatform(wakeImageEvidenceV1, string) (string, error) {
 	return "", nil
 }
 
+func planWakeRestartStageForRecordPlatform(wakeRestartRecord) (string, error) {
+	return "", nil
+}
+
 func validateWakeRestartStageStatePlatform(record wakeRestartRecord) error {
 	if record.StagePath != "" || record.BoundImage != nil {
 		return fmt.Errorf("linux wake restart record contains Darwin stage state")
@@ -29,5 +33,7 @@ func validateWakeRestartPersistedBoundPlatform(record wakeRestartRecord, _ wakeI
 func wakeRestartStageExistsPlatform(wakeRestartRecord) (bool, error) {
 	return false, nil
 }
+
+func wakeRestartStageUsesStableStatePlatform(string) (bool, error) { return false, nil }
 
 func reclaimWakeRestartRunningImagePlatform(wakeLock) error { return nil }

--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -173,11 +173,21 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 		result.Reason = err.Error()
 		return result, err
 	}
-	stagePath, err := planWakeRestartStagePlatform(candidate, requestID)
+	record := wakeRestartRecord{
+		Schema:    wakeRestartSchemaV1,
+		RequestID: requestID,
+		Status:    wakeRestartPending,
+		Root:      root,
+		Agent:     me,
+		Owner:     *owner,
+		Candidate: candidate,
+	}
+	stagePath, err := planWakeRestartStageForRecordPlatform(record)
 	if err != nil {
 		result.Reason = err.Error()
 		return result, err
 	}
+	record.StagePath = stagePath
 
 	agentDir, err := openWakeAgentDir(root, me)
 	if err != nil {
@@ -189,16 +199,6 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 	var expected wakeLockInspection
 	adopted := false
 	needsNotify := true
-	record := wakeRestartRecord{
-		Schema:    wakeRestartSchemaV1,
-		RequestID: requestID,
-		Status:    wakeRestartPending,
-		Root:      root,
-		Agent:     me,
-		Owner:     *owner,
-		Candidate: candidate,
-		StagePath: stagePath,
-	}
 	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
 		expected = inspectWakeLockAt(dirfd, agentDir, root, me)
 		if err := validateWakeRestartIncumbent(expected, root, me, *owner); err != nil {

--- a/internal/cli/wake_restart_unix_test.go
+++ b/internal/cli/wake_restart_unix_test.go
@@ -176,7 +176,7 @@ func prepareWakeRestartRecordForBoundResumeTest(
 	}
 }
 
-func TestRequestedAndBoundWakeImageEvidenceHasOnlyDarwinHardlinkCTimeException(t *testing.T) {
+func TestRequestedAndBoundWakeImageEvidenceAllowsDarwinStagedIdentity(t *testing.T) {
 	candidate, err := captureCurrentWakeImageEvidence()
 	if err != nil {
 		t.Fatal(err)
@@ -191,11 +191,12 @@ func TestRequestedAndBoundWakeImageEvidenceHasOnlyDarwinHardlinkCTimeException(t
 		t.Fatalf("ctime exception accepted=%v on %s", got, runtime.GOOS)
 	}
 	mutations := []struct {
-		name   string
-		mutate func(*wakeImageEvidenceV1)
+		name             string
+		acceptedOnDarwin bool
+		mutate           func(*wakeImageEvidenceV1)
 	}{
-		{name: "device", mutate: func(value *wakeImageEvidenceV1) { value.Device++ }},
-		{name: "inode", mutate: func(value *wakeImageEvidenceV1) { value.Inode++ }},
+		{name: "device", acceptedOnDarwin: true, mutate: func(value *wakeImageEvidenceV1) { value.Device++ }},
+		{name: "inode", acceptedOnDarwin: true, mutate: func(value *wakeImageEvidenceV1) { value.Inode++ }},
 		{name: "size", mutate: func(value *wakeImageEvidenceV1) { value.Size++ }},
 		{name: "digest", mutate: func(value *wakeImageEvidenceV1) { value.SHA256 = strings.Repeat("0", len(value.SHA256)) }},
 		{name: "version", mutate: func(value *wakeImageEvidenceV1) { value.EmbeddedVersion += ".other" }},
@@ -204,8 +205,9 @@ func TestRequestedAndBoundWakeImageEvidenceHasOnlyDarwinHardlinkCTimeException(t
 		t.Run(test.name, func(t *testing.T) {
 			changed := bound
 			test.mutate(&changed)
-			if sameRequestedAndBoundWakeImageEvidence(candidate, changed) {
-				t.Fatalf("%s delta was accepted", test.name)
+			want := runtime.GOOS == "darwin" && test.acceptedOnDarwin
+			if got := sameRequestedAndBoundWakeImageEvidence(candidate, changed); got != want {
+				t.Fatalf("%s delta accepted=%v, want %v", test.name, got, want)
 			}
 		})
 	}

--- a/internal/cli/wake_self_upgrade_e2e_darwin_test.go
+++ b/internal/cli/wake_self_upgrade_e2e_darwin_test.go
@@ -16,6 +16,7 @@ func TestDarwinWakeSelfUpgradeRealPTYStableSymlink(t *testing.T) {
 	if testing.Short() {
 		t.Skip("real Darwin PTY self-upgrade E2E")
 	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	stable, oldBinary, newBinary, root, oldVersion, newVersion := prepareWakeSelfUpgradeE2E(t)
 	testBinary, err := os.Executable()
 	if err != nil {

--- a/internal/cli/wake_self_upgrade_unix.go
+++ b/internal/cli/wake_self_upgrade_unix.go
@@ -572,10 +572,6 @@ func maintainWakeSelfUpgrade(
 	if err != nil {
 		return wakeSelfUpgradeDecision{}, err
 	}
-	stagePath, err := planWakeRestartStagePlatform(evidence, requestID)
-	if err != nil {
-		return wakeSelfUpgradeDecision{}, err
-	}
 	record := wakeRestartRecord{
 		Schema:             wakeRestartSchemaV1,
 		RequestID:          requestID,
@@ -586,9 +582,13 @@ func maintainWakeSelfUpgrade(
 		Generation:         inspection.Lock.Generation,
 		Owner:              *inspection.Lock.ResumeOwner,
 		Candidate:          evidence,
-		StagePath:          stagePath,
 		PreviousBoundImage: previousDarwinWakeRestartStageForLock(inspection.Lock),
 	}
+	stagePath, err := planWakeRestartStageForRecordPlatform(record)
+	if err != nil {
+		return wakeSelfUpgradeDecision{}, err
+	}
+	record.StagePath = stagePath
 	decision, err = publishWakeSelfUpgradePending(agentDir, inspection, record, decision)
 	if err != nil {
 		return decision, err


### PR DESCRIPTION
Root-cause fix for the 2026-08-18 stale-lock incident (amq-ju3; hotfix was #572, E2E #574, diagnostics #575).

- Darwin wake restart images are staged under the machine-local AMQ state dir (`DefaultLaunchStateDir()/wake-stages/<sha256(tree identity)>/<handle>/<id>/`, mode 0700), never adjacent to the running executable — a Homebrew upgrade removing the old Cellar dir can no longer orphan a wake lock.
- Hardlink first; on EXDEV exclusive copy + fsync + exact sha256 verification; evidence binds the staged file's own identity.
- Empty stage hierarchy pruned on cleanup; legacy adjacent records remain reclaimable; refuses a state dir inside/symlinked into AM_ROOT.
- Tests: survives `rm -rf` of the candidate dir (real fs), cross-device copy (seam), wrong-bytes-after-copy rejection, two-root isolation, prune, 0700, AM_ROOT containment; Linux/Windows vet green.

Peer review: lead execution gate (delegated 7-mutant review: adjacent-staging, evidence binding, prune, root hash, legacy, mode all red) + codex authored. Pushed by the lead from codex's approved worktree (its harness blocks GitHub writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestRequestedAndBoundWakeImageEvidenceHasOnlyDarwinHardlinkCTimeException: renamed to TestRequestedAndBoundWakeImageEvidenceAllowsDarwinStagedIdentity; the retained behavior is now the staged-image identity allowance (hardlink same-fs keeps the ctime exception; EXDEV copy binds the staged file identity), same assertions extended, none removed.
END_WAKE_TEST_CHANGE_JUSTIFICATION
