### PR TITLE
fix(wake): self-upgrade after Homebrew Cellar unlink

### DIFF
--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -581,7 +581,12 @@ A resume-eligible wake started by `coop exec` follows the stable AMQ launch
 symlink. When an installer atomically points that locator at a strictly newer
 self-reported semantic version, the wake waits for a fully quiescent delivery
 boundary and replaces its running image without changing PID, terminal
-ownership, or unread work. A failed upgrade candidate is attempted at most
+ownership, or unread work. An inconclusive live-image comparison defers and
+retries on the next maintenance tick; it does not consume refusal memory.
+Darwin treats a still-running, identity-confirmed wake whose recorded path is
+gone (`proc_pidpath` ENOENT or ESRCH after an installer unlink) as a
+conclusive deleted image, so Homebrew Cellar replacement can exec in place.
+A failed upgrade candidate is attempted at most
 once per candidate within one wake generation, bounded to the 8 most recent
 distinct candidates; a new generation resets that refusal memory. Pinned
 binaries, ownerless/keepalive wakes, repair flows, destructive interrupts, and

--- a/internal/cli/doctor_stale_wake_binary_darwin.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin.go
@@ -9,11 +9,21 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 const wakeStartedTimestampUncertainty = time.Second
 
 const deletedWakeImageReason = "wake is running a deleted image; restart it"
+
+// darwinWakeMappedImageGone reports whether Darwin could not name the live
+// process image because the vnode is already gone. Homebrew Cellar unlinks
+// produce ESRCH from proc_pidpath while the wake is still running; ENOENT is
+// the same class. Other inspection failures stay unknown.
+func darwinWakeMappedImageGone(err error) bool {
+	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, unix.ESRCH)
+}
 
 func inspectWakeBinaryStalenessPlatform(
 	inspection wakeLockInspection,
@@ -59,7 +69,7 @@ func inspectWakeBinaryStalenessPlatform(
 
 	running, err := inspectDarwinWakeProcessImage(inspection.PID)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) && inspection.IdentityConfirmed && inspection.Process.Running {
+		if darwinWakeMappedImageGone(err) && inspection.IdentityConfirmed && inspection.Process.Running {
 			imagePath := running.Path
 			if imagePath == "" {
 				imagePath = recorded.ExecutionPath

--- a/internal/cli/doctor_stale_wake_binary_darwin_test.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 const testDarwinCorroboratedImageMethod wakeBinaryComparisonMethod = "darwin_process_image"
@@ -486,50 +488,71 @@ func TestDarwinWakeBinaryComparisonReportsDeletedLiveImageStale(t *testing.T) {
 
 func TestDarwinWakeBinaryComparisonReportsDeletedRecordedImageWhenProcPIDPathReturnsENOENT(t *testing.T) {
 	started := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
-	dir := t.TempDir()
-	runningPath := filepath.Join(dir, "Cellar", "amq", "0.52.0", "bin", "amq")
-	currentPath := filepath.Join(dir, "Cellar", "amq", "0.52.3", "bin", "amq")
-	for _, path := range []string{runningPath, currentPath} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
-			t.Fatal(err)
-		}
-	}
-	runningInfo, err := os.Stat(runningPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	currentInfo, err := os.Stat(currentPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
-	stubDarwinProcessImage(t, darwinWakeProcessImage{}, os.ErrNotExist)
-	if err := os.Remove(runningPath); err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range []struct {
+		name     string
+		inspect  error
+		remove   bool
+		wantGone bool
+	}{
+		{name: "ENOENT deleted path", inspect: os.ErrNotExist, remove: true, wantGone: true},
+		{name: "ESRCH deleted path", inspect: fmt.Errorf("resolve wake process executable: proc_pidpath pid %d: %w", 4242, unix.ESRCH), remove: true, wantGone: true},
+		{name: "ESRCH path still present", inspect: fmt.Errorf("resolve wake process executable: proc_pidpath pid %d: %w", 4242, unix.ESRCH), remove: false, wantGone: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			runningPath := filepath.Join(dir, "Cellar", "amq", "old", "bin", "amq")
+			currentPath := filepath.Join(dir, "Cellar", "amq", "new", "bin", "amq")
+			for _, path := range []string{runningPath, currentPath} {
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			runningInfo, err := os.Stat(runningPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			currentInfo, err := os.Stat(currentPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			evidence := darwinWakeImageEvidenceForTest(t, runningPath, runningInfo)
+			stubDarwinProcessImage(t, darwinWakeProcessImage{}, tc.inspect)
+			if tc.remove {
+				if err := os.Remove(runningPath); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	got, err := inspectWakeBinaryStalenessPlatform(
-		wakeLockInspection{
-			PID:               4242,
-			IdentityConfirmed: true,
-			Process:           wakeProcessInfo{PID: 4242, Running: true},
-			Lock: wakeLock{
-				Started:              started.Format(time.RFC3339),
-				ImagePath:            runningPath,
-				ImageVersion:         evidence.EmbeddedVersion,
-				RunningImageEvidence: &evidence,
-			},
-		},
-		resolvedWakeBinary{Path: currentPath, Info: currentInfo},
-	)
-	if err != nil {
-		t.Fatalf("compare deleted recorded image after proc_pidpath ENOENT: %v", err)
-	}
-	if !got.Stale || got.Method != wakeBinaryComparisonDarwinDeletedImage || got.Reason != deletedWakeImageReason {
-		t.Fatalf("deleted recorded image comparison = %#v, want proven stale", got)
+			got, err := inspectWakeBinaryStalenessPlatform(
+				wakeLockInspection{
+					PID:               4242,
+					IdentityConfirmed: true,
+					Process:           wakeProcessInfo{PID: 4242, Running: true},
+					Lock: wakeLock{
+						Started:              started.Format(time.RFC3339),
+						ImagePath:            runningPath,
+						ImageVersion:         evidence.EmbeddedVersion,
+						RunningImageEvidence: &evidence,
+					},
+				},
+				resolvedWakeBinary{Path: currentPath, Info: currentInfo},
+			)
+			if tc.wantGone {
+				if err != nil {
+					t.Fatalf("compare deleted recorded image: %v", err)
+				}
+				if !got.Stale || got.Method != wakeBinaryComparisonDarwinDeletedImage || got.Reason != deletedWakeImageReason {
+					t.Fatalf("deleted recorded image comparison = %#v, want proven stale", got)
+				}
+				return
+			}
+			if err == nil || got.Stale {
+				t.Fatalf("live image still present = %#v, %v; want unknown error", got, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/wake.go
+++ b/internal/cli/wake.go
@@ -1617,12 +1617,10 @@ func reconcileWakeInputAfterInboxDrain(cfg *wakeConfig) error {
 		return nil
 	}
 	if cfg.inputDelivery.phase == wakeInputPayloadPending {
-		if cfg.inputDelivery.acceptedBytes == 0 {
-			// No terminal byte was confirmed, so there is no stale composer input
-			// to finish after the inbox made progress.
-			clearWakeInputState(cfg)
-			return nil
-		}
+		// Inbox is empty: never finish or repeat doorbell text. A queued submit
+		// may still complete so an already-presented prompt does not sit idle.
+		clearWakeInputState(cfg)
+		return nil
 	}
 	_, err := resumeWakeInputDelivery(cfg)
 	return err

--- a/internal/cli/wake_self_upgrade_unix.go
+++ b/internal/cli/wake_self_upgrade_unix.go
@@ -557,14 +557,25 @@ func maintainWakeSelfUpgrade(
 		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
 	}
 	different, comparisonErr := wakeSelfUpgradeLiveDifference(inspection, probe)
-	if comparisonErr != nil || !different {
+	if comparisonErr != nil {
+		// Inconclusive identity is transient (Homebrew Cellar unlink, proc_pidpath
+		// ESRCH). Do not remember the probe or write refusal memory; retry next tick.
+		decision.Action = wakeSelfUpgradeActionDeferred
+		decision.Reason = wakeRestartReasonWithRemedy(
+			"live wake image identity is unknown or ambiguous: "+comparisonErr.Error(),
+			inspection.Root,
+			inspection.Agent,
+		)
+		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
+	}
+	if !different {
 		state.lastProbe = probe
 		decision.Action = wakeSelfUpgradeActionRefused
-		reason := "candidate image identity is not conclusively different from the live wake"
-		if comparisonErr != nil {
-			reason = "live wake image identity is unknown or ambiguous: " + comparisonErr.Error()
-		}
-		decision.Reason = wakeRestartReasonWithRemedy(reason, inspection.Root, inspection.Agent)
+		decision.Reason = wakeRestartReasonWithRemedy(
+			"candidate image identity is not conclusively different from the live wake",
+			inspection.Root,
+			inspection.Agent,
+		)
 		return decision, recordWakeSelfUpgradeDecision(agentDir, inspection, *state, decision)
 	}
 

--- a/internal/cli/wake_self_upgrade_unix_test.go
+++ b/internal/cli/wake_self_upgrade_unix_test.go
@@ -256,11 +256,12 @@ func TestMaintainWakeSelfUpgradeUsesLiveProcessImageOverRecordedEvidence(t *test
 	}
 }
 
-func TestMaintainWakeSelfUpgradeRefusesUnknownLiveProcessImage(t *testing.T) {
+func TestMaintainWakeSelfUpgradeDefersUnknownLiveProcessImage(t *testing.T) {
 	fixture := newWakeRestartFixture(t)
 	removeWakeRestartRecordForTest(t, fixture)
 	candidate := writeWakeSelfUpgradeCandidate(t, t.TempDir(), "candidate")
 	state := selfUpgradeStateForCandidate(t, candidate)
+	initialProbe := state.lastProbe
 	stubWakeSelfUpgradeVersion(t, "99.0.0")
 	fixture.lock.PID = 1 << 30
 
@@ -268,12 +269,26 @@ func TestMaintainWakeSelfUpgradeRefusesUnknownLiveProcessImage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decision.Action != wakeSelfUpgradeActionRefused ||
+	if decision.Action != wakeSelfUpgradeActionDeferred ||
 		!strings.Contains(decision.Reason, "unknown or ambiguous") {
-		t.Fatalf("unknown live image decision = %#v, want refused", decision)
+		t.Fatalf("unknown live image decision = %#v, want deferred", decision)
+	}
+	if state.lastProbe != initialProbe {
+		t.Fatal("unknown live image advanced the probe baseline")
 	}
 	if _, err := os.Lstat(filepath.Join(fixture.agentDir.path, wakeRestartFileName)); !os.IsNotExist(err) {
 		t.Fatalf("unknown live image created restart record: %v", err)
+	}
+
+	decision, err = maintainWakeSelfUpgrade(&state, fixture.agentDir, fixture.lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Action != wakeSelfUpgradeActionDeferred {
+		t.Fatalf("retry after unknown live image = %#v, want deferred not unchanged/refused", decision)
+	}
+	if state.lastProbe != initialProbe {
+		t.Fatal("retry after unknown live image advanced the probe baseline")
 	}
 }
 

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -3297,7 +3297,7 @@ func TestNotifyNewMessagesResumesExactTIOCSTISuffix(t *testing.T) {
 	}
 }
 
-func TestNotifyNewMessagesFinishesPartialPayloadAfterInboxDrain(t *testing.T) {
+func TestNotifyNewMessagesDiscardsPartialPayloadAfterInboxDrain(t *testing.T) {
 	for _, mode := range []string{wakeInjectModeRaw, wakeInjectModePaste} {
 		t.Run(mode, func(t *testing.T) {
 			root := secureTempDirForTest(t)
@@ -3369,12 +3369,9 @@ func TestNotifyNewMessagesFinishesPartialPayloadAfterInboxDrain(t *testing.T) {
 				t.Fatalf("empty-inbox reconciliation: %v", err)
 			}
 
-			want := firstPayload + "\r"
-			if mode == wakeInjectModeRaw {
-				want = firstPayload + "\n\r\r"
-			}
-			if got := accepted.String(); got != want {
-				t.Fatalf("accepted bytes = %q, want exact reconciled sequence %q", got, want)
+			partial := firstPayload[:len(firstPayload)/2]
+			if got := accepted.String(); got != partial {
+				t.Fatalf("accepted bytes after empty inbox = %q, want discarded partial %q", got, partial)
 			}
 			if cfg.inputDelivery.pending() {
 				t.Fatalf("input delivery remained pending: %#v", cfg.inputDelivery)
@@ -3405,8 +3402,12 @@ func TestNotifyNewMessagesFinishesPartialPayloadAfterInboxDrain(t *testing.T) {
 			if len(laterWrites) == 0 {
 				t.Fatal("later notify wrote no terminal input")
 			}
+			joined := strings.Join(laterWrites, "")
+			if !strings.Contains(joined, coopWakeDoorbell) {
+				t.Fatalf("later notify missing fresh doorbell: %q", laterWrites)
+			}
 			staleSuffix := firstPayload[len(firstPayload)/2:]
-			if strings.HasPrefix(strings.Join(laterWrites, ""), staleSuffix) {
+			if strings.HasPrefix(joined, staleSuffix) {
 				t.Fatalf("later notify replayed stale suffix %q: %q", staleSuffix, laterWrites)
 			}
 		})


### PR DESCRIPTION
## Summary
- Darwin treats `proc_pidpath` ESRCH on a still-running, identity-confirmed wake whose recorded Cellar path is gone as a deleted image (same as ENOENT), so `brew upgrade amq` can exec in place.
- Inconclusive live-image comparison defers and retries; it no longer sticky-refuses or advances `lastProbe`.
- Empty `inbox/new` drops leftover doorbell text instead of finishing `amq drain...` after the mail is already gone.

## Testing
- [x] `make ci` passes
- [x] New tests added (if applicable)

## Related Issues
Fixes amq-sht

Bead `amq-sht`. Codex still has unread review_request mail in session1 (Ghostty wake is live but has not drained).

BEGIN_WAKE_TEST_CHANGE_JUSTIFICATION
TestMaintainWakeSelfUpgradeRefusesUnknownLiveProcessImage: renamed to TestMaintainWakeSelfUpgradeDefersUnknownLiveProcessImage because inconclusive live identity now defers and retries instead of sticky-refusing
TestNotifyNewMessagesFinishesPartialPayloadAfterInboxDrain: renamed to TestNotifyNewMessagesDiscardsPartialPayloadAfterInboxDrain because empty inbox/new must drop leftover doorbell text instead of finishing it
END_WAKE_TEST_CHANGE_JUSTIFICATION