### PR TITLE
feat(launch): name managed Claude sessions from the plan

### DIFF
--- a/COOP.md
+++ b/COOP.md
@@ -70,8 +70,10 @@ for example `codex resume session1/codex`. Cursor `agent` resumes through its
 picker only; resume-by-name is unproven. Disable this with `--named=false`,
 `AMQ_COOP_NAMED=0`, or `"named": false` in `.amq/launch.json`. Existing names
 and resume or continue flags are preserved, including `codex resume` and
-`agent --resume`. Managed launches keep naming disabled until their
-provider-name contract is available.
+`agent --resume`. Committed managed launches apply the same policy to Claude
+fresh plans: `agents[].named` overrides top-level `named` (default true), and
+the ticket owns `--name`. Resume plans never add it. Codex, Cursor, and Grok
+remain unnamed under managed launch; Pi remains direct-only.
 
 Creating a missing named session, explicit root, or declared default session
 still works in this release and prints one deprecation warning. Use

--- a/docs/launch-api.md
+++ b/docs/launch-api.md
@@ -74,6 +74,8 @@ ordered `-c model_reasoning_effort=<value>` pairs with values `minimal`, `low`,
 `medium`, `high`, or `xhigh`; duplicate keys and unknown keys or values reject.
 Every `env_overlay` key uses the POSIX environment grammar
 `[A-Za-z_][A-Za-z0-9_]*`; shell syntax such as `X;touch /tmp/pwn` is refused.
+Claude's GrammarVersion is 2: it covers the scoped `--allowedTools` grammar
+(`entry := name["("spec")"]`) and `-n`, `--name`, and `--name=` session labels.
 
 Public JSON decoders perform a bounded structural pass before contract
 decoding. A structural refusal is returned as `*launchapi.StrictJSONError`;
@@ -197,8 +199,13 @@ then bootstraps the same ID with a no-tools turn before it proves exact resume.
 It uses an already-trusted checkout as the Claude cwd and keeps its AMQ session
 root in a temporary directory; it never changes Claude trust state.
 
-Pi is excluded because it has no provider CLI; Gemini CLI and OpenCode also
-remain outside this adapter set.
+Pi remains direct-only because it has no launch API adapter; Gemini CLI and
+OpenCode also remain outside this adapter set. In committed
+`.amq/launch.json`, `agents[].named` overrides the top-level `named` setting,
+and naming defaults to enabled. Managed Claude fresh plans carry
+`--name <session>/<handle>` in the ticket and trust digest. Resume plans never
+add or rename a session. Codex, Cursor, and Grok remain unnamed under managed
+launch in this release.
 
 ## Prepare and Apply
 

--- a/internal/cli/coop_exec_named.go
+++ b/internal/cli/coop_exec_named.go
@@ -19,12 +19,12 @@ const (
 	coopNamedModeUnknown
 )
 
-type coopNamedResumeSyntax uint8
+type coopNamedResumeSyntax = launch.ResumeSyntax
 
 const (
-	coopNamedResumeFlags coopNamedResumeSyntax = iota
-	coopNamedResumeCodex
-	coopNamedResumeCursor
+	coopNamedResumeFlags  = launch.ResumeSyntaxFlags
+	coopNamedResumeCodex  = launch.ResumeSyntaxCodex
+	coopNamedResumeCursor = launch.ResumeSyntaxCursor
 )
 
 type coopNamedHarness struct {
@@ -54,20 +54,7 @@ func coopNamedModeFor(binary string) coopNamedMode {
 }
 
 func agentArgsHasNameFlag(args []string) bool {
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--" {
-			return false
-		}
-		if coopNamedValueFlag(arg) {
-			i++
-			continue
-		}
-		if arg == "-n" || arg == "--name" || strings.HasPrefix(arg, "--name=") {
-			return true
-		}
-	}
-	return false
+	return launch.ArgsHaveNameFlag(args)
 }
 
 func agentArgsPreventAutoName(args []string) bool {
@@ -83,67 +70,7 @@ func agentArgsPreventAutoNameFor(cmdName string, args []string) bool {
 }
 
 func agentArgsHaveResume(args []string, syntax coopNamedResumeSyntax) bool {
-	switch syntax {
-	case coopNamedResumeCodex:
-		return agentArgsHaveCodexResume(args)
-	case coopNamedResumeCursor:
-		return agentArgsHaveResumeFlags(args, false)
-	default:
-		return agentArgsHaveResumeFlags(args, true)
-	}
-}
-
-func agentArgsHaveResumeFlags(args []string, allowContinue bool) bool {
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--" {
-			return false
-		}
-		if coopNamedValueFlag(arg) {
-			i++
-			continue
-		}
-		if arg == "-r" || arg == "--resume" || strings.HasPrefix(arg, "--resume=") ||
-			allowContinue && (arg == "-c" || arg == "--continue" || strings.HasPrefix(arg, "--continue=")) {
-			return true
-		}
-	}
-	return false
-}
-
-func agentArgsHaveCodexResume(args []string) bool {
-	var firstPositional string
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--" {
-			return false
-		}
-		if coopNamedValueFlag(arg) {
-			i++
-			continue
-		}
-		if strings.HasPrefix(arg, "-") {
-			continue
-		}
-		if firstPositional == "" {
-			firstPositional = arg
-			if arg == "resume" {
-				return true
-			}
-			continue
-		}
-		return firstPositional == "exec" && arg == "resume"
-	}
-	return false
-}
-
-func coopNamedValueFlag(arg string) bool {
-	switch arg {
-	case "--model", "-m", "--config", "--cwd", "--output-format", "--permission-mode", "--settings", "--system-prompt", "--append-system-prompt", "--session":
-		return true
-	default:
-		return false
-	}
+	return launch.ArgsHaveResume(args, syntax)
 }
 
 func injectCoopNamedArgv(cmdName string, agentArgs []string, me string) []string {

--- a/internal/cli/coop_exec_test.go
+++ b/internal/cli/coop_exec_test.go
@@ -384,7 +384,38 @@ func TestCoopExecNamedRefusedUnderManagedLaunch(t *testing.T) {
 	}
 }
 
+func TestCoopExecNamedTicketArgvAllowsManagedName(t *testing.T) {
+	nonce := "11111111-1111-4111-8111-111111111111"
+	t.Setenv(launch.InternalLaunchNonceEnv, nonce)
+	execution := &launch.PrepareExecutionOptions{Named: true, WakeMode: "disabled", AuditReason: "test"}
+	root := seedManagedCoopExecTicketWithTarget(t, "claude", nonce, []string{"/usr/bin/true", "--name", "session1/claude"}, execution)
+
+	var gotArgv []string
+	sentinel := errors.New("exec sentinel")
+	oldExec := coopExecProcess
+	coopExecProcess = func(_ string, argv []string, _ []string) error {
+		gotArgv = append([]string{}, argv...)
+		return sentinel
+	}
+	t.Cleanup(func() { coopExecProcess = oldExec })
+
+	err := runCoopExec([]string{
+		"--root", root, "--me", "claude", "--named", "--no-wake", "--managed-no-wake-reason", "test",
+		"/usr/bin/true", "--", "--name", "session1/claude",
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want coopExecProcess sentinel", err)
+	}
+	if len(gotArgv) < 5 || !reflect.DeepEqual(gotArgv[len(gotArgv)-3:], []string{"/usr/bin/true", "--name", "session1/claude"}) {
+		t.Fatalf("managed wrapper target argv = %#v", gotArgv)
+	}
+}
+
 func seedManagedCoopExecTicket(t *testing.T, handle, nonce string) string {
+	return seedManagedCoopExecTicketWithTarget(t, handle, nonce, []string{"/usr/bin/true"}, &launch.PrepareExecutionOptions{WakeMode: "disabled", AuditReason: "test"})
+}
+
+func seedManagedCoopExecTicketWithTarget(t *testing.T, handle, nonce string, targetArgv []string, execution *launch.PrepareExecutionOptions) string {
 	t.Helper()
 	project := t.TempDir()
 	session := filepath.Join(project, "session")
@@ -415,11 +446,10 @@ func seedManagedCoopExecTicket(t *testing.T, handle, nonce string) string {
 		t.Fatal(err)
 	}
 	ticket, err := launch.NewExecutionTicket(launch.ExecutionTicketRequest{
-		Handle: handle, LaunchNonce: nonce, Mode: launch.AdapterModeMint, Provider: "test",
+		Handle: handle, LaunchNonce: nonce, Mode: launch.AdapterModeMint, Provider: launch.ClaudeProvider,
 		ProjectRoot: project, SessionRoot: session, Cwd: project,
 		ProviderExecutable: "/usr/bin/true", AMQExecutable: amqExecutable,
-		TargetArgv: []string{"/usr/bin/true"},
-		Execution:  &launch.PrepareExecutionOptions{WakeMode: "disabled", AuditReason: "test"},
+		TargetArgv: targetArgv, Execution: execution,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/coop_exec_unix.go
+++ b/internal/cli/coop_exec_unix.go
@@ -111,14 +111,21 @@ func runCoopExec(args []string) error {
 	if err != nil {
 		return err
 	}
-	if managedLaunchNonce != "" && flagWasVisited(fs, "named") && *namedFlag {
-		return UsageError("--named is not supported under a managed launch; declare the name in the launch plan instead")
-	}
 	if managedLaunchNonce != "" {
-		// Managed launches have no trusted provider-name field until the
-		// managed naming contract lands. Keep the existing launch boundary
-		// fail-closed while the direct path defaults to named sessions.
+		// Managed launches use the ticket's exact provider argv for naming.
 		namedEnabled = false
+	}
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return UsageError("command required (e.g., 'claude', 'codex', 'bash')")
+	}
+	cmdName := remaining[0]
+	// Extra positional args before "--" are appended to agent args.
+	if len(remaining) > 1 {
+		agentArgs = append(remaining[1:], agentArgs...)
+	}
+	if managedLaunchNonce != "" && flagWasVisited(fs, "named") && *namedFlag && !launch.ArgsHaveNameFlag(agentArgs) {
+		return UsageError("--named is not supported under a managed launch; declare the name in the launch plan instead")
 	}
 	if managedLaunchNonce != "" {
 		if !flagWasVisited(fs, "root") || strings.TrimSpace(*rootFlag) == "" || !filepath.IsAbs(*rootFlag) {
@@ -163,7 +170,7 @@ func runCoopExec(args []string) error {
 		return UsageError("managed execution options require a trusted launch ticket")
 	}
 	var executionOptions *launch.PrepareExecutionOptions
-	if managedLaunchNonce != "" && (managedOnlyOptions ||
+	if managedLaunchNonce != "" && (managedOnlyOptions || flagWasVisited(fs, "named") ||
 		flagWasVisited(fs, "no-gitignore") || flagWasVisited(fs, "no-wake") ||
 		flagWasVisited(fs, "require-wake") || flagWasVisited(fs, "wake-inject-mode") ||
 		flagWasVisited(fs, "wake-inject-via") || flagWasVisited(fs, "wake-inject-arg")) {
@@ -178,6 +185,7 @@ func runCoopExec(args []string) error {
 		options := launch.PrepareExecutionOptions{
 			RequireWake:          *requireWakeFlag,
 			NoGitignore:          *noGitignoreFlag,
+			Named:                flagWasVisited(fs, "named") && *namedFlag,
 			WakeMode:             wakeMode,
 			AuditReason:          *managedNoWakeReasonFlag,
 			InjectorMode:         managedInjectorMode,
@@ -190,16 +198,6 @@ func runCoopExec(args []string) error {
 			return UsageError("managed execution options: %v", err)
 		}
 		executionOptions = &options
-	}
-
-	remaining := fs.Args()
-	if len(remaining) == 0 {
-		return UsageError("command required (e.g., 'claude', 'codex', 'bash')")
-	}
-	cmdName := remaining[0]
-	// Extra positional args before "--" are appended to agent args.
-	if len(remaining) > 1 {
-		agentArgs = append(remaining[1:], agentArgs...)
 	}
 
 	// Derive agent handle from command basename (or --me override).

--- a/internal/cli/launch_tmux_e2e_test.go
+++ b/internal/cli/launch_tmux_e2e_test.go
@@ -111,12 +111,13 @@ exec /bin/sleep 60
 	}
 	adapter := launch.NewClaudeAdapter(launch.ClaudeProvider)
 	freshPlan, err := adapter.PlanFresh(launch.PlanRequest{
-		Handle: "claude", ProjectRoot: canonicalProject, Cwd: canonicalProject,
-		LaunchNonce: "019c5a10-75d8-7eef-8db7-5ee77f70e8a1", ResumePolicy: launch.ResumeEnabled,
+		Handle: "claude", Session: "collab", ProjectRoot: canonicalProject, Cwd: canonicalProject,
+		LaunchNonce: "019c5a10-75d8-7eef-8db7-5ee77f70e8a1", Named: true, ResumePolicy: launch.ResumeEnabled,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	freshPlan.Execution = &launch.PrepareExecutionOptions{Named: true}
 	trustPlan(t, store, launch.Plan{Version: launch.PlanVersion, Agents: []launch.AgentPlan{freshPlan}}, root)
 
 	socketDir, err := os.MkdirTemp("/tmp", "amq-tmux-e2e-")

--- a/internal/cli/managed_execution_options_test.go
+++ b/internal/cli/managed_execution_options_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestManagedExecutionOptionsCodecRoundTripAndHostileInput(t *testing.T) {
 	want := launch.PrepareExecutionOptions{
-		RequireWake: true, NoGitignore: true, WakeMode: "enabled",
+		RequireWake: true, NoGitignore: true, Named: true, WakeMode: "enabled",
 		InjectorMode: "paste", InjectorVia: "/opt/amq/injector", InjectorArgs: []string{"--fixed", "value"},
 		SymphonyEvents: []string{"after_create", "before_run"}, SymphonyWorkspaceKey: "workspace-7",
 	}

--- a/internal/launch/adapter.go
+++ b/internal/launch/adapter.go
@@ -79,8 +79,8 @@ func ProviderStaticInputCapabilities(provider string) StaticInputCapabilities {
 	switch provider {
 	case ClaudeProvider:
 		return StaticInputCapabilities{
-			GrammarVersion: 1, VerifiedProviderVersion: "2.1.233",
-			AllowedArgumentForms: []string{"--allowedTools"}, InitialInputKinds: []InitialInputKind{InitialInputArgument},
+			GrammarVersion: 2, VerifiedProviderVersion: "2.1.233",
+			AllowedArgumentForms: []string{"--allowedTools", "-n", "--name"}, InitialInputKinds: []InitialInputKind{InitialInputArgument},
 		}
 	case CodexProvider:
 		reasoningValues := slices.Clone(codexReasoningEffortValues)
@@ -106,6 +106,7 @@ func ProviderStaticInputCapabilities(provider string) StaticInputCapabilities {
 
 type PlanRequest struct {
 	Handle        string
+	Session       string
 	ProjectRoot   string
 	SessionRoot   string
 	AMQExecutable string
@@ -116,6 +117,7 @@ type PlanRequest struct {
 	// the historical project-contained rule.
 	AllowExternalCwd bool
 	LaunchNonce      string
+	Named            bool
 	ResumePolicy     ResumePolicy
 	CommittedArgs    []string
 	BypassArgs       []string
@@ -287,12 +289,12 @@ func PartitionStaticProviderArgs(provider string, args []string) (committed, byp
 			bypass = append(bypass, arg)
 			continue
 		}
-		rule, ok := argRules[arg]
+		rule, _, inline, ok := argumentRuleFor(arg, argRules)
 		if !ok {
 			return nil, nil, fmt.Errorf("static argument %q is not allowed by adapter grammar", arg)
 		}
 		committed = append(committed, arg)
-		if rule.value {
+		if rule.value && !inline {
 			if i+1 >= len(args) {
 				return nil, nil, fmt.Errorf("static argument %q requires a value", arg)
 			}
@@ -309,11 +311,17 @@ func validateStaticProviderArgs(args []string, rules map[string]argumentRule, by
 		if _, ok := bypassAllowed[arg]; ok {
 			continue
 		}
-		rule, ok := rules[arg]
+		rule, inlineValue, inline, ok := argumentRuleFor(arg, rules)
 		if !ok {
 			return fmt.Errorf("static argument %q is not allowed by adapter grammar", arg)
 		}
 		if !rule.value {
+			continue
+		}
+		if inline {
+			if rule.validate != nil && !rule.validate(inlineValue) {
+				return fmt.Errorf("static argument %q has invalid value %q", arg, inlineValue)
+			}
 			continue
 		}
 		if i+1 >= len(args) {
@@ -563,14 +571,33 @@ type argumentRule struct {
 	validate valueRule
 }
 
+func argumentRuleFor(arg string, rules map[string]argumentRule) (rule argumentRule, inlineValue string, inline bool, ok bool) {
+	if rule, ok := rules[arg]; ok {
+		return rule, "", false, true
+	}
+	if value, found := strings.CutPrefix(arg, "--name="); found {
+		rule, ok := rules["--name"]
+		if ok && rule.value {
+			return rule, value, true, true
+		}
+	}
+	return argumentRule{}, "", false, false
+}
+
 func validateCommittedArgs(args []string, rules map[string]argumentRule) error {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		rule, ok := rules[arg]
+		rule, inlineValue, inline, ok := argumentRuleFor(arg, rules)
 		if !ok {
 			return fmt.Errorf("committed argument %q is not allowed by adapter grammar", arg)
 		}
 		if !rule.value {
+			continue
+		}
+		if inline {
+			if rule.validate != nil && !rule.validate(inlineValue) {
+				return fmt.Errorf("committed argument %q has invalid value %q", arg, inlineValue)
+			}
 			continue
 		}
 		if i+1 >= len(args) {
@@ -588,6 +615,23 @@ var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[
 
 func safeArgumentValue(value string) bool {
 	return !strings.HasPrefix(value, "-") && safeEnvironmentValue(value)
+}
+
+func validSessionLabel(value string) bool {
+	parts := strings.Split(value, "/")
+	if len(parts) > 2 {
+		return false
+	}
+	for _, part := range parts {
+		if !canonicalSessionPattern.MatchString(part) || strings.HasPrefix(part, "-") {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func supportsManagedPlanNaming(provider string) bool {
+	return provider == ClaudeProvider
 }
 
 func validUUID(value string) bool {

--- a/internal/launch/adapter_claude.go
+++ b/internal/launch/adapter_claude.go
@@ -63,6 +63,16 @@ func (adapter *ClaudeAdapter) PlanFresh(request PlanRequest) (AgentPlan, error) 
 	}
 	argv := append([]string{executable}, request.CommittedArgs...)
 	argv = append(argv, request.BypassArgs...)
+	if request.Named && !ArgsHaveNameFlag(request.CommittedArgs) {
+		name := request.Handle
+		if request.Session != "" {
+			name = request.Session + "/" + request.Handle
+		}
+		if !validSessionLabel(name) {
+			return AgentPlan{}, fmt.Errorf("generated session name %q is invalid", name)
+		}
+		argv = append(argv, "--name", name)
+	}
 	argv = append(argv, "--session-id", request.LaunchNonce)
 	plan := AgentPlan{
 		Handle: request.Handle, Argv: argv, EnvOverlay: cloneEnv(request.EnvOverlay), Cwd: request.Cwd,
@@ -116,6 +126,8 @@ func claudeArgRules() map[string]argumentRule {
 		"--allowedTools":    {value: true, validate: validClaudeAllowedTools},
 		"--effort":          {value: true, validate: oneOf("low", "medium", "high", "xhigh", "max")},
 		"--model":           {value: true, validate: safeArgumentValue},
+		"-n":                {value: true, validate: validSessionLabel},
+		"--name":            {value: true, validate: validSessionLabel},
 		"--no-chrome":       {},
 		"--permission-mode": {value: true, validate: oneOf("acceptEdits", "auto", "manual", "dontAsk", "plan")},
 		"--safe-mode":       {},

--- a/internal/launch/adapter_test.go
+++ b/internal/launch/adapter_test.go
@@ -179,6 +179,108 @@ func TestClaudePlansUseExactMintAndResumeShapes(t *testing.T) {
 	}
 }
 
+func TestClaudeNamedFreshPlanIsTicketBoundAndResumeStable(t *testing.T) {
+	project, executable := testExecutable(t, ClaudeProvider)
+	adapter := NewClaudeAdapter(executable)
+	request := planRequest(project, ClaudeProvider)
+	request.CommittedArgs = []string{"--model", "opus"}
+	request.Session = "session1"
+
+	unnamed, err := adapter.PlanFresh(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantUnnamed := []string{executable, "--model", "opus", "--session-id", testLaunchNonce}
+	if !slices.Equal(unnamed.Argv, wantUnnamed) {
+		t.Fatalf("unnamed fresh argv = %#v, want %#v", unnamed.Argv, wantUnnamed)
+	}
+	legacyRequest := request
+	legacyRequest.Session = ""
+	legacy, err := adapter.PlanFresh(legacyRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(legacy, unnamed) {
+		t.Fatalf("unnamed fresh plan changed when session was supplied: legacy=%#v unnamed=%#v", legacy, unnamed)
+	}
+	namedRequest := request
+	namedRequest.Named = true
+	named, err := adapter.PlanFresh(namedRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(named.Argv[len(named.Argv)-4:], []string{"--name", "session1/claude", "--session-id", testLaunchNonce}) {
+		t.Fatalf("named fresh argv = %#v", named.Argv)
+	}
+	if countClaudeNameFlags(named.Argv) != 1 {
+		t.Fatalf("named fresh argv has duplicate name flags: %#v", named.Argv)
+	}
+	planDigest := func(plan AgentPlan) (string, string) {
+		t.Helper()
+		container := Plan{Version: PlanVersion, Agents: []AgentPlan{plan}}
+		semantic, semanticErr := container.SemanticDigest()
+		if semanticErr != nil {
+			t.Fatal(semanticErr)
+		}
+		trust, trustErr := container.TrustSemanticDigest()
+		if trustErr != nil {
+			t.Fatal(trustErr)
+		}
+		return semantic, trust
+	}
+	unnamedDigest, unnamedTrust := planDigest(unnamed)
+	namedDigest, namedTrust := planDigest(named)
+	if unnamedDigest == namedDigest || unnamedTrust == namedTrust {
+		t.Fatalf("name did not change plan and trust digests: %q/%q", namedDigest, namedTrust)
+	}
+
+	resume, err := adapter.PlanResume(ResumeRequest{
+		PlanRequest:  namedRequest,
+		Conversation: ConversationIdentity{Provider: ClaudeProvider, ID: testConversationID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countClaudeNameFlags(resume.Argv) != 0 {
+		t.Fatalf("resume added a generated name: %#v", resume.Argv)
+	}
+
+	committed := namedRequest
+	committed.CommittedArgs = []string{"-n", "custom"}
+	committedPlan, err := adapter.PlanFresh(committed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countClaudeNameFlags(committedPlan.Argv) != 1 || slices.Contains(committedPlan.Argv, "--name") {
+		t.Fatalf("committed short name was duplicated or rewritten: %#v", committedPlan.Argv)
+	}
+
+	inline := namedRequest
+	inline.CommittedArgs = []string{"--name=custom"}
+	inlinePlan, err := adapter.PlanFresh(inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countClaudeNameFlags(inlinePlan.Argv) != 1 {
+		t.Fatalf("committed inline name was duplicated: %#v", inlinePlan.Argv)
+	}
+	invalid := namedRequest
+	invalid.CommittedArgs = []string{"--name", "bad/name/extra"}
+	if _, err := adapter.PlanFresh(invalid); err == nil || !strings.Contains(err.Error(), "invalid value") {
+		t.Fatalf("invalid committed name error = %v", err)
+	}
+}
+
+func countClaudeNameFlags(argv []string) int {
+	count := 0
+	for _, arg := range argv {
+		if arg == "-n" || arg == "--name" || strings.HasPrefix(arg, "--name=") {
+			count++
+		}
+	}
+	return count
+}
+
 func TestGrokPlansUseExactMintAndResumeShapes(t *testing.T) {
 	project, executable := testExecutable(t, GrokProvider)
 	adapter := NewGrokAdapter(executable)

--- a/internal/launch/apply.go
+++ b/internal/launch/apply.go
@@ -624,9 +624,10 @@ func buildApplyReconcileRequest(ctx context.Context, prepared PrepareRequest, ru
 			digest := initialInputDigest(participant.InitialInput.Text)
 			initial = &InitialInputRequest{Kind: participant.InitialInput.Kind, Value: participant.InitialInput.Text, SHA256: digest}
 		}
+		named := participant.Execution.Named
 		config.Agents = append(config.Agents, ProjectAgentConfig{
 			Handle: participant.Handle, Adapter: key, Command: command, Env: cloneEnv(participant.EnvOverlay),
-			Cwd: participant.Cwd, ResumePolicy: participant.ResumePolicy, InitialInput: initial, Wrapper: cloneWrapper(participant.Wrapper),
+			Named: &named, Cwd: participant.Cwd, ResumePolicy: participant.ResumePolicy, InitialInput: initial, Wrapper: cloneWrapper(participant.Wrapper),
 		})
 		adapters[key] = adapter
 		executionOptions[participant.Handle] = *clonePrepareExecutionOptions(&participant.Execution)

--- a/internal/launch/argv_scan.go
+++ b/internal/launch/argv_scan.go
@@ -1,0 +1,92 @@
+package launch
+
+import "strings"
+
+type ResumeSyntax uint8
+
+const (
+	ResumeSyntaxFlags ResumeSyntax = iota
+	ResumeSyntaxCodex
+	ResumeSyntaxCursor
+)
+
+func ArgsHaveNameFlag(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return false
+		}
+		if argvValueFlag(arg) {
+			i++
+			continue
+		}
+		if arg == "-n" || arg == "--name" || strings.HasPrefix(arg, "--name=") {
+			return true
+		}
+	}
+	return false
+}
+
+func ArgsHaveResume(args []string, syntax ResumeSyntax) bool {
+	switch syntax {
+	case ResumeSyntaxCodex:
+		return argsHaveCodexResume(args)
+	case ResumeSyntaxCursor:
+		return argsHaveResumeFlags(args, false)
+	default:
+		return argsHaveResumeFlags(args, true)
+	}
+}
+
+func argsHaveResumeFlags(args []string, allowContinue bool) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return false
+		}
+		if argvValueFlag(arg) {
+			i++
+			continue
+		}
+		if arg == "-r" || arg == "--resume" || strings.HasPrefix(arg, "--resume=") ||
+			allowContinue && (arg == "-c" || arg == "--continue" || strings.HasPrefix(arg, "--continue=")) {
+			return true
+		}
+	}
+	return false
+}
+
+func argsHaveCodexResume(args []string) bool {
+	var firstPositional string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return false
+		}
+		if argvValueFlag(arg) {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if firstPositional == "" {
+			firstPositional = arg
+			if arg == "resume" {
+				return true
+			}
+			continue
+		}
+		return firstPositional == "exec" && arg == "resume"
+	}
+	return false
+}
+
+func argvValueFlag(arg string) bool {
+	switch arg {
+	case "--model", "-m", "--config", "--cwd", "--output-format", "--permission-mode", "--settings", "--system-prompt", "--append-system-prompt", "--session":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/launch/argv_scan_test.go
+++ b/internal/launch/argv_scan_test.go
@@ -1,0 +1,48 @@
+package launch
+
+import "testing"
+
+func TestArgsHaveNameFlagScansProviderArguments(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "empty", want: false},
+		{name: "short", args: []string{"-n", "session/claude"}, want: true},
+		{name: "long", args: []string{"--name", "session/claude"}, want: true},
+		{name: "equals", args: []string{"--name=session/claude"}, want: true},
+		{name: "value that looks like name", args: []string{"--model", "--name"}, want: false},
+		{name: "after separator", args: []string{"--", "--name", "session/claude"}, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ArgsHaveNameFlag(test.args); got != test.want {
+				t.Fatalf("ArgsHaveNameFlag(%#v) = %v, want %v", test.args, got, test.want)
+			}
+		})
+	}
+}
+
+func TestArgsHaveResumeUsesProviderSyntax(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		syntax ResumeSyntax
+		args   []string
+		want   bool
+	}{
+		{name: "claude continue", syntax: ResumeSyntaxFlags, args: []string{"--continue"}, want: true},
+		{name: "claude resume", syntax: ResumeSyntaxFlags, args: []string{"--resume=thread"}, want: true},
+		{name: "cursor resume", syntax: ResumeSyntaxCursor, args: []string{"--resume", "chat"}, want: true},
+		{name: "cursor continue is not resume", syntax: ResumeSyntaxCursor, args: []string{"--continue"}, want: false},
+		{name: "codex resume", syntax: ResumeSyntaxCodex, args: []string{"resume", "thread"}, want: true},
+		{name: "codex exec resume", syntax: ResumeSyntaxCodex, args: []string{"exec", "resume", "thread"}, want: true},
+		{name: "codex plain exec", syntax: ResumeSyntaxCodex, args: []string{"exec"}, want: false},
+		{name: "resume after separator", syntax: ResumeSyntaxFlags, args: []string{"--", "--resume", "thread"}, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ArgsHaveResume(test.args, test.syntax); got != test.want {
+				t.Fatalf("ArgsHaveResume(%#v, %d) = %v, want %v", test.args, test.syntax, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/launch/commands.go
+++ b/internal/launch/commands.go
@@ -126,6 +126,9 @@ func coopExecOptionArgs(options *PrepareExecutionOptions) []string {
 		return nil
 	}
 	args := make([]string, 0, 16)
+	if options.Named {
+		args = append(args, "--named")
+	}
 	if options.NoGitignore {
 		args = append(args, "--no-gitignore")
 	}

--- a/internal/launch/commands_test.go
+++ b/internal/launch/commands_test.go
@@ -198,7 +198,7 @@ func TestCommandsCoopExecOldShapeFailsGrammar(t *testing.T) {
 
 func TestTypedExecutionOptionsRoundTripAndSingleCoopExec(t *testing.T) {
 	options := &PrepareExecutionOptions{
-		RequireWake: true, NoGitignore: true, WakeMode: "enabled",
+		RequireWake: true, NoGitignore: true, Named: true, WakeMode: "enabled",
 		InjectorMode: "raw", InjectorVia: "/opt/amq/injector", InjectorArgs: []string{"--fixed", "value with space"},
 		SymphonyEvents: []string{"after_create", "before_run", "after_run", "before_remove"}, SymphonyWorkspaceKey: "workspace-7",
 	}
@@ -235,6 +235,9 @@ func TestTypedExecutionOptionsRoundTripAndSingleCoopExec(t *testing.T) {
 	}
 	if !slices.Contains(argv, "--require-wake") || !slices.Contains(argv, "--no-gitignore") || slices.Contains(argv, "--session") {
 		t.Fatalf("typed option or exact-root transport mismatch: %#v", argv)
+	}
+	if !slices.Contains(argv, "--named") {
+		t.Fatalf("named option was not transported: %#v", argv)
 	}
 }
 

--- a/internal/launch/config.go
+++ b/internal/launch/config.go
@@ -38,11 +38,26 @@ type ProjectAgentConfig struct {
 	Handle       string               `json:"handle"`
 	Adapter      string               `json:"adapter"`
 	Command      []string             `json:"command"`
+	Named        *bool                `json:"named,omitempty"`
 	Env          map[string]string    `json:"env,omitempty"`
 	Cwd          string               `json:"cwd,omitempty"`
 	ResumePolicy ResumePolicy         `json:"resume_policy"`
 	InitialInput *InitialInputRequest `json:"initial_input,omitempty"`
 	Wrapper      *Wrapper             `json:"wrapper,omitempty"`
+}
+
+func ResolveAgentNamed(agent, project *bool) bool {
+	if agent != nil {
+		return *agent
+	}
+	if project != nil {
+		return *project
+	}
+	return true
+}
+
+func (cfg ProjectConfig) EffectiveAgentNamed(agent ProjectAgentConfig) bool {
+	return ResolveAgentNamed(agent.Named, cfg.Named)
 }
 
 type LayoutIntent struct {

--- a/internal/launch/config_test.go
+++ b/internal/launch/config_test.go
@@ -79,6 +79,44 @@ func TestProjectConfigAcceptsOptionalNamedPreference(t *testing.T) {
 	}
 }
 
+func TestProjectConfigResolvesPerAgentNamedPrecedence(t *testing.T) {
+	boolPointer := func(value bool) *bool { return &value }
+	for _, test := range []struct {
+		name    string
+		project *bool
+		agent   *bool
+		want    bool
+	}{
+		{name: "default enabled", want: true},
+		{name: "project false", project: boolPointer(false), want: false},
+		{name: "agent true overrides project false", project: boolPointer(false), agent: boolPointer(true), want: true},
+		{name: "agent false overrides project true", project: boolPointer(true), agent: boolPointer(false), want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := ProjectConfig{Named: test.project}
+			agent := ProjectAgentConfig{Named: test.agent}
+			if got := cfg.EffectiveAgentNamed(agent); got != test.want {
+				t.Fatalf("effective named = %v, want %v", got, test.want)
+			}
+		})
+	}
+
+	parsed, err := ParseProjectConfig([]byte(`{"schema":1,"named":false,"agents":[{"handle":"claude","command":["claude"],"named":true}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Agents[0].Named == nil || !*parsed.Agents[0].Named || !parsed.EffectiveAgentNamed(parsed.Agents[0]) {
+		t.Fatalf("per-agent named override = %#v", parsed.Agents[0].Named)
+	}
+	data, err := MarshalProjectConfig(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"named": true`) {
+		t.Fatalf("marshaled config omitted per-agent named override: %s", data)
+	}
+}
+
 func TestProjectConfigRejectsExplicitEmptyOptionalDefaults(t *testing.T) {
 	for _, raw := range []string{
 		`{"schema":1,"default_session":"","agents":[{"handle":"claude","command":["claude"]}]}`,

--- a/internal/launch/journal.go
+++ b/internal/launch/journal.go
@@ -315,12 +315,19 @@ func (record LaunchJournal) ValidateRequest(request ReconcileRequest) error {
 		seenExecution[agent.Handle] = struct{}{}
 		options, ok := request.ExecutionOptions[agent.Handle]
 		if !ok {
-			if agent.Execution != nil {
+			if !executionOptionsOnlyName(agent.Execution) {
 				return fmt.Errorf("launch journal execution options changed for %q", agent.Handle)
 			}
 			continue
 		}
-		if !reflect.DeepEqual(agent.Execution, clonePrepareExecutionOptions(&options)) {
+		// Named is deliberately not part of execution-option identity: its effect
+		// is the --name argv element, which the plan and trust digests already
+		// cover. Keeping it out preserves legacy journal bindings and V1 comparisons.
+		expected := CanonicalExecutionOptions(agent.Execution)
+		actual := CanonicalExecutionOptions(&options)
+		expected.Named = false
+		actual.Named = false
+		if !reflect.DeepEqual(expected, actual) {
 			return fmt.Errorf("launch journal execution options changed for %q", agent.Handle)
 		}
 	}
@@ -330,6 +337,18 @@ func (record LaunchJournal) ValidateRequest(request ReconcileRequest) error {
 		}
 	}
 	return nil
+}
+
+func executionOptionsOnlyName(options *PrepareExecutionOptions) bool {
+	// Named is deliberately not part of execution-option identity: its effect is
+	// the --name argv element, which the plan and trust digests already cover.
+	if options == nil {
+		return true
+	}
+	return !options.RequireWake && !options.NoGitignore &&
+		(options.WakeMode == "" || options.WakeMode == "enabled") && options.AuditReason == "" &&
+		(options.InjectorMode == "" || options.InjectorMode == "none") && options.InjectorVia == "" &&
+		len(options.InjectorArgs) == 0 && len(options.SymphonyEvents) == 0 && options.SymphonyWorkspaceKey == ""
 }
 
 func WriteJournal(root *fsq.DeliveryRoot, lease *Lease, record LaunchJournal) error {

--- a/internal/launch/prepare.go
+++ b/internal/launch/prepare.go
@@ -81,6 +81,7 @@ type PlannedWrite struct {
 type PrepareExecutionOptions struct {
 	RequireWake          bool     `json:"require_wake"`
 	NoGitignore          bool     `json:"no_gitignore"`
+	Named                bool     `json:"named,omitempty"`
 	WakeMode             string   `json:"wake_mode"`
 	AuditReason          string   `json:"audit_reason,omitempty"`
 	InjectorMode         string   `json:"injector_mode,omitempty"`
@@ -913,9 +914,13 @@ func inspectPrepareRoster(root *fsq.DeliveryRoot, authorization *fsq.MailboxConf
 }
 
 func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetState, dependencies PrepareDependencies, mailbox string, subjectSchema int) (PreparedParticipant, PrepareObservation, *AgentPlan, []PrepareRequiredAction, error) {
+	preparedExecution := participant.Execution
+	if subjectSchema == SubjectSchemaV1 {
+		preparedExecution.Named = false
+	}
 	prepared := PreparedParticipant{
 		Handle: participant.Handle, Runnable: participant.Runnable, Provider: participant.Provider,
-		ResumePolicy: participant.ResumePolicy, Execution: participant.Execution, PlannedOutcome: "participant_only",
+		ResumePolicy: participant.ResumePolicy, Execution: preparedExecution, PlannedOutcome: "participant_only",
 	}
 	if participant.OnLive == OnLiveKeep {
 		prepared.OnLive = OnLiveKeep
@@ -997,10 +1002,14 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 		return prepared, observation, nil, nil, fmt.Errorf("provider %q has no adapter", participant.Provider)
 	}
 
+	execution := participant.Execution
+	// V1 subjects must reproduce the pre-naming plan for existing callers
+	// (amq-squad); naming is a V2 capability.
+	execution.Named = execution.Named && subjectSchema == SubjectSchemaV2 && supportsManagedPlanNaming(participant.Provider)
 	base := PlanRequest{
-		Handle: participant.Handle, ProjectRoot: state.target.ProjectRoot, SessionRoot: state.target.SessionRoot,
+		Handle: participant.Handle, Session: state.target.Session, ProjectRoot: state.target.ProjectRoot, SessionRoot: state.target.SessionRoot,
 		AMQExecutable: dependencies.AMQPath, Cwd: cwd, AllowExternalCwd: true,
-		LaunchNonce: preparePlaceholderUUID, ResumePolicy: participant.ResumePolicy,
+		LaunchNonce: preparePlaceholderUUID, Named: execution.Named, ResumePolicy: participant.ResumePolicy,
 		CommittedArgs: slices.Clone(participant.Args), BypassArgs: slices.Clone(participant.BypassArgs), EnvOverlay: cloneEnv(participant.EnvOverlay),
 	}
 	if participant.InitialInput != nil {
@@ -1034,11 +1043,12 @@ func prepareOneParticipant(participant PrepareParticipant, state *prepareTargetS
 	if err != nil {
 		return prepared, observation, nil, actions, err
 	}
+	execution.Named = execution.Named && !useResume
 	plan, err = applyWrapper(plan, participant.Wrapper)
 	if err != nil {
 		return prepared, observation, nil, actions, fmt.Errorf("wrapper for %s: %w", participant.Handle, err)
 	}
-	plan.Execution = clonePrepareExecutionOptions(&participant.Execution)
+	plan.Execution = clonePrepareExecutionOptions(&execution)
 	prepared.Command = previewStaticCommand(plan)
 	return prepared, observation, &plan, actions, nil
 }

--- a/internal/launch/prepare_test.go
+++ b/internal/launch/prepare_test.go
@@ -223,6 +223,50 @@ func TestPrepareSubjectSchemasProduceDistinctDigestsForSameState(t *testing.T) {
 	}
 }
 
+func TestPrepareV1KeepsClaudeNameOutOfLegacyPlan(t *testing.T) {
+	fixture := newInternalPrepareFixture(t)
+	_, executable := testExecutable(t, ClaudeProvider)
+	adapter := NewClaudeAdapter(executable)
+	request := fixture.request
+	request.SubjectSchema = SubjectSchemaV1
+	request.Participants = append([]PrepareParticipant(nil), fixture.request.Participants...)
+	request.Participants[0].Executable = executable
+	request.Participants[0].Execution.Named = true
+	dependencies := fixture.dependencies(&prepareTestBackend{})
+	dependencies.AdapterFor = func(_, _ string) HarnessAdapter { return adapter }
+	result, err := Prepare(context.Background(), request, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Participants) != 1 || result.Participants[0].Command == nil {
+		t.Fatalf("v1 prepared participant = %#v", result.Participants)
+	}
+	expected, err := adapter.PlanFresh(PlanRequest{
+		Handle: "claude", Session: "collab", ProjectRoot: fixture.projectRoot, SessionRoot: fixture.sessionRoot,
+		Cwd: fixture.cwd, AllowExternalCwd: true, LaunchNonce: preparePlaceholderUUID, ResumePolicy: ResumeEnabled,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(result.Participants[0].Command.Argv, previewStaticCommand(expected).Argv) {
+		t.Fatalf("v1 named plan argv = %#v, want %#v", result.Participants[0].Command.Argv, expected.Argv)
+	}
+	if slices.Contains(result.Participants[0].Command.Argv, "--name") {
+		t.Fatalf("v1 plan added --name: %#v", result.Participants[0].Command.Argv)
+	}
+
+	legacyRequest := request
+	legacyRequest.Participants = append([]PrepareParticipant(nil), request.Participants...)
+	legacyRequest.Participants[0].Execution.Named = false
+	legacyResult, err := Prepare(context.Background(), legacyRequest, dependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SubjectDigest != legacyResult.SubjectDigest || result.PlanDigest != legacyResult.PlanDigest || result.TrustDigest != legacyResult.TrustDigest {
+		t.Fatalf("v1 named preference changed legacy digests: named=%#v legacy=%#v", result, legacyResult)
+	}
+}
+
 func TestPrepareOwningLayerIsZeroWriteAndBuildsTypedActions(t *testing.T) {
 	fixture := newInternalPrepareFixture(t)
 	writePrepareConversation(t, fixture.sessionRoot, ConversationRecord{

--- a/internal/launch/reconcile.go
+++ b/internal/launch/reconcile.go
@@ -1014,10 +1014,11 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			result.Agents = append(result.Agents, item)
 			continue
 		}
+		named := request.Config.EffectiveAgentNamed(cfg) && supportsManagedPlanNaming(adapter.Name())
 		base := PlanRequest{
-			Handle: cfg.Handle, ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(),
+			Handle: cfg.Handle, Session: request.Session, ProjectRoot: request.ProjectRoot, SessionRoot: request.Root.Base(),
 			AMQExecutable: request.AMQPath, Cwd: cwd,
-			LaunchNonce: nonce, ResumePolicy: policy, CommittedArgs: committedArgs, BypassArgs: bypassArgs,
+			LaunchNonce: nonce, Named: named, ResumePolicy: policy, CommittedArgs: committedArgs, BypassArgs: bypassArgs,
 			EnvOverlay: cfg.Env, AllowExternalCwd: request.AllowExternalCwd, InitialInput: cfg.InitialInput, Wrapper: cloneWrapper(cfg.Wrapper),
 		}
 		conversation, loadErr := LoadConversation(request.Root, cfg.Handle)
@@ -1135,9 +1136,9 @@ func buildReconcilePlan(request ReconcileRequest, nonce string, result *Reconcil
 			result.Agents = append(result.Agents, item)
 			continue
 		}
-		if execution, ok := request.ExecutionOptions[cfg.Handle]; ok {
-			agentPlan.Execution = clonePrepareExecutionOptions(&execution)
-		}
+		execution := request.ExecutionOptions[cfg.Handle]
+		execution.Named = named && disposition != DispositionResumed
+		agentPlan.Execution = clonePrepareExecutionOptions(&execution)
 		item.ConversationDisposition, item.Reason = disposition, planReason
 		result.Agents = append(result.Agents, item)
 		record := ConversationRecord{

--- a/internal/launch/reconcile_test.go
+++ b/internal/launch/reconcile_test.go
@@ -1312,7 +1312,7 @@ func TestReconcileMintStaysPendingUntilAcknowledgedThenResumesExactIdentity(t *t
 	}
 	if _, err := PrepareExecution(req.Root, "claude", ticket.LaunchNonce, ExecutionEnvelope{
 		Cwd: ticket.Cwd, AMQExecutable: ticket.AMQExecutable,
-		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv,
+		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv, Execution: ticket.Execution,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1373,7 +1373,7 @@ func TestReconcileCrashAfterBackendCreatedAcknowledgedThenRecoversReady(t *testi
 	}
 	acknowledged, err := PrepareExecution(req.Root, "claude", ticket.LaunchNonce, ExecutionEnvelope{
 		Cwd: ticket.Cwd, AMQExecutable: ticket.AMQExecutable,
-		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv,
+		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv, Execution: ticket.Execution,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/launch/tmux_test.go
+++ b/internal/launch/tmux_test.go
@@ -212,7 +212,7 @@ func TestTmuxReconcileCrashRestartThenRelaunchResumes(t *testing.T) {
 	}
 	if _, err := PrepareExecution(req.Root, "claude", ticket.LaunchNonce, ExecutionEnvelope{
 		Cwd: ticket.Cwd, AMQExecutable: ticket.AMQExecutable,
-		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv,
+		ProviderExecutable: ticket.ProviderExecutable, TargetArgv: ticket.TargetArgv, Execution: ticket.Execution,
 	}); err != nil {
 		t.Fatalf("provider start acknowledgement = %v", err)
 	}

--- a/launchapi/prepare_test.go
+++ b/launchapi/prepare_test.go
@@ -50,8 +50,8 @@ func TestPrepareIsZeroWriteAndDeterministic(t *testing.T) {
 		t.Fatalf("new Prepare subject schema = %d", first.SubjectSchema)
 	}
 	wantCapabilities := []ProviderCapabilitiesV1{{
-		Provider: "claude", GrammarVersion: 1, VerifiedProviderVersion: "2.1.233",
-		AllowedArgumentForms: []string{"--allowedTools"}, ConfigOverrides: []ConfigOverrideCapabilityV1{},
+		Provider: "claude", GrammarVersion: 2, VerifiedProviderVersion: "2.1.233",
+		AllowedArgumentForms: []string{"--allowedTools", "-n", "--name"}, ConfigOverrides: []ConfigOverrideCapabilityV1{},
 		InitialInputKinds: []InitialInputKindV1{InitialInputArgument},
 	}}
 	if !reflect.DeepEqual(first.Preview.Capabilities, wantCapabilities) {


### PR DESCRIPTION
## Summary

Session naming, PR 2 of the design (D4): managed launches name Claude sessions from the plan instead of mutating argv after ticketing.

- `.amq/launch.json`: `agents[].named` overrides the top-level `named` (default `true`).
- Claude `PlanFresh` appends `--name <session>/<handle>` (never `PlanResume`; skipped when committed args already carry `-n`/`--name`), so the name is part of the ticket argv and of the plan and trust digests.
- `-n`, `--name`, `--name=` join the Claude arg allowlist with a strict label grammar (`<session>/<handle>` or `<handle>`).
- Naming is a **SubjectSchema V2** capability: V1 subjects reproduce the pre-naming plan byte-for-byte for existing callers.
- `Named` is deliberately not part of execution-option identity (journal binding, reconcile drift compare): its only effect is the `--name` argv element, which the digests already cover.
- `coop exec` under a managed nonce proceeds unchanged when the ticket argv already carries `--name`; an explicit `--named` flag there is still refused (#659).
- The argv name/resume scanner now lives in `internal/launch` and is the single implementation used by both `internal/cli` and the launch package.
- Codex, Cursor, and Grok stay unnamed under managed launch; Pi has no launch adapter (direct-only).
- Claude capability `GrammarVersion` is now 2, covering the scoped `--allowedTools` grammar (#663) and the name flags.

## Tests

Per-agent precedence; fresh Claude plan carries `--name` and the digests change accordingly; V1 subject keeps `--name` out; resume plans never add it; committed `-n` is not duplicated; `coop exec` with a nonce and a ticket argv containing `--name` proceeds unchanged.

Refs bead `agent-message-queue-0qy`. Design: `~/worktrees/notes/design-session-naming-2026-08-26.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
