### PR TITLE
docs: align two-host docs with apply-file hops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ own worktrees, dependency scheduling, task decomposition, and PR landing.
 ## Build and Development Commands
 
 ```bash
-make build          # go build -o amq ./cmd/amq
+make build          # go build amq, amq-keepalive, amq-bridge, amq-acp
 make test           # go test ./...
 make fmt            # gofmt -w
 make vet            # go vet
@@ -65,7 +65,8 @@ required by `make lint` and `make ci`.
 ```text
 cmd/amq/             CLI entry point
 cmd/amq-keepalive/   macOS wake supervisor companion
-cmd/amq-bridge/      Cross-host HTTPS courier companion (not Core)
+cmd/amq-bridge/      Cross-host courier companion (apply-file + HTTPS, not Core)
+cmd/amq-acp/         Preview ACP v1 stdio companion (not Core)
 internal/cli/        Command handlers and routing policy
 internal/fsq/        Maildir delivery, atomic operations, and scans
 internal/format/     JSON frontmatter plus Markdown message serialization
@@ -74,6 +75,8 @@ internal/receipt/    Consumer-local drained and DLQ receipts
 internal/integration Shared adapter support for Symphony and Kanban
 internal/launch/     Plans, adapters, trust, leases, bindings, and resume state
 internal/keepalive/  Companion registry, adapters, hooks, and supervision
+internal/bridge/     Envelope, auth, and crash-idempotent local apply
+internal/acp/        ACP v1 session and prompt delivery
 internal/sessionguard Shared fail-closed session decision table
 internal/swarm/      Claude Code Agent Teams interoperability
 internal/thread/     Cross-mailbox thread collection
@@ -87,6 +90,7 @@ Mailbox layout:
 <root>/agents/<agent>/outbox/sent/
 <root>/agents/<agent>/receipts/
 <root>/agents/<agent>/dlq/{tmp,new,cur}/
+<root>/bridge/{host-id,identity,trusted/<host>,outbox,drop,receipts}/
 ```
 
 ## Core Concepts
@@ -128,9 +132,11 @@ code and cleanup does not remove extension data. See
 
 Two-host fleets, alias routing, and the v1 kill-list are
 [the two-host fleets ADR](docs/adr-two-host-fleets.md). Companion `amq-bridge`
-wire format is [the bridge protocol ADR](docs/adr-bridge-protocol.md). Wake
-capability (no silent downgrade) is
-[the wake capability-vector ADR](docs/adr-wake-capability-vector.md).
+wire format is [the bridge protocol ADR](docs/adr-bridge-protocol.md); the
+proven hop is `apply-file`, and HTTPS needs an operator-provided rendezvous.
+Wake capability (no silent downgrade) is
+[the wake capability-vector ADR](docs/adr-wake-capability-vector.md). Preview
+ACP v1 is [the amq-acp companion](cmd/amq-acp/README.md).
 
 ## CLI Commands
 

--- a/COOP.md
+++ b/COOP.md
@@ -8,6 +8,7 @@ AMQ is the communication layer in this setup, not the coordinator. The initiator
 
 - **Co-op**: lightweight, peer-to-peer messaging between agents via AMQ threads (`p2p/...`).
 - **Swarm**: join Claude Code Agent Teams and coordinate via the shared task list (`amq swarm ...`).
+- **Two-host**: two machines, two AMQ roots; only companion `amq-bridge` crosses the hosts. See [amq-bridge](cmd/amq-bridge/README.md). Same-machine co-op does not replace that path.
 - **Messaging**: swarm bridge delivers task notifications only. Claude Code teammates can `amq send` to external agents, but external agents cannot DM a specific Claude Code teammate directly. External -> team messages must go to the leader's AMQ inbox, then the leader drains and forwards via Claude Code internal messaging.
 
 For swarm command reference, see [CLAUDE.md](CLAUDE.md).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -154,6 +154,14 @@ and rollbacks replace the file at the stable path, then rerun
 `amq-keepalive install-launchd` to restart the supervisor. The registry is
 retained; do not move the executable while registered wakes still identify it.
 
+The optional cross-host courier is published separately as
+`amq-bridge_*_{linux,darwin}_{amd64,arm64}.tar.gz`. Homebrew does not install
+it. Install it next to `amq` at a stable path using the same checksum dance
+as keepalive, substituting the `amq-bridge` asset name and the host's
+platform (`linux_amd64` on Grok computer, `darwin_arm64` on Apple Silicon).
+See [amq-bridge](cmd/amq-bridge/README.md). `amq-acp` is a preview companion
+built by `make build`; it is not a release asset.
+
 ### Platform capability matrix
 
 | Platform | Core queue (`send`, `drain`, `read`, threads) | `coop init` | `coop exec` | `wake` notifications | Installer script |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ AMQ gives agents a **local interoperability bus**: they can send messages, reply
 - **Swarm mode** — Join Claude Code Agent Teams, claim tasks, and bridge task notifications into AMQ.
 - **Optional adapters** — Lightweight Symphony hooks and an experimental Kanban bridge can emit normal AMQ messages with structured metadata.
 - **Operational diagnostics** — `amq doctor --ops` shows queue depth, sibling-session backlogs, DLQ state, presence freshness, and integration hints.
+- **Two-host fleets** — Companion `amq-bridge` hops signed envelopes between two local AMQ roots (`apply-file` today; HTTPS courier when an operator provisions a rendezvous).
 
 ### v1 will not
 
@@ -45,7 +46,7 @@ product claims (see [two-host fleets](docs/adr-two-host-fleets.md) and
 - AMQ holding a Buzz nsec; Mac mailbox files on the Grok Bot VM
 - silent inject→notify or submit→prefill; Accessibility scraping of ChatGPT
 
-Cross-host mail is companion `amq-bridge` (send / local apply / reply), not Core.
+Cross-host mail is companion `amq-bridge` (alias send / local apply / same-thread reply), not Core. The proven hop is `amq-bridge apply-file` on the destination host. The HTTPS courier stays implemented for an operator-provided rendezvous; AMQ does not ship a hosted relay. See [amq-bridge](cmd/amq-bridge/README.md).
 
 ![AMQ Demo — Claude and Codex collaborating via split-pane terminal](docs/assets/demo.gif)
 
@@ -632,6 +633,10 @@ Building something on AMQ? Open an issue or PR to be listed here.
 - [Getting started](#getting-started) — Install, start two agents, send one message
 - [INSTALL.md](INSTALL.md) — Alternative installation methods
 - [docs/amq-keepalive.md](docs/amq-keepalive.md) — Keepalive command and safety reference
+- [cmd/amq-bridge/README.md](cmd/amq-bridge/README.md) — Two-host courier: identity, apply-file, HTTPS rendezvous
+- [docs/adr-two-host-fleets.md](docs/adr-two-host-fleets.md) — Two-host identity, aliases, receipts, v1 kill-list
+- [docs/adr-bridge-protocol.md](docs/adr-bridge-protocol.md) — Bridge envelope, auth, and transport
+- [cmd/amq-acp/README.md](cmd/amq-acp/README.md) — Preview ACP v1 stdio companion
 - [docs/session-routing.md](docs/session-routing.md) — Session selection, routing guards, and worktree behavior
 - [docs/wake-operations.md](docs/wake-operations.md) — Wake inspection, repair, recovery, and retirement
 - [docs/wake-lifecycle.md](docs/wake-lifecycle.md) — Wake lock/target state contract, self-upgrade, log retention, JSON schema, injector identity
@@ -649,7 +654,7 @@ Building something on AMQ? Open an issue or PR to be listed here.
 ```bash
 git clone https://github.com/avivsinai/agent-message-queue.git
 cd agent-message-queue
-make build   # Build binary
+make build   # Build amq plus companion binaries
 make test    # Run tests
 make ci      # Full CI: vet + lint + test + smoke
 ```
@@ -671,7 +676,7 @@ with the Linux binary for the complete co-op workflow. See the explicit
 For local development workflows, yes. AMQ is intentionally simple—it's not trying to be a distributed message broker.
 
 **How does AMQ compare to other multi-agent tools?**
-Tools like [MCP Agent Mail](https://github.com/Dicklesworthstone/mcp_agent_mail) (server-based coordination + SQLite), [Gas Town](https://github.com/steveyegge/gastown) (tmux-based orchestration), and others offer richer features. AMQ is intentionally minimal: single binary, no server, Maildir delivery. Best for 2-3 agents on one machine.
+Tools like [MCP Agent Mail](https://github.com/Dicklesworthstone/mcp_agent_mail) (server-based coordination + SQLite), [Gas Town](https://github.com/steveyegge/gastown) (tmux-based orchestration), and others offer richer features. AMQ is intentionally minimal: single Core binary, no server, Maildir delivery. Best for a handful of local agents. Two machines use companion `amq-bridge`, not a shared filesystem.
 
 ## License
 

--- a/cmd/amq-bridge/README.md
+++ b/cmd/amq-bridge/README.md
@@ -1,25 +1,18 @@
 # amq-bridge
 
-`amq-bridge` is the companion HTTPS courier. It is separate from the local
-`amq` binary and does not open a listener or synchronise Maildirs.
+`amq-bridge` is the companion cross-host courier. It is separate from the
+local `amq` binary and does not open a listener or synchronise Maildirs.
 
-The default outbound spool is:
-
-```
-<AMQ root>/bridge/outbox/<source-handle>/new/
-```
-
-Place complete AMQ message files there. `amq-bridge enqueue --dest-alias` writes
-a sibling `.dest` sidecar next to the spool `.md`, and the courier stamps that
-`dest_alias` on the wire (not `--dest-alias` on the courier if a sidecar exists).
-After the rendezvous returns the exact `transport_accepted` receipt, the courier
-archives the file in the sibling `sent/` directory and writes a typed receipt
-under `<AMQ root>/bridge/receipts/`.
+The signed envelope and local Maildir apply path are
+[the bridge protocol ADR](../../docs/adr-bridge-protocol.md). Every hop uses
+the same `ApplyEnvelope` commit. Install the binary from the matching
+`amq-bridge_*_{linux,darwin}_{amd64,arm64}.tar.gz` release asset; Homebrew
+does not install it. See [INSTALL.md](../../INSTALL.md).
 
 ## Identity initialization
 
-Initialize one Ed25519 bridge identity for each host before starting the
-courier. The root contains:
+Initialize one Ed25519 bridge identity for each host before applying or
+sending envelopes. The root contains:
 
 - `bridge/host-id` (mode `0600`), the local host alias;
 - `bridge/identity` (mode `0600`), the active generation and private seed; and
@@ -35,15 +28,15 @@ amq-bridge identity public --root "$AM_ROOT"
 ```
 
 Copy only that public identity record to the peer's
-`<root>/bridge/trusted/<source_host>` path. Never copy the private seed. The
-rendezvous is an untrusted blob store; `--allow-source-host` is only an exact
-routing allowlist and does not authenticate the peer. The courier verifies the
-Ed25519 signature before applying a polled envelope.
+`<root>/bridge/trusted/<source_host>` path. Never copy the private seed.
+`--allow-source-host` is only an exact routing allowlist and does not
+authenticate the peer. The receiver verifies the Ed25519 signature before
+applying an envelope.
 
 ## Local file apply
 
-For a Bot-local handoff without a public rendezvous, drop one complete JSON
-`internal/bridge.Envelope` under the ignored local queue path
+This is the proven bidirectional hop. There is no public locker. Drop one
+complete JSON `internal/bridge.Envelope` under the ignored local queue path
 `<AMQ root>/bridge/drop/`, then run:
 
 ```sh
@@ -61,12 +54,28 @@ The command reads only that regular, non-symlink file. It loads the local
 Repeating the same file is an idempotent replay; the same transfer key with a
 different payload is a conflict. Unsigned or forged envelopes, foreign
 destinations, symlinks, and files outside `bridge/drop` are rejected. The
-same command on the peer host applies the reverse hop. It does not create a
-public locker. Run `scripts/amq-bot-envelope-hop-probe.sh` to sign a drop
-file; set `AMQ_BOT_ENVELOPE_HOP_THREAD` when the payload must keep an
-existing opaque thread id.
+same command on the peer host applies the reverse hop. Run
+`scripts/amq-bot-envelope-hop-probe.sh` to sign a drop file; set
+`AMQ_BOT_ENVELOPE_HOP_THREAD` when the payload must keep an existing opaque
+thread id.
 
-One bounded bidirectional cycle on the Mac uses a **local** receive alias and
+## HTTPS courier
+
+When an operator provisions a rendezvous, the courier dials out. AMQ does
+not ship a hosted relay. The default outbound spool is:
+
+```
+<AMQ root>/bridge/outbox/<source-handle>/new/
+```
+
+Place complete AMQ message files there. `amq-bridge enqueue --dest-alias` writes
+a sibling `.dest` sidecar next to the spool `.md`, and the courier stamps that
+`dest_alias` on the wire (not `--dest-alias` on the courier if a sidecar exists).
+After the rendezvous returns the exact `transport_accepted` receipt, the courier
+archives the file in the sibling `sent/` directory and writes a typed receipt
+under `<AMQ root>/bridge/receipts/`.
+
+One bounded bidirectional cycle on a host uses a **local** receive alias and
 a **remote** send alias. Do not poll a foreign dest alias into this root:
 
 ```sh
@@ -91,34 +100,34 @@ The rendezvous contract is:
 
 The receiver allowlist is exact. A polled envelope for another alias, an
 unknown envelope field, a digest conflict, or an ACK before local Maildir
-commit is rejected.
+commit is rejected. Until a rendezvous exists, use apply-file; do not treat
+this courier loop as the live hop.
 
 ## Host G (Grok computer)
 
 Install AMQ and `amq-bridge` on G the same way as on the Mac. G is a normal
-AMQ host: its own root, its own agents, outbound HTTPS only.
+Linux AMQ host: its own root, its own agents, no inbound SSH. Durable queue
+state belongs under a path that survives Bot client close (`/workspace` is
+the proven layout). G update/reset and a second Bot seat on the same VM
+remain untested.
 
-1. Put durable state under a directory that survives computer *update* and
-   *restart* (prove this on live G; `/workspace` vs `~/.grok` vs `/tmp` is an
-   `amq-hws` measurement, not a guess).
-2. Pin `AM_ROOT` / `AM_ME` in operator config, never in Bot chat.
-3. Set `bridge/host-id` to the G host alias. It must match `--source-host` for
+1. Pin `AM_ROOT` / `AM_ME` in operator config, never in Bot chat.
+2. Set `bridge/host-id` to the G host alias. It must match `--source-host` for
    push and the host component of `--receive-alias` for poll. Copy G's public
    identity record to the Mac's `bridge/trusted/grok` file, and copy the Mac's
    public identity record to G's `bridge/trusted/mac` file.
-4. Run the same courier with G as `--source-host` and Mac aliases on
-   `--allow-dest`. G does not listen.
-5. Bot submit is config-only enqueue (`amq-bridge enqueue --config FILE
+3. Apply inbound envelopes with `amq-bridge apply-file` on G. Reverse hops
+   use the same command on the Mac. If a rendezvous exists, run the courier
+   with G as `--source-host` and Mac aliases on `--allow-dest`. G does not
+   listen.
+4. Bot submit is config-only enqueue (`amq-bridge enqueue --config FILE
    --dest-alias host/agent`, stdin = one AMQ message). It writes a sibling
    `.dest` sidecar next to the spool `.md`. Prompt/chat must not pass
    `--root`, `--rendezvous`, `--me`, or `--spool` to `enqueue`.
-6. Bot chat must invoke the fixed wrapper
+5. Bot chat must invoke the fixed wrapper
    [`scripts/amq-bridge-bot-enqueue.sh`](../../scripts/amq-bridge-bot-enqueue.sh)
    instead of `amq-bridge enqueue` directly. Its argv is exactly
    `--dest-alias host/agent`; prompt content cannot add `--root`,
    `--rendezvous`, `--me`, `--spool`, or any extra argument. It reads the
    config path from `AMQ_BRIDGE_ENQUEUE_CONFIG` and refuses a missing,
    symlinked, or non-0600 config before stdin is ever read.
-
-Live G layout and Bot-client load path remain `amq-hws`. This README does not
-close that spike.

--- a/docs/adr-bridge-protocol.md
+++ b/docs/adr-bridge-protocol.md
@@ -12,13 +12,13 @@ Accepted.
 
 [Two-host fleets](adr-two-host-fleets.md) freeze identity: host M and host G
 each run local AMQ; cross-host mail is a companion, not Core. This ADR freezes
-the `amq-bridge` wire, transport, and threat model before courier code.
+the `amq-bridge` wire, transport, and threat model.
 
-The Grok Bot computer spike (`amq-hws`) is docs-only so far: no live G host
-from the Mac. Public xAI material supports outbound HTTPS and rejects hosted
-MCP to localhost. It does not prove git, inbound SSH, or process supervision.
-That is enough to choose a transport. It is not enough to close the live-G
-operational spike.
+Host G is a live Linux AMQ host. Durable queue state lives under a path that
+survives Bot client close (`/workspace` is the proven layout). Hosted MCP to
+localhost is rejected, so the Bot client is a fixed local CLI wrapper, not a
+remote plugin. Git, inbound SSH, and process supervision are still not
+transport.
 
 ## Decision
 
@@ -30,16 +30,23 @@ existing Maildir `publishTmpNoReplace` on a stable transfer filename.
 
 ### Transport
 
-v1 transport is **HTTPS store-and-forward**. Both nodes dial out. Host G
-accepts no inbound connection. The rendezvous is an opaque blob store with
-lease, retry, backoff, and bounded batches. It never reads AMQ handles or
-Maildir state.
+The wire unit is the signed envelope below. Local apply is the same
+`ApplyEnvelope` path in every hop.
+
+v1 hops without a public locker use **`amq-bridge apply-file`**: the operator
+moves one envelope into `<root>/bridge/drop/` on the destination host; that
+host verifies and commits it. The reverse hop is the same command on the
+peer. This is the proven bidirectional path.
+
+The courier class remains **HTTPS store-and-forward**. Both nodes dial out.
+Host G accepts no inbound connection. The rendezvous is an opaque blob store
+with lease, retry, backoff, and bounded batches. It never reads AMQ handles
+or Maildir state. AMQ does not ship a hosted relay. A public rendezvous is
+operator-provided; until one exists, do not treat HTTPS poll/push as the live
+hop.
 
 Not v1: git, Maildir sync, reverse tunnels, inbound SSH to G, remote drain,
 or sockets inside `amq`.
-
-Live G may change the rendezvous URL, idle timeout, and whether a courier
-survives Bot-client close. It does not change this transport class.
 
 ### Envelope
 
@@ -75,7 +82,7 @@ Keep three layers distinct:
 
 | State | Meaning |
 | --- | --- |
-| `transport_accepted` | The courier accepted the envelope for HTTPS. |
+| `transport_accepted` | The HTTPS courier accepted the envelope. `apply-file` does not emit this stage. |
 | `destination_maildir_committed` | `publishTmpNoReplace` committed `xfer-<transfer_id>.md`. |
 | consumer-local drain/start/complete | Optional; may stay on the consuming host. |
 
@@ -117,7 +124,7 @@ v1 Bot→AMQ is a fixed, audited local CLI wrapper. Not a general plugin. Not
 hosted remote MCP (that requires a public URL and cannot target localhost).
 The wrapper must not take prompt-controlled roots, argv, env, or endpoints.
 
-Mac `Grok Bot.app` (this machine, 2026-08-20) is the operator UI, not host G:
+Mac `Grok Bot.app` is the operator UI, not host G:
 
 - Bundle `com.anysphere.sand`, Team `DCNK4UB866`, Electron 0.20.0
 - URL schemes `grokbot` and `sand`
@@ -127,17 +134,17 @@ Mac `Grok Bot.app` (this machine, 2026-08-20) is the operator UI, not host G:
 - Support files include an encrypted gateway descriptor; do not treat that
   blob as a rendezvous URL or as proof of the cloud computer layout
 
-Live `amq-hws` still requires a shell **on G** (`/workspace`, `~/.grok`,
-courier vs routine, two Bot seats vs one host principal). The Mac app being
-open does not close that spike.
+The Mac app being open does not make this machine host G. G update/reset and
+a second Bot seat on the same VM remain untested; treat G as one host
+principal until a live test proves isolation.
 
 ## Consequences
 
 - Courier code implements this envelope and HTTPS poll/push. It does not add
   listeners to `amq`.
-- Mac node (`amq-baj.1`) can be built and tested against a fake rendezvous
-  before live G exists.
-- G node (`amq-baj.2`) still waits on live `amq-hws` for install layout and
-  how Bot actually invokes the wrapper.
-- Operators provision a public HTTPS rendezvous. AMQ does not ship a hosted
-  relay as Core.
+- `amq-bridge apply-file` is the proven bidirectional hop: same envelope,
+  same local apply, no public locker.
+- Operators may provision a public HTTPS rendezvous. AMQ does not ship a
+  hosted relay as Core.
+- G is a normal AMQ install. Pin `AM_ROOT` in operator config, never in Bot
+  chat. Durable state belongs under a path that survives Bot client close.

--- a/docs/adr-two-host-fleets.md
+++ b/docs/adr-two-host-fleets.md
@@ -60,13 +60,12 @@ Bidirectional v1 means all of:
    as an opaque correlation key, not as routing authority.
 
 Both bridge nodes dial out. Host G accepts no inbound SSH. Reachability is
-operator-provided. Transport is HTTPS store-and-forward as frozen in the
-protocol ADR.
-
-Protocol, envelope, and transport for `amq-bridge` are
-[the companion bridge protocol ADR](adr-bridge-protocol.md). That ADR keeps
-outbound-only HTTPS store-and-forward, not git-by-default, and no sockets in
-Core.
+operator-provided. The signed envelope and local apply path are frozen in
+[the companion bridge protocol ADR](adr-bridge-protocol.md). Proven
+bidirectional hops use `amq-bridge apply-file` on the destination host.
+HTTPS store-and-forward remains the courier class when an operator
+provisions a rendezvous; AMQ does not ship a hosted relay. Git is not the
+default cross-host transport. Core has no sockets.
 
 ### Routing aliases
 
@@ -147,16 +146,14 @@ v1 does not:
   optional and alias-only.
 - Skills and launch plans teach receiver-owned `<host>/<agent>` aliases, not
   foreign `--root` values and not remote drain.
-- Companion `amq-bridge` may exist beside `amq`, as `amq-keepalive` does.
+- Companion `amq-bridge` exists beside `amq`, as `amq-keepalive` does.
   Core stays a local CLI.
 - Receipt APIs and docs name transport, destination commit, and consumer
   evidence separately. Callers that need destination commit wait for
   `destination_maildir_committed`, not for `transport_accepted`.
 - Adapters continue to emit local messages. They do not become a remote
   workflow engine or a foreign-host drain.
-- Bridge wire format, auth material, and transport selection wait for the
-  protocol ADR. This freeze already rules out inbound-SSH-to-G, git-by-default,
-  and sockets in Core.
+- Inbound SSH to G, git-by-default, and sockets in Core stay out.
 - Wake adapters, when specified elsewhere, advertise real capability. They
   do not substitute a weaker path and do not drive GUI automation from prompt
   text.

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -141,6 +141,7 @@ Before diving in, match the task to the right workflow — this avoids wasted ef
 |-----------|-----------|
 | **"spec", "design with", "collaborative spec"** | Use `/amq-spec` instead — it has structured phase-by-phase guidance for parallel-research workflows. |
 | **Send a message, review request, question** | Use `amq send` (see Messaging below) |
+| **Two-host / Grok computer / `amq-bridge`** | Companion `amq-bridge`, never a foreign `--root`. See Two-host fleets below. |
 | **Swarm / agent teams** | Read [references/swarm-mode.md](references/swarm-mode.md), then use `amq swarm` |
 | **Received message with labels `workflow:spec`** | Follow the spec skill protocol: do independent research first, then engage on the `spec/<topic>` thread — don't skip straight to implementation. |
 
@@ -472,6 +473,24 @@ When you receive a message where `from` matches your own handle (e.g., `from: "c
 
 After sending a cross-project message (via `--project`), your `AM_ROOT` still points to YOUR project. To send to your own partner (same project), use plain `amq send --to codex` — do NOT use `--project`. The `--project` flag is ONLY for sending to agents in OTHER projects.
 
+## Two-host fleets
+
+A different machine is a different AMQ host, not a `--project` and not a
+foreign `--root`. Each host has its own handles; `claude` on G is not `claude`
+on the Mac. Cross-host mail is companion `amq-bridge` only.
+
+- Address receiver-owned aliases `<host>/<agent>`.
+- The destination host applies the signed envelope into its own Maildir.
+- The proven hop is `amq-bridge apply-file` (operator-moved drop file, no
+  public locker). Replies keep the inbound opaque thread id.
+- HTTPS courier remains for an operator-provided rendezvous. AMQ does not
+  ship a hosted relay. Do not treat a missing rendezvous as a reason to
+  remote-drain or copy Maildirs.
+- Prompt text must not pass `--root`, `--rendezvous`, `--me`, or `--spool` to
+  the Bot enqueue wrapper.
+
+See [amq-bridge](https://github.com/avivsinai/agent-message-queue/blob/main/cmd/amq-bridge/README.md).
+
 ## Decision Threads
 
 Decentralized decision protocol using existing AMQ primitives (no new CLI commands).
@@ -639,4 +658,5 @@ For detailed protocols, read the reference file FIRST, then follow its instructi
 - [references/integrations.md](references/integrations.md) — Symphony + Kanban integration commands, global root fallback, ops checks
 - [references/message-format.md](references/message-format.md) — Message format: frontmatter schema, field reference
 - [references/cross-project.md](references/cross-project.md) — Cross-project routing: peer config, addressing, decision threads
+- [amq-bridge](https://github.com/avivsinai/agent-message-queue/blob/main/cmd/amq-bridge/README.md) — Two-host courier: apply-file, identity, HTTPS rendezvous
 - [references/review-loop.md](references/review-loop.md) — Token-efficient review cycles: delegate multi-round reviews to background agents


### PR DESCRIPTION
## Summary
- Evergreen two-host docs after closed epic `amq-64q`: `amq-bridge apply-file` is the proven bidirectional hop.
- ADRs, companion README, CLAUDE/README/INSTALL/COOP, and the CLI skill stop talking as if live G / `amq-hws` were still open.
- HTTPS courier stays implemented for an operator-provided rendezvous; AMQ does not ship a hosted relay.

## Test plan
- [x] `make ci` on `docs/two-host-evergreen`
- [x] Codex APPROVE on frozen digest `db13d8c98a907f6c168fc68ca3718abe24faeb93c6c991e05bfdb35522d03975`


Made with [Cursor](https://cursor.com)