### PR TITLE
fix(launch): check raw and resolved paths for amq executable containment

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -78,6 +78,12 @@ argument. Unsupported `stdin` and `file` carriers remain typed refusals when a
 wrapper is present. The `wrapper` feature is advertised, and a strict decode
 accepts the field.
 
+Executable containment refusals use stable typed codes: `provider_project_contained`
+for a provider path presented from the project, `wrapper_project_contained` for
+a wrapper path presented from the project, and `amq_launcher_project_contained` for the
+AMQ launcher path. Both the raw path and its resolved target are checked before
+the executable can be planned or ticketed.
+
 ## Intent
 
 The intent owns the desired participants. Discovery owns the project root,

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -450,8 +450,13 @@ func validateKnownExecutable(executable, projectRoot, provider string) (string, 
 	if err != nil {
 		return "", fmt.Errorf("resolve project root: %w", err)
 	}
+	if raw, rawErr := rawExecutablePath(executable); rawErr != nil {
+		return "", fmt.Errorf("resolve %s executable: %w", provider, rawErr)
+	} else if pathWithin(raw, resolvedProject) {
+		return "", fmt.Errorf("%s: %s executable is inside the project", providerProjectContainedCode, provider)
+	}
 	if pathWithin(resolvedExecutable, resolvedProject) {
-		return "", fmt.Errorf("%s executable resolves inside the project", provider)
+		return "", fmt.Errorf("%s: %s executable is inside the project", providerProjectContainedCode, provider)
 	}
 	info, err := os.Stat(resolvedExecutable)
 	if err != nil {
@@ -475,8 +480,7 @@ func validateExecutableContainment(executable, projectRoot, provider string) err
 	if strings.TrimSpace(executable) == "" || strings.TrimSpace(projectRoot) == "" {
 		return nil
 	}
-	project, err := resolvedPath(projectRoot)
-	if err != nil {
+	if _, err := resolvedPath(projectRoot); err != nil {
 		return fmt.Errorf("resolve project root for %s executable: %w", provider, err)
 	}
 	candidate := executable
@@ -491,17 +495,14 @@ func validateExecutableContainment(executable, projectRoot, provider string) err
 	if err != nil {
 		return fmt.Errorf("make %s executable absolute: %w", provider, err)
 	}
-	if pathWithin(filepath.Clean(requested), project) {
-		return &LaunchPathError{Code: ProviderProjectContainedCode, Path: executable}
-	}
 	resolved, err := resolvedPath(requested)
 	if err != nil {
 		// An unavailable executable is reported by the adapter capability
 		// probe. There is no executable identity to classify as contained.
 		return nil
 	}
-	if pathWithin(resolved, project) {
-		return &LaunchPathError{Code: ProviderProjectContainedCode, Path: executable}
+	if err := rejectProjectContained(projectRoot, requested, resolved, ProviderProjectContainedCode); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -367,6 +368,33 @@ func TestAdapterRejectsProjectExecutableAndProviderMismatch(t *testing.T) {
 	request = planRequest(otherProject, ClaudeProvider)
 	if _, err := NewClaudeAdapter(codexExecutable).PlanFresh(request); err == nil || !strings.Contains(err.Error(), "cannot execute") {
 		t.Fatalf("provider executable error = %v", err)
+	}
+}
+
+func TestAdapterRejectsProjectTrackedProviderSymlinkBeforeSentinelExec(t *testing.T) {
+	project := t.TempDir()
+	outside := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "provider-ran")
+	provider := filepath.Join(outside, ClaudeProvider)
+	if err := os.WriteFile(provider, []byte("#!/bin/sh\nprintf ran > \"$AMQ_SENTINEL\"\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tracked := filepath.Join(project, ClaudeProvider)
+	if err := os.Symlink(provider, tracked); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMQ_SENTINEL", marker)
+	request := planRequest(project, ClaudeProvider)
+	plan, err := NewClaudeAdapter(tracked).PlanFresh(request)
+	if err == nil {
+		_ = exec.Command(plan.Argv[0]).Run()
+		t.Fatal("project-tracked provider symlink was accepted")
+	}
+	if !strings.Contains(err.Error(), providerProjectContainedCode) {
+		t.Fatalf("project-tracked provider error = %v, want %s", err, providerProjectContainedCode)
+	}
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("provider sentinel was executed: %v", statErr)
 	}
 }
 

--- a/internal/launch/containment.go
+++ b/internal/launch/containment.go
@@ -1,0 +1,61 @@
+package launch
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	providerProjectContainedCode = ProviderProjectContainedCode
+	wrapperProjectContainedCode  = WrapperProjectContainedCode
+	amqProjectContainedCode      = AMQProjectContainedCode
+)
+
+// rejectProjectContained refuses both the path presented by the caller and
+// its physical target. Checking only the latter lets a project-tracked
+// symlink point at an external executable while retaining a project-writable
+// argv[0].
+func rejectProjectContained(projectRoot, raw, resolved, code string) error {
+	project, err := resolvedPath(projectRoot)
+	if err != nil {
+		return fmt.Errorf("resolve project root: %w", err)
+	}
+	rawPath, err := rawExecutablePath(raw)
+	if err != nil {
+		return err
+	}
+	if pathWithin(rawPath, project) || (resolved != "" && pathWithin(resolved, project)) {
+		return &LaunchPathError{Code: code, Path: raw}
+	}
+	return nil
+}
+
+func absoluteExecutablePath(path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		lookedUp, err := exec.LookPath(path)
+		if err != nil {
+			return "", err
+		}
+		path = lookedUp
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+// rawExecutablePath resolves symlinks in the parent directories but leaves
+// the executable's final directory entry untouched.
+func rawExecutablePath(path string) (string, error) {
+	abs, err := absoluteExecutablePath(path)
+	if err != nil {
+		return "", err
+	}
+	parent, err := resolvedPath(filepath.Dir(abs))
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(parent, filepath.Base(abs)), nil
+}

--- a/internal/launch/execution.go
+++ b/internal/launch/execution.go
@@ -136,16 +136,22 @@ func NewExecutionTicket(request ExecutionTicketRequest) (ExecutionTicket, error)
 	if err != nil {
 		return ExecutionTicket{}, fmt.Errorf("cwd: %w", err)
 	}
+	if err := rejectProjectContained(project, request.ProviderExecutable, "", providerProjectContainedCode); err != nil {
+		return ExecutionTicket{}, fmt.Errorf("provider executable: %w", err)
+	}
 	provider, providerID, err := canonicalFile(request.ProviderExecutable)
 	if err != nil {
 		return ExecutionTicket{}, fmt.Errorf("provider executable: %w", err)
 	}
 	if pathWithin(provider, project) {
-		return ExecutionTicket{}, fmt.Errorf("provider executable resolves inside the project")
+		return ExecutionTicket{}, fmt.Errorf("%s: provider executable is inside the project", providerProjectContainedCode)
 	}
 	amq, amqID, err := canonicalFile(request.AMQExecutable)
 	if err != nil {
 		return ExecutionTicket{}, fmt.Errorf("amq executable: %w", err)
+	}
+	if err := rejectProjectContained(project, request.AMQExecutable, amq, amqProjectContainedCode); err != nil {
+		return ExecutionTicket{}, fmt.Errorf("AMQ executable: %w", err)
 	}
 	execution := clonePrepareExecutionOptions(request.Execution)
 	if execution != nil {
@@ -1021,6 +1027,9 @@ func ValidateExecutionEnvelope(root *fsq.DeliveryRoot, ticket ExecutionTicket, e
 		return fmt.Errorf("working directory identity changed")
 	}
 	provider, providerID, err := canonicalFile(ticket.ProviderExecutable)
+	if containmentErr := rejectProjectContained(project, ticket.ProviderExecutable, provider, providerProjectContainedCode); containmentErr != nil {
+		return containmentErr
+	}
 	if err != nil || provider != ticket.ProviderExecutable || providerID != ticket.ProviderExecutableIdentity || pathWithin(provider, project) {
 		return fmt.Errorf("provider executable identity changed")
 	}
@@ -1053,7 +1062,13 @@ func ValidateExecutionEnvelope(root *fsq.DeliveryRoot, ticket ExecutionTicket, e
 		}
 	}
 	amq, amqID, err := canonicalFile(envelope.AMQExecutable)
-	if err != nil || amq != ticket.AMQExecutable || amqID != ticket.AMQExecutableIdentity {
+	if err != nil {
+		return fmt.Errorf("amq executable identity changed")
+	}
+	if containmentErr := rejectProjectContained(project, envelope.AMQExecutable, amq, amqProjectContainedCode); containmentErr != nil {
+		return containmentErr
+	}
+	if amq != ticket.AMQExecutable || amqID != ticket.AMQExecutableIdentity {
 		return fmt.Errorf("amq executable identity changed")
 	}
 	if !reflect.DeepEqual(envelope.TargetArgv, ticket.TargetArgv) {

--- a/internal/launch/execution_test.go
+++ b/internal/launch/execution_test.go
@@ -88,6 +88,67 @@ func TestExecutionTicketAllowsEmptyArgOnlyForDeclaredInitialInput(t *testing.T) 
 	}
 }
 
+func TestNewExecutionTicketRejectsProjectContainedExecutableSymlinks(t *testing.T) {
+	fixture := newExecutionFixture(t)
+	providerLink := filepath.Join(fixture.project, "claude")
+	if err := os.Symlink(fixture.provider, providerLink); err != nil {
+		t.Fatal(err)
+	}
+	base := ExecutionTicketRequest{
+		Handle: "claude", LaunchNonce: "12121212-1212-4212-8212-121212121212", Mode: AdapterModeMint,
+		Provider: ClaudeProvider, ConversationID: "12121212-1212-4212-8212-121212121212",
+		ProjectRoot: fixture.project, SessionRoot: fixture.session, Cwd: fixture.cwd,
+		ProviderExecutable: fixture.provider, AMQExecutable: fixture.amq,
+		TargetArgv: []string{fixture.provider},
+	}
+	providerCase := base
+	providerCase.ProviderExecutable = providerLink
+	providerCase.TargetArgv = []string{providerLink}
+	if _, err := NewExecutionTicket(providerCase); err == nil || !strings.Contains(err.Error(), providerProjectContainedCode) {
+		t.Fatalf("provider project containment error = %v", err)
+	}
+
+	wrapperLink := filepath.Join(fixture.project, "wrapper")
+	if err := os.Symlink(fixture.provider, wrapperLink); err != nil {
+		t.Fatal(err)
+	}
+	wrapperCase := base
+	wrapperCase.Wrapper = &Wrapper{Executable: wrapperLink}
+	wrapperCase.TargetArgv = []string{wrapperLink, fixture.provider}
+	if _, err := NewExecutionTicket(wrapperCase); err == nil || !strings.Contains(err.Error(), wrapperProjectContainedCode) {
+		t.Fatalf("wrapper project containment error = %v", err)
+	}
+
+	amqLink := filepath.Join(fixture.project, "amq")
+	if err := os.Symlink(fixture.amq, amqLink); err != nil {
+		t.Fatal(err)
+	}
+	amqCase := base
+	amqCase.AMQExecutable = amqLink
+	if _, err := NewExecutionTicket(amqCase); err == nil || !strings.Contains(err.Error(), amqProjectContainedCode) {
+		t.Fatalf("AMQ project containment error = %v", err)
+	}
+	insideTarget := filepath.Join(fixture.project, "amq-target")
+	if err := os.WriteFile(insideTarget, []byte("amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rawOutsideLink := filepath.Join(t.TempDir(), "amq")
+	if err := os.Symlink(insideTarget, rawOutsideLink); err != nil {
+		t.Fatal(err)
+	}
+	amqCase.AMQExecutable = rawOutsideLink
+	if _, err := NewExecutionTicket(amqCase); err == nil || !strings.Contains(err.Error(), amqProjectContainedCode) {
+		t.Fatalf("raw-outside/resolved-inside AMQ containment error = %v", err)
+	}
+	ticket := mustExecutionTicket(t, fixture, "13131313-1313-4313-8313-131313131313")
+	if err := ValidateExecutionEnvelope(fixture.root, ticket, ExecutionEnvelope{
+		Cwd: fixture.cwd, AMQExecutable: rawOutsideLink, ProviderExecutable: fixture.provider,
+		TargetArgv: ticket.TargetArgv, Environment: nil, Execution: ticket.Execution,
+	}); err == nil || !strings.Contains(err.Error(), amqProjectContainedCode) {
+		t.Fatalf("raw-outside/resolved-inside envelope AMQ containment error = %v", err)
+	}
+}
+
 func TestExecutionTicketWritesRequireNonceAndHandleLock(t *testing.T) {
 	fixture := newExecutionFixture(t)
 	lease, err := AcquireLease(fixture.root, "22222222-2222-4222-8222-222222222222")

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -769,16 +769,8 @@ func resolveLaunchAMQExecutable(value, projectRoot string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve amq executable identity: %w", err)
 	}
-	project, err := resolvedPath(projectRoot)
-	if err != nil {
-		return "", fmt.Errorf("resolve project root for amq executable: %w", err)
-	}
-	requested, err := filepath.Abs(path)
-	if err != nil {
-		return "", fmt.Errorf("resolve amq executable path: %w", err)
-	}
-	if pathWithin(requested, project) || pathWithin(resolved, project) {
-		return "", &LaunchPathError{Code: AMQProjectContainedCode, Path: path}
+	if err := rejectProjectContained(projectRoot, path, resolved, amqProjectContainedCode); err != nil {
+		return "", err
 	}
 	return resolved, nil
 }

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -60,6 +60,34 @@ func TestReconcileRejectsProjectProviderBeforeCapabilities(t *testing.T) {
 	}
 }
 
+func TestReconcileRejectsProjectTrackedProviderSymlinkBeforeSentinelExec(t *testing.T) {
+	req := reconcileFixture(t, Commands{})
+	outside := t.TempDir()
+	provider := filepath.Join(outside, ClaudeProvider)
+	marker := filepath.Join(t.TempDir(), "provider-ran")
+	script := "#!/bin/sh\nprintf ran > \"$AMQ_419_SENTINEL\"\ncase \"$1\" in\n  --version) echo 2.1.233 ;;\n  --help) echo '--session-id <uuid> --resume [value]' ;;\nesac\n"
+	if err := os.WriteFile(provider, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tracked := filepath.Join(req.ProjectRoot, ClaudeProvider)
+	if err := os.Symlink(provider, tracked); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", filepath.Dir(tracked)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AMQ_419_SENTINEL", marker)
+	req.Adapters = map[string]HarnessAdapter{ClaudeProvider: NewClaudeAdapter(tracked)}
+	result, err := Reconcile(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AggregateCode != 6 || len(result.Agents) != 1 || !strings.Contains(result.Agents[0].Reason, ProviderProjectContainedCode) {
+		t.Fatalf("project-tracked provider result = %#v, want typed containment refusal", result)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("project-tracked provider sentinel ran: %v", err)
+	}
+}
+
 func TestReconcileRejectsProjectAMQBeforeCreateQuickly(t *testing.T) {
 	backend := &reconcileBackend{name: "test", inspect: InspectAbsent}
 	req := reconcileFixture(t, backend)

--- a/internal/launch/wrapper.go
+++ b/internal/launch/wrapper.go
@@ -68,28 +68,17 @@ func validateWrapperFile(wrapper *Wrapper) error {
 }
 
 func validateWrapperFileForProject(wrapper *Wrapper, projectRoot string) error {
-	if wrapper == nil {
-		return nil
-	}
 	if err := validateWrapperFile(wrapper); err != nil {
 		return err
 	}
-	project, err := resolvedPath(projectRoot)
-	if err != nil {
-		return fmt.Errorf("resolve project root for wrapper: %w", err)
+	if wrapper == nil {
+		return nil
 	}
-	requested, err := filepath.Abs(wrapper.Executable)
-	if err != nil {
-		return fmt.Errorf("resolve wrapper path: %w", err)
-	}
-	resolved, err := resolvedPath(wrapper.Executable)
+	resolved, err := filepath.EvalSymlinks(wrapper.Executable)
 	if err != nil {
 		return fmt.Errorf("resolve wrapper executable: %w", err)
 	}
-	if pathWithin(requested, project) || pathWithin(resolved, project) {
-		return &LaunchPathError{Code: WrapperProjectContainedCode, Path: wrapper.Executable}
-	}
-	return nil
+	return rejectProjectContained(projectRoot, wrapper.Executable, resolved, wrapperProjectContainedCode)
 }
 
 func cloneWrapper(wrapper *Wrapper) *Wrapper {


### PR DESCRIPTION
Bead amq-u1q — follow-up to ChatGPT Pro review A (containment alignment from the amq-419 review).

- Provider and AMQ-executable containment checks both raw and symlink-resolved paths (a project-tracked symlink to an outside binary, and an outside symlink resolving inside the project, are refused) at ticket creation and at the exec-boundary envelope validation; typed `wrapper_project_contained` / `amq_project_contained` codes documented.
- The Reconcile-level sentinel test fires on ANY invocation (including `--version`/`--help`), so the containment-before-Capabilities ordering is proven end-to-end. The envelope-site containment check is defense-in-depth behind the ticket identity pin.

Review: execution-gated across two rounds; raw-only/resolved-only mutants and ordering mutants killed.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
