### PR TITLE
fix(bridge): keep opaque thread id on Bot hop replies

### DIFF
--- a/cmd/amq-bridge/README.md
+++ b/cmd/amq-bridge/README.md
@@ -60,9 +60,11 @@ The command reads only that regular, non-symlink file. It loads the local
 `destination_maildir_committed` receipt under `<AMQ root>/bridge/receipts/`.
 Repeating the same file is an idempotent replay; the same transfer key with a
 different payload is a conflict. Unsigned or forged envelopes, foreign
-destinations, symlinks, and files outside `bridge/drop` are rejected. This
-path does not provide reverse Mac-to-G communication and does not create a
-public locker.
+destinations, symlinks, and files outside `bridge/drop` are rejected. The
+same command on the peer host applies the reverse hop. It does not create a
+public locker. Run `scripts/amq-bot-envelope-hop-probe.sh` to sign a drop
+file; set `AMQ_BOT_ENVELOPE_HOP_THREAD` when the payload must keep an
+existing opaque thread id.
 
 One bounded bidirectional cycle on the Mac uses a **local** receive alias and
 a **remote** send alias. Do not poll a foreign dest alias into this root:

--- a/scripts/amq-bot-envelope-hop-probe-tool/main.go
+++ b/scripts/amq-bot-envelope-hop-probe-tool/main.go
@@ -43,6 +43,7 @@ func runWrite(args []string) error {
 	sourceHostFlag := fs.String("source-host", defaultSourceHost, "source host alias")
 	sourceHandleFlag := fs.String("source-handle", defaultSourceHandle, "source AMQ handle")
 	destAliasFlag := fs.String("dest-alias", defaultDestAlias, "receiver-owned destination alias")
+	threadFlag := fs.String("thread", "", "opaque AMQ thread id; default probe/<transfer-id>")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -96,7 +97,10 @@ func runWrite(args []string) error {
 		return fmt.Errorf("transfer id: %w", err)
 	}
 	messageID := "probe-message-" + strings.TrimPrefix(transferID, "xfer-probe-")
-	threadID := "probe/" + transferID
+	threadID := strings.TrimSpace(*threadFlag)
+	if threadID == "" {
+		threadID = "probe/" + transferID
+	}
 	payload, err := probeMessage(messageID, threadID, sourceHandle, destAgent, transferID)
 	if err != nil {
 		return fmt.Errorf("marshal probe payload: %w", err)

--- a/scripts/amq-bot-envelope-hop-probe.sh
+++ b/scripts/amq-bot-envelope-hop-probe.sh
@@ -13,6 +13,7 @@ mac_root=${AMQ_BOT_ENVELOPE_HOP_MAC_ROOT:-}
 source_host=${AMQ_BOT_ENVELOPE_HOP_SOURCE_HOST:-grok}
 source_handle=${AMQ_BOT_ENVELOPE_HOP_SOURCE_HANDLE:-codex}
 dest_alias=${AMQ_BOT_ENVELOPE_HOP_DEST_ALIAS:-mac/claude}
+thread_id=${AMQ_BOT_ENVELOPE_HOP_THREAD:-}
 
 usage() {
 	cat >&2 <<'EOF'
@@ -111,14 +112,26 @@ write_probe() {
 	transfer_id=xfer-probe-$nonce
 	valid_transfer_id "$transfer_id" || unproven 'generated invalid transfer id'
 	target=$g_dir/envelope-$transfer_id.json
-	output=$(run_writer \
-		--root "$g_root" \
-		--output "$target" \
-		--transfer-id "$transfer_id" \
-		--source-host "$source_host" \
-		--source-handle "$source_handle" \
-		--dest-alias "$dest_alias") ||
-		unproven "cannot create signed envelope $target"
+	if [ -n "$thread_id" ]; then
+		output=$(run_writer \
+			--root "$g_root" \
+			--output "$target" \
+			--transfer-id "$transfer_id" \
+			--source-host "$source_host" \
+			--source-handle "$source_handle" \
+			--dest-alias "$dest_alias" \
+			--thread "$thread_id") ||
+			unproven "cannot create signed envelope $target"
+	else
+		output=$(run_writer \
+			--root "$g_root" \
+			--output "$target" \
+			--transfer-id "$transfer_id" \
+			--source-host "$source_host" \
+			--source-handle "$source_handle" \
+			--dest-alias "$dest_alias") ||
+			unproven "cannot create signed envelope $target"
+	fi
 	mode=$(file_mode "$target") || unproven "cannot inspect mode on $target"
 	case "$mode" in
 		600|0600) ;;

--- a/scripts/amq-bot-envelope-hop-probe_test.sh
+++ b/scripts/amq-bot-envelope-hop-probe_test.sh
@@ -77,6 +77,27 @@ printf '%s\n' "$first_check" | grep -Fq 'BOT_ENVELOPE_HOP_PROVEN transfer_id=' |
 first_payload="$mac_root/agents/claude/inbox/new/xfer-grok-$first_id.md"
 [[ -s "$first_payload" ]] || fail "faithful envelope did not commit a payload"
 
+reply_dir="$work/reply-hop"
+reply_write="$(
+  AMQ_BOT_ENVELOPE_HOP_G_ROOT="$g_root" \
+  AMQ_BOT_ENVELOPE_HOP_G_DIR="$reply_dir" \
+  AMQ_BOT_ENVELOPE_HOP_SOURCE_HOST=grok \
+  AMQ_BOT_ENVELOPE_HOP_SOURCE_HANDLE=codex \
+  AMQ_BOT_ENVELOPE_HOP_DEST_ALIAS=mac/claude \
+  AMQ_BOT_ENVELOPE_HOP_THREAD="probe/$first_id" \
+  sh "$probe" write
+)"
+reply_id="$(printf '%s\n' "$reply_write" | sed -n 's/^BOT_ENVELOPE_HOP_TRANSFER_ID=//p')"
+reply_source="$(printf '%s\n' "$reply_write" | sed -n 's/^BOT_ENVELOPE_HOP_SOURCE=//p')"
+[[ -f "$reply_source" ]] || fail "threaded write did not create $reply_source"
+python3 - "$reply_source" "probe/$first_id" <<'PY' || fail "threaded write did not keep the inbound thread"
+import json, sys
+path, want = sys.argv[1], sys.argv[2]
+envelope = json.load(open(path, encoding="utf-8"))
+if envelope.get("thread_id") != want:
+    raise SystemExit(f"thread_id={envelope.get('thread_id')!r} want {want!r}")
+PY
+
 second_write="$(write_probe)"
 second_id="$(printf '%s\n' "$second_write" | sed -n 's/^BOT_ENVELOPE_HOP_TRANSFER_ID=//p')"
 second_source="$(printf '%s\n' "$second_write" | sed -n 's/^BOT_ENVELOPE_HOP_SOURCE=//p')"


### PR DESCRIPTION
## Summary
The live G↔Mac reply had to keep the inbound opaque thread id. The probe writer always minted `probe/<transfer-id>`, so that path was a local patch. This ships `--thread` / `AMQ_BOT_ENVELOPE_HOP_THREAD` and tells the truth that Bot-local `apply-file` is bidirectional.

## Changes
- Writer accepts `--thread`; shell probe passes `AMQ_BOT_ENVELOPE_HOP_THREAD`
- Synthetic test: threaded write keeps the inbound thread
- `cmd/amq-bridge` README: reverse hop is apply-file on the peer host; no public locker

## Testing
- [x] `bash scripts/amq-bot-envelope-hop-probe_test.sh`
- [x] Pre-push passed

## Related Issues
Does not reopen epic `amq-64q`.

Made with [Cursor](https://cursor.com)