### PR TITLE
feat(launch): honor project-root authority and adopt squad argv grammar

### DIFF
--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -105,7 +105,18 @@ the executable can be planned or ticketed.
 
 The intent owns the desired participants. Discovery owns the project root,
 default session, session root, and local launcher preference. A public intent
-does not replace committed project configuration.
+does not replace committed project configuration. `amq setup --project-root
+<dir>` overrides discovery: the named directory, with parent components
+canonicalized, is the project root, `.amqrc`, `.amq/launch.json`, and
+`.gitignore` are written there, and upward base discovery does not redirect
+writes into a parent repo's live base root. A symlinked leaf is refused; a
+symlinked parent component is canonicalized (followed). An existing
+`.amq/launch.json` in cwd is authority without the flag, so a nested
+directory that already owns its config is the project root. A parent `.amqrc`
+found above an explicit project root (or a cwd that owns its config) is
+ignored, not adopted, so the parent tree stays byte-identical; the implicit
+case still refuses an upward-discovered parent `.amqrc` with the parent path
+named.
 
 ```json
 {
@@ -309,10 +320,24 @@ The equivalent CLI split is:
 ```bash
 amq launch --plan intent.json --prepare --json --launcher commands
 amq launch --apply apply-request.json --json
+amq launch --request prepare-request.json --json
 ```
 
-Both commands accept `-` for standard input. The Apply document contains the
-complete target and launcher, so `--session`, `--root`, and `--launcher` are not
-valid with `--apply`. Exit code `6` means the JSON result requires an operator
+All three commands accept `-` for standard input. `--plan` is the intent-only
+convenience: discovery resolves the target (project root, default session,
+session root, and local launcher preference) from the committed project
+config, and `--plan` carries only the `LaunchIntentV1`. `--apply` and
+`--request` carry the complete target and launcher in the document itself, so
+`--session`, `--root`, `--launcher`, and `--placement` are not valid with
+either. `--request` decodes a full `PrepareRequestV1` (including
+`target.base_root` and `caller_context`) through `DecodePrepareRequestV1` and
+runs the same Prepare/Apply path as `--plan`; it is mutually exclusive with
+`--plan`, `--apply`, and `--placement`. `--prepare` pairs with `--plan` or
+`--request` to run prepare-only with no mutation, so a consumer can read the
+subject digest before Apply. With `--request`, the CLI and the Go package
+share one contract: every field a package caller can set on
+`PrepareRequestV1` is reachable from the CLI.
+`--plan` remains the intent-only convenience for callers that rely on
+committed discovery. Exit code `6` means the JSON result requires an operator
 action. JSON on stdout remains the machine contract; stderr is for people and
 must not be parsed.

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -60,6 +60,7 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 	prepareFlag := fs.Bool("prepare", false, "Prepare the public launch intent without mutation (requires --plan and --json)")
 	applyFlag := fs.String("apply", "", "Public ApplyRequestV1 file, or - for stdin (requires --json)")
 	placementFlag := fs.String("placement", "", "Public PlacementV1 JSON object (with --plan)")
+	requestFlag := fs.String("request", "", "Public PrepareRequestV1 file, or - for stdin (requires --json)")
 	usageName := "amq launch [options]"
 	if options.resumeOnly {
 		usageName = "amq session resume <name> [options]"
@@ -72,16 +73,16 @@ func runLaunchEngine(args []string, options launchCLIOptions) error {
 	} else if handled {
 		return nil
 	}
-	publicMode := flagWasVisited(fs, "plan") || flagWasVisited(fs, "prepare") || flagWasVisited(fs, "apply") || flagWasVisited(fs, "placement")
+	publicMode := flagWasVisited(fs, "plan") || flagWasVisited(fs, "prepare") || flagWasVisited(fs, "apply") || flagWasVisited(fs, "placement") || flagWasVisited(fs, "request")
 	if publicMode {
 		if options.resumeOnly {
-			return UsageError("session resume does not accept --plan, --prepare, or --apply")
+			return UsageError("session resume does not accept --plan, --prepare, --apply, or --request")
 		}
 		if flagWasVisited(fs, "fresh") || flagWasVisited(fs, "allow-fresh-fallback") ||
 			flagWasVisited(fs, "rebind") || flagWasVisited(fs, "require-agent") {
-			return UsageError("--plan, --prepare, and --apply do not accept legacy launch decision flags")
+			return UsageError("--plan, --prepare, --apply, and --request do not accept legacy launch decision flags")
 		}
-		return runPublicLaunch(common, *sessionFlag, *launcherFlag, *planFlag, *prepareFlag, *applyFlag, *placementFlag, fs)
+		return runPublicLaunch(common, *sessionFlag, *launcherFlag, *planFlag, *prepareFlag, *applyFlag, *placementFlag, *requestFlag, fs)
 	}
 	if *freshFlag && *allowFreshFlag {
 		return UsageError("--fresh and --allow-fresh-fallback are mutually exclusive")

--- a/internal/cli/launch_public_api.go
+++ b/internal/cli/launch_public_api.go
@@ -13,19 +13,32 @@ import (
 	"github.com/avivsinai/agent-message-queue/launchapi"
 )
 
-func runPublicLaunch(common *commonFlags, session, launcher, planSource string, prepareOnly bool, applySource, placementJSON string, fs *flag.FlagSet) error {
+func runPublicLaunch(common *commonFlags, session, launcher, planSource string, prepareOnly bool, applySource, placementJSON, requestSource string, fs *flag.FlagSet) error {
 	planExplicit, applyExplicit := flagWasVisited(fs, "plan"), flagWasVisited(fs, "apply")
+	requestExplicit := flagWasVisited(fs, "request")
 	if prepareOnly && !common.JSON {
 		return UsageError("--prepare requires --json")
 	}
 	if applyExplicit && !common.JSON {
 		return UsageError("--apply requires --json")
 	}
+	if requestExplicit && !common.JSON {
+		return UsageError("--request requires --json")
+	}
 	if applyExplicit && (planExplicit || prepareOnly) {
 		return UsageError("--apply is mutually exclusive with --plan and --prepare")
 	}
-	if prepareOnly && !planExplicit {
-		return UsageError("--prepare requires --plan")
+	if requestExplicit && (planExplicit || applyExplicit) {
+		return UsageError("--request is mutually exclusive with --plan and --apply")
+	}
+	if requestExplicit && flagWasVisited(fs, "placement") {
+		return UsageError("--request is mutually exclusive with --placement")
+	}
+	if requestExplicit && (flagWasVisited(fs, "session") || flagWasVisited(fs, "launcher") || common.rootExplicit()) {
+		return UsageError("--request takes its target and launcher from PrepareRequestV1")
+	}
+	if prepareOnly && !planExplicit && !requestExplicit {
+		return UsageError("--prepare requires --plan or --request")
 	}
 	if applyExplicit && (flagWasVisited(fs, "session") || flagWasVisited(fs, "launcher") || common.rootExplicit()) {
 		return UsageError("--apply takes its target and launcher from ApplyRequestV1")
@@ -44,6 +57,9 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 	}
 	if applyExplicit && strings.TrimSpace(applySource) == "" {
 		return UsageError("--apply must name a file or -")
+	}
+	if requestExplicit && strings.TrimSpace(requestSource) == "" {
+		return UsageError("--request must name a file or -")
 	}
 
 	ctx := context.Background()
@@ -64,6 +80,18 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 			return err
 		}
 		return publicApplyExit(result)
+	}
+
+	if requestExplicit {
+		data, err := readLaunchAPIDocument(requestSource)
+		if err != nil {
+			return err
+		}
+		prepareRequest, err := launchapi.DecodePrepareRequestV1(data)
+		if err != nil {
+			return UsageError("%v", err)
+		}
+		return runPublicPrepareThenApply(ctx, prepareRequest, prepareOnly)
 	}
 
 	target, err := resolvePublicLaunchTarget(common, session)
@@ -91,6 +119,19 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 		}
 		request.Placement = placement
 	}
+	return runPublicPrepareThenApply(ctx, request, prepareOnly)
+}
+
+func outputPublicLaunchResult(result any) error {
+	return launchapi.EncodeResultV1(os.Stdout, result)
+}
+
+// runPublicPrepareThenApply runs the shared Prepare (and, unless prepareOnly,
+// Apply) flow for a PrepareRequestV1. The --plan and --request paths both
+// decode their document into a PrepareRequestV1 and delegate here, so the
+// outcome handling, action-required mapping, and Apply construction live in
+// one place. With prepareOnly, the result is emitted with no mutation.
+func runPublicPrepareThenApply(ctx context.Context, request launchapi.PrepareRequestV1, prepareOnly bool) error {
 	prepared, err := launchapi.Prepare(ctx, request)
 	if err != nil {
 		return err
@@ -121,10 +162,6 @@ func runPublicLaunch(common *commonFlags, session, launcher, planSource string, 
 		return err
 	}
 	return publicApplyExit(result)
-}
-
-func outputPublicLaunchResult(result any) error {
-	return launchapi.EncodeResultV1(os.Stdout, result)
 }
 
 func resolvePublicLaunchTarget(common *commonFlags, session string) (launchapi.TargetV1, error) {

--- a/internal/cli/launch_public_api_test.go
+++ b/internal/cli/launch_public_api_test.go
@@ -167,6 +167,166 @@ func TestPublicLaunchPlanAppliesWithEmptyDecisionsWhenReady(t *testing.T) {
 	}
 }
 
+func TestPublicLaunchRequestRunsPrepareApplyFromFullRequest(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	// Resolve macOS /var -> /private/var symlinks: openPrepareTarget requires
+	// target.project_root to be canonical when base_root is set.
+	resolvedProject, err := filepath.EvalSymlinks(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project = resolvedProject
+	// Authorize a profile base root under the project's configured root so the
+	// request's target.base_root flows through Prepare/Apply exactly as the
+	// package path does (issue #648 item 1(b)).
+	configuredRoot := filepath.Join(project, defaultCoopRoot)
+	profileRoot := filepath.Join(configuredRoot, "profile-a")
+	sessionRoot := filepath.Join(profileRoot, "collab")
+	amqrc, err := json.Marshal(map[string]string{"root": configuredRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), append(amqrc, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	request := launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target: launchapi.TargetV1{
+			ProjectRoot: project,
+			BaseRoot:    profileRoot,
+			SessionRoot: sessionRoot,
+			Session:     "collab",
+		},
+		Launcher: "commands",
+		CallerContext: map[string]string{
+			"run_id": "run-42", "task_generation": "3",
+		},
+		Intent: launchapi.LaunchIntentV1{IntentVersion: launchapi.IntentVersionV1, Participants: []launchapi.ParticipantV1{{
+			Handle: "operator", Runnable: false,
+		}}},
+	}
+	data, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "prepare.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The pre-existing session root under the configured root is the parent
+	// base; the profile base root must be created fresh and leave the parent
+	// untouched.
+	parentSessionRoot := filepath.Join(configuredRoot, "collab")
+	parentBefore := strings.Join(snapshotTree(t, parentSessionRoot), "\n")
+
+	stdout, _, cliErr := captureEnvOutput(t, func() error { return runLaunch([]string{"--request", path, "--json"}) })
+	if cliErr != nil {
+		t.Fatalf("CLI --request: %v\n%s", cliErr, stdout)
+	}
+	var result launchapi.ApplyResultV1
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "provisioned_no_runnable" || result.SemanticDigest != result.TrustDigest || len(result.Roster.Desired) != 1 || result.Roster.Desired[0] != "operator" {
+		t.Fatalf("CLI --request result = %#v", result)
+	}
+	// The session lands under the nested profile base root.
+	if _, statErr := os.Stat(filepath.Join(sessionRoot, "agents", "operator")); statErr != nil {
+		t.Fatalf("--request did not create the nested session: %v", statErr)
+	}
+	// The parent base root session is byte-for-byte unchanged.
+	if after := strings.Join(snapshotTree(t, parentSessionRoot), "\n"); after != parentBefore {
+		t.Fatalf("--request changed the parent session root\nbefore:\n%s\nafter:\n%s", parentBefore, after)
+	}
+}
+
+func TestPublicLaunchRequestRejectsPrepareRequestV1ThroughPlan(t *testing.T) {
+	launchCLIFixture(t, "collab")
+	// A full PrepareRequestV1 (with request_version) fed to --plan must still
+	// reject with the unknown-field error the issue cites, confirming --request
+	// is the path that owns the full request and --plan stays intent-only.
+	request := launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target:         launchapi.TargetV1{ProjectRoot: "/tmp/project", SessionRoot: "/tmp/project/.agent-mail/collab", Session: "collab"},
+		Launcher:       "commands",
+		Intent:         launchapi.LaunchIntentV1{IntentVersion: launchapi.IntentVersionV1, Participants: []launchapi.ParticipantV1{{Handle: "operator", Runnable: false}}},
+	}
+	data, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "prepare.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = runLaunch([]string{"--plan", path, "--prepare", "--json"})
+	if GetExitCode(err) != ExitUsage || !strings.Contains(err.Error(), "request_version") {
+		t.Fatalf("--plan on a PrepareRequestV1 error = %v (exit=%d), want usage mentioning request_version", err, GetExitCode(err))
+	}
+}
+
+// TestPublicLaunchRequestPrepareOnlyPerformsNoMutation covers issue #648 item
+// 1(b) + review R3: --request combined with --prepare runs prepare-only, so a
+// consumer can read the subject digest before Apply. The PrepareResultV1 is
+// emitted and the nested session is NOT created (no mutation).
+func TestPublicLaunchRequestPrepareOnlyPerformsNoMutation(t *testing.T) {
+	project, _ := launchCLIFixture(t, "collab")
+	resolvedProject, err := filepath.EvalSymlinks(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project = resolvedProject
+	configuredRoot := filepath.Join(project, defaultCoopRoot)
+	profileRoot := filepath.Join(configuredRoot, "profile-b")
+	sessionRoot := filepath.Join(profileRoot, "collab")
+	amqrc, err := json.Marshal(map[string]string{"root": configuredRoot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), append(amqrc, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	request := launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target: launchapi.TargetV1{
+			ProjectRoot: project,
+			BaseRoot:    profileRoot,
+			SessionRoot: sessionRoot,
+			Session:     "collab",
+		},
+		Launcher: "commands",
+		Intent: launchapi.LaunchIntentV1{IntentVersion: launchapi.IntentVersionV1, Participants: []launchapi.ParticipantV1{{
+			Handle: "operator", Runnable: false,
+		}}},
+	}
+	data, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "prepare.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, cliErr := captureEnvOutput(t, func() error { return runLaunch([]string{"--request", path, "--prepare", "--json"}) })
+	if cliErr != nil {
+		t.Fatalf("CLI --request --prepare: %v\n%s", cliErr, stdout)
+	}
+	var result launchapi.PrepareResultV1
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("--request --prepare must emit a PrepareResultV1: %v\n%s", err, stdout)
+	}
+	if result.Outcome != launchapi.PrepareOutcomeReady {
+		t.Fatalf("--request --prepare outcome = %v, want %s", result.Outcome, launchapi.PrepareOutcomeReady)
+	}
+	if result.SubjectDigest == "" {
+		t.Fatal("--request --prepare did not surface a subject digest")
+	}
+	// Prepare-only performs no mutation: the nested session is not created.
+	if _, statErr := os.Stat(filepath.Join(sessionRoot, "agents", "operator")); !os.IsNotExist(statErr) {
+		t.Fatalf("--request --prepare mutated the session root: %v", statErr)
+	}
+}
+
 func TestPublicLaunchModeFlagRefusals(t *testing.T) {
 	launchCLIFixture(t, "collab")
 	for _, test := range []struct {
@@ -174,7 +334,7 @@ func TestPublicLaunchModeFlagRefusals(t *testing.T) {
 		args []string
 		want string
 	}{
-		{name: "prepare without plan", args: []string{"--prepare", "--json"}, want: "--prepare requires --plan"},
+		{name: "prepare without plan", args: []string{"--prepare", "--json"}, want: "--prepare requires --plan or --request"},
 		{name: "prepare without json", args: []string{"--plan", "intent.json", "--prepare"}, want: "--prepare requires --json"},
 		{name: "apply without json", args: []string{"--apply", "apply.json"}, want: "--apply requires --json"},
 		{name: "mixed apply and plan", args: []string{"--apply", "apply.json", "--plan", "intent.json", "--json"}, want: "mutually exclusive"},
@@ -190,6 +350,12 @@ func TestPublicLaunchModeFlagRefusals(t *testing.T) {
 		{name: "apply with placement flag", args: []string{"--apply", "apply.json", "--json", "--placement", `{"target":"session","layout":"columns"}`}, want: "takes placement"},
 		{name: "empty placement", args: []string{"--plan", "intent.json", "--prepare", "--json", "--placement", ""}, want: "--placement must be a PlacementV1 JSON object"},
 		{name: "whitespace placement", args: []string{"--plan", "intent.json", "--prepare", "--json", "--placement", " \t"}, want: "--placement must be a PlacementV1 JSON object"},
+		{name: "request without json", args: []string{"--request", "prepare.json"}, want: "--request requires --json"},
+		{name: "request with plan", args: []string{"--request", "prepare.json", "--plan", "intent.json", "--json"}, want: "mutually exclusive"},
+		{name: "request with apply", args: []string{"--request", "prepare.json", "--apply", "apply.json", "--json"}, want: "mutually exclusive"},
+		{name: "request with placement", args: []string{"--request", "prepare.json", "--json", "--placement", `{"target":"session","layout":"columns"}`}, want: "mutually exclusive"},
+		{name: "request target override", args: []string{"--request", "prepare.json", "--session", "collab", "--json"}, want: "takes its target"},
+		{name: "request launcher override", args: []string{"--request", "prepare.json", "--launcher", "commands", "--json"}, want: "takes its target"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := runLaunch(test.args)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -135,6 +135,7 @@ func runSetup(args []string) (returnErr error) {
 	applyFlag := fs.String("apply", "", "Apply only when the recomputed preview matches this digest")
 	yesFlag := fs.Bool("y", false, "Accept the preview without prompting")
 	jsonFlag := fs.Bool("json", false, "Emit JSON output")
+	projectRootFlag := fs.String("project-root", "", "Directory treated as the project root (writes .amqrc, .amq, and .gitignore there)")
 	usage := usageWithFlags(fs, "amq setup [options]",
 		"Configure this project after previewing every change.",
 		"Detects Claude, Codex, Cursor, and Grok through their adapter capability probes.",
@@ -167,20 +168,40 @@ func runSetup(args []string) (returnErr error) {
 	if *layoutFlag != launch.LayoutColumns {
 		return UsageError("unsupported --layout %q", *layoutFlag)
 	}
+	projectRootExplicit := flagWasVisited(fs, "project-root")
+	if projectRootExplicit && strings.TrimSpace(*projectRootFlag) == "" {
+		return UsageError("--project-root must not be blank")
+	}
 
 	originalCWD, err := os.Getwd()
 	if err != nil {
 		return err
 	}
+	// An existing explicit project config in cwd is authority: a nested
+	// directory that already owns .amq/launch.json is the project root without
+	// --project-root, so upward base discovery cannot redirect writes into a
+	// parent repo's live base root.
+	cwdOwnsProjectConfig := projectConfigExistsInDir(originalCWD)
 	projectRoot := originalCWD
-	if top, worktree := gitWorktreeTopFromCWD(); worktree {
-		projectRoot = top
-	} else if boundary, insideGit := gitWorktreeRootFromCWD(); insideGit {
-		return noEligibleRootInGitError(boundary)
+	if projectRootExplicit {
+		resolved, resolveErr := resolveSetupProjectRoot(*projectRootFlag, originalCWD)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		projectRoot = resolved
+	} else if !cwdOwnsProjectConfig {
+		// Without an explicit root or a local config, preserve the v0.61
+		// behavior: a Git worktree top is the project root, and a plain Git
+		// repo without a worktree refuses.
+		if top, worktree := gitWorktreeTopFromCWD(); worktree {
+			projectRoot = top
+		} else if boundary, insideGit := gitWorktreeRootFromCWD(); insideGit {
+			return noEligibleRootInGitError(boundary)
+		}
 	}
 	if !sameTreeIdentity(originalCWD, projectRoot) {
 		if err := os.Chdir(projectRoot); err != nil {
-			return fmt.Errorf("enter Git worktree top %q: %w", projectRoot, err)
+			return fmt.Errorf("enter project root %q: %w", projectRoot, err)
 		}
 		resetAmqrcCache()
 		defer func() {
@@ -196,8 +217,8 @@ func runSetup(args []string) (returnErr error) {
 		input = bufio.NewReader(os.Stdin)
 	}
 	state, err := buildSetupState(setupOptions{
-		projectRoot: projectRoot,
-		root:        *rootFlag, rootExplicit: flagWasVisited(fs, "root"),
+		projectRoot: projectRoot, projectRootExplicit: projectRootExplicit || cwdOwnsProjectConfig,
+		root: *rootFlag, rootExplicit: flagWasVisited(fs, "root"),
 		agents: *agentsFlag, agentsExplicit: flagWasVisited(fs, "agents"),
 		defaultSession: *sessionFlag, sessionExplicit: flagWasVisited(fs, "default-session"),
 		launchers: *launchersFlag, launchersExplicit: flagWasVisited(fs, "launcher-preference"),
@@ -257,6 +278,7 @@ type setupOptions struct {
 	launchers, layout                  string
 	rootExplicit, agentsExplicit       bool
 	sessionExplicit, launchersExplicit bool
+	projectRootExplicit                bool
 	noGitignore, nonInteractive        bool
 	input                              *bufio.Reader
 }
@@ -278,7 +300,7 @@ func buildSetupState(options setupOptions) (setupState, error) {
 		return setupState{}, UsageError("first non-interactive setup requires explicit --agents, --default-session, and --launcher-preference")
 	}
 
-	root, amqrcData, amqrcExists, err := setupRoot(options.root, options.rootExplicit, options.projectRoot)
+	root, amqrcData, amqrcExists, err := setupRoot(options.root, options.rootExplicit, options.projectRoot, options.projectRootExplicit)
 	if err != nil {
 		return setupState{}, err
 	}
@@ -721,27 +743,91 @@ func splitSetupList(raw string) []string {
 	return result
 }
 
-func setupRoot(requested string, explicit bool, projectRoot string) (string, []byte, bool, error) {
+// projectConfigExistsInDir reports whether dir contains the committed
+// project launch config (.amq/launch.json). An existing explicit config is
+// authority: setup treats such a directory as the project root without
+// --project-root, so upward base discovery cannot redirect writes into a
+// parent repo's live base root.
+func projectConfigExistsInDir(dir string) bool {
+	info, err := os.Lstat(filepath.Join(dir, setupConfigPath))
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return false
+	}
+	return true
+}
+
+// resolveSetupProjectRoot resolves a --project-root value to an absolute,
+// real directory. A relative path is interpreted against the original cwd so
+// the flag composes with `cd` in a shell. Parent components are canonicalized
+// with EvalSymlinks (this is what makes /tmp resolve to /private/tmp on macOS,
+// so a symlinked parent is followed, not refused); the leaf directory is then
+// Lstat'd inside the canonical parent and refused if it is itself a symlink,
+// so setup never writes through a link into a directory the operator did not
+// name. The returned path is canonicalParent/leaf.
+func resolveSetupProjectRoot(value, originalCWD string) (string, error) {
+	resolved := strings.TrimSpace(value)
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(originalCWD, resolved)
+	}
+	abs, err := filepath.Abs(filepath.Clean(resolved))
+	if err != nil {
+		return "", fmt.Errorf("resolve --project-root: %w", err)
+	}
+	parent, leaf := filepath.Split(abs)
+	if leaf == "" {
+		return "", UsageError("--project-root %q is not a directory", value)
+	}
+	canonicalParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", UsageError("--project-root %q does not exist", value)
+	}
+	leafPath := filepath.Join(canonicalParent, leaf)
+	info, err := os.Lstat(leafPath)
+	if err != nil {
+		return "", UsageError("--project-root %q does not exist", value)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", UsageError("--project-root %q is a symlink; pass the real directory", value)
+	}
+	if !info.IsDir() {
+		return "", UsageError("--project-root %q is not a directory", value)
+	}
+	return leafPath, nil
+}
+
+func setupRoot(requested string, explicit bool, projectRoot string, projectRootExplicit bool) (string, []byte, bool, error) {
 	result, err := findAndLoadAmqrc()
 	if err == nil {
 		if !sameTreeIdentity(result.Dir, projectRoot) {
-			return "", nil, false, fmt.Errorf("project setup resolved parent .amqrc at %s", result.Path)
+			if projectRootExplicit {
+				// Explicit beats inferred: an explicit --project-root (or a
+				// cwd that owns .amq/launch.json) suppresses upward base
+				// discovery. A parent .amqrc found above the project root is
+				// ignored, not adopted, so setup writes into the project root
+				// and the parent tree stays byte-identical. The implicit case
+				// still refuses an upward-discovered parent .amqrc.
+				err = errAmqrcNotFound
+			} else {
+				return "", nil, false, fmt.Errorf("project setup resolved parent .amqrc at %s", result.Path)
+			}
 		}
-		raw, readErr := os.ReadFile(result.Path)
-		if readErr != nil {
-			return "", nil, false, readErr
+		if err == nil {
+			raw, readErr := os.ReadFile(result.Path)
+			if readErr != nil {
+				return "", nil, false, readErr
+			}
+			var fields map[string]json.RawMessage
+			if jsonErr := json.Unmarshal(raw, &fields); jsonErr != nil {
+				return "", nil, false, jsonErr
+			}
+			if _, conflict := fields["default_session"]; conflict {
+				return "", nil, false, &launch.ConfigAuthorityConflictError{Path: ".amqrc", Field: "default_session"}
+			}
+			if explicit && requested != result.Config.Root {
+				return "", nil, false, fmt.Errorf(".amqrc already selects root %q", result.Config.Root)
+			}
+			return result.Config.Root, raw, true, nil
 		}
-		var fields map[string]json.RawMessage
-		if jsonErr := json.Unmarshal(raw, &fields); jsonErr != nil {
-			return "", nil, false, jsonErr
-		}
-		if _, conflict := fields["default_session"]; conflict {
-			return "", nil, false, &launch.ConfigAuthorityConflictError{Path: ".amqrc", Field: "default_session"}
-		}
-		if explicit && requested != result.Config.Root {
-			return "", nil, false, fmt.Errorf(".amqrc already selects root %q", result.Config.Root)
-		}
-		return result.Config.Root, raw, true, nil
 	}
 	if !errors.Is(err, errAmqrcNotFound) {
 		return "", nil, false, err

--- a/internal/cli/setup_project_root_test.go
+++ b/internal/cli/setup_project_root_test.go
@@ -1,0 +1,353 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/launch"
+)
+
+// seedParentProject runs a complete setup in dir so it owns a committed
+// .amqrc, .amq/launch.json, and a provisioned base root, then turns it into a
+// Git repo. A nested non-Git directory under it resolves the parent top
+// through gitWorktreeTopFromCWD.
+func seedParentProject(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands", "--json"})
+	}); err != nil {
+		t.Fatalf("seed parent setup: %v", err)
+	}
+	runGitForTest(t, dir, "init")
+	runGitForTest(t, dir, "add", ".amqrc", setupConfigPath)
+	runGitForTest(t, dir, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "-m", "fixture")
+}
+
+// TestSetupWithoutProjectRootFlagResolvesParentWorktreeTop covers the unchanged
+// v0.61 behavior (issue #648 item 1(a)): a nested scratch directory under a
+// parent Git repo, without --project-root and without a local config, resolves
+// the Git worktree top (the parent) as the project root. The flag is the
+// opt-in override.
+func TestSetupWithoutProjectRootFlagResolvesParentWorktreeTop(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for nested project-root authority tests")
+	}
+	parent := setupProjectFixture(t, "claude")
+	seedParentProject(t, parent)
+	parentMail := filepath.Join(parent, defaultCoopRoot)
+
+	nested := filepath.Join(parent, "nested", "scratch")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(nested); err != nil {
+		t.Fatal(err)
+	}
+	resetAmqrcCache()
+
+	_, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("nested setup without flag: %v", err)
+	}
+	// The parent base root gained a collab session: project root resolved to
+	// the parent top, so writes landed there, not in the nested dir.
+	if _, statErr := os.Stat(filepath.Join(parentMail, "collab")); statErr != nil {
+		t.Fatalf("unchanged-behavior run did not provision parent collab session: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(nested, ".amqrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("unchanged-behavior run wrote nested .amqrc: %v", statErr)
+	}
+}
+
+// TestSetupProjectRootFlagIgnoresParentAmqrcAndWritesNestedConfig covers the
+// ignore path (issue #648 item 1(a) + review R1): when --project-root names a
+// nested dir but a parent .amqrc exists, setup ignores the parent .amqrc
+// (explicit beats inferred) and writes .amqrc/.amq/launch.json into the
+// project root. The parent's .amqrc, .amq/launch.json, and .agent-mail are
+// left byte-for-byte unchanged, and a subsequent findAndLoadAmqrc from the
+// nested dir resolves the NESTED .amqrc (discovery suppressed).
+func TestSetupProjectRootFlagIgnoresParentAmqrcAndWritesNestedConfig(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for nested project-root authority tests")
+	}
+	parent := setupProjectFixture(t, "claude")
+	seedParentProject(t, parent)
+
+	parentAmqrc := filepath.Join(parent, ".amqrc")
+	parentAmqrcBefore, err := os.ReadFile(parentAmqrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentConfig := filepath.Join(parent, setupConfigPath)
+	parentConfigBefore, err := os.ReadFile(parentConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentMail := filepath.Join(parent, defaultCoopRoot)
+	parentMailBefore := setupTreeDigest(t, parentMail)
+
+	nested := filepath.Join(parent, "nested", "scratch")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(nested); err != nil {
+		t.Fatal(err)
+	}
+	resetAmqrcCache()
+
+	_, err = captureEnvStdout(t, func() error {
+		return runSetup([]string{
+			"-y", "--agents", "claude", "--default-session", "collab",
+			"--launcher-preference", "commands", "--project-root", nested, "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("setup with --project-root and parent .amqrc: %v", err)
+	}
+	// The explicit project root owns its config: .amqrc and .amq/launch.json
+	// land in the nested dir, not the parent.
+	if _, statErr := os.Stat(filepath.Join(nested, ".amqrc")); statErr != nil {
+		t.Fatalf("--project-root did not write nested .amqrc: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(nested, setupConfigPath)); statErr != nil {
+		t.Fatalf("--project-root did not write nested project config: %v", statErr)
+	}
+	// The parent's .amqrc and project config are byte-for-byte unchanged.
+	if after, readErr := os.ReadFile(parentAmqrc); readErr != nil || string(after) != string(parentAmqrcBefore) {
+		t.Fatalf("parent .amqrc changed: before=%q after=%q err=%v", parentAmqrcBefore, after, readErr)
+	}
+	if after, readErr := os.ReadFile(parentConfig); readErr != nil || string(after) != string(parentConfigBefore) {
+		t.Fatalf("parent project config changed: before=%q after=%q err=%v", parentConfigBefore, after, readErr)
+	}
+	// The parent's live base root is byte-for-byte unchanged.
+	if after := setupTreeDigest(t, parentMail); after != parentMailBefore {
+		t.Fatalf("parent base root changed during nested setup")
+	}
+	// Discovery is suppressed: a subsequent findAndLoadAmqrc from the nested
+	// dir resolves the NESTED .amqrc, never the parent's. This is the
+	// assertion that proves upward base discovery no longer redirects writes
+	// into a parent repo's live base root.
+	resetAmqrcCache()
+	result, findErr := findAndLoadAmqrc()
+	if findErr != nil {
+		t.Fatalf("findAndLoadAmqrc from nested: %v", findErr)
+	}
+	if !sameTreeIdentity(result.Dir, nested) {
+		t.Fatalf("findAndLoadAmqrc resolved %s, want nested %s", result.Dir, nested)
+	}
+}
+
+// TestSetupProjectRootFlagOwnsNestedDirWithoutParentAmqrc covers the write path
+// (issue #648 item 1(a)): with --project-root naming a nested dir that has no
+// parent .amqrc, setup treats that dir as the project root and writes .amqrc,
+// .amq/launch.json, and .gitignore there. No chdir to a Git worktree top
+// redirects the writes.
+func TestSetupProjectRootFlagOwnsNestedDirWithoutParentAmqrc(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for nested project-root authority tests")
+	}
+	parent := setupProjectFixture(t, "claude")
+	// A parent Git repo with NO .amqrc: the nested dir is the sole project
+	// root authority through the flag.
+	runGitForTest(t, parent, "init")
+	runGitForTest(t, parent, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "--allow-empty", "-m", "fixture")
+
+	nested := filepath.Join(parent, "nested", "scratch")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(nested); err != nil {
+		t.Fatal(err)
+	}
+	resetAmqrcCache()
+
+	_, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{
+			"-y", "--agents", "claude", "--default-session", "collab",
+			"--launcher-preference", "commands", "--project-root", nested, "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("nested setup with --project-root: %v", err)
+	}
+	// The flag owns its own project root: .amqrc and .amq/launch.json land in
+	// the nested dir, not the parent.
+	if _, statErr := os.Stat(filepath.Join(nested, ".amqrc")); statErr != nil {
+		t.Fatalf("--project-root did not write nested .amqrc: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(nested, setupConfigPath)); statErr != nil {
+		t.Fatalf("--project-root did not write nested project config: %v", statErr)
+	}
+	// The parent gained no AMQ files.
+	if _, statErr := os.Stat(filepath.Join(parent, ".amqrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("--project-root wrote parent .amqrc: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(parent, defaultCoopRoot)); !os.IsNotExist(statErr) {
+		t.Fatalf("--project-root provisioned parent base root: %v", statErr)
+	}
+}
+
+// TestSetupTreatsCwdWithLocalConfigAsProjectRootWithoutFlag covers issue #648
+// item 1(a): an existing explicit .amq/launch.json in cwd is authority, so
+// setup treats cwd as the project root without --project-root and does not
+// redirect writes to a Git worktree top. The parent here owns no .amqrc, so
+// there is no parent adoption to refuse; the local config alone pins the root.
+func TestSetupTreatsCwdWithLocalConfigAsProjectRootWithoutFlag(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for nested project-root authority tests")
+	}
+	parent := setupProjectFixture(t, "claude")
+	// A parent Git repo with NO .amqrc: only the nested dir's local config
+	// can pin the project root.
+	runGitForTest(t, parent, "init")
+	runGitForTest(t, parent, "-c", "user.name=AMQ Test", "-c", "user.email=amq@example.invalid", "commit", "--allow-empty", "-m", "fixture")
+	parentMail := filepath.Join(parent, defaultCoopRoot)
+
+	// A nested dir that already owns .amq/launch.json is its own project root.
+	nested := filepath.Join(parent, "nested", "owned")
+	if err := os.MkdirAll(filepath.Join(nested, ".amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	projectConfig := launch.ProjectConfig{
+		Schema: launch.ProjectConfigSchema, DefaultSession: "collab", Layout: launch.LayoutIntent{Type: launch.LayoutColumns},
+		Agents: []launch.ProjectAgentConfig{{Handle: "claude", Adapter: "claude", Command: []string{"claude"}, ResumePolicy: launch.ResumeEnabled}},
+	}
+	projectData, err := launch.MarshalProjectConfig(projectConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, setupConfigPath), projectData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(nested); err != nil {
+		t.Fatal(err)
+	}
+	resetAmqrcCache()
+
+	_, err = captureEnvStdout(t, func() error {
+		return runSetup([]string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("nested setup with local config: %v", err)
+	}
+	// The nested dir owns its base root; the parent never gains one.
+	if _, statErr := os.Stat(filepath.Join(nested, ".amqrc")); statErr != nil {
+		t.Fatalf("local-config cwd did not write nested .amqrc: %v", statErr)
+	}
+	if _, statErr := os.Stat(parentMail); !os.IsNotExist(statErr) {
+		t.Fatalf("parent base root was created when cwd owned a local config: %v", statErr)
+	}
+}
+
+// TestSetupProjectRootFlagValidation covers the flag's own input validation.
+func TestSetupProjectRootFlagValidation(t *testing.T) {
+	setupProjectFixture(t, "claude")
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "blank project root", args: []string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands", "--project-root", "  "}, want: "must not be blank"},
+		{name: "missing project root", args: []string{"-y", "--agents", "claude", "--default-session", "collab", "--launcher-preference", "commands", "--project-root", "/definitely/does/not/exist/xyz"}, want: "does not exist"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := runSetup(test.args)
+			if GetExitCode(err) != ExitUsage || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v (exit=%d), want usage containing %q", err, GetExitCode(err), test.want)
+			}
+		})
+	}
+}
+
+// TestSetupProjectRootFlagRefusesSymlink covers review R5: a --project-root that
+// is a symlink is refused rather than followed, so setup never writes through
+// the link into a directory the operator did not name. Both the link path and
+// its target must stay free of .amqrc/.amq.
+func TestSetupProjectRootFlagRefusesSymlink(t *testing.T) {
+	setupProjectFixture(t, "claude")
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link-to-target")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	_, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{
+			"-y", "--agents", "claude", "--default-session", "collab",
+			"--launcher-preference", "commands", "--project-root", link, "--json",
+		})
+	})
+	if err == nil || !strings.Contains(err.Error(), "is a symlink") {
+		t.Fatalf("setup with symlinked --project-root error = %v, want 'is a symlink'", err)
+	}
+	// Nothing is written through the link: neither the link path nor the
+	// target directory gains AMQ files.
+	if _, statErr := os.Stat(filepath.Join(link, ".amqrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("symlink --project-root wrote through the link: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(target, ".amqrc")); !os.IsNotExist(statErr) {
+		t.Fatalf("symlink --project-root wrote into the target dir: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(target, setupConfigPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("symlink --project-root wrote target project config: %v", statErr)
+	}
+}
+
+// TestSetupProjectRootFollowsSymlinkedParent covers review R7: a symlinked
+// PARENT component is canonicalized (followed), not refused — this is what
+// makes /tmp resolve to /private/tmp on macOS. The leaf inside the canonical
+// parent is a real directory, so setup writes land under the canonical target
+// path and nowhere else. The link path and the target path resolve to the
+// same directory, and exactly one .amqrc exists.
+func TestSetupProjectRootFollowsSymlinkedParent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for project-root authority tests")
+	}
+	setupProjectFixture(t, "claude")
+	// A real target dir with a nested leaf; link is a symlink to target.
+	target := t.TempDir()
+	leaf := "project"
+	if err := os.MkdirAll(filepath.Join(target, leaf), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkParent := filepath.Join(t.TempDir(), "link-to-target")
+	if err := os.Symlink(target, linkParent); err != nil {
+		t.Fatal(err)
+	}
+	// --project-root points through the symlinked parent to the leaf.
+	rootViaLink := filepath.Join(linkParent, leaf)
+	_, err := captureEnvStdout(t, func() error {
+		return runSetup([]string{
+			"-y", "--agents", "claude", "--default-session", "collab",
+			"--launcher-preference", "commands", "--project-root", rootViaLink, "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("setup with symlinked parent --project-root: %v", err)
+	}
+	// The canonical target leaf gains the config; the link path resolves to
+	// the same directory, so exactly one .amqrc exists.
+	canonicalTarget, terr := filepath.EvalSymlinks(target)
+	if terr != nil {
+		t.Fatal(terr)
+	}
+	canonicalLeaf := filepath.Join(canonicalTarget, leaf)
+	if _, statErr := os.Stat(filepath.Join(canonicalLeaf, ".amqrc")); statErr != nil {
+		t.Fatalf("symlinked parent did not write canonical leaf .amqrc: %v", statErr)
+	}
+	linkResolved, lerr := filepath.EvalSymlinks(rootViaLink)
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	if linkResolved != canonicalLeaf {
+		t.Fatalf("link path resolves to %s, want canonical %s", linkResolved, canonicalLeaf)
+	}
+	// Exactly one .amqrc exists (the link path and target path are the same dir).
+	if _, statErr := os.Stat(filepath.Join(rootViaLink, ".amqrc")); statErr != nil {
+		t.Fatalf(".amqrc not visible through the link: %v", statErr)
+	}
+}

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -83,12 +83,16 @@ func ProviderStaticInputCapabilities(provider string) StaticInputCapabilities {
 			AllowedArgumentForms: []string{"--allowedTools"}, InitialInputKinds: []InitialInputKind{InitialInputArgument},
 		}
 	case CodexProvider:
-		values := slices.Clone(codexReasoningEffortValues)
+		reasoningValues := slices.Clone(codexReasoningEffortValues)
+		reviewerValues := slices.Clone(codexApprovalsReviewerValues)
 		return StaticInputCapabilities{
 			GrammarVersion: 1, VerifiedProviderVersion: codexCaptureVersion,
 			AllowedArgumentForms: []string{"-c"},
-			ConfigOverrides:      []ConfigOverrideCapability{{Key: "model_reasoning_effort", AllowedValues: values}},
-			InitialInputKinds:    []InitialInputKind{InitialInputArgument},
+			ConfigOverrides: []ConfigOverrideCapability{
+				{Key: "model_reasoning_effort", AllowedValues: reasoningValues},
+				{Key: "approvals_reviewer", AllowedValues: reviewerValues},
+			},
+			InitialInputKinds: []InitialInputKind{InitialInputArgument},
 		}
 	case GrokProvider:
 		return StaticInputCapabilities{

--- a/internal/launch/adapter_claude.go
+++ b/internal/launch/adapter_claude.go
@@ -123,20 +123,125 @@ func claudeArgRules() map[string]argumentRule {
 	}
 }
 
+// claudeAllowedToolsMaxBytes caps the total byte length of a --allowedTools
+// value. 512 accommodates a realistic scoped list such as
+// `Bash(gh pr create:*),Read,Edit` and a handful of mcp__owner__tool entries
+// without admitting an unbounded attacker-controlled blob. The previous cap
+// of 128 rejected that real shape (issue #648 item 2), forcing consumers to
+// either widen to blanket `Bash` or drop the grant.
+const claudeAllowedToolsMaxBytes = 512
+
+// validClaudeAllowedTools validates Claude's --allowedTools value against a
+// single scoped-pattern grammar:
+//
+//	entry := name [ "(" spec ")" ]
+//	list  := entry ( "," entry )*
+//
+// name matches ^[A-Za-z][A-Za-z0-9_]*$ (Bash, Read, mcp__x__y). The optional
+// parenthesized spec is 1..N bytes with no control byte (anything < 0x20)
+// and no nested parentheses; it may carry spaces, ':', '*', '-', '/', '.',
+// and commas, so scoped grants like `Bash(gh pr view:*,gh pr create:*)` parse.
+// Entries are split on commas at paren depth 0 only. An entry must not
+// start with '-', and each entry must have no leading or trailing
+// whitespace. A bare name followed by `:*` (e.g. `Bash:*`) rejects because
+// the name part fails the name regex; a scoped pattern requires the
+// parentheses. The grammar accepts real Claude tool-pattern syntax and
+// rejects flag-looking values such as `--dangerously-skip-permissions`,
+// closing the prior strictness inversion where the latter was admitted while
+// the former was rejected.
 func validClaudeAllowedTools(value string) bool {
-	if value == "" || len(value) > 128 || strings.ContainsRune(value, 0) {
+	if value == "" || len(value) > claudeAllowedToolsMaxBytes || strings.ContainsRune(value, 0) || strings.ContainsAny(value, "\r\n") {
 		return false
 	}
-	parts := strings.Split(value, ",")
-	if len(parts) == 0 {
+	// Split into entries on commas at paren depth 0 only, so a spec may
+	// itself contain commas (e.g. Bash(gh pr view:*,gh pr create:*)). Depth
+	// is 0 outside any paren and 1 inside the single balanced pair; depth>1
+	// or an unmatched paren rejects.
+	var entries []string
+	start := 0
+	depth := 0
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case '(':
+			depth++
+			if depth > 1 {
+				return false
+			}
+		case ')':
+			depth--
+			if depth < 0 {
+				return false
+			}
+		case ',':
+			if depth == 0 {
+				entries = append(entries, value[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if depth != 0 {
 		return false
 	}
-	for _, part := range parts {
-		if part == "" || strings.TrimSpace(part) != part || !safeEnvironmentValue(part) {
+	entries = append(entries, value[start:])
+	for _, part := range entries {
+		if part == "" || part != strings.TrimSpace(part) || strings.HasPrefix(part, "-") {
+			return false
+		}
+		name, spec, hasSpec := strings.Cut(part, "(")
+		if !validClaudeToolName(name) {
+			return false
+		}
+		if !hasSpec {
+			continue
+		}
+		// A scoped entry is exactly name(spec) with one balanced pair and no
+		// trailing bytes after the closing paren.
+		if !strings.HasSuffix(spec, ")") {
+			return false
+		}
+		specBody := spec[:len(spec)-1]
+		if specBody == "" || strings.ContainsRune(specBody, '(') || strings.ContainsRune(specBody, ')') {
+			return false
+		}
+		if containsControlByte(specBody) {
+			return false
+		}
+		if strings.TrimSpace(specBody) != specBody {
 			return false
 		}
 	}
 	return true
+}
+
+func validClaudeToolName(name string) bool {
+	if name == "" || len(name) > 128 {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case i == 0:
+			isAlpha := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z')
+			if !isAlpha {
+				return false
+			}
+		case r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// containsControlByte reports whether s contains any byte below 0x20 (NUL,
+// tab, newline, CR, and other C0 control bytes). A scoped-tool spec is a
+// single-line value, so any control byte rejects.
+func containsControlByte(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 {
+			return true
+		}
+	}
+	return false
 }
 
 func claudeBypassArgs() map[string]struct{} {

--- a/internal/launch/adapter_claude.go
+++ b/internal/launch/adapter_claude.go
@@ -143,7 +143,8 @@ const claudeAllowedToolsMaxBytes = 512
 // and commas, so scoped grants like `Bash(gh pr view:*,gh pr create:*)` parse.
 // Entries are split on commas at paren depth 0 only. An entry must not
 // start with '-', and each entry must have no leading or trailing
-// whitespace. A bare name followed by `:*` (e.g. `Bash:*`) rejects because
+// whitespace. A spec must not start with '-' either (no legitimate scoped
+// pattern begins with a dash; a dash elsewhere is fine). A bare name followed by `:*` (e.g. `Bash:*`) rejects because
 // the name part fails the name regex; a scoped pattern requires the
 // parentheses. The grammar accepts real Claude tool-pattern syntax and
 // rejects flag-looking values such as `--dangerously-skip-permissions`,
@@ -201,6 +202,13 @@ func validClaudeAllowedTools(value string) bool {
 		}
 		specBody := spec[:len(spec)-1]
 		if specBody == "" || strings.ContainsRune(specBody, '(') || strings.ContainsRune(specBody, ')') {
+			return false
+		}
+		// A spec must not start with '-': there is no legitimate scoped pattern
+		// that begins with a dash, and refusing it keeps a flag-looking value
+		// such as Bash(--dangerously-skip-permissions) from passing. A dash
+		// elsewhere in the spec (e.g. Bash(git -C x:*)) is fine.
+		if specBody[0] == '-' {
 			return false
 		}
 		if containsControlByte(specBody) {

--- a/internal/launch/adapter_claude_test.go
+++ b/internal/launch/adapter_claude_test.go
@@ -19,6 +19,10 @@ func TestValidClaudeAllowedToolsGrammar(t *testing.T) {
 		"Bash(ls)",
 		"Bash(ls:*)",
 		"Bash(gh pr create:*)",
+		"Bash(gh pr view:*,gh pr create:*)",
+		"Bash(a,b)",
+		"Bash(gh pr view:*,gh pr create:*),Read",
+		"Bash(git -C x:*)",
 	}
 	for _, value := range accept {
 		t.Run("accept/"+value, func(t *testing.T) {
@@ -32,6 +36,9 @@ func TestValidClaudeAllowedToolsGrammar(t *testing.T) {
 		"Bash:*",
 		"--dangerously-skip-permissions",
 		"--verbose",
+		"Bash(--dangerously-skip-permissions)",
+		"Bash(--verbose)",
+		"Bash(-la)",
 		"Bash(",
 		"Bash()",
 		"Bash(a)b",

--- a/internal/launch/adapter_claude_test.go
+++ b/internal/launch/adapter_claude_test.go
@@ -1,0 +1,81 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidClaudeAllowedToolsGrammar exercises the single scoped-pattern
+// grammar for Claude's --allowedTools (issue #648 item 2). The ACCEPT set is
+// the issue's verified value-grammar probes; the REJECT set closes the prior
+// strictness inversion where flag-looking values were admitted while real
+// Claude tool-pattern syntax was rejected.
+func TestValidClaudeAllowedToolsGrammar(t *testing.T) {
+	accept := []string{
+		"Bash",
+		"Bash,Read",
+		"Edit",
+		"mcp__x__y",
+		"Bash(ls)",
+		"Bash(ls:*)",
+		"Bash(gh pr create:*)",
+	}
+	for _, value := range accept {
+		t.Run("accept/"+value, func(t *testing.T) {
+			if !validClaudeAllowedTools(value) {
+				t.Fatalf("validClaudeAllowedTools(%q) = false, want true", value)
+			}
+		})
+	}
+
+	reject := []string{
+		"Bash:*",
+		"--dangerously-skip-permissions",
+		"--verbose",
+		"Bash(",
+		"Bash()",
+		"Bash(a)b",
+		"Bash(a\nb)",
+		"Bash (ls)",
+		"Bash,,Read",
+		"Bash(a,(b))",
+		"Bash(a,",
+		"a),b",
+		"",
+		",Bash",
+		"Bash,",
+		" Bash",
+		"Bash ",
+		"-Bash",
+		"Bash(a(b)c)",
+		"Bash(a)b(c)",
+		"Bash( ls)",
+		"Bash(ls )",
+		"Bash\x00ls",
+		"Bash(ls\x00)",
+		"Bash(ls\ta)",
+		"Bash(a\tb)",
+		"Bash(\x01)",
+		strings.Repeat("Bash", 200),
+	}
+	for _, value := range reject {
+		t.Run("reject/"+value, func(t *testing.T) {
+			if validClaudeAllowedTools(value) {
+				t.Fatalf("validClaudeAllowedTools(%q) = true, want false", value)
+			}
+		})
+	}
+}
+
+// TestValidClaudeAllowedToolsScopedListAcceptsRealisticEntries confirms the
+// length cap (512) admits a realistic scoped list that the previous 128-byte
+// cap rejected, forcing a consumer to widen to blanket Bash.
+func TestValidClaudeAllowedToolsScopedListAcceptsRealisticEntries(t *testing.T) {
+	value := "Bash(gh pr create:*),Read,Edit"
+	if !validClaudeAllowedTools(value) {
+		t.Fatalf("validClaudeAllowedTools(%q) = false, want true", value)
+	}
+	if len(value) > claudeAllowedToolsMaxBytes {
+		t.Fatalf("test value exceeds cap: %d > %d", len(value), claudeAllowedToolsMaxBytes)
+	}
+}

--- a/internal/launch/adapter_codex.go
+++ b/internal/launch/adapter_codex.go
@@ -172,8 +172,18 @@ func codexArgRules() map[string]argumentRule {
 
 var codexReasoningEffortValues = []string{"minimal", "low", "medium", "high", "xhigh"}
 
+// codexApprovalsReviewerValues is the allowlist for the `-c approvals_reviewer`
+// config override. codex-cli 0.149.1 parses the value as TOML and accepts
+// exactly these variants; an unknown value errors with `unknown variant '<x>',
+// expected one of 'user', 'auto_review', 'guardian_subagent'`. Both quoted
+// (`approvals_reviewer="auto_review"`) and bare
+// (`approvals_reviewer=auto_review`) forms parse, so validCodexConfigOverride
+// strips one surrounding quote pair before the allowlist lookup.
+var codexApprovalsReviewerValues = []string{"user", "auto_review", "guardian_subagent"}
+
 var codexConfigOverrideValues = map[string]map[string]struct{}{
 	"model_reasoning_effort": valueSet(codexReasoningEffortValues),
+	"approvals_reviewer":     valueSet(codexApprovalsReviewerValues),
 }
 
 func valueSet(values []string) map[string]struct{} {
@@ -193,8 +203,29 @@ func validCodexConfigOverride(value string) bool {
 	if !ok {
 		return false
 	}
-	_, ok = values[configured]
+	// codex-cli parses `-c key=value` as TOML, so the squad's live emission
+	// carries a literal surrounding quote pair
+	// (`approvals_reviewer="auto_review"`). Normalize exactly one pair: a
+	// value with unbalanced or inner quotes rejects rather than being
+	// silently trimmed.
+	normalized := stripOneSurroundingQuotePair(configured)
+	_, ok = values[normalized]
 	return ok
+}
+
+// stripOneSurroundingQuotePair removes a single leading and trailing double
+// quote from value when both are present and no inner quote remains. It leaves
+// unbalanced quotes and embedded quotes intact so the allowlist lookup fails
+// for those cases.
+func stripOneSurroundingQuotePair(value string) string {
+	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+		return value
+	}
+	body := value[1 : len(value)-1]
+	if strings.ContainsRune(body, '"') {
+		return value
+	}
+	return body
 }
 
 func validateCodexConfigOverrides(args []string) error {

--- a/internal/launch/adapter_codex_test.go
+++ b/internal/launch/adapter_codex_test.go
@@ -1,0 +1,89 @@
+package launch
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidCodexConfigOverrideApprovalsReviewer covers the `-c
+// approvals_reviewer` allowlist (issue #648 item 3). codex-cli 0.149.1 parses
+// the value as TOML and accepts `user`, `auto_review`, and `guardian_subagent`
+// in both quoted (`approvals_reviewer="auto_review"`) and bare
+// (`approvals_reviewer=auto_review`) forms; an unknown value errors
+// `unknown variant '<x>', expected one of 'user', 'auto_review',
+// 'guardian_subagent'`. validCodexConfigOverride normalizes one surrounding
+// quote pair and rejects unbalanced or inner quotes plus duplicate keys.
+func TestValidCodexConfigOverrideApprovalsReviewer(t *testing.T) {
+	accept := []string{
+		`approvals_reviewer=user`,
+		`approvals_reviewer=auto_review`,
+		`approvals_reviewer=guardian_subagent`,
+		`approvals_reviewer="user"`,
+		`approvals_reviewer="auto_review"`,
+		`approvals_reviewer="guardian_subagent"`,
+	}
+	for _, value := range accept {
+		t.Run("accept/"+value, func(t *testing.T) {
+			if !validCodexConfigOverride(value) {
+				t.Fatalf("validCodexConfigOverride(%q) = false, want true", value)
+			}
+		})
+	}
+
+	reject := []string{
+		`approvals_reviewer=`,
+		`approvals_reviewer="auto_review`,
+		`approvals_reviewer=auto_review"`,
+		`approvals_reviewer="auto"review"`,
+		`approvals_reviewer=rm -rf`,
+		`approvals_reviewer=on_request`,
+		`approvals_reviewer="on_request"`,
+		`approvals_reviewer`,
+		`=auto_review`,
+		`approvals_reviewer=""`,
+	}
+	for _, value := range reject {
+		t.Run("reject/"+value, func(t *testing.T) {
+			if validCodexConfigOverride(value) {
+				t.Fatalf("validCodexConfigOverride(%q) = true, want false", value)
+			}
+		})
+	}
+}
+
+// TestValidateCodexConfigOverridesApprovalsReviewerSet asserts the full
+// amq-squad "approve-for-me" override set accepts as a whole once
+// approvals_reviewer is seeded. The issue records that the live set rejected as
+// a whole and accepted only with this key removed; this reproduces the live
+// emission, including the literal TOML quotes around the reviewer value.
+func TestValidateCodexConfigOverridesApprovalsReviewerSet(t *testing.T) {
+	set := []string{
+		"-c", "model_reasoning_effort=high",
+		"-c", `approvals_reviewer="auto_review"`,
+	}
+	if err := validateCodexConfigOverrides(set); err != nil {
+		t.Fatalf("validateCodexConfigOverrides(%q) = %v, want nil", set, err)
+	}
+
+	bareSet := []string{
+		"-c", "model_reasoning_effort=high",
+		"-c", "approvals_reviewer=auto_review",
+	}
+	if err := validateCodexConfigOverrides(bareSet); err != nil {
+		t.Fatalf("validateCodexConfigOverrides(%q) = %v, want nil", bareSet, err)
+	}
+}
+
+// TestValidateCodexConfigOverridesApprovalsReviewerDuplicateKey confirms a
+// repeated approvals_reviewer key is rejected as duplicated, matching the
+// existing model_reasoning_effort duplicate-key behavior.
+func TestValidateCodexConfigOverridesApprovalsReviewerDuplicateKey(t *testing.T) {
+	set := []string{
+		"-c", "approvals_reviewer=user",
+		"-c", `approvals_reviewer="auto_review"`,
+	}
+	err := validateCodexConfigOverrides(set)
+	if err == nil || !strings.Contains(err.Error(), "duplicated") {
+		t.Fatalf("validateCodexConfigOverrides(%q) = %v, want duplicated", set, err)
+	}
+}

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -239,6 +239,25 @@ func TestGrokCommittedConfigRejectsDuplicateToolFlags(t *testing.T) {
 	}
 }
 
+// TestGrokCommittedConfigRejectsBypassFlagAsToolValue confirms the leading-dash
+// guard in validGrokToolList refuses a flag-looking value smuggled into
+// --tools or --disallowed-tools (e.g. the Grok bypass flag), mirroring the
+// Claude strictness-inversion fix in issue #648 item 2.
+func TestGrokCommittedConfigRejectsBypassFlagAsToolValue(t *testing.T) {
+	project := t.TempDir()
+	adapter := NewGrokAdapter("definitely-not-installed-grok")
+	for _, args := range [][]string{
+		{"--tools", "--dangerously-bypass-approvals-and-sandbox"},
+		{"--disallowed-tools", "--dangerously-bypass-approvals-and-sandbox"},
+		{"--tools", "--verbose"},
+	} {
+		err := ValidateCommittedConfig(adapter, CommittedConfigRequest{ProjectRoot: project, Args: args})
+		if err == nil || !strings.Contains(err.Error(), "invalid value") {
+			t.Fatalf("ValidateCommittedConfig(%q) error = %v, want invalid value", args, err)
+		}
+	}
+}
+
 func TestGrokPlansForwardOpaqueToolNames(t *testing.T) {
 	project, executable := testExecutable(t, GrokProvider)
 	adapter := NewGrokAdapter(executable)


### PR DESCRIPTION
> **Supersedes #662 (rebased onto origin/main incl. #659/#661 + review R7/R8 applied). Closes #648.

## Summary

Closes #648. Three items from amq-squad's v0.70.0 adoption asks, all additive and opt-in.

### Item 1 — base-root/project-root authority (highest severity)

**Problem:** In a nested scratch project under a parent repo, `amq setup` resolved the project root to the Git worktree top (the parent), adopted the parent's `.amqrc`/`.amq/launch.json`, and `launch --plan` then wrote a stray session into the **parent repo's live base root** (state-corruption class: writes to the wrong live queue rather than refusing).

**Fix:**
- `amq setup --project-root <dir>` — the named directory IS the project root: no chdir to Git top; `.amqrc`, `.amq/launch.json`, `.gitignore` written there. A symlinked `--project-root` is **refused before any write** (R5: `Lstat` the user-supplied path first; `ModeSymlink` → `UsageError`; neither the link nor its target gains files). An existing `.amq/launch.json` in cwd is authority without the flag.
- **Explicit beats inferred:** a parent `.amqrc` found above an explicit project root (or a cwd owning its config) is **ignored, not adopted** — parent tree stays byte-identical. The implicit case still refuses an upward-discovered parent `.amqrc` with the parent path named.
- `amq launch --request <file|->` — decodes a full `PrepareRequestV1` (incl. `target.base_root` and `caller_context`) via `DecodePrepareRequestV1` and runs the same Prepare/Apply path as `--plan`. Mutually exclusive with `--plan`/`--apply`/`--placement` and the target/launcher flags. `--prepare` pairs with `--request` for prepare-only (no mutation) so a consumer can read the subject digest before Apply.

**Live evidence (nested repro):** A parent repo with committed AMQ config + a nested `scratch/` dir. With `--project-root scratch`, setup writes `.amqrc`/`.amq/launch.json` into `scratch/`; the parent's `.amqrc`, `launch.json`, and `.agent-mail` tree are **byte-for-byte unchanged** (digest-asserted); a subsequent `findAndLoadAmqrc` from `scratch/` resolves the **nested** `.amqrc`, never the parent's. `--request` with a `base_root` under the nested root creates the session there and leaves the parent session root byte-identical (snapshot-asserted).

### Item 2 — Claude `--allowedTools` scoped-pattern grammar (privilege-escalation-or-regression fork)

**Problem:** The only accepted narrow grant was blanket `Bash`; `Bash(ls)`/`Bash(ls:*)`/`Bash(gh pr create:*)` were rejected. Simultaneously, `--allowedTools --dangerously-skip-permissions` and `--allowedTools --verbose` were **accepted** (strictness inversion).

**Fix:** One grammar, one function:
```
entry := name [ "(" spec ")" ]
name  := ^[A-Za-z][A-Za-z0-9_]*$          (Bash, Read, mcp__x__y)
spec  := 1..N bytes, one balanced paren pair, no nesting,
         no control byte (< 0x20), no leading/trailing whitespace;
         may contain spaces, ':', '*', '-', '/', '.'
entry must not start with '-'
```

| ACCEPT | REJECT |
|--------|--------|
| `Bash` | `Bash:*` (name fails regex; scoped needs parens) |
| `Bash,Read` | `--dangerously-skip-permissions` |
| `Edit` | `--verbose` |
| `mcp__x__y` | `Bash(`, `Bash()`, `Bash(a)b` |
| `Bash(ls)` | `Bash(a\nb)`, `Bash (ls)`, `Bash,,Read` |
| `Bash(ls:*)` | nested parens, NUL, tab/`\x01` in spec |
| `Bash(gh pr create:*)` | leading/trailing ws, `-Bash`, empty parts |

Length cap raised **128 → 512**: the issue's real `Bash(gh pr create:*),Read,Edit` shape exceeds 128; 512 admits realistic lists + several `mcp__owner__tool` entries while bounding attacker blob size. Grok `--tools`/`--disallowed-tools` leading-dash guard covered by a negative test.

### Item 3 — Codex `-c approvals_reviewer` (refuse-to-launch class)

**Problem:** `approvals_reviewer` was unlisted, so both `approvals_reviewer="auto_review"` (quoted, the squad's live default) and `approvals_reviewer=auto_review` (bare) rejected; the full approve-for-me set rejected as a whole.

**Fix:** `approvals_reviewer` added to `codexConfigOverrideValues` with allowlist **{`user`, `auto_review`, `guardian_subagent`}** — the verified codex-cli 0.149.1 TOML variants (`codex-cli` parses `-c key=value` as TOML; unknown value errors `unknown variant '<x>', expected one of 'user', 'auto_review', 'guardian_subagent'`). `validCodexConfigOverride` strips **exactly one** surrounding double-quote pair before the lookup; unbalanced or inner quotes reject. Full approve-for-me set now accepts; duplicate key rejects.

## Implementation notes
- `--plan` and `--request` share one `runPublicPrepareThenApply(ctx, request, prepareOnly)` helper (DRY).
- CLI and Go package now share one contract: every `PrepareRequestV1` field is reachable from the CLI (`--request`).
- Review feedback applied: R1 (parent `.amqrc` ignored not refused), R2 (shared helper), R3 (`--request --prepare` prepare-only), R4 (reject control bytes `< 0x20` in spec), R5 (symlink `--project-root` refused), R6 (test comment wording), R7 (parent components canonicalized via `EvalSymlinks`; symlinked leaf refused inside canonical parent — fixes `/tmp`→`/private/tmp` and symlinked-parent redirect), R8 (depth-tracking comma scanner so commas inside a spec like `Bash(gh pr view:*,gh pr create:*)` parse; nested/dangling parens reject).

## Test plan
- `go test ./internal/launch/... ./internal/cli/...` — green.
- Item 2 + Item 3 table tests run explicitly (all ACCEPT/REJECT subtests pass).
- `GOOS=linux go vet ./...` — clean. `gofmt -l` on all changed files — clean.
- Pre-existing toolchain-local failures (bead 5ks, now codex's): `fmt-check` on `internal/cli/wake_owner_observation_darwin.go` and `TestCmuxInjectEnterFailureAfterTextIsUncertain` — local Go 1.27.0/golangci-lint 2.13.1 artifacts (CI uses go 1.25.12 via `go-version-file`); do not touch files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
