### PR TITLE
fix(keepalive): fail closed on hook config rewrites and launchd plist identity

### DIFF
--- a/internal/keepalive/hookinstall/hookinstall.go
+++ b/internal/keepalive/hookinstall/hookinstall.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -270,8 +271,20 @@ func Install(opts Options) (Result, error) {
 		DryRun:             normalized.DryRun,
 	}
 
+	if normalized.Agent == AgentClaude || normalized.Agent == AgentBoth {
+		result.Commands[AgentClaude] = command
+		result.Snippets[AgentClaude] = claudeSessionStartEntry(command, hookTimeoutSeconds)
+	}
+	if normalized.Agent == AgentCodex || normalized.Agent == AgentBoth {
+		result.Commands[AgentCodex] = command
+		result.Snippets[AgentCodex] = codexSessionStartEntry(command, hookTimeoutSeconds)
+	}
+
 	scriptResult := FileResult{Path: normalized.ScriptPath}
 	if !normalized.DryRun {
+		if err := preflightHookConfigs(normalized, command, hookTimeoutSeconds); err != nil {
+			return Result{}, err
+		}
 		changed, err := writeExecutableIfChanged(normalized.ScriptPath, []byte(SessionStartScript))
 		if err != nil {
 			return Result{}, err
@@ -280,31 +293,38 @@ func Install(opts Options) (Result, error) {
 	}
 	result.Script = scriptResult
 
-	if normalized.Agent == AgentClaude || normalized.Agent == AgentBoth {
-		snippet := claudeSessionStartEntry(command, hookTimeoutSeconds)
-		result.Commands[AgentClaude] = command
-		result.Snippets[AgentClaude] = snippet
-		if !normalized.DryRun {
-			fileResult, err := installClaudeHook(normalized.ClaudeConfig, command, hookTimeoutSeconds)
-			if err != nil {
-				return Result{}, err
-			}
-			result.Configs[AgentClaude] = fileResult
+	if !normalized.DryRun && (normalized.Agent == AgentClaude || normalized.Agent == AgentBoth) {
+		fileResult, err := installClaudeHook(normalized.ClaudeConfig, command, hookTimeoutSeconds)
+		if err != nil {
+			return result, err
 		}
+		result.Configs[AgentClaude] = fileResult
 	}
-	if normalized.Agent == AgentCodex || normalized.Agent == AgentBoth {
-		snippet := codexSessionStartEntry(command, hookTimeoutSeconds)
-		result.Commands[AgentCodex] = command
-		result.Snippets[AgentCodex] = snippet
-		if !normalized.DryRun {
-			fileResult, err := installCodexHook(normalized.CodexConfig, command, hookTimeoutSeconds)
-			if err != nil {
-				return Result{}, err
+	if !normalized.DryRun && (normalized.Agent == AgentCodex || normalized.Agent == AgentBoth) {
+		fileResult, err := installCodexHook(normalized.CodexConfig, command, hookTimeoutSeconds)
+		if err != nil {
+			if result.Configs[AgentClaude].Changed {
+				return result, fmt.Errorf("partial hookinstall commit: %s updated; %s failed: %w", AgentClaude, AgentCodex, err)
 			}
-			result.Configs[AgentCodex] = fileResult
+			return result, err
 		}
+		result.Configs[AgentCodex] = fileResult
 	}
 	return result, nil
+}
+
+func preflightHookConfigs(opts Options, command string, hookTimeoutSeconds int) error {
+	if opts.Agent == AgentClaude || opts.Agent == AgentBoth {
+		if _, _, err := prepareClaudeHook(opts.ClaudeConfig, command, hookTimeoutSeconds); err != nil {
+			return err
+		}
+	}
+	if opts.Agent == AgentCodex || opts.Agent == AgentBoth {
+		if _, _, err := prepareCodexHook(opts.CodexConfig, command, hookTimeoutSeconds); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func NormalizeOptions(opts Options) (Options, error) {
@@ -370,63 +390,83 @@ func NormalizeOptions(opts Options) (Options, error) {
 }
 
 func installClaudeHook(path, command string, hookTimeoutSeconds int) (FileResult, error) {
-	doc, err := loadJSONObject(path)
+	doc, changed, err := prepareClaudeHook(path, command, hookTimeoutSeconds)
 	if err != nil {
 		return FileResult{}, err
-	}
-	hooks, err := objectField(doc, "hooks")
-	if err != nil {
-		return FileResult{}, err
-	}
-	sessionStart, err := arrayField(hooks, "SessionStart")
-	if err != nil {
-		return FileResult{}, err
-	}
-	changed := false
-	if !claudeHasCommand(sessionStart, command) {
-		sessionStart = append(sessionStart, claudeSessionStartEntry(command, hookTimeoutSeconds))
-		hooks["SessionStart"] = sessionStart
-		doc["hooks"] = hooks
-		changed = true
 	}
 	return saveJSONIfChanged(path, doc, changed)
 }
 
 func installCodexHook(path, command string, hookTimeoutSeconds int) (FileResult, error) {
-	doc, err := loadJSONObject(path)
+	doc, changed, err := prepareCodexHook(path, command, hookTimeoutSeconds)
 	if err != nil {
 		return FileResult{}, err
+	}
+	return saveJSONIfChanged(path, doc, changed)
+}
+
+func prepareClaudeHook(path, command string, hookTimeoutSeconds int) (map[string]interface{}, bool, error) {
+	doc, err := loadJSONObject(path)
+	if err != nil {
+		return nil, false, err
 	}
 	hooks, err := objectField(doc, "hooks")
 	if err != nil {
-		return FileResult{}, err
+		return nil, false, err
 	}
 	sessionStart, err := arrayField(hooks, "SessionStart")
 	if err != nil {
-		return FileResult{}, err
+		return nil, false, err
 	}
-	changed := false
-	if !codexHasCommand(sessionStart, command) {
-		hook := codexHook(command, hookTimeoutSeconds)
-		if len(sessionStart) == 0 {
+	if err := validateSessionStartEntries(sessionStart); err != nil {
+		return nil, false, err
+	}
+	if claudeHasCommand(sessionStart, command) {
+		return doc, false, nil
+	}
+	sessionStart = append(sessionStart, claudeSessionStartEntry(command, hookTimeoutSeconds))
+	hooks["SessionStart"] = sessionStart
+	doc["hooks"] = hooks
+	return doc, true, nil
+}
+
+func prepareCodexHook(path, command string, hookTimeoutSeconds int) (map[string]interface{}, bool, error) {
+	doc, err := loadJSONObject(path)
+	if err != nil {
+		return nil, false, err
+	}
+	hooks, err := objectField(doc, "hooks")
+	if err != nil {
+		return nil, false, err
+	}
+	sessionStart, err := arrayField(hooks, "SessionStart")
+	if err != nil {
+		return nil, false, err
+	}
+	if err := validateSessionStartEntries(sessionStart); err != nil {
+		return nil, false, err
+	}
+	if codexHasCommand(sessionStart, command) {
+		return doc, false, nil
+	}
+	hook := codexHook(command, hookTimeoutSeconds)
+	if len(sessionStart) == 0 {
+		sessionStart = append(sessionStart, map[string]interface{}{"hooks": []interface{}{hook}})
+	} else {
+		first, ok := sessionStart[0].(map[string]interface{})
+		if !ok {
 			sessionStart = append(sessionStart, map[string]interface{}{"hooks": []interface{}{hook}})
 		} else {
-			first, ok := sessionStart[0].(map[string]interface{})
-			if !ok {
-				sessionStart = append(sessionStart, map[string]interface{}{"hooks": []interface{}{hook}})
-				hooks["SessionStart"] = sessionStart
-				doc["hooks"] = hooks
-				return saveJSONIfChanged(path, doc, true)
+			hookList, err := innerHookList(first)
+			if err != nil {
+				return nil, false, err
 			}
-			hookList := interfaceArray(first["hooks"])
-			hookList = append(hookList, hook)
-			first["hooks"] = hookList
+			first["hooks"] = append(hookList, hook)
 		}
-		hooks["SessionStart"] = sessionStart
-		doc["hooks"] = hooks
-		changed = true
 	}
-	return saveJSONIfChanged(path, doc, changed)
+	hooks["SessionStart"] = sessionStart
+	doc["hooks"] = hooks
+	return doc, true, nil
 }
 
 func claudeSessionStartEntry(command string, hookTimeoutSeconds int) map[string]interface{} {
@@ -496,6 +536,12 @@ func loadJSONObject(path string) (map[string]interface{}, error) {
 	if err := decoder.Decode(&doc); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("parse %s: trailing JSON value", path)
+		}
+		return nil, fmt.Errorf("parse %s: trailing JSON: %w", path, err)
+	}
 	if doc == nil {
 		doc = map[string]interface{}{}
 	}
@@ -531,11 +577,46 @@ func backupIfExists(path string) (string, error) {
 		}
 		return "", err
 	}
-	backup := fmt.Sprintf("%s.bak-%s", path, time.Now().UTC().Format("20060102T150405Z"))
-	if err := os.WriteFile(backup, data, 0o600); err != nil {
-		return "", err
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	for i := 0; i < 100; i++ {
+		backup := fmt.Sprintf("%s.bak-%s", path, ts)
+		if i > 0 {
+			backup = fmt.Sprintf("%s.bak-%s-%d", path, ts, i)
+		}
+		err := writeExclusiveRegularFile(backup, data, 0o600)
+		if err == nil {
+			return backup, nil
+		}
+		if !os.IsExist(err) {
+			return "", err
+		}
 	}
-	return backup, nil
+	return "", fmt.Errorf("create backup %s.bak-%s: names exhausted", path, ts)
+}
+
+func writeExclusiveRegularFile(path string, data []byte, mode os.FileMode) (err error) {
+	file, err := os.OpenFile(path, exclusiveCreateFlags(), mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cerr := file.Close()
+		if err != nil {
+			_ = os.Remove(path)
+			return
+		}
+		if cerr != nil {
+			_ = os.Remove(path)
+			err = cerr
+		}
+	}()
+	if err = file.Chmod(mode); err != nil {
+		return err
+	}
+	if _, err = file.Write(data); err != nil {
+		return err
+	}
+	return file.Sync()
 }
 
 func writeExecutableIfChanged(path string, data []byte) (bool, error) {
@@ -608,6 +689,31 @@ func interfaceArray(raw interface{}) []interface{} {
 		return values
 	}
 	return []interface{}{}
+}
+
+func validateSessionStartEntries(entries []interface{}) error {
+	for _, entry := range entries {
+		obj, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, err := innerHookList(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func innerHookList(entry map[string]interface{}) ([]interface{}, error) {
+	raw, exists := entry["hooks"]
+	if !exists || raw == nil {
+		return []interface{}{}, nil
+	}
+	values, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%q must be a JSON array", "hooks")
+	}
+	return values, nil
 }
 
 func buildHookCommand(binaryPath, scriptPath string, timeout time.Duration) string {

--- a/internal/keepalive/hookinstall/hookinstall_other.go
+++ b/internal/keepalive/hookinstall/hookinstall_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package hookinstall
+
+import "os"
+
+func exclusiveCreateFlags() int {
+	return os.O_WRONLY | os.O_CREATE | os.O_EXCL
+}

--- a/internal/keepalive/hookinstall/hookinstall_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_test.go
@@ -146,6 +146,120 @@ func TestInstallCodexCreatesFirstSessionStartEntryWhenListIsEmpty(t *testing.T) 
 	}
 }
 
+func TestInstallRefusesTrailingJSON(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+	original := []byte("{\"hooks\":{}}\n{\"injected\":true}\n")
+	mustWrite(t, configPath, original)
+
+	_, err := Install(Options{
+		Agent:        AgentClaude,
+		ScriptPath:   filepath.Join(dir, "hook.sh"),
+		BinaryPath:   writeExecutable(t, filepath.Join(dir, "amq-keepalive")),
+		ClaudeConfig: configPath,
+		Timeout:      time.Second,
+	})
+	if err == nil {
+		t.Fatal("Install() error = nil, want trailing JSON refusal")
+	}
+	if !strings.Contains(err.Error(), "trailing JSON") {
+		t.Fatalf("Install() error = %v, want trailing JSON", err)
+	}
+	got, readErr := os.ReadFile(configPath)
+	if readErr != nil || !bytes.Equal(got, original) {
+		t.Fatalf("config changed after trailing JSON: err=%v bytes=%q", readErr, got)
+	}
+}
+
+func TestInstallCodexRefusesWrongTypeInnerHooks(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "hooks.json")
+	original := []byte(`{"hooks":{"SessionStart":[{"hooks":{"type":"command","command":"existing"}}]}}`)
+	mustWrite(t, configPath, original)
+
+	_, err := Install(Options{
+		Agent:       AgentCodex,
+		ScriptPath:  filepath.Join(dir, "hook.sh"),
+		BinaryPath:  writeExecutable(t, filepath.Join(dir, "amq-keepalive")),
+		CodexConfig: configPath,
+		Timeout:     time.Second,
+	})
+	if err == nil {
+		t.Fatal("Install() error = nil, want wrong-type inner hooks refusal")
+	}
+	if !strings.Contains(err.Error(), `"hooks" must be a JSON array`) {
+		t.Fatalf("Install() error = %v, want typed inner hooks", err)
+	}
+	got, readErr := os.ReadFile(configPath)
+	if readErr != nil || !bytes.Equal(got, original) {
+		t.Fatalf("wrong-type inner hooks were wiped: err=%v bytes=%q", readErr, got)
+	}
+}
+
+func TestInstallBothRefusesWhenSecondConfigFailsPreflight(t *testing.T) {
+	dir := t.TempDir()
+	claudeConfig := filepath.Join(dir, "claude", "settings.json")
+	claudeOriginal := []byte(`{"hooks":{"SessionStart":[]}}`)
+	mustWrite(t, claudeConfig, claudeOriginal)
+	codexConfig := filepath.Join(dir, "codex", "hooks.json")
+	if err := os.MkdirAll(codexConfig, 0o700); err != nil {
+		t.Fatalf("mkdir codex config path: %v", err)
+	}
+
+	_, err := Install(Options{
+		Agent:        AgentBoth,
+		ScriptPath:   filepath.Join(dir, "hook.sh"),
+		BinaryPath:   writeExecutable(t, filepath.Join(dir, "amq-keepalive")),
+		ClaudeConfig: claudeConfig,
+		CodexConfig:  codexConfig,
+		Timeout:      time.Second,
+	})
+	if err == nil {
+		t.Fatal("Install() error = nil, want second-config refusal")
+	}
+	if strings.Contains(err.Error(), "partial hookinstall commit") {
+		t.Fatalf("preflight failure committed Claude: %v", err)
+	}
+	got, readErr := os.ReadFile(claudeConfig)
+	if readErr != nil || !bytes.Equal(got, claudeOriginal) {
+		t.Fatalf("Claude config changed after Codex preflight failure: err=%v bytes=%q", readErr, got)
+	}
+}
+
+func TestBackupIfExistsUsesExclusiveSameSecondName(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "settings.json")
+	original := []byte(`{"keep":true}`)
+	mustWrite(t, src, original)
+	occupant := []byte("occupant\n")
+
+	for attempt := 0; attempt < 8; attempt++ {
+		ts := time.Now().UTC().Format("20060102T150405Z")
+		planted := fmt.Sprintf("%s.bak-%s", src, ts)
+		mustWrite(t, planted, occupant)
+		if time.Now().UTC().Format("20060102T150405Z") != ts {
+			continue
+		}
+		backup, err := backupIfExists(src)
+		if err != nil {
+			t.Fatalf("backupIfExists() error = %v", err)
+		}
+		if backup == planted {
+			t.Fatal("backup reused occupied same-second name")
+		}
+		gotOccupant, readErr := os.ReadFile(planted)
+		if readErr != nil || !bytes.Equal(gotOccupant, occupant) {
+			t.Fatalf("occupied backup changed: err=%v bytes=%q", readErr, gotOccupant)
+		}
+		got, readErr := os.ReadFile(backup)
+		if readErr != nil || !bytes.Equal(got, original) {
+			t.Fatalf("exclusive backup: err=%v bytes=%q", readErr, got)
+		}
+		return
+	}
+	t.Fatal("could not plant a same-second backup name")
+}
+
 func TestNormalizeOptionsTimeoutBoundary(t *testing.T) {
 	dir := t.TempDir()
 	base := Options{

--- a/internal/keepalive/hookinstall/hookinstall_unix.go
+++ b/internal/keepalive/hookinstall/hookinstall_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package hookinstall
+
+import (
+	"os"
+	"syscall"
+)
+
+func exclusiveCreateFlags() int {
+	return os.O_WRONLY | os.O_CREATE | os.O_EXCL | syscall.O_NOFOLLOW
+}

--- a/internal/keepalive/hookinstall/hookinstall_unix_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_unix_test.go
@@ -2,7 +2,97 @@
 
 package hookinstall
 
-import "syscall"
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestBackupIfExistsDoesNotFollowSymlink(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "settings.json")
+	original := []byte(`{"keep":true}`)
+	mustWrite(t, src, original)
+	victim := filepath.Join(dir, "victim")
+	victimBytes := []byte("do-not-clobber\n")
+	mustWrite(t, victim, victimBytes)
+
+	for attempt := 0; attempt < 8; attempt++ {
+		ts := time.Now().UTC().Format("20060102T150405Z")
+		planted := fmt.Sprintf("%s.bak-%s", src, ts)
+		_ = os.Remove(planted)
+		if err := os.Symlink(victim, planted); err != nil {
+			t.Fatalf("Symlink backup name: %v", err)
+		}
+		if time.Now().UTC().Format("20060102T150405Z") != ts {
+			continue
+		}
+		backup, err := backupIfExists(src)
+		gotVictim, readErr := os.ReadFile(victim)
+		if readErr != nil || !bytes.Equal(gotVictim, victimBytes) {
+			t.Fatalf("backup followed symlink: err=%v bytes=%q backup=%q installErr=%v", readErr, gotVictim, backup, err)
+		}
+		info, statErr := os.Lstat(planted)
+		if statErr != nil || info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("planted backup name is no longer a symlink: err=%v mode=%v", statErr, info.Mode())
+		}
+		if err == nil {
+			if backup == planted {
+				t.Fatal("backup reused symlink path")
+			}
+			got, readErr := os.ReadFile(backup)
+			if readErr != nil || !bytes.Equal(got, original) {
+				t.Fatalf("exclusive backup: err=%v bytes=%q", readErr, got)
+			}
+		}
+		return
+	}
+	t.Fatal("could not plant a same-second backup symlink")
+}
+
+func TestInstallBothReportsPartialCommitWhenSecondWriteFails(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory write permissions")
+	}
+	dir := t.TempDir()
+	claudeConfig := filepath.Join(dir, "claude", "settings.json")
+	mustWrite(t, claudeConfig, []byte(`{"hooks":{"SessionStart":[]}}`))
+	codexDir := filepath.Join(dir, "codex")
+	codexConfig := filepath.Join(codexDir, "hooks.json")
+	mustWrite(t, codexConfig, []byte(`{"hooks":{"SessionStart":[]}}`))
+	if err := os.Chmod(codexDir, 0o500); err != nil {
+		t.Fatalf("chmod codex dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(codexDir, 0o700) })
+
+	result, err := Install(Options{
+		Agent:        AgentBoth,
+		ScriptPath:   filepath.Join(dir, "hook.sh"),
+		BinaryPath:   writeExecutable(t, filepath.Join(dir, "amq-keepalive")),
+		ClaudeConfig: claudeConfig,
+		CodexConfig:  codexConfig,
+		Timeout:      time.Second,
+	})
+	if err == nil {
+		t.Fatal("Install() error = nil, want second-config write failure")
+	}
+	claude := readJSON(t, claudeConfig)
+	claudeChanged := countCommand(claude, result.Commands[AgentClaude]) == 1
+	if claudeChanged {
+		if !strings.Contains(err.Error(), "partial hookinstall commit") {
+			t.Fatalf("committed Claude without partial-commit error: %v", err)
+		}
+		return
+	}
+	if strings.Contains(err.Error(), "partial hookinstall commit") {
+		t.Fatalf("partial-commit reported without Claude write: %v", err)
+	}
+}
 
 func processRunning(pid int) bool {
 	return syscall.Kill(pid, 0) == nil

--- a/internal/keepalive/launchd/launchd.go
+++ b/internal/keepalive/launchd/launchd.go
@@ -9,11 +9,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 )
+
+var launchdLabelPattern = regexp.MustCompile(`^[A-Za-z0-9]+(-[A-Za-z0-9]+)*(\.[A-Za-z0-9]+(-[A-Za-z0-9]+)*)+$`)
 
 const DefaultLabel = "io.github.avivsinai.amq-keepalive"
 
@@ -37,6 +40,9 @@ func DefaultPlistPath(label string) (string, error) {
 	if label == "" {
 		label = DefaultLabel
 	}
+	if err := validateLaunchdLabel(label); err != nil {
+		return "", err
+	}
 	return filepath.Join(home, "Library", "LaunchAgents", label+".plist"), nil
 }
 
@@ -48,8 +54,18 @@ func DefaultLogPaths(label string) (stdoutPath, stderrPath string, err error) {
 	if label == "" {
 		label = DefaultLabel
 	}
+	if err := validateLaunchdLabel(label); err != nil {
+		return "", "", err
+	}
 	dir := filepath.Join(home, "Library", "Logs", "amq-keepalive")
 	return filepath.Join(dir, label+".out.log"), filepath.Join(dir, label+".err.log"), nil
+}
+
+func validateLaunchdLabel(label string) error {
+	if !launchdLabelPattern.MatchString(label) || len(label) > 253 || label != filepath.Base(label) {
+		return fmt.Errorf("launchd label %q must be reverse-DNS", label)
+	}
+	return nil
 }
 
 func ResolveExecutable(path string) (string, error) {
@@ -76,6 +92,9 @@ func ResolveExecutable(path string) (string, error) {
 func NormalizeOptions(opts Options) (Options, error) {
 	if opts.Label == "" {
 		opts.Label = DefaultLabel
+	}
+	if err := validateLaunchdLabel(opts.Label); err != nil {
+		return Options{}, err
 	}
 	if opts.BinaryPath == "" {
 		return Options{}, errors.New("binary path is required")
@@ -160,6 +179,9 @@ func Install(ctx context.Context, opts Options) error {
 func Uninstall(ctx context.Context, label string, plistPath string, unload bool) error {
 	if label == "" {
 		label = DefaultLabel
+	}
+	if err := validateLaunchdLabel(label); err != nil {
+		return err
 	}
 	if plistPath == "" {
 		path, err := DefaultPlistPath(label)
@@ -257,13 +279,159 @@ func ensureExistingPlistOwned(path, label string) error {
 }
 
 func isOwnedPlist(data []byte, label string) bool {
-	return bytes.Contains(data, []byte("<key>Label</key>")) &&
-		bytes.Contains(data, []byte("<string>"+label+"</string>")) &&
-		bytes.Contains(data, []byte("<key>ProgramArguments</key>")) &&
-		bytes.Contains(data, []byte("<string>supervise</string>")) &&
-		bytes.Contains(data, []byte("<string>--registry</string>")) &&
-		bytes.Contains(data, []byte("<string>--amq</string>")) &&
-		bytes.Contains(data, []byte("<string>--self</string>"))
+	dict, err := parsePlistRootDict(data)
+	if err != nil {
+		return false
+	}
+	gotLabel, _ := dict["Label"].(string)
+	if gotLabel != label {
+		return false
+	}
+	rawArgs, ok := dict["ProgramArguments"].([]any)
+	if !ok {
+		return false
+	}
+	have := make(map[string]bool, len(rawArgs))
+	for _, arg := range rawArgs {
+		text, ok := arg.(string)
+		if !ok {
+			return false
+		}
+		have[text] = true
+	}
+	for _, required := range []string{"supervise", "--registry", "--amq", "--self"} {
+		if !have[required] {
+			return false
+		}
+	}
+	return true
+}
+
+func parsePlistRootDict(data []byte) (map[string]any, error) {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		switch start.Name.Local {
+		case "plist":
+			continue
+		case "dict":
+			return parsePlistDict(dec)
+		default:
+			return nil, fmt.Errorf("plist root must be a dict")
+		}
+	}
+}
+
+func parsePlistDict(dec *xml.Decoder) (map[string]any, error) {
+	out := make(map[string]any)
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.EndElement:
+			if t.Name.Local == "dict" {
+				return out, nil
+			}
+			return nil, fmt.Errorf("unexpected plist end element %s", t.Name.Local)
+		case xml.StartElement:
+			if t.Name.Local != "key" {
+				return nil, fmt.Errorf("plist dict expected key, got %s", t.Name.Local)
+			}
+			var key string
+			if err := dec.DecodeElement(&key, &t); err != nil {
+				return nil, err
+			}
+			if key == "" {
+				return nil, fmt.Errorf("plist dict key is empty")
+			}
+			if _, exists := out[key]; exists {
+				return nil, fmt.Errorf("plist dict duplicate key %q", key)
+			}
+			start, err := nextPlistStart(dec)
+			if err != nil {
+				return nil, err
+			}
+			value, err := parsePlistValue(dec, start)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = value
+		}
+	}
+}
+
+func parsePlistArray(dec *xml.Decoder) ([]any, error) {
+	var out []any
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.EndElement:
+			if t.Name.Local == "array" {
+				return out, nil
+			}
+			return nil, fmt.Errorf("unexpected plist end element %s", t.Name.Local)
+		case xml.StartElement:
+			value, err := parsePlistValue(dec, t)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, value)
+		}
+	}
+}
+
+func parsePlistValue(dec *xml.Decoder, start xml.StartElement) (any, error) {
+	switch start.Name.Local {
+	case "dict":
+		return parsePlistDict(dec)
+	case "array":
+		return parsePlistArray(dec)
+	case "string", "integer", "real", "date", "data":
+		var text string
+		if err := dec.DecodeElement(&text, &start); err != nil {
+			return nil, err
+		}
+		return text, nil
+	case "true":
+		if err := dec.Skip(); err != nil {
+			return nil, err
+		}
+		return true, nil
+	case "false":
+		if err := dec.Skip(); err != nil {
+			return nil, err
+		}
+		return false, nil
+	default:
+		return nil, fmt.Errorf("unsupported plist element %s", start.Name.Local)
+	}
+}
+
+func nextPlistStart(dec *xml.Decoder) (xml.StartElement, error) {
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return xml.StartElement{}, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			return t, nil
+		case xml.EndElement:
+			return xml.StartElement{}, fmt.Errorf("plist value missing")
+		}
+	}
 }
 
 func runLaunchctl(ctx context.Context, args ...string) error {

--- a/internal/keepalive/launchd/launchd_test.go
+++ b/internal/keepalive/launchd/launchd_test.go
@@ -310,6 +310,98 @@ func TestNormalizeOptionsFillsIndependentDefaults(t *testing.T) {
 	}
 }
 
+func TestNormalizeOptionsRefusesPathLabel(t *testing.T) {
+	dir := t.TempDir()
+	_, err := NormalizeOptions(Options{
+		Label:        "../x",
+		PlistPath:    filepath.Join(dir, "x.plist"),
+		BinaryPath:   "/bin/echo",
+		RegistryPath: filepath.Join(dir, "registry.json"),
+		AMQPath:      "/bin/echo",
+		StdoutPath:   filepath.Join(dir, "out.log"),
+		StderrPath:   filepath.Join(dir, "err.log"),
+	})
+	if err == nil {
+		t.Fatal("NormalizeOptions accepted path label ../x")
+	}
+	if !strings.Contains(err.Error(), "reverse-DNS") {
+		t.Fatalf("NormalizeOptions error = %v, want reverse-DNS refusal", err)
+	}
+}
+
+func TestDefaultPlistPathRefusesPathLabel(t *testing.T) {
+	path, err := DefaultPlistPath("../x")
+	if err == nil {
+		t.Fatalf("DefaultPlistPath(../x) path = %q, want refusal", path)
+	}
+	if !strings.Contains(err.Error(), "reverse-DNS") {
+		t.Fatalf("DefaultPlistPath error = %v, want reverse-DNS refusal", err)
+	}
+}
+
+func TestUnrelatedPlistWithMatchingSubstringsIsNotOwned(t *testing.T) {
+	const label = "com.example.amq-keepalive"
+	foreign := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.example.unrelated</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/bin/true</string>
+	</array>
+	<key>Notes</key>
+	<array>
+		<string>supervise</string>
+		<string>--registry</string>
+		<string>--amq</string>
+		<string>--self</string>
+	</array>
+	<key>Also</key>
+	<string>com.example.amq-keepalive</string>
+</dict>
+</plist>
+`)
+	if !bytes.Contains(foreign, []byte("<key>Label</key>")) ||
+		!bytes.Contains(foreign, []byte("<string>"+label+"</string>")) ||
+		!bytes.Contains(foreign, []byte("<key>ProgramArguments</key>")) ||
+		!bytes.Contains(foreign, []byte("<string>supervise</string>")) {
+		t.Fatal("fixture missing substring markers that used to fool ownership")
+	}
+	if isOwnedPlist(foreign, label) {
+		t.Fatal("unrelated plist with matching substrings was treated as owned")
+	}
+
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "unrelated.plist")
+	if err := os.WriteFile(plistPath, foreign, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	opts := Options{
+		Label:        label,
+		PlistPath:    plistPath,
+		BinaryPath:   "/bin/echo",
+		RegistryPath: filepath.Join(dir, "registry.json"),
+		AMQPath:      "/bin/echo",
+		Interval:     time.Second,
+		Load:         false,
+	}
+	if err := Install(context.Background(), opts); err == nil {
+		t.Fatal("Install() error = nil, want substring-only plist refusal")
+	}
+	got, err := os.ReadFile(plistPath)
+	if err != nil || !bytes.Equal(got, foreign) {
+		t.Fatalf("foreign plist was modified: err=%v bytes=%q", err, got)
+	}
+	if err := Uninstall(context.Background(), label, plistPath, false); err == nil {
+		t.Fatal("Uninstall() error = nil, want substring-only plist refusal")
+	}
+	got, err = os.ReadFile(plistPath)
+	if err != nil || !bytes.Equal(got, foreign) {
+		t.Fatalf("Uninstall modified foreign plist: err=%v bytes=%q", err, got)
+	}
+}
+
 func TestServiceTargetUsesLaunchdLabelTarget(t *testing.T) {
 	want := "gui/" + strconv.Itoa(os.Getuid()) + "/com.example.amq-keepalive"
 	if got := serviceTarget("com.example.amq-keepalive"); got != want {


### PR DESCRIPTION
Bead amq-a6t — ChatGPT Pro review B findings 25, 26.

- hookinstall config rewrite fails closed: JSON decode requires EOF, wrong-typed inner `hooks` refused (not wiped), backups via exclusive nofollow opens with unique names, both configs preflighted with explicit partial-commit results.
- launchd labels restricted to a separator-free reverse-DNS grammar; plist ownership decided by parsing exact Label/ProgramArguments, not substring match.

Review: execution-gated, 6/6 mutants killed, over-tighten negatives held.

Authored by cursor (session1); pushed by claude to parallelize landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
