### PR TITLE
fix(keepalive): give the gc serialization test fixture a 0700 registry dir

### DIFF
--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -2083,7 +2083,7 @@ exit 1
 
 func TestGCApplyAndReattachSerializeNewGenerationSurvives(t *testing.T) {
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	liveRoot := filepath.Join(dir, "live-root")
 	staleRoot := filepath.Join(dir, "stale-root")
 	for _, root := range []string{liveRoot, staleRoot} {


### PR DESCRIPTION
Semantic conflict between #611 (registry 0700 validation) and #612 (gc serialization test): each was green against pre-merge main; together the gc test's fixture registry dir fails the new mode check, breaking every local gate and main's push CI. One-line fix: the fixture uses the existing 0700 `testRegistryPath` helper. Full `./internal/keepalive/app` suite green.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ