### PR TITLE
fix(launch): persist exact ghostty candidates and refuse changed recovery markers

### DIFF
--- a/internal/launch/backend.go
+++ b/internal/launch/backend.go
@@ -157,6 +157,10 @@ type CreateRequest struct {
 	// skip them. JoinProgress is called after each added window is marked.
 	JoinDeltas   []JoinDelta
 	JoinProgress func(JoinDelta) error
+	// PersistCandidate stores an exact managed binding before Create returns.
+	// Backends use it as an immutable crash marker; nil means the caller does
+	// not own a journaled create transaction.
+	PersistCandidate func(BindingRecord) error
 }
 
 type EmittedCommand struct {

--- a/internal/launch/ghostty.go
+++ b/internal/launch/ghostty.go
@@ -195,6 +195,11 @@ func (b *GhosttyBackend) Create(req CreateRequest) (CreateResult, error) {
 	if err := binding.Validate(); err != nil {
 		return CreateResult{}, err
 	}
+	if req.PersistCandidate != nil {
+		if err := req.PersistCandidate(binding); err != nil {
+			return CreateResult{}, fmt.Errorf("persist ghostty candidate binding: %w", err)
+		}
+	}
 	b.rememberGeneration(nonce, windowID)
 	return CreateResult{Outcome: OutcomeCreated, Profile: binding.Profile, Binding: binding}, nil
 }
@@ -877,21 +882,29 @@ func firstGhosttyTerminalID(binding BindingRecord) string {
 }
 
 func ghosttyJournalTerminals(journal LaunchJournal) ([]string, string, error) {
-	if journal.Binding == nil {
+	binding := journal.Binding
+	if binding == nil {
+		binding = journal.CandidateBinding
+	}
+	if binding == nil {
 		return nil, "", nil
 	}
-	windowID, _, err := parseGhosttyWindowResource(*journal.Binding)
+	windowID, _, err := parseGhosttyWindowResource(*binding)
 	if err != nil {
 		windowID = ""
 	}
-	return ghosttyBoundTerminals(*journal.Binding), windowID, nil
+	return ghosttyBoundTerminals(*binding), windowID, nil
 }
 
 func ghosttyJournalTab(journal LaunchJournal) string {
-	if journal.Binding == nil {
+	binding := journal.Binding
+	if binding == nil {
+		binding = journal.CandidateBinding
+	}
+	if binding == nil {
 		return ""
 	}
-	for _, resource := range journal.Binding.Resources.Resources {
+	for _, resource := range binding.Resources.Resources {
 		id, ok := strings.CutPrefix(resource.OpaqueID, ghosttyTabPrefix)
 		if ok && resource.Agent == "" {
 			if parsed, err := parseGhosttyOpaqueID(id); err == nil {

--- a/internal/launch/ghostty_test.go
+++ b/internal/launch/ghostty_test.go
@@ -269,6 +269,87 @@ func TestGhosttyBackendLifecycleAndRecovery(t *testing.T) {
 	}
 }
 
+func TestGhosttyCreatePersistsExactCandidateBeforeReturn(t *testing.T) {
+	backend, _ := newFakeGhosttyBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70e8b5")
+	var persisted BindingRecord
+	var calls int
+	created, err := backend.Create(CreateRequest{
+		ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root,
+		PersistCandidate: func(candidate BindingRecord) error {
+			calls++
+			persisted = candidate
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || !reflect.DeepEqual(persisted, created.Binding) || countGhosttyAgentResources(persisted) != len(plan.Agents) {
+		t.Fatalf("persisted candidate=%#v calls=%d created=%#v", persisted, calls, created)
+	}
+}
+
+func TestGhosttyManagedCreateCrashHooksNeverSilentlyOrphan(t *testing.T) {
+	for _, stage := range []string{
+		"journal_written", "backend_created", "evidence_written", "journal_created",
+		"conversations_written", "binding_written", "journal_cleared",
+	} {
+		t.Run(stage, func(t *testing.T) {
+			backend, fake := newFakeGhosttyBackend(t)
+			req := reconcileFixture(t, backend)
+			req.HostIdentity = ""
+			crash := errors.New("injected crash")
+			fired := false
+			req.CrashHook = func(got string) error {
+				if got == stage && !fired {
+					fired = true
+					return crash
+				}
+				return nil
+			}
+			if _, err := Reconcile(req); !errors.Is(err, crash) {
+				t.Fatalf("first reconcile error=%v", err)
+			}
+			journal, journalErr := LoadJournal(req.Root)
+			if stage == "journal_written" {
+				if journalErr != nil || journal.CandidateBinding != nil || fake.windowCount() != 0 {
+					t.Fatalf("pre-create crash journal=%#v err=%v windows=%d", journal, journalErr, fake.windowCount())
+				}
+			} else if stage == "backend_created" {
+				if journalErr != nil || journal.CandidateBinding == nil || countGhosttyAgentResources(*journal.CandidateBinding) != 1 {
+					t.Fatalf("backend-created marker journal=%#v err=%v", journal, journalErr)
+				}
+			} else if journalErr != nil && stage != "journal_cleared" {
+				t.Fatalf("journal after %s: %v", stage, journalErr)
+			}
+
+			req.CrashHook = nil
+			result, err := Reconcile(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stage == "journal_written" {
+				if result.AggregateCode != 6 || result.Outcome != OutcomeActionRequired || result.Reason != "ghostty_orphan_unclassified" {
+					t.Fatalf("unclassified orphan result=%#v", result)
+				}
+				return
+			}
+			if stage == "journal_cleared" {
+				if result.AggregateCode != 6 || result.Reason != "binding_present_without_resumable_conversation" {
+					t.Fatalf("journal-cleared recovery result=%#v", result)
+				}
+				return
+			}
+			if result.AggregateCode != 0 {
+				t.Fatalf("recovery result=%#v", result)
+			}
+		})
+	}
+}
+
 func TestGhosttyBackendConformance(t *testing.T) {
 	backend, _ := newFakeGhosttyBackend(t)
 	RunConformance(t, backend)

--- a/internal/launch/journal.go
+++ b/internal/launch/journal.go
@@ -60,6 +60,9 @@ type LaunchJournal struct {
 	JoinDeltas       []JoinDelta            `json:"join_deltas,omitempty"`
 	Placement        PlacementPreview       `json:"placement,omitempty"`
 	CallerContext    map[string]string      `json:"caller_context,omitempty"`
+	// CandidateBinding is an immutable backend marker for an exact resource
+	// discovered before reconciliation can publish the created phase.
+	CandidateBinding *BindingRecord `json:"candidate_binding,omitempty"`
 }
 
 // JoinDelta is the durable proof for one window added to an existing managed
@@ -204,7 +207,18 @@ func (record LaunchJournal) Validate() error {
 		if record.Binding != nil {
 			return fmt.Errorf("intent journal must not contain a binding")
 		}
+		if record.CandidateBinding != nil {
+			if err := record.CandidateBinding.Validate(); err != nil {
+				return fmt.Errorf("intent journal candidate binding: %w", err)
+			}
+			if !journalMatchesBinding(record, *record.CandidateBinding) {
+				return fmt.Errorf("intent journal candidate binding does not match its launch generation")
+			}
+		}
 		return nil
+	}
+	if record.CandidateBinding != nil {
+		return fmt.Errorf("created journal must not retain candidate binding")
 	}
 	if record.Binding == nil {
 		return fmt.Errorf("created journal requires a candidate binding")

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -402,6 +402,23 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 	if _, ok := backend.(*TmuxBackend); !ok {
 		tmuxJoinJournal = false
 	}
+	persistCandidate := func(candidate BindingRecord) error {
+		candidate.CallerContext = cloneCallerContext(request.CallerContext)
+		if err := candidate.Validate(); err != nil {
+			return fmt.Errorf("backend returned invalid candidate binding: %w", err)
+		}
+		if !journalMatchesBinding(journal, candidate) {
+			return fmt.Errorf("backend returned candidate outside the journaled launch generation")
+		}
+		if journal.CandidateBinding != nil {
+			if !reflect.DeepEqual(*journal.CandidateBinding, candidate) {
+				return fmt.Errorf("backend changed its immutable candidate binding")
+			}
+			return nil
+		}
+		journal.CandidateBinding = &candidate
+		return WriteJournal(request.Root, lease, journal)
+	}
 
 	if !recoveredCreate {
 		if !journalActive && detect.Profile.Has(CapCreate) && (joinBinding == nil || tmuxJoinJournal) {
@@ -447,11 +464,16 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 				return nil
 			}
 		}
+		candidateHook := persistCandidate
+		if !journalActive {
+			candidateHook = nil
+		}
 		create, err = backend.Create(CreateRequest{
 			ProjectRoot: request.ProjectRoot, Session: request.Session, Plan: createPlan,
 			AMQPath: amqExecutable, Root: request.Root, Placement: request.Placement,
 			JoinBinding: joinBinding,
 			JoinDeltas:  slices.Clone(journal.JoinDeltas), JoinProgress: joinProgress,
+			PersistCandidate: candidateHook,
 		})
 		if err != nil {
 			var crashErr *joinProgressCrashError
@@ -507,7 +529,7 @@ func Reconcile(request ReconcileRequest) (result ReconcileResult, returnErr erro
 			result.AggregateCode, result.Outcome, result.Reason = 6, OutcomeActionRequired, "managed_create_not_completed"
 			return result, nil
 		}
-		journal.Phase, journal.Binding = JournalCreated, candidate
+		journal.Phase, journal.Binding, journal.CandidateBinding = JournalCreated, candidate, nil
 		journal.Agents, journal.Conversations = plannedAgentResults(result.Agents, planned), plannedConversations(planned)
 		if err := WriteJournal(request.Root, lease, journal); err != nil {
 			return result, err
@@ -678,6 +700,10 @@ func recoverJournal(request ReconcileRequest, journal LaunchJournal, binding Bin
 			result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_identity_mismatch"
 			return journal.Backend, backend, detect, CreateResult{}, false, nil
 		}
+		if journal.CandidateBinding != nil && !reflect.DeepEqual(*journal.CandidateBinding, reclaim.Binding) {
+			result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_candidate_changed"
+			return journal.Backend, backend, detect, CreateResult{}, false, nil
+		}
 		if journal.Phase == JournalCreated && (journal.Binding == nil || !reflect.DeepEqual(*journal.Binding, reclaim.Binding)) {
 			result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_identity_mismatch"
 			return journal.Backend, backend, detect, CreateResult{}, false, nil
@@ -692,7 +718,12 @@ func recoverJournal(request ReconcileRequest, journal LaunchJournal, binding Bin
 	case ReclaimForeign:
 		result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_foreign"
 	case ReclaimUnknown:
-		result.Outcome, result.Reason = OutcomeActionRequired, "launch_recovery_unknown"
+		result.Outcome = OutcomeActionRequired
+		if journal.Backend == LauncherGhostty {
+			result.Reason = "ghostty_orphan_unclassified"
+		} else {
+			result.Reason = "launch_recovery_unknown"
+		}
 	default:
 		return journal.Backend, backend, detect, CreateResult{}, false, fmt.Errorf("backend reclaim returned invalid status %q", reclaim.Status)
 	}

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -422,6 +422,7 @@ type reconcileBackend struct {
 	joinBindingSeen           bool
 	planNonce                 string
 	planHandles               []string
+	persistCandidate          bool
 }
 
 type unsupportedReconcileBackend struct{ reconcileBackend }
@@ -510,6 +511,11 @@ func (b *reconcileBackend) Create(req CreateRequest) (CreateResult, error) {
 			b.captured = &evidence
 		}
 		result.CaptureEvidence = map[string][]CaptureEvidence{req.Plan.Agents[0].Handle: {*b.captured}}
+	}
+	if b.persistCandidate && req.PersistCandidate != nil {
+		if err := req.PersistCandidate(result.Binding); err != nil {
+			return CreateResult{}, err
+		}
 	}
 	return result, nil
 }
@@ -1683,6 +1689,51 @@ func TestReconcileRevalidatesAdoptionImmediatelyBeforeBinding(t *testing.T) {
 	}
 	if _, err := LoadJournal(req.Root); err != nil {
 		t.Fatalf("changed adoption lost journal: %v", err)
+	}
+}
+
+func TestReconcileRecoveryRejectsChangedCandidateBinding(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent, persistCandidate: true}
+	req := reconcileFixture(t, backend)
+	crash := errors.New("injected crash after immutable candidate")
+	req.CrashHook = func(stage string) error {
+		if stage == "backend_created" {
+			return crash
+		}
+		return nil
+	}
+	if _, err := Reconcile(req); !errors.Is(err, crash) {
+		t.Fatalf("initial reconcile error = %v", err)
+	}
+	journ, err := LoadJournal(req.Root)
+	if err != nil || journ.CandidateBinding == nil {
+		t.Fatalf("candidate marker journal=%#v err=%v", journ, err)
+	}
+	journ.CandidateBinding.Resources.Resources[0].OpaqueID = "resource:tampered"
+	lease, err := AcquireLease(req.Root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteJournal(req.Root, lease, journ); err != nil {
+		_ = lease.Release()
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	req.CrashHook = nil
+	result, err := Reconcile(req)
+	if err != nil || result.AggregateCode != 6 || result.Outcome != OutcomeActionRequired || result.Reason != "launch_recovery_candidate_changed" {
+		t.Fatalf("changed candidate recovery result=%#v err=%v", result, err)
+	}
+	if backend.reclaims != 1 {
+		t.Fatalf("reclaim calls=%d, want one immutable-marker comparison", backend.reclaims)
+	}
+	if _, err := LoadBinding(req.Root); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("changed candidate published binding: %v", err)
+	}
+	if _, err := LoadJournal(req.Root); err != nil {
+		t.Fatalf("changed candidate lost journal: %v", err)
 	}
 }
 

--- a/internal/launch/tmux.go
+++ b/internal/launch/tmux.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -38,14 +39,16 @@ var (
 // The socket namespace is stable across tmux server restarts; resource IDs are
 // still live tmux IDs and are never reconstructed from display names.
 type TmuxBackend struct {
-	binary     string
-	socketName string
-	run        func(context.Context, ...string) (string, error)
-	focus      func(context.Context, string) error
-	hostname   func() (string, error)
-	getenv     func(string) string
-	uid        func() string
-	sleep      func(context.Context, time.Duration) error
+	binary          string
+	socketName      string
+	run             func(context.Context, ...string) (string, error)
+	focus           func(context.Context, string) error
+	hostname        func() (string, error)
+	getenv          func(string) string
+	uid             func() string
+	sleep           func(context.Context, time.Duration) error
+	socketOnce      sync.Once
+	socketPathValue string
 }
 
 func NewTmuxBackend(binary string) *TmuxBackend {
@@ -764,6 +767,9 @@ func (b *TmuxBackend) agentCommand(req CreateRequest, agent AgentPlan) string {
 
 func (b *TmuxBackend) args(args ...string) []string {
 	if b.socketName == "" || b.socketName == "default" {
+		if socketPath := b.socketPath(); socketPath != "" {
+			return append([]string{"-S", socketPath}, args...)
+		}
 		return args
 	}
 	return append([]string{"-L", b.socketName}, args...)
@@ -779,6 +785,13 @@ func (b *TmuxBackend) runCommand(ctx context.Context, args ...string) (string, e
 }
 
 func (b *TmuxBackend) socketPath() string {
+	b.socketOnce.Do(func() {
+		b.socketPathValue = b.resolveSocketPath()
+	})
+	return b.socketPathValue
+}
+
+func (b *TmuxBackend) resolveSocketPath() string {
 	if active := strings.TrimSpace(b.getenv("TMUX")); b.socketName == "" && active != "" {
 		if path, _, ok := strings.Cut(active, ","); ok && filepath.IsAbs(path) {
 			return filepath.Clean(path)

--- a/internal/launch/tmux.go
+++ b/internal/launch/tmux.go
@@ -39,16 +39,17 @@ var (
 // The socket namespace is stable across tmux server restarts; resource IDs are
 // still live tmux IDs and are never reconstructed from display names.
 type TmuxBackend struct {
-	binary          string
-	socketName      string
-	run             func(context.Context, ...string) (string, error)
-	focus           func(context.Context, string) error
-	hostname        func() (string, error)
-	getenv          func(string) string
-	uid             func() string
-	sleep           func(context.Context, time.Duration) error
-	socketOnce      sync.Once
-	socketPathValue string
+	binary           string
+	socketName       string
+	run              func(context.Context, ...string) (string, error)
+	focus            func(context.Context, string) error
+	hostname         func() (string, error)
+	getenv           func(string) string
+	uid              func() string
+	sleep            func(context.Context, time.Duration) error
+	socketOnce       sync.Once
+	socketPathValue  string
+	socketFromActive bool
 }
 
 func NewTmuxBackend(binary string) *TmuxBackend {
@@ -767,7 +768,7 @@ func (b *TmuxBackend) agentCommand(req CreateRequest, agent AgentPlan) string {
 
 func (b *TmuxBackend) args(args ...string) []string {
 	if b.socketName == "" || b.socketName == "default" {
-		if socketPath := b.socketPath(); socketPath != "" {
+		if socketPath := b.socketPath(); b.socketFromActive && socketPath != "" {
 			return append([]string{"-S", socketPath}, args...)
 		}
 		return args
@@ -786,15 +787,15 @@ func (b *TmuxBackend) runCommand(ctx context.Context, args ...string) (string, e
 
 func (b *TmuxBackend) socketPath() string {
 	b.socketOnce.Do(func() {
-		b.socketPathValue = b.resolveSocketPath()
+		b.socketPathValue, b.socketFromActive = b.resolveSocketPath()
 	})
 	return b.socketPathValue
 }
 
-func (b *TmuxBackend) resolveSocketPath() string {
+func (b *TmuxBackend) resolveSocketPath() (string, bool) {
 	if active := strings.TrimSpace(b.getenv("TMUX")); b.socketName == "" && active != "" {
 		if path, _, ok := strings.Cut(active, ","); ok && filepath.IsAbs(path) {
-			return filepath.Clean(path)
+			return filepath.Clean(path), true
 		}
 	}
 	base := strings.TrimSpace(b.getenv("TMUX_TMPDIR"))
@@ -808,7 +809,7 @@ func (b *TmuxBackend) resolveSocketPath() string {
 	if name == "" {
 		name = "default"
 	}
-	return filepath.Join(base, "tmux-"+b.uid(), name)
+	return filepath.Join(base, "tmux-"+b.uid(), name), false
 }
 
 func currentUserID() string {

--- a/internal/launch/tmux_test.go
+++ b/internal/launch/tmux_test.go
@@ -122,6 +122,32 @@ func TestTmuxBackendConformance(t *testing.T) {
 	RunConformance(t, backend)
 }
 
+func TestTmuxCloseUsesPinnedSocketAfterEnvironmentCleanup(t *testing.T) {
+	backend := NewTmuxBackend("tmux")
+	backend.socketName = ""
+	active := true
+	socket := filepath.Join(t.TempDir(), "tmux-agent-socket")
+	backend.getenv = func(key string) string {
+		if key == "TMUX" && active {
+			return socket + ",123,0"
+		}
+		return ""
+	}
+	pinned := backend.socketPath()
+	binding := BindingRecord{
+		Version: BindingVersion, Backend: LauncherTMux, HostIdentity: "host",
+		InstanceIdentity: "tmux-socket:" + pinned, Profile: TmuxProfile().Identity(),
+		LaunchNonce: "019c5a10-75d8-7eef-8db7-5ee77f70e7a5",
+		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: []ResourceIdentity{{OpaqueID: "tmux:v1:session:$1:amq-session"}}},
+	}
+	backend.hostname = func() (string, error) { return "host", nil }
+	active = false
+	closed, err := backend.Close(CloseRequest{Binding: binding})
+	if err != nil || closed.Outcome != OutcomeClosed {
+		t.Fatalf("Close after TMUX cleanup = %#v, %v; want closed on the pinned socket", closed, err)
+	}
+}
+
 func TestTmuxReconcileCrashRestartThenRelaunchResumes(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux is not installed")


### PR DESCRIPTION
Bead amq-275 — ChatGPT Pro review A finding 21.

- Ghostty `Create` persists exact candidate window/tab/terminal IDs via an immutable candidate callback before returning; Reconcile stores the `CandidateBinding` in the intent journal and validates the exact candidate on reclaim — a crash at `backend_created` now converges instead of orphaning the live launch.
- A changed/foreign candidate mid-recovery is refused with `launch_recovery_candidate_changed` (full-identity comparison, proven against bypass and backend-only-comparison mutants); unclassifiable Ghostty state returns typed `ghostty_orphan_unclassified`, never a silent orphan.

Review: execution-gated; crash hooks at every journal stage assert convergence or typed refusal.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
