### PR TITLE
fix(keepalive): harden registry identity, locks, and canonicalization

### DIFF
--- a/internal/cli/symlink_resolution_other.go
+++ b/internal/cli/symlink_resolution_other.go
@@ -1,0 +1,12 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package cli
+
+import (
+	"errors"
+	"os"
+)
+
+func isUncertainSymlinkResolution(err error) bool {
+	return errors.Is(err, os.ErrPermission)
+}

--- a/internal/cli/symlink_resolution_unix.go
+++ b/internal/cli/symlink_resolution_unix.go
@@ -1,0 +1,13 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package cli
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+)
+
+func isUncertainSymlinkResolution(err error) bool {
+	return errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.ELOOP) || strings.Contains(strings.ToLower(err.Error()), "too many links")
+}

--- a/internal/cli/wake_lock.go
+++ b/internal/cli/wake_lock.go
@@ -167,10 +167,17 @@ func inspectWakeLockWithReader(root, me, lockPath string, read wakeLockFileReade
 func readWakeLockMetadataWithReader(root, me, lockPath string, read wakeLockFileReader) wakeLockInspection {
 	inspection := wakeLockInspection{
 		Status:   wakeLockMissing,
-		Root:     canonicalWakeRoot(root),
 		Agent:    me,
 		LockPath: lockPath,
 	}
+	canonicalRoot, err := canonicalizeWakeRoot(root)
+	if err != nil {
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = fmt.Sprintf("canonicalize root: %v", err)
+		inspection.observationErr = err
+		return inspection
+	}
+	inspection.Root = canonicalRoot
 
 	data, fileInfo, err := read()
 	if err != nil {
@@ -286,7 +293,19 @@ func classifyWakeLock(root, me string, inspection *wakeLockInspection) {
 		inspection.Reason = "lock root missing"
 		return
 	}
-	if canonicalWakeRoot(lock.Root) != canonicalWakeRoot(root) {
+	lockRoot, err := canonicalizeWakeRoot(lock.Root)
+	if err != nil {
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = fmt.Sprintf("canonicalize lock root: %v", err)
+		return
+	}
+	inspectRoot, err := canonicalizeWakeRoot(root)
+	if err != nil {
+		inspection.Status = wakeLockUnverified
+		inspection.Reason = fmt.Sprintf("canonicalize root: %v", err)
+		return
+	}
+	if lockRoot != inspectRoot {
 		inspection.Status = wakeLockStale
 		inspection.Reason = "root mismatch"
 		return
@@ -730,14 +749,26 @@ func currentWakeLockMatches(lock wakeLock) bool {
 }
 
 func canonicalWakeRoot(root string) string {
+	canonical, err := canonicalizeWakeRoot(root)
+	if err != nil {
+		return ""
+	}
+	return canonical
+}
+
+func canonicalizeWakeRoot(root string) (string, error) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
-		absRoot = root
+		return "", err
 	}
-	if realRoot, err := filepath.EvalSymlinks(absRoot); err == nil {
-		absRoot = realRoot
+	realRoot, err := filepath.EvalSymlinks(absRoot)
+	if err == nil {
+		return filepath.Clean(realRoot), nil
 	}
-	return filepath.Clean(absRoot)
+	if isUncertainSymlinkResolution(err) {
+		return "", fmt.Errorf("canonicalize wake root %q: %w", absRoot, err)
+	}
+	return filepath.Clean(absRoot), nil
 }
 
 func wakeLockAlreadyRunningError(me string, inspection wakeLockInspection) error {

--- a/internal/cli/wake_lock_identity_unix_test.go
+++ b/internal/cli/wake_lock_identity_unix_test.go
@@ -1,0 +1,55 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestCanonicalizeWakeRootFailsClosedOnELOOPAndEACCES(t *testing.T) {
+	dir := t.TempDir()
+	loopA := filepath.Join(dir, "loop-a")
+	loopB := filepath.Join(dir, "loop-b")
+	if err := os.Symlink(loopB, loopA); err != nil {
+		t.Fatalf("Symlink A: %v", err)
+	}
+	if err := os.Symlink(loopA, loopB); err != nil {
+		t.Fatalf("Symlink B: %v", err)
+	}
+	got, err := canonicalizeWakeRoot(loopA)
+	if err == nil || got != "" {
+		t.Fatalf("canonicalizeWakeRoot(ELOOP) = %q, %v; want error not identity", got, err)
+	}
+	if !errors.Is(err, syscall.ELOOP) && !strings.Contains(strings.ToLower(err.Error()), "too many links") {
+		t.Fatalf("canonicalizeWakeRoot(ELOOP) error = %v, want ELOOP", err)
+	}
+	if canonicalWakeRoot(loopA) != "" {
+		t.Fatalf("canonicalWakeRoot(ELOOP) = %q, want empty rather than lexical identity", canonicalWakeRoot(loopA))
+	}
+
+	denied := filepath.Join(dir, "denied")
+	if err := os.Mkdir(denied, 0o700); err != nil {
+		t.Fatalf("Mkdir denied: %v", err)
+	}
+	child := filepath.Join(denied, "root")
+	if err := os.Mkdir(child, 0o700); err != nil {
+		t.Fatalf("Mkdir child: %v", err)
+	}
+	if err := os.Chmod(denied, 0); err != nil {
+		t.Fatalf("Chmod denied: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(denied, 0o700) })
+	got, err = canonicalizeWakeRoot(child)
+	_ = os.Chmod(denied, 0o700)
+	if err == nil || got != "" {
+		t.Fatalf("canonicalizeWakeRoot(EACCES) = %q, %v; want error not identity", got, err)
+	}
+	if !errors.Is(err, syscall.EACCES) && !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("canonicalizeWakeRoot(EACCES) error = %v, want EACCES", err)
+	}
+}

--- a/internal/keepalive/app/app.go
+++ b/internal/keepalive/app/app.go
@@ -1276,14 +1276,7 @@ func (a App) retireSession(ctx context.Context, args []string) error {
 }
 
 func canonicalExistingPath(path string) (string, error) {
-	abs, err := filepath.Abs(filepath.Clean(path))
-	if err != nil {
-		return "", err
-	}
-	if real, err := filepath.EvalSymlinks(abs); err == nil {
-		return real, nil
-	}
-	return abs, nil
+	return registry.CanonicalRoot(path)
 }
 
 func parseRequiredAgents(raw string) ([]string, error) {

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -123,7 +123,7 @@ func TestRegistrationTargetInventoryUsesGhosttyDirectProbe(t *testing.T) {
 
 func TestReattachReplacesCurrentSessionAdapterEntry(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := filepath.Join(dir, "old-inbox.txt")
 	newTarget := filepath.Join(dir, "new-inbox.txt")
 	otherTarget := filepath.Join(dir, "other-inbox.txt")
@@ -183,7 +183,7 @@ func TestReattachReplacesCurrentSessionAdapterEntry(t *testing.T) {
 
 func TestAttachRejectsSecondRegistrationForSameAMQRootAndAgent(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	firstTarget := filepath.Join(dir, "first-inbox.txt")
 	secondTarget := filepath.Join(dir, "second-inbox.txt")
 	canonicalFirstTarget, err := (adapter.File{}).NormalizeTarget(firstTarget)
@@ -222,7 +222,7 @@ func TestAttachRejectsSecondRegistrationForSameAMQRootAndAgent(t *testing.T) {
 
 func TestAttachRejectsCanonicalRootAliasWithoutStartingWake(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	realRoot := filepath.Join(dir, "real-root")
 	if err := os.Mkdir(realRoot, 0o700); err != nil {
 		t.Fatalf("Mkdir root: %v", err)
@@ -272,7 +272,7 @@ func TestAttachIsIdempotentForSamePhysicalCmuxOwner(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	target := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	runner := appCommandRunnerFunc(func(context.Context, string, ...string) ([]byte, error) {
 		return []byte(`{"windows":[{"workspaces":[{"id":"WS-1","panes":[{"surfaces":[{"id":"F901D722-6789-4BBB-9818-C4E97F20BEB3","tty":"ttys101"}]}]}]}]}`), nil
@@ -309,7 +309,7 @@ func TestReattachRejectsDifferentSurfaceAliasOnOwnedPhysicalTTY(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	firstTarget := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	secondTarget := "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2"
 	store := registry.New(registryPath)
@@ -351,7 +351,7 @@ func TestReattachIgnoresUnrelatedDegradedRegisteredCmuxTarget(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	degradedTarget := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	degradedAlias := "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2"
 	candidateTarget := "cmux:surface:C71381D9-29D5-4D2D-A1C9-E101556BCB49"
@@ -431,7 +431,7 @@ func TestReattachRejectsRegisteredCmuxTargetWithUnknownPhysicalKeyBeforeWake(t *
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	unknownTarget := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	candidateTarget := "cmux:surface:C71381D9-29D5-4D2D-A1C9-E101556BCB49"
 	store := registry.New(registryPath)
@@ -483,7 +483,7 @@ func TestReattachRejectsSamePhysicalKeyFromDegradedRegisteredTargetBeforeWake(t 
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	degradedTarget := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	candidateTarget := "cmux:surface:C71381D9-29D5-4D2D-A1C9-E101556BCB49"
 	store := registry.New(registryPath)
@@ -539,7 +539,7 @@ func TestReattachDoesNotEvictUnknownCmuxAliasForCurrentSurface(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	corpseID := "F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	liveID := "B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2"
 	corpseTarget := "cmux:surface:" + corpseID
@@ -593,7 +593,7 @@ func TestReattachDoesNotEvictUnknownCmuxAliasForCurrentSurface(t *testing.T) {
 
 func TestConcurrentReattachClaimStartsOnlyWinningWake(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	target := filepath.Join(dir, "inbox.txt")
 	canonicalTarget := normalizedFileTarget(t, target)
 	if err := os.WriteFile(target, nil, 0o600); err != nil {
@@ -666,7 +666,7 @@ printf ready > "$ready"
 		t.Fatalf("write fake AMQ: %v", err)
 	}
 	runApp(t, "attach",
-		"--registry", filepath.Join(dir, "registry.json"),
+		"--registry", testRegistryPath(t, dir),
 		"--adapter", "file",
 		"--target", target,
 		"--root", "/tmp/amq-root",
@@ -731,7 +731,7 @@ exit 12
 				t.Fatalf("reset calls: %v", err)
 			}
 			opts := base
-			opts.RegistryPath = filepath.Join(t.TempDir(), "registry.json")
+			opts.RegistryPath = testRegistryTempPath(t)
 			test.mutate(&opts)
 			if err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).registerWithOptions(context.Background(), opts); err != nil {
 				t.Fatalf("registerWithOptions: %v", err)
@@ -746,7 +746,7 @@ exit 12
 
 func TestReattachPreservesRegistryWhenWakeTargetCannotChange(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := filepath.Join(dir, "old-inbox.txt")
 	newTarget := filepath.Join(dir, "new-inbox.txt")
 	canonicalOldTarget := normalizedFileTarget(t, oldTarget)
@@ -795,7 +795,7 @@ func TestReattachPreservesRegistryWhenWakeTargetCannotChange(t *testing.T) {
 
 func TestReattachPersistsRecoverableReservationBeforeWakeReadiness(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := filepath.Join(dir, "old-inbox.txt")
 	newTarget := filepath.Join(dir, "new-inbox.txt")
 	canonicalOldTarget := normalizedFileTarget(t, oldTarget)
@@ -865,7 +865,7 @@ func TestReattachPersistsRecoverableReservationBeforeWakeReadiness(t *testing.T)
 
 func TestReattachPersistsCandidateOnlyAfterWakeReady(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := filepath.Join(dir, "old-inbox.txt")
 	newTarget := filepath.Join(dir, "new-inbox.txt")
 	canonicalNewTarget := normalizedFileTarget(t, newTarget)
@@ -917,7 +917,7 @@ printf ready > "$ready"
 
 func TestReattachCancellationPreservesReservationForLateReadyWake(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := filepath.Join(dir, "old-inbox.txt")
 	newTarget := filepath.Join(dir, "new-inbox.txt")
 	canonicalNewTarget := normalizedFileTarget(t, newTarget)
@@ -1009,7 +1009,7 @@ func TestReattachRetireDetachedRetiresPreviousWakeThenStarts(t *testing.T) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatalf("MkdirAll root: %v", err)
 	}
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	newTarget := "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2"
 	store := registry.New(registryPath)
@@ -1098,7 +1098,7 @@ func TestReattachRetireDetachedStartsWhenOldTargetMissingAndWakeLockAlreadyAbsen
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatalf("MkdirAll root: %v", err)
 	}
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	newTarget := "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2"
 	store := registry.New(registryPath)
@@ -1176,7 +1176,7 @@ func TestReattachRetireDetachedLeavesOldRowWhenRetireRefused(t *testing.T) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatalf("MkdirAll root: %v", err)
 	}
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	newTarget := "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2"
 	store := registry.New(registryPath)
@@ -1265,7 +1265,7 @@ func TestReattachRetireDetachedNeverRetargetsLiveCmuxWake(t *testing.T) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatalf("MkdirAll root: %v", err)
 	}
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	oldTarget := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	newTarget := "cmux:surface:B8A8C4A7-3C88-4DAD-93BE-97E9701D07D2"
 	store := registry.New(registryPath)
@@ -1325,7 +1325,7 @@ func TestRetireSessionRetiresConfirmedWakesAndRemovesRows(t *testing.T) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatalf("MkdirAll root: %v", err)
 	}
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	store := registry.New(registryPath)
 	entries := []registry.Entry{
 		{Root: root, BaseRoot: dir, SessionName: "dashboard", Agent: "codex", Adapter: "cmux", Target: "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3", State: registry.StateDetached},
@@ -1401,7 +1401,7 @@ func TestRetireSessionRefusesWhenTargetStillExists(t *testing.T) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatalf("MkdirAll root: %v", err)
 	}
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	store := registry.New(registryPath)
 	for _, entry := range []registry.Entry{
 		{Root: root, Agent: "codex", Adapter: "cmux", Target: "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3", State: registry.StateDetached},
@@ -1443,7 +1443,7 @@ func TestRetireSessionRemovesRetiredAndLeavesRefused(t *testing.T) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatalf("MkdirAll root: %v", err)
 	}
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	store := registry.New(registryPath)
 	for _, entry := range []registry.Entry{
 		{Root: root, Agent: "codex", Adapter: "cmux", Target: "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3", State: registry.StateDetached},
@@ -1560,7 +1560,7 @@ func (w *appBlockingWake) Release() {
 
 func TestSuperviseUsesInjectedClockOnWakeFailure(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	target := filepath.Join(dir, "target")
 	if err := os.WriteFile(target, nil, 0o600); err != nil {
 		t.Fatalf("write target: %v", err)
@@ -1592,7 +1592,7 @@ func TestSuperviseUsesInjectedClockOnWakeFailure(t *testing.T) {
 
 func TestSuperviseWarnsOncePerPersistentFailureTransition(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	canonicalRoot, err := registry.CanonicalRoot("/tmp/amq-root")
 	if err != nil {
 		t.Fatalf("CanonicalRoot: %v", err)
@@ -1659,7 +1659,7 @@ func (w *appCancelingWake) StartWake(ctx context.Context, _ amq.StartWakeRequest
 
 func TestSuperviseCancellationStopsLaterStartsAndLeavesRegistryUnchanged(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	store := registry.New(registryPath)
 	for index := 0; index < 2; index++ {
 		target := filepath.Join(dir, fmt.Sprintf("target-%d", index))
@@ -1698,7 +1698,7 @@ func TestSuperviseBatchesCmuxInventoryAndDefersHealthyEntries(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	store := registry.New(registryPath)
 	targets := []string{
 		"cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3",
@@ -1749,7 +1749,7 @@ func TestSuperviseFailsClosedWhenOneRegisteredSurfaceHasLiveTTYAlias(t *testing.
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	store := registry.New(registryPath)
 	if _, err := store.Upsert(registry.Entry{
 		Root: "/tmp/tty-owner", Agent: "codex", Adapter: "cmux",
@@ -1815,7 +1815,7 @@ func TestSuperviseRefusesCmuxTTYDriftAcrossRestart(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	target := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	store := registry.New(registryPath)
 	if _, err := store.Upsert(registry.Entry{
@@ -1877,7 +1877,7 @@ func TestSuperviseRefusesCmuxTTYDriftAcrossRestart(t *testing.T) {
 
 func TestSuperviseFailsClosedOnNormalizedTargetOwnershipCollision(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	upper := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	lower := strings.ToLower(upper)
 	entries := []registry.Entry{
@@ -1905,7 +1905,7 @@ func TestSuperviseFailsClosedOnNormalizedTargetOwnershipCollision(t *testing.T) 
 }
 
 func TestContinuousSuperviseDoesNotEmitPerPassJSON(t *testing.T) {
-	registryPath := filepath.Join(t.TempDir(), "registry.json")
+	registryPath := testRegistryTempPath(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
 	var stdout bytes.Buffer
@@ -1926,7 +1926,7 @@ func TestGCDryRunIsNonMutatingAndApplyRetiresCandidates(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	target := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	store := registry.New(registryPath)
 	entry, err := store.Upsert(registry.Entry{
@@ -1991,7 +1991,7 @@ func TestGCDryRunExcludesPhysicalTTYOwnershipCollisions(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	store := registry.New(registryPath)
 	for index, target := range []string{
 		"cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3",
@@ -2030,7 +2030,7 @@ func TestGCApplyLeavesCandidateWhenRetireRefused(t *testing.T) {
 		t.Skip("cmux adapter requires macOS")
 	}
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	target := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	store := registry.New(registryPath)
 	entry, err := store.Upsert(registry.Entry{
@@ -2163,7 +2163,7 @@ func TestRegisterEnvFailureDependsOnlyOnRequiredIdentity(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := base
-			opts.RegistryPath = filepath.Join(t.TempDir(), "registry.json")
+			opts.RegistryPath = testRegistryTempPath(t)
 			tc.mutate(&opts)
 			err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).registerWithOptions(context.Background(), opts)
 			if (err != nil) != tc.wantErr {
@@ -2188,7 +2188,7 @@ func TestRegisterUsesEnvBaseRootAndSessionIndependently(t *testing.T) {
 	}
 	for _, missing := range []string{"base", "session"} {
 		t.Run(missing, func(t *testing.T) {
-			registryPath := filepath.Join(t.TempDir(), "registry.json")
+			registryPath := testRegistryTempPath(t)
 			opts := registerOptions{
 				RegistryPath: registryPath,
 				AdapterName:  "file",
@@ -2237,7 +2237,7 @@ func TestRegisterReturnsOnlyNonDetachedReconcileErrors(t *testing.T) {
 			}
 			adapters := adapter.NewRegistry(selected)
 			opts := base
-			opts.RegistryPath = filepath.Join(t.TempDir(), "registry.json")
+			opts.RegistryPath = testRegistryTempPath(t)
 			opts.AdapterName = "boundary"
 			err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, Adapters: &adapters}).registerWithOptions(context.Background(), opts)
 			if (err != nil) != tc.wantErr {
@@ -2248,7 +2248,7 @@ func TestRegisterReturnsOnlyNonDetachedReconcileErrors(t *testing.T) {
 }
 
 func TestResolveRegistrationReadinessFailurePersistsRetryState(t *testing.T) {
-	store := registry.New(filepath.Join(t.TempDir(), "registry.json"))
+	store := registry.New(testRegistryTempPath(t))
 	reservation, err := store.Upsert(registry.Entry{Root: "/tmp/root", Agent: "codex", Adapter: "file", Target: "/tmp/target"})
 	if err != nil {
 		t.Fatal(err)
@@ -2267,7 +2267,7 @@ func TestResolveRegistrationReadinessFailurePersistsRetryState(t *testing.T) {
 }
 
 func TestResolveRegistrationReadinessFailureReportsRestoreFailure(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := testRegistryTempPath(t)
 	if err := os.Mkdir(path, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -2320,7 +2320,7 @@ func TestSuperviseRejectsNonPositiveInterval(t *testing.T) {
 }
 
 func TestContinuousSuperviseLogsPersistentPassErrorsAndContinues(t *testing.T) {
-	registryPath := filepath.Join(t.TempDir(), "registry.json")
+	registryPath := testRegistryTempPath(t)
 	if err := os.Mkdir(registryPath, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -2393,10 +2393,16 @@ func TestRetireSessionMatchesRootAdapterAndAgentTogether(t *testing.T) {
 	if err := os.Mkdir(root, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	correct := registry.Entry{ID: "correct", Root: root, Agent: "codex", Adapter: "boundary", Target: "correct"}
-	wrongAdapter := registry.Entry{ID: "wrong-adapter", Root: root, Agent: "codex", Adapter: "other", Target: "wrong-adapter"}
-	wrongAgent := registry.Entry{ID: "wrong-agent", Root: root, Agent: "claude", Adapter: "boundary", Target: "wrong-agent"}
-	registryPath := filepath.Join(dir, "registry.json")
+	correct := registry.Entry{
+		ID: registry.EntryID(root, "codex", "boundary", "correct"), Root: root, Agent: "codex", Adapter: "boundary", Target: "correct",
+	}
+	wrongAdapter := registry.Entry{
+		ID: registry.EntryID(root, "codex", "other", "wrong-adapter"), Root: root, Agent: "codex", Adapter: "other", Target: "wrong-adapter",
+	}
+	wrongAgent := registry.Entry{
+		ID: registry.EntryID(root, "claude", "boundary", "wrong-agent"), Root: root, Agent: "claude", Adapter: "boundary", Target: "wrong-agent",
+	}
+	registryPath := testRegistryPath(t, dir)
 	if err := registry.New(registryPath).Save(registry.File{Entries: []registry.Entry{correct, wrongAdapter, wrongAgent}}); err != nil {
 		t.Fatal(err)
 	}
@@ -2425,6 +2431,19 @@ func TestRetireSessionMatchesRootAdapterAndAgentTogether(t *testing.T) {
 			t.Fatalf("exact entry remained: %#v", loaded.Entries)
 		}
 	}
+}
+
+func testRegistryPath(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("Chmod registry test dir: %v", err)
+	}
+	return filepath.Join(dir, "registry.json")
+}
+
+func testRegistryTempPath(t *testing.T) string {
+	t.Helper()
+	return testRegistryPath(t, t.TempDir())
 }
 
 func TestNormalizeAMQPathsCoversIndependentPathBoundaries(t *testing.T) {

--- a/internal/keepalive/app/app_unix_test.go
+++ b/internal/keepalive/app/app_unix_test.go
@@ -1,0 +1,133 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/registry"
+)
+
+func TestAttachRefusesHostileRegistryWithoutStartingWake(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, dir string) (registryPath, root, target string)
+	}{
+		{
+			name: "symlink dir",
+			setup: func(t *testing.T, dir string) (string, string, string) {
+				t.Helper()
+				realDir := filepath.Join(dir, "real-registry")
+				if err := os.Mkdir(realDir, 0o700); err != nil {
+					t.Fatalf("Mkdir: %v", err)
+				}
+				linkDir := filepath.Join(dir, "link-registry")
+				if err := os.Symlink(realDir, linkDir); err != nil {
+					t.Fatalf("Symlink: %v", err)
+				}
+				root := filepath.Join(dir, "amq-root")
+				if err := os.Mkdir(root, 0o700); err != nil {
+					t.Fatalf("Mkdir root: %v", err)
+				}
+				return filepath.Join(linkDir, "registry.json"), root, filepath.Join(dir, "inbox.txt")
+			},
+		},
+		{
+			name: "duplicate ids",
+			setup: func(t *testing.T, dir string) (string, string, string) {
+				t.Helper()
+				if err := os.Chmod(dir, 0o700); err != nil {
+					t.Fatalf("Chmod registry dir: %v", err)
+				}
+				root := filepath.Join(dir, "amq-root")
+				if err := os.Mkdir(root, 0o700); err != nil {
+					t.Fatalf("Mkdir root: %v", err)
+				}
+				path := filepath.Join(dir, "registry.json")
+				entry := registry.Entry{
+					ID:   registry.EntryID(root, "codex", "file", filepath.Join(dir, "inbox.txt")),
+					Root: root, Agent: "codex", Adapter: "file", Target: filepath.Join(dir, "inbox.txt"),
+					State: registry.StateAttached,
+				}
+				data, err := json.Marshal(registry.File{SchemaVersion: registry.SchemaVersion, Entries: []registry.Entry{entry, entry}})
+				if err != nil {
+					t.Fatalf("Marshal: %v", err)
+				}
+				if err := os.WriteFile(path, data, 0o600); err != nil {
+					t.Fatalf("WriteFile: %v", err)
+				}
+				return path, root, filepath.Join(dir, "other-inbox.txt")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			registryPath, root, target := tc.setup(t, dir)
+			amqCalls := filepath.Join(dir, "amq-calls.log")
+			fakeAMQ := filepath.Join(dir, "amq")
+			if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nprintf wake >> \"$AMQ_KEEPALIVE_AMQ_CALLS\"\nexit 7\n"), 0o700); err != nil {
+				t.Fatalf("write fake amq: %v", err)
+			}
+			t.Setenv("AMQ_KEEPALIVE_AMQ_CALLS", amqCalls)
+			var stderr bytes.Buffer
+			code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr}).Run(context.Background(), []string{
+				"attach", "--registry", registryPath, "--adapter", "file", "--target", target,
+				"--root", root, "--base-root", dir, "--session", "amq-root", "--me", "codex", "--amq", fakeAMQ,
+			})
+			if code == 0 {
+				t.Fatalf("attach code=0 stderr=%s, want refusal", stderr.String())
+			}
+			if _, err := os.Stat(amqCalls); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("refused attach started a wake: stat err=%v", err)
+			}
+		})
+	}
+}
+
+func TestCanonicalExistingPathFailsClosedOnELOOPAndEACCES(t *testing.T) {
+	dir := t.TempDir()
+	loopA := filepath.Join(dir, "loop-a")
+	loopB := filepath.Join(dir, "loop-b")
+	if err := os.Symlink(loopB, loopA); err != nil {
+		t.Fatalf("Symlink A: %v", err)
+	}
+	if err := os.Symlink(loopA, loopB); err != nil {
+		t.Fatalf("Symlink B: %v", err)
+	}
+	got, err := canonicalExistingPath(loopA)
+	if err == nil || got != "" {
+		t.Fatalf("canonicalExistingPath(ELOOP) = %q, %v; want error not identity", got, err)
+	}
+	if !errors.Is(err, syscall.ELOOP) && !strings.Contains(strings.ToLower(err.Error()), "too many links") {
+		t.Fatalf("canonicalExistingPath(ELOOP) error = %v, want ELOOP", err)
+	}
+
+	denied := filepath.Join(dir, "denied")
+	if err := os.Mkdir(denied, 0o700); err != nil {
+		t.Fatalf("Mkdir denied: %v", err)
+	}
+	child := filepath.Join(denied, "root")
+	if err := os.Mkdir(child, 0o700); err != nil {
+		t.Fatalf("Mkdir child: %v", err)
+	}
+	if err := os.Chmod(denied, 0); err != nil {
+		t.Fatalf("Chmod denied: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(denied, 0o700) })
+	got, err = canonicalExistingPath(child)
+	_ = os.Chmod(denied, 0o700)
+	if err == nil || got != "" {
+		t.Fatalf("canonicalExistingPath(EACCES) = %q, %v; want error not identity", got, err)
+	}
+	if !errors.Is(err, syscall.EACCES) && !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("canonicalExistingPath(EACCES) error = %v, want EACCES", err)
+	}
+}

--- a/internal/keepalive/registry/canonical_other.go
+++ b/internal/keepalive/registry/canonical_other.go
@@ -1,0 +1,12 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package registry
+
+import (
+	"errors"
+	"os"
+)
+
+func uncertainSymlinkResolution(err error) bool {
+	return errors.Is(err, os.ErrPermission)
+}

--- a/internal/keepalive/registry/canonical_unix.go
+++ b/internal/keepalive/registry/canonical_unix.go
@@ -1,0 +1,13 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package registry
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+)
+
+func uncertainSymlinkResolution(err error) bool {
+	return errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.ELOOP) || strings.Contains(strings.ToLower(err.Error()), "too many links")
+}

--- a/internal/keepalive/registry/store.go
+++ b/internal/keepalive/registry/store.go
@@ -58,6 +58,28 @@ type Store struct {
 var ErrCorrupt = errors.New("registry file is corrupt")
 var ErrTargetOwned = errors.New("adapter target is already owned")
 var ErrRegistrationOwned = errors.New("AMQ root and agent already have a wake registration")
+var ErrInvalidIdentity = errors.New("registry entry identity is invalid")
+
+// CommittedDurabilityError means the registry rename succeeded, but chmod or
+// parent-directory sync could not finish. The visible file at Path is already
+// the committed artifact; retrying with a new write may duplicate it.
+type CommittedDurabilityError struct {
+	Path string
+	Err  error
+}
+
+func (e *CommittedDurabilityError) Error() string {
+	return fmt.Sprintf("registry committed at %s, but durability is indeterminate: %v; do not retry blindly", e.Path, e.Err)
+}
+
+func (e *CommittedDurabilityError) Unwrap() error {
+	return e.Err
+}
+
+var finishCommittedRegistry = finishCommittedRegistryFile
+var chmodRegistryFile = os.Chmod
+var syncRegistryDir = syncDir
+var afterRegistryLockAcquired = func(_ *os.File, _ string) error { return nil }
 
 type EntryUpdate struct {
 	Before Entry
@@ -100,7 +122,8 @@ func EntryID(root, agent, adapterName, target string) string {
 }
 
 // CanonicalRoot returns the stable filesystem identity used for AMQ wake
-// ownership. Existing roots are resolved through symlinks; a not-yet-created
+// ownership. Existing roots are resolved through symlinks. EACCES and ELOOP
+// fail closed instead of falling back to a lexical spelling. A not-yet-created
 // root still receives an absolute, cleaned spelling so registration remains
 // deterministic before AMQ creates its layout.
 func CanonicalRoot(root string) (string, error) {
@@ -111,8 +134,12 @@ func CanonicalRoot(root string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if real, err := filepath.EvalSymlinks(abs); err == nil {
+	real, err := filepath.EvalSymlinks(abs)
+	if err == nil {
 		return real, nil
+	}
+	if uncertainSymlinkResolution(err) {
+		return "", fmt.Errorf("canonicalize root %q: %w", abs, err)
 	}
 	return abs, nil
 }
@@ -170,20 +197,25 @@ func (s *Store) WithRegistrationLockContext(ctx context.Context, fn func() error
 	if err := ensureRegistryDir(filepath.Dir(path)); err != nil {
 		return err
 	}
-	lock, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	lock, err := openPinnedLock(path)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = lock.Close() }()
-	if err := lock.Chmod(0o600); err != nil {
-		return err
-	}
 	for {
 		acquired, err := flockTryExclusive(lock)
 		if err != nil {
 			return err
 		}
 		if acquired {
+			if err := afterRegistryLockAcquired(lock, path); err != nil {
+				flockRelease(lock)
+				return err
+			}
+			if err := recheckLockIdentity(lock, path); err != nil {
+				flockRelease(lock)
+				return err
+			}
 			break
 		}
 		timer := time.NewTimer(25 * time.Millisecond)
@@ -219,6 +251,9 @@ func (s *Store) loadUnlocked() (File, error) {
 	if file.SchemaVersion != SchemaVersion {
 		return File{}, fmt.Errorf("unsupported registry schema version %d", file.SchemaVersion)
 	}
+	if err := validateFileIdentities(file); err != nil {
+		return File{}, fmt.Errorf("%w %q: %w", ErrCorrupt, s.Path, err)
+	}
 	sortEntries(file.Entries)
 	return file, nil
 }
@@ -234,6 +269,9 @@ func (s *Store) Save(file File) error {
 
 func (s *Store) saveUnlocked(file File) error {
 	file.SchemaVersion = SchemaVersion
+	if err := validateFileIdentities(file); err != nil {
+		return err
+	}
 	sortEntries(file.Entries)
 
 	dir := filepath.Dir(s.Path)
@@ -264,10 +302,17 @@ func (s *Store) saveUnlocked(file File) error {
 	if err := os.Rename(tmpName, s.Path); err != nil {
 		return err
 	}
-	if err := os.Chmod(s.Path, 0o600); err != nil {
-		return err
+	return finishCommittedRegistry(s.Path, dir)
+}
+
+func finishCommittedRegistryFile(path, dir string) error {
+	if err := chmodRegistryFile(path, 0o600); err != nil {
+		return &CommittedDurabilityError{Path: path, Err: err}
 	}
-	return syncDir(dir)
+	if err := syncRegistryDir(dir); err != nil {
+		return &CommittedDurabilityError{Path: path, Err: err}
+	}
+	return nil
 }
 
 func (s *Store) Upsert(entry Entry) (Entry, error) {
@@ -422,9 +467,11 @@ func (s *Store) prepareEntry(entry Entry) (Entry, error) {
 	if entry.Target == "" {
 		return Entry{}, errors.New("entry target is required")
 	}
-	if entry.ID == "" {
-		entry.ID = EntryID(entry.Root, entry.Agent, entry.Adapter, entry.Target)
+	wantID := EntryID(entry.Root, entry.Agent, entry.Adapter, entry.Target)
+	if entry.ID != "" && entry.ID != wantID {
+		return Entry{}, fmt.Errorf("%w: id %q does not match identity", ErrInvalidIdentity, entry.ID)
 	}
+	entry.ID = wantID
 	if entry.State == "" {
 		entry.State = StateAttached
 	}
@@ -442,6 +489,12 @@ func (s *Store) UpdateEntry(entry Entry) error {
 		}
 		for i := range file.Entries {
 			if file.Entries[i].ID == entry.ID {
+				if err := validateEntryIdentity(entry); err != nil {
+					return err
+				}
+				if !sameEntryIdentity(file.Entries[i], entry) {
+					return fmt.Errorf("%w: entry %q identity fields are immutable", ErrInvalidIdentity, entry.ID)
+				}
 				file.Entries[i] = entry
 				return s.saveUnlocked(file)
 			}
@@ -463,6 +516,9 @@ func (s *Store) UpdateEntries(updates []EntryUpdate) (UpdateResult, error) {
 		}
 		if update.Before.ID != update.After.ID {
 			return result, fmt.Errorf("batch update changes entry id from %q to %q", update.Before.ID, update.After.ID)
+		}
+		if !sameEntryIdentity(update.Before, update.After) {
+			return result, fmt.Errorf("%w: entry %q identity fields are immutable", ErrInvalidIdentity, update.Before.ID)
 		}
 		if _, ok := seen[update.Before.ID]; ok {
 			return result, fmt.Errorf("batch update contains duplicate entry %q", update.Before.ID)
@@ -490,6 +546,9 @@ func (s *Store) UpdateEntries(updates []EntryUpdate) (UpdateResult, error) {
 			}
 			if update.Before == update.After {
 				continue
+			}
+			if !sameEntryIdentity(file.Entries[i], update.After) {
+				return fmt.Errorf("%w: entry %q identity fields are immutable", ErrInvalidIdentity, update.After.ID)
 			}
 			file.Entries[i] = update.After
 			result.Updated++
@@ -619,8 +678,24 @@ func sameRegistration(left, right Entry) bool {
 		canonicalStoredTarget(left.Adapter, left.Target) == canonicalStoredTarget(right.Adapter, right.Target)
 }
 
+func sameEntryIdentity(left, right Entry) bool {
+	return left.ID == right.ID &&
+		left.Root == right.Root &&
+		left.Agent == right.Agent &&
+		left.Adapter == right.Adapter &&
+		left.Target == right.Target
+}
+
 func sameRootAgent(left, right Entry) bool {
-	return left.Agent == right.Agent && canonicalRoot(left.Root) == canonicalRoot(right.Root)
+	if left.Agent != right.Agent {
+		return false
+	}
+	leftRoot, leftErr := CanonicalRoot(left.Root)
+	rightRoot, rightErr := CanonicalRoot(right.Root)
+	if leftErr != nil || rightErr != nil {
+		return false
+	}
+	return leftRoot == rightRoot
 }
 
 func canonicalStoredTarget(adapterName, target string) string {
@@ -701,34 +776,84 @@ func (s *Store) withLock(fn func() error) error {
 		return err
 	}
 
-	lock, err := os.OpenFile(s.Path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	lockPath := s.Path + ".lock"
+	lock, err := openPinnedLock(lockPath)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = lock.Close() }()
-	if err := lock.Chmod(0o600); err != nil {
-		return err
-	}
 	if err := flockExclusive(lock); err != nil {
 		return err
 	}
 	defer flockRelease(lock)
+	if err := afterRegistryLockAcquired(lock, lockPath); err != nil {
+		return err
+	}
+	if err := recheckLockIdentity(lock, lockPath); err != nil {
+		return err
+	}
 
 	return fn()
 }
 
+func openPinnedLock(path string) (*os.File, error) {
+	lock, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|lockNoFollow, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := lock.Chmod(0o600); err != nil {
+		_ = lock.Close()
+		return nil, err
+	}
+	return lock, nil
+}
+
 func ensureRegistryDir(dir string) error {
-	_, err := os.Stat(dir)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
+	info, err := os.Lstat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return err
+		}
+		info, err = os.Lstat(dir)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
+	return validateRegistryDir(dir, info)
+}
+
+func validateFileIdentities(file File) error {
+	seen := make(map[string]struct{}, len(file.Entries))
+	for _, entry := range file.Entries {
+		if err := validateEntryIdentity(entry); err != nil {
+			return err
+		}
+		if _, ok := seen[entry.ID]; ok {
+			return fmt.Errorf("%w: duplicate entry id %q", ErrInvalidIdentity, entry.ID)
+		}
+		seen[entry.ID] = struct{}{}
 	}
-	return os.Chmod(dir, 0o700)
+	return nil
+}
+
+func validateEntryIdentity(entry Entry) error {
+	if entry.Agent == "" || entry.Adapter == "" || entry.Target == "" {
+		return fmt.Errorf("%w: entry %q is missing identity fields", ErrInvalidIdentity, entry.ID)
+	}
+	root, err := CanonicalRoot(entry.Root)
+	if err != nil {
+		return fmt.Errorf("%w: canonicalize entry %q root: %w", ErrInvalidIdentity, entry.ID, err)
+	}
+	want := EntryID(root, entry.Agent, entry.Adapter, entry.Target)
+	if entry.ID != want {
+		return fmt.Errorf("%w: entry id %q does not match identity", ErrInvalidIdentity, entry.ID)
+	}
+	return nil
 }
 
 func syncDir(dir string) error {

--- a/internal/keepalive/registry/store_other.go
+++ b/internal/keepalive/registry/store_other.go
@@ -1,0 +1,37 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package registry
+
+import (
+	"fmt"
+	"os"
+)
+
+const lockNoFollow = 0
+
+func validateRegistryDir(dir string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("registry directory %q must not be a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("registry directory %q must be a directory", dir)
+	}
+	if info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("registry directory %q must be mode 0700", dir)
+	}
+	return nil
+}
+
+func recheckLockIdentity(_ *os.File, path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("registry lock %q must be a regular file", path)
+	}
+	if info.Mode().Perm() != 0o600 {
+		return fmt.Errorf("registry lock %q must be mode 0600", path)
+	}
+	return nil
+}

--- a/internal/keepalive/registry/store_test.go
+++ b/internal/keepalive/registry/store_test.go
@@ -66,7 +66,7 @@ func TestStoreUpsertRoundTripAndPermissions(t *testing.T) {
 }
 
 func TestStoreForget(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	store := New(path)
 	entry, err := store.Upsert(Entry{
 		Root:    "/tmp/amq-root",
@@ -95,7 +95,7 @@ func TestStoreForget(t *testing.T) {
 }
 
 func TestStoreForgetManyRemovesRequestedEntriesInOneSave(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	store := New(path)
 	var ids []string
 	for _, agent := range []string{"codex", "claude", "observer"} {
@@ -119,7 +119,7 @@ func TestStoreForgetManyRemovesRequestedEntriesInOneSave(t *testing.T) {
 }
 
 func TestStoreForgetManyRefusesPartialMatchWithoutRemovingAnything(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	store := New(path)
 	entry, err := store.Upsert(Entry{Root: "/tmp/amq-root", Agent: "codex", Adapter: "file", Target: "/tmp/codex"})
 	if err != nil {
@@ -136,7 +136,7 @@ func TestStoreForgetManyRefusesPartialMatchWithoutRemovingAnything(t *testing.T)
 }
 
 func TestStoreRejectsSecondOwnerForSameAdapterTarget(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	target := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	if _, err := store.Upsert(Entry{Root: "/tmp/first", Agent: "codex", Adapter: "cmux", Target: target}); err != nil {
 		t.Fatalf("Upsert(first) error = %v", err)
@@ -152,7 +152,7 @@ func TestStoreRejectsSecondOwnerForSameAdapterTarget(t *testing.T) {
 }
 
 func TestStoreRejectsSecondRegistrationForSameRootAndAgentAcrossAdapters(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	first, err := store.Upsert(Entry{Root: "/tmp/amq-root", Agent: "codex", Adapter: "file", Target: "/tmp/first.txt"})
 	if err != nil {
 		t.Fatalf("Upsert(first) error = %v", err)
@@ -169,6 +169,9 @@ func TestStoreRejectsSecondRegistrationForSameRootAndAgentAcrossAdapters(t *test
 
 func TestStoreUsesCanonicalRootForRegistrationOwnershipAndReattach(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	realRoot := filepath.Join(dir, "real-root")
 	if err := os.Mkdir(realRoot, 0o700); err != nil {
 		t.Fatalf("Mkdir real root: %v", err)
@@ -209,6 +212,9 @@ func TestStoreUsesCanonicalRootForRegistrationOwnershipAndReattach(t *testing.T)
 
 func TestStoreUpsertRewritesEquivalentLegacyRootAlias(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	realRoot := filepath.Join(dir, "real-root")
 	if err := os.Mkdir(realRoot, 0o700); err != nil {
 		t.Fatalf("Mkdir real root: %v", err)
@@ -223,7 +229,7 @@ func TestStoreUpsertRewritesEquivalentLegacyRootAlias(t *testing.T) {
 	}
 	target := filepath.Join(dir, "inbox.txt")
 	legacy := Entry{
-		ID:      "legacy-alias-id",
+		ID:      EntryID(aliasRoot, "codex", "file", target),
 		Root:    aliasRoot,
 		Agent:   "codex",
 		Adapter: "file",
@@ -245,7 +251,7 @@ func TestStoreUpsertRewritesEquivalentLegacyRootAlias(t *testing.T) {
 }
 
 func TestStoreRejectsCanonicalCmuxTargetOwnedByLegacyLowercaseRow(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	lower := "cmux:surface:f901d722-6789-4bbb-9818-c4e97f20beb3"
 	legacy := Entry{
 		ID: EntryID("/tmp/first", "codex", "cmux", lower), Root: "/tmp/first", Agent: "codex",
@@ -266,9 +272,9 @@ func TestStoreRejectsCanonicalCmuxTargetOwnedByLegacyLowercaseRow(t *testing.T) 
 }
 
 func TestStoreRejectsCanonicalGhosttyTargetOwnedByLegacyLowercaseRow(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	legacy := Entry{
-		ID: "legacy-ghostty-id", Root: "/tmp/first", Agent: "codex",
+		ID: EntryID("/tmp/first", "codex", "ghostty", "ghostty:terminal:terminal-1"), Root: "/tmp/first", Agent: "codex",
 		Adapter: "ghostty", Target: "ghostty:terminal:terminal-1", State: StateActive,
 	}
 	if err := store.Save(File{Entries: []Entry{legacy}}); err != nil {
@@ -286,6 +292,9 @@ func TestStoreRejectsCanonicalGhosttyTargetOwnedByLegacyLowercaseRow(t *testing.
 
 func TestStoreRejectsFileTargetOwnedByLegacySymlinkAlias(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	realParent := filepath.Join(dir, "real")
 	if err := os.Mkdir(realParent, 0o700); err != nil {
 		t.Fatalf("Mkdir real parent: %v", err)
@@ -295,7 +304,7 @@ func TestStoreRejectsFileTargetOwnedByLegacySymlinkAlias(t *testing.T) {
 		t.Fatalf("Symlink file target parent: %v", err)
 	}
 	legacy := Entry{
-		ID: "legacy-file-id", Root: "/tmp/first", Agent: "codex",
+		ID: EntryID("/tmp/first", "codex", "file", filepath.Join(aliasParent, "inbox.txt")), Root: "/tmp/first", Agent: "codex",
 		Adapter: "file", Target: filepath.Join(aliasParent, "inbox.txt"), State: StateActive,
 	}
 	store := New(filepath.Join(dir, "registry.json"))
@@ -315,7 +324,7 @@ func TestStoreRejectsFileTargetOwnedByLegacySymlinkAlias(t *testing.T) {
 }
 
 func TestRegistrationLockWaitHonorsContextCancellation(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	done := make(chan error, 1)
@@ -344,7 +353,7 @@ func TestRegistrationLockWaitHonorsContextCancellation(t *testing.T) {
 }
 
 func TestStoreReplacePreflightRejectsTargetOwnedByDifferentSession(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	target := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	if _, err := store.Upsert(Entry{Root: "/tmp/first", Agent: "codex", Adapter: "cmux", Target: target}); err != nil {
 		t.Fatalf("Upsert(first) error = %v", err)
@@ -356,7 +365,7 @@ func TestStoreReplacePreflightRejectsTargetOwnedByDifferentSession(t *testing.T)
 }
 
 func TestStoreBatchUpdateCASPreservesConcurrentChangesAndNewEntries(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	first, err := store.Upsert(Entry{Root: "/tmp/first", Agent: "codex", Adapter: "file", Target: "/tmp/first.txt"})
 	if err != nil {
 		t.Fatalf("Upsert(first): %v", err)
@@ -413,7 +422,7 @@ func TestStoreBatchUpdateCASPreservesConcurrentChangesAndNewEntries(t *testing.T
 }
 
 func TestStoreForgetIfUnchangedSkipsNewerState(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	entry, err := store.Upsert(Entry{Root: "/tmp/root", Agent: "codex", Adapter: "file", Target: "/tmp/inbox.txt"})
 	if err != nil {
 		t.Fatalf("Upsert: %v", err)
@@ -429,35 +438,8 @@ func TestStoreForgetIfUnchangedSkipsNewerState(t *testing.T) {
 	}
 }
 
-func TestStoreDoesNotChmodExistingCustomRegistryDir(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "custom")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	if err := os.Chmod(dir, 0o755); err != nil {
-		t.Fatalf("Chmod() error = %v", err)
-	}
-	store := New(filepath.Join(dir, "registry.json"))
-	_, err := store.Upsert(Entry{
-		Root:    "/tmp/amq-root",
-		Agent:   "codex",
-		Adapter: "file",
-		Target:  "/tmp/inbox.txt",
-	})
-	if err != nil {
-		t.Fatalf("Upsert() error = %v", err)
-	}
-	info, err := os.Stat(dir)
-	if err != nil {
-		t.Fatalf("Stat() error = %v", err)
-	}
-	if got := info.Mode().Perm(); got != 0o755 {
-		t.Fatalf("dir mode = %v, want existing 0755 preserved", got)
-	}
-}
-
 func TestStoreReplaceSessionAdapterRemovesAllEntriesForRootAndAgent(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	store := New(path)
 
 	replaceMe, err := store.Upsert(Entry{
@@ -479,6 +461,7 @@ func TestStoreReplaceSessionAdapterRemovesAllEntriesForRootAndAgent(t *testing.T
 		t.Fatalf("Upsert(keepDifferentAgent) error = %v", err)
 	}
 	replaceDifferentAdapter := Entry{
+		ID:      EntryID("/tmp/amq-root", "codex", "ghostty", "ghostty:terminal:old"),
 		Root:    "/tmp/amq-root",
 		Agent:   "codex",
 		Adapter: "ghostty",
@@ -536,7 +519,7 @@ func TestStoreReplaceSessionAdapterRemovesAllEntriesForRootAndAgent(t *testing.T
 }
 
 func TestStoreRestoresPreviousRowsOnlyWhileReservationIsUnchanged(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	previous, err := store.Upsert(Entry{Root: "/tmp/root", Agent: "codex", Adapter: "file", Target: "/tmp/old"})
 	if err != nil {
 		t.Fatalf("Upsert previous: %v", err)
@@ -574,7 +557,7 @@ func TestStoreRestoresPreviousRowsOnlyWhileReservationIsUnchanged(t *testing.T) 
 }
 
 func TestStoreConcurrentUpsertsDoNotLoseEntries(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	store := New(path)
 
 	var wg sync.WaitGroup
@@ -605,7 +588,7 @@ func TestStoreConcurrentUpsertsDoNotLoseEntries(t *testing.T) {
 }
 
 func TestStoreConcurrentSameTargetReplacementsConverge(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	store := New(path)
 	if _, err := store.Upsert(Entry{
 		Root:    "/tmp/amq-root",
@@ -644,7 +627,7 @@ func TestStoreConcurrentSameTargetReplacementsConverge(t *testing.T) {
 }
 
 func TestStoreCorruptRegistryReturnsTypedError(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	if err := os.WriteFile(path, []byte("{not-json"), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
@@ -657,7 +640,7 @@ func TestStoreCorruptRegistryReturnsTypedError(t *testing.T) {
 }
 
 func TestStoreLoadsSchemaZeroAsCurrent(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	if err := os.WriteFile(path, []byte(`{"entries":[]}`), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -671,7 +654,7 @@ func TestStoreLoadsSchemaZeroAsCurrent(t *testing.T) {
 }
 
 func TestStoreSaveReportsRenameFailure(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "registry.json")
+	path := registryTestPath(t)
 	if err := os.Mkdir(path, 0o700); err != nil {
 		t.Fatalf("Mkdir registry destination: %v", err)
 	}
@@ -680,8 +663,66 @@ func TestStoreSaveReportsRenameFailure(t *testing.T) {
 	}
 }
 
+func TestStoreSaveReportsCommittedDurabilityError(t *testing.T) {
+	previous := finishCommittedRegistry
+	t.Cleanup(func() { finishCommittedRegistry = previous })
+	finishCommittedRegistry = func(path, _ string) error {
+		return &CommittedDurabilityError{Path: path, Err: errors.New("sync failed")}
+	}
+	path := registryTestPath(t)
+	err := New(path).Save(File{})
+	var committed *CommittedDurabilityError
+	if !errors.As(err, &committed) || committed.Path != path {
+		t.Fatalf("Save error = %T %v, want CommittedDurabilityError for %q", err, err, path)
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("committed registry missing after durability error: %v", statErr)
+	}
+}
+
+func TestStoreSaveWrapsPostRenameChmodAndSyncFailures(t *testing.T) {
+	previousChmod, previousSync := chmodRegistryFile, syncRegistryDir
+	t.Cleanup(func() {
+		chmodRegistryFile = previousChmod
+		syncRegistryDir = previousSync
+	})
+
+	for _, test := range []struct {
+		name  string
+		setup func()
+	}{
+		{
+			name: "chmod",
+			setup: func() {
+				chmodRegistryFile = func(string, os.FileMode) error { return errors.New("chmod failed") }
+				syncRegistryDir = previousSync
+			},
+		},
+		{
+			name: "sync",
+			setup: func() {
+				chmodRegistryFile = previousChmod
+				syncRegistryDir = func(string) error { return errors.New("sync failed") }
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			test.setup()
+			path := registryTestPath(t)
+			err := New(path).Save(File{})
+			var committed *CommittedDurabilityError
+			if !errors.As(err, &committed) || committed.Path != path {
+				t.Fatalf("Save error = %T %v, want committed durability error for %q", err, err, path)
+			}
+			if _, statErr := os.Stat(path); statErr != nil {
+				t.Fatalf("committed registry missing after %s failure: %v", test.name, statErr)
+			}
+		})
+	}
+}
+
 func TestStoreRestoreMissingReservationIsNoOp(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	existing, err := store.Upsert(Entry{Root: "/tmp/root", Agent: "codex", Adapter: "file", Target: "/tmp/current"})
 	if err != nil {
 		t.Fatalf("Upsert: %v", err)
@@ -699,7 +740,7 @@ func TestStoreRestoreMissingReservationIsNoOp(t *testing.T) {
 }
 
 func TestStoreUpdateEntriesRejectsEitherMissingID(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	before := Entry{ID: "entry-1"}
 	after := before
 	for _, test := range []struct {
@@ -718,8 +759,33 @@ func TestStoreUpdateEntriesRejectsEitherMissingID(t *testing.T) {
 	}
 }
 
+func TestStoreUpdatesRejectIdentityFieldChanges(t *testing.T) {
+	store := New(registryTestPath(t))
+	entry, err := store.Upsert(Entry{Root: "/tmp/root", Agent: "codex", Adapter: "file", Target: "/tmp/inbox"})
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	changed := entry
+	changed.Agent = "claude"
+	if err := store.UpdateEntry(changed); !errors.Is(err, ErrInvalidIdentity) {
+		t.Fatalf("UpdateEntry identity change error = %v, want ErrInvalidIdentity", err)
+	}
+
+	changed = entry
+	changed.Target = "/tmp/other"
+	result, err := store.UpdateEntries([]EntryUpdate{{Before: entry, After: changed}})
+	if !errors.Is(err, ErrInvalidIdentity) || result.Updated != 0 {
+		t.Fatalf("UpdateEntries identity change result=%+v err=%v, want immutable identity refusal", result, err)
+	}
+	loaded, err := store.Load()
+	if err != nil || len(loaded.Entries) != 1 || loaded.Entries[0] != entry {
+		t.Fatalf("identity change mutated registry: entries=%#v err=%v", loaded.Entries, err)
+	}
+}
+
 func TestStoreForgetIfUnchangedDoesNotRemoveAnotherEntry(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	first, err := store.Upsert(Entry{Root: "/tmp/first", Agent: "codex", Adapter: "file", Target: "/tmp/first"})
 	if err != nil {
 		t.Fatalf("Upsert first: %v", err)
@@ -743,7 +809,7 @@ func TestStoreForgetIfUnchangedDoesNotRemoveAnotherEntry(t *testing.T) {
 }
 
 func TestStoreForgetIfUnchangedRemovesExactLaterEntry(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
+	store := New(registryTestPath(t))
 	first, err := store.Upsert(Entry{Root: "/tmp/first", Agent: "codex", Adapter: "file", Target: "/tmp/first"})
 	if err != nil {
 		t.Fatalf("Upsert first: %v", err)
@@ -763,16 +829,28 @@ func TestStoreForgetIfUnchangedRemovesExactLaterEntry(t *testing.T) {
 }
 
 func TestStoreSortsEntriesByID(t *testing.T) {
-	store := New(filepath.Join(t.TempDir(), "registry.json"))
-	if err := store.Save(File{Entries: []Entry{{ID: "z-entry"}, {ID: "a-entry"}}}); err != nil {
-		t.Fatalf("Save: %v", err)
+	store := New(registryTestPath(t))
+	second, err := store.Upsert(Entry{Root: "/tmp/z", Agent: "codex", Adapter: "file", Target: "/tmp/z"})
+	if err != nil {
+		t.Fatalf("Upsert second: %v", err)
+	}
+	first, err := store.Upsert(Entry{Root: "/tmp/a", Agent: "claude", Adapter: "file", Target: "/tmp/a"})
+	if err != nil {
+		t.Fatalf("Upsert first: %v", err)
 	}
 	loaded, err := store.Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(loaded.Entries) != 2 || loaded.Entries[0].ID != "a-entry" || loaded.Entries[1].ID != "z-entry" {
+	if len(loaded.Entries) != 2 {
+		t.Fatalf("entries = %#v, want 2", loaded.Entries)
+	}
+	if loaded.Entries[0].ID > loaded.Entries[1].ID {
 		t.Fatalf("entries = %#v, want ascending IDs", loaded.Entries)
+	}
+	seen := map[string]bool{loaded.Entries[0].ID: true, loaded.Entries[1].ID: true}
+	if !seen[first.ID] || !seen[second.ID] {
+		t.Fatalf("entries = %#v, want IDs %q and %q", loaded.Entries, first.ID, second.ID)
 	}
 }
 
@@ -781,7 +859,7 @@ func TestStoreRegistrationOwnershipRequiresSameAdapterAndTarget(t *testing.T) {
 		{Root: "/tmp/root", Agent: "codex", Adapter: "file", Target: "/tmp/different"},
 		{Root: "/tmp/root", Agent: "codex", Adapter: "ghostty", Target: "/tmp/original"},
 	} {
-		store := New(filepath.Join(t.TempDir(), "registry.json"))
+		store := New(registryTestPath(t))
 		original, err := store.Upsert(Entry{Root: "/tmp/root", Agent: "codex", Adapter: "file", Target: "/tmp/original"})
 		if err != nil {
 			t.Fatalf("Upsert original: %v", err)
@@ -803,4 +881,13 @@ func findTestEntry(entries []Entry, id string) (Entry, bool) {
 		}
 	}
 	return Entry{}, false
+}
+
+func registryTestPath(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), ".amq-keepalive")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("Mkdir registry test dir: %v", err)
+	}
+	return filepath.Join(dir, "registry.json")
 }

--- a/internal/keepalive/registry/store_unix.go
+++ b/internal/keepalive/registry/store_unix.go
@@ -1,0 +1,55 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package registry
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const lockNoFollow = syscall.O_NOFOLLOW
+
+func validateRegistryDir(dir string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("registry directory %q must not be a symlink", dir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("registry directory %q must be a directory", dir)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("registry directory %q has unavailable ownership metadata", dir)
+	}
+	if uint32(stat.Uid) != uint32(os.Geteuid()) {
+		return fmt.Errorf("registry directory %q is owned by uid %d, want current uid %d", dir, stat.Uid, os.Geteuid())
+	}
+	if info.Mode().Perm() != 0o700 {
+		return fmt.Errorf("registry directory %q must be mode 0700", dir)
+	}
+	return nil
+}
+
+func recheckLockIdentity(lock *os.File, path string) error {
+	var fdStat syscall.Stat_t
+	if err := syscall.Fstat(int(lock.Fd()), &fdStat); err != nil {
+		return err
+	}
+	var pathStat syscall.Stat_t
+	if err := syscall.Lstat(path, &pathStat); err != nil {
+		return err
+	}
+	if fdStat.Dev != pathStat.Dev || fdStat.Ino != pathStat.Ino {
+		return fmt.Errorf("registry lock %q was replaced", path)
+	}
+	if fdStat.Mode&syscall.S_IFMT != syscall.S_IFREG {
+		return fmt.Errorf("registry lock %q is not a regular file", path)
+	}
+	if fdStat.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("registry lock %q is owned by uid %d, want current uid %d", path, fdStat.Uid, os.Geteuid())
+	}
+	if fdStat.Mode&0o777 != 0o600 {
+		return fmt.Errorf("registry lock %q must be mode 0600", path)
+	}
+	return nil
+}

--- a/internal/keepalive/registry/store_unix_test.go
+++ b/internal/keepalive/registry/store_unix_test.go
@@ -1,0 +1,253 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package registry
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestStoreRefusesHostileRegistryIdentity(t *testing.T) {
+	sample := Entry{Root: "/tmp/amq-root", Agent: "codex", Adapter: "file", Target: "/tmp/inbox.txt"}
+
+	t.Run("symlink dir", func(t *testing.T) {
+		base := t.TempDir()
+		realDir := filepath.Join(base, "real")
+		if err := os.Mkdir(realDir, 0o700); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		linkDir := filepath.Join(base, "link")
+		if err := os.Symlink(realDir, linkDir); err != nil {
+			t.Fatalf("Symlink: %v", err)
+		}
+		_, err := New(filepath.Join(linkDir, "registry.json")).Upsert(sample)
+		if err == nil {
+			t.Fatal("Upsert error = nil, want symlink registry dir refusal")
+		}
+		if _, statErr := os.Stat(filepath.Join(realDir, "registry.json")); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("followed symlink registry dir: stat err=%v", statErr)
+		}
+	})
+
+	t.Run("wrong mode", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "registry-dir")
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		if err := os.Chmod(dir, 0o755); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		if _, err := New(filepath.Join(dir, "registry.json")).Upsert(sample); err == nil {
+			t.Fatal("Upsert error = nil, want 0755 registry dir refusal")
+		}
+	})
+
+	t.Run("wrong owner", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "registry-dir")
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		if err := os.Lchown(dir, os.Getuid()+1, -1); err != nil {
+			t.Skipf("cannot chown registry dir: %v", err)
+		}
+		if _, err := New(filepath.Join(dir, "registry.json")).Upsert(sample); err == nil {
+			t.Fatal("Upsert error = nil, want foreign-owner registry dir refusal")
+		}
+	})
+
+	t.Run("lock symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		victim := filepath.Join(dir, "victim")
+		if err := os.WriteFile(victim, []byte("keep\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.Symlink(victim, filepath.Join(dir, "registry.json.lock")); err != nil {
+			t.Fatalf("Symlink lock: %v", err)
+		}
+		if _, err := New(filepath.Join(dir, "registry.json")).Upsert(sample); err == nil {
+			t.Fatal("Upsert error = nil, want nofollow lock refusal")
+		}
+		got, err := os.ReadFile(victim)
+		if err != nil || string(got) != "keep\n" {
+			t.Fatalf("lock symlink followed: contents=%q err=%v", got, err)
+		}
+	})
+
+	t.Run("lock replacement", func(t *testing.T) {
+		dir := t.TempDir()
+		lockPath := filepath.Join(dir, "registry.json.lock")
+		lock, err := openPinnedLock(lockPath)
+		if err != nil {
+			t.Fatalf("openPinnedLock: %v", err)
+		}
+		defer func() { _ = lock.Close() }()
+		if err := flockExclusive(lock); err != nil {
+			t.Fatalf("flockExclusive: %v", err)
+		}
+		defer flockRelease(lock)
+		if err := os.Remove(lockPath); err != nil {
+			t.Fatalf("Remove lock: %v", err)
+		}
+		if err := os.WriteFile(lockPath, []byte("replacement\n"), 0o600); err != nil {
+			t.Fatalf("WriteFile replacement: %v", err)
+		}
+		if err := recheckLockIdentity(lock, lockPath); err == nil {
+			t.Fatal("recheckLockIdentity error = nil, want replacement refusal")
+		}
+	})
+
+	t.Run("duplicate and mismatched ids", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "registry.json")
+		valid := Entry{
+			ID: EntryID("/tmp/first", "codex", "file", "/tmp/first"), Root: "/tmp/first",
+			Agent: "codex", Adapter: "file", Target: "/tmp/first", State: StateAttached,
+		}
+		writeRawRegistry(t, path, []Entry{valid, valid})
+		if _, err := New(path).Load(); !errors.Is(err, ErrCorrupt) && !errors.Is(err, ErrInvalidIdentity) {
+			t.Fatalf("Load(duplicate id) error = %v, want identity refusal", err)
+		}
+
+		mismatched := valid
+		mismatched.ID = "not-the-identity-hash"
+		writeRawRegistry(t, path, []Entry{mismatched})
+		if _, err := New(path).Load(); !errors.Is(err, ErrCorrupt) && !errors.Is(err, ErrInvalidIdentity) {
+			t.Fatalf("Load(mismatched id) error = %v, want identity refusal", err)
+		}
+
+		store := New(filepath.Join(dir, "live.json"))
+		victim, err := store.Upsert(valid)
+		if err != nil {
+			t.Fatalf("Upsert victim: %v", err)
+		}
+		_, err = store.Upsert(Entry{
+			ID: victim.ID, Root: "/tmp/other", Agent: "claude", Adapter: "file", Target: "/tmp/other",
+		})
+		if !errors.Is(err, ErrInvalidIdentity) {
+			t.Fatalf("Upsert(stolen id) error = %v, want ErrInvalidIdentity", err)
+		}
+		loaded, loadErr := store.Load()
+		if loadErr != nil || len(loaded.Entries) != 1 || loaded.Entries[0].ID != victim.ID {
+			t.Fatalf("stolen-id upsert replaced victim: entries=%#v err=%v", loaded.Entries, loadErr)
+		}
+	})
+
+	t.Run("ELOOP and EACCES", func(t *testing.T) {
+		dir := t.TempDir()
+		loopA := filepath.Join(dir, "loop-a")
+		loopB := filepath.Join(dir, "loop-b")
+		if err := os.Symlink(loopB, loopA); err != nil {
+			t.Fatalf("Symlink A: %v", err)
+		}
+		if err := os.Symlink(loopA, loopB); err != nil {
+			t.Fatalf("Symlink B: %v", err)
+		}
+		got, err := CanonicalRoot(loopA)
+		if err == nil || got != "" {
+			t.Fatalf("CanonicalRoot(ELOOP) = %q, %v; want error not identity", got, err)
+		}
+		if !errors.Is(err, syscall.ELOOP) && !strings.Contains(strings.ToLower(err.Error()), "too many links") {
+			t.Fatalf("CanonicalRoot(ELOOP) error = %v, want ELOOP", err)
+		}
+		absLoop, _ := filepath.Abs(loopA)
+		if got == absLoop || got == loopA {
+			t.Fatalf("CanonicalRoot(ELOOP) minted lexical identity %q", got)
+		}
+
+		denied := filepath.Join(dir, "denied")
+		if err := os.Mkdir(denied, 0o700); err != nil {
+			t.Fatalf("Mkdir denied: %v", err)
+		}
+		child := filepath.Join(denied, "root")
+		if err := os.Mkdir(child, 0o700); err != nil {
+			t.Fatalf("Mkdir child: %v", err)
+		}
+		if err := os.Chmod(denied, 0); err != nil {
+			t.Fatalf("Chmod denied: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(denied, 0o700) })
+		got, err = CanonicalRoot(child)
+		_ = os.Chmod(denied, 0o700)
+		if err == nil || got != "" {
+			t.Fatalf("CanonicalRoot(EACCES) = %q, %v; want error not identity", got, err)
+		}
+		if !errors.Is(err, syscall.EACCES) && !errors.Is(err, os.ErrPermission) {
+			t.Fatalf("CanonicalRoot(EACCES) error = %v, want EACCES", err)
+		}
+	})
+}
+
+func TestStoreRefusesLockReplacementAtAcquisitionSeam(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*Store) (error, bool)
+	}{
+		{
+			name: "ordinary mutation lock",
+			run: func(store *Store) (error, bool) {
+				_, err := store.Upsert(Entry{Root: "/tmp/seam", Agent: "codex", Adapter: "file", Target: "/tmp/seam"})
+				return err, false
+			},
+		},
+		{
+			name: "registration lock",
+			run: func(store *Store) (error, bool) {
+				called := false
+				err := store.WithRegistrationLock(func() error {
+					called = true
+					return nil
+				})
+				return err, called
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := New(registryTestPath(t))
+			replaced := false
+			previous := afterRegistryLockAcquired
+			t.Cleanup(func() { afterRegistryLockAcquired = previous })
+			afterRegistryLockAcquired = func(_ *os.File, lockPath string) error {
+				if replaced {
+					t.Fatal("lock replacement seam called more than once")
+				}
+				replaced = true
+				if err := os.Remove(lockPath); err != nil {
+					return err
+				}
+				return os.WriteFile(lockPath, []byte("replacement\n"), 0o600)
+			}
+
+			err, called := tt.run(store)
+			if err == nil {
+				t.Fatal("operation error = nil, want refusal after lock replacement")
+			}
+			if called {
+				t.Fatal("registration callback ran after lock replacement")
+			}
+			if !replaced {
+				t.Fatal("lock replacement seam was not called")
+			}
+		})
+	}
+}
+
+func writeRawRegistry(t *testing.T, path string, entries []Entry) {
+	t.Helper()
+	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("Chmod registry dir: %v", err)
+	}
+	data, err := json.Marshal(File{SchemaVersion: SchemaVersion, Entries: entries})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}


### PR DESCRIPTION
Bead amq-7qp — ChatGPT Pro review B findings 21, 22, 18, 33.

- Registry dir must be a real current-uid 0700 directory (no symlink follow); lock files open nofollow 0600 with a post-flock inode recheck proven at both call sites via an acquisition seam.
- Persisted registration IDs are recomputed and validated on load/save (duplicates and mismatches refused; identity fields immutable on update).
- EvalSymlinks EACCES/ELOOP fail closed across registry, wake locks, and app canonicalization (lexical fallback only for ENOENT); post-rename chmod/sync failures wrap as typed CommittedDurabilityError.

Review: execution-gated across three rounds; 9/9 mutants killed incl. the acquisition-seam wiring at both lock paths.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ