### PR TITLE
fix(launch): contain wrappers and the amq launcher to non-project paths and validate before capabilities

### DIFF
--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -467,6 +467,45 @@ func validateKnownExecutable(executable, projectRoot, provider string) (string, 
 	return executable, nil
 }
 
+// validateExecutableContainment checks the property that must be established
+// before an adapter capability probe: a provider executable must not resolve
+// into the project. Availability and executable shape remain capability/plan
+// concerns; a missing command cannot be a project-contained process.
+func validateExecutableContainment(executable, projectRoot, provider string) error {
+	if strings.TrimSpace(executable) == "" || strings.TrimSpace(projectRoot) == "" {
+		return nil
+	}
+	project, err := resolvedPath(projectRoot)
+	if err != nil {
+		return fmt.Errorf("resolve project root for %s executable: %w", provider, err)
+	}
+	candidate := executable
+	if !filepath.IsAbs(candidate) {
+		lookedUp, lookupErr := exec.LookPath(candidate)
+		if lookupErr != nil {
+			return nil
+		}
+		candidate = lookedUp
+	}
+	requested, err := filepath.Abs(candidate)
+	if err != nil {
+		return fmt.Errorf("make %s executable absolute: %w", provider, err)
+	}
+	if pathWithin(filepath.Clean(requested), project) {
+		return &LaunchPathError{Code: ProviderProjectContainedCode, Path: executable}
+	}
+	resolved, err := resolvedPath(requested)
+	if err != nil {
+		// An unavailable executable is reported by the adapter capability
+		// probe. There is no executable identity to classify as contained.
+		return nil
+	}
+	if pathWithin(resolved, project) {
+		return &LaunchPathError{Code: ProviderProjectContainedCode, Path: executable}
+	}
+	return nil
+}
+
 func validateWorkingDirectory(cwd, projectRoot string) error {
 	resolvedProject, err := resolvedPath(projectRoot)
 	if err != nil {

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -161,7 +161,7 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 	}
 	var wrapperIdentity string
 	if request.Wrapper != nil {
-		if err := validateWrapperFile(request.Wrapper); err != nil {
+		if err := validateWrapperFileForProject(request.Wrapper, request.ProjectRoot); err != nil {
 			return ExecutionTicket{}, fmt.Errorf("wrapper: %w", err)
 		}
 		wrapperIdentity, err = probeExecutableIdentityJSON(request.Wrapper.Executable)
@@ -1040,7 +1040,7 @@ func ValidateExecutionEnvelope(root *fsq.DeliveryRoot, ticket ExecutionTicket, e
 			}
 			return fmt.Errorf("wrapper executable identity changed: %w", identityErr)
 		}
-		if err := validateWrapperFile(ticket.Wrapper); err != nil {
+		if err := validateWrapperFileForProject(ticket.Wrapper, ticket.ProjectRoot); err != nil {
 			return fmt.Errorf("wrapper executable changed: %w", err)
 		}
 		if envelope.ProviderExecutable != ticket.Wrapper.Executable {

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -347,7 +347,7 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	if err := ValidateCallerContext(request.CallerContext); err != nil {
 		return PrepareResult{}, err
 	}
-	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath)
+	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath, request.Target.ProjectRoot)
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -926,7 +926,7 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 		observation.ReasonCode = reason
 		return prepared, observation, nil, nil, nil
 	}
-	if err := validateWrapperFile(participant.Wrapper); err != nil {
+	if err := validateWrapperFileForProject(participant.Wrapper, state.target.ProjectRoot); err != nil {
 		return prepared, observation, nil, nil, fmt.Errorf("wrapper for %s: %w", participant.Handle, err)
 	}
 	if subjectSchema == SubjectSchemaV2 && participant.Wrapper != nil {

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -515,7 +515,7 @@ func plannedFromJournal(request ReconcileRequest, journal LaunchJournal, result 
 		if err := validateWrapperFileForProject(plan.Wrapper, request.ProjectRoot); err != nil {
 			return nil, fmt.Errorf("launch journal wrapper for %q: %w", plan.Handle, err)
 		}
-		if _, err := validateKnownExecutable(cfg.Command[0], request.ProjectRoot, adapter.Name()); err != nil {
+		if err := validateExecutableContainment(cfg.Command[0], request.ProjectRoot, adapter.Name()); err != nil {
 			return nil, fmt.Errorf("launch journal provider for %q: %w", plan.Handle, err)
 		}
 		capabilities := adapter.Capabilities(request.Context)
@@ -793,7 +793,7 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			result.Agents = append(result.Agents, item)
 			continue
 		}
-		if _, err := validateKnownExecutable(cfg.Command[0], request.ProjectRoot, adapter.Name()); err != nil {
+		if err := validateExecutableContainment(cfg.Command[0], request.ProjectRoot, adapter.Name()); err != nil {
 			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
 			result.Agents = append(result.Agents, item)
 			continue

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -134,7 +134,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	if err := request.Config.Validate(); err != nil {
 		return result, err
 	}
-	amqExecutable, err := resolveLaunchAMQExecutable(request.AMQPath)
+	amqExecutable, err := resolveLaunchAMQExecutable(request.AMQPath, request.ProjectRoot)
 	if err != nil {
 		return result, err
 	}
@@ -512,6 +512,12 @@ func plannedFromJournal(request ReconcileRequest, journal LaunchJournal, result 
 		if adapter == nil || adapter.Mode() != plan.AdapterMode {
 			return nil, fmt.Errorf("launch journal adapter for %q is unavailable or changed", plan.Handle)
 		}
+		if err := validateWrapperFileForProject(plan.Wrapper, request.ProjectRoot); err != nil {
+			return nil, fmt.Errorf("launch journal wrapper for %q: %w", plan.Handle, err)
+		}
+		if _, err := validateKnownExecutable(cfg.Command[0], request.ProjectRoot, adapter.Name()); err != nil {
+			return nil, fmt.Errorf("launch journal provider for %q: %w", plan.Handle, err)
+		}
 		capabilities := adapter.Capabilities(request.Context)
 		if err := ValidateAdapterCapabilities(adapter, capabilities); err != nil {
 			return nil, err
@@ -730,7 +736,7 @@ func writeExecutionTickets(request ReconcileRequest, lease *Lease, planned []pla
 	return nil
 }
 
-func resolveLaunchAMQExecutable(value string) (string, error) {
+func resolveLaunchAMQExecutable(value, projectRoot string) (string, error) {
 	if strings.TrimSpace(value) == "" {
 		path, err := os.Executable()
 		if err != nil {
@@ -745,6 +751,17 @@ func resolveLaunchAMQExecutable(value string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		return "", fmt.Errorf("resolve amq executable identity: %w", err)
+	}
+	project, err := resolvedPath(projectRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve project root for amq executable: %w", err)
+	}
+	requested, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve amq executable path: %w", err)
+	}
+	if pathWithin(requested, project) || pathWithin(resolved, project) {
+		return "", &LaunchPathError{Code: AMQProjectContainedCode, Path: path}
 	}
 	return resolved, nil
 }
@@ -773,6 +790,16 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 		adapter := request.Adapters[cfg.Adapter]
 		if adapter == nil {
 			item.ConversationDisposition, item.Reason = DispositionUnsupported, "adapter_not_registered"
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		if _, err := validateKnownExecutable(cfg.Command[0], request.ProjectRoot, adapter.Name()); err != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
+			result.Agents = append(result.Agents, item)
+			continue
+		}
+		if err := validateWrapperFileForProject(cfg.Wrapper, request.ProjectRoot); err != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionDegraded, err.Error()
 			result.Agents = append(result.Agents, item)
 			continue
 		}

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -39,6 +39,90 @@ func TestReconcileEmitsCanonicalResolvedWorkingDirectory(t *testing.T) {
 	}
 }
 
+func TestReconcileRejectsProjectProviderBeforeCapabilities(t *testing.T) {
+	req := reconcileFixture(t, Commands{})
+	provider, sentinel := writeProjectSideEffectingClaude(t, req.ProjectRoot)
+	t.Setenv("PATH", filepath.Dir(provider)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AMQ_419_SENTINEL", sentinel)
+	req.Adapters = map[string]HarnessAdapter{ClaudeProvider: NewClaudeAdapter(ClaudeProvider)}
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || len(result.Agents) != 1 || !strings.Contains(result.Agents[0].Reason, "inside the project") {
+		t.Fatalf("project provider result = %#v, want typed containment refusal", result)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("project provider capability probe ran side effect: %v", err)
+	}
+}
+
+func TestReconcileJournalRejectsProjectProviderBeforeCapabilities(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	provider, sentinel := writeProjectSideEffectingClaude(t, req.ProjectRoot)
+	t.Setenv("PATH", filepath.Dir(provider)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AMQ_419_SENTINEL", sentinel)
+	nonce := "019c8a2f-2b13-7000-8000-000000000099"
+	plan, agents, conversations := journalFixturePlan(nonce)
+	plan.Agents[0].Argv[0] = provider
+	digest, err := plan.SemanticDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := NewLaunchJournal(req, backend.name, backend.Detect(), plan, digest, nonce, agents, conversations, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := AcquireLease(req.Root, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteJournal(req.Root, lease, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	req.Adapters = map[string]HarnessAdapter{ClaudeProvider: NewClaudeAdapter(ClaudeProvider)}
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Reason != "launch_journal_plan_unavailable" {
+		t.Fatalf("project provider journal result = %#v, want plan refusal", result)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("journal capability probe ran side effect: %v", err)
+	}
+}
+
+func TestResolveLaunchAMQExecutableRejectsProjectPath(t *testing.T) {
+	project := t.TempDir()
+	inside := filepath.Join(project, "amq")
+	if err := os.WriteFile(inside, []byte("amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveLaunchAMQExecutable(inside, project); err == nil || !strings.Contains(err.Error(), AMQProjectContainedCode) {
+		t.Fatalf("project-contained AMQ path error = %v, want %s", err, AMQProjectContainedCode)
+	}
+}
+
+func writeProjectSideEffectingClaude(t *testing.T, project string) (string, string) {
+	t.Helper()
+	bin := filepath.Join(project, "bin")
+	if err := os.MkdirAll(bin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	provider := filepath.Join(bin, ClaudeProvider)
+	sentinel := filepath.Join(project, "capability-probe-ran")
+	script := "#!/bin/sh\nprintf touched > \"$AMQ_419_SENTINEL\"\n"
+	if err := os.WriteFile(provider, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return provider, sentinel
+}
+
 func TestReconcileUsesAndRetainsCallerHeldLease(t *testing.T) {
 	req := reconcileFixture(t, Commands{})
 	lease, err := AcquireLease(req.Root, "")

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -52,8 +52,33 @@ func TestReconcileRejectsProjectProviderBeforeCapabilities(t *testing.T) {
 	if result.AggregateCode != 6 || len(result.Agents) != 1 || !strings.Contains(result.Agents[0].Reason, "inside the project") {
 		t.Fatalf("project provider result = %#v, want typed containment refusal", result)
 	}
+	if !strings.Contains(result.Agents[0].Reason, ProviderProjectContainedCode) {
+		t.Fatalf("project provider reason = %q, want %s", result.Agents[0].Reason, ProviderProjectContainedCode)
+	}
 	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
 		t.Fatalf("project provider capability probe ran side effect: %v", err)
+	}
+}
+
+func TestReconcileRejectsProjectAMQBeforeCreateQuickly(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	amq := filepath.Join(req.ProjectRoot, "amq")
+	if err := os.WriteFile(amq, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	req.AMQPath = amq
+	started := time.Now()
+	_, err := Reconcile(req)
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("project-contained AMQ refusal took %s", elapsed)
+	}
+	var pathErr *LaunchPathError
+	if err == nil || !errors.As(err, &pathErr) || pathErr.Code != AMQProjectContainedCode {
+		t.Fatalf("AMQ refusal error = %v, want typed code %s", err, AMQProjectContainedCode)
+	}
+	if backend.creates != 0 {
+		t.Fatalf("project-contained AMQ refusal created %d resources", backend.creates)
 	}
 }
 

--- a/internal/launch/wrapper.go
+++ b/internal/launch/wrapper.go
@@ -15,8 +15,9 @@ type Wrapper struct {
 }
 
 const (
-	WrapperProjectContainedCode = "wrapper_project_contained"
-	AMQProjectContainedCode     = "amq_launcher_project_contained"
+	WrapperProjectContainedCode  = "wrapper_project_contained"
+	ProviderProjectContainedCode = "provider_project_contained"
+	AMQProjectContainedCode      = "amq_launcher_project_contained"
 )
 
 type LaunchPathError struct {
@@ -25,7 +26,7 @@ type LaunchPathError struct {
 }
 
 func (e *LaunchPathError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Code, e.Path)
+	return fmt.Sprintf("%s: %s resolves inside the project", e.Code, e.Path)
 }
 
 func (wrapper Wrapper) Validate() error {

--- a/internal/launch/wrapper.go
+++ b/internal/launch/wrapper.go
@@ -14,6 +14,20 @@ type Wrapper struct {
 	Args       []string `json:"args,omitempty"`
 }
 
+const (
+	WrapperProjectContainedCode = "wrapper_project_contained"
+	AMQProjectContainedCode     = "amq_launcher_project_contained"
+)
+
+type LaunchPathError struct {
+	Code string
+	Path string
+}
+
+func (e *LaunchPathError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Path)
+}
+
 func (wrapper Wrapper) Validate() error {
 	if !utf8.ValidString(wrapper.Executable) || strings.ContainsRune(wrapper.Executable, 0) {
 		return fmt.Errorf("executable must be valid UTF-8 without NUL")
@@ -48,6 +62,31 @@ func validateWrapperFile(wrapper *Wrapper) error {
 	}
 	if err := validateWrapperExecutable(wrapper.Executable, info.Mode()); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateWrapperFileForProject(wrapper *Wrapper, projectRoot string) error {
+	if wrapper == nil {
+		return nil
+	}
+	if err := validateWrapperFile(wrapper); err != nil {
+		return err
+	}
+	project, err := resolvedPath(projectRoot)
+	if err != nil {
+		return fmt.Errorf("resolve project root for wrapper: %w", err)
+	}
+	requested, err := filepath.Abs(wrapper.Executable)
+	if err != nil {
+		return fmt.Errorf("resolve wrapper path: %w", err)
+	}
+	resolved, err := resolvedPath(wrapper.Executable)
+	if err != nil {
+		return fmt.Errorf("resolve wrapper executable: %w", err)
+	}
+	if pathWithin(requested, project) || pathWithin(resolved, project) {
+		return &LaunchPathError{Code: WrapperProjectContainedCode, Path: wrapper.Executable}
 	}
 	return nil
 }

--- a/internal/launch/wrapper_test.go
+++ b/internal/launch/wrapper_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -79,6 +80,39 @@ func TestWrapperValidationRejectsNonExecutableRegularFile(t *testing.T) {
 	}
 	if err := validateWrapperFile(&Wrapper{Executable: path}); err == nil || !strings.Contains(err.Error(), "execute") {
 		t.Fatalf("non-executable wrapper error = %v", err)
+	}
+}
+
+func TestWrapperProjectContainmentRejectsProjectPathAndAcceptsOutside(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	if err := os.Mkdir(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	inside := filepath.Join(project, "wrapper")
+	if err := os.WriteFile(inside, []byte("wrapper"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	err := validateWrapperFileForProject(&Wrapper{Executable: inside}, project)
+	var pathErr *LaunchPathError
+	if !errors.As(err, &pathErr) || pathErr.Code != WrapperProjectContainedCode {
+		t.Fatalf("project wrapper error = %v, want %s", err, WrapperProjectContainedCode)
+	}
+	projectLink := filepath.Join(root, "project-link")
+	if err := os.Symlink(inside, projectLink); err != nil {
+		t.Fatal(err)
+	}
+	err = validateWrapperFileForProject(&Wrapper{Executable: projectLink}, project)
+	if !errors.As(err, &pathErr) || pathErr.Code != WrapperProjectContainedCode {
+		t.Fatalf("symlinked project wrapper error = %v, want %s", err, WrapperProjectContainedCode)
+	}
+
+	outside := filepath.Join(root, "wrapper")
+	if err := os.WriteFile(outside, []byte("wrapper"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateWrapperFileForProject(&Wrapper{Executable: outside}, project); err != nil {
+		t.Fatalf("outside wrapper rejected: %v", err)
 	}
 }
 

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -183,6 +183,23 @@ func TestPrepareWrapperComposesVerbatimArgvAndChangesAllDigests(t *testing.T) {
 	}
 }
 
+func TestPrepareRejectsProjectContainedWrapperAndAcceptsOutside(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, true)
+	inside := filepath.Join(fixture.request.Target.ProjectRoot, "wrapper")
+	if err := os.WriteFile(inside, []byte("wrapper"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fixture.request.Intent.Participants[0].Wrapper = &WrapperV1{Executable: inside}
+	if _, err := Prepare(context.Background(), fixture.request); err == nil || !strings.Contains(err.Error(), internallaunch.WrapperProjectContainedCode) {
+		t.Fatalf("project-contained wrapper error = %v, want %s", err, internallaunch.WrapperProjectContainedCode)
+	}
+
+	fixture.request.Intent.Participants[0].Wrapper = &WrapperV1{Executable: writePublicTestWrapper(t)}
+	if _, err := Prepare(context.Background(), fixture.request); err != nil {
+		t.Fatalf("outside wrapper rejected: %v", err)
+	}
+}
+
 func TestPrepareWrapperFileValidationAndStdinRefusalAreZeroWrite(t *testing.T) {
 	for _, test := range []struct {
 		name       string


### PR DESCRIPTION
Bead amq-419 — ChatGPT Pro review A findings 5,7 (+6/8 containment).

- Wrappers and the amq launcher were not contained to non-project paths, and capabilities were not validated before use.
- Contains wrapper/launcher execution to non-project paths and adds validation before capabilities are exercised.

Review: execution-gated, 6/6 mutants killed; owning-package tests run; local pre-push `make ci` green.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ