### PR TITLE
test(keepalive): make wake-cancel and cmux probe tests contention-proof

### DIFF
--- a/internal/keepalive/amq/runner_test.go
+++ b/internal/keepalive/amq/runner_test.go
@@ -562,16 +562,17 @@ while [ ! -f "$AMQ_KEEPALIVE_RELEASE" ]; do sleep 0.01; done
 : > "$AMQ_KEEPALIVE_EXITED"
 `)
 	registerDetachedWakeCleanup(t, pidFile, allowReady, release)
+	budget := testWaitBudget(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	done := make(chan error, 1)
 	go func() {
 		done <- NewCLI(fakeAMQ).StartWake(ctx, StartWakeRequest{
 			Root: "/tmp/amq-root", Me: "codex", InjectVia: "/tmp/amq-keepalive",
-			Adapter: "cmux", Target: "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3", Timeout: 5 * time.Second,
+			Adapter: "cmux", Target: "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3", Timeout: budget,
 		})
 	}()
-	waitForFile(t, started, 2*time.Second)
+	waitForFile(t, started, testWaitBudget(t))
 	cancel()
 	err := <-done
 	if !errors.Is(err, ErrWakeReadinessUncertain) || !errors.Is(err, context.Canceled) {
@@ -580,11 +581,11 @@ while [ ! -f "$AMQ_KEEPALIVE_RELEASE" ]; do sleep 0.01; done
 	if err := os.WriteFile(allowReady, nil, 0o600); err != nil {
 		t.Fatalf("allow late readiness: %v", err)
 	}
-	waitForFile(t, lateReady, 2*time.Second)
+	waitForFile(t, lateReady, testWaitBudget(t))
 	if err := os.WriteFile(release, nil, 0o600); err != nil {
 		t.Fatalf("release child: %v", err)
 	}
-	waitForFile(t, exited, 2*time.Second)
+	waitForFile(t, exited, testWaitBudget(t))
 }
 
 func TestStartWakeTimesOutWhenReadyFileNeverAppears(t *testing.T) {
@@ -1417,6 +1418,23 @@ func writeExecutable(t *testing.T, path string, body string) string {
 		t.Fatalf("write executable: %v", err)
 	}
 	return path
+}
+
+func testWaitBudget(t *testing.T) time.Duration {
+	t.Helper()
+	const reserve = 2 * time.Second
+	deadline, ok := t.Deadline()
+	if !ok {
+		return 30 * time.Second
+	}
+	remain := time.Until(deadline)
+	if remain > reserve {
+		return remain - reserve
+	}
+	if remain > 0 {
+		return remain
+	}
+	return time.Millisecond
 }
 
 func waitForFile(t *testing.T, path string, timeout time.Duration) {

--- a/internal/launch/cmux.go
+++ b/internal/launch/cmux.go
@@ -32,17 +32,18 @@ const (
 
 // CmuxBackend manages one cmux workspace per AMQ project/session generation.
 type CmuxBackend struct {
-	binary        string
-	run           func(context.Context, ...string) (string, error)
-	hostname      func() (string, error)
-	getenv        func(string) string
-	lookPath      func(string) (string, error)
-	userHomeDir   func() (string, error)
-	isExecutable  func(string) bool
-	sleep         func(context.Context, time.Duration) error
-	createTimeout time.Duration
-	healthTimeout time.Duration
-	healthPoll    time.Duration
+	binary         string
+	run            func(context.Context, ...string) (string, error)
+	hostname       func() (string, error)
+	getenv         func(string) string
+	lookPath       func(string) (string, error)
+	userHomeDir    func() (string, error)
+	isExecutable   func(string) bool
+	sleep          func(context.Context, time.Duration) error
+	createTimeout  time.Duration
+	commandTimeout time.Duration
+	healthTimeout  time.Duration
+	healthPoll     time.Duration
 }
 
 func NewCmuxBackend(binary string) *CmuxBackend {
@@ -69,12 +70,15 @@ func (b *CmuxBackend) Detect() DetectResult {
 	if _, err := b.resolveExecutable(); err != nil {
 		return result
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), cmuxCommandTimeout)
-	defer cancel()
-	if _, err := b.run(ctx, "ping"); err != nil {
+	probe := func(args ...string) (string, error) {
+		ctx, cancel := b.commandCallContext()
+		defer cancel()
+		return b.run(ctx, args...)
+	}
+	if _, err := probe("ping"); err != nil {
 		return result
 	}
-	raw, err := b.run(ctx, "--json", "capabilities")
+	raw, err := probe("--json", "capabilities")
 	if err != nil {
 		cmuxUnsupported(&result, "cmux capabilities: "+err.Error())
 		return result
@@ -104,7 +108,7 @@ func (b *CmuxBackend) Detect() DetectResult {
 		cmuxUnsupported(&result, fmt.Sprintf("cmux protocol version %d is unsupported (want %d)", caps.ProtocolVersion, cmuxProtocolVersion))
 		return result
 	}
-	verRaw, err := b.run(ctx, "version")
+	verRaw, err := probe("version")
 	if err != nil {
 		cmuxUnsupported(&result, "cmux version: "+err.Error())
 		return result
@@ -259,6 +263,17 @@ func (b *CmuxBackend) createOpTimeout() time.Duration {
 		return b.createTimeout
 	}
 	return cmuxCreateTimeout
+}
+
+func (b *CmuxBackend) commandOpTimeout() time.Duration {
+	if b.commandTimeout > 0 {
+		return b.commandTimeout
+	}
+	return cmuxCommandTimeout
+}
+
+func (b *CmuxBackend) commandCallContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), b.commandOpTimeout())
 }
 
 func (b *CmuxBackend) createCallContext() (context.Context, context.CancelFunc) {

--- a/internal/launch/cmux_test.go
+++ b/internal/launch/cmux_test.go
@@ -617,6 +617,9 @@ func TestCmuxDefaultCreateTimeoutExceedsCommandTimeout(t *testing.T) {
 	if got < 30*time.Second {
 		t.Fatalf("default create timeout %s is below 30s", got)
 	}
+	if command := NewCmuxBackend("").commandOpTimeout(); command != cmuxCommandTimeout {
+		t.Fatalf("default command timeout %s, want %s", command, cmuxCommandTimeout)
+	}
 }
 
 func TestCmuxCreateMissingAMQRefusesBeforeMutation(t *testing.T) {
@@ -842,9 +845,27 @@ func newFakeCmuxBackend(t *testing.T) (*CmuxBackend, string) {
 	t.Setenv("AMQ_CMUX_FAKE_UNHEALTHY", "")
 	t.Setenv("AMQ_CMUX_FAKE_MISSING", "")
 	backend := NewCmuxBackend(script)
+	backend.commandTimeout = testWaitBudget(t)
 	backend.healthTimeout = time.Second
 	backend.healthPoll = 10 * time.Millisecond
 	return backend, logPath
+}
+
+func testWaitBudget(t *testing.T) time.Duration {
+	t.Helper()
+	const reserve = 2 * time.Second
+	deadline, ok := t.Deadline()
+	if !ok {
+		return 30 * time.Second
+	}
+	remain := time.Until(deadline)
+	if remain > reserve {
+		return remain - reserve
+	}
+	if remain > 0 {
+		return remain
+	}
+	return time.Millisecond
 }
 
 func writeSleepAMQ(t *testing.T) string {


### PR DESCRIPTION
Bead amq-9yu — local test robustness.

- `TestStartWakeCancelBeforeReadyLeavesChildUnsignaled` and the cmux version-probe tests replace fixed 2s/5s walls with readiness signals/budgeted deadlines; assertions unchanged (child still unsignaled, cmux identity still refused) — verified line-by-line and under 6x parallel load (10/10), with both property mutants still failing under load.

Authored by cursor (session1); pushed by claude to parallelize landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
