### PR TITLE
fix(keepalive): isolate hookinstall tests from HOME and self-heal stale hooks

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -164,6 +164,9 @@ func runDoctor(args []string) error {
 	result.Checks = append(result.Checks, checkSkill("codex"))
 	result.Checks = append(result.Checks, checkSkill("grok"))
 
+	// Hook config health: flag AMQ-owned SessionStart hooks whose script is gone.
+	result.Checks = append(result.Checks, checkHookConfigs())
+
 	// Ops checks (runtime health)
 	if *opsFlag && root != "" {
 		// Resolve root source once here; avoids re-resolving with empty flags in runOpsChecks.

--- a/internal/cli/doctor_hookinstall.go
+++ b/internal/cli/doctor_hookinstall.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -46,10 +47,10 @@ func checkHookConfigs() doctorCheck {
 		if err != nil {
 			// A missing config file is not an error: AMQ hooks may not be
 			// installed. Any other error (corrupt JSON, permission denied) is
-			// surfaced as a warning naming the path and the error so it is not
-			// silently swallowed.
+			// surfaced as a warning naming the path, the error, and a remedy so it
+			// is not silently swallowed.
 			if !os.IsNotExist(err) {
-				warnings = append(warnings, fmt.Sprintf("%s config %s: %v", c.agent, c.path, err))
+				warnings = append(warnings, fmt.Sprintf("%s config %s: %v; %s", c.agent, c.path, err, hookConfigErrorRemedy(c.path, c.agent, err)))
 			}
 			continue
 		}
@@ -118,4 +119,23 @@ func uniqueNonEmpty(values []string) []string {
 		out = append(out, v)
 	}
 	return out
+}
+
+// hookConfigErrorRemedy returns a concrete remedy for a hook config read error.
+// A JSON parse error points at restoring the newest backup or fixing the JSON;
+// a permission error points at chmod. Other errors get a generic re-install
+// remedy.
+func hookConfigErrorRemedy(path, agent string, err error) string {
+	msg := err.Error()
+	if errors.Is(err, os.ErrPermission) || strings.Contains(msg, "permission denied") {
+		return fmt.Sprintf("chmod u+rw %s", path)
+	}
+	// loadJSONObject wraps JSON decode failures with a "parse <path>:" prefix;
+	// the underlying json error mentions syntax/invalid/unexpected characters.
+	if strings.Contains(msg, "parse ") || strings.Contains(msg, "invalid") ||
+		strings.Contains(msg, "unexpected") || strings.Contains(msg, "JSON") ||
+		strings.Contains(msg, "syntax") {
+		return fmt.Sprintf("restore from the newest %s.bak-* backup or fix the JSON by hand, then rerun amq-keepalive install-hook --agent %s", path, agent)
+	}
+	return fmt.Sprintf("rerun amq-keepalive install-hook --agent %s", agent)
 }

--- a/internal/cli/doctor_hookinstall.go
+++ b/internal/cli/doctor_hookinstall.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/hookinstall"
+)
+
+// checkHookConfigs scans the default Claude and Codex hook config files for
+// AMQ-owned SessionStart hook commands whose installed script path no longer
+// exists (the WP-646 leak class: macOS reclaims /var/folders temp dirs and the
+// dead command then fails with exit 127 on every session start). It is
+// read-only; it never repairs. The remedy is the exact install command that
+// rewrites a live hook and prunes the stale ones via the installer's self-heal,
+// scoped to the agent(s) actually found stale.
+func checkHookConfigs() doctorCheck {
+	check := doctorCheck{Name: "Hook configs"}
+	claudeConfig, claudeErr := hookinstall.DefaultClaudeConfig()
+	codexConfig, codexErr := hookinstall.DefaultCodexConfig()
+
+	type staleAgent struct {
+		agent string
+		hooks []hookinstall.StaleSessionStartHook
+	}
+	var perAgent []staleAgent
+	var warnings []string
+
+	for _, c := range []struct {
+		path, agent string
+		pathErr     error
+	}{
+		{codexConfig, hookinstall.AgentCodex, codexErr},
+		{claudeConfig, hookinstall.AgentClaude, claudeErr},
+	} {
+		if c.pathErr != nil {
+			// Could not resolve the default config path at all.
+			warnings = append(warnings, fmt.Sprintf("%s config path: %v", c.agent, c.pathErr))
+			continue
+		}
+		if c.path == "" {
+			continue
+		}
+		found, err := hookinstall.StaleSessionStartHooks(c.path, c.agent)
+		if err != nil {
+			// A missing config file is not an error: AMQ hooks may not be
+			// installed. Any other error (corrupt JSON, permission denied) is
+			// surfaced as a warning naming the path and the error so it is not
+			// silently swallowed.
+			if !os.IsNotExist(err) {
+				warnings = append(warnings, fmt.Sprintf("%s config %s: %v", c.agent, c.path, err))
+			}
+			continue
+		}
+		if len(found) > 0 {
+			perAgent = append(perAgent, staleAgent{agent: c.agent, hooks: found})
+		}
+	}
+
+	totalStale := 0
+	for _, a := range perAgent {
+		totalStale += len(a.hooks)
+	}
+	if totalStale == 0 && len(warnings) == 0 {
+		check.Status = "ok"
+		check.Message = "no stale AMQ SessionStart hooks"
+		return check
+	}
+	if totalStale == 0 {
+		// Only warnings (e.g. a corrupt config file), no stale hooks.
+		check.Status = "warn"
+		check.Message = strings.Join(warnings, "; ")
+		return check
+	}
+
+	var paths []string
+	var agents []string
+	for _, a := range perAgent {
+		agents = append(agents, a.agent)
+		for _, h := range a.hooks {
+			paths = append(paths, h.ScriptPath)
+		}
+	}
+	// The remedy uses the real install-hook subcommand spelling, scoped to the
+	// agent(s) actually found stale. Verified via `amq-keepalive install-hook
+	// --help`: -agent accepts claude, codex, or both.
+	remedyAgent := strings.Join(agents, ",")
+	if len(agents) > 1 {
+		remedyAgent = hookinstall.AgentBoth
+	}
+	check.Status = "warn"
+	message := fmt.Sprintf(
+		"%d stale AMQ SessionStart hook(s) point at missing scripts (%s); remedy: amq-keepalive install-hook --agent %s",
+		totalStale,
+		strings.Join(uniqueNonEmpty(paths), ", "),
+		remedyAgent,
+	)
+	// Surface config warnings alongside stale findings rather than hiding the
+	// stale hooks when one agent's config is corrupt and another has dead hooks.
+	if len(warnings) > 0 {
+		message += "; " + strings.Join(warnings, "; ")
+	}
+	check.Message = message
+	return check
+}
+
+// uniqueNonEmpty returns the deduplicated, non-empty subset of values, preserving
+// first-seen order. Used to keep the doctor remedy message compact.
+func uniqueNonEmpty(values []string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, v := range values {
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}

--- a/internal/cli/doctor_hookinstall_test.go
+++ b/internal/cli/doctor_hookinstall_test.go
@@ -146,6 +146,13 @@ func TestCheckHookConfigsSurfacesCorruptJSON(t *testing.T) {
 	if !strings.Contains(got.Message, "codex") {
 		t.Fatalf("message does not name the agent: %q", got.Message)
 	}
+	// B2: a corrupt-JSON warning must name a concrete remedy.
+	if !strings.Contains(got.Message, ".bak-* backup") {
+		t.Fatalf("message does not name the restore-from-backup remedy: %q", got.Message)
+	}
+	if !strings.Contains(got.Message, "install-hook --agent codex") {
+		t.Fatalf("message does not name the re-install remedy: %q", got.Message)
+	}
 }
 
 // writeDoctorHookBinary writes a minimal executable at path and returns it.
@@ -213,5 +220,37 @@ func TestCheckHookConfigsReportsStaleAndCorruptTogether(t *testing.T) {
 	// The corrupt claude config warning must also be present.
 	if !strings.Contains(got.Message, claudeConfig) {
 		t.Fatalf("message missing corrupt claude config warning: %q", got.Message)
+	}
+}
+
+// TestCheckHookConfigsPermissionErrorRemedy is the B2 permission case: a config
+// file that exists but is unreadable (permission denied) is surfaced as a
+// warning with a chmod remedy, not silently skipped.
+func TestCheckHookConfigsPermissionErrorRemedy(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions; cannot reproduce EACCES")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeConfig := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(claudeConfig), 0o700); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	// Valid JSON but unreadable.
+	if err := os.WriteFile(claudeConfig, []byte(`{"hooks":{"SessionStart":[]}}`), 0o000); err != nil {
+		t.Fatalf("write unreadable claude config: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(claudeConfig, 0o600) })
+
+	got := checkHookConfigs()
+	if got.Status != "warn" {
+		t.Fatalf("status = %q, want warn; message=%q", got.Status, got.Message)
+	}
+	if !strings.Contains(got.Message, claudeConfig) {
+		t.Fatalf("message does not name the unreadable config path: %q", got.Message)
+	}
+	if !strings.Contains(got.Message, "chmod u+rw") {
+		t.Fatalf("message does not name the chmod remedy: %q", got.Message)
 	}
 }

--- a/internal/cli/doctor_hookinstall_test.go
+++ b/internal/cli/doctor_hookinstall_test.go
@@ -1,0 +1,217 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCheckHookConfigsFlagsStaleAMQHooks runs `amq doctor --json` under an
+// isolated HOME whose ~/.codex/hooks.json contains a stale AMQ SessionStart
+// hook (script path missing) and asserts the "Hook configs" check flags it as
+// a warning that names the missing script and the remedy command.
+func TestCheckHookConfigsFlagsStaleAMQHooks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	binaryPath := writeDoctorHookBinary(t, filepath.Join(home, "amq-keepalive"))
+	deadScript := "/nonexistent/gremlins/TestCheckHookConfigs/hook.sh"
+	deadCommand := buildAMQHookCommandForTest(t, binaryPath, deadScript)
+	codexConfig := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(codexConfig), 0o700); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	seed := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"hooks": []any{
+						map[string]any{"type": "command", "command": deadCommand, "timeout": 6},
+						map[string]any{"type": "command", "command": "echo foreign", "timeout": 6},
+					},
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(seed, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := os.WriteFile(codexConfig, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	got := checkHookConfigs()
+	if got.Name != "Hook configs" {
+		t.Fatalf("check name = %q, want %q", got.Name, "Hook configs")
+	}
+	if got.Status != "warn" {
+		t.Fatalf("status = %q, want warn; message=%q", got.Status, got.Message)
+	}
+	if !strings.Contains(got.Message, deadScript) {
+		t.Fatalf("message does not name the dead script %q: %q", deadScript, got.Message)
+	}
+	// R7: remedy is scoped to the agent actually found stale (codex), not always both.
+	if !strings.Contains(got.Message, "install-hook --agent codex") {
+		t.Fatalf("message does not name the codex-scoped remedy: %q", got.Message)
+	}
+	if strings.Contains(got.Message, "--agent both") {
+		t.Fatalf("remedy should be scoped to codex, not both: %q", got.Message)
+	}
+}
+
+// TestCheckHookConfigsCleanWhenNoStaleHooks asserts the check is ok when the
+// config has only a live AMQ hook and a foreign hook (no stale entries).
+func TestCheckHookConfigsCleanWhenNoStaleHooks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	binaryPath := writeDoctorHookBinary(t, filepath.Join(home, "amq-keepalive"))
+	liveScript := filepath.Join(home, "hooks", "amq-keepalive-session-start.sh")
+	if err := os.MkdirAll(filepath.Dir(liveScript), 0o700); err != nil {
+		t.Fatalf("mkdir live script dir: %v", err)
+	}
+	if err := os.WriteFile(liveScript, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write live script: %v", err)
+	}
+	liveCommand := buildAMQHookCommandForTest(t, binaryPath, liveScript)
+	codexConfig := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(codexConfig), 0o700); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	seed := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"hooks": []any{
+						map[string]any{"type": "command", "command": liveCommand, "timeout": 6},
+						map[string]any{"type": "command", "command": "echo foreign", "timeout": 6},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(codexConfig, append(data, '\n'), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	got := checkHookConfigs()
+	if got.Status != "ok" {
+		t.Fatalf("status = %q, want ok; message=%q", got.Status, got.Message)
+	}
+}
+
+// TestDoctorJSONIncludesHookConfigsCheck asserts the check appears in the full
+// `amq doctor --json` output next to the skill checks.
+func TestDoctorJSONIncludesHookConfigsCheck(t *testing.T) {
+	root := healthyDoctorMailboxRoot(t, "claude")
+	// Isolate HOME so checkHookConfigs does not read the real user config.
+	t.Setenv("HOME", t.TempDir())
+	findDoctorCheck(t, runDoctorMailboxJSON(t, root).Checks, "Hook configs")
+}
+
+// TestCheckHookConfigsSurfacesCorruptJSON is the R6 contract: a hook config
+// that exists but is corrupt JSON is NOT silently skipped. The check reports a
+// warning naming the path and the error. Only a missing file (os.IsNotExist)
+// is treated as "hooks not installed" and skipped.
+func TestCheckHookConfigsSurfacesCorruptJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	codexConfig := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(codexConfig), 0o700); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	// Corrupt JSON: unbalanced object.
+	if err := os.WriteFile(codexConfig, []byte(`{"hooks":{"SessionStart":[{"hooks":[}`), 0o600); err != nil {
+		t.Fatalf("write corrupt codex config: %v", err)
+	}
+
+	got := checkHookConfigs()
+	if got.Name != "Hook configs" {
+		t.Fatalf("check name = %q, want %q", got.Name, "Hook configs")
+	}
+	if got.Status != "warn" {
+		t.Fatalf("status = %q, want warn; message=%q", got.Status, got.Message)
+	}
+	if !strings.Contains(got.Message, codexConfig) {
+		t.Fatalf("message does not name the corrupt config path: %q", got.Message)
+	}
+	if !strings.Contains(got.Message, "codex") {
+		t.Fatalf("message does not name the agent: %q", got.Message)
+	}
+}
+
+// writeDoctorHookBinary writes a minimal executable at path and returns it.
+func writeDoctorHookBinary(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir binary dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	return path
+}
+
+// buildAMQHookCommandForTest builds an AMQ-owned hook command identical in
+// shape to the unexported hookinstall.buildHookCommand without depending on the unexported
+// function from the hookinstall package.
+func buildAMQHookCommandForTest(t *testing.T, binaryPath, scriptPath string) string {
+	t.Helper()
+	return "AMQ_KEEPALIVE_BIN='" + binaryPath + "' AMQ_KEEPALIVE_TIMEOUT_SECONDS='" +
+		strconv.Itoa(int(time.Second.Seconds())) + "' '" + scriptPath + "'"
+}
+
+// TestCheckHookConfigsReportsStaleAndCorruptTogether is the R10 contract: when
+// one agent's config is corrupt (a warning) and the other has dead hooks (stale
+// findings), the check reports BOTH in one message rather than hiding the stale
+// hooks behind the corrupt-config warning.
+func TestCheckHookConfigsReportsStaleAndCorruptTogether(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Codex config: a stale AMQ hook (dead script path).
+	binaryPath := writeDoctorHookBinary(t, filepath.Join(home, "amq-keepalive"))
+	deadScript := "/nonexistent/r10/dead.sh"
+	deadCommand := buildAMQHookCommandForTest(t, binaryPath, deadScript)
+	codexConfig := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(codexConfig), 0o700); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	codexSeed := fmt.Sprintf(`{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":%q,"timeout":6}]}]}}`, deadCommand)
+	if err := os.WriteFile(codexConfig, []byte(codexSeed), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	// Claude config: corrupt JSON (a warning, not a missing file).
+	claudeConfig := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(claudeConfig), 0o700); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.WriteFile(claudeConfig, []byte(`{"hooks":{"SessionStart":[`), 0o600); err != nil {
+		t.Fatalf("write corrupt claude config: %v", err)
+	}
+
+	got := checkHookConfigs()
+	if got.Status != "warn" {
+		t.Fatalf("status = %q, want warn; message=%q", got.Status, got.Message)
+	}
+	// The stale codex finding must be present.
+	if !strings.Contains(got.Message, deadScript) {
+		t.Fatalf("message missing stale codex script %q: %q", deadScript, got.Message)
+	}
+	if !strings.Contains(got.Message, "install-hook --agent codex") {
+		t.Fatalf("message missing codex-scoped remedy: %q", got.Message)
+	}
+	// The corrupt claude config warning must also be present.
+	if !strings.Contains(got.Message, claudeConfig) {
+		t.Fatalf("message missing corrupt claude config warning: %q", got.Message)
+	}
+}

--- a/internal/keepalive/hookinstall/hookinstall.go
+++ b/internal/keepalive/hookinstall/hookinstall.go
@@ -588,9 +588,9 @@ func classifyHook(hookObj map[string]interface{}) hookClass {
 func scriptPathFromAMQCommand(command string) (string, bool) {
 	s := command
 	// Token 1: AMQ_KEEPALIVE_BIN=<quoted>, then a space.
-	rest := strings.TrimPrefix(s, amqOwnedCommandPrefix)
-	if len(rest) == len(s) {
-		return "", false // prefix guard already passed in isAMQOwnedCommand
+	rest, ok := strings.CutPrefix(s, amqOwnedCommandPrefix)
+	if !ok {
+		return "", false
 	}
 	token1, rest, ok := shellUnquoteToken(rest)
 	if !ok || token1 == "" {
@@ -600,11 +600,18 @@ func scriptPathFromAMQCommand(command string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	// Token 2: AMQ_KEEPALIVE_TIMEOUT_SECONDS=<quoted>, then a space. The
-	// "AMQ_KEEPALIVE_TIMEOUT_SECONDS=" prefix precedes the second quoted token.
-	rest = strings.TrimPrefix(rest, "AMQ_KEEPALIVE_TIMEOUT_SECONDS=")
-	_, rest, ok = shellUnquoteToken(rest)
+	// Token 2: AMQ_KEEPALIVE_TIMEOUT_SECONDS=<quoted>, then a space. The prefix
+	// must be present exactly (CutPrefix, not TrimPrefix) and the decoded token
+	// must be all digits, because buildHookCommand emits shellQuote(fmt.Sprintf("%d",...)).
+	rest, ok = strings.CutPrefix(rest, "AMQ_KEEPALIVE_TIMEOUT_SECONDS=")
 	if !ok {
+		return "", false
+	}
+	timeoutToken, rest, ok := shellUnquoteToken(rest)
+	if !ok || timeoutToken == "" {
+		return "", false
+	}
+	if !isAllDigits(timeoutToken) {
 		return "", false
 	}
 	rest, ok = consumeSingleSpace(rest)
@@ -621,6 +628,21 @@ func scriptPathFromAMQCommand(command string) (string, bool) {
 		return "", false
 	}
 	return path, true
+}
+
+// isAllDigits reports whether s is non-empty and consists only of ASCII digits,
+// matching the shape buildHookCommand emits for the timeout (an int seconds
+// value rendered by fmt.Sprintf("%d", ...)).
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // shellUnquoteToken consumes one single-quoted token from the start of s and
@@ -706,6 +728,10 @@ func selfHealSessionStart(sessionStart []interface{}) ([]interface{}, bool) {
 // are preserved, not dropped. Uses classifyHook so it agrees with the doctor
 // scan.
 func pruneStaleAMQHooks(hooks []interface{}) ([]interface{}, bool) {
+	// Duplicate collapse keys on the exact full command string, the same
+	// identity the installer's claudeHasCommand uses: two LIVE owned hooks that
+	// share a script path but differ in AMQ_KEEPALIVE_BIN or timeout are distinct
+	// commands and must both be preserved; only byte-identical commands collapse.
 	seen := make(map[string]bool)
 	filtered := make([]interface{}, 0, len(hooks))
 	changed := false
@@ -725,7 +751,8 @@ func pruneStaleAMQHooks(hooks []interface{}) ([]interface{}, bool) {
 			filtered = append(filtered, hook)
 			continue
 		}
-		if seen[class.scriptPath] {
+		command := strings.TrimSpace(fmt.Sprint(hookObj["command"]))
+		if seen[command] {
 			changed = true
 			continue
 		}
@@ -733,7 +760,7 @@ func pruneStaleAMQHooks(hooks []interface{}) ([]interface{}, bool) {
 			changed = true
 			continue
 		}
-		seen[class.scriptPath] = true
+		seen[command] = true
 		filtered = append(filtered, hook)
 	}
 	return filtered, changed

--- a/internal/keepalive/hookinstall/hookinstall.go
+++ b/internal/keepalive/hookinstall/hookinstall.go
@@ -19,6 +19,12 @@ const (
 	AgentCodex  = "codex"
 
 	DefaultTimeout = 10 * time.Second
+
+	// amqOwnedCommandPrefix marks every SessionStart hook command the AMQ
+	// keepalive installer writes. buildHookCommand stamps each command with an
+	// AMQ_KEEPALIVE_BIN= env assignment, so its presence is a reliable ownership
+	// signal that does not require a separate marker file.
+	amqOwnedCommandPrefix = "AMQ_KEEPALIVE_BIN="
 )
 
 const SessionStartScript = `#!/usr/bin/env bash
@@ -421,8 +427,11 @@ func prepareClaudeHook(path, command string, hookTimeoutSeconds int) (map[string
 	if err := validateSessionStartEntries(sessionStart); err != nil {
 		return nil, false, err
 	}
+	sessionStart, healed := selfHealSessionStart(sessionStart)
+	hooks["SessionStart"] = sessionStart
+	doc["hooks"] = hooks
 	if claudeHasCommand(sessionStart, command) {
-		return doc, false, nil
+		return doc, healed, nil
 	}
 	sessionStart = append(sessionStart, claudeSessionStartEntry(command, hookTimeoutSeconds))
 	hooks["SessionStart"] = sessionStart
@@ -446,8 +455,11 @@ func prepareCodexHook(path, command string, hookTimeoutSeconds int) (map[string]
 	if err := validateSessionStartEntries(sessionStart); err != nil {
 		return nil, false, err
 	}
+	sessionStart, healed := selfHealSessionStart(sessionStart)
+	hooks["SessionStart"] = sessionStart
+	doc["hooks"] = hooks
 	if codexHasCommand(sessionStart, command) {
-		return doc, false, nil
+		return doc, healed, nil
 	}
 	hook := codexHook(command, hookTimeoutSeconds)
 	if len(sessionStart) == 0 {
@@ -517,6 +529,264 @@ func claudeHasCommand(entries []interface{}, command string) bool {
 
 func codexHasCommand(entries []interface{}, command string) bool {
 	return claudeHasCommand(entries, command)
+}
+
+// isAMQOwnedCommand reports whether a SessionStart hook command was written by
+// the AMQ keepalive installer, by detecting the AMQ_KEEPALIVE_BIN= env prefix
+// that buildHookCommand stamps on every command it emits. The prefix is
+// matched at the start of the command so a foreign hook that merely echoes the
+// env var name (e.g. `echo AMQ_KEEPALIVE_BIN=x`) is not misclassified as owned.
+func isAMQOwnedCommand(command string) bool {
+	return strings.HasPrefix(strings.TrimSpace(command), amqOwnedCommandPrefix)
+}
+
+// hookClass is the shared classification of a single hook command used by both
+// the install-time self-heal and the read-only doctor scan so the two never
+// disagree. owned is true for AMQ-written commands; scriptPath is the parsed
+// installed script path (empty when the command could not be parsed); stale is
+// true only when the path parsed and the script does not exist on disk. An
+// owned command that cannot be parsed is NOT stale: self-heal and doctor never
+// delete or report what they cannot read.
+type hookClass struct {
+	owned      bool
+	scriptPath string
+	stale      bool
+}
+
+// classifyHook inspects a single hook object and returns its classification.
+// It is the single source of truth for ownership, path extraction, and
+// staleness shared by pruneStaleAMQHooks (install-time self-heal) and
+// StaleSessionStartHooks (doctor scan).
+func classifyHook(hookObj map[string]interface{}) hookClass {
+	command := strings.TrimSpace(fmt.Sprint(hookObj["command"]))
+	if !isAMQOwnedCommand(command) {
+		return hookClass{}
+	}
+	scriptPath, ok := scriptPathFromAMQCommand(command)
+	if !ok || scriptPath == "" {
+		// Owned but unparseable: preserve, do not report stale.
+		return hookClass{owned: true}
+	}
+	_, err := os.Stat(scriptPath)
+	stale := os.IsNotExist(err)
+	// An unreadable path (e.g. EACCES) is not stale: unreadable is not the
+	// same as missing, so we do not prune or report it.
+	return hookClass{owned: true, scriptPath: scriptPath, stale: stale}
+}
+
+// scriptPathFromAMQCommand extracts the installed script path from an AMQ-owned
+// SessionStart hook command. buildHookCommand emits a fixed layout of three
+// single-quoted tokens: AMQ_KEEPALIVE_BIN=<q> AMQ_KEEPALIVE_TIMEOUT_SECONDS=<q>
+// <q>, where the third token is the script path. This is a forward decoder of
+// that fixed shape: it consumes one single-quoted token at a time (decoding the
+// 4-byte escaped-quote sequence that shellQuote emits for an embedded quote), skips the
+// single space separators, and returns the third token. Any leftover non-space
+// bytes after the third token, or the wrong number of tokens, means the command
+// does not match the shape buildHookCommand produces and is not parseable.
+// Returns the unescaped path and true on success; false (without dropping
+// anything) otherwise.
+func scriptPathFromAMQCommand(command string) (string, bool) {
+	s := command
+	// Token 1: AMQ_KEEPALIVE_BIN=<quoted>, then a space.
+	rest := strings.TrimPrefix(s, amqOwnedCommandPrefix)
+	if len(rest) == len(s) {
+		return "", false // prefix guard already passed in isAMQOwnedCommand
+	}
+	token1, rest, ok := shellUnquoteToken(rest)
+	if !ok || token1 == "" {
+		return "", false
+	}
+	rest, ok = consumeSingleSpace(rest)
+	if !ok {
+		return "", false
+	}
+	// Token 2: AMQ_KEEPALIVE_TIMEOUT_SECONDS=<quoted>, then a space. The
+	// "AMQ_KEEPALIVE_TIMEOUT_SECONDS=" prefix precedes the second quoted token.
+	rest = strings.TrimPrefix(rest, "AMQ_KEEPALIVE_TIMEOUT_SECONDS=")
+	_, rest, ok = shellUnquoteToken(rest)
+	if !ok {
+		return "", false
+	}
+	rest, ok = consumeSingleSpace(rest)
+	if !ok {
+		return "", false
+	}
+	// Token 3: the script path.
+	path, left, ok := shellUnquoteToken(rest)
+	if !ok {
+		return "", false
+	}
+	// Any leftover non-space bytes mean a 4th token is present: not parseable.
+	if strings.TrimSpace(left) != "" {
+		return "", false
+	}
+	return path, true
+}
+
+// shellUnquoteToken consumes one single-quoted token from the start of s and
+// returns its decoded value, the unconsumed remainder, and ok. It is the exact
+// inverse of shellQuote, which produces a token of the form '<value>' where
+// every embedded single quote is encoded as a 4-byte close-escape-reopen
+// sequence: close the quote, a backslash-escaped quote, reopen the quote.
+// Decoding therefore strips the outer quotes and replaces each such sequence
+// with a literal single quote.
+// ok is false if s does not begin with a complete, well-formed token.
+func shellUnquoteToken(s string) (token, rest string, ok bool) {
+	if len(s) == 0 || s[0] != '\'' {
+		return "", s, false
+	}
+	// Find the closing quote that ends this token. A token is a run of
+	// '<...>' segments joined by escaped-quote sequences; the token ends at the
+	// first single quote that is not followed by the rest of an escape.
+	i := 1
+	for i < len(s) {
+		if s[i] != '\'' {
+			i++
+			continue
+		}
+		// s[i] == quote. If this is the start of an escaped-quote sequence (close,
+		// backslash, quote, reopen), skip the 4 bytes and continue inside the token.
+		if i+3 < len(s) && s[i+1] == '\\' && s[i+2] == '\'' && s[i+3] == '\'' {
+			i += 4
+			continue
+		}
+		// This quote closes the token.
+		break
+	}
+	if i >= len(s) {
+		return "", s, false // unterminated quote
+	}
+	// s[1:i] is the raw token body; decode escaped-quote sequences back to
+	// single quotes.
+	raw := s[1:i]
+	token = strings.ReplaceAll(raw, "'\\''", "'")
+	return token, s[i+1:], true
+}
+
+// consumeSingleSpace consumes exactly one ASCII space from the start of s. It
+// returns the remainder and ok; ok is false if s does not start with a space.
+func consumeSingleSpace(s string) (rest string, ok bool) {
+	if len(s) == 0 || s[0] != ' ' {
+		return s, false
+	}
+	return s[1:], true
+}
+
+// selfHealSessionStart prunes stale AMQ-owned hooks from every SessionStart
+// entry. Foreign hooks are preserved verbatim. AMQ-owned hooks whose script
+// path does not exist are dropped, and duplicate AMQ-owned hooks referencing
+// the same existing script path are de-duplicated to the first occurrence.
+// Owned hooks that cannot be parsed are preserved (never deleted unread).
+// Returns the (possibly same) slice and whether any entry changed.
+func selfHealSessionStart(sessionStart []interface{}) ([]interface{}, bool) {
+	changed := false
+	for i, entry := range sessionStart {
+		obj, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		inner, err := innerHookList(obj)
+		if err != nil || len(inner) == 0 {
+			continue
+		}
+		pruned, entryChanged := pruneStaleAMQHooks(inner)
+		if entryChanged {
+			obj["hooks"] = pruned
+			sessionStart[i] = obj
+			changed = true
+		}
+	}
+	return sessionStart, changed
+}
+
+// pruneStaleAMQHooks filters the inner hooks list of a single SessionStart
+// entry. Non-AMQ hooks are preserved verbatim. AMQ-owned hooks whose script
+// path is missing are dropped; duplicates referencing the same existing script
+// path are collapsed to the first occurrence. Owned hooks that cannot be parsed
+// are preserved, not dropped. Uses classifyHook so it agrees with the doctor
+// scan.
+func pruneStaleAMQHooks(hooks []interface{}) ([]interface{}, bool) {
+	seen := make(map[string]bool)
+	filtered := make([]interface{}, 0, len(hooks))
+	changed := false
+	for _, hook := range hooks {
+		hookObj, ok := hook.(map[string]interface{})
+		if !ok {
+			filtered = append(filtered, hook)
+			continue
+		}
+		class := classifyHook(hookObj)
+		if !class.owned {
+			filtered = append(filtered, hook)
+			continue
+		}
+		if class.scriptPath == "" {
+			// Owned but unparseable: preserve verbatim.
+			filtered = append(filtered, hook)
+			continue
+		}
+		if seen[class.scriptPath] {
+			changed = true
+			continue
+		}
+		if class.stale {
+			changed = true
+			continue
+		}
+		seen[class.scriptPath] = true
+		filtered = append(filtered, hook)
+	}
+	return filtered, changed
+}
+
+// StaleSessionStartHook describes an AMQ-owned SessionStart hook command whose
+// script path does not exist. It is used by amq doctor to flag dead hooks.
+type StaleSessionStartHook struct {
+	ConfigPath string `json:"config_path"`
+	Agent      string `json:"agent"`
+	ScriptPath string `json:"script_path"`
+}
+
+// StaleSessionStartHooks scans a Claude or Codex hook config file for AMQ-owned
+// SessionStart hook commands whose script path does not exist. It does not
+// modify the file. Returns one entry per stale hook. Uses classifyHook so it
+// agrees with the install-time self-heal. Owned hooks that cannot be parsed are
+// not reported (they are preserved, not stale).
+func StaleSessionStartHooks(configPath, agent string) ([]StaleSessionStartHook, error) {
+	doc, err := loadJSONObject(configPath)
+	if err != nil {
+		return nil, err
+	}
+	hooks, ok := doc["hooks"].(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	sessionStart, ok := hooks["SessionStart"].([]interface{})
+	if !ok {
+		return nil, nil
+	}
+	var stale []StaleSessionStartHook
+	for _, entry := range sessionStart {
+		obj, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, hook := range interfaceArray(obj["hooks"]) {
+			hookObj, ok := hook.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			class := classifyHook(hookObj)
+			if class.owned && class.stale {
+				stale = append(stale, StaleSessionStartHook{
+					ConfigPath: configPath,
+					Agent:      agent,
+					ScriptPath: class.scriptPath,
+				})
+			}
+		}
+	}
+	return stale, nil
 }
 
 func loadJSONObject(path string) (map[string]interface{}, error) {

--- a/internal/keepalive/hookinstall/hookinstall_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_test.go
@@ -1319,3 +1319,114 @@ func TestScriptPathFromAMQCommandRoundTrip(t *testing.T) {
 		t.Errorf("4th-token command should not parse: %q", extra)
 	}
 }
+
+// TestScriptPathFromAMQCommandRejectsNonFixedShape is the B1 contract: a command
+// that has the AMQ prefix but is not the exact fixed shape buildHookCommand
+// emits must NOT parse, so self-heal preserves it and the doctor does not
+// report it stale. Cases: missing AMQ_KEEPALIVE_TIMEOUT_SECONDS= prefix; a
+// non-digit timeout token.
+func TestScriptPathFromAMQCommandRejectsNonFixedShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "missing timeout prefix",
+			command: "AMQ_KEEPALIVE_BIN='/b' 'not-timeout' '/dead.sh'",
+		},
+		{
+			name:    "non-digit timeout",
+			command: "AMQ_KEEPALIVE_BIN='/b' AMQ_KEEPALIVE_TIMEOUT_SECONDS='abc' '/dead.sh'",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := scriptPathFromAMQCommand(tc.command); ok {
+				t.Fatalf("command parsed but is not the fixed shape: %q", tc.command)
+			}
+		})
+	}
+}
+
+// TestSelfHealPreservesNonFixedShapeAMQCommand is the B1 self-heal side: a
+// non-fixed-shape owned command is preserved verbatim (not pruned) and not
+// reported stale by the doctor, because it is owned-but-unparseable.
+func TestSelfHealPreservesNonFixedShapeAMQCommand(t *testing.T) {
+	withIsolatedHome(t, func(t *testing.T) {
+		dir := t.TempDir()
+		scriptPath := filepath.Join(dir, "hook.sh")
+		binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+		claudeConfig := filepath.Join(dir, "settings.json")
+		// Missing the AMQ_KEEPALIVE_TIMEOUT_SECONDS= prefix: owned but unparseable.
+		nonFixed := "AMQ_KEEPALIVE_BIN='" + binaryPath + "' 'not-timeout' '/nonexistent/dead.sh'"
+		mustWrite(t, claudeConfig, []byte(fmt.Sprintf(`{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":%q}]}]}}`, nonFixed)))
+
+		_, err := Install(Options{
+			Agent:        AgentClaude,
+			ScriptPath:   scriptPath,
+			BinaryPath:   binaryPath,
+			ClaudeConfig: claudeConfig,
+			Timeout:      time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+		doc := readJSON(t, claudeConfig)
+		if countCommand(doc, nonFixed) != 1 {
+			t.Fatalf("non-fixed-shape owned command was pruned by self-heal:\n%s", mustMarshal(t, doc))
+		}
+		stale, err := StaleSessionStartHooks(claudeConfig, AgentClaude)
+		if err != nil {
+			t.Fatalf("StaleSessionStartHooks error = %v", err)
+		}
+		if len(stale) != 0 {
+			t.Fatalf("non-fixed-shape command reported as stale: %#v", stale)
+		}
+	})
+}
+
+// TestSelfHealDedupKeysOnFullCommand is the B3 contract: duplicate collapse
+// keys on the exact full command string, not the decoded script path. Two LIVE
+// owned hooks that share a script path but differ in timeout are distinct
+// commands and must both be preserved; only byte-identical commands collapse to
+// one.
+func TestSelfHealDedupKeysOnFullCommand(t *testing.T) {
+	withIsolatedHome(t, func(t *testing.T) {
+		dir := t.TempDir()
+		liveScript := filepath.Join(dir, "hooks", "amq-keepalive-session-start.sh")
+		binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+		codexConfig := filepath.Join(dir, "codex", "hooks.json")
+		mustWrite(t, liveScript, []byte(SessionStartScript))
+		if err := os.Chmod(liveScript, 0o755); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+		// Two live AMQ hooks, same script, different timeout -> distinct commands.
+		cmdTimeout1 := buildHookCommand(binaryPath, liveScript, 1*time.Second)
+		cmdTimeout2 := buildHookCommand(binaryPath, liveScript, 2*time.Second)
+		// A byte-identical duplicate of cmdTimeout1 -> should collapse to one.
+		seed := fmt.Sprintf(`{"hooks":{"SessionStart":[{"hooks":[`+
+			`{"type":"command","command":%q,"timeout":6},`+
+			`{"type":"command","command":%q,"timeout":6},`+
+			`{"type":"command","command":%q,"timeout":6}`+
+			`]}]}}`, cmdTimeout1, cmdTimeout2, cmdTimeout1)
+		mustWrite(t, codexConfig, []byte(seed))
+
+		if _, err := Install(Options{
+			Agent:       AgentCodex,
+			ScriptPath:  liveScript,
+			BinaryPath:  binaryPath,
+			CodexConfig: codexConfig,
+			Timeout:     time.Second,
+		}); err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+		doc := readJSON(t, codexConfig)
+		// Both distinct-timeout live hooks preserved.
+		if countCommand(doc, cmdTimeout1) != 1 {
+			t.Fatalf("timeout-1 live hook not preserved exactly once:\n%s", mustMarshal(t, doc))
+		}
+		if countCommand(doc, cmdTimeout2) != 1 {
+			t.Fatalf("timeout-2 live hook not preserved exactly once:\n%s", mustMarshal(t, doc))
+		}
+	})
+}

--- a/internal/keepalive/hookinstall/hookinstall_test.go
+++ b/internal/keepalive/hookinstall/hookinstall_test.go
@@ -14,6 +14,35 @@ import (
 	"time"
 )
 
+// TestMain isolates HOME (and USERPROFILE) to a fresh temp dir for the whole
+// package before any test runs. DefaultScriptPath/DefaultClaudeConfig/
+// DefaultCodexConfig resolve via os.UserHomeDir, which honors HOME, so this
+// guarantees no test in the package can write to the real ~/.codex/hooks.json
+// or ~/.claude/settings.json under ANY mutation — not only the two named
+// tests. Tests that need their own sentinel HOME (the negative case) still set
+// it via t.Setenv inside the run.
+func TestMain(m *testing.M) {
+	home, err := os.MkdirTemp("", "amq-hookinstall-home-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hookinstall TestMain: temp home: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("HOME", home); err != nil {
+		fmt.Fprintf(os.Stderr, "hookinstall TestMain: set HOME: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("USERPROFILE", home); err != nil {
+		fmt.Fprintf(os.Stderr, "hookinstall TestMain: set USERPROFILE: %v\n", err)
+		os.Exit(1)
+	}
+	// os.Exit skips defers, so clean up before exiting with the real code.
+	code := m.Run()
+	if err := os.RemoveAll(home); err != nil {
+		fmt.Fprintf(os.Stderr, "hookinstall TestMain: remove temp home: %v\n", err)
+	}
+	os.Exit(code)
+}
+
 func TestInstallBothWritesScriptAndMergesConfigs(t *testing.T) {
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "hooks", "amq-keepalive-session-start.sh")
@@ -977,4 +1006,316 @@ func mustMarshal(t *testing.T, v interface{}) string {
 		t.Fatalf("marshal: %v", err)
 	}
 	return string(data)
+}
+
+// withIsolatedHome runs fn with HOME (and USERPROFILE) pointed at a fresh temp
+// dir. TestMain already isolates HOME for the whole package; this helper is for
+// tests that need a SECOND, distinct sentinel HOME inside the run (the negative
+// case that asserts a different home tree is byte-identical before/after).
+func withIsolatedHome(t *testing.T, fn func(t *testing.T)) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Some platforms consult USERPROFILE; set it too so the isolation is robust
+	// when the suite runs under mutation testing or a cross-platform harness.
+	t.Setenv("USERPROFILE", home)
+	fn(t)
+}
+
+// TestInstallDoesNotTouchRealHomeWhenDefaultsResolve asserts the regression at
+// the core of WP-646: when a caller omits CodexConfig (so NormalizeOptions
+// resolves it via DefaultCodexConfig -> os.UserHomeDir), install writes only
+// into the isolated HOME's tree and never touches a second sentinel HOME.
+func TestInstallDoesNotTouchRealHomeWhenDefaultsResolve(t *testing.T) {
+	// First, capture a sentinel representing "the real user home" and pre-seed
+	// its ~/.codex/hooks.json so we can assert byte-identity after install.
+	sentinelHome := t.TempDir()
+	mustWrite(t, filepath.Join(sentinelHome, ".codex", "hooks.json"),
+		[]byte(`{"hooks":{"SessionStart":[]}}`))
+	before, err := os.ReadFile(filepath.Join(sentinelHome, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatalf("read sentinel before: %v", err)
+	}
+
+	// Run install under an isolated HOME that is NOT the sentinel. Omit
+	// CodexConfig so the default resolution path is exercised.
+	withIsolatedHome(t, func(t *testing.T) {
+		dir := t.TempDir()
+		binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+		scriptPath := filepath.Join(dir, "hook.sh")
+		claudeConfig := filepath.Join(dir, "settings.json")
+
+		result, err := Install(Options{
+			Agent:        AgentBoth,
+			ScriptPath:   scriptPath,
+			BinaryPath:   binaryPath,
+			ClaudeConfig: claudeConfig,
+			// CodexConfig intentionally omitted: exercises DefaultCodexConfig.
+			Timeout: time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+		// The default codex config resolved under the isolated HOME, so it must
+		// exist there and contain exactly one AMQ command.
+		resolvedCodex := filepath.Join(os.Getenv("HOME"), ".codex", "hooks.json")
+		codexDoc := readJSON(t, resolvedCodex)
+		if countCommand(codexDoc, result.Commands[AgentCodex]) != 1 {
+			t.Fatalf("default CodexConfig not installed exactly once:\n%s", mustMarshal(t, codexDoc))
+		}
+	})
+
+	// Negative assertion: the sentinel HOME's ~/.codex/hooks.json is byte-identical.
+	after, err := os.ReadFile(filepath.Join(sentinelHome, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatalf("read sentinel after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("sentinel ~/.codex/hooks.json was mutated by install: before=%s after=%s", before, after)
+	}
+}
+
+// TestSelfHealPrunesStaleAMQHooksAndPreservesForeign is the WP-646 self-heal
+// contract: a config seeded with 3 dead AMQ entries + 1 foreign entry + 1 live
+// AMQ entry results, after install, in the foreign entry preserved verbatim,
+// exactly one live AMQ entry, and all dead entries gone.
+func TestSelfHealPrunesStaleAMQHooksAndPreservesForeign(t *testing.T) {
+	withIsolatedHome(t, func(t *testing.T) {
+		dir := t.TempDir()
+		liveScript := filepath.Join(dir, "hooks", "amq-keepalive-session-start.sh")
+		binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+		codexConfig := filepath.Join(dir, "codex", "hooks.json")
+
+		// Build three dead AMQ commands pointing at nonexistent scripts, plus a
+		// foreign entry and one live AMQ entry (script exists on disk).
+		dead1 := buildHookCommand(binaryPath, "/nonexistent/gremlins-1/hook.sh", time.Second)
+		dead2 := buildHookCommand(binaryPath, "/nonexistent/gremlins-2/hook.sh", time.Second)
+		dead3 := buildHookCommand(binaryPath, filepath.Join(dir, "also-missing.sh"), time.Second)
+		live := buildHookCommand(binaryPath, liveScript, time.Second)
+		foreign := `echo "not amq"`
+		seed := fmt.Sprintf(`{"hooks":{"SessionStart":[{"hooks":[`+
+			`{"type":"command","command":%q,`+`"timeout":6},`+
+			`{"type":"command","command":%q,`+`"timeout":6},`+
+			`{"type":"command","command":%q,`+`"timeout":6},`+
+			`{"type":"command","command":%q,`+`"timeout":6},`+
+			`{"type":"command","command":%q,`+`"timeout":6}`+
+			`]}]}}`, dead1, dead2, dead3, foreign, live)
+		mustWrite(t, codexConfig, []byte(seed))
+		// Create the live script on disk so the live entry survives pruning.
+		mustWrite(t, liveScript, []byte(SessionStartScript))
+		if err := os.Chmod(liveScript, 0o755); err != nil {
+			t.Fatalf("chmod live script: %v", err)
+		}
+
+		result, err := Install(Options{
+			Agent:       AgentCodex,
+			ScriptPath:  liveScript,
+			BinaryPath:  binaryPath,
+			CodexConfig: codexConfig,
+			Timeout:     time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+
+		doc := readJSON(t, codexConfig)
+		// Foreign entry preserved verbatim.
+		if countCommand(doc, foreign) != 1 {
+			t.Fatalf("foreign hook not preserved verbatim:\n%s", mustMarshal(t, doc))
+		}
+		// Exactly one live AMQ entry (the install command equals the live one,
+		// so self-heal keeps it and install does not append a duplicate).
+		if countCommand(doc, result.Commands[AgentCodex]) != 1 {
+			t.Fatalf("live AMQ command count != 1 after install:\n%s", mustMarshal(t, doc))
+		}
+		// All dead entries gone.
+		if countCommand(doc, dead1) != 0 || countCommand(doc, dead2) != 0 || countCommand(doc, dead3) != 0 {
+			t.Fatalf("dead AMQ entries survived self-heal:\n%s", mustMarshal(t, doc))
+		}
+	})
+}
+
+// TestSelfHealPreservesForeignWhenNoAMQEntryExists confirms the self-heal pass
+// touches only AMQ-owned hooks: a foreign-only config is rewritten only by the
+// normal install append, never by pruning.
+func TestSelfHealPreservesForeignWhenNoAMQEntryExists(t *testing.T) {
+	withIsolatedHome(t, func(t *testing.T) {
+		dir := t.TempDir()
+		scriptPath := filepath.Join(dir, "hook.sh")
+		binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+		claudeConfig := filepath.Join(dir, "settings.json")
+		foreign := `echo foreign-tool`
+		mustWrite(t, claudeConfig, []byte(`{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":"`+foreign+`"}]}]}}`))
+
+		_, err := Install(Options{
+			Agent:        AgentClaude,
+			ScriptPath:   scriptPath,
+			BinaryPath:   binaryPath,
+			ClaudeConfig: claudeConfig,
+			Timeout:      time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+		doc := readJSON(t, claudeConfig)
+		if countCommand(doc, foreign) != 1 {
+			t.Fatalf("foreign hook altered when no stale AMQ hook present:\n%s", mustMarshal(t, doc))
+		}
+	})
+}
+
+// TestStaleSessionStartHooksDetectsDeadAMQEntries exercises the read-only scan
+// used by amq doctor: it reports AMQ-owned commands whose script is missing and
+// ignores foreign and live entries.
+func TestStaleSessionStartHooksDetectsDeadAMQEntries(t *testing.T) {
+	withIsolatedHome(t, func(t *testing.T) {
+		dir := t.TempDir()
+		liveScript := filepath.Join(dir, "live.sh")
+		mustWrite(t, liveScript, []byte("#!/bin/sh\nexit 0\n"))
+		if err := os.Chmod(liveScript, 0o755); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+		binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+		dead := buildHookCommand(binaryPath, "/nonexistent/dead.sh", time.Second)
+		live := buildHookCommand(binaryPath, liveScript, time.Second)
+		codexConfig := filepath.Join(dir, "codex", "hooks.json")
+		mustWrite(t, codexConfig, []byte(fmt.Sprintf(`{"hooks":{"SessionStart":[{"hooks":[`+
+			`{"type":"command","command":%q,"timeout":6},`+
+			`{"type":"command","command":"echo foreign","timeout":6},`+
+			`{"type":"command","command":%q,"timeout":6}`+
+			`]}]}}`, dead, live)))
+
+		stale, err := StaleSessionStartHooks(codexConfig, AgentCodex)
+		if err != nil {
+			t.Fatalf("StaleSessionStartHooks error = %v", err)
+		}
+		if len(stale) != 1 {
+			t.Fatalf("want 1 stale hook, got %d: %#v", len(stale), stale)
+		}
+		if stale[0].ScriptPath != "/nonexistent/dead.sh" {
+			t.Fatalf("stale script path = %q, want /nonexistent/dead.sh", stale[0].ScriptPath)
+		}
+		if stale[0].Agent != AgentCodex {
+			t.Fatalf("stale agent = %q, want %s", stale[0].Agent, AgentCodex)
+		}
+	})
+}
+
+// TestIsAMQOwnedCommandRejectsForeignEchoOfEnvVar is the R2 negative: a foreign
+// hook that merely echoes the AMQ env var name (e.g. `echo AMQ_KEEPALIVE_BIN=x`)
+// must NOT be classified as AMQ-owned, so it is preserved verbatim by self-heal
+// and never reported stale by the doctor scan. isAMQOwnedCommand matches the
+// prefix at the start of the command, not anywhere inside it.
+func TestIsAMQOwnedCommandRejectsForeignEchoOfEnvVar(t *testing.T) {
+	withIsolatedHome(t, func(t *testing.T) {
+		dir := t.TempDir()
+		scriptPath := filepath.Join(dir, "hook.sh")
+		binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+		claudeConfig := filepath.Join(dir, "settings.json")
+		foreign := `echo AMQ_KEEPALIVE_BIN=x`
+		// Seed only the foreign echo; install must not prune it and must add the
+		// real AMQ command alongside it.
+		mustWrite(t, claudeConfig, []byte(`{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":"`+foreign+`"}]}]}}`))
+
+		result, err := Install(Options{
+			Agent:        AgentClaude,
+			ScriptPath:   scriptPath,
+			BinaryPath:   binaryPath,
+			ClaudeConfig: claudeConfig,
+			Timeout:      time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+		doc := readJSON(t, claudeConfig)
+		if countCommand(doc, foreign) != 1 {
+			t.Fatalf("foreign echo of env var was pruned or duplicated:\n%s", mustMarshal(t, doc))
+		}
+		if countCommand(doc, result.Commands[AgentClaude]) != 1 {
+			t.Fatalf("AMQ command not installed exactly once:\n%s", mustMarshal(t, doc))
+		}
+		// Doctor scan must not report the foreign echo as stale.
+		stale, err := StaleSessionStartHooks(claudeConfig, AgentClaude)
+		if err != nil {
+			t.Fatalf("StaleSessionStartHooks error = %v", err)
+		}
+		for _, s := range stale {
+			if s.ScriptPath == "x" || strings.Contains(s.ScriptPath, "AMQ_KEEPALIVE_BIN") {
+				t.Fatalf("foreign echo reported as stale: %#v", s)
+			}
+		}
+	})
+}
+
+// TestSelfHealPreservesUnparseableAMQCommand is the R4 contract: an AMQ-owned
+// command whose script path cannot be parsed (here: a malformed command missing
+// the trailing single quote that buildHookCommand always emits) is preserved
+// verbatim, never deleted. Self-heal only drops a hook when the path parsed and
+// os.Stat reports it missing.
+func TestSelfHealPreservesUnparseableAMQCommand(t *testing.T) {
+	withIsolatedHome(t, func(t *testing.T) {
+		dir := t.TempDir()
+		scriptPath := filepath.Join(dir, "hook.sh")
+		binaryPath := writeExecutable(t, filepath.Join(dir, "amq-keepalive"))
+		claudeConfig := filepath.Join(dir, "settings.json")
+		// Malformed AMQ-owned command: has the prefix but no closing single quote
+		// on the final token, so scriptPathFromAMQCommand cannot parse it.
+		unparseable := "AMQ_KEEPALIVE_BIN='" + binaryPath + "' AMQ_KEEPALIVE_TIMEOUT_SECONDS='1' '/nonexistent/missing-trailing-quote"
+		mustWrite(t, claudeConfig, []byte(fmt.Sprintf(`{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command","command":%q}]}]}}`, unparseable)))
+
+		_, err := Install(Options{
+			Agent:        AgentClaude,
+			ScriptPath:   scriptPath,
+			BinaryPath:   binaryPath,
+			ClaudeConfig: claudeConfig,
+			Timeout:      time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+		doc := readJSON(t, claudeConfig)
+		if countCommand(doc, unparseable) != 1 {
+			t.Fatalf("unparseable AMQ-owned command was dropped by self-heal:\n%s", mustMarshal(t, doc))
+		}
+		// Doctor scan must not report an unparseable command as stale.
+		stale, err := StaleSessionStartHooks(claudeConfig, AgentClaude)
+		if err != nil {
+			t.Fatalf("StaleSessionStartHooks error = %v", err)
+		}
+		if len(stale) != 0 {
+			t.Fatalf("unparseable command reported as stale: %#v", stale)
+		}
+	})
+}
+
+// TestScriptPathFromAMQCommandRoundTrip is the R8 contract: for paths with
+// plain bytes, spaces, embedded quotes, multibyte runes, and trailing quotes,
+// scriptPathFromAMQCommand must exactly invert buildHookCommand. A command
+// carrying a 4th token must not parse.
+func TestScriptPathFromAMQCommandRoundTrip(t *testing.T) {
+	bin := "/bin/amq-keepalive"
+	cases := []string{
+		"/plain/path.sh",
+		"/with space/hook.sh",
+		"/it's/a.sh",
+		"/ünïcode/路径/hook.sh",
+		"/trailing'quote/a.sh",
+	}
+	for _, p := range cases {
+		cmd := buildHookCommand(bin, p, time.Second)
+		got, ok := scriptPathFromAMQCommand(cmd)
+		if !ok {
+			t.Errorf("path=%q: not parseable from %q", p, cmd)
+			continue
+		}
+		if got != p {
+			t.Errorf("path=%q: decoded %q from %q", p, got, cmd)
+		}
+	}
+	// Negative: a 4th token after the script path is not the buildHookCommand
+	// shape, so it must not parse.
+	extra := "AMQ_KEEPALIVE_BIN='/b' AMQ_KEEPALIVE_TIMEOUT_SECONDS='1' '/p.sh' extra"
+	if _, ok := scriptPathFromAMQCommand(extra); ok {
+		t.Errorf("4th-token command should not parse: %q", extra)
+	}
 }


### PR DESCRIPTION
fix(keepalive): isolate hookinstall tests from HOME and self-heal stale hooks

## Root cause
DefaultScriptPath/DefaultClaudeConfig/DefaultCodexConfig resolve via
os.UserHomeDir (reads $HOME on darwin), and NormalizeOptions always resolves
the Codex default even for Agent=claude. The installer tests passed explicit
temp config paths, so the leak required a gremlins mutation flipping the
codex-write gate while defaults still pointed at the real HOME: fixture paths
were then merged into ~/.codex/hooks.json. After macOS reclaims /var/folders
temp dirs, every leaked SessionStart hook fails with exit 127 on session start.

## Changes
1. Package-wide HOME isolation: a TestMain in hookinstall_test.go sets HOME
   (and USERPROFILE) to a fresh temp dir before m.Run(), so every test in the
   package is isolated under any mutation — not only the two named tests. A
   negative sentinel test asserts a second HOME's ~/.codex/hooks.json is
   byte-identical before/after install when defaults resolve.
2. Install-time self-heal: prepareClaudeHook/prepareCodexHook now prune
   AMQ-owned SessionStart hooks whose script path does not exist (de-duplicating
   duplicates on the same existing path) before appending. Ownership is detected
   via the AMQ_KEEPALIVE_BIN= prefix buildHookCommand already stamps; the script
   path is decoded by a forward single-quote-token decoder that is the exact
   inverse of shellQuote (handles embedded quotes and multibyte paths). Foreign
   hooks are preserved verbatim; owned-but-unparseable commands are preserved,
   never deleted unread. The prune runs on every install, so one install-hook
   call cleans a polluted file.
3. amq doctor 'Hook configs' check: a read-only scan of the default Claude and
   Codex hook configs flags AMQ-owned SessionStart hooks whose script is missing,
   with the remedy scoped to the agent(s) actually found stale
   (amq-keepalive install-hook --agent <claude|codex|both>). Non-IsNotExist
   errors (e.g. corrupt JSON) are surfaced as warnings alongside stale findings.

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
