### PR TITLE
ci(release): publish Scoop bucket from GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,3 +135,15 @@ brews:
     license: "MIT"
     test: |
       system "#{bin}/amq", "--version"
+
+scoops:
+  - name: amq
+    ids: [amq]
+    repository:
+      owner: avivsinai
+      name: scoop-bucket
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: bucket
+    homepage: "https://github.com/avivsinai/agent-message-queue"
+    description: "Agent Message Queue - file-based inter-agent messaging for Claude Code and Codex CLI"
+    license: "MIT"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GoReleaser already updates Homebrew (`brews` → `avivsinai/homebrew-tap`) on each tagged release. The Scoop app already exists at `avivsinai/scoop-bucket` (`bucket/amq.json`, currently 0.68.0) but was not on the same path.

This adds a `scoops` sibling of `brews` so the next tag updates `bucket/amq.json` automatically.

## Changes

- Add `scoops` in `.goreleaser.yaml` for app `amq` (`ids: [amq]`), repository `avivsinai/scoop-bucket`, directory `bucket`.
- Homepage, description, and license match the existing `brews` `amq` entry.
- Reuse `HOMEBREW_TAP_GITHUB_TOKEN` as `repository.token`. No new secret.

`release.yml` already passes `HOMEBREW_TAP_GITHUB_TOKEN` into the Release job. Brew, skill publish, and release-please are unchanged. No Windows Scoop install-verify workflow is added.

GoReleaser OSS v2 `scoops` generates a manifest from the `amq` Windows zip archives (`amq.exe`). The existing manual bucket lists 64bit only; the pipe also includes any Windows `arm64` zip from the same archive id if present.

## Token note

`HOMEBREW_TAP_GITHUB_TOKEN` must be able to push to **both**:

- `avivsinai/homebrew-tap` (existing)
- `avivsinai/scoop-bucket` (this change)

If the current PAT is scoped only to the tap, extend it (or its fine-grained repository list) before the next tag. Do not invent a second secret.

## Testing

Cloud VM `goreleaser check` (GoReleaser OSS v2.17.1, commit `1f429cf`):

| Config | Result |
| --- | --- |
| This branch `.goreleaser.yaml` | Valid. Exit 2 only for the pre-existing `brews` deprecation (same as `main`). No `scoops` issues. |
| `main` `.goreleaser.yaml` (control) | Same: valid + `brews` deprecation, exit 2. |
| Scoops-only (local, `brews` stripped, not committed) | Exit 0. |

`brews` was not migrated to `homebrew_casks` (out of scope). `goreleaser release` still publishes formulas; `check` treats that deprecation as an issue on `main` already.

Full log:

<pre>
=== environment ===
date: 2026-08-23T19:20:11Z
cwd: /workspace
branch: cursor/scoop-goreleaser-97dd
commit: 1f429cf4249b0a80eff6ac005d4f4baf794d3db6

=== goreleaser --version ===
GitVersion:    v2.17.1
Platform:      linux/amd64

=== goreleaser check --verbose (.goreleaser.yaml on this branch) ===
  • checking                                  path=.goreleaser.yaml
  • DEPRECATED:  brews  should not be used anymore, check https://goreleaser.com/deprecations#brews for more info
  • .goreleaser.yaml                                 error=configuration is valid, but uses deprecated properties
  ⨯ check failed                                     error=1 out of 1 configuration file(s) have issues
exit_code=2

=== goreleaser check --verbose (main .goreleaser.yaml, control) ===
  • checking                                  path=/tmp/goreleaser.main.yaml
  • DEPRECATED:  brews  should not be used anymore, check https://goreleaser.com/deprecations#brews for more info
  • /tmp/goreleaser.main.yaml                        error=configuration is valid, but uses deprecated properties
  ⨯ check failed                                     error=1 out of 1 configuration file(s) have issues
main_exit_code=2

=== goreleaser check --verbose (scoops-only, brews stripped locally, not committed) ===
  • checking                                  path=/tmp/goreleaser.scoops-only.yaml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
scoops_only_exit_code=0
</pre>

Raw log file:

<a href="/opt/cursor/artifacts/goreleaser-check.log">goreleaser-check.log</a>

- [x] `goreleaser check` on the Cloud VM (log attached)
- [x] CI green on head (`ci / build`, `ci / windows-claim-test`, GitGuardian, Gitleaks)

## Related Issues

None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4deffc68-4c2a-45de-a95b-97f3c12e97dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4deffc68-4c2a-45de-a95b-97f3c12e97dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

