### PR TITLE
fix(wake): generation CAS for retire and fail-closed darwin signaling

### DIFF
--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -602,10 +602,13 @@ their own log growth.
 
 ### 9.3 JSON schema 1 vs. schema 2
 
-Schema 1 is the byte-compatible default. Schema 2 is explicit with
+Schema 1 is the byte-compatible default for a missing lock. Live or stale
+locks additionally report `wake_generation` and `wake_target_digest` when
+those values exist (omitted when empty). Schema 2 is explicit with
 `--json-schema=2` and requires `--json`. It replaces prose parsing with a
 closed action kind, actor, reason code, and an argv command object when one
-action is directly executable. Missing evidence is an explicit JSON `null`;
+action is directly executable. Missing evidence is an explicit JSON `null`,
+including `wake.generation` and `wake.target_digest`;
 `image.status="unknown"` remains a real classification, not an error. In
 doctor schema 2, each wake-lock entry carries the same decision under
 `wake_check` rather than duplicating the wake advice as flat fields. Check

--- a/docs/wake-operations.md
+++ b/docs/wake-operations.md
@@ -77,6 +77,16 @@ malformed owner state is preserved.
 ordered fixed arguments. It stops only an identity-confirmed live inject-via
 wake with an unchanged saved target, using Linux pidfd signaling or the Darwin
 control socket. It can also remove an exactly bound proven-stale lock.
+`--if-generation` is a compare-and-swap against the generation from
+`amq wake check`: schema 1 reports `wake_generation` and `wake_target_digest`
+(omitted when empty); schema 2 reports `wake.generation` and
+`wake.target_digest` (JSON null when absent). A replacement published after
+that check is refused and preserved.
+
+Darwin does not signal by numeric PID. A process that appears between the last
+identity recheck and TERM/KILL is never signaled; raw numeric signaling is
+`operator_only`. Live inject-via retirement uses the cooperative control
+socket. Raw wakes are stopped from the owning terminal or supervisor.
 
 Retirement preserves mailbox contents. Exact lock removal is its commit point:
 a failure before that point is `refused`; a later target or state cleanup

--- a/internal/cli/coop_wake_reclaim_darwin_test.go
+++ b/internal/cli/coop_wake_reclaim_darwin_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"os"
 	"strings"
-	"syscall"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -52,114 +51,8 @@ func TestPrepareCoopWakeLockLiveRawUnknownTTYAttachedIsRefusedWithoutMutation(t 
 	})
 }
 
-func TestPrepareCoopWakeLockLiveRawUndeterminableYesTakesOverWithWarning(t *testing.T) {
-	testPrepareCoopWakeLockLiveRawTakeover(t, "unknown", wakeProcessInfo{},
-		"running; cannot determine whether its terminal is still attached", false)
-}
-
-func TestPrepareCoopWakeLockConsentedWakeSelfCleanupIsSuccess(t *testing.T) {
-	testPrepareCoopWakeLockLiveRawTakeover(t, "unknown", wakeProcessInfo{},
-		"running; cannot determine whether its terminal is still attached", true)
-}
-
-func TestPrepareCoopWakeLockConsentedWakeSelfCleanupWithoutProvenExitWarnsAndProceeds(t *testing.T) {
-	tests := []struct {
-		name        string
-		afterSignal wakeProcessInfo
-	}{
-		{
-			name: "same identity",
-			afterSignal: wakeProcessInfo{
-				Running:    true,
-				StartToken: "start",
-				BootID:     "boot",
-				Executable: "/opt/homebrew/bin/amq",
-			},
-		},
-		{
-			name: "unknown identity",
-			afterSignal: wakeProcessInfo{
-				Running:      true,
-				InspectError: errors.New("test identity inspection failure"),
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			const (
-				pid = 66121
-				tty = "unknown"
-			)
-			root := secureTempDirForTest(t)
-			args := []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}
-			lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
-				PID:          pid,
-				TTY:          tty,
-				ProcessStart: "start",
-				BootID:       "boot",
-				Executable:   "/opt/homebrew/bin/amq",
-				Args:         args,
-				Generation:   "live-raw-partial-takeover",
-			})
-			signaled := false
-			stubInspectWakeProcess(t, func(got int) wakeProcessInfo {
-				if signaled {
-					info := test.afterSignal
-					info.PID = got
-					return info
-				}
-				return wakeProcessInfo{
-					PID:        got,
-					Running:    true,
-					StartToken: "start",
-					BootID:     "boot",
-					Executable: "/opt/homebrew/bin/amq",
-					Args:       args,
-				}
-			})
-			var signals []os.Signal
-			stubSignalWakeProcess(t, func(got int, signal os.Signal) error {
-				signals = append(signals, signal)
-				if got != pid || signal != syscall.SIGTERM {
-					t.Fatalf("signal = (%d, %v), want (%d, SIGTERM)", got, signal, pid)
-				}
-				signaled = true
-				if err := os.Remove(lockPath); err != nil {
-					t.Fatalf("simulate old wake self-cleanup: %v", err)
-				}
-				return nil
-			})
-
-			var prepareErr error
-			stderr := captureWakeStderr(t, func() {
-				prepareErr = prepareCoopWakeLock(root, "codex", true, "unused")
-			})
-			if prepareErr != nil {
-				t.Fatalf("approved takeover after partial old-wake cleanup: %v", prepareErr)
-			}
-			if len(signals) != 1 || signals[0] != syscall.SIGTERM {
-				t.Fatalf("signals = %v, want [SIGTERM]", signals)
-			}
-			if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-				t.Fatalf("self-cleaned live raw lock exists after takeover: %v", err)
-			}
-			for _, want := range []string{
-				"superseded wake helper",
-				"pid 66121",
-				tty,
-				"without a confirmed exit",
-				"duplicate notifications may continue",
-			} {
-				if !strings.Contains(stderr, want) {
-					t.Fatalf("partial-takeover output %q missing %q", stderr, want)
-				}
-			}
-			if got := strings.Count(stderr, "duplicate notifications may continue"); got != 1 {
-				t.Fatalf("duplicate warning count = %d, want 1 in %q", got, stderr)
-			}
-		})
-	}
+func TestPrepareCoopWakeLockConsentedRawNumericSignalingFailsClosed(t *testing.T) {
+	testPrepareCoopWakeLockLiveRawTakeoverRefused(t, "unknown", wakeProcessInfo{})
 }
 
 func TestPrepareCoopWakeLockSameTerminalDifferentSessionDefersToSilentReplacement(t *testing.T) {
@@ -337,12 +230,10 @@ func testPrepareCoopWakeLockHealthyRawRefused(
 	}
 }
 
-func testPrepareCoopWakeLockLiveRawTakeover(
+func testPrepareCoopWakeLockLiveRawTakeoverRefused(
 	t *testing.T,
 	tty string,
 	terminal wakeProcessInfo,
-	wantState string,
-	selfRemoves bool,
 ) {
 	t.Helper()
 
@@ -357,11 +248,7 @@ func testPrepareCoopWakeLockLiveRawTakeover(
 		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
 		Generation:   "live-raw-takeover",
 	})
-	stopped := false
 	stubInspectWakeProcess(t, func(got int) wakeProcessInfo {
-		if stopped {
-			return wakeProcessInfo{PID: got}
-		}
 		terminal.PID = got
 		terminal.Running = true
 		terminal.StartToken = "start"
@@ -370,35 +257,17 @@ func testPrepareCoopWakeLockLiveRawTakeover(
 		terminal.Args = []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"}
 		return terminal
 	})
-	stubSignalWakeProcess(t, func(got int, signal os.Signal) error {
-		if got != pid || signal != syscall.SIGTERM {
-			t.Fatalf("signal %d %v", got, signal)
-		}
-		stopped = true
-		if selfRemoves {
-			if err := os.Remove(lockPath); err != nil {
-				t.Fatalf("old wake self-remove lock: %v", err)
-			}
-		}
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("darwin must not signal a raw wake by numeric PID")
 		return nil
 	})
 
-	stderr := captureWakeStderr(t, func() {
-		if err := prepareCoopWakeLock(root, "codex", true, "unused"); err != nil {
-			t.Fatalf("take over live raw wake: %v", err)
-		}
-	})
-	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Fatalf("live raw lock remains: %v", err)
+	err := prepareCoopWakeLock(root, "codex", true, "unused")
+	var operatorOnly *wakeOperatorOnlyError
+	if !errors.As(err, &operatorOnly) || operatorOnly.RestartCapability() != wakeRestartOperatorOnly {
+		t.Fatalf("consented live raw takeover error = %T %v, want typed operator_only", err, err)
 	}
-	for _, want := range []string{
-		wantState,
-		"warning: took over blocking wake for codex",
-		"pid 66121",
-		"on " + tty,
-	} {
-		if !strings.Contains(stderr, want) {
-			t.Fatalf("takeover output %q missing %q", stderr, want)
-		}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("live raw lock changed: %v", statErr)
 	}
 }

--- a/internal/cli/wake_auto_replace_darwin_test.go
+++ b/internal/cli/wake_auto_replace_darwin_test.go
@@ -5,19 +5,18 @@ package cli
 import (
 	"errors"
 	"os"
-	"syscall"
 	"testing"
 
 	"golang.org/x/sys/unix"
 )
 
-func TestAcquireWakeLockAutomaticallyReplacesTerminalGoneRawWake(t *testing.T) {
+func TestAcquireWakeLockTerminalGoneRawWakeFailsClosedWithoutSignal(t *testing.T) {
 	testAcquireWakeLockAutomaticallyReplacesRawWake(t, wakeProcessInfo{
 		ControllingTerminalKnown: true,
 	})
 }
 
-func TestAcquireWakeLockAutomaticallyReplacesSameTerminalDifferentSessionRawWake(t *testing.T) {
+func TestAcquireWakeLockSameTerminalDifferentSessionRawWakeFailsClosedWithoutSignal(t *testing.T) {
 	const (
 		wakePID = 66121
 		tdev    = 268435464
@@ -136,12 +135,8 @@ func testAcquireWakeLockAutomaticallyReplacesRawWake(
 		WakeMode:     wakeInjectModeRaw,
 		Generation:   "automatic-replacement",
 	})
-	stopped := false
 	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
 		if pid != wakePID {
-			return wakeProcessInfo{PID: pid}
-		}
-		if stopped {
 			return wakeProcessInfo{PID: pid}
 		}
 		terminal.PID = pid
@@ -153,38 +148,30 @@ func testAcquireWakeLockAutomaticallyReplacesRawWake(
 		return terminal
 	})
 	var signals []os.Signal
-	stubSignalWakeProcess(t, func(pid int, signal os.Signal) error {
-		if pid != wakePID {
-			t.Fatalf("signal pid = %d, want %d", pid, wakePID)
-		}
-		signals = append(signals, signal)
-		if signal == syscall.SIGTERM {
-			stopped = true
-		}
+	stubSignalWakeProcess(t, func(int, os.Signal) error {
+		t.Fatal("darwin must not signal a raw wake by numeric PID")
 		return nil
 	})
 
 	cleanup, err := acquireWakeLockWithOptions(root, "codex", wakeLockAcquireOptions{
 		wakeMode: wakeInjectModeRaw,
 	})
-	if err != nil {
-		t.Fatalf("automatic raw-wake replacement: %v", err)
+	if cleanup != nil {
+		cleanup()
+		t.Fatal("automatic raw-wake replacement returned cleanup")
 	}
-	if cleanup == nil {
-		t.Fatal("automatic raw-wake replacement returned nil cleanup")
+	var operatorOnly *wakeOperatorOnlyError
+	if !errors.As(err, &operatorOnly) || operatorOnly.RestartCapability() != wakeRestartOperatorOnly {
+		t.Fatalf("automatic raw-wake replacement error = %T %v, want typed operator_only", err, err)
 	}
-	if len(signals) != 1 || signals[0] != syscall.SIGTERM {
-		t.Fatalf("signals = %v, want exact SIGTERM", signals)
+	if len(signals) != 0 {
+		t.Fatalf("signals = %v, want none", signals)
 	}
 	current := inspectWakeLock(root, "codex")
-	if !current.Exists ||
-		current.Lock.PID != os.Getpid() ||
-		current.Lock.Generation == "automatic-replacement" {
-		t.Fatalf("replacement lock = %#v", current)
+	if !current.Exists || current.Lock.Generation != "automatic-replacement" {
+		t.Fatalf("raw wake was mutated: %#v", current)
 	}
-
-	cleanup()
-	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
-		t.Fatalf("replacement cleanup left lock: %v", statErr)
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("raw wake lock removed: %v", statErr)
 	}
 }

--- a/internal/cli/wake_check_schema.go
+++ b/internal/cli/wake_check_schema.go
@@ -108,11 +108,13 @@ type wakeCheckStartDecision struct {
 }
 
 type wakeCheckWakeDecision struct {
-	Status     string
-	Live       bool
-	PID        *int
-	Mode       *string
-	OwnerBound bool
+	Status       string
+	Live         bool
+	PID          *int
+	Mode         *string
+	OwnerBound   bool
+	Generation   *string
+	TargetDigest *string
 }
 
 type wakeCheckImageDecision struct {
@@ -204,11 +206,13 @@ type wakeCheckStartV2 struct {
 }
 
 type wakeCheckWakeV2 struct {
-	Status     string  `json:"status"`
-	Live       bool    `json:"live"`
-	PID        *int    `json:"pid"`
-	Mode       *string `json:"mode"`
-	OwnerBound bool    `json:"owner_bound"`
+	Status       string  `json:"status"`
+	Live         bool    `json:"live"`
+	PID          *int    `json:"pid"`
+	Mode         *string `json:"mode"`
+	OwnerBound   bool    `json:"owner_bound"`
+	Generation   *string `json:"generation"`
+	TargetDigest *string `json:"target_digest"`
 }
 
 type wakeCheckImageV2 struct {
@@ -281,11 +285,13 @@ func renderWakeCheckV2(decision wakeCheckDecision) wakeCheckResultV2 {
 			Detail:     decision.Start.Detail,
 		},
 		Wake: wakeCheckWakeV2{
-			Status:     decision.Wake.Status,
-			Live:       decision.Wake.Live,
-			PID:        decision.Wake.PID,
-			Mode:       decision.Wake.Mode,
-			OwnerBound: decision.Wake.OwnerBound,
+			Status:       decision.Wake.Status,
+			Live:         decision.Wake.Live,
+			PID:          decision.Wake.PID,
+			Mode:         decision.Wake.Mode,
+			OwnerBound:   decision.Wake.OwnerBound,
+			Generation:   decision.Wake.Generation,
+			TargetDigest: decision.Wake.TargetDigest,
 		},
 		Image: wakeCheckImageV2{
 			Running: wakeCheckImageEvidenceV2(decision.Image.Running),

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -214,7 +214,8 @@ func TestWakeCheckJSONSchemaV2DirectStartUsesExplicitNullsAndArgv(t *testing.T) 
 	}
 	wake := requireJSONObject(t, got, "wake")
 	if wake["status"] != string(wakeLockMissing) || wake["live"] != false ||
-		wake["pid"] != nil || wake["mode"] != nil || wake["owner_bound"] != false {
+		wake["pid"] != nil || wake["mode"] != nil || wake["owner_bound"] != false ||
+		wake["generation"] != nil || wake["target_digest"] != nil {
 		t.Fatalf("wake = %#v", wake)
 	}
 	image := requireJSONObject(t, got, "image")

--- a/internal/cli/wake_check_schema_v2_unix_test.go
+++ b/internal/cli/wake_check_schema_v2_unix_test.go
@@ -1436,6 +1436,39 @@ func TestWakeCheckV2AdvertisedRepairRevalidatesChangedGeneration(t *testing.T) {
 	assertWakeCheckTreeUnchanged(t, root, before)
 }
 
+func TestWakeCheckV2ReportsLiveLockGenerationAndTargetDigest(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested, _ := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, 4242)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+	wantDigest, err := wakeTargetDigest(requested)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json", "--json-schema=2"})
+	})
+	if err != nil {
+		t.Fatalf("wake check v2: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, output)
+	}
+	wake := requireJSONObject(t, got, "wake")
+	if wake["generation"] != generation {
+		t.Fatalf("wake.generation = %#v, want %q", wake["generation"], generation)
+	}
+	if wake["target_digest"] != wantDigest {
+		t.Fatalf("wake.target_digest = %#v, want %q", wake["target_digest"], wantDigest)
+	}
+}
+
 func requireJSONObject(t *testing.T, object map[string]any, key string) map[string]any {
 	t.Helper()
 	value, ok := object[key].(map[string]any)

--- a/internal/cli/wake_check_unix.go
+++ b/internal/cli/wake_check_unix.go
@@ -26,6 +26,8 @@ type wakeCheckResult struct {
 	WakePID                  int    `json:"wake_pid,omitempty"`
 	WakeMode                 string `json:"wake_mode,omitempty"`
 	OwnerBound               bool   `json:"owner_bound"`
+	WakeGeneration           string `json:"wake_generation,omitempty"`
+	WakeTargetDigest         string `json:"wake_target_digest,omitempty"`
 	RunningImagePath         string `json:"running_image_path"`
 	RunningVersion           string `json:"running_version"`
 	CurrentImagePath         string `json:"current_image_path"`
@@ -436,10 +438,12 @@ func buildWakeCheckDecision(
 			Detail:     startDetail,
 		},
 		Wake: wakeCheckWakeDecision{
-			Status:     wakeStatus,
-			PID:        wakeCheckOptionalInt(inspection.PID),
-			Mode:       wakeCheckOptionalString(inspection.Lock.WakeMode),
-			OwnerBound: ownerBound,
+			Status:       wakeStatus,
+			PID:          wakeCheckOptionalInt(inspection.PID),
+			Mode:         wakeCheckOptionalString(inspection.Lock.WakeMode),
+			OwnerBound:   ownerBound,
+			Generation:   wakeCheckOptionalString(inspection.Lock.Generation),
+			TargetDigest: wakeCheckOptionalString(inspection.Lock.TargetDigest),
 		},
 		Image: wakeCheckImageDecision{
 			Current: wakeCheckImageEvidenceDecision{
@@ -547,6 +551,8 @@ func renderWakeCheckV1(decision wakeCheckDecision) wakeCheckResult {
 		WakePID:                  wakeCheckIntValue(decision.Wake.PID),
 		WakeMode:                 wakeCheckStringValue(decision.Wake.Mode, ""),
 		OwnerBound:               decision.Wake.OwnerBound,
+		WakeGeneration:           wakeCheckStringValue(decision.Wake.Generation, ""),
+		WakeTargetDigest:         wakeCheckStringValue(decision.Wake.TargetDigest, ""),
 		RunningImagePath:         wakeCheckStringValue(decision.Image.Running.Path, wakeCheckUnknown),
 		RunningVersion:           wakeCheckStringValue(decision.Image.Running.Version, wakeCheckUnknown),
 		CurrentImagePath:         wakeCheckStringValue(decision.Image.Current.Path, wakeCheckUnknown),

--- a/internal/cli/wake_operator_only.go
+++ b/internal/cli/wake_operator_only.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package cli
 
 // wakeOperatorOnlyError marks an action that AMQ will not take automatically.

--- a/internal/cli/wake_operator_only.go
+++ b/internal/cli/wake_operator_only.go
@@ -1,0 +1,20 @@
+package cli
+
+// wakeOperatorOnlyError marks an action that AMQ will not take automatically.
+// Callers must treat restart_capability as operator_only: the owning terminal
+// or supervisor acts; agents must not signal, guess, or retry a force path.
+type wakeOperatorOnlyError struct {
+	reason string
+}
+
+func (err *wakeOperatorOnlyError) Error() string {
+	return err.reason
+}
+
+func (err *wakeOperatorOnlyError) RestartCapability() string {
+	return wakeRestartOperatorOnly
+}
+
+func newWakeOperatorOnlyError(reason string) error {
+	return &wakeOperatorOnlyError{reason: reason}
+}

--- a/internal/cli/wake_p0_golden_abi_unix_test.go
+++ b/internal/cli/wake_p0_golden_abi_unix_test.go
@@ -563,7 +563,7 @@ func TestWakeP0BinaryJSONFieldsAndEnums(t *testing.T) {
 	if start["mode"] != startMode || start["reason_code"] != startReason || start["detail"] != startDetail {
 		t.Fatalf("start missing-lock decision = %#v, want mode=%q reason=%q detail=%q", start, startMode, startReason, startDetail)
 	}
-	if wake["status"] != "missing" || wake["live"] != false || wake["owner_bound"] != false || wake["pid"] != nil || wake["mode"] != nil {
+	if wake["status"] != "missing" || wake["live"] != false || wake["owner_bound"] != false || wake["pid"] != nil || wake["mode"] != nil || wake["generation"] != nil || wake["target_digest"] != nil {
 		t.Fatalf("wake missing-lock decision = %#v", wake)
 	}
 	if image["status"] != "unknown" {

--- a/internal/cli/wake_retire_generation_cas_unix_test.go
+++ b/internal/cli/wake_retire_generation_cas_unix_test.go
@@ -1,0 +1,79 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRetireWakeIfGenerationRefusesReplacementAndPreservesG2(t *testing.T) {
+	const (
+		oldPID         = 4242
+		replacementPID = 4343
+		observed       = "0123456789abcdef0123456789abcdef"
+		replacement    = "fedcba9876543210fedcba9876543210"
+	)
+	root := secureTempDirForTest(t)
+	injector := writeExecutableForTest(t, "injector")
+	requested, lockPath := installRetireWakeFixture(t, root, "codex", injector, []string{"exec", "terminal-a"}, oldPID)
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		return matchingRetireWakeProcess(pid, root, "codex", injector)
+	})
+	stubWakeCheckRuntime(t, false, "0.49.14")
+
+	output, err := captureEnvStdout(t, func() error {
+		return runWake([]string{"check", "--root", root, "--me", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("wake check: %v", err)
+	}
+	var observedCheck struct {
+		WakeGeneration   string `json:"wake_generation"`
+		WakeTargetDigest string `json:"wake_target_digest"`
+	}
+	if err := json.Unmarshal([]byte(output), &observedCheck); err != nil {
+		t.Fatalf("decode wake check: %v\n%s", err, output)
+	}
+	if observedCheck.WakeGeneration != observed {
+		t.Fatalf("observed generation = %q, want %q", observedCheck.WakeGeneration, observed)
+	}
+	if observedCheck.WakeTargetDigest == "" {
+		t.Fatal("observed check omitted wake_target_digest")
+	}
+
+	replacementTarget := mustNewWakeTargetForTest(t, root, "codex", injector, []string{"exec", "terminal-b"})
+	if err := writeWakeTarget(root, "codex", replacementTarget); err != nil {
+		t.Fatalf("write replacement target: %v", err)
+	}
+	replacementLock := bindWakeLockToTarget(wakeLock{
+		PID:          replacementPID,
+		TTY:          "unknown",
+		ProcessStart: "wake-start",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"amq", "wake", "--root", root, "--me", "codex", "--inject-via", injector},
+		Generation:   replacement,
+	}, replacementTarget)
+	replacementLock.ControlSocket = wakeControlSocketPath(root, "codex", replacementLock.Generation)
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLockForTest(t, root, "codex", replacementLock)
+
+	result, retireErr := retireWakeIfGeneration(root, "codex", requested, observed)
+	if retireErr == nil || result.Status != "refused" || !strings.Contains(result.Reason, "generation changed") {
+		t.Fatalf("retire result = %#v err=%v, want generation CAS refusal", result, retireErr)
+	}
+
+	current := inspectWakeLock(root, "codex")
+	if !current.Exists || current.PID != replacementPID || current.Lock.Generation != replacement {
+		t.Fatalf("G2 did not survive: %#v", current)
+	}
+	persisted, exists, err := readWakeTarget(root, "codex")
+	if err != nil || !exists || !sameWakeInjectorIdentity(persisted, replacementTarget) {
+		t.Fatalf("G2 target changed: (%#v,%v,%v)", persisted, exists, err)
+	}
+}

--- a/internal/cli/wake_retire_unix.go
+++ b/internal/cli/wake_retire_unix.go
@@ -47,6 +47,7 @@ func runWakeRetire(args []string) error {
 	fs := flag.NewFlagSet("wake retire", flag.ContinueOnError)
 	common := addCommonFlags(fs)
 	injectViaFlag := fs.String("inject-via", "", "Expected external injection executable")
+	ifGenerationFlag := fs.String("if-generation", "", "Retire only if the current lock generation still matches this exact value")
 	retryUntilFlag := fs.String("retry-until", wakeRetryUntilDrained, "Expected doorbell acknowledgement: drained or injected")
 	var injectArgFlags multiStringFlag
 	fs.Var(&injectArgFlags, "inject-arg", "Expected fixed injection argument (repeatable)")
@@ -54,6 +55,7 @@ func runWakeRetire(args []string) error {
 		"Stop an identity-confirmed live inject-via wake or remove its exactly-bound proven-stale lock.",
 		"",
 		"The expected executable and ordered arguments must exactly match the saved target.",
+		"Pass --if-generation with the generation from amq wake check so a replacement published after that check is refused.",
 		"Retirement preserves the mailbox, removes the exact saved target and coupled state projection, and never stops raw wakes.")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
@@ -85,7 +87,7 @@ func runWakeRetire(args []string) error {
 	if retryUntil == wakeRetryUntilInjected {
 		requested.RetryUntil = retryUntil
 	}
-	result, retireErr := retireWake(root, me, requested)
+	result, retireErr := retireWakeIfGeneration(root, me, requested, strings.TrimSpace(*ifGenerationFlag))
 	if common.JSON {
 		if err := writeJSON(os.Stdout, result); err != nil {
 			return err
@@ -106,6 +108,10 @@ func runWakeRetire(args []string) error {
 }
 
 func retireWake(root, me string, requested wakeTarget) (wakeRetireResult, error) {
+	return retireWakeIfGeneration(root, me, requested, "")
+}
+
+func retireWakeIfGeneration(root, me string, requested wakeTarget, ifGeneration string) (wakeRetireResult, error) {
 	result := wakeRetireResult{
 		Status: "refused",
 		Agent:  me,
@@ -123,6 +129,9 @@ func retireWake(root, me string, requested wakeTarget) (wakeRetireResult, error)
 		return refuse("no wake lock present; wake process absence cannot be proven")
 	}
 	result.PID = inspection.PID
+	if ifGeneration != "" && inspection.Lock.Generation != ifGeneration {
+		return refuse("wake generation changed before retirement")
+	}
 	if wakeLockHasOwnerMarkers(inspection) {
 		return refuse(fmt.Sprintf("owner-bound wake claims require 'amq wake recover-owner --me %s'", me))
 	}
@@ -147,6 +156,9 @@ func retireWake(root, me string, requested wakeTarget) (wakeRetireResult, error)
 			confirmed = inspectWakeLockAt(dirfd, agentDir, root, me)
 			if !sameWakeLockInspection(inspection, confirmed) || !confirmed.IdentityConfirmed {
 				return errors.New("wake lock changed before retirement")
+			}
+			if ifGeneration != "" && confirmed.Lock.Generation != ifGeneration {
+				return errors.New("wake generation changed before retirement")
 			}
 			var snapshotErr error
 			artifacts, snapshotErr = snapshotWakeRetireArtifactsAt(
@@ -192,6 +204,9 @@ func retireWake(root, me string, requested wakeTarget) (wakeRetireResult, error)
 			current := inspectWakeLockAt(dirfd, agentDir, root, me)
 			if !sameWakeLockGeneration(inspection, current) || current.Status != wakeLockStale {
 				return errors.New("wake lock changed before retirement")
+			}
+			if ifGeneration != "" && current.Lock.Generation != ifGeneration {
+				return errors.New("wake generation changed before retirement")
 			}
 			if err := validateWakeLockStaleRemovalAt(dirfd, agentDir, current); err != nil {
 				return err

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -5,19 +5,20 @@ package cli
 import (
 	"fmt"
 	"os"
-	"syscall"
-	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-var signalWakeProcess = func(pid int, sig os.Signal) error {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return err
+var (
+	signalWakeProcess = func(pid int, sig os.Signal) error {
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return err
+		}
+		return proc.Signal(sig)
 	}
-	return proc.Signal(sig)
-}
+	afterDarwinWakeSignalValidation = func() {}
+)
 
 func terminateAndRemoveOrphanedWakeLock(inspection wakeLockInspection) (bool, error) {
 	return terminateAndRemoveOrphanedWakeLockWithRawConsent(inspection, false)
@@ -165,35 +166,13 @@ func terminateWakeProcess(inspection wakeLockInspection) error {
 	if !sameConfirmedWakeLock(inspection) {
 		return fmt.Errorf("wake process identity changed before SIGTERM")
 	}
-	if err := signalWakeProcess(inspection.PID, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("signal wake process SIGTERM: %w", err)
-	}
-	time.Sleep(wakeTerminateGrace)
-	switch state := inspectWakeIdentity(inspection); state {
-	case wakeIdentityGoneOrDifferent:
-		return nil
-	case wakeIdentityUnknown:
-		return fmt.Errorf("wake process identity is unknown after SIGTERM; preserving wake lock")
-	}
-	if !sameConfirmedWakeLock(inspection) {
-		return fmt.Errorf("wake process identity changed before SIGKILL")
-	}
-	if err := signalWakeProcess(inspection.PID, syscall.SIGKILL); err != nil {
-		return fmt.Errorf("signal wake process SIGKILL: %w", err)
-	}
-	deadline := time.Now().Add(wakeTerminateKillConfirm)
-	for {
-		switch state := inspectWakeIdentity(inspection); state {
-		case wakeIdentityGoneOrDifferent:
-			return nil
-		case wakeIdentityUnknown:
-			return fmt.Errorf("wake process identity is unknown after SIGKILL; preserving wake lock")
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("wake process still alive after SIGKILL")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	afterDarwinWakeSignalValidation()
+	// Darwin has no pidfd. kill(pid) after the last identity recheck can hit a
+	// recycled PID. Cooperative control is the only agent-safe stop; raw numeric
+	// signaling is operator_only.
+	return newWakeOperatorOnlyError(
+		"darwin raw numeric signaling is operator_only; stop the wake from its owning terminal or supervisor",
+	)
 }
 
 func terminateWakeProcessInDir(
@@ -203,35 +182,10 @@ func terminateWakeProcessInDir(
 	if !sameConfirmedWakeLockInDir(agentDir, inspection) {
 		return fmt.Errorf("wake process identity changed before SIGTERM")
 	}
-	if err := signalWakeProcess(inspection.PID, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("signal wake process SIGTERM: %w", err)
-	}
-	time.Sleep(wakeTerminateGrace)
-	switch state := inspectWakeIdentity(inspection); state {
-	case wakeIdentityGoneOrDifferent:
-		return nil
-	case wakeIdentityUnknown:
-		return fmt.Errorf("wake process identity is unknown after SIGTERM; preserving wake lock")
-	}
-	if !sameConfirmedWakeLockInDir(agentDir, inspection) {
-		return fmt.Errorf("wake process identity changed before SIGKILL")
-	}
-	if err := signalWakeProcess(inspection.PID, syscall.SIGKILL); err != nil {
-		return fmt.Errorf("signal wake process SIGKILL: %w", err)
-	}
-	deadline := time.Now().Add(wakeTerminateKillConfirm)
-	for {
-		switch state := inspectWakeIdentity(inspection); state {
-		case wakeIdentityGoneOrDifferent:
-			return nil
-		case wakeIdentityUnknown:
-			return fmt.Errorf("wake process identity is unknown after SIGKILL; preserving wake lock")
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("wake process still alive after SIGKILL")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	afterDarwinWakeSignalValidation()
+	return newWakeOperatorOnlyError(
+		"darwin raw numeric signaling is operator_only; stop the wake from its owning terminal or supervisor",
+	)
 }
 
 func sameConfirmedWakeLockInDir(

--- a/internal/cli/wake_terminate_darwin_test.go
+++ b/internal/cli/wake_terminate_darwin_test.go
@@ -1,0 +1,83 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestTerminateWakeProcessDoesNotSignalReplacementBetweenValidationAndKill(t *testing.T) {
+	const wakePID = 4242
+	root := secureTempDirForTest(t)
+	lockPath := writeWakeLockForTest(t, root, "codex", wakeLock{
+		PID:          wakePID,
+		TTY:          "/dev/amq-missing-tty",
+		ProcessStart: "start-1",
+		BootID:       "boot-1",
+		Executable:   "/opt/homebrew/bin/amq",
+		Args:         []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		WakeMode:     wakeInjectModeRaw,
+		Generation:   "observed-generation",
+	})
+	replaced := false
+	stubInspectWakeProcess(t, func(pid int) wakeProcessInfo {
+		if pid != wakePID {
+			return wakeProcessInfo{PID: pid}
+		}
+		info := wakeProcessInfo{
+			PID:        pid,
+			Running:    true,
+			StartToken: "start-1",
+			BootID:     "boot-1",
+			Executable: "/opt/homebrew/bin/amq",
+			Args:       []string{"/opt/homebrew/bin/amq", "wake", "--root", root, "--me", "codex"},
+		}
+		if replaced {
+			info.StartToken = "replacement-start"
+			info.Executable = "/bin/sleep"
+			info.Args = []string{"/bin/sleep", "100"}
+		}
+		return info
+	})
+	var signals []os.Signal
+	stubSignalWakeProcess(t, func(pid int, sig os.Signal) error {
+		signals = append(signals, sig)
+		t.Errorf("signaled replacement pid=%d sig=%v", pid, sig)
+		return nil
+	})
+
+	oldSeam := afterDarwinWakeSignalValidation
+	afterDarwinWakeSignalValidation = func() {
+		replaced = true
+		writeWakeLockForTest(t, root, "codex", wakeLock{
+			PID:          wakePID,
+			TTY:          "/dev/amq-missing-tty",
+			ProcessStart: "replacement-start",
+			BootID:       "boot-1",
+			Executable:   "/bin/sleep",
+			Args:         []string{"/bin/sleep", "100"},
+			WakeMode:     wakeInjectModeRaw,
+			Generation:   "replacement-generation",
+		})
+	}
+	t.Cleanup(func() { afterDarwinWakeSignalValidation = oldSeam })
+
+	inspection := inspectWakeLock(root, "codex")
+	err := terminateWakeProcess(inspection)
+	var operatorOnly *wakeOperatorOnlyError
+	if !errors.As(err, &operatorOnly) || operatorOnly.RestartCapability() != wakeRestartOperatorOnly {
+		t.Fatalf("terminate error = %T %v, want typed operator_only", err, err)
+	}
+	if len(signals) != 0 {
+		t.Fatalf("signals = %v, want none to the replacement", signals)
+	}
+	current := inspectWakeLock(root, "codex")
+	if !current.Exists || current.Lock.Generation != "replacement-generation" {
+		t.Fatalf("replacement was not preserved: %#v", current)
+	}
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Fatalf("replacement lock missing: %v", statErr)
+	}
+}

--- a/internal/cli/wake_terminate_legacy_test_darwin.go
+++ b/internal/cli/wake_terminate_legacy_test_darwin.go
@@ -6,4 +6,5 @@ import "testing"
 
 func requireBarePIDWakeTermination(t *testing.T) {
 	t.Helper()
+	t.Skip("bare-PID termination is unavailable; Darwin fails closed to cooperative stop")
 }

--- a/internal/keepalive/amq/runner.go
+++ b/internal/keepalive/amq/runner.go
@@ -61,28 +61,33 @@ type StartWakeRequest struct {
 	Timeout   time.Duration
 }
 
-type wakeCheckResult struct {
+type WakeCheckResult struct {
 	Schema      int    `json:"schema"`
 	LiveWake    bool   `json:"live_wake"`
 	ImageStatus string `json:"image_status"`
+	Generation  string `json:"wake_generation"`
 }
 
 type wakeCheckWireResult struct {
 	Schema      *int    `json:"schema"`
 	LiveWake    *bool   `json:"live_wake"`
 	ImageStatus *string `json:"image_status"`
+	Generation  *string `json:"wake_generation"`
 }
 
 // RetireWakeRequest names the exact inject-via identity that AMQ must match
 // before it stops a wake. Root, Me, Adapter, and Target reproduce the fixed
 // argv the wake was started with (inject <adapter> <target>), so AMQ retires
-// only a wake whose saved target is identical.
+// only a wake whose saved target is identical. Generation is the CAS token
+// from amq wake check; when set, AMQ refuses if a replacement generation was
+// published in between.
 type RetireWakeRequest struct {
-	Root      string
-	Me        string
-	InjectVia string
-	Adapter   string
-	Target    string
+	Root       string
+	Me         string
+	InjectVia  string
+	Adapter    string
+	Target     string
+	Generation string
 }
 
 // RetireWakeResult mirrors `amq wake retire -json`. Both "retired" and
@@ -298,12 +303,16 @@ func (c CLI) refreshWakeImage(ctx context.Context, req StartWakeRequest) error {
 	case wakeImageCurrent:
 		return nil
 	case wakeImageDifferent:
+		if check.Generation == "" {
+			return fmt.Errorf("%w: live wake omitted generation", ErrWakeImageIdentityInconclusive)
+		}
 		_, err := c.RetireWake(ctx, RetireWakeRequest{
-			Root:      req.Root,
-			Me:        req.Me,
-			InjectVia: req.InjectVia,
-			Adapter:   req.Adapter,
-			Target:    req.Target,
+			Root:       req.Root,
+			Me:         req.Me,
+			InjectVia:  req.InjectVia,
+			Adapter:    req.Adapter,
+			Target:     req.Target,
+			Generation: check.Generation,
 		})
 		if err != nil {
 			return fmt.Errorf("retire stale amq wake image: %w", err)
@@ -314,7 +323,11 @@ func (c CLI) refreshWakeImage(ctx context.Context, req StartWakeRequest) error {
 	}
 }
 
-func (c CLI) checkWake(ctx context.Context, req StartWakeRequest) (wakeCheckResult, error) {
+func (c CLI) CheckWake(ctx context.Context, req StartWakeRequest) (WakeCheckResult, error) {
+	return c.checkWake(ctx, req)
+}
+
+func (c CLI) checkWake(ctx context.Context, req StartWakeRequest) (WakeCheckResult, error) {
 	args := []string{"wake", "check", "--me", req.Me}
 	if req.Root != "" {
 		args = append(args, "--root", req.Root)
@@ -327,23 +340,27 @@ func (c CLI) checkWake(ctx context.Context, req StartWakeRequest) (wakeCheckResu
 		if detail == "" {
 			detail = err.Error()
 		}
-		return wakeCheckResult{}, fmt.Errorf("amq wake check failed: %v: %s", err, detail)
+		return WakeCheckResult{}, fmt.Errorf("amq wake check failed: %v: %s", err, detail)
 	}
 	var wire wakeCheckWireResult
 	if err := json.Unmarshal(bytes.TrimSpace(stdout), &wire); err != nil {
-		return wakeCheckResult{}, fmt.Errorf("parse amq wake check output: %w", err)
+		return WakeCheckResult{}, fmt.Errorf("parse amq wake check output: %w", err)
 	}
 	if wire.Schema == nil || wire.LiveWake == nil || wire.ImageStatus == nil {
-		return wakeCheckResult{}, errors.New("amq wake check omitted required schema, live_wake, or image_status field")
+		return WakeCheckResult{}, errors.New("amq wake check omitted required schema, live_wake, or image_status field")
 	}
 	if *wire.Schema != wakeCheckSchemaV1 {
-		return wakeCheckResult{}, fmt.Errorf("amq wake check returned schema %d, want %d", *wire.Schema, wakeCheckSchemaV1)
+		return WakeCheckResult{}, fmt.Errorf("amq wake check returned schema %d, want %d", *wire.Schema, wakeCheckSchemaV1)
 	}
-	return wakeCheckResult{
+	result := WakeCheckResult{
 		Schema:      *wire.Schema,
 		LiveWake:    *wire.LiveWake,
 		ImageStatus: *wire.ImageStatus,
-	}, nil
+	}
+	if wire.Generation != nil {
+		result.Generation = strings.TrimSpace(*wire.Generation)
+	}
+	return result, nil
 }
 
 // RetireWake asks AMQ to stop an identity-confirmed live inject-via wake (or
@@ -376,6 +393,11 @@ func (c CLI) RetireWake(ctx context.Context, req RetireWakeRequest) (RetireWakeR
 		"--inject-arg", "inject",
 		"--inject-arg", req.Adapter,
 		"--inject-arg", req.Target,
+	)
+	if req.Generation != "" {
+		args = append(args, "--if-generation", req.Generation)
+	}
+	args = append(args,
 		"--retry-until", keepaliveWakeRetryUntil,
 		"-json",
 	)

--- a/internal/keepalive/amq/runner_real_amq_unix_test.go
+++ b/internal/keepalive/amq/runner_real_amq_unix_test.go
@@ -409,6 +409,7 @@ func TestStartWakeRealAMQBinaryBecomesReadyAndMatchesTarget(t *testing.T) {
 	const wantMismatchReason = "saved wake target uses a different injector identity or retry acknowledgement policy"
 	mismatched, mismatchErr := NewCLI(binary).RetireWake(context.Background(), RetireWakeRequest{
 		Root: root, Me: handle, InjectVia: injector, Adapter: adapter, Target: target + "-wrong",
+		Generation: check.Generation,
 	})
 	if mismatched.Retired() {
 		t.Fatalf("RetireWake() with a mismatched target retired the real wake: %+v", mismatched)
@@ -430,6 +431,7 @@ func TestStartWakeRealAMQBinaryBecomesReadyAndMatchesTarget(t *testing.T) {
 	// returned JSON claiming "retired" is not sufficient proof on its own.
 	result, retireErr := NewCLI(binary).RetireWake(context.Background(), RetireWakeRequest{
 		Root: root, Me: handle, InjectVia: injector, Adapter: adapter, Target: target,
+		Generation: check.Generation,
 	})
 	if retireErr != nil || !result.Retired() {
 		t.Fatalf("RetireWake() with the exact StartWake identity = %+v, err = %v, want retired", result, retireErr)

--- a/internal/keepalive/amq/runner_test.go
+++ b/internal/keepalive/amq/runner_test.go
@@ -205,7 +205,7 @@ func TestStartWakeRefreshesOnlyConclusivelyDifferentLiveImages(t *testing.T) {
 	}{
 		{
 			name:         "different image retires then starts",
-			checkOutput:  `{"schema":1,"live_wake":true,"image_status":"different"}`,
+			checkOutput:  `{"schema":1,"live_wake":true,"image_status":"different","wake_generation":"0123456789abcdef0123456789abcdef"}`,
 			retireOutput: `{"status":"retired","agent":"codex","pid":4242}`,
 			wantCalls:    []string{"check", "retire", "start"},
 		},
@@ -274,7 +274,7 @@ func TestStartWakeRefreshesOnlyConclusivelyDifferentLiveImages(t *testing.T) {
 		},
 		{
 			name:          "retirement refusal does not start",
-			checkOutput:   `{"schema":1,"live_wake":true,"image_status":"different"}`,
+			checkOutput:   `{"schema":1,"live_wake":true,"image_status":"different","wake_generation":"0123456789abcdef0123456789abcdef"}`,
 			retireOutput:  `{"status":"refused","reason":"target identity changed"}`,
 			retireExit:    "1",
 			wantCalls:     []string{"check", "retire"},
@@ -283,7 +283,7 @@ func TestStartWakeRefreshesOnlyConclusivelyDifferentLiveImages(t *testing.T) {
 		},
 		{
 			name:          "retired output with failed exit does not start",
-			checkOutput:   `{"schema":1,"live_wake":true,"image_status":"different"}`,
+			checkOutput:   `{"schema":1,"live_wake":true,"image_status":"different","wake_generation":"0123456789abcdef0123456789abcdef"}`,
 			retireOutput:  `{"status":"retired","agent":"codex","pid":4242}`,
 			retireExit:    "1",
 			wantCalls:     []string{"check", "retire"},
@@ -1278,11 +1278,12 @@ printf '%s\n' '{"status":"retired","agent":"codex","pid":4242}'
 `)
 
 	result, err := NewCLI(fakeAMQ).RetireWake(context.Background(), RetireWakeRequest{
-		Root:      "/tmp/amq-root",
-		Me:        "codex",
-		InjectVia: "/tmp/amq-keepalive",
-		Adapter:   "cmux",
-		Target:    "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3",
+		Root:       "/tmp/amq-root",
+		Me:         "codex",
+		InjectVia:  "/tmp/amq-keepalive",
+		Adapter:    "cmux",
+		Target:     "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3",
+		Generation: "0123456789abcdef0123456789abcdef",
 	})
 	if err != nil {
 		t.Fatalf("RetireWake() error = %v", err)
@@ -1304,6 +1305,7 @@ printf '%s\n' '{"status":"retired","agent":"codex","pid":4242}'
 		"--inject-arg", "inject",
 		"--inject-arg", "cmux",
 		"--inject-arg", "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3",
+		"--if-generation", "0123456789abcdef0123456789abcdef",
 		"--retry-until", "injected",
 		"-json",
 	}

--- a/internal/keepalive/amq/runner_test.go
+++ b/internal/keepalive/amq/runner_test.go
@@ -210,6 +210,13 @@ func TestStartWakeRefreshesOnlyConclusivelyDifferentLiveImages(t *testing.T) {
 			wantCalls:    []string{"check", "retire", "start"},
 		},
 		{
+			name:          "different image without generation preserves wake",
+			checkOutput:   `{"schema":1,"live_wake":true,"image_status":"different"}`,
+			wantCalls:     []string{"check"},
+			wantErrIs:     ErrWakeImageIdentityInconclusive,
+			wantErrString: "omitted generation",
+		},
+		{
 			name:        "current image starts without retire",
 			checkOutput: `{"schema":1,"live_wake":true,"image_status":"current"}`,
 			wantCalls:   []string{"check", "start"},

--- a/internal/keepalive/app/app.go
+++ b/internal/keepalive/app/app.go
@@ -52,7 +52,20 @@ type adapterLogState struct {
 // concrete implementation is amq.CLI; the interface keeps the app callers
 // testable with the same fake amq executables used across this package.
 type wakeRetirer interface {
+	CheckWake(ctx context.Context, req amq.StartWakeRequest) (amq.WakeCheckResult, error)
 	RetireWake(ctx context.Context, req amq.RetireWakeRequest) (amq.RetireWakeResult, error)
+}
+
+func observeWakeGeneration(ctx context.Context, retirer wakeRetirer, root, me string) (string, error) {
+	check, err := retirer.CheckWake(ctx, amq.StartWakeRequest{Root: root, Me: me})
+	if err != nil {
+		return "", fmt.Errorf("observe wake generation: %w", err)
+	}
+	generation := strings.TrimSpace(check.Generation)
+	if check.LiveWake && generation == "" {
+		return "", errors.New("live wake omitted generation")
+	}
+	return generation, nil
 }
 
 func (a App) Run(ctx context.Context, args []string) int {
@@ -551,6 +564,11 @@ func recoverDetachedRegistration(
 		return next, false, fmt.Errorf("refusing detached wake recovery for %s because target absence is not proven: %w", previous.Agent, probeErr)
 	}
 
+	generation, err := observeWakeGeneration(ctx, retirer, next.Root, next.Agent)
+	if err != nil {
+		return next, false, fmt.Errorf("recover detached %s wake: %w", previous.Agent, err)
+	}
+
 	updated, initialStart := reconciler.StartFresh(ctx, next)
 	if initialStart.Error == nil {
 		return updated, true, nil
@@ -565,11 +583,12 @@ func recoverDetachedRegistration(
 	// live wake with an unchanged matching saved target, or removes its
 	// exactly-bound proven-stale lock; it refuses anything else.
 	if _, retireErr := retirer.RetireWake(ctx, amq.RetireWakeRequest{
-		Root:      next.Root,
-		Me:        next.Agent,
-		InjectVia: reconciler.InjectVia,
-		Adapter:   previous.Adapter,
-		Target:    previous.Target,
+		Root:       next.Root,
+		Me:         next.Agent,
+		InjectVia:  reconciler.InjectVia,
+		Adapter:    previous.Adapter,
+		Target:     previous.Target,
+		Generation: generation,
 	}); retireErr != nil {
 		return next, false, fmt.Errorf(
 			"recover detached %s wake: exact-target start failed (%v) and retiring the previous wake was not confirmed: %w",
@@ -1104,6 +1123,16 @@ func (a App) gc(ctx context.Context, args []string) error {
 				result.Entries[index].Reason = normalizeErr.Error()
 				continue
 			}
+			var generation string
+			if *apply {
+				observed, observeErr := observeWakeGeneration(ctx, retirer, entry.Root, entry.Agent)
+				if observeErr != nil {
+					result.Entries[index].Status = "skipped"
+					result.Entries[index].Reason = observeErr.Error()
+					continue
+				}
+				generation = observed
+			}
 			probeErr := probes[entry.Adapter].Probe(ctx, target)
 			if probeErr == nil {
 				result.Entries[index].Status = "skipped"
@@ -1123,11 +1152,12 @@ func (a App) gc(ctx context.Context, args []string) error {
 			// identity-confirmed live wake with this saved target (or its
 			// exactly-bound proven-stale lock); any refusal leaves the entry.
 			if _, retireErr := retirer.RetireWake(ctx, amq.RetireWakeRequest{
-				Root:      entry.Root,
-				Me:        entry.Agent,
-				InjectVia: *self,
-				Adapter:   entry.Adapter,
-				Target:    target,
+				Root:       entry.Root,
+				Me:         entry.Agent,
+				InjectVia:  *self,
+				Adapter:    entry.Adapter,
+				Target:     target,
+				Generation: generation,
 			}); retireErr != nil {
 				result.Entries[index].Status = "error"
 				result.Entries[index].Reason = retireErr.Error()
@@ -1254,7 +1284,14 @@ func (a App) retireSession(ctx context.Context, args []string) error {
 		// post-retire forget matches exactly; normalized targets feed the probe
 		// and the retire identity.
 		targets := make([]string, len(entries))
+		generations := make([]string, len(entries))
+		var retirer wakeRetirer = amq.NewCLI(*amqPath)
 		for i := range entries {
+			generation, observeErr := observeWakeGeneration(ctx, retirer, entries[i].Root, entries[i].Agent)
+			if observeErr != nil {
+				return fmt.Errorf("observe %s wake generation: %w", entries[i].Agent, observeErr)
+			}
+			generations[i] = generation
 			target := entries[i].Target
 			if normalizer, ok := selected.(adapter.TargetNormalizer); ok {
 				normalized, normalizeErr := normalizer.NormalizeTarget(target)
@@ -1275,15 +1312,15 @@ func (a App) retireSession(ctx context.Context, args []string) error {
 
 		// Retire each identity-confirmed wake and forget only the rows AMQ
 		// confirmed retired. A refusal leaves that row for the next pass.
-		var retirer wakeRetirer = amq.NewCLI(*amqPath)
 		var retireErrs []error
 		for i := range entries {
 			if _, retireErr := retirer.RetireWake(ctx, amq.RetireWakeRequest{
-				Root:      entries[i].Root,
-				Me:        entries[i].Agent,
-				InjectVia: *self,
-				Adapter:   entries[i].Adapter,
-				Target:    targets[i],
+				Root:       entries[i].Root,
+				Me:         entries[i].Agent,
+				InjectVia:  *self,
+				Adapter:    entries[i].Adapter,
+				Target:     targets[i],
+				Generation: generations[i],
 			}); retireErr != nil {
 				retireErrs = append(retireErrs, fmt.Errorf("retire %s wake: %w", entries[i].Agent, retireErr))
 				continue

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -1351,7 +1351,7 @@ func TestRetireSessionRetiresConfirmedWakesAndRemovesRows(t *testing.T) {
 	argsLog := filepath.Join(dir, "amq-args.log")
 	t.Setenv("AMQ_KEEPALIVE_ARGS_LOG", argsLog)
 	fakeAMQ := filepath.Join(dir, "amq")
-	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+	if err := os.WriteFile(fakeAMQ, fakeAMQWakeCheckThen(`
 printf 'RETIRE %s\n' "$*" >> "$AMQ_KEEPALIVE_ARGS_LOG"
 printf '{"status":"retired","pid":4242}\n'
 `), 0o700); err != nil {
@@ -1422,7 +1422,7 @@ func TestRetireSessionRefusesWhenTargetStillExists(t *testing.T) {
 	}
 	t.Setenv("CMUX_BUNDLED_CLI_PATH", fakeCmux)
 	fakeAMQ := filepath.Join(dir, "amq")
-	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nexit 99\n"), 0o700); err != nil {
+	if err := os.WriteFile(fakeAMQ, fakeAMQWakeCheckThen("exit 99\n"), 0o700); err != nil {
 		t.Fatalf("write fake AMQ: %v", err)
 	}
 	adapters := hermeticCmuxRegistry(fakeCmux)
@@ -1466,7 +1466,7 @@ func TestRetireSessionRemovesRetiredAndLeavesRefused(t *testing.T) {
 	argsLog := filepath.Join(dir, "amq-args.log")
 	t.Setenv("AMQ_KEEPALIVE_ARGS_LOG", argsLog)
 	fakeAMQ := filepath.Join(dir, "amq")
-	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+	if err := os.WriteFile(fakeAMQ, fakeAMQWakeCheckThen(`
 printf 'RETIRE %s\n' "$*" >> "$AMQ_KEEPALIVE_ARGS_LOG"
 agent=""
 previous=""
@@ -1963,7 +1963,7 @@ func TestGCDryRunIsNonMutatingAndApplyRetiresCandidates(t *testing.T) {
 	amqCalls := filepath.Join(dir, "amq-calls.log")
 	t.Setenv("AMQ_KEEPALIVE_AMQ_CALLS", amqCalls)
 	fakeAMQ := filepath.Join(dir, "amq")
-	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+	if err := os.WriteFile(fakeAMQ, fakeAMQWakeCheckThen(`
 printf '%s\n' "$*" >> "$AMQ_KEEPALIVE_AMQ_CALLS"
 printf '%s\n' '{"status":"retired","agent":"codex","pid":4242}'
 `), 0o700); err != nil {
@@ -2053,7 +2053,7 @@ func TestGCApplyLeavesCandidateWhenRetireRefused(t *testing.T) {
 	amqCalls := filepath.Join(dir, "amq-calls.log")
 	t.Setenv("AMQ_KEEPALIVE_AMQ_CALLS", amqCalls)
 	fakeAMQ := filepath.Join(dir, "amq")
-	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+	if err := os.WriteFile(fakeAMQ, fakeAMQWakeCheckThen(`
 printf '%s\n' "$*" >> "$AMQ_KEEPALIVE_AMQ_CALLS"
 printf '%s\n' '{"status":"refused","reason":"owner-bound wake claims require recover-owner"}'
 exit 1
@@ -2121,6 +2121,10 @@ for arg in "$@"; do
   if [ "$previous" = "-ready-file" ]; then ready="$arg"; fi
   previous="$arg"
 done
+if [ "$1" = "wake" ] && [ "$2" = "check" ]; then
+  printf '%s\n' '{"schema":1,"live_wake":true,"image_status":"current","wake_generation":"0123456789abcdef0123456789abcdef"}'
+  exit 0
+fi
 if [ "$1" = "wake" ] && [ "$2" = "retire" ]; then
   printf 'RETIRE %s\n' "$me" >> "$AMQ_KEEPALIVE_AMQ_CALLS"
   sleep 0.05
@@ -2265,6 +2269,78 @@ printf '%s\n' '{"schema":1,"generation":"test-generation","target_digest":"test-
 	}
 }
 
+func TestGCApplyPassesObservedGenerationWhenLaterCheckWouldSeeReplacement(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cmux adapter requires macOS")
+	}
+	const (
+		observed    = "0123456789abcdef0123456789abcdef"
+		replacement = "fedcba9876543210fedcba9876543210"
+	)
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "registry.json")
+	target := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
+	store := registry.New(registryPath)
+	if _, err := store.Upsert(registry.Entry{
+		Root: "/tmp/old-session", Agent: "codex", Adapter: "cmux", Target: target,
+		State: registry.StateDetached, DetachedSince: time.Now().Add(-48 * time.Hour),
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	fakeCmux := filepath.Join(dir, "cmux")
+	if err := os.WriteFile(fakeCmux, []byte("#!/bin/sh\nprintf '%s\\n' '{\"windows\":[]}'\n"), 0o700); err != nil {
+		t.Fatalf("write fake cmux: %v", err)
+	}
+	t.Setenv("CMUX_BUNDLED_CLI_PATH", fakeCmux)
+	amqCalls := filepath.Join(dir, "amq-calls.log")
+	checkCount := filepath.Join(dir, "check-count")
+	t.Setenv("AMQ_KEEPALIVE_AMQ_CALLS", amqCalls)
+	t.Setenv("AMQ_KEEPALIVE_CHECK_COUNT", checkCount)
+	fakeAMQ := filepath.Join(dir, "amq")
+	if err := os.WriteFile(fakeAMQ, []byte(`#!/bin/sh
+printf '%s\n' "$*" >> "$AMQ_KEEPALIVE_AMQ_CALLS"
+if [ "$1" = "wake" ] && [ "$2" = "check" ]; then
+  n=0
+  if [ -f "$AMQ_KEEPALIVE_CHECK_COUNT" ]; then
+    n=$(cat "$AMQ_KEEPALIVE_CHECK_COUNT")
+  fi
+  printf '%s\n' "$((n + 1))" > "$AMQ_KEEPALIVE_CHECK_COUNT"
+  if [ "$n" = "0" ]; then
+    printf '%s\n' '{"schema":1,"live_wake":true,"image_status":"current","wake_generation":"0123456789abcdef0123456789abcdef"}'
+  else
+    printf '%s\n' '{"schema":1,"live_wake":true,"image_status":"current","wake_generation":"fedcba9876543210fedcba9876543210"}'
+  fi
+  exit 0
+fi
+printf '%s\n' '{"status":"retired","agent":"codex","pid":4242}'
+`), 0o700); err != nil {
+		t.Fatalf("write fake amq: %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{
+		"gc", "--registry", registryPath, "--min-detached-age", "0", "--apply",
+		"--amq", fakeAMQ, "--self", "/bin/amq-keepalive",
+	})
+	if code != 0 {
+		t.Fatalf("gc apply code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	data, err := os.ReadFile(amqCalls)
+	if err != nil {
+		t.Fatalf("read amq calls: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "wake check") || !strings.Contains(log, "wake retire") {
+		t.Fatalf("gc apply calls = %q, want check then retire", log)
+	}
+	if !strings.Contains(log, "--if-generation "+observed) {
+		t.Fatalf("retire used a later check: %q, want observed %s", log, observed)
+	}
+	if strings.Contains(log, "--if-generation "+replacement) {
+		t.Fatalf("retire used replacement generation: %q", log)
+	}
+}
+
 type boundaryAdapter struct {
 	name     string
 	probeErr error
@@ -2345,6 +2421,10 @@ func (a nilInventoryBoundaryAdapter) Inventory(context.Context, adapter.Ownershi
 }
 
 type countingRetirer struct{ calls int }
+
+func (r *countingRetirer) CheckWake(context.Context, amq.StartWakeRequest) (amq.WakeCheckResult, error) {
+	return amq.WakeCheckResult{Generation: "0123456789abcdef0123456789abcdef"}, nil
+}
 
 func (r *countingRetirer) RetireWake(context.Context, amq.RetireWakeRequest) (amq.RetireWakeResult, error) {
 	r.calls++
@@ -2627,7 +2707,7 @@ func TestRetireSessionMatchesRootAdapterAndAgentTogether(t *testing.T) {
 		t.Fatal(err)
 	}
 	fakeAMQ := filepath.Join(dir, "amq")
-	if err := os.WriteFile(fakeAMQ, []byte("#!/bin/sh\nprintf '%s\\n' '{\"status\":\"retired\",\"pid\":42}'\n"), 0o700); err != nil {
+	if err := os.WriteFile(fakeAMQ, fakeAMQWakeCheckThen("printf '%s\\n' '{\"status\":\"retired\",\"pid\":42}'\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	adapters := adapter.NewRegistry(
@@ -2729,10 +2809,14 @@ func hermeticCmuxRegistry(fakeCmuxPath string) adapter.Registry {
 }
 
 func fakeStartWakeScript(body string) []byte {
+	return fakeAMQWakeCheckThen(body)
+}
+
+func fakeAMQWakeCheckThen(body string) []byte {
 	body = strings.TrimPrefix(body, "#!/bin/sh\n")
 	return []byte(`#!/bin/sh
 if [ "$1" = "wake" ] && [ "$2" = "check" ]; then
-  printf '%s\n' '{"schema":1,"live_wake":false,"image_status":"unknown"}'
+  printf '%s\n' '{"schema":1,"live_wake":true,"image_status":"current","wake_generation":"0123456789abcdef0123456789abcdef"}'
   exit 0
 fi
 ` + body)

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -2431,6 +2431,49 @@ func (r *countingRetirer) RetireWake(context.Context, amq.RetireWakeRequest) (am
 	return amq.RetireWakeResult{}, nil
 }
 
+func TestObserveWakeGenerationRefusesLiveWakeWithoutGeneration(t *testing.T) {
+	const generation = "0123456789abcdef0123456789abcdef"
+	cases := []struct {
+		name    string
+		check   amq.WakeCheckResult
+		wantErr bool
+		want    string
+	}{
+		{name: "live omitted", check: amq.WakeCheckResult{LiveWake: true}, wantErr: true},
+		{name: "live present", check: amq.WakeCheckResult{LiveWake: true, Generation: generation}, want: generation},
+		{name: "not live omitted", check: amq.WakeCheckResult{LiveWake: false}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			retirer := &recordingRetirer{check: tc.check}
+			got, err := observeWakeGeneration(context.Background(), retirer, "/tmp/root", "codex")
+			if tc.wantErr {
+				if err == nil || got != "" || retirer.retireCalls != 0 {
+					t.Fatalf("got=%q err=%v retire=%d, want refuse with no retire", got, err, retirer.retireCalls)
+				}
+				return
+			}
+			if err != nil || got != tc.want || retirer.retireCalls != 0 {
+				t.Fatalf("got=%q err=%v retire=%d, want %q with no retire", got, err, retirer.retireCalls, tc.want)
+			}
+		})
+	}
+}
+
+type recordingRetirer struct {
+	check       amq.WakeCheckResult
+	retireCalls int
+}
+
+func (r *recordingRetirer) CheckWake(context.Context, amq.StartWakeRequest) (amq.WakeCheckResult, error) {
+	return r.check, nil
+}
+
+func (r *recordingRetirer) RetireWake(context.Context, amq.RetireWakeRequest) (amq.RetireWakeResult, error) {
+	r.retireCalls++
+	return amq.RetireWakeResult{}, nil
+}
+
 func TestRegisterEnvFailureDependsOnlyOnRequiredIdentity(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "target")

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -2278,7 +2278,7 @@ func TestGCApplyPassesObservedGenerationWhenLaterCheckWouldSeeReplacement(t *tes
 		replacement = "fedcba9876543210fedcba9876543210"
 	)
 	dir := t.TempDir()
-	registryPath := filepath.Join(dir, "registry.json")
+	registryPath := testRegistryPath(t, dir)
 	target := "cmux:surface:F901D722-6789-4BBB-9818-C4E97F20BEB3"
 	store := registry.New(registryPath)
 	if _, err := store.Upsert(registry.Entry{


### PR DESCRIPTION
## Summary
- Bead **amq-mmg** (review B findings 13 and 14).
- `wake check` exposes generation and target digest; `wake retire --if-generation` CAS under the lifecycle guard.
- Keepalive observes generation before probe/start so a replacement G2 survives.
- Darwin raw `kill(pid)` is `operator_only`; inject-via still uses the cooperative control socket.
- Tests: schema-2 live lock generation/digest values; omitted-generation refuse on refreshWakeImage and observeWakeGeneration.

## Test plan
- [x] `go test ./internal/cli ./internal/keepalive/amq ./internal/keepalive/app -count=1`
- [x] `go vet` native and `GOOS=windows GOARCH=amd64`

## Related
Bead amq-mmg. Review B findings 13, 14.

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestAcquireWakeLockAutomaticallyReplacesSameTerminalDifferentSessionRawWake: renamed to FailClosedWithoutSignal; Darwin raw numeric signaling is operator_only (B14) so acquisition must not SIGTERM a live raw wake
TestAcquireWakeLockAutomaticallyReplacesTerminalGoneRawWake: renamed to FailClosedWithoutSignal; Darwin has no pidfd, so a recycled PID must not be signaled
TestPrepareCoopWakeLockConsentedWakeSelfCleanupIsSuccess: removed automatic SIGTERM self-cleanup; Darwin fail-closed leaves the raw wake for the owning terminal
TestPrepareCoopWakeLockConsentedWakeSelfCleanupWithoutProvenExitWarnsAndProceeds: same B14 fail-closed path; no numeric signal after last identity recheck
TestPrepareCoopWakeLockLiveRawUndeterminableYesTakesOverWithWarning: takeover-by-signal is operator_only; test now proves refuse without mutation
END_WAKE_TEST_CHANGE_JUSTIFICATION

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ