### PR TITLE
feat(bridge): apply Bot-dropped envelopes into local Maildir

### DIFF
--- a/cmd/amq-bridge/README.md
+++ b/cmd/amq-bridge/README.md
@@ -40,6 +40,30 @@ rendezvous is an untrusted blob store; `--allow-source-host` is only an exact
 routing allowlist and does not authenticate the peer. The courier verifies the
 Ed25519 signature before applying a polled envelope.
 
+## Local file apply
+
+For a Bot-local handoff without a public rendezvous, drop one complete JSON
+`internal/bridge.Envelope` under the ignored local queue path
+`<AMQ root>/bridge/drop/`, then run:
+
+```sh
+amq-bridge apply-file \
+  --root "$AM_ROOT" \
+  --file "$AM_ROOT/bridge/drop/envelope.json"
+```
+
+The command reads only that regular, non-symlink file. It loads the local
+`bridge/host-id` and the trusted public key selected by the envelope's
+`source_host`, verifies the Ed25519 signature and payload digest, requires the
+`dest_alias` host to match the local host-id, and then calls the same
+`ApplyEnvelope` Maildir path as the courier. It prints and durably records a
+`destination_maildir_committed` receipt under `<AMQ root>/bridge/receipts/`.
+Repeating the same file is an idempotent replay; the same transfer key with a
+different payload is a conflict. Unsigned or forged envelopes, foreign
+destinations, symlinks, and files outside `bridge/drop` are rejected. This
+path does not provide reverse Mac-to-G communication and does not create a
+public locker.
+
 One bounded bidirectional cycle on the Mac uses a **local** receive alias and
 a **remote** send alias. Do not poll a foreign dest alias into this root:
 

--- a/cmd/amq-bridge/apply_file.go
+++ b/cmd/amq-bridge/apply_file.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/bridge"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	applyDropRelDir    = "bridge/drop"
+	maxApplyFileSize   = 16 * 1024 * 1024
+	applyReceiptRelDir = "bridge/receipts"
+)
+
+// runApplyFile authenticates one complete envelope dropped under the local
+// bridge drop directory, applies it to the receiver-owned Maildir, and emits
+// a local destination_maildir_committed receipt. It never contacts a
+// rendezvous or executes anything from the envelope.
+func runApplyFile(args []string) error {
+	fs := flag.NewFlagSet("amq-bridge apply-file", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	rootFlag := fs.String("root", os.Getenv("AM_ROOT"), "local AMQ root")
+	fileFlag := fs.String("file", "", "complete envelope file under <root>/bridge/drop")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return usageError("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if strings.TrimSpace(*rootFlag) == "" {
+		return usageError("--root is required")
+	}
+	if strings.TrimSpace(*fileFlag) == "" {
+		return usageError("--file is required")
+	}
+
+	rootPath, err := filepath.Abs(strings.TrimSpace(*rootFlag))
+	if err != nil {
+		return fmt.Errorf("resolve bridge root: %w", err)
+	}
+	fileRel, err := applyFileRelPath(rootPath, *fileFlag)
+	if err != nil {
+		return err
+	}
+	identity, err := fsq.SnapshotDeliveryRoot(rootPath)
+	if err != nil {
+		return err
+	}
+	root, err := fsq.OpenDeliveryRoot(rootPath, identity)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+
+	raw, err := readApplyFile(root, fileRel)
+	if err != nil {
+		return fmt.Errorf("read dropped envelope %s: %w", root.DisplayPath(fileRel), err)
+	}
+	env, err := bridge.UnmarshalEnvelope(raw)
+	if err != nil {
+		return fmt.Errorf("parse dropped envelope %s: %w", root.DisplayPath(fileRel), err)
+	}
+	localHost, err := bridge.LoadHostIDFromDeliveryRoot(root)
+	if err != nil {
+		return err
+	}
+	destHost, destAgent, err := bridge.ParseAlias(env.DestAlias)
+	if err != nil {
+		return err
+	}
+	if destHost != localHost {
+		return fmt.Errorf("bridge dest_alias host %q is not local host-id %q", destHost, localHost)
+	}
+	public, generation, err := bridge.LoadTrustedFromDeliveryRoot(root, env.SourceHost)
+	if err != nil {
+		return fmt.Errorf("authenticate source host %q: %w", env.SourceHost, err)
+	}
+	if err := bridge.VerifyEnvelope(env, public, generation); err != nil {
+		return fmt.Errorf("authenticate transfer %s: %w", env.TransferID, err)
+	}
+	applyResult, err := bridge.ApplyEnvelope(root, localHost, destAgent, env)
+	if err != nil {
+		return fmt.Errorf("apply transfer %s: %w", env.TransferID, err)
+	}
+	receipt := Receipt{
+		Stage:           ReceiptDestinationMaildirCommit,
+		TransferID:      env.TransferID,
+		PayloadSHA256:   env.PayloadSHA256,
+		Replayed:        applyResult.Replayed,
+		SourceMessageID: env.SourceMessageID,
+		CommittedPath:   applyResult.Path,
+		EmittedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if err := writeBridgeReceipt(root, applyReceiptRelDir, receipt); err != nil {
+		return fmt.Errorf("write destination receipt for %s: %w", env.TransferID, err)
+	}
+	return json.NewEncoder(os.Stdout).Encode(receipt)
+}
+
+func applyFileRelPath(rootPath, rawPath string) (string, error) {
+	path := strings.TrimSpace(rawPath)
+	if path == "" {
+		return "", usageError("--file is required")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(rootPath, path)
+	}
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve dropped envelope: %w", err)
+	}
+	dropPath := filepath.Join(rootPath, applyDropRelDir)
+	rel, err := filepath.Rel(dropPath, path)
+	if err != nil {
+		return "", fmt.Errorf("resolve dropped envelope: %w", err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("dropped envelope must be under %s", dropPath)
+	}
+	return filepath.Join(applyDropRelDir, rel), nil
+}
+
+func readApplyFile(root *fsq.DeliveryRoot, rel string) ([]byte, error) {
+	file, info, err := root.OpenRegularNoFollow(rel)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	if info.Size() > maxApplyFileSize {
+		return nil, fmt.Errorf("envelope exceeds %d bytes", maxApplyFileSize)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxApplyFileSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxApplyFileSize {
+		return nil, fmt.Errorf("envelope exceeds %d bytes", maxApplyFileSize)
+	}
+	return data, nil
+}

--- a/cmd/amq-bridge/apply_file_test.go
+++ b/cmd/amq-bridge/apply_file_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/bridge"
+)
+
+func TestApplyFileVerifiesAndCommitsEnvelopeWithReceipt(t *testing.T) {
+	root := newBridgeRoot(t, "claude")
+	ensureHostID(t, root, "mac")
+	ensureTrusted(t, root, "grok-host")
+	env := applyFileTestEnvelope(t, "apply-file", testMessage(t, "apply-file-message", "apply-file-thread", "codex", "from bot"))
+	path := writeApplyFileEnvelope(t, root, "envelope.json", env)
+
+	if err := runApplyFile([]string{"--root", root, "--file", path}); err != nil {
+		t.Fatalf("runApplyFile: %v", err)
+	}
+
+	committed := filepath.Join(root, "agents", "claude", "inbox", "new", bridge.TransferFilename(env.SourceHost, env.TransferID))
+	got, err := os.ReadFile(committed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(env.Payload) {
+		t.Fatalf("committed payload = %q, want %q", got, env.Payload)
+	}
+	receipt := readApplyReceipt(t, root, env)
+	if receipt.Stage != ReceiptDestinationMaildirCommit || receipt.Replayed || receipt.CommittedPath != committed {
+		t.Fatalf("receipt = %#v, want first destination commit at %s", receipt, committed)
+	}
+}
+
+func TestApplyFileReplayAndConflictPreserveMaildirAndReceipt(t *testing.T) {
+	root := newBridgeRoot(t, "claude")
+	ensureHostID(t, root, "mac")
+	ensureTrusted(t, root, "grok-host")
+	env := applyFileTestEnvelope(t, "replay-file", []byte("first"))
+	path := writeApplyFileEnvelope(t, root, "envelope.json", env)
+
+	if err := runApplyFile([]string{"--root", root, "--file", path}); err != nil {
+		t.Fatalf("first runApplyFile: %v", err)
+	}
+	if err := runApplyFile([]string{"--root", root, "--file", path}); err != nil {
+		t.Fatalf("replay runApplyFile: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "agents", "claude", "inbox", "new"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("inbox entries after replay = %d, want 1", len(entries))
+	}
+
+	conflict := applyFileTestEnvelope(t, env.TransferID, []byte("different"))
+	writeApplyFileEnvelope(t, root, "envelope.json", conflict)
+	err = runApplyFile([]string{"--root", root, "--file", path})
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("conflict error = %v, want EEXIST", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "agents", "claude", "inbox", "new", bridge.TransferFilename(env.SourceHost, env.TransferID)))
+	if err != nil || string(got) != "first" {
+		t.Fatalf("conflict changed committed payload: %q %v", got, err)
+	}
+	receipt := readApplyReceipt(t, root, env)
+	if receipt.PayloadSHA256 != env.PayloadSHA256 {
+		t.Fatalf("conflict changed receipt digest: %#v", receipt)
+	}
+}
+
+func TestApplyFileRejectsForgedSourceHostBeforeMaildirCommit(t *testing.T) {
+	root := newBridgeRoot(t, "claude")
+	ensureHostID(t, root, "mac")
+	ensureTrusted(t, root, "grok-host")
+	env := applyFileTestEnvelope(t, "forged-file", []byte("forged"))
+	if err := bridge.SignEnvelope(&env, testHostKey("attacker", "1")); err != nil {
+		t.Fatal(err)
+	}
+	path := writeApplyFileEnvelope(t, root, "forged.json", env)
+
+	err := runApplyFile([]string{"--root", root, "--file", path})
+	if err == nil || !strings.Contains(err.Error(), "authenticate") {
+		t.Fatalf("forged source error = %v, want authentication refusal", err)
+	}
+	assertApplyNotCommitted(t, root, env)
+}
+
+func TestApplyFileRejectsUnsignedEnvelopeBeforeMaildirCommit(t *testing.T) {
+	root := newBridgeRoot(t, "claude")
+	ensureHostID(t, root, "mac")
+	ensureTrusted(t, root, "grok-host")
+	env := applyFileTestEnvelope(t, "unsigned-file", []byte("unsigned"))
+	env.Signature = ""
+	raw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := writeApplyFileRaw(t, root, "unsigned.json", raw)
+
+	if err := runApplyFile([]string{"--root", root, "--file", path}); err == nil {
+		t.Fatal("unsigned envelope was accepted")
+	}
+	assertApplyNotCommitted(t, root, env)
+}
+
+func TestApplyFileRejectsForeignDestinationAndSymlink(t *testing.T) {
+	root := newBridgeRoot(t, "claude")
+	ensureHostID(t, root, "mac")
+	ensureTrusted(t, root, "grok-host")
+	env := applyFileTestEnvelope(t, "foreign-file", []byte("foreign"))
+	env.DestAlias = "other/claude"
+	if err := bridge.SignEnvelope(&env, testHostKey("grok-host", "1")); err != nil {
+		t.Fatal(err)
+	}
+	path := writeApplyFileEnvelope(t, root, "foreign.json", env)
+	if err := runApplyFile([]string{"--root", root, "--file", path}); err == nil || !strings.Contains(err.Error(), "local host-id") {
+		t.Fatalf("foreign destination error = %v, want local host refusal", err)
+	}
+	assertApplyNotCommitted(t, root, env)
+
+	env = applyFileTestEnvelope(t, "symlink-file", []byte("symlink"))
+	realPath := writeApplyFileEnvelope(t, root, "real.json", env)
+	symlinkPath := filepath.Join(root, applyDropRelDir, "symlink.json")
+	if err := os.Symlink(realPath, symlinkPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := runApplyFile([]string{"--root", root, "--file", symlinkPath}); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlink error = %v, want symlink refusal", err)
+	}
+	assertApplyNotCommitted(t, root, env)
+}
+
+func TestApplyFileRejectsTrailingJSON(t *testing.T) {
+	root := newBridgeRoot(t, "claude")
+	ensureHostID(t, root, "mac")
+	ensureTrusted(t, root, "grok-host")
+	env := applyFileTestEnvelope(t, "trailing-file", []byte("trailing"))
+	path := writeApplyFileEnvelope(t, root, "trailing.json", env)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(raw, []byte("\n{}\n")...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = runApplyFile([]string{"--root", root, "--file", path})
+	if err == nil || !strings.Contains(err.Error(), "trailing JSON") {
+		t.Fatalf("trailing JSON error = %v", err)
+	}
+	assertApplyNotCommitted(t, root, env)
+}
+
+func TestApplyFileRejectsFileOutsideDropDirectory(t *testing.T) {
+	root := newBridgeRoot(t, "claude")
+	ensureHostID(t, root, "mac")
+	ensureTrusted(t, root, "grok-host")
+	env := applyFileTestEnvelope(t, "outside-file", []byte("outside"))
+	raw, err := bridge.MarshalEnvelope(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "outside.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runApplyFile([]string{"--root", root, "--file", path}); err == nil || !strings.Contains(err.Error(), "under") {
+		t.Fatalf("outside drop error = %v, want drop-directory refusal", err)
+	}
+	assertApplyNotCommitted(t, root, env)
+}
+
+func applyFileTestEnvelope(t *testing.T, transferID string, payload []byte) bridge.Envelope {
+	t.Helper()
+	sum := sha256.Sum256(payload)
+	env := bridge.Envelope{
+		Version:         bridge.EnvelopeVersion,
+		TransferID:      transferID,
+		SourceHost:      "grok-host",
+		SourceHandle:    "codex",
+		DestAlias:       "mac/claude",
+		SourceMessageID: transferID + "-message",
+		ThreadID:        transferID + "-thread",
+		PayloadSHA256:   hex.EncodeToString(sum[:]),
+		KeyGeneration:   "1",
+		Payload:         payload,
+	}
+	if err := bridge.SignEnvelope(&env, testHostKey("grok-host", "1")); err != nil {
+		t.Fatal(err)
+	}
+	return env
+}
+
+func writeApplyFileEnvelope(t *testing.T, root, name string, env bridge.Envelope) string {
+	t.Helper()
+	raw, err := bridge.MarshalEnvelope(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return writeApplyFileRaw(t, root, name, raw)
+}
+
+func writeApplyFileRaw(t *testing.T, root, name string, raw []byte) string {
+	t.Helper()
+	drop := filepath.Join(root, applyDropRelDir)
+	if err := os.MkdirAll(drop, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(drop, name)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readApplyReceipt(t *testing.T, root string, env bridge.Envelope) Receipt {
+	t.Helper()
+	path := filepath.Join(root, applyReceiptRelDir, receiptFilename(env.TransferID, ReceiptDestinationMaildirCommit))
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt Receipt
+	if err := json.Unmarshal(raw, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+func assertApplyNotCommitted(t *testing.T, root string, env bridge.Envelope) {
+	t.Helper()
+	path := filepath.Join(root, "agents", "claude", "inbox", "new", bridge.TransferFilename(env.SourceHost, env.TransferID))
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("unexpected committed file %s: %v", path, err)
+	}
+	receipt := filepath.Join(root, applyReceiptRelDir, receiptFilename(env.TransferID, ReceiptDestinationMaildirCommit))
+	if _, err := os.Stat(receipt); !os.IsNotExist(err) {
+		t.Fatalf("unexpected receipt %s: %v", receipt, err)
+	}
+}

--- a/cmd/amq-bridge/courier.go
+++ b/cmd/amq-bridge/courier.go
@@ -796,6 +796,10 @@ func (c *Courier) existingReceipt(root *fsq.DeliveryRoot, env bridge.Envelope, s
 }
 
 func (c *Courier) writeReceipt(root *fsq.DeliveryRoot, receipt Receipt) error {
+	return writeBridgeReceipt(root, c.receiptRelDir, receipt)
+}
+
+func writeBridgeReceipt(root *fsq.DeliveryRoot, receiptRelDir string, receipt Receipt) error {
 	if receipt.EmittedAt == "" {
 		receipt.EmittedAt = time.Now().UTC().Format(time.RFC3339Nano)
 	}
@@ -805,8 +809,8 @@ func (c *Courier) writeReceipt(root *fsq.DeliveryRoot, receipt Receipt) error {
 	}
 	data = append(data, '\n')
 	filename := receiptFilename(receipt.TransferID, receipt.Stage)
-	path := filepath.Join(c.receiptRelDir, filename)
-	if _, err := root.WriteFileExclusive(c.receiptRelDir, filename, data, 0o600); err == nil {
+	path := filepath.Join(receiptRelDir, filename)
+	if _, err := root.WriteFileExclusive(receiptRelDir, filename, data, 0o600); err == nil {
 		return nil
 	} else if !errors.Is(err, os.ErrExist) {
 		return err

--- a/cmd/amq-bridge/main.go
+++ b/cmd/amq-bridge/main.go
@@ -54,6 +54,19 @@ func main() {
 		}
 		return
 	}
+	if len(args) > 0 && args[0] == "apply-file" {
+		if err := runApplyFile(args[1:]); err != nil {
+			if errors.Is(err, flag.ErrHelp) {
+				return
+			}
+			fmt.Fprintln(os.Stderr, "amq-bridge apply-file:", err)
+			if isUsageError(err) {
+				os.Exit(2)
+			}
+			os.Exit(1)
+		}
+		return
+	}
 	opts, err := parseFlags(args)
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {

--- a/internal/bridge/auth.go
+++ b/internal/bridge/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -102,6 +103,22 @@ func LoadHostID(root string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("bridge host-id: %w", err)
 	}
+	return parseHostID(path, data)
+}
+
+// LoadHostIDFromDeliveryRoot reads host-id through an already-authorized
+// delivery-root capability so the identity used for routing cannot be
+// replaced through the ambient root path after authorization.
+func LoadHostIDFromDeliveryRoot(root *fsq.DeliveryRoot) (string, error) {
+	const rel = "bridge/host-id"
+	data, err := readPrivateKeyRootFile(root, rel)
+	if err != nil {
+		return "", fmt.Errorf("bridge host-id: %w", err)
+	}
+	return parseHostID(root.DisplayPath(rel), data)
+}
+
+func parseHostID(path string, data []byte) (string, error) {
 	host := strings.TrimSpace(string(data))
 	if err := fsq.ValidateHandle(host); err != nil {
 		return "", fmt.Errorf("bridge host-id: %w", err)
@@ -163,6 +180,33 @@ func LoadTrusted(root, host string) (ed25519.PublicKey, string, error) {
 	return ed25519.PublicKey(pub), fields["generation"], nil
 }
 
+// LoadTrustedFromDeliveryRoot reads a trusted public key through an
+// already-authorized delivery-root capability. The source host remains an
+// envelope claim until this exact trusted file is loaded and signature
+// verification succeeds.
+func LoadTrustedFromDeliveryRoot(root *fsq.DeliveryRoot, host string) (ed25519.PublicKey, string, error) {
+	if err := fsq.ValidateHandle(host); err != nil {
+		return nil, "", fmt.Errorf("trusted source host: %w", err)
+	}
+	rel := filepath.Join("bridge", TrustedDirName, host)
+	data, err := readPrivateKeyRootFile(root, rel)
+	if err != nil {
+		return nil, "", fmt.Errorf("trusted host %s: %w", host, err)
+	}
+	fields, err := parseKeyFields(root.DisplayPath(rel), data, "public")
+	if err != nil {
+		return nil, "", fmt.Errorf("trusted host %s: %w", host, err)
+	}
+	pub, err := hex.DecodeString(fields["public"])
+	if err != nil {
+		return nil, "", fmt.Errorf("trusted host %s public key: %w", host, err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, "", fmt.Errorf("trusted host %s public key must be %d bytes", host, ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(pub), fields["generation"], nil
+}
+
 func WriteTrusted(root, host string, pub ed25519.PublicKey, generation string) error {
 	if err := fsq.ValidateHandle(host); err != nil {
 		return fmt.Errorf("trusted source host: %w", err)
@@ -186,6 +230,10 @@ func readKeyFields(path, secretField string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseKeyFields(path, data, secretField)
+}
+
+func parseKeyFields(path string, data []byte, secretField string) (map[string]string, error) {
 	fields := map[string]string{}
 	for i, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
 		key, value, ok := strings.Cut(strings.TrimSpace(line), " ")
@@ -210,21 +258,52 @@ func readKeyFields(path, secretField string) (map[string]string, error) {
 	return fields, nil
 }
 
+func readPrivateKeyRootFile(root *fsq.DeliveryRoot, rel string) ([]byte, error) {
+	if root == nil {
+		return nil, fmt.Errorf("delivery root is required")
+	}
+	file, info, err := root.OpenRegularNoFollow(rel)
+	if err != nil {
+		return nil, err
+	}
+	path := root.DisplayPath(rel)
+	if err := validatePrivateKeyInfo(path, info); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	data, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return data, nil
+}
+
 func readPrivateKeyFile(path string) ([]byte, error) {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return nil, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("%s must not be a symlink", path)
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s must be a regular file", path)
-	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		return nil, fmt.Errorf("%s mode is %o, want 0600", path, got)
+	if err := validatePrivateKeyInfo(path, info); err != nil {
+		return nil, err
 	}
 	return fsq.ReadRegularNoFollow(path)
+}
+
+func validatePrivateKeyInfo(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s must not be a symlink", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s must be a regular file", path)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		return fmt.Errorf("%s mode is %o, want 0600", path, got)
+	}
+	return nil
 }
 
 func writePrivateFile(path string, data []byte) error {

--- a/internal/bridge/envelope.go
+++ b/internal/bridge/envelope.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -41,6 +42,13 @@ func UnmarshalEnvelope(raw []byte) (Envelope, error) {
 	var env Envelope
 	if err := dec.Decode(&env); err != nil {
 		return Envelope{}, fmt.Errorf("bridge envelope: %w", err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return Envelope{}, fmt.Errorf("bridge envelope has trailing JSON")
+		}
+		return Envelope{}, fmt.Errorf("bridge envelope trailer: %w", err)
 	}
 	if err := ValidateEnvelope(env); err != nil {
 		return Envelope{}, err


### PR DESCRIPTION
## Summary
Adds `amq-bridge apply-file` so a Bot-local drop under `<AMQ root>/bridge/drop/` can be authenticated and committed into the local Maildir without a public rendezvous.

## Changes
- Verify Ed25519, dest host == local `host-id`, then call `ApplyEnvelope`
- Record `destination_maildir_committed` with existing replay/conflict semantics
- Reject unsigned/forged `source_host`, foreign dest, symlink, trailing JSON, and files outside `bridge/drop`

## Testing
- [x] `make ci` / pre-push passed in worktree
- [x] Hostile apply-file tests: unsigned, forged host, foreign dest, symlink, trailing JSON, outside drop, replay, digest conflict

## Related Issues
Does not close the two-host epic. Reverse Mac-to-G hop and a live G→Mac envelope apply remain open.

Made with [Cursor](https://cursor.com)