### PR TITLE
fix(launch): bind apply authorization and reconcile to the authorized target and identities

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -48,7 +48,10 @@ it. Prepare records each runnable provider's consulted path (PATH lookup or
 absolute) plus the on-disk identity tuple, including symlink hops. Schema 1
 omits that binding. A same-path inode, mtime, symlink-hop, or PATH retarget
 changes `subject_digest`; Apply then returns `subject_changed` with no launch
-mutation. Plan and trust digests stay stable across those replacements.
+mutation. If the provider, wrapper, or cwd changes after Apply authorization,
+Reconcile refuses before capability probing or ticket creation with the typed
+`authorized_identity_changed` result. Plan and trust digests stay stable across
+those replacements.
 
 The initial-input carrier is typed. Claude and Codex currently advertise
 `argument`; AMQ appends its exact text as the final provider argv element.

--- a/internal/fsq/delivery_root.go
+++ b/internal/fsq/delivery_root.go
@@ -14,6 +14,10 @@ import (
 
 const deliveryRootChangedRemedy = "re-run the command against the current root"
 
+// ErrDeliveryRootChanged reports that an authorized directory was replaced
+// through its ambient path after the capability was opened.
+var ErrDeliveryRootChanged = errors.New("delivery root changed after authorization")
+
 // DeliveryRootIdentity is an opaque physical-identity snapshot taken at the
 // authorization boundary and consumed when the directory capability is opened.
 type DeliveryRootIdentity struct {
@@ -108,7 +112,7 @@ func OpenDeliveryRoot(base string, expected DeliveryRootIdentity) (*DeliveryRoot
 	}
 	if !os.SameFile(expected.info, identity) {
 		_ = root.Close()
-		return nil, fmt.Errorf("delivery root changed between authorization and capability open: %s", abs)
+		return nil, fmt.Errorf("%w between authorization and capability open: %s", ErrDeliveryRootChanged, abs)
 	}
 	return &DeliveryRoot{base: abs, root: root, identity: identity}, nil
 }
@@ -520,7 +524,8 @@ func (r *DeliveryRoot) VerifyBase() error {
 	current, err := os.Stat(r.base)
 	if err != nil {
 		return fmt.Errorf(
-			"delivery root changed after authorization: %s: %w; %s",
+			"%w: %s: %w; %s",
+			ErrDeliveryRootChanged,
 			r.base,
 			err,
 			deliveryRootChangedRemedy,
@@ -528,7 +533,8 @@ func (r *DeliveryRoot) VerifyBase() error {
 	}
 	if !os.SameFile(r.identity, current) {
 		return fmt.Errorf(
-			"delivery root changed after authorization: %s; %s",
+			"%w: %s; %s",
+			ErrDeliveryRootChanged,
 			r.base,
 			deliveryRootChangedRemedy,
 		)

--- a/internal/fsq/delivery_root_unix_test.go
+++ b/internal/fsq/delivery_root_unix_test.go
@@ -3,6 +3,7 @@
 package fsq
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,7 +39,7 @@ func TestOpenDeliveryRootRejectsSwapBetweenAuthorizationAndOpen(t *testing.T) {
 		_ = root.Close()
 		t.Fatal("OpenDeliveryRoot returned a capability for the swapped root")
 	}
-	if err == nil || !strings.Contains(err.Error(), "changed between authorization and capability open") {
+	if err == nil || !errors.Is(err, ErrDeliveryRootChanged) || !strings.Contains(err.Error(), "between authorization and capability open") {
 		t.Fatalf("OpenDeliveryRoot error = %v, want authorization/open mismatch", err)
 	}
 }

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -58,6 +59,10 @@ type ApplyResult struct {
 
 var afterApplySessionPublishedForTest func()
 var beforeApplySessionPublishForTest func()
+var beforeApplyAuthorizeApplyForTest func()
+var beforeApplyReconcileForTest func()
+var afterApplyReconcileForTest func()
+var openPrepareTargetForApply = openPrepareTarget
 var beforeApplyRosterMutationForTest func()
 var beforeApplyBaseRootCreateForTest func()
 var afterApplyBaseRootCreatedForTest func() error
@@ -83,7 +88,7 @@ func Apply(ctx context.Context, request ApplyRequest, dependencies ApplyDependen
 	if !validDigest(request.SubjectDigest) {
 		return ApplyResult{}, fmt.Errorf("invalid Apply subject digest")
 	}
-	state, err := openPrepareTarget(request.Prepare.Target)
+	state, err := openPrepareTargetForApply(request.Prepare.Target)
 	if err != nil {
 		return ApplyResult{}, err
 	}
@@ -127,16 +132,42 @@ func Apply(ctx context.Context, request ApplyRequest, dependencies ApplyDependen
 }
 
 func applyUnderAuthority(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies, state *prepareTargetState, lease *Lease) (result ApplyResult, returnErr error) {
-	prepared, decisions, refusal, allowed, err := authorizeApply(ctx, request, dependencies)
+	if err := state.verify(); err != nil {
+		if lease != nil {
+			lease.abandonCapability()
+		}
+		if !isPrepareAuthorityDrift(err) {
+			return ApplyResult{}, err
+		}
+		return applyActionResult(PrepareResult{}, "subject_changed"), nil
+	}
+	if beforeApplyAuthorizeApplyForTest != nil {
+		beforeApplyAuthorizeApplyForTest()
+	}
+	prepared, decisions, refusal, allowed, err := authorizeApply(ctx, request, dependencies, state)
 	if err != nil || !allowed {
+		if !allowed && lease != nil {
+			if driftErr := state.verify(); isPrepareAuthorityDrift(driftErr) {
+				lease.abandonCapability()
+			}
+		}
 		return refusal, err
 	}
 	return applyPreparedUnderAuthority(ctx, request, dependencies, state, lease, prepared, decisions)
 }
 
-func authorizeApply(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies) (PrepareResult, map[RequiredActionKind]string, ApplyResult, bool, error) {
-	prepared, err := Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+func authorizeApply(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies, state *prepareTargetState) (PrepareResult, map[RequiredActionKind]string, ApplyResult, bool, error) {
+	ctx, subjectSchema, prepareDependencies, err := validatePrepareRequest(ctx, request.Prepare, dependencies.PrepareDependencies)
 	if err != nil {
+		return PrepareResult{}, nil, ApplyResult{}, false, err
+	}
+	prepared, err := prepareAtTarget(ctx, request.Prepare, prepareDependencies, state, subjectSchema)
+	if err != nil {
+		if isPrepareAuthorityDrift(err) {
+			refusal := applyActionResult(PrepareResult{SubjectSchema: subjectSchema}, "subject_changed")
+			refusal.SubjectDigest = request.SubjectDigest
+			return PrepareResult{}, nil, refusal, false, nil
+		}
 		return PrepareResult{}, nil, ApplyResult{}, false, err
 	}
 	if prepared.SubjectDigest != request.SubjectDigest {
@@ -209,7 +240,7 @@ func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, depe
 			}
 			return ApplyResult{}, err
 		}
-		defer func() { _ = root.Close() }()
+		state.sessionRoot = root
 		if afterApplySessionPublishedForTest != nil {
 			afterApplySessionPublishedForTest()
 		}
@@ -238,8 +269,11 @@ func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, depe
 		}
 	}
 	if len(runnable) == 0 {
-		prepared, err = Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+		prepared, err = prepareApplyStatus(ctx, request.Prepare, dependencies.PrepareDependencies, state)
 		if err != nil {
+			if isPrepareAuthorityDrift(err) {
+				return applyActionResult(prepared, "subject_changed"), nil
+			}
 			return ApplyResult{}, err
 		}
 		result := applyResultFromPrepare(prepared)
@@ -254,13 +288,28 @@ func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, depe
 	if err != nil {
 		return ApplyResult{}, err
 	}
+	if beforeApplyReconcileForTest != nil {
+		beforeApplyReconcileForTest()
+	}
 	reconciled, err := Reconcile(reconcileRequest)
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	finalPrepared, err := Prepare(ctx, request.Prepare, dependencies.PrepareDependencies)
+	if afterApplyReconcileForTest != nil {
+		afterApplyReconcileForTest()
+	}
+	finalPrepared, err := prepareApplyStatus(ctx, request.Prepare, dependencies.PrepareDependencies, state)
 	if err != nil {
+		if isPrepareAuthorityDrift(err) {
+			if lease != nil {
+				lease.abandonCapability()
+			}
+			return applyActionResult(prepared, "subject_changed"), nil
+		}
 		return ApplyResult{}, err
+	}
+	if reconciled.AggregateCode == 0 && reconciled.Outcome != "" && reconciled.Outcome != OutcomeNoAction && !authorizedIdentitiesEqual(prepared, finalPrepared) {
+		return applyActionResult(finalPrepared, "subject_changed"), nil
 	}
 	result = applyResultFromPrepare(finalPrepared)
 	result.SubjectDigest = request.SubjectDigest
@@ -283,11 +332,19 @@ func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, depe
 	return result, nil
 }
 
+func prepareApplyStatus(ctx context.Context, request PrepareRequest, dependencies PrepareDependencies, state *prepareTargetState) (PrepareResult, error) {
+	ctx, subjectSchema, dependencies, err := validatePrepareRequest(ctx, request, dependencies)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	return prepareAtTarget(ctx, request, dependencies, state, subjectSchema)
+}
+
 func applyMissingBaseRoot(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies, state *prepareTargetState) (result ApplyResult, returnErr error) {
 	if state.baseAuthority == nil || !state.baseAuthority.baseMissing || state.baseAuthority.parentRoot == nil {
 		return ApplyResult{}, fmt.Errorf("missing base-root creation authority")
 	}
-	prepared, decisions, refusal, allowed, err := authorizeApply(ctx, request, dependencies)
+	prepared, decisions, refusal, allowed, err := authorizeApply(ctx, request, dependencies, state)
 	if err != nil || !allowed {
 		return refusal, err
 	}
@@ -311,6 +368,7 @@ func applyMissingBaseRoot(ctx context.Context, request ApplyRequest, dependencie
 		return ApplyResult{}, err
 	}
 	state.baseRoot = baseRoot
+	state.baseAuthority.baseMissing = false
 	if afterApplyBaseRootCreatedForTest != nil {
 		if err := afterApplyBaseRootCreatedForTest(); err != nil {
 			return ApplyResult{}, err
@@ -510,6 +568,17 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 	config := ProjectConfig{Schema: ProjectConfigSchema, DefaultSession: prepared.Target.Session, Layout: LayoutIntent{Type: LayoutColumns}}
 	adapters := make(map[string]HarnessAdapter, len(runnable))
 	executionOptions := make(map[string]PrepareExecutionOptions, len(runnable))
+	authorizedIdentities := make(map[string]AuthorizedParticipantIdentity, len(snapshot.Participants))
+	for _, participant := range snapshot.Participants {
+		if !participant.Runnable || (participant.Executable == nil && participant.Wrapper == nil && participant.CwdIdentity == "") {
+			continue
+		}
+		authorizedIdentities[participant.Handle] = AuthorizedParticipantIdentity{
+			Executable:  cloneConsultedExecutable(participant.Executable),
+			Wrapper:     cloneConsultedExecutable(participant.Wrapper),
+			CwdIdentity: participant.CwdIdentity,
+		}
+	}
 	for _, participant := range runnable {
 		adapter := dependencies.AdapterFor(participant.Provider, participant.Executable)
 		if adapter == nil {
@@ -540,11 +609,12 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		Adapters: adapters, TrustStore: dependencies.TrustStore, HeldLease: lease,
 		TrustAuthorityDigest: snapshot.BaseAuthorityDigest,
 		HostIdentity:         dependencies.HostIdentity, AllowExternalCwd: true,
-		ExecutionOptions:   executionOptions,
-		AllowFreshFallback: decisions[ActionStaleConversation] == "fresh_once",
-		Placement:          prepared.Placement,
-		OnLive:             onLivePolicies(runnable),
-		CallerContext:      cloneCallerContext(prepared.CallerContext),
+		ExecutionOptions:     executionOptions,
+		AuthorizedIdentities: authorizedIdentities,
+		AllowFreshFallback:   decisions[ActionStaleConversation] == "fresh_once",
+		Placement:            prepared.Placement,
+		OnLive:               onLivePolicies(runnable),
+		CallerContext:        cloneCallerContext(prepared.CallerContext),
 	}
 	if choice := decisions[ActionTrustConfirmation]; choice == "trust_exact_subject" {
 		request.ConfirmTrust = func(plan Plan, actualTrustDigest string) (bool, error) {
@@ -593,6 +663,27 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		}
 	}
 	return request, nil
+}
+
+func authorizedIdentitiesEqual(first, second PrepareResult) bool {
+	if len(first.Participants) != len(second.Participants) {
+		return false
+	}
+	for i := range first.Participants {
+		left, right := first.Participants[i], second.Participants[i]
+		if left.Handle != right.Handle || left.Runnable != right.Runnable || left.CwdIdentity != right.CwdIdentity ||
+			!consultedExecutableEqual(left.Executable, right.Executable) || !consultedExecutableEqual(left.Wrapper, right.Wrapper) {
+			return false
+		}
+	}
+	return true
+}
+
+func consultedExecutableEqual(first, second *ConsultedExecutable) bool {
+	if first == nil || second == nil {
+		return first == second
+	}
+	return first.Requested == second.Requested && first.Consulted == second.Consulted && bytes.Equal(first.Identity, second.Identity)
 }
 
 // WithSessionCreationLock serializes in-repository creators for one direct

--- a/internal/launch/apply_authority_test.go
+++ b/internal/launch/apply_authority_test.go
@@ -1,0 +1,343 @@
+//go:build unix
+
+package launch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+func TestApplyRefusesTargetSwapBeforeAnyReplacementTreeWrite(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	fixture.request.Participants = append(fixture.request.Participants, PrepareParticipant{Handle: "reviewer", Runnable: false})
+	backend := &prepareTestBackend{}
+	dependencies := ApplyDependencies{PrepareDependencies: fixture.dependencies(backend)}
+	prepared, err := Prepare(context.Background(), fixture.request, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: fixture.request, SubjectDigest: prepared.SubjectDigest}
+	var openCount atomic.Int32
+	previousOpenPrepareTarget := openPrepareTargetForApply
+	openPrepareTargetForApply = func(target PrepareTarget) (*prepareTargetState, error) {
+		openCount.Add(1)
+		return openPrepareTarget(target)
+	}
+
+	parked := fixture.sessionRoot + ".authorized"
+	replacement := fixture.sessionRoot + ".replacement"
+	marker := filepath.Join(fixture.sessionRoot, "meta", "marker")
+	replacementMarker := filepath.Join(replacement, "meta", "marker")
+	var callbackCalls atomic.Int32
+	beforeApplyAuthorizeApplyForTest = func() {
+		callbackCalls.Add(1)
+		if err := os.Rename(fixture.sessionRoot, parked); err != nil {
+			t.Fatalf("park authorized session: %v", err)
+		}
+		if err := fsq.EnsureRootDirs(replacement); err != nil {
+			t.Fatalf("create replacement session: %v", err)
+		}
+		if err := os.WriteFile(replacementMarker, []byte("replacement\n"), 0o600); err != nil {
+			t.Fatalf("mark replacement session: %v", err)
+		}
+		if err := os.Rename(replacement, fixture.sessionRoot); err != nil {
+			t.Fatalf("publish replacement session: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		beforeApplyAuthorizeApplyForTest = nil
+		openPrepareTargetForApply = previousOpenPrepareTarget
+		_ = os.RemoveAll(fixture.sessionRoot)
+		_ = os.Rename(parked, fixture.sessionRoot)
+		_ = os.RemoveAll(replacement)
+	})
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callbackCalls.Load() != 1 {
+		t.Fatalf("authorization hook calls = %d", callbackCalls.Load())
+	}
+	if openCount.Load() != 1 {
+		t.Fatalf("Apply opened prepare target %d times, want exactly once", openCount.Load())
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "subject_changed" {
+		t.Fatalf("target swap result = %#v", result)
+	}
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, []byte("replacement\n")) {
+		t.Fatalf("replacement tree changed: %q", got)
+	}
+	if backend.creates != 0 {
+		t.Fatalf("target swap created backend resources: %d", backend.creates)
+	}
+}
+
+type countingApplyAdapter struct {
+	reconcileAdapter
+	capabilityCalls *atomic.Int32
+}
+
+func (adapter countingApplyAdapter) Capabilities(ctx context.Context) AdapterCapabilities {
+	adapter.capabilityCalls.Add(1)
+	return adapter.reconcileAdapter.Capabilities(ctx)
+}
+
+func TestApplyRejectsAuthorizedIdentityReplacementBeforeCapabilitiesOrCreate(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, fixture *internalPrepareFixture) func()
+	}{
+		{
+			name: "provider executable",
+			setup: func(t *testing.T, fixture *internalPrepareFixture) func() {
+				path := filepath.Join(fixture.root, "provider")
+				writeExec(t, path, "#!/bin/sh\necho one\n")
+				fixture.request.Participants[0].Executable = path
+				return replaceExecutableAfterAuthorization(t, path, "#!/bin/sh\necho replacement\n")
+			},
+		},
+		{
+			name: "wrapper executable",
+			setup: func(t *testing.T, fixture *internalPrepareFixture) func() {
+				path := filepath.Join(fixture.root, "wrapper")
+				writeExec(t, path, "#!/bin/sh\necho one\n")
+				fixture.request.Participants[0].Wrapper = &Wrapper{Executable: path, Args: []string{"--wrapped"}}
+				return replaceExecutableAfterAuthorization(t, path, "#!/bin/sh\necho replacement\n")
+			},
+		},
+		{
+			name: "working directory",
+			setup: func(t *testing.T, fixture *internalPrepareFixture) func() {
+				path := fixture.cwd
+				parked := path + ".authorized"
+				return func() {
+					if err := os.Rename(path, parked); err != nil {
+						t.Fatalf("park authorized cwd: %v", err)
+					}
+					if err := os.Mkdir(path, 0o700); err != nil {
+						t.Fatalf("create replacement cwd: %v", err)
+					}
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newInternalPrepareFixture(t)
+			mutate := test.setup(t, &fixture)
+			backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+			var capabilityCalls atomic.Int32
+			adapter := countingApplyAdapter{
+				reconcileAdapter: reconcileAdapter{name: ClaudeProvider, mode: AdapterModeMint, available: true},
+				capabilityCalls:  &capabilityCalls,
+			}
+			store, err := OpenTrustStore(t.TempDir(), fixture.projectRoot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+				Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"}, TrustStore: store, HostIdentity: "host:test",
+				AdapterFor: func(provider, executable string) HarnessAdapter { return adapter },
+			}}
+			prepared, err := Prepare(context.Background(), fixture.request, dependencies.PrepareDependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := ApplyRequest{Prepare: fixture.request, SubjectDigest: prepared.SubjectDigest}
+			for _, action := range prepared.RequiredActions {
+				request.Decisions = append(request.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: "trust_exact_subject"})
+			}
+			beforeApplyReconcileForTest = mutate
+			t.Cleanup(func() { beforeApplyReconcileForTest = nil })
+
+			result, err := Apply(context.Background(), request, dependencies)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "authorized_identity_changed" {
+				t.Fatalf("replacement result = %#v", result)
+			}
+			if capabilityCalls.Load() != 0 {
+				t.Fatalf("replacement reached adapter capabilities: %d", capabilityCalls.Load())
+			}
+			if backend.creates != 0 {
+				t.Fatalf("replacement created backend resources: %d", backend.creates)
+			}
+		})
+	}
+}
+
+func replaceExecutableAfterAuthorization(t *testing.T, path, body string) func() {
+	t.Helper()
+	return func() {
+		replacement := path + ".next"
+		writeExec(t, replacement, body)
+		if err := os.Rename(replacement, path); err != nil {
+			t.Fatalf("replace authorized executable: %v", err)
+		}
+	}
+}
+
+func TestApplyKeepsUnchangedAuthorizedIdentities(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	provider := filepath.Join(fixture.root, "provider")
+	writeExec(t, provider, "#!/bin/sh\necho one\n")
+	fixture.request.Participants[0].Executable = provider
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	var capabilityCalls atomic.Int32
+	adapter := countingApplyAdapter{
+		reconcileAdapter: reconcileAdapter{name: ClaudeProvider, mode: AdapterModeMint, available: true},
+		capabilityCalls:  &capabilityCalls,
+	}
+	store, err := OpenTrustStore(t.TempDir(), fixture.projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"}, TrustStore: store, HostIdentity: "host:test",
+		AdapterFor: func(provider, executable string) HarnessAdapter { return adapter },
+	}}
+	prepared, err := Prepare(context.Background(), fixture.request, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: fixture.request, SubjectDigest: prepared.SubjectDigest}
+	for _, action := range prepared.RequiredActions {
+		request.Decisions = append(request.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: "trust_exact_subject"})
+	}
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeApplied {
+		t.Fatalf("unchanged identities result = %#v", result)
+	}
+	if capabilityCalls.Load() == 0 || backend.creates != 1 {
+		t.Fatalf("unchanged identities did not execute reconciliation: capabilities=%d creates=%d", capabilityCalls.Load(), backend.creates)
+	}
+}
+
+func TestReconcileJournalRecoveryRefusesProviderReplacementBeforeCapabilities(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	request := reconcileFixture(t, backend)
+	provider := filepath.Join(t.TempDir(), "claude")
+	writeExec(t, provider, "#!/bin/sh\necho one\n")
+	t.Setenv("PATH", filepath.Dir(provider)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	request.Config.Agents[0].Command = []string{"claude"}
+	resolved, err := ResolveConsultedExecutable("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwdIdentity, err := fsq.StableTreeIdentity(request.ProjectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.AuthorizedIdentities = map[string]AuthorizedParticipantIdentity{
+		"claude": {Executable: &resolved, CwdIdentity: cwdIdentity},
+	}
+	crash := errors.New("crash after journal write")
+	request.CrashHook = func(stage string) error {
+		if stage == "journal_written" {
+			return crash
+		}
+		return nil
+	}
+	initial, err := Reconcile(request)
+	if !errors.Is(err, crash) {
+		t.Fatalf("initial crash error = %v result=%#v", err, initial)
+	}
+	if _, err := LoadJournal(request.Root); err != nil {
+		t.Fatalf("journal after injected crash: %v", err)
+	}
+	replacement := provider + ".next"
+	writeExec(t, replacement, "#!/bin/sh\necho replacement\n")
+	if err := os.Rename(replacement, provider); err != nil {
+		t.Fatal(err)
+	}
+	var capabilityCalls atomic.Int32
+	request.CrashHook = nil
+	request.Adapters["claude"] = countingApplyAdapter{
+		reconcileAdapter: reconcileAdapter{name: ClaudeProvider, mode: AdapterModeMint, available: true},
+		capabilityCalls:  &capabilityCalls,
+	}
+	result, err := Reconcile(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || result.Outcome != OutcomeActionRequired || result.Reason != "authorized_identity_changed" {
+		t.Fatalf("recovery replacement result = %#v", result)
+	}
+	if capabilityCalls.Load() != 0 || backend.creates != 0 {
+		t.Fatalf("recovery replacement reached execution: capabilities=%d creates=%d", capabilityCalls.Load(), backend.creates)
+	}
+}
+
+func TestApplyPostReconcileTargetSwapCannotReportApplied(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	provider := filepath.Join(fixture.root, "provider")
+	writeExec(t, provider, "#!/bin/sh\necho one\n")
+	fixture.request.Participants[0].Executable = provider
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	var capabilityCalls atomic.Int32
+	adapter := countingApplyAdapter{
+		reconcileAdapter: reconcileAdapter{name: ClaudeProvider, mode: AdapterModeMint, available: true},
+		capabilityCalls:  &capabilityCalls,
+	}
+	store, err := OpenTrustStore(t.TempDir(), fixture.projectRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"}, TrustStore: store, HostIdentity: "host:test",
+		AdapterFor: func(provider, executable string) HarnessAdapter { return adapter },
+	}}
+	prepared, err := Prepare(context.Background(), fixture.request, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: fixture.request, SubjectDigest: prepared.SubjectDigest}
+	for _, action := range prepared.RequiredActions {
+		request.Decisions = append(request.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: "trust_exact_subject"})
+	}
+	parked := fixture.sessionRoot + ".authorized"
+	replacement := fixture.sessionRoot + ".replacement"
+	afterApplyReconcileForTest = func() {
+		if err := os.Rename(fixture.sessionRoot, parked); err != nil {
+			t.Fatalf("park post-reconcile session: %v", err)
+		}
+		if err := fsq.EnsureRootDirs(replacement); err != nil {
+			t.Fatalf("create post-reconcile replacement: %v", err)
+		}
+		if err := os.Rename(replacement, fixture.sessionRoot); err != nil {
+			t.Fatalf("publish post-reconcile replacement: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		afterApplyReconcileForTest = nil
+		_ = os.RemoveAll(fixture.sessionRoot)
+		_ = os.Rename(parked, fixture.sessionRoot)
+		_ = os.RemoveAll(replacement)
+	})
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "subject_changed" {
+		t.Fatalf("post-reconcile swap result = %#v", result)
+	}
+	if backend.creates != 1 || capabilityCalls.Load() == 0 {
+		t.Fatalf("post-reconcile swap did not execute the original plan: creates=%d capabilities=%d", backend.creates, capabilityCalls.Load())
+	}
+}

--- a/internal/launch/execidentity.go
+++ b/internal/launch/execidentity.go
@@ -154,6 +154,15 @@ type ConsultedExecutable struct {
 	Identity  json.RawMessage `json:"identity,omitempty"`
 }
 
+func cloneConsultedExecutable(value *ConsultedExecutable) *ConsultedExecutable {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	clone.Identity = append(json.RawMessage(nil), value.Identity...)
+	return &clone
+}
+
 // ResolveConsultedExecutable looks up requested on PATH when it is not
 // absolute, then probes the consulted path when it exists. Missing paths stay
 // identity-free so schema v2 stays stable for plan-only names.

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -213,6 +213,27 @@ type prepareTargetState struct {
 	baseAuthority   *explicitBaseAuthority
 }
 
+var ErrPrepareAuthorityDrift = errors.New("prepare authority drift")
+
+type prepareAuthorityDriftError struct{ err error }
+
+func (err *prepareAuthorityDriftError) Error() string { return err.err.Error() }
+func (err *prepareAuthorityDriftError) Unwrap() error { return err.err }
+func (err *prepareAuthorityDriftError) Is(target error) bool {
+	return target == ErrPrepareAuthorityDrift || errors.Is(err.err, target)
+}
+
+func prepareAuthorityDrift(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &prepareAuthorityDriftError{err: err}
+}
+
+func isPrepareAuthorityDrift(err error) bool {
+	return errors.Is(err, ErrPrepareAuthorityDrift) || errors.Is(err, fsq.ErrDeliveryRootChanged)
+}
+
 func (state *prepareTargetState) close() {
 	if state == nil {
 		return
@@ -237,24 +258,24 @@ func (state *prepareTargetState) close() {
 func (state *prepareTargetState) verify() error {
 	if state.mailboxConfig != nil {
 		if err := state.mailboxConfig.Verify(); err != nil {
-			return fmt.Errorf("mailbox config changed during Prepare: %w", err)
+			return prepareAuthorityDrift(fmt.Errorf("mailbox config changed during Prepare: %w", err))
 		}
 	}
 	if err := state.projectRoot.VerifyBase(); err != nil {
-		return fmt.Errorf("project root changed during Prepare: %w", err)
+		return prepareAuthorityDrift(fmt.Errorf("project root changed during Prepare: %w", err))
 	}
 	if state.baseAuthority != nil {
 		if err := state.baseAuthority.verify(state.projectRoot, state.baseRoot); err != nil {
-			return fmt.Errorf("base-root authority changed during Prepare: %w", err)
+			return prepareAuthorityDrift(fmt.Errorf("base-root authority changed during Prepare: %w", err))
 		}
 	} else {
 		if err := state.baseRoot.VerifyBase(); err != nil {
-			return fmt.Errorf("session base root changed during Prepare: %w", err)
+			return prepareAuthorityDrift(fmt.Errorf("session base root changed during Prepare: %w", err))
 		}
 	}
 	if state.sessionRoot != nil {
 		if err := state.sessionRoot.VerifyBase(); err != nil {
-			return fmt.Errorf("session root changed during Prepare: %w", err)
+			return prepareAuthorityDrift(fmt.Errorf("session root changed during Prepare: %w", err))
 		}
 		return nil
 	}
@@ -264,10 +285,10 @@ func (state *prepareTargetState) verify() error {
 	child, err := state.baseRoot.OpenDirectChild(state.target.Session)
 	if err == nil {
 		_ = child.Close()
-		return fmt.Errorf("session root appeared during Prepare")
+		return prepareAuthorityDrift(fmt.Errorf("session root appeared during Prepare"))
 	}
 	if !errors.Is(err, os.ErrNotExist) {
-		return err
+		return prepareAuthorityDrift(err)
 	}
 	return nil
 }
@@ -306,52 +327,10 @@ type prepareSubject struct {
 // Focus, trust replacement, journal writer, or mailbox repair callback is
 // reachable from this function.
 func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDependencies) (PrepareResult, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if err := ctx.Err(); err != nil {
-		return PrepareResult{}, err
-	}
-	if !validDigest(request.IntentDigest) {
-		return PrepareResult{}, fmt.Errorf("invalid intent digest")
-	}
-	if len(request.Participants) == 0 {
-		return PrepareResult{}, fmt.Errorf("prepare requires at least one participant")
-	}
-	subjectSchema, err := normalizeSubjectSchema(request.SubjectSchema)
+	ctx, subjectSchema, dependencies, err := validatePrepareRequest(ctx, request, dependencies)
 	if err != nil {
 		return PrepareResult{}, err
 	}
-	if request.Placement != nil {
-		if subjectSchema == SubjectSchemaV1 {
-			return PrepareResult{}, fmt.Errorf("placement requires subject schema %d", SubjectSchemaV2)
-		}
-		if err := request.Placement.Validate(); err != nil {
-			return PrepareResult{}, err
-		}
-	}
-	for _, participant := range request.Participants {
-		switch participant.OnLive {
-		case "", OnLiveRefuse:
-		case OnLiveKeep:
-			if subjectSchema == SubjectSchemaV1 {
-				return PrepareResult{}, fmt.Errorf("on_live keep requires subject schema %d", SubjectSchemaV2)
-			}
-		default:
-			return PrepareResult{}, fmt.Errorf("invalid on_live %q", participant.OnLive)
-		}
-	}
-	if len(request.CallerContext) > 0 && subjectSchema == SubjectSchemaV1 {
-		return PrepareResult{}, fmt.Errorf("caller_context requires subject schema %d", SubjectSchemaV2)
-	}
-	if err := ValidateCallerContext(request.CallerContext); err != nil {
-		return PrepareResult{}, err
-	}
-	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath, request.Target.ProjectRoot)
-	if err != nil {
-		return PrepareResult{}, err
-	}
-	dependencies.AMQPath = amqPath
 	state, err := openPrepareTarget(request.Target)
 	if err != nil {
 		if reason := baseRootRefusalReason(err); reason != "" {
@@ -360,7 +339,60 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 		return PrepareResult{}, err
 	}
 	defer state.close()
+	return prepareAtTarget(ctx, request, dependencies, state, subjectSchema)
+}
 
+func validatePrepareRequest(ctx context.Context, request PrepareRequest, dependencies PrepareDependencies) (context.Context, int, PrepareDependencies, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, 0, PrepareDependencies{}, err
+	}
+	if !validDigest(request.IntentDigest) {
+		return nil, 0, PrepareDependencies{}, fmt.Errorf("invalid intent digest")
+	}
+	if len(request.Participants) == 0 {
+		return nil, 0, PrepareDependencies{}, fmt.Errorf("prepare requires at least one participant")
+	}
+	subjectSchema, err := normalizeSubjectSchema(request.SubjectSchema)
+	if err != nil {
+		return nil, 0, PrepareDependencies{}, err
+	}
+	if request.Placement != nil {
+		if subjectSchema == SubjectSchemaV1 {
+			return nil, 0, PrepareDependencies{}, fmt.Errorf("placement requires subject schema %d", SubjectSchemaV2)
+		}
+		if err := request.Placement.Validate(); err != nil {
+			return nil, 0, PrepareDependencies{}, err
+		}
+	}
+	for _, participant := range request.Participants {
+		switch participant.OnLive {
+		case "", OnLiveRefuse:
+		case OnLiveKeep:
+			if subjectSchema == SubjectSchemaV1 {
+				return nil, 0, PrepareDependencies{}, fmt.Errorf("on_live keep requires subject schema %d", SubjectSchemaV2)
+			}
+		default:
+			return nil, 0, PrepareDependencies{}, fmt.Errorf("invalid on_live %q", participant.OnLive)
+		}
+	}
+	if len(request.CallerContext) > 0 && subjectSchema == SubjectSchemaV1 {
+		return nil, 0, PrepareDependencies{}, fmt.Errorf("caller_context requires subject schema %d", SubjectSchemaV2)
+	}
+	if err := ValidateCallerContext(request.CallerContext); err != nil {
+		return nil, 0, PrepareDependencies{}, err
+	}
+	amqPath, err := resolveLaunchAMQExecutable(dependencies.AMQPath, request.Target.ProjectRoot)
+	if err != nil {
+		return nil, 0, PrepareDependencies{}, err
+	}
+	dependencies.AMQPath = amqPath
+	return ctx, subjectSchema, dependencies, nil
+}
+
+func prepareAtTarget(ctx context.Context, request PrepareRequest, dependencies PrepareDependencies, state *prepareTargetState, subjectSchema int) (PrepareResult, error) {
 	binding, bindingObservation, err := inspectPrepareBinding(state.sessionRoot)
 	if err != nil {
 		return PrepareResult{}, err
@@ -545,6 +577,10 @@ func Prepare(ctx context.Context, request PrepareRequest, dependencies PrepareDe
 	result.SubjectDigest, err = digestCanonical(subject)
 	if err != nil {
 		return PrepareResult{}, err
+	}
+	if state.mailboxConfig != nil {
+		_ = state.mailboxConfig.Close()
+		state.mailboxConfig = nil
 	}
 	return result, nil
 }

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -77,11 +78,21 @@ type ReconcileRequest struct {
 	// ExecutionOptions carries normalized wrapper policy into the plan, journal,
 	// and ticket. The exact-root/options boundary owns later consumption.
 	ExecutionOptions map[string]PrepareExecutionOptions
+	// AuthorizedIdentities carries the physical provider, wrapper, and cwd
+	// identities captured by Apply's authorization Prepare. Reconcile checks
+	// these before any adapter capability probe or ticket creation.
+	AuthorizedIdentities map[string]AuthorizedParticipantIdentity
 	// Placement is the caller-requested tuple. Nil preserves v0.61 Create.
 	Placement *Placement
 	// OnLive is the per-handle live-seat policy. Missing keys are refuse.
 	OnLive        map[string]string
 	CallerContext map[string]string
+}
+
+type AuthorizedParticipantIdentity struct {
+	Executable  *ConsultedExecutable
+	Wrapper     *ConsultedExecutable
+	CwdIdentity string
 }
 
 type AgentReconcileResult struct {
@@ -517,6 +528,22 @@ func plannedFromJournal(request ReconcileRequest, journal LaunchJournal, result 
 		if !foundConfig {
 			return nil, fmt.Errorf("launch journal handle %q does not match current roster", plan.Handle)
 		}
+		resultIndex := -1
+		for j, agentResult := range journal.Agents {
+			if agentResult.Handle == plan.Handle {
+				resultIndex = j
+				break
+			}
+		}
+		if resultIndex < 0 {
+			return nil, fmt.Errorf("launch journal handle %q has no result", plan.Handle)
+		}
+		if err := verifyAuthorizedParticipantIdentity(request, cfg); err != nil {
+			result.Agents[resultIndex].Code = 6
+			result.Agents[resultIndex].ConversationDisposition = DispositionActionRequired
+			result.Agents[resultIndex].Reason = "authorized_identity_changed"
+			return nil, nil
+		}
 		adapter := request.Adapters[cfg.Adapter]
 		if adapter == nil || adapter.Mode() != plan.AdapterMode {
 			return nil, fmt.Errorf("launch journal adapter for %q is unavailable or changed", plan.Handle)
@@ -533,16 +560,6 @@ func plannedFromJournal(request ReconcileRequest, journal LaunchJournal, result 
 		}
 		if !capabilities.Available {
 			return nil, fmt.Errorf("launch journal adapter for %q is unavailable", plan.Handle)
-		}
-		resultIndex := -1
-		for j, agentResult := range journal.Agents {
-			if agentResult.Handle == plan.Handle {
-				resultIndex = j
-				break
-			}
-		}
-		if resultIndex < 0 {
-			return nil, fmt.Errorf("launch journal handle %q has no result", plan.Handle)
 		}
 		write := journal.Agents[resultIndex].ConversationDisposition != DispositionResumed
 		planned[i] = plannedAgent{
@@ -800,10 +817,66 @@ func commitRecoveredJournal(request ReconcileRequest, lease *Lease, journal Laun
 	return ClearJournal(request.Root, lease, journal)
 }
 
+func verifyAuthorizedParticipantIdentity(request ReconcileRequest, cfg ProjectAgentConfig) error {
+	expected, ok := request.AuthorizedIdentities[cfg.Handle]
+	if !ok {
+		return nil
+	}
+	if expected.Executable != nil {
+		if len(cfg.Command) == 0 {
+			return fmt.Errorf("provider executable is missing")
+		}
+		actual, err := ResolveConsultedExecutable(cfg.Command[0])
+		if err != nil {
+			return fmt.Errorf("resolve provider executable: %w", err)
+		}
+		if actual.Requested != expected.Executable.Requested || actual.Consulted != expected.Executable.Consulted || !bytes.Equal(actual.Identity, expected.Executable.Identity) {
+			return fmt.Errorf("provider executable identity changed")
+		}
+	}
+	if expected.Wrapper != nil {
+		if cfg.Wrapper == nil {
+			return fmt.Errorf("wrapper was removed")
+		}
+		actual, err := ResolveConsultedExecutable(cfg.Wrapper.Executable)
+		if err != nil {
+			return fmt.Errorf("resolve wrapper executable: %w", err)
+		}
+		if actual.Requested != expected.Wrapper.Requested || actual.Consulted != expected.Wrapper.Consulted || !bytes.Equal(actual.Identity, expected.Wrapper.Identity) {
+			return fmt.Errorf("wrapper executable identity changed")
+		}
+	} else if cfg.Wrapper != nil {
+		return fmt.Errorf("wrapper was added")
+	}
+	cwd := cfg.Cwd
+	if strings.TrimSpace(cwd) == "" {
+		cwd = request.ProjectRoot
+	} else if !filepath.IsAbs(cwd) {
+		cwd = filepath.Join(request.ProjectRoot, cwd)
+	}
+	resolvedCwd, err := resolvedPath(cwd)
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	cwdIdentity, err := fsq.StableTreeIdentity(resolvedCwd)
+	if err != nil {
+		return fmt.Errorf("identify working directory: %w", err)
+	}
+	if expected.CwdIdentity != "" && cwdIdentity != expected.CwdIdentity {
+		return fmt.Errorf("working directory identity changed")
+	}
+	return nil
+}
+
 func buildReconcilePlan(request ReconcileRequest, nonce string, result *ReconcileResult) ([]plannedAgent, error) {
 	planned := make([]plannedAgent, 0, len(request.Config.Agents))
 	for _, cfg := range request.Config.Agents {
 		item := AgentReconcileResult{Handle: cfg.Handle}
+		if err := verifyAuthorizedParticipantIdentity(request, cfg); err != nil {
+			item.Code, item.ConversationDisposition, item.Reason = 6, DispositionActionRequired, "authorized_identity_changed"
+			result.Agents = append(result.Agents, item)
+			continue
+		}
 		adapter := request.Adapters[cfg.Adapter]
 		if adapter == nil {
 			item.ConversationDisposition, item.Reason = DispositionUnsupported, "adapter_not_registered"


### PR DESCRIPTION
Bead amq-14a — ChatGPT Pro review A findings 1, 2 (both P0).

- Apply authorization is bound to the already-open prepare target (`prepareAtTarget` on the pinned state); a target swap between open and authorization is refused with typed `subject_changed` before any write. An `openPrepareTarget` open-once invariant test pins the binding directly.
- Authorized provider/wrapper/cwd physical identities are carried into `ReconcileRequest` and verified before any adapter capability subprocess and before ticket creation (`authorized_identity_changed`), including the journal-recovery path.
- Error-text drift mapping replaced with typed sentinels (`fsq.ErrDeliveryRootChanged`, `launch.ErrPrepareAuthorityDrift`) matched via `errors.Is`.
- The trailing status Prepare is pinned to the same state so a post-Reconcile swap cannot mis-report roster/observations.

Review: execution-gated across two rounds; mutants for journal-recovery guard, typed drift chain, per-identity checks (provider/wrapper/cwd), path-vs-physical comparison, over-tighten negative, and post-Reconcile swap all killed. Local pre-push `make ci` green.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
