### PR TITLE
fix(fsq): make windows publication and dlq moves no-replace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       # tracked separately from this claim-exclusivity gate. read/monitor/DLQ
       # capture all claim through the same MoveNewToCur primitive proven here.
       - name: Claim primitive and maildir contracts
-        run: go test ./internal/fsq -run '^TestMoveNewToCur|^TestClaimRename|^TestClaimCollision|^TestClaimPinnedRoot|^TestMaildir' -count=1
+        run: go test ./internal/fsq -run '^TestMoveNewToCur|^TestClaimRename|^TestClaimCollision|^TestClaimPinnedRoot|^TestMaildir|^TestWindowsNoReplace' -count=1
       - name: Concurrent drain single-winner gate
         run: go test ./internal/cli -run '^TestDrainInboxItemsConcurrentClaimsSingleWinner$' -count=50
       - name: Drain claim path

--- a/internal/fsq/direct_child_rename_windows.go
+++ b/internal/fsq/direct_child_rename_windows.go
@@ -27,13 +27,16 @@ func (r *DeliveryRoot) renameDirectChildNoReplace(oldName, newName string) error
 	}
 	defer func() { _ = dir.Close() }()
 	dirHandle := windows.Handle(dir.Fd())
+	return renameWindowsNoReplace(dirHandle, oldName, dirHandle, newName)
+}
 
+func renameWindowsNoReplace(oldDir windows.Handle, oldName string, newDir windows.Handle, newName string) error {
 	objectName, err := windows.NewNTUnicodeString(oldName)
 	if err != nil {
 		return err
 	}
 	attributes := &windows.OBJECT_ATTRIBUTES{
-		Length: uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})), RootDirectory: dirHandle,
+		Length: uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})), RootDirectory: oldDir,
 		ObjectName: objectName, Attributes: windows.OBJ_CASE_INSENSITIVE,
 	}
 	var source windows.Handle
@@ -59,7 +62,7 @@ func (r *DeliveryRoot) renameDirectChildNoReplace(oldName, newName string) error
 	buffer := make([]byte, int(headerSize)+len(name)*2)
 	info := (*fileRenameInformationEx)(unsafe.Pointer(&buffer[0]))
 	info.Flags = windows.FILE_RENAME_POSIX_SEMANTICS
-	info.RootDirectory = dirHandle
+	info.RootDirectory = newDir
 	info.FileNameLength = uint32(len(name) * 2)
 	copy(unsafe.Slice(&info.FileName[0], len(name)), name)
 

--- a/internal/fsq/dlq.go
+++ b/internal/fsq/dlq.go
@@ -665,6 +665,8 @@ func FindDLQMessage(root *DeliveryRoot, agent, filename string) (string, string,
 }
 
 // MoveDLQNewToCur moves a DLQ message from new to cur (marks as inspected).
+var beforeMoveDLQNewToCurRenameForTest func(*DeliveryRoot, string, string)
+
 func MoveDLQNewToCur(root *DeliveryRoot, agent, filename string) error {
 	return root.WithDLQEnvelopeLock(agent, filename, func(batch *DeliveryRoot) error {
 		return moveDLQNewToCurLocked(batch, agent, filename)
@@ -689,7 +691,10 @@ func moveDLQNewToCurLocked(root *DeliveryRoot, agent, filename string) error {
 	} else if reconciled {
 		return nil
 	}
-	if err := root.root.Rename(newPath, curPath); err != nil {
+	if beforeMoveDLQNewToCurRenameForTest != nil {
+		beforeMoveDLQNewToCurRenameForTest(root, newPath, curPath)
+	}
+	if err := root.renameNoReplace(newPath, curPath); err != nil {
 		return err
 	}
 	var durabilityErr error

--- a/internal/fsq/dlq_noreplace_unix_test.go
+++ b/internal/fsq/dlq_noreplace_unix_test.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package fsq
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUnixNoReplaceDLQMovePreservesCollision(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	const filename = "unix-dlq-collision.md"
+	newPath := filepath.Join(AgentDLQNew(base, "alice"), filename)
+	curPath := filepath.Join(AgentDLQCur(base, "alice"), filename)
+	if err := os.WriteFile(newPath, []byte("new envelope"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := openDeliveryRootForTest(t, base)
+	oldHook := beforeMoveDLQNewToCurRenameForTest
+	beforeMoveDLQNewToCurRenameForTest = func(_ *DeliveryRoot, _, destination string) {
+		if err := os.WriteFile(filepath.Join(base, destination), []byte("retained envelope"), 0o600); err != nil {
+			t.Errorf("create racing DLQ cur: %v", err)
+		}
+	}
+	t.Cleanup(func() { beforeMoveDLQNewToCurRenameForTest = oldHook })
+	err := MoveDLQNewToCur(root, "alice", filename)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("DLQ no-replace move error = %T %v, want os.ErrExist", err, err)
+	}
+	got, readErr := os.ReadFile(curPath)
+	if readErr != nil || string(got) != "retained envelope" {
+		t.Fatalf("cur bytes = %q, %v; no-replace move must preserve destination", got, readErr)
+	}
+	got, readErr = os.ReadFile(newPath)
+	if readErr != nil || string(got) != "new envelope" {
+		t.Fatalf("new bytes = %q, %v; failed move must preserve source", got, readErr)
+	}
+}

--- a/internal/fsq/maildir_noreplace_windows_test.go
+++ b/internal/fsq/maildir_noreplace_windows_test.go
@@ -1,0 +1,88 @@
+//go:build windows
+
+package fsq
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsNoReplacePublicationPreservesCollisionAndIdempotence(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	const filename = "windows-collision.md"
+	retained := []byte("retained unread message")
+	conflict := []byte("different colliding message")
+	newPath := filepath.Join(AgentInboxNew(base, "alice"), filename)
+	if err := os.WriteFile(newPath, retained, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := openDeliveryRootForTest(t, base)
+	if _, err := DeliverToInbox(root, "alice", filename, conflict); !errors.Is(err, os.ErrExist) {
+		t.Fatalf("conflicting publication error = %T %v, want os.ErrExist", err, err)
+	}
+	got, err := os.ReadFile(newPath)
+	if err != nil || !bytes.Equal(got, retained) {
+		t.Fatalf("new bytes = %q, %v; collision must not replace unread mail", got, err)
+	}
+
+	if _, err := DeliverToInbox(root, "alice", filename, retained); err != nil {
+		t.Fatalf("identical-byte publication = %v, want idempotent success", err)
+	}
+	got, err = os.ReadFile(newPath)
+	if err != nil || !bytes.Equal(got, retained) {
+		t.Fatalf("idempotent new bytes = %q, %v", got, err)
+	}
+
+	entries, err := os.ReadDir(AgentInboxTmp(base, "alice"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("tmp entries = %d, want one retained conflicting attempt", len(entries))
+	}
+	leftover, err := os.ReadFile(filepath.Join(AgentInboxTmp(base, "alice"), entries[0].Name()))
+	if err != nil || !bytes.Equal(leftover, conflict) {
+		t.Fatalf("retained tmp bytes = %q, %v", leftover, err)
+	}
+}
+
+func TestWindowsNoReplaceDLQMovePreservesCollision(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureAgentDirs(base, "alice"); err != nil {
+		t.Fatalf("EnsureAgentDirs: %v", err)
+	}
+	const filename = "windows-dlq-collision.md"
+	newPath := filepath.Join(AgentDLQNew(base, "alice"), filename)
+	curPath := filepath.Join(AgentDLQCur(base, "alice"), filename)
+	if err := os.WriteFile(newPath, []byte("new envelope"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := openDeliveryRootForTest(t, base)
+	oldHook := beforeMoveDLQNewToCurRenameForTest
+	beforeMoveDLQNewToCurRenameForTest = func(_ *DeliveryRoot, _, destination string) {
+		if err := os.WriteFile(filepath.Join(base, destination), []byte("retained envelope"), 0o600); err != nil {
+			t.Errorf("create racing DLQ cur: %v", err)
+		}
+	}
+	t.Cleanup(func() { beforeMoveDLQNewToCurRenameForTest = oldHook })
+	err := MoveDLQNewToCur(root, "alice", filename)
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("DLQ no-replace move error = %T %v, want os.ErrExist", err, err)
+	}
+	got, readErr := os.ReadFile(curPath)
+	if readErr != nil || string(got) != "retained envelope" {
+		t.Fatalf("cur bytes = %q, %v; no-replace move must preserve destination", got, readErr)
+	}
+	got, readErr = os.ReadFile(newPath)
+	if readErr != nil || string(got) != "new envelope" {
+		t.Fatalf("new bytes = %q, %v; failed move must preserve source", got, readErr)
+	}
+}

--- a/internal/fsq/rename_noreplace_other.go
+++ b/internal/fsq/rename_noreplace_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package fsq
 

--- a/internal/fsq/rename_noreplace_windows.go
+++ b/internal/fsq/rename_noreplace_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package fsq
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// renameNoReplace publishes oldPath onto newPath without replacing an
+// existing destination. os.Root.Rename requests replacement semantics on
+// Windows, so publication uses the same exclusive NT disposition primitive
+// as the Windows claim path.
+func (r *DeliveryRoot) renameNoReplace(oldPath, newPath string) error {
+	oldDir, err := r.root.Open(filepath.Dir(oldPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = oldDir.Close() }()
+
+	newDir, err := r.root.Open(filepath.Dir(newPath))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = newDir.Close() }()
+
+	err = renameWindowsNoReplace(
+		windows.Handle(oldDir.Fd()), filepath.Base(oldPath),
+		windows.Handle(newDir.Fd()), filepath.Base(newPath),
+	)
+	if errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) ||
+		errors.Is(err, windows.ERROR_ALREADY_EXISTS) ||
+		errors.Is(err, windows.ERROR_FILE_EXISTS) {
+		return os.ErrExist
+	}
+	return windowsClaimError(err)
+}


### PR DESCRIPTION
Bead amq-1zy — Windows follow-up to amq-lzh (found in its review).

- Windows tmp→new publication and DLQ new→cur moves are no-replace: a `renameNoReplace` primitive reuses the proven `FileRenameInformationEx` pattern (no `FILE_RENAME_REPLACE_IF_EXISTS`), mapping collision statuses to `os.ErrExist`; the stdlib `os.Root.Rename` replace-if-exists behavior no longer silently overwrites unread mail on Windows.
- Collisions are exercised through `MoveDLQNewToCur` itself (race hook) and through publication, with identical-bytes idempotence preserved; the new `TestWindowsNoReplace*` tests run on the windows-latest CI job (regex extended).

Review: execution-gated; darwin-executable mutants killed, Windows behavior proven by the CI run on this PR.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ
