### PR TITLE
docs(wake): stop calling wake experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ AMQ gives agents a **local interoperability bus**: they can send messages, reply
 - **Zero infrastructure** — Pure file-based. No server, no daemon, no database. Works anywhere files work.
 - **Crash-safe** — Atomic Maildir delivery (tmp→new→cur). Messages are never partially written or lost.
 - **Human-readable** — JSON frontmatter + Markdown body. Inspect with `cat`, debug with `grep`, version with `git`.
-- **Real-time notifications** — `amq wake` injects terminal notifications when messages arrive (experimental).
+- **Real-time notifications** — `amq wake` injects terminal notifications when messages arrive.
 - **Built for agents** — Priority levels, message kinds, threading, delivery receipts, and waitable handoffs.
 - **Cross-project federation** — Route messages across peer repos, preserve reply routing, and run decision threads that span projects.
 - **Swarm mode** — Join Claude Code Agent Teams, claim tasks, and bridge task notifications into AMQ.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,7 +56,7 @@ hardening beyond the above is intentionally out of scope.
 
 #### TIOCSTI Terminal Injection (`amq wake`)
 
-The `amq wake` command uses TIOCSTI (terminal input character stuffing) to inject notification text into the terminal. This is an **experimental feature** with inherent security considerations:
+The `amq wake` command uses TIOCSTI (terminal input character stuffing) to inject notification text into the terminal. TIOCSTI has inherent security considerations:
 
 - TIOCSTI allows a process to inject input characters as if they were typed
 - On some systems (hardened Linux kernels), TIOCSTI is disabled for security reasons

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -68,7 +68,7 @@ func init() {
 		},
 		{
 			Name:    "wake",
-			Summary: "Background waker (TIOCSTI injection, experimental)",
+			Summary: "Background waker (TIOCSTI injection)",
 			Handler: runWake,
 			Children: []CommandInfo{
 				{Name: "check", Summary: "Inspect wake start and restart capability without mutation", Handler: runWake},


### PR DESCRIPTION
## Summary
Stop labeling `amq wake` as experimental. It is a supported product command. TIOCSTI risk stays documented; Kanban stays experimental.

## Changes
- README feature list: drop `(experimental)` from the wake bullet
- SECURITY.md: keep TIOCSTI considerations without calling wake experimental
- `amq wake` help summary: drop `, experimental`

## Testing
- [x] `make ci` passes (pre-push)
- [ ] New tests added (if applicable) — N/A, wording only

## Related Issues
N/A

Made with [Cursor](https://cursor.com)