### PR TITLE
fix(wake): run restart preflight outside the lifecycle guard with CAS republication

### DIFF
--- a/internal/cli/wake_restart_unix.go
+++ b/internal/cli/wake_restart_unix.go
@@ -196,110 +196,55 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 	}
 	defer func() { _ = agentDir.Close() }()
 
-	var expected wakeLockInspection
-	adopted := false
-	needsNotify := true
+	state := wakeRestartPublicationState{
+		root:        root,
+		me:          me,
+		owner:       *owner,
+		agentDir:    agentDir,
+		record:      record,
+		requestID:   requestID,
+		candidate:   candidate,
+		needsNotify: true,
+	}
+	// Candidate preflight execs a child and can wait up to
+	// wakeResumePreflightTimeout. Hold the exclusive lifecycle guard only for
+	// snapshot and later exact lock-record CAS; never across the child wait.
+	var needPreflight bool
 	err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
-		expected = inspectWakeLockAt(dirfd, agentDir, root, me)
-		if err := validateWakeRestartIncumbent(expected, root, me, *owner); err != nil {
-			return err
-		}
-		existing, exists, readErr := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
-		if readErr != nil {
-			if !exists || existing.Object.FileInfo == nil {
-				return readErr
-			}
-			if errors.Is(readErr, errWakeRestartSchemaTooNew) {
-				return fmt.Errorf(
-					"future-schema wake restart request is preserved at %s; retry with a newer AMQ: %w",
-					wakeRestartFileName,
-					readErr,
-				)
-			}
-			quarantined, quarantineErr := quarantineWakeRestartRecordAt(dirfd, agentDir, existing)
-			if quarantineErr != nil {
-				return errors.Join(readErr, quarantineErr)
-			}
-			return fmt.Errorf(
-				"invalid wake restart request was preserved as %s; retry restart: %w",
-				quarantined,
-				readErr,
-			)
-		}
-		if exists && existing.Record.Status == wakeRestartPending {
-			disposition := classifyPendingWakeRestart(
-				existing.Record,
-				expected,
-				root,
-				me,
-				*owner,
-			)
-			if disposition == wakeRestartPendingPreserve {
-				return fmt.Errorf(
-					"pending wake restart for predecessor generation %s is preserved because it does not match live generation %s",
-					existing.Record.Generation,
-					expected.Lock.Generation,
-				)
-			}
-			if disposition == wakeRestartPendingClaimUnstable {
-				return fmt.Errorf(
-					"pending wake restart claim from generation %s to %s is preserved before successor publication",
-					existing.Record.Generation,
-					existing.Record.SuccessorGeneration,
-				)
-			}
-			record = existing.Record
-			requestID = record.RequestID
-			candidate = record.Candidate
-			adopted = true
-			needsNotify = disposition == wakeRestartPendingAdoptNotify
-		}
-		if exists && existing.Record.Status == wakeRestartRefused {
-			if err := reclaimWakeRestartStagePlatform(existing.Record); err != nil {
-				return fmt.Errorf("reclaim refused wake restart stage before retry: %w", err)
-			}
-			if _, err := quarantineWakeRestartRecordAt(dirfd, agentDir, existing); err != nil {
-				return fmt.Errorf("quarantine refused wake restart request before retry: %w", err)
-			}
-		}
-		if needsNotify {
-			if err := validateWakeRestartArgv(expected.Lock.Args, root, me); err != nil {
-				return err
-			}
-		}
-		if !adopted {
-			record.Generation = expected.Lock.Generation
-			record.PreviousBoundImage = previousDarwinWakeRestartStageForLock(expected.Lock)
-			bootstrap := wakeResumeBootstrap{
-				Schema:             wakeRestartSchemaV1,
-				RequestID:          record.RequestID,
-				Generation:         record.Generation,
-				PreviousBoundImage: record.PreviousBoundImage,
-			}
-			if err := wakeRestartPreflight(candidate, expected.Lock.Args, bootstrap); err != nil {
-				return fmt.Errorf("wake restart candidate preflight failed: %w", err)
-			}
-			if err := writeWakeRestartRecordAt(dirfd, agentDir, record); err != nil {
-				return err
-			}
-			createdSnapshot, created, readErr := readWakeRestartRecordSnapshotAt(dirfd, agentDir)
-			if readErr != nil {
-				return readErr
-			}
-			if !created || !sameWakeRestartRecord(createdSnapshot.Record, record) {
-				return fmt.Errorf("wake restart request changed after creation")
-			}
-		}
-		current := inspectWakeLockAt(dirfd, agentDir, root, me)
-		if !sameWakeLockInspection(expected, current) || !current.IdentityConfirmed {
-			return fmt.Errorf("wake changed while publishing restart request")
-		}
-		return nil
+		var recErr error
+		needPreflight, recErr = reconcileWakeRestartPublicationAt(dirfd, &state, false)
+		return recErr
 	})
 	if err != nil {
 		result.Reason = err.Error()
 		return result, err
 	}
+	if needPreflight {
+		bootstrap := wakeResumeBootstrap{
+			Schema:             wakeRestartSchemaV1,
+			RequestID:          state.record.RequestID,
+			Generation:         state.record.Generation,
+			PreviousBoundImage: state.record.PreviousBoundImage,
+		}
+		if err := wakeRestartPreflight(state.candidate, state.expected.Lock.Args, bootstrap); err != nil {
+			err = fmt.Errorf("wake restart candidate preflight failed: %w", err)
+			result.Reason = err.Error()
+			return result, err
+		}
+		err = withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
+			_, recErr := reconcileWakeRestartPublicationAt(dirfd, &state, true)
+			return recErr
+		})
+		if err != nil {
+			result.Reason = err.Error()
+			return result, err
+		}
+	}
+	expected := state.expected
+	record = state.record
+	requestID = state.requestID
+	candidate = state.candidate
+	needsNotify := state.needsNotify
 	result.PID = expected.PID
 	result.PreviousGeneration = record.Generation
 
@@ -367,6 +312,139 @@ func requestWakeRestart(root, me string) (result wakeRestartResult, returnErr er
 	err = fmt.Errorf("wake restart did not complete within %s", wakeRestartWaitTimeout)
 	result.Reason = err.Error()
 	return result, err
+}
+
+type wakeRestartPublicationState struct {
+	root        string
+	me          string
+	owner       wakeOwner
+	agentDir    *wakeAgentDir
+	record      wakeRestartRecord
+	requestID   string
+	candidate   wakeImageEvidenceV1
+	expected    wakeLockInspection
+	adopted     bool
+	needsNotify bool
+}
+
+func reconcileWakeRestartPublicationAt(
+	dirfd int,
+	state *wakeRestartPublicationState,
+	publish bool,
+) (needPreflight bool, err error) {
+	current := inspectWakeLockAt(dirfd, state.agentDir, state.root, state.me)
+	if publish {
+		if !sameWakeLockInspection(state.expected, current) || !current.IdentityConfirmed {
+			return false, fmt.Errorf("wake changed while publishing restart request")
+		}
+	} else {
+		state.expected = current
+		if err := validateWakeRestartIncumbent(state.expected, state.root, state.me, state.owner); err != nil {
+			return false, err
+		}
+	}
+
+	existing, exists, readErr := readWakeRestartRecordSnapshotAt(dirfd, state.agentDir)
+	if readErr != nil {
+		if !exists || existing.Object.FileInfo == nil {
+			return false, readErr
+		}
+		if errors.Is(readErr, errWakeRestartSchemaTooNew) {
+			return false, fmt.Errorf(
+				"future-schema wake restart request is preserved at %s; retry with a newer AMQ: %w",
+				wakeRestartFileName,
+				readErr,
+			)
+		}
+		quarantined, quarantineErr := quarantineWakeRestartRecordAt(dirfd, state.agentDir, existing)
+		if quarantineErr != nil {
+			return false, errors.Join(readErr, quarantineErr)
+		}
+		return false, fmt.Errorf(
+			"invalid wake restart request was preserved as %s; retry restart: %w",
+			quarantined,
+			readErr,
+		)
+	}
+
+	adopted := false
+	needsNotify := true
+	record := state.record
+	requestID := state.requestID
+	candidate := state.candidate
+	if exists && existing.Record.Status == wakeRestartPending {
+		disposition := classifyPendingWakeRestart(
+			existing.Record,
+			state.expected,
+			state.root,
+			state.me,
+			state.owner,
+		)
+		if disposition == wakeRestartPendingPreserve {
+			return false, fmt.Errorf(
+				"pending wake restart for predecessor generation %s is preserved because it does not match live generation %s",
+				existing.Record.Generation,
+				state.expected.Lock.Generation,
+			)
+		}
+		if disposition == wakeRestartPendingClaimUnstable {
+			return false, fmt.Errorf(
+				"pending wake restart claim from generation %s to %s is preserved before successor publication",
+				existing.Record.Generation,
+				existing.Record.SuccessorGeneration,
+			)
+		}
+		record = existing.Record
+		requestID = record.RequestID
+		candidate = record.Candidate
+		adopted = true
+		needsNotify = disposition == wakeRestartPendingAdoptNotify
+	}
+	if exists && existing.Record.Status == wakeRestartRefused {
+		if err := reclaimWakeRestartStagePlatform(existing.Record); err != nil {
+			return false, fmt.Errorf("reclaim refused wake restart stage before retry: %w", err)
+		}
+		if _, err := quarantineWakeRestartRecordAt(dirfd, state.agentDir, existing); err != nil {
+			return false, fmt.Errorf("quarantine refused wake restart request before retry: %w", err)
+		}
+	}
+	if needsNotify {
+		if err := validateWakeRestartArgv(state.expected.Lock.Args, state.root, state.me); err != nil {
+			return false, err
+		}
+	}
+	if !adopted {
+		record.Generation = state.expected.Lock.Generation
+		record.PreviousBoundImage = previousDarwinWakeRestartStageForLock(state.expected.Lock)
+		if !publish {
+			state.record = record
+			state.requestID = requestID
+			state.candidate = candidate
+			state.adopted = false
+			state.needsNotify = needsNotify
+			return true, nil
+		}
+		if err := writeWakeRestartRecordAt(dirfd, state.agentDir, record); err != nil {
+			return false, err
+		}
+		createdSnapshot, created, readErr := readWakeRestartRecordSnapshotAt(dirfd, state.agentDir)
+		if readErr != nil {
+			return false, readErr
+		}
+		if !created || !sameWakeRestartRecord(createdSnapshot.Record, record) {
+			return false, fmt.Errorf("wake restart request changed after creation")
+		}
+	}
+	current = inspectWakeLockAt(dirfd, state.agentDir, state.root, state.me)
+	if !sameWakeLockInspection(state.expected, current) || !current.IdentityConfirmed {
+		return false, fmt.Errorf("wake changed while publishing restart request")
+	}
+	state.record = record
+	state.requestID = requestID
+	state.candidate = candidate
+	state.adopted = adopted
+	state.needsNotify = needsNotify
+	return false, nil
 }
 
 func newWakeRestartRequestID() (string, error) {

--- a/internal/cli/wake_restart_unix_test.go
+++ b/internal/cli/wake_restart_unix_test.go
@@ -1180,6 +1180,188 @@ func TestWakeRestartIncompatibleCandidatePreflightLeavesIncumbentLive(t *testing
 	}
 }
 
+func TestWakeRestartPreflightReleasesLifecycleGuard(t *testing.T) {
+	fixture := newWakeRestartFixture(t)
+	removeWakeRestartRecordForTest(t, fixture)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	oldPreflight := wakeRestartPreflight
+	oldNotify := wakeRestartNotify
+	wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+		close(entered)
+		<-release
+		return nil
+	}
+	notifyErr := errors.New("stop after publication")
+	wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+		return notifyErr
+	}
+	t.Cleanup(func() {
+		wakeRestartPreflight = oldPreflight
+		wakeRestartNotify = oldNotify
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := requestWakeRestart(fixture.root, fixture.agent)
+		done <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("restart preflight was not reached")
+	}
+
+	guardDone := make(chan error, 1)
+	go func() {
+		guardDone <- withWakeLifecycleGuard(fixture.root, fixture.agent, func() error { return nil })
+	}()
+	select {
+	case err := <-guardDone:
+		if err != nil {
+			t.Fatalf("lifecycle op during restart preflight: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("lifecycle guard remained held during restart preflight")
+	}
+	close(release)
+	select {
+	case err := <-done:
+		if !errors.Is(err, notifyErr) {
+			t.Fatalf("restart after released preflight: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("restart did not finish after preflight released")
+	}
+}
+
+func TestWakeRestartPublicationFailsWhenLockChangesDuringPreflight(t *testing.T) {
+	t.Run("lock record changed", func(t *testing.T) {
+		fixture := newWakeRestartFixture(t)
+		removeWakeRestartRecordForTest(t, fixture)
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		oldPreflight := wakeRestartPreflight
+		oldNotify := wakeRestartNotify
+		wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+			close(entered)
+			<-release
+			return nil
+		}
+		notifyCalled := false
+		wakeRestartNotify = func(*wakeAgentDir, wakeLockInspection, wakeRestartRecord) error {
+			notifyCalled = true
+			return nil
+		}
+		t.Cleanup(func() {
+			wakeRestartPreflight = oldPreflight
+			wakeRestartNotify = oldNotify
+		})
+
+		done := make(chan struct {
+			result wakeRestartResult
+			err    error
+		}, 1)
+		go func() {
+			result, err := requestWakeRestart(fixture.root, fixture.agent)
+			done <- struct {
+				result wakeRestartResult
+				err    error
+			}{result, err}
+		}()
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("restart preflight was not reached")
+		}
+		changed := fixture.lock.Lock
+		changed.Generation = "cccccccccccccccccccccccccccccccc"
+		writeWakeLockForTest(t, fixture.root, fixture.agent, changed)
+		close(release)
+
+		var outcome struct {
+			result wakeRestartResult
+			err    error
+		}
+		select {
+		case outcome = <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("restart did not finish after lock replacement")
+		}
+		if outcome.err == nil || !strings.Contains(outcome.err.Error(), "wake changed while publishing restart request") {
+			t.Fatalf("changed lock result=%#v err=%v", outcome.result, outcome.err)
+		}
+		if notifyCalled {
+			t.Fatal("changed lock still notified the incumbent")
+		}
+		if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
+			t.Fatalf("changed lock published a restart record: %v", err)
+		}
+	})
+
+	t.Run("unchanged lock record still publishes", func(t *testing.T) {
+		fixture := newWakeRestartFixture(t)
+		removeWakeRestartRecordForTest(t, fixture)
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		oldPreflight := wakeRestartPreflight
+		oldNotify := wakeRestartNotify
+		wakeRestartPreflight = func(wakeImageEvidenceV1, []string, wakeResumeBootstrap) error {
+			close(entered)
+			<-release
+			return nil
+		}
+		notifyErr := errors.New("stop after unchanged publication")
+		wakeRestartNotify = func(_ *wakeAgentDir, current wakeLockInspection, record wakeRestartRecord) error {
+			if !sameWakeLockInspection(current, fixture.lock) ||
+				record.Generation != fixture.lock.Lock.Generation {
+				t.Fatalf("unchanged publication current=%#v record=%#v", current, record)
+			}
+			return notifyErr
+		}
+		t.Cleanup(func() {
+			wakeRestartPreflight = oldPreflight
+			wakeRestartNotify = oldNotify
+		})
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := requestWakeRestart(fixture.root, fixture.agent)
+			done <- err
+		}()
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("restart preflight was not reached")
+		}
+		close(release)
+		select {
+		case err := <-done:
+			if !errors.Is(err, notifyErr) {
+				t.Fatalf("unchanged lock restart: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("restart did not finish after unchanged preflight")
+		}
+		if err := fixture.agentDir.withFD(func(dirfd int) error {
+			current, exists, readErr := readWakeRestartRecordAt(dirfd, fixture.agentDir)
+			if readErr != nil {
+				return readErr
+			}
+			if !exists || current.Status != wakeRestartPending ||
+				current.Generation != fixture.lock.Lock.Generation {
+				return fmt.Errorf("unchanged lock did not publish: exists=%v record=%#v", exists, current)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestWakeRestartRequiresCurrentPlatformTransportBeforePublication(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)


### PR DESCRIPTION
Bead amq-cvx — ChatGPT Pro review B finding 15.

- Wake restart candidate preflight runs outside the exclusive lifecycle guard: snapshot under guard, release, preflight, reacquire with exact lock+record CAS before publishing `.wake.restart`. Concurrent lifecycle operations proceed during preflight; a changed lock record refuses publication.

Review: execution-gated, 3/3 mutants killed; no constructible TOCTOU; timing behavior preserved.

Authored by cursor (session1); pushed by claude to parallelize landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
