### PR TITLE
fix(launch): bind wrapper identity into tickets and harden strict decode

### DIFF
--- a/internal/launch/execidentity.go
+++ b/internal/launch/execidentity.go
@@ -133,6 +133,18 @@ func MarshalExecutableIdentity(identity ExecutableIdentity) ([]byte, error) {
 	return bytes.TrimSpace(buf.Bytes()), nil
 }
 
+func probeExecutableIdentityJSON(path string) (string, error) {
+	identity, err := ProbeExecutableIdentity(path)
+	if err != nil {
+		return "", err
+	}
+	raw, err := MarshalExecutableIdentity(identity)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
 // ConsultedExecutable is the Prepare-subject binding for one provider
 // executable. Requested is the caller string; Consulted is the PATH lookup or
 // absolute path that was probed. Identity is MarshalExecutableIdentity JSON.

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -68,6 +68,7 @@ type ExecutionTicket struct {
 	InjectorExecutable         string   `json:"injector_executable,omitempty"`
 	InjectorExecutableIdentity string   `json:"injector_executable_identity,omitempty"`
 	Wrapper                    *Wrapper `json:"wrapper,omitempty"`
+	WrapperExecutableIdentity  string   `json:"wrapper_executable_identity,omitempty"`
 
 	TargetArgv    []string                 `json:"target_argv"`
 	DynamicArgv   []DynamicArg             `json:"dynamic_argv,omitempty"`
@@ -158,6 +159,16 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 			return ExecutionTicket{}, fmt.Errorf("injector executable: %w", err)
 		}
 	}
+	var wrapperIdentity string
+	if request.Wrapper != nil {
+		if err := validateWrapperFile(request.Wrapper); err != nil {
+			return ExecutionTicket{}, fmt.Errorf("wrapper: %w", err)
+		}
+		wrapperIdentity, err = probeExecutableIdentityJSON(request.Wrapper.Executable)
+		if err != nil {
+			return ExecutionTicket{}, fmt.Errorf("wrapper executable: %w", err)
+		}
+	}
 	env := cloneExecutionEnv(request.TargetEnv)
 	digest, err := executionEnvDigest(env)
 	if err != nil {
@@ -175,7 +186,8 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 		InitialInput: clonePlannedInitialInput(request.InitialInput),
 		TargetEnv:    env, EnvDigest: digest, State: request.State, Reason: request.Reason,
 		Execution: execution, InjectorExecutable: injector, InjectorExecutableIdentity: injectorID,
-		CallerContext: cloneCallerContext(request.CallerContext), Wrapper: cloneWrapper(request.Wrapper),
+		WrapperExecutableIdentity: wrapperIdentity,
+		CallerContext:             cloneCallerContext(request.CallerContext), Wrapper: cloneWrapper(request.Wrapper),
 	}
 	if ticket.State == "" {
 		ticket.State = ExecutionPending
@@ -229,12 +241,18 @@ func (ticket ExecutionTicket) Validate() error {
 	} else if ticket.InjectorExecutable != "" || ticket.InjectorExecutableIdentity != "" {
 		return fmt.Errorf("injector executable identity exists without injector via")
 	}
+	if ticket.Wrapper == nil && ticket.WrapperExecutableIdentity != "" {
+		return fmt.Errorf("wrapper executable identity exists without wrapper")
+	}
 	if len(ticket.TargetArgv) == 0 || strings.TrimSpace(ticket.TargetArgv[0]) == "" {
 		return fmt.Errorf("target argv is required")
 	}
 	if ticket.Wrapper != nil {
 		if err := ticket.Wrapper.Validate(); err != nil {
 			return fmt.Errorf("wrapper: %w", err)
+		}
+		if strings.TrimSpace(ticket.WrapperExecutableIdentity) == "" {
+			return fmt.Errorf("wrapper executable identity is required")
 		}
 		prefix := append([]string{ticket.Wrapper.Executable}, ticket.Wrapper.Args...)
 		providerIndex := len(prefix)
@@ -1014,6 +1032,13 @@ func ValidateExecutionEnvelope(root *fsq.DeliveryRoot, ticket ExecutionTicket, e
 		targetProvider, targetProviderID, targetProviderErr := canonicalFile(ticket.TargetArgv[providerIndex])
 		if targetProviderErr != nil || targetProvider != ticket.ProviderExecutable || targetProviderID != ticket.ProviderExecutableIdentity {
 			return fmt.Errorf("provider target identity changed")
+		}
+		identity, identityErr := probeExecutableIdentityJSON(ticket.Wrapper.Executable)
+		if identityErr != nil || identity != ticket.WrapperExecutableIdentity {
+			if identityErr == nil {
+				identityErr = fmt.Errorf("identity tuple differs from the execution ticket")
+			}
+			return fmt.Errorf("wrapper executable identity changed: %w", identityErr)
 		}
 		if err := validateWrapperFile(ticket.Wrapper); err != nil {
 			return fmt.Errorf("wrapper executable changed: %w", err)

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -346,6 +346,58 @@ func TestPrepareExecutionRejectsRetargetedProviderWithoutPromotion(t *testing.T)
 	}
 }
 
+func TestPrepareExecutionRejectsReplacedWrapperWithoutPromotion(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "68686868-6868-4868-8868-686868686868"
+	wrapper := testWrapper(t)
+	targetArgv := []string{wrapper.Executable, "--profile", "lead", fixture.provider, "--session-id", nonce}
+	lease, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeMint, Provider: ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: targetArgv, TargetEnv: map[string]string{"LANG": "C"}, Wrapper: wrapper,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteExecutionTicket(fixture.root, lease, ticket); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(fixture.root, lease, ConversationRecord{
+		Version: ConversationVersion, Handle: "claude", State: CapturePending, LaunchNonce: nonce,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	replacement := wrapper.Executable + ".replacement"
+	if err := os.WriteFile(replacement, []byte("replacement wrapper"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, wrapper.Executable); err != nil {
+		t.Fatal(err)
+	}
+	_, err = PrepareExecution(fixture.root, "claude", nonce, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: wrapper.Executable,
+		TargetArgv: targetArgv, Environment: []string{"LANG=C"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "wrapper executable identity changed") {
+		t.Fatalf("wrapper replacement error = %v", err)
+	}
+	record, loadErr := LoadConversation(fixture.root, "claude")
+	if loadErr != nil || record.State != CapturePending {
+		t.Fatalf("conversation mutated = %#v, %v", record, loadErr)
+	}
+}
+
 func TestPrepareExecutionRejectsRetargetedInjectorWithoutPromotion(t *testing.T) {
 	fixture := newExecutionFixture(t)
 	nonce := "67676767-6767-4767-8767-676767676767"

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -398,6 +398,48 @@ func TestPrepareExecutionRejectsReplacedWrapperWithoutPromotion(t *testing.T) {
 	}
 }
 
+func TestValidateExecutionEnvelopeRejectsRetargetedWrapper(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "69696969-6969-4969-8969-696969696969"
+	dir := t.TempDir()
+	first, second := filepath.Join(dir, "wrapper-one"), filepath.Join(dir, "wrapper-two")
+	link := filepath.Join(dir, "wrapper")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink(first, link); err != nil {
+		t.Fatal(err)
+	}
+	targetArgv := []string{link, "--profile", "lead", fixture.provider, "--session-id", nonce}
+	ticket, err := NewExecutionTicket(ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: nonce, Mode: AdapterModeMint, Provider: ClaudeProvider, ConversationID: nonce,
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: targetArgv, TargetEnv: map[string]string{"LANG": "C"}, Wrapper: &Wrapper{Executable: link, Args: []string{"--profile", "lead"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: fixture.amq, ProviderExecutable: link,
+		TargetArgv: targetArgv, Environment: []string{"LANG=C"},
+	}
+	if err := ValidateExecutionEnvelope(fixture.root, ticket, envelope); err != nil {
+		t.Fatalf("unchanged wrapper rejected: %v", err)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(second, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateExecutionEnvelope(fixture.root, ticket, envelope); err == nil || !strings.Contains(err.Error(), "wrapper executable identity changed") {
+		t.Fatalf("retargeted wrapper error = %v", err)
+	}
+}
+
 func TestPrepareExecutionRejectsRetargetedInjectorWithoutPromotion(t *testing.T) {
 	fixture := newExecutionFixture(t)
 	nonce := "67676767-6767-4767-8767-676767676767"

--- a/internal/launch/wrapper.go
+++ b/internal/launch/wrapper.go
@@ -46,6 +46,9 @@ func validateWrapperFile(wrapper *Wrapper) error {
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("executable must resolve to one regular file")
 	}
+	if err := validateWrapperExecutable(wrapper.Executable, info.Mode()); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/launch/wrapper_executable_unix.go
+++ b/internal/launch/wrapper_executable_unix.go
@@ -1,0 +1,20 @@
+//go:build unix
+
+package launch
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func validateWrapperExecutable(path string, mode os.FileMode) error {
+	if mode.Perm()&0o111 == 0 {
+		return fmt.Errorf("executable must have an execute bit")
+	}
+	if err := unix.Access(path, unix.X_OK); err != nil {
+		return fmt.Errorf("executable is not executable by current user: %w", err)
+	}
+	return nil
+}

--- a/internal/launch/wrapper_executable_windows.go
+++ b/internal/launch/wrapper_executable_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package launch
+
+import (
+	"fmt"
+	"os"
+)
+
+func validateWrapperExecutable(_ string, mode os.FileMode) error {
+	if mode.Perm()&0o111 == 0 {
+		return fmt.Errorf("executable must have an execute bit")
+	}
+	return nil
+}

--- a/internal/launch/wrapper_test.go
+++ b/internal/launch/wrapper_test.go
@@ -69,6 +69,19 @@ func TestWrapperValidationAcceptsRegularFileAndResolvableSymlink(t *testing.T) {
 	}
 }
 
+func TestWrapperValidationRejectsNonExecutableRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wrapper")
+	if err := os.WriteFile(path, []byte("not executable"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateWrapperFile(&Wrapper{Executable: path}); err == nil || !strings.Contains(err.Error(), "execute") {
+		t.Fatalf("non-executable wrapper error = %v", err)
+	}
+}
+
 func TestWrapperValidateRejectsUnsafeSyntax(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/launchapi/intent.go
+++ b/launchapi/intent.go
@@ -301,6 +301,9 @@ func requireObjectFields(raw json.RawMessage, context string, required ...string
 }
 
 func decodeStrictJSON(data []byte, target any) error {
+	if !utf8.Valid(data) {
+		return fmt.Errorf("invalid UTF-8")
+	}
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {

--- a/launchapi/intent_test.go
+++ b/launchapi/intent_test.go
@@ -60,6 +60,14 @@ func TestLaunchIntentRejectsAMQOwnedFields(t *testing.T) {
 	}
 }
 
+func TestDecodeLaunchIntentRejectsInvalidUTF8(t *testing.T) {
+	raw := append([]byte(`{"intent_version":1,"participants":[{"handle":"operator","runnable":false,"note":"`), 0xff)
+	raw = append(raw, []byte(`"}]}`)...)
+	if _, err := DecodeLaunchIntentV1(raw); err == nil || !strings.Contains(err.Error(), "invalid UTF-8") {
+		t.Fatalf("DecodeLaunchIntentV1 error = %v", err)
+	}
+}
+
 func TestLaunchIntentNonRunnableIsHandleOnly(t *testing.T) {
 	tests := []struct {
 		name string

--- a/launchapi/requests_test.go
+++ b/launchapi/requests_test.go
@@ -53,6 +53,14 @@ func TestPublicRequestCodecsRejectUnknownAndMalformedAuthority(t *testing.T) {
 	}
 }
 
+func TestDecodeInspectRequestRejectsInvalidUTF8(t *testing.T) {
+	raw := append([]byte(`{"request_version":1,"target":{"project_root":"`), 0xff)
+	raw = append(raw, []byte(`","base_root":"","session_root":"/tmp/session","session":"collab"}}`)...)
+	if _, err := DecodeInspectRequestV1(raw); err == nil || !strings.Contains(err.Error(), "invalid UTF-8") {
+		t.Fatalf("DecodeInspectRequestV1 error = %v", err)
+	}
+}
+
 func TestApplyRequestV1RejectsDigestAndDecisionReplayShapes(t *testing.T) {
 	root := filepath.Clean(t.TempDir())
 	intent, err := DecodeLaunchIntentV1([]byte(validIntentJSON(t)))


### PR DESCRIPTION
Round-4a mutation sweep of today's WB3 code in `internal/launch` + `launchapi` (bead amq-3n8): placement, initial_input, base_root, on_live, caller_context, provider identity, subject_schema/compat all clear by execution. Three real survivors fixed:

- **fix(launch)**: the execution ticket stored only the wrapper *path*; `ValidateExecutionEnvelope` accepted a different regular file at that path. The ticket now carries the wrapper's probed identity JSON and exec-time validation re-probes and refuses replacement (incl. symlink retarget).
- **fix(launch)**: strict decoders (`decodeStrictJSON`, shared by intent + request decoders) reject invalid UTF-8 before `encoding/json` can silently replace bytes; a wrapper executable must have an execute bit and pass `access(X_OK)` at Prepare (mode-only on Windows), typed refusal instead of a launch-time failure.
- **test(launch)**: symlink-retarget refusal coverage.

Peer review: lead execution gate on each slice (focused suites green; red repros before fixes). Pushed by the lead from codex's approved worktree (its harness blocks GitHub writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ