### PR TITLE
feat(cli): treat Grok Build as a first-class skill peer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ __pycache__/
 .agents/**
 !.agents/skills/
 !.agents/skills/**
+.grok/**
+!.grok/skills/
+!.grok/skills/**
 .agent-mail/
 
 # Added by ggshield

--- a/.grok/skills/amq-cli
+++ b/.grok/skills/amq-cli
@@ -1,0 +1,1 @@
+../../skills/amq-cli

--- a/.grok/skills/amq-spec
+++ b/.grok/skills/amq-spec
@@ -1,0 +1,1 @@
+../../skills/amq-spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,9 +272,9 @@ hostile boundary rather than only a helper or mock.
 ## Skill Development
 
 Canonical skills live in `skills/amq-cli/` and `skills/amq-spec/`.
-`.claude/skills/` and `.agents/skills/` are symlinks to those directories so
-local runs use repository changes. Project skills take precedence over user
-installations.
+`.claude/skills/`, `.agents/skills/`, and `.grok/skills/` are symlinks to those
+directories so local runs use repository changes. Project skills take
+precedence over user installations.
 
 Edit only the canonical directory, bump skill metadata when publishing, run
 `make check-skills`, and test the project-local skill. Do not create divergent

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,7 @@ mkdir -p ~/.grok/skills
 cp -r /tmp/amq/.agents/skills/amq-cli ~/.grok/skills/
 rm -rf /tmp/amq
 ```
-A project-local copy under `.grok/skills/amq-cli` in the repo works the same way if you prefer per-project installs. Inside a checkout of this repository, Grok discovers the bundled `.claude/skills/amq-cli` through its Claude Code compatibility with no copying at all; it also supports user-level `~/.agents/skills`. See the [xAI skill discovery docs](https://docs.x.ai/build/features/skills-plugins-marketplaces) for the authoritative list of paths Grok CLI checks.
+This repository ships `.grok/skills/amq-cli` as a symlink to the canonical skill, so Grok Build loads it without copying. Grok also discovers `.agents/skills` and `.claude/skills`. See the [xAI skill discovery docs](https://docs.x.ai/build/features/skills-plugins-marketplaces) for the authoritative list of paths Grok CLI checks.
 
 Restart your agent after installing.
 

--- a/Makefile
+++ b/Makefile
@@ -52,15 +52,8 @@ contract-check:
 		go build -o "$$candidate_dir/amq" ./cmd/amq; \
 		bash scripts/check-keepalive-amq-contract.sh "$$candidate_dir/amq"
 
-# Skill integrity: skills/ is canonical, .claude/skills/ and .agents/skills/ are symlinks
+# Skill integrity: skills/ is canonical; .claude, .agents, and .grok skills are symlinks.
+# The negative fixture must run first so a fail-open checker cannot hide behind a later live pass.
 check-skills:
-	@echo "Checking skill symlinks..."
-	@for skill in amq-cli amq-spec; do \
-		test -L .claude/skills/$$skill || (echo "❌ .claude/skills/$$skill is not a symlink" && exit 1); \
-		test -L .agents/skills/$$skill || (echo "❌ .agents/skills/$$skill is not a symlink" && exit 1); \
-		test "$$(readlink .claude/skills/$$skill)" = "../../skills/$$skill" || (echo "❌ .claude/skills/$$skill target wrong" && exit 1); \
-		test "$$(readlink .agents/skills/$$skill)" = "../../skills/$$skill" || (echo "❌ .agents/skills/$$skill target wrong" && exit 1); \
-	done
-	@diff -rq skills/amq-cli .claude/skills/amq-cli || (echo "❌ amq-cli content mismatch" && exit 1)
-	@diff -rq skills/amq-spec .claude/skills/amq-spec || (echo "❌ amq-spec content mismatch" && exit 1)
-	@echo "✓ Skill symlinks valid"
+	@bash scripts/test_check_skills.sh
+	@bash scripts/check-skills.sh

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Cross-host mail is companion `amq-bridge` (send / local apply / reply), not Core
 
 About five minutes from install to the first delivered message. You need two
 agent CLIs on `PATH`. This walkthrough uses **Claude Code** (`claude`) and
-**Codex CLI** (`codex`) on one machine. `amq setup` also detects Cursor when
-`agent` is on `PATH` (or legacy `cursor-agent` if `agent` is absent).
+**Codex CLI** (`codex`) on one machine. `amq setup` also detects Grok Build
+(`grok`) and Cursor when `agent` is on `PATH` (or legacy `cursor-agent` if
+`agent` is absent).
 
 Native Windows can run the core queue from the Windows ZIP, but this
 walkthrough needs `coop exec` and `wake`, which are not supported natively.
@@ -117,7 +118,7 @@ In the repository the two agents will share:
 amq setup
 ```
 
-Setup probes for Claude and Codex (and Cursor when present), previews the
+Setup probes for Claude, Codex, and Grok (and Cursor when present), previews the
 roster and launcher preference, then writes `.amqrc`, `.amq/launch.json`,
 local preferences, the default session, and roster mailboxes. Confirm the
 preview.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -60,7 +60,7 @@ func runDoctor(args []string) error {
 		"  - Mailbox directory permissions",
 		"  - Agent configuration (config.json)",
 		"  - Extension metadata manifests and diagnostics",
-		"  - Skill installation (Claude Code / Codex)",
+		"  - Skill installation (Claude Code / Codex / Grok Build)",
 		"",
 		"With --ops, also checks runtime health:",
 		"  - Queue depth and oldest unread per agent",
@@ -159,11 +159,10 @@ func runDoctor(args []string) error {
 		result.Checks = append(result.Checks, checkExtensions(manifests, diagnostics))
 	}
 
-	// Check 7: Claude Code skill
+	// Check 7-9: Claude Code, Codex, and Grok Build skills
 	result.Checks = append(result.Checks, checkSkill("claude"))
-
-	// Check 8: Codex skill
 	result.Checks = append(result.Checks, checkSkill("codex"))
+	result.Checks = append(result.Checks, checkSkill("grok"))
 
 	// Ops checks (runtime health)
 	if *opsFlag && root != "" {
@@ -859,7 +858,9 @@ func checkMailboxInventory(inventory fsq.MailboxInventory, repair *fsq.MailboxRe
 func checkSkill(agent string) doctorCheck {
 	check := doctorCheck{Name: fmt.Sprintf("%s skill", agent)}
 
-	if agent != "claude" && agent != "codex" {
+	switch agent {
+	case "claude", "codex", "grok":
+	default:
 		check.Status = "warn"
 		check.Message = "unknown agent"
 		return check

--- a/internal/cli/doctor_skill_test.go
+++ b/internal/cli/doctor_skill_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckSkillGrokProjectLocalInstalled(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("HOME", dir)
+	writeSkillFile(t, filepath.Join(".grok", "skills", "amq-cli", "SKILL.md"))
+
+	got := checkSkill("grok")
+	if got.Name != "grok skill" || got.Status != "ok" || got.Message != "installed (project-local)" {
+		t.Fatalf("grok project-local skill = %#v", got)
+	}
+}
+
+func TestCheckSkillGrokMissingWarnsNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("HOME", dir)
+
+	got := checkSkill("grok")
+	if got.Status != "warn" || !strings.Contains(got.Message, "not installed") {
+		t.Fatalf("missing grok skill = %#v", got)
+	}
+}
+
+func TestCheckSkillUnknownAgent(t *testing.T) {
+	got := checkSkill("not-an-agent")
+	if got.Status != "warn" || got.Message != "unknown agent" {
+		t.Fatalf("unknown agent skill = %#v", got)
+	}
+}
+
+func TestCheckSkillGrokDoesNotInheritClaudePath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("HOME", dir)
+	writeSkillFile(t, filepath.Join(".claude", "skills", "amq-cli", "SKILL.md"))
+
+	got := checkSkill("grok")
+	if got.Status != "warn" || !strings.Contains(got.Message, "not installed") {
+		t.Fatalf("grok skill with only claude path = %#v", got)
+	}
+}
+
+func TestDoctorJSONIncludesGrokSkillCheck(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "claude")
+	findDoctorCheck(t, runDoctorMailboxJSON(t, root).Checks, "grok skill")
+}
+
+func writeSkillFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("# skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -137,7 +137,7 @@ func runSetup(args []string) (returnErr error) {
 	jsonFlag := fs.Bool("json", false, "Emit JSON output")
 	usage := usageWithFlags(fs, "amq setup [options]",
 		"Configure this project after previewing every change.",
-		"Detects Claude and Codex through their adapter capability probes.",
+		"Detects Claude, Codex, Cursor, and Grok through their adapter capability probes.",
 		"Launcher detection is probe-only; setup never calls a launcher backend.")
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err

--- a/scripts/check-skills.sh
+++ b/scripts/check-skills.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Canonical skills/ must match the .claude, .agents, and .grok skill trees.
+set -euo pipefail
+
+fail() {
+	echo "❌ $*" >&2
+	exit 1
+}
+
+echo "Checking skill symlinks..."
+for dest in .claude .agents .grok; do
+	for skill in amq-cli amq-spec; do
+		[[ -L "$dest/skills/$skill" ]] || fail "$dest/skills/$skill is not a symlink"
+		[[ "$(readlink "$dest/skills/$skill")" == "../../skills/$skill" ]] || fail "$dest/skills/$skill target wrong"
+	done
+	diff -rq skills/amq-cli "$dest/skills/amq-cli" || fail "amq-cli content mismatch in $dest"
+	diff -rq skills/amq-spec "$dest/skills/amq-spec" || fail "amq-spec content mismatch in $dest"
+done
+echo "✓ Skill symlinks valid"

--- a/scripts/test_check_skills.sh
+++ b/scripts/test_check_skills.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Negative proof: a wrong Grok skill symlink must fail the checker.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/scripts/check-skills.sh"
+FIX="$(mktemp -d "${TMPDIR:-/tmp}/amq-check-skills.XXXXXX")"
+cleanup() { rm -rf "$FIX"; }
+trap cleanup EXIT INT TERM
+
+mkdir -p "$FIX/skills/amq-cli" "$FIX/skills/amq-spec" \
+	"$FIX/.claude/skills" "$FIX/.agents/skills" "$FIX/.grok/skills"
+printf 'cli\n' >"$FIX/skills/amq-cli/SKILL.md"
+printf 'spec\n' >"$FIX/skills/amq-spec/SKILL.md"
+for dest in .claude .agents .grok; do
+	ln -s ../../skills/amq-cli "$FIX/$dest/skills/amq-cli"
+	ln -s ../../skills/amq-spec "$FIX/$dest/skills/amq-spec"
+done
+
+if ! (cd "$FIX" && bash "$SCRIPT" >/dev/null); then
+	echo "FAIL: valid skill tree was rejected" >&2
+	exit 1
+fi
+
+rm -f "$FIX/.grok/skills/amq-cli"
+ln -s ../../skills/not-amq-cli "$FIX/.grok/skills/amq-cli"
+if (cd "$FIX" && bash "$SCRIPT" >/dev/null 2>&1); then
+	echo "FAIL: bad grok symlink passed; checker fails open" >&2
+	exit 1
+fi
+
+echo "✓ check-skills fails closed on a bad grok symlink"


### PR DESCRIPTION
## Summary
Grok Build (`grok`) already has a launch adapter. This makes skill discovery and `amq doctor` match Claude/Codex.

- Ship `.grok/skills/{amq-cli,amq-spec}` as canonical skill symlinks
- `amq doctor` checks the grok skill
- `make check-skills` fails closed; negative fixture plants a bad grok symlink and requires nonzero

## Review
Codex APPROVE on session1 (`p2p/codex__grok`) after a BLOCK on fail-open `check-skills`. Bead `amq-029`.

## Test plan
- [x] `go test ./internal/cli -run 'TestCheckSkill|TestDoctorJSONIncludesGrokSkillCheck'`
- [x] `make check-skills` (includes hostile grok symlink fixture)
- [x] Pre-push `make ci` passed