### PR TITLE
fix(fsq): no-replace publication and claim on unix with unique tmp attempts and DLQ byte-compare recovery

### DIFF
--- a/internal/fsq/claim_collision_windows_test.go
+++ b/internal/fsq/claim_collision_windows_test.go
@@ -11,9 +11,10 @@ import (
 
 // TestClaimCollisionPreservesBothCopies proves the loud-collision contract:
 // when inbox/new and inbox/cur both hold the claimed filename, the claim is
-// refused with *ClaimCollisionError and neither copy is modified. Unix
-// deliberately keeps rename-replace semantics (the state is unreachable
-// through AMQ's own flows), so this contract is Windows-only.
+// refused with *ClaimCollisionError and neither copy is modified. Unix uses
+// rename no-replace for the same refuse-to-replace contract; this file stays
+// Windows-only so the native hard-link claim gate in windows-claim-test keeps
+// exercising issue #485.
 func TestClaimCollisionPreservesBothCopies(t *testing.T) {
 	base := t.TempDir()
 	if err := EnsureAgentDirs(base, "alice"); err != nil {

--- a/internal/fsq/claim_rename_other.go
+++ b/internal/fsq/claim_rename_other.go
@@ -2,15 +2,37 @@
 
 package fsq
 
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
 // claimRename is the exclusive-claim primitive behind MoveNewToCur. On POSIX,
 // rename(2) resolves the source by path atomically: exactly one of several
 // concurrent claimers moves new/<name> to cur/<name> and every loser observes
-// ENOENT. A pre-existing cur/<name> is replaced — that state is unreachable
-// through AMQ's own flows (see ClaimCollisionError), and rename's atomicity is
-// the exclusivity guarantee, so no pre-check is added here.
+// ENOENT. The destination is published with no-replace semantics so a
+// pre-existing cur/<name> is never overwritten; that collision is reported as
+// ClaimCollisionError and both copies survive.
 //
 // The Windows implementation must provide the same winner/loser contract
 // without path-atomic rename: see claim_rename_windows.go and issue #485.
 func claimRename(root *DeliveryRoot, newPath, curPath string) error {
-	return root.root.Rename(newPath, curPath)
+	err := root.renameNoReplace(newPath, curPath)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	if _, statErr := root.root.Lstat(newPath); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return os.ErrNotExist
+		}
+		return fmt.Errorf("inspect claim source after collision: %w", statErr)
+	}
+	return &ClaimCollisionError{
+		NewPath: root.displayPath(newPath),
+		CurPath: root.displayPath(curPath),
+	}
 }

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -365,7 +365,10 @@ func deliverToDLQ(root *DeliveryRoot, agent, filename string, data []byte) (stri
 		return "", err
 	}
 
-	tmpPath := filepath.Join(tmpDir, filename)
+	tmpPath, err := uniqueAttemptTmpPath(tmpDir, filename)
+	if err != nil {
+		return "", err
+	}
 	newPath := filepath.Join(newDir, filename)
 
 	if err := root.writeAndSync(tmpPath, data, 0o600); err != nil {
@@ -374,8 +377,8 @@ func deliverToDLQ(root *DeliveryRoot, agent, filename string, data []byte) (stri
 	if err := root.syncDir(tmpDir); err != nil {
 		return "", root.cleanupTemp(tmpPath, err)
 	}
-	if err := root.root.Rename(tmpPath, newPath); err != nil {
-		return "", root.cleanupTemp(tmpPath, err)
+	if err := root.publishTmpNoReplace(tmpPath, newPath, data); err != nil {
+		return "", err
 	}
 	committedPath := root.displayPath(newPath)
 	if err := root.syncDir(newDir); err != nil {
@@ -502,12 +505,19 @@ func retryFromDLQLocked(root *DeliveryRoot, agent, dlqFilename string, force boo
 
 	if envelope.RetryState == RetryStatePending || envelope.RetryState == RetryStateIndeterminate {
 		if originalPresentBox == "" {
-			return fmt.Errorf(
-				"%w: %s retry for %s has no visible inbox destination; do not retry blindly",
-				ErrDLQRetryIndeterminate,
-				envelope.RetryState,
-				envelope.OriginalFile,
-			)
+			recovered, recoverErr := recoverPendingInboxTmp(root, agent, envelope.OriginalFile, originalContent)
+			if recoverErr != nil {
+				return recoverErr
+			}
+			if !recovered {
+				return fmt.Errorf(
+					"%w: %s retry for %s has no visible inbox destination; do not retry blindly",
+					ErrDLQRetryIndeterminate,
+					envelope.RetryState,
+					envelope.OriginalFile,
+				)
+			}
+			originalPresentBox = BoxNew
 		}
 		setRetryState(envelope, RetryStateDelivered)
 		updatedData, err := serializeDLQMessage(*envelope, originalContent)
@@ -744,6 +754,45 @@ func reconcileDLQCurAuthorityLocked(root *DeliveryRoot, agent, filename string) 
 			Err:       durabilityErr,
 		}
 	}
+	return true, nil
+}
+
+func recoverPendingInboxTmp(root *DeliveryRoot, agent, filename string, want []byte) (bool, error) {
+	tmpDir := filepath.Join("agents", agent, "inbox", "tmp")
+	entries, err := root.ReadDir(tmpDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("list retained inbox tmp: %w", err)
+	}
+
+	var match string
+	for _, entry := range entries {
+		if entry.IsDir() || !attemptTmpMatches(filename, entry.Name()) {
+			continue
+		}
+		tmpPath := filepath.Join(tmpDir, entry.Name())
+		got, readErr := root.ReadRegularNoFollow(tmpPath)
+		if readErr != nil {
+			return false, fmt.Errorf("read retained inbox tmp: %w", readErr)
+		}
+		if bytes.Equal(got, want) {
+			match = tmpPath
+			break
+		}
+	}
+	if match == "" {
+		return false, nil
+	}
+
+	newDir := filepath.Join("agents", agent, "inbox", "new")
+	newPath := filepath.Join(newDir, filename)
+	if err := root.publishTmpNoReplace(match, newPath, want); err != nil {
+		return false, fmt.Errorf("complete retained inbox tmp: %w", err)
+	}
+	_ = root.syncDir(newDir)
+	_ = root.syncDir(tmpDir)
 	return true, nil
 }
 

--- a/internal/fsq/dlq_retry_lock_test.go
+++ b/internal/fsq/dlq_retry_lock_test.go
@@ -304,6 +304,67 @@ func TestRetryFromDLQCrashRecoveryRefusesPendingRetryWithoutDestination(t *testi
 	}
 }
 
+func TestRetryFromDLQPendingRetainedTmpCompletesAfterByteCompare(t *testing.T) {
+	rootPath := t.TempDir()
+	if err := EnsureAgentDirs(rootPath, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	const filename = "retained-tmp.md"
+	content := []byte("original body")
+	dlqPath := createDLQMessage(t, rootPath, "alice", filename, content)
+	env, body, err := ReadDLQEnvelopePath(dlqPath)
+	if err != nil {
+		t.Fatalf("read envelope: %v", err)
+	}
+	env.RetryCount = 1
+	setRetryState(env, RetryStatePending)
+	data, err := serializeDLQMessage(*env, body)
+	if err != nil {
+		t.Fatalf("serialize pending envelope: %v", err)
+	}
+	if err := os.WriteFile(dlqPath, data, 0o600); err != nil {
+		t.Fatalf("write pending envelope: %v", err)
+	}
+
+	tmpDir := AgentInboxTmp(rootPath, "alice")
+	mismatch := filepath.Join(tmpDir, "."+filename+".tmp-mismatch")
+	match := filepath.Join(tmpDir, "."+filename+".tmp-retained")
+	if err := os.WriteFile(mismatch, []byte("wrong bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(match, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RetryFromDLQ(openDeliveryRootForTest(t, rootPath), "alice", filepath.Base(dlqPath), false); !errors.Is(err, ErrDLQRetryDelivered) {
+		t.Fatalf("pending retained tmp = %v, want terminal delivered result", err)
+	}
+	got, readErr := os.ReadFile(filepath.Join(AgentInboxNew(rootPath, "alice"), filename))
+	if readErr != nil || string(got) != string(content) {
+		t.Fatalf("recovered new/ = %q, %v", got, readErr)
+	}
+	if _, statErr := os.Stat(match); !os.IsNotExist(statErr) {
+		t.Fatalf("matching tmp still present after completion: %v", statErr)
+	}
+	got, readErr = os.ReadFile(mismatch)
+	if readErr != nil || string(got) != "wrong bytes" {
+		t.Fatalf("mismatched tmp = %q, %v; byte-compare must leave it", got, readErr)
+	}
+	curPath := filepath.Join(AgentDLQCur(rootPath, "alice"), filepath.Base(dlqPath))
+	resumed, _, err := ReadDLQEnvelopePath(curPath)
+	if err != nil {
+		t.Fatalf("read resumed envelope: %v", err)
+	}
+	if resumed.RetryCount != 1 || resumed.RetryPending || !resumed.RetryDelivered {
+		t.Fatalf(
+			"resumed retry = count:%d pending:%t delivered:%t, want count 1 terminal",
+			resumed.RetryCount,
+			resumed.RetryPending,
+			resumed.RetryDelivered,
+		)
+	}
+}
+
 func TestRetryFromDLQPendingFinalizeFailureIsNotTerminal(t *testing.T) {
 	const (
 		agent    = "alice"

--- a/internal/fsq/maildir.go
+++ b/internal/fsq/maildir.go
@@ -1,6 +1,8 @@
 package fsq
 
 import (
+	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -8,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // DeliverToInbox writes a message using Maildir semantics (tmp -> new).
@@ -96,7 +99,10 @@ func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, 
 		if err := root.root.MkdirAll(newDir, 0o700); err != nil {
 			return nil, cleanupStagedTmp(root, stages, err)
 		}
-		tmpPath := filepath.Join(tmpDir, filename)
+		tmpPath, err := uniqueAttemptTmpPath(tmpDir, filename)
+		if err != nil {
+			return nil, cleanupStagedTmp(root, stages, err)
+		}
 		newPath := filepath.Join(newDir, filename)
 		if err := root.writeAndSync(tmpPath, data, 0o600); err != nil {
 			return nil, cleanupStagedTmp(root, stages, err)
@@ -114,7 +120,7 @@ func DeliverToInboxes(root *DeliveryRoot, recipients []string, filename string, 
 	}
 
 	for i, stage := range stages {
-		if err := root.root.Rename(stage.tmpPath, stage.newPath); err != nil {
+		if err := root.publishTmpNoReplace(stage.tmpPath, stage.newPath, data); err != nil {
 			if errors.Is(err, syscall.EXDEV) {
 				err = fmt.Errorf("rename tmp->new for %s: different filesystems: %w", stage.recipient, err)
 			} else {
@@ -172,7 +178,10 @@ func DeliverToExistingInbox(root *DeliveryRoot, agent, filename string, data []b
 		return "", fmt.Errorf("peer inbox new dir does not exist: %s", root.displayPath(newDir))
 	}
 
-	tmpPath := filepath.Join(tmpDir, filename)
+	tmpPath, err := uniqueAttemptTmpPath(tmpDir, filename)
+	if err != nil {
+		return "", err
+	}
 	newPath := filepath.Join(newDir, filename)
 
 	if err := root.writeAndSync(tmpPath, data, 0o600); err != nil {
@@ -181,8 +190,8 @@ func DeliverToExistingInbox(root *DeliveryRoot, agent, filename string, data []b
 	if err := root.syncDir(tmpDir); err != nil {
 		return "", root.cleanupTemp(tmpPath, err)
 	}
-	if err := root.root.Rename(tmpPath, newPath); err != nil {
-		return "", root.cleanupTemp(tmpPath, fmt.Errorf("rename tmp->new for %s: %w", agent, err))
+	if err := root.publishTmpNoReplace(tmpPath, newPath, data); err != nil {
+		return "", fmt.Errorf("rename tmp->new for %s: %w", agent, err)
 	}
 	committedPath := root.displayPath(newPath)
 	if err := root.syncDir(newDir); err != nil {
@@ -215,9 +224,13 @@ func partialDeliveryError(root *DeliveryRoot, committed []stagedDelivery, failed
 		pendingRecipients = append(pendingRecipients, stage.recipient)
 	}
 
-	undelivered := make([]stagedDelivery, 0, 1+len(pending))
-	undelivered = append(undelivered, failed)
-	undelivered = append(undelivered, pending...)
+	// A no-replace collision must keep the failed attempt so both copies survive.
+	undelivered := pending
+	if !errors.Is(primary, os.ErrExist) {
+		undelivered = make([]stagedDelivery, 0, 1+len(pending))
+		undelivered = append(undelivered, failed)
+		undelivered = append(undelivered, pending...)
+	}
 	if cleanupErr := cleanupTmpStages(root, undelivered); cleanupErr != nil {
 		primary = fmt.Errorf("%w (cleanup: %v)", primary, cleanupErr)
 	}
@@ -260,4 +273,51 @@ func cleanupTmpStages(root *DeliveryRoot, stages []stagedDelivery) error {
 		}
 	}
 	return cleanupErr
+}
+
+func uniqueAttemptTmpPath(tmpDir, filename string) (string, error) {
+	name, err := uniqueAttemptTmpName(filename)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(tmpDir, name), nil
+}
+
+func uniqueAttemptTmpName(filename string) (string, error) {
+	var b [6]byte
+	if _, err := readRandom(b[:]); err != nil {
+		return "", fmt.Errorf("generate unique tmp name: %w", err)
+	}
+	return fmt.Sprintf(".%s.tmp-%d-%d-%s", filename, time.Now().UnixNano(), os.Getpid(), hex.EncodeToString(b[:])), nil
+}
+
+func attemptTmpMatches(filename, name string) bool {
+	if name == filename {
+		return true
+	}
+	return strings.HasPrefix(name, "."+filename+".tmp-")
+}
+
+func (r *DeliveryRoot) publishTmpNoReplace(tmpPath, newPath string, data []byte) error {
+	if err := r.renameNoReplace(tmpPath, newPath); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return r.resolvePublishCollision(tmpPath, newPath, data, err)
+		}
+		return r.cleanupTemp(tmpPath, err)
+	}
+	return nil
+}
+
+func (r *DeliveryRoot) resolvePublishCollision(tmpPath, newPath string, data []byte, renameErr error) error {
+	existing, err := r.ReadRegularNoFollow(newPath)
+	if err != nil {
+		return fmt.Errorf("%w (inspect dest: %v)", renameErr, err)
+	}
+	if bytes.Equal(existing, data) {
+		if removeErr := r.root.Remove(tmpPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return fmt.Errorf("remove idempotent tmp after collision: %w", removeErr)
+		}
+		return nil
+	}
+	return renameErr
 }

--- a/internal/fsq/maildir_noreplace_unix_test.go
+++ b/internal/fsq/maildir_noreplace_unix_test.go
@@ -1,0 +1,91 @@
+//go:build unix
+
+package fsq
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUnixNoReplacePublicationAndClaimPreservesCollision(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	const filename = "collide.md"
+	original := []byte("retained new copy")
+	attacker := []byte("colliding attempt")
+	newPath := filepath.Join(AgentInboxNew(base, "alice"), filename)
+	if err := os.WriteFile(newPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := openDeliveryRootForTest(t, base)
+	_, err := DeliverToInbox(root, "alice", filename, attacker)
+	if err == nil {
+		t.Fatal("DeliverToInbox replaced an unread new/ copy")
+	}
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("collision error = %T %v, want EEXIST", err, err)
+	}
+	got, readErr := os.ReadFile(newPath)
+	if readErr != nil || !bytes.Equal(got, original) {
+		t.Fatalf("new/ bytes = %q, %v; collision must not overwrite unread mail", got, readErr)
+	}
+	tmpEntries := regularTmpFiles(t, AgentInboxTmp(base, "alice"))
+	if len(tmpEntries) != 1 {
+		t.Fatalf("tmp leftovers = %#v, want the colliding attempt", tmpEntries)
+	}
+	got, readErr = os.ReadFile(filepath.Join(AgentInboxTmp(base, "alice"), tmpEntries[0]))
+	if readErr != nil || !bytes.Equal(got, attacker) {
+		t.Fatalf("tmp bytes = %q, %v; colliding attempt must survive", got, readErr)
+	}
+
+	_, err = DeliverToInbox(root, "alice", filename, original)
+	if err != nil {
+		t.Fatalf("identical-byte publish = %v, want idempotent success", err)
+	}
+	got, readErr = os.ReadFile(newPath)
+	if readErr != nil || !bytes.Equal(got, original) {
+		t.Fatalf("idempotent new/ bytes = %q, %v", got, readErr)
+	}
+	if leftovers := regularTmpFiles(t, AgentInboxTmp(base, "alice")); len(leftovers) != 1 {
+		t.Fatalf("idempotent retry left tmp = %#v, want only the earlier colliding attempt", leftovers)
+	}
+
+	curPath := filepath.Join(AgentInboxCur(base, "alice"), filename)
+	if err := os.WriteFile(curPath, []byte("retained cur copy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = MoveNewToCur(root, "alice", filename)
+	var collision *ClaimCollisionError
+	if !errors.As(err, &collision) {
+		t.Fatalf("claim error = %T %v, want *ClaimCollisionError", err, err)
+	}
+	got, readErr = os.ReadFile(curPath)
+	if readErr != nil || string(got) != "retained cur copy" {
+		t.Fatalf("cur bytes = %q, %v; claim must not replace retained cur/", got, readErr)
+	}
+	got, readErr = os.ReadFile(newPath)
+	if readErr != nil || !bytes.Equal(got, original) {
+		t.Fatalf("new bytes = %q, %v; claim collision must not consume new/", got, readErr)
+	}
+}
+
+func regularTmpFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", dir, err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	return names
+}

--- a/internal/fsq/maildir_test.go
+++ b/internal/fsq/maildir_test.go
@@ -311,6 +311,40 @@ func TestDeliverToInboxesSyncFailureCountsRenamedStageOnlyAsDelivered(t *testing
 	}
 }
 
+func TestDeliverToInboxRetryAfterTmpFsyncConverges(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureAgentDirs(base, "codex"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	const filename = "retry.md"
+	staleSameName := filepath.Join(AgentInboxTmp(base, "codex"), filename)
+	staleUnique := filepath.Join(AgentInboxTmp(base, "codex"), "."+filename+".tmp-crash")
+	if err := os.WriteFile(staleSameName, []byte("stale same-name attempt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(staleUnique, []byte("stale unique attempt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fresh := []byte("fresh payload")
+	path, err := DeliverToInbox(openDeliveryRootForTest(t, base), "codex", filename, fresh)
+	if err != nil {
+		t.Fatalf("retry after tmp fsync = %v, want converge without EEXIST", err)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil || string(got) != string(fresh) {
+		t.Fatalf("published bytes = %q, %v", got, readErr)
+	}
+	got, readErr = os.ReadFile(staleSameName)
+	if readErr != nil || string(got) != "stale same-name attempt" {
+		t.Fatalf("same-name leftover = %q, %v; retry must not overwrite it", got, readErr)
+	}
+	got, readErr = os.ReadFile(staleUnique)
+	if readErr != nil || string(got) != "stale unique attempt" {
+		t.Fatalf("unique leftover = %q, %v; retry must not overwrite it", got, readErr)
+	}
+}
+
 func openDeliveryRootForTest(t testing.TB, base string) *DeliveryRoot {
 	t.Helper()
 	identity, err := SnapshotDeliveryRoot(base)

--- a/internal/fsq/rename_noreplace.go
+++ b/internal/fsq/rename_noreplace.go
@@ -1,0 +1,29 @@
+//go:build linux || darwin
+
+package fsq
+
+import "path/filepath"
+
+// renameNoReplace publishes oldPath onto newPath without replacing an existing
+// destination. Directories are opened through the pinned os.Root so an ambient
+// alias of Base cannot redirect the rename.
+func (r *DeliveryRoot) renameNoReplace(oldPath, newPath string) error {
+	oldDir, err := r.root.Open(filepath.Dir(oldPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = oldDir.Close() }()
+
+	newDir, err := r.root.Open(filepath.Dir(newPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = newDir.Close() }()
+
+	return renameatNoReplace(
+		int(oldDir.Fd()),
+		filepath.Base(oldPath),
+		int(newDir.Fd()),
+		filepath.Base(newPath),
+	)
+}

--- a/internal/fsq/rename_noreplace_darwin.go
+++ b/internal/fsq/rename_noreplace_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package fsq
+
+import "golang.org/x/sys/unix"
+
+func renameatNoReplace(oldDirFD int, oldName string, newDirFD int, newName string) error {
+	return unix.RenameatxNp(oldDirFD, oldName, newDirFD, newName, unix.RENAME_EXCL)
+}

--- a/internal/fsq/rename_noreplace_linux.go
+++ b/internal/fsq/rename_noreplace_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package fsq
+
+import "golang.org/x/sys/unix"
+
+func renameatNoReplace(oldDirFD int, oldName string, newDirFD int, newName string) error {
+	return unix.Renameat2(oldDirFD, oldName, newDirFD, newName, unix.RENAME_NOREPLACE)
+}

--- a/internal/fsq/rename_noreplace_other.go
+++ b/internal/fsq/rename_noreplace_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+
+package fsq
+
+// renameNoReplace falls back to os.Root.Rename on platforms without a nested
+// no-replace primitive. Windows claims use claimRename instead of this path.
+func (r *DeliveryRoot) renameNoReplace(oldPath, newPath string) error {
+	return r.root.Rename(oldPath, newPath)
+}


### PR DESCRIPTION
Bead amq-lzh — ChatGPT Pro review B findings 2, 3, 4.

- Unix tmp→new publication and new→cur claim are no-replace (`renameat2 RENAME_NOREPLACE` on Linux, `renameatx_np RENAME_EXCL` on Darwin); collisions keep both files and bytes, identical-byte publishes are idempotent, claims raise `ClaimCollisionError` (matching the Windows contract).
- tmp files use unique attempt names, so a crash after fsync no longer wedges retry with EEXIST; pending DLQ retry completes a retained tmp after byte-compare.

Review: execution-gated, 5/5 mutants killed; Windows claim contract untouched. Follow-up bead filed for the Windows publication path (stdlib Root.Rename replaces).

Authored by cursor (session1); pushed by claude to parallelize landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
