### PR TITLE
docs(skill): route ACP and Bot enqueue in amq-cli

### DIFF
--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -141,6 +141,7 @@ Before diving in, match the task to the right workflow — this avoids wasted ef
 |-----------|-----------|
 | **"spec", "design with", "collaborative spec"** | Use `/amq-spec` instead — it has structured phase-by-phase guidance for parallel-research workflows. |
 | **Send a message, review request, question** | Use `amq send` (see Messaging below) |
+| **Buzz / ACP / `amq-acp`** | Companion `amq-acp` queues to `AMQ_ACP_TO`; pool workers must not drain. Chat must not pass `--root`, recipients, or argv. See [`cmd/amq-acp/README.md`](../../cmd/amq-acp/README.md). |
 | **Two-host / Grok computer / `amq-bridge`** | Companion `amq-bridge`, never a foreign `--root`. See Two-host fleets below. |
 | **Swarm / agent teams** | Read [references/swarm-mode.md](references/swarm-mode.md), then use `amq swarm` |
 | **Received message with labels `workflow:spec`** | Follow the spec skill protocol: do independent research first, then engage on the `spec/<topic>` thread — don't skip straight to implementation. |
@@ -483,11 +484,12 @@ on the Mac. Cross-host mail is companion `amq-bridge` only.
 - The destination host applies the signed envelope into its own Maildir.
 - The proven hop is `amq-bridge apply-file` (operator-moved drop file, no
   public locker). Replies keep the inbound opaque thread id.
+- Bot chat must invoke `scripts/amq-bridge-bot-enqueue.sh` with argv exactly
+  `--dest-alias host/agent`; it reads `AMQ_BRIDGE_ENQUEUE_CONFIG`. Prompt text
+  must not pass `--root`, `--rendezvous`, `--me`, or `--spool`.
 - HTTPS courier remains for an operator-provided rendezvous. AMQ does not
   ship a hosted relay. Do not treat a missing rendezvous as a reason to
   remote-drain or copy Maildirs.
-- Prompt text must not pass `--root`, `--rendezvous`, `--me`, or `--spool` to
-  the Bot enqueue wrapper.
 
 See [amq-bridge](https://github.com/avivsinai/agent-message-queue/blob/main/cmd/amq-bridge/README.md).
 
@@ -659,4 +661,5 @@ For detailed protocols, read the reference file FIRST, then follow its instructi
 - [references/message-format.md](references/message-format.md) — Message format: frontmatter schema, field reference
 - [references/cross-project.md](references/cross-project.md) — Cross-project routing: peer config, addressing, decision threads
 - [amq-bridge](https://github.com/avivsinai/agent-message-queue/blob/main/cmd/amq-bridge/README.md) — Two-host courier: apply-file, identity, HTTPS rendezvous
+- [amq-acp](https://github.com/avivsinai/agent-message-queue/blob/main/cmd/amq-acp/README.md) — ACP v1 stdio companion and Buzz BYOH JSON
 - [references/review-loop.md](references/review-loop.md) — Token-efficient review cycles: delegate multi-round reviews to background agents


### PR DESCRIPTION
## Summary
- One conversation skill still. Task routing now names Buzz/ACP/`amq-acp`: queue only, Edge owner drains, no `--root`/recipients/argv from chat.
- Two-host: Bot chat uses `scripts/amq-bridge-bot-enqueue.sh --dest-alias host/agent` and `AMQ_BRIDGE_ENQUEUE_CONFIG`.
- References link `cmd/amq-acp/README.md`.

Bead **amq-dsz**. Codex implemented; Cursor APPROVE on digest `344f9705…`.

## Testing
- [x] `make check-skills`
- [x] Local pre-push `make ci`

## Related Issues
amq-dsz


Made with [Cursor](https://cursor.com)