### PR TITLE
test(cli): re-sign spawned AMQ test binaries for macOS launch constraints

### DIFF
--- a/internal/cli/coop_raw_injection_adversarial_unix_test.go
+++ b/internal/cli/coop_raw_injection_adversarial_unix_test.go
@@ -311,21 +311,11 @@ done
 	if err := os.WriteFile(agentPath, []byte(agentScript), 0o700); err != nil {
 		t.Fatalf("write public coop agent: %v", err)
 	}
-	testBinary, err := os.Executable()
-	if err != nil {
-		t.Fatalf("resolve test binary: %v", err)
-	}
 	// Wake identity validation intentionally requires an executable named amq.
 	// Preserve the compiled package-test entry point while giving the public
 	// subprocess the same executable identity as a shipped binary.
 	amqBinary := filepath.Join(dir, "amq")
-	testData, err := os.ReadFile(testBinary)
-	if err != nil {
-		t.Fatalf("read compiled test binary: %v", err)
-	}
-	if err := os.WriteFile(amqBinary, testData, 0o700); err != nil {
-		t.Fatalf("write hermetic amq binary: %v", err)
-	}
+	copyTestAMQ(t, amqBinary)
 	commandScript := `printf '%s\n' "$$" > "$1"
 shift
 exec "$@"

--- a/internal/cli/cross_project_test.go
+++ b/internal/cli/cross_project_test.go
@@ -581,13 +581,7 @@ func advertisedPeerRepairCommand(t *testing.T, err error) string {
 func executeAdvertisedAMQCommand(t *testing.T, commandText string) {
 	t.Helper()
 	binDir := t.TempDir()
-	helperBinary, absErr := filepath.Abs(os.Args[0])
-	if absErr != nil {
-		t.Fatal(absErr)
-	}
-	if linkErr := os.Symlink(helperBinary, filepath.Join(binDir, "amq")); linkErr != nil {
-		t.Fatal(linkErr)
-	}
+	copyTestAMQ(t, filepath.Join(binDir, "amq"))
 	command := exec.Command("/bin/sh", "-c", commandText)
 	command.Env = append(os.Environ(),
 		cliHelperEnv+"=1",

--- a/internal/cli/doctor_stale_wake_binary_darwin_test.go
+++ b/internal/cli/doctor_stale_wake_binary_darwin_test.go
@@ -71,16 +71,10 @@ func TestDarwinSameVersionPathReplacementCannotReportCurrent(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	testImage, err := os.ReadFile(os.Args[0])
-	if err != nil {
-		t.Fatal(err)
-	}
 	executionPath := filepath.Join(dir, "amq-test")
 	replacementPath := filepath.Join(dir, "amq-replacement")
 	for _, path := range []string{executionPath, replacementPath} {
-		if err := os.WriteFile(path, testImage, 0o700); err != nil {
-			t.Fatal(err)
-		}
+		copyTestAMQ(t, path)
 		old := time.Now().Add(-time.Hour)
 		if err := os.Chtimes(path, old, old); err != nil {
 			t.Fatal(err)

--- a/internal/cli/launch_adoption_smoke_e2e_test.go
+++ b/internal/cli/launch_adoption_smoke_e2e_test.go
@@ -411,11 +411,7 @@ func buildAdoptionSmokeAMQ(t *testing.T) string {
 		t.Fatal(err)
 	}
 	amqBinary := filepath.Join(t.TempDir(), "amq")
-	build := exec.Command("go", "build", "-o", amqBinary, "./cmd/amq")
-	build.Dir = repoRoot
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build real amq: %v\n%s", err, output)
-	}
+	buildTestAMQ(t, repoRoot, amqBinary)
 	return amqBinary
 }
 

--- a/internal/cli/launch_api_e2e_test.go
+++ b/internal/cli/launch_api_e2e_test.go
@@ -209,11 +209,7 @@ func TestV061PrepareV0611ApplyCompatibility(t *testing.T) {
 	}
 	binDir := t.TempDir()
 	currentBinary := filepath.Join(binDir, "amq-v0611")
-	buildCurrent := exec.Command("go", "build", "-o", currentBinary, "./cmd/amq")
-	buildCurrent.Dir = repoRoot
-	if output, err := buildCurrent.CombinedOutput(); err != nil {
-		t.Fatalf("build v0.61.1 contract binary: %v\n%s", err, output)
-	}
+	buildTestAMQ(t, repoRoot, currentBinary)
 	legacyBinary := buildHistoricalLaunchBinary(t, repoRoot, binDir, launchContractV061BaselineCommit)
 
 	fixture := newPublicLaunchE2EFixture(t, binDir, launch.LauncherCommands)
@@ -294,11 +290,7 @@ func buildHistoricalLaunchBinary(t *testing.T, repoRoot, binDir, commit string) 
 		t.Fatalf("extract v0.61.0 contract source: %v\n%s", err, output)
 	}
 	binary := filepath.Join(binDir, "amq-v0610")
-	build := exec.Command("go", "build", "-o", binary, "./cmd/amq")
-	build.Dir = sourceDir
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build v0.61.0 contract binary: %v\n%s", err, output)
-	}
+	buildTestAMQ(t, sourceDir, binary)
 	return binary
 }
 

--- a/internal/cli/launch_tmux_e2e_test.go
+++ b/internal/cli/launch_tmux_e2e_test.go
@@ -32,11 +32,7 @@ func TestTmuxRealBinaryFreshServerRestartResumeLoop(t *testing.T) {
 	}
 	binDir := t.TempDir()
 	amqBinary := filepath.Join(binDir, "amq")
-	build := exec.Command("go", "build", "-o", amqBinary, "./cmd/amq")
-	build.Dir = repo
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build real amq: %v\n%s", err, output)
-	}
+	buildTestAMQ(t, repo, amqBinary)
 
 	project := t.TempDir()
 	canonicalProject, err := filepath.EvalSymlinks(project)
@@ -227,11 +223,7 @@ func TestRunRealAMQJSONParseIgnoresUpdateHintOnStderr(t *testing.T) {
 		t.Fatal(err)
 	}
 	amqBinary := filepath.Join(t.TempDir(), "amq")
-	build := exec.Command("go", "build", "-ldflags", "-X main.version=0.62.1-99-gdeadbeef", "-o", amqBinary, "./cmd/amq")
-	build.Dir = repo
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build real amq: %v\n%s", err, output)
-	}
+	buildTestAMQ(t, repo, amqBinary, "-ldflags", "-X main.version=0.62.1-99-gdeadbeef")
 	home := t.TempDir()
 	cachePayload := []byte(`{"checked_at":"2026-08-17T00:00:00Z","latest_version":"0.63.0"}`)
 	for _, cacheDir := range []string{

--- a/internal/cli/test_binary_darwin_test.go
+++ b/internal/cli/test_binary_darwin_test.go
@@ -1,0 +1,74 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func signTestAMQ(t *testing.T, path string) {
+	t.Helper()
+	codesign, err := exec.LookPath("codesign")
+	if err != nil {
+		t.Fatalf("codesign is required for Darwin AMQ test binaries; install the Xcode command line tools with xcode-select --install: %v", err)
+	}
+	output, err := exec.Command(codesign, "--sign", "-", "--force", path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("codesign test AMQ %s: %v\n%s", path, err, output)
+	}
+	if err := verifyTestAMQ(path); err != nil {
+		t.Fatalf("verify re-signed test AMQ %s: %v", path, err)
+	}
+}
+
+func verifyTestAMQ(path string) error {
+	codesign, err := exec.LookPath("codesign")
+	if err != nil {
+		return fmt.Errorf("find codesign (install the Xcode command line tools with xcode-select --install): %w", err)
+	}
+	output, err := exec.Command(codesign, "--verify", "--strict", path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func TestTestAMQSignatureRejectsTampering(t *testing.T) {
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed := filepath.Join(t.TempDir(), "amq")
+	data, err := os.ReadFile(testBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(signed, data, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	signTestAMQ(t, signed)
+	if err := verifyTestAMQ(signed); err != nil {
+		t.Fatalf("re-signed test AMQ failed verification: %v", err)
+	}
+
+	signedData, err := os.ReadFile(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(signedData) <= 4096 {
+		t.Fatalf("signed test AMQ is too small to tamper safely: %d bytes", len(signedData))
+	}
+	signedData[4096] ^= 1
+	corrupted := filepath.Join(t.TempDir(), "amq-corrupted")
+	if err := os.WriteFile(corrupted, signedData, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyTestAMQ(corrupted); err == nil {
+		t.Fatal("codesign accepted a deliberately corrupted AMQ binary")
+	}
+}

--- a/internal/cli/test_binary_other_test.go
+++ b/internal/cli/test_binary_other_test.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package cli
+
+import "testing"
+
+func signTestAMQ(t *testing.T, path string) {
+	t.Helper()
+}

--- a/internal/cli/test_binary_test.go
+++ b/internal/cli/test_binary_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// buildTestAMQ signs the test copy after Go links it. macOS 26.5 can reject
+// linker-signed ad hoc binaries spawned from a temporary directory with a
+// Launch Constraint violation; installed AMQ builds are unaffected.
+func buildTestAMQ(t *testing.T, repoRoot, destination string, buildArgs ...string) {
+	t.Helper()
+	args := make([]string, 0, len(buildArgs)+4)
+	args = append(args, "build")
+	args = append(args, buildArgs...)
+	args = append(args, "-o", destination, "./cmd/amq")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("build test amq timed out: %v\n%s", ctx.Err(), output)
+	}
+	if err != nil {
+		t.Fatalf("build test amq: %v\n%s", err, output)
+	}
+	signTestAMQ(t, destination)
+}
+
+func copyTestAMQ(t *testing.T, destination string) {
+	t.Helper()
+	source, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read test binary: %v", err)
+	}
+	if err := os.WriteFile(destination, data, 0o700); err != nil {
+		t.Fatalf("write test amq: %v", err)
+	}
+	signTestAMQ(t, destination)
+}

--- a/internal/cli/wake_brew_upgrade_two_binary_e2e_darwin_test.go
+++ b/internal/cli/wake_brew_upgrade_two_binary_e2e_darwin_test.go
@@ -224,12 +224,8 @@ func buildRepoAMQForTest(t *testing.T, sourceDir, dest, version string) {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("go", "build", "-ldflags", "-X main.version="+version, "-o", dest, "./cmd/amq")
-	cmd.Dir = sourceDir
-	cmd.Env = wakeABICleanEnv()
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("build %s: %v\n%s", dest, err, output)
-	}
+	// AMQ_* variables do not affect go build; keep the inherited build environment.
+	buildTestAMQ(t, sourceDir, dest, "-ldflags", "-X main.version="+version)
 }
 
 func buildCommitAMQForTest(t *testing.T, repoRoot, commit, dest, version string) {

--- a/internal/cli/wake_owner_mixed_version_test.go
+++ b/internal/cli/wake_owner_mixed_version_test.go
@@ -50,7 +50,7 @@ func TestOwnerFencePreservesClaimAgainstExactE370Binary(t *testing.T) {
 	)
 	commandOutputForOwnerFence(t, "", "tar", "-xf", archivePath, "-C", sourceRoot)
 	legacyBinary := filepath.Join(buildRoot, "amq-e37067a")
-	commandOutputForOwnerFence(t, sourceRoot, "go", "build", "-o", legacyBinary, "./cmd/amq")
+	buildTestAMQ(t, sourceRoot, legacyBinary)
 
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -638,7 +638,7 @@ func buildHistoricalAMQForWakeStateTest(t *testing.T, commit string) string {
 	commandOutputForOwnerFence(t, repoRoot, "git", "archive", "--format=tar", "--output="+archivePath, commit)
 	commandOutputForOwnerFence(t, "", "tar", "-xf", archivePath, "-C", sourceRoot)
 	binary := filepath.Join(buildRoot, "amq-legacy-state-writer")
-	commandOutputForOwnerFence(t, sourceRoot, "go", "build", "-o", binary, "./cmd/amq")
+	buildTestAMQ(t, sourceRoot, binary)
 	return binary
 }
 

--- a/internal/cli/wake_p0_golden_abi_unix_test.go
+++ b/internal/cli/wake_p0_golden_abi_unix_test.go
@@ -50,18 +50,7 @@ func buildWakeABIBinary(t *testing.T) (string, string) {
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", ".."))
 
 	binary := filepath.Join(t.TempDir(), "amq")
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "go", "build", "-o", binary, "./cmd/amq")
-	cmd.Dir = repoRoot
-	cmd.Env = wakeABICleanEnv()
-	output, err := cmd.CombinedOutput()
-	if ctx.Err() != nil {
-		t.Fatalf("build amq timed out: %v\n%s", ctx.Err(), output)
-	}
-	if err != nil {
-		t.Fatalf("build amq: %v\n%s", err, output)
-	}
+	buildTestAMQ(t, repoRoot, binary)
 	return binary, repoRoot
 }
 

--- a/internal/cli/wake_repair_continuity_unix_test.go
+++ b/internal/cli/wake_repair_continuity_unix_test.go
@@ -175,14 +175,8 @@ func stopWakeContinuityHelper(pid int, helper, root, me string) bool {
 
 func copyTestBinaryForWakeContinuity(t *testing.T) string {
 	t.Helper()
-	data, err := os.ReadFile(os.Args[0])
-	if err != nil {
-		t.Fatalf("read test binary: %v", err)
-	}
 	path := filepath.Join(secureTempDirForTest(t), "amq")
-	if err := os.WriteFile(path, data, 0o700); err != nil {
-		t.Fatalf("write test helper: %v", err)
-	}
+	copyTestAMQ(t, path)
 	return path
 }
 

--- a/internal/cli/wake_restart_darwin_test.go
+++ b/internal/cli/wake_restart_darwin_test.go
@@ -60,19 +60,9 @@ func TestDarwinStagedWakeImageCTimeExceptionDoesNotWeakenIdentityOrContent(t *te
 }
 
 func TestDarwinWakeRestartBindingSurvivesPublicPathSwapAndCleansStage(t *testing.T) {
-	testBinary, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	binaryA, err := os.ReadFile(testBinary)
-	if err != nil {
-		t.Fatal(err)
-	}
 	dir := t.TempDir()
 	publicPath := filepath.Join(dir, "amq")
-	if err := os.WriteFile(publicPath, binaryA, 0o700); err != nil {
-		t.Fatal(err)
-	}
+	copyTestAMQ(t, publicPath)
 	candidate, err := captureWakeImageEvidence(publicPath, "bound-swap-test")
 	if err != nil {
 		t.Fatal(err)
@@ -96,13 +86,8 @@ func TestDarwinWakeRestartBindingSurvivesPublicPathSwapAndCleansStage(t *testing
 	stagePath := bound.executionPath
 	stageDir := filepath.Dir(stagePath)
 
-	binaryB, err := os.ReadFile("/usr/bin/false")
-	if err != nil {
-		_ = bound.close()
-		t.Fatal(err)
-	}
 	replacement := filepath.Join(dir, "amq.replacement")
-	if err := os.WriteFile(replacement, binaryB, 0o700); err != nil {
+	if err := os.Symlink("/usr/bin/false", replacement); err != nil {
 		_ = bound.close()
 		t.Fatal(err)
 	}
@@ -248,19 +233,9 @@ func TestDarwinWakeRestartRealPTYPreservesPIDAndUnreadWork(t *testing.T) {
 // ctime-only difference on the same inode is not an image change, so both binds
 // succeed and both bound evidences pass sameRequestedAndBoundWakeImageEvidence.
 func TestDarwinWakeRestartTwoBindersShareOneCandidateInode(t *testing.T) {
-	testBinary, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	binaryBytes, err := os.ReadFile(testBinary)
-	if err != nil {
-		t.Fatal(err)
-	}
 	dir := t.TempDir()
 	candidatePath := filepath.Join(dir, "amq")
-	if err := os.WriteFile(candidatePath, binaryBytes, 0o700); err != nil {
-		t.Fatal(err)
-	}
+	copyTestAMQ(t, candidatePath)
 	candidate, err := captureWakeImageEvidence(candidatePath, "two-binder-test")
 	if err != nil {
 		t.Fatal(err)
@@ -309,19 +284,9 @@ func TestDarwinWakeRestartTwoBindersShareOneCandidateInode(t *testing.T) {
 }
 
 func TestDarwinWakeRestartBindFailsWhenCandidateReplacedDuringLink(t *testing.T) {
-	testBinary, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	binaryBytes, err := os.ReadFile(testBinary)
-	if err != nil {
-		t.Fatal(err)
-	}
 	dir := t.TempDir()
 	candidatePath := filepath.Join(dir, "amq")
-	if err := os.WriteFile(candidatePath, binaryBytes, 0o700); err != nil {
-		t.Fatal(err)
-	}
+	copyTestAMQ(t, candidatePath)
 	candidate, err := captureWakeImageEvidence(candidatePath, "replaced-inode-test")
 	if err != nil {
 		t.Fatal(err)
@@ -335,6 +300,10 @@ func TestDarwinWakeRestartBindFailsWhenCandidateReplacedDuringLink(t *testing.T)
 		if !replaced {
 			replaced = true
 			next := filepath.Join(dir, "amq.next")
+			binaryBytes, err := os.ReadFile(candidatePath)
+			if err != nil {
+				return err
+			}
 			if err := os.WriteFile(next, append(binaryBytes, []byte("mutated")...), 0o700); err != nil {
 				return err
 			}
@@ -555,18 +524,8 @@ func TestDarwinWakeSelfUpgradeDefersHashTimeCTimeThenBindsOnRetry(t *testing.T) 
 
 func writeWakeRestartLoopCandidateCopy(t *testing.T, fixture *wakeRestartFixture) string {
 	t.Helper()
-	exe, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	binary, err := os.ReadFile(exe)
-	if err != nil {
-		t.Fatal(err)
-	}
 	path := filepath.Join(t.TempDir(), "amq")
-	if err := os.WriteFile(path, binary, 0o700); err != nil {
-		t.Fatal(err)
-	}
+	copyTestAMQ(t, path)
 	candidate, err := captureWakeImageEvidence(path, fixture.candidate.EmbeddedVersion)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/wake_restart_e2e_unix_test.go
+++ b/internal/cli/wake_restart_e2e_unix_test.go
@@ -3,7 +3,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -19,24 +18,7 @@ func buildVersionedWakeRestartBinary(
 	repoRoot, destination, version string,
 ) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-	cmd := exec.CommandContext(
-		ctx,
-		"go", "build",
-		"-ldflags", "-X main.version="+version,
-		"-o", destination,
-		"./cmd/amq",
-	)
-	cmd.Dir = repoRoot
-	cmd.Env = wakeABICleanEnv()
-	output, err := cmd.CombinedOutput()
-	if ctx.Err() != nil {
-		t.Fatalf("build %s timed out: %v\n%s", version, ctx.Err(), output)
-	}
-	if err != nil {
-		t.Fatalf("build %s: %v\n%s", version, err, output)
-	}
+	buildTestAMQ(t, repoRoot, destination, "-ldflags", "-X main.version="+version)
 }
 
 func runWakeRestartPTYCommand(t *testing.T, binary string, args ...string) string {

--- a/internal/cli/wake_restart_linux_test.go
+++ b/internal/cli/wake_restart_linux_test.go
@@ -37,17 +37,11 @@ func TestLinuxWakeRestartBoundExecHelper(t *testing.T) {
 }
 
 func TestLinuxWakeRestartBindingSurvivesPublicPathSwap(t *testing.T) {
-	testBinary, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	binaryA, err := os.ReadFile(testBinary)
-	if err != nil {
-		t.Fatal(err)
-	}
 	dir := t.TempDir()
 	publicPath := filepath.Join(dir, "amq")
-	if err := os.WriteFile(publicPath, binaryA, 0o700); err != nil {
+	copyTestAMQ(t, publicPath)
+	testBinary, err := os.Executable()
+	if err != nil {
 		t.Fatal(err)
 	}
 	candidate, err := captureWakeImageEvidence(publicPath, "bound-swap-test")

--- a/internal/cli/wake_restart_stage_darwin_test.go
+++ b/internal/cli/wake_restart_stage_darwin_test.go
@@ -26,18 +26,8 @@ func newDarwinWakeRestartStageRecordForRootTest(t *testing.T, root, agent string
 	if os.Getenv("AMQ_TEST_DARWIN_WAKE_STAGE_STATE") == "" {
 		setDarwinWakeRestartStateHomeForTest(t, t.TempDir())
 	}
-	testBinary, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	raw, err := os.ReadFile(testBinary)
-	if err != nil {
-		t.Fatal(err)
-	}
 	path := filepath.Join(t.TempDir(), "amq")
-	if err := os.WriteFile(path, raw, 0o700); err != nil {
-		t.Fatal(err)
-	}
+	copyTestAMQ(t, path)
 	candidate, err := captureWakeImageEvidence(path, "stage-reclaim-test")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/wake_self_upgrade_bound_unix_test.go
+++ b/internal/cli/wake_self_upgrade_bound_unix_test.go
@@ -202,6 +202,7 @@ func main() {
 	if err != nil {
 		t.Fatalf("build bound probe helper: %v\n%s", err, output)
 	}
+	signTestAMQ(t, binary)
 	if err := os.Chmod(binary, 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/wake_self_upgrade_broken_unix_test.go
+++ b/internal/cli/wake_self_upgrade_broken_unix_test.go
@@ -142,6 +142,7 @@ func main() {
 	if err != nil {
 		t.Fatalf("build broken candidate: %v\n%s", err, output)
 	}
+	signTestAMQ(t, binary)
 	if err := os.Chmod(binary, 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/wake_test.go
+++ b/internal/cli/wake_test.go
@@ -222,14 +222,8 @@ func injectViaCaptureConfig(t *testing.T, fixedArgs ...string) (*wakeConfig, str
 func copyTestBinaryForInjectVia(t *testing.T) string {
 	t.Helper()
 
-	data, err := os.ReadFile(os.Args[0])
-	if err != nil {
-		t.Fatalf("read test binary: %v", err)
-	}
 	path := filepath.Join(secureTempDirForTest(t), "inject-via-helper")
-	if err := os.WriteFile(path, data, 0o700); err != nil {
-		t.Fatalf("write inject-via helper: %v", err)
-	}
+	copyTestAMQ(t, path)
 	return path
 }
 


### PR DESCRIPTION
Refs bead: agent-message-queue-2ap

## Diagnosis
Go-linked ad hoc test binaries launched from temporary directories can hit macOS 26.5 Launch Constraint Violation / Code Signature Invalid (SIGKILL). Installed AMQ builds are unaffected. The original Darwin runs produced 24 crash reports.

## Change
- Add a Darwin-only helper that force-signs and strictly verifies every built or copied AMQ test child; missing codesign fails with the Xcode command-line tools remedy. Non-Darwin builds are a no-op.
- Route built cmd/amq children in adoption, launch API/tmux, brew, owner mixed-version, P0 ABI, and restart-version tests.
- Route copied amq children in coop raw, cross-project PATH, repair continuity, Darwin/Linux restart, Darwin restart stage, plus the doctor stale-image and inject-via helper children.
- Add a Darwin tamper-negative signature test.

## Verification
- Darwin: go test ./internal/cli -count=1 PASS (218.309s); diagnostic reports remained 29.
- Focused signing, wake self-upgrade, stale-image, and inject-via tests PASS.
- GOOS=linux GOARCH=arm64 and GOOS=windows GOARCH=amd64 test compilation PASS.
- go vet ./... and make check-skills PASS.
- make fmt-check and make lint still report pre-existing findings outside this change.