### PR TITLE
fix(coop): unify the harness naming table with the launch provider set

### DIFF
--- a/internal/cli/coop_exec_named.go
+++ b/internal/cli/coop_exec_named.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 type coopNamedMode int
@@ -31,10 +33,12 @@ type coopNamedHarness struct {
 }
 
 var coopNamedHarnesses = map[string]coopNamedHarness{
-	"claude": {mode: coopNamedModeArgv, resumeSyntax: coopNamedResumeFlags},
-	"pi":     {mode: coopNamedModeArgv, resumeSyntax: coopNamedResumeFlags},
-	"codex":  {mode: coopNamedModeTUI, resumeSyntax: coopNamedResumeCodex},
-	"agent":  {mode: coopNamedModeTUI, resumeSyntax: coopNamedResumeCursor},
+	launch.ClaudeProvider: {mode: coopNamedModeArgv, resumeSyntax: coopNamedResumeFlags},
+	"pi":                  {mode: coopNamedModeArgv, resumeSyntax: coopNamedResumeFlags},
+	launch.CodexProvider:  {mode: coopNamedModeTUI, resumeSyntax: coopNamedResumeCodex},
+	"agent":               {mode: coopNamedModeTUI, resumeSyntax: coopNamedResumeCursor},
+	launch.CursorProvider: {mode: coopNamedModeTUI, resumeSyntax: coopNamedResumeCursor},
+	launch.GrokProvider:   {mode: coopNamedModeUnknown, resumeSyntax: coopNamedResumeFlags},
 }
 
 func coopNamedHarnessFor(binary string) (coopNamedHarness, bool) {

--- a/internal/cli/coop_exec_named_store_unix.go
+++ b/internal/cli/coop_exec_named_store_unix.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/launch"
 )
 
 const (
@@ -46,10 +48,10 @@ type coopNamedStoreReader interface {
 }
 
 func coopNamedStoreReaderFor(binary string) (coopNamedStoreReader, bool) {
-	switch strings.ToLower(filepath.Base(binary)) {
-	case "codex":
+	switch launch.ProviderForExecutable(binary) {
+	case launch.CodexProvider:
 		return codexNamedStoreReader{}, true
-	case "agent":
+	case launch.CursorProvider:
 		return cursorNamedStoreReader{}, true
 	default:
 		return nil, false

--- a/internal/cli/coop_exec_named_store_unix_test.go
+++ b/internal/cli/coop_exec_named_store_unix_test.go
@@ -341,6 +341,23 @@ func TestCursorNamedStoreReaderFiltersCWDAndWindow(t *testing.T) {
 	}
 }
 
+func TestCoopNamedStoreReaderRecognizesCursorAliases(t *testing.T) {
+	current, currentOK := coopNamedStoreReaderFor("agent")
+	if !currentOK {
+		t.Fatal("current Cursor executable does not use the Cursor named store reader")
+	}
+	if _, ok := current.(cursorNamedStoreReader); !ok {
+		t.Fatal("current Cursor executable returned the wrong named store reader")
+	}
+	legacy, legacyOK := coopNamedStoreReaderFor("cursor-agent")
+	if !legacyOK {
+		t.Fatal("legacy Cursor executable does not use the Cursor named store reader")
+	}
+	if _, ok := legacy.(cursorNamedStoreReader); !ok {
+		t.Fatal("legacy Cursor executable returned the wrong named store reader")
+	}
+}
+
 func TestCursorNamedStoreReaderAcceptsClockSlackButFiltersOlderChats(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -500,6 +500,42 @@ func TestCoopExecNamedDisabledByFlag(t *testing.T) {
 	}
 }
 
+func TestCoopNamedHarnessesMatchLaunchProviderSet(t *testing.T) {
+	want := make(map[string]struct{})
+	for _, executable := range []string{
+		launch.ClaudeProvider,
+		launch.CodexProvider,
+		"agent",
+		launch.CursorProvider,
+		launch.GrokProvider,
+	} {
+		provider := launch.ProviderForExecutable(executable)
+		if provider == "" {
+			t.Fatalf("launch.ProviderForExecutable(%q) returned an empty provider", executable)
+		}
+		want[provider] = struct{}{}
+	}
+
+	got := make(map[string]struct{})
+	for executable := range coopNamedHarnesses {
+		if provider := launch.ProviderForExecutable(executable); provider != "" {
+			got[provider] = struct{}{}
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("named harness providers = %#v, want launch providers %#v", got, want)
+	}
+
+	agentHarness, agentOK := coopNamedHarnessFor("agent")
+	cursorHarness, cursorOK := coopNamedHarnessFor(launch.CursorProvider)
+	if !agentOK || !cursorOK || agentHarness != cursorHarness {
+		t.Fatalf("Cursor aliases do not share a harness: agent=%#v/%v cursor-agent=%#v/%v", agentHarness, agentOK, cursorHarness, cursorOK)
+	}
+	if got := coopNamedModeFor(launch.GrokProvider); got != coopNamedModeUnknown {
+		t.Fatalf("Grok named mode = %d, want unknown", got)
+	}
+}
+
 func TestCoopNamedTUICommand(t *testing.T) {
 	if got := coopNamedTUICommand("codex", "coder1"); got != "/rename coder1" {
 		t.Fatalf("codex command = %q", got)
@@ -661,6 +697,24 @@ func TestApplyCoopNamedUnknownBinaryLeavesArgs(t *testing.T) {
 	reminder := coopNamedUnknownReminder("coder1", "/bin/bash")
 	if !strings.Contains(reminder, "coder1") || !strings.Contains(reminder, "bash") {
 		t.Fatalf("reminder = %q", reminder)
+	}
+}
+
+func TestApplyCoopNamedGrokPrintsUnknownReminder(t *testing.T) {
+	var gotArgs []string
+	_, stderr, err := captureEnvOutput(t, func() error {
+		var err error
+		gotArgs, err = applyCoopNamedBeforeExec(true, launch.GrokProvider, []string{"--model", "grok-4.5"}, "feature/grok")
+		return err
+	})
+	if err != nil {
+		t.Fatalf("applyCoopNamedBeforeExec: %v", err)
+	}
+	if !reflect.DeepEqual(gotArgs, []string{"--model", "grok-4.5"}) {
+		t.Fatalf("args = %#v, want unchanged", gotArgs)
+	}
+	if !strings.Contains(stderr, `name this CLI session "feature/grok" manually`) || !strings.Contains(stderr, `unknown binary "grok"`) {
+		t.Fatalf("Grok reminder = %q", stderr)
 	}
 }
 


### PR DESCRIPTION
## Purpose

Keep direct co-op naming aligned with the launch adapter provider set.

## Changes

- Add the canonical `cursor-agent` alias to the Cursor TUI naming harness and route both Cursor executable aliases through the same named-store reader.
- Add Grok to the harness table as an unknown provider, preserving argv and printing the existing manual naming reminder.
- Add a parity test against `launch.ProviderForExecutable` so the supported provider sets cannot drift, plus alias and reminder coverage.

## Verification

- Full `internal/cli` test suite passes.
- Full `make ci` passes: check-skills, vet, lint (`0 issues`), all Go tests, smoke checks, builds, and hooks.
- Cursor `/rename` live proof is pending until the provider team usage limit resets on `2026-09-01`; the authenticated attempt reached Cursor but returned `ActionRequiredError: Your team has reached its usage limit`. No live proof is claimed.

Refs: agent-message-queue-j39
