### PR TITLE
feat(coop): name harness sessions <session>/<handle> by default

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -62,6 +62,16 @@ amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox
 amq coop exec grok
 ```
 
+Direct `coop exec` names sessions by default as `<session>/<handle>`, or as
+`<handle>` for a sessionless root. Claude and Pi receive the name as an argv
+flag. Codex and Cursor `agent` receive a best-effort TUI rename only after AMQ
+finds one newly created session for the spawn directory. Codex resumes by name,
+for example `codex resume session1/codex`. Cursor `agent` resumes through its
+picker only; resume-by-name is unproven. Disable this with `--named=false`,
+`AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`. Existing names
+and resume or continue flags are preserved. Managed launches keep naming
+disabled until their provider-name contract is available.
+
 Creating a missing named session, explicit root, or declared default session
 still works in this release and prints one deprecation warning. Use
 `amq session create <name>` or `amq init --root` instead; the next major release

--- a/COOP.md
+++ b/COOP.md
@@ -69,8 +69,9 @@ finds one newly created session for the spawn directory. Codex resumes by name,
 for example `codex resume session1/codex`. Cursor `agent` resumes through its
 picker only; resume-by-name is unproven. Disable this with `--named=false`,
 `AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`. Existing names
-and resume or continue flags are preserved. Managed launches keep naming
-disabled until their provider-name contract is available.
+and resume or continue flags are preserved, including `codex resume` and
+`agent --resume`. Managed launches keep naming disabled until their
+provider-name contract is available.
 
 Creating a missing named session, explicit root, or declared default session
 still works in this release and prints one deprecation warning. Use

--- a/README.md
+++ b/README.md
@@ -287,6 +287,17 @@ Dangerous permission-bypass flags are not valid committed arguments. Keep
 them in an operator-controlled direct `coop exec` invocation when that
 low-level path is intentionally required.
 
+Direct `coop exec` names the provider session by default as
+`<session>/<handle>` (or `<handle>` for a sessionless root). Claude and Pi
+receive the name in their argv. Codex and Cursor `agent` receive a best-effort
+TUI rename after AMQ verifies the newly created session. Codex supports direct
+resume by name, for example `codex resume session1/codex`. Cursor `agent`
+resumes through its picker only; resume-by-name is unproven. Set
+`--named=false`, `AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`
+to disable it. Explicit provider names and resume or continue flags remain
+unchanged. Managed launches keep naming disabled until their provider-name
+contract is available.
+
 ### Named sessions
 
 For isolated pairs (multiple pairs on different features):

--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ resume by name, for example `codex resume session1/codex`. Cursor `agent`
 resumes through its picker only; resume-by-name is unproven. Set
 `--named=false`, `AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`
 to disable it. Explicit provider names and resume or continue flags remain
-unchanged. Managed launches keep naming disabled until their provider-name
-contract is available.
+unchanged, including `codex resume` and `agent --resume`. Managed launches keep
+naming disabled until their provider-name contract is available.
 
 ### Named sessions
 

--- a/internal/cli/coop_exec_named.go
+++ b/internal/cli/coop_exec_named.go
@@ -17,15 +17,36 @@ const (
 	coopNamedModeUnknown
 )
 
+type coopNamedResumeSyntax uint8
+
+const (
+	coopNamedResumeFlags coopNamedResumeSyntax = iota
+	coopNamedResumeCodex
+	coopNamedResumeCursor
+)
+
+type coopNamedHarness struct {
+	mode         coopNamedMode
+	resumeSyntax coopNamedResumeSyntax
+}
+
+var coopNamedHarnesses = map[string]coopNamedHarness{
+	"claude": {mode: coopNamedModeArgv, resumeSyntax: coopNamedResumeFlags},
+	"pi":     {mode: coopNamedModeArgv, resumeSyntax: coopNamedResumeFlags},
+	"codex":  {mode: coopNamedModeTUI, resumeSyntax: coopNamedResumeCodex},
+	"agent":  {mode: coopNamedModeTUI, resumeSyntax: coopNamedResumeCursor},
+}
+
+func coopNamedHarnessFor(binary string) (coopNamedHarness, bool) {
+	harness, ok := coopNamedHarnesses[strings.ToLower(filepath.Base(binary))]
+	return harness, ok
+}
+
 func coopNamedModeFor(binary string) coopNamedMode {
-	switch strings.ToLower(filepath.Base(binary)) {
-	case "claude", "pi":
-		return coopNamedModeArgv
-	case "codex", "agent":
-		return coopNamedModeTUI
-	default:
-		return coopNamedModeUnknown
+	if harness, ok := coopNamedHarnessFor(binary); ok {
+		return harness.mode
 	}
+	return coopNamedModeUnknown
 }
 
 func agentArgsHasNameFlag(args []string) bool {
@@ -46,6 +67,29 @@ func agentArgsHasNameFlag(args []string) bool {
 }
 
 func agentArgsPreventAutoName(args []string) bool {
+	return agentArgsPreventAutoNameFor("", args)
+}
+
+func agentArgsPreventAutoNameFor(cmdName string, args []string) bool {
+	resumeSyntax := coopNamedResumeFlags
+	if harness, ok := coopNamedHarnessFor(cmdName); ok {
+		resumeSyntax = harness.resumeSyntax
+	}
+	return agentArgsHasNameFlag(args) || agentArgsHaveResume(args, resumeSyntax)
+}
+
+func agentArgsHaveResume(args []string, syntax coopNamedResumeSyntax) bool {
+	switch syntax {
+	case coopNamedResumeCodex:
+		return agentArgsHaveCodexResume(args)
+	case coopNamedResumeCursor:
+		return agentArgsHaveResumeFlags(args, false)
+	default:
+		return agentArgsHaveResumeFlags(args, true)
+	}
+}
+
+func agentArgsHaveResumeFlags(args []string, allowContinue bool) bool {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
@@ -55,11 +99,36 @@ func agentArgsPreventAutoName(args []string) bool {
 			i++
 			continue
 		}
-		if arg == "-n" || arg == "--name" || strings.HasPrefix(arg, "--name=") ||
-			arg == "-r" || arg == "--resume" || strings.HasPrefix(arg, "--resume=") ||
-			arg == "-c" || arg == "--continue" || strings.HasPrefix(arg, "--continue=") {
+		if arg == "-r" || arg == "--resume" || strings.HasPrefix(arg, "--resume=") ||
+			allowContinue && (arg == "-c" || arg == "--continue" || strings.HasPrefix(arg, "--continue=")) {
 			return true
 		}
+	}
+	return false
+}
+
+func agentArgsHaveCodexResume(args []string) bool {
+	var firstPositional string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return false
+		}
+		if coopNamedValueFlag(arg) {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if firstPositional == "" {
+			firstPositional = arg
+			if arg == "resume" {
+				return true
+			}
+			continue
+		}
+		return firstPositional == "exec" && arg == "resume"
 	}
 	return false
 }
@@ -74,7 +143,7 @@ func coopNamedValueFlag(arg string) bool {
 }
 
 func injectCoopNamedArgv(cmdName string, agentArgs []string, me string) []string {
-	if coopNamedModeFor(cmdName) != coopNamedModeArgv || agentArgsPreventAutoName(agentArgs) {
+	if coopNamedModeFor(cmdName) != coopNamedModeArgv || agentArgsPreventAutoNameFor(cmdName, agentArgs) {
 		return agentArgs
 	}
 	return append([]string{"--name", me}, agentArgs...)
@@ -145,6 +214,9 @@ func applyCoopNamedBeforeExecAt(
 	execStart time.Time,
 ) ([]string, error) {
 	if !named {
+		return agentArgs, nil
+	}
+	if agentArgsPreventAutoNameFor(cmdName, agentArgs) {
 		return agentArgs, nil
 	}
 	switch coopNamedModeFor(cmdName) {

--- a/internal/cli/coop_exec_named.go
+++ b/internal/cli/coop_exec_named.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type coopNamedMode int
@@ -29,21 +31,84 @@ func coopNamedModeFor(binary string) coopNamedMode {
 func agentArgsHasNameFlag(args []string) bool {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		if arg == "-n" || arg == "--name" {
-			return true
+		if arg == "--" {
+			return false
 		}
-		if strings.HasPrefix(arg, "--name=") {
+		if coopNamedValueFlag(arg) {
+			i++
+			continue
+		}
+		if arg == "-n" || arg == "--name" || strings.HasPrefix(arg, "--name=") {
 			return true
 		}
 	}
 	return false
 }
 
+func agentArgsPreventAutoName(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return false
+		}
+		if coopNamedValueFlag(arg) {
+			i++
+			continue
+		}
+		if arg == "-n" || arg == "--name" || strings.HasPrefix(arg, "--name=") ||
+			arg == "-r" || arg == "--resume" || strings.HasPrefix(arg, "--resume=") ||
+			arg == "-c" || arg == "--continue" || strings.HasPrefix(arg, "--continue=") {
+			return true
+		}
+	}
+	return false
+}
+
+func coopNamedValueFlag(arg string) bool {
+	switch arg {
+	case "--model", "-m", "--config", "--cwd", "--output-format", "--permission-mode", "--settings", "--system-prompt", "--append-system-prompt", "--session":
+		return true
+	default:
+		return false
+	}
+}
+
 func injectCoopNamedArgv(cmdName string, agentArgs []string, me string) []string {
-	if coopNamedModeFor(cmdName) != coopNamedModeArgv || agentArgsHasNameFlag(agentArgs) {
+	if coopNamedModeFor(cmdName) != coopNamedModeArgv || agentArgsPreventAutoName(agentArgs) {
 		return agentArgs
 	}
 	return append([]string{"--name", me}, agentArgs...)
+}
+
+func coopNamedSessionLabel(session, handle string) string {
+	if session == "" {
+		return handle
+	}
+	return session + "/" + handle
+}
+
+func resolveCoopNamedEnabled(fsFlagVisited bool, flagValue bool) (bool, error) {
+	if fsFlagVisited {
+		return flagValue, nil
+	}
+	if raw, ok := os.LookupEnv("AMQ_COOP_NAMED"); ok {
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case "0", "false", "off", "no":
+			return false, nil
+		case "1", "true", "on", "yes":
+			return true, nil
+		default:
+			return false, UsageError("AMQ_COOP_NAMED must be 0 or 1")
+		}
+	}
+	config, present, err := loadProjectLaunchConfig()
+	if err != nil {
+		return false, err
+	}
+	if present && config.Named != nil {
+		return *config.Named, nil
+	}
+	return true, nil
 }
 
 func coopNamedTUICommand(binaryBase, me string) string {
@@ -69,19 +134,29 @@ func applyCoopNamedBeforeExec(
 	agentArgs []string,
 	me string,
 ) ([]string, error) {
+	return applyCoopNamedBeforeExecAt(named, cmdName, agentArgs, me, time.Now())
+}
+
+func applyCoopNamedBeforeExecAt(
+	named bool,
+	cmdName string,
+	agentArgs []string,
+	name string,
+	execStart time.Time,
+) ([]string, error) {
 	if !named {
 		return agentArgs, nil
 	}
 	switch coopNamedModeFor(cmdName) {
 	case coopNamedModeArgv:
-		return injectCoopNamedArgv(cmdName, agentArgs, me), nil
+		return injectCoopNamedArgv(cmdName, agentArgs, name), nil
 	case coopNamedModeTUI:
-		if err := startCoopNamedTUIInjector(me, cmdName); err != nil {
+		if err := startCoopNamedTUIInjector(name, cmdName, execStart); err != nil {
 			_ = writeStderr("warning: coop named inject: %v\n", err)
 		}
 		return agentArgs, nil
 	case coopNamedModeUnknown:
-		_ = writeStderr("%s\n", coopNamedUnknownReminder(me, cmdName))
+		_ = writeStderr("%s\n", coopNamedUnknownReminder(name, cmdName))
 		return agentArgs, nil
 	default:
 		return agentArgs, nil

--- a/internal/cli/coop_exec_named_other.go
+++ b/internal/cli/coop_exec_named_other.go
@@ -2,11 +2,15 @@
 
 package cli
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
-var startCoopNamedTUIInjector = func(me, cmdName string) error {
-	_ = me
+var startCoopNamedTUIInjector = func(name, cmdName string, execStart time.Time) error {
+	_ = name
 	_ = cmdName
+	_ = execStart
 	return errors.New("coop named TUI inject requires macOS or Linux")
 }
 

--- a/internal/cli/coop_exec_named_store_birth_darwin.go
+++ b/internal/cli/coop_exec_named_store_birth_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func cursorChatDirectoryBirthTime(metaPath string) (time.Time, bool, error) {
+	info, err := os.Stat(filepath.Dir(metaPath))
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || (stat.Birthtimespec.Sec == 0 && stat.Birthtimespec.Nsec == 0) {
+		return time.Time{}, false, nil
+	}
+	return time.Unix(stat.Birthtimespec.Sec, stat.Birthtimespec.Nsec), true, nil
+}

--- a/internal/cli/coop_exec_named_store_birth_linux.go
+++ b/internal/cli/coop_exec_named_store_birth_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package cli
+
+import "time"
+
+func cursorChatDirectoryBirthTime(string) (time.Time, bool, error) {
+	return time.Time{}, false, nil
+}

--- a/internal/cli/coop_exec_named_store_unix.go
+++ b/internal/cli/coop_exec_named_store_unix.go
@@ -1,0 +1,259 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// state_5 is Codex's current state schema generation. A different file is
+	// an unknown store and must not be used for automatic naming.
+	codexStateFilename           = "state_5.sqlite"
+	codexThreadsQuery            = "SELECT cwd, name, title, rollout_path FROM threads"
+	coopNamedTUIReadbackInterval = 500 * time.Millisecond
+)
+
+var (
+	coopNamedTUIReadbackTimeout = 5 * time.Second
+	coopNamedReadbackSleep      = time.Sleep
+	runCodexSQLiteQuery         = runCodexSQLiteQueryProcess
+)
+
+type coopNamedStoreCandidate struct {
+	storePath string
+	key       string
+	name      string
+	modTime   time.Time
+}
+
+type coopNamedStoreReader interface {
+	locate(cwd string, execStart time.Time) (coopNamedStoreCandidate, error)
+	readName(candidate coopNamedStoreCandidate) (string, error)
+}
+
+func coopNamedStoreReaderFor(binary string) (coopNamedStoreReader, bool) {
+	switch strings.ToLower(filepath.Base(binary)) {
+	case "codex":
+		return codexNamedStoreReader{}, true
+	case "agent":
+		return cursorNamedStoreReader{}, true
+	default:
+		return nil, false
+	}
+}
+
+func selectCoopNamedStoreCandidate(candidates []coopNamedStoreCandidate, description string) (coopNamedStoreCandidate, error) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].modTime.After(candidates[j].modTime)
+	})
+	switch len(candidates) {
+	case 0:
+		return coopNamedStoreCandidate{}, fmt.Errorf("no new %s store candidate", description)
+	case 1:
+		return candidates[0], nil
+	default:
+		return coopNamedStoreCandidate{}, fmt.Errorf("%d new %s store candidates are ambiguous", len(candidates), description)
+	}
+}
+
+type codexThreadRow struct {
+	CWD         string `json:"cwd"`
+	Name        string `json:"name"`
+	Title       string `json:"title"`
+	RolloutPath string `json:"rollout_path"`
+}
+
+type codexNamedStoreReader struct{}
+
+func (codexNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamedStoreCandidate, error) {
+	dbPath, err := codexStatePath()
+	if err != nil {
+		return coopNamedStoreCandidate{}, err
+	}
+	rows, err := readCodexThreadRows(dbPath)
+	if err != nil {
+		return coopNamedStoreCandidate{}, err
+	}
+	candidates := make([]coopNamedStoreCandidate, 0, 1)
+	for _, row := range rows {
+		if row.CWD != cwd || row.RolloutPath == "" {
+			continue
+		}
+		info, statErr := os.Stat(row.RolloutPath)
+		if statErr != nil {
+			if errors.Is(statErr, fs.ErrNotExist) {
+				continue
+			}
+			return coopNamedStoreCandidate{}, fmt.Errorf("stat Codex rollout %q: %w", row.RolloutPath, statErr)
+		}
+		if info.ModTime().Before(execStart) {
+			continue
+		}
+		candidates = append(candidates, coopNamedStoreCandidate{
+			storePath: dbPath,
+			key:       row.RolloutPath,
+			name:      row.Name,
+			modTime:   info.ModTime(),
+		})
+	}
+	return selectCoopNamedStoreCandidate(candidates, "Codex thread")
+}
+
+func (codexNamedStoreReader) readName(candidate coopNamedStoreCandidate) (string, error) {
+	rows, err := readCodexThreadRows(candidate.storePath)
+	if err != nil {
+		return "", err
+	}
+	var name string
+	found := 0
+	for _, row := range rows {
+		if row.RolloutPath != candidate.key {
+			continue
+		}
+		name = row.Name
+		found++
+	}
+	if found != 1 {
+		return "", fmt.Errorf("codex rollout %q has %d matching rows", candidate.key, found)
+	}
+	if strings.TrimSpace(name) != "" {
+		return name, nil
+	}
+	// Codex versions before the explicit thread-name field persisted /rename
+	// in title. Keep that legacy store readable without treating generated
+	// titles as an existing explicit name before injection.
+	for _, row := range rows {
+		if row.RolloutPath == candidate.key {
+			return row.Title, nil
+		}
+	}
+	return "", nil
+}
+
+func codexStatePath() (string, error) {
+	home := strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve Codex home: %w", err)
+		}
+	}
+	if home == "" {
+		return "", errors.New("codex home is empty")
+	}
+	return filepath.Join(home, codexStateFilename), nil
+}
+
+func readCodexThreadRows(dbPath string) ([]codexThreadRow, error) {
+	data, err := runCodexSQLiteQuery(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	var rows []codexThreadRow
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&rows); err != nil {
+		return nil, fmt.Errorf("decode Codex thread store: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("decode Codex thread store: multiple JSON values")
+		}
+		return nil, fmt.Errorf("decode Codex thread store: %w", err)
+	}
+	return rows, nil
+}
+
+func runCodexSQLiteQueryProcess(dbPath string) ([]byte, error) {
+	cmd := exec.Command("sqlite3", "-readonly", "-json", dbPath, codexThreadsQuery)
+	data, err := cmd.Output()
+	if err == nil {
+		return data, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) != 0 {
+		return nil, fmt.Errorf("sqlite3 query failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
+	}
+	return nil, fmt.Errorf("run sqlite3 query: %w", err)
+}
+
+type cursorChatMeta struct {
+	Title string `json:"title"`
+	CWD   string `json:"cwd"`
+}
+
+type cursorNamedStoreReader struct{}
+
+func (cursorNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamedStoreCandidate, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return coopNamedStoreCandidate{}, fmt.Errorf("resolve Cursor home: %w", err)
+	}
+	root := filepath.Join(home, ".cursor", "chats")
+	var candidates []coopNamedStoreCandidate
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || entry.Name() != "meta.json" || entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if !info.Mode().IsRegular() || info.ModTime().Before(execStart) {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		var meta cursorChatMeta
+		if err := json.Unmarshal(data, &meta); err != nil {
+			return fmt.Errorf("decode Cursor metadata %q: %w", path, err)
+		}
+		if meta.CWD != cwd {
+			return nil
+		}
+		candidates = append(candidates, coopNamedStoreCandidate{
+			storePath: path,
+			name:      meta.Title,
+			modTime:   info.ModTime(),
+		})
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return coopNamedStoreCandidate{}, errors.New("cursor chat store is absent")
+		}
+		return coopNamedStoreCandidate{}, fmt.Errorf("scan Cursor chat store: %w", err)
+	}
+	return selectCoopNamedStoreCandidate(candidates, "Cursor chat")
+}
+
+func (cursorNamedStoreReader) readName(candidate coopNamedStoreCandidate) (string, error) {
+	data, err := os.ReadFile(candidate.storePath)
+	if err != nil {
+		return "", err
+	}
+	var meta cursorChatMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", fmt.Errorf("decode Cursor metadata %q: %w", candidate.storePath, err)
+	}
+	return meta.Title, nil
+}

--- a/internal/cli/coop_exec_named_store_unix.go
+++ b/internal/cli/coop_exec_named_store_unix.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -22,6 +22,8 @@ const (
 	// an unknown store and must not be used for automatic naming.
 	codexStateFilename           = "state_5.sqlite"
 	codexThreadsQuery            = "SELECT cwd, name, title, rollout_path FROM threads"
+	codexRolloutTimestampLayout  = "2006-01-02T15-04-05"
+	coopNamedStoreClockSlack     = 2 * time.Second
 	coopNamedTUIReadbackInterval = 500 * time.Millisecond
 )
 
@@ -55,9 +57,6 @@ func coopNamedStoreReaderFor(binary string) (coopNamedStoreReader, bool) {
 }
 
 func selectCoopNamedStoreCandidate(candidates []coopNamedStoreCandidate, description string) (coopNamedStoreCandidate, error) {
-	sort.SliceStable(candidates, func(i, j int) bool {
-		return candidates[i].modTime.After(candidates[j].modTime)
-	})
 	switch len(candidates) {
 	case 0:
 		return coopNamedStoreCandidate{}, fmt.Errorf("no new %s store candidate", description)
@@ -86,6 +85,7 @@ func (codexNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamedS
 	if err != nil {
 		return coopNamedStoreCandidate{}, err
 	}
+	windowStart := execStart.Add(-coopNamedStoreClockSlack)
 	candidates := make([]coopNamedStoreCandidate, 0, 1)
 	for _, row := range rows {
 		if row.CWD != cwd || row.RolloutPath == "" {
@@ -98,7 +98,8 @@ func (codexNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamedS
 			}
 			return coopNamedStoreCandidate{}, fmt.Errorf("stat Codex rollout %q: %w", row.RolloutPath, statErr)
 		}
-		if info.ModTime().Before(execStart) {
+		createdAt, ok := codexRolloutCreationTime(row.RolloutPath, execStart.Location())
+		if !ok || createdAt.Before(windowStart) {
 			continue
 		}
 		candidates = append(candidates, coopNamedStoreCandidate{
@@ -109,6 +110,24 @@ func (codexNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamedS
 		})
 	}
 	return selectCoopNamedStoreCandidate(candidates, "Codex thread")
+}
+
+func codexRolloutCreationTime(path string, location *time.Location) (time.Time, bool) {
+	base := filepath.Base(path)
+	const prefix = "rollout-"
+	if !strings.HasPrefix(base, prefix) || !strings.HasSuffix(base, ".jsonl") {
+		return time.Time{}, false
+	}
+	stampStart := len(prefix)
+	stampEnd := stampStart + len(codexRolloutTimestampLayout)
+	if len(base) <= stampEnd || base[stampEnd] != '-' {
+		return time.Time{}, false
+	}
+	createdAt, err := time.ParseInLocation(codexRolloutTimestampLayout, base[stampStart:stampEnd], location)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return createdAt, true
 }
 
 func (codexNamedStoreReader) readName(candidate coopNamedStoreCandidate) (string, error) {
@@ -192,8 +211,10 @@ func runCodexSQLiteQueryProcess(dbPath string) ([]byte, error) {
 }
 
 type cursorChatMeta struct {
-	Title string `json:"title"`
-	CWD   string `json:"cwd"`
+	Title       string          `json:"title"`
+	CWD         string          `json:"cwd"`
+	CreatedAt   json.RawMessage `json:"createdAt"`
+	CreatedAtMs json.RawMessage `json:"createdAtMs"`
 }
 
 type cursorNamedStoreReader struct{}
@@ -204,6 +225,7 @@ func (cursorNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamed
 		return coopNamedStoreCandidate{}, fmt.Errorf("resolve Cursor home: %w", err)
 	}
 	root := filepath.Join(home, ".cursor", "chats")
+	windowStart := execStart.Add(-coopNamedStoreClockSlack)
 	var candidates []coopNamedStoreCandidate
 	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -216,7 +238,7 @@ func (cursorNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamed
 		if infoErr != nil {
 			return infoErr
 		}
-		if !info.Mode().IsRegular() || info.ModTime().Before(execStart) {
+		if !info.Mode().IsRegular() {
 			return nil
 		}
 		data, readErr := os.ReadFile(path)
@@ -228,6 +250,13 @@ func (cursorNamedStoreReader) locate(cwd string, execStart time.Time) (coopNamed
 			return fmt.Errorf("decode Cursor metadata %q: %w", path, err)
 		}
 		if meta.CWD != cwd {
+			return nil
+		}
+		createdAt, hasCreationTime, creationErr := cursorChatCreationTime(path, meta)
+		if creationErr != nil {
+			return fmt.Errorf("read Cursor chat creation time %q: %w", path, creationErr)
+		}
+		if !hasCreationTime || createdAt.Before(windowStart) {
 			return nil
 		}
 		candidates = append(candidates, coopNamedStoreCandidate{
@@ -256,4 +285,47 @@ func (cursorNamedStoreReader) readName(candidate coopNamedStoreCandidate) (strin
 		return "", fmt.Errorf("decode Cursor metadata %q: %w", candidate.storePath, err)
 	}
 	return meta.Title, nil
+}
+
+func cursorChatCreationTime(metaPath string, meta cursorChatMeta) (time.Time, bool, error) {
+	for _, value := range []struct {
+		field string
+		raw   json.RawMessage
+	}{
+		{field: "createdAtMs", raw: meta.CreatedAtMs},
+		{field: "createdAt", raw: meta.CreatedAt},
+	} {
+		if raw := bytes.TrimSpace(value.raw); len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+			continue
+		}
+		createdAt, err := parseCursorCreationValue(value.raw, value.field)
+		if err != nil {
+			return time.Time{}, false, err
+		}
+		return createdAt, true, nil
+	}
+	return cursorChatDirectoryBirthTime(metaPath)
+}
+
+func parseCursorCreationValue(raw json.RawMessage, field string) (time.Time, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) != 0 && raw[0] == '"' {
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return time.Time{}, fmt.Errorf("decode %s: %w", field, err)
+		}
+		if createdAt, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return createdAt, nil
+		}
+		millis, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("parse %s %q: %w", field, value, err)
+		}
+		return time.UnixMilli(millis), nil
+	}
+	var millis int64
+	if err := json.Unmarshal(raw, &millis); err != nil {
+		return time.Time{}, fmt.Errorf("decode %s: %w", field, err)
+	}
+	return time.UnixMilli(millis), nil
 }

--- a/internal/cli/coop_exec_named_store_unix_test.go
+++ b/internal/cli/coop_exec_named_store_unix_test.go
@@ -8,10 +8,16 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+func codexTestRolloutPath(dir string, createdAt time.Time, suffix string) string {
+	return filepath.Join(dir, "rollout-"+createdAt.Format(codexRolloutTimestampLayout)+"-"+suffix+".jsonl")
+}
 
 func TestCoopNamedSessionLabel(t *testing.T) {
 	for _, test := range []struct {
@@ -104,7 +110,8 @@ func TestResolveCoopNamedEnabledUsesLaunchConfig(t *testing.T) {
 func TestCodexNamedStoreReaderUsesReadOnlyStoreAndFiltersWindow(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", home)
-	rollout := filepath.Join(home, "rollout.jsonl")
+	start := time.Now()
+	rollout := codexTestRolloutPath(home, start, "test")
 	if err := os.WriteFile(rollout, []byte("{}\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +130,6 @@ func TestCodexNamedStoreReaderUsesReadOnlyStoreAndFiltersWindow(t *testing.T) {
   "rollout_path": "` + rollout + `"
 }]`), nil
 	}
-	start := time.Now().Add(-time.Second)
 	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
 	if err != nil {
 		t.Fatalf("locate Codex candidate: %v", err)
@@ -134,13 +140,9 @@ func TestCodexNamedStoreReaderUsesReadOnlyStoreAndFiltersWindow(t *testing.T) {
 	if gotDB != candidate.storePath {
 		t.Fatalf("sqlite database = %q, want %q", gotDB, candidate.storePath)
 	}
+	second := codexTestRolloutPath(home, start, "second")
 	runCodexSQLiteQuery = func(string) ([]byte, error) {
-		return []byte(`[{
-  "cwd": "` + cwd + `",
-  "name": "",
-  "title": "feature/codex",
-  "rollout_path": "` + rollout + `"
-}]`), nil
+		return []byte(`[{"cwd":"` + cwd + `","name":"","title":"feature/codex","rollout_path":"` + rollout + `"},{"cwd":"` + cwd + `","name":"other","rollout_path":"` + second + `"}]`), nil
 	}
 	if got, err := (codexNamedStoreReader{}).readName(candidate); err != nil || got != "feature/codex" {
 		t.Fatalf("legacy Codex title readback = %q, %v", got, err)
@@ -154,10 +156,9 @@ func TestCodexNamedStoreReaderUsesReadOnlyStoreAndFiltersWindow(t *testing.T) {
 }, {
   "cwd": "` + cwd + `",
   "name": "other",
-  "rollout_path": "` + rollout + ".second" + `"
+  "rollout_path": "` + second + `"
 }]`), nil
 	}
-	second := rollout + ".second"
 	if err := os.WriteFile(second, []byte("{}\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -174,15 +175,15 @@ func TestCodexNamedStoreReaderSkipsCWDAndOldRollouts(t *testing.T) {
 		t.Fatal(err)
 	}
 	start := time.Now()
-	current := filepath.Join(home, "current.jsonl")
-	other := filepath.Join(home, "other.jsonl")
-	old := filepath.Join(home, "old.jsonl")
+	current := codexTestRolloutPath(home, start, "current")
+	other := codexTestRolloutPath(home, start, "other")
+	old := codexTestRolloutPath(home, start.Add(-3*time.Second), "old")
 	for _, path := range []string{current, other, old} {
 		if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
-	oldTime := start.Add(-time.Second)
+	oldTime := time.Now()
 	if err := os.Chtimes(old, oldTime, oldTime); err != nil {
 		t.Fatal(err)
 	}
@@ -203,6 +204,50 @@ func TestCodexNamedStoreReaderSkipsCWDAndOldRollouts(t *testing.T) {
 	}
 	if candidate.key != current {
 		t.Fatalf("candidate = %#v, want current rollout", candidate)
+	}
+}
+
+func TestCodexNamedStoreReaderAcceptsClockSlackButFiltersOlderRollouts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	withinCreated := start.Add(-time.Second)
+	oldCreated := start.Add(-3 * time.Second)
+	within := codexTestRolloutPath(home, withinCreated, "within")
+	old := codexTestRolloutPath(home, oldCreated, "old")
+	for _, path := range []string{within, old} {
+		if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	withinTime := time.Now()
+	oldTime := withinTime
+	if err := os.Chtimes(within, withinTime, withinTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(old, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := json.Marshal([]codexThreadRow{
+		{CWD: cwd, RolloutPath: within},
+		{CWD: cwd, RolloutPath: old},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldQuery := runCodexSQLiteQuery
+	t.Cleanup(func() { runCodexSQLiteQuery = oldQuery })
+	runCodexSQLiteQuery = func(string) ([]byte, error) { return rows, nil }
+	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
+	if err != nil {
+		t.Fatalf("locate Codex candidate with clock slack: %v", err)
+	}
+	if candidate.key != within {
+		t.Fatalf("candidate = %#v, want rollout within clock slack", candidate)
 	}
 }
 
@@ -264,14 +309,16 @@ func TestCursorNamedStoreReaderFiltersCWDAndWindow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	start := time.Now()
+	createdAt := strconv.FormatInt(start.UnixMilli(), 10)
 	metaPath := filepath.Join(home, ".cursor", "chats", "workspace", "chat", "meta.json")
 	if err := os.MkdirAll(filepath.Dir(metaPath), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(metaPath, []byte(`{"title":"","cwd":"`+cwd+`"}`), 0o600); err != nil {
+	if err := os.WriteFile(metaPath, []byte(`{"title":"","createdAtMs":`+createdAt+`,"cwd":"`+cwd+`"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	candidate, err := (cursorNamedStoreReader{}).locate(cwd, time.Now().Add(-time.Second))
+	candidate, err := (cursorNamedStoreReader{}).locate(cwd, start)
 	if err != nil {
 		t.Fatalf("locate Cursor candidate: %v", err)
 	}
@@ -286,11 +333,88 @@ func TestCursorNamedStoreReaderFiltersCWDAndWindow(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(other), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(other, []byte(`{"title":"other","cwd":"`+cwd+`"}`), 0o600); err != nil {
+	if err := os.WriteFile(other, []byte(`{"title":"other","createdAtMs":`+createdAt+`,"cwd":"`+cwd+`"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := (cursorNamedStoreReader{}).locate(cwd, time.Now().Add(-time.Second)); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+	if _, err := (cursorNamedStoreReader{}).locate(cwd, start); err == nil || !strings.Contains(err.Error(), "ambiguous") {
 		t.Fatalf("multiple Cursor candidates error = %v", err)
+	}
+}
+
+func TestCursorNamedStoreReaderAcceptsClockSlackButFiltersOlderChats(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	withinCreated := start.Add(-time.Second)
+	oldCreated := start.Add(-3 * time.Second)
+	within := filepath.Join(home, ".cursor", "chats", "workspace", "within", "meta.json")
+	old := filepath.Join(home, ".cursor", "chats", "workspace", "old", "meta.json")
+	for _, test := range []struct {
+		path      string
+		createdAt time.Time
+	}{
+		{path: within, createdAt: withinCreated},
+		{path: old, createdAt: oldCreated},
+	} {
+		path := test.path
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(`{"title":"","createdAtMs":`+strconv.FormatInt(test.createdAt.UnixMilli(), 10)+`,"cwd":"`+cwd+`"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	withinTime := time.Now()
+	oldTime := withinTime
+	if err := os.Chtimes(within, withinTime, withinTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(old, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := (cursorNamedStoreReader{}).locate(cwd, start)
+	if err != nil {
+		t.Fatalf("locate Cursor candidate with clock slack: %v", err)
+	}
+	if candidate.storePath != within {
+		t.Fatalf("candidate = %#v, want chat within clock slack", candidate)
+	}
+}
+
+func TestCursorNamedStoreReaderWithoutCreationEvidenceSkips(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux has no supported Cursor chat birth-time fallback")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	metaPath := filepath.Join(home, ".cursor", "chats", "workspace", "chat", "meta.json")
+	if err := os.MkdirAll(filepath.Dir(metaPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(metaPath, []byte(`{"title":"","cwd":"`+cwd+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldInject := coopNamedTTYInject
+	t.Cleanup(func() { coopNamedTTYInject = oldInject })
+	injections := 0
+	coopNamedTTYInject = func(string, string) error {
+		injections++
+		return nil
+	}
+	_, stderr, err := captureEnvOutput(t, func() error {
+		reader := cursorNamedStoreReader{}
+		return runCoopNamedTUI(&reader, "feature/agent", "agent", cwd, time.Now())
+	})
+	if err != nil || injections != 0 || !strings.Contains(stderr, "manually") {
+		t.Fatalf("missing Cursor creation evidence: err=%v injections=%d stderr=%q", err, injections, stderr)
 	}
 }
 

--- a/internal/cli/coop_exec_named_store_unix_test.go
+++ b/internal/cli/coop_exec_named_store_unix_test.go
@@ -1,0 +1,475 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCoopNamedSessionLabel(t *testing.T) {
+	for _, test := range []struct {
+		session string
+		handle  string
+		want    string
+	}{
+		{session: "", handle: "codex", want: "codex"},
+		{session: "feature-x", handle: "codex", want: "feature-x/codex"},
+	} {
+		if got := coopNamedSessionLabel(test.session, test.handle); got != test.want {
+			t.Fatalf("coopNamedSessionLabel(%q, %q) = %q, want %q", test.session, test.handle, got, test.want)
+		}
+	}
+}
+
+func TestAgentArgsPreventAutoName(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "explicit name", args: []string{"--name", "custom"}, want: true},
+		{name: "resume", args: []string{"--resume", "thread"}, want: true},
+		{name: "continue", args: []string{"-c"}, want: true},
+		{name: "model value looks like name flag", args: []string{"--model", "--name"}},
+		{name: "end of options", args: []string{"--", "--name"}},
+		{name: "name after model value", args: []string{"--model", "opus", "--name", "custom"}, want: true},
+		{name: "name in model equals value", args: []string{"--model=--name"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := agentArgsPreventAutoName(test.args); got != test.want {
+				t.Fatalf("agentArgsPreventAutoName(%#v) = %v, want %v", test.args, got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveCoopNamedEnabledPrecedence(t *testing.T) {
+	t.Setenv("AMQ_COOP_NAMED", "0")
+	got, err := resolveCoopNamedEnabled(false, true)
+	if err != nil || got {
+		t.Fatalf("environment off switch = %v, %v", got, err)
+	}
+	got, err = resolveCoopNamedEnabled(true, true)
+	if err != nil || !got {
+		t.Fatalf("flag precedence = %v, %v", got, err)
+	}
+
+	t.Setenv("AMQ_COOP_NAMED", "bad")
+	if _, err := resolveCoopNamedEnabled(false, true); err == nil || GetExitCode(err) != ExitUsage {
+		t.Fatalf("invalid environment value error = %v", err)
+	}
+}
+
+func TestResolveCoopNamedEnabledUsesLaunchConfig(t *testing.T) {
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(project, ".amq"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"schema":1,"named":false,"agents":[{"handle":"claude","adapter":"claude","command":["claude"]}]}`)
+	if err := os.WriteFile(filepath.Join(project, ".amq", "launch.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previous, wasSet := os.LookupEnv("AMQ_COOP_NAMED")
+	if err := os.Unsetenv("AMQ_COOP_NAMED"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if wasSet {
+			_ = os.Setenv("AMQ_COOP_NAMED", previous)
+		} else {
+			_ = os.Unsetenv("AMQ_COOP_NAMED")
+		}
+	})
+	got, err := resolveCoopNamedEnabled(false, true)
+	if err != nil || got {
+		t.Fatalf("launch config off switch = %v, %v", got, err)
+	}
+}
+
+func TestCodexNamedStoreReaderUsesReadOnlyStoreAndFiltersWindow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	rollout := filepath.Join(home, "rollout.jsonl")
+	if err := os.WriteFile(rollout, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldQuery := runCodexSQLiteQuery
+	t.Cleanup(func() { runCodexSQLiteQuery = oldQuery })
+	var gotDB string
+	runCodexSQLiteQuery = func(dbPath string) ([]byte, error) {
+		gotDB = dbPath
+		return []byte(`[{
+  "cwd": "` + cwd + `",
+  "name": "",
+  "rollout_path": "` + rollout + `"
+}]`), nil
+	}
+	start := time.Now().Add(-time.Second)
+	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
+	if err != nil {
+		t.Fatalf("locate Codex candidate: %v", err)
+	}
+	if candidate.storePath != filepath.Join(home, codexStateFilename) || candidate.key != rollout {
+		t.Fatalf("candidate = %#v", candidate)
+	}
+	if gotDB != candidate.storePath {
+		t.Fatalf("sqlite database = %q, want %q", gotDB, candidate.storePath)
+	}
+	runCodexSQLiteQuery = func(string) ([]byte, error) {
+		return []byte(`[{
+  "cwd": "` + cwd + `",
+  "name": "",
+  "title": "feature/codex",
+  "rollout_path": "` + rollout + `"
+}]`), nil
+	}
+	if got, err := (codexNamedStoreReader{}).readName(candidate); err != nil || got != "feature/codex" {
+		t.Fatalf("legacy Codex title readback = %q, %v", got, err)
+	}
+
+	runCodexSQLiteQuery = func(string) ([]byte, error) {
+		return []byte(`[{
+  "cwd": "` + cwd + `",
+  "name": "",
+  "rollout_path": "` + rollout + `"
+}, {
+  "cwd": "` + cwd + `",
+  "name": "other",
+  "rollout_path": "` + rollout + ".second" + `"
+}]`), nil
+	}
+	second := rollout + ".second"
+	if err := os.WriteFile(second, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (codexNamedStoreReader{}).locate(cwd, start); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("multiple candidates error = %v", err)
+	}
+}
+
+func TestCodexNamedStoreReaderSkipsCWDAndOldRollouts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	current := filepath.Join(home, "current.jsonl")
+	other := filepath.Join(home, "other.jsonl")
+	old := filepath.Join(home, "old.jsonl")
+	for _, path := range []string{current, other, old} {
+		if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldTime := start.Add(-time.Second)
+	if err := os.Chtimes(old, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := json.Marshal([]codexThreadRow{
+		{CWD: cwd, RolloutPath: current},
+		{CWD: filepath.Join(home, "other-cwd"), RolloutPath: other},
+		{CWD: cwd, RolloutPath: old},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldQuery := runCodexSQLiteQuery
+	t.Cleanup(func() { runCodexSQLiteQuery = oldQuery })
+	runCodexSQLiteQuery = func(string) ([]byte, error) { return rows, nil }
+	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
+	if err != nil {
+		t.Fatalf("locate filtered Codex candidate: %v", err)
+	}
+	if candidate.key != current {
+		t.Fatalf("candidate = %#v, want current rollout", candidate)
+	}
+}
+
+func TestCodexNamedStoreReaderMissingSQLiteIsUnknown(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (codexNamedStoreReader{}).locate(cwd, time.Now())
+	if err == nil || !strings.Contains(err.Error(), "sqlite3") {
+		t.Fatalf("missing sqlite3 error = %v", err)
+	}
+}
+
+func TestRunCodexSQLiteQueryProcessUsesFixedReadOnlyQuery(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := filepath.Join(dir, "sqlite3")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$AMQ_TEST_SQLITE_ARGS\"\nprintf '[]\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("AMQ_TEST_SQLITE_ARGS", argsPath)
+	dbPath := filepath.Join(dir, "database with spaces")
+	data, err := runCodexSQLiteQueryProcess(dbPath)
+	if err != nil {
+		t.Fatalf("run sqlite3 query: %v", err)
+	}
+	if string(data) != "[]\n" {
+		t.Fatalf("sqlite3 output = %q", data)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "-readonly\n-json\n" + dbPath + "\n" + codexThreadsQuery + "\n"
+	if string(args) != want {
+		t.Fatalf("sqlite3 args = %q, want %q", args, want)
+	}
+}
+
+func TestReadCodexThreadRowsRejectsSchemaMismatch(t *testing.T) {
+	oldQuery := runCodexSQLiteQuery
+	t.Cleanup(func() { runCodexSQLiteQuery = oldQuery })
+	runCodexSQLiteQuery = func(string) ([]byte, error) {
+		return []byte(`[{"cwd":"cwd","name":"name","rollout_path":"rollout","unexpected":true}]`), nil
+	}
+	if _, err := readCodexThreadRows("ignored"); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("schema mismatch error = %v", err)
+	}
+}
+
+func TestCursorNamedStoreReaderFiltersCWDAndWindow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	metaPath := filepath.Join(home, ".cursor", "chats", "workspace", "chat", "meta.json")
+	if err := os.MkdirAll(filepath.Dir(metaPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(metaPath, []byte(`{"title":"","cwd":"`+cwd+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := (cursorNamedStoreReader{}).locate(cwd, time.Now().Add(-time.Second))
+	if err != nil {
+		t.Fatalf("locate Cursor candidate: %v", err)
+	}
+	if candidate.storePath != metaPath || candidate.name != "" {
+		t.Fatalf("candidate = %#v", candidate)
+	}
+	if got, err := (cursorNamedStoreReader{}).readName(candidate); err != nil || got != "" {
+		t.Fatalf("Cursor readback = %q, %v", got, err)
+	}
+
+	other := filepath.Join(home, ".cursor", "chats", "workspace", "other", "meta.json")
+	if err := os.MkdirAll(filepath.Dir(other), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(other, []byte(`{"title":"other","cwd":"`+cwd+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (cursorNamedStoreReader{}).locate(cwd, time.Now().Add(-time.Second)); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("multiple Cursor candidates error = %v", err)
+	}
+}
+
+type fakeCoopNamedStoreReader struct {
+	candidate coopNamedStoreCandidate
+	locateErr error
+	names     []string
+	readCalls int
+}
+
+func (r *fakeCoopNamedStoreReader) locate(string, time.Time) (coopNamedStoreCandidate, error) {
+	if r.locateErr != nil {
+		return coopNamedStoreCandidate{}, r.locateErr
+	}
+	return r.candidate, nil
+}
+
+func (r *fakeCoopNamedStoreReader) readName(coopNamedStoreCandidate) (string, error) {
+	r.readCalls++
+	if len(r.names) == 0 {
+		return "", nil
+	}
+	index := r.readCalls - 1
+	if index >= len(r.names) {
+		index = len(r.names) - 1
+	}
+	return r.names[index], nil
+}
+
+func TestRunCoopNamedTUISkipsNamedStoreAndConfirmsReadback(t *testing.T) {
+	oldInject := coopNamedTTYInject
+	oldTimeout := coopNamedTUIReadbackTimeout
+	oldSleep := coopNamedReadbackSleep
+	t.Cleanup(func() {
+		coopNamedTTYInject = oldInject
+		coopNamedTUIReadbackTimeout = oldTimeout
+		coopNamedReadbackSleep = oldSleep
+	})
+
+	reader := &fakeCoopNamedStoreReader{candidate: coopNamedStoreCandidate{name: "existing"}}
+	injections := 0
+	coopNamedTTYInject = func(string, string) error {
+		injections++
+		return nil
+	}
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runCoopNamedTUI(reader, "feature/codex", "codex", "/tmp/project", time.Now())
+	})
+	if err != nil || injections != 0 || stderr != "" {
+		t.Fatalf("named store skip: err=%v injections=%d stderr=%q", err, injections, stderr)
+	}
+
+	reader = &fakeCoopNamedStoreReader{candidate: coopNamedStoreCandidate{}, names: []string{"", "feature/codex"}}
+	coopNamedTUIReadbackTimeout = time.Second
+	coopNamedReadbackSleep = func(time.Duration) {}
+	_, stderr, err = captureEnvOutput(t, func() error {
+		return runCoopNamedTUI(reader, "feature/codex", "codex", "/tmp/project", time.Now())
+	})
+	if err != nil || injections != 1 || !strings.Contains(stderr, "named feature/codex") {
+		t.Fatalf("readback success: err=%v injections=%d stderr=%q", err, injections, stderr)
+	}
+}
+
+func TestRunCoopNamedTUIReadbackFailureDoesNotReinject(t *testing.T) {
+	oldInject := coopNamedTTYInject
+	oldTimeout := coopNamedTUIReadbackTimeout
+	oldSleep := coopNamedReadbackSleep
+	t.Cleanup(func() {
+		coopNamedTTYInject = oldInject
+		coopNamedTUIReadbackTimeout = oldTimeout
+		coopNamedReadbackSleep = oldSleep
+	})
+	reader := &fakeCoopNamedStoreReader{candidate: coopNamedStoreCandidate{}}
+	injections := 0
+	coopNamedTTYInject = func(string, string) error {
+		injections++
+		return nil
+	}
+	coopNamedTUIReadbackTimeout = time.Millisecond
+	coopNamedReadbackSleep = time.Sleep
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runCoopNamedTUI(reader, "feature/codex", "codex", "/tmp/project", time.Now())
+	})
+	if err != nil || injections != 1 || reader.readCalls == 0 {
+		t.Fatalf("readback failure execution: err=%v injections=%d reads=%d", err, injections, reader.readCalls)
+	}
+	if !strings.Contains(stderr, "enter \"/rename feature/codex\" manually") {
+		t.Fatalf("manual reminder = %q", stderr)
+	}
+}
+
+func TestRunCoopNamedTUIUnknownStoreSkipsInjection(t *testing.T) {
+	oldInject := coopNamedTTYInject
+	t.Cleanup(func() { coopNamedTTYInject = oldInject })
+	injections := 0
+	coopNamedTTYInject = func(string, string) error {
+		injections++
+		return nil
+	}
+	reader := &fakeCoopNamedStoreReader{locateErr: errors.New("store unavailable")}
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runCoopNamedTUI(reader, "feature/codex", "codex", "/tmp/project", time.Now())
+	})
+	if err != nil || injections != 0 || !strings.Contains(stderr, "store unavailable") {
+		t.Fatalf("unknown store: err=%v injections=%d stderr=%q", err, injections, stderr)
+	}
+}
+
+func TestRunCoopNamedInjectMissingSQLiteSkipsInjection(t *testing.T) {
+	t.Setenv("CODEX_HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+	oldInject := coopNamedTTYInject
+	t.Cleanup(func() { coopNamedTTYInject = oldInject })
+	injections := 0
+	coopNamedTTYInject = func(string, string) error {
+		injections++
+		return nil
+	}
+	reader := codexNamedStoreReader{}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, err := captureEnvOutput(t, func() error {
+		return runCoopNamedTUI(&reader, "feature/codex", "codex", cwd, time.Now())
+	})
+	if err != nil || injections != 0 || !strings.Contains(stderr, "manually") {
+		t.Fatalf("missing sqlite3: err=%v injections=%d stderr=%q", err, injections, stderr)
+	}
+}
+
+func TestCodexNamedStoreReaderLive(t *testing.T) {
+	if os.Getenv("AMQ_CODEX_LIVE") != "1" {
+		t.Skip("set AMQ_CODEX_LIVE=1 to run the scratch Codex session proof")
+	}
+	codex, err := exec.LookPath("codex")
+	if err != nil {
+		t.Skipf("codex is unavailable: %v", err)
+	}
+	home := t.TempDir()
+	cwd := t.TempDir()
+	start := time.Now()
+	cmd := exec.Command(codex, "exec", "--skip-git-repo-check", "--json", "Reply with exactly OK")
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), "CODEX_HOME="+home)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("scratch Codex session: %v\n%s", err, output)
+	}
+	candidate, err := (codexNamedStoreReader{}).locate(cwd, start)
+	if err != nil {
+		t.Fatalf("read scratch Codex store: %v", err)
+	}
+	if _, err := (codexNamedStoreReader{}).readName(candidate); err != nil {
+		t.Fatalf("read scratch Codex name: %v", err)
+	}
+}
+
+func TestCursorNamedStoreReaderLive(t *testing.T) {
+	if os.Getenv("AMQ_CURSOR_LIVE") != "1" {
+		t.Skip("set AMQ_CURSOR_LIVE=1 to run the scratch Cursor session proof")
+	}
+	agent, err := exec.LookPath("agent")
+	if err != nil {
+		t.Skipf("Cursor agent is unavailable: %v", err)
+	}
+	home := t.TempDir()
+	cwd := t.TempDir()
+	start := time.Now()
+	cmd := exec.Command(agent, "--print", "Reply with exactly OK")
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("scratch Cursor session: %v\n%s", err, output)
+	}
+	candidate, err := (cursorNamedStoreReader{}).locate(cwd, start)
+	if err != nil {
+		t.Fatalf("read scratch Cursor store: %v", err)
+	}
+	if _, err := (cursorNamedStoreReader{}).readName(candidate); err != nil {
+		t.Fatalf("read scratch Cursor name: %v", err)
+	}
+}

--- a/internal/cli/coop_exec_named_unix.go
+++ b/internal/cli/coop_exec_named_unix.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -25,14 +26,14 @@ var (
 	coopNamedTTYInject = func(me, binaryBase string) error {
 		return injectCoopNamedSlashCommand(me, binaryBase)
 	}
-	coopNamedStartupSleep = func(time.Duration) { time.Sleep(coopNamedTUIStartupDelay) }
+	coopNamedStartupSleep = func(delay time.Duration) { time.Sleep(delay) }
 )
 
-var startCoopNamedTUIInjector = func(me, cmdName string) error {
-	return startCoopNamedTUIInjectorProcess(me, cmdName)
+var startCoopNamedTUIInjector = func(name, cmdName string, execStart time.Time) error {
+	return startCoopNamedTUIInjectorProcess(name, cmdName, execStart)
 }
 
-func startCoopNamedTUIInjectorProcess(me, cmdName string) error {
+func startCoopNamedTUIInjectorProcess(name, cmdName string, execStart time.Time) error {
 	amqExecutable, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve amq executable for coop named inject: %w", err)
@@ -46,8 +47,9 @@ func startCoopNamedTUIInjectorProcess(me, cmdName string) error {
 		"--no-update-check",
 		"coop",
 		"named-inject",
-		"--me", me,
+		"--name", name,
 		"--binary", filepath.Base(cmdName),
+		"--exec-start-ns", strconv.FormatInt(execStart.UnixNano(), 10),
 	)
 	// Leave stdin/stdout on the null device so the helper does not steal the
 	// agent's TTY fds. Injection opens the controlling terminal via /dev/tty.
@@ -75,23 +77,28 @@ func coopNamedHasControllingTTY() bool {
 
 func runCoopNamedInject(args []string) error {
 	fs := flag.NewFlagSet("coop named-inject", flag.ContinueOnError)
-	meFlag := fs.String("me", "", "AMQ handle to stamp onto the CLI session")
+	nameFlag := fs.String("name", "", "Session name to stamp onto the CLI session")
+	meFlag := fs.String("me", "", "Legacy alias for --name")
 	binaryFlag := fs.String("binary", "", "Spawned CLI binary basename")
 	delayFlag := fs.Duration("startup-delay", coopNamedTUIStartupDelay, "Delay before terminal injection")
+	execStartFlag := fs.Int64("exec-start-ns", 0, "Internal coop exec start timestamp")
 	usage := func() {
-		_ = writeStderr("usage: amq coop named-inject --me <handle> --binary <basename>\n")
+		_ = writeStderr("usage: amq coop named-inject --name <session/name> --binary <basename>\n")
 	}
 	if handled, err := parseFlags(fs, args, usage); err != nil {
 		return err
 	} else if handled {
 		return nil
 	}
-	me := strings.TrimSpace(*meFlag)
-	if me == "" {
-		return UsageError("--me is required")
+	name := strings.TrimSpace(*nameFlag)
+	if name == "" {
+		name = strings.TrimSpace(*meFlag)
 	}
-	if _, err := normalizeHandle(me); err != nil {
-		return UsageError("--me: %v", err)
+	if name == "" {
+		return UsageError("--name is required")
+	}
+	if err := validateCoopNamedSessionLabel(name); err != nil {
+		return UsageError("--name: %v", err)
 	}
 	binaryBase := strings.TrimSpace(*binaryFlag)
 	if binaryBase == "" {
@@ -100,12 +107,83 @@ func runCoopNamedInject(args []string) error {
 	if coopNamedModeFor(binaryBase) != coopNamedModeTUI {
 		return UsageError("--binary %q does not use coop named terminal injection", binaryBase)
 	}
+	execStart := time.Now()
+	if *execStartFlag != 0 {
+		execStart = time.Unix(0, *execStartFlag)
+	}
 	if *delayFlag > 0 {
 		coopNamedStartupSleep(*delayFlag)
 	}
-	if err := coopNamedTTYInject(me, binaryBase); err != nil {
-		_ = writeStderr("warning: coop named inject failed: %v\n", err)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve coop named spawn cwd: %w", err)
 	}
+	reader, ok := coopNamedStoreReaderFor(binaryBase)
+	if !ok {
+		_ = writeStderr("%s\n", coopNamedTUIManualReminder(name, binaryBase, "unsupported store"))
+		return nil
+	}
+	if err := runCoopNamedTUI(reader, name, binaryBase, cwd, execStart); err != nil {
+		_ = writeStderr("warning: coop named inject: %v\n", err)
+	}
+	return nil
+}
+
+func validateCoopNamedSessionLabel(name string) error {
+	parts := strings.Split(name, "/")
+	switch len(parts) {
+	case 1:
+		_, err := normalizeHandle(parts[0])
+		return err
+	case 2:
+		if err := validateSessionName(parts[0]); err != nil {
+			return err
+		}
+		_, err := normalizeHandle(parts[1])
+		return err
+	default:
+		return fmt.Errorf("must be <handle> or <session>/<handle>")
+	}
+}
+
+func coopNamedTUIManualReminder(name, binaryBase, reason string) string {
+	return fmt.Sprintf(
+		"warning: cannot confirm %s CLI session %q (%s); enter %q manually",
+		filepath.Base(binaryBase), name, reason, coopNamedTUICommand(binaryBase, name),
+	)
+}
+
+func runCoopNamedTUI(reader coopNamedStoreReader, name, binaryBase, cwd string, execStart time.Time) error {
+	candidate, err := reader.locate(cwd, execStart)
+	if err != nil {
+		_ = writeStderr("%s\n", coopNamedTUIManualReminder(name, binaryBase, err.Error()))
+		return nil
+	}
+	if strings.TrimSpace(candidate.name) != "" {
+		return nil
+	}
+	if err := coopNamedTTYInject(name, binaryBase); err != nil {
+		_ = writeStderr("%s\n", coopNamedTUIManualReminder(name, binaryBase, err.Error()))
+		return nil
+	}
+
+	deadline := time.Now().Add(coopNamedTUIReadbackTimeout)
+	for {
+		actual, readErr := reader.readName(candidate)
+		if readErr == nil && strings.TrimSpace(actual) == name {
+			_ = writeStderr("named %s\n", name)
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		remaining := time.Until(deadline)
+		if remaining > coopNamedTUIReadbackInterval {
+			remaining = coopNamedTUIReadbackInterval
+		}
+		coopNamedReadbackSleep(remaining)
+	}
+	_ = writeStderr("%s\n", coopNamedTUIManualReminder(name, binaryBase, "rename was not confirmed"))
 	return nil
 }
 

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -254,6 +254,29 @@ func TestInjectCoopNamedArgv(t *testing.T) {
 	}
 }
 
+func TestAgentArgsPreventAutoNameForHarness(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		binary string
+		args   []string
+		want   bool
+	}{
+		{name: "codex resume", binary: "codex", args: []string{"resume", "thread"}, want: true},
+		{name: "codex exec resume", binary: "codex", args: []string{"exec", "resume", "thread"}, want: true},
+		{name: "codex plain", binary: "codex", args: []string{"exec"}},
+		{name: "cursor resume", binary: "agent", args: []string{"--resume", "chat"}, want: true},
+		{name: "cursor resume equals", binary: "agent", args: []string{"--resume=chat"}, want: true},
+		{name: "claude continue", binary: "claude", args: []string{"--continue"}, want: true},
+		{name: "pi resume", binary: "pi", args: []string{"-r", "thread"}, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := agentArgsPreventAutoNameFor(test.binary, test.args); got != test.want {
+				t.Fatalf("agentArgsPreventAutoNameFor(%q, %#v) = %v, want %v", test.binary, test.args, got, test.want)
+			}
+		})
+	}
+}
+
 func TestCoopExecNamedInjectsArgv(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
@@ -572,6 +595,42 @@ func TestApplyCoopNamedStartsTUIInjector(t *testing.T) {
 	}
 	if !reflect.DeepEqual(args, []string{"--foo"}) {
 		t.Fatalf("args = %#v, want unchanged agent flags", args)
+	}
+}
+
+func TestApplyCoopNamedSuppressesTUIInjectorForExistingSession(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{name: "codex resume", args: []string{"resume", "thread"}},
+		{name: "codex exec resume", args: []string{"exec", "resume", "thread"}},
+		{name: "cursor resume", args: []string{"--resume", "chat"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			started := false
+			oldStart := startCoopNamedTUIInjector
+			startCoopNamedTUIInjector = func(string, string, time.Time) error {
+				started = true
+				return nil
+			}
+			t.Cleanup(func() { startCoopNamedTUIInjector = oldStart })
+
+			binary := "codex"
+			if strings.Contains(test.name, "cursor") {
+				binary = "agent"
+			}
+			args, err := applyCoopNamedBeforeExecAt(true, binary, test.args, "feature/"+binary, time.Now())
+			if err != nil {
+				t.Fatalf("applyCoopNamedBeforeExecAt: %v", err)
+			}
+			if started {
+				t.Fatal("TUI injector started for an existing session")
+			}
+			if !reflect.DeepEqual(args, test.args) {
+				t.Fatalf("args = %#v, want unchanged %#v", args, test.args)
+			}
+		})
 	}
 }
 

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -217,6 +217,20 @@ func TestInjectCoopNamedArgv(t *testing.T) {
 			unchanged: true,
 		},
 		{
+			name:      "skips resume",
+			cmd:       "claude",
+			args:      []string{"--resume", "thread"},
+			me:        "coder1",
+			unchanged: true,
+		},
+		{
+			name: "ignores name-looking model value",
+			cmd:  "claude",
+			args: []string{"--model", "--name"},
+			me:   "coder1",
+			want: []string{"--name", "coder1", "--model", "--name"},
+		},
+		{
 			name:      "codex unchanged",
 			cmd:       "codex",
 			args:      []string{"--foo"},
@@ -293,7 +307,7 @@ func TestCoopExecNamedRefusedUnderManagedLaunch(t *testing.T) {
 
 				tuiInjectorCalled := false
 				oldTUIInjector := startCoopNamedTUIInjector
-				startCoopNamedTUIInjector = func(string, string) error {
+				startCoopNamedTUIInjector = func(string, string, time.Time) error {
 					tuiInjectorCalled = true
 					return nil
 				}
@@ -401,7 +415,7 @@ func seedManagedCoopExecTicket(t *testing.T, handle, nonce string) string {
 	return session
 }
 
-func TestCoopExecNamedWithoutFlagDoesNotInject(t *testing.T) {
+func TestCoopExecNamedDefaultsOn(t *testing.T) {
 	root := secureTempDirForTest(t)
 	if err := fsq.EnsureRootDirs(root); err != nil {
 		t.Fatal(err)
@@ -426,9 +440,40 @@ func TestCoopExecNamedWithoutFlagDoesNotInject(t *testing.T) {
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("coop exec error = %v, want sentinel", err)
 	}
-	wantArgv := []string{"claude"}
+	wantArgv := []string{"claude", "--name", "coder1"}
 	if !reflect.DeepEqual(gotArgv, wantArgv) {
 		t.Fatalf("argv = %#v, want %#v", gotArgv, wantArgv)
+	}
+}
+
+func TestCoopExecNamedDisabledByFlag(t *testing.T) {
+	root := secureTempDirForTest(t)
+	if err := fsq.EnsureRootDirs(root); err != nil {
+		t.Fatal(err)
+	}
+	putBareCommandOnPATH(t, "claude")
+
+	sentinel := errors.New("exec sentinel")
+	var gotArgv []string
+	oldExec := coopExecProcess
+	coopExecProcess = func(_ string, argv []string, _ []string) error {
+		gotArgv = append([]string{}, argv...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err := runCoopExec([]string{
+		"--root", root,
+		"--me", "coder1",
+		"--named=false",
+		"--no-wake",
+		"claude",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("coop exec error = %v, want sentinel", err)
+	}
+	if !reflect.DeepEqual(gotArgv, []string{"claude"}) {
+		t.Fatalf("argv = %#v, want naming disabled", gotArgv)
 	}
 }
 
@@ -509,7 +554,7 @@ func TestInjectCoopNamedSlashCommandRequiresControllingTTY(t *testing.T) {
 func TestApplyCoopNamedStartsTUIInjector(t *testing.T) {
 	var started bool
 	oldStart := startCoopNamedTUIInjector
-	startCoopNamedTUIInjector = func(me, cmdName string) error {
+	startCoopNamedTUIInjector = func(me, cmdName string, _ time.Time) error {
 		started = true
 		if me != "coder1" || cmdName != "codex" {
 			t.Fatalf("startCoopNamedTUIInjector me=%q cmd=%q", me, cmdName)
@@ -532,7 +577,7 @@ func TestApplyCoopNamedStartsTUIInjector(t *testing.T) {
 
 func TestApplyCoopNamedTUIInjectorFailureIsBestEffort(t *testing.T) {
 	oldStart := startCoopNamedTUIInjector
-	startCoopNamedTUIInjector = func(me, cmdName string) error {
+	startCoopNamedTUIInjector = func(me, cmdName string, _ time.Time) error {
 		return errors.New("inject helper unavailable")
 	}
 	t.Cleanup(func() { startCoopNamedTUIInjector = oldStart })

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -72,7 +72,7 @@ func runCoopExec(args []string) error {
 	fs.Var(&managedSymphonyEventFlags, "managed-symphony-event", "")
 	managedSymphonyWorkspaceFlag := fs.String("managed-symphony-workspace-key", "", "")
 	yesFlag := fs.Bool("y", false, "Skip confirmation prompts (including clearing a blocking wake)")
-	namedFlag := fs.Bool("named", false, "Stamp AM_ME onto the spawned CLI session name (opt-in; not under a managed launch)")
+	namedFlag := fs.Bool("named", true, "Stamp the session and AM_ME onto the spawned CLI session name")
 
 	usage := usageWithFlags(fs, "amq coop exec [options] <command> [-- <command-flags>]",
 		"Set up co-op mode and exec into the agent (replaces this process).",
@@ -94,7 +94,7 @@ func runCoopExec(args []string) error {
 		"  amq coop exec --require-wake --wake-inject-mode none claude  # Zero-input wake",
 		"  amq coop exec --wake-inject-via /path/to/injector codex",
 		"  amq coop exec --me myagent bash                   # Debug shell with AMQ env",
-		"  amq coop exec --named --me coder1 pi            # Exec pi --name coder1",
+		"  amq coop exec --named=false claude              # Disable automatic session naming",
 		"",
 		"Wake readiness:",
 		"  Coop never reuses a generic wake because it has no persisted",
@@ -107,8 +107,18 @@ func runCoopExec(args []string) error {
 	} else if handled {
 		return nil
 	}
-	if managedLaunchNonce != "" && *namedFlag {
+	namedEnabled, err := resolveCoopNamedEnabled(flagWasVisited(fs, "named"), *namedFlag)
+	if err != nil {
+		return err
+	}
+	if managedLaunchNonce != "" && flagWasVisited(fs, "named") && *namedFlag {
 		return UsageError("--named is not supported under a managed launch; declare the name in the launch plan instead")
+	}
+	if managedLaunchNonce != "" {
+		// Managed launches have no trusted provider-name field until the
+		// managed naming contract lands. Keep the existing launch boundary
+		// fail-closed while the direct path defaults to named sessions.
+		namedEnabled = false
 	}
 	if managedLaunchNonce != "" {
 		if !flagWasVisited(fs, "root") || strings.TrimSpace(*rootFlag) == "" || !filepath.IsAbs(*rootFlag) {
@@ -704,8 +714,11 @@ func runCoopExec(args []string) error {
 	sessionIdentity := coopSessionIdentity(root, requestedSession, *rootFlag)
 	env := buildCoopExecEnvironment(baseEnv, root, agentHandle, sessionIdentity)
 
-	// Optional --named: argv injection for claude/pi, TUI inject for codex/agent.
-	agentArgs, err = applyCoopNamedBeforeExec(*namedFlag, cmdName, agentArgs, agentHandle)
+	// Automatic naming uses the resolved session identity. A custom sessionless
+	// root has no session prefix and therefore uses only the agent handle.
+	namedLabel := coopNamedSessionLabel(sessionIdentity, agentHandle)
+	execStart := time.Now()
+	agentArgs, err = applyCoopNamedBeforeExecAt(namedEnabled, cmdName, agentArgs, namedLabel, execStart)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -311,6 +311,9 @@ func buildSetupState(options setupOptions) (setupState, error) {
 		Schema: launch.ProjectConfigSchema, DefaultSession: defaultSession, Agents: agents,
 		Layout: launch.LayoutIntent{Type: options.layout},
 	}
+	if projectExists {
+		projectConfig.Named = existingProject.Named
+	}
 	projectData, err := launch.MarshalProjectConfig(projectConfig)
 	if err != nil {
 		return setupState{}, err

--- a/internal/launch/config.go
+++ b/internal/launch/config.go
@@ -29,6 +29,7 @@ func knownLaunchers() []string {
 type ProjectConfig struct {
 	Schema         int                  `json:"schema"`
 	DefaultSession string               `json:"default_session"`
+	Named          *bool                `json:"named,omitempty"`
 	Agents         []ProjectAgentConfig `json:"agents"`
 	Layout         LayoutIntent         `json:"layout"`
 }
@@ -107,7 +108,7 @@ func ParseLocalConfig(path string, data []byte) (LocalConfig, error) {
 	}
 	for _, field := range []string{
 		"agents", "default_session", "layout", "resume_policy", "command",
-		"argv", "env", "cwd", "bypass_args", "trust", "root",
+		"argv", "env", "cwd", "bypass_args", "trust", "root", "named",
 	} {
 		if _, ok := fields[field]; ok {
 			return LocalConfig{}, &ConfigAuthorityConflictError{Path: path, Field: field}

--- a/internal/launch/config_test.go
+++ b/internal/launch/config_test.go
@@ -62,6 +62,23 @@ func TestProjectConfigAcceptsCursorCurrentExecutableAlias(t *testing.T) {
 	}
 }
 
+func TestProjectConfigAcceptsOptionalNamedPreference(t *testing.T) {
+	parsed, err := ParseProjectConfig([]byte(`{"schema":1,"named":false,"agents":[{"handle":"claude","command":["claude"]}]}`))
+	if err != nil {
+		t.Fatalf("ParseProjectConfig: %v", err)
+	}
+	if parsed.Named == nil || *parsed.Named {
+		t.Fatalf("named preference = %#v, want false", parsed.Named)
+	}
+	data, err := MarshalProjectConfig(parsed)
+	if err != nil {
+		t.Fatalf("MarshalProjectConfig: %v", err)
+	}
+	if !strings.Contains(string(data), `"named": false`) {
+		t.Fatalf("marshaled config omitted named preference: %s", data)
+	}
+}
+
 func TestProjectConfigRejectsExplicitEmptyOptionalDefaults(t *testing.T) {
 	for _, raw := range []string{
 		`{"schema":1,"default_session":"","agents":[{"handle":"claude","command":["claude"]}]}`,
@@ -78,7 +95,7 @@ func TestProjectConfigRejectsExplicitEmptyOptionalDefaults(t *testing.T) {
 }
 
 func TestLocalConfigRejectsAuthorityFields(t *testing.T) {
-	for _, field := range []string{"agents", "default_session", "argv", "env", "cwd", "bypass_args", "root"} {
+	for _, field := range []string{"agents", "default_session", "argv", "env", "cwd", "bypass_args", "root", "named"} {
 		raw := `{"schema":1,"launcher_preference":["commands"],"` + field + `":"forged"}`
 		_, err := ParseLocalConfig(".amq/launch.local.json", []byte(raw))
 		var conflict *ConfigAuthorityConflictError

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -203,10 +203,16 @@ Managed `tmux`, `cmux`, and `ghostty` backends run the plan in-app instead.
 
 Without `--session` or `--root`, `coop exec` uses the declared `default_session` from `.amq/launch.json`, or `collab` when none is declared. Creating a missing session or root from `coop exec` is deprecated and prints `warning: creating a missing session or root from coop exec is deprecated; use 'amq session create <name>' or 'amq init --root'. The next major release makes this exit 3.`
 
-Add `--named` to stamp `AM_ME` onto the CLI conversation title (`claude`/`pi`
-get `--name`; Codex and Cursor `agent` get a best-effort `/rename` on Unix).
-`--named` is not supported under a managed launch; declare the name in the
-launch plan instead.
+Direct `coop exec` names the provider session by default as
+`<session>/<handle>`, or as `<handle>` for a sessionless root. Claude and Pi
+get `--name`; Codex and Cursor `agent` get a best-effort TUI rename after the
+new session store is verified. Codex resumes by name, for example `codex resume
+session1/codex`. Cursor `agent` resumes through its picker only; resume-by-name
+is unproven. Existing names and `--resume`, `-r`, `--continue`, or `-c` flags
+are preserved. Disable naming with `--named=false`, `AMQ_COOP_NAMED=0`, or
+`"named": false` in `.amq/launch.json`. Managed launches keep naming disabled
+until their provider-name contract is available; explicit `--named` remains
+refused there.
 
 Add `--no-gitignore` when `coop exec` should auto-initialize the project without changing `.gitignore`.
 

--- a/skills/amq-cli/SKILL.md
+++ b/skills/amq-cli/SKILL.md
@@ -209,7 +209,8 @@ get `--name`; Codex and Cursor `agent` get a best-effort TUI rename after the
 new session store is verified. Codex resumes by name, for example `codex resume
 session1/codex`. Cursor `agent` resumes through its picker only; resume-by-name
 is unproven. Existing names and `--resume`, `-r`, `--continue`, or `-c` flags
-are preserved. Disable naming with `--named=false`, `AMQ_COOP_NAMED=0`, or
+are preserved, including `codex resume` and `agent --resume`. Disable naming
+with `--named=false`, `AMQ_COOP_NAMED=0`, or
 `"named": false` in `.amq/launch.json`. Managed launches keep naming disabled
 until their provider-name contract is available; explicit `--named` remains
 refused there.


### PR DESCRIPTION
## Purpose
Direct `coop exec` now gives each provider session a stable operator label so an agent can resume the intended conversation.

## Contract
- Default label is `<session>/<handle>`, or `<handle>` for a sessionless root.
- Precedence is `--named` flag, `AMQ_COOP_NAMED`, `.amq/launch.json` top-level `"named"`, then enabled by default.
- Disable with `--named=false`, `AMQ_COOP_NAMED=0`, or `"named": false`.
- Claude and Pi receive `--name`; existing `--name`, resume, and continue arguments are preserved, including `codex resume` and `agent --resume`.
- Codex and Cursor `agent` use one best-effort TUI rename only after AMQ finds exactly one session created by this exec for the spawn CWD. Existing names, resumed sessions, missing creation evidence, and ambiguous matches are never overwritten; failed readback never retries injection.
- Codex reads `CODEX_HOME/state_5.sqlite` read-only and binds candidates to the creation timestamp in the rollout filename.
- Cursor reads `~/.cursor/chats/**/meta.json` and binds candidates to `createdAtMs`/`createdAt`, or the chat-directory birth time on Darwin. Linux skips chats without creation evidence with a manual hint.
- The design note's `session_meta`/PID binding was replaced by provider-store creation-time binding. The project preference is top-level `"named"`, not `agents[].named`.

## Live evidence
- Claude: `claude --name s1/claude` persisted the exact slash label in JSONL and showed it in the resume picker.
- Codex `0.145.0`: `/rename s1/codex` reported the exact label, persisted it in `threads.title`, and `codex resume s1/codex` reopened that thread. This legacy version leaves `threads.name` null; readback accepts the legacy title.
- Cursor: rename with `/` is unverified because `agent` hit the account usage limit; this is recorded in bead `agent-message-queue-dro` for recheck after reset.

## Notes
- Managed launches remain disabled until a trusted provider-name contract exists; explicit `--named=true` is refused.
- Release note: coop exec now names harness sessions by default; disable with `--named=false`, `AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`.

Refs: agent-message-queue-dro
