### PR TITLE
fix(launch): require reprepare for schema-1 apply with runnable participants

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -283,6 +283,8 @@ caller has no `subject_schema`; `0.61.1` interprets that omission as schema `1`
 and reports `reprepare_recommended` in the result hints. A new caller must copy
 the returned schema. It must not omit the field to select legacy behavior.
 
+Apply with schema 1 remains compatible for participant-only requests; if any participant is runnable, it returns `action_required` with `reason_code` `reprepare_required` and performs no launch mutation, so the caller must re-Prepare and Apply with schema 2.
+
 `reviewedChoiceFor` is intentionally caller-owned. AMQ does not choose trust,
 stale-conversation, rebind, or degraded-capability decisions for the caller.
 

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -183,6 +183,9 @@ func authorizeApply(ctx context.Context, request ApplyRequest, dependencies Appl
 		}
 		return PrepareResult{}, nil, ApplyResult{}, false, err
 	}
+	if request.Prepare.SubjectSchema == SubjectSchemaV1 && hasRunnableParticipants(request.Prepare.Participants) {
+		return prepared, nil, applyActionResult(prepared, "reprepare_required"), false, nil
+	}
 	if prepared.SubjectDigest != request.SubjectDigest {
 		return prepared, nil, applyActionResult(prepared, "subject_changed"), false, nil
 	}
@@ -197,6 +200,15 @@ func authorizeApply(ctx context.Context, request ApplyRequest, dependencies Appl
 		return prepared, nil, applyActionResult(prepared, reason), false, nil
 	}
 	return prepared, decisions, ApplyResult{}, true, nil
+}
+
+func hasRunnableParticipants(participants []PrepareParticipant) bool {
+	for _, participant := range participants {
+		if participant.Runnable {
+			return true
+		}
+	}
+	return false
 }
 
 func applyPreparedUnderAuthority(ctx context.Context, request ApplyRequest, dependencies ApplyDependencies, state *prepareTargetState, lease *Lease, prepared PrepareResult, decisions map[RequiredActionKind]string) (result ApplyResult, returnErr error) {

--- a/internal/launch/apply_test.go
+++ b/internal/launch/apply_test.go
@@ -336,6 +336,59 @@ func TestApplyMapsUnsupportedCreateToActionRequiredAndSupportedCreateToApplied(t
 	}
 }
 
+func TestApplyV1RunnableParticipantsRequireReprepare(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	backend := &prepareTestBackend{}
+	request := fixture.request
+	request.SubjectSchema = SubjectSchemaV1
+	// Keep the requested runnable handle absent from the pre-existing roster.
+	// If the reprepare guard moves after roster provisioning, Apply must expose
+	// that mutant by creating reviewer and adding it to config.json.
+	request.Participants[0].Handle = "reviewer"
+	configPath := filepath.Join(fixture.sessionRoot, "meta", "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"version":1,"agents":["claude"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dependencies := ApplyDependencies{PrepareDependencies: fixture.dependencies(backend)}
+	prepared, err := Prepare(context.Background(), request, dependencies.PrepareDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeRoster := prepareTreeSnapshot(t, filepath.Join(fixture.sessionRoot, "agents"))
+
+	applyRequest := ApplyRequest{Prepare: request, SubjectDigest: prepared.SubjectDigest}
+	for _, action := range prepared.RequiredActions {
+		applyRequest.Decisions = append(applyRequest.Decisions, ApplyDecision{ActionID: action.ActionID, Choice: "trust_exact_subject"})
+	}
+	result, err := Apply(context.Background(), applyRequest, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != ApplyOutcomeActionRequired || result.ReasonCode != "reprepare_required" {
+		t.Fatalf("v1 runnable Apply result = %#v, want typed reprepare refusal", result)
+	}
+	if result.SubjectDigest != prepared.SubjectDigest || result.PlanDigest != prepared.PlanDigest || result.TrustDigest != prepared.TrustDigest {
+		t.Fatalf("reprepare result lost prepared digests: result=%#v prepared=%#v", result, prepared)
+	}
+	if backend.creates != 0 {
+		t.Fatalf("v1 reprepare refusal created backend resources: %d", backend.creates)
+	}
+	afterConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(afterConfig, beforeConfig) {
+		t.Fatalf("v1 reprepare refusal changed session config: before=%q after=%q", beforeConfig, afterConfig)
+	}
+	if afterRoster := prepareTreeSnapshot(t, filepath.Join(fixture.sessionRoot, "agents")); afterRoster != beforeRoster {
+		t.Fatalf("v1 reprepare refusal changed durable roster: before=%s after=%s", beforeRoster, afterRoster)
+	}
+}
+
 func TestApplyPublishedSessionCannotLoseLeaseTransitionRace(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "project")

--- a/launchapi/apply_test.go
+++ b/launchapi/apply_test.go
@@ -634,6 +634,81 @@ func TestApplyOmittedSubjectSchemaUsesV1AndRecommendsReprepare(t *testing.T) {
 	}
 }
 
+func TestApplyV1RunnableParticipantRequiresReprepare(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	internalRequest, dependencies, err := prepareInputs(fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	internalRequest.SubjectSchema = internallaunch.SubjectSchemaV1
+	legacy, err := internallaunch.Prepare(context.Background(), internalRequest, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyPublic := fromInternalPrepareResult(legacy)
+	decisions := make([]DecisionV1, 0, len(legacyPublic.RequiredActions))
+	for _, action := range legacyPublic.RequiredActions {
+		decisions = append(decisions, DecisionV1{ActionID: action.ActionID, Choice: DecisionTrustExactSubject})
+	}
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1,
+		Prepare:        fixture.request,
+		SubjectSchema:  SubjectSchemaV1,
+		SubjectDigest:  legacy.SubjectDigest,
+		Decisions:      decisions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "action_required" || result.ReasonCode != "reprepare_required" {
+		t.Fatalf("v1 runnable Apply result = %#v, want typed reprepare refusal", result)
+	}
+	if result.SubjectSchema != SubjectSchemaV1 || !slices.Contains(result.Hints, HintReprepareRecommended) {
+		t.Fatalf("v1 reprepare result migration fields = %#v", result)
+	}
+	if result.SubjectDigest != legacy.SubjectDigest || result.PlanDigest != legacy.PlanDigest || result.TrustDigest != legacy.TrustDigest {
+		t.Fatalf("v1 reprepare result lost legacy digests: result=%#v legacy=%#v", result, legacy)
+	}
+	if _, err := os.Stat(fixture.request.Target.SessionRoot); !os.IsNotExist(err) {
+		t.Fatalf("v1 reprepare refusal mutated session: %v", err)
+	}
+}
+
+func TestApplyV1ParticipantOnlyNonRunnableSucceeds(t *testing.T) {
+	fixture := newPublicPrepareFixture(t, false)
+	fixture.request.Intent.Participants = []ParticipantV1{{Handle: "operator", Runnable: false}}
+	internalRequest, dependencies, err := prepareInputs(fixture.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	internalRequest.SubjectSchema = internallaunch.SubjectSchemaV1
+	legacy, err := internallaunch.Prepare(context.Background(), internalRequest, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyPublic := fromInternalPrepareResult(legacy)
+	decisions := make([]DecisionV1, 0, len(legacyPublic.RequiredActions))
+	for _, action := range legacyPublic.RequiredActions {
+		decisions = append(decisions, DecisionV1{ActionID: action.ActionID, Choice: DecisionTrustExactSubject})
+	}
+	result, err := Apply(context.Background(), ApplyRequestV1{
+		RequestVersion: RequestVersionV1,
+		Prepare:        fixture.request,
+		SubjectSchema:  SubjectSchemaV1,
+		SubjectDigest:  legacy.SubjectDigest,
+		Decisions:      decisions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "provisioned_no_runnable" {
+		t.Fatalf("v1 participant-only Apply result = %#v, want provisioned success", result)
+	}
+	if info, err := os.Stat(filepath.Join(fixture.request.Target.SessionRoot, "agents", "operator")); err != nil || !info.IsDir() {
+		t.Fatalf("v1 participant-only mailbox: info=%v err=%v", info, err)
+	}
+}
+
 func TestApplyReportsRosterDriftWithoutDeletingHistory(t *testing.T) {
 	fixture := newPublicPrepareFixture(t, true)
 	if err := fsq.EnsureAgentDirs(fixture.request.Target.SessionRoot, "operator"); err != nil {


### PR DESCRIPTION
Bead amq-qvg — follow-up to ChatGPT Pro review A (subject-schema v1 gap surfaced in the amq-14a review).

- An `ApplyRequestV1` on `subject_schema: 1` with runnable participants is refused with typed `action_required/reprepare_required` before any roster/session write (v1 carries no executable/wrapper identity, so Apply's identity verification would silently be skipped). Participant-only v1 and all v2 behavior unchanged (`provisioned_no_runnable` positive pinned).

Review: execution-gated across three rounds; refusal-dropped, moved-after-mutation (proven against a non-preseeded roster on disk), over-tightened, and wrong-reason-code mutants killed in both internal and public suites.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
