### PR TITLE
fix(launch): classify an exited tmux server as a missing target

### DIFF
--- a/internal/launch/tmux.go
+++ b/internal/launch/tmux.go
@@ -1211,7 +1211,8 @@ func tmuxTargetMissing(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "couldn't find") ||
 		strings.Contains(msg, "can't find") ||
-		strings.Contains(msg, "no server running")
+		strings.Contains(msg, "no server running") ||
+		strings.Contains(msg, "server exited unexpectedly")
 }
 
 func tmuxCreateTimeout(req CreateRequest) time.Duration {

--- a/internal/launch/tmux_test.go
+++ b/internal/launch/tmux_test.go
@@ -122,6 +122,21 @@ func TestTmuxBackendConformance(t *testing.T) {
 	RunConformance(t, backend)
 }
 
+func TestTmuxTargetMissingClassifiesExitedServer(t *testing.T) {
+	for _, message := range []string{
+		"tmux display-message: server exited unexpectedly",
+		"tmux display-message: no server running",
+		"tmux display-message: couldn't find pane: %%%%1",
+	} {
+		if !tmuxTargetMissing(errors.New(message)) {
+			t.Fatalf("tmuxTargetMissing(%q) = false, want true", message)
+		}
+	}
+	if tmuxTargetMissing(errors.New("tmux display-message: permission denied")) {
+		t.Fatal("tmuxTargetMissing classified an unrelated error as a missing target")
+	}
+}
+
 func TestTmuxCloseUsesPinnedSocketAfterEnvironmentCleanup(t *testing.T) {
 	backend := NewTmuxBackend("tmux")
 	backend.socketName = ""


### PR DESCRIPTION
## Purpose

Treat tmux's `server exited unexpectedly` response as a missing target when the server has already gone away during resource verification.

## Evidence

- `TestTmuxBackendConformance/stale_binding_recovery` flaked on Ubuntu in runs `32966438231` and `33007827131`.
- `TestTmuxPlacementSessionLayouts/columns` also flaked in run `33010943353` without tmux code changes.
- The failure occurs when closing the last owned pane lets the per-socket tmux server exit before the next `display-message`.
- The existing target-missing classifier already treats `no server running` as absence. `server exited unexpectedly` is the same stale-closed state, so `Close` can truthfully report closed. Other errors remain action required.

## Verification

- 20 combined stale-binding/placement-columns loops pass.
- Target classifier test passes 20 times.
- Live-pane preservation tests pass 5 times.
- `go test ./internal/launch`, `go vet ./internal/launch`, and `golangci-lint run ./internal/launch` pass.
- Full `make ci` passes, including all Go tests, smoke checks, builds, and hooks.

Refs: agent-message-queue-z7h
