### PR TITLE
test(keepalive): isolate cmux enter-failure inject from real TTYs

### DIFF
--- a/internal/keepalive/adapter/cmux_test.go
+++ b/internal/keepalive/adapter/cmux_test.go
@@ -646,9 +646,10 @@ func TestCmuxInjectEnterFailureAfterTextIsUncertain(t *testing.T) {
 		{output: []byte("enter failed"), err: errors.New("exit status 1")},
 	}}
 	adapter := Cmux{
-		Runner: runner,
-		Path:   "/fake/cmux",
-		Sleep:  func(context.Context, time.Duration) error { return nil },
+		Runner:            runner,
+		Path:              "/fake/cmux",
+		LiveTTYOwnerCount: liveOwner,
+		Sleep:             func(context.Context, time.Duration) error { return nil },
 	}
 	err := adapter.Inject(context.Background(), "cmux:surface:"+testCmuxSurfaceID, "payload")
 	if !errors.Is(err, ErrInjectUncertain) {


### PR DESCRIPTION
## Summary
- Root cause is **test isolation**, not adapter alias logic: `TestCmuxInjectEnterFailureAfterTextIsUncertain` omitted `LiveTTYOwnerCount`, so `Inventory` ran real `sysctl` against fixture `ttys001` (`/dev/ttys001` is a live PTY on this Mac) and degraded as `tty alias ambiguity` before the enter-after-text path.
- Siblings already inject `liveOwner`. This test now does too. The duplicate-alias negative `TestCmuxInjectRejectsDuplicateTTYAliasesBeforeSendingText` is unchanged.

## Test plan
- [x] Reproduced on this Mac without the fake: `cmux tty alias ambiguity on /dev/ttys001`
- [x] `go test ./internal/keepalive/adapter -run 'TestCmuxInjectEnterFailureAfterTextIsUncertain|TestCmuxInjectDoesNotSendEnterWhenTextFails|TestCmuxInjectUsesRawRPCThenSettlesAndSendsEnter|TestCmuxInjectRejectsDuplicateTTYAliasesBeforeSendingText'`
- [x] `GOOS=linux go vet ./internal/keepalive/adapter` and `GOOS=linux go test -c ./internal/keepalive/adapter`

Refs bead `agent-message-queue-4qp`. Do not merge; Claude runs Pro.


Made with [Cursor](https://cursor.com)