### PR TITLE
feat(coop): add opt-in --named flag for CLI session naming

### DIFF
--- a/internal/cli/coop.go
+++ b/internal/cli/coop.go
@@ -33,6 +33,8 @@ func runCoop(args []string) error {
 		return runCoopInit(args[1:])
 	case "exec":
 		return runCoopExec(args[1:])
+	case "named-inject":
+		return runCoopNamedInject(args[1:])
 	default:
 		return formatUnknownSubcommand("coop", args[0])
 	}

--- a/internal/cli/coop_exec_named.go
+++ b/internal/cli/coop_exec_named.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type coopNamedMode int
+
+const (
+	coopNamedModeOff coopNamedMode = iota
+	coopNamedModeArgv
+	coopNamedModeTUI
+	coopNamedModeUnknown
+)
+
+func coopNamedModeFor(binary string) coopNamedMode {
+	switch strings.ToLower(filepath.Base(binary)) {
+	case "claude", "pi":
+		return coopNamedModeArgv
+	case "codex", "agent":
+		return coopNamedModeTUI
+	default:
+		return coopNamedModeUnknown
+	}
+}
+
+func agentArgsHasNameFlag(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "-n" || arg == "--name" {
+			return true
+		}
+		if strings.HasPrefix(arg, "--name=") {
+			return true
+		}
+	}
+	return false
+}
+
+func injectCoopNamedArgv(cmdName string, agentArgs []string, me string) []string {
+	if coopNamedModeFor(cmdName) != coopNamedModeArgv || agentArgsHasNameFlag(agentArgs) {
+		return agentArgs
+	}
+	return append([]string{"--name", me}, agentArgs...)
+}
+
+func coopNamedTUICommand(binaryBase, me string) string {
+	switch strings.ToLower(filepath.Base(binaryBase)) {
+	case "pi":
+		return "/name " + me
+	default:
+		return "/rename " + me
+	}
+}
+
+func coopNamedUnknownReminder(me, binary string) string {
+	return fmt.Sprintf(
+		"amq coop exec --named: name this CLI session %q manually (unknown binary %q)",
+		me,
+		filepath.Base(binary),
+	)
+}
+
+func applyCoopNamedBeforeExec(
+	named bool,
+	cmdName string,
+	agentArgs []string,
+	me string,
+) ([]string, error) {
+	if !named {
+		return agentArgs, nil
+	}
+	switch coopNamedModeFor(cmdName) {
+	case coopNamedModeArgv:
+		return injectCoopNamedArgv(cmdName, agentArgs, me), nil
+	case coopNamedModeTUI:
+		if err := startCoopNamedTUIInjector(me, cmdName); err != nil {
+			_ = writeStderr("warning: coop named inject: %v\n", err)
+		}
+		return agentArgs, nil
+	case coopNamedModeUnknown:
+		_ = writeStderr("%s\n", coopNamedUnknownReminder(me, cmdName))
+		return agentArgs, nil
+	default:
+		return agentArgs, nil
+	}
+}

--- a/internal/cli/coop_exec_named_other.go
+++ b/internal/cli/coop_exec_named_other.go
@@ -1,0 +1,15 @@
+//go:build !darwin && !linux
+
+package cli
+
+import "errors"
+
+func startCoopNamedTUIInjector(me, cmdName string) error {
+	_ = me
+	_ = cmdName
+	return nil
+}
+
+func runCoopNamedInject(_ []string) error {
+	return errors.New("amq coop named-inject is not supported on this platform (requires macOS or Linux)")
+}

--- a/internal/cli/coop_exec_named_other.go
+++ b/internal/cli/coop_exec_named_other.go
@@ -4,10 +4,10 @@ package cli
 
 import "errors"
 
-func startCoopNamedTUIInjector(me, cmdName string) error {
+var startCoopNamedTUIInjector = func(me, cmdName string) error {
 	_ = me
 	_ = cmdName
-	return nil
+	return errors.New("coop named TUI inject requires macOS or Linux")
 }
 
 func runCoopNamedInject(_ []string) error {

--- a/internal/cli/coop_exec_named_unix.go
+++ b/internal/cli/coop_exec_named_unix.go
@@ -1,0 +1,131 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const coopNamedTUIStartupDelay = 3 * time.Second
+
+var (
+	coopNamedTTYReady = func() bool {
+		return tiocsti.Available() && tiocsti.IsTTY()
+	}
+	coopNamedTTYInject = func(me, binaryBase string) error {
+		return injectCoopNamedSlashCommand(me, binaryBase)
+	}
+	coopNamedStartupSleep = func(time.Duration) { time.Sleep(coopNamedTUIStartupDelay) }
+)
+
+var startCoopNamedTUIInjector = func(me, cmdName string) error {
+	return startCoopNamedTUIInjectorProcess(me, cmdName)
+}
+
+func startCoopNamedTUIInjectorProcess(me, cmdName string) error {
+	amqExecutable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve amq executable for coop named inject: %w", err)
+	}
+	amqBin, err := coopWakeExecutionPath(amqExecutable)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(
+		amqBin,
+		"--no-update-check",
+		"coop",
+		"named-inject",
+		"--me", me,
+		"--binary", filepath.Base(cmdName),
+	)
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start coop named inject helper: %w", err)
+	}
+	return nil
+}
+
+func runCoopNamedInject(args []string) error {
+	fs := flag.NewFlagSet("coop named-inject", flag.ContinueOnError)
+	meFlag := fs.String("me", "", "AMQ handle to stamp onto the CLI session")
+	binaryFlag := fs.String("binary", "", "Spawned CLI binary basename")
+	delayFlag := fs.Duration("startup-delay", coopNamedTUIStartupDelay, "Delay before terminal injection")
+	usage := func() {
+		_ = writeStderr("usage: amq coop named-inject --me <handle> --binary <basename>\n")
+	}
+	if handled, err := parseFlags(fs, args, usage); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+	me := strings.TrimSpace(*meFlag)
+	if me == "" {
+		return UsageError("--me is required")
+	}
+	if _, err := normalizeHandle(me); err != nil {
+		return UsageError("--me: %v", err)
+	}
+	binaryBase := strings.TrimSpace(*binaryFlag)
+	if binaryBase == "" {
+		return UsageError("--binary is required")
+	}
+	if coopNamedModeFor(binaryBase) != coopNamedModeTUI {
+		return UsageError("--binary %q does not use coop named terminal injection", binaryBase)
+	}
+	if *delayFlag > 0 {
+		coopNamedStartupSleep(*delayFlag)
+	}
+	if err := coopNamedTTYInject(me, binaryBase); err != nil {
+		_ = writeStderr("warning: coop named inject failed: %v\n", err)
+	}
+	return nil
+}
+
+func injectCoopNamedSlashCommand(me, binaryBase string) error {
+	if !coopNamedTTYReady() {
+		if !tiocsti.Available() {
+			return errors.New("TIOCSTI terminal injection is unavailable")
+		}
+		return errors.New("no controlling terminal for coop named inject")
+	}
+	command := coopNamedTUICommand(binaryBase, me)
+	for _, ch := range command {
+		if ch < 0x20 || ch > 0x7e {
+			return fmt.Errorf("coop named command contains non-printable ASCII")
+		}
+	}
+	if err := tiocstiInject(command); err != nil {
+		return err
+	}
+	if prelude := coopNamedSubmitPrelude(binaryBase); prelude != "" {
+		rawInjectSleep(rawInjectSettleDelay)
+		if err := tiocstiInject(prelude); err != nil {
+			return err
+		}
+	}
+	rawInjectSleep(rawInjectSettleDelay)
+	if err := tiocstiInject("\r"); err != nil {
+		return err
+	}
+	rawInjectSleep(rawInjectSettleDelay)
+	return tiocstiInject("\r")
+}
+
+func coopNamedSubmitPrelude(binaryBase string) string {
+	switch strings.ToLower(filepath.Base(binaryBase)) {
+	case "codex", "agent":
+		return "\n"
+	default:
+		return ""
+	}
+}

--- a/internal/cli/coop_exec_named_unix.go
+++ b/internal/cli/coop_exec_named_unix.go
@@ -52,6 +52,10 @@ func startCoopNamedTUIInjectorProcess(me, cmdName string) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start coop named inject helper: %w", err)
 	}
+	// Detach from Wait so the helper is not a tracked child of the agent after exec.
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("release coop named inject helper: %w", err)
+	}
 	return nil
 }
 
@@ -107,25 +111,8 @@ func injectCoopNamedSlashCommand(me, binaryBase string) error {
 	if err := tiocstiInject(command); err != nil {
 		return err
 	}
-	if prelude := coopNamedSubmitPrelude(binaryBase); prelude != "" {
-		rawInjectSleep(rawInjectSettleDelay)
-		if err := tiocstiInject(prelude); err != nil {
-			return err
-		}
-	}
-	rawInjectSleep(rawInjectSettleDelay)
-	if err := tiocstiInject("\r"); err != nil {
-		return err
-	}
+	// One Enter to submit the slash command. Extra newlines can land in the
+	// composer as a blank user message if the TUI is already at a prompt.
 	rawInjectSleep(rawInjectSettleDelay)
 	return tiocstiInject("\r")
-}
-
-func coopNamedSubmitPrelude(binaryBase string) string {
-	switch strings.ToLower(filepath.Base(binaryBase)) {
-	case "codex", "agent":
-		return "\n"
-	default:
-		return ""
-	}
 }

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -325,7 +325,7 @@ func TestInjectCoopNamedSlashCommand(t *testing.T) {
 	if err := injectCoopNamedSlashCommand("coder1", "codex"); err != nil {
 		t.Fatalf("injectCoopNamedSlashCommand: %v", err)
 	}
-	want := []string{"/rename coder1", "\n", "\r", "\r"}
+	want := []string{"/rename coder1", "\r"}
 	if !reflect.DeepEqual(injected, want) {
 		t.Fatalf("injected = %#v, want %#v", injected, want)
 	}
@@ -368,6 +368,20 @@ func TestApplyCoopNamedTUIInjectorFailureIsBestEffort(t *testing.T) {
 	}
 	if !reflect.DeepEqual(args, []string{"--foo"}) {
 		t.Fatalf("args = %#v, want unchanged agent flags", args)
+	}
+}
+
+func TestApplyCoopNamedUnknownBinaryLeavesArgs(t *testing.T) {
+	args, err := applyCoopNamedBeforeExec(true, "bash", []string{"-lc", "true"}, "coder1")
+	if err != nil {
+		t.Fatalf("applyCoopNamedBeforeExec: %v", err)
+	}
+	if !reflect.DeepEqual(args, []string{"-lc", "true"}) {
+		t.Fatalf("args = %#v, want unchanged", args)
+	}
+	reminder := coopNamedUnknownReminder("coder1", "/bin/bash")
+	if !strings.Contains(reminder, "coder1") || !strings.Contains(reminder, "bash") {
+		t.Fatalf("reminder = %q", reminder)
 	}
 }
 

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/agent-message-queue/internal/config"
 	"github.com/avivsinai/agent-message-queue/internal/fsq"
@@ -144,6 +145,229 @@ func TestCoopExecForwardsCommandArguments(t *testing.T) {
 	wantArgv := []string{"sh", "-c", "echo ok", "--tail-flag"}
 	if !reflect.DeepEqual(gotArgv, wantArgv) {
 		t.Fatalf("argv = %#v, want %#v", gotArgv, wantArgv)
+	}
+}
+
+func TestAgentArgsHasNameFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "empty", args: nil, want: false},
+		{name: "short flag", args: []string{"-n", "foo"}, want: true},
+		{name: "long flag", args: []string{"--name", "foo"}, want: true},
+		{name: "long equals", args: []string{"--name=foo"}, want: true},
+		{name: "other flags", args: []string{"--model", "gpt"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agentArgsHasNameFlag(tt.args); got != tt.want {
+				t.Fatalf("agentArgsHasNameFlag(%#v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInjectCoopNamedArgv(t *testing.T) {
+	tests := []struct {
+		name      string
+		cmd       string
+		args      []string
+		me        string
+		want      []string
+		unchanged bool
+	}{
+		{
+			name: "claude injects name",
+			cmd:  "claude",
+			me:   "coder1",
+			want: []string{"--name", "coder1"},
+		},
+		{
+			name: "pi injects before flags",
+			cmd:  "pi",
+			args: []string{"--foo"},
+			me:   "coder1",
+			want: []string{"--name", "coder1", "--foo"},
+		},
+		{
+			name:      "skips existing name",
+			cmd:       "claude",
+			args:      []string{"--name", "custom"},
+			me:        "coder1",
+			unchanged: true,
+		},
+		{
+			name:      "skips existing short name",
+			cmd:       "pi",
+			args:      []string{"-n", "custom"},
+			me:        "coder1",
+			unchanged: true,
+		},
+		{
+			name:      "codex unchanged",
+			cmd:       "codex",
+			args:      []string{"--foo"},
+			me:        "coder1",
+			unchanged: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := injectCoopNamedArgv(tt.cmd, append([]string{}, tt.args...), tt.me)
+			if tt.unchanged {
+				if !reflect.DeepEqual(got, tt.args) {
+					t.Fatalf("got %#v, want unchanged %#v", got, tt.args)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCoopExecNamedInjectsArgv(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+
+	sentinel := errors.New("exec sentinel")
+	var gotArgv []string
+	oldExec := coopExecProcess
+	coopExecProcess = func(_ string, argv []string, _ []string) error {
+		gotArgv = append([]string{}, argv...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err := runCoopExec([]string{
+		"--root", root,
+		"--me", "coder1",
+		"--named",
+		"--no-wake",
+		"pi",
+		"--",
+		"--foo",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want sentinel", err)
+	}
+	wantArgv := []string{"pi", "--name", "coder1", "--foo"}
+	if !reflect.DeepEqual(gotArgv, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", gotArgv, wantArgv)
+	}
+}
+
+func TestCoopExecNamedWithoutFlagDoesNotInject(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+
+	sentinel := errors.New("exec sentinel")
+	var gotArgv []string
+	oldExec := coopExecProcess
+	coopExecProcess = func(_ string, argv []string, _ []string) error {
+		gotArgv = append([]string{}, argv...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err := runCoopExec([]string{
+		"--root", root,
+		"--me", "coder1",
+		"--no-wake",
+		"claude",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want sentinel", err)
+	}
+	wantArgv := []string{"claude"}
+	if !reflect.DeepEqual(gotArgv, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", gotArgv, wantArgv)
+	}
+}
+
+func TestCoopNamedTUICommand(t *testing.T) {
+	if got := coopNamedTUICommand("codex", "coder1"); got != "/rename coder1" {
+		t.Fatalf("codex command = %q", got)
+	}
+	if got := coopNamedTUICommand("agent", "coder1"); got != "/rename coder1" {
+		t.Fatalf("agent command = %q", got)
+	}
+	if got := coopNamedTUICommand("pi", "coder1"); got != "/name coder1" {
+		t.Fatalf("pi fallback command = %q", got)
+	}
+}
+
+func TestInjectCoopNamedSlashCommand(t *testing.T) {
+	oldInject := tiocstiInject
+	oldSleep := rawInjectSleep
+	oldReady := coopNamedTTYReady
+	t.Cleanup(func() {
+		tiocstiInject = oldInject
+		rawInjectSleep = oldSleep
+		coopNamedTTYReady = oldReady
+	})
+	rawInjectSleep = func(time.Duration) {}
+	coopNamedTTYReady = func() bool { return true }
+
+	var injected []string
+	tiocstiInject = func(text string) error {
+		injected = append(injected, text)
+		return nil
+	}
+
+	if err := injectCoopNamedSlashCommand("coder1", "codex"); err != nil {
+		t.Fatalf("injectCoopNamedSlashCommand: %v", err)
+	}
+	want := []string{"/rename coder1", "\n", "\r", "\r"}
+	if !reflect.DeepEqual(injected, want) {
+		t.Fatalf("injected = %#v, want %#v", injected, want)
+	}
+}
+
+func TestApplyCoopNamedStartsTUIInjector(t *testing.T) {
+	var started bool
+	oldStart := startCoopNamedTUIInjector
+	startCoopNamedTUIInjector = func(me, cmdName string) error {
+		started = true
+		if me != "coder1" || cmdName != "codex" {
+			t.Fatalf("startCoopNamedTUIInjector me=%q cmd=%q", me, cmdName)
+		}
+		return nil
+	}
+	t.Cleanup(func() { startCoopNamedTUIInjector = oldStart })
+
+	args, err := applyCoopNamedBeforeExec(true, "codex", []string{"--foo"}, "coder1")
+	if err != nil {
+		t.Fatalf("applyCoopNamedBeforeExec: %v", err)
+	}
+	if !started {
+		t.Fatal("expected TUI injector to start for codex")
+	}
+	if !reflect.DeepEqual(args, []string{"--foo"}) {
+		t.Fatalf("args = %#v, want unchanged agent flags", args)
+	}
+}
+
+func TestApplyCoopNamedTUIInjectorFailureIsBestEffort(t *testing.T) {
+	oldStart := startCoopNamedTUIInjector
+	startCoopNamedTUIInjector = func(me, cmdName string) error {
+		return errors.New("inject helper unavailable")
+	}
+	t.Cleanup(func() { startCoopNamedTUIInjector = oldStart })
+
+	args, err := applyCoopNamedBeforeExec(true, "codex", []string{"--foo"}, "coder1")
+	if err != nil {
+		t.Fatalf("applyCoopNamedBeforeExec: %v, want best-effort continue", err)
+	}
+	if !reflect.DeepEqual(args, []string{"--foo"}) {
+		t.Fatalf("args = %#v, want unchanged agent flags", args)
 	}
 }
 

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -148,6 +148,16 @@ func TestCoopExecForwardsCommandArguments(t *testing.T) {
 	}
 }
 
+func putBareCommandOnPATH(t *testing.T, name string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func TestAgentArgsHasNameFlag(t *testing.T) {
 	tests := []struct {
 		name string
@@ -234,6 +244,7 @@ func TestCoopExecNamedInjectsArgv(t *testing.T) {
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatal(err)
 	}
+	putBareCommandOnPATH(t, "pi")
 
 	sentinel := errors.New("exec sentinel")
 	var gotArgv []string
@@ -267,6 +278,7 @@ func TestCoopExecNamedWithoutFlagDoesNotInject(t *testing.T) {
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatal(err)
 	}
+	putBareCommandOnPATH(t, "claude")
 
 	sentinel := errors.New("exec sentinel")
 	var gotArgv []string

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -66,6 +66,7 @@ func runCoopExec(args []string) error {
 	var wakeInjectArgFlags multiStringFlag
 	fs.Var(&wakeInjectArgFlags, "wake-inject-arg", "Fixed argument for wake --inject-via before the payload (repeatable)")
 	yesFlag := fs.Bool("y", false, "Skip confirmation prompts (including clearing a blocking wake)")
+	namedFlag := fs.Bool("named", false, "Stamp AM_ME onto the spawned CLI session name (opt-in)")
 
 	usage := usageWithFlags(fs, "amq coop exec [options] <command> [-- <command-flags>]",
 		"Set up co-op mode and exec into the agent (replaces this process).",
@@ -86,6 +87,7 @@ func runCoopExec(args []string) error {
 		"  amq coop exec --require-wake --wake-inject-mode none claude  # Zero-input wake",
 		"  amq coop exec --wake-inject-via /path/to/injector codex",
 		"  amq coop exec --me myagent bash                   # Debug shell with AMQ env",
+		"  amq coop exec --named --me coder1 pi            # Exec pi --name coder1",
 		"",
 		"Wake readiness:",
 		"  Coop never reuses a generic wake because it has no persisted",
@@ -568,6 +570,12 @@ func runCoopExec(args []string) error {
 	// independent of AM_ROOT. A custom sessionless --root clears inherited pins.
 	sessionIdentity := coopSessionIdentity(root, *sessionFlag, *rootFlag)
 	env := buildCoopExecEnvironment(baseEnv, root, agentHandle, sessionIdentity)
+
+	// Optional --named: argv injection for claude/pi, TUI inject for codex/agent.
+	agentArgs, err = applyCoopNamedBeforeExec(*namedFlag, cmdName, agentArgs, agentHandle)
+	if err != nil {
+		return err
+	}
 
 	// Build argv: command name + agent args.
 	argv := append([]string{cmdName}, agentArgs...)

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -158,6 +158,9 @@ amq coop exec grok  # Terminal 3 (optional peer) — caller flags forwarded unch
 
 Without `--session` or `--root`, `coop exec` defaults to `--session collab`.
 
+Add `--named` to stamp `AM_ME` onto the CLI conversation title (`claude`/`pi`
+get `--name`; Codex and Cursor `agent` get a best-effort `/rename` on Unix).
+
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
 
 ### Standalone wake interrupt safety


### PR DESCRIPTION
## Summary
- Adds opt-in `amq coop exec --named` so the spawned CLI conversation title matches `AM_ME` (the AMQ handle). Claude/Pi get argv `--name`; Codex and Cursor `agent` get a best-effort `/rename` TUI inject on Unix.
- Default stays off. Unknown binaries only print a reminder. TUI inject failure warns and still execs.

Fixes https://github.com/avivsinai/agent-message-queue/issues/641

## Test plan
- [ ] `go test ./internal/cli -run 'CoopNamed|InjectCoopNamed|AgentArgsHasName|CoopExecNamed|ApplyCoopNamed'`
- [ ] `amq coop exec --named --me coder1 --no-wake pi -- --help` includes `--name coder1`
- [ ] without `--named`, argv is unchanged
- [ ] `amq coop exec --named --me coder1 --no-wake bash` reminds to name the session manually
- [ ] (manual TTY) `amq coop exec --named --me coder1 agent` attempts `/rename coder1` after startup; launch still works if inject is unavailable


Made with [Cursor](https://cursor.com)