### PR TITLE
fix(launch): make lease release retryable and notify/revert lease-bounded

### DIFF
--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -813,7 +813,7 @@ func RecordCodexNotify(root *fsq.DeliveryRoot, handle, nonce, amqExecutable stri
 }
 
 func recordCodexNotify(root *fsq.DeliveryRoot, handle, nonce, amqExecutable string, raw []byte, hook prepareExecutionHook) (result CodexNotifyResult, returnErr error) {
-	lease, err := AcquireLease(root, nonce)
+	lease, err := acquireExecutionLease(root, nonce)
 	if err != nil {
 		return result, err
 	}
@@ -957,7 +957,7 @@ func acquireExecutionLease(root *fsq.DeliveryRoot, nonce string) (*Lease, error)
 // mint generation created by this exact ticket; an older resumed identity is
 // retained.
 func RevertExecution(root *fsq.DeliveryRoot, handle, nonce string) (returnErr error) {
-	lease, err := AcquireLease(root, nonce)
+	lease, err := acquireExecutionLease(root, nonce)
 	if err != nil {
 		return err
 	}

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -292,6 +292,99 @@ func TestPrepareExecutionRefusesDifferentLauncherLeaseImmediately(t *testing.T) 
 	}
 }
 
+func TestRecordCodexNotifyWaitsForOwnLeaseAndIsIdempotent(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "58585858-5858-4858-8858-585858585858"
+	ticket := seedPendingCodexNotifyExecution(t, fixture, nonce)
+	blocker, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type result struct {
+		notify CodexNotifyResult
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		notify, notifyErr := RecordCodexNotify(fixture.root, "codex", nonce, fixture.amq, codexNotifyTestPayload(testConversationID, ticket.Cwd))
+		done <- result{notify: notify, err: notifyErr}
+	}()
+	time.Sleep(200 * time.Millisecond)
+	select {
+	case early := <-done:
+		t.Fatalf("notify returned before own lease release: %#v", early)
+	default:
+	}
+	if err := blocker.Release(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-done:
+		if got.err != nil || got.notify.ConversationID != testConversationID {
+			t.Fatalf("notify after own lease release = %#v, %v", got.notify, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("notify did not acquire the released own lease")
+	}
+	second, err := RecordCodexNotify(fixture.root, "codex", nonce, fixture.amq, codexNotifyTestPayload(testConversationID, ticket.Cwd))
+	if err != nil || !second.AlreadyReady {
+		t.Fatalf("idempotent notify = %#v, %v", second, err)
+	}
+}
+
+func TestRevertExecutionWaitsForOwnLeaseAndRefusesForeignLease(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	nonce := "59595959-5959-4959-8959-595959595959"
+	_, envelope := seedPendingMintExecution(t, fixture, nonce)
+	if prepared, err := PrepareExecution(fixture.root, "claude", nonce, envelope); err != nil || prepared.State != ExecutionAcknowledged {
+		t.Fatalf("prepare before revert = %#v, %v", prepared, err)
+	}
+	blocker, err := AcquireLease(fixture.root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- RevertExecution(fixture.root, "claude", nonce) }()
+	time.Sleep(200 * time.Millisecond)
+	select {
+	case early := <-done:
+		t.Fatalf("revert returned before own lease release: %v", early)
+	default:
+	}
+	if err := blocker.Release(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("revert after own lease release = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("revert did not acquire the released own lease")
+	}
+	if got, err := LoadExecutionTicket(fixture.root, "claude"); err != nil || got.State != ExecutionPending {
+		t.Fatalf("reverted execution ticket = %#v, %v", got, err)
+	}
+
+	foreignFixture := newExecutionFixture(t)
+	foreignNonce := "60606060-6060-4060-8060-606060606060"
+	seedPendingMintExecution(t, foreignFixture, foreignNonce)
+	foreign, err := AcquireLease(foreignFixture.root, "foreign-nonce")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = foreign.Release() }()
+	started := time.Now()
+	err = RevertExecution(foreignFixture.root, "claude", foreignNonce)
+	var held *LeaseHeldError
+	if !errors.As(err, &held) || held.Nonce != "foreign-nonce" {
+		t.Fatalf("foreign lease refusal = %v, want LeaseHeldError for foreign nonce", err)
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("foreign lease refusal took %s, want immediate", elapsed)
+	}
+}
+
 func TestPrepareExecutionRejectsRetargetedProviderWithoutPromotion(t *testing.T) {
 	fixture := newExecutionFixture(t)
 	nonce := "66666666-6666-4666-8666-666666666666"

--- a/internal/launch/lease.go
+++ b/internal/launch/lease.go
@@ -105,6 +105,13 @@ var inspectProcess = inspectProcessPlatform
 
 var liveLeaseSecrets sync.Map
 
+// These seams keep failure handling testable without changing the filesystem
+// capability contract. Production calls use the standard implementations.
+var leaseRandomRead = rand.Read
+var removeLeaseRecord = func(root *fsq.DeliveryRoot) error {
+	return root.Remove(filepath.Join(bindingDirectory, leaseFilename))
+}
+
 type LeaseInspection struct {
 	State    LeaseState
 	Evidence string
@@ -130,6 +137,7 @@ func AcquireLease(root *fsq.DeliveryRoot, nonce string) (*Lease, error) {
 			return nil, err
 		}
 	}
+	var secret uint64
 	if err := withLeaseInterlock(root, func() error {
 		inspection, inspectErr := inspectLeaseLocked(root)
 		if inspectErr != nil {
@@ -141,15 +149,25 @@ func AcquireLease(root *fsq.DeliveryRoot, nonce string) (*Lease, error) {
 		case LeaseUnverified:
 			return &LeaseUnverifiedError{Evidence: inspection.Evidence}
 		case LeaseStale, LeaseMissing:
-			return writeLeaseRecord(root, leaseRecord{Version: LeaseVersion, Holder: holder, LaunchNonce: nonce})
+			secret, err = newSecret()
+			if err != nil {
+				return err
+			}
+			if _, loaded := liveLeaseSecrets.LoadOrStore(secret, struct{}{}); loaded {
+				return fmt.Errorf("lease secret collision")
+			}
+			if err := writeLeaseRecord(root, leaseRecord{Version: LeaseVersion, Holder: holder, LaunchNonce: nonce}); err != nil {
+				liveLeaseSecrets.Delete(secret)
+				return err
+			}
+			return nil
 		default:
 			return fmt.Errorf("unknown lease state %q", inspection.State)
 		}
 	}); err != nil {
 		return nil, err
 	}
-	lease := &Lease{root: root, nonce: nonce, holder: holder, secret: newSecret()}
-	liveLeaseSecrets.Store(lease.secret, struct{}{})
+	lease := &Lease{root: root, nonce: nonce, holder: holder, secret: secret}
 	return lease, nil
 }
 
@@ -213,11 +231,13 @@ func (l *Lease) Release() error {
 		if inspection.State != LeaseValid || inspection.Nonce != l.nonce {
 			return fmt.Errorf("launch lease is no longer held by this process")
 		}
-		return l.root.Remove(filepath.Join(bindingDirectory, leaseFilename))
+		return removeLeaseRecord(l.root)
 	})
-	l.released = true
-	liveLeaseSecrets.Delete(l.secret)
-	l.secret = 0
+	if err == nil {
+		l.released = true
+		liveLeaseSecrets.Delete(l.secret)
+		l.secret = 0
+	}
 	return err
 }
 
@@ -394,16 +414,23 @@ func generateNonce() (string, error) {
 		buf[0:4], buf[4:6], buf[6:8], buf[8:10], buf[10:16]), nil
 }
 
-func newSecret() uint64 {
+func newSecret() (uint64, error) {
 	var buf [8]byte
-	if _, err := rand.Read(buf[:]); err != nil {
-		return 1
+	n, err := leaseRandomRead(buf[:])
+	if err != nil {
+		return 0, fmt.Errorf("generate lease secret: %w", err)
+	}
+	if n != len(buf) {
+		return 0, fmt.Errorf("generate lease secret: short random read: got %d bytes, want %d", n, len(buf))
 	}
 	secret := binary.BigEndian.Uint64(buf[:])
 	if secret == 0 {
-		return 1
+		return 0, fmt.Errorf("generate lease secret: zero value")
 	}
-	return secret
+	if _, loaded := liveLeaseSecrets.Load(secret); loaded {
+		return 0, fmt.Errorf("generate lease secret: collision")
+	}
+	return secret, nil
 }
 
 func evidenceOr(base string, err error) string {

--- a/internal/launch/lease_test.go
+++ b/internal/launch/lease_test.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"os"
@@ -39,6 +40,80 @@ func TestAcquireLeaseExclusiveAndRelease(t *testing.T) {
 	}
 	if err := second.Release(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestLeaseReleaseRetriesAfterRemovalFailure(t *testing.T) {
+	dir, root := openTestRoot(t)
+	lease, err := AcquireLease(root, "retry-release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	injected := errors.New("injected lease removal failure")
+	oldRemove := removeLeaseRecord
+	calls := 0
+	removeLeaseRecord = func(root *fsq.DeliveryRoot) error {
+		calls++
+		if calls == 1 {
+			return injected
+		}
+		return oldRemove(root)
+	}
+	t.Cleanup(func() { removeLeaseRecord = oldRemove })
+
+	if err := lease.Release(); !errors.Is(err, injected) {
+		t.Fatalf("first Release = %v, want injected failure", err)
+	}
+	if lease.released || lease.secret == 0 {
+		t.Fatalf("failed Release discarded capability: released=%v secret=%d", lease.released, lease.secret)
+	}
+	if _, err := os.Stat(LeasePath(dir)); err != nil {
+		t.Fatalf("lease record after failed Release = %v", err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("second Release = %v", err)
+	}
+	if _, err := os.Stat(LeasePath(dir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lease record after successful retry = %v, want absent", err)
+	}
+}
+
+func TestAcquireLeaseRNGFailureDoesNotPublishLease(t *testing.T) {
+	dir, root := openTestRoot(t)
+	injected := errors.New("injected RNG failure")
+	oldRandomRead := leaseRandomRead
+	leaseRandomRead = func([]byte) (int, error) { return 0, injected }
+	t.Cleanup(func() { leaseRandomRead = oldRandomRead })
+
+	if _, err := AcquireLease(root, "rng-failure"); !errors.Is(err, injected) {
+		t.Fatalf("AcquireLease = %v, want injected RNG failure", err)
+	}
+	if _, err := os.Stat(LeasePath(dir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lease record after RNG failure = %v, want absent", err)
+	}
+}
+
+func TestNewSecretRejectsZeroAndCollision(t *testing.T) {
+	oldRandomRead := leaseRandomRead
+	t.Cleanup(func() { leaseRandomRead = oldRandomRead })
+
+	leaseRandomRead = func(buf []byte) (int, error) {
+		clear(buf)
+		return len(buf), nil
+	}
+	if _, err := newSecret(); err == nil || !strings.Contains(err.Error(), "zero") {
+		t.Fatalf("zero secret = %v, want zero-value error", err)
+	}
+
+	const secret = uint64(0x0102030405060708)
+	liveLeaseSecrets.Store(secret, struct{}{})
+	t.Cleanup(func() { liveLeaseSecrets.Delete(secret) })
+	leaseRandomRead = func(buf []byte) (int, error) {
+		binary.BigEndian.PutUint64(buf, secret)
+		return len(buf), nil
+	}
+	if _, err := newSecret(); err == nil || !strings.Contains(err.Error(), "collision") {
+		t.Fatalf("colliding secret = %v, want collision error", err)
 	}
 }
 


### PR DESCRIPTION
Bead amq-68v — ChatGPT Pro review A findings 29, 30, 20.

- `Release` keeps the lease unreleased and the live secret intact when `os.Remove` fails, so a second `Release` can succeed (previously the valid lease file stayed on disk with no retry capability).
- `newSecret` fails closed on RNG error, short read, zero, or collision instead of returning the constant `1` (which made every live lease share one secret).
- `__codex-notify` and `RevertExecution` go through the bounded same-nonce `acquireExecutionLease` (10s / 50ms) so a transiently held lease makes them wait and complete idempotently; a foreign nonce is refused immediately.

Review: execution-gated, 8/8 mutants killed (release-retry, swallow, RNG→1, zero, collision, notify no-retry, revert no-retry, foreign nonce); `go test ./internal/launch`, vet, gofmt, diff-check clean; local pre-push `make ci` green.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ