### PR TITLE
fix(launch): refuse undecided apply, map unsupported create, and require exact journal identities

### DIFF
--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -184,6 +187,36 @@ type launchJournalCleanupReport struct {
 	ResourceEvidence string                    `json:"resource_evidence"`
 }
 
+const launchJournalRelativePath = "meta/launch/journal.json"
+
+func loadLaunchJournalForCleanup(root *fsq.DeliveryRoot) (launch.LaunchJournal, []byte, error) {
+	file, info, err := root.OpenRegularNoFollow(launchJournalRelativePath)
+	if err != nil {
+		return launch.LaunchJournal{}, nil, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Mode().Perm() != 0o600 {
+		return launch.LaunchJournal{}, nil, fmt.Errorf("launch journal permissions are %04o, want 0600", info.Mode().Perm())
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return launch.LaunchJournal{}, nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var record launch.LaunchJournal
+	if err := decoder.Decode(&record); err != nil {
+		return launch.LaunchJournal{}, nil, fmt.Errorf("decode launch journal: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return launch.LaunchJournal{}, nil, fmt.Errorf("decode launch journal: multiple JSON values")
+		}
+		return launch.LaunchJournal{}, nil, fmt.Errorf("decode launch journal: %w", err)
+	}
+	return record, data, nil
+}
+
 func cleanupLaunchJournal(root string, jsonOutput, dryRun, yes bool) error {
 	identity, err := fsq.SnapshotDeliveryRoot(root)
 	if err != nil {
@@ -194,7 +227,7 @@ func cleanupLaunchJournal(root string, jsonOutput, dryRun, yes bool) error {
 		return err
 	}
 	defer func() { _ = deliveryRoot.Close() }()
-	record, err := launch.LoadJournal(deliveryRoot)
+	record, raw, err := loadLaunchJournalForCleanup(deliveryRoot)
 	if err != nil {
 		return err
 	}
@@ -230,7 +263,7 @@ func cleanupLaunchJournal(root string, jsonOutput, dryRun, yes bool) error {
 		return err
 	}
 	defer func() { _ = lease.Release() }()
-	if err := launch.ClearJournal(deliveryRoot, lease, record); err != nil {
+	if err := launch.ClearJournalRaw(deliveryRoot, lease, raw); err != nil {
 		return err
 	}
 	if jsonOutput {

--- a/internal/cli/cleanup_launch_journal_test.go
+++ b/internal/cli/cleanup_launch_journal_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -99,5 +100,85 @@ func TestCleanupLaunchJournalReportsExactTargetAndRequiresExplicitRoot(t *testin
 	}
 	if _, err := launch.LoadJournal(root); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("journal after cleanup: %v", err)
+	}
+}
+
+func TestReconcileUnreadableJournalIsActionRequiredAndCleanupRemovesExactRawJournal(t *testing.T) {
+	rootPath := t.TempDir()
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	nonce := "019c8a2f-2b13-7000-8000-000000000021"
+	project := t.TempDir()
+	config := launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: "collab", Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+		Agents: []launch.ProjectAgentConfig{{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: launch.ResumeEnabled}},
+	}
+	plan := launch.Plan{Version: launch.PlanVersion, Agents: []launch.AgentPlan{{
+		Handle: "claude", Argv: []string{"/usr/bin/true", nonce}, Cwd: project,
+		AdapterMode: launch.AdapterModeMint, ResumePolicy: launch.ResumeEnabled,
+		LaunchNonce: nonce, ConversationID: nonce,
+		DynamicArgv: []launch.DynamicArg{{Index: 1, Kind: launch.DynamicArgLaunchNonce}},
+	}}}
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := launch.NewLaunchJournal(
+		launch.ReconcileRequest{ProjectRoot: project, Session: "collab", Root: root, Config: config},
+		"test", launch.DetectResult{Available: true, Profile: launch.Profile{Backend: "test", Platform: "test", VersionRange: "*", Version: 1, Capabilities: []launch.Capability{launch.CapCreate}}, HostIdentity: "host:test", InstanceIdentity: "instance:test"},
+		plan, digest, nonce,
+		[]launch.AgentReconcileResult{{Handle: "claude", ConversationDisposition: launch.DispositionFresh}},
+		[]launch.ConversationRecord{{Version: launch.ConversationVersion, Handle: "claude", State: launch.CapturePending, ProviderVersion: "test", LaunchNonce: nonce}},
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := launch.AcquireLease(root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.WriteJournal(root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+
+	record.ProjectPhysical, record.RootPhysical = "", ""
+	raw, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = append(raw, '\n')
+	if err := os.WriteFile(launch.JournalPath(rootPath), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reconciled, err := launch.Reconcile(launch.ReconcileRequest{
+		Context: context.Background(), ProjectRoot: project, Session: "collab", Root: root,
+		Config: config, Launcher: "test", Preferences: []string{"test"},
+		Backends: map[string]launch.Backend{"test": launch.Commands{}},
+		Adapters: map[string]launch.HarnessAdapter{}, HostIdentity: "host:test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reconciled.Outcome != launch.OutcomeActionRequired || reconciled.AggregateCode != 6 || reconciled.Reason != "launch_journal_unreadable" {
+		t.Fatalf("Reconcile unreadable journal = %#v, want action_required launch_journal_unreadable", reconciled)
+	}
+
+	if err := runCleanup([]string{"--launch-journal", "--root", rootPath, "--yes"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(launch.JournalPath(rootPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unreadable journal after cleanup: %v", err)
 	}
 }

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	ApplyOutcomeApplied               = "applied"
-	ApplyOutcomeActionRequired        = "action_required"
-	ApplyOutcomeProvisionedNoRunnable = "provisioned_no_runnable"
+	ApplyOutcomeApplied                             = "applied"
+	ApplyOutcomeActionRequired                      = "action_required"
+	ApplyOutcomeProvisionedNoRunnable               = "provisioned_no_runnable"
+	ApplyReasonPrepareActionRequiredWithoutDecision = "prepare_action_required_without_decision"
 )
 
 type ApplyDecision struct {
@@ -143,6 +144,9 @@ func authorizeApply(ctx context.Context, request ApplyRequest, dependencies Appl
 	}
 	if prepared.Outcome == PrepareOutcomeUnsupported {
 		return prepared, nil, applyActionResult(prepared, prepared.Reason), false, nil
+	}
+	if prepared.Outcome == PrepareOutcomeActionRequired && len(prepared.RequiredActions) == 0 {
+		return prepared, nil, applyActionResult(prepared, ApplyReasonPrepareActionRequiredWithoutDecision), false, nil
 	}
 	decisions, reason := validateApplyDecisions(prepared.RequiredActions, request.Decisions)
 	if reason != "" {

--- a/internal/launch/apply_test.go
+++ b/internal/launch/apply_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -229,6 +230,109 @@ func TestApplyDoesNotPromoteNoActionToApplied(t *testing.T) {
 	}
 	if backend.creates != 0 {
 		t.Fatalf("unavailable adapter created backend resources: %d", backend.creates)
+	}
+}
+
+type applyInspectUnknownBackend struct{ prepareTestBackend }
+
+func (backend *applyInspectUnknownBackend) Inspect(InspectRequest) (InspectResult, error) {
+	backend.inspects++
+	return InspectResult{Status: InspectUnknown, Evidence: "test inspection unavailable", ActionRequired: true}, nil
+}
+
+func TestApplyRefusesActionRequiredWithoutDecisionBeforeRosterMutation(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	fixture.request.Participants[0] = PrepareParticipant{Handle: "claude", Runnable: false}
+	backend := &applyInspectUnknownBackend{}
+	writePrepareBinding(t, fixture.sessionRoot, prepareBinding("host:test", "instance:test", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+	dependencies := PrepareDependencies{
+		Backends:     map[string]Backend{"test": backend},
+		Preferences:  []string{"test"},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test",
+	}
+	prepared, err := Prepare(context.Background(), fixture.request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Outcome != PrepareOutcomeActionRequired || len(prepared.RequiredActions) != 0 {
+		t.Fatalf("Prepare = %#v, want action_required without decisions", prepared)
+	}
+	before := prepareTreeSnapshot(t, fixture.sessionRoot)
+	result, err := Apply(context.Background(), ApplyRequest{
+		Prepare:       fixture.request,
+		SubjectDigest: prepared.SubjectDigest,
+	}, ApplyDependencies{PrepareDependencies: dependencies})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != ApplyReasonPrepareActionRequiredWithoutDecision {
+		t.Fatalf("Apply = %#v, want typed action-required refusal", result)
+	}
+	if after := prepareTreeSnapshot(t, fixture.sessionRoot); after != before {
+		t.Fatalf("Apply mutated roster/config on action_required without decision: before=%s after=%s", before, after)
+	}
+}
+
+type applyUnsupportedNoCreateBackend struct{ reconcileBackend }
+
+func (backend *applyUnsupportedNoCreateBackend) Detect() DetectResult {
+	profile := Profile{Backend: backend.name, Platform: "test", VersionRange: "*", Version: 1, Capabilities: []Capability{CapInspect}}
+	return DetectResult{Available: true, Profile: profile, Effective: slices.Clone(profile.Capabilities), HostIdentity: "host:test", InstanceIdentity: "instance:test"}
+}
+
+func (backend *applyUnsupportedNoCreateBackend) Create(CreateRequest) (CreateResult, error) {
+	backend.creates++
+	return CreateResult{Outcome: OutcomeUnsupported, Reason: "test backend unsupported"}, nil
+}
+
+func applyF31Result(t *testing.T, backend Backend) ApplyResult {
+	t.Helper()
+	providerBin := t.TempDir()
+	providerPath := filepath.Join(providerBin, "claude")
+	if err := os.WriteFile(providerPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", providerBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	fixture := newInternalPrepareFixture(t)
+	store, err := OpenTrustStore(t.TempDir(), fixture.projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"},
+		AdapterFor:   func(provider, executable string) HarnessAdapter { return prepareTestAdapter{provider: provider} },
+		HostIdentity: "host:test", TrustStore: store,
+	}}
+	prepared, err := Prepare(context.Background(), fixture.request, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: fixture.request, SubjectDigest: prepared.SubjectDigest}
+	for _, action := range prepared.RequiredActions {
+		request.Decisions = append(request.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: "trust_exact_subject"})
+	}
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestApplyMapsUnsupportedCreateToActionRequiredAndSupportedCreateToApplied(t *testing.T) {
+	unsupported := &applyUnsupportedNoCreateBackend{reconcileBackend: reconcileBackend{name: "test", inspect: InspectAbsent}}
+	unsupportedResult := applyF31Result(t, unsupported)
+	if unsupportedResult.Outcome != ApplyOutcomeActionRequired || unsupportedResult.ReasonCode != "test backend unsupported" {
+		t.Fatalf("unsupported Apply result = %#v, want action_required", unsupportedResult)
+	}
+	if unsupportedResult.Outcome == ApplyOutcomeApplied {
+		t.Fatal("unsupported Create was promoted to Applied")
+	}
+
+	supported := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	supportedResult := applyF31Result(t, supported)
+	if supportedResult.Outcome != ApplyOutcomeApplied {
+		t.Fatalf("supported Apply result = %#v, want applied", supportedResult)
 	}
 }
 

--- a/internal/launch/journal.go
+++ b/internal/launch/journal.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -21,6 +22,9 @@ const (
 	JournalVersion  = 1
 	journalFilename = "journal.json"
 )
+
+var stableTreeIdentity = fsq.StableTreeIdentity
+var stableTreeIdentityInfo = fsq.StableTreeIdentityInfo
 
 type JournalPhase string
 
@@ -78,6 +82,9 @@ func (record LaunchJournal) Validate() error {
 	if !filepath.IsAbs(record.RootIdentity) || filepath.Clean(record.RootIdentity) != record.RootIdentity {
 		return fmt.Errorf("root identity must be a canonical absolute path")
 	}
+	if strings.TrimSpace(record.ProjectPhysical) == "" || strings.TrimSpace(record.RootPhysical) == "" {
+		return fmt.Errorf("launch journal physical identities are required")
+	}
 	if !canonicalSessionPattern.MatchString(record.Session) || strings.HasPrefix(record.Session, "-") {
 		return fmt.Errorf("invalid launch journal session %q", record.Session)
 	}
@@ -111,7 +118,7 @@ func (record LaunchJournal) Validate() error {
 	if digest != record.PlanDigest {
 		return fmt.Errorf("launch journal plan digest mismatch")
 	}
-	if len(record.Agents) == 0 || len(record.Conversations) != len(record.Plan.Agents) {
+	if len(record.Agents) == 0 || len(record.Agents) != len(record.Plan.Agents) || len(record.Conversations) != len(record.Plan.Agents) {
 		return fmt.Errorf("launch journal roster lengths do not match")
 	}
 	agentHandles := make(map[string]struct{}, len(record.Agents))
@@ -192,8 +199,14 @@ func NewLaunchJournal(request ReconcileRequest, backend string, detect DetectRes
 		Placement:     preview,
 		CallerContext: cloneCallerContext(request.CallerContext),
 	}
-	record.ProjectPhysical, _ = fsq.StableTreeIdentity(projectIdentity)
-	record.RootPhysical, _ = fsq.StableTreeIdentityInfo(request.Root.FileInfo())
+	record.ProjectPhysical, err = stableTreeIdentity(projectIdentity)
+	if err != nil {
+		return LaunchJournal{}, fmt.Errorf("resolve project physical identity: %w", err)
+	}
+	record.RootPhysical, err = stableTreeIdentityInfo(request.Root.FileInfo())
+	if err != nil {
+		return LaunchJournal{}, fmt.Errorf("resolve session root physical identity: %w", err)
+	}
 	if err := record.Validate(); err != nil {
 		return LaunchJournal{}, err
 	}
@@ -216,8 +229,14 @@ func (record LaunchJournal) ValidateRequest(request ReconcileRequest) error {
 	if record.ProjectIdentity != projectIdentity || record.RootIdentity != rootIdentity || record.Session != request.Session {
 		return fmt.Errorf("launch journal belongs to a different project or session root")
 	}
-	projectPhysical, _ := fsq.StableTreeIdentity(projectIdentity)
-	rootPhysical, _ := fsq.StableTreeIdentityInfo(request.Root.FileInfo())
+	projectPhysical, err := stableTreeIdentity(projectIdentity)
+	if err != nil {
+		return fmt.Errorf("resolve project physical identity: %w", err)
+	}
+	rootPhysical, err := stableTreeIdentityInfo(request.Root.FileInfo())
+	if err != nil {
+		return fmt.Errorf("resolve session root physical identity: %w", err)
+	}
 	if (record.ProjectPhysical != "" && record.ProjectPhysical != projectPhysical) ||
 		(record.RootPhysical != "" && record.RootPhysical != rootPhysical) {
 		return fmt.Errorf("launch journal physical project or session root changed")
@@ -303,6 +322,23 @@ func ClearJournal(root *fsq.DeliveryRoot, lease *Lease, expected LaunchJournal) 
 		return err
 	}
 	if !reflect.DeepEqual(current, expected) {
+		return fmt.Errorf("launch journal changed before clear")
+	}
+	return root.Remove(filepath.Join(bindingDirectory, journalFilename))
+}
+
+// ClearJournalRaw removes a journal after an exact byte-for-byte compare. It
+// is reserved for operator cleanup of a journal whose semantic validation
+// fails, while retaining the same lease and replacement guard as ClearJournal.
+func ClearJournalRaw(root *fsq.DeliveryRoot, lease *Lease, expected []byte) error {
+	if err := lease.authorizeWrite(root); err != nil {
+		return err
+	}
+	current, err := root.ReadFile(filepath.Join(bindingDirectory, journalFilename))
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(current, expected) {
 		return fmt.Errorf("launch journal changed before clear")
 	}
 	return root.Remove(filepath.Join(bindingDirectory, journalFilename))

--- a/internal/launch/journal_test.go
+++ b/internal/launch/journal_test.go
@@ -129,6 +129,75 @@ func TestLaunchJournalRejectsPlanRosterAndBindingDrift(t *testing.T) {
 	}
 }
 
+func TestLaunchJournalRejectsExtraAgentRecord(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	request := reconcileFixture(t, backend)
+	nonce := "019c8a2f-2b13-7000-8000-000000000013"
+	plan, agents, conversations := journalFixturePlan(nonce)
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := NewLaunchJournal(request, backend.name, backend.Detect(), plan, digest, nonce, agents, conversations, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	record.Agents = append(record.Agents, AgentReconcileResult{Handle: "operator", ConversationDisposition: DispositionFresh})
+	if err := record.Validate(); err == nil || !strings.Contains(err.Error(), "roster lengths") {
+		t.Fatalf("journal accepted extra agent record: %v", err)
+	}
+}
+
+func TestNewLaunchJournalFailsClosedOnPhysicalIdentityProbeError(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	request := reconcileFixture(t, backend)
+	nonce := "019c8a2f-2b13-7000-8000-000000000014"
+	plan, agents, conversations := journalFixturePlan(nonce)
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	probeErr := errors.New("injected physical identity failure")
+	oldTree := stableTreeIdentity
+	oldTreeInfo := stableTreeIdentityInfo
+	t.Cleanup(func() {
+		stableTreeIdentity = oldTree
+		stableTreeIdentityInfo = oldTreeInfo
+	})
+	stableTreeIdentity = func(string) (string, error) { return "", probeErr }
+	if _, err := NewLaunchJournal(request, backend.name, backend.Detect(), plan, digest, nonce, agents, conversations, time.Now()); !errors.Is(err, probeErr) {
+		t.Fatalf("NewLaunchJournal = %v, want physical identity failure", err)
+	}
+
+	stableTreeIdentity = oldTree
+	stableTreeIdentityInfo = func(os.FileInfo) (string, error) { return "", probeErr }
+	if _, err := NewLaunchJournal(request, backend.name, backend.Detect(), plan, digest, nonce, agents, conversations, time.Now()); !errors.Is(err, probeErr) {
+		t.Fatalf("NewLaunchJournal root probe = %v, want physical identity failure", err)
+	}
+}
+
+func TestLaunchJournalValidateRequestFailsClosedOnProjectPhysicalIdentityProbeError(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	request := reconcileFixture(t, backend)
+	nonce := "019c8a2f-2b13-7000-8000-000000000015"
+	plan, agents, conversations := journalFixturePlan(nonce)
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := NewLaunchJournal(request, backend.name, backend.Detect(), plan, digest, nonce, agents, conversations, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	probeErr := errors.New("injected project physical identity failure")
+	oldTree := stableTreeIdentity
+	stableTreeIdentity = func(string) (string, error) { return "", probeErr }
+	t.Cleanup(func() { stableTreeIdentity = oldTree })
+	if err := record.ValidateRequest(request); !errors.Is(err, probeErr) || !strings.Contains(err.Error(), "resolve project physical identity") {
+		t.Fatalf("ValidateRequest = %v, want wrapped project physical identity error", err)
+	}
+}
+
 func journalFixturePlan(nonce string) (Plan, []AgentReconcileResult, []ConversationRecord) {
 	plan := Plan{Version: PlanVersion, Agents: []AgentPlan{{
 		Handle: "claude", Argv: []string{"/usr/bin/true", nonce}, Cwd: "/tmp",

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -362,7 +362,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 
 	if !recoveredCreate {
 		if detect.Profile.Has(CapCreate) && joinBinding == nil {
-			journal, err = NewLaunchJournal(request, backendName, detect, plan, planDigest, nonce, result.Agents, plannedConversations(planned), time.Now())
+			journal, err = NewLaunchJournal(request, backendName, detect, plan, planDigest, nonce, plannedAgentResults(result.Agents, planned), plannedConversations(planned), time.Now())
 			if err != nil {
 				return result, err
 			}
@@ -411,6 +411,15 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		}
 	}
 	result.Outcome, result.Commands = create.Outcome, create.Commands
+	if create.Outcome == OutcomeUnsupported {
+		reason := create.Reason
+		if reason == "" {
+			reason = "backend_unsupported"
+		}
+		markPlannedAgents(&result, planned, 6, reason)
+		result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, reason
+		return result, nil
+	}
 	var candidate *BindingRecord
 	if create.Outcome == OutcomeCreated {
 		if journalActive && journal.Phase == JournalCreated {
@@ -431,7 +440,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 			return result, nil
 		}
 		journal.Phase, journal.Binding = JournalCreated, candidate
-		journal.Agents, journal.Conversations = slices.Clone(result.Agents), plannedConversations(planned)
+		journal.Agents, journal.Conversations = plannedAgentResults(result.Agents, planned), plannedConversations(planned)
 		if err := WriteJournal(request.Root, lease, journal); err != nil {
 			return result, err
 		}
@@ -696,6 +705,14 @@ func plannedConversations(planned []plannedAgent) []ConversationRecord {
 		records[i] = planned[i].record
 	}
 	return records
+}
+
+func plannedAgentResults(results []AgentReconcileResult, planned []plannedAgent) []AgentReconcileResult {
+	rows := make([]AgentReconcileResult, len(planned))
+	for i, agent := range planned {
+		rows[i] = results[agent.index]
+	}
+	return rows
 }
 
 func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []plannedAgent, amqPath, backend, profile string) error {

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -283,6 +283,28 @@ type reconcileBackend struct {
 	planHandles []string
 }
 
+type unsupportedReconcileBackend struct{ reconcileBackend }
+
+func (backend *unsupportedReconcileBackend) Create(CreateRequest) (CreateResult, error) {
+	backend.creates++
+	return CreateResult{Outcome: OutcomeUnsupported, Reason: "test backend unsupported"}, nil
+}
+
+func TestReconcileMapsUnsupportedCreateToActionRequired(t *testing.T) {
+	backend := &unsupportedReconcileBackend{reconcileBackend: reconcileBackend{name: "unsupported"}}
+	request := reconcileFixture(t, backend)
+	result, err := Reconcile(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != OutcomeActionRequired || result.AggregateCode != 6 || result.Reason != "test backend unsupported" {
+		t.Fatalf("unsupported Create result = %#v, want action_required code 6", result)
+	}
+	if len(result.Agents) != 1 || result.Agents[0].Code != 6 || result.Agents[0].Reason != "test backend unsupported" {
+		t.Fatalf("unsupported Create agent result = %#v", result.Agents)
+	}
+}
+
 func (b *reconcileBackend) Detect() DetectResult {
 	profile := Profile{Backend: b.name, Platform: "test", VersionRange: "*", Version: 1, Capabilities: []Capability{CapCreate, CapInspect, CapClose, CapFocus, CapReclaim}}
 	return DetectResult{


### PR DESCRIPTION
Bead amq-201 — ChatGPT Pro review A findings 16, 31, 32, 25.

- Apply refuses a Prepare `action_required` that exposes no `RequiredActions` (typed reason `prepare_action_required_without_decision`) before any roster/config write; previously empty decisions passed and roster/config were mutated before Reconcile refused.
- Reconcile maps a backend `OutcomeUnsupported` (zero agent codes) to code 6 / `action_required`; previously the aggregate stayed 0 and public Apply reported `applied`. Covered at Apply level with a no-`CapCreate` backend (the `journalActive == false` shape that was actually broken).
- Launch journals require an exact `Plan`/`Agents`/`Conversations` handle set; only planned agent results are persisted.
- Journal creation and `ValidateRequest` propagate physical-identity probe errors instead of comparing empty identities. `amq cleanup --launch-journal` now decodes raw JSON (byte-exact CAS via `ClearJournalRaw`) so a journal that newly fails `Validate()` is still removable instead of wedging.

Note: on native Windows `NewLaunchJournal` now fails loud (tree identity is out of scope there); `coop exec` is already unsupported on that platform.

Review: execution-gated, 8 mutants killed across two rounds (undecided-apply guard, write-before-refuse, unsupported mapping at Reconcile and Apply level, extra journal agent, probe-error discard in both NewLaunchJournal and ValidateRequest, validating loader in cleanup); `go test ./internal/launch`, `./internal/cli -run 'Cleanup|LaunchJournal'`, vet, gofmt, diff-check, `GOOS=windows` compile clean; local pre-push `make ci` green.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ