### PR TITLE
build: make fmt and lint follow the pinned toolchain versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: latest
+          version: v2.13.1
 
   # Native Windows leg for the exclusive drain-claim contract (issue #485).
   # Cross-compilation cannot exercise the bug: os.Root.Rename on Windows is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,9 @@ make ci             # fmt-check, vet, lint, test, smoke checks
 make check-skills   # validate canonical and symlinked skill content
 ```
 
+Formatting and lint use the toolchain pinned in `go.mod` and the golangci-lint
+version in the Makefile; other versions are refused.
+
 Go 1.25+ is required. `golangci-lint` is optional for local development and
 required by `make lint` and `make ci`.
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 # GoReleaser {{.Version}} is bare semver; strip one leading v from VERSION.
 EMBED_VERSION := $(patsubst v%,%,$(VERSION))
 GOLANGCI_LINT_CACHE ?= $(CURDIR)/.golangci-cache
+# Keep this in lockstep with the version pinned in .github/workflows/ci.yml.
+GOLANGCI_LINT_VERSION := 2.13.1
+# Use go.mod's toolchain so direct gofmt does not drift from setup-go.
+GO_TOOLCHAIN := $(shell sed -n 's/^toolchain //p' go.mod)
+GOFMT := $(shell GOTOOLCHAIN=$(GO_TOOLCHAIN) go env GOROOT)/bin/gofmt
 
 build:
 	go build -ldflags "-X main.version=$(EMBED_VERSION)" -o amq ./cmd/amq
@@ -16,16 +21,21 @@ test:
 	go test ./...
 
 fmt:
-	gofmt -w $(GO_FILES)
+	$(GOFMT) -w $(GO_FILES)
 
 fmt-check:
-	@test -z "$(shell gofmt -l $(GO_FILES))"
+	@test -z "$(shell $(GOFMT) -l $(GO_FILES))"
 
 vet:
 	go vet ./...
 
 lint:
 	@command -v golangci-lint >/dev/null 2>&1 || { echo "golangci-lint not installed. Install from https://golangci-lint.run/usage/install/"; exit 1; }
+	@actual="$$(golangci-lint version --short 2>/dev/null || true)"; \
+	if [ "$$actual" != "$(GOLANGCI_LINT_VERSION)" ]; then \
+		echo "golangci-lint $(GOLANGCI_LINT_VERSION) required (found $${actual:-unknown}); install that version from https://golangci-lint.run/usage/install/"; \
+		exit 1; \
+	fi
 	GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" golangci-lint run
 
 # Keep this hostile AMQ context tuple aligned with smoke-test.sh's startup scrub.

--- a/internal/cli/wake_terminate_darwin.go
+++ b/internal/cli/wake_terminate_darwin.go
@@ -63,12 +63,13 @@ func terminateAndRemoveOrphanedWakeLockInDir(
 		return cooperativeStopInjectViaInDir(agentDir, recheck)
 	}
 	if recheck.Process.Running {
-		if err := terminateWakeProcessInDir(agentDir, recheck); err != nil {
-			if !sameConfirmedWakeLockInDir(agentDir, recheck) {
-				return true, nil
-			}
-			return false, err
+		// Darwin raw signaling is operator_only, so terminate* always errors here.
+		// The lock-removal path below is reachable only through the cooperative stop.
+		err := terminateWakeProcessInDir(agentDir, recheck)
+		if !sameConfirmedWakeLockInDir(agentDir, recheck) {
+			return true, nil
 		}
+		return false, err
 	}
 	removed := false
 	err := withWakeLifecycleGuardInDir(agentDir, func(dirfd int) error {
@@ -136,9 +137,9 @@ func terminateAndRemoveOrphanedWakeLockWithRawConsent(
 	}
 	// Process termination can wait. It must happen after releasing the guard.
 	if recheck.Process.Running {
-		if err := terminateWakeProcess(recheck); err != nil {
-			return resolveMissingWakeLockAfterTermination(recheck, err)
-		}
+		// Darwin raw signaling is operator_only, so terminate* always errors here.
+		// The lock-removal path below is reachable only through the cooperative stop.
+		return resolveMissingWakeLockAfterTermination(recheck, terminateWakeProcess(recheck))
 	}
 	removed := false
 	err := withWakeLifecycleGuard(inspection.Root, inspection.Agent, func() error {


### PR DESCRIPTION
## Drift cause
The local PATH `gofmt` was Go 1.27 while CI followed the Go 1.26.6 `toolchain` directive in `go.mod`, so local format results diverged.

## Changes
- Make `fmt` and `fmt-check` resolve `gofmt` from the `go.mod` toolchain.
- Pin golangci-lint to v2.13.1 in the Makefile and CI action, with a local version check and install remedy.
- Remove two Darwin SA4023 dead error branches; raw signaling is always `operator_only`, so the rewrites preserve behavior and retain the cooperative-stop path.
- Document the local/CI tool version contract.

## Verification
- `GOTOOLCHAIN=go1.26.6 GOLANGCI_LINT_CACHE=/tmp/amq-5ks-ci-cache-pinned-20260826 make ci`
- `make fmt-check` with PATH gofmt 1.27
- `make lint` with golangci-lint 2.13.1

Refs bead `5ks`.