### PR TITLE
fix(launch): report committed/uncertain mutation dispositions for apply and lifecycle

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -286,6 +286,12 @@ the returned schema. It must not omit the field to select legacy behavior.
 `reviewedChoiceFor` is intentionally caller-owned. AMQ does not choose trust,
 stale-conversation, rebind, or degraded-capability decisions for the caller.
 
+Apply and lifecycle results include a typed mutation disposition (`not_applied`,
+`committed`, or `uncertain`) and, after a launch commit, its binding generation;
+these fields describe the launch backend binding only, not session or roster
+durability codes. Post-commit failures remain action-required results with exit
+code `6`, not bare errors.
+
 The equivalent CLI split is:
 
 ```bash

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -23,6 +23,14 @@ const (
 	ApplyReasonPrepareActionRequiredWithoutDecision = "prepare_action_required_without_decision"
 )
 
+type MutationDisposition string
+
+const (
+	MutationNotApplied MutationDisposition = "not_applied"
+	MutationCommitted  MutationDisposition = "committed"
+	MutationUncertain  MutationDisposition = "uncertain"
+)
+
 type ApplyDecision struct {
 	ActionID string
 	Choice   string
@@ -36,25 +44,28 @@ type ApplyRequest struct {
 
 type ApplyDependencies struct {
 	PrepareDependencies
-	AMQPath string
+	AMQPath   string
+	CrashHook func(string) error
 }
 
 type ApplyResult struct {
-	Outcome         string
-	ReasonCode      string
-	FailureDetail   string
-	SubjectSchema   int
-	SubjectDigest   string
-	PlanDigest      string
-	TrustDigest     string
-	Backend         string
-	Profile         string
-	Roster          PrepareRoster
-	Observations    []PrepareObservation
-	Commands        []EmittedCommand
-	RequiredActions []PrepareRequiredAction
-	Evidence        []EvidenceRef
-	CallerContext   map[string]string
+	Outcome           string
+	ReasonCode        string
+	FailureDetail     string
+	SubjectSchema     int
+	SubjectDigest     string
+	PlanDigest        string
+	TrustDigest       string
+	Backend           string
+	Profile           string
+	Disposition       MutationDisposition
+	BindingGeneration string
+	Roster            PrepareRoster
+	Observations      []PrepareObservation
+	Commands          []EmittedCommand
+	RequiredActions   []PrepareRequiredAction
+	Evidence          []EvidenceRef
+	CallerContext     map[string]string
 }
 
 var afterApplySessionPublishedForTest func()
@@ -66,6 +77,8 @@ var openPrepareTargetForApply = openPrepareTarget
 var beforeApplyRosterMutationForTest func()
 var beforeApplyBaseRootCreateForTest func()
 var afterApplyBaseRootCreatedForTest func() error
+var beforeApplyFinalPrepareForTest func()
+var collectApplyEvidenceRefs = CollectEvidenceRefs
 var publishApplySession = func(base *fsq.DeliveryRoot, session string, initialize func(*fsq.DeliveryRoot) error) (*fsq.DeliveryRoot, error) {
 	return base.PublishInitializedDirectChildExclusive(session, 0o700, initialize)
 }
@@ -293,7 +306,12 @@ func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, depe
 	}
 	reconciled, err := Reconcile(reconcileRequest)
 	if err != nil {
-		return ApplyResult{}, err
+		result := applyActionResult(prepared, "launch_reconcile_failed")
+		result.FailureDetail = err.Error()
+		return classifyApplyMutation(result, root), nil
+	}
+	if beforeApplyFinalPrepareForTest != nil {
+		beforeApplyFinalPrepareForTest()
 	}
 	if afterApplyReconcileForTest != nil {
 		afterApplyReconcileForTest()
@@ -306,7 +324,7 @@ func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, depe
 			}
 			return applyActionResult(prepared, "subject_changed"), nil
 		}
-		return ApplyResult{}, err
+		return applyPostCommitFailure(applyResultFromPrepare(prepared), request, root, reconciled, "post_commit_prepare_failed", err), nil
 	}
 	if reconciled.AggregateCode == 0 && reconciled.Outcome != "" && reconciled.Outcome != OutcomeNoAction && !authorizedIdentitiesEqual(prepared, finalPrepared) {
 		return applyActionResult(finalPrepared, "subject_changed"), nil
@@ -316,9 +334,11 @@ func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, depe
 	result.RequiredActions = nil
 	result.Commands = slices.Clone(reconciled.Commands)
 	result.Backend, result.TrustDigest = reconciled.Backend, reconciled.SemanticDigest
-	result.Evidence, err = CollectEvidenceRefs(root, handles)
+	classified := classifyApplyMutation(result, root)
+	result.Disposition, result.BindingGeneration = classified.Disposition, classified.BindingGeneration
+	result.Evidence, err = collectApplyEvidenceRefs(root, handles)
 	if err != nil {
-		return ApplyResult{}, err
+		return applyPostCommitFailure(result, request, root, reconciled, "post_commit_evidence_failed", err), nil
 	}
 	if reconciled.AggregateCode == 0 && reconciled.Outcome != "" && reconciled.Outcome != OutcomeNoAction {
 		result.Outcome = ApplyOutcomeApplied
@@ -607,6 +627,7 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 		AMQPath: dependencies.AMQPath, Root: root, Config: config, Launcher: prepared.Launcher,
 		Preferences: slices.Clone(dependencies.Preferences), Backends: dependencies.Backends,
 		Adapters: adapters, TrustStore: dependencies.TrustStore, HeldLease: lease,
+		CrashHook:            dependencies.CrashHook,
 		TrustAuthorityDigest: snapshot.BaseAuthorityDigest,
 		HostIdentity:         dependencies.HostIdentity, AllowExternalCwd: true,
 		ExecutionOptions:     executionOptions,
@@ -740,6 +761,7 @@ func applyActionResult(prepared PrepareResult, reason string) ApplyResult {
 	result := applyResultFromPrepare(prepared)
 	result.Outcome = ApplyOutcomeActionRequired
 	result.ReasonCode = reason
+	result.Disposition = MutationNotApplied
 	return result
 }
 
@@ -749,7 +771,40 @@ func applyResultFromPrepare(prepared PrepareResult) ApplyResult {
 		Backend: prepared.Backend, Profile: prepared.Profile, Roster: prepared.Roster,
 		Observations: slices.Clone(prepared.Observations), RequiredActions: slices.Clone(prepared.RequiredActions),
 		CallerContext: cloneCallerContext(prepared.CallerContext),
+		Disposition:   MutationNotApplied,
 	}
+}
+
+func classifyApplyMutation(result ApplyResult, root *fsq.DeliveryRoot) ApplyResult {
+	binding, bindingErr := LoadBinding(root)
+	if bindingErr == nil {
+		result.Disposition = MutationCommitted
+		result.BindingGeneration = binding.LaunchNonce
+		return result
+	}
+	if journal, present, journalErr := loadOptionalJournal(root); present {
+		result.Disposition = MutationUncertain
+		result.BindingGeneration = journal.LaunchNonce
+		return result
+	} else if journalErr != nil && !errors.Is(journalErr, os.ErrNotExist) {
+		// A journal that exists but cannot be decoded is still evidence that
+		// reconciliation may have crossed the backend mutation boundary.
+		result.Disposition = MutationUncertain
+		return result
+	}
+	if !errors.Is(bindingErr, os.ErrNotExist) {
+		result.Disposition = MutationUncertain
+		return result
+	}
+	result.Disposition = MutationNotApplied
+	return result
+}
+
+func applyPostCommitFailure(result ApplyResult, request ApplyRequest, root *fsq.DeliveryRoot, reconciled ReconcileResult, reason string, err error) ApplyResult {
+	result.SubjectDigest = request.SubjectDigest
+	result.Backend, result.TrustDigest = reconciled.Backend, reconciled.SemanticDigest
+	result.Outcome, result.ReasonCode, result.FailureDetail = ApplyOutcomeActionRequired, reason, err.Error()
+	return classifyApplyMutation(result, root)
 }
 
 func onLivePolicies(participants []PrepareParticipant) map[string]string {

--- a/internal/launch/apply_test.go
+++ b/internal/launch/apply_test.go
@@ -628,6 +628,192 @@ func TestApplyReturnsTypedOutcomeForCommittedRosterConfigDurabilityFailure(t *te
 	}
 }
 
+func TestApplyFinalPrepareFailureReturnsCommittedBinding(t *testing.T) {
+	request, dependencies, _ := committedRunnableApplyFixture(t)
+	beforeApplyFinalPrepareForTest = func() {
+		request.Prepare.Participants[0].Executable = "\x00"
+	}
+	t.Cleanup(func() { beforeApplyFinalPrepareForTest = nil })
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "post_commit_prepare_failed" ||
+		result.Disposition != MutationCommitted || result.BindingGeneration == "" || result.Backend != "test" {
+		t.Fatalf("post-commit Prepare result = %#v", result)
+	}
+}
+
+func TestApplyReconcileCrashAfterBindingReturnsCommittedGeneration(t *testing.T) {
+	request, dependencies, _ := committedRunnableApplyFixture(t)
+	crash := errors.New("crash after binding write")
+	dependencies.CrashHook = func(stage string) error {
+		if stage == "binding_written" {
+			return crash
+		}
+		return nil
+	}
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.Disposition != MutationCommitted || result.BindingGeneration == "" || result.Backend != "test" {
+		t.Fatalf("binding-written crash result = %#v", result)
+	}
+}
+
+func TestApplyReconcileCrashAfterJournalWrittenWithoutBindingIsUncertain(t *testing.T) {
+	request, dependencies, _ := committedRunnableApplyFixture(t)
+	crash := errors.New("crash after journal write")
+	dependencies.CrashHook = func(stage string) error {
+		if stage == "journal_written" {
+			return crash
+		}
+		return nil
+	}
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.Disposition != MutationUncertain || result.BindingGeneration == "" {
+		t.Fatalf("journal-written crash result = %#v", result)
+	}
+}
+
+func TestClassifyApplyMutationCorruptJournalWithoutBindingIsUncertain(t *testing.T) {
+	request, dependencies, _ := committedRunnableApplyFixture(t)
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeApplied || result.Disposition != MutationCommitted {
+		t.Fatalf("successful Apply = %#v", result)
+	}
+	if err := os.Remove(BindingPath(request.Prepare.Target.SessionRoot)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(JournalPath(request.Prepare.Target.SessionRoot), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(request.Prepare.Target.SessionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(request.Prepare.Target.SessionRoot, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	classified := classifyApplyMutation(ApplyResult{Outcome: ApplyOutcomeActionRequired}, root)
+	if classified.Disposition != MutationUncertain {
+		t.Fatalf("corrupt journal classification = %#v, want uncertain", classified)
+	}
+}
+
+func TestApplyEvidenceFailureReturnsCommittedBinding(t *testing.T) {
+	request, dependencies, _ := committedRunnableApplyFixture(t)
+	collectApplyEvidenceRefs = func(*fsq.DeliveryRoot, []string) ([]EvidenceRef, error) {
+		return nil, errors.New("evidence read timeout")
+	}
+	t.Cleanup(func() { collectApplyEvidenceRefs = CollectEvidenceRefs })
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "post_commit_evidence_failed" ||
+		result.Disposition != MutationCommitted || result.BindingGeneration == "" || result.Backend != "test" {
+		t.Fatalf("post-commit evidence result = %#v", result)
+	}
+}
+
+func TestApplyDefinitePreMutationFailureIsNotApplied(t *testing.T) {
+	request, dependencies, backend := committedRunnableApplyFixture(t)
+	backend.createErr = errors.New("create refused before mutation")
+	backend.definiteErr = true
+
+	result, err := Apply(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.Disposition != MutationNotApplied || result.BindingGeneration != "" {
+		t.Fatalf("pre-mutation result = %#v", result)
+	}
+}
+
+func committedRunnableApplyFixture(t *testing.T) (ApplyRequest, ApplyDependencies, *reconcileBackend) {
+	t.Helper()
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	base := filepath.Join(root, "mail")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_, executable := testExecutable(t, ClaudeProvider)
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	store, err := OpenTrustStore(filepath.Join(root, "state"), project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := ApplyRequest{Prepare: PrepareRequest{
+		Target:   PrepareTarget{ProjectRoot: project, SessionRoot: filepath.Join(base, "collab"), Session: "collab"},
+		Launcher: "test", IntentDigest: "sha256:" + string(bytes.Repeat([]byte{'a'}, 64)),
+		Participants: []PrepareParticipant{{Handle: "claude", Provider: ClaudeProvider, Executable: executable, Runnable: true, Cwd: project, ResumePolicy: ResumeDisabled}},
+	}}
+	dependencies := ApplyDependencies{PrepareDependencies: PrepareDependencies{
+		Backends: map[string]Backend{"test": backend}, Preferences: []string{"test"}, TrustStore: store,
+		AdapterFor: func(provider, executable string) HarnessAdapter {
+			return reconcileAdapter{name: provider, mode: AdapterModeMint, available: true}
+		},
+		HostIdentity: "host:test",
+	}}
+	prepared, err := Prepare(context.Background(), request.Prepare, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.SubjectDigest = prepared.SubjectDigest
+	for _, action := range prepared.RequiredActions {
+		request.Decisions = append(request.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: "trust_exact_subject"})
+	}
+	return request, dependencies, backend
+}
+
+func TestClassifyApplyMutationUnreadableBindingWithoutJournalIsUncertain(t *testing.T) {
+	request, _, _ := committedRunnableApplyFixture(t)
+	session := request.Prepare.Target.SessionRoot
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(BindingPath(session)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(BindingPath(session), []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(JournalPath(session)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	classified := classifyApplyMutation(ApplyResult{Outcome: ApplyOutcomeActionRequired}, root)
+	if classified.Disposition != MutationUncertain {
+		t.Fatalf("unreadable binding classification = %#v, want uncertain", classified)
+	}
+}
+
 func TestOnLiveOmittedMatchesV061Apply(t *testing.T) {
 	// Apply-path guard: omit matches explicit refuse (v0.61 whole-binding
 	// refusal). Digest stability is TestPrepareV2SubjectDigestIncludesOnLiveKeepOnly.

--- a/internal/launch/lifecycle.go
+++ b/internal/launch/lifecycle.go
@@ -17,14 +17,16 @@ type LifecycleRequest struct{ Target PrepareTarget }
 type LifecycleDependencies struct{ Backends map[string]Backend }
 
 type LifecycleResult struct {
-	Outcome       string
-	ReasonCode    string
-	Backend       string
-	Profile       string
-	State         string
-	Observations  []PrepareObservation
-	Evidence      []EvidenceRef
-	CallerContext map[string]string
+	Outcome           string
+	ReasonCode        string
+	Backend           string
+	Profile           string
+	Disposition       MutationDisposition
+	BindingGeneration string
+	State             string
+	Observations      []PrepareObservation
+	Evidence          []EvidenceRef
+	CallerContext     map[string]string
 }
 
 var beforeLifecycleBackendMutationForTest func()
@@ -33,33 +35,33 @@ var afterLifecycleSnapshotForTest func()
 func InspectLifecycle(ctx context.Context, request LifecycleRequest, dependencies LifecycleDependencies) (LifecycleResult, error) {
 	state, err := openLifecycleTarget(ctx, request.Target)
 	if err != nil {
-		return LifecycleResult{}, err
+		return LifecycleResult{Disposition: MutationNotApplied}, err
 	}
 	defer state.close()
 	if state.sessionRoot == nil {
-		return LifecycleResult{Outcome: LifecycleOutcomeInspected, State: string(InspectAbsent)}, nil
+		return LifecycleResult{Outcome: LifecycleOutcomeInspected, State: string(InspectAbsent), Disposition: MutationNotApplied}, nil
 	}
 	binding, err := LoadBinding(state.sessionRoot)
 	if errors.Is(err, os.ErrNotExist) {
-		return LifecycleResult{Outcome: LifecycleOutcomeInspected, State: string(InspectAbsent), ReasonCode: "binding_missing"}, nil
+		return LifecycleResult{Outcome: LifecycleOutcomeInspected, State: string(InspectAbsent), ReasonCode: "binding_missing", Disposition: MutationNotApplied}, nil
 	}
 	if err != nil {
 		var contextError *CallerContextValidationError
 		if errors.As(err, &contextError) {
-			return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "caller_context_corrupt"}, nil
+			return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "caller_context_corrupt", Disposition: MutationNotApplied}, nil
 		}
-		return LifecycleResult{}, err
+		return LifecycleResult{Disposition: MutationNotApplied, State: string(InspectUnknown)}, err
 	}
 	backend, detect, refusal, err := validateLifecycleBinding(binding, dependencies, CapInspect)
 	if err != nil {
-		return LifecycleResult{}, err
+		return lifecycleMetadata(binding), err
 	}
 	if refusal != "" {
 		return lifecycleRefusal(binding, detect, refusal), nil
 	}
 	inspection, err := backend.Inspect(InspectRequest{Binding: binding, Root: state.sessionRoot})
 	if err != nil {
-		return LifecycleResult{}, err
+		return lifecycleMetadata(binding), err
 	}
 	result, err := lifecycleResultFromBinding(state.sessionRoot, binding)
 	if err != nil {
@@ -67,7 +69,7 @@ func InspectLifecycle(ctx context.Context, request LifecycleRequest, dependencie
 		if errors.As(err, &corrupt) {
 			return lifecycleRefusal(binding, detect, "evidence_corrupt"), nil
 		}
-		return LifecycleResult{}, err
+		return lifecycleMetadata(binding), err
 	}
 	if afterLifecycleSnapshotForTest != nil {
 		afterLifecycleSnapshotForTest()
@@ -110,38 +112,38 @@ func CloseLifecycle(ctx context.Context, request LifecycleRequest, dependencies 
 func mutateLifecycle(ctx context.Context, request LifecycleRequest, dependencies LifecycleDependencies, capability Capability, operation func(Backend, BindingRecord, *fsq.DeliveryRoot) (Outcome, string, error)) (result LifecycleResult, returnErr error) {
 	state, err := openLifecycleTarget(ctx, request.Target)
 	if err != nil {
-		return LifecycleResult{}, err
+		return LifecycleResult{Disposition: MutationNotApplied}, err
 	}
 	defer state.close()
 	if state.sessionRoot == nil {
-		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectAbsent), ReasonCode: "binding_missing"}, nil
+		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectAbsent), ReasonCode: "binding_missing", Disposition: MutationNotApplied}, nil
 	}
 	lease, err := AcquireLease(state.sessionRoot, "")
 	if err != nil {
-		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "launch_lease_unavailable"}, nil
+		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "launch_lease_unavailable", Disposition: MutationNotApplied}, nil
 	}
 	defer func() { returnErr = errors.Join(returnErr, lease.Release()) }()
 	binding, err := LoadBinding(state.sessionRoot)
 	if errors.Is(err, os.ErrNotExist) {
-		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectAbsent), ReasonCode: "binding_missing"}, nil
+		return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectAbsent), ReasonCode: "binding_missing", Disposition: MutationNotApplied}, nil
 	}
 	if err != nil {
 		var contextError *CallerContextValidationError
 		if errors.As(err, &contextError) {
-			return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "caller_context_corrupt"}, nil
+			return LifecycleResult{Outcome: string(OutcomeActionRequired), State: string(InspectUnknown), ReasonCode: "caller_context_corrupt", Disposition: MutationNotApplied}, nil
 		}
-		return LifecycleResult{}, err
+		return LifecycleResult{Disposition: MutationNotApplied, State: string(InspectUnknown)}, err
 	}
 	backend, detect, refusal, err := validateLifecycleBinding(binding, dependencies, capability)
 	if err != nil {
-		return LifecycleResult{}, err
+		return lifecycleMetadata(binding), err
 	}
 	if refusal != "" {
 		return lifecycleRefusal(binding, detect, refusal), nil
 	}
 	inspection, err := backend.Inspect(InspectRequest{Binding: binding, Root: state.sessionRoot})
 	if err != nil {
-		return LifecycleResult{}, err
+		return lifecycleMetadata(binding), err
 	}
 	if inspection.Status != InspectPresent && (capability != CapClose || inspection.Status != InspectAbsent) {
 		refusal := "inspect_unknown"
@@ -162,7 +164,7 @@ func mutateLifecycle(ctx context.Context, request LifecycleRequest, dependencies
 	}
 	currentBackend, currentDetect, refusal, err := validateLifecycleBinding(current, dependencies, capability)
 	if err != nil {
-		return LifecycleResult{}, err
+		return lifecycleMetadata(current), err
 	}
 	if refusal != "" || currentBackend != backend || !reflect.DeepEqual(currentDetect, detect) {
 		if refusal == "" {
@@ -176,18 +178,23 @@ func mutateLifecycle(ctx context.Context, request LifecycleRequest, dependencies
 		if errors.As(err, &corrupt) {
 			return lifecycleRefusal(current, currentDetect, "evidence_corrupt"), nil
 		}
-		return LifecycleResult{}, err
+		return lifecycleMetadata(current), err
 	}
+	result.Disposition = MutationNotApplied
+	result.BindingGeneration = current.LaunchNonce
 	outcome, _, err := operation(backend, current, state.sessionRoot)
 	if err != nil {
-		return LifecycleResult{}, err
+		result.Outcome, result.ReasonCode, result.Disposition, result.State = string(OutcomeActionRequired), "mutation_uncertain", MutationUncertain, string(InspectUnknown)
+		return result, nil
 	}
 	if outcome == OutcomeActionRequired || outcome == OutcomeUnsupported {
 		return lifecycleRefusal(current, currentDetect, "backend_refused"), nil
 	}
+	result.Disposition = MutationCommitted
 	postMutation, err := backend.Inspect(InspectRequest{Binding: current, Root: state.sessionRoot})
 	if err != nil {
-		return LifecycleResult{}, err
+		result.Outcome, result.ReasonCode, result.State = string(OutcomeActionRequired), "post_mutation_inspect_failed", string(InspectUnknown)
+		return result, nil
 	}
 	result.Outcome = string(outcome)
 	result.State = string(postMutation.Status)
@@ -240,7 +247,14 @@ func lifecycleRefusal(binding BindingRecord, detect DetectResult, reason string)
 	if detect.Profile.Backend != "" {
 		profile = detect.Profile.Identity()
 	}
-	return LifecycleResult{Outcome: string(OutcomeActionRequired), ReasonCode: reason, Backend: binding.Backend, Profile: profile, State: string(InspectUnknown)}
+	return LifecycleResult{Outcome: string(OutcomeActionRequired), ReasonCode: reason, Backend: binding.Backend, Profile: profile, Disposition: MutationNotApplied, BindingGeneration: binding.LaunchNonce, State: string(InspectUnknown)}
+}
+
+func lifecycleMetadata(binding BindingRecord) LifecycleResult {
+	return LifecycleResult{
+		Backend: binding.Backend, Profile: binding.Profile, Disposition: MutationNotApplied,
+		BindingGeneration: binding.LaunchNonce, State: string(InspectUnknown),
+	}
 }
 
 func lifecycleResultFromBinding(root *fsq.DeliveryRoot, binding BindingRecord) (LifecycleResult, error) {
@@ -261,7 +275,7 @@ func lifecycleResultFromBinding(root *fsq.DeliveryRoot, binding BindingRecord) (
 	}
 	_, mailboxes, err := inspectPrepareRoster(root, nil, participants)
 	if err != nil {
-		return LifecycleResult{}, err
+		return lifecycleMetadata(binding), err
 	}
 	observations := make([]PrepareObservation, 0, len(handles))
 	for _, handle := range handles {
@@ -273,25 +287,25 @@ func lifecycleResultFromBinding(root *fsq.DeliveryRoot, binding BindingRecord) (
 			observation.Conversation = string(conversation.State)
 			observation.ConversationIdentityDigest, err = digestCanonical(conversation)
 			if err != nil {
-				return LifecycleResult{}, err
+				return lifecycleMetadata(binding), err
 			}
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return LifecycleResult{}, err
+			return lifecycleMetadata(binding), err
 		}
 		if ticket, err := LoadExecutionTicket(root, handle); err == nil {
 			observation.Execution = string(ticket.State)
 			observation.ExecutionIdentityDigest, err = digestCanonical(ticket)
 			if err != nil {
-				return LifecycleResult{}, err
+				return lifecycleMetadata(binding), err
 			}
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return LifecycleResult{}, err
+			return lifecycleMetadata(binding), err
 		}
 		observations = append(observations, observation)
 	}
 	evidence, err := CollectEvidenceRefs(root, handles)
 	if err != nil {
-		return LifecycleResult{}, err
+		return lifecycleMetadata(binding), err
 	}
-	return LifecycleResult{Backend: binding.Backend, Profile: binding.Profile, Observations: observations, Evidence: evidence, CallerContext: cloneCallerContext(binding.CallerContext)}, nil
+	return LifecycleResult{Backend: binding.Backend, Profile: binding.Profile, BindingGeneration: binding.LaunchNonce, Disposition: MutationNotApplied, Observations: observations, Evidence: evidence, CallerContext: cloneCallerContext(binding.CallerContext)}, nil
 }

--- a/internal/launch/lifecycle_test.go
+++ b/internal/launch/lifecycle_test.go
@@ -304,6 +304,36 @@ func moveReconcileFixtureToLifecycleSession(t *testing.T, request *ReconcileRequ
 	request.Root = root
 }
 
+func TestMissingBindingLifecycleMutationsAreNotApplied(t *testing.T) {
+	project := t.TempDir()
+	sessionPath := filepath.Join(project, ".agent-mail", "collab")
+	if err := fsq.EnsureRootDirs(sessionPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionPath, "meta", "config.json"), []byte(`{"version":1,"agents":["operator"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := LifecycleRequest{Target: PrepareTarget{ProjectRoot: project, SessionRoot: sessionPath, Session: "collab"}}
+	for _, test := range []struct {
+		name string
+		call func() (LifecycleResult, error)
+	}{
+		{name: "focus", call: func() (LifecycleResult, error) {
+			return FocusLifecycle(context.Background(), target, LifecycleDependencies{})
+		}},
+		{name: "close", call: func() (LifecycleResult, error) {
+			return CloseLifecycle(context.Background(), target, LifecycleDependencies{})
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := test.call()
+			if err != nil || result.Disposition != MutationNotApplied || result.ReasonCode != "binding_missing" || result.BindingGeneration != "" {
+				t.Fatalf("missing binding %s = %#v, %v", test.name, result, err)
+			}
+		})
+	}
+}
+
 type lifecycleCountingBackend struct {
 	*TmuxBackend
 	unknown             bool

--- a/launchapi/apply.go
+++ b/launchapi/apply.go
@@ -40,6 +40,7 @@ func fromInternalApplyResult(result internallaunch.ApplyResult) ApplyResultV1 {
 		ResultVersion: ResultVersionV1, SubjectSchema: result.SubjectSchema, Outcome: result.Outcome, ReasonCode: result.ReasonCode, FailureDetail: result.FailureDetail,
 		SubjectDigest: result.SubjectDigest, PlanDigest: result.PlanDigest, TrustDigest: result.TrustDigest,
 		SemanticDigest: result.TrustDigest, Backend: result.Backend, Profile: result.Profile,
+		Disposition: MutationDispositionV1(result.Disposition), BindingGeneration: result.BindingGeneration,
 		Roster: RosterDriftV1{
 			Desired: slices.Clone(result.Roster.Desired), Present: slices.Clone(result.Roster.Present),
 			Missing: slices.Clone(result.Roster.Missing), Extra: slices.Clone(result.Roster.Extra),

--- a/launchapi/encoding_test.go
+++ b/launchapi/encoding_test.go
@@ -110,6 +110,7 @@ func goldenApplyResultV1() ApplyResultV1 {
 	return ApplyResultV1{
 		ResultVersion: 1, SubjectSchema: SubjectSchemaV2, Outcome: "applied", SubjectDigest: goldenDigest('a'), PlanDigest: goldenDigest('b'),
 		TrustDigest: goldenDigest('c'), SemanticDigest: goldenDigest('c'), Backend: "commands", Profile: "commands/portable/v1",
+		Disposition: "committed", BindingGeneration: "75757575-7575-4575-8575-757575757575",
 		Roster: RosterDriftV1{Desired: []string{"claude"}, Present: []string{"claude"}, Missing: []string{}, Extra: []string{}},
 		Observations: []ParticipantObservationV1{{
 			Handle: "claude", Mailbox: "present", Runnable: true, Conversation: "ready", Execution: "acknowledged", Resource: "commands:claude",

--- a/launchapi/lifecycle.go
+++ b/launchapi/lifecycle.go
@@ -55,7 +55,7 @@ var lifecycleBackends = internallaunch.DefaultBackends
 func lifecycleResult(result internallaunch.LifecycleResult) LifecycleResultV1 {
 	public := LifecycleResultV1{
 		ResultVersion: ResultVersionV1, Outcome: result.Outcome, ReasonCode: result.ReasonCode,
-		Backend: result.Backend, Profile: result.Profile, State: result.State,
+		Backend: result.Backend, Profile: result.Profile, Disposition: MutationDispositionV1(result.Disposition), BindingGeneration: result.BindingGeneration, State: result.State,
 		Observations:  make([]ParticipantObservationV1, 0, len(result.Observations)),
 		Evidence:      make([]EvidenceRefV1, 0, len(result.Evidence)),
 		CallerContext: cloneStringMap(result.CallerContext),

--- a/launchapi/lifecycle_test.go
+++ b/launchapi/lifecycle_test.go
@@ -3,6 +3,7 @@ package launchapi
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,6 +13,68 @@ import (
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
 	internallaunch "github.com/avivsinai/agent-message-queue/internal/launch"
 )
+
+func TestLifecycleResultsMatchPublishedSchema(t *testing.T) {
+	project := t.TempDir()
+	session := filepath.Join(project, ".agent-mail", "collab")
+	if err := fsq.EnsureRootDirs(session); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(session, "meta", "config.json"), []byte(`{"version":1,"agents":["claude"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fsq.EnsureAgentDirs(session, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := fsq.OpenDeliveryRoot(session, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+	backend := &publicLifecycleBackend{}
+	detect := backend.Detect()
+	binding := internallaunch.BindingRecord{
+		Version: internallaunch.BindingVersion, Backend: detect.Profile.Backend,
+		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
+		Profile: detect.Profile.Identity(), LaunchNonce: "78787878-7878-4787-8787-787878787878",
+		Resources: internallaunch.ResourceIdentitySet{Version: internallaunch.ResourceSetVersion, Resources: []internallaunch.ResourceIdentity{
+			{OpaqueID: "session:one"}, {OpaqueID: "window:one", Agent: "claude"},
+		}},
+	}
+	lease, err := internallaunch.AcquireLease(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := internallaunch.WriteBinding(root, lease, binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	previous := lifecycleBackends
+	lifecycleBackends = func() map[string]internallaunch.Backend { return map[string]internallaunch.Backend{"test": backend} }
+	t.Cleanup(func() { lifecycleBackends = previous })
+	request := InspectRequestV1{RequestVersion: RequestVersionV1, Target: TargetV1{ProjectRoot: project, SessionRoot: session, Session: "collab"}}
+	inspected, err := Inspect(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLiveResultMatchesPublishedSchema(t, "InspectResultV1", inspected)
+	focused, err := Focus(context.Background(), FocusRequestV1(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLiveResultMatchesPublishedSchema(t, "FocusResultV1", focused)
+	closed, err := Close(context.Background(), CloseRequestV1(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLiveResultMatchesPublishedSchema(t, "CloseResultV1", closed)
+}
 
 func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	project := t.TempDir()
@@ -65,6 +128,7 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	if err != nil || inspected.ResultVersion != ResultVersionV1 || inspected.State != "present" || len(inspected.Observations) != 1 || inspected.Observations[0].Resource != "window:one" {
 		t.Fatalf("Inspect = %#v, %v", inspected, err)
 	}
+	assertLiveLifecycleResultMatchesPublishedSchema(t, "InspectResultV1", inspected)
 	if !reflect.DeepEqual(inspected.CallerContext, binding.CallerContext) {
 		t.Fatalf("Inspect caller context = %#v, want %#v", inspected.CallerContext, binding.CallerContext)
 	}
@@ -75,12 +139,26 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 	if err != nil || focused.Outcome != "attached" || backend.focuses != 1 {
 		t.Fatalf("Focus = %#v, %v focuses=%d", focused, err, backend.focuses)
 	}
+	assertLiveLifecycleResultMatchesPublishedSchema(t, "FocusResultV1", focused)
 	closed, err := Close(context.Background(), CloseRequestV1(request))
 	if err != nil || closed.Outcome != "closed" || backend.closes != 1 {
 		t.Fatalf("Close = %#v, %v closes=%d", closed, err, backend.closes)
 	}
+	assertLiveLifecycleResultMatchesPublishedSchema(t, "CloseResultV1", closed)
 	if _, err := internallaunch.LoadBinding(root); err != nil {
 		t.Fatalf("public Close removed AMQ binding: %v", err)
+	}
+	backend.failInspectCall = backend.inspectCalls + 2
+	postMutationFailure, err := Close(context.Background(), CloseRequestV1(request))
+	if err != nil || postMutationFailure.Outcome != "action_required" || postMutationFailure.ReasonCode != "post_mutation_inspect_failed" ||
+		postMutationFailure.Disposition != MutationDispositionCommittedV1 || postMutationFailure.BindingGeneration == "" {
+		t.Fatalf("post-mutation Inspect failure = %#v, %v", postMutationFailure, err)
+	}
+	backend.closeErr = errors.New("close mutation failed")
+	operationFailure, err := Close(context.Background(), CloseRequestV1(request))
+	if err != nil || operationFailure.Outcome != "action_required" || operationFailure.ReasonCode != "mutation_uncertain" ||
+		operationFailure.Disposition != MutationDispositionUncertainV1 || operationFailure.BindingGeneration == "" {
+		t.Fatalf("mutation failure = %#v, %v", operationFailure, err)
 	}
 	bindingPath := internallaunch.BindingPath(session)
 	bindingData, err := os.ReadFile(bindingPath)
@@ -144,15 +222,33 @@ func TestLifecycleFacadeUsesOwnedBinding(t *testing.T) {
 		t.Fatal(err)
 	}
 	corrupt, err := Inspect(context.Background(), request)
-	if err != nil || corrupt.Outcome != "action_required" || corrupt.ReasonCode != "evidence_corrupt" || backend.focuses != 1 || backend.closes != 1 {
+	if err != nil || corrupt.Outcome != "action_required" || corrupt.ReasonCode != "evidence_corrupt" || backend.focuses != 1 || backend.closes != 3 {
 		t.Fatalf("corrupt evidence Inspect = %#v, %v", corrupt, err)
+	}
+	if err := os.Remove(bindingPath); err != nil {
+		t.Fatal(err)
+	}
+	missingInspect, err := Inspect(context.Background(), request)
+	if err != nil || missingInspect.Disposition != MutationDispositionNotAppliedV1 || missingInspect.BindingGeneration != "" {
+		t.Fatalf("missing-binding Inspect = %#v, %v", missingInspect, err)
+	}
+	missingFocus, err := Focus(context.Background(), FocusRequestV1(request))
+	if err != nil || missingFocus.Disposition != MutationDispositionNotAppliedV1 || missingFocus.BindingGeneration != "" {
+		t.Fatalf("missing-binding Focus = %#v, %v", missingFocus, err)
+	}
+	missingClose, err := Close(context.Background(), CloseRequestV1(request))
+	if err != nil || missingClose.Disposition != MutationDispositionNotAppliedV1 || missingClose.BindingGeneration != "" {
+		t.Fatalf("missing-binding Close = %#v, %v", missingClose, err)
 	}
 }
 
 type publicLifecycleBackend struct {
-	focuses int
-	closes  int
-	closed  bool
+	focuses         int
+	closes          int
+	closed          bool
+	closeErr        error
+	inspectCalls    int
+	failInspectCall int
 }
 
 func (*publicLifecycleBackend) Detect() internallaunch.DetectResult {
@@ -170,6 +266,10 @@ func (*publicLifecycleBackend) Create(internallaunch.CreateRequest) (internallau
 }
 
 func (backend *publicLifecycleBackend) Inspect(internallaunch.InspectRequest) (internallaunch.InspectResult, error) {
+	backend.inspectCalls++
+	if backend.inspectCalls == backend.failInspectCall {
+		return internallaunch.InspectResult{}, errors.New("inspect timeout")
+	}
 	if backend.closed {
 		return internallaunch.InspectResult{Status: internallaunch.InspectAbsent, Evidence: "closed"}, nil
 	}
@@ -183,6 +283,9 @@ func (backend *publicLifecycleBackend) Focus(internallaunch.FocusRequest) (inter
 
 func (backend *publicLifecycleBackend) Close(internallaunch.CloseRequest) (internallaunch.CloseResult, error) {
 	backend.closes++
+	if backend.closeErr != nil {
+		return internallaunch.CloseResult{}, backend.closeErr
+	}
 	backend.closed = true
 	return internallaunch.CloseResult{Outcome: internallaunch.OutcomeClosed}, nil
 }

--- a/launchapi/schema_test.go
+++ b/launchapi/schema_test.go
@@ -54,6 +54,7 @@ func TestLaunchAPIV1SchemaContract(t *testing.T) {
 	assertSchemaPropertiesMatchType(t, defs, "PrepareResultV1", reflect.TypeFor[PrepareResultV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ApplyRequestV1", reflect.TypeFor[ApplyRequestV1]())
 	assertSchemaPropertiesMatchType(t, defs, "ApplyResultV1", reflect.TypeFor[ApplyResultV1]())
+	assertSchemaPropertiesMatchType(t, defs, "LifecycleResultV1", reflect.TypeFor[LifecycleResultV1]())
 	runnableFields := jsonFieldNames(reflect.TypeFor[ParticipantV1]())
 	assertStringSetsEqual(t, schemaPropertyNames(t, defs, "RunnableParticipantV1"), runnableFields, "runnable participant fields")
 	assertStringSetsEqual(
@@ -111,6 +112,37 @@ func TestPrepareResultMatchesPublishedSchema(t *testing.T) {
 	}
 	if err := schema.Validate(document); err != nil {
 		t.Fatalf("schema rejected live Prepare result: %v\n%s", err, rawResult)
+	}
+}
+
+func assertLiveResultMatchesPublishedSchema(t *testing.T, definition string, result any) {
+	t.Helper()
+	rawSchema, err := os.ReadFile("../schemas/launch-api-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(rawSchema, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("launch-api-v1.schema.json", schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("launch-api-v1.schema.json#/$defs/" + definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawResult, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(rawResult, &document); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(document); err != nil {
+		t.Fatalf("schema rejected live %s result: %v\n%s", definition, err, rawResult)
 	}
 }
 
@@ -267,6 +299,37 @@ func assertStringSetsEqual(t *testing.T, got, want []string, context string) {
 	sort.Strings(want)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("%s = %v, want %v", context, got, want)
+	}
+}
+
+func assertLiveLifecycleResultMatchesPublishedSchema(t *testing.T, definition string, result any) {
+	t.Helper()
+	rawSchema, err := os.ReadFile("../schemas/launch-api-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(rawSchema, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("launch-api-v1.schema.json", schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("launch-api-v1.schema.json#/$defs/" + definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawResult, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(rawResult, &document); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(document); err != nil {
+		t.Fatalf("live %s rejected by published schema: %v\n%s", definition, err, rawResult)
 	}
 }
 

--- a/launchapi/testdata/apply_result_v1.golden.json
+++ b/launchapi/testdata/apply_result_v1.golden.json
@@ -8,6 +8,8 @@
   "semantic_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
   "backend": "commands",
   "profile": "commands/portable/v1",
+  "disposition": "committed",
+  "binding_generation": "75757575-7575-4575-8575-757575757575",
   "roster": {
     "desired": [
       "claude"

--- a/launchapi/types.go
+++ b/launchapi/types.go
@@ -17,6 +17,14 @@ type ResultHintV1 string
 
 const HintReprepareRecommended ResultHintV1 = "reprepare_recommended"
 
+type MutationDispositionV1 string
+
+const (
+	MutationDispositionNotAppliedV1 MutationDispositionV1 = "not_applied"
+	MutationDispositionCommittedV1  MutationDispositionV1 = "committed"
+	MutationDispositionUncertainV1  MutationDispositionV1 = "uncertain"
+)
+
 const (
 	PrepareOutcomeReady          = "ready"
 	PrepareOutcomeActionRequired = "action_required"
@@ -366,15 +374,17 @@ type ApplyResultV1 struct {
 	PlanDigest    string `json:"plan_digest"`
 	TrustDigest   string `json:"trust_digest"`
 	// SemanticDigest is a deprecated compatibility alias of TrustDigest.
-	SemanticDigest string                     `json:"semantic_digest"`
-	Backend        string                     `json:"backend"`
-	Profile        string                     `json:"profile"`
-	Roster         RosterDriftV1              `json:"roster"`
-	Observations   []ParticipantObservationV1 `json:"observations"`
-	Commands       []CommandV1                `json:"commands,omitempty"`
-	FollowUps      []RequiredActionV1         `json:"follow_ups,omitempty"`
-	Evidence       []EvidenceRefV1            `json:"evidence,omitempty"`
-	CallerContext  map[string]string          `json:"caller_context,omitempty"`
+	SemanticDigest    string                     `json:"semantic_digest"`
+	Backend           string                     `json:"backend"`
+	Profile           string                     `json:"profile"`
+	Disposition       MutationDispositionV1      `json:"disposition"`
+	BindingGeneration string                     `json:"binding_generation,omitempty"`
+	Roster            RosterDriftV1              `json:"roster"`
+	Observations      []ParticipantObservationV1 `json:"observations"`
+	Commands          []CommandV1                `json:"commands,omitempty"`
+	FollowUps         []RequiredActionV1         `json:"follow_ups,omitempty"`
+	Evidence          []EvidenceRefV1            `json:"evidence,omitempty"`
+	CallerContext     map[string]string          `json:"caller_context,omitempty"`
 }
 
 type InspectRequestV1 struct {
@@ -386,15 +396,17 @@ type FocusRequestV1 = InspectRequestV1
 type CloseRequestV1 = InspectRequestV1
 
 type LifecycleResultV1 struct {
-	ResultVersion int                        `json:"result_version"`
-	Outcome       string                     `json:"outcome"`
-	ReasonCode    string                     `json:"reason_code,omitempty"`
-	Backend       string                     `json:"backend"`
-	Profile       string                     `json:"profile"`
-	State         string                     `json:"state"`
-	Observations  []ParticipantObservationV1 `json:"observations"`
-	Evidence      []EvidenceRefV1            `json:"evidence,omitempty"`
-	CallerContext map[string]string          `json:"caller_context,omitempty"`
+	ResultVersion     int                        `json:"result_version"`
+	Outcome           string                     `json:"outcome"`
+	ReasonCode        string                     `json:"reason_code,omitempty"`
+	Backend           string                     `json:"backend"`
+	Profile           string                     `json:"profile"`
+	Disposition       MutationDispositionV1      `json:"disposition"`
+	BindingGeneration string                     `json:"binding_generation,omitempty"`
+	State             string                     `json:"state"`
+	Observations      []ParticipantObservationV1 `json:"observations"`
+	Evidence          []EvidenceRefV1            `json:"evidence,omitempty"`
+	CallerContext     map[string]string          `json:"caller_context,omitempty"`
 }
 
 type InspectResultV1 = LifecycleResultV1

--- a/schemas/launch-api-v1.schema.json
+++ b/schemas/launch-api-v1.schema.json
@@ -396,7 +396,7 @@
     "ApplyResultV1": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["result_version", "subject_schema", "outcome", "subject_digest", "plan_digest", "trust_digest", "semantic_digest", "backend", "profile", "roster", "observations"],
+      "required": ["result_version", "subject_schema", "outcome", "subject_digest", "plan_digest", "trust_digest", "semantic_digest", "backend", "profile", "disposition", "roster", "observations"],
       "properties": {
         "result_version": {"const": 1},
         "subject_schema": {"enum": [1, 2]},
@@ -409,6 +409,8 @@
         "semantic_digest": {"$ref": "#/$defs/Digest"},
         "backend": {"type": "string"},
         "profile": {"type": "string"},
+        "disposition": {"enum": ["not_applied", "committed", "uncertain"]},
+        "binding_generation": {"type": "string", "minLength": 1},
         "roster": {"$ref": "#/$defs/RosterDriftV1"},
         "observations": {"type": "array", "items": {"$ref": "#/$defs/ParticipantObservationV1"}},
         "commands": {"type": "array", "items": {"$ref": "#/$defs/CommandV1"}},
@@ -432,13 +434,15 @@
     "LifecycleResultV1": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["result_version", "outcome", "backend", "profile", "state", "observations"],
+      "required": ["result_version", "outcome", "backend", "profile", "disposition", "state", "observations"],
       "properties": {
         "result_version": {"const": 1},
         "outcome": {"type": "string", "minLength": 1},
         "reason_code": {"type": "string"},
         "backend": {"type": "string"},
         "profile": {"type": "string"},
+        "disposition": {"enum": ["not_applied", "committed", "uncertain"]},
+        "binding_generation": {"type": "string", "minLength": 1},
         "state": {"enum": ["present", "absent", "unknown"]},
         "observations": {"type": "array", "items": {"$ref": "#/$defs/ParticipantObservationV1"}},
         "evidence": {"type": "array", "items": {"$ref": "#/$defs/EvidenceRefV1"}},


### PR DESCRIPTION
Bead amq-ko1 — ChatGPT Pro review A findings 17, 18.

- Apply and lifecycle results carry a typed `disposition` (`not_applied` / `committed` / `uncertain`) plus `binding_generation`; post-commit final-Prepare/evidence failures return `action_required` with the committed binding instead of a bare error (exit 6), and pre-mutation failures stay `not_applied`.
- `classifyApplyMutation` treats corrupt/unreadable journals or bindings as `uncertain` (never `not_applied`); the journal-written-but-binding-not-written crash window is classified `uncertain`.
- Lifecycle mutation errors are `uncertain`; post-mutation Inspect failure reports `committed`; every early return carries a valid disposition (live Inspect/Focus/Close schema validation added).

Review: execution-gated across three rounds; 11+ mutants killed (bare-error reverts, mislabels, generation-drop, ordering, schema-drop, corrupt journal/binding fallbacks, crash-window branch).

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
