### PR TITLE
fix(fsq): validate mailbox entrypoints, keep destinations on rename failure, fail closed on DLQ id RNG error

### DIFF
--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -39,7 +39,7 @@ func TestListCanInspectFlagShapedLegacyMailboxButDrainRejectsIt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := deliverToInboxForTest(t, root, legacy, "legacy-message.md", data); err != nil {
+	if err := os.WriteFile(filepath.Join(fsq.AgentInboxNew(root, legacy), "legacy-message.md"), data, 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/fsq/atomic_replace_other.go
+++ b/internal/fsq/atomic_replace_other.go
@@ -5,17 +5,5 @@ package fsq
 import "os"
 
 func replaceFile(tmpPath, finalPath string) error {
-	if err := os.Rename(tmpPath, finalPath); err != nil {
-		if _, statErr := os.Stat(finalPath); statErr == nil {
-			if removeErr := os.Remove(finalPath); removeErr != nil && !os.IsNotExist(removeErr) {
-				return err
-			}
-			if err := os.Rename(tmpPath, finalPath); err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
-	return nil
+	return os.Rename(tmpPath, finalPath)
 }

--- a/internal/fsq/atomic_replace_other_test.go
+++ b/internal/fsq/atomic_replace_other_test.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package fsq
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceFileMissingTmpLeavesDestIntact(t *testing.T) {
+	dir := t.TempDir()
+	finalPath := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(finalPath, []byte("keep-me"), 0o600); err != nil {
+		t.Fatalf("write dest: %v", err)
+	}
+	missingTmp := filepath.Join(dir, ".state.json.tmp-missing")
+
+	err := replaceFile(missingTmp, finalPath)
+	if err == nil {
+		t.Fatal("replaceFile(missing tmp) error = nil, want error")
+	}
+
+	got, readErr := os.ReadFile(finalPath)
+	if readErr != nil {
+		t.Fatalf("dest unreadable after failed replace: %v", readErr)
+	}
+	if string(got) != "keep-me" {
+		t.Fatalf("dest bytes = %q, want keep-me", got)
+	}
+}
+
+func TestReplaceFileMissingTmpLeavesEmptyDestDir(t *testing.T) {
+	dir := t.TempDir()
+	finalPath := filepath.Join(dir, "emptydir")
+	if err := os.Mkdir(finalPath, 0o700); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+	missingTmp := filepath.Join(dir, ".emptydir.tmp-missing")
+
+	err := replaceFile(missingTmp, finalPath)
+	if err == nil {
+		t.Fatal("replaceFile(missing tmp) error = nil, want error")
+	}
+
+	info, statErr := os.Stat(finalPath)
+	if statErr != nil {
+		t.Fatalf("empty dest dir removed: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatalf("dest mode = %v, want directory", info.Mode())
+	}
+}

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -115,11 +115,15 @@ func setRetryState(env *DLQEnvelope, state string) {
 	env.RetryDelivered = state == RetryStateDelivered
 }
 
+var readRandom = rand.Read
+
 // GenerateDLQID creates a unique ID for a DLQ envelope.
-func GenerateDLQID() string {
+func GenerateDLQID() (string, error) {
 	b := make([]byte, 6)
-	_, _ = rand.Read(b)
-	return fmt.Sprintf("dlq_%d_%d_%s", time.Now().UnixNano(), os.Getpid(), hex.EncodeToString(b))
+	if _, err := readRandom(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("dlq_%d_%d_%s", time.Now().UnixNano(), os.Getpid(), hex.EncodeToString(b)), nil
 }
 
 var removeDLQSource = func(root *DeliveryRoot, path string) error {
@@ -261,10 +265,15 @@ func moveInboxMessageToDLQ(root *DeliveryRoot, agent, readDir, envelopeSourceDir
 		return "", fmt.Errorf("read original: %w", err)
 	}
 
+	dlqID, err := GenerateDLQID()
+	if err != nil {
+		return "", fmt.Errorf("generate dlq id: %w", err)
+	}
+
 	// Create envelope
 	envelope := DLQEnvelope{
 		Schema:        DLQSchemaVersion,
-		ID:            GenerateDLQID(),
+		ID:            dlqID,
 		OriginalID:    originalID,
 		OriginalFile:  filename,
 		FailureReason: failureReason,

--- a/internal/fsq/dlq_test.go
+++ b/internal/fsq/dlq_test.go
@@ -65,6 +65,44 @@ func TestMoveToDLQ(t *testing.T) {
 	}
 }
 
+func TestMoveToDLQFailsWhenRandomReadFails(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureAgentDirs(root, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+
+	filename := "need_dlq.md"
+	if err := os.WriteFile(filepath.Join(AgentInboxNew(root, "alice"), filename), []byte("payload"), 0o600); err != nil {
+		t.Fatalf("write inbox message: %v", err)
+	}
+
+	injected := errors.New("injected rand.Read failure")
+	orig := readRandom
+	readRandom = func([]byte) (int, error) { return 0, injected }
+	t.Cleanup(func() { readRandom = orig })
+
+	dlqPath, err := MoveToDLQ(openDeliveryRootForTest(t, root), "alice", filename, "need_dlq", "parse_error", "bad")
+	if err == nil {
+		t.Fatal("MoveToDLQ error = nil, want RNG failure")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("MoveToDLQ error = %v, want injected rand.Read failure", err)
+	}
+	if dlqPath != "" {
+		t.Fatalf("dlqPath = %q, want empty", dlqPath)
+	}
+
+	for _, dir := range []string{AgentDLQNew(root, "alice"), AgentDLQTmp(root, "alice"), AgentDLQCur(root, "alice")} {
+		entries, readErr := os.ReadDir(dir)
+		if readErr != nil {
+			t.Fatalf("ReadDir %s: %v", dir, readErr)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("%s has files after RNG failure: %#v", dir, entries)
+		}
+	}
+}
+
 func TestMoveToDLQClaimsBeforeDLQDelivery(t *testing.T) {
 	root := t.TempDir()
 	if err := EnsureAgentDirs(root, "alice"); err != nil {

--- a/internal/fsq/find.go
+++ b/internal/fsq/find.go
@@ -13,6 +13,9 @@ const (
 )
 
 func FindMessage(root, agent, filename string) (string, string, error) {
+	if err := ValidateHandle(agent); err != nil {
+		return "", "", err
+	}
 	if err := ValidateMessageFilename(filename); err != nil {
 		return "", "", err
 	}
@@ -32,6 +35,9 @@ func FindMessage(root, agent, filename string) (string, string, error) {
 }
 
 func MoveNewToCur(root *DeliveryRoot, agent, filename string) error {
+	if err := ValidateHandle(agent); err != nil {
+		return err
+	}
 	if err := ValidateMessageFilename(filename); err != nil {
 		return err
 	}

--- a/internal/fsq/mailbox_entry_test.go
+++ b/internal/fsq/mailbox_entry_test.go
@@ -1,0 +1,165 @@
+package fsq
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	traversalHandle   = "../meta"
+	traversalFilename = "../../.wake.lock"
+	validHandle       = "codex"
+	validFilename     = "ok.md"
+)
+
+func TestMailboxEntrypointsRejectTraversalBeforeMutation(t *testing.T) {
+	t.Run("DeliverToInboxes", func(t *testing.T) {
+		root := newQueueRoot(t)
+		delivery := openDeliveryRootForTest(t, root)
+
+		_, err := DeliverToInboxes(delivery, []string{traversalHandle}, validFilename, []byte("payload"))
+		if err == nil {
+			t.Fatal("DeliverToInboxes(../meta) error = nil, want rejection")
+		}
+		assertNoMetaInbox(t, root)
+
+		_, err = DeliverToInboxes(delivery, []string{validHandle}, traversalFilename, []byte("payload"))
+		if err == nil {
+			t.Fatal("DeliverToInboxes(../../.wake.lock) error = nil, want rejection")
+		}
+		assertNoWakeLockEscape(t, root, validHandle)
+
+		path, err := DeliverToInboxes(delivery, []string{validHandle}, validFilename, []byte("payload"))
+		if err != nil {
+			t.Fatalf("DeliverToInboxes(valid) error = %v", err)
+		}
+		got, readErr := os.ReadFile(path[validHandle])
+		if readErr != nil || string(got) != "payload" {
+			t.Fatalf("delivered content = %q err=%v, want payload", got, readErr)
+		}
+	})
+
+	t.Run("DeliverToExistingInbox", func(t *testing.T) {
+		root := newQueueRoot(t)
+		delivery := openDeliveryRootForTest(t, root)
+
+		_, err := DeliverToExistingInbox(delivery, traversalHandle, validFilename, []byte("payload"))
+		if err == nil {
+			t.Fatal("DeliverToExistingInbox(../meta) error = nil, want rejection")
+		}
+		assertNoMetaInbox(t, root)
+
+		_, err = DeliverToExistingInbox(delivery, validHandle, traversalFilename, []byte("payload"))
+		if err == nil {
+			t.Fatal("DeliverToExistingInbox(../../.wake.lock) error = nil, want rejection")
+		}
+		assertNoWakeLockEscape(t, root, validHandle)
+
+		path, err := DeliverToExistingInbox(delivery, validHandle, validFilename, []byte("payload"))
+		if err != nil {
+			t.Fatalf("DeliverToExistingInbox(valid) error = %v", err)
+		}
+		got, readErr := os.ReadFile(path)
+		if readErr != nil || string(got) != "payload" {
+			t.Fatalf("delivered content = %q err=%v, want payload", got, readErr)
+		}
+	})
+
+	t.Run("MoveNewToCur", func(t *testing.T) {
+		root := newQueueRoot(t)
+		if err := os.WriteFile(filepath.Join(AgentInboxNew(root, validHandle), validFilename), []byte("payload"), 0o600); err != nil {
+			t.Fatalf("write inbox message: %v", err)
+		}
+		delivery := openDeliveryRootForTest(t, root)
+
+		if err := MoveNewToCur(delivery, traversalHandle, validFilename); err == nil {
+			t.Fatal("MoveNewToCur(../meta) error = nil, want rejection")
+		}
+		assertNoMetaInbox(t, root)
+
+		if err := MoveNewToCur(delivery, validHandle, traversalFilename); err == nil {
+			t.Fatal("MoveNewToCur(../../.wake.lock) error = nil, want rejection")
+		}
+		assertNoWakeLockEscape(t, root, validHandle)
+
+		if err := MoveNewToCur(delivery, validHandle, validFilename); err != nil {
+			t.Fatalf("MoveNewToCur(valid) error = %v", err)
+		}
+		got, readErr := os.ReadFile(filepath.Join(AgentInboxCur(root, validHandle), validFilename))
+		if readErr != nil || string(got) != "payload" {
+			t.Fatalf("claimed content = %q err=%v, want payload", got, readErr)
+		}
+	})
+
+	t.Run("FindMessage", func(t *testing.T) {
+		root := newQueueRoot(t)
+		decoy := filepath.Join(root, "meta", "inbox", "new", validFilename)
+		if err := os.MkdirAll(filepath.Dir(decoy), 0o700); err != nil {
+			t.Fatalf("mkdir decoy: %v", err)
+		}
+		if err := os.WriteFile(decoy, []byte("escaped"), 0o600); err != nil {
+			t.Fatalf("write decoy: %v", err)
+		}
+		inboxPath := filepath.Join(AgentInboxNew(root, validHandle), validFilename)
+		if err := os.WriteFile(inboxPath, []byte("payload"), 0o600); err != nil {
+			t.Fatalf("write inbox message: %v", err)
+		}
+
+		path, box, err := FindMessage(root, traversalHandle, validFilename)
+		if err == nil {
+			t.Fatalf("FindMessage(../meta) = (%q, %q), want rejection of decoy at %s", path, box, decoy)
+		}
+		if path != "" || box != "" {
+			t.Fatalf("FindMessage(../meta) leaked path (%q, %q)", path, box)
+		}
+
+		path, box, err = FindMessage(root, validHandle, traversalFilename)
+		if err == nil {
+			t.Fatalf("FindMessage(../../.wake.lock) = (%q, %q), want rejection", path, box)
+		}
+
+		path, box, err = FindMessage(root, validHandle, validFilename)
+		if err != nil {
+			t.Fatalf("FindMessage(valid) error = %v", err)
+		}
+		if path != inboxPath || box != BoxNew {
+			t.Fatalf("FindMessage(valid) = (%q, %q), want (%q, %q)", path, box, inboxPath, BoxNew)
+		}
+	})
+}
+
+func newQueueRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := EnsureRootDirs(root); err != nil {
+		t.Fatalf("EnsureRootDirs: %v", err)
+	}
+	if err := EnsureAgentDirs(root, validHandle); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	return root
+}
+
+func assertNoMetaInbox(t *testing.T, root string) {
+	t.Helper()
+	metaInbox := filepath.Join(root, "meta", "inbox")
+	if _, err := os.Lstat(metaInbox); !os.IsNotExist(err) {
+		t.Fatalf("traversal created %s: %v", metaInbox, err)
+	}
+}
+
+func assertNoWakeLockEscape(t *testing.T, root, agent string) {
+	t.Helper()
+	for _, path := range []string{
+		filepath.Join(root, ".wake.lock"),
+		filepath.Join(root, "agents", ".wake.lock"),
+		filepath.Join(root, "agents", agent, ".wake.lock"),
+		filepath.Join(AgentInboxTmp(root, agent), traversalFilename),
+		filepath.Join(AgentInboxNew(root, agent), traversalFilename),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("escaped path created: %s (%v)", path, err)
+		}
+	}
+}

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -75,6 +75,14 @@ func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, 
 	if len(recipients) == 0 {
 		return nil, fmt.Errorf("no recipients provided")
 	}
+	if err := ValidateMessageFilename(filename); err != nil {
+		return nil, err
+	}
+	for _, recipient := range recipients {
+		if err := ValidateHandle(recipient); err != nil {
+			return nil, err
+		}
+	}
 	if err := root.VerifyBase(); err != nil {
 		return nil, err
 	}
@@ -141,6 +149,12 @@ func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, 
 // directories — the target inbox must already exist. This prevents a sender
 // from accidentally scaffolding structure in a peer project.
 func DeliverToExistingInbox(root *DeliveryRoot, agent, filename string, data []byte) (string, error) {
+	if err := ValidateHandle(agent); err != nil {
+		return "", err
+	}
+	if err := ValidateMessageFilename(filename); err != nil {
+		return "", err
+	}
 	if err := root.VerifyBase(); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- Bead **amq-2pf** (review B findings 5, 1, and 3-rand).
- Validate handle and message filename at mailbox entrypoints (`DeliverToInboxes`, `DeliverToExistingInbox`, `MoveNewToCur`, `FindMessage`).
- POSIX `replaceFile` is rename-only so a missing destination stays intact, including an empty directory.
- `GenerateDLQID` fails closed: RNG error writes no DLQ file.

## Testing
- Mutants: 7/7 killed (each entrypoint independently; replaceFile dest intact including empty dir; RNG error → no DLQ file).
- Windows/linux cross-compile clean.
- `list_test` change is fixture-only (leading `-` mailbox planted by direct write because delivery now rejects that handle).

## Related
Bead amq-2pf. Review B findings 5, 1, 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ

Made with [Cursor](https://cursor.com)