### PR TITLE
fix(coop): detect named inject TTY via /dev/tty

### DIFF
--- a/internal/cli/coop_exec_named_unix.go
+++ b/internal/cli/coop_exec_named_unix.go
@@ -16,8 +16,11 @@ import (
 const coopNamedTUIStartupDelay = 3 * time.Second
 
 var (
+	openCoopNamedTTY = func() (*os.File, error) {
+		return os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	}
 	coopNamedTTYReady = func() bool {
-		return tiocsti.Available() && tiocsti.IsTTY()
+		return tiocsti.Available() && coopNamedHasControllingTTY()
 	}
 	coopNamedTTYInject = func(me, binaryBase string) error {
 		return injectCoopNamedSlashCommand(me, binaryBase)
@@ -46,6 +49,8 @@ func startCoopNamedTUIInjectorProcess(me, cmdName string) error {
 		"--me", me,
 		"--binary", filepath.Base(cmdName),
 	)
+	// Leave stdin/stdout on the null device so the helper does not steal the
+	// agent's TTY fds. Injection opens the controlling terminal via /dev/tty.
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = os.Stderr
@@ -57,6 +62,15 @@ func startCoopNamedTUIInjectorProcess(me, cmdName string) error {
 		return fmt.Errorf("release coop named inject helper: %w", err)
 	}
 	return nil
+}
+
+func coopNamedHasControllingTTY() bool {
+	tty, err := openCoopNamedTTY()
+	if err != nil {
+		return false
+	}
+	_ = tty.Close()
+	return true
 }
 
 func runCoopNamedInject(args []string) error {

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -343,6 +343,41 @@ func TestInjectCoopNamedSlashCommand(t *testing.T) {
 	}
 }
 
+func TestCoopNamedHasControllingTTYUsesDevTTY(t *testing.T) {
+	oldOpen := openCoopNamedTTY
+	t.Cleanup(func() { openCoopNamedTTY = oldOpen })
+
+	opened := false
+	openCoopNamedTTY = func() (*os.File, error) {
+		opened = true
+		return os.Open(os.DevNull)
+	}
+	if !coopNamedHasControllingTTY() {
+		t.Fatal("expected controlling TTY probe to succeed when /dev/tty opens")
+	}
+	if !opened {
+		t.Fatal("did not open /dev/tty")
+	}
+
+	openCoopNamedTTY = func() (*os.File, error) {
+		return nil, os.ErrNotExist
+	}
+	if coopNamedHasControllingTTY() {
+		t.Fatal("expected false when /dev/tty cannot be opened")
+	}
+}
+
+func TestInjectCoopNamedSlashCommandRequiresControllingTTY(t *testing.T) {
+	oldReady := coopNamedTTYReady
+	t.Cleanup(func() { coopNamedTTYReady = oldReady })
+	coopNamedTTYReady = func() bool { return false }
+
+	err := injectCoopNamedSlashCommand("coder1", "agent")
+	if err == nil || !strings.Contains(err.Error(), "no controlling terminal") {
+		t.Fatalf("error = %v, want controlling terminal failure", err)
+	}
+}
+
 func TestApplyCoopNamedStartsTUIInjector(t *testing.T) {
 	var started bool
 	oldStart := startCoopNamedTUIInjector


### PR DESCRIPTION
## Summary
- `--named` TUI inject (`codex` / Cursor `agent`) always warned `no controlling terminal` because the helper starts with stdin on `/dev/null` and the ready check used `tiocsti.IsTTY()` (stdin).
- Probe `/dev/tty` instead, which is what TIOCSTI injection already opens. Stdin stays disconnected so the helper does not steal the agent's TTY.

## Test plan
- [ ] `go test ./internal/cli -run 'CoopNamed|InjectCoopNamed'`
- [ ] `amq coop exec --named --me cursor agent` no longer prints `no controlling terminal`
- [ ] Claude/Pi argv `--name` path unchanged


Made with [Cursor](https://cursor.com)