### PR TITLE
fix(keepalive): use a private exclusive timeout marker and process-group termination in the session hook

### DIFF
--- a/internal/keepalive/hookinstall/hookinstall.go
+++ b/internal/keepalive/hookinstall/hookinstall.go
@@ -152,23 +152,30 @@ run_reattach() {
     "$BIN" "${args[@]}" >> "$LOG_PATH" 2>&1
 }
 
-timeout_marker="${TMPDIR:-/tmp}/amq-keepalive-timeout.$$"
-rm -f "$timeout_marker" 2>/dev/null || true
+# GOLDEN-CHANGE: private exclusive timeout marker (mktemp 0700 dir) and process-group kill.
+timeout_dir="$(mktemp -d "${TMPDIR:-/tmp}/amq-keepalive-timeout.XXXXXX" 2>/dev/null)" || {
+    log "timeout marker: mktemp failed"
+    printf '{}\n'
+    exit 0
+}
+chmod 0700 "$timeout_dir" 2>/dev/null || true
+timeout_marker="${timeout_dir}/flag"
+trap 'rm -rf -- "$timeout_dir"' EXIT
 
+set -m
 (
     trap 'exit 143' TERM
     run_reattach
 ) 2>> "$LOG_PATH" &
 reattach_pid=$!
+set +m
 (
     "$SLEEP_CMD" "$TIMEOUT_SECONDS"
     if kill -0 "$reattach_pid" 2>/dev/null; then
         : > "$timeout_marker" 2>/dev/null || true
-        pkill -TERM -P "$reattach_pid" 2>/dev/null || true
-        kill -TERM "$reattach_pid" 2>/dev/null || true
+        kill -TERM -- -"$reattach_pid" 2>/dev/null || true
         "$SLEEP_CMD" 1
-        pkill -KILL -P "$reattach_pid" 2>/dev/null || true
-        kill -KILL "$reattach_pid" 2>/dev/null || true
+        kill -KILL -- -"$reattach_pid" 2>/dev/null || true
     fi
 ) >/dev/null 2>&1 &
 watchdog_pid=$!
@@ -180,7 +187,6 @@ kill "$watchdog_pid" 2>/dev/null || true
 wait "$watchdog_pid" 2>/dev/null || true
 
 if [[ -f "$timeout_marker" ]]; then
-    rm -f "$timeout_marker" 2>/dev/null || true
     log "reattach timed out after ${TIMEOUT_SECONDS}s adapter=$ADAPTER target=${TARGET:-auto}"
     printf '{}\n'
     exit 0

--- a/internal/keepalive/hookinstall/hookinstall_other_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_other_test.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package hookinstall
+
+func processRunning(int) bool { return false }
+
+func killPID(int) {}

--- a/internal/keepalive/hookinstall/hookinstall_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -747,7 +746,7 @@ exit 0
 		t.Fatalf("success path logged a timeout:\n%s", logText)
 	}
 	pid := readPIDFile(t, wakePidPath)
-	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	t.Cleanup(func() { killPID(pid) })
 	if !processRunning(pid) {
 		t.Fatalf("already-ready wake pid %d was killed by watchdog cancel", pid)
 	}
@@ -779,10 +778,6 @@ func readPIDFile(t *testing.T, path string) int {
 		t.Fatalf("pid file %s = %q, want a pid", path, data)
 	}
 	return pid
-}
-
-func processRunning(pid int) bool {
-	return syscall.Kill(pid, 0) == nil
 }
 
 func writeExecutable(t *testing.T, path string) string {

--- a/internal/keepalive/hookinstall/hookinstall_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_test.go
@@ -649,6 +649,7 @@ wait
 		"CMUX_SURFACE_ID",
 		"TMPDIR",
 	),
+		"TMPDIR="+dir,
 		"AMQ_KEEPALIVE_BIN="+binaryPath,
 		"AMQ_KEEPALIVE_LOG="+logPath,
 		"AMQ_KEEPALIVE_TARGET=ghostty:terminal:BEDE3893-CE56-4309-8AEC-3D930F11225D",
@@ -681,6 +682,13 @@ wait
 	}
 	if processRunning(pid) {
 		t.Fatalf("grandchild pid %d still running after process-group timeout", pid)
+	}
+	leftovers, err := filepath.Glob(filepath.Join(dir, "amq-keepalive-timeout.*"))
+	if err != nil {
+		t.Fatalf("glob timeout_dir: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("timeout_dir leftover: %v", leftovers)
 	}
 }
 

--- a/internal/keepalive/hookinstall/hookinstall_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -543,6 +546,235 @@ printf '%s\n' "$@" > "$AMQ_KEEPALIVE_CAPTURE"
 	if !strings.Contains(string(logData), "wake timeout 3000ms must be shorter than outer 3000ms; using 2500ms") {
 		t.Fatalf("clamp was not logged:\n%s", logData)
 	}
+}
+
+func TestSessionStartTimeoutMarkerDoesNotFollowPIDSymlink(t *testing.T) {
+	dir := t.TempDir()
+	tmpdir := t.TempDir()
+	scriptPath := writeSessionStartScript(t, dir)
+	victimPath := filepath.Join(dir, "victim")
+	victimBytes := []byte("do-not-truncate\n")
+	mustWrite(t, victimPath, victimBytes)
+	startedPath := filepath.Join(dir, "started")
+	binaryPath := writeExecutableBody(t, filepath.Join(dir, "amq-keepalive"), `#!/bin/sh
+printf 'started\n' > "$AMQ_KEEPALIVE_STARTED"
+sleep 30
+`)
+	logPath := filepath.Join(dir, "session-start.log")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", scriptPath)
+	cmd.Stdin = strings.NewReader("{}\n")
+	cmd.Env = append(withoutEnv(os.Environ(),
+		"AMQ_KEEPALIVE_ADAPTER",
+		"AMQ_KEEPALIVE_TARGET",
+		"AMQ_KEEPALIVE_BIN",
+		"AMQ_KEEPALIVE_SLEEP",
+		"AMQ_KEEPALIVE_DISABLED",
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_DEFAULT_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_WAKE_TIMEOUT_MILLISECONDS",
+		"CMUX_SURFACE_ID",
+		"TMPDIR",
+	),
+		"TMPDIR="+tmpdir,
+		"AMQ_KEEPALIVE_BIN="+binaryPath,
+		"AMQ_KEEPALIVE_LOG="+logPath,
+		"AMQ_KEEPALIVE_TARGET=ghostty:terminal:BEDE3893-CE56-4309-8AEC-3D930F11225D",
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS=2",
+		"AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS=1",
+		"AMQ_KEEPALIVE_STARTED="+startedPath,
+	)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("hook start error = %v", err)
+	}
+	waitForFile(t, startedPath, 8*time.Second)
+
+	planted := filepath.Join(tmpdir, fmt.Sprintf("amq-keepalive-timeout.%d", cmd.Process.Pid))
+	if err := os.Symlink(victimPath, planted); err != nil {
+		t.Fatalf("plant pid-named symlink: %v", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("hook run error = %v", err)
+	}
+	if got := stdout.String(); got != "{}\n" {
+		t.Fatalf("stdout = %q, want empty hook response", got)
+	}
+	gotVictim, err := os.ReadFile(victimPath)
+	if err != nil {
+		t.Fatalf("read victim: %v", err)
+	}
+	if !bytes.Equal(gotVictim, victimBytes) {
+		t.Fatalf("victim truncated via pid-named timeout path: got %q", gotVictim)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logData), "reattach timed out after 2s") {
+		t.Fatalf("missing timeout log:\n%s", logData)
+	}
+}
+
+func TestSessionStartTimeoutKillsReattachProcessGroup(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := writeSessionStartScript(t, dir)
+	grandchildPidPath := filepath.Join(dir, "grandchild.pid")
+	binaryPath := writeExecutableBody(t, filepath.Join(dir, "amq-keepalive"), `#!/bin/sh
+sleep 60 &
+printf '%s\n' "$!" > "$AMQ_KEEPALIVE_GRANDCHILD_PID"
+wait
+`)
+	logPath := filepath.Join(dir, "session-start.log")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", scriptPath)
+	cmd.Stdin = strings.NewReader("{}\n")
+	cmd.Env = append(withoutEnv(os.Environ(),
+		"AMQ_KEEPALIVE_ADAPTER",
+		"AMQ_KEEPALIVE_TARGET",
+		"AMQ_KEEPALIVE_BIN",
+		"AMQ_KEEPALIVE_SLEEP",
+		"AMQ_KEEPALIVE_DISABLED",
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_DEFAULT_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_WAKE_TIMEOUT_MILLISECONDS",
+		"CMUX_SURFACE_ID",
+		"TMPDIR",
+	),
+		"AMQ_KEEPALIVE_BIN="+binaryPath,
+		"AMQ_KEEPALIVE_LOG="+logPath,
+		"AMQ_KEEPALIVE_TARGET=ghostty:terminal:BEDE3893-CE56-4309-8AEC-3D930F11225D",
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS=2",
+		"AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS=1",
+		"AMQ_KEEPALIVE_GRANDCHILD_PID="+grandchildPidPath,
+	)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("hook start error = %v", err)
+	}
+	pid := readPIDFile(t, grandchildPidPath)
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("hook run error = %v", err)
+	}
+	if got := stdout.String(); got != "{}\n" {
+		t.Fatalf("stdout = %q, want empty hook response", got)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logData), "reattach timed out after 2s") {
+		t.Fatalf("missing timeout log:\n%s", logData)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for processRunning(pid) && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if processRunning(pid) {
+		t.Fatalf("grandchild pid %d still running after process-group timeout", pid)
+	}
+}
+
+func TestSessionStartSuccessDoesNotKillReadyWake(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := writeSessionStartScript(t, dir)
+	wakePidPath := filepath.Join(dir, "wake.pid")
+	binaryPath := writeExecutableBody(t, filepath.Join(dir, "amq-keepalive"), `#!/bin/sh
+sleep 30 &
+printf '%s\n' "$!" > "$AMQ_KEEPALIVE_WAKE_PID"
+exit 0
+`)
+	logPath := filepath.Join(dir, "session-start.log")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", scriptPath)
+	cmd.Stdin = strings.NewReader("{}\n")
+	cmd.Env = append(withoutEnv(os.Environ(),
+		"AMQ_KEEPALIVE_ADAPTER",
+		"AMQ_KEEPALIVE_TARGET",
+		"AMQ_KEEPALIVE_BIN",
+		"AMQ_KEEPALIVE_SLEEP",
+		"AMQ_KEEPALIVE_DISABLED",
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_DEFAULT_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS",
+		"AMQ_KEEPALIVE_WAKE_TIMEOUT_MILLISECONDS",
+		"CMUX_SURFACE_ID",
+		"TMPDIR",
+	),
+		"AMQ_KEEPALIVE_BIN="+binaryPath,
+		"AMQ_KEEPALIVE_LOG="+logPath,
+		"AMQ_KEEPALIVE_TARGET=ghostty:terminal:BEDE3893-CE56-4309-8AEC-3D930F11225D",
+		"AMQ_KEEPALIVE_TIMEOUT_SECONDS=3",
+		"AMQ_KEEPALIVE_STDIN_TIMEOUT_SECONDS=1",
+		"AMQ_KEEPALIVE_WAKE_PID="+wakePidPath,
+	)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook run error = %v", err)
+	}
+	if got := stdout.String(); got != "{}\n" {
+		t.Fatalf("stdout = %q, want empty hook response", got)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "reattach ok") {
+		t.Fatalf("missing success log:\n%s", logText)
+	}
+	if strings.Contains(logText, "reattach timed out") {
+		t.Fatalf("success path logged a timeout:\n%s", logText)
+	}
+	pid := readPIDFile(t, wakePidPath)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	if !processRunning(pid) {
+		t.Fatalf("already-ready wake pid %d was killed by watchdog cancel", pid)
+	}
+}
+
+func waitForFile(t *testing.T, path string, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func readPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	waitForFile(t, path, 8*time.Second)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pid file: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("pid file %s = %q, want a pid", path, data)
+	}
+	return pid
+}
+
+func processRunning(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
 }
 
 func writeExecutable(t *testing.T, path string) string {

--- a/internal/keepalive/hookinstall/hookinstall_unix_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_unix_test.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package hookinstall
+
+import "syscall"
+
+func processRunning(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+func killPID(pid int) {
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/scripts/amq-keepalive-session-start.sh
+++ b/scripts/amq-keepalive-session-start.sh
@@ -130,23 +130,30 @@ run_reattach() {
     "$BIN" "${args[@]}" >> "$LOG_PATH" 2>&1
 }
 
-timeout_marker="${TMPDIR:-/tmp}/amq-keepalive-timeout.$$"
-rm -f "$timeout_marker" 2>/dev/null || true
+# GOLDEN-CHANGE: private exclusive timeout marker (mktemp 0700 dir) and process-group kill.
+timeout_dir="$(mktemp -d "${TMPDIR:-/tmp}/amq-keepalive-timeout.XXXXXX" 2>/dev/null)" || {
+    log "timeout marker: mktemp failed"
+    printf '{}\n'
+    exit 0
+}
+chmod 0700 "$timeout_dir" 2>/dev/null || true
+timeout_marker="${timeout_dir}/flag"
+trap 'rm -rf -- "$timeout_dir"' EXIT
 
+set -m
 (
     trap 'exit 143' TERM
     run_reattach
 ) 2>> "$LOG_PATH" &
 reattach_pid=$!
+set +m
 (
     "$SLEEP_CMD" "$TIMEOUT_SECONDS"
     if kill -0 "$reattach_pid" 2>/dev/null; then
         : > "$timeout_marker" 2>/dev/null || true
-        pkill -TERM -P "$reattach_pid" 2>/dev/null || true
-        kill -TERM "$reattach_pid" 2>/dev/null || true
+        kill -TERM -- -"$reattach_pid" 2>/dev/null || true
         "$SLEEP_CMD" 1
-        pkill -KILL -P "$reattach_pid" 2>/dev/null || true
-        kill -KILL "$reattach_pid" 2>/dev/null || true
+        kill -KILL -- -"$reattach_pid" 2>/dev/null || true
     fi
 ) >/dev/null 2>&1 &
 watchdog_pid=$!
@@ -158,7 +165,6 @@ kill "$watchdog_pid" 2>/dev/null || true
 wait "$watchdog_pid" 2>/dev/null || true
 
 if [[ -f "$timeout_marker" ]]; then
-    rm -f "$timeout_marker" 2>/dev/null || true
     log "reattach timed out after ${TIMEOUT_SECONDS}s adapter=$ADAPTER target=${TARGET:-auto}"
     printf '{}\n'
     exit 0


### PR DESCRIPTION
## Summary
- Bead **amq-6u0** (review B findings 23 and 24).
- Session-start hook uses a private exclusive `mktemp -d` 0700 timeout dir instead of a PID-named `/tmp` marker.
- Timeout kills the reattach process group (`kill -- -$reattach_pid`); success leaves a ready child alive.
- Test asserts the timeout marker dir is removed on EXIT (trap cleanup).

## Testing
- Mutants: 5/6 killed (predictable marker, file-vs-dir, pkill -P, ready-gate, self-pgid). Trap-drop covered by leftover-dir assertion.
- macOS portability (BSD mktemp, set -m pgid) verified.
- `go test ./internal/keepalive/hookinstall -count=1` green.

## Related
Bead amq-6u0. Review B findings 23, 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ

Made with [Cursor](https://cursor.com)