### PR TITLE
fix(launch): close only exact acknowledged backend resources and reconstruct full reclaim identity

### DIFF
--- a/internal/launch/cmux.go
+++ b/internal/launch/cmux.go
@@ -180,16 +180,16 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 	createRaw, err := b.runJSON(createCtx, "new-workspace", "--name", name, "--cwd", req.ProjectRoot, "--focus", "false")
 	createCancel()
 	if err != nil {
-		return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("create cmux workspace: %w", err))
+		return CreateResult{}, b.reconcileCreateFailure("", false, fmt.Errorf("create cmux workspace: %w", err))
 	}
 	if err := parseCmuxOKWorkspaceAck(createRaw); err != nil {
-		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
+		return CreateResult{}, b.reconcileCreateFailure("", false, err)
 	}
 	resolveCtx, resolveCancel := b.inspectCallContext()
 	createdWS, err := b.uniqueWorkspaceByName(resolveCtx, name)
 	resolveCancel()
 	if err != nil {
-		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
+		return CreateResult{}, b.reconcileCreateFailure("", false, err)
 	}
 	workspaceID = createdWS.ID
 	windowID := createdWS.WindowID
@@ -197,10 +197,10 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 	firstSurfaces, err := b.workspaceSurfaces(surfaceCtx, workspaceID)
 	surfaceCancel()
 	if err != nil {
-		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
+		return CreateResult{}, b.reconcileCreateFailure(workspaceID, false, err)
 	}
 	if len(firstSurfaces) != 1 {
-		return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("cmux workspace created %d surfaces, want 1", len(firstSurfaces)))
+		return CreateResult{}, b.reconcileCreateFailure(workspaceID, false, fmt.Errorf("cmux workspace created %d surfaces, want 1", len(firstSurfaces)))
 	}
 	surfaceIDs := []string{firstSurfaces[0]}
 	for i, agent := range req.Plan.Agents[1:] {
@@ -211,16 +211,16 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 		splitRaw, splitErr := b.runJSON(splitCtx, "new-split", cmuxSplitDirection(preview.Effective.Layout), "--workspace", workspaceID, "--surface", surfaceIDs[len(surfaceIDs)-1], "--focus", "false")
 		splitCancel()
 		if splitErr != nil {
-			return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("create cmux split for %s: %w", agent.Handle, splitErr))
+			return CreateResult{}, b.reconcileCreateFailure(workspaceID, false, fmt.Errorf("create cmux split for %s: %w", agent.Handle, splitErr))
 		}
 		surfaceID, splitErr := parseCmuxSplitSurface(splitRaw)
 		if splitErr != nil {
-			return CreateResult{}, b.reconcileCreateFailure(name, false, fmt.Errorf("cmux split for %s: %w", agent.Handle, splitErr))
+			return CreateResult{}, b.reconcileCreateFailure(workspaceID, false, fmt.Errorf("cmux split for %s: %w", agent.Handle, splitErr))
 		}
 		surfaceIDs = append(surfaceIDs, surfaceID)
 	}
 	if _, err := b.waitHealthy(context.Background(), workspaceID, len(surfaceIDs)); err != nil {
-		return CreateResult{}, b.reconcileCreateFailure(name, false, err)
+		return CreateResult{}, b.reconcileCreateFailure(workspaceID, false, err)
 	}
 	for i, agent := range req.Plan.Agents {
 		line := b.agentCommand(req, agent)
@@ -228,13 +228,13 @@ func (b *CmuxBackend) Create(req CreateRequest) (CreateResult, error) {
 		_, err := b.run(sendCtx, "send", "--workspace", workspaceID, "--surface", surfaceIDs[i], "--", line)
 		sendCancel()
 		if err != nil {
-			return CreateResult{}, b.reconcileCreateFailure(name, true, fmt.Errorf("send cmux command for %s: %w", agent.Handle, err))
+			return CreateResult{}, b.reconcileCreateFailure(workspaceID, true, fmt.Errorf("send cmux command for %s: %w", agent.Handle, err))
 		}
 		enterCtx, enterCancel := b.inspectCallContext()
 		_, err = b.run(enterCtx, "send-key", "--workspace", workspaceID, "--surface", surfaceIDs[i], "enter")
 		enterCancel()
 		if err != nil {
-			return CreateResult{}, b.reconcileCreateFailure(name, true, fmt.Errorf("submit cmux command for %s: %w", agent.Handle, err))
+			return CreateResult{}, b.reconcileCreateFailure(workspaceID, true, fmt.Errorf("submit cmux command for %s: %w", agent.Handle, err))
 		}
 	}
 	resources := cmuxBindingResources(workspaceID, windowID, nonce, req.Plan, surfaceIDs)
@@ -302,32 +302,27 @@ func (b *CmuxBackend) restoreSelectedWorkspace(previousSelected, skipID string) 
 	_, _ = b.run(ctx, "select-workspace", "--workspace", previousSelected)
 }
 
-func (b *CmuxBackend) reconcileCreateFailure(name string, inputSent bool, cause error) error {
+func (b *CmuxBackend) reconcileCreateFailure(knownWorkspaceID string, inputSent bool, cause error) error {
 	if inputSent {
 		return cause
 	}
+	if knownWorkspaceID == "" {
+		return fmt.Errorf("%w (cmux workspace ownership unknown, never guessed)", cause)
+	}
 	ctx, cancel := b.orphanCallContext()
 	defer cancel()
-	matches, err := b.namedWorkspaces(ctx, name)
+	records, err := b.listWorkspaceRecords(ctx)
 	if err != nil {
 		return fmt.Errorf("%w (orphan workspace reconciliation failed: %v)", cause, err)
 	}
-	switch len(matches) {
-	case 0:
-		return fmt.Errorf("%w (no cmux workspace named %q appeared)", cause, name)
-	case 1:
-		id := strings.ToLower(matches[0].ID)
-		if _, closeErr := b.run(ctx, "close-workspace", "--workspace", id); closeErr != nil {
-			return fmt.Errorf("%w (close orphan %s: %v)", cause, id, closeErr)
-		}
-		return fmt.Errorf("%w (closed orphan cmux workspace %s)", cause, id)
-	default:
-		ids := make([]string, 0, len(matches))
-		for _, workspace := range matches {
-			ids = append(ids, strings.ToLower(workspace.ID))
-		}
-		return fmt.Errorf("%w (ambiguous cmux workspaces named %q: %s; unknown, never guessed)", cause, name, strings.Join(ids, ","))
+	id := strings.ToLower(knownWorkspaceID)
+	if !cmuxContainsID(cmuxWorkspaceIDs(records), id) {
+		return fmt.Errorf("%w (acknowledged cmux workspace %s is absent)", cause, id)
 	}
+	if _, closeErr := b.run(ctx, "close-workspace", "--workspace", id); closeErr != nil {
+		return fmt.Errorf("%w (close orphan %s: %v)", cause, id, closeErr)
+	}
+	return fmt.Errorf("%w (closed orphan cmux workspace %s)", cause, id)
 }
 
 func (b *CmuxBackend) Inspect(req InspectRequest) (InspectResult, error) {
@@ -422,18 +417,31 @@ func (b *CmuxBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
 	if err != nil {
 		return ReclaimResult{}, err
 	}
-	workspaceID, err := b.workspaceByName(ctx, name)
+	matches, err := b.namedWorkspaces(ctx, name)
 	if err != nil {
 		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
 	}
-	if workspaceID == "" {
+	if req.Journal.Phase == JournalIntent {
+		if len(matches) == 0 {
+			return ReclaimResult{Status: ReclaimAbsent, Evidence: "deterministic cmux workspace is absent"}, nil
+		}
+		return ReclaimResult{Status: ReclaimForeign, Evidence: "journal intent must not adopt a same-name cmux workspace"}, nil
+	}
+	if len(matches) == 0 {
 		return ReclaimResult{Status: ReclaimAbsent, Evidence: "deterministic cmux workspace is absent"}, nil
 	}
-	surfaceIDs, err := b.workspaceSurfaces(ctx, workspaceID)
+	if len(matches) != 1 {
+		return ReclaimResult{Status: ReclaimUnknown, Evidence: fmt.Sprintf("ambiguous cmux workspaces named %q", name)}, nil
+	}
+	workspace := matches[0]
+	if workspace.WindowID == "" {
+		return ReclaimResult{Status: ReclaimIncomplete, Evidence: "cmux workspace has no window identity"}, nil
+	}
+	surfaceIDs, err := b.workspaceSurfaces(ctx, workspace.ID)
 	if err != nil {
 		return ReclaimResult{Status: ReclaimUnknown, Evidence: err.Error()}, nil
 	}
-	resources := cmuxBindingResources(workspaceID, "", req.Journal.LaunchNonce, req.Journal.Plan, surfaceIDs)
+	resources := cmuxBindingResources(workspace.ID, workspace.WindowID, req.Journal.LaunchNonce, req.Journal.Plan, surfaceIDs)
 	issues := cmuxInventoryIssues(resources, req.Journal.Plan)
 	if len(issues) != 0 {
 		return ReclaimResult{
@@ -447,6 +455,7 @@ func (b *CmuxBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
 		InstanceIdentity: req.Journal.InstanceIdentity, Profile: req.Journal.Profile,
 		LaunchNonce: req.Journal.LaunchNonce,
 		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: resources},
+		Placement:   req.Journal.Placement,
 	}
 	if !detect.Available || detect.HostIdentity != binding.HostIdentity ||
 		detect.InstanceIdentity != binding.InstanceIdentity || CmuxProfile().Identity() != binding.Profile {
@@ -651,21 +660,6 @@ func (b *CmuxBackend) namedWorkspaces(ctx context.Context, name string) ([]cmuxL
 		return nil, err
 	}
 	return namedCmuxWorkspaces(records, name), nil
-}
-
-func (b *CmuxBackend) workspaceByName(ctx context.Context, name string) (string, error) {
-	matches, err := b.namedWorkspaces(ctx, name)
-	if err != nil {
-		return "", err
-	}
-	switch len(matches) {
-	case 0:
-		return "", nil
-	case 1:
-		return strings.ToLower(matches[0].ID), nil
-	default:
-		return "", fmt.Errorf("ambiguous cmux workspaces named %q", name)
-	}
 }
 
 func (b *CmuxBackend) listWorkspaces(ctx context.Context) ([]string, error) {

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -258,9 +259,10 @@ func TestCmuxBackendLifecycleAndRecovery(t *testing.T) {
 	}
 
 	journal := LaunchJournal{
-		ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
+		Phase: JournalCreated, ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
 		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
 		Backend: LauncherCMux, Profile: detect.Profile.Identity(),
+		Binding: &created.Binding, Placement: created.Binding.Placement,
 	}
 	journal.RootIdentity, err = canonicalIdentity(root.Base())
 	if err != nil {
@@ -270,6 +272,15 @@ func TestCmuxBackendLifecycleAndRecovery(t *testing.T) {
 	reclaimed, err := backend.Reclaim(ReclaimRequest{Context: context.Background(), Journal: journal, Root: root})
 	if err != nil || reclaimed.Status != ReclaimAdoptable || countCmuxAgentResources(BindingRecord{Resources: ResourceIdentitySet{Resources: reclaimed.Resources}}) != 2 {
 		t.Fatalf("Reclaim = %#v, %v", reclaimed, err)
+	}
+	if cmuxWindowID(reclaimed.Binding) == "" || cmuxWindowID(reclaimed.Binding) != cmuxWindowID(created.Binding) {
+		t.Fatalf("Reclaim window = %q, want %q", cmuxWindowID(reclaimed.Binding), cmuxWindowID(created.Binding))
+	}
+	if !reflect.DeepEqual(reclaimed.Binding.Placement, created.Binding.Placement) {
+		t.Fatalf("Reclaim placement = %#v, want %#v", reclaimed.Binding.Placement, created.Binding.Placement)
+	}
+	if !reflect.DeepEqual(reclaimed.Binding.Resources, created.Binding.Resources) {
+		t.Fatalf("Reclaim resources = %#v, want %#v", reclaimed.Binding.Resources, created.Binding.Resources)
 	}
 
 	if _, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: fakeAMQ, Root: root}); err == nil {
@@ -406,6 +417,109 @@ func TestCmuxMissingIDFailsClosed(t *testing.T) {
 	}
 }
 
+func TestCmuxCreateDoesNotCloseInterleavedForeignWorkspace(t *testing.T) {
+	backend, logPath := newFakeCmuxBackend(t)
+	t.Setenv("AMQ_CMUX_FAKE_FAIL", "new-split")
+	foreign := seedCmuxSelectedWorkspace(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eca6"), AMQPath: writeSleepAMQ(t), Root: root})
+	if err == nil {
+		t.Fatal("Create succeeded after split failure")
+	}
+	if !strings.Contains(err.Error(), "closed orphan cmux workspace") {
+		t.Fatalf("Create error = %v, want closed orphan", err)
+	}
+	closed := false
+	for _, argv := range readCmuxArgvLog(t, logPath) {
+		if len(argv) == 0 || argv[0] != "close-workspace" {
+			continue
+		}
+		closed = true
+		joined := strings.Join(argv, " ")
+		if strings.Contains(strings.ToLower(joined), foreign) {
+			t.Fatalf("close-workspace targeted foreign workspace %s: %v", foreign, argv)
+		}
+	}
+	if !closed {
+		t.Fatal("split failure did not close the acknowledged orphan")
+	}
+	if !cmuxFakeContainsWorkspace(t, foreign) {
+		t.Fatal("cleanup closed the interleaved foreign workspace")
+	}
+	if cmuxFakeWorkspaceCount(t) != 1 {
+		t.Fatalf("cleanup closed extra workspaces: %d", cmuxFakeWorkspaceCount(t))
+	}
+}
+
+func TestCmuxJournalIntentDoesNotAdoptSameNameWorkspace(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude", "codex")
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70ead1"
+	plan := cmuxTestPlan(project, nonce)
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	detect := backend.Detect()
+	journal := LaunchJournal{
+		Phase: JournalIntent, ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
+		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
+		Backend: LauncherCMux, Profile: detect.Profile.Identity(),
+		Placement: created.Binding.Placement,
+	}
+	journal.RootIdentity, err = canonicalIdentity(root.Base())
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal.RootPhysical, _ = fsq.StableTreeIdentityInfo(root.FileInfo())
+	reclaimed, err := backend.Reclaim(ReclaimRequest{Context: context.Background(), Journal: journal, Root: root})
+	if err != nil || reclaimed.Status != ReclaimForeign {
+		t.Fatalf("JournalIntent Reclaim = %#v, %v, want foreign", reclaimed, err)
+	}
+	if reclaimed.Binding.LaunchNonce != "" {
+		t.Fatalf("JournalIntent adopted a binding: %#v", reclaimed.Binding)
+	}
+	present, err := backend.Inspect(InspectRequest{Binding: created.Binding, Root: root})
+	if err != nil || present.Status != InspectPresent {
+		t.Fatalf("JournalIntent reclaim mutated live workspace: %#v, %v", present, err)
+	}
+}
+
+func TestCmuxReclaimMissingWindowIDIsIncomplete(t *testing.T) {
+	backend, _ := newFakeCmuxBackend(t)
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	nonce := "019c5a10-75d8-7eef-8db7-5ee77f70ead2"
+	plan := cmuxTestPlan(project, nonce)
+	plan.Agents = plan.Agents[:1]
+	created, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	clearCmuxFakeWindowIDs(t)
+	detect := backend.Detect()
+	journal := LaunchJournal{
+		Phase: JournalCreated, ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
+		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
+		Backend: LauncherCMux, Profile: detect.Profile.Identity(),
+		Binding: &created.Binding, Placement: created.Binding.Placement,
+	}
+	journal.RootIdentity, err = canonicalIdentity(root.Base())
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal.RootPhysical, _ = fsq.StableTreeIdentityInfo(root.FileInfo())
+	reclaimed, err := backend.Reclaim(ReclaimRequest{Context: context.Background(), Journal: journal, Root: root})
+	if err != nil || reclaimed.Status != ReclaimIncomplete {
+		t.Fatalf("Reclaim = %#v, %v, want incomplete without window identity", reclaimed, err)
+	}
+	if reclaimed.Binding.LaunchNonce != "" {
+		t.Fatalf("missing WindowID adopted a binding: %#v", reclaimed.Binding)
+	}
+}
+
 func TestCmuxCrashAfterWorkspaceIsUncertain(t *testing.T) {
 	backend, logPath := newFakeCmuxBackend(t)
 	t.Setenv("AMQ_CMUX_FAKE_FAIL", "new-split")
@@ -427,17 +541,12 @@ func TestCmuxCrashAfterWorkspaceIsUncertain(t *testing.T) {
 	}
 }
 
-func TestCmuxCreateTimeoutClosesSingleOrphanWorkspace(t *testing.T) {
+func TestCmuxCreateTimeoutDoesNotCloseUnackedWorkspace(t *testing.T) {
 	backend, logPath := newFakeCmuxBackend(t)
 	backend.createTimeout = 20 * time.Millisecond
 	inner := backend.run
-	afterCreate := false
 	backend.run = func(ctx context.Context, args ...string) (string, error) {
-		if afterCreate {
-			assertCmuxOrphanCtxFresh(t, ctx, args)
-		}
 		if cmuxArgvHas(args, "new-workspace") {
-			afterCreate = true
 			if _, err := inner(context.Background(), args...); err != nil {
 				return "", err
 			}
@@ -454,14 +563,14 @@ func TestCmuxCreateTimeoutClosesSingleOrphanWorkspace(t *testing.T) {
 	if err == nil {
 		t.Fatal("Create succeeded after create-call timeout")
 	}
-	if !strings.Contains(err.Error(), "closed orphan cmux workspace") {
-		t.Fatalf("Create error = %v, want closed orphan", err)
+	if !strings.Contains(err.Error(), "never guessed") {
+		t.Fatalf("Create error = %v, want unacknowledged unknown", err)
 	}
-	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") < 0 {
-		t.Fatal("timeout did not close the orphan workspace")
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") >= 0 {
+		t.Fatal("timeout closed an unacknowledged workspace")
 	}
-	if cmuxFakeWorkspaceCount(t) != 0 {
-		t.Fatalf("timeout left orphan workspaces: %d", cmuxFakeWorkspaceCount(t))
+	if cmuxFakeWorkspaceCount(t) != 1 {
+		t.Fatalf("timeout closed unacked workspaces: %d", cmuxFakeWorkspaceCount(t))
 	}
 }
 
@@ -485,8 +594,8 @@ func TestCmuxCreateTimeoutDoesNotCloseAmbiguousWorkspaces(t *testing.T) {
 	plan := cmuxTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa2")
 	plan.Agents = plan.Agents[:1]
 	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeSleepAMQ(t), Root: root})
-	if err == nil || !strings.Contains(err.Error(), "ambiguous cmux workspaces") {
-		t.Fatalf("Create error = %v, want ambiguous unknown", err)
+	if err == nil || !strings.Contains(err.Error(), "never guessed") {
+		t.Fatalf("Create error = %v, want unacknowledged unknown", err)
 	}
 	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") >= 0 {
 		t.Fatal("ambiguous timeout guessed a workspace to close")
@@ -496,17 +605,11 @@ func TestCmuxCreateTimeoutDoesNotCloseAmbiguousWorkspaces(t *testing.T) {
 	}
 }
 
-func TestCmuxCreateNonJSONClosesOrphanOnFreshContext(t *testing.T) {
+func TestCmuxCreateNonJSONDoesNotCloseUnackedWorkspace(t *testing.T) {
 	backend, logPath := newFakeCmuxBackend(t)
-	backend.createTimeout = 20 * time.Millisecond
 	inner := backend.run
-	afterCreate := false
 	backend.run = func(ctx context.Context, args ...string) (string, error) {
-		if afterCreate {
-			assertCmuxOrphanCtxFresh(t, ctx, args)
-		}
 		if cmuxArgvHas(args, "new-workspace") {
-			afterCreate = true
 			if _, err := inner(context.Background(), args...); err != nil {
 				return "", err
 			}
@@ -522,14 +625,14 @@ func TestCmuxCreateNonJSONClosesOrphanOnFreshContext(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "parse cmux new-workspace") {
 		t.Fatalf("Create error = %v, want parse failure", err)
 	}
-	if !strings.Contains(err.Error(), "closed orphan cmux workspace") {
-		t.Fatalf("Create error = %v, want closed orphan after parse failure", err)
+	if !strings.Contains(err.Error(), "never guessed") {
+		t.Fatalf("Create error = %v, want unacknowledged unknown", err)
 	}
-	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") < 0 {
-		t.Fatal("parse failure did not close the orphan workspace")
+	if indexOfCmuxCommand(readCmuxArgvLog(t, logPath), "close-workspace") >= 0 {
+		t.Fatal("parse failure closed an unacknowledged workspace")
 	}
-	if cmuxFakeWorkspaceCount(t) != 0 {
-		t.Fatalf("parse failure left orphan workspaces: %d", cmuxFakeWorkspaceCount(t))
+	if cmuxFakeWorkspaceCount(t) != 1 {
+		t.Fatalf("parse failure closed unacked workspaces: %d", cmuxFakeWorkspaceCount(t))
 	}
 }
 
@@ -984,23 +1087,6 @@ func cmuxArgvHas(args []string, command string) bool {
 	return false
 }
 
-func assertCmuxOrphanCtxFresh(t *testing.T, ctx context.Context, args []string) {
-	t.Helper()
-	if !cmuxArgvHas(args, "list-workspaces") && !cmuxArgvHas(args, "close-workspace") {
-		return
-	}
-	if err := ctx.Err(); err != nil {
-		t.Fatalf("%v used cancelled context: %v", args, err)
-	}
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		t.Fatalf("%v missing deadline", args)
-	}
-	if remain := time.Until(deadline); remain < 20*time.Second {
-		t.Fatalf("%v leftover deadline %s, want a fresh create-timeout-scale bound", args, remain)
-	}
-}
-
 func assertCmuxFocusFalse(t *testing.T, calls [][]string) {
 	t.Helper()
 	seen := false
@@ -1177,6 +1263,58 @@ func cmuxFakeWorkspaceCount(t *testing.T) int {
 		t.Fatal(err)
 	}
 	return len(state.Workspaces)
+}
+
+func cmuxFakeContainsWorkspace(t *testing.T, id string) bool {
+	t.Helper()
+	want := strings.ToLower(id)
+	data, err := os.ReadFile(os.Getenv("AMQ_CMUX_FAKE_STATE"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state struct {
+		Workspaces []struct {
+			ID string `json:"id"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	for _, workspace := range state.Workspaces {
+		if strings.ToLower(workspace.ID) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func clearCmuxFakeWindowIDs(t *testing.T) {
+	t.Helper()
+	t.Setenv("AMQ_CMUX_FAKE_WINDOW", "")
+	path := os.Getenv("AMQ_CMUX_FAKE_STATE")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	state["window_id"] = ""
+	workspaces, _ := state["workspaces"].([]any)
+	for i, item := range workspaces {
+		workspace, _ := item.(map[string]any)
+		workspace["window_id"] = ""
+		workspaces[i] = workspace
+	}
+	state["workspaces"] = workspaces
+	out, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func duplicateCmuxFakeNamedWorkspace(t *testing.T) {

--- a/internal/launch/ghostty.go
+++ b/internal/launch/ghostty.go
@@ -235,34 +235,28 @@ func (b *GhosttyBackend) reconcileCreateFailure(before []string, knownWindowID s
 		return fmt.Errorf("%w (orphan window reconciliation failed: %v)", cause, err)
 	}
 	newIDs := ghosttyIDsNotIn(listed, before)
-	if knownWindowID != "" {
-		extras := make([]string, 0, len(newIDs))
-		for _, id := range newIDs {
-			if id != knownWindowID {
-				extras = append(extras, id)
-			}
+	if knownWindowID == "" {
+		if len(newIDs) == 0 {
+			return fmt.Errorf("%w (no new ghostty window appeared)", cause)
 		}
-		if containsString(listed, knownWindowID) {
-			if _, closeErr := b.run(ctx, "close-window", knownWindowID); closeErr != nil {
-				return fmt.Errorf("%w (close orphan %s: %v)", cause, knownWindowID, closeErr)
-			}
-		}
-		if len(extras) > 0 {
-			return fmt.Errorf("%w (closed orphan %s; ambiguous extra windows %s, unknown, never guessed)", cause, knownWindowID, strings.Join(extras, ","))
-		}
-		return fmt.Errorf("%w (closed orphan ghostty window %s)", cause, knownWindowID)
+		return fmt.Errorf("%w (unacknowledged ghostty windows %s; unknown, never guessed)", cause, strings.Join(newIDs, ","))
 	}
-	switch len(newIDs) {
-	case 0:
-		return fmt.Errorf("%w (no new ghostty window appeared)", cause)
-	case 1:
-		if _, closeErr := b.run(ctx, "close-window", newIDs[0]); closeErr != nil {
-			return fmt.Errorf("%w (close orphan %s: %v)", cause, newIDs[0], closeErr)
-		}
-		return fmt.Errorf("%w (closed orphan ghostty window %s)", cause, newIDs[0])
-	default:
-		return fmt.Errorf("%w (ambiguous new ghostty windows %s; unknown, never guessed)", cause, strings.Join(newIDs, ","))
+	if !containsString(listed, knownWindowID) {
+		return fmt.Errorf("%w (acknowledged ghostty window %s is absent)", cause, knownWindowID)
 	}
+	if _, closeErr := b.run(ctx, "close-window", knownWindowID); closeErr != nil {
+		return fmt.Errorf("%w (close orphan %s: %v)", cause, knownWindowID, closeErr)
+	}
+	extras := make([]string, 0, len(newIDs))
+	for _, id := range newIDs {
+		if id != knownWindowID {
+			extras = append(extras, id)
+		}
+	}
+	if len(extras) > 0 {
+		return fmt.Errorf("%w (closed orphan %s; ambiguous extra windows %s, unknown, never guessed)", cause, knownWindowID, strings.Join(extras, ","))
+	}
+	return fmt.Errorf("%w (closed orphan ghostty window %s)", cause, knownWindowID)
 }
 
 func ghosttyIDsNotIn(listed, before []string) []string {
@@ -383,7 +377,7 @@ func (b *GhosttyBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
 		return ReclaimResult{Status: ReclaimUnknown, Evidence: "ghostty window id is absent while terminals remain"}, nil
 	}
 	if windowID == "" {
-		return ReclaimResult{Status: ReclaimUnknown, Evidence: "journal has no ghostty window identity"}, nil
+		return ReclaimResult{Status: ReclaimIncomplete, Evidence: "journal has no ghostty window identity"}, nil
 	}
 	live, err := b.windowTerminals(ctx, windowID)
 	if err != nil {
@@ -412,6 +406,7 @@ func (b *GhosttyBackend) Reclaim(req ReclaimRequest) (ReclaimResult, error) {
 		InstanceIdentity: req.Journal.InstanceIdentity, Profile: req.Journal.Profile,
 		LaunchNonce: req.Journal.LaunchNonce,
 		Resources:   ResourceIdentitySet{Version: ResourceSetVersion, Resources: resources},
+		Placement:   req.Journal.Placement,
 	}
 	if !detect.Available || detect.HostIdentity != binding.HostIdentity ||
 		detect.InstanceIdentity != binding.InstanceIdentity || GhosttyProfile().Identity() != binding.Profile {

--- a/internal/launch/ghostty_test.go
+++ b/internal/launch/ghostty_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -215,10 +216,10 @@ func TestGhosttyBackendLifecycleAndRecovery(t *testing.T) {
 	}
 
 	journal := LaunchJournal{
-		ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
+		Phase: JournalCreated, ProjectIdentity: project, Session: "collab", Plan: plan, LaunchNonce: nonce,
 		HostIdentity: detect.HostIdentity, InstanceIdentity: detect.InstanceIdentity,
 		Backend: LauncherGhostty, Profile: detect.Profile.Identity(),
-		Binding: &created.Binding,
+		Binding: &created.Binding, Placement: created.Binding.Placement,
 	}
 	journal.RootIdentity, err = canonicalIdentity(root.Base())
 	if err != nil {
@@ -228,6 +229,20 @@ func TestGhosttyBackendLifecycleAndRecovery(t *testing.T) {
 	reclaimed, err := backend.Reclaim(ReclaimRequest{Context: context.Background(), Journal: journal, Root: root})
 	if err != nil || reclaimed.Status != ReclaimAdoptable || countGhosttyAgentResources(BindingRecord{Resources: ResourceIdentitySet{Resources: reclaimed.Resources}}) != 2 {
 		t.Fatalf("Reclaim = %#v, %v", reclaimed, err)
+	}
+	createdWindow, _, err := parseGhosttyWindowResource(created.Binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reclaimedWindow, _, err := parseGhosttyWindowResource(reclaimed.Binding)
+	if err != nil || reclaimedWindow != createdWindow {
+		t.Fatalf("Reclaim window = %q, %v, want %q", reclaimedWindow, err, createdWindow)
+	}
+	if !reflect.DeepEqual(reclaimed.Binding.Placement, created.Binding.Placement) {
+		t.Fatalf("Reclaim placement = %#v, want %#v", reclaimed.Binding.Placement, created.Binding.Placement)
+	}
+	if !reflect.DeepEqual(reclaimed.Binding.Resources, created.Binding.Resources) {
+		t.Fatalf("Reclaim resources = %#v, want %#v", reclaimed.Binding.Resources, created.Binding.Resources)
 	}
 
 	intent := journal
@@ -398,7 +413,7 @@ func TestGhosttyCrashAfterWindowIsUncertain(t *testing.T) {
 	}
 }
 
-func TestGhosttyCreateTimeoutClosesSingleOrphanWindow(t *testing.T) {
+func TestGhosttyCreateTimeoutDoesNotCloseUnackedWindow(t *testing.T) {
 	backend, fake := newFakeGhosttyBackend(t)
 	backend.createTimeout = 20 * time.Millisecond
 	inner := fake.run
@@ -420,14 +435,40 @@ func TestGhosttyCreateTimeoutClosesSingleOrphanWindow(t *testing.T) {
 	if err == nil {
 		t.Fatal("Create succeeded after create-call timeout")
 	}
-	if !strings.Contains(err.Error(), "closed orphan ghostty window") {
-		t.Fatalf("Create error = %v, want closed orphan", err)
+	if !strings.Contains(err.Error(), "never guessed") {
+		t.Fatalf("Create error = %v, want unacknowledged unknown", err)
 	}
-	if fake.windowCount() != 0 {
-		t.Fatalf("timeout left orphan windows: %d", fake.windowCount())
+	if fake.windowCount() != 1 {
+		t.Fatalf("timeout closed unacked window: %d", fake.windowCount())
 	}
-	if indexOfGhosttyOp(fake.ops(), "close-window") < 0 {
-		t.Fatal("timeout did not close the orphan window")
+	if indexOfGhosttyOp(fake.ops(), "close-window") >= 0 {
+		t.Fatal("timeout closed an unacknowledged window")
+	}
+}
+
+func TestGhosttyCreateDoesNotCloseForeignInferredWindow(t *testing.T) {
+	backend, fake := newFakeGhosttyBackend(t)
+	inner := fake.run
+	backend.run = func(ctx context.Context, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "new-window" {
+			fake.addWindow("foreign-window", "tab-foreign", "019C5A10-75D8-7EEF-8DB7-0000000000FF")
+			return "", errors.New("injected failure")
+		}
+		return inner(ctx, args...)
+	}
+	project := t.TempDir()
+	root := tmuxTestRoot(t, "claude")
+	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa0")
+	plan.Agents = plan.Agents[:1]
+	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root})
+	if err == nil || !strings.Contains(err.Error(), "never guessed") {
+		t.Fatalf("Create error = %v, want unacknowledged unknown", err)
+	}
+	if fake.windowCount() != 1 {
+		t.Fatalf("inferred cleanup destroyed foreign window: %d", fake.windowCount())
+	}
+	if indexOfGhosttyOp(fake.ops(), "close-window") >= 0 {
+		t.Fatal("close-window invoked for an inferred foreign id")
 	}
 }
 
@@ -451,8 +492,8 @@ func TestGhosttyCreateTimeoutDoesNotCloseAmbiguousWindows(t *testing.T) {
 	plan := ghosttyTestPlan(project, "019c5a10-75d8-7eef-8db7-5ee77f70eaa2")
 	plan.Agents = plan.Agents[:1]
 	_, err := backend.Create(CreateRequest{ProjectRoot: project, Session: "collab", Plan: plan, AMQPath: writeGhosttySleepAMQ(t), Root: root})
-	if err == nil || !strings.Contains(err.Error(), "ambiguous new ghostty windows") {
-		t.Fatalf("Create error = %v, want ambiguous unknown", err)
+	if err == nil || !strings.Contains(err.Error(), "never guessed") {
+		t.Fatalf("Create error = %v, want unacknowledged unknown", err)
 	}
 	if fake.windowCount() != 2 {
 		t.Fatalf("ambiguous timeout closed windows: %d", fake.windowCount())


### PR DESCRIPTION
Bead amq-a4x — ChatGPT Pro review A findings 11, 13, 19.

- cmux/Ghostty create-failure cleanup closes only an exact acknowledged workspace/window ID; foreign or unacknowledged resources are preserved and the journal stays action_required.
- After `journal_created`, Reclaim copies journal Placement and reconstructs every resource ID (incl. cmux WindowID) so recovery converges byte-for-byte; missing WindowID is `ReclaimIncomplete`; `JournalIntent` never adopts a same-name workspace (`ReclaimForeign`).

Review: execution-gated, 6/6 mutants killed; hermetic fake backends.

Authored by cursor (session1); pushed by claude to parallelize landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
