### PR TITLE
test(scripts): add Grok Bot envelope hop probe

### DIFF
--- a/scripts/amq-bot-envelope-hop-probe-tool/main.go
+++ b/scripts/amq-bot-envelope-hop-probe-tool/main.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/bridge"
+	"github.com/avivsinai/agent-message-queue/internal/format"
+	"github.com/avivsinai/agent-message-queue/internal/fsq"
+)
+
+const (
+	defaultSourceHost   = "grok"
+	defaultSourceHandle = "codex"
+	defaultDestAlias    = "mac/claude"
+)
+
+func main() {
+	if len(os.Args) < 2 || os.Args[1] != "write" {
+		fmt.Fprintln(os.Stderr, "usage: amq-bot-envelope-hop-probe-tool write --root ROOT --output FILE")
+		os.Exit(2)
+	}
+	if err := runWrite(os.Args[2:]); err != nil {
+		fmt.Fprintln(os.Stderr, "amq-bot-envelope-hop-probe-tool:", err)
+		os.Exit(1)
+	}
+}
+
+func runWrite(args []string) error {
+	fs := flag.NewFlagSet("amq-bot-envelope-hop-probe-tool write", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	rootFlag := fs.String("root", "", "G bridge root containing host-id and identity")
+	outputFlag := fs.String("output", "", "exclusive envelope output path")
+	transferIDFlag := fs.String("transfer-id", "", "probe transfer id; generated when empty")
+	sourceHostFlag := fs.String("source-host", defaultSourceHost, "source host alias")
+	sourceHandleFlag := fs.String("source-handle", defaultSourceHandle, "source AMQ handle")
+	destAliasFlag := fs.String("dest-alias", defaultDestAlias, "receiver-owned destination alias")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	rootPath, err := requiredAbsolutePath("--root", *rootFlag)
+	if err != nil {
+		return err
+	}
+	outputPath, err := requiredAbsolutePath("--output", *outputFlag)
+	if err != nil {
+		return err
+	}
+	sourceHost := strings.TrimSpace(*sourceHostFlag)
+	sourceHandle := strings.TrimSpace(*sourceHandleFlag)
+	destAlias := strings.TrimSpace(*destAliasFlag)
+	if err := fsq.ValidateHandle(sourceHost); err != nil {
+		return fmt.Errorf("source host: %w", err)
+	}
+	if err := fsq.ValidateHandle(sourceHandle); err != nil {
+		return fmt.Errorf("source handle: %w", err)
+	}
+	_, destAgent, err := bridge.ParseAlias(destAlias)
+	if err != nil {
+		return err
+	}
+
+	hostID, err := bridge.LoadHostID(rootPath)
+	if err != nil {
+		return err
+	}
+	if hostID != sourceHost {
+		return fmt.Errorf("source host %q does not match G bridge host-id %q", sourceHost, hostID)
+	}
+	key, err := bridge.LoadIdentity(rootPath)
+	if err != nil {
+		return err
+	}
+	transferID := strings.TrimSpace(*transferIDFlag)
+	if transferID == "" {
+		transferID, err = randomID("xfer-probe-")
+		if err != nil {
+			return fmt.Errorf("generate transfer id: %w", err)
+		}
+	}
+	if err := fsq.ValidateHandle(transferID); err != nil {
+		return fmt.Errorf("transfer id: %w", err)
+	}
+	messageID := "probe-message-" + strings.TrimPrefix(transferID, "xfer-probe-")
+	threadID := "probe/" + transferID
+	payload, err := probeMessage(messageID, threadID, sourceHandle, destAgent, transferID)
+	if err != nil {
+		return fmt.Errorf("marshal probe payload: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	env := bridge.Envelope{
+		Version:         bridge.EnvelopeVersion,
+		TransferID:      transferID,
+		SourceHost:      sourceHost,
+		SourceHandle:    sourceHandle,
+		DestAlias:       destAlias,
+		SourceMessageID: messageID,
+		ThreadID:        threadID,
+		PayloadSHA256:   hex.EncodeToString(digest[:]),
+		KeyGeneration:   key.Generation,
+		Payload:         payload,
+	}
+	if err := bridge.SignEnvelope(&env, key); err != nil {
+		return fmt.Errorf("sign envelope: %w", err)
+	}
+	raw, err := bridge.MarshalEnvelope(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	if err := writeExclusive(outputPath, raw); err != nil {
+		return fmt.Errorf("write envelope: %w", err)
+	}
+
+	fmt.Printf("BOT_ENVELOPE_HOP_TRANSFER_ID=%s\n", transferID)
+	fmt.Printf("BOT_ENVELOPE_HOP_SOURCE=%s\n", outputPath)
+	fmt.Printf("BOT_ENVELOPE_HOP_SOURCE_HOST=%s\n", sourceHost)
+	fmt.Printf("BOT_ENVELOPE_HOP_DEST_ALIAS=%s\n", destAlias)
+	fmt.Printf("BOT_ENVELOPE_HOP_KEY_GENERATION=%s\n", key.Generation)
+	fmt.Printf("BOT_ENVELOPE_HOP_PUBLIC=%s\n", hex.EncodeToString(key.Public()))
+	fmt.Println("BOT_ENVELOPE_HOP_NEXT=move this envelope file with Grok Bot; do not paste its contents")
+	return nil
+}
+
+func requiredAbsolutePath(name, raw string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", name, err)
+	}
+	return abs, nil
+}
+
+func randomID(prefix string) (string, error) {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", err
+	}
+	id := prefix + hex.EncodeToString(nonce[:])
+	if err := fsq.ValidateHandle(id); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func probeMessage(messageID, threadID, sourceHandle, destAgent, transferID string) ([]byte, error) {
+	return (format.Message{
+		Header: format.Header{
+			Schema:  format.CurrentSchema,
+			ID:      messageID,
+			From:    sourceHandle,
+			To:      []string{destAgent},
+			Thread:  threadID,
+			Subject: "AMQ envelope hop probe",
+			Created: time.Now().UTC().Format(time.RFC3339Nano),
+			Kind:    format.KindStatus,
+		},
+		Body: "AMQ envelope hop probe payload " + transferID,
+	}).Marshal()
+}
+
+func writeExclusive(path string, data []byte) error {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(parent, ".envelope-hop-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	keep := false
+	defer func() {
+		_ = tmp.Close()
+		if !keep {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Link(tmpPath, path); err != nil {
+		return err
+	}
+	if err := os.Remove(tmpPath); err != nil {
+		return err
+	}
+	keep = true
+	dir, err := os.Open(parent)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}

--- a/scripts/amq-bot-envelope-hop-probe.sh
+++ b/scripts/amq-bot-envelope-hop-probe.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+# Probe whether Grok Bot can move one signed bridge envelope from host G to
+# this Mac. This is evidence only. It is not an AMQ transport, mailbox, or
+# public locker.
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+g_root=${AMQ_BOT_ENVELOPE_HOP_G_ROOT:-$repo_root}
+g_dir=${AMQ_BOT_ENVELOPE_HOP_G_DIR:-/workspace/amq/bridge/hop-probe}
+mac_dir=${AMQ_BOT_ENVELOPE_HOP_MAC_DIR:-$repo_root/dist/amq-bot-envelope-hop-probe}
+mac_root=${AMQ_BOT_ENVELOPE_HOP_MAC_ROOT:-}
+source_host=${AMQ_BOT_ENVELOPE_HOP_SOURCE_HOST:-grok}
+source_handle=${AMQ_BOT_ENVELOPE_HOP_SOURCE_HANDLE:-codex}
+dest_alias=${AMQ_BOT_ENVELOPE_HOP_DEST_ALIAS:-mac/claude}
+
+usage() {
+	cat >&2 <<'EOF'
+usage:
+  amq-bot-envelope-hop-probe.sh write
+  amq-bot-envelope-hop-probe.sh check <transfer-id>
+
+write runs on host G. It signs one complete internal/bridge.Envelope with
+G's bridge identity and writes it under the hop-probe drop. Bot must move the
+reported envelope file to the Mac without pasting its contents.
+
+check runs on the Mac. Set AMQ_BOT_ENVELOPE_HOP_MAC_ROOT to a throwaway AMQ
+root whose bridge/host-id matches the destination alias host and whose
+bridge/trusted/<source-host> contains G's public identity record. The command
+copies the moved envelope into bridge/drop, runs amq-bridge apply-file, and
+checks the destination receipt and inbox/new payload.
+EOF
+}
+
+unproven() {
+	printf 'BOT_ENVELOPE_HOP_UNPROVEN: %s\n' "$*"
+	exit 1
+}
+
+valid_transfer_id() {
+	id=$1
+	[ -n "$id" ] || return 1
+	case "$id" in
+		-*) return 1 ;;
+		*[!a-z0-9_-]*) return 1 ;;
+		.*|*..*) return 1 ;;
+		*) return 0 ;;
+	esac
+}
+
+validate_config() {
+	valid_transfer_id "$source_host" || unproven "invalid source host: $source_host"
+	case "$dest_alias" in
+		*/*) ;;
+		*) unproven "invalid destination alias: $dest_alias" ;;
+	esac
+	case "$dest_alias" in
+		*/|*/*/*|/*) unproven "invalid destination alias: $dest_alias" ;;
+	esac
+	dest_host_config=${dest_alias%%/*}
+	dest_agent_config=${dest_alias#*/}
+	valid_transfer_id "$dest_host_config" || unproven "invalid destination host: $dest_host_config"
+	valid_transfer_id "$dest_agent_config" || unproven "invalid destination agent: $dest_agent_config"
+}
+
+file_mode() {
+	path=$1
+	if mode=$(stat -c '%a' "$path" 2>/dev/null); then
+		printf '%s\n' "$mode"
+		return 0
+	fi
+	if mode=$(stat -f '%Lp' "$path" 2>/dev/null); then
+		printf '%s\n' "$mode"
+		return 0
+	fi
+	return 1
+}
+
+run_writer() {
+	(cd "$repo_root" && go run ./scripts/amq-bot-envelope-hop-probe-tool write "$@")
+}
+
+run_bridge() {
+	if [ -n "${AMQ_BOT_ENVELOPE_HOP_BRIDGE_BIN:-}" ]; then
+		"$AMQ_BOT_ENVELOPE_HOP_BRIDGE_BIN" "$@"
+		return
+	fi
+	if command -v amq-bridge >/dev/null 2>&1; then
+		amq-bridge "$@"
+		return
+	fi
+	if [ -x "$repo_root/amq-bridge" ]; then
+		"$repo_root/amq-bridge" "$@"
+		return
+	fi
+	(cd "$repo_root" && go run ./cmd/amq-bridge "$@")
+}
+
+write_probe() {
+	[ -d "$g_root" ] || unproven "G root is missing: $g_root"
+	[ ! -L "$g_root" ] || unproven "G root must not be a symlink: $g_root"
+	if ! mkdir -p "$g_dir" 2>/dev/null; then
+		unproven "cannot create required G directory $g_dir"
+	fi
+	if ! chmod 700 "$g_dir" 2>/dev/null; then
+		unproven "cannot set G directory mode on $g_dir"
+	fi
+
+	nonce=$(LC_ALL=C od -An -N16 -tx1 /dev/urandom | tr -d '[:space:]') ||
+		unproven 'cannot generate transfer nonce'
+	transfer_id=xfer-probe-$nonce
+	valid_transfer_id "$transfer_id" || unproven 'generated invalid transfer id'
+	target=$g_dir/envelope-$transfer_id.json
+	output=$(run_writer \
+		--root "$g_root" \
+		--output "$target" \
+		--transfer-id "$transfer_id" \
+		--source-host "$source_host" \
+		--source-handle "$source_handle" \
+		--dest-alias "$dest_alias") ||
+		unproven "cannot create signed envelope $target"
+	mode=$(file_mode "$target") || unproven "cannot inspect mode on $target"
+	case "$mode" in
+		600|0600) ;;
+		*) unproven "G envelope $target has mode $mode, want 0600" ;;
+	esac
+	[ -s "$target" ] || unproven "G envelope $target is empty"
+	printf '%s\n' "$output"
+	printf 'BOT_ENVELOPE_HOP_G_ROOT=%s\n' "$g_root"
+	printf 'BOT_ENVELOPE_HOP_G_DIR=%s\n' "$g_dir"
+}
+
+check_host_files() {
+	expected_host=$1
+	[ -n "$mac_root" ] || unproven 'AMQ_BOT_ENVELOPE_HOP_MAC_ROOT must name a throwaway root'
+	[ -d "$mac_root" ] || unproven "Mac root is missing: $mac_root"
+	[ ! -L "$mac_root" ] || unproven "Mac root must not be a symlink: $mac_root"
+	mac_root=$(CDPATH='' cd -- "$mac_root" && pwd) || unproven "cannot resolve Mac root: $mac_root"
+	host_file=$mac_root/bridge/host-id
+	trusted_file=$mac_root/bridge/trusted/$source_host
+	[ -f "$host_file" ] || unproven "Mac host-id is missing: $host_file"
+	[ ! -L "$host_file" ] || unproven "Mac host-id must not be a symlink: $host_file"
+	[ -f "$trusted_file" ] || unproven "trusted source record is missing: $trusted_file"
+	[ ! -L "$trusted_file" ] || unproven "trusted source record must not be a symlink: $trusted_file"
+	actual_host=$(cat "$host_file") || unproven "cannot read Mac host-id: $host_file"
+	actual_host=$(printf '%s' "$actual_host" | tr -d '\r\n')
+	[ "$actual_host" = "$expected_host" ] ||
+		unproven "Mac host-id is $actual_host, want $expected_host"
+}
+
+digest_file() {
+	path=$1
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$path" | awk '{print $1}'
+		return
+	fi
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$path" | awk '{print $1}'
+		return
+	fi
+	return 1
+}
+
+check_receipt() {
+	receipt=$1
+	transfer_id=$2
+	payload_path=$3
+	printf '%s\n' "$receipt" | grep -Fq '"stage":"destination_maildir_committed"' ||
+		unproven 'apply-file did not emit destination_maildir_committed'
+	printf '%s\n' "$receipt" | grep -Fq "\"transfer_id\":\"$transfer_id\"" ||
+		unproven 'destination receipt has the wrong transfer id'
+	printf '%s\n' "$receipt" | grep -Fq "\"committed_path\":\"$payload_path\"" ||
+		unproven 'destination receipt has the wrong committed path'
+	[ -f "$payload_path" ] || unproven "payload is missing from inbox/new: $payload_path"
+	[ ! -L "$payload_path" ] || unproven "payload in inbox/new is a symlink: $payload_path"
+	[ -s "$payload_path" ] || unproven "payload in inbox/new is empty: $payload_path"
+	payload_digest=$(digest_file "$payload_path") ||
+		unproven 'no SHA-256 utility is available to verify the committed payload'
+	printf '%s\n' "$receipt" | grep -Fq "\"payload_sha256\":\"$payload_digest\"" ||
+		unproven 'destination receipt digest does not match the inbox payload'
+}
+
+check_probe() {
+	transfer_id=$1
+	valid_transfer_id "$transfer_id" ||
+		unproven 'transfer id must use lowercase [a-z0-9_-] without path components'
+	check_host_files "${dest_alias%%/*}"
+	source=$mac_dir/envelope-$transfer_id.json
+	[ -f "$source" ] || unproven "moved envelope is missing: $source"
+	[ ! -L "$source" ] || unproven "moved envelope must not be a symlink: $source"
+	mode=$(file_mode "$source") || unproven "cannot inspect mode on $source"
+	case "$mode" in
+		600|0600|644|0644) ;;
+		*) unproven "Mac envelope $source has mode $mode, want 0600 or 0644" ;;
+	esac
+	[ -s "$source" ] || unproven "Mac envelope is empty: $source"
+
+	drop_dir=$mac_root/bridge/drop
+	apply_file=$drop_dir/envelope-$transfer_id.json
+	if [ "$source" != "$apply_file" ]; then
+		if [ -e "$apply_file" ] || [ -L "$apply_file" ]; then
+			unproven "apply-file drop already exists: $apply_file"
+		fi
+		if ! mkdir -p "$drop_dir" 2>/dev/null; then
+			unproven "cannot create apply-file drop: $drop_dir"
+		fi
+		if ! (umask 077 && cp "$source" "$apply_file"); then
+			unproven "cannot copy moved envelope into apply-file drop"
+		fi
+		if ! chmod 600 "$apply_file"; then
+			unproven "cannot set apply-file drop mode on $apply_file"
+		fi
+	fi
+
+	dest_host=${dest_alias%%/*}
+	dest_agent=${dest_alias#*/}
+	payload_path=$mac_root/agents/$dest_agent/inbox/new/xfer-$source_host-$transfer_id.md
+	err_file=$(mktemp "${TMPDIR:-/tmp}/amq-envelope-hop-error.XXXXXX") ||
+		unproven 'cannot create apply-file error capture'
+	trap 'rm -f "$err_file"' 0 HUP INT TERM
+	if ! receipt=$(run_bridge apply-file --root "$mac_root" --file "$apply_file" 2>"$err_file"); then
+		cat "$err_file" >&2
+		unproven "apply-file refused envelope $transfer_id"
+	fi
+	check_receipt "$receipt" "$transfer_id" "$payload_path"
+	printf 'BOT_ENVELOPE_HOP_PROVEN transfer_id=%s receipt=destination_maildir_committed payload=%s\n' \
+		"$transfer_id" "$payload_path"
+}
+
+[ "$#" -ge 1 ] || { usage; exit 2; }
+validate_config
+case "$1" in
+	write)
+		[ "$#" -eq 1 ] || { usage; exit 2; }
+		write_probe
+		;;
+	check)
+		[ "$#" -eq 2 ] || { usage; exit 2; }
+		check_probe "$2"
+		;;
+	*)
+		usage
+		exit 2
+		;;
+esac

--- a/scripts/amq-bot-envelope-hop-probe_test.sh
+++ b/scripts/amq-bot-envelope-hop-probe_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Synthetic envelope hop-probe test. Does not claim a live G↔Mac Bot transfer.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+probe="$script_dir/amq-bot-envelope-hop-probe.sh"
+work="$(mktemp -d "${TMPDIR:-/tmp}/amq-bot-envelope-hop-probe-test.XXXXXX")"
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+amq_bin="$work/amq"
+bridge_bin="$work/amq-bridge"
+(
+  cd "$repo_root"
+  go build -o "$amq_bin" ./cmd/amq
+  go build -o "$bridge_bin" ./cmd/amq-bridge
+)
+
+g_root="$work/g-root"
+g_dir="$work/g-hop"
+mac_dir="$work/mac-hop"
+grok_public=''
+grok_generation=''
+
+"$amq_bin" init --root "$g_root" --agents codex,claude >/dev/null
+mkdir -p "$g_root/bridge"
+printf 'grok\n' >"$g_root/bridge/host-id"
+chmod 600 "$g_root/bridge/host-id"
+"$bridge_bin" identity init --root "$g_root" --generation 1 >/dev/null
+
+write_probe() {
+  AMQ_BOT_ENVELOPE_HOP_G_ROOT="$g_root" \
+  AMQ_BOT_ENVELOPE_HOP_G_DIR="$g_dir" \
+  AMQ_BOT_ENVELOPE_HOP_BRIDGE_BIN="$bridge_bin" \
+  sh "$probe" write
+}
+
+first_write="$(write_probe)"
+first_id="$(printf '%s\n' "$first_write" | sed -n 's/^BOT_ENVELOPE_HOP_TRANSFER_ID=//p')"
+first_source="$(printf '%s\n' "$first_write" | sed -n 's/^BOT_ENVELOPE_HOP_SOURCE=//p')"
+grok_public="$(printf '%s\n' "$first_write" | sed -n 's/^BOT_ENVELOPE_HOP_PUBLIC=//p')"
+grok_generation="$(printf '%s\n' "$first_write" | sed -n 's/^BOT_ENVELOPE_HOP_KEY_GENERATION=//p')"
+[[ "$first_id" == xfer-probe-* ]] || fail "write did not print a probe transfer id"
+[[ -f "$first_source" ]] || fail "write did not create $first_source"
+[[ -n "$grok_public" && -n "$grok_generation" ]] || fail "write did not expose trusted public identity metadata"
+
+setup_mac_root() {
+  local root="$1"
+  "$amq_bin" init --root "$root" --agents claude >/dev/null
+  mkdir -p "$root/bridge/trusted"
+  printf 'mac\n' >"$root/bridge/host-id"
+  chmod 600 "$root/bridge/host-id"
+  printf 'generation %s\npublic %s\n' "$grok_generation" "$grok_public" >"$root/bridge/trusted/grok"
+  chmod 600 "$root/bridge/trusted/grok"
+}
+
+mac_root="$work/mac-root"
+setup_mac_root "$mac_root"
+mkdir -p "$mac_dir"
+cp "$first_source" "$mac_dir/envelope-$first_id.json"
+chmod 644 "$mac_dir/envelope-$first_id.json"
+
+first_check="$(
+  AMQ_BOT_ENVELOPE_HOP_MAC_ROOT="$mac_root" \
+  AMQ_BOT_ENVELOPE_HOP_MAC_DIR="$mac_dir" \
+  AMQ_BOT_ENVELOPE_HOP_BRIDGE_BIN="$bridge_bin" \
+  sh "$probe" check "$first_id"
+)"
+printf '%s\n' "$first_check" | grep -Fq 'BOT_ENVELOPE_HOP_PROVEN transfer_id=' ||
+  fail "faithful moved envelope did not prove"
+first_payload="$mac_root/agents/claude/inbox/new/xfer-grok-$first_id.md"
+[[ -s "$first_payload" ]] || fail "faithful envelope did not commit a payload"
+
+second_write="$(write_probe)"
+second_id="$(printf '%s\n' "$second_write" | sed -n 's/^BOT_ENVELOPE_HOP_TRANSFER_ID=//p')"
+second_source="$(printf '%s\n' "$second_write" | sed -n 's/^BOT_ENVELOPE_HOP_SOURCE=//p')"
+[[ "$second_id" == xfer-probe-* ]] || fail "second write did not print a probe transfer id"
+[[ -f "$second_source" ]] || fail "second write did not create $second_source"
+
+unsigned_root="$work/unsigned-root"
+setup_mac_root "$unsigned_root"
+unsigned_file="$unsigned_root/bridge/drop/envelope-$second_id.json"
+mkdir -p "$(dirname "$unsigned_file")"
+cp "$second_source" "$unsigned_file"
+chmod 600 "$unsigned_file"
+python3 - "$unsigned_file" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    envelope = json.load(handle)
+envelope["signature"] = ""
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(envelope, handle, separators=(",", ":"))
+PY
+if "$bridge_bin" apply-file --root "$unsigned_root" --file "$unsigned_file" >/dev/null 2>&1; then
+  fail "unsigned envelope committed"
+fi
+[[ ! -e "$unsigned_root/agents/claude/inbox/new/xfer-grok-$second_id.md" ]] ||
+  fail "unsigned envelope left a payload"
+
+forged_root="$work/forged-root"
+setup_mac_root "$forged_root"
+printf 'generation %s\npublic %s\n' "$grok_generation" "$grok_public" >"$forged_root/bridge/trusted/attacker"
+chmod 600 "$forged_root/bridge/trusted/attacker"
+forged_file="$forged_root/bridge/drop/envelope-$second_id.json"
+mkdir -p "$(dirname "$forged_file")"
+cp "$second_source" "$forged_file"
+chmod 600 "$forged_file"
+python3 - "$forged_file" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    envelope = json.load(handle)
+envelope["source_host"] = "attacker"
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(envelope, handle, separators=(",", ":"))
+PY
+if "$bridge_bin" apply-file --root "$forged_root" --file "$forged_file" >/dev/null 2>&1; then
+  fail "forged source_host committed"
+fi
+[[ ! -e "$forged_root/agents/claude/inbox/new/xfer-attacker-$second_id.md" ]] ||
+  fail "forged source_host left a payload"
+
+printf 'amq-bot-envelope-hop-probe synthetic tests passed\n'

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -540,4 +540,5 @@ echo "integration: kanban needs a live websocket workspace, skipping invocation 
 bash scripts/test_install_checksum.sh
 AMQ_TEST_BIN="$BIN" bash scripts/test_stop_hook.sh
 bash scripts/test_version_embed.sh
+bash scripts/amq-bot-envelope-hop-probe_test.sh
 echo "smoke test ok"


### PR DESCRIPTION
## Summary
Adds a fail-closed G→Mac envelope hop probe: G signs one complete `internal/bridge.Envelope`, Bot moves the file, Mac `apply-file` must emit `destination_maildir_committed` with the payload in `inbox/new`.

## Changes
- `scripts/amq-bot-envelope-hop-probe.sh` write/check plus a Go writer that signs from `bridge/identity`
- Synthetic test: faithful move proves; unsigned and forged `source_host` refuse before commit
- Wired into `scripts/smoke-test.sh`

## Testing
- [x] `bash scripts/amq-bot-envelope-hop-probe_test.sh`
- [x] Pre-push / smoke includes the new probe test

## Related Issues
Does not close the two-host epic. Live Bot copy of a real envelope and reverse Mac→G remain unproven.

Made with [Cursor](https://cursor.com)