### PR TITLE
feat(wake): ship gated GUI deep-link prefill seats

### DIFF
--- a/docs/adr-wake-capability-vector.md
+++ b/docs/adr-wake-capability-vector.md
@@ -45,8 +45,8 @@ match the TTY contract. `notifier_live` is not consumption.
 | --- | --- | --- |
 | TTY inject | current fail-closed inject | yes (existing) |
 | Hermes Desktop | `submitted` + `existing-exact` only after live attach to the Desktop-owned gateway | **no** until spike |
-| Claude Desktop Code | `prefilled` + `new` + `requires_human` (`claude://code/new`). Does not send. No existing-Code inject | optional human doorbell only |
-| ChatGPT.app | none | **kill** |
+| Claude Desktop Code | `prefilled` + `new` + `requires_human` (`claude://code/new`). Does not send. No existing-Code inject. **Shipped** behind the registration capability gate (`internal/keepalive/adapter/claudedesktop.go`): registered in `DefaultRegistry`, reachable only when the caller explicitly accepts a requires-human seat (`--accept-requires-human`) with delivery/session minima at or below prefilled/new; refused under the default zero-value minimum. Identity pins the `claude://` scheme owner (bundle `com.anthropic.claudefordesktop`) and revalidates before the `open` write. | yes (gated) |
+| ChatGPT.app (Codex app) | `execute javascript` is DEAD (issue #640: `-1723`, `AllowJavaScriptAppleEvents` pref compiled out) — kill for inject. But the `codex://` deep-link is a live prefill seat: `codex://threads/new?prompt=` prefills a NEW thread; `codex://threads/<uuid>?prompt=` opens the EXACT EXISTING conversation and prefills it. Neither auto-submits. **Shipped** behind the registration capability gate (`internal/keepalive/adapter/codexapp.go`): registered in `DefaultRegistry`, two targets (`codex-app:new` → SessionNew, `codex-app:thread:<uuid>` → SessionExistingExact) declared via `TargetCapabilityDeclarer`; reachable only when the caller explicitly accepts a requires-human seat with delivery/session minima at or below prefilled/new-or-existing-exact; refused under the default zero-value minimum. Identity pins the `codex://` scheme owner (bundle `com.openai.codex`) and revalidates before the `open` write. Dispatch caveat: `open` exiting 0 proves DISPATCH only, not delivery — the app can refuse a deep-link with no adapter-visible signal (e.g. a thread with an ACTIVE WRITER shows an error toast and leaves the composer empty), so the thread target must name an IDLE conversation; the app is AX-opaque so the adapter cannot observe the refusal. | yes (gated, deep-link only) |
 | Grok Bot.app | none | **not a wake seat** (Mac operator UI for host G) |
 
 Hermes HTTP `/v1/runs` and `hermes acp` stdio are other processes, not the GUI
@@ -68,12 +68,54 @@ closed.
 | Hermes.app | — | — | — | Not in `/Applications`, not in `~/Applications`, not on PATH. Live Desktop gateway attach remains unproven. |
 | Grok Bot.app | `com.anysphere.sand` / `DCNK4UB866` | 0.20.0 (CFBundleVersion 0.20.0) | `grokbot`, `sand` | Electron Mac client (Anysphere lineage). Not host G and not a GUI-inject seat. |
 
-Do not write GUI wake adapters from this table. Hermes stays refused until a live Desktop-owned gateway attach. Claude stays optional human prefill. ChatGPT stays kill.
+Do not write GUI wake adapters from this table beyond the implemented Claude Desktop prefill seat. Hermes stays refused until a live Desktop-owned gateway attach; the Claude Desktop prefill seat is implemented in `internal/keepalive/adapter/claudedesktop.go` behind the registration capability gate; ChatGPT stays kill.
+
+## Implementation note
+
+The Go `Capability` type (`internal/keepalive/adapter/capability.go`) covers
+`activation`, `delivery`, `session`, and `requires_human` — the four axes a
+seat advertises and a caller's minimum is checked against via `Satisfies`
+(refusal over substitution). The `evidence` dimension from the vector table
+above is deliberately **not** a Go axis: it is a prose-level contract whose
+semantics (`notifier_live` vs stronger, never `drained`) live elsewhere in AMQ
+(receipts, wake-lock inspection). Omitting it from the type is intentional, not
+an oversight — a speculative axis would invite half-implemented strength
+claims. Adapters declare a `Capability` via the `CapabilityDeclarer` interface;
+an adapter that does not implement it is treated as `UnknownCapability()` —
+weakest on every ordered axis and most-restrictive on the tolerance axis
+(`requires_human` true) — so it is refused unless the caller explicitly
+tolerates a human-required seat, never masquerading as an unattended
+full-strength seat. The capability gate runs at
+registration (`internal/keepalive/app/app.go`), after target resolution
+(discovery when no explicit target was given, then normalization) and before
+any write — a refusal mutates no registry state and performs no injection.
+(Discovery may run a read-only identity probe when no explicit target was
+given, since the adapter must prove its identity before naming a seat; this
+probe is not a write.)
+
+### Identity-pin exception for the deep-link prefill seats
+
+This launch-type prefill seat applies to both the Claude Desktop seat
+(`claude://`, bundle `com.anthropic.claudefordesktop`) and the Codex app seat
+(`codex://`, bundle `com.openai.codex`). Each pins the `codex://`/`claude://`
+scheme-owner bundle id only, and revalidates it before the `open` write. The
+ADR's full identity pin set (Team ID, resolved executable, adapter version,
+session id, process generation, endpoint identity) is deliberately deferred
+for these seats: they have no persistent process to pin a generation on (a
+deep-link launch is stateless), and the remaining pins are same-machine-
+attacker hardening deferred under the personal single-user tool policy. The
+Team-ID codesign pin in particular is tracked as a named backlog follow-up,
+not implemented in v1. This exception is recorded here so a reader knows the
+narrower pin is intentional, not an omission. (Note: the Codex app also
+registers `http`/`https`; only the `codex` scheme is pinned.)
 
 ## Consequences
 
 - `amq-64q.2` local inspect is complete. Hermes Desktop is not installed here,
   so Hermes stays refused until a live Desktop-owned gateway attach.
-- `amq-64q.3` ships no GUI v1 adapters. TTY inject is unchanged. ChatGPT stays
-  out. Claude prefill is optional and not shipped. GUI wake does not inherit
-  TTY repair.
+- The Claude Desktop prefill seat is shipped behind the registration
+  capability gate (`internal/keepalive/adapter/claudedesktop.go`): registered
+  in `DefaultRegistry`, reachable only when the caller explicitly accepts a
+  requires-human seat with delivery/session minima at or below prefilled/new,
+  and refused under the default zero-value minimum. TTY inject is unchanged.
+  ChatGPT stays out. GUI wake does not inherit TTY repair.

--- a/internal/keepalive/adapter/adapter.go
+++ b/internal/keepalive/adapter/adapter.go
@@ -36,6 +36,27 @@ type TargetNormalizer interface {
 	NormalizeTarget(target string) (string, error)
 }
 
+// CapabilityDeclarer lets an adapter publish its honest delivery vector. An
+// adapter that does not implement it is treated as UnknownCapability()
+// (weakest on every ordered axis and requires a human), so it is refused
+// unless the caller explicitly tolerates a human-required seat. This keeps an
+// adapter that forgets to declare a Capability from masquerading as an
+// unattended full-strength seat.
+type CapabilityDeclarer interface {
+	Capability() Capability
+}
+
+// TargetCapabilityDeclarer is implemented by adapters whose capability vector
+// depends on the resolved target (for example, a deep-link adapter that can
+// prefill either a new session or an exact existing conversation). When an
+// adapter implements this, the registration gate prefers
+// CapabilityForTarget(target) over the target-blind Capability() so a caller
+// requesting an existing-exact session is refused a new-only target rather
+// than silently downgraded. An error from CapabilityForTarget fails closed.
+type TargetCapabilityDeclarer interface {
+	CapabilityForTarget(target string) (Capability, error)
+}
+
 // TargetInventory is a point-in-time existence snapshot. Implementations must
 // return ErrTargetNotFound only when absence is proven by the snapshot; parse,
 // transport, and permission failures remain ambiguous errors. When ownership
@@ -81,17 +102,22 @@ func NewRegistry(adapters ...Adapter) Registry {
 }
 
 func DefaultRegistry() Registry {
-	// GUI adapters remain deliberately unregistered until the task-0 Codex app
-	// Apple Events gate is proven on the target Mac. Do not turn a skeleton or a
-	// prefill fallback into a submitted wake by adding them here early.
-	return NewRegistry(File{}, Ghostty{}, Cmux{recorded: newCmuxOwnershipRecord()})
+	// claude-desktop and codex-app are registered and reachable behind the
+	// capability gate in app.registerWithOptions: a caller gets one only by
+	// explicitly accepting a requires-human seat (--accept-requires-human) with
+	// delivery/session minima at or below what the target declares. With the
+	// default zero-value minimum both are refused automatically, and a
+	// submitted/unattended caller is refused too. (The Codex app's dead
+	// execute-javascript path stays dead — issue #640 — but its live codex://
+	// deep-link prefill seat is shipped here.)
+	return NewRegistry(File{}, Ghostty{}, Cmux{recorded: newCmuxOwnershipRecord()}, ClaudeDesktop{}, CodexApp{})
 }
 
 // DefaultRegistryWithLogf returns the production adapter set with non-fatal
 // adapter diagnostics wired to logf. Callers that do not own a diagnostic
 // stream can continue using DefaultRegistry.
 func DefaultRegistryWithLogf(logf func(format string, args ...any)) Registry {
-	return NewRegistry(File{}, Ghostty{}, Cmux{Logf: logf, recorded: newCmuxOwnershipRecord()})
+	return NewRegistry(File{}, Ghostty{}, Cmux{Logf: logf, recorded: newCmuxOwnershipRecord()}, ClaudeDesktop{}, CodexApp{})
 }
 
 func (r Registry) Get(name string) (Adapter, error) {

--- a/internal/keepalive/adapter/capability.go
+++ b/internal/keepalive/adapter/capability.go
@@ -1,0 +1,71 @@
+package adapter
+
+// Capability models the wake capability vector from
+// docs/adr-wake-capability-vector.md. Each seat advertises the strongest
+// delivery it can honestly claim; callers request a minimum. Weaker is
+// refused, never substituted (ADR §"refusal over substitution").
+type Capability struct {
+	Activation    Activation
+	Delivery      Delivery
+	Session       SessionScope
+	RequiresHuman bool
+}
+
+// Activation is how strongly a seat can bring its surface to the user.
+type Activation int // none < launch < foreground
+
+const (
+	ActivationNone Activation = iota
+	ActivationLaunch
+	ActivationForeground
+)
+
+// Delivery is how much of the prompt reaches the composer.
+type Delivery int // none < prefilled < submitted
+
+const (
+	DeliveryNone Delivery = iota
+	DeliveryPrefilled
+	DeliverySubmitted
+)
+
+// SessionScope is how precisely the seat addresses an existing surface.
+type SessionScope int // none < new < existing-exact
+
+const (
+	SessionNone SessionScope = iota
+	SessionNew
+	SessionExistingExact
+)
+
+// Satisfies reports whether this seat is at least as strong as the caller's
+// minimum on every axis. Weaker is REFUSED, never substituted
+// (ADR §"refusal over substitution"). A caller that needs an unattended wake
+// (min.RequiresHuman == false) must refuse a requires-human seat; a caller
+// that accepts a human handoff (min.RequiresHuman == true) accepts either.
+func (c Capability) Satisfies(min Capability) bool {
+	if c.Activation < min.Activation {
+		return false
+	}
+	if c.Delivery < min.Delivery {
+		return false
+	}
+	if c.Session < min.Session {
+		return false
+	}
+	if !min.RequiresHuman && c.RequiresHuman {
+		return false
+	}
+	return true
+}
+
+// UnknownCapability is the vector assumed for an adapter that does not
+// implement CapabilityDeclarer: weakest on every ordered axis
+// (Activation/Delivery/Session all None) and most-restrictive on the tolerance
+// axis (RequiresHuman true). An undeclared adapter is therefore refused
+// unless the caller explicitly tolerates a human-required seat, so an adapter
+// that forgets to declare a Capability can never masquerade as an unattended
+// full-strength seat. This is worst-case on the tolerance axis, not zero-value:
+// the zero-value Capability has RequiresHuman=false, which would let an unknown
+// adapter pass the default zero minimum as if it delivered unattended.
+func UnknownCapability() Capability { return Capability{RequiresHuman: true} }

--- a/internal/keepalive/adapter/capability_test.go
+++ b/internal/keepalive/adapter/capability_test.go
@@ -1,0 +1,122 @@
+package adapter
+
+import "testing"
+
+func TestCapabilitySatisfies(t *testing.T) {
+	// The honest claude-desktop seat from the live smoke: prefilled + new +
+	// requires_human. Activation is launch (deep-link opens the app/surface).
+	claudeDesktop := Capability{
+		Activation:    ActivationLaunch,
+		Delivery:      DeliveryPrefilled,
+		Session:       SessionNew,
+		RequiresHuman: true,
+	}
+	// A full-strength TTY seat: foreground + submitted + existing-exact,
+	// unattended.
+	tty := Capability{
+		Activation:    ActivationForeground,
+		Delivery:      DeliverySubmitted,
+		Session:       SessionExistingExact,
+		RequiresHuman: false,
+	}
+	zero := Capability{}
+
+	tests := []struct {
+		name string
+		seat Capability
+		min  Capability
+		want bool
+	}{
+		{
+			name: "submitted-caller vs prefilled seat is refused (the core submit-to-prefill downgrade)",
+			seat: claudeDesktop,
+			min:  Capability{Delivery: DeliverySubmitted},
+			want: false,
+		},
+		{
+			name: "existing-exact-caller vs new-only seat is refused",
+			seat: claudeDesktop,
+			min:  Capability{Session: SessionExistingExact},
+			want: false,
+		},
+		{
+			name: "unattended caller vs requires-human seat is refused",
+			seat: claudeDesktop,
+			min:  Capability{RequiresHuman: false, Delivery: DeliveryPrefilled, Session: SessionNew},
+			want: false,
+		},
+		{
+			name: "human-handoff caller accepts the requires-human prefilled seat",
+			seat: claudeDesktop,
+			min:  Capability{Delivery: DeliveryPrefilled, Session: SessionNew, RequiresHuman: true},
+			want: true,
+		},
+		{
+			name: "equal on all axes satisfies",
+			seat: claudeDesktop,
+			min:  claudeDesktop,
+			want: true,
+		},
+		{
+			name: "stronger-than-min on every axis satisfies",
+			seat: tty,
+			min:  claudeDesktop,
+			want: true,
+		},
+		{
+			name: "zero-value seat satisfies only the zero-value min",
+			seat: zero,
+			min:  zero,
+			want: true,
+		},
+		{
+			name: "zero-value seat does not satisfy a submitted min",
+			seat: zero,
+			min:  Capability{Delivery: DeliverySubmitted},
+			want: false,
+		},
+		{
+			name: "requires-human seat with unattended min and zero axes is refused",
+			seat: Capability{RequiresHuman: true},
+			min:  Capability{RequiresHuman: false},
+			want: false,
+		},
+		{
+			name: "requires-human seat with unattended min and otherwise-equal axes is refused",
+			seat: Capability{Activation: ActivationLaunch, Delivery: DeliveryPrefilled, Session: SessionNew, RequiresHuman: true},
+			min:  Capability{Activation: ActivationLaunch, Delivery: DeliveryPrefilled, Session: SessionNew, RequiresHuman: false},
+			want: false,
+		},
+		{
+			name: "requires-human seat with requires-human min and zero axes satisfies",
+			seat: Capability{RequiresHuman: true},
+			min:  Capability{RequiresHuman: true},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.seat.Satisfies(tt.min); got != tt.want {
+				t.Fatalf("Satisfies() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCapabilityZeroValueIsWeakest(t *testing.T) {
+	// The zero value must be the weakest seat on the ordered axes: it
+	// satisfies nothing stronger than the zero-value minimum on activation,
+	// delivery, or session. (RequiresHuman on the min is a tolerance, not a
+	// strength axis: a min that accepts human handoff also accepts an
+	// unattended seat, so it is deliberately not in this list.)
+	zero := Capability{}
+	for _, min := range []Capability{
+		{Activation: ActivationLaunch},
+		{Delivery: DeliveryPrefilled},
+		{Session: SessionNew},
+	} {
+		if zero.Satisfies(min) {
+			t.Fatalf("zero-value seat satisfied %+v; want refusal", min)
+		}
+	}
+}

--- a/internal/keepalive/adapter/claudedesktop.go
+++ b/internal/keepalive/adapter/claudedesktop.go
@@ -3,21 +3,41 @@ package adapter
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 )
 
 const claudeDesktopTarget = "claude-desktop:new"
 
-// ClaudeDesktop describes the honest deep-link seat from the wake capability
-// ADR: prefilled + new + requires_human. The existing inject-via interface
-// cannot claim that vector, so this skeleton stays out of DefaultRegistry
-// until a capability-aware caller owns the explicit human handoff.
+// claudeDesktopBundleID is the identity pin for Claude Desktop from
+// docs/adr-wake-capability-vector.md. A Probe that cannot prove this bundle id
+// owns the claude:// scheme fails closed.
+const claudeDesktopBundleID = "com.anthropic.claudefordesktop"
+
+// ClaudeDesktop implements the honest deep-link seat from the wake capability
+// ADR: prefilled + new + requires_human. `claude://code/new?q=<prompt>`
+// PREFILLS the composer on the Code surface and never auto-submits; a human
+// send is always required (verified live on Claude Desktop 1.34493.1). This
+// adapter only launches the deep-link; it does not and cannot submit.
 type ClaudeDesktop struct {
 	Runner CommandRunner
 }
 
 func (ClaudeDesktop) Name() string {
 	return "claude-desktop"
+}
+
+// Capability declares the proven seat vector: the deep-link launches the app
+// (ActivationLaunch), prefills the composer without submitting
+// (DeliveryPrefilled), always targets a new session (SessionNew), and a human
+// must press send (RequiresHuman).
+func (ClaudeDesktop) Capability() Capability {
+	return Capability{
+		Activation:    ActivationLaunch,
+		Delivery:      DeliveryPrefilled,
+		Session:       SessionNew,
+		RequiresHuman: true,
+	}
 }
 
 func (ClaudeDesktop) NormalizeTarget(target string) (string, error) {
@@ -27,18 +47,70 @@ func (ClaudeDesktop) NormalizeTarget(target string) (string, error) {
 	return claudeDesktopTarget, nil
 }
 
-func (ClaudeDesktop) Discover(context.Context) (string, error) {
-	return "", claudeDesktopGateError()
+// Discover returns the single new-session seat. It is deliberately reachable
+// so an explicit `attach --adapter claude-desktop --target claude-desktop:new`
+// can name it; the human-handoff gate is enforced at registration
+// (CapabilityDeclarer), not here. Discovery does not auto-open the app.
+func (c ClaudeDesktop) Discover(ctx context.Context) (string, error) {
+	if err := requireDarwin(); err != nil {
+		return "", err
+	}
+	if err := c.Probe(ctx, claudeDesktopTarget); err != nil {
+		return "", err
+	}
+	return claudeDesktopTarget, nil
 }
 
-func (ClaudeDesktop) Probe(context.Context, string) error {
-	return claudeDesktopGateError()
+// Probe verifies the Claude Desktop app identity before blessing the target.
+// It resolves the actual default handler of the `claude://` scheme and asserts
+// it is the pinned bundle id com.anthropic.claudefordesktop — the same app
+// that `open claude://...` will dispatch to at write time. A mismatch, a
+// missing handler, a non-darwin platform, or any command failure fails closed.
+func (c ClaudeDesktop) Probe(ctx context.Context, target string) error {
+	if err := requireDarwin(); err != nil {
+		return err
+	}
+	if _, err := c.NormalizeTarget(target); err != nil {
+		return err
+	}
+	return probeSchemeOwner(ctx, c.runner(), "claude", claudeDesktopBundleID)
 }
 
-func (ClaudeDesktop) Inject(context.Context, string, string) error {
-	return claudeDesktopGateError()
+// Inject launches the prefill-only deep-link. The payload becomes a properly
+// query-escaped `q` parameter; the resulting URL is passed as a single
+// argument to `open`. The prompt text never enters AppleScript/osascript or
+// any script source — it exists only as the single query-escaped `open`
+// argument. There is no System Events/keystroke/clipboard/activate, and
+// crucially no submit — this seat never sends Enter.
+//
+// Identity is revalidated before the write: `open` is scheme-bound, not
+// identity-bound (it dispatches to whatever app owns claude:// at call time),
+// so Probe runs here, not only at Discover/registration. On any identity
+// mismatch or command failure Inject fails closed without emitting the open.
+func (c ClaudeDesktop) Inject(ctx context.Context, target string, payload string) error {
+	if err := requireDarwin(); err != nil {
+		return err
+	}
+	if _, err := c.NormalizeTarget(target); err != nil {
+		return err
+	}
+	if err := c.Probe(ctx, target); err != nil {
+		return fmt.Errorf("inject Claude Desktop: %w", err)
+	}
+	u := url.URL{Scheme: "claude", Host: "code", Path: "/new"}
+	q := url.Values{}
+	q.Set("q", payload)
+	u.RawQuery = q.Encode()
+	out, err := c.runner().Run(ctx, "open", u.String())
+	if err != nil {
+		return fmt.Errorf("inject Claude Desktop deep-link: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
-func claudeDesktopGateError() error {
-	return fmt.Errorf("%w: Claude Desktop deep-link delivery needs a capability-aware human handoff", ErrGUIAdapterNotReady)
+func (c ClaudeDesktop) runner() CommandRunner {
+	if c.Runner != nil {
+		return c.Runner
+	}
+	return ExecRunner{}
 }

--- a/internal/keepalive/adapter/cmux.go
+++ b/internal/keepalive/adapter/cmux.go
@@ -148,6 +148,20 @@ func (Cmux) Name() string {
 	return "cmux"
 }
 
+// Capability declares the full-strength TTY seat on delivery and session:
+// the adapter submits the payload (text + Enter) into an exact existing cmux
+// surface with no human in the loop. Activation is None — Inject sends text
+// and Enter via cmux RPC (surface.send_text / surface.send_key) WITHOUT
+// raising/focusing the surface.
+func (Cmux) Capability() Capability {
+	return Capability{
+		Activation:    ActivationNone,
+		Delivery:      DeliverySubmitted,
+		Session:       SessionExistingExact,
+		RequiresHuman: false,
+	}
+}
+
 func (c Cmux) Discover(_ context.Context) (string, error) {
 	if err := requireCmuxPlatform(); err != nil {
 		return "", err

--- a/internal/keepalive/adapter/codexapp.go
+++ b/internal/keepalive/adapter/codexapp.go
@@ -3,23 +3,57 @@ package adapter
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"regexp"
 	"strings"
-	"unicode"
 )
 
-const codexAppTargetPrefix = "codex-app:tab:"
+// codexAppBundleID is the identity pin for the Codex app (rebranded ChatGPT.app)
+// from docs/adr-wake-capability-vector.md. A Probe that cannot prove this
+// bundle id owns the codex:// scheme fails closed.
+const codexAppBundleID = "com.openai.codex"
 
-// CodexApp is the task-0-gated seat for the native Codex app Apple Events
-// surface. The adapter is intentionally a skeleton until the fixed
-// execute-javascript probe has been run on a Mac with a window open.
-// Task-0 live evidence (Codex app 26.814.41407) returned Access not allowed
-// (-1723), and the AllowJavaScriptAppleEvents defaults key was absent. The
-// finding is recorded at https://github.com/avivsinai/agent-message-queue/issues/640#issuecomment-5402828566;
-// keep this seat refused until an explicit operator decision changes the gate.
+// codexAppTargetNew and codexAppTargetThreadPrefix are the two stable target
+// grammars. codex-app:new prefills a brand-new thread; codex-app:thread:<uuid>
+// prefills the composer of an exact existing conversation identified by its
+// rollout uuid (the trailing uuidv7 of a
+// ~/.codex/sessions/YYYY/MM/DD/rollout-*-<uuid>.jsonl filename).
+const (
+	codexAppTargetNew          = "codex-app:new"
+	codexAppTargetThreadPrefix = "codex-app:thread:"
+)
+
+// codexAppThreadUUIDRe matches an exact lowercase uuidv7 (8-4-4-4-12 hex). It
+// is anchored so no path-segment, query, or extra-component smuggling can
+// reach the URL built from the target.
+var codexAppThreadUUIDRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// CodexApp implements the honest deep-link seat for the Codex app
+// (com.openai.codex): `codex://threads/new?prompt=<text>` prefills a NEW
+// thread, and `codex://threads/<uuid>?prompt=<text>` opens the EXACT EXISTING
+// conversation <uuid> and prefills its composer. Neither auto-submits; a human
+// send is always required (verified live on app 26.818.61809). This adapter
+// only launches the deep-link; it does not and cannot submit.
 //
-// The Runner field is reserved for the native osascript implementation after
-// the gate is recorded. Keeping the dependency injectable now makes the
-// eventual identity and submit tests deterministic without invoking a GUI.
+// Dispatch-vs-delivery caveat (live finding, issue #640): `open` exits 0 once
+// the OS dispatches the URL to the registered handler — that proves DISPATCH
+// only, not delivery. The app can refuse the deep-link with no adapter-visible
+// signal: e.g. a thread with an ACTIVE WRITER shows an "Error creating chat —
+// thread <uuid> already has an active writer" toast and leaves the composer
+// empty, yet `open` still exits 0 and Inject reports success. Therefore the
+// codex-app:thread:<uuid> target must name an IDLE conversation (no active
+// writer), and callers must treat Inject success as "launched, not confirmed
+// delivered". The adapter cannot observe the in-app refusal because the Codex
+// app is AX-opaque (Chromium content is not exposed to System Events).
+//
+// The native `execute javascript` Apple Events path is DEAD and stays dead:
+// live smoke on app 26.818.61809 returned `Access not allowed (-1723)`, and
+// writing browser.allow_javascript_apple_events=true into the profile
+// Preferences did not unlock it (the pref survives quit but the runtime check
+// is compiled out). Do not re-try that path; the finding is recorded at
+// https://github.com/avivsinai/agent-message-queue/issues/640#issuecomment-5406484999.
+// The task-0 probe script in scripts/probe-codex-app-execute-javascript.sh
+// remains as historical evidence and is intentionally not invoked here.
 type CodexApp struct {
 	Runner CommandRunner
 }
@@ -28,61 +62,125 @@ func (CodexApp) Name() string {
 	return "codex-app"
 }
 
+// CapabilityForTarget declares the per-target vector this deep-link seat can
+// honestly claim. Both targets are launch + prefilled + requires_human; they
+// differ only on session scope: codex-app:new is SessionNew, and
+// codex-app:thread:<uuid> is SessionExistingExact (it opens a specific
+// existing conversation). A caller requesting an existing-exact session is
+// therefore refused the new-only target rather than silently downgraded.
+func (CodexApp) CapabilityForTarget(target string) (Capability, error) {
+	switch target {
+	case codexAppTargetNew:
+		return Capability{Activation: ActivationLaunch, Delivery: DeliveryPrefilled, Session: SessionNew, RequiresHuman: true}, nil
+	default:
+		if _, err := parseCodexAppThreadUUID(target); err != nil {
+			return Capability{}, err
+		}
+		return Capability{Activation: ActivationLaunch, Delivery: DeliveryPrefilled, Session: SessionExistingExact, RequiresHuman: true}, nil
+	}
+}
+
 func (CodexApp) NormalizeTarget(target string) (string, error) {
-	id, err := parseCodexAppTarget(target)
-	if err != nil {
+	target = strings.TrimSpace(target)
+	if target == codexAppTargetNew {
+		return codexAppTargetNew, nil
+	}
+	if id, err := parseCodexAppThreadUUID(target); err == nil {
+		return codexAppTargetThreadPrefix + id, nil
+	} else {
 		return "", err
 	}
-	return codexAppTargetPrefix + id, nil
 }
 
-func (CodexApp) Discover(context.Context) (string, error) {
-	return "", codexAppGateError()
+// Discover returns the new-thread seat (the only target that does not require
+// a pre-existing conversation id). It is deliberately reachable so an explicit
+// `attach --adapter codex-app --target codex-app:new` can name it; the
+// human-handoff gate is enforced at registration, not here. Discovery does not
+// auto-open the app.
+func (c CodexApp) Discover(ctx context.Context) (string, error) {
+	if err := requireDarwin(); err != nil {
+		return "", err
+	}
+	if err := c.Probe(ctx, codexAppTargetNew); err != nil {
+		return "", err
+	}
+	return codexAppTargetNew, nil
 }
 
-func (CodexApp) Probe(context.Context, string) error {
-	return codexAppGateError()
+// Probe verifies the Codex app identity before blessing the target. It
+// resolves the actual default handler of the `codex://` scheme and asserts it
+// is the pinned bundle id com.openai.codex — the same app that
+// `open codex://...` will dispatch to at write time. (The app also registers
+// http/https; only the codex scheme is pinned.) A mismatch, a missing
+// handler, a non-darwin platform, or any command failure fails closed.
+func (c CodexApp) Probe(ctx context.Context, target string) error {
+	if err := requireDarwin(); err != nil {
+		return err
+	}
+	if _, err := c.NormalizeTarget(target); err != nil {
+		return err
+	}
+	return probeSchemeOwner(ctx, c.runner(), "codex", codexAppBundleID)
 }
 
-func (CodexApp) Inject(context.Context, string, string) error {
-	return codexAppGateError()
+// Inject launches the prefill-only deep-link. The payload becomes a properly
+// query-escaped `prompt` parameter; the resulting URL is passed as a single
+// argument to `open`. The prompt text never enters AppleScript/osascript or
+// any script source — it exists only as the single query-escaped `open`
+// argument. There is no System Events/keystroke/clipboard/activate, and
+// crucially no submit — this seat never sends Enter.
+//
+// Identity is revalidated before the write: `open` is scheme-bound, not
+// identity-bound (it dispatches to whatever app owns codex:// at call time),
+// so Probe runs here, not only at Discover/registration. On any identity
+// mismatch or command failure Inject fails closed without emitting the open.
+func (c CodexApp) Inject(ctx context.Context, target string, payload string) error {
+	if err := requireDarwin(); err != nil {
+		return err
+	}
+	normalized, err := c.NormalizeTarget(target)
+	if err != nil {
+		return err
+	}
+	if err := c.Probe(ctx, normalized); err != nil {
+		return fmt.Errorf("inject Codex app: %w", err)
+	}
+	u := url.URL{Scheme: "codex", Host: "threads"}
+	switch normalized {
+	case codexAppTargetNew:
+		u.Path = "/new"
+	default:
+		u.Path = "/" + strings.TrimPrefix(normalized, codexAppTargetThreadPrefix)
+	}
+	q := url.Values{}
+	q.Set("prompt", payload)
+	u.RawQuery = q.Encode()
+	out, err := c.runner().Run(ctx, "open", u.String())
+	if err != nil {
+		return fmt.Errorf("inject Codex app deep-link: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
-func codexAppGateError() error {
-	return fmt.Errorf("%w: codex-app execute-javascript task-0 evidence is required before registration", ErrGUIAdapterNotReady)
+func (c CodexApp) runner() CommandRunner {
+	if c.Runner != nil {
+		return c.Runner
+	}
+	return ExecRunner{}
 }
 
-func parseCodexAppTarget(target string) (string, error) {
-	target = strings.TrimSpace(target)
-	id, ok := strings.CutPrefix(target, codexAppTargetPrefix)
+// parseCodexAppThreadUUID extracts and validates the conversation uuid from a
+// codex-app:thread:<uuid> target. It returns an error for anything that is not
+// an exact lowercase 8-4-4-4-12 hex uuid, so no path-segment, query, or extra
+// component can be smuggled into the URL built from the target.
+func parseCodexAppThreadUUID(target string) (string, error) {
+	id, ok := strings.CutPrefix(strings.TrimSpace(target), codexAppTargetThreadPrefix)
 	if !ok {
-		return "", fmt.Errorf("unsupported Codex app target %q; reattach required with a pinned tab identity", target)
+		return "", fmt.Errorf("unsupported Codex app target %q; use %q or %s<uuid>", target, codexAppTargetNew, codexAppTargetThreadPrefix)
 	}
 	id = strings.TrimSpace(id)
-	if id == "" {
-		return "", fmt.Errorf("codex app target is missing a tab identity")
-	}
-	for _, char := range id {
-		if unicode.IsSpace(char) || unicode.IsControl(char) {
-			return "", fmt.Errorf("codex app target contains unsafe tab identity")
-		}
+	if !codexAppThreadUUIDRe.MatchString(id) {
+		return "", fmt.Errorf("invalid Codex app thread uuid %q; want an exact lowercase 8-4-4-4-12 hex uuid", id)
 	}
 	return id, nil
 }
-
-// codexAppTask0AppleScript is the fixed native probe represented by
-// scripts/probe-codex-app-execute-javascript.sh. It has no payload input and
-// only returns a constant from the selected single tab.
-const codexAppTask0AppleScript = `
-on run
-	tell application "ChatGPT"
-		set windowCount to count of windows
-		if windowCount is not 1 then error "task-0 requires exactly one Codex app window"
-		set targetWindow to item 1 of windows
-		set tabCount to count of tabs of targetWindow
-		if tabCount is not 1 then error "task-0 requires exactly one Codex app tab"
-		set targetTab to item 1 of tabs of targetWindow
-		return execute javascript "(() => 'AMQ_CODEX_APP_EXECUTE_JS_TASK_0')()" in targetTab
-	end tell
-end run
-`

--- a/internal/keepalive/adapter/file.go
+++ b/internal/keepalive/adapter/file.go
@@ -19,6 +19,19 @@ func (File) Name() string {
 	return "file"
 }
 
+// Capability declares the file seat as full-strength on delivery and session:
+// Inject appends the payload (with a trailing newline) to an exact, resolved
+// target path with no human in the loop. Activation is None — appending to a
+// file path does not foreground or raise any surface.
+func (File) Capability() Capability {
+	return Capability{
+		Activation:    ActivationNone,
+		Delivery:      DeliverySubmitted,
+		Session:       SessionExistingExact,
+		RequiresHuman: false,
+	}
+}
+
 // NormalizeTarget resolves a file target to its stable absolute pathname.
 // Registration persists this value, so a later launchd invocation cannot
 // reinterpret a relative target from a different working directory. Resolving

--- a/internal/keepalive/adapter/ghostty.go
+++ b/internal/keepalive/adapter/ghostty.go
@@ -29,6 +29,21 @@ func (Ghostty) Name() string {
 	return "ghostty"
 }
 
+// Capability declares the full-strength TTY seat on delivery and session:
+// the adapter submits the payload (text + Enter) into an exact existing
+// terminal surface with no human in the loop. Activation is None because
+// Inject types into a pinned terminal id WITHOUT raising/focusing it
+// (`activate`/`AXRaise` are banned in adapter scripts); it does not claim to
+// bring the surface to the foreground.
+func (Ghostty) Capability() Capability {
+	return Capability{
+		Activation:    ActivationNone,
+		Delivery:      DeliverySubmitted,
+		Session:       SessionExistingExact,
+		RequiresHuman: false,
+	}
+}
+
 func (Ghostty) NormalizeTarget(target string) (string, error) {
 	id, err := parseGhosttyTerminalTarget(target)
 	if err != nil {

--- a/internal/keepalive/adapter/gui_adapter_test.go
+++ b/internal/keepalive/adapter/gui_adapter_test.go
@@ -3,74 +3,305 @@ package adapter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
 
-func TestDefaultRegistryKeepsGUIAdaptersGated(t *testing.T) {
+func TestDefaultRegistryRegistersClaudeDesktopBehindCapabilityGate(t *testing.T) {
 	registry := DefaultRegistry()
-	for _, name := range []string{"codex-app", "claude-desktop"} {
-		if _, err := registry.Get(name); err == nil {
-			t.Fatalf("DefaultRegistry().Get(%q) succeeded before the GUI capability gate", name)
+	// claude-desktop is now registered (it is an honest prefill-only seat),
+	// but the capability gate in app.registerWithOptions refuses it under the
+	// default zero-value minimum and under a submitted/unattended minimum.
+	// The gate-behavior assertions live in internal/keepalive/app.
+	if _, err := registry.Get("claude-desktop"); err != nil {
+		t.Fatalf("DefaultRegistry().Get(%q) failed; claude-desktop should be registered: %v", "claude-desktop", err)
+	}
+	cap := (ClaudeDesktop{}).Capability()
+	if cap.Delivery != DeliveryPrefilled {
+		t.Fatalf("claude-desktop Delivery = %v, want prefilled", cap.Delivery)
+	}
+	if cap.Session != SessionNew {
+		t.Fatalf("claude-desktop Session = %v, want new", cap.Session)
+	}
+	if !cap.RequiresHuman {
+		t.Fatalf("claude-desktop RequiresHuman = false, want true")
+	}
+	// Default zero-value minimum must refuse the requires-human seat.
+	if cap.Satisfies(Capability{}) {
+		t.Fatal("claude-desktop satisfies the zero-value minimum; the default gate must refuse it")
+	}
+	// A submitted/unattended caller must also be refused.
+	if cap.Satisfies(Capability{Delivery: DeliverySubmitted, RequiresHuman: false}) {
+		t.Fatal("claude-desktop satisfies a submitted/unattended minimum; the gate must refuse it")
+	}
+	// Only an explicit human-handoff prefill caller is accepted.
+	if !cap.Satisfies(Capability{Delivery: DeliveryPrefilled, Session: SessionNew, RequiresHuman: true}) {
+		t.Fatal("claude-desktop does not satisfy the explicit prefill+new+requires-human minimum")
+	}
+}
+
+func TestDefaultRegistryRegistersCodexAppBehindCapabilityGate(t *testing.T) {
+	registry := DefaultRegistry()
+	// codex-app is now registered (deep-link prefill seat); the capability gate
+	// in app.registerWithOptions refuses it under the default zero-value minimum.
+	if _, err := registry.Get("codex-app"); err != nil {
+		t.Fatalf("DefaultRegistry().Get(%q) failed; codex-app should be registered: %v", "codex-app", err)
+	}
+	newCap, _ := (CodexApp{}).CapabilityForTarget(codexAppTargetNew)
+	if newCap.Delivery != DeliveryPrefilled || newCap.Session != SessionNew || !newCap.RequiresHuman {
+		t.Fatalf("codex-app:new capability = %+v, want prefilled+new+requires_human", newCap)
+	}
+	threadCap, _ := (CodexApp{}).CapabilityForTarget(codexAppTargetThreadPrefix + "01a01f5f-69d6-7dd0-868f-9376f3d2c0a1")
+	if threadCap.Session != SessionExistingExact {
+		t.Fatalf("codex-app:thread capability Session = %v, want existing-exact", threadCap.Session)
+	}
+	// Both targets are requires-human; default zero min (unattended) refuses them.
+	if newCap.Satisfies(Capability{}) || threadCap.Satisfies(Capability{}) {
+		t.Fatal("codex-app satisfies the zero-value minimum; the default gate must refuse it")
+	}
+	// A new-only target must NOT satisfy an existing-exact min (no downgrade).
+	if newCap.Satisfies(Capability{Delivery: DeliveryPrefilled, Session: SessionExistingExact, RequiresHuman: true}) {
+		t.Fatal("codex-app:new satisfies an existing-exact minimum; the gate must refuse the downgrade")
+	}
+	// The thread target DOES satisfy an existing-exact+prefill+RH-tolerant min.
+	if !threadCap.Satisfies(Capability{Delivery: DeliveryPrefilled, Session: SessionExistingExact, RequiresHuman: true}) {
+		t.Fatal("codex-app:thread does not satisfy the existing-exact+prefill+requires-human minimum")
+	}
+}
+
+func TestCodexAppNormalizeTargetAcceptsNewAndThreadUUID(t *testing.T) {
+	app := CodexApp{}
+	if got, err := app.NormalizeTarget(" codex-app:new "); err != nil || got != codexAppTargetNew {
+		t.Fatalf("NormalizeTarget(new) = %q, %v; want %q", got, err, codexAppTargetNew)
+	}
+	const uuid = "01a01f5f-69d6-7dd0-868f-9376f3d2c0a1"
+	if got, err := app.NormalizeTarget("codex-app:thread:" + uuid); err != nil || got != codexAppTargetThreadPrefix+uuid {
+		t.Fatalf("NormalizeTarget(thread) = %q, %v; want %q", got, err, codexAppTargetThreadPrefix+uuid)
+	}
+}
+
+func TestCodexAppTargetRejectsUnsafeOrMalformedIdentity(t *testing.T) {
+	for _, target := range []string{
+		"",
+		"ChatGPT",
+		"codex-app:tab:window-1/tab-1", // legacy grammar, no longer supported
+		"codex-app:thread:",            // empty uuid
+		"codex-app:thread:01A01F5F-69D6-7DD0-868F-9376F3D2C0A1",       // uppercase
+		"codex-app:thread:01a01f5f-69d6-7dd0-868f-9376f3d2c0a",        // 35 chars
+		"codex-app:thread:../../../etc/passwd",                        // path traversal
+		"codex-app:thread:01a01f5f-69d6-7dd0-868f-9376f3d2c0a1/extra", // extra segment
+		"codex-app:existing",
+	} {
+		if _, err := (CodexApp{}).NormalizeTarget(target); err == nil {
+			t.Fatalf("NormalizeTarget(%q) succeeded; want refusal", target)
+		}
+		if _, err := (CodexApp{}).CapabilityForTarget(target); err == nil {
+			t.Fatalf("CapabilityForTarget(%q) succeeded; want refusal", target)
 		}
 	}
 }
 
-func TestCodexAppSkeletonRefusesEveryLiveOperationBeforeTask0(t *testing.T) {
-	app := CodexApp{}
-	if got, err := app.NormalizeTarget(" codex-app:tab:window-1/tab-1 "); err != nil || got != "codex-app:tab:window-1/tab-1" {
-		t.Fatalf("NormalizeTarget() = %q, %v; want stable target", got, err)
+func TestClaudeDesktopNormalizeTargetAcceptsOnlyNewSession(t *testing.T) {
+	app := ClaudeDesktop{}
+	if got, err := app.NormalizeTarget(" claude-desktop:new "); err != nil || got != claudeDesktopTarget {
+		t.Fatalf("NormalizeTarget() = %q, %v; want new-session target", got, err)
 	}
-	if _, err := app.Discover(context.Background()); !errors.Is(err, ErrGUIAdapterNotReady) {
-		t.Fatalf("Discover() error = %v, want task-0 refusal", err)
-	}
-	if err := app.Probe(context.Background(), "codex-app:tab:window-1/tab-1"); !errors.Is(err, ErrGUIAdapterNotReady) {
-		t.Fatalf("Probe() error = %v, want task-0 refusal", err)
-	}
-	if err := app.Inject(context.Background(), "codex-app:tab:window-1/tab-1", "payload"); !errors.Is(err, ErrGUIAdapterNotReady) {
-		t.Fatalf("Inject() error = %v, want task-0 refusal", err)
-	}
-}
-
-func TestCodexAppTargetRejectsUnpinnedOrUnsafeIdentity(t *testing.T) {
-	for _, target := range []string{
-		"",
-		"ChatGPT",
-		"codex-app:tab:",
-		"codex-app:tab:window-1/tab\n1",
-	} {
-		if _, err := (CodexApp{}).NormalizeTarget(target); err == nil {
+	for _, target := range []string{"", "claude-desktop", "claude-desktop:existing", "claude-desktop:code:existing"} {
+		if _, err := app.NormalizeTarget(target); err == nil {
 			t.Fatalf("NormalizeTarget(%q) succeeded; want refusal", target)
 		}
 	}
 }
 
-func TestClaudeDesktopSkeletonRefusesEveryLiveOperation(t *testing.T) {
-	app := ClaudeDesktop{}
-	if got, err := app.NormalizeTarget(" claude-desktop:new "); err != nil || got != claudeDesktopTarget {
-		t.Fatalf("NormalizeTarget() = %q, %v; want new-session target", got, err)
+func TestClaudeDesktopInjectPrefillsOnlyWithEscapedURL(t *testing.T) {
+	skipNonDarwin(t)
+	// The first runner call is the Inject-time identity Probe (the swift
+	// scheme-handler probe); it must return the pinned bundle id. The second
+	// call is the prefill open.
+	runner := &fakeCommandRunner{results: []fakeCommandResult{
+		{output: []byte(claudeDesktopBundleID + "\n")},
+		{},
+	}}
+	payload := "hello world & q=x"
+	if err := (ClaudeDesktop{Runner: runner}).Inject(context.Background(), claudeDesktopTarget, payload); err != nil {
+		t.Fatalf("Inject() error = %v", err)
 	}
-	if _, err := app.Discover(context.Background()); !errors.Is(err, ErrGUIAdapterNotReady) {
-		t.Fatalf("Discover() error = %v, want capability refusal", err)
+	// Prefill-only: exactly two runner calls (probe + open), no submit step.
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %d, want probe + open (no submit)", len(runner.calls))
 	}
-	if err := app.Probe(context.Background(), claudeDesktopTarget); !errors.Is(err, ErrGUIAdapterNotReady) {
-		t.Fatalf("Probe() error = %v, want capability refusal", err)
+	probeCall := runner.calls[0]
+	if probeCall.name != "swift" {
+		t.Fatalf("first call = %q, want swift scheme-handler probe", probeCall.name)
 	}
-	if err := app.Inject(context.Background(), claudeDesktopTarget, "payload"); !errors.Is(err, ErrGUIAdapterNotReady) {
-		t.Fatalf("Inject() error = %v, want capability refusal", err)
+	call := runner.calls[1]
+	if call.name != "open" {
+		t.Fatalf("second call = %q, want open", call.name)
+	}
+	if len(call.args) != 1 {
+		t.Fatalf("open args = %#v, want a single URL argument", call.args)
+	}
+	// The payload must be query-escaped as the q parameter; &/space/= must be
+	// percent- or plus-encoded, never concatenated raw into a script.
+	wantURL := "claude://code/new?q=hello+world+%26+q%3Dx"
+	if call.args[0] != wantURL {
+		t.Fatalf("open URL = %q, want %q", call.args[0], wantURL)
+	}
+	if strings.Contains(call.args[0], payload) {
+		t.Fatalf("raw payload leaked unescaped into URL: %q", call.args[0])
+	}
+	// No forbidden generic-automation APIs anywhere in the command line.
+	for _, forbidden := range []string{"System Events", "keystroke", "the clipboard", "AXRaise", "activate"} {
+		if strings.Contains(call.name, forbidden) || strings.Contains(strings.Join(call.args, " "), forbidden) {
+			t.Fatalf("command line uses forbidden %q: %#v", forbidden, call)
+		}
 	}
 }
 
-func TestGUIAppleScriptUsesNoForbiddenGenericAutomation(t *testing.T) {
-	for _, forbidden := range []string{"System Events", "keystroke", "the clipboard", "AXRaise", "activate"} {
-		if strings.Contains(codexAppTask0AppleScript, forbidden) {
-			t.Fatalf("Codex app task-0 script contains forbidden %q", forbidden)
+func TestClaudeDesktopInjectFailsClosedOnIdentityMismatchWithoutOpen(t *testing.T) {
+	skipNonDarwin(t)
+	// The Inject write is scheme-bound, not identity-bound, so Inject must
+	// revalidate identity and fail closed before emitting the open. A mismatched
+	// bundle id on the Inject-time Probe must produce zero open calls.
+	mismatch := &fakeCommandRunner{output: []byte("com.some.other.app\n")}
+	injectErr := (ClaudeDesktop{Runner: mismatch}).Inject(context.Background(), claudeDesktopTarget, "payload")
+	if injectErr == nil {
+		t.Fatal("Inject() with mismatched bundle id succeeded; want fail-closed")
+	}
+	for _, c := range mismatch.calls {
+		if c.name == "open" {
+			t.Fatalf("Inject emitted an open call after identity mismatch; the write must be gated: %#v", c)
 		}
 	}
-	if !strings.Contains(codexAppTask0AppleScript, "execute javascript") {
-		t.Fatal("Codex app task-0 script does not use execute javascript")
+	if !strings.Contains(fmt.Sprint(injectErr), claudeDesktopBundleID) {
+		t.Fatalf("Inject() error = %v, want it to surface the identity mismatch", injectErr)
 	}
-	if !strings.Contains(codexAppTask0AppleScript, "AMQ_CODEX_APP_EXECUTE_JS_TASK_0") {
-		t.Fatal("Codex app task-0 script does not use the fixed probe result")
+}
+
+func TestClaudeDesktopProbeFailsClosedOnIdentityMismatch(t *testing.T) {
+	skipNonDarwin(t)
+	mismatch := &fakeCommandRunner{output: []byte("com.some.other.app\n")}
+	err := (ClaudeDesktop{Runner: mismatch}).Probe(context.Background(), claudeDesktopTarget)
+	if err == nil {
+		t.Fatal("Probe() with mismatched bundle id succeeded; want fail-closed")
+	}
+	if !strings.Contains(fmt.Sprint(err), claudeDesktopBundleID) {
+		t.Fatalf("Probe() error = %v, want it to name the expected bundle id", err)
+	}
+	// A command failure (e.g. app not installed) must also fail closed.
+	failing := &fakeCommandRunner{output: []byte("no such app"), err: errors.New("exit status 1")}
+	if err := (ClaudeDesktop{Runner: failing}).Probe(context.Background(), claudeDesktopTarget); err == nil {
+		t.Fatal("Probe() with command failure succeeded; want fail-closed")
+	}
+}
+
+func TestClaudeDesktopDiscoverReturnsSeatAfterIdentityProbe(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte(claudeDesktopBundleID + "\n")}
+	target, err := (ClaudeDesktop{Runner: runner}).Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if target != claudeDesktopTarget {
+		t.Fatalf("Discover() target = %q, want %q", target, claudeDesktopTarget)
+	}
+	if len(runner.calls) != 1 || runner.calls[0].name != "swift" {
+		t.Fatalf("calls = %#v, want one swift scheme-handler probe", runner.calls)
+	}
+}
+
+func TestCodexAppInjectPrefillsOnlyWithEscapedURL(t *testing.T) {
+	skipNonDarwin(t)
+	// The first runner call is the Inject-time identity Probe (swift scheme
+	// handler); it must return the pinned bundle id. The second call is the
+	// prefill open. Tested for both targets.
+	for _, tc := range []struct {
+		name    string
+		target  string
+		wantURL string
+	}{
+		{name: "new", target: codexAppTargetNew, wantURL: "codex://threads/new?prompt=hello+world+%26+q%3Dx"},
+		{name: "thread", target: codexAppTargetThreadPrefix + "01a01f5f-69d6-7dd0-868f-9376f3d2c0a1", wantURL: "codex://threads/01a01f5f-69d6-7dd0-868f-9376f3d2c0a1?prompt=hello+world+%26+q%3Dx"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeCommandRunner{results: []fakeCommandResult{
+				{output: []byte(codexAppBundleID + "\n")},
+				{},
+			}}
+			payload := "hello world & q=x"
+			if err := (CodexApp{Runner: runner}).Inject(context.Background(), tc.target, payload); err != nil {
+				t.Fatalf("Inject() error = %v", err)
+			}
+			if len(runner.calls) != 2 {
+				t.Fatalf("calls = %d, want probe + open (no submit)", len(runner.calls))
+			}
+			if runner.calls[0].name != "swift" {
+				t.Fatalf("first call = %q, want swift scheme-handler probe", runner.calls[0].name)
+			}
+			openCall := runner.calls[1]
+			if openCall.name != "open" {
+				t.Fatalf("second call = %q, want open", openCall.name)
+			}
+			if len(openCall.args) != 1 || openCall.args[0] != tc.wantURL {
+				t.Fatalf("open args = %#v, want single URL %q", openCall.args, tc.wantURL)
+			}
+			if strings.Contains(openCall.args[0], payload) {
+				t.Fatalf("raw payload leaked unescaped into URL: %q", openCall.args[0])
+			}
+			// No forbidden generic-automation APIs anywhere in the command line.
+			for _, forbidden := range []string{"System Events", "keystroke", "the clipboard", "AXRaise", "activate"} {
+				if strings.Contains(openCall.name, forbidden) || strings.Contains(strings.Join(openCall.args, " "), forbidden) {
+					t.Fatalf("command line uses forbidden %q: %#v", forbidden, openCall)
+				}
+			}
+		})
+	}
+}
+
+func TestCodexAppInjectFailsClosedOnIdentityMismatchWithoutOpen(t *testing.T) {
+	skipNonDarwin(t)
+	// The Inject write is scheme-bound, so Inject must revalidate identity and
+	// fail closed before emitting the open. A mismatched bundle id on the
+	// Inject-time Probe must produce zero open calls.
+	mismatch := &fakeCommandRunner{output: []byte("com.some.other.app\n")}
+	injectErr := (CodexApp{Runner: mismatch}).Inject(context.Background(), codexAppTargetNew, "payload")
+	if injectErr == nil {
+		t.Fatal("Inject() with mismatched bundle id succeeded; want fail-closed")
+	}
+	for _, c := range mismatch.calls {
+		if c.name == "open" {
+			t.Fatalf("Inject emitted an open call after identity mismatch; the write must be gated: %#v", c)
+		}
+	}
+	if !strings.Contains(fmt.Sprint(injectErr), codexAppBundleID) {
+		t.Fatalf("Inject() error = %v, want it to surface the identity mismatch", injectErr)
+	}
+}
+
+func TestCodexAppProbeFailsClosedOnIdentityMismatch(t *testing.T) {
+	skipNonDarwin(t)
+	mismatch := &fakeCommandRunner{output: []byte("com.some.other.app\n")}
+	if err := (CodexApp{Runner: mismatch}).Probe(context.Background(), codexAppTargetNew); err == nil {
+		t.Fatal("Probe() with mismatched bundle id succeeded; want fail-closed")
+	}
+	failing := &fakeCommandRunner{output: []byte("no such app"), err: errors.New("exit status 1")}
+	if err := (CodexApp{Runner: failing}).Probe(context.Background(), codexAppTargetNew); err == nil {
+		t.Fatal("Probe() with command failure succeeded; want fail-closed")
+	}
+}
+
+func TestCodexAppDiscoverReturnsNewSeatAfterIdentityProbe(t *testing.T) {
+	skipNonDarwin(t)
+	runner := &fakeCommandRunner{output: []byte(codexAppBundleID + "\n")}
+	target, err := (CodexApp{Runner: runner}).Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if target != codexAppTargetNew {
+		t.Fatalf("Discover() target = %q, want %q", target, codexAppTargetNew)
+	}
+	if len(runner.calls) != 1 || runner.calls[0].name != "swift" {
+		t.Fatalf("calls = %#v, want one swift scheme-handler probe", runner.calls)
 	}
 }

--- a/internal/keepalive/adapter/schemeprobe.go
+++ b/internal/keepalive/adapter/schemeprobe.go
@@ -1,0 +1,55 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// validSchemeRe pins the shape of a URL scheme accepted by
+// schemeOwnerProbeScript. Both call sites pass fixed literals ("claude",
+// "codex"), but the scheme is concatenated into Swift source, so an unanchored
+// or caller-supplied value could inject. This makes the invalid state
+// unrepresentable: a scheme that is not ^[a-z][a-z0-9+.-]*$ panics at the call
+// site rather than reaching the script builder.
+var validSchemeRe = regexp.MustCompile(`^[a-z][a-z0-9+.-]*$`)
+
+// schemeOwnerProbeScript returns a fixed Swift one-liner (no payload) that
+// resolves the actual default handler of the given URL scheme and prints its
+// bundle id, or an empty string if no handler is registered. It pins the
+// scheme owner — the app that `open <scheme>://...` dispatches to — not an
+// app looked up by name, so a stale or conflicting scheme registration fails
+// closed instead of blessing the wrong app.
+//
+// Swift (not JXA) is used because LSCopyDefaultApplicationURLForURL returns
+// NULL for an unregistered scheme and Swift's Optional handling is
+// crash-proof there, where JXA crashes (a native memory fault that JXA
+// try/catch cannot intercept). The scheme is a fixed literal per adapter, never
+// caller-supplied, so it cannot inject into the script source.
+func schemeOwnerProbeScript(scheme string) string {
+	if !validSchemeRe.MatchString(scheme) {
+		panic(fmt.Sprintf("probeSchemeOwner: invalid scheme %q (must match ^[a-z][a-z0-9+.-]*$)", scheme))
+	}
+	return `import CoreServices; import Foundation; let u=URL(string:"` + scheme + `://x") as CFURL?; if let r=LSCopyDefaultApplicationURLForURL(u!,.all,nil){print(Bundle(url:r.takeRetainedValue() as URL)?.bundleIdentifier ?? "")}else{print("")}`
+}
+
+// probeSchemeOwner resolves the default handler bundle id for scheme through
+// runner and asserts it equals wantBundleID. Used by deep-link adapters
+// (claude-desktop, codex-app) to pin the scheme owner before the `open` write.
+// A mismatch, a missing handler, a non-darwin platform, or any command failure
+// fails closed.
+func probeSchemeOwner(ctx context.Context, runner CommandRunner, scheme, wantBundleID string) error {
+	if err := requireDarwin(); err != nil {
+		return err
+	}
+	out, err := runner.Run(ctx, "swift", "-e", schemeOwnerProbeScript(scheme))
+	if err != nil {
+		return fmt.Errorf("probe %s:// scheme handler: %w: %s", scheme, err, strings.TrimSpace(string(out)))
+	}
+	got := strings.TrimSpace(string(out))
+	if got != wantBundleID {
+		return fmt.Errorf("%s:// scheme handler is %q, want %q", scheme, got, wantBundleID)
+	}
+	return nil
+}

--- a/internal/keepalive/app/app.go
+++ b/internal/keepalive/app/app.go
@@ -136,11 +136,92 @@ type registerOptions struct {
 	NoStart        bool
 	Replace        bool
 	RetireDetached bool
+	MinCapability  adapter.Capability
 }
 
 type registerResult struct {
 	Entry          registry.Entry   `json:"entry"`
 	RemovedEntries []registry.Entry `json:"removed_entries,omitempty"`
+}
+
+// parseMinCapability translates the --min-delivery / --min-session /
+// --accept-requires-human flags into a Capability minimum. A zero value (the
+// default) preserves today's behavior: only the strongest unattended seats
+// satisfy it, so a human-required prefill seat like claude-desktop is refused
+// unless the caller explicitly opts into it.
+func parseMinCapability(delivery, session string, acceptRequiresHuman bool) (adapter.Capability, error) {
+	d, err := parseDeliveryFlag(delivery)
+	if err != nil {
+		return adapter.Capability{}, err
+	}
+	s, err := parseSessionFlag(session)
+	if err != nil {
+		return adapter.Capability{}, err
+	}
+	return adapter.Capability{
+		Delivery:      d,
+		Session:       s,
+		RequiresHuman: acceptRequiresHuman,
+	}, nil
+}
+
+func parseDeliveryFlag(s string) (adapter.Delivery, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "none":
+		return adapter.DeliveryNone, nil
+	case "prefilled":
+		return adapter.DeliveryPrefilled, nil
+	case "submitted":
+		return adapter.DeliverySubmitted, nil
+	default:
+		return 0, fmt.Errorf("invalid --min-delivery %q: want none|prefilled|submitted", s)
+	}
+}
+
+func parseSessionFlag(s string) (adapter.SessionScope, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "none":
+		return adapter.SessionNone, nil
+	case "new":
+		return adapter.SessionNew, nil
+	case "existing-exact":
+		return adapter.SessionExistingExact, nil
+	default:
+		return 0, fmt.Errorf("invalid --min-session %q: want none|new|existing-exact", s)
+	}
+}
+
+func minCapabilityLabel(d adapter.Delivery) string {
+	switch d {
+	case adapter.DeliveryPrefilled:
+		return "prefilled"
+	case adapter.DeliverySubmitted:
+		return "submitted"
+	default:
+		return "none"
+	}
+}
+
+func sessionLabel(s adapter.SessionScope) string {
+	switch s {
+	case adapter.SessionNew:
+		return "new"
+	case adapter.SessionExistingExact:
+		return "existing-exact"
+	default:
+		return "none"
+	}
+}
+
+func activationLabel(a adapter.Activation) string {
+	switch a {
+	case adapter.ActivationLaunch:
+		return "launch"
+	case adapter.ActivationForeground:
+		return "foreground"
+	default:
+		return "none"
+	}
 }
 
 func (a App) attach(ctx context.Context, args []string) error {
@@ -170,7 +251,14 @@ func (a App) register(ctx context.Context, args []string, replace bool) error {
 	wakeTimeout := fs.Duration("wake-ready-timeout", 10*time.Second, "maximum time to wait for amq wake readiness")
 	noStart := fs.Bool("no-start", false, "register without starting/reconciling wake")
 	retireDetached := fs.Bool("retire-detached", false, "on a recreated terminal, retire the proven-absent previous wake via amq wake retire before converging on the exact new target")
+	minDelivery := fs.String("min-delivery", "none", "minimum delivery capability required from the adapter: none|prefilled|submitted")
+	minSession := fs.String("min-session", "none", "minimum session capability required from the adapter: none|new|existing-exact")
+	acceptRequiresHuman := fs.Bool("accept-requires-human", false, "accept an adapter that requires a human to send the prompt (prefill-only seats)")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	minCapability, err := parseMinCapability(*minDelivery, *minSession, *acceptRequiresHuman)
+	if err != nil {
 		return err
 	}
 	return a.registerWithOptions(ctx, registerOptions{
@@ -187,6 +275,7 @@ func (a App) register(ctx context.Context, args []string, replace bool) error {
 		NoStart:        *noStart,
 		Replace:        replace,
 		RetireDetached: *retireDetached,
+		MinCapability:  minCapability,
 	})
 }
 
@@ -239,6 +328,28 @@ func (a App) registerWithOptions(ctx context.Context, opts registerOptions) erro
 			return err
 		}
 		opts.Target = normalized
+	}
+	// Capability gate runs AFTER target normalization so a target-aware adapter
+	// can declare a per-target vector (e.g. new vs existing-exact). A target
+	// normalization error has already failed above. Prefer
+	// CapabilityForTarget(target) when implemented; else Capability(); else
+	// UnknownCapability() (weakest + requires a human). An adapter that forgets
+	// to declare any Capability is refused unless the caller explicitly
+	// tolerates a human-required seat — fail-closed, not fail-open.
+	var declared adapter.Capability
+	if td, ok := selected.(adapter.TargetCapabilityDeclarer); ok {
+		c, err := td.CapabilityForTarget(opts.Target)
+		if err != nil {
+			return fmt.Errorf("adapter %s target %q: %w", opts.AdapterName, opts.Target, err)
+		}
+		declared = c
+	} else if d, ok := selected.(adapter.CapabilityDeclarer); ok {
+		declared = d.Capability()
+	} else {
+		declared = adapter.UnknownCapability()
+	}
+	if !declared.Satisfies(opts.MinCapability) {
+		return fmt.Errorf("adapter %s does not satisfy the requested capability (declared: activation=%s delivery=%s session=%s requires_human=%t; min: activation=%s delivery=%s session=%s requires_human=%t); refusing without substitution", opts.AdapterName, activationLabel(declared.Activation), minCapabilityLabel(declared.Delivery), sessionLabel(declared.Session), declared.RequiresHuman, activationLabel(opts.MinCapability.Activation), minCapabilityLabel(opts.MinCapability.Delivery), sessionLabel(opts.MinCapability.Session), opts.MinCapability.RequiresHuman)
 	}
 	ownershipContext := registrationOwnershipContext(ctx, selected, opts.Target)
 	store := registry.New(opts.RegistryPath)

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -747,6 +747,240 @@ exit 12
 	}
 }
 
+func TestRegisterCapabilityGateRefusesClaudeDesktopUnderWeakMinimum(t *testing.T) {
+	// The capability gate must refuse a requires-human prefill seat under the
+	// default zero-value minimum (today's implicit unattended minimum) and
+	// under a submitted/unattended minimum. No substitution, no fallback.
+	base := registerOptions{
+		AdapterName:  "claude-desktop",
+		Target:       "claude-desktop:new",
+		Root:         "/tmp/amq-root",
+		BaseRoot:     "/tmp",
+		SessionName:  "amq-root",
+		Me:           "codex",
+		NoStart:      true,
+		RegistryPath: testRegistryTempPath(t),
+	}
+	for _, tc := range []struct {
+		name string
+		min  adapter.Capability
+	}{
+		{name: "zero-value default minimum", min: adapter.Capability{}},
+		{name: "submitted unattended minimum", min: adapter.Capability{Delivery: adapter.DeliverySubmitted, RequiresHuman: false}},
+		{name: "existing-exact minimum", min: adapter.Capability{Session: adapter.SessionExistingExact}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			callCount := 0
+			trackingRunner := appCommandRunnerFunc(func(_ context.Context, name string, _ ...string) ([]byte, error) {
+				callCount++
+				return []byte("com.anthropic.claudefordesktop\n"), nil
+			})
+			trackingAdapters := adapter.NewRegistry(adapter.ClaudeDesktop{Runner: trackingRunner})
+			registryPath := testRegistryTempPath(t)
+			opts := base
+			opts.RegistryPath = registryPath
+			opts.MinCapability = tc.min
+			app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, Adapters: &trackingAdapters}
+			err := app.registerWithOptions(context.Background(), opts)
+			if err == nil {
+				t.Fatalf("registerWithOptions succeeded under %s; want capability refusal", tc.name)
+			}
+			if !strings.Contains(err.Error(), "does not satisfy") {
+				t.Fatalf("error = %v, want a capability refusal naming the shortfall", err)
+			}
+			// FIX-5: a refusal must happen before discovery/injection, so the
+			// runner is never invoked and the registry file is left untouched.
+			if callCount != 0 {
+				t.Fatalf("runner called %d time(s) on refusal; want 0 (gate fires before any command)", callCount)
+			}
+			if info, statErr := os.Stat(registryPath); !os.IsNotExist(statErr) {
+				t.Fatalf("registry file exists after refusal (stat=%v %v); want it never written", info, statErr)
+			}
+		})
+	}
+}
+
+func TestRegisterCapabilityGateAcceptsClaudeDesktopUnderExplicitHumanHandoff(t *testing.T) {
+	// Only an explicit human-handoff caller (min accepts requires-human and
+	// only needs prefill+new) is accepted. Inject must then launch the deep-link
+	// prefill-only (the fake runner records the open call; no submit step).
+	var openArgs []string
+	runner := appCommandRunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "open" {
+			openArgs = append([]string{}, args...)
+		}
+		return []byte("com.anthropic.claudefordesktop\n"), nil
+	})
+	adapters := adapter.NewRegistry(adapter.ClaudeDesktop{Runner: runner})
+	opts := registerOptions{
+		AdapterName:  "claude-desktop",
+		Target:       "claude-desktop:new",
+		Root:         "/tmp/amq-root",
+		BaseRoot:     "/tmp",
+		SessionName:  "amq-root",
+		Me:           "codex",
+		NoStart:      true,
+		RegistryPath: testRegistryTempPath(t),
+		MinCapability: adapter.Capability{
+			Delivery:      adapter.DeliveryPrefilled,
+			Session:       adapter.SessionNew,
+			RequiresHuman: true,
+		},
+	}
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, Adapters: &adapters}
+	if err := app.registerWithOptions(context.Background(), opts); err != nil {
+		t.Fatalf("registerWithOptions under explicit human handoff failed: %v", err)
+	}
+	// FIX-5: registration with NoStart does not itself inject, so no open call
+	// is expected here — the exact-escaped-URL assertion lives at the adapter
+	// layer in TestClaudeDesktopInjectPrefillsOnlyWithEscapedURL (it asserts
+	// `claude://code/new?q=hello+world+%26+q%3Dx`). Here we just confirm the
+	// gate accepted and the runner was not asked to inject during registration.
+	if len(openArgs) != 0 {
+		t.Fatalf("registration invoked open with %#v; NoStart must not inject", openArgs)
+	}
+}
+
+// undeclaredAdapter implements adapter.Adapter but NOT CapabilityDeclarer, so
+// it is treated as UnknownCapability() (weakest on every ordered axis and
+// requires a human). This is the FIX-A regression: such an adapter must NOT
+// bypass the gate — it is refused under the default zero-value minimum (which
+// is unattended) and under a submitted minimum, and accepted only when the
+// caller explicitly tolerates a human-required seat.
+type undeclaredAdapter struct{}
+
+func (undeclaredAdapter) Name() string                                 { return "undeclared" }
+func (undeclaredAdapter) Probe(context.Context, string) error          { return nil }
+func (undeclaredAdapter) Inject(context.Context, string, string) error { return nil }
+
+func TestRegisterCapabilityGateTreatsUndeclaredAdapterAsUnknown(t *testing.T) {
+	// An undeclared adapter is treated as UnknownCapability(): weakest on
+	// every ordered axis and requires a human. It is REFUSED under the default
+	// zero-value minimum (which is unattended) AND under a submitted minimum,
+	// and ACCEPTED only when the caller explicitly tolerates a human-required
+	// seat. This is the FIX-A regression: an unknown adapter must never
+	// masquerade as unattended full-strength.
+	adapters := adapter.NewRegistry(undeclaredAdapter{})
+	base := registerOptions{
+		AdapterName:  "undeclared",
+		Target:       "claude-desktop:new",
+		Root:         "/tmp/amq-root",
+		BaseRoot:     "/tmp",
+		SessionName:  "amq-root",
+		Me:           "codex",
+		NoStart:      true,
+		RegistryPath: testRegistryTempPath(t),
+	}
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, Adapters: &adapters}
+	for _, tc := range []struct {
+		name string
+		min  adapter.Capability
+	}{
+		{name: "zero-value default minimum", min: adapter.Capability{}},
+		{name: "submitted unattended minimum", min: adapter.Capability{Delivery: adapter.DeliverySubmitted, RequiresHuman: false}},
+	} {
+		t.Run(tc.name+" refuses", func(t *testing.T) {
+			opts := base
+			opts.RegistryPath = testRegistryTempPath(t)
+			opts.MinCapability = tc.min
+			if err := app.registerWithOptions(context.Background(), opts); err == nil {
+				t.Fatalf("undeclared adapter accepted under %s; want refusal", tc.name)
+			} else if !strings.Contains(err.Error(), "does not satisfy") {
+				t.Fatalf("error = %v, want a capability refusal", err)
+			}
+		})
+	}
+	// Accepted only when the caller explicitly tolerates a human-required seat.
+	acceptOpts := base
+	acceptOpts.RegistryPath = testRegistryTempPath(t)
+	acceptOpts.MinCapability = adapter.Capability{RequiresHuman: true}
+	if err := app.registerWithOptions(context.Background(), acceptOpts); err != nil {
+		t.Fatalf("undeclared adapter under explicit requires-human min failed: %v", err)
+	}
+}
+
+func TestRegisterCapabilityGateRefusalShowsActivationShortfall(t *testing.T) {
+	// FIX-B: the refusal error must include activation for both declared and
+	// min, so an activation-only shortfall is distinguishable. claude-desktop
+	// (ActivationLaunch) vs a foreground minimum must be refused and the
+	// message must show activation=launch vs activation=foreground.
+	runner := appCommandRunnerFunc(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("com.anthropic.claudefordesktop\n"), nil
+	})
+	adapters := adapter.NewRegistry(adapter.ClaudeDesktop{Runner: runner})
+	opts := registerOptions{
+		AdapterName:  "claude-desktop",
+		Target:       "claude-desktop:new",
+		Root:         "/tmp/amq-root",
+		BaseRoot:     "/tmp",
+		SessionName:  "amq-root",
+		Me:           "codex",
+		NoStart:      true,
+		RegistryPath: testRegistryTempPath(t),
+		MinCapability: adapter.Capability{
+			Activation:    adapter.ActivationForeground,
+			Delivery:      adapter.DeliveryPrefilled,
+			Session:       adapter.SessionNew,
+			RequiresHuman: true,
+		},
+	}
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, Adapters: &adapters}
+	err := app.registerWithOptions(context.Background(), opts)
+	if err == nil {
+		t.Fatal("registerWithOptions succeeded under foreground min for a launch seat; want refusal")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "does not satisfy") {
+		t.Fatalf("error = %v, want a capability refusal", err)
+	}
+	if !strings.Contains(msg, "activation=launch") {
+		t.Fatalf("error %q does not show the declared activation=launch", msg)
+	}
+	if !strings.Contains(msg, "activation=foreground") {
+		t.Fatalf("error %q does not show the min activation=foreground", msg)
+	}
+}
+
+func TestRegisterCapabilityGatePrefersTargetCapabilityForCodexApp(t *testing.T) {
+	// The codex-app adapter implements TargetCapabilityDeclarer: its two
+	// targets differ on session scope (new vs existing-exact). The gate must
+	// prefer CapabilityForTarget(target) so a caller requesting existing-exact
+	// is refused the new-only target rather than silently downgraded, and
+	// accepted for the thread target under the same min.
+	runner := appCommandRunnerFunc(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("com.openai.codex\n"), nil
+	})
+	adapters := adapter.NewRegistry(adapter.CodexApp{Runner: runner})
+	base := registerOptions{
+		Root: "/tmp/amq-root", BaseRoot: "/tmp", SessionName: "amq-root", Me: "codex",
+		AMQPath: "/bin/false", NoStart: true,
+		MinCapability: adapter.Capability{
+			Delivery:      adapter.DeliveryPrefilled,
+			Session:       adapter.SessionExistingExact,
+			RequiresHuman: true,
+		},
+	}
+	// codex-app:thread:<uuid> satisfies an existing-exact+prefill+RH-tolerant min.
+	acceptOpts := base
+	acceptOpts.RegistryPath = testRegistryTempPath(t)
+	acceptOpts.AdapterName = "codex-app"
+	acceptOpts.Target = "codex-app:thread:01a01f5f-69d6-7dd0-868f-9376f3d2c0a1"
+	app := App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, Adapters: &adapters}
+	if err := app.registerWithOptions(context.Background(), acceptOpts); err != nil {
+		t.Fatalf("codex-app:thread under existing-exact min failed: %v", err)
+	}
+	// codex-app:new does NOT satisfy an existing-exact min (no new→existing downgrade).
+	refuseOpts := base
+	refuseOpts.RegistryPath = testRegistryTempPath(t)
+	refuseOpts.AdapterName = "codex-app"
+	refuseOpts.Target = "codex-app:new"
+	if err := app.registerWithOptions(context.Background(), refuseOpts); err == nil {
+		t.Fatal("codex-app:new under existing-exact min succeeded; want refusal (no downgrade)")
+	} else if !strings.Contains(err.Error(), "does not satisfy") {
+		t.Fatalf("error = %v, want a capability refusal", err)
+	}
+}
+
 func TestReattachPreservesRegistryWhenWakeTargetCannotChange(t *testing.T) {
 	dir := t.TempDir()
 	registryPath := testRegistryPath(t, dir)
@@ -2348,6 +2582,17 @@ type boundaryAdapter struct {
 
 func (a boundaryAdapter) Name() string { return a.name }
 
+// boundaryAdapter is a stand-in for a real adapter in behavioral tests, so it
+// declares the full-strength unattended vector real TTY/file seats declare.
+func (boundaryAdapter) Capability() adapter.Capability {
+	return adapter.Capability{
+		Activation:    adapter.ActivationNone,
+		Delivery:      adapter.DeliverySubmitted,
+		Session:       adapter.SessionExistingExact,
+		RequiresHuman: false,
+	}
+}
+
 func (a boundaryAdapter) Probe(context.Context, string) error { return a.probeErr }
 
 func (a boundaryAdapter) Inject(context.Context, string, string) error { return nil }
@@ -2359,6 +2604,17 @@ type presenceAdapter struct {
 }
 
 func (a *presenceAdapter) Name() string { return a.name }
+
+// presenceAdapter is a stand-in for a real adapter in presence/inventory
+// tests, so it declares the full-strength unattended vector real seats declare.
+func (*presenceAdapter) Capability() adapter.Capability {
+	return adapter.Capability{
+		Activation:    adapter.ActivationNone,
+		Delivery:      adapter.DeliverySubmitted,
+		Session:       adapter.SessionExistingExact,
+		RequiresHuman: false,
+	}
+}
 
 func (a *presenceAdapter) Probe(ctx context.Context, target string) error {
 	if err := ctx.Err(); err != nil {

--- a/internal/keepalive/app/app_test.go
+++ b/internal/keepalive/app/app_test.go
@@ -801,6 +801,9 @@ func TestRegisterCapabilityGateRefusesClaudeDesktopUnderWeakMinimum(t *testing.T
 }
 
 func TestRegisterCapabilityGateAcceptsClaudeDesktopUnderExplicitHumanHandoff(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("claude-desktop adapter requires macOS")
+	}
 	// Only an explicit human-handoff caller (min accepts requires-human and
 	// only needs prefill+new) is accepted. Inject must then launch the deep-link
 	// prefill-only (the fake runner records the open call; no submit step).
@@ -942,6 +945,9 @@ func TestRegisterCapabilityGateRefusalShowsActivationShortfall(t *testing.T) {
 }
 
 func TestRegisterCapabilityGatePrefersTargetCapabilityForCodexApp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("codex-app adapter requires macOS")
+	}
 	// The codex-app adapter implements TargetCapabilityDeclarer: its two
 	// targets differ on session scope (new vs existing-exact). The gate must
 	// prefer CapabilityForTarget(target) so a caller requesting existing-exact


### PR DESCRIPTION
## Summary

Ship two honest GUI deep-link wake seats — Claude Desktop and the Codex app (rebranded ChatGPT.app) — behind a capability-vector gate, and add the minimum-capability gate that makes registering them honest. Implements both halves of #640.

- **New `Capability` type** (`internal/keepalive/adapter/capability.go`) modeling the ADR vector: `Activation` (none<launch<foreground), `Delivery` (none<prefilled<submitted), `Session` (none<new<existing-exact), `RequiresHuman`. `Satisfies()` enforces the refusal partial order — weaker is refused, never substituted (no submit→prefill, existing-exact→new, or unattended→requires-human downgrade). `UnknownCapability()` returns the worst-case (weakest on every ordered axis, requires-human) so a non-declarer can never masquerade as an unattended full-strength seat.
- **`CapabilityDeclarer` + `TargetCapabilityDeclarer` interfaces** in `adapter.go`: a target-aware adapter declares a per-target vector via `CapabilityForTarget(target)` (e.g. new vs existing-exact). File/Ghostty/Cmux declare their real full-strength vector (foreground+submitted+existing-exact+unattended).
- **Shared Swift scheme-owner probe** (`internal/keepalive/adapter/schemeprobe.go`, new): `probeSchemeOwner(ctx, runner, scheme, wantBundleID)` resolves the actual default handler of a URL scheme and asserts it equals the pinned bundle id — pinning the scheme owner (what `open <scheme>://...` dispatches to), not an app looked up by name, so a stale/conflicting scheme registration fails closed. Swift (not JXA) because `LSCopyDefaultApplicationURLForURL` returns NULL for an unregistered scheme and Swift's Optional handling is crash-proof there, where JXA segfaults. `schemeOwnerProbeScript(scheme)` validates scheme against anchored `^[a-z][a-z0-9+.-]*$` and panics on mismatch before concatenating into the Swift source — unrepresentable-invalid-state insurance (both call sites pass fixed literals today).
- **`claude-desktop` adapter** (`claudedesktop.go`): the honest `prefilled + new + requires_human` deep-link seat. `Inject` builds a `net/url`-query-escaped `claude://code/new?q=<prompt>` and passes it as a single `open` argument — no shell, no osascript, no `System Events`/`keystroke`/`clipboard`/`activate`, and **no submit step** (this seat never sends Enter). Identity is revalidated before the write: `Probe` pins the `claude://` scheme owner (bundle `com.anthropic.claudefordesktop`) via the shared Swift probe, and `Inject` calls `Probe` before `open` so the scheme-bound write is identity-gated and fails closed on mismatch.
- **`codex-app` adapter** (`codexapp.go`, repurposed): two targets declared via `TargetCapabilityDeclarer` — `codex-app:new` (`codex://threads/new?prompt=<escaped>` → SessionNew) and `codex-app:thread:<uuid>` (`codex://threads/<uuid>?prompt=<escaped>` → SessionExistingExact). Strict anchored-regex uuid validation rejects uppercase, wrong-length, path traversal (`../`), and extra segments. Same prefill-only, no-submit, identity-gated write pattern as claude-desktop. The native `execute javascript` Apple Events path is DEAD and stays dead (issue #640: `-1723`, `AllowJavaScriptAppleEvents` pref compiled out); the dead path is recorded in the doc comment, the task-0 probe script in `scripts/` remains as historical evidence and is intentionally not invoked.
- **Capability gate at registration** (`internal/keepalive/app/app.go`): `registerOptions.MinCapability` plus three flags — `--min-delivery` (none|prefilled|submitted), `--min-session` (none|new|existing-exact), `--accept-requires-human`. The gate runs **after target resolution** (discovery when no explicit target was given, then normalization) and before any write, so a target-aware adapter's per-target vector is checked. Branch order: `CapabilityForTarget(target)` → `Capability()` → `UnknownCapability()` — fail-closed for non-declarers. A refusal mutates no registry state and performs no injection.
- **Both adapters registered in `DefaultRegistry()`** behind the gate: with the default zero-value minimum both are refused automatically (requires-human seats vs unattended min), and a submitted/unattended caller is refused too. A caller gets a seat only by explicitly accepting a requires-human seat with delivery/session minima at or below what the target declares.

### What these seats are (honesty)

Both adapters **prefill a session** via deep link and **require a human to press send**. They are honest GUI best-effort, **not** full wakes into existing agent sessions. Neither claims `submitted`; there is no existing-session inject for Claude Desktop. The capability vector makes that contract machine-checkable: a caller that needs unattended `submitted` delivery is refused rather than silently downgraded to a prefill.

### Dispatch-vs-delivery caveat (live finding, codex-app)

`open` exiting 0 proves **DISPATCH only, not delivery** — the app can refuse a deep-link with no adapter-visible signal. Verified on app 26.818.61809: a thread with an **ACTIVE WRITER** shows an "Error creating chat — thread already has an active writer" toast and leaves the composer empty, yet `open` still exits 0 and `Inject` reports success. Therefore `codex-app:thread:<uuid>` must name an **IDLE** conversation, and callers must treat `Inject` success as "launched, not confirmed delivered." The adapter cannot observe the in-app refusal because the Codex app is AX-opaque (Chromium content is not exposed to System Events). Recorded in `codexapp.go`'s doc comment and the ADR.

### Live smoke evidence (both idle prefills visually confirmed by lead)

- **Claude Desktop**: `claude://code/new?q=` prefills the Code-tab composer, no auto-submit. Verified via AX accessibility tree. Real adapter `Inject` with `ExecRunner`: Probe PASS, Inject PASS, no auto-submit.
- **Codex app**: `codex://threads/new?prompt=` and `codex://threads/<uuid>?prompt=` both prefill-only (no auto-submit, smoke strings not persisted). Corrected `codex-app:thread:<idle-uuid>` smoke against the idle 2026-08-20T16:32 rollout: existing-exact conversation opened with the smoke string prefilled in its composer, unsent. (An earlier smoke against the newest/active-writer rollout was refused — see the caveat above.)
- **Codex app execute-javascript gate**: DEAD (`-1723`, pref compiled out). Evidence: https://github.com/avivsinai/agent-message-queue/issues/640#issuecomment-5406484999

### Out of scope (unchanged from #640)
- No Windows paths, no cowork-vs-code selection logic (defaults to `claude://code/new`), no Team-ID codesign pin (bundle-id pin + Inject-time revalidation is the v1 gate).
- Core TTY wake (`internal/cli/wake.go`, `wake_target.go`) is untouched.
- No new config or CLI surface beyond the three `--min-*` flags.

## Verification

- `go test ./internal/keepalive/...` (all 7 packages green)
- `go test ./internal/keepalive/adapter -run 'Capability|ClaudeDesktop|CodexApp|DefaultRegistry' -count=1` (Satisfies table, prefill escaping, fail-closed Probe, fail-closed Inject-without-open, uuid negatives, the target-aware seam)
- `go test ./internal/keepalive/app -run 'CapabilityGate|PrefersTargetCapability' -count=1` (gate refusal/acceptance incl. the codex-app new-vs-existing-exact downgrade refusal)
- `gofmt -l` clean on every changed file
- `go vet ./internal/keepalive/...` clean
- `go build ./...` clean

Pre-existing gofmt issue in `internal/cli/wake_owner_observation_darwin.go` is unrelated and untouched.

## Review provenance

- **ChatGPT-Pro**: GO on wave 1 (claude-desktop) after 3 rounds — all findings resolved (undeclared-adapter fail-open → `UnknownCapability()`; scheme-owner pin via fixed Swift constant; activation honesty; ADR + test gaps).
- **Lead line-by-line review**: final gate on the combined wave-1+wave-2 head per operator ruling (a tier-ladder drift in the review tool was found and is being fixed in its own repo; the operator accepts the lead review as the final gate, no further Pro rounds). Four findings (F1 evidence-critical corrected smoke + active-writer caveat; F2 ADR gate-order text; F3 `validSchemeRe` guard; F4 test comment) — all resolved. Idle prefill screenshots visually confirmed by lead.
- **codex second review**: pending (offline).

## Named backlog

- Team-ID codesign pin (defense-in-depth for the bundle-id scheme-owner pin).
- codex-app active-writer detection: today `open` exit 0 ≠ delivered and the app can refuse a deep-link with no adapter-visible signal; a future mechanism to detect/avoid active-writer threads.

Refs #640.
