### PR TITLE
feat(acp): publish amq-acp asset and Buzz BYOH harness

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,6 +54,23 @@ builds:
       post:
         - sh -ceu 'if [ "$2" = darwin ]; then codesign --force --sign - --identifier io.github.avivsinai.amq-bridge "$1"; fi' _ "{{ .Path }}" "{{ .Os }}"
 
+  - id: amq-acp
+    main: ./cmd/amq-acp
+    binary: amq-acp
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    hooks:
+      post:
+        - sh -ceu 'if [ "$2" = darwin ]; then codesign --force --sign - --identifier io.github.avivsinai.amq-acp "$1"; fi' _ "{{ .Path }}" "{{ .Os }}"
+
 archives:
   - id: amq
     ids: [amq]
@@ -72,6 +89,11 @@ archives:
     ids: [amq-bridge]
     formats: [tar.gz]
     name_template: "amq-bridge_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+  - id: amq-acp
+    ids: [amq-acp]
+    formats: [tar.gz]
+    name_template: "amq-acp_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "checksums.txt"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -159,8 +159,10 @@ The optional cross-host courier is published separately as
 it. Install it next to `amq` at a stable path using the same checksum dance
 as keepalive, substituting the `amq-bridge` asset name and the host's
 platform (`linux_amd64` on Grok computer, `darwin_arm64` on Apple Silicon).
-See [amq-bridge](cmd/amq-bridge/README.md). `amq-acp` is a preview companion
-built by `make build`; it is not a release asset.
+See [amq-bridge](cmd/amq-bridge/README.md). The preview ACP v1 companion is
+published as `amq-acp_*_{linux,darwin}_{amd64,arm64}.tar.gz`. Homebrew does
+not install it. Install it the same way, then see
+[amq-acp](cmd/amq-acp/README.md).
 
 ### Platform capability matrix
 

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Building something on AMQ? Open an issue or PR to be listed here.
 - [cmd/amq-bridge/README.md](cmd/amq-bridge/README.md) — Two-host courier: identity, apply-file, HTTPS rendezvous
 - [docs/adr-two-host-fleets.md](docs/adr-two-host-fleets.md) — Two-host identity, aliases, receipts, v1 kill-list
 - [docs/adr-bridge-protocol.md](docs/adr-bridge-protocol.md) — Bridge envelope, auth, and transport
-- [cmd/amq-acp/README.md](cmd/amq-acp/README.md) — Preview ACP v1 stdio companion
+- [cmd/amq-acp/README.md](cmd/amq-acp/README.md) — Preview ACP v1 stdio companion and Buzz BYOH JSON
 - [docs/session-routing.md](docs/session-routing.md) — Session selection, routing guards, and worktree behavior
 - [docs/wake-operations.md](docs/wake-operations.md) — Wake inspection, repair, recovery, and retirement
 - [docs/wake-lifecycle.md](docs/wake-lifecycle.md) — Wake lock/target state contract, self-upgrade, log retention, JSON schema, injector identity

--- a/cmd/amq-acp/README.md
+++ b/cmd/amq-acp/README.md
@@ -46,6 +46,24 @@ all refuse with exit code 5 before any message is written.
 AM_ROOT="$AM_ROOT" AM_ME=cursor AMQ_ACP_TO=codex amq-acp
 ```
 
+Pin those values in operator config or in a local Buzz harness copy. Chat and
+prompt text must not pass `--root`, recipients, or argv.
+
+Install the binary from the matching `amq-acp_*_{linux,darwin}_{amd64,arm64}.tar.gz`
+release asset; Homebrew does not install it. See [INSTALL.md](../../INSTALL.md).
+
+## Buzz BYOH
+
+This is a Tier-3 custom harness, not a Buzz preset. Copy
+[`buzz-harness.json`](buzz-harness.json) to Buzz Desktop
+`custom_harnesses/amq_acp.json`. Then add `env` on **that machine copy** with
+`AM_ROOT`, `AM_ME`, and `AMQ_ACP_TO`. The committed example has empty `args` and
+no env: Buzz's default `BUZZ_ACP_AGENT_ARGS=acp` would be extra argv and
+`amq-acp` would refuse.
+
+ACP pool workers must not drain AMQ mailboxes. `amq-acp` only writes
+`inbox/new`. A separate Edge owner drains with `amq drain`.
+
 ## Limitations
 
 - A prompt is **queued**, not consumed. `session/prompt` reports

--- a/cmd/amq-acp/buzz-harness.json
+++ b/cmd/amq-acp/buzz-harness.json
@@ -1,0 +1,8 @@
+{
+  "id": "amq_acp",
+  "label": "AMQ ACP v1",
+  "command": "amq-acp",
+  "args": [],
+  "installInstructionsUrl": "https://github.com/avivsinai/agent-message-queue/blob/main/cmd/amq-acp/README.md",
+  "installHint": "Install the amq-acp release asset next to amq. Pin AM_ROOT, AM_ME, and AMQ_ACP_TO in this file's env on the machine; do not pass them from chat."
+}

--- a/cmd/amq-acp/buzz_harness_test.go
+++ b/cmd/amq-acp/buzz_harness_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestBuzzHarnessIsPreviewBYOH(t *testing.T) {
+	raw, err := os.ReadFile("buzz-harness.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var harness struct {
+		ID      string            `json:"id"`
+		Label   string            `json:"label"`
+		Command string            `json:"command"`
+		Args    []string          `json:"args"`
+		Env     map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(raw, &harness); err != nil {
+		t.Fatal(err)
+	}
+	if !regexp.MustCompile(`^[a-z0-9_][a-z0-9_-]*$`).MatchString(harness.ID) {
+		t.Fatalf("id %q is not a Buzz custom harness id", harness.ID)
+	}
+	if harness.Command != "amq-acp" {
+		t.Fatalf("command = %q, want amq-acp", harness.Command)
+	}
+	if len(harness.Args) != 0 {
+		t.Fatalf("args = %#v, want empty (Buzz default acp argv is a usage error)", harness.Args)
+	}
+	if len(harness.Env) != 0 {
+		t.Fatalf("env = %#v, want omitted so a committed file cannot ship a root", harness.Env)
+	}
+}

--- a/cmd/amq-acp/main_test.go
+++ b/cmd/amq-acp/main_test.go
@@ -321,6 +321,21 @@ func TestBinaryRejectsUnknownFlag(t *testing.T) {
 	}
 }
 
+func TestBinaryRejectsBuzzDefaultACPArg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real binary end-to-end")
+	}
+	_, amqACP := binaries(t)
+
+	code, stderr := runACPExpectingFailure(t, amqACP, []string{"acp"}, "AM_ROOT=/tmp", "AM_ME="+testMe, "AMQ_ACP_TO="+testTo)
+	if code != exitUsage {
+		t.Fatalf("exit code = %d, want %d (stderr: %s)", code, exitUsage, stderr)
+	}
+	if !strings.Contains(stderr, "unexpected arguments") {
+		t.Fatalf("stderr = %q, want unexpected arguments", stderr)
+	}
+}
+
 func TestBinaryPrintsVersion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("real binary end-to-end")

--- a/cmd/amq-acp/no_cli_import_test.go
+++ b/cmd/amq-acp/no_cli_import_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestACPSourcesDoNotImportCLI(t *testing.T) {
+	root := repoRoot()
+	dirs := []string{
+		filepath.Join(root, "cmd", "amq-acp"),
+		filepath.Join(root, "internal", "acp"),
+	}
+	fset := token.NewFileSet()
+	for _, dir := range dirs {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			for _, spec := range file.Imports {
+				imp := strings.Trim(spec.Path.Value, `"`)
+				if strings.Contains(imp, "/internal/cli") {
+					t.Errorf("%s imports %s; ACP workers must not drain via the CLI", path, imp)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Publish `amq-acp` as a GoReleaser companion archive (`linux`/`darwin`, amd64/arm64), matching `amq-bridge`. Homebrew still does not install it.
- Commit a root-free Buzz Desktop Tier-3 BYOH JSON (`empty args`, no `env`) so operators can register without a Buzz PR. Machine copies add `AM_ROOT` / `AM_ME` / `AMQ_ACP_TO`.
- Prove the hostile boundaries: extra argv `acp` is usage 2, ACP packages cannot import `internal/cli`, committed harness cannot ship a queue root.

This closes the remaining **amq-rqo** product gap (companion already speaks truthful ACP v1). It does **not** claim live Buzz consume (**amq-1nr**).

## Changes
- `.goreleaser.yaml`: `amq-acp` build + archive + ad-hoc codesign identifier
- `cmd/amq-acp/buzz-harness.json` plus harness/CLI-import/argv tests
- `INSTALL.md`, `README.md`, `cmd/amq-acp/README.md`

## Testing
- [x] `make ci` passes (local pre-push)
- [x] New tests added (`buzz_harness_test.go`, `no_cli_import_test.go`, `TestBinaryRejectsBuzzDefaultACPArg`)

## Related Issues
Fixes amq-rqo (Beads). Does not close amq-1nr.


Made with [Cursor](https://cursor.com)