### PR TITLE
docs(acp): name the Buzz NIP-PL lease the BYOH gate waits for

### DIFF
--- a/cmd/amq-acp/README.md
+++ b/cmd/amq-acp/README.md
@@ -67,8 +67,10 @@ no env: Buzz's default `BUZZ_ACP_AGENT_ARGS=acp` would be extra argv and
   `inbox/new`. A separate Edge owner drains with `amq drain`.
 - `amq-acp` refuses `BUZZ_ACP_AGENTS` other than `1` and `BUZZ_ACP_RESPOND_TO`
   other than `owner-only`, then unsets every `BUZZ_*` variable so a leaked
-  nsec cannot enter AMQ messages. A deployment lease is an upstream Buzz
-  capability; this companion does not invent one.
+  nsec cannot enter AMQ messages. The gate waits for the harness to hold a
+  Buzz NIP-PL kind:30350 lease with a quota-1 deployment-identity profile
+  (block/buzz#5667); this companion does not invent a lease, it gates inbound
+  on that lease once the profile ships.
 - When `_meta.nostr.eventId` (or `_meta.triggeringEventIds`) names one 64-hex
   Nostr event, that id is the idempotency key. A second prompt with the same
   id is a no-op. Two ids in one prompt are refused: one event, one AMQ job.

--- a/cmd/amq-acp/main.go
+++ b/cmd/amq-acp/main.go
@@ -94,8 +94,9 @@ Environment:
   AM_BASE_ROOT_ID  identity token authenticating AM_BASE_ROOT
 
 BUZZ_* variables are read only to refuse agents!=1 and non-owner inbound, then
-stripped before any message is written. A deployment lease is upstream; this
-binary does not treat an env string as one.
+stripped before any message is written. The gate waits for the harness to hold
+a Buzz NIP-PL kind:30350 lease with a quota-1 deployment-identity profile
+(block/buzz#5667); this binary does not treat an env string as one.
 
 A session pin that cannot be authenticated is refused with exit code 5.
 `

--- a/docs/adr-two-host-fleets.md
+++ b/docs/adr-two-host-fleets.md
@@ -136,6 +136,9 @@ v1 does not:
 - claim ACP v2
 - put `--always-approve` in committed launch plans
 - hold a Buzz nsec inside AMQ
+  - The `amq-acp` companion instead gates inbound `BUZZ_ACP_AGENTS`/`RESPOND_TO`
+    on the harness holding a Buzz NIP-PL kind:30350 lease with a quota-1
+    deployment-identity profile (block/buzz#5667); it does not invent one.
 - silently downgrade inject→notify or submit→prefill
 - scrape ChatGPT through Accessibility
 - run generic `osascript` from prompt text

--- a/internal/acp/worker.go
+++ b/internal/acp/worker.go
@@ -14,16 +14,18 @@ const (
 // PrepareWorkerEnv enforces the Buzz remote-task policy on this process, then
 // strips every BUZZ_* variable so secrets cannot leak into later work.
 //
-// agents must be 1 and inbound must be owner-only. A deployment lease is an
-// upstream Buzz capability; this companion does not treat an env string as one.
+// agents must be 1 and inbound must be owner-only. The gate waits for the
+// harness to hold a Buzz NIP-PL kind:30350 lease with a quota-1
+// deployment-identity profile (block/buzz#5667); this companion does not
+// treat an env string as one.
 func PrepareWorkerEnv() error {
 	agents := strings.TrimSpace(os.Getenv(envBuzzAgents))
 	if agents != "" && agents != "1" {
-		return fmt.Errorf("%s=%s: amq-acp accepts only agents=1 until a deployment lease exists", envBuzzAgents, agents)
+		return fmt.Errorf("%s=%s: amq-acp accepts only agents=1 until the harness holds a Buzz NIP-PL kind:30350 lease with a quota-1 deployment-identity profile (block/buzz#5667)", envBuzzAgents, agents)
 	}
 	respondTo := strings.TrimSpace(os.Getenv(envBuzzRespondTo))
 	if respondTo != "" && respondTo != "owner-only" {
-		return fmt.Errorf("%s=%s: amq-acp accepts only owner-only inbound until a deployment lease exists", envBuzzRespondTo, respondTo)
+		return fmt.Errorf("%s=%s: amq-acp accepts only owner-only inbound until the harness holds a Buzz NIP-PL kind:30350 lease with a quota-1 deployment-identity profile (block/buzz#5667)", envBuzzRespondTo, respondTo)
 	}
 	stripBuzzSecrets()
 	return nil


### PR DESCRIPTION
## Summary

Doc-only change for bead agent-message-queue-1xl. Names the Buzz NIP-PL kind:30350 lease precisely everywhere the `amq-acp` BYOH (bring-your-own-harness) gate is described.

## Context

Buzz ships NIP-PL kind:30350 deployment leases (desktop-v0.5.20: d-tag identity, expiration bounded by `max_lease_ttl`, generation watermark, per-delivery re-check). The remaining gap is a **quota-1 deployment-identity lease profile** being added to RFC §4.2 (block/buzz#5667). The `amq-acp` companion hard-refuses `BUZZ_ACP_AGENTS` other than `1` and `BUZZ_ACP_RESPOND_TO` other than `owner-only`; the gate message and docs previously named the wait condition only as "a deployment lease", leaving the actual mechanism unnamed. The code stays gated until that profile ships.

## Changes
- **`internal/acp/worker.go`**: `PrepareWorkerEnv` comment + both error strings now name "the harness holds a Buzz NIP-PL kind:30350 lease with a quota-1 deployment-identity profile (block/buzz#5667)".
- **`cmd/amq-acp/README.md`**: BYOH bullet rewritten — same fact + "this companion does not invent a lease, it gates inbound on that lease once the profile ships."
- **`docs/adr-two-host-fleets.md`**: one sub-bullet beside the existing "hold a Buzz nsec inside AMQ" line, pointing at kind:30350 and the issue.
- **`cmd/amq-acp/main.go`**: environment help block had the identical stale phrase — updated to the same lease wording for consistency.

## Test plan
- No test asserts the literal "deployment lease" phrase (workers assert `agents=1` / `owner-only` substrings, which the new error strings preserve). `grep 'deployment lease' *_test.go` → none.
- `go test ./internal/acp/... ./cmd/amq-acp/...` — green.
- `gofmt -l` + `go vet` + `GOOS=linux go vet ./...` — clean.
- Present tense throughout; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
