### PR TITLE
fix(launch): keep mint conversations pending until provider start is acknowledged

### DIFF
--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -666,13 +666,23 @@ func finalizeCreatedState(root *fsq.DeliveryRoot, lease *Lease, create CreateRes
 	}
 	for i := range planned {
 		agent := &planned[i]
-		if agent.write && !agent.plan.PreSpawnAcquire {
+		if agent.write && !agent.plan.PreSpawnAcquire && agent.plan.AdapterMode != AdapterModeMint {
 			evidence := executionEvidence
 			agent.record.ExecutionEvidence = &evidence
 		}
 		if agent.plan.AdapterMode == AdapterModeMint && agent.write {
-			agent.record.State = CaptureReady
-			agent.record.Identity = ConversationIdentity{Provider: agent.adapter.Name(), ID: agent.plan.ConversationID}
+			// A mint identity is resumable only after the execution wrapper has
+			// durably acknowledged provider start. Backend creation alone can
+			// succeed while the wrapper is killed before exec.
+			if ticket, ticketErr := LoadExecutionTicket(root, agent.plan.Handle); ticketErr == nil && ticket.State == ExecutionAcknowledged {
+				record, recordErr := LoadConversation(root, agent.plan.Handle)
+				if recordErr != nil {
+					return nil, recordErr
+				}
+				agent.record = record
+			} else if ticketErr != nil && !errors.Is(ticketErr, os.ErrNotExist) {
+				return nil, ticketErr
+			}
 		}
 		if agent.plan.AdapterMode == AdapterModeCapture && agent.write && !agent.plan.PreSpawnAcquire {
 			captureEvidence := create.CaptureEvidence[agent.plan.Handle]

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -1113,7 +1113,7 @@ func TestReconcilePlanOnlyMintWithoutExecutionRemintsPending(t *testing.T) {
 	}
 }
 
-func TestReconcileMintExecutionEvidencePromotesThenResumesExactIdentity(t *testing.T) {
+func TestReconcileMintStaysPendingUntilAcknowledgedThenResumesExactIdentity(t *testing.T) {
 	commands := Commands{}
 	req := reconcileFixture(t, commands)
 	first, err := Reconcile(req)
@@ -1138,8 +1138,28 @@ func TestReconcileMintExecutionEvidencePromotesThenResumesExactIdentity(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if record.State != CaptureReady || record.Identity.ID != readyID || record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != managed.name {
-		t.Fatalf("promoted record=%#v", record)
+	if record.State != CapturePending || record.Identity.ID != "" || record.ExecutionEvidence != nil {
+		t.Fatalf("backend creation made conversation resumable: %#v", record)
+	}
+	ticket, err := LoadExecutionTicket(req.Root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ticket.State != ExecutionPending || ticket.LaunchNonce != readyID {
+		t.Fatalf("execution ticket=%#v, want pending generation %q", ticket, readyID)
+	}
+	if _, err := PrepareExecution(req.Root, "claude", ticket.LaunchNonce, ExecutionEnvelope{
+		Cwd: ticket.Cwd, AMQExecutable: ticket.AMQExecutable,
+		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, err = LoadConversation(req.Root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State != CaptureReady || record.Identity.ID != readyID || record.ExecutionEvidence == nil || record.ExecutionEvidence.Backend != CommandsBackendName {
+		t.Fatalf("acknowledged record=%#v", record)
 	}
 
 	third, err := Reconcile(req)
@@ -1148,6 +1168,70 @@ func TestReconcileMintExecutionEvidencePromotesThenResumesExactIdentity(t *testi
 	}
 	if third.Agents[0].ConversationDisposition != DispositionResumed || third.Plan.Agents[0].ConversationID != readyID {
 		t.Fatalf("third result=%#v, want resumed ID %q", third, readyID)
+	}
+}
+
+func TestReconcileCrashAfterBackendCreatedAcknowledgedThenRecoversReady(t *testing.T) {
+	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
+	req := reconcileFixture(t, backend)
+	crash := errors.New("injected crash after backend creation")
+	req.CrashHook = func(stage string) error {
+		if stage == "backend_created" {
+			return crash
+		}
+		return nil
+	}
+	first, err := Reconcile(req)
+	if !errors.Is(err, crash) {
+		t.Fatalf("first result=%#v err=%v, want backend_created crash", first, err)
+	}
+	ticket, err := LoadExecutionTicket(req.Root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ticket.State != ExecutionPending {
+		t.Fatalf("pre-ack execution ticket=%#v, want pending", ticket)
+	}
+	journal, err := LoadJournal(req.Root)
+	if err != nil || len(journal.Conversations) != 1 {
+		t.Fatalf("crashed journal=%#v err=%v", journal, err)
+	}
+	lease, err := AcquireLease(req.Root, ticket.LaunchNonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.LockHandles("claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteConversation(req.Root, lease, journal.Conversations[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	acknowledged, err := PrepareExecution(req.Root, "claude", ticket.LaunchNonce, ExecutionEnvelope{
+		Cwd: ticket.Cwd, AMQExecutable: ticket.AMQExecutable,
+		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acknowledged.State != ExecutionAcknowledged {
+		t.Fatalf("acknowledged execution ticket=%#v", acknowledged)
+	}
+	record, err := LoadConversation(req.Root, "claude")
+	if err != nil || record.State != CaptureReady || record.Identity.Provider != ClaudeProvider || record.Identity.ID != ticket.ConversationID || record.ExecutionEvidence == nil {
+		t.Fatalf("acknowledged conversation=%#v err=%v, want ready identity/evidence", record, err)
+	}
+
+	req.CrashHook = nil
+	recovered, err := Reconcile(req)
+	if err != nil || recovered.AggregateCode != 0 {
+		t.Fatalf("recovery result=%#v err=%v, want aggregate code 0", recovered, err)
+	}
+	recoveredRecord, err := LoadConversation(req.Root, "claude")
+	if err != nil || recoveredRecord.State != CaptureReady || recoveredRecord.Identity.ID != ticket.ConversationID || recoveredRecord.ExecutionEvidence == nil {
+		t.Fatalf("recovered conversation=%#v err=%v, want ready identity/evidence", recoveredRecord, err)
 	}
 }
 
@@ -1309,7 +1393,14 @@ func TestReconcileManagedCreateCrashMatrixConvergesWithoutDuplicateSpawn(t *test
 
 			req.CrashHook = nil
 			result, err := Reconcile(req)
-			if err != nil || result.AggregateCode != 0 {
+			wantCode := 0
+			if stage == "journal_cleared" {
+				// The binding and pending conversation are durable, but the
+				// provider was never acknowledged. Do not expose a resumable
+				// conversation or silently start a duplicate.
+				wantCode = 6
+			}
+			if err != nil || result.AggregateCode != wantCode {
 				t.Fatalf("recovery result=%#v err=%v", result, err)
 			}
 			if backend.creates != 1 {
@@ -1322,8 +1413,8 @@ func TestReconcileManagedCreateCrashMatrixConvergesWithoutDuplicateSpawn(t *test
 				t.Fatalf("binding after recovery: %v", err)
 			}
 			record, err := LoadConversation(req.Root, "claude")
-			if err != nil || record.State != CaptureReady || record.ExecutionEvidence == nil {
-				t.Fatalf("conversation after recovery=%#v err=%v", record, err)
+			if err != nil || record.State != CapturePending || record.Identity.ID != "" || record.ExecutionEvidence != nil {
+				t.Fatalf("conversation after recovery=%#v err=%v, want pending until execution acknowledgement", record, err)
 			}
 		})
 	}

--- a/internal/launch/tmux_test.go
+++ b/internal/launch/tmux_test.go
@@ -165,6 +165,16 @@ func TestTmuxReconcileCrashRestartThenRelaunchResumes(t *testing.T) {
 	if _, err := LoadJournal(req.Root); !os.IsNotExist(err) {
 		t.Fatalf("journal after recovery: %v", err)
 	}
+	ticket, err := LoadExecutionTicket(req.Root, "claude")
+	if err != nil || ticket.State != ExecutionPending {
+		t.Fatalf("recovered execution ticket = %#v, %v", ticket, err)
+	}
+	if _, err := PrepareExecution(req.Root, "claude", ticket.LaunchNonce, ExecutionEnvelope{
+		Cwd: ticket.Cwd, AMQExecutable: ticket.AMQExecutable,
+		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv,
+	}); err != nil {
+		t.Fatalf("provider start acknowledgement = %v", err)
+	}
 	relaunched, err := Reconcile(req)
 	if err != nil || relaunched.AggregateCode != 0 || relaunched.Outcome != OutcomeAttached || relaunched.Agents[0].ConversationDisposition != DispositionResumed {
 		t.Fatalf("resume Reconcile = %#v, %v", relaunched, err)


### PR DESCRIPTION
Bead amq-1yh — ChatGPT Pro review A finding 22.

- Mint conversations stay `CapturePending` until the execution wrapper durably acknowledges provider start; a kill after ticket acknowledgement but before exec no longer leaves a resumable phantom conversation (it ages back to stale), and a genuinely acknowledged start still promotes to `CaptureReady` on the next Reconcile pass.

Review: execution-gated; promotion-removal mutant killed by the positive acknowledged-then-Ready test; kill-before-exec negative holds.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
