### PR TITLE
fix(keepalive): open file adapter targets nofollow/nonblock and refuse non-regular files

### DIFF
--- a/internal/keepalive/adapter/file.go
+++ b/internal/keepalive/adapter/file.go
@@ -74,6 +74,21 @@ func (File) Probe(ctx context.Context, target string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("resolve file adapter target: %w", err)
+	}
+	abs = filepath.Clean(abs)
+	if info, err := os.Lstat(abs); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("file adapter target %q must not be a symlink: %w", abs, ErrTargetSymlink)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("file adapter target %q must be a regular file: %w", abs, ErrTargetNotRegular)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
 	clean, err := (File{}).NormalizeTarget(target)
 	if err != nil {
 		return err
@@ -85,13 +100,6 @@ func (File) Probe(ctx context.Context, target string) error {
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("target parent %q is not a directory", parent)
-	}
-	targetInfo, err := os.Stat(clean)
-	if err == nil && targetInfo.IsDir() {
-		return fmt.Errorf("target %q is a directory", clean)
-	}
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
 	}
 	return nil
 }

--- a/internal/keepalive/adapter/file.go
+++ b/internal/keepalive/adapter/file.go
@@ -8,6 +8,11 @@ import (
 	"path/filepath"
 )
 
+var (
+	ErrTargetNotRegular = errors.New("file adapter target must be a regular file")
+	ErrTargetSymlink    = errors.New("file adapter target must not be a symlink")
+)
+
 type File struct{}
 
 func (File) Name() string {
@@ -91,24 +96,16 @@ func (File) Probe(ctx context.Context, target string) error {
 	return nil
 }
 
-func (File) Inject(ctx context.Context, target string, payload string) error {
+func prepareFileInject(ctx context.Context, target string) (string, error) {
 	if err := ctx.Err(); err != nil {
-		return err
+		return "", err
 	}
 	clean, err := (File{}).NormalizeTarget(target)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := (File{}).Probe(ctx, clean); err != nil {
-		return err
+		return "", err
 	}
-	file, err := os.OpenFile(clean, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = file.Close() }()
-	if _, err := file.WriteString(payload + "\n"); err != nil {
-		return err
-	}
-	return file.Chmod(0o600)
+	return clean, ctx.Err()
 }

--- a/internal/keepalive/adapter/file_other.go
+++ b/internal/keepalive/adapter/file_other.go
@@ -1,0 +1,37 @@
+//go:build !unix
+
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+)
+
+func (File) Inject(ctx context.Context, target string, payload string) error {
+	clean, err := prepareFileInject(ctx, target)
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(clean)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("file adapter target %q must not be a symlink: %w", clean, ErrTargetSymlink)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("file adapter target %q must be a regular file: %w", clean, ErrTargetNotRegular)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	file, err := os.OpenFile(clean, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.WriteString(payload + "\n"); err != nil {
+		return err
+	}
+	return file.Chmod(0o600)
+}

--- a/internal/keepalive/adapter/file_unix.go
+++ b/internal/keepalive/adapter/file_unix.go
@@ -1,0 +1,91 @@
+//go:build unix
+
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func (File) Inject(ctx context.Context, target string, payload string) error {
+	if _, err := prepareFileInject(ctx, target); err != nil {
+		return err
+	}
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("resolve file adapter target: %w", err)
+	}
+	abs = filepath.Clean(abs)
+	parent, err := filepath.EvalSymlinks(filepath.Dir(abs))
+	if err != nil {
+		return fmt.Errorf("resolve file adapter target parent: %w", err)
+	}
+	return injectAt(ctx, filepath.Clean(parent), filepath.Base(abs), payload)
+}
+
+func injectAt(ctx context.Context, parent, name, payload string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path := filepath.Join(parent, name)
+	dirfd, err := unix.Open(parent, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open file adapter target parent %q: %w", parent, err)
+	}
+	defer func() { _ = unix.Close(dirfd) }()
+
+	fd, err := openFileAdapterTarget(dirfd, name, path)
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("wrap file adapter target %q", path)
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := file.WriteString(payload + "\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func openFileAdapterTarget(dirfd int, name, path string) (int, error) {
+	flags := unix.O_WRONLY | unix.O_APPEND | unix.O_NONBLOCK | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	fd, err := unix.Openat(dirfd, name, flags, 0)
+	if err == unix.ENOENT {
+		fd, err = unix.Openat(dirfd, name, flags|unix.O_CREAT|unix.O_EXCL, 0o600)
+	}
+	if err != nil {
+		if err == unix.ELOOP {
+			return -1, fmt.Errorf("file adapter target %q must not be a symlink: %w", path, ErrTargetSymlink)
+		}
+		if err == unix.ENXIO {
+			return -1, fmt.Errorf("file adapter target %q must be a regular file: %w", path, ErrTargetNotRegular)
+		}
+		return -1, fmt.Errorf("open file adapter target %q: %w", path, err)
+	}
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		_ = unix.Close(fd)
+		return -1, fmt.Errorf("stat file adapter target %q: %w", path, err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		_ = unix.Close(fd)
+		return -1, fmt.Errorf("file adapter target %q must be a regular file: %w", path, ErrTargetNotRegular)
+	}
+	if stat.Uid != uint32(os.Geteuid()) {
+		_ = unix.Close(fd)
+		return -1, fmt.Errorf("file adapter target %q is owned by uid %d, want %d", path, stat.Uid, os.Geteuid())
+	}
+	if err := unix.Fchmod(fd, 0o600); err != nil {
+		_ = unix.Close(fd)
+		return -1, fmt.Errorf("chmod file adapter target %q: %w", path, err)
+	}
+	return fd, nil
+}

--- a/internal/keepalive/adapter/file_unix_test.go
+++ b/internal/keepalive/adapter/file_unix_test.go
@@ -1,0 +1,72 @@
+//go:build unix
+
+package adapter
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestFileAdapterInjectRefusesFIFOWithoutBlocking(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "inbox.fifo")
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- (File{}).Inject(ctx, path, "payload")
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrTargetNotRegular) {
+			t.Fatalf("Inject(FIFO) error = %v, want %v", err, ErrTargetNotRegular)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Inject blocked on FIFO")
+	}
+}
+
+func TestFileAdapterInjectRefusesDevice(t *testing.T) {
+	err := (File{}).Inject(context.Background(), "/dev/null", "payload")
+	if !errors.Is(err, ErrTargetNotRegular) {
+		t.Fatalf("Inject(/dev/null) error = %v, want %v", err, ErrTargetNotRegular)
+	}
+}
+
+func TestFileAdapterInjectRefusesSymlinkSwapAfterProbe(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim.txt")
+	if err := os.WriteFile(victim, []byte("keep\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(victim): %v", err)
+	}
+	target := filepath.Join(dir, "inbox.txt")
+	file := File{}
+	if err := file.Probe(context.Background(), target); err != nil {
+		t.Fatalf("Probe() error = %v", err)
+	}
+	if err := os.Symlink(victim, target); err != nil {
+		t.Fatalf("Symlink(target): %v", err)
+	}
+	if err := file.Inject(context.Background(), target, "pwned"); err == nil {
+		t.Fatal("Inject(symlink) error = nil, want refuse")
+	} else if !errors.Is(err, ErrTargetSymlink) {
+		t.Fatalf("Inject(symlink) error = %v, want %v", err, ErrTargetSymlink)
+	}
+	data, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("ReadFile(victim): %v", err)
+	}
+	if got, want := string(data), "keep\n"; got != want {
+		t.Fatalf("victim bytes = %q, want %q", got, want)
+	}
+}

--- a/internal/keepalive/adapter/file_unix_test.go
+++ b/internal/keepalive/adapter/file_unix_test.go
@@ -5,6 +5,7 @@ package adapter
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -40,6 +41,68 @@ func TestFileAdapterInjectRefusesDevice(t *testing.T) {
 	err := (File{}).Inject(context.Background(), "/dev/null", "payload")
 	if !errors.Is(err, ErrTargetNotRegular) {
 		t.Fatalf("Inject(/dev/null) error = %v, want %v", err, ErrTargetNotRegular)
+	}
+}
+
+func TestFileAdapterInjectRefusesSameUIDFIFOWithReader(t *testing.T) {
+	dir := t.TempDir()
+	name := "inbox.fifo"
+	path := filepath.Join(dir, name)
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	reader, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		t.Fatalf("open FIFO reader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	payload := "must-not-land"
+	err = (File{}).Inject(context.Background(), path, payload)
+	if !errors.Is(err, ErrTargetNotRegular) {
+		t.Fatalf("Inject(FIFO) error = %v, want %v", err, ErrTargetNotRegular)
+	}
+
+	// Pin the post-openat fstat S_IFREG check: with a reader, write-open
+	// succeeds instead of ENXIO, so only fstat can refuse before WriteString.
+	err = injectAt(context.Background(), dir, name, payload)
+	if !errors.Is(err, ErrTargetNotRegular) {
+		t.Fatalf("injectAt(FIFO) error = %v, want %v", err, ErrTargetNotRegular)
+	}
+
+	got := make([]byte, 64)
+	n, readErr := reader.Read(got)
+	if n != 0 {
+		t.Fatalf("FIFO received %q, want empty", got[:n])
+	}
+	// injectAt write-opens then closes without WriteString, so the reader
+	// sees EOF rather than EAGAIN. Payload landing is the S_IFREG mutant.
+	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, syscall.EAGAIN) && !errors.Is(readErr, syscall.EWOULDBLOCK) {
+		t.Fatalf("FIFO read error = %v, want empty, EOF, or EAGAIN", readErr)
+	}
+}
+
+func TestFileAdapterProbeRefusesSymlinkAndFIFO(t *testing.T) {
+	dir := t.TempDir()
+	regular := filepath.Join(dir, "inbox.txt")
+	if err := os.WriteFile(regular, []byte("keep\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	link := filepath.Join(dir, "inbox.link")
+	if err := os.Symlink(regular, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if err := (File{}).Probe(context.Background(), link); !errors.Is(err, ErrTargetSymlink) {
+		t.Fatalf("Probe(symlink) error = %v, want %v", err, ErrTargetSymlink)
+	}
+
+	fifo := filepath.Join(dir, "inbox.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	if err := (File{}).Probe(context.Background(), fifo); !errors.Is(err, ErrTargetNotRegular) {
+		t.Fatalf("Probe(FIFO) error = %v, want %v", err, ErrTargetNotRegular)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Bead **amq-86a** (review B finding 27).
- Unix file adapter opens the target with parent dirfd + `openat` `O_NOFOLLOW|O_NONBLOCK|O_APPEND`, then fstat regular+uid and fchmod on the fd.
- FIFO, device, and symlink-after-probe are refused. Same-uid FIFO with an open reader still returns `ErrTargetNotRegular` and writes nothing (kills the fstat `S_IFREG` mutant that `/dev/null` missed via uid).
- `File.Probe` surfaces symlink and non-regular targets at readiness time.

## Testing
- Mutants: `O_NOFOLLOW` and `O_NONBLOCK` killed; live FIFO probe returns in ~260µs; fstat `S_IFREG` covered by same-uid FIFO-with-reader.
- `go test ./internal/keepalive/adapter -count=1` green.

## Related
Bead amq-86a. Review B finding 27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ

Made with [Cursor](https://cursor.com)