### PR TITLE
docs(skills): align coop guide and skills with current behavior

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -32,7 +32,9 @@ an example. Managed `tmux`, `cmux`, and `ghostty` backends do not print those
 lines; they create the panes or windows themselves.
 
 Include Grok in the setup roster when it should join the session. AMQ starts
-only adapters that pass their capability probe.
+only adapters that pass their capability probe. For Cursor, `amq setup` uses
+the current `agent` command when it is on `PATH`, and falls back to legacy
+`cursor-agent` only when `agent` is absent.
 
 To disable auto-wake (e.g., in CI or non-TTY environments):
 ```bash

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -173,6 +173,10 @@ amq session resume feature-x
 approved `sha256:<hex>` digest matches. It is mutually exclusive with `-y`;
 `--preview` is also mutually exclusive with `-y`.
 
+For Cursor, setup uses the current `agent` command when it is on `PATH`; if it
+is absent, the preview explains that setup is falling back to legacy
+`cursor-agent`.
+
 Put provider flags in the committed `.amq/launch.json` `command` arrays. The
 launcher validates them and includes them in the semantic trust digest. The
 first semantic plan, and each plan change, needs an interactive trust
@@ -294,6 +298,15 @@ Do not parse stderr prose as a stable discriminator. `--json` preserves the
 same process exit codes. A read-only `list` on a mismatched session pin warns
 and continues; commands that consume or mutate mailbox state fail with code
 `5`.
+
+When a command reports per-agent outcomes, whole-command failures that precede
+any per-agent work keep codes `2`, `5`, and `3` and preempt mixed results. Once
+per-agent work begins, the process exit code is the highest-precedence per-agent
+outcome: `6` over `4` over `1` over `0`. Expected dispositions (`disabled`,
+`unsupported`, and policy-consistent `fresh`) contribute `0`. Launch Apply and
+lifecycle JSON also carry a typed mutation disposition (`not_applied`,
+`committed`, or `uncertain`) for the backend binding; that field is not a
+process exit code.
 
 ## Delivery Receipts
 

--- a/skills/amq-cli/references/message-format.md
+++ b/skills/amq-cli/references/message-format.md
@@ -48,6 +48,9 @@ Routing fields (set automatically by CLI — do not hand-craft):
 
 Notes:
 - Don’t edit message files directly; use the CLI.
+- On macOS and Linux, publication into `inbox/new` is a no-replace rename: a
+  colliding name keeps the existing file and the new attempt, rather than
+  overwriting. Readers still scan only `new` and `cur`.
 - The CLI auto-fills `id`, `created`, and a default `thread` when not provided.
 - `reply_to`, `reply_project`, and `from_project` are transport metadata stamped by the CLI.
 - Delivery outcomes are tracked separately in consumer-local receipt files. `drained` means the consumer ingested the message; `dlq` means ingest failed and the message moved to DLQ.


### PR DESCRIPTION
## Summary
- Align COOP.md and amq-cli with shipped behavior: Cursor `agent` default, unix no-replace into inbox/new, launch dispositions.
- Did not pre-document amq-mmg generation CAS.

## Test plan
- [x] `make check-skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ

Made with [Cursor](https://cursor.com)