### PR TITLE
docs: align launch and wake docs with the hardening wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,12 @@ lists cmux and Ghostty in `available_launchers` only after their Detect ping
 succeeds, not from `LookPath` alone. Operator live proofs are in
 [the public launch API guide](docs/launch-api.md).
 
-The stable executable path before symlink resolution is the trusted identity;
-retargeting that symlink is machine-owner territory, in the same trust class
-as changing `PATH`.
+Prepare records the requested and consulted executable paths plus their
+physical identity, including symlink hops. In subject schema 2, an inode,
+mtime, symlink-hop, or `PATH` retarget changes the subject before Apply. A
+provider, wrapper, or cwd replacement after authorization returns the typed
+`authorized_identity_changed` refusal before capability probing or ticket
+creation.
 
 The `commands` backend prints complete `coop exec` commands and exits `6`
 because executing them is the remaining operator action. When launch uses that
@@ -231,6 +234,11 @@ field and is advertised. amq-squad maps
 `current-window` to `current_window`, `vertical` to `columns`, and `horizontal`
 to `rows`; the decoder accepts only those underscore enums. Details live in
 [docs/launch-api.md](docs/launch-api.md).
+
+Schema-1 Apply remains valid for participant-only requests. A runnable
+participant requires re-Prepare: Apply returns exit code `6` with
+`reason_code=reprepare_required` and performs no launch mutation. Re-Prepare
+and Apply with schema 2 before launching runnable participants.
 
 Each command sets up the session environment, starts wake notifications, and
 launches the agent. See [COOP.md](COOP.md#running-co-op-mode) for co-op
@@ -610,10 +618,15 @@ For the read-only trace contract and its evidence limits, see [docs/trace.md](do
 
 AMQ uses the battle-tested [Maildir](https://cr.yp.to/proto/maildir.html) format:
 
-1. **Write** — Message written to `tmp/` directory
+1. **Write** — Message written to a unique attempt file in `tmp/`
 2. **Sync** — File fsynced to disk
-3. **Deliver** — Atomic rename to `new/` (never partial)
+3. **Deliver** — No-replace publication to `new/` (never overwrites a retained
+   same-name message; identical bytes are idempotent)
 4. **Process** — Reader moves to `cur/` after reading
+
+If a different same-name message is already in `new/`, AMQ preserves both
+copies and reports a collision. A claim never replaces a retained same-name
+message in `cur/`.
 
 This guarantees crash-safety: if the process dies mid-write, no corrupt message appears in the inbox. See [CLAUDE.md](CLAUDE.md) for the full directory layout.
 

--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -292,6 +292,11 @@ these fields describe the launch backend binding only, not session or roster
 durability codes. Post-commit failures remain action-required results with exit
 code `6`, not bare errors.
 
+Apply with schema 1 remains compatible for participant-only requests. If any
+participant is runnable, it returns `action_required` with
+`reason_code=reprepare_required` before launch mutation; re-Prepare and Apply
+with schema 2. A participant-only schema-1 Apply remains provisionable.
+
 The equivalent CLI split is:
 
 ```bash

--- a/docs/launch-recovery.md
+++ b/docs/launch-recovery.md
@@ -11,6 +11,13 @@ creation time. It can also retain the validated candidate binding and final
 conversation records needed to finish an interrupted commit. It contains no
 message data and is never a launcher binding.
 
+For a managed tmux join, the journal also records the authorized session
+binding and one identity-checked delta per added window. Each delta carries
+the session ID, name, nonce, epoch, window, and pane identity; AMQ revalidates
+that session before the next window mutation. A crash after a delta is written
+replays only the remaining deltas, so it cannot duplicate an added window or
+write to a replacement session.
+
 On the next launch, AMQ holds the session lease and follows these rules:
 
 - A valid binding from the same launch generation is authoritative. AMQ
@@ -26,7 +33,8 @@ On the next launch, AMQ holds the session lease and follows these rules:
   exact resource inventory known to the backend.
 
 `Create` failures preserve the journal unless the backend returns the typed
-definite-pre-create error that proves no resource was made. Partial creation is
+definite-pre-create error that proves no resource was made. That definite
+pre-create path also removes the pending execution tickets. Partial creation is
 never adoptable. A Ghostty crash between window creation and binding persistence
 leaves that window for manual close; AMQ never treats the gap as proven absence
 and never creates a duplicate.

--- a/docs/session-routing.md
+++ b/docs/session-routing.md
@@ -53,6 +53,12 @@ or delete message files; unsafe types, symlinks, unreadable paths, and
 concurrent layout changes fail closed. `--base-root` must name the target or
 its direct parent.
 
+Message publication uses a unique attempt file in `inbox/tmp` and a
+no-replace `tmp -> new` commit. An existing same-name `new` file is never
+overwritten: identical bytes are an idempotent success, while different bytes
+preserve both copies and return a collision. Claiming `new -> cur` also refuses
+to replace a retained same-name message.
+
 `send --from-session` is deliberately double-explicit and resolves its source
 from the supplied raw base; callers must verify that base. See
 [issue #104](https://github.com/avivsinai/agent-message-queue/issues/104).


### PR DESCRIPTION
Aligns README and docs/{launch-api,launch-recovery,session-routing}.md with the landed hardening wave (identity binding, reprepare_required, no-replace maildir semantics incl. Windows via #1zy, tmux join journaling). All claims verified against main by an execution-gated docs review.

Authored by codex (session1); pushed by claude because the codex harness blocks GitHub writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K8p3E2gg24vxNb3djgpVQ