### PR TITLE
fix(launch): return a coherent snapshot when the lifecycle binding changes during inspect

### DIFF
--- a/internal/launch/lifecycle.go
+++ b/internal/launch/lifecycle.go
@@ -28,6 +28,7 @@ type LifecycleResult struct {
 }
 
 var beforeLifecycleBackendMutationForTest func()
+var afterLifecycleSnapshotForTest func()
 
 func InspectLifecycle(ctx context.Context, request LifecycleRequest, dependencies LifecycleDependencies) (LifecycleResult, error) {
 	state, err := openLifecycleTarget(ctx, request.Target)
@@ -67,6 +68,19 @@ func InspectLifecycle(ctx context.Context, request LifecycleRequest, dependencie
 			return lifecycleRefusal(binding, detect, "evidence_corrupt"), nil
 		}
 		return LifecycleResult{}, err
+	}
+	if afterLifecycleSnapshotForTest != nil {
+		afterLifecycleSnapshotForTest()
+	}
+	current, err := LoadBinding(state.sessionRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return lifecycleRefusal(binding, detect, "binding_changed"), nil
+	}
+	if err != nil {
+		return lifecycleRefusal(binding, detect, "binding_changed"), nil
+	}
+	if !reflect.DeepEqual(current, binding) {
+		return lifecycleRefusal(current, DetectResult{}, "binding_changed"), nil
 	}
 	result.Outcome, result.State = LifecycleOutcomeInspected, string(inspection.Status)
 	if inspection.Status == InspectUnknown || inspection.ActionRequired {

--- a/internal/launch/lifecycle_test.go
+++ b/internal/launch/lifecycle_test.go
@@ -162,6 +162,148 @@ func TestInspectMissingBindingCreatesNothing(t *testing.T) {
 	}
 }
 
+func TestInspectLifecycleRefusesBindingChangeDuringSnapshot(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	request := reconcileFixture(t, backend)
+	moveReconcileFixtureToLifecycleSession(t, &request)
+	writeReconcileBinding(t, request, backend, backend.Detect().Profile.Identity())
+	changed := BindingRecord{
+		Version: BindingVersion, Backend: backend.name, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: backend.Detect().Profile.Identity(), LaunchNonce: testLaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:changed"}}},
+	}
+	previousHook := afterLifecycleSnapshotForTest
+	afterLifecycleSnapshotForTest = func() { writeLifecycleBindingRaw(t, request.Root.Base(), changed) }
+	t.Cleanup(func() { afterLifecycleSnapshotForTest = previousHook })
+
+	result, err := InspectLifecycle(context.Background(), LifecycleRequest{Target: PrepareTarget{
+		ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Session: request.Session,
+	}}, LifecycleDependencies{Backends: map[string]Backend{backend.name: backend}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != string(OutcomeActionRequired) || result.ReasonCode != "binding_changed" || result.State != string(InspectUnknown) {
+		t.Fatalf("changed binding Inspect = %#v", result)
+	}
+	if result.Profile != changed.Profile {
+		t.Fatalf("changed binding profile = %q, want current %q", result.Profile, changed.Profile)
+	}
+}
+
+func TestInspectLifecycleRefusesDifferentBackendBindingDuringSnapshot(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	other := &reconcileBackend{name: "other", inspect: InspectPresent}
+	request := reconcileFixture(t, backend)
+	moveReconcileFixtureToLifecycleSession(t, &request)
+	writeReconcileBinding(t, request, backend, backend.Detect().Profile.Identity())
+	changed := BindingRecord{
+		Version: BindingVersion, Backend: other.name, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: other.Detect().Profile.Identity(), LaunchNonce: testLaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:other"}}},
+	}
+	previousHook := afterLifecycleSnapshotForTest
+	afterLifecycleSnapshotForTest = func() { writeLifecycleBindingRaw(t, request.Root.Base(), changed) }
+	t.Cleanup(func() { afterLifecycleSnapshotForTest = previousHook })
+
+	result, err := InspectLifecycle(context.Background(), LifecycleRequest{Target: PrepareTarget{
+		ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Session: request.Session,
+	}}, LifecycleDependencies{Backends: map[string]Backend{backend.name: backend, other.name: other}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != string(OutcomeActionRequired) || result.ReasonCode != "binding_changed" ||
+		result.Backend != other.name || result.Profile != changed.Profile {
+		t.Fatalf("different backend binding Inspect = %#v, want backend=%q profile=%q", result, other.name, changed.Profile)
+	}
+}
+
+func TestInspectLifecycleRefusesBindingDisappearanceDuringSnapshot(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	request := reconcileFixture(t, backend)
+	moveReconcileFixtureToLifecycleSession(t, &request)
+	writeReconcileBinding(t, request, backend, backend.Detect().Profile.Identity())
+	previousHook := afterLifecycleSnapshotForTest
+	afterLifecycleSnapshotForTest = func() {
+		if err := os.Remove(BindingPath(request.Root.Base())); err != nil {
+			t.Fatalf("remove binding in hook: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterLifecycleSnapshotForTest = previousHook })
+
+	result, err := InspectLifecycle(context.Background(), LifecycleRequest{Target: PrepareTarget{
+		ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Session: request.Session,
+	}}, LifecycleDependencies{Backends: map[string]Backend{backend.name: backend}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != string(OutcomeActionRequired) || result.ReasonCode != "binding_changed" {
+		t.Fatalf("disappeared binding Inspect = %#v", result)
+	}
+}
+
+func TestInspectLifecycleRefusesBindingRereadCorruptionDuringSnapshot(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	request := reconcileFixture(t, backend)
+	moveReconcileFixtureToLifecycleSession(t, &request)
+	writeReconcileBinding(t, request, backend, backend.Detect().Profile.Identity())
+	previousHook := afterLifecycleSnapshotForTest
+	afterLifecycleSnapshotForTest = func() {
+		if err := os.WriteFile(BindingPath(request.Root.Base()), []byte("{"), 0o600); err != nil {
+			t.Fatalf("corrupt binding in hook: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterLifecycleSnapshotForTest = previousHook })
+
+	result, err := InspectLifecycle(context.Background(), LifecycleRequest{Target: PrepareTarget{
+		ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Session: request.Session,
+	}}, LifecycleDependencies{Backends: map[string]Backend{backend.name: backend}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != string(OutcomeActionRequired) || result.ReasonCode != "binding_changed" {
+		t.Fatalf("corrupt binding Inspect = %#v", result)
+	}
+}
+
+func TestInspectLifecycleStableBindingReturnsCoherentSnapshot(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectPresent}
+	request := reconcileFixture(t, backend)
+	moveReconcileFixtureToLifecycleSession(t, &request)
+	writeReconcileBinding(t, request, backend, backend.Detect().Profile.Identity())
+	previousHook := afterLifecycleSnapshotForTest
+	afterLifecycleSnapshotForTest = nil
+	t.Cleanup(func() { afterLifecycleSnapshotForTest = previousHook })
+
+	result, err := InspectLifecycle(context.Background(), LifecycleRequest{Target: PrepareTarget{
+		ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(), Session: request.Session,
+	}}, LifecycleDependencies{Backends: map[string]Backend{backend.name: backend}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != LifecycleOutcomeInspected || result.State != string(InspectPresent) {
+		t.Fatalf("stable binding Inspect = %#v", result)
+	}
+}
+
+func moveReconcileFixtureToLifecycleSession(t *testing.T, request *ReconcileRequest) {
+	t.Helper()
+	base := request.Root.Base()
+	session := filepath.Join(base, request.Session)
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = request.Root.Close()
+	request.Root = root
+}
+
 type lifecycleCountingBackend struct {
 	*TmuxBackend
 	unknown             bool


### PR DESCRIPTION
Bead amq-ggc — ChatGPT Pro review A finding 26.

- `InspectLifecycle` rereads the binding after observation collection; a binding that changed, disappeared, or became unreadable during the window returns `action_required/binding_changed` instead of a torn multi-generation snapshot, and the refusal reports the replacement binding's Backend/Profile (not the stale detect).
- Stable bindings return a coherent result unchanged.

Review: execution-gated across two rounds; mutants for check-removed, check-before-collection, nonce-only comparison, stale-detect pairing, disappearance, unreadable-reread, and refuse-everything over-tightening all killed.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
