### PR TITLE
fix(launch): journal managed tmux joins and always clean tickets on definite pre-create failure

### DIFF
--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -153,6 +153,10 @@ type CreateRequest struct {
 	// JoinBinding, when set, adds Plan agents into this owned session instead
 	// of creating a new generation. Nil preserves create-from-absent.
 	JoinBinding *BindingRecord
+	// JoinDeltas records windows already added to JoinBinding so a retry can
+	// skip them. JoinProgress is called after each added window is marked.
+	JoinDeltas   []JoinDelta
+	JoinProgress func(JoinDelta) error
 }
 
 type EmittedCommand struct {

--- a/internal/launch/journal.go
+++ b/internal/launch/journal.go
@@ -56,8 +56,22 @@ type LaunchJournal struct {
 	Agents           []AgentReconcileResult `json:"agents"`
 	Conversations    []ConversationRecord   `json:"conversations"`
 	Binding          *BindingRecord         `json:"binding,omitempty"`
+	JoinBinding      *BindingRecord         `json:"join_binding,omitempty"`
+	JoinDeltas       []JoinDelta            `json:"join_deltas,omitempty"`
 	Placement        PlacementPreview       `json:"placement,omitempty"`
 	CallerContext    map[string]string      `json:"caller_context,omitempty"`
+}
+
+// JoinDelta is the durable proof for one window added to an existing managed
+// tmux session. Its session identity is checked before the next mutation.
+type JoinDelta struct {
+	Handle       string `json:"handle"`
+	SessionID    string `json:"session_id"`
+	SessionName  string `json:"session_name"`
+	SessionNonce string `json:"session_nonce"`
+	Epoch        string `json:"epoch,omitempty"`
+	WindowID     string `json:"window_id"`
+	PaneID       string `json:"pane_id"`
 }
 
 func (record LaunchJournal) Validate() error {
@@ -93,6 +107,38 @@ func (record LaunchJournal) Validate() error {
 	}
 	if err := ValidateCallerContext(record.CallerContext); err != nil {
 		return err
+	}
+	if record.JoinBinding == nil && len(record.JoinDeltas) != 0 {
+		return fmt.Errorf("launch journal join deltas require a join binding")
+	}
+	if record.JoinBinding != nil {
+		if err := record.JoinBinding.Validate(); err != nil {
+			return fmt.Errorf("launch journal join binding: %w", err)
+		}
+		if record.JoinBinding.Backend != record.Backend || record.JoinBinding.Profile != record.Profile ||
+			record.JoinBinding.HostIdentity != record.HostIdentity || record.JoinBinding.InstanceIdentity != record.InstanceIdentity {
+			return fmt.Errorf("launch journal join binding context does not match")
+		}
+		sessionID, sessionName, err := parseTmuxSessionResource(*record.JoinBinding)
+		expectedSessionName, nameErr := tmuxSessionName(record.ProjectIdentity, record.Session)
+		if err != nil || nameErr != nil || sessionName != expectedSessionName {
+			return fmt.Errorf("launch journal join binding session does not match")
+		}
+		epoch := parseTmuxEpoch(*record.JoinBinding)
+		seenJoinHandles := make(map[string]struct{}, len(record.JoinDeltas))
+		for i, delta := range record.JoinDeltas {
+			if err := fsq.ValidateHandle(delta.Handle); err != nil {
+				return fmt.Errorf("launch journal join delta %d: %w", i, err)
+			}
+			if _, ok := seenJoinHandles[delta.Handle]; ok {
+				return fmt.Errorf("duplicate launch journal join delta handle %q", delta.Handle)
+			}
+			seenJoinHandles[delta.Handle] = struct{}{}
+			if delta.SessionID != sessionID || delta.SessionName != sessionName || delta.SessionNonce != record.JoinBinding.LaunchNonce ||
+				delta.Epoch != epoch || delta.WindowID == "" || !tmuxPaneID(delta.PaneID) {
+				return fmt.Errorf("launch journal join delta %q identity does not match its binding", delta.Handle)
+			}
+		}
 	}
 	if !validUUID(record.LaunchNonce) {
 		return fmt.Errorf("launch journal nonce must be a UUID")
@@ -380,9 +426,13 @@ func journalPlacementMatches(record LaunchJournal, request ReconcileRequest) err
 }
 
 func journalMatchesBinding(journal LaunchJournal, binding BindingRecord) bool {
+	launchNonce := journal.LaunchNonce
+	if journal.JoinBinding != nil {
+		launchNonce = journal.JoinBinding.LaunchNonce
+	}
 	return binding.Backend == journal.Backend && binding.Profile == journal.Profile &&
 		binding.HostIdentity == journal.HostIdentity && binding.InstanceIdentity == journal.InstanceIdentity &&
-		binding.LaunchNonce == journal.LaunchNonce && reflect.DeepEqual(binding.CallerContext, journal.CallerContext)
+		binding.LaunchNonce == launchNonce && reflect.DeepEqual(binding.CallerContext, journal.CallerContext)
 }
 
 func canonicalIdentity(path string) (string, error) {

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -120,6 +120,11 @@ type plannedAgent struct {
 	providerVersion string
 }
 
+type joinProgressCrashError struct{ err error }
+
+func (e *joinProgressCrashError) Error() string { return e.err.Error() }
+func (e *joinProgressCrashError) Unwrap() error { return e.err }
+
 func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr error) {
 	result = ReconcileResult{Session: request.Session, Agents: []AgentReconcileResult{}, Commands: []EmittedCommand{}}
 	if request.Context == nil {
@@ -268,34 +273,57 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 			return result, nil
 		}
 		journal = current
-		backendName, backend, detect, create, recoveredCreate, err = recoverJournal(request, journal, binding, hasBinding, &result)
-		if err != nil {
-			return result, err
-		}
-		if result.Outcome == OutcomeActionRequired {
-			markPlannedAgents(&result, planned, 6, result.Reason)
-			result.AggregateCode = 6
-			return result, nil
-		}
-		if hasBinding && journalMatchesBinding(journal, binding) {
-			if journal.Phase != JournalCreated {
-				result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_incomplete"
+		if journal.JoinBinding != nil {
+			if !hasBinding || !reflect.DeepEqual(*journal.JoinBinding, binding) {
+				result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_binding_conflict"
 				return result, nil
 			}
-			if err := commitRecoveredJournal(request, lease, journal); err != nil {
+			copied := *journal.JoinBinding
+			joinBinding = &copied
+			backendName = journal.Backend
+			backend = request.Backends[backendName]
+			if backend == nil {
+				result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "journaled_launcher_not_available"
+				return result, nil
+			}
+			detect = backend.Detect()
+			if err := detect.Validate(); err != nil {
 				return result, err
 			}
-			result.Backend, result.Outcome = journal.Backend, OutcomeCreated
-			result.AggregateCode = aggregateReconcileCode(result.Agents)
-			return result, nil
-		}
-		if !recoveredCreate {
-			// Reclaim proved the old generation absent. Recreate the exact trusted
-			// plan under the existing resume policy and journal generation.
-			if err := ClearJournal(request.Root, lease, journal); err != nil {
+			if !detect.Available || detect.Profile.Identity() != journal.Profile || detect.HostIdentity != journal.HostIdentity || detect.InstanceIdentity != journal.InstanceIdentity {
+				result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_context_mismatch"
+				return result, nil
+			}
+		} else {
+			backendName, backend, detect, create, recoveredCreate, err = recoverJournal(request, journal, binding, hasBinding, &result)
+			if err != nil {
 				return result, err
 			}
-			journalActive = false
+			if result.Outcome == OutcomeActionRequired {
+				markPlannedAgents(&result, planned, 6, result.Reason)
+				result.AggregateCode = 6
+				return result, nil
+			}
+			if hasBinding && journalMatchesBinding(journal, binding) {
+				if journal.Phase != JournalCreated {
+					result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "launch_journal_incomplete"
+					return result, nil
+				}
+				if err := commitRecoveredJournal(request, lease, journal); err != nil {
+					return result, err
+				}
+				result.Backend, result.Outcome = journal.Backend, OutcomeCreated
+				result.AggregateCode = aggregateReconcileCode(result.Agents)
+				return result, nil
+			}
+			if !recoveredCreate {
+				// Reclaim proved the old generation absent. Recreate the exact trusted
+				// plan under the existing resume policy and journal generation.
+				if err := ClearJournal(request.Root, lease, journal); err != nil {
+					return result, err
+				}
+				journalActive = false
+			}
 		}
 	} else {
 		if hasBinding {
@@ -359,12 +387,20 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 		}
 	}
 	result.Backend = backendName
+	tmuxJoinJournal := joinBinding != nil && backendName == LauncherTMux
+	if _, ok := backend.(*TmuxBackend); !ok {
+		tmuxJoinJournal = false
+	}
 
 	if !recoveredCreate {
-		if detect.Profile.Has(CapCreate) && joinBinding == nil {
+		if !journalActive && detect.Profile.Has(CapCreate) && (joinBinding == nil || tmuxJoinJournal) {
 			journal, err = NewLaunchJournal(request, backendName, detect, plan, planDigest, nonce, plannedAgentResults(result.Agents, planned), plannedConversations(planned), time.Now())
 			if err != nil {
 				return result, err
+			}
+			if tmuxJoinJournal {
+				copied := *joinBinding
+				journal.JoinBinding = &copied
 			}
 			if err := WriteJournal(request.Root, lease, journal); err != nil {
 				return result, err
@@ -374,7 +410,8 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 				return result, err
 			}
 		}
-		if err := writeExecutionTickets(request, lease, ticketAgentsForCreate(planned, joinBinding), amqExecutable, backendName, detect.Profile.Identity()); err != nil {
+		ticketAgents := ticketAgentsForCreate(planned, joinBinding)
+		if err := writeExecutionTickets(request, lease, ticketAgents, amqExecutable, backendName, detect.Profile.Identity()); err != nil {
 			return result, err
 		}
 		createPlan := plan
@@ -386,19 +423,39 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 				}
 			}
 		}
+		var joinProgress func(JoinDelta) error
+		if journalActive && tmuxJoinJournal {
+			joinProgress = func(delta JoinDelta) error {
+				journal.JoinDeltas = append(journal.JoinDeltas, delta)
+				if err := WriteJournal(request.Root, lease, journal); err != nil {
+					return err
+				}
+				if err := callCrashHook(request.CrashHook, "join_delta_written:"+delta.Handle); err != nil {
+					return &joinProgressCrashError{err: err}
+				}
+				return nil
+			}
+		}
 		create, err = backend.Create(CreateRequest{
 			ProjectRoot: request.ProjectRoot, Session: request.Session, Plan: createPlan,
 			AMQPath: amqExecutable, Root: request.Root, Placement: request.Placement,
 			JoinBinding: joinBinding,
+			JoinDeltas:  slices.Clone(journal.JoinDeltas), JoinProgress: joinProgress,
 		})
 		if err != nil {
+			var crashErr *joinProgressCrashError
+			if errors.As(err, &crashErr) {
+				return result, crashErr
+			}
 			var definite *DefinitePreCreateError
-			if journalActive && errors.As(err, &definite) {
-				if clearErr := removeExecutionTickets(request.Root, lease, planned); clearErr != nil {
+			if errors.As(err, &definite) {
+				if clearErr := removeExecutionTickets(request.Root, lease, ticketAgents); clearErr != nil {
 					return result, errors.Join(err, clearErr)
 				}
-				if clearErr := ClearJournal(request.Root, lease, journal); clearErr != nil {
-					return result, errors.Join(err, clearErr)
+				if journalActive {
+					if clearErr := ClearJournal(request.Root, lease, journal); clearErr != nil {
+						return result, errors.Join(err, clearErr)
+					}
 				}
 			}
 			code := reconcileErrorCode(err)

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -369,27 +371,29 @@ func (a reconcileAdapter) CaptureIdentity(request CaptureRequest) CaptureResult 
 }
 
 type reconcileBackend struct {
-	mu          sync.Mutex
-	name        string
-	inspect     InspectStatus
-	creates     int
-	closes      int
-	focuses     int
-	createGate  chan struct{}
-	createStart chan struct{}
-	capture     bool
-	captured    *CaptureEvidence
-	invalidBind bool
-	reclaims    int
-	resourceUp  bool
-	reclaimAs   ReclaimStatus
-	reclaimList []ResourceIdentity
-	reclaimFlip bool
-	createErr   error
-	definiteErr bool
-	joined      bool
-	planNonce   string
-	planHandles []string
+	mu                        sync.Mutex
+	name                      string
+	inspect                   InspectStatus
+	creates                   int
+	closes                    int
+	focuses                   int
+	createGate                chan struct{}
+	createStart               chan struct{}
+	capture                   bool
+	captured                  *CaptureEvidence
+	invalidBind               bool
+	reclaims                  int
+	resourceUp                bool
+	reclaimAs                 ReclaimStatus
+	reclaimList               []ResourceIdentity
+	reclaimFlip               bool
+	createErr                 error
+	definiteErr               bool
+	leaveJournalOnCreateError bool
+	joined                    bool
+	joinBindingSeen           bool
+	planNonce                 string
+	planHandles               []string
 }
 
 type unsupportedReconcileBackend struct{ reconcileBackend }
@@ -424,9 +428,15 @@ func (b *reconcileBackend) Detect() DetectResult {
 func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
 	b.mu.Lock()
 	b.creates++
-	createErr, definiteErr := b.createErr, b.definiteErr
+	createErr, definiteErr, leaveJournal := b.createErr, b.definiteErr, b.leaveJournalOnCreateError
+	b.joinBindingSeen = req.JoinBinding != nil
 	if createErr != nil {
 		b.mu.Unlock()
+		if leaveJournal {
+			if err := os.WriteFile(JournalPath(req.Root.Base()), []byte("join-create-error-sentinel"), 0o600); err != nil {
+				return CreateResult{}, errors.Join(createErr, err)
+			}
+		}
 		if definiteErr {
 			return CreateResult{}, &DefinitePreCreateError{Err: createErr}
 		}
@@ -710,6 +720,124 @@ func TestReconcileOnLiveKeepJoinWritesTicketsUnderLeaseNonce(t *testing.T) {
 	}
 	if err := held.Release(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestReconcileTmuxJoinCrashJournalRetriesWithoutDuplicateWindow(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	project := t.TempDir()
+	_, root := harnessRoot(t)
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-reconcile-join-%d-%d", os.Getpid(), time.Now().UnixNano())
+	backend.focus = func(context.Context, string) error { return nil }
+	t.Cleanup(func() { stopTmuxTestServer(t, backend) })
+	store, err := OpenTrustStore(t.TempDir(), project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := ReconcileRequest{
+		ProjectRoot: project, Session: "collab", Root: root, AMQPath: writeTmuxSleepAMQ(t),
+		Config: ProjectConfig{Schema: ProjectConfigSchema, DefaultSession: "collab", Layout: LayoutIntent{Type: LayoutColumns}, Agents: []ProjectAgentConfig{
+			{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeEnabled},
+		}},
+		Launcher: LauncherTMux, Preferences: []string{LauncherTMux}, Backends: map[string]Backend{LauncherTMux: backend},
+		Adapters:   map[string]HarnessAdapter{"claude": reconcileAdapter{name: "claude", mode: AdapterModeMint, available: true}},
+		TrustStore: store, ConfirmTrust: func(Plan, string) (bool, error) { return true, nil }, HostIdentity: backend.Detect().HostIdentity,
+	}
+	first, err := Reconcile(req)
+	if err != nil || first.AggregateCode != 0 {
+		t.Fatalf("initial tmux reconcile=%#v err=%v", first, err)
+	}
+	req.Config.Agents = append(req.Config.Agents, ProjectAgentConfig{Handle: "codex", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeFresh})
+	req.Adapters["codex"] = reconcileAdapter{name: "claude", mode: AdapterModeMint, available: true}
+	req.OnLive = map[string]string{"claude": OnLiveKeep, "codex": OnLiveKeep}
+	crash := errors.New("crash after join delta")
+	req.CrashHook = func(stage string) error {
+		if strings.HasPrefix(stage, "join_delta_written:") {
+			return crash
+		}
+		return nil
+	}
+	joinAttempt, err := Reconcile(req)
+	if !errors.Is(err, crash) {
+		t.Fatalf("join crash result=%#v error=%v", joinAttempt, err)
+	}
+	journal, err := LoadJournal(req.Root)
+	if err != nil || journal.JoinBinding == nil || len(journal.JoinDeltas) != 1 {
+		t.Fatalf("join journal=%#v err=%v", journal, err)
+	}
+	req.CrashHook = nil
+	recovered, err := Reconcile(req)
+	if err != nil || recovered.AggregateCode != 0 || recovered.Outcome != OutcomeCreated {
+		t.Fatalf("recovered tmux join=%#v err=%v", recovered, err)
+	}
+	if got := countLiveTmuxWindows(t, backend); got != 2 {
+		t.Fatalf("tmux windows after join recovery=%d, want exactly two", got)
+	}
+	if _, err := LoadJournal(req.Root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("join journal after recovery=%v", err)
+	}
+}
+
+func TestReconcileTmuxJoinDefiniteReplacementCleansPreCreateTickets(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	project := t.TempDir()
+	_, root := harnessRoot(t)
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = fmt.Sprintf("amq-reconcile-join-clean-%d-%d", os.Getpid(), time.Now().UnixNano())
+	backend.focus = func(context.Context, string) error { return nil }
+	t.Cleanup(func() { stopTmuxTestServer(t, backend) })
+	store, err := OpenTrustStore(t.TempDir(), project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := ReconcileRequest{
+		ProjectRoot: project, Session: "collab", Root: root, AMQPath: writeTmuxSleepAMQ(t),
+		Config: ProjectConfig{Schema: ProjectConfigSchema, DefaultSession: "collab", Layout: LayoutIntent{Type: LayoutColumns}, Agents: []ProjectAgentConfig{
+			{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeEnabled},
+		}},
+		Launcher: LauncherTMux, Preferences: []string{LauncherTMux}, Backends: map[string]Backend{LauncherTMux: backend},
+		Adapters:   map[string]HarnessAdapter{"claude": reconcileAdapter{name: "claude", mode: AdapterModeMint, available: true}},
+		TrustStore: store, ConfirmTrust: func(Plan, string) (bool, error) { return true, nil }, HostIdentity: backend.Detect().HostIdentity,
+	}
+	if result, err := Reconcile(req); err != nil || result.AggregateCode != 0 {
+		t.Fatalf("initial tmux reconcile=%#v err=%v", result, err)
+	}
+	req.Config.Agents = append(req.Config.Agents, ProjectAgentConfig{Handle: "codex", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeFresh})
+	req.Adapters["codex"] = reconcileAdapter{name: "claude", mode: AdapterModeMint, available: true}
+	req.OnLive = map[string]string{"claude": OnLiveKeep, "codex": OnLiveKeep}
+	req.CrashHook = func(stage string) error {
+		if stage != "journal_written" {
+			return nil
+		}
+		name, nameErr := tmuxSessionName(project, "collab")
+		if nameErr != nil {
+			return nameErr
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
+		defer cancel()
+		if _, killErr := backend.run(ctx, backend.args("kill-session", "-t", "="+name)...); killErr != nil {
+			return killErr
+		}
+		_, createErr := backend.run(ctx, backend.args("new-session", "-d", "-s", name, "-e", tmuxNonceEnvironment+"=foreign", "-P", "-F", "#{pane_id}", "/bin/sleep", "60")...)
+		return createErr
+	}
+	result, err := Reconcile(req)
+	if err != nil || result.AggregateCode == 0 {
+		t.Fatalf("replacement join result=%#v err=%v", result, err)
+	}
+	if _, err := LoadJournal(req.Root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("definite replacement retained journal: %v", err)
+	}
+	if _, err := LoadExecutionTicket(req.Root, "codex"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("definite replacement retained codex ticket: %v", err)
+	}
+	if got := countLiveTmuxWindows(t, backend); got != 1 {
+		t.Fatalf("foreign replacement windows=%d, want one", got)
 	}
 }
 
@@ -1463,6 +1591,52 @@ func TestReconcileCreateFailureClassificationControlsJournalClear(t *testing.T) 
 				t.Fatalf("uncertain create failure lost execution ticket: %v", ticketErr)
 			}
 		})
+	}
+}
+
+func TestReconcileJoinDefiniteCreateFailureCleansTicketsWithoutClearingJournal(t *testing.T) {
+	backend := &reconcileBackend{name: LauncherTMux, inspect: InspectPresent, createErr: errors.New("join create refused before mutation"), definiteErr: true, leaveJournalOnCreateError: true}
+	req := reconcileFixture(t, backend)
+	req.Config.Agents = append(req.Config.Agents, ProjectAgentConfig{
+		Handle: "codex", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: ResumeFresh,
+	})
+	req.Adapters["codex"] = reconcileAdapter{name: "claude", mode: AdapterModeMint, available: true}
+	req.OnLive = map[string]string{"claude": OnLiveKeep, "codex": OnLiveKeep}
+	lease, err := AcquireLease(req.Root, testLaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherTMux, HostIdentity: "host:test", InstanceIdentity: "instance:test",
+		Profile: backend.Detect().Profile.Identity(), LaunchNonce: testLaunchNonce,
+		Resources: ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "resource:claude", Agent: "claude"}}},
+	}
+	if err := WriteBinding(req.Root, lease, binding); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	held, err := AcquireLease(req.Root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.HeldLease = held
+	result, err := Reconcile(req)
+	if err := held.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if err != nil || result.AggregateCode != 1 {
+		t.Fatalf("join definite failure result=%#v err=%v", result, err)
+	}
+	if !backend.joinBindingSeen {
+		t.Fatal("expected failed create to receive a join binding")
+	}
+	if got, err := os.ReadFile(JournalPath(req.Root.Base())); err != nil || string(got) != "join-create-error-sentinel" {
+		t.Fatalf("join create error journal sentinel = %q err=%v, want preserved because journalActive=false", got, err)
+	}
+	if _, err := LoadExecutionTicket(req.Root, "codex"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("join definite failure retained new-seat execution ticket: %v", err)
 	}
 }
 

--- a/internal/launch/tmux.go
+++ b/internal/launch/tmux.go
@@ -423,17 +423,40 @@ func (b *TmuxBackend) joinExistingSession(req CreateRequest, detect DetectResult
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)
 	defer cancel()
-	present, err := b.hasSession(ctx, name)
-	if err != nil {
-		return CreateResult{}, err
-	}
-	if !present {
-		return CreateResult{}, fmt.Errorf("tmux session %q is absent; keep cannot join", name)
+	if err := b.validateJoinSession(ctx, *req.JoinBinding, sessionID, name); err != nil {
+		return CreateResult{}, &DefinitePreCreateError{Err: err}
 	}
 	nonce := req.JoinBinding.LaunchNonce
+	journaled := make(map[string]JoinDelta, len(req.JoinDeltas))
+	for _, delta := range req.JoinDeltas {
+		journaled[delta.Handle] = delta
+	}
 	for _, agent := range req.Plan.Agents {
+		resources, resourceErr := b.liveResources(ctx, name)
+		if resourceErr != nil {
+			return CreateResult{}, resourceErr
+		}
+		if resource := tmuxResourceForAgent(resources, agent.Handle); resource != nil {
+			delta, deltaErr := b.joinDelta(ctx, *req.JoinBinding, sessionID, name, nonce, agent.Handle, *resource)
+			if deltaErr != nil {
+				return CreateResult{}, &DefinitePreCreateError{Err: deltaErr}
+			}
+			if prior, ok := journaled[agent.Handle]; ok && prior != delta {
+				return CreateResult{}, &DefinitePreCreateError{Err: fmt.Errorf("tmux joined delta for %s changed", agent.Handle)}
+			}
+			if _, ok := journaled[agent.Handle]; !ok && req.JoinProgress != nil {
+				if err := req.JoinProgress(delta); err != nil {
+					return CreateResult{}, err
+				}
+			}
+			journaled[agent.Handle] = delta
+			continue
+		}
+		if err := b.validateJoinSession(ctx, *req.JoinBinding, sessionID, name); err != nil {
+			return CreateResult{}, &DefinitePreCreateError{Err: err}
+		}
 		createdWindow, createErr := b.run(ctx, b.args("new-window", "-d", "-P", "-F", "#{window_id}\t#{pane_id}",
-			"-t", "="+name, "-n", agent.Handle, b.agentCommand(req, agent))...)
+			"-t", sessionID, "-n", agent.Handle, b.agentCommand(req, agent))...)
 		if createErr != nil {
 			return CreateResult{}, fmt.Errorf("join tmux window for %s: %w", agent.Handle, createErr)
 		}
@@ -441,12 +464,26 @@ func (b *TmuxBackend) joinExistingSession(req CreateRequest, detect DetectResult
 		if len(windowFields) != 2 || windowFields[0] == "" || !tmuxPaneID(windowFields[1]) {
 			return CreateResult{}, fmt.Errorf("tmux returned no window identity for %s", agent.Handle)
 		}
+		if err := b.validateJoinSession(ctx, *req.JoinBinding, sessionID, name); err != nil {
+			return CreateResult{}, &DefinitePreCreateError{Err: err}
+		}
 		if err := b.markWindow(ctx, windowFields[0], agent.Handle); err != nil {
 			return CreateResult{}, err
+		}
+		if err := b.validateJoinSession(ctx, *req.JoinBinding, sessionID, name); err != nil {
+			return CreateResult{}, &DefinitePreCreateError{Err: err}
 		}
 		if err := b.markPane(ctx, windowFields[1], agent.Handle, nonce); err != nil {
 			return CreateResult{}, err
 		}
+		delta := JoinDelta{Handle: agent.Handle, SessionID: sessionID, SessionName: name, SessionNonce: nonce,
+			Epoch: parseTmuxEpoch(*req.JoinBinding), WindowID: windowFields[0], PaneID: windowFields[1]}
+		if req.JoinProgress != nil {
+			if err := req.JoinProgress(delta); err != nil {
+				return CreateResult{}, err
+			}
+		}
+		journaled[agent.Handle] = delta
 	}
 	resources, err := b.liveResources(ctx, name)
 	if err != nil {
@@ -467,6 +504,78 @@ func (b *TmuxBackend) joinExistingSession(req CreateRequest, detect DetectResult
 		return CreateResult{}, fmt.Errorf("joined tmux session identity changed before binding")
 	}
 	return b.createdBinding(detect, nonce, resources, req.JoinBinding.Placement)
+}
+
+func (b *TmuxBackend) validateJoinSession(ctx context.Context, binding BindingRecord, sessionID, name string) error {
+	if err := b.checkBindingEpoch(ctx, binding); err != nil {
+		return err
+	}
+	present, err := b.hasSession(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return fmt.Errorf("tmux session %q is absent; keep cannot join", name)
+	}
+	currentID, err := b.sessionIDForName(ctx, name)
+	if err != nil {
+		return err
+	}
+	if currentID != sessionID {
+		return fmt.Errorf("tmux session identity changed from %s to %s", sessionID, currentID)
+	}
+	nonce, err := b.sessionNonce(ctx, name)
+	if err != nil {
+		return err
+	}
+	if nonce != binding.LaunchNonce {
+		return fmt.Errorf("tmux session nonce changed")
+	}
+	return nil
+}
+
+func (b *TmuxBackend) sessionIDForName(ctx context.Context, name string) (string, error) {
+	out, err := b.run(ctx, b.args("list-sessions", "-F", "#{session_id}\t#{session_name}")...)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		fields := strings.Split(line, "\t")
+		if len(fields) == 2 && fields[1] == name && strings.HasPrefix(fields[0], "$") {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("tmux session %q is absent", name)
+}
+
+func (b *TmuxBackend) joinDelta(ctx context.Context, binding BindingRecord, sessionID, name, nonce, handle string, resource ResourceIdentity) (JoinDelta, error) {
+	paneID, ok := parseTmuxPaneResource(resource.OpaqueID)
+	if !ok {
+		return JoinDelta{}, fmt.Errorf("tmux joined resource for %s has no pane identity", handle)
+	}
+	windowID, err := b.paneWindowID(ctx, paneID)
+	if err != nil {
+		return JoinDelta{}, err
+	}
+	markerHandle, markerNonce, err := b.paneMarkers(ctx, paneID)
+	if err != nil {
+		return JoinDelta{}, err
+	}
+	if markerHandle != handle || markerNonce != nonce {
+		return JoinDelta{}, fmt.Errorf("tmux joined pane %s identity changed", paneID)
+	}
+	return JoinDelta{Handle: handle, SessionID: sessionID, SessionName: name, SessionNonce: nonce,
+		Epoch: parseTmuxEpoch(binding), WindowID: windowID, PaneID: paneID}, nil
+}
+
+func tmuxResourceForAgent(resources []ResourceIdentity, handle string) *ResourceIdentity {
+	for i := range resources {
+		if resources[i].Agent == handle {
+			resource := resources[i]
+			return &resource
+		}
+	}
+	return nil
 }
 
 func (b *TmuxBackend) inspect(ctx context.Context, binding BindingRecord) (InspectResult, error) {

--- a/internal/launch/tmux_placement_test.go
+++ b/internal/launch/tmux_placement_test.go
@@ -67,6 +67,105 @@ func TestTmuxPlacementSessionLayouts(t *testing.T) {
 	}
 }
 
+func TestTmuxJoinCrashAfterEachWindowRetriesWithoutDuplicates(t *testing.T) {
+	for _, crashAfter := range []int{1, 2} {
+		t.Run(fmt.Sprintf("window_%d", crashAfter), func(t *testing.T) {
+			backend, project, root, allPlan := newTmuxPlacementFixture(t, "claude", "codex", "operator")
+			initialPlan := Plan{Version: PlanVersion, Agents: []AgentPlan{allPlan.Agents[0]}}
+			created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: initialPlan, AMQPath: writeTmuxSleepAMQ(t), Root: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			nonce := created.Binding.LaunchNonce
+			joinPlan := Plan{Version: PlanVersion, Agents: []AgentPlan{
+				{Handle: "codex", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e901"},
+				{Handle: "operator", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh, LaunchNonce: nonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e902"},
+			}}
+			var deltas []JoinDelta
+			calls := 0
+			crash := errors.New("crash after joined window")
+			first, err := backend.Create(CreateRequest{
+				ProjectRoot: project, Session: "collab", Plan: joinPlan, AMQPath: writeTmuxSleepAMQ(t), Root: root,
+				JoinBinding: &created.Binding, JoinProgress: func(delta JoinDelta) error {
+					calls++
+					deltas = append(deltas, delta)
+					if calls == crashAfter {
+						return crash
+					}
+					return nil
+				},
+			})
+			if !errors.Is(err, crash) || first.Outcome != "" || len(deltas) != crashAfter {
+				t.Fatalf("crashed join result=%#v err=%v deltas=%#v", first, err, deltas)
+			}
+			second, err := backend.Create(CreateRequest{
+				ProjectRoot: project, Session: "collab", Plan: joinPlan, AMQPath: writeTmuxSleepAMQ(t), Root: root,
+				JoinBinding: &created.Binding, JoinDeltas: deltas,
+				JoinProgress: func(delta JoinDelta) error { deltas = append(deltas, delta); return nil },
+			})
+			if err != nil || second.Outcome != OutcomeCreated || len(deltas) != 2 {
+				t.Fatalf("recovered join result=%#v err=%v deltas=%#v", second, err, deltas)
+			}
+			if got := countLiveTmuxWindows(t, backend); got != 3 {
+				t.Fatalf("joined windows=%d, want original plus two unique additions", got)
+			}
+			inspection, err := backend.Inspect(InspectRequest{Binding: second.Binding, Root: root})
+			if err != nil || inspection.Status != InspectPresent {
+				t.Fatalf("joined inspection=%#v err=%v", inspection, err)
+			}
+		})
+	}
+}
+
+func TestTmuxJoinReplacementBeforeEachMutationWritesNoForeignWindow(t *testing.T) {
+	for _, phase := range []string{"new-window", "mark-window", "mark-pane"} {
+		t.Run(phase, func(t *testing.T) {
+			backend, project, root, allPlan := newTmuxPlacementFixture(t, "claude", "codex")
+			initialPlan := Plan{Version: PlanVersion, Agents: []AgentPlan{allPlan.Agents[0]}}
+			created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: initialPlan, AMQPath: writeTmuxSleepAMQ(t), Root: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			name, err := tmuxSessionName(project, "collab")
+			if err != nil {
+				t.Fatal(err)
+			}
+			realRun := backend.run
+			replaced := false
+			listSessionsCalls := 0
+			backend.run = func(ctx context.Context, args ...string) (string, error) {
+				command := strings.Join(args, " ")
+				if strings.Contains(command, "list-sessions") {
+					listSessionsCalls++
+				}
+				targetCall := map[string]int{"new-window": 1, "mark-window": 2, "mark-pane": 3}[phase]
+				matches := strings.Contains(command, "list-sessions") && listSessionsCalls == targetCall
+				if !replaced && matches {
+					replaced = true
+					if _, killErr := realRun(ctx, backend.args("kill-session", "-t", "="+name)...); killErr != nil {
+						return "", killErr
+					}
+					if _, createErr := realRun(ctx, backend.args("new-session", "-d", "-s", name, "-e", tmuxNonceEnvironment+"=foreign", "-P", "-F", "#{pane_id}", "/bin/sleep", "60")...); createErr != nil {
+						return "", createErr
+					}
+				}
+				return realRun(ctx, args...)
+			}
+			joinPlan := Plan{Version: PlanVersion, Agents: []AgentPlan{{
+				Handle: "codex", Argv: []string{"/bin/sleep", "60"}, Cwd: project, AdapterMode: AdapterModeMint, ResumePolicy: ResumeFresh,
+				LaunchNonce: created.Binding.LaunchNonce, ConversationID: "019c5a10-75d8-7eef-8db7-5ee77f70e911",
+			}}}
+			_, err = backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: joinPlan, AMQPath: writeTmuxSleepAMQ(t), Root: root, JoinBinding: &created.Binding})
+			if !replaced {
+				t.Fatalf("replacement hook did not fire for %s", phase)
+			}
+			if got := countLiveTmuxWindows(t, backend); got != 1 {
+				t.Fatalf("replacement session windows=%d after %s (err=%v), want one foreign window", got, phase, err)
+			}
+		})
+	}
+}
+
 func TestTmuxPlacementCurrentWindowCloseLeavesLauncher(t *testing.T) {
 	backend, project, root, plan := newTmuxPlacementFixture(t, "claude", "codex")
 	ctx, cancel := context.WithTimeout(context.Background(), tmuxCommandTimeout)


### PR DESCRIPTION
Bead amq-59d — ChatGPT Pro review A finding 14.

- Managed tmux joins are journaled (join deltas, exact prior binding); session id, server epoch, and nonce are revalidated immediately before each mutation, so a crash after any added window retries without duplicates and a replaced session gets zero foreign writes.
- A `DefinitePreCreateError` now always removes execution tickets (previously ticket cleanup was gated on `journalActive`, which is false for joins, leaving stale tickets); `ClearJournal` remains journal-gated.

Review: execution-gated across two rounds; the corrected regression drives the real bug shape (OnLive Keep join, non-tmux backend, definite failure) and kills both the re-gated-ticket and unconditional-clear mutants.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
