### PR TITLE
fix(launch): refuse --apply with --prepare before requiring --plan

### DIFF
--- a/internal/cli/launch_public_api.go
+++ b/internal/cli/launch_public_api.go
@@ -15,9 +15,6 @@ import (
 
 func runPublicLaunch(common *commonFlags, session, launcher, planSource string, prepareOnly bool, applySource, placementJSON string, fs *flag.FlagSet) error {
 	planExplicit, applyExplicit := flagWasVisited(fs, "plan"), flagWasVisited(fs, "apply")
-	if prepareOnly && !planExplicit {
-		return UsageError("--prepare requires --plan")
-	}
 	if prepareOnly && !common.JSON {
 		return UsageError("--prepare requires --json")
 	}
@@ -26,6 +23,9 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 	}
 	if applyExplicit && (planExplicit || prepareOnly) {
 		return UsageError("--apply is mutually exclusive with --plan and --prepare")
+	}
+	if prepareOnly && !planExplicit {
+		return UsageError("--prepare requires --plan")
 	}
 	if applyExplicit && (flagWasVisited(fs, "session") || flagWasVisited(fs, "launcher") || common.rootExplicit()) {
 		return UsageError("--apply takes its target and launcher from ApplyRequestV1")

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -184,6 +184,7 @@ func TestPublicLaunchModeFlagRefusals(t *testing.T) {
 		{name: "rebind is legacy only", args: []string{"--plan", "intent.json", "--rebind"}, want: "legacy launch decision flags"},
 		{name: "allow fresh is legacy only", args: []string{"--plan", "intent.json", "--allow-fresh-fallback"}, want: "legacy launch decision flags"},
 		{name: "mixed apply and prepare", args: []string{"--apply", "apply.json", "--prepare", "--plan", "intent.json", "--json"}, want: "mutually exclusive"},
+		{name: "apply and prepare without plan", args: []string{"--apply", "apply.json", "--prepare", "--json"}, want: "mutually exclusive"},
 		{name: "apply launcher override", args: []string{"--apply", "apply.json", "--launcher", "commands", "--json"}, want: "takes its target"},
 		{name: "placement without plan", args: []string{"--placement", `{"target":"session","layout":"columns"}`, "--json"}, want: "--placement requires --plan"},
 		{name: "apply with placement flag", args: []string{"--apply", "apply.json", "--json", "--placement", `{"target":"session","layout":"columns"}`}, want: "takes placement"},

--- a/internal/cli/wake_check_unix_test.go
+++ b/internal/cli/wake_check_unix_test.go
@@ -1390,16 +1390,16 @@ func assertWakeCheckTreeUnchanged(
 
 func TestSameWakeCheckInspectionExistenceEachClause(t *testing.T) {
 	missing := wakeLockInspection{}
-	present := wakeLockInspection{Exists: true, Status: wakeLockValid}
+	present := wakeLockInspection{Exists: true}
 	if !sameWakeCheckInspection(missing, wakeLockInspection{}) {
 		t.Fatal("two missing inspections not equal")
 	}
 	if sameWakeCheckInspection(missing, present) || sameWakeCheckInspection(present, missing) {
 		t.Fatal("missing vs present inspections treated as equal")
 	}
-	other := present
-	other.Status = wakeLockStale
-	if sameWakeCheckInspection(present, other) {
+	stale := wakeLockInspection{Exists: true, Status: wakeLockStale}
+	valid := wakeLockInspection{Exists: true, Status: wakeLockValid}
+	if sameWakeCheckInspection(valid, stale) {
 		t.Fatal("status mismatch treated as equal")
 	}
 }


### PR DESCRIPTION
## Summary
- Checks `--apply`/`--prepare` mutual exclusion before `--prepare requires --plan`, so `--apply apply.json --prepare --json` (no `--plan`) is refused. Codex's 0nk review showed `prepareOnly` in that condition was otherwise unreachable.
- Tightens `TestSameWakeCheckInspectionExistenceEachClause` so a missing-vs-present comparison uses equal remaining fields; flipping the existence guard from `||` to `&&` now fails.

Follow-up to #579 on `094013d`. Does not rewrite the merged 0nk branch.

## Test plan
- [x] `go test ./internal/cli -run 'PublicLaunch|Adoption|TestSameWakeCheckInspectionExistenceEachClause'`
- [x] `make ci` via pre-push
- [ ] GitHub CI green
- [ ] Codex execute-review of HEAD `b814726`


Made with [Cursor](https://cursor.com)