### PR TITLE
fix(launchapi): advertise only platform-callable compatibility features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,5 @@ jobs:
         run: go test ./internal/cli -run '^TestDrainInboxItemsConcurrentClaimsSingleWinner$' -count=50
       - name: Drain claim path
         run: go test ./internal/cli -run '^TestDrainInboxItems' -count=1
+      - name: Windows launch API compatibility
+        run: go test ./launchapi -run '^TestWindowsCompatibilityAdvertisesOnlyCallableLaunchSurface$' -count=1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -166,6 +166,9 @@ retained; do not move the executable while registered wakes still identify it.
 WSL is a Linux environment: install a Linux asset there, not the Windows ZIP.
 On native Windows, `doctor --ops` can report wake lock files but cannot verify
 live wake process identity or auto-fix `unverified` locks.
+The native Windows launch API advertises only `launch_intent_v1` and
+`plan_only_commands_v1`; managed Prepare/Apply, lifecycle, and tmux features
+are omitted and fail negotiation.
 
 For manual installs, verify the selected asset against `checksums.txt` before extracting it:
 

--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -26,6 +26,17 @@ A `0.61.1` binary advertises `placement`, `initial_input`, `base_root`,
 require every feature it uses. Contract semver alone does not claim that an
 unadvertised feature is available.
 
+The advertised feature set is derived from the callable platform
+implementation at build time:
+
+| Build platform | Advertised launch features |
+| --- | --- |
+| macOS, Linux (including WSL) | The full v1 set: `launch_intent_v1`, `prepare_apply_v1`, `lifecycle_v1`, `managed_tmux_v1`, `plan_only_commands_v1`, plus `initial_input`, `placement`, `base_root`, `on_live`, `caller_context`, `executable_identity`, and `wrapper`. |
+| Native Windows | `launch_intent_v1` and `plan_only_commands_v1` only. `prepare_apply_v1`, `lifecycle_v1`, and `managed_tmux_v1` are not callable and are rejected by negotiation. |
+
+WSL uses the Linux binary and therefore gets the Linux row. Negotiation fails
+closed for a feature that is not in the current build's advertised set.
+
 `PreviewV1.capabilities` reports the selected providers' static adapter grammar
 without executing a caller-supplied provider. `grammar_version` is the
 adapter-owned version that consumers compare. It changes when the allowed

--- a/launchapi/compatibility.go
+++ b/launchapi/compatibility.go
@@ -10,20 +10,7 @@ import (
 
 const ContractSemverV1 = "0.61.1"
 
-var compatibilityFeaturesV1 = []string{
-	"launch_intent_v1",
-	"prepare_apply_v1",
-	"lifecycle_v1",
-	"managed_tmux_v1",
-	"plan_only_commands_v1",
-	FeatureInitialInput,
-	FeaturePlacement,
-	FeatureBaseRoot,
-	FeatureOnLive,
-	FeatureCallerContext,
-	FeatureExecutableIdentity,
-	FeatureWrapper,
-}
+var compatibilityFeaturesV1 = platformCompatibilityFeaturesV1()
 
 func Compatibility() CompatibilityV1 {
 	return CompatibilityV1{

--- a/launchapi/compatibility_features_other.go
+++ b/launchapi/compatibility_features_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux && !windows
+
+package launchapi
+
+// Other platforms have the same fail-closed surface as native Windows until
+// their callable launch implementations are available.
+func platformCompatibilityFeaturesV1() []string {
+	return []string{
+		"launch_intent_v1",
+		"plan_only_commands_v1",
+	}
+}

--- a/launchapi/compatibility_features_other_test.go
+++ b/launchapi/compatibility_features_other_test.go
@@ -1,0 +1,25 @@
+//go:build !darwin && !linux && !windows
+
+package launchapi
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestOtherCompatibilityAdvertisesOnlyCallableLaunchSurface(t *testing.T) {
+	want := []string{"launch_intent_v1", "plan_only_commands_v1"}
+	if got := Compatibility().Features; !reflect.DeepEqual(got, want) {
+		t.Fatalf("other-platform compatibility features = %v, want %v", got, want)
+	}
+	for _, feature := range []string{"prepare_apply_v1", "lifecycle_v1", "managed_tmux_v1"} {
+		_, err := Negotiate(RequirementV1{
+			ContractSemver: ContractSemverV1, IntentVersion: IntentVersionV1, ResultVersion: ResultVersionV1,
+			Features: []string{feature},
+		})
+		if err == nil || !strings.Contains(err.Error(), "unsupported required feature") {
+			t.Fatalf("other platform negotiated %q: %v", feature, err)
+		}
+	}
+}

--- a/launchapi/compatibility_features_unix.go
+++ b/launchapi/compatibility_features_unix.go
@@ -1,0 +1,22 @@
+//go:build darwin || linux
+
+package launchapi
+
+// platformCompatibilityFeaturesV1 is the callable launch surface on macOS
+// and Linux. Keep this order stable: it is the canonical negotiation order.
+func platformCompatibilityFeaturesV1() []string {
+	return []string{
+		"launch_intent_v1",
+		"prepare_apply_v1",
+		"lifecycle_v1",
+		"managed_tmux_v1",
+		"plan_only_commands_v1",
+		FeatureInitialInput,
+		FeaturePlacement,
+		FeatureBaseRoot,
+		FeatureOnLive,
+		FeatureCallerContext,
+		FeatureExecutableIdentity,
+		FeatureWrapper,
+	}
+}

--- a/launchapi/compatibility_features_unix_test.go
+++ b/launchapi/compatibility_features_unix_test.go
@@ -1,0 +1,19 @@
+//go:build darwin || linux
+
+package launchapi
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUnixCompatibilityAdvertisesCallableLaunchSurface(t *testing.T) {
+	want := []string{
+		"launch_intent_v1", "prepare_apply_v1", "lifecycle_v1", "managed_tmux_v1", "plan_only_commands_v1",
+		FeatureInitialInput, FeaturePlacement, FeatureBaseRoot, FeatureOnLive, FeatureCallerContext,
+		FeatureExecutableIdentity, FeatureWrapper,
+	}
+	if got := Compatibility().Features; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Unix compatibility features = %v, want %v", got, want)
+	}
+}

--- a/launchapi/compatibility_features_windows.go
+++ b/launchapi/compatibility_features_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package launchapi
+
+// Native Windows can expose intent decoding and the plan-only commands
+// contract. coop exec, managed execution, leases, and lifecycle backends are
+// not callable there, so their execution-backed features are not advertised.
+func platformCompatibilityFeaturesV1() []string {
+	return []string{
+		"launch_intent_v1",
+		"plan_only_commands_v1",
+	}
+}

--- a/launchapi/compatibility_features_windows_test.go
+++ b/launchapi/compatibility_features_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package launchapi
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestWindowsCompatibilityAdvertisesOnlyCallableLaunchSurface(t *testing.T) {
+	want := []string{"launch_intent_v1", "plan_only_commands_v1"}
+	if got := Compatibility().Features; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Windows compatibility features = %v, want %v", got, want)
+	}
+	for _, feature := range []string{"prepare_apply_v1", "lifecycle_v1", "managed_tmux_v1"} {
+		_, err := Negotiate(RequirementV1{
+			ContractSemver: ContractSemverV1, IntentVersion: IntentVersionV1, ResultVersion: ResultVersionV1,
+			Features: []string{feature},
+		})
+		if err == nil || !strings.Contains(err.Error(), "unsupported required feature") {
+			t.Fatalf("Windows negotiated %q: %v", feature, err)
+		}
+	}
+}

--- a/launchapi/compatibility_test.go
+++ b/launchapi/compatibility_test.go
@@ -18,48 +18,46 @@ func TestCompatibilityAndNegotiateV1(t *testing.T) {
 	if Compatibility().Features[0] != "launch_intent_v1" {
 		t.Fatal("Compatibility returned shared mutable feature storage")
 	}
-	if !slices.Contains(Compatibility().Features, FeaturePlacement) {
-		t.Fatal("Compatibility omitted advertised placement")
-	}
-	if !slices.Contains(Compatibility().Features, FeatureInitialInput) {
-		t.Fatal("Compatibility did not advertise the completed initial_input feature")
-	}
-	if !slices.Contains(Compatibility().Features, FeatureBaseRoot) {
-		t.Fatal("Compatibility did not advertise the completed base_root feature")
-	}
-	if !slices.Contains(Compatibility().Features, FeatureOnLive) {
-		t.Fatal("Compatibility omitted advertised on_live")
-	}
-	if !slices.Contains(Compatibility().Features, FeatureCallerContext) {
-		t.Fatal("Compatibility did not advertise the completed caller_context feature")
-	}
-	if !slices.Contains(Compatibility().Features, FeatureExecutableIdentity) {
-		t.Fatal("Compatibility omitted advertised executable_identity")
-	}
-	if !slices.Contains(Compatibility().Features, FeatureWrapper) {
-		t.Fatal("Compatibility did not advertise the completed wrapper feature")
+	if slices.Contains(Compatibility().Features, "prepare_apply_v1") {
+		for _, feature := range []string{
+			FeaturePlacement, FeatureInitialInput, FeatureBaseRoot, FeatureOnLive,
+			FeatureCallerContext, FeatureExecutableIdentity, FeatureWrapper,
+		} {
+			if !slices.Contains(Compatibility().Features, feature) {
+				t.Fatalf("Compatibility omitted advertised %s", feature)
+			}
+		}
 	}
 
-	negotiated, err := Negotiate(RequirementV1{
+	requirement := RequirementV1{
 		ContractSemver: ">=0.61.0 <0.62.0",
 		IntentVersion:  1,
 		ResultVersion:  1,
 		Features:       []string{"managed_tmux_v1", "launch_intent_v1"},
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(negotiated.Features, []string{"launch_intent_v1", "managed_tmux_v1"}) {
-		t.Fatalf("negotiated features = %v", negotiated.Features)
+	negotiated, err := Negotiate(requirement)
+	if slices.Contains(Compatibility().Features, "managed_tmux_v1") {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(negotiated.Features, []string{"launch_intent_v1", "managed_tmux_v1"}) {
+			t.Fatalf("negotiated features = %v", negotiated.Features)
+		}
+	} else if err == nil || !strings.Contains(err.Error(), "unsupported required feature") {
+		t.Fatalf("unsupported managed_tmux negotiation = %v", err)
 	}
 	placed, err := Negotiate(RequirementV1{
 		ContractSemver: "0.61.1", IntentVersion: 1, ResultVersion: 1, Features: []string{FeaturePlacement},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(placed.Features, []string{FeaturePlacement}) {
-		t.Fatalf("negotiated placement = %v", placed.Features)
+	if slices.Contains(Compatibility().Features, FeaturePlacement) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(placed.Features, []string{FeaturePlacement}) {
+			t.Fatalf("negotiated placement = %v", placed.Features)
+		}
+	} else if err == nil || !strings.Contains(err.Error(), "unsupported required feature") {
+		t.Fatalf("unsupported placement negotiation = %v", err)
 	}
 
 	if _, err := Negotiate(RequirementV1{ContractSemver: ">=0.61.0", IntentVersion: 1, ResultVersion: 1}); err != nil {


### PR DESCRIPTION
Bead amq-dey — ChatGPT Pro review A findings 23,24.

- launchapi compatibility.go advertised prepare/apply/lifecycle features on native Windows that the platform cannot actually run (coop_exec_other.go, launch_exec_other.go, lease_holder_other.go are Windows no-ops).
- Compatibility is now derived from per-GOOS callable capabilities instead of a static table; unsupported features are absent or negotiated as unsupported on windows, darwin/linux unchanged.

Implementor-reported gates (codex, self-review, not independently re-verified this cycle): go test ./launchapi -count=1 PASS (14.031s); go vet ./launchapi PASS; golangci-lint run ./launchapi/... (0 issues); GOOS=windows GOARCH=amd64 go test -c ./launchapi PASS; GOOS=freebsd GOARCH=amd64 go test -c ./launchapi PASS; gofmt and git diff --check PASS.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
