### PR TITLE
fix(launch): make execution policy trust-bearing and reject unsafe initial input

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -43,11 +43,19 @@ The initial-input carrier is typed. Claude and Codex currently advertise
 `argument`; AMQ appends its exact text as the final provider argv element.
 `stdin` and `file` remain typed but unadvertised and return
 `initial_input_unsupported` until real stdin/file seams exist. Content is
-limited to 262,144 UTF-8 bytes without NUL. Content changes the plan and
-subject digests but not the trust digest.
+limited to 262,144 UTF-8 bytes without C0 controls, DEL, CR, or LF, and must
+not begin with `-`; invalid text returns a typed `initial_input_control` or
+`initial_input_leading_dash` validation code before Prepare inspects the
+target. Content changes the plan and subject digests but not the trust digest.
+Initial input is a one-time bootstrap carrier: a resume plan never appends it
+again. The normalized execution and wake policy enters both the plan and trust
+digests, so any non-default execution, wake, or injector policy is
+trust-bearing and requires fresh trust for the exact policy.
 Claude admits one `--allowedTools <comma-separated-list>` pair. Codex admits
 ordered `-c model_reasoning_effort=<value>` pairs with values `minimal`, `low`,
 `medium`, `high`, or `xhigh`; duplicate keys and unknown keys or values reject.
+Every `env_overlay` key uses the POSIX environment grammar
+`[A-Za-z_][A-Za-z0-9_]*`; shell syntax such as `X;touch /tmp/pwn` is refused.
 
 An optional participant `wrapper` contains a clean absolute `executable` path
 and static `args`. The path must resolve to one regular file; resolvable

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -111,11 +111,26 @@ func appendInitialInput(plan *AgentPlan, input *InitialInputRequest) error {
 	if input.Kind != InitialInputArgument {
 		return fmt.Errorf("initial input kind %q is unsupported", input.Kind)
 	}
-	if !validDigest(input.SHA256) || strings.ContainsRune(input.Value, 0) {
+	if !validDigest(input.SHA256) {
 		return fmt.Errorf("initial input is invalid")
+	}
+	if err := validateInitialInputText(input.Value); err != nil {
+		return err
 	}
 	plan.Argv = append(plan.Argv, input.Value)
 	plan.InitialInput = &PlannedInitialInput{Kind: input.Kind, SHA256: input.SHA256, ArgvIndex: len(plan.Argv) - 1}
+	return nil
+}
+
+func validateInitialInputText(value string) error {
+	if strings.HasPrefix(value, "-") {
+		return fmt.Errorf("initial input must not begin with '-'")
+	}
+	for _, r := range value {
+		if r <= 0x1f || r == 0x7f {
+			return fmt.Errorf("initial input contains control character")
+		}
+	}
 	return nil
 }
 

--- a/internal/launch/adapter_env.go
+++ b/internal/launch/adapter_env.go
@@ -9,6 +9,7 @@ import (
 type valueRule func(string) bool
 
 var safeEnvironmentValue = regexp.MustCompile(`^[A-Za-z0-9_.@+:-]{1,128}$`).MatchString
+var validPOSIXEnvironmentKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString
 
 func commonCommittedEnvRules() map[string]valueRule {
 	return map[string]valueRule{

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -182,6 +183,33 @@ func TestAdaptersAppendTypedInitialInputAfterOwnedArguments(t *testing.T) {
 			}
 			if plan.Argv[len(plan.Argv)-1] != text || plan.InitialInput == nil || plan.InitialInput.ArgvIndex != len(plan.Argv)-1 {
 				t.Fatalf("initial input plan = %#v", plan)
+			}
+		})
+	}
+}
+
+func TestAdaptersRejectUnsafeInitialInputBeforePlanning(t *testing.T) {
+	for _, provider := range []string{ClaudeProvider, CodexProvider} {
+		t.Run(provider, func(t *testing.T) {
+			project, executable := testExecutable(t, provider)
+			for _, text := range []string{"-option", "line\nfeed", "tab\tvalue", "delete\x7f"} {
+				t.Run(fmt.Sprintf("%q", text), func(t *testing.T) {
+					request := planRequest(project, provider)
+					sum := sha256.Sum256([]byte(text))
+					request.InitialInput = &InitialInputRequest{
+						Kind: InitialInputArgument, Value: text, SHA256: "sha256:" + hex.EncodeToString(sum[:]),
+					}
+					var err error
+					switch provider {
+					case ClaudeProvider:
+						_, err = NewClaudeAdapter(executable).PlanFresh(request)
+					case CodexProvider:
+						_, err = NewCodexAdapter(executable).PlanFresh(request)
+					}
+					if err == nil || !strings.Contains(err.Error(), "initial input") {
+						t.Fatalf("unsafe initial input error = %v", err)
+					}
+				})
 			}
 		})
 	}

--- a/internal/launch/plan.go
+++ b/internal/launch/plan.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -130,7 +131,7 @@ func (a AgentPlan) validate() error {
 		return fmt.Errorf("invalid resume policy %q", a.ResumePolicy)
 	}
 	for key := range a.EnvOverlay {
-		if key == "" || strings.ContainsRune(key, '=') {
+		if !validPOSIXEnvironmentKey(key) {
 			return fmt.Errorf("invalid environment key %q", key)
 		}
 	}
@@ -193,6 +194,9 @@ func (a AgentPlan) validate() error {
 		if _, dynamic := seenDynamic[a.InitialInput.ArgvIndex]; dynamic {
 			return fmt.Errorf("initial input argv index is dynamic")
 		}
+		if err := validateInitialInputText(a.Argv[a.InitialInput.ArgvIndex]); err != nil {
+			return err
+		}
 		sum := sha256.Sum256([]byte(a.Argv[a.InitialInput.ArgvIndex]))
 		if "sha256:"+hex.EncodeToString(sum[:]) != a.InitialInput.SHA256 {
 			return fmt.Errorf("initial input digest does not match argument")
@@ -212,15 +216,16 @@ type canonicalArgument struct {
 }
 
 type staticAgentPlan struct {
-	Handle          string                 `json:"handle"`
-	Argv            []canonicalArgument    `json:"argv"`
-	EnvOverlay      map[string]string      `json:"env_overlay,omitempty"`
-	Cwd             string                 `json:"cwd"`
-	AdapterMode     AdapterMode            `json:"adapter_mode"`
-	ResumePolicy    ResumePolicy           `json:"resume_policy"`
-	PreSpawnAcquire bool                   `json:"pre_spawn_acquire,omitempty"`
-	InitialInput    *canonicalInitialInput `json:"initial_input,omitempty"`
-	Wrapper         *Wrapper               `json:"wrapper,omitempty"`
+	Handle          string                   `json:"handle"`
+	Argv            []canonicalArgument      `json:"argv"`
+	EnvOverlay      map[string]string        `json:"env_overlay,omitempty"`
+	Cwd             string                   `json:"cwd"`
+	AdapterMode     AdapterMode              `json:"adapter_mode"`
+	ResumePolicy    ResumePolicy             `json:"resume_policy"`
+	PreSpawnAcquire bool                     `json:"pre_spawn_acquire,omitempty"`
+	Execution       *PrepareExecutionOptions `json:"execution,omitempty"`
+	InitialInput    *canonicalInitialInput   `json:"initial_input,omitempty"`
+	Wrapper         *Wrapper                 `json:"wrapper,omitempty"`
 }
 
 type canonicalInitialInput struct {
@@ -277,7 +282,8 @@ func (p Plan) semanticDigest(allowEmpty, trustProjection bool) (string, error) {
 		agents[i] = staticAgentPlan{
 			Handle: agent.Handle, Argv: argv, EnvOverlay: agent.EnvOverlay,
 			Cwd: agent.Cwd, AdapterMode: agent.AdapterMode, ResumePolicy: agent.ResumePolicy,
-			PreSpawnAcquire: agent.PreSpawnAcquire, InitialInput: initial, Wrapper: cloneWrapper(agent.Wrapper),
+			PreSpawnAcquire: agent.PreSpawnAcquire, Execution: canonicalPlanExecution(agent.Execution),
+			InitialInput: initial, Wrapper: cloneWrapper(agent.Wrapper),
 		}
 	}
 	slices.SortFunc(agents, func(a, b staticAgentPlan) int { return strings.Compare(a.Handle, b.Handle) })
@@ -290,6 +296,18 @@ func (p Plan) semanticDigest(allowEmpty, trustProjection bool) (string, error) {
 	}
 	sum := sha256.Sum256(canonical)
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func canonicalPlanExecution(options *PrepareExecutionOptions) *PrepareExecutionOptions {
+	if options == nil {
+		return nil
+	}
+	canonical := CanonicalExecutionOptions(options)
+	defaults := CanonicalExecutionOptions(nil)
+	if reflect.DeepEqual(canonical, defaults) {
+		return nil
+	}
+	return &canonical
 }
 
 func (p Plan) validateForDigest(allowEmpty bool) error {

--- a/internal/launch/plan_test.go
+++ b/internal/launch/plan_test.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -61,6 +62,161 @@ func TestInitialInputChangesPlanButNotTrustProjection(t *testing.T) {
 	second.Agents[0].InitialInput.Kind = InitialInputFile
 	if _, err := second.TrustSemanticDigest(); err == nil || !strings.Contains(err.Error(), "invalid initial input kind") {
 		t.Fatalf("unsupported carrier kind was accepted: %v", err)
+	}
+}
+
+func TestExecutionOptionsChangePlanAndTrustDigests(t *testing.T) {
+	base := validPlan()
+	base.Agents[0].Execution = &PrepareExecutionOptions{
+		RequireWake: true, NoGitignore: true, WakeMode: "enabled", AuditReason: "baseline",
+		InjectorMode: "raw", InjectorVia: "/opt/injector", InjectorArgs: []string{"send"},
+		SymphonyEvents: []string{"after_create"}, SymphonyWorkspaceKey: "workspace-a",
+	}
+	planDigest, err := base.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	trustDigest, err := base.TrustSemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*PrepareExecutionOptions)
+	}{
+		{"require wake", func(options *PrepareExecutionOptions) { options.RequireWake = false }},
+		{"no gitignore", func(options *PrepareExecutionOptions) { options.NoGitignore = false }},
+		{"wake mode", func(options *PrepareExecutionOptions) { options.WakeMode = "disabled" }},
+		{"audit reason", func(options *PrepareExecutionOptions) { options.AuditReason = "changed" }},
+		{"injector mode", func(options *PrepareExecutionOptions) { options.InjectorMode = "paste" }},
+		{"injector via", func(options *PrepareExecutionOptions) { options.InjectorVia = "/opt/other" }},
+		{"injector args", func(options *PrepareExecutionOptions) { options.InjectorArgs[0] = "paste" }},
+		{"symphony events", func(options *PrepareExecutionOptions) { options.SymphonyEvents[0] = "before_run" }},
+		{"symphony workspace", func(options *PrepareExecutionOptions) { options.SymphonyWorkspaceKey = "workspace-b" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := base
+			candidate.Agents = append([]AgentPlan(nil), base.Agents...)
+			candidate.Agents[0].Execution = clonePrepareExecutionOptions(base.Agents[0].Execution)
+			test.mutate(candidate.Agents[0].Execution)
+			gotPlan, err := candidate.SemanticDigest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotTrust, err := candidate.TrustSemanticDigest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotPlan == planDigest || gotTrust == trustDigest {
+				t.Fatalf("execution change did not invalidate both digests: plan=%t trust=%t", gotPlan != planDigest, gotTrust != trustDigest)
+			}
+		})
+	}
+
+	identical := base
+	identical.Agents = append([]AgentPlan(nil), base.Agents...)
+	identical.Agents[0].Execution = clonePrepareExecutionOptions(base.Agents[0].Execution)
+	identicalPlan, err := identical.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identicalTrust, err := identical.TrustSemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identicalPlan != planDigest || identicalTrust != trustDigest {
+		t.Fatalf("identical execution options changed digests: plan=%s/%s trust=%s/%s", identicalPlan, planDigest, identicalTrust, trustDigest)
+	}
+}
+
+func TestPlanRejectsUnsafeInitialInputAndEnvironmentKey(t *testing.T) {
+	base := validPlan()
+	text := "safe"
+	sum := sha256.Sum256([]byte(text))
+	base.Agents[0].Argv = append(base.Agents[0].Argv, text)
+	base.Agents[0].InitialInput = &PlannedInitialInput{Kind: InitialInputArgument, SHA256: "sha256:" + hex.EncodeToString(sum[:]), ArgvIndex: len(base.Agents[0].Argv) - 1}
+	for _, value := range []string{"-option", "line\nfeed", "tab\tvalue", "delete\x7f"} {
+		t.Run(fmt.Sprintf("initial input %q", value), func(t *testing.T) {
+			candidate := base
+			candidate.Agents = append([]AgentPlan(nil), base.Agents...)
+			candidate.Agents[0].Argv = append([]string(nil), base.Agents[0].Argv...)
+			candidate.Agents[0].InitialInput = &PlannedInitialInput{Kind: InitialInputArgument, ArgvIndex: len(candidate.Agents[0].Argv) - 1}
+			candidate.Agents[0].Argv[candidate.Agents[0].InitialInput.ArgvIndex] = value
+			valueSum := sha256.Sum256([]byte(value))
+			candidate.Agents[0].InitialInput.SHA256 = "sha256:" + hex.EncodeToString(valueSum[:])
+			if err := candidate.Validate(); err == nil || !strings.Contains(err.Error(), "initial input") {
+				t.Fatalf("unsafe initial input validation error = %v", err)
+			}
+		})
+	}
+
+	for _, key := range []string{"FOO;BAR", "1FOO", "FOO-BAR"} {
+		t.Run("environment key "+key, func(t *testing.T) {
+			candidate := validPlan()
+			candidate.Agents[0].EnvOverlay = map[string]string{key: "value"}
+			if err := candidate.Validate(); err == nil || !strings.Contains(err.Error(), "invalid environment key") {
+				t.Fatalf("unsafe environment key validation error = %v", err)
+			}
+		})
+	}
+}
+
+func TestDefaultExecutionOptionsPreserveLegacyDigest(t *testing.T) {
+	const want = "sha256:ce711c6541227a6093d8bc6ac33aba32f49b3e683d61bfe781d7d55b0029d8e6"
+	for _, options := range []*PrepareExecutionOptions{
+		nil,
+		{},
+		{WakeMode: "enabled"},
+		{InjectorMode: "none"},
+		{WakeMode: "enabled", InjectorMode: "none"},
+	} {
+		plan := validPlan()
+		plan.Agents[0].Execution = options
+		got, err := plan.SemanticDigest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("default execution changed legacy digest: got %s want %s", got, want)
+		}
+		trust, err := plan.TrustSemanticDigest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if trust != want {
+			t.Fatalf("default execution changed legacy trust digest: got %s want %s", trust, want)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*PrepareExecutionOptions)
+	}{
+		{"require wake", func(options *PrepareExecutionOptions) { options.RequireWake = true }},
+		{"no gitignore", func(options *PrepareExecutionOptions) { options.NoGitignore = true }},
+		{"wake mode", func(options *PrepareExecutionOptions) { options.WakeMode = "disabled" }},
+		{"audit reason", func(options *PrepareExecutionOptions) { options.AuditReason = "audit" }},
+		{"injector mode", func(options *PrepareExecutionOptions) { options.InjectorMode = "raw" }},
+		{"injector via", func(options *PrepareExecutionOptions) { options.InjectorVia = "/opt/injector" }},
+		{"injector args", func(options *PrepareExecutionOptions) { options.InjectorArgs = []string{"send"} }},
+		{"symphony events", func(options *PrepareExecutionOptions) { options.SymphonyEvents = []string{"after_create"} }},
+		{"symphony workspace", func(options *PrepareExecutionOptions) { options.SymphonyWorkspaceKey = "workspace" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plan := validPlan()
+			plan.Agents[0].Execution = &PrepareExecutionOptions{}
+			test.mutate(plan.Agents[0].Execution)
+			got, err := plan.SemanticDigest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == want {
+				t.Fatalf("non-default execution retained legacy digest %s", got)
+			}
+		})
 	}
 }
 

--- a/launchapi/intent.go
+++ b/launchapi/intent.go
@@ -150,8 +150,16 @@ func (input InitialInputV1) validate() error {
 	default:
 		return fmt.Errorf("invalid kind %q", input.Kind)
 	}
-	if !utf8.ValidString(input.Text) || strings.ContainsRune(input.Text, 0) {
-		return fmt.Errorf("text must be valid UTF-8 without NUL")
+	if !utf8.ValidString(input.Text) {
+		return &InitialInputValidationError{Code: InitialInputInvalidUTF8, Detail: "text must be valid UTF-8"}
+	}
+	if strings.HasPrefix(input.Text, "-") {
+		return &InitialInputValidationError{Code: InitialInputLeadingDash, Detail: "text must not begin with '-'"}
+	}
+	for _, r := range input.Text {
+		if r <= 0x1f || r == 0x7f {
+			return &InitialInputValidationError{Code: InitialInputControl, Detail: "text must not contain C0, DEL, CR, or LF control characters"}
+		}
 	}
 	return nil
 }

--- a/launchapi/intent_test.go
+++ b/launchapi/intent_test.go
@@ -2,11 +2,44 @@ package launchapi
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestInitialInputValidationReturnsTypedCodes(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		text string
+		code InitialInputErrorCode
+	}{
+		{name: "nul", text: "before\x00after", code: InitialInputControl},
+		{name: "control", text: "before\tafter", code: InitialInputControl},
+		{name: "delete", text: "before\x7fafter", code: InitialInputControl},
+		{name: "carriage return", text: "before\rafter", code: InitialInputControl},
+		{name: "line feed", text: "before\nafter", code: InitialInputControl},
+		{name: "leading dash", text: "-danger", code: InitialInputLeadingDash},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			intent := LaunchIntentV1{
+				IntentVersion: IntentVersionV1,
+				Participants: []ParticipantV1{{
+					Handle: "codex", Runnable: true, Executable: "codex",
+					Cwd:          &WorkingDirectoryV1{Kind: WorkingDirectoryAbsolute, Path: t.TempDir()},
+					ResumePolicy: ResumePolicyFresh,
+					Execution:    &ExecutionOptionsV1{Wake: WakeOptionsV1{Mode: WakeEnabled}},
+					InitialInput: &InitialInputV1{Kind: InitialInputArgument, Text: test.text},
+				}},
+			}
+			var typed *InitialInputValidationError
+			if err := intent.Validate(); !errors.As(err, &typed) || typed.Code != test.code {
+				t.Fatalf("Validate error = %v, typed=%#v; want code %q", err, typed, test.code)
+			}
+		})
+	}
+}
 
 func validIntentJSON(t *testing.T) string {
 	t.Helper()
@@ -212,7 +245,7 @@ func TestLaunchIntentV1InitialInputStrictShape(t *testing.T) {
 		{name: "unknown kind", input: `{"kind":"pipe","text":"hello"}`, want: "invalid kind"},
 		{name: "missing text", input: `{"kind":"stdin"}`, want: "requires text"},
 		{name: "unknown field", input: `{"kind":"file","text":"hello","path":"/tmp/pwn"}`, want: "unknown field"},
-		{name: "nul", input: `{"kind":"argument","text":"hello\u0000world"}`, want: "without NUL"},
+		{name: "nul", input: `{"kind":"argument","text":"hello\u0000world"}`, want: "initial_input_control"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := DecodeLaunchIntentV1([]byte(fmt.Sprintf(base, test.input)))

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -522,7 +522,7 @@ func TestPrepareSubjectDigestTracksFrozenInputs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if withOptions.PlanDigest != baseline.PlanDigest || withOptions.TrustDigest != baseline.TrustDigest || withOptions.SubjectDigest == baseline.SubjectDigest {
+	if withOptions.PlanDigest == baseline.PlanDigest || withOptions.TrustDigest == baseline.TrustDigest || withOptions.SubjectDigest == baseline.SubjectDigest {
 		t.Fatalf("option-only digest change = plan %t trust %t subject %t",
 			withOptions.PlanDigest != baseline.PlanDigest,
 			withOptions.TrustDigest != baseline.TrustDigest,

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -248,6 +248,32 @@ type InitialInputV1 struct {
 	Text string             `json:"text"`
 }
 
+type InitialInputErrorCode string
+
+const (
+	InitialInputInvalidUTF8 InitialInputErrorCode = "initial_input_invalid_utf8"
+	InitialInputControl     InitialInputErrorCode = "initial_input_control"
+	InitialInputLeadingDash InitialInputErrorCode = "initial_input_leading_dash"
+)
+
+// InitialInputValidationError is returned before Prepare inspects or mutates
+// any target state when bootstrap text cannot be safely carried as one argv
+// argument.
+type InitialInputValidationError struct {
+	Code   InitialInputErrorCode
+	Detail string
+}
+
+func (e *InitialInputValidationError) Error() string {
+	if e == nil {
+		return "initial input validation failed"
+	}
+	if e.Detail == "" {
+		return string(e.Code)
+	}
+	return string(e.Code) + ": " + e.Detail
+}
+
 type ConfigOverrideCapabilityV1 struct {
 	Key           string   `json:"key"`
 	AllowedValues []string `json:"allowed_values"`


### PR DESCRIPTION
Bead amq-7wa — ChatGPT Pro review A findings 3, 9, 10, 28.

- `PlanDigest` and `TrustDigest` now include canonical execution policy (wake mode, require-wake, injector mode/via/args, Symphony events/workspace, audit reason, no-gitignore). A new injector executable or wake policy no longer auto-Applies under old trust. All-default options are omitted from the canonical form, so existing trusted plans with default policy keep their exact digest (golden `TestDefaultExecutionOptionsPreserveLegacyDigest` pins the v0.65.2 value); only a non-default policy changes the digests.
- Initial input rejects C0/DEL/CR/LF and leading `-` at `launchapi` (typed codes `initial_input_control`, `initial_input_leading_dash`, `initial_input_invalid_utf8`) and again at the launch layer before planning; backends validate the plan before building typed shell lines.
- `AgentPlan` env keys must be POSIX identifiers (`commandLine` concatenated keys unquoted).

Review: execution-gated, 8/8 mutants killed incl. per-layer independence and per-field digest property (9 fields); isolated env-key negatives (`FOO;BAR`, `1FOO`, `FOO-BAR`); default-policy digest stability verified against origin/main. Local pre-push `make ci` green.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ