### PR TITLE
fix(launchapi): reject duplicate JSON keys at every depth with a bounded typed strict decoder

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -57,6 +57,16 @@ ordered `-c model_reasoning_effort=<value>` pairs with values `minimal`, `low`,
 Every `env_overlay` key uses the POSIX environment grammar
 `[A-Za-z_][A-Za-z0-9_]*`; shell syntax such as `X;touch /tmp/pwn` is refused.
 
+Public JSON decoders perform a bounded structural pass before contract
+decoding. A structural refusal is returned as `*launchapi.StrictJSONError`;
+inspect its typed `Code` instead of parsing the message. The validation codes
+are `launchapi.StrictJSONDuplicateKey` (`duplicate_json_key`) for an exact
+duplicate object key and `launchapi.StrictJSONDepthExceeded` (`depth_exceeded`)
+when nesting exceeds `launchapi.StrictJSONMaxDepth` (256). Object keys are
+compared after JSON string decoding, so case- or whitespace-distinct keys are
+different keys. The error also carries the containing `Path` and duplicate
+`Key` where applicable.
+
 An optional participant `wrapper` contains a clean absolute `executable` path
 and static `args`. The path must resolve to one regular file; resolvable
 symlinks are accepted. AMQ executes the exact argv `wrapper executable + wrapper

--- a/launchapi/intent.go
+++ b/launchapi/intent.go
@@ -24,7 +24,7 @@ func DecodeLaunchIntentV1(data []byte) (LaunchIntentV1, error) {
 func (intent *LaunchIntentV1) UnmarshalJSON(data []byte) error {
 	type wireLaunchIntentV1 LaunchIntentV1
 	var decoded wireLaunchIntentV1
-	if err := decodeStrictJSON(data, &decoded); err != nil {
+	if err := decodeStrictJSONValue(data, &decoded); err != nil {
 		return err
 	}
 	if err := requireLaunchIntentFields(data); err != nil {
@@ -308,10 +308,66 @@ func requireObjectFields(raw json.RawMessage, context string, required ...string
 	return nil
 }
 
+// StrictJSONMaxDepth bounds the recursive structural scan performed before a
+// public JSON document is decoded into a contract type.
+const StrictJSONMaxDepth = 256
+
+// StrictJSONErrorCode identifies a structural error found before decoding a
+// public JSON document into its contract type.
+type StrictJSONErrorCode string
+
+const (
+	StrictJSONDuplicateKey  StrictJSONErrorCode = "duplicate_json_key"
+	StrictJSONDepthExceeded StrictJSONErrorCode = "depth_exceeded"
+)
+
+// StrictJSONError reports a structural JSON error with a stable machine code.
+// Path and Key are retained as structured data so callers do not need to parse
+// the human-readable error string.
+type StrictJSONError struct {
+	Code StrictJSONErrorCode
+	Path string
+	Key  string
+}
+
+func (e *StrictJSONError) Error() string {
+	if e == nil {
+		return "strict JSON decoding failed"
+	}
+	switch e.Code {
+	case StrictJSONDuplicateKey:
+		return fmt.Sprintf("duplicate key %q at %s (code=%s)", e.Key, e.Path, e.Code)
+	case StrictJSONDepthExceeded:
+		return fmt.Sprintf("JSON nesting exceeds maximum depth %d at %s (code=%s)", StrictJSONMaxDepth, e.Path, e.Code)
+	default:
+		return fmt.Sprintf("strict JSON decoding failed at %s (code=%s)", e.Path, e.Code)
+	}
+}
+
+type strictJSONPathSegment struct {
+	key   string
+	index int
+	array bool
+}
+
 func decodeStrictJSON(data []byte, target any) error {
 	if !utf8.Valid(data) {
 		return fmt.Errorf("invalid UTF-8")
 	}
+	scanner := json.NewDecoder(bytes.NewReader(data))
+	if err := rejectDuplicateJSONKeys(scanner); err != nil {
+		return err
+	}
+	if err := scanner.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return decodeStrictJSONValue(data, target)
+}
+
+func decodeStrictJSONValue(data []byte, target any) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
@@ -324,4 +380,86 @@ func decodeStrictJSON(data []byte, target any) error {
 		return err
 	}
 	return nil
+}
+
+// rejectDuplicateJSONKeys walks the complete JSON token stream. Decoder's
+// struct handling silently keeps the last value for duplicate object keys, so
+// this pass must happen before the contract decode and must recurse through
+// arrays as well as objects. It carries path segments and renders them only
+// when returning a typed error, keeping deeply nested failures linear.
+func rejectDuplicateJSONKeys(decoder *json.Decoder) error {
+	return rejectDuplicateJSONValue(decoder, nil, 0)
+}
+
+func rejectDuplicateJSONValue(decoder *json.Decoder, path []strictJSONPathSegment, depth int) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	switch delimiter := token.(type) {
+	case json.Delim:
+		if depth >= StrictJSONMaxDepth {
+			return &StrictJSONError{Code: StrictJSONDepthExceeded, Path: renderStrictJSONPath(path)}
+		}
+		switch delimiter {
+		case '{':
+			seen := make(map[string]struct{})
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return fmt.Errorf("JSON object key at %s is not a string", renderStrictJSONPath(path))
+				}
+				if _, duplicate := seen[key]; duplicate {
+					return &StrictJSONError{Code: StrictJSONDuplicateKey, Path: renderStrictJSONPath(path), Key: key}
+				}
+				seen[key] = struct{}{}
+				childPath := append(path, strictJSONPathSegment{key: key})
+				if err := rejectDuplicateJSONValue(decoder, childPath, depth+1); err != nil {
+					return err
+				}
+			}
+			end, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if end != json.Delim('}') {
+				return fmt.Errorf("JSON object at %s is not closed", renderStrictJSONPath(path))
+			}
+		case '[':
+			for index := 0; decoder.More(); index++ {
+				childPath := append(path, strictJSONPathSegment{index: index, array: true})
+				if err := rejectDuplicateJSONValue(decoder, childPath, depth+1); err != nil {
+					return err
+				}
+			}
+			end, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			if end != json.Delim(']') {
+				return fmt.Errorf("JSON array at %s is not closed", renderStrictJSONPath(path))
+			}
+		default:
+			return fmt.Errorf("unexpected JSON delimiter %q at %s", delimiter, renderStrictJSONPath(path))
+		}
+	}
+	return nil
+}
+
+func renderStrictJSONPath(path []strictJSONPathSegment) string {
+	var builder strings.Builder
+	builder.WriteByte('$')
+	for _, segment := range path {
+		if segment.array {
+			fmt.Fprintf(&builder, "[%d]", segment.index)
+			continue
+		}
+		builder.WriteByte('.')
+		builder.WriteString(segment.key)
+	}
+	return builder.String()
 }

--- a/launchapi/requests.go
+++ b/launchapi/requests.go
@@ -25,11 +25,11 @@ func ValidateDigest(digest string) error {
 }
 
 func DecodePrepareRequestV1(data []byte) (PrepareRequestV1, error) {
-	if err := validateCallerContextJSON(data); err != nil {
-		return PrepareRequestV1{}, fmt.Errorf("decode prepare request v1: %w", err)
-	}
 	var request PrepareRequestV1
 	if err := decodeStrictJSON(data, &request); err != nil {
+		return PrepareRequestV1{}, fmt.Errorf("decode prepare request v1: %w", err)
+	}
+	if err := validateCallerContextJSON(data); err != nil {
 		return PrepareRequestV1{}, fmt.Errorf("decode prepare request v1: %w", err)
 	}
 	if err := request.Validate(); err != nil {
@@ -63,6 +63,10 @@ func DecodeApplyRequestV1(data []byte) (ApplyRequestV1, error) {
 	if !utf8.Valid(data) {
 		return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: invalid UTF-8")
 	}
+	var request ApplyRequestV1
+	if err := decodeStrictJSON(data, &request); err != nil {
+		return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: %w", err)
+	}
 	prepare, present, err := rawObjectField(data, "prepare")
 	if err != nil {
 		return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: %w", err)
@@ -71,10 +75,6 @@ func DecodeApplyRequestV1(data []byte) (ApplyRequestV1, error) {
 		if err := validateCallerContextJSON(prepare); err != nil {
 			return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: prepare: %w", err)
 		}
-	}
-	var request ApplyRequestV1
-	if err := decodeStrictJSON(data, &request); err != nil {
-		return ApplyRequestV1{}, fmt.Errorf("decode apply request v1: %w", err)
 	}
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {

--- a/launchapi/strict_decode_test.go
+++ b/launchapi/strict_decode_test.go
@@ -1,0 +1,101 @@
+package launchapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStrictJSONRejectsDeepDocumentWithTypedCodeQuickly(t *testing.T) {
+	const documentSize = 2 << 20
+	depth := documentSize / 2
+	raw := []byte(strings.Repeat("[", depth) + "null" + strings.Repeat("]", depth))
+
+	start := time.Now()
+	var decoded any
+	err := decodeStrictJSON(raw, &decoded)
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("deep document took %s to reject; want bounded scan", elapsed)
+	}
+	var strictErr *StrictJSONError
+	if !errors.As(err, &strictErr) || strictErr.Code != StrictJSONDepthExceeded {
+		t.Fatalf("deep document error = %v, typed=%#v; want code %q", err, strictErr, StrictJSONDepthExceeded)
+	}
+}
+
+func TestStrictJSONAcceptsSixtyFourNestedArrays(t *testing.T) {
+	raw := []byte(strings.Repeat("[", 64) + "null" + strings.Repeat("]", 64))
+	var decoded any
+	if err := decodeStrictJSON(raw, &decoded); err != nil {
+		t.Fatalf("64-depth document rejected: %v", err)
+	}
+}
+
+func TestStrictJSONDepthBoundary(t *testing.T) {
+	for _, test := range []struct {
+		depth int
+		want  StrictJSONErrorCode
+	}{
+		{depth: StrictJSONMaxDepth},
+		{depth: StrictJSONMaxDepth + 1, want: StrictJSONDepthExceeded},
+	} {
+		t.Run(fmt.Sprintf("depth_%d", test.depth), func(t *testing.T) {
+			raw := []byte(strings.Repeat("[", test.depth) + "null" + strings.Repeat("]", test.depth))
+			var decoded any
+			err := decodeStrictJSON(raw, &decoded)
+			if test.want == "" {
+				if err != nil {
+					t.Fatalf("%d-depth document rejected: %v", test.depth, err)
+				}
+				return
+			}
+			var strictErr *StrictJSONError
+			if !errors.As(err, &strictErr) || strictErr.Code != test.want {
+				t.Fatalf("%d-depth document error = %v, typed=%#v; want code %q", test.depth, err, strictErr, test.want)
+			}
+		})
+	}
+}
+
+func TestStrictJSONAcceptsCaseAndWhitespaceDistinctKeys(t *testing.T) {
+	var decoded map[string]int
+	if err := decodeStrictJSON([]byte(`{"Key":1," key ":2}`), &decoded); err != nil {
+		t.Fatalf("case/whitespace-distinct keys rejected: %v", err)
+	}
+	if decoded["Key"] != 1 || decoded[" key "] != 2 {
+		t.Fatalf("decoded keys = %#v", decoded)
+	}
+}
+
+func TestStrictJSONDuplicateKeyReturnsTypedCode(t *testing.T) {
+	var decoded map[string]int
+	err := decodeStrictJSON([]byte(`{"outer":{"Key":1,"Key":2}}`), &decoded)
+	var strictErr *StrictJSONError
+	if !errors.As(err, &strictErr) || strictErr.Code != StrictJSONDuplicateKey {
+		t.Fatalf("duplicate error = %v, typed=%#v; want code %q", err, strictErr, StrictJSONDuplicateKey)
+	}
+	if strictErr.Path != "$.outer" || strictErr.Key != "Key" {
+		t.Fatalf("duplicate location = %#v; want $.outer/Key", strictErr)
+	}
+}
+
+func FuzzDecodeStrictJSONRejectsDuplicateKeys(f *testing.F) {
+	f.Add("fuzz-key")
+	f.Add("nested/key")
+	f.Fuzz(func(t *testing.T, key string) {
+		encoded, err := json.Marshal(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw := []byte(`{"outer":[{"` + string(encoded[1:len(encoded)-1]) + `":1,"` + string(encoded[1:len(encoded)-1]) + `":2}]}`)
+		var decoded map[string]any
+		err = decodeStrictJSON(raw, &decoded)
+		var strictErr *StrictJSONError
+		if !errors.As(err, &strictErr) || strictErr.Code != StrictJSONDuplicateKey {
+			t.Fatalf("key %q error = %v, typed=%#v", key, err, strictErr)
+		}
+	})
+}


### PR DESCRIPTION
Bead amq-axs — ChatGPT Pro review A finding 27.

- `decodeStrictJSON` now token-walks the whole document and rejects duplicate keys at every depth (objects and objects-in-arrays) with exported typed `StrictJSONError` (`StrictJSONDuplicateKey`, path, key); all public decoders (Prepare, Apply, Inspect/Focus/Close, LaunchIntent) route through it before typed decoding.
- The walk is bounded: depth cap 256 with typed `StrictJSONDepthExceeded` (2 MiB hostile deep array refused in milliseconds; previously unbounded recursion OOM-killed the process), path carried as segments and rendered only at the error site.
- Keys differing only by case/whitespace remain distinct (JSON-exact comparison); valid documents unchanged; fuzz target included.

Review: execution-gated, mutants for depth-0-only, array-skip, first-wins, per-decoder bypass, untyped error, unknown-field regression, cap removal, 64-deep accept, case normalization, and the exact 256/257 boundary all killed. Local pre-push `make ci` green.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
