### PR TITLE
fix(wake): report uncertain terminal progress after text lands instead of replaying

### DIFF
--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -1147,11 +1147,16 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 	}
 
 	// External injection: delegate to user-specified command instead of TIOCSTI.
-	// The command receives the notification text as its last argument. This
-	// transport does not participate in inputDelivery, so exit zero is its only
-	// presentation-confirmation evidence; an unchanged confirmed cohort therefore
-	// invokes the injector with a submit-only CR on its next reminder.
+	// The command receives the notification text as its last argument. Exit zero
+	// remains presentation-confirmation evidence. Post-text Enter/submit failure
+	// is encoded in child output as AMQ_INJECT_PROGRESS=uncertain; that path
+	// must not replay the payload.
 	if cfg.injectVia != "" {
+		if cfg.inputDelivery.acceptanceUncertain {
+			return &wakeInputDemotionBlockedError{
+				err: errors.New("a prior terminal write has uncertain acceptance"),
+			}
+		}
 		allowed, guardErr := authorizeTerminalWrite(cfg)
 		if guardErr != nil {
 			return deliverWakeAttentionAfterInputRefusal(
@@ -1164,6 +1169,13 @@ func deliverWakeNotification(cfg *wakeConfig, notice wakeNotification, deferForI
 			return deliverWakeAttentionOnly(cfg, notice.output)
 		}
 		if err := injectVia(cfg, plainText); err != nil {
+			var uncertain *wakeTerminalProgressUncertainError
+			if errors.As(err, &uncertain) {
+				cfg.inputDelivery.acceptanceUncertain = true
+				_ = writeWakeDiagnostic(cfg, "amq wake: warning: %v\n", uncertain)
+				cfg.fallbackWarn = false
+				return &wakeInputDemotionBlockedError{err: uncertain}
+			}
 			if cfg.fallbackWarn {
 				_ = writeWakeDiagnostic(cfg, "amq wake: --inject-via failed: %v\n", err)
 				_ = writeWakeDiagnostic(cfg, "amq wake: falling back to stderr notification\n")
@@ -1949,6 +1961,9 @@ func injectVia(cfg *wakeConfig, text string) error {
 	if runErr != nil {
 		if cfg.debug {
 			_ = writeWakeDiagnostic(cfg, "amq wake [debug]: inject-via failed: %v (%s)\n", runErr, string(out))
+		}
+		if strings.Contains(string(out), "AMQ_INJECT_PROGRESS=uncertain") {
+			return &wakeTerminalProgressUncertainError{err: runErr}
 		}
 		return runErr
 	}

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -534,6 +534,9 @@ func TestInjectViaTimeout(t *testing.T) {
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected timeout error, got %v", err)
 	}
+	if isWakeTerminalProgressUncertain(err) {
+		t.Fatalf("timeout marked uncertain: %v", err)
+	}
 }
 
 func TestInjectViaTimeoutBoundsInheritedDescendantOutput(t *testing.T) {

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -6156,6 +6156,33 @@ exit 1
 	}
 }
 
+func TestDeliverWakeNotificationUncertainSkipsInjectViaWithoutRecoveryShortCircuit(t *testing.T) {
+	logPath := filepath.Join(secureTempDirForTest(t), "inject.log")
+	injector := writeExecutableScriptForTest(t, "must-not-run", fmt.Sprintf(`#!/bin/sh
+printf 'ran\n' >> %q
+exit 0
+`, logPath))
+	cfg := &wakeConfig{
+		me:             "codex",
+		wakeOwner:      &wakeOwner{},
+		injectMode:     wakeInjectModePaste,
+		injectVia:      injector,
+		injectTimeout:  time.Second,
+		inputDelivery:  wakeInputDeliveryState{acceptanceUncertain: true},
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			return len(data), nil
+		},
+	}
+	err := deliverWakeNotification(cfg, peerWakeNotification("pending message"), false)
+	if !isWakeInputDemotionBlocked(err) {
+		t.Fatalf("error = %v, want demotion blocked", err)
+	}
+	if _, statErr := os.Stat(logPath); !os.IsNotExist(statErr) {
+		t.Fatalf("injector ran; log stat = %v", statErr)
+	}
+}
+
 func TestDeliverNewMessageNotificationInjectViaOrdinaryFailureFallsBack(t *testing.T) {
 	current := wakeDoorbellTestFiles(t, "pending.md")
 	logPath := filepath.Join(secureTempDirForTest(t), "inject.log")

--- a/internal/cli/wake_unix_test.go
+++ b/internal/cli/wake_unix_test.go
@@ -707,8 +707,13 @@ func liveWakeOwnerObservationForTest() wakeOwnerObservation {
 
 func writeExecutableForTest(t *testing.T, name string) string {
 	t.Helper()
+	return writeExecutableScriptForTest(t, name, "#!/bin/sh\nexit 0\n")
+}
+
+func writeExecutableScriptForTest(t *testing.T, name, script string) string {
+	t.Helper()
 	path := filepath.Join(secureTempDirForTest(t), name)
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write executable: %v", err)
 	}
 	return path
@@ -6058,6 +6063,138 @@ func TestInjectViaRevalidatesExecutableBeforeExec(t *testing.T) {
 				t.Fatalf("expected %q rejection, got %v", tc.wantText, err)
 			}
 		})
+	}
+}
+
+func TestInjectViaMapsUncertainSentinel(t *testing.T) {
+	injector := writeExecutableScriptForTest(t, "uncertain-injector", `#!/bin/sh
+echo AMQ_INJECT_PROGRESS=uncertain >&2
+exit 1
+`)
+	err := injectVia(&wakeConfig{injectVia: injector, injectTimeout: time.Second}, "payload")
+	if !isWakeTerminalProgressUncertain(err) {
+		t.Fatalf("injectVia error = %v, want uncertain progress", err)
+	}
+}
+
+func TestInjectViaOrdinaryFailureIsNotUncertain(t *testing.T) {
+	injector := writeExecutableScriptForTest(t, "ordinary-fail-injector", `#!/bin/sh
+echo failed >&2
+exit 1
+`)
+	err := injectVia(&wakeConfig{injectVia: injector, injectTimeout: time.Second}, "payload")
+	if err == nil {
+		t.Fatal("injectVia error = nil, want failure")
+	}
+	if isWakeTerminalProgressUncertain(err) {
+		t.Fatalf("ordinary inject-via failure marked uncertain: %v", err)
+	}
+}
+
+func TestDeliverNewMessageNotificationInjectViaUncertainDoesNotReplay(t *testing.T) {
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	logPath := filepath.Join(secureTempDirForTest(t), "inject.log")
+	injector := writeExecutableScriptForTest(t, "uncertain-injector", fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$1" >> %q
+echo AMQ_INJECT_PROGRESS=uncertain >&2
+exit 1
+`, logPath))
+	attentionWrites := 0
+	cfg := &wakeConfig{
+		me:             "codex",
+		wakeOwner:      &wakeOwner{},
+		injectMode:     wakeInjectModePaste,
+		injectVia:      injector,
+		injectTimeout:  time.Second,
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
+	}
+
+	err := deliverNewMessageNotification(
+		cfg,
+		peerWakeNotification("pending message"),
+		false,
+		current,
+	)
+	if err != nil {
+		t.Fatalf("delivery error = %v, want live recovery transition", err)
+	}
+	if !cfg.inputDelivery.acceptanceUncertain {
+		t.Fatalf("uncertain acceptance was not retained: %#v", cfg.inputDelivery)
+	}
+	if !cfg.inputRecoveryRequired {
+		t.Fatal("uncertain input did not enter recovery-required mode")
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("uncertain input emitted %d recovery alerts, want one", attentionWrites)
+	}
+	first, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("read inject log: %v", readErr)
+	}
+	if got, want := string(first), coopWakeDoorbell+"\n"; got != want {
+		t.Fatalf("inject log = %q, want payload once (%q)", got, want)
+	}
+
+	if err := deliverNewMessageNotification(
+		cfg,
+		peerWakeNotification("pending message"),
+		false,
+		current,
+	); err != nil {
+		t.Fatalf("second delivery error = %v", err)
+	}
+	second, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("read inject log after second delivery: %v", readErr)
+	}
+	if string(second) != string(first) {
+		t.Fatalf("second delivery replayed payload: first=%q second=%q", first, second)
+	}
+}
+
+func TestDeliverNewMessageNotificationInjectViaOrdinaryFailureFallsBack(t *testing.T) {
+	current := wakeDoorbellTestFiles(t, "pending.md")
+	logPath := filepath.Join(secureTempDirForTest(t), "inject.log")
+	injector := writeExecutableScriptForTest(t, "ordinary-fail-injector", fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$1" >> %q
+echo failed >&2
+exit 1
+`, logPath))
+	attentionWrites := 0
+	cfg := &wakeConfig{
+		me:             "codex",
+		wakeOwner:      &wakeOwner{},
+		injectMode:     wakeInjectModePaste,
+		injectVia:      injector,
+		injectTimeout:  time.Second,
+		attentionIsTTY: func() bool { return false },
+		attentionWrite: func(data []byte) (int, error) {
+			attentionWrites++
+			return len(data), nil
+		},
+	}
+
+	err := deliverNewMessageNotification(
+		cfg,
+		peerWakeNotification("pending message"),
+		false,
+		current,
+	)
+	if err != nil {
+		t.Fatalf("ordinary inject-via failure error = %v, want attention fallback", err)
+	}
+	if cfg.inputDelivery.acceptanceUncertain {
+		t.Fatalf("ordinary inject-via failure marked uncertain: %#v", cfg.inputDelivery)
+	}
+	if cfg.inputRecoveryRequired {
+		t.Fatal("ordinary inject-via failure entered recovery")
+	}
+	if attentionWrites != 1 {
+		t.Fatalf("ordinary inject-via failure emitted %d attention writes, want one", attentionWrites)
 	}
 }
 

--- a/internal/keepalive/adapter/adapter.go
+++ b/internal/keepalive/adapter/adapter.go
@@ -12,6 +12,10 @@ var (
 	// ownership. Supervisors must retry without mutating durable registry
 	// bookkeeping because the uncertainty may be transient.
 	ErrTargetDegraded = errors.New("adapter target ownership degraded")
+	// ErrInjectUncertain means text already landed and Enter/submit failed.
+	// App.Run prints this to stderr so inject-via can map it without a typed
+	// error crossing the child process boundary. Never replay the payload.
+	ErrInjectUncertain = errors.New("AMQ_INJECT_PROGRESS=uncertain")
 )
 
 type Adapter interface {

--- a/internal/keepalive/adapter/cmux.go
+++ b/internal/keepalive/adapter/cmux.go
@@ -629,7 +629,7 @@ func (c Cmux) Inject(ctx context.Context, target string, payload string) error {
 	}
 
 	if err := c.sleep(ctx, c.settleDelay()); err != nil {
-		return fmt.Errorf("wait before submitting cmux target %q: %w", target, err)
+		return fmt.Errorf("%w: wait before submitting cmux target %q: %v", ErrInjectUncertain, target, err)
 	}
 
 	keyParams, err := json.Marshal(map[string]string{
@@ -640,7 +640,7 @@ func (c Cmux) Inject(ctx context.Context, target string, payload string) error {
 		return fmt.Errorf("encode cmux key parameters: %w", err)
 	}
 	if out, err := c.runner().Run(ctx, path, "rpc", "surface.send_key", string(keyParams)); err != nil {
-		return fmt.Errorf("submit cmux target %q: %w: %s", target, err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("%w: submit cmux target %q: %v: %s", ErrInjectUncertain, target, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/internal/keepalive/adapter/cmux_test.go
+++ b/internal/keepalive/adapter/cmux_test.go
@@ -630,8 +630,41 @@ func TestCmuxInjectDoesNotSendEnterWhenTextFails(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "surface unavailable") {
 		t.Fatalf("Inject() error = %v, want command output", err)
 	}
+	if errors.Is(err, ErrInjectUncertain) {
+		t.Fatalf("text failure marked uncertain: %v", err)
+	}
 	if len(runner.calls) != 2 {
 		t.Fatalf("calls = %d, want inventory and failed text call only", len(runner.calls))
+	}
+}
+
+func TestCmuxInjectEnterFailureAfterTextIsUncertain(t *testing.T) {
+	skipCmuxNonDarwin(t)
+	runner := &fakeCommandRunner{results: []fakeCommandResult{
+		{output: cmuxTreeWithSurfaces(testCmuxSurfaceID)},
+		{},
+		{output: []byte("enter failed"), err: errors.New("exit status 1")},
+	}}
+	adapter := Cmux{
+		Runner: runner,
+		Path:   "/fake/cmux",
+		Sleep:  func(context.Context, time.Duration) error { return nil },
+	}
+	err := adapter.Inject(context.Background(), "cmux:surface:"+testCmuxSurfaceID, "payload")
+	if !errors.Is(err, ErrInjectUncertain) {
+		t.Fatalf("Inject() error = %v, want ErrInjectUncertain", err)
+	}
+	if !strings.Contains(err.Error(), "enter failed") {
+		t.Fatalf("Inject() error = %v, want command output", err)
+	}
+	if len(runner.calls) != 3 {
+		t.Fatalf("calls = %d, want inventory, text, and failed enter", len(runner.calls))
+	}
+	if got := runner.calls[1].args[1]; got != "surface.send_text" {
+		t.Fatalf("text call = %#v, want surface.send_text", runner.calls[1])
+	}
+	if got := runner.calls[2].args[1]; got != "surface.send_key" {
+		t.Fatalf("key call = %#v, want surface.send_key", runner.calls[2])
 	}
 }
 

--- a/internal/keepalive/adapter/ghostty.go
+++ b/internal/keepalive/adapter/ghostty.go
@@ -79,9 +79,13 @@ func (g Ghostty) Inject(ctx context.Context, target string, payload string) erro
 		return err
 	}
 	payload = sanitizePayloadForSubmit(payload)
-	out, err := g.runner().Run(ctx, "osascript", "-e", ghosttyInjectScript, id, payload)
+	out, err := g.runner().Run(ctx, "osascript", "-e", ghosttyInjectTextScript, id, payload)
 	if err != nil {
-		return fmt.Errorf("inject into Ghostty target %q: %w: %s", target, err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("inject text into Ghostty target %q: %w: %s", target, err, strings.TrimSpace(string(out)))
+	}
+	out, err = g.runner().Run(ctx, "osascript", "-e", ghosttyInjectSubmitScript, id)
+	if err != nil {
+		return fmt.Errorf("%w: submit Ghostty target %q: %v: %s", ErrInjectUncertain, target, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }
@@ -140,7 +144,7 @@ on run argv
 end run
 `
 
-const ghosttyInjectScript = `
+const ghosttyInjectTextScript = `
 on run argv
 	set targetID to item 1 of argv
 	set payload to item 2 of argv
@@ -151,6 +155,19 @@ on run argv
 		if matchCount is greater than 1 then error "ambiguous Ghostty terminal id: " & targetID
 		set targetTerminal to item 1 of matches
 		input text payload to targetTerminal
+	end tell
+end run
+`
+
+const ghosttyInjectSubmitScript = `
+on run argv
+	set targetID to item 1 of argv
+	tell application "Ghostty"
+		set matches to terminals whose id is targetID
+		set matchCount to count of matches
+		if matchCount is 0 then error "no Ghostty terminal with id: " & targetID
+		if matchCount is greater than 1 then error "ambiguous Ghostty terminal id: " & targetID
+		set targetTerminal to item 1 of matches
 		send key "enter" to targetTerminal
 	end tell
 end run

--- a/internal/keepalive/adapter/ghostty_test.go
+++ b/internal/keepalive/adapter/ghostty_test.go
@@ -119,22 +119,37 @@ func TestGhosttyInjectPassesTerminalIDAndPayloadAsArguments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Inject() error = %v", err)
 	}
-	call := runner.calls[0]
-	if got := call.args[len(call.args)-2]; got != "TERMINAL-1" {
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %d, want text then enter", len(runner.calls))
+	}
+	textCall := runner.calls[0]
+	if got := textCall.args[len(textCall.args)-2]; got != "TERMINAL-1" {
 		t.Fatalf("target arg = %q, want terminal id", got)
 	}
-	if got := call.args[len(call.args)-1]; got != payload {
+	if got := textCall.args[len(textCall.args)-1]; got != payload {
 		t.Fatalf("payload arg = %q, want payload", got)
 	}
-	if !strings.Contains(call.args[1], "input text payload to targetTerminal") {
-		t.Fatalf("script does not use native Ghostty input: %q", call.args[1])
+	if !strings.Contains(textCall.args[1], "input text payload to targetTerminal") {
+		t.Fatalf("text script does not use native Ghostty input: %q", textCall.args[1])
 	}
-	if !strings.Contains(call.args[1], `send key "enter" to targetTerminal`) {
-		t.Fatalf("script does not send enter to target terminal: %q", call.args[1])
+	if strings.Contains(textCall.args[1], `send key "enter"`) {
+		t.Fatalf("text script still sends enter: %q", textCall.args[1])
 	}
-	for _, disallowed := range []string{"System Events", "the clipboard", "keystroke", "AXRaise", "activate"} {
-		if strings.Contains(call.args[1], disallowed) {
-			t.Fatalf("script still uses %q: %q", disallowed, call.args[1])
+	submitCall := runner.calls[1]
+	if got := submitCall.args[len(submitCall.args)-1]; got != "TERMINAL-1" {
+		t.Fatalf("submit target arg = %q, want terminal id", got)
+	}
+	if !strings.Contains(submitCall.args[1], `send key "enter" to targetTerminal`) {
+		t.Fatalf("submit script does not send enter: %q", submitCall.args[1])
+	}
+	if strings.Contains(submitCall.args[1], "input text") {
+		t.Fatalf("submit script still sends text: %q", submitCall.args[1])
+	}
+	for _, call := range runner.calls {
+		for _, disallowed := range []string{"System Events", "the clipboard", "keystroke", "AXRaise", "activate"} {
+			if strings.Contains(call.args[1], disallowed) {
+				t.Fatalf("script still uses %q: %q", disallowed, call.args[1])
+			}
 		}
 	}
 }
@@ -172,16 +187,24 @@ func TestGhosttyInjectTrimsTrailingLineBreaksBeforeEnter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Inject() error = %v", err)
 	}
-	call := runner.calls[0]
-	if got, want := call.args[len(call.args)-1], "AMQ [team-upgrader_v3]: message from claude\nline two"; got != want {
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %d, want text then enter", len(runner.calls))
+	}
+	textCall := runner.calls[0]
+	if got, want := textCall.args[len(textCall.args)-1], "AMQ [team-upgrader_v3]: message from claude\nline two"; got != want {
 		t.Fatalf("payload arg = %q, want %q", got, want)
+	}
+	submitCall := runner.calls[1]
+	if !strings.Contains(submitCall.args[1], `send key "enter" to targetTerminal`) {
+		t.Fatalf("second call is not enter: %q", submitCall.args[1])
 	}
 }
 
 func TestGhosttyScriptsFailClosedOnTerminalIDs(t *testing.T) {
 	for name, script := range map[string]string{
 		"probe":  ghosttyProbeScript,
-		"inject": ghosttyInjectScript,
+		"text":   ghosttyInjectTextScript,
+		"submit": ghosttyInjectSubmitScript,
 	} {
 		if !strings.Contains(script, "matchCount") {
 			t.Fatalf("%s script does not count matching terminals", name)
@@ -192,6 +215,47 @@ func TestGhosttyScriptsFailClosedOnTerminalIDs(t *testing.T) {
 		if !strings.Contains(script, "ambiguous Ghostty terminal id") {
 			t.Fatalf("%s script does not fail on duplicate target", name)
 		}
+	}
+}
+
+func TestGhosttyInjectEnterFailureAfterTextIsUncertain(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{results: []fakeCommandResult{
+		{},
+		{output: []byte("enter failed"), err: errors.New("exit status 1")},
+	}}
+	err := (Ghostty{Runner: runner}).Inject(context.Background(), "ghostty:terminal:terminal-1", "payload")
+	if !errors.Is(err, ErrInjectUncertain) {
+		t.Fatalf("Inject() error = %v, want ErrInjectUncertain", err)
+	}
+	if !strings.Contains(err.Error(), "enter failed") {
+		t.Fatalf("Inject() error = %v, want command output", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %d, want text then failed enter", len(runner.calls))
+	}
+	if !strings.Contains(runner.calls[0].args[1], "input text payload to targetTerminal") {
+		t.Fatalf("first call is not text inject: %#v", runner.calls[0])
+	}
+	if !strings.Contains(runner.calls[1].args[1], `send key "enter" to targetTerminal`) {
+		t.Fatalf("second call is not enter: %#v", runner.calls[1])
+	}
+}
+
+func TestGhosttyInjectDoesNotSendEnterWhenTextFails(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{results: []fakeCommandResult{
+		{output: []byte("text failed"), err: errors.New("exit status 1")},
+	}}
+	err := (Ghostty{Runner: runner}).Inject(context.Background(), "ghostty:terminal:terminal-1", "payload")
+	if err == nil || !strings.Contains(err.Error(), "text failed") {
+		t.Fatalf("Inject() error = %v, want command output", err)
+	}
+	if errors.Is(err, ErrInjectUncertain) {
+		t.Fatalf("text failure marked uncertain: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls = %d, want failed text call only", len(runner.calls))
 	}
 }
 


### PR DESCRIPTION
Bead amq-rda — ChatGPT Pro review B finding 32.

- cmux/Ghostty wake injection returns a typed accepted/uncertain result once text has landed; a failed Enter or cancellation maps to `wakeTerminalProgressUncertainError` so the doorbell never replays the full payload (no duplicated composer text); a failed `send_text` itself stays retryable.

Review: execution-gated, mutants killed (ordinary-error revert, uncertain-but-replays, ghostty path independently); plus an added acceptanceUncertain unit test.

Authored by cursor (session1); pushed by claude to parallelize landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
