### PR TITLE
feat(wake): add gated GUI app seat scaffolds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ hook-env-check:
 	@sh scripts/test_pre_push_hook_env.sh
 
 contract-check:
+	@sh scripts/probe-codex-app-execute-javascript_test.sh
 	@bash scripts/check-keepalive-amq-contract_test.sh
 	@candidate_dir="$$(mktemp -d "$${TMPDIR:-/tmp}/amq-keepalive-candidate.XXXXXX")"; \
 		trap 'rm -rf "$$candidate_dir"' EXIT; \

--- a/internal/keepalive/adapter/adapter.go
+++ b/internal/keepalive/adapter/adapter.go
@@ -16,6 +16,10 @@ var (
 	// App.Run prints this to stderr so inject-via can map it without a typed
 	// error crossing the child process boundary. Never replay the payload.
 	ErrInjectUncertain = errors.New("AMQ_INJECT_PROGRESS=uncertain")
+	// ErrGUIAdapterNotReady keeps GUI seats out of the generic wake path until
+	// their capability gate has live evidence. A refusal is not a weaker
+	// delivery claim.
+	ErrGUIAdapterNotReady = errors.New("GUI wake adapter is not ready")
 )
 
 type Adapter interface {
@@ -77,6 +81,9 @@ func NewRegistry(adapters ...Adapter) Registry {
 }
 
 func DefaultRegistry() Registry {
+	// GUI adapters remain deliberately unregistered until the task-0 Codex app
+	// Apple Events gate is proven on the target Mac. Do not turn a skeleton or a
+	// prefill fallback into a submitted wake by adding them here early.
 	return NewRegistry(File{}, Ghostty{}, Cmux{recorded: newCmuxOwnershipRecord()})
 }
 

--- a/internal/keepalive/adapter/claudedesktop.go
+++ b/internal/keepalive/adapter/claudedesktop.go
@@ -1,0 +1,44 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const claudeDesktopTarget = "claude-desktop:new"
+
+// ClaudeDesktop describes the honest deep-link seat from the wake capability
+// ADR: prefilled + new + requires_human. The existing inject-via interface
+// cannot claim that vector, so this skeleton stays out of DefaultRegistry
+// until a capability-aware caller owns the explicit human handoff.
+type ClaudeDesktop struct {
+	Runner CommandRunner
+}
+
+func (ClaudeDesktop) Name() string {
+	return "claude-desktop"
+}
+
+func (ClaudeDesktop) NormalizeTarget(target string) (string, error) {
+	if strings.TrimSpace(target) != claudeDesktopTarget {
+		return "", fmt.Errorf("unsupported Claude Desktop target %q; only the new-session seat is stable", target)
+	}
+	return claudeDesktopTarget, nil
+}
+
+func (ClaudeDesktop) Discover(context.Context) (string, error) {
+	return "", claudeDesktopGateError()
+}
+
+func (ClaudeDesktop) Probe(context.Context, string) error {
+	return claudeDesktopGateError()
+}
+
+func (ClaudeDesktop) Inject(context.Context, string, string) error {
+	return claudeDesktopGateError()
+}
+
+func claudeDesktopGateError() error {
+	return fmt.Errorf("%w: Claude Desktop deep-link delivery needs a capability-aware human handoff", ErrGUIAdapterNotReady)
+}

--- a/internal/keepalive/adapter/codexapp.go
+++ b/internal/keepalive/adapter/codexapp.go
@@ -1,0 +1,88 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+const codexAppTargetPrefix = "codex-app:tab:"
+
+// CodexApp is the task-0-gated seat for the native Codex app Apple Events
+// surface. The adapter is intentionally a skeleton until the fixed
+// execute-javascript probe has been run on a Mac with a window open.
+// Task-0 live evidence (Codex app 26.814.41407) returned Access not allowed
+// (-1723), and the AllowJavaScriptAppleEvents defaults key was absent. The
+// finding is recorded at https://github.com/avivsinai/agent-message-queue/issues/640#issuecomment-5402828566;
+// keep this seat refused until an explicit operator decision changes the gate.
+//
+// The Runner field is reserved for the native osascript implementation after
+// the gate is recorded. Keeping the dependency injectable now makes the
+// eventual identity and submit tests deterministic without invoking a GUI.
+type CodexApp struct {
+	Runner CommandRunner
+}
+
+func (CodexApp) Name() string {
+	return "codex-app"
+}
+
+func (CodexApp) NormalizeTarget(target string) (string, error) {
+	id, err := parseCodexAppTarget(target)
+	if err != nil {
+		return "", err
+	}
+	return codexAppTargetPrefix + id, nil
+}
+
+func (CodexApp) Discover(context.Context) (string, error) {
+	return "", codexAppGateError()
+}
+
+func (CodexApp) Probe(context.Context, string) error {
+	return codexAppGateError()
+}
+
+func (CodexApp) Inject(context.Context, string, string) error {
+	return codexAppGateError()
+}
+
+func codexAppGateError() error {
+	return fmt.Errorf("%w: codex-app execute-javascript task-0 evidence is required before registration", ErrGUIAdapterNotReady)
+}
+
+func parseCodexAppTarget(target string) (string, error) {
+	target = strings.TrimSpace(target)
+	id, ok := strings.CutPrefix(target, codexAppTargetPrefix)
+	if !ok {
+		return "", fmt.Errorf("unsupported Codex app target %q; reattach required with a pinned tab identity", target)
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("Codex app target is missing a tab identity")
+	}
+	for _, char := range id {
+		if unicode.IsSpace(char) || unicode.IsControl(char) {
+			return "", fmt.Errorf("Codex app target contains unsafe tab identity")
+		}
+	}
+	return id, nil
+}
+
+// codexAppTask0AppleScript is the fixed native probe represented by
+// scripts/probe-codex-app-execute-javascript.sh. It has no payload input and
+// only returns a constant from the selected single tab.
+const codexAppTask0AppleScript = `
+on run
+	tell application "ChatGPT"
+		set windowCount to count of windows
+		if windowCount is not 1 then error "task-0 requires exactly one Codex app window"
+		set targetWindow to item 1 of windows
+		set tabCount to count of tabs of targetWindow
+		if tabCount is not 1 then error "task-0 requires exactly one Codex app tab"
+		set targetTab to item 1 of tabs of targetWindow
+		return execute javascript "(() => 'AMQ_CODEX_APP_EXECUTE_JS_TASK_0')()" in targetTab
+	end tell
+end run
+`

--- a/internal/keepalive/adapter/codexapp.go
+++ b/internal/keepalive/adapter/codexapp.go
@@ -60,11 +60,11 @@ func parseCodexAppTarget(target string) (string, error) {
 	}
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", fmt.Errorf("Codex app target is missing a tab identity")
+		return "", fmt.Errorf("codex app target is missing a tab identity")
 	}
 	for _, char := range id {
 		if unicode.IsSpace(char) || unicode.IsControl(char) {
-			return "", fmt.Errorf("Codex app target contains unsafe tab identity")
+			return "", fmt.Errorf("codex app target contains unsafe tab identity")
 		}
 	}
 	return id, nil

--- a/internal/keepalive/adapter/gui_adapter_test.go
+++ b/internal/keepalive/adapter/gui_adapter_test.go
@@ -1,0 +1,76 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDefaultRegistryKeepsGUIAdaptersGated(t *testing.T) {
+	registry := DefaultRegistry()
+	for _, name := range []string{"codex-app", "claude-desktop"} {
+		if _, err := registry.Get(name); err == nil {
+			t.Fatalf("DefaultRegistry().Get(%q) succeeded before the GUI capability gate", name)
+		}
+	}
+}
+
+func TestCodexAppSkeletonRefusesEveryLiveOperationBeforeTask0(t *testing.T) {
+	app := CodexApp{}
+	if got, err := app.NormalizeTarget(" codex-app:tab:window-1/tab-1 "); err != nil || got != "codex-app:tab:window-1/tab-1" {
+		t.Fatalf("NormalizeTarget() = %q, %v; want stable target", got, err)
+	}
+	if _, err := app.Discover(context.Background()); !errors.Is(err, ErrGUIAdapterNotReady) {
+		t.Fatalf("Discover() error = %v, want task-0 refusal", err)
+	}
+	if err := app.Probe(context.Background(), "codex-app:tab:window-1/tab-1"); !errors.Is(err, ErrGUIAdapterNotReady) {
+		t.Fatalf("Probe() error = %v, want task-0 refusal", err)
+	}
+	if err := app.Inject(context.Background(), "codex-app:tab:window-1/tab-1", "payload"); !errors.Is(err, ErrGUIAdapterNotReady) {
+		t.Fatalf("Inject() error = %v, want task-0 refusal", err)
+	}
+}
+
+func TestCodexAppTargetRejectsUnpinnedOrUnsafeIdentity(t *testing.T) {
+	for _, target := range []string{
+		"",
+		"ChatGPT",
+		"codex-app:tab:",
+		"codex-app:tab:window-1/tab\n1",
+	} {
+		if _, err := (CodexApp{}).NormalizeTarget(target); err == nil {
+			t.Fatalf("NormalizeTarget(%q) succeeded; want refusal", target)
+		}
+	}
+}
+
+func TestClaudeDesktopSkeletonRefusesEveryLiveOperation(t *testing.T) {
+	app := ClaudeDesktop{}
+	if got, err := app.NormalizeTarget(" claude-desktop:new "); err != nil || got != claudeDesktopTarget {
+		t.Fatalf("NormalizeTarget() = %q, %v; want new-session target", got, err)
+	}
+	if _, err := app.Discover(context.Background()); !errors.Is(err, ErrGUIAdapterNotReady) {
+		t.Fatalf("Discover() error = %v, want capability refusal", err)
+	}
+	if err := app.Probe(context.Background(), claudeDesktopTarget); !errors.Is(err, ErrGUIAdapterNotReady) {
+		t.Fatalf("Probe() error = %v, want capability refusal", err)
+	}
+	if err := app.Inject(context.Background(), claudeDesktopTarget, "payload"); !errors.Is(err, ErrGUIAdapterNotReady) {
+		t.Fatalf("Inject() error = %v, want capability refusal", err)
+	}
+}
+
+func TestGUIAppleScriptUsesNoForbiddenGenericAutomation(t *testing.T) {
+	for _, forbidden := range []string{"System Events", "keystroke", "the clipboard", "AXRaise", "activate"} {
+		if strings.Contains(codexAppTask0AppleScript, forbidden) {
+			t.Fatalf("Codex app task-0 script contains forbidden %q", forbidden)
+		}
+	}
+	if !strings.Contains(codexAppTask0AppleScript, "execute javascript") {
+		t.Fatal("Codex app task-0 script does not use execute javascript")
+	}
+	if !strings.Contains(codexAppTask0AppleScript, "AMQ_CODEX_APP_EXECUTE_JS_TASK_0") {
+		t.Fatal("Codex app task-0 script does not use the fixed probe result")
+	}
+}

--- a/scripts/probe-codex-app-execute-javascript.sh
+++ b/scripts/probe-codex-app-execute-javascript.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Task-0 evidence harness for the native Codex app Apple Events dictionary.
+# Run this manually on macOS with exactly one Codex app window and tab open.
+# It is not a live-delivery test and is intentionally not run by this change.
+# Current live result (Codex app 26.814.41407) is recorded at:
+# https://github.com/avivsinai/agent-message-queue/issues/640#issuecomment-5402828566
+set -eu
+
+expected='AMQ_CODEX_APP_EXECUTE_JS_TASK_0'
+
+if [ "$(uname -s)" != 'Darwin' ]; then
+  printf '%s\n' 'Codex app task-0 probe requires macOS; no live probe was run.' >&2
+  exit 2
+fi
+if ! command -v osascript >/dev/null 2>&1; then
+  printf '%s\n' 'Codex app task-0 probe requires osascript.' >&2
+  exit 2
+fi
+
+apple_script=$(cat <<'APPLESCRIPT'
+on run
+	tell application "ChatGPT"
+		set windowCount to count of windows
+		if windowCount is not 1 then error "task-0 requires exactly one Codex app window"
+		set targetWindow to item 1 of windows
+		set tabCount to count of tabs of targetWindow
+		if tabCount is not 1 then error "task-0 requires exactly one Codex app tab"
+		set targetTab to item 1 of tabs of targetWindow
+		return execute javascript "(() => 'AMQ_CODEX_APP_EXECUTE_JS_TASK_0')()" in targetTab
+	end tell
+end run
+APPLESCRIPT
+)
+
+if result=$(osascript -e "$apple_script"); then
+  :
+else
+  status=$?
+  printf 'Codex app task-0 probe failed (exit %s).\n' "$status" >&2
+  exit "$status"
+fi
+result=$(printf '%s' "$result" | tr -d '\r\n')
+if [ "$result" != "$expected" ]; then
+  printf 'Codex app task-0 probe returned %s; want %s.\n' "$result" "$expected" >&2
+  exit 1
+fi
+
+printf 'Codex app execute-javascript task-0 probe: PASS (%s)\n' "$expected"

--- a/scripts/probe-codex-app-execute-javascript_test.sh
+++ b/scripts/probe-codex-app-execute-javascript_test.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Static and fake-command tests for the non-live task-0 evidence harness.
+set -eu
+
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+PROBE=$ROOT/scripts/probe-codex-app-execute-javascript.sh
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/codex-app-task0-test.XXXXXX")
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -x "$PROBE" ] || fail "probe is not executable"
+sh -n "$PROBE" || fail "probe has invalid shell syntax"
+if command -v shellcheck >/dev/null 2>&1; then
+  shellcheck "$PROBE" || fail "probe failed shellcheck"
+fi
+
+for forbidden in 'System Events' 'keystroke' 'the clipboard' 'AXRaise' 'activate'; do
+  if grep -F -q -- "$forbidden" "$PROBE"; then
+    fail "probe contains forbidden automation API: $forbidden"
+  fi
+done
+grep -F -q -- 'execute javascript' "$PROBE" || fail 'probe does not call execute javascript'
+grep -F -q -- "AMQ_CODEX_APP_EXECUTE_JS_TASK_0" "$PROBE" || fail 'probe marker is not fixed'
+if grep -E -q '\$[0-9]|\$@|\$\*' "$PROBE"; then
+  fail 'probe accepts message-derived shell arguments'
+fi
+
+BIN=$WORK/bin
+mkdir -p "$BIN"
+cat >"$BIN/uname" <<'EOF'
+#!/bin/sh
+printf '%s\n' Darwin
+EOF
+cat >"$BIN/osascript" <<'EOF'
+#!/bin/sh
+set -eu
+[ "${1:-}" = '-e' ] || exit 2
+printf '%s' "${2:-}" >"${CODEX_APP_TASK0_SCRIPT_CAPTURE:?}"
+printf '%s\n' 'AMQ_CODEX_APP_EXECUTE_JS_TASK_0'
+EOF
+chmod 0755 "$BIN/uname" "$BIN/osascript"
+
+CODEX_APP_TASK0_SCRIPT_CAPTURE=$WORK/apple-script.txt \
+  PATH="$BIN:/bin:/usr/bin" sh "$PROBE" >"$WORK/pass.out"
+grep -F -q -- 'task-0 probe: PASS' "$WORK/pass.out" || fail 'fake successful probe did not pass'
+grep -F -q -- 'execute javascript' "$WORK/apple-script.txt" || fail 'fixed AppleScript was not passed to osascript'
+grep -F -q -- "AMQ_CODEX_APP_EXECUTE_JS_TASK_0" "$WORK/apple-script.txt" || fail 'fixed JavaScript marker was not passed'
+
+cat >"$BIN/osascript" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'unexpected result'
+EOF
+chmod 0755 "$BIN/osascript"
+status=0
+PATH="$BIN:/bin:/usr/bin" sh "$PROBE" >"$WORK/fail.out" 2>"$WORK/fail.err" || status=$?
+[ "$status" -ne 0 ] || fail 'wrong fixed result was accepted'
+
+printf '%s\n' 'Codex app task-0 probe tests passed'


### PR DESCRIPTION
## Summary

- add a non-live Codex app task-0 Apple Events probe with fixed `execute javascript` and fake-command negative tests
- add fail-closed `codex-app` and `claude-desktop` adapter skeletons
- keep both GUI adapters out of `DefaultRegistry` until the capability gate is proven
- record the live Codex app 26.814.41407 gate result: `Access not allowed (-1723)` and no `AllowJavaScriptAppleEvents` key

Closes #640 only for the honest refusal-side gate; the issue remains open for an operator-approved opt-in path. Evidence: https://github.com/avivsinai/agent-message-queue/issues/640#issuecomment-5402828566

## Verification

- `go test ./internal/keepalive/...`
- `go test ./internal/keepalive/adapter -count=1`
- `sh scripts/probe-codex-app-execute-javascript_test.sh`
- `shellcheck scripts/probe-codex-app-execute-javascript.sh scripts/probe-codex-app-execute-javascript_test.sh`
- `git diff --check`
- `make ci` reaches the pre-existing `gofmt` failure in `internal/cli/wake_owner_observation_darwin.go`; changed Go files are gofmt-clean

The live `osascript` probe was run by Claude on the Mac with one throwaway window/tab and then closed; this session did not run it.