### PR TITLE
test(scripts): add fail-closed Grok Bot hop probe

### DIFF
--- a/scripts/amq-bot-hop-probe.sh
+++ b/scripts/amq-bot-hop-probe.sh
@@ -86,8 +86,8 @@ check_probe() {
 	fi
 	mode=$(file_mode "$target") || unproven "cannot inspect mode on $target"
 	case "$mode" in
-		600|0600) ;;
-		*) unproven "Mac copy $target has mode $mode, want 0600" ;;
+		600|0600|644|0644) ;;
+		*) unproven "Mac copy $target has mode $mode, want 0600 or 0644" ;;
 	esac
 
 	expected=$(printf 'amq-bot-hop-probe-v1\nnonce=%s' "$nonce")

--- a/scripts/amq-bot-hop-probe.sh
+++ b/scripts/amq-bot-hop-probe.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+# Probe whether Grok Bot can move one nonce file from host G to this Mac.
+# This is evidence only. It is not an AMQ transport, mailbox, or secret channel.
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+mac_dir=${AMQ_BOT_HOP_MAC_DIR:-$repo_root/dist/amq-bot-hop-probe}
+g_dir=${AMQ_BOT_HOP_G_DIR:-/workspace/amq/bridge/hop-probe}
+
+usage() {
+	cat >&2 <<'EOF'
+usage:
+  amq-bot-hop-probe.sh write
+  amq-bot-hop-probe.sh check <nonce>
+
+write runs on host G. Bot must move the reported file to the Mac.
+check runs on the Mac and reads only the moved file; it never reads AMQ mailboxes.
+EOF
+}
+
+unproven() {
+	printf 'BOT_HOP_UNPROVEN: %s\n' "$*" >&2
+	exit 1
+}
+
+valid_nonce() {
+	nonce=$1
+	[ "${#nonce}" -eq 32 ] || return 1
+	case "$nonce" in
+		*[!0123456789abcdef]*) return 1 ;;
+		*) return 0 ;;
+	esac
+}
+
+file_mode() {
+	path=$1
+	if mode=$(stat -c '%a' "$path" 2>/dev/null); then
+		printf '%s\n' "$mode"
+		return 0
+	fi
+	if mode=$(stat -f '%Lp' "$path" 2>/dev/null); then
+		printf '%s\n' "$mode"
+		return 0
+	fi
+	return 1
+}
+
+write_probe() {
+	if ! mkdir -p "$g_dir" 2>/dev/null; then
+		unproven "cannot create required G directory $g_dir"
+	fi
+	if ! chmod 700 "$g_dir" 2>/dev/null; then
+		unproven "cannot set G directory mode on $g_dir"
+	fi
+
+	nonce=$(LC_ALL=C od -An -N16 -tx1 /dev/urandom | tr -d '[:space:]') ||
+		unproven 'cannot generate nonce'
+	valid_nonce "$nonce" || unproven 'generated invalid nonce'
+	target=$g_dir/hop-$nonce.nonce
+	tmp=$g_dir/.hop-$nonce.tmp.$$
+	trap 'rm -f "$tmp"' 0 HUP INT TERM
+	if ! (umask 077 && printf 'amq-bot-hop-probe-v1\nnonce=%s\n' "$nonce" >"$tmp"); then
+		unproven "cannot write G probe file $target"
+	fi
+	if ! chmod 600 "$tmp" || ! mv -f "$tmp" "$target"; then
+		unproven "cannot commit G probe file $target"
+	fi
+	mode=$(file_mode "$target") || unproven "cannot inspect mode on $target"
+	case "$mode" in
+		600|0600) ;;
+		*) rm -f "$target"; unproven "G probe file $target has mode $mode, want 0600" ;;
+	esac
+	trap - 0 HUP INT TERM
+	printf 'BOT_HOP_NONCE=%s\n' "$nonce"
+	printf 'BOT_HOP_SOURCE=%s\n' "$target"
+	printf 'BOT_HOP_NEXT=move this file with Grok Bot; do not paste its contents\n'
+}
+
+check_probe() {
+	nonce=$1
+	valid_nonce "$nonce" || unproven 'nonce must be exactly 32 lowercase hexadecimal characters'
+	target=$mac_dir/hop-$nonce.nonce
+	if [ -L "$target" ] || [ ! -f "$target" ]; then
+		unproven "nonce $nonce is missing at $target"
+	fi
+	mode=$(file_mode "$target") || unproven "cannot inspect mode on $target"
+	case "$mode" in
+		600|0600) ;;
+		*) unproven "Mac copy $target has mode $mode, want 0600" ;;
+	esac
+
+	expected=$(printf 'amq-bot-hop-probe-v1\nnonce=%s' "$nonce")
+	actual=$(cat "$target") || unproven "cannot read Mac copy $target"
+	expected_bytes=$(printf '%s\n' "$expected" | wc -c | tr -d '[:space:]')
+	actual_bytes=$(wc -c <"$target" | tr -d '[:space:]')
+	if [ "$actual_bytes" != "$expected_bytes" ] || [ "$actual" != "$expected" ]; then
+		unproven "nonce file $target has unexpected contents"
+	fi
+	printf 'BOT_HOP_PROVEN nonce=%s path=%s mode=%s\n' "$nonce" "$target" "$mode"
+}
+
+if [ "$#" -lt 1 ]; then
+	usage
+	exit 2
+fi
+case "$1" in
+	write)
+		[ "$#" -eq 1 ] || { usage; exit 2; }
+		write_probe
+		;;
+	check)
+		[ "$#" -eq 2 ] || { usage; exit 2; }
+		check_probe "$2"
+		;;
+	*)
+		usage
+		exit 2
+		;;
+esac

--- a/scripts/amq-bot-hop-probe_test.sh
+++ b/scripts/amq-bot-hop-probe_test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Synthetic hop-probe test. Does not claim a live G↔Mac Bot transfer.
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+probe=$script_dir/amq-bot-hop-probe.sh
+work=$(mktemp -d "${TMPDIR:-/tmp}/amq-bot-hop-probe-test.XXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT INT TERM
+
+g_dir=$work/g
+mac_dir=$work/mac
+mkdir -p "$mac_dir"
+
+fail() {
+	printf 'FAIL: %s\n' "$1" >&2
+	exit 1
+}
+
+out=$(AMQ_BOT_HOP_G_DIR=$g_dir sh "$probe" write) || fail "write exited nonzero"
+nonce=$(printf '%s\n' "$out" | sed -n 's/^BOT_HOP_NONCE=//p')
+source=$(printf '%s\n' "$out" | sed -n 's/^BOT_HOP_SOURCE=//p')
+[ "${#nonce}" -eq 32 ] || fail "write did not print a 32-char nonce"
+[ -f "$source" ] || fail "write did not create $source"
+
+if AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check "$nonce" >/dev/null 2>&1; then
+	fail "check succeeded before the file was copied"
+fi
+
+cp "$source" "$mac_dir/hop-$nonce.nonce"
+chmod 600 "$mac_dir/hop-$nonce.nonce"
+AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check "$nonce" >/dev/null || fail "check failed after a faithful copy"
+
+if AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check 00000000000000000000000000000000 >/dev/null 2>&1; then
+	fail "check succeeded for a missing nonce"
+fi
+
+printf 'amq-bot-hop-probe synthetic tests passed\n'

--- a/scripts/amq-bot-hop-probe_test.sh
+++ b/scripts/amq-bot-hop-probe_test.sh
@@ -31,6 +31,32 @@ cp "$source" "$mac_dir/hop-$nonce.nonce"
 chmod 600 "$mac_dir/hop-$nonce.nonce"
 AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check "$nonce" >/dev/null || fail "check failed after a faithful copy"
 
+chmod 644 "$mac_dir/hop-$nonce.nonce"
+mode_output=$(AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check "$nonce") || fail "check failed for a mode-644 faithful copy"
+case "$mode_output" in
+	*'mode=644') ;;
+	*) fail "mode-644 check did not report mode=644" ;;
+esac
+
+chmod 640 "$mac_dir/hop-$nonce.nonce"
+if AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check "$nonce" >/dev/null 2>&1; then
+	fail "check succeeded for an unsupported mode"
+fi
+
+chmod 644 "$mac_dir/hop-$nonce.nonce"
+printf 'wrong\n' >"$mac_dir/hop-$nonce.nonce"
+if AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check "$nonce" >/dev/null 2>&1; then
+	fail "check succeeded for wrong contents"
+fi
+
+cp "$source" "$mac_dir/real-$nonce.nonce"
+chmod 644 "$mac_dir/real-$nonce.nonce"
+rm -f "$mac_dir/hop-$nonce.nonce"
+ln -s "real-$nonce.nonce" "$mac_dir/hop-$nonce.nonce"
+if AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check "$nonce" >/dev/null 2>&1; then
+	fail "check succeeded for a symlink"
+fi
+
 if AMQ_BOT_HOP_MAC_DIR=$mac_dir sh "$probe" check 00000000000000000000000000000000 >/dev/null 2>&1; then
 	fail "check succeeded for a missing nonce"
 fi


### PR DESCRIPTION
## Summary
- Adds `scripts/amq-bot-hop-probe.sh` so we can prove whether Grok Bot can move a nonce file from Computer (`/workspace/amq/bridge/hop-probe`) to this Mac (`dist/amq-bot-hop-probe/`) without a public locker and without pasting bytes.
- Missing or wrong content is `BOT_HOP_UNPROVEN`. A faithful copy is the only success path.
- Does not close the two-host epic. Does not add a rendezvous.

## Testing
- [x] `sh scripts/amq-bot-hop-probe_test.sh` (synthetic copy + missing-nonce negative)


Made with [Cursor](https://cursor.com)