### PR TITLE
fix(acp): accept v1 baseline resource_link in session/prompt

### DIFF
--- a/cmd/amq-acp/README.md
+++ b/cmd/amq-acp/README.md
@@ -22,9 +22,11 @@ Implemented methods:
 | `session/cancel` | Acknowledged. Prompt turns complete synchronously, so nothing is ever in flight to abort. |
 
 Everything else returns JSON-RPC `-32601`. There is no `session/load`, no
-`fs/*`, no `terminal/*`, and no tool calling. `promptCapabilities` are all
-false, so only `text` content blocks are accepted; any other block type is
-refused rather than silently dropped.
+`fs/*`, no `terminal/*`, and no tool calling. The v1 baseline block types are
+accepted: `text` passes through and `resource_link` is rendered into the AMQ
+body as a markdown link (`[title-or-name](uri)`). `promptCapabilities` are all
+false, so `image`, `audio`, and embedded `resource` blocks are refused rather
+than silently dropped.
 
 ## Configuration
 

--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -161,9 +161,10 @@ type initializeResult struct {
 }
 
 // agentCapabilities advertises the smallest honest v1 surface. Omitting
-// mcpCapabilities declares no MCP support, and every prompt capability is false
-// because only text blocks are accepted. Filesystem and terminal access are
-// client capabilities this companion never calls.
+// mcpCapabilities declares no MCP support. Every prompt capability is false:
+// those flags gate image, audio, and embedded context, while text and
+// resource_link are the v1 baseline every agent must accept. Filesystem and
+// terminal access are client capabilities this companion never calls.
 type agentCapabilities struct {
 	LoadSession        bool               `json:"loadSession"`
 	PromptCapabilities promptCapabilities `json:"promptCapabilities"`
@@ -237,8 +238,11 @@ type promptParams struct {
 }
 
 type contentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	URI   string `json:"uri"`
+	Name  string `json:"name"`
+	Title string `json:"title"`
 }
 
 type promptResult struct {
@@ -288,22 +292,35 @@ func (s *Server) prompt(params json.RawMessage) (any, *rpcError) {
 	}, nil
 }
 
-// promptText joins the text blocks of a prompt. Any other block type is refused
-// rather than silently dropped, because initialize advertised text only.
+// promptText renders the v1 baseline block types: text passes through and
+// resource_link becomes a markdown link. Any other block type is refused rather
+// than silently dropped, because the false promptCapabilities declared image,
+// audio, and embedded context unsupported.
 func promptText(blocks []contentBlock) (string, *rpcError) {
 	if len(blocks) == 0 {
-		return "", newRPCError(codeInvalidParams, "prompt must contain at least one text content block")
+		return "", newRPCError(codeInvalidParams, "prompt must contain at least one content block")
 	}
 	parts := make([]string, 0, len(blocks))
 	for _, block := range blocks {
-		if block.Type != "text" {
+		switch block.Type {
+		case "text":
+			parts = append(parts, block.Text)
+		case "resource_link":
+			if strings.TrimSpace(block.URI) == "" || strings.TrimSpace(block.Name) == "" {
+				return "", newRPCError(codeInvalidParams, "resource_link block requires non-empty uri and name")
+			}
+			label := strings.TrimSpace(block.Title)
+			if label == "" {
+				label = block.Name
+			}
+			parts = append(parts, fmt.Sprintf("[%s](%s)", label, block.URI))
+		default:
 			return "", newRPCError(
 				codeInvalidParams,
-				"content block type %q is not supported; this companion advertises text-only prompts",
+				"content block type %q is not supported; this companion accepts text and resource_link only",
 				block.Type,
 			)
 		}
-		parts = append(parts, block.Text)
 	}
 	return strings.Join(parts, "\n"), nil
 }

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -330,6 +330,85 @@ func TestSessionPromptRefusesNonTextContent(t *testing.T) {
 	assertNoDeliveredMessages(t, cfg.Root)
 }
 
+// TestSessionPromptDeliversResourceLink proves a resource_link block renders as
+// a markdown link in the delivered body, labeled by name or by title when set.
+func TestSessionPromptDeliversResourceLink(t *testing.T) {
+	for _, tc := range []struct {
+		block string
+		want  string
+	}{
+		{`{"type":"resource_link","uri":"file:///tmp/report.md","name":"report.md"}`, "[report.md](file:///tmp/report.md)"},
+		{`{"type":"resource_link","uri":"file:///tmp/report.md","name":"report.md","title":"Weekly Report"}`, "[Weekly Report](file:///tmp/report.md)"},
+	} {
+		cfg := testConfig(t)
+		server, sessionID := initializedServer(t, cfg)
+
+		line := serveOne(t, server, `{"jsonrpc":"2.0","id":10,"method":"session/prompt","params":{"sessionId":"`+sessionID+`","prompt":[`+tc.block+`]}}`)
+		result := decodeResult[struct {
+			Meta struct {
+				AMQ struct {
+					MessageID string `json:"messageId"`
+				} `json:"amq"`
+			} `json:"_meta"`
+		}](t, line)
+
+		path := filepath.Join(cfg.Root, "agents", testTo, "inbox", "new", result.Meta.AMQ.MessageID+".md")
+		message, err := format.ReadMessageFile(path)
+		if err != nil {
+			t.Fatalf("read delivered message %s: %v", path, err)
+		}
+		if got := strings.TrimSpace(message.Body); got != tc.want {
+			t.Errorf("delivered body = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+// TestSessionPromptJoinsTextAndResourceLink proves mixed baseline blocks join
+// with a newline in prompt order.
+func TestSessionPromptJoinsTextAndResourceLink(t *testing.T) {
+	cfg := testConfig(t)
+	server, sessionID := initializedServer(t, cfg)
+
+	line := serveOne(t, server, `{"jsonrpc":"2.0","id":11,"method":"session/prompt","params":{"sessionId":"`+sessionID+`","prompt":[{"type":"text","text":"please review"},{"type":"resource_link","uri":"file:///tmp/diff.patch","name":"diff.patch"}]}}`)
+	result := decodeResult[struct {
+		Meta struct {
+			AMQ struct {
+				MessageID string `json:"messageId"`
+			} `json:"amq"`
+		} `json:"_meta"`
+	}](t, line)
+
+	path := filepath.Join(cfg.Root, "agents", testTo, "inbox", "new", result.Meta.AMQ.MessageID+".md")
+	message, err := format.ReadMessageFile(path)
+	if err != nil {
+		t.Fatalf("read delivered message %s: %v", path, err)
+	}
+	want := "please review\n[diff.patch](file:///tmp/diff.patch)"
+	if got := strings.TrimSpace(message.Body); got != want {
+		t.Errorf("delivered body = %q, want %q", got, want)
+	}
+}
+
+// TestSessionPromptRefusesIncompleteResourceLink refuses a resource_link that
+// is missing either required field, with no delivery.
+func TestSessionPromptRefusesIncompleteResourceLink(t *testing.T) {
+	for _, block := range []string{
+		`{"type":"resource_link","name":"report.md"}`,
+		`{"type":"resource_link","uri":"file:///tmp/report.md"}`,
+		`{"type":"resource_link","uri":"   ","name":"report.md"}`,
+		`{"type":"resource_link","uri":"file:///tmp/report.md","name":"  "}`,
+	} {
+		cfg := testConfig(t)
+		server, sessionID := initializedServer(t, cfg)
+
+		line := serveOne(t, server, `{"jsonrpc":"2.0","id":12,"method":"session/prompt","params":{"sessionId":"`+sessionID+`","prompt":[`+block+`]}}`)
+		if code := decodeError(t, line).Code; code != codeInvalidParams {
+			t.Errorf("error code = %d for %s, want %d", code, block, codeInvalidParams)
+		}
+		assertNoDeliveredMessages(t, cfg.Root)
+	}
+}
+
 func TestSessionPromptRefusesEmptyPrompt(t *testing.T) {
 	cfg := testConfig(t)
 	server, sessionID := initializedServer(t, cfg)


### PR DESCRIPTION
## Summary
- ACP v1 requires Text **and** ResourceLink. `session/prompt` now accepts `resource_link` and renders `[title-or-name](uri)` into the AMQ body.
- Image, audio, and embedded `resource` stay refused (`promptCapabilities` remain all false). Incomplete links (missing uri/name) are `-32602` with no delivery.

Fable blocker only. Dual review: Fable subagent APPROVE, Codex APPROVE on digest `a7808575…`.

## Testing
- [x] `go test ./internal/acp ./cmd/amq-acp`
- [x] Local pre-push `make ci`
- [x] New tests: deliver link, join text+link, refuse incomplete link; existing image refusal kept

## Related Issues
Follow-up to #629 / v0.67.0. Does not close amq-1nr.


Made with [Cursor](https://cursor.com)