### PR TITLE
feat(keepalive): re-exec a strictly newer supervisor image in place

### DIFF
--- a/cmd/amq-keepalive/main.go
+++ b/cmd/amq-keepalive/main.go
@@ -56,7 +56,7 @@ func main() {
 		signal.Stop(signals)
 		cancel()
 	}()
-	code := app.App{}.Run(ctx, os.Args[1:])
+	code := (app.App{SelfVersion: getVersion()}).Run(ctx, os.Args[1:])
 	signal.Stop(signals)
 	cancel()
 	os.Exit(code)

--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -125,6 +125,10 @@ version. A candidate must also have different bytes from the running image and
 must pass the same ownership, mode, identity, and hash checks used by wake
 self-upgrade.
 
+On Darwin, the private `0700` PID-scoped stage is re-verified immediately
+before pathname exec because Darwin has no `fexecve`; same-UID races in that
+narrow window are outside AMQ's threat model, as for wake self-upgrade.
+
 The `register` and `attach` commands keep `executablePath()` as their default
 injector path. Only `supervise` derives its default self-upgrade locator from
 the launch `argv[0]` or `PATH`, because launchd and direct invocations name the
@@ -139,11 +143,11 @@ upgrade.
 
 Candidate version probes that fail or time out defer and are retried after a
 later pass. Exec failures fail closed and are recorded in the private
-`.selfupgrade.json` sidecar next to the registry; each fully identified
-candidate is attempted at most once in the current supervisor generation. A
-new process generation starts with an empty refusal set. The sidecar is mode
-`0600`; a corrupt or unsafe sidecar disables self-upgrade for that process. Use
-`supervise --no-self-upgrade` to opt out.
+`.selfupgrade.json` sidecar next to the registry; each exec-attempted candidate
+is refused at most once per generation. A new process generation starts with
+an empty refusal set. The sidecar is mode `0600`; a corrupt or unsafe sidecar
+disables self-upgrade for that process. Use `supervise --no-self-upgrade` to
+opt out.
 
 ### Detached wake stderr protocol
 

--- a/docs/amq-keepalive.md
+++ b/docs/amq-keepalive.md
@@ -116,6 +116,35 @@ amq-keepalive gc --min-detached-age 24h --apply
 minimum age and whose target is again proven absent. AMQ must confirm the exact
 wake retirement before the registry row is forgotten.
 
+### Self-upgrade
+
+The continuous supervisor watches the direct executable path named by its
+launch arguments. After each completed supervisor pass, and before the next
+interval wait, it probes that path for a strictly newer self-reported semantic
+version. A candidate must also have different bytes from the running image and
+must pass the same ownership, mode, identity, and hash checks used by wake
+self-upgrade.
+
+The `register` and `attach` commands keep `executablePath()` as their default
+injector path. Only `supervise` derives its default self-upgrade locator from
+the launch `argv[0]` or `PATH`, because launchd and direct invocations name the
+stable file that a sibling-and-rename install replaces.
+
+When the candidate is accepted, keepalive calls `execve` in place. The process
+PID, command arguments, and environment are preserved. The new image re-reads
+the registry and reinitializes supervisor state; open descriptors remain open
+only when they are not marked close-on-exec. Registry reconciliation must
+finish before this check; an uncertain pass or candidate identity defers the
+upgrade.
+
+Candidate version probes that fail or time out defer and are retried after a
+later pass. Exec failures fail closed and are recorded in the private
+`.selfupgrade.json` sidecar next to the registry; each fully identified
+candidate is attempted at most once in the current supervisor generation. A
+new process generation starts with an empty refusal set. The sidecar is mode
+`0600`; a corrupt or unsafe sidecar disables self-upgrade for that process. Use
+`supervise --no-self-upgrade` to opt out.
+
 ### Detached wake stderr protocol
 
 The short-lived launcher cannot leave the wake writing to a pipe whose reader

--- a/docs/wake-lifecycle.md
+++ b/docs/wake-lifecycle.md
@@ -597,6 +597,8 @@ binaries, ownerless/keepalive wakes, repair flows, destructive interrupts, and
 arbitrary `--inject-cmd` wakes never self-upgrade. The eligible default is
 disabled with `amq wake --no-self-upgrade` or `AMQ_WAKE_NO_SELF_UPGRADE=1`;
 schema-2 wake/doctor JSON reports the latest decision under `self_upgrade`.
+The separate `amq-keepalive` supervisor has its own direct-image self-upgrade
+contract documented in `docs/amq-keepalive.md`.
 
 ### 9.2 `.wake.log` retention
 

--- a/internal/keepalive/app/app.go
+++ b/internal/keepalive/app/app.go
@@ -27,6 +27,10 @@ type App struct {
 	Adapters *adapter.Registry
 	Wake     supervisor.WakeRunner
 	Now      func() time.Time
+	// SelfVersion is the version embedded in the running keepalive binary.
+	// The command entry point supplies it; tests and library callers may leave
+	// it empty to keep self-upgrade disabled.
+	SelfVersion string
 
 	adapterLogState *adapterLogState
 }
@@ -725,15 +729,20 @@ func (a App) supervise(ctx context.Context, args []string) error {
 	fs.SetOutput(a.Stderr)
 	registryPath := fs.String("registry", mustDefaultRegistryPath(), "registry file path")
 	amqPath := fs.String("amq", "amq", "amq executable path")
-	self := fs.String("self", executablePath(), "amq-keepalive executable path for --inject-via")
+	self := fs.String("self", selfUpgradeDefaultLocator(), "amq-keepalive executable path for --inject-via")
 	once := fs.Bool("once", false, "run one supervisor pass")
 	interval := fs.Duration("interval", time.Minute, "supervisor interval")
 	wakeTimeout := fs.Duration("wake-ready-timeout", 10*time.Second, "maximum time to wait for amq wake readiness")
+	noSelfUpgrade := fs.Bool("no-self-upgrade", false, "disable automatic replacement by a newer keepalive image")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if *interval <= 0 {
 		return errors.New("--interval must be greater than zero")
+	}
+	selfUpgrade := newSelfUpgradeController(*registryPath, *self, a.SelfVersion, !*noSelfUpgrade)
+	if selfUpgrade.enabled && !selfUpgrade.eligible && selfUpgrade.reason != "" {
+		_, _ = fmt.Fprintf(a.Stderr, "amq-keepalive self-upgrade unavailable: %s\n", selfUpgrade.reason)
 	}
 
 	runOnce := func(emitJSON bool) error {
@@ -750,7 +759,10 @@ func (a App) supervise(ctx context.Context, args []string) error {
 		return runOnce(true)
 	}
 	for {
-		if err := runOnce(false); err != nil {
+		passErr := runOnce(false)
+		if passErr != nil {
+			_, _ = fmt.Fprintln(a.Stderr, passErr)
+		} else if err := selfUpgrade.maintain(ctx); err != nil {
 			_, _ = fmt.Fprintln(a.Stderr, err)
 		}
 		timer := time.NewTimer(*interval)

--- a/internal/keepalive/app/selfupgrade.go
+++ b/internal/keepalive/app/selfupgrade.go
@@ -1,0 +1,409 @@
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
+)
+
+const (
+	selfUpgradeStateSchema       = 1
+	selfUpgradeStateFileName     = ".selfupgrade.json"
+	selfUpgradeVersionProbeLimit = 5 * time.Second
+	selfUpgradeActionUnchanged   = "unchanged"
+	selfUpgradeActionRefused     = "refused"
+	selfUpgradeActionExec        = "exec"
+)
+
+var errSelfUpgradeVersionProbeTimeout = errors.New("self-upgrade candidate version probe timed out")
+
+var (
+	selfUpgradeExecutable      = os.Executable
+	selfUpgradeEvalSymlinks    = filepath.EvalSymlinks
+	selfUpgradeCaptureImage    = selfupgrade.CaptureImageEvidence
+	selfUpgradeRunVersion      = runSelfUpgradeVersion
+	selfUpgradeExecImage       = selfupgrade.ExecImage
+	selfUpgradeGeneration      = newSelfUpgradeGeneration
+	selfUpgradeStateFileInfo   = os.Lstat
+	selfUpgradeStateReadFile   = os.ReadFile
+	selfUpgradeStateCreateTemp = os.CreateTemp
+	selfUpgradeStateRename     = os.Rename
+	selfUpgradeStateRemove     = os.Remove
+	selfUpgradeStateWrite      = io.WriteString
+	selfUpgradeSyncDir         = syncSelfUpgradeDir
+)
+
+type selfUpgradeController struct {
+	enabled         bool
+	eligible        bool
+	reason          string
+	locator         string
+	incumbent       selfupgrade.ImageEvidence
+	generation      string
+	statePath       string
+	refused         []selfupgrade.RefusedCandidate
+	statePublished  bool
+	lastObservation *selfUpgradeObservation
+}
+
+type selfUpgradeObservation struct {
+	evidence selfupgrade.ImageEvidence
+	action   string
+}
+
+type selfUpgradeStateFile struct {
+	Schema            int                            `json:"schema"`
+	Generation        string                         `json:"generation"`
+	IncumbentVersion  string                         `json:"incumbent_version"`
+	IncumbentSHA256   string                         `json:"incumbent_sha256"`
+	RefusedCandidates []selfupgrade.RefusedCandidate `json:"refused_candidates,omitempty"`
+}
+
+func newSelfUpgradeController(registryPath, locator, version string, enabled bool) *selfUpgradeController {
+	controller := &selfUpgradeController{enabled: enabled}
+	if !enabled {
+		controller.reason = "disabled by --no-self-upgrade"
+		return controller
+	}
+	if strings.TrimSpace(version) == "" || strings.TrimSpace(version) != version {
+		controller.reason = "running image version is unavailable"
+		return controller
+	}
+	generation, err := selfUpgradeGeneration()
+	if err != nil {
+		controller.reason = "self-upgrade generation is unavailable"
+		return controller
+	}
+	controller.generation = generation
+	path, err := canonicalSelfUpgradePath(locator)
+	if err != nil {
+		controller.reason = err.Error()
+		return controller
+	}
+	controller.locator = path
+	registryPath, err = canonicalSelfUpgradePath(registryPath)
+	if err != nil {
+		controller.reason = fmt.Sprintf("self-upgrade state path is unavailable: %v", err)
+		return controller
+	}
+	controller.statePath = filepath.Join(filepath.Dir(registryPath), selfUpgradeStateFileName)
+
+	runningPath, err := selfUpgradeExecutable()
+	if err != nil {
+		controller.reason = fmt.Sprintf("resolve running image: %v", err)
+		return controller
+	}
+	runningPath, err = resolvedSelfUpgradePath(runningPath)
+	if err != nil {
+		controller.reason = fmt.Sprintf("resolve running image: %v", err)
+		return controller
+	}
+	incumbent, err := selfUpgradeCaptureImage(runningPath, version)
+	if err != nil {
+		controller.reason = fmt.Sprintf("capture running image: %v", err)
+		return controller
+	}
+	locatorImage, err := selfUpgradeCaptureImage(path, version)
+	if err != nil {
+		controller.reason = fmt.Sprintf("capture self-upgrade locator: %v", err)
+		return controller
+	}
+	if !sameSelfUpgradeFileIdentity(incumbent, locatorImage) {
+		controller.reason = "self-upgrade locator does not name the running image"
+		return controller
+	}
+	controller.incumbent = incumbent
+	if err := selfupgrade.CleanupStages(path); err != nil {
+		controller.reason = fmt.Sprintf("clean up self-upgrade stages: %v", err)
+		return controller
+	}
+	if err := loadSelfUpgradeState(controller); err != nil {
+		controller.reason = fmt.Sprintf("self-upgrade refusal state is unavailable: %v", err)
+		return controller
+	}
+	controller.eligible = true
+	return controller
+}
+
+func canonicalSelfUpgradePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("self-upgrade path is empty")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve self-upgrade path: %w", err)
+	}
+	abs = filepath.Clean(abs)
+	if !filepath.IsAbs(abs) || filepath.Clean(abs) != abs {
+		return "", errors.New("self-upgrade path is not canonical")
+	}
+	return abs, nil
+}
+
+func selfUpgradeDefaultLocator() string {
+	if len(os.Args) > 0 {
+		argv0 := strings.TrimSpace(os.Args[0])
+		if argv0 != "" {
+			if resolved, err := exec.LookPath(argv0); err == nil {
+				return resolved
+			}
+			return argv0
+		}
+	}
+	return executablePath()
+}
+
+func resolvedSelfUpgradePath(path string) (string, error) {
+	path, err := canonicalSelfUpgradePath(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := selfUpgradeEvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err = canonicalSelfUpgradePath(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolved self-upgrade path: %w", err)
+	}
+	return resolved, nil
+}
+
+func newSelfUpgradeGeneration() (string, error) {
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d-%x", os.Getpid(), bytes[:]), nil
+}
+
+func loadSelfUpgradeState(controller *selfUpgradeController) error {
+	info, err := selfUpgradeStateFileInfo(controller.statePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		return errors.New("self-upgrade refusal state is not a private regular file")
+	}
+	raw, err := selfUpgradeStateReadFile(controller.statePath)
+	if err != nil {
+		return err
+	}
+	var state selfUpgradeStateFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return err
+	}
+	if state.Schema != selfUpgradeStateSchema || strings.TrimSpace(state.Generation) == "" {
+		return errors.New("self-upgrade refusal state schema is invalid")
+	}
+	if err := validateSelfUpgradeRefusals(state.RefusedCandidates); err != nil {
+		return err
+	}
+	if state.Generation == controller.generation {
+		controller.refused = append([]selfupgrade.RefusedCandidate(nil), state.RefusedCandidates...)
+	}
+	return nil
+}
+
+func validateSelfUpgradeRefusals(candidates []selfupgrade.RefusedCandidate) error {
+	if len(candidates) > selfupgrade.RefusalLimit {
+		return fmt.Errorf("self-upgrade refusal state exceeds the limit of %d", selfupgrade.RefusalLimit)
+	}
+	seen := make(map[selfupgrade.RefusedCandidate]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.Platform != runtime.GOOS || candidate.Device == 0 || candidate.Inode == 0 ||
+			candidate.Size <= 0 || !selfupgrade.ValidSHA256(candidate.SHA256) {
+			return errors.New("self-upgrade refusal identity is invalid")
+		}
+		version := strings.TrimSpace(candidate.EmbeddedVersion)
+		if version == "" || version != candidate.EmbeddedVersion || strings.ContainsRune(version, 0) {
+			return errors.New("self-upgrade refusal version is invalid")
+		}
+		if _, exists := seen[candidate]; exists {
+			return errors.New("self-upgrade refusal state contains a duplicate candidate")
+		}
+		seen[candidate] = struct{}{}
+	}
+	return nil
+}
+
+func (controller *selfUpgradeController) ensureStatePublished() error {
+	if controller.statePublished {
+		return nil
+	}
+	if err := controller.saveState(); err != nil {
+		controller.eligible = false
+		controller.reason = fmt.Sprintf("publish self-upgrade state: %v", err)
+		return err
+	}
+	controller.statePublished = true
+	return nil
+}
+
+func (controller *selfUpgradeController) saveState() error {
+	if controller.statePath == "" {
+		return errors.New("self-upgrade state path is empty")
+	}
+	state := selfUpgradeStateFile{
+		Schema:            selfUpgradeStateSchema,
+		Generation:        controller.generation,
+		IncumbentVersion:  controller.incumbent.EmbeddedVersion,
+		IncumbentSHA256:   controller.incumbent.SHA256,
+		RefusedCandidates: append([]selfupgrade.RefusedCandidate(nil), controller.refused...),
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	dir := filepath.Dir(controller.statePath)
+	tmp, err := selfUpgradeStateCreateTemp(dir, ".selfupgrade-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = selfUpgradeStateRemove(tmpName) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := selfUpgradeStateWrite(tmp, string(data)); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := selfUpgradeStateRename(tmpName, controller.statePath); err != nil {
+		return err
+	}
+	if err := selfUpgradeSyncDir(dir); err != nil {
+		return fmt.Errorf("sync self-upgrade state directory: %w", err)
+	}
+	return nil
+}
+
+func (controller *selfUpgradeController) maintain(ctx context.Context) error {
+	if controller == nil || !controller.enabled || !controller.eligible {
+		return nil
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
+	if err := controller.ensureStatePublished(); err != nil {
+		return fmt.Errorf("self-upgrade deferred: %w", err)
+	}
+	preflight, err := selfUpgradeCaptureImage(controller.locator, controller.incumbent.EmbeddedVersion)
+	if err != nil {
+		controller.lastObservation = nil
+		return nil
+	}
+	if controller.lastObservation != nil &&
+		sameSelfUpgradeFileIdentity(controller.lastObservation.evidence, preflight) {
+		return nil
+	}
+	if sameSelfUpgradeContent(controller.incumbent, preflight) {
+		controller.lastObservation = &selfUpgradeObservation{evidence: preflight, action: selfUpgradeActionUnchanged}
+		return nil
+	}
+	version, err := selfUpgradeRunVersion(controller.locator)
+	if err != nil {
+		controller.lastObservation = nil
+		if errors.Is(err, errSelfUpgradeVersionProbeTimeout) {
+			return nil
+		}
+		return fmt.Errorf("self-upgrade deferred for candidate %s: version probe: %w", controller.locator, err)
+	}
+	candidate, err := selfUpgradeCaptureImage(controller.locator, version)
+	if err != nil || !sameSelfUpgradeFileIdentity(preflight, candidate) {
+		controller.lastObservation = nil
+		return nil
+	}
+	controller.lastObservation = &selfUpgradeObservation{evidence: candidate}
+	if sameSelfUpgradeContent(controller.incumbent, candidate) {
+		controller.lastObservation.action = selfUpgradeActionUnchanged
+		return nil
+	}
+	if !selfupgrade.VersionStrictlyNewer(controller.incumbent.EmbeddedVersion, candidate.EmbeddedVersion) {
+		controller.lastObservation.action = selfUpgradeActionUnchanged
+		return nil
+	}
+	if selfupgrade.RefusedCandidatesContain(controller.refused, candidate) {
+		controller.lastObservation.action = selfUpgradeActionRefused
+		return nil
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
+	argv := append([]string(nil), os.Args...)
+	env := append([]string(nil), os.Environ()...)
+	if err := selfUpgradeExecImage(candidate, argv, env); err != nil {
+		return controller.refuse(candidate, fmt.Errorf("exec newer self-upgrade image: %w", err))
+	}
+	controller.lastObservation.action = selfUpgradeActionExec
+	return nil
+}
+
+func (controller *selfUpgradeController) refuse(candidate selfupgrade.ImageEvidence, cause error) error {
+	controller.refused = selfupgrade.RememberRefusal(controller.refused, candidate)
+	controller.lastObservation = &selfUpgradeObservation{evidence: candidate, action: selfUpgradeActionRefused}
+	if err := controller.saveState(); err != nil {
+		return errors.Join(cause, fmt.Errorf("persist self-upgrade refusal: %w", err))
+	}
+	return cause
+}
+
+func runSelfUpgradeVersion(path string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), selfUpgradeVersionProbeLimit)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, path, "--version").Output()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("%w: %v", errSelfUpgradeVersionProbeTimeout, ctx.Err())
+		}
+		return "", err
+	}
+	version := strings.TrimSpace(string(out))
+	if version == "" || strings.ContainsAny(version, "\r\n\t ") {
+		return "", errors.New("candidate version probe returned a malformed version")
+	}
+	return version, nil
+}
+
+func sameSelfUpgradeContent(first, second selfupgrade.ImageEvidence) bool {
+	return first.Platform == second.Platform &&
+		first.Size == second.Size &&
+		first.SHA256 == second.SHA256
+}
+
+func sameSelfUpgradeFileIdentity(first, second selfupgrade.ImageEvidence) bool {
+	return sameSelfUpgradeContent(first, second) &&
+		first.Device == second.Device && first.Inode == second.Inode
+}

--- a/internal/keepalive/app/selfupgrade.go
+++ b/internal/keepalive/app/selfupgrade.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/json"
@@ -21,6 +22,7 @@ const (
 	selfUpgradeStateSchema       = 1
 	selfUpgradeStateFileName     = ".selfupgrade.json"
 	selfUpgradeVersionProbeLimit = 5 * time.Second
+	selfUpgradeVersionMaxOutput  = 4 * 1024
 	selfUpgradeActionUnchanged   = "unchanged"
 	selfUpgradeActionRefused     = "refused"
 	selfUpgradeActionExec        = "exec"
@@ -74,6 +76,10 @@ func newSelfUpgradeController(registryPath, locator, version string, enabled boo
 	controller := &selfUpgradeController{enabled: enabled}
 	if !enabled {
 		controller.reason = "disabled by --no-self-upgrade"
+		return controller
+	}
+	if !selfupgrade.ExecSupported() {
+		controller.reason = fmt.Sprintf("self-upgrade is unsupported on %s", runtime.GOOS)
 		return controller
 	}
 	if strings.TrimSpace(version) == "" || strings.TrimSpace(version) != version {
@@ -380,17 +386,41 @@ func (controller *selfUpgradeController) refuse(candidate selfupgrade.ImageEvide
 	return cause
 }
 
+type selfUpgradeVersionOutput struct {
+	buffer    bytes.Buffer
+	remaining int64
+	overflow  bool
+}
+
+func (output *selfUpgradeVersionOutput) Write(data []byte) (int, error) {
+	if int64(len(data)) > output.remaining {
+		output.overflow = true
+	}
+	limited := io.LimitReader(bytes.NewReader(data), output.remaining)
+	written, err := io.Copy(&output.buffer, limited)
+	output.remaining -= written
+	return len(data), err
+}
+
 func runSelfUpgradeVersion(path string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), selfUpgradeVersionProbeLimit)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, path, "--version").Output()
-	if err != nil {
+	command := exec.CommandContext(ctx, path, "--version")
+	command.WaitDelay = selfUpgradeVersionProbeLimit
+	configureSelfUpgradeVersionProbe(command)
+	output := &selfUpgradeVersionOutput{remaining: selfUpgradeVersionMaxOutput}
+	command.Stdout = output
+	command.Stderr = io.Discard
+	if err := command.Run(); err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return "", fmt.Errorf("%w: %v", errSelfUpgradeVersionProbeTimeout, ctx.Err())
 		}
 		return "", err
 	}
-	version := strings.TrimSpace(string(out))
+	if output.overflow {
+		return "", errors.New("candidate version probe returned too much output")
+	}
+	version := strings.TrimSpace(output.buffer.String())
 	if version == "" || strings.ContainsAny(version, "\r\n\t ") {
 		return "", errors.New("candidate version probe returned a malformed version")
 	}

--- a/internal/keepalive/app/selfupgrade_live_unix_test.go
+++ b/internal/keepalive/app/selfupgrade_live_unix_test.go
@@ -1,0 +1,189 @@
+//go:build darwin || linux
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/keepalive/registry"
+)
+
+func TestKeepaliveSelfUpgradeLive(t *testing.T) {
+	if os.Getenv("AMQ_KEEPALIVE_LIVE") != "1" {
+		t.Skip("set AMQ_KEEPALIVE_LIVE=1 for the real keepalive self-upgrade proof")
+	}
+	if testing.Short() {
+		t.Skip("real keepalive self-upgrade proof")
+	}
+
+	dir := t.TempDir()
+	repoRoot := keepaliveAppRepoRoot(t)
+	releases := filepath.Join(dir, "releases")
+	install := filepath.Join(dir, "install")
+	if err := os.MkdirAll(releases, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(install, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldBinary := filepath.Join(releases, "old", "amq-keepalive")
+	newBinary := filepath.Join(releases, "new", "amq-keepalive")
+	if err := os.MkdirAll(filepath.Dir(oldBinary), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(newBinary), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	buildKeepaliveVersionedBinary(t, repoRoot, oldBinary, "1.0.0")
+	buildKeepaliveVersionedBinary(t, repoRoot, newBinary, "1.1.0")
+	stable := filepath.Join(install, "amq-keepalive")
+	if err := os.Rename(oldBinary, stable); err != nil {
+		t.Fatalf("install old keepalive: %v", err)
+	}
+
+	registryPath := filepath.Join(install, "registry.json")
+	target := filepath.Join(dir, "supervised-target")
+	if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.New(registryPath).Upsert(registry.Entry{
+		Root: "/tmp/amq-keepalive-live", Agent: "codex", Adapter: "file", Target: target,
+	}); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+	fakeAMQ := filepath.Join(dir, "amq")
+	callLog := filepath.Join(dir, "amq-calls.log")
+	writeKeepaliveLiveFakeAMQ(t, fakeAMQ)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, stable, "supervise", "--registry", registryPath, "--amq", fakeAMQ, "--self", stable, "--interval", "20ms")
+	cmd.Env = append(os.Environ(), "AMQ_KEEPALIVE_LIVE=1", "AMQ_KEEPALIVE_LIVE_CALLS="+callLog)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		_, _ = cmd.Process.Wait()
+	})
+
+	statePath := filepath.Join(install, selfUpgradeStateFileName)
+	waitForKeepaliveVersion(t, statePath, "1.0.0")
+	registryBefore, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("read initial registry: %v", err)
+	}
+	callsBefore, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read initial AMQ calls: %v", err)
+	}
+
+	next := stable + ".next"
+	if err := os.Rename(newBinary, next); err != nil {
+		t.Fatalf("stage newer keepalive: %v", err)
+	}
+	if err := os.Rename(next, stable); err != nil {
+		t.Fatalf("publish newer keepalive: %v", err)
+	}
+	waitForKeepaliveVersion(t, statePath, "1.1.0")
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("keepalive pid %d is not alive after exec: %v\n%s", pid, err, output.String())
+	}
+	registryAfter, err := os.ReadFile(registryPath)
+	if err != nil {
+		t.Fatalf("read upgraded registry: %v", err)
+	}
+	if !bytes.Equal(registryBefore, registryAfter) {
+		t.Fatalf("registry changed across self-upgrade:\nbefore=%safter=%s", registryBefore, registryAfter)
+	}
+	callsAfter, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read upgraded AMQ calls: %v", err)
+	}
+	if !bytes.Equal(callsBefore, callsAfter) {
+		t.Fatalf("supervised wake was touched during self-upgrade:\nbefore=%qafter=%q", callsBefore, callsAfter)
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("stop keepalive: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("keepalive exit: %v\n%s", err, output.String())
+	}
+}
+
+func buildKeepaliveVersionedBinary(t *testing.T, repoRoot, output, version string) {
+	t.Helper()
+	cmd := exec.Command("go", "build", "-ldflags", "-X main.version="+version, "-o", output, "./cmd/amq-keepalive")
+	cmd.Dir = repoRoot
+	if outputBytes, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build keepalive %s: %v\n%s", version, err, outputBytes)
+	}
+}
+
+func writeKeepaliveLiveFakeAMQ(t *testing.T, path string) {
+	t.Helper()
+	const script = `#!/bin/sh
+printf '%s\n' "$*" >> "$AMQ_KEEPALIVE_LIVE_CALLS"
+if [ "$1" = "wake" ] && [ "$2" = "check" ]; then
+  printf '%s\n' '{"schema":1,"live_wake":false,"image_status":"none"}'
+  exit 0
+fi
+if [ "$1" = "wake" ]; then
+  ready=""
+  previous=""
+  for arg in "$@"; do
+    if [ "$previous" = "-ready-file" ]; then ready="$arg"; fi
+    previous="$arg"
+  done
+  [ -n "$ready" ] || exit 11
+  umask 077
+  printf '%s\n' '{"schema":1,"generation":"live-generation","target_digest":"live-digest"}' > "$ready"
+  exit 0
+fi
+exit 12
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForKeepaliveVersion(t *testing.T, statePath, want string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(statePath)
+		if err == nil {
+			var state selfUpgradeStateFile
+			if json.Unmarshal(data, &state) == nil && state.IncumbentVersion == want {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	data, _ := os.ReadFile(statePath)
+	t.Fatalf("keepalive did not publish incumbent version %q at %s: %s", want, statePath, fmt.Sprint(data))
+}
+
+func keepaliveAppRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve app test source path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", "..", ".."))
+}

--- a/internal/keepalive/app/selfupgrade_live_unix_test.go
+++ b/internal/keepalive/app/selfupgrade_live_unix_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -176,7 +175,7 @@ func waitForKeepaliveVersion(t *testing.T, statePath, want string) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	data, _ := os.ReadFile(statePath)
-	t.Fatalf("keepalive did not publish incumbent version %q at %s: %s", want, statePath, fmt.Sprint(data))
+	t.Fatalf("keepalive did not publish incumbent version %q at %s: %s", want, statePath, string(data))
 }
 
 func keepaliveAppRepoRoot(t *testing.T) string {

--- a/internal/keepalive/app/selfupgrade_platform_other_test.go
+++ b/internal/keepalive/app/selfupgrade_platform_other_test.go
@@ -1,0 +1,20 @@
+//go:build !darwin && !linux
+
+package app
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestSelfUpgradeIsIneligibleOnUnsupportedPlatform(t *testing.T) {
+	controller := newSelfUpgradeController("", "", "1.0.0", true)
+	if controller.eligible {
+		t.Fatal("unsupported platform controller is eligible")
+	}
+	want := fmt.Sprintf("self-upgrade is unsupported on %s", runtime.GOOS)
+	if controller.reason != want {
+		t.Fatalf("controller reason = %q, want %q", controller.reason, want)
+	}
+}

--- a/internal/keepalive/app/selfupgrade_probe_other.go
+++ b/internal/keepalive/app/selfupgrade_probe_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package app
+
+import "os/exec"
+
+func configureSelfUpgradeVersionProbe(*exec.Cmd) {}

--- a/internal/keepalive/app/selfupgrade_probe_unix.go
+++ b/internal/keepalive/app/selfupgrade_probe_unix.go
@@ -1,0 +1,26 @@
+//go:build darwin || linux
+
+package app
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureSelfUpgradeVersionProbe(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return os.ErrProcessDone
+		}
+		if err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+}

--- a/internal/keepalive/app/selfupgrade_probe_unix_test.go
+++ b/internal/keepalive/app/selfupgrade_probe_unix_test.go
@@ -1,0 +1,43 @@
+//go:build darwin || linux
+
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
+)
+
+func TestSelfUpgradeVersionProbeKillsInheritedPipeProcess(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	if err := os.WriteFile(candidatePath, []byte("#!/bin/sh\nprintf '1.1.0\\n'\n(sleep 60) &\nwait\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+
+	previousExec := selfUpgradeExecImage
+	t.Cleanup(func() { selfUpgradeExecImage = previousExec })
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		t.Fatal("timed-out candidate must not be executed")
+		return nil
+	}
+
+	started := time.Now()
+	if err := controller.maintain(context.Background()); err != nil {
+		t.Fatalf("maintain() error = %v, want deferred timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > selfUpgradeVersionProbeLimit+2*time.Second {
+		t.Fatalf("version probe took %s, want it bounded near %s", elapsed, selfUpgradeVersionProbeLimit)
+	}
+	if len(controller.refused) != 0 {
+		t.Fatalf("timed-out candidate consumed refusal memory: %#v", controller.refused)
+	}
+}

--- a/internal/keepalive/app/selfupgrade_sync_other.go
+++ b/internal/keepalive/app/selfupgrade_sync_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package app
+
+// Directory fsync is unavailable on the platforms where self-upgrade exec is
+// unsupported. The sidecar file is still written and fsynced before rename.
+func syncSelfUpgradeDir(string) error { return nil }

--- a/internal/keepalive/app/selfupgrade_sync_unix.go
+++ b/internal/keepalive/app/selfupgrade_sync_unix.go
@@ -1,0 +1,14 @@
+//go:build darwin || linux
+
+package app
+
+import "os"
+
+func syncSelfUpgradeDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}

--- a/internal/keepalive/app/selfupgrade_test.go
+++ b/internal/keepalive/app/selfupgrade_test.go
@@ -1,0 +1,302 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/internal/selfupgrade"
+)
+
+func TestSelfUpgradeExecsStrictlyNewerImageAtQuiescentBoundary(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+
+	previousVersion := selfUpgradeRunVersion
+	previousExec := selfUpgradeExecImage
+	t.Cleanup(func() {
+		selfUpgradeRunVersion = previousVersion
+		selfUpgradeExecImage = previousExec
+	})
+	selfUpgradeRunVersion = func(string) (string, error) { return "1.1.0", nil }
+	var got selfupgrade.ImageEvidence
+	var gotArgv, gotEnv []string
+	selfUpgradeExecImage = func(candidate selfupgrade.ImageEvidence, argv, env []string) error {
+		got = candidate
+		gotArgv = append([]string(nil), argv...)
+		gotEnv = append([]string(nil), env...)
+		return nil
+	}
+
+	if err := controller.maintain(nil); err != nil {
+		t.Fatalf("maintain() error = %v", err)
+	}
+	if got.EmbeddedVersion != "1.1.0" {
+		t.Fatalf("executed candidate version = %q, want 1.1.0", got.EmbeddedVersion)
+	}
+	if len(gotArgv) == 0 || len(gotEnv) == 0 {
+		t.Fatalf("exec did not receive process argv/env: argv=%#v env=%#v", gotArgv, gotEnv)
+	}
+	if controller.lastObservation == nil || controller.lastObservation.action != selfUpgradeActionExec {
+		t.Fatalf("last observation = %#v, want exec", controller.lastObservation)
+	}
+	assertSelfUpgradeStateMode(t, controller.statePath)
+}
+
+func TestSelfUpgradeDoesNotExecIdenticalBytesWithDifferentVersion(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	contents := "same image"
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, contents)
+	writeExecutableForSelfUpgradeTest(t, candidatePath, contents)
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+
+	previousVersion := selfUpgradeRunVersion
+	previousExec := selfUpgradeExecImage
+	t.Cleanup(func() {
+		selfUpgradeRunVersion = previousVersion
+		selfUpgradeExecImage = previousExec
+	})
+	selfUpgradeRunVersion = func(string) (string, error) {
+		t.Fatal("identical image should not require a version probe")
+		return "", nil
+	}
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		t.Fatal("identical image must not be executed")
+		return nil
+	}
+
+	if err := controller.maintain(nil); err != nil {
+		t.Fatalf("maintain() error = %v", err)
+	}
+	if controller.lastObservation == nil || controller.lastObservation.action != selfUpgradeActionUnchanged {
+		t.Fatalf("last observation = %#v, want unchanged", controller.lastObservation)
+	}
+}
+
+func TestSelfUpgradeDefersFailedCandidateVersionProbe(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "good image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "corrupt image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+
+	previousVersion := selfUpgradeRunVersion
+	previousExec := selfUpgradeExecImage
+	t.Cleanup(func() {
+		selfUpgradeRunVersion = previousVersion
+		selfUpgradeExecImage = previousExec
+	})
+	versionCalls := 0
+	selfUpgradeRunVersion = func(string) (string, error) {
+		versionCalls++
+		return "", errors.New("candidate exited unsuccessfully")
+	}
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		t.Fatal("corrupt candidate must not be executed")
+		return nil
+	}
+
+	if err := controller.maintain(nil); err == nil || !strings.Contains(err.Error(), "deferred for candidate "+candidatePath) {
+		t.Fatalf("first maintain() error = %v, want deferred probe error", err)
+	}
+	if err := controller.maintain(nil); err == nil || !strings.Contains(err.Error(), "deferred for candidate "+candidatePath) {
+		t.Fatalf("second maintain() error = %v, want deferred probe error", err)
+	}
+	if versionCalls != 2 {
+		t.Fatalf("version probe calls = %d, want retry after deferred failure", versionCalls)
+	}
+	if len(controller.refused) != 0 {
+		t.Fatalf("refusal memory length = %d, want no refusal for an inconclusive probe", len(controller.refused))
+	}
+	assertSelfUpgradeStateMode(t, controller.statePath)
+}
+
+func TestSelfUpgradeDoesNotReprobeSameCandidateIdentity(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+
+	previousVersion := selfUpgradeRunVersion
+	previousExec := selfUpgradeExecImage
+	t.Cleanup(func() {
+		selfUpgradeRunVersion = previousVersion
+		selfUpgradeExecImage = previousExec
+	})
+	versionCalls := 0
+	selfUpgradeRunVersion = func(string) (string, error) {
+		versionCalls++
+		return "1.1.0", nil
+	}
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error { return nil }
+
+	if err := controller.maintain(nil); err != nil {
+		t.Fatalf("first maintain() error = %v", err)
+	}
+	if err := controller.maintain(nil); err != nil {
+		t.Fatalf("second maintain() error = %v", err)
+	}
+	if versionCalls != 1 {
+		t.Fatalf("version probe calls = %d, want one for one candidate identity", versionCalls)
+	}
+}
+
+func TestSelfUpgradeExecFailureIsRememberedOnce(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+
+	previousVersion := selfUpgradeRunVersion
+	previousExec := selfUpgradeExecImage
+	t.Cleanup(func() {
+		selfUpgradeRunVersion = previousVersion
+		selfUpgradeExecImage = previousExec
+	})
+	selfUpgradeRunVersion = func(string) (string, error) { return "1.1.0", nil }
+	execCalls := 0
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		execCalls++
+		return errors.New("exec denied")
+	}
+
+	if err := controller.maintain(nil); err == nil || !strings.Contains(err.Error(), "exec newer self-upgrade image") {
+		t.Fatalf("first maintain() error = %v, want exec refusal", err)
+	}
+	if err := controller.maintain(nil); err != nil {
+		t.Fatalf("second maintain() error = %v, want cached refusal", err)
+	}
+	if execCalls != 1 || len(controller.refused) != 1 {
+		t.Fatalf("exec calls=%d refusal memory=%d, want 1 and 1", execCalls, len(controller.refused))
+	}
+}
+
+func TestSelfUpgradeTimeoutDoesNotConsumeRefusalMemory(t *testing.T) {
+	dir := t.TempDir()
+	incumbentPath := filepath.Join(dir, "incumbent")
+	candidatePath := filepath.Join(dir, "candidate")
+	writeExecutableForSelfUpgradeTest(t, incumbentPath, "old image")
+	writeExecutableForSelfUpgradeTest(t, candidatePath, "new image")
+	incumbent := captureSelfUpgradeTestImage(t, incumbentPath, "1.0.0")
+	controller := testSelfUpgradeController(dir, candidatePath, incumbent)
+
+	previousVersion := selfUpgradeRunVersion
+	t.Cleanup(func() { selfUpgradeRunVersion = previousVersion })
+	selfUpgradeRunVersion = func(string) (string, error) {
+		return "", fmt.Errorf("%w: test timeout", errSelfUpgradeVersionProbeTimeout)
+	}
+
+	if err := controller.maintain(nil); err != nil {
+		t.Fatalf("maintain() error = %v, want defer", err)
+	}
+	if len(controller.refused) != 0 {
+		t.Fatalf("timeout consumed refusal memory: %#v", controller.refused)
+	}
+}
+
+func TestSelfUpgradeOptOutDoesNotPublishOrProbe(t *testing.T) {
+	dir := t.TempDir()
+	controller := &selfUpgradeController{
+		enabled:   false,
+		eligible:  false,
+		statePath: filepath.Join(dir, selfUpgradeStateFileName),
+	}
+	previousVersion := selfUpgradeRunVersion
+	previousExec := selfUpgradeExecImage
+	t.Cleanup(func() {
+		selfUpgradeRunVersion = previousVersion
+		selfUpgradeExecImage = previousExec
+	})
+	selfUpgradeRunVersion = func(string) (string, error) {
+		t.Fatal("opt-out should not probe the candidate")
+		return "", nil
+	}
+	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error {
+		t.Fatal("opt-out should not exec a candidate")
+		return nil
+	}
+
+	if err := controller.maintain(nil); err != nil {
+		t.Fatalf("maintain() error = %v", err)
+	}
+	if _, err := os.Stat(controller.statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("opt-out state path error = %v, want no state file", err)
+	}
+}
+
+func TestSelfUpgradeRejectsLocatorNotRunningImage(t *testing.T) {
+	dir := t.TempDir()
+	runningPath := filepath.Join(dir, "running")
+	locatorPath := filepath.Join(dir, "locator")
+	writeExecutableForSelfUpgradeTest(t, runningPath, "running image")
+	writeExecutableForSelfUpgradeTest(t, locatorPath, "candidate image")
+
+	previousExecutable := selfUpgradeExecutable
+	t.Cleanup(func() { selfUpgradeExecutable = previousExecutable })
+	selfUpgradeExecutable = func() (string, error) { return runningPath, nil }
+
+	controller := newSelfUpgradeController(filepath.Join(dir, "registry.json"), locatorPath, "1.0.0", true)
+	if controller.eligible {
+		t.Fatal("controller eligible for a locator that does not name the running image")
+	}
+	if controller.reason != "self-upgrade locator does not name the running image" {
+		t.Fatalf("controller reason = %q, want exact locator identity refusal", controller.reason)
+	}
+}
+
+func testSelfUpgradeController(dir, locator string, incumbent selfupgrade.ImageEvidence) *selfUpgradeController {
+	return &selfUpgradeController{
+		enabled:    true,
+		eligible:   true,
+		locator:    locator,
+		incumbent:  incumbent,
+		generation: "test-generation",
+		statePath:  filepath.Join(dir, selfUpgradeStateFileName),
+	}
+}
+
+func writeExecutableForSelfUpgradeTest(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func captureSelfUpgradeTestImage(t *testing.T, path, version string) selfupgrade.ImageEvidence {
+	t.Helper()
+	evidence, err := selfupgrade.CaptureImageEvidence(path, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return evidence
+}
+
+func assertSelfUpgradeStateMode(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("state mode = %o, want 600", info.Mode().Perm())
+	}
+}

--- a/internal/keepalive/app/selfupgrade_test.go
+++ b/internal/keepalive/app/selfupgrade_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -36,7 +37,7 @@ func TestSelfUpgradeExecsStrictlyNewerImageAtQuiescentBoundary(t *testing.T) {
 		return nil
 	}
 
-	if err := controller.maintain(nil); err != nil {
+	if err := controller.maintain(context.Background()); err != nil {
 		t.Fatalf("maintain() error = %v", err)
 	}
 	if got.EmbeddedVersion != "1.1.0" {
@@ -76,7 +77,7 @@ func TestSelfUpgradeDoesNotExecIdenticalBytesWithDifferentVersion(t *testing.T) 
 		return nil
 	}
 
-	if err := controller.maintain(nil); err != nil {
+	if err := controller.maintain(context.Background()); err != nil {
 		t.Fatalf("maintain() error = %v", err)
 	}
 	if controller.lastObservation == nil || controller.lastObservation.action != selfUpgradeActionUnchanged {
@@ -109,10 +110,10 @@ func TestSelfUpgradeDefersFailedCandidateVersionProbe(t *testing.T) {
 		return nil
 	}
 
-	if err := controller.maintain(nil); err == nil || !strings.Contains(err.Error(), "deferred for candidate "+candidatePath) {
+	if err := controller.maintain(context.Background()); err == nil || !strings.Contains(err.Error(), "deferred for candidate "+candidatePath) {
 		t.Fatalf("first maintain() error = %v, want deferred probe error", err)
 	}
-	if err := controller.maintain(nil); err == nil || !strings.Contains(err.Error(), "deferred for candidate "+candidatePath) {
+	if err := controller.maintain(context.Background()); err == nil || !strings.Contains(err.Error(), "deferred for candidate "+candidatePath) {
 		t.Fatalf("second maintain() error = %v, want deferred probe error", err)
 	}
 	if versionCalls != 2 {
@@ -146,10 +147,10 @@ func TestSelfUpgradeDoesNotReprobeSameCandidateIdentity(t *testing.T) {
 	}
 	selfUpgradeExecImage = func(selfupgrade.ImageEvidence, []string, []string) error { return nil }
 
-	if err := controller.maintain(nil); err != nil {
+	if err := controller.maintain(context.Background()); err != nil {
 		t.Fatalf("first maintain() error = %v", err)
 	}
-	if err := controller.maintain(nil); err != nil {
+	if err := controller.maintain(context.Background()); err != nil {
 		t.Fatalf("second maintain() error = %v", err)
 	}
 	if versionCalls != 1 {
@@ -179,10 +180,10 @@ func TestSelfUpgradeExecFailureIsRememberedOnce(t *testing.T) {
 		return errors.New("exec denied")
 	}
 
-	if err := controller.maintain(nil); err == nil || !strings.Contains(err.Error(), "exec newer self-upgrade image") {
+	if err := controller.maintain(context.Background()); err == nil || !strings.Contains(err.Error(), "exec newer self-upgrade image") {
 		t.Fatalf("first maintain() error = %v, want exec refusal", err)
 	}
-	if err := controller.maintain(nil); err != nil {
+	if err := controller.maintain(context.Background()); err != nil {
 		t.Fatalf("second maintain() error = %v, want cached refusal", err)
 	}
 	if execCalls != 1 || len(controller.refused) != 1 {
@@ -205,7 +206,7 @@ func TestSelfUpgradeTimeoutDoesNotConsumeRefusalMemory(t *testing.T) {
 		return "", fmt.Errorf("%w: test timeout", errSelfUpgradeVersionProbeTimeout)
 	}
 
-	if err := controller.maintain(nil); err != nil {
+	if err := controller.maintain(context.Background()); err != nil {
 		t.Fatalf("maintain() error = %v, want defer", err)
 	}
 	if len(controller.refused) != 0 {
@@ -235,7 +236,7 @@ func TestSelfUpgradeOptOutDoesNotPublishOrProbe(t *testing.T) {
 		return nil
 	}
 
-	if err := controller.maintain(nil); err != nil {
+	if err := controller.maintain(context.Background()); err != nil {
 		t.Fatalf("maintain() error = %v", err)
 	}
 	if _, err := os.Stat(controller.statePath); !errors.Is(err, os.ErrNotExist) {

--- a/internal/selfupgrade/exec.go
+++ b/internal/selfupgrade/exec.go
@@ -1,0 +1,22 @@
+package selfupgrade
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrExecUnsupported = errors.New("self-upgrade exec is unsupported on this platform")
+
+// ExecImage verifies the named image again at the exec boundary and then
+// replaces the current process with that image. The platform implementations
+// bind the verified bytes before calling execve where the host provides a
+// suitable primitive.
+func ExecImage(candidate ImageEvidence, argv, env []string) error {
+	if err := ValidateImageEvidence(candidate); err != nil {
+		return fmt.Errorf("self-upgrade candidate evidence is invalid: %w", err)
+	}
+	if len(argv) == 0 || argv[0] == "" {
+		return errors.New("self-upgrade argv is empty")
+	}
+	return execImagePlatform(candidate, argv, env)
+}

--- a/internal/selfupgrade/exec.go
+++ b/internal/selfupgrade/exec.go
@@ -7,10 +7,14 @@ import (
 
 var ErrExecUnsupported = errors.New("self-upgrade exec is unsupported on this platform")
 
+// ExecSupported reports whether this platform has a verified in-place image
+// replacement implementation.
+func ExecSupported() bool { return execSupportedPlatform() }
+
 // ExecImage verifies the named image again at the exec boundary and then
-// replaces the current process with that image. The platform implementations
-// bind the verified bytes before calling execve where the host provides a
-// suitable primitive.
+// replaces the current process with that image. Linux binds the verified file
+// descriptor for fexecve via /proc/self/fd; Darwin re-verifies a private stage
+// immediately before pathname exec because it has no fexecve primitive.
 func ExecImage(candidate ImageEvidence, argv, env []string) error {
 	if err := ValidateImageEvidence(candidate); err != nil {
 		return fmt.Errorf("self-upgrade candidate evidence is invalid: %w", err)

--- a/internal/selfupgrade/exec_darwin.go
+++ b/internal/selfupgrade/exec_darwin.go
@@ -1,0 +1,98 @@
+//go:build darwin
+
+package selfupgrade
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func execImagePlatform(candidate ImageEvidence, argv, env []string) error {
+	if candidate.ExecutionPath == "" {
+		return errors.New("self-upgrade candidate path is empty")
+	}
+	sourceInfo, err := os.Lstat(candidate.ExecutionPath)
+	if err != nil {
+		return fmt.Errorf("stat self-upgrade candidate: %w", err)
+	}
+	if sourceInfo.Mode()&os.ModeSymlink != 0 {
+		return errors.New("self-upgrade candidate must not be a symlink")
+	}
+	sourceFD, err := unix.Open(candidate.ExecutionPath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open self-upgrade candidate: %w", err)
+	}
+	source := os.NewFile(uintptr(sourceFD), candidate.ExecutionPath)
+	if source == nil {
+		_ = unix.Close(sourceFD)
+		return errors.New("open self-upgrade candidate file descriptor")
+	}
+	defer func() { _ = source.Close() }()
+	opened, err := source.Stat()
+	if err != nil {
+		return fmt.Errorf("stat opened self-upgrade candidate: %w", err)
+	}
+	if !os.SameFile(sourceInfo, opened) {
+		return errors.New("self-upgrade candidate changed while binding")
+	}
+	sourceEvidence, err := CaptureImageEvidenceFromOpenFile(
+		source,
+		candidate.ExecutionPath,
+		candidate.EmbeddedVersion,
+		ImageMethodPathnameObserved,
+	)
+	if err != nil {
+		return err
+	}
+	if !SameDarwinStagedImageEvidence(sourceEvidence, candidate) {
+		return errors.New("self-upgrade candidate changed while binding")
+	}
+
+	stageDir, err := os.MkdirTemp(
+		filepath.Dir(candidate.ExecutionPath),
+		selfUpgradeStagePrefix(candidate.ExecutionPath)+strconv.Itoa(os.Getpid())+"-",
+	)
+	if err != nil {
+		return fmt.Errorf("create self-upgrade stage: %w", err)
+	}
+	stagePath := filepath.Join(stageDir, filepath.Base(candidate.ExecutionPath))
+	removeStage := true
+	defer func() {
+		if removeStage {
+			_ = os.Remove(stagePath)
+			_ = os.Remove(stageDir)
+		}
+	}()
+	if err := os.Link(candidate.ExecutionPath, stagePath); err != nil {
+		return fmt.Errorf("stage self-upgrade candidate: %w", err)
+	}
+	stageFD, err := unix.Open(stagePath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open self-upgrade stage: %w", err)
+	}
+	stage := os.NewFile(uintptr(stageFD), stagePath)
+	if stage == nil {
+		_ = unix.Close(stageFD)
+		return errors.New("open self-upgrade stage file descriptor")
+	}
+	defer func() { _ = stage.Close() }()
+	staged, err := CaptureImageEvidenceFromOpenFile(
+		stage,
+		stagePath,
+		candidate.EmbeddedVersion,
+		ImageMethodPathnameExecObserved,
+	)
+	if err != nil {
+		return err
+	}
+	if !SameDarwinStagedImageEvidence(staged, candidate) {
+		return errors.New("self-upgrade stage changed while binding")
+	}
+	return syscall.Exec(stagePath, argv, env)
+}

--- a/internal/selfupgrade/exec_darwin.go
+++ b/internal/selfupgrade/exec_darwin.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func execSupportedPlatform() bool { return true }
+
 func execImagePlatform(candidate ImageEvidence, argv, env []string) error {
 	if candidate.ExecutionPath == "" {
 		return errors.New("self-upgrade candidate path is empty")
@@ -94,5 +96,9 @@ func execImagePlatform(candidate ImageEvidence, argv, env []string) error {
 	if !SameDarwinStagedImageEvidence(staged, candidate) {
 		return errors.New("self-upgrade stage changed while binding")
 	}
+	// Darwin cannot exec an open file descriptor. The private 0700 stage
+	// directory named with our PID is re-verified immediately before exec;
+	// same-UID races in that window are outside AMQ's threat model, as for wake
+	// self-upgrade.
 	return syscall.Exec(stagePath, argv, env)
 }

--- a/internal/selfupgrade/exec_linux.go
+++ b/internal/selfupgrade/exec_linux.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func execSupportedPlatform() bool { return true }
+
 func execImagePlatform(candidate ImageEvidence, argv, env []string) error {
 	lstat, err := os.Lstat(candidate.ExecutionPath)
 	if err != nil {

--- a/internal/selfupgrade/exec_linux.go
+++ b/internal/selfupgrade/exec_linux.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package selfupgrade
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func execImagePlatform(candidate ImageEvidence, argv, env []string) error {
+	lstat, err := os.Lstat(candidate.ExecutionPath)
+	if err != nil {
+		return fmt.Errorf("stat self-upgrade candidate: %w", err)
+	}
+	if lstat.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("self-upgrade candidate must not be a symlink")
+	}
+	fd, err := unix.Open(candidate.ExecutionPath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open self-upgrade candidate: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), candidate.ExecutionPath)
+	if file == nil {
+		_ = unix.Close(fd)
+		return errors.New("open self-upgrade candidate file descriptor")
+	}
+	defer func() { _ = file.Close() }()
+	opened, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat opened self-upgrade candidate: %w", err)
+	}
+	if !os.SameFile(lstat, opened) {
+		return errors.New("self-upgrade candidate changed while binding")
+	}
+	executionPath := fmt.Sprintf("/proc/self/fd/%d", fd)
+	bound, err := CaptureImageEvidenceFromOpenFile(
+		file,
+		executionPath,
+		candidate.EmbeddedVersion,
+		ImageMethodFDExec,
+	)
+	if err != nil {
+		return err
+	}
+	if !SameImageEvidenceExceptMethodPath(bound, candidate) {
+		return errors.New("self-upgrade candidate changed while binding")
+	}
+	return syscall.Exec(executionPath, argv, env)
+}

--- a/internal/selfupgrade/exec_other.go
+++ b/internal/selfupgrade/exec_other.go
@@ -2,4 +2,6 @@
 
 package selfupgrade
 
+func execSupportedPlatform() bool { return false }
+
 func execImagePlatform(ImageEvidence, []string, []string) error { return ErrExecUnsupported }

--- a/internal/selfupgrade/exec_other.go
+++ b/internal/selfupgrade/exec_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin && !linux
+
+package selfupgrade
+
+func execImagePlatform(ImageEvidence, []string, []string) error { return ErrExecUnsupported }

--- a/internal/selfupgrade/stages.go
+++ b/internal/selfupgrade/stages.go
@@ -1,0 +1,14 @@
+package selfupgrade
+
+import "path/filepath"
+
+func selfUpgradeStagePrefix(locator string) string {
+	return "." + filepath.Base(locator) + ".amq-self-upgrade-"
+}
+
+// CleanupStages removes only the private Darwin stage directories created by
+// ExecImage. A successful Darwin exec cannot run cleanup in the old image, so
+// the replacement performs this bounded cleanup after capturing its image.
+func CleanupStages(locator string) error {
+	return cleanupImageStagesPlatform(locator)
+}

--- a/internal/selfupgrade/stages.go
+++ b/internal/selfupgrade/stages.go
@@ -1,11 +1,5 @@
 package selfupgrade
 
-import "path/filepath"
-
-func selfUpgradeStagePrefix(locator string) string {
-	return "." + filepath.Base(locator) + ".amq-self-upgrade-"
-}
-
 // CleanupStages removes only the private Darwin stage directories created by
 // ExecImage. A successful Darwin exec cannot run cleanup in the old image, so
 // the replacement performs this bounded cleanup after capturing its image.

--- a/internal/selfupgrade/stages_darwin.go
+++ b/internal/selfupgrade/stages_darwin.go
@@ -12,6 +12,10 @@ import (
 	"syscall"
 )
 
+func selfUpgradeStagePrefix(locator string) string {
+	return "." + filepath.Base(locator) + ".amq-self-upgrade-"
+}
+
 func cleanupImageStagesPlatform(locator string) error {
 	dir := filepath.Dir(locator)
 	prefix := selfUpgradeStagePrefix(locator)

--- a/internal/selfupgrade/stages_darwin.go
+++ b/internal/selfupgrade/stages_darwin.go
@@ -1,0 +1,85 @@
+//go:build darwin
+
+package selfupgrade
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func cleanupImageStagesPlatform(locator string) error {
+	dir := filepath.Dir(locator)
+	prefix := selfUpgradeStagePrefix(locator)
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		pid, ok := selfUpgradeStagePID(entry.Name(), prefix)
+		if !ok || selfUpgradeStagePIDLive(pid) {
+			continue
+		}
+		stageDir := filepath.Join(dir, entry.Name())
+		info, err := os.Lstat(stageDir)
+		if err != nil {
+			return fmt.Errorf("inspect self-upgrade stage %q: %w", stageDir, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() || info.Mode().Perm() != 0o700 {
+			return fmt.Errorf("self-upgrade stage %q is not a private directory", stageDir)
+		}
+		children, err := os.ReadDir(stageDir)
+		if err != nil {
+			return fmt.Errorf("read self-upgrade stage %q: %w", stageDir, err)
+		}
+		if len(children) != 1 || children[0].Name() != filepath.Base(locator) {
+			return fmt.Errorf("self-upgrade stage %q has unexpected contents", stageDir)
+		}
+		stagePath := filepath.Join(stageDir, children[0].Name())
+		stageInfo, err := os.Lstat(stagePath)
+		if err != nil {
+			return fmt.Errorf("inspect self-upgrade stage image %q: %w", stagePath, err)
+		}
+		if stageInfo.Mode()&os.ModeSymlink != 0 || !stageInfo.Mode().IsRegular() || stageInfo.Mode().Perm()&0o111 == 0 {
+			return fmt.Errorf("self-upgrade stage image %q is not executable", stagePath)
+		}
+		if err := validateImagePathOwnership("self-upgrade stage image", stagePath, stageInfo); err != nil {
+			return err
+		}
+		if err := os.Remove(stagePath); err != nil {
+			return fmt.Errorf("remove self-upgrade stage image %q: %w", stagePath, err)
+		}
+		if err := os.Remove(stageDir); err != nil {
+			return fmt.Errorf("remove self-upgrade stage directory %q: %w", stageDir, err)
+		}
+	}
+	return nil
+}
+
+func selfUpgradeStagePID(name, prefix string) (int, bool) {
+	remainder := strings.TrimPrefix(name, prefix)
+	separator := strings.IndexByte(remainder, '-')
+	if separator <= 0 {
+		return 0, false
+	}
+	pid, err := strconv.ParseInt(remainder[:separator], 10, 32)
+	return int(pid), err == nil && pid > 0
+}
+
+func selfUpgradeStagePIDLive(pid int) bool {
+	if pid == os.Getpid() {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || !errors.Is(err, syscall.ESRCH)
+}

--- a/internal/selfupgrade/stages_darwin_test.go
+++ b/internal/selfupgrade/stages_darwin_test.go
@@ -1,0 +1,57 @@
+//go:build darwin
+
+package selfupgrade
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+func TestCleanupStagesLeavesLiveProcessStages(t *testing.T) {
+	dir := t.TempDir()
+	locator := filepath.Join(dir, "amq-keepalive")
+	liveProcess := exec.Command("sleep", "30")
+	if err := liveProcess.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = liveProcess.Process.Kill()
+		_ = liveProcess.Wait()
+	})
+	liveDir := filepath.Join(dir, selfUpgradeStagePrefix(locator)+strconv.Itoa(liveProcess.Process.Pid)+"-live")
+	deadPID := deadSelfUpgradeStagePID(t)
+	deadDir := filepath.Join(dir, selfUpgradeStagePrefix(locator)+strconv.Itoa(deadPID)+"-dead")
+	for _, stageDir := range []string{liveDir, deadDir} {
+		if err := os.Mkdir(stageDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(stageDir, filepath.Base(locator)), []byte("stage"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := CleanupStages(locator); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(liveDir); err != nil {
+		t.Fatalf("live stage = %v, want preserved", err)
+	}
+	if _, err := os.Stat(deadDir); !os.IsNotExist(err) {
+		t.Fatalf("dead stage = %v, want removed", err)
+	}
+}
+
+func deadSelfUpgradeStagePID(t *testing.T) int {
+	t.Helper()
+	for pid := os.Getpid() + 1; pid < os.Getpid()+10000; pid++ {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return pid
+		}
+	}
+	t.Fatal("could not find a dead process id")
+	return 0
+}

--- a/internal/selfupgrade/stages_other.go
+++ b/internal/selfupgrade/stages_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package selfupgrade
+
+func cleanupImageStagesPlatform(string) error { return nil }


### PR DESCRIPTION
Implements bead agent-message-queue-qgr (PR 2 after #671).

- K1: checks exactly after a successful superviseOnce pass, after registration locking and child activity are complete, before interval wait.
- K2/K3: reuses internal/selfupgrade evidence, strict-version, staged comparison, and refusal primitives; the direct launchd/argv0 path is the locator and candidate identity is revalidated at the exec boundary.
- K4: syscall.Exec preserves PID, argv, environment, and non-CLOEXEC descriptors; the new image re-reads the registry and rebuilds supervisor state.
- K5: identity/capture and version failures defer; exec failures are remembered once per candidate in the current generation in a 0600 atomic sidecar with directory fsync.
- K6: --no-self-upgrade disables probing; Darwin stages use PID-scoped private directories and cleanup leaves live creator stages in place.

Verification:
- go test ./internal/keepalive/app ./internal/selfupgrade ./cmd/amq-keepalive: PASS
- AMQ_KEEPALIVE_LIVE=1 go test ./internal/keepalive/app -run ^TestKeepaliveSelfUpgradeLive -count=1 -v: PASS
- GOOS=linux GOTOOLCHAIN=local go vet ./...: PASS
- GOOS=windows GOTOOLCHAIN=local go vet ./...: PASS
- GOOS=linux GOTOOLCHAIN=local go test -c ./internal/keepalive/app and ./internal/selfupgrade: PASS
- GOOS=windows GOTOOLCHAIN=local go build ./...: PASS

Refs: bead agent-message-queue-qgr, #671.